### PR TITLE
fix(docs): working prisma link

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -2,7 +2,7 @@
 
 > This directory is forked from https://github.com/chrishoermann/zod-prisma-types
 
-`zod-prisma-types` is a generator for [prisma](www.prisma.io) that generates [zod](https://github.com/colinhacks/zod) schemas from your prisma models. This includes schemas of models, enums, inputTypes, argTypes, filters and so on. It also provides options to write advanced zod validators directly in the prisma schema comments.
+`zod-prisma-types` is a generator for [prisma](https://www.prisma.io) that generates [zod](https://github.com/colinhacks/zod) schemas from your prisma models. This includes schemas of models, enums, inputTypes, argTypes, filters and so on. It also provides options to write advanced zod validators directly in the prisma schema comments.
 
 Since I'm maintaining the generator in my spare time consider buying me a coffee or sponsor me if you like the project. Thanks!
 


### PR DESCRIPTION
Link to https://www.prisma.io instead of https://github.com/electric-sql/electric/edit/main/generator/www.prisma.io.