### PR TITLE
fix: run GC before applying the incoming txn

### DIFF
--- a/.changeset/afraid-suns-wink.md
+++ b/.changeset/afraid-suns-wink.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixed conflict resolution issue leading to a wrong state on the client

--- a/clients/typescript/src/satellite/oplog.ts
+++ b/clients/typescript/src/satellite/oplog.ts
@@ -414,7 +414,11 @@ export const primaryKeyToStr = (primaryKeyObj: {
   return json.slice(0, -1) + '}'
 }
 
-export const generateTag = (instanceId: string, timestamp: Date): Tag => {
-  const milliseconds = timestamp.getTime()
+export const generateTag = (
+  instanceId: string,
+  timestamp: Date | number
+): Tag => {
+  const milliseconds =
+    typeof timestamp === 'number' ? timestamp : timestamp.getTime()
   return instanceId + '@' + milliseconds.toString()
 }

--- a/clients/typescript/test/migrators/builder.test.ts
+++ b/clients/typescript/test/migrators/builder.test.ts
@@ -120,7 +120,7 @@ test('read migration meta data', async (t) => {
   t.deepEqual(versions, ['20230613112725_814', '20230613112735_992'])
 })
 
-test('load migration from meta data', async (t) => {
+test.skip('load migration from meta data', async (t) => {
   const db = new Database(':memory:')
   const migration = makeMigration(parseMetadata(migrationMetaData))
   const electric = await electrify(db, new DbSchema({}, [migration]), {

--- a/clients/typescript/test/migrators/builder.test.ts
+++ b/clients/typescript/test/migrators/builder.test.ts
@@ -14,6 +14,7 @@ import Database from 'better-sqlite3'
 import { electrify } from '../../src/drivers/better-sqlite3'
 import path from 'path'
 import { DbSchema } from '../../src/client/model'
+import { MockSocketFactory } from '../../src/sockets/mock'
 
 function encodeSatOpMigrateMsg(request: SatOpMigrate) {
   return (
@@ -120,14 +121,19 @@ test('read migration meta data', async (t) => {
   t.deepEqual(versions, ['20230613112725_814', '20230613112735_992'])
 })
 
-test.skip('load migration from meta data', async (t) => {
+test('load migration from meta data', async (t) => {
   const db = new Database(':memory:')
   const migration = makeMigration(parseMetadata(migrationMetaData))
-  const electric = await electrify(db, new DbSchema({}, [migration]), {
-    auth: {
-      token: 'test-token',
+  const electric = await electrify(
+    db,
+    new DbSchema({}, [migration]),
+    {
+      auth: {
+        token: 'test-token',
+      },
     },
-  })
+    { socketFactory: new MockSocketFactory() }
+  )
 
   // Check that the DB is initialized with the stars table
   const tables = await electric.db.raw({


### PR DESCRIPTION
Problem was that GC was called after the application, so when a transaction did a round-trip to the server and back, it would then be included in the conflict resolution against itself, which is a big problem if the tx was altered on the server-side conflict resolution process. Removing these transactions first ensures we don't have this problem.