### PR TITLE
fix: insert all column values on update

### DIFF
--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -679,7 +679,8 @@ export class SatelliteProcess implements Satellite {
           local_origin,
           localChanges.changes,
           incoming_origin,
-          incomingChanges.changes
+          incomingChanges.changes,
+          incomingChanges.fullRow
         )
         let optype
 
@@ -996,11 +997,11 @@ function _applyDeleteOperation(
 }
 
 function _applyNonDeleteOperation(
-  { changes, primaryKeyCols }: ShadowEntryChanges,
+  { fullRow, primaryKeyCols }: ShadowEntryChanges,
   tablenameStr: string
 ): Statement {
-  const columnNames = Object.keys(changes)
-  const columnValues = Object.values(changes).map((c) => c.value)
+  const columnNames = Object.keys(fullRow)
+  const columnValues = Object.values(fullRow)
   let insertStmt = `INTO ${tablenameStr}(${columnNames.join(
     ', '
   )}) VALUES (${columnValues.map((_) => '?').join(',')})`
@@ -1010,7 +1011,7 @@ function _applyNonDeleteOperation(
     .reduce(
       (acc, c) => {
         acc.where.push(`${c} = ?`)
-        acc.values.push(changes[c].value)
+        acc.values.push(fullRow[c])
         return acc
       },
       { where: [] as string[], values: [] as SqlValue[] }

--- a/clients/typescript/test/satellite/process.migration.test.ts
+++ b/clients/typescript/test/satellite/process.migration.test.ts
@@ -146,7 +146,7 @@ const fetchParentRows = async (adapter: DatabaseAdapter): Promise<Row[]> => {
   })
 }
 
-const eqSet = (xs, ys) =>
+const eqSet = (xs: any[], ys: any[]) =>
   xs.length === ys.length &&
   xs.every((x) => ys.some(y => isequal(x, y)))
 
@@ -318,7 +318,7 @@ test('apply migration containing DDL and non-conflicting DML', async (t: any) =>
       return {
         ...row,
         baz: null,
-      }
+      } as Row
     })
     .concat([insertExtendedRow])
 

--- a/clients/typescript/test/satellite/process.migration.test.ts
+++ b/clients/typescript/test/satellite/process.migration.test.ts
@@ -1,10 +1,10 @@
 import test from 'ava'
 import Long from 'long'
-import {makeContext, cleanAndStopSatellite, relations} from './common'
+import { makeContext, cleanAndStopSatellite, relations } from './common'
 import { DatabaseAdapter } from '../../src/drivers/better-sqlite3'
-import {DataChangeType, Row, Statement} from '../../src/util'
+import { DataChangeType, Row, Statement } from '../../src/util'
 import { SatOpMigrate_Type } from '../../src/_generated/protocol/satellite'
