### PR TITLE
fix(electric): Prevent creation of duplicate DDL commands in migration history

### DIFF
--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -247,7 +247,8 @@ defmodule Electric.Postgres.Extension do
       Migrations.Migration_20230424154425_DDLX,
       Migrations.Migration_20230512000000_conflict_resolution_triggers,
       Migrations.Migration_20230605141256_ElectrifyFunction,
-      Migrations.Migration_20230715000000_UtilitiesTable
+      Migrations.Migration_20230715000000_UtilitiesTable,
+      Migrations.Migration_20230918115714_DDLCommandUniqueConstraint
     ]
   end
 

--- a/components/electric/lib/electric/postgres/extension/migrations/20230918115714_add_unique_constraint_ddl_commands.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230918115714_add_unique_constraint_ddl_commands.ex
@@ -1,0 +1,50 @@
+defmodule Electric.Postgres.Extension.Migrations.Migration_20230918115714_DDLCommandUniqueConstraint do
+  alias Electric.Postgres.Extension
+
+  @behaviour Extension.Migration
+
+  @txid_type "xid8"
+
+  @impl true
+  def version, do: 2023_09_18_11_57_14
+
+  @impl true
+  def up(schema) do
+    ddl_table = Extension.ddl_table()
+
+    [
+      """
+      ALTER TABLE #{ddl_table}
+        ADD CONSTRAINT ddl_table_unique_migrations
+        UNIQUE (txid, txts ,version, query); 
+      """,
+      """
+      CREATE OR REPLACE FUNCTION #{schema}.create_active_migration(
+          _txid #{@txid_type},
+          _txts timestamptz,
+          _version text,
+          _query text DEFAULT NULL
+      ) RETURNS int8 AS
+      $function$
+      DECLARE
+          trid int8;
+      BEGIN
+          IF _query IS NULL THEN
+              _query := current_query();
+          END IF;
+          RAISE NOTICE 'capture migration: % => %', _version, _query;
+          INSERT INTO #{ddl_table} (txid, txts, version, query) VALUES
+                (_txid, _txts, _version, _query)
+              ON CONFLICT ON CONSTRAINT ddl_table_unique_migrations DO NOTHING
+              RETURNING id INTO trid;
+          RETURN trid;
+      END;
+      $function$
+      LANGUAGE PLPGSQL;
+      """
+    ]
+  end
+
+  @impl true
+  def down(_), do: []
+end


### PR DESCRIPTION
the alter table add column and the create index result in two invocations of the event trigger with the same query sql, resulting in duplicate entries in the ddl_history table and duplicate migrations streaming to the client.

this commit adds a unique constraint on the ddl_commands table and the insert sql has been updated to ignore violations of this constraint, so the duplicate ddl sql is just silently ignored