### PR TITLE
Expand serialization tests with float and integer values

### DIFF
--- a/clients/typescript/test/satellite/serialization.test.ts
+++ b/clients/typescript/test/satellite/serialization.test.ts
@@ -13,10 +13,22 @@ test('serialize/deserialize row data', async (t) => {
       { name: 'name1', type: 'TEXT' },
       { name: 'name2', type: 'TEXT' },
       { name: 'name3', type: 'TEXT' },
+      { name: 'int1', type: 'INTEGER' },
+      { name: 'int2', type: 'INTEGER' },
+      { name: 'float1', type: 'FLOAT4' },
+      { name: 'float2', type: 'FLOAT4' },
     ],
   }
 
-  const record: Record = { name1: 'Hello', name2: 'World!', name3: null }
+  const record: Record = { 
+    name1: 'Hello', 
+    name2: 'World!', 
+    name3: null, 
+    int1: 1,
+    int2: -30,
+    float1: 1.1,
+    float2: -30.3,
+  }
   const s_row = serializeRow(record, rel)
   const d_row = deserializeRow(s_row, rel)
 

--- a/clients/typescript/test/satellite/serialization.test.ts
+++ b/clients/typescript/test/satellite/serialization.test.ts
@@ -20,10 +20,10 @@ test('serialize/deserialize row data', async (t) => {
     ],
   }
 
-  const record: Record = { 
-    name1: 'Hello', 
-    name2: 'World!', 
-    name3: null, 
+  const record: Record = {
+    name1: 'Hello',
+    name2: 'World!',
+    name3: null,
     int1: 1,
     int2: -30,
     float1: 1.1,


### PR DESCRIPTION
I added some additional serialization test cases, as only Strings and null values were being tested.

Related to this, does Electric support Blob columns? I haven't found any example in the tests, so I'm not sure if it's supported or not. 