### PR TITLE
feat(electric): support unsubscribe messages

### DIFF
--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -343,12 +343,23 @@ defmodule Electric.Satellite.Protocol do
   end
 
   # Satellite requests a new subscription to a set of shapes
-  def process_message(%SatSubsReq{subscription_id: id, shape_requests: []}, state)
+  def process_message(%SatSubsReq{subscription_id: id}, state)
       when byte_size(id) > 128 do
     {%SatSubsResp{
        subscription_id: String.slice(id, 1..128) <> "...",
        err: %SatSubsError{
-         message: "ID too long, "
+         message: "ID too long"
+       }
+     }, state}
+  end
+
+  def process_message(%SatSubsReq{subscription_id: id}, state)
+      when is_map_key(state.subscriptions, id) do
+    {%SatSubsResp{
+       subscription_id: id,
+       err: %SatSubsError{
+         message:
+           "Cannot establish multiple subscriptions with the same ID. If you want to change the subscription, you need to unsubscribe first."
        }
      }, state}
   end

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -203,6 +203,7 @@ defmodule Electric.Satellite.Protocol do
 
   @spec process_message(PB.sq_pb_msg(), State.t()) ::
           {nil | :stop | PB.sq_pb_msg() | [PB.sq_pb_msg()], State.t()}
+          | {:force_unpause, PB.sq_pb_msg() | [PB.sq_pb_msg()], State.t()}
           | {:error, PB.sq_pb_msg()}
   def process_message(msg, %State{} = state) when not auth_passed?(state) do
     case msg do
@@ -446,6 +447,27 @@ defmodule Electric.Satellite.Protocol do
       e ->
         Logger.error(Exception.format(:error, e, __STACKTRACE__))
         {:error, %SatErrorResp{error_type: :INVALID_REQUEST}}
+    end
+  end
+
+  def process_message(%SatUnsubsReq{subscription_ids: ids}, %State{} = state) do
+    needs_unpausing? =
+      is_out_rep_paused(state) and Enum.any?(ids, &is_pending_subscription(state, &1))
+
+    out_rep =
+      ids
+      |> Enum.reduce(state.out_rep, &OutRep.remove_pause_point(&2, &1))
+      |> Map.update!(:subscription_data_to_send, &Map.drop(&1, ids))
+
+    state =
+      state
+      |> Map.put(:out_rep, out_rep)
+      |> Map.update!(:subscriptions, &Map.drop(&1, ids))
+
+    if needs_unpausing? do
+      {:force_unpause, %SatUnsubsResp{}, state}
+    else
+      {%SatUnsubsResp{}, state}
     end
   end
 

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -194,6 +194,15 @@ defmodule Electric.Satellite.WsServer do
     {binary_frames(msgs), state}
   end
 
+  def websocket_info({:subscription_data, subscription_id, _, _}, %State{} = state)
+      when not is_map_key(state.subscriptions, subscription_id) do
+    Logger.debug(
+      "Received initial data for unknown subscription #{subscription_id}, likely it has been cancelled"
+    )
+
+    {[], state}
+  end
+
   def websocket_info({:subscription_data, subscription_id, _, data}, %State{} = state)
       when is_out_rep_paused(state) and is_pending_subscription(state, subscription_id) do
     Logger.debug(

--- a/components/electric/test/electric/satellite/subscriptions_test.exs
+++ b/components/electric/test/electric/satellite/subscriptions_test.exs
@@ -311,6 +311,61 @@ defmodule Electric.Satellite.SubscriptionsTest do
                          }}
       end)
     end
+
+    test "The client can connect and subscribe, and then unsubscribe, and gets no data after unsubscribing",
+         %{conn: pg_conn} = ctx do
+      MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
+        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        assert_initial_replication_response(conn, 3)
+
+        request_id = uuid4()
+        sub_id = uuid4()
+
+        MockClient.send_data(conn, %SatSubsReq{
+          subscription_id: sub_id,
+          shape_requests: [
+            %SatShapeReq{
+              request_id: request_id,
+              shape_definition: %SatShapeDef{
+                selects: [%SatShapeDef.Select{tablename: "users"}]
+              }
+            }
+          ]
+        })
+
+        assert_receive {^conn, %SatSubsResp{subscription_id: ^sub_id, err: nil}}
+        assert %{request_id => []} == receive_subscription_data(conn, sub_id)
+
+        {:ok, 1} =
+          :epgsql.equery(pg_conn, "INSERT INTO public.users (id, name) VALUES ($1, $2)", [
+            uuid4(),
+            "Garry"
+          ])
+
+        # We get the message of insertion for a table we have a subscription for
+        assert_receive {^conn,
+                        %SatOpLog{
+                          ops: [
+                            %{op: {:begin, _}},
+                            %{op: {:insert, %{row_data: %{values: [_, "Garry"]}}}},
+                            %{op: {:commit, _}}
+                          ]
+                        }},
+                       1000
+
+        MockClient.send_data(conn, %SatUnsubsReq{subscription_ids: [sub_id]})
+        assert_receive {^conn, %SatUnsubsResp{}}
+
+        {:ok, 1} =
+          :epgsql.equery(pg_conn, "INSERT INTO public.users (id, name) VALUES ($1, $2)", [
+            uuid4(),
+            "Garry"
+          ])
+
+        # But not for the one we don't have included in the subscription
+        refute_receive {^conn, %SatOpLog{}}
+      end)
+    end
   end
 
   defp active_clients() do

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -449,6 +449,39 @@ defmodule Electric.Satellite.WsServerTest do
         refute_receive {^conn, %SatOpLog{}}
       end)
     end
