### PR TITLE
refactor(electric): Refactor event processing in Replication.Postgres.MigrationConsumer

### DIFF
--- a/components/electric/lib/electric/replication/postgres/migration_consumer.ex
+++ b/components/electric/lib/electric/replication/postgres/migration_consumer.ex
@@ -156,10 +156,6 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
 
     register_relation(table, columns, state)
     |> refresh_subscription()
-
-    # update the subscription to add any new
-    # tables (this only works when data has been added -- doing it at the
-    # point of receiving the migration has no effect).
   end
 
   defp register_relation(table, columns, state) do
@@ -180,6 +176,9 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
     state
   end
 
+  # update the subscription to add any new
+  # tables (this only works when data has been added -- doing it at the
+  # point of receiving the migration has no effect).
   defp refresh_subscription(state) do
     Logger.debug("#{__MODULE__} refreshing subscription '#{state.subscription}'")
     :ok = SchemaLoader.refresh_subscription(state.loader, state.subscription)

--- a/components/electric/lib/electric/replication/postgres/migration_consumer.ex
+++ b/components/electric/lib/electric/replication/postgres/migration_consumer.ex
@@ -89,19 +89,13 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
 
   @impl GenStage
   def handle_events(events, _from, state) do
-    {:noreply, filter_events(events, []), process_events(events, {[], state})}
+    {:noreply, filter_transactions(events), process_events(events, {[], state})}
   end
 
-  defp filter_events([], acc) do
-    Enum.reverse(acc)
-  end
-
-  defp filter_events([%Relation{} | events], acc) do
-    filter_events(events, acc)
-  end
-
-  defp filter_events([event | events], acc) do
-    filter_events(events, [filter_transaction(event) | acc])
+  defp filter_transactions(events) do
+    for event <- events, not match?(%Relation{}, event) do
+      filter_transaction(event)
+    end
   end
 
   # FIXME: we need this to prevent extension metadata tables from being

--- a/components/electric/lib/electric/replication/postgres/migration_consumer.ex
+++ b/components/electric/lib/electric/replication/postgres/migration_consumer.ex
@@ -4,7 +4,6 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
   """
   use GenStage
 
-  alias Ecto.Adapter.Transaction
   alias Electric.Replication.Connectors
 
   alias Electric.Replication.Changes.{


### PR DESCRIPTION
In trying to understand the logic in the code, I found it helpful to refactor it to use a more functional programming style. There's no change in behaviour.

I recommend reviewing this PR one commit at a time.