### PR TITLE
fix(electric): Preload internal schema in SchemaCache before looking up an internal relation

### DIFF
--- a/components/electric/lib/electric/postgres/extension/schema_cache.ex
+++ b/components/electric/lib/electric/postgres/extension/schema_cache.ex
@@ -379,6 +379,7 @@ defmodule Electric.Postgres.Extension.SchemaCache do
   end
 
   def handle_call({:internal_relation, relation}, _from, state) do
+    state = load_internal_schema(state)
     {:reply, Schema.table_info(state.internal_schema, relation), state}
   end
 


### PR DESCRIPTION
As a reminder, we have to have this internal schema in order for Electric to be able to send writes to `electric.acknowledged_client_lsn` over the Electric->PG logical replication connection.