### PR TITLE
fix(electric): Fix the {:error, :relation_missing} error that regularly causes E2E tests to fail on CI

### DIFF
--- a/components/electric/lib/electric/postgres/extension/schema_cache.ex
+++ b/components/electric/lib/electric/postgres/extension/schema_cache.ex
@@ -217,7 +217,7 @@ defmodule Electric.Postgres.Extension.SchemaCache do
       internal_schema: nil
     }
 
-    {:ok, state, {:continue, :init}}
+    {:ok, state}
   end
 
   @impl GenServer
@@ -267,6 +267,7 @@ defmodule Electric.Postgres.Extension.SchemaCache do
   end
 
   def handle_call(:internal_schema, _from, state) do
+    state = load_internal_schema(state)
     {:reply, state.internal_schema, state}
   end
 
@@ -368,8 +369,12 @@ defmodule Electric.Postgres.Extension.SchemaCache do
     {:noreply, state}
   end
 
-  def handle_continue(:init, state) do
-    {:noreply, %{state | internal_schema: SchemaLoader.internal_schema(state.backend)}}
+  defp load_internal_schema(%{internal_schema: nil} = state) do
+    %{state | internal_schema: SchemaLoader.internal_schema(state.backend)}
+  end
+
+  defp load_internal_schema(state) do
+    state
   end
 
   defp current_schema(%{current: nil} = state) do

--- a/e2e/tests/04.01_electric_api_returns_migrations.lux
+++ b/e2e/tests/04.01_electric_api_returns_migrations.lux
@@ -28,8 +28,8 @@
     ?$psql
 
 [shell electric]
-    ?? [info] Applying migration $migration_version_1
-    ?? [info] Applying migration $migration_version_2
+    ?? [info] Saved schema version $migration_version_1
+    ?? [info] Saved schema version $migration_version_2
 
 
 [newshell developer]


### PR DESCRIPTION
At least with this change in place, I can no longer reproduce the error. Whereas before it would take me 2-3 runs to see it happen.

FIxes VAX-980.