### PR TITLE
chore(client): enable foreign_keys pragma on startup

### DIFF
--- a/.changeset/warm-teachers-obey.md
+++ b/.changeset/warm-teachers-obey.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Enable foreign_keys pragma on startup.

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -21,6 +21,11 @@ export interface ElectrifyOptions {
   notifier?: Notifier
   socketFactory?: SocketFactory
   registry?: Registry
+  prepare?: (connection: DatabaseAdapter) => Promise<void>
+}
+
+const defaultPrepare = async (connection: DatabaseAdapter) => {
+  await connection.run({ sql: 'PRAGMA foreign_keys = ON;' })
 }
 
 /**
@@ -38,7 +43,8 @@ export const electrify = async <DB extends DbSchema<any>>(
   opts?: Omit<ElectrifyOptions, 'adapter' | 'socketFactory'>
 ): Promise<ElectricClient<DB>> => {
   setLogLevel(config.debug ? 'TRACE' : 'WARN')
-  await adapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
+  const prepare = opts?.prepare ?? defaultPrepare
+  await prepare(adapter)
 
   const configWithDefaults = hydrateConfig(config)
   const migrator =

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -21,6 +21,13 @@ export interface ElectrifyOptions {
   notifier?: Notifier
   socketFactory?: SocketFactory
   registry?: Registry
+  /**
+   * Function that prepares the database connection.
+   * If not overridden, the default prepare function
+   * enables the `foreign_key` pragma on the DB connection.
+   * @param connection The database connection.
+   * @returns A promise that resolves when the database connection is prepared.
+   */
   prepare?: (connection: DatabaseAdapter) => Promise<void>
 }
 

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -38,6 +38,7 @@ export const electrify = async <DB extends DbSchema<any>>(
   opts?: Omit<ElectrifyOptions, 'adapter' | 'socketFactory'>
 ): Promise<ElectricClient<DB>> => {
   setLogLevel(config.debug ? 'TRACE' : 'WARN')
+  await adapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
 
   const configWithDefaults = hydrateConfig(config)
   const migrator =

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -205,7 +205,6 @@ export class SatelliteProcess implements Satellite {
   }
 
   async start(authConfig: AuthConfig): Promise<ConnectionWrapper> {
-    await this.adapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
     await this.migrator.up()
 
     const isVerified = await this._verifyTableStructure()

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -205,6 +205,7 @@ export class SatelliteProcess implements Satellite {
   }
 
   async start(authConfig: AuthConfig): Promise<ConnectionWrapper> {
+    await this.adapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
     await this.migrator.up()
 
     const isVerified = await this._verifyTableStructure()


### PR DESCRIPTION
Closes VAX-880.
No need to also enable the compensations because they are already enabled by the base migration:
- defined here with compensations set to 1: https://github.com/electric-sql/electric/blob/main/clients/typescript/src/migrators/schema.ts#L20
- and applied here: https://github.com/electric-sql/electric/blob/main/clients/typescript/src/migrators/bundle.ts#L38