### PR TITLE
fix(electric): New extension migrations fail to apply on top of Electric v0.6.4 schema

### DIFF
--- a/.changeset/funny-pianos-hang.md
+++ b/.changeset/funny-pianos-hang.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+[VAX-1245] New extension migrations fail to apply on top of Electric v0.6.4 schema

--- a/components/electric/lib/electric/postgres/extension/migrations/20230921161418_proxy_compatibility.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230921161418_proxy_compatibility.ex
@@ -87,13 +87,13 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20230921161418_ProxyC
       """,
       # functions that are being re-defined as procedures:
       """
-      DROP FUNCTION IF EXISTS capture_ddl;
+      DROP FUNCTION IF EXISTS #{schema}.capture_ddl;
       """,
       """
-      DROP FUNCTION IF EXISTS create_active_migration;
+      DROP FUNCTION IF EXISTS #{schema}.create_active_migration;
       """,
       """
-      DROP FUNCTION IF EXISTS migration_version;
+      DROP FUNCTION IF EXISTS #{schema}.migration_version;
       """,
       # we don't track indexes within pg anymore
       """


### PR DESCRIPTION
Hard to test without using docker images and the reproduction strategy in VAX-1245, have created an issue to track the need for a test of this migration path: https://linear.app/electric-sql/issue/VAX-1248/e2e-test-to-validate-upgrade-path-from-release-to-release