### PR TITLE
fix (generator): fix type issue on schemas containing relations

### DIFF
--- a/.changeset/weak-years-explode.md
+++ b/.changeset/weak-years-explode.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/prisma-generator": patch
+---
+
+Fix type issue in generated client for DB schemas containing relations.

--- a/generator/src/functions/writeSingleFileArgTypeStatements.ts
+++ b/generator/src/functions/writeSingleFileArgTypeStatements.ts
@@ -15,7 +15,8 @@ export const writeSingleFileArgTypeStatements: WriteStatements = (
 
   fileWriter.writeHeading(`ARGS`, 'FAT')
 
-  dmmf.schema.outputObjectTypes.argTypes.forEach((outputType) => {
+  const types = dmmf.schema.outputObjectTypes
+  types.argTypes.forEach((outputType) => {
     outputType.prismaActionFields.forEach((field) => {
       writeOutputObjectType({ dmmf, fileWriter }, field)
     })


### PR DESCRIPTION
This PR fixes the problem where the generated client may contain type errors for models containing relations.
This is a known problem with Zod and Prisma and is described here: https://github.com/chrishoermann/zod-prisma-types/issues/98. That issue also proposes a solution with a dirty type cast: https://github.com/chrishoermann/zod-prisma-types/issues/98#issuecomment-1800112669 which is implemented in this PR.

This PR removes the need for pinning the version of Zod (https://github.com/electric-sql/electric/pull/700).

To test this fix, you will need a schema containing at least one FK relation and make sure to modify the dependency to your generator to point to the modified generator (e.g. `npm pack` the generator and use a dependency to the packed file).