### PR TITLE
feat(Satellite, DAL): rename `dataReceived` and `Sub`

### DIFF
--- a/clients/typescript/src/client/model/model.ts
+++ b/clients/typescript/src/client/model/model.ts
@@ -8,7 +8,7 @@ import { DeleteInput, DeleteManyInput } from '../input/deleteInput'
 import { QualifiedTablename } from '../../util/tablename'
 import { HKT, Kind } from '../util/hkt'
 import { SyncInput } from '../input/syncInput'
-import { Sub } from '../../satellite/process'
+import { ShapeSubscription } from '../../satellite/process'
 
 /**
  * Interface that is implemented by Electric clients.
@@ -24,7 +24,7 @@ export interface Model<
   ScalarFieldEnum,
   GetPayload extends HKT
 > {
-  sync<T extends SyncInput<Include>>(i?: T): Promise<Sub>
+  sync<T extends SyncInput<Include>>(i?: T): Promise<ShapeSubscription>
 
   /**
    * Creates a unique record in the DB.

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -41,14 +41,14 @@ export class ShapeManager implements IShapeManager {
 
     const sub = await this.satellite.subscribe([shapeDef])
 
-    const dataReceivedProm = sub.dataReceived.then(() => {
+    const dataReceivedProm = sub.synced.then(() => {
       // When all data is received
       // we store the fact that these tables are synced
       shape.tables.forEach((tbl) => this.tablesPreviouslySubscribed.add(tbl))
     })
 
     return {
-      dataReceived: dataReceivedProm,
+      synced: dataReceivedProm,
     }
   }
 
@@ -67,7 +67,7 @@ export class ShapeManagerMock extends ShapeManager {
     shape.tables.forEach((tbl) => this.tablesPreviouslySubscribed.add(tbl))
 
     return {
-      dataReceived: Promise.resolve(),
+      synced: Promise.resolve(),
     }
   }
 }

--- a/clients/typescript/src/client/model/shapes.ts
+++ b/clients/typescript/src/client/model/shapes.ts
@@ -1,4 +1,4 @@
-import { Satellite, Sub } from '../../satellite'
+import { Satellite, ShapeSubscription } from '../../satellite'
 
 export type TableName = string
 
@@ -8,7 +8,7 @@ export type Shape = {
 
 interface IShapeManager {
   init(satellite: Satellite): void
-  sync(shape: Shape): Promise<Sub>
+  sync(shape: Shape): Promise<ShapeSubscription>
   hasBeenSubscribed(shape: TableName): boolean
 }
 
@@ -24,7 +24,7 @@ export class ShapeManager implements IShapeManager {
     this.satellite = satellite
   }
 
-  async sync(shape: Shape): Promise<Sub> {
+  async sync(shape: Shape): Promise<ShapeSubscription> {
     if (this.satellite === undefined)
       throw new Error(
         'Shape cannot be synced because the `ShapeManager` is not yet initialised.'
@@ -62,7 +62,7 @@ export class ShapeManagerMock extends ShapeManager {
     super()
   }
 
-  override async sync(shape: Shape): Promise<Sub> {
+  override async sync(shape: Shape): Promise<ShapeSubscription> {
     // Do not contact the server but directly store the synced tables
     shape.tables.forEach((tbl) => this.tablesPreviouslySubscribed.add(tbl))
 

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -32,7 +32,7 @@ import * as z from 'zod'
 import { parseTableNames, Row, Statement } from '../../util'
 import { NarrowInclude } from '../input/inputNarrowing'
 import { shapeManager } from './shapes'
-import { Sub } from '../../satellite'
+import { ShapeSubscription } from '../../satellite'
 
 type AnyTable = Table<any, any, any, any, any, any, any, any, any, HKT>
 
@@ -163,7 +163,7 @@ export class Table<
     return includedTables
   }
 
-  sync<T extends SyncInput<Include>>(i?: T): Promise<Sub> {
+  sync<T extends SyncInput<Include>>(i?: T): Promise<ShapeSubscription> {
     const validatedInput = this.syncSchema.parse(i ?? {})
     // Recursively go over the included fields
     // and for each field store its table

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -22,11 +22,11 @@ import {
   SubscriptionErrorCallback,
   UnsubscribeResponse,
 } from './shapes/types'
-import { Sub } from './process'
+import { ShapeSubscription } from './process'
 
 export { SatelliteProcess } from './process'
 export { GlobalRegistry, globalRegistry } from './registry'
-export type { Sub } from './process'
+export type { ShapeSubscription } from './process'
 
 // `Registry` that starts one Satellite process per database.
 export interface Registry {
@@ -63,7 +63,9 @@ export interface Satellite {
     opts?: SatelliteReplicationOptions
   ): Promise<ConnectionWrapper>
   stop(): Promise<void>
-  subscribe(shapeDefinitions: ClientShapeDefinition[]): Promise<Sub>
+  subscribe(
+    shapeDefinitions: ClientShapeDefinition[]
+  ): Promise<ShapeSubscription>
   unsubscribe(shapeUuid: string): Promise<void>
 }
 

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -44,7 +44,7 @@ import {
   SatSubsDataError_ShapeReqError,
   SatSubsDataError_ShapeReqError_Code,
 } from '../_generated/protocol/satellite'
-import { Sub } from './process'
+import { ShapeSubscription } from './process'
 
 export const MOCK_BEHIND_WINDOW_LSN = 42
 export const MOCK_INVALID_POSITION_LSN = 27
@@ -72,7 +72,9 @@ export class MockSatelliteProcess implements Satellite {
     this.socketFactory = socketFactory
     this.opts = opts
   }
-  subscribe(_shapeDefinitions: ClientShapeDefinition[]): Promise<Sub> {
+  subscribe(
+    _shapeDefinitions: ClientShapeDefinition[]
+  ): Promise<ShapeSubscription> {
     return Promise.resolve({
       dataReceived: Promise.resolve(),
     })

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -76,7 +76,7 @@ export class MockSatelliteProcess implements Satellite {
     _shapeDefinitions: ClientShapeDefinition[]
   ): Promise<ShapeSubscription> {
     return Promise.resolve({
-      dataReceived: Promise.resolve(),
+      synced: Promise.resolve(),
     })
   }
 

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -81,7 +81,7 @@ type ChangeAccumulator = {
   [key: string]: Change
 }
 
-export type Sub = {
+export type ShapeSubscription = {
   dataReceived: Promise<void>
 }
 
@@ -308,7 +308,9 @@ export class SatelliteProcess implements Satellite {
     await this.client.close()
   }
 
-  async subscribe(shapeDefinitions: ClientShapeDefinition[]): Promise<Sub> {
+  async subscribe(
+    shapeDefinitions: ClientShapeDefinition[]
+  ): Promise<ShapeSubscription> {
     const shapeReqs: ShapeRequest[] = shapeDefinitions.map((definition) => ({
       requestId: this.shapeRequestIdGenerator(),
       definition,

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -82,7 +82,7 @@ type ChangeAccumulator = {
 }
 
 export type ShapeSubscription = {
-  dataReceived: Promise<void>
+  synced: Promise<void>
 }
 
 const throwErrors = [
@@ -345,7 +345,7 @@ export class SatelliteProcess implements Satellite {
     this.subscriptions.subscriptionRequested(subscriptionId, shapeReqs)
 
     return {
-      dataReceived: prom,
+      synced: prom,
     }
   }
 

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -225,17 +225,17 @@ test.serial('promise resolves when subscription starts loading', async (t) => {
   client.setRelationData('Post', post)
 
   const { Post } = t.context as ContextType
-  const { dataReceived } = await Post.sync()
+  const { synced } = await Post.sync()
   // always await this promise otherwise the next test may issue a subscription
   // while this one is not yet fulfilled and that will lead to issues
-  await dataReceived
+  await synced
   t.pass()
 })
 
 // resolves when starts loading
 // resolves when data is fulfilled
 test.serial(
-  'dataReceived promise resolves when subscription is fulfilled',
+  'synced promise resolves when subscription is fulfilled',
   async (t) => {
     Object.setPrototypeOf(shapeManager, ShapeManager.prototype)
 
@@ -246,8 +246,8 @@ test.serial(
     client.setRelationData('Post', post)
 
     const { Post } = t.context as ContextType
-    const { dataReceived } = await Post.sync()
-    await dataReceived
+    const { synced } = await Post.sync()
+    await synced
 
     // Check that the data was indeed received
     const posts = await Post.findMany()
@@ -268,7 +268,7 @@ test.serial('promise is rejected on failed subscription request', async (t) => {
   }
 })
 
-test.serial('dataReceived promise is rejected on invalid shape', async (t) => {
+test.serial('synced promise is rejected on invalid shape', async (t) => {
   const { satellite } = t.context as ContextType
   await satellite.start(config.auth)
 
@@ -276,13 +276,13 @@ test.serial('dataReceived promise is rejected on invalid shape', async (t) => {
   let loadingPromResolved = false
 
   try {
-    const { dataReceived } = await User.sync()
+    const { synced } = await User.sync()
     loadingPromResolved = true
-    await dataReceived
+    await synced
     t.fail()
   } catch (_e) {
     // fails if first promise got rejected
-    // instead of the `dataReceived` promise
+    // instead of the `synced` promise
     t.assert(loadingPromResolved)
     t.pass()
   }

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1275,8 +1275,8 @@ test('apply shape data and persist subscription', async (t) => {
   }
 
   satellite!.relations = relations
-  const { dataReceived } = await satellite.subscribe([shapeDef])
-  await dataReceived
+  const { synced } = await satellite.subscribe([shapeDef])
+  await synced
 
   // wait for process to apply shape data
   try {
@@ -1319,8 +1319,8 @@ test('applied shape data will be acted upon correctly', async (t) => {
   }
 
   satellite!.relations = relations
-  const { dataReceived } = await satellite.subscribe([shapeDef])
-  await dataReceived
+  const { synced } = await satellite.subscribe([shapeDef])
+  await synced
 
   // wait for process to apply shape data
   try {
@@ -1371,8 +1371,8 @@ test('a subscription that failed to apply because of FK constraint triggers GC',
   }
 
   satellite!.relations = relations
-  const { dataReceived } = await satellite.subscribe([shapeDef1])
-  await dataReceived // wait for subscription to be fulfilled
+  const { synced } = await satellite.subscribe([shapeDef1])
+  await synced // wait for subscription to be fulfilled
 
   try {
     const row = await adapter.query({
@@ -1409,8 +1409,8 @@ test('a second successful subscription', async (t) => {
 
   satellite!.relations = relations
   await satellite.subscribe([shapeDef1])
-  const { dataReceived } = await satellite.subscribe([shapeDef2])
-  await dataReceived
+  const { synced } = await satellite.subscribe([shapeDef2])
+  await synced
 
   try {
     const row = await adapter.query({
@@ -1505,12 +1505,12 @@ test.serial('a shape delivery that triggers garbage collection', async (t) => {
   }
 
   satellite!.relations = relations
-  const { dataReceived: dataReceived1 } = await satellite.subscribe([shapeDef1])
-  await dataReceived1
-  const { dataReceived } = await satellite.subscribe([shapeDef2])
+  const { synced: synced1 } = await satellite.subscribe([shapeDef1])
+  await synced1
+  const { synced } = await satellite.subscribe([shapeDef2])
 
   try {
-    await dataReceived
+    await synced
     t.fail()
   } catch (expected: any) {
     try {
@@ -1557,8 +1557,8 @@ test('a subscription request failure does not clear the manager state', async (t
   }
 
   satellite!.relations = relations
-  const { dataReceived } = await satellite.subscribe([shapeDef1])
-  await dataReceived
+  const { synced } = await satellite.subscribe([shapeDef1])
+  await synced
 
   try {
     const row = await adapter.query({

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -44,8 +44,8 @@ export const set_subscribers = (db: Electric) => {
 }
 
 export const syncTable = async (electric: Electric, table: 'items' | 'other_items') => {
-  const {dataReceived} = await electric.db[table].sync()
-  return await dataReceived
+  const { synced } = await electric.db[table].sync()
+  return await synced
 }
 
 export const get_tables = async (electric: Electric) => {


### PR DESCRIPTION
Renames `dataReceived` to `synced` and `Sub` to `ShapeSubscription`.
I did not rename `Sub` to `Shape` because there is already a `Shape` type.
So i think it makes more sense that the client passes a `Shape` to sync and that they get back a `ShapeSubscription`.
```typescript
sync(shape: Shape): Promise<ShapeSubscription>
```