### PR TITLE
chore(electric): Clean up the response returned from the Status API

### DIFF
--- a/components/electric/lib/electric/plug/status.ex
+++ b/components/electric/lib/electric/plug/status.ex
@@ -5,25 +5,20 @@ defmodule Electric.Plug.Status do
   use Plug.Router
   import Plug.Conn
 
-  plug(:match)
-  plug(:dispatch)
+  plug :match
+  plug :dispatch
 
   get "/" do
-    origins =
-      PostgresConnector.connectors()
-      |> Enum.map(fn origin ->
-        case PostgresConnectorMng.status(origin) do
-          :ready -> {origin, true}
-          :migration -> {origin, :migration}
-          _ -> {origin, false}
-        end
-      end)
+    [origin] = PostgresConnector.connectors()
 
-    data = %{
-      connectors: Map.new(origins)
-    }
+    msg =
+      if :ready == PostgresConnectorMng.status(origin) do
+        "Connection to Postgres is up!"
+      else
+        "Initializing connection to Postgres..."
+      end
 
-    send_resp(conn, 200, Jason.encode!(data))
+    send_resp(conn, 200, msg)
   end
 
   match _ do

--- a/e2e/tests/01.01_simple_startup.lux
+++ b/e2e/tests/01.01_simple_startup.lux
@@ -5,7 +5,7 @@
 
 [newshell electric_curl]
     !curl http://localhost:5133/api/status
-    ?{"connectors":{"postgres_1":true}}
+    ??Connection to Postgres is up!
 
 [cleanup]
     [invoke teardown]

--- a/examples/beer-stars/README.md
+++ b/examples/beer-stars/README.md
@@ -92,7 +92,7 @@ Another service is an Electric sync service running replication on port `5133`:
 
 ```shell
 $ curl http://localhost:5133/api/status
-{"connectors":{"postgres_1":true}}
+Connection to Postgres is up!
 ```
 
 Finally, the app backend that talks to GitHub's GraphQL API runs on port `40001`:


### PR DESCRIPTION
We should review the usage of connectors in the code base and refactor those bits of code now that we have a single connector. In this PR I'm only addressing the issue raised on Linear because it made sense to me to make the Status API return a human-readable explanation of the server's status.