### PR TITLE
VAX-483: `replication.insecure` field is required on the config object

### DIFF
--- a/integration_tests/satellite_client/src/client.ts
+++ b/integration_tests/satellite_client/src/client.ts
@@ -26,7 +26,7 @@ export const open_db = (name: string,
     replication: {
       host: host,
       port: port,
-      insecure: true,
+      ssl: false,
     },
     token: "token",
     debug: true

--- a/integration_tests/satellite_client/yarn.lock
+++ b/integration_tests/satellite_client/yarn.lock
@@ -255,7 +255,7 @@ diff@^4.0.1:
 
 "electric-sql@https://github.com/electric-sql/typescript-client.git":
   version "0.3.1"
-  resolved "https://github.com/electric-sql/typescript-client.git#79aee3f4909b64facf4d7e5f849a9336e9b8cc92"
+  resolved "https://github.com/electric-sql/typescript-client.git#00716f0b143d28e2e45244f6617ddd08040a493b"
   dependencies:
     base-64 "^1.0.0"
     events "^3.3.0"


### PR DESCRIPTION
Companion patch to update integration tests config.