### PR TITLE
fix(starter): [VAX-1187] Modify db:psql to connect to PG via Docker container

### DIFF
--- a/.changeset/brave-ways-hide.md
+++ b/.changeset/brave-ways-hide.md
@@ -1,0 +1,7 @@
+---
+"create-electric-app": patch
+---
+
+Update the `db:psql` script to connect to the database using `psql` running inside of the postgres container.
+
+This lifts the requirement of having a Postgres client installed on the host OS.

--- a/examples/starter/template/backend/startCompose.js
+++ b/examples/starter/template/backend/startCompose.js
@@ -1,19 +1,16 @@
-const shell = require('shelljs')
-const path = require('path')
+const { dockerCompose } = require('../util/util.js')
+const process = require('process')
 
-const envrcFile = path.join(__dirname, 'compose', '.envrc')
-const composeFile = path.join(__dirname, 'compose', 'docker-compose.yaml')
+const cliArguments = process.argv.slice(2)
 
-const cliArguments = process.argv.slice(2).join(' ')
-
-const res = shell.exec(`docker compose --env-file ${envrcFile} -f ${composeFile} up ${cliArguments}`)
-
-if (res.code !== 0 && res.stderr.includes('port is already allocated')) {
-  // inform the user that they should change ports
-  console.error(
-    '\x1b[31m',
-    'Could not start Electric because the port seems to be taken.\n' +
-    'To run Electric on another port execute `yarn ports:configure`',
-    '\x1b[0m'
-  )
-}
+dockerCompose('up', cliArguments, (code) => {
+  if (code !== 0) {
+    console.error(
+      '\x1b[31m',
+      'Failed to start the Electric backend. Check the output from `docker compose` above.\n' +
+      'If the error message mentions a port already being allocated or address being already in use,\n' +
+      'execute `yarn ports:configure` to run Electric on another port.',
+      '\x1b[0m'
+    )
+  }
+})

--- a/examples/starter/template/db/connect.js
+++ b/examples/starter/template/db/connect.js
@@ -1,6 +1,6 @@
 const { dockerCompose } = require('../util/util.js')
-const { PUBLIC_DATABASE_URL } = require('./util.js')
+const { DATABASE_NAME, PUBLIC_DATABASE_URL } = require('./util.js')
 
 console.info(`Connecting to postgres at ${PUBLIC_DATABASE_URL}`)
 
-dockerCompose('exec', ['-it', 'postgres', 'psql', '-U', 'postgres'])
+dockerCompose('exec', ['-it', 'postgres', 'psql', '-U', 'postgres', DATABASE_NAME])

--- a/examples/starter/template/db/connect.js
+++ b/examples/starter/template/db/connect.js
@@ -1,6 +1,6 @@
-const { DATABASE_URL, PUBLIC_DATABASE_URL } = require('./util.js')
-const { spawn } = require('child_process')
+const { dockerCompose } = require('../util/util.js')
+const { PUBLIC_DATABASE_URL } = require('./util.js')
 
 console.info(`Connecting to postgres at ${PUBLIC_DATABASE_URL}`)
 
-spawn("psql", [DATABASE_URL], { cwd: __dirname, stdio: 'inherit' })
+dockerCompose('exec', ['-it', 'postgres', 'psql', '-U', 'postgres'])

--- a/examples/starter/template/db/util.js
+++ b/examples/starter/template/db/util.js
@@ -14,6 +14,9 @@ const DEFAULT_URL = `postgresql://postgres:password@localhost:${pgPort}/${appNam
 const DATABASE_URL = process.env.DATABASE_URL || DEFAULT_URL
 const PUBLIC_DATABASE_URL = DATABASE_URL.split('@')[1]
 
+const urlComponents = DATABASE_URL.split('/')
+const DATABASE_NAME = urlComponents[urlComponents.length-1]
+
 function error(err) {
   console.error('\x1b[31m', err, '\x1b[0m')
   process.exit(1)
@@ -65,4 +68,5 @@ function fetchAppName() {
 
 exports.DATABASE_URL = DATABASE_URL
 exports.PUBLIC_DATABASE_URL = PUBLIC_DATABASE_URL
+exports.DATABASE_NAME = DATABASE_NAME
 exports.fetchHostPortElectric = fetchHostPortElectric

--- a/examples/starter/template/util/util.js
+++ b/examples/starter/template/util/util.js
@@ -1,5 +1,7 @@
-const path = require('path')
 const fs = require('fs/promises')
+const path = require('path')
+const { spawn } = require('child_process')
+const process = require('process')
 
 async function findFirstMatchInFile(regex, file, notFoundError) {
   const content = await fs.readFile(file, 'utf8')
@@ -18,5 +20,15 @@ async function fetchConfiguredElectricPort() {
   return Number.parseInt(port)
 }
 
+const envrcFile = path.join(__dirname, '../backend/compose/.envrc')
+const composeFile = path.join(__dirname, '../backend/compose/docker-compose.yaml')
+
+function dockerCompose(command, userArgs, callback) {
+  const args = ['compose', '--ansi', 'always', '--env-file', envrcFile, '-f',  composeFile, command, ...userArgs]
+  const proc = spawn('docker', args, {stdio: 'inherit'})
+  if (callback) { proc.on('exit', callback) }
+}
+
 exports.findFirstMatchInFile = findFirstMatchInFile
 exports.fetchConfiguredElectricPort = fetchConfiguredElectricPort
+exports.dockerCompose = dockerCompose


### PR DESCRIPTION
I've defined a utility function to run `docker compose` without shelljs, and used that for both `backend/startCompose.js` and `db/connect.js`.

The benefit is that we get output coloring back.

The drawback is inability to capture the output and inspect it for error messages. But the current code that's supposed to find the port reuse error in the output already does not work as expected on Linux because the error message printed there is `address already in use`.