### PR TITLE
ci: Remove the "docker push ghcr.io" step from E2E runs on CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: components/electric
       - run: make docker-build-ci
         env:
-          ELECTRIC_IMAGE_NAME: ghcr.io/${{ github.repository }}/electric
+          ELECTRIC_IMAGE_NAME: electric-sql-ci/electric
         working-directory: components/electric
       - run: make pretest_compile
         working-directory: components/electric
@@ -94,7 +94,7 @@ jobs:
       - run: make test
         id: tests
         env:
-          ELECTRIC_IMAGE_NAME: ghcr.io/${{ github.repository }}/electric
+          ELECTRIC_IMAGE_NAME: electric-sql-ci/electric
           ELECTRIC_IMAGE_TAG: ${{ env.ELECTRIC_VERSION }}
 
       - name: Upload lux logs

--- a/components/electric/Makefile
+++ b/components/electric/Makefile
@@ -67,10 +67,8 @@ docker-build-ci:
 	docker build --build-arg ELECTRIC_VERSION=${ELECTRIC_VERSION} \
       -t ${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION} \
       -t electric:local-build .
-	docker push ${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION}
 ifeq (${TAG_AS_LATEST}, true)
 	docker tag "${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION}" "${ELECTRIC_IMAGE_NAME}:latest"
-	docker push "${ELECTRIC_IMAGE_NAME}:latest"
 endif
 
 docker-build-ci-crossplatform:


### PR DESCRIPTION
This step causes the CI workflow to fail for outside contributors.