### PR TITLE
feat(DAL): made argument of liveMany optional

### DIFF
--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -258,12 +258,12 @@ export class Table<
   liveMany<
     T extends FindInput<Select, Where, Include, OrderBy, ScalarFieldEnum>
   >(
-    i: SelectSubset<
+    i?: SelectSubset<
       T,
       FindInput<Select, Where, Include, OrderBy, ScalarFieldEnum>
     >
   ): LiveResultContext<Kind<GetPayload, T>[]> {
-    return this.makeLiveResult(() => this.findMany(i), i)
+    return this.makeLiveResult(() => this.findMany(i), i ?? {})
   }
 
   async update<T extends UpdateInput<UpdateData, Select, WhereUnique, Include>>(

--- a/clients/typescript/src/drivers/react-native-sqlite-storage/mock.ts
+++ b/clients/typescript/src/drivers/react-native-sqlite-storage/mock.ts
@@ -165,12 +165,15 @@ class MockTransaction implements Transaction {
     errorCallback?: StatementErrorCallback
   ): void
   executeSql(
-    _sqlStatement: string,
+    sqlStatement: string,
     _args?: any[],
     callback?: StatementCallback,
     errorCallback?: StatementErrorCallback
   ): void | Promise<[Transaction, ResultSet]> {
-    const results = mockResults([{ i: 0 }])
+    let results = mockResults([{ i: 0 }])
+    if (sqlStatement.startsWith('SELECT value, nbr FROM Items')) {
+      results = mockResults([{ value: 'mockValue', nbr: 5 }])
+    }
 
     if (callback) {
       callback(this, results)

--- a/clients/typescript/src/frameworks/react/hooks/useLiveQuery.ts
+++ b/clients/typescript/src/frameworks/react/hooks/useLiveQuery.ts
@@ -69,7 +69,7 @@ function useLiveQuery<Res>(runQuery: LiveResultContext<Res>): ResultData<Res>
  * to `useMemo` to rerun the function.
  *
  * @param runQueryFn - a function that returns a live query
- * @param dependencies - a list of React depenencies that causes the function returning the live query to rerun
+ * @param dependencies - a list of React dependencies that causes the function returning the live query to rerun
  *
  * @example Using a simple live query with a dependency. The table will depend on your application
  * ```ts

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -228,7 +228,22 @@ test('findUnique query with no filters throws an error', (t) => {
   ])
 })
 
-test('findMany allows results to be ordered', (t) => {
+test('findMany allows results to be ordered on one field', (t) => {
+  const query = tbl
+    .findMany({
+      // `where` argument must not be provided when using the actual API because it is added as default by the validator
+      // but since we directly use the query builder we need to provide it
+      where: {},
+      orderBy: {
+        id: 'asc',
+      },
+    })
+    .toString()
+
+  t.is(query, 'SELECT id, title, contents, nbr FROM Post ORDER BY id ASC')
+})
+
+test('findMany allows results to be ordered on several fields', (t) => {
   const query = tbl
     .findMany({
       // `where` argument must not be provided when using the actual API because it is added as default by the validator

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -438,6 +438,55 @@ test.serial('findFirst query returns first result', async (t) => {
   t.deepEqual(res, post2)
 })
 
+test.serial(
+  'FindFirst query with descending order returns last result',
+  async (t) => {
+    const allRecords = await tbl.findMany({
+      where: {
+        nbr: commonNbr,
+      },
+      orderBy: {
+        id: 'asc',
+      },
+    })
+
+    t.assert(allRecords.length > 1)
+
+    const lastRecord = allRecords[allRecords.length - 1]
+    const foundRecord = await tbl.findFirst({
+      where: {
+        nbr: commonNbr,
+      },
+      orderBy: {
+        id: 'desc',
+      },
+    })
+
+    t.deepEqual(foundRecord, lastRecord)
+  }
+)
+
+test.serial('FindFirst query supports skip', async (t) => {
+  const skip = 1
+  const allRecords = await tbl.findMany({
+    orderBy: {
+      id: 'asc',
+    },
+  })
+
+  t.assert(allRecords.length > 1)
+
+  const matchingRecord = allRecords[skip]
+  const foundRecord = await tbl.findFirst({
+    orderBy: {
+      id: 'asc',
+    },
+    skip,
+  })
+
+  t.deepEqual(foundRecord, matchingRecord)
+})
+
 test.serial('findFirst query argument is optional', async (t) => {
   const res = await tbl.findFirst()
   t.deepEqual(res, post1)
@@ -572,6 +621,23 @@ test.serial(
     ])
   }
 )
+
+/*
+// Not supported yet:
+test.serial('findMany can fetch records based on fields of related records', async (t) => {
+  const postsByAlice = await tbl.findMany({
+    where: {
+      author: {
+        is: {
+          name: 'alice'
+        }
+      }
+    }
+  })
+
+  t.deepEqual(postsByAlice, [post1, post2])
+})
+*/
 
 test.serial('findMany allows results to be ordered', async (t) => {
   const res = await tbl.findMany({


### PR DESCRIPTION
Small changes to make the argument of `liveMany` optional such that we can write `db.items.liveMany()` instead of `db.items.liveMany({})`.

Also introduces some additional unit tests for the query builder to test functionality of the DAL.