### PR TITLE
fix(satellite): clients overload the server on fatal errors 

### DIFF
--- a/.changeset/famous-cars-agree.md
+++ b/.changeset/famous-cars-agree.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+prevent reconnect loop of doom on fatal errors

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -1,6 +1,8 @@
-import { IBackOffOptions } from 'exponential-backoff'
 import { AuthConfig } from '../auth/index'
-import { satelliteDefaults } from '../satellite/config'
+import {
+  ConnectionBackoffOptions as ConnectionBackOffOptions,
+  satelliteDefaults,
+} from '../satellite/config'
 
 export interface ElectricConfig {
   auth: AuthConfig
@@ -29,7 +31,7 @@ export interface ElectricConfig {
   /**
    * Optional backoff options for connecting with Electric
    */
-  backoffOpts?: Omit<IBackOffOptions, 'retry'>
+  connectionBackOffOptions?: ConnectionBackOffOptions
 }
 
 export type HydratedConfig = {
@@ -40,7 +42,7 @@ export type HydratedConfig = {
     ssl: boolean
   }
   debug: boolean
-  backoffOpts: Omit<IBackOffOptions, 'retry'>
+  connectionBackOffOptions: ConnectionBackOffOptions
 }
 
 export type InternalElectricConfig = {
@@ -51,7 +53,7 @@ export type InternalElectricConfig = {
     ssl: boolean
   }
   debug?: boolean
-  backoffOpts?: Omit<IBackOffOptions, 'retry'>
+  connectionBackOffOptions?: ConnectionBackOffOptions
 }
 
 export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
@@ -76,12 +78,30 @@ export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
     ssl: sslEnabled,
   }
 
-  const backoffOpts = config.backoffOpts || satelliteDefaults.backoffOpts
+  const {
+    delayFirstAttempt,
+    jitter,
+    maxDelay,
+    numOfAttempts,
+    startingDelay,
+    timeMultiple,
+  } =
+    config.connectionBackOffOptions ??
+    satelliteDefaults.connectionBackOffOptions
+
+  const connectionBackOffOptions = {
+    delayFirstAttempt,
+    jitter,
+    maxDelay,
+    numOfAttempts,
+    startingDelay,
+    timeMultiple,
+  }
 
   return {
     auth,
     replication,
     debug,
-    backoffOpts,
+    connectionBackOffOptions,
   }
 }

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -1,4 +1,6 @@
+import { IBackOffOptions } from 'exponential-backoff'
 import { AuthConfig } from '../auth/index'
+import { satelliteDefaults } from '../satellite/config'
 
 export interface ElectricConfig {
   auth: AuthConfig
@@ -24,6 +26,10 @@ export interface ElectricConfig {
    * Defaults to `false`.
    */
   debug?: boolean
+  /**
+   * Optional backoff options for connecting with Electric
+   */
+  backoffOpts?: Omit<IBackOffOptions, 'retry'>
 }
 
 export type HydratedConfig = {
@@ -34,6 +40,7 @@ export type HydratedConfig = {
     ssl: boolean
   }
   debug: boolean
+  backoffOpts: Omit<IBackOffOptions, 'retry'>
 }
 
 export type InternalElectricConfig = {
@@ -44,6 +51,7 @@ export type InternalElectricConfig = {
     ssl: boolean
   }
   debug?: boolean
+  backoffOpts?: Omit<IBackOffOptions, 'retry'>
 }
 
 export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
@@ -68,9 +76,12 @@ export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
     ssl: sslEnabled,
   }
 
+  const backoffOpts = config.backoffOpts || satelliteDefaults.backoffOpts
+
   return {
     auth,
     replication,
     debug,
+    backoffOpts,
   }
 }

