### PR TITLE
client: reduce severity of unsynced table warning.

### DIFF
--- a/clients/typescript/src/client/model/builder.ts
+++ b/clients/typescript/src/client/model/builder.ts
@@ -135,7 +135,7 @@ export class Builder {
     const identificationFields = this.getFields(whereObject, idRequired)
 
     if (!this.shapeManager.hasBeenSubscribed(this._tableName))
-      Log.warn('Reading from unsynced table ' + this._tableName)
+      Log.debug('Reading from unsynced table ' + this._tableName)
 
     const query = squelPostgres.select().from(this._tableName) // specify from which table to select
     // only select the fields provided in `i.select` and the ones in `i.where`

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -29,7 +29,7 @@ Log.methodFactory = function (methodName, logLevel, loggerName) {
     }
   }
 }
-Log.setLevel(Log.getLevel()) // Be sure to call setLevel method in order to apply plugin
+Log.setLevel(Log.levels.DEBUG) // Be sure to call setLevel method in order to apply plugin
 
 const config = {
   auth: {


### PR DESCRIPTION
It's a perfectly valid pattern to bind a liveQuery to an unsynced table.

Plus a warning really messes with the React Native DX.