### PR TITLE
chore (client): refactored socket implementation

### DIFF
--- a/clients/typescript/src/sockets/genericSocket.ts
+++ b/clients/typescript/src/sockets/genericSocket.ts
@@ -1,0 +1,111 @@
+import EventEmitter from 'events'
+import { ConnectionOptions, Data, Socket } from '.'
+import { SatelliteError, SatelliteErrorCode } from '../util'
+
+type WriteType<SupportBuffer extends boolean> = SupportBuffer extends false
+  ? Data
+  : Data | Buffer
+
+interface MessageEvent<T = any> {
+  data: T
+}
+
+export interface IWebSocket<SupportBuffer extends boolean> {
+  send(data: WriteType<SupportBuffer>): void
+
+  addEventListener(event: 'open', cb: () => void): void
+  addEventListener(event: 'message', cb: (ev: MessageEvent) => void): void
+  addEventListener(event: 'error', cb: (ev: any) => void): void
+  addEventListener(event: 'close', cb: () => void): void
+
+  removeEventListener(
+    event: 'open' | 'message' | 'error' | 'close',
+    cb: (...args: any[]) => void
+  ): void
+
+  close(): void
+}
+
+export abstract class GenericWebSocket<SupportBuffer extends boolean = false>
+  extends EventEmitter
+  implements Socket
+{
+  protected abstract socket?: IWebSocket<SupportBuffer>
+  protected abstract makeSocket(
+    opts: ConnectionOptions
+  ): IWebSocket<SupportBuffer>
+
+  private openListener = () => this.emit('open')
+  protected messageListener = (ev: MessageEvent) => {
+    const buffer = new Uint8Array(ev.data)
+    this.emit('message', buffer)
+  }
+  private errorListener = () =>
+    this.emit(
+      'error',
+      new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
+    )
+  private closeListener = () => this.emit('close')
+
+  constructor() {
+    super()
+  }
+
+  open(opts: ConnectionOptions): this {
+    if (this.socket) {
+      throw new SatelliteError(
+        SatelliteErrorCode.INTERNAL,
+        'trying to open a socket before closing existing socket'
+      )
+    }
+
+    this.socket = this.makeSocket(opts)
+
+    this.socket.addEventListener('open', this.openListener.bind(this))
+    this.socket.addEventListener('message', this.messageListener.bind(this))
+    this.socket.addEventListener('error', this.errorListener.bind(this))
+    this.socket.addEventListener('close', this.closeListener.bind(this))
+
+    return this
+  }
+
+  write(data: WriteType<SupportBuffer>): this {
+    this.socket?.send(data)
+    return this
+  }
+
+  closeAndRemoveListeners(): this {
+    this.removeAllListeners()
+    //this.removeAllSocketListeners()
+    this.socket?.removeEventListener('open', this.openListener)
+    this.socket?.removeEventListener('message', this.messageListener)
+    this.socket?.removeEventListener('error', this.errorListener)
+    this.socket?.removeEventListener('close', this.closeListener)
+    this.socket?.close()
+    return this
+  }
+
+  onMessage(cb: (data: Data) => void): void {
+    this.on('message', cb)
+  }
+
+  onError(cb: (error: SatelliteError) => void): void {
+    this.on('error', cb)
+  }
+
+  onClose(cb: () => void): void {
+    this.on('close', cb)
+  }
+
+  onceConnect(cb: () => void): void {
+    this.once('open', cb)
+  }
+
+  onceError(cb: (error: SatelliteError) => void): void {
+    this.once('error', cb)
+  }
+
+  removeErrorListener(cb: (error: SatelliteError) => void): void {
+    this.removeListener('error', cb)
+  }
+}

--- a/clients/typescript/src/sockets/node.ts
+++ b/clients/typescript/src/sockets/node.ts
@@ -1,71 +1,17 @@
-import EventEmitter from 'events'
-import { ConnectionOptions, Data, Socket } from './index'
+import { ConnectionOptions } from './index'
 import { WebSocket } from 'ws'
-import { SatelliteError, SatelliteErrorCode } from '../util'
+import { GenericWebSocket } from './genericSocket'
 
