### PR TITLE
fix (generator): let generated client import types using TypeScript's import type

### DIFF
--- a/.changeset/tasty-lizards-boil.md
+++ b/.changeset/tasty-lizards-boil.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/prisma-generator": patch
+---
+
+Import types using import type in generated Electric client.

--- a/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/generator/src/functions/writeSingleFileImportStatements.ts
@@ -19,7 +19,7 @@ export const writeSingleFileImportStatements: WriteStatements = (
   }
 
   writeImport(
-    `{ TableSchema, DbSchema, Relation, ElectricClient, HKT }`,
+    `{ type TableSchema, DbSchema, Relation, ElectricClient, type HKT }`,
     'electric-sql/client/model'
   )
 


### PR DESCRIPTION
This PR fixes #707 by explicitly importing types using `import type` instead of just `import`.