### PR TITLE
chore(examples): Update examples/expo with the new starter template

### DIFF
--- a/examples/expo/backend/compose/.envrc
+++ b/examples/expo/backend/compose/.envrc
@@ -1,4 +1,6 @@
 # Docker images for the local stack
 export POSTGRESQL_IMAGE=postgres:14-alpine
-export ELECTRIC_IMAGE=electricsql/electric:latest
 export APP_NAME=expo
+export ELECTRIC_PORT=5133
+export ELECTRIC_PROXY_PORT=65432
+export ELECTRIC_IMAGE=electricsql/electric@sha256:ac68b8a4adbf6ea14db8ba0027ec6bc28264887b51e293914d9f94b0cd0bec09

--- a/examples/expo/backend/compose/docker-compose.yaml
+++ b/examples/expo/backend/compose/docker-compose.yaml
@@ -1,4 +1,5 @@
 version: "3.8"
+name: "${APP_NAME:-electric}"
 
 configs:
   postgres_config:
@@ -13,7 +14,7 @@ services:
     environment:
       POSTGRES_DB: ${APP_NAME:-electric}
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: pg_password
     command:
       - -c
       - config_file=/etc/postgresql.conf
@@ -33,10 +34,12 @@ services:
     image: "${ELECTRIC_IMAGE:-electricsql/electric:latest}"
     init: true
     environment:
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/${APP_NAME:-electric}
+      DATABASE_URL: postgresql://postgres:pg_password@postgres:5432/${APP_NAME:-electric}
+      PG_PROXY_PASSWORD: proxy_password
       LOGICAL_PUBLISHER_HOST: electric
       AUTH_MODE: insecure
     ports:
-      - 5133:5133
+      - ${ELECTRIC_PORT:-5133}:5133
+      - ${ELECTRIC_PROXY_PORT:-65432}:65432
     depends_on:
       - postgres

--- a/examples/expo/backend/startCompose.js
+++ b/examples/expo/backend/startCompose.js
@@ -1,0 +1,16 @@
+const { dockerCompose } = require('../util/util.js')
+const process = require('process')
+
+const cliArguments = process.argv.slice(2)
+
+dockerCompose('up', cliArguments, (code) => {
+  if (code !== 0) {
+    console.error(
+      '\x1b[31m',
+      'Failed to start the Electric backend. Check the output from `docker compose` above.\n' +
+      'If the error message mentions a port already being allocated or address being already in use,\n' +
+      'execute `yarn ports:configure` to run Electric on another port.',
+      '\x1b[0m'
+    )
+  }
+})

--- a/examples/expo/backend/startElectric.js
+++ b/examples/expo/backend/startElectric.js
@@ -1,36 +1,81 @@
 const shell = require('shelljs')
 
 let db = process.env.DATABASE_URL
+let electricPort = process.env.ELECTRIC_PORT ?? 5133
+let electricProxyPort = process.env.ELECTRIC_PROXY_PORT ?? 65432
 
