### PR TITLE
chore(starter): improved output and commands

### DIFF
--- a/.changeset/five-fishes-sparkle.md
+++ b/.changeset/five-fishes-sparkle.md
@@ -1,0 +1,6 @@
+---
+"electric-sql": patch
+"create-electric-app": patch
+---
+
+Improve starter template output and introduced new db:connect command.

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -101,6 +101,9 @@
       ],
       "satellite": [
         "./dist/satellite/index.d.ts"
+      ],
+      "util": [
+        "./dist/util/index.d.ts"
       ]
     }
   },

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -459,7 +459,7 @@ async function executeShellCommand(
   return new Promise((resolve, reject) => {
     const proc = exec(command, { cwd: appRoot }, (error, _stdout, _stderr) => {
       if (error) {
-        console.error(error);
+        console.error(error)
       }
     })
 

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -7,7 +7,7 @@ import https from 'node:https'
 import decompress from 'decompress'
 import Database from 'better-sqlite3'
 import { buildMigrations, getMigrationNames } from './builder'
-import { exec, StdioOptions } from 'child_process'
+import { exec } from 'child_process'
 import { dedent } from 'ts-dedent'
 
 const appRoot = path.resolve() // path where the user ran `npx electric migrate`
@@ -227,7 +227,8 @@ async function _generate(opts: Omit<GeneratorOptions, 'watch'>) {
     await buildMigrations(migrationsFolder, migrationsFile)
     console.log('Successfully built migrations')
   } catch (e: any) {
-    console.error('generate command failed: ' + JSON.stringify(e.message))
+    console.error('generate command failed: ' + e)
+    process.exit(1)
   } finally {
     // Delete our temporary directory
     await fs.rm(tmpFolder, { recursive: true })
@@ -437,11 +438,6 @@ async function setDataSource(
   await fs.writeFile(prismaSchema, data)
 }
 
-const shellOpts = {
-  cwd: appRoot,
-  stdio: 'inherit' as StdioOptions,
-}
-
 async function introspectDB(prismaSchema: string): Promise<void> {
   await executeShellCommand(
     `npx prisma db pull --schema="${prismaSchema}"`,
@@ -461,9 +457,11 @@ async function executeShellCommand(
   errMsg: string
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const proc = exec(command, shellOpts)
-    proc.stdout!.pipe(process.stdout)
-    proc.stderr!.pipe(process.stderr)
+    const proc = exec(command, { cwd: appRoot }, (error, _stdout, _stderr) => {
+      if (error) {
+        console.error(error);
+      }
+    })
 
     proc.on('close', (code) => {
       if (code === 0) {

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -17,7 +17,10 @@
     "build": "rm -rf ./dist && tsc && tsmodule build"
   },
   "devDependencies": {
-    "@types/node": "^18.8.4",
-    "@tsmodule/tsmodule": "42"
+    "@tsmodule/tsmodule": "42",
+    "@types/node": "^18.8.4"
+  },
+  "dependencies": {
+    "ora": "^7.0.1"
   }
 }

--- a/examples/starter/src/index.ts
+++ b/examples/starter/src/index.ts
@@ -6,6 +6,9 @@ import { spawn } from 'child_process'
 import * as fs from 'fs/promises'
 import { fileURLToPath } from 'url'
 import path from 'path'
+import ora from 'ora'
+
+const spinner = ora('Creating project structure').start()
 
 // The first argument will be the project name
 const projectName = process.argv[2]
@@ -69,7 +72,7 @@ if (name) {
 }
 
 // Run `yarn install` in the project directory to install the dependencies
-console.log('Installing dependencies (may take some time) ...')
+spinner.text = 'Installing dependencies (may take some time) ...'
 const proc = spawn('yarn install', [], { stdio: ['ignore', 'ignore', 'pipe'], cwd: projectDir, shell: true })
 
 let errors: Uint8Array[] = []
@@ -78,6 +81,7 @@ proc.stderr.on('data', (data) => {
 })
 
 proc.on('close', (code) => {
+  spinner.stop()
   if (code === 0) {
     console.log(`⚡️ Your ElectricSQL app is ready at \`./${projectName}\``)
   }
@@ -85,6 +89,6 @@ proc.on('close', (code) => {
     console.error(Buffer.concat(errors).toString())
     console.log(`⚡️ Could not install project dependencies. Nevertheless the template for your app can be found at \`./${projectName}\``)
   }
-  
+
   console.log(`Navigate to your app folder \`cd ${projectName}\` and follow the instructions in the readme.`)
 })

--- a/examples/starter/src/index.ts
+++ b/examples/starter/src/index.ts
@@ -90,5 +90,5 @@ proc.on('close', (code) => {
     console.log(`⚡️ Could not install project dependencies. Nevertheless the template for your app can be found at \`./${projectName}\``)
   }
 
-  console.log(`Navigate to your app folder \`cd ${projectName}\` and follow the instructions in the readme.`)
+  console.log(`Navigate to your app folder \`cd ${projectName}\` and follow the instructions in the README.md.`)
 })

--- a/examples/starter/src/index.ts
+++ b/examples/starter/src/index.ts
@@ -85,4 +85,6 @@ proc.on('close', (code) => {
     console.error(Buffer.concat(errors).toString())
     console.log(`⚡️ Could not install project dependencies. Nevertheless the template for your app can be found at \`./${projectName}\``)
   }
+  
+  console.log(`Navigate to your app folder \`cd ${projectName}\` and follow the instructions in the readme.`)
 })

--- a/examples/starter/src/index.ts
+++ b/examples/starter/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-warnings
 
 // Usage: npx create-electric-app my-app
 
@@ -69,13 +69,20 @@ if (name) {
 }
 
 // Run `yarn install` in the project directory to install the dependencies
-const proc = spawn('yarn install', [], { stdio: 'inherit', cwd: projectDir, shell: true })
+console.log('Installing dependencies (may take some time) ...')
+const proc = spawn('yarn install', [], { stdio: ['ignore', 'ignore', 'pipe'], cwd: projectDir, shell: true })
+
+let errors: Uint8Array[] = []
+proc.stderr.on('data', (data) => {
+  errors = errors.concat(data)
+})
 
 proc.on('close', (code) => {
   if (code === 0) {
-    console.log(`Success! Your ElectricSQL app is ready at \`./${projectName}\``)
+    console.log(`⚡️ Your ElectricSQL app is ready at \`./${projectName}\``)
   }
   else {
-    console.log(`Could not install project dependencies. Nevertheless the template for your app can be found at \`./${projectName}\``)
+    console.error(Buffer.concat(errors).toString())
+    console.log(`⚡️ Could not install project dependencies. Nevertheless the template for your app can be found at \`./${projectName}\``)
   }
 })

--- a/examples/starter/template/README.md
+++ b/examples/starter/template/README.md
@@ -12,8 +12,6 @@ Open a new tab in your terminal. Navigate back to the same folder. Apply the mig
 ```shell
 yarn db:migrate
 ```
-The above command applies all sql files in the migrations folder so make sure they are idempotent if you run the command multiple times.
-Or, alternatively, use proper migration tooling.
 
 Generate your client:
 

--- a/examples/starter/template/README.md
+++ b/examples/starter/template/README.md
@@ -12,6 +12,8 @@ Open a new tab in your terminal. Navigate back to the same folder. Apply the mig
 ```shell
 yarn db:migrate
 ```
+The above command applies all sql files in the migrations folder so make sure they are idempotent if you run the command multiple times.
+Or, alternatively, use proper migration tooling.
 
 Generate your client:
 

--- a/examples/starter/template/db/connect.js
+++ b/examples/starter/template/db/connect.js
@@ -1,0 +1,3 @@
+const { DATABASE_URL } = require('./util.js')
+const { spawn } = require('child_process')
+spawn(`psql ${DATABASE_URL}`, [], { cwd: __dirname, stdio: 'inherit', shell: true })

--- a/examples/starter/template/db/migrate.js
+++ b/examples/starter/template/db/migrate.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const shell = require('shelljs')
+shell.config.silent = true // don't log output of child processes
 
 const createPool = require('@databases/pg')
 const { sql } = require('@databases/pg')
@@ -16,15 +17,12 @@ const DEFAULT_URL = `postgresql://postgres:password@localhost:${pgPort}/${appNam
 const DATABASE_URL = process.env.DATABASE_URL || DEFAULT_URL
 const MIGRATIONS_DIR = process.env.MIGRATIONS_DIR || path.resolve(__dirname, 'migrations')
 
-if (!process.env.DATABASE_URL) {
-  console.info(`Connecting to Postgres via host port ${pgPort}`)
-}
-
+console.info(`Connecting to Postgres..`)
 const db = createPool(DATABASE_URL)
 
 const apply = async (fileName) => {
   const filePath = path.join(MIGRATIONS_DIR, fileName)
-  console.log('apply', filePath)
+  console.log('Applying', filePath)
 
   await db.tx(
     (tx) => tx.query(

--- a/examples/starter/template/db/migrate.js
+++ b/examples/starter/template/db/migrate.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const path = require('path')
-const parseArgs = require('minimist')
 const shell = require('shelljs')
 
 const createPool = require('@databases/pg')
@@ -16,9 +15,6 @@ const appName = fetchAppName() ?? 'electric'
 const DEFAULT_URL = `postgresql://postgres:password@localhost:${pgPort}/${appName}`
 const DATABASE_URL = process.env.DATABASE_URL || DEFAULT_URL
 const MIGRATIONS_DIR = process.env.MIGRATIONS_DIR || path.resolve(__dirname, 'migrations')
-
-const argv = parseArgs(process.argv.slice(2))
-const targetFile = argv.file
 
 if (!process.env.DATABASE_URL) {
   console.info(`Connecting to Postgres via host port ${pgPort}`)
@@ -38,13 +34,10 @@ const apply = async (fileName) => {
 }
 
 const main = async () => {
-  if (targetFile !== undefined) {
-    await apply(targetFile)
-  }
-  else {
-    const fileNames = fs.readdirSync(MIGRATIONS_DIR)
-    for (const file of fileNames) {
-      await apply(file)  
+  const fileNames = fs.readdirSync(MIGRATIONS_DIR)
+  for (const file of fileNames) {
+    if (path.extname(file) === '.sql') {
+      await apply(file)
     }
   }
 }

--- a/examples/starter/template/db/migrate.js
+++ b/examples/starter/template/db/migrate.js
@@ -38,6 +38,7 @@ const main = async () => {
       await apply(file)
     }
   }
+  console.log('⚡️ Database is migrated.')
 }
 
 try {

--- a/examples/starter/template/db/migrate.js
+++ b/examples/starter/template/db/migrate.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const { DATABASE_URL } = require('util.js')
+const { DATABASE_URL } = require('./util.js')
 
 const createPool = require('@databases/pg')
 const { sql } = require('@databases/pg')
@@ -28,7 +28,7 @@ const main = async () => {
       await apply(file)
     }
   }
-  console.log('⚡️ Database is migrated.')
+  console.log('⚡️ Database migrated.')
 }
 
 try {

--- a/examples/starter/template/db/migrate.js
+++ b/examples/starter/template/db/migrate.js
@@ -1,20 +1,10 @@
 const fs = require('fs')
 const path = require('path')
-const shell = require('shelljs')
-shell.config.silent = true // don't log output of child processes
+const { DATABASE_URL } = require('util.js')
 
 const createPool = require('@databases/pg')
 const { sql } = require('@databases/pg')
 
-// If we are running the docker compose file
-// there will be a compose-postgres-1 container running
-// which binds the container's 5432 port used by PG
-// to some available port on the host machine.
-// So we fetch this host port and use it in the default url.
-const pgPort = fetchHostPortPG() ?? 5432
-const appName = fetchAppName() ?? 'electric'
-const DEFAULT_URL = `postgresql://postgres:password@localhost:${pgPort}/${appName}`
-const DATABASE_URL = process.env.DATABASE_URL || DEFAULT_URL
 const MIGRATIONS_DIR = process.env.MIGRATIONS_DIR || path.resolve(__dirname, 'migrations')
 
 console.info(`Connecting to Postgres..`)
@@ -50,40 +40,4 @@ catch (err) {
 }
 finally {
   db.dispose()
-}
-
-function fetchHostPortPG() {
-  return fetchHostPort('compose-postgres-1', 5432)
-}
-
-// Returns the host port to which the `containerPort` of the `container` is bound.
-// Returns undefined if the port is not bound or container does not exist.
-function fetchHostPort(container, containerPort) {
-  const output = shell.exec(`docker inspect --format='{{(index (index .NetworkSettings.Ports "${containerPort}/tcp") 0).HostPort}}' ${container}`)
-  const port = parseInt(output)
-  if (!isNaN(port)) {
-    return port
-  }
-}
-
-// Reads the app name from the backend/.envrc file
-function fetchAppName() {
-  const envrcFile = path.join(__dirname, '..', 'backend', 'compose', '.envrc')
-  const envrc = fs.readFileSync(envrcFile, 'utf8')
-
-  let appName = undefined
-
-  envrc
-  .split(/\r?\n/) // split lines
-  .reverse() // in case the app name would be defined several times
-  .find(line => {
-    const match = line.match(/^(export APP_NAME=)(.*)/)
-    if (match) {
-      appName = match[2]
-      return true
-    }
-    return false
-  })
-
-  return appName
 }

--- a/examples/starter/template/db/migrations/create_items_table.sql
+++ b/examples/starter/template/db/migrations/create_items_table.sql
@@ -1,5 +1,5 @@
 -- Create a simple items table.
-CREATE TABLE items (
+CREATE TABLE IF NOT EXISTS items (
   value TEXT PRIMARY KEY NOT NULL
 );
 

--- a/examples/starter/template/db/util.js
+++ b/examples/starter/template/db/util.js
@@ -1,0 +1,52 @@
+const fs = require('fs')
+const path = require('path')
+const shell = require('shelljs')
+shell.config.silent = true // don't log output of child processes
+
+// If we are running the docker compose file
+// there will be a compose-postgres-1 container running
+// which binds the container's 5432 port used by PG
+// to some available port on the host machine.
+// So we fetch this host port and use it in the default url.
+const pgPort = fetchHostPortPG() ?? 5432
+const appName = fetchAppName() ?? 'electric'
+const DEFAULT_URL = `postgresql://postgres:password@localhost:${pgPort}/${appName}`
+const DATABASE_URL = process.env.DATABASE_URL || DEFAULT_URL
+
+function fetchHostPortPG() {
+  return fetchHostPort('compose-postgres-1', 5432)
+}
+
+// Returns the host port to which the `containerPort` of the `container` is bound.
+// Returns undefined if the port is not bound or container does not exist.
+function fetchHostPort(container, containerPort) {
+  const output = shell.exec(`docker inspect --format='{{(index (index .NetworkSettings.Ports "${containerPort}/tcp") 0).HostPort}}' ${container}`)
+  const port = parseInt(output)
+  if (!isNaN(port)) {
+    return port
+  }
+}
+
+// Reads the app name from the backend/.envrc file
+function fetchAppName() {
+  const envrcFile = path.join(__dirname, '..', 'backend', 'compose', '.envrc')
+  const envrc = fs.readFileSync(envrcFile, 'utf8')
+
+  let appName = undefined
+
+  envrc
+  .split(/\r?\n/) // split lines
+  .reverse() // in case the app name would be defined several times
+  .find(line => {
+    const match = line.match(/^(export APP_NAME=)(.*)/)
+    if (match) {
+      appName = match[2]
+      return true
+    }
+    return false
+  })
+
+  return appName
+}
+
+exports.DATABASE_URL = DATABASE_URL

--- a/examples/starter/template/dot_gitignore
+++ b/examples/starter/template/dot_gitignore
@@ -1,2 +1,5 @@
 dist
 node_modules
+public/wa-sqlite-async.wasm
+public/wa-sqlite-async.mjs
+src/generated

--- a/examples/starter/template/package.json
+++ b/examples/starter/template/package.json
@@ -7,7 +7,7 @@
     "backend:stop": "docker compose -f backend/compose/docker-compose.yaml down --volumes",
     "electric:start": "node ./backend/startElectric.js",
     "db:migrate": "node ./db/migrate.js",
-    "db:connect": "node ./db/connect.js",
+    "db:psql": "node ./db/connect.js",
     "client:generate": "npx electric-sql generate",
     "client:watch": "npx electric-sql generate --watch",
     "build": "node copy-wasm-files.js && node builder.js",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@electric-sql/prisma-generator": "next",
-    "@types/node": "^16.9.1",
+    "@types/node": ">=16.11.0",
     "@types/react": "^18.0.18",
     "@types/react-dom": "^18.0.11",
     "esbuild": "^0.12.26",

--- a/examples/starter/template/package.json
+++ b/examples/starter/template/package.json
@@ -7,6 +7,7 @@
     "backend:stop": "docker compose -f backend/compose/docker-compose.yaml down --volumes",
     "electric:start": "node ./backend/startElectric.js",
     "db:migrate": "node ./db/migrate.js",
+    "db:connect": "node ./db/connect.js",
     "client:generate": "npx electric-sql generate",
     "client:watch": "npx electric-sql generate --watch",
     "build": "node copy-wasm-files.js && node builder.js",

--- a/examples/starter/template/src/Example.tsx
+++ b/examples/starter/template/src/Example.tsx
@@ -6,7 +6,7 @@ import { ElectricDatabase, electrify } from 'electric-sql/wa-sqlite'
 import { authToken } from 'electric-sql/auth'
 import { genUUID } from 'electric-sql/util'
 
-import { Electric, Item, schema } from './generated/client'
+import { Electric, Items, schema } from './generated/client'
 
 import './Example.css'
 
@@ -81,7 +81,7 @@ const ExampleComponent = () => {
     await db.items.deleteMany()
   }
 
-  const items: Item[] = results !== undefined ? results : []
+  const items: Items[] = results !== undefined ? results : []
 
   return (
     <div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,10 @@ importers:
         version: 4.9.5
 
   examples/starter:
+    dependencies:
+      ora:
+        specifier: ^7.0.1
+        version: 7.0.1
     devDependencies:
       '@tsmodule/tsmodule':
         specifier: '42'
@@ -3968,7 +3972,6 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -4536,7 +4539,6 @@ packages:
       buffer: 6.0.3
       inherits: 2.0.4
       readable-stream: 3.6.2
-    dev: true
 
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
@@ -4568,7 +4570,7 @@ packages:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 7.0.1
-      chalk: 5.2.0
+      chalk: 5.3.0
       cli-boxes: 3.0.0
       string-width: 5.1.2
       type-fest: 2.19.0
@@ -4697,7 +4699,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    dev: true
 
   /builtin-modules@1.1.1:
     resolution: {integrity: sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==}
@@ -4895,6 +4896,10 @@ packages:
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
@@ -5012,7 +5017,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       restore-cursor: 4.0.0
-    dev: true
 
   /cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
@@ -5849,7 +5853,6 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
 
   /ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
@@ -5874,6 +5877,10 @@ packages:
     resolution: {integrity: sha512-S/7tzL6v5i+4iJd627Nhv9cLFIo5weAIlGccqJFpnBoDB8U1TF2k5tez4J/QNuxyyhWuFqHg1L84Kd3m7iXg6g==}
     engines: {node: '>=12'}
     dev: true
+
+  /emoji-regex@10.2.1:
+    resolution: {integrity: sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==}
+    dev: false
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -8091,7 +8098,7 @@ packages:
     engines: {node: '>=14.18.0'}
     dependencies:
       ansi-escapes: 6.2.0
-      chalk: 5.2.0
+      chalk: 5.3.0
       cli-cursor: 4.0.0
       cli-width: 4.0.0
       external-editor: 3.1.0
@@ -8369,7 +8376,6 @@ packages:
   /is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
-    dev: true
 
   /is-invalid-path@0.1.0:
     resolution: {integrity: sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==}
@@ -8530,7 +8536,6 @@ packages:
   /is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
-    dev: true
 
   /is-valid-path@0.1.1:
     resolution: {integrity: sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==}
@@ -9242,9 +9247,8 @@ packages:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
     dependencies:
-      chalk: 5.2.0
+      chalk: 5.3.0
       is-unicode-supported: 1.3.0
-    dev: true
 
   /log-update@4.0.0:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
@@ -10456,7 +10460,7 @@ packages:
     resolution: {integrity: sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
-      chalk: 5.2.0
+      chalk: 5.3.0
       cli-cursor: 4.0.0
       cli-spinners: 2.9.0
       is-interactive: 2.0.0
@@ -10466,6 +10470,21 @@ packages:
       strip-ansi: 7.1.0
       wcwidth: 1.0.1
     dev: true
+
+  /ora@7.0.1:
+    resolution: {integrity: sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==}
+    engines: {node: '>=16'}
+    dependencies:
+      chalk: 5.3.0
+      cli-cursor: 4.0.0
+      cli-spinners: 2.9.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 1.3.0
+      log-symbols: 5.1.0
+      stdin-discarder: 0.1.0
+      string-width: 6.1.0
+      strip-ansi: 7.1.0
+    dev: false
 
   /os-homedir@1.0.2:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
@@ -11756,7 +11775,6 @@ packages:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    dev: true
 
   /ret@0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
@@ -12367,7 +12385,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       bl: 5.1.0
-    dev: true
 
   /stealthy-require@1.1.1:
     resolution: {integrity: sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==}
@@ -12418,6 +12435,15 @@ packages:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
     dev: true
+
+  /string-width@6.1.0:
+    resolution: {integrity: sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 10.2.1
+      strip-ansi: 7.1.0
+    dev: false
 
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
@@ -12485,7 +12511,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -13331,7 +13356,7 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       boxen: 7.1.0
-      chalk: 5.2.0
+      chalk: 5.3.0
       configstore: 6.0.0
       has-yarn: 3.0.0
       import-lazy: 4.0.0


### PR DESCRIPTION
This PR hides output from the underlying processes when running `npx create-electric-app my-app` as well as in the output of the yarn commands. Also introduces a new command `db:connect` that connects to the PG database using the `DATABASE_URL` env variable. If that variable is not defined it assumes that we're running the entire stack and it will connect to the PG that is running in Docker.