### PR TITLE
fix(e2e): increase base timeout multiplier on CI to reduce flakiness

### DIFF
--- a/e2e/common.mk
+++ b/e2e/common.mk
@@ -35,6 +35,14 @@ else
 	export ELECTRIC_CLIENT_IMAGE=${ELECTRIC_CLIENT_IMAGE_NAME}:${ELECTRIC_IMAGE_TAG}
 endif
 
+# Any timeouts in the tests, specified in seconds,
+# are multiplied by this to convert to milliseconds.
+# If in CI, double all timeouts to reduce flakiness
+TIMEOUT_MULTIPLIER = 1000
+ifeq ($(CI), true)
+    TIMEOUT_MULTIPLIER = 2000
+endif
+
 lux: ${LUX}
 
 ${LUX}:
@@ -123,7 +131,7 @@ docker-make:
 		make ${MK_TARGET}
 
 single_test:
-	${LUX} --progress doc ${TEST}
+	${LUX} --multiplier ${TIMEOUT_MULTIPLIER} --progress doc ${TEST}
 
 single_test_debug:
 	${LUX} --debug ${TEST}

--- a/e2e/common.mk
+++ b/e2e/common.mk
@@ -12,7 +12,8 @@ ifeq ($(CI), true)
     TIMEOUT_MULTIPLIER = 2000
 endif
 
-LUX=${E2E_ROOT}lux/bin/lux --multiplier ${TIMEOUT_MULTIPLIER}
+LUX_PATH=${E2E_ROOT}lux/bin/lux
+LUX=${LUX_PATH} --multiplier ${TIMEOUT_MULTIPLIER}
 
 DOCKER_REGISTRY  = europe-docker.pkg.dev/vaxine/vaxine-io
 DOCKER_REGISTRY2 = europe-docker.pkg.dev/vaxine/ci
@@ -46,7 +47,7 @@ else
 endif
 
 
-lux: ${LUX}
+lux: ${LUX_PATH}
 
 ${LUX}:
 	git clone https://github.com/hawk/lux.git

--- a/e2e/tests/04.02_prisma_introspection_generates_correct_schema.lux
+++ b/e2e/tests/04.02_prisma_introspection_generates_correct_schema.lux
@@ -8,7 +8,6 @@
     ?SH-PROMPT:
     !cp ../prisma_example/schema.prisma ../prisma_example/prisma/
     ?SH-PROMPT:
-    [timeout 20]
     !make docker-prisma ARGS='prisma_example_1 prisma db pull'
     ?The introspected database was empty
     ?SH-PROMPT:

--- a/e2e/tests/04.03_prisma_migration_version_captured.lux
+++ b/e2e/tests/04.03_prisma_migration_version_captured.lux
@@ -7,7 +7,6 @@
     # apply the baseline migration
     !make docker-prisma ARGS='--workdir /app/migrations-1 prisma_example_1 prisma migrate resolve --applied 0_init'
     ?SH-PROMPT:
-    [timeout 10]
     !make docker-prisma ARGS='--workdir /app/migrations-1 prisma_example_1 prisma migrate deploy'
     ?SH-PROMPT:
 

--- a/e2e/tests/_satellite_macros.luxinc
+++ b/e2e/tests/_satellite_macros.luxinc
@@ -21,6 +21,7 @@
 [endmacro]
 
 [macro setup_client_with_migrations satellite_number electric port migrations]
+    [timeout 5]
     [invoke start_satellite $satellite_number]
     -$fail_pattern
     ??$node

--- a/e2e/tests/_satellite_macros.luxinc
+++ b/e2e/tests/_satellite_macros.luxinc
@@ -21,7 +21,6 @@
 [endmacro]
 
 [macro setup_client_with_migrations satellite_number electric port migrations]
-    [timeout 5]
     [invoke start_satellite $satellite_number]
     -$fail_pattern
     ??$node

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -14,10 +14,8 @@
     [newshell pg_1]
         [invoke start_psql pg_1 5432]
         -$fail_pattern
-        [timeout 2]
 
     [newshell electric]
-        [timeout 5]
         !make start_electric_1
         -$fail_pattern
         ??Successfully initialized Postgres connector "postgres_1"
@@ -34,7 +32,6 @@
     [newshell proxy_1]
         [invoke start_proxy pg_1 electric_1]
         -$fail_pattern
-        [timeout 2]
 
 [endmacro]
 


### PR DESCRIPTION
I've noticed the e2e running satellite is a bit flaky because the docker startup occasionally times out.

We have explicitly specified a larger timeout for most docker startup commands so this should be more consistent and reduce flakiness.

Example of flake logs for reference:
```
2024-01-08T09:28:00.4851831Z test case         : tests/03.01_node_satellite_loads_local_migrations.lux
2024-01-08T09:28:11.5151352Z progress          : (()..:...:.)()((...:...:..):...:.:.:.26????26)23C..:...:.(stop development environment..:.(.:.:.:.:.:.:.:.:.:.:.:.:...:.:...))
2024-01-08T09:28:11.5167772Z result            : FAIL at line 23:26 in shell satellite_1
2024-01-08T09:28:11.5168696Z expected=
2024-01-08T09:28:11.5169046Z 	>
2024-01-08T09:28:11.5177569Z actual match_timeout
2024-01-08T09:28:11.5178463Z 	make start_satellite_client_1
2024-01-08T09:28:11.5179705Z 	make[1]: Entering directory '/home/runner/work/electric/electric/e2e/tests'
2024-01-08T09:28:11.5180750Z 	docker compose -f compose.yaml run \
2024-01-08T09:28:11.5181374Z 		--rm \
2024-01-08T09:28:11.5182049Z 		-e TERM=dumb \
2024-01-08T09:28:11.5182551Z 		satellite_client_1
2024-01-08T09:28:11.5183101Z 	[1A[1B[0G[?25l[+] Creating 1/0
2024-01-08T09:28:11.5184022Z 	 [32m✔[0m Network tests_default  [32mCreated[0m[34m0.1s [0m
2024-01-08T09:28:11.5184832Z 	[?25h
```