### PR TITLE
feat: move Elixir WS client into a docker release to speed up CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
+      - name: Inject variables for `docker buildx` github actions caching
+        uses: crazy-max/ghaction-github-runtime@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -50,22 +54,6 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
 
-      - name: Restore dependencies
-        id: cache-deps
-        uses: actions/cache/restore@v3
-        with:
-          path: components/electric/deps
-          key: ${{ runner.os }}-mixdeps-${{ hashFiles('components/electric/**/mix.lock') }}
-
-      - name: Restore compiled code
-        id: cache-build
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            components/electric/_build/*/lib
-            !components/electric/_build/*/lib/electric
-          key: ${{ runner.os }}-mixbuild-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('components/electric/**/mix.lock') }}
-
       - run: |
           echo "ELECTRIC_VERSION=$(make --silent print_version_from_git)" >> $GITHUB_ENV
         working-directory: components/electric
@@ -73,7 +61,9 @@ jobs:
         env:
           ELECTRIC_IMAGE_NAME: electric-sql-ci/electric
         working-directory: components/electric
-      - run: make pretest_compile
+      - run: make docker-build-ws-client
+        env:
+          ELECTRIC_CLIENT_IMAGE_NAME: electric-sql-ci/electric-ws-client
         working-directory: components/electric
 
       - name: Cache built lux
@@ -91,10 +81,12 @@ jobs:
 
       - run: make postgres
 
-      - run: make test
+      - run: make deps pull
+      - run: make test_only
         id: tests
         env:
           ELECTRIC_IMAGE_NAME: electric-sql-ci/electric
+          ELECTRIC_CLIENT_IMAGE_NAME: electric-sql-ci/electric-ws-client
           ELECTRIC_IMAGE_TAG: ${{ env.ELECTRIC_VERSION }}
 
       - name: Upload lux logs

