### PR TITLE
fix: malformed psql command in docs

### DIFF
--- a/examples/introduction/src/components/commands/PSQLCommand.tsx
+++ b/examples/introduction/src/components/commands/PSQLCommand.tsx
@@ -64,6 +64,7 @@ const PSQLCommand = () => {
   }
 
   const [protocol, remainder] = DATABASE_URL.split('://')
+  const [_loginPassword, hostPortDb] = remainder.split('@')
   const { userId, password } = userCreds
 
   const parts = [
@@ -73,7 +74,7 @@ const PSQLCommand = () => {
     ':',
     password,
     '@',
-    remainder
+    hostPortDb
   ]
 
   return (


### PR DESCRIPTION
Before:
```
psql "postgresql://generated_user:generated_passwd@core_user:core_password@postgres:54321/electric"
```

After:
```
psql "postgresql://generated_user:generated_passwd@postgres:54321/electric"
```