-if (process.argv.length === 4) {
-  const command = process.argv[2]
+let args = process.argv.slice(2)
 
-  if (command !== '-db') {
-    console.error(`Unsupported option ${command}. Only '-db' option is supported.`)
+while (args.length > 0) {
+  // There are arguments to parse
+  const flag = args[0]
+  const value = args[1]
 
-    process.exit(1)
+  args = args.slice(2)
+
+  const checkValue = () => {
+    if (typeof value === 'undefined') {
+      error(`Missing value for option '${flag}'.`)
+    }
   }
 
-  db = process.argv[3]
+  switch (flag) {
+    case '-db':
+      checkValue()
+      db = value
+      break
+    case '--electric-port':
+      checkValue()
+      electricPort = parsePort(value)
+      break
+    case '--electric-proxy-port':
+      checkValue()
+      electricProxyPort = parsePort(value)
+      break
+    default:
+      error(`Unrecognized option: '${flag}'.`)
+  }
 }
-else if (process.argv.length !== 2) {
-  console.log('Wrong number of arguments provided. Only one optional argument `-db <Postgres connection url>` is supported.')
+
+function parsePort(port) {
+  // checks that the number is between 0 and 65535
+  const portRegex = /^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$/
+  if (!portRegex.test(port)) {
+    error(`Invalid port '${port}. Port should be between 0 and 65535.'`)
+  }
+  return port
 }
 
 if (db === undefined) {
   console.error(`Database URL is not provided. Please provide one using the DATABASE_URL environment variable.`)
-
   process.exit(1)
 }
 
 const electric = process.env.ELECTRIC_IMAGE ?? "electricsql/electric:latest"
 
-shell.exec('docker pull electricsql/electric:latest')
-shell.exec(
+// 5433 is the logical publisher port
+// it is exposed because PG must be able to connect to Electric
+const res = shell.exec(
   `docker run \
       -e "DATABASE_URL=${db}" \
       -e "LOGICAL_PUBLISHER_HOST=localhost" \
       -e "AUTH_MODE=insecure" \
-      -p 5133:5133 \
+      -p ${electricPort}:5133 \
+      -p ${electricProxyPort}:65432 \
       -p 5433:5433 ${electric}`
 )
+
+if (res.code !== 0 && res.stderr.includes('port is already allocated')) {
+  // inform the user that they should change ports
+  console.error(
+    '\x1b[31m',
+    'Could not start Electric because the port seems to be taken.\n' +
+    'To run Electric on another port execute `yarn ports:configure`',
+    '\x1b[0m'
+  )
+}
+
+function error(err) {
+  console.error('\x1b[31m', err + '\nyarn electric:start [-db <Postgres connection url>] [--electric-port <port>] [--electric-proxy-port <port>]', '\x1b[0m')
+  process.exit(1)
+}

--- a/examples/expo/builder.js
+++ b/examples/expo/builder.js
@@ -1,0 +1,99 @@
+const { build, serve } = require('esbuild')
+
+const { createServer, request } = require('http')
+const { spawn } = require('child_process')
+
+const fs = require('fs-extra')
+const inlineImage = require('esbuild-plugin-inline-image')
+
+const shouldMinify = process.env.NODE_ENV === 'production'
+const shouldServe = process.env.SERVE === 'true'
+
+// https://github.com/evanw/esbuild/issues/802#issuecomment-819578182
+const liveServer = (buildOpts) => {
+  const clients = []
+
+  build(
+    {
+      ...buildOpts,
+      banner: { js: ' (() => new EventSource("/esbuild").onmessage = () => location.reload())();' },
+      watch: {
+        onRebuild(error, result) {
+          clients.forEach((res) => res.write('data: update\n\n'))
+          clients.length = 0
+          console.log(error ? error : '...')
+        },
+      }
+    }
+  ).catch(() => process.exit(1))
+
+  serve({servedir: 'dist' }, {})
+    .then((serveResult) => {
+      createServer((req, res) => {
+        const { url, method, headers } = req
+
+        if (url === '/esbuild')
+          return clients.push(
+            res.writeHead(200, {
+              'Content-Type': 'text/event-stream',
+              'Cache-Control': 'no-cache',
+              Connection: 'keep-alive',
+            })
+          )
+
+        const path = ~url.split('/').pop().indexOf('.') ? url : `/index.html` //for PWA with router
+        req.pipe(
+          request({ hostname: '0.0.0.0', port: serveResult.port, path, method, headers }, (prxRes) => {
+            res.writeHead(prxRes.statusCode, prxRes.headers)
+            prxRes.pipe(res, { end: true })
+          }),
+          { end: true }
+        )
+      }).listen(3001)
+
+    setTimeout(() => {
+      const op = { darwin: ['open'], linux: ['xdg-open'], win32: ['cmd', '/c', 'start'] }
+      const ptf = process.platform
+      const url = "http://localhost:3001"
+      if (clients.length === 0) spawn(op[ptf][0], [...[op[ptf].slice(1)], url])
+      console.info(`Your app is running at ${url}`)
+    }, 500) // open the default browser only if it is not opened yet
+  })
+}
+
+/**
+ * ESBuild Params
+ * @link https://esbuild.github.io/api/#build-api
+ */
+let buildParams = {
+  color: true,
+  entryPoints: ["src/index.tsx"],
+  loader: { ".ts": "tsx" },
+  outdir: "dist",
+  minify: shouldMinify,
+  format: "cjs",
+  bundle: true,
+  sourcemap: true,
+  logLevel: "error",
+  incremental: true,
+  define: {
+    __DEBUG_MODE__: JSON.stringify(process.env.DEBUG_MODE === 'true'),
+    __ELECTRIC_URL__: JSON.stringify(process.env.ELECTRIC_URL ?? 'ws://localhost:5133'),
+  },
+  external: ["fs", "path"],
+  plugins: [inlineImage()],
+};
+
+(async () => {
+  fs.removeSync("dist");
+  fs.copySync("public", "dist");
+
+  if (shouldServe) {
+    liveServer(buildParams)
+  }
+  else {
+    await build(buildParams)
+
+    process.exit(0)
+  }
+})();

--- a/examples/expo/change-ports.js
+++ b/examples/expo/change-ports.js
@@ -1,0 +1,135 @@
+const portUsed = require('tcp-port-used')
+const prompt = require('prompt')
+const path = require('path')
+const fs = require('fs/promises')
+const { findFirstMatchInFile, fetchConfiguredElectricPort, fetchConfiguredElectricProxyPort } = require('./util/util.js')
+
+// Regex to check that a number is between 0 and 65535
+const portRegex = /^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$/
+
+init()
+
+// Wrap code in an anonymous async function
+// such that we can await
+async function init() {
+  // Find the old ports for Electric, its proxy, and the webserver
+  // such that we know which ports to replace
+  const webserverPortRegex = /listen\(([0-9]+)\)/
+  
+  const packageJsonFile = path.join(__dirname, 'package.json')
+  const builderFile = path.join(__dirname, 'builder.js')
+  
+  const oldElectricPort = await fetchConfiguredElectricPort()
+  const oldElectricProxyPort = await fetchConfiguredElectricProxyPort()
+  const oldWebserverPort = await findFirstMatchInFile(webserverPortRegex, builderFile, 'Could not find current webserver port in builder.js')
+
+  prompt.start()
+  let electricPort = oldElectricPort
+  let electricProxyPort = oldElectricProxyPort
+  let webserverPort = oldWebserverPort
+  
+  const userInput = await prompt.get({
+    properties: {
+      electricPort: {
+        description: 'Choose a port for Electric',
+        type: 'number',
+        pattern: portRegex,
+        message: 'Port should be between 0 and 65535.',
+        default: oldElectricPort
+      },
+      electricProxyPort: {
+        description: "Choose a port for Electric's DB proxy",
+        type: 'number',
+        pattern: portRegex,
+        message: 'Port should be between 0 and 65535.',
+        default: electricProxyPort
+      },
+      webserverPort: {
+        description: 'Choose a port the webserver',
+        type: 'number',
+        pattern: portRegex,
+        message: 'Port should be between 0 and 65535.',
+        default: oldWebserverPort
+      },
+    }
+  })
+  
+  electricPort = await checkPort(userInput.electricPort, 'Electric', 5133)
+  electricProxyPort = await checkPort(userInput.electricProxyPort, "Electric's proxy", 65432)
+  webserverPort = await checkPort(userInput.webserverPort, 'the web server', 3001)
+  
+  // Update port in package.json file
+  await findAndReplaceInFile(`http://localhost:${oldElectricPort}`, `http://localhost:${electricPort}`, packageJsonFile)
+  await findAndReplaceInFile(
+    `postgresql://prisma:proxy_password@localhost:${oldElectricProxyPort}/electric`,
+    `postgresql://prisma:proxy_password@localhost:${electricProxyPort}/electric`, packageJsonFile
+  )
+  
+  // Update the port on which Electric runs in the builder.js file
+  await findAndReplaceInFile(`ws://localhost:${oldElectricPort}`, `ws://localhost:${electricPort}`, builderFile)
+  
+  // Update the port on which Electric and its proxy run in startElectric.js file
+  const startElectricFile = path.join(__dirname, 'backend', 'startElectric.js')
+  await findAndReplaceInFile(oldElectricPort, `${electricPort}`, startElectricFile)
+  await findAndReplaceInFile(oldElectricProxyPort, `${electricProxyPort}`, startElectricFile)
+  
+  // Update the port of the web server of the example in the builder.js file
+  await findAndReplaceInFile(`listen(${oldWebserverPort})`, `listen(${webserverPort})`, builderFile)
+  await findAndReplaceInFile(`http://localhost:${oldWebserverPort}`, `http://localhost:${webserverPort}`, builderFile)
+  
+  // Update the port for Electric and its proxy in .envrc
+  const envrcFile = path.join(__dirname, 'backend', 'compose', '.envrc')
+  await findAndReplaceInFile(`export ELECTRIC_PORT=${oldElectricPort}`, `export ELECTRIC_PORT=${electricPort}`, envrcFile)
+  await findAndReplaceInFile(`export ELECTRIC_PROXY_PORT=${oldElectricProxyPort}`, `export ELECTRIC_PROXY_PORT=${electricProxyPort}`, envrcFile)
+  
+  console.info(`⚡️ Success! Your project is now configured to run Electric on port ${electricPort}, the DB proxy on port ${electricProxyPort}, and the webserver on port ${webserverPort}.`)
+}
+
+/*
+* Replaces the first occurence of `find` by `replace` in the file `file`.
+* If `find` is a regular expression that sets the `g` flag, then it replaces all occurences.
+*/ 
+async function findAndReplaceInFile(find, replace, file) {
+  const content = await fs.readFile(file, 'utf8')
+  const replacedContent = content.replace(find, replace)
+  await fs.writeFile(file, replacedContent)
+}
+
+/**
+ * Checks if the given port is open.
+ * If not, it will ask the user if
+ * they want to choose another port.
+ * @returns The chosen port.
+ */
+async function checkPort(port, process, defaultPort) {
+  const portOccupied = await portUsed.check(port)
+  if (!portOccupied) {
+    return port
+  }
+  
+  // Warn the user that the chosen port is occupied
+  console.warn(`Port ${port} for ${process} is already in use.`)
+  // Propose user to change port
+  prompt.start()
+  
+  const { port: newPort } = (await prompt.get({
+    properties: {
+      port: {
+        description: 'Hit Enter to keep it or enter a different port number',
+        type: 'number',
+        pattern: portRegex,
+        message: 'Please choose a port between 0 and 65535',
+        default: port,
+      }
+    }
+  }))
+
+  if (newPort === port) {
+    // user chose not to change port
+    return newPort
+  }
+  else {
+    // user changed port, check that it is free
+    return checkPort(newPort, process, defaultPort)
+  }
+}

--- a/examples/expo/check-electric-is-running.js
+++ b/examples/expo/check-electric-is-running.js
@@ -1,0 +1,34 @@
+const { fetchHostPortElectric, fetchHostProxyPortElectric } = require('./db/util.js')
+const { fetchConfiguredElectricPort, fetchConfiguredElectricProxyPort } = require('./util/util.js')
+
+async function checkElectricIsRunning() {
+  const port = fetchHostPortElectric() // will raise an error if Electric is not running
+  
+  // Check that the port on which Electric is running
+  // is the same as the port to which the app will connect
+  const configuredPort = await fetchConfiguredElectricPort()
+  
+  if (configuredPort !== port) {
+    console.error(
+      '\x1b[31m',
+      `Your application is configured to connect to Electric on port ${configuredPort} ` +
+      `but your instance of Electric is running on port ${port}`,
+      '\x1b[0m'
+    )
+    process.exit(1)
+  }
+
+  // Also check that the proxy port is configured correctly
+  const proxyPort = fetchHostProxyPortElectric()
+  const configuredProxyPort = await fetchConfiguredElectricProxyPort()
+  if (configuredProxyPort !== proxyPort) {
+    console.error(
+      '\x1b[31m',
+      `Your application is configured to connect to Electric's DB proxy on port ${configuredProxyPort} ` +
+      `but your instance of Electric is running the DB proxy on port ${proxyPort}`,
+      '\x1b[0m'
+    )
+  }
+}
+
+checkElectricIsRunning()

--- a/examples/expo/db/connect.js
+++ b/examples/expo/db/connect.js
@@ -1,3 +1,6 @@
-const { DATABASE_URL } = require('./util.js')
-const { spawn } = require('child_process')
-spawn(`psql ${DATABASE_URL}`, [], { cwd: __dirname, stdio: 'inherit', shell: true })
+const { dockerCompose } = require('../util/util.js')
+const { CONTAINER_DATABASE_URL, PUBLIC_DATABASE_URL } = require('./util.js')
+
+console.info(`Connecting to proxy at ${PUBLIC_DATABASE_URL}`)
+
+dockerCompose('exec', ['-it', 'postgres', 'psql', CONTAINER_DATABASE_URL])

--- a/examples/expo/db/migrate.js
+++ b/examples/expo/db/migrate.js
@@ -1,43 +1,34 @@
-const fs = require('fs')
-const path = require('path')
-const { DATABASE_URL } = require('./util.js')
+const { DATABASE_URL, PUBLIC_DATABASE_URL } = require('./util.js')
+const { spawn } = require('child_process')
+const process = require('process')
 
-const createPool = require('@databases/pg')
-const { sql } = require('@databases/pg')
+console.info(`Connecting to proxy at ${PUBLIC_DATABASE_URL}`)
 
-const MIGRATIONS_DIR = process.env.MIGRATIONS_DIR || path.resolve(__dirname, 'migrations')
+const args = ["run", "-s", "pg-migrations", "apply", "--database",  DATABASE_URL, "--directory", "./db/migrations"]
+const proc = spawn("yarn", args, { cwd: __dirname, stdio: ['inherit', 'pipe', 'inherit']  })
 
-console.info(`Connecting to Postgres..`)
-const db = createPool(DATABASE_URL)
+let newMigrationsApplied = true
 
-const apply = async (fileName) => {
-  const filePath = path.join(MIGRATIONS_DIR, fileName)
-  console.log('Applying', filePath)
-
-  await db.tx(
-    (tx) => tx.query(
-      sql.file(filePath)
-    )
-  )
-}
-
-const main = async () => {
-  const fileNames = fs.readdirSync(MIGRATIONS_DIR)
-  for (const file of fileNames) {
-    if (path.extname(file) === '.sql') {
-      await apply(file)
-    }
+proc.stdout.on('data', (data) => {
+  if (data.toString().trim() === 'No migrations required') {
+    newMigrationsApplied = false
+  } else {
+    process.stdout.write(data)
   }
-  console.log('⚡️ Database is migrated.')
-}
+})
 
-try {
-  main()
-}
-catch (err) {
-  console.error(err)
-  process.exitCode = 1
-}
-finally {
-  db.dispose()
-}
+proc.on('exit', (code) => {
+  if (code === 0) {
+    if (newMigrationsApplied) {
+      console.log('⚡️ Database migrated.') 
+    } else {
+      console.log('⚡ Database already up to date.')
+    }
+  } else {
+     console.error(
+      '\x1b[31m',
+      'Failed to connect to the DB. Exit code: ' + code,
+      '\x1b[0m'
+    )
+  }
+})

--- a/examples/expo/db/migrations/01-create_items_table.sql
+++ b/examples/expo/db/migrations/01-create_items_table.sql
@@ -16,4 +16,4 @@ CREATE TABLE IF NOT EXISTS items (
 
 -- ⚡
 -- Electrify the items table
-CALL electric.electrify('items');
+ALTER TABLE items ENABLE ELECTRIC;

--- a/examples/expo/db/util.js
+++ b/examples/expo/db/util.js
@@ -3,24 +3,56 @@ const path = require('path')
 const shell = require('shelljs')
 shell.config.silent = true // don't log output of child processes
 
-// If we are running the docker compose file
-// there will be a compose-postgres-1 container running
-// which binds the container's 5432 port used by PG
-// to some available port on the host machine.
-// So we fetch this host port and use it in the default url.
-const pgPort = fetchHostPortPG() ?? 5432
+// If we are running the docker compose file,
+// the container running `electric` service will be exposing
+// the proxy port which should be used for all DB connections
+// that intend to use the DDLX syntax extension of SQL.
 const appName = fetchAppName() ?? 'electric'
-const DEFAULT_URL = `postgresql://postgres:password@localhost:${pgPort}/${appName}`
-const DATABASE_URL = process.env.DATABASE_URL || DEFAULT_URL
+const proxyPort = fetchHostProxyPortElectric() ?? 65432
+const dbUser = 'postgres'
+const proxyPassword = 'proxy_password'
 
-function fetchHostPortPG() {
-  return fetchHostPort('compose-postgres-1', 5432)
+// URL to use when connecting to the proxy from the host OS
+const DATABASE_URL = buildDatabaseURL(dbUser, proxyPassword, 'localhost', proxyPort, appName)
+
+// URL to use when connecting to the proxy from a Docker container. This is used when `psql` is exec'd inside the
+// `postgres` service's container to connect to the poxy running in the `electric` service's container.
+const CONTAINER_DATABASE_URL = buildDatabaseURL(dbUser, proxyPassword, 'electric', 65432, appName)
+
+// URL to display in the terminal for informational purposes. It omits the password but is still a valid URL that can be
+// passed to `psql` running on the host OS.
+const PUBLIC_DATABASE_URL = buildDatabaseURL(dbUser, null, 'localhost', proxyPort, appName)
+
+function buildDatabaseURL(user, password, host, port, dbName) {
+  let url = 'postgresql://' + user
+  if (password) {
+    url += ':' + password
+  }
+  url += '@' + host + ':' + port + '/' + dbName
+  return url
+}
+
+function error(err) {
+  console.error('\x1b[31m', err, '\x1b[0m')
+  process.exit(1)
+}
+
+function fetchHostPortElectric() {
+  return fetchHostPort(`${appName}-electric-1`, 5133, 'Electric')
+}
+
+function fetchHostProxyPortElectric() {
+  return fetchHostPort(`${appName}-electric-1`, 65432, 'Electric')
 }
 
 // Returns the host port to which the `containerPort` of the `container` is bound.
 // Returns undefined if the port is not bound or container does not exist.
-function fetchHostPort(container, containerPort) {
+function fetchHostPort(container, containerPort, service) {
   const output = shell.exec(`docker inspect --format='{{(index (index .NetworkSettings.Ports "${containerPort}/tcp") 0).HostPort}}' ${container}`)
+  if (output.code !== 0) {
+    // Electric is not running for this app
+    error(`${service} appears not to be running for this app.\nDocker container ${container} not running.`)
+  }
   const port = parseInt(output)
   if (!isNaN(port)) {
     return port
@@ -50,3 +82,7 @@ function fetchAppName() {
 }
 
 exports.DATABASE_URL = DATABASE_URL
+exports.CONTAINER_DATABASE_URL = CONTAINER_DATABASE_URL
+exports.PUBLIC_DATABASE_URL = PUBLIC_DATABASE_URL
+exports.fetchHostPortElectric = fetchHostPortElectric
+exports.fetchHostProxyPortElectric = fetchHostProxyPortElectric

--- a/examples/expo/package.json
+++ b/examples/expo/package.json
@@ -1,20 +1,20 @@
 {
   "name": "electric-sql-expo-example",
-  "version": "1.0.0",
+  "version": "0.7.0",
   "author": "ElectricSQL",
   "license": "Apache-2.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "electric:pull": "docker pull electricsql/electric:latest",
-    "backend:down": "yarn electric:pull && docker compose -f backend/compose/docker-compose.yaml down --volumes",
-    "backend:start": "docker pull electricsql/electric:latest && docker compose --env-file backend/compose/.envrc -f backend/compose/docker-compose.yaml up",
-    "backend:stop": "yarn backend:down",
+    "backend:start": "node ./backend/startCompose.js",
+    "backend:stop": "docker compose --env-file backend/compose/.envrc -f backend/compose/docker-compose.yaml stop",
     "backend:up": "yarn backend:start --detach",
-    "client:generate": "npx electric-sql generate",
-    "client:watch": "npx electric-sql generate --watch",
+    "backend:down": "docker compose --env-file backend/compose/.envrc -f backend/compose/docker-compose.yaml down --volumes",
+    "client:generate": "yarn electric:check && npx electric-sql generate --service http://localhost:5133 --proxy postgresql://prisma:proxy_password@localhost:65432/electric",
+    "client:watch": "yarn client:generate --watch",
     "db:migrate": "node ./db/migrate.js",
     "db:psql": "node ./db/connect.js",
-    "electric:start": "node ./backend/startElectric.js",
+    "electric:check": "node ./check-electric-is-running.js",
+    "ports:configure": "node ./change-ports.js",
     "start": "expo start",
     "start:android": "expo start --android",
     "start:ios": "expo start --ios"
@@ -32,14 +32,17 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
-    "@databases/pg": "^5.4.1",
     "@electric-sql/prisma-generator": "latest",
+    "@databases/pg-migrations": "^5.0.2",
     "@prisma/client": "4.8.1",
     "@tsconfig/react-native": "^2.0.2",
     "@types/react": "^18.0.18",
     "@types/react-native": "^0.72.2",
+    "fs-extra": "^10.0.0",
     "prisma": "4.8.1",
+    "prompt": "^1.3.0",
     "shelljs": "^0.8.5",
+    "tcp-port-used": "^1.0.2",
     "typescript": "^5.1.3"
   }
 }

--- a/examples/expo/util/util.js
+++ b/examples/expo/util/util.js
@@ -1,0 +1,42 @@
+const fs = require('fs/promises')
+const path = require('path')
+const { spawn } = require('child_process')
+const process = require('process')
+
+async function findFirstMatchInFile(regex, file, notFoundError) {
+  const content = await fs.readFile(file, 'utf8')
+  const res = content.match(regex)
+  if (res === null) {
+    console.error(notFoundError)
+    process.exit(1)
+  }
+  return res[1]
+}
+
+async function fetchConfiguredElectricPort() {
+  const electricPortRegex =   /ws:\/\/localhost:([0-9]+)/
+  const builderFile = path.join(__dirname, '..', 'builder.js')
+  const port = await findFirstMatchInFile(electricPortRegex, builderFile, 'Could not find current Electric port in builder.js')
+  return Number.parseInt(port)
+}
+
+async function fetchConfiguredElectricProxyPort() {
+  const proxyPortRegex = /export ELECTRIC_PROXY_PORT=([0-9]+)/
+  const builderFile = path.join(__dirname, '..', 'backend', 'compose', '.envrc')
+  const port = await findFirstMatchInFile(proxyPortRegex, builderFile, "Could not find Electric's current proxy port in .envrc")
+  return Number.parseInt(port)
+}
+
+const envrcFile = path.join(__dirname, '../backend/compose/.envrc')
+const composeFile = path.join(__dirname, '../backend/compose/docker-compose.yaml')
+
+function dockerCompose(command, userArgs, callback) {
+  const args = ['compose', '--ansi', 'always', '--env-file', envrcFile, '-f',  composeFile, command, ...userArgs]
+  const proc = spawn('docker', args, {stdio: 'inherit'})
+  if (callback) { proc.on('exit', callback) }
+}
+
+exports.findFirstMatchInFile = findFirstMatchInFile
+exports.fetchConfiguredElectricPort = fetchConfiguredElectricPort
+exports.fetchConfiguredElectricProxyPort = fetchConfiguredElectricProxyPort
+exports.dockerCompose = dockerCompose

--- a/examples/expo/yarn.lock
+++ b/examples/expo/yarn.lock
@@ -1163,6 +1163,11 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@databases/connection-pool@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@databases/connection-pool/-/connection-pool-1.1.0.tgz#e8ebc3f7e7f7912fb43ca8c7b423310fdbedbe49"
@@ -1185,7 +1190,20 @@
   dependencies:
     "@databases/queue" "^1.0.0"
 
-"@databases/pg-config@^3.1.0":
+"@databases/migrations-base@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@databases/migrations-base/-/migrations-base-3.0.1.tgz#744e4921bbd713434435ee92b0183c9dcb6e5c19"
+  integrity sha512-CutCQ1AjsEWqSuXInD8KwaZYa3/InYGFu3uZ/2pu0Ku4MHRab14+sKNXLk/dxHaJLplngLtCraBo8rL7/21Vhg==
+  dependencies:
+    assert-never "^1.2.1"
+    chalk "^4.1.0"
+    deep-equal "^2.0.4"
+    interrogator "^2.0.0"
+    is-interactive "^1.0.0"
+    parameter-reducers "^2.0.0"
+    semver "^7.3.2"
+
+"@databases/pg-config@^3.1.0", "@databases/pg-config@^3.1.1":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@databases/pg-config/-/pg-config-3.2.0.tgz#90d21333114d22b8b69039b92416d938dfbf04a8"
   integrity sha512-hoPAK/F8gLcLgEJ8mLSnNvRlKqShwx5+GglDHIIfQhKF+Zz6M6QceiOefckS4WSjA0x2HClPvpercnXp9i24ag==
@@ -1207,6 +1225,22 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@databases/pg-errors/-/pg-errors-1.0.0.tgz#ea4a1320d84872a13085365fea44f922db180a99"
   integrity sha512-Yz3exbptZwOn4ZD/MSwY6z++XVyOFsMh5DERvSw3awRwJFnfdaqdeiIxxX0MVjM6KPihF0xxp8lPO7vTc5ydpw==
+
+"@databases/pg-migrations@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@databases/pg-migrations/-/pg-migrations-5.0.2.tgz#b1bf7794b2a1a13d26171901850201b71c3d9b56"
+  integrity sha512-l3mRxMTmmY7MGBhEJgjzVKxChwNqNLPtiLBOO6V6L4INFXO3Vuiundj3WAZl6qlYmE8NwPvQLr+e9aMWq0rnnA==
+  dependencies:
+    "@databases/migrations-base" "^3.0.1"
+    "@databases/pg" "^5.4.1"
+    "@databases/pg-config" "^3.1.1"
+    assert-never "^1.2.1"
+    chalk "^4.1.0"
+    interrogator "^2.0.0"
+    is-interactive "^1.0.0"
+    parameter-reducers "^2.0.0"
+    semver "^7.3.2"
+    sucrase "^3.16.0"
 
 "@databases/pg@^5.4.1":
   version "5.4.1"
@@ -1742,6 +1776,13 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@ljharb/through@^2.3.9":
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/@ljharb/through/-/through-2.3.11.tgz#783600ff12c06f21a76cc26e33abd0b1595092f9"
+  integrity sha512-ccfcIDlogiXNq5KcbAwbaO7lMh3Tm1i3khMPYpxlK8hH/W53zN81KM9coerRLOnTGu3nfXIniAmQbRI9OxbC0w==
+  dependencies:
+    call-bind "^1.0.2"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2459,6 +2500,18 @@ async-mutex@^0.4.0:
   dependencies:
     tslib "^2.4.0"
 
+async@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
+
+async@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
+
 async@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
@@ -2813,6 +2866,15 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
+call-bind@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
+  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
+  dependencies:
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.1"
+    set-function-length "^1.1.1"
+
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -2869,6 +2931,16 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
+  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
 charenc@0.0.2, charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
@@ -2917,6 +2989,11 @@ cli-spinners@^2.0.0, cli-spinners@^2.5.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.0.tgz#5881d0ad96381e117bbe07ad91f2008fe6ffd8db"
   integrity sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==
+
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -2988,6 +3065,11 @@ colorette@^1.0.7:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+
+colors@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+  integrity sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -3170,6 +3252,11 @@ cuid@^2.1.8:
   resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
   integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
 
+cycle@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
+  integrity sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==
+
 dag-map@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-1.0.2.tgz#e8379f041000ed561fc515475c1ed2c85eece8d7"
@@ -3191,6 +3278,13 @@ debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, de
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
 
@@ -3266,10 +3360,39 @@ decompress@^4.2.1:
     pify "^2.3.0"
     strip-dirs "^2.0.0"
 
+deep-equal@^2.0.4:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.2.tgz#9b2635da569a13ba8e1cc159c2f744071b115daa"
+  integrity sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.2"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.1"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.2"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.0"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.9"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 deepmerge@^4.3.0:
   version "4.3.1"
@@ -3290,6 +3413,15 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
+
+define-data-property@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
+  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
+  dependencies:
+    get-intrinsic "^1.2.1"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.0"
 
 define-lazy-prop@^2.0.0:
   version "2.0.0"
@@ -3520,6 +3652,21 @@ es-abstract@^1.19.0, es-abstract@^1.20.4:
     unbox-primitive "^1.0.2"
     which-typed-array "^1.1.10"
 
+es-get-iterator@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
+  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    is-arguments "^1.1.1"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.7"
+    isarray "^2.0.5"
+    stop-iteration-iterator "^1.0.0"
+
 es-set-tostringtag@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"
@@ -3557,6 +3704,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
@@ -3729,6 +3881,20 @@ exponential-backoff@^3.1.0:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
 
+external-editor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
+eyes@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
+  integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
+
 fast-base64-decode@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
@@ -3807,6 +3973,14 @@ fetch-retry@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-4.1.1.tgz#fafe0bb22b54f4d0a9c788dff6dd7f8673ca63f3"
   integrity sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==
+
+figures@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-5.0.0.tgz#126cd055052dea699f8a54e8c9450e6ecfc44d5f"
+  integrity sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==
+  dependencies:
+    escape-string-regexp "^5.0.0"
+    is-unicode-supported "^1.2.0"
 
 file-type@^3.8.0:
   version "3.9.0"
@@ -3961,6 +4135,15 @@ fs-extra@9.0.0:
     jsonfile "^6.0.1"
     universalify "^1.0.0"
 
+fs-extra@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0, fs-extra@~8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -4002,6 +4185,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 function.prototype.name@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
@@ -4041,6 +4229,16 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
     has "^1.0.3"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
+
+get-intrinsic@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz#281b7622971123e1ef4b3c90fd7539306da93f3b"
+  integrity sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
+  dependencies:
+    function-bind "^1.1.2"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    hasown "^2.0.0"
 
 get-port@^3.2.0:
   version "3.2.0"
@@ -4232,6 +4430,13 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hasown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
+  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  dependencies:
+    function-bind "^1.1.2"
+
 hermes-estree@0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.12.0.tgz#8a289f9aee854854422345e6995a48613bac2ca8"
@@ -4282,7 +4487,7 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-iconv-lite@0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4360,6 +4565,27 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+inquirer@^9.1.4:
+  version "9.2.11"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-9.2.11.tgz#e9003755c233a414fceda1891c23bd622cad4a95"
+  integrity sha512-B2LafrnnhbRzCWfAdOXisUzL89Kg8cVJlYmhqoi3flSiV/TveO+nsXwgKr9h9PIo+J1hz7nBSk6gegRIMBBf7g==
+  dependencies:
+    "@ljharb/through" "^2.3.9"
+    ansi-escapes "^4.3.2"
+    chalk "^5.3.0"
+    cli-cursor "^3.1.0"
+    cli-width "^4.1.0"
+    external-editor "^3.1.0"
+    figures "^5.0.0"
+    lodash "^4.17.21"
+    mute-stream "1.0.0"
+    ora "^5.4.1"
+    run-async "^3.0.0"
+    rxjs "^7.8.1"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^6.2.0"
+
 internal-ip@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
@@ -4367,6 +4593,15 @@ internal-ip@4.3.0:
   dependencies:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
+
+internal-slot@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.6.tgz#37e756098c4911c5e912b8edbf71ed3aa116f930"
+  integrity sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==
+  dependencies:
+    get-intrinsic "^1.2.2"
+    hasown "^2.0.0"
+    side-channel "^1.0.4"
 
 internal-slot@^1.0.5:
   version "1.0.5"
@@ -4382,6 +4617,13 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+interrogator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/interrogator/-/interrogator-2.0.0.tgz#f5639aca1aa9728fe7cb9f72e5cbe36ac07cd53b"
+  integrity sha512-1qxXpxXznMEpBz4SwV6H16jlCdzDhj2Oww2IEpecZ1ouu3Hr34JOibSRmKe+8fdWZiicaAH80hUispXEuCb4Jw==
+  dependencies:
+    inquirer "^9.1.4"
+
 invariant@*, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
@@ -4394,6 +4636,11 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==
 
+ip-regex@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
+
 ip@^1.1.5:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
@@ -4403,6 +4650,14 @@ ipaddr.js@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+is-arguments@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
 
 is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
@@ -4450,7 +4705,7 @@ is-core-module@^2.13.0:
   dependencies:
     has "^1.0.3"
 
-is-date-object@^1.0.1:
+is-date-object@^1.0.1, is-date-object@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
@@ -4513,6 +4768,11 @@ is-invalid-path@^0.1.0:
   dependencies:
     is-glob "^2.0.0"
 
+is-map@^2.0.1, is-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
+
 is-natural-number@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
@@ -4570,6 +4830,11 @@ is-root@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
+is-set@^2.0.1, is-set@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
+
 is-shared-array-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
@@ -4613,6 +4878,16 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
+is-unicode-supported@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
+  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
+
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
 is-valid-path@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-valid-path/-/is-valid-path-0.1.1.tgz#110f9ff74c37f663e1ec7915eb451f2db93ac9df"
@@ -4620,12 +4895,25 @@ is-valid-path@^0.1.1:
   dependencies:
     is-invalid-path "^0.1.0"
 
+is-weakmap@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.1.tgz#5008b59bdc43b698201d18f62b37b2ca243e8cf2"
+  integrity sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==
+
 is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+is-weakset@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.2.tgz#4569d67a747a1ce5a994dfd4ef6dcea76e7c0a1d"
+  integrity sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -4638,6 +4926,15 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+is2@^2.0.6:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.9.tgz#ff63b441f90de343fa8fac2125ee170da8e8240d"
+  integrity sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==
+  dependencies:
+    deep-is "^0.1.3"
+    ip-regex "^4.1.0"
+    is-url "^1.2.4"
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -4658,6 +4955,11 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+isstream@0.1.x:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 jest-environment-node@^29.2.1:
   version "29.6.4"
@@ -5034,7 +5336,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
-lodash@^4.17.13, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5660,6 +5962,16 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mute-stream@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
+  integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
+mute-stream@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 mv@~2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
@@ -5822,6 +6134,14 @@ object-inspect@^1.12.3, object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
+
+object-is@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -6008,6 +6328,11 @@ packet-reader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
   integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
+parameter-reducers@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parameter-reducers/-/parameter-reducers-2.1.0.tgz#183d1b39611c3c468a47d3ad8fd8b86d6f3895a2"
+  integrity sha512-aj9V6DUnNbj4YEmVxloPLX9duhklIC+SIOVUrVdaT3WfgEownET+TYg/JsjANQUNGe46dmOCHEKiuycL36cOnw==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -6346,6 +6671,17 @@ promise@^8.3.0:
   dependencies:
     asap "~2.0.6"
 
+prompt@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prompt/-/prompt-1.3.0.tgz#b1f6d47cb1b6beed4f0660b470f5d3ec157ad7ce"
+  integrity sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    async "3.2.3"
+    read "1.0.x"
+    revalidator "0.1.x"
+    winston "2.x"
+
 prompts@^2.3.2, prompts@^2.4.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -6557,6 +6893,13 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+read@1.0.x:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  integrity sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==
+  dependencies:
+    mute-stream "~0.0.4"
+
 readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
@@ -6749,6 +7092,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+revalidator@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
+  integrity sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==
+
 rimraf@^2.6.2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -6777,12 +7125,24 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
+run-async@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-3.0.0.tgz#42a432f6d76c689522058984384df28be379daad"
+  integrity sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@^7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
 
 safe-array-concat@^1.0.0:
   version "1.0.0"
@@ -6864,7 +7224,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.5.2, semver@^7.5.3:
+semver@^7.3.2, semver@^7.3.5, semver@^7.5.2, semver@^7.5.3:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -6916,6 +7276,16 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
+set-function-length@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.1.1.tgz#4bc39fafb0307224a33e106a7d35ca1218d659ed"
+  integrity sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==
+  dependencies:
+    define-data-property "^1.1.1"
+    get-intrinsic "^1.2.1"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.0"
 
 setimmediate@^1.0.5:
   version "1.0.5"
@@ -7095,6 +7465,11 @@ ssri@^8.0.1:
   dependencies:
     minipass "^3.1.1"
 
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
+
 stack-utils@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
@@ -7123,6 +7498,13 @@ statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+stop-iteration-iterator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz#6a60be0b4ee757d1ed5254858ec66b10c49285e4"
+  integrity sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==
+  dependencies:
+    internal-slot "^1.0.4"
 
 stream-buffers@2.2.x:
   version "2.2.0"
@@ -7225,7 +7607,7 @@ structured-headers@^0.4.1:
   resolved "https://registry.yarnpkg.com/structured-headers/-/structured-headers-0.4.1.tgz#77abd9410622c6926261c09b9d16cf10592694d1"
   integrity sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==
 
-sucrase@^3.20.0:
+sucrase@^3.16.0, sucrase@^3.20.0:
   version "3.34.0"
   resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.34.0.tgz#1e0e2d8fcf07f8b9c3569067d92fbd8690fb576f"
   integrity sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==
@@ -7332,6 +7714,14 @@ tar@^6.0.2, tar@^6.0.5:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tcp-port-used@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.2.tgz#9652b7436eb1f4cfae111c79b558a25769f6faea"
+  integrity sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==
+  dependencies:
+    debug "4.3.1"
+    is2 "^2.0.6"
 
 temp-dir@^1.0.0:
   version "1.0.0"
@@ -7827,6 +8217,16 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
+which-collection@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.1.tgz#70eab71ebbbd2aefaf32f917082fc62cdcb70906"
+  integrity sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==
+  dependencies:
+    is-map "^2.0.1"
+    is-set "^2.0.1"
+    is-weakmap "^2.0.1"
+    is-weakset "^2.0.1"
+
 which-module@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
@@ -7839,6 +8239,17 @@ which-typed-array@^1.1.10, which-typed-array@^1.1.11:
   dependencies:
     available-typed-arrays "^1.0.5"
     call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+
+which-typed-array@^1.1.9:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.13.tgz#870cd5be06ddb616f504e7b039c4c24898184d36"
+  integrity sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.4"
     for-each "^0.3.3"
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
@@ -7856,6 +8267,18 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+winston@2.x:
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.7.tgz#5791fe08ea7e90db090f1cb31ef98f32531062f1"
+  integrity sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==
+  dependencies:
+    async "^2.6.4"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
 
 wonka@^4.0.14:
   version "4.0.15"


### PR DESCRIPTION
I have verified that the basic instructions from README work. I couldn't verify whether any of the `yarn start`, `yarn start:android` or `yarn start:ios` still work.

@samwillis @thruflo can any one of you verify that the those commands still work?

Testing notes:
* git checkout the `examples/expo` branch
* modify `ELECTRIC_IMAGE` in `examples/expo/backend/compose/.envrc` to use `electric:local-build`
* `cd` to the project root
* `pnpm install`
* `cd clients/typescript; pnpm build; yalc publish`
* `cd ../../generator; pnpm build; yalc publish`
* `cd ../components/electric; make docker-build`
* `cd ../../examples/expo`
* `yalc add electric-sql @electric-sql/prisma-generator`
* `yarn`
* proceed with the instructions from README