### PR TITLE
feat (client): configurable subscription timeout

### DIFF
--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -23,7 +23,9 @@ export interface ElectricConfig {
    */
   url?: string
   /**
-   * Timeout (in milliseconds) for RPC requests to fulfill shape subscriptions.
+   * Timeout (in milliseconds) for RPC requests.
+   * Needs to be large enough for the server to have time to deliver the full initial subscription data
+   * when the client subscribes to a shape for the first time.
    */
   timeout?: number
   /**

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -23,7 +23,7 @@ export interface ElectricConfig {
    */
   url?: string
   /**
-   * Timeout (in milliseconds) for shape subscriptions to be fulfilled.
+   * Timeout (in milliseconds) for RPC requests to fulfill shape subscriptions.
    */
   timeout?: number
   /**

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -19,9 +19,13 @@ export interface ElectricConfig {
    * ssl is enabled or 80 when it isn't.
    *
    * Defaults to:
-   * `http://127.0.0.1:5133`
+   * `http://localhost:5133`
    */
   url?: string
+  /**
+   * Timeout (in milliseconds) for shape subscriptions to be fulfilled.
+   */
+  timeout?: number
   /**
    * Optional flag to activate debug mode
    * which produces more verbose output.
@@ -40,6 +44,7 @@ export type HydratedConfig = {
     host: string
     port: number
     ssl: boolean
+    timeout: number
   }
   debug: boolean
   connectionBackOffOptions: ConnectionBackOffOptions
@@ -51,6 +56,7 @@ export type InternalElectricConfig = {
     host: string
     port: number
     ssl: boolean
+    timeout: number
   }
   debug?: boolean
   connectionBackOffOptions?: ConnectionBackOffOptions
@@ -63,7 +69,7 @@ export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
   }
 
   const debug = config.debug ?? false
-  const url = new URL(config.url ?? 'http://127.0.0.1:5133')
+  const url = new URL(config.url ?? 'http://localhost:5133')
 
   const isSecureProtocol = url.protocol === 'https:' || url.protocol === 'wss:'
   const sslEnabled = isSecureProtocol || url.searchParams.get('ssl') === 'true'
@@ -76,6 +82,7 @@ export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
     host: url.hostname,
     port: port,
     ssl: sslEnabled,
+    timeout: config.timeout ?? 3000,
   }
 
   const {

--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -52,7 +52,6 @@ export const satelliteDefaults: SatelliteOpts = {
 }
 
 export const satelliteClientDefaults = {
-  timeout: 3000,
   pushPeriod: 500,
 }
 
@@ -60,7 +59,7 @@ export interface SatelliteClientOpts {
   host: string
   port: number
   ssl: boolean
-  timeout?: number
+  timeout: number
   pushPeriod?: number
 }
 

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -9,7 +9,6 @@ import {
   SatelliteClientOpts,
   SatelliteOpts,
   SatelliteOverrides,
-  satelliteClientDefaults,
   satelliteDefaults,
   validateConfig,
 } from './config'
@@ -205,10 +204,10 @@ export class GlobalRegistry extends BaseRegistry {
     }
 
     const satelliteClientOpts: SatelliteClientOpts = {
-      ...satelliteClientDefaults,
       host: config.replication.host,
       port: config.replication.port,
       ssl: config.replication.ssl,
+      timeout: config.replication.timeout,
     }
 
     const client = new SatelliteClient(

--- a/clients/typescript/test/config/config.test.ts
+++ b/clients/typescript/test/config/config.test.ts
@@ -8,9 +8,10 @@ test('hydrateConfig adds expected defaults', async (t) => {
     },
   })
 
-  t.is(hydrated.replication.host, '127.0.0.1')
+  t.is(hydrated.replication.host, 'localhost')
   t.is(hydrated.replication.port, 5133)
   t.is(hydrated.replication.ssl, false)
+  t.is(hydrated.replication.timeout, 3000)
 
   t.is(hydrated.auth.token, 'test-token')
 


### PR DESCRIPTION
This PR adds an option to electrify to configure the timeout for subscriptions as requested in https://github.com/electric-sql/electric/issues/605