### PR TITLE
fix: make sure that if slot server dies, it can continue from a known point

### DIFF
--- a/.changeset/tough-actors-divide.md
+++ b/.changeset/tough-actors-divide.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fixed a bug with lost writes when PG dropped the replication connection

--- a/components/electric/lib/electric/replication/satellite_collector_producer.ex
+++ b/components/electric/lib/electric/replication/satellite_collector_producer.ex
@@ -55,7 +55,8 @@ defmodule Electric.Replication.SatelliteCollectorProducer do
       "Subscription request to satellite collector producer from #{producer_or_consumer} with #{inspect(subscription_options)}"
     )
 
-    {:automatic, %{state | starting_from: Keyword.get(subscription_options, :starting_from) || -1}}
+    {:automatic,
+     %{state | starting_from: Keyword.get(subscription_options, :starting_from) || -1}}
   end
 
   @impl GenStage

--- a/components/electric/lib/electric/replication/satellite_collector_producer.ex
+++ b/components/electric/lib/electric/replication/satellite_collector_producer.ex
@@ -30,7 +30,7 @@ defmodule Electric.Replication.SatelliteCollectorProducer do
   @impl GenStage
   def init(_) do
     table = ETS.Set.new!(ordered: true, keypos: 2)
-    {:producer, %{table: table, next_key: 0, demand: 0}}
+    {:producer, %{table: table, next_key: 0, demand: 0, starting_from: -1}}
   end
 
   @impl GenStage
@@ -55,7 +55,7 @@ defmodule Electric.Replication.SatelliteCollectorProducer do
       "Subscription request to satellite collector producer from #{producer_or_consumer} with #{inspect(subscription_options)}"
     )
 
-    {:automatic, state}
+    {:automatic, %{state | starting_from: Keyword.get(subscription_options, :starting_from) || -1}}
   end
 
   @impl GenStage
@@ -64,21 +64,29 @@ defmodule Electric.Replication.SatelliteCollectorProducer do
     send_events_from_ets(Map.update!(state, :demand, &(&1 + incoming_demand)))
   end
 
+  @impl GenStage
+  def handle_info({:sent_all_up_to, key}, state) do
+    ETS.Set.select_delete!(state.table, [{{:_, :"$1"}, [{:"=<", :"$1", key}], [true]}])
+
+    {:noreply, [], state}
+  end
+
   defp send_events_from_ets(%{demand: 0} = state), do: {:noreply, [], state}
 
-  defp send_events_from_ets(%{demand: demand, table: set} = state) do
-    {results, _} = ETS.Set.match!(set, {:"$1", :"$2"}, demand)
+  defp send_events_from_ets(%{demand: demand, table: set, starting_from: from} = state) do
+    results =
+      case ETS.Set.select!(set, [{{:"$1", :"$2"}, [{:>, :"$2", from}], [:"$$"]}], demand) do
+        :"$end_of_table" -> []
+        {results, _continuation} -> results
+      end
 
     case Electric.Utils.list_last_and_length(results) do
       {_, 0} ->
         {:noreply, [], state}
 
       {[_, last_key], fulfilled} ->
-        # Delete items we're going to return now
-        ETS.Set.select_delete!(set, [{{:_, :"$1"}, [{:"=<", :"$1", last_key}], [true]}])
-
         {:noreply, Enum.map(results, fn [tx, pos] -> {tx, pos} end),
-         Map.update!(state, :demand, &(&1 - fulfilled))}
+         %{state | demand: demand - fulfilled, starting_from: last_key}}
     end
   end
 end

--- a/components/electric/test/electric/replication/satellite_collector_producer_test.exs
+++ b/components/electric/test/electric/replication/satellite_collector_producer_test.exs
@@ -17,7 +17,8 @@ defmodule Electric.Replication.SatelliteCollectorProducerTest do
     {:ok, pid} = Producer.start_link([])
     assert :ok = Producer.store_incoming_transactions(pid, [tx(), tx(), tx()])
 
-    {:ok, consumer} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, cancel: :temporary}])
+    {:ok, consumer} =
+      DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, cancel: :temporary}])
 
     # Get all the transactions
     assert_receive {:dummy_consumer, ^pid, [_, {_, second}, {_, third}]}
@@ -25,7 +26,8 @@ defmodule Electric.Replication.SatelliteCollectorProducerTest do
     assert :ok = Producer.store_incoming_transactions(pid, [tx()])
 
     # Tell the server that we want everything since second tx
-    {:ok, _} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, starting_from: second}])
+    {:ok, _} =
+      DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, starting_from: second}])
 
     # Get the third and the fourth items
     assert_receive {:dummy_consumer, ^pid, [{_, ^third}, _]}
@@ -50,7 +52,8 @@ defmodule Electric.Replication.SatelliteCollectorProducerTest do
     {:ok, pid} = Producer.start_link([])
     assert :ok = Producer.store_incoming_transactions(pid, [tx(), tx(), tx()])
 
