### PR TITLE
chore (client): expose a close method on the ElectricNamespace to dispose its resources

### DIFF
--- a/.changeset/brave-colts-change.md
+++ b/.changeset/brave-colts-change.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Dispose listeners when Electric client is closed.

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -5,7 +5,7 @@ import { Row, Statement } from '../../util'
 import { LiveResult, LiveResultContext } from './model'
 import { Notifier } from '../../notifiers'
 import { DatabaseAdapter } from '../../electric/adapter'
-import { Satellite } from '../../satellite'
+import { GlobalRegistry, Registry, Satellite } from '../../satellite'
 import { ShapeManager } from './shapes'
 
 export type ClientTables<DB extends DbSchema<any>> = {
@@ -64,9 +64,10 @@ export class ElectricClient<
     dbName: string,
     adapter: DatabaseAdapter,
     notifier: Notifier,
-    public readonly satellite: Satellite
+    public readonly satellite: Satellite,
+    registry: Registry | GlobalRegistry
   ) {
-    super(dbName, adapter, notifier)
+    super(dbName, adapter, notifier, registry)
     this.satellite = satellite
   }
 
@@ -76,7 +77,8 @@ export class ElectricClient<
     dbDescription: DB,
     adapter: DatabaseAdapter,
     notifier: Notifier,
-    satellite: Satellite
+    satellite: Satellite,
+    registry: Registry | GlobalRegistry
   ): ElectricClient<DB> {
     const tables = dbDescription.extendedTables
     const shapeManager = new ShapeManager(satellite)
@@ -109,6 +111,13 @@ export class ElectricClient<
       liveRaw: liveRaw.bind(null, adapter),
     }
 
