### PR TITLE
chore(starter): Use docker psql

### DIFF
--- a/examples/expo/db/connect.js
+++ b/examples/expo/db/connect.js
@@ -1,3 +1,3 @@
 const { DATABASE_URL } = require('./util.js')
 const { spawn } = require('child_process')
-spawn(`psql ${DATABASE_URL}`, [], { cwd: __dirname, stdio: 'inherit', shell: true })
+spawn(`docker compose --file ../backend/compose/docker-compose.yaml exec  -it postgres psql -h localhost -U postgres`, [], { cwd: __dirname, stdio: 'inherit', shell: true })


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/532 

Uses postgres container's `psql` to connect to the db
![image](https://github.com/electric-sql/electric/assets/77761194/e525529d-c054-4355-8478-71f1f6eddca5)
