### PR TITLE
chore(electric): Remove misleading log entry

### DIFF
--- a/components/electric/lib/electric/postgres/schema/update.ex
+++ b/components/electric/lib/electric/postgres/schema/update.ex
@@ -86,9 +86,6 @@ defmodule Electric.Postgres.Schema.Update do
   end
 
   defp do_update(%Pg.CreateStmt{} = action, schema, opts) do
-    %{relation: name} = action
-    Logger.info("CREATE TABLE #{name.relname} (...)")
-
     table = AST.create(action, opts)
 
     schema = %{schema | tables: schema.tables ++ [table]}


### PR DESCRIPTION
This looks more like leftover debug info. Definitely shouldn't be an info-level log.