### PR TITLE
fix(electric): Adorn electric-generated trigger functions with SECURITY DEFINER

### DIFF
--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/trigger_function_installers.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/trigger_function_installers.sql
@@ -36,7 +36,7 @@ BEGIN
     EXECUTE format($injected$
         CREATE OR REPLACE FUNCTION electric.%1$I()
         RETURNS TRIGGER
-        LANGUAGE PLPGSQL AS
+        LANGUAGE PLPGSQL SECURITY DEFINER AS
         $function$
         DECLARE
             shadow_row electric.%2$I%%ROWTYPE;
@@ -99,7 +99,7 @@ BEGIN
     EXECUTE format($injected$
         CREATE OR REPLACE FUNCTION electric.%1$I()
         RETURNS TRIGGER
-        LANGUAGE PLPGSQL AS
+        LANGUAGE PLPGSQL SECURITY DEFINER AS
         $function$
         DECLARE
             __current_tag electric.tag;
@@ -160,7 +160,7 @@ BEGIN
     EXECUTE format($injected$
         CREATE OR REPLACE FUNCTION electric.%1$I()
             RETURNS TRIGGER
-            LANGUAGE PLPGSQL AS
+            LANGUAGE PLPGSQL SECURITY DEFINER AS
         $function$
         DECLARE
             __current_tag electric.tag;
@@ -227,7 +227,7 @@ BEGIN
     EXECUTE format($injected$
         CREATE OR REPLACE FUNCTION electric.%1$I()
             RETURNS TRIGGER
-            LANGUAGE PLPGSQL AS
+            LANGUAGE PLPGSQL SECURITY DEFINER AS
         $function$
         DECLARE
             -- This will throw an error if this setting is missing -- that would be an unexpected situation, so an error is appropriate
@@ -299,7 +299,7 @@ BEGIN
     EXECUTE format($injected$
         CREATE OR REPLACE FUNCTION electric.%1$I()
             RETURNS TRIGGER
-            LANGUAGE PLPGSQL AS
+            LANGUAGE PLPGSQL SECURITY DEFINER AS
         $function$
         DECLARE
             _shadow_row_tmp electric.%2$I%%ROWTYPE;
@@ -349,7 +349,7 @@ BEGIN
     EXECUTE format($injected$
         CREATE OR REPLACE FUNCTION electric.%1$I()
             RETURNS TRIGGER
-            LANGUAGE PLPGSQL AS
+            LANGUAGE PLPGSQL SECURITY DEFINER AS
         $function$
         BEGIN
             RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
@@ -418,7 +418,7 @@ BEGIN
     EXECUTE format($injected$
         CREATE OR REPLACE FUNCTION electric.%1$I()
             RETURNS TRIGGER
-            LANGUAGE PLPGSQL AS
+            LANGUAGE PLPGSQL SECURITY DEFINER AS
         $function$
         BEGIN
             RAISE DEBUG 'Trigger %% executed by operation %% at depth %% (tx %%)', TG_NAME, TG_OP, pg_trigger_depth(), pg_current_xact_id();
@@ -544,7 +544,7 @@ BEGIN
     EXECUTE format($injected$
         CREATE OR REPLACE FUNCTION electric.%1$I(shadow_row electric.%2$I)
             RETURNS VOID
-            LANGUAGE PLPGSQL AS
+            LANGUAGE PLPGSQL SECURITY DEFINER AS
         $function$
         DECLARE
             built_row %4$s%%ROWTYPE;


### PR DESCRIPTION
As explained in the official docs[1]:

  > SECURITY INVOKER indicates that the function is to be executed
  > with the privileges of the user that calls it. That is the default.
  > SECURITY DEFINER specifies that the function is to be executed
  > with the privileges of the user that owns it.

[1]: https://www.postgresql.org/docs/current/sql-createfunction.html

While testing the scenario described in VAX-806, I was hitting multiple permission denials, such as

    ERROR:  permission denied for schema electric
    LINE 3:             __current_tag electric.tag;

and, after granting the demo user access to the "electric" schema,

    ERROR:  permission denied for table shadow__public__sliders
    CONTEXT:  SQL statement "INSERT INTO electric.shadow__public__sliders (_last_modified, _tag, _tags, _resolved,
                                              id, _tag_value, _tag_demo_id, _tag_demo_name, _tag_electric_user_id)

The root cause of those permission issues was the fact that the demo user didn't have access to all the internal types and tables that live under the "electric" schema.

Instead of granting the demo user access to everything, we can alter the definitions of trigger functions to ensure they'll run with the priveleges of the user who created them, that is, Electric's "super user".

I found this solution at https://github.com/orgs/supabase/discussions/306#discussioncomment-138424