### PR TITLE
fix (client): use WebSocketWeb as the default socket for capacitor

### DIFF
--- a/.changeset/happy-emus-push.md
+++ b/.changeset/happy-emus-push.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix default socket for capacitor driver.

--- a/clients/typescript/src/drivers/capacitor-sqlite/index.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/index.ts
@@ -11,7 +11,7 @@ import {
 import { DatabaseAdapter } from './adapter'
 import { ElectricConfig } from '../../config'
 import { Database } from './database'
-import { MockSocket } from '../../sockets/mock'
+import { WebSocketWeb } from '../../sockets/web'
 import { ElectricClient } from '../../client/model/client'
 import { DbSchema } from '../../client/model/schema'
 
@@ -26,7 +26,7 @@ export const electrify = async <T extends Database, DB extends DbSchema<any>>(
 ): Promise<ElectricClient<DB>> => {
   const dbName: DbName = db.dbname!
   const adapter = opts?.adapter || new DatabaseAdapter(db)
-  const socketFactory = opts?.socketFactory || MockSocket
+  const socketFactory = opts?.socketFactory || WebSocketWeb
 
   const namespace = await baseElectrify(
     dbName,


### PR DESCRIPTION
This PR fixes the default socket that is used by the capacitor driver to be the `WebSocketWeb` socket.
Note that the cordova driver is still using `MockSocket` as the default.
Not sure what should be the default for the Cordova driver? And whether it's worth spending any time in this since it is not used.