### PR TITLE
fix (generator): escape client generator path on Windows

### DIFF
--- a/.changeset/cool-bugs-clean.md
+++ b/.changeset/cool-bugs-clean.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Properly escape path for Windows in the generator.

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -242,7 +242,7 @@ async function createPrismaSchema(
 
     generator client {
       provider = "prisma-client-js"
-      output   = "${output}"
+      output   = "${escapePathForString(output)}"
     }
 
     datasource db {


### PR DESCRIPTION
This PR escapes also the output path for the Prisma client generator in the intermediate Prisma schema when running on Windows.