### PR TITLE
chore: Add target to bump electric-sql version for satellite client

### DIFF
--- a/integration_tests/satellite_client/Makefile
+++ b/integration_tests/satellite_client/Makefile
@@ -15,6 +15,9 @@ build:
 local-build: node_modules
 	yarn build
 
+bump-electric-sql:
+	yarn remove electric-sql && yarn add git+https://github.com/electric-sql/typescript-client.git#${COMMIT}
+
 run_node:
 	yarn node
 


### PR DESCRIPTION
Tiny pr for bumping version based on the commit.