### PR TITLE
Adapt cap-sqlite mock.ts to new generic adapter

### DIFF
--- a/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
@@ -21,7 +21,6 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
       wrapInTransaction
     )
 
-    // TODO: `result.values!` is typed as `any[]`. Is this an array of objects (i.e. `Row[]`) or is it something else, e.g. an array of arrays?
     return result.values ?? []
   }
 

--- a/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
@@ -1,4 +1,4 @@
-import { capSQLiteChanges } from '@capacitor-community/sqlite'
+import { DBSQLiteValues, capSQLiteChanges } from '@capacitor-community/sqlite'
 import { DbName } from '../../util/types'
 import { Database } from './database'
 
@@ -13,16 +13,17 @@ export class MockDatabase implements Database {
     return this.resolveIfNotFail({
       changes: {
         changes: 0,
-        values: [
-          { textColumn: 'text1', numberColumn: 1 },
-          { textColumn: 'text2', numberColumn: 2 },
-        ],
       },
     })
   }
 
-  query(): Promise<any> {
-    throw new Error('Not implemented')
+  query(): Promise<DBSQLiteValues> {
+    return this.resolveIfNotFail({
+      values: [
+        { textColumn: 'text1', numberColumn: 1 },
+        { textColumn: 'text2', numberColumn: 2 },
+      ],
+    })
   }
 
   private resolveIfNotFail<T>(value: T): Promise<T> {


### PR DESCRIPTION
* Removed todo comment RE return type of cap-sqlite `query`, the result type is an array of objects as expected.
* Adapted `mock.ts` to the new requirements

My tests pass, but am getting 2 other failed tests which are probably tied to env/update issues?

`Error: Cannot find module '/Users/gregoriozanon/Documents/Dev/electric/clients/typescript/node_modules/@electric-sql/prisma-generator/dist/generator.js'. Please verify that the package.json has a valid "main" entry`

Makes those tests fail:
```
✖ test/cli/migrations/handler.test.ts exited with a non-zero exit code: 1
✖ test/cli/migrations/migrate.test.ts exited with a non-zero exit code: 1
```