### PR TITLE
fix(electric): Initial sync of migrations

### DIFF
--- a/components/electric/lib/electric/plug/migrations.ex
+++ b/components/electric/lib/electric/plug/migrations.ex
@@ -75,7 +75,7 @@ defmodule Electric.Plug.Migrations do
 
   defp migrations_zipfile(migrations, dialect) do
     file_list =
-      Enum.flat_map(migrations, fn {version, schema, stmts} ->
+      Enum.flat_map(migrations, fn {_txid, _txts, version, schema, stmts} ->
         ops = translate_stmts(version, schema, stmts, dialect)
 
         sql =

--- a/components/electric/lib/electric/replication/initial_sync.ex
+++ b/components/electric/lib/electric/replication/initial_sync.ex
@@ -6,7 +6,6 @@ defmodule Electric.Replication.InitialSync do
   history, etc.
   """
 
-  alias Electric.Postgres.Extension.SchemaCache
   alias Electric.Replication.Shapes
   alias Electric.Postgres.{CachedWal, Extension, Lsn}
   alias Electric.Replication.Changes.{NewRecord, Transaction}
@@ -24,36 +23,32 @@ defmodule Electric.Replication.InitialSync do
   The LSN returned along with the list of transactions corresponds to the latest known cached LSN just prior to starting
   the data fetching.
   """
-  @spec transactions(Keyword.t()) :: {term(), [Transaction.t()]}
-  def transactions(connector_opts) do
-    # It's important to store the current timestamp prior to fetching the cached LSN to ensure that we're not creating
-    # a transaction "in the future" relative to the LSN.
-    timestamp = DateTime.utc_now()
+  @spec migrations_since(nil | String.t(), Keyword.t()) :: [Transaction.t()]
+  def migrations_since(version, connector_opts) do
+    {:ok, migrations} = Extension.SchemaCache.migration_history(version)
+    origin = Connectors.origin(connector_opts)
+    publication = Connectors.get_replication_opts(connector_opts).publication
 
-    migration_transactions = migration_transactions(connector_opts, timestamp)
-
-    current_position = CachedWal.Api.get_current_position()
-
-    current_lsn = current_position || 0
-    txs_with_lsn = Enum.map(migration_transactions, &with_lsn/1)
-
-    {current_lsn, txs_with_lsn}
-  end
-
-  defp migration_transactions(connector_opts, commit_timestamp) do
-    {:ok, migrations} = Extension.SchemaCache.migration_history(nil)
-    lsn = 0
-
-    for {version, _schema, stmts} <- migrations do
+    for {txid, txts, version, _schema, stmts} <- migrations do
       records =
         for sql <- stmts do
           %NewRecord{
             relation: Extension.ddl_relation(),
-            record: %{"version" => version, "query" => sql, "txid" => "", "txts" => ""}
+            record: %{"version" => version, "query" => sql, "txid" => txid, "txts" => txts}
           }
         end
 
-      build_transaction(connector_opts, records, lsn, commit_timestamp)
+      transaction = %Transaction{
+        xid: txid,
+        changes: records,
+        commit_timestamp: txts,
+        origin: origin,
+        publication: publication,
+        lsn: 0,
+        ack_fn: fn -> :ok end
+      }
+
+      {transaction, transaction.lsn}
     end
   end
 
@@ -89,7 +84,7 @@ defmodule Electric.Replication.InitialSync do
       ) do
     Client.with_conn(Connectors.get_connection_opts(opts), fn conn ->
       origin = Connectors.origin(opts)
-      {:ok, _, schema} = SchemaCache.load(origin)
+      {:ok, _, schema} = Extension.SchemaCache.load(origin)
 
       :epgsql.with_transaction(
         conn,
@@ -125,20 +120,4 @@ defmodule Electric.Replication.InitialSync do
       )
     end)
   end
-
-  defp build_transaction(connector_opts, changes, lsn, commit_timestamp) do
-    publication = Connectors.get_replication_opts(connector_opts).publication
-
-    %Transaction{
-      changes: changes,
-      # NOTE(alco): not sure to which extent the value of this timestamp can affect the client.
-      commit_timestamp: commit_timestamp,
-      origin: Connectors.origin(connector_opts),
-      publication: publication,
-      lsn: lsn,
-      ack_fn: fn -> :ok end
-    }
-  end
-
-  defp with_lsn(%Transaction{lsn: lsn} = tx), do: {tx, lsn}
 end

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -1,6 +1,7 @@
 defmodule Electric.Satellite.WsServer do
   require Pathex
   alias Electric.Utils
+  alias Electric.Postgres.CachedWal
   alias Electric.Replication.InitialSync
   alias Electric.Satellite.Protocol
   alias Electric.Satellite.Protocol.{State, InRep, OutRep}
@@ -183,9 +184,12 @@ defmodule Electric.Satellite.WsServer do
   # client has connected which needs to perform the initial sync of migrations and the current database state before
   # subscribing to the replication stream.
   def websocket_info(:perform_initial_sync_and_subscribe, %State{} = state) do
-    {lsn, transactions} = Electric.Replication.InitialSync.transactions(state.pg_connector_opts)
-    {msgs, state} = Protocol.handle_outgoing_txs(transactions, state)
+    migration_transactions = InitialSync.migrations_since(nil, state.pg_connector_opts)
+    {msgs, state} = Protocol.handle_outgoing_txs(migration_transactions, state)
+
+    lsn = CachedWal.Api.get_current_position()
     state = Protocol.initiate_subscription(state, lsn)
+
     {binary_frames(msgs), state}
   end
 

--- a/components/electric/test/electric/plug_test.exs
+++ b/components/electric/test/electric/plug_test.exs
@@ -39,6 +39,7 @@ defmodule Electric.PlugTest do
           end)
 
         assert :ok = Extension.save_schema(conn, version, schema, stmts)
