### PR TITLE
fix(satellite): use proper `TEXT` type for shadow table columns

### DIFF
--- a/clients/typescript/src/migrators/schema.ts
+++ b/clients/typescript/src/migrators/schema.ts
@@ -8,7 +8,7 @@ export const data = {
     {
       satellite_body: [
         //`-- The ops log table\n`,
-        `CREATE TABLE IF NOT EXISTS ${oplogTable} (\n  rowid INTEGER PRIMARY KEY AUTOINCREMENT,\n  namespace String NOT NULL,\n  tablename String NOT NULL,\n  optype String NOT NULL,\n  primaryKey String NOT NULL,\n  newRow String,\n  oldRow String,\n  timestamp TEXT,  clearTags TEXT DEFAULT "[]" NOT NULL\n);`,
+        `CREATE TABLE IF NOT EXISTS ${oplogTable} (\n  rowid INTEGER PRIMARY KEY AUTOINCREMENT,\n  namespace TEXT NOT NULL,\n  tablename TEXT NOT NULL,\n  optype TEXT NOT NULL,\n  primaryKey TEXT NOT NULL,\n  newRow TEXT,\n  oldRow TEXT,\n  timestamp TEXT,  clearTags TEXT DEFAULT "[]" NOT NULL\n);`,
         //`-- Somewhere to keep our metadata\n`,
         `CREATE TABLE IF NOT EXISTS ${metaTable} (\n  key TEXT PRIMARY KEY,\n  value BLOB\n);`,
         //`-- Somewhere to track migrations\n`,
@@ -19,7 +19,7 @@ export const data = {
         `DROP TABLE IF EXISTS ${triggersTable};`,
         `CREATE TABLE ${triggersTable} (tablename STRING PRIMARY KEY, flag INTEGER);`,
         //`-- Somewhere to keep dependency tracking information\n`,
-        `CREATE TABLE ${shadowTable} (\n  namespace String NOT NULL,\n  tablename String NOT NULL,\n  primaryKey String NOT NULL,\n  tags TEXT NOT NULL,\n  PRIMARY KEY (namespace, tablename, primaryKey));`,
+        `CREATE TABLE ${shadowTable} (\n  namespace TEXT NOT NULL,\n  tablename TEXT NOT NULL,\n  primaryKey TEXT NOT NULL,\n  tags TEXT NOT NULL,\n  PRIMARY KEY (namespace, tablename, primaryKey));`,
       ],
       encoding: 'escaped',
       name: '1666288242_init',

--- a/components/electric/test/test_helper.exs
+++ b/components/electric/test/test_helper.exs
@@ -2,7 +2,7 @@ if System.get_env("INTEGRATION") do
   ExUnit.configure(capture_log: true, exclude: :test, include: :integration)
 else
   Mox.defmock(Electric.Replication.MockPostgresClient, for: Electric.Replication.Postgres.Client)
-  ExUnit.configure(exclude: :integration)
+  ExUnit.configure(capture_log: true, exclude: :integration)
   Logger.configure(level: :info)
 end
 


### PR DESCRIPTION
The initial migration was still using String instead of Text when defining the tables.