### PR TITLE
fix: make sure the subscription request is saved early

### DIFF
--- a/.changeset/shiny-pears-accept.md
+++ b/.changeset/shiny-pears-accept.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixed subscription being registered too late preventing deduplication

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -344,6 +344,8 @@ export class SatelliteProcess implements Satellite {
     }))
 
     const subId = this.subscriptionIdGenerator()
+    this.subscriptions.subscriptionRequested(subId, shapeReqs)
+
     // store the resolve and reject
     // such that we can resolve/reject
     // the promise later when the shape
@@ -357,17 +359,18 @@ export class SatelliteProcess implements Satellite {
     const { subscriptionId, error }: SubscribeResponse =
       await this.client.subscribe(subId, shapeReqs)
     if (subId !== subscriptionId) {
+      delete this.subscriptionNotifiers[subId]
+      this.subscriptions.subscriptionCancelled(subId)
       throw new Error(
         `Expected SubscripeResponse for subscription id: ${subId} but got it for another id: ${subscriptionId}`
       )
     }
+
     if (error) {
       delete this.subscriptionNotifiers[subscriptionId]
       this.subscriptions.subscriptionCancelled(subscriptionId)
       throw error
     }
-
-    this.subscriptions.subscriptionRequested(subscriptionId, shapeReqs)
 
     return {
       synced: this.subscriptionNotifiers[subId].promise,


### PR DESCRIPTION
Continuation of #278, adding the test and covering additional behaviour