-import {generateTag} from '../../src/satellite/oplog'
+import { generateTag } from '../../src/satellite/oplog'
 import isequal from 'lodash.isequal'
 
 test.beforeEach(async (t: any) => {
@@ -22,7 +22,7 @@ test.beforeEach(async (t: any) => {
   const ackTx = {
     origin: satellite._authState.clientId,
     commit_timestamp: Long.fromNumber(txDate.getTime()),
-    changes: [ ], // doesn't matter, only the origin and timestamp matter for GC of the oplog
+    changes: [], // doesn't matter, only the origin and timestamp matter for GC of the oplog
     lsn: new Uint8Array(),
   }
   await satellite._applyTransaction(ackTx)
@@ -147,8 +147,7 @@ const fetchParentRows = async (adapter: DatabaseAdapter): Promise<Row[]> => {
 }
 
 const eqSet = (xs: any[], ys: any[]) =>
-  xs.length === ys.length &&
-  xs.every((x) => ys.some(y => isequal(x, y)))
+  xs.length === ys.length && xs.every((x) => ys.some((y) => isequal(x, y)))
 
 test('apply migration containing only DDL', async (t: any) => {
   const { satellite, adapter, txDate } = t.context
@@ -203,21 +202,21 @@ test('apply migration containing DDL and non-conflicting DML', async (t: any) =>
   const { satellite, adapter, txDate } = t.context
   const timestamp = txDate.getTime()
 
-  const txTags = [ generateTag('remote', txDate) ]
+  const txTags = [generateTag('remote', txDate)]
   const mkInsertChange = (record: any) => {
     return {
       type: DataChangeType.INSERT,
       relation: relations['parent'],
       record: record,
       oldRecord: {},
-      tags: txTags
+      tags: txTags,
     }
   }
 
   const insertRow = {
     id: 3,
     value: 'remote',
-    other: 1
+    other: 1,
   }
 
   const insertChange = mkInsertChange(insertRow)
@@ -225,13 +224,13 @@ test('apply migration containing DDL and non-conflicting DML', async (t: any) =>
   const oldUpdateRow = {
     id: 1,
     value: 'local',
-    other: null
+    other: null,
   }
 
   const updateRow = {
     id: 1,
     value: 'remote',
-    other: 5
+    other: 5,
   }
 
   const updateChange = {
@@ -240,18 +239,20 @@ test('apply migration containing DDL and non-conflicting DML', async (t: any) =>
     relation: relations['parent'],
     record: updateRow,
     oldRecord: oldUpdateRow,
-    tags: txTags
+    tags: txTags,
   }
 
   // Delete overwrites the insert for row with id 2
   // Thus, it overwrites the shadow tag for that row
   const localEntries = await satellite._getEntries()
-  const shadowEntryForRow2 = await satellite._getOplogShadowEntry(localEntries[1]) // shadow entry for insert of row with id 2
+  const shadowEntryForRow2 = await satellite._getOplogShadowEntry(
+    localEntries[1]
+  ) // shadow entry for insert of row with id 2
   const shadowTagsRow2 = JSON.parse(shadowEntryForRow2[0].tags)
 
   const deleteRow = {
     id: 2,
-    value: 'local'
+    value: 'local',
   }
 
   const deleteChange = {
@@ -259,40 +260,46 @@ test('apply migration containing DDL and non-conflicting DML', async (t: any) =>
     relation: relations['parent'],
     record: deleteRow,
     oldRecord: {},
-    tags: shadowTagsRow2
+    tags: shadowTagsRow2,
   }
 
   const insertExtendedRow = {
     id: 4,
     value: 'remote',
     other: 6,
-    baz: 'foo'
+    baz: 'foo',
   }
   const insertExtendedChange = mkInsertChange(insertExtendedRow)
 
   const insertExtendedWithoutValueRow = {
     id: 5,
     value: 'remote',
-    other: 7
+    other: 7,
   }
-  const insertExtendedWithoutValueChange = mkInsertChange(insertExtendedWithoutValueRow)
+  const insertExtendedWithoutValueChange = mkInsertChange(
+    insertExtendedWithoutValueRow
+  )
 
   const insertInNewTableRow = {
     id: '1',
     foo: 1,
-    bar: '2'
+    bar: '2',
   }
   const insertInNewTableChange = {
     type: DataChangeType.INSERT,
     relation: relations['NewTable'],
     record: insertInNewTableRow,
     oldRecord: {},
-    tags: txTags
+    tags: txTags,
   }
 
-  const dml1 = [ insertChange, updateChange, deleteChange ]
-  const ddl1 = [ addColumn, createTable ]
-  const dml2 = [ insertExtendedChange, insertExtendedWithoutValueChange, insertInNewTableChange ]
+  const dml1 = [insertChange, updateChange, deleteChange]
+  const ddl1 = [addColumn, createTable]
+  const dml2 = [
+    insertExtendedChange,
+    insertExtendedWithoutValueChange,
+    insertInNewTableChange,
+  ]
 
   const migrationTx = {
     origin: 'remote',
@@ -339,16 +346,16 @@ test('apply migration containing DDL and conflicting DML', async (t: any) => {
 
   // Fetch the shadow tag for row 1 such that delete will overwrite it
   const localEntries = await satellite._getEntries()
-  const shadowEntryForRow1 = await satellite._getOplogShadowEntry(localEntries[0]) // shadow entry for insert of row with id 1
+  const shadowEntryForRow1 = await satellite._getOplogShadowEntry(
+    localEntries[0]
+  ) // shadow entry for insert of row with id 1
   const shadowTagsRow1 = JSON.parse(shadowEntryForRow1[0].tags)
 
   // Locally update row with id 1
-  await adapter.runInTransaction(
-    {
-      sql: `UPDATE parent SET value = ?, other = ? WHERE id = ?;`,
-      args: ['still local', 5, 1],
-    }
-  )
+  await adapter.runInTransaction({
+    sql: `UPDATE parent SET value = ?, other = ? WHERE id = ?;`,
+    args: ['still local', 5, 1],
+  })
 
   await satellite._performSnapshot()
 
@@ -359,7 +366,7 @@ test('apply migration containing DDL and conflicting DML', async (t: any) => {
 
   const deleteRow = {
     id: 1,
-    value: 'local'
+    value: 'local',
   }
 
   const deleteChange = {
@@ -367,12 +374,12 @@ test('apply migration containing DDL and conflicting DML', async (t: any) => {
     relation: relations['parent'],
     record: deleteRow,
     oldRecord: {},
-    tags: shadowTagsRow1
+    tags: shadowTagsRow1,
   }
 
   // Process the incoming delete
-  const ddl = [ addColumn, createTable ]
-  const dml = [ deleteChange ]
+  const ddl = [addColumn, createTable]
+  const dml = [deleteChange]
 
   const migrationTx = {
     origin: 'remote',
@@ -382,7 +389,9 @@ test('apply migration containing DDL and conflicting DML', async (t: any) => {
   }
 
   const rowsBeforeMigration = await fetchParentRows(adapter)
-  const rowsBeforeMigrationExceptConflictingRow = rowsBeforeMigration.filter(r => r.id !== deleteRow.id)
+  const rowsBeforeMigrationExceptConflictingRow = rowsBeforeMigration.filter(
+    (r) => r.id !== deleteRow.id
+  )
 
   // Apply the migration transaction
   await satellite._applyTransaction(migrationTx)
@@ -393,30 +402,29 @@ test('apply migration containing DDL and conflicting DML', async (t: any) => {
   // The local update and remote delete happened concurrently
   // Check that the update wins
   const rowsAfterMigration = await fetchParentRows(adapter)
-  const newRowsExceptConflictingRow = rowsAfterMigration.filter(r => r.id !== deleteRow.id)
-  const conflictingRow = rowsAfterMigration.find(r => r.id === deleteRow.id)
+  const newRowsExceptConflictingRow = rowsAfterMigration.filter(
+    (r) => r.id !== deleteRow.id
+  )
+  const conflictingRow = rowsAfterMigration.find((r) => r.id === deleteRow.id)
 
   t.assert(
     eqSet(
-      rowsBeforeMigrationExceptConflictingRow.map(r => {
+      rowsBeforeMigrationExceptConflictingRow.map((r) => {
         return {
           baz: null,
-          ...r
+          ...r,
         }
       }),
       newRowsExceptConflictingRow
     )
   )
 
-  t.deepEqual(
-    conflictingRow,
-    {
-      id: 1,
-      value: 'still local',
-      other: 5,
-      baz: null
-    }
-  )
+  t.deepEqual(conflictingRow, {
+    id: 1,
+    value: 'still local',
+    other: 5,
+    baz: null,
+  })
 })
 
 test('apply migration and concurrent transaction', async (t: any) => {
@@ -425,8 +433,8 @@ test('apply migration and concurrent transaction', async (t: any) => {
   const timestamp = txDate.getTime()
   const remoteA = 'remoteA'
   const remoteB = 'remoteB'
-  const txTagsRemoteA = [ generateTag(remoteA, txDate) ]
-  const txTagsRemoteB = [ generateTag(remoteB, txDate) ]
+  const txTagsRemoteA = [generateTag(remoteA, txDate)]
+  const txTagsRemoteB = [generateTag(remoteB, txDate)]
 
   const mkInsertChange = (record: any, tags: string[]) => {
     return {
@@ -434,20 +442,20 @@ test('apply migration and concurrent transaction', async (t: any) => {
       relation: relations['parent'],
       record: record,
       oldRecord: {},
-      tags: tags
+      tags: tags,
     }
   }
 
   const insertRowA = {
     id: 3,
     value: 'remote A',
-    other: 8
+    other: 8,
   }
 
   const insertRowB = {
     id: 3,
     value: 'remote B',
-    other: 9
+    other: 9,
   }
 
   // Make 2 concurrent insert changes.
@@ -459,16 +467,16 @@ test('apply migration and concurrent transaction', async (t: any) => {
   const txA = {
     origin: remoteA,
     commit_timestamp: Long.fromNumber(timestamp),
-    changes: [ insertChangeA ],
+    changes: [insertChangeA],
     lsn: new Uint8Array(),
   }
 
-  const ddl = [ addColumn, createTable ]
+  const ddl = [addColumn, createTable]
 
   const txB = {
     origin: remoteB,
     commit_timestamp: Long.fromNumber(timestamp),
-    changes: [ ...ddl, insertChangeB ],
+    changes: [...ddl, insertChangeB],
     lsn: new Uint8Array(),
   }
 
@@ -486,22 +494,22 @@ test('apply migration and concurrent transaction', async (t: any) => {
   const extendRow = (r: Row) => {
     return {
       ...r,
-      baz: null
+      baz: null,
     }
   }
   const extendedRows = rowsBeforeMigration.map(extendRow)
 
   // Check that all rows now have an additional column
   t.deepEqual(
-    rowsAfterMigration.filter(r => r.id !== insertRowA.id),
+    rowsAfterMigration.filter((r) => r.id !== insertRowA.id),
     extendedRows
   )
 
-  const conflictingRow = rowsAfterMigration.find(r => r.id === insertRowA.id)
+  const conflictingRow = rowsAfterMigration.find((r) => r.id === insertRowA.id)
 
   // Now also check the row that was concurrently inserted
   t.assert(
     isequal(conflictingRow, extendRow(insertRowA)) ||
-    isequal(conflictingRow, extendRow(insertRowB))
+      isequal(conflictingRow, extendRow(insertRowB))
   )
 })

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -655,9 +655,9 @@ test('concurrent updates take all changed values', async (t) => {
       {
         id: 1,
         value: 'local',
-        other: 0
+        other: 0,
       }
-    )
+    ),
   ]
 
   const local = [
@@ -676,7 +676,7 @@ test('concurrent updates take all changed values', async (t) => {
       {
         id: 1,
         value: 'local',
-        other: 0
+        other: 0,
       }
     ),
   ]
@@ -745,7 +745,7 @@ test('merge incoming with empty local', async (t) => {
       id: { value: 1, timestamp: incomingTs },
     },
     fullRow: {
-      id: 1
+      id: 1,
     },
     tags: [generateTag('remote', new Date(incomingTs))],
   })

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -310,6 +310,11 @@ test('take snapshot and merge local wins', async (t) => {
       value: { value: 'local', timestamp: localTimestamp },
       other: { value: 1, timestamp: localTimestamp },
     },
+    fullRow: {
+      id: 1,
+      value: 'local',
+      other: 1,
+    },
     tags: [
       generateTag(clientId, localTime),
       generateTag('remote', new Date(incomingTs)),
@@ -360,6 +365,11 @@ test('take snapshot and merge incoming wins', async (t) => {
       id: { value: 1, timestamp: incomingTs },
       value: { value: 'incoming', timestamp: incomingTs },
       other: { value: 1, timestamp: localTimestamp },
+    },
+    fullRow: {
+      id: 1,
+      value: 'incoming',
+      other: 1,
     },
     tags: [
       generateTag(clientId, new Date(localTimestamp)),
@@ -608,6 +618,89 @@ test('INSERT wins over DELETE and restored deleted values', async (t) => {
       value: { value: 'local', timestamp: localTs },
       other: { value: 1, timestamp: incomingTs },
     },
+    fullRow: {
+      id: 1,
+      value: 'local',
+      other: 1,
+    },
+    tags: [
+      generateTag(clientId, new Date(localTs)),
+      generateTag('remote', new Date(incomingTs)),
+    ],
+  })
+})
+
+test('concurrent updates take all changed values', async (t) => {
+  const { runMigrations, satellite, tableInfo } = t.context as any
+  await runMigrations()
+  await satellite._setAuthState()
+  const clientId = satellite['_authState']['clientId']
+
+  const localTs = new Date().getTime()
+  const incomingTs = localTs + 1
+
+  const incoming = [
+    generateRemoteOplogEntry(
+      tableInfo,
+      'main',
+      'parent',
+      OPTYPES.update,
+      incomingTs,
+      genEncodedTags('remote', [incomingTs]),
+      {
+        id: 1,
+        value: 'remote', // the only modified column
+        other: 0,
+      },
+      {
+        id: 1,
+        value: 'local',
+        other: 0
+      }
+    )
+  ]
+
+  const local = [
+    generateLocalOplogEntry(
+      tableInfo,
+      'main',
+      'parent',
+      OPTYPES.update,
+      localTs,
+      genEncodedTags(clientId, [localTs]),
+      {
+        id: 1,
+        value: 'local',
+        other: 1, // the only modified column
+      },
+      {
+        id: 1,
+        value: 'local',
+        other: 0
+      }
+    ),
+  ]
+
+  const merged = satellite._mergeEntries(clientId, local, 'remote', incoming)
+  const item = merged['main.parent']['1']
+
+  // The incoming entry modified the value of the `value` column to `'remote'`
+  // The local entry concurrently modified the value of the `other` column to 1.
+  // The merged entries should have `value = 'remote'` and `other = 1`.
+  t.deepEqual(item, {
+    namespace: 'main',
+    tablename: 'parent',
+    primaryKeyCols: { id: 1 },
+    optype: OPTYPES.upsert,
+    changes: {
+      value: { value: 'remote', timestamp: incomingTs },
+      other: { value: 1, timestamp: localTs },
+    },
+    fullRow: {
+      id: 1,
+      value: 'remote',
+      other: 1,
+    },
     tags: [
       generateTag(clientId, new Date(localTs)),
       generateTag('remote', new Date(incomingTs)),
@@ -650,6 +743,9 @@ test('merge incoming with empty local', async (t) => {
     optype: OPTYPES.upsert,
     changes: {
       id: { value: 1, timestamp: incomingTs },
+    },
+    fullRow: {
+      id: 1
     },
     tags: [generateTag('remote', new Date(incomingTs))],
   })


### PR DESCRIPTION
Fixes VAX-659: Updates are translated to an insert of the modified columns. However, if some columns are not updated, it will not be part of the insert query and thus we loose those values.

This PR fixes this issue by using the complete row information in insert.
However, we need to be careful that this row contains the latest information for all columns, i.e. the incoming entry may have a bigger timestamp than the local change but if some column was only changed locally we should take that value and only use LWW for columns that were modified by both the incoming and the local change.