### PR TITLE
feat(electric): Initial sync from PG

### DIFF
--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -13,7 +13,7 @@ defmodule Electric.Postgres.CachedWal.Api do
   @typedoc "Wal segment, where segment is just an abstraction term within Electric"
   @type segment :: Electric.Replication.Changes.Transaction.t()
 
-  @callback get_current_lsn() :: lsn | nil
+  @callback get_current_position() :: lsn | nil
   @callback get_wal_position_from_lsn(lsn()) :: {:ok, wal_pos()} | {:error, term()}
   @callback next_segment(wal_pos()) ::
               {:ok, segment(), new_position :: wal_pos()} | :latest | {:error, term()}
@@ -31,9 +31,9 @@ defmodule Electric.Postgres.CachedWal.Api do
 
   Returns nil if the cached WAL hasn't processed any non-empty transactions yet.
   """
-  @spec get_current_lsn(module()) :: lsn | nil
-  def get_current_lsn(module) do
-    module.get_current_lsn()
+  @spec get_current_position(module()) :: lsn | nil
+  def get_current_position(module) do
+    module.get_current_position()
   end
 
   @doc """

--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -14,7 +14,6 @@ defmodule Electric.Postgres.CachedWal.Api do
   @type segment :: Electric.Replication.Changes.Transaction.t()
 
   @callback get_current_position() :: lsn | nil
-  @callback get_wal_position_from_lsn(lsn()) :: {:ok, wal_pos()} | {:error, term()}
   @callback next_segment(wal_pos()) ::
               {:ok, segment(), new_position :: wal_pos()} | :latest | {:error, term()}
   @callback request_notification(wal_pos()) :: {:ok, await_ref()} | {:error, term()}
@@ -34,19 +33,6 @@ defmodule Electric.Postgres.CachedWal.Api do
   @spec get_current_position(module()) :: lsn | nil
   def get_current_position(module) do
     module.get_current_position()
-  end
-
-  @doc """
-  Convert a "public" LSN position to an opaque pointer for the cached WAL.
-
-  Opaque pointer can be used with this API to request further segments.
-  There could be a case where lsn is already too old (i.e. out of the cached window),
-  in which case an error will be returned, and the client is expected to query source
-  database directly to catch up.
-  """
-  @spec get_wal_position_from_lsn(module(), lsn()) :: {:ok, wal_pos()} | {:error, :lsn_too_old}
-  def get_wal_position_from_lsn(module \\ @default_adapter, lsn) do
-    module.get_wal_position_from_lsn(lsn)
   end
 
   @doc """

--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -13,7 +13,7 @@ defmodule Electric.Postgres.CachedWal.Api do
   @typedoc "Wal segment, where segment is just an abstraction term within Electric"
   @type segment :: Electric.Replication.Changes.Transaction.t()
 
-  @callback get_current_position() :: lsn | nil
+  @callback get_current_position() :: wal_pos | nil
   @callback next_segment(wal_pos()) ::
               {:ok, segment(), new_position :: wal_pos()} | :latest | {:error, term()}
   @callback request_notification(wal_pos()) :: {:ok, await_ref()} | {:error, term()}
@@ -30,7 +30,7 @@ defmodule Electric.Postgres.CachedWal.Api do
 
   Returns nil if the cached WAL hasn't processed any non-empty transactions yet.
   """
-  @spec get_current_position(module()) :: lsn | nil
+  @spec get_current_position(module()) :: wal_pos | nil
   def get_current_position(module) do
     module.get_current_position()
   end

--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -13,6 +13,7 @@ defmodule Electric.Postgres.CachedWal.Api do
   @typedoc "Wal segment, where segment is just an abstraction term within Electric"
   @type segment :: Electric.Replication.Changes.Transaction.t()
 
+  @callback get_current_lsn() :: lsn | nil
   @callback get_wal_position_from_lsn(lsn()) :: {:ok, wal_pos()} | {:error, term()}
   @callback next_segment(wal_pos()) ::
               {:ok, segment(), new_position :: wal_pos()} | :latest | {:error, term()}
@@ -24,6 +25,16 @@ defmodule Electric.Postgres.CachedWal.Api do
 
   @default_adapter Application.compile_env!(:electric, [__MODULE__, :adapter])
   def default_module(), do: @default_adapter
