### PR TITLE
fix: updated service to use new postgres image

### DIFF
--- a/integration_tests/services_templates.yaml
+++ b/integration_tests/services_templates.yaml
@@ -35,8 +35,7 @@ services:
     volumes:
       - ./init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh:ro
       - ./postgres.conf:/etc/postgresql.conf:ro
-    entrypoint:
-      - /docker-entrypoint.sh
+    command:
       - -c
       - config_file=/etc/postgresql.conf
     cap_add:


### PR DESCRIPTION
I've updated our postgres image to be more in line with the "common" postgres image, and that broke our usage. I've updated it to match how we would use the "common" image