### PR TITLE
fix (client): fix race condition in process.subscribe that made the client crash

### DIFF
--- a/.changeset/nine-boats-burn.md
+++ b/.changeset/nine-boats-burn.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix race condition in process.subscribe that made the client crash.


### PR DESCRIPTION
This PR fixes the race condition described in #426.
The problem was that `process.subscribe` was creating a promise, storing it, making an async call, fetching the promise and returning it. But, depending on the order in which messages are received from Electric, the async call may resolve after the subscription was already delivered and hence the promise had already been deleted. The fix consists of storing the promise in a local variable inside `process.subscribe` such that it doesn't need to fetch the promise after the async call. 