### PR TITLE
chore(electric): Remove the operator class for the `electric.tag` type

### DIFF
--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/electric_tag_type_and_operators.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/electric_tag_type_and_operators.sql
@@ -146,13 +146,3 @@ CREATE OR REPLACE FUNCTION electric.tag_operator_cmp(first electric.tag, second 
         WHEN first < second then -1
         ELSE 1
     END;
-
-
-CREATE OPERATOR CLASS btree__electric_tag_ops
-    DEFAULT FOR TYPE electric.tag USING btree AS
-        OPERATOR 1 <,
-        OPERATOR 2 <=,
-        OPERATOR 3 =,
-        OPERATOR 4 >=,
-        OPERATOR 5 >,
-        FUNCTION 1 electric.tag_operator_cmp(electric.tag, electric.tag);


### PR DESCRIPTION
_Note: I've extracted this commit from https://github.com/electric-sql/electric/pull/626 to preserve the explanation below in the commit history._

Only a superuser can create an operator class but we're moving away from the superuser requirement for Electric.

An operator class is used in the following situations:

  * an index is created on a column that has a user-defined type with custom operators defined for it

  * values of the user-defined type appear in the ORDER BY clause

  * values of the user-defined type are used in DISTINCT or GROUP BY clauses

I haven't been able to conduct an exhaustive audit of the code to confirm that we don't use the electric.tag type in those contexts. So I'm proposing we merge this change into main and see if that causes any issues in how Electric works.