### PR TITLE
chore(client): Make the `sqliteDistPath ` argument to `ElectricDatabase.init` optional, enabling wasm bundling

### DIFF
--- a/.changeset/nasty-rockets-lick.md
+++ b/.changeset/nasty-rockets-lick.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Make the `locateSqliteDist` argument `ElectricDatabase.init` optional, this allows bundlers to find and bundle the wa-sqlite wasm file.

--- a/clients/typescript/src/drivers/wa-sqlite/database.ts
+++ b/clients/typescript/src/drivers/wa-sqlite/database.ts
@@ -83,13 +83,19 @@ export class ElectricDatabase {
   }
 
   // Creates and opens a DB backed by an IndexedDB filesystem
-  static async init(dbName: string, sqliteDistPath: string) {
+  static async init(
+    dbName: string,
+    locateSqliteDist?: string | ((path: string) => string)
+  ) {
     // Initialize SQLite
-    const SQLiteAsyncModule = await SQLiteAsyncESMFactory({
-      locateFile: (path: string) => {
-        return sqliteDistPath + path
-      },
-    })
+    const locateFile =
+      typeof locateSqliteDist === 'string'
+        ? (path: string) => {
+            return locateSqliteDist + path
+          }
+        : locateSqliteDist
+
+    const SQLiteAsyncModule = await SQLiteAsyncESMFactory({ locateFile })
 
     // Build API objects for the module
     const sqlite3 = SQLite.Factory(SQLiteAsyncModule)


### PR DESCRIPTION
Currently `ElectricDatabase.init` requires a second argument that is the path to the directory where the wa-sqlite wasm file is located. This makes it impossible to have a bundler automatically find and include the wasm in your built apps bundle with a cache busting filename.

Internally wa-sqlite uses the `new URL('wa-sqlite-async.wasm', import.meta.url)` pattern described here https://vitejs.dev/guide/assets#new-url-url-import-meta-url that is supported by (all?) bundlers. This is the default if you do not pass a `locateFile` function to `SQLiteAsyncESMFactory`.

This PR makes our second argument optional allowing the default behaviour of wa-sqlite. Additionally, it allows parsing a function - rather than a string - to the second argument, which is passed through to wa-sqlite.

This removes the need to copy the wasm file to the apps public dir - see #786

Fixes VAX-1050