### PR TITLE
chore: switch ping/pong to ws-level

### DIFF
--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -96,6 +96,13 @@ defmodule Electric.Satellite.WebsocketServer do
   end
 
   @impl WebSock
+  # Either a `:ping` or a `:pong` message are enough to keep the connection open
+  def handle_control(_, %State{} = state) do
+    last_msg_time = :erlang.timestamp()
+    {:ok, %State{state | last_msg_time: last_msg_time}}
+  end
+
+  @impl WebSock
   # These four `handle_info` cases allow this websocket to act as a GenStage consumer and producer
   def handle_info({:"$gen_consumer", from, msg}, state) do
     Logger.debug("msg from producer: #{inspect(msg)}")
@@ -127,7 +134,7 @@ defmodule Electric.Satellite.WebsocketServer do
 
       last_msg_time ->
         if :timer.now_diff(:erlang.timestamp(), last_msg_time) > @ping_interval * 1000 do
-          push({%SatPingReq{}, schedule_ping(%{state | last_msg_time: :ping_sent})})
+          {:push, {:ping, ""}, schedule_ping(%{state | last_msg_time: :ping_sent})}
         else
           {:ok, schedule_ping(state)}
         end

--- a/e2e/tests/03.09_fresh_node_satellite_receives_only_missing_migrations_during_initial_sync.lux
+++ b/e2e/tests/03.09_fresh_node_satellite_receives_only_missing_migrations_during_initial_sync.lux
@@ -36,7 +36,7 @@
   ??[proto] send: #SatInStartReplicationReq{lsn: , schema: $migration1_vsn
   ??[proto] recv: #SatInStartReplicationResp{}
 
-  # The client receives only the second migration. Since the client sends migrations in order, we're sure that we haven't seen migraiton 1
+  # The client receives only the second migration. Since the client sends migrations in order, we're sure that we haven't seen migration 1
   ?\[proto\] recv: #SatOpLog\{.*#Migrate\{vsn: $migration2_vsn, for: bar
 
 [cleanup]

--- a/e2e/tests/03.09_fresh_node_satellite_receives_only_missing_migrations_during_initial_sync.lux
+++ b/e2e/tests/03.09_fresh_node_satellite_receives_only_missing_migrations_during_initial_sync.lux
@@ -25,7 +25,7 @@
 
 [shell satellite_1]
   # Make sure we don't receive a SatOpLog message with $migration1_vsn in it.
-  -"version":"$migration1_vsn"
+  -vsn: $migration1_vsn
 
   # The client has the first migration bundled.
 	?applying migration: $migration1_vsn
@@ -36,11 +36,8 @@
   ??[proto] send: #SatInStartReplicationReq{lsn: , schema: $migration1_vsn
   ??[proto] recv: #SatInStartReplicationResp{}
 
-  # The client receives only the second migration.
+  # The client receives only the second migration. Since the client sends migrations in order, we're sure that we haven't seen migraiton 1
   ?\[proto\] recv: #SatOpLog\{.*#Migrate\{vsn: $migration2_vsn, for: bar
-
-  # Wait for the ping message to make sure we don't receive anything mentioning $migration1_vsn from the server.
-  ??[proto] recv: #SatPingReq{}
 
 [cleanup]
   [invoke teardown]


### PR DESCRIPTION
Utilize ws-level ping/pong frames for heartbeat. We technically stop using protocol level ping/pong messages here, but they were not used anyway, and are fully removed in the next PR