+        assert :ok = save_migration_version(conn, version)
         schema
       end)
 

--- a/components/electric/test/electric/postgres/extension_test.exs
+++ b/components/electric/test/electric/postgres/extension_test.exs
@@ -199,16 +199,17 @@ defmodule Electric.Postgres.ExtensionTest do
           end)
 
         assert :ok = Extension.save_schema(conn, version, schema, stmts)
+        assert :ok = save_migration_version(conn, version)
         schema
       end)
 
     assert {:ok, versions} = Extension.migration_history(conn)
 
-    assert migrations == Enum.map(versions, fn {v, _, s} -> {v, s} end)
+    assert migrations == Enum.map(versions, fn {_txid, _txts, v, _, s} -> {v, s} end)
 
     assert {:ok, versions} = Extension.migration_history(conn, "0002")
 
-    versions = Enum.map(versions, fn {v, _, s} -> {v, s} end)
+    versions = Enum.map(versions, fn {_txid, _txts, v, _, s} -> {v, s} end)
 
     assert versions == Enum.slice(migrations, 2..-1)
   end

--- a/components/electric/test/support/extension_case.ex
+++ b/components/electric/test/support/extension_case.ex
@@ -61,6 +61,17 @@ defmodule Electric.Extension.Case.Helpers do
     {:ok, _, _} = :epgsql.squery(conn, "SET SEARCH_PATH = #{search_path};")
     conn
   end
+
+  def save_migration_version(conn, version) do
+    {:ok, 1} =
+      :epgsql.equery(conn, "INSERT INTO electric.migration_versions VALUES ($1, $2, $3)", [
+        String.to_integer(version),
+        Extension.encode_epgsql_timestamp(DateTime.utc_now()),
+        version
+      ])
+
+    :ok
+  end
 end
 
 defmodule Electric.Extension.Case do

