### PR TITLE
fix(CLI): Generate ts file of migrations instead of js file

### DIFF
--- a/.changeset/lemon-seals-mix.md
+++ b/.changeset/lemon-seals-mix.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Modify generated migrations file to be a .ts file instead of .js file

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -448,5 +448,5 @@ async function fetchMigrations(
 
 function migrationsFilePath(opts: Omit<GeneratorOptions, 'watch'>) {
   const outFolder = path.resolve(opts.out)
-  return path.join(outFolder, 'migrations.js')
+  return path.join(outFolder, 'migrations.ts')
 }


### PR DESCRIPTION
Modify the generate command in the CLI to output the migrations in a .ts file instead of a .js file.