-export class WebSocketNode extends EventEmitter implements Socket {
-  private socket?: WebSocket
+export class WebSocketNode extends GenericWebSocket<true> {
+  protected socket?: WebSocket
 
   constructor(private protocolVsn: string) {
     super()
   }
 
-  open(opts: ConnectionOptions): this {
-    if (this.socket) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'trying to open a socket before closing existing socket'
-      )
-    }
-
-    this.socket = new WebSocket(opts.url, [this.protocolVsn])
-    this.socket.binaryType = 'nodebuffer'
-
-    this.socket.on('open', () => this.emit('open'))
-    this.socket.on('message', (data) => this.emit('message', data))
-    this.socket.on('error', (_unusedError) =>
-      this.emit(
-        'error',
-        new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-      )
-    )
-
-    return this
-  }
-
-  write(data: string | Uint8Array | Buffer): this {
-    this.socket?.send(data)
-    return this
-  }
-
-  closeAndRemoveListeners(): this {
-    this.removeAllListeners()
-    this.socket?.removeAllListeners()
-    this.socket?.close()
-    return this
-  }
-
-  onMessage(cb: (data: Data) => void): void {
-    this.on('message', cb)
-  }
-
-  onError(cb: (error: SatelliteError) => void): void {
-    this.on('error', cb)
-  }
-
-  onClose(cb: () => void): void {
-    this.on('close', cb)
-  }
-
-  onceConnect(cb: () => void): void {
-    this.once('open', cb)
-  }
-
-  onceError(cb: (error: SatelliteError) => void): void {
-    this.once('error', cb)
-  }
-
-  removeErrorListener(cb: (error: SatelliteError) => void): void {
-    this.removeListener('error', cb)
+  makeSocket(opts: ConnectionOptions): WebSocket {
+    const ws = new WebSocket(opts.url, [this.protocolVsn])
+    ws.binaryType = 'nodebuffer'
+    return ws
   }
 }

--- a/clients/typescript/src/sockets/react-native.ts
+++ b/clients/typescript/src/sockets/react-native.ts
@@ -1,112 +1,16 @@
-import { ConnectionOptions, Data, Socket } from '.'
-import { SatelliteError, SatelliteErrorCode } from '../util'
+import { ConnectionOptions } from '.'
+import { GenericWebSocket } from './genericSocket'
 
