### PR TITLE
chore(examples): fix @types/react-native dev dependency

### DIFF
--- a/examples/expo/package.json
+++ b/examples/expo/package.json
@@ -36,7 +36,7 @@
     "@prisma/client": "4.8.1",
     "@tsconfig/react-native": "^2.0.2",
     "@types/react": "^18.0.18",
-    "@types/react-native": "^18.0.18",
+    "@types/react-native": "^0.72.2",
     "prisma": "4.8.1",
     "shelljs": "^0.8.5",
     "typescript": "^5.1.3"

--- a/examples/expo/yarn.lock
+++ b/examples/expo/yarn.lock
@@ -2183,7 +2183,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react-native@^18.0.18":
+"@types/react-native@^0.72.2":
   version "0.72.2"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.72.2.tgz#27c931a899c555b28e20cdd12e570b017808de96"
   integrity sha512-/eEjr04Zqo7mTMszuSdrLx90+j5nWhDMMOgtnKZfAYyV3RwmlpSb7F17ilmMMxZWJY81n/JZ4e6wdhMJFpjrCg==


### PR DESCRIPTION
Changes the version of the `@types/react-native` dev dependency to a valid version in the expo example app.