### PR TITLE
bug(satellite): potential race condition in _performSnapshot()

### DIFF
--- a/.changeset/chilled-cameras-swim.md
+++ b/.changeset/chilled-cameras-swim.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+handle exceptions properly in \_performSnapshot


### PR DESCRIPTION
`_performSnapshot()` must be executed serially. All calls to are protected with a mutex and we have an assertion on the function to ensure we enforce serial execution. However, sometimes we'd still see the assertion fail.

We are not setting properly the `performingSnapshot` variable when exceptions occur in `_performSnapshot()`. Although this probably constitutes a bug, it happens. The exceptions being thrown might also be swallowed sometimes, which made more difficult to track the error (and potentially still hiding other error).