### PR TITLE
feat(satellite,electric): Rely on client-supplied schema version to push only missing transactions to the client

### DIFF
--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -127,6 +127,8 @@ export interface SatInStartReplicationReq {
   syncBatchSize: number;
   /** the subscriptions identifiers the client wants to resume subscription */
   subscriptionIds: string[];
+  /** The version of the most recent migration seen by the client. */
+  schemaVersion?: string | undefined;
 }
 
 export enum SatInStartReplicationReq_Option {
@@ -946,6 +948,7 @@ function createBaseSatInStartReplicationReq(): SatInStartReplicationReq {
     options: [],
     syncBatchSize: 0,
     subscriptionIds: [],
+    schemaVersion: undefined,
   };
 }
 
@@ -966,6 +969,9 @@ export const SatInStartReplicationReq = {
     }
     for (const v of message.subscriptionIds) {
       writer.uint32(34).string(v!);
+    }
+    if (message.schemaVersion !== undefined) {
+      writer.uint32(42).string(message.schemaVersion);
     }
     return writer;
   },
@@ -1015,6 +1021,13 @@ export const SatInStartReplicationReq = {
 
           message.subscriptionIds.push(reader.string());
           continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
+          message.schemaVersion = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1034,6 +1047,7 @@ export const SatInStartReplicationReq = {
     message.options = object.options?.map((e) => e) || [];
     message.syncBatchSize = object.syncBatchSize ?? 0;
     message.subscriptionIds = object.subscriptionIds?.map((e) => e) || [];
+    message.schemaVersion = object.schemaVersion ?? undefined;
     return message;
   },
 };

--- a/clients/typescript/src/migrators/bundle.ts
+++ b/clients/typescript/src/migrators/bundle.ts
@@ -87,8 +87,11 @@ export class BundleMigrator implements Migrator {
       return
     }
 
+    // The hard-coded version '0' below corresponds to the version of the internal migration defined in `schema.ts`.
+    // We're ignoring it because this function is supposed to return the application schema version.
     const schemaVersion = `
       SELECT version FROM ${this.tableName}
+        WHERE version != '0'
         ORDER BY version DESC
         LIMIT 1
     `

