### PR TITLE
fix(client_cli) Fix argName when option starts with ELECTRIC_

### DIFF
--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -156,7 +156,7 @@ export function addOptionToCommand(
 ) {
   let argName = optionName.toLocaleLowerCase().replace(/_/g, '-')
   if (argName.startsWith('electric-')) {
-    argName = optionName.slice('electric-'.length)
+    argName = argName.slice('electric-'.length)
   }
   let localName: string = optionName
   if (!optionName.startsWith('ELECTRIC_')) {


### PR DESCRIPTION
There is a small bug in the CLI options generation. The argName is not turned into lowercase when the option starts with ELECTRIC_

` npx electric-sql start --help`

![image](https://github.com/electric-sql/electric/assets/22084723/06248726-c634-4b52-a84d-4a97da41813e)


@samwillis Related to the new CLI, when looking into adding support for it in `electric_dart` we had some questions.

## 1. Start command

Should there be a `docker compose pull <image>` before starting the docker? The CLI already uses the correct docker image, but it might be important to pull in case the user was using image tag `0.x` (`0.x.0` under the hood) and later there is a patch in the service, so the user might not pull `0.x.1`

## 2. start-command usage from the generate command

The generate command runs the start command when fetching migrations, but when stopping the service, it uses the flag `remove: true`. Why is that? Wouldn't that cause data loss to the user? It would be deleting the docker volumes. Or are we missing something? 

Awesome work on the CLI btw, I think it can really help people to get started without many extra script files :smile: 