### PR TITLE
chore(electric): Remove use of tuples to hold row data

### DIFF
--- a/components/electric/lib/electric/postgres/logical_replication/decoder.ex
+++ b/components/electric/lib/electric/postgres/logical_replication/decoder.ex
@@ -30,7 +30,7 @@ defmodule Electric.Postgres.LogicalReplication.Decoder do
       %#{Begin}{commit_timestamp: ~U[2019-07-18 17:02:35.726322Z], final_lsn: %#{Lsn}{segment: 2, offset: 2817828992}, xid: 619}
 
       iex> decode(<<73, 0, 0, 64, 12, 78, 0, 2, 116, 0, 0, 0, 36, 48, 54, 97, 99, 57, 101, 57, 97, 45, 102, 51, 49, 99, 45, 52, 101, 102, 52, 45, 97, 53, 55, 102, 45, 99, 52, 55, 55, 54, 98, 49, 51, 57, 50, 48, 49, 116, 0, 0, 0, 2, 111, 107>>)
-      %#{Insert}{relation_id: 16396, tuple_data: {"06ac9e9a-f31c-4ef4-a57f-c4776b139201", "ok"}}
+      %#{Insert}{relation_id: 16396, tuple_data: ["06ac9e9a-f31c-4ef4-a57f-c4776b139201", "ok"]}
 
       iex> decode(<<67, 0, 0, 0, 0, 0, 1, 115, 90, 104, 0, 0, 0, 0, 1, 115, 90, 152, 0, 2, 131, 255, 114, 87, 68, 106>>)
       %#{Commit}{commit_timestamp: ~U[2022-06-09 09:45:11.642218Z], end_lsn: %#{Lsn}{segment: 0, offset: 24337048}, flags: [], lsn: %#{Lsn}{segment: 0, offset: 24337000}}
@@ -50,16 +50,16 @@ defmodule Electric.Postgres.LogicalReplication.Decoder do
       iex> decode(<<85, 0, 0, 64, 12, 79, 0, 2, 116, 0, 0, 0, 36, 99, 48, 100, 55, 51, 49, 99, 97, 45, 48, 101, 55, 50, 45, 52, 57, 53, 48, 45, 57, 52, 57, 57, 45, 56, 100, 98, 56, 51, 98, 97, 100, 98, 48, 53, 49, 116, 0, 0, 0, 2, 111, 107, 78, 0, 2, 116, 0, 0, 0, 36, 99, 48, 100, 55, 51, 49, 99, 97, 45, 48, 101, 55, 50, 45, 52, 57, 53, 48, 45, 57, 52, 57, 57, 45, 56, 100, 98, 56, 51, 98, 97, 100, 98, 48, 53, 49, 116, 0, 0, 0, 3, 121, 101, 115>>)
       %#{Update}{
         changed_key_tuple_data: nil,
-        old_tuple_data: {"c0d731ca-0e72-4950-9499-8db83badb051", "ok"},
+        old_tuple_data: ["c0d731ca-0e72-4950-9499-8db83badb051", "ok"],
         relation_id: 16396,
-        tuple_data: {"c0d731ca-0e72-4950-9499-8db83badb051", "yes"}
+        tuple_data: ["c0d731ca-0e72-4950-9499-8db83badb051", "yes"]
       }
 
       iex> decode(<<68, 0, 0, 64, 12, 79, 0, 2, 116, 0, 0, 0, 36, 99, 48, 100, 55, 51, 49, 99, 97, 45, 48, 101, 55, 50, 45, 52, 57, 53, 48, 45, 57, 52, 57, 57, 45, 56, 100, 98, 56, 51, 98, 97, 100, 98, 48, 53, 49, 116, 0, 0, 0, 3, 121, 101, 115>>)
       %#{Delete}{
         relation_id: 16396,
         changed_key_tuple_data: nil,
