### PR TITLE
chore(electric): Publish canary images to Docker Hub on every push to main

### DIFF
--- a/.buildkite/docker-image.yml
+++ b/.buildkite/docker-image.yml
@@ -16,6 +16,7 @@ steps:
       - export ELECTRIC_IMAGE_NAME="${DOCKER_REPO}/${IMAGE_NAME}"
       - cd ./components/electric
       - export ELECTRIC_VERSION=$(make --silent print_version_from_git)
+      - export ELECTRIC_CANARY_IMAGE="${DOCKERHUB_REPO}/${IMAGE_NAME}:canary"
       - make docker-build-ci
   - wait
   - label: ":rocket: Publish the image to DockerHub"

--- a/.changeset/gorgeous-knives-drum.md
+++ b/.changeset/gorgeous-knives-drum.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Automatically publish electricsql/electric:canary images to Docker Hub on every push to main.

--- a/.changeset/real-walls-perform.md
+++ b/.changeset/real-walls-perform.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Log the version of the Electric sync service on startup.

--- a/components/electric/Makefile
+++ b/components/electric/Makefile
@@ -78,9 +78,11 @@ docker-build-ci:
 ifeq (${TAG_AS_LATEST_AND_PUSH}, true)
 	docker tag "${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION}" "${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION_MINOR}"
 	docker tag "${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION}" "${ELECTRIC_IMAGE_NAME}:latest"
+	docker tag "${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION}" "${ELECTRIC_CANARY_IMAGE}"
 	docker push "${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION}"
 	docker push "${ELECTRIC_IMAGE_NAME}:${ELECTRIC_VERSION_MINOR}"
 	docker push "${ELECTRIC_IMAGE_NAME}:latest"
+	docker push "${ELECTRIC_CANARY_IMAGE}"
 endif
 
 docker-build-ws-client:

--- a/components/electric/lib/electric/application.ex
+++ b/components/electric/lib/electric/application.ex
@@ -1,10 +1,12 @@
 defmodule Electric.Application do
   @moduledoc false
 
+  use Application
+
   alias Electric.Replication.Connectors
   alias Electric.Replication.PostgresConnector
 
-  use Application
+  require Logger
 
   def start(_type, _args) do
     children = [
@@ -43,6 +45,10 @@ defmodule Electric.Application do
           []
         end
 
+    app_vsn = Application.spec(:electric, :vsn)
+    write_to_pg_mode = Electric.write_to_pg_mode()
+    Logger.info("Starting ElectricSQL #{app_vsn} in #{write_to_pg_mode} mode.")
+
     opts = [strategy: :one_for_one, name: Electric.Supervisor]
     {:ok, supervisor} = Supervisor.start_link(children, opts)
 
@@ -52,7 +58,7 @@ defmodule Electric.Application do
         PostgresConnector,
         config
         |> Keyword.put(:origin, to_string(name))
-        |> Keyword.put(:write_to_pg_mode, Electric.write_to_pg_mode())
+        |> Keyword.put(:write_to_pg_mode, write_to_pg_mode)
       )
     end)
 


### PR DESCRIPTION
I've added a log entry that output the server version and the configured write mode, like so:
```
$ docker run --rm -t -e AUTH_MODE=insecure -e DATABASE_URL=postgres://postgres:password@postgres/electric -e ELECTRIC_WRITE_TO_PG_MODE=direct_writes -e PG_PROXY_PASSWORD=password electric:local-build
10:50:11.035 pid=<0.2308.0> [notice]     :alarm_handler: {:set, {:system_memory_high_watermark, []}}
10:50:11.036 pid=<0.2451.0> [info] Starting ElectricSQL 0.8.0-10-g7e1a0e0 in direct_writes mode.
```

This will make it easier for people to identify the commit which their local `canary` image was built from.