### PR TITLE
chore(electric): Add an e2e test that verifies migration deduplication

### DIFF
--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -127,6 +127,8 @@ export interface SatInStartReplicationReq {
   syncBatchSize: number;
   /** the subscriptions identifiers the client wants to resume subscription */
   subscriptionIds: string[];
+  /** The version of the most recent migration seen by the client. */
+  schemaVersion?: string | undefined;
 }
 
 export enum SatInStartReplicationReq_Option {
@@ -946,6 +948,7 @@ function createBaseSatInStartReplicationReq(): SatInStartReplicationReq {
     options: [],
     syncBatchSize: 0,
     subscriptionIds: [],
+    schemaVersion: undefined,
   };
 }
 
@@ -966,6 +969,9 @@ export const SatInStartReplicationReq = {
     }
     for (const v of message.subscriptionIds) {
       writer.uint32(34).string(v!);
+    }
+    if (message.schemaVersion !== undefined) {
+      writer.uint32(42).string(message.schemaVersion);
     }
     return writer;
   },
@@ -1015,6 +1021,13 @@ export const SatInStartReplicationReq = {
 
           message.subscriptionIds.push(reader.string());
           continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
+          message.schemaVersion = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1034,6 +1047,7 @@ export const SatInStartReplicationReq = {
     message.options = object.options?.map((e) => e) || [];
     message.syncBatchSize = object.syncBatchSize ?? 0;
     message.subscriptionIds = object.subscriptionIds?.map((e) => e) || [];
+    message.schemaVersion = object.schemaVersion ?? undefined;
     return message;
   },
 };

--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -154,6 +154,8 @@ export enum SatInStartReplicationReq_Option {
    * whatever this position is. Used for tests only.
    */
   LAST_LSN = 4,
+  /** PAUSE_DURING_INITIAL_SYNC - This option is only used by some E2E tests. */
+  PAUSE_DURING_INITIAL_SYNC = 5,
   UNRECOGNIZED = -1,
 }
 

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -1,4 +1,5 @@
 import { AuthConfig } from '../auth/index'