-    return new ElectricClient(db, dbName, adapter, notifier, satellite)
+    return new ElectricClient(
+      db,
+      dbName,
+      adapter,
+      notifier,
+      satellite,
+      registry
+    )
   }
 }

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -59,23 +59,20 @@ interface RawQueries {
 export class ElectricClient<
   DB extends DbSchema<any>
 > extends ElectricNamespace {
-  private _satellite: Satellite
-  public get satellite(): Satellite {
-    return this._satellite
-  }
-
   private constructor(
     public db: ClientTables<DB> & RawQueries,
+    dbName: string,
     adapter: DatabaseAdapter,
     notifier: Notifier,
-    satellite: Satellite
+    public readonly satellite: Satellite
   ) {
-    super(adapter, notifier)
-    this._satellite = satellite
+    super(dbName, adapter, notifier)
+    this.satellite = satellite
   }
 
   // Builds the DAL namespace from a `dbDescription` object
   static create<DB extends DbSchema<any>>(
+    dbName: string,
     dbDescription: DB,
     adapter: DatabaseAdapter,
     notifier: Notifier,
@@ -112,6 +109,6 @@ export class ElectricClient<
       liveRaw: liveRaw.bind(null, adapter),
     }
 
-    return new ElectricClient(db, adapter, notifier, satellite)
+    return new ElectricClient(db, dbName, adapter, notifier, satellite)
   }
 }

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -74,7 +74,8 @@ export const electrify = async <DB extends DbSchema<any>>(
     dbDescription,
     adapter,
     notifier,
-    satellite
+    satellite,
+    registry
   )
 
   if (satellite.connectivityState !== undefined) {

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -70,6 +70,7 @@ export const electrify = async <DB extends DbSchema<any>>(
   )
 
   const electric = ElectricClient.create(
+    dbName,
     dbDescription,
     adapter,
     notifier,

--- a/clients/typescript/src/electric/namespace.ts
+++ b/clients/typescript/src/electric/namespace.ts
@@ -3,12 +3,13 @@
 import { DatabaseAdapter } from './adapter'
 import { Notifier } from '../notifiers'
 import { ConnectivityState } from '../util/types'
-import { globalRegistry } from '../satellite'
+import { GlobalRegistry, Registry } from '../satellite'
 
 export class ElectricNamespace {
   dbName: string
   adapter: DatabaseAdapter
   notifier: Notifier
+  public readonly registry: Registry | GlobalRegistry
   private _isConnected: boolean
   public get isConnected(): boolean {
     return this._isConnected
@@ -16,10 +17,16 @@ export class ElectricNamespace {
 
   private _stateChangeSubscription: string
 
-  constructor(dbName: string, adapter: DatabaseAdapter, notifier: Notifier) {
+  constructor(
+    dbName: string,
+    adapter: DatabaseAdapter,
+    notifier: Notifier,
+    registry: Registry | GlobalRegistry
+  ) {
     this.dbName = dbName
     this.adapter = adapter
     this.notifier = notifier
+    this.registry = registry
     this._isConnected = false
 
     this._stateChangeSubscription =
@@ -44,10 +51,10 @@ export class ElectricNamespace {
   /**
    * Cleans up the resources used by the `ElectricNamespace`.
    */
-  close(): void {
+  async close(): Promise<void> {
     this.notifier.unsubscribeFromConnectivityStateChanges(
       this._stateChangeSubscription
     )
-    globalRegistry.stop(this.dbName)
+    await this.registry.stop(this.dbName)
   }
 }

--- a/clients/typescript/src/notifiers/event.ts
+++ b/clients/typescript/src/notifiers/event.ts
@@ -239,7 +239,7 @@ export class EventNotifier implements Notifier {
 
     this._unsubscribe(EVENT_NAMES.connectivityStateChange, callback)
 
-    delete this._changeCallbacks[key]
+    delete this._connectivityStatusCallbacks[key]
   }
 
   _getDbNames(): DbName[] {

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -34,6 +34,10 @@ export type { ShapeSubscription } from './process'
 
 // `Registry` that starts one Satellite process per database.
 export interface Registry {
+  satellites: {
+    [key: DbName]: Satellite
+  }
+
   ensureStarted(
     dbName: DbName,
     dbDescription: DbSchema<any>,

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -4,7 +4,7 @@ import Database from 'better-sqlite3'
 import { schema } from '../generated'
 import { DatabaseAdapter } from '../../../src/drivers/better-sqlite3'
 import { SatelliteProcess } from '../../../src/satellite/process'
-import { MockSatelliteClient } from '../../../src/satellite/mock'
+import { MockRegistry, MockSatelliteClient } from '../../../src/satellite/mock'
 import { BundleMigrator } from '../../../src/migrators'
 import { MockNotifier } from '../../../src/notifiers'
 import { randomValue } from '../../../src/util'
@@ -46,6 +46,7 @@ async function makeContext(t: ExecutionContext<ContextType>) {
   const migrator = new BundleMigrator(adapter, migrations)
   const dbName = `.tmp/test-${randomValue()}.db`
   const notifier = new MockNotifier(dbName)
+  const registry = new MockRegistry()
 
   const satellite = new SatelliteProcess(
     dbName,
@@ -61,7 +62,8 @@ async function makeContext(t: ExecutionContext<ContextType>) {
     schema,
     adapter,
     notifier,
-    satellite
+    satellite,
+    registry
   )
   const Post = electric.db.Post
   const Items = electric.db.Items

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -56,7 +56,13 @@ async function makeContext(t: ExecutionContext<ContextType>) {
     satelliteDefaults
   )
 
-  const electric = ElectricClient.create(schema, adapter, notifier, satellite)
+  const electric = ElectricClient.create(
+    dbName,
+    schema,
+    adapter,
+    notifier,
+    satellite
+  )
   const Post = electric.db.Post
   const Items = electric.db.Items
   const User = electric.db.User

--- a/clients/typescript/test/frameworks/react.test.tsx
+++ b/clients/typescript/test/frameworks/react.test.tsx
@@ -56,7 +56,13 @@ test.beforeEach((t) => {
     {} as SocketFactory,
     {} as SatelliteOpts
   )
-  const dal = ElectricClient.create(schema, adapter, notifier, satellite)
+  const dal = ElectricClient.create(
+    'test.db',
+    schema,
+    adapter,
+    notifier,
+    satellite
+  )
 
   dal.db.Items.sync()
 

--- a/clients/typescript/test/frameworks/react.test.tsx
+++ b/clients/typescript/test/frameworks/react.test.tsx
@@ -21,7 +21,7 @@ import {
 import { makeElectricContext } from '../../src/frameworks/react/provider'
 import { ElectricClient } from '../../src/client/model/client'
 import { schema, Electric } from '../client/generated'
-import { MockSatelliteProcess } from '../../src/satellite/mock'
+import { MockRegistry, MockSatelliteProcess } from '../../src/satellite/mock'
 import { Migrator } from '../../src/migrators'
 import { SocketFactory } from '../../src/sockets'
 import { SatelliteOpts } from '../../src/satellite/config'
@@ -56,12 +56,14 @@ test.beforeEach((t) => {
     {} as SocketFactory,
     {} as SatelliteOpts
   )
+  const registry = new MockRegistry()
   const dal = ElectricClient.create(
     'test.db',
     schema,
     adapter,
     notifier,
-    satellite
+    satellite,
+    registry
   )
 
   dal.db.Items.sync()

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -6,7 +6,7 @@ import { DatabaseAdapter } from '../../src/drivers/better-sqlite3'
 import { BundleMigrator } from '../../src/migrators'
 import { EventNotifier, MockNotifier } from '../../src/notifiers'
 import { MockSatelliteClient } from '../../src/satellite/mock'
-import { SatelliteProcess } from '../../src/satellite'
+import { GlobalRegistry, Registry, SatelliteProcess } from '../../src/satellite'
 import { TableInfo, initTableInfo } from '../support/satellite-helpers'
 import { satelliteDefaults, SatelliteOpts } from '../../src/satellite/config'
 import { Table, generateTableTriggers } from '../../src/migrators/triggers'
@@ -161,6 +161,7 @@ import { AuthState } from '../../src/auth'
 import { DbSchema, TableSchema } from '../../src/client/model/schema'
 import { PgBasicType } from '../../src/client/conversions/types'
 import { HKT } from '../../src/client/util/hkt'
+import { ElectricClient } from '../../src/client/model'
 
 // Speed up the intervals for testing.
 export const opts = Object.assign({}, satelliteDefaults, {
@@ -229,6 +230,32 @@ export const makeContext = async (
     timestamp,
     authState,
   }
+}
+
+export const mockElectricClient = async (
+  db: SqliteDB,
+  registry: Registry | GlobalRegistry,
+  options: Opts = opts
+): Promise<ElectricClient<any>> => {
+  const dbName = db.name
+  const adapter = new DatabaseAdapter(db)
+  const migrator = new BundleMigrator(adapter, migrations)
+  const notifier = new MockNotifier(dbName)
+  const client = new MockSatelliteClient()
+  const satellite = new SatelliteProcess(
+    dbName,
+    adapter,
+    migrator,
+    notifier,
+    client,
+    options
+  )
+
+  await satellite.start({ clientId: '', token: 'test-token' })
+  registry.satellites[dbName] = satellite
+
+  // @ts-ignore Mock Electric client that does not contain the DAL
+  return new ElectricClient({}, dbName, adapter, notifier, satellite, registry)
 }
 
 export const clean = async (t: ExecutionContext<{ dbName: string }>) => {


### PR DESCRIPTION
This PR addresses the first task of #243.
As suggested, the `ElectricNamespace` (and thus also the `ElectricClient` as it extends the namespace) now exposes a `close` method that can be called by the user to dispose all resources used by the Electric client. This `close` method calls the `stop` on the global registry such that it also stops the client's satellite process.