### PR TITLE
feat (DAL): support for enumerations

### DIFF
--- a/.changeset/moody-carpets-allow.md
+++ b/.changeset/moody-carpets-allow.md
@@ -1,0 +1,6 @@
+---
+"electric-sql": patch
+"@electric-sql/prisma-generator": patch
+---
+
+Adds client-side support for enumerations.

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -1128,15 +1128,6 @@ function deserializeColumnData(
   columnType: PgType
 ): string | number {
   switch (columnType) {
-    case PgBasicType.PG_CHAR:
-    case PgDateType.PG_DATE:
-    case PgBasicType.PG_TEXT:
-    case PgDateType.PG_TIME:
-    case PgDateType.PG_TIMESTAMP:
-    case PgDateType.PG_TIMESTAMPTZ:
-    case PgBasicType.PG_UUID:
-    case PgBasicType.PG_VARCHAR:
-      return typeDecoder.text(column)
     case PgBasicType.PG_BOOL:
       return typeDecoder.bool(column)
     case PgBasicType.PG_INT:
@@ -1152,11 +1143,8 @@ function deserializeColumnData(
     case PgDateType.PG_TIMETZ:
       return typeDecoder.timetz(column)
     default:
-      // should not occur
-      throw new SatelliteError(
-        SatelliteErrorCode.UNKNOWN_DATA_TYPE,
-        `can't deserialize ${columnType}`
-      )
+      // also covers user-defined enumeration types
+      return typeDecoder.text(column)
   }
 }
 

--- a/e2e/tests/03.19_node_satellite_can_sync_enums.lux
+++ b/e2e/tests/03.19_node_satellite_can_sync_enums.lux
@@ -29,7 +29,7 @@
 [shell satellite_1]
     # Wait for the row to arrive
     [invoke node_await_get_enum "row1"]
-        
+
     [invoke node_get_enum "row1" "'RED'"]
 
     [invoke node_write_enum "row2" "'GREEN'"]
@@ -39,7 +39,7 @@
     [invoke node_get_enum "row3" null]
 
 [shell pg_1]
-    [invoke wait-for "SELECT * FROM public.enums;" "row1" 10 $psql]
+    [invoke wait-for "SELECT * FROM public.enums;" "row2" 10 $psql]
 
     !SELECT * FROM public.enums;
     ??row1 | RED

--- a/generator/src/functions/tableDescriptionWriters/writeTableSchemas.ts
+++ b/generator/src/functions/tableDescriptionWriters/writeTableSchemas.ts
@@ -123,6 +123,7 @@ function pgType(field: ExtendedDMMFField, modelName: string): string {
     case 'JSON':
       return 'JSON'
     default:
+      if (field.kind === 'enum') return 'TEXT' // treat enums as TEXT such that the ts-client correctly serializes/deserialises them as text
       return 'UNRECOGNIZED PRISMA TYPE'
   }
 }


### PR DESCRIPTION
This PR adds support for enumerations by:
- modifying the generator to store enumeration types as "TEXT" type in the generated client
- modifying satellite to serialise/deserialise enumerations as text
  - since enumeration types are unknown to Satellite it serialises/deserialises them as text