### PR TITLE
feat(electric): allow subscription resume on reconnect

### DIFF
--- a/components/electric/lib/electric/application.ex
+++ b/components/electric/lib/electric/application.ex
@@ -23,6 +23,7 @@ defmodule Electric.Application do
       Electric.Postgres.SchemaRegistry,
       Electric.Replication.OffsetStorage,
       {Plug.Cowboy, scheme: :http, plug: Electric.Plug.Router, options: [port: status_port()]},
+      Electric.Satellite.SubscriptionManager,
       Electric.Satellite.ClientManager,
       Electric.Replication.Connectors,
       Electric.Satellite.WsServer.child_spec(

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -318,6 +318,8 @@ defmodule Electric.Satellite.Protocol do
             {[%SatInStartReplicationResp{}], state}
           end
         else
+          # Once the client is outside the WAL window, we are assuming the client will re-establish subscriptions, so we'll discard them
+          SubscriptionManager.delete_all_subscriptions(state.client_id)
           error = %SatInStartReplicationResp.ReplicationError{code: :BEHIND_WINDOW}
           {[%SatInStartReplicationResp{err: error}], state}
         end

--- a/components/electric/lib/electric/satellite/subscription_manager.ex
+++ b/components/electric/lib/electric/satellite/subscription_manager.ex
@@ -9,6 +9,8 @@ defmodule Electric.Satellite.SubscriptionManager do
   use GenServer
   require Logger
 
+  alias Electric.Replication.Shapes.ShapeRequest
+
   @ets_table :saved_subscription_ids
 
   def start_link(_) do
@@ -18,7 +20,7 @@ defmodule Electric.Satellite.SubscriptionManager do
   @doc """
   Saves the given shape requests under given subscription id for this client
   """
-  @spec save_subscription(String.t(), String.t(), [term()]) :: :ok
+  @spec save_subscription(String.t(), String.t(), [ShapeRequest.t()]) :: :ok
   def save_subscription(client_id, subscription_id, shape_requests) do
     GenServer.call(__MODULE__, {:save_subscription, {client_id, subscription_id}, shape_requests})
   end
@@ -26,7 +28,7 @@ defmodule Electric.Satellite.SubscriptionManager do
   @doc """
   Finds the shape requests associated with a given subscription id for this client
   """
-  @spec fetch_subscription(String.t(), String.t()) :: {:ok, term()} | :error
+  @spec fetch_subscription(String.t(), String.t()) :: {:ok, ShapeRequest.t()} | :error
   def fetch_subscription(client_id, subscription_id) do
     case :ets.lookup(@ets_table, {client_id, subscription_id}) do
       [] -> :error

--- a/components/electric/lib/electric/satellite/subscription_manager.ex
+++ b/components/electric/lib/electric/satellite/subscription_manager.ex
@@ -1,0 +1,81 @@
+defmodule Electric.Satellite.SubscriptionManager do
+  @moduledoc """
+  Keep track of previously-established subscriptions to be able to resume them.
+
+  Currently this uses an ETS without "cold storage" because subscription continuation
+  is tied to being able to resume from the PG cached WAL, which is neither persisted
+  nor restored for now.
+  """
+  use GenServer
+  require Logger
+
+  @ets_table :saved_subscription_ids
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc """
+  Saves the given shape requests under given subscription id for this client
+  """
+  @spec save_subscription(String.t(), String.t(), [term()]) :: :ok
+  def save_subscription(client_id, subscription_id, shape_requests) do
+    GenServer.call(__MODULE__, {:save_subscription, {client_id, subscription_id}, shape_requests})
+  end
+
+  @doc """
+  Finds the shape requests associated with a given subscription id for this client
+  """
+  @spec fetch_subscription(String.t(), String.t()) :: {:ok, term()} | :error
+  def fetch_subscription(client_id, subscription_id) do
+    case :ets.lookup(@ets_table, {client_id, subscription_id}) do
+      [] -> :error
+      [{_key, data}] -> {:ok, data}
+    end
+  end
+
+  @doc """
+  Remove a subscription for a client
+  """
+  @spec delete_subscription(String.t(), String.t()) :: :ok
+  def delete_subscription(client_id, subscription_id) do
+    GenServer.call(__MODULE__, {:delete_subscription, {client_id, subscription_id}})
+  end
+
+  @doc """
+  Remove all subscriptions for a client
+  """
+  @spec delete_all_subscriptions(String.t()) :: :ok
+  def delete_all_subscriptions(client_id) do
+    GenServer.call(__MODULE__, {:delete_all_subscriptions, client_id})
+  end
+
+  # GenServer API
+
+  @impl GenServer
+  def init(_) do
+    Logger.metadata(component: "SubscriptionManager")
+    table = :ets.new(@ets_table, [:named_table, :protected, :set])
+    {:ok, %{table: table}}
+  end
+
+  @impl GenServer
+  def handle_call({:save_subscription, key, shape_requests}, _, state) do
+    Logger.debug("Saved subscription #{inspect(key)}")
+    :ets.insert(state.table, {key, shape_requests})
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:delete_subscription, key}, _, state) do
+    :ets.delete(state.table, key)
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:delete_all_subscriptions, client_id}, _, state) do
+    :ets.match_delete(state.table, {{client_id, :_}, :_})
+
+    {:reply, :ok, state}
+  end
+end

