### PR TITLE
fix(e2e): Fix flaky prisma E2E that times out every few runs

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,8 +1,15 @@
 # Integration tests
 
 Tests dependencies:
-- lux tool
-- docker compose
+- [Lux (LUcid eXpect scripting) ](https://github.com/hawk/lux/blob/master/INSTALL.md)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+
+You will also need an Electric Docker image, specified by the environment variables ```ELECTRIC_IMAGE_NAME``` and ```ELECTRIC_IMAGE_TAG```, which defaults to the image ```electric:local-build``` that can be built using:
+```sh
+cd ../components/electric
+make docker-build
+```
 
 ## How to add new test
 
@@ -11,23 +18,28 @@ Add a new `.lux` file in the `tests/` directory. The files are number-prefixed, 
 2. to group them by purpose.
 
 Current groups are:
-- `1.*` - Sanity checks, startup, and electric-PG interaction
-- `2.*` - Replication verification between PG and Satellites, without actual clients
-- `3.*` - Replication using an actual typescript client in Node
-- `4.*` - Auxillary Electric functions not immediately related to replication
-- `5.*` - Conflict resolution semantics tests
-- `6.*` - Permissions and write validations
+- `01.*` - Sanity checks, startup, and electric-PG interaction
+- `02.*` - Replication verification between PG and Satellites, without actual clients
+- `03.*` - Replication using an actual typescript client in Node
+- `04.*` - Auxillary Electric functions not immediately related to replication
+- `05.*` - Conflict resolution semantics tests
+- `06.*` - Permissions and write validations
 
 Feel free to add more.
 
 ## Common ways to run tests
 
-To run all tests in integration_tests directory
+Build test dependencies at least once to ensure every test can be run
+```sh
+make deps
+```
+
+To build dependencies and run all tests in integration_tests directory
 ```sh
 make test
 ```
 
-If you don't want to rebuild the dependencies, you can run
+If you don't want to rebuild the dependencies before testing, you can run
 ```sh
 make test_only
 ```
@@ -35,11 +47,11 @@ make test_only
 In order to run single test in one of the integration tests directories, run:
 
 ```sh
-TEST=tests/1.1_simple_startup.lux make single_test
+TEST=tests/01.01_simple_startup.lux make single_test
 ```
 
 In order to run a [LUX debugger](https://github.com/hawk/lux/blob/master/doc/lux.md#debug_cmds) for that single test, run: 
 
 ```sh
-TEST=tests/1.1_simple_startup.lux make single_test_debug
+TEST=tests/01.01_simple_startup.lux make single_test_debug
 ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -5,7 +5,7 @@ Tests dependencies:
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
 
-You will also need an Electric Docker image, specified by the environment variables ```ELECTRIC_IMAGE_NAME``` and ```ELECTRIC_IMAGE_TAG```, which defaults to the image ```electric:local-build``` that can be built using:
+You will also need an Electric Docker image, specified by the environment variables `ELECTRIC_IMAGE_NAME` and `ELECTRIC_IMAGE_TAG`, which defaults to the image `electric:local-build` that can be built using:
 ```sh
 cd ../components/electric
 make docker-build

--- a/e2e/common.mk
+++ b/e2e/common.mk
@@ -3,7 +3,7 @@ export PROJECT_ROOT=$(shell git rev-parse --show-toplevel)
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 export E2E_ROOT := $(dir $(mkfile_path))
 
-LUX=${E2E_ROOT}/lux/bin/lux
+LUX=${E2E_ROOT}lux/bin/lux
 DOCKER_REGISTRY  = europe-docker.pkg.dev/vaxine/vaxine-io
 DOCKER_REGISTRY2 = europe-docker.pkg.dev/vaxine/ci
 export BUILDER_IMAGE=${DOCKER_REGISTRY2}/electric-builder:latest

--- a/e2e/tests/04.02_prisma_introspection_generates_correct_schema.lux
+++ b/e2e/tests/04.02_prisma_introspection_generates_correct_schema.lux
@@ -8,7 +8,7 @@
     ?SH-PROMPT:
     !cp ../prisma_example/schema.prisma ../prisma_example/prisma/
     ?SH-PROMPT:
-    [timeout 10]
+    [timeout 20]
     !make docker-prisma ARGS='prisma_example_1 prisma db pull'
     ?The introspected database was empty
     ?SH-PROMPT:


### PR DESCRIPTION
I noticed that both locally on a fresh run and on CI, the ```04.02_prisma_introspection_generates_correct_schema.lux``` test was occasionally either throwing a warning about the timeout being close to max or timing out.

It seems to be the only test flaking consistently so I figured it makes sense to increase the timeout slightly to make the e2e results more reliable.

I've also updated the README with some info I needed as I set it up to run the e2e locally.