### PR TITLE
fix(client_cli): Proxy fixes 

### DIFF
--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -34,9 +34,11 @@ export const configOptions = {
     defaultVal: () => {
       const host = getConfigValue('SERVICE_HOST')
       const port = getConfigValue('PG_PROXY_PORT')
+      const user = 'postgres'
       const password = getConfigValue('PG_PROXY_PASSWORD')
       const dbName = getConfigValue('DATABASE_NAME')
-      return `postgresql://postgres:${password}@${host}:${port}/${dbName}`
+      const ssl = getConfigValue('DATABASE_REQUIRE_SSL')
+      return buildDatabaseURL({ host, port, user, password, dbName, ssl })
     },
     constructedDefault:
       'postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{ELECTRIC_SERVICE_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}',
@@ -85,7 +87,8 @@ export const configOptions = {
       const user = getConfigValue('DATABASE_USER')
       const password = getConfigValue('DATABASE_PASSWORD')
       const dbName = getConfigValue('DATABASE_NAME')
-      return buildDatabaseURL({ host, port, user, password, dbName })
+      const ssl = getConfigValue('DATABASE_REQUIRE_SSL')
+      return buildDatabaseURL({ host, port, user, password, dbName, ssl })
     },
     constructedDefault:
       'postgresql://{ELECTRIC_DATABASE_USER}:{ELECTRIC_DATABASE_PASSWORD}@{ELECTRIC_DATABASE_HOST}:{ELECTRIC_DATABASE_PORT}/{ELECTRIC_DATABASE_NAME}',

--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -45,7 +45,6 @@ export function defaultServiceUrlPart<T>(
   const url = process.env.ELECTRIC_SERVICE
   if (url) {
     const parsed = extractServiceURL(url)
-    console.log(parsed)
     if (parsed && parsed[part] !== undefined) {
       return parsed[part] as T
     }

--- a/clients/typescript/src/cli/utils.ts
+++ b/clients/typescript/src/cli/utils.ts
@@ -86,12 +86,17 @@ export function buildDatabaseURL(opts: {
   host: string
   port: number
   dbName: string
+  ssl?: boolean
 }) {
   let url = 'postgresql://' + opts.user
   if (opts.password) {
     url += ':' + opts.password
   }
   url += '@' + opts.host + ':' + opts.port + '/' + opts.dbName
+
+  if (opts.ssl === false) {
+    url += '?sslmode=disable'
+  }
   return url
 }
 


### PR DESCRIPTION
A couple of minor issues I found:

1. ~~Use the prisma user in the db proxy url, otherwise non elecrified tables are generated.~~ Bad call, the prisma user is correctly being used for the introspection. The proxy url doesn't always need to use the prisma user. We can however log the correct proxy url used when generating the client, because the one in the config differs the one used for the introspection.
https://github.com/electric-sql/electric/blob/7fbf292ef1bcb07a71fd4e2a528d2cda965ac5ce/clients/typescript/src/cli/migrations/migrate.ts#L73
https://github.com/electric-sql/electric/blob/7fbf292ef1bcb07a71fd4e2a528d2cda965ac5ce/clients/typescript/src/cli/migrations/migrate.ts#L303-L309

2. Handle ssl mode when building the db url, so that when running locally, the db and proxy urls are built with `?sslmode=disable`. Some postgres migration clients won't connect without that flag in the url when running without ssl.