### PR TITLE
chore(electric,client): Create new protocol op to represent a compensation

### DIFF
--- a/.changeset/itchy-carrots-invite.md
+++ b/.changeset/itchy-carrots-invite.md
@@ -1,0 +1,6 @@
+---
+"@core/electric": patch
+"electric-sql": patch
+---
+
+[VAX-1335] Create new protocol op to represent a compensation

--- a/.changeset/itchy-carrots-invite.md
+++ b/.changeset/itchy-carrots-invite.md
@@ -1,6 +1,6 @@
 ---
-"@core/electric": patch
-"electric-sql": patch
+"@core/electric": minor
+"electric-sql": minor
 ---
 
 [VAX-1335] Create new protocol op to represent a compensation

--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -217,6 +217,7 @@ export interface SatTransOp {
   insert?: SatOpInsert | undefined;
   delete?: SatOpDelete | undefined;
   migrate?: SatOpMigrate | undefined;
+  compensation?: SatOpCompensation | undefined;
 }
 
 /**
@@ -293,6 +294,16 @@ export interface SatOpDelete {
   $type: "Electric.Satellite.SatOpDelete";
   relationId: number;
   oldRowData:
+    | SatOpRow
+    | undefined;
+  /** dependency information */
+  tags: string[];
+}
+
+export interface SatOpCompensation {
+  $type: "Electric.Satellite.SatOpCompensation";
+  relationId: number;
+  pkData:
     | SatOpRow
     | undefined;
   /** dependency information */
@@ -1508,6 +1519,7 @@ function createBaseSatTransOp(): SatTransOp {
     insert: undefined,
     delete: undefined,
     migrate: undefined,
+    compensation: undefined,
   };
 }
 
@@ -1532,6 +1544,9 @@ export const SatTransOp = {
     }
     if (message.migrate !== undefined) {
       SatOpMigrate.encode(message.migrate, writer.uint32(50).fork()).ldelim();
+    }
+    if (message.compensation !== undefined) {
+      SatOpCompensation.encode(message.compensation, writer.uint32(58).fork()).ldelim();
     }
     return writer;
   },
