### PR TITLE
chore (client): improved interface for the generic adapter

### DIFF
--- a/.changeset/rare-guests-kick.md
+++ b/.changeset/rare-guests-kick.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Modified interface of the generic database adapter and modified the drivers accordingly.

--- a/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
@@ -21,7 +21,6 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
       wrapInTransaction
     )
 
-    // TODO: `result.values!` is typed as `any[]`. Is this an array of objects (i.e. `Row[]`) or is it something else, e.g. an array of arrays?
     return result.values ?? []
   }
 

--- a/clients/typescript/src/drivers/capacitor-sqlite/database.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/database.ts
@@ -6,6 +6,7 @@ type OriginalDatabase = SQLiteDBConnection
 
 // The relevant subset of the SQLitePlugin database client API
 // that we need to ensure the client we're electrifying provides.
-export interface Database extends Pick<OriginalDatabase, 'executeSet' | 'run'> {
+export interface Database
+  extends Pick<OriginalDatabase, 'executeSet' | 'run' | 'query'> {
   dbname?: DbName
 }

--- a/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
@@ -21,6 +21,10 @@ export class MockDatabase implements Database {
     })
   }
 
+  query(): Promise<any> {
+    throw new Error('Not implemented')
+  }
+
   private resolveIfNotFail<T>(value: T): Promise<T> {
     if (typeof this.fail !== 'undefined') return Promise.reject(this.fail)
     else return Promise.resolve(value)

--- a/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
@@ -1,4 +1,4 @@
-import { capSQLiteChanges } from '@capacitor-community/sqlite'
+import { DBSQLiteValues, capSQLiteChanges } from '@capacitor-community/sqlite'
 import { DbName } from '../../util/types'
 import { Database } from './database'
 
@@ -13,16 +13,17 @@ export class MockDatabase implements Database {
     return this.resolveIfNotFail({
       changes: {
         changes: 0,
-        values: [
-          { textColumn: 'text1', numberColumn: 1 },
-          { textColumn: 'text2', numberColumn: 2 },
-        ],
       },
     })
   }
 
-  query(): Promise<any> {
-    throw new Error('Not implemented')
+  query(): Promise<DBSQLiteValues> {
+    return this.resolveIfNotFail({
+      values: [
+        { textColumn: 'text1', numberColumn: 1 },
+        { textColumn: 'text2', numberColumn: 2 },
+      ],
+    })
   }
 
   private resolveIfNotFail<T>(value: T): Promise<T> {

--- a/clients/typescript/src/drivers/expo-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/expo-sqlite/adapter.ts
@@ -2,6 +2,7 @@ import { Row } from '../../util/types'
 import { Statement } from '../../util'
 import { SerialDatabaseAdapter as GenericDatabaseAdapter } from '../generic'
 import { Database } from './database'
+import { RunResult } from '../../electric/adapter'
 
 export class DatabaseAdapter extends GenericDatabaseAdapter {
   readonly db: Database
@@ -12,7 +13,7 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
     this.db = db
   }
 
-  async exec(statement: Statement): Promise<Row[]> {
+  private async exec(statement: Statement): Promise<Row[]> {
     return new Promise((resolve, reject) => {
       const stmt = { sql: statement.sql, args: statement.args ?? [] }
       this.db.execRawQuery([stmt], false, (err, result) => {
@@ -33,7 +34,18 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
     })
   }
 
-  getRowsModified() {
+  private getRowsModified() {
     return this.#rowsModified
+  }
+
+  async _run(statement: Statement): Promise<RunResult> {
+    await this.exec(statement)
+    return {
+      rowsAffected: this.getRowsModified(),
+    }
+  }
+
+  _query(statement: Statement): Promise<Row[]> {
+    return this.exec(statement)
   }
 }

--- a/clients/typescript/src/drivers/generic/adapter.ts
+++ b/clients/typescript/src/drivers/generic/adapter.ts
@@ -5,7 +5,6 @@ import {
   Transaction as Tx,
 } from '../../electric/adapter'
 import { Row, Statement } from '../../util'
-import { isInsertUpdateOrDeleteStatement } from '../../util/statements'
 import { Mutex } from 'async-mutex'
 import { AnyDatabase } from '..'
 
@@ -28,14 +27,19 @@ abstract class DatabaseAdapter
   }
 
   /**
-   * @param statement A SQL statement to execute against the DB.
+   * Runs a single SQL statement against the DB.
+   * @param stmt The SQL statement to execute
+   * @returns The number of rows modified by this statement.
    */
-  abstract exec(statement: Statement): Promise<Row[]>
+  abstract _run(stmt: Statement): Promise<RunResult>
 
   /**
-   * @returns The number of rows modified by the last insert/update/delete query.
+   * Runs a single SQL query against the DB.
+   * The query should be read-only.
+   * @param stmt The SQL statement to execute
+   * @returns The rows read by the query.
    */
-  abstract getRowsModified(): number
+  abstract _query(stmt: Statement): Promise<Row[]>
 
   /**
    * @param statements A list of SQL statements to execute against the DB.
@@ -48,7 +52,7 @@ abstract class DatabaseAdapter
     const release = await this.txMutex.acquire()
 
     try {
-      await this.exec({ sql: 'BEGIN' })
+      await this._run({ sql: 'BEGIN' })
     } catch (e) {
       release()
       throw e
@@ -66,7 +70,7 @@ abstract class DatabaseAdapter
       f(tx, (res) => {
         // Commit the transaction when the user sets the result.
         // This assumes that the user does not execute any more queries after setting the result.
-        this.exec({ sql: 'COMMIT' })
+        this._run({ sql: 'COMMIT' })
           .then(() => {
             release()
             resolve(res)
@@ -83,17 +87,8 @@ abstract class DatabaseAdapter
     // Also uses the mutex to avoid running this query while a transaction is executing.
     // Because that would make the query part of the transaction which was not the intention.
     return this.txMutex.runExclusive(() => {
-      return this._runUncoordinated(stmt)
+      return this._run(stmt)
     })
-  }
-
-  // Do not use this uncoordinated version directly!
-  // It is only meant to be used within transactions.
-  async _runUncoordinated(stmt: Statement): Promise<RunResult> {
-    await this.exec(stmt)
-    return {
-      rowsAffected: this.getRowsModified(),
-    }
   }
 
   // This `query` function does not enforce that the query is read-only
@@ -101,14 +96,8 @@ abstract class DatabaseAdapter
     // Also uses the mutex to avoid running this query while a transaction is executing.
     // Because that would make the query part of the transaction which was not the intention.
     return this.txMutex.runExclusive(() => {
-      return this._queryUncoordinated(stmt)
+      return this._query(stmt)
     })
-  }
-
-  // Do not use this uncoordinated version directly!
-  // It is only meant to be used within transactions.
-  async _queryUncoordinated(stmt: Statement): Promise<Row[]> {
-    return await this.exec(stmt)
   }
 }
 
@@ -147,25 +136,22 @@ export abstract class SerialDatabaseAdapter
     let open = false
     let rowsAffected = 0
     try {
-      await this.exec({ sql: 'BEGIN' })
+      await this._run({ sql: 'BEGIN' })
       open = true
       for (const stmt of statements) {
-        await this.exec(stmt)
-        if (isInsertUpdateOrDeleteStatement(stmt.sql)) {
-          // Fetch the number of rows affected by the last insert, update, or delete
-          rowsAffected += this.getRowsModified()
-        }
+        const { rowsAffected: rowsModified } = await this._run(stmt)
+        rowsAffected += rowsModified
       }
       return {
         rowsAffected: rowsAffected,
       }
     } catch (error) {
-      await this.exec({ sql: 'ROLLBACK' })
+      await this._run({ sql: 'ROLLBACK' })
       open = false
       throw error // rejects the promise with the reason for the rollback
     } finally {
       if (open) {
-        await this.exec({ sql: 'COMMIT' })
+        await this._run({ sql: 'COMMIT' })
       }
       release()
     }
@@ -185,7 +171,7 @@ class Transaction implements Tx {
     }
 
     this.adapter
-      ._runUncoordinated({ sql: 'ROLLBACK' })
+      ._run({ sql: 'ROLLBACK' })
       .then(() => {
         invokeErrorCallbackAndSignalFailure()
       })
@@ -211,8 +197,8 @@ class Transaction implements Tx {
     successCallback?: (tx: Transaction, result: RunResult) => void,
     errorCallback?: (error: any) => void
   ): void {
-    // uses _runUncoordinated because we're in a transaction that already acquired the lock
-    const prom = this.adapter._runUncoordinated(statement)
+    // uses _run because we're in a transaction that already acquired the lock
+    const prom = this.adapter._run(statement)
     this.invokeCallback(prom, successCallback, errorCallback)
   }
 
@@ -221,8 +207,8 @@ class Transaction implements Tx {
     successCallback: (tx: Transaction, res: Row[]) => void,
     errorCallback?: (error: any) => void
   ): void {
-    // uses _queryUncoordinated because we're in a transaction that already acquired the lock
-    const prom = this.adapter._queryUncoordinated(statement)
+    // uses _query because we're in a transaction that already acquired the lock
+    const prom = this.adapter._query(statement)
     this.invokeCallback(prom, successCallback, errorCallback)
   }
 }

--- a/clients/typescript/src/drivers/generic/adapter.ts
+++ b/clients/typescript/src/drivers/generic/adapter.ts
@@ -35,7 +35,6 @@ abstract class DatabaseAdapter
 
   /**
    * Runs a single SQL query against the DB.
-   * The query should be read-only.
    * @param stmt The SQL statement to execute
    * @returns The rows read by the query.
    */
@@ -91,7 +90,6 @@ abstract class DatabaseAdapter
     })
   }
 
-  // This `query` function does not enforce that the query is read-only
   query(stmt: Statement): Promise<Row[]> {
     // Also uses the mutex to avoid running this query while a transaction is executing.
     // Because that would make the query part of the transaction which was not the intention.

--- a/clients/typescript/src/drivers/wa-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/wa-sqlite/adapter.ts
@@ -2,6 +2,7 @@ import { Database } from './database'
 import { Row } from '../../util/types'
 import { Statement } from '../../util'
 import { SerialDatabaseAdapter as GenericDatabaseAdapter } from '../generic'
+import { RunResult } from '../../electric/adapter'
 
 export class DatabaseAdapter extends GenericDatabaseAdapter {
   readonly db: Database
@@ -11,11 +12,22 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
     this.db = db
   }
 
-  async exec(statement: Statement): Promise<Row[]> {
+  private exec(statement: Statement): Promise<Row[]> {
     return this.db.exec(statement)
   }
 
-  getRowsModified() {
+  private getRowsModified() {
     return this.db.getRowsModified()
+  }
+
+  async _run(statement: Statement): Promise<RunResult> {
+    await this.exec(statement)
+    return {
+      rowsAffected: this.getRowsModified(),
+    }
+  }
+
+  _query(statement: Statement): Promise<Row[]> {
+    return this.exec(statement)
   }
 }


### PR DESCRIPTION
This PR improves the generic database adapter to require `_query` and `_run` methods instead of an `exec` method.