### PR TITLE
chore(electric): Move the definition of create_active_migration() out of migrations

### DIFF
--- a/components/electric/lib/electric/postgres/extension/functions.ex
+++ b/components/electric/lib/electric/postgres/extension/functions.ex
@@ -34,6 +34,12 @@ defmodule Electric.Postgres.Extension.Functions do
 
   @function_names function_names
 
+  # https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-PG-SNAPSHOT
+  # pg_current_xact_id() -> xid8
+  # The internal transaction ID type .. xid8 ... [id] a 64-bit type xid8 that
+  # does not wrap around during the life of an installation
+  @txid_type "xid8"
+
   @doc """
   Get a list of `{name, SQL}` pairs where the the SQL code contains the definition of a function (or multiple functions).
 
@@ -62,7 +68,9 @@ defmodule Electric.Postgres.Extension.Functions do
   # This map of assigns is the same for all function templates.
   defp assigns do
     %{
-      schema: Extension.schema()
+      schema: Extension.schema(),
+      ddl_table: Extension.ddl_table(),
+      txid_type: @txid_type
     }
   end
 end

--- a/components/electric/lib/electric/postgres/extension/functions/create_active_migration.sql.eex
+++ b/components/electric/lib/electric/postgres/extension/functions/create_active_migration.sql.eex
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION <%= @schema %>.create_active_migration(
+    _txid <%= @txid_type %>,
+    _txts timestamptz,
+    _version text,
+    _query text DEFAULT NULL
+) RETURNS int8 AS
+$function$
+DECLARE
+    trid int8;
+BEGIN
+    IF _query IS NULL THEN
+        _query := current_query();
+    END IF;
+    RAISE NOTICE 'capture migration: % => %', _version, _query;
+    INSERT INTO <%= @ddl_table %> (txid, txts, version, query) VALUES
+          (_txid, _txts, _version, _query)
+        ON CONFLICT ON CONSTRAINT ddl_table_unique_migrations DO NOTHING
+        RETURNING id INTO trid;
+    RETURN trid;
+END;
+$function$
+LANGUAGE PLPGSQL;

--- a/components/electric/lib/electric/postgres/extension/migrations/20230328113927_setup_extension.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230328113927_setup_extension.ex
@@ -113,6 +113,12 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20230328113927 do
       $function$ LANGUAGE PLPGSQL;
       """,
       ##################
+      # This function is overriden at Electric startup by a slightly modified defintion stored in
+      # `functions/create_active_migrations.sql.eex`. We're only keep the old version here so that the migration keeps
+      # working for new users.
+      #
+      # Once all function definitions are evaluated at Electric startup, as outlined in VAX-1016, we'll be able to
+      # remove this legacy one.
       """
       CREATE OR REPLACE FUNCTION #{schema}.create_active_migration(_txid #{@txid_type}, _txts timestamptz, _version text, _query text DEFAULT NULL) RETURNS int8 AS
       $function$
@@ -147,7 +153,7 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20230328113927 do
       ##################
       # this function is over-written by later versions
       """
-      CREATE OR REPLACE FUNCTION #{schema}.ddlx_command_end_handler() 
+      CREATE OR REPLACE FUNCTION #{schema}.ddlx_command_end_handler()
           RETURNS EVENT_TRIGGER AS $function$
       BEGIN
           NULL;
@@ -161,7 +167,7 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20230328113927 do
           EXECUTE FUNCTION #{schema}.ddlx_command_end_handler();
       """,
       """
-      CREATE PUBLICATION "#{publication_name}"; 
+      CREATE PUBLICATION "#{publication_name}";
       """,
       Extension.add_table_to_publication_sql(ddl_table)
     ]

--- a/components/electric/lib/electric/postgres/extension/migrations/20230918115714_add_unique_constraint_ddl_commands.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230918115714_add_unique_constraint_ddl_commands.ex
@@ -3,44 +3,18 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20230918115714_DDLCom
 
   @behaviour Extension.Migration
 
-  @txid_type "xid8"
-
   @impl true
   def version, do: 2023_09_18_11_57_14
 
   @impl true
-  def up(schema) do
+  def up(_schema) do
     ddl_table = Extension.ddl_table()
 
     [
       """
       ALTER TABLE #{ddl_table}
         ADD CONSTRAINT ddl_table_unique_migrations
-        UNIQUE (txid, txts ,version, query); 
-      """,
-      """
-      CREATE OR REPLACE FUNCTION #{schema}.create_active_migration(
-          _txid #{@txid_type},
-          _txts timestamptz,
-          _version text,
-          _query text DEFAULT NULL
-      ) RETURNS int8 AS
-      $function$
-      DECLARE
-          trid int8;
-      BEGIN
-          IF _query IS NULL THEN
-              _query := current_query();
-          END IF;
-          RAISE NOTICE 'capture migration: % => %', _version, _query;
-          INSERT INTO #{ddl_table} (txid, txts, version, query) VALUES
-                (_txid, _txts, _version, _query)
-              ON CONFLICT ON CONSTRAINT ddl_table_unique_migrations DO NOTHING
-              RETURNING id INTO trid;
-          RETURN trid;
-      END;
-      $function$
-      LANGUAGE PLPGSQL;
+        UNIQUE (txid, txts, version, query);
       """
     ]
   end


### PR DESCRIPTION
At least I think it was an accidental change when the updated version of the `create_active_migration()` function was introduced in https://github.com/electric-sql/electric/pull/439/files#diff-578136eb5d1250bc92bc4ccdde42fdeea6bed399bb1f22f4d621074813070932R35.