### PR TITLE
client: Log SQLite version when starting

### DIFF
--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -22,6 +22,8 @@ export interface SatelliteOpts {
   clearOnBehindWindow: boolean
   /** Backoff options for connecting with Electric*/
   connectionBackOffOptions: ConnectionBackoffOptions
+  /** With debug mode enabled, Satellite can show additional logs. */
+  debug: boolean
 }
 
 export interface SatelliteOverrides {
@@ -49,6 +51,7 @@ export const satelliteDefaults: SatelliteOpts = {
     numOfAttempts: 50,
     timeMultiple: 2,
   },
+  debug: false,
 }
 
 export const satelliteClientDefaults = {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -203,10 +203,9 @@ export class SatelliteProcess implements Satellite {
   }
 
   async start(authConfig: AuthConfig): Promise<ConnectionWrapper> {
-    const sqliteVersionRow = await this.adapter.query({
-      sql: 'SELECT sqlite_version() AS version',
-    })
-    Log.info(`Using SQLite version: ${sqliteVersionRow[0]['version']}`)
+    if (this.opts.debug) {
+      await this.logSQLiteVersion()
+    }
 
     await this.migrator.up()
 
@@ -284,6 +283,13 @@ export class SatelliteProcess implements Satellite {
 
     const connectionPromise = this._connectWithBackoff()
     return { connectionPromise }
+  }
+
+  private async logSQLiteVersion(): Promise<void> {
+    const sqliteVersionRow = await this.adapter.query({
+      sql: 'SELECT sqlite_version() AS version',
+    })
+    Log.info(`Using SQLite version: ${sqliteVersionRow[0]['version']}`)
   }
 
   async _setAuthState(authState: AuthState): Promise<void> {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -203,6 +203,11 @@ export class SatelliteProcess implements Satellite {
   }
 
   async start(authConfig: AuthConfig): Promise<ConnectionWrapper> {
+    const sqliteVersionRow = await this.adapter.query({
+      sql: 'SELECT sqlite_version() AS version',
+    })
+    Log.info(`Using SQLite version: ${sqliteVersionRow[0]['version']}`)
+
     await this.migrator.up()
 
     const isVerified = await this._verifyTableStructure()

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -219,6 +219,7 @@ export class GlobalRegistry extends BaseRegistry {
     const satelliteOpts: SatelliteOpts = {
       ...satelliteDefaults,
       connectionBackOffOptions: config.connectionBackOffOptions,
+      debug: config.debug,
     }
 
     const satellite = new SatelliteProcess(


### PR DESCRIPTION
Log the SQLite version that is running on the client.
I feel it could end up being useful, given how there could be features/bugs on different versions of SQLite that run on the multiple supported adapters.