### PR TITLE
feat(client): New "npx electric-sql proxy-tunnel" command

### DIFF
--- a/.changeset/hip-ducks-behave.md
+++ b/.changeset/hip-ducks-behave.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+New "npx electric-sql proxy-tunnel" command that tunnels a Postgres TCP connection over a websocket for the Postgres Proxy.

--- a/clients/typescript/src/cli/index.ts
+++ b/clients/typescript/src/cli/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { handleGenerate } from './migrations'
+import { handleTunnel } from './tunnel'
 
 const args = process.argv
 
@@ -19,6 +20,7 @@ const [_node, _file, command, ...commandArgs] = process.argv
 type CommandHandlers = Record<string, (...args: string[]) => Promise<void>>
 const commandHandlers: CommandHandlers = {
   generate: handleGenerate,
+  'proxy-tunnel': handleTunnel,
 }
 
 if (!Object.prototype.hasOwnProperty.call(commandHandlers, command)) {

--- a/clients/typescript/src/cli/tunnel/handler.ts
+++ b/clients/typescript/src/cli/tunnel/handler.ts
@@ -29,6 +29,10 @@ export async function handleTunnel(...args: string[]) {
  * @returns The parsed arguments.
  */
 function parseTunnelArgs(args: string[]) {
+  if (args.length % 2 !== 0 || args.length > 4) {
+    throw new Error('Invalid number of arguments')
+  }
+
   const opts: Partial<TunnelOptions> = {}
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]

--- a/clients/typescript/src/cli/tunnel/handler.ts
+++ b/clients/typescript/src/cli/tunnel/handler.ts
@@ -1,0 +1,54 @@
+import { tunnel, defaultOptions, type TunnelOptions } from './tunnel'
+
+/**
+ * Handles calls to `npx electric-sql proxy-tunnel`, this opens a tunnel to the Electric
+ * Postgres Proxy and binds it to a local port.
+ * The proxy-tunnel command supports the following arguments:
+ *  - `--service <url>`
+ *     Optional argument providing the url to connect to Electric.
+ *     If not provided, it uses the url set in the `ELECTRIC_URL`
+ *     environment variable. If that variable is not set, it
+ *     resorts to the default url which is `http://localhost:5133`.
+ * - `--local-port <url>`
+ *    Optional argument providing the local port to bind the tunnel to.
+ * @param args Arguments passed to the proxy-tunnel command.
+ */
+export async function handleTunnel(...args: string[]) {
+  // merge default options with the provided arguments
+  const opts: TunnelOptions = {
+    ...defaultOptions,
+    ...parseTunnelArgs(args),
+  }
+
+  tunnel(opts)
+}
+
+/**
+ * Parses the arguments passed to the proxy-tunnel command.
+ * @param args Arguments passed to the proxy-tunnel command.
+ * @returns The parsed arguments.
+ */
+function parseTunnelArgs(args: string[]) {
+  const opts: Partial<TunnelOptions> = {}
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    switch (arg) {
+      case '--service':
+        opts.serviceUrl = args[++i]
+        break
+      case '--local-port':
+        opts.localPort = parseInt(args[++i])
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  // prepend protocol if not provided in service url
+  const serviceUrl = opts.serviceUrl?.trim()
+  if (serviceUrl && !/^(http|ws)s?:\/\//.test(serviceUrl)) {
+    opts.serviceUrl = 'ws://' + serviceUrl
+  }
+
+  return opts
+}

--- a/clients/typescript/src/cli/tunnel/index.ts
+++ b/clients/typescript/src/cli/tunnel/index.ts
@@ -1,0 +1,1 @@
+export { handleTunnel } from './handler'

--- a/clients/typescript/src/cli/tunnel/tunnel.ts
+++ b/clients/typescript/src/cli/tunnel/tunnel.ts
@@ -1,0 +1,56 @@
+import net from 'net'
+import { WebSocket, createWebSocketStream } from 'ws'
+
+export interface TunnelOptions {
+  serviceUrl: string
+  localPort: number
+}
+
+export const defaultOptions: TunnelOptions = {
+  serviceUrl: 'ws://localhost:5133',
+  localPort: 65432,
+}
+
+export function tunnel({ serviceUrl, localPort }: TunnelOptions) {
+  const server = net.createServer((clientSocket) => {
+    log('New connection!')
+
+    const websocketUrl = `${serviceUrl}/proxy`
+    const websocket = new WebSocket(websocketUrl, [], {
+      perMessageDeflate: false,
+      skipUTF8Validation: true,
+    })
+    const wsStream = createWebSocketStream(websocket)
+    wsStream.on('error', (error) => {
+      log('WebSocket error:', error)
+    })
+    log('Created WebSocket stream')
+
+    clientSocket.on('end', () => {
+      websocket.close()
+      log('Client disconnected')
+    })
+
+    clientSocket.pipe(wsStream).pipe(clientSocket)
+  })
+
+  server.listen(localPort, () => {
+    console.log(
+      `ElectricSQL Postgres Proxy Tunnel listening on port ${localPort}`
+    )
+    console.log(`Connected to ElectricSQL Service at ${serviceUrl}`)
+    console.log('Connect to the database using:')
+    console.log(`  psql -h localhost -p ${localPort} -U <username> <database>`)
+    console.log('Or with the connection string:')
+    console.log(
+      `  psql "postgres://<username>:<password>@localhost:${localPort}/<database>"`
+    )
+    console.log('Press Ctrl+C to exit')
+    console.log('--')
+  })
+}
+
+function log(...args: any[]) {
+  const timestamp = new Date().toISOString()
+  console.log(timestamp, ...args)
+}


### PR DESCRIPTION
@alco this builds on your WIP [alco/pg-proxy-over-websocket](https://github.com/electric-sql/electric/tree/alco/pg-proxy-over-websocket) branch 

To connect to the service, and create a local proxy tunnel:
```sh
npx electric-sql proxy-tunnel --service http://something --local-port 65431
```

then to run migrations:
```sh
yarn run -s pg-migrations apply --database postgres://postgres:proxy_password@localhost:65431 --directory ./db/migrations
```

and the generator:
```sh
npx electric-sql generate --service http://localhost:5133 --proxy postgresql://prisma:proxy_password@localhost:65431/electric
```