### PR TITLE
drivers: use web socket in wa-sqlite driver.

### DIFF
--- a/.changeset/pretty-melons-ring.md
+++ b/.changeset/pretty-melons-ring.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Bugfix: update the `wa-sqlite` driver to use the `WebSocketFactory`.

--- a/clients/typescript/src/drivers/wa-sqlite/index.ts
+++ b/clients/typescript/src/drivers/wa-sqlite/index.ts
@@ -2,7 +2,7 @@ import { DatabaseAdapter } from './adapter'
 import { ElectricDatabase } from './database'
 import { ElectricConfig } from '../../config'
 import { electrify as baseElectrify, ElectrifyOptions } from '../../electric'
-import { WebSocketReactNativeFactory } from '../../sockets/react-native'
+import { WebSocketWebFactory } from '../../sockets/web'
 import { ElectricClient, DbSchema } from '../../client/model'
 import { Database } from './database'
 
@@ -17,7 +17,7 @@ export const electrify = async <T extends Database, DB extends DbSchema<any>>(
 ): Promise<ElectricClient<DB>> => {
   const dbName = db.name
   const adapter = opts?.adapter || new DatabaseAdapter(db)
-  const socketFactory = opts?.socketFactory || new WebSocketReactNativeFactory()
+  const socketFactory = opts?.socketFactory || new WebSocketWebFactory()
 
   const client = await baseElectrify(
     dbName,


### PR DESCRIPTION
I noticed my web application's web socket came from a file called `react-native.js`, which I assume is a bug.

Unless the `ReactNativeSocketFactory` is meant to be a general one and should perhaps be renamed?