### PR TITLE
chore (client): provide generic DB adapters for serial and batch execution of SQL

### DIFF
--- a/.changeset/few-apples-buy.md
+++ b/.changeset/few-apples-buy.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Generic implementation of serial and batched database adapters.

--- a/clients/typescript/src/drivers/expo-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/expo-sqlite/adapter.ts
@@ -1,6 +1,6 @@
 import { Row } from '../../util/types'
 import { Statement } from '../../util'
-import { DatabaseAdapter as GenericDatabaseAdapter } from '../generic'
+import { SerialDatabaseAdapter as GenericDatabaseAdapter } from '../generic'
 import { Database } from './database'
 
 export class DatabaseAdapter extends GenericDatabaseAdapter {

--- a/clients/typescript/src/drivers/generic/adapter.ts
+++ b/clients/typescript/src/drivers/generic/adapter.ts
@@ -33,7 +33,7 @@ abstract class DatabaseAdapter
   abstract exec(statement: Statement): Promise<Row[]>
 
   /**
-   * @returns The number of rows modified by the last SQL query.
+   * @returns The number of rows modified by the last insert/update/delete query.
    */
   abstract getRowsModified(): number
 

--- a/clients/typescript/src/drivers/generic/index.ts
+++ b/clients/typescript/src/drivers/generic/index.ts
@@ -1,3 +1,1 @@
-import { DatabaseAdapter } from './adapter'
-
-export { DatabaseAdapter }
+export { SerialDatabaseAdapter, BatchDatabaseAdapter } from './adapter'

--- a/clients/typescript/src/drivers/wa-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/wa-sqlite/adapter.ts
@@ -1,7 +1,7 @@
 import { Database } from './database'
 import { Row } from '../../util/types'
 import { Statement } from '../../util'
-import { DatabaseAdapter as GenericDatabaseAdapter } from '../generic'
+import { SerialDatabaseAdapter as GenericDatabaseAdapter } from '../generic'
 
 export class DatabaseAdapter extends GenericDatabaseAdapter {
   readonly db: Database

--- a/clients/typescript/src/util/statements.ts
+++ b/clients/typescript/src/util/statements.ts
@@ -1,12 +1,7 @@
 import { SqlValue, Statement } from './types'
 
-export function isInsertUpdateOrDeleteStatement(sql: string) {
-  const tpe = sql.toLowerCase().trimStart()
-  return (
-    tpe.startsWith('insert') ||
-    tpe.startsWith('update') ||
-    tpe.startsWith('delete')
-  )
+export function isInsertUpdateOrDeleteStatement(stmt: string) {
+  return /^\s*(insert|update|delete)/i.test(stmt)
 }
 
 /**


### PR DESCRIPTION
This PR splits the generic database adapter into two separate ones, one for serial execution of SQL queries and one for batched execution of SQL queries.