--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -43,7 +43,7 @@ export const satelliteDefaults: SatelliteOpts = {
   clearOnBehindWindow: true,
   connectionBackOffOptions: {
     delayFirstAttempt: false,
-    startingDelay: 0,
+    startingDelay: 1000,
     jitter: 'full',
     maxDelay: 10000,
     numOfAttempts: 50,

--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -1,3 +1,4 @@
+import { IBackOffOptions } from 'exponential-backoff'
 import { QualifiedTablename } from '../util/tablename'
 
 export interface SatelliteOpts {
@@ -18,6 +19,8 @@ export interface SatelliteOpts {
   minSnapshotWindow: number
   /** On reconnect, clear client's state if cannot catch up with Electric buffered WAL*/
   clearOnBehindWindow: boolean
+  /** Backoff options for connecting with Electric*/
+  backoffOpts: Omit<IBackOffOptions, 'retry'>
 }
 
 export interface SatelliteOverrides {
@@ -37,6 +40,14 @@ export const satelliteDefaults: SatelliteOpts = {
   pollingInterval: 2000,
   minSnapshotWindow: 40,
   clearOnBehindWindow: true,
+  backoffOpts: {
+    delayFirstAttempt: false,
+    startingDelay: 1000,
+    jitter: 'full',
+    maxDelay: 10000,
+    numOfAttempts: 50,
+    timeMultiple: 2,
+  },
 }
 
 export const satelliteClientDefaults = {

--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -1,6 +1,7 @@
 import { IBackOffOptions } from 'exponential-backoff'
 import { QualifiedTablename } from '../util/tablename'
 
+export type ConnectionBackoffOptions = Omit<IBackOffOptions, 'retry'>
 export interface SatelliteOpts {
   /** The database table where Satellite keeps its processing metadata. */
   metaTable: QualifiedTablename
@@ -20,7 +21,7 @@ export interface SatelliteOpts {
   /** On reconnect, clear client's state if cannot catch up with Electric buffered WAL*/
   clearOnBehindWindow: boolean
   /** Backoff options for connecting with Electric*/
-  backoffOpts: Omit<IBackOffOptions, 'retry'>
+  connectionBackOffOptions: ConnectionBackoffOptions
 }
 
 export interface SatelliteOverrides {
@@ -40,9 +41,9 @@ export const satelliteDefaults: SatelliteOpts = {
   pollingInterval: 2000,
   minSnapshotWindow: 40,
   clearOnBehindWindow: true,
-  backoffOpts: {
+  connectionBackOffOptions: {
     delayFirstAttempt: false,
-    startingDelay: 1000,
+    startingDelay: 0,
     jitter: 'full',
     maxDelay: 10000,
     numOfAttempts: 50,

--- a/clients/typescript/src/satellite/error.ts
+++ b/clients/typescript/src/satellite/error.ts
@@ -2,7 +2,7 @@ import { SatelliteError, SatelliteErrorCode } from '../util'
 import Log from 'loglevel'
 
 const fatalErrorDescription =
-  "Client can't connect with the server after a fatal error. This can happen due to divergence between local client and server. Use developer tools to clear the local database, or delete the database file. We're working on tools to allow recovering the state of the local database. Check the progess XXX"
+  "Client can't connect with the server after a fatal error. This can happen due to divergence between local client and server. Use developer tools to clear the local database, or delete the database file. We're working on tools to allow recovering the state of the local database."
 
 const throwErrors = [
   SatelliteErrorCode.INTERNAL,

--- a/clients/typescript/src/satellite/error.ts
+++ b/clients/typescript/src/satellite/error.ts
@@ -1,0 +1,46 @@
+import { SatelliteError, SatelliteErrorCode } from '../util'
+import Log from 'loglevel'
+
+const fatalErrorDescription =
+  "Client can't connect with the server after a fatal error. This can happen due to divergence between local client and server. Use developer tools to clear the local database, or delete the database file. We're working on tools to allow recovering the state of the local database. Check the progess XXX"
+
+const throwErrors = [
+  SatelliteErrorCode.INTERNAL,
+  SatelliteErrorCode.FATAL_ERROR,
+]
+
+const fatalErrors = [
+  SatelliteErrorCode.INVALID_REQUEST,
+  SatelliteErrorCode.UNKNOWN_SCHEMA_VSN,
+  SatelliteErrorCode.AUTH_REQUIRED,
+]
+
+const outOfSyncErrors = [
+  SatelliteErrorCode.INVALID_POSITION,
+  SatelliteErrorCode.BEHIND_WINDOW,
+  SatelliteErrorCode.SUBSCRIPTION_NOT_FOUND,
+]
+
+export function isThrowable(error: SatelliteError) {
+  return throwErrors.includes(error.code)
+}
+
+export function isFatal(error: SatelliteError) {
+  return fatalErrors.includes(error.code)
+}
+
+export function isOutOfSyncError(error: SatelliteError) {
+  return outOfSyncErrors.includes(error.code)
+}
+
+function logFatalErrorDescription() {
+  Log.error(fatalErrorDescription)
+}
+
+export function wrapFatalError(error: SatelliteError) {
+  logFatalErrorDescription()
+  return new SatelliteError(
+    SatelliteErrorCode.FATAL_ERROR,
+    `Fatal error: ${error.message}. Check log for more information`
+  )
+}

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -69,7 +69,7 @@ import {
   SubscribeResponse,
   SubscriptionData,
 } from './shapes/types'
-import { IBackOffOptions, backOff } from 'exponential-backoff'
+import { backOff } from 'exponential-backoff'
 import { chunkBy } from '../util'
 import { isFatal, isOutOfSyncError, isThrowable, wrapFatalError } from './error'
 
@@ -106,16 +106,6 @@ const connectRetryHandler: ConnectRetryHandler = (error) => {
     return false
   }
   return true
-}
-
-// default values are set to not overload the server
-const connectionRetryPolicy: Partial<IBackOffOptions> = {
-  delayFirstAttempt: true,
-  startingDelay: 1000,
-  jitter: 'full',
-  maxDelay: 10000,
-  numOfAttempts: 50,
-  timeMultiple: 2,
 }
 
 export class SatelliteProcess implements Satellite {
@@ -686,7 +676,7 @@ export class SatelliteProcess implements Satellite {
     }
 
     const opts = {
-      ...connectionRetryPolicy,
+      ...this.opts.backoffOpts,
       retry: this._connectRetryHandler,
     }
 

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -209,7 +209,7 @@ export class GlobalRegistry extends BaseRegistry {
 
     const satelliteOpts: SatelliteOpts = {
       ...satelliteDefaults,
-      backoffOpts: config.backoffOpts,
+      connectionBackOffOptions: config.connectionBackOffOptions,
     }
 
     const satellite = new SatelliteProcess(

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -7,6 +7,7 @@ import { DbName } from '../util/types'
 import { Satellite, Registry } from './index'
 import {
   SatelliteClientOpts,
+  SatelliteOpts,
   SatelliteOverrides,
   satelliteClientDefaults,
   satelliteDefaults,
@@ -205,13 +206,19 @@ export class GlobalRegistry extends BaseRegistry {
       notifier,
       satelliteClientOpts
     )
+
+    const satelliteOpts: SatelliteOpts = {
+      ...satelliteDefaults,
+      backoffOpts: config.backoffOpts,
+    }
+
     const satellite = new SatelliteProcess(
       dbName,
       adapter,
       migrator,
       notifier,
       client,
-      satelliteDefaults
+      satelliteOpts
     )
     await satellite.start(config.auth)
 

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -46,6 +46,7 @@ export enum SatelliteErrorCode {
   UNKNOWN_DATA_TYPE,
   SOCKET_ERROR,
   UNRECOGNIZED,
+  FATAL_ERROR,
 
   // auth errors
   AUTH_ERROR,
@@ -181,8 +182,4 @@ export enum ReplicationStatus {
 
 export type ErrorCallback = (error: SatelliteError) => void
 
-export type ConnectivityState =
-  | 'available'
-  | 'connected'
-  | 'disconnected'
-  | 'error'
+export type ConnectivityState = 'available' | 'connected' | 'disconnected'

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -229,6 +229,7 @@ test('starting and stopping the process works', async (t) => {
 
   const conn1 = await satellite.start(authState)
   await conn1.connectionPromise
+  await sleepAsync(opts.pollingInterval)
 
   // connect, 4th txn
   t.is(notifier.notifications.length, 6)
@@ -1261,7 +1262,7 @@ test('throw other replication errors', async (t) => {
   return Promise.all(
     [satellite['initializing']?.waitOn(), conn.connectionPromise].map((p) =>
       p?.catch((e: SatelliteError) => {
-        t.is(e.code, SatelliteErrorCode.FATAL_ERROR)
+        t.is(e.code, SatelliteErrorCode.INTERNAL)
       })
     )
   )

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1161,8 +1161,7 @@ test('get transactions from opLogEntries', async (t) => {
 })
 
 test('handling connectivity state change stops queueing operations', async (t) => {
-  const { runMigrations, dbName, satellite, adapter, authState, notifier } =
-    t.context
+  const { runMigrations, satellite, adapter, authState } = t.context
   await runMigrations()
   const conn = await satellite.start(authState)
   await conn.connectionPromise

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -70,8 +70,7 @@ test('setup starts a satellite process', async (t) => {
 test('start creates system tables', async (t) => {
   const { adapter, satellite, authState } = t.context
 
-  const conn = await satellite.start(authState)
-  await conn.connectionPromise
+  await satellite.start(authState)
 
   const sql = "select name from sqlite_master where type = 'table'"
   const rows = await adapter.query({ sql })
@@ -96,14 +95,12 @@ test('load metadata', async (t) => {
 test('set persistent client id', async (t) => {
   const { satellite, authState } = t.context
 
-  const conn = await satellite.start(authState)
-  await conn.connectionPromise
+  await satellite.start(authState)
   const clientId1 = satellite._authState!.clientId
   t.truthy(clientId1)
   await satellite.stop()
 
-  const conn1 = await satellite.start(authState)
-  await conn1.connectionPromise
+  await satellite.start(authState)
 
   const clientId2 = satellite._authState!.clientId
   t.truthy(clientId2)
@@ -1164,8 +1161,7 @@ test('get transactions from opLogEntries', async (t) => {
 test('handling connectivity state change stops queueing operations', async (t) => {
   const { runMigrations, satellite, adapter, authState } = t.context
   await runMigrations()
-  const conn = await satellite.start(authState)
-  await conn.connectionPromise
+  await satellite.start(authState)
 
   adapter.run({
     sql: `INSERT INTO parent(id, value, other) VALUES (1, 'local', 1)`,
@@ -1200,8 +1196,7 @@ test('garbage collection is triggered when transaction from the same origin is r
   const { satellite } = t.context
   const { runMigrations, adapter, authState } = t.context
   await runMigrations()
-  const conn = await satellite.start(authState)
-  await conn.connectionPromise
+  await satellite.start(authState)
 
   adapter.run({
     sql: `INSERT INTO parent(id, value, other) VALUES (1, 'local', 1);`,
@@ -1643,8 +1638,7 @@ test('a subscription request failure does not clear the manager state', async (t
 
 test("Garbage collecting the subscription doesn't generate oplog entries", async (t) => {
   const { adapter, runMigrations, satellite, authState } = t.context
-  const conn = await satellite.start(authState)
-  await conn.connectionPromise
+  await satellite.start(authState)
   await runMigrations()
   await adapter.run({ sql: `INSERT INTO parent(id) VALUES ('1'),('2')` })
   const ts = await satellite._performSnapshot()


### PR DESCRIPTION
Some errors would trigger a reconnect loop on the server. This patch modifies error handling for preventing the client from reconnecting in a loop on FATAL errors.

Initially, we thought about DROPping the database when FATAL errors occur, but I've decided not to do that as part of this patch. The main reason is that FATAL errors should not occur in production if not because of a bug or re-deploying the backend database without refreshing the client code. In both cases, using some recovery tool is a more sensible way of addressing any potential issues -- which we're currently working on.

Meanwhile, we point the user to the logs for learning how to address the issue and raise that a recovery tool is underway.

This patch additionally exposes the backoff configuration to the application through the Electrify config.

