### PR TITLE
(tmp) Do not publish to Docker Hub from Buildkite. Only echo the versions

### DIFF
--- a/.buildkite/docker-image.yml
+++ b/.buildkite/docker-image.yml
@@ -25,4 +25,4 @@ steps:
       - export ELECTRIC_IMAGE_NAME="${DOCKERHUB_REPO}/${IMAGE_NAME}"
       - cd ./components/electric
       - export ELECTRIC_VERSION=$(make --silent print_version_from_git)
-      - make docker-build-ci-crossplatform
+      - echo $ELECTRIC_IMAGE_NAME $ELECTRIC_VERSION


### PR DESCRIPTION
This is a temporary change that needs to be in main to enable testing of Buildkite's tag-triggered build behaviour.