### PR TITLE
fix (generator): correctly capitalise table named model

### DIFF
--- a/.changeset/chilled-planes-attack.md
+++ b/.changeset/chilled-planes-attack.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix bug for table named "model"

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -309,7 +309,8 @@ export function doPascalCaseTableNames(lines: string[]): string[] {
   const replacements: Map<string, string> = new Map() // maps table names to their PascalCased model name
   const modelNameToDbName: Map<string, string> = new Map() // maps the PascalCased model names to their original table name
 
-  const getModelName = (ln: string) => ln.match(/^\s*model\s+(\w+)/)?.[1]
+  const modelRegex = /^\s*model\s+(\w+)\s*{/
+  const getModelName = (ln: string) => ln.match(modelRegex)?.[1]
 
   lines.forEach((ln, idx) => {
     const tableName = getModelName(ln)
@@ -320,7 +321,10 @@ export function doPascalCaseTableNames(lines: string[]): string[] {
         : capitaliseFirstLetter(tableName) // always capitalise first letter
 
       // Replace the model name on this line
-      const newLn = ln.replace(tableName, modelName)
+      //const newLn = ln.replace(tableName, modelName)
+      const newLn = ln.replace(modelRegex, (_, _tableName) => {
+        return `model ${modelName} {`
+      })
       lines[idx] = newLn
 
       replacements.set(tableName, modelName)

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -321,7 +321,6 @@ export function doPascalCaseTableNames(lines: string[]): string[] {
         : capitaliseFirstLetter(tableName) // always capitalise first letter
 
       // Replace the model name on this line
-      //const newLn = ln.replace(tableName, modelName)
       const newLn = ln.replace(modelRegex, (_, _tableName) => {
         return `model ${modelName} {`
       })

--- a/clients/typescript/test/cli/migrations/migrate.test.ts
+++ b/clients/typescript/test/cli/migrations/migrate.test.ts
@@ -112,6 +112,5 @@ test('migrator correctly PascalCases model names', (t) => {
   const newSchema = doPascalCaseTableNames(
     lowerCasePrismaSchema.split(/\r?\n/)
   ).join('\n')
-  console.log(expectedPrismaSchema)
   t.assert(newSchema === expectedPrismaSchema)
 })

--- a/clients/typescript/test/cli/migrations/migrate.test.ts
+++ b/clients/typescript/test/cli/migrations/migrate.test.ts
@@ -46,6 +46,10 @@ model user_profile {
   userId Int    @unique
   user   user?  @relation(fields: [userId], references: [id])
 }
+
+model model {
+  id Int @id
+}
 `
 
 const expectedPrismaSchema = `
@@ -97,11 +101,17 @@ model UserProfile {
   userId Int    @unique
   user   User?  @relation(fields: [userId], references: [id])
 }
+
+model Model {
+  @@map("model")
+  id Int @id
+}
 `
 
 test('migrator correctly PascalCases model names', (t) => {
   const newSchema = doPascalCaseTableNames(
     lowerCasePrismaSchema.split(/\r?\n/)
   ).join('\n')
+  console.log(expectedPrismaSchema)
   t.assert(newSchema === expectedPrismaSchema)
 })


### PR DESCRIPTION
This PR fixes the bug for a table named "model", described by a user on [Discord](https://discord.com/channels/933657521581858818/933657523049885698/1156342498453639260).
We were parsing the Prisma schema in order to capitalise model names but if the model name itself was "model" we would capitalise the "model" keyword instead of the model name "model". This is fixed by replacing the exact match in the string instead of replacing the first occurrence of the table name.

Also extended the unit test to check this case.