### PR TITLE
Add test to verify pg types are used correctly when serializing

### DIFF
--- a/clients/typescript/src/util/relations.ts
+++ b/clients/typescript/src/util/relations.ts
@@ -1,4 +1,3 @@
-
 import { SatRelation_RelationType } from '../_generated/protocol/satellite'
 import { DatabaseAdapter } from '../electric/adapter'
 import { SatelliteOpts } from '../satellite/config'

--- a/clients/typescript/src/util/relations.ts
+++ b/clients/typescript/src/util/relations.ts
@@ -1,0 +1,69 @@
+
+import { SatRelation_RelationType } from '../_generated/protocol/satellite'
+import { DatabaseAdapter } from '../electric/adapter'
+import { SatelliteOpts } from '../satellite/config'
+import { Relation, RelationsCache } from './types'
+
+// TODO: Improve this code once with Migrator and consider simplifying oplog.
+export async function inferRelationsFromSQLite(
+  adapter: DatabaseAdapter,
+  opts: SatelliteOpts
+): Promise<{ [k: string]: Relation }> {
+  const tableNames = await _getLocalTableNames(adapter, opts)
+  const relations: RelationsCache = {}
+
+  let id = 0
+  const schema = 'public' // TODO
+  for (const table of tableNames) {
+    const tableName = table.name
+    const sql = 'SELECT * FROM pragma_table_info(?)'
+    const args = [tableName]
+    const columnsForTable = await adapter.query({ sql, args })
+    if (columnsForTable.length == 0) {
+      continue
+    }
+    const relation: Relation = {
+      id: id++,
+      schema: schema,
+      table: tableName,
+      tableType: SatRelation_RelationType.TABLE,
+      columns: [],
+    }
+    for (const c of columnsForTable) {
+      relation.columns.push({
+        name: c.name!.toString(),
+        type: c.type!.toString(),
+        isNullable: Boolean(!c.notnull!.valueOf()),
+        primaryKey: Boolean(c.pk!.valueOf()),
+      })
+    }
+    relations[`${tableName}`] = relation
+  }
+
+  return Promise.resolve(relations)
+}
+
+async function _getLocalTableNames(
+  adapter: DatabaseAdapter,
+  opts: SatelliteOpts
+): Promise<{ name: string }[]> {
+  const notIn = [
+    opts.metaTable.tablename.toString(),
+    opts.migrationsTable.tablename.toString(),
+    opts.oplogTable.tablename.toString(),
+    opts.triggersTable.tablename.toString(),
+    opts.shadowTable.tablename.toString(),
+    'sqlite_schema',
+    'sqlite_sequence',
+    'sqlite_temp_schema',
+  ]
+
+  const tables = `
+      SELECT name FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT IN (${notIn.map(() => '?').join(',')})
+    `
+  return (await adapter.query({ sql: tables, args: notIn })) as {
+    name: string
+  }[]
+}

--- a/clients/typescript/src/util/relations.ts
+++ b/clients/typescript/src/util/relations.ts
@@ -39,7 +39,7 @@ export async function inferRelationsFromSQLite(
     relations[`${tableName}`] = relation
   }
 
-  return Promise.resolve(relations)
+  return relations
 }
 
 async function _getLocalTableNames(
@@ -62,7 +62,6 @@ async function _getLocalTableNames(
         WHERE type = 'table'
           AND name NOT IN (${notIn.map(() => '?').join(',')})
     `
-  return (await adapter.query({ sql: tables, args: notIn })) as {
-    name: string
-  }[]
+  const rows = await adapter.query({ sql: tables, args: notIn })
+  return rows as Array<{ name: string }>
 }

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -28,7 +28,7 @@ export const dbDescription = new DbSchema(
     parent: {
       fields: new Map([
         ['id', PgBasicType.PG_INTEGER],
-        ['value', PgBasicType.PG_INTEGER],
+        ['value', PgBasicType.PG_TEXT],
         ['other', PgBasicType.PG_INTEGER],
       ]),
       relations: [],

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -47,6 +47,11 @@ import {
   SubscriptionData,
 } from '../../src/satellite/shapes/types'
 import { mergeEntries } from '../../src/satellite/merge'
+import { PgBasicType } from '../../src/client/conversions/types'
+import { deserializeRow, serializeRow } from '../../src/satellite/client'
+import { serialiseBoolean } from '../../src/client/conversions/datatypes/boolean'
+import { DbSchema, TableSchema } from '../../src/client/model/schema'
+import { HKT } from '../../src/client/util/hkt'
 
 const parentRecord = {
   id: 1,
@@ -1781,6 +1786,61 @@ test.serial('connection backoff success', async (t) => {
       (p) => p?.catch(() => t.pass())
     )
   )
+})
+
+test('serialize correctly to the satellite protocol using pg types', async (t) => {
+  const { satellite, authState, adapter } = t.context
+
+  await adapter.run({
+    sql: 'CREATE TABLE bools (id INTEGER PRIMARY KEY, b INTEGER)',
+  })
+
+  await satellite.start(authState)
+
+  const sqliteInferredRelations = satellite.relations
+  const boolsInferredRelation = sqliteInferredRelations['bools']
+
+  // Inferred types only support SQLite types, so the bool column is INTEGER
+  const boolColumn = boolsInferredRelation.columns[1]
+  t.is(boolColumn.name, 'b')
+  t.is(boolColumn.type, 'INTEGER')
+
+  // Db schema holds the correct Postgres types
+  const boolsDbDescription = new DbSchema(
+    {
+      bools: {
+        fields: new Map([
+          ['id', PgBasicType.PG_INTEGER],
+          ['b', PgBasicType.PG_BOOL],
+        ]),
+        relations: [],
+      },
+    } as unknown as Record<
+      string,
+      TableSchema<any, any, any, any, any, any, any, any, any, HKT>
+    >,
+    []
+  )
+
+  const satOpRow = serializeRow(
+    { id: 5, b: 1 },
+    boolsInferredRelation,
+    boolsDbDescription
+  )
+
+  // Encoded values ["5", "t"]
+  t.deepEqual(satOpRow.values, [
+    new Uint8Array(['5'.charCodeAt(0)]),
+    new Uint8Array(['t'.charCodeAt(0)]),
+  ])
+
+  const deserializedRow = deserializeRow(
+    satOpRow,
+    boolsInferredRelation,
+    boolsDbDescription
+  )
+
+  t.deepEqual(deserializedRow, { id: 5, b: 1 })
 })
 
 // TODO: implement reconnect protocol

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -49,7 +49,6 @@ import {
 import { mergeEntries } from '../../src/satellite/merge'
 import { PgBasicType } from '../../src/client/conversions/types'
 import { deserializeRow, serializeRow } from '../../src/satellite/client'
-import { serialiseBoolean } from '../../src/client/conversions/datatypes/boolean'
 import { DbSchema, TableSchema } from '../../src/client/model/schema'
 import { HKT } from '../../src/client/util/hkt'
 


### PR DESCRIPTION
This tests the behavior of the `getColumnType` function which uses the DbSchema Postgres types and fallbacks to the type name in the Relation.
Bools are inferred as INTEGER from SQLite, but Satellite encodes them in a special way, not like integers.

There is also a small bugfix in the tests dbDescription, which doesn't affect the test suite nor the new test.  