### PR TITLE
Remove .only in client tests

### DIFF
--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -409,7 +409,7 @@ test.serial('acknowledge lsn', async (t) => {
   })
 })
 
-test.serial.only('send transaction', async (t) => {
+test.serial('send transaction', async (t) => {
   await connectAndAuth(t.context)
   const { client, server } = t.context
 


### PR DESCRIPTION
It looks like this was missed in a recent commit.