### PR TITLE
fix(client): Validate urls in the Electric config

### DIFF
--- a/.changeset/clean-houses-enjoy.md
+++ b/.changeset/clean-houses-enjoy.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Validate urls in the Electric config

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -133,6 +133,10 @@ function parseServiceUrl(inputUrl?: string): {
     warnings.push('Username and password are not supported.')
   }
 
+  if (url.pathname !== '/' && url.pathname !== '') {
+    warnings.push('An URL path is not supported.')
+  }
+
   const isSecureProtocol = url.protocol === 'https:' || url.protocol === 'wss:'
   const sslEnabled = isSecureProtocol || url.searchParams.get('ssl') === 'true'
 

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -1,5 +1,4 @@
 import testAny, { TestFn, ExecutionContext } from 'ava'
-import Log from 'loglevel'
 import Database from 'better-sqlite3'
 import { schema } from '../generated'
 import { DatabaseAdapter } from '../../../src/drivers/better-sqlite3'
@@ -10,26 +9,13 @@ import { MockNotifier } from '../../../src/notifiers'
 import { randomValue } from '../../../src/util'
 import { ElectricClient } from '../../../src/client/model/client'
 import { cleanAndStopSatellite } from '../../satellite/common'
+import { LoggedMsg, setupLoggerMock } from '../../support/log-mock'
 import { satelliteDefaults } from '../../../src/satellite/config'
 
 const test = testAny as TestFn<ContextType>
 
-// Modify `loglevel` to store the logged messages
-// based on "Writing plugins" in https://github.com/pimterry/loglevel
-type LoggedMsg = string
 let log: Array<LoggedMsg> = []
