### PR TITLE
Add websocket e2e tests with elixir mocked client.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.KEY_TO_ACCESS_SATELLITE_JS_PROTO }}
-      - run: make deps
+      - run: make deps pretest_compile
       - uses: actions/cache@v3
         with:
           path: |

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ pretest_compile: deps
 	MIX_ENV="test" mix compile --force --warnings-as-error
 
 tests:
-	mix test
+	mix test --trace
 
 format:
 	mix format

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,8 +2,7 @@ import Config
 
 config :electric, Electric.VaxRepo, hostname: "localhost", port: 8087
 
-config :electric, Electric.Replication.VaxinePostgresOffsetStorage,
-  file: "./vx_pg_offset_storage_dev.dat"
+config :electric, Electric.Replication.OffsetStorage, file: "./vx_pg_offset_storage_dev.dat"
 
 config :electric, Electric.Migrations, dir: "./integration_tests/migrations/migration_schemas/"
 
@@ -70,9 +69,5 @@ config :electric, Electric.Replication.SQConnectors,
   vaxine_hostname: "localhost",
   vaxine_port: 8088,
   vaxine_connection_timeout: 5000
-
-# config :electric, Electric.Satellite.Auth,
-#  auth_url: "http://localhost:1080/auth_success",
-#  cluster_id: "cluster_auth_id"
 
 config :logger, level: :debug

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,6 @@
 import Config
 
-config :electric, Electric.Replication.VaxinePostgresOffsetStorage,
-  file: "./vx_pg_offset_storage_prod.dat"
+config :electric, Electric.Replication.OffsetStorage, file: "./vx_pg_offset_storage_prod.dat"
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,6 @@
 import Config
 
-config :electric, Electric.Replication.VaxinePostgresOffsetStorage,
-  file: "./vx_pg_offset_storage_test.dat"
+config :electric, Electric.Replication.OffsetStorage, file: "./vx_pg_offset_storage_test.dat"
 
 config :electric, Electric.VaxRepo, hostname: "localhost", port: 8087
 

--- a/init-user-db.sh
+++ b/init-user-db.sh
@@ -10,6 +10,20 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" "dbname=$POSTGRES_DB replica
     content_b VARCHAR(64)
   );
 
+  CREATE TABLE entries_default (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    content VARCHAR(64) NOT NULL,
+    content_b VARCHAR(64)
+  );
+  ALTER TABLE entries_default REPLICA IDENTITY DEFAULT;
+
+  CREATE TABLE entries_no (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    content VARCHAR(64) NOT NULL,
+    content_b VARCHAR(64)
+  );
+  ALTER TABLE entries_no REPLICA IDENTITY NOTHING;
+
   CREATE SCHEMA electric;
   CREATE TABLE electric.migrations (
     id SERIAL PRIMARY KEY,

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -13,7 +13,6 @@ build:
 pull:
 	docker-compose -f services_templates.yaml pull sysbench postgresql vaxine
 
-
 clean:
 	$(foreach dir, $(LUX_DIRS),make -C ${dir} clean;)
 	rm -rf lux

--- a/integration_tests/common.luxinc
+++ b/integration_tests/common.luxinc
@@ -77,3 +77,43 @@
         [sleep 1]
     [endloop]
 [endmacro]
+
+[macro start_elixir_test]
+    !make start_elixir_test
+    [invoke ok2 $dprompt]
+    !mix local.hex --force --no-color
+    ?archives
+    [invoke ok2 $dprompt]
+    !iex -S mix run --no-start --no-deps-check -e "Application.put_env(:elixir, :ansi_enabled, false)"
+    ?$eprompt
+[endmacro]
+
+[macro sysbench_prepare host table_size tables]
+    !sysbench --db-driver=pgsql \
+              --table-size=${table_size} \
+              --tables=${tables} \
+              --threads=1 \
+              --pgsql-host=${host} \
+              --pgsql-port=5432 \
+              --pgsql-user=electric \
+              --pgsql-password=password \
+              --pgsql-db=electric \
+              oltp_write_only prepare
+    [invoke ok2 $dprompt]
+[endmacro]
+
+[macro sysbench_run host table_size tables]
+    !sysbench --db-driver=pgsql \
+              --table-size=${table_size} \
+              --tables=${tables} \
+              --threads=1 \
+              --time=10 \
+              --report-interval=1 \
+              --pgsql-host=${host} \
+              --pgsql-port=5432 \
+              --pgsql-user=electric \
+              --pgsql-password=password \
+              --pgsql-db=electric \
+              oltp_write_only run
+    [invoke ok2 $dprompt]
+[endmacro]

--- a/integration_tests/common.mk
+++ b/integration_tests/common.mk
@@ -61,6 +61,12 @@ start_sysbench:
 		--rm --entrypoint=/bin/bash \
 		sysbench
 
+start_elixir_test:
+	docker-compose -f ${DOCKER_COMPOSE_FILE} run \
+		--rm --entrypoint=/bin/bash \
+		--workdir=${PROJECT_ROOT} \
+		test_client
+
 VAXINE_BRANCH?=main
 vaxine:
 ifdef USE_LOCAL_IMAGE

--- a/integration_tests/init-user-db.sh
+++ b/integration_tests/init-user-db.sh
@@ -9,8 +9,16 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" "dbname=$POSTGRES_DB replica
     content VARCHAR(64) NOT NULL,
     content_b VARCHAR(64)
   );
