### PR TITLE
fix: respect `electric_user_id` filtering on initial sync

### DIFF
--- a/.changeset/bright-doors-cheer.md
+++ b/.changeset/bright-doors-cheer.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fixed sync from subscription not respecting `electric_user_id` filtering

--- a/components/electric/lib/electric/replication/changes.ex
+++ b/components/electric/lib/electric/replication/changes.ex
@@ -90,9 +90,9 @@ defmodule Electric.Replication.Changes do
     defstruct [:relation]
   end
 
-  @spec belongs_to_user?(Transaction.t(), binary()) :: boolean()
-  def belongs_to_user?(%Transaction{} = tx, user_id) do
-    Changes.Ownership.belongs_to_user?(tx, user_id)
+  @spec filter_changes_belonging_to_user(Transaction.t(), binary()) :: Transaction.t()
+  def filter_changes_belonging_to_user(%Transaction{changes: changes} = tx, user_id) do
+    %{tx | changes: Enum.filter(changes, &Changes.Ownership.change_belongs_to_user?(&1, user_id))}
   end
 
   @spec generateTag(Transaction.t()) :: binary()

--- a/components/electric/lib/electric/replication/changes/ownership.ex
+++ b/components/electric/lib/electric/replication/changes/ownership.ex
@@ -8,33 +8,24 @@ defmodule Electric.Replication.Changes.Ownership do
   def id_column_name, do: @user_id_column
 
   @doc """
-  Given a `%Changes.Transaction{}` checks each update within it to verify that they all belong to
-  the given user_id.
+  Given a change, checks if belongs to the given user_id.
 
-  If any of the changes fail this test then the transaction is deemed not to belong to the user.
+  For a change to belong to a user with id `user_id` the row must satisfy one of the conditions:
 
-  For a change to belong to a user with id `user_id` every changed row has to satisfy one of the
-  following conditions:
-
-  1. The table being modified has an `electric_user_id` and the value of this column is either
-     `user_id`, `""` or `NULL`.
-
-  2. The table being modified does not have an `electric_user_id` column. This would be classified
+  1. The table being modified has an `#{@user_id_column}` and the value of this column either
+     matches provided `user_id`, or the column value is `""` or `NULL`.
+  2. The table being modified does not have an `#{@user_id_column}` column. This would be classified
      as a "global" table where all entries are visible by everyone.
   """
-  @spec belongs_to_user?(Changes.Transaction.t(), Auth.user_id()) :: boolean()
-  def belongs_to_user?(transaction, user_id) do
-    # FIXME: for now we hard-code the user id column for a table to be `electric_user_id`
-    Enum.all?(transaction.changes, &change_belongs_to_user?(&1, user_id, @user_id_column))
-  end
-
   @spec change_belongs_to_user?(Changes.change(), Auth.user_id(), Changes.db_identifier()) ::
           boolean()
-  defp change_belongs_to_user?(%Changes.DeletedRecord{old_record: record}, user_id, owner_column) do
+  def change_belongs_to_user?(change, user_id, owner_column \\ @user_id_column)
+
+  def change_belongs_to_user?(%Changes.DeletedRecord{old_record: record}, user_id, owner_column) do
     validate_record(record, user_id, owner_column)
   end
 
-  defp change_belongs_to_user?(%{record: record}, user_id, owner_column) do
+  def change_belongs_to_user?(%{record: record}, user_id, owner_column) do
     validate_record(record, user_id, owner_column)
   end
 

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -817,11 +817,12 @@ defmodule Electric.Satellite.Protocol do
     # I'm dereferencing these here because calling this in Task implies copying over entire `state` just for two fields.
     fun = state.subscription_data_fun
     opts = state.pg_connector_opts
+    context = %{user_id: Pathex.get(state, path(:auth / :user_id))}
 
     Task.start(fn ->
       # This is `InitiaSync.query_subscription_data/2` by default, but can be overridden for tests.
       # Please see documentation on that function for context on the next `receive` block.
-      fun.({id, requests}, reply_to: {ref, parent}, connection: opts)
+      fun.({id, requests, context}, reply_to: {ref, parent}, connection: opts)
     end)
 
     receive do

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -583,9 +583,10 @@ defmodule Electric.Satellite.Protocol do
       tx
       |> maybe_strip_migration_ddl(state.out_rep.last_migration_xid_at_initial_sync)
       |> Shapes.filter_changes_from_tx(current_shapes(state))
+      |> Changes.filter_changes_belonging_to_user(state.auth.user_id)
 
     {out_rep, acc} =
-      if filtered_tx.changes != [] and Changes.belongs_to_user?(filtered_tx, state.auth.user_id) do
+      if filtered_tx.changes != [] do
         {relations, transaction, out_rep} = handle_out_trans({filtered_tx, offset}, state)
         {out_rep, Enum.concat([transaction, relations, acc])}
       else

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -655,7 +655,11 @@ defmodule Electric.Satellite.WsServerTest do
   end
 
   # -------------------------------------------------------------------------------
-  def mock_data_function({id, requests}, [reply_to: {ref, pid}, connection: _], opts \\ []) do
+  def mock_data_function(
+        {id, requests, _context},
+        [reply_to: {ref, pid}, connection: _],
+        opts \\ []
+      ) do
     insertion_point = Keyword.get(opts, :insertion_point, 0)
     data_delay_ms = Keyword.get(opts, :data_delay_ms, 0)
     send(pid, {:subscription_insertion_point, ref, insertion_point})

--- a/components/electric/test/support/postgres_test_connection.ex
+++ b/components/electric/test/support/postgres_test_connection.ex
@@ -152,7 +152,7 @@ defmodule Electric.Postgres.TestConnection do
       CREATE TABLE public.documents (
         id UUID PRIMARY KEY,
         title TEXT NOT NULL,
-        user_id UUID REFERENCES users(id)
+        electric_user_id UUID REFERENCES users(id)
       )
       """)
 


### PR DESCRIPTION
This is a somewhat temporary fix to allow for partial replication based on user id. This assumes user id is kinda immutable per device for the on-device database lifetime (as does a lot of our code), so no effort has been made to ensure row deduplication. Should tide us over until proper DDLX