+import { SatelliteReplicationOptions } from '../satellite'
 
 export interface ElectricConfig {
   auth: AuthConfig
@@ -16,6 +17,10 @@ export interface ElectricConfig {
    * Defaults to `false`.
    */
   debug?: boolean
+  /**
+   * ...
+   */
+  replicationOptions?: string[]
 }
 
 export type HydratedConfig = {
@@ -24,6 +29,7 @@ export type HydratedConfig = {
     host: string
     port: number
     ssl: boolean
+    options?: SatelliteReplicationOptions
   }
   debug: boolean
 }
@@ -46,6 +52,17 @@ export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
 
   const debug = config.debug ?? false
 
+  let replicationOptions: SatelliteReplicationOptions | undefined = {}
+  if (config.replicationOptions?.includes('clearOnBehindWindow')) {
+    replicationOptions.clearOnBehindWindow = true
+  }
+  if (config.replicationOptions?.includes('pauseDuringInitialSync')) {
+    replicationOptions.pauseDuringInitialSync = true
+  }
+  if (Object.keys(replicationOptions).length === 0) {
+    replicationOptions = undefined
+  }
+
   const url = config.url ?? 'electric://127.0.0.1:5133'
   const matches = url.match(/(?:electric:\/\/)(.+):([0-9]*)/)
   if (matches === null) {
@@ -58,6 +75,7 @@ export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
     host,
     port: parseInt(port, 10),
     ssl: false,
+    options: replicationOptions,
   }
 
   return {

--- a/clients/typescript/src/migrators/index.ts
+++ b/clients/typescript/src/migrators/index.ts
@@ -30,6 +30,7 @@ export interface Migrator {
   up(): Promise<number>
   apply(migration: StmtMigration): Promise<void>
   applyIfNotAlready(migration: StmtMigration): Promise<boolean>
+  querySchemaVersion(): Promise<string | undefined>
 }
 
 export interface MigratorOptions {

--- a/clients/typescript/src/migrators/mock.ts
+++ b/clients/typescript/src/migrators/mock.ts
@@ -12,4 +12,8 @@ export class MockMigrator implements Migrator {
   async applyIfNotAlready(_: StmtMigration): Promise<boolean> {
     return true
   }
+
+  async querySchemaVersion(): Promise<string | undefined> {
+    return
+  }
 }

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -303,7 +303,11 @@ export class SatelliteClient extends EventEmitter implements Client {
     return !this.socketHandler
   }
 
-  startReplication(lsn?: LSN, subscriptionIds?: string[]): Promise<void> {
+  startReplication(
+    lsn?: LSN,
+    schemaVersion?: string,
+    subscriptionIds?: string[]
+  ): Promise<void> {
     if (this.inbound.isReplicating !== ReplicationStatus.STOPPED) {
       return Promise.reject(
         new SatelliteError(
@@ -320,6 +324,7 @@ export class SatelliteClient extends EventEmitter implements Client {
       Log.info(`no previous LSN, start replication with option FIRST_LSN`)
       request = SatInStartReplicationReq.fromPartial({
         options: [SatInStartReplicationReq_Option.FIRST_LSN],
+        schemaVersion,
         subscriptionIds,
       })
     } else {

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -84,6 +84,7 @@ import {
   UnsubscribeResponse,
 } from './shapes/types'
 import { SubscriptionsDataCache } from './shapes/cache'
+import { SatelliteReplicationOptions } from '.'
 
 type IncomingHandler = {
   handle: (
@@ -306,6 +307,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   startReplication(
     lsn?: LSN,
     schemaVersion?: string,
+    replicationOptions?: SatelliteReplicationOptions,
     subscriptionIds?: string[]
   ): Promise<void> {
     if (this.inbound.isReplicating !== ReplicationStatus.STOPPED) {
@@ -322,8 +324,12 @@ export class SatelliteClient extends EventEmitter implements Client {
     let request
     if (!lsn || lsn.length == 0) {
       Log.info(`no previous LSN, start replication with option FIRST_LSN`)
+      const options = [SatInStartReplicationReq_Option.FIRST_LSN]
+      if (replicationOptions?.pauseDuringInitialSync) {
+        options.push(SatInStartReplicationReq_Option.PAUSE_DURING_INITIAL_SYNC)
+      }
       request = SatInStartReplicationReq.fromPartial({
-        options: [SatInStartReplicationReq_Option.FIRST_LSN],
+        options: options,
         schemaVersion,
         subscriptionIds,
       })

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -46,7 +46,10 @@ export type ConnectionWrapper = {
   connectionPromise: Promise<void | Error>
 }
 
-export type SatelliteReplicationOptions = { clearOnBehindWindow: boolean }
+export type SatelliteReplicationOptions = {
+  clearOnBehindWindow?: boolean
+  pauseDuringInitialSync?: boolean
+}
 
 // `Satellite` is the main process handling ElectricSQL replication,
 // processing the opslog and notifying when there are data changes.
@@ -76,6 +79,7 @@ export interface Client {
   startReplication(
     lsn?: LSN,
     schemaVersion?: string,
+    replicationOptions?: SatelliteReplicationOptions,
     subscriptionIds?: string[]
   ): Promise<void>
   stopReplication(): Promise<void>

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -73,7 +73,11 @@ export interface Client {
   close(): Promise<void>
   authenticate(authState: AuthState): Promise<AuthResponse>
   isClosed(): boolean
-  startReplication(lsn?: LSN, subscriptionIds?: string[]): Promise<void>
+  startReplication(
+    lsn?: LSN,
+    schemaVersion?: string,
+    subscriptionIds?: string[]
+  ): Promise<void>
   stopReplication(): Promise<void>
   subscribeToRelations(callback: (relation: Relation) => void): void
   subscribeToTransactions(

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -484,11 +484,12 @@ export class SatelliteProcess implements Satellite {
       throw new Error(`trying to connect before authentication`)
     }
     const authState = this._authState
+    const schemaVersion = await this.migrator.querySchemaVersion()
 
     return this.client
       .connect()
       .then(() => this.client.authenticate(authState))
-      .then(() => this.client.startReplication(this._lsn))
+      .then(() => this.client.startReplication(this._lsn, schemaVersion))
       .catch(async (error) => {
         if (
           error.code == SatelliteErrorCode.BEHIND_WINDOW &&

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -490,7 +490,7 @@ export class SatelliteProcess implements Satellite {
       .then(() => this.client.authenticate(authState))
       .then(() => this.migrator.querySchemaVersion())
       .then((schemaVersion) =>
-        this.client.startReplication(this._lsn, schemaVersion)
+        this.client.startReplication(this._lsn, schemaVersion, opts)
       )
       .catch(async (error) => {
         if (

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -475,7 +475,7 @@ export class SatelliteProcess implements Satellite {
     }
   }
 
-  async _connectAndStartReplication(
+  _connectAndStartReplication(
     opts?: SatelliteReplicationOptions
   ): Promise<void | SatelliteError> {
     Log.info(`connecting and starting replication`)
@@ -484,12 +484,12 @@ export class SatelliteProcess implements Satellite {
       throw new Error(`trying to connect before authentication`)
     }
     const authState = this._authState
-    const schemaVersion = await this.migrator.querySchemaVersion()
 
     return this.client
       .connect()
       .then(() => this.client.authenticate(authState))
-      .then(() => this.client.startReplication(this._lsn, schemaVersion))
+      .then(() => this.migrator.querySchemaVersion())
+      .then((schemaVersion) => this.client.startReplication(this._lsn, schemaVersion))
       .catch(async (error) => {
         if (
           error.code == SatelliteErrorCode.BEHIND_WINDOW &&

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -489,7 +489,9 @@ export class SatelliteProcess implements Satellite {
       .connect()
       .then(() => this.client.authenticate(authState))
       .then(() => this.migrator.querySchemaVersion())
-      .then((schemaVersion) => this.client.startReplication(this._lsn, schemaVersion))
+      .then((schemaVersion) =>
+        this.client.startReplication(this._lsn, schemaVersion)
+      )
       .catch(async (error) => {
         if (
           error.code == SatelliteErrorCode.BEHIND_WINDOW &&

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -215,7 +215,7 @@ export class GlobalRegistry extends BaseRegistry {
       client,
       satelliteDefaults
     )
-    await satellite.start(config.auth)
+    await satellite.start(config.auth, config.replication.options)
 
     return satellite
   }

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -208,6 +208,26 @@ test.serial('replication start sends FIRST_LSN', async (t) => {
   })
 })
 
+test.serial('replication start sends schemaVersion', async(t) => {
+  await connectAndAuth(t.context)
+  const { client, server } = t.context
+
+  return new Promise(async (resolve) => {
+    server.nextResponses([
+      (data?: Buffer) => {
+        const msgType = data!.readUInt8()
+        t.assert(msgType == getTypeFromString(Proto.SatInStartReplicationReq.$type))
+
+        const req = decode(data!) as Proto.SatInStartReplicationReq
+        t.assert(req.schemaVersion === '20230711')
+
+        resolve()
+      },
+    ])
+    await client.startReplication(new Uint8Array(), '20230711')
+  })
+})
+
 test.serial('replication start failure', async (t) => {
   await connectAndAuth(t.context)
   const { client, server } = t.context

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -208,7 +208,7 @@ test.serial('replication start sends FIRST_LSN', async (t) => {
   })
 })
 
-test.serial('replication start sends schemaVersion', async(t) => {
+test.serial('replication start sends schemaVersion', async (t) => {
   await connectAndAuth(t.context)
   const { client, server } = t.context
 
@@ -216,7 +216,9 @@ test.serial('replication start sends schemaVersion', async(t) => {
     server.nextResponses([
       (data?: Buffer) => {
         const msgType = data!.readUInt8()
-        t.assert(msgType == getTypeFromString(Proto.SatInStartReplicationReq.$type))
+        t.assert(
+          msgType == getTypeFromString(Proto.SatInStartReplicationReq.$type)
+        )
 
         const req = decode(data!) as Proto.SatInStartReplicationReq
         t.assert(req.schemaVersion === '20230711')

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -51,7 +51,12 @@ defmodule Electric.Postgres.Extension do
   defp migration_history_query(after_version) do
     where_clause =
       if after_version do
-        ~s|WHERE #{@version_table}.txid > (SELECT txid FROM #{@version_table} WHERE version = $1)|
+        ~s"""
+        WHERE coalesce(
+          #{@version_table}.txid > (SELECT txid FROM #{@version_table} WHERE version = $1),
+          true
+        )
+        """
       else
         # Dummy condition just to keep the $1 parameter in the query.
         ~s|WHERE $1::text IS NULL|

--- a/components/electric/lib/electric/replication/initial_sync.ex
+++ b/components/electric/lib/electric/replication/initial_sync.ex
@@ -27,7 +27,7 @@ defmodule Electric.Replication.InitialSync do
   def migrations_since(version, connector_opts) do
     {:ok, migrations} = Extension.SchemaCache.migration_history(version)
     origin = Connectors.origin(connector_opts)
-    publication = Connectors.get_replication_opts(connector_opts).publication
+    publication = Extension.publication_name()
 
     for {txid, txts, version, _schema, stmts} <- migrations do
       records =

--- a/components/electric/lib/electric/satellite/protobuf_messages.ex
+++ b/components/electric/lib/electric/satellite/protobuf_messages.ex
@@ -304,6 +304,15 @@
           def encode("LAST_LSN") do
             4
           end
+        ),
+        (
+          def encode(:PAUSE_DURING_INITIAL_SYNC) do
+            5
+          end
+
+          def encode("PAUSE_DURING_INITIAL_SYNC") do
+            5
+          end
         )
       ]
 
@@ -327,6 +336,9 @@
         end,
         def decode(4) do
           :LAST_LSN
+        end,
+        def decode(5) do
+          :PAUSE_DURING_INITIAL_SYNC
         end
       ]
 
@@ -336,7 +348,14 @@
 
       @spec constants() :: [{integer(), atom()}]
       def constants() do
-        [{0, :NONE}, {1, :LAST_ACKNOWLEDGED}, {2, :SYNC_MODE}, {3, :FIRST_LSN}, {4, :LAST_LSN}]
+        [
+          {0, :NONE},
+          {1, :LAST_ACKNOWLEDGED},
+          {2, :SYNC_MODE},
+          {3, :FIRST_LSN},
+          {4, :LAST_LSN},
+          {5, :PAUSE_DURING_INITIAL_SYNC}
+        ]
       end
 
       @spec has_constant?(any()) :: boolean()
@@ -355,6 +374,9 @@
             true
           end,
           def has_constant?(:LAST_LSN) do
+            true
+          end,
+          def has_constant?(:PAUSE_DURING_INITIAL_SYNC) do
             true
           end
         ]

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -207,7 +207,10 @@ defmodule Electric.Satellite.WsServer do
     migration_transactions = InitialSync.migrations_since(schema_version, state.pg_connector_opts)
     {msgs, state} = Protocol.handle_outgoing_txs(migration_transactions, state)
 
-    max_txid = Enum.max_by(migration_transactions, fn {tx, _offset} -> tx.xid end, fn -> 0 end)
+    max_txid =
+      migration_transactions
+      |> Enum.map(fn {tx, _offset} -> tx.xid end)
+      |> Enum.max(fn -> 0 end)
 
     state =
       state

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -189,7 +189,8 @@ defmodule Electric.Satellite.WsServer do
   # client has connected which needs to perform the initial sync of migrations and the current database state before
   # subscribing to the replication stream.
   def websocket_info({:perform_initial_sync_and_subscribe, msg}, %State{} = state) do
-    migration_transactions = InitialSync.migrations_since(nil, state.pg_connector_opts)
+    %SatInStartReplicationReq{schema_version: schema_version} = msg
+    migration_transactions = InitialSync.migrations_since(schema_version, state.pg_connector_opts)
     {msgs, state} = Protocol.handle_outgoing_txs(migration_transactions, state)
 
     lsn = CachedWal.Api.get_current_position()

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -189,11 +189,18 @@ defmodule Electric.Satellite.WsServer do
   # client has connected which needs to perform the initial sync of migrations and the current database state before
   # subscribing to the replication stream.
   def websocket_info({:perform_initial_sync_and_subscribe, msg}, %State{} = state) do
+    # Fetch the latest observed LSN from the cached WAL. We have to do it before fetching migrations.
+    #
+    # If we were to do it the other way around, we could miss a migration that is committed right after the call to
+    # migrations_since() but before the client subscribes to the replication stream. If the migration was immediately
+    # followed by another write in PG, we could have fetched the LSN of this last write with get_current_position() and
+    # thus miss the migration committed just before it.
+    lsn = CachedWal.Api.get_current_position()
+
     %SatInStartReplicationReq{schema_version: schema_version} = msg
     migration_transactions = InitialSync.migrations_since(schema_version, state.pg_connector_opts)
     {msgs, state} = Protocol.handle_outgoing_txs(migration_transactions, state)
 
-    lsn = CachedWal.Api.get_current_position()
     max_txid = Enum.max_by(migration_transactions, fn {tx, _offset} -> tx.xid end, fn -> 0 end)
 
     state =

--- a/components/electric/test/electric/postgres/extension_test.exs
+++ b/components/electric/test/electric/postgres/extension_test.exs
@@ -203,15 +203,13 @@ defmodule Electric.Postgres.ExtensionTest do
         schema
       end)
 
-    assert {:ok, versions} = Extension.migration_history(conn)
+    assert migrations == migration_history(conn)
 
-    assert migrations == Enum.map(versions, fn {_txid, _txts, v, _, s} -> {v, s} end)
+    [_m1, _m2, m3, m4] = migrations
+    assert [m3, m4] == migration_history(conn, "0002")
 
-    assert {:ok, versions} = Extension.migration_history(conn, "0002")
-
-    versions = Enum.map(versions, fn {_txid, _txts, v, _, s} -> {v, s} end)
-
-    assert versions == Enum.slice(migrations, 2..-1)
+    # When trying to load migrations after a non-existent version, all migrations are returned
+    assert migrations == migration_history(conn, "foo")
   end
 
   test_tx "logical replication ddl is not captured", fn conn ->
@@ -441,5 +439,10 @@ defmodule Electric.Postgres.ExtensionTest do
       refute Extension.electrified?(conn, "daisy")
       refute Extension.electrified?(conn, "public", "daisy")
     end
+  end
+
+  defp migration_history(conn, after_version \\ nil) do
+    assert {:ok, versions} = Extension.migration_history(conn, after_version)
+    Enum.map(versions, fn {_txid, _txts, version, _, sql} -> {version, sql} end)
   end
 end

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -13,7 +13,8 @@ export const open_db = async (
   name: string,
   host: string,
   port: number,
-  migrations: any
+  migrations: any,
+  replicationOptions?: string[]
 ): Promise<Electric> => {
   const original = new Database(name)
   const config: ElectricConfig = {
@@ -21,7 +22,8 @@ export const open_db = async (
     debug: true,
     auth: {
       token: authToken(process.env.SATELLITE_AUTH_SIGNING_ISS, process.env.SATELLITE_AUTH_SIGNING_KEY)
-    }
+    },
+    replicationOptions: replicationOptions
   }
   console.log(`config: ${JSON.stringify(config)}`)
   schema.migrations = migrations

--- a/e2e/tests/3.8_node_satellite_no_duplicate_migrations_after_initial_sync.lux
+++ b/e2e/tests/3.8_node_satellite_no_duplicate_migrations_after_initial_sync.lux
@@ -1,0 +1,64 @@
+[doc When NodeJS Satellite connects to Electric and receives initial migrations, the server guarantees it won't send a repeat migration afterwards]
+[include _shared.luxinc]
+[include _satellite_macros.luxinc]
+
+[invoke setup]
+
+[global migration1_vsn=20230710150000]
+[global migration2_vsn=20230710150001]
+
+[shell pg_1]
+  [local sql=
+    """
+    CREATE TABLE items (id TEXT PRIMARY KEY, content TEXT NOT NULL);
+    CALL electric.electrify('public.items');
+    """]
+  [invoke migrate_pg $migration1_vsn $sql]
+
+# Start a Satellite client and verify that it gets all migrations during initial sync.
+[invoke setup_client 1 "electric_1" 5133]
+
+[shell satellite_1]
+  # Verifying it's a fresh client
+  ?applying migration: 0
+  ?no lsn retrieved from store
+  ?connecting and starting replication
+  ?no previous LSN, start replication with option FIRST_LSN
+
+  ?Sending message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationReq","lsn":\{\}
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationResp"\}
+
+# Verify that the server is paused waiting for the next write in PG
+[shell electric]
+  ?WsServer pausing until the next write
+
+# Commit a new migration. The server will unpause automatically once it sees another write.
+[shell pg_1]
+  [local sql=
+    """
+    CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+    CALL electric.electrify('public.users');
+    """]
+  [invoke migrate_pg $migration2_vsn $sql]
+
+# Verify that the client receives initial migrations
+[shell satellite_1]
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"items"
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"$migration1_vsn",.*,"table":\{.*,"name":"items"
+
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"users"
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"$migration2_vsn",.*,"table":\{.*,"name":"users"
+
+# Verify that the server has filtered out the duplicate migration
+[shell electric]
+  ?Filtering transaction %Electric.Replication.Changes.Transaction\{\
+     ack_fn: nil, \
+     changes: \[\
+       %Electric.Replication.Changes.NewRecord\{record: %\{.*"query" => "CREATE TABLE users
+
+[cleanup]
+  [invoke teardown]

--- a/e2e/tests/3.8_node_satellite_no_duplicate_migrations_after_initial_sync.lux
+++ b/e2e/tests/3.8_node_satellite_no_duplicate_migrations_after_initial_sync.lux
@@ -6,6 +6,7 @@
 
 [global migration1_vsn=20230710150000]
 [global migration2_vsn=20230710150001]
+[global migration3_vsn=20230710150002]
 
 [shell pg_1]
   [local sql=
@@ -59,6 +60,20 @@
      ack_fn: nil, \
      changes: \[\
        %Electric.Replication.Changes.NewRecord\{record: %\{.*"query" => "CREATE TABLE users
+
+# Make sure the server keeps streaming migrations to the client after the initial sync is done.
+[shell pg_1]
+  [local sql=
+    """
+    ALTER TABLE users ADD COLUMN foo TEXT DEFAULT 'bar';
+    """]
+  [invoke migrate_pg $migration3_vsn $sql]
+
+[shell satellite_1]
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatRelation","schemaName":"public",.*"tableName":"users"
+  ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatOpLog","ops":\[\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","begin":\{.*\}\},\
+    \{"\$$type":"Electric.Satellite.v[0-9_]+.SatTransOp","migrate":\{.*,"version":"$migration3_vsn",.*,"table":\{.*,"name":"users"
 
 [cleanup]
   [invoke teardown]

--- a/e2e/tests/3.8_node_satellite_no_duplicate_migrations_after_initial_sync.lux
+++ b/e2e/tests/3.8_node_satellite_no_duplicate_migrations_after_initial_sync.lux
@@ -16,7 +16,7 @@
   [invoke migrate_pg $migration1_vsn $sql]
 
 # Start a Satellite client and verify that it gets all migrations during initial sync.
-[invoke setup_client 1 "electric_1" 5133]
+[invoke setup_client_with_options 1 "electric_1" 5133 "['pauseDuringInitialSync']"]
 
 [shell satellite_1]
   # Verifying it's a fresh client

--- a/e2e/tests/_satellite_macros.luxinc
+++ b/e2e/tests/_satellite_macros.luxinc
@@ -1,6 +1,6 @@
 [global node=>]
 
-[macro connect_to_electric host port migrations]
+[macro connect_to_electric host port migrations options]
     !client = await import('./dist/client.js')
     ?$node
     # !migrations = await client.read_migrations(process.env.MIGRATION_DIRS + "/index.js")
@@ -9,7 +9,8 @@
     !db = await client.open_db( process.env.SATELLITE_DB_PATH + "/$LUX_SHELLNAME", \
                                 "$host", \
                                 $port, \
-                                migrations)
+                                migrations, \
+                                $options)
     ?^$node
 [endmacro]
 
@@ -17,11 +18,18 @@
     [invoke start_satellite $satellite_number]
     -$fail_pattern
     ?$node
-    [invoke connect_to_electric $electric $port $migrations]
+    [invoke connect_to_electric $electric $port $migrations "[]"]
 [endmacro]
 
 [macro setup_client satellite_number electric port]
     [invoke setup_client_with_migrations $satellite_number $electric $port "[]"]
+[endmacro]
+
+[macro setup_client_with_options satellite_number electric port options]
+    [invoke start_satellite $satellite_number]
+    -$fail_pattern
+    ?$node
+    [invoke connect_to_electric $electric $port "[]" $options]
 [endmacro]
 
 [macro node_await_get match]

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -123,6 +123,9 @@ message SatInStartReplicationReq {
     // the subscriptions identifiers the client wants to resume subscription    
     repeated string subscription_ids = 4;
 
+    // The version of the most recent migration seen by the client.
+    optional string schema_version = 5;
+
     // Note:
     // - a client might resume replication only for a subset of previous subscriptions 
     // in case the application cancelled some subscriptions while disconnected from the

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -112,6 +112,8 @@ message SatInStartReplicationReq {
         // Asks receiver to start replication from the last position in the log,
         // whatever this position is. Used for tests only.
         LAST_LSN = 4;
+        // This option is only used by some E2E tests.
+        PAUSE_DURING_INITIAL_SYNC = 5;
     }
     // LSN position of the log on the producer side
     bytes lsn = 1;


### PR DESCRIPTION
Follow-up to https://github.com/electric-sql/electric/pull/225 but based on changes https://github.com/electric-sql/electric/pull/226.

This is a rough implementation that I'm not too happy about. Would love to hear ideas for a simpler approach to testing that the server discards repeat migrations after initial sync.