+  ALTER TABLE entries REPLICA IDENTITY FULL;
 
-CREATE SCHEMA electric;
+  CREATE TABLE entries_default (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    content VARCHAR(64) NOT NULL,
+    content_b VARCHAR(64)
+  );
+  ALTER TABLE entries_default REPLICA IDENTITY DEFAULT;
+
+  CREATE SCHEMA electric;
   CREATE TABLE electric.migrations (
     id SERIAL PRIMARY KEY,
     version VARCHAR(64) NOT NULL,
@@ -19,7 +27,6 @@ CREATE SCHEMA electric;
     UNIQUE(version)
   );
 
-  ALTER TABLE entries REPLICA IDENTITY FULL;
   INSERT INTO electric.migrations (version, hash) VALUES ('1', 'initial');
 
   CREATE PUBLICATION all_tables FOR ALL TABLES;

--- a/integration_tests/multi_dc/one_direction.lux
+++ b/integration_tests/multi_dc/one_direction.lux
@@ -1,4 +1,4 @@
-[doc Test one direction replication from pg_1 to pg_2]
+[doc Test one direction replication from pg_1 (dc1) to pg_2 (dc2)]
 
 [global fail_pattern=[Ee][Rr][Rr][Oo][Rr]]
 [global psql=electric]
@@ -7,24 +7,57 @@
 [invoke setup]
 [timeout 10000]
 
-[shell pg_1]
-    !INSERT INTO entries (content) VALUES ('Hello from a');
-    ?INSERT 0 1
+[shell vaxine_1]
+    -$fail_pattern
+[shell electric_1]
+    -$fail_pattern
+[shell vaxine_2]
+    -$fail_pattern
+[shell electric_2]
+    -$fail_pattern
 
+[macro validate_insert identity table]
+[shell pg_1]
+    [invoke log "Insert data for identity=${identity}"]
+    !INSERT INTO ${table} (id, content) VALUES ('46ae8d74-ea44-4322-a4f3-9cd1b680a5bf', 'Hello from a');
+    ?INSERT 0 1
 [shell electric_2]
     ?.* origin=pg_2 .* \[debug\] Sending \d messages to the subscriber
-
 [shell pg_2]
-    [invoke wait-for "SELECT * FROM entries;" "Hello from a" 10 "electric=#"]
+    [invoke log "Confirm insert operation"]
+    [invoke wait-for "SELECT * FROM ${table};" "Hello from a" 10 "electric=#"]
+[endmacro]
 
-    !select * FROM entries;
-    ?Hello from a
-    ?(1 row)
-
+[macro validate_update identity table]
 [shell pg_1]
