### PR TITLE
feat: Specialise API types

### DIFF
--- a/clients/typescript/src/client/input/createInput.ts
+++ b/clients/typescript/src/client/input/createInput.ts
@@ -1,7 +1,9 @@
+import { NarrowCreateData, NarrowInclude, NarrowSelect } from './inputNarrowing'
+
 export interface CreateInput<Data extends object, Select, Include> {
-  data: Data
-  select?: Select
-  include?: Include
+  data: NarrowCreateData<Data>
+  select?: NarrowSelect<Select>
+  include?: NarrowInclude<Include>
 }
 
 export interface CreateManyInput<T> {

--- a/clients/typescript/src/client/input/deleteInput.ts
+++ b/clients/typescript/src/client/input/deleteInput.ts
@@ -1,9 +1,11 @@
+import { NarrowInclude, NarrowSelect, NarrowWhere } from './inputNarrowing'
+
 export interface DeleteInput<Select, WhereUnique, Include> {
   where: WhereUnique
-  select?: Select
-  include?: Include
+  select?: NarrowSelect<Select>
+  include?: NarrowInclude<Include>
 }
 
 export interface DeleteManyInput<Where> {
-  where?: Where
+  where?: NarrowWhere<Where>
 }

--- a/clients/typescript/src/client/input/findInput.ts
+++ b/clients/typescript/src/client/input/findInput.ts
@@ -1,17 +1,24 @@
 //export type SelectInput<T> = { [field in keyof T]?: boolean }
 
+import {
+  NarrowInclude,
+  NarrowOrderBy,
+  NarrowSelect,
+  NarrowWhere,
+} from './inputNarrowing'
+
 export interface FindInput<Select, Where, Include, OrderBy, ScalarFieldEnum> {
-  where?: Where
-  select?: Select
-  include?: Include
+  where?: NarrowWhere<Where>
+  select?: NarrowSelect<Select>
+  include?: NarrowInclude<Include>
   distinct?: ScalarFieldEnum[]
   take?: number
   skip?: number
-  orderBy?: OrderBy | OrderBy[]
+  orderBy?: NarrowOrderBy<OrderBy | OrderBy[]>
 }
 
 export interface FindUniqueInput<Select, Where, Include> {
   where: Where
-  select?: Select
-  include?: Include
+  select?: NarrowSelect<Select>
+  include?: NarrowInclude<Include>
 }

--- a/clients/typescript/src/client/input/inputNarrowing.ts
+++ b/clients/typescript/src/client/input/inputNarrowing.ts
@@ -1,0 +1,82 @@
+import { Removed, RemovedType } from '../util/types'
+
+/*
+ * This file defines types that are used
+ * to narrow the Prisma-generated types
+ * to contain only the features that are supported.
+ */
+
+/**
+ * Narrows the type of create data to remove unsupported properties.
+ */
+export type NarrowCreateData<T> = Removed<
+  T,
+  | 'connectOrCreate'
+  | 'createMany'
+  | 'connect'
+  | 'upsert'
+  | 'set'
+  | 'disconnect'
+  | 'delete'
+  | 'update'
+  | 'updateMany'
+  | 'deleteMany'
+>
+
+export type NarrowUpdateData<T> = Removed<
+  T,
+  | 'create'
+  | 'connectOrCreate'
+  | 'createMany'
+  | 'connect'
+  | 'upsert'
+  | 'set'
+  | 'disconnect'
+  | 'delete'
+  | 'deleteMany'
+>
+
+export type NarrowUpsertCreate<T> = Removed<
+  T,
+  'connectOrCreate' | 'createMany' | 'connect'
+>
+
+/**
+ * Narrows the type of update data to remove unsupported properties.
+ */
+export type NarrowUpdateManyData<T> = Removed<
+  T,
+  'set' | 'increment' | 'decrement' | 'multiply' | 'divide'
+>
+
+/**
+ * Narrows select types to remove the unsupported `_count` and `cursor` properties.
+ */
+export type NarrowSelect<T> = Removed<T, '_count' | 'cursor'>
+
+export type NarrowInclude<T> = NarrowSelect<T>
+
+/**
+ * Narrows where types by removing the unsupported relational filters
+ * and removing Prisma's `QueryMode` because it is used for case-insensitive search
+ * (cf. https://www.prisma.io/docs/concepts/components/prisma-client/filtering-and-sorting#case-insensitive-filtering)
+ * but that is not supported at the moment because of differences between SQLite and Postgres.
+ */
+export type NarrowWhere<T> = RemovedType<
+  Removed<T, 'every' | 'some' | 'none'>,
+  'mode',
+  'default' | 'insensitive' | 'undefined'
+>
+
+export type NarrowOrderBy<T> = Removed<T, '_count'>
+
+/**
+ * Narrows the type of create arguments to remove unsupported properties.
+ */
+/*
+type NarrowCreateArgs<T extends CreateInput<object, any, any>> = {
+  select?: NarrowSelect<T['select']>
+  include?: NarrowSelect<T['include']>
+  data: NarrowCreateData<T['data']>
+}
+ */

--- a/clients/typescript/src/client/input/updateInput.ts
+++ b/clients/typescript/src/client/input/updateInput.ts
@@ -1,11 +1,16 @@
 import { FindUniqueInput } from './findInput'
+import {
+  NarrowUpdateData,
+  NarrowUpdateManyData,
+  NarrowWhere,
+} from './inputNarrowing'
 
 export interface UpdateInput<Data, Select, Where, Include>
   extends FindUniqueInput<Select, Where, Include> {
-  data: Data
+  data: NarrowUpdateManyData<NarrowUpdateData<Data>>
 }
 
 export interface UpdateManyInput<Data, Where> {
-  data: Data
-  where?: Where
+  data: NarrowUpdateManyData<Data>
+  where?: NarrowWhere<Where>
 }

--- a/clients/typescript/src/client/input/upsertInput.ts
+++ b/clients/typescript/src/client/input/upsertInput.ts
@@ -1,7 +1,15 @@
+import {
+  NarrowInclude,
+  NarrowSelect,
+  NarrowUpdateData,
+  NarrowUpdateManyData,
+  NarrowUpsertCreate,
+} from './inputNarrowing'
+
 export interface UpsertInput<Create, Update, Select, WhereUnique, Include> {
-  select?: Select
+  select?: NarrowSelect<Select>
   where: WhereUnique
-  create: Create
-  update: Update
-  include?: Include
+  create: NarrowUpsertCreate<Create>
+  update: NarrowUpdateManyData<NarrowUpdateData<Update>>
+  include?: NarrowInclude<Include>
 }

--- a/clients/typescript/src/client/model/schema.ts
+++ b/clients/typescript/src/client/model/schema.ts
@@ -172,6 +172,10 @@ export class DbSchema<T extends TableSchemas> {
     return this.extendedTables[table].fields
   }
 
+  hasRelationForField(table: TableName, field: FieldName): boolean {
+    return this.getRelations(table).some((r) => r.relationField === field)
+  }
+
   getRelationName(table: TableName, field: FieldName): RelationName {
     return this.getRelations(table).find((r) => r.relationField === field)!
       .relationName

--- a/clients/typescript/src/client/util/types.ts
+++ b/clients/typescript/src/client/util/types.ts
@@ -1,6 +1,7 @@
 // We define Prisma's `SelectSubset` type here because TypeScript does not support higher kinded types
 // in practice, this means we cannot pass the `SelectSubset` type constructor as a type argument to a class.
 // We cannot just import this type from the Prisma library because it is part of the generated Prisma client.
+
 export type SelectSubset<T, U> = {
   [key in keyof T]: key extends keyof U ? T[key] : never
 } & (T extends SelectAndInclude
@@ -11,3 +12,35 @@ type SelectAndInclude = {
   select: any
   include: any
 }
+
+/**
+ * Removes fields that are in `Drop` from `T` and from
+ * all objects that are recursively reachable from `T`.
+ */
+export type Removed<T, Drop> = T extends object
+  ? {
+      // taken from: https://stackoverflow.com/questions/65888383/typing-recursive-function-removing-property-from-object
+      [K in keyof T]: K extends Drop ? never : Removed<T[K], Drop>
+      // Note that we can't rewrite it as:
+      //  [K in Exclude<keyof T, Drop>]: Removed<T[K], Drop>
+      // because the type needs to be homomorphic
+      // in order to keep property modifiers
+      // such as optional properties and readonly properties
+      // (cf. https://stackoverflow.com/questions/56140221/why-is-this-mapped-type-removing-the-decorator-how-can-we-achieve-a-similar)
+    }
+  : T
+
+/**
+ * Removes fields from `T` that are in `DropKey` and whose type is in `DropType`.
+ * It does this for all objects that are recursively reachable from `T`.
+ */
+export type RemovedType<T, DropKey, DropType> = T extends object
+  ? {
+      // drops fields whose key extends `DropKey` and whose type extends `DropType`
+      [K in keyof T]: K extends DropKey
+        ? T[K] extends DropType
+          ? never
+          : RemovedType<T[K], DropKey, DropType>
+        : RemovedType<T[K], DropKey, DropType>
+    }
+  : T

--- a/clients/typescript/src/client/validation/validation.ts
+++ b/clients/typescript/src/client/validation/validation.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod'
+import { InvalidArgumentError } from './errors/invalidArgumentError'
 
 function deepOmit(obj: Record<string, any>) {
   Object.keys(obj).forEach((key) => {
@@ -16,4 +17,77 @@ export function validate<I>(i: I, schema: z.ZodTypeAny): I {
   // Hence, we have to do an additional pass over the `parsedObject` to remove fields whose value is `undefined`.
   deepOmit(parsedObject)
   return parsedObject
+}
+
+export function parseNestedCreate(relationField: any): { create?: any } {
+  const createRelatedObjSchema = z
+    .object({
+      create: z.any().optional(),
+    })
+    .strict()
+
+  try {
+    return createRelatedObjSchema.parse(relationField)
+  } catch (err) {
+    if (
+      err instanceof z.ZodError &&
+      err.issues.some((e) => e.code === 'unrecognized_keys')
+    )
+      throw new InvalidArgumentError(
+        'Unsupported operation. Currently, only nested `create` operation is supported on create query.'
+      )
+    else throw err
+  }
+}
+
+export function parseNestedUpdate(relationField: any): {
+  update?: any
+  updateMany?: any
+} {
+  const updateRelatedObjSchema = z
+    .object({
+      update: z.any().optional(),
+      updateMany: z.any().optional(),
+      //create?: object,
+      //upsert?: object,
+      //delete?: boolean
+    })
+    .strict()
+
+  try {
+    return updateRelatedObjSchema.parse(relationField)
+  } catch (err) {
+    if (
+      err instanceof z.ZodError &&
+      err.issues.some((e) => e.code === 'unrecognized_keys')
+    )
+      throw new InvalidArgumentError(
+        'Unsupported operation. Currently, only nested `update` and `updateMany` operations are supported on an update query.'
+      )
+    else throw err
+  }
+}
+
+/**
+ * Takes a schema for an object containing an optional `select` property
+ * which has an optional `_count` property and removes the `_count` property.
+ * @param s Schema for an object containing an optional `select` property.
+ */
+export function omitCountFromSelectAndIncludeSchema<T extends z.ZodTypeAny>(
+  s: T
+): T {
+  const schema = s as unknown as z.AnyZodObject
+  const omitCount = (s: any) => {
+    return s
+      .unwrap() // `select` and `include` are optional fields, unwrap its schema out of the optional
+      .omit({ _count: true }) // remove `_count` field
+      .optional() // wrap it back into an optional
+  }
+  const obj: { select: any; include?: any } = {
+    select: omitCount(schema.shape.select),
+  }
+  if (schema.shape.include) {
+    obj['include'] = omitCount(schema.shape.include)
+  }
+  return schema.merge(z.object(obj)) as unknown as T
 }

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -3,6 +3,7 @@ import Database from 'better-sqlite3'
 import { electrify } from '../../../src/drivers/better-sqlite3'
 import { dbSchema } from '../generated'
 import { ZodError } from 'zod'
+import { InvalidArgumentError } from '../../../src/client/validation/errors/invalidArgumentError'
 
 /*
  * This test file is meant to check that the DAL
@@ -19,7 +20,18 @@ const electric = await electrify(db, dbSchema, {
 //const postTable = electric.db.Post
 const userTable = electric.db.User
 
-test('create query throws error for unsupported arguments', async (t) => {
+test.beforeEach((_t) => {
+  db.exec('DROP TABLE IF EXISTS Post')
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS Post('id' int PRIMARY KEY, 'title' varchar, 'contents' varchar, 'nbr' int, 'authorId' int);"
+  )
+  db.exec('DROP TABLE IF EXISTS User')
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS User('id' int PRIMARY KEY, 'name' varchar);"
+  )
+})
+
+test('create query throws error for unsupported _count argument', async (t) => {
   await t.throwsAsync(
     async () => {
       await userTable.create({
@@ -28,13 +40,1073 @@ test('create query throws error for unsupported arguments', async (t) => {
           name: 't1',
         },
         select: {
-          // @ts-expect-error
+          // @ts-expect-error: Unsupported argument
           _count: true,
         },
       })
     },
     { instanceOf: ZodError }
   )
-
-  //console.log('error is: ' + err.name + ' - ' + err.message)
 })
+
+test('create query throws error when selecting related objects', async (t) => {
+  await t.throwsAsync(
+    async () => {
+      await userTable.create({
+        data: {
+          id: 1,
+          name: 't1',
+        },
+        select: {
+          name: true,
+          // @ts-expect-error: We do not yet support selecting related objects (use include instead)
+          posts: {
+            take: 5,
+          },
+        },
+      })
+    },
+    {
+      instanceOf: InvalidArgumentError,
+      message:
+        "Cannot select field posts on table User. Use 'include' to fetch related objects.",
+    }
+  )
+})
+
+// TODO: allow select to fetch related objects (currently only supported by include)
+
+test('create query throws error for unsupported cursor argument', async (t) => {
+  await t.throwsAsync(
+    async () => {
+      await userTable.create({
+        data: {
+          id: 1,
+          name: 't1',
+        },
+        include: {
+          posts: {
+            take: 5,
+            // @ts-expect-error: Unsupported argument
+            cursor: {
+              id: 2,
+            },
+          },
+        },
+      })
+    },
+    {
+      instanceOf: InvalidArgumentError,
+      message: 'Unsupported cursor argument.',
+    }
+  )
+})
+
+test('create query throws error for createMany on related object', async (t) => {
+  await t.throwsAsync(
+    async () => {
+      await userTable.create({
+        data: {
+          id: 1,
+          name: 'n1',
+          posts: {
+            // @ts-expect-error: `createMany` is not supported for related objects because `create` accepts an array of related objects
+            createMany: {
+              data: [
+                {
+                  id: 1,
+                  title: 't1',
+                  contents: 'c1',
+                },
+              ],
+            },
+          },
+        },
+      })
+    },
+    {
+      instanceOf: InvalidArgumentError,
+      message:
+        'Unsupported operation. Currently, only nested `create` operation is supported on create query.',
+    }
+  )
+})
+
+test('update query throws error for unsupported _count argument in select', async (t) => {
+  await t.throwsAsync(
+    async () => {
+      await userTable.update({
+        data: {
+          name: 'newName',
+        },
+        where: {
+          id: 1,
+        },
+        select: {
+          // @ts-expect-error: Unsupported argument
+          _count: true,
+        },
+      })
+    },
+    { instanceOf: ZodError }
+  )
+})
+
+async function createUser1() {
+  await userTable.create({
+    data: {
+      id: 1,
+      name: 'name',
+    },
+  })
+}
+
+// Some tests below need to run serially because
+// they actually update the DB and there should not be concurrent transactions
+// (because SQLite does not have proper isolation
+//  between transactions on the same DB connection)
+test.serial(
+  'update query throws error for unsupported _count argument in include',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.update({
+          data: {
+            name: 'newName',
+          },
+          where: {
+            id: 1,
+          },
+          include: {
+            // @ts-expect-error: Unsupported argument
+            _count: true,
+          },
+        })
+      },
+      { instanceOf: ZodError }
+    )
+  }
+)
+
+test.serial(
+  'update query throws error when selecting related objects',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.update({
+          data: {
+            name: 'newName',
+          },
+          where: {
+            id: 1,
+          },
+          select: {
+            name: true,
+            // @ts-expect-error: We do not yet support selecting related objects (use include instead)
+            posts: {
+              take: 5,
+            },
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field posts on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial(
+  'update query throws error for createMany on related object',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.update({
+          data: {
+            name: 'n1',
+            posts: {
+              // @ts-expect-error: `createMany` is not supported for related objects
+              createMany: {
+                data: [
+                  {
+                    id: 1,
+                    title: 't1',
+                    contents: 'c1',
+                  },
+                ],
+              },
+            },
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          'Unsupported operation. Currently, only nested `update` and `updateMany` operations are supported on an update query.',
+      }
+    )
+  }
+)
+
+test.serial(
+  'update query throws error for unsupported increment',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.update({
+          data: {
+            id: {
+              // @ts-expect-error: `increment` operation is not supported for updates
+              increment: 3,
+            },
+            name: 'n1',
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          'Unsupported value {"increment":3} for field "id" in update query.',
+      }
+    )
+  }
+)
+
+test('updateMany query throws error for unsupported set operation', async (t) => {
+  await t.throwsAsync(
+    async () => {
+      await userTable.updateMany({
+        data: {
+          id: {
+            // @ts-expect-error: `set` operation is not supported for updateMany
+            set: 3,
+          },
+          name: 'n1',
+        },
+      })
+    },
+    {
+      instanceOf: InvalidArgumentError,
+      message: `Unsupported value {"set":3} for field "id" in update query.`,
+    }
+  )
+})
+
+test('updateMany query throws error for unsupported relational filters', async (t) => {
+  const error: ZodError | undefined = await t.throwsAsync(
+    async () => {
+      await userTable.updateMany({
+        data: {
+          name: 'n1',
+        },
+        where: {
+          posts: {
+            // @ts-expect-error: relational filters are not yet supported
+            some: {
+              id: 5,
+            },
+          },
+        },
+      })
+    },
+    {
+      instanceOf: ZodError,
+    }
+  )
+
+  if (error) {
+    error.issues.some(
+      (err) =>
+        t.assert(err.code === 'unrecognized_keys') &&
+        t.assert(err.message === "Unrecognized key(s) in object: 'some'")
+    )
+  }
+})
+
+test('updateMany query throws error for unsupported query mode', async (t) => {
+  const error: ZodError | undefined = await t.throwsAsync(
+    async () => {
+      await userTable.updateMany({
+        data: {
+          name: 'n1',
+        },
+        where: {
+          name: {
+            // @ts-expect-error: query mode is not supported
+            mode: 'insensitive',
+          },
+        },
+      })
+    },
+    {
+      instanceOf: ZodError,
+    }
+  )
+
+  if (error) {
+    error.issues.some(
+      (err) =>
+        t.assert(err.code === 'unrecognized_keys') &&
+        t.assert(err.message === "Unrecognized key(s) in object: 'mode'")
+    )
+  }
+})
+
+test.serial(
+  'upsert query throws error when selecting related objects',
+  async (t) => {
+    await t.throwsAsync(
+      async () => {
+        await userTable.upsert({
+          create: {
+            id: 1,
+            name: 'user1',
+          },
+          update: {
+            name: 'user1',
+          },
+          where: {
+            id: 1,
+          },
+          select: {
+            name: true,
+            // @ts-expect-error: We do not yet support selecting related objects (use include instead)
+            posts: {
+              take: 5,
+            },
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field posts on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial('upsert query throws error when selecting count', async (t) => {
+  const err: ZodError | undefined = await t.throwsAsync(
+    async () => {
+      await userTable.upsert({
+        create: {
+          id: 1,
+          name: 'user1',
+        },
+        update: {
+          name: 'user1',
+        },
+        where: {
+          id: 1,
+        },
+        select: {
+          name: true,
+          // @ts-expect-error: selecting _count is not supported yet
+          _count: true,
+        },
+      })
+    },
+    {
+      instanceOf: ZodError,
+    }
+  )
+
+  if (err)
+    err.issues.some(
+      (err) =>
+        t.assert(err.code === 'unrecognized_keys') &&
+        t.assert(err.message === "Unrecognized key(s) in object: '_count'")
+    )
+})
+
+test.serial('upsert query throws error when including count', async (t) => {
+  const err: ZodError | undefined = await t.throwsAsync(
+    async () => {
+      await userTable.upsert({
+        create: {
+          id: 1,
+          name: 'user1',
+        },
+        update: {
+          name: 'user1',
+        },
+        where: {
+          id: 1,
+        },
+        include: {
+          // @ts-expect-error: including _count is not supported yet
+          _count: true,
+        },
+      })
+    },
+    {
+      instanceOf: ZodError,
+    }
+  )
+
+  if (err)
+    err.issues.some(
+      (err) =>
+        t.assert(err.code === 'unrecognized_keys') &&
+        t.assert(err.message === "Unrecognized key(s) in object: '_count'")
+    )
+})
+
+test.serial(
+  'upsert query throws error for nested connectOrCreate on create argument',
+  async (t) => {
+    await t.throwsAsync(
+      async () => {
+        await userTable.upsert({
+          create: {
+            id: 1,
+            name: 'user1',
+            posts: {
+              // @ts-expect-error: nested connectOrCreate is not supported yet
+              connectOrCreate: {
+                create: {
+                  id: 1,
+                  title: 't1',
+                  contents: 'c1',
+                },
+                where: {},
+              },
+            },
+          },
+          update: {
+            name: 'user1',
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          'Unsupported operation. Currently, only nested `create` operation is supported on create query.',
+      }
+    )
+  }
+)
+
+test.serial(
+  'upsert query throws error for unsupported multiply operation',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.upsert({
+          create: {
+            id: 1,
+            name: 'user1',
+          },
+          update: {
+            id: {
+              // @ts-expect-error: multiply operation is not yet supported
+              multiply: 5,
+            },
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          'Unsupported value {"multiply":5} for field "id" in update query.',
+      }
+    )
+  }
+)
+
+test.serial(
+  'upsert query throws error for nested disconnect on update argument',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.upsert({
+          create: {
+            id: 1,
+            name: 'user1',
+          },
+          update: {
+            posts: {
+              // @ts-expect-error: disconnect operation is not yet supported
+              disconnect: {
+                id: 1,
+              },
+            },
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          'Unsupported operation. Currently, only nested `update` and `updateMany` operations are supported on an update query.',
+      }
+    )
+  }
+)
+
+test.serial(
+  'delete query throws error when selecting related objects',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.delete({
+          select: {
+            id: true,
+            // @ts-expect-error: We do not yet support selecting related objects (use include instead)
+            posts: {
+              take: 2,
+            },
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field posts on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial('delete query throws error when selecting count', async (t) => {
+  await createUser1()
+
+  await t.throwsAsync(
+    async () => {
+      await userTable.delete({
+        select: {
+          id: true,
+          // @ts-expect-error: selecting _count is not supported yet
+          _count: true,
+        },
+        where: {
+          id: 1,
+        },
+      })
+    },
+    {
+      instanceOf: InvalidArgumentError,
+      message:
+        "Cannot select field _count on table User. Use 'include' to fetch related objects.",
+    }
+  )
+})
+
+test.serial('delete query throws error when including count', async (t) => {
+  await createUser1()
+
+  await t.throwsAsync(
+    async () => {
+      await userTable.delete({
+        include: {
+          // @ts-expect-error: including _count is not supported yet
+          _count: true,
+        },
+        where: {
+          id: 1,
+        },
+      })
+    },
+    {
+      instanceOf: InvalidArgumentError,
+      message: 'Unexpected field `_count` in `include` argument.',
+    }
+  )
+})
+
+test.serial(
+  'deleteMany query throws error for relational filters',
+  async (t) => {
+    await createUser1()
+
+    const error: ZodError | undefined = await t.throwsAsync(
+      async () => {
+        await userTable.deleteMany({
+          where: {
+            posts: {
+              // @ts-expect-error: relational filters are not yet supported
+              some: {
+                id: 5,
+              },
+            },
+          },
+        })
+      },
+      {
+        instanceOf: ZodError,
+      }
+    )
+
+    if (error) {
+      error.issues.some(
+        (err) =>
+          t.assert(err.code === 'unrecognized_keys') &&
+          t.assert(err.message === "Unrecognized key(s) in object: 'some'")
+      )
+    }
+  }
+)
+
+test.serial(
+  'deleteMany query throws error for unsupported query mode',
+  async (t) => {
+    await createUser1()
+
+    const error: ZodError | undefined = await t.throwsAsync(
+      async () => {
+        await userTable.deleteMany({
+          where: {
+            name: {
+              // @ts-expect-error: query mode is not supported
+              mode: 'insensitive',
+            },
+          },
+        })
+      },
+      {
+        instanceOf: ZodError,
+      }
+    )
+
+    if (error) {
+      error.issues.some(
+        (err) =>
+          t.assert(err.code === 'unrecognized_keys') &&
+          t.assert(err.message === "Unrecognized key(s) in object: 'mode'")
+      )
+    }
+  }
+)
+
+test.serial(
+  'findUnique query throws error when selecting related objects',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findUnique({
+          select: {
+            // @ts-expect-error: We do not yet support selecting related objects (use include instead)
+            posts: true,
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field posts on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial(
+  'findUnique query throws error for unsupported count in select',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findUnique({
+          select: {
+            // @ts-expect-error: count is not yet supported
+            _count: true,
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field _count on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial(
+  'findUnique query throws error for unsupported count in include',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findUnique({
+          include: {
+            // @ts-expect-error: count is not yet supported
+            _count: true,
+          },
+          where: {
+            id: 1,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message: 'Unexpected field `_count` in `include` argument.',
+      }
+    )
+  }
+)
+
+test.serial(
+  'findMany query throws error when selecting related objects',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findMany({
+          select: {
+            // @ts-expect-error: We do not yet support selecting related objects (use include instead)
+            posts: true,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field posts on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial(
+  'findMany query throws error for unsupported count in select',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findMany({
+          select: {
+            // @ts-expect-error: count is not yet supported
+            _count: true,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field _count on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial(
+  'findMany query throws error for unsupported count in include',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findMany({
+          include: {
+            // @ts-expect-error: count is not yet supported
+            _count: true,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message: 'Unexpected field `_count` in `include` argument.',
+      }
+    )
+  }
+)
+
+test.serial('findMany query throws error for relational filters', async (t) => {
+  await createUser1()
+
+  const error: ZodError | undefined = await t.throwsAsync(
+    async () => {
+      await userTable.findMany({
+        where: {
+          posts: {
+            // @ts-expect-error: relational filters are not yet supported
+            some: {
+              id: 1,
+            },
+          },
+        },
+      })
+    },
+    {
+      instanceOf: ZodError,
+    }
+  )
+
+  if (error) {
+    error.issues.some(
+      (err) =>
+        t.assert(err.code === 'unrecognized_keys') &&
+        t.assert(err.message === "Unrecognized key(s) in object: 'some'")
+    )
+  }
+})
+
+test.serial(
+  'findMany query throws error for unsupported query mode',
+  async (t) => {
+    await createUser1()
+
+    const error: ZodError | undefined = await t.throwsAsync(
+      async () => {
+        await userTable.findMany({
+          where: {
+            name: {
+              // @ts-expect-error: query mode is not supported
+              mode: 'insensitive',
+            },
+          },
+        })
+      },
+      {
+        instanceOf: ZodError,
+      }
+    )
+
+    if (error) {
+      error.issues.some(
+        (err) =>
+          t.assert(err.code === 'unrecognized_keys') &&
+          t.assert(err.message === "Unrecognized key(s) in object: 'mode'")
+      )
+    }
+  }
+)
+
+test.serial(
+  'findMany query throws error for unsupported count in orderBy argument',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findMany({
+          // @ts-expect-error: ordering by a property of a related object is not yet supported
+          orderBy: {
+            profile: {
+              id: 'asc',
+            },
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Ordering query results based on the 'profile' related object(s) is not yet supported",
+      }
+    )
+  }
+)
+
+//////
+//////
+//////
+
+test.serial(
+  'findFirst query throws error when selecting related objects',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findFirst({
+          select: {
+            // @ts-expect-error: We do not yet support selecting related objects (use include instead)
+            posts: true,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field posts on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial(
+  'findFirst query throws error for unsupported count in select',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findFirst({
+          select: {
+            // @ts-expect-error: count is not yet supported
+            _count: true,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Cannot select field _count on table User. Use 'include' to fetch related objects.",
+      }
+    )
+  }
+)
+
+test.serial(
+  'findFirst query throws error for unsupported count in include',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findFirst({
+          include: {
+            // @ts-expect-error: count is not yet supported
+            _count: true,
+          },
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message: 'Unexpected field `_count` in `include` argument.',
+      }
+    )
+  }
+)
+
+test.serial(
+  'findFirst query throws error for relational filters',
+  async (t) => {
+    await createUser1()
+
+    const error: ZodError | undefined = await t.throwsAsync(
+      async () => {
+        await userTable.findFirst({
+          where: {
+            posts: {
+              // @ts-expect-error: relational filters are not yet supported
+              some: {
+                id: 1,
+              },
+            },
+          },
+        })
+      },
+      {
+        instanceOf: ZodError,
+      }
+    )
+
+    if (error) {
+      error.issues.some(
+        (err) =>
+          t.assert(err.code === 'unrecognized_keys') &&
+          t.assert(err.message === "Unrecognized key(s) in object: 'some'")
+      )
+    }
+  }
+)
+
+test.serial(
+  'findFirst query throws error for unsupported query mode',
+  async (t) => {
+    await createUser1()
+
+    const error: ZodError | undefined = await t.throwsAsync(
+      async () => {
+        await userTable.findFirst({
+          where: {
+            name: {
+              // @ts-expect-error: query mode is not supported
+              mode: 'insensitive',
+            },
+          },
+        })
+      },
+      {
+        instanceOf: ZodError,
+      }
+    )
+
+    if (error) {
+      error.issues.some(
+        (err) =>
+          t.assert(err.code === 'unrecognized_keys') &&
+          t.assert(err.message === "Unrecognized key(s) in object: 'mode'")
+      )
+    }
+  }
+)
+
+test.serial(
+  'findFirst query throws error for unsupported count in orderBy argument',
+  async (t) => {
+    await createUser1()
+
+    await t.throwsAsync(
+      async () => {
+        await userTable.findFirst({
+          orderBy: [
+            {
+              name: 'asc',
+            },
+            // @ts-expect-error: ordering by a property of a related object is not yet supported
+            {
+              profile: {
+                id: 'asc',
+              },
+            },
+          ],
+        })
+      },
+      {
+        instanceOf: InvalidArgumentError,
+        message:
+          "Ordering query results based on the 'profile' related object(s) is not yet supported",
+      }
+    )
+  }
+)
+
+// TODO: check why we broke some of the regular tests

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -1,0 +1,40 @@
+import test from 'ava'
+import Database from 'better-sqlite3'
+import { electrify } from '../../../src/drivers/better-sqlite3'
+import { dbSchema } from '../generated'
+import { ZodError } from 'zod'
+
+/*
+ * This test file is meant to check that the DAL
+ * reports unrecognized/unsupported arguments
+ * through both type errors and runtime errors.
+ */
+
+const db = new Database(':memory:')
+const electric = await electrify(db, dbSchema, {
+  app: 'CRUD-Test',
+  env: 'env',
+  migrations: [],
+})
+//const postTable = electric.db.Post
+const userTable = electric.db.User
+
+test('create query throws error for unsupported arguments', async (t) => {
+  await t.throwsAsync(
+    async () => {
+      await userTable.create({
+        data: {
+          id: 1,
+          name: 't1',
+        },
+        select: {
+          // @ts-expect-error
+          _count: true,
+        },
+      })
+    },
+    { instanceOf: ZodError }
+  )
+
+  //console.log('error is: ' + err.name + ' - ' + err.message)
+})


### PR DESCRIPTION
This PR introduces some type magic that modifies the Prisma-generated types to expose only the supported operations.
The various input types (cf. `clients/typescript/src/client/input` folder) are narrowed using the types defined in `clients/typescript/src/client/input/inputNarrowing.ts`.

Additionally, this PR adds unit tests to check that illegal uses throw type errors as well as runtime errors.
The code has been fixed in various places in order to throw meaningful errors.