### PR TITLE
chore(electric): Disallow UUID columns in electrify()

### DIFF
--- a/components/electric/lib/electric/satellite/serialization.ex
+++ b/components/electric/lib/electric/satellite/serialization.ex
@@ -22,11 +22,9 @@ defmodule Electric.Satellite.Serialization do
   @spec supported_pg_types :: [atom]
   def supported_pg_types do
     ~w[
-      bytea
       int2 int4 int8
       float8
       text
-      uuid
       varchar
     ]a
   end

--- a/components/electric/test/electric/postgres/extension/electrify_test.exs
+++ b/components/electric/test/electric/postgres/extension/electrify_test.exs
@@ -16,7 +16,7 @@ defmodule Electric.Postgres.Extension.ElectrifyTest do
   end
 
   test_tx "inserts a row into the electrified table", fn conn ->
-    sql = "CREATE TABLE buttercup (id uuid PRIMARY KEY DEFAULT uuid_generate_v4());"
+    sql = "CREATE TABLE buttercup (id text PRIMARY KEY DEFAULT uuid_generate_v4());"
     {:ok, _cols, _rows} = :epgsql.squery(conn, sql)
 
     sql = "CALL electric.electrify('buttercup');"
@@ -32,7 +32,7 @@ defmodule Electric.Postgres.Extension.ElectrifyTest do
   test_tx "inserts the DDL for the table into the migration table", fn conn ->
     sql = """
     CREATE TABLE buttercup (
-      id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+      id text PRIMARY KEY DEFAULT uuid_generate_v4(),
       value text,
       secret integer
     );
@@ -56,7 +56,7 @@ defmodule Electric.Postgres.Extension.ElectrifyTest do
   test_tx "duplicate call raises", fn conn ->
     sql = """
     CREATE TABLE buttercup (
-      id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+      id text PRIMARY KEY DEFAULT uuid_generate_v4(),
       value text,
       secret integer
     );
@@ -75,10 +75,10 @@ defmodule Electric.Postgres.Extension.ElectrifyTest do
   end
 
   test_tx "handles quoted table names", fn conn ->
-    sql = "CREATE TABLE \"la la daisy\" (id uuid PRIMARY KEY DEFAULT uuid_generate_v4());"
+    sql = "CREATE TABLE \"la la daisy\" (id text PRIMARY KEY DEFAULT uuid_generate_v4());"
     {:ok, _cols, _rows} = :epgsql.squery(conn, sql)
 
-    sql = "CREATE TABLE \"la la buttercup\" (id uuid PRIMARY KEY DEFAULT uuid_generate_v4());"
+    sql = "CREATE TABLE \"la la buttercup\" (id text PRIMARY KEY DEFAULT uuid_generate_v4());"
     {:ok, _cols, _rows} = :epgsql.squery(conn, sql)
 
     sql = "CALL electric.electrify('public', 'la la daisy');"
@@ -96,7 +96,7 @@ defmodule Electric.Postgres.Extension.ElectrifyTest do
   end
 
   test_tx "allows for namespaced table names", fn conn ->
-    sql = "CREATE TABLE daisy (id uuid PRIMARY KEY DEFAULT uuid_generate_v4());"
+    sql = "CREATE TABLE daisy (id text PRIMARY KEY DEFAULT uuid_generate_v4());"
     {:ok, _cols, _rows} = :epgsql.squery(conn, sql)
 
     sql = "CALL electric.electrify('public.daisy');"
@@ -123,7 +123,7 @@ defmodule Electric.Postgres.Extension.ElectrifyTest do
 
     sql = """
     CREATE TABLE balloons.buttercup (
-      id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+      id text PRIMARY KEY DEFAULT uuid_generate_v4(),
       value text,
       secret integer
     );
@@ -167,7 +167,7 @@ defmodule Electric.Postgres.Extension.ElectrifyTest do
   test_tx "adds the electrified table to the publication", fn conn ->
     assert published_tables(conn) == []
 
-    sql = "CREATE TABLE buttercup (id uuid PRIMARY KEY DEFAULT uuid_generate_v4(), value text);"
+    sql = "CREATE TABLE buttercup (id text PRIMARY KEY DEFAULT uuid_generate_v4(), value text);"
 
     {:ok, _cols, _rows} = :epgsql.squery(conn, sql)
 
@@ -185,7 +185,7 @@ defmodule Electric.Postgres.Extension.ElectrifyTest do
 
     sql = """
     CREATE TABLE buttercup (
-      id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+      id text PRIMARY KEY DEFAULT uuid_generate_v4(),
       value text,
       secret integer
     );

