### PR TITLE
feat(client): Add new names for safe and unsafe raw APIs and deprecate old ones

### DIFF
--- a/.changeset/silent-pillows-jog.md
+++ b/.changeset/silent-pillows-jog.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Added new names for raw query APIs (`rawQuery`, `liveRawQuery`, and `unsafeExec`) and deprecated old ones (`raw` and `liveRaw`)

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -65,7 +65,7 @@ interface RawQueries {
    * @deprecated
    * For safe, read-only SQL queries, use the `rawQuery` API
    * For unsafe, store-modifying queries, use the `unsafeExec` API
-   * 
+   *
    * Executes a raw SQL query.
    * @param sql - A raw SQL query and its bind parameters.
    * @returns The rows that result from the query.
@@ -75,7 +75,7 @@ interface RawQueries {
   /**
    * @deprecated
    * Use `liveRawQuery` instead for reactive read-only SQL queries.
-   * 
+   *
    * A read-only raw SQL query that can be used with {@link useLiveQuery}.
    * Same as {@link RawQueries#raw} but wraps the result in a {@link LiveResult} object.
    * @param sql - A raw SQL query and its bind parameters.

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -1,6 +1,6 @@
 import { ElectricNamespace } from '../../electric/namespace'
 import { DbSchema, TableSchema } from './schema'
-import { unsafeExec, Table, rawQuery, liveRawQuery } from './table'
+import { rawQuery, liveRawQuery, unsafeExec, Table } from './table'
 import { Row, Statement } from '../../util'
 import { LiveResult, LiveResultContext } from './model'
 import { Notifier } from '../../notifiers'

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -1,6 +1,6 @@
 import { ElectricNamespace } from '../../electric/namespace'
 import { DbSchema, TableSchema } from './schema'
-import { liveRaw, raw, unsafeExec, Table } from './table'
+import { unsafeExec, Table, query, liveQuery } from './table'
 import { Row, Statement } from '../../util'
 import { LiveResult, LiveResultContext } from './model'
 import { Notifier } from '../../notifiers'
@@ -46,13 +46,36 @@ interface RawQueries {
    * @returns The rows that result from the query.
    */
   unsafeExec(sql: Statement): Promise<Row[]>
+
   /**
    * Executes a read-only raw SQL query.
    * @param sql - A raw SQL query and its bind parameters.
    * @returns The rows that result from the query.
    */
-  raw(sql: Statement): Promise<Row[]>
+  query(sql: Statement): Promise<Row[]>
+
   /**
+   * A read-only raw SQL query that can be used with {@link useLiveQuery}.
+   * Same as {@link RawQueries#raw} but wraps the result in a {@link LiveResult} object.
+   * @param sql - A raw SQL query and its bind parameters.
+   */
+  liveQuery(sql: Statement): LiveResultContext<any>
+
+  /**
+   * @deprecated
+   * For safe, read-only SQL queries, use the `query` API
+   * For unsafe, store-modifying queries, use the `unsafeExec` API
+   * 
+   * Executes a raw SQL query.
+   * @param sql - A raw SQL query and its bind parameters.
+   * @returns The rows that result from the query.
+   */
+  raw(sql: Statement): Promise<Row[]>
+
+  /**
+   * @deprecated
+   * Use `liveQuery` instead for reactive read-only SQL queries.
+   * 
    * A read-only raw SQL query that can be used with {@link useLiveQuery}.
    * Same as {@link RawQueries#raw} but wraps the result in a {@link LiveResult} object.
    * @param sql - A raw SQL query and its bind parameters.
@@ -117,8 +140,10 @@ export class ElectricClient<
     const db: ClientTables<DB> & RawQueries = {
       ...dal,
       unsafeExec: unsafeExec.bind(null, adapter),
-      raw: raw.bind(null, adapter),
-      liveRaw: liveRaw.bind(null, adapter),
+      query: query.bind(null, adapter),
+      liveQuery: liveQuery.bind(null, adapter),
+      raw: unsafeExec.bind(null, adapter),
+      liveRaw: liveQuery.bind(null, adapter),
     }
 
     return new ElectricClient(

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -1,6 +1,6 @@
 import { ElectricNamespace } from '../../electric/namespace'
 import { DbSchema, TableSchema } from './schema'
-import { unsafeExec, Table, query, liveQuery } from './table'
+import { unsafeExec, Table, rawQuery, liveRawQuery } from './table'
 import { Row, Statement } from '../../util'
 import { LiveResult, LiveResultContext } from './model'
 import { Notifier } from '../../notifiers'
@@ -52,18 +52,18 @@ interface RawQueries {
    * @param sql - A raw SQL query and its bind parameters.
    * @returns The rows that result from the query.
    */
-  query(sql: Statement): Promise<Row[]>
+  rawQuery(sql: Statement): Promise<Row[]>
 
   /**
    * A read-only raw SQL query that can be used with {@link useLiveQuery}.
    * Same as {@link RawQueries#raw} but wraps the result in a {@link LiveResult} object.
    * @param sql - A raw SQL query and its bind parameters.
    */
-  liveQuery(sql: Statement): LiveResultContext<any>
+  liveRawQuery(sql: Statement): LiveResultContext<any>
 
   /**
    * @deprecated
-   * For safe, read-only SQL queries, use the `query` API
+   * For safe, read-only SQL queries, use the `rawQuery` API
    * For unsafe, store-modifying queries, use the `unsafeExec` API
    * 
    * Executes a raw SQL query.
@@ -74,7 +74,7 @@ interface RawQueries {
 
   /**
    * @deprecated
-   * Use `liveQuery` instead for reactive read-only SQL queries.
+   * Use `liveRawQuery` instead for reactive read-only SQL queries.
    * 
    * A read-only raw SQL query that can be used with {@link useLiveQuery}.
    * Same as {@link RawQueries#raw} but wraps the result in a {@link LiveResult} object.
@@ -140,10 +140,10 @@ export class ElectricClient<
     const db: ClientTables<DB> & RawQueries = {
       ...dal,
       unsafeExec: unsafeExec.bind(null, adapter),
-      query: query.bind(null, adapter),
-      liveQuery: liveQuery.bind(null, adapter),
+      rawQuery: rawQuery.bind(null, adapter),
+      liveRawQuery: liveRawQuery.bind(null, adapter),
       raw: unsafeExec.bind(null, adapter),
-      liveRaw: liveQuery.bind(null, adapter),
+      liveRaw: liveRawQuery.bind(null, adapter),
     }
 
     return new ElectricClient(

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -1553,7 +1553,10 @@ export function unsafeExec(
   return adapter.query(sql)
 }
 
-export function rawQuery(adapter: DatabaseAdapter, sql: Statement): Promise<Row[]> {
+export function rawQuery(
+  adapter: DatabaseAdapter,
+  sql: Statement
+): Promise<Row[]> {
   // only allow safe queries from the client
   if (isPotentiallyDangerous(sql.sql)) {
     throw new InvalidArgumentError(

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -1553,7 +1553,7 @@ export function unsafeExec(
   return adapter.query(sql)
 }
 
-export function raw(adapter: DatabaseAdapter, sql: Statement): Promise<Row[]> {
+export function query(adapter: DatabaseAdapter, sql: Statement): Promise<Row[]> {
   // only allow safe queries from the client
   if (isPotentiallyDangerous(sql.sql)) {
     throw new InvalidArgumentError(
@@ -1565,7 +1565,7 @@ export function raw(adapter: DatabaseAdapter, sql: Statement): Promise<Row[]> {
   return unsafeExec(adapter, sql)
 }
 
-export function liveRaw(
+export function liveQuery(
   adapter: DatabaseAdapter,
   sql: Statement
 ): LiveResultContext<Row[]> {
@@ -1574,7 +1574,7 @@ export function liveRaw(
     // because this is a raw query so
     // we cannot trust that it queries this table
     const tablenames = parseTableNames(sql.sql)
-    const res = await raw(adapter, sql)
+    const res = await query(adapter, sql)
     return new LiveResult(res, tablenames)
   })
   result.sourceQuery = sql

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -1553,7 +1553,7 @@ export function unsafeExec(
   return adapter.query(sql)
 }
 
-export function query(adapter: DatabaseAdapter, sql: Statement): Promise<Row[]> {
+export function rawQuery(adapter: DatabaseAdapter, sql: Statement): Promise<Row[]> {
   // only allow safe queries from the client
   if (isPotentiallyDangerous(sql.sql)) {
     throw new InvalidArgumentError(
@@ -1565,7 +1565,7 @@ export function query(adapter: DatabaseAdapter, sql: Statement): Promise<Row[]> 
   return unsafeExec(adapter, sql)
 }
 
-export function liveQuery(
+export function liveRawQuery(
   adapter: DatabaseAdapter,
   sql: Statement
 ): LiveResultContext<Row[]> {
@@ -1574,7 +1574,7 @@ export function liveQuery(
     // because this is a raw query so
     // we cannot trust that it queries this table
     const tablenames = parseTableNames(sql.sql)
-    const res = await query(adapter, sql)
+    const res = await rawQuery(adapter, sql)
     return new LiveResult(res, tablenames)
   })
   result.sourceQuery = sql

--- a/clients/typescript/test/client/conversions/sqlite.test.ts
+++ b/clients/typescript/test/client/conversions/sqlite.test.ts
@@ -53,7 +53,7 @@ test.serial('date is converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes = await electric.db.raw({
+  const rawRes = await electric.db.rawQuery({
     sql: 'SELECT date FROM DataTypes WHERE id = ?',
     args: [1],
   })
@@ -71,7 +71,7 @@ test.serial('time is converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes = await electric.db.raw({
+  const rawRes = await electric.db.rawQuery({
     sql: 'SELECT time FROM DataTypes WHERE id = ?',
     args: [1],
   })
@@ -95,13 +95,13 @@ test.serial('timetz is converted correctly to SQLite', async (t) => {
     ],
   })
 
-  const rawRes1 = await electric.db.raw({
+  const rawRes1 = await electric.db.rawQuery({
     sql: 'SELECT timetz FROM DataTypes WHERE id = ?',
     args: [1],
   })
   t.is(rawRes1[0].timetz, '16:28:35.421') // time must have been converted to UTC time
 
-  const rawRes2 = await electric.db.raw({
+  const rawRes2 = await electric.db.rawQuery({
     sql: 'SELECT timetz FROM DataTypes WHERE id = ?',
     args: [2],
   })
@@ -117,7 +117,7 @@ test.serial('timestamp is converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes = await electric.db.raw({
+  const rawRes = await electric.db.rawQuery({
     sql: 'SELECT timestamp FROM DataTypes WHERE id = ?',
     args: [1],
   })
@@ -140,13 +140,13 @@ test.serial('timestamptz is converted correctly to SQLite', async (t) => {
     ],
   })
 
-  const rawRes1 = await electric.db.raw({
+  const rawRes1 = await electric.db.rawQuery({
     sql: 'SELECT timestamptz FROM DataTypes WHERE id = ?',
     args: [1],
   })
   t.is(rawRes1[0].timestamptz, '2023-08-07 16:28:35.421Z') // timestamp must have been converted to UTC timestamp
 
-  const rawRes2 = await electric.db.raw({
+  const rawRes2 = await electric.db.rawQuery({
     sql: 'SELECT timestamptz FROM DataTypes WHERE id = ?',
     args: [2],
   })
@@ -167,7 +167,7 @@ test.serial('booleans are converted correctly to SQLite', async (t) => {
     ],
   })
 
-  const rawRes = await electric.db.raw({
+  const rawRes = await electric.db.rawQuery({
     sql: 'SELECT id, bool FROM DataTypes ORDER BY id ASC',
     args: [],
   })
@@ -204,7 +204,7 @@ test.serial('floats are converted correctly to SQLite', async (t) => {
     ],
   })
 
-  const rawRes = await electric.db.raw({
+  const rawRes = await electric.db.rawQuery({
     sql: 'SELECT id, float4, float8 FROM DataTypes ORDER BY id ASC',
     args: [],
   })
@@ -233,7 +233,7 @@ test.serial('BigInts are converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes = await electric.db.raw({
+  const rawRes = await electric.db.rawQuery({
     sql: 'SELECT id, cast(int8 as TEXT) AS int8 FROM DataTypes WHERE id = ?',
     args: [1],
   })
@@ -253,7 +253,7 @@ test.serial('json is converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes = await electric.db.raw({
+  const rawRes = await electric.db.rawQuery({
     sql: 'SELECT json FROM DataTypes WHERE id = ?',
     args: [1],
   })
@@ -269,7 +269,7 @@ test.serial('json is converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes2 = await electric.db.raw({
+  const rawRes2 = await electric.db.rawQuery({
     sql: 'SELECT json FROM DataTypes WHERE id = ?',
     args: [2],
   })
@@ -283,7 +283,7 @@ test.serial('json is converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes3 = await electric.db.raw({
+  const rawRes3 = await electric.db.rawQuery({
     sql: 'SELECT json FROM DataTypes WHERE id = ?',
     args: [3],
   })
@@ -297,7 +297,7 @@ test.serial('json is converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes4 = await electric.db.raw({
+  const rawRes4 = await electric.db.rawQuery({
     sql: 'SELECT json FROM DataTypes WHERE id = ?',
     args: [4],
   })
@@ -312,7 +312,7 @@ test.serial('json is converted correctly to SQLite', async (t) => {
     },
   })
 
-  const rawRes5 = await electric.db.raw({
+  const rawRes5 = await electric.db.rawQuery({
     sql: 'SELECT json FROM DataTypes WHERE id = ?',
     args: [5],
   })

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -1120,7 +1120,7 @@ test.serial(
 test('raw insert query throws error for unsupported unsafe queries', async (t) => {
   await t.throwsAsync(
     async () => {
-      await electric.db.raw({
+      await electric.db.rawQuery({
         sql: "INSERT INTO user (id, name) VALUES (1, 'John Doe')",
       })
     },
@@ -1135,7 +1135,7 @@ test('raw insert query throws error for unsupported unsafe queries', async (t) =
 test('raw update query throws error for unsupported unsafe queries', async (t) => {
   await t.throwsAsync(
     async () => {
-      await electric.db.raw({
+      await electric.db.rawQuery({
         sql: "UPDATE user SET name = 'New Name' WHERE id = 1;",
       })
     },
@@ -1150,7 +1150,7 @@ test('raw update query throws error for unsupported unsafe queries', async (t) =
 test('raw delete query throws error for unsupported unsafe queries', async (t) => {
   await t.throwsAsync(
     async () => {
-      await electric.db.raw({
+      await electric.db.rawQuery({
         sql: 'DELETE FROM user WHERE id = 1;',
       })
     },
@@ -1165,7 +1165,7 @@ test('raw delete query throws error for unsupported unsafe queries', async (t) =
 test('raw drop table query throws error for unsupported unsafe queries', async (t) => {
   await t.throwsAsync(
     async () => {
-      await electric.db.raw({
+      await electric.db.rawQuery({
         sql: 'DROP TABLE IF EXISTS User',
       })
     },
@@ -1180,7 +1180,7 @@ test('raw drop table query throws error for unsupported unsafe queries', async (
 test('raw create table query throws error for unsupported unsafe queries', async (t) => {
   await t.throwsAsync(
     async () => {
-      await electric.db.raw({
+      await electric.db.rawQuery({
         sql: "CREATE TABLE IF NOT EXISTS User('id' int PRIMARY KEY, 'name' varchar);",
       })
     },
@@ -1195,7 +1195,7 @@ test('raw create table query throws error for unsupported unsafe queries', async
 test('liveRaw insert query throws error for unsupported unsafe queries', async (t) => {
   await t.throwsAsync(
     async () => {
-      await electric.db.liveRaw({
+      await electric.db.liveRawQuery({
         sql: "INSERT INTO user (id, name) VALUES (1, 'John Doe')",
       })()
     },

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -357,7 +357,7 @@ test.serial('findUnique query', async (t) => {
 })
 
 test.serial('raw query', async (t) => {
-  const res = await electricDb.raw({
+  const res = await electricDb.rawQuery({
     sql: 'SELECT * FROM Post WHERE id = ?',
     args: [post2.id],
   })

--- a/clients/typescript/test/frameworks/react.test.tsx
+++ b/clients/typescript/test/frameworks/react.test.tsx
@@ -111,7 +111,7 @@ test('useLiveQuery returns query results', async (t) => {
   const { dal, adapter } = t.context
 
   const query = 'select i from bars'
-  const liveQuery = dal.db.liveRaw({
+  const liveQuery = dal.db.liveRawQuery({
     sql: query,
   })
 
@@ -146,7 +146,7 @@ test('useLiveQuery re-runs query when data changes', async (t) => {
   const { dal, notifier } = t.context
 
   const query = 'select foo from bars'
-  const liveQuery = dal.db.liveRaw({
+  const liveQuery = dal.db.liveRawQuery({
     sql: query,
   })
 
@@ -184,7 +184,7 @@ test('useLiveQuery re-runs query when *aliased* data changes', async (t) => {
   }
 
   const query = 'select foo from baz.bars'
-  const liveQuery = dal.db.liveRaw({
+  const liveQuery = dal.db.liveRawQuery({
     sql: query,
   })
 
@@ -212,7 +212,7 @@ test('useLiveQuery never sets results if unmounted immediately', async (t) => {
   const { dal } = t.context
 
   const query = 'select foo from bars'
-  const liveQuery = dal.db.liveRaw({
+  const liveQuery = dal.db.liveRawQuery({
     sql: query,
   })
 
@@ -233,7 +233,7 @@ test('useLiveQuery unsubscribes to data changes when unmounted', async (t) => {
   const { dal, notifier } = t.context
 
   const query = 'select foo from bars'
-  const liveQuery = dal.db.liveRaw({
+  const liveQuery = dal.db.liveRawQuery({
     sql: query,
   })
 
@@ -268,7 +268,7 @@ test('useLiveQuery ignores results if unmounted whilst re-querying', async (t) =
   const { dal, notifier } = t.context
 
   const query = 'select foo from bars'
-  const liveQuery = dal.db.liveRaw({
+  const liveQuery = dal.db.liveRawQuery({
     sql: query,
   })
   const slowLiveQuery = async () => {

--- a/clients/typescript/test/migrators/builder.test.ts
+++ b/clients/typescript/test/migrators/builder.test.ts
@@ -323,7 +323,7 @@ test('load migration from meta data', async (t) => {
   )
 
   // Check that the DB is initialized with the stars table
-  const tables = await electric.db.raw({
+  const tables = await electric.db.rawQuery({
     sql: `SELECT name FROM sqlite_master WHERE type='table' AND name='stars';`,
   })
 
@@ -331,7 +331,7 @@ test('load migration from meta data', async (t) => {
   t.assert(starIdx >= 0) // must exist
 
   const columns = await electric.db
-    .raw({
+    .rawQuery({
       sql: `PRAGMA table_info(stars);`,
     })
     .then((columns) => columns.map((column) => column.name))

--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -132,8 +132,9 @@ export type ClientTables<DB> = {
 }
 
 interface RawQueries {
-  raw(sql: Statement): Promise<Row[]>
-  liveRaw(sql: Statement): LiveResultContext<any>
+  rawQuery(sql: Statement): Promise<Row[]>
+  liveRawQuery(sql: Statement): LiveResultContext<any>
+  unsafeExec(sql: Statement): Promise<Row[]>
 }
 
 type Statement = {
@@ -145,8 +146,8 @@ type Statement = {
 
 The Electric client above defines a property for every table in our data model: `electric.db.users`, `electric.db.projects`, etc.
 The API of these tables is explained below when we discuss the [supported queries](#queries).
-In addition, one can execute raw SQL queries using the `electric.db.raw` and `electric.db.liveRaw` escape patches.
-Raw queries should be used with caution as they are unchecked and may cause the sync service to stop if they are ill-formed.
+In addition, one can execute raw read-only SQL queries using the `electric.db.rawQuery` and `electric.db.liveRawQuery` escape patches.
+It is also possible to execute raw queries that can modify the store using `electric.db.unsafeExec`, but it should be used with caution as the changes are unchecked and may cause the sync service to stop if they are ill-formed.
 Therefore, only use raw queries for features that are not supported by our regular API.
 
 ## Configuration

--- a/docs/integrations/drivers/other/generic.md
+++ b/docs/integrations/drivers/other/generic.md
@@ -30,7 +30,7 @@ export interface DatabaseAdapter {
 
   // Get the tables potentially used by an SQL statement.
   // This supports reactivity for raw SQL use via the
-  // `db.liveRaw` function.
+  // `db.liveRawQuery` function.
   tableNames(statement: Statement): QualifiedTablename[]
 }
 ```

--- a/docs/integrations/frontend/react.md
+++ b/docs/integrations/frontend/react.md
@@ -100,7 +100,7 @@ const ExampleComponent = () => {
   const [ value, setValue ] = useState()
 
   const generate = async () => {
-    const { newValue } = await db.raw({
+    const { newValue } = await db.rawQuery({
       sql: 'select random() as newValue'
     })
 
@@ -140,7 +140,7 @@ const Component = () => {
 
   // Use the raw SQL API.
   const { results: countResults } = useLiveQuery(
-    db.liveRaw({
+    db.liveRawQuery({
       sql: 'select count(*) from items'
     })
   )

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -135,7 +135,7 @@ Either using the [Prisma-inspired client](../usage/data-access/queries.md) or if
 
 ```tsx
 const { results } = useLiveQuery(
-  db.liveRaw({
+  db.liveRawQuery({
     sql: 'SELECT * FROM items where foo = ?',
     args: ['bar']
   })

--- a/docs/usage/data-access/queries.md
+++ b/docs/usage/data-access/queries.md
@@ -237,7 +237,7 @@ If the higher-level client API doesn't support the SQL features that you need fo
 To run a static query (or just execute SQL):
 
 ```ts
-const projects = db.raw({
+const projects = db.rawQuery({
   sql: 'select * from projects where id = ?',
   bindParams: ['abcd']
 })
@@ -246,7 +246,7 @@ const projects = db.raw({
 To run a live query that supports arbitrary SQL whilst still working automatically with the reactivity machinery to pick up on live changes:
 
 ```ts
-const liveQuery = db.liveRaw({
+const liveQuery = db.liveRawQuery({
   sql: 'select * from projects where id = ?',
   bindParams: ['abcd']
 })
@@ -259,7 +259,7 @@ For example:
 const MyComponent = () => {
   const { db } = useElectric()!
   const { results } = useLiveQuery(
-    db.liveRaw({
+    db.liveRawQuery({
       sql: 'select * from projects where status = ?',
       bindParams: ['active']
     })

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -67,15 +67,15 @@ export const syncTable = async (electric: Electric, table: string) => {
 }
 
 export const get_tables = (electric: Electric) => {
-  return electric.db.raw({ sql: `SELECT name FROM sqlite_master WHERE type='table';` })
+  return electric.db.rawQuery({ sql: `SELECT name FROM sqlite_master WHERE type='table';` })
 }
 
 export const get_columns = (electric: Electric, table: string) => {
-  return electric.db.raw({ sql: `SELECT * FROM pragma_table_info(?);`, args: [table] })
+  return electric.db.rawQuery({ sql: `SELECT * FROM pragma_table_info(?);`, args: [table] })
 }
 
 export const get_rows = (electric: Electric, table: string) => {
-  return electric.db.raw({sql: `SELECT * FROM ${table};`})
+  return electric.db.rawQuery({sql: `SELECT * FROM ${table};`})
 }
 
 export const get_timestamps = (electric: Electric) => {
@@ -224,7 +224,7 @@ export const write_float = (electric: Electric, id: string, f4: number, f8: numb
 }
 
 export const get_json_raw = async (electric: Electric, id: string) => {
-  const res = await electric.db.raw({
+  const res = await electric.db.rawQuery({
     sql: `SELECT js FROM jsons WHERE id = ?;`,
     args: [id]
   }) as unknown as Array<{ js: string }>
@@ -232,7 +232,7 @@ export const get_json_raw = async (electric: Electric, id: string) => {
 }
 
 export const get_jsonb_raw = async (electric: Electric, id: string) => {
-  const res = await electric.db.raw({
+  const res = await electric.db.rawQuery({
     sql: `SELECT jsb FROM jsons WHERE id = ?;`,
     args: [id]
   }) as unknown as Array<{ jsb: string }>
@@ -276,7 +276,7 @@ export const write_json = async (electric: Electric, id: string, js: any, jsb: a
 }
 
 export const get_item_columns = (electric: Electric, table: string, column: string) => {
-  return electric.db.raw({ sql: `SELECT ${column} FROM ${table};` })
+  return electric.db.rawQuery({ sql: `SELECT ${column} FROM ${table};` })
 }
 
 export const insert_item = async (electric: Electric, keys: [string]) => {


### PR DESCRIPTION
Having split the raw APIs to read-only safe ones and an unsafe one, I've also renamed them:

- `raw` with read-only checks to `rawQuery`
- `liveRaw` to `liveRawQuery`
- `raw` without checks to `unsafeExec`

I've updated all relevant docs I could find as well.

Some exampels (beer-stars, introduction, and linearlite) will be using the old versions of the API as they have their electric-sql version fixed to 0.7.0, so when it's updated those PRs should take care of also fixing the deprecated APIs.