### PR TITLE
feat: add support for filters in 'where' argument in DAL

### DIFF
--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -243,6 +243,9 @@ function makeFilter(
       lte: z.any().optional(),
       gt: z.any().optional(),
       gte: z.any().optional(),
+      startsWith: z.string().optional(),
+      endsWith: z.string().optional(),
+      contains: z.string().optional(),
     }
 
     const fsHandlers = {
@@ -253,6 +256,9 @@ function makeFilter(
       lte: makeLteFilter.bind(null),
       gt: makeGtFilter.bind(null),
       gte: makeGteFilter.bind(null),
+      startsWith: makeStartsWithFilter.bind(null),
+      endsWith: makeEndsWithFilter.bind(null),
+      contains: makeContainsFilter.bind(null),
     }
 
     const filterSchema = z
@@ -334,6 +340,27 @@ function makeGteFilter(
   value: unknown
 ): { sql: string; args?: unknown[] } {
   return { sql: `${fieldName} >= ?`, args: [value] }
+}
+
+function makeStartsWithFilter(
+  fieldName: string,
+  value: unknown
+): { sql: string; args?: unknown[] } {
+  return { sql: `${fieldName} LIKE ?`, args: [`${value}%`] }
+}
+
+function makeEndsWithFilter(
+  fieldName: string,
+  value: unknown
+): { sql: string; args?: unknown[] } {
+  return { sql: `${fieldName} LIKE ?`, args: [`%${value}`] }
+}
+
+function makeContainsFilter(
+  fieldName: string,
+  value: unknown
+): { sql: string; args?: unknown[] } {
+  return { sql: `${fieldName} LIKE ?`, args: [`%${value}%`] }
 }
 
 function addOffset(i: AnyFindInput, q: PostgresSelect): PostgresSelect {

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -225,7 +225,10 @@ function addFilters<T, Q extends QueryBuilder & WhereMixin>(
   }, q)
 }
 
