### PR TITLE
feat(client): logs when encountering unhandled errors in Satellite

### DIFF
--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -639,7 +639,7 @@ export class SatelliteProcess implements Satellite {
       throw satelliteError
     }
 
-    Log.warn(`an error occurred in satellite: ${satelliteError.message}`);
+    Log.warn(`an error occurred in satellite: ${satelliteError.message}`)
 
     // all other errors are handled by closing the client (if not yet) and retrying
     this._connectivityStateChanged('disconnected').then(() =>

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -639,6 +639,8 @@ export class SatelliteProcess implements Satellite {
       throw satelliteError
     }
 
+    Log.warn(`an error occurred in satellite: ${satelliteError.message}`);
+
     // all other errors are handled by closing the client (if not yet) and retrying
     this._connectivityStateChanged('disconnected').then(() =>
       this._connectivityStateChanged('available')


### PR DESCRIPTION
While developing the Dart client we were having some trouble debugging an unhandled exception while decoding the new supported types (bool and date) because it was not being logged anywhere.
This unhandled exception was silent because this branch of the code doesn't throw, it just swallows the exception and disconnects the client.
I would propose to at least log a warning/error when we reach here. 