-    !SELECT * FROM entries;
-    ?Hello from a
-    ?(1 row)
+    [invoke log "Update data for identity=${identity}"]
+    !UPDATE ${table} SET content = 'other' WHERE id = '46ae8d74-ea44-4322-a4f3-9cd1b680a5bf';
+    ?UPDATE 1
+[shell electric_2]
+    ?.* origin=pg_2 .* \[debug\] Sending \d messages to the subscriber
+[shell pg_2]
+    [invoke log "Confirm update operation"]
+    [invoke wait-for "SELECT * FROM ${table};" "other" 10 "electric=#"]
+[endmacro]
+
+[macro validate_delete identity table]
+[shell pg_1]
+    [invoke log "Update data for identity=${identity}"]
+    !DELETE FROM ${table} WHERE id = '46ae8d74-ea44-4322-a4f3-9cd1b680a5bf';
+    ?DELETE 1
+[shell electric_2]
+    ?.* origin=pg_2 .* \[debug\] Sending \d messages to the subscriber
+[shell pg_2]
+    [invoke log "Confirm delete operation"]
+    [invoke wait-for "SELECT * FROM ${table};" "(0 rows)" 10 "electric=#"]
+[endmacro]
+
+[invoke validate_insert "FULL" "entries"]
+[invoke validate_insert "DEFAULT" "entries_default"]
+[invoke validate_update "FULL" "entries"]
+[invoke validate_update "DEFAULT" "entries_default"]
+[invoke validate_delete "FULL" "entries"]
+[invoke validate_delete "DEFAULT" "entries_default"]
 
 [cleanup]
     [invoke teardown]

--- a/integration_tests/services_templates.yaml
+++ b/integration_tests/services_templates.yaml
@@ -26,6 +26,21 @@ services:
   sysbench:
     image: "${SYSBENCH_IMAGE}"
 
+  elixir_test:
+    image: "hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+    user: "${UID}:${GID}"
+    environment:
+      UID: ${UID}
+      GID: ${GID}
+      MIX_HOME: ${PROJECT_ROOT}
+      MIX_ENV: test
+    volumes:
+      - ${PROJECT_ROOT}:${PROJECT_ROOT}
+      - /etc/group:/etc/group:ro
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/shadow:/etc/shadow:ro
+    privileged: true
+
   postgresql:
     image: "${POSTGRESQL_IMAGE}"
     environment:

--- a/integration_tests/single_dc/compose.yaml
+++ b/integration_tests/single_dc/compose.yaml
@@ -46,6 +46,11 @@ services:
       file: ../services_templates.yaml
       service: sysbench
 
+  test_client:
+    extends:
+      file: ../services_templates.yaml
+      service: elixir_test
+
   pg_1:
     extends:
       file: ../services_templates.yaml

--- a/integration_tests/single_dc/one_direction.lux
+++ b/integration_tests/single_dc/one_direction.lux
@@ -6,24 +6,53 @@
 [include shared.luxinc]
 [invoke setup]
 
-[shell pg_1]
-    !INSERT INTO entries (content) VALUES ('Hello from a');
-    ?INSERT 0 1
+[shell vaxine]
+    -$fail_pattern
+[shell electric]
+    -$fail_pattern
 
+[macro validate_insert identity table]
+[shell pg_1]
+    [invoke log "Insert data for identity=${identity}"]
+    !INSERT INTO ${table} (id, content) VALUES ('46ae8d74-ea44-4322-a4f3-9cd1b680a5bf', 'Hello from a');
+    ?INSERT 0 1
 [shell electric]
     ?.* origin=postgres_2 .* \[debug\] Sending \d messages to the subscriber
-
 [shell pg_2]
-    [invoke wait-for "SELECT * FROM entries;" "Hello from a" 10 "electric=#"]
+    [invoke log "Confirm insert operation"]
+    [invoke wait-for "SELECT * FROM ${table};" "Hello from a" 10 "electric=#"]
+[endmacro]
 
-    !SELECT * FROM entries;
-    ?Hello from a
-    ?(1 row)
-
+[macro validate_update identity table]
 [shell pg_1]
