### PR TITLE
feature(protocol): Add missing error codes to the protocol definition

### DIFF
--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -177,6 +177,13 @@ export enum SatInStartReplicationResp_ReplicationError_Code {
   INVALID_POSITION = 2,
   /** SUBSCRIPTION_NOT_FOUND - requested subscription not found */
   SUBSCRIPTION_NOT_FOUND = 3,
+  /** MALFORMED_LSN - the replication request has malformed LSN */
+  MALFORMED_LSN = 4,
+  /**
+   * UNKNOWN_SCHEMA_VSN - consumer requested replication at schema version that is
+   * not known to the producer
+   */
+  UNKNOWN_SCHEMA_VSN = 5,
   UNRECOGNIZED = -1,
 }
 
@@ -493,6 +500,10 @@ export enum SatSubsResp_SatSubsError_ShapeReqError_Code {
   TABLE_NOT_FOUND = 1,
   /** REFERENTIAL_INTEGRITY_VIOLATION - Requested shape does not maintain referential integirty */
   REFERENTIAL_INTEGRITY_VIOLATION = 2,
+  /** EMPTY_SHAPE_DEFINITION - The shape request contains an empty shape definition */
+  EMPTY_SHAPE_DEFINITION = 3,
+  /** DUPLICATE_TABLE_IN_SHAPE_DEFINITION - Attempt to request the same table more than once in one shape */
+  DUPLICATE_TABLE_IN_SHAPE_DEFINITION = 4,
   UNRECOGNIZED = -1,
 }
 

--- a/clients/typescript/src/util/proto.ts
+++ b/clients/typescript/src/util/proto.ts
@@ -23,6 +23,10 @@ const startReplicationErrorToSatError: Record<
     SatelliteErrorCode.INVALID_POSITION,
   [Pb.SatInStartReplicationResp_ReplicationError_Code.SUBSCRIPTION_NOT_FOUND]:
     SatelliteErrorCode.SUBSCRIPTION_NOT_FOUND,
+  [Pb.SatInStartReplicationResp_ReplicationError_Code.MALFORMED_LSN]:
+    SatelliteErrorCode.MALFORMED_LSN,
+  [Pb.SatInStartReplicationResp_ReplicationError_Code.UNKNOWN_SCHEMA_VSN]:
+    SatelliteErrorCode.UNKNOWN_SCHEMA_VSN,
 }
 
 const subsErrorToSatError: Record<
@@ -51,6 +55,11 @@ const subsErrorShapeReqErrorToSatError: Record<
   [Pb.SatSubsResp_SatSubsError_ShapeReqError_Code
     .REFERENTIAL_INTEGRITY_VIOLATION]:
     SatelliteErrorCode.REFERENTIAL_INTEGRITY_VIOLATION,