--- a/components/electric/test/support/schema_loader.ex
+++ b/components/electric/test/support/schema_loader.ex
@@ -37,7 +37,16 @@ defmodule Electric.Postgres.MockSchemaLoader do
   @impl true
   def save({versions, opts}, version, schema, stmts) do
     notify(opts, {:save, version, schema, stmts})
-    {:ok, {[{version, schema, stmts} | versions], opts}}
+
+    migration = {
+      String.to_integer(version),
+      DateTime.utc_now(),
+      version,
+      schema,
+      stmts
+    }
+
+    {:ok, {[migration | versions], opts}}
   end
 
   @impl true

--- a/e2e/tests/3.5_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
+++ b/e2e/tests/3.5_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
@@ -13,25 +13,26 @@
 
 [invoke electrify_table pg_1 entries]
 
-[global migration_vsn=20230704150000]
-
 # Create a new table, electrify it immediately, and then insert a few rows.
 [shell pg_1]
   [local sql=
     """
-    CREATE TABLE public.items (
+    BEGIN;
+
+    CREATE TABLE items (
       id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
       content VARCHAR(64) NOT NULL
     );
     CALL electric.electrify('public.items');
+
+    INSERT INTO items(id, content) VALUES ('00000000-0000-0000-0000-000000000011', 'first item');
+    INSERT INTO items(id, content) VALUES ('00000000-0000-0000-0000-000000000012', 'second item');
+
+    COMMIT;
     """]
 
-  [invoke migrate_pg $migration_vsn $sql]
-
-  !INSERT INTO items(id, content) VALUES ('00000000-0000-0000-0000-000000000011', 'first item');
-  ?INSERT 0 1
-  !INSERT INTO items(id, content) VALUES ('00000000-0000-0000-0000-000000000012', 'second item');
-  ?INSERT 0 1
+  !$sql
+  ?COMMIT
 
 # Start a Satellite client and verify that it gets all migrations during initial sync.
 [invoke setup_client 1 "electric_1" 5133]
@@ -46,24 +47,16 @@
   ?Sending message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationReq","lsn":\{\}
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationResp"\}
 
-  # Verifying the initial sync
-
-  ## The client first receives migrations corresponding to all electrified tables on the server.
-  ##
-  ## We know the order in which the migrations are streamed because
-  ##
-  ##   a) the version of the migration that created the "items" table is static.
-  ##   b) the version of the migration that created the "entries" table is the e2e test suite start time.
-  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"items"
-  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
-    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
-    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"$migration_vsn",.*,"table":\{.*,"name":"items"
-
+  # Verifying the initial sync. The client receives migrations corresponding to all electrified tables on the server.
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"entries"
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
     \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
     \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"[0-9_]+",.*,"table":\{.*,"name":"entries"
 
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"items"
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"[0-9_]+",.*,"table":\{.*,"name":"items"
 
 [cleanup]
   [invoke teardown]


### PR DESCRIPTION
Closes VAX-734.

These changes are based on https://github.com/electric-sql/electric/pull/222 so that PR needs to be merged first.

This PR fixes the issue described in the ticket as follows:

  * `Extension.migration_history()` is updated to include `txid` and `txts` of migration transactions in its return value.
  * Those `txid` and `txts` are included in the `Transaction` structs created by InitialSync.
  * The `txid` of the most recent migration is stored in WsServer's state.
  * When WsServer receives a transaction from CachedWal.Producer, it checks whether it is a migration and whether its `xid` is greater than the `txid` stored in its state. If not, the transaction is dropped because it was already included in the initial sync previously.

NOTE: If a newly connected client doesn't do initial sync (i.e. its a resuming client), the `txid` in WsServer's state will be 0, so every subsequent migration transaction will be delivered to the client.

Remaining work:

  * ~[ ] Write an e2e test that verifies migration transaction flitering.~ Addressed separately in https://github.com/electric-sql/electric/pull/231.
  * [x] Wait for #222 to get merged and rebase this PR on top of `main`.