--- a/components/electric/Dockerfile
+++ b/components/electric/Dockerfile
@@ -13,20 +13,24 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -f /var/lib/apt/lists/*_*
 
+RUN mix local.hex --force && mix local.rebar --force
+
 ENV MIX_ENV=prod
 
 WORKDIR /app
 COPY Makefile /app/
-RUN make build_tools
 
 COPY mix.*  /app/
-RUN make deps
-COPY config /app/config/
+RUN mix deps.get
+COPY config/config.exs config/prod.exs /app/config/
 RUN mix deps.compile
 
 COPY lib    /app/lib/
+
+RUN make build_tools
 ARG ELECTRIC_VERSION=local
-RUN make compile release
+ARG MAKE_RELEASE_TASK=release
+RUN make compile ${MAKE_RELEASE_TASK}
 
 FROM ${RUNNER_IMAGE} AS runner_setup
 
@@ -47,9 +51,12 @@ RUN chown nobody /app
 
 FROM runner_setup AS runner
 
+ARG RELEASE_NAME=electric
 ## Vaxine configuration via environment variables
-COPY --from=builder /app/_build/prod/rel/electric ./
+COPY --from=builder /app/_build/prod/rel/${RELEASE_NAME} ./
+RUN ln -s /app/bin/${RELEASE_NAME} /app/bin/entrypoint
 
 VOLUME ./offset_storage_data.dat
 
-ENTRYPOINT /app/bin/electric start
+ENTRYPOINT ["/app/bin/entrypoint"]
+CMD ["start"]

--- a/components/electric/lib/satellite/satellite_ws_client.ex
+++ b/components/electric/lib/satellite/satellite_ws_client.ex
@@ -3,7 +3,7 @@ defmodule Electric.Test.SatelliteWsClient do
 
   """
   alias Electric.Satellite.Serialization
-  alias Electric.Replication.Changes.{Transaction}
+  alias Electric.Replication.Changes.Transaction
 
   use Electric.Satellite.Protobuf
 

--- a/components/electric/mix.exs
+++ b/components/electric/mix.exs
@@ -15,7 +15,15 @@ defmodule Electric.MixProject do
         coveralls: :test,
         "coveralls.lcov": :test,
         "coveralls.html": :test
-      ]
+      ],
+      releases: [
+        electric: [applications: [electric: :permanent], include_executables_for: [:unix]],
+        ws_client: [
+          applications: [electric: :load, gun: :permanent],
+          include_executables_for: [:unix]
+        ]
+      ],
+      default_release: :electric
     ]
   end
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -9,17 +9,18 @@ deps: lux
 	make -C satellite_client build
 	make -C elixir_client build
 
-test: deps build pull
-	${LUX} ${LUX_DIRS}
-
 build:
 	$(foreach dir, $(LUX_DIRS),make -C ${dir} build;)
+
+test_only:
+	${LUX} ${LUX_DIRS}
+
+test: deps build pull test_only
 
 pull:
 	docker compose -f services_templates.yaml pull \
 		vaxine \
 		sysbench \
-		elixir_client \
 		postgresql
 
 stop:

--- a/e2e/common.luxinc
+++ b/e2e/common.luxinc
@@ -1,3 +1,6 @@
+[global dprompt=\w+!?@\w+:(\S+)[\#\$]]
+[global eprompt=iex\(ws_client@.*\)\d+>\s]
+
 [global _global_log_string_counter=0]
 [macro log string]
     [my old=$LUX_SHELLNAME]
@@ -65,8 +68,8 @@
 
 [macro start_elixir_test id]
     !make start_elixir_test_${id}
-    [invoke ok2 $dprompt]
-    !make run_elixir
+    ?$eprompt
+    !Application.put_env(:elixir, :ansi_enabled, false)
     ?$eprompt
 [endmacro]
 

--- a/e2e/common.mk
+++ b/e2e/common.mk
@@ -27,8 +27,10 @@ endif
 
 ifeq (${ELECTRIC_IMAGE_NAME}${ELECTRIC_IMAGE_TAG},)
 	export ELECTRIC_IMAGE=electric:local-build
+	export ELECTRIC_CLIENT_IMAGE=electric-ws-client:local-build
 else
 	export ELECTRIC_IMAGE=${ELECTRIC_IMAGE_NAME}:${ELECTRIC_IMAGE_TAG}
+	export ELECTRIC_CLIENT_IMAGE=${ELECTRIC_CLIENT_IMAGE_NAME}:${ELECTRIC_IMAGE_TAG}
 endif
 
 lux: ${LUX}
@@ -93,9 +95,7 @@ start_sysbench:
 
 start_elixir_test_%:
 	docker compose -f ${DOCKER_COMPOSE_FILE} run \
-		--rm --entrypoint=/bin/bash \
-		--workdir=${E2E_ROOT}/elixir_client \
-		-e ELECTRIC_VERSION=`git describe --abbrev=7 --tags --always --first-parent` \
+		--rm \
 		elixir_client_$*
 
 start_satellite_client_%:

--- a/e2e/elixir_client/Makefile
+++ b/e2e/elixir_client/Makefile
@@ -5,18 +5,12 @@ DOCKER_COMPOSE_FILE=../services_templates.yaml
 DOCKER_WORKDIR=${E2E_ROOT}/elixir_client
 
 export DOCKER_REPO ?= europe-docker.pkg.dev/vaxine/ci
-export BUILDER_IMAGE=${DOCKER_REPO}/electric-builder:latest
+export ELECTRIC_CLIENT_IMAGE_NAME ?= electric-ws-client
 
 ELECTRIC_DIR=${PROJECT_ROOT}/components/electric
 
 build:
-	make docker-make MK_TARGET=local-build MK_DOCKER=${ELIXIR_BUILD_DOCKER}
-
-local-build:
-	(cd ${ELECTRIC_DIR} && make build_tools deps compile-test)
-
-run_elixir:
-	(cd ${ELECTRIC_DIR} && iex -S mix run --no-start --no-deps-check -e "Application.put_env(:elixir, :ansi_enabled, false)")
+	make -C ${ELECTRIC_DIR} docker-build-ws-client
 
 clean:
 	rm -rf _build

--- a/e2e/migrations_v2/api.lux
+++ b/e2e/migrations_v2/api.lux
@@ -1,7 +1,5 @@
 [doc Test that the API allows the client to download the migrations as a zip]
 
-[global dprompt=\w+!?@\w+:(\S+)[\#\$]]
-[global eprompt=iex\(\d+\)>\s]
 [global psql=electric]
 [global user_id_1=1]
 [global migration_version_1=20230504114018]

--- a/e2e/migrations_v2/replication.lux
+++ b/e2e/migrations_v2/replication.lux
@@ -1,7 +1,5 @@
 [doc test flow of migrations from pg -> electric -> replication stream]
 
-[global dprompt=\w+!?@\w+:(\S+)[\#\$]]
-[global eprompt=iex\(\d+\)>\s]
 [global psql=electric]
 [global user_id_1=1]
 [global migration_version=20230504114018]

--- a/e2e/satellite_client/Dockerfile
+++ b/e2e/satellite_client/Dockerfile
@@ -13,11 +13,14 @@ RUN pnpm fetch
 COPY pnpm-workspace.yaml ./
 COPY clients/typescript ./clients/typescript
 COPY generator ./generator
-COPY e2e/satellite_client ./e2e/satellite_client
+COPY e2e/satellite_client/package.json  ./e2e/satellite_client/
 
 RUN pnpm install -r --filter satellite_client^...
 RUN pnpm run -r --filter satellite_client^... build
 RUN pnpm install -r --filter satellite_client
+COPY e2e/satellite_client/src  ./e2e/satellite_client/src
+COPY e2e/satellite_client/prisma  ./e2e/satellite_client/prisma
+COPY e2e/satellite_client/tsconfig.json  ./e2e/satellite_client
 RUN pnpm run -r --filter satellite_client build
 
 RUN pnpm --filter satellite_client --prod deploy output

--- a/e2e/satellite_client/Makefile
+++ b/e2e/satellite_client/Makefile
@@ -4,10 +4,15 @@ NODEJS_DOCKER=satellite_client
 DOCKER_COMPOSE_FILE=../services_templates.yaml
 DOCKER_WORKDIR=${E2E_ROOT}/satellite_client
 
+ifneq ($(GITHUB_ACTION),)
+CACHING_SETTINGS := --cache-to type=gha,mode=max,scope=$GITHUB_REF_NAME-node-client --cache-from type=gha,scope=$GITHUB_REF_NAME-node-client
+# else
+# CACHING_SETTINGS := --cache-to type=local,mode=max --cache-from type=local
+endif
 # By default we would like to build in docker, as we intend
 # to run tests with Satellite in it
 build:
-	docker build -f ./Dockerfile -t satellite_client:local ${PROJECT_ROOT}
+	docker buildx build --load ${CACHING_SETTINGS} -f ./Dockerfile -t satellite_client:local ${PROJECT_ROOT}
 
 local-build:
 	pnpm i --frozen-lockfile

--- a/e2e/services_templates.yaml
+++ b/e2e/services_templates.yaml
@@ -83,20 +83,14 @@ services:
     privileged: true
 
   elixir_client:
-    image: ${BUILDER_IMAGE}
-    user: "${UID}:${GID}"
+    image: ${ELECTRIC_CLIENT_IMAGE}
+    command: start_iex
     environment:
-      MIX_ENV: test
-      MIX_HOME:       ${E2E_ROOT}/elixir_client/
-      MIX_BUILD_ROOT: ${E2E_ROOT}/elixir_client/_build
-      MIX_DEPS_PATH:  ${E2E_ROOT}/elixir_client/deps
-      HEX_HOME:       ${E2E_ROOT}/elixir_client/.hex
-      UID: ${UID}
-      GID: ${GID}
-    volumes:
-      - ${PROJECT_ROOT}:${PROJECT_ROOT}:ro
-      - ${E2E_ROOT}/elixir_client:${E2E_ROOT}/elixir_client
-      - /etc/group:/etc/group:ro
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/shadow:/etc/shadow:ro
+      SATELLITE_AUTH_SIGNING_ISS: dev.electric-sql.com
+      SATELLITE_AUTH_SIGNING_KEY: integration-tests-signing-key-example
+      LOG_LEVEL: debug
+      GLOBAL_CLUSTER_ID: "doesn't matter"
+      ELECTRIC_INSTANCE_ID: "doesn't matter"
+      ELECTRIC_REGIONAL_ID: "doesn't matter"
+      ELECTRIC_HOST: "doesn't matter"
     privileged: true

--- a/e2e/single_dc/sysbench_ws.lux.ignored
+++ b/e2e/single_dc/sysbench_ws.lux.ignored
@@ -1,8 +1,6 @@
 [doc One-direction replication pg_1 -> pg_2]
 
 [global psql=electric]
-[global dprompt=\w+!?@\w+:(\S+)[\#\$]]
-[global eprompt=iex\(\d+\)>\s]
 [global table_count=10]
 [global row_count=10]
 


### PR DESCRIPTION
This commit moved the Satellite WS client into an Elixir release, as if it was part of the production code. That way we can rely on building the docker image rather than mounting pieces of code into an already-running container. Having that set up, we can the utilize `docker buildx build` command (which supercedes now-deprecated `docker build` legacy builder) to utilize Github Actions cache for built docker images while avoiding any pushes to external registries.