### PR TITLE
chore(electric): Reject electrification of tables that have no PRIMARY KEY or have unsupported constraints

### DIFF
--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -318,7 +318,8 @@ defmodule Electric.Postgres.Extension do
       Migrations.Migration_20231009121515_AllowLargeMigrations,
       Migrations.Migration_20231010123118_AddPriorityToVersion,
       Migrations.Migration_20231016141000_ConvertFunctionToProcedure,
-      Migrations.Migration_20231206130400_ConvertReplicaTriggersToAlways
+      Migrations.Migration_20231206130400_ConvertReplicaTriggersToAlways,
+      Migrations.Migration_20240110110200_DropUnusedFunctions
     ]
   end
 

--- a/components/electric/lib/electric/postgres/extension/migrations/20240110110200_drop_unused_functions.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240110110200_drop_unused_functions.ex
@@ -1,0 +1,21 @@
+defmodule Electric.Postgres.Extension.Migrations.Migration_20240110110200_DropUnusedFunctions do
+  alias Electric.Postgres.Extension
+
+  @behaviour Extension.Migration
+
+  @impl true
+  def version, do: 2024_01_10_11_02_00
+
+  @impl true
+  def up(schema) do
+    [
+      "DROP ROUTINE IF EXISTS #{schema}.__validate_table_column_defaults(text)",
+      "DROP ROUTINE IF EXISTS #{schema}.__validate_table_column_types(text)"
+    ]
+  end
+
+  @impl true
+  def down(_schema) do
+    []
+  end
+end

--- a/components/electric/priv/sql_function_templates/__constraint_validation_enabled.sql.eex
+++ b/components/electric/priv/sql_function_templates/__constraint_validation_enabled.sql.eex
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION <%= schema() %>.__constraint_validation_enabled()
+RETURNS boolean
+SECURITY DEFINER
+AS $$
+DECLARE
+  _disable_validation boolean;
+BEGIN
+  SELECT current_setting('electric.disable_constraint_validation') INTO _disable_validation;
+  RETURN NOT coalesce(_disable_validation, false);
+EXCEPTION WHEN undefined_object THEN
+  RETURN true;
+END;
+$$ LANGUAGE PLPGSQL;

--- a/components/electric/priv/sql_function_templates/electrify.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify.sql.eex
@@ -29,6 +29,7 @@ BEGIN
 
         CALL <%= schema() %>.__validate_table_column_types(_quoted_name);
         CALL <%= schema() %>.__validate_table_column_defaults(_quoted_name);
+        CALL <%= schema() %>.__validate_table_constraints(_quoted_name);
 
         -- insert the required ddl into the migrations table
         SELECT <%= schema() %>.generate_electrified_sql(_oid) INTO _create_sql;

