### PR TITLE
Fix migration version in the README

### DIFF
--- a/.changeset/good-cooks-watch.md
+++ b/.changeset/good-cooks-watch.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Relax the client-side migration version validation to allow an arbitrary suffix to follow the version itself.

--- a/clients/typescript/src/migrators/bundle.ts
+++ b/clients/typescript/src/migrators/bundle.ts
@@ -18,7 +18,7 @@ const DEFAULTS: MigratorOptions = {
   tableName: '_electric_migrations',
 }
 
-const VALID_VERSION_EXP = new RegExp('^[0-9_]+$')
+const VALID_VERSION_EXP = new RegExp('^[0-9_]+')
 
 export class BundleMigrator implements Migrator {
   adapter: DatabaseAdapter

--- a/components/electric/README.md
+++ b/components/electric/README.md
@@ -135,7 +135,7 @@ will reach the clients and be created there as well. For example:
 
 ```sql
 BEGIN;
-SELECT electric.migration_version('1_version');
+SELECT electric.migration_version('20230920_114900');
 CREATE TABLE public.mtable1 (id uuid PRIMARY KEY);
 CALL electric.electrify('public.mtable1');
 COMMIT;


### PR DESCRIPTION
As reported in the [#bug-reports channel in Discord](https://discord.com/channels/933657521581858818/1079688869852753981/1153973432497750108), we have a [client-side validation](https://github.com/electric-sql/electric/blob/5f44c1a54b06b4e851d695478a284440c9900309/clients/typescript/src/migrators/bundle.ts#L21) that only allows numbers and the underscore to be used in migration versions.

Here I'm also implementing the relaxation of the migration version validation that was proposed along with the bug report.