### PR TITLE
fix: properly send all pending txs instead of discarding

### DIFF
--- a/.changeset/fast-forks-reply.md
+++ b/.changeset/fast-forks-reply.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixed not sending all the transactions if more than one was done within a throttle window

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -438,9 +438,8 @@ export class SatelliteClient extends EventEmitter implements Client {
       )
     }
 
-    while (this.outbound.transactions.length > 0) {
-      const next = this.outbound.transactions.splice(0)[0]
-
+    let next: DataTransaction | undefined
+    while ((next = this.outbound.transactions.shift())) {
       // TODO: divide into SatOpLog array with max size
       this.sendMissingRelations(next, this.outbound)
       const satOpLog: SatOpLog = this.transactionToSatOpLog(next)


### PR DESCRIPTION
`.splice(0)` without a second argument removes all elements from the array, returning them. We essentially cleared the array and did nothing with removed elements.

The changes in the test are from the fact that the outbound transactions starts filling up only after the third transaction: first write calls the debounced function immediately, second write falls into the debounce window, and third write gets accumulated with the second and then doesn't get sent.