### PR TITLE
fix (generator): capitalise model names

### DIFF
--- a/.changeset/quiet-otters-film.md
+++ b/.changeset/quiet-otters-film.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Rely on Prisma's conversion of PG table names to Prisma model names. No longer turn snake_cased table names into PascalCased model names.

--- a/clients/typescript/test/cli/migrations/migrate.test.ts
+++ b/clients/typescript/test/cli/migrations/migrate.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { doPascalCaseTableNames } from '../../../src/cli/migrations/migrate'
+import { doCapitaliseTableNames } from '../../../src/cli/migrations/migrate'
 
 const lowerCasePrismaSchema = `
 datasource db {
@@ -71,45 +71,45 @@ generator client {
 }
 
 model Items {
-  @@map("items")
   value String @id
   nbr   Int?
+  @@map("items")
 }
 
 model User {
-  @@map("user")
   id      Int      @id
   name    String?
   posts   Post[]
-  profile UserProfile?
+  profile User_profile?
+  @@map("user")
 }
 
 model Post {
-  @@map("post")
   id        Int @id
   title     String @unique
   contents  String
   nbr       Int?
   authorId  Int
   author    User?  @relation(fields: [authorId], references: [id])
+  @@map("post")
 }
 
-model UserProfile {
-  @@map("user_profile")
+model User_profile {
   id     Int    @id
   bio    String
   userId Int    @unique
   user   User?  @relation(fields: [userId], references: [id])
+  @@map("user_profile")
 }
 
 model Model {
-  @@map("model")
   id Int @id
+  @@map("model")
 }
 `
 
-test('migrator correctly PascalCases model names', (t) => {
-  const newSchema = doPascalCaseTableNames(
+test('migrator correctly capitalises model names', (t) => {
+  const newSchema = doCapitaliseTableNames(
     lowerCasePrismaSchema.split(/\r?\n/)
   ).join('\n')
   t.assert(newSchema === expectedPrismaSchema)


### PR DESCRIPTION
This PR modifies the generator to capitalise the first letter of model names in the generated Prisma schema.
We no longer turn snake_cased model names into PascalCase because this may lead to additional name clashes.
We also let Prisma turn PG table names such as `_foo` into valid model names like `foo`.