### PR TITLE
chore(electric): Remove unused SYNC_MODE option from SatInStartReplicationReq

### DIFF
--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -114,11 +114,6 @@ export interface SatInStartReplicationReq {
   /** LSN position of the log on the producer side */
   lsn: Uint8Array;
   options: SatInStartReplicationReq_Option[];
-  /**
-   * Amount of message after which SatPingResp message is expected to be
-   * delivered when SYNC_MODE is used
-   */
-  syncBatchSize: number;
   /** the subscriptions identifiers the client wants to resume subscription */
   subscriptionIds: string[];
   /** The version of the most recent migration seen by the client. */
@@ -128,11 +123,6 @@ export interface SatInStartReplicationReq {
 export enum SatInStartReplicationReq_Option {
   /** NONE - Required by the Protobuf spec. */
   NONE = 0,
-  /**
-   * SYNC_MODE - In sync mode consumer of the stream is expected to send SatPingResp
-   * message for every committed batch of SatOpLog messages
-   */
-  SYNC_MODE = 2,
   UNRECOGNIZED = -1,
 }
 
@@ -939,7 +929,6 @@ function createBaseSatInStartReplicationReq(): SatInStartReplicationReq {
     $type: "Electric.Satellite.v1_4.SatInStartReplicationReq",
     lsn: new Uint8Array(),
     options: [],
-    syncBatchSize: 0,
     subscriptionIds: [],
     schemaVersion: undefined,
   };
@@ -957,9 +946,6 @@ export const SatInStartReplicationReq = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.syncBatchSize !== 0) {
-      writer.uint32(24).int32(message.syncBatchSize);
-    }
     for (const v of message.subscriptionIds) {
       writer.uint32(34).string(v!);
     }
@@ -1000,13 +986,6 @@ export const SatInStartReplicationReq = {
           }
 
           break;
-        case 3:
-          if (tag !== 24) {
-            break;
-          }
-
-          message.syncBatchSize = reader.int32();
-          continue;
         case 4:
           if (tag !== 34) {
             break;
@@ -1038,7 +1017,6 @@ export const SatInStartReplicationReq = {
     const message = createBaseSatInStartReplicationReq();
     message.lsn = object.lsn ?? new Uint8Array();
     message.options = object.options?.map((e) => e) || [];
-    message.syncBatchSize = object.syncBatchSize ?? 0;
     message.subscriptionIds = object.subscriptionIds?.map((e) => e) || [];
     message.schemaVersion = object.schemaVersion ?? undefined;
     return message;

--- a/components/electric/lib/electric/satellite/protobuf_messages.ex
+++ b/components/electric/lib/electric/satellite/protobuf_messages.ex
@@ -253,15 +253,6 @@
           def encode("NONE") do
             0
           end
-        ),
-        (
-          def encode(:SYNC_MODE) do
-            2
-          end
-
-          def encode("SYNC_MODE") do
-            2
-          end
         )
       ]
 
@@ -273,9 +264,6 @@
       [
         def decode(0) do
           :NONE
-        end,
-        def decode(2) do
-          :SYNC_MODE
         end
       ]
 
@@ -285,16 +273,13 @@
 
       @spec constants() :: [{integer(), atom()}]
       def constants() do
-        [{0, :NONE}, {2, :SYNC_MODE}]
+        [{0, :NONE}]
       end
 
       @spec has_constant?(any()) :: boolean()
       (
         [
           def has_constant?(:NONE) do
-            true
-          end,
-          def has_constant?(:SYNC_MODE) do
             true
           end
         ]
@@ -1424,12 +1409,7 @@
   end,
   defmodule Electric.Satellite.V14.SatInStartReplicationReq do
     @moduledoc false
-    defstruct lsn: "",
-              options: [],
-              sync_batch_size: 0,
-              subscription_ids: [],
-              schema_version: nil,
-              __uf__: []
+    defstruct lsn: "", options: [], subscription_ids: [], schema_version: nil, __uf__: []
 
     (
       (
@@ -1448,7 +1428,6 @@
           |> encode_schema_version(msg)
           |> encode_lsn(msg)
           |> encode_options(msg)
-          |> encode_sync_batch_size(msg)
           |> encode_subscription_ids(msg)
           |> encode_unknown_fields(msg)
         end
@@ -1499,19 +1478,6 @@
           rescue
             ArgumentError ->
               reraise Protox.EncodingError.new(:options, "invalid field value"), __STACKTRACE__
-          end
-        end,
-        defp encode_sync_batch_size(acc, msg) do
-          try do
-            if msg.sync_batch_size == 0 do
-              acc
-            else
-              [acc, "\x18", Protox.Encode.encode_int32(msg.sync_batch_size)]
-            end
-          rescue
-            ArgumentError ->
-              reraise Protox.EncodingError.new(:sync_batch_size, "invalid field value"),
-                      __STACKTRACE__
           end
         end,
         defp encode_subscription_ids(acc, msg) do
@@ -1628,10 +1594,6 @@
 
                 {[options: msg.options ++ [value]], rest}
 
-              {3, _, bytes} ->
-                {value, rest} = Protox.Decode.parse_int32(bytes)
-                {[sync_batch_size: value], rest}
-
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
@@ -1706,7 +1668,6 @@
           1 => {:lsn, {:scalar, ""}, :bytes},
           2 =>
             {:options, :packed, {:enum, Electric.Satellite.V14.SatInStartReplicationReq.Option}},
-          3 => {:sync_batch_size, {:scalar, 0}, :int32},
           4 => {:subscription_ids, :unpacked, :string},
           5 => {:schema_version, {:oneof, :_schema_version}, :string}
         }
@@ -1721,8 +1682,7 @@
           lsn: {1, {:scalar, ""}, :bytes},
           options: {2, :packed, {:enum, Electric.Satellite.V14.SatInStartReplicationReq.Option}},
           schema_version: {5, {:oneof, :_schema_version}, :string},
-          subscription_ids: {4, :unpacked, :string},
-          sync_batch_size: {3, {:scalar, 0}, :int32}
+          subscription_ids: {4, :unpacked, :string}
         }
       end
     )
@@ -1748,15 +1708,6 @@
             name: :options,
             tag: 2,
             type: {:enum, Electric.Satellite.V14.SatInStartReplicationReq.Option}
-          },
-          %{
-            __struct__: Protox.Field,
-            json_name: "syncBatchSize",
-            kind: {:scalar, 0},
-            label: :optional,
-            name: :sync_batch_size,
-            tag: 3,
-            type: :int32
           },
           %{
             __struct__: Protox.Field,
@@ -1838,46 +1789,6 @@
           end
 
           []
-        ),
-        (
-          def field_def(:sync_batch_size) do
-            {:ok,
-             %{
-               __struct__: Protox.Field,
-               json_name: "syncBatchSize",
-               kind: {:scalar, 0},
-               label: :optional,
-               name: :sync_batch_size,
-               tag: 3,
-               type: :int32
-             }}
-          end
-
-          def field_def("syncBatchSize") do
-            {:ok,
-             %{
-               __struct__: Protox.Field,
-               json_name: "syncBatchSize",
-               kind: {:scalar, 0},
-               label: :optional,
-               name: :sync_batch_size,
-               tag: 3,
-               type: :int32
-             }}
-          end
-
-          def field_def("sync_batch_size") do
-            {:ok,
-             %{
-               __struct__: Protox.Field,
-               json_name: "syncBatchSize",
-               kind: {:scalar, 0},
-               label: :optional,
-               name: :sync_batch_size,
-               tag: 3,
-               type: :int32
-             }}
-          end
         ),
         (
           def field_def(:subscription_ids) do
@@ -2003,9 +1914,6 @@
       end,
       def default(:options) do
         {:error, :no_default_value}
-      end,
-      def default(:sync_batch_size) do
-        {:ok, 0}
       end,
       def default(:subscription_ids) do
         {:error, :no_default_value}

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -39,9 +39,7 @@ defmodule Electric.Satellite.Protocol do
               incomplete_trans: nil,
               demand: 0,
               sub_retry: nil,
-              queue: :queue.new(),
-              sync_counter: 0,
-              sync_batch_size: nil
+              queue: :queue.new()
 
     @typedoc """
     Incoming replication Satellite -> PG
@@ -62,10 +60,7 @@ defmodule Electric.Satellite.Protocol do
             },
             incomplete_trans: nil | Transaction.t(),
             demand: pos_integer(),
-            queue: :queue.queue(Transaction.t()),
-            # Parameters used to acknowledge received messages
-            sync_batch_size: nil | non_neg_integer,
-            sync_counter: nil | non_neg_integer()
+            queue: :queue.queue(Transaction.t())
           }
   end
 
@@ -75,8 +70,6 @@ defmodule Electric.Satellite.Protocol do
               pid: nil,
               stage_sub: nil,
               relations: %{},
-              sync_counter: 0,
-              sync_batch_size: nil,
               last_seen_wal_pos: 0,
               subscription_pause_queue: {nil, :queue.new()},
               outgoing_ops_buffer: :queue.new(),
@@ -97,9 +90,6 @@ defmodule Electric.Satellite.Protocol do
             status: nil | :active | :paused,
             stage_sub: GenStage.subscription_tag() | nil,
             relations: %{Changes.relation() => PB.relation_id()},
-            # Parameters used to acknowledge received messages
-            sync_batch_size: nil | non_neg_integer,
-            sync_counter: nil | non_neg_integer,
             last_seen_wal_pos: non_neg_integer,
             # The first element of the tuple is the head of the queue, which is pulled out to be available in guards/pattern matching
             subscription_pause_queue:
@@ -454,7 +444,7 @@ defmodule Electric.Satellite.Protocol do
              msg,
              in_rep.incomplete_trans,
              in_rep.relations,
-             fn lsn -> report_lsn(state.client_id, self, in_rep.sync_batch_size, lsn) end
+             fn lsn -> report_lsn(state.client_id, self, lsn) end
            ) do
         {incomplete, []} ->
           {nil, %State{state | in_rep: %InRep{in_rep | incomplete_trans: incomplete}}}
@@ -572,14 +562,7 @@ defmodule Electric.Satellite.Protocol do
     end
   end
 
-  defp report_lsn(satellite, _pid, nil, lsn) do
-    Logger.info("report lsn: #{inspect(lsn)} for #{satellite}")
-    OffsetStorage.put_satellite_lsn(satellite, lsn)
-    # We are not operating in a sync mode, so no need to acknowledge lsn in
-    # this call
-  end
-
-  defp report_lsn(satellite, pid, 1, lsn) do
+  defp report_lsn(satellite, pid, lsn) do
     Logger.info("report lsn: #{inspect(lsn)} for #{satellite}")
     OffsetStorage.put_satellite_lsn(satellite, lsn)
     Process.send(pid, {__MODULE__, :lsn_report, lsn}, [])

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -210,8 +210,7 @@ defmodule Electric.Satellite.WsServer do
     max_txid = migrations |> Enum.map(& &1.xid) |> Enum.max(fn -> 0 end)
 
     state =
-      state
-      |> Protocol.subscribe_client_to_replication_stream(msg, lsn)
+      Protocol.subscribe_client_to_replication_stream(lsn, state)
       |> Map.update!(:out_rep, &%{&1 | last_migration_xid_at_initial_sync: max_txid})
 
     {binary_frames(msgs), state}
@@ -369,7 +368,6 @@ defmodule Electric.Satellite.WsServer do
         in_rep.status == nil or in_rep.status == :paused ->
           [
             %SatInStartReplicationReq{
-              options: [:SYNC_MODE],
               sync_batch_size: 1,
               lsn: lsn
             }
@@ -379,7 +377,6 @@ defmodule Electric.Satellite.WsServer do
           [
             %SatInStopReplicationReq{},
             %SatInStartReplicationReq{
-              options: [:SYNC_MODE],
               sync_batch_size: 1,
               lsn: lsn
             }

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -179,8 +179,8 @@ defmodule Electric.Satellite.WsServer do
     end
   end
 
-  # Consumer (SatelliteCollectorConsumer) has reported that this lsn has been stored successfully
-  # and as long as %InRep.sync_batch_size is enabled we need to report to Satellite.
+  # Consumer (SatelliteCollectorConsumer) has reported that this lsn has been stored successfully.
+  # We need to report to Satellite.
   def websocket_info({Protocol, :lsn_report, lsn}, %State{} = state) do
     {[binary_frame(%SatPingResp{lsn: lsn})], state}
   end
@@ -380,15 +380,7 @@ defmodule Electric.Satellite.WsServer do
           []
       end
 
-    in_rep = %InRep{
-      in_rep
-      | stage_sub: sub_tag,
-        pid: pid,
-        status: :requested,
-        sync_batch_size: 1,
-        sync_counter: 0
-    }
-
+    in_rep = %InRep{in_rep | stage_sub: sub_tag, pid: pid, status: :requested}
     {binary_frames(msgs), %State{state | in_rep: in_rep}}
   end
 

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -367,19 +367,13 @@ defmodule Electric.Satellite.WsServer do
       cond do
         in_rep.status == nil or in_rep.status == :paused ->
           [
-            %SatInStartReplicationReq{
-              sync_batch_size: 1,
-              lsn: lsn
-            }
+            %SatInStartReplicationReq{lsn: lsn}
           ]
 
         in_rep.status == :active ->
           [
             %SatInStopReplicationReq{},
-            %SatInStartReplicationReq{
-              sync_batch_size: 1,
-              lsn: lsn
-            }
+            %SatInStartReplicationReq{lsn: lsn}
           ]
 
         in_rep.status == :requested ->

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -96,20 +96,17 @@ message SatErrorResp {
 // (Consumer) Starts replication stream from producer to consumer
 message SatInStartReplicationReq {
     enum Option {
-        reserved 1, 3, 4;
+        reserved 1, 2, 3, 4;
 
         // Required by the Protobuf spec.
         NONE = 0;
-        // In sync mode consumer of the stream is expected to send SatPingResp
-        // message for every committed batch of SatOpLog messages
-        SYNC_MODE = 2;
     }
+
+    reserved 3;
+
     // LSN position of the log on the producer side
     bytes lsn = 1;
     repeated Option options = 2;
-    // Amount of message after which SatPingResp message is expected to be
-    // delivered when SYNC_MODE is used
-    int32 sync_batch_size = 3;
 
     // the subscriptions identifiers the client wants to resume subscription    
     repeated string subscription_ids = 4;


### PR DESCRIPTION
We have no logic on the client handling it. There is a bit of server-side code that checked for the presence of SYNC_MODE but since that option is never used, we can simplify the code by removing the conditional branches.