### PR TITLE
Replaced the patched PG version with a trigger

### DIFF
--- a/integration_tests/00_shared_init.sql
+++ b/integration_tests/00_shared_init.sql
@@ -9,3 +9,69 @@ CREATE TABLE electric.migrations (
 );
 
 INSERT INTO electric.migrations (version, hash) VALUES ('1', 'initial');
+
+CREATE OR REPLACE FUNCTION upsert_from_replication_stream_insert()
+RETURNS TRIGGER AS $$
+DECLARE
+  _table_name text;
+  _schema_name text;
+  _primary_key_cols text[];
+  _column_list text[];
+  _insert_columns text;
+  _update_columns text;
+  _values_clause text;
+  _column_name text;
+  _quoted_value text;
+BEGIN
+  _table_name := TG_TABLE_NAME;
+  _schema_name := TG_TABLE_SCHEMA;
+
+  -- Get the primary key and column names
+  SELECT array_agg(column_name)
+  INTO _column_list
+  FROM information_schema.columns
+  WHERE table_schema = _schema_name AND table_name = _table_name;
+
+  SELECT array_agg(a.attname ORDER BY i.indkey)
+  INTO _primary_key_cols
+  FROM
+    pg_index i
+    JOIN pg_class c ON c.oid = i.indrelid
+    JOIN pg_attribute a ON a.attrelid = c.oid
+      AND a.attnum = ANY (i.indkey)
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE
+    relname = _table_name AND nspname = _schema_name
+    AND indisprimary;
+
+  -- Build clauses
+  _insert_columns := format('(%s)', array_to_string(_column_list, ', '));
+  _update_columns := (SELECT string_agg(column_name || ' = EXCLUDED.' || column_name, ', ') FROM unnest(_column_list) AS t(column_name) WHERE column_name != ALL (_primary_key_cols));
+
+  _values_clause := '';
+  FOREACH _column_name IN ARRAY _column_list LOOP
+    EXECUTE 'SELECT quote_nullable($1.' || quote_ident(_column_name) || ')'
+    INTO _quoted_value
+    USING NEW;
+    _values_clause := _values_clause || _quoted_value || ', ';
+  END LOOP;
+  _values_clause := format('(%s)', rtrim(_values_clause, ', '));
+
+
+  EXECUTE format('
+    INSERT INTO %I.%I %s
+    VALUES %s
+    ON CONFLICT (%s)
+    DO UPDATE SET %s',
+    _schema_name,
+    _table_name,
+    _insert_columns,
+    _values_clause,
+    array_to_string(_primary_key_cols, ', '),
+    _update_columns
+  );
+
+  -- Skip the original UPDATE operation
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;

--- a/integration_tests/common.mk
+++ b/integration_tests/common.mk
@@ -19,7 +19,7 @@ ifdef USE_LOCAL_IMAGE
 	export SYSBENCH_IMAGE?=sysbench:local-build
 else
 	export VAXINE_IMAGE?=${DOCKER_REGISTRY}/vaxine:latest
-	export POSTGRESQL_IMAGE?=${DOCKER_REGISTRY}/postgres:latest
+	export POSTGRESQL_IMAGE?=postgres:14
 	export SYSBENCH_IMAGE?=${DOCKER_REGISTRY}/sysbench:latest
 endif
 

--- a/integration_tests/init.sql
+++ b/integration_tests/init.sql
@@ -11,3 +11,11 @@ CREATE TABLE owned_entries (
   content VARCHAR(64) NOT NULL
 );
 ALTER TABLE owned_entries REPLICA IDENTITY FULL;
+
+CREATE OR REPLACE TRIGGER insert_on_conflict_for_logical_trigger
+BEFORE INSERT ON "entries"
+FOR EACH ROW
+WHEN (pg_trigger_depth() < 1)
+EXECUTE PROCEDURE upsert_from_replication_stream_insert();
+
+ALTER TABLE "entries" enable replica trigger insert_on_conflict_for_logical_trigger;

