### PR TITLE
chore (client): pin Zod to 3.21.1 to avoid code generator bug in client

### DIFF
--- a/.changeset/happy-lobsters-type.md
+++ b/.changeset/happy-lobsters-type.md
@@ -1,7 +1,5 @@
 ---
 "electric-sql": patch
-"@core/electric": patch
-"create-electric-app": patch
 "@electric-sql/prisma-generator": patch
 ---
 

--- a/.changeset/happy-lobsters-type.md
+++ b/.changeset/happy-lobsters-type.md
@@ -1,0 +1,8 @@
+---
+"electric-sql": patch
+"@core/electric": patch
+"create-electric-app": patch
+"@electric-sql/prisma-generator": patch
+---
+
+Pin Zod to version 3.21.1

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -175,7 +175,7 @@
     "uuid": "^9.0.0",
     "walkjs": "^3.2.4",
     "ws": "^8.8.1",
-    "zod": "^3.20.2"
+    "zod": "3.21.1"
   },
   "devDependencies": {
     "@ikscodes/browser-env": "^1.0.0",

--- a/e2e/satellite_client/package.json
+++ b/e2e/satellite_client/package.json
@@ -21,7 +21,7 @@
     "electric-sql": "workspace:*",
     "jsonwebtoken": "^9.0.0",
     "uuid": "^9.0.0",
-    "zod": "^3.21.4"
+    "zod": "3.21.1"
   },
   "devDependencies": {
     "@electric-sql/prisma-generator": "workspace:*",

--- a/examples/linearlite/package.json
+++ b/examples/linearlite/package.json
@@ -67,7 +67,7 @@
     "uuid": "^9.0.0",
     "vite-plugin-svgr": "^3.2.0",
     "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8",
-    "zod": "^3.22.2"
+    "zod": "3.21.1"
   },
   "devDependencies": {
     "@databases/pg": "^5.4.1",

--- a/generator/package.json
+++ b/generator/package.json
@@ -54,6 +54,6 @@
     "@prisma/generator-helper": "^4.11.0",
     "code-block-writer": "^11.0.3",
     "lodash": "^4.17.21",
-    "zod": "^3.21.1"
+    "zod": "3.21.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: ^8.8.1
         version: 8.13.0
       zod:
-        specifier: ^3.20.2
-        version: 3.21.4
+        specifier: 3.21.1
+        version: 3.21.1
     devDependencies:
       '@electric-sql/prisma-generator':
         specifier: workspace:*
@@ -353,8 +353,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       zod:
-        specifier: ^3.21.1
-        version: 3.21.4
+        specifier: 3.21.1
+        version: 3.21.1
     devDependencies:
       '@prisma/internals':
         specifier: ^4.11.0
@@ -14356,6 +14356,10 @@ packages:
       compress-commons: 4.1.1
       readable-stream: 3.6.2
     dev: true
+
+  /zod@3.21.1:
+    resolution: {integrity: sha512-+dTu2m6gmCbO9Ahm4ZBDapx2O6ZY9QSPXst2WXjcznPMwf2YNpn3RevLx4KkZp1OPW/ouFcoBtBzFz/LeY69oA==}
+    dev: false
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,8 +261,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       zod:
-        specifier: ^3.21.4
-        version: 3.21.4
+        specifier: 3.21.1
+        version: 3.21.1
     devDependencies:
       '@electric-sql/prisma-generator':
         specifier: workspace:*
@@ -14359,10 +14359,6 @@ packages:
 
   /zod@3.21.1:
     resolution: {integrity: sha512-+dTu2m6gmCbO9Ahm4ZBDapx2O6ZY9QSPXst2WXjcznPMwf2YNpn3RevLx4KkZp1OPW/ouFcoBtBzFz/LeY69oA==}
-    dev: false
-
-  /zod@3.21.4:
-    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
   github.com/rhashimoto/wa-sqlite/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a:


### PR DESCRIPTION
## Summary
As discussed on Discord with @kevin-dp, it appears that the dependencies for Zod can pull in a version that causes the generated client to contain invalid casts.

![image](https://github.com/electric-sql/electric/assets/984279/e37012af-5192-4a2a-ab4f-29783dd37d6e)

The issue in Zod + Prisma can be found here:
https://github.com/colinhacks/zod/issues/2184
https://github.com/chrishoermann/zod-prisma-types/issues/98

## Background

For us, the problem manifests itself by adding any kind of basic table relationship and generating a client. Indeed, it appears to also happen in this example code created by a third party:
https://github.com/KyleAMathews/vite-react-router-electric-sql-starter/tree/main

In both that example, and our internal code, it is enough to comment out any relationships and the generated code is fine, or rather doesn't contain the code blocks that are causing the issues.

![image](https://github.com/electric-sql/electric/assets/984279/9a7c2429-19cd-407b-b9cc-27f3094a32e7)

Patching the packages lock file in both cases to resolve Zod to 3.21.1 (as suggested in the linked issue threads) fixed the issue for both our code and the third-party example.

![image](https://github.com/electric-sql/electric/assets/984279/e3a17b0a-6f2d-4b31-ba19-f2c8149cf3f2)
![image](https://github.com/electric-sql/electric/assets/984279/7779f8e5-d07d-47d8-9244-8911ca955c1b)

## Temporary Workaround

Since we are using PNPM we could achieve the same result by adding a forced version override to our root package.json file:
```
  "pnpm": {
    "overrides": {
      "zod": "3.21.1"
    }
  }
```

Using that we could also experiment with different Zod versions, and indeed, going to 3.21.2 or higher reintroduced the problem.

## Suggested Fix

This PR pins the version of Zod to 3.21.1 which is the latest version that did not cause the issue. Hopefully, this will mean that new users will get a local package lock file that resolves Zod to 3.21.1 and a working client generator. That last part is a bit hard for me to verify locally though.

## Caveat

I have only updated the TypeScript Client and the Client Generator, but there are at least two places in this mono repo that explicitly reference higher versions of Zod:
- e2e/satellite_client - `^3.21.4`
- examples/linearlite - `^3.22.2`
- 
I was not comfortable downgrading those dependencies since I do not know _why_ they require a higher version.

