### PR TITLE
chore: publish versioned tags to DockerHub [VAX-539, VAX-541]

### DIFF
--- a/.buildkite/docker-image.yml
+++ b/.buildkite/docker-image.yml
@@ -1,5 +1,6 @@
 env:
   DOCKER_REPO: europe-docker.pkg.dev/vaxine/electric-sql
+  DOCKERHUB_REPO: electricsql
   IMAGE_NAME: electric
 
 agent:
@@ -15,3 +16,9 @@ steps:
       - export ELECTRIC_IMAGE_NAME="${DOCKER_REPO}/${IMAGE_NAME}"
       - export ELECTRIC_VERSION=$(make --silent print_version_from_git)
       - make docker-build-ci
+  - wait
+  - label: ":rocket: Publish the image to DockerHub"
+    if: build.tag =~ /^[0-9]+\.[0-9]+\.[0-9]+/
+    command:
+      - export ELECTRIC_IMAGE_NAME="${DOCKERHUB_REPO}/${IMAGE_NAME}"
+      - make docker-build-ci-crossplatform

--- a/.buildkite/docker-image.yml
+++ b/.buildkite/docker-image.yml
@@ -1,5 +1,5 @@
 env:
-  DOCKER_REPO: europe-docker.pkg.dev/vaxine/electric
+  DOCKER_REPO: europe-docker.pkg.dev/vaxine/electric-sql
   IMAGE_NAME: electric
 
 agent:

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,13 @@ ifeq (${TAG_AS_LATEST}, true)
 	docker push "${ELECTRIC_IMAGE_NAME}:latest"
 endif
 
+docker-build-ci-crossplatform:
+	mkdir -p deps
+	docker buildx build --platform linux/arm64/v8,linux/amd64 --push \
+			--build-arg ELECTRIC_VERSION=${ELECTRIC_VERSION} \
+			-t ${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION} \
+			-t ${ELECTRIC_IMAGE_NAME}:latest .
+
 docker-clean:
 ifneq ($(docker images -q electric:local-build 2> /dev/null), "")
 	docker image rm -f electric:local-build


### PR DESCRIPTION
- Fill the version field of `mix.exs` from closest git tag
- Use that version to tag docker images
- Push images to Dockerhub if a tag is pushed