### PR TITLE
chore(satellite): VAX-1208: improve client events type safety

### DIFF
--- a/.changeset/curvy-bobcats-walk.md
+++ b/.changeset/curvy-bobcats-walk.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Improved client events type safety

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -125,6 +125,8 @@ interface SafeEventEmitter {
   removeListener(event: 'outbound_started', callback: () => void): void
   // TODO: missing removeListeners
 
+  removeAllListeners(): void
+
   listenerCount(event: 'error'): number
 }
 
@@ -151,6 +153,7 @@ export class SatelliteClient implements Client {
   private allowedMutexedRpcResponses: Array<keyof Root> = []
 
   private dbDescription: DbSchema<any>
+  private isDown: boolean = false
 
   private handlerForMessageType: { [k: string]: IncomingHandler } =
     Object.fromEntries(
@@ -216,15 +219,21 @@ export class SatelliteClient implements Client {
   }
 
   async connect(): Promise<void> {
-    if (!this.isClosed()) {
-      this.close()
+    if (this.isDown) {
+      throw new SatelliteError(
+        SatelliteErrorCode.UNEXPECTED_STATE,
+        'client has already shutdown'
+      )
+    }
+    if (!this.isDisconnected()) {
+      this.disconnect()
     }
 
     return new Promise<void>((resolve, reject) => {
       this.socket = new this.socketFactory(PROTOCOL_VSN)
 
       const onceError = (error: Error) => {
-        this.close()
+        this.disconnect()
         reject(error)
       }
 
@@ -241,7 +250,7 @@ export class SatelliteClient implements Client {
         this.socket.onMessage(this.socketHandler)
         this.socket.onError((error) => {
           if (this.emitter.listenerCount('error') === 0) {
-            this.close()
+            this.disconnect()
             Log.error(
               `socket error but no listener is attached: ${error.message}`
             )
@@ -249,7 +258,7 @@ export class SatelliteClient implements Client {
           this.emitter.emit('error', error)
         })
         this.socket.onClose(() => {
-          this.close()
+          this.disconnect()
           if (this.emitter.listenerCount('error') === 0) {
             Log.error(`socket closed but no listener is attached`)
           }
@@ -271,7 +280,7 @@ export class SatelliteClient implements Client {
     })
   }
 
-  close() {
+  disconnect() {
     this.outbound = this.resetReplication(this.outbound.last_lsn)
     this.inbound = this.resetReplication(this.inbound.last_lsn)
 
@@ -283,8 +292,14 @@ export class SatelliteClient implements Client {
     }
   }
 
-  isClosed(): boolean {
+  isDisconnected(): boolean {
     return !this.socketHandler
+  }
+
+  shutdown(): void {
+    this.disconnect()
+    this.emitter.removeAllListeners()
+    this.isDown = true
   }
 
   async startReplication(
@@ -978,7 +993,7 @@ export class SatelliteClient implements Client {
 
   private sendMessage<T extends SatPbMsg>(request: T) {
     if (Log.getLevel() <= 1) Log.debug(`[proto] send: ${msgToString(request)}`)
-    if (!this.socket || this.isClosed()) {
+    if (!this.socket || this.isDisconnected()) {
       throw new SatelliteError(
         SatelliteErrorCode.UNEXPECTED_STATE,
         'trying to send message, but client is closed'

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -219,7 +219,7 @@ export class SatelliteClient implements Client {
     }
   }
 
-  async connect(): Promise<void> {
+  connect(): Promise<void> {
     if (this.isDown) {
       throw new SatelliteError(
         SatelliteErrorCode.UNEXPECTED_STATE,
@@ -294,7 +294,7 @@ export class SatelliteClient implements Client {
   }
 
   isConnected(): boolean {
-    return this.socketHandler !== undefined
+    return !!this.socketHandler
   }
 
   shutdown(): void {
@@ -303,7 +303,7 @@ export class SatelliteClient implements Client {
     this.isDown = true
   }
 
-  async startReplication(
+  startReplication(
     lsn?: LSN,
     schemaVersion?: string,
     subscriptionIds?: string[]
@@ -380,8 +380,9 @@ export class SatelliteClient implements Client {
   }
 
   subscribeToTransactions(callback: TransactionCallback) {
-    this.emitter.on('transaction', (txn, ackCb) => {
-      callback(txn).then(() => ackCb())
+    this.emitter.on('transaction', async (txn, ackCb) => {
+      await callback(txn)
+      ackCb()
     })
   }
 

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -225,7 +225,7 @@ export class SatelliteClient implements Client {
         'client has already shutdown'
       )
     }
-    if (!this.isDisconnected()) {
+    if (this.isConnected()) {
       this.disconnect()
     }
 
@@ -292,8 +292,8 @@ export class SatelliteClient implements Client {
     }
   }
 
-  isDisconnected(): boolean {
-    return !this.socketHandler
+  isConnected(): boolean {
+    return this.socketHandler !== undefined
   }
 
   shutdown(): void {
@@ -993,7 +993,7 @@ export class SatelliteClient implements Client {
 
   private sendMessage<T extends SatPbMsg>(request: T) {
     if (Log.getLevel() <= 1) Log.debug(`[proto] send: ${msgToString(request)}`)
-    if (!this.socket || this.isDisconnected()) {
+    if (!this.socket || !this.isConnected()) {
       throw new SatelliteError(
         SatelliteErrorCode.UNEXPECTED_STATE,
         'trying to send message, but client is closed'

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -156,7 +156,7 @@ export class SatelliteClient implements Client {
   private allowedMutexedRpcResponses: Array<keyof Root> = []
 
   private dbDescription: DbSchema<any>
-  private isDown: boolean = false
+  private isDown = false
 
   private handlerForMessageType: { [k: string]: IncomingHandler } =
     Object.fromEntries(

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -75,7 +75,6 @@ import {
 } from '../util/common'
 import { Client } from '.'
 import { SatelliteClientOpts, satelliteClientDefaults } from './config'
-import { Notifier } from '../notifiers'
 import Log from 'loglevel'
 import { AuthState } from '../auth'
 import isequal from 'lodash.isequal'
@@ -177,10 +176,8 @@ export class SatelliteClient implements Client {
   }
 
   constructor(
-    _dbName: string,
     dbDescription: DbSchema<any>,
     socketFactory: SocketFactory,
-    _notifier: Notifier,
     opts: SatelliteClientOpts
   ) {
     this.emitter = new EventEmitter() as SafeEventEmitter

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -121,8 +121,12 @@ interface SafeEventEmitter {
   emit(event: 'outbound_started', lsn: LSN): boolean
 
   removeListener(event: 'error', callback: ErrorCallback): void
-  removeListener(event: 'outbound_started', callback: () => void): void
-  // TODO: missing removeListeners
+  removeListener(event: 'relation', callback: RelationCallback): void
+  removeListener(event: 'transaction', callback: TransactionCallback): void
+  removeListener(
+    event: 'outbound_started',
+    callback: OutboundStartedCallback
+  ): void
 
   removeAllListeners(): void
 
@@ -381,8 +385,16 @@ export class SatelliteClient implements Client {
     })
   }
 
+  unsubscribeToTransactions(callback: TransactionCallback) {
+    this.emitter.removeListener('transaction', callback)
+  }
+
   subscribeToRelations(callback: RelationCallback) {
     this.emitter.on('relation', callback)
+  }
+
+  unsubscribeToRelations(callback: RelationCallback) {
+    this.emitter.removeListener('relation', callback)
   }
 
   enqueueTransaction(transaction: DataTransaction): void {
@@ -425,11 +437,11 @@ export class SatelliteClient implements Client {
     this.emitter.removeListener('error', callback)
   }
 
-  subscribeToOutboundEvent(_event: 'started', callback: () => void): void {
+  subscribeToOutboundStarted(callback: OutboundStartedCallback): void {
     this.emitter.on('outbound_started', callback)
   }
 
-  unsubscribeToOutboundEvent(_event: 'started', callback: () => void) {
+  unsubscribeToOutboundStarted(callback: OutboundStartedCallback) {
     this.emitter.removeListener('outbound_started', callback)
   }
 

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -63,7 +63,7 @@ export interface Satellite {
   connectivityState?: ConnectivityState
 
   start(authConfig: AuthConfig): Promise<ConnectionWrapper>
-  stop(): Promise<void>
+  stop(shutdown: boolean): Promise<void>
   subscribe(
     shapeDefinitions: ClientShapeDefinition[]
   ): Promise<ShapeSubscription>
@@ -72,9 +72,10 @@ export interface Satellite {
 
 export interface Client {
   connect(): Promise<void>
-  close(): void
+  disconnect(): void
+  shutdown(): void
   authenticate(authState: AuthState): Promise<AuthResponse>
-  isClosed(): boolean
+  isDisconnected(): boolean
   startReplication(
     lsn?: LSN,
     schemaVersion?: string,

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -75,7 +75,7 @@ export interface Client {
   disconnect(): void
   shutdown(): void
   authenticate(authState: AuthState): Promise<AuthResponse>
-  isDisconnected(): boolean
+  isConnected(): boolean
   startReplication(
     lsn?: LSN,
     schemaVersion?: string,

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -10,11 +10,12 @@ import {
   DbName,
   LSN,
   DataTransaction,
-  Transaction,
-  Relation,
   StartReplicationResponse,
   StopReplicationResponse,
   ErrorCallback,
+  TransactionCallback,
+  RelationCallback,
+  OutboundStartedCallback,
 } from '../util/types'
 import {
   ClientShapeDefinition,
@@ -82,22 +83,19 @@ export interface Client {
     subscriptionIds?: string[]
   ): Promise<StartReplicationResponse>
   stopReplication(): Promise<StopReplicationResponse>
-  subscribeToRelations(callback: (relation: Relation) => void): void
-  subscribeToTransactions(
-    callback: (transaction: Transaction) => Promise<void>
-  ): void
+  subscribeToRelations(callback: RelationCallback): void
+  unsubscribeToRelations(callback: RelationCallback): void
+  subscribeToTransactions(callback: TransactionCallback): void
+  unsubscribeToTransactions(callback: TransactionCallback): void
   enqueueTransaction(transaction: DataTransaction): void
   getLastSentLsn(): LSN
-  subscribeToOutboundEvent(event: 'started', callback: () => void): void
-  unsubscribeToOutboundEvent(event: 'started', callback: () => void): void
+  subscribeToOutboundStarted(callback: OutboundStartedCallback): void
+  unsubscribeToOutboundStarted(callback: OutboundStartedCallback): void
   subscribeToError(callback: ErrorCallback): void
   unsubscribeToError(callback: ErrorCallback): void
 
   subscribe(subId: string, shapes: ShapeRequest[]): Promise<SubscribeResponse>
   unsubscribe(subIds: string[]): Promise<UnsubscribeResponse>
-
-  // TODO: there is currently no way of unsubscribing from the server
-  // unsubscribe(subscriptionId: string): Promise<void>
 
   subscribeToSubscriptionEvents(
     successCallback: SubscriptionDeliveredCallback,

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -64,7 +64,7 @@ export interface Satellite {
   connectivityState?: ConnectivityState
 
   start(authConfig: AuthConfig): Promise<ConnectionWrapper>
-  stop(shutdown: boolean): Promise<void>
+  stop(shutdown?: boolean): Promise<void>
   subscribe(
     shapeDefinitions: ClientShapeDefinition[]
   ): Promise<ShapeSubscription>

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -256,8 +256,8 @@ export class MockSatelliteClient extends EventEmitter implements Client {
     this.removeListener('error', cb)
   }
 
-  isDisconnected(): boolean {
-    return this.disconnected
+  isConnected(): boolean {
+    return !this.disconnected
   }
 
   shutdown(): void {

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -9,13 +9,14 @@ import {
   LSN,
   SatelliteError,
   DataTransaction,
-  Transaction,
   Relation,
   SatelliteErrorCode,
   RelationsCache,
   Record as DataRecord,
   StartReplicationResponse,
   StopReplicationResponse,
+  OutboundStartedCallback,
+  TransactionCallback,
 } from '../util/types'
 import { ElectricConfig } from '../config/index'
 
@@ -148,7 +149,7 @@ export class MockSatelliteClient extends EventEmitter implements Client {
 
   relations: RelationsCache = {}
   relationsCb?: (relation: Relation) => void
-  transactionsCb?: (tx: Transaction) => void
+  transactionsCb?: TransactionCallback
 
   relationData: Record<string, DataRecord[]> = {}
 
@@ -156,12 +157,6 @@ export class MockSatelliteClient extends EventEmitter implements Client {
     this.relations = relations
     if (this.relationsCb) {
       Object.values(relations).forEach(this.relationsCb)
-    }
-  }
-
-  setTransactions(transactions: Transaction[]): void {
-    if (this.transactionsCb) {
-      transactions.forEach(this.transactionsCb)
     }
   }
 
@@ -322,21 +317,28 @@ export class MockSatelliteClient extends EventEmitter implements Client {
     this.relationsCb = callback
   }
 
-  subscribeToTransactions(
-    callback: (transaction: Transaction) => Promise<void>
-  ): void {
+  unsubscribeToRelations(): void {
+    this.relationsCb = undefined
+  }
+
+  subscribeToTransactions(callback: TransactionCallback): void {
     this.transactionsCb = callback
+  }
+
+  unsubscribeToTransactions(): void {
+    throw new Error('Method not implemented.')
   }
 
   enqueueTransaction(transaction: DataTransaction): void {
     this.outboundSent = transaction.lsn
   }
 
-  subscribeToOutboundEvent(_event: 'started', callback: () => void): void {
+  subscribeToOutboundStarted(callback: OutboundStartedCallback): void {
     this.on('outbound_started', callback)
   }
-  unsubscribeToOutboundEvent(_event: 'started', callback: () => void): void {
-    this.removeListener('outbound_started', callback)
+
+  unsubscribeToOutboundStarted(): void {
+    throw new Error('Method not implemented.')
   }
 
   sendErrorAfterTimeout(subscriptionId: string, timeout: number): void {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -632,14 +632,6 @@ export class SatelliteProcess implements Satellite {
   _handleOrThrowClientError(error: SatelliteError): Promise<void> {
     this._disconnect()
 
-    if (!error) {
-      const e = new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'received an error event without an error code'
-      )
-      throw wrapFatalError(e)
-    }
-
     if (isThrowable(error)) {
       throw error
     }

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -940,7 +940,7 @@ export class SatelliteProcess implements Satellite {
 
       if (oplogEntries.length > 0) this._notifyChanges(oplogEntries)
 
-      if (!this.client.isDisconnected()) {
+      if (this.client.isConnected()) {
         const enqueued = this.client.getLastSentLsn()
         const enqueuedLogPos = bytesToNumber(enqueued)
 
@@ -992,7 +992,7 @@ export class SatelliteProcess implements Satellite {
 
   async _replicateSnapshotChanges(results: OplogEntry[]): Promise<void> {
     // TODO: Don't try replicating when outbound is inactive
-    if (this.client.isDisconnected()) {
+    if (!this.client.isConnected()) {
       return
     }
 

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -320,10 +320,7 @@ export class SatelliteProcess implements Satellite {
     this.client.subscribeToRelations(this._updateRelations.bind(this))
     // FIXME: calling an async function in an event emitter
     this.client.subscribeToTransactions(this._applyTransaction.bind(this))
-    this.client.subscribeToOutboundEvent(
-      'started',
-      this._throttledSnapshot.bind(this)
-    )
+    this.client.subscribeToOutboundStarted(this._throttledSnapshot.bind(this))
 
     this.client.subscribeToSubscriptionEvents(
       this._handleSubscriptionData.bind(this),

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -158,7 +158,7 @@ export abstract class BaseRegistry implements Registry {
     const satellites = this.satellites
     const satellite = satellites[dbName]
     if (satellite !== undefined) {
-      const stoppingPromise = satellite.stop().then(() => {
+      const stoppingPromise = satellite.stop(true).then(() => {
         delete satellites[dbName]
         delete stoppingPromises[dbName]
       })

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -136,7 +136,7 @@ export abstract class BaseRegistry implements Registry {
     throw new Error(`Satellite not running for db: ${dbName}`)
   }
 
-  async stop(dbName: DbName, shouldIncludeStarting = true): Promise<void> {
+  stop(dbName: DbName, shouldIncludeStarting = true): Promise<void> {
     // If in the process of starting, wait for it to start and then stop it.
     if (shouldIncludeStarting) {
       const stop = this.stop.bind(this)
@@ -165,6 +165,8 @@ export abstract class BaseRegistry implements Registry {
 
       stoppingPromises[dbName] = stoppingPromise
       return stoppingPromise
+    } else {
+      return Promise.resolve()
     }
   }
 

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -210,10 +210,8 @@ export class GlobalRegistry extends BaseRegistry {
     }
 
     const client = new SatelliteClient(
-      dbName,
       dbDescription,
       socketFactory,
-      notifier,
       satelliteClientOpts
     )
 

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -181,5 +181,14 @@ export enum ReplicationStatus {
 }
 
 export type ErrorCallback = (error: SatelliteError) => void
+export type RelationCallback = (relation: Relation) => void
+export type TransactionCallback = (
+  transaction: DataTransaction
+) => Promise<void>
+export type IncomingTransactionCallback = (
+  transaction: DataTransaction,
+  AckCb: () => void
+) => void
+export type OutboundStartedCallback = (lsn: LSN) => void
 
 export type ConnectivityState = 'available' | 'connected' | 'disconnected'

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -2,7 +2,6 @@ import anyTest, { TestFn } from 'ava'
 import Long from 'long'
 import * as Proto from '../../src/_generated/protocol/satellite'
 import { AuthState } from '../../src/auth'
-import { MockNotifier } from '../../src/notifiers'
 import {
   deserializeRow,
   SatelliteClient,
@@ -37,21 +36,13 @@ test.beforeEach((t) => {
   const server = new SatelliteWSServerStub(t)
   server.start()
 
-  const dbName = 'dbName'
-
-  const client = new SatelliteClient(
-    dbName,
-    dbDescription,
-    WebSocketNode,
-    new MockNotifier(dbName),
-    {
-      host: '127.0.0.1',
-      port: 30002,
-      timeout: 10000,
-      ssl: false,
-      pushPeriod: 100,
-    }
-  )
+  const client = new SatelliteClient(dbDescription, WebSocketNode, {
+    host: '127.0.0.1',
+    port: 30002,
+    timeout: 10000,
+    ssl: false,
+    pushPeriod: 100,
+  })
   const clientId = '91eba0c8-28ba-4a86-a6e8-42731c2c6694'
 
   t.context = {

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -64,7 +64,7 @@ test.beforeEach((t) => {
 
 test.afterEach.always(async (t) => {
   const { server, client } = t.context
-  client.close()
+  client.disconnect()
   server.close()
 })
 

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -185,29 +185,6 @@ export interface TestNotifier extends EventNotifier {
   notifications: any[]
 }
 
-export interface TestSatellite extends Satellite {
-  _authState?: AuthState
-  relations: RelationsCache
-  initializing?: {
-    promise: Promise<void>
-    resolve: () => void
-    reject: (e?: unknown) => void
-  }
-
-  _setAuthState(authState: AuthState): Promise<void>
-  _performSnapshot(): Promise<Date>
-  _getEntries(): Promise<OplogEntry[]>
-  _apply(incoming: OplogEntry[], incoming_origin: string): void
-  _applyTransaction(transaction: DataTransaction): any
-  _setMeta(key: string, value: SqlValue): Promise<void>
-  _getMeta(key: string): Promise<string>
-  _ack(lsn: number, isAck: boolean): Promise<void>
-  _connectivityStateChanged(status: ConnectivityState): void
-  _getLocalRelations(): Promise<{ [k: string]: Relation }>
-  _connectRetryHandler: (error: Error, attempt: number) => boolean
-  _connectWithBackoff(): Promise<void>
-}
-
 export type ContextType<Extra = {}> = {
   dbName: string
   adapter: DatabaseAdapter

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -1,19 +1,12 @@
 import { mkdir, rm as removeFile } from 'node:fs/promises'
-import {
-  ConnectivityState,
-  DataTransaction,
-  Relation,
-  RelationsCache,
-  SqlValue,
-  randomValue,
-} from '../../src/util'
+import { randomValue } from '../../src/util'
 import Database from 'better-sqlite3'
 import type { Database as SqliteDB } from 'better-sqlite3'
 import { DatabaseAdapter } from '../../src/drivers/better-sqlite3'
 import { BundleMigrator } from '../../src/migrators'
 import { EventNotifier, MockNotifier } from '../../src/notifiers'
 import { MockSatelliteClient } from '../../src/satellite/mock'
-import { Satellite, SatelliteProcess } from '../../src/satellite'
+import { SatelliteProcess } from '../../src/satellite'
 import { TableInfo, initTableInfo } from '../support/satellite-helpers'
 import { satelliteDefaults, SatelliteOpts } from '../../src/satellite/config'
 import { Table, generateTableTriggers } from '../../src/migrators/triggers'
@@ -165,7 +158,6 @@ export const relations = {
 import migrations from '../support/migrations/migrations.js'
 import { ExecutionContext } from 'ava'
 import { AuthState } from '../../src/auth'
-import { OplogEntry } from '../../src/satellite/oplog'
 import { DbSchema, TableSchema } from '../../src/client/model/schema'
 import { PgBasicType } from '../../src/client/conversions/types'
 import { HKT } from '../../src/client/util/hkt'

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -1786,7 +1786,7 @@ test.serial('connection backoff success', async (t) => {
   t.plan(3)
   const { client, satellite } = t.context
 
-  client.close()
+  client.disconnect()
 
   const retry = (_e: any, a: number) => {
     if (a > 0) {


### PR DESCRIPTION
Type check events emitted by the client. The consequence is that client no longer extends the eventEmitter, which shouldn't from the start.

Additionally, I added a shutdown mode to satellite.stop that clears event handlers assigned to the client. Not that it was a great harm because the client is scoped to the satellite instance. This allows to tick one more checkbox in #243