+  [Pb.SatSubsResp_SatSubsError_ShapeReqError_Code.EMPTY_SHAPE_DEFINITION]:
+    SatelliteErrorCode.EMPTY_SHAPE_DEFINITION,
+  [Pb.SatSubsResp_SatSubsError_ShapeReqError_Code
+    .DUPLICATE_TABLE_IN_SHAPE_DEFINITION]:
+    SatelliteErrorCode.DUPLICATE_TABLE_IN_SHAPE_DEFINITION,
 }
 
 const subsDataErrorToSatError: Record<

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -52,6 +52,8 @@ export enum SatelliteErrorCode {
   INVALID_POSITION,
   SUBSCRIPTION_NOT_FOUND,
   SUBSCRIPTION_ERROR,
+  MALFORMED_LSN,
+  UNKNOWN_SCHEMA_VSN,
 
   // subscription errors
   SHAPE_REQUEST_ERROR,
@@ -60,6 +62,8 @@ export enum SatelliteErrorCode {
   // shape request errors
   TABLE_NOT_FOUND,
   REFERENTIAL_INTEGRITY_VIOLATION,
+  EMPTY_SHAPE_DEFINITION,
+  DUPLICATE_TABLE_IN_SHAPE_DEFINITION,
 
   // shape data errors
   SHAPE_DELIVERY_ERROR,

--- a/components/electric/lib/electric/replication/shapes.ex
+++ b/components/electric/lib/electric/replication/shapes.ex
@@ -70,7 +70,7 @@ defmodule Electric.Replication.Shapes do
   end
 
   defp request_cannot_be_empty(%SatShapeDef{selects: []}),
-    do: {:CODE_UNSPECIFIED, "Empty shape requests are not allowed"}
+    do: {:EMPTY_SHAPE_DEFINITION, "Empty shape requests are not allowed"}
 
   defp request_cannot_be_empty(_), do: :ok
 
@@ -96,7 +96,7 @@ defmodule Electric.Replication.Shapes do
 
   defp tables_should_not_duplicate(%SatShapeDef{selects: selects}) do
     if Utils.has_duplicates_by?(selects, & &1.tablename) do
-      {:CODE_UNSPECIFIED, "Cannot select same table twice"}
+      {:DUPLICATE_TABLE_IN_SHAPE_DEFINITION, "Cannot select same table twice"}
     else
       :ok
     end
@@ -110,7 +110,7 @@ defmodule Electric.Replication.Shapes do
         :ok
 
       missing_reachable ->
-        {:CODE_UNSPECIFIED,
+        {:REFERENTIAL_INTEGRITY_VIOLATION,
          "Some tables are missing from the shape request, but are referenced by FKs on the requested tables: #{Enum.join(missing_reachable, ",")}"}
     end
   end

--- a/components/electric/lib/electric/satellite/protobuf_messages.ex
+++ b/components/electric/lib/electric/satellite/protobuf_messages.ex
@@ -399,6 +399,24 @@
           def encode("SUBSCRIPTION_NOT_FOUND") do
             3
           end
+        ),
+        (
+          def encode(:MALFORMED_LSN) do
+            4
+          end
+
+          def encode("MALFORMED_LSN") do
+            4
+          end
+        ),
+        (
+          def encode(:UNKNOWN_SCHEMA_VSN) do
+            5
+          end
+
+          def encode("UNKNOWN_SCHEMA_VSN") do
+            5
+          end
         )
       ]
 
@@ -419,6 +437,12 @@
         end,
         def decode(3) do
           :SUBSCRIPTION_NOT_FOUND
+        end,
+        def decode(4) do
+          :MALFORMED_LSN
+        end,
+        def decode(5) do
+          :UNKNOWN_SCHEMA_VSN
         end
       ]
 
@@ -432,7 +456,9 @@
           {0, :CODE_UNSPECIFIED},
           {1, :BEHIND_WINDOW},
           {2, :INVALID_POSITION},
-          {3, :SUBSCRIPTION_NOT_FOUND}
+          {3, :SUBSCRIPTION_NOT_FOUND},
+          {4, :MALFORMED_LSN},
+          {5, :UNKNOWN_SCHEMA_VSN}
         ]
       end
 
@@ -449,6 +475,12 @@
             true
           end,
           def has_constant?(:SUBSCRIPTION_NOT_FOUND) do
+            true
+          end,
+          def has_constant?(:MALFORMED_LSN) do
+            true
+          end,
+          def has_constant?(:UNKNOWN_SCHEMA_VSN) do
             true
           end
         ]
@@ -929,6 +961,24 @@
           def encode("REFERENTIAL_INTEGRITY_VIOLATION") do
             2
           end
+        ),
+        (
+          def encode(:EMPTY_SHAPE_DEFINITION) do
+            3
+          end
+
+          def encode("EMPTY_SHAPE_DEFINITION") do
+            3
+          end
+        ),
+        (
+          def encode(:DUPLICATE_TABLE_IN_SHAPE_DEFINITION) do
+            4
+          end
+
+          def encode("DUPLICATE_TABLE_IN_SHAPE_DEFINITION") do
+            4
+          end
         )
       ]
 
@@ -946,6 +996,12 @@
         end,
         def decode(2) do
           :REFERENTIAL_INTEGRITY_VIOLATION
+        end,
+        def decode(3) do
+          :EMPTY_SHAPE_DEFINITION
+        end,
+        def decode(4) do
+          :DUPLICATE_TABLE_IN_SHAPE_DEFINITION
         end
       ]
 
@@ -955,7 +1011,13 @@
 
       @spec constants() :: [{integer(), atom()}]
       def constants() do
-        [{0, :CODE_UNSPECIFIED}, {1, :TABLE_NOT_FOUND}, {2, :REFERENTIAL_INTEGRITY_VIOLATION}]
+        [
+          {0, :CODE_UNSPECIFIED},
+          {1, :TABLE_NOT_FOUND},
+          {2, :REFERENTIAL_INTEGRITY_VIOLATION},
+          {3, :EMPTY_SHAPE_DEFINITION},
+          {4, :DUPLICATE_TABLE_IN_SHAPE_DEFINITION}
+        ]
       end
 
       @spec has_constant?(any()) :: boolean()
