### PR TITLE
chore(electric): Remove unused replication config options

### DIFF
--- a/components/electric/config/dev.exs
+++ b/components/electric/config/dev.exs
@@ -17,8 +17,6 @@ config :electric, Electric.Replication.Connectors,
       ssl: false
     ],
     replication: [
-      publication: "all_tables",
-      slot: "all_changes",
       electric_connection: [
         host: "host.docker.internal",
         port: 5433,

--- a/components/electric/config/runtime.exs
+++ b/components/electric/config/runtime.exs
@@ -58,8 +58,6 @@ if config_env() == :prod do
   config :electric, Electric.StatusPlug,
     port: System.get_env("STATUS_PORT", "5050") |> String.to_integer()
 
-  publication = System.get_env("POSTGRES_PUBLICATION", "all_tables")
-  slot = System.get_env("POSTGRES_SLOT", "all_changes")
   electric_host = System.get_env("ELECTRIC_HOST") || raise "Env variable ELECTRIC_HOST is not set"
 
   electric_port = System.get_env("POSTGRES_REPLICATION_PORT", "5433") |> String.to_integer()
@@ -83,8 +81,6 @@ if config_env() == :prod do
      producer: Electric.Replication.Postgres.LogicalReplicationProducer,
      connection: postgresql_connection,
      replication: [
-       publication: publication,
-       slot: slot,
        electric_connection: [
          host: electric_host,
          port: electric_port,

--- a/components/electric/test/electric/replication/postgres/migration_consumer_test.exs
+++ b/components/electric/test/electric/replication/postgres/migration_consumer_test.exs
@@ -81,7 +81,7 @@ defmodule Electric.Replication.Postgres.MigrationConsumerTest do
       {:ok, pid} =
         start_supervised(
           {MigrationConsumer,
-           {[origin: origin, replication: [publication: "all_tables"]],
+           {[origin: origin, replication: []],
             [
               producer: producer_name,
               backend: {MockSchemaLoader, parent: self(), oids: oids, pks: pks}

--- a/components/electric/test/support/postgres_test_connection.ex
+++ b/components/electric/test/support/postgres_test_connection.ex
@@ -248,8 +248,6 @@ defmodule Electric.Postgres.TestConnection do
           ssl: false
         ),
       replication: [
-        publication: "all_tables",
-        slot: "all_changes",
         electric_connection: [
           host: "host.docker.internal",
           port: 5433,


### PR DESCRIPTION
These options have been retired since d3095ca42285380ac4b001d57a3795889fe96a9f.

This needs to wait for https://github.com/electric-sql/electric/pull/222 to get merged because that PR moves some replication config around.