### PR TITLE
chore(electric): Use a PG connection pool instead of opening a new connection for every query

### DIFF
--- a/components/electric/lib/electric/application.ex
+++ b/components/electric/lib/electric/application.ex
@@ -1,10 +1,9 @@
 defmodule Electric.Application do
   @moduledoc false
 
-  alias Electric.Replication.Connectors
-  alias Electric.Replication.PostgresConnector
-
   use Application
+
+  alias Electric.Replication.PostgresConnector
 
   def start(_type, _args) do
     children = [
@@ -12,7 +11,7 @@ defmodule Electric.Application do
       Electric.Postgres.OidDatabase,
       Electric.Satellite.SubscriptionManager,
       Electric.Satellite.ClientManager,
-      Electric.Replication.Connectors,
+      {Electric.Replication.Connectors, pg_connectors()},
       {ThousandIsland,
        port: pg_server_port(), handler_module: Electric.Replication.Postgres.TcpServer}
     ]
@@ -28,30 +27,15 @@ defmodule Electric.Application do
           []
         end
 
-    opts = [strategy: :one_for_one, name: Electric.Supervisor]
-    {:ok, supervisor} = Supervisor.start_link(children, opts)
-
-    Application.get_env(:electric, Electric.Replication.Connectors, [])
-    |> Enum.each(fn {name, config} ->
-      Connectors.start_connector(
-        PostgresConnector,
-        Keyword.put(config, :origin, to_string(name))
-      )
-    end)
-
-    {:ok, supervisor}
-  end
-
-  def pg_connection_opts() do
-    # NOTE(alco): Intentionally making the assumption here that there's only a single connector configured.
-    # With Vaxine and multi-master PG replication going away, this is going to become the new reality soon.
-
-    case Application.get_env(:electric, Electric.Replication.Connectors, []) do
-      [{name, config}] -> Keyword.put(config, :origin, to_string(name))
-      [] -> raise "Electric isn't meant to be ran without a connection to PostgreSQL"
-    end
+    Supervisor.start_link(children, strategy: :one_for_one, name: Electric.Supervisor)
   end
 
   defp http_port, do: Application.fetch_env!(:electric, :http_port)
   defp pg_server_port, do: Application.fetch_env!(:electric, :pg_server_port)
+
+  defp pg_connectors do
+    for {name, config} <- Application.get_env(:electric, Electric.Replication.Connectors, []) do
+      {PostgresConnector, Keyword.put(config, :origin, to_string(name))}
+    end
+  end
 end

--- a/components/electric/lib/electric/plug/satellite_websocket_plug.ex
+++ b/components/electric/lib/electric/plug/satellite_websocket_plug.ex
@@ -6,17 +6,20 @@ defmodule Electric.Plug.SatelliteWebsocketPlug do
 
   def init(handler_opts), do: handler_opts
 
-  defp build_websocket_opts(base_opts, client_version),
-    do:
-      base_opts
-      |> Keyword.put(:client_version, client_version)
-      |> Keyword.put_new_lazy(:auth_provider, fn -> Electric.Satellite.Auth.provider() end)
-      |> Keyword.put_new_lazy(:pg_connector_opts, fn ->
-        Electric.Application.pg_connection_opts()
-      end)
-      |> Keyword.put_new_lazy(:subscription_data_fun, fn ->
-        &Electric.Replication.InitialSync.query_subscription_data/2
-      end)
+  # These options that are passed to WebsocketServer.init() eventually. We fetch them here because in the test env we
+  # start a dedicated Bandit listener intead of the standard one defined in the Application module. Passing test-only
+  # overrides as options to this Plug is the most straightforward approach with that setup.
+  defp build_websocket_opts(base_opts, client_version) do
+    base_opts
+    |> Keyword.put(:client_version, client_version)
+    |> Keyword.put_new_lazy(:auth_provider, fn -> Electric.Satellite.Auth.provider() end)
+    |> Keyword.put_new_lazy(:pg_connector_opts, fn ->
+      Electric.Application.pg_connection_opts()
+    end)
+    |> Keyword.put_new_lazy(:subscription_data_fun, fn ->
+      &Electric.Replication.InitialSync.query_subscription_data/2
+    end)
+  end
 
   @currently_supported_versions ">= 0.6.0 and <= #{%{Electric.vsn() | pre: []}}"
 

