### PR TITLE
fix: make sure that PG continues to be fed after restart

### DIFF
--- a/.changeset/dry-walls-decide.md
+++ b/.changeset/dry-walls-decide.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fixed an issue with transactions not propagating to PG after Electric restart


### PR DESCRIPTION
Issue here was that we're storing PG's position in Electric's source stream in dets, which means it gets correctly restored on Electric restart, but upon the Electric restart, Electric's source stream itself is lost, so position now makes no sense.

A larger scope fix we've discussed also will include not storing PG's position at all in a persistent way, as it makes little sense across restarts