### PR TITLE
chore(DAL): Bump capacitor-community/sqlite version to enable Android support

### DIFF
--- a/.changeset/popular-years-live.md
+++ b/.changeset/popular-years-live.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Bump minimum capacitor-community/sqlite version to enable Android support

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -220,7 +220,7 @@
     "web-worker": "^1.2.0"
   },
   "peerDependencies": {
-    "@capacitor-community/sqlite": ">= 5.2.3",
+    "@capacitor-community/sqlite": ">= 5.4.1",
     "cordova-sqlite-storage": ">= 5.0.0",
     "expo-sqlite": ">= 10.0.0",
     "react": ">= 16.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   clients/typescript:
     dependencies:
       '@capacitor-community/sqlite':
-        specifier: '>= 5.2.3'
-        version: 5.2.5(@capacitor/core@5.4.2)
+        specifier: '>= 5.4.1'
+        version: 5.4.1(@capacitor/core@5.4.2)
       async-mutex:
         specifier: ^0.4.0
         version: 0.4.0
@@ -1812,8 +1812,8 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@capacitor-community/sqlite@5.2.5(@capacitor/core@5.4.2):
-    resolution: {integrity: sha512-WyLBmI1zxoiGnd+oBTBdEe1A+o/gEhcvVx9qNVpmdPXqcGxguNRfdlVqVe67e2n7E5NI+9iyueU2yJneTFtSig==}
+  /@capacitor-community/sqlite@5.4.1(@capacitor/core@5.4.2):
+    resolution: {integrity: sha512-N2OKk4ja8tpcN6YJZ7JwRGLlZRpZi+zi7Plve/dRennIk7GXok13NlbHRlthwS+mmC8/SAHlQ0ZW2UGoEisgww==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@capacitor/core': ^5.0.0


### PR DESCRIPTION
There was a bug in capacitor-community/sqlite that prevented our driver working on Android, this is fixed in the latest version. This sets the min version to that current published version.