### PR TITLE
[VAX-585] Fix memory explosion when running load tests

### DIFF
--- a/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -306,6 +306,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
       | origin: origin,
         publication: state.publication,
         lsn: end_lsn,
+        # Make sure not to pass state.field into ack function, as this
+        # will create a copy of the whole state in memory when sending a message
         ack_fn: fn -> ack(conn, origin, end_lsn) end
     }
   end

--- a/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -298,12 +298,15 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   end
 
   defp build_message(%Transaction{} = transaction, end_lsn, %State{} = state) do
+    conn = state.conn
+    origin = state.origin
+
     %Transaction{
       transaction
-      | origin: state.origin,
+      | origin: origin,
         publication: state.publication,
         lsn: end_lsn,
-        ack_fn: fn -> ack(state.conn, state.origin, end_lsn) end
+        ack_fn: fn -> ack(conn, origin, end_lsn) end
     }
   end
 


### PR DESCRIPTION
Referencing `State.origin` and `State.conn` from within lambda function will add the entire `State` to the free variables of the fun, which will cause immerse memory growth when sending this message to a different process, because it will affectively copy the whole state in it.