### PR TITLE
chore: remove ack logic from the client as unused

### DIFF
--- a/clients/typescript/src/electric/adapter.ts
+++ b/clients/typescript/src/electric/adapter.ts
@@ -17,8 +17,14 @@ export interface DatabaseAdapter {
   // Query the database.
   query(statement: Statement): Promise<Row[]>
 
-  // Runs the provided function inside a transaction
-  // The function may not use async/await otherwise the transaction may commit before the queries are actually executed
+  /**
+   * Runs the provided __non-async__ function inside a transaction.
+   *
+   * The function may not use async/await otherwise the transaction may commit before
+   * the queries are actually executed. This is a limitation of some adapters, that the
+   * function passed to the transaction runs "synchronously" through callbacks without
+   * releasing the event loop.
+   */
   transaction<T>(
     f: (tx: Transaction, setResult: (res: T) => void) => void
   ): Promise<T>

--- a/clients/typescript/src/migrators/schema.ts
+++ b/clients/typescript/src/migrators/schema.ts
@@ -17,7 +17,7 @@ export const data = {
         //`-- Somewhere to track migrations\n`,
         `CREATE TABLE IF NOT EXISTS ${migrationsTable} (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  version TEXT NOT NULL UNIQUE,\n  applied_at TEXT NOT NULL\n);`,
         //`-- Initialisation of the metadata table\n`,
-        `INSERT INTO ${metaTable} (key, value) VALUES ('compensations', 1), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', ''), ('clientId', ''), ('subscriptions', '');`,
+        `INSERT INTO ${metaTable} (key, value) VALUES ('compensations', 1), ('lsn', ''), ('clientId', ''), ('subscriptions', '');`,
         //`-- These are toggles for turning the triggers on and off\n`,
         `DROP TABLE IF EXISTS ${triggersTable};`,
         `CREATE TABLE ${triggersTable} (tablename TEXT PRIMARY KEY, flag INTEGER);`,

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -45,7 +45,6 @@ import _m0 from 'protobufjs/minimal.js'
 import { EventEmitter } from 'events'
 import {
   AckCallback,
-  AckType,
   AuthResponse,
   DataChangeType,
   LSN,
@@ -63,6 +62,7 @@ import {
   StartReplicationResponse,
   StopReplicationResponse,
   ErrorCallback,
+  AckType,
 } from '../util/types'
 import {
   base64,
@@ -643,8 +643,8 @@ export class SatelliteClient extends EventEmitter implements Client {
     if (this.outbound.isReplicating == ReplicationStatus.STOPPED) {
       const replication = {
         ...this.outbound,
-        ack_lsn: DEFAULT_LOG_POS,
-        enqueued_lsn: DEFAULT_LOG_POS,
+        ack_lsn: this.outbound.ack_lsn ?? DEFAULT_LOG_POS,
+        enqueued_lsn: this.outbound.enqueued_lsn ?? DEFAULT_LOG_POS,
       }
 
       this.outbound = this.resetReplication(
@@ -772,12 +772,9 @@ export class SatelliteClient extends EventEmitter implements Client {
     this.sendMessage(pong)
   }
 
-  // TODO: emit ping request to clear oplog.
-  private handlePingResp(message: SatPingResp) {
-    if (message.lsn) {
-      this.outbound.ack_lsn = message.lsn
-      this.emit('ack_lsn', message.lsn, AckType.REMOTE_COMMIT)
-    }
+  private handlePingResp(_message: SatPingResp) {
+    // TODO: might be dropping client-initiated pings completely
+    throw Error('not implemented')
   }
 
   private handleError(error: SatErrorResp) {
@@ -1039,6 +1036,12 @@ export class SatelliteClient extends EventEmitter implements Client {
 
   resetOutboundLogPositions(sent: LSN, ack: LSN): void {
     this.outbound = this.resetReplication(sent, ack)
+  }
+
+  setOutboundLogPositions(positions: { enqueued?: LSN; ack?: LSN }) {
+    this.outbound.enqueued_lsn =
+      positions.enqueued ?? this.outbound.enqueued_lsn
+    this.outbound.ack_lsn = positions.ack ?? this.outbound.ack_lsn
   }
 
   getOutboundLogPositions(): { enqueued: LSN; ack: LSN } {

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -5,7 +5,6 @@ import { Migrator } from '../migrators/index'
 import { Notifier } from '../notifiers/index'
 import { SocketFactory } from '../sockets'
 import {
-  AckCallback,
   AuthResponse,
   ConnectivityState,
   DbName,
@@ -85,11 +84,7 @@ export interface Client {
     callback: (transaction: Transaction) => Promise<void>
   ): void
   enqueueTransaction(transaction: DataTransaction): void
-  subscribeToAck(callback: AckCallback): void
-  unsubscribeToAck(callback: AckCallback): void
-  resetOutboundLogPositions(sent?: LSN, ack?: LSN): void
-  setOutboundLogPositions(positions: { sent?: LSN; ack?: LSN }): void
-  getOutboundLogPositions(): { enqueued: LSN; ack: LSN }
+  getLastSentLsn(): LSN
   subscribeToOutboundEvent(event: 'started', callback: () => void): void
   unsubscribeToOutboundEvent(event: 'started', callback: () => void): void
   subscribeToError(callback: ErrorCallback): void

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -88,6 +88,7 @@ export interface Client {
   subscribeToAck(callback: AckCallback): void
   unsubscribeToAck(callback: AckCallback): void
   resetOutboundLogPositions(sent?: LSN, ack?: LSN): void
+  setOutboundLogPositions(positions: { sent?: LSN; ack?: LSN }): void
   getOutboundLogPositions(): { enqueued: LSN; ack: LSN }
   subscribeToOutboundEvent(event: 'started', callback: () => void): void
   unsubscribeToOutboundEvent(event: 'started', callback: () => void): void

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -238,10 +238,16 @@ export class MockSatelliteClient extends EventEmitter implements Client {
   isClosed(): boolean {
     return this.closed
   }
-  resetOutboundLogPositions(sent: Uint8Array, ack: Uint8Array): void {
+  resetOutboundLogPositions(sent: LSN, ack: LSN): void {
     this.outboundSent = sent
     this.outboundAck = ack
   }
+
+  setOutboundLogPositions(positions: { sent?: LSN; ack?: LSN }): void {
+    this.outboundSent = positions.sent ?? this.outboundSent
+    this.outboundAck = positions.ack ?? this.outboundAck
+  }
+
   getOutboundLogPositions(): { enqueued: Uint8Array; ack: Uint8Array } {
     return { enqueued: this.outboundSent, ack: this.outboundAck }
   }
@@ -317,11 +323,6 @@ export class MockSatelliteClient extends EventEmitter implements Client {
 
   unsubscribeToAck(callback: AckCallback): void {
     this.removeListener('ack_lsn', callback)
-  }
-
-  setOutboundLogPositions(sent: LSN, ack: LSN): void {
-    this.outboundSent = sent
-    this.outboundAck = ack
   }
 
   subscribeToOutboundEvent(_event: 'started', callback: () => void): void {

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -156,7 +156,10 @@ export type Replication = {
   transactions: Transaction[]
 }
 
-export type OutgoingReplication = Omit<Replication, 'transactions'> & {
+export type OutgoingReplication = Omit<
+  Replication,
+  'transactions' | 'ack_lsn'
+> & {
   transactions: DataTransaction[] // outgoing transactions cannot contain migrations
 }
 
@@ -184,12 +187,6 @@ export enum ReplicationStatus {
   ACTIVE,
 }
 
-export enum AckType {
-  LOCAL_SEND,
-  REMOTE_COMMIT,
-}
-
-export type AckCallback = (lsn: LSN, type: AckType) => void
 export type ErrorCallback = (error: SatelliteError) => void
 
 export type ConnectivityState =

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -147,20 +147,12 @@ export function isDataChange(change: Change): change is DataChange {
 
 export type Record = { [key: string]: string | number | undefined | null }
 
-export type Replication = {
+export type Replication<TransactionType> = {
   authenticated: boolean
   isReplicating: ReplicationStatus
   relations: Map<number, Relation>
-  ack_lsn?: LSN
-  enqueued_lsn?: LSN
-  transactions: Transaction[]
-}
-
-export type OutgoingReplication = Omit<
-  Replication,
-  'transactions' | 'ack_lsn'
-> & {
-  transactions: DataTransaction[] // outgoing transactions cannot contain migrations
+  last_lsn: LSN | undefined
+  transactions: TransactionType[]
 }
 
 export type Relation = {

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -365,10 +365,10 @@ test.serial('acknowledge lsn', async (t) => {
 
   await new Promise<void>(async (res) => {
     client.on('transaction', (_t: DataTransaction, ack: any) => {
-      const lsn0 = client['inbound'].ack_lsn
+      const lsn0 = client['inbound'].last_lsn
       t.is(lsn0, undefined)
       ack()
-      const lsn1 = base64.fromBytes(client['inbound'].ack_lsn!)
+      const lsn1 = base64.fromBytes(client['inbound'].last_lsn!)
       t.is(lsn1, 'FAKE')
       res()
     })

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -100,7 +100,6 @@ export interface TestNotifier extends EventNotifier {
 }
 
 export interface TestSatellite extends Satellite {
-  _lastSentRowId: number
   _authState?: AuthState
   relations: RelationsCache
   initializing?: {

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1017,8 +1017,8 @@ test('compensations: using triggers with flag 1', async (t) => {
     sql: `INSERT INTO main.parent(id, value) VALUES (1, '1')`,
   })
   await satellite._setAuthState(authState)
-  await satellite._performSnapshot()
-  await satellite._garbageCollectOplog
+  const ts = await satellite._performSnapshot()
+  await satellite._garbageCollectOplog(ts)
 
   await adapter.run({ sql: `INSERT INTO main.child(id, parent) VALUES (1, 1)` })
   await satellite._performSnapshot()

--- a/clients/typescript/test/satellite/process.timing.test.ts
+++ b/clients/typescript/test/satellite/process.timing.test.ts
@@ -15,8 +15,7 @@ test.beforeEach(async (t) => makeContext(t, opts))
 test.afterEach.always(clean)
 
 test('throttled snapshot respects window', async (t) => {
-  const { adapter, notifier, runMigrations, satellite, authState } =
-    t.context as any
+  const { adapter, notifier, runMigrations, satellite, authState } = t.context
   await runMigrations()
 
   await satellite._setAuthState(authState)

--- a/components/electric/lib/electric/replication/satellite_collector_producer.ex
+++ b/components/electric/lib/electric/replication/satellite_collector_producer.ex
@@ -36,7 +36,7 @@ defmodule Electric.Replication.SatelliteCollectorProducer do
   @impl GenStage
   def handle_call({:store_incoming_transactions, transactions}, _, state) do
     transactions
-    |> Stream.each(& &1.ack_fn())
+    |> Stream.each(& &1.ack_fn.())
     |> Stream.reject(&Enum.empty?(&1.changes))
     |> Stream.with_index(state.next_key)
     |> Enum.to_list()

--- a/e2e/tests/03.12_server_correctly_continues_the_replication.lux
+++ b/e2e/tests/03.12_server_correctly_continues_the_replication.lux
@@ -1,0 +1,46 @@
+[doc When client resumes, server correctly requests stream continuation]
+[include _shared.luxinc]
+[include _satellite_macros.luxinc]
+
+[invoke setup]
+
+[invoke setup_client 1 "electric_1" 5133]
+
+[shell pg_1]
+  [invoke migrate_items_table 20230504114018]
+
+[shell satellite_1]
+  ??[proto] recv: #SatInStartReplicationResp
+  [invoke node_await_table "items"]
+
+  # First write gets propagated
+  [invoke node_await_insert "['hello from satellite - first']"]
+
+[shell pg_1]
+  [invoke wait-for "SELECT * FROM public.items;" "hello from satellite - first" 10 $psql]
+
+[shell satellite_1]
+  [progress stopping client]
+  !await client.stop(db)
+  ?$node
+
+  # Verify that the client retrieves previously stored LSN when it reestablishes the replication connection.
+  [progress resuming client]
+  [invoke electrify_db "originalDb" "electric_1" 5133 "[]"]
+  ?$node
+
+  -no previous LSN
+
+  # Server requests replication. The `AAAAAQ==` here is [0, 0, 0, 1] UInt8Array, representing an integer 1 - the one rowid
+  ?+\[proto\] recv: #SatInStartReplicationReq\{lsn: AAAAAQ==,
+  ?\[proto\] send: #SatInStartReplicationReq\{lsn: [a-zA-Z0-9=]+,
+  ??[proto] recv: #SatInStartReplicationResp
+
+  # Second write gets propagated
+  [invoke node_await_insert "['hello from satellite - second']"]
+
+[shell pg_1]
+  [invoke wait-for "SELECT * FROM public.items;" "hello from satellite - second" 10 $psql]
+
+[cleanup]
+  [invoke teardown]


### PR DESCRIPTION
This PR simplifies the client by removing `_lastAck` and `_lastSent` from the process, and `ack_lsn` from the outbound replication state in the client.

There are three parts to validity of these changes:
1. `this.outbound.ack_lsn` in the client was just unused. It was assigned in a bunch of places, but read only in one function (`getOutboundLogPositions`), where the only calling place (`SatelliteProcess#_performSnapshot`) didn't use that part of the return value.
    This PR removes this field, and simplifies function signatures appropriately.
2. `_lastSentRowId` in the client was set in a lot of places as well, but only usage place was to fill `client.outbound.enqueued_lsn`. This allowed the client to continue streaming to the server from the LSN it didn't sent before, however that logic is incorrect: `SatInStartReplicationReq` message sent by the server has an LSN in it which is the actual LSN the client is expected to start from - current code just didn't respect this (because of a bug in the server that didn't actually set that field correctly, which is also fixed in this PR). Correct behaviour is to keep track of enqueued LSN only for the lifetime of the client connection, because on reconnect server will tell the client where to start from - which makes keeping `_lastSentRowId` useless.
    This PR removes this field, as well as the preset row in the meta table with `lastSentRowId` key.
3. `_lastAckdRowId` is the most complicated to explain.
    1. It was set based on the pings from the server, which are currently incorrect. There are changes in #386 which fix the acknowledges on the server to be only done on actual persistence to Postgres. If Electric had reached the transaction saving the persisted position to Postgres, that means it reached the original sent transaction itself and is about to send it out to clients. Hence, there is no difference in time between receiving the acknowledge and the transaction itself after the round-trip.
    2. The queries in `_performSnapshot` used `rowid > _lastAckdRowId` check in all queries, but if have received back the original transaction, we have already deleted the irrelevant oplog entries. Furthermore, queries have equality checks on `timestamp` column that made `rowid` checks useless regardless of other context.
    3. The other place where `_lastAckdRowId` was used, was in `_apply` call, which called `this._getEntries()`. `this._getEntries()` without arguments used to do a query with `rowid > _lastAckdRowId` to avoid including acknowledged rows in conflict resolution, however, as described above, any acknowledged rows can be safely considered garbage collected.
        _This is actually more correct now, because before we receive back the transaction and GC the oplog entry, all other transactions came before ours from Postgres point of view, and to replicate conflict resolution exactly we should use all oplog entries regardless if the server has seen them, persisted them, or whatever._
    
    So this PR makes it so we rely only on GC of oplog for all queries, removes `_lastAckdRowId` property, as well as the preset row in the meta table with `lastAckdRowId` key.
    
There is a follow-up to be made that we don't actually use ping data neither on the client nor on the server, but that's a separate PR.