### PR TITLE
fix(examples/starter): Fix the issue where ConnectionPool would be disposed of after running the 1st migration

### DIFF
--- a/examples/starter/template/db/migrate.js
+++ b/examples/starter/template/db/migrate.js
@@ -14,7 +14,7 @@ const apply = async (fileName) => {
   const filePath = path.join(MIGRATIONS_DIR, fileName)
   console.log('Applying', filePath)
 
-  await db.tx(
+  db.tx(
     (tx) => tx.query(
       sql.file(filePath)
     )


### PR DESCRIPTION
Fixes VAX-1113.

@kevin-dp How can we unit-test this?