-export class WebSocketReactNative implements Socket {
-  private socket?: WebSocket
+export class WebSocketReactNative extends GenericWebSocket {
+  protected socket?: WebSocket
 
-  private connectCallbacks: (() => void)[] = []
-  private errorCallbacks: ((error: SatelliteError) => void)[] = []
-  private onceErrorCallbacks: ((error: SatelliteError) => void)[] = []
-  private messageCallbacks: ((data: any) => void)[] = []
-
-  constructor(private protocolVsn: string) {}
-
-  open(opts: ConnectionOptions): this {
-    if (this.socket) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'trying to open a socket before closing existing socket'
-      )
-    }
-
-    this.socket = new WebSocket(opts.url, [this.protocolVsn])
-    this.socket.binaryType = 'arraybuffer'
-
-    this.socket.onopen = () => {
-      let callback: (() => void) | undefined
-      while ((callback = this.connectCallbacks.pop())) {
-        callback()
-      }
-    }
-
-    // event doesn't provide much
-    this.socket.onerror = () => {
-      for (const callback of this.errorCallbacks) {
-        callback(
-          new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-        )
-      }
-
-      let callback: ((error: SatelliteError) => void) | undefined
-      while ((callback = this.onceErrorCallbacks.pop())) {
-        callback(
-          new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-        )
-      }
-    }
-
-    this.socket.onmessage = (event: any) => {
-      for (const cb of this.messageCallbacks) {
-        // no alloc because message.data is ArrayBuffer
-        const buffer = new Uint8Array(event.data)
-        cb(buffer)
-      }
-    }
-
-    return this
+  constructor(private protocolVsn: string) {
+    super()
   }
 
-  write(data: Data): this {
-    this.socket?.send(data)
-    return this
-  }
-
-  closeAndRemoveListeners(): this {
-    this.connectCallbacks = []
-    this.errorCallbacks = []
-    this.messageCallbacks = []
-
-    this.socket?.close()
-    return this
-  }
-
-  onMessage(cb: (data: Data) => void): void {
-    this.messageCallbacks.push(cb)
-  }
-
-  onError(cb: (error: SatelliteError) => void): void {
-    if (this.socket) {
-      this.socket.onerror = () => {
-        cb(new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error'))
-      }
-    }
-  }
-
-  onClose(cb: () => void): void {
-    if (this.socket) {
-      this.socket.onclose = () => {
-        cb()
-      }
-    }
-  }
-
-  onceConnect(cb: () => void): void {
-    this.connectCallbacks.push(cb)
-  }
-
-  onceError(cb: (error: SatelliteError) => void): void {
-    this.onceErrorCallbacks.push(cb)
-  }
-
-  removeErrorListener(cb: (error: SatelliteError) => void): void {
-    const idx = this.errorCallbacks.indexOf(cb)
-    if (idx >= 0) {
-      this.errorCallbacks.splice(idx, 1)
-    }
-
-    const idxOnce = this.onceErrorCallbacks.indexOf(cb)
-    if (idxOnce >= 0) {
-      this.onceErrorCallbacks.splice(idxOnce, 1)
-    }
+  makeSocket(opts: ConnectionOptions): WebSocket {
+    const ws = new WebSocket(opts.url, [this.protocolVsn])
+    ws.binaryType = 'arraybuffer'
+    return ws
   }
 }

--- a/clients/typescript/src/sockets/web.ts
+++ b/clients/typescript/src/sockets/web.ts
@@ -1,125 +1,16 @@
-import { ConnectionOptions, Data, Socket } from '.'
-import { SatelliteError, SatelliteErrorCode } from '../util'
+import { ConnectionOptions } from '.'
+import { GenericWebSocket } from './genericSocket'
 
-// FIXME: This implementation is a bit contrived because it is not using EventEmitter
-export class WebSocketWeb implements Socket {
-  private socket?: WebSocket
+export class WebSocketWeb extends GenericWebSocket {
+  protected socket?: WebSocket
 
-  private connectCallbacks: (() => void)[] = []
-  private errorCallbacks: ((error: SatelliteError) => void)[] = []
-  private onceErrorCallbacks: ((error: SatelliteError) => void)[] = []
-
-  // event doesn't provide much
-  private errorListener = () => {
-    for (const callback of this.errorCallbacks) {
-      callback(
-        new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-      )
-    }
-
-    let callback: ((error: SatelliteError) => void) | undefined
-    while ((callback = this.onceErrorCallbacks.pop())) {
-      callback(
-        new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-      )
-    }
+  constructor(private protocolVsn: string) {
+    super()
   }
 
-  private connectListener = () => {
-    let callback: (() => void) | undefined
-    while ((callback = this.connectCallbacks.pop())) {
-      callback()
-    }
-  }
-  private messageListener?: (event: MessageEvent<any>) => void
-  private closeListener?: () => void
-
-  constructor(private protocolVsn: string) {}
-
-  open(opts: ConnectionOptions): this {
-    if (this.socket) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'trying to open a socket before closing existing socket'
-      )
-    }
-
-    this.socket = new WebSocket(opts.url, [this.protocolVsn])
-    this.socket.binaryType = 'arraybuffer'
-
-    this.socket.addEventListener('open', this.connectListener)
-
-    this.socket.addEventListener('error', this.errorListener)
-
-    return this
-  }
-
-  write(data: Data): this {
-    this.socket?.send(data)
-    return this
-  }
-
-  closeAndRemoveListeners(): this {
-    this.socket?.removeEventListener('error', this.errorListener)
-    if (this.messageListener)
-      this.socket?.removeEventListener('message', this.messageListener)
-    if (this.closeListener)
-      this.socket?.removeEventListener('close', this.closeListener)
-
-    this.socket?.close()
-
-    this.socket = undefined
-    return this
-  }
-
-  onMessage(cb: (data: Data) => void): void {
-    if (this.messageListener) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'socket does not support multiple message listeners'
-      )
-    }
-
-    this.messageListener = (event: MessageEvent<any>) => {
-      const buffer = new Uint8Array(event.data)
-      cb(buffer)
-    }
-    this.socket?.addEventListener('message', this.messageListener)
-  }
-
-  onError(cb: (error: SatelliteError) => void): void {
-    this.errorCallbacks.push(cb)
-  }
-
-  onClose(cb: () => void): void {
-    if (this.closeListener) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'socket does not support multiple close listeners'
-      )
-    }
-
-    this.closeListener = cb
-    this.socket?.addEventListener('close', this.closeListener)
-  }
-
-  onceConnect(cb: () => void): void {
-    this.connectCallbacks.push(cb)
-  }
-
-  onceError(cb: (error: SatelliteError) => void): void {
-    this.onceErrorCallbacks.push(cb)
-  }
-
-  removeErrorListener(cb: (error: SatelliteError) => void): void {
-    const idx = this.errorCallbacks.indexOf(cb)
-    if (idx >= 0) {
-      this.errorCallbacks.splice(idx, 1)
-    }
-
-    const idxOnce = this.onceErrorCallbacks.indexOf(cb)
-    if (idxOnce >= 0) {
-      this.onceErrorCallbacks.splice(idxOnce, 1)
-    }
+  makeSocket(opts: ConnectionOptions): WebSocket {
+    const ws = new WebSocket(opts.url, [this.protocolVsn])
+    ws.binaryType = 'arraybuffer'
+    return ws
   }
 }


### PR DESCRIPTION
This PR refactors the implementation of the sockets for the different drivers.
It unifies their implementations in a common `GenericWebSocket` class.
Concrete socket implementations need to extend this class and implement the `makeSocket(opts: ConnectionOptions): WebSocket` method.