### PR TITLE
fix(satellite): vax-807 cannot catch up to the servers current state

### DIFF
--- a/.changeset/young-cougars-marry.md
+++ b/.changeset/young-cougars-marry.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixedreconnect issues after BEHIND_WINDOW

--- a/.changeset/young-cougars-marry.md
+++ b/.changeset/young-cougars-marry.md
@@ -2,4 +2,4 @@
 "electric-sql": patch
 ---
 
-Fixedreconnect issues after BEHIND_WINDOW
+Fixed reconnect issues when the client is too far behind the server

--- a/clients/typescript/src/migrators/bundle.ts
+++ b/clients/typescript/src/migrators/bundle.ts
@@ -113,7 +113,9 @@ export class BundleMigrator implements Migrator {
 
       if (migration.version !== version) {
         throw new Error(
-          `Migrations cannot be altered once applied: expecting ${version} at index ${i}. Check documentation (https://electric-sql.com/docs/reference/limitations) to learn possible reasons for this error.`
+          `Local migrations ${version} does not match server version ${migration.version}.\
+          This is an unrecoverable error. Please clear your local storage and try again.\
+          Check documentation (https://electric-sql.com/docs/reference/limitations) to learn more.`
         )
       }
     })

--- a/clients/typescript/src/migrators/bundle.ts
+++ b/clients/typescript/src/migrators/bundle.ts
@@ -113,7 +113,7 @@ export class BundleMigrator implements Migrator {
 
       if (migration.version !== version) {
         throw new Error(
-          `Migrations cannot be altered once applied: expecting ${version} at index ${i}.`
+          `Migrations cannot be altered once applied: expecting ${version} at index ${i}. Check documentation (https://electric-sql.com/docs/reference/limitations) to learn possible reasons for this error.`
         )
       }
     })

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -238,7 +238,8 @@ export class SatelliteClient extends EventEmitter implements Client {
   connect(
     retryHandler?: (error: any, attempt: number) => boolean
   ): Promise<void> {
-    this.initializing = emptyPromise()
+    const initializing = emptyPromise()
+    this.initializing = initializing
 
     const connectPromise = new Promise<void>((resolve, reject) => {
       // TODO: ensure any previous socket is closed, or reject
@@ -286,7 +287,7 @@ export class SatelliteClient extends EventEmitter implements Client {
     return backOff(() => connectPromise, retryPolicy).catch((e) => {
       // We're very sure that no calls are going to modify `this.initializing` before this promise resolves
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.initializing!.reject(e)
+      initializing.reject(e)
       throw e
     })
   }
@@ -516,7 +517,10 @@ export class SatelliteClient extends EventEmitter implements Client {
   }
 
   unsubscribe(subIds: string[]): Promise<UnsubscribeResponse> {
-    if (this.inbound.isReplicating !== ReplicationStatus.ACTIVE) {
+    if (
+      this.inbound.isReplicating !== ReplicationStatus.ACTIVE &&
+      this.inbound.isReplicating !== ReplicationStatus.SERVER_ERROR
+    ) {
       return Promise.reject(
         new SatelliteError(
           SatelliteErrorCode.REPLICATION_NOT_STARTED,

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -815,6 +815,9 @@ export class SatelliteClient extends EventEmitter implements Client {
   }
 
   private handleError(error: SatErrorResp) {
+    // TODO: this causing intermittent issues in tests because
+    // no one might catch this error. We shall pass this information
+    // as part of connectivity state
     this.emit(
       'error',
       new SatelliteError(
@@ -1046,7 +1049,7 @@ export class SatelliteClient extends EventEmitter implements Client {
       }, this.opts.timeout)
 
       // reject on any error
-      const errorListener = (error: SatelliteError) => {
+      const errorListener = (error: any) => {
         return reject(error)
       }
 

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -238,8 +238,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   connect(
     retryHandler?: (error: any, attempt: number) => boolean
   ): Promise<void> {
-
-    if(!this.isClosed){
+    if (!this.isClosed) {
       this.close()
     }
 

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -367,7 +367,9 @@ export class SatelliteClient extends EventEmitter implements Client {
     const promise = this.rpc<void>(request)
       .then(() => this.initializing?.resolve())
       .catch((e) => {
-        this.initializing?.reject(e)
+        // when subscribe is not waiting on promise this is not caught.
+        // a subscriber pattern would only call reject if someone is waiting
+        // this.initializing?.reject(e)
         throw e
       })
     this.inbound = this.resetReplication(lsn, lsn, ReplicationStatus.STARTING)

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -373,9 +373,14 @@ export class SatelliteClient extends EventEmitter implements Client {
 
     // Then set the replication state
     this.inbound = this.resetReplication(lsn, lsn, ReplicationStatus.STARTING)
-    return this.rpc<StartReplicationResponse>(request)
+    return this.rpc<StartReplicationResponse, SatInStartReplicationReq>(request)
       .then((resp) => {
-        this.initializing?.resolve()
+        if (resp.error) {
+          this.initializing?.reject(resp.error)
+          return resp
+        } else {
+          this.initializing?.resolve()
+        }
         return resp
       })
       .catch((e) => {

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -238,6 +238,11 @@ export class SatelliteClient extends EventEmitter implements Client {
   connect(
     retryHandler?: (error: any, attempt: number) => boolean
   ): Promise<void> {
+
+    if(!this.isClosed){
+      this.close()
+    }
+
     const initializing = emptyPromise()
     this.initializing = initializing
 
@@ -292,7 +297,7 @@ export class SatelliteClient extends EventEmitter implements Client {
     })
   }
 
-  close(): Promise<void> {
+  close() {
     Log.info('closing client')
 
     this.outbound = this.resetReplication(
@@ -318,8 +323,6 @@ export class SatelliteClient extends EventEmitter implements Client {
       this.socket!.closeAndRemoveListeners()
       this.socket = undefined
     }
-
-    return Promise.resolve()
   }
 
   isClosed(): boolean {
@@ -354,7 +357,11 @@ export class SatelliteClient extends EventEmitter implements Client {
       }
       request = SatInStartReplicationReq.fromPartial({ schemaVersion })
     } else {
-      Log.info(`starting replication with lsn: ${base64.fromBytes(lsn)}`)
+      Log.info(
+        `starting replication with lsn: ${base64.fromBytes(
+          lsn
+        )} subscriptions: ${subscriptionIds}`
+      )
       request = SatInStartReplicationReq.fromPartial({ lsn, subscriptionIds })
     }
 

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -517,10 +517,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   }
 
   unsubscribe(subIds: string[]): Promise<UnsubscribeResponse> {
-    if (
-      this.inbound.isReplicating !== ReplicationStatus.ACTIVE &&
-      this.inbound.isReplicating !== ReplicationStatus.SERVER_ERROR
-    ) {
+    if (this.inbound.isReplicating !== ReplicationStatus.ACTIVE) {
       return Promise.reject(
         new SatelliteError(
           SatelliteErrorCode.REPLICATION_NOT_STARTED,

--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -16,6 +16,8 @@ export interface SatelliteOpts {
   pollingInterval: number
   /** Throttle snapshotting to once per `minSnapshotWindow` milliseconds. */
   minSnapshotWindow: number
+  /** On reconnect, clear client's state if cannot catch up with Electric buffered WAL*/
+  clearOnBehindWindow: boolean
 }
 
 export interface SatelliteOverrides {
@@ -34,6 +36,7 @@ export const satelliteDefaults: SatelliteOpts = {
   shadowTable: new QualifiedTablename('main', '_electric_shadow'),
   pollingInterval: 2000,
   minSnapshotWindow: 40,
+  clearOnBehindWindow: true,
 }
 
 export const satelliteClientDefaults = {

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -47,8 +47,6 @@ export type ConnectionWrapper = {
   connectionPromise: Promise<void | Error>
 }
 
-export type SatelliteReplicationOptions = { clearOnBehindWindow: boolean }
-
 // `Satellite` is the main process handling ElectricSQL replication,
 // processing the opslog and notifying when there are data changes.
 export interface Satellite {
@@ -60,10 +58,7 @@ export interface Satellite {
 
   connectivityState?: ConnectivityState
 
-  start(
-    authConfig: AuthConfig,
-    opts?: SatelliteReplicationOptions
-  ): Promise<ConnectionWrapper>
+  start(authConfig: AuthConfig): Promise<ConnectionWrapper>
   stop(): Promise<void>
   subscribe(
     shapeDefinitions: ClientShapeDefinition[]

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -13,6 +13,8 @@ import {
   DataTransaction,
   Transaction,
   Relation,
+  StartReplicationResponse,
+  StopReplicationResponse,
 } from '../util/types'
 import {
   ClientShapeDefinition,
@@ -77,8 +79,8 @@ export interface Client {
     lsn?: LSN,
     schemaVersion?: string,
     subscriptionIds?: string[]
-  ): Promise<void>
-  stopReplication(): Promise<void>
+  ): Promise<StartReplicationResponse>
+  stopReplication(): Promise<StopReplicationResponse>
   subscribeToRelations(callback: (relation: Relation) => void): void
   subscribeToTransactions(
     callback: (transaction: Transaction) => Promise<void>

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -70,7 +70,7 @@ export interface Client {
   connect(
     retryHandler?: (error: any, attempt: number) => boolean
   ): Promise<void>
-  close(): Promise<void>
+  close(): void
   authenticate(authState: AuthState): Promise<AuthResponse>
   isClosed(): boolean
   startReplication(

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -16,6 +16,8 @@ import {
   SatelliteErrorCode,
   RelationsCache,
   Record as DataRecord,
+  StartReplicationResponse,
+  StopReplicationResponse,
 } from '../util/types'
 import { ElectricConfig } from '../config/index'
 
@@ -250,7 +252,7 @@ export class MockSatelliteClient extends EventEmitter implements Client {
   authenticate(_authState: AuthState): Promise<AuthResponse> {
     return Promise.resolve({})
   }
-  startReplication(lsn: LSN): Promise<void> {
+  startReplication(lsn: LSN): Promise<StartReplicationResponse> {
     this.replicating = true
     this.inboundAck = lsn
 
@@ -258,28 +260,29 @@ export class MockSatelliteClient extends EventEmitter implements Client {
     this.timeouts.push(t)
 
     if (lsn && bytesToNumber(lsn) == MOCK_BEHIND_WINDOW_LSN) {
-      return Promise.reject(
-        new SatelliteError(
+      return Promise.resolve({
+        error: new SatelliteError(
           SatelliteErrorCode.BEHIND_WINDOW,
           'MOCK BEHIND_WINDOW_LSN ERROR'
-        )
-      )
+        ),
+      })
     }
 
     if (lsn && bytesToNumber(lsn) == MOCK_INVALID_POSITION_LSN) {
-      return Promise.reject(
-        new SatelliteError(
+      return Promise.resolve({
+        error: new SatelliteError(
           SatelliteErrorCode.INVALID_POSITION,
           'MOCK INVALID_POSITION ERROR'
-        )
-      )
+        ),
+      })
     }
 
-    return Promise.resolve()
+    return Promise.resolve({})
   }
-  stopReplication(): Promise<void> {
+
+  stopReplication(): Promise<StopReplicationResponse> {
     this.replicating = false
-    return Promise.resolve()
+    return Promise.resolve({})
   }
 
   subscribeToRelations(_callback: (relation: Relation) => void): void {}

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -660,21 +660,19 @@ export class SatelliteProcess implements Satellite {
       )
 
       if (error) {
+        if (
+          error.code == SatelliteErrorCode.BEHIND_WINDOW &&
+          this.opts?.clearOnBehindWindow &&
+          !currentlyReconnecting
+        ) {
+          return await this._handleBehindWindow()
+        }
         throw error
       }
     } catch (error: any) {
       if (!(error instanceof SatelliteError)) {
         throw error
       }
-
-      if (
-        error.code == SatelliteErrorCode.BEHIND_WINDOW &&
-        this.opts?.clearOnBehindWindow &&
-        !currentlyReconnecting
-      ) {
-        return await this._handleBehindWindow()
-      }
-
       if (throwErrors.includes(error.code)) {
         throw error
       }

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -196,10 +196,7 @@ export class SatelliteProcess implements Satellite {
     }
   }
 
-  async start(
-    authConfig: AuthConfig,
-    opts?: SatelliteReplicationOptions
-  ): Promise<ConnectionWrapper> {
+  async start(authConfig: AuthConfig): Promise<ConnectionWrapper> {
     await this.migrator.up()
 
     const isVerified = await this._verifyTableStructure()
@@ -283,7 +280,7 @@ export class SatelliteProcess implements Satellite {
       this.subscriptions.setState(subscriptionsState)
     }
 
-    const connectionPromise = this._connectAndStartReplication(opts)
+    const connectionPromise = this._connectAndStartReplication()
     return { connectionPromise }
   }
 
@@ -606,9 +603,7 @@ export class SatelliteProcess implements Satellite {
     }
   }
 
-  async _connectAndStartReplication(
-    opts?: SatelliteReplicationOptions
-  ): Promise<void> {
+  async _connectAndStartReplication(): Promise<void> {
     Log.info(`connecting and starting replication`)
 
     if (!this._authState) {
@@ -635,7 +630,7 @@ export class SatelliteProcess implements Satellite {
     } catch (error: any) {
       if (
         error.code == SatelliteErrorCode.BEHIND_WINDOW &&
-        opts?.clearOnBehindWindow
+        this.opts?.clearOnBehindWindow
       ) {
         return this._handleSubscriptionError(error).then(() =>
           this._connectAndStartReplication()

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -576,7 +576,7 @@ export class SatelliteProcess implements Satellite {
 
   async _connectivityStateChanged(status: ConnectivityState): Promise<void> {
     this.connectivityState = status
-
+    Log.debug(`connectivity state changed ${status}`)
     // TODO: no op if state is the same
     switch (status) {
       case 'available': {
@@ -633,14 +633,14 @@ export class SatelliteProcess implements Satellite {
         await this._handleSubscriptionError(error)
         await this.client.close()
         // after clearing subscriptions can't enter here
-        return await this._connectAndStartReplication()
+        await this._connectAndStartReplication()
+        return
       }
 
       if (throwErrors.includes(error.code)) {
         throw error
       }
       Log.warn(`couldn't start replication: ${error}`)
-      return Promise.resolve()
     }
   }
 

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -566,7 +566,7 @@ export class SatelliteProcess implements Satellite {
 
     await this._resetClientState()
 
-    await this._connectAndStartReplication(true)
+    await this._connectAndStartReplication()
 
     Log.warn(`successfully reconnected with server. re-subscribing.`)
 
@@ -628,14 +628,8 @@ export class SatelliteProcess implements Satellite {
     }
   }
 
-  async _connectAndStartReplication(
-    currentlyReconnecting?: boolean
-  ): Promise<void> {
+  async _connectAndStartReplication(): Promise<void> {
     Log.info(`connecting and starting replication`)
-
-    if (currentlyReconnecting) {
-      Log.warn(`trying to reconnect after server error`)
-    }
 
     if (!this._authState) {
       throw new Error(`trying to connect before authentication`)
@@ -662,8 +656,7 @@ export class SatelliteProcess implements Satellite {
       if (error) {
         if (
           error.code == SatelliteErrorCode.BEHIND_WINDOW &&
-          this.opts?.clearOnBehindWindow &&
-          !currentlyReconnecting
+          this.opts?.clearOnBehindWindow
         ) {
           return await this._handleBehindWindow()
         }

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -9,12 +9,7 @@ import {
   ConnectivityStateChangeNotification,
   Notifier,
 } from '../notifiers/index'
-import {
-  Client,
-  ConnectionWrapper,
-  Satellite,
-  SatelliteReplicationOptions,
-} from './index'
+import { Client, ConnectionWrapper, Satellite } from './index'
 import { QualifiedTablename } from '../util/tablename'
 import {
   AckType,

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -654,10 +654,6 @@ export class SatelliteProcess implements Satellite {
       // about fulfilled subscriptions
       const subscriptionIds = this.subscriptions.getFulfilledSubscriptions()
 
-      Log.warn(
-        `${this._lsn} ${schemaVersion} ${JSON.stringify(subscriptionIds)}`
-      )
-
       await this.client.startReplication(
         this._lsn,
         schemaVersion,

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -102,8 +102,6 @@ const throwErrors = [
   SatelliteErrorCode.BEHIND_WINDOW,
 ]
 
-const allowedErrors = []
-
 export class SatelliteProcess implements Satellite {
   dbName: DbName
   adapter: DatabaseAdapter

--- a/clients/typescript/src/sockets/node.ts
+++ b/clients/typescript/src/sockets/node.ts
@@ -1,6 +1,7 @@
 import EventEmitter from 'events'
 import { ConnectionOptions, Data, Socket, SocketFactory } from './index'
 import { WebSocket } from 'ws'
+import { SatelliteError, SatelliteErrorCode } from '../util'
 
 export class WebSocketNodeFactory implements SocketFactory {
   create() {
@@ -43,7 +44,14 @@ export class WebSocketNode extends EventEmitter implements Socket {
   }
 
   onError(cb: (error: Error) => void): void {
-    this.on('error', () => cb(new Error('socket error')))
+    this.on('error', () =>
+      cb(
+        new SatelliteError(
+          SatelliteErrorCode.CONNECTION_FAILED,
+          'failed to establish connection'
+        )
+      )
+    )
   }
 
   onClose(cb: () => void): void {

--- a/clients/typescript/src/sockets/react-native.ts
+++ b/clients/typescript/src/sockets/react-native.ts
@@ -1,4 +1,5 @@
 import { ConnectionOptions, Data, Socket, SocketFactory } from '.'
+import { SatelliteError, SatelliteErrorCode } from '../util'
 
 export class WebSocketReactNativeFactory implements SocketFactory {
   create() {
@@ -31,7 +32,12 @@ export class WebSocketReactNative implements Socket {
 
     this.socket.onerror = (event: any) => {
       while (this.errorCallbacks.length > 0) {
-        this.errorCallbacks.pop()!(new Error(event.message))
+        this.errorCallbacks.pop()!(
+          new SatelliteError(
+            SatelliteErrorCode.CONNECTION_FAILED,
+            event.message
+          )
+        )
       }
     }
 

--- a/clients/typescript/src/sockets/web.ts
+++ b/clients/typescript/src/sockets/web.ts
@@ -1,4 +1,5 @@
 import { ConnectionOptions, Data, Socket, SocketFactory } from '.'
+import { SatelliteError, SatelliteErrorCode } from '../util'
 
 export class WebSocketWebFactory implements SocketFactory {
   create() {
@@ -30,7 +31,12 @@ export class WebSocketWeb implements Socket {
     // event doesn't provide much
     this.socket.addEventListener('error', () => {
       while (this.errorCallbacks.length > 0) {
-        this.errorCallbacks.pop()!(new Error('failed to establish connection'))
+        this.errorCallbacks.pop()!(
+          new SatelliteError(
+            SatelliteErrorCode.CONNECTION_FAILED,
+            'failed to establish connection'
+          )
+        )
       }
     })
 

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -164,6 +164,7 @@ export enum ReplicationStatus {
   STARTING,
   STOPPING,
   ACTIVE,
+  SERVER_ERROR,
 }
 
 export enum AckType {

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -35,6 +35,7 @@ export class SatelliteError extends Error {
 }
 
 export enum SatelliteErrorCode {
+  CONNECTION_FAILED,
   INTERNAL,
   TIMEOUT,
   REPLICATION_NOT_STARTED,

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -45,6 +45,7 @@ export enum SatelliteErrorCode {
   PROTOCOL_VIOLATION,
   UNKNOWN_DATA_TYPE,
   AUTH_ERROR,
+  SERVER_ERROR,
 
   SUBSCRIPTION_ALREADY_EXISTS,
   UNEXPECTED_SUBSCRIPTION_STATE,
@@ -75,6 +76,14 @@ export enum SatelliteErrorCode {
 export type AuthResponse = {
   serverId?: string
   error?: Error
+}
+
+export type StartReplicationResponse = {
+  error?: SatelliteError
+}
+
+export type StopReplicationResponse = {
+  error?: SatelliteError
 }
 
 export type Transaction = {

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -164,7 +164,6 @@ export enum ReplicationStatus {
   STARTING,
   STOPPING,
   ACTIVE,
-  SERVER_ERROR,
 }
 
 export enum AckType {

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -67,7 +67,7 @@ test.beforeEach((t) => {
 test.afterEach.always(async (t) => {
   const { server, client } = t.context
 
-  await client.close()
+  client.close()
   server.close()
 })
 

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -153,10 +153,10 @@ test.serial('connect subscription error', async (t) => {
   server.nextResponses([startResp])
 
   try {
-    await client.startReplication()
-    t.fail()
+    const resp = await client.startReplication()
+    t.is(resp.error?.code, SatelliteErrorCode.BEHIND_WINDOW)
   } catch (e: any) {
-    t.is(e.code, SatelliteErrorCode.BEHIND_WINDOW)
+    t.fail()
   }
 })
 

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1199,7 +1199,7 @@ test('clear database on BEHIND_WINDOW', async (t) => {
   const base64lsn = base64.fromBytes(numberToBytes(MOCK_BEHIND_WINDOW_LSN))
   await satellite._setMeta('lsn', base64lsn)
   try {
-    const conn = await satellite.start(authState, { clearOnBehindWindow: true })
+    const conn = await satellite.start(authState)
     await conn.connectionPromise
     const lsnAfter = await satellite._getMeta('lsn')
     t.not(lsnAfter, base64lsn)


### PR DESCRIPTION
After server is gone, it loses information about clients. Right now it is throwing a BEHIND_WINDOW error when a client tries to reconnect and server doesn't find any info regarding that client. It's arguable if this is the appropriate error to throw, but it highlighted a problem with failures to reconnect on error.

1. the client would not trigger subscriptions cleanup because of improper configuration
2. it would send unsubscribe requests to the server without first starting replication, which would result in an error
3. there was de-referencing error to a variable that was out of scope

After fixing all that, application was connecting but not catching up with the server yet. The problem was that we had cleared subscriptions and did not request them again. There is a question here: is re-subscribing an internal procedure of the client, or should it be tied to the lifecycle of the application and the app should decide what to do... the second approach raises new issues because we would need to appropriately call sync based on reporting the errors to the app. I've taken the first approach for now.

I'd like to know your feedback on the approach