### PR TITLE
feat(DAL, Satellite): add sync shape functionality to DAL

### DIFF
--- a/clients/typescript/src/client/input/findInput.ts
+++ b/clients/typescript/src/client/input/findInput.ts
@@ -1,5 +1,3 @@
-//export type SelectInput<T> = { [field in keyof T]?: boolean }
-
 import {
   NarrowInclude,
   NarrowOrderBy,

--- a/clients/typescript/src/client/input/syncInput.ts
+++ b/clients/typescript/src/client/input/syncInput.ts
@@ -1,0 +1,3 @@
+export interface SyncInput<Include> {
+  include?: Include
+}

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -130,7 +130,7 @@ export class Builder {
     const whereObject = i.where
     const identificationFields = this.getFields(whereObject, idRequired)
 
-    if (!shapeManager.isSynced(this._tableName))
+    if (!shapeManager.hasBeenSubscribed(this._tableName))
       Log.warn('Reading from unsynced table ' + this._tableName)
 
     const query = squelPostgres.select().from(this._tableName) // specify from which table to select

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -11,6 +11,8 @@ import { DeleteInput, DeleteManyInput } from '../input/deleteInput'
 import flow from 'lodash.flow'
 import { InvalidArgumentError } from '../validation/errors/invalidArgumentError'
 import * as z from 'zod'
+import { shapeManager } from './shapes'
+import Log from 'loglevel'
 
 const squelPostgres = squel.useFlavour('postgres')
 
@@ -127,6 +129,9 @@ export class Builder {
 
     const whereObject = i.where
     const identificationFields = this.getFields(whereObject, idRequired)
+
+    if (!shapeManager.isSynced(this._tableName))
+      Log.warn("Reading from unsynced table " + this._tableName)
 
     const query = squelPostgres.select().from(this._tableName) // specify from which table to select
     // only select the fields provided in `i.select` and the ones in `i.where`

--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -131,7 +131,7 @@ export class Builder {
     const identificationFields = this.getFields(whereObject, idRequired)
 
     if (!shapeManager.isSynced(this._tableName))
-      Log.warn("Reading from unsynced table " + this._tableName)
+      Log.warn('Reading from unsynced table ' + this._tableName)
 
     const query = squelPostgres.select().from(this._tableName) // specify from which table to select
     // only select the fields provided in `i.select` and the ones in `i.where`

--- a/clients/typescript/src/client/model/model.ts
+++ b/clients/typescript/src/client/model/model.ts
@@ -8,6 +8,7 @@ import { DeleteInput, DeleteManyInput } from '../input/deleteInput'
 import { QualifiedTablename } from '../../util/tablename'
 import { HKT, Kind } from '../util/hkt'
 import { SyncInput } from '../input/syncInput'
+import { Sub } from '../../satellite/process'
 
 /**
  * Interface that is implemented by Electric clients.
@@ -24,9 +25,8 @@ export interface Model<
   GetPayload extends HKT
 > {
   sync<T extends SyncInput<Include>>(
-    i?: T,
-    onLoading?: () => void
-  ): Promise<void>
+    i?: T
+  ): Promise<Sub>
 
   /**
    * Creates a unique record in the DB.

--- a/clients/typescript/src/client/model/model.ts
+++ b/clients/typescript/src/client/model/model.ts
@@ -23,7 +23,10 @@ export interface Model<
   ScalarFieldEnum,
   GetPayload extends HKT
 > {
-  sync<T extends SyncInput<Include>>(i?: T): Promise<void>
+  sync<T extends SyncInput<Include>>(
+    i?: T,
+    onLoading?: () => void
+  ): Promise<void>
 
   /**
    * Creates a unique record in the DB.

--- a/clients/typescript/src/client/model/model.ts
+++ b/clients/typescript/src/client/model/model.ts
@@ -24,9 +24,7 @@ export interface Model<
   ScalarFieldEnum,
   GetPayload extends HKT
 > {
-  sync<T extends SyncInput<Include>>(
-    i?: T
-  ): Promise<Sub>
+  sync<T extends SyncInput<Include>>(i?: T): Promise<Sub>
 
   /**
    * Creates a unique record in the DB.

--- a/clients/typescript/src/client/model/model.ts
+++ b/clients/typescript/src/client/model/model.ts
@@ -7,6 +7,7 @@ import { UpsertInput } from '../input/upsertInput'
 import { DeleteInput, DeleteManyInput } from '../input/deleteInput'
 import { QualifiedTablename } from '../../util/tablename'
 import { HKT, Kind } from '../util/hkt'
+import { SyncInput } from '../input/syncInput'
 
 /**
  * Interface that is implemented by Electric clients.
@@ -22,6 +23,8 @@ export interface Model<
   ScalarFieldEnum,
   GetPayload extends HKT
 > {
+  sync<T extends SyncInput<Include>>(i?: T): Promise<void>
+
   /**
    * Creates a unique record in the DB.
    * @param i - The record to create.

--- a/clients/typescript/src/client/model/schema.ts
+++ b/clients/typescript/src/client/model/schema.ts
@@ -186,6 +186,12 @@ export class DbSchema<T extends TableSchemas> {
     return this.getRelations(table).find((r) => r.relationName === relation)!
   }
 
+  getRelatedTable(table: TableName, field: FieldName): TableName {
+    const relationName = this.getRelationName(table, field)
+    const relation = this.getRelation(table, relationName)
+    return relation.relatedTable
+  }
+
   // Profile.post <-> Post.profile (from: profileId, to: id)
   getRelations(table: TableName): Relation[] {
     return this.extendedTables[table].relations

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -12,7 +12,7 @@ interface IShapeManager {
   isSynced(table: TableName): boolean
 }
 
-class ShapeManager implements IShapeManager {
+export class ShapeManager implements IShapeManager {
   protected syncedTables: Set<TableName>
   protected satellite?: Satellite
 
@@ -44,11 +44,11 @@ class ShapeManager implements IShapeManager {
     const dataReceivedProm = sub.dataReceived.then(() => {
       // When all data is received
       // we store the fact that these tables are synced
-      shape.tables.forEach(this.syncedTables.add)
+      shape.tables.forEach((tbl) => this.syncedTables.add(tbl))
     })
 
     return {
-      dataReceived: dataReceivedProm
+      dataReceived: dataReceivedProm,
     }
   }
 
@@ -67,7 +67,7 @@ export class ShapeManagerMock extends ShapeManager {
     shape.tables.forEach((tbl) => this.syncedTables.add(tbl))
 
     return {
-      dataReceived: Promise.resolve()
+      dataReceived: Promise.resolve(),
     }
   }
 }

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -8,7 +8,7 @@ export type Shape = {
 
 interface IShapeManager {
   init(satellite: Satellite): void
-  sync(shape: Shape): Promise<void>
+  sync(shape: Shape, onLoading?: () => void): Promise<void>
   isSynced(table: TableName): boolean
 }
 
@@ -24,7 +24,7 @@ class ShapeManager implements IShapeManager {
     this.satellite = satellite
   }
 
-  async sync(shape: Shape): Promise<void> {
+  async sync(shape: Shape, onLoading?: () => void): Promise<void> {
     if (this.satellite === undefined)
       throw new Error(
         'Shape cannot be synced because the `ShapeManager` is not yet initialised.'
@@ -38,7 +38,8 @@ class ShapeManager implements IShapeManager {
         }
       }),
     }
-    await this.satellite.subscribe([shapeDef])
+
+    await this.satellite.subscribe([shapeDef], onLoading)
 
     // Now that the subscription is active we can store the synced tables
     shape.tables.forEach(this.syncedTables.add)
@@ -54,7 +55,8 @@ export class ShapeManagerMock extends ShapeManager {
     super()
   }
 
-  override async sync(shape: Shape): Promise<void> {
+  override async sync(shape: Shape, onLoading?: () => void): Promise<void> {
+    onLoading?.()
     // Do not contact the server but directly store the synced tables
     shape.tables.forEach((tbl) => this.syncedTables.add(tbl))
     // method returns and promise will resolve

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -9,15 +9,15 @@ export type Shape = {
 interface IShapeManager {
   init(satellite: Satellite): void
   sync(shape: Shape): Promise<Sub>
-  isSynced(table: TableName): boolean
+  hasBeenSubscribed(shape: TableName): boolean
 }
 
 export class ShapeManager implements IShapeManager {
-  protected syncedTables: Set<TableName>
+  protected tablesPreviouslySubscribed: Set<TableName>
   protected satellite?: Satellite
 
   constructor() {
-    this.syncedTables = new Set()
+    this.tablesPreviouslySubscribed = new Set()
   }
 
   init(satellite: Satellite) {
@@ -44,7 +44,7 @@ export class ShapeManager implements IShapeManager {
     const dataReceivedProm = sub.dataReceived.then(() => {
       // When all data is received
       // we store the fact that these tables are synced
-      shape.tables.forEach((tbl) => this.syncedTables.add(tbl))
+      shape.tables.forEach((tbl) => this.tablesPreviouslySubscribed.add(tbl))
     })
 
     return {
@@ -52,8 +52,8 @@ export class ShapeManager implements IShapeManager {
     }
   }
 
-  isSynced(table: TableName): boolean {
-    return this.syncedTables.has(table)
+  hasBeenSubscribed(table: TableName): boolean {
+    return this.tablesPreviouslySubscribed.has(table)
   }
 }
 
@@ -64,7 +64,7 @@ export class ShapeManagerMock extends ShapeManager {
 
   override async sync(shape: Shape): Promise<Sub> {
     // Do not contact the server but directly store the synced tables
-    shape.tables.forEach((tbl) => this.syncedTables.add(tbl))
+    shape.tables.forEach((tbl) => this.tablesPreviouslySubscribed.add(tbl))
 
     return {
       dataReceived: Promise.resolve(),

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -56,7 +56,7 @@ export class ShapeManagerMock extends ShapeManager {
 
   override async sync(shape: Shape): Promise<void> {
     // Do not contact the server but directly store the synced tables
-    shape.tables.forEach(tbl => this.syncedTables.add(tbl))
+    shape.tables.forEach((tbl) => this.syncedTables.add(tbl))
     // method returns and promise will resolve
     // as if the server acknowledged the subscription
   }

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -1,0 +1,66 @@
+import { Satellite } from '../../satellite'
+
+export type TableName = string
+
+export type Shape = {
+  tables: TableName[]
+}
+
+interface IShapeManager {
+  init(satellite: Satellite): void
+  sync(shape: Shape): Promise<void>
+  isSynced(table: TableName): boolean
+}
+
+class ShapeManager implements IShapeManager {
+  protected syncedTables: Set<TableName>
+  protected satellite?: Satellite
+
+  constructor() {
+    this.syncedTables = new Set()
+  }
+
+  init(satellite: Satellite) {
+    this.satellite = satellite
+  }
+
+  async sync(shape: Shape): Promise<void> {
+    if (this.satellite === undefined)
+      throw new Error(
+        'Shape cannot be synced because the `ShapeManager` is not yet initialised.'
+      )
+
+    // Convert the shape to the format expected by the Satellite process
+    const shapeDef = {
+      selects: shape.tables.map((tbl) => {
+        return {
+          tablename: tbl,
+        }
+      }),
+    }
+    await this.satellite.subscribe([shapeDef])
+
+    // Now that the subscription is active we can store the synced tables
+    shape.tables.forEach(this.syncedTables.add)
+  }
+
+  isSynced(table: TableName): boolean {
+    return this.syncedTables.has(table)
+  }
+}
+
+export class ShapeManagerMock extends ShapeManager {
+  constructor() {
+    super()
+  }
+
+  override async sync(shape: Shape): Promise<void> {
+    // Do not contact the server but directly store the synced tables
+    shape.tables.forEach(tbl => this.syncedTables.add(tbl))
+    // method returns and promise will resolve
+    // as if the server acknowledged the subscription
+  }
+}
+
+// a shape manager singleton
+export const shapeManager = new ShapeManager()

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -162,7 +162,7 @@ export class Table<
     return includedTables
   }
 
-  async syncShape<T extends SyncInput<Include>>(i?: T): Promise<void> {
+  async sync<T extends SyncInput<Include>>(i?: T): Promise<void> {
     const validatedInput = this.syncSchema.parse(i ?? {})
     // Recursively go over the included fields
     // and for each field store its table

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -32,6 +32,7 @@ import * as z from 'zod'
 import { parseTableNames, Row, Statement } from '../../util'
 import { NarrowInclude } from '../input/inputNarrowing'
 import { shapeManager } from './shapes'
+import { Sub } from '../../satellite'
 
 type AnyTable = Table<any, any, any, any, any, any, any, any, any, HKT>
 
@@ -162,10 +163,7 @@ export class Table<
     return includedTables
   }
 
-  async sync<T extends SyncInput<Include>>(
-    i?: T,
-    onLoading?: () => void
-  ): Promise<void> {
+  sync<T extends SyncInput<Include>>(i?: T): Promise<Sub> {
     const validatedInput = this.syncSchema.parse(i ?? {})
     // Recursively go over the included fields
     // and for each field store its table
@@ -174,7 +172,7 @@ export class Table<
     const shape = {
       tables: tableNames,
     }
-    await shapeManager.sync(shape, onLoading)
+    return shapeManager.sync(shape)
   }
 
   /*

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -162,7 +162,10 @@ export class Table<
     return includedTables
   }
 
-  async sync<T extends SyncInput<Include>>(i?: T): Promise<void> {
+  async sync<T extends SyncInput<Include>>(
+    i?: T,
+    onLoading?: () => void
+  ): Promise<void> {
     const validatedInput = this.syncSchema.parse(i ?? {})
     // Recursively go over the included fields
     // and for each field store its table
@@ -171,7 +174,7 @@ export class Table<
     const shape = {
       tables: tableNames,
     }
-    await shapeManager.sync(shape)
+    await shapeManager.sync(shape, onLoading)
   }
 
   /*

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -9,6 +9,7 @@ import { setLogLevel } from '../util/debug'
 import { ElectricNamespace } from './namespace'
 import { ElectricClient } from '../client/model/client'
 import { DbSchema } from '../client/model/schema'
+import { shapeManager } from '../client/model/shapes'
 
 export { ElectricNamespace }
 
@@ -46,9 +47,8 @@ export const electrify = async <DB extends DbSchema<any>>(
   const registry = opts?.registry || globalRegistry
 
   const electric = new ElectricNamespace(adapter, notifier)
-  const namespace = ElectricClient.create(dbDescription, electric) // extends the electric namespace with a `dal` property for the data access library
 
-  await registry.ensureStarted(
+  const satellite = await registry.ensureStarted(
     dbName,
     adapter,
     migrator,
@@ -57,5 +57,8 @@ export const electrify = async <DB extends DbSchema<any>>(
     configWithDefaults
   )
 
+  // initialize the shape manager
+  shapeManager.init(satellite)
+  const namespace = ElectricClient.create(dbDescription, electric) // extends the electric namespace with a `dal` property for the data access library
   return namespace
 }

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -61,7 +61,10 @@ export interface Satellite {
     opts?: SatelliteReplicationOptions
   ): Promise<ConnectionWrapper>
   stop(): Promise<void>
-  subscribe(shapeDefinitions: ClientShapeDefinition[]): Promise<void>
+  subscribe(
+    shapeDefinitions: ClientShapeDefinition[],
+    onLoading?: () => void
+  ): Promise<void>
   unsubscribe(shapeUuid: string): Promise<void>
 }
 

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -22,9 +22,11 @@ import {
   SubscriptionErrorCallback,
   UnsubscribeResponse,
 } from './shapes/types'
+import { Sub } from './process'
 
 export { SatelliteProcess } from './process'
 export { GlobalRegistry, globalRegistry } from './registry'
+export type { Sub } from './process'
 
 // `Registry` that starts one Satellite process per database.
 export interface Registry {
@@ -62,9 +64,8 @@ export interface Satellite {
   ): Promise<ConnectionWrapper>
   stop(): Promise<void>
   subscribe(
-    shapeDefinitions: ClientShapeDefinition[],
-    onLoading?: () => void
-  ): Promise<void>
+    shapeDefinitions: ClientShapeDefinition[]
+  ): Promise<Sub>
   unsubscribe(shapeUuid: string): Promise<void>
 }
 

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -63,9 +63,7 @@ export interface Satellite {
     opts?: SatelliteReplicationOptions
   ): Promise<ConnectionWrapper>
   stop(): Promise<void>
-  subscribe(
-    shapeDefinitions: ClientShapeDefinition[]
-  ): Promise<Sub>
+  subscribe(shapeDefinitions: ClientShapeDefinition[]): Promise<Sub>
   unsubscribe(shapeUuid: string): Promise<void>
 }
 

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -71,7 +71,11 @@ export class MockSatelliteProcess implements Satellite {
     this.socketFactory = socketFactory
     this.opts = opts
   }
-  subscribe(_shapeDefinitions: ClientShapeDefinition[]): Promise<void> {
+  subscribe(
+    _shapeDefinitions: ClientShapeDefinition[],
+    onLoading?: () => void
+  ): Promise<void> {
+    onLoading?.()
     return Promise.resolve()
   }
 

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -72,11 +72,9 @@ export class MockSatelliteProcess implements Satellite {
     this.socketFactory = socketFactory
     this.opts = opts
   }
-  subscribe(
-    _shapeDefinitions: ClientShapeDefinition[],
-  ): Promise<Sub> {
+  subscribe(_shapeDefinitions: ClientShapeDefinition[]): Promise<Sub> {
     return Promise.resolve({
-      dataReceived: Promise.resolve()
+      dataReceived: Promise.resolve(),
     })
   }
 
@@ -159,16 +157,18 @@ export class MockSatelliteClient extends EventEmitter implements Client {
 
     for (const shape of shapes) {
       for (const { tablename } of shape.definition.selects) {
-        if (tablename === 'failure') {
+        if (tablename === 'failure' || tablename === 'Items') {
           return Promise.resolve({
             subscriptionId,
             error: new SatelliteError(SatelliteErrorCode.TABLE_NOT_FOUND),
           })
         }
-        if (tablename === 'another') {
-          this.sendErrorAfterTimeout(subscriptionId, 1)
-          return Promise.resolve({
-            subscriptionId,
+        if (tablename === 'another' || tablename === 'User') {
+          return new Promise((resolve) => {
+            this.sendErrorAfterTimeout(subscriptionId, 1)
+            resolve({
+              subscriptionId,
+            })
           })
         } else {
           shapeReqToUuid[shape.requestId] = uuid()
@@ -186,16 +186,18 @@ export class MockSatelliteClient extends EventEmitter implements Client {
       }
     }
 
-    setTimeout(() => {
-      this.emit(SUBSCRIPTION_DELIVERED, {
-        subscriptionId,
-        data,
-        shapeReqToUuid,
-      })
-    }, 1)
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        this.emit(SUBSCRIPTION_DELIVERED, {
+          subscriptionId,
+          data,
+          shapeReqToUuid,
+        })
+      }, 1)
 
-    return Promise.resolve({
-      subscriptionId,
+      resolve({
+        subscriptionId,
+      })
     })
   }
 
@@ -330,7 +332,7 @@ export class MockSatelliteClient extends EventEmitter implements Client {
       })
 
       const satError = subsDataErrorToSatelliteError(satSubsError)
-      this.emit(SUBSCRIPTION_ERROR, satError)
+      this.emit(SUBSCRIPTION_ERROR, satError, subscriptionId)
     }, timeout)
   }
 }

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -44,6 +44,7 @@ import {
   SatSubsDataError_ShapeReqError,
   SatSubsDataError_ShapeReqError_Code,
 } from '../_generated/protocol/satellite'
+import { Sub } from './process'
 
 export const MOCK_BEHIND_WINDOW_LSN = 42
 export const MOCK_INVALID_POSITION_LSN = 27
@@ -73,10 +74,10 @@ export class MockSatelliteProcess implements Satellite {
   }
   subscribe(
     _shapeDefinitions: ClientShapeDefinition[],
-    onLoading?: () => void
-  ): Promise<void> {
-    onLoading?.()
-    return Promise.resolve()
+  ): Promise<Sub> {
+    return Promise.resolve({
+      dataReceived: Promise.resolve()
+    })
   }
 
   unsubscribe(_shapeUuid: string): Promise<void> {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -299,7 +299,10 @@ export class SatelliteProcess implements Satellite {
     await this.client.close()
   }
 
-  async subscribe(shapeDefinitions: ClientShapeDefinition[]): Promise<void> {
+  async subscribe(
+    shapeDefinitions: ClientShapeDefinition[],
+    onLoading?: () => void
+  ): Promise<void> {
     const shapeReqs: ShapeRequest[] = shapeDefinitions.map((definition) => ({
       requestId: this.shapeRequestIdGenerator(),
       definition,

--- a/clients/typescript/src/satellite/shapes/cache.ts
+++ b/clients/typescript/src/satellite/shapes/cache.ts
@@ -238,10 +238,7 @@ export class SubscriptionsDataCache extends EventEmitter {
       )
     }
 
-    this.emit(SUBSCRIPTION_ERROR, {
-      subscriptionId: msg.subscriptionId,
-      error
-    })
+    this.emit(SUBSCRIPTION_ERROR, msg.subscriptionId, error)
     throw error
   }
 

--- a/clients/typescript/src/satellite/shapes/cache.ts
+++ b/clients/typescript/src/satellite/shapes/cache.ts
@@ -238,7 +238,10 @@ export class SubscriptionsDataCache extends EventEmitter {
       )
     }
 
-    this.emit(SUBSCRIPTION_ERROR, error)
+    this.emit(SUBSCRIPTION_ERROR, {
+      subscriptionId: msg.subscriptionId,
+      error
+    })
     throw error
   }
 

--- a/clients/typescript/src/satellite/shapes/types.ts
+++ b/clients/typescript/src/satellite/shapes/types.ts
@@ -4,7 +4,10 @@ export const SUBSCRIPTION_DELIVERED = 'subscription_delivered'
 export const SUBSCRIPTION_ERROR = 'subscription_error'
 
 export type SubscriptionDeliveredCallback = (data: SubscriptionData) => void
-export type SubscriptionErrorCallback = (error: SatelliteError, subscriptionId?: string) => void
+export type SubscriptionErrorCallback = (
+  error: SatelliteError,
+  subscriptionId?: string
+) => void
 
 export type SubscribeResponse = {
   subscriptionId: string

--- a/clients/typescript/src/satellite/shapes/types.ts
+++ b/clients/typescript/src/satellite/shapes/types.ts
@@ -4,7 +4,7 @@ export const SUBSCRIPTION_DELIVERED = 'subscription_delivered'
 export const SUBSCRIPTION_ERROR = 'subscription_error'
 
 export type SubscriptionDeliveredCallback = (data: SubscriptionData) => void
-export type SubscriptionErrorCallback = (error: SatelliteError) => void
+export type SubscriptionErrorCallback = (error: SatelliteError, subscriptionId?: string) => void
 
 export type SubscribeResponse = {
   subscriptionId: string

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -1,6 +1,9 @@
 import test from 'ava'
 import { Builder } from '../../../src/client/model/builder'
-import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+import {
+  shapeManager,
+  ShapeManagerMock,
+} from '../../../src/client/model/shapes'
 import { ZodError } from 'zod'
 
 const tbl = new Builder('Post', ['id', 'title', 'contents', 'nbr'])
@@ -11,7 +14,7 @@ const tbl = new Builder('Post', ['id', 'title', 'contents', 'nbr'])
 Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
 
 // Sync all shapes such that we don't get warnings on every query
-shapeManager.sync({ tables: [ 'Post' ] })
+shapeManager.sync({ tables: ['Post'] })
 
 const post1 = {
   id: 'i1',

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -1,8 +1,17 @@
 import test from 'ava'
 import { Builder } from '../../../src/client/model/builder'
+import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
 import { ZodError } from 'zod'
 
 const tbl = new Builder('Post', ['id', 'title', 'contents', 'nbr'])
+
+// Use a mocked shape manager for these tests
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
+
+// Sync all shapes such that we don't get warnings on every query
+shapeManager.sync({ tables: [ 'Post' ] })
 
 const post1 = {
   id: 'i1',

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -97,3 +97,11 @@ test.serial(
     t.assert(log.length === 0)
   }
 )
+
+test.serial('onLoading callback gets called', async (t) => {
+  let gotCalled = false
+  await Post.sync({}, () => {
+    gotCalled = true
+  })
+  t.assert(gotCalled)
+})

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -93,7 +93,7 @@ test.serial('Upsert query issues warning if table is not synced', async (t) => {
 
 test.serial('Read queries no longer warn after syncing the table', async (t) => {
   t.assert(log.length === 0)
-  await Post.syncShape() // syncs only the Post table
+  await Post.sync() // syncs only the Post table
   await Post.findMany() // now we can query it
   t.assert(log.length === 0)
 })

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -117,7 +117,7 @@ function init() {
 
 test.beforeEach(makeContext)
 test.afterEach.always((t: ExecutionContext) => {
-  shapeManager['syncedTables'] = new Set<string>()
+  shapeManager['tablesPreviouslySubscribed'] = new Set<string>()
   return cleanAndStopSatellite(t)
 })
 

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -3,7 +3,10 @@ import Log from 'loglevel'
 import Database from 'better-sqlite3'
 import { dbSchema, Post } from '../generated'
 import { electrify } from '../../../src/drivers/better-sqlite3'
-import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+import {
+  shapeManager,
+  ShapeManagerMock,
+} from '../../../src/client/model/shapes'
 
 // Modify `loglevel` to store the logged messages
 // based on "Writing plugins" in https://github.com/pimterry/loglevel
@@ -15,7 +18,7 @@ Log.methodFactory = function (methodName, logLevel, loggerName) {
 
   return function (message) {
     log.push(message)
-    if (message !== "Reading from unsynced table Post") {
+    if (message !== 'Reading from unsynced table Post') {
       rawMethod(message)
     }
   }
@@ -51,10 +54,7 @@ test.beforeEach(init)
 test.serial('Read queries issue warning if table is not synced', async (t) => {
   t.assert(log.length === 0)
   await Post.findMany()
-  t.deepEqual(
-    log,
-    [ "Reading from unsynced table Post" ]
-  )
+  t.deepEqual(log, ['Reading from unsynced table Post'])
 })
 
 test.serial('Upsert query issues warning if table is not synced', async (t) => {
@@ -82,18 +82,18 @@ test.serial('Upsert query issues warning if table is not synced', async (t) => {
   // because upsert first tries to find the record
   // and then reads the created/updated record
   // and both of those reads will raise the warning
-  t.deepEqual(
-    log,
-    [
-      "Reading from unsynced table Post",
-      "Reading from unsynced table Post"
-    ]
-  )
+  t.deepEqual(log, [
+    'Reading from unsynced table Post',
+    'Reading from unsynced table Post',
+  ])
 })
 
-test.serial('Read queries no longer warn after syncing the table', async (t) => {
-  t.assert(log.length === 0)
-  await Post.sync() // syncs only the Post table
-  await Post.findMany() // now we can query it
-  t.assert(log.length === 0)
-})
+test.serial(
+  'Read queries no longer warn after syncing the table',
+  async (t) => {
+    t.assert(log.length === 0)
+    await Post.sync() // syncs only the Post table
+    await Post.findMany() // now we can query it
+    t.assert(log.length === 0)
+  }
+)

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -239,13 +239,13 @@ test.serial(
   async (t) => {
     Object.setPrototypeOf(shapeManager, ShapeManager.prototype)
 
-    const {satellite, client} = t.context as ContextType
+    const { satellite, client } = t.context as ContextType
     await satellite.start(config.auth)
 
     client.setRelations(relations)
     client.setRelationData('Post', post)
 
-    const {Post} = t.context as ContextType
+    const { Post } = t.context as ContextType
     const { dataReceived } = await Post.sync()
     await dataReceived
 

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -1,0 +1,99 @@
+import test from 'ava'
+import Log from 'loglevel'
+import Database from 'better-sqlite3'
+import { dbSchema, Post } from '../generated'
+import { electrify } from '../../../src/drivers/better-sqlite3'
+import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+
+// Modify `loglevel` to store the logged messages
+// based on "Writing plugins" in https://github.com/pimterry/loglevel
+type LoggedMsg = string
+let log: Array<LoggedMsg> = []
+const originalFactory = Log.methodFactory
+Log.methodFactory = function (methodName, logLevel, loggerName) {
+  var rawMethod = originalFactory(methodName, logLevel, loggerName)
+
+  return function (message) {
+    log.push(message)
+    if (message !== "Reading from unsynced table Post") {
+      rawMethod(message)
+    }
+  }
+}
+Log.setLevel(Log.getLevel()) // Be sure to call setLevel method in order to apply plugin
+
+// Use a mocked shape manager for these tests
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
+
+const db = new Database(':memory:')
+const config = {
+  auth: {
+    token: 'test-token',
+  },
+}
+const electric = await electrify(db, dbSchema, config)
+const Post = electric.db.Post
+
+// Create a Post table in the DB first
+function init() {
+  db.exec('DROP TABLE IF EXISTS Post')
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS Post('id' int PRIMARY KEY, 'title' varchar, 'contents' varchar, 'nbr' int, 'authorId' int);"
+  )
+
+  log = []
+}
+
+test.beforeEach(init)
+
+test.serial('Read queries issue warning if table is not synced', async (t) => {
+  t.assert(log.length === 0)
+  await Post.findMany()
+  t.deepEqual(
+    log,
+    [ "Reading from unsynced table Post" ]
+  )
+})
+
+test.serial('Upsert query issues warning if table is not synced', async (t) => {
+  t.assert(log.length === 0)
+
+  const newPost = {
+    id: 4,
+    title: 't4',
+    contents: 'c4',
+    nbr: 5,
+    authorId: 1,
+  }
+
+  const updatePost = { title: 'Modified title' }
+
+  await Post.upsert({
+    create: newPost,
+    update: updatePost,
+    where: {
+      id: newPost.id,
+    },
+  })
+
+  // The log contains the warning twice
+  // because upsert first tries to find the record
+  // and then reads the created/updated record
+  // and both of those reads will raise the warning
+  t.deepEqual(
+    log,
+    [
+      "Reading from unsynced table Post",
+      "Reading from unsynced table Post"
+    ]
+  )
+})
+
+test.serial('Read queries no longer warn after syncing the table', async (t) => {
+  t.assert(log.length === 0)
+  await Post.syncShape() // syncs only the Post table
+  await Post.findMany() // now we can query it
+  t.assert(log.length === 0)
+})

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -98,10 +98,8 @@ test.serial(
   }
 )
 
-test.serial('onLoading callback gets called', async (t) => {
-  let gotCalled = false
-  await Post.sync({}, () => {
-    gotCalled = true
-  })
-  t.assert(gotCalled)
+test.serial('loading and fulfilled promises get resolved', async (t) => {
+  const { dataReceived } = await Post.sync()
+  await dataReceived
+  t.pass()
 })

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -27,7 +27,7 @@ const userTable = electric.db.User
 Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
 
 // Sync all shapes such that we don't get warnings on every query
-await userTable.syncShape()
+await userTable.sync()
 
 test.beforeEach((_t) => {
   db.exec('DROP TABLE IF EXISTS Post')

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -4,6 +4,7 @@ import { electrify } from '../../../src/drivers/better-sqlite3'
 import { dbSchema } from '../generated'
 import { ZodError } from 'zod'
 import { InvalidArgumentError } from '../../../src/client/validation/errors/invalidArgumentError'
+import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
 
 /*
  * This test file is meant to check that the DAL
@@ -19,6 +20,14 @@ const electric = await electrify(db, dbSchema, {
 })
 //const postTable = electric.db.Post
 const userTable = electric.db.User
+
+// Use a mocked shape manager for this test
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
+
+// Sync all shapes such that we don't get warnings on every query
+await userTable.syncShape()
 
 test.beforeEach((_t) => {
   db.exec('DROP TABLE IF EXISTS Post')

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -4,7 +4,10 @@ import { electrify } from '../../../src/drivers/better-sqlite3'
 import { dbSchema } from '../generated'
 import { ZodError } from 'zod'
 import { InvalidArgumentError } from '../../../src/client/validation/errors/invalidArgumentError'
-import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+import {
+  shapeManager,
+  ShapeManagerMock,
+} from '../../../src/client/model/shapes'
 
 /*
  * This test file is meant to check that the DAL

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -36,9 +36,9 @@ const profileTable = electric.db.Profile
 Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
 
 // Sync all shapes such that we don't get warnings on every query
-await postTable.syncShape()
-await userTable.syncShape()
-await profileTable.syncShape()
+await postTable.sync()
+await userTable.sync()
+await profileTable.sync()
 
 const post1 = {
   id: 1,

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -10,6 +10,7 @@ import {
   _RECORD_NOT_FOUND_,
 } from '../../../src/client/validation/errors/messages'
 import { dbSchema, Post } from '../generated'
+import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
 
 const db = new Database(':memory:')
 const electric = await electrify(db, dbSchema, {
@@ -28,6 +29,16 @@ const tbl = electric.db.Post
 const postTable = tbl
 const userTable = electric.db.User
 const profileTable = electric.db.Profile
+
+// Use a mocked shape manager for this test
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
+
+// Sync all shapes such that we don't get warnings on every query
+await postTable.syncShape()
+await userTable.syncShape()
+await profileTable.syncShape()
 
 const post1 = {
   id: 1,

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -10,7 +10,10 @@ import {
   _RECORD_NOT_FOUND_,
 } from '../../../src/client/validation/errors/messages'
 import { dbSchema, Post } from '../generated'
-import { shapeManager, ShapeManagerMock } from '../../../src/client/model/shapes'
+import {
+  shapeManager,
+  ShapeManagerMock,
+} from '../../../src/client/model/shapes'
 
 const db = new Database(':memory:')
 const electric = await electrify(db, dbSchema, {

--- a/clients/typescript/test/client/notifications.test.ts
+++ b/clients/typescript/test/client/notifications.test.ts
@@ -17,7 +17,7 @@ const config = {
 }
 
 const { notifier, adapter, db } = await electrify(conn, dbSchema, config)
-await db.Items.syncShape() // sync the Items table
+await db.Items.sync() // sync the Items table
 
 async function runAndCheckNotifications(f: () => Promise<void>) {
   let notifications = 0

--- a/clients/typescript/test/client/notifications.test.ts
+++ b/clients/typescript/test/client/notifications.test.ts
@@ -2,6 +2,12 @@ import test from 'ava'
 import Database from 'better-sqlite3'
 import { electrify } from '../../src/drivers/better-sqlite3'
 import { dbSchema } from './generated'
+import { shapeManager, ShapeManagerMock } from '../../src/client/model/shapes'
+
+// Use a mocked shape manager for these tests
+// which does not wait for Satellite
+// to acknowledge the subscription
+Object.setPrototypeOf(shapeManager, ShapeManagerMock.prototype)
 
 const conn = new Database(':memory:')
 const config = {
@@ -11,6 +17,7 @@ const config = {
 }
 
 const { notifier, adapter, db } = await electrify(conn, dbSchema, config)
+await db.Items.syncShape() // sync the Items table
 
 async function runAndCheckNotifications(f: () => Promise<void>) {
   let notifications = 0

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1519,7 +1519,7 @@ test('a subscription request failure does not clear the manager state', async (t
 
   try {
     await satellite.subscribe([shapeDef2])
-  } catch(error: any) {
+  } catch (error: any) {
     t.is(error.code, SatelliteErrorCode.TABLE_NOT_FOUND)
   }
 })


### PR DESCRIPTION
This PR extends the DAL with functionality to sync shapes.
The signature of this `sync` method is:
```
sync<T extends SyncInput<Include>>(i?: T): Promise<Sub>

interface SyncInput<Include> {
  include?: Include
}

type Sub = {
  dataReceived: Promise<void>
}
```

The returned promise resolves when the subscription request is accepted by Electric.
The value to which it resolves is an object containing a `dataReceived` property that is again a promise.
The `dataReceived` promise resolves when the subscription request is fulfilled, i.e. all data has been loaded.

Example usage:
```
// Sync only the `Post` table
const { dataReceived } = await db.Post.sync()
await dataReceived

// Sync the `Post` table and the tables for the related `author` and `profile` fields
const { dataReceived } = await Post.sync({
      include: {
        author: {
          include: {
            profile: true
          }
        }
      }
    })

await dataReceived
```

Note that Satellite cannot handle concurrent subscription requests.
Hence, it is important to always await the nested promise before making a new subscription request!!
For example:

```
await db.Post.sync() // problematic
await db.User.sync() // this subscription request may be issued before the previous one was fulfilled!
```

**For reviewers:** the DAL has a shape manager abstraction that keeps track of which shapes have been synced etc. I chose to expose a single shared shape manager instance which every DAL table uses. As such that instance does not need to be passed to every table separately. Not sure if that is a good idea, let me know what you think.