### PR TITLE
client: fix buggy connectivity hook.

### DIFF
--- a/.changeset/flat-rabbits-scream.md
+++ b/.changeset/flat-rabbits-scream.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix unreliable behaviour in the React `useConnectivityState` hook.

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -1,6 +1,4 @@
 import { ElectricNamespace } from '../../electric/namespace'
-import { DatabaseAdapter } from '../../electric/adapter'
-import { Notifier } from '../../notifiers'
 import { DbSchema, TableSchema } from './schema'
 import { liveRaw, raw, Table } from './table'
 import { Row, Statement } from '../../util'
@@ -59,10 +57,14 @@ export class ElectricClient<
 > extends ElectricNamespace {
   private constructor(
     public db: ClientTables<DB> & RawQueries,
-    adapter: DatabaseAdapter,
-    notifier: Notifier
+    electric: ElectricNamespace
   ) {
-    super(adapter, notifier)
+    super(electric.adapter, electric.notifier)
+
+    Object.defineProperty(this, 'isConnected', {
+      get: () => electric.isConnected,
+      set: (_value) => { /* noop */ }
+    })
   }
 
   // Builds the DAL namespace from a `dbDescription` object
@@ -98,6 +100,6 @@ export class ElectricClient<
       liveRaw: liveRaw.bind(null, electric.adapter),
     }
 
-    return new ElectricClient(db, electric.adapter, electric.notifier)
+    return new ElectricClient(db, electric)
   }
 }

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -63,7 +63,9 @@ export class ElectricClient<
 
     Object.defineProperty(this, 'isConnected', {
       get: () => electric.isConnected,
-      set: (_value) => { /* noop */ }
+      set: (_value) => {
+        /* noop */
+      },
     })
   }
 

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -57,6 +57,10 @@ export const electrify = async <DB extends DbSchema<any>>(
     configWithDefaults
   )
 
