### PR TITLE
capacitor-sqlite runInTransaction now takes the lock.

### DIFF
--- a/.changeset/quick-rats-end.md
+++ b/.changeset/quick-rats-end.md
@@ -2,4 +2,4 @@
 "electric-sql": patch
 ---
 
-Capacitor sqlite DB driver re-imlemented to extend the new generic BatchDatabaseAdapter.
+Capacitor sqlite DB driver re-implemented to extend the new generic BatchDatabaseAdapter.

--- a/.changeset/quick-rats-end.md
+++ b/.changeset/quick-rats-end.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Capacitor sqlite DB driver re-imlemented to extend the new generic BatchDatabaseAdapter.

--- a/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
@@ -41,6 +41,14 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
     return { rowsAffected: this.#rowsAffected }
   }
 
+  /**
+   *
+   * @returns the number of rows modifierd by the last exec or execBatch call.
+   * Because Capacitor-SQLite does not expose sqlite3_changes, the value returned here is cached
+   * from the previous query's reported value, which is 0 for queries other than INSERT, UPDATE or DELETE.
+   * Calling getRowsModified() right after execBatch should return an accurate aggregated result, regardless
+   * of the type of statements executed in the batch.
+   */
   getRowsModified() {
     return this.#rowsAffected
   }

--- a/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
@@ -43,7 +43,7 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
 
   /**
    *
-   * @returns the number of rows modifierd by the last exec or execBatch call.
+   * @returns the number of rows modified by the last exec or execBatch call.
    * Because Capacitor-SQLite does not expose sqlite3_changes, the value returned here is cached
    * from the previous query's reported value, which is 0 for queries other than INSERT, UPDATE or DELETE.
    * Calling getRowsModified() right after execBatch should return an accurate aggregated result, regardless

--- a/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
@@ -1,153 +1,47 @@
-import { capSQLiteSet } from '@capacitor-community/sqlite'
-import {
-  DatabaseAdapter as DatabaseAdapterInterface,
-  RunResult,
-  TableNameImpl,
-  Transaction as Tx,
-} from '../../electric/adapter'
-import { Row, SqlValue, Statement } from '../../util'
 import { Database } from './database'
-import { Mutex } from 'async-mutex'
+import { Row, SqlValue } from '../../util/types'
+import { Statement } from '../../util'
+import { BatchDatabaseAdapter as GenericDatabaseAdapter } from '../generic'
+import { capSQLiteSet } from '@capacitor-community/sqlite'
+import { RunResult } from '../../electric/adapter'
 
-export class DatabaseAdapter
-  extends TableNameImpl
-  implements DatabaseAdapterInterface
-{
-  #txMutex: Mutex
+export class DatabaseAdapter extends GenericDatabaseAdapter {
+  readonly db: Database
+  #rowsAffected = 0
 
-  constructor(public db: Database) {
+  constructor(db: Database) {
     super()
-    this.#txMutex = new Mutex()
+    this.db = db
   }
 
-  /**
-   * Executes a single SQLite statement, without taking the lock and without wrapping it in a transaction.
-   * @param statement:
-   * @returns
-   */
-  async run({ sql, args }: Statement): Promise<RunResult> {
+  async exec(statement: Statement): Promise<Row[]> {
     const wrapInTransaction = false
+    const result = await this.db.run(
+      statement.sql,
+      statement.args,
+      wrapInTransaction
+    )
 
-    const result = await this.db.run(sql, args, wrapInTransaction)
-    const rowsAffected = result.changes?.changes ?? 0
-    return { rowsAffected }
+    this.#rowsAffected = result.changes?.changes ?? 0
+
+    return result.changes?.values ? result.changes.values : []
   }
 
-  /**
-   * Runs one or more statements within a transaction block, taking the lock.
-   * @param statements
-   * @returns
-   */
-  async runInTransaction(...statements: Statement[]): Promise<RunResult> {
+  async execBatch(statements: Statement[]): Promise<RunResult> {
     const set: capSQLiteSet[] = statements.map(({ sql, args }) => ({
       statement: sql,
       values: (args ?? []) as SqlValue[],
     }))
 
     const wrapInTransaction = true
-
-    const releaseMutex = await this.#txMutex.acquire()
     const result = await this.db.executeSet(set, wrapInTransaction)
-    releaseMutex()
 
-    const rowsAffected = result.changes?.changes ?? 0
-    // TODO: unsure how capacitor-sqlite populates the changes value (additive?), and what is expected of electric here.
-    return { rowsAffected }
+    this.#rowsAffected = result.changes?.changes ?? 0
+
+    return { rowsAffected: this.#rowsAffected }
   }
 
-  /**
-   * Queries a single statement, without taking the lock or wrapping in a transaction. Intended for select statements.
-   * @param
-   * @returns
-   */
-  async query({ sql, args }: Statement): Promise<Row[]> {
-    const result = await this.db.query(sql, args)
-    return result.values ?? []
-  }
-
-  // No async await on capacitor-sqlite promise-based APIs + the complexity of the transaction<T> API make for one ugly implementation...
-  async transaction<T>(
-    f: (_tx: Tx, setResult: (res: T) => void) => void
-  ): Promise<T> {
-    // Acquire mutex before even instantiating the transaction object.
-    // This will ensure transactions cannot get interleaved.
-    const releaseMutex = await this.#txMutex.acquire()
-    return new Promise<T>((resolve, reject) => {
-      // Convenience function. Rejecting should always release the acquired mutex.
-      const releaseMutexAndReject = (err?: any) => {
-        releaseMutex()
-        reject(err)
-      }
-
-      this.db
-        .beginTransaction()
-        .then(() => {
-          const wrappedTx = new WrappedTx(this)
-          try {
-            f(wrappedTx, (res) => {
-              // Client calls this setResult function when done. Commit and resolve.
-              this.db
-                .commitTransaction()
-                .then(() => {
-                  releaseMutex()
-                  resolve(res)
-                })
-                .catch((err) => releaseMutexAndReject(err))
-            })
-          } catch (err) {
-            this.db
-              .rollbackTransaction()
-              .then(() => {
-                releaseMutexAndReject(err)
-              })
-              .catch((err) => releaseMutexAndReject(err))
-          }
-        })
-        .catch((err) => releaseMutexAndReject(err)) // Are all those catch -> rejects needed? Apparently, yes because of explicit promises. Tests confirm this.
-    })
-  }
-}
-
-// Did consider handling begin/commit/rollback transaction in this wrapper, but in the end it made more sense
-// to do so within the transaction<T> implementation, promises bubble up naturally that way and no need for inTransaction flag.
-class WrappedTx implements Tx {
-  constructor(private adapter: DatabaseAdapter) {}
-
-  run(
-    statement: Statement,
-    successCallback?: (tx: Tx, res: RunResult) => void,
-    errorCallback?: (error: any) => void
-  ): void {
-    this.adapter
-      .run(statement)
-      .then((runResult) => {
-        if (typeof successCallback !== 'undefined') {
-          successCallback(this, runResult)
-        }
-      })
-      .catch((err) => {
-        if (typeof errorCallback !== 'undefined') {
-          errorCallback(err)
-        }
-      })
-  }
-
-  query(
-    statement: Statement,
-    successCallback: (tx: Tx, res: Row[]) => void,
-    errorCallback?: (error: any) => void
-  ): void {
-    this.adapter
-      .query(statement)
-      .then((result) => {
-        if (typeof successCallback !== 'undefined') {
-          successCallback(this, result)
-        }
-      })
-      .catch((err) => {
-        if (typeof errorCallback !== 'undefined') {
-          errorCallback(err)
-        }
-      })
+  getRowsModified() {
+    return this.#rowsAffected
   }
 }

--- a/clients/typescript/src/drivers/capacitor-sqlite/database.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/database.ts
@@ -2,12 +2,10 @@ import { SQLiteDBConnection } from '@capacitor-community/sqlite'
 import { DbName } from '../../util/types'
 
 // A bit of a hack, but that lets us reference the actual types of the library
-// TODO: Is this the type we want to expose?
 type OriginalDatabase = SQLiteDBConnection
 
 // The relevant subset of the SQLitePlugin database client API
 // that we need to ensure the client we're electrifying provides.
-// TODO: verify which functions we actually need.
 export interface Database extends Pick<OriginalDatabase, 'executeSet' | 'run'> {
   dbname?: DbName
 }

--- a/clients/typescript/src/drivers/capacitor-sqlite/database.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/database.ts
@@ -8,15 +8,6 @@ type OriginalDatabase = SQLiteDBConnection
 // The relevant subset of the SQLitePlugin database client API
 // that we need to ensure the client we're electrifying provides.
 // TODO: verify which functions we actually need.
-export interface Database
-  extends Pick<
-    OriginalDatabase,
-    | 'executeSet'
-    | 'query'
-    | 'run'
-    | 'beginTransaction'
-    | 'commitTransaction'
-    | 'rollbackTransaction'
-  > {
+export interface Database extends Pick<OriginalDatabase, 'executeSet' | 'run'> {
   dbname?: DbName
 }

--- a/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
@@ -1,4 +1,4 @@
-import { capSQLiteChanges, DBSQLiteValues } from '@capacitor-community/sqlite'
+import { capSQLiteChanges } from '@capacitor-community/sqlite'
 import { DbName } from '../../util/types'
 import { Database } from './database'
 
@@ -9,26 +9,16 @@ export class MockDatabase implements Database {
     return this.resolveIfNotFail({ changes: { changes: 0 } })
   }
 
-  query(): Promise<DBSQLiteValues> {
-    return this.resolveIfNotFail({
-      values: [
-        { textColumn: 'text1', numberColumn: 1 },
-        { textColumn: 'text2', numberColumn: 2 },
-      ],
-    })
-  }
-
   run(): Promise<capSQLiteChanges> {
-    return this.resolveIfNotFail({ changes: { changes: 0 } })
-  }
-  beginTransaction(): Promise<capSQLiteChanges> {
-    return this.resolveIfNotFail({ changes: { changes: 0 } })
-  }
-  commitTransaction(): Promise<capSQLiteChanges> {
-    return this.resolveIfNotFail({ changes: { changes: 0 } })
-  }
-  rollbackTransaction(): Promise<capSQLiteChanges> {
-    return this.resolveIfNotFail({ changes: { changes: 0 } })
+    return this.resolveIfNotFail({
+      changes: {
+        changes: 0,
+        values: [
+          { textColumn: 'text1', numberColumn: 1 },
+          { textColumn: 'text2', numberColumn: 2 },
+        ],
+      },
+    })
   }
 
   private resolveIfNotFail<T>(value: T): Promise<T> {

--- a/clients/typescript/src/drivers/capacitor-sqlite/test.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/test.ts
@@ -9,13 +9,14 @@ import { Notifier } from '../../notifiers/index'
 import { MockNotifier } from '../../notifiers/mock'
 import { MockRegistry } from '../../satellite/mock'
 
-import { DatabaseAdapter } from './adapter'
+import { DatabaseAdapter as CapacitorSQLiteAdapater } from './adapter'
 import { Database } from './database'
 import { MockDatabase } from './mock'
 import { MockSocket } from '../../sockets/mock'
 import { ElectricClient } from '../../client/model/client'
 import { ElectricConfig } from '../../config'
 import { DbSchema } from '../../client/model'
+import { DatabaseAdapter } from '../better-sqlite3'
 
 const testConfig = {
   auth: {
@@ -38,7 +39,7 @@ export const initTestable = async <
 ): RetVal<DB, N> => {
   const db = new MockDatabase(dbName)
 
-  const adapter = opts?.adapter || new DatabaseAdapter(db)
+  const adapter = opts?.adapter || new CapacitorSQLiteAdapater(db)
   const notifier = (opts?.notifier as N) || new MockNotifier(dbName)
   const migrator = opts?.migrator || new MockMigrator()
   const socketFactory = opts?.socketFactory || MockSocket
@@ -47,7 +48,7 @@ export const initTestable = async <
   const dal = await electrify(
     dbName,
     dbDescription,
-    adapter,
+    adapter as DatabaseAdapter,
     socketFactory,
     config,
     {

--- a/clients/typescript/src/drivers/capacitor-sqlite/test.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/test.ts
@@ -9,14 +9,13 @@ import { Notifier } from '../../notifiers/index'
 import { MockNotifier } from '../../notifiers/mock'
 import { MockRegistry } from '../../satellite/mock'
 
-import { DatabaseAdapter as CapacitorSQLiteAdapater } from './adapter'
+import { DatabaseAdapter as CapacitorSQLiteAdapter } from './adapter'
 import { Database } from './database'
 import { MockDatabase } from './mock'
 import { MockSocket } from '../../sockets/mock'
 import { ElectricClient } from '../../client/model/client'
 import { ElectricConfig } from '../../config'
 import { DbSchema } from '../../client/model'
-import { DatabaseAdapter } from '../better-sqlite3'
 
 const testConfig = {
   auth: {
@@ -39,7 +38,7 @@ export const initTestable = async <
 ): RetVal<DB, N> => {
   const db = new MockDatabase(dbName)
 
-  const adapter = opts?.adapter || new CapacitorSQLiteAdapater(db)
+  const adapter = opts?.adapter || new CapacitorSQLiteAdapter(db)
   const notifier = (opts?.notifier as N) || new MockNotifier(dbName)
   const migrator = opts?.migrator || new MockMigrator()
   const socketFactory = opts?.socketFactory || MockSocket
@@ -48,7 +47,7 @@ export const initTestable = async <
   const dal = await electrify(
     dbName,
     dbDescription,
-    adapter as DatabaseAdapter,
+    adapter,
     socketFactory,
     config,
     {

--- a/clients/typescript/test/drivers/capacitor-sqlite.test.ts
+++ b/clients/typescript/test/drivers/capacitor-sqlite.test.ts
@@ -18,7 +18,7 @@ test('database adapter query works', async (t) => {
   const db = new MockDatabase(dbName)
   const adapter = new DatabaseAdapter(db)
 
-  const sql = 'select * from bars'
+  const sql = 'select * from bars;'
   const result = await adapter.query({ sql })
 
   t.deepEqual(result, [
@@ -48,7 +48,7 @@ test('database adapter interactive transaction works', async (t) => {
   const db = new MockDatabase(dbName)
   const adapter = new DatabaseAdapter(db)
 
-  const sql = 'select * from bars'
+  const sql = 'select * from bars;'
   const res = await adapter.transaction<number>((tx, setResult) => {
     tx.run({ sql }, (tx, res) => {
       t.assert(res.rowsAffected == 0)


### PR DESCRIPTION
[EDIT] Following @kevin-dp 's work on generic adapters, this PR has been repurposed. The concurrency issue is now taken care of by implementing BatchDatabaseAdapter.

## ORIGINAL PR DESCRIPTION
This PR fixes a concurrency issue with the capacitor-sqlite database adapter. The mutex was previously only acquired in the `transaction` method, causing concurrency conflicts when calling `runInTransaction`.

Comments have been added to other public methods of the adapter in order to clarify the intended behaviour of each method. In effect, `run`, `execute` and `query` have ambiguous meanings depending on the layer (electric driver -> capacitor-sqlite -> native SQLite). It is therefore important to make sure that the methods as implemented correspond to what is expected of `electric`'s API.