-        old_tuple_data: {"c0d731ca-0e72-4950-9499-8db83badb051", "yes"}
+        old_tuple_data: ["c0d731ca-0e72-4950-9499-8db83badb051", "yes"]
       }
   """
   def decode(message) when is_binary(message) do
@@ -224,7 +224,7 @@ defmodule Electric.Postgres.LogicalReplication.Decoder do
   defp decode_tuple_data(binary, columns_remaining, accumulator \\ [])
 
   defp decode_tuple_data(remaining_binary, 0, accumulator) when is_binary(remaining_binary),
-    do: {remaining_binary, accumulator |> Enum.reverse() |> List.to_tuple()}
+    do: {remaining_binary, accumulator |> Enum.reverse()}
 
   defp decode_tuple_data(<<"n", rest::binary>>, columns_remaining, accumulator),
     do: decode_tuple_data(rest, columns_remaining - 1, [nil | accumulator])

--- a/components/electric/lib/electric/postgres/logical_replication/encoder.ex
+++ b/components/electric/lib/electric/postgres/logical_replication/encoder.ex
@@ -27,7 +27,7 @@ defmodule Electric.Postgres.LogicalReplication.Encoder do
       iex> encode(%#{Begin}{commit_timestamp: ~U[2019-07-18 17:02:35.726322Z], final_lsn: %#{Lsn}{segment: 2, offset: 2817828992}, xid: 619})
       <<66, 0, 0, 0, 2, 167, 244, 168, 128, 0, 2, 48, 246, 88, 88, 213, 242, 0, 0, 2, 107>>
 
-      iex> encode(%#{Insert}{relation_id: 16396, tuple_data: {"06ac9e9a-f31c-4ef4-a57f-c4776b139201", "ok"}})
+      iex> encode(%#{Insert}{relation_id: 16396, tuple_data: ["06ac9e9a-f31c-4ef4-a57f-c4776b139201", "ok"]})
       <<73, 0, 0, 64, 12, 78, 0, 2, 116, 0, 0, 0, 36, 48, 54, 97, 99, 57, 101, 57, 97, 45, 102, 51, 49, 99, 45, 52, 101, 102, 52, 45, 97, 53, 55, 102, 45, 99, 52, 55, 55, 54, 98, 49, 51, 57, 50, 48, 49, 116, 0, 0, 0, 2, 111, 107>>
 
       iex> encode(%#{Commit}{commit_timestamp: ~U[2022-06-09 09:45:11.642218Z], end_lsn: %#{Lsn}{segment: 0, offset: 24337048}, flags: [], lsn: %#{Lsn}{segment: 0, offset: 24337000}})
@@ -47,16 +47,16 @@ defmodule Electric.Postgres.LogicalReplication.Encoder do
 
       iex> encode(%#{Update}{
       ...>   changed_key_tuple_data: nil,
-      ...>   old_tuple_data: {"c0d731ca-0e72-4950-9499-8db83badb051", "ok"},
+      ...>   old_tuple_data: ["c0d731ca-0e72-4950-9499-8db83badb051", "ok"],
       ...>   relation_id: 16396,
-      ...>   tuple_data: {"c0d731ca-0e72-4950-9499-8db83badb051", "yes"}
+      ...>   tuple_data: ["c0d731ca-0e72-4950-9499-8db83badb051", "yes"]
       ...> })
       <<85, 0, 0, 64, 12, 79, 0, 2, 116, 0, 0, 0, 36, 99, 48, 100, 55, 51, 49, 99, 97, 45, 48, 101, 55, 50, 45, 52, 57, 53, 48, 45, 57, 52, 57, 57, 45, 56, 100, 98, 56, 51, 98, 97, 100, 98, 48, 53, 49, 116, 0, 0, 0, 2, 111, 107, 78, 0, 2, 116, 0, 0, 0, 36, 99, 48, 100, 55, 51, 49, 99, 97, 45, 48, 101, 55, 50, 45, 52, 57, 53, 48, 45, 57, 52, 57, 57, 45, 56, 100, 98, 56, 51, 98, 97, 100, 98, 48, 53, 49, 116, 0, 0, 0, 3, 121, 101, 115>>
 
       iex> encode(%#{Delete}{
       ...>   relation_id: 16396,
       ...>   changed_key_tuple_data: nil,
-      ...>   old_tuple_data: {"c0d731ca-0e72-4950-9499-8db83badb051", "yes"}
+      ...>   old_tuple_data: ["c0d731ca-0e72-4950-9499-8db83badb051", "yes"]
       ...> })
       <<68, 0, 0, 64, 12, 79, 0, 2, 116, 0, 0, 0, 36, 99, 48, 100, 55, 51, 49, 99, 97, 45, 48, 101, 55, 50, 45, 52, 57, 53, 48, 45, 57, 52, 57, 57, 45, 56, 100, 98, 56, 51, 98, 97, 100, 98, 48, 53, 49, 116, 0, 0, 0, 3, 121, 101, 115>>
   """