-    !SELECT * FROM entries;
-    ?Hello from a
-    ?(1 row)
+    [invoke log "Update data for identity=${identity}"]
+    !UPDATE ${table} SET content = 'other' WHERE id = '46ae8d74-ea44-4322-a4f3-9cd1b680a5bf';
+    ?UPDATE 1
+[shell electric]
+    ?.* origin=postgres_2 .* \[debug\] Sending \d messages to the subscriber
+[shell pg_2]
+    [invoke log "Confirm update operation"]
+    [invoke wait-for "SELECT * FROM ${table};" "other" 10 "electric=#"]
+[endmacro]
+
+[macro validate_delete identity table]
+[shell pg_1]
+    [invoke log "Update data for identity=${identity}"]
+    !DELETE FROM ${table} WHERE id = '46ae8d74-ea44-4322-a4f3-9cd1b680a5bf';
+    ?DELETE 1
+[shell electric]
+    ?.* origin=postgres_2 .* \[debug\] Sending \d messages to the subscriber
+[shell pg_2]
+    [invoke log "Confirm delete operation"]
+    [invoke wait-for "SELECT * FROM ${table};" "(0 rows)" 10 "electric=#"]
+[endmacro]
+
+[invoke validate_insert "FULL" "entries"]
+[invoke validate_insert "DEFAULT" "entries_default"]
+[invoke validate_update "FULL" "entries"]
+[invoke validate_update "DEFAULT" "entries_default"]
+[invoke validate_delete "FULL" "entries"]
+[invoke validate_delete "DEFAULT" "entries_default"]
 
 [cleanup]
     [invoke teardown]

--- a/integration_tests/single_dc/shared.luxinc
+++ b/integration_tests/single_dc/shared.luxinc
@@ -46,4 +46,3 @@
 [invoke setup_rest]
 
 [endmacro]
-

