### PR TITLE
chore(protocol): Remove FIRST_LSN, LAST_LSN, and LAST_ACKNOWLEDGED from the protocol

### DIFF
--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -113,7 +113,8 @@
     "posttest": "npm run typecheck",
     "prepublishOnly": "pnpm run build",
     "lint": "eslint src --fix",
-    "check-styleguide": "prettier --check --loglevel warn . && eslint src --quiet"
+    "check-styleguide": "prettier --check --loglevel warn . && eslint src --quiet",
+    "format": "prettier --write --loglevel warn ."
   },
   "ava": {
     "timeout": "10m",

--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -126,28 +126,13 @@ export interface SatInStartReplicationReq {
 }
 
 export enum SatInStartReplicationReq_Option {
+  /** NONE - Required by the Protobuf spec. */
   NONE = 0,
-  /**
-   * LAST_ACKNOWLEDGED - Flag that indicates to Producer, to start replication from the latest
-   * position that has been acknowledged by this Consumer. In such a case
-   * provided lsn will be ignored
-   */
-  LAST_ACKNOWLEDGED = 1,
   /**
    * SYNC_MODE - In sync mode consumer of the stream is expected to send SatPingResp
    * message for every committed batch of SatOpLog messages
    */
   SYNC_MODE = 2,
-  /**
-   * FIRST_LSN - Asks receiver to start replication from the first transaction in the log
-   * without necessity to know about the actual internal format of the LSN
-   */
-  FIRST_LSN = 3,
-  /**
-   * LAST_LSN - Asks receiver to start replication from the last position in the log,
-   * whatever this position is. Used for tests only.
-   */
-  LAST_LSN = 4,
   UNRECOGNIZED = -1,
 }
 

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -655,8 +655,8 @@ export class SatelliteClient extends EventEmitter implements Client {
     if (this.outbound.isReplicating == ReplicationStatus.STOPPED) {
       const replication = {
         ...this.outbound,
-        ack_lsn: message.lsn,
-        enqueued_lsn: message.lsn,
+        ack_lsn: DEFAULT_LOG_POS,
+        enqueued_lsn: DEFAULT_LOG_POS,
       }
 
       this.outbound = this.resetReplication(

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -6,7 +6,6 @@ import {
   SatErrorResp,
   SatErrorResp_ErrorCode,
   SatInStartReplicationReq,
-  SatInStartReplicationReq_Option,
   SatInStartReplicationResp,
   SatInStopReplicationReq,
   SatInStopReplicationResp,
@@ -341,7 +340,7 @@ export class SatelliteClient extends EventEmitter implements Client {
     // Perform validations and prepare the request
     let request
     if (!lsn || lsn.length == 0) {
-      Log.info(`no previous LSN, start replication with option FIRST_LSN`)
+      Log.info(`no previous LSN, start replication from scratch`)
       if (subscriptionIds && subscriptionIds.length > 0) {
         return Promise.reject(
           new SatelliteError(
@@ -350,10 +349,7 @@ export class SatelliteClient extends EventEmitter implements Client {
           )
         )
       }
-      request = SatInStartReplicationReq.fromPartial({
-        options: [SatInStartReplicationReq_Option.FIRST_LSN],
-        schemaVersion,
-      })
+      request = SatInStartReplicationReq.fromPartial({ schemaVersion })
     } else {
       Log.info(`starting replication with lsn: ${base64.fromBytes(lsn)}`)
       request = SatInStartReplicationReq.fromPartial({ lsn, subscriptionIds })
@@ -657,23 +653,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   private handleStartReq(message: SatInStartReplicationReq) {
     Log.info(`received replication request ${JSON.stringify(message)}`)
     if (this.outbound.isReplicating == ReplicationStatus.STOPPED) {
-      const replication = { ...this.outbound }
-      if (
-        !message.options.find(
-          (o) => o == SatInStartReplicationReq_Option.LAST_ACKNOWLEDGED
-        )
-      ) {
-        replication.ack_lsn = message.lsn
-        replication.enqueued_lsn = message.lsn
-      }
-      if (
-        !message.options.find(
-          (o) => o == SatInStartReplicationReq_Option.FIRST_LSN
-        )
-      ) {
-        replication.ack_lsn = DEFAULT_LOG_POS
-        replication.enqueued_lsn = DEFAULT_LOG_POS
-      }
+      const replication = { ...this.outbound, ack_lsn: message.lsn, enqueued_lsn: message.lsn}
 
       this.outbound = this.resetReplication(
         replication.enqueued_lsn,

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -653,7 +653,11 @@ export class SatelliteClient extends EventEmitter implements Client {
   private handleStartReq(message: SatInStartReplicationReq) {
     Log.info(`received replication request ${JSON.stringify(message)}`)
     if (this.outbound.isReplicating == ReplicationStatus.STOPPED) {
-      const replication = { ...this.outbound, ack_lsn: message.lsn, enqueued_lsn: message.lsn}
+      const replication = {
+        ...this.outbound,
+        ack_lsn: message.lsn,
+        enqueued_lsn: message.lsn,
+      }
 
       this.outbound = this.resetReplication(
         replication.enqueued_lsn,

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -183,7 +183,7 @@ test.serial('replication start success', async (t) => {
   t.pass()
 })
 
-test.serial('replication start sends FIRST_LSN', async (t) => {
+test.serial('replication start sends empty', async (t) => {
   await connectAndAuth(t.context)
   const { client, server } = t.context
 
@@ -195,10 +195,7 @@ test.serial('replication start sends FIRST_LSN', async (t) => {
           msgType == getTypeFromString(Proto.SatInStartReplicationReq.$type)
         ) {
           const req = decode(data!) as Proto.SatInStartReplicationReq
-          t.deepEqual(
-            req.options[0],
-            Proto.SatInStartReplicationReq_Option.FIRST_LSN
-          )
+          t.deepEqual( req.lsn, new Uint8Array())
           t.pass()
           resolve()
         }

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -195,7 +195,7 @@ test.serial('replication start sends empty', async (t) => {
           msgType == getTypeFromString(Proto.SatInStartReplicationReq.$type)
         ) {
           const req = decode(data!) as Proto.SatInStartReplicationReq
-          t.deepEqual( req.lsn, new Uint8Array())
+          t.deepEqual(req.lsn, new Uint8Array())
           t.pass()
           resolve()
         }

--- a/components/electric/lib/electric/postgres/cached_wal/producer.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/producer.ex
@@ -38,14 +38,8 @@ defmodule Electric.Postgres.CachedWal.Producer do
   @impl GenStage
   def handle_subscribe(:consumer, options, _, state) do
     Logger.debug("Got a subscription request with options #{inspect(options)}")
-
-    case Keyword.fetch(options, :start_subscription) do
-      {:ok, :start_from_latest} ->
-        raise "This producer doesn't currently support subscription starting from the tip of the stream"
-
-      {:ok, wal_pos} ->
-        {:automatic, %{state | current_position: wal_pos}}
-    end
+    wal_pos = Keyword.fetch!(options, :start_subscription)
+    {:automatic, %{state | current_position: wal_pos}}
   end
 
   @impl GenStage

--- a/components/electric/lib/electric/satellite/protobuf_messages.ex
+++ b/components/electric/lib/electric/satellite/protobuf_messages.ex
@@ -255,39 +255,12 @@
           end
         ),
         (
-          def encode(:LAST_ACKNOWLEDGED) do
-            1
-          end
-
-          def encode("LAST_ACKNOWLEDGED") do
-            1
-          end
-        ),
-        (
           def encode(:SYNC_MODE) do
             2
           end
 
           def encode("SYNC_MODE") do
             2
-          end
-        ),
-        (
-          def encode(:FIRST_LSN) do
-            3
-          end
-
-          def encode("FIRST_LSN") do
-            3
-          end
-        ),
-        (
-          def encode(:LAST_LSN) do
-            4
-          end
-
-          def encode("LAST_LSN") do
-            4
           end
         )
       ]
@@ -301,17 +274,8 @@
         def decode(0) do
           :NONE
         end,
-        def decode(1) do
-          :LAST_ACKNOWLEDGED
-        end,
         def decode(2) do
           :SYNC_MODE
-        end,
-        def decode(3) do
-          :FIRST_LSN
-        end,
-        def decode(4) do
-          :LAST_LSN
         end
       ]
 
@@ -321,7 +285,7 @@
 
       @spec constants() :: [{integer(), atom()}]
       def constants() do
-        [{0, :NONE}, {1, :LAST_ACKNOWLEDGED}, {2, :SYNC_MODE}, {3, :FIRST_LSN}, {4, :LAST_LSN}]
+        [{0, :NONE}, {2, :SYNC_MODE}]
       end
 
       @spec has_constant?(any()) :: boolean()
@@ -330,16 +294,7 @@
           def has_constant?(:NONE) do
             true
           end,
-          def has_constant?(:LAST_ACKNOWLEDGED) do
-            true
-          end,
           def has_constant?(:SYNC_MODE) do
-            true
-          end,
-          def has_constant?(:FIRST_LSN) do
-            true
-          end,
-          def has_constant?(:LAST_LSN) do
             true
           end
         ]

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -398,7 +398,7 @@ defmodule Electric.Satellite.WsServer do
         sync_counter: 0
     }
 
-    {Enum.map(msgs, fn x -> binary_frame(x) end), %State{state | in_rep: in_rep}}
+    {binary_frames(msgs), %State{state | in_rep: in_rep}}
   end
 
   # Gen consumer cancels subscription, may only happen for subscribed consumer

--- a/components/electric/lib/satellite/satellite_ws_client.ex
+++ b/components/electric/lib/satellite/satellite_ws_client.ex
@@ -568,15 +568,10 @@ defmodule Electric.Test.SatelliteWsClient do
       nil ->
         :ok
 
-      "0" ->
-        sub_req = serialize(%SatInStartReplicationReq{options: [:FIRST_LSN]})
+      "" ->
+        sub_req = serialize(%SatInStartReplicationReq{})
         :gun.ws_send(conn, stream_ref, {:binary, sub_req})
         Logger.debug("Subscribed at LSN=0")
-
-      "eof" ->
-        sub_req = serialize(%SatInStartReplicationReq{options: [:LAST_LSN]})
-        :gun.ws_send(conn, stream_ref, {:binary, sub_req})
-        Logger.debug("Subscribed at LAST_LSN")
 
       lsn ->
         sub_req =

--- a/components/electric/test/electric/satellite/subscriptions_test.exs
+++ b/components/electric/test/electric/satellite/subscriptions_test.exs
@@ -39,7 +39,7 @@ defmodule Electric.Satellite.SubscriptionsTest do
 
     test "The client can connect and immediately gets migrations", ctx do
       MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
-        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        MockClient.send_data(conn, %SatInStartReplicationReq{})
 
         assert_receive {^conn, %SatInStartReplicationResp{}}
 
@@ -63,7 +63,7 @@ defmodule Electric.Satellite.SubscriptionsTest do
     test "The client can connect and immediately gets migrations but gets neither already inserted data, nor new inserts",
          %{conn: pg_conn} = ctx do
       MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
-        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        MockClient.send_data(conn, %SatInStartReplicationReq{})
 
         assert_receive {^conn, %SatInStartReplicationResp{}}
 
@@ -101,7 +101,7 @@ defmodule Electric.Satellite.SubscriptionsTest do
     test "The client can connect and subscribe, and he gets data upon subscription and thereafter",
          %{conn: pg_conn} = ctx do
       MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
-        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        MockClient.send_data(conn, %SatInStartReplicationReq{})
         assert_initial_replication_response(conn, 3)
 
         request_id = uuid4()
@@ -159,7 +159,7 @@ defmodule Electric.Satellite.SubscriptionsTest do
     test "The client can connect and subscribe, and that works with multiple shape requests",
          %{conn: pg_conn} = ctx do
       MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
-        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        MockClient.send_data(conn, %SatInStartReplicationReq{})
         assert_initial_replication_response(conn, 3)
 
         {:ok, 1} =
@@ -236,7 +236,7 @@ defmodule Electric.Satellite.SubscriptionsTest do
     test "The client can connect and subscribe, and that works with multiple subscriptions",
          %{conn: pg_conn} = ctx do
       MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
-        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        MockClient.send_data(conn, %SatInStartReplicationReq{})
         assert_initial_replication_response(conn, 3)
 
         sub_id = uuid4()
@@ -315,7 +315,7 @@ defmodule Electric.Satellite.SubscriptionsTest do
     test "The client can connect and subscribe, and then unsubscribe, and gets no data after unsubscribing",
          %{conn: pg_conn} = ctx do
       MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
-        MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+        MockClient.send_data(conn, %SatInStartReplicationReq{})
         assert_initial_replication_response(conn, 3)
 
         request_id = uuid4()
@@ -373,7 +373,7 @@ defmodule Electric.Satellite.SubscriptionsTest do
 
       last_lsn =
         MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
-          MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+          MockClient.send_data(conn, %SatInStartReplicationReq{})
           assert_initial_replication_response(conn, 3)
 
           request_id = uuid4()

--- a/components/electric/test/electric/satellite/ws_pg_to_satellite_test.exs
+++ b/components/electric/test/electric/satellite/ws_pg_to_satellite_test.exs
@@ -40,7 +40,7 @@ defmodule Electric.Satellite.WsPgToSatelliteTest do
     with_connect(ctx.conn_opts, fn conn ->
       assert_receive {^conn, %SatInStartReplicationReq{}}
 
-      MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+      MockClient.send_data(conn, %SatInStartReplicationReq{})
       assert_receive {^conn, %SatInStartReplicationResp{}}
 
       ping_server(conn)
@@ -61,7 +61,7 @@ defmodule Electric.Satellite.WsPgToSatelliteTest do
 
       assert_receive {^conn, %SatInStartReplicationReq{}}
 
-      MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+      MockClient.send_data(conn, %SatInStartReplicationReq{})
       assert_receive {^conn, %SatInStartReplicationResp{}}
 
       assert_receive {^ref, :server_paused}
@@ -94,7 +94,7 @@ defmodule Electric.Satellite.WsPgToSatelliteTest do
     with_connect(ctx.conn_opts, fn conn ->
       assert_receive {^conn, %SatInStartReplicationReq{}}
 
-      MockClient.send_data(conn, %SatInStartReplicationReq{options: [:FIRST_LSN]})
+      MockClient.send_data(conn, %SatInStartReplicationReq{})
       assert_receive {^conn, %SatInStartReplicationResp{}}
 
       assert_receive_migration(conn, vsn1, "foo")
@@ -108,7 +108,7 @@ defmodule Electric.Satellite.WsPgToSatelliteTest do
     with_connect(ctx.conn_opts, fn conn ->
       assert_receive {^conn, %SatInStartReplicationReq{}}
 
-      req = %SatInStartReplicationReq{options: [:FIRST_LSN], schema_version: vsn1}
+      req = %SatInStartReplicationReq{schema_version: vsn1}
       MockClient.send_data(conn, req)
       assert_receive {^conn, %SatInStartReplicationResp{}}
 

--- a/e2e/tests/3.10_node_satellite_can_resume_replication_on_reconnect.lux
+++ b/e2e/tests/3.10_node_satellite_can_resume_replication_on_reconnect.lux
@@ -16,7 +16,7 @@
 
 [shell satellite_1]
   # The client starts replication from scratch.
-  ?no previous LSN, start replication with option FIRST_LSN
+  ?no previous LSN, start replication from scratch
   ?Sending message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationReq","lsn":\{\}
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationResp"\}
 

--- a/e2e/tests/3.9_fresh_node_satellite_receives_only_missing_migrations_during_initial_sync.lux
+++ b/e2e/tests/3.9_fresh_node_satellite_receives_only_missing_migrations_during_initial_sync.lux
@@ -31,7 +31,7 @@
 	?applying migration: $migration1_vsn
 
   # The client starts replication from scratch.
-  ?no previous LSN, start replication with option FIRST_LSN
+  ?no previous LSN, start replication from scratch
   # It passes its schema version to the server.
   ?Sending message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationReq","lsn":\{\},.*?"schemaVersion":"$migration1_vsn"
   ?Received message \{"\$$type":"Electric.Satellite.v[0-9_]+.SatInStartReplicationResp"\}

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -42,7 +42,7 @@
                         auth: %{auth_config: auth_config, user_id: "$user_id"},
                         id: "$client_id",
                         debug: true,
-                        sub: "0",
+                        sub: "",
                         auto_in_sub: true,
                         format: :term,
                         host: "electric_1",

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -96,20 +96,13 @@ message SatErrorResp {
 // (Consumer) Starts replication stream from producer to consumer
 message SatInStartReplicationReq {
     enum Option {
+        reserved 1, 3, 4;
+
+        // Required by the Protobuf spec.
         NONE = 0;
-        // Flag that indicates to Producer, to start replication from the latest
-        // position that has been acknowledged by this Consumer. In such a case
-        // provided lsn will be ignored
-        LAST_ACKNOWLEDGED = 1;
         // In sync mode consumer of the stream is expected to send SatPingResp
         // message for every committed batch of SatOpLog messages
         SYNC_MODE = 2;
-        // Asks receiver to start replication from the first transaction in the log
-        // without necessity to know about the actual internal format of the LSN
-        FIRST_LSN = 3;
-        // Asks receiver to start replication from the last position in the log,
-        // whatever this position is. Used for tests only.
-        LAST_LSN = 4;
     }
     // LSN position of the log on the producer side
     bytes lsn = 1;


### PR DESCRIPTION
Closes VAX-759.