@@ -120,13 +120,13 @@ defmodule Electric.Postgres.LogicalReplication.Encoder do
   end
 
   def encode(%Update{changed_key_tuple_data: changed_data, relation_id: id, tuple_data: new_data})
-      when is_tuple(changed_data) do
+      when is_list(changed_data) do
     <<"U", id::integer-32, "K", encode_tuple_data(changed_data)::binary, "N",
       encode_tuple_data(new_data)::binary>>
   end
 
   def encode(%Update{old_tuple_data: old_data, relation_id: id, tuple_data: new_data})
-      when is_tuple(old_data) do
+      when is_list(old_data) do
     <<"U", id::integer-32, "O", encode_tuple_data(old_data)::binary, "N",
       encode_tuple_data(new_data)::binary>>
   end
@@ -135,11 +135,11 @@ defmodule Electric.Postgres.LogicalReplication.Encoder do
     <<"U", id::integer-32, "N", encode_tuple_data(new_data)::binary>>
   end
 
-  def encode(%Delete{relation_id: id, old_tuple_data: data}) when is_tuple(data) do
+  def encode(%Delete{relation_id: id, old_tuple_data: data}) when is_list(data) do
     <<"D", id::integer-32, "O", encode_tuple_data(data)::binary>>
   end
 
-  def encode(%Delete{relation_id: id, changed_key_tuple_data: data}) when is_tuple(data) do
+  def encode(%Delete{relation_id: id, changed_key_tuple_data: data}) when is_list(data) do
     <<"D", id::integer-32, "K", encode_tuple_data(data)::binary>>
   end
 
@@ -179,9 +179,8 @@ defmodule Electric.Postgres.LogicalReplication.Encoder do
 
   defp encode_tuple_data(tuple) do
     tuple
-    |> Tuple.to_list()
     |> Enum.map_join(&encode_tuple_element/1)
-    |> then(&<<tuple_size(tuple)::integer-16, &1::binary>>)
+    |> then(&<<length(tuple)::integer-16, &1::binary>>)
   end
 
   defp encode_tuple_element(nil), do: "n"

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -322,12 +322,12 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   end
 
   # TODO: Typecast to meaningful Elixir types here later
-  @spec data_tuple_to_map([Relation.Column.t()], tuple()) :: term()
+  @spec data_tuple_to_map([Relation.Column.t()], list()) :: term()
   defp data_tuple_to_map(_columns, nil), do: %{}
 
   defp data_tuple_to_map(columns, tuple_data) do
     columns
-    |> Enum.zip(Tuple.to_list(tuple_data))
+    |> Enum.zip(tuple_data)
     |> Map.new(fn {column, data} -> {column.name, data} end)
   end
 

--- a/components/electric/lib/electric/replication/postgres/slot_server.ex
+++ b/components/electric/lib/electric/replication/postgres/slot_server.ex
@@ -482,9 +482,7 @@ defmodule Electric.Replication.Postgres.SlotServer do
   end
 
   defp record_to_tuple(record, columns) do
