### PR TITLE
feat(CLI): watch flag for generate command

### DIFF
--- a/clients/typescript/src/cli/migrations/handler.ts
+++ b/clients/typescript/src/cli/migrations/handler.ts
@@ -1,3 +1,4 @@
+import * as z from 'zod'
 import { generate, defaultOptions, GeneratorOptions } from './migrate'
 
 type GeneratorArgs = Partial<GeneratorOptions>
@@ -14,6 +15,11 @@ type GeneratorArgs = Partial<GeneratorOptions>
  *     Optional argument to specify where to write the generated client.
  *     If this argument is not provided the generated client is written
  *     to `./src/generated/client`.
+ *  - `--watch [<pollingInterval>]`
+ *     Optional flag to specify that the migrations should be watched.
+ *     When new migrations are found, the client is rebuilt automatically.
+ *     You can provide an optional polling interval in milliseconds,
+ *     which is how often we should poll Electric for new migrations.
  * @param args Arguments passed to the generate command.
  */
 export async function handleGenerate(...args: string[]) {
@@ -26,7 +32,7 @@ export async function handleGenerate(...args: string[]) {
   await generate(opts)
 }
 
-function parseGenerateArgs(args: string[]): GeneratorArgs {
+export function parseGenerateArgs(args: string[]): GeneratorArgs {
   const genArgs: GeneratorArgs = {}
   let flag: keyof GeneratorArgs | undefined = undefined
   for (const arg of args) {
@@ -36,12 +42,28 @@ function parseGenerateArgs(args: string[]): GeneratorArgs {
     else {
       // the value for the flag
       if (flag === 'watch') {
-        console.error(`--watch flag does not accept arguments`)
-        process.exit(9)
+        // the --watch flag is special because
+        // it accepts an optional argument
+        // which is the polling interval in ms
+        genArgs[flag] = true
+        try {
+          genArgs.pollingInterval = z
+            .number()
+            .int()
+            .positive()
+            .parse(parseInt(arg))
+        } catch (_e) {
+          console.error(
+            `The provided argument to --watch is not a valid polling interval. Should be a time in milliseconds (i.e. a positive integer).`
+          )
+          process.exit(9)
+        }
       } else {
-        genArgs[flag] = arg
-        flag = undefined
+        genArgs[
+          flag as keyof Omit<GeneratorArgs, 'watch' | 'pollingInterval'>
+        ] = arg
       }
+      flag = undefined
     }
   }
 

--- a/clients/typescript/src/cli/migrations/handler.ts
+++ b/clients/typescript/src/cli/migrations/handler.ts
@@ -35,17 +35,26 @@ function parseGenerateArgs(args: string[]): GeneratorArgs {
       flag = checkFlag(arg)
     else {
       // the value for the flag
-      genArgs[flag] = arg
-      flag = undefined
+      if (flag === 'watch') {
+        console.error(`--watch flag does not accept arguments`)
+        process.exit(9)
+      } else {
+        genArgs[flag] = arg
+        flag = undefined
+      }
     }
   }
 
   if (flag) {
-    // a flag was provided but without argument
-    console.error(
-      `Missing argument for flag --${flag} passed to generate command.`
-    )
-    process.exit(9)
+    if (flag === 'watch') {
+      genArgs[flag] = true
+    } else {
+      // a flag that expects an argument was provided but the argument is missing
+      console.error(
+        `Missing argument for flag --${flag} passed to generate command.`
+      )
+      process.exit(9)
+    }
   }
 
   // prepend protocol if not provided in service url
@@ -54,15 +63,15 @@ function parseGenerateArgs(args: string[]): GeneratorArgs {
   }
 
   return genArgs
+}
 
-  function checkFlag(flag: string): keyof GeneratorArgs {
-    const supportedFlags = ['--service', '--out']
-    if (supportedFlags.includes(flag))
-      return flag.substring(2) as keyof GeneratorArgs
-    // substring removes the double dash --
-    else {
-      console.error(`Unsupported flag '${flag}' passed to generate command.`)
-      process.exit(9)
-    }
+function checkFlag(flag: string): keyof GeneratorArgs {
+  const supportedFlags = ['--service', '--out', '--watch']
+  if (supportedFlags.includes(flag))
+    return flag.substring(2) as keyof GeneratorArgs
+  // substring removes the double dash --
+  else {
+    console.error(`Unsupported flag '${flag}' passed to generate command.`)
+    process.exit(9)
   }
 }

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -15,6 +15,7 @@ export const defaultOptions = {
   service: process.env.ELECTRIC_URL ?? 'http://localhost:5050',
   out: path.join(appRoot, 'src/generated/client'),
   watch: false,
+  pollingInterval: 1000, // in ms
 }
 
 export type GeneratorOptions = typeof defaultOptions
@@ -50,7 +51,7 @@ export async function generate(opts: GeneratorOptions) {
  * when there are new migrations.
  */
 async function watchMigrations(opts: Omit<GeneratorOptions, 'watch'>) {
-  const pollingInterval = 1000 // ms
+  const pollingInterval = opts.pollingInterval
   const pollMigrations = async () => {
     // Create a unique temporary folder in which to save
     // intermediate files without risking collisions

--- a/clients/typescript/test/cli/migrations/handler.test.ts
+++ b/clients/typescript/test/cli/migrations/handler.test.ts
@@ -1,0 +1,52 @@
+import test from 'ava'
+import { parseGenerateArgs } from '../../../src/cli/migrations/handler'
+
+test('generate accepts url to Electric endpoint', (t) => {
+  const url = 'http://127.0.0.1:5050'
+  const opts = parseGenerateArgs(['--service', url])
+  t.deepEqual(opts, {
+    service: url,
+  })
+})
+
+test('generate accepts url without http prefix to Electric endpoint', (t) => {
+  const url = '127.0.0.1:5050'
+  const opts = parseGenerateArgs(['--service', url])
+  t.deepEqual(opts, {
+    service: 'http://' + url,
+  })
+})
+
+test('generate accepts output path', (t) => {
+  const path = './src'
+  const opts = parseGenerateArgs(['--out', path])
+  t.deepEqual(opts, {
+    out: path,
+  })
+})
+
+test('generate accepts watch flag without polling interval', (t) => {
+  const opts = parseGenerateArgs(['--watch'])
+  t.deepEqual(opts, {
+    watch: true,
+  })
+})
+
+test('generate accepts watch flag with polling interval', (t) => {
+  const opts = parseGenerateArgs(['--watch', '2000'])
+  t.deepEqual(opts, {
+    watch: true,
+    pollingInterval: 2000,
+  })
+})
+
+test('generate accepts several flags', (t) => {
+  const url = 'http://127.0.0.1:5050'
+  const path = './src'
+  const opts = parseGenerateArgs(['--service', url, '--out', path])
+
+  t.deepEqual(opts, {
+    service: url,
+    out: path,
+  })
+})

--- a/components/electric/lib/electric/plug/migrations.ex
+++ b/components/electric/lib/electric/plug/migrations.ex
@@ -22,12 +22,15 @@ defmodule Electric.Plug.Migrations do
     conn = fetch_query_params(conn)
 
     with {:ok, dialect} <- get_dialect(conn),
-         {:ok, migrations} <- get_migrations(conn),
+         {:ok, migrations} when migrations != [] <- get_migrations(conn),
          {:ok, body} <- migrations_zipfile(migrations, dialect) do
       conn
       |> put_resp_content_type("application/zip", nil)
       |> send_resp(200, body)
     else
+      {:ok, []} ->
+        send_resp(conn, 204, "")
+
       {:error, reason} ->
         json(conn, 403, %{error: to_string(reason)})
     end


### PR DESCRIPTION
This PR introduces an optional `--watch` flag for the CLI's `generate` command.
When running with the `--watch` flag, the process periodically polls Electric's migration endpoint for new migrations. Use it as follows:
```sh
npx electric-sql generate --watch
```

We modified the Electric http endpoint to return a 204 if there are no new migrations.