--- a/components/electric/lib/electric/plug/satellite_websocket_plug.ex
+++ b/components/electric/lib/electric/plug/satellite_websocket_plug.ex
@@ -12,10 +12,8 @@ defmodule Electric.Plug.SatelliteWebsocketPlug do
   defp build_websocket_opts(base_opts, client_version) do
     base_opts
     |> Keyword.put(:client_version, client_version)
-    |> Keyword.put_new_lazy(:auth_provider, fn -> Electric.Satellite.Auth.provider() end)
-    |> Keyword.put_new_lazy(:pg_connector_opts, fn ->
-      Electric.Application.pg_connection_opts()
-    end)
+    |> Keyword.put_new_lazy(:auth_provider, &Electric.Satellite.Auth.provider/0)
+    |> Keyword.put_new_lazy(:pg_connector_opts, &Electric.Replication.PostgresConnector.config/0)
     |> Keyword.put_new_lazy(:subscription_data_fun, fn ->
       &Electric.Replication.InitialSync.query_subscription_data/2
     end)

--- a/components/electric/lib/electric/postgres/connection_pool.ex
+++ b/components/electric/lib/electric/postgres/connection_pool.ex
@@ -32,11 +32,19 @@ defmodule Electric.Postgres.ConnectionPool do
     NimblePool.checkout!(
       pool,
       :checkout,
-      fn _pool, conn ->
-        {fun.(conn), :ok}
-      end,
+      fn _pool, conn -> {execute_fun_with_conn(fun, conn), :ok} end,
       @pool_timeout
     )
+  end
+
+  defp execute_fun_with_conn(fun, conn) do
+    try do
+      fun.(conn)
+    rescue
+      e ->
+        Logger.error(Exception.format(:error, e, __STACKTRACE__))
+        {:error, e}
+    end
   end
 
   @spec name(Connectors.origin()) :: Electric.reg_name()

--- a/components/electric/lib/electric/postgres/connection_pool.ex
+++ b/components/electric/lib/electric/postgres/connection_pool.ex
@@ -18,7 +18,7 @@ defmodule Electric.Postgres.ConnectionPool do
       worker: {__MODULE__, conn_config},
       # only connect when required, not immediately
       lazy: true,
-      pool_size: 4,
+      pool_size: 20,
       worker_idle_timeout: 30_000,
       name: name(Connectors.origin(conn_config))
     )

--- a/components/electric/lib/electric/postgres/connection_pool.ex
+++ b/components/electric/lib/electric/postgres/connection_pool.ex
@@ -1,0 +1,89 @@
+defmodule Electric.Postgres.ConnectionPool do
+  @moduledoc false
+
+  @behaviour NimblePool
+
+  alias Electric.Replication.Connectors
+
+  require Logger
+
+  @pool_timeout 5_000
+
+  def child_spec(conn_config) do
+    %{id: __MODULE__, start: {__MODULE__, :start_link, [conn_config]}}
+  end
+
+  def start_link(conn_config) do
+    NimblePool.start_link(
+      worker: {__MODULE__, conn_config},
+      # only connect when required, not immediately
+      lazy: true,
+      pool_size: 4,
+      worker_idle_timeout: 30_000,
+      name: name(Connectors.origin(conn_config))
+    )
+  end
+
+  def checkout!(origin, fun) when is_binary(origin) do
+    checkout!(name(origin), fun)
+  end
+
+  def checkout!(pool, fun) do
+    NimblePool.checkout!(
+      pool,
+      :checkout,
+      fn _pool, conn ->
+        {fun.(conn), :ok}
+      end,
+      @pool_timeout
+    )
+  end
+
+  @spec name(Connectors.origin()) :: Electric.reg_name()
+  def name(origin) when is_binary(origin) do
+    Electric.name(__MODULE__, origin)
+  end
+
+  ###
+
+  @impl NimblePool
+  def init_worker(conn_config) do
+    Logger.debug("Starting SchemaLoader pg connection: #{inspect(conn_config)}")
+    # NOTE: use `__connection__: conn` in tests to pass an existing connection
+    {:ok, conn} =
+      case Keyword.fetch(conn_config, :__connection__) do
+        {:ok, conn} ->
+          {:ok, conn}
+
+        :error ->
+          conn_config
+          |> Connectors.get_connection_opts(replication: false)
+          |> :epgsql.connect()
+      end
+
+    {:ok, conn, conn_config}
+  end
+
+  @impl NimblePool
+  # Transfer the port to the caller
+  def handle_checkout(:checkout, _from, conn, pool_state) do
+    {:ok, conn, conn, pool_state}
+  end
+
+  @impl NimblePool
+  def handle_checkin(:ok, _from, conn, pool_state) do
+    {:ok, conn, pool_state}
+  end
+
+  @impl NimblePool
+  def terminate_worker(_reason, conn, pool_state) do
+    Logger.debug("Terminating idle db connection #{inspect(conn)}")
+    :epgsql.close(conn)
+    {:ok, pool_state}
+  end
+
+  @impl NimblePool
+  def handle_ping(_conn, _pool_state) do
+    {:remove, :idle}
+  end
+end

