### PR TITLE
fix: make sure the subscribe call is held off until the replication is established

### DIFF
--- a/.changeset/old-ways-bow.md
+++ b/.changeset/old-ways-bow.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixed using `.sync()` calls before the replication is established. Now we defer trying to subscribe until the replication is succesfully established if we're already in the process of connecting and starting.

--- a/clients/typescript/.eslintrc.cjs
+++ b/clients/typescript/.eslintrc.cjs
@@ -13,6 +13,10 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-explicit-any': ['warn', { ignoreRestArgs: true }],
+    '@typescript-eslint/ban-ts-comment': [
+      'error',
+      { 'ts-ignore': 'allow-with-description' },
+    ],
     'no-constant-condition': ['error', { checkLoops: false }],
   },
   ignorePatterns: ['**/*/mock.ts'],

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -223,14 +223,11 @@ export class SatelliteClient extends EventEmitter implements Client {
   private resetReplication(
     enqueued?: LSN,
     ack?: LSN,
-    isReplicating?: ReplicationStatus,
-    replicationStartingPromise?: Promise<void>
+    isReplicating?: ReplicationStatus
   ): OutgoingReplication {
     return {
       authenticated: false,
       isReplicating: isReplicating ? isReplicating : ReplicationStatus.STOPPED,
-      replicationStartingPromise:
-        replicationStartingPromise ?? Promise.resolve(),
       relations: new Map(),
       ack_lsn: ack,
       enqueued_lsn: enqueued,
@@ -370,12 +367,7 @@ export class SatelliteClient extends EventEmitter implements Client {
         this.initializing?.reject(e)
         throw e
       })
-    this.inbound = this.resetReplication(
-      lsn,
-      lsn,
-      ReplicationStatus.STARTING,
-      promise
-    )
+    this.inbound = this.resetReplication(lsn, lsn, ReplicationStatus.STARTING)
 
     return promise
   }

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -66,6 +66,7 @@ import {
   DEFAULT_LOG_POS,
   typeEncoder,
   typeDecoder,
+  emptyPromise,
 } from '../util/common'
 import { Client } from '.'
 import { SatelliteClientOpts, satelliteClientDefaults } from './config'
@@ -100,6 +101,12 @@ export class SatelliteClient extends EventEmitter implements Client {
   private socket?: Socket
 
   private notifier: Notifier
+
+  private initializing?: {
+    promise: Promise<void>
+    resolve: () => void
+    reject: (e?: unknown) => void
+  }
 
   private inbound: Replication
   private outbound: OutgoingReplication
@@ -216,11 +223,14 @@ export class SatelliteClient extends EventEmitter implements Client {
   private resetReplication(
     enqueued?: LSN,
     ack?: LSN,
-    isReplicating?: ReplicationStatus
-  ) {
+    isReplicating?: ReplicationStatus,
+    replicationStartingPromise?: Promise<void>
+  ): OutgoingReplication {
     return {
       authenticated: false,
       isReplicating: isReplicating ? isReplicating : ReplicationStatus.STOPPED,
+      replicationStartingPromise:
+        replicationStartingPromise ?? Promise.resolve(),
       relations: new Map(),
       ack_lsn: ack,
       enqueued_lsn: enqueued,
@@ -231,6 +241,8 @@ export class SatelliteClient extends EventEmitter implements Client {
   connect(
     retryHandler?: (error: any, attempt: number) => boolean
   ): Promise<void> {
+    this.initializing = emptyPromise()
+
     const connectPromise = new Promise<void>((resolve, reject) => {
       // TODO: ensure any previous socket is closed, or reject
       if (this.socket) {
@@ -274,7 +286,12 @@ export class SatelliteClient extends EventEmitter implements Client {
       retryPolicy.retry = retryHandler
     }
 
-    return backOff(() => connectPromise, retryPolicy)
+    return backOff(() => connectPromise, retryPolicy).catch((e) => {
+      // We're very sure that no calls are going to modify `this.initializing` before this promise resolves
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.initializing!.reject(e)
+      throw e
+    })
   }
 
   close(): Promise<void> {
@@ -291,6 +308,13 @@ export class SatelliteClient extends EventEmitter implements Client {
 
     this.socketHandler = undefined
     this.removeAllListeners()
+    this.initializing?.reject(
+      new SatelliteError(
+        SatelliteErrorCode.INTERNAL,
+        'Socket is closed by the client while initializing'
+      )
+    )
+    this.initializing = undefined
     if (this.socket != undefined) {
       this.socket!.closeAndRemoveListeners()
       this.socket = undefined
@@ -317,8 +341,7 @@ export class SatelliteClient extends EventEmitter implements Client {
       )
     }
 
-    this.inbound = this.resetReplication(lsn, lsn, ReplicationStatus.STARTING)
-
+    // Perform validations and prepare the request
     let request
     if (!lsn || lsn.length == 0) {
       Log.info(`no previous LSN, start replication with option FIRST_LSN`)
@@ -339,7 +362,21 @@ export class SatelliteClient extends EventEmitter implements Client {
       request = SatInStartReplicationReq.fromPartial({ lsn, subscriptionIds })
     }
 
-    return this.rpc(request)
+    // Then set the replication state
+    const promise = this.rpc<void>(request)
+      .then(() => this.initializing?.resolve())
+      .catch((e) => {
+        this.initializing?.reject(e)
+        throw e
+      })
+    this.inbound = this.resetReplication(
+      lsn,
+      lsn,
+      ReplicationStatus.STARTING,
+      promise
+    )
+
+    return promise
   }
 
   stopReplication(): Promise<void> {
@@ -369,7 +406,10 @@ export class SatelliteClient extends EventEmitter implements Client {
       token: token,
       headers: headers,
     })
-    return this.rpc<AuthResponse>(request)
+    return this.rpc<AuthResponse>(request).catch((e) => {
+      this.initializing?.reject(e)
+      throw e
+    })
   }
 
   subscribeToTransactions(
@@ -460,10 +500,14 @@ export class SatelliteClient extends EventEmitter implements Client {
     )
   }
 
-  subscribe(
+  async subscribe(
     subscriptionId: string,
     shapes: ShapeRequest[]
   ): Promise<SubscribeResponse> {
+    if (this.initializing) {
+      await this.initializing.promise
+    }
+
     if (this.inbound.isReplicating !== ReplicationStatus.ACTIVE) {
       return Promise.reject(
         new SatelliteError(

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -308,6 +308,7 @@ export class SatelliteClient extends EventEmitter implements Client {
 
     this.socketHandler = undefined
     this.removeAllListeners()
+    this.initializing?.promise.catch(() => void 0)
     this.initializing?.reject(
       new SatelliteError(
         SatelliteErrorCode.INTERNAL,

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -34,7 +34,7 @@ export abstract class BaseRegistry implements Registry {
     this.stoppingPromises = {}
   }
 
-  startProcess(
+  abstract startProcess(
     _dbName: DbName,
     _adapter: DatabaseAdapter,
     _migrator: Migrator,
@@ -42,9 +42,7 @@ export abstract class BaseRegistry implements Registry {
     _socketFactory: SocketFactory,
     _config: InternalElectricConfig,
     _opts?: SatelliteOverrides
-  ): Promise<Satellite> {
-    throw `Subclasses must implement startProcess`
-  }
+  ): Promise<Satellite>
 
   async ensureStarted(
     dbName: DbName,

--- a/clients/typescript/src/util/common.ts
+++ b/clients/typescript/src/util/common.ts
@@ -59,10 +59,13 @@ export function uuid() {
 }
 
 export function emptyPromise<T = void>() {
-  let resolve: ((value: T | PromiseLike<T>) => void);
+  let resolve: (value: T | PromiseLike<T>) => void
   let reject: (reason?: any) => void
-  const promise = new Promise<T>((res, rej) => {resolve = res; reject = rej})
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
 
   // @ts-ignore TS complains that resolve/reject are used here before assignment, but promise constructor will run synchronously
-  return {promise, resolve, reject}
+  return { promise, resolve, reject }
 }

--- a/clients/typescript/src/util/common.ts
+++ b/clients/typescript/src/util/common.ts
@@ -57,3 +57,12 @@ export function bytesToNumber(bs: Uint8Array) {
 export function uuid() {
   return (globalThis as any).uuid()
 }
+
+export function emptyPromise<T = void>() {
+  let resolve: ((value: T | PromiseLike<T>) => void);
+  let reject: (reason?: any) => void
+  const promise = new Promise<T>((res, rej) => {resolve = res; reject = rej})
+
+  // @ts-ignore TS complains that resolve/reject are used here before assignment, but promise constructor will run synchronously
+  return {promise, resolve, reject}
+}

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -123,7 +123,6 @@ export type Record = { [key: string]: string | number | undefined | null }
 export type Replication = {
   authenticated: boolean
   isReplicating: ReplicationStatus
-  replicationStartingPromise: Promise<void>
   relations: Map<number, Relation>
   ack_lsn?: LSN
   enqueued_lsn?: LSN

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -123,6 +123,7 @@ export type Record = { [key: string]: string | number | undefined | null }
 export type Replication = {
   authenticated: boolean
   isReplicating: ReplicationStatus
+  replicationStartingPromise: Promise<void>
   relations: Map<number, Relation>
   ack_lsn?: LSN
   enqueued_lsn?: LSN


### PR DESCRIPTION
We've checked if the replication is already established in the `subscribe` call, but we actually don't wait (or even expose a way to know) if the replication has been established. This addresses one part of it: the `subscribe` call will wait until `startReplication()` call resolves after `connect()`. That way we can reliably send the subscription request only after the replication is started, even if `.sync()` call is made immediately after `await electrify(...)`. Any fails in `connect()` or `authenticate()` will abort the `.sync()` call with the same error, since at that point we cannot do any online calls.

 We may still want to the result of `startReplication()` on `electrify` call, but that's for another PR.