### PR TITLE
Intoduce ELECTRIC_MIGRATIONS_DIR

### DIFF
--- a/lib/electric/migration_utils.ex
+++ b/lib/electric/migration_utils.ex
@@ -3,7 +3,7 @@ defmodule Electric.Migration.Utils do
 
   @spec available_migrations() :: [vsn()]
   def available_migrations() do
-    migration_path = Application.get_env(:electric, Electric.Migrations)
+    migration_path = get_migration_dir()
 
     Enum.map(
       Path.wildcard(Path.join(migration_path, "*.sql")),
@@ -26,12 +26,20 @@ defmodule Electric.Migration.Utils do
 
   @spec get_migration_path(vsn()) :: binary
   def get_migration_path(vsn) do
-    migration_path =
-      Keyword.fetch!(
-        Application.get_env(:electric, Electric.Migrations),
-        :dir
-      )
-
+    migration_path = get_migration_dir()
     Path.join(migration_path, vsn <> ".sql")
+  end
+
+  defp get_migration_dir() do
+    case :os.getenv(to_charlist("ELECTRIC_MIGRATIONS_DIR")) do
+      false ->
+        Keyword.fetch!(
+          Application.get_env(:electric, Electric.Migrations),
+          :dir
+        )
+
+      value ->
+        value
+    end
   end
 end


### PR DESCRIPTION
New environment variable is introduced to provide possibility to overwrite configuration provided in the config file for migrations directory