--- a/components/electric/lib/electric/replication/postgres_connector.ex
+++ b/components/electric/lib/electric/replication/postgres_connector.ex
@@ -34,7 +34,10 @@ defmodule Electric.Replication.PostgresConnector do
     :ets.new(@ets_table, [:named_table])
     store_config(conn_config)
 
-    [{PostgresConnectorMng, conn_config}]
+    [
+      {Electric.Postgres.ConnectionPool, conn_config},
+      {PostgresConnectorMng, conn_config}
+    ]
     |> Supervisor.init(strategy: :one_for_all)
   end
 

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -5,7 +5,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
   alias Electric.Replication.Connectors
   alias Electric.Replication.Postgres
   alias Electric.Postgres.Extension.SchemaCache
-  alias Electric.Postgres.CachedWal
+  alias Electric.Postgres.{CachedWal, ConnectionPool}
   alias Electric.Replication.SatelliteCollectorProducer
 
   @spec start_link(Connectors.config()) :: :ignore | {:error, any} | {:ok, pid}
@@ -27,6 +27,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
     postgres_producer_consumer = Postgres.MigrationConsumer.name(origin)
 
     children = [
+      {ConnectionPool, conn_config},
       %{
         id: :postgres_schema_cache,
         start: {SchemaCache, :start_link, [conn_config]}

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -5,7 +5,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
   alias Electric.Replication.Connectors
   alias Electric.Replication.Postgres
   alias Electric.Postgres.Extension.SchemaCache
-  alias Electric.Postgres.{CachedWal, ConnectionPool}
+  alias Electric.Postgres.CachedWal
   alias Electric.Replication.SatelliteCollectorProducer
 
   @spec start_link(Connectors.config()) :: :ignore | {:error, any} | {:ok, pid}
@@ -27,7 +27,6 @@ defmodule Electric.Replication.PostgresConnectorSup do
     postgres_producer_consumer = Postgres.MigrationConsumer.name(origin)
 
     children = [
-      {ConnectionPool, conn_config},
       %{
         id: :postgres_schema_cache,
         start: {SchemaCache, :start_link, [conn_config]}

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -22,6 +22,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
   def init(conn_config) do
     origin = Connectors.origin(conn_config)
     Electric.reg(name(origin))
+
     postgres_producer = Postgres.LogicalReplicationProducer.get_name(origin)
     postgres_producer_consumer = Postgres.MigrationConsumer.name(origin)
 

--- a/components/electric/lib/electric/satellite/client_manager.ex
+++ b/components/electric/lib/electric/satellite/client_manager.ex
@@ -90,8 +90,7 @@ defmodule Electric.Satellite.ClientManager do
       nil ->
         {:ok, sup_pid} =
           Connectors.start_connector(
-            SatelliteConnector,
-            %{name: client_name, producer: reg_name}
+            {SatelliteConnector, %{name: client_name, producer: reg_name}}
           )
 
         client_ref = Process.monitor(client_pid)
@@ -165,11 +164,11 @@ defmodule Electric.Satellite.ClientManager do
     {{client_pid, ^sup_pid}, reverse} = Map.pop(state.reverse, client_name)
 
     case Connectors.start_connector(
-           SatelliteConnector,
-           %{
-             name: client_name,
-             producer: Electric.Satellite.WebsocketServer.reg_name(client_name)
-           }
+           {SatelliteConnector,
+            %{
+              name: client_name,
+              producer: Electric.Satellite.WebsocketServer.reg_name(client_name)
+            }}
          ) do
       {:ok, sup_pid1} ->
         resource_ref = Process.monitor(sup_pid)

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -54,6 +54,8 @@ defmodule Electric.Satellite.WebsocketServer do
      schedule_ping(%State{
        last_msg_time: :erlang.timestamp(),
        auth_provider: Keyword.fetch!(opts, :auth_provider),
+       # WebsocketServer is designed to work with a PostgresConnector. So it needs to access its connection options that
+       # include the origin field to be able to execute statements and run queries against the DB.
        pg_connector_opts: Keyword.fetch!(opts, :pg_connector_opts),
        subscription_data_fun: Keyword.fetch!(opts, :subscription_data_fun),
        telemetry: %Telemetry{

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -501,9 +501,9 @@ defmodule Electric.Satellite.WebsocketServer do
     defp maybe_pause(_), do: :ok
 
     def fetch_last_acked_client_lsn(state) do
-      state.pg_connector_opts
-      |> Electric.Replication.Connectors.get_connection_opts(replication: false)
-      |> Electric.Replication.Postgres.Client.with_conn(fn conn ->
+      origin = Electric.Replication.Connectors.origin(state.pg_connector_opts)
+
+      Electric.Postgres.ConnectionPool.checkout!(origin, fn conn ->
         Electric.Postgres.Extension.fetch_last_acked_client_lsn(conn, state.client_id)
       end)
     end

--- a/components/electric/test/electric/postgres/extension/schema_cache_test.exs
+++ b/components/electric/test/electric/postgres/extension/schema_cache_test.exs
@@ -45,6 +45,7 @@ defmodule Electric.Postgres.Extension.SchemaCacheTest do
   use Electric.Extension.Case, async: false
 
   alias Electric.Replication.Postgres
+  alias Electric.Postgres.ConnectionPool
   alias Electric.Postgres.Extension
   alias Electric.Postgres.Schema
   alias Electric.Postgres.Replication.{Column, Table}
@@ -88,7 +89,8 @@ defmodule Electric.Postgres.Extension.SchemaCacheTest do
       replication: []
     ]
 
-    {:ok, _pid} = start_supervised({Extension.SchemaCache, {conn_config, [producer: producer]}})
+    _pool = start_link_supervised!({ConnectionPool, conn_config})
+    {:ok, _pid} = start_supervised({Extension.SchemaCache, conn_config})
 
     {:ok, migration_consumer} =
       start_supervised(

--- a/components/electric/test/electric/replication/electrification_test.exs
+++ b/components/electric/test/electric/replication/electrification_test.exs
@@ -7,7 +7,7 @@ defmodule Electric.Replication.ElectrificationTest do
   alias Electric.Replication.Changes.{NewRecord, Transaction}
 
   @origin "electrification-test"
-  @sleep_timeout 5000
+  @sleep_timeout 1000
 
   setup ctx, do: Map.put(ctx, :origin, @origin)
   setup :setup_replicated_db

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -43,19 +43,16 @@ defmodule Electric.Satellite.WebsocketServerTest do
         fn {name, opts} -> &apply(__MODULE__, name, [&1, &2, opts]) end
       )
 
-    port = 55133
-
     plug =
       {Electric.Plug.SatelliteWebsocketPlug,
        auth_provider: Auth.provider(),
        pg_connector_opts: [origin: "fake_origin"],
        subscription_data_fun: ctx.subscription_data_fun}
 
+    port = 55133
     start_link_supervised!({Bandit, port: port, plug: plug})
 
-    server_id = Electric.instance_id()
-
-    {:ok, port: port, server_id: server_id}
+    {:ok, port: port, server_id: Electric.instance_id()}
   end
 
   setup_with_mocks([
@@ -101,12 +98,9 @@ defmodule Electric.Satellite.WebsocketServerTest do
 
   describe "resource related check" do
     test "Check that resources are create and removed accordingly", ctx do
-      with_connect(
-        [auth: ctx, port: ctx.port],
-        fn _conn ->
-          [{Electric.Replication.SatelliteConnector, _pid}] = connectors()
-        end
-      )
+      with_connect([auth: ctx, port: ctx.port], fn _conn ->
+        [{SatelliteConnector, _pid}] = connectors()
+      end)
 
       drain_active_resources(connectors())
       assert [] = connectors()
@@ -641,7 +635,7 @@ defmodule Electric.Satellite.WebsocketServerTest do
     :ok
   end
 
-  defp drain_active_resources([{Electric.Replication.SatelliteConnector, _} | _] = list) do
+  defp drain_active_resources([{SatelliteConnector, _} | _] = list) do
     drain_pids(list)
   end
 


### PR DESCRIPTION
Closes VAX-1035.

* [ ] Test error handling inside ConnectionPool: failing query, transaction rollback, transaction isolation level change, etc.
* [ ] Investigate the new kind of E2E test failures - https://github.com/electric-sql/electric/actions/runs/6323249430/job/17170446899?pr=500
* [ ] Investigate the new failures in ElectrificationTest that are caused by the initial call to `CachedWal.Api.current_position()` returning `nil`.