+  if (satellite.connectivityState !== undefined) {
+    electric.setIsConnected(satellite.connectivityState)
+  }
+
   // initialize the shape manager
   shapeManager.init(satellite)
   const namespace = ElectricClient.create(dbDescription, electric) // extends the electric namespace with a `dal` property for the data access library

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -46,7 +46,7 @@ export const electrify = async <DB extends DbSchema<any>>(
   const notifier = opts?.notifier || new EventNotifier(dbName)
   const registry = opts?.registry || globalRegistry
 
-  const electric = new ElectricNamespace(adapter, notifier)
+  const electric = ElectricClient.create(dbDescription, adapter, notifier)
 
   const satellite = await registry.ensureStarted(
     dbName,
@@ -63,6 +63,5 @@ export const electrify = async <DB extends DbSchema<any>>(
 
   // initialize the shape manager
   shapeManager.init(satellite)
-  const namespace = ElectricClient.create(dbDescription, electric) // extends the electric namespace with a `dal` property for the data access library
-  return namespace
+  return electric
 }

--- a/clients/typescript/src/electric/namespace.ts
+++ b/clients/typescript/src/electric/namespace.ts
@@ -2,6 +2,7 @@
 // (technically via the proxy machinery) as the `.electric` property.
 import { DatabaseAdapter } from './adapter'
 import { Notifier } from '../notifiers'
+import { ConnectivityState } from  '../util/types'
 
 export class ElectricNamespace {
   adapter: DatabaseAdapter
@@ -13,11 +14,25 @@ export class ElectricNamespace {
     this.notifier = notifier
     this.isConnected = false
 
+    // XXX if you're implementing VAX-799, see the note below and maybe refactor
+    // this out of here whilst cleaning up the subscription.
+
     // we need to set isConnected before the first event is emitted,
     // otherwise application might be out of sync with satellite state.
-    this.notifier.subscribeToConnectivityStateChanges((notification) => {
-      this.isConnected = notification.connectivityState == 'connected'
-    })
+    this.notifier.subscribeToConnectivityStateChanges(
+      ({ connectivityState }) => {
+        this.setIsConnected(connectivityState)
+      }
+    )
+  }
+
+  // XXX this `isConnected` property is now only used via the ElectricClient.
+  // Now ... because the connectivity state change subscription is wired up
+  // here, we proxy this property from a dynamic `isConnected` getter on the
+  // ElectricClient. All of which is a bit unecessary and something of a
+  // code smell. As is the subscription above not being cleaned up.
+  setIsConnected(connectivityState: ConnectivityState): void {
+    this.isConnected = connectivityState === 'connected'
   }
 
   // We lift this function a level so the user can call

--- a/clients/typescript/src/electric/namespace.ts
+++ b/clients/typescript/src/electric/namespace.ts
@@ -2,7 +2,7 @@
 // (technically via the proxy machinery) as the `.electric` property.
 import { DatabaseAdapter } from './adapter'
 import { Notifier } from '../notifiers'
-import { ConnectivityState } from  '../util/types'
+import { ConnectivityState } from '../util/types'
 
 export class ElectricNamespace {
   adapter: DatabaseAdapter

--- a/clients/typescript/src/electric/namespace.ts
+++ b/clients/typescript/src/electric/namespace.ts
@@ -7,12 +7,15 @@ import { ConnectivityState } from '../util/types'
 export class ElectricNamespace {
   adapter: DatabaseAdapter
   notifier: Notifier
-  isConnected: boolean
+  private _isConnected: boolean
+  public get isConnected(): boolean {
+    return this._isConnected
+  }
 
   constructor(adapter: DatabaseAdapter, notifier: Notifier) {
     this.adapter = adapter
     this.notifier = notifier
-    this.isConnected = false
+    this._isConnected = false
 
     // XXX if you're implementing VAX-799, see the note below and maybe refactor
     // this out of here whilst cleaning up the subscription.
@@ -32,7 +35,7 @@ export class ElectricNamespace {
   // ElectricClient. All of which is a bit unecessary and something of a
   // code smell. As is the subscription above not being cleaned up.
   setIsConnected(connectivityState: ConnectivityState): void {
-    this.isConnected = connectivityState === 'connected'
+    this._isConnected = connectivityState === 'connected'
   }
 
   // We lift this function a level so the user can call

--- a/clients/typescript/src/frameworks/react/hooks/useConnectivityState.ts
+++ b/clients/typescript/src/frameworks/react/hooks/useConnectivityState.ts
@@ -6,20 +6,20 @@ import { ConnectivityState } from '../../../util/types'
 import { ElectricContext } from '../provider'
 
 type RetVal = {
-  connectivityState: ConnectivityState,
-  setConnectivityState: (state: ConnectivityState) => void,
+  connectivityState: ConnectivityState
+  setConnectivityState: (state: ConnectivityState) => void
   toggleConnectivityState: () => void
 }
 type HookFn = () => RetVal
 
 const STATES: {
-  available: ConnectivityState,
-  connected: ConnectivityState,
+  available: ConnectivityState
+  connected: ConnectivityState
   disconnected: ConnectivityState
 } = {
   available: 'available',
   connected: 'connected',
-  disconnected: 'disconnected'
+  disconnected: 'disconnected',
 }
 const VALID_STATES = Object.values(STATES)
 
@@ -28,22 +28,14 @@ const getElectricState = (electric?: ElectricNamespace) => {
     return STATES.disconnected
   }
 
-  return electric.isConnected
-    ? STATES.connected
-    : STATES.disconnected
+  return electric.isConnected ? STATES.connected : STATES.disconnected
 }
 
-const getNextState = (currentState: ConnectivityState) => (
-  currentState === STATES.connected
-  ? STATES.disconnected
-  : STATES.available
-)
+const getNextState = (currentState: ConnectivityState) =>
+  currentState === STATES.connected ? STATES.disconnected : STATES.available
 
-const getValidState = (candidateState: ConnectivityState) => (
-  VALID_STATES.includes(candidateState)
-  ? candidateState
-  : STATES.disconnected
-)
+const getValidState = (candidateState: ConnectivityState) =>
+  VALID_STATES.includes(candidateState) ? candidateState : STATES.disconnected
 
 /**
  * React Hook to observe and manage Electric's connectivity state
@@ -51,7 +43,7 @@ const getValidState = (candidateState: ConnectivityState) => (
 const useConnectivityState: HookFn = () => {
   const electric = useContext(ElectricContext)
   const initialState: ConnectivityState = getElectricState(electric)
-  const [ state, setState ] = useState<ConnectivityState>(initialState)
+  const [state, setState] = useState<ConnectivityState>(initialState)
 
   useEffect(() => {
     let shouldStop = false
@@ -71,7 +63,8 @@ const useConnectivityState: HookFn = () => {
       setState(getValidState(connectivityState))
     }
 
-    const subscriptionKey = notifier.subscribeToConnectivityStateChanges(handler)
+    const subscriptionKey =
+      notifier.subscribeToConnectivityStateChanges(handler)
 
     return () => {
       shouldStop = true
@@ -98,7 +91,7 @@ const useConnectivityState: HookFn = () => {
   return {
     connectivityState: state,
     setConnectivityState: setState,
-    toggleConnectivityState: toggleState
+    toggleConnectivityState: toggleState,
   }
 }
 

--- a/clients/typescript/src/frameworks/react/hooks/useConnectivityState.ts
+++ b/clients/typescript/src/frameworks/react/hooks/useConnectivityState.ts
@@ -2,7 +2,6 @@ import { useContext, useEffect, useState } from 'react'
 
 import { ElectricNamespace } from '../../../electric'
 import { ConnectivityStateChangeNotification as Notification } from '../../../notifiers'
-import { genUUID } from '../../../util/random'
 import { ConnectivityState } from '../../../util/types'
 import { ElectricContext } from '../provider'
 

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -7,6 +7,7 @@ import { SocketFactory } from '../sockets'
 import {
   AckCallback,
   AuthResponse,
+  ConnectivityState,
   DbName,
   LSN,
   DataTransaction,
@@ -56,6 +57,8 @@ export interface Satellite {
   adapter: DatabaseAdapter
   migrator: Migrator
   notifier: Notifier
+
+  connectivityState?: ConnectivityState
 
   start(
     authConfig: AuthConfig,

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -121,9 +121,11 @@ export class SatelliteProcess implements Satellite {
   _authState?: AuthState
   _authStateSubscription?: string
 
+  connectivityState?: ConnectivityState
+  _connectivityChangeSubscription?: string
+
   _pollingInterval?: any
   _potentialDataChangeSubscription?: string
-  _connectivityChangeSubscription?: string
   _throttledSnapshot: ThrottleFunction
 
   _lastAckdRowId: number
@@ -585,10 +587,13 @@ export class SatelliteProcess implements Satellite {
   }
 
   async _connectivityStateChanged(status: ConnectivityState): Promise<void> {
+    this.connectivityState = status
+
     // TODO: no op if state is the same
     switch (status) {
       case 'available': {
         this.setClientListeners()
+
         return this._connectAndStartReplication()
       }
       case 'error':

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -13,7 +13,6 @@ import { MockSatelliteClient } from '../../../src/satellite/mock'
 import { BundleMigrator } from '../../../src/migrators'
 import { MockNotifier } from '../../../src/notifiers'
 import { randomValue } from '../../../src/util'
-import { ElectricNamespace } from '../../../src/electric/namespace'
 import { ElectricClient } from '../../../src/client/model/client'
 import { cleanAndStopSatellite } from '../../satellite/common'
 import { satelliteDefaults } from '../../../src/satellite/config'
@@ -67,9 +66,8 @@ async function makeContext(t: ExecutionContext<ContextType>) {
     satelliteDefaults
   )
 
-  const ns = new ElectricNamespace(adapter, notifier)
   shapeManager.init(satellite)
-  const electric = ElectricClient.create(schema, ns)
+  const electric = ElectricClient.create(schema, adapter, notifier)
   const Post = electric.db.Post
   const Items = electric.db.Items
   const User = electric.db.User

--- a/clients/typescript/test/frameworks/react.test.tsx
+++ b/clients/typescript/test/frameworks/react.test.tsx
@@ -10,7 +10,6 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { DatabaseAdapter } from '../../src/drivers/react-native-sqlite-storage/adapter'
 import { MockDatabase } from '../../src/drivers/react-native-sqlite-storage/mock'
 
-import { ElectricNamespace } from '../../src/electric/index'
 import { MockNotifier } from '../../src/notifiers/mock'
 import { QualifiedTablename } from '../../src/util/tablename'
 import { sleepAsync } from '../../src/util/timer'
@@ -38,8 +37,7 @@ test('useLiveQuery returns query results', async (t) => {
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const query = 'select i from bars'
   const liveQuery = dal.db.liveRaw({
@@ -61,8 +59,7 @@ test('useLiveQuery returns error when query errors', async (t) => {
   const adapter = new DatabaseAdapter(original, false)
 
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const wrapper: FC = ({ children }) => {
     return <ElectricProvider db={dal}>{children}</ElectricProvider>
@@ -82,8 +79,7 @@ test('useLiveQuery re-runs query when data changes', async (t) => {
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const query = 'select foo from bars'
   const liveQuery = dal.db.liveRaw({
@@ -118,8 +114,7 @@ test('useLiveQuery re-runs query when *aliased* data changes', async (t) => {
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   await notifier.attach('baz.db', 'baz')
 
@@ -156,8 +151,7 @@ test('useLiveQuery never sets results if unmounted immediately', async (t) => {
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const query = 'select foo from bars'
   const liveQuery = dal.db.liveRaw({
@@ -181,8 +175,7 @@ test('useLiveQuery unsubscribes to data changes when unmounted', async (t) => {
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const query = 'select foo from bars'
   const liveQuery = dal.db.liveRaw({
@@ -220,8 +213,7 @@ test('useLiveQuery ignores results if unmounted whilst re-querying', async (t) =
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const query = 'select foo from bars'
   const liveQuery = dal.db.liveRaw({
@@ -263,8 +255,7 @@ test('useConnectivityState defaults to disconnected', async (t) => {
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const wrapper: FC = ({ children }) => {
     return <ElectricProvider db={dal}>{children}</ElectricProvider>
@@ -282,8 +273,7 @@ test('useConnectivityState handles connectivity events', async (t) => {
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const wrapper: FC = ({ children }) => {
     return <ElectricProvider db={dal}>{children}</ElectricProvider>
@@ -301,8 +291,7 @@ test('useConnectivityState ignores connectivity events after unmounting', async 
   const original = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(original, false)
   const notifier = new MockNotifier('test.db')
-  const namespace = new ElectricNamespace(adapter, notifier)
-  const dal = ElectricClient.create(schema, namespace)
+  const dal = ElectricClient.create(schema, adapter, notifier)
 
   const wrapper: FC = ({ children }) => {
     return <ElectricProvider db={dal}>{children}</ElectricProvider>


### PR DESCRIPTION
The problem was that existing satellite processes were not reporting their existing connectivity status to the connectivity hook. This was confusing the hook into always starting in a disconnected state, despite the connection being connected.

I've left one note in the code about a future refactor. I'm not convinced by the current code structure and connectivity state machine. But suggesting we merge this as we need the fix urgently.