### PR TITLE
client: rename dbSchema to schema.

### DIFF
--- a/clients/typescript/test/client/generated/index.ts
+++ b/clients/typescript/test/client/generated/index.ts
@@ -3348,5 +3348,5 @@ export const tableSchemas = {
   >,
 }
 
-export const dbSchema = new DbSchema(tableSchemas, [])
-export type Electric = ElectricClient<typeof dbSchema>
+export const schema = new DbSchema(tableSchemas, [])
+export type Electric = ElectricClient<typeof schema>

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import Log from 'loglevel'
 import Database from 'better-sqlite3'
-import { dbSchema } from '../generated'
+import { schema } from '../generated'
 import { DatabaseAdapter } from '../../../src/drivers/better-sqlite3'
 import {
   shapeManager,
@@ -51,7 +51,7 @@ const config = {
 async function makeContext(t: ExecutionContext) {
   const client = new MockSatelliteClient()
   const adapter = new DatabaseAdapter(db)
-  const migrations = dbSchema.migrations
+  const migrations = schema.migrations
   const migrator = new BundleMigrator(adapter, migrations)
   const dbName = `.tmp/test-${randomValue()}.db`
   const notifier = new MockNotifier(dbName)
@@ -67,7 +67,7 @@ async function makeContext(t: ExecutionContext) {
 
   const ns = new ElectricNamespace(adapter, notifier)
   shapeManager.init(satellite)
-  const electric = ElectricClient.create(dbSchema, ns)
+  const electric = ElectricClient.create(schema, ns)
   const Post = electric.db.Post
   const Items = electric.db.Items
   const User = electric.db.User
@@ -91,15 +91,15 @@ async function makeContext(t: ExecutionContext) {
   init()
 }
 
-type TableType<T extends keyof ElectricClient<typeof dbSchema>['db']> =
-  ElectricClient<typeof dbSchema>['db'][T]
+type TableType<T extends keyof ElectricClient<typeof schema>['db']> =
+  ElectricClient<typeof schema>['db'][T]
 type ContextType = {
   dbName: string
   db: typeof db
   satellite: SatelliteProcess
   client: MockSatelliteClient
   runMigrations: () => Promise<number>
-  electric: ElectricClient<typeof dbSchema>
+  electric: ElectricClient<typeof schema>
   Post: TableType<'Post'>
   Items: TableType<'Items'>
   User: TableType<'User'>

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import Database from 'better-sqlite3'
 import { electrify } from '../../../src/drivers/better-sqlite3'
-import { dbSchema } from '../generated'
+import { schema } from '../generated'
 import { ZodError } from 'zod'
 import { InvalidArgumentError } from '../../../src/client/validation/errors/invalidArgumentError'
 import {
@@ -16,7 +16,7 @@ import {
  */
 
 const db = new Database(':memory:')
-const electric = await electrify(db, dbSchema, {
+const electric = await electrify(db, schema, {
   auth: {
     token: 'test-token',
   },

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -9,14 +9,14 @@ import {
   _NOT_UNIQUE_,
   _RECORD_NOT_FOUND_,
 } from '../../../src/client/validation/errors/messages'
-import { dbSchema, Post } from '../generated'
+import { schema, Post } from '../generated'
 import {
   shapeManager,
   ShapeManagerMock,
 } from '../../../src/client/model/shapes'
 
 const db = new Database(':memory:')
-const electric = await electrify(db, dbSchema, {
+const electric = await electrify(db, schema, {
   auth: {
     token: 'test-token',
   },

--- a/clients/typescript/test/client/notifications.test.ts
+++ b/clients/typescript/test/client/notifications.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import Database from 'better-sqlite3'
 import { electrify } from '../../src/drivers/better-sqlite3'
-import { dbSchema } from './generated'
+import { schema } from './generated'
 import { shapeManager, ShapeManagerMock } from '../../src/client/model/shapes'
 
 // Use a mocked shape manager for these tests
@@ -16,7 +16,7 @@ const config = {
   },
 }
 
-const { notifier, adapter, db } = await electrify(conn, dbSchema, config)
+const { notifier, adapter, db } = await electrify(conn, schema, config)
 await db.Items.sync() // sync the Items table
 
 async function runAndCheckNotifications(f: () => Promise<void>) {

--- a/clients/typescript/test/example-typing-usage/better-sqlite3.ts
+++ b/clients/typescript/test/example-typing-usage/better-sqlite3.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3'
 
 import { electrify } from '../../src/drivers/better-sqlite3'
-import { dbSchema } from '../client/generated'
+import { schema } from '../client/generated'
 
 const config = {
   auth: {
@@ -12,7 +12,7 @@ const config = {
 const original = new Database('example.db')
 
 // Electrify the DB and use the DAL to query the `Items` table
-const { db } = await electrify(original, dbSchema, config)
+const { db } = await electrify(original, schema, config)
 await db.Items.findMany({
   select: {
     value: true,

--- a/clients/typescript/test/example-typing-usage/cordova-sqlite-storage.ts
+++ b/clients/typescript/test/example-typing-usage/cordova-sqlite-storage.ts
@@ -1,5 +1,5 @@
 import { electrify } from '../../src/drivers/cordova-sqlite-storage'
-import { dbSchema } from '../client/generated'
+import { schema } from '../client/generated'
 
 const config = {
   auth: {
@@ -14,7 +14,7 @@ const opts = {
 
 document.addEventListener('deviceready', () => {
   window.sqlitePlugin.openDatabase(opts, async (original) => {
-    const { db } = await electrify(original, dbSchema, config)
+    const { db } = await electrify(original, schema, config)
     await db.Items.findMany({
       select: {
         value: true,

--- a/clients/typescript/test/example-typing-usage/expo-sqlite.ts
+++ b/clients/typescript/test/example-typing-usage/expo-sqlite.ts
@@ -1,7 +1,7 @@
 import * as SQLite from 'expo-sqlite'
 
 import { electrify } from '../../src/drivers/expo-sqlite'
-import { dbSchema } from '../client/generated'
+import { schema } from '../client/generated'
 
 const config = {
   auth: {
@@ -11,7 +11,7 @@ const config = {
 
 const original = SQLite.openDatabase('example.db')
 
-const { db } = await electrify(original, dbSchema, config)
+const { db } = await electrify(original, schema, config)
 await db.Items.findMany({
   select: {
     value: true,

--- a/clients/typescript/test/example-typing-usage/react-native-sqlite-storage.ts
+++ b/clients/typescript/test/example-typing-usage/react-native-sqlite-storage.ts
@@ -1,6 +1,6 @@
 import SQLite from 'react-native-sqlite-storage'
 import { electrify } from '../../src/drivers/react-native-sqlite-storage'
-import { dbSchema } from '../client/generated'
+import { schema } from '../client/generated'
 
 // You can use the driver with or without the promise API enabled.
 // Either way, you need to pass in a flag to the `electrify` function
@@ -15,7 +15,7 @@ const config = {
 }
 
 const original = await SQLite.openDatabase({ name: 'example.db' })
-const { db } = await electrify(original, dbSchema, promisesEnabled, config)
+const { db } = await electrify(original, schema, promisesEnabled, config)
 
 await db.Items.findMany({
   select: {

--- a/clients/typescript/test/frameworks/react.test.tsx
+++ b/clients/typescript/test/frameworks/react.test.tsx
@@ -17,7 +17,7 @@ import { QualifiedTablename } from '../../src/util/tablename'
 import { useLiveQuery } from '../../src/frameworks/react/hooks'
 import { makeElectricContext } from '../../src/frameworks/react/provider'
 import { ElectricClient } from '../../src/client/model/client'
-import { dbSchema, Electric } from '../client/generated'
+import { schema, Electric } from '../client/generated'
 
 const assert = (stmt: any, msg: string = 'Assertion failed.'): void => {
   if (!stmt) {
@@ -35,7 +35,7 @@ test('useLiveQuery returns query results', async (t) => {
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
   const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(dbSchema, namespace)
+  const dal = ElectricClient.create(schema, namespace)
 
   const query = 'select i from bars'
   const liveQuery = dal.db.liveRaw({
@@ -58,7 +58,7 @@ test('useLiveQuery returns error when query errors', async (t) => {
 
   const notifier = new MockNotifier('test.db')
   const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(dbSchema, namespace)
+  const dal = ElectricClient.create(schema, namespace)
 
   const wrapper: FC = ({ children }) => {
     return <ElectricProvider db={dal}>{children}</ElectricProvider>
@@ -79,7 +79,7 @@ test('useLiveQuery re-runs query when data changes', async (t) => {
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
   const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(dbSchema, namespace)
+  const dal = ElectricClient.create(schema, namespace)
 
   const query = 'select foo from bars'
   const liveQuery = dal.db.liveRaw({
@@ -115,7 +115,7 @@ test('useLiveQuery re-runs query when *aliased* data changes', async (t) => {
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
   const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(dbSchema, namespace)
+  const dal = ElectricClient.create(schema, namespace)
 
   await notifier.attach('baz.db', 'baz')
 

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -5,7 +5,7 @@ import { authToken } from 'electric-sql/auth'
 import { setLogLevel } from 'electric-sql/debug'
 import { electrify } from 'electric-sql/node'
 import { v4 as uuidv4 } from 'uuid'
-import { dbSchema, Electric } from './generated/models'
+import { schema, Electric } from './generated/models'
 
 setLogLevel('DEBUG')
 
@@ -24,8 +24,8 @@ export const open_db = async (
     }
   }
   console.log(`config: ${JSON.stringify(config)}`)
-  dbSchema.migrations = migrations
-  return await electrify(original, dbSchema, config)
+  schema.migrations = migrations
+  return await electrify(original, schema, config)
 }
 
 export const set_subscribers = (db: Electric) => {

--- a/e2e/satellite_client/src/generated/models/index.ts
+++ b/e2e/satellite_client/src/generated/models/index.ts
@@ -795,5 +795,5 @@ export const tableSchemas = {
   >,
 }
 
-export const dbSchema = new DbSchema(tableSchemas, migrations)
-export type Electric = ElectricClient<typeof dbSchema>
+export const schema = new DbSchema(tableSchemas, migrations)
+export type Electric = ElectricClient<typeof schema>

--- a/examples/web-wa-sqlite/README.md
+++ b/examples/web-wa-sqlite/README.md
@@ -113,7 +113,7 @@ export const Example = () => {
   useEffect(() => {
     const init = async () => {
       const conn = await ElectricDatabase.init('electric.db', '')
-      const db = await electrify(conn, dbSchema, config)
+      const db = await electrify(conn, schema, config)
       setElectric(db)
     }
     init()

--- a/examples/web-wa-sqlite/src/Example.tsx
+++ b/examples/web-wa-sqlite/src/Example.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import './Example.css'
 
-import { dbSchema, Electric } from './generated/client'
+import { schema, Electric } from './generated/client'
 import { electrify, ElectricDatabase } from 'electric-sql/wa-sqlite'
 import { makeElectricContext, useLiveQuery } from 'electric-sql/react'
 
@@ -19,7 +19,7 @@ export const Example = () => {
   useEffect(() => {
     const init = async () => {
       const conn = await ElectricDatabase.init('electric.db', '')
-      const db = await electrify(conn, dbSchema, config)
+      const db = await electrify(conn, schema, config)
       setElectric(db)
     }
 

--- a/generator/src/functions/tableDescriptionWriters/writeTableSchemas.ts
+++ b/generator/src/functions/tableDescriptionWriters/writeTableSchemas.ts
@@ -72,8 +72,8 @@ export function writeTableSchemas(
     .blankLine()
 
   writer
-    .writeLine('export const dbSchema = new DbSchema(tableSchemas, migrations)')
-    .writeLine('export type Electric = ElectricClient<typeof dbSchema>')
+    .writeLine('export const schema = new DbSchema(tableSchemas, migrations)')
+    .writeLine('export type Electric = ElectricClient<typeof schema>')
 }
 
 export function writeFieldNamesArray(


### PR DESCRIPTION
Hey, mind if I rename this? It just makes all the initial instantiation examples much sweeter to be:

```tsx
await electrify(conn, schema, config)
```

As opposed to:

```tsx
await electrify(conn, dbSchema, config)
```

I'll obviously update the docs. I think this catches all the current uses, certainly in the monorepo.