### PR TITLE
chore (client): upgrade version of wa-sqlite

### DIFF
--- a/.changeset/fluffy-hotels-push.md
+++ b/.changeset/fluffy-hotels-push.md
@@ -1,0 +1,6 @@
+---
+"electric-sql": patch
+"create-electric-app": patch
+---
+
+Upgrade wa-sqlite version because of a critical bug fix in wa-sqlite.

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -217,7 +217,7 @@
     "ts-proto": "^1.125.0",
     "typeorm": "^0.3.9",
     "typescript": "^4.9",
-    "wa-sqlite": "git+https://github.com/rhashimoto/wa-sqlite#master",
+    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8",
     "web-worker": "^1.2.0"
   },
   "peerDependencies": {
@@ -229,7 +229,7 @@
     "react-native": ">= 0.68.0",
     "react-native-sqlite-storage": ">= 6.0.0",
     "typeorm": ">=0.3.0",
-    "wa-sqlite": "git+https://github.com/rhashimoto/wa-sqlite#master"
+    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8"
   },
   "peerDependenciesMeta": {
     "@capacitor-community/sqlite": {

--- a/examples/beer-stars/package.json
+++ b/examples/beer-stars/package.json
@@ -36,7 +36,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.0",
-    "wa-sqlite": "rhashimoto/wa-sqlite"
+    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8"
   },
   "devDependencies": {
     "@databases/pg": "^5.4.1",

--- a/examples/beer-stars/yarn.lock
+++ b/examples/beer-stars/yarn.lock
@@ -2307,9 +2307,9 @@ uuid@^9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
-wa-sqlite@rhashimoto/wa-sqlite:
-  version "0.9.8"
-  resolved "https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/56628cec216432bfa67186766f02f503fae8471f"
+"wa-sqlite@rhashimoto/wa-sqlite#semver:^0.9.8":
+  version "0.9.9"
+  resolved "https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a"
 
 walkjs@^3.2.4:
   version "3.2.4"

--- a/examples/ionic-demo/package-lock.json
+++ b/examples/ionic-demo/package-lock.json
@@ -27,7 +27,7 @@
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
         "uuid": "^9.0.0",
-        "wa-sqlite": "rhashimoto/wa-sqlite"
+        "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8"
       },
       "devDependencies": {
         "@capacitor/assets": "^3.0.0",
@@ -14923,8 +14923,8 @@
       }
     },
     "node_modules/wa-sqlite": {
-      "version": "0.9.5",
-      "resolved": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#a856e82f1f5736892539f6d05abbb569dd59011b"
+      "version": "0.9.9",
+      "resolved": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#5266fd8cdb4b3ced41352ba7b1f0e919ac37027a"
     },
     "node_modules/walkjs": {
       "version": "3.2.4",

--- a/examples/ionic-demo/package.json
+++ b/examples/ionic-demo/package.json
@@ -49,7 +49,7 @@
     "react-router": "^5.3.4",
     "react-router-dom": "^5.3.4",
     "uuid": "^9.0.0",
-    "wa-sqlite": "rhashimoto/wa-sqlite"
+    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.0",

--- a/examples/linearlite/package-lock.json
+++ b/examples/linearlite/package-lock.json
@@ -42,7 +42,7 @@
         "tiptap-markdown": "^0.8.2",
         "uuid": "^9.0.0",
         "vite-plugin-svgr": "^3.2.0",
-        "wa-sqlite": "github:rhashimoto/wa-sqlite#master",
+        "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -10289,8 +10289,8 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/wa-sqlite": {
-      "version": "0.9.6",
-      "resolved": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#6e2fcb56237cd6080c1dd5e89a18a54c71c98ee0"
+      "version": "0.9.9",
+      "resolved": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#5266fd8cdb4b3ced41352ba7b1f0e919ac37027a"
     },
     "node_modules/walkjs": {
       "version": "3.2.4",
@@ -17700,8 +17700,8 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "wa-sqlite": {
-      "version": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#6e2fcb56237cd6080c1dd5e89a18a54c71c98ee0",
-      "from": "wa-sqlite@github:rhashimoto/wa-sqlite#master"
+      "version": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#5266fd8cdb4b3ced41352ba7b1f0e919ac37027a",
+      "from": "wa-sqlite@rhashimoto/wa-sqlite#semver:^0.9.8"
     },
     "walkjs": {
       "version": "3.2.4",

--- a/examples/linearlite/package.json
+++ b/examples/linearlite/package.json
@@ -66,7 +66,7 @@
     "tiptap-markdown": "^0.8.2",
     "uuid": "^9.0.0",
     "vite-plugin-svgr": "^3.2.0",
-    "wa-sqlite": "github:rhashimoto/wa-sqlite#master",
+    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8",
     "zod": "^3.22.2"
   },
   "devDependencies": {

--- a/examples/starter/template/package.json
+++ b/examples/starter/template/package.json
@@ -25,7 +25,7 @@
     "electric-sql": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wa-sqlite": "rhashimoto/wa-sqlite"
+    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8"
   },
   "devDependencies": {
     "@databases/pg-migrations": "^5.0.2",

--- a/examples/web-wa-sqlite/package.json
+++ b/examples/web-wa-sqlite/package.json
@@ -27,7 +27,7 @@
     "electric-sql": "^0.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wa-sqlite": "rhashimoto/wa-sqlite"
+    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8"
   },
   "devDependencies": {
     "@databases/pg-migrations": "^5.0.2",

--- a/examples/web-wa-sqlite/yarn.lock
+++ b/examples/web-wa-sqlite/yarn.lock
@@ -2724,9 +2724,9 @@ uuid@^9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
-wa-sqlite@rhashimoto/wa-sqlite:
-  version "0.9.8"
-  resolved "https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/56628cec216432bfa67186766f02f503fae8471f"
+"wa-sqlite@rhashimoto/wa-sqlite#semver:^0.9.8":
+  version "0.9.9"
+  resolved "https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a"
 
 walkjs@^3.2.4:
   version "3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: ^4.9
         version: 4.9.5
       wa-sqlite:
-        specifier: git+https://github.com/rhashimoto/wa-sqlite#master
-        version: github.com/rhashimoto/wa-sqlite/6e2fcb56237cd6080c1dd5e89a18a54c71c98ee0
+        specifier: rhashimoto/wa-sqlite#semver:^0.9.8
+        version: github.com/rhashimoto/wa-sqlite/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a
       web-worker:
         specifier: ^1.2.0
         version: 1.2.0
@@ -14361,8 +14361,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/rhashimoto/wa-sqlite/6e2fcb56237cd6080c1dd5e89a18a54c71c98ee0:
-    resolution: {tarball: https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/6e2fcb56237cd6080c1dd5e89a18a54c71c98ee0}
+  github.com/rhashimoto/wa-sqlite/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a:
+    resolution: {tarball: https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a}
     name: wa-sqlite
-    version: 0.9.6
+    version: 0.9.9
     dev: true


### PR DESCRIPTION
Upgrades the ts-client, the starter, and the examples to use wa-sqlite version ^0.9.8 in order to include a critical bug fix released in v0.9.8.