### PR TITLE
chore(electric, docs): Update docs to mention supported data types

### DIFF
--- a/.changeset/moody-clouds-itch.md
+++ b/.changeset/moody-clouds-itch.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Remove int8 from the list of supported types supported in electrified tables.

--- a/components/electric/lib/electric/satellite/serialization.ex
+++ b/components/electric/lib/electric/satellite/serialization.ex
@@ -27,7 +27,7 @@ defmodule Electric.Satellite.Serialization do
       bool
       date
       float8
-      int2 int4 int8
+      int2 int4
       text
       time
       timestamp timestamptz

--- a/components/electric/test/electric/postgres/extension/ddl_capture_test.exs
+++ b/components/electric/test/electric/postgres/extension/ddl_capture_test.exs
@@ -15,8 +15,8 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "ALTER electrified TABLE is captured", fn conn ->
-    sql1 = "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
+    sql1 = "CREATE TABLE buttercup (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
+    sql2 = "CREATE TABLE daisy (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
     sql3 = "CALL electric.electrify('buttercup')"
     sql4 = "ALTER TABLE buttercup ADD COLUMN petal text;"
     sql5 = "ALTER TABLE daisy ADD COLUMN stem text, ADD COLUMN leaf text;"
@@ -32,10 +32,8 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "CREATE INDEX on electrified table is captured", fn conn ->
-    sql1 =
-      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
-
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql1 = "CREATE TABLE buttercup (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql2 = "CREATE TABLE daisy (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
     sql4 = "CREATE INDEX buttercup_value_idx ON buttercup (value);"
     sql5 = "CREATE INDEX daisy_value_idx ON daisy (value);"
@@ -51,10 +49,8 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "DROP INDEX on electrified table is captured", fn conn ->
-    sql1 =
-      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
-
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql1 = "CREATE TABLE buttercup (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql2 = "CREATE TABLE daisy (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
     sql4 = "CREATE INDEX buttercup_value_idx ON buttercup (value);"
     sql5 = "DROP INDEX buttercup_value_idx;"
@@ -74,10 +70,8 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "DROP electrified TABLE is rejected", fn conn ->
-    sql1 =
-      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
-
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql1 = "CREATE TABLE buttercup (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql2 = "CREATE TABLE daisy (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
 
     assert {:ok, []} = Extension.electrified_indexes(conn)
@@ -92,10 +86,8 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "ALTER electrified TABLE DROP COLUMN is rejected", fn conn ->
-    sql1 =
-      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
-
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql1 = "CREATE TABLE buttercup (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql2 = "CREATE TABLE daisy (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
 
     assert {:ok, []} = Extension.electrified_indexes(conn)
@@ -110,10 +102,8 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
   end
 
   test_tx "ALTER electrified TABLE RENAME COLUMN is rejected", fn conn ->
-    sql1 =
-      "CREATE TABLE buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
-
-    sql2 = "CREATE TABLE daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql1 = "CREATE TABLE buttercup (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
+    sql2 = "CREATE TABLE daisy (id int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, value text);"
     sql3 = "CALL electric.electrify('buttercup')"
 
     assert {:ok, []} = Extension.electrified_indexes(conn)

--- a/components/electric/test/electric/postgres/extension_test.exs
+++ b/components/electric/test/electric/postgres/extension_test.exs
@@ -401,8 +401,8 @@ defmodule Electric.Postgres.ExtensionTest do
     end
 
     test_tx "table electrification creates shadow tables", fn conn ->
-      sql1 = "CREATE TABLE public.buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
-      sql2 = "CREATE TABLE public.daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
+      sql1 = "CREATE TABLE public.buttercup (id int4 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
+      sql2 = "CREATE TABLE public.daisy (id int4 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
       sql3 = "CALL electric.electrify('buttercup')"
 
       for sql <- [sql1, sql2, sql3] do
@@ -434,8 +434,6 @@ defmodule Electric.Postgres.ExtensionTest do
                  num4a INT4,
                  num4b INT,
                  num4c INTEGER,
-                 num8a INT8,
-                 num8b BIGINT,
                  real8a FLOAT8,
                  real8b DOUBLE PRECISION,
                  ts TIMESTAMP,
@@ -459,6 +457,10 @@ defmodule Electric.Postgres.ExtensionTest do
                  c1 CHARACTER,
                  c2 CHARACTER(11),
                  c3 VARCHAR(11),
+                 num8a INT8,
+                 num8b BIGINT,
+                 real4a FLOAT4,
+                 real4b REAL,
                  created_at TIMETZ
                );
                CALL electric.electrify('public.t1');
@@ -470,14 +472,18 @@ defmodule Electric.Postgres.ExtensionTest do
                  "c1" character(1)
                  "c2" character(11)
                  "c3" character varying(11)
+                 "num8a" bigint
+                 "num8b" bigint
+                 "real4a" real
+                 "real4b" real
                  "created_at" time with time zone
                """
                |> String.trim()
     end
 
     test_tx "electrified?/2", fn conn ->
-      sql1 = "CREATE TABLE public.buttercup (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
-      sql2 = "CREATE TABLE public.daisy (id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
+      sql1 = "CREATE TABLE public.buttercup (id int4 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
+      sql2 = "CREATE TABLE public.daisy (id int4 GENERATED ALWAYS AS IDENTITY PRIMARY KEY);"
       sql3 = "CALL electric.electrify('buttercup')"
 
       for sql <- [sql1, sql2, sql3] do

--- a/components/electric/test/electric/satellite/ws_validations_test.exs
+++ b/components/electric/test/electric/satellite/ws_validations_test.exs
@@ -138,15 +138,16 @@ defmodule Electric.Satellite.WsValidationsTest do
         ctx.db,
         vsn,
         "public.foo",
-        "CREATE TABLE public.foo (id TEXT PRIMARY KEY, i2_1 SMALLINT, i2_2 INT2, i4_1 INTEGER, i4_2 INT4, i8_1 BIGINT, i8_2 INT8)"
+        "CREATE TABLE public.foo (id TEXT PRIMARY KEY, i2_1 SMALLINT, i2_2 INT2, i4_1 INTEGER, i4_2 INT4)"
+        # "CREATE TABLE public.foo (id TEXT PRIMARY KEY, i2_1 SMALLINT, i2_2 INT2, i4_1 INTEGER, i4_2 INT4, i8_1 BIGINT, i8_2 INT8)"
       )
 
     valid_records = [
       %{"id" => "1", "i2_1" => "1", "i2_2" => "-1"},
       %{"id" => "2", "i2_1" => "32767", "i2_2" => "-32768"},
       %{"id" => "3", "i4_1" => "+0", "i4_2" => "-0"},
-      %{"id" => "4", "i4_1" => "2147483647", "i4_2" => "-2147483648"},
-      %{"id" => "5", "i8_1" => "-9223372036854775808", "i8_2" => "+9223372036854775807"}
+      %{"id" => "4", "i4_1" => "2147483647", "i4_2" => "-2147483648"}
+      # %{"id" => "5", "i8_1" => "-9223372036854775808", "i8_2" => "+9223372036854775807"}
     ]
 
     within_replication_context(ctx, vsn, fn conn ->
@@ -163,9 +164,9 @@ defmodule Electric.Satellite.WsValidationsTest do
       %{"id" => "11", "i2_2" => "five"},
       %{"id" => "12", "i4_1" => "."},
       %{"id" => "13", "i4_2" => "-"},
-      %{"id" => "14", "i8_1" => "+"},
-      %{"id" => "15", "i8_2" => "0.0"},
-      %{"id" => "16", "i8_1" => "1_000"},
+      # %{"id" => "14", "i8_1" => "+"},
+      # %{"id" => "15", "i8_2" => "0.0"},
+      # %{"id" => "16", "i8_1" => "1_000"},
       %{"id" => "17", "i4_2" => "-1+5"},
       %{"id" => "18", "i4_1" => "0x33"},
       %{"id" => "19", "i2_2" => "0b101011"},

--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -21,21 +21,29 @@ You are responsible for ensuring the uniqueness of your primary keys. If you som
 
 ## Supported data types
 
+**Numeric**:
+
+- `smallint` / `int2`
+- `integer` / `int`/ `int4`
+- `double precision` / `float8`
+
 **Strings**:
 
+- `character varying` / `varchar` (without length specifier)
 - `text`
-- non-length-limited `varchar`
 
-**Numbers**:
+**Date and time**:
 
-- `smallint`
-- `integer`
-- `bigint`
-- `double precision`
+- `date`
+- `time` (without precision specifier)
+- `timestamp`, `timestamptz` (without precision specifier)
+
+**Other**:
+
+- `boolean`
+- `uuid`
 
 The authoritative list of supported data types is maintained in the [`supported_pg_types/0` function](https://github.com/search?q=repo%3Aelectric-sql%2Felectric+symbol%3Asupported_pg_types&type=code).
-
-<hr className="doc-divider" />
 
 :::caution Work in progress
 We are actively working on building out data type support. If you need a type we don't yet support, please [let us know on Discord](https://discord.electric-sql.com).

--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -24,7 +24,7 @@ You are responsible for ensuring the uniqueness of your primary keys. If you som
 **Numeric**:
 
 - `smallint` / `int2`
-- `integer` / `int`/ `int4`
+- `integer` / `int` / `int4`
 - `double precision` / `float8`
 
 **Strings**:


### PR DESCRIPTION
Here I'm also removing `int8` from the list of types accepted by the `electrify()` function since it's not handled correctly on the client.

Closes VAX-1034.