### PR TITLE
Add precise typings for _getMeta

### DIFF
--- a/.changeset/stale-zoos-poke.md
+++ b/.changeset/stale-zoos-poke.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Chore: made `_getMeta` types more precise

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -188,6 +188,7 @@
     "@types/react": "^18.0.18",
     "@types/react-native-sqlite-storage": "^6.0.0",
     "@types/react-native-uuid": "^2.0.0",
+    "@types/uuid": "^9.0.1",
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.34.0",
     "@typescript-eslint/parser": "^5.34.0",

--- a/clients/typescript/src/declarations.d.ts
+++ b/clients/typescript/src/declarations.d.ts
@@ -1,2 +1,1 @@
 declare module 'sqlite-parser'
-declare module 'uuid'

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -1325,7 +1325,7 @@ export class SatelliteProcess implements Satellite {
   private async _getClientId(): Promise<Uuid> {
     const clientIdKey = 'clientId'
 
-    let clientId = (await this._getMeta(clientIdKey))
+    let clientId = await this._getMeta(clientIdKey)
 
     if (clientId === '') {
       clientId = uuid() as Uuid

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -1,5 +1,16 @@
 import throttle from 'lodash.throttle'
 
+type Uuid = `${string}-${string}-${string}-${string}-${string}`
+
+type MetaEntries = {
+  clientId: Uuid | '',
+  compensations: number,
+  lastAckdRowId: `${ number }`,
+  lastSentRowId: `${ number }`,
+  lsn: string | null,
+  subscriptions: string,
+}
+
 import { AuthConfig, AuthState } from '../auth/index'
 import { DatabaseAdapter, RunResult } from '../electric/adapter'
 import { Migrator } from '../migrators/index'
@@ -1269,7 +1280,9 @@ export class SatelliteProcess implements Satellite {
     }
   }
 
-  _setMetaStatement(key: string, value: SqlValue): Statement {
+  _setMetaStatement<K extends keyof MetaEntries>(key: K, value: MetaEntries[K]): Statement
+  _setMetaStatement(key: Uuid, value: string | null): Statement
+  _setMetaStatement(key: string, value: SqlValue) {
     const meta = this.opts.metaTable.toString()
 
     const sql = `UPDATE ${meta} SET value = ? WHERE key = ?`
@@ -1277,12 +1290,16 @@ export class SatelliteProcess implements Satellite {
     return { sql, args }
   }
 
-  async _setMeta(key: string, value: SqlValue): Promise<void> {
+  async _setMeta<K extends keyof MetaEntries>(key: K, value: MetaEntries[K]): Promise<void>
+  async _setMeta(key: Uuid, value: string | null): Promise<void>
+  async _setMeta(key: Parameters<this['_setMetaStatement']>[0], value: Parameters<this['_setMetaStatement']>[1]) {
     const stmt = this._setMetaStatement(key, value)
     await this.adapter.run(stmt)
   }
 
-  async _getMeta(key: string): Promise<string> {
+  async _getMeta(key: Uuid): Promise<string | null>
+  async _getMeta<K extends keyof MetaEntries>(key: K): Promise< MetaEntries[K]>
+  async _getMeta(key: string) {
     const meta = this.opts.metaTable.toString()
 
     const sql = `SELECT value from ${meta} WHERE key = ?`
@@ -1293,16 +1310,16 @@ export class SatelliteProcess implements Satellite {
       throw `Invalid metadata table: missing ${key}`
     }
 
-    return rows[0].value as string
+    return rows[0].value
   }
 
-  private async _getClientId(): Promise<string> {
+  private async _getClientId(): Promise<Uuid> {
     const clientIdKey = 'clientId'
 
-    let clientId: string = await this._getMeta(clientIdKey)
+    let clientId = await this._getMeta(clientIdKey) as Uuid | ''
 
     if (clientId === '') {
-      clientId = uuid() as string
+      clientId = uuid() as Uuid
       await this._setMeta(clientIdKey, clientId)
     }
     return clientId

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -3,12 +3,12 @@ import throttle from 'lodash.throttle'
 type Uuid = `${string}-${string}-${string}-${string}-${string}`
 
 type MetaEntries = {
-  clientId: Uuid | '',
-  compensations: number,
-  lastAckdRowId: `${ number }`,
-  lastSentRowId: `${ number }`,
-  lsn: string | null,
-  subscriptions: string,
+  clientId: Uuid | ''
+  compensations: number
+  lastAckdRowId: `${number}`
+  lastSentRowId: `${number}`
+  lsn: string | null
+  subscriptions: string
 }
 
 import { AuthConfig, AuthState } from '../auth/index'
@@ -1280,7 +1280,10 @@ export class SatelliteProcess implements Satellite {
     }
   }
 
-  _setMetaStatement<K extends keyof MetaEntries>(key: K, value: MetaEntries[K]): Statement
+  _setMetaStatement<K extends keyof MetaEntries>(
+    key: K,
+    value: MetaEntries[K]
+  ): Statement
   _setMetaStatement(key: Uuid, value: string | null): Statement
   _setMetaStatement(key: string, value: SqlValue) {
     const meta = this.opts.metaTable.toString()
@@ -1290,15 +1293,21 @@ export class SatelliteProcess implements Satellite {
     return { sql, args }
   }
 
-  async _setMeta<K extends keyof MetaEntries>(key: K, value: MetaEntries[K]): Promise<void>
+  async _setMeta<K extends keyof MetaEntries>(
+    key: K,
+    value: MetaEntries[K]
+  ): Promise<void>
   async _setMeta(key: Uuid, value: string | null): Promise<void>
-  async _setMeta(key: Parameters<this['_setMetaStatement']>[0], value: Parameters<this['_setMetaStatement']>[1]) {
+  async _setMeta(
+    key: Parameters<this['_setMetaStatement']>[0],
+    value: Parameters<this['_setMetaStatement']>[1]
+  ) {
     const stmt = this._setMetaStatement(key, value)
     await this.adapter.run(stmt)
   }
 
   async _getMeta(key: Uuid): Promise<string | null>
-  async _getMeta<K extends keyof MetaEntries>(key: K): Promise< MetaEntries[K]>
+  async _getMeta<K extends keyof MetaEntries>(key: K): Promise<MetaEntries[K]>
   async _getMeta(key: string) {
     const meta = this.opts.metaTable.toString()
 
@@ -1316,7 +1325,7 @@ export class SatelliteProcess implements Satellite {
   private async _getClientId(): Promise<Uuid> {
     const clientIdKey = 'clientId'
 
-    let clientId = await this._getMeta(clientIdKey) as Uuid | ''
+    let clientId = (await this._getMeta(clientIdKey)) as Uuid | ''
 
     if (clientId === '') {
       clientId = uuid() as Uuid

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -1325,7 +1325,7 @@ export class SatelliteProcess implements Satellite {
   private async _getClientId(): Promise<Uuid> {
     const clientIdKey = 'clientId'
 
-    let clientId = (await this._getMeta(clientIdKey)) as Uuid | ''
+    let clientId = (await this._getMeta(clientIdKey))
 
     if (clientId === '') {
       clientId = uuid() as Uuid

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@types/react-native-uuid':
         specifier: ^2.0.0
         version: 2.0.0
+      '@types/uuid':
+        specifier: ^9.0.1
+        version: 9.0.1
       '@types/ws':
         specifier: ^8.5.3
         version: 8.5.4


### PR DESCRIPTION
This small change now guarantees the result type from `_getMeta` depending on the entry key:

<img width="404" alt="image" src="https://github.com/electric-sql/electric/assets/28248193/2c0aa19b-df71-46d2-8f5f-8b61120afe1a">

To ensure this result, `_setMeta` also checks its inputs:

<img width="621" alt="image" src="https://github.com/electric-sql/electric/assets/28248193/31c4f4ba-daa5-44eb-ba2d-ed14829bccd4">

Here, we read `Argument of type '"nonsense"' is not assignable to parameter of type '"" | `${string}-${string}-${string}-${string}-${string}`'.`, _i.e._, it is not a valid `Uuid`.

While editing the `Uuid` type, I also noticed that the module was declared empty in `declarations.d.ts`. I put the official typings instead.

Closes #259.