### PR TITLE
feat(electric): Detect when a client is outside of the cached WAL window

### DIFF
--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -45,6 +45,14 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   @impl Api
+  def lsn_in_cached_window?(client_wal_pos) do
+    case :ets.first(@ets_table_name) do
+      :"$end_of_table" -> false
+      position -> position <= client_wal_pos
+    end
+  end
+
+  @impl Api
   def get_current_position do
     with :"$end_of_table" <- :ets.last(@ets_table_name) do
       nil

--- a/components/electric/test/electric/replication/initial_sync_test.exs
+++ b/components/electric/test/electric/replication/initial_sync_test.exs
@@ -11,7 +11,6 @@ defmodule Electric.Replication.InitialSyncTest do
   require Logger
 
   @origin "initial-sync-test"
-  @cached_wal_module CachedWal.EtsBacked
   @sleep_timeout 50
 
   describe "migrations_since" do
@@ -216,7 +215,7 @@ defmodule Electric.Replication.InitialSyncTest do
     after
       @sleep_timeout * 10 ->
         flunk(
-          "Timed out while waiting to see #{current_lsn} in CachedWal, with it's position being #{inspect(CachedWal.Api.get_current_position(@cached_wal_module))}"
+          "Timed out while waiting to see #{current_lsn} in CachedWal, with it's position being #{inspect(CachedWal.Api.get_current_position())}"
         )
     end
   end


### PR DESCRIPTION
Closes VAX-735.

These changes are based on https://github.com/electric-sql/electric/pull/225 so that PR needs to be merged first.

This PR implement a check to see if the client's LSN falls into the cached WAL window. If not, `BEHIND_WINDOW` error is returned in `SatInStartReplicationResp` which then results in the client dropping all of its subscriptions, as implemented in https://github.com/electric-sql/electric/commit/bc9589702906926af334164c1ab7f7035f95dec3.

Remaining work:

  * ~[ ] Write an e2e test that verifies the client discards its subscriptions when it receives the `BEHIND_WINDOW` error.~ I couldn't implement the ability to stop a client and write its LSN in e2e tests. Another way to write the e2e test would be to configure CachedWal.EtsBacked.max_cache_count per test but that would also require a bit of hairy setup code.
    We can get by with having separate client-side and server-side tests for it for now.
  * [x] Wait for https://github.com/electric-sql/electric/pull/225 to get merged and rebase this PR on top of main.