### PR TITLE
chore(electric): Improve error handling of the case when another Electric is already connected to the same DB

### DIFF
--- a/.changeset/violet-ladybugs-sip.md
+++ b/.changeset/violet-ladybugs-sip.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Log a descriptive error message when Electric fails to open a replication connection to Postgres.

--- a/components/electric/lib/electric/plug/status.ex
+++ b/components/electric/lib/electric/plug/status.ex
@@ -11,14 +11,11 @@ defmodule Electric.Plug.Status do
   get "/" do
     [origin] = PostgresConnector.connectors()
 
-    msg =
-      if :ready == PostgresConnectorMng.status(origin) do
-        "Connection to Postgres is up!"
-      else
-        "Initializing connection to Postgres..."
-      end
-
-    send_resp(conn, 200, msg)
+    if :ready == PostgresConnectorMng.status(origin) do
+      send_resp(conn, 200, "Connection to Postgres is up!")
+    else
+      send_resp(conn, 503, "Initializing connection to Postgres...")
+    end
   end
 
   match _ do

--- a/components/electric/test/support/postgres_test_connection.ex
+++ b/components/electric/test/support/postgres_test_connection.ex
@@ -258,13 +258,13 @@ defmodule Electric.Postgres.TestConnection do
 
   # Wait for the Postgres connector to start. It starts the CachedWal.Producer which this test module depends on.
   defp wait_for_postgres_initialization(origin) do
-    status = PostgresConnectorMng.status(origin)
+    case PostgresConnectorMng.status(origin) do
+      :ready ->
+        :ready
 
-    if status in [:init, :subscribe] do
-      Process.sleep(50)
-      wait_for_postgres_initialization(origin)
-    else
-      status
+      _ ->
+        Process.sleep(50)
+        wait_for_postgres_initialization(origin)
     end
   end
 end

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -20,7 +20,7 @@
         [timeout 5]
         !make start_electric_1
         -$fail_pattern
-        ??successfully initialized connector "postgres_1"
+        ??Successfully initialized Postgres connector "postgres_1"
         [progress setup finished]
 
     [shell postgres_logs]