-    columns
-    |> Enum.map(&Map.fetch!(record, &1.name))
-    |> List.to_tuple()
+    Enum.map(columns, &Map.fetch!(record, &1.name))
   end
 
   # Get last element from the list and the list's length in one pass

--- a/components/electric/test/electric/postgres/logical_replication/decoder_test.exs
+++ b/components/electric/test/electric/postgres/logical_replication/decoder_test.exs
@@ -163,21 +163,21 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                  48>>
              ) == %Insert{
                relation_id: 24576,
-               tuple_data: {"baz", "560"}
+               tuple_data: ["baz", "560"]
              }
     end
 
     test "decodes insert messages with null values" do
       assert decode(<<73, 0, 0, 96, 0, 78, 0, 2, 110, 116, 0, 0, 0, 3, 53, 54, 48>>) == %Insert{
                relation_id: 24576,
-               tuple_data: {nil, "560"}
+               tuple_data: [nil, "560"]
              }
     end
 
     test "decodes insert messages with unchanged toasted values" do
       assert decode(<<73, 0, 0, 96, 0, 78, 0, 2, 117, 116, 0, 0, 0, 3, 53, 54, 48>>) == %Insert{
                relation_id: 24576,
-               tuple_data: {:unchanged_toast, "560"}
+               tuple_data: [:unchanged_toast, "560"]
              }
     end
 
@@ -189,7 +189,7 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                relation_id: 24576,
                changed_key_tuple_data: nil,
                old_tuple_data: nil,
-               tuple_data: {"example", "560"}
+               tuple_data: ["example", "560"]
              }
     end
 
@@ -201,8 +201,8 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
              ) == %Update{
                relation_id: 24576,
                changed_key_tuple_data: nil,
-               old_tuple_data: {"baz", "560"},
-               tuple_data: {"example", "560"}
+               old_tuple_data: ["baz", "560"],
+               tuple_data: ["example", "560"]
              }
     end
 
@@ -212,9 +212,9 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                  0, 0, 7, 101, 120, 97, 109, 112, 108, 101, 116, 0, 0, 0, 3, 53, 54, 48>>
              ) == %Update{
                relation_id: 24576,
-               changed_key_tuple_data: {"baz", nil},
+               changed_key_tuple_data: ["baz", nil],
                old_tuple_data: nil,
-               tuple_data: {"example", "560"}
+               tuple_data: ["example", "560"]
              }
     end
 
@@ -224,7 +224,7 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                  110>>
              ) == %Delete{
                relation_id: 24576,
-               changed_key_tuple_data: {"example", nil}
+               changed_key_tuple_data: ["example", nil]
              }
     end
 
@@ -234,7 +234,7 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                  48>>
              ) == %Delete{
                relation_id: 24576,
-               old_tuple_data: {"baz", "560"}
+               old_tuple_data: ["baz", "560"]
              }
     end
   end

--- a/components/electric/test/electric/postgres/logical_replication/encoder_test.exs
+++ b/components/electric/test/electric/postgres/logical_replication/encoder_test.exs
@@ -150,7 +150,7 @@ defmodule Electric.Postgres.LogicalReplication.EncoderTest do
     test "encodes insert messages" do
       assert encode(%Insert{
                relation_id: 24576,
-               tuple_data: {"baz", "560"}
+               tuple_data: ["baz", "560"]
              }) ==
                <<73, 0, 0, 96, 0, 78, 0, 2, 116, 0, 0, 0, 3, 98, 97, 122, 116, 0, 0, 0, 3, 53, 54,
                  48>>
