### PR TITLE
fix: correctly disable triggers on shape GC

### DIFF
--- a/.changeset/odd-timers-tickle.md
+++ b/.changeset/odd-timers-tickle.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixed garbage collection on shape unsubscribe (also called on subscription errors), which caused the DELETEs performed by GC get noted in operations log and sent to the server, causing data loss


### PR DESCRIPTION
Shapes don't use fully qualified table names, but the functions disabling the triggers expect FQ names. So we didn't disable the triggers before. Ideally FQ names should be represented by a different type (e.g. a tuple), but that's for another day