### PR TITLE
Modify test to un-silence wrong expectation

### DIFF
--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1179,7 +1179,7 @@ test('handling connectivity state change stops queueing operations', async (t) =
   const lsn1 = await satellite._getMeta('lastSentRowId')
   t.is(lsn1, '1')
 
-  satellite._connectivityStateChange('connected')
+  satellite._connectivityStateChange('available')
 
   await sleepAsync(200)
   const lsn2 = await satellite._getMeta('lastSentRowId')

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1181,10 +1181,9 @@ test('handling connectivity state change stops queueing operations', async (t) =
 
   satellite._connectivityStateChange('connected')
 
-  setTimeout(async () => {
-    const lsn2 = await satellite._getMeta('lastSentRowId')
-    t.is(lsn2, '2')
-  }, 200)
+  await sleepAsync(200)
+  const lsn2 = await satellite._getMeta('lastSentRowId')
+  t.is(lsn2, '2')
 })
 
 test('garbage collection is triggered when transaction from the same origin is replicated', async (t) => {


### PR DESCRIPTION
This has been mentioned in #132 , but since most of those have already been fixed, I include this PR to isolate it and leave it for discussion.

The `t.is(lsn2, '2')` is never executed in the original code, and the test passes, but the assert actually fails.