### PR TITLE
feat(electric): Initial sync from Postgres to fresh clients

### DIFF
--- a/components/electric/lib/electric/application.ex
+++ b/components/electric/lib/electric/application.ex
@@ -11,6 +11,12 @@ defmodule Electric.Application do
 
     auth_provider = Electric.Satellite.Auth.provider()
 
+    postgres_connector_opts =
+      case Application.get_env(:electric, Electric.Replication.Connectors, []) do
+        [{name, config}] -> Keyword.put(config, :origin, to_string(name))
+        [] -> []
+      end
+
     children = [
       Electric.Telemetry,
       Electric.Postgres.SchemaRegistry,
@@ -21,7 +27,8 @@ defmodule Electric.Application do
       Electric.Satellite.ClientManager,
       Electric.Satellite.WsServer.child_spec(
         port: sqlite_server_port(),
-        auth_provider: auth_provider
+        auth_provider: auth_provider,
+        pg_connector_opts: postgres_connector_opts
       ),
       Electric.Replication.Connectors
     ]

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -53,6 +53,16 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   @impl Api
+  def get_current_lsn do
+    with {:ok, table} <- ETS.Set.wrap_existing(@ets_table_name) do
+      case ETS.Set.last(table) do
+        {:ok, wal_pos} -> {:ok, position_to_lsn(wal_pos)}
+        {:error, :empty_table} -> :empty_db
+      end
+    end
+  end
+
+  @impl Api
   def get_wal_position_from_lsn(lsn) do
     with {:ok, table} <- ETS.Set.wrap_existing(@ets_table_name) do
       if ETS.Set.has_key!(table, lsn_to_position(lsn)) do
@@ -179,6 +189,7 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   defp lsn_to_position(lsn), do: Lsn.to_integer(lsn)
+  defp position_to_lsn(wal_pos), do: Lsn.from_integer(wal_pos)
 
   @spec trim_cache(state()) :: state()
   defp trim_cache(%{current_cache_count: current, max_cache_count: max} = state)