@@ -968,6 +1030,12 @@
             true
           end,
           def has_constant?(:REFERENTIAL_INTEGRITY_VIOLATION) do
+            true
+          end,
+          def has_constant?(:EMPTY_SHAPE_DEFINITION) do
+            true
+          end,
+          def has_constant?(:DUPLICATE_TABLE_IN_SHAPE_DEFINITION) do
             true
           end
         ]

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -296,15 +296,24 @@ defmodule Electric.Satellite.Protocol do
 
         {:error,
          start_replication_error(
-           :CODE_UNSPECIFIED,
+           :UNKNOWN_SCHEMA_VSN,
            "Unknown schema version: #{inspect(msg.schema_version)}"
          )}
+
+      {:error, {:malformed_lsn, client_lsn}} ->
+        Logger.warning("Client has supplied invalid LSN in the request: #{inspect(client_lsn)}")
+
+        {:error,
+         start_replication_error(:MALFORMED_LSN, "Could not validate start replication request")}
 
       {:error, reason} ->
         Logger.warning("Bad start replication request: #{inspect(reason)}")
 
         {:error,
-         start_replication_error(:CODE_UNSPECIFIED, "Could validate start replication request")}
+         start_replication_error(
+           :CODE_UNSPECIFIED,
+           "Could not validate start replication request"
+         )}
     end
   end
 
@@ -748,7 +757,7 @@ defmodule Electric.Satellite.Protocol do
       {false, false} ->
         case CachedWal.Api.parse_wal_position(client_lsn) do
           {:ok, value} -> {:ok, value}
-          :error -> {:error, {:lsn_invalid, client_lsn}}
+          :error -> {:error, {:malformed_lsn, client_lsn}}
         end
     end
   end

--- a/components/electric/test/electric/replication/shapes_test.exs
+++ b/components/electric/test/electric/replication/shapes_test.exs
@@ -98,7 +98,7 @@ defmodule Electric.Replication.ShapesTest do
         }
       }
 
-      assert {:error, [{"id1", :CODE_UNSPECIFIED, "Empty shape requests are not allowed"}]} =
+      assert {:error, [{"id1", :EMPTY_SHAPE_DEFINITION, "Empty shape requests are not allowed"}]} =
                Shapes.validate_requests([request], origin)
     end
 
@@ -113,7 +113,8 @@ defmodule Electric.Replication.ShapesTest do
         }
       }
 
-      assert {:error, [{"id1", :CODE_UNSPECIFIED, "Cannot select same table twice"}]} =
+      assert {:error,
+              [{"id1", :DUPLICATE_TABLE_IN_SHAPE_DEFINITION, "Cannot select same table twice"}]} =
                Shapes.validate_requests([request], origin)
     end
 
@@ -126,7 +127,10 @@ defmodule Electric.Replication.ShapesTest do
       }
 
       assert {:error,
-              [{"id1", :CODE_UNSPECIFIED, "Some tables are missing from the shape request" <> _}]} =
+              [
+                {"id1", :REFERENTIAL_INTEGRITY_VIOLATION,
+                 "Some tables are missing from the shape request" <> _}
+              ]} =
                Shapes.validate_requests([request], origin)
     end
   end

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -152,6 +152,13 @@ message SatInStartReplicationResp {
 
             // requested subscription not found
             SUBSCRIPTION_NOT_FOUND = 3;
+
+            // the replication request has malformed LSN
+            MALFORMED_LSN = 4;
+
+            // consumer requested replication at schema version that is
+            // not known to the producer
+            UNKNOWN_SCHEMA_VSN = 5;
         }
 
         // error code
@@ -417,6 +424,12 @@ message SatSubsResp {
 
                 // Requested shape does not maintain referential integirty
                 REFERENTIAL_INTEGRITY_VIOLATION = 2;
+
+                // The shape request contains an empty shape definition 
+                EMPTY_SHAPE_DEFINITION = 3;
+
+                // Attempt to request the same table more than once in one shape
+                DUPLICATE_TABLE_IN_SHAPE_DEFINITION = 4;
             }
 
             // error code


### PR DESCRIPTION
I thought I had made this changes in my previous PR that touched the protocol. But noticed today there were still instances of `CODE_UNSPECIFIED` in the code. Thank god for `git reflog`.