### PR TITLE
fix(client): incorrect truthy value

### DIFF
--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -246,7 +246,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   connect(
     retryHandler?: (error: any, attempt: number) => boolean
   ): Promise<void> {
-    if (!this.isClosed) {
+    if (!this.isClosed() {
       this.close()
     }
 

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -246,7 +246,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   connect(
     retryHandler?: (error: any, attempt: number) => boolean
   ): Promise<void> {
-    if (!this.isClosed() {
+    if (!this.isClosed()) {
       this.close()
     }
 


### PR DESCRIPTION
This if statement is actually checking if the function exists, which is true always.

It might be beneficial to add this Typescript lint, it would have caught it:
https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md