### PR TITLE
chore(electric): Relax JWT timestamp validation by introducing the idea of "clock drift"

### DIFF
--- a/.changeset/slow-lies-boil.md
+++ b/.changeset/slow-lies-boil.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+[VAX-1449] Add the notion of "clock drift" to Electric and use it when validating timestamps in auth tokens. Among other things, this fixes the issue where an auth token is used to authenticate with Electric before even a second passes after it was generated.

--- a/clients/typescript/src/auth/secure/index.ts
+++ b/clients/typescript/src/auth/secure/index.ts
@@ -11,10 +11,7 @@ export function secureAuthToken(
 ): Promise<string> {
   const algorithm = alg ?? 'HS256'
   const expiration = exp ?? '2h'
-
-  const nowInSecs = Math.floor(Date.now() / 1000)
-  // Subtract 1 second to account for clock precision when validating the token
-  const iat = nowInSecs - 1
+  const iat = Math.floor(Date.now() / 1000)
 
   const encodedKey = new TextEncoder().encode(key)
 

--- a/components/electric/config/runtime.exs
+++ b/components/electric/config/runtime.exs
@@ -60,6 +60,18 @@ config :electric, Electric.Replication.Postgres,
 config :electric, Electric.Postgres.Proxy.Handler.Tracing, colour: true
 
 config :electric,
+  # The default acceptable clock drift is set to 2 seconds based on the following mental model:
+  #
+  #   - assume there's a server that generates JWTs and its internal clock has +1 second drift from UTC
+  #
+  #   - assume that Electric runs on a server that has -1 second clock drift from UTC
+  #
+  #   - when a new auth token is generated and is immediately sent to Electric, the latter will
+  #     see its `iat` date being 2 seconds in the future (minus network and processing latencies)
+  #
+  #   - JWT timestamp validation has 1-second resolution. So we pick 1 second as the upper bound for clock drift on
+  #     servers that regularly synchronize their clocks via NTP
+  #
   max_clock_drift_seconds: 2,
   telemetry_url: "https://checkpoint.electric-sql.com"
 

--- a/components/electric/config/runtime.exs
+++ b/components/electric/config/runtime.exs
@@ -59,7 +59,9 @@ config :electric, Electric.Replication.Postgres,
 
 config :electric, Electric.Postgres.Proxy.Handler.Tracing, colour: true
 
-config :electric, :telemetry_url, "https://checkpoint.electric-sql.com"
+config :electric,
+  max_clock_drift_seconds: 2,
+  telemetry_url: "https://checkpoint.electric-sql.com"
 
 ##########################
 ### User configuration ###

--- a/components/electric/lib/electric.ex
+++ b/components/electric/lib/electric.ex
@@ -103,4 +103,7 @@ defmodule Electric do
 
   @spec write_to_pg_mode :: write_to_pg_mode
   def write_to_pg_mode, do: Application.fetch_env!(:electric, :write_to_pg_mode)
+
+  @spec max_clock_drift_seconds :: non_neg_integer
+  def max_clock_drift_seconds, do: Application.fetch_env!(:electric, :max_clock_drift_seconds)
 end

--- a/components/electric/lib/electric/satellite/auth/insecure.ex
+++ b/components/electric/lib/electric/satellite/auth/insecure.ex
@@ -12,7 +12,6 @@ defmodule Electric.Satellite.Auth.Insecure do
 
   @behaviour Electric.Satellite.Auth
 
-  import Joken, only: [current_time: 0]
   alias Electric.Satellite.Auth
   alias Electric.Satellite.Auth.JWTUtil
 
@@ -30,9 +29,9 @@ defmodule Electric.Satellite.Auth.Insecure do
   def build_config(opts) do
     token_config =
       %{}
-      |> Joken.Config.add_claim("iat", nil, &(&1 < current_time()))
-      |> Joken.Config.add_claim("nbf", nil, &(&1 < current_time()))
-      |> Joken.Config.add_claim("exp", nil, &(&1 > current_time()))
+      |> Joken.Config.add_claim("iat", nil, &JWTUtil.past_timestamp?/1)
+      |> Joken.Config.add_claim("nbf", nil, &JWTUtil.past_timestamp?/1)
+      |> Joken.Config.add_claim("exp", nil, &JWTUtil.future_timestamp?/1)
 
     %{namespace: opts[:namespace], joken_config: token_config}
   end

--- a/components/electric/lib/electric/satellite/auth/jwt_util.ex
+++ b/components/electric/lib/electric/satellite/auth/jwt_util.ex
@@ -106,4 +106,18 @@ defmodule Electric.Satellite.Auth.JWTUtil do
       Jason.DecodeError -> {:error, :token_malformed}
     end
   end
+
+  def gen_timestamp(add_seconds \\ 0) do
+    now() + add_seconds
+  end
+
+  def past_timestamp?(ts) do
+    ts - Electric.max_clock_drift_seconds() <= now()
+  end
+
+  def future_timestamp?(ts) do
+    ts + Electric.max_clock_drift_seconds() >= now()
+  end
+
+  defp now, do: Joken.current_time()
 end


### PR DESCRIPTION
Fixes VAX-1449, #777.