### PR TITLE
fix (client): solve migration bug with indexes

### DIFF
--- a/.changeset/funny-terms-knock.md
+++ b/.changeset/funny-terms-knock.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Do not build triggers if table information is missing.

--- a/.changeset/funny-terms-knock.md
+++ b/.changeset/funny-terms-knock.md
@@ -2,4 +2,4 @@
 "electric-sql": patch
 ---
 
-Do not build triggers if table information is missing.
+Fix the bug where the client would crash/stop working/stop syncing if it received a migration containing a new index creation.

--- a/clients/typescript/src/migrators/builder.ts
+++ b/clients/typescript/src/migrators/builder.ts
@@ -1,5 +1,8 @@
 import * as z from 'zod'
-import { SatOpMigrate, SatOpMigrate_Table } from '../_generated/protocol/satellite'
+import {
+  SatOpMigrate,
+  SatOpMigrate_Table,
+} from '../_generated/protocol/satellite'
 import { base64, getProtocolVersion } from '../util'
 import { Migration } from './index'
 import { generateTriggersForTable } from '../satellite/process'
@@ -73,11 +76,11 @@ export function makeMigration(migration: MetaData): Migration {
   const statements = migration.ops
     .map((op) => op.stmts.map((stmt) => stmt.sql))
     .flat()
-  const tables = (migration.ops
-    .map((op) => op.table)
+  const tables = migration.ops
     // if the operation did not change any table
     // then ignore it as we don't have to build triggers for it
-    .filter((tbl) => tbl !== undefined) as Array<SatOpMigrate_Table>)
+    .filter((op) => op.table !== undefined)
+    .map((op) => op.table!)
     // remove duplicate tables
     .filter((tbl, idx, arr) => {
       return arr.findIndex((t) => t?.name === tbl?.name) === idx

--- a/clients/typescript/src/migrators/builder.ts
+++ b/clients/typescript/src/migrators/builder.ts
@@ -1,5 +1,5 @@
 import * as z from 'zod'
-import { SatOpMigrate } from '../_generated/protocol/satellite'
+import { SatOpMigrate, SatOpMigrate_Table } from '../_generated/protocol/satellite'
 import { base64, getProtocolVersion } from '../util'
 import { Migration } from './index'
 import { generateTriggersForTable } from '../satellite/process'
@@ -73,8 +73,11 @@ export function makeMigration(migration: MetaData): Migration {
   const statements = migration.ops
     .map((op) => op.stmts.map((stmt) => stmt.sql))
     .flat()
-  const tables = migration.ops
-    .map((op) => op.table!)
+  const tables = (migration.ops
+    .map((op) => op.table)
+    // if the operation did not change any table
+    // then ignore it as we don't have to build triggers for it
+    .filter((tbl) => tbl !== undefined) as Array<SatOpMigrate_Table>)
     // remove duplicate tables
     .filter((tbl, idx, arr) => {
       return arr.findIndex((t) => t?.name === tbl?.name) === idx

--- a/clients/typescript/src/migrators/builder.ts
+++ b/clients/typescript/src/migrators/builder.ts
@@ -1,8 +1,5 @@
 import * as z from 'zod'
-import {
-  SatOpMigrate,
-  SatOpMigrate_Table,
-} from '../_generated/protocol/satellite'
+import { SatOpMigrate } from '../_generated/protocol/satellite'
 import { base64, getProtocolVersion } from '../util'
 import { Migration } from './index'
 import { generateTriggersForTable } from '../satellite/process'

--- a/clients/typescript/test/migrators/builder.test.ts
+++ b/clients/typescript/test/migrators/builder.test.ts
@@ -124,7 +124,7 @@ test('generate index creation migration from meta data', (t) => {
             SatOpMigrate_Stmt.create({
               type: SatOpMigrate_Type.CREATE_INDEX,
               sql: 'CREATE INDEX idx_stars_username ON stars(username);',
-            })
+            }),
           ],
         })
       ),
@@ -134,12 +134,9 @@ test('generate index creation migration from meta data', (t) => {
   })
   const migration = makeMigration(metaData)
   t.assert(migration.version === migrationMetaData.version)
-  t.deepEqual(
-    migration.statements,
-    [
-      'CREATE INDEX idx_stars_username ON stars(username);',
-    ]
-  )
+  t.deepEqual(migration.statements, [
+    'CREATE INDEX idx_stars_username ON stars(username);',
+  ])
 })
 
 const migrationsFolder = path.join('./test/migrators/support/migrations')

--- a/clients/typescript/test/migrators/builder.test.ts
+++ b/clients/typescript/test/migrators/builder.test.ts
@@ -113,6 +113,35 @@ test('generate migration from meta data', (t) => {
   )
 })
 
+test('generate index creation migration from meta data', (t) => {
+  const metaData = parseMetadata({
+    format: 'SatOpMigrate',
+    ops: [
+      encodeSatOpMigrateMsg(
+        SatOpMigrate.fromPartial({
+          version: '20230613112725_814',
+          stmts: [
+            SatOpMigrate_Stmt.create({
+              type: SatOpMigrate_Type.CREATE_INDEX,
+              sql: 'CREATE INDEX idx_stars_username ON stars(username);',
+            })
+          ],
+        })
+      ),
+    ],
+    protocol_version: 'Electric.Satellite',
+    version: '20230613112725_814',
+  })
+  const migration = makeMigration(metaData)
+  t.assert(migration.version === migrationMetaData.version)
+  t.deepEqual(
+    migration.statements,
+    [
+      'CREATE INDEX idx_stars_username ON stars(username);',
+    ]
+  )
+})
+
 const migrationsFolder = path.join('./test/migrators/support/migrations')
 
 test('read migration meta data', async (t) => {


### PR DESCRIPTION
This PR solves the index bug described in #457.
The bug was caused by the client migration code which tried to build table triggers even if the table information is missing. The code was modified not to build any triggers if the table information is missing. The table information may be missing e.g. when only creating an index.