+
+    @tag subscription_data_fun: {:mock_data_function, insertion_point: 4}
+    test "unsubscribing works even on not-yet-fulfilled subscriptions",
+         ctx do
+      with_connect([port: ctx.port, auth: ctx, id: ctx.client_id], fn conn ->
+        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        assert_initial_replication_response(conn, 1)
+
+        [{client_name, _client_pid}] = active_clients()
+        mocked_producer = Producer.name(client_name)
+        subscription_id = "00000000-0000-0000-0000-000000000000"
+
+        MockClient.send_data(conn, %SatSubsReq{
+          subscription_id: subscription_id,
+          shape_requests: [
+            %SatShapeReq{
+              request_id: "fake_id",
+              shape_definition: %SatShapeDef{
+                selects: [%SatShapeDef.Select{tablename: @test_table}]
+              }
+            }
+          ]
+        })
+
+        assert_receive {^conn, %SatSubsResp{subscription_id: sub_id, err: nil}}
+        MockClient.send_data(conn, %SatUnsubsReq{subscription_ids: [sub_id]})
+        assert_receive {^conn, %SatUnsubsResp{}}
+
+        DownstreamProducerMock.produce(mocked_producer, simple_transes(ctx.user_id, 10))
+        refute_receive {^conn, %SatSubsDataBegin{}}
+        refute_receive {^conn, %SatOpLog{}}
+      end)
+    end
   end
 
   describe "Incoming replication (Satellite -> PG)" do

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -386,6 +386,50 @@ defmodule Electric.Satellite.WsServerTest do
       end)
     end
 
+    test "The client cannot establish two subscriptions with the same ID", ctx do
+      MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
+        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        assert_initial_replication_response(conn, 1)
+
+        sub_id = "00000000-0000-0000-0000-000000000000"
+
+        MockClient.send_data(conn, %SatSubsReq{
+          subscription_id: sub_id,
+          shape_requests: [
+            %SatShapeReq{
+              request_id: "request_id1",
+              shape_definition: %SatShapeDef{
+                selects: [%SatShapeDef.Select{tablename: @test_table}]
+              }
+            }
+          ]
+        })
+
+        MockClient.send_data(conn, %SatSubsReq{
+          subscription_id: sub_id,
+          shape_requests: [
+            %SatShapeReq{
+              request_id: "request_id1",
+              shape_definition: %SatShapeDef{
+                selects: [%SatShapeDef.Select{tablename: @test_table}]
+              }
+            }
+          ]
+        })
+
+        assert_receive {^conn, %SatSubsResp{subscription_id: ^sub_id, err: nil}}
+
+        assert_receive {^conn,
+                        %SatSubsResp{
+                          subscription_id: ^sub_id,
+                          err: %{
+                            message:
+                              "Cannot establish multiple subscriptions with the same ID" <> _
+                          }
+                        }}
+      end)
+    end
+
     @tag subscription_data_fun: {:mock_data_function, data_delay_ms: 500}
     test "replication stream is paused until the data is sent to client", ctx do
       with_connect([port: ctx.port, auth: ctx, id: ctx.client_id], fn conn ->

--- a/components/electric/test/test_helper.exs
+++ b/components/electric/test/test_helper.exs
@@ -3,7 +3,7 @@ if System.get_env("INTEGRATION") do
 else
   Mox.defmock(Electric.Replication.MockPostgresClient, for: Electric.Replication.Postgres.Client)
   ExUnit.configure(capture_log: true, exclude: :integration, timeout: 15_000)
-  Logger.configure(level: :debug)
+  Logger.configure(level: :info)
 end
 
 File.rm(

--- a/components/electric/test/test_helper.exs
+++ b/components/electric/test/test_helper.exs
@@ -3,7 +3,7 @@ if System.get_env("INTEGRATION") do
 else
   Mox.defmock(Electric.Replication.MockPostgresClient, for: Electric.Replication.Postgres.Client)
   ExUnit.configure(capture_log: true, exclude: :integration, timeout: 15_000)
-  Logger.configure(level: :info)
+  Logger.configure(level: :debug)
 end
 
 File.rm(


### PR DESCRIPTION
Adds support for the `SatUnsubsReq` message, that stops ongoing subscriptions. That means the client will no longer receive data for that particular subscription, and any yet-unfulfilled subscription listed in the unsubscribe request will get immediately cancelled and their data discarded.

Note: E2E tests are missing because although `unsubscribe` call can be issued by the client, we're yet to expose a public interface for it to e2e test.