--- a/clients/typescript/src/migrators/index.ts
+++ b/clients/typescript/src/migrators/index.ts
@@ -30,6 +30,7 @@ export interface Migrator {
   up(): Promise<number>
   apply(migration: StmtMigration): Promise<void>
   applyIfNotAlready(migration: StmtMigration): Promise<boolean>
+  querySchemaVersion(): Promise<string | undefined>
 }
 
 export interface MigratorOptions {

--- a/clients/typescript/src/migrators/mock.ts
+++ b/clients/typescript/src/migrators/mock.ts
@@ -12,4 +12,8 @@ export class MockMigrator implements Migrator {
   async applyIfNotAlready(_: StmtMigration): Promise<boolean> {
     return true
   }
+
+  async querySchemaVersion(): Promise<string | undefined> {
+    return
+  }
 }

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -303,7 +303,11 @@ export class SatelliteClient extends EventEmitter implements Client {
     return !this.socketHandler
   }
 
-  startReplication(lsn?: LSN, subscriptionIds?: string[]): Promise<void> {
+  startReplication(
+    lsn?: LSN,
+    schemaVersion?: string,
+    subscriptionIds?: string[]
+  ): Promise<void> {
     if (this.inbound.isReplicating !== ReplicationStatus.STOPPED) {
       return Promise.reject(
         new SatelliteError(
@@ -328,6 +332,7 @@ export class SatelliteClient extends EventEmitter implements Client {
       }
       request = SatInStartReplicationReq.fromPartial({
         options: [SatInStartReplicationReq_Option.FIRST_LSN],
+        schemaVersion,
       })
     } else {
       Log.info(`starting replication with lsn: ${base64.fromBytes(lsn)}`)

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -75,7 +75,11 @@ export interface Client {
   close(): Promise<void>
   authenticate(authState: AuthState): Promise<AuthResponse>
   isClosed(): boolean
-  startReplication(lsn?: LSN, subscriptionIds?: string[]): Promise<void>
+  startReplication(
+    lsn?: LSN,
+    schemaVersion?: string,
+    subscriptionIds?: string[]
+  ): Promise<void>
   stopReplication(): Promise<void>
   subscribeToRelations(callback: (relation: Relation) => void): void
   subscribeToTransactions(

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -479,7 +479,7 @@ export class SatelliteProcess implements Satellite {
 
   async _connectAndStartReplication(
     opts?: SatelliteReplicationOptions
-  ): Promise<void | SatelliteError> {
+  ): Promise<void> {
     Log.info(`connecting and starting replication`)
 
     if (!this._authState) {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -491,12 +491,18 @@ export class SatelliteProcess implements Satellite {
       await this.client.connect()
       await this.client.authenticate(authState)
 
+      const schemaVersion = await this.migrator.querySchemaVersion()
+
       // Fetch the subscription IDs that were fulfilled
       // such that we can resume and inform Electric
       // about fulfilled subscriptions
       const subscriptionIds = this.subscriptions.getFulfilledSubscriptions()
 
-      await this.client.startReplication(this._lsn, subscriptionIds)
+      await this.client.startReplication(
+        this._lsn,
+        schemaVersion,
+        subscriptionIds
+      )
     } catch (error: any) {
       if (
         error.code == SatelliteErrorCode.BEHIND_WINDOW &&

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -208,6 +208,28 @@ test.serial('replication start sends FIRST_LSN', async (t) => {
   })
 })
 
+test.serial('replication start sends schemaVersion', async (t) => {
+  await connectAndAuth(t.context)
+  const { client, server } = t.context
+
+  return new Promise(async (resolve) => {
+    server.nextResponses([
+      (data?: Buffer) => {
+        const msgType = data!.readUInt8()
+        t.assert(
+          msgType == getTypeFromString(Proto.SatInStartReplicationReq.$type)
+        )
+
+        const req = decode(data!) as Proto.SatInStartReplicationReq
+        t.assert(req.schemaVersion === '20230711')
+
+        resolve()
+      },
+    ])
+    await client.startReplication(new Uint8Array(), '20230711')
+  })
+})
+
 test.serial('replication start failure', async (t) => {
   await connectAndAuth(t.context)
   const { client, server } = t.context

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -51,13 +51,13 @@ defmodule Electric.Postgres.Extension do
   defp migration_history_query(after_version) do
     where_clause =
       if after_version do
-        ~s|WHERE #{@version_table}.txid > (SELECT txid FROM #{@version_table} WHERE version = $1)|
+        "WHERE #{@version_table}.txid > (SELECT txid FROM #{@version_table} WHERE version = $1)"
       else
         # Dummy condition just to keep the $1 parameter in the query.
-        ~s|WHERE $1::text IS NULL|
+        "WHERE $1::text IS NULL"
       end
 
-    ~s"""
+    """
     SELECT
       #{@version_table}.txid,
       #{@version_table}.txts,

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -157,6 +157,13 @@ defmodule Electric.Postgres.Extension do
     end
   end
 
+  def known_migration_version?(conn, version) when is_binary(version) do
+    case :epgsql.equery(conn, "SELECT 1 FROM #{@version_table} WHERE version = $1", [version]) do
+      {:ok, [_], [{"t"}]} -> true
+      _ -> false
+    end
+  end
+
   defp load_migrations(rows) do
     Enum.map(rows, fn {txid_str, txts_tuple, version, schema_json, stmts} ->
       txid = String.to_integer(txid_str)

--- a/components/electric/lib/electric/postgres/extension/schema_loader.ex
+++ b/components/electric/lib/electric/postgres/extension/schema_loader.ex
@@ -22,6 +22,7 @@ defmodule Electric.Postgres.Extension.SchemaLoader do
   @callback primary_keys(state(), schema(), name()) :: pk_result()
   @callback refresh_subscription(state(), name()) :: :ok | {:error, term()}
   @callback migration_history(state(), version() | nil) :: {:ok, [migration()]} | {:error, term()}
+  @callback known_migration_version?(state(), version()) :: boolean
 
   @default_backend {__MODULE__.Epgsql, []}
 
@@ -69,6 +70,10 @@ defmodule Electric.Postgres.Extension.SchemaLoader do
 
   def migration_history({module, state}, version) do
     module.migration_history(state, version)
+  end
+
+  def known_migration_version?({module, state}, version) do
+    module.known_migration_version?(state, version)
   end
 end
 
@@ -180,5 +185,10 @@ defmodule Electric.Postgres.Extension.SchemaLoader.Epgsql do
   @impl true
   def migration_history(conn, version) do
     Extension.migration_history(conn, version)
+  end
+
+  @impl true
+  def known_migration_version?(conn, version) do
+    Extension.known_migration_version?(conn, version)
   end
 end

--- a/components/electric/lib/electric/replication/initial_sync.ex
+++ b/components/electric/lib/electric/replication/initial_sync.ex
@@ -27,7 +27,7 @@ defmodule Electric.Replication.InitialSync do
   def migrations_since(version, connector_opts) do
     {:ok, migrations} = Extension.SchemaCache.migration_history(version)
     origin = Connectors.origin(connector_opts)
-    publication = Connectors.get_replication_opts(connector_opts).publication
+    publication = Extension.publication_name()
 
     for {txid, txts, version, _schema, stmts} <- migrations do
       records =

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -288,52 +288,14 @@ defmodule Electric.Satellite.Protocol do
     )
 
     case validate_lsn(client_lsn, opts) do
-      {:ok, :start_from_first} ->
-        if msg.subscription_ids != [] do
-          {:error,
-           %SatInStartReplicationResp{
-             err: %SatInStartReplicationResp.ReplicationError{
-               code: :INVALID_POSITION,
-               message: "Cannot continue subscriptions while also starting from first LSN"
-             }
-           }}
-        else
-          # This particular client is connecting for the first time, so it needs to perform
-          # the initial sync before we start streaming any changes to it.
-          #
-          # Sending a message to self() here ensures that the SatInStartReplicationResp message is delivered to the
-          # client first, followed by the initial migrations and data.
-          send(self(), {:perform_initial_sync_and_subscribe, msg})
-          {[%SatInStartReplicationResp{}], state}
-        end
-
-      {:ok, :start_from_latest} ->
-        state = subscribe_client_to_replication_stream(state, msg, :start_from_latest)
-        {[%SatInStartReplicationResp{}], state}
-
       {:ok, lsn} ->
-        if CachedWal.Api.lsn_in_cached_window?(lsn) do
-          with {:ok, state} <- restore_subscriptions(msg.subscription_ids, state) do
-            state = subscribe_client_to_replication_stream(state, msg, lsn)
-            {[%SatInStartReplicationResp{}], state}
-          end
-        else
-          # Once the client is outside the WAL window, we are assuming the client will re-establish subscriptions, so we'll discard them
-          SubscriptionManager.delete_all_subscriptions(state.client_id)
-          error = %SatInStartReplicationResp.ReplicationError{code: :BEHIND_WINDOW}
-          {[%SatInStartReplicationResp{err: error}], state}
-        end
+        handle_start_replication_request(msg, lsn, state)
 
       {:error, reason} ->
         Logger.warning("Bad start replication options: #{inspect(reason)}")
 
         {:error,
-         %SatInStartReplicationResp{
-           err: %SatInStartReplicationResp.ReplicationError{
-             code: :CODE_UNSPECIFIED,
-             message: "Could not parse replication options"
-           }
-         }}
+         start_replication_error(:CODE_UNSPECIFIED, "Could not parse replication options")}
     end
   end
 
@@ -528,6 +490,49 @@ defmodule Electric.Satellite.Protocol do
 
   def process_message(_, %State{}) do
     {:error, %SatErrorResp{error_type: :INVALID_REQUEST}}
+  end
+
+  defp handle_start_replication_request(%{subscription_ids: []} = msg, :start_from_first, state) do
+    # This particular client is connecting for the first time, so it needs to perform
+    # the initial sync before we start streaming any changes to it.
+    #
+    # Sending a message to self() here ensures that the SatInStartReplicationResp message is delivered to the
+    # client first, followed by the initial migrations and data.
+    send(self(), {:perform_initial_sync_and_subscribe, msg})
+    {%SatInStartReplicationResp{}, state}
+  end
+
+  defp handle_start_replication_request(_msg, :start_from_first, _state) do
+    {:error,
+     start_replication_error(
+       :INVALID_POSITION,
+       "Cannot continue subscriptions while also starting from first LSN"
+     )}
+  end
+
+  defp handle_start_replication_request(msg, :start_from_latest, state) do
+    state = subscribe_client_to_replication_stream(state, msg, :start_from_latest)
+    {%SatInStartReplicationResp{}, state}
+  end
+
+  defp handle_start_replication_request(msg, lsn, state) do
+    if CachedWal.Api.lsn_in_cached_window?(lsn) do
+      case restore_subscriptions(msg.subscription_ids, state) do
+        {:ok, state} ->
+          state = subscribe_client_to_replication_stream(state, msg, lsn)
+          {%SatInStartReplicationResp{}, state}
+
+        {:error, bad_id} ->
+          {:error,
+           start_replication_error(:SUBSCRIPTION_NOT_FOUND, "Unknown subscription: #{bad_id}")}
+      end
+    else
+      # Once the client is outside the WAL window, we are assuming the client will re-establish subscriptions, so we'll discard them
+      SubscriptionManager.delete_all_subscriptions(state.client_id)
+
+      {:error,
+       start_replication_error(:BEHIND_WINDOW, "Cannot catch up to the server's current state")}
+    end
   end
 
   def send_downstream(%InRep{} = in_rep) do
@@ -835,20 +840,19 @@ defmodule Electric.Satellite.Protocol do
     Enum.reduce_while(subscription_ids, {:ok, state}, fn id, {:ok, state} ->
       case SubscriptionManager.fetch_subscription(state.client_id, id) do
         {:ok, results} ->
-          {:cont, {:ok, Map.update!(state, :subscriptions, &Map.put(&1, id, results))}}
+          state = Map.update!(state, :subscriptions, &Map.put(&1, id, results))
+          {:cont, {:ok, state}}
 
         :error ->
           id = if String.length(id) > 128, do: String.slice(id, 0..125) <> "...", else: id
-
-          {:halt,
-           {:error,
-            %SatInStartReplicationResp{
-              err: %SatInStartReplicationResp.ReplicationError{
-                code: :SUBSCRIPTION_NOT_FOUND,
-                message: "Unknown subscription: #{id}"
-              }
-            }}}
+          {:halt, {:error, id}}
       end
     end)
+  end
+
+  defp start_replication_error(code, message) do
+    %SatInStartReplicationResp{
+      err: %SatInStartReplicationResp.ReplicationError{code: code, message: message}
+    }
   end
 end

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -189,7 +189,8 @@ defmodule Electric.Satellite.WsServer do
   # client has connected which needs to perform the initial sync of migrations and the current database state before
   # subscribing to the replication stream.
   def websocket_info({:perform_initial_sync_and_subscribe, msg}, %State{} = state) do
-    migration_transactions = InitialSync.migrations_since(nil, state.pg_connector_opts)
+    %SatInStartReplicationReq{schema_version: schema_version} = msg
+    migration_transactions = InitialSync.migrations_since(schema_version, state.pg_connector_opts)
     {msgs, state} = Protocol.handle_outgoing_txs(migration_transactions, state)
 
     lsn = CachedWal.Api.get_current_position()

--- a/components/electric/test/electric/replication/shapes_test.exs
+++ b/components/electric/test/electric/replication/shapes_test.exs
@@ -33,11 +33,14 @@ defmodule Electric.Replication.ShapesTest do
 
   describe "validate_requests/2" do
     setup do
-      start_schema_cache("""
-      CREATE TABLE public.entries (id uuid PRIMARY KEY);
-      CREATE TABLE public.parent (id uuid PRIMARY KEY);
-      CREATE TABLE public.child (id uuid PRIMARY KEY, parent_id uuid REFERENCES public.parent(id) );
-      """)
+      start_schema_cache("test_publication", [
+        {"2023071300",
+         """
+         CREATE TABLE public.entries (id uuid PRIMARY KEY);
+         CREATE TABLE public.parent (id uuid PRIMARY KEY);
+         CREATE TABLE public.child (id uuid PRIMARY KEY, parent_id uuid REFERENCES public.parent(id) );
+         """}
+      ])
     end
 
     test "validates correct Protobuf requests", %{origin: origin} do

--- a/components/electric/test/support/schema_loader.ex
+++ b/components/electric/test/support/schema_loader.ex
@@ -96,6 +96,13 @@ defmodule Electric.Postgres.MockSchemaLoader do
     {:ok, migrations}
   end
 
+  @impl true
+  def known_migration_version?({versions, opts}, version) do
+    notify(opts, {:known_migration_version?, version})
+
+    version in versions
+  end
+
   defp notify(%{parent: parent}, msg) when is_pid(parent) do
     send(parent, {__MODULE__, msg})
   end

--- a/components/electric/test/support/schema_loader.ex
+++ b/components/electric/test/support/schema_loader.ex
@@ -23,14 +23,14 @@ defmodule Electric.Postgres.MockSchemaLoader do
 
   @impl true
   def load({versions, opts}, version) do
-    case List.keyfind(versions, version, 0, nil) do
-      {^version, schema} ->
+    case List.keyfind(versions, version, 2, nil) do
+      {_txid, _txts, ^version, schema, _stmts} ->
         notify(opts, {:load, version, schema})
 
         {:ok, version, schema}
 
       nil ->
-        {:error, "schema version #{version} not found"}
+        {:error, "schema version not found: #{version}"}
     end
   end
 
@@ -90,7 +90,9 @@ defmodule Electric.Postgres.MockSchemaLoader do
           versions
 
         version when is_binary(version) ->
-          for {v, schema, stmts} <- versions, v > version, do: {v, schema, stmts}
+          for {txid, txts, v, schema, stmts} <- versions,
+              v > version,
+              do: {txid, txts, v, schema, stmts}
       end
 
     {:ok, migrations}
@@ -100,7 +102,7 @@ defmodule Electric.Postgres.MockSchemaLoader do
   def known_migration_version?({versions, opts}, version) do
     notify(opts, {:known_migration_version?, version})
 
-    version in versions
+    not is_nil(List.keyfind(versions, version, 2))
   end
 
   defp notify(%{parent: parent}, msg) when is_pid(parent) do

--- a/components/electric/test/support/setup_helpers.ex
+++ b/components/electric/test/support/setup_helpers.ex
@@ -10,32 +10,64 @@ defmodule ElectricTest.SetupHelpers do
   Starts SchemaCache process with a given origin, and
   immediately fills it from given SQL.
   """
-  def start_schema_cache(origin \\ "fake_origin", sql) do
+  def start_schema_cache(origin \\ "fake_origin", publication, sql_migrations) do
     start_supervised!(
       {Electric.Postgres.Extension.SchemaCache,
        {[origin: origin], [backend: {Electric.Postgres.MockSchemaLoader, parent: self()}]}}
     )
 
     schema =
-      Electric.Postgres.Schema.new()
-      |> Electric.Postgres.Schema.update(sql,
-        oid_loader: fn type, schema, name ->
-          {:ok, Enum.join(["#{type}", schema, name], ".") |> :erlang.phash2(50_000)}
-        end
-      )
+      Enum.reduce(sql_migrations, Electric.Postgres.Schema.new(), fn {_version, sql}, schema ->
+        Electric.Postgres.Schema.update(schema, sql,
+          oid_loader: fn type, pg_schema, table_name ->
+            {:ok, Enum.join(["#{type}", pg_schema, table_name], ".") |> :erlang.phash2(50_000)}
+          end
+        )
+      end)
 
-    # Split statements on a unquoted semicolon. In "real" code we receive a list of statements
-    # but here we need to split them up for ease of use in tests
-    stmts =
-      Regex.split(~r/((?:[^;'"]*(?:"(?:\\.|[^"])*"|'(?:\\.|[^'])*')[^;'"]*)+)|;/, sql, trim: true)
+    Enum.each(schema.tables, fn table ->
+      %{name: %{schema: pg_schema, name: table_name}} = table
 
-    assert {:ok, _} =
-             Electric.Postgres.Extension.SchemaCache.save(
-               origin,
-               "20230101",
-               schema,
-               stmts
-             )
+      pks =
+        Enum.find_value(table.constraints, fn
+          %{constraint: {:primary, %{keys: pks}}} -> pks
+          _ -> nil
+        end)
+
+      Electric.Postgres.SchemaRegistry.put_replicated_tables(publication, [
+        %{
+          schema: pg_schema,
+          name: table_name,
+          oid: table.oid,
+          replica_identity: :all_columns,
+          primary_keys: pks
+        }
+      ])
+
+      columns =
+        Enum.map(table.columns, fn column ->
+          %{name: column.name, type: :varchar, type_modifier: -1, part_of_identity?: true}
+        end)
+
+      Electric.Postgres.SchemaRegistry.put_table_columns({pg_schema, table_name}, columns)
+    end)
+
+    Enum.each(sql_migrations, fn {version, sql} ->
+      # Split statements on a unquoted semicolon. In "real" code we receive a list of statements
+      # but here we need to split them up for ease of use in tests
+      stmts =
+        Regex.split(~r/((?:[^;'"]*(?:"(?:\\.|[^"])*"|'(?:\\.|[^'])*')[^;'"]*)+)|;/, sql,
+          trim: true
+        )
+
+      assert {:ok, _} =
+               Electric.Postgres.Extension.SchemaCache.save(
+                 origin,
+                 version,
+                 schema,
+                 stmts
+               )
+    end)
 
     [origin: origin]
   end

--- a/e2e/tests/3.1_node_satellite_loads_local_migrations.lux
+++ b/e2e/tests/3.1_node_satellite_loads_local_migrations.lux
@@ -2,9 +2,6 @@
 [include _shared.luxinc]
 [include _satellite_macros.luxinc]
 
-# We don't actually need either Electric or PG here, but Satellite shows an error in the logs and that breaks the test
-[invoke setup]
-
 [global migrations=
     """
     [

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -123,6 +123,9 @@ message SatInStartReplicationReq {
     // the subscriptions identifiers the client wants to resume subscription    
     repeated string subscription_ids = 4;
 
+    // The version of the most recent migration seen by the client.
+    optional string schema_version = 5;
+
     // Note:
     // - a client might resume replication only for a subset of previous subscriptions 
     // in case the application cancelled some subscriptions while disconnected from the


### PR DESCRIPTION
Closes VAX-733.

These changes are based on https://github.com/electric-sql/electric/pull/218 so that PR needs to be merged first.

This PR updates the client to include its local `schemaVersion` in the `SatInStartReplicationReq` message which the server then uses to only fetch migrations that the client is missing.

Remaining work:

  * ~[ ] Write an e2e test that verifies the server only sends migrations that the client doesn't already have.~ It seemed like a good idea initially, but after struggling with implementing proper setup for discarding client's local state, I've abandoned it. Currently, this functionality is covered with TypeScript tests on the client and Elixir tests on the server.
  * [x] Wait for https://github.com/electric-sql/electric/pull/218 to get merged and rebase this PR on top of main.