### PR TITLE
chore(generator) Change generator to add .js extention to imports for nodenext compatibility

### DIFF
--- a/.changeset/thirty-pots-wash.md
+++ b/.changeset/thirty-pots-wash.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/prisma-generator": patch
+---
+
+Change generator to add .js extention to imports for nodenext compatibility

--- a/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/generator/src/functions/writeSingleFileImportStatements.ts
@@ -10,7 +10,7 @@ export const writeSingleFileImportStatements: WriteStatements = (
 ) => {
   writeImport('{ z }', 'zod')
 
-  writeImport(`type { Prisma }`, `./prismaClient`)
+  writeImport(`type { Prisma }`, `./prismaClient.js`)
 
   if (dmmf.customImports) {
     dmmf.customImports.forEach((statement) => {
@@ -23,5 +23,5 @@ export const writeSingleFileImportStatements: WriteStatements = (
     'electric-sql/client/model'
   )
 
-  writeImport(`migrations`, './migrations')
+  writeImport(`migrations`, './migrations.js')
 }


### PR DESCRIPTION
When you have `"moduleResolution": "nodenext"` in `tsconfig.json` all imports need to have the full path including a `.js` extension, even if to a `.ts` file.

This is backwards compatibly with all typescript settings, its always possible to import a `.ts` or `.d.ts` when the import has a `.js` extension.