### PR TITLE
chore(electric): Mention extra_apps in mix.exs that are needed to run Observer

### DIFF
--- a/components/electric/config/runtime.dev.exs
+++ b/components/electric/config/runtime.dev.exs
@@ -2,6 +2,10 @@ import Config
 
 config :logger, level: :debug
 
+config :electric,
+  num_http_acceptors: 2,
+  num_pg_acceptors: 2
+
 auth_provider = System.get_env("AUTH_MODE", "secure") |> Electric.Satellite.Auth.build_provider!()
 config :electric, Electric.Satellite.Auth, provider: auth_provider
 

--- a/components/electric/config/runtime.exs
+++ b/components/electric/config/runtime.exs
@@ -11,6 +11,8 @@ default_log_level = "info"
 default_auth_mode = "secure"
 default_http_server_port = "5133"
 default_pg_server_port = "5433"
+default_num_http_acceptors = 100
+default_num_pg_acceptors = 5
 
 ###
 
@@ -65,7 +67,9 @@ config :electric,
   # Used in telemetry, and to identify the server to the client
   instance_id: System.get_env("ELECTRIC_INSTANCE_ID", Electric.Utils.uuid4()),
   http_port: System.get_env("HTTP_PORT", default_http_server_port) |> String.to_integer(),
-  pg_server_port: pg_server_port
+  pg_server_port: pg_server_port,
+  num_http_acceptors: default_num_http_acceptors,
+  num_pg_acceptors: default_num_pg_acceptors
 
 config :electric, Electric.Replication.Postgres,
   pg_client: Electric.Replication.Postgres.Client,

--- a/components/electric/lib/electric/application.ex
+++ b/components/electric/lib/electric/application.ex
@@ -14,7 +14,9 @@ defmodule Electric.Application do
       Electric.Satellite.ClientManager,
       Electric.Replication.Connectors,
       {ThousandIsland,
-       port: pg_server_port(), handler_module: Electric.Replication.Postgres.TcpServer}
+       port: pg_server_port(),
+       handler_module: Electric.Replication.Postgres.TcpServer,
+       num_acceptors: num_pg_acceptors()}
     ]
 
     children =
@@ -22,7 +24,10 @@ defmodule Electric.Application do
         unless Application.get_env(:electric, :disable_listeners, false) do
           [
             # Satellite websocket connections are served from this router
-            {Bandit, plug: Electric.Plug.Router, port: http_port()}
+            {Bandit,
+             plug: Electric.Plug.Router,
+             port: http_port(),
+             thousand_island_options: [num_acceptors: num_http_acceptors()]}
           ]
         else
           []
@@ -54,4 +59,7 @@ defmodule Electric.Application do
 
   defp http_port, do: Application.fetch_env!(:electric, :http_port)
   defp pg_server_port, do: Application.fetch_env!(:electric, :pg_server_port)
+
+  defp num_http_acceptors, do: Application.fetch_env!(:electric, :num_http_acceptors)
+  defp num_pg_acceptors, do: Application.fetch_env!(:electric, :num_pg_acceptors)
 end

--- a/components/electric/mix.exs
+++ b/components/electric/mix.exs
@@ -31,7 +31,7 @@ defmodule Electric.MixProject do
   def application do
     [
       mod: {Electric.Application, []},
-      extra_applications: [:logger, :os_mon]
+      extra_applications: [:logger, :os_mon, :runtime_tools, :wx, :observer]
     ]
   end
 


### PR DESCRIPTION
Regarding the num_acceptors configuration, I lowered the number of acceptors for the Postgres TCP server in `prod`. I also lowered the numbers for both Postgres and HTTP listeners in `dev` to make the Applications tab in Observer usable.