--- a/components/electric/lib/satellite/satellite_ws_client.ex
+++ b/components/electric/lib/satellite/satellite_ws_client.ex
@@ -60,6 +60,8 @@ defmodule Electric.Test.SatelliteWsClient do
           | {:id, term()}
           # Automatically subscribe to Electric starting from lsn
           | {:sub, String.t()}
+          # Request to continue following subscriptions
+          | {:subscription_ids, [String.t()]}
           | {:auto_register, boolean()}
 
   @type conn() :: atom() | pid()
@@ -581,7 +583,7 @@ defmodule Electric.Test.SatelliteWsClient do
         Logger.debug("Subscribed")
 
       lsn ->
-        sub_req = serialize(%SatInStartReplicationReq{lsn: lsn})
+        sub_req = serialize(%SatInStartReplicationReq{lsn: lsn, subscription_ids: Keyword.get(opts, :subscription_ids, [])})
         :gun.ws_send(conn, stream_ref, {:binary, sub_req})
         Logger.debug("Subscribed")
     end

--- a/components/electric/lib/satellite/satellite_ws_client.ex
+++ b/components/electric/lib/satellite/satellite_ws_client.ex
@@ -583,7 +583,12 @@ defmodule Electric.Test.SatelliteWsClient do
         Logger.debug("Subscribed")
 
       lsn ->
-        sub_req = serialize(%SatInStartReplicationReq{lsn: lsn, subscription_ids: Keyword.get(opts, :subscription_ids, [])})
+        sub_req =
+          serialize(%SatInStartReplicationReq{
+            lsn: lsn,
+            subscription_ids: Keyword.get(opts, :subscription_ids, [])
+          })
+
         :gun.ws_send(conn, stream_ref, {:binary, sub_req})
         Logger.debug("Subscribed")
     end

