### PR TITLE
VAX-469 Better error handling and fail recovery after unsuccesfull migration

### DIFF
--- a/integration_tests/migrations/satellite_test.lux
+++ b/integration_tests/migrations/satellite_test.lux
@@ -35,8 +35,8 @@
     ?HTTP/1.1 200 OK
 
  [shell ${electric}]
-    ?.* origin=${pg} .* \[notice\] ready to migrate to version: ${vsn}
-    ?.* origin=${pg} .* \[notice\] successfull migration to version: ${vsn}
+    ?.* origin=${pg} .* \[notice\] migration: prepare to migrate to vsn: ${vsn}
+    ?.* origin=${pg} .* \[notice\] migration: successfully migrated to version: ${vsn}
     ?.* Successfully initialized origin ${pg}
 [endmacro]
 

--- a/integration_tests/migrations/simple_test.lux
+++ b/integration_tests/migrations/simple_test.lux
@@ -27,8 +27,10 @@
     ?HTTP/1.1 200 OK
 
 [shell electric_1]
-    ?.* origin=postgres_1 .* \[notice\] ready to migrate to version: 1669232573_init
-    ?.* origin=postgres_1 .* \[notice\] successfull migration to version: 1669232573_init
+    ?.* origin=postgres_1 .* \[notice\] migration: prepare to migrate to vsn: 1669232573_init
+    ?.* origin=postgres_1 .* \[notice\] migration: about to stop postgresql replication and subscriptions
+    ?.* origin=postgres_1 .* \[notice\] migration: about to apply migration
+    ?.* origin=postgres_1 .* \[notice\] migration: successfully migrated to version: 1669232573_init
     ?.* Successfully initialized origin postgres_1
 
 [shell electric_migrate]
@@ -37,8 +39,10 @@
     ?HTTP/1.1 200 OK
 
 [shell electric_1]
-    ?.* origin=postgres_2 .* \[notice\] ready to migrate to version: 1669232573_init
-    ?.* origin=postgres_2 .* \[notice\] successfull migration to version: 1669232573_init
+    ?.* origin=postgres_2 .* \[notice\] migration: prepare to migrate to vsn: 1669232573_init
+    ?.* origin=postgres_2 .* \[notice\] migration: about to stop postgresql replication and subscriptions
+    ?.* origin=postgres_2 .* \[notice\] migration: about to apply migration
+    ?.* origin=postgres_2 .* \[notice\] migration: successfully migrated to version: 1669232573_init
     ?.* Successfully initialized origin postgres_2
 
 [shell electric_curl]
@@ -53,6 +57,11 @@
           -H 'Content-Type: application/json' -d '{"vsn":"1669232573_init"}'
     ?HTTP/1.1 403 Forbidden
     ?:already_migrated
+
+    !curl -v -X PUT http://localhost:5050/api/migrations/postgres_2 \
+          -H 'Content-Type: application/json' -d '{"vsn":"3"}'
+    ?HTTP/1.1 403 Forbidden
+    ?:vsn_not_found
 
     !curl -v -X PUT http://localhost:5050/api/migrations/postgres_2 \
           -H 'Content-Type: application/json' -d '{"vsn":"3"}'


### PR DESCRIPTION
- do not try to migrate if migration is not available
- previously in case of an error postgres manager would have left system half-initialised, which would eventually lead to a crash on a next attempt. This has been fixed.