### PR TITLE
feat(satellite): ignore already applied migrations

### DIFF
--- a/clients/typescript/src/migrators/bundle.ts
+++ b/clients/typescript/src/migrators/bundle.ts
@@ -56,15 +56,15 @@ export class BundleMigrator implements Migrator {
     // If this is the first time we're running migrations, then the
     // migrations table won't exist.
     const tableExists = `
-      SELECT count(name) as numTables FROM sqlite_master
+      SELECT 1 FROM sqlite_master
         WHERE type = 'table'
           AND name = ?
     `
-    const [{ numTables }] = await this.adapter.query({
+    const tables = await this.adapter.query({
       sql: tableExists,
       args: [this.tableName],
     })
-    if (numTables == 0) {
+    if (tables.length === 0) {
       return []
     }
 
@@ -122,15 +122,15 @@ export class BundleMigrator implements Migrator {
    */
   async applyIfNotAlready(migration: StmtMigration): Promise<boolean> {
     const versionExists = `
-      SELECT count(version) as numVersions FROM ${this.tableName}
+      SELECT 1 FROM ${this.tableName}
         WHERE version = ?
     `
-    const [{ numVersions }] = await this.adapter.query({
+    const rows = await this.adapter.query({
       sql: versionExists,
       args: [migration.version],
     })
 
-    const shouldApply = numVersions == 0
+    const shouldApply = rows.length === 0
 
     if (shouldApply) {
       // This is a new migration because its version number

--- a/clients/typescript/src/migrators/index.ts
+++ b/clients/typescript/src/migrators/index.ts
@@ -28,6 +28,7 @@ export function makeStmtMigration(migration: Migration): StmtMigration {
 export interface Migrator {
   up(): Promise<number>
   apply(migration: StmtMigration): Promise<void>
+  applyIfNotAlready(migration: StmtMigration): Promise<boolean>
 }
 
 export interface MigratorOptions {

--- a/clients/typescript/src/migrators/mock.ts
+++ b/clients/typescript/src/migrators/mock.ts
@@ -8,4 +8,8 @@ export class MockMigrator implements Migrator {
   async apply(_: StmtMigration): Promise<void> {
     return
   }
+
+  async applyIfNotAlready(_: StmtMigration): Promise<boolean> {
+    return true
+  }
 }

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -892,7 +892,7 @@ export class SatelliteProcess implements Satellite {
     if (transaction.migrationVersion) {
       // If a migration version is specified
       // then the transaction is a migration
-      await this.migrator.apply({
+      await this.migrator.applyIfNotAlready({
         statements: allStatements,
         version: transaction.migrationVersion,
       })


### PR DESCRIPTION
This PR introduces a safeguard in Satellite that applies incoming migrations only if they were not already applied.