### PR TITLE
feature(client) Modify client notifier to emit info about changed rows

### DIFF
--- a/.changeset/polite-insects-chew.md
+++ b/.changeset/polite-insects-chew.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Add row primary key infomation to the ActuallyChanged notification.

--- a/clients/typescript/src/notifiers/event.ts
+++ b/clients/typescript/src/notifiers/event.ts
@@ -11,6 +11,7 @@ import {
   Change,
   ChangeCallback,
   ChangeNotification,
+  ChangeOrigin,
   ConnectivityStateChangeCallback,
   ConnectivityStateChangeNotification,
   Notification,
@@ -117,13 +118,17 @@ export class EventNotifier implements Notifier {
 
     dbNames.forEach(emitPotentialChange)
   }
-  actuallyChanged(dbName: DbName, changes: Change[]): void {
+  actuallyChanged(
+    dbName: DbName,
+    changes: Change[],
+    origin: ChangeOrigin
+  ): void {
     Log.info('actually changed notifier')
     if (!this._hasDbName(dbName)) {
       return
     }
 
-    this._emitActualChange(dbName, changes)
+    this._emitActualChange(dbName, changes, origin)
   }
 
   subscribeToPotentialDataChanges(
@@ -219,8 +224,13 @@ export class EventNotifier implements Notifier {
 
     return notification
   }
-  _emitActualChange(dbName: DbName, changes: Change[]): ChangeNotification {
+  _emitActualChange(
+    dbName: DbName,
+    changes: Change[],
+    origin: ChangeOrigin
+  ): ChangeNotification {
     const notification = {
+      origin: origin,
       dbName: dbName,
       changes: changes,
     }

--- a/clients/typescript/src/notifiers/event.ts
+++ b/clients/typescript/src/notifiers/event.ts
@@ -230,9 +230,9 @@ export class EventNotifier implements Notifier {
     origin: ChangeOrigin
   ): ChangeNotification {
     const notification = {
-      origin: origin,
       dbName: dbName,
       changes: changes,
+      origin: origin,
     }
 
     this._emit(EVENT_NAMES.actualDataChange, notification)

--- a/clients/typescript/src/notifiers/index.ts
+++ b/clients/typescript/src/notifiers/index.ts
@@ -18,8 +18,6 @@ export interface AuthStateNotification {
 export type RecordChange = {
   primaryKey: Record
   type: `${DataChangeType}` | 'INITIAL'
-  record?: Record
-  oldRecord?: Record
 }
 export interface Change {
   qualifiedTablename: QualifiedTablename

--- a/clients/typescript/src/notifiers/index.ts
+++ b/clients/typescript/src/notifiers/index.ts
@@ -26,9 +26,9 @@ export interface Change {
 }
 export type ChangeOrigin = 'local' | 'remote' | 'initial'
 export interface ChangeNotification {
-  origin: ChangeOrigin
   dbName: DbName
   changes: Change[]
+  origin: ChangeOrigin
 }
 export interface PotentialChangeNotification {
   dbName: DbName

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -598,7 +598,6 @@ export class SatelliteProcess implements Satellite {
                 })
               ),
               type: 'INITIAL',
-              record: change.record,
             }
           }),
         })
@@ -1098,7 +1097,6 @@ export class SatelliteProcess implements Satellite {
         change.recordChanges.push({
           primaryKey: JSON.parse(entry.primaryKey),
           type: entry.optype,
-          record: entry.newRow ? JSON.parse(entry.newRow) : undefined,
         })
       } else {
         acc[key] = {
@@ -1108,7 +1106,6 @@ export class SatelliteProcess implements Satellite {
             {
               primaryKey: JSON.parse(entry.primaryKey),
               type: entry.optype,
-              record: entry.newRow ? JSON.parse(entry.newRow) : undefined,
             },
           ],
         }

--- a/clients/typescript/test/frameworks/react.test.tsx
+++ b/clients/typescript/test/frameworks/react.test.tsx
@@ -174,7 +174,7 @@ test('useLiveQuery re-runs query when data changes', async (t) => {
     const qtn = new QualifiedTablename('main', 'bars')
     const changes = [{ qualifiedTablename: qtn }]
 
-    notifier.actuallyChanged('test.db', changes)
+    notifier.actuallyChanged('test.db', changes, 'local')
   })
 
   await waitFor(() => assert(result.current.updatedAt! > updatedAt!), {
@@ -208,7 +208,7 @@ test('useLiveQuery re-runs query when *aliased* data changes', async (t) => {
     const qtn = new QualifiedTablename('main', 'bars')
     const changes = [{ qualifiedTablename: qtn }]
 
-    notifier.actuallyChanged('baz.db', changes)
+    notifier.actuallyChanged('baz.db', changes, 'local')
   })
 
   await waitFor(() => assert(result.current.updatedAt! > updatedAt!), {
@@ -266,7 +266,7 @@ test('useLiveQuery unsubscribes to data changes when unmounted', async (t) => {
     const qtn = new QualifiedTablename('main', 'bars')
     const changes = [{ qualifiedTablename: qtn }]
 
-    notifier.actuallyChanged('test.db', changes)
+    notifier.actuallyChanged('test.db', changes, 'local')
   })
 
   await sleepAsync(1000)
@@ -308,7 +308,7 @@ test('useLiveQuery ignores results if unmounted whilst re-querying', async (t) =
     const qtn = new QualifiedTablename('main', 'bars')
     const changes = [{ qualifiedTablename: qtn }]
 
-    notifier.actuallyChanged('test.db', changes)
+    notifier.actuallyChanged('test.db', changes, 'local')
     unmount()
   })
 

--- a/clients/typescript/test/frameworks/vuejs.test.ts
+++ b/clients/typescript/test/frameworks/vuejs.test.ts
@@ -136,9 +136,11 @@ test('useLiveQuery re-runs query when data changes', async (t) => {
 
   // trigger notifier
   adapter.query = async () => [{ count: 3 }]
-  notifier.actuallyChanged('test.db', [
-    { qualifiedTablename: new QualifiedTablename('main', 'bars') },
-  ])
+  notifier.actuallyChanged(
+    'test.db',
+    [{ qualifiedTablename: new QualifiedTablename('main', 'bars') }],
+    'local'
+  )
 
   await flushPromises()
 
@@ -200,7 +202,7 @@ test('useLiveQuery unsubscribes to data changes when unmounted', async (t) => {
   adapter.query = async () => [{ count: 3 }]
   const qtn = new QualifiedTablename('main', 'bars')
   const changes = [{ qualifiedTablename: qtn }]
-  notifier.actuallyChanged('test.db', changes)
+  notifier.actuallyChanged('test.db', changes, 'local')
 
   // no updates triggered
   await flushPromises()
@@ -239,7 +241,7 @@ test('useLiveQuery ignores results if unmounted whilst re-querying', async (t) =
   adapter.query = async () => [{ count: 3 }]
   const qtn = new QualifiedTablename('main', 'bars')
   const changes = [{ qualifiedTablename: qtn }]
-  notifier.actuallyChanged('test.db', changes)
+  notifier.actuallyChanged('test.db', changes, 'local')
   await wrapper.unmount()
 
   // no updates triggered

--- a/clients/typescript/test/notifiers/event.test.ts
+++ b/clients/typescript/test/notifiers/event.test.ts
@@ -55,7 +55,7 @@ test('subscribe to actual data changes', async (t) => {
 
   const qualifiedTablename = new QualifiedTablename('main', 'Items')
 
-  source.actuallyChanged('test.db', [{ qualifiedTablename }])
+  source.actuallyChanged('test.db', [{ qualifiedTablename }], 'local')
 
   t.is(notifications.length, 1)
 })
@@ -77,21 +77,21 @@ test('actual data change subscriptions are scoped by dbName', async (t) => {
   const qualifiedTablename = new QualifiedTablename('main', 'Items')
   const changes = [{ qualifiedTablename }]
 
-  source.actuallyChanged('foo.db', changes)
+  source.actuallyChanged('foo.db', changes, 'local')
   t.is(notifications.length, 1)
 
-  source.actuallyChanged('lala.db', changes)
+  source.actuallyChanged('lala.db', changes, 'local')
   t.is(notifications.length, 1)
 
-  source.actuallyChanged('bar.db', changes)
+  source.actuallyChanged('bar.db', changes, 'local')
   t.is(notifications.length, 1)
 
   source.attach('bar.db', 'bar.db')
-  source.actuallyChanged('bar.db', changes)
+  source.actuallyChanged('bar.db', changes, 'local')
   t.is(notifications.length, 2)
 
   t2.attach('foo.db', 'foo.db')
-  source.actuallyChanged('foo.db', changes)
+  source.actuallyChanged('foo.db', changes, 'local')
   t.is(notifications.length, 4)
 })
 

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -175,6 +175,10 @@ test('snapshot works', async (t) => {
   const expectedChange = {
     qualifiedTablename: new QualifiedTablename('main', 'parent'),
     rowids: [1, 2],
+    recordChanges: [
+      { primaryKey: { id: 1 }, type: 'INSERT' },
+      { primaryKey: { id: 2 }, type: 'INSERT' },
+    ],
   }
 
   t.deepEqual(changes, [expectedChange])
@@ -1407,6 +1411,12 @@ test('apply shape data and persist subscription', async (t) => {
   t.is(notifier.notifications[1].changes.length, 1)
   t.deepEqual(notifier.notifications[1].changes[0], {
     qualifiedTablename: qualified,
+    recordChanges: [
+      {
+        primaryKey: { id: 1 },
+        type: 'INITIAL',
+      },
+    ],
     rowids: [],
   })
 

--- a/clients/typescript/test/util/subscribe.test.ts
+++ b/clients/typescript/test/util/subscribe.test.ts
@@ -60,9 +60,11 @@ test('should yield subsequent updates as notifier signals changes', async (t) =>
   const updates: LiveResultUpdate<string>[] = []
   subscribe((u) => updates.push(u))
   await wait()
-  t.context.notifier.actuallyChanged(mockDbName, [
-    { qualifiedTablename: mockTablename },
-  ])
+  t.context.notifier.actuallyChanged(
+    mockDbName,
+    [{ qualifiedTablename: mockTablename }],
+    'local'
+  )
   await wait()
   t.is(updates[1].results, 'foo')
   t.is(updates.length, 2)
@@ -80,9 +82,11 @@ test('should NOT yield subsequent updates if change is to irrelevant table', asy
   subscribe((u) => updates.push(u))
   await wait()
 
-  t.context.notifier.actuallyChanged(mockDbName, [
-    { qualifiedTablename: mockTablenameAlt },
-  ])
+  t.context.notifier.actuallyChanged(
+    mockDbName,
+    [{ qualifiedTablename: mockTablenameAlt }],
+    'local'
+  )
   await wait()
   t.is(updates.length, 1)
   t.is(getNumCalls(), 1)
@@ -100,9 +104,11 @@ test('should NOT yield subsequent updates after unsubscribing', async (t) => {
   await wait()
 
   unsubscribe()
-  t.context.notifier.actuallyChanged(mockDbName, [
-    { qualifiedTablename: mockTablename },
-  ])
+  t.context.notifier.actuallyChanged(
+    mockDbName,
+    [{ qualifiedTablename: mockTablename }],
+    'local'
+  )
   await wait()
   t.is(updates.length, 1)
   t.is(getNumCalls(), 1)
@@ -143,9 +149,11 @@ test('should populate relevant tablename from result if not provided', async (t)
   await wait()
 
   // if tablename is populated, update to relevant table should trigger result
-  t.context.notifier.actuallyChanged(mockDbName, [
-    { qualifiedTablename: mockTablename },
-  ])
+  t.context.notifier.actuallyChanged(
+    mockDbName,
+    [{ qualifiedTablename: mockTablename }],
+    'local'
+  )
   await wait()
   t.is(updates[1].results, 'foo')
   t.is(updates.length, 2)
@@ -191,17 +199,21 @@ test('should return error in subsequent updates but not interrupt', async (t) =>
   t.is(updates[0].results, 'foo')
   t.is(updates[0].error, undefined)
 
-  t.context.notifier.actuallyChanged(mockDbName, [
-    { qualifiedTablename: mockTablename },
-  ])
+  t.context.notifier.actuallyChanged(
+    mockDbName,
+    [{ qualifiedTablename: mockTablename }],
+    'local'
+  )
   await wait()
   t.is(updates.length, 2)
   t.is(updates[1].results, undefined)
   t.deepEqual(updates[1].error, new Error('test'))
 
-  t.context.notifier.actuallyChanged(mockDbName, [
-    { qualifiedTablename: mockTablename },
-  ])
+  t.context.notifier.actuallyChanged(
+    mockDbName,
+    [{ qualifiedTablename: mockTablename }],
+    'local'
+  )
   await wait()
 
   t.is(updates.length, 3)


### PR DESCRIPTION
Currently the event from `subscribeToDataChanges` only lists the table that has changed, along with the `rowid`s for oplog entries for local changes. This isn't sufficient to watch for a change of a specific row, and requires a full re-query in most cases.

This modifies the notifier to emit info about each row that has changes, along with where the change originated - local, remote, or "initial" for first sync of a shape.

@balegas could you take a look and see if this is a sensible way of doing this?

It is emiting the `record` and `type` ("inset", "update"...) for each row that's change, and I've also extracted the PK(s) for the row changed which makes it easy to then lookup the row.

Once we move to a multi tab/window/process model this could result in large amounts of data being pushed over the broadcast channel. We probably want to add an optional "filter" to `subscribeToDataChanges` so you can do something like:

```ts
notifier.subscribeToDataChanges((changes) => {
  // Do something
}, {
  tables: ['table1', 'table2']
  filter: {
    id: '123123'  
  }
})
```

(I'm using this in the Linearlite+Yjs PR #788)