### PR TITLE
chore: rewritten `_performSnapshot` function

### DIFF
--- a/.changeset/moody-comics-pretend.md
+++ b/.changeset/moody-comics-pretend.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Updated snapshotting function to be more efficient when handling a large oplog

--- a/clients/typescript/src/migrators/schema.ts
+++ b/clients/typescript/src/migrators/schema.ts
@@ -9,6 +9,9 @@ export const data = {
       statements: [
         //`-- The ops log table\n`,
         `CREATE TABLE IF NOT EXISTS ${oplogTable} (\n  rowid INTEGER PRIMARY KEY AUTOINCREMENT,\n  namespace TEXT NOT NULL,\n  tablename TEXT NOT NULL,\n  optype TEXT NOT NULL,\n  primaryKey TEXT NOT NULL,\n  newRow TEXT,\n  oldRow TEXT,\n  timestamp TEXT,  clearTags TEXT DEFAULT "[]" NOT NULL\n);`,
+        // Add an index for the oplog
+        `CREATE INDEX IF NOT EXISTS ${oplogTable.namespace}._electric_table_pk_reference ON ${oplogTable.tablename} (namespace, tablename, primaryKey)`,
+        `CREATE INDEX IF NOT EXISTS ${oplogTable.namespace}._electric_timestamp ON ${oplogTable.tablename} (timestamp)`,
         //`-- Somewhere to keep our metadata\n`,
         `CREATE TABLE IF NOT EXISTS ${metaTable} (\n  key TEXT PRIMARY KEY,\n  value BLOB\n);`,
         //`-- Somewhere to track migrations\n`,

--- a/clients/typescript/src/migrators/triggers.ts
+++ b/clients/typescript/src/migrators/triggers.ts
@@ -207,8 +207,14 @@ export function generateTriggers(tables: Tables): Statement[] {
 
 function joinColsForJSON(cols: string[], target?: 'new' | 'old') {
   if (typeof target === 'undefined') {
-    return cols.map((col) => `'${col}', ${col}`).join(', ')
+    return cols
+      .sort()
+      .map((col) => `'${col}', ${col}`)
+      .join(', ')
   } else {
-    return cols.map((col) => `'${col}', ${target}.${col}`).join(', ')
+    return cols
+      .sort()
+      .map((col) => `'${col}', ${target}.${col}`)
+      .join(', ')
   }
 }

--- a/clients/typescript/src/satellite/oplog.ts
+++ b/clients/typescript/src/satellite/oplog.ts
@@ -348,7 +348,7 @@ export const getShadowPrimaryKey = (
   oplogEntry: OplogEntry | OplogEntryChanges | ShadowEntryChanges
 ): ShadowKey => {
   if ('primaryKey' in oplogEntry) {
-    return primaryKeyToStr(JSON.parse(oplogEntry.primaryKey))
+    return oplogEntry.primaryKey
   } else {
     return primaryKeyToStr(oplogEntry.primaryKeyCols)
   }

--- a/clients/typescript/src/satellite/oplog.ts
+++ b/clients/typescript/src/satellite/oplog.ts
@@ -274,7 +274,9 @@ export const fromTransaction = (
       Object.fromEntries(
         relations[`${t.relation.table}`].columns
           .filter((c) => c.primaryKey)
-          .map((col) => [col.name, columnValues![col.name]])
+          .map((col) => col.name)
+          .sort()
+          .map((name) => [name, columnValues![name]])
       )
     )
 
@@ -393,7 +395,7 @@ export const opLogEntryToChange = (
 export const primaryKeyToStr = (primaryKeyJson: {
   [key: string]: string | number
 }): string => {
-  return Object.values(primaryKeyJson).sort().join('_')
+  return JSON.stringify(primaryKeyJson, Object.keys(primaryKeyJson).sort())
 }
 
 export const generateTag = (instanceId: string, timestamp: Date): Tag => {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -711,7 +711,7 @@ export class SatelliteProcess implements Satellite {
     // Update the timestamps on all "new" entries - they have been added but timestamp is still `NULL`
     const q1: Statement = {
       sql: `
-      UPDATE ${oplog} set timestamp = ?
+      UPDATE ${oplog} SET timestamp = ?
       WHERE rowid in (
         SELECT rowid FROM ${oplog}
             WHERE timestamp is NULL
@@ -737,7 +737,7 @@ export class SatelliteProcess implements Satellite {
             AND op.primaryKey = op.primaryKey
         WHERE op.timestamp = ?
               AND op.rowid > ?
-        GROUP BY (op.namespace, op.tablename, op.primaryKey)
+        GROUP BY op.namespace, op.tablename, op.primaryKey
       ) AS updates
       WHERE updates.op_rowid = ${oplog}.rowid
     `,
@@ -752,7 +752,7 @@ export class SatelliteProcess implements Satellite {
         FROM ${oplog} AS op
         WHERE timestamp = ?
               AND rowid > ?
-        GROUP BY (namespace, tablename, primaryKey)
+        GROUP BY namespace, tablename, primaryKey
         HAVING rowid = max(rowid) AND optype != 'DELETE'
     `,
       args: [
@@ -771,7 +771,7 @@ export class SatelliteProcess implements Satellite {
         FROM ${oplog} AS op
         WHERE timestamp = ?
               AND rowid > ?
-        GROUP BY (namespace, tablename, primaryKey)
+        GROUP BY namespace, tablename, primaryKey
         HAVING rowid = max(rowid) AND optype = 'DELETE'
       )
     `,
@@ -880,6 +880,7 @@ export class SatelliteProcess implements Satellite {
           primaryKey: getShadowPrimaryKey(entryChanges),
           tags: encodeTags(entryChanges.tags),
         }
+
         switch (entryChanges.optype) {
           case OPTYPES.delete:
             stmts.push(_applyDeleteOperation(entryChanges, tablenameStr))

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -81,7 +81,7 @@ import {
   SubscriptionData,
 } from './shapes/types'
 import { SubscriptionsManager } from './shapes'
-import { prepareBatchedStatements } from '../util/statements'
+import { prepareInsertBatchedStatements } from '../util/statements'
 import { Mutex } from 'async-mutex'
 
 type ChangeAccumulator = {
@@ -512,7 +512,7 @@ export class SatelliteProcess implements Satellite {
       const sqlBase = `INSERT INTO ${table} (${columns.join(', ')}) VALUES `
 
       stmts.push(
-        ...prepareBatchedStatements(
+        ...prepareInsertBatchedStatements(
           sqlBase,
           columns,
           records as Record<string, SqlValue>[],
@@ -527,7 +527,7 @@ export class SatelliteProcess implements Satellite {
     // Then do a batched insert for the shadow table
     const upsertShadowStmt = `INSERT or REPLACE INTO ${this.opts.shadowTable.toString()} (namespace, tablename, primaryKey, tags) VALUES `
     stmts.push(
-      ...prepareBatchedStatements(
+      ...prepareInsertBatchedStatements(
         upsertShadowStmt,
         ['namespace', 'tablename', 'primaryKey', 'tags'],
         allArgsForShadowInsert,
@@ -695,16 +695,110 @@ export class SatelliteProcess implements Satellite {
       this.performingSnapshot = true
     }
 
+    const oplog = this.opts.oplogTable
+    const shadow = this.opts.shadowTable
     const timestamp = new Date()
+    const newTag = this._generateTag(timestamp)
 
-    await this._updateOplogTimestamp(timestamp)
-    const oplogEntries = await this._getUpdatedEntries(timestamp)
+    /*
+     * IMPORTANT!
+     * 
+     * The following queries make use of a documented but rare SQLite behaviour that allows selecting bare column
+     * on aggregate queries: https://sqlite.org/lang_select.html#bare_columns_in_an_aggregate_query
+     * 
+     * In short, when a query has a `GROUP BY` clause with a single `min()` or `max()` present in SELECT/HAVING,
+     * then the "bare" columns (i.e. those not mentioned in a `GROUP BY` clause) are definitely the ones from the
+     * row that satisfied that `min`/`max` function. We make use of it here to find first/last operations in the
+     * oplog that touch a particular row.
+     */
 
-    if (oplogEntries.length !== 0) {
-      const stmts = await this._handleShadowOperations(timestamp, oplogEntries)
-      await this.adapter.runInTransaction(...stmts)
-      this._notifyChanges(oplogEntries)
+    // Update the timestamps on all "new" entries - they have been added but timestamp is still `NULL`
+    const q1: Statement = {
+      sql: `
+      UPDATE ${oplog} set timestamp = ?
+      WHERE rowid in (
+        SELECT rowid FROM ${oplog}
+            WHERE timestamp is NULL
+            AND rowid > ?
+        ORDER BY rowid ASC
+        )
+      RETURNING *
+    `,
+      args: [timestamp.toISOString(), this._lastAckdRowId],
     }
+
+    // For each first oplog entry per element, set `clearTags` array to previous tags from the shadow table
+    const q2: Statement = {
+      sql: `
+      UPDATE ${oplog}
+      SET clearTags = updates.tags
+      FROM (
+        SELECT shadow.tags as tags, min(op.rowid) as op_rowid
+        FROM ${shadow} AS shadow
+        JOIN ${oplog} as op
+          ON op.namespace = shadow.namespace
+            AND op.tablename = op.tablename
+            AND op.primaryKey = op.primaryKey
+        WHERE op.timestamp = ?
+              AND op.rowid > ?
+        GROUP BY (op.namespace, op.tablename, op.primaryKey)
+      ) AS updates
+      WHERE updates.op_rowid = ${oplog}.rowid
+    `,
+      args: [timestamp.toISOString(), this._lastAckdRowId],
+    }
+
+    // For each affected shadow row, set new tag array, unless the last oplog operation was a DELETE
+    const q3: Statement = {
+      sql: `
+      INSERT OR REPLACE INTO ${shadow} (namespace, tablename, primaryKey, tags)
+      SELECT namespace, tablename, primaryKey, ?
+        FROM ${oplog} AS op
+        WHERE timestamp = ?
+              AND rowid > ?
+        GROUP BY (namespace, tablename, primaryKey)
+        HAVING rowid = max(rowid) AND optype != 'DELETE'
+    `,
+      args: [
+        encodeTags([newTag]),
+        timestamp.toISOString(),
+        this._lastAckdRowId,
+      ],
+    }
+
+    // And finally delete any shadow rows where the last oplog operation was a `DELETE`
+    const q4: Statement = {
+      sql: `
+      DELETE FROM ${shadow}
+      WHERE EXISTS (
+        SELECT 1
+        FROM ${oplog} AS op
+        WHERE timestamp = ?
+              AND rowid > ?
+        GROUP BY (namespace, tablename, primaryKey)
+        HAVING rowid = max(rowid) AND optype = 'DELETE'
+      )
+    `,
+      args: [timestamp.toISOString(), this._lastAckdRowId],
+    }
+
+    // Execute the four queries above in a transaction, returning the results from the first query
+    // We're dropping down to this transaction interface because `runInTransaction` doesn't allow queries
+    const oplogEntries = await this.adapter.transaction<OplogEntry[]>((tx, setResult) => {
+      tx.query(q1, (tx, res) => {
+        if (res.length > 0)
+          tx.run(q2, (tx) =>
+            tx.run(q3, (tx) =>
+              tx.run(q4, () => setResult(res as unknown as OplogEntry[]))
+            )
+          )
+        else {
+          setResult([])
+        }
+      })
+    }) as OplogEntry[]
+
+    if (oplogEntries.length > 0) this._notifyChanges(oplogEntries)
 
     if (!this.client.isClosed()) {
       const { enqueued } = this.client.getOutboundLogPositions()
@@ -717,92 +811,6 @@ export class SatelliteProcess implements Satellite {
     }
     this.performingSnapshot = false
     return timestamp
-  }
-
-  async _handleShadowOperations(
-    timestamp: Date,
-    oplogEntries: OplogEntry[]
-  ): Promise<Statement[]> {
-    const stmts: Statement[] = []
-
-    const shadowEntries = new Map<string, ShadowEntry>()
-    for (const oplogEntry of oplogEntries) {
-      // should get shadow entries at once to prevent querying in a loop
-      const [cached, shadowEntry] = await this._lookupCachedShadowEntry(
-        oplogEntry,
-        shadowEntries
-      )
-
-      // Clear should not contain the tag for this timestamp, so if
-      // the entry was previously in cache - it means, that we already
-      // read it within the same snapshot
-      if (cached) {
-        oplogEntry.clearTags = encodeTags(
-          difference(decodeTags(shadowEntry.tags), [
-            this._generateTag(timestamp),
-          ])
-        )
-      } else {
-        oplogEntry.clearTags = shadowEntry.tags
-      }
-
-      if (oplogEntry.optype == OPTYPES.delete) {
-        shadowEntry.tags = shadowTagsDefault
-      } else {
-        const newTag = this._generateTag(timestamp)
-        shadowEntry.tags = encodeTags([newTag])
-      }
-
-      stmts.push(this._updateOplogEntryTagsStatement(oplogEntry))
-      this._updateCachedShadowEntry(oplogEntry, shadowEntry, shadowEntries)
-    }
-
-    shadowEntries.forEach((value: ShadowEntry, _key: string) => {
-      if (value.tags == shadowTagsDefault) {
-        stmts.push(this._deleteShadowTagsStatement(value))
-      } else {
-        stmts.push(this._updateShadowTagsStatement(value))
-      }
-    })
-
-    return stmts
-  }
-
-  _updateCachedShadowEntry(
-    oplogEntry: OplogEntry,
-    shadowEntry: ShadowEntry,
-    shadowEntries: Map<string, ShadowEntry>
-  ) {
-    const pk = getShadowPrimaryKey(oplogEntry)
-    const key: string = [oplogEntry.namespace, oplogEntry.tablename, pk].join(
-      '.'
-    )
-
-    shadowEntries.set(key, shadowEntry)
-  }
-
-  async _lookupCachedShadowEntry(
-    oplogEntry: OplogEntry,
-    shadowEntries: Map<string, ShadowEntry>
-  ): Promise<[boolean, ShadowEntry]> {
-    const pk = getShadowPrimaryKey(oplogEntry)
-    const key: string = [oplogEntry.namespace, oplogEntry.tablename, pk].join(
-      '.'
-    )
-
-    let shadowEntry: ShadowEntry
-    if (shadowEntries.has(key)) {
-      return [true, shadowEntries.get(key)!]
-    } else {
-      const shadowEntriesList = await this._getOplogShadowEntry(oplogEntry)
-      if (shadowEntriesList.length == 0) {
-        shadowEntry = newShadowEntry(oplogEntry)
-      } else {
-        shadowEntry = shadowEntriesList[0]
-      }
-      shadowEntries.set(key, shadowEntry)
-      return [false, shadowEntry]
-    }
   }
 
   async _notifyChanges(results: OplogEntry[]): Promise<void> {
@@ -910,61 +918,6 @@ export class SatelliteProcess implements Satellite {
     return rows as unknown as OplogEntry[]
   }
 
-  async _getUpdatedEntries(
-    timestamp: Date,
-    since?: number
-  ): Promise<OplogEntry[]> {
-    if (since === undefined) {
-      since = this._lastAckdRowId
-    }
-    const oplog = this.opts.oplogTable.toString()
-
-    const selectChanges = `
-      SELECT * FROM ${oplog}
-      WHERE timestamp = ? AND
-            rowid > ?
-      ORDER BY rowid ASC
-    `
-
-    const rows = await this.adapter.query({
-      sql: selectChanges,
-      args: [timestamp.toISOString(), since],
-    })
-    return rows as unknown as OplogEntry[]
-  }
-
-  _getOplogShadowEntryStatement(oplog?: OplogEntry | undefined): Statement {
-    const shadow = this.opts.shadowTable.toString()
-    let query
-    let selectTags = `SELECT * FROM ${shadow}`
-    if (oplog != undefined) {
-      selectTags =
-        selectTags +
-        ` WHERE
-         namespace = ? AND
-         tablename = ? AND
-         primaryKey = ?
-      `
-      const args = [
-        oplog.namespace,
-        oplog.tablename,
-        getShadowPrimaryKey(oplog),
-      ]
-      query = { sql: selectTags, args: args }
-    } else {
-      query = { sql: selectTags }
-    }
-
-    return query
-  }
-
-  async _getOplogShadowEntry(
-    oplog?: OplogEntry | undefined
-  ): Promise<ShadowEntry[]> {
-    const stmt = this._getOplogShadowEntryStatement(oplog)
-    return (await this.adapter.query(stmt)) as unknown as ShadowEntry[]
-  }
-
   _deleteShadowTagsStatement(shadow: ShadowEntry): Statement {
     const shadowTable = this.opts.shadowTable.toString()
     const deleteRow = `
@@ -994,35 +947,6 @@ export class SatelliteProcess implements Satellite {
         shadow.tags,
       ],
     }
-  }
-
-  _updateOplogEntryTagsStatement(oplog: OplogEntry): Statement {
-    const oplogTable = this.opts.oplogTable.toString()
-    const updateTags = `
-      UPDATE ${oplogTable} set clearTags = ?
-        WHERE rowid = ?
-    `
-    return {
-      sql: updateTags,
-      args: [oplog.clearTags, oplog.rowid],
-    }
-  }
-
-  async _updateOplogTimestamp(timestamp: Date): Promise<RunResult> {
-    const oplog = this.opts.oplogTable.toString()
-
-    const updateTimestamps = `
-      UPDATE ${oplog} set timestamp = ?
-        WHERE rowid in (
-          SELECT rowid FROM ${oplog}
-              WHERE timestamp is NULL
-              AND rowid > ?
-          ORDER BY rowid ASC
-          )
-    `
-
-    const updateArgs = [timestamp.toISOString(), `${this._lastAckdRowId}`]
-    return this.adapter.run({ sql: updateTimestamps, args: updateArgs })
   }
 
   // Merge changes, with last-write-wins and add-wins semantics.

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -733,8 +733,8 @@ export class SatelliteProcess implements Satellite {
         FROM ${shadow} AS shadow
         JOIN ${oplog} as op
           ON op.namespace = shadow.namespace
-            AND op.tablename = op.tablename
-            AND op.primaryKey = op.primaryKey
+            AND op.tablename = shadow.tablename
+            AND op.primaryKey = shadow.primaryKey
         WHERE op.timestamp = ?
               AND op.rowid > ?
         GROUP BY op.namespace, op.tablename, op.primaryKey

--- a/clients/typescript/src/util/sets.ts
+++ b/clients/typescript/src/util/sets.ts
@@ -1,6 +1,6 @@
 /**
  * Calculate a set difference between two arrays
- * 
+ *
  * @returns an array with elements from the first array that are not present in the second array
  */
 export function difference<T>(a: T[], b: T[]): T[] {
@@ -10,9 +10,9 @@ export function difference<T>(a: T[], b: T[]): T[] {
 
 /**
  * Calculate a set union of two arrays.
- * 
+ *
  * If there are non-unique elements in either array, they will be lost.
- * 
+ *
  * @returns an array with all unique elements from two source arrays
  */
 export function union<T>(a: T[], b: T[]): T[] {

--- a/clients/typescript/src/util/sets.ts
+++ b/clients/typescript/src/util/sets.ts
@@ -1,8 +1,20 @@
+/**
+ * Calculate a set difference between two arrays
+ * 
+ * @returns an array with elements from the first array that are not present in the second array
+ */
 export function difference<T>(a: T[], b: T[]): T[] {
   const bset = new Set(b)
   return a.filter((x) => !bset.has(x))
 }
 
+/**
+ * Calculate a set union of two arrays.
+ * 
+ * If there are non-unique elements in either array, they will be lost.
+ * 
+ * @returns an array with all unique elements from two source arrays
+ */
 export function union<T>(a: T[], b: T[]): T[] {
   return Array.from(new Set([...a, ...b]))
 }

--- a/clients/typescript/src/util/statements.ts
+++ b/clients/typescript/src/util/statements.ts
@@ -23,7 +23,7 @@ export function isInsertUpdateOrDeleteStatement(sql: string) {
  * @param maxParameters max parameters this SQLite can accept - determines batching factor
  * @returns array of statements ready to be executed by the adapter
  */
-export function prepareBatchedStatements(
+export function prepareInsertBatchedStatements(
   baseSql: string,
   columns: string[],
   records: Record<string, SqlValue>[],

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -683,10 +683,6 @@ test.serial('default and null test', async (t) => {
 
   const record: any = deserializeRow(serializedRow, rel)!
 
-  console.log(`record: ${JSON.stringify(record)}`)
-
-  console.log(`insert: ${JSON.stringify(insertOp)}`)
-
   const firstOpLogMessage = Proto.SatOpLog.fromPartial({
     ops: [
       Proto.SatTransOp.fromPartial({ begin }),

--- a/clients/typescript/test/satellite/process.migration.test.ts
+++ b/clients/typescript/test/satellite/process.migration.test.ts
@@ -21,6 +21,7 @@ import {
   makeContext,
   relations,
 } from './common'
+import { getMatchingShadowEntries } from '../support/satellite-helpers'
 
 type CurrentContext = ContextType<{ clientId: string; txDate: Date }>
 const test = testAny as TestFn<CurrentContext>
@@ -343,7 +344,8 @@ test.serial(
     // Delete overwrites the insert for row with id 2
     // Thus, it overwrites the shadow tag for that row
     const localEntries = await satellite._getEntries()
-    const shadowEntryForRow2 = await satellite._getOplogShadowEntry(
+    const shadowEntryForRow2 = await getMatchingShadowEntries(
+      adapter,
       localEntries[1]
     ) // shadow entry for insert of row with id 2
     const shadowTagsRow2 = JSON.parse(shadowEntryForRow2[0].tags)
@@ -463,7 +465,8 @@ test.serial('apply migration containing DDL and conflicting DML', async (t) => {
 
   // Fetch the shadow tag for row 1 such that delete will overwrite it
   const localEntries = await satellite._getEntries()
-  const shadowEntryForRow1 = await satellite._getOplogShadowEntry(
+  const shadowEntryForRow1 = await getMatchingShadowEntries(
+    adapter,
     localEntries[0]
   ) // shadow entry for insert of row with id 1
   const shadowTagsRow1 = JSON.parse(shadowEntryForRow1[0].tags)

--- a/clients/typescript/test/satellite/process.tags.test.ts
+++ b/clients/typescript/test/satellite/process.tags.test.ts
@@ -264,13 +264,13 @@ test('remote tx (INSERT) concurrently with local tx (INSERT -> DELETE)', async (
     {
       namespace: 'main',
       tablename: 'parent',
-      primaryKey: '1',
+      primaryKey: '{"id":1}',
       tags: genEncodedTags('remote', [prevTs]),
     },
     {
       namespace: 'main',
       tablename: 'parent',
-      primaryKey: '2',
+      primaryKey: '{"id":2}',
       tags: genEncodedTags('remote', [nextTs]),
     },
   ]
@@ -374,13 +374,13 @@ test('remote tx (INSERT) concurrently with 2 local txses (INSERT -> DELETE)', as
     {
       namespace: 'main',
       tablename: 'parent',
-      primaryKey: '1',
+      primaryKey: '{"id":1}',
       tags: genEncodedTags('remote', [prevTs]),
     },
     {
       namespace: 'main',
       tablename: 'parent',
-      primaryKey: '2',
+      primaryKey: '{"id":2}',
       tags: genEncodedTags('remote', [nextTs]),
     },
   ]
@@ -488,7 +488,7 @@ test('remote tx (INSERT) concurrently with local tx (INSERT -> UPDATE)', async (
     {
       namespace: 'main',
       tablename: 'parent',
-      primaryKey: '1',
+      primaryKey: '{"id":1}',
       tags: encodeTags([
         generateTag(clientId, new Date(txDate1)),
         generateTag('remote', new Date(prevTs)),
@@ -497,7 +497,7 @@ test('remote tx (INSERT) concurrently with local tx (INSERT -> UPDATE)', async (
     {
       namespace: 'main',
       tablename: 'parent',
-      primaryKey: '2',
+      primaryKey: '{"id":2}',
       tags: encodeTags([
         generateTag(clientId, new Date(txDate1)),
         generateTag('remote', new Date(nextTs)),
@@ -614,7 +614,7 @@ test('origin tx (INSERT) concurrently with local txses (INSERT -> DELETE)', asyn
     {
       namespace: 'main',
       tablename: 'parent',
-      primaryKey: '2',
+      primaryKey: '{"id":2}',
       tags: genEncodedTags('remote', [txDate1]),
     },
   ]
@@ -677,7 +677,7 @@ test('local (INSERT -> UPDATE -> DELETE) with remote equivalent', async (t) => {
     {
       namespace: 'main',
       tablename: 'parent',
-      primaryKey: '1',
+      primaryKey: '{"id":1}',
       tags: genEncodedTags('remote', [txDate1]),
     },
   ]

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -266,7 +266,7 @@ test('snapshot of INSERT after DELETE', async (t) => {
     const resultingValue = keyChanges.changes.value.value
     t.is(resultingValue, null)
   } catch (error) {
-    console.log(error)
+    t.fail(error)
   }
 })
 
@@ -1669,13 +1669,11 @@ test('snapshots: generated oplog entries have the correct tags', async (t) => {
   const row = await adapter.query({
     sql: `SELECT id FROM ${qualified}`,
   })
-  console.log(row)
   t.is(row.length, 2)
 
   const shadowRows = await adapter.query({
     sql: `SELECT * FROM _electric_shadow`,
   })
-  console.log(shadowRows)
   t.is(shadowRows.length, 2)
   t.like(shadowRows[0], {
     namespace: 'main',
@@ -1688,7 +1686,6 @@ test('snapshots: generated oplog entries have the correct tags', async (t) => {
   const oplogs = await adapter.query({
     sql: `SELECT * FROM _electric_oplog`,
   })
-  console.log(oplogs)
   t.is(oplogs[0].clearTags, genEncodedTags('remote', [expectedTs]))
 })
 

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1,6 +1,4 @@
 import anyTest, { TestFn } from 'ava'
-import log from 'loglevel'
-log.enableAll()
 
 import {
   MOCK_BEHIND_WINDOW_LSN,
@@ -264,7 +262,7 @@ test('snapshot of INSERT after DELETE', async (t) => {
     const merged = localOperationsToTableChanges(entries, (timestamp: Date) => {
       return generateTag(clientId, timestamp)
     })
-    const [_, keyChanges] = merged['main.parent']['1']
+    const [_, keyChanges] = merged['main.parent']['{"id":1}']
     const resultingValue = keyChanges.changes.value.value
     t.is(resultingValue, null)
   } catch (error) {
@@ -303,7 +301,7 @@ test('take snapshot and merge local wins', async (t) => {
   const merged = satellite._mergeEntries(clientId, local, 'remote', [
     incomingEntry,
   ])
-  const item = merged['main.parent']['1']
+  const item = merged['main.parent']['{"id":1}']
 
   t.deepEqual(item, {
     namespace: 'main',
@@ -360,7 +358,7 @@ test('take snapshot and merge incoming wins', async (t) => {
   const merged = satellite._mergeEntries(clientId, local, 'remote', [
     incomingEntry,
   ])
-  const item = merged['main.parent']['1']
+  const item = merged['main.parent']['{"id":1}']
 
   t.deepEqual(item, {
     namespace: 'main',
@@ -616,7 +614,7 @@ test('INSERT wins over DELETE and restored deleted values', async (t) => {
   ]
 
   const merged = satellite._mergeEntries(clientId, local, 'remote', incoming)
-  const item = merged['main.parent']['1']
+  const item = merged['main.parent']['{"id":1}']
 
   t.deepEqual(item, {
     namespace: 'main',
@@ -692,7 +690,7 @@ test('concurrent updates take all changed values', async (t) => {
   ]
 
   const merged = satellite._mergeEntries(clientId, local, 'remote', incoming)
-  const item = merged['main.parent']['1']
+  const item = merged['main.parent']['{"id":1}']
 
   // The incoming entry modified the value of the `value` column to `'remote'`
   // The local entry concurrently modified the value of the `other` column to 1.
@@ -744,7 +742,7 @@ test('merge incoming with empty local', async (t) => {
 
   const local: OplogEntry[] = []
   const merged = satellite._mergeEntries(clientId, local, 'remote', incoming)
-  const item = merged['main.parent']['1']
+  const item = merged['main.parent']['{"id":1}']
 
   t.deepEqual(item, {
     namespace: 'main',

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -26,6 +26,7 @@ import {
   generateLocalOplogEntry,
   generateRemoteOplogEntry,
   genEncodedTags,
+  getMatchingShadowEntries,
 } from '../support/satellite-helpers'
 import Long from 'long'
 import {
@@ -430,7 +431,7 @@ test('apply does not add anything to oplog', async (t) => {
   t.is(row.other, 1)
 
   const localEntries = await satellite._getEntries()
-  const shadowEntry = await satellite._getOplogShadowEntry(localEntries[0])
+  const shadowEntry = await getMatchingShadowEntries(adapter, localEntries[0])
 
   t.deepEqual(
     encodeTags([
@@ -468,7 +469,7 @@ test('apply incoming with no local', async (t) => {
 
   const sql = 'SELECT * from parent WHERE id=1'
   const rows = await adapter.query({ sql })
-  const shadowEntries = await satellite._getOplogShadowEntry()
+  const shadowEntries = await getMatchingShadowEntries(adapter)
 
   t.is(shadowEntries.length, 0)
   t.is(rows.length, 0)

--- a/clients/typescript/test/util/statements.test.ts
+++ b/clients/typescript/test/util/statements.test.ts
@@ -1,14 +1,14 @@
 import test from 'ava'
 
-import { prepareBatchedStatements } from '../../src/util/statements'
+import { prepareInsertBatchedStatements } from '../../src/util/statements'
 
-test('prepareBatchedStatements correctly splits up data in batches', (t) => {
+test('prepareInsertBatchedStatements correctly splits up data in batches', (t) => {
   const data = [
     { a: 1, b: 2 },
     { a: 3, b: 4 },
     { a: 5, b: 6 },
   ]
-  const stmts = prepareBatchedStatements(
+  const stmts = prepareInsertBatchedStatements(
     'INSERT INTO test (a, b) VALUES',
     ['a', 'b'],
     data,
@@ -24,13 +24,13 @@ test('prepareBatchedStatements correctly splits up data in batches', (t) => {
   ])
 })
 
-test('prepareBatchedStatements respects column order', (t) => {
+test('prepareInsertBatchedStatements respects column order', (t) => {
   const data = [
     { a: 1, b: 2 },
     { a: 3, b: 4 },
     { a: 5, b: 6 },
   ]
-  const stmts = prepareBatchedStatements(
+  const stmts = prepareInsertBatchedStatements(
     'INSERT INTO test (a, b) VALUES',
     ['b', 'a'],
     data,

--- a/e2e/common.mk
+++ b/e2e/common.mk
@@ -55,7 +55,8 @@ log_dev_env:
 	docker compose -f ${DOCKER_COMPOSE_FILE} logs --no-color --follow pg_1
 
 start_electric_%:
-	docker compose -f ${DOCKER_COMPOSE_FILE} up --no-color --no-log-prefix electric_$*
+	docker compose -f ${DOCKER_COMPOSE_FILE} up --no-color --no-log-prefix -d electric_$*
+	docker compose -f ${DOCKER_COMPOSE_FILE} logs --no-color --follow electric_$*
 
 stop_electric_%:
 	docker compose -f ${DOCKER_COMPOSE_FILE} stop electric_$*


### PR DESCRIPTION
Previous implementation executed 3N+2 queries for N oplog entries (`UPDATE` timestamps, `SELECT` updated, then, per oplog entry, `SELECT` shadow row, `UPDATE` oplog entry, `UPDATE` or `DELETE` shadow row).

This implementation always executes exactly 4 queries to achieve the same. This lowers the amount of times we're traversing C or WASM boundary and offloads more work to SQLite.

This shouldn't affect the performance of current "lightweight" apps, but is likely to show significant improvements over 100+ oplog entries