### PR TITLE
fix(generator) Revert #753 as it breaks for some bundlers - will fix this bug in the CLI

### DIFF
--- a/.changeset/modern-shrimps-retire.md
+++ b/.changeset/modern-shrimps-retire.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/prisma-generator": patch
+---
+
+Revert change to generator to add .js extension to imports for nodenext compatibility as it broke for some bundlers.

--- a/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/generator/src/functions/writeSingleFileImportStatements.ts
@@ -10,7 +10,7 @@ export const writeSingleFileImportStatements: WriteStatements = (
 ) => {
   writeImport('{ z }', 'zod')
 
-  writeImport(`type { Prisma }`, `./prismaClient.js`)
+  writeImport(`type { Prisma }`, `./prismaClient`)
 
   if (dmmf.customImports) {
     dmmf.customImports.forEach((statement) => {
@@ -23,5 +23,5 @@ export const writeSingleFileImportStatements: WriteStatements = (
     'electric-sql/client/model'
   )
 
-  writeImport(`migrations`, './migrations.js')
+  writeImport(`migrations`, './migrations')
 }


### PR DESCRIPTION
Revert "chore(generator) Change generator to add .js extention to imports for nodenext compatibility (#753)"

This reverts commit 22652fb3e7616bc5d48f445cdad2d77a0c99c9a8.