### PR TITLE
Disable SASL logs

### DIFF
--- a/components/electric/config/config.exs
+++ b/components/electric/config/config.exs
@@ -28,7 +28,7 @@ config :logger, :console,
 
 config :logger,
   handle_otp_reports: true,
-  handle_sasl_reports: true,
+  handle_sasl_reports: false,
   level: :debug
 
 config :electric, Electric.Replication.Postgres,

--- a/components/electric/mix.exs
+++ b/components/electric/mix.exs
@@ -23,7 +23,7 @@ defmodule Electric.MixProject do
   def application do
     [
       mod: {Electric.Application, []},
-      extra_applications: [:sasl, :logger]
+      extra_applications: [:logger]
     ]
   end
 


### PR DESCRIPTION
These are generating a lot of noise. SASL progress reports are generally not useful whereas process crashes are already logged by the Elixir logger.