### PR TITLE
client config: improve URL parsing.

### DIFF
--- a/.changeset/tasty-buckets-smoke.md
+++ b/.changeset/tasty-buckets-smoke.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+client: improved `config.url` parsing and.

--- a/.changeset/tasty-buckets-smoke.md
+++ b/.changeset/tasty-buckets-smoke.md
@@ -2,4 +2,4 @@
 "electric-sql": patch
 ---
 
-client: improved `config.url` parsing and.
+Improved `config.url` parsing and SSL support.


### PR DESCRIPTION
Fixing a problem of my own making because I 💯 asked @kevin-dp to implement as is but now having used it a bit ...

This changes the `config.url` parsing when instantiating the client. The current implement uses an `electric://` protocol and doesn't support SSL.

This change updates to support `http[s]://` and `ws[s]://`protocols and an `ssl=true` parameter and uses `new URL(s)` to do the parsing, rather than a regex.

This allows us to use SSL by default when the user provides a url with a secure protocol and also defaults the port to 443 for secure and 80 for insecure. This allows URLs like `wss://my-electric-service.example.com` to default to 443 rather than `5133`, which is more realistic in production.