### PR TITLE
chore(electric): Log failure reason when client fails to establish a WebSocket connection

### DIFF
--- a/components/electric/lib/electric/plug/satellite_websocket_plug.ex
+++ b/components/electric/lib/electric/plug/satellite_websocket_plug.ex
@@ -41,6 +41,7 @@ defmodule Electric.Plug.SatelliteWebsocketPlug do
       )
     else
       {:error, code, body} ->
+        Logger.debug("Clients WebSocket connection failed with reason: #{body}")
         send_resp(conn, code, body)
     end
   end


### PR DESCRIPTION
This should provide more useful debug logs than the current

    [info] Get /ws
    [info] Sent 400 in 153 us