### PR TITLE
ci: Add package write permission to the e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,8 @@ jobs:
     defaults:
       run:
         working-directory: e2e
+    permissions:
+      packages: write
     env:
       VAXINE_IMAGE: europe-docker.pkg.dev/vaxine/vaxine-io/vaxine:latest
     steps:


### PR DESCRIPTION
Without this permission, PRs opened by dependabot failed on the "docker push to ghcr.io" step. See, for example, https://github.com/electric-sql/electric/pull/148.