### PR TITLE
feat(DAL): method to sync shapes

### DIFF
--- a/clients/typescript/src/client/input/findInput.ts
+++ b/clients/typescript/src/client/input/findInput.ts
@@ -1,5 +1,3 @@
-//export type SelectInput<T> = { [field in keyof T]?: boolean }
-
 import {
   NarrowInclude,
   NarrowOrderBy,

--- a/clients/typescript/src/client/input/syncInput.ts
+++ b/clients/typescript/src/client/input/syncInput.ts
@@ -1,0 +1,3 @@
+export interface SyncInput<Include> {
+  include?: Include
+}

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -11,6 +11,8 @@ import { DeleteInput, DeleteManyInput } from '../input/deleteInput'
 import flow from 'lodash.flow'
 import { InvalidArgumentError } from '../validation/errors/invalidArgumentError'
 import * as z from 'zod'
+import { shapeManager } from './shapes'
+import Log from 'loglevel'
 
 const squelPostgres = squel.useFlavour('postgres')
 
@@ -127,6 +129,9 @@ export class Builder {
 
     const whereObject = i.where
     const identificationFields = this.getFields(whereObject, idRequired)
+
+    if (!shapeManager.isSynced(this._tableName))
+      Log.warn("Reading from unsynced table " + this._tableName)
 
     const query = squelPostgres.select().from(this._tableName) // specify from which table to select
     // only select the fields provided in `i.select` and the ones in `i.where`

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -131,7 +131,7 @@ export class Builder {
     const identificationFields = this.getFields(whereObject, idRequired)
 
     if (!shapeManager.isSynced(this._tableName))
-      Log.warn("Reading from unsynced table " + this._tableName)
+      Log.warn('Reading from unsynced table ' + this._tableName)
 
     const query = squelPostgres.select().from(this._tableName) // specify from which table to select
     // only select the fields provided in `i.select` and the ones in `i.where`

--- a/clients/typescript/src/client/model/model.ts
+++ b/clients/typescript/src/client/model/model.ts
@@ -7,6 +7,7 @@ import { UpsertInput } from '../input/upsertInput'
 import { DeleteInput, DeleteManyInput } from '../input/deleteInput'
 import { QualifiedTablename } from '../../util/tablename'
 import { HKT, Kind } from '../util/hkt'
+import { SyncInput } from '../input/syncInput'
 
 /**
  * Interface that is implemented by Electric clients.
@@ -22,6 +23,8 @@ export interface Model<
   ScalarFieldEnum,
   GetPayload extends HKT
 > {
+  sync<T extends SyncInput<Include>>(i?: T): Promise<void>
+
   /**
    * Creates a unique record in the DB.
    * @param i - The record to create.

--- a/clients/typescript/src/client/model/schema.ts
+++ b/clients/typescript/src/client/model/schema.ts
@@ -186,6 +186,12 @@ export class DbSchema<T extends TableSchemas> {
     return this.getRelations(table).find((r) => r.relationName === relation)!
   }
 
+  getRelatedTable(table: TableName, field: FieldName): TableName {
+    const relationName = this.getRelationName(table, field)
+    const relation = this.getRelation(table, relationName)
+    return relation.relatedTable
+  }
+
   // Profile.post <-> Post.profile (from: profileId, to: id)
   getRelations(table: TableName): Relation[] {
     return this.extendedTables[table].relations

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -56,7 +56,7 @@ export class ShapeManagerMock extends ShapeManager {
 
   override async sync(shape: Shape): Promise<void> {
     // Do not contact the server but directly store the synced tables
-    shape.tables.forEach(tbl => this.syncedTables.add(tbl))
+    shape.tables.forEach((tbl) => this.syncedTables.add(tbl))
     // method returns and promise will resolve
     // as if the server acknowledged the subscription
   }

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -1,0 +1,66 @@
+import { Satellite } from '../../satellite'
+
+export type TableName = string
+
+export type Shape = {
+  tables: TableName[]
+}
+
+interface IShapeManager {
+  init(satellite: Satellite): void
+  sync(shape: Shape): Promise<void>
+  isSynced(table: TableName): boolean
+}
+
+class ShapeManager implements IShapeManager {
+  protected syncedTables: Set<TableName>
+  protected satellite?: Satellite
+
+  constructor() {
+    this.syncedTables = new Set()
+  }
+
+  init(satellite: Satellite) {
+    this.satellite = satellite
+  }
+
+  async sync(shape: Shape): Promise<void> {
+    if (this.satellite === undefined)
+      throw new Error(
+        'Shape cannot be synced because the `ShapeManager` is not yet initialised.'
+      )
+
+    // Convert the shape to the format expected by the Satellite process
+    const shapeDef = {
+      selects: shape.tables.map((tbl) => {
+        return {
+          tablename: tbl,
+        }
+      }),
+    }
+    await this.satellite.subscribe([shapeDef])
+
+    // Now that the subscription is active we can store the synced tables
+    shape.tables.forEach(this.syncedTables.add)
+  }
+
+  isSynced(table: TableName): boolean {
+    return this.syncedTables.has(table)
+  }
+}
+
+export class ShapeManagerMock extends ShapeManager {
+  constructor() {
+    super()
+  }
+
+  override async sync(shape: Shape): Promise<void> {
+    // Do not contact the server but directly store the synced tables
+    shape.tables.forEach(tbl => this.syncedTables.add(tbl))
+    // method returns and promise will resolve
+    // as if the server acknowledged the subscription
+  }
+}
+
+// a shape manager singleton
+export const shapeManager = new ShapeManager()

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -162,7 +162,7 @@ export class Table<
     return includedTables
   }
 
-  async syncShape<T extends SyncInput<Include>>(i?: T): Promise<void> {
+  async sync<T extends SyncInput<Include>>(i?: T): Promise<void> {
     const validatedInput = this.syncSchema.parse(i ?? {})
     // Recursively go over the included fields
     // and for each field store its table

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -9,6 +9,7 @@ import { setLogLevel } from '../util/debug'
 import { ElectricNamespace } from './namespace'
 import { ElectricClient } from '../client/model/client'
 import { DbSchema } from '../client/model/schema'
+import { shapeManager } from '../client/model/shapes'
 
 export { ElectricNamespace }
 
@@ -46,9 +47,8 @@ export const electrify = async <DB extends DbSchema<any>>(
   const registry = opts?.registry || globalRegistry
 
   const electric = new ElectricNamespace(adapter, notifier)
-  const namespace = ElectricClient.create(dbDescription, electric) // extends the electric namespace with a `dal` property for the data access library
 
-  await registry.ensureStarted(
+  const satellite = await registry.ensureStarted(
     dbName,
     adapter,
     migrator,
@@ -57,5 +57,8 @@ export const electrify = async <DB extends DbSchema<any>>(
     configWithDefaults
   )
 
+  // initialize the shape manager
+  shapeManager.init(satellite)
+  const namespace = ElectricClient.create(dbDescription, electric) // extends the electric namespace with a `dal` property for the data access library
   return namespace
 }

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -1,6 +1,9 @@
 import test from 'ava'
 import { Builder } from '../../../src/client/model/builder'
-import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+import {
+  shapeManager,
+  ShapeManagerMock,
+} from '../../../src/client/model/shapes'
 import { ZodError } from 'zod'
 
 const tbl = new Builder('Post', ['id', 'title', 'contents', 'nbr'])
@@ -11,7 +14,7 @@ const tbl = new Builder('Post', ['id', 'title', 'contents', 'nbr'])
 Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
 
 // Sync all shapes such that we don't get warnings on every query
-shapeManager.sync({ tables: [ 'Post' ] })
+shapeManager.sync({ tables: ['Post'] })
 
 const post1 = {
   id: 'i1',

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -1,8 +1,17 @@
 import test from 'ava'
 import { Builder } from '../../../src/client/model/builder'
+import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
 import { ZodError } from 'zod'
 
 const tbl = new Builder('Post', ['id', 'title', 'contents', 'nbr'])
+
+// Use a mocked shape manager for these tests
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
+
+// Sync all shapes such that we don't get warnings on every query
+shapeManager.sync({ tables: [ 'Post' ] })
 
 const post1 = {
   id: 'i1',

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -93,7 +93,7 @@ test.serial('Upsert query issues warning if table is not synced', async (t) => {
 
 test.serial('Read queries no longer warn after syncing the table', async (t) => {
   t.assert(log.length === 0)
-  await Post.syncShape() // syncs only the Post table
+  await Post.sync() // syncs only the Post table
   await Post.findMany() // now we can query it
   t.assert(log.length === 0)
 })

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -3,7 +3,10 @@ import Log from 'loglevel'
 import Database from 'better-sqlite3'
 import { dbSchema, Post } from '../generated'
 import { electrify } from '../../../src/drivers/better-sqlite3'
-import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+import {
+  shapeManager,
+  ShapeManagerMock,
+} from '../../../src/client/model/shapes'
 
 // Modify `loglevel` to store the logged messages
 // based on "Writing plugins" in https://github.com/pimterry/loglevel
@@ -15,7 +18,7 @@ Log.methodFactory = function (methodName, logLevel, loggerName) {
 
   return function (message) {
     log.push(message)
-    if (message !== "Reading from unsynced table Post") {
+    if (message !== 'Reading from unsynced table Post') {
       rawMethod(message)
     }
   }
@@ -51,10 +54,7 @@ test.beforeEach(init)
 test.serial('Read queries issue warning if table is not synced', async (t) => {
   t.assert(log.length === 0)
   await Post.findMany()
-  t.deepEqual(
-    log,
-    [ "Reading from unsynced table Post" ]
-  )
+  t.deepEqual(log, ['Reading from unsynced table Post'])
 })
 
 test.serial('Upsert query issues warning if table is not synced', async (t) => {
@@ -82,18 +82,18 @@ test.serial('Upsert query issues warning if table is not synced', async (t) => {
   // because upsert first tries to find the record
   // and then reads the created/updated record
   // and both of those reads will raise the warning
-  t.deepEqual(
-    log,
-    [
-      "Reading from unsynced table Post",
-      "Reading from unsynced table Post"
-    ]
-  )
+  t.deepEqual(log, [
+    'Reading from unsynced table Post',
+    'Reading from unsynced table Post',
+  ])
 })
 
-test.serial('Read queries no longer warn after syncing the table', async (t) => {
-  t.assert(log.length === 0)
-  await Post.sync() // syncs only the Post table
-  await Post.findMany() // now we can query it
-  t.assert(log.length === 0)
-})
+test.serial(
+  'Read queries no longer warn after syncing the table',
+  async (t) => {
+    t.assert(log.length === 0)
+    await Post.sync() // syncs only the Post table
+    await Post.findMany() // now we can query it
+    t.assert(log.length === 0)
+  }
+)

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -1,0 +1,99 @@
+import test from 'ava'
+import Log from 'loglevel'
+import Database from 'better-sqlite3'
+import { dbSchema, Post } from '../generated'
+import { electrify } from '../../../src/drivers/better-sqlite3'
+import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+
+// Modify `loglevel` to store the logged messages
+// based on "Writing plugins" in https://github.com/pimterry/loglevel
+type LoggedMsg = string
+let log: Array<LoggedMsg> = []
+const originalFactory = Log.methodFactory
+Log.methodFactory = function (methodName, logLevel, loggerName) {
+  var rawMethod = originalFactory(methodName, logLevel, loggerName)
+
+  return function (message) {
+    log.push(message)
+    if (message !== "Reading from unsynced table Post") {
+      rawMethod(message)
+    }
+  }
+}
+Log.setLevel(Log.getLevel()) // Be sure to call setLevel method in order to apply plugin
+
+// Use a mocked shape manager for these tests
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
+
+const db = new Database(':memory:')
+const config = {
+  auth: {
+    token: 'test-token',
+  },
+}
+const electric = await electrify(db, dbSchema, config)
+const Post = electric.db.Post
+
+// Create a Post table in the DB first
+function init() {
+  db.exec('DROP TABLE IF EXISTS Post')
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS Post('id' int PRIMARY KEY, 'title' varchar, 'contents' varchar, 'nbr' int, 'authorId' int);"
+  )
+
+  log = []
+}
+
+test.beforeEach(init)
+
+test.serial('Read queries issue warning if table is not synced', async (t) => {
+  t.assert(log.length === 0)
+  await Post.findMany()
+  t.deepEqual(
+    log,
+    [ "Reading from unsynced table Post" ]
+  )
+})
+
+test.serial('Upsert query issues warning if table is not synced', async (t) => {
+  t.assert(log.length === 0)
+
+  const newPost = {
+    id: 4,
+    title: 't4',
+    contents: 'c4',
+    nbr: 5,
+    authorId: 1,
+  }
+
+  const updatePost = { title: 'Modified title' }
+
+  await Post.upsert({
+    create: newPost,
+    update: updatePost,
+    where: {
+      id: newPost.id,
+    },
+  })
+
+  // The log contains the warning twice
+  // because upsert first tries to find the record
+  // and then reads the created/updated record
+  // and both of those reads will raise the warning
+  t.deepEqual(
+    log,
+    [
+      "Reading from unsynced table Post",
+      "Reading from unsynced table Post"
+    ]
+  )
+})
+
+test.serial('Read queries no longer warn after syncing the table', async (t) => {
+  t.assert(log.length === 0)
+  await Post.syncShape() // syncs only the Post table
+  await Post.findMany() // now we can query it
+  t.assert(log.length === 0)
+})

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -27,7 +27,7 @@ const userTable = electric.db.User
 Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
 
 // Sync all shapes such that we don't get warnings on every query
-await userTable.syncShape()
+await userTable.sync()
 
 test.beforeEach((_t) => {
   db.exec('DROP TABLE IF EXISTS Post')

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -4,6 +4,7 @@ import { electrify } from '../../../src/drivers/better-sqlite3'
 import { dbSchema } from '../generated'
 import { ZodError } from 'zod'
 import { InvalidArgumentError } from '../../../src/client/validation/errors/invalidArgumentError'
+import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
 
 /*
  * This test file is meant to check that the DAL
@@ -19,6 +20,14 @@ const electric = await electrify(db, dbSchema, {
 })
 //const postTable = electric.db.Post
 const userTable = electric.db.User
+
+// Use a mocked shape manager for this test
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
+
+// Sync all shapes such that we don't get warnings on every query
+await userTable.syncShape()
 
 test.beforeEach((_t) => {
   db.exec('DROP TABLE IF EXISTS Post')

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -4,7 +4,10 @@ import { electrify } from '../../../src/drivers/better-sqlite3'
 import { dbSchema } from '../generated'
 import { ZodError } from 'zod'
 import { InvalidArgumentError } from '../../../src/client/validation/errors/invalidArgumentError'
-import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+import {
+  shapeManager,
+  ShapeManagerMock,
+} from '../../../src/client/model/shapes'
 
 /*
  * This test file is meant to check that the DAL

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -36,9 +36,9 @@ const profileTable = electric.db.Profile
 Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
 
 // Sync all shapes such that we don't get warnings on every query
-await postTable.syncShape()
-await userTable.syncShape()
-await profileTable.syncShape()
+await postTable.sync()
+await userTable.sync()
+await profileTable.sync()
 
 const post1 = {
   id: 1,

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -10,6 +10,7 @@ import {
   _RECORD_NOT_FOUND_,
 } from '../../../src/client/validation/errors/messages'
 import { dbSchema, Post } from '../generated'
+import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
 
 const db = new Database(':memory:')
 const electric = await electrify(db, dbSchema, {
@@ -28,6 +29,16 @@ const tbl = electric.db.Post
 const postTable = tbl
 const userTable = electric.db.User
 const profileTable = electric.db.Profile
+
+// Use a mocked shape manager for this test
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
+
+// Sync all shapes such that we don't get warnings on every query
+await postTable.syncShape()
+await userTable.syncShape()
+await profileTable.syncShape()
 
 const post1 = {
   id: 1,

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -10,7 +10,10 @@ import {
   _RECORD_NOT_FOUND_,
 } from '../../../src/client/validation/errors/messages'
 import { dbSchema, Post } from '../generated'
-import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+import {
+  shapeManager,
+  ShapeManagerMock,
+} from '../../../src/client/model/shapes'
 
 const db = new Database(':memory:')
 const electric = await electrify(db, dbSchema, {

--- a/clients/typescript/test/client/notifications.test.ts
+++ b/clients/typescript/test/client/notifications.test.ts
@@ -17,7 +17,7 @@ const config = {
 }
 
 const { notifier, adapter, db } = await electrify(conn, dbSchema, config)
-await db.Items.syncShape() // sync the Items table
+await db.Items.sync() // sync the Items table
 
 async function runAndCheckNotifications(f: () => Promise<void>) {
   let notifications = 0

--- a/clients/typescript/test/client/notifications.test.ts
+++ b/clients/typescript/test/client/notifications.test.ts
@@ -2,6 +2,12 @@ import test from 'ava'
 import Database from 'better-sqlite3'
 import { electrify } from '../../src/drivers/better-sqlite3'
 import { dbSchema } from './generated'
+import { shapeManager, ShapeManagerMock } from '../../src/client/model/shapes'
+
+// Use a mocked shape manager for these tests
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
 
 const conn = new Database(':memory:')
 const config = {
@@ -11,6 +17,7 @@ const config = {
 }
 
 const { notifier, adapter, db } = await electrify(conn, dbSchema, config)
+await db.Items.syncShape() // sync the Items table
 
 async function runAndCheckNotifications(f: () => Promise<void>) {
   let notifications = 0


### PR DESCRIPTION
This PR extends the DAL with a `sync` method that allows developers to sync shapes.
Example usage:

```
await db.Profile.sync() // syncs the `Profile` table
// syncs the `Users` table and the related `Post` table
await db.User.sync({
  include: {
    Post: true
  }
})
```

The implementation introduces a shape manager which is a global object that keeps track of all synchronized shapes.
The shape manager is global such that it does not need to be passed into every table.