--- a/components/electric/priv/sql_function_templates/electrify.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify.sql.eex
@@ -5,31 +5,27 @@ CREATE OR REPLACE PROCEDURE <%= schema() %>.electrify(
 DECLARE
     _schema name;
     _table text;
-    _quoted_name text;
     _oid regclass;
     _create_sql text;
 BEGIN
     SELECT
-        table_name, schema_name, table_oid
+        schema_name, table_name, table_oid
     INTO
-        _table, _schema, _oid
+        _schema, _table, _oid
     FROM <%= schema() %>.__resolve_table_from_names(name1, name2);
 
-    _quoted_name := format('%I.%I', _schema, _table);
-    _oid := (SELECT _quoted_name::regclass);
-
     IF NOT EXISTS (SELECT pc.oid FROM pg_class pc WHERE pc.oid = _oid AND pc.relkind = 'r') THEN
-        RAISE EXCEPTION '% is not an ordinary table', _quoted_name;
+        RAISE EXCEPTION '%I.%I is not an ordinary table', _schema, _table;
     END IF;
 
     IF NOT EXISTS (
         SELECT oid FROM <%= electrified_tracking_table() %> WHERE schema_name = _schema AND table_name = _table LIMIT 1
         ) THEN
-        RAISE NOTICE 'Electrify table %', _quoted_name;
+        RAISE NOTICE 'Electrify table %I.%I', _schema, _table;
 
-        CALL <%= schema() %>.__validate_table_column_types(_quoted_name);
-        CALL <%= schema() %>.__validate_table_column_defaults(_quoted_name);
-        CALL <%= schema() %>.__validate_table_constraints(_quoted_name);
+        CALL <%= schema() %>.__validate_table_column_types(_oid);
+        CALL <%= schema() %>.__validate_table_column_defaults(_oid);
+        CALL <%= schema() %>.__validate_table_constraints(_oid);
 
         -- insert the required ddl into the migrations table
         SELECT <%= schema() %>.generate_electrified_sql(_oid) INTO _create_sql;

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_column_defaults.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_column_defaults.sql.eex
@@ -1,4 +1,4 @@
--- This function validates each column of the table that's being electrified
+-- This procedure validates each column of the table that's being electrified
 -- and aborts electrification if any column has DEFAULT expression.
 
 CREATE OR REPLACE PROCEDURE <%= schema() %>.__validate_table_column_defaults(table_name text)
@@ -20,7 +20,7 @@ BEGIN
     END LOOP;
 
     IF _invalid_cols IS NOT NULL THEN
-        RAISE EXCEPTION E'Cannot electrify "%" because some of its columns have DEFAULT expression which is not currently supported by Electric:\n  %',
+        RAISE EXCEPTION E'Cannot electrify % because some of its columns have DEFAULT expressions which are not currently supported by Electric:\n  %',
                         table_name, array_to_string(_invalid_cols, E'\n  ');
     END IF;
 END;

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_column_defaults.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_column_defaults.sql.eex
@@ -1,7 +1,7 @@
 -- This procedure validates each column of the table that's being electrified
 -- and aborts electrification if any column has DEFAULT expression.
 
-CREATE OR REPLACE PROCEDURE <%= schema() %>.__validate_table_column_defaults(table_name text)
+CREATE OR REPLACE PROCEDURE <%= schema() %>.__validate_table_column_defaults(table_oid regclass)
 SECURITY DEFINER AS $function$
 DECLARE
     _col_name text;
@@ -11,7 +11,7 @@ BEGIN
     FOR _col_name, _col_has_default IN
         SELECT attname, atthasdef
             FROM pg_attribute
-            WHERE attrelid = table_name::regclass AND attnum > 0 AND NOT attisdropped
+            WHERE attrelid = table_oid AND attnum > 0 AND NOT attisdropped
             ORDER BY attnum
     LOOP
         IF _col_has_default THEN
@@ -21,7 +21,7 @@ BEGIN
 
     IF _invalid_cols IS NOT NULL THEN
         RAISE EXCEPTION E'Cannot electrify % because some of its columns have DEFAULT expressions which are not currently supported by Electric:\n  %',
-                        table_name, array_to_string(_invalid_cols, E'\n  ');
+                        table_oid::regclass, array_to_string(_invalid_cols, E'\n  ');
     END IF;
 END;
 $function$ LANGUAGE PLPGSQL;

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_column_types.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_column_types.sql.eex
@@ -8,7 +8,7 @@
     |> Enum.join(",")
 %>
 
-CREATE OR REPLACE PROCEDURE <%= schema() %>.__validate_table_column_types(table_name text)
+CREATE OR REPLACE PROCEDURE <%= schema() %>.__validate_table_column_types(table_oid regclass)
 SECURITY DEFINER AS $function$
 DECLARE
     _col_name text;
@@ -22,7 +22,7 @@ BEGIN
         SELECT attname, typname, atttypmod, format_type(atttypid, atttypmod), typtype = 'e'
             FROM pg_attribute
             JOIN pg_type on atttypid = pg_type.oid
-            WHERE attrelid = table_name::regclass AND attnum > 0 AND NOT attisdropped
+            WHERE attrelid = table_oid AND attnum > 0 AND NOT attisdropped
             ORDER BY attnum
     LOOP
         IF (_col_type NOT IN (<%= valid_column_types %>)
@@ -36,7 +36,7 @@ BEGIN
 
     IF _invalid_cols IS NOT NULL THEN
         RAISE EXCEPTION E'Cannot electrify % because some of its columns have types not supported by Electric:\n  %',
-                        table_name, array_to_string(_invalid_cols, E'\n  ');
+                        table_oid::regclass, array_to_string(_invalid_cols, E'\n  ');
     END IF;
 END;
 $function$ LANGUAGE PLPGSQL;

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_column_types.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_column_types.sql.eex
@@ -1,4 +1,4 @@
--- This function validates the type of each column of the table that's being electrified,
+-- This procedure validates the type of each column of the table that's being electrified
 -- to check if the type is supported by Electric.
 
 <%
@@ -35,7 +35,7 @@ BEGIN
     END LOOP;
 
     IF _invalid_cols IS NOT NULL THEN
-        RAISE EXCEPTION E'Cannot electrify "%" because some of its columns have types not supported by Electric:\n  %',
+        RAISE EXCEPTION E'Cannot electrify % because some of its columns have types not supported by Electric:\n  %',
                         table_name, array_to_string(_invalid_cols, E'\n  ');
     END IF;
 END;

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
@@ -15,8 +15,9 @@ BEGIN
                          FROM pg_attribute
                          WHERE attnum = ANY(pg_constraint.conkey)
                                AND attrelid = pg_constraint.conrelid)
-            FROM pg_constraint
-            WHERE conrelid = table_name::regclass
+        FROM pg_constraint
+        WHERE conrelid = table_oid
+        ORDER BY contype
     LOOP
         IF _con_type = 'p' THEN
             _has_primary_key = true;

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
@@ -1,0 +1,30 @@
+-- This procedure checks whether the table that's being electrified
+-- has a primary key and any other contraints.
+-- If there are any CHECK or UNIQUE constraints, electrification is aborted.
+
+CREATE OR REPLACE PROCEDURE <%= schema() %>.__validate_table_constraints(table_name text)
+SECURITY DEFINER AS $function$
+DECLARE
+    _con_type char;
+    _con_columns text[];
+    _invalid_cols text[];
+BEGIN
+    FOR _con_type, _con_columns IN
+        SELECT contype, (SELECT array_agg(format('%I', attname) ORDER BY attname)
+                         FROM pg_attribute
+                         WHERE attnum = ANY(pg_constraint.conkey)
+                               AND attrelid = pg_constraint.conrelid)
+            FROM pg_constraint
+            WHERE conrelid = table_name::regclass
+    LOOP
+        IF _con_type NOT IN ('p', 'f') THEN
+            _invalid_cols = array_cat(_invalid_cols, _con_columns);
+        END IF;
+    END LOOP;
+
+    IF _invalid_cols IS NOT NULL THEN
+        RAISE EXCEPTION E'Cannot electrify % because some of its columns have CHECK, UNIQUE, EXCLUDE or user-defined constraints which are not currently supported by Electric:\n  %',
+                        table_name, array_to_string(_invalid_cols, E'\n  ');
+    END IF;
+END;
+$function$ LANGUAGE PLPGSQL;

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
@@ -29,7 +29,7 @@ BEGIN
         RAISE EXCEPTION E'Cannot electrify % because it doesn''t have a PRIMARY KEY.', table_name;
     END IF;
 
-    IF _invalid_cols IS NOT NULL THEN
+    IF _invalid_cols IS NOT NULL AND <%= schema() %>.__constraint_validation_enabled() THEN
         RAISE EXCEPTION E'Cannot electrify % because some of its columns have CHECK, UNIQUE, EXCLUDE or user-defined constraints which are not currently supported by Electric:\n  %',
                         table_name, array_to_string(_invalid_cols, E'\n  ');
     END IF;

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
@@ -8,6 +8,7 @@ DECLARE
     _con_type char;
     _con_columns text[];
     _invalid_cols text[];
+    _has_primary_key boolean := false;
 BEGIN
     FOR _con_type, _con_columns IN
         SELECT contype, (SELECT array_agg(format('%I', attname) ORDER BY attname)
@@ -17,10 +18,16 @@ BEGIN
             FROM pg_constraint
             WHERE conrelid = table_name::regclass
     LOOP
-        IF _con_type NOT IN ('p', 'f') THEN
+        IF _con_type = 'p' THEN
+            _has_primary_key = true;
+        ELSIF _con_type NOT IN ('p', 'f') THEN
             _invalid_cols = array_cat(_invalid_cols, _con_columns);
         END IF;
     END LOOP;
+
+    IF NOT _has_primary_key THEN
+        RAISE EXCEPTION E'Cannot electrify % because it doesn''t have a PRIMARY KEY.', table_name;
+    END IF;
 
     IF _invalid_cols IS NOT NULL THEN
         RAISE EXCEPTION E'Cannot electrify % because some of its columns have CHECK, UNIQUE, EXCLUDE or user-defined constraints which are not currently supported by Electric:\n  %',

--- a/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/__validate_table_constraints.sql.eex
@@ -2,7 +2,7 @@
 -- has a primary key and any other contraints.
 -- If there are any CHECK or UNIQUE constraints, electrification is aborted.
 
-CREATE OR REPLACE PROCEDURE <%= schema() %>.__validate_table_constraints(table_name text)
+CREATE OR REPLACE PROCEDURE <%= schema() %>.__validate_table_constraints(table_oid regclass)
 SECURITY DEFINER AS $function$
 DECLARE
     _con_type char;
@@ -26,12 +26,12 @@ BEGIN
     END LOOP;
 
     IF NOT _has_primary_key THEN
-        RAISE EXCEPTION E'Cannot electrify % because it doesn''t have a PRIMARY KEY.', table_name;
+        RAISE EXCEPTION E'Cannot electrify % because it doesn''t have a PRIMARY KEY.', table_oid::regclass;
     END IF;
 
     IF _invalid_cols IS NOT NULL AND <%= schema() %>.__constraint_validation_enabled() THEN
         RAISE EXCEPTION E'Cannot electrify % because some of its columns have CHECK, UNIQUE, EXCLUDE or user-defined constraints which are not currently supported by Electric:\n  %',
-                        table_name, array_to_string(_invalid_cols, E'\n  ');
+                        table_oid::regclass, array_to_string(_invalid_cols, E'\n  ');
     END IF;
 END;
 $function$ LANGUAGE PLPGSQL;

--- a/components/electric/test/electric/postgres/extension_test.exs
+++ b/components/electric/test/electric/postgres/extension_test.exs
@@ -550,6 +550,19 @@ defmodule Electric.Postgres.ExtensionTest do
                        """
                        |> String.trim()
             end
+
+    test_tx "rejects tables with missing primary key", fn conn ->
+      assert [
+               {:ok, [], []},
+               {:error, {:error, :error, _, :raise_exception, error_msg, _}}
+             ] =
+               :epgsql.squery(conn, """
+               CREATE TABLE public.t1 (id TEXT, val INTEGER);
+               CALL electric.electrify('public.t1');
+               """)
+
+      assert error_msg == "Cannot electrify public.t1 because it doesn't have a PRIMARY KEY."
+    end
   end
 
   defp migration_history(conn, after_version \\ nil) do

--- a/components/electric/test/electric/postgres/extension_test.exs
+++ b/components/electric/test/electric/postgres/extension_test.exs
@@ -473,7 +473,7 @@ defmodule Electric.Postgres.ExtensionTest do
 
       assert error_msg ==
                """
-               Cannot electrify public.t1 because some of its columns have types not supported by Electric:
+               Cannot electrify t1 because some of its columns have types not supported by Electric:
                  c1 character(1)
                  c2 character(11)
                  "C3" character varying(11)
@@ -500,7 +500,7 @@ defmodule Electric.Postgres.ExtensionTest do
 
       assert error_msg ==
                """
-               Cannot electrify public.t1 because some of its columns have DEFAULT expressions which are not currently supported by Electric:
+               Cannot electrify t1 because some of its columns have DEFAULT expressions which are not currently supported by Electric:
                  t1
                  "Ts"
                """
@@ -527,7 +527,7 @@ defmodule Electric.Postgres.ExtensionTest do
 
               assert error_msg ==
                        """
-                       Cannot electrify public.t1 because some of its columns have CHECK, UNIQUE, EXCLUDE or user-defined constraints which are not currently supported by Electric:
+                       Cannot electrify t1 because some of its columns have CHECK, UNIQUE, EXCLUDE or user-defined constraints which are not currently supported by Electric:
                          "Ts"
                          t1
                          uu
@@ -545,7 +545,7 @@ defmodule Electric.Postgres.ExtensionTest do
                CALL electric.electrify('public.t1');
                """)
 
-      assert error_msg == "Cannot electrify public.t1 because it doesn't have a PRIMARY KEY."
+      assert error_msg == "Cannot electrify t1 because it doesn't have a PRIMARY KEY."
     end
   end
 

--- a/e2e/tests/01.03_postgres_writes_propagate_to_electric.lux
+++ b/e2e/tests/01.03_postgres_writes_propagate_to_electric.lux
@@ -15,7 +15,7 @@
     # We shouldn't see a value from an un-electrified table
     -bad sentinel value
     # But we should see a transaction with one change
-    ?component=CachedWal.EtsBacked \[debug\] Saving transaction \d+ at \d+/[0-9A-E]+ with changes \[%Electric.Replication.Changes.NewRecord\{
+    ?component=CachedWal.EtsBacked \[debug\] Saving transaction \d+ at \d+/[0-9A-F]+ with changes \[%Electric.Replication.Changes.NewRecord\{
     ?+relation: \{"public", "entries"\}
     # We also see that the `tags` field has been correctly-ish filled (i.e. not empty and has correct origin)
     ?+tags: \["postgres_1@\d+"\]\}\]

--- a/e2e/tests/04.02_prisma_introspection_generates_correct_schema.lux
+++ b/e2e/tests/04.02_prisma_introspection_generates_correct_schema.lux
@@ -17,6 +17,8 @@
 [shell proxy_1]
     [invoke log "run migration $migration_version_1 on postgres"]
     """!
+    SET electric.disable_constraint_validation = true;
+
     BEGIN;
       CALL electric.migration_version('$migration_version_1');
       CREATE TABLE public.with_constraint (


### PR DESCRIPTION
Closes VAX-1278, VAX-1326.