--- a/components/electric/lib/electric/replication/initial_sync.ex
+++ b/components/electric/lib/electric/replication/initial_sync.ex
@@ -1,0 +1,108 @@
+defmodule Electric.Replication.InitialSync do
+  import Electric.Postgres.Extension, only: [is_ddl_relation: 1, is_extension_relation: 1]
+
+  alias Electric.Postgres.{CachedWal, Lsn}
+  alias Electric.Replication.Changes.{NewRecord, Transaction}
+  alias Electric.Replication.Connectors
+  alias Electric.Replication.Postgres.Client
+
+  @spec transactions(Keyword.t(), atom) :: {Lsn.t(), [Transaction.t()]}
+  def transactions(connector_opts, cached_wal_module \\ Electric.Postgres.CachedWal.EtsBacked) do
+    # NOTE(alco): this is a placeholder to show where schema migrations will fit into the initial sync, once implemented.
+    # Here we need to fetch ALL migrations from Postgres and convert them to %Transaction{} structs. On the client,
+    # already applied migrations need to be skipped, the rest need to be applied.
+    #
+    # Since this is an idempotent action, the client shouldn't update its cached LSN before it applies the initial DATA
+    # transaction. In other words, applying any of these migration transactions on the client should leave its LSN undefined.
+    migration_transactions = []
+
+    # It's important to store the current timestamp prior to fetching the current LSN to ensure that we're not creating
+    # a transaction "in the future" relative to the LSN.
+    timestamp = DateTime.utc_now()
+
+    {data_transactions, lsn} =
+      case CachedWal.Api.get_current_lsn(cached_wal_module) do
+        {:ok, current_lsn} ->
+          tx = initial_data_transaction(connector_opts, current_lsn, timestamp)
+          {[{tx, current_lsn}], current_lsn}
+
+        :empty_db ->
+          {[], Lsn.from_integer(0)}
+      end
+
+    {lsn, migration_transactions ++ data_transactions}
+  end
+
+  defp initial_data_transaction(connector_opts, lsn, commit_timestamp) do
+    publication = Connectors.get_replication_opts(connector_opts).publication
+    conn_config = Connectors.get_connection_opts(connector_opts)
+
+    perform_in_transaction(conn_config, fn conn ->
+      new_records = fetch_data_from_all_tables(conn, publication)
+
+      %Transaction{
+        changes: new_records,
+        # NOTE(alco): not sure to which extent the value of this timestamp can affect the client.
+        commit_timestamp: commit_timestamp,
+        origin: Connectors.origin(connector_opts),
+        publication: publication,
+        lsn: lsn,
+        ack_fn: fn -> :ok end
+      }
+    end)
+  end
+
+  defp perform_in_transaction(conn_config, fun) do
+    Client.with_conn(conn_config, fn conn ->
+      :epgsql.with_transaction(conn, fn conn ->
+        {:ok, [], []} =
+          :epgsql.squery(conn, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+
+        fun.(conn)
+      end)
+    end)
+  end
+
+  def fetch_data_from_all_tables(conn, publication) do
+    conn
+    |> Client.query_replicated_tables(publication)
+    |> Enum.reject(fn table_info ->
+      relation = relation(table_info)
+      is_ddl_relation(relation) or is_extension_relation(relation)
+    end)
+    |> Enum.flat_map(fn %{
+                          schema: schema_name,
+                          name: table_name,
+                          primary_keys: pks,
+                          columns: cols
+                        } = table_info ->
+      sql = "SELECT * FROM #{schema_name}.#{table_name} ORDER BY #{Enum.join(pks, ",")}"
+      {:ok, _cols, rows} = :epgsql.squery(conn, sql)
+      rows_to_records(rows, cols, relation(table_info))
+    end)
+  end
+
+  ###
+
+  defp relation(%{schema: schema, name: table_name}), do: {schema, table_name}
+
+  defp rows_to_records(rows, cols, relation) when is_list(rows) do
+    for row_tuple <- rows do
+      column_names = Enum.map(cols, & &1.name)
+
+      values =
+        row_tuple
+        |> Tuple.to_list()
+        |> Enum.map(fn
+          :null -> nil
+          other -> other
+        end)
+
+      row =
+        Enum.zip(column_names, values)
+        |> Map.new()
+
+      %NewRecord{relation: relation, record: row}
+    end
+  end
+end

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -21,6 +21,7 @@ defmodule Electric.Satellite.WsServer do
   def start_link(opts) do
     port = Keyword.fetch!(opts, :port)
     auth_provider = Keyword.fetch!(opts, :auth_provider)
+    pg_connector_opts = Keyword.fetch!(opts, :pg_connector_opts)
 
     # cowboy requires a unique name. so allow for configuration for test servers
     name = Keyword.get(opts, :name, :ws)
@@ -31,7 +32,11 @@ defmodule Electric.Satellite.WsServer do
 
     dispatch =
       :cowboy_router.compile([
-        {:_, [{"/ws", __MODULE__, [auth_provider: auth_provider]}]}
+        {:_,
+         [
+           {"/ws", __MODULE__,
+            [auth_provider: auth_provider, pg_connector_opts: pg_connector_opts]}
+         ]}
       ])
 
     :cowboy.start_clear(name, [port: port], %{
@@ -51,6 +56,7 @@ defmodule Electric.Satellite.WsServer do
     {ip, port} = :cowboy_req.peer(req)
     client = "#{:inet.ntoa(ip)}:#{port}"
     auth_provider = Keyword.fetch!(opts, :auth_provider)
+    pg_connector_opts = Keyword.fetch!(opts, :pg_connector_opts)
 
     # Add the cluster id to the logger metadata to make filtering easier in the case of global log
     # aggregation
@@ -60,7 +66,8 @@ defmodule Electric.Satellite.WsServer do
      %State{
        client: client,
        last_msg_time: :erlang.timestamp(),
-       auth_provider: auth_provider
+       auth_provider: auth_provider,
+       pg_connector_opts: pg_connector_opts
      }}
   end
 
@@ -158,6 +165,13 @@ defmodule Electric.Satellite.WsServer do
   # and as long as %InRep.sync_batch_size is enabled we need to report to Satellite.
   def websocket_info({Protocol, :lsn_report, lsn}, %State{} = state) do
     {[binary_frame(%SatPingResp{lsn: lsn})], state}
+  end
+
+  def websocket_info(:perform_initial_sync_and_subscribe, %State{} = state) do
+    {lsn, transactions} = Electric.Replication.InitialSync.transactions(state.pg_connector_opts)
+    {msgs, state} = Protocol.handle_out_transes(transactions, state)
+    out_rep = Protocol.initiate_subscription(state.client_id, lsn, state.out_rep)
+    {binary_frames(msgs), %State{state | out_rep: out_rep}}
   end
 
   def websocket_info(msg, state) do


### PR DESCRIPTION
Initial implementation to get feedback on the general approach.

These changes are based off `ilia/vax-662-fanout` which I have rebased on top of `main`.