### PR TITLE
fix: use init that makes containers handle SIGTERM

### DIFF
--- a/compose-mounts.yaml
+++ b/compose-mounts.yaml
@@ -1,5 +1,5 @@
 # Run using `docker-compose -f databases.yaml up`.
-version: '3.1'
+version: '3.7'
 
 services:
   vaxine:

--- a/integration_tests/common.luxinc
+++ b/integration_tests/common.luxinc
@@ -13,8 +13,8 @@
 [endmacro]
 
 [macro ok]
-    [timeout 1]
     ?SH-PROMPT:
+    [timeout 1]
     !echo ==$$?==
     ?^==0==
     [timeout]

--- a/integration_tests/common.luxinc
+++ b/integration_tests/common.luxinc
@@ -13,9 +13,11 @@
 [endmacro]
 
 [macro ok]
+    [timeout 1]
     ?SH-PROMPT:
     !echo ==$$?==
     ?^==0==
+    [timeout]
 [endmacro]
 
 [macro ok2 prompt]

--- a/integration_tests/common.mk
+++ b/integration_tests/common.mk
@@ -65,6 +65,9 @@ stop_dev_env:
 	if [ -n "`docker ps --filter name=elixir_client --format '{{.Names}}'`" ]; then \
 		docker ps --filter name=elixir_client --format '{{.Names}}' | xargs docker kill; \
 	fi
+	if [ -n "`docker ps --filter name=satellite_client --format '{{.Names}}'`" ]; then \
+		docker ps --filter name=satellite_client --format '{{.Names}}' | xargs docker kill; \
+	fi
 	docker-compose -f ${DOCKER_COMPOSE_FILE} down
 	docker-compose -f ${DOCKER_COMPOSE_FILE} stop
 

--- a/integration_tests/common.mk
+++ b/integration_tests/common.mk
@@ -62,7 +62,9 @@ start_electric_%:
 	docker-compose -f ${DOCKER_COMPOSE_FILE} up --no-color --no-log-prefix electric_$*
 
 stop_dev_env:
-	docker ps --filter name=elixir_client --format '{{.Names}}' | xargs docker kill
+	if [ -n "`docker ps --filter name=elixir_client --format '{{.Names}}'`" ]; then \
+		docker ps --filter name=elixir_client --format '{{.Names}}' | xargs docker kill; \
+	fi
 	docker-compose -f ${DOCKER_COMPOSE_FILE} down
 	docker-compose -f ${DOCKER_COMPOSE_FILE} stop
 

--- a/integration_tests/common.mk
+++ b/integration_tests/common.mk
@@ -62,6 +62,7 @@ start_electric_%:
 	docker-compose -f ${DOCKER_COMPOSE_FILE} up --no-color --no-log-prefix electric_$*
 
 stop_dev_env:
+	docker ps --filter name=elixir_client --format '{{.Names}}' | xargs docker kill
 	docker-compose -f ${DOCKER_COMPOSE_FILE} down
 	docker-compose -f ${DOCKER_COMPOSE_FILE} stop
 

--- a/integration_tests/migrations/compose.yaml
+++ b/integration_tests/migrations/compose.yaml
@@ -1,5 +1,5 @@
 # Run using `docker-compose -f databases.yaml up`.
-version: '3.1'
+version: '3.7'
 
 services:
   vaxine_1:

--- a/integration_tests/multi_dc/compose.yaml
+++ b/integration_tests/multi_dc/compose.yaml
@@ -1,5 +1,5 @@
 # Run using `docker-compose -f databases.yaml up`.
-version: '3.1'
+version: '3.7'
 
 services:
   vaxine_1:

--- a/integration_tests/services_templates.yaml
+++ b/integration_tests/services_templates.yaml
@@ -1,6 +1,7 @@
 services:
   vaxine:
     image: "${VAXINE_IMAGE}"
+    init: true
     environment:
       RING_SIZE: "1"
       ANTIDOTE_TXN_CERT: "false" # disabled because we must accept all transactions
@@ -21,6 +22,7 @@ services:
 
   electric:
     image: "${ELECTRIC_IMAGE}"
+    init: true
     privileged: true
 
   sysbench:

--- a/integration_tests/single_dc/compose.yaml
+++ b/integration_tests/single_dc/compose.yaml
@@ -1,5 +1,5 @@
 # Run using `docker-compose -f databases.yaml up`.
-version: '3.1'
+version: '3.7'
 
 services:
   vaxine_1:


### PR DESCRIPTION
This change requires Docker engine 18.06.0+ to be installed. That's more than 2 years ago so I think that's ok for our modern dev. `electric` and `vaxine` containers don't seem to handle SIGTERMs in how they implement entrypoints, so this makes them behave.

A more universal approach would be to bake in `tini` or smth like that into the docker images, but this is faster for now.

References:
1. https://vsupalov.com/docker-compose-stop-slow/
2. https://github.com/krallin/tini