-    {:ok, consumer} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, cancel: :temporary}])
+    {:ok, consumer} =
+      DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, cancel: :temporary}])
 
     # Get all the transactions
     assert_receive {:dummy_consumer, ^pid, [_, {_, second}, {_, third}]}
@@ -61,7 +64,9 @@ defmodule Electric.Replication.SatelliteCollectorProducerTest do
     send(pid, {:sent_all_up_to, third})
 
     # Connection from second TX will not yield third because it has been garbage collected
-    {:ok, _} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, starting_from: second}])
+    {:ok, _} =
+      DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, starting_from: second}])
+
     assert_receive {:dummy_consumer, ^pid, [{_, fourth}]}
     refute third == fourth
   end

--- a/components/electric/test/electric/replication/satellite_collector_producer_test.exs
+++ b/components/electric/test/electric/replication/satellite_collector_producer_test.exs
@@ -1,0 +1,70 @@
+defmodule Electric.Replication.SatelliteCollectorProducerTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Replication.SatelliteCollectorProducer, as: Producer
+  alias Electric.DummyConsumer
+
+  test "producer immediately fulfills the demand if txs are available" do
+    {:ok, pid} = Producer.start_link([])
+    assert :ok = Producer.store_incoming_transactions(pid, [tx(), tx(), tx()])
+
+    {:ok, _} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, []}])
+
+    assert_receive {:dummy_consumer, ^pid, [_, _, _]}
+  end
+
+  test "producer allows specifying a starting point on reconnect" do
+    {:ok, pid} = Producer.start_link([])
+    assert :ok = Producer.store_incoming_transactions(pid, [tx(), tx(), tx()])
+
+    {:ok, consumer} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, cancel: :temporary}])
+
+    # Get all the transactions
+    assert_receive {:dummy_consumer, ^pid, [_, {_, second}, {_, third}]}
+    GenServer.stop(consumer)
+    assert :ok = Producer.store_incoming_transactions(pid, [tx()])
+
+    # Tell the server that we want everything since second tx
+    {:ok, _} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, starting_from: second}])
+
+    # Get the third and the fourth items
+    assert_receive {:dummy_consumer, ^pid, [{_, ^third}, _]}
+  end
+
+  test "producer correctly forwards new events" do
+    {:ok, pid} = Producer.start_link([])
+    assert :ok = Producer.store_incoming_transactions(pid, [tx(), tx(), tx()])
+
+    {:ok, _} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, cancel: :temporary}])
+
+    # Get all the transactions
+    assert_receive {:dummy_consumer, ^pid, [_, _, {_, third}]}
+
+    assert :ok = Producer.store_incoming_transactions(pid, [tx(), tx()])
+    assert_receive {:dummy_consumer, ^pid, [{_, fourth}, _]}
+
+    assert third < fourth
+  end
+
+  test "producer allows notifying about persisted items to garbage-collect" do
+    {:ok, pid} = Producer.start_link([])
+    assert :ok = Producer.store_incoming_transactions(pid, [tx(), tx(), tx()])
+
+    {:ok, consumer} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, cancel: :temporary}])
+
+    # Get all the transactions
+    assert_receive {:dummy_consumer, ^pid, [_, {_, second}, {_, third}]}
+    GenServer.stop(consumer)
+    assert :ok = Producer.store_incoming_transactions(pid, [tx()])
+
+    # Notify for GC
+    send(pid, {:sent_all_up_to, third})
+
+    # Connection from second TX will not yield third because it has been garbage collected
+    {:ok, _} = DummyConsumer.start_link(notify: self(), subscribe_to: [{pid, starting_from: second}])
+    assert_receive {:dummy_consumer, ^pid, [{_, fourth}]}
+    refute third == fourth
+  end
+
+  defp tx(), do: %{ack_fn: fn -> nil end, changes: ["change 1"]}
+end


### PR DESCRIPTION
Original issue is that when PG cuts the TCP connection that is sourcing the replication from Electric, the process structure wasn't implemented in a way that allowed correct continuation of the replication stream to PG without losing operations by the clients.

1. I've moved in `OffsetStorage.save_pg_position` into the loop because the loop crashes on a closed connection when trying to call the `send()` function that matches on `:ok`
2. When PG reconnects, it will tell us the latest LSN it persisted - we use the saved mapping to restore that position in the cache and now we can continue from there.
3. If all `send()` calls have succeeded we notify our producer that the Satellite-sent txs can be garbage collected

There are still two issues after this PR:
1. We're calling `ack` on the Satellite txs within this producer, which is a problem on the server restart, as they've not yet been persisted. Proper fix would be to listen for a ping message from PG and ACK only then, but there are yet more issues with that approach.
2. If the a "bad" txn is last in the batch, the PG will close the connection, but only after the last `send()` call, so we will have called garbage collection too early and may lose a write. This requires a more systematic fix.