### PR TITLE
chore: fixed duplicating coverage comment on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,15 @@ jobs:
         env:
           MIX_ENV: test
 
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
       - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@v1
+        uses: zgosalvez/github-actions-report-lcov@v3
         with:
           coverage-files: cover/lcov.info
           artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          update-comment: true
 
   dialyzer:
     name: dialyzer and formatting


### PR DESCRIPTION
Instead of creating a comment with coverage on each push, now one comment will be created and updated with each push instead