### PR TITLE
feat: suffix slot name with db name

### DIFF
--- a/.changeset/gold-knives-dress.md
+++ b/.changeset/gold-knives-dress.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Suffix electric-created slot with db name to be able to run Electric per database on a single PostgreSQL instance

--- a/components/electric/lib/electric/plug/satellite_websocket_plug.ex
+++ b/components/electric/lib/electric/plug/satellite_websocket_plug.ex
@@ -18,7 +18,7 @@ defmodule Electric.Plug.SatelliteWebsocketPlug do
         &Electric.Replication.InitialSync.query_subscription_data/2
       end)
 
-  @currently_supported_versions ">= 0.6.0 and <= #{Electric.vsn()}"
+  @currently_supported_versions ">= 0.6.0 and <= #{%{Electric.vsn() | pre: []}}"
 
   def call(conn, handler_opts) do
     with {:ok, conn} <- check_if_valid_upgrade(conn),

--- a/components/electric/lib/electric/replication/connectors.ex
+++ b/components/electric/lib/electric/replication/connectors.ex
@@ -79,7 +79,7 @@ defmodule Electric.Replication.Connectors do
   @spec get_replication_opts(config()) :: replication_opts()
   def get_replication_opts(config) do
     origin = origin(config)
-    database_name = get_connection_opts(config).database
+    database_name = get_in(config, [:connection, :database]) || "test"
 
     config
     |> Keyword.fetch!(:replication)

--- a/components/electric/lib/electric/replication/connectors.ex
+++ b/components/electric/lib/electric/replication/connectors.ex
@@ -79,11 +79,12 @@ defmodule Electric.Replication.Connectors do
   @spec get_replication_opts(config()) :: replication_opts()
   def get_replication_opts(config) do
     origin = origin(config)
+    database_name = get_connection_opts(config).database
 
     config
     |> Keyword.fetch!(:replication)
     |> Map.new()
-    |> Map.put(:slot, Extension.slot_name())
+    |> Map.put(:slot, Extension.slot_name() <> "_#{database_name}")
     |> Map.put(:publication, Extension.publication_name())
     |> Map.put(:subscription, to_string(origin))
   end


### PR DESCRIPTION
This change allows running electric per db, since slots have to be instance-unique, not database-unique. This is not related to horizontally scaling Electrics against a single PG instance.