--- a/integration_tests/migrations/m_null_default_support/1669232573_init/postgres.sql
+++ b/integration_tests/migrations/m_null_default_support/1669232573_init/postgres.sql
@@ -14,3 +14,11 @@ CREATE TABLE public.items (
 
 ALTER TABLE public.items REPLICA IDENTITY FULL;
 
+CREATE OR REPLACE TRIGGER insert_on_conflict_for_logical_trigger
+BEFORE INSERT ON public.items
+FOR EACH ROW
+WHEN (pg_trigger_depth() < 1)
+EXECUTE PROCEDURE upsert_from_replication_stream_insert();
+
+ALTER TABLE public.items enable replica trigger insert_on_conflict_for_logical_trigger;
+

--- a/integration_tests/migrations/m_sanity_check/1669232573_init/postgres.sql
+++ b/integration_tests/migrations/m_sanity_check/1669232573_init/postgres.sql
@@ -10,6 +10,14 @@ CREATE TABLE public.items (
 
 ALTER TABLE public.items REPLICA IDENTITY FULL;
 
+CREATE OR REPLACE TRIGGER insert_on_conflict_for_logical_trigger
+BEFORE INSERT ON public.items
+FOR EACH ROW
+WHEN (pg_trigger_depth() < 1)
+EXECUTE PROCEDURE upsert_from_replication_stream_insert();
+
+ALTER TABLE public.items enable replica trigger insert_on_conflict_for_logical_trigger;
+
 CREATE TABLE public.other_items (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     content VARCHAR(64) DEFAULT '' NOT NULL,
@@ -17,3 +25,11 @@ CREATE TABLE public.other_items (
 );
 
 ALTER TABLE public.other_items REPLICA IDENTITY FULL;
+
+CREATE OR REPLACE TRIGGER insert_on_conflict_for_logical_trigger
+BEFORE INSERT ON public.other_items
+FOR EACH ROW
+WHEN (pg_trigger_depth() < 1)
+EXECUTE PROCEDURE upsert_from_replication_stream_insert();
+
+ALTER TABLE public.other_items enable replica trigger insert_on_conflict_for_logical_trigger;

--- a/integration_tests/single_dc/sysbench_ws.lux
+++ b/integration_tests/single_dc/sysbench_ws.lux
@@ -27,6 +27,34 @@
     !exit
     [invoke ok]
 
+[shell pg_1]
+    [loop iter 1..10]
+        """!
+        CREATE OR REPLACE TRIGGER insert_on_conflict_for_logical_trigger
+        BEFORE INSERT ON "sbtest$iter"
+        FOR EACH ROW
+        WHEN (pg_trigger_depth() < 1)
+        EXECUTE PROCEDURE upsert_from_replication_stream_insert();
+
+        ALTER TABLE "sbtest$iter" enable replica trigger insert_on_conflict_for_logical_trigger;
+        """
+        ?$psql
+    [endloop]
+
+[shell pg_2]
+    [loop iter 1..10]
+        """!
+        CREATE OR REPLACE TRIGGER insert_on_conflict_for_logical_trigger
+        BEFORE INSERT ON "sbtest$iter"
+        FOR EACH ROW
+        WHEN (pg_trigger_depth() < 1)
+        EXECUTE PROCEDURE upsert_from_replication_stream_insert();
+
+        ALTER TABLE "sbtest$iter" enable replica trigger insert_on_conflict_for_logical_trigger;
+        """
+        ?$psql
+    [endloop]
+
 [invoke setup_rest]
 
 [macro wait_table table]

--- a/lib/electric/replication/postgres/slot_server.ex
+++ b/lib/electric/replication/postgres/slot_server.ex
@@ -393,19 +393,19 @@ defmodule Electric.Replication.Postgres.SlotServer do
          %Changes.UpdatedRecord{relation: table, old_record: nil, record: new},
          relations
        ) do
-    %ReplicationMessages.Update{
+    %ReplicationMessages.Insert{
       relation_id: relations[table].oid,
       tuple_data: record_to_tuple(new, relations[table].columns)
     }
   end
 
   defp changes_to_wal(
-         %Changes.UpdatedRecord{relation: table, old_record: old, record: new},
+         %Changes.UpdatedRecord{relation: table, old_record: _old, record: new},
          relations
        ) do
-    %ReplicationMessages.Update{
+    %ReplicationMessages.Insert{
       relation_id: relations[table].oid,
-      old_tuple_data: record_to_tuple(old, relations[table].columns),
+      # old_tuple_data: record_to_tuple(old, relations[table].columns),
       tuple_data: record_to_tuple(new, relations[table].columns)
     }
   end


### PR DESCRIPTION
There are multiple aspects here that need to be highlighted:
1. Previously, any updates coming from Vaxine were treated as `UPDATE` and converted to `INSERT` as needed by the PG patch. To get rid of the patch, we need to do the same but with triggers
2. We can't use `BEFORE UPDATE` trigger and convert to `INSERT` because on a "vanilla" PG any update that affects a nonexistent row is discarded **before** it executes the trigger. Hence, the only approach here is to convert `INSERT` to `UPDATE` instead.
3. This commit modifies the **slot server** for Postgres to convert all outgoing messages to INSERTs, in hopes that PG will figure out the rest. This might not be the best approach long-term if we want to actually allow Satellite to send "pure" updates, but we need to think about this more carefully closer to the implementation.
4. This change assumes that the trigger **definitely exists** for all tables that will be part of the replication. In the current setup this means that we need to add the migration code, however I've not added any code to migration generation yet, as I'm not sure if it's needed right now. The relevant code is added to the integration tests so that they pass for now with the new image
5. This solution utilizes a uniform trigger function that introspects PG columns/primary keys to work. This makes it generic with regards to table structure, however it's slower than doing code-generation at migration to make tailored functions for each table. The per-table approach is more complicated at migration time, and we'd need to regenerate the functions on column add. Would love some input from @magnetised 