### PR TITLE
chore(protocol): Remove unused SCHEMA_VERSION enum value from Satellite protocol

### DIFF
--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -35,12 +35,6 @@ export enum SatAuthHeader {
    * the package statement of this protobuf file, for example "Electric.Satellite.v10_13"
    */
   PROTO_VERSION = 1,
-  /**
-   * SCHEMA_VERSION - required header
-   * last schema version applied on the client. Is prepended with the hash
-   * algorithm type, for example: "sha256:71c9f..."
-   */
-  SCHEMA_VERSION = 2,
   UNRECOGNIZED = -1,
 }
 

--- a/components/electric/lib/electric/satellite/protobuf_messages.ex
+++ b/components/electric/lib/electric/satellite/protobuf_messages.ex
@@ -31,15 +31,6 @@
           def encode("PROTO_VERSION") do
             1
           end
-        ),
-        (
-          def encode(:SCHEMA_VERSION) do
-            2
-          end
-
-          def encode("SCHEMA_VERSION") do
-            2
-          end
         )
       ]
 
@@ -54,9 +45,6 @@
         end,
         def decode(1) do
           :PROTO_VERSION
-        end,
-        def decode(2) do
-          :SCHEMA_VERSION
         end
       ]
 
@@ -66,7 +54,7 @@
 
       @spec constants() :: [{integer(), atom()}]
       def constants() do
-        [{0, :UNSPECIFIED}, {1, :PROTO_VERSION}, {2, :SCHEMA_VERSION}]
+        [{0, :UNSPECIFIED}, {1, :PROTO_VERSION}]
       end
 
       @spec has_constant?(any()) :: boolean()
@@ -76,9 +64,6 @@
             true
           end,
           def has_constant?(:PROTO_VERSION) do
-            true
-          end,
-          def has_constant?(:SCHEMA_VERSION) do
             true
           end
         ]

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -44,11 +44,6 @@ enum SatAuthHeader {
     // protobuf protocol version, this version is picked from
     // the package statement of this protobuf file, for example "Electric.Satellite.v10_13"
     PROTO_VERSION = 1;
-
-    // required header
-    // last schema version applied on the client. Is prepended with the hash
-    // algorithm type, for example: "sha256:71c9f..."
-    SCHEMA_VERSION = 2;
 }
 
 message SatAuthHeaderPair {


### PR DESCRIPTION
While technically a breaking change, we haven't been using this enum value. So I don't see the need in bumping the protocol version or reserving the value 2 in SatAuthHeader to prevent its reuse in the future simply because nothing running in the wild is depending on it.