### PR TITLE
fix(satellite): use proper `TEXT` in _electric_trigger_settings table

### DIFF
--- a/clients/typescript/src/migrators/schema.ts
+++ b/clients/typescript/src/migrators/schema.ts
@@ -17,7 +17,7 @@ export const data = {
         `INSERT INTO ${metaTable} (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', ''), ('clientId', ''), ('token', 'INITIAL_INVALID_TOKEN'), ('refreshToken', '');`,
         //`-- These are toggles for turning the triggers on and off\n`,
         `DROP TABLE IF EXISTS ${triggersTable};`,
-        `CREATE TABLE ${triggersTable} (tablename STRING PRIMARY KEY, flag INTEGER);`,
+        `CREATE TABLE ${triggersTable} (tablename TEXT PRIMARY KEY, flag INTEGER);`,
         //`-- Somewhere to keep dependency tracking information\n`,
         `CREATE TABLE ${shadowTable} (\n  namespace TEXT NOT NULL,\n  tablename TEXT NOT NULL,\n  primaryKey TEXT NOT NULL,\n  tags TEXT NOT NULL,\n  PRIMARY KEY (namespace, tablename, primaryKey));`,
       ],

--- a/clients/typescript/test/support/.electric/tarragon-envy-5432/default/index.js
+++ b/clients/typescript/test/support/.electric/tarragon-envy-5432/default/index.js
@@ -17,7 +17,7 @@ export default {
       postgres_body: '',
       satellite_body: [
         'DROP TABLE IF EXISTS _electric_trigger_settings;',
-        'CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);',
+        'CREATE TABLE _electric_trigger_settings(tablename TEXT PRIMARY KEY, flag INTEGER);',
       ],
       sha256:
         '01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b',
@@ -33,7 +33,7 @@ export default {
         'CREATE TABLE IF NOT EXISTS parent (\n  id INTEGER PRIMARY KEY NOT NULL,\n  value TEXT,\n  other INTEGER DEFAULT 0\n) WITHOUT ROWID;',
         'CREATE TABLE IF NOT EXISTS child (\n  id INTEGER PRIMARY KEY NOT NULL,\n  parent INTEGER NOT NULL,\n  FOREIGN KEY(parent) REFERENCES parent(id)\n) WITHOUT ROWID;',
         'DROP TABLE IF EXISTS _electric_trigger_settings;',
-        'CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);',
+        'CREATE TABLE _electric_trigger_settings(tablename TEXT PRIMARY KEY, flag INTEGER);',
         "INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.child', 1);",
         "INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.items', 1);",
         "INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.parent', 1);",

--- a/clients/typescript/test/support/migrations/20230123_170527_569_init/satellite.sql
+++ b/clients/typescript/test/support/migrations/20230123_170527_569_init/satellite.sql
@@ -6,6 +6,6 @@ Below are templated triggers added by Satellite
 
 -- These are toggles for turning the triggers on and off
 DROP TABLE IF EXISTS _electric_trigger_settings;
-CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);
+CREATE TABLE _electric_trigger_settings(tablename TEXT PRIMARY KEY, flag INTEGER);
 
 

--- a/clients/typescript/test/support/migrations/20230123_170646_833_test_schema/satellite.sql
+++ b/clients/typescript/test/support/migrations/20230123_170646_833_test_schema/satellite.sql
@@ -21,7 +21,7 @@ Below are templated triggers added by Satellite
 
 -- These are toggles for turning the triggers on and off
 DROP TABLE IF EXISTS _electric_trigger_settings;
-CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);
+CREATE TABLE _electric_trigger_settings(tablename TEXT PRIMARY KEY, flag INTEGER);
 INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.child', 1);
 INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.items', 1);
 INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.parent', 1);

--- a/clients/typescript/test/support/migrations/manifest.json
+++ b/clients/typescript/test/support/migrations/manifest.json
@@ -7,7 +7,7 @@
       "postgres_body": "",
       "satellite_body": [
         "DROP TABLE IF EXISTS _electric_trigger_settings;",
-        "CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);"
+        "CREATE TABLE _electric_trigger_settings(tablename TEXT PRIMARY KEY, flag INTEGER);"
       ],
       "sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
       "title": "init"
@@ -21,7 +21,7 @@
         "CREATE TABLE IF NOT EXISTS parent (\n  id INTEGER PRIMARY KEY NOT NULL,\n  value TEXT,\n  other INTEGER DEFAULT 0\n) WITHOUT ROWID;",
         "CREATE TABLE IF NOT EXISTS child (\n  id INTEGER PRIMARY KEY NOT NULL,\n  parent INTEGER NOT NULL,\n  FOREIGN KEY(parent) REFERENCES parent(id)\n) WITHOUT ROWID;",
         "DROP TABLE IF EXISTS _electric_trigger_settings;",
-        "CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);",
+        "CREATE TABLE _electric_trigger_settings(tablename TEXT PRIMARY KEY, flag INTEGER);",
         "INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.child', 1);",
         "INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.items', 1);",
         "INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.parent', 1);",

--- a/e2e/migrations/m_sanity_check/index.js
+++ b/e2e/migrations/m_sanity_check/index.js
@@ -35,7 +35,7 @@
       "satellite_body": [
         "ALTER TABLE items ADD added_column TEXT DEFAULT '';",
         "DROP TABLE IF EXISTS _electric_trigger_settings;",
-        "CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);",
+        "CREATE TABLE _electric_trigger_settings(tablename TEXT PRIMARY KEY, flag INTEGER);",
         "INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.items', 1);",
         "INSERT INTO _electric_trigger_settings(tablename,flag) VALUES ('main.other_items', 1);",
         "DROP TRIGGER IF EXISTS update_ensure_main_items_primarykey;",


### PR DESCRIPTION
Related to #165 I found some more references to String instead of Text.
I made a few searches for String in the project and it appears to be the only one remaining (hopefully).