--- a/e2e/tests/2.6_subscriptions_can_be_resumed_on_reconnect.lux
+++ b/e2e/tests/2.6_subscriptions_can_be_resumed_on_reconnect.lux
@@ -1,0 +1,49 @@
+[doc PG writes stream to connected Satellite]
+[global fail_pattern=[Ee][Rr][Rr][Oo][Rr]]
+[include _shared.luxinc]
+
+[invoke setup]
+[invoke electrify_table pg_1 entries ]
+
+[global user_id_1=1]
+[newshell user_1_ws1]
+    -($fail_pattern|bad sentined value)
+    [invoke start_elixir_test 1]
+    [invoke client_session $user_id_1 1]
+    [invoke elixir_client_subscribe_with_id "00000000-0000-0000-0000-000000000000" "entries"]
+
+[shell pg_1]
+    !BEGIN;
+    !INSERT INTO entries (id, content) VALUES ('00000000-0000-0000-0000-000000000000', 'sentinel value');
+    # Table `owned_entries` is not electrified and not subscribed, so we shouldn't see it
+    !INSERT INTO owned_entries (id, electric_user_id, content) VALUES ('00000000-0000-0000-0000-000000000000', 'test', 'bad sentinel value');
+    !COMMIT;
+    ?$psql
+
+[shell user_1_ws1]
+    # We expect to receive the transaction on Satellite
+    ?rec \[\d+\]: %Electric.Satellite.V\d+.SatOpLog\{(?:.*)lsn: "(\d+)"(?:.*)row_data: %Electric\.Satellite\.V\d+\.SatOpRow\{
+    [local lsn=$1]
+    ?values: \["00000000-0000-0000-0000-000000000000", "sentinel value", ""\]
+    ?\}
+    ?tags: \["postgres_1@\d{13,16}"\]
+    ?\}
+    !:proc_lib.stop(conn)
+    ?$eprompt
+
+# New row inserted while client is "offline"
+[shell pg_1]
+    !INSERT INTO entries (id, content) VALUES ('00000000-0000-0000-0000-000000000001', 'sentinel value');
+    ?$psql
+
+[shell user_1_ws1]
+    [invoke client_session_continue $user_id_1 1 $lsn "00000000-0000-0000-0000-000000000000"]
+    # We expect to receive the transaction on Satellite immediately after reconnect
+    ?rec \[\d+\]: %Electric.Satellite.V\d+.SatOpLog\{(?:.*)row_data: %Electric\.Satellite\.V\d+\.SatOpRow\{
+    ?values: \["00000000-0000-0000-0000-000000000001", "sentinel value", ""\]
+    ?\}
+    ?tags: \["postgres_1@\d{13,16}"\]
+    ?\}
+
+[cleanup]
+    [invoke teardown]

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -56,7 +56,7 @@
 [macro client_session_continue user_id session_id position subscription_ids]
     [invoke log "user ${user_id}: session ${session_id}: start"]
     [local client_id=client_${user_id}_${session_id}]
-    !auth_config = Electric.Satellite.Auth.JWT.build_config!( \
+    !auth_config = Electric.Satellite.Auth.Secure.build_config!( \
                      alg: "HS256", key: "integration-tests-signing-key-example" \
                    )
     ?$eprompt

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -53,9 +53,40 @@
     ?rec \[\d\]: %Electric.Satellite.V\d+.SatInStartReplicationResp\{
 [endmacro]
 
+[macro client_session_continue user_id session_id position subscription_ids]
+    [invoke log "user ${user_id}: session ${session_id}: start"]
+    [local client_id=client_${user_id}_${session_id}]
+    !auth_config = Electric.Satellite.Auth.JWT.build_config!( \
+                     alg: "HS256", key: "integration-tests-signing-key-example" \
+                   )
+    ?$eprompt
+    """!{:ok, conn} = Electric.Test.SatelliteWsClient.connect_and_spawn(
+                        auth: %{auth_config: auth_config, user_id: "$user_id"},
+                        id: "$client_id",
+                        debug: true,
+                        sub: "$position",
+                        subscription_ids: ~w|$subscription_ids|,
+                        auto_in_sub: true,
+                        format: :term,
+                        host: "electric_1",
+                        auto_ping: true)
+    """
+    ?+$eprompt
+    ?+sending to: (.*)%Electric.Satellite.V\d+.SatInStartReplicationReq\{(.*)lsn: "", ([^\}]*)\}
+    ?rec \[\d\]: %Electric.Satellite.V\d+.SatInStartReplicationResp\{
+[endmacro]
+
 [macro elixir_client_subscribe tables]
     """!
     Electric.Test.SatelliteWsClient.send_data(conn, Electric.Test.SatelliteWsClient.build_subscription_request(request_1: [tables: ~w|$tables|]))
+    """
+    ?+$eprompt
+    ?rec \[\d\]: %Electric.Satellite.V\d+.SatSubsResp\{[^\}]+err: nil
+[endmacro]
+
+[macro elixir_client_subscribe_with_id id tables]
+    """!
+    Electric.Test.SatelliteWsClient.send_data(conn, Electric.Test.SatelliteWsClient.build_subscription_request("$id", request_1: [tables: ~w|$tables|]))
     """
     ?+$eprompt
     ?rec \[\d\]: %Electric.Satellite.V\d+.SatSubsResp\{[^\}]+err: nil


### PR DESCRIPTION
Allow subscription resume on reconnect by accepting a list of subscriptions the client wants to continue. The subscriptions are stored **in memory** for now, which aligns with how we allow subscriptions to resume -- only if still within the cached WAL window. WAL cache is in memory, so storing subscriptions with a "longer" lifetime makes little sense for now. If the client ever tries to connect outside the window, we immediately consider them fallen behind and remove saved subscriptions.