### PR TITLE
chore: Add stop target for all integration tests

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -22,6 +22,9 @@ pull:
 		postgresql \
 		satellite_client
 
+stop:
+	$(foreach dir, $(LUX_DIRS),make -C ${dir} stop_dev_env;)
+
 clean:
 	$(foreach dir, $(LUX_DIRS),make -C ${dir} clean;)
 	rm -rf lux


### PR DESCRIPTION
Tiny PR for stopping all docker instances in integration tests.