### PR TITLE
fix(electric): tag serialization wasn't working assigning `null` to tags

### DIFF
--- a/components/electric/lib/electric/postgres/shadow_table_transformation.ex
+++ b/components/electric/lib/electric/postgres/shadow_table_transformation.ex
@@ -58,14 +58,15 @@ defmodule Electric.Postgres.ShadowTableTransformation do
   @spec split_change_into_main_and_shadow(
           change :: Changes.change(),
           relations :: relations_map(),
-          tag :: {DateTime.t(), String.t()} | String.t()
+          tag :: {DateTime.t(), String.t()} | String.t(),
+          origin :: String.t()
         ) :: [Changes.change()]
-  def split_change_into_main_and_shadow(change, relations, tag)
+  def split_change_into_main_and_shadow(change, relations, tag, origin)
 
-  def split_change_into_main_and_shadow(change, relations, {_, _} = tag),
-    do: split_change_into_main_and_shadow(change, relations, serialize_tag_to_pg(tag))
+  def split_change_into_main_and_shadow(change, relations, {_, _} = tag, origin),
+    do: split_change_into_main_and_shadow(change, relations, serialize_tag_to_pg(tag), origin)
 
-  def split_change_into_main_and_shadow(change, relations, tag) do
+  def split_change_into_main_and_shadow(change, relations, tag, origin) do
     main_table_info = relations[change.relation]
     main_record = get_record(change)
     shadow_table_info = relations[shadow_of(change.relation)]
@@ -83,7 +84,7 @@ defmodule Electric.Postgres.ShadowTableTransformation do
         "_tag" => tag,
         "_is_a_delete_operation" =>
           if(is_struct(change, Changes.DeletedRecord), do: "t", else: "f"),
-        "_observed_tags" => convert_tag_list_satellite_to_pg(change.tags),
+        "_observed_tags" => convert_tag_list_satellite_to_pg(change.tags, origin),
         "_modified_columns_bit_mask" => serialize_pg_array(modified_bitmask)
       })
 

--- a/e2e/tests/2.5_delete_gets_registered_correctly.lux
+++ b/e2e/tests/2.5_delete_gets_registered_correctly.lux
@@ -1,0 +1,48 @@
+[doc Satellite-originating DELETE with correct observed tags gets accepted by PG]
+[include _shared.luxinc]
+
+[invoke setup]
+[invoke electrify_table pg_1 entries]
+
+[newshell user_1_ws1]
+    -$fail_pattern
+    [invoke start_elixir_test 1]
+    [invoke client_session 1 1]
+    !Electric.Test.SatelliteWsClient.send_test_relation(conn)
+    ?:ok
+    ?$eprompt
+
+[shell pg_1]
+    !\pset tuples_only
+    # Given an already-inserted row
+    !INSERT INTO entries (id, content) VALUES ('00000000-0000-0000-0000-000000000000', 'original value');
+    ?$psql
+
+
+[shell user_1_ws1]
+    ?%Electric.Satellite.V\d+.SatOpInsert\{.*tags: \["(postgres_1@\d+)"\]
+    [my seen_tag=$1]
+    # We do an update having "seen" only the insert
+    """!
+    Electric.Test.SatelliteWsClient.entries_table_send_delete(
+        conn,
+        "1", # lsn
+        DateTime.utc_now() |> DateTime.to_unix(:millisecond),
+        %{"id" => "00000000-0000-0000-0000-000000000000", "content" => "original value", "content_b" => nil},
+        ["$seen_tag"]
+    )
+    """
+    ?:ok
+    ?$eprompt
+
+[shell electric]
+    # Wait for it to be sent to PG
+    ??pg_slot=postgres_1 [debug] Will send 1 to subscriber:
+
+[shell pg_1]
+    # We expect for the row to be deleted
+    !\x
+    [invoke wait-for "SELECT COUNT(*) FROM ENTRIES;" "count \| 0" 10 $psql]
+
+[cleanup]
+    [invoke teardown]


### PR DESCRIPTION
Internal representation of tags on PG is done in a way that any PG-originating tag has it's origin component set to NULL, and then NULL origins are ordered higher than any strings. When PG-originating tags are sent to Satellites, we preprocess tags to replace NULL values with pg origin name. But the inverse path has an error, whereby on a return trip the pg origin in observed tags is not set back to NULL before being set to PG like it should.

Closes VAX-762