+
+  @doc """
+  Get the latest LSN that the cached WAL has seen.
+
+  Returns nil if the cached WAL hasn't processed any non-empty transactions yet.
+  """
+  @spec get_current_lsn(module()) :: lsn | nil
+  def get_current_lsn(module) do
+    module.get_current_lsn()
+  end
 
   @doc """
   Convert a "public" LSN position to an opaque pointer for the cached WAL.

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -46,9 +46,8 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
 
   @impl Api
   def get_current_position do
-    case :ets.last(@ets_table_name) do
-      :"$end_of_table" -> nil
-      position -> position
+    with :"$end_of_table" <- :ets.last(@ets_table_name) do
+      nil
     end
   end
 

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -53,15 +53,6 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   @impl Api
-  def get_wal_position_from_lsn(lsn) do
-    if :ets.member(@ets_table_name, lsn_to_position(lsn)) do
-      {:ok, lsn_to_position(lsn)}
-    else
-      {:error, :lsn_too_old}
-    end
-  end
-
-  @impl Api
   def next_segment(wal_pos) do
     case :ets.next(@ets_table_name, wal_pos) do
       :"$end_of_table" -> :latest

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -45,12 +45,10 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   @impl Api
-  def get_current_lsn do
-    with {:ok, table} <- ETS.Set.wrap_existing(@ets_table_name) do
-      case ETS.Set.last(table) do
-        {:ok, wal_pos} -> position_to_lsn(wal_pos)
-        {:error, :empty_table} -> nil
-      end
+  def get_current_position do
+    case :ets.last(@ets_table_name) do
+      :"$end_of_table" -> nil
+      position -> position
     end
   end
 
@@ -193,7 +191,6 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   defp lsn_to_position(lsn), do: Lsn.to_integer(lsn)
-  defp position_to_lsn(wal_pos), do: Lsn.from_integer(wal_pos)
 
   @spec trim_cache(state()) :: state()
   defp trim_cache(%{current_cache_count: current, max_cache_count: max} = state)

--- a/components/electric/lib/electric/postgres/cached_wal/producer.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/producer.ex
@@ -54,7 +54,7 @@ defmodule Electric.Postgres.CachedWal.Producer do
           {:ok, 0}
 
         {:ok, lsn} ->
-          CachedWal.Api.get_wal_position_from_lsn(state.cached_wal_module, lsn)
+          {:ok, lsn}
 
         :error ->
           {:ok, 0}

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -147,7 +147,7 @@ defmodule Electric.Postgres.Extension do
   @electrifed_index_query "SELECT id, table_id  FROM #{@electrified_index_table} ORDER BY id ASC"
 
   def electrified_tables(conn) do
-    with {:ok, _, rows} <- :epgsql.equery(conn, @electrifed_table_query, []) do
+    with {:ok, _, rows} <- :epgsql.squery(conn, @electrifed_table_query) do
       {:ok, rows}
     end
   end

--- a/components/electric/lib/electric/replication/initial_sync.ex
+++ b/components/electric/lib/electric/replication/initial_sync.ex
@@ -1,0 +1,117 @@
+defmodule Electric.Replication.InitialSync do
+  @moduledoc """
+  Initial sync of migrations and data.
+
+  This module relies on the functionality provided by Postgres.Extension to fetch all "electrified" tables, migration
+  history, etc.
+  """
+
+  alias Electric.Postgres.{CachedWal, Extension, Lsn}
+  alias Electric.Replication.Changes.{NewRecord, Transaction}
+  alias Electric.Replication.Connectors
+  alias Electric.Replication.Postgres.Client
+
+  @doc """
+  Get a list of transactions that, taken together, represent the current state of the Postgres database.
+
+  The list always starts with migration transactions, followed by a single data transaction that includes all of the
+  data the client can access.
+
+  All table data are fetched in a single REPEATABLE READ transaction to ensure consisency between all tables.
+
+  The LSN returned along with the list of transactions corresponds to the latest known cached LSN just prior to starting
+  the data fetching.
+  """
+  @spec transactions(Keyword.t(), atom) :: {Lsn.t(), [Transaction.t()]}
+  def transactions(connector_opts, cached_wal_module \\ Electric.Postgres.CachedWal.EtsBacked) do
+    # NOTE(alco): this is a placeholder to show where schema migrations will fit into the initial sync, once implemented.
+    # Here we need to fetch ALL migrations from Postgres and convert them to %Transaction{} structs. On the client,
+    # already applied migrations need to be skipped, the rest need to be applied.
+    #
+    # Since this is an idempotent action, the client shouldn't update its cached LSN before it applies the initial DATA
+    # transaction. In other words, applying any of these migration transactions on the client should leave its LSN undefined.
+    migration_transactions = []
+
+    # It's important to store the current timestamp prior to fetching the current LSN to ensure that we're not creating
+    # a transaction "in the future" relative to the LSN.
+    timestamp = DateTime.utc_now()
+
+    {data_transactions, lsn} =
+      if current_lsn = CachedWal.Api.get_current_lsn(cached_wal_module) do
+        tx = initial_data_transaction(connector_opts, current_lsn, timestamp)
+        {[{tx, current_lsn}], current_lsn}
+      else
+        {[], Lsn.from_integer(0)}
+      end
+
+    {lsn, migration_transactions ++ data_transactions}
+  end
+
+  defp initial_data_transaction(connector_opts, lsn, commit_timestamp) do
+    origin = Connectors.origin(connector_opts)
+    conn_config = Connectors.get_connection_opts(connector_opts)
+
+    Client.with_conn(conn_config, fn conn ->
+      :epgsql.with_transaction(conn, fn conn ->
+        :ok = set_repeatable_read_transaction(conn)
+        new_records = fetch_data_from_all_tables(conn, origin)
+
+        %Transaction{
+          changes: new_records,
+          # NOTE(alco): not sure to which extent the value of this timestamp can affect the client.
+          commit_timestamp: commit_timestamp,
+          origin: origin,
+          publication: Connectors.get_replication_opts(connector_opts).publication,
+          lsn: lsn,
+          ack_fn: fn -> :ok end
+        }
+      end)
+    end)
+  end
+
+  defp set_repeatable_read_transaction(conn) do
+    {:ok, [], []} =
+      :epgsql.squery(conn, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+
+    :ok
+  end
+
+  def fetch_data_from_all_tables(conn, origin) do
+    {:ok, tables} = Extension.electrified_tables(conn)
+
+    Enum.flat_map(tables, fn {_id, schema_name, table_name, _oid} ->
+      relation = {schema_name, table_name}
+      {:ok, pks} = Extension.SchemaCache.primary_keys(origin, schema_name, table_name)
+
+      sql = fetch_all_rows_from_table_query(relation, pks)
+      {:ok, cols, rows} = :epgsql.squery(conn, sql)
+
+      col_names = Enum.map(cols, fn tuple -> elem(tuple, 1) end)
+      rows_to_records(rows, col_names, relation)
+    end)
+  end
+
+  def fetch_all_rows_from_table_query({schema_name, table_name}, primary_keys) do
+    # TODO(alco): Replace the * with an explicit list of columns
+    # (once https://github.com/electric-sql/electric/pull/191 is merged).
+    "SELECT * FROM #{schema_name}.#{table_name} ORDER BY #{Enum.join(primary_keys, ",")}"
+  end
+
+  defp rows_to_records(rows, col_names, relation) when is_list(rows) do
+    for row_tuple <- rows do
+      values =
+        row_tuple
+        |> Tuple.to_list()
+        |> Enum.map(fn
+          :null -> nil
+          other -> other
+        end)
+
+      row =
+        Enum.zip(col_names, values)
+        |> Map.new()
+
+      %NewRecord{relation: relation, record: row}
+    end
+  end
+end

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -191,45 +191,34 @@ defmodule Electric.Satellite.Protocol do
   # Satellite client request replication
   def process_message(
         %SatInStartReplicationReq{lsn: client_lsn, options: opts} = msg,
-        %State{in_rep: _in_rep, out_rep: out_rep} = state
+        %State{} = state
       ) do
-    with {:ok, lsn} <- validate_lsn(client_lsn, opts) do
-      out_rep =
-        case Enum.member?(opts, :SYNC_MODE) do
-          true ->
-            sync_batch_size = msg.sync_batch_size
-            true = sync_batch_size > 0
-            %OutRep{out_rep | sync_batch_size: sync_batch_size, sync_counter: sync_batch_size}
+    case validate_lsn(client_lsn, opts) do
+      {:ok, :start_from_first} ->
+        # This particular client is connecting for the first time, so it needs to perform
+        # the initial sync before we start streaming any changes to it.
+        #
+        # Sending a message to self() here ensures that the SatInStartReplicationResp message is delivered to the
+        # client first, followed by the initial migrations and data.
+        send(self(), :perform_initial_sync_and_subscribe)
+        {[%SatInStartReplicationResp{}], state}
 
-          false ->
-            # No confirmation
-            out_rep
-        end
-
-      Logger.debug(
-        "Received start replication request lsn: #{inspect(client_lsn)} with options: #{inspect(opts)}"
-      )
-
-      Metrics.satellite_replication_event(%{started: 1})
-
-      state =
-        if lsn == :start_from_first do
-          # This particular client is connecting for the first time, so it needs to perform
-          # the initial sync before we start streaming any changes to it.
-          #
-          # Sending a message to self() here ensures that the SatInStartReplicationResp message is delivered to the
-          # client first, followed by the initial migrations and data.
-          send(self(), :perform_initial_sync_and_subscribe)
+      {:ok, lsn} ->
+        state =
           state
-        else
-          out_rep = initiate_subscription(state.client_id, lsn, out_rep)
-          %State{state | out_rep: out_rep}
-        end
+          |> maybe_setup_batch_counter(msg)
+          |> initiate_subscription(lsn)
 
-      {[%SatInStartReplicationResp{}], state}
-    else
-      error ->
-        Logger.warn("Bad start replication options: #{inspect(error)}")
+        Logger.debug(
+          "Received start replication request lsn: #{inspect(client_lsn)} with options: #{inspect(opts)}"
+        )
+
+        Metrics.satellite_replication_event(%{started: 1})
+
+        {[%SatInStartReplicationResp{}], state}
+
+      {:error, reason} ->
+        Logger.warn("Bad start replication options: #{inspect(reason)}")
         {:error, %SatErrorResp{error_type: :INVALID_REQUEST}}
     end
   end
@@ -410,9 +399,23 @@ defmodule Electric.Satellite.Protocol do
     {serialized_relations, serialized_log, out_rep}
   end
 
-  @spec initiate_subscription(String.t(), any(), OutRep.t()) :: OutRep.t()
-  def initiate_subscription(client, lsn, out_rep) do
-    {:via, :gproc, producer} = Producer.name(client)
+  defp maybe_setup_batch_counter(
+         %State{out_rep: out_rep} = state,
+         %SatInStartReplicationReq{options: opts} = msg
+       ) do
+    if :SYNC_MODE in opts do
+      sync_batch_size = msg.sync_batch_size
+      true = sync_batch_size > 0
+      out_rep = %OutRep{out_rep | sync_batch_size: sync_batch_size, sync_counter: sync_batch_size}
+      %State{state | out_rep: out_rep}
+    else
+      state
+    end
+  end
+
+  @spec initiate_subscription(State.t(), any()) :: State.t()
+  def initiate_subscription(%State{out_rep: out_rep} = state, lsn) do
+    {:via, :gproc, producer} = Producer.name(state.client_id)
     {sub_pid, _} = :gproc.await(producer, @producer_timeout)
     sub_ref = Process.monitor(sub_pid)
 
@@ -428,7 +431,8 @@ defmodule Electric.Satellite.Protocol do
     Process.send(sub_pid, msg, [])
     ask({sub_pid, sub_ref}, @producer_demand)
 
-    %OutRep{out_rep | pid: sub_pid, status: :active, stage_sub: sub_ref}
+    out_rep = %OutRep{out_rep | pid: sub_pid, status: :active, stage_sub: sub_ref}
+    %State{state | out_rep: out_rep}
   end
 
   # copied from gen_stage.ask, but form is defined as opaque there :/

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -94,7 +94,8 @@ defmodule Electric.Satellite.Protocol do
               ping_tref: nil,
               transport: nil,
               socket: nil,
-              auth_provider: nil
+              auth_provider: nil,
+              pg_connector_opts: []
 
     @type t() :: %__MODULE__{
             auth_passed: boolean(),
@@ -107,7 +108,8 @@ defmodule Electric.Satellite.Protocol do
             socket: :ranch_transport.socket(),
             in_rep: InRep.t(),
             out_rep: OutRep.t(),
-            auth_provider: Electric.Satellite.Auth.provider()
+            auth_provider: Electric.Satellite.Auth.provider(),
+            pg_connector_opts: Keyword.t()
           }
   end
 
@@ -210,8 +212,21 @@ defmodule Electric.Satellite.Protocol do
 
       Metrics.satellite_replication_event(%{started: 1})
 
-      out_rep = initiate_subscription(state.client_id, lsn, out_rep)
-      {[%SatInStartReplicationResp{}], %State{state | out_rep: out_rep}}
+      state =
+        if lsn == :start_from_first do
+          # This particular client is connecting for the first time, so it needs to perform
+          # the initial sync before we start streaming any changes to it.
+          #
+          # Sending a message to self() here ensures that the SatInStartReplicationResp message is delivered to the
+          # client first, followed by the initial migrations and data.
+          send(self(), :perform_initial_sync_and_subscribe)
+          state
+        else
+          out_rep = initiate_subscription(state.client_id, lsn, out_rep)
+          %State{state | out_rep: out_rep}
+        end
+
+      {[%SatInStartReplicationResp{}], state}
     else
       error ->
         Logger.warn("Bad start replication options: #{inspect(error)}")

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -173,8 +173,8 @@ defmodule Electric.Satellite.WsServer do
   def websocket_info(:perform_initial_sync_and_subscribe, %State{} = state) do
     {lsn, transactions} = Electric.Replication.InitialSync.transactions(state.pg_connector_opts)
     {msgs, state} = Protocol.handle_outgoing_txs(transactions, state)
-    out_rep = Protocol.initiate_subscription(state.client_id, lsn, state.out_rep)
-    {binary_frames(msgs), %State{state | out_rep: out_rep}}
+    state = Protocol.initiate_subscription(state, lsn)
+    {binary_frames(msgs), state}
   end
 
   def websocket_info(msg, state) do

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -21,6 +21,7 @@ defmodule Electric.Satellite.WsServer do
   def start_link(opts) do
     port = Keyword.fetch!(opts, :port)
     auth_provider = Keyword.fetch!(opts, :auth_provider)
+    pg_connector_opts = Keyword.fetch!(opts, :pg_connector_opts)
 
     # cowboy requires a unique name. so allow for configuration for test servers
     name = Keyword.get(opts, :name, :ws)
@@ -31,7 +32,11 @@ defmodule Electric.Satellite.WsServer do
 
     dispatch =
       :cowboy_router.compile([
-        {:_, [{"/ws", __MODULE__, [auth_provider: auth_provider]}]}
+        {:_,
+         [
+           {"/ws", __MODULE__,
+            [auth_provider: auth_provider, pg_connector_opts: pg_connector_opts]}
+         ]}
       ])
 
     :cowboy.start_clear(name, [port: port], %{
@@ -51,6 +56,7 @@ defmodule Electric.Satellite.WsServer do
     {ip, port} = :cowboy_req.peer(req)
     client = "#{:inet.ntoa(ip)}:#{port}"
     auth_provider = Keyword.fetch!(opts, :auth_provider)
+    pg_connector_opts = Keyword.fetch!(opts, :pg_connector_opts)
 
     # Add the cluster id to the logger metadata to make filtering easier in the case of global log
     # aggregation
@@ -60,7 +66,8 @@ defmodule Electric.Satellite.WsServer do
      %State{
        client: client,
        last_msg_time: :erlang.timestamp(),
-       auth_provider: auth_provider
+       auth_provider: auth_provider,
+       pg_connector_opts: pg_connector_opts
      }}
   end
 
@@ -158,6 +165,16 @@ defmodule Electric.Satellite.WsServer do
   # and as long as %InRep.sync_batch_size is enabled we need to report to Satellite.
   def websocket_info({Protocol, :lsn_report, lsn}, %State{} = state) do
     {[binary_frame(%SatPingResp{lsn: lsn})], state}
+  end
+
+  # While processing the SatInStartReplicationReq message, Protocol has determined that a new
+  # client has connected which needs to perform the initial sync of migrations and the current database state before
+  # subscribing to the replication stream.
+  def websocket_info(:perform_initial_sync_and_subscribe, %State{} = state) do
+    {lsn, transactions} = Electric.Replication.InitialSync.transactions(state.pg_connector_opts)
+    {msgs, state} = Protocol.handle_outgoing_txs(transactions, state)
+    out_rep = Protocol.initiate_subscription(state.client_id, lsn, state.out_rep)
+    {binary_frames(msgs), %State{state | out_rep: out_rep}}
   end
 
   def websocket_info(msg, state) do

--- a/components/electric/test/electric/replication/initial_sync_test.exs
+++ b/components/electric/test/electric/replication/initial_sync_test.exs
@@ -98,17 +98,15 @@ defmodule Electric.Replication.InitialSyncTest do
         ])
 
       latest_lsn = fetch_current_lsn(conn)
-
       assert :ok == wait_for_cached_lsn_to_catch_up(current_lsn)
-      zero_lsn = 0
 
       assert {^current_lsn,
               [
                 {%Transaction{
                    changes: [migration],
                    origin: "initial-sync-test",
-                   lsn: ^zero_lsn
-                 }, ^zero_lsn},
+                   lsn: 0
+                 }, 0},
                 {%Transaction{
                    changes: data_changes,
                    origin: "initial-sync-test",
@@ -178,20 +176,19 @@ defmodule Electric.Replication.InitialSyncTest do
 
       current_lsn = fetch_current_lsn(conn)
       assert :ok == wait_for_cached_lsn_to_catch_up(current_lsn)
-      zero_lsn = 0
 
       assert {^current_lsn,
               [
                 {%Transaction{
                    changes: [migration1],
                    origin: "initial-sync-test",
-                   lsn: ^zero_lsn
-                 }, ^zero_lsn},
+                   lsn: 0
+                 }, 0},
                 {%Transaction{
                    changes: [migration2],
                    origin: "initial-sync-test",
-                   lsn: ^zero_lsn
-                 }, ^zero_lsn},
+                   lsn: 0
+                 }, 0},
                 {%Transaction{
                    changes: data_changes,
                    origin: "initial-sync-test",

--- a/components/electric/test/electric/replication/initial_sync_test.exs
+++ b/components/electric/test/electric/replication/initial_sync_test.exs
@@ -1,0 +1,344 @@
+defmodule Electric.Replication.InitialSyncTest do
+  use ExUnit.Case, async: false
+
+  import Electric.Postgres.TestConnection
+  import Electric.Utils, only: [uuid4: 0]
+
+  alias Electric.Postgres.{CachedWal, Extension, Lsn, SchemaRegistry}
+  alias Electric.Replication.Changes.{NewRecord, Transaction}
+  alias Electric.Replication.{InitialSync, PostgresConnectorMng, PostgresConnector}
+
+  require Logger
+
+  @origin "initial-sync-test"
+  @cached_wal_module CachedWal.EtsBacked
+  @sleep_timeout 50
+
+  describe "transactions" do
+    setup do
+      # SchemaRegistry is a global store, so it needs to be reset when a new test database is created.
+      SchemaRegistry.clear_replicated_tables(Extension.publication_name())
+
+      # Initialize the test DB to the state which Electric can work with.
+      setup_fun = fn conn ->
+        init_sql = File.read!("dev/init.sql")
+        results = :epgsql.squery(conn, init_sql)
+        assert Enum.all?(results, fn result -> is_tuple(result) and elem(result, 0) == :ok end)
+      end
+
+      # Dropping the subscription is necessary before the test DB can be removed.
+      teardown_fun = fn conn ->
+        :epgsql.squery(
+          conn,
+          """
+          ALTER SUBSCRIPTION "#{@origin}" DISABLE;
+          ALTER SUBSCRIPTION "#{@origin}" SET (slot_name=NONE);
+          DROP SUBSCRIPTION "#{@origin}";
+          """
+        )
+      end
+
+      context = setup_test_db(setup_fun, teardown_fun)
+
+      pg_connector_opts =
+        context
+        |> pg_connector_config()
+        |> Keyword.put(:origin, @origin)
+
+      {:ok, _} = PostgresConnector.start_link(pg_connector_opts)
+      assert :ready == wait_for_postgres_initialization()
+
+      Map.put(context, :pg_connector_opts, pg_connector_opts)
+    end
+
+    test "returns the lsn=0 and no data for an empty DB", %{
+      conn: conn,
+      pg_connector_opts: pg_connector_opts
+    } do
+      # Verify that the cached LSN is not going to catch up since we don't have any electrified tables.
+      assert :error == conn |> fetch_current_lsn() |> wait_for_cached_lsn_to_catch_up()
+
+      assert {Lsn.from_integer(0), []} == InitialSync.transactions(pg_connector_opts)
+    end
+
+    test "returns the current lsn, electrified table migrations, and a single transaction containing all electrified data",
+         %{
+           conn: conn,
+           pg_connector_opts: pg_connector_opts
+         } do
+      :ok = create_users_table(conn)
+      :ok = create_documents_table(conn)
+
+      :ok = electrify_table(conn, "public.users")
+
+      [{user1_id, user1_name}, {user2_id, user2_name}] =
+        users = [{uuid4(), "Mark"}, {uuid4(), "Stan"}]
+
+      {:ok, 1} =
+        :epgsql.equery(conn, "INSERT INTO public.users VALUES ($1, $2)", [
+          user1_id,
+          user1_name
+        ])
+
+      {:ok, 1} =
+        :epgsql.equery(conn, "INSERT INTO public.users VALUES ($1, $2)", [
+          user2_id,
+          user2_name
+        ])
+
+      current_lsn = fetch_current_lsn(conn)
+
+      [{doc_id, doc_title, _}] = [{uuid4(), "Test Document", user1_id}]
+
+      {:ok, 1} =
+        :epgsql.equery(conn, "INSERT INTO public.documents VALUES ($1, $2, $3)", [
+          doc_id,
+          doc_title,
+          user1_id
+        ])
+
+      latest_lsn = fetch_current_lsn(conn)
+
+      assert :ok == wait_for_cached_lsn_to_catch_up(current_lsn)
+      zero_lsn = Lsn.from_integer(0)
+
+      assert {^current_lsn,
+              [
+                {%Transaction{
+                   changes: [migration],
+                   origin: "initial-sync-test",
+                   lsn: ^zero_lsn
+                 }, ^zero_lsn},
+                {%Transaction{
+                   changes: data_changes,
+                   origin: "initial-sync-test",
+                   lsn: ^current_lsn
+                 }, ^current_lsn}
+              ]} = InitialSync.transactions(pg_connector_opts)
+
+      migration_version = Map.fetch!(migration.record, "version")
+
+      expected_users =
+        for {id, name} <- users do
+          new_record("users", %{"id" => id, "name" => name})
+        end
+
+      migration_relation = Extension.ddl_relation()
+
+      assert %NewRecord{
+               relation: ^migration_relation,
+               record: %{
+                 "query" => "CREATE TABLE users" <> _,
+                 "version" => ^migration_version
+               },
+               tags: []
+             } = migration
+
+      assert Enum.sort(expected_users) == Enum.sort(data_changes)
+
+      # Verify that the cached WAL is not going to catch up to the latest LSN because the latest changes were made to a
+      # non-electrified table.
+      assert :error == wait_for_cached_lsn_to_catch_up(latest_lsn)
+    end
+
+    test "returns the current lsn, all electrified table migrations, and a single transaction containing all data",
+         %{
+           conn: conn,
+           pg_connector_opts: pg_connector_opts
+         } do
+      :ok = create_users_table(conn)
+      :ok = create_documents_table(conn)
+
+      :ok = electrify_table(conn, "public.users")
+      :ok = electrify_table(conn, "public.documents")
+
+      [{user1_id, user1_name}, {user2_id, user2_name}] =
+        users = [{uuid4(), "Mark"}, {uuid4(), "Stan"}]
+
+      {:ok, 1} =
+        :epgsql.equery(conn, "INSERT INTO public.users VALUES ($1, $2)", [
+          user1_id,
+          user1_name
+        ])
+
+      {:ok, 1} =
+        :epgsql.equery(conn, "INSERT INTO public.users VALUES ($1, $2)", [
+          user2_id,
+          user2_name
+        ])
+
+      [{doc_id, doc_title, _}] = documents = [{uuid4(), "Test Document", user2_id}]
+
+      {:ok, 1} =
+        :epgsql.equery(conn, "INSERT INTO public.documents VALUES ($1, $2, $3)", [
+          doc_id,
+          doc_title,
+          user2_id
+        ])
+
+      current_lsn = fetch_current_lsn(conn)
+      assert :ok == wait_for_cached_lsn_to_catch_up(current_lsn)
+      zero_lsn = Lsn.from_integer(0)
+
+      assert {^current_lsn,
+              [
+                {%Transaction{
+                   changes: [migration1],
+                   origin: "initial-sync-test",
+                   lsn: ^zero_lsn
+                 }, ^zero_lsn},
+                {%Transaction{
+                   changes: [migration2],
+                   origin: "initial-sync-test",
+                   lsn: ^zero_lsn
+                 }, ^zero_lsn},
+                {%Transaction{
+                   changes: data_changes,
+                   origin: "initial-sync-test",
+                   lsn: ^current_lsn
+                 }, ^current_lsn}
+              ]} = InitialSync.transactions(pg_connector_opts)
+
+      migration1_version = Map.fetch!(migration1.record, "version")
+      migration2_version = Map.fetch!(migration2.record, "version")
+      assert migration1_version < migration2_version
+
+      expected_users =
+        for {id, name} <- users do
+          new_record("users", %{"id" => id, "name" => name})
+        end
+
+      expected_documents =
+        for {id, title, user_id} <- documents do
+          new_record("documents", %{"id" => id, "title" => title, "user_id" => user_id})
+        end
+
+      migration_relation = Extension.ddl_relation()
+
+      assert [
+               %NewRecord{
+                 relation: ^migration_relation,
+                 record: %{
+                   "query" => "CREATE TABLE users" <> _,
+                   "version" => ^migration1_version
+                 },
+                 tags: []
+               },
+               %NewRecord{
+                 relation: ^migration_relation,
+                 record: %{
+                   "query" => "CREATE TABLE documents" <> _,
+                   "version" => ^migration2_version
+                 },
+                 tags: []
+               }
+             ] = [migration1, migration2]
+
+      assert Enum.sort(expected_users ++ expected_documents) == Enum.sort(data_changes)
+    end
+  end
+
+  ###
+  # Utility functions
+  ###
+
+  defp pg_connector_config(%{pg_config: pg_config}) do
+    [
+      producer: Electric.Replication.Postgres.LogicalReplicationProducer,
+      connection:
+        Keyword.merge(pg_config,
+          replication: 'database',
+          ssl: false
+        ),
+      replication: [
+        publication: "all_tables",
+        slot: "all_changes",
+        electric_connection: [
+          host: "host.docker.internal",
+          port: 5433,
+          dbname: "test"
+        ]
+      ],
+      downstream: [
+        producer: Electric.Replication.Vaxine.LogProducer,
+        producer_opts: [
+          vaxine_hostname: "localhost",
+          vaxine_port: 8088,
+          vaxine_connection_timeout: 5000
+        ]
+      ]
+    ]
+  end
+
+  # Wait for the Postgres connector to start. It starts the CachedWal.Producer which this test module depends on.
+  defp wait_for_postgres_initialization do
+    status = PostgresConnectorMng.status(@origin)
+
+    if status in [:init, :subscribe] do
+      Process.sleep(@sleep_timeout)
+      wait_for_postgres_initialization()
+    else
+      status
+    end
+  end
+
+  defp fetch_current_lsn(conn) do
+    {:ok, _, [{lsn_str}]} = :epgsql.squery(conn, "SELECT pg_current_wal_lsn()")
+    Lsn.from_string(lsn_str)
+  end
+
+  defp electrify_table(conn, name) do
+    {:ok, [], []} = :epgsql.squery(conn, "CALL electric.electrify('#{name}')")
+    :ok
+  end
+
+  defp create_users_table(conn) do
+    {:ok, [], []} =
+      :epgsql.squery(conn, """
+      CREATE TABLE public.users (
+        id UUID PRIMARY KEY,
+        name TEXT NOT NULL
+      )
+      """)
+
+    :ok
+  end
+
+  defp create_documents_table(conn) do
+    {:ok, [], []} =
+      :epgsql.squery(conn, """
+      CREATE TABLE public.documents (
+        id UUID PRIMARY KEY,
+        title TEXT NOT NULL,
+        user_id UUID REFERENCES users(id)
+      )
+      """)
+
+    :ok
+  end
+
+  defp new_record(relation, map) when is_binary(relation) do
+    new_record({"public", relation}, map)
+  end
+
+  defp new_record(relation, map) do
+    %NewRecord{relation: relation, record: map, tags: []}
+  end
+
+  # There's a delay between inserting some data into the DB and the moment it becomes available in the cached WAL. In
+  # order to make unit tests deterministic, we need to wait until the cached WAL implementation has seen the given
+  # LSN and only then verify the stream of changes in the cached WAL.
+  defp wait_for_cached_lsn_to_catch_up(current_lsn, num_attempts \\ 5)
+  defp wait_for_cached_lsn_to_catch_up(_current_lsn, 0), do: :error
+
+  defp wait_for_cached_lsn_to_catch_up(current_lsn, num_attempts) do
+    cached_lsn = CachedWal.Api.get_current_lsn(@cached_wal_module)
+
+    if cached_lsn && Lsn.compare(cached_lsn, current_lsn) == :eq do
+      :ok
+    else
+      Process.sleep(@sleep_timeout)
+      wait_for_cached_lsn_to_catch_up(current_lsn, num_attempts - 1)
+    end
+  end
+end

--- a/components/electric/test/electric/satellite/satellite_ws_test.exs
+++ b/components/electric/test/electric/satellite/satellite_ws_test.exs
@@ -44,7 +44,8 @@ defmodule Electric.Satellite.WsServerTest do
       Electric.Satellite.WsServer.start_link(
         name: :ws_test,
         port: port,
-        auth_provider: Auth.provider()
+        auth_provider: Auth.provider(),
+        pg_connector_opts: []
       )
 
     server_id = Electric.regional_id()

--- a/components/electric/test/support/postgres_case.ex
+++ b/components/electric/test/support/postgres_case.ex
@@ -6,10 +6,6 @@ defmodule Electric.Postgres.Case do
       alias Electric.{Postgres, Postgres.Schema, Postgres.Schema.Proto}
       alias Electric.Postgres.SQLGenerator
 
-      def esc(str) do
-        String.replace(str, "'", "''")
-      end
-
       def parse(sql) do
         Electric.Postgres.parse!(sql)
       end

--- a/e2e/tests/3.1_node_satellite_loads_local_migrations.lux
+++ b/e2e/tests/3.1_node_satellite_loads_local_migrations.lux
@@ -2,6 +2,9 @@
 [include _shared.luxinc]
 [include _satellite_macros.luxinc]
 
+# We don't actually need either Electric or PG here, but Satellite shows an error in the logs and that breaks the test
+[invoke setup]
+
 [global migrations=
     """
     [

--- a/e2e/tests/3.5_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
+++ b/e2e/tests/3.5_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
@@ -13,6 +13,8 @@
 
 [invoke electrify_table pg_1 entries]
 
+[global migration_vsn=20230704150000]
+
 # Create a new table, electrify it immediately, and then insert a few rows.
 [shell pg_1]
   [local sql=
@@ -24,7 +26,7 @@
     CALL electric.electrify('public.items');
     """]
 
-  [invoke migrate_pg 20230704150000 $sql]
+  [invoke migrate_pg $migration_vsn $sql]
 
   !INSERT INTO items(id, content) VALUES ('00000000-0000-0000-0000-000000000011', 'first item');
   ?INSERT 0 1
@@ -55,7 +57,7 @@
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"items"
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
     \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
-    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"[0-9_]+",.*,"table":\{.*,"name":"items"
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"$migration_vsn",.*,"table":\{.*,"name":"items"
 
   ## Now the client receives a single transaction containing all electrified data (4 rows)
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\

--- a/e2e/tests/3.5_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
+++ b/e2e/tests/3.5_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
@@ -1,0 +1,74 @@
+[doc When NodeJS Satellite connects to Electric for the first time, it receives all migrations in one go]
+[include _shared.luxinc]
+[include _satellite_macros.luxinc]
+
+[invoke setup]
+
+# Insert a few rows to 'entries' before electrifying it.
+[shell pg_1]
+  !INSERT INTO entries (id, content) VALUES ('00000000-0000-0000-0000-000000000001', 'first entry');
+  ?INSERT 0 1
+  !INSERT INTO entries (id, content) VALUES ('00000000-0000-0000-0000-000000000002', 'second entry');
+  ?INSERT 0 1
+
+[invoke electrify_table pg_1 entries]
+
+# Create a new table, electrify it immediately, and then insert a few rows.
+[shell pg_1]
+  [local sql=
+    """
+    CREATE TABLE public.items (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      content VARCHAR(64) NOT NULL
+    );
+    CALL electric.electrify('public.items');
+    """]
+
+  [invoke migrate_pg 20230704150000 $sql]
+
+  !INSERT INTO items(id, content) VALUES ('00000000-0000-0000-0000-000000000011', 'first item');
+  ?INSERT 0 1
+  !INSERT INTO items(id, content) VALUES ('00000000-0000-0000-0000-000000000012', 'second item');
+  ?INSERT 0 1
+
+# Start a Satellite client and verify that it gets all migrations during initial sync.
+[invoke setup_client 1 "electric_1" 5133]
+
+[shell satellite_1]
+  # Verifying it's a fresh client
+  ?applying migration: 0
+  ?no lsn retrieved from store
+  ?connecting and starting replication
+  ?no previous LSN, start replication with option FIRST_LSN
+
+  ?Sending message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationReq","lsn":\{\}
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationResp"\}
+
+  # Verifying the initial sync
+
+  ## The client first receives migrations corresponding to all electrified tables on the server
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"entries"
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"[0-9_]+",.*,"table":\{.*,"name":"entries"
+
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"items"
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"[0-9_]+",.*,"table":\{.*,"name":"items"
+
+  ## Now the client receives a single transaction containing all electrified data (4 rows)
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","insert":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","insert":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","insert":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","insert":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","commit":\{.*\}\}
+
+  ?apply incoming changes for LSN: \d+
+
+  -Received message
+
+[cleanup]
+  [invoke teardown]

--- a/e2e/tests/3.5_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
+++ b/e2e/tests/3.5_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
@@ -48,16 +48,21 @@
 
   # Verifying the initial sync
 
-  ## The client first receives migrations corresponding to all electrified tables on the server
-  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"entries"
-  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
-    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
-    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"[0-9_]+",.*,"table":\{.*,"name":"entries"
-
+  ## The client first receives migrations corresponding to all electrified tables on the server.
+  ##
+  ## We know the order in which the migrations are streamed because
+  ##
+  ##   a) the version of the migration that created the "items" table is static.
+  ##   b) the version of the migration that created the "entries" table is the e2e test suite start time.
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"items"
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
     \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
     \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"$migration_vsn",.*,"table":\{.*,"name":"items"
+
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"entries"
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"[0-9_]+",.*,"table":\{.*,"name":"entries"
 
   ## Now the client receives a single transaction containing all electrified data (4 rows)
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\

--- a/e2e/tests/compose.yaml
+++ b/e2e/tests/compose.yaml
@@ -1,5 +1,5 @@
 # Run using `docker compose -f databases.yaml up`.
-version: '3.7'
+version: "3.7"
 
 services:
   pg_1:
@@ -7,7 +7,7 @@ services:
       file: ../services_templates.yaml
       service: postgresql
     ports:
-      - "54321:5432"
+      - "54320:5432"
 
   electric_1:
     extends:


### PR DESCRIPTION
Closes VAX-669.

This PR implements a "full initial sync" that sends the migration history as well as all data from electrified tables to a fresh client in one go. Subsequent improvements are coming up as defined by VAX-732, VAX-733, and VAX-734.

Note that the commits authored by Ilia in this PR overlap with the changes made in https://github.com/electric-sql/electric/pull/205. Once that PR is merged, I will rebase mine on top.