### PR TITLE
VAX-299: Do not crash on nil value, coming from Vaxine

### DIFF
--- a/integration_tests/common.mk
+++ b/integration_tests/common.mk
@@ -60,8 +60,9 @@ else
 	docker pull ${POSTGRESQL_IMAGE}
 endif
 
+DOCKER_PREFIX:=$(shell basename $(CURDIR))
 docker-psql-%:
-	docker exec -it -e PGPASSWORD=password integration_tests_$*_1 psql -h $* -U electric -d electric
+	docker exec -it -e PGPASSWORD=password ${DOCKER_PREFIX}_$*_1 psql -h $* -U electric -d electric
 
 docker-attach-%:
 	docker-compose -f ${DOCKER_COMPOSE_FILE} exec $* bash

--- a/integration_tests/single_dc/compose.yaml
+++ b/integration_tests/single_dc/compose.yaml
@@ -22,6 +22,7 @@ services:
       - ./electric.exs:/app/releases/0.1.0/runtime.exs:ro
     ports:
       - "5050:5050"
+      - "5133:5133"
     depends_on:
       - pg_1
       - pg_2
@@ -33,6 +34,9 @@ services:
       service: electric
     volumes:
       - ./electric_b.exs:/app/releases/0.1.0/runtime.exs:ro
+    ports:
+      - "5051:5050"
+      - "5134:5133"
     depends_on:
       - pg_3
       - vaxine_1

--- a/integration_tests/single_dc/electric.exs
+++ b/integration_tests/single_dc/electric.exs
@@ -63,4 +63,9 @@ config :electric, Electric.Replication.Connectors,
     ]
   ]
 
+config :electric, Electric.Replication.SQConnectors,
+  vaxine_hostname: "vaxine_1",
+  vaxine_port: 8088,
+  vaxine_connection_timeout: 5000
+
 config :logger, backends: [:console], level: :debug

--- a/integration_tests/single_dc/electric_b.exs
+++ b/integration_tests/single_dc/electric_b.exs
@@ -34,4 +34,9 @@ config :electric, Electric.Replication.Connectors,
     ]
   ]
 
+config :electric, Electric.Replication.SQConnectors,
+  vaxine_hostname: "vaxine_1",
+  vaxine_port: 8088,
+  vaxine_connection_timeout: 5000
+
 config :logger, backends: [:console], level: :debug

--- a/lib/electric/satellite/satellite_serialization.ex
+++ b/lib/electric/satellite/satellite_serialization.ex
@@ -97,7 +97,14 @@ defmodule Electric.Satellite.Replication do
   defp map_to_record(data, rel_cols) do
     # FIXME: This is ineficient, data should be stored in order, so that we
     # do not have to do lookup here, but filter columns based on the schema instead
-    Enum.map(rel_cols, fn column_name -> Map.get(data, column_name, <<>>) end)
+    Enum.map(rel_cols, fn column_name ->
+      # FIXME: NULL is stored in Vaxine as :nil, but we should be able to distringuish it
+      # from empty string
+      case Map.get(data, column_name, nil) do
+        nil -> <<>>
+        d -> d
+      end
+    end)
   end
 
   def fetch_relation_id(relation, known_relations) do


### PR DESCRIPTION
The intention of this PR is to eliminate the crash. The proper fix to the protocol going to be part of a different PR.
Add websocket endpoints to Electric instances in single_dc tests for local test purposes.