@@ -1585,6 +1600,13 @@ export const SatTransOp = {
 
           message.migrate = SatOpMigrate.decode(reader, reader.uint32());
           continue;
+        case 7:
+          if (tag !== 58) {
+            break;
+          }
+
+          message.compensation = SatOpCompensation.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1617,6 +1639,9 @@ export const SatTransOp = {
       : undefined;
     message.migrate = (object.migrate !== undefined && object.migrate !== null)
       ? SatOpMigrate.fromPartial(object.migrate)
+      : undefined;
+    message.compensation = (object.compensation !== undefined && object.compensation !== null)
+      ? SatOpCompensation.fromPartial(object.compensation)
       : undefined;
     return message;
   },
@@ -2041,6 +2066,80 @@ export const SatOpDelete = {
 };
 
 messageTypeRegistry.set(SatOpDelete.$type, SatOpDelete);
+
+function createBaseSatOpCompensation(): SatOpCompensation {
+  return { $type: "Electric.Satellite.SatOpCompensation", relationId: 0, pkData: undefined, tags: [] };
+}
+
+export const SatOpCompensation = {
+  $type: "Electric.Satellite.SatOpCompensation" as const,
+
+  encode(message: SatOpCompensation, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.relationId !== 0) {
+      writer.uint32(8).uint32(message.relationId);
+    }
+    if (message.pkData !== undefined) {
+      SatOpRow.encode(message.pkData, writer.uint32(18).fork()).ldelim();
+    }
+    for (const v of message.tags) {
+      writer.uint32(34).string(v!);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SatOpCompensation {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSatOpCompensation();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 8) {
+            break;
+          }
+
+          message.relationId = reader.uint32();
+          continue;
+        case 2:
+          if (tag !== 18) {
+            break;
+          }
+
+          message.pkData = SatOpRow.decode(reader, reader.uint32());
+          continue;
+        case 4:
+          if (tag !== 34) {
+            break;
+          }
+
+          message.tags.push(reader.string());
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  create<I extends Exact<DeepPartial<SatOpCompensation>, I>>(base?: I): SatOpCompensation {
+    return SatOpCompensation.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SatOpCompensation>, I>>(object: I): SatOpCompensation {
+    const message = createBaseSatOpCompensation();
+    message.relationId = object.relationId ?? 0;
+    message.pkData = (object.pkData !== undefined && object.pkData !== null)
+      ? SatOpRow.fromPartial(object.pkData)
+      : undefined;
+    message.tags = object.tags?.map((e) => e) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(SatOpCompensation.$type, SatOpCompensation);
 
 function createBaseSatOpRow(): SatOpRow {
   return { $type: "Electric.Satellite.SatOpRow", nullsBitmask: new Uint8Array(), values: [] };

--- a/clients/typescript/src/migrators/triggers.ts
+++ b/clients/typescript/src/migrators/triggers.ts
@@ -118,10 +118,9 @@ export function generateOplogTriggers(
 /**
  * Generates triggers for compensations for all foreign keys in the provided table.
  *
- * Compensation is recorded as a specially-formatted update. It acts as a no-op, with
- * previous value set to NULL, and it's on the server to figure out that this is a no-op
- * compensation operation (usually `UPDATE` would have previous row state known). The entire
- * reason for it existing is to maybe revive the row if it has been deleted, so we need correct tags.
+ * Compensation is recorded as a SatOpCompensation messaage. The entire reason
+ * for it existing is to maybe revive the row if it has been deleted, so we need
+ * correct tags.
  *
  * The compensation update contains _just_ the primary keys, no other columns are present.
  *

--- a/clients/typescript/src/migrators/triggers.ts
+++ b/clients/typescript/src/migrators/triggers.ts
@@ -155,7 +155,7 @@ function generateCompensationTriggers(table: Table): Statement[] {
              1 == (SELECT value from _electric_meta WHERE key == 'compensations')
       BEGIN
         INSERT INTO _electric_oplog (namespace, tablename, optype, primaryKey, newRow, oldRow, timestamp)
-        SELECT '${fkTableNamespace}', '${fkTableName}', 'UPDATE', json_object(${joinedFkPKs}), json_object(${joinedFkPKs}), NULL, NULL
+        SELECT '${fkTableNamespace}', '${fkTableName}', 'COMPENSATION', json_object(${joinedFkPKs}), json_object(${joinedFkPKs}), NULL, NULL
         FROM "${fkTableNamespace}"."${fkTableName}" WHERE "${foreignKey.parentKey}" = new."${foreignKey.childKey}";
       END;
       `,
@@ -167,7 +167,7 @@ function generateCompensationTriggers(table: Table): Statement[] {
               1 == (SELECT value from _electric_meta WHERE key == 'compensations')
       BEGIN
         INSERT INTO _electric_oplog (namespace, tablename, optype, primaryKey, newRow, oldRow, timestamp)
-        SELECT '${fkTableNamespace}', '${fkTableName}', 'UPDATE', json_object(${joinedFkPKs}), json_object(${joinedFkPKs}), NULL, NULL
+        SELECT '${fkTableNamespace}', '${fkTableName}', 'COMPENSATION', json_object(${joinedFkPKs}), json_object(${joinedFkPKs}), NULL, NULL
         FROM "${fkTableNamespace}"."${fkTableName}" WHERE "${foreignKey.parentKey}" = new."${foreignKey.childKey}";
       END;
       `,

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -592,6 +592,16 @@ export class SatelliteClient implements Client {
             },
           })
           break
+        case DataChangeType.COMPENSATION:
+          console.log('compensation', record)
+          changeOp = SatTransOp.fromPartial({
+            compensation: {
+              pkData: record,
+              relationId: relation.id,
+              tags: tags,
+            },
+          })
+          break
       }
       ops.push(changeOp)
     })

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -593,7 +593,6 @@ export class SatelliteClient implements Client {
           })
           break
         case DataChangeType.COMPENSATION:
-          console.log('compensation', record)
           changeOp = SatTransOp.fromPartial({
             compensation: {
               pkData: record,

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -118,6 +118,7 @@ export enum DataChangeType {
   INSERT = 'INSERT',
   UPDATE = 'UPDATE',
   DELETE = 'DELETE',
+  COMPENSATION = 'COMPENSATION',
 }
 
 export type Change = DataChange | SchemaChange

--- a/components/electric/lib/electric/postgres/shadow_table_transformation.ex
+++ b/components/electric/lib/electric/postgres/shadow_table_transformation.ex
@@ -96,6 +96,10 @@ defmodule Electric.Postgres.ShadowTableTransformation do
 
   defp build_bitmask(%Changes.NewRecord{}, columns), do: Enum.map(columns, fn _ -> "t" end)
 
+  defp build_bitmask(%Changes.Compensation{}, columns), do: Enum.map(columns, fn _ -> "f" end)
+
+  # TODO: Kept for compatibility with old clients that send a special update for compensation
+  # messages. remove once we're sure all clients have been updated.
   defp build_bitmask(%Changes.UpdatedRecord{old_record: nil}, columns),
     do: Enum.map(columns, fn _ -> "f" end)
 

--- a/components/electric/lib/electric/postgres/shadow_table_transformation.ex
+++ b/components/electric/lib/electric/postgres/shadow_table_transformation.ex
@@ -98,11 +98,6 @@ defmodule Electric.Postgres.ShadowTableTransformation do
 
   defp build_bitmask(%Changes.Compensation{}, columns), do: Enum.map(columns, fn _ -> "f" end)
 
-  # TODO: Kept for compatibility with old clients that send a special update for compensation
-  # messages. remove once we're sure all clients have been updated.
-  defp build_bitmask(%Changes.UpdatedRecord{old_record: nil}, columns),
-    do: Enum.map(columns, fn _ -> "f" end)
-
   defp build_bitmask(%Changes.UpdatedRecord{old_record: old, record: new}, columns),
     do: Enum.map(columns, fn col -> if old[col] != new[col], do: "t", else: "f" end)
 

--- a/components/electric/lib/electric/replication/postgres/slot_server.ex
+++ b/components/electric/lib/electric/replication/postgres/slot_server.ex
@@ -458,6 +458,13 @@ defmodule Electric.Replication.Postgres.SlotServer do
     }
   end
 
+  defp changes_to_wal(%Changes.Compensation{relation: table, record: new}, relations) do
+    %ReplicationMessages.Update{
+      relation_id: relations[table].oid,
+      tuple_data: record_to_tuple(new, relations[table].columns)
+    }
+  end
+
   defp changes_to_wal(
          %Changes.UpdatedRecord{relation: table, old_record: nil, record: new},
          relations

--- a/components/electric/lib/electric/replication/postgres/slot_server.ex
+++ b/components/electric/lib/electric/replication/postgres/slot_server.ex
@@ -466,16 +466,6 @@ defmodule Electric.Replication.Postgres.SlotServer do
   end
 
   defp changes_to_wal(
-         %Changes.UpdatedRecord{relation: table, old_record: nil, record: new},
-         relations
-       ) do
-    %ReplicationMessages.Update{
-      relation_id: relations[table].oid,
-      tuple_data: record_to_tuple(new, relations[table].columns)
-    }
-  end
-
-  defp changes_to_wal(
          %Changes.UpdatedRecord{relation: table, old_record: old, record: new},
          relations
        ) do

--- a/components/electric/lib/electric/satellite/protobuf.ex
+++ b/components/electric/lib/electric/satellite/protobuf.ex
@@ -107,6 +107,7 @@ defmodule Electric.Satellite.Protobuf do
         SatOpInsert,
         SatOpUpdate,
         SatOpMigrate,
+        SatOpCompensation,
         SatTransOp,
         SatRelation,
         SatRelationColumn,

--- a/components/electric/lib/electric/satellite/protobuf.ex
+++ b/components/electric/lib/electric/satellite/protobuf.ex
@@ -126,15 +126,6 @@ defmodule Electric.Satellite.Protobuf do
     end
   end
 
-  defmodule Version do
-    defstruct major: nil, minor: nil
-
-    @type t() :: %__MODULE__{
-            major: integer,
-            minor: integer
-          }
-  end
-
   @spec decode(byte(), binary()) :: {:ok, sq_pb_msg()} | {:error, any()}
   for {module, tag} <- @mapping do
     def decode(unquote(tag), binary) do

--- a/components/electric/lib/electric/satellite/serialization.ex
+++ b/components/electric/lib/electric/satellite/serialization.ex
@@ -7,7 +7,8 @@ defmodule Electric.Satellite.Serialization do
     Transaction,
     NewRecord,
     UpdatedRecord,
-    DeletedRecord
+    DeletedRecord,
+    Compensation
   }
 
   use Electric.Satellite.Protobuf
@@ -393,13 +394,18 @@ defmodule Electric.Satellite.Serialization do
     %NewRecord{record: decode_record!(row_data, columns), tags: tags}
   end
 
-  defp op_to_change(
-         %SatOpUpdate{row_data: row_data, old_row_data: nil, tags: tags},
-         columns
-       ) do
-    %UpdatedRecord{
+  defp op_to_change(%SatOpCompensation{pk_data: pk_data, tags: tags}, columns) do
+    %Compensation{
+      record: decode_record!(pk_data, columns, :allow_nulls),
+      tags: tags
+    }
+  end
+
+  # TODO: Kept for compatibility with old clients that send a special update for compensation
+  # messages. remove once we're sure all clients have been updated.
+  defp op_to_change(%SatOpUpdate{row_data: row_data, old_row_data: nil, tags: tags}, columns) do
+    %Compensation{
       record: decode_record!(row_data, columns, :allow_nulls),
-      old_record: nil,
       tags: tags
     }
   end

--- a/components/electric/lib/electric/satellite/serialization.ex
+++ b/components/electric/lib/electric/satellite/serialization.ex
@@ -403,7 +403,9 @@ defmodule Electric.Satellite.Serialization do
 
   # TODO: Kept for compatibility with old clients that send a special update for compensation
   # messages. remove once we're sure all clients have been updated.
-  defp op_to_change(%SatOpUpdate{row_data: row_data, old_row_data: nil, tags: tags}, columns) do
+  defp op_to_change(%SatOpUpdate{row_data: row_data, old_row_data: nil, tags: tags} = op, columns) do
+    Logger.warning("Received old-style compensation update #{inspect(op)}")
+
     %Compensation{
       record: decode_record!(row_data, columns, :allow_nulls),
       tags: tags

--- a/components/electric/lib/satellite/protocol_helpers.ex
+++ b/components/electric/lib/satellite/protocol_helpers.ex
@@ -129,6 +129,7 @@ defmodule Satellite.ProtocolHelpers do
         %SatOpInsert{} = op -> %SatTransOp{op: {:insert, op}}
         %SatOpUpdate{} = op -> %SatTransOp{op: {:update, op}}
         %SatOpDelete{} = op -> %SatTransOp{op: {:delete, op}}
+        %SatOpCompensation{} = op -> %SatTransOp{op: {:compensation, op}}
       end)
 
     %SatOpLog{ops: ops}

--- a/e2e/tests/05.05_compensations_within_same_tx_are_fine.lux
+++ b/e2e/tests/05.05_compensations_within_same_tx_are_fine.lux
@@ -26,7 +26,7 @@
     [invoke start_elixir_test 1]
     [invoke client_session 1 1]
     
-    !alias Electric.Satellite.{SatRelation, SatRelationColumn, SatOpInsert, SatOpUpdate, SatOpRow}
+    !alias Electric.Satellite.{SatRelation, SatRelationColumn, SatOpInsert, SatOpUpdate, SatOpCompensation, SatOpRow}
 
     """!
     Satellite.TestWsClient.send_data(conn, %SatRelation{
@@ -58,7 +58,7 @@
     """!
     Satellite.TestWsClient.send_data(conn, ProtocolHelpers.transaction("1", DateTime.to_unix(DateTime.utc_now(), :millisecond), [
         %SatOpInsert{relation_id: 1, row_data: %SatOpRow{nulls_bitmask: <<0>>, values: ["00000000-0000-0000-0000-000000000000", "test_content"]}},
-        %SatOpUpdate{relation_id: 1, row_data: %SatOpRow{nulls_bitmask: <<0::1, 1::1, 0::6>>, values: ["00000000-0000-0000-0000-000000000000", ""]}},
+        %SatOpCompensation{relation_id: 1, pk_data: %SatOpRow{nulls_bitmask: <<0::1, 1::1, 0::6>>, values: ["00000000-0000-0000-0000-000000000000", ""]}},
         %SatOpInsert{relation_id: 2, row_data: %SatOpRow{nulls_bitmask: <<0>>, values: ["00000000-0000-0000-0000-000000000001", "child content", "00000000-0000-0000-0000-000000000000"]}},
     ]))
     """

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -225,6 +225,7 @@ message SatTransOp {
         SatOpInsert insert = 4;
         SatOpDelete delete = 5;
         SatOpMigrate migrate = 6;
+        SatOpCompensation compensation = 7;
     }
 }
 
@@ -281,6 +282,13 @@ message SatOpDelete {
     // dependency information
     repeated string tags = 3;
 
+}
+
+message SatOpCompensation {
+    uint32 relation_id = 1;
+    SatOpRow pk_data = 2;
+    // dependency information
+    repeated string tags = 4;
 }
 
 // Dependency information for row data.


### PR DESCRIPTION
For permissions etc we need to always have the `OLD` values available, so for clarity don't send out SatOpUpdate with no old_data values