-function makeFilter(fieldValue: unknown, fieldName: string): { sql: string, args?: unknown[] } {
+function makeFilter(
+  fieldValue: unknown,
+  fieldName: string
+): { sql: string; args?: unknown[] } {
   if (fieldValue === null) return { sql: `${fieldName} IS NULL` }
   else if (typeof fieldValue === 'object') {
     // an object containing filters is provided
@@ -233,7 +236,7 @@ function makeFilter(fieldValue: unknown, fieldName: string): { sql: string, args
     const filterSchema = z
       .object({
         in: z.any().array().optional(),
-        not: z.any().optional() // fixme: make this a XOR such that exactly one of the filters must be provided
+        not: z.any().optional(), // fixme: make this a XOR such that exactly one of the filters must be provided
       })
       .strict('Unsupported filter in where clause')
     // TODO: remove this schema check once we support all filters
@@ -244,19 +247,16 @@ function makeFilter(fieldValue: unknown, fieldName: string): { sql: string, args
     if ('in' in obj) {
       const values = obj.in
       return { sql: `${fieldName} IN ?`, args: values }
-    }
-    else if ('not' in obj) {
+    } else if ('not' in obj) {
       const value = obj.not
       if (value === null) {
         // needed because `WHERE field != NULL` is not valid SQL
         return { sql: `${fieldName} IS NOT NULL` }
+      } else {
+        return { sql: `${fieldName} != ?`, args: [value] }
       }
-      else {
-        return { sql: `${fieldName} != ?`, args: [ value ]}
-      }
-    }
-    else {
-      throw new Error("Object provided to where argument is missing a filter")
+    } else {
+      throw new Error('Object provided to where argument is missing a filter')
     }
   }
   // needed because `WHERE field = NULL` is not valid SQL

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -239,7 +239,7 @@ function makeFilter(
       .object({
         in: z.any().array().optional(),
         not: z.any().optional(),
-        notIn: z.any().optional()
+        notIn: z.any().optional(),
       })
       .strict()
       .refine(

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -239,10 +239,11 @@ function makeFilter(
       .object({
         in: z.any().array().optional(),
         not: z.any().optional(),
+        notIn: z.any().optional()
       })
       .strict()
       .refine(
-        (data) => 'in' in data || 'not' in data,
+        (data) => 'in' in data || 'not' in data || 'notIn' in data,
         'Please provide at least one filter.'
       )
     // TODO: remove this schema check once we support all filters
@@ -250,12 +251,14 @@ function makeFilter(
 
     const obj = filterSchema.parse(fieldValue)
     const filters: Array<{ sql: string; args?: unknown[] }> = []
-    //const filtersSql: string[] = []
-    //let filtersArgs: any[] = []
 
-    if ('in' in obj && typeof obj.in !== 'undefined') {
+    if ('in' in obj) {
       const values = obj.in
       filters.push({ sql: `${fieldName} IN ?`, args: values })
+    }
+    if ('notIn' in obj) {
+      const values = obj.notIn
+      filters.push({ sql: `${fieldName} NOT IN ?`, args: values })
     }
     if ('not' in obj) {
       const value = obj.not

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -220,24 +220,47 @@ function addFilters<T, Q extends QueryBuilder & WhereMixin>(
 ): Q {
   return fields.reduce<Q>((query: Q, fieldName: string) => {
     const fieldValue = whereObject[fieldName as keyof T]
-    if (fieldValue === null) return query.where(`${fieldName} IS NULL`)
-    else if (typeof fieldValue === 'object') {
-      // an object containing filters is provided
-      // e.g. users.findMany({ where: { id: in([1, 2, 3]) } })
-      const filterSchema = z
-        .object({
-          in: z.any().array(),
-        })
-        .strict('Unsupported filter in where clause')
-      // TODO: remove this schema check once we support all filters
-      //       or remove the unsupported filters from the types and schemas that are generated from the Prisma schema
-
-      const values = filterSchema.parse(fieldValue).in
-      return query.where(`${fieldName} IN ?`, values)
-    }
-    // needed because `WHERE field = NULL` is not valid SQL
-    else return query.where(`${fieldName} = ?`, [fieldValue])
+    const filter = makeFilter(fieldValue, fieldName)
+    return query.where(filter.sql, filter.args)
   }, q)
+}
+
+function makeFilter(fieldValue: unknown, fieldName: string): { sql: string, args?: unknown[] } {
+  if (fieldValue === null) return { sql: `${fieldName} IS NULL` }
+  else if (typeof fieldValue === 'object') {
+    // an object containing filters is provided
+    // e.g. users.findMany({ where: { id: in([1, 2, 3]) } })
+    const filterSchema = z
+      .object({
+        in: z.any().array().optional(),
+        not: z.any().optional() // fixme: make this a XOR such that exactly one of the filters must be provided
+      })
+      .strict('Unsupported filter in where clause')
+    // TODO: remove this schema check once we support all filters
+    //       or remove the unsupported filters from the types and schemas that are generated from the Prisma schema
+
+    const obj = filterSchema.parse(fieldValue)
+
+    if ('in' in obj) {
+      const values = obj.in
+      return { sql: `${fieldName} IN ?`, args: values }
+    }
+    else if ('not' in obj) {
+      const value = obj.not
+      if (value === null) {
+        // needed because `WHERE field != NULL` is not valid SQL
+        return { sql: `${fieldName} IS NOT NULL` }
+      }
+      else {
+        return { sql: `${fieldName} != ?`, args: [ value ]}
+      }
+    }
+    else {
+      throw new Error("Object provided to where argument is missing a filter")
+    }
+  }
+  // needed because `WHERE field = NULL` is not valid SQL
+  else return { sql: `${fieldName} = ?`, args: [fieldValue] }
 }
 
 function addOffset(i: AnyFindInput, q: PostgresSelect): PostgresSelect {

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -231,7 +231,7 @@ function makeFilter(
   fieldValue: unknown,
   fieldName: string
 ): Array<{ sql: string; args?: unknown[] }> {
-  if (fieldValue === null) return [ { sql: `${fieldName} IS NULL` } ]
+  if (fieldValue === null) return [{ sql: `${fieldName} IS NULL` }]
   else if (typeof fieldValue === 'object') {
     // an object containing filters is provided
     // e.g. users.findMany({ where: { id: in([1, 2, 3]) } })
@@ -242,8 +242,8 @@ function makeFilter(
       })
       .strict()
       .refine(
-        data => 'in' in data || 'not' in data,
-        'Please provide at least one filter.',
+        (data) => 'in' in data || 'not' in data,
+        'Please provide at least one filter.'
       )
     // TODO: remove this schema check once we support all filters
     //       or remove the unsupported filters from the types and schemas that are generated from the Prisma schema
@@ -270,7 +270,7 @@ function makeFilter(
     return filters
   }
   // needed because `WHERE field = NULL` is not valid SQL
-  else return [ { sql: `${fieldName} = ?`, args: [fieldValue] } ]
+  else return [{ sql: `${fieldName} = ?`, args: [fieldValue] }]
 }
 
 function addOffset(i: AnyFindInput, q: PostgresSelect): PostgresSelect {

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 import { Builder } from '../../../src/client/model/builder'
-import {ZodError} from "zod";
+import { ZodError } from 'zod'
 
 const tbl = new Builder('Post', ['id', 'title', 'contents', 'nbr'])
 
@@ -198,23 +198,25 @@ test('findUnique query supports several filters', (t) => {
 })
 
 test('findUnique query with no filters throws an error', (t) => {
-  const error = t.throws(() => {
-    tbl
-      .findUnique({
+  const error = t.throws(
+    () => {
+      tbl.findUnique({
         where: {
           id: 'i2',
           nbr: 21,
-          foo: { },
+          foo: {},
         },
       })
-  }, { instanceOf: ZodError })
+    },
+    { instanceOf: ZodError }
+  )
 
-  t.deepEqual((error as ZodError).issues,  [
+  t.deepEqual((error as ZodError).issues, [
     {
-      "code": "custom",
-      "message": "Please provide at least one filter.",
-      "path": []
-    }
+      code: 'custom',
+      message: 'Please provide at least one filter.',
+      path: [],
+    },
   ])
 })
 

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -304,6 +304,26 @@ test('findMany supports NOT IN filters in where argument', (t) => {
   )
 })
 
+test('findMany supports lt, lte, gt, gte filters in where argument', (t) => {
+  const query = tbl
+    .findMany({
+      where: {
+        nbr: {
+          lt: 11,
+          lte: 10,
+          gt: 4,
+          gte: 5,
+        },
+      },
+    })
+    .toString()
+
+  t.is(
+    query,
+    'SELECT nbr, id, title, contents FROM Post WHERE (nbr < (11)) AND (nbr <= (10)) AND (nbr > (4)) AND (nbr >= (5))'
+  )
+})
+
 test('update query', (t) => {
   const query = tbl
     .update({

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -287,6 +287,23 @@ test('findMany supports IN filters in where argument', (t) => {
   )
 })
 
+test('findMany supports NOT IN filters in where argument', (t) => {
+  const query = tbl
+    .findMany({
+      where: {
+        nbr: {
+          notIn: [1, 5, 18],
+        },
+      },
+    })
+    .toString()
+
+  t.is(
+    query,
+    'SELECT nbr, id, title, contents FROM Post WHERE (nbr NOT IN (1, 5, 18))'
+  )
+})
+
 test('update query', (t) => {
   const query = tbl
     .update({

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -137,6 +137,48 @@ test('findUnique query with selection of NULL value', (t) => {
   )
 })
 
+test('findUnique query with selection of non-NULL value', (t) => {
+  const query = tbl
+    .findUnique({
+      where: {
+        id: 'i2',
+        nbr: 21,
+        foo: { not: null },
+      },
+      select: {
+        title: true,
+        contents: false,
+      },
+    })
+    .toString()
+
+  t.is(
+    query,
+    "SELECT id, nbr, foo, title FROM Post WHERE (id = ('i2')) AND (nbr = (21)) AND (foo IS NOT NULL) LIMIT 2"
+  )
+})
+
+test('findUnique query with selection of row that does not equal a value', (t) => {
+  const query = tbl
+    .findUnique({
+      where: {
+        id: 'i2',
+        nbr: 21,
+        foo: { not: 5 },
+      },
+      select: {
+        title: true,
+        contents: false,
+      },
+    })
+    .toString()
+
+  t.is(
+    query,
+    "SELECT id, nbr, foo, title FROM Post WHERE (id = ('i2')) AND (nbr = (21)) AND (foo != (5)) LIMIT 2"
+  )
+})
+
 test('findMany allows results to be ordered', (t) => {
   const query = tbl
     .findMany({

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -324,6 +324,57 @@ test('findMany supports lt, lte, gt, gte filters in where argument', (t) => {
   )
 })
 
+test('findMany supports startsWith filter in where argument', (t) => {
+  const query = tbl
+    .findMany({
+      where: {
+        title: {
+          startsWith: 'foo',
+        },
+      },
+    })
+    .toString()
+
+  t.is(
+    query,
+    "SELECT title, id, contents, nbr FROM Post WHERE (title LIKE ('foo%'))"
+  )
+})
+
+test('findMany supports endsWith filter in where argument', (t) => {
+  const query = tbl
+    .findMany({
+      where: {
+        title: {
+          endsWith: 'foo',
+        },
+      },
+    })
+    .toString()
+
+  t.is(
+    query,
+    "SELECT title, id, contents, nbr FROM Post WHERE (title LIKE ('%foo'))"
+  )
+})
+
+test('findMany supports contains filter in where argument', (t) => {
+  const query = tbl
+    .findMany({
+      where: {
+        title: {
+          contains: 'foo',
+        },
+      },
+    })
+    .toString()
+
+  t.is(
+    query,
+    "SELECT title, id, contents, nbr FROM Post WHERE (title LIKE ('%foo%'))"
+  )
+})
+
 test('update query', (t) => {
   const query = tbl
     .update({

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -577,7 +577,7 @@ test.serial('findMany allows results to be ordered', async (t) => {
 test.serial('findMany supports `not` and `in` filters', async (t) => {
   const res = await tbl.findMany({
     where: {
-      id: { not: 3, in: [1,2,3] }
+      id: { not: 3, in: [1, 2, 3] },
     },
     orderBy: [
       {

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -574,6 +574,24 @@ test.serial('findMany allows results to be ordered', async (t) => {
   t.deepEqual(res, [post1, post3, post2])
 })
 
+test.serial('findMany supports `not` and `in` filters', async (t) => {
+  const res = await tbl.findMany({
+    where: {
+      id: { not: 3, in: [1,2,3] }
+    },
+    orderBy: [
+      {
+        title: 'asc',
+      },
+      {
+        contents: 'desc',
+      },
+    ],
+  })
+
+  t.deepEqual(res, [post1, post2])
+})
+
 test.serial('update query', async (t) => {
   // Regular update
   const res = await tbl.update({


### PR DESCRIPTION
Adds support for `not` and `notIn` filters (closes VAX-692).
Adds support for `lt`, `lte`, `gt`, `gte`, `contains`, `startsWith`, and `endsWith` filters (closes VAX-525).