### PR TITLE
tests(client): Include tests for bigint support in the oplog triggers and the merge logic 

### DIFF
--- a/clients/typescript/src/satellite/oplog.ts
+++ b/clients/typescript/src/satellite/oplog.ts
@@ -306,9 +306,6 @@ function serialiseRow(row?: Rec): string {
         return '-Inf'
       }
     }
-    if (typeof value === 'bigint') {
-      return value.toString()
-    }
     return value
   })
 }

--- a/clients/typescript/test/migrators/triggers.test.ts
+++ b/clients/typescript/test/migrators/triggers.test.ts
@@ -32,7 +32,7 @@ test('generateTableTriggers should create correct triggers for a table', (t) => 
        WHEN 1 == (SELECT flag from _electric_trigger_settings WHERE tablename == 'personTable')
     BEGIN
       INSERT INTO _electric_oplog (namespace, tablename, optype, primaryKey, newRow, oldRow, timestamp)
-      VALUES ('main', 'personTable', 'INSERT', json_object('id', cast(new."id" as TEXT)), json_object('age', new."age", 'bmi', cast(new."bmi" as TEXT), 'id', cast(new."id" as TEXT), 'name', new."name"), NULL, NULL);
+      VALUES ('main', 'personTable', 'INSERT', json_object('id', cast(new."id" as TEXT)), json_object('age', new."age", 'bmi', cast(new."bmi" as TEXT), 'id', cast(new."id" as TEXT), 'int8', cast(new."int8" as TEXT), 'name', new."name"), NULL, NULL);
     END;
     `
     )
@@ -46,7 +46,7 @@ test('generateTableTriggers should create correct triggers for a table', (t) => 
        WHEN 1 == (SELECT flag from _electric_trigger_settings WHERE tablename == 'personTable')
     BEGIN
       INSERT INTO _electric_oplog (namespace, tablename, optype, primaryKey, newRow, oldRow, timestamp)
-      VALUES ('main', 'personTable', 'UPDATE', json_object('id', cast(new."id" as TEXT)), json_object('age', new."age", 'bmi', cast(new."bmi" as TEXT), 'id', cast(new."id" as TEXT), 'name', new."name"), json_object('age', old."age", 'bmi', cast(old."bmi" as TEXT), 'id', cast(old."id" as TEXT), 'name', old."name"), NULL);
+      VALUES ('main', 'personTable', 'UPDATE', json_object('id', cast(new."id" as TEXT)), json_object('age', new."age", 'bmi', cast(new."bmi" as TEXT), 'id', cast(new."id" as TEXT), 'int8', cast(new."int8" as TEXT), 'name', new."name"), json_object('age', old."age", 'bmi', cast(old."bmi" as TEXT), 'id', cast(old."id" as TEXT), 'int8', cast(old."int8" as TEXT), 'name', old."name"), NULL);
     END;
     `
     )