--- a/components/electric/test/electric/postgres/extension/schema_cache_test.exs
+++ b/components/electric/test/electric/postgres/extension/schema_cache_test.exs
@@ -54,7 +54,7 @@ defmodule Electric.Postgres.Extension.SchemaCacheTest do
     Transaction
   }
 
-  @create_a "CREATE TABLE a (aid uuid NOT NULL PRIMARY KEY, avalue text);"
+  @create_a "CREATE TABLE a (aid text NOT NULL PRIMARY KEY, avalue text);"
   @create_b "CREATE TABLE b.b (bid1 int4, bid2 int4, bvalue text, PRIMARY KEY (bid1, bid2));"
   @sqls [
     @create_a,
@@ -188,7 +188,7 @@ defmodule Electric.Postgres.Extension.SchemaCacheTest do
                columns: [
                  %Column{
                    name: "aid",
-                   type: :uuid,
+                   type: :text,
                    nullable?: false,
                    type_modifier: -1,
                    part_of_identity?: true
@@ -220,7 +220,7 @@ defmodule Electric.Postgres.Extension.SchemaCacheTest do
                columns: [
                  %Column{
                    name: "aid",
-                   type: :uuid,
+                   type: :text,
                    nullable?: false,
                    type_modifier: -1,
                    part_of_identity?: true
@@ -254,7 +254,7 @@ defmodule Electric.Postgres.Extension.SchemaCacheTest do
       assert table_info.columns == [
                %Column{
                  name: "aid",
-                 type: :uuid,
+                 type: :text,
                  nullable?: false,
                  type_modifier: -1,
                  part_of_identity?: true
@@ -304,7 +304,7 @@ defmodule Electric.Postgres.Extension.SchemaCacheTest do
       assert table_info.columns == [
                %Column{
                  name: "aid",
-                 type: :uuid,
+                 type: :text,
                  nullable?: false,
                  type_modifier: -1,
                  part_of_identity?: true
@@ -338,7 +338,7 @@ defmodule Electric.Postgres.Extension.SchemaCacheTest do
       assert table_info.columns == [
                %Column{
                  name: "aid",
-                 type: :uuid,
+                 type: :text,
                  nullable?: false,
                  type_modifier: -1,
                  part_of_identity?: true

--- a/components/electric/test/electric/postgres/extension_test.exs
+++ b/components/electric/test/electric/postgres/extension_test.exs
@@ -426,7 +426,7 @@ defmodule Electric.Postgres.ExtensionTest do
       assert [{:ok, [], []}, {:ok, [], []}] ==
                :epgsql.squery(conn, """
                CREATE TABLE public.t1 (
-                 id UUID PRIMARY KEY,
+                 id TEXT PRIMARY KEY,
                  content TEXT NOT NULL,
                  words VARCHAR,
                  num2a INT2,
@@ -462,6 +462,7 @@ defmodule Electric.Postgres.ExtensionTest do
       assert error_msg ==
                """
                Cannot electrify "public.t1" because some of its columns have types not supported by Electric:
+                 "id" uuid
                  "c1" character(1)
                  "c2" character(11)
                  "c3" character varying(11)

--- a/components/electric/test/electric/replication/initial_sync_test.exs
+++ b/components/electric/test/electric/replication/initial_sync_test.exs
@@ -125,7 +125,7 @@ defmodule Electric.Replication.InitialSyncTest do
     {:ok, [], []} =
       :epgsql.squery(conn, """
       CREATE TABLE public.users (
-        id UUID PRIMARY KEY,
+        id TEXT PRIMARY KEY,
         name TEXT NOT NULL
       )
       """)
@@ -137,9 +137,9 @@ defmodule Electric.Replication.InitialSyncTest do
     {:ok, [], []} =
       :epgsql.squery(conn, """
       CREATE TABLE public.documents (
-        id UUID PRIMARY KEY,
+        id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
-        user_id UUID REFERENCES users(id)
+        user_id TEXT REFERENCES users(id)
       )
       """)
 

--- a/components/electric/test/electric/satellite/ws_validations_test.exs
+++ b/components/electric/test/electric/satellite/ws_validations_test.exs
@@ -202,6 +202,9 @@ defmodule Electric.Satellite.WsValidationsTest do
     end)
   end
 
+  # Support for UUID is already implemented on the server but not in DAL on the client. Once the latter is ready, we can
+  # add `:uuid` to the list of supported types in `Electric.Satellite.Serialization` and re-enable this test.
+  @tag :skip
   test "validates uuid values", ctx do
     vsn = "2023072504"
     :ok = migrate(ctx.db, vsn, "public.foo", "CREATE TABLE public.foo (id UUID PRIMARY KEY)")

--- a/components/electric/test/support/postgres_test_connection.ex
+++ b/components/electric/test/support/postgres_test_connection.ex
@@ -142,7 +142,7 @@ defmodule Electric.Postgres.TestConnection do
     {:ok, [], []} =
       :epgsql.squery(conn, """
       CREATE TABLE public.users (
-        id UUID PRIMARY KEY,
+        id TEXT PRIMARY KEY,
         name TEXT NOT NULL
       )
       """)
@@ -150,16 +150,16 @@ defmodule Electric.Postgres.TestConnection do
     {:ok, [], []} =
       :epgsql.squery(conn, """
       CREATE TABLE public.documents (
-        id UUID PRIMARY KEY,
+        id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
-        electric_user_id UUID REFERENCES users(id)
+        electric_user_id TEXT REFERENCES users(id)
       )
       """)
 
     {:ok, [], []} =
       :epgsql.squery(conn, """
       CREATE TABLE public.my_entries (
-        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        id TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
         content VARCHAR NOT NULL,
         content_b TEXT
       );

--- a/e2e/init.sql
+++ b/e2e/init.sql
@@ -1,11 +1,11 @@
 CREATE TABLE entries (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
   content VARCHAR NOT NULL,
   content_b TEXT
 );
 
 CREATE TABLE owned_entries (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
   electric_user_id TEXT NOT NULL,
   content VARCHAR NOT NULL
 );

--- a/e2e/tests/02.02_migrations_get_streamed_to_satellite.lux
+++ b/e2e/tests/02.02_migrations_get_streamed_to_satellite.lux
@@ -16,7 +16,7 @@
     """!
     BEGIN;
     SELECT electric.migration_version('$migration_version');
-    CREATE TABLE mtable1 (id uuid PRIMARY KEY);
+    CREATE TABLE mtable1 (id text PRIMARY KEY);
     CALL electric.electrify('mtable1');
     COMMIT;
     """

--- a/e2e/tests/03.05_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
+++ b/e2e/tests/03.05_fresh_node_satellite_receives_all_migrations_during_initial_sync.lux
@@ -20,7 +20,7 @@
     BEGIN;
 
     CREATE TABLE items (
-      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      id TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
       content VARCHAR NOT NULL
     );
     CALL electric.electrify('public.items');

--- a/e2e/tests/04.01_electric_api_returns_migrations.lux
+++ b/e2e/tests/04.01_electric_api_returns_migrations.lux
@@ -9,7 +9,7 @@
     """!
     BEGIN;
     SELECT electric.migration_version('$migration_version_1');
-    CREATE TABLE mtable1 (id uuid PRIMARY KEY);
+    CREATE TABLE mtable1 (id text PRIMARY KEY);
     CALL electric.electrify('mtable1');
     COMMIT;
     """
@@ -21,7 +21,7 @@
     """!
     BEGIN;
     SELECT electric.migration_version('$migration_version_2');
-    CREATE TABLE mtable2 (id uuid PRIMARY KEY);
+    CREATE TABLE mtable2 (id text PRIMARY KEY);
     CALL electric.electrify('mtable2');
     COMMIT;
     """

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -119,7 +119,7 @@
     [local sql=
         """
         CREATE TABLE public.items (
-            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            id TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
             content VARCHAR NOT NULL,
             content_text_null VARCHAR,
             content_text_null_default VARCHAR DEFAULT '',


### PR DESCRIPTION
Even though we support this type on the server, our generator (and maybe DAL also) cannot handle it properly yet. So letting users electrify tables that have the UUID type would lead to runtime errors at the booting time of their web app.