### PR TITLE
chore (client): refactoring subscribe methods of the event notifier

### DIFF
--- a/.changeset/twelve-pigs-give.md
+++ b/.changeset/twelve-pigs-give.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Refactorings to the event notifier.

--- a/clients/typescript/src/frameworks/react/hooks/useConnectivityState.ts
+++ b/clients/typescript/src/frameworks/react/hooks/useConnectivityState.ts
@@ -63,13 +63,11 @@ const useConnectivityState: HookFn = () => {
       setState(getValidState(connectivityState))
     }
 
-    const subscriptionKey =
-      notifier.subscribeToConnectivityStateChanges(handler)
+    const unsubscribe = notifier.subscribeToConnectivityStateChanges(handler)
 
     return () => {
       shouldStop = true
-
-      notifier.unsubscribeFromConnectivityStateChanges(subscriptionKey)
+      unsubscribe()
     }
   }, [electric])
 

--- a/clients/typescript/src/notifiers/index.ts
+++ b/clients/typescript/src/notifiers/index.ts
@@ -47,6 +47,8 @@ export type NotificationCallback =
   | PotentialChangeCallback
   | ConnectivityStateChangeCallback
 
+export type UnsubscribeFunction = () => void
+
 export interface Notifier {
   // The name of the primary database that components communicating via this
   // notifier have open and are using.
@@ -78,8 +80,7 @@ export interface Notifier {
   // Calling `authStateChanged` notifies the Satellite process that the
   // user's authentication credentials have changed.
   authStateChanged(authState: AuthState): void
-  subscribeToAuthStateChanges(callback: AuthStateCallback): string
-  unsubscribeFromAuthStateChanges(key: string): void
+  subscribeToAuthStateChanges(callback: AuthStateCallback): UnsubscribeFunction
 
   // The data change notification workflow starts by the electric database
   // clients (or the user manually) calling `potentiallyChanged` whenever
@@ -90,8 +91,9 @@ export interface Notifier {
   // Satellite processes subscribe to these "data has potentially changed"
   // notifications. When they get one, they check the `_oplog` table in the
   // database for *actual* changes persisted by the triggers.
-  subscribeToPotentialDataChanges(callback: PotentialChangeCallback): string
-  unsubscribeFromPotentialDataChanges(key: string): void
+  subscribeToPotentialDataChanges(
+    callback: PotentialChangeCallback
+  ): UnsubscribeFunction
 
   // When Satellite detects actual data changes in the oplog for a given
   // database, it replicates it and calls  `actuallyChanged` with the list
@@ -102,8 +104,7 @@ export interface Notifier {
   // using the info to trigger re-queries, if the changes affect databases and
   // tables that their queries depend on. This then trigger re-rendering if
   // the query results are actually affected by the data changes.
-  subscribeToDataChanges(callback: ChangeCallback): string
-  unsubscribeFromDataChanges(key: string): void
+  subscribeToDataChanges(callback: ChangeCallback): UnsubscribeFunction
 
   // Notification for network connectivity state changes.
   // A connectivity change s can be triggered manually,
@@ -116,6 +117,5 @@ export interface Notifier {
 
   subscribeToConnectivityStateChanges(
     callback: ConnectivityStateChangeCallback
-  ): string
-  unsubscribeFromConnectivityStateChanges(key: string): void
+  ): UnsubscribeFunction
 }

--- a/clients/typescript/src/notifiers/mock.ts
+++ b/clients/typescript/src/notifiers/mock.ts
@@ -2,12 +2,13 @@ import { DbName } from '../util/types'
 
 import { Notification, Notifier } from './index'
 import { EventNotifier } from './event'
+import EventEmitter from 'events'
 
 export class MockNotifier extends EventNotifier implements Notifier {
   notifications: Notification[]
 
-  constructor(dbName: DbName) {
-    super(dbName)
+  constructor(dbName: DbName, emitter?: EventEmitter) {
+    super(dbName, emitter)
 
     this.notifications = []
   }

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -352,20 +352,20 @@ export class SatelliteProcess implements Satellite {
       this._pollingInterval = undefined
     }
 
-    if (this._unsubscribeFromAuthState !== undefined) {
-      this._unsubscribeFromAuthState()
-      this._unsubscribeFromAuthState = undefined
-    }
+    // Unsubscribe all listeners and remove them
+    const unsubscribers = [
+      '_unsubscribeFromAuthState',
+      '_unsubscribeFromConnectivityChanges',
+      '_unsubscribeFromPotentialDataChanges',
+    ] as const
 
-    if (this._unsubscribeFromConnectivityChanges !== undefined) {
-      this._unsubscribeFromConnectivityChanges()
-      this._unsubscribeFromConnectivityChanges = undefined
-    }
-
-    if (this._unsubscribeFromPotentialDataChanges !== undefined) {
-      this._unsubscribeFromPotentialDataChanges()
-      this._unsubscribeFromPotentialDataChanges = undefined
-    }
+    unsubscribers.forEach((unsubscriber) => {
+      const unsub = this[unsubscriber]
+      if (unsub !== undefined) {
+        unsub!()
+        this[unsubscriber] = undefined
+      }
+    })
 
     this._disconnect()
 

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -12,6 +12,7 @@ import {
   Change,
   ConnectivityStateChangeNotification,
   Notifier,
+  UnsubscribeFunction,
 } from '../notifiers/index'
 import {
   Waiter,
@@ -119,13 +120,13 @@ export class SatelliteProcess implements Satellite {
   opts: SatelliteOpts
 
   _authState?: AuthState
-  _authStateSubscription?: string
+  _unsubscribeFromAuthState?: UnsubscribeFunction
 
   connectivityState?: ConnectivityState
-  _connectivityChangeSubscription?: string
+  _unsubscribeFromConnectivityChanges?: UnsubscribeFunction
 
   _pollingInterval?: any
-  _potentialDataChangeSubscription?: string
+  _unsubscribeFromPotentialDataChanges?: UnsubscribeFunction
   _throttledSnapshot: ThrottleFunction
 
   _lsn?: LSN
@@ -221,9 +222,10 @@ export class SatelliteProcess implements Satellite {
     await this._setAuthState({ clientId: clientId, token: authConfig.token })
 
     const notifierSubscriptions = Object.entries({
-      _authStateSubscription: this._authStateSubscription,
-      _connectivityChangeSubscription: this._connectivityChangeSubscription,
-      _potentialDataChangeSubscription: this._potentialDataChangeSubscription,
+      _authStateSubscription: this._unsubscribeFromAuthState,
+      _connectivityChangeSubscription: this._unsubscribeFromConnectivityChanges,
+      _potentialDataChangeSubscription:
+        this._unsubscribeFromPotentialDataChanges,
     })
     notifierSubscriptions.forEach(([name, value]) => {
       if (value !== undefined) {
@@ -237,7 +239,7 @@ export class SatelliteProcess implements Satellite {
 
     // Monitor auth state changes.
     const authStateHandler = this._updateAuthState.bind(this)
-    this._authStateSubscription =
+    this._unsubscribeFromAuthState =
       this.notifier.subscribeToAuthStateChanges(authStateHandler)
 
     // Monitor connectivity state changes.
@@ -246,13 +248,13 @@ export class SatelliteProcess implements Satellite {
     }: ConnectivityStateChangeNotification) => {
       this._handleConnectivityStateChange(connectivityState)
     }
-    this._connectivityChangeSubscription =
+    this._unsubscribeFromConnectivityChanges =
       this.notifier.subscribeToConnectivityStateChanges(
         connectivityStateHandler
       )
 
     // Request a snapshot whenever the data in our database potentially changes.
-    this._potentialDataChangeSubscription =
+    this._unsubscribeFromPotentialDataChanges =
       this.notifier.subscribeToPotentialDataChanges(this._throttledSnapshot)
 
     // Start polling to request a snapshot every `pollingInterval` ms.
@@ -350,26 +352,19 @@ export class SatelliteProcess implements Satellite {
       this._pollingInterval = undefined
     }
 
-    if (this._authStateSubscription !== undefined) {
-      this.notifier.unsubscribeFromAuthStateChanges(this._authStateSubscription)
-
-      this._authStateSubscription = undefined
+    if (this._unsubscribeFromAuthState !== undefined) {
+      this._unsubscribeFromAuthState()
+      this._unsubscribeFromAuthState = undefined
     }
 
-    if (this._connectivityChangeSubscription !== undefined) {
-      this.notifier.unsubscribeFromConnectivityStateChanges(
-        this._connectivityChangeSubscription
-      )
-
-      this._connectivityChangeSubscription = undefined
+    if (this._unsubscribeFromConnectivityChanges !== undefined) {
+      this._unsubscribeFromConnectivityChanges()
+      this._unsubscribeFromConnectivityChanges = undefined
     }
 
-    if (this._potentialDataChangeSubscription !== undefined) {
-      this.notifier.unsubscribeFromPotentialDataChanges(
-        this._potentialDataChangeSubscription
-      )
-
-      this._potentialDataChangeSubscription = undefined
+    if (this._unsubscribeFromPotentialDataChanges !== undefined) {
+      this._unsubscribeFromPotentialDataChanges()
+      this._unsubscribeFromPotentialDataChanges = undefined
     }
 
     this._disconnect()

--- a/clients/typescript/test/notifiers/event.test.ts
+++ b/clients/typescript/test/notifiers/event.test.ts
@@ -120,13 +120,13 @@ test('no more connectivity events after unsubscribe', async (t) => {
 
   const notifications: ConnectivityStateChangeNotification[] = []
 
-  const key = target.subscribeToConnectivityStateChanges((x) => {
+  const unsubscribe = target.subscribeToConnectivityStateChanges((x) => {
     notifications.push(x)
   })
 
   source.connectivityStateChanged('test.db', 'connected')
 
-  target.unsubscribeFromConnectivityStateChanges(key)
+  unsubscribe()
 
   source.connectivityStateChanged('test.db', 'connected')
 

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -180,6 +180,7 @@ import { DbSchema, TableSchema } from '../../src/client/model/schema'
 import { PgBasicType } from '../../src/client/conversions/types'
 import { HKT } from '../../src/client/util/hkt'
 import { ElectricClient } from '../../src/client/model'
+import EventEmitter from 'events'
 
 // Speed up the intervals for testing.
 export const opts = Object.assign({}, satelliteDefaults, {
@@ -258,7 +259,7 @@ export const mockElectricClient = async (
   const dbName = db.name
   const adapter = new DatabaseAdapter(db)
   const migrator = new BundleMigrator(adapter, migrations)
-  const notifier = new MockNotifier(dbName)
+  const notifier = new MockNotifier(dbName, new EventEmitter())
   const client = new MockSatelliteClient()
   const satellite = new SatelliteProcess(
     dbName,


### PR DESCRIPTION
This PR refactors the various subscribe methods provided by the event notifier. For every listener that was being subscribed, the event notifier would generate a random key, store the listener under that key, and return that key. To unsubscribe, the user had to pass that key to the corresponding unsubscribe method which would lookup the listener and then unsubscribe it from the underlying event emitter. Storing the listener under a key is not needed and is a bit redundant as the underlying event emitter already stores them.

This PR modified the event notifier such that it does not keep track of registered callbacks but instead returns an unsubscribe function from the subscribe methods. The unsubscribe function closes over the callback that needs to be unregistered from the underlying event emitter.