### PR TITLE
chore(electric): Lower the default test timeout to 5 seconds

### DIFF
--- a/components/electric/test/test_helper.exs
+++ b/components/electric/test/test_helper.exs
@@ -2,7 +2,7 @@ if System.get_env("INTEGRATION") do
   ExUnit.configure(capture_log: true, exclude: :test, include: :integration)
 else
   Mox.defmock(Electric.Replication.MockPostgresClient, for: Electric.Replication.Postgres.Client)
-  ExUnit.configure(capture_log: true, exclude: :integration)
+  ExUnit.configure(capture_log: true, exclude: :integration, timeout: 5_000)
   Logger.configure(level: :info)
 end
 


### PR DESCRIPTION
Reasoning: no use waiting a whole minute for a deadlocked test to time out. In my limited testing, 5 seconds has proven to be reasonable for all current unit tests to pass.