### PR TITLE
chore(electric): Remove the sending of the :lsn_ack message that nobody receives

### DIFF
--- a/components/electric/lib/electric/replication/postgres/migration_consumer.ex
+++ b/components/electric/lib/electric/replication/postgres/migration_consumer.ex
@@ -111,18 +111,6 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
         %{relation: relation} when is_ddl_relation(relation) ->
           true
 
-        %{relation: relation} = change when is_acked_client_lsn_relation(relation) ->
-          %{"client_id" => client_id, "lsn" => encoded_client_lsn} = change.record
-
-          with {:ok, client_pid} <- Electric.Satellite.ClientManager.fetch_client(client_id) do
-            client_lsn = Electric.Postgres.Bytea.from_postgres_hex(encoded_client_lsn)
-            send(client_pid, {:lsn_ack, client_lsn})
-            Logger.info("acknowledged lsn: #{inspect(client_lsn)} for #{client_id}")
-          end
-
-          Logger.debug("---- Filtering #{inspect(change)}")
-          false
-
         %{relation: relation} = change when is_extension_relation(relation) ->
           Logger.debug("---- Filtering #{inspect(change)}")
           false

--- a/components/electric/lib/electric/replication/postgres/migration_consumer.ex
+++ b/components/electric/lib/electric/replication/postgres/migration_consumer.ex
@@ -22,8 +22,7 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
 
   require Logger
 
-  import Electric.Postgres.Extension,
-    only: [is_ddl_relation: 1, is_acked_client_lsn_relation: 1, is_extension_relation: 1]
+  import Electric.Postgres.Extension, only: [is_ddl_relation: 1, is_extension_relation: 1]
 
   @spec name(Connectors.config()) :: Electric.reg_name()
   def name(conn_config) when is_list(conn_config) do


### PR DESCRIPTION
This is a leftover from the work done on VAX-911 (GitHub PR #386). It should have been removed during a rebase of the PR, since pings and acks had already been removed from main by then, see
https://github.com/electric-sql/electric/pull/408/files#diff-b0cea52cb9ec25d24558bed7297b456f66bd57a5080ef259d568bc3bffc05093L144-L149.