### PR TITLE
fix(client): toMessage call incorrectly used as union

### DIFF
--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -877,12 +877,14 @@ export class SatelliteClient extends EventEmitter implements Client {
 
   // TODO: properly handle socket errors; update connectivity state
   private handleIncoming(data: Buffer) {
-    const messageOrError = toMessage(data)
-    if (Log.getLevel() <= 1 && !(messageOrError instanceof SatelliteError))
-      Log.debug(`[proto] recv: ${msgToString(messageOrError)}`)
     let handleIsRpc = false
     try {
       const message = toMessage(data)
+
+      if (Log.getLevel() <= 1) {
+        Log.debug(`[proto] recv: ${msgToString(message)}`)
+      }
+
       const handler = this.handlerForMessageType[message.$type]
       const response = handler.handle(message)
       if ((handleIsRpc = handler.isRpc)) {


### PR DESCRIPTION
Now `toMessage` no longer returns an union type, it throws, so the `messageOrError instanceof SatelliteError` logic would not be properly checked.
The Log.debug condition can be moved to the try/catch so that both success and errors can be handled correctly.