### PR TITLE
fix: Update migrate_pg lux macro to actually wait for migration to finish

### DIFF
--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -107,7 +107,7 @@
     ?$psql
     [my old=$LUX_SHELLNAME]
     [shell electric]
-        ??[info] Applying migration $version
+        ??[info] Saved schema version $version
     [shell $old]
 [endmacro]
 


### PR DESCRIPTION
This is an attempt to reduce the flakiness of the E2E tests.
Sometimes the following exception is thrown in the electric service

![image](https://github.com/electric-sql/electric/assets/22084723/9ca1f935-d80c-46d1-923b-b874967a41f4)

It happens when calling the macro migrate_pg sequentially, like in the test 03.10

![image](https://github.com/electric-sql/electric/assets/22084723/d0d32585-5732-4737-96f3-f0345767ae68)

My guess by looking at the macro and the "Unable to retrieve oid for table" message is that Electric is looking at the migration before it has been applied. The macro only waits for the message `Applying migration $version`, but we could match `Saved schema version $version` to know when it finished.

https://github.com/electric-sql/electric/blob/cf4ee7c2344b2391e65cb6aa4e63314728776656/e2e/tests/_shared.luxinc#L110

I'm not experienced at all with lux, but we've been using it for the Dart client as well and we learned a few things :sweat_smile: 
I hope this small change makes it more robust.