### PR DESCRIPTION
## Before
```
14:57:31.823 pid=<0.721.0> [info] Starting replication from postgres_1
14:57:31.823 pid=<0.721.0> [info] Connection settings: %{database: ~c"electric", host: ~c"localhost", password: ~c"******", port: 54321, replication: ~c"database", ssl: false, username: ~c"postgres"}
14:57:31.842 pid=<0.721.0> [debug] Elixir.Electric.Replication.Postgres.Client: CREATE_REPLICATION_SLOT "electric_replication_out_electric" LOGICAL pgoutput NOEXPORT_SNAPSHOT
14:57:31.846 pid=<0.719.0> [debug] Starting SchemaLoader pg connection: [write_to_pg_mode: :direct_writes, origin: "postgres_1", producer: Electric.Replication.Postgres.LogicalReplicationProducer, connection: [host: ~c"localhost", port: 54321, database: ~c"electric", username: ~c"postgres", password: ~c"password", replication: ~c"database", ssl: false], replication: [electric_connection: [host: "host.docker.internal", port: 5433, dbname: "test"]], proxy: [listen: [port: 65433], password: "password", log_level: :info]]
14:57:31.869 pid=<0.721.0> [debug] Elixir.Electric.Replication.Postgres.Client start_replication: slot: 'electric_replication_out_electric', publication: 'electric_publication'
14:57:31.869 pid=<0.719.0> [debug] Terminating idle db connection #PID<0.723.0>
14:57:31.869 pid=<0.715.0> origin=postgres_1 [error] GenServer #PID<0.715.0> terminating
** (MatchError) no match of right hand side value: {:error, {{:shutdown, {:failed_to_start_child, :postgres_producer, {:bad_return_value, {:error, {:error, :error, "55006", :object_in_use, "replication slot \"electric_replication_out_electric\" is active for PID 4771", [file: "slot.c", line: "446", routine: "ReplicationSlotAcquire", severity: "ERROR"]}}}}}, {:child, :undefined, :sup, {Electric.Replication.PostgresConnectorSup, :start_link, [[write_to_pg_mode: :direct_writes, origin: "postgres_1", producer: Electric.Replication.Postgres.LogicalReplicationProducer, connection: [host: ~c"localhost", port: 54321, database: ~c"electric", username: ~c"postgres", password: ~c"password", replication: ~c"database", ssl: false], replication: [electric_connection: [host: "host.docker.internal", port: 5433, dbname: "test"]], proxy: [listen: [port: 65433], password: "password", log_level: :info]]]}, :temporary, false, :infinity, :supervisor, [Electric.Replication.PostgresConnectorSup]}}}
    (electric 0.8.0-9-gddb70c9) lib/electric/replication/postgres_manager.ex:96: Electric.Replication.PostgresConnectorMng.handle_continue/2
    (stdlib 4.3) gen_server.erl:1123: :gen_server.try_dispatch/4
    (stdlib 4.3) gen_server.erl:865: :gen_server.loop/7
    (stdlib 4.3) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: {:continue, :init}
State: %Electric.Replication.PostgresConnectorMng.State{state: :init, conn_config: %{database: ~c"electric", host: ~c"localhost", password: ~c"password", port: 54321, ssl: false, username: ~c"postgres"}, repl_config: %{electric_connection: [host: "host.docker.internal", port: 5433, dbname: "test"], publication: "electric_publication", slot: "electric_replication_out_electric", subscription: "postgres_1"}, backoff: {{:backoff, 1000, 10000, 1000, :normal, :undefined, :undefined}, nil}, origin: "postgres_1", config: [write_to_pg_mode: :direct_writes, origin: "postgres_1", producer: Electric.Replication.Postgres.LogicalReplicationProducer, connection: [host: ~c"localhost", port: 54321, database: ~c"electric", username: ~c"postgres", password: ~c"password", replication: ~c"database", ssl: false], replication: [electric_connection: [host: "host.docker.internal", port: 5433, dbname: "test"]], proxy: [listen: [port: 65433], password: "password", log_level: :info]], pg_connector_sup_monitor: nil}
```
The above error is followed by another attempt to initialize Electric's Postgres state from scratch (redefining all SQL functions etc.), and the whole process repeats a number of times in quick succession until the Elixir supervisor runs out of restart attempts.

## After
```
14:56:25.745 pid=<0.678.0> [debug] Elixir.Electric.Replication.Postgres.LogicalReplicationProducer init:: publication: 'electric_publication', slot: 'electric_replication_out_electric'
14:56:25.745 pid=<0.678.0> [info] Starting replication from postgres_1
14:56:25.745 pid=<0.678.0> [info] Connection settings: %{database: ~c"electric", host: ~c"localhost", password: ~c"******", port: 54321, replication: ~c"database", ssl: false, username: ~c"postgres"}
14:56:25.762 pid=<0.678.0> [debug] Elixir.Electric.Replication.Postgres.Client: CREATE_REPLICATION_SLOT "electric_replication_out_electric" LOGICAL pgoutput NOEXPORT_SNAPSHOT
14:56:25.767 pid=<0.676.0> [debug] Starting SchemaLoader pg connection: [write_to_pg_mode: :direct_writes, origin: "postgres_1", producer: Electric.Replication.Postgres.LogicalReplicationProducer, connection: [host: ~c"localhost", port: 54321, database: ~c"electric", username: ~c"postgres", password: ~c"password", replication: ~c"database", ssl: false], replication: [electric_connection: [host: "host.docker.internal", port: 5433, dbname: "test"]], proxy: [listen: [port: 65433], password: "password", log_level: :info]]
14:56:25.793 pid=<0.678.0> [debug] Elixir.Electric.Replication.Postgres.Client start_replication: slot: 'electric_replication_out_electric', publication: 'electric_publication'
14:56:25.796 pid=<0.669.0> origin=postgres_1 [error] Initialization of replication connection to Postgres failed with reason: replication slot "electric_replication_out_electric" is active for PID 4771. Another instance of Electric appears to be connected to this database.
14:56:25.796 pid=<0.669.0> origin=postgres_1 [info] schedule retry: 2000
14:56:25.798 pid=<0.676.0> [debug] Terminating idle db connection #PID<0.680.0>
```