### PR TITLE
Update lastAckRowId on client

### DIFF
--- a/clients/typescript/src/drivers/better-sqlite3/adapter.ts
+++ b/clients/typescript/src/drivers/better-sqlite3/adapter.ts
@@ -42,11 +42,11 @@ export class DatabaseAdapter
 
   async transaction<T>(
     f: (_tx: Tx, setResult: (res: T) => void) => void
-  ): Promise<T | void> {
-    let result: T | void = undefined
+  ): Promise<T> {
+    let result: T
     const txn = this.db.transaction(f)
     txn(new WrappedTx(this.db), (res) => (result = res))
-    return result
+    return result!
   }
 
   // Promise interface, but impl not actually async

--- a/clients/typescript/src/drivers/cordova-sqlite-storage/adapter.ts
+++ b/clients/typescript/src/drivers/cordova-sqlite-storage/adapter.ts
@@ -67,8 +67,8 @@ export class DatabaseAdapter
 
   transaction<T>(
     f: (_tx: Tx, setResult: (res: T) => void) => void
-  ): Promise<T | void> {
-    let result: T | void = undefined
+  ): Promise<T> {
+    let result: T
     return new Promise<void>((resolve, reject) => {
       const txFn = (tx: SQLitePlugin.Transaction) => {
         f(new WrappedTx(tx), (res) => (result = res))

--- a/clients/typescript/src/drivers/expo-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/expo-sqlite/adapter.ts
@@ -40,8 +40,8 @@ export class DatabaseAdapter
 
   transaction<T>(
     f: (_tx: Tx, setResult: (res: T) => void) => void
-  ): Promise<T | void> {
-    let result: T | void = undefined
+  ): Promise<T> {
+    let result: T
     return new Promise<void>((resolve, reject) => {
       const wrappedFn = (tx: Transaction) => {
         f(new WrappedTx(tx), (res) => (result = res))

--- a/clients/typescript/src/drivers/react-native-sqlite-storage/adapter.ts
+++ b/clients/typescript/src/drivers/react-native-sqlite-storage/adapter.ts
@@ -78,8 +78,8 @@ export class DatabaseAdapter
 
   transaction<T>(
     f: (_tx: Tx, setResult: (res: T) => void) => void
-  ): Promise<T | void> {
-    let result: T | void = undefined
+  ): Promise<T> {
+    let result: T
     return new Promise((resolve, reject) => {
       const txFn = (tx: Transaction) => {
         f(new WrappedTx(tx), (res) => (result = res))

--- a/clients/typescript/src/drivers/wa-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/wa-sqlite/adapter.ts
@@ -51,7 +51,7 @@ export class DatabaseAdapter implements DatabaseAdapterInterface {
 
   async transaction<T>(
     f: (_tx: Tx, setResult: (res: T) => void) => void
-  ): Promise<T | void> {
+  ): Promise<T> {
     const release = await this.txMutex.acquire()
 
     try {

--- a/clients/typescript/src/electric/adapter.ts
+++ b/clients/typescript/src/electric/adapter.ts
@@ -21,7 +21,7 @@ export interface DatabaseAdapter {
   // The function may not use async/await otherwise the transaction may commit before the queries are actually executed
   transaction<T>(
     f: (tx: Transaction, setResult: (res: T) => void) => void
-  ): Promise<T | void>
+  ): Promise<T>
 
   // Get the tables potentially used by the query (so that we
   // can re-query if the data in them changes).

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -89,6 +89,7 @@ export interface Client {
   subscribeToAck(callback: AckCallback): void
   unsubscribeToAck(callback: AckCallback): void
   resetOutboundLogPositions(sent?: LSN, ack?: LSN): void
+  setOutboundLogPositions(positions: { sent?: LSN; ack?: LSN }): void
   getOutboundLogPositions(): { enqueued: LSN; ack: LSN }
   subscribeToOutboundEvent(event: 'started', callback: () => void): void
   unsubscribeToOutboundEvent(event: 'started', callback: () => void): void

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -230,10 +230,16 @@ export class MockSatelliteClient extends EventEmitter implements Client {
   isClosed(): boolean {
     return this.closed
   }
-  resetOutboundLogPositions(sent: Uint8Array, ack: Uint8Array): void {
+  resetOutboundLogPositions(sent: LSN, ack: LSN): void {
     this.outboundSent = sent
     this.outboundAck = ack
   }
+
+  setOutboundLogPositions(positions: { sent?: LSN; ack?: LSN }): void {
+    this.outboundSent = positions.sent ?? this.outboundSent
+    this.outboundAck = positions.ack ?? this.outboundAck
+  }
+
   getOutboundLogPositions(): { enqueued: Uint8Array; ack: Uint8Array } {
     return { enqueued: this.outboundSent, ack: this.outboundAck }
   }
@@ -310,11 +316,6 @@ export class MockSatelliteClient extends EventEmitter implements Client {
 
   unsubscribeToAck(callback: AckCallback): void {
     this.removeListener('ack_lsn', callback)
-  }
-
-  setOutboundLogPositions(sent: LSN, ack: LSN): void {
-    this.outboundSent = sent
-    this.outboundAck = ack
   }
 
   subscribeToOutboundEvent(_event: 'started', callback: () => void): void {


### PR DESCRIPTION
Initial protocol implementation assumed that a ping message would arrive and trigger the clear of the oplog. At that time we could do gc of oplog at any time.
When we moved to new semantics, it became mandatory to clear oplog ahead of applying incoming operations to prevent re-introducing tags in the system. The ping message became decoupled from the GC of the oplog, but it became redundant and useless because we can update acked immediately when we apply the incoming tx that generated those entries in the oplog

However, currently there are no ping requests flowing from client to server (which might be a good thing) and the acked row id never advances. Also, server is not implementing the ping response correctly.

Protocol somehow still works without advancing acked, because the oplog is being cleared.

This patch shall be combined with ilia/vax-912-conflict-resolution-bug to do GC at the right moment and to we advance ackedrowid

at the moment of writing this patch node I noticed that implementation might actually do gc ahead of applying txn and server could crash in-between (I haven't checked if Ilia ensures this is an atomic change). 
In any case, I think it would be safe because ackRowId means we know it has been applied on the server, but only when we advance LSN we move past the point we would not apply the same txn again in case of recovery (gc-ing oplog would be a noop).