@@ -159,7 +159,7 @@ defmodule Electric.Postgres.LogicalReplication.EncoderTest do
     test "encodes insert messages with null values" do
       assert encode(%Insert{
                relation_id: 24576,
-               tuple_data: {nil, "560"}
+               tuple_data: [nil, "560"]
              }) ==
                <<73, 0, 0, 96, 0, 78, 0, 2, 110, 116, 0, 0, 0, 3, 53, 54, 48>>
     end
@@ -167,7 +167,7 @@ defmodule Electric.Postgres.LogicalReplication.EncoderTest do
     test "encodes insert messages with unchanged toasted values" do
       assert encode(%Insert{
                relation_id: 24576,
-               tuple_data: {:unchanged_toast, "560"}
+               tuple_data: [:unchanged_toast, "560"]
              }) ==
                <<73, 0, 0, 96, 0, 78, 0, 2, 117, 116, 0, 0, 0, 3, 53, 54, 48>>
     end
@@ -177,7 +177,7 @@ defmodule Electric.Postgres.LogicalReplication.EncoderTest do
                relation_id: 24576,
                changed_key_tuple_data: nil,
                old_tuple_data: nil,
-               tuple_data: {"example", "560"}
+               tuple_data: ["example", "560"]
              }) ==
                <<85, 0, 0, 96, 0, 78, 0, 2, 116, 0, 0, 0, 7, 101, 120, 97, 109, 112, 108, 101,
                  116, 0, 0, 0, 3, 53, 54, 48>>
@@ -187,8 +187,8 @@ defmodule Electric.Postgres.LogicalReplication.EncoderTest do
       assert encode(%Update{
                relation_id: 24576,
                changed_key_tuple_data: nil,
-               old_tuple_data: {"baz", "560"},
-               tuple_data: {"example", "560"}
+               old_tuple_data: ["baz", "560"],
+               tuple_data: ["example", "560"]
              }) ==
                <<85, 0, 0, 96, 0, 79, 0, 2, 116, 0, 0, 0, 3, 98, 97, 122, 116, 0, 0, 0, 3, 53, 54,
                  48, 78, 0, 2, 116, 0, 0, 0, 7, 101, 120, 97, 109, 112, 108, 101, 116, 0, 0, 0, 3,
@@ -198,9 +198,9 @@ defmodule Electric.Postgres.LogicalReplication.EncoderTest do
     test "encodes update messages with USING INDEX replica identity setting" do
       assert encode(%Update{
                relation_id: 24576,
-               changed_key_tuple_data: {"baz", nil},
+               changed_key_tuple_data: ["baz", nil],
                old_tuple_data: nil,
-               tuple_data: {"example", "560"}
+               tuple_data: ["example", "560"]
              }) ==
                <<85, 0, 0, 96, 0, 75, 0, 2, 116, 0, 0, 0, 3, 98, 97, 122, 110, 78, 0, 2, 116, 0,
                  0, 0, 7, 101, 120, 97, 109, 112, 108, 101, 116, 0, 0, 0, 3, 53, 54, 48>>
@@ -209,7 +209,7 @@ defmodule Electric.Postgres.LogicalReplication.EncoderTest do
     test "encodes DELETE messages with USING INDEX replica identity setting" do
       assert encode(%Delete{
                relation_id: 24576,
-               changed_key_tuple_data: {"example", nil}
+               changed_key_tuple_data: ["example", nil]
              }) ==
                <<68, 0, 0, 96, 0, 75, 0, 2, 116, 0, 0, 0, 7, 101, 120, 97, 109, 112, 108, 101,
                  110>>
@@ -218,7 +218,7 @@ defmodule Electric.Postgres.LogicalReplication.EncoderTest do
     test "encodes DELETE messages with FULL replica identity setting" do
       assert encode(%Delete{
                relation_id: 24576,
-               old_tuple_data: {"baz", "560"}
+               old_tuple_data: ["baz", "560"]
              }) ==
                <<68, 0, 0, 96, 0, 79, 0, 2, 116, 0, 0, 0, 3, 98, 97, 122, 116, 0, 0, 0, 3, 53, 54,
                  48>>

