### PR TITLE
chore(ci): Revert "add package write permission to the e2e workflow (#156)"

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,8 +27,6 @@ jobs:
     defaults:
       run:
         working-directory: e2e
-    permissions:
-      packages: write
     env:
       BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_TEST_ANALYTICS_E2E }}
     steps:


### PR DESCRIPTION
This reverts commit 1d78f9fa49a99a18284adbe17d26368ee3cde5b3.

This permission is no longer needed since we have removed the "docker push to ghcr.io" step from the workflow in 1a3393830ca47d494c20b8b5f74b912c8a52c56e.