### PR TITLE
feat!(pg): move conflict resolution to PG using special triggers

### DIFF
--- a/clients/typescript/src/satellite/oplog.ts
+++ b/clients/typescript/src/satellite/oplog.ts
@@ -381,12 +381,8 @@ export const opLogEntryToChange = (
     throw new Error(`Could not find relation for ${entry.tablename}`)
   }
 
-  // FIXME: We should not loose UPDATE information here, as otherwise
-  // it will be identical to setting all values in a transaction, instead
-  // of updating values (different CR outcome)
   return {
-    type:
-      entry.optype == 'DELETE' ? DataChangeType.DELETE : DataChangeType.INSERT,
+    type: entry.optype as DataChangeType,
     relation: relation,
     record,
     oldRecord,

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1084,7 +1084,7 @@ test('get transactions from opLogEntries', async (t) => {
         },
         {
           relation: relations.parent,
-          type: DataChangeType.INSERT,
+          type: DataChangeType.UPDATE,
           record: { id: 1 },
           oldRecord: { id: 1 },
           tags: [],

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -389,6 +389,12 @@ defmodule Electric.Postgres.Extension do
   with one column having same name as the main table, and the other having the name
   `__reordered_<original_column_name>`. We can thus remove all non-pk columns if
   they have a paired reordered column.
+
+  The reason to use this function as opposed to querying `SchemaCache` is when we need
+  this information before the transaction got propagated to `MigrationsConsumer`. This
+  function's main place of use is in `PostgresReplicationProducer`, which will always
+  be ahead of `MigrationsConsumer`, and thus may need to access that information
+  before it's written to cache.
   """
   def infer_shadow_primary_keys(record) when is_map(record) do
     infer_shadow_primary_keys(Map.keys(record))

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -37,7 +37,7 @@ defmodule Electric.Postgres.Extension do
   @partial_migration_history_query ~s(SELECT "version", "schema", "migration_ddl" FROM #{@schema_table} WHERE "version" > $1 ORDER BY "version" ASC)
   @current_schema_query ~s(SELECT "schema", "version" FROM #{@schema_table} ORDER BY "id" DESC LIMIT 1)
   @schema_version_query ~s(SELECT "schema", "version" FROM #{@schema_table} WHERE "version" = $1 LIMIT 1)
-  # FIXME: VAX-600 insert into schema ignoring conflicts (which I think arise from inter-pg replication, a problem 
+  # FIXME: VAX-600 insert into schema ignoring conflicts (which I think arise from inter-pg replication, a problem
   # that will go away once we stop replicating all tables by default)
   @save_schema_query ~s[INSERT INTO #{@schema_table} ("version", "schema", "migration_ddl") VALUES ($1, $2, $3) ON CONFLICT ("id") DO NOTHING]
   @ddl_history_query "SELECT id, txid, txts, query FROM #{@ddl_table} ORDER BY id ASC;"
@@ -193,6 +193,7 @@ defmodule Electric.Postgres.Extension do
     [
       Migrations.Migration_20230328113927,
       Migrations.Migration_20230424154425_DDLX,
+      Migrations.Migration_20230512000000_conflict_resolution_triggers,
       Migrations.Migration_20230605141256_ElectrifyFunction
     ]
   end

--- a/components/electric/lib/electric/postgres/extension/migrations/20230328113927_setup_extension.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230328113927_setup_extension.ex
@@ -157,7 +157,7 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20230328113927 do
       ##################
       """
       CREATE EVENT TRIGGER #{event_triggers[:ddl_command_end]} ON ddl_command_end
-          WHEN TAG IN (#{Enum.join(event_trigger_tags, ", ")}) 
+          WHEN TAG IN (#{Enum.join(event_trigger_tags, ", ")})
           EXECUTE FUNCTION #{schema}.ddlx_command_end_handler();
       """,
       """

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers.ex
@@ -24,45 +24,7 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20230512000000_confli
       @contents["utility_functions"],
       @contents["trigger_function_installers"],
       @contents["shadow_table_creation_and_update"],
-      # This next function is overridden in the next migration
-      """
-      CREATE OR REPLACE FUNCTION #{schema}.ddlx_command_end_handler() RETURNS EVENT_TRIGGER AS
-      $function$
-      DECLARE
-          _txid #{@txid_type};
-          _txts timestamptz;
-          _version text;
-          trid int8;
-          v_cmd_rec record;
-          _capture bool;
-      BEGIN
-          -- Usually, this would be a great place for `pg_trigger_depth()`, but for event triggers that's always
-          IF (current_setting('electric.is_in_event_trigger', true) = 'true') THEN RETURN; END IF;
-          RAISE DEBUG 'command_end_handler:: version: % :: start (depth %)', _version, pg_trigger_depth();
-
-          SELECT v.txid, v.txts, v.version
-            INTO _txid, _txts, _version
-            FROM #{schema}.current_migration_version() v;
-
-          trid := (SELECT #{schema}.create_active_migration(_txid, _txts, _version));
-
-          -- We're maybe going to create multiple tables here. We don't want to re-trigger this function
-          PERFORM set_config('electric.is_in_event_trigger', 'true', true);
-          FOR v_cmd_rec IN (SELECT * FROM pg_event_trigger_ddl_commands())
-          LOOP
-              RAISE DEBUG '  Current statement touches a % in schema % with objid %', v_cmd_rec.object_type, v_cmd_rec.schema_name, v_cmd_rec.object_identity;
-              IF v_cmd_rec.object_type = 'table' AND v_cmd_rec.schema_name <> '#{schema}' THEN
-                  PERFORM electric.ddlx_make_or_update_shadow_tables(v_cmd_rec.command_tag, v_cmd_rec.schema_name, v_cmd_rec.objid);
-              END IF;
-          END LOOP;
-          PERFORM set_config('electric.is_in_event_trigger', '', true);
-
-          RAISE DEBUG 'create_active_migration = %', trid;
-          RAISE DEBUG 'command_end_handler:: version: % :: end', _version;
-      END;
-      $function$
-      LANGUAGE PLPGSQL;
-      """
+      # We need to actually run shadow table creation/updates, but that's handled in the next migration.
     ]
     |> Enum.map(&String.replace(&1, "electric", schema))
   end

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers.ex
@@ -23,7 +23,7 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20230512000000_confli
       @contents["electric_tag_type_and_operators"],
       @contents["utility_functions"],
       @contents["trigger_function_installers"],
-      @contents["shadow_table_creation_and_update"],
+      @contents["shadow_table_creation_and_update"]
       # We need to actually run shadow table creation/updates, but that's handled in the next migration.
     ]
     |> Enum.map(&String.replace(&1, "electric", schema))

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers.ex
@@ -1,0 +1,74 @@
+defmodule Electric.Postgres.Extension.Migrations.Migration_20230512000000_conflict_resolution_triggers do
+  alias Electric.Postgres.Extension
+
+  @behaviour Extension.Migration
+
+  files =
+    "20230512000000_conflict_resolution_triggers/*.sql"
+    |> Path.expand(__DIR__)
+    |> Path.wildcard()
+
+  for file <- files, do: @external_resource(file)
+
+  @contents for file <- files, into: %{}, do: {Path.basename(file, ".sql"), File.read!(file)}
+
+  @txid_type "xid8"
+
+  @impl true
+  def version, do: 2023_05_12_00_00_00
+
+  @impl true
+  def up(schema) do
+    [
+      @contents["electric_tag_type_and_operators"],
+      @contents["utility_functions"],
+      @contents["trigger_function_installers"],
+      @contents["shadow_table_creation_and_update"],
+      # This next function is overridden in the next migration
+      """
+      CREATE OR REPLACE FUNCTION #{schema}.ddlx_command_end_handler() RETURNS EVENT_TRIGGER AS
+      $function$
+      DECLARE
+          _txid #{@txid_type};
+          _txts timestamptz;
+          _version text;
+          trid int8;
+          v_cmd_rec record;
+          _capture bool;
+      BEGIN
+          -- Usually, this would be a great place for `pg_trigger_depth()`, but for event triggers that's always
+          IF (current_setting('electric.is_in_event_trigger', true) = 'true') THEN RETURN; END IF;
+          RAISE DEBUG 'command_end_handler:: version: % :: start (depth %)', _version, pg_trigger_depth();
+
+          SELECT v.txid, v.txts, v.version
+            INTO _txid, _txts, _version
+            FROM #{schema}.current_migration_version() v;
+
+          trid := (SELECT #{schema}.create_active_migration(_txid, _txts, _version));
+
+          -- We're maybe going to create multiple tables here. We don't want to re-trigger this function
+          PERFORM set_config('electric.is_in_event_trigger', 'true', true);
+          FOR v_cmd_rec IN (SELECT * FROM pg_event_trigger_ddl_commands())
+          LOOP
+              RAISE DEBUG '  Current statement touches a % in schema % with objid %', v_cmd_rec.object_type, v_cmd_rec.schema_name, v_cmd_rec.object_identity;
+              IF v_cmd_rec.object_type = 'table' AND v_cmd_rec.schema_name <> '#{schema}' THEN
+                  PERFORM electric.ddlx_make_or_update_shadow_tables(v_cmd_rec.command_tag, v_cmd_rec.schema_name, v_cmd_rec.objid);
+              END IF;
+          END LOOP;
+          PERFORM set_config('electric.is_in_event_trigger', '', true);
+
+          RAISE DEBUG 'create_active_migration = %', trid;
+          RAISE DEBUG 'command_end_handler:: version: % :: end', _version;
+      END;
+      $function$
+      LANGUAGE PLPGSQL;
+      """
+    ]
+    |> Enum.map(&String.replace(&1, "electric", schema))
+  end
+
+  @impl true
+  def down(_schema) do
+    []
+  end
+end

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/electric_tag_type_and_operators.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/electric_tag_type_and_operators.sql
@@ -1,0 +1,158 @@
+CREATE TYPE electric.unbounded_tag AS (
+  timestamp TIMESTAMP WITH TIME ZONE,
+  source_id varchar(255)
+);
+
+CREATE DOMAIN electric.tag AS electric.unbounded_tag
+    CHECK (VALUE IS NULL OR (VALUE).timestamp IS NOT NULL);
+
+
+CREATE OR REPLACE FUNCTION electric.tag_operator_eq(first electric.tag, second electric.tag) RETURNS boolean
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    COST 1
+    RETURNS NULL ON NULL INPUT
+    RETURN first.timestamp = second.timestamp AND first.source_id IS NOT DISTINCT FROM second.source_id;
+
+
+CREATE OR REPLACE FUNCTION electric.tag_operator_neq(first electric.tag, second electric.tag) RETURNS boolean
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    COST 1
+    RETURNS NULL ON NULL INPUT
+    RETURN first.timestamp <> second.timestamp OR first.source_id IS DISTINCT FROM second.source_id;
+
+
+CREATE OR REPLACE FUNCTION electric.tag_operator_lt(first electric.tag, second electric.tag) RETURNS boolean
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    COST 1
+    RETURN first.timestamp < second.timestamp
+           OR (first.timestamp = second.timestamp
+               AND (first.source_id IS NOT NULL AND second.source_id IS NULL
+                    OR (first.source_id IS NOT NULL AND second.source_id IS NOT NULL AND first.source_id < second.source_id)));
+
+
+CREATE OR REPLACE FUNCTION electric.tag_operator_gt(first electric.tag, second electric.tag) RETURNS boolean
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    COST 1
+    RETURNS NULL ON NULL INPUT
+    RETURN first.timestamp > second.timestamp
+           OR (first.timestamp = second.timestamp
+               AND (first.source_id IS NULL AND second.source_id IS NOT NULL
+                    OR (first.source_id IS NOT NULL AND second.source_id IS NOT NULL AND first.source_id > second.source_id)));
+
+
+CREATE OR REPLACE FUNCTION electric.tag_operator_gte(first electric.tag, second electric.tag) RETURNS boolean
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    COST 1
+    RETURNS NULL ON NULL INPUT
+    RETURN first.timestamp > second.timestamp
+           OR (first.timestamp = second.timestamp
+               AND (first.source_id IS NULL AND second.source_id IS NOT NULL
+                    OR first.source_id IS NOT DISTINCT FROM second.source_id)
+                    OR (first.source_id IS NOT NULL AND second.source_id IS NOT NULL AND first.source_id > second.source_id));
+
+
+CREATE OR REPLACE FUNCTION electric.tag_operator_lte(first electric.tag, second electric.tag) RETURNS boolean
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    COST 1
+    RETURNS NULL ON NULL INPUT
+    RETURN first.timestamp < second.timestamp
+           OR (first.timestamp = second.timestamp
+               AND (first.source_id IS NOT NULL AND second.source_id IS NULL
+                    OR first.source_id IS NOT DISTINCT FROM second.source_id)
+                    OR (first.source_id IS NOT NULL AND second.source_id IS NOT NULL AND first.source_id < second.source_id));
+
+CREATE OPERATOR = (
+    LEFTARG = electric.tag,
+    RIGHTARG = electric.tag,
+    FUNCTION = electric.tag_operator_eq,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG = electric.tag,
+    RIGHTARG = electric.tag,
+    FUNCTION = electric.tag_operator_neq,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG = electric.tag,
+    RIGHTARG = electric.tag,
+    FUNCTION = electric.tag_operator_lt,
+    COMMUTATOR = >,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG = electric.tag,
+    RIGHTARG = electric.tag,
+    FUNCTION = electric.tag_operator_gt,
+    COMMUTATOR = <,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+
+CREATE OPERATOR >= (
+    LEFTARG = electric.tag,
+    RIGHTARG = electric.tag,
+    FUNCTION = electric.tag_operator_gte,
+    COMMUTATOR = <=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG = electric.tag,
+    RIGHTARG = electric.tag,
+    FUNCTION = electric.tag_operator_lte,
+    COMMUTATOR = >=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OR REPLACE FUNCTION electric.tag_operator_cmp(first electric.tag, second electric.tag) RETURNS integer
+    LANGUAGE SQL
+    IMMUTABLE PARALLEL SAFE
+    COST 1
+    RETURNS NULL ON NULL INPUT
+    RETURN CASE
+        WHEN first = second then 0
+        WHEN first < second then -1
+        ELSE 1
+    END;
+
+
+CREATE OPERATOR CLASS btree__electric_tag_ops
+    DEFAULT FOR TYPE electric.tag USING btree AS
+        OPERATOR 1 <,
+        OPERATOR 2 <=,
+        OPERATOR 3 =,
+        OPERATOR 4 >=,
+        OPERATOR 5 >,
+        FUNCTION 1 electric.tag_operator_cmp(electric.tag, electric.tag);

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/shadow_table_creation_and_update.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/shadow_table_creation_and_update.sql
@@ -88,6 +88,7 @@ BEGIN
         END LOOP;
 
         -- Create a shadow table in the electric namespace and using the table name with `shadow__` prefix
+        -- If you update or modify this table structure, please make sure it is fully reflected in `Electric.Postgres.Schema.build_shadow_table/1`
         EXECUTE format(
             E'CREATE TABLE electric.%I (\n'
             '    _tags electric.tag[] DEFAULT array[]::electric.tag[],\n'

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/shadow_table_creation_and_update.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/shadow_table_creation_and_update.sql
@@ -66,7 +66,7 @@ BEGIN
             -- Shadow table primary key duplicates the one on the main table, but other columns are of the `tag` type
             shadow_column_definitions :=
                 shadow_column_definitions
-                || format(E'    %I %s,\n', cols.col_name, (CASE WHEN cols.col_primary THEN cols.col_type || ' NOT NULL' ELSE 'electric.tag' END));
+                || format(E'    %I %s,\n', (CASE WHEN cols.col_primary THEN '' ELSE '_tag_' END) || cols.col_name, (CASE WHEN cols.col_primary THEN cols.col_type || ' NOT NULL' ELSE 'electric.tag' END));
 
             -- Reordered columns have the same type as the original columns, but will be stored in a shadow table.
             -- PK columns aren't reordered since we consider them immutable
@@ -163,7 +163,7 @@ BEGIN
                 -- Shadow table is missing a column, meaning it got added
                 shadow_column_definitions :=
                     shadow_column_definitions
-                    || format(E'    ADD COLUMN %I electric.tag,\n', cols.main_col_name);
+                    || format(E'    ADD COLUMN %I electric.tag,\n', '_tag_' || cols.main_col_name);
 
                 reordered_column_definitions :=
                     reordered_column_definitions

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/shadow_table_creation_and_update.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/shadow_table_creation_and_update.sql
@@ -1,0 +1,213 @@
+
+-- This function returns information about columns of the table based on it's oid, skipping any columns starting with an underscore
+CREATE OR REPLACE FUNCTION electric.lookup_columns(search_oid oid, include_hidden_columns boolean DEFAULT false)
+    RETURNS TABLE (col_name name, col_type text, col_not_null boolean, col_default text, col_primary boolean)
+    STABLE PARALLEL SAFE
+    RETURNS NULL ON NULL INPUT
+    ROWS 10
+    LANGUAGE SQL AS $$
+        SELECT
+            attname AS col_name,
+            pg_catalog.format_type(atttypid, atttypmod) AS col_type,
+            attnotnull AS col_not_null,
+            pg_get_expr(adbin, adrelid) AS col_default,
+            indexrelid IS NOT NULL AS col_primary
+        FROM pg_attribute
+        LEFT JOIN pg_attrdef
+            ON attrelid = adrelid AND attnum = adnum
+        LEFT JOIN pg_index
+            ON attrelid = indrelid AND attnum = ANY(indkey) AND indisprimary
+        WHERE
+            attrelid = search_oid
+            AND attnum > 0
+            AND (include_hidden_columns OR attname NOT LIKE '\_%')
+        ORDER BY attnum
+    $$;
+
+-- This function creates or updates shadow tables for conflict resolution
+CREATE OR REPLACE FUNCTION electric.ddlx_make_or_update_shadow_tables(tag text, schema_name text, target_oid oid)
+    RETURNS VOID
+    LANGUAGE PLPGSQL AS $function$
+DECLARE
+    cols RECORD;
+    sql_statement TEXT := '';
+    reordered_column_definitions TEXT := '';
+    shadow_column_definitions TEXT := '';
+    tombstone_column_definitions TEXT := '';
+    primary_key_list TEXT[];
+    non_pk_column_list TEXT[] := array[]::TEXT[];
+    table_name TEXT;
+    full_table_identifier TEXT;
+    generated_functions JSONB;
+    shadow_table_name NAME;
+    tombstone_table_name NAME;
+    shadow_table_oid oid;
+    tombstone_table_oid oid;
+BEGIN
+    -- Get table name to modify
+    SELECT relname INTO table_name FROM pg_class WHERE oid = target_oid;
+    shadow_table_name := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name := 'tombstone__' || schema_name || '__' || table_name;
+
+    -- Get primary keys
+    SELECT array_agg(attname ORDER BY array_position(indkey, attnum))
+        INTO primary_key_list
+    FROM pg_index JOIN pg_attribute ON attrelid = indrelid AND attnum = ANY(indkey) AND indisprimary
+    WHERE indrelid = target_oid;
+
+
+    IF tag = 'CREATE TABLE' THEN
+        -- Table got created, so we need to just copy it's structure for the shadow table
+
+        -- Get a list of columns, which are going to be used in both shadow and the tombstone tables
+        FOR cols IN
+            SELECT * from electric.lookup_columns(target_oid)
+        LOOP
+            -- Shadow table primary key duplicates the one on the main table, but other columns are of the `tag` type
+            shadow_column_definitions :=
+                shadow_column_definitions
+                || format(E'    %I %s,\n', cols.col_name, (CASE WHEN cols.col_primary THEN cols.col_type || ' NOT NULL' ELSE 'electric.tag' END));
+
+            -- Reordered columns have the same type as the original columns, but will be stored in a shadow table.
+            -- PK columns aren't reordered since we consider them immutable
+            -- They are also always nullable, so that we can reset them to null after reordering is done.
+            IF NOT cols.col_primary THEN
+                reordered_column_definitions :=
+                  reordered_column_definitions
+                  || format(E'    %I %s,\n', '__reordered_' || cols.col_name, cols.col_type);
+                
+                -- We're also building up a non-pk column name list, that's going to be used in trigger function creation
+                non_pk_column_list := non_pk_column_list || cols.col_name;
+            END IF;
+
+            -- Tombstone table copies the original table structure, since we're going to copy deleted rows there
+            tombstone_column_definitions :=
+                tombstone_column_definitions
+                || format(E'    %I %s %sNULL,\n', cols.col_name, cols.col_type, (CASE WHEN cols.col_not_null THEN 'NOT ' ELSE '' END));
+
+        END LOOP;
+
+        -- Create a shadow table in the electric namespace and using the table name with `shadow__` prefix
+        EXECUTE format(
+            E'CREATE TABLE electric.%I (\n'
+            '    _tags electric.tag[] DEFAULT array[]::electric.tag[],\n'
+            '    _last_modified bigint,\n'
+            '    _is_a_delete_operation boolean DEFAULT false,\n'
+            '    _tag electric.tag,\n'
+            '    _observed_tags electric.tag[],\n'
+            '    _modified_columns_bit_mask boolean[],\n'
+            '    _resolved boolean,\n'
+            '    _currently_reordering boolean,\n'
+            '%s'
+            '%s'
+            '    PRIMARY KEY(%s)\n'
+            ')',
+            shadow_table_name,
+            reordered_column_definitions,
+            shadow_column_definitions,
+            electric.format_every_and_join(primary_key_list, '%I')
+        );
+
+        EXECUTE format('ALTER TABLE electric.%I REPLICA IDENTITY FULL', shadow_table_name);
+
+        -- Create a tombstone table in the electric namespace and using the table name with `tombstone__` prefix
+        EXECUTE format(
+            E'CREATE TABLE electric.%I (\n'
+            '%s'
+            '    PRIMARY KEY(%s)\n'
+            ')',
+            tombstone_table_name,
+            tombstone_column_definitions,
+            electric.format_every_and_join(primary_key_list, '%I')
+        );
+
+        -- We install generate functions for newly created tables & triggers using those functions
+        PERFORM electric.install_functions_and_triggers(schema_name, table_name, primary_key_list, non_pk_column_list);
+    ELSIF tag = 'ALTER TABLE' THEN
+        -- Table got altered. Since we currently only support additive migrations,
+        -- this can only be a column addition, but we can prepare for the future a little and query for more possible cases
+
+        -- Find the shadow table oid
+        SELECT pg_class.oid INTO shadow_table_oid
+            FROM pg_class JOIN pg_namespace ON relnamespace = pg_namespace.oid
+            WHERE relname = shadow_table_name AND nspname = 'electric';
+
+        SELECT pg_class.oid INTO tombstone_table_oid
+            FROM pg_class JOIN pg_namespace ON relnamespace = pg_namespace.oid
+            WHERE relname = tombstone_table_name AND nspname = 'electric';
+
+        RAISE DEBUG 'TARGET (%) %', target_oid, (SELECT to_json(array_agg(t)) FROM (SELECT * FROM electric.lookup_columns(target_oid)) t);
+        RAISE DEBUG 'TOMBSTONE (%) %', tombstone_table_oid, (SELECT to_json(array_agg(t)) FROM (SELECT * FROM electric.lookup_columns(tombstone_table_oid)) t);
+
+        -- Get all columns that are different between the main table & the shadow table:
+        -- either missing or changed type.
+        -- TODO: Support or guard against column removal and/or type changes.
+        --       Also we currently ignore defaults and NULL constraints. This is fine
+        --       since only our triggers should write to these tables anyhow
+        FOR cols IN
+            WITH main AS (SELECT * FROM electric.lookup_columns(target_oid)),
+                 tomb AS (SELECT * FROM electric.lookup_columns(tombstone_table_oid))
+            SELECT
+                main.col_name as main_col_name,
+                tomb.col_name as tomb_col_name,
+                main.col_type as main_col_type,
+                tomb.col_type as tomb_col_type
+            FROM main
+                FULL JOIN tomb ON main.col_name = tomb.col_name
+            WHERE tomb.col_name IS NULL
+                OR main.col_name IS NULL
+                OR (main.col_name = tomb.col_name AND (main.col_type <> tomb.col_type))
+        LOOP
+            IF cols.tomb_col_name IS NULL THEN
+                -- Shadow table is missing a column, meaning it got added
+                shadow_column_definitions :=
+                    shadow_column_definitions
+                    || format(E'    ADD COLUMN %I electric.tag,\n', cols.main_col_name);
+
+                reordered_column_definitions :=
+                    reordered_column_definitions
+                    || format(E'    ADD COLUMN %I %s,\n', '__reordered_' || cols.main_col_name, cols.main_col_type);
+
+                -- Tombstone as well
+                tombstone_column_definitions :=
+                    tombstone_column_definitions
+                    || format(E'    ADD COLUMN %I %s,\n', cols.main_col_name, cols.main_col_type);
+            ELSEIF cols.main_col_name IS NULL THEN
+                -- Main table is missing a column, meaning it got removed
+                RAISE EXCEPTION 'Column removal is not an additive migration';
+            ELSE
+                -- Column exists in both tables, meaning the type got altered
+                RAISE EXCEPTION 'Column type change is not an additive migration';
+            END IF;
+        END LOOP;
+
+        -- true if loop executed at least once
+        IF FOUND THEN
+            shadow_column_definitions := left(shadow_column_definitions, -2);
+            tombstone_column_definitions := left(tombstone_column_definitions, -2);
+
+            EXECUTE format(
+                E'ALTER TABLE electric.%I\n%s',
+                shadow_table_name,
+                reordered_column_definitions || shadow_column_definitions
+            );
+
+            EXECUTE format(
+                E'ALTER TABLE electric.%I\n%s',
+                tombstone_table_name,
+                tombstone_column_definitions
+            );
+
+            SELECT array_agg(col_name) INTO non_pk_column_list
+                FROM electric.lookup_columns(target_oid) WHERE NOT col_primary;
+
+            /*
+            We regenerate column-dependent functions, but not the triggers themselves since one of the triggers is `CREATE CONSTRAINT TRIGGER` which cannot be `CREATE OR REPLACE`-ed.
+            This is a little less flexible (if trigger logic gets altered, `install_functions_and_triggers` will need to be reran explicitly) but safer since `DROP` + `CREATE`
+            can have some unexpected effects.
+            */
+            PERFORM electric.install_conflict_resolution_functions(schema_name, table_name, primary_key_list, non_pk_column_list);
+        END IF;
+    END IF;
+END;
+$function$;

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/trigger_function_installers.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/trigger_function_installers.sql
@@ -1,0 +1,729 @@
+/*
+ * COMMON TRIGGER FUNCTIONS
+ */
+CREATE OR REPLACE FUNCTION electric.install_function__generate_tombstone_entry(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS TEXT
+    LANGUAGE PLPGSQL AS $outer_function$
+DECLARE
+    function_name TEXT := 'generate_tombstone_entry___' || schema_name || '__' || table_name;
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name TEXT := 'tombstone__' || schema_name || '__' || table_name;
+    primary_key_where_clause TEXT;
+    insertion_identifiers TEXT;
+    values_from_old TEXT;
+    on_conflict_assignment_block TEXT;
+BEGIN
+    -- pk1 = OLD.pk1 AND pk2 = OLD.pk2 ...
+    primary_key_where_clause := electric.format_every_and_join(primary_key_list, '%1$I = OLD.%1$I', ' AND ');
+
+    -- pk1, pk2, col1, col2 ...
+    insertion_identifiers := electric.format_every_and_join(primary_key_list || non_pk_column_list, '%I');
+
+    -- pk1, pk2, col1, col2 ...
+    values_from_old := electric.format_every_and_join(primary_key_list || non_pk_column_list, 'OLD.%I');
+
+    -- col1 = OLD.col1, col2 = OLD.col2 ...
+    on_conflict_assignment_block := electric.format_every_and_join(non_pk_column_list, '        %1$I = OLD.%1$I');
+
+    IF array_length(non_pk_column_list, 1) > 0 THEN
+        on_conflict_assignment_block := E'DO UPDATE SET\n' || on_conflict_assignment_block;
+    ELSE
+        on_conflict_assignment_block := 'DO NOTHING'; -- Not much to really do for pk-only tables
+    END IF;
+
+    -- The `%n$I` placeholders use n-th argument for formatting.
+    -- Generally, 1 is a function name, 2 is a shadow table name, 3 is a tombstone table name
+    EXECUTE format($injected$
+        CREATE OR REPLACE FUNCTION electric.%1$I()
+        RETURNS TRIGGER
+        LANGUAGE PLPGSQL AS
+        $function$
+        DECLARE
+            shadow_row electric.%2$I%%ROWTYPE;
+        BEGIN
+            RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
+            SELECT * INTO shadow_row FROM electric.%2$I WHERE %4$s;
+
+            -- USES COLUMN LIST
+            INSERT INTO electric.%3$I (%5$s)
+                VALUES (%6$s)
+                ON CONFLICT (%7$s) %8$s;
+
+            RETURN NULL;
+        END;
+        $function$;$injected$,
+    function_name,
+    shadow_table_name,
+    tombstone_table_name,
+    primary_key_where_clause,
+    insertion_identifiers,
+    values_from_old,
+    electric.format_every_and_join(primary_key_list, '%I'),
+    on_conflict_assignment_block);
+
+    RETURN function_name;
+END;
+$outer_function$;
+
+/*
+ * POSTGRES TRIGGER FUNCTIONS
+ */
+CREATE OR REPLACE FUNCTION electric.install_function__create_shadow_row_from_upsert(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS TEXT
+    LANGUAGE PLPGSQL AS $outer_function$
+DECLARE
+    function_name TEXT := 'create_shadow_row_from_upsert___' || schema_name || '__' || table_name;
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name TEXT := 'tombstone__' || schema_name || '__' || table_name;
+    insertion_identifiers TEXT;
+    insert_values TEXT;
+    modified_columns_pattern TEXT;
+    modified_columns_bitmask_merger TEXT := '';
+BEGIN
+    insertion_identifiers := electric.format_every_and_join(primary_key_list || non_pk_column_list, '%I');
+    insert_values := electric.append_string_unless_empty(
+        electric.format_every_and_join(primary_key_list, 'NEW.%I'),
+        electric.format_every_and_join(non_pk_column_list, '__current_tag')
+    );
+
+    modified_columns_pattern := format('_modified_columns_bit_mask[%%2$s] = (NEW.%%1$I IS DISTINCT FROM OLD.%%1$I) OR COALESCE(%I._modified_columns_bit_mask[%%2$s], false)', shadow_table_name);
+    modified_columns_bitmask_merger := electric.format_every_and_join(non_pk_column_list, modified_columns_pattern, E',\n');
+
+    IF modified_columns_bitmask_merger != '' THEN
+        modified_columns_bitmask_merger := E',\n-- REPEATED BLOCK PER COLUMN\n' || modified_columns_bitmask_merger;
+    END IF;
+
+    -- The `%n$I` placeholders use n-th argument for formatting.
+    -- Generally, 1 is a function name, 2 is a shadow table name, 3 is a tombstone table name
+    EXECUTE format($injected$
+        CREATE OR REPLACE FUNCTION electric.%1$I()
+        RETURNS TRIGGER
+        LANGUAGE PLPGSQL AS
+        $function$
+        DECLARE
+            __current_tag electric.tag;
+            -- __current_tag_text text;
+            modified_mask boolean[];
+        BEGIN
+            RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
+            RAISE DEBUG '  Given OLD %%', to_json(OLD);
+            RAISE DEBUG '  Given NEW %%', to_json(NEW);
+            __current_tag := (CURRENT_TIMESTAMP, NULL);
+
+            -- USES COLUMN LIST
+            INSERT INTO electric.%2$I (_last_modified, _tag, _tags, _resolved,
+                                                    %4$s)
+                VALUES (pg_current_xact_id()::text::bigint, __current_tag, ARRAY[__current_tag], false,
+                        %5$s)
+                ON CONFLICT (%6$s) DO UPDATE
+                    SET _last_modified = pg_current_xact_id()::text::bigint,
+                        _tag = __current_tag,
+                        _is_a_delete_operation = false,
+                        _resolved = false%7$s
+                    -- We're only taking the timestamp here, since we want to override any Satellite writes,
+                    -- and we order `NULL` source as larger than any other, so we're keeping that
+                    RETURNING (GREATEST(__current_tag, %8$s)).timestamp INTO __current_tag.timestamp;
+
+            RAISE DEBUG '  Storing max tag %%', __current_tag;
+            PERFORM set_config('electric.current_transaction_max_tag', __current_tag::text, true);
+
+            RETURN NEW;
+        END;
+        $function$;$injected$,
+    function_name,
+    shadow_table_name,
+    tombstone_table_name,
+    insertion_identifiers,
+    insert_values,
+    electric.format_every_and_join(primary_key_list, '%I'),
+    modified_columns_bitmask_merger,
+    electric.append_string_unless_empty('_tag', electric.format_every_and_join(non_pk_column_list, '%I')));
+
+    RETURN function_name;
+END;
+$outer_function$;
+
+
+CREATE OR REPLACE FUNCTION electric.install_function__update_shadow_row_from_delete(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS TEXT
+    LANGUAGE PLPGSQL AS $outer_function$
+DECLARE
+    function_name TEXT := 'update_shadow_row_from_delete___' || schema_name || '__' || table_name;
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name TEXT := 'tombstone__' || schema_name || '__' || table_name;
+    primary_key_where_clause TEXT;
+BEGIN
+    primary_key_where_clause := electric.format_every_and_join(primary_key_list, '%1$I = OLD.%1$I', ' AND ');
+    -- The `%n$I` placeholders use n-th argument for formatting.
+    -- Generally, 1 is a function name, 2 is a shadow table name, 3 is a tombstone table name
+    EXECUTE format($injected$
+        CREATE OR REPLACE FUNCTION electric.%1$I()
+            RETURNS TRIGGER
+            LANGUAGE PLPGSQL AS
+        $function$
+        DECLARE
+            __current_tag electric.tag;
+        BEGIN
+            RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
+            RAISE DEBUG '  Given OLD %%', to_json(OLD);
+            __current_tag := (CURRENT_TIMESTAMP, NULL);
+
+            -- USES COLUMN LIST
+            UPDATE electric.%2$I
+                SET _last_modified = pg_current_xact_id()::text::bigint,
+                    _tag = __current_tag,
+                    _is_a_delete_operation = true,
+                    _resolved = false
+                WHERE %4$s
+                RETURNING GREATEST(__current_tag, %5$s) INTO __current_tag;
+
+            PERFORM set_config('electric.current_transaction_max_tag', __current_tag::text, true);
+
+            RETURN OLD;
+        END;
+        $function$;$injected$,
+    function_name,
+    shadow_table_name,
+    tombstone_table_name,
+    primary_key_where_clause,
+    electric.append_string_unless_empty('_tag', electric.format_every_and_join(non_pk_column_list, '%I'))
+    );
+
+    RETURN function_name;
+END;
+$outer_function$;
+
+
+CREATE OR REPLACE FUNCTION electric.install_function__write_correct_max_tag(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS TEXT
+    LANGUAGE PLPGSQL AS $outer_function$
+DECLARE
+    function_name TEXT := 'write_correct_max_tag___' || schema_name || '__' || table_name;
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name TEXT := 'tombstone__' || schema_name || '__' || table_name;
+    columns_to_write_blocks TEXT;
+    where_pk_substitution TEXT;
+    next_substitution_position_after_pk INTEGER;
+    using_new_pk TEXT;
+    where_pk_clause TEXT;
+BEGIN
+    next_substitution_position_after_pk := array_length(primary_key_list, 1) + 1;
+    columns_to_write_blocks := electric.format_every_and_join(
+        non_pk_column_list,
+        format($$
+                IF NEW._modified_columns_bit_mask[%%2$s] THEN
+                columns_to_write := array_append(columns_to_write, '%%1$I = $%s');
+                END IF;$$, next_substitution_position_after_pk),
+        '');
+
+    where_pk_substitution := electric.format_every_and_join(primary_key_list, '%I = $%s', ' AND ');
+    using_new_pk := electric.format_every_and_join(primary_key_list, 'NEW.%I');
+    where_pk_clause := electric.format_every_and_join(primary_key_list, '%1$I = NEW.%1$I', ' AND ');
+
+    -- The `%n$I` placeholders use n-th argument for formatting.
+    -- Generally, 1 is a function name, 2 is a shadow table name, 3 is a tombstone table name
+    EXECUTE format($injected$
+        CREATE OR REPLACE FUNCTION electric.%1$I()
+            RETURNS TRIGGER
+            LANGUAGE PLPGSQL AS
+        $function$
+        DECLARE
+            -- This will throw an error if this setting is missing -- that would be an unexpected situation, so an error is appropriate
+            max_tag electric.tag;
+            columns_to_write text[] := array[]::text[];
+        BEGIN
+            RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
+            max_tag := current_setting('electric.current_transaction_max_tag')::electric.tag;
+            RAISE DEBUG '  In particular, with bitmask %% and max tag %%', NEW._modified_columns_bit_mask, max_tag;
+
+            IF NEW._is_a_delete_operation THEN
+                RAISE DEBUG '  Handling as DELETE operation';
+                UPDATE electric.%2$I
+                    SET _tag = max_tag, _tags = array[]::electric.tag[], _resolved = true
+                    WHERE %8$s;
+            ELSE
+                RAISE DEBUG '  Handling as UPSERT operation';
+                -- REPEATED BLOCK PER COLUMN
+                %4$s
+
+                EXECUTE format(
+                    E'UPDATE electric.%2$I\n'
+                    '   SET _tag = $%5$s, _tags = ARRAY[$%5$s], _resolved = true, _modified_columns_bit_mask = array[]::boolean[], %%s\n'
+                    '   WHERE %6$s', array_to_string(columns_to_write, ', '))
+                    USING %7$s, max_tag;
+            END IF;
+
+            RETURN NULL;
+        END;
+        $function$;$injected$,
+    function_name,
+    shadow_table_name,
+    tombstone_table_name,
+    columns_to_write_blocks,
+    next_substitution_position_after_pk,
+    where_pk_substitution,
+    using_new_pk,
+    where_pk_clause);
+
+    RETURN function_name;
+END;
+$outer_function$;
+
+
+/*
+ * SATELLITE TRIGGER FUNCTIONS
+ */
+CREATE OR REPLACE FUNCTION electric.install_function__reorder_main_op(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS TEXT
+    LANGUAGE PLPGSQL AS $outer_function$
+DECLARE
+    function_name TEXT := 'reorder_main_op___' || schema_name || '__' || table_name;
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name TEXT := 'tombstone__' || schema_name || '__' || table_name;
+    reordered_column_list TEXT[];
+    reordered_column_insert TEXT;
+    insert_values TEXT;
+    reordered_column_update TEXT := '';
+BEGIN
+    reordered_column_list := electric.format_every(non_pk_column_list, '__reordered_%s');
+    reordered_column_insert := electric.format_every_and_join(reordered_column_list, '%I');
+    insert_values := electric.format_every_and_join(primary_key_list || non_pk_column_list, 'NEW.%I');
+
+    -- __reordered_col1 = NEW.col1, ...
+    reordered_column_update := electric.zip_format_every_and_join(reordered_column_list, non_pk_column_list, '%I = NEW.%I');
+
+    -- The `%n$I` placeholders use n-th argument for formatting.
+    -- Generally, 1 is a function name, 2 is a shadow table name, 3 is a tombstone table name
+    EXECUTE format($injected$
+        CREATE OR REPLACE FUNCTION electric.%1$I()
+            RETURNS TRIGGER
+            LANGUAGE PLPGSQL AS
+        $function$
+        DECLARE
+            _shadow_row_tmp electric.%2$I%%ROWTYPE;
+        BEGIN
+            RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
+
+            -- We have received an INSERT (or an UPDATE, in development) that comes before the
+            -- shadow table change (this is to reorder locking within the transaction). We need
+            -- to save those values without performing an UPSERT to the main table yet
+
+            -- USES COLUMN LIST
+            INSERT INTO electric.%2$I (_currently_reordering, %5$s)
+                VALUES (true, %6$s)
+                ON CONFLICT (%4$s) DO UPDATE SET
+                    %7$s
+                RETURNING * INTO _shadow_row_tmp;
+
+            RAISE DEBUG '  Resulting in a shadow row state %%', to_json(_shadow_row_tmp);
+            
+            RETURN NULL;
+        END;
+        $function$;$injected$,
+    function_name,
+    shadow_table_name,
+    tombstone_table_name,
+    electric.format_every_and_join(primary_key_list, '%I'),
+    electric.format_every_and_join(primary_key_list || reordered_column_list, '%I'),
+    insert_values,
+    electric.append_string_unless_empty('_currently_reordering = true', reordered_column_update));
+
+    RETURN function_name;
+END;
+$outer_function$;
+
+
+CREATE OR REPLACE FUNCTION electric.install_function__shadow_insert_to_upsert(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS TEXT
+    LANGUAGE PLPGSQL AS $outer_function$
+DECLARE
+    function_name TEXT := 'shadow_insert_to_upsert___' || schema_name || '__' || table_name;
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name TEXT := 'tombstone__' || schema_name || '__' || table_name;
+BEGIN
+    -- The `%n$I` placeholders use n-th argument for formatting.
+    -- Generally, 1 is a function name, 2 is a shadow table name, 3 is a tombstone table name
+    EXECUTE format($injected$
+        CREATE OR REPLACE FUNCTION electric.%1$I()
+            RETURNS TRIGGER
+            LANGUAGE PLPGSQL AS
+        $function$
+        BEGIN
+            RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
+            RAISE DEBUG '  Insert for shadow row %%', to_json(NEW);
+
+            -- USES COLUMN LIST
+            INSERT INTO electric.%2$I (_last_modified, _tag, _tags, %4$s)
+                VALUES (pg_current_xact_id()::text::bigint, NEW._tag, ARRAY[NEW._tag], %5$s)
+                ON CONFLICT (%6$s) DO UPDATE
+                    SET _currently_reordering = NULL,
+                        _last_modified = pg_current_xact_id()::text::bigint,
+                        _tag = NEW._tag,
+                        _is_a_delete_operation = NEW._is_a_delete_operation,
+                        _observed_tags = NEW._observed_tags,
+                        _modified_columns_bit_mask = NEW._modified_columns_bit_mask;
+
+            RETURN NULL;
+        END;
+        $function$;$injected$,
+    function_name,
+    shadow_table_name,
+    tombstone_table_name,
+    electric.format_every_and_join(primary_key_list || non_pk_column_list, '%I'),
+    electric.append_string_unless_empty(
+        electric.format_every_and_join(primary_key_list, 'NEW.%I'),
+        electric.format_every_and_join(non_pk_column_list, 'NEW._tag')
+    ),
+    electric.format_every_and_join(primary_key_list, '%I'));
+
+    RETURN function_name;
+END;
+$outer_function$;
+
+
+CREATE OR REPLACE FUNCTION electric.install_function__resolve_observed_tags(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS TEXT
+    LANGUAGE PLPGSQL AS $outer_function$
+DECLARE
+    function_name TEXT := 'resolve_observed_tags___' || schema_name || '__' || table_name;
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name TEXT := 'tombstone__' || schema_name || '__' || table_name;
+    reordered_insert_function_name TEXT := 'perform_reordered_op___' || schema_name || '__' || table_name;
+    reordered_column_list TEXT[];
+    tag_resolution_blocks TEXT;
+    reordered_column_save TEXT;
+    reordered_column_reset TEXT;
+BEGIN
+    reordered_column_list := electric.format_every(non_pk_column_list, '__reordered_%s');
+    tag_resolution_blocks := electric.format_every_and_join(
+        non_pk_column_list,
+        $$
+            IF NEW._is_a_delete_operation OR NEW._tag < OLD.%1$I OR NOT NEW._modified_columns_bit_mask[%2$s] THEN
+                NEW.%1$I = OLD.%1$I;
+            ELSE
+                NEW.%1$I = NEW._tag;
+            END IF;
+        $$, E'\n');
+
+    reordered_column_save := electric.format_every_and_join(reordered_column_list, E'\n            NEW.%1$I = OLD.%1$I;', '');
+
+    reordered_column_reset := electric.format_every_and_join(reordered_column_list, E'\n            NEW.%1$I = null;', '');
+
+    -- The `%n$I` placeholders use n-th argument for formatting.
+    -- Generally, 1 is a function name, 2 is a shadow table name, 3 is a tombstone table name
+    EXECUTE format($injected$
+        CREATE OR REPLACE FUNCTION electric.%1$I()
+            RETURNS TRIGGER
+            LANGUAGE PLPGSQL AS
+        $function$
+        BEGIN
+            RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
+            RAISE DEBUG '  Handling for shadow row %%', to_json(NEW);
+
+            -- Remove observed tags from the tag set
+            SELECT INTO NEW._tags ARRAY(SELECT unnest(OLD._tags) except SELECT unnest(NEW._observed_tags));    
+            NEW._observed_tags = NULL;
+
+            -- Append tags for UPSERT operations
+            IF NEW._is_a_delete_operation IS DISTINCT FROM TRUE THEN
+                NEW._tags = array_append(NEW._tags, NEW._tag);
+            END IF;
+
+            -- If operation is a DELETE, or the column on the OLD row is newer than the current insert, or if UPDATE didn't mark the column as modified
+            --   Then we use `OLD.%%column%%`, since those updates are coming from Electric and `NEW` row values may be incorrect if they weren't modified
+            -- Else, we use the value from the UPDATE
+
+            -- REPEATED BLOCK PER COLUMN
+            %4$s
+
+            -- REPEATED BLOCK PER COLUMN    
+            %5$s
+
+            PERFORM electric.%7$I(NEW);
+
+            -- REPEATED BLOCK PER COLUMN
+            NEW._currently_reordering = null;
+            %6$s
+
+            RETURN NEW;
+        END;
+        $function$;$injected$,
+    function_name,
+    shadow_table_name,
+    tombstone_table_name,
+    tag_resolution_blocks,
+    reordered_column_save,
+    reordered_column_reset,
+    reordered_insert_function_name);
+
+    RETURN function_name;
+END;
+$outer_function$;
+
+
+CREATE OR REPLACE FUNCTION electric.install_function__perform_reordered_op(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS TEXT
+    LANGUAGE PLPGSQL AS $outer_function$
+DECLARE
+    function_name TEXT := 'perform_reordered_op___' || schema_name || '__' || table_name;
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    tombstone_table_name TEXT := 'tombstone__' || schema_name || '__' || table_name;
+    reordered_column_list TEXT[];
+    where_pks_equal_shadow TEXT;
+    built_row_fill_pks TEXT;
+    built_row_fill_from_reordered TEXT;
+    all_pks_present_formatter TEXT;
+    case_columns_formatter TEXT;
+    case_pks TEXT;
+    case_columns TEXT;
+    on_primary_keys TEXT;
+    where_pk_main_or_tomb_clause TEXT;
+    current_row_fill_from_reordered TEXT;
+    built_row_overrides TEXT;
+    update_clause TEXT;
+BEGIN
+    reordered_column_list := electric.format_every(non_pk_column_list, '__reordered_%s');
+
+    where_pks_equal_shadow := electric.format_every_and_join(primary_key_list, '%1$I = shadow_row.%1$I', ' AND ');
+
+    built_row_fill_pks := electric.format_every_and_join(primary_key_list, E'\n            built_row.%1$I := shadow_row.%1$I;', '');
+    built_row_fill_from_reordered := electric.zip_format_every_and_join(non_pk_column_list, reordered_column_list, E'\n            built_row.%1$I := shadow_row.%2$I;', '');
+
+    case_pks := electric.format_every_and_join(primary_key_list,
+        $$
+                CASE
+                    WHEN main.%1$I IS NOT NULL THEN main.%1$I
+                    ELSE NULL
+                END as %1$I$$, ',');
+
+    all_pks_present_formatter := electric.format_every_and_join(primary_key_list, '%%1$I.%1$I IS NOT NULL', ' AND ');
+    case_columns_formatter := format(
+        $$
+                CASE
+                    WHEN %s THEN main.%%1$s
+                    WHEN %s THEN tomb.%%1$s
+                END as %%1$s$$, format(all_pks_present_formatter, 'main'), format(all_pks_present_formatter, 'tomb'));
+    case_columns := electric.format_every_and_join(non_pk_column_list, case_columns_formatter, ',');
+
+    on_primary_keys := electric.format_every_and_join(primary_key_list, 'main.%1$I = tomb.%1$I', ' AND ');
+    where_pk_main_or_tomb_clause :=
+        '(' || electric.format_every_and_join(primary_key_list, 'main.%1$I = shadow_row.%1$I', ' AND ')
+            || ') OR ('
+            || electric.format_every_and_join(primary_key_list, 'tomb.%1$I = shadow_row.%1$I', ' AND ') || ')';
+
+    current_row_fill_from_reordered := electric.zip_format_every_and_join(non_pk_column_list, reordered_column_list, E'\n                current_row.%1$I = shadow_row.%2$I;', '');
+
+    built_row_overrides := electric.format_every_and_join(non_pk_column_list,
+        $$
+            IF shadow_row.%1$I != shadow_row._tag THEN
+                built_row.%1$I = current_row.%1$I;
+            END IF;
+        $$, '');
+    
+    IF array_length(non_pk_column_list, 1) > 0 THEN
+        update_clause := format($$
+                UPDATE %1$s SET
+                    -- REPEATED BLOCK PER COLUMN
+                    %3$s
+                WHERE %2$s;
+            $$,
+            format('%I.%I', schema_name, table_name),
+            where_pks_equal_shadow,
+            electric.format_every_and_join(non_pk_column_list, '%1$I = built_row.%1$I'));
+    ELSE
+        update_clause := 'NULL;'; -- No-op, since there are no non-pk columns
+    END IF;
+
+    -- The `%n$I` placeholders use n-th argument for formatting.
+    -- Generally, 1 is a function name, 2 is a shadow table name, 3 is a tombstone table name
+    EXECUTE format($injected$
+        CREATE OR REPLACE FUNCTION electric.%1$I(shadow_row electric.%2$I)
+            RETURNS VOID
+            LANGUAGE PLPGSQL AS
+        $function$
+        DECLARE
+            built_row %4$s%%ROWTYPE;
+            current_row %4$s%%ROWTYPE;
+            tombstone_row electric.%3$I%%ROWTYPE;
+            old_row_found boolean;
+        BEGIN
+            RAISE DEBUG '  Preparing a real operation based on shadow row %%', to_json(shadow_row);
+
+            -- Tags are empty: process as a DELETE
+            IF COALESCE(array_length(shadow_row._tags, 1), 0) = 0 THEN  
+                DELETE FROM %4$s WHERE %5$s;
+                RAISE DEBUG '    Handled as DELETE';    
+                RETURN;
+            END IF;
+
+            -- Tags are not empty, process as UPSERT
+            --   We accept ALL operations from Electric as INSERTs to correctly process them,
+            --   and we need to convert the insert to UPSERT (with possible conflict resolution against an already-deleted row)
+
+            -- Reconstruct row-to-be-inserted from the reordered values
+            %6$s
+            %7$s
+
+            RAISE DEBUG '  Starting from %%', to_json(built_row);
+
+            -- We do a join here to avoid a race between main table & tombstone, just in case
+            SELECT
+                -- REPEATED BLOCK PER COLUMN
+                %8$s
+                INTO current_row
+                FROM %4$s AS main
+                FULL OUTER JOIN electric.%3$I AS tomb
+                    ON %9$s
+                WHERE %10$s;
+            IF NOT FOUND THEN
+                -- REPEATED BLOCK PER COLUMN
+                %11$s
+            END IF;
+
+            old_row_found := FOUND AND %12$s;
+
+            -- If tag of the column differs from the tag of the entire operation, prefer saved one
+            -- otherwise, prefer what has been sent in the reordered operation
+            -- REPEATED BLOCK PER COLUMN
+            %13$s
+
+            RAISE DEBUG '    After resolution %%', to_json(built_row);
+
+            IF NOT old_row_found THEN
+                -- Handle as INSERT
+                -- USES COLUMN LIST
+                INSERT INTO %4$s
+                        (%14$s)
+                    VALUES
+                        (%15$s);
+                RAISE DEBUG '    Handled as INSERT';
+            ELSE
+                -- Handle as UPDATE
+                %16$s
+                RAISE DEBUG '    Handled as UPDATE';
+            END IF;
+        END;
+        $function$;$injected$,
+    function_name, -- 1
+    shadow_table_name, -- 2
+    tombstone_table_name, -- 3
+    format('%I.%I', schema_name, table_name), -- 4
+    where_pks_equal_shadow, -- 5
+    built_row_fill_pks, -- 6
+    built_row_fill_from_reordered, -- 7
+    electric.append_string_unless_empty(case_pks, case_columns), -- 8
+    on_primary_keys, -- 9
+    where_pk_main_or_tomb_clause, -- 10
+    current_row_fill_from_reordered, -- 11
+    format(all_pks_present_formatter, 'current_row'), -- 12
+    built_row_overrides, -- 13
+    electric.format_every_and_join(primary_key_list || non_pk_column_list, '%I'), -- 14
+    electric.format_every_and_join(primary_key_list || non_pk_column_list, 'built_row.%I'), -- 15
+    update_clause -- 16
+    );
+
+    RETURN function_name;
+END;
+$outer_function$;
+
+CREATE OR REPLACE FUNCTION electric.install_conflict_resolution_functions(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS JSONB
+    LANGUAGE PLPGSQL AS $function$
+DECLARE
+    function_names JSONB := '{}'::jsonb;
+BEGIN
+    function_names := jsonb_set(function_names, '{perform_reordered_op}', to_jsonb(electric.install_function__perform_reordered_op(schema_name, table_name, primary_key_list, non_pk_column_list)));
+    function_names := jsonb_set(function_names, '{generate_tombstone_entry}', to_jsonb(electric.install_function__generate_tombstone_entry(schema_name, table_name, primary_key_list, non_pk_column_list)));
+    function_names := jsonb_set(function_names, '{create_shadow_row_from_upsert}', to_jsonb(electric.install_function__create_shadow_row_from_upsert(schema_name, table_name, primary_key_list, non_pk_column_list)));
+    function_names := jsonb_set(function_names, '{update_shadow_row_from_delete}', to_jsonb(electric.install_function__update_shadow_row_from_delete(schema_name, table_name, primary_key_list, non_pk_column_list)));
+    function_names := jsonb_set(function_names, '{write_correct_max_tag}', to_jsonb(electric.install_function__write_correct_max_tag(schema_name, table_name, primary_key_list, non_pk_column_list)));
+    function_names := jsonb_set(function_names, '{reorder_main_op}', to_jsonb(electric.install_function__reorder_main_op(schema_name, table_name, primary_key_list, non_pk_column_list)));
+    function_names := jsonb_set(function_names, '{shadow_insert_to_upsert}', to_jsonb(electric.install_function__shadow_insert_to_upsert(schema_name, table_name, primary_key_list, non_pk_column_list)));
+    function_names := jsonb_set(function_names, '{resolve_observed_tags}', to_jsonb(electric.install_function__resolve_observed_tags(schema_name, table_name, primary_key_list, non_pk_column_list)));
+
+    RETURN function_names;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION electric.install_functions_and_triggers(schema_name TEXT, table_name TEXT, primary_key_list TEXT[], non_pk_column_list TEXT[])
+    RETURNS VOID
+    LANGUAGE PLPGSQL
+    AS $function$
+DECLARE
+    shadow_table_name TEXT := 'shadow__' || schema_name || '__' || table_name;
+    full_table_identifier TEXT := format('%I.%I', schema_name, table_name);
+    generated_functions JSONB;
+BEGIN
+    -- Install function to be used in the triggers
+    generated_functions := electric.install_conflict_resolution_functions(schema_name, table_name, primary_key_list, non_pk_column_list); 
+
+    -- Install actual triggers
+    EXECUTE format($$
+        CREATE OR REPLACE TRIGGER as_first__save_deleted_rows_to_tombstone_table
+        AFTER DELETE ON %s
+        FOR EACH ROW
+        EXECUTE PROCEDURE electric.%I()
+    $$, full_table_identifier, generated_functions->>'generate_tombstone_entry');
+    EXECUTE format($$ ALTER TABLE %s ENABLE ALWAYS TRIGGER as_first__save_deleted_rows_to_tombstone_table $$, full_table_identifier);
+
+    EXECUTE format($$
+        CREATE OR REPLACE TRIGGER postgres_write__upsert_generate_shadow_rows
+        BEFORE INSERT OR UPDATE ON %s
+        FOR EACH ROW
+        EXECUTE PROCEDURE electric.%I();
+    $$, full_table_identifier, generated_functions->>'create_shadow_row_from_upsert');
+
+    EXECUTE format($$ ALTER TABLE %s ENABLE TRIGGER postgres_write__upsert_generate_shadow_rows $$, full_table_identifier);
+
+    EXECUTE format($$
+        CREATE OR REPLACE TRIGGER postgres_write__delete_generate_shadow_rows
+        BEFORE DELETE ON %s
+        FOR EACH ROW
+        EXECUTE PROCEDURE electric.%I();
+    $$, full_table_identifier, generated_functions->>'update_shadow_row_from_delete');
+
+    EXECUTE format($$ ALTER TABLE %s ENABLE TRIGGER postgres_write__delete_generate_shadow_rows $$, full_table_identifier);
+
+    EXECUTE format($$ DROP TRIGGER IF EXISTS postgres_write__write_resolved_tags ON electric.%I $$, shadow_table_name);
+    EXECUTE format($$
+        CREATE CONSTRAINT TRIGGER postgres_write__write_resolved_tags
+        AFTER UPDATE ON electric.%I
+        DEFERRABLE INITIALLY DEFERRED
+        FOR EACH ROW
+        WHEN (NOT NEW._resolved)
+        EXECUTE PROCEDURE electric.%I();
+    $$, shadow_table_name, generated_functions->>'write_correct_max_tag');
+
+    EXECUTE format($$ ALTER TABLE electric.%I ENABLE TRIGGER postgres_write__write_resolved_tags $$, shadow_table_name);
+
+    EXECUTE format($$
+        CREATE OR REPLACE TRIGGER satellite_write__upsert_rows
+        BEFORE INSERT ON electric.%I
+        FOR EACH ROW
+        WHEN (pg_trigger_depth() < 1 AND NEW._currently_reordering IS NULL)
+        EXECUTE PROCEDURE electric.%I();
+    $$, shadow_table_name, generated_functions->>'shadow_insert_to_upsert');
+
+    EXECUTE format($$ ALTER TABLE electric.%I ENABLE REPLICA TRIGGER satellite_write__upsert_rows $$, shadow_table_name);
+
+    EXECUTE format($$
+        CREATE OR REPLACE TRIGGER satellite_write__resolve_observed_tags
+        BEFORE UPDATE ON electric.%I
+        FOR EACH ROW
+        WHEN (NEW._currently_reordering IS NULL)
+        EXECUTE PROCEDURE electric.%I();
+    $$, shadow_table_name, generated_functions->>'resolve_observed_tags');
+
+    EXECUTE format($$ ALTER TABLE electric.%I ENABLE REPLICA TRIGGER satellite_write__resolve_observed_tags $$, shadow_table_name);
+
+    EXECUTE format($$
+        CREATE OR REPLACE TRIGGER satellite_write__save_operation_for_reordering
+        BEFORE INSERT OR UPDATE ON %s
+        FOR EACH ROW
+        WHEN (pg_trigger_depth() < 1) 
+        EXECUTE PROCEDURE electric.%I();
+    $$, full_table_identifier, generated_functions->>'reorder_main_op');
+
+    EXECUTE format($$ ALTER TABLE %s ENABLE REPLICA TRIGGER satellite_write__save_operation_for_reordering $$, full_table_identifier);
+END
+$function$;

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/utility_functions.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/utility_functions.sql
@@ -1,0 +1,40 @@
+-- Utility function
+CREATE OR REPLACE FUNCTION electric.format_every(arr TEXT[], format_pattern TEXT)
+    RETURNS TEXT[]
+    STABLE PARALLEL SAFE
+    RETURNS NULL ON NULL INPUT
+    LANGUAGE SQL AS $$
+    SELECT array_agg(format(format_pattern, val)) FROM unnest(arr) AS val;
+    $$;
+
+-- Utility function
+CREATE OR REPLACE FUNCTION electric.format_every_and_join(arr TEXT[], format_pattern TEXT, joiner TEXT DEFAULT ', ')
+    RETURNS TEXT
+    STABLE PARALLEL SAFE
+    RETURNS NULL ON NULL INPUT
+    LANGUAGE SQL AS $$
+    SELECT array_to_string(array_agg(format(format_pattern, val, ordinality)), joiner) FROM unnest(arr) WITH ORDINALITY AS val;
+    $$;
+
+-- Utility function
+CREATE OR REPLACE FUNCTION electric.zip_format_every_and_join(arr1 TEXT[], arr2 TEXT[], format_pattern TEXT, joiner TEXT DEFAULT ', ')
+    RETURNS TEXT
+    STABLE PARALLEL SAFE
+    RETURNS NULL ON NULL INPUT
+    LANGUAGE SQL AS $$
+    SELECT array_to_string(array_agg(format(format_pattern, x, y, ordinality)), joiner) FROM unnest(arr1, arr2) WITH ORDINALITY AS val(x, y, ordinality);
+    $$;
+
+CREATE OR REPLACE FUNCTION electric.append_string_unless_empty(str1 TEXT, str2 TEXT, joiner TEXT DEFAULT ', ')
+    RETURNS TEXT
+    STABLE PARALLEL SAFE
+    CALLED ON NULL INPUT
+    LANGUAGE PLPGSQL AS $$
+    BEGIN
+        IF str2 IS NOT NULL AND str2 != '' THEN
+            RETURN str1 || joiner || str2;
+        ELSE
+            RETURN str1;
+        END IF;
+    END
+    $$;

--- a/components/electric/lib/electric/postgres/extension/migrations/20230605141256_electrify_function/electrify.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230605141256_electrify_function/electrify.sql
@@ -184,7 +184,7 @@ DECLARE
     _capture bool := false;
     _table_id int8;
 BEGIN
-    -- Usually, this would be a great place for `pg_trigger_depth()`, but for event triggers that's always
+    -- Usually, this would be a great place for `pg_trigger_depth()`, but for event triggers that's always 0.
     IF (current_setting('electric.is_in_event_trigger', true) = 'true') THEN RETURN; END IF;
     RAISE DEBUG 'command_end_handler:: start';
 

--- a/components/electric/lib/electric/postgres/extension/migrations/20230605141256_electrify_function/electrify.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230605141256_electrify_function/electrify.sql
@@ -119,21 +119,10 @@ BEGIN
 
     EXECUTE format('ALTER TABLE %I.%I REPLICA IDENTITY FULL;', _schema, _table);
 
-    IF NOT EXISTS (
-        SELECT pr.oid FROM pg_publication_rel pr
-        INNER JOIN pg_publication pp ON pr.prpubid = pp.oid
-        WHERE pp.pubname = '<%= publication_name %>'
-        AND pr.prrelid = _oid
-        ) THEN
-        EXECUTE format('<%= publication_sql %>;', _schema, _table);
-    ELSE
-        RAISE WARNING 'table %.% is already electrified', _schema, _table;
-    END IF;
-
     INSERT INTO <%= electrified_tracking_table %> (schema_name, table_name, oid)
-        VALUES (_schema, _table, _oid) 
-        ON CONFLICT ON CONSTRAINT unique_table_name
-        DO NOTHING;
+    VALUES (_schema, _table, _oid) 
+    ON CONFLICT ON CONSTRAINT unique_table_name
+    DO NOTHING;
 
     -- insert the required ddl into the migrations table
     SELECT <%= schema %>.ddlx_create(_oid) INTO _create_sql; 
@@ -141,6 +130,24 @@ BEGIN
     RAISE DEBUG '%', _create_sql;
 
     PERFORM <%= schema %>.capture_ddl(_create_sql);
+
+    IF NOT EXISTS (
+        SELECT pr.oid FROM pg_publication_rel pr
+        INNER JOIN pg_publication pp ON pr.prpubid = pp.oid
+        WHERE pp.pubname = '<%= publication_name %>'
+        AND pr.prrelid = _oid
+        ) THEN
+        EXECUTE format('<%= publication_sql %>;', _schema, _table);
+
+        -- We want to disable any possible hooks from `CREATE TABLE` statements
+        PERFORM set_config('<%= schema %>.is_in_event_trigger', 'true', true);
+        PERFORM <%= schema %>.ddlx_make_or_update_shadow_tables('CREATE TABLE', _schema, _oid);
+        PERFORM set_config('<%= schema %>.is_in_event_trigger', '', true);
+
+        EXECUTE format('<%= publication_sql %>;', '<%= schema %>', ('shadow__' || _schema || '__' || _table)::name);
+    ELSE
+        RAISE WARNING 'table %.% is already electrified', _schema, _table;
+    END IF;
 END;
 $function$ LANGUAGE PLPGSQL;
 
@@ -177,6 +184,8 @@ DECLARE
     _capture bool := false;
     _table_id int8;
 BEGIN
+    -- Usually, this would be a great place for `pg_trigger_depth()`, but for event triggers that's always
+    IF (current_setting('electric.is_in_event_trigger', true) = 'true') THEN RETURN; END IF;
     RAISE DEBUG 'command_end_handler:: start';
 
     FOR _cmd IN SELECT * FROM pg_event_trigger_ddl_commands() 
@@ -207,6 +216,19 @@ BEGIN
     IF _capture THEN
         _trid := (SELECT <%= schema %>.capture_ddl());
         RAISE DEBUG 'create_active_migration = %', _trid;
+
+        -- We're going to alter multiple tables here. We don't want to re-trigger this function.
+        PERFORM set_config('<%= schema %>.is_in_event_trigger', 'true', true);
+        FOR _cmd IN (SELECT * FROM pg_event_trigger_ddl_commands())
+        LOOP
+            RAISE DEBUG '  Current statement touches a % in schema % with objid %', _cmd.object_type, _cmd.schema_name, _cmd.object_identity;
+            IF _cmd.object_type = 'table' AND <%= schema %>.__table_is_electrified(_cmd.classid, _cmd.objid) THEN
+                -- Since we're performing these calls only against already-electrified tables, this can only be an "ALTER TABLE" statement
+                -- which means we won't be creating new tables, which means we don't need to add them to publications
+                PERFORM <%= schema %>.ddlx_make_or_update_shadow_tables(_cmd.command_tag, _cmd.schema_name, _cmd.objid);
+            END IF;
+        END LOOP;
+        PERFORM set_config('<%= schema %>.is_in_event_trigger', '', true);
     END IF;
 
     RAISE DEBUG 'command_end_handler:: end';

--- a/components/electric/lib/electric/postgres/schema.ex
+++ b/components/electric/lib/electric/postgres/schema.ex
@@ -346,8 +346,17 @@ defmodule Electric.Postgres.Schema do
     {:ok, pk_column_names} = primary_keys(main)
 
     {pks, non_pks} = Enum.split_with(stripped_columns, &(&1.name in pk_column_names))
-    timestamps = Enum.map(non_pks, &Map.put(&1, :type, @electric_tag_type))
-    reordered = Enum.map(non_pks, &Map.update!(&1, :name, fn n -> "__reordered_#{n}" end))
+
+    timestamps =
+      non_pks
+      |> Enum.map(&Map.put(&1, :type, @electric_tag_type))
+      |> Enum.map(&Map.update!(&1, :name, fn n -> String.slice("_tag_#{n}", 0..63) end))
+
+    reordered =
+      Enum.map(
+        non_pks,
+        &Map.update!(&1, :name, fn n -> String.slice("__reordered_#{n}", 0..63) end)
+      )
 
     %Proto.Table{
       # `MigrationConsumer` code currently has logic that for any incoming relation, we're the OID already in the `SchemaRegistry`.

--- a/components/electric/lib/electric/postgres/schema.ex
+++ b/components/electric/lib/electric/postgres/schema.ex
@@ -117,7 +117,7 @@ defmodule Electric.Postgres.Schema do
       Enum.map(table.columns, fn col ->
         %{
           name: col.name,
-          type: col_type(col.type.name),
+          type: col_type(col.type),
           type_modifier: List.first(col.type.size, -1),
           part_of_identity?: nil
         }
@@ -126,19 +126,13 @@ defmodule Electric.Postgres.Schema do
     {:ok, table_info, columns}
   end
 
-  defp col_type(t) when t in ["serial", "serial4"] do
-    :int4
-  end
+  defp col_type(%{name: name, array: [_]}), do: {:array, col_type(name)}
+  defp col_type(%{name: name}), do: col_type(name)
 
-  defp col_type("serial8") do
-    :int8
-  end
-
-  defp col_type("serial2") do
-    :int2
-  end
-
-  defp col_type(t), do: String.to_atom(t)
+  defp col_type("serial2"), do: :int2
+  defp col_type(t) when t in ["serial", "serial4"], do: :int4
+  defp col_type("serial8"), do: :int8
+  defp col_type(t) when is_binary(t), do: String.to_atom(t)
 
   def struct_order(list) do
     Enum.sort(list)
@@ -289,4 +283,89 @@ defmodule Electric.Postgres.Schema do
   defp blank(nil), do: nil
   defp blank(""), do: nil
   defp blank(s) when is_binary(s), do: s
+
+  @doc """
+  Enrich the schema with shadow tables for each table.
+
+  We don't check if the shadow tables actually exist, so only electrified
+  tables (or other tables that are expected to have shadows) should be included
+  in the schema passed to this function
+  """
+  def add_shadow_tables(%Proto.Schema{tables: tables} = schema) do
+    shadow_tables =
+      tables
+      |> Enum.reject(&is_shadow_table?/1)
+      |> Enum.map(&build_shadow_table/1)
+
+    %{schema | tables: tables ++ shadow_tables}
+  end
+
+  @schema Electric.Postgres.Extension.schema()
+  defp is_shadow_table?(%Proto.Table{
+         name: %Proto.RangeVar{schema: @schema, name: "shadow__" <> _}
+       }),
+       do: true
+
+  defp is_shadow_table?(%Proto.Table{}), do: false
+
+  @electric_tag_type %Proto.Column.Type{
+    name: "electric.tag",
+    size: [],
+    array: []
+  }
+
+  # These are missing their DEFAULT constraints, but I don't think it matters
+  #   _tags electric.tag[] DEFAULT array[]::electric.tag[],
+  #   _last_modified bigint,
+  #   _is_a_delete_operation boolean DEFAULT false,
+  #   _tag electric.tag,
+  #   _observed_tags electric.tag[],
+  #   _modified_columns_bit_mask boolean[],
+  #   _resolved boolean,
+  #   _currently_reordering boolean
+  @shadow_columns [
+    %Proto.Column{name: "_tags", type: %Proto.Column.Type{name: "electric.tag", array: [-1]}},
+    %Proto.Column{name: "_last_modified", type: %Proto.Column.Type{name: "int8"}},
+    %Proto.Column{name: "_is_a_delete_operation", type: %Proto.Column.Type{name: "bool"}},
+    %Proto.Column{name: "_tag", type: %Proto.Column.Type{name: "electric.tag"}},
+    %Proto.Column{
+      name: "_observed_tags",
+      type: %Proto.Column.Type{name: "electric.tag", array: [-1]}
+    },
+    %Proto.Column{
+      name: "_modified_columns_bit_mask",
+      type: %Proto.Column.Type{name: "bool", array: [-1]}
+    },
+    %Proto.Column{name: "_resolved", type: %Proto.Column.Type{name: "bool"}},
+    %Proto.Column{name: "_currently_reordering", type: %Proto.Column.Type{name: "bool"}}
+  ]
+
+  defp build_shadow_table(%Proto.Table{} = main) do
+    # The columns based on the main table lack any defaults/constraints on shadow tables
+    stripped_columns = Enum.map(main.columns, &Map.put(&1, :constraints, []))
+    {:ok, pk_column_names} = primary_keys(main)
+
+    {pks, non_pks} = Enum.split_with(stripped_columns, &(&1.name in pk_column_names))
+    timestamps = Enum.map(non_pks, &Map.put(&1, :type, @electric_tag_type))
+    reordered = Enum.map(non_pks, &Map.update!(&1, :name, fn n -> "__reordered_#{n}" end))
+
+    %Proto.Table{
+      # `MigrationConsumer` code currently has logic that for any incoming relation, we're the OID already in the `SchemaRegistry`.
+      # Hence, we just need any oid that's not going to collide. `oid` type is uint4, with max being 4,294,967,295.
+      # Let's add 2,000,000,000 to original table oid and hope for the best.
+      # OID generation is done on PG side by an increasing counter [1] and not a random value,
+      # and that counter functionally starts at 16384 [2]. I think that starting our "fake" oid generation near the end,
+      # with it only being required to not conflict within one table (`pg_class`) seems fine for now.
+      #
+      # TODO: Add more robust checks to definitely not collide in our own SchemaRegistry or alternatives.
+      oid: 2_000_000_000 + main.oid,
+      name: %Proto.RangeVar{
+        schema: @schema,
+        name: "shadow__#{main.name.schema}__#{main.name.name}"
+      },
+      columns: pks ++ @shadow_columns ++ timestamps ++ reordered,
+      constraints: Enum.filter(main.constraints, &match?(%{constraint: {:primary, _}}, &1)),
+      indexes: []
+    }
+  end
 end

--- a/components/electric/lib/electric/postgres/shadow_table_transformation.ex
+++ b/components/electric/lib/electric/postgres/shadow_table_transformation.ex
@@ -1,0 +1,392 @@
+defmodule Electric.Postgres.ShadowTableTransformation do
+  import Electric.Postgres.Extension,
+    only: [
+      shadow_of: 1,
+      is_shadow_relation: 1,
+      is_tombstone_relation: 1,
+      infer_shadow_primary_keys: 1,
+      is_extension_relation: 1
+    ]
+
+  alias Electric.Replication.Changes
+  alias Electric.Replication.Changes.Transaction
+  alias Electric.Replication.Changes.DeletedRecord
+
+  @type column :: %{name: String.t()}
+  @type relations_map :: %{
+          optional(Changes.relation()) => %{
+            primary_keys: [String.t(), ...],
+            columns: [column()]
+          }
+        }
+
+  @doc """
+  Splits the change event into main table event and shadow table event to be handled by
+  Postgres triggers for conflict resolution.
+
+  It accepts a change that's going to be split, a map of relations which describe columns
+  of both the main table and the shadow table, and a tag that's going to be assigned to the
+  change.
+
+  This function is meant to work together with Postgres conflict resolution triggers,
+  which expect that all operations coming from Electric are `INSERT`s and consist of
+  two operations: one for main table and one for shadow table.
+
+  The operations must all be `INSERT`s so that PostgreSQL will execute a trigger for each of
+  them: for `UPDATE`s it will not execute any triggers if the row is missing. We convert
+  all operations to `INSERT`s, even `DELETE`s, since the actual operation is going to be
+  determined by the triggers based on the shadow row contents.
+
+  Shadow row operation is built based on the incoming change, and we set the following:
+  - Primary key columns (same as on the main table)
+  - If the operation is a `DELETE`
+  - Observed tags for the operation
+  - Modified columns bitmask
+
+  The actual data is sent in the main table `INSERT`, and how that is applied is determined
+  by the shadow table `INSERT`. We "resend" the deleted data as the `INSERT` instead of a
+  `DELETE` operation, since it's likely valid and it will get discarded anyway.
+
+  The order of operation is very important here: triggers expect main table `INSERT` to come
+  before the shadow table `INSERT`. The reason for this choice is the locking order: when
+  writing triggers for PG-originating transactions, we cannot alter the locking order: the
+  `BEFORE UPDATE` triggers on the main table that want to alter the shadow table will run
+  only after the lock has been taken out on the main table. To avoid same-table deadlocks,
+  we're explicitly ordering the operations on the replication stream in the same order
+  as they would be on PG-originating transactions.
+  """
+  @spec split_change_into_main_and_shadow(
+          change :: Changes.change(),
+          relations :: relations_map(),
+          tag :: {DateTime.t(), String.t()} | String.t()
+        ) :: [Changes.change()]
+  def split_change_into_main_and_shadow(change, relations, tag)
+
+  def split_change_into_main_and_shadow(change, relations, {_, _} = tag),
+    do: split_change_into_main_and_shadow(change, relations, serialize_tag_to_pg(tag))
+
+  def split_change_into_main_and_shadow(change, relations, tag) do
+    main_table_info = relations[change.relation]
+    main_record = get_record(change)
+    shadow_table_info = relations[shadow_of(change.relation)]
+
+    non_pk_columns = Enum.map(main_table_info.columns, & &1.name) -- main_table_info.primary_keys
+
+    modified_bitmask = build_bitmask(change, non_pk_columns)
+    primary_keys = Map.take(main_record, shadow_table_info.primary_keys)
+
+    shadow_record =
+      shadow_table_info.columns
+      |> Map.new(&{&1.name, nil})
+      |> Map.merge(primary_keys)
+      |> Map.merge(%{
+        "_tag" => tag,
+        "_is_a_delete_operation" =>
+          if(is_struct(change, Changes.DeletedRecord), do: "t", else: "f"),
+        "_observed_tags" => convert_tag_list_satellite_to_pg(change.tags),
+        "_modified_columns_bit_mask" => serialize_pg_array(modified_bitmask)
+      })
+
+    [
+      %Changes.NewRecord{relation: change.relation, record: main_record},
+      %Changes.NewRecord{relation: shadow_of(change.relation), record: shadow_record}
+    ]
+  end
+
+  defp build_bitmask(%Changes.NewRecord{}, columns), do: Enum.map(columns, fn _ -> "t" end)
+
+  defp build_bitmask(%Changes.UpdatedRecord{old_record: nil}, columns),
+    do: Enum.map(columns, fn _ -> "t" end)
+
+  defp build_bitmask(%Changes.UpdatedRecord{old_record: old, record: new}, columns),
+    do: Enum.map(columns, fn col -> if old[col] != new[col], do: "t", else: "f" end)
+
+  defp build_bitmask(%Changes.DeletedRecord{}, columns), do: Enum.map(columns, fn _ -> "f" end)
+
+  defp get_record(%{record: record}) when is_map(record), do: record
+  defp get_record(%{old_record: record}), do: record
+
+  @doc """
+  Returns a transaction with origin & timestamp set based on the shadow operations,
+  and with `tags` for each operation filled from relevant shadow operation.
+
+  Expects a transaction, where for each "main" table change, there exists a "shadow"
+  change that sets the `_tags` field to the correct value. This function only uses two
+  fields from the `shadow` changes: `_tag` and `_tags`. Shadow operations are removed
+  from the changes.
+
+  The `_tag` is expected to be a transient value which doesn't get affected by the
+  triggers on Postgres side, so we can use it to restore the origin & timestamp of
+  the transaction. Within a transaction, all "shadow" changes are expected to have the
+  same tag, so we're just getting a first one we can find.
+
+  The `_tags` field may be set to different values within the transaction, but since
+  we're sending a "source of truth" set of tags from here, we can take the latest
+  "shadow" change for a given row and use those tags for all operations in the transaction.
+
+  The "delete" operation is special-cased here, as it should have an empty tag set always,
+  if sent from PG.
+  """
+  @spec enrich_tx_from_shadow_ops(transaction :: Transaction.t()) :: Transaction.t()
+  def enrich_tx_from_shadow_ops(%Transaction{} = tx) do
+    # tx.changes is REVERSED at this point, so `shadow` and `non_shadow` will be too
+    {shadow, non_shadow} =
+      tx.changes
+      |> Enum.reject(&is_tombstone_relation(&1.relation))
+      |> Enum.split_with(&is_shadow_relation(&1.relation))
+
+    # Convert changes touching any shadow tables, intentionally keeping only latest ones
+    #   `shadow_map` is keyed by a pair of the relation and a map with all the PK column values
+    #   `pk_specs` is keyed by a relation and contains an unordered list of PK column names
+    {shadow_map, pk_specs} =
+      shadow
+      |> Enum.reverse()
+      |> Enum.reject(&is_struct(&1, DeletedRecord))
+      |> Enum.reduce({%{}, %{}}, fn change, {shadow_map, pk_specs} ->
+        %{relation: {"electric", "shadow__" <> ns_and_name}} = change
+        [ns, name] = String.split(ns_and_name, "__", parts: 2)
+
+        pk_specs =
+          Map.put_new_lazy(pk_specs, {ns, name}, fn ->
+            infer_shadow_primary_keys(change.record)
+          end)
+
+        pk_list = Map.fetch!(pk_specs, {ns, name})
+
+        shadow_map = Map.put(shadow_map, {{ns, name}, Map.take(change.record, pk_list)}, change)
+
+        {shadow_map, pk_specs}
+      end)
+
+    # Find any shadow change, and take it's tag.
+    # `DELETE` changes aren't expected on shadow tables, so we skip those unexpected ops.
+    {timestamp, origin} =
+      case Enum.find(shadow, &(not is_struct(&1, DeletedRecord))) do
+        nil -> {tx.commit_timestamp, tx.origin}
+        %{record: %{"_tag" => tag}} -> parse_pg_electric_tag(tag, tx.origin)
+      end
+
+    %{
+      tx
+      | commit_timestamp: timestamp,
+        origin: origin,
+        changes: merge_shadow_changes(non_shadow, shadow_map, pk_specs, tx.origin)
+    }
+  end
+
+  # This function uses tail recursion which reverses the list, but that's expected since source is reversed
+  @spec merge_shadow_changes(
+          non_shadow_changes :: [Changes.change()],
+          shadow_map :: %{optional({Changes.relation(), map()}) => Changes.change()},
+          pk_specs :: %{optional(Changes.relation()) => list(String.t())},
+          default_origin :: String.t(),
+          acc :: [Changes.change()]
+        ) :: [Changes.change()]
+  defp merge_shadow_changes(non_shadow_changes, shadow_map, pk_specs, default_origin, acc \\ [])
+
+  defp merge_shadow_changes([], _, _, _, acc), do: acc
+
+  defp merge_shadow_changes(
+         [%DeletedRecord{} = change | rest],
+         shadow_map,
+         pk_specs,
+         default_origin,
+         acc
+       )
+       when is_map_key(pk_specs, change.relation) do
+    # Although this function is (currently) applied to both PG-originating txs and Electric-originating txs,
+    # the actual `DELETE` operation can show up on the replication stream only in two cases:
+    #    1. It's PG-originating, meaning that tags are magically handled as overriding everything already
+    #    2. It's Electric-originating AND PG had resolved the tags to be an empty set (otherwise a DELETE wouldn't have been executed)
+    # Hence, we can assign empty tag set on the downstream path in both occasions
+    acc = [%{change | tags: []} | acc]
+    merge_shadow_changes(rest, shadow_map, pk_specs, default_origin, acc)
+  end
+
+  defp merge_shadow_changes([change | rest], shadow_map, pk_specs, default_origin, acc)
+       when is_map_key(pk_specs, change.relation) do
+    pk_map = Map.take(change.record, pk_specs[change.relation])
+
+    case Map.fetch(shadow_map, {change.relation, pk_map}) do
+      {:ok, %{record: %{"_tags" => tags}}} ->
+        change = %{change | tags: convert_tag_list_pg_to_satellite(tags, default_origin)}
+
+        merge_shadow_changes(rest, shadow_map, pk_specs, default_origin, [change | acc])
+
+      :error ->
+        merge_shadow_changes(rest, shadow_map, pk_specs, default_origin, [change | acc])
+    end
+  end
+
+  defp merge_shadow_changes([change | rest], shadow_map, pk_specs, default_origin, acc) do
+    # Shadow entry is missing completely, best we can do is just pass this through
+    merge_shadow_changes(rest, shadow_map, pk_specs, default_origin, [change | acc])
+  end
+
+  @doc """
+  Adds shadow relation for every mentioned non-extension relation to the list
+
+  ## Examples
+
+      iex> add_shadow_relations([{"public", "test"}])
+      [{"public", "test"}, {"electric", "shadow__public__test"}]
+
+      iex> add_shadow_relations([{"public", "test"}, {"electric", "testing"}])
+      [{"electric", "testing"}, {"public", "test"}, {"electric", "shadow__public__test"}]
+  """
+  def add_shadow_relations(relations, acc \\ [])
+  def add_shadow_relations([], acc), do: acc
+
+  def add_shadow_relations([relation | tail], acc) when is_extension_relation(relation),
+    do: add_shadow_relations(tail, [relation | acc])
+
+  def add_shadow_relations([relation | tail], acc),
+    do: add_shadow_relations(tail, [relation, shadow_of(relation) | acc])
+
+  @doc """
+  Parse a postgres string-serialized electric.tag value into an origin & a timestamp.
+
+  If the origin in the tuple is empty, returns `default_origin` instead (`nil` by default)
+
+  ## Examples
+
+      iex> ~s|("2023-06-15 11:18:05.372698+00",)| |> parse_pg_electric_tag()
+      {~U[2023-06-15 11:18:05.372698Z], nil}
+
+      iex> ~s|("2023-06-15 11:18:05.372698+00",test)| |> parse_pg_electric_tag()
+      {~U[2023-06-15 11:18:05.372698Z], "test"}
+
+      iex> ~s|("2023-06-15 11:18:05.372698+00",)| |> parse_pg_electric_tag("default")
+      {~U[2023-06-15 11:18:05.372698Z], "default"}
+  """
+  def parse_pg_electric_tag(tag, default_origin \\ nil) when is_binary(tag) do
+    [ts, origin] =
+      tag
+      |> String.slice(1..-2//1)
+      |> String.split(",", parts: 2)
+      |> Enum.map(&String.trim(&1, ~s|"|))
+      |> Enum.map(&String.replace(&1, ~S|\"|, ~S|"|))
+
+    {:ok, ts, _} = DateTime.from_iso8601(ts)
+
+    {ts, if(origin == "", do: default_origin, else: origin)}
+  end
+
+  @doc """
+  Serialize an origin-timestamp pair into a postgres string-serialized electric.tag value
+
+  If the origin matches `nil_origin` (second argument), then `null` PG value will be used in place
+
+  ## Examples
+
+      iex> {~U[2023-06-15 11:18:05.372698Z], nil} |> serialize_tag_to_pg()
+      ~s|("2023-06-15T11:18:05.372698Z",)|
+
+      iex> {~U[2023-06-15 11:18:05.372698Z], "test"} |> serialize_tag_to_pg()
+      ~s|("2023-06-15T11:18:05.372698Z","test")|
+
+      iex> {~U[2023-06-15 11:18:05.372698Z], "default"} |> serialize_tag_to_pg("default")
+      ~s|("2023-06-15T11:18:05.372698Z",)|
+  """
+  def serialize_tag_to_pg({timestamp, origin}, nil_origin \\ nil) do
+    origin =
+      if origin == nil_origin, do: nil, else: ~s|"#{String.replace(origin, ~S|"|, ~S|\"|)}"|
+
+    ~s|("#{DateTime.to_iso8601(timestamp)}",#{origin})|
+  end
+
+  @doc ~S"""
+  Parse a PG array of electric tags and serialize them as Satellite-formatted tags.
+
+  There is some loss in precision here, as PG serializes the timestamp with microseconds,
+  while satellite string tags are millisecond-precision unix timestamps
+
+  ## Examples
+
+      iex> ~s|{"(\\"2023-06-15 11:18:05.372698+00\\",)"}| |> convert_tag_list_pg_to_satellite("postgres")
+      ["postgres@1686827885372"]
+  """
+  def convert_tag_list_pg_to_satellite(array, default_origin \\ nil) when is_binary(array) do
+    array
+    |> parse_pg_array()
+    |> Enum.map(&parse_pg_electric_tag(&1, default_origin))
+    |> Enum.map(&pg_electric_tag_to_satellite_tag/1)
+  end
+
+  @doc ~S"""
+  Parse a list of electric tags and serialize them to pg array.
+
+  ## Examples
+
+      iex> ["postgres@1686827885372"] |> convert_tag_list_satellite_to_pg("postgres")
+      ~s|{"(\\"2023-06-15T11:18:05.372Z\\",)"}|
+  """
+  def convert_tag_list_satellite_to_pg(array, nil_origin \\ nil) do
+    array
+    |> Enum.map(&split_satellite_tag/1)
+    |> Enum.map(&serialize_tag_to_pg(&1, nil_origin))
+    |> serialize_pg_array()
+  end
+
+  @split_array_on_unquoted_comma ~r/((?<=,)|^)([^",]+|"((\\{2})*|(.*?[^\\](\\{2})*))")(?<comma>,)/
+
+  @doc ~S"""
+  Parse a postgres string-serialized array into a list of strings, unwrapping the escapes
+
+  ## Examples
+
+      iex> ~s|{"(\\"2023-06-15 11:18:05.372698+00\\",)"}| |> parse_pg_array()
+      [~s|("2023-06-15 11:18:05.372698+00",)|]
+
+      iex> ~s|{"(\\"2023-06-15 11:18:05.372698+00\\",)","(\\"2023-06-15 11:18:05.372698+00\\",)"}| |> parse_pg_array()
+      [~s|("2023-06-15 11:18:05.372698+00",)|, ~s|("2023-06-15 11:18:05.372698+00",)|]
+  """
+  def parse_pg_array(array) when is_binary(array) do
+    array
+    |> String.slice(1..-2//1)
+    |> then(&Regex.split(@split_array_on_unquoted_comma, &1, on: [:comma]))
+    |> Enum.map(fn
+      ~s|"| <> _ = quoted_string ->
+        quoted_string |> String.slice(1..-2//1) |> String.replace(~S|\"|, ~S|"|)
+
+      unquoted_string ->
+        unquoted_string
+    end)
+    |> case do
+      [""] -> []
+      arr -> arr
+    end
+  end
+
+  @doc ~S"""
+  Serialize a list of strings into a postgres string-serialized array into a list of strings, wrapping the contents
+
+  ## Examples
+
+      iex> [~s|("2023-06-15 11:18:05.372698+00",)|] |> serialize_pg_array()
+      ~s|{"(\\"2023-06-15 11:18:05.372698+00\\",)"}|
+
+      iex> [~s|("2023-06-15 11:18:05.372698+00",)|, ~s|("2023-06-15 11:18:05.372698+00",)|] |> serialize_pg_array()
+      ~s|{"(\\"2023-06-15 11:18:05.372698+00\\",)","(\\"2023-06-15 11:18:05.372698+00\\",)"}|
+
+      iex> str = ~s|{"(\\"2023-06-15 11:18:05.372698+00\\",)","(\\"2023-06-15 11:18:05.372698+00\\",)"}|
+      iex> str |> parse_pg_array |> serialize_pg_array
+      str
+  """
+  def serialize_pg_array(array) when is_list(array) do
+    array
+    |> Enum.map_join(",", fn
+      nil -> "null"
+      val when is_binary(val) -> ~s|"| <> String.replace(val, ~s|"|, ~S|\"|) <> ~s|"|
+    end)
+    |> then(&"{#{&1}}")
+  end
+
+  def split_satellite_tag(tag) do
+    [origin, ts] = String.split(tag, "@", parts: 2)
+    {DateTime.from_unix!(String.to_integer(ts), :millisecond), origin}
+  end
+
+  defp pg_electric_tag_to_satellite_tag({timestamp, origin}),
+    do: "#{origin}@#{DateTime.to_unix(timestamp, :millisecond)}"
+end

--- a/components/electric/lib/electric/replication/downstream_producer.ex
+++ b/components/electric/lib/electric/replication/downstream_producer.ex
@@ -11,7 +11,7 @@ defmodule Electric.Replication.DownstreamProducer do
   @typedoc "The events produced follow this typespec"
   @type event :: {Electric.Replication.Changes.Transaction.t(), offset_state}
 
-  @callback start_link(name :: String.t(), opts :: keyword()) :: {:ok, pid()} | {:error, term()}
+  @callback start_link(name :: any, opts :: keyword()) :: {:ok, pid()} | {:error, term()}
   @callback start_replication(producer :: pid(), offset_state) :: :ok
   @callback connected?(producer :: pid()) :: boolean()
 

--- a/components/electric/lib/electric/replication/postgres/migration_consumer.ex
+++ b/components/electric/lib/electric/replication/postgres/migration_consumer.ex
@@ -202,10 +202,12 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
     oid_loader = &SchemaLoader.relation_oid(state.loader, &1, &2, &3)
 
     schema =
-      Enum.reduce(stmts, schema, fn stmt, schema ->
+      stmts
+      |> Enum.reduce(schema, fn stmt, schema ->
         Logger.info("Applying migration #{version}: #{inspect(stmt)}")
         Schema.update(schema, stmt, oid_loader: oid_loader)
       end)
+      |> Schema.add_shadow_tables()
 
     save_schema(state, version, schema, stmts)
   end

--- a/components/electric/lib/electric/replication/postgres/slot_server.ex
+++ b/components/electric/lib/electric/replication/postgres/slot_server.ex
@@ -21,6 +21,7 @@ defmodule Electric.Replication.Postgres.SlotServer do
   alias Electric.Replication.Connectors
   alias Electric.Replication.Changes
   alias Electric.Replication.OffsetStorage
+  alias Electric.Postgres.ShadowTableTransformation
 
   alias Electric.Replication.DownstreamProducer
 
@@ -40,6 +41,8 @@ defmodule Electric.Replication.Postgres.SlotServer do
               producer_pid: nil,
               sent_relations: %{},
               current_vx_offset: nil,
+              preprocess_relation_list_fn: nil,
+              preprocess_change_fn: nil,
               opts: []
   end
 
@@ -51,9 +54,23 @@ defmodule Electric.Replication.Postgres.SlotServer do
   @type slot_name :: String.t()
   @type slot_reg :: Electric.reg_name()
 
+  @type column :: %{name: String.t()}
+  @type relations_map :: %{
+          optional(Changes.relation()) => %{
+            primary_keys: [String.t(), ...],
+            columns: [column()],
+            oid: non_neg_integer()
+          }
+        }
+  @type preprocess_change_fn ::
+          (Changes.change(), relations_map(), {DateTime.t(), String.t()} -> [Changes.change()])
+  @type preprocess_relation_list_fn :: ([Changes.relation()] -> [Changes.relation()])
+
   @type opts ::
           {:conn_config, Connectors.config()}
           | {:producer, Electric.reg_name()}
+          | {:preprocess_change_fn, preprocess_change_fn()}
+          | {:preprocess_relation_list_fn, preprocess_relation_list_fn()}
 
   # Public interface
 
@@ -135,7 +152,10 @@ defmodule Electric.Replication.Postgres.SlotServer do
     :gproc.reg(name({:slot_name, slot}))
 
     Logger.metadata(origin: origin, pg_slot: slot)
-    Logger.debug("slot server started")
+
+    Logger.debug(
+      "slot server started, registered as #{inspect(name(origin))} and #{inspect(name({:slot_name, slot}))}"
+    )
 
     {:consumer,
      %State{
@@ -144,7 +164,24 @@ defmodule Electric.Replication.Postgres.SlotServer do
        origin: origin,
        producer_name: producer,
        producer: downstream_opts.producer,
-       opts: Map.get(replication_opts, :opts, [])
+       opts: Map.get(replication_opts, :opts, []),
+       # Under the current implementation, this function is always going to be
+       # `ShadowTableTransformation.split_change_into_main_and_shadow/3`,
+       # but I'm using the "plain" behaviour of SlotServer for working with Postgres, so it's
+       # "dependency-injected" here so that I can easily disable it
+       preprocess_change_fn:
+         Keyword.get(
+           opts,
+           :preprocess_change_fn,
+           &ShadowTableTransformation.split_change_into_main_and_shadow/3
+         ),
+       # Comment for `preprocess_change_fn` also relevant here
+       preprocess_relation_list_fn:
+         Keyword.get(
+           opts,
+           :preprocess_relation_list_fn,
+           &ShadowTableTransformation.add_shadow_relations/1
+         )
      }}
   end
 
@@ -366,15 +403,19 @@ defmodule Electric.Replication.Postgres.SlotServer do
     end
   end
 
-  defp convert_to_wal(%Changes.Transaction{commit_timestamp: ts, changes: changes}, state) do
+  defp convert_to_wal(
+         %Changes.Transaction{commit_timestamp: ts, changes: changes, origin: origin},
+         %State{} = state
+       ) do
     first_lsn = Lsn.increment(state.current_lsn)
 
-    # always fetch the table info from the schema registry, don't rely on 
+    # always fetch the table info from the schema registry, don't rely on
     # our cache, which is just to determine which relations to send
     # this keeps the column lists up to date in the case of migrations
     relations =
       changes
       |> Enum.map(& &1.relation)
+      |> state.preprocess_relation_list_fn.()
       |> Enum.uniq()
       |> Enum.map(&SchemaRegistry.fetch_table_info!/1)
       |> Enum.map(&Map.put(&1, :columns, SchemaRegistry.fetch_table_columns!(&1.oid)))
@@ -391,6 +432,7 @@ defmodule Electric.Replication.Postgres.SlotServer do
     # Final LSN as specified by `BEGIN` message should be after all LSNs of actual changes but before the LSN of the commit
     {messages, final_lsn} =
       changes
+      |> Enum.flat_map(&preprocess_changes(state, &1, relations, {ts, origin}))
       |> Enum.map(&changes_to_wal(&1, relations))
       |> Enum.map_reduce(first_lsn, fn elem, lsn -> {{lsn, elem}, Lsn.increment(lsn)} end)
 
@@ -422,6 +464,12 @@ defmodule Electric.Replication.Postgres.SlotServer do
 
     {begin ++ relation_messages ++ messages ++ commit, relations, commit_lsn}
   end
+
+  defp preprocess_changes(%State{preprocess_change_fn: nil}, change, _, _), do: [change]
+
+  defp preprocess_changes(%State{preprocess_change_fn: fun}, change, relations, tag)
+       when is_function(fun, 3),
+       do: fun.(change, relations, tag)
 
   defp changes_to_wal(%Changes.NewRecord{record: data, relation: table}, relations) do
     %ReplicationMessages.Insert{
@@ -488,6 +536,7 @@ defmodule Electric.Replication.Postgres.SlotServer do
     }
   end
 
+  # TODO: Should probably have backfilling of columns with defaults/nulls
   defp record_to_tuple(record, columns) do
     Enum.map(columns, &Map.fetch!(record, &1.name))
   end

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -42,10 +42,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
         start:
           {Postgres.MigrationConsumer, :start_link, [conn_config, [producer: postgres_producer]]}
       },
-      %{
-        id: :slot_server,
-        start: {Postgres.SlotServer, :start_link, [conn_config, vaxine_producer]}
-      },
+      {Postgres.SlotServer, conn_config: conn_config, producer: MagicProducer.name()},
       {CachedWal.EtsBacked,
        subscribe_to: [postgres_producer_consumer], name: CachedWal.EtsBacked},
       %{

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -4,9 +4,9 @@ defmodule Electric.Replication.PostgresConnectorSup do
 
   alias Electric.Replication.Connectors
   alias Electric.Replication.Postgres
-  alias Electric.Replication.Vaxine
   alias Electric.Postgres.Extension.SchemaCache
   alias Electric.Postgres.CachedWal
+  alias Electric.Replication.SatelliteCollectorProducer
 
   @spec start_link(Connectors.config()) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(conn_config) do
@@ -22,9 +22,6 @@ defmodule Electric.Replication.PostgresConnectorSup do
   def init(conn_config) do
     origin = Connectors.origin(conn_config)
     Electric.reg(name(origin))
-
-    downstream = Connectors.get_downstream_opts(conn_config)
-    vaxine_producer = Vaxine.LogProducer.get_name(origin)
     postgres_producer = Postgres.LogicalReplicationProducer.get_name(origin)
     postgres_producer_consumer = Postgres.MigrationConsumer.name(origin)
 
@@ -33,6 +30,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
         id: :postgres_schema_cache,
         start: {SchemaCache, :start_link, [conn_config]}
       },
+      {SatelliteCollectorProducer, name: SatelliteCollectorProducer.name()},
       %{
         id: :postgres_producer,
         start: {Postgres.LogicalReplicationProducer, :start_link, [conn_config]}
@@ -42,13 +40,10 @@ defmodule Electric.Replication.PostgresConnectorSup do
         start:
           {Postgres.MigrationConsumer, :start_link, [conn_config, [producer: postgres_producer]]}
       },
-      {Postgres.SlotServer, conn_config: conn_config, producer: MagicProducer.name()},
+      {Postgres.SlotServer,
+       conn_config: conn_config, producer: SatelliteCollectorProducer.name()},
       {CachedWal.EtsBacked,
-       subscribe_to: [postgres_producer_consumer], name: CachedWal.EtsBacked},
-      %{
-        id: :vaxine_producer,
-        start: {Vaxine.LogProducer, :start_link, [origin, downstream.producer_opts]}
-      }
+       subscribe_to: [{postgres_producer_consumer, []}], name: CachedWal.EtsBacked}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/components/electric/lib/electric/replication/satellite_collector_consumer.ex
+++ b/components/electric/lib/electric/replication/satellite_collector_consumer.ex
@@ -1,0 +1,29 @@
+defmodule Electric.Replication.SatelliteCollectorConsumer do
+  @moduledoc """
+  A consumer that generates demand to pull data from Satellites, and stores received
+  events by forwarding them to `Electric.Replication.SatelliteCollectorProducer`.
+  """
+  alias Electric.Replication.SatelliteCollectorProducer
+
+  use GenStage
+
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
+  end
+
+  def name(param) do
+    {:via, :gproc, {:n, :l, {__MODULE__, param}}}
+  end
+
+  @impl GenStage
+  def init(opts) do
+    {:consumer, Map.new(Keyword.take(opts, [:push_to])), Keyword.take(opts, [:subscribe_to])}
+  end
+
+  @impl GenStage
+  def handle_events(events, _, state) do
+    SatelliteCollectorProducer.store_incoming_transactions(state.push_to, events)
+
+    {:noreply, [], state}
+  end
+end

--- a/components/electric/lib/electric/replication/satellite_collector_producer.ex
+++ b/components/electric/lib/electric/replication/satellite_collector_producer.ex
@@ -1,0 +1,84 @@
+defmodule Electric.Replication.SatelliteCollectorProducer do
+  @moduledoc """
+  A producer that's meant to feed the SlotServer from a cache of transactions which
+  came from a number of Satellites.
+
+  This is a "fan-in" piece of architecture, where we merge the incoming operations
+  from all clients into one stream, and push them to Postgres. Conflict resolution
+  triggers on Postgres should take care of properly conflict-resolving inserts based
+  on the metadata, regardless of observed operation order.
+  """
+  use GenStage
+  require Logger
+
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, [], Keyword.take(opts, [:name]))
+  end
+
+  def name(identifier \\ :default) do
+    {:via, :gproc, {:n, :l, {__MODULE__, identifier}}}
+  end
+
+  def store_incoming_transactions(_, []), do: :ok
+
+  def store_incoming_transactions(server, transactions) do
+    GenStage.call(server, {:store_incoming_transactions, transactions})
+  end
+
+  # Internal API
+
+  @impl GenStage
+  def init(_) do
+    table = ETS.Set.new!(ordered: true, keypos: 2)
+    {:producer, %{table: table, next_key: 0, demand: 0}}
+  end
+
+  @impl GenStage
+  def handle_call({:store_incoming_transactions, transactions}, _, state) do
+    transactions
+    |> Stream.each(& &1.ack_fn())
+    |> Stream.reject(&Enum.empty?(&1.changes))
+    |> Stream.with_index(state.next_key)
+    |> Enum.to_list()
+    |> then(&ETS.Set.put(state.table, &1))
+
+    next_key = ETS.Set.last!(state.table) + 1
+
+    {:noreply, events, state} = send_events_from_ets(%{state | next_key: next_key})
+
+    {:reply, :ok, events, state}
+  end
+
+  @impl GenStage
+  def handle_subscribe(producer_or_consumer, subscription_options, _from, state) do
+    Logger.debug(
+      "Subscription request to satellite collector producer from #{producer_or_consumer} with #{inspect(subscription_options)}"
+    )
+
+    {:automatic, state}
+  end
+
+  @impl GenStage
+  def handle_demand(incoming_demand, state) do
+    Logger.debug("Handling incoming demand #{incoming_demand}")
+    send_events_from_ets(Map.update!(state, :demand, &(&1 + incoming_demand)))
+  end
+
+  defp send_events_from_ets(%{demand: 0} = state), do: {:noreply, [], state}
+
+  defp send_events_from_ets(%{demand: demand, table: set} = state) do
+    {results, _} = ETS.Set.match!(set, {:"$1", :"$2"}, demand)
+
+    case Electric.Utils.list_last_and_length(results) do
+      {_, 0} ->
+        {:noreply, [], state}
+
+      {[_, last_key], fulfilled} ->
+        # Delete items we're going to return now
+        ETS.Set.select_delete!(set, [{{:_, :"$1"}, [{:"=<", :"$1", last_key}], [true]}])
+
+        {:noreply, Enum.map(results, fn [tx, pos] -> {tx, pos} end),
+         Map.update!(state, :demand, &(&1 - fulfilled))}
+    end
+  end
+end

--- a/components/electric/lib/electric/replication/satellite_connector.ex
+++ b/components/electric/lib/electric/replication/satellite_connector.ex
@@ -1,40 +1,31 @@
 defmodule Electric.Replication.SatelliteConnector do
-  alias Electric.Replication.Vaxine
+  alias Electric.Replication.SatelliteCollectorProducer
+  alias Electric.Replication.SatelliteCollectorConsumer
   use Supervisor
 
   require Logger
 
   @type init_arg() :: %{
           :name => String.t(),
-          :producer => Electric.reg_name(),
-          :vaxine_opts => %{}
+          :producer => Electric.reg_name()
         }
 
   @spec start_link(init_arg()) :: Supervisor.on_start()
   def start_link(init_arg) do
-    vaxine_opts =
-      Application.get_env(
-        :electric,
-        Electric.Replication.SQConnectors
-      )
-
-    Supervisor.start_link(
-      __MODULE__,
-      Map.put(init_arg, :vaxine_opts, vaxine_opts)
-    )
+    Supervisor.start_link(__MODULE__, init_arg)
   end
 
   @impl Supervisor
   def init(init_arg) do
     name = init_arg.name
-    producer = init_arg.producer
-    # vaxine_opts = init_arg.vaxine_opts
 
+    # `cancel: :temporary` is used here since the death of the Satellite WS process will eventually kill the supervisor,
+    # but it'll kill SatelliteCollectorConsumer first and cause it to restart with nowhere to resubscribe.
     children = [
-      %{
-        id: :vx_consumer,
-        start: {Vaxine.LogConsumer, :start_link, [name, producer]}
-      },
+      {SatelliteCollectorConsumer,
+       name: SatelliteCollectorConsumer.name(name),
+       subscribe_to: [{init_arg.producer, cancel: :temporary}],
+       push_to: SatelliteCollectorProducer.name()},
       {Electric.Postgres.CachedWal.Producer,
        name: Electric.Postgres.CachedWal.Producer.name(name)}
     ]

--- a/components/electric/test/electric/postgres/extension/ddl_capture_test.exs
+++ b/components/electric/test/electric/postgres/extension/ddl_capture_test.exs
@@ -15,8 +15,8 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "ALTER electrified TABLE is captured", fn conn ->
-    sql1 = "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY);"
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY);"
+    sql1 = "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
+    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
     sql3 = "CALL electric.electrify('buttercup')"
     sql4 = "ALTER TABLE buttercup ADD COLUMN petal text;"
     sql5 = "ALTER TABLE daisy ADD COLUMN stem text, ADD COLUMN leaf text;"
@@ -32,8 +32,10 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "CREATE INDEX on electrified table is captured", fn conn ->
-    sql1 = "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
+    sql1 =
+      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+
+    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
     sql4 = "CREATE INDEX buttercup_value_idx ON buttercup (value);"
     sql5 = "CREATE INDEX daisy_value_idx ON daisy (value);"
@@ -49,8 +51,10 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "DROP INDEX on electrified table is captured", fn conn ->
-    sql1 = "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
+    sql1 =
+      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+
+    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
     sql4 = "CREATE INDEX buttercup_value_idx ON buttercup (value);"
     sql5 = "DROP INDEX buttercup_value_idx;"
@@ -70,8 +74,10 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "DROP electrified TABLE is rejected", fn conn ->
-    sql1 = "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
+    sql1 =
+      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+
+    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
 
     assert {:ok, []} = Extension.electrified_indexes(conn)
@@ -86,8 +92,10 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "ALTER electrified TABLE DROP COLUMN is rejected", fn conn ->
-    sql1 = "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
+    sql1 =
+      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+
+    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
 
     assert {:ok, []} = Extension.electrified_indexes(conn)
@@ -102,8 +110,10 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "ALTER electrified TABLE RENAME COLUMN is rejected", fn conn ->
-    sql1 = "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY, value text);"
+    sql1 =
+      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+
+    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
 
     assert {:ok, []} = Extension.electrified_indexes(conn)

--- a/components/electric/test/electric/postgres/shadow_table_transformation_test.exs
+++ b/components/electric/test/electric/postgres/shadow_table_transformation_test.exs
@@ -1,0 +1,262 @@
+defmodule Electric.Postgres.ShadowTableTransformationTest do
+  use ExUnit.Case, async: true
+  doctest Electric.Postgres.ShadowTableTransformation, import: true
+
+  alias Electric.Postgres.ShadowTableTransformation
+  alias Electric.Replication.Changes
+  alias Electric.Replication.Changes.Transaction
+
+  import Electric.Postgres.Extension, only: [shadow_of: 1]
+
+  import Electric.Postgres.ShadowTableTransformation,
+    only: [serialize_tag_to_pg: 1, serialize_pg_array: 1]
+
+  @relation {"public", "test"}
+  @transaction_tag {~U[2023-01-01 00:00:00Z], "no origin"}
+  @pg_transaction_tag serialize_tag_to_pg(@transaction_tag)
+  @observed "local@#{DateTime.to_unix(~U[2022-01-01 00:00:00Z], :millisecond)}"
+  @shadow_table_columns [
+    "_tag",
+    "_is_a_delete_operation",
+    "_observed_tags",
+    "_modified_columns_bit_mask"
+  ]
+
+  describe "split_change_into_main_and_shadow/3" do
+    test "INSERT operation gets converted and split correctly" do
+      assert [main_change, shadow_change] =
+               ShadowTableTransformation.split_change_into_main_and_shadow(
+                 %Changes.NewRecord{
+                   relation: @relation,
+                   record: %{"id" => "wow", "content" => "test", "content_b" => "test_b"},
+                   tags: [@observed]
+                 },
+                 relations(),
+                 @transaction_tag
+               )
+
+      assert is_struct(main_change, Changes.NewRecord)
+      assert main_change.relation == @relation
+      assert main_change.record == %{"id" => "wow", "content" => "test", "content_b" => "test_b"}
+
+      assert is_struct(shadow_change, Changes.NewRecord)
+      assert shadow_change.relation == shadow_of(@relation)
+
+      assert Map.take(shadow_change.record, @shadow_table_columns) == %{
+               "_tag" => ShadowTableTransformation.serialize_tag_to_pg(@transaction_tag),
+               "_is_a_delete_operation" => "f",
+               "_observed_tags" =>
+                 ShadowTableTransformation.convert_tag_list_satellite_to_pg([@observed]),
+               "_modified_columns_bit_mask" =>
+                 ShadowTableTransformation.serialize_pg_array(["t", "t"])
+             }
+    end
+
+    test "UPDATE operation gets converted and split correctly" do
+      assert [main_change, shadow_change] =
+               ShadowTableTransformation.split_change_into_main_and_shadow(
+                 %Changes.UpdatedRecord{
+                   relation: @relation,
+                   record: %{"id" => "wow", "content" => "test", "content_b" => "new"},
+                   old_record: %{"id" => "wow", "content" => "test", "content_b" => "old"},
+                   tags: [@observed]
+                 },
+                 relations(),
+                 @transaction_tag
+               )
+
+      assert is_struct(main_change, Changes.NewRecord)
+      assert main_change.relation == @relation
+      assert main_change.record == %{"id" => "wow", "content" => "test", "content_b" => "new"}
+
+      assert is_struct(shadow_change, Changes.NewRecord)
+      assert shadow_change.relation == shadow_of(@relation)
+
+      assert Map.take(shadow_change.record, @shadow_table_columns) == %{
+               "_tag" => ShadowTableTransformation.serialize_tag_to_pg(@transaction_tag),
+               "_is_a_delete_operation" => "f",
+               "_observed_tags" =>
+                 ShadowTableTransformation.convert_tag_list_satellite_to_pg([@observed]),
+               "_modified_columns_bit_mask" =>
+                 ShadowTableTransformation.serialize_pg_array(["f", "t"])
+             }
+    end
+
+    test "DELETE operation gets converted and split correctly" do
+      assert [main_change, shadow_change] =
+               ShadowTableTransformation.split_change_into_main_and_shadow(
+                 %Changes.DeletedRecord{
+                   relation: @relation,
+                   old_record: %{"id" => "wow", "content" => "test", "content_b" => "old"},
+                   tags: [@observed]
+                 },
+                 relations(),
+                 @transaction_tag
+               )
+
+      assert is_struct(main_change, Changes.NewRecord)
+      assert main_change.relation == @relation
+      assert main_change.record == %{"id" => "wow", "content" => "test", "content_b" => "old"}
+
+      assert is_struct(shadow_change, Changes.NewRecord)
+      assert shadow_change.relation == shadow_of(@relation)
+
+      assert Map.take(shadow_change.record, @shadow_table_columns) == %{
+               "_tag" => ShadowTableTransformation.serialize_tag_to_pg(@transaction_tag),
+               "_is_a_delete_operation" => "t",
+               "_observed_tags" =>
+                 ShadowTableTransformation.convert_tag_list_satellite_to_pg([@observed]),
+               "_modified_columns_bit_mask" =>
+                 ShadowTableTransformation.serialize_pg_array(["f", "f"])
+             }
+    end
+  end
+
+  describe "enrich_tx_from_shadow_ops/1" do
+    test "if a shadow entry is present, its tag overrides the tx timestamp & origin" do
+      tx = %Transaction{
+        changes: [
+          %Changes.NewRecord{
+            relation: shadow_of(@relation),
+            record: %{"_tag" => serialize_tag_to_pg(@transaction_tag)}
+          }
+        ]
+      }
+
+      assert %Transaction{
+               origin: "no origin",
+               commit_timestamp: ~U[2023-01-01 00:00:00Z],
+               changes: []
+             } = ShadowTableTransformation.enrich_tx_from_shadow_ops(tx)
+    end
+
+    test "if a shadow entry is present, its tags are used to fill the tags of same row op" do
+      tx = %Transaction{
+        changes: [
+          %Changes.NewRecord{
+            relation: @relation,
+            record: %{"id" => "wow"}
+          },
+          %Changes.NewRecord{
+            relation: shadow_of(@relation),
+            record: %{
+              "id" => "wow",
+              "_tag" => @pg_transaction_tag,
+              "_tags" => serialize_pg_array([@pg_transaction_tag])
+            }
+          }
+        ]
+      }
+
+      assert %Transaction{
+               origin: "no origin",
+               commit_timestamp: ~U[2023-01-01 00:00:00Z],
+               changes: [
+                 %Electric.Replication.Changes.NewRecord{
+                   relation: {"public", "test"},
+                   record: %{"id" => "wow"},
+                   tags: ["no origin@1672531200000"]
+                 }
+               ]
+             } = ShadowTableTransformation.enrich_tx_from_shadow_ops(tx)
+    end
+
+    test "if multiple shadow entry changes are present, last operation in the list is preferred" do
+      tx = %Transaction{
+        changes:
+          [
+            %Changes.NewRecord{
+              relation: @relation,
+              record: %{"id" => "wow"}
+            },
+            %Changes.NewRecord{
+              relation: shadow_of(@relation),
+              record: %{
+                "id" => "wow",
+                "_tag" => @pg_transaction_tag,
+                "_tags" => serialize_pg_array([])
+              }
+            },
+            %Changes.UpdatedRecord{
+              relation: shadow_of(@relation),
+              record: %{
+                "id" => "wow",
+                "_tag" => @pg_transaction_tag,
+                "_tags" => serialize_pg_array([@pg_transaction_tag])
+              }
+            }
+          ]
+          # to match the parsing order of logical replication producer
+          |> Enum.reverse()
+      }
+
+      assert %Transaction{
+               origin: "no origin",
+               commit_timestamp: ~U[2023-01-01 00:00:00Z],
+               changes: [
+                 %Electric.Replication.Changes.NewRecord{
+                   relation: {"public", "test"},
+                   record: %{"id" => "wow"},
+                   tags: ["no origin@1672531200000"]
+                 }
+               ]
+             } = ShadowTableTransformation.enrich_tx_from_shadow_ops(tx)
+    end
+
+    test "only the shadow row updates that match the row by PK are used" do
+      tx = %Transaction{
+        changes:
+          [
+            %Changes.NewRecord{
+              relation: @relation,
+              record: %{"id" => "wow"}
+            },
+            %Changes.NewRecord{
+              relation: shadow_of(@relation),
+              record: %{
+                "id" => "not wow",
+                "_tag" => @pg_transaction_tag,
+                "_tags" => serialize_pg_array([@pg_transaction_tag])
+              }
+            },
+            %Changes.NewRecord{
+              relation: shadow_of(@relation),
+              record: %{
+                "id" => "wow",
+                "_tag" => @pg_transaction_tag,
+                "_tags" =>
+                  serialize_pg_array([serialize_tag_to_pg({~U[2023-01-01 00:00:00Z], "correct"})])
+              }
+            }
+          ]
+          |> Enum.reverse()
+      }
+
+      assert %Transaction{
+               origin: "no origin",
+               commit_timestamp: ~U[2023-01-01 00:00:00Z],
+               changes: [
+                 %Electric.Replication.Changes.NewRecord{
+                   relation: {"public", "test"},
+                   record: %{"id" => "wow"},
+                   tags: ["correct@1672531200000"]
+                 }
+               ]
+             } = ShadowTableTransformation.enrich_tx_from_shadow_ops(tx)
+    end
+  end
+
+  defp relations() do
+    %{
+      @relation => %{
+        primary_keys: ["id"],
+        columns: [%{name: "id"}, %{name: "content"}, %{name: "content_b"}]
+      },
+      shadow_of(@relation) => %{
+        primary_keys: ["id"],
+        # The functions don't actually use this column list, so I'll save me some typing
+        columns: []
+      }
+    }
+  end
+end

--- a/components/electric/test/electric/replication/downstream_producer_test.exs
+++ b/components/electric/test/electric/replication/downstream_producer_test.exs
@@ -2,7 +2,7 @@ defmodule Electric.Replication.DownstreamProducerTest do
   use ExUnit.Case, async: true
 
   alias Electric.Replication.DownstreamProducer
-  @producer_name "producer"
+  @producer_name {:via, :gproc, {:n, :l, {DownstreamProducerMock, :tmp_producer}}}
 
   test "start_link/2 starts the producer" do
     assert {:ok, pid} = DownstreamProducer.start_link(DownstreamProducerMock, @producer_name)

--- a/components/electric/test/electric/replication/postgres/migration_consumer_test.exs
+++ b/components/electric/test/electric/replication/postgres/migration_consumer_test.exs
@@ -182,7 +182,10 @@ defmodule Electric.Replication.Postgres.MigrationConsumerTest do
       assert Enum.map(schema.tables, & &1.name.name) == [
                "something_else",
                "other_thing",
-               "yet_another_thing"
+               "yet_another_thing",
+               "shadow__public__something_else",
+               "shadow__public__other_thing",
+               "shadow__public__yet_another_thing"
              ]
     end
 

--- a/components/electric/test/electric/replication/postgres/slot_server_test.exs
+++ b/components/electric/test/electric/replication/postgres/slot_server_test.exs
@@ -102,15 +102,6 @@ defmodule Electric.Replication.Postgres.SlotServerTest do
       {:ok, server: server, send_fn: send_back_message(self()), producer: producer}
     end
 
-    test "downstream_connected? calls downstream producer to check if its connected", %{
-      server: server,
-      producer: producer
-    } do
-      refute SlotServer.downstream_connected?(server)
-      DownstreamProducerMock.set_expected_producer_connected(producer, true)
-      assert SlotServer.downstream_connected?(server)
-    end
-
     test "starts and reports current LSN", %{server: server} do
       assert %Lsn{segment: 0, offset: 1} = SlotServer.get_current_lsn(server)
     end

--- a/components/electric/test/electric/replication/postgres/slot_server_test.exs
+++ b/components/electric/test/electric/replication/postgres/slot_server_test.exs
@@ -96,14 +96,7 @@ defmodule Electric.Replication.Postgres.SlotServerTest do
 
   describe "Slot server lifecycle" do
     setup do
-      server =
-        start_supervised!(
-          Supervisor.child_spec(
-            %{id: SlotServer, start: {SlotServer, :start_link, start_args("fake_slot")}},
-            []
-          )
-        )
-
+      server = start_supervised!({SlotServer, start_args("fake_slot")})
       producer = start_supervised!({DownstreamProducerMock, producer_name()})
 
       {:ok, server: server, send_fn: send_back_message(self()), producer: producer}
@@ -175,13 +168,7 @@ defmodule Electric.Replication.Postgres.SlotServerTest do
 
   describe "Interaction with TCP server" do
     test "stops replication when process that started replication dies" do
-      server =
-        start_supervised!(
-          Supervisor.child_spec(
-            %{id: SlotServer, start: {SlotServer, :start_link, start_args("test_slot")}},
-            []
-          )
-        )
+      server = start_supervised!({SlotServer, start_args("test_slot")})
 
       _producer = start_supervised!({DownstreamProducerMock, producer_name()})
 
@@ -243,12 +230,13 @@ defmodule Electric.Replication.Postgres.SlotServerTest do
 
   defp start_args(slot) do
     [
-      [
+      conn_config: [
         origin: slot,
         replication: [subscription: slot],
         downstream: [producer: DownstreamProducerMock]
       ],
-      LogProducer.get_name(producer_name())
+      producer: LogProducer.get_name(producer_name()),
+      preprocess_change_fn: nil
     ]
   end
 

--- a/components/electric/test/electric/replication/postgres/slot_server_test.exs
+++ b/components/electric/test/electric/replication/postgres/slot_server_test.exs
@@ -236,7 +236,8 @@ defmodule Electric.Replication.Postgres.SlotServerTest do
         downstream: [producer: DownstreamProducerMock]
       ],
       producer: LogProducer.get_name(producer_name()),
-      preprocess_change_fn: nil
+      preprocess_change_fn: nil,
+      preprocess_relation_list_fn: & &1
     ]
   end
 

--- a/components/electric/test/electric/satellite/satellite_ws_test.exs
+++ b/components/electric/test/electric/satellite/satellite_ws_test.exs
@@ -1,7 +1,6 @@
 defmodule Electric.Satellite.WsServerTest do
-  alias Electric.Replication.Vaxine.LogConsumer
-  alias Electric.Replication.Vaxine.LogProducer
-  alias Electric.Replication.Vaxine
+  alias Electric.Replication.SatelliteConnector
+  alias Electric.Postgres.CachedWal.Producer
 
   alias Electric.Test.SatelliteWsClient, as: MockClient
   use Electric.Satellite.Protobuf
@@ -62,15 +61,20 @@ defmodule Electric.Satellite.WsServerTest do
   end
 
   setup_with_mocks([
-    {LogProducer, [:passthrough],
+    {SatelliteConnector, [:passthrough],
      [
-       start_link: fn a, b -> DownstreamProducerMock.start_link(a, b) end,
-       start_replication: fn a, b -> DownstreamProducerMock.start_replication(a, b) end
-     ]},
-    # [:passthrough],
-    {Vaxine, [],
-     [
-       transaction_to_vaxine: fn _tx, _pub -> :ok end
+       start_link: fn %{name: name, producer: producer} ->
+         Supervisor.start_link(
+           [
+             {Electric.DummyConsumer,
+              subscribe_to: [{producer, []}],
+              run_on_each_event: & &1.ack_fn.(),
+              name: :dummy_consumer},
+             {DownstreamProducerMock, Producer.name(name)}
+           ],
+           strategy: :one_for_one
+         )
+       end
      ]}
   ]) do
     {:ok, %{}}
@@ -277,8 +281,7 @@ defmodule Electric.Satellite.WsServerTest do
     end
   end
 
-  describe "Outgoing replication (Vaxine -> Satellite)" do
-    @describetag skip: "We'll deal with producer naming issues in the next PR"
+  describe "Outgoing replication (PG -> Satellite)" do
     test "common replication", cxt do
       with_connect([port: cxt.port, auth: cxt, id: cxt.client_id], fn conn ->
         MockClient.send_data(conn, %SatInStartReplicationReq{options: [:LAST_LSN]})
@@ -286,7 +289,7 @@ defmodule Electric.Satellite.WsServerTest do
         assert_receive {^conn, %SatInStartReplicationResp{}}, @default_wait
 
         [{client_name, _client_pid}] = active_clients()
-        mocked_producer = LogProducer.get_name(client_name)
+        mocked_producer = Producer.name(client_name)
 
         :ok =
           DownstreamProducerMock.produce(
@@ -298,7 +301,7 @@ defmodule Electric.Satellite.WsServerTest do
           %SatOpLog{ops: ops} = receive_trans()
           [%SatTransOp{op: begin} | _] = ops
           {:begin, %SatOpBegin{lsn: lsn}} = begin
-          assert :erlang.term_to_binary(n) == lsn
+          assert to_string(n) == lsn
         end)
       end)
     end
@@ -312,7 +315,7 @@ defmodule Electric.Satellite.WsServerTest do
         assert_receive {^conn, %SatInStartReplicationResp{}}, @default_wait
 
         [{client_name, _client_pid}] = active_clients()
-        mocked_producer = LogProducer.get_name(client_name)
+        mocked_producer = Producer.name(client_name)
 
         :ok =
           DownstreamProducerMock.produce(
@@ -325,7 +328,7 @@ defmodule Electric.Satellite.WsServerTest do
         assert last_received_lsn !== Kernel.inspect(limit)
 
         MockClient.send_data(conn, %SatInStartReplicationReq{lsn: last_received_lsn})
-        num_lsn = :erlang.binary_to_term(last_received_lsn)
+        num_lsn = last_received_lsn |> String.to_integer()
 
         :ok =
           DownstreamProducerMock.produce(
@@ -337,18 +340,18 @@ defmodule Electric.Satellite.WsServerTest do
           %SatOpLog{ops: ops} = receive_trans()
           [%SatTransOp{op: begin} | _] = ops
           {:begin, %SatOpBegin{lsn: lsn}} = begin
-          assert :erlang.term_to_binary(n) == lsn
+          assert to_string(n) == lsn
         end)
       end)
     end
   end
 
-  describe "Incoming replication (Satellite -> Vaxine)" do
+  describe "Incoming replication (Satellite -> PG)" do
     test "common replication", cxt do
       self = self()
 
-      with_mock Vaxine,
-        transaction_to_vaxine: fn tx, pub -> Process.send(self, {tx, pub, tx.origin}, []) end do
+      with_mock Electric.DummyConsumer, [:passthrough],
+        notify: fn _, ws_pid, events -> send(self, {:dummy_consumer, ws_pid, events}) end do
         with_connect([auth: cxt, id: cxt.client_id, port: cxt.port], fn conn ->
           MockClient.send_data(conn, %SatInStartReplicationReq{options: [:LAST_LSN]})
           assert_receive {^conn, %SatInStartReplicationResp{}}, @default_wait
@@ -399,14 +402,7 @@ defmodule Electric.Satellite.WsServerTest do
           MockClient.send_data(conn, op_log1)
           MockClient.send_data(conn, op_log2)
 
-          {tx, _pub, _origin} =
-            receive do
-              {%Transaction{} = tx, pub, origin} ->
-                {tx, pub, origin}
-            after
-              @default_wait ->
-                flunk("timeout")
-            end
+          assert_receive {:dummy_consumer, _, [%Transaction{} = tx]}
 
           assert tx.lsn == lsn
           assert tx.commit_timestamp == dt
@@ -423,6 +419,7 @@ defmodule Electric.Satellite.WsServerTest do
                  ]
 
           assert tx.origin !== ""
+
           assert_receive {^conn, %SatPingResp{lsn: ^lsn}}, @default_wait
 
           # After restart we still get same lsn
@@ -439,44 +436,34 @@ defmodule Electric.Satellite.WsServerTest do
     end
 
     test "stop subscription when consumer is not available, and restart when it's back", cxt do
-      self = self()
+      with_connect([auth: cxt, id: cxt.client_id, port: cxt.port], fn conn ->
+        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:LAST_LSN]})
+        assert_receive {^conn, %SatInStartReplicationResp{}}, @default_wait
 
-      with_mock Vaxine,
-        transaction_to_vaxine: fn tx, pub -> Process.send(self, {tx, pub, tx.origin}, []) end do
-        with_connect([auth: cxt, id: cxt.client_id, port: cxt.port], fn conn ->
-          MockClient.send_data(conn, %SatInStartReplicationReq{options: [:LAST_LSN]})
-          assert_receive {^conn, %SatInStartReplicationResp{}}, @default_wait
+        assert_receive {^conn, %SatInStartReplicationReq{}}, @default_wait
+        MockClient.send_data(conn, %SatInStartReplicationResp{})
 
-          assert_receive {^conn, %SatInStartReplicationReq{}}, @default_wait
-          MockClient.send_data(conn, %SatInStartReplicationResp{})
+        pid = Process.whereis(:dummy_consumer)
+        Process.monitor(pid)
+        Process.exit(pid, :terminate)
+        assert_receive {:DOWN, _, :process, ^pid, _}
 
-          [{client_name, _client_pid}] = active_clients()
-          {:via, :gproc, mocked_consumer} = LogConsumer.get_name(client_name)
-          pid = :gproc.whereis_name(mocked_consumer)
-          Process.monitor(pid)
-          Process.exit(pid, :terminate)
-          assert_receive {:DOWN, _, :process, ^pid, _}
-
-          assert_receive {^conn, %SatInStopReplicationReq{}}
-          assert_receive {^conn, %SatInStartReplicationReq{}}
-        end)
-      end
+        assert_receive {^conn, %SatInStopReplicationReq{}}
+        assert_receive {^conn, %SatInStartReplicationReq{}}
+      end)
     end
   end
 
   # -------------------------------------------------------------------------------
 
   defp with_connect(opts, fun) do
-    case MockClient.connect_and_spawn(opts) do
-      {:ok, pid} when is_pid(pid) ->
-        try do
-          fun.(pid)
-        after
-          assert :ok = MockClient.disconnect(pid)
-        end
+    assert {:ok, pid} = MockClient.connect_and_spawn(opts)
+    assert is_pid(pid)
 
-      error ->
-        error
+    try do
+      fun.(pid)
+    after
+      assert :ok = MockClient.disconnect(pid)
     end
   end
 

--- a/components/electric/test/support/downstream_producer_mock.ex
+++ b/components/electric/test/support/downstream_producer_mock.ex
@@ -2,7 +2,6 @@ defmodule DownstreamProducerMock do
   use GenStage
   require Logger
 
-  alias Electric.Replication.Vaxine.LogProducer
   @behaviour Electric.Replication.DownstreamProducer
 
   defmodule State do
@@ -14,14 +13,12 @@ defmodule DownstreamProducerMock do
 
   @impl true
   def start_link(name, _opts \\ %{}) do
-    GenStage.start_link(__MODULE__, name)
+    GenStage.start_link(__MODULE__, [], name: name)
   end
 
   @impl true
-  def init(name) do
-    {:via, :gproc, name1} = LogProducer.get_name(name)
-    :gproc.reg(name1)
-    {:producer, %State{}, [{:dispatcher, GenStage.DemandDispatcher}, {:buffer_size, 1}]}
+  def init(_) do
+    {:producer, %State{}, buffer_size: 1}
   end
 
   @impl true

--- a/components/electric/test/support/dummy_consumer.ex
+++ b/components/electric/test/support/dummy_consumer.ex
@@ -1,0 +1,29 @@
+defmodule Electric.DummyConsumer do
+  use GenStage
+
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
+  end
+
+  def init(opts) do
+    {:consumer,
+     %{
+       notify: Keyword.get(opts, :notify),
+       run_on_each_event: Keyword.get(opts, :run_on_each_event, & &1)
+     }, Keyword.take(opts, [:subscribe_to])}
+  end
+
+  def notify(%{notify: nil}, _, _), do: :ok
+
+  def notify(%{notify: target}, producer_pid, events) when is_pid(target) or is_atom(target),
+    do: send(target, {:dummy_consumer, producer_pid, events})
+
+  def handle_events(events, {pid, _}, state) do
+    # The __MODULE__ here is to allow mocking out the `notify` function at the place of call to "inject" test's pid
+    __MODULE__.notify(state, pid, events)
+
+    Enum.each(events, state.run_on_each_event)
+
+    {:noreply, [], state}
+  end
+end

--- a/components/electric/test/support/extension_case.ex
+++ b/components/electric/test/support/extension_case.ex
@@ -13,6 +13,7 @@ defmodule Electric.Extension.Case.Helpers do
         tx(
           fn conn ->
             migrate(conn)
+
             unquote(fun).(conn)
           end,
           cxt
@@ -46,6 +47,9 @@ defmodule Electric.Extension.Case.Helpers do
       |> Enum.map(&apply(&1, :version, []))
 
     ExUnit.Assertions.assert({:ok, ^expected_versions} = Extension.migrate(conn))
+
+    {:ok, oid} = Electric.Replication.Postgres.Client.query_oids(conn)
+    Electric.Postgres.OidDatabase.save_oids(oid)
 
     public_schema(conn, opts)
   end


### PR DESCRIPTION
This PR addresses the "write path" from Satellites to PG.

It introduces special conflict resolution triggers, that are installed and/or updated for electrified tables. The general logic is that each Satellite operation is mapped to two operations on PG: one on the shadow table, and one on the main table, with main table operation coming first in the replication stream to keep with the lock order that PG does on transactions that are done via psql. When receiving the writes from PG, we also need to "merge" shadow and main table operations (although we're interested only in one column, `_tags`, from the shadow table. We also use the `_tag` column as a transient value - it doesn't get conflict-resolved, which means that for every transaction it'll stay the same. We're using that knowledge to restore timestamp/origin of the transaction

## `electric.tag` type
This is a special timestamp, which is a pair of a wall-clock timestamp & origin. We're ordering operations by that timestamp, with `NULL` origin on Postgres ordering higher in case of equal timestamps - this is to make sure PG always wins conflicts to keep expected PG write semantics.

## Shadow table structure

Given a table:
```sql
CREATE TABLE public.entries (
    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
    content character varying(64) NOT NULL,
    content_b character varying(64)
);
```
We expect a shadow table structure:
```sql
CREATE TABLE electric.shadow__public__entries (
    _tags electric.tag[] DEFAULT ARRAY[]::electric.tag[],
    _last_modified bigint,
    _is_a_delete_operation boolean DEFAULT false,
    _tag electric.tag,
    _observed_tags electric.tag[],
    _modified_columns_bit_mask boolean[],
    _resolved boolean,
    _currently_reordering boolean,
    __reordered_content character varying(64),
    __reordered_content_b character varying(64),
    id uuid NOT NULL,
    _tag_content electric.tag,
    _tag_content_b electric.tag
);
```

Information about how the conflict resolution triggers work will be available in https://github.com/electric-sql/pg_triggers.

## Collector processes
We need to merge all transactions coming from Satellite instances into a single stream feeding PostgreSQL, while also having a GenStage subscriber to the `WsServer` process to initiate streaming from Satellite to Electric. This is solved by a pair of processes: `SatelliteCollectorConsumer` and `SatelliteCollectorProducer`. The producer here acts as a GenStage producer to feed `SlotServer`, and gets the data from an internal ETS table, acting as cache in case Postgres needs to reconnect. The consumer generates demand for the websocket process, and stores the events sent by Satellite forwards the events to the producer to be stored in the ETS and eventually fed to PostgreSQL.

Closes VAX-657, VAX-696

## Notes for review
1. This is a __second PR__ in the order, after the one that distributes PG writes to Satellite
2. E2E tests are still expected to fail, fixed in the next PR