### PR TITLE
bug(satellite): Cleanup startingPromise in registry when the Satellite process fails to start

### DIFF
--- a/.changeset/shiny-steaks-raise.md
+++ b/.changeset/shiny-steaks-raise.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Cleanup startingPromise in registry when the Satellite process fails to start

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -98,10 +98,10 @@ export class MockSatelliteProcess implements Satellite {
 }
 
 export class MockRegistry extends BaseRegistry {
-  _shouldFailToStart = false
+  private shouldFailToStart = false
 
   setShouldFailToStart(shouldFail: boolean): void {
-    this._shouldFailToStart = shouldFail
+    this.shouldFailToStart = shouldFail
   }
 
   async startProcess(
@@ -113,7 +113,7 @@ export class MockRegistry extends BaseRegistry {
     config: ElectricConfig,
     overrides?: SatelliteOverrides
   ): Promise<Satellite> {
-    if (this._shouldFailToStart) {
+    if (this.shouldFailToStart) {
       throw new Error('Failed to start satellite process')
     }
 

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -98,6 +98,12 @@ export class MockSatelliteProcess implements Satellite {
 }
 
 export class MockRegistry extends BaseRegistry {
+  _shouldFailToStart = false
+
+  setShouldFailToStart(shouldFail: boolean): void {
+    this._shouldFailToStart = shouldFail
+  }
+
   async startProcess(
     dbName: DbName,
     adapter: DatabaseAdapter,
@@ -107,6 +113,10 @@ export class MockRegistry extends BaseRegistry {
     config: ElectricConfig,
     overrides?: SatelliteOverrides
   ): Promise<Satellite> {
+    if (this._shouldFailToStart) {
+      throw new Error('Failed to start satellite process')
+    }
+
     const opts = { ...satelliteDefaults, ...overrides }
 
     const satellite = new MockSatelliteProcess(

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -102,13 +102,16 @@ export abstract class BaseRegistry implements Registry {
       notifier,
       socketFactory,
       config
-    ).then((satellite) => {
-      delete startingPromises[dbName]
+    )
+      .then((satellite) => {
+        satellites[dbName] = satellite
 
-      satellites[dbName] = satellite
-
-      return satellite
-    })
+        return satellite
+      })
+      .finally(() => {
+        // Clean up the starting promise, whether it resolved or rejected.
+        delete startingPromises[dbName]
+      })
 
     startingPromises[dbName] = startingPromise
     return startingPromise

--- a/clients/typescript/test/satellite/registry.test.ts
+++ b/clients/typescript/test/satellite/registry.test.ts
@@ -73,6 +73,24 @@ test('ensure satellite process started works', async (t) => {
   t.true(satellite instanceof MockSatelliteProcess)
 })
 
+test('can stop failed process', async (t) => {
+  const mockRegistry = new MockRegistry()
+
+  // Mock the satellite process to fail.
+  mockRegistry.setShouldFailToStart(true)
+
+  await t.throwsAsync(mockRegistry.ensureStarted(...args))
+
+  // This should not throw. This tests that failed processes are properly cleaned up.
+  await mockRegistry.stop(dbName)
+
+  // Next run a successful process to make sure that works.
+  mockRegistry.setShouldFailToStart(false)
+
+  const satellite = await mockRegistry.ensureStarted(...args)
+  t.true(satellite instanceof MockSatelliteProcess)
+})
+
 test('ensure starting multiple satellite processes works', async (t) => {
   const mockRegistry = new MockRegistry()
   const s1 = await mockRegistry.ensureStarted(


### PR DESCRIPTION
When the satellite process fails (local state is invalid or out of date, invalid migrations, etc...), if the app cleans up the state and retries again (without a browser refresh), it currently will keep failing, because the `startingPromise` is being cached and not released when the promise rejects.