--- a/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
+++ b/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
@@ -32,11 +32,15 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
     {_, events} =
       begin()
       |> relation("entities", id: :uuid, data: :varchar)
-      |> insert("entities", {"test", "value"})
+      |> insert("entities", ["test", "value"])
       |> commit_and_get_messages()
-      |> process_messages(initialize_producer(), &LogicalReplicationProducer.handle_info/2)
+      |> process_messages(
+        initialize_producer(),
+        &LogicalReplicationProducer.handle_info/2
+      )
 
     assert [%Relation{name: "entities"}, %Transaction{} = transaction] = events
+
     assert [%NewRecord{record: %{"id" => "test", "data" => "value"}}] = transaction.changes
   end
 
@@ -44,12 +48,15 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
     {_, events} =
       begin()
       |> relation("entities", id: :uuid, data: :varchar)
-      |> insert("entities", {"test1", "value"})
-      |> insert("entities", {"test2", "value"})
-      |> insert("entities", {"test3", "value"})
-      |> insert("entities", {"test4", "value"})
+      |> insert("entities", ["test1", "value"])
+      |> insert("entities", ["test2", "value"])
+      |> insert("entities", ["test3", "value"])
+      |> insert("entities", ["test4", "value"])
       |> commit_and_get_messages()
-      |> process_messages(initialize_producer(), &LogicalReplicationProducer.handle_info/2)
+      |> process_messages(
+        initialize_producer(),
+        &LogicalReplicationProducer.handle_info/2
+      )
 
     assert [%Relation{name: "entities"}, %Transaction{} = transaction] = events
     assert length(transaction.changes) == 4
@@ -66,13 +73,16 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
     {_, events} =
       begin()
       |> relation("entities", id: :uuid, data: :varchar)
-      |> insert("entities", {"test", "1"})
-      |> update("entities", {"test", "1"}, {"test", "2"})
-      |> update("entities", {"test", "2"}, {"test", "3"})
-      |> update("entities", {"test", "3"}, {"test", "4"})
-      |> update("entities", {"test", "4"}, {"test", "5"})
+      |> insert("entities", ["test", "1"])
+      |> update("entities", ["test", "1"], ["test", "2"])
+      |> update("entities", ["test", "2"], ["test", "3"])
+      |> update("entities", ["test", "3"], ["test", "4"])
+      |> update("entities", ["test", "4"], ["test", "5"])
       |> commit_and_get_messages()
-      |> process_messages(initialize_producer(), &LogicalReplicationProducer.handle_info/2)
+      |> process_messages(
+        initialize_producer(),
+        &LogicalReplicationProducer.handle_info/2
+      )
 
     assert [%Relation{name: "entities"}, %Transaction{} = transaction] = events
     assert length(transaction.changes) == 5
@@ -146,7 +156,7 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
     })
   end
 
-  defp update(state, relation, old_record, data) when is_tuple(old_record) do
+  defp update(state, relation, old_record, data) when is_list(old_record) do
     add_action(state, %Messages.Update{
       relation_id: Map.fetch!(state.relations, relation),
       old_tuple_data: old_record,
@@ -156,7 +166,12 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
 
   defp commit_and_get_messages(%{lsn: lsn, actions: actions}) do
     timestamp = DateTime.utc_now()
-    begin = %Messages.Begin{xid: lsn.segment, final_lsn: lsn, commit_timestamp: timestamp}
+
+    begin = %Messages.Begin{
+      xid: lsn.segment,
+      final_lsn: lsn,
+      commit_timestamp: timestamp
+    }
 
     commit = %Messages.Commit{
       commit_timestamp: timestamp,


### PR DESCRIPTION
Using tuples as the internal representation of row data requires additional list -> tuple -> list transforms throughout the lifetime of the data.

This pr just uses lists throughout thus removing the need for this transform.

Checks:

- [x] premature optimization