--- a/integration_tests/single_dc/sysbench_ws.lux
+++ b/integration_tests/single_dc/sysbench_ws.lux
@@ -1,0 +1,159 @@
+[doc One-direction replication pg_1 -> pg_2]
+
+[global fail_pattern=[Ee][Rr][Rr][Oo][Rr]]
+[global psql=electric]
+[global dprompt=\w+@\w+:(\S+)[\#\$]]
+[global eprompt=iex\(\d+\)>\s]
+
+[include shared.luxinc]
+
+[invoke setup_pg_and_vaxine]
+
+[shell sysbench_pg1]
+    [invoke log "Prepare tables and generate data for PG1"]
+    !make start_sysbench
+    ?$dprompt
+    [invoke sysbench_prepare pg_1 10 10]
+    !exit
+    [invoke ok]
+
+[shell sysbench_pg2]
+    [invoke log "Prepare tables for PG2"]
+    !make start_sysbench
+    ?$dprompt
+    [invoke sysbench_prepare pg_2 0 10]
+    !exit
+    [invoke ok]
+
+[shell vaxine]
+    -$fail_pattern
+#[shell electric]
+#    -$fail_pattern
+
+[invoke setup_rest]
+
+[macro wait_table table]
+    [invoke wait-for "select count(id) from ${table};" "  10" 10 $psql]
+[endmacro]
+
+[shell pg_2]
+   # couldn't figure out quickly why loop in the loop was not reliable
+   [invoke wait_table sbtest1]
+
+[shell ws1]
+    [invoke log "Start WS client and start consuming data"]
+    [invoke start_elixir_test]
+    !Electric.Test.SatelliteWsClient.connect_and_spawn( \
+            [:auth, {:id, "ws1"}, {:sub, "0"}, \
+            {:auto_in_sub, true}, \
+            {:format, :compact}, \
+            {:host, "electric_1"}, \
+            {:auto_ping, :true} \
+            ])
+    ?$eprompt
+    ?(.*) %Electric.Satellite.SatInStartReplicationReq{__uf__: \[], lsn: "0", (.*)
+
+[shell pg_2]
+    [invoke log "Make sure we replicate all data from PG1 -> PG2"]
+    [invoke wait_table sbtest2]
+    [invoke wait_table sbtest3]
+    [invoke wait_table sbtest4]
+    [invoke wait_table sbtest5]
+    [invoke wait_table sbtest6]
+    [invoke wait_table sbtest7]
+    [invoke wait_table sbtest8]
+    [invoke wait_table sbtest9]
+    [invoke wait_table sbtest10]
+
+[shell ws1]
+    [invoke log "Wait for sync up to current state"]
+    ?\d+:\d+:\d+.\d+ \[info\]  rec \[13]: %{commit_timestamp: \d+, lsn: (.*), trans_id: "", update: 9}
+    [local middle_lsn=$1]
+    ?\d+:\d+:\d+.\d+ \[info\]  rec \[21]: %{commit_timestamp: \d+, lsn: (.*), trans_id: "", update: 9}
+
+#
+#[shell sysbench_pg1]
+#    [invoke log "Start generating more data while WS client is subscribed"]
+#    [timeout 15]
+#    !make start_sysbench
+#    ?$dprompt
+#    [invoke sysbench_run pg_1 10 10]
+#    !exit
+#    [invoke ok]
+#    [sleep 5]
+
+[shell pg_2]
+    [invoke log "Send new tx from PG2"]
+    !INSERT INTO entries (content) VALUES ('Hello from a');
+    ?INSERT 0 1
+
+[shell ws1]
+    [timeout 10]
+    [invoke log "Wait for Satellite to receive transaction from PG2"]
+    ?\d+:\d+:\d+.\d+ \[info\]  rec \[23]: %{commit_timestamp: \d+, lsn: (.*), trans_id: "", update: \d+}
+    [local middle_lsn=$1]
+
+    [invoke log "Send transaction with insert from Satellite"]
+    !Electric.Test.SatelliteWsClient.send_test_relation()
+    ?:ok
+    !Electric.Test.SatelliteWsClient.send_new_data("1", 1666371243516, "1f922fbb-016b-40c3-aeb1-e52682f82241", "Hello from Satellite")
+    ?:ok
+    ?%Electric.Satellite.SatPingResp{.* lsn: "1"}
+
+[shell electric]
+    ?Hello from Satellite
+[shell pg_2]
+    [invoke wait-for "select * from entries;" "Hello from Satellite" 10 $psql]
+[shell pg_1]
+    [invoke wait-for "select * from entries;" "Hello from Satellite" 10 $psql]
+
+[shell ws1]
+    [invoke log "Send transaction with update from Satellite"]
+    !Electric.Test.SatelliteWsClient.send_update_data("2", 1666371243516, "1f922fbb-016b-40c3-aeb1-e52682f82241", "How are you?")
+    ?:ok
+    ?%Electric.Satellite.SatPingResp{.* lsn: "2"}
+
+[shell electric]
+    ?How are you?
+[shell pg_2]
+    [invoke wait-for "select * from entries;" "How are you?" 10 $psql]
+[shell pg_1]
+    [invoke wait-for "select * from entries;" "How are you?" 10 $psql]
+
+[shell ws1]
+    [invoke log "Send transaction with delete from Satellite"]
+    !Electric.Test.SatelliteWsClient.send_delete_data("3", 1666371243516, "1f922fbb-016b-40c3-aeb1-e52682f82241", "How are you?")
+    ?:ok
+    ?%Electric.Satellite.SatPingResp{.* lsn: "3"}
+
+[shell electric]
+    ?How are you?
+[shell pg_2]
+    [invoke wait-for "select * from entries;" "(1 row)" 10 $psql]
+[shell pg_1]
+    [invoke wait-for "select * from entries;" "(1 row)" 10 $psql]
+
+[shell ws1]
+    !Electric.Test.SatelliteWsClient.disconnect()
+    ?:ok
+
+#[shell electric]
+#    !make stop_electric_1
+#    [invoke ok]
+
+#    !make start_electric_1
+#    ?START_REPLICATION SLOT
+
+#[shell ws1]
+#    !Electric.Test.SatelliteWsClient.connect_and_spawn( \
+#            [:auth, {:id, "ws1"}, {:sub, "eof"}, \
+#            {:auto_in_sub, true}, \
+#            {:format, :compact}, \
+#            {:host, "electric_1"}, \
+#            {:auto_ping, :true} \
+#            ])
+#    ?$eprompt
+#    ?(.*) %Electric.Satellite.SatInStartReplicationReq{__uf__: \[], lsn: "3", (.*)
+
+[cleanup]
+    [invoke teardown]

--- a/lib/electric/application.ex
+++ b/lib/electric/application.ex
@@ -11,7 +11,7 @@ defmodule Electric.Application do
 
     children = [
       Electric.Postgres.SchemaRegistry,
-      Electric.Replication.VaxinePostgresOffsetStorage,
+      Electric.Replication.OffsetStorage,
       {Plug.Cowboy, scheme: :http, plug: Electric.Plug.Router, options: [port: status_port()]},
       Electric.VaxRepo,
       Electric.PostgresServer.child_spec(port: postgres_server_port()),

--- a/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -113,9 +113,10 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     {:noreply, [], %{state | transaction: {msg.final_lsn, tx}}}
   end
 
-  defp process_message(%Origin{}, state) do
+  defp process_message(%Origin{} = msg, state) do
     # If we got the "origin" message, it means that the Postgres sending the data has got it from Electric already
     # so we just drop the transaction altogether
+    Logger.debug("origin: #{inspect(msg.name)}")
     {:noreply, [], %{state | drop_current_transaction?: true}}
   end
 

--- a/lib/electric/replication/postgres/slot_server.ex
+++ b/lib/electric/replication/postgres/slot_server.ex
@@ -18,7 +18,7 @@ defmodule Electric.Replication.Postgres.SlotServer do
   alias Electric.Postgres.Messaging
   alias Electric.Postgres.SchemaRegistry
   alias Electric.Replication.Changes
-  alias Electric.Replication.VaxinePostgresOffsetStorage
+  alias Electric.Replication.OffsetStorage
 
   alias Electric.Replication.DownstreamProducer
 
@@ -248,7 +248,7 @@ defmodule Electric.Replication.Postgres.SlotServer do
         %{state | current_lsn: new_lsn, sent_relations: relations, current_vx_offset: vx_offset}
       end)
 
-    VaxinePostgresOffsetStorage.put_relation(
+    OffsetStorage.put_pg_relation(
       state.slot_name,
       state.current_lsn,
       state.current_vx_offset
@@ -300,9 +300,9 @@ defmodule Electric.Replication.Postgres.SlotServer do
   end
 
   defp get_vx_offset(slot_name, start_lsn) do
-    case VaxinePostgresOffsetStorage.get_vx_offset(slot_name, start_lsn) do
+    case OffsetStorage.get_vx_offset(slot_name, start_lsn) do
       nil ->
-        case VaxinePostgresOffsetStorage.get_largest_known_lsn_smaller_than(slot_name, start_lsn) do
+        case OffsetStorage.get_largest_known_lsn_smaller_than(slot_name, start_lsn) do
           {lsn, vx_offset} ->
             Logger.debug("Lsn #{inspect(start_lsn)} not found, falling back to #{inspect(lsn)}")
             vx_offset

--- a/test/electric/replication/vaxine_postgres_offset_storage_test.exs
+++ b/test/electric/replication/vaxine_postgres_offset_storage_test.exs
@@ -1,7 +1,7 @@
-defmodule Electric.Replication.VaxinePostgresOffsetStorageTest do
+defmodule Electric.Replication.OffsetStorageTest do
   use ExUnit.Case
 
-  alias Electric.Replication.VaxinePostgresOffsetStorage
+  alias Electric.Replication.OffsetStorage
   alias Electric.Postgres.Lsn
 
   setup do
@@ -11,13 +11,13 @@ defmodule Electric.Replication.VaxinePostgresOffsetStorageTest do
   test "put_relation/3 upserts the relation for a slot and Lsn combination", %{slot: slot} do
     lsn = Lsn.from_integer(1)
 
-    assert is_nil(VaxinePostgresOffsetStorage.get_vx_offset(slot, lsn))
+    assert is_nil(OffsetStorage.get_vx_offset(slot, lsn))
 
-    assert :ok = VaxinePostgresOffsetStorage.put_relation(slot, lsn, 1)
-    assert 1 = VaxinePostgresOffsetStorage.get_vx_offset(slot, lsn)
+    assert :ok = OffsetStorage.put_pg_relation(slot, lsn, 1)
+    assert 1 = OffsetStorage.get_vx_offset(slot, lsn)
 
-    assert :ok = VaxinePostgresOffsetStorage.put_relation(slot, lsn, 2)
-    assert 2 = VaxinePostgresOffsetStorage.get_vx_offset(slot, lsn)
+    assert :ok = OffsetStorage.put_pg_relation(slot, lsn, 2)
+    assert 2 = OffsetStorage.get_vx_offset(slot, lsn)
   end
 
   test "get_largest_known_lsn_smaller_than/3 finds the largest acceptable LSN in the table", %{
@@ -27,12 +27,12 @@ defmodule Electric.Replication.VaxinePostgresOffsetStorageTest do
     0..100//3
     |> Enum.each(fn x ->
       lsn = Lsn.from_integer(x)
-      VaxinePostgresOffsetStorage.put_relation(slot, lsn, x)
+      OffsetStorage.put_pg_relation(slot, lsn, x)
     end)
 
     # Searching for 61, get 60
     assert {_lsn, 60} =
-             VaxinePostgresOffsetStorage.get_largest_known_lsn_smaller_than(
+             OffsetStorage.get_largest_known_lsn_smaller_than(
                slot,
                Lsn.from_integer(61)
              )
@@ -40,7 +40,7 @@ defmodule Electric.Replication.VaxinePostgresOffsetStorageTest do
 
   test "get_largest_known_lsn_smaller_than/3 returns nil if nothing found", %{slot: slot} do
     assert is_nil(
-             VaxinePostgresOffsetStorage.get_largest_known_lsn_smaller_than(
+             OffsetStorage.get_largest_known_lsn_smaller_than(
                slot,
                Lsn.from_integer(10)
              )

--- a/test/electric/to_vaxine_test.exs
+++ b/test/electric/to_vaxine_test.exs
@@ -24,6 +24,14 @@ defmodule Electric.Replication.VaxineTest do
     }
   end
 
+  def updated_record_change_old_empty(new_columns) do
+    %Changes.UpdatedRecord{
+      old_record: nil,
+      record: Map.put(new_columns, "id", @id),
+      relation: {"fake", "to_vaxine_test"}
+    }
+  end
+
   def deleted_record_change(old_columns) do
     %Changes.DeletedRecord{
       old_record: Map.put(old_columns, "id", @id),
@@ -59,6 +67,14 @@ defmodule Electric.Replication.VaxineTest do
       assert :ok =
                %{"content" => "a"}
                |> updated_record_change(%{"content" => "b"})
+               |> ToVaxine.handle_change()
+
+      assert %{row: %{"content" => "b"}} = VaxRepo.reload(@row)
+    end
+
+    test "for UpdatedRecord without old row" do
+      assert :ok =
+               updated_record_change_old_empty(%{"content" => "b"})
                |> ToVaxine.handle_change()
 
       assert %{row: %{"content" => "b"}} = VaxRepo.reload(@row)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,7 +3,14 @@ if System.get_env("INTEGRATION") do
 else
   Mox.defmock(Electric.Replication.MockPostgresClient, for: Electric.Replication.Postgres.Client)
   ExUnit.configure(exclude: :integration)
-  Logger.configure(level: :warn)
+  Logger.configure(level: :info)
 end
+
+File.rm(
+  Keyword.fetch!(
+    Application.get_env(:electric, Electric.Replication.OffsetStorage),
+    :file
+  )
+)
 
 ExUnit.start()


### PR DESCRIPTION
* [vax-269, vax-301] Add websocket protobuff e2e tests for Satellite
* [vax-320] OffsetStorage is updated to persist LSN coming from Satellite
* [vax-365] Add support for REPLICA IDENTITY DEFAULT
* Add periodic ping functionality to WS server to detect stale clients
* Bug has been fixed which would sometimes cause replication to pause indefinitely due to GenStage demands inproper handling
* Bug corrected where we would not detect that one of the PK keys is missing