### PR TITLE
electric: fix a duplicate metric warning

### DIFF
--- a/components/electric/lib/electric/telemetry.ex
+++ b/components/electric/lib/electric/telemetry.ex
@@ -25,7 +25,6 @@ defmodule Electric.Telemetry do
       Metrics.counter("electric.vaxine_consumer.replication.saved"),
       Metrics.counter("electric.vaxine_consumer.replication.failed_to_write"),
       Metrics.counter("electric.satellite.connection.authorized_connection"),
-      Metrics.counter("electric.satellite.connection.authorized_connection"),
       Metrics.counter("electric.satellite.replication.started"),
       Metrics.counter("electric.satellite.replication.stopped"),
       Metrics.last_value("vm.memory.total", unit: :byte),


### PR DESCRIPTION
The warning is logged during application startup:
```
12:19:25.206 pid=<0.452.0> [warning] Metric name already exists. Dropping measure. metric_name:=[:electric, :satellite, :connection, :authorized_connection]
```