### PR TITLE
chore (client): detach electrification from connection

### DIFF
--- a/.changeset/chilled-avocados-compare.md
+++ b/.changeset/chilled-avocados-compare.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Detach database electrification from connecting to the Electric sync service.

--- a/clients/typescript/src/auth/index.ts
+++ b/clients/typescript/src/auth/index.ts
@@ -2,12 +2,12 @@ export { insecureAuthToken } from './insecure'
 
 export interface AuthState {
   clientId: string
-  token: string
+  userId?: string
+  token?: string
 }
 
 export interface AuthConfig {
   clientId?: string
-  token: string
 }
 
 export interface TokenClaims {

--- a/clients/typescript/src/auth/secure/index.ts
+++ b/clients/typescript/src/auth/secure/index.ts
@@ -1,6 +1,7 @@
-import { SignJWT } from 'jose'
+import { SignJWT, decodeJwt, JWTPayload } from 'jose'
 
 import { TokenClaims } from '../index'
+import { InvalidArgumentError } from '../../client/validation/errors/invalidArgumentError'
 
 export function secureAuthToken(
   claims: TokenClaims,
@@ -31,4 +32,12 @@ export function mockSecureAuthToken(
   const mockKey = key ?? 'integration-tests-signing-key-example'
 
   return secureAuthToken({ sub: 'test-user' }, mockIss, mockKey)
+}
+
+export function decodeToken(token: string): JWTPayload & { sub: string } {
+  const decoded = decodeJwt(token)
+  if (typeof decoded.sub === 'undefined') {
+    throw new InvalidArgumentError('Token does not contain a sub claim')
+  }
+  return decoded as JWTPayload & { sub: string }
 }

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -5,7 +5,12 @@ import { Row, Statement } from '../../util'
 import { LiveResult, LiveResultContext } from './model'
 import { Notifier } from '../../notifiers'
 import { DatabaseAdapter } from '../../electric/adapter'
-import { GlobalRegistry, Registry, Satellite } from '../../satellite'
+import {
+  ConnectionWrapper,
+  GlobalRegistry,
+  Registry,
+  Satellite,
+} from '../../satellite'
 import { ShapeManager } from './shapes'
 
 export type ClientTables<DB extends DbSchema<any>> = {
@@ -101,6 +106,15 @@ export class ElectricClient<
   ) {
     super(dbName, adapter, notifier, registry)
     this.satellite = satellite
+  }
+
+  /**
+   * Connects to the Electric sync service.
+   * This method is idempotent, it is safe to call it multiple times.
+   */
+  async connect(): Promise<ConnectionWrapper> {
+    const connectionPromise = this.satellite.connectWithBackoff()
+    return { connectionPromise }
   }
 
   // Builds the DAL namespace from a `dbDescription` object

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -5,12 +5,8 @@ import { Row, Statement } from '../../util'
 import { LiveResult, LiveResultContext } from './model'
 import { Notifier } from '../../notifiers'
 import { DatabaseAdapter } from '../../electric/adapter'
-import {
-  ConnectionWrapper,
-  GlobalRegistry,
-  Registry,
-  Satellite,
-} from '../../satellite'
+import type { ConnectionWrapper } from '../../satellite'
+import { GlobalRegistry, Registry, Satellite } from '../../satellite'
 import { ShapeManager } from './shapes'
 
 export type ClientTables<DB extends DbSchema<any>> = {
@@ -111,8 +107,10 @@ export class ElectricClient<
   /**
    * Connects to the Electric sync service.
    * This method is idempotent, it is safe to call it multiple times.
+   * @param token - The JWT token to use to connect to the Electric sync service.
    */
-  async connect(): Promise<ConnectionWrapper> {
+  async connect(token: string): Promise<ConnectionWrapper> {
+    this.satellite.setToken(token)
     const connectionPromise = this.satellite.connectWithBackoff()
     return { connectionPromise }
   }

--- a/clients/typescript/src/client/model/client.ts
+++ b/clients/typescript/src/client/model/client.ts
@@ -5,7 +5,6 @@ import { Row, Statement } from '../../util'
 import { LiveResult, LiveResultContext } from './model'
 import { Notifier } from '../../notifiers'
 import { DatabaseAdapter } from '../../electric/adapter'
-import type { ConnectionWrapper } from '../../satellite'
 import { GlobalRegistry, Registry, Satellite } from '../../satellite'
 import { ShapeManager } from './shapes'
 
@@ -109,10 +108,9 @@ export class ElectricClient<
    * This method is idempotent, it is safe to call it multiple times.
    * @param token - The JWT token to use to connect to the Electric sync service.
    */
-  async connect(token: string): Promise<ConnectionWrapper> {
+  async connect(token: string): Promise<void> {
     this.satellite.setToken(token)
-    const connectionPromise = this.satellite.connectWithBackoff()
-    return { connectionPromise }
+    await this.satellite.connectWithBackoff()
   }
 
   // Builds the DAL namespace from a `dbDescription` object

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -1,4 +1,4 @@
-import { AuthConfig } from '../auth/index'
+import { AuthConfig } from '../auth'
 import {
   ConnectionBackoffOptions as ConnectionBackOffOptions,
   satelliteDefaults,

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -5,7 +5,11 @@ import {
 } from '../satellite/config'
 
 export interface ElectricConfig {
-  auth: AuthConfig
+  /**
+   * Optional authentication configuration.
+   * If not provided, a client ID is generated.
+   */
+  auth?: AuthConfig
   /**
    * Optional URL string to connect to the Electric sync service.
    *
@@ -65,10 +69,7 @@ export type InternalElectricConfig = {
 }
 
 export const hydrateConfig = (config: ElectricConfig): HydratedConfig => {
-  const auth = config.auth
-  if (!auth || !auth.token) {
-    throw new Error('Invalid configuration. Missing authentication token.')
-  }
+  const auth = config.auth ?? {}
 
   const debug = config.debug ?? false
   const url = new URL(config.url ?? 'http://localhost:5133')

--- a/clients/typescript/src/drivers/better-sqlite3/index.ts
+++ b/clients/typescript/src/drivers/better-sqlite3/index.ts
@@ -22,7 +22,7 @@ export type { Database }
 export const electrify = async <DB extends DbSchema<any>, T extends Database>(
   db: T,
   dbDescription: DB,
-  config: ElectricConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): Promise<ElectricClient<DB>> => {
   const dbName: DbName = db.name

--- a/clients/typescript/src/drivers/capacitor-sqlite/index.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/index.ts
@@ -21,7 +21,7 @@ export type { Database }
 export const electrify = async <T extends Database, DB extends DbSchema<any>>(
   db: T,
   dbDescription: DB,
-  config: ElectricConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): Promise<ElectricClient<DB>> => {
   const dbName: DbName = db.dbname!

--- a/clients/typescript/src/drivers/capacitor-sqlite/test.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/test.ts
@@ -44,7 +44,7 @@ export const initTestable = async <
   const socketFactory = opts?.socketFactory || MockSocket
   const registry = opts?.registry || new MockRegistry()
 
-  const dal = await electrify(
+  const client = await electrify(
     dbName,
     dbDescription,
     adapter,
@@ -56,6 +56,7 @@ export const initTestable = async <
       registry: registry,
     }
   )
+  await client.connect()
 
-  return [db, notifier, dal]
+  return [db, notifier, client]
 }

--- a/clients/typescript/src/drivers/capacitor-sqlite/test.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/test.ts
@@ -17,11 +17,7 @@ import { ElectricClient } from '../../client/model/client'
 import { ElectricConfig } from '../../config'
 import { DbSchema } from '../../client/model'
 
-const testConfig = {
-  auth: {
-    token: 'test-token',
-  },
-}
+const testToken = 'test-token'
 
 type RetVal<DB extends DbSchema<any>, N extends Notifier> = Promise<
   [Database, N, ElectricClient<DB>]
@@ -33,7 +29,7 @@ export const initTestable = async <
 >(
   dbName: DbName,
   dbDescription: DB,
-  config: ElectricConfig = testConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): RetVal<DB, N> => {
   const db = new MockDatabase(dbName)
@@ -56,7 +52,7 @@ export const initTestable = async <
       registry: registry,
     }
   )
-  await client.connect()
+  await client.connect(testToken)
 
   return [db, notifier, client]
 }

--- a/clients/typescript/src/drivers/cordova-sqlite-storage/index.ts
+++ b/clients/typescript/src/drivers/cordova-sqlite-storage/index.ts
@@ -21,7 +21,7 @@ export type { Database }
 export const electrify = async <T extends Database, DB extends DbSchema<any>>(
   db: T,
   dbDescription: DB,
-  config: ElectricConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): Promise<ElectricClient<DB>> => {
   const dbName: DbName = db.dbname!

--- a/clients/typescript/src/drivers/cordova-sqlite-storage/test.ts
+++ b/clients/typescript/src/drivers/cordova-sqlite-storage/test.ts
@@ -44,7 +44,7 @@ export const initTestable = async <
   const socketFactory = opts?.socketFactory || MockSocket
   const registry = opts?.registry || new MockRegistry()
 
-  const dal = await electrify(
+  const client = await electrify(
     dbName,
     dbDescription,
     adapter,
@@ -56,6 +56,7 @@ export const initTestable = async <
       registry: registry,
     }
   )
+  await client.connect()
 
-  return [db, notifier, dal]
+  return [db, notifier, client]
 }

--- a/clients/typescript/src/drivers/cordova-sqlite-storage/test.ts
+++ b/clients/typescript/src/drivers/cordova-sqlite-storage/test.ts
@@ -17,11 +17,7 @@ import { ElectricClient } from '../../client/model/client'
 import { ElectricConfig } from '../../config'
 import { DbSchema } from '../../client/model'
 
-const testConfig = {
-  auth: {
-    token: 'test-token',
-  },
-}
+const testToken = 'test-token'
 
 type RetVal<DB extends DbSchema<any>, N extends Notifier> = Promise<
   [Database, N, ElectricClient<DB>]
@@ -33,7 +29,7 @@ export const initTestable = async <
 >(
   dbName: DbName,
   dbDescription: DB,
-  config: ElectricConfig = testConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): RetVal<DB, N> => {
   const db = new MockDatabase(dbName)
@@ -56,7 +52,7 @@ export const initTestable = async <
       registry: registry,
     }
   )
-  await client.connect()
+  await client.connect(testToken)
 
   return [db, notifier, client]
 }

--- a/clients/typescript/src/drivers/expo-sqlite/index.ts
+++ b/clients/typescript/src/drivers/expo-sqlite/index.ts
@@ -30,7 +30,7 @@ export type { Database }
 export const electrify = async <T extends Database, DB extends DbSchema<any>>(
   db: T,
   dbDescription: DB,
-  config: ElectricConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): Promise<ElectricClient<DB>> => {
   const dbName: DbName = db._name

--- a/clients/typescript/src/drivers/expo-sqlite/test.ts
+++ b/clients/typescript/src/drivers/expo-sqlite/test.ts
@@ -17,11 +17,7 @@ import { ElectricConfig } from '../../config'
 import { ElectricClient } from '../../client/model/client'
 import { DbSchema } from '../../client/model'
 
-const testConfig = {
-  auth: {
-    token: 'test-token',
-  },
-}
+const testToken = 'test-token'
 
 type RetVal<
   S extends DbSchema<any>,
@@ -60,7 +56,7 @@ export async function initTestable<
   dbName: DbName,
   dbDescription: S,
   _useWebSQLDatabase = false,
-  config: ElectricConfig = testConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): RetVal<S, N> {
   const db = new MockDatabase(dbName)
@@ -84,7 +80,7 @@ export async function initTestable<
     }
   )
 
-  await client.connect()
+  await client.connect(testToken)
 
   return [db, notifier, client]
 }

--- a/clients/typescript/src/drivers/expo-sqlite/test.ts
+++ b/clients/typescript/src/drivers/expo-sqlite/test.ts
@@ -71,7 +71,7 @@ export async function initTestable<
   const socketFactory = opts?.socketFactory || MockSocket
   const registry = opts?.registry || new MockRegistry()
 
-  const dal = await electrify(
+  const client = await electrify(
     dbName,
     dbDescription,
     adapter,
@@ -83,5 +83,8 @@ export async function initTestable<
       registry: registry,
     }
   )
-  return [db, notifier, dal]
+
+  await client.connect()
+
+  return [db, notifier, client]
 }

--- a/clients/typescript/src/drivers/react-native-sqlite-storage/index.ts
+++ b/clients/typescript/src/drivers/react-native-sqlite-storage/index.ts
@@ -31,7 +31,7 @@ export const electrify = async <T extends Database, DB extends DbSchema<any>>(
   db: T,
   dbDescription: DB,
   promisesEnabled: boolean,
-  config: ElectricConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): Promise<ElectricClient<DB>> => {
   const dbName: DbName = db.dbName

--- a/clients/typescript/src/drivers/react-native-sqlite-storage/test.ts
+++ b/clients/typescript/src/drivers/react-native-sqlite-storage/test.ts
@@ -20,11 +20,7 @@ import { ElectricClient } from '../../client/model/client'
 import { ElectricConfig } from '../../config'
 import { DbSchema } from '../../client/model'
 
-const testConfig = {
-  auth: {
-    token: 'test-token',
-  },
-}
+const testToken = 'test-token'
 
 type RetVal<S extends DbSchema<any>, N extends Notifier> = Promise<
   [Database, N, ElectricClient<S>]
@@ -37,7 +33,7 @@ export const initTestable = async <
   dbName: DbName,
   dbDescription: S,
   promisesEnabled = false,
-  config: ElectricConfig = testConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): RetVal<S, N> => {
   let db = new MockDatabase(dbName)
@@ -62,7 +58,7 @@ export const initTestable = async <
     }
   )
 
-  await client.connect()
+  await client.connect(testToken)
 
   return [db, notifier, client]
 }

--- a/clients/typescript/src/drivers/react-native-sqlite-storage/test.ts
+++ b/clients/typescript/src/drivers/react-native-sqlite-storage/test.ts
@@ -49,7 +49,7 @@ export const initTestable = async <
   const socketFactory = opts?.socketFactory || MockSocket
   const registry = opts?.registry || new MockRegistry()
 
-  const dal = await baseElectrify(
+  const client = await baseElectrify(
     dbName,
     dbDescription,
     adapter,
@@ -62,5 +62,7 @@ export const initTestable = async <
     }
   )
 
-  return [db, notifier, dal]
+  await client.connect()
+
+  return [db, notifier, client]
 }

--- a/clients/typescript/src/drivers/wa-sqlite/index.ts
+++ b/clients/typescript/src/drivers/wa-sqlite/index.ts
@@ -12,7 +12,7 @@ export type { Database }
 export const electrify = async <T extends Database, DB extends DbSchema<any>>(
   db: T,
   dbDescription: DB,
-  config: ElectricConfig,
+  config: ElectricConfig = {},
   opts?: ElectrifyOptions
 ): Promise<ElectricClient<DB>> => {
   const dbName = db.name

--- a/clients/typescript/src/electric/index.ts
+++ b/clients/typescript/src/electric/index.ts
@@ -46,7 +46,7 @@ export const electrify = async <DB extends DbSchema<any>>(
   dbDescription: DB,
   adapter: DatabaseAdapter,
   socketFactory: SocketFactory,
-  config: ElectricConfig,
+  config: ElectricConfig = {},
   opts?: Omit<ElectrifyOptions, 'adapter' | 'socketFactory'>
 ): Promise<ElectricClient<DB>> => {
   setLogLevel(config.debug ? 'TRACE' : 'WARN')

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -53,7 +53,7 @@ export interface Registry {
 }
 
 export type ConnectionWrapper = {
-  connectionPromise: Promise<void | Error>
+  connectionPromise: Promise<void>
 }
 
 // `Satellite` is the main process handling ElectricSQL replication,
@@ -69,6 +69,7 @@ export interface Satellite {
 
   start(authConfig: AuthConfig): Promise<void>
   stop(shutdown?: boolean): Promise<void>
+  setToken(token: string): void
   connectWithBackoff(): Promise<void>
   subscribe(
     shapeDefinitions: ClientShapeDefinition[]

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -67,8 +67,9 @@ export interface Satellite {
 
   connectivityState?: ConnectivityState
 
-  start(authConfig: AuthConfig): Promise<ConnectionWrapper>
+  start(authConfig: AuthConfig): Promise<void>
   stop(shutdown?: boolean): Promise<void>
+  connectWithBackoff(): Promise<void>
   subscribe(
     shapeDefinitions: ClientShapeDefinition[]
   ): Promise<ShapeSubscription>

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -52,10 +52,6 @@ export interface Registry {
   stopAll(): Promise<void>
 }
 
-export type ConnectionWrapper = {
-  connectionPromise: Promise<void>
-}
-
 // `Satellite` is the main process handling ElectricSQL replication,
 // processing the opslog and notifying when there are data changes.
 export interface Satellite {

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -20,7 +20,7 @@ import {
 } from '../util/types'
 import { ElectricConfig } from '../config/index'
 
-import { Client, ConnectionWrapper, Satellite } from './index'
+import { Client, Satellite } from './index'
 import { SatelliteOpts, SatelliteOverrides, satelliteDefaults } from './config'
 import { BaseRegistry } from './registry'
 import { SocketFactory } from '../sockets'
@@ -91,11 +91,20 @@ export class MockSatelliteProcess implements Satellite {
     throw new Error('Method not implemented.')
   }
 
-  async start(_authConfig: AuthConfig): Promise<ConnectionWrapper> {
+  async start(): Promise<void> {
     await sleepAsync(50)
-    return {
-      connectionPromise: new Promise((resolve) => resolve()),
-    }
+  }
+
+  async auth(_authConfig: AuthConfig): Promise<void> {
+    await sleepAsync(50)
+  }
+
+  async connect(): Promise<void> {
+    await sleepAsync(50)
+  }
+
+  async connectWithBackoff(): Promise<void> {
+    await this.connect()
   }
 
   async stop(): Promise<void> {
@@ -117,7 +126,7 @@ export class MockRegistry extends BaseRegistry {
     migrator: Migrator,
     notifier: Notifier,
     socketFactory: SocketFactory,
-    config: ElectricConfig,
+    _config: ElectricConfig,
     overrides?: SatelliteOverrides
   ): Promise<Satellite> {
     if (this.shouldFailToStart) {
@@ -134,7 +143,7 @@ export class MockRegistry extends BaseRegistry {
       socketFactory,
       opts
     )
-    await satellite.start(config.auth)
+    await satellite.start()
 
     return satellite
   }

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -1,4 +1,4 @@
-import { AuthConfig, AuthState } from '../auth/index'
+import { AuthState } from '../auth/index'
 import { DatabaseAdapter } from '../electric/adapter'
 import { Migrator } from '../migrators/index'
 import { Notifier } from '../notifiers/index'
@@ -95,9 +95,7 @@ export class MockSatelliteProcess implements Satellite {
     await sleepAsync(50)
   }
 
-  async auth(_authConfig: AuthConfig): Promise<void> {
-    await sleepAsync(50)
-  }
+  setToken(_token: string): void {}
 
   async connect(): Promise<void> {
     await sleepAsync(50)

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -74,6 +74,8 @@ import { backOff } from 'exponential-backoff'
 import { chunkBy } from '../util'
 import { isFatal, isOutOfSyncError, isThrowable, wrapFatalError } from './error'
 import { inferRelationsFromSQLite } from '../util/relations'
+import { decodeToken } from '../auth/secure'
+import { InvalidArgumentError } from '../client/validation/errors/invalidArgumentError'
 
 type ChangeAccumulator = {
   [key: string]: Change
@@ -203,7 +205,7 @@ export class SatelliteProcess implements Satellite {
     }
   }
 
-  async start(authConfig: AuthConfig): Promise<void> {
+  async start(authConfig?: AuthConfig): Promise<void> {
     if (this.opts.debug) {
       await this.logSQLiteVersion()
     }
@@ -216,10 +218,10 @@ export class SatelliteProcess implements Satellite {
     }
 
     const clientId =
-      authConfig.clientId && authConfig.clientId !== ''
+      authConfig?.clientId && authConfig.clientId !== ''
         ? authConfig.clientId
         : await this._getClientId()
-    await this._setAuthState({ clientId: clientId, token: authConfig.token })
+    await this._setAuthState({ clientId: clientId }) //, token: authConfig.token })
 
     const notifierSubscriptions = Object.entries({
       _authStateSubscription: this._unsubscribeFromAuthState,
@@ -683,6 +685,28 @@ export class SatelliteProcess implements Satellite {
         throw new Error(`unexpected connectivity state: ${status}`)
       }
     }
+  }
+
+  /**
+   * Sets the JWT token.
+   * @param token The JWT token.
+   */
+  setToken(token: string): void {
+    const { sub } = decodeToken(token)
+    const userId: string | undefined = this._authState?.userId
+    if (typeof userId !== 'undefined' && sub !== userId) {
+      // We must check that the new token is still using the same user ID.
+      // We can't accept a re-connection that changes the user ID because the Satellite process is statefull.
+      // To change user ID the user must re-electrify the database.
+      throw new InvalidArgumentError(
+        `Can't change user ID when reconnecting. Previously connected with user ID '${userId}' but trying to reconnect with user ID '${sub}'`
+      )
+    }
+    this._setAuthState({
+      ...this._authState!,
+      userId: sub,
+      token,
+    })
   }
 
   async connectWithBackoff(): Promise<void> {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -221,7 +221,7 @@ export class SatelliteProcess implements Satellite {
       authConfig?.clientId && authConfig.clientId !== ''
         ? authConfig.clientId
         : await this._getClientId()
-    await this._setAuthState({ clientId: clientId }) //, token: authConfig.token })
+    this._setAuthState({ clientId: clientId })
 
     const notifierSubscriptions = Object.entries({
       _authStateSubscription: this._unsubscribeFromAuthState,

--- a/clients/typescript/src/sockets/genericSocket.ts
+++ b/clients/typescript/src/sockets/genericSocket.ts
@@ -1,0 +1,111 @@
+import EventEmitter from 'events'
+import { ConnectionOptions, Data, Socket } from '.'
+import { SatelliteError, SatelliteErrorCode } from '../util'
+
+type WriteType<SupportBuffer extends boolean> = SupportBuffer extends false
+  ? Data
+  : Data | Buffer
+
+interface MessageEvent<T = any> {
+  data: T
+}
+
+export interface IWebSocket<SupportBuffer extends boolean> {
+  send(data: WriteType<SupportBuffer>): void
+
+  addEventListener(event: 'open', cb: () => void): void
+  addEventListener(event: 'message', cb: (ev: MessageEvent) => void): void
+  addEventListener(event: 'error', cb: (ev: any) => void): void
+  addEventListener(event: 'close', cb: () => void): void
+
+  removeEventListener(
+    event: 'open' | 'message' | 'error' | 'close',
+    cb: (...args: any[]) => void
+  ): void
+
+  close(): void
+}
+
+export abstract class GenericWebSocket<SupportBuffer extends boolean = false>
+  extends EventEmitter
+  implements Socket
+{
+  protected abstract socket?: IWebSocket<SupportBuffer>
+  protected abstract makeSocket(
+    opts: ConnectionOptions
+  ): IWebSocket<SupportBuffer>
+
+  private openListener = () => this.emit('open')
+  protected messageListener = (ev: MessageEvent) => {
+    const buffer = new Uint8Array(ev.data)
+    this.emit('message', buffer)
+  }
+  private errorListener = () =>
+    this.emit(
+      'error',
+      new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
+    )
+  private closeListener = () => this.emit('close')
+
+  constructor() {
+    super()
+  }
+
+  open(opts: ConnectionOptions): this {
+    if (this.socket) {
+      throw new SatelliteError(
+        SatelliteErrorCode.INTERNAL,
+        'trying to open a socket before closing existing socket'
+      )
+    }
+
+    this.socket = this.makeSocket(opts)
+
+    this.socket.addEventListener('open', this.openListener.bind(this))
+    this.socket.addEventListener('message', this.messageListener.bind(this))
+    this.socket.addEventListener('error', this.errorListener.bind(this))
+    this.socket.addEventListener('close', this.closeListener.bind(this))
+
+    return this
+  }
+
+  write(data: WriteType<SupportBuffer>): this {
+    this.socket?.send(data)
+    return this
+  }
+
+  closeAndRemoveListeners(): this {
+    this.removeAllListeners()
+    //this.removeAllSocketListeners()
+    this.socket?.removeEventListener('open', this.openListener)
+    this.socket?.removeEventListener('message', this.messageListener)
+    this.socket?.removeEventListener('error', this.errorListener)
+    this.socket?.removeEventListener('close', this.closeListener)
+    this.socket?.close()
+    return this
+  }
+
+  onMessage(cb: (data: Data) => void): void {
+    this.on('message', cb)
+  }
+
+  onError(cb: (error: SatelliteError) => void): void {
+    this.on('error', cb)
+  }
+
+  onClose(cb: () => void): void {
+    this.on('close', cb)
+  }
+
+  onceConnect(cb: () => void): void {
+    this.once('open', cb)
+  }
+
+  onceError(cb: (error: SatelliteError) => void): void {
+    this.once('error', cb)
+  }
+
+  removeErrorListener(cb: (error: SatelliteError) => void): void {
+    this.removeListener('error', cb)
+  }
+}

--- a/clients/typescript/src/sockets/node.ts
+++ b/clients/typescript/src/sockets/node.ts
@@ -1,71 +1,17 @@
-import EventEmitter from 'events'
-import { ConnectionOptions, Data, Socket } from './index'
+import { ConnectionOptions } from './index'
 import { WebSocket } from 'ws'
-import { SatelliteError, SatelliteErrorCode } from '../util'
+import { GenericWebSocket } from './genericSocket'
 
-export class WebSocketNode extends EventEmitter implements Socket {
-  private socket?: WebSocket
+export class WebSocketNode extends GenericWebSocket<true> {
+  protected socket?: WebSocket
 
   constructor(private protocolVsn: string) {
     super()
   }
 
-  open(opts: ConnectionOptions): this {
-    if (this.socket) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'trying to open a socket before closing existing socket'
-      )
-    }
-
-    this.socket = new WebSocket(opts.url, [this.protocolVsn])
-    this.socket.binaryType = 'nodebuffer'
-
-    this.socket.on('open', () => this.emit('open'))
-    this.socket.on('message', (data) => this.emit('message', data))
-    this.socket.on('error', (_unusedError) =>
-      this.emit(
-        'error',
-        new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-      )
-    )
-
-    return this
-  }
-
-  write(data: string | Uint8Array | Buffer): this {
-    this.socket?.send(data)
-    return this
-  }
-
-  closeAndRemoveListeners(): this {
-    this.removeAllListeners()
-    this.socket?.removeAllListeners()
-    this.socket?.close()
-    return this
-  }
-
-  onMessage(cb: (data: Data) => void): void {
-    this.on('message', cb)
-  }
-
-  onError(cb: (error: SatelliteError) => void): void {
-    this.on('error', cb)
-  }
-
-  onClose(cb: () => void): void {
-    this.on('close', cb)
-  }
-
-  onceConnect(cb: () => void): void {
-    this.once('open', cb)
-  }
-
-  onceError(cb: (error: SatelliteError) => void): void {
-    this.once('error', cb)
-  }
-
-  removeErrorListener(cb: (error: SatelliteError) => void): void {
-    this.removeListener('error', cb)
+  makeSocket(opts: ConnectionOptions): WebSocket {
+    const ws = new WebSocket(opts.url, [this.protocolVsn])
+    ws.binaryType = 'nodebuffer'
+    return ws
   }
 }

--- a/clients/typescript/src/sockets/react-native.ts
+++ b/clients/typescript/src/sockets/react-native.ts
@@ -1,112 +1,16 @@
-import { ConnectionOptions, Data, Socket } from '.'
-import { SatelliteError, SatelliteErrorCode } from '../util'
+import { ConnectionOptions } from '.'
+import { GenericWebSocket } from './genericSocket'
 
-export class WebSocketReactNative implements Socket {
-  private socket?: WebSocket
+export class WebSocketReactNative extends GenericWebSocket {
+  protected socket?: WebSocket
 
-  private connectCallbacks: (() => void)[] = []
-  private errorCallbacks: ((error: SatelliteError) => void)[] = []
-  private onceErrorCallbacks: ((error: SatelliteError) => void)[] = []
-  private messageCallbacks: ((data: any) => void)[] = []
-
-  constructor(private protocolVsn: string) {}
-
-  open(opts: ConnectionOptions): this {
-    if (this.socket) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'trying to open a socket before closing existing socket'
-      )
-    }
-
-    this.socket = new WebSocket(opts.url, [this.protocolVsn])
-    this.socket.binaryType = 'arraybuffer'
-
-    this.socket.onopen = () => {
-      let callback: (() => void) | undefined
-      while ((callback = this.connectCallbacks.pop())) {
-        callback()
-      }
-    }
-
-    // event doesn't provide much
-    this.socket.onerror = () => {
-      for (const callback of this.errorCallbacks) {
-        callback(
-          new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-        )
-      }
-
-      let callback: ((error: SatelliteError) => void) | undefined
-      while ((callback = this.onceErrorCallbacks.pop())) {
-        callback(
-          new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-        )
-      }
-    }
-
-    this.socket.onmessage = (event: any) => {
-      for (const cb of this.messageCallbacks) {
-        // no alloc because message.data is ArrayBuffer
-        const buffer = new Uint8Array(event.data)
-        cb(buffer)
-      }
-    }
-
-    return this
+  constructor(private protocolVsn: string) {
+    super()
   }
 
-  write(data: Data): this {
-    this.socket?.send(data)
-    return this
-  }
-
-  closeAndRemoveListeners(): this {
-    this.connectCallbacks = []
-    this.errorCallbacks = []
-    this.messageCallbacks = []
-
-    this.socket?.close()
-    return this
-  }
-
-  onMessage(cb: (data: Data) => void): void {
-    this.messageCallbacks.push(cb)
-  }
-
-  onError(cb: (error: SatelliteError) => void): void {
-    if (this.socket) {
-      this.socket.onerror = () => {
-        cb(new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error'))
-      }
-    }
-  }
-
-  onClose(cb: () => void): void {
-    if (this.socket) {
-      this.socket.onclose = () => {
-        cb()
-      }
-    }
-  }
-
-  onceConnect(cb: () => void): void {
-    this.connectCallbacks.push(cb)
-  }
-
-  onceError(cb: (error: SatelliteError) => void): void {
-    this.onceErrorCallbacks.push(cb)
-  }
-
-  removeErrorListener(cb: (error: SatelliteError) => void): void {
-    const idx = this.errorCallbacks.indexOf(cb)
-    if (idx >= 0) {
-      this.errorCallbacks.splice(idx, 1)
-    }
-
-    const idxOnce = this.onceErrorCallbacks.indexOf(cb)
-    if (idxOnce >= 0) {
-      this.onceErrorCallbacks.splice(idxOnce, 1)
-    }
+  makeSocket(opts: ConnectionOptions): WebSocket {
+    const ws = new WebSocket(opts.url, [this.protocolVsn])
+    ws.binaryType = 'arraybuffer'
+    return ws
   }
 }

--- a/clients/typescript/src/sockets/web.ts
+++ b/clients/typescript/src/sockets/web.ts
@@ -1,125 +1,16 @@
-import { ConnectionOptions, Data, Socket } from '.'
-import { SatelliteError, SatelliteErrorCode } from '../util'
+import { ConnectionOptions } from '.'
+import { GenericWebSocket } from './genericSocket'
 
-// FIXME: This implementation is a bit contrived because it is not using EventEmitter
-export class WebSocketWeb implements Socket {
-  private socket?: WebSocket
+export class WebSocketWeb extends GenericWebSocket {
+  protected socket?: WebSocket
 
-  private connectCallbacks: (() => void)[] = []
-  private errorCallbacks: ((error: SatelliteError) => void)[] = []
-  private onceErrorCallbacks: ((error: SatelliteError) => void)[] = []
-
-  // event doesn't provide much
-  private errorListener = () => {
-    for (const callback of this.errorCallbacks) {
-      callback(
-        new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-      )
-    }
-
-    let callback: ((error: SatelliteError) => void) | undefined
-    while ((callback = this.onceErrorCallbacks.pop())) {
-      callback(
-        new SatelliteError(SatelliteErrorCode.SOCKET_ERROR, 'socket error')
-      )
-    }
+  constructor(private protocolVsn: string) {
+    super()
   }
 
-  private connectListener = () => {
-    let callback: (() => void) | undefined
-    while ((callback = this.connectCallbacks.pop())) {
-      callback()
-    }
-  }
-  private messageListener?: (event: MessageEvent<any>) => void
-  private closeListener?: () => void
-
-  constructor(private protocolVsn: string) {}
-
-  open(opts: ConnectionOptions): this {
-    if (this.socket) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'trying to open a socket before closing existing socket'
-      )
-    }
-
-    this.socket = new WebSocket(opts.url, [this.protocolVsn])
-    this.socket.binaryType = 'arraybuffer'
-
-    this.socket.addEventListener('open', this.connectListener)
-
-    this.socket.addEventListener('error', this.errorListener)
-
-    return this
-  }
-
-  write(data: Data): this {
-    this.socket?.send(data)
-    return this
-  }
-
-  closeAndRemoveListeners(): this {
-    this.socket?.removeEventListener('error', this.errorListener)
-    if (this.messageListener)
-      this.socket?.removeEventListener('message', this.messageListener)
-    if (this.closeListener)
-      this.socket?.removeEventListener('close', this.closeListener)
-
-    this.socket?.close()
-
-    this.socket = undefined
-    return this
-  }
-
-  onMessage(cb: (data: Data) => void): void {
-    if (this.messageListener) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'socket does not support multiple message listeners'
-      )
-    }
-
-    this.messageListener = (event: MessageEvent<any>) => {
-      const buffer = new Uint8Array(event.data)
-      cb(buffer)
-    }
-    this.socket?.addEventListener('message', this.messageListener)
-  }
-
-  onError(cb: (error: SatelliteError) => void): void {
-    this.errorCallbacks.push(cb)
-  }
-
-  onClose(cb: () => void): void {
-    if (this.closeListener) {
-      throw new SatelliteError(
-        SatelliteErrorCode.INTERNAL,
-        'socket does not support multiple close listeners'
-      )
-    }
-
-    this.closeListener = cb
-    this.socket?.addEventListener('close', this.closeListener)
-  }
-
-  onceConnect(cb: () => void): void {
-    this.connectCallbacks.push(cb)
-  }
-
-  onceError(cb: (error: SatelliteError) => void): void {
-    this.onceErrorCallbacks.push(cb)
-  }
-
-  removeErrorListener(cb: (error: SatelliteError) => void): void {
-    const idx = this.errorCallbacks.indexOf(cb)
-    if (idx >= 0) {
-      this.errorCallbacks.splice(idx, 1)
-    }
-
-    const idxOnce = this.onceErrorCallbacks.indexOf(cb)
-    if (idxOnce >= 0) {
-      this.onceErrorCallbacks.splice(idxOnce, 1)
-    }
+  makeSocket(opts: ConnectionOptions): WebSocket {
+    const ws = new WebSocket(opts.url, [this.protocolVsn])
+    ws.binaryType = 'arraybuffer'
+    return ws
   }
 }

--- a/clients/typescript/test/client/conversions/input.test.ts
+++ b/clients/typescript/test/client/conversions/input.test.ts
@@ -22,7 +22,6 @@ const electric = await electrify(
   },
   { registry: new MockRegistry() }
 )
-
 const tbl = electric.db.DataTypes
 
 // Sync all shapes such that we don't get warnings on every query

--- a/clients/typescript/test/client/conversions/input.test.ts
+++ b/clients/typescript/test/client/conversions/input.test.ts
@@ -15,11 +15,7 @@ const db = new Database(':memory:')
 const electric = await electrify(
   db,
   schema,
-  {
-    auth: {
-      token: 'test-token',
-    },
-  },
+  {},
   { registry: new MockRegistry() }
 )
 const tbl = electric.db.DataTypes

--- a/clients/typescript/test/client/conversions/sqlite.test.ts
+++ b/clients/typescript/test/client/conversions/sqlite.test.ts
@@ -14,11 +14,7 @@ const db = new Database(':memory:')
 const electric = await electrify(
   db,
   schema,
-  {
-    auth: {
-      token: 'test-token',
-    },
-  },
+  {},
   { registry: new MockRegistry() }
 )
 

--- a/clients/typescript/test/client/model/datatype.test.ts
+++ b/clients/typescript/test/client/model/datatype.test.ts
@@ -15,11 +15,7 @@ const db = new Database(':memory:')
 const electric = await electrify(
   db,
   schema,
-  {
-    auth: {
-      token: 'test-token',
-    },
-  },
+  {},
   { registry: new MockRegistry() }
 )
 

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -11,6 +11,7 @@ import { randomValue } from '../../../src/util'
 import { ElectricClient } from '../../../src/client/model/client'
 import { cleanAndStopSatellite } from '../../satellite/common'
 import { satelliteDefaults } from '../../../src/satellite/config'
+import { AuthConfig } from '../../../src/auth'
 
 const test = testAny as TestFn<ContextType>
 
@@ -245,9 +246,18 @@ const profile = {
   userId: 1,
 }
 
+const startSatellite = async (
+  satellite: SatelliteProcess,
+  config: AuthConfig
+) => {
+  await satellite.start(config)
+  await satellite.connectWithBackoff()
+}
+
 test.serial('promise resolves when subscription starts loading', async (t) => {
   const { satellite, client } = t.context as ContextType
   await satellite.start(config.auth)
+  await satellite.connectWithBackoff()
 
   client.setRelations(relations)
   client.setRelationData('Post', post)
@@ -264,7 +274,7 @@ test.serial(
   'synced promise resolves when subscription is fulfilled',
   async (t) => {
     const { satellite, client } = t.context as ContextType
-    await satellite.start(config.auth)
+    await startSatellite(satellite, config.auth)
 
     // We can request a subscription
     client.setRelations(relations)
@@ -292,7 +302,7 @@ test.serial(
 
 test.serial('promise is rejected on failed subscription request', async (t) => {
   const { satellite } = t.context as ContextType
-  await satellite.start(config.auth)
+  await startSatellite(satellite, config.auth)
 
   const { Items } = t.context as ContextType
   try {
@@ -305,7 +315,7 @@ test.serial('promise is rejected on failed subscription request', async (t) => {
 
 test.serial('synced promise is rejected on invalid shape', async (t) => {
   const { satellite, User } = t.context as ContextType
-  await satellite.start(config.auth)
+  await startSatellite(satellite, config.auth)
 
   let loadingPromResolved = false
 

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -11,7 +11,7 @@ import { randomValue } from '../../../src/util'
 import { ElectricClient } from '../../../src/client/model/client'
 import { cleanAndStopSatellite } from '../../satellite/common'
 import { satelliteDefaults } from '../../../src/satellite/config'
-import { AuthConfig } from '../../../src/auth'
+import { insecureAuthToken } from '../../../src/auth'
 
 const test = testAny as TestFn<ContextType>
 
@@ -34,7 +34,7 @@ Log.setLevel(Log.levels.DEBUG) // Be sure to call setLevel method in order to ap
 
 const config = {
   auth: {
-    token: 'test-token',
+    token: insecureAuthToken({ sub: 'test-token' }),
   },
 }
 
@@ -246,18 +246,15 @@ const profile = {
   userId: 1,
 }
 
-const startSatellite = async (
-  satellite: SatelliteProcess,
-  config: AuthConfig
-) => {
-  await satellite.start(config)
+const startSatellite = async (satellite: SatelliteProcess, token: string) => {
+  await satellite.start()
+  satellite.setToken(token)
   await satellite.connectWithBackoff()
 }
 
 test.serial('promise resolves when subscription starts loading', async (t) => {
   const { satellite, client } = t.context as ContextType
-  await satellite.start(config.auth)
-  await satellite.connectWithBackoff()
+  await startSatellite(satellite, config.auth.token)
 
   client.setRelations(relations)
   client.setRelationData('Post', post)
@@ -274,7 +271,7 @@ test.serial(
   'synced promise resolves when subscription is fulfilled',
   async (t) => {
     const { satellite, client } = t.context as ContextType
-    await startSatellite(satellite, config.auth)
+    await startSatellite(satellite, config.auth.token)
 
     // We can request a subscription
     client.setRelations(relations)
@@ -302,7 +299,7 @@ test.serial(
 
 test.serial('promise is rejected on failed subscription request', async (t) => {
   const { satellite } = t.context as ContextType
-  await startSatellite(satellite, config.auth)
+  await startSatellite(satellite, config.auth.token)
 
   const { Items } = t.context as ContextType
   try {
@@ -315,7 +312,7 @@ test.serial('promise is rejected on failed subscription request', async (t) => {
 
 test.serial('synced promise is rejected on invalid shape', async (t) => {
   const { satellite, User } = t.context as ContextType
-  await startSatellite(satellite, config.auth)
+  await startSatellite(satellite, config.auth.token)
 
   let loadingPromResolved = false
 

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -15,11 +15,7 @@ const db = new Database(':memory:')
 const electric = await electrify(
   db,
   schema,
-  {
-    auth: {
-      token: 'test-token',
-    },
-  },
+  {},
   { registry: new MockRegistry() }
 )
 //const postTable = electric.db.Post

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -17,11 +17,7 @@ const db = new Database(':memory:')
 const electric = await electrify(
   db,
   schema,
-  {
-    auth: {
-      token: 'test-token',
-    },
-  },
+  {},
   { registry: new MockRegistry() }
 )
 

--- a/clients/typescript/test/client/notifications.test.ts
+++ b/clients/typescript/test/client/notifications.test.ts
@@ -8,11 +8,7 @@ import { mockElectricClient } from '../satellite/common'
 import { EVENT_NAMES } from '../../src/notifiers/event'
 
 const conn = new Database(':memory:')
-const config = {
-  auth: {
-    token: 'test-token',
-  },
-}
+const config = {}
 
 const { notifier, adapter, db } = await electrify(conn, schema, config, {
   registry: new MockRegistry(),

--- a/clients/typescript/test/config/config.test.ts
+++ b/clients/typescript/test/config/config.test.ts
@@ -2,18 +2,14 @@ import test from 'ava'
 import { hydrateConfig } from '../../src/config'
 
 test('hydrateConfig adds expected defaults', async (t) => {
-  const hydrated = hydrateConfig({
-    auth: {
-      token: 'test-token',
-    },
-  })
+  const hydrated = hydrateConfig({})
 
   t.is(hydrated.replication.host, 'localhost')
   t.is(hydrated.replication.port, 5133)
   t.is(hydrated.replication.ssl, false)
   t.is(hydrated.replication.timeout, 3000)
 
-  t.is(hydrated.auth.token, 'test-token')
+  t.deepEqual(hydrated.auth, {})
 
   t.false(hydrated.debug)
 })

--- a/clients/typescript/test/example-typing-usage/better-sqlite3.ts
+++ b/clients/typescript/test/example-typing-usage/better-sqlite3.ts
@@ -3,16 +3,10 @@ import Database from 'better-sqlite3'
 import { electrify } from '../../src/drivers/better-sqlite3'
 import { schema } from '../client/generated'
 
-const config = {
-  auth: {
-    token: 'test-token',
-  },
-}
-
 const original = new Database('example.db')
 
 // Electrify the DB and use the DAL to query the `Items` table
-const { db } = await electrify(original, schema, config)
+const { db } = await electrify(original, schema)
 await db.Items.findMany({
   select: {
     value: true,

--- a/clients/typescript/test/example-typing-usage/cordova-sqlite-storage.ts
+++ b/clients/typescript/test/example-typing-usage/cordova-sqlite-storage.ts
@@ -1,12 +1,6 @@
 import { electrify } from '../../src/drivers/cordova-sqlite-storage'
 import { schema } from '../client/generated'
 
-const config = {
-  auth: {
-    token: 'test-token',
-  },
-}
-
 const opts = {
   name: 'example.db',
   location: 'default',
@@ -14,7 +8,7 @@ const opts = {
 
 document.addEventListener('deviceready', () => {
   window.sqlitePlugin.openDatabase(opts, async (original) => {
-    const { db } = await electrify(original, schema, config)
+    const { db } = await electrify(original, schema)
     await db.Items.findMany({
       select: {
         value: true,

--- a/clients/typescript/test/example-typing-usage/expo-sqlite.ts
+++ b/clients/typescript/test/example-typing-usage/expo-sqlite.ts
@@ -3,15 +3,9 @@ import * as SQLite from 'expo-sqlite'
 import { electrify } from '../../src/drivers/expo-sqlite'
 import { schema } from '../client/generated'
 
-const config = {
-  auth: {
-    token: 'test-token',
-  },
-}
-
 const original = SQLite.openDatabase('example.db')
 
-const { db } = await electrify(original, schema, config)
+const { db } = await electrify(original, schema)
 await db.Items.findMany({
   select: {
     value: true,

--- a/clients/typescript/test/example-typing-usage/react-native-sqlite-storage.ts
+++ b/clients/typescript/test/example-typing-usage/react-native-sqlite-storage.ts
@@ -8,14 +8,8 @@ import { schema } from '../client/generated'
 const promisesEnabled = true
 SQLite.enablePromise(promisesEnabled)
 
-const config = {
-  auth: {
-    token: 'test-token',
-  },
-}
-
 const original = await SQLite.openDatabase({ name: 'example.db' })
-const { db } = await electrify(original, schema, promisesEnabled, config)
+const { db } = await electrify(original, schema, promisesEnabled)
 
 await db.Items.findMany({
   select: {

--- a/clients/typescript/test/migrators/builder.test.ts
+++ b/clients/typescript/test/migrators/builder.test.ts
@@ -314,11 +314,7 @@ test('load migration from meta data', async (t) => {
   const electric = await electrify(
     db,
     new DbSchema({}, [migration]),
-    {
-      auth: {
-        token: 'test-token',
-      },
-    },
+    {},
     { socketFactory: MockSocket }
   )
 

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -288,7 +288,16 @@ export const mockElectricClient = async (
   registry.satellites[dbName] = satellite
 
   // @ts-ignore Mock Electric client that does not contain the DAL
-  return new ElectricClient({}, dbName, adapter, notifier, satellite, registry)
+  const electric = new ElectricClient(
+    {},
+    dbName,
+    adapter,
+    notifier,
+    satellite,
+    registry
+  )
+  await electric.connect()
+  return electric
 }
 
 export const clean = async (t: ExecutionContext<{ dbName: string }>) => {

--- a/clients/typescript/test/satellite/common.ts
+++ b/clients/typescript/test/satellite/common.ts
@@ -189,7 +189,7 @@ export const relations = {
 
 import migrations from '../support/migrations/migrations.js'
 import { ExecutionContext } from 'ava'
-import { AuthState } from '../../src/auth'
+import { AuthState, insecureAuthToken } from '../../src/auth'
 import { DbSchema, TableSchema } from '../../src/client/model/schema'
 import { PgBasicType } from '../../src/client/conversions/types'
 import { HKT } from '../../src/client/util/hkt'
@@ -250,7 +250,7 @@ export const makeContext = async (
     await migrator.up()
   }
 
-  const authState = { clientId: '', token: 'test-token' }
+  const authState = { clientId: '' }
 
   t.context = {
     dbName,
@@ -284,7 +284,7 @@ export const mockElectricClient = async (
     options
   )
 
-  await satellite.start({ clientId: '', token: 'test-token' })
+  await satellite.start({ clientId: '' })
   registry.satellites[dbName] = satellite
 
   // @ts-ignore Mock Electric client that does not contain the DAL
@@ -296,7 +296,7 @@ export const mockElectricClient = async (
     satellite,
     registry
   )
-  await electric.connect()
+  await electric.connect(insecureAuthToken({ sub: 'test-token' }))
   return electric
 }
 

--- a/clients/typescript/test/satellite/process.migration.test.ts
+++ b/clients/typescript/test/satellite/process.migration.test.ts
@@ -30,6 +30,7 @@ test.beforeEach(async (t) => {
   await makeContext(t)
   const { satellite, authState } = t.context
   await satellite.start(authState)
+  await satellite.connectWithBackoff()
   t.context['clientId'] = satellite._authState!.clientId // store clientId in the context
   await populateDB(t)
   const txDate = await satellite._performSnapshot()

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -49,7 +49,7 @@ import {
 } from '../../src/satellite/shapes/types'
 import { mergeEntries } from '../../src/satellite/merge'
 import { MockSubscriptionsManager } from '../../src/satellite/shapes/manager'
-import { AuthState } from '../../src/auth'
+import { AuthState, insecureAuthToken } from '../../src/auth'
 
 const parentRecord = {
   id: 1,
@@ -67,6 +67,7 @@ const startSatellite = async (
   authState: AuthState
 ) => {
   await satellite.start(authState)
+  satellite.setToken(insecureAuthToken({ sub: 'test-user' }))
   const connectionPromise = satellite.connectWithBackoff()
   return { connectionPromise }
 }
@@ -117,6 +118,19 @@ test('set persistent client id', async (t) => {
   const clientId2 = satellite._authState!.clientId
   t.truthy(clientId2)
   t.assert(clientId1 === clientId2)
+})
+
+test('cannot update user id', async (t) => {
+  const { satellite, authState } = t.context
+
+  await startSatellite(satellite, authState)
+  const error = t.throws(() => {
+    satellite.setToken(insecureAuthToken({ sub: 'test-user2' }))
+  })
+  t.is(
+    error?.message,
+    "Can't change user ID when reconnecting. Previously connected with user ID 'test-user' but trying to reconnect with user ID 'test-user2'"
+  )
 })
 
 test('cannot UPDATE primary key', async (t) => {

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -49,6 +49,7 @@ import {
 } from '../../src/satellite/shapes/types'
 import { mergeEntries } from '../../src/satellite/merge'
 import { MockSubscriptionsManager } from '../../src/satellite/shapes/manager'
+import { AuthState } from '../../src/auth'
 
 const parentRecord = {
   id: 1,
@@ -59,6 +60,15 @@ const parentRecord = {
 const childRecord = {
   id: 1,
   parent: 1,
+}
+
+const startSatellite = async (
+  satellite: SatelliteProcess,
+  authState: AuthState
+) => {
+  await satellite.start(authState)
+  const connectionPromise = satellite.connectWithBackoff()
+  return { connectionPromise }
 }
 
 const test = anyTest as TestFn<ContextType>
@@ -97,12 +107,12 @@ test('load metadata', async (t) => {
 test('set persistent client id', async (t) => {
   const { satellite, authState } = t.context
 
-  await satellite.start(authState)
+  await startSatellite(satellite, authState)
   const clientId1 = satellite._authState!.clientId
   t.truthy(clientId1)
   await satellite.stop()
 
-  await satellite.start(authState)
+  await startSatellite(satellite, authState)
 
   const clientId2 = satellite._authState!.clientId
   t.truthy(clientId2)
@@ -205,7 +215,7 @@ test('starting and stopping the process works', async (t) => {
 
   await adapter.run({ sql: `INSERT INTO parent(id) VALUES ('1'),('2')` })
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   await sleepAsync(opts.pollingInterval)
@@ -226,7 +236,7 @@ test('starting and stopping the process works', async (t) => {
   // no txn notified
   t.is(notifier.notifications.length, 4)
 
-  const conn1 = await satellite.start(authState)
+  const conn1 = await startSatellite(satellite, authState)
   await conn1.connectionPromise
   await sleepAsync(opts.pollingInterval)
 
@@ -1211,7 +1221,7 @@ test('get transactions from opLogEntries', async (t) => {
 test('handling connectivity state change stops queueing operations', async (t) => {
   const { runMigrations, satellite, adapter, authState } = t.context
   await runMigrations()
-  await satellite.start(authState)
+  await startSatellite(satellite, authState)
 
   adapter.run({
     sql: `INSERT INTO parent(id, value, other) VALUES (1, 'local', 1)`,
@@ -1246,7 +1256,7 @@ test('garbage collection is triggered when transaction from the same origin is r
   const { satellite } = t.context
   const { runMigrations, adapter, authState } = t.context
   await runMigrations()
-  await satellite.start(authState)
+  await startSatellite(satellite, authState)
 
   adapter.run({
     sql: `INSERT INTO parent(id, value, other) VALUES (1, 'local', 1);`,
@@ -1283,7 +1293,7 @@ test('clear database on BEHIND_WINDOW', async (t) => {
   const base64lsn = base64.fromBytes(numberToBytes(MOCK_BEHIND_WINDOW_LSN))
   await satellite._setMeta('lsn', base64lsn)
   try {
-    const conn = await satellite.start(authState)
+    const conn = await startSatellite(satellite, authState)
     await conn.connectionPromise
     const lsnAfter = await satellite._getMeta('lsn')
     t.not(lsnAfter, base64lsn)
@@ -1303,7 +1313,7 @@ test('throw other replication errors', async (t) => {
   const base64lsn = base64.fromBytes(numberToBytes(MOCK_INTERNAL_ERROR))
   await satellite._setMeta('lsn', base64lsn)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   return Promise.all(
     [satellite['initializing']?.waitOn(), conn.connectionPromise].map((p) =>
       p?.catch((e: SatelliteError) => {
@@ -1326,7 +1336,7 @@ test('apply shape data and persist subscription', async (t) => {
   client.setRelations(relations)
   client.setRelationData(tablename, parentRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef: ClientShapeDefinition = {
@@ -1379,7 +1389,7 @@ test('(regression) shape subscription succeeds even if subscription data is deli
   client.setRelations(relations)
   client.setRelationData(tablename, parentRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef: ClientShapeDefinition = {
@@ -1411,7 +1421,7 @@ test('multiple subscriptions for the same shape are deduplicated', async (t) => 
   client.setRelations(relations)
   client.setRelationData(tablename, parentRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef: ClientShapeDefinition = {
@@ -1453,7 +1463,7 @@ test('applied shape data will be acted upon correctly', async (t) => {
   client.setRelations(relations)
   client.setRelationData(tablename, parentRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef: ClientShapeDefinition = {
@@ -1505,7 +1515,7 @@ test('a subscription that failed to apply because of FK constraint triggers GC',
   client.setRelations(relations)
   client.setRelationData(tablename, childRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef1: ClientShapeDefinition = {
@@ -1539,7 +1549,7 @@ test('a second successful subscription', async (t) => {
   client.setRelationData('parent', parentRecord)
   client.setRelationData(tablename, childRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef1: ClientShapeDefinition = {
@@ -1585,7 +1595,7 @@ test('a single subscribe with multiple tables with FKs', async (t) => {
   client.setRelationData('parent', parentRecord)
   client.setRelationData('child', childRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef1: ClientShapeDefinition = {
@@ -1639,7 +1649,7 @@ test.serial('a shape delivery that triggers garbage collection', async (t) => {
   client.setRelationData(tablename, parentRecord)
   client.setRelationData('another', {})
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef1: ClientShapeDefinition = {
@@ -1690,7 +1700,7 @@ test('a subscription request failure does not clear the manager state', async (t
   client.setRelations(relations)
   client.setRelationData(tablename, parentRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef1: ClientShapeDefinition = {
@@ -1757,7 +1767,7 @@ test('unsubscribing all subscriptions does not trigger FK violations', async (t)
 
 test("Garbage collecting the subscription doesn't generate oplog entries", async (t) => {
   const { adapter, runMigrations, satellite, authState } = t.context
-  await satellite.start(authState)
+  await startSatellite(satellite, authState)
   await runMigrations()
   await adapter.run({ sql: `INSERT INTO parent(id) VALUES ('1'),('2')` })
   const ts = await satellite._performSnapshot()
@@ -1785,7 +1795,7 @@ test('snapshots: generated oplog entries have the correct tags', async (t) => {
   client.setRelations(relations)
   client.setRelationData(tablename, parentRecord)
 
-  const conn = await satellite.start(authState)
+  const conn = await startSatellite(satellite, authState)
   await conn.connectionPromise
 
   const shapeDef: ClientShapeDefinition = {
@@ -1896,7 +1906,7 @@ test.serial('connection backoff success', async (t) => {
   satellite['_connectRetryHandler'] = retry
 
   await Promise.all(
-    [satellite._connectWithBackoff(), satellite['initializing']?.waitOn()].map(
+    [satellite.connectWithBackoff(), satellite['initializing']?.waitOn()].map(
       (p) => p?.catch(() => t.pass())
     )
   )

--- a/clients/typescript/test/satellite/registry.test.ts
+++ b/clients/typescript/test/satellite/registry.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { ElectricConfig } from '../../src/config/index'
+import { InternalElectricConfig } from '../../src/config/index'
 import { DatabaseAdapter } from '../../src/electric/adapter'
 import { Migrator } from '../../src/migrators/index'
 import { Notifier } from '../../src/notifiers/index'
@@ -15,10 +15,8 @@ const adapter = {} as DatabaseAdapter
 const migrator = {} as Migrator
 const notifier = {} as Notifier
 const socketFactory = {} as SocketFactory
-const config: ElectricConfig = {
-  auth: {
-    token: 'test-token ',
-  },
+const config: InternalElectricConfig = {
+  auth: {},
 }
 const args = [
   dbName,

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { schema, Electric, ColorType as Color } from './generated/client'
 export { JsonNull } from './generated/client'
 import { globalRegistry } from 'electric-sql/satellite'
+import { DbSchema, ElectricClient } from 'electric-sql/client/model'
 
 setLogLevel('DEBUG')
 
@@ -34,6 +35,7 @@ export const electrify_db = async (
   console.log(`(in electrify_db) config: ${JSON.stringify(config)}`)
   schema.migrations = migrations
   const result = await electrify(db, schema, config)
+  await result.connect() // connect to Electric
 
   result.notifier.subscribeToConnectivityStateChanges((x) => console.log("Connectivity state changed", x))
 

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -8,7 +8,6 @@ import { v4 as uuidv4 } from 'uuid'
 import { schema, Electric, ColorType as Color } from './generated/client'
 export { JsonNull } from './generated/client'
 import { globalRegistry } from 'electric-sql/satellite'
-import { DbSchema, ElectricClient } from 'electric-sql/client/model'
 
 setLogLevel('DEBUG')
 
@@ -28,14 +27,12 @@ export const electrify_db = async (
   const config: ElectricConfig = {
     url: `electric://${host}:${port}`,
     debug: true,
-    auth: {
-      token: await mockSecureAuthToken()
-    }
   }
   console.log(`(in electrify_db) config: ${JSON.stringify(config)}`)
   schema.migrations = migrations
   const result = await electrify(db, schema, config)
-  await result.connect() // connect to Electric
+  const token = await mockSecureAuthToken()
+  await result.connect(token) // connect to Electric
 
   result.notifier.subscribeToConnectivityStateChanges((x) => console.log("Connectivity state changed", x))
 


### PR DESCRIPTION
This PR detaches electrification of a database from connecting to the Electric sync service.
Authentication credentials still need to be passed when calling `electrify` because the client ID is used for generating tags when snapshotting the oplog.

Note that the ts-client will complain if you try to sync a shape before being connected to the Electric sync service.

The flow is as follows:

```ts
const electric = await electrify(conn, schema, config)
await electric.connect()
// only now can one sync shapes
```

This PR unblocks https://github.com/electric-sql/electric/issues/491 as it enables using Electric in local-only mode as one can essentially never call `electric.connect`. In local-only mode, one never syncs any shape.