### PR TITLE
fix: Update npx electric-sql generate to support Windows path format

### DIFF
--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -198,6 +198,17 @@ async function _generate(opts: Omit<GeneratorOptions, 'watch'>) {
 }
 
 /**
+ * Escapes file path for use in strings.
+ * On Windows, replaces backslashes with double backslashes for string escaping.
+ * 
+ * @param {string} inputPath - The file path to escape.
+ * @return {string} The escaped file path.
+ */
+function escapePathForString(inputPath: string): string {
+  return process.platform === 'win32' ? inputPath.replace(/\\/g, '\\\\') : inputPath;
+}
+
+/**
  * Creates a fresh Prisma schema in the provided folder.
  * The Prisma schema is initialised with a generator and a datasource.
  */
@@ -219,8 +230,8 @@ async function createPrismaSchema(
     }
 
     generator electric {
-      provider      = "${provider}"
-      output        = "${output}"
+      provider      = "${escapePathForString(provider)}"
+      output        = "${escapePathForString(output)}"
       relationModel = "false"
     }
 

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -200,12 +200,14 @@ async function _generate(opts: Omit<GeneratorOptions, 'watch'>) {
 /**
  * Escapes file path for use in strings.
  * On Windows, replaces backslashes with double backslashes for string escaping.
- * 
+ *
  * @param {string} inputPath - The file path to escape.
  * @return {string} The escaped file path.
  */
 function escapePathForString(inputPath: string): string {
-  return process.platform === 'win32' ? inputPath.replace(/\\/g, '\\\\') : inputPath;
+  return process.platform === 'win32'
+    ? inputPath.replace(/\\/g, '\\\\')
+    : inputPath
 }
 
 /**


### PR DESCRIPTION
This PR introduces the escapePathForString function to ensure correct path handling on Windows in our Prisma schema setup. Paths for provider and output are now escaped appropriately, resolving potential issues with backslashes on Windows systems.

Fixes #535 

