### PR TITLE
fix (DAL): transform all data types in input structures

### DIFF
--- a/.changeset/neat-pens-raise.md
+++ b/.changeset/neat-pens-raise.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix bug where data types provided in input structures could not be bound to SQLite types.

--- a/clients/typescript/src/client/conversions/input.ts
+++ b/clients/typescript/src/client/conversions/input.ts
@@ -1,6 +1,6 @@
 import mapValues from 'lodash.mapvalues'
 import { FieldName, Fields } from '../model/schema'
-import { fromSqlite, toSqlite } from './sqlite'
+import { fromSqlite, toSqlite, isDataObject } from './sqlite'
 import { InvalidArgumentError } from '../validation/errors/invalidArgumentError'
 import { mapObject } from '../util/functions'
 import { PgType } from './types'
@@ -333,7 +333,7 @@ function isObject(v: any): boolean {
 function isFilterObject(value: any): boolean {
   // if it is an object it can only be a timestamp or a filter object
   // because those are the only objects we support in where clauses
-  return isObject(value) && !(value instanceof Date)
+  return isObject(value) && !isDataObject(value)
 }
 
 /**

--- a/clients/typescript/src/client/conversions/input.ts
+++ b/clients/typescript/src/client/conversions/input.ts
@@ -3,7 +3,7 @@ import { FieldName, Fields } from '../model/schema'
 import { fromSqlite, toSqlite } from './sqlite'
 import { InvalidArgumentError } from '../validation/errors/invalidArgumentError'
 import { mapObject } from '../util/functions'
-import { PgDateType, PgType } from './types'
+import { PgType } from './types'
 
 export enum Transformation {
   Js2Sqlite,
@@ -318,25 +318,22 @@ function transformFieldsAllowingFilters(
 
   if (!pgType) throw new InvalidArgumentError(`Unknown field ${field}`)
 
-  switch (pgType) {
-    // Types that require transformations
-    case PgDateType.PG_DATE:
-    case PgDateType.PG_TIME:
-    case PgDateType.PG_TIMESTAMP:
-    case PgDateType.PG_TIMESTAMPTZ:
-    case PgDateType.PG_TIMETZ:
-      if (value instanceof Date) {
-        // transform it
-        return toSqlite(value, pgType)
-      } else {
-        // it must be an object containing filters
-        // transform the values that are nested in those filters
-        return transformFilterObject(field, value, pgType, fields)
-      }
-    // other types that don't require transformations
-    default:
-      return value
+  if (isFilterObject(value)) {
+    // transform the values that are nested in those filters
+    return transformFilterObject(field, value, pgType, fields)
   }
+
+  return toSqlite(value, pgType)
+}
+
+function isObject(v: any): boolean {
+  return typeof v === 'object' && !Array.isArray(v) && v !== null
+}
+
+function isFilterObject(value: any): boolean {
+  // if it is an object it can only be a timestamp or a filter object
+  // because those are the only objects we support in where clauses
+  return isObject(value) && !(value instanceof Date)
 }
 
 /**
@@ -388,6 +385,7 @@ function transformFilterObject(
   })
 
   return {
+    ...o,
     ...transformedSimpleFilterObj,
     ...transformedArrayFilterObj,
     ...transformedNotFilterObj,

--- a/clients/typescript/src/client/conversions/sqlite.ts
+++ b/clients/typescript/src/client/conversions/sqlite.ts
@@ -55,6 +55,18 @@ export function fromSqlite(v: any, pgType: PgType): any {
   }
 }
 
+/**
+ * Checks whether the provided value is a user-provided data object, e.g. a timestamp.
+ * This is important because `input.ts` needs to distinguish between data objects and filter objects.
+ * Data objects need to be converted to a SQLite storeable value, whereas filter objects need to be treated specially
+ * as we have to transform the values of the filter's fields (cf. `transformFieldsAllowingFilters` in `input.ts`).
+ * @param v The value to check
+ * @returns True if it is a data object, false otherwise.
+ */
+export function isDataObject(v: unknown): boolean {
+  return v instanceof Date
+}
+
 function isPgDateType(pgType: PgType): boolean {
   return (Object.values(PgDateType) as Array<string>).includes(pgType)
 }

--- a/clients/typescript/test/client/conversions/input.test.ts
+++ b/clients/typescript/test/client/conversions/input.test.ts
@@ -76,6 +76,21 @@ test.serial('findFirst transforms JS objects to SQLite', async (t) => {
   t.deepEqual(res?.timestamp, new Date(date))
 })
 
+test.serial('findFirst transforms booleans to integer in SQLite', async (t) => {
+  await electric.adapter.run({
+    sql: `INSERT INTO DataTypes('id', 'bool') VALUES (1, 0), (2, 1)`,
+  })
+
+  const res = await tbl.findFirst({
+    where: {
+      bool: true,
+    },
+  })
+
+  t.is(res?.id, 2)
+  t.is(res?.bool, true)
+})
+
 test.serial(
   'findFirst transforms JS objects in equals filter to SQLite',
   async (t) => {


### PR DESCRIPTION
This PR fixes the bug reported by Kyle Mathews on Discord: https://discord.com/channels/933657521581858818/1079688869852753981/1169710877201674300

> Possible bug in 0.7. Upgraded and changed column type to boolean now my node.js liveMany query is failing with SQLite error that it can't bind to the type past in. In the better-sqlite adapter, if I log out queries and args passed to the query function then I see a "true" is being passed in which presumably should be 1. If I try to change the query back to use 1, I get a zod error (as I'd expect).

The problem came from the fact that we were only transforming date objects to SQLite strings but not the other values that were added later (booleans, floats, etc.).