-const originalFactory = Log.methodFactory
-Log.methodFactory = function (methodName, logLevel, loggerName) {
-  var rawMethod = originalFactory(methodName, logLevel, loggerName)
-
-  return function (message) {
-    log.push(message)
-    if (message !== 'Reading from unsynced table Post') {
-      rawMethod(message)
-    }
-  }
-}
-Log.setLevel(Log.levels.DEBUG) // Be sure to call setLevel method in order to apply plugin
+setupLoggerMock(test, () => log)
 
 const config = {
   auth: {

--- a/clients/typescript/test/config/config.test.ts
+++ b/clients/typescript/test/config/config.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { hydrateConfig } from '../../src/config'
 
-test('hydrateConfig adds expected defaults', async (t) => {
+test('hydrateConfig adds expected defaults', (t) => {
   const hydrated = hydrateConfig({
     auth: {
       token: 'test-token',
@@ -16,4 +16,117 @@ test('hydrateConfig adds expected defaults', async (t) => {
   t.is(hydrated.auth.token, 'test-token')
 
   t.false(hydrated.debug)
+})
+
+test('hydrageConfig custom config', (t) => {
+  const hydrated = hydrateConfig({
+    auth: {
+      token: 'test-token-2',
+    },
+    url: 'https://192.169.2.10',
+    debug: true,
+  })
+
+  t.is(hydrated.replication.host, '192.169.2.10')
+  t.is(hydrated.replication.port, 443)
+  t.is(hydrated.replication.ssl, true)
+
+  t.is(hydrated.auth.token, 'test-token-2')
+  t.is(hydrated.debug, true)
+})
+
+test('hydrateConfig port inference', (t) => {
+  const expectations: Record<string, { port: number; ssl: boolean }> = {
+    http: {
+      port: 80,
+      ssl: false,
+    },
+    https: {
+      port: 443,
+      ssl: true,
+    },
+    electric: {
+      port: 80,
+      ssl: false,
+    },
+    ws: {
+      port: 80,
+      ssl: false,
+    },
+    wss: {
+      port: 443,
+      ssl: true,
+    },
+  }
+
+  Object.entries(expectations).forEach(([protocol, expect]) => {
+    const url = `${protocol}://1.1.1.1`
+    const config = hydrateConfig({
+      auth: {
+        token: 'test-token',
+      },
+      url,
+    })
+
+    t.is(config.replication.port, expect.port)
+    t.is(config.replication.ssl, expect.ssl)
+  })
+})
+
+test('hydrateConfig ssl', (t) => {
+  const hydrated = hydrateConfig({
+    auth: {
+      token: 'test-token',
+    },
+    url: 'http://1.1.1.1?ssl=true',
+  })
+
+  t.is(hydrated.replication.ssl, true)
+})
+
+test('hydrateConfig checks for auth token', (t) => {
+  t.throws(
+    () => {
+      hydrateConfig({
+        auth: {
+          token: '',
+        },
+      })
+    },
+    {
+      message: 'Invalid configuration. Missing authentication token.',
+    }
+  )
+})
+
+test('hydrateConfig checks for valid service url', (t) => {
+  const errorReasons = {
+    'postgresql://somehost.com': 'Invalid url protocol.',
+    'https://user@somehost.com': 'Username and password are not supported.',
+    'https://user:pass@somehost.com':
+      'Username and password are not supported.',
+    // No reason, but it returns an invalid url error as well
+    'https://somehost.com:wrongport': '',
+  }
+
+  Object.entries(errorReasons).forEach(([url, reason]) => {
+    let expectedErrorMsg = "Invalid 'url' in the configuration."
+    if (reason) {
+      expectedErrorMsg = expectedErrorMsg + ' ' + reason
+    }
+
+    t.throws(
+      () => {
+        hydrateConfig({
+          auth: {
+            token: 'test-token',
+          },
+          url,
+        })
+      },
+      {
+        message: expectedErrorMsg,
+      }
+    )
+  })
 })

--- a/clients/typescript/test/config/config.test.ts
+++ b/clients/typescript/test/config/config.test.ts
@@ -131,6 +131,7 @@ test('hydrateConfig warns unexpected service urls', (t) => {
       'Unsupported URL protocol.',
       'Username and password are not supported.',
     ],
+    'http://somehost.com:1234/some/path': ['An URL path is not supported.'],
   }
 
   Object.entries(warnReasons).forEach(([url, reasons]) => {

--- a/clients/typescript/test/config/config.test.ts
+++ b/clients/typescript/test/config/config.test.ts
@@ -5,6 +5,10 @@ import { LoggedMsg, setupLoggerMock } from '../support/log-mock'
 let log: Array<LoggedMsg> = []
 setupLoggerMock(test, () => log)
 
+const validAuth = {
+  token: 'test-token',
+}
+
 test('hydrateConfig adds expected defaults', (t) => {
   const hydrated = hydrateConfig({
     auth: {
@@ -66,9 +70,7 @@ test('hydrateConfig port inference', (t) => {
   Object.entries(expectations).forEach(([protocol, expect]) => {
     const url = `${protocol}://1.1.1.1`
     const config = hydrateConfig({
-      auth: {
-        token: 'test-token',
-      },
+      auth: validAuth,
       url,
     })
 
@@ -79,9 +81,7 @@ test('hydrateConfig port inference', (t) => {
 
 test('hydrateConfig ssl', (t) => {
   const hydrated = hydrateConfig({
-    auth: {
-      token: 'test-token',
-    },
+    auth: validAuth,
     url: 'http://1.1.1.1?ssl=true',
   })
 
@@ -112,9 +112,7 @@ test('hydrateConfig throws for invalid service url', (t) => {
     t.throws(
       () => {
         hydrateConfig({
-          auth: {
-            token: 'test-token',
-          },
+          auth: validAuth,
           url,
         })
       },
@@ -146,9 +144,7 @@ test('hydrateConfig warns unexpected service urls', (t) => {
     expectedWarningMsg += " An URL like 'http(s)://<host>:<port>' is expected."
 
     hydrateConfig({
-      auth: {
-        token: 'test-token',
-      },
+      auth: validAuth,
       url,
     })
 

--- a/clients/typescript/test/support/log-mock.ts
+++ b/clients/typescript/test/support/log-mock.ts
@@ -1,0 +1,32 @@
+import { TestFn } from 'ava'
+import Log from 'loglevel'
+
+export type LoggedMsg = string
+
+// Mock the logged messages storing them into `log`
+// based on "Writing plugins" in https://github.com/pimterry/loglevel
+export function setupLoggerMock<T>(
+  test: TestFn<T>,
+  getLog: () => Array<LoggedMsg>
+) {
+  const originalFactory = Log.methodFactory
+  Log.methodFactory = function (methodName, logLevel, loggerName) {
+    const rawMethod = originalFactory(methodName, logLevel, loggerName)
+
+    return function (message) {
+      getLog().push(message)
+
+      // eslint-disable-next-line no-constant-condition
+      if (false) {
+        // We can call the logger for debug purposes
+        rawMethod(message)
+      }
+    }
+  }
+  Log.setLevel(Log.levels.DEBUG) // Be sure to call setLevel method in order to apply plugin
+
+  test.beforeEach(() => {
+    // Clear the log before each test
+    getLog().length = 0
+  })
+}


### PR DESCRIPTION
Attempt to prevent / warn users to provide invalid URLs to the config.

Discord source: https://discord.com/channels/933657521581858818/1110941752875028530/1194966674026270831

In this example, the user provides that URL by mistake, probably because of lack of familiarity with Electric/Postgres and the client works correctly. The problem is that now the app is embedded with some credentials.

![image](https://github.com/electric-sql/electric/assets/22084723/eb5ae738-c76a-49c8-8297-0059e3eaa774)
