### PR TITLE
fix: don't send rows to clients that have already seen this particular table

### DIFF
--- a/.changeset/healthy-dingos-destroy.md
+++ b/.changeset/healthy-dingos-destroy.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Support for intersecting shape subscriptions

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -18,6 +18,7 @@ defmodule Electric.Satellite.Protocol do
   alias Electric.Postgres.Extension.SchemaCache
   alias Electric.Replication.Changes
   alias Electric.Replication.Shapes
+  alias Electric.Replication.Shapes.ShapeRequest
   alias Electric.Replication.OffsetStorage
   alias Electric.Satellite.Serialization
   alias Electric.Satellite.ClientManager
@@ -818,7 +819,15 @@ defmodule Electric.Satellite.Protocol do
     # I'm dereferencing these here because calling this in Task implies copying over entire `state` just for two fields.
     fun = state.subscription_data_fun
     opts = state.pg_connector_opts
-    context = %{user_id: Pathex.get(state, path(:auth / :user_id))}
+
+    context = %{
+      user_id: Pathex.get(state, path(:auth / :user_id)),
+      sent_tables:
+        Map.values(state.subscriptions)
+        |> List.flatten()
+        |> Enum.flat_map(fn %ShapeRequest{included_tables: tables} -> tables end)
+        |> MapSet.new()
+    }
 
     Task.start(fn ->
       # This is `InitiaSync.query_subscription_data/2` by default, but can be overridden for tests.

--- a/components/electric/test/electric/replication/shapes/shape_request_test.exs
+++ b/components/electric/test/electric/replication/shapes/shape_request_test.exs
@@ -82,5 +82,21 @@ defmodule Electric.Replication.Shapes.ShapeRequestTest do
                  user_id: "00000000-0000-0000-0000-000000000001"
                })
     end
+
+    @tag with_sql: """
+         INSERT INTO public.my_entries (content) VALUES ('test content');
+         """
+    test "should not fulfill full-table requests if the table has already been sent", %{
+      origin: origin,
+      conn: conn,
+      schema: schema
+    } do
+      request = %ShapeRequest{id: "id", included_tables: [{"public", "my_entries"}]}
+
+      assert {:ok, []} =
+               ShapeRequest.query_initial_data(request, conn, schema, origin, %{
+                 sent_tables: MapSet.new([{"public", "my_entries"}])
+               })
+    end
   end
 end


### PR DESCRIPTION
This is a very simplified enabling implementation so that we remove a foot-gun of intersecting shapes while we only support unfiltered full-table sync (with one immutable filter of user id).