### PR TITLE
examples: add library version to scoped db names.

### DIFF
--- a/examples/introduction/src/electric.ts
+++ b/examples/introduction/src/electric.ts
@@ -1,3 +1,4 @@
+import { version } from 'electric-sql/package.json'
 import { makeElectricContext } from 'electric-sql/react'
 import { globalRegistry } from 'electric-sql/satellite'
 import { ElectricDatabase, electrify } from 'electric-sql/wa-sqlite'
@@ -22,9 +23,9 @@ export const { ElectricProvider, useElectric } = makeElectricContext<Electric>()
 
 export const initElectric = async (name: string = 'intro') => {
   const { tabId } = uniqueTabId()
-  const tabScopedDbName = `${name}-${tabId}.db`
+  const scopedDbName = `${name}-${version}-${tabId}.db`
 
-  const conn = await ElectricDatabase.init(tabScopedDbName, '/')
+  const conn = await ElectricDatabase.init(scopedDbName, '/')
 
   const config = {
     auth: {

--- a/examples/introduction/src/electric.ts
+++ b/examples/introduction/src/electric.ts
@@ -1,6 +1,6 @@
-import { version } from 'electric-sql/package.json'
 import { makeElectricContext } from 'electric-sql/react'
 import { globalRegistry } from 'electric-sql/satellite'
+import { LIB_VERSION } from 'electric-sql/version'
 import { ElectricDatabase, electrify } from 'electric-sql/wa-sqlite'
 import { ClientTables } from 'electric-sql/client/model'
 import { uniqueTabId } from 'electric-sql/util'
@@ -23,7 +23,7 @@ export const { ElectricProvider, useElectric } = makeElectricContext<Electric>()
 
 export const initElectric = async (name: string = 'intro') => {
   const { tabId } = uniqueTabId()
-  const scopedDbName = `${name}-${version}-${tabId}.db`
+  const scopedDbName = `${name}-${LIB_VERSION}-${tabId}.db`
 
   const conn = await ElectricDatabase.init(scopedDbName, '/')
 

--- a/examples/web-wa-sqlite/src/Example.tsx
+++ b/examples/web-wa-sqlite/src/Example.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
+import { version } from 'electric-sql/package.json'
 import { makeElectricContext, useLiveQuery } from 'electric-sql/react'
 import { genUUID, uniqueTabId } from 'electric-sql/util'
 import { ElectricDatabase, electrify } from 'electric-sql/wa-sqlite'
@@ -28,9 +29,9 @@ export const Example = () => {
       }
 
       const { tabId } = uniqueTabId()
-      const tabScopedDbName = `electric-${tabId}.db`
+      const scopedDbName = `electric-${version}-${tabId}.db`
 
-      const conn = await ElectricDatabase.init(tabScopedDbName, '')
+      const conn = await ElectricDatabase.init(scopedDbName, '')
       const electric = await electrify(conn, schema, config)
 
       if (!isMounted) {

--- a/examples/web-wa-sqlite/src/Example.tsx
+++ b/examples/web-wa-sqlite/src/Example.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-import { version } from 'electric-sql/package.json'
+import { LIB_VERSION } from 'electric-sql/version'
 import { makeElectricContext, useLiveQuery } from 'electric-sql/react'
 import { genUUID, uniqueTabId } from 'electric-sql/util'
 import { ElectricDatabase, electrify } from 'electric-sql/wa-sqlite'
@@ -29,7 +29,7 @@ export const Example = () => {
       }
 
       const { tabId } = uniqueTabId()
-      const scopedDbName = `electric-${version}-${tabId}.db`
+      const scopedDbName = `electric-${LIB_VERSION}-${tabId}.db`
 
       const conn = await ElectricDatabase.init(scopedDbName, '')
       const electric = await electrify(conn, schema, config)


### PR DESCRIPTION
This updates the web and intro examples to scope the local database name to the library version. The result is that users who previously had a local database with a previous library version will use a new database after the library is updated.

The intention is to prevent some local-db incompatibility bugs with users that return to the website.

Note that the implementation uses a json file import. Is there any potential compatibility issue with this?