@@ -60,7 +60,7 @@ test('generateTableTriggers should create correct triggers for a table', (t) => 
        WHEN 1 == (SELECT flag from _electric_trigger_settings WHERE tablename == 'personTable')
     BEGIN
       INSERT INTO _electric_oplog (namespace, tablename, optype, primaryKey, newRow, oldRow, timestamp)
-      VALUES ('main', 'personTable', 'DELETE', json_object('id', cast(old."id" as TEXT)), NULL, json_object('age', old."age", 'bmi', cast(old."bmi" as TEXT), 'id', cast(old."id" as TEXT), 'name', old."name"), NULL);
+      VALUES ('main', 'personTable', 'DELETE', json_object('id', cast(old."id" as TEXT)), NULL, json_object('age', old."age", 'bmi', cast(old."bmi" as TEXT), 'id', cast(old."id" as TEXT), 'int8', cast(old."int8" as TEXT), 'name', old."name"), NULL);
     END;
     `
     )
@@ -75,7 +75,7 @@ test('oplog insertion trigger should insert row into oplog table', (t) => {
   migrateDb()
 
   // Insert a row in the table
-  const insertRowSQL = `INSERT INTO ${tableName} (id, name, age, bmi) VALUES (1, 'John Doe', 30, 25.5)`
+  const insertRowSQL = `INSERT INTO ${tableName} (id, name, age, bmi, int8) VALUES (1, 'John Doe', 30, 25.5, 7)`
   db.exec(insertRowSQL)
 
   // Check that the oplog table contains an entry for the inserted row
@@ -99,6 +99,7 @@ test('oplog insertion trigger should insert row into oplog table', (t) => {
       age: 30,
       bmi: '25.5',
       id: '1.0',
+      int8: '7', // BigInts are serialized as strings in the oplog
       name: 'John Doe',
     }),
     oldRow: null,
@@ -116,7 +117,7 @@ test('oplog trigger should handle Infinity values correctly', (t) => {
   migrateDb()
 
   // Insert a row in the table
-  const insertRowSQL = `INSERT INTO ${tableName} (id, name, age, bmi) VALUES (-9e999, 'John Doe', 30, 9e999)`
+  const insertRowSQL = `INSERT INTO ${tableName} (id, name, age, bmi, int8) VALUES (-9e999, 'John Doe', 30, 9e999, 7)`
   db.exec(insertRowSQL)
 
   // Check that the oplog table contains an entry for the inserted row
@@ -140,6 +141,7 @@ test('oplog trigger should handle Infinity values correctly', (t) => {
       age: 30,
       bmi: 'Inf',
       id: '-Inf',
+      int8: '7', // BigInts are serialized as strings in the oplog
       name: 'John Doe',
     }),
     oldRow: null,

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -101,10 +101,10 @@ export const relations = {
       },
     ],
   },
-  floatTable: {
+  mergeTable: {
     id: 3,
     schema: 'public',
-    table: 'floatTable',
+    table: 'mergeTable',
     tableType: 0,
     columns: [
       {
@@ -114,8 +114,20 @@ export const relations = {
         primaryKey: true,
       },
       {
-        name: 'value',
+        name: 'real',
         type: 'REAL',
+        isNullable: true,
+        primaryKey: false,
+      },
+      {
+        name: 'int8',
+        type: 'INT8',
+        isNullable: true,
+        primaryKey: false,
+      },
+      {
+        name: 'bigint',
+        type: 'BIGINT',
         isNullable: true,
         primaryKey: false,
       },

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -163,6 +163,12 @@ export const relations = {
         isNullable: true,
         primaryKey: false,
       },
+      {
+        name: 'int8',
+        type: 'INT8',
+        isNullable: true,
+        primaryKey: false,
+      },
     ],
   },
 }
@@ -261,7 +267,7 @@ export const cleanAndStopSatellite = async (
 export function migrateDb(db: SqliteDB, table: Table) {
   const tableName = table.tableName
   // Create the table in the database
-  const createTableSQL = `CREATE TABLE ${tableName} (id REAL PRIMARY KEY, name TEXT, age INTEGER, bmi REAL)`
+  const createTableSQL = `CREATE TABLE ${tableName} (id REAL PRIMARY KEY, name TEXT, age INTEGER, bmi REAL, int8 INTEGER)`
   db.exec(createTableSQL)
 
   // Apply the initial migration on the database
@@ -282,7 +288,7 @@ export function migrateDb(db: SqliteDB, table: Table) {
 export const personTable: Table = {
   namespace: 'main',
   tableName: 'personTable',
-  columns: ['id', 'name', 'age', 'bmi'],
+  columns: ['id', 'name', 'age', 'bmi', 'int8'],
   primary: ['id'],
   foreignKeys: [],
   columnTypes: {
@@ -290,5 +296,6 @@ export const personTable: Table = {
     name: { sqliteType: 'TEXT', pgType: PgBasicType.PG_TEXT },
     age: { sqliteType: 'INTEGER', pgType: PgBasicType.PG_INTEGER },
     bmi: { sqliteType: 'REAL', pgType: PgBasicType.PG_REAL },
+    int8: { sqliteType: 'INTEGER', pgType: PgBasicType.PG_INT8 },
   },
 }

--- a/clients/typescript/test/satellite/merge.test.ts
+++ b/clients/typescript/test/satellite/merge.test.ts
@@ -167,7 +167,7 @@ test('merge works on oplog entries', (t) => {
   migrateDb(db, personTable)
 
   // Insert a row in the table
-  const insertRowSQL = `INSERT INTO ${personTable.tableName} (id, name, age, bmi) VALUES (9e999, 'John Doe', 30, 25.5)`
+  const insertRowSQL = `INSERT INTO ${personTable.tableName} (id, name, age, bmi, int8) VALUES (9e999, 'John Doe', 30, 25.5, 7)`
   db.exec(insertRowSQL)
 
   // Fetch the oplog entry for the inserted row
@@ -188,7 +188,14 @@ test('merge works on oplog entries', (t) => {
       {
         relation: relations[personTable.tableName as keyof typeof relations],
         type: DataChangeType.INSERT,
-        record: { age: 30, bmi: 8e888, id: 9e999, name: 'John Doe' }, // fields must be ordered alphabetically to match the behavior of the triggers
+        record: {
+          // fields must be ordered alphabetically to match the behavior of the triggers
+          age: 30,
+          bmi: 8e888,
+          id: 9e999,
+          int8: '224', // Big ints are serialized as strings in the oplog
+          name: 'John Doe',
+        },
         tags: [],
       },
     ],
@@ -214,5 +221,6 @@ test('merge works on oplog entries', (t) => {
     name: 'John Doe',
     age: 30,
     bmi: Infinity,
+    int8: 224n,
   })
 })


### PR DESCRIPTION
In addition to the tests, the following logic is removed because at the oplog level, the Record values cannot be BigInt, as the oplog trigger serializes those values as string. Is the `deserialize` who checks the postgres type to turn it into the correct JS object.
Leaving the type check there might cause confusion in the future.

```js
if (typeof value === 'bigint') {
    return value.toString()
}
```