### PR TITLE
fix(client) Fix bugs in the CLI

### DIFF
--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -149,6 +149,7 @@
     "exponential-backoff": "^3.1.0",
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "frame-stream": "^3.0.1",
+    "get-port": "^7.0.0",
     "jose": "^4.14.4",
     "lodash.flow": "^3.5.0",
     "lodash.groupby": "^4.6.0",

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -97,8 +97,7 @@ export const configOptions = {
       const user = getConfigValue('DATABASE_USER', options)
       const password = getConfigValue('DATABASE_PASSWORD', options)
       const dbName = getConfigValue('DATABASE_NAME', options)
-      const ssl = getConfigValue('DATABASE_REQUIRE_SSL', options)
-      return buildDatabaseURL({ host, port, user, password, dbName, ssl })
+      return buildDatabaseURL({ host, port, user, password, dbName })
     },
     constructedDefault:
       'postgresql://{ELECTRIC_DATABASE_USER}:{ELECTRIC_DATABASE_PASSWORD}@{ELECTRIC_DATABASE_HOST}:{ELECTRIC_DATABASE_PORT}/{ELECTRIC_DATABASE_NAME}',

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -4,7 +4,7 @@ import {
   defaultServiceUrlPart,
   getConfigValue,
 } from './config'
-import { dedent, getAppName, buildDatabaseURL } from './utils'
+import { dedent, getAppName, buildDatabaseURL, parsePgProxyPort } from './utils'
 import { LIB_VERSION } from '../version'
 
 const minorVersion = LIB_VERSION.split('.').slice(0, 2).join('.')
@@ -33,7 +33,9 @@ export const configOptions = {
     shortForm: 'p',
     defaultVal: (options: any) => {
       const host = getConfigValue('PG_PROXY_HOST', options)
-      const port = getConfigValue('PG_PROXY_PORT', options)
+      const port = parsePgProxyPort(
+        getConfigValue('PG_PROXY_PORT', options)
+      ).port
       const user = 'postgres'
       const password = getConfigValue('PG_PROXY_PASSWORD', options)
       const dbName = getConfigValue('DATABASE_NAME', options)
@@ -183,7 +185,7 @@ export const configOptions = {
   },
   PG_PROXY_PORT: {
     defaultVal: '65432',
-    valueType: Number,
+    valueType: String,
     valueTypeName: 'port',
     doc: 'Port number for connections to the Postgres migration proxy.',
     groups: ['electric', 'client', 'proxy'],

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -18,9 +18,9 @@ export const configOptions = {
     doc: 'URL of the Electric service.',
     groups: ['client', 'tunnel'],
     shortForm: 's',
-    defaultVal: () => {
-      const host = getConfigValue('SERVICE_HOST')
-      const port = getConfigValue('HTTP_PORT')
+    defaultVal: (options: any) => {
+      const host = getConfigValue('SERVICE_HOST', options)
+      const port = getConfigValue('HTTP_PORT', options)
       return `http://${host}:${port}`
     },
     constructedDefault: 'http://{ELECTRIC_SERVICE_HOST}:{ELECTRIC_HTTP_PORT}',
@@ -31,15 +31,15 @@ export const configOptions = {
     doc: "URL of the Electric service's PostgreSQL proxy.",
     groups: ['client', 'proxy'],
     shortForm: 'p',
-    defaultVal: () => {
-      const host = getConfigValue('SERVICE_HOST')
-      const port = getConfigValue('PG_PROXY_PORT')
-      const password = getConfigValue('PG_PROXY_PASSWORD')
-      const dbName = getConfigValue('DATABASE_NAME')
+    defaultVal: (options: any) => {
+      const host = getConfigValue('PG_PROXY_HOST', options)
+      const port = getConfigValue('PG_PROXY_PORT', options)
+      const password = getConfigValue('PG_PROXY_PASSWORD', options)
+      const dbName = getConfigValue('DATABASE_NAME', options)
       return `postgresql://postgres:${password}@${host}:${port}/${dbName}`
     },
     constructedDefault:
-      'postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{ELECTRIC_SERVICE_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}',
+      'postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{PG_PROXY_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}',
   },
   CLIENT_PATH: {
     valueType: String,
@@ -55,6 +55,13 @@ export const configOptions = {
     doc: 'Hostname the Electric service is running on.',
     groups: ['client', 'proxy'],
     defaultVal: () => defaultServiceUrlPart('host', 'localhost'),
+  },
+  PG_PROXY_HOST: {
+    valueType: String,
+    valueTypeName: 'hostname',
+    doc: 'Port number for connections to the Postgres migration proxy.',
+    groups: ['client', 'proxy'],
+    defaultVal: (options: any) => getConfigValue('SERVICE_HOST', options),
   },
   MODULE_RESOLUTION: {
     valueType: String,
@@ -79,12 +86,12 @@ export const configOptions = {
     valueType: String,
     valueTypeName: 'url',
     shortForm: 'db',
-    defaultVal: () => {
-      const host = getConfigValue('DATABASE_HOST')
-      const port = getConfigValue('DATABASE_PORT')
-      const user = getConfigValue('DATABASE_USER')
-      const password = getConfigValue('DATABASE_PASSWORD')
-      const dbName = getConfigValue('DATABASE_NAME')
+    defaultVal: (options: any) => {
+      const host = getConfigValue('DATABASE_HOST', options)
+      const port = getConfigValue('DATABASE_PORT', options)
+      const user = getConfigValue('DATABASE_USER', options)
+      const password = getConfigValue('DATABASE_PASSWORD', options)
+      const dbName = getConfigValue('DATABASE_NAME', options)
       return buildDatabaseURL({ host, port, user, password, dbName })
     },
     constructedDefault:
@@ -253,6 +260,13 @@ export const configOptions = {
     valueTypeName: 'image',
     defaultVal: `electricsql/electric:${minorVersion}`, // Latest minor version of this library
     doc: 'The Docker image to use for Electric.',
+    groups: ['electric'],
+  },
+  CONTAINER_NAME: {
+    valueType: String,
+    valueTypeName: 'name',
+    defaultVal: (): string => getAppName() ?? 'electric',
+    doc: 'The name to use for the Docker container.',
     groups: ['electric'],
   },
 } as const

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -34,9 +34,11 @@ export const configOptions = {
     defaultVal: (options: any) => {
       const host = getConfigValue('PG_PROXY_HOST', options)
       const port = getConfigValue('PG_PROXY_PORT', options)
+      const user = 'postgres'
       const password = getConfigValue('PG_PROXY_PASSWORD', options)
       const dbName = getConfigValue('DATABASE_NAME', options)
-      return `postgresql://postgres:${password}@${host}:${port}/${dbName}`
+      const ssl = getConfigValue('DATABASE_REQUIRE_SSL', options)
+      return buildDatabaseURL({ host, port, user, password, dbName, ssl })
     },
     constructedDefault:
       'postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{PG_PROXY_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}',
@@ -92,7 +94,8 @@ export const configOptions = {
       const user = getConfigValue('DATABASE_USER', options)
       const password = getConfigValue('DATABASE_PASSWORD', options)
       const dbName = getConfigValue('DATABASE_NAME', options)
-      return buildDatabaseURL({ host, port, user, password, dbName })
+      const ssl = getConfigValue('DATABASE_REQUIRE_SSL', options)
+      return buildDatabaseURL({ host, port, user, password, dbName, ssl })
     },
     constructedDefault:
       'postgresql://{ELECTRIC_DATABASE_USER}:{ELECTRIC_DATABASE_PASSWORD}@{ELECTRIC_DATABASE_HOST}:{ELECTRIC_DATABASE_PORT}/{ELECTRIC_DATABASE_NAME}',

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -44,7 +44,7 @@ export const configOptions = {
       return buildDatabaseURL({ host, port, user, password, dbName, ssl })
     },
     constructedDefault:
-      'postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{PG_PROXY_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}',
+      'postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{ELECTRIC_PG_PROXY_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}',
   },
   CLIENT_PATH: {
     valueType: String,

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -3,6 +3,7 @@ import {
   defaultDbUrlPart,
   defaultServiceUrlPart,
   getConfigValue,
+  type ConfigMap,
 } from './config'
 import { dedent, getAppName, buildDatabaseURL, parsePgProxyPort } from './utils'
 import { LIB_VERSION } from '../version'
@@ -18,7 +19,7 @@ export const configOptions = {
     doc: 'URL of the Electric service.',
     groups: ['client', 'tunnel'],
     shortForm: 's',
-    defaultVal: (options: any) => {
+    defaultVal: (options: ConfigMap) => {
       const host = getConfigValue('SERVICE_HOST', options)
       const port = getConfigValue('HTTP_PORT', options)
       return `http://${host}:${port}`
@@ -31,7 +32,7 @@ export const configOptions = {
     doc: "URL of the Electric service's PostgreSQL proxy.",
     groups: ['client', 'proxy'],
     shortForm: 'p',
-    defaultVal: (options: any) => {
+    defaultVal: (options: ConfigMap) => {
       const host = getConfigValue('PG_PROXY_HOST', options)
       const port = parsePgProxyPort(
         getConfigValue('PG_PROXY_PORT', options)
@@ -65,7 +66,7 @@ export const configOptions = {
     valueTypeName: 'hostname',
     doc: 'Port number for connections to the Postgres migration proxy.',
     groups: ['client', 'proxy'],
-    defaultVal: (options: any) => getConfigValue('SERVICE_HOST', options),
+    defaultVal: (options: ConfigMap) => getConfigValue('SERVICE_HOST', options),
   },
   MODULE_RESOLUTION: {
     valueType: String,
@@ -90,7 +91,7 @@ export const configOptions = {
     valueType: String,
     valueTypeName: 'url',
     shortForm: 'db',
-    defaultVal: (options: any) => {
+    defaultVal: (options: ConfigMap) => {
       const host = getConfigValue('DATABASE_HOST', options)
       const port = getConfigValue('DATABASE_PORT', options)
       const user = getConfigValue('DATABASE_USER', options)

--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -2,6 +2,8 @@ import type { Command } from 'commander'
 import { extractDatabaseURL, extractServiceURL } from './utils'
 import { configOptions } from './config-options'
 
+export type ConfigMap = Record<string, string | number | boolean>
+
 export interface AnyConfigOption {
   doc: string
   valueType: typeof String | typeof Number | typeof Boolean
@@ -11,7 +13,7 @@ export interface AnyConfigOption {
     | string
     | number
     | boolean
-    | ((options: any) => string | number | boolean)
+    | ((options: ConfigMap) => string | number | boolean)
   constructedDefault?: string
   groups?: Readonly<string[]>
 }
@@ -90,7 +92,7 @@ export function getConfigValue<K extends ConfigOptionName>(
   // Finally, check if the option has a default value
   const defaultVal = (configOptions[name] as AnyConfigOption).defaultVal as
     | ConfigOptionValue<K>
-    | ((options: any) => ConfigOptionValue<K>)
+    | ((options: ConfigMap) => ConfigOptionValue<K>)
   if (typeof defaultVal === 'function') {
     return defaultVal(options)
   }

--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -7,7 +7,11 @@ export interface AnyConfigOption {
   valueType: typeof String | typeof Number | typeof Boolean
   valueTypeName?: string
   shortForm?: string
-  defaultVal?: string | number | boolean | (() => string | number | boolean)
+  defaultVal?:
+    | string
+    | number
+    | boolean
+    | ((options: any) => string | number | boolean)
   constructedDefault?: string
   groups?: Readonly<string[]>
 }
@@ -45,7 +49,6 @@ export function defaultServiceUrlPart<T>(
   const url = process.env.ELECTRIC_SERVICE
   if (url) {
     const parsed = extractServiceURL(url)
-    console.log(parsed)
     if (parsed && parsed[part] !== undefined) {
       return parsed[part] as T
     }
@@ -87,9 +90,9 @@ export function getConfigValue<K extends ConfigOptionName>(
   // Finally, check if the option has a default value
   const defaultVal = (configOptions[name] as AnyConfigOption).defaultVal as
     | ConfigOptionValue<K>
-    | (() => ConfigOptionValue<K>)
+    | ((options: any) => ConfigOptionValue<K>)
   if (typeof defaultVal === 'function') {
-    return defaultVal()
+    return defaultVal(options)
   }
   return defaultVal
 }

--- a/clients/typescript/src/cli/docker-commands/command-psql.ts
+++ b/clients/typescript/src/cli/docker-commands/command-psql.ts
@@ -4,7 +4,7 @@ import {
   getConfig,
   GetConfigOptionsForGroup,
 } from '../config'
-import { buildDatabaseURL } from '../utils'
+import { buildDatabaseURL, parsePgProxyPort } from '../utils'
 import { dockerCompose } from './docker-utils'
 
 export function makePsqlCommand() {
@@ -32,7 +32,7 @@ export function psql(
     user: config.DATABASE_USER,
     password: config.PG_PROXY_PASSWORD,
     host: 'electric',
-    port: config.PG_PROXY_PORT,
+    port: parsePgProxyPort(config.PG_PROXY_PORT).port,
     dbName: config.DATABASE_NAME,
   })
   dockerCompose(

--- a/clients/typescript/src/cli/docker-commands/command-psql.ts
+++ b/clients/typescript/src/cli/docker-commands/command-psql.ts
@@ -4,7 +4,7 @@ import {
   getConfig,
   GetConfigOptionsForGroup,
 } from '../config'
-import { getAppName, buildDatabaseURL } from '../utils'
+import { buildDatabaseURL } from '../utils'
 import { dockerCompose } from './docker-utils'
 
 export function makePsqlCommand() {
@@ -20,15 +20,12 @@ export function makePsqlCommand() {
   return command
 }
 
-export function psql(opts: GetConfigOptionsForGroup<'proxy'>) {
+export function psql(
+  opts: GetConfigOptionsForGroup<'proxy'> & GetConfigOptionsForGroup<'electric'>
+) {
   // TODO: Do we want a version of this that works without the postgres container
   // using a local psql client if available?
   const config = getConfig(opts)
-  const appName = getAppName()
-  const env = {
-    ELECTRIC_APP_NAME: appName,
-    COMPOSE_PROJECT_NAME: appName,
-  }
   // As we are connecting to the proxy from within the docker network, we have to
   // use the container name instead of localhost.
   const containerDbUrl = buildDatabaseURL({
@@ -38,5 +35,9 @@ export function psql(opts: GetConfigOptionsForGroup<'proxy'>) {
     port: config.PG_PROXY_PORT,
     dbName: config.DATABASE_NAME,
   })
-  dockerCompose('exec', ['-it', 'postgres', 'psql', containerDbUrl], env)
+  dockerCompose(
+    'exec',
+    ['-it', 'postgres', 'psql', containerDbUrl],
+    opts.CONTAINER_NAME
+  )
 }

--- a/clients/typescript/src/cli/docker-commands/command-psql.ts
+++ b/clients/typescript/src/cli/docker-commands/command-psql.ts
@@ -34,6 +34,6 @@ export function psql(opts: GetConfigOptionsForGroup<'proxy' | 'electric'>) {
   dockerCompose(
     'exec',
     ['-it', 'postgres', 'psql', containerDbUrl],
-    opts.CONTAINER_NAME
+    config.CONTAINER_NAME
   )
 }

--- a/clients/typescript/src/cli/docker-commands/command-psql.ts
+++ b/clients/typescript/src/cli/docker-commands/command-psql.ts
@@ -20,11 +20,7 @@ export function makePsqlCommand() {
   return command
 }
 
-export function psql(
-  opts: GetConfigOptionsForGroup<'proxy'> & GetConfigOptionsForGroup<'electric'>
-) {
-  // TODO: Do we want a version of this that works without the postgres container
-  // using a local psql client if available?
+export function psql(opts: GetConfigOptionsForGroup<'proxy' | 'electric'>) {
   const config = getConfig(opts)
   // As we are connecting to the proxy from within the docker network, we have to
   // use the container name instead of localhost.

--- a/clients/typescript/src/cli/docker-commands/command-start.ts
+++ b/clients/typescript/src/cli/docker-commands/command-start.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { dedent } from '../utils'
+import { dedent, parsePgProxyPort } from '../utils'
 import { addOptionGroupToCommand, getConfig, Config } from '../config'
 import { dockerCompose } from './docker-utils'
 
@@ -57,6 +57,11 @@ export function start(options: StartSettings) {
     )
 
     const env = configToEnv(options.config)
+    // PG_PROXY_PORT can have a 'http:' prefix, which we need to remove
+    // for port mapping to work.
+    env.PG_PROXY_PORT_PARSED = parsePgProxyPort(
+      env.PG_PROXY_PORT
+    ).port.toString()
 
     const dockerConfig = {
       ...env,

--- a/clients/typescript/src/cli/docker-commands/docker-utils.ts
+++ b/clients/typescript/src/cli/docker-commands/docker-utils.ts
@@ -1,7 +1,6 @@
 import { spawn } from 'child_process'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { getAppName } from '../utils'
 
 const composeFile = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -12,9 +11,9 @@ const composeFile = path.join(
 export function dockerCompose(
   command: string,
   userArgs: string[] = [],
+  containerName?: string,
   env: { [key: string]: string } = {}
 ) {
-  const appName = getAppName() ?? 'electric'
   const args = [
     'compose',
     '--ansi',
@@ -28,8 +27,7 @@ export function dockerCompose(
     stdio: 'inherit',
     env: {
       ...process.env,
-      APP_NAME: appName,
-      COMPOSE_PROJECT_NAME: appName,
+      ...(containerName ? { COMPOSE_PROJECT_NAME: containerName } : {}),
       ...env,
     },
   })

--- a/clients/typescript/src/cli/docker-commands/docker/compose-base.yaml
+++ b/clients/typescript/src/cli/docker-commands/docker/compose-base.yaml
@@ -6,7 +6,7 @@ services:
     init: true
     ports:
       - ${HTTP_PORT:-5133}:${HTTP_PORT:-5133}
-      - ${PG_PROXY_PORT:-65432}:${PG_PROXY_PORT:-65432}
+      - ${PG_PROXY_PORT_PARSED:-65432}:${PG_PROXY_PORT_PARSED:-65432}
     environment:
       DATABASE_REQUIRE_SSL: ${DATABASE_REQUIRE_SSL:-}
       DATABASE_URL: ${DATABASE_URL:-}

--- a/clients/typescript/src/cli/docker-commands/docker/compose.yaml
+++ b/clients/typescript/src/cli/docker-commands/docker/compose.yaml
@@ -12,21 +12,27 @@ services:
     profiles: ['with-postgres']
     image: '${POSTGRESQL_IMAGE:-postgres:14-alpine}'
     environment:
-      POSTGRES_DB: ${APP_NAME:-electric}
+      POSTGRES_DB: ${DATABASE_NAME:-electric}
       POSTGRES_USER: ${DATABASE_USER:-postgres}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-db_password}
     command:
       - -c
       - config_file=/etc/postgresql.conf
+      - -p
+      - ${DATABASE_PORT:-5432}
     configs:
       - source: postgres_config
         target: /etc/postgresql.conf
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U ${DATABASE_USER:-postgres}']
+      test:
+        [
+          'CMD-SHELL',
+          'pg_isready -U ${DATABASE_USER:-postgres} -p ${DATABASE_PORT:-5432}',
+        ]
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     ports:
-      - ${DATABASE_PORT:-5432}:5432
+      - ${DATABASE_PORT:-5432}:${DATABASE_PORT:-5432}
     volumes:
       - pg_data:/var/lib/postgresql/data
 

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -45,7 +45,7 @@ export interface GeneratorOptions {
 }
 
 export async function generate(options: GeneratorOptions) {
-  let opts = {
+  const opts = {
     exitOnError: true,
     ...options,
   }

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -307,7 +307,7 @@ function buildProxyUrlForIntrospection(config: Config) {
   return buildDatabaseURL({
     user: 'prisma', // We use the "prisma" user to put the proxy into introspection mode
     password: config.PG_PROXY_PASSWORD,
-    host: config.SERVICE_HOST,
+    host: config.PG_PROXY_HOST,
     port: parsePgProxyPort(config.PG_PROXY_PORT).port,
     dbName: config.DATABASE_NAME,
   })

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -9,7 +9,7 @@ import http from 'node:http'
 import https from 'node:https'
 import Module from 'node:module'
 import path from 'path'
-import { buildDatabaseURL } from '../utils'
+import { buildDatabaseURL, parsePgProxyPort } from '../utils'
 import { buildMigrations, getMigrationNames } from './builder'
 import { findAndReplaceInFile } from '../util'
 import { getConfig, type Config } from '../config'
@@ -308,7 +308,7 @@ function buildProxyUrlForIntrospection(config: Config) {
     user: 'prisma', // We use the "prisma" user to put the proxy into introspection mode
     password: config.PG_PROXY_PASSWORD,
     host: config.SERVICE_HOST,
-    port: config.PG_PROXY_PORT,
+    port: parsePgProxyPort(config.PG_PROXY_PORT).port,
     dbName: config.DATABASE_NAME,
   })
 }
@@ -706,7 +706,7 @@ async function rewriteImportsForNodeNext(clientDir: string): Promise<void> {
 async function withMigrationsConfig(containerName: string) {
   return {
     HTTP_PORT: await getPort(),
-    PG_PROXY_PORT: await getPort(),
+    PG_PROXY_PORT: (await getPort()).toString(),
     DATABASE_PORT: await getPort(),
     SERVICE_HOST: 'localhost',
     PG_PROXY_HOST: 'localhost',

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -82,7 +82,7 @@ export async function generate(options: GeneratorOptions) {
       withConfig(opts.withMigrations, opts.config)
     }
     console.log('Service URL: ' + opts.config.SERVICE)
-    console.log('Proxy URL: ' + opts.config.PROXY)
+    console.log('Proxy URL: ' + buildProxyUrlForIntrospection(opts.config))
     // Generate the client
     if (opts.watch) {
       watchMigrations(opts)
@@ -303,6 +303,16 @@ function escapePathForString(inputPath: string): string {
     : inputPath
 }
 
+function buildProxyUrlForIntrospection(config: Config) {
+  return buildDatabaseURL({
+    user: 'prisma', // We use the "prisma" user to put the proxy into introspection mode
+    password: config.PG_PROXY_PASSWORD,
+    host: config.SERVICE_HOST,
+    port: config.PG_PROXY_PORT,
+    dbName: config.DATABASE_NAME,
+  })
+}
+
 /**
  * Creates a fresh Prisma schema in the provided folder.
  * The Prisma schema is initialised with a generator and a datasource.
@@ -313,13 +323,7 @@ async function createPrismaSchema(folder: string, opts: GeneratorOptions) {
   const prismaSchemaFile = path.join(prismaDir, 'schema.prisma')
   await fs.mkdir(prismaDir)
   const output = path.resolve(config.CLIENT_PATH)
-  const proxyUrl = buildDatabaseURL({
-    user: 'prisma', // We use the "prisma" user to put the proxy into introspection mode
-    password: config.PG_PROXY_PASSWORD,
-    host: config.PG_PROXY_HOST,
-    port: config.PG_PROXY_PORT,
-    dbName: config.DATABASE_NAME,
-  })
+  const proxyUrl = buildProxyUrlForIntrospection(config)
   const schema = dedent`
     generator electric {
       provider      = "node ${escapePathForString(generatorPath)}"

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -1,17 +1,18 @@
-import path from 'path'
-import * as z from 'zod'
-import * as fs from 'fs/promises'
 import { createWriteStream } from 'fs'
+import { dedent } from 'ts-dedent'
+import { exec } from 'child_process'
+import * as fs from 'fs/promises'
+import * as z from 'zod'
+import decompress from 'decompress'
+import getPort from 'get-port'
 import http from 'node:http'
 import https from 'node:https'
-import decompress from 'decompress'
-import { buildMigrations, getMigrationNames } from './builder'
-import { exec } from 'child_process'
-import { dedent } from 'ts-dedent'
-import { findAndReplaceInFile } from '../util'
 import Module from 'node:module'
-import type { Config } from '../config'
+import path from 'path'
 import { buildDatabaseURL } from '../utils'
+import { buildMigrations, getMigrationNames } from './builder'
+import { findAndReplaceInFile } from '../util'
+import { getConfig, type Config } from '../config'
 import { start } from '../docker-commands/command-start'
 import { stop } from '../docker-commands/command-stop'
 import { withConfig } from '../configure/command-with-config'
@@ -44,10 +45,11 @@ export interface GeneratorOptions {
 }
 
 export async function generate(options: GeneratorOptions) {
-  const opts = {
+  let opts = {
     exitOnError: true,
     ...options,
   }
+  let config = opts.config
   if (opts.watch && opts.withMigrations) {
     console.error(
       'Cannot use --watch and --with-migrations at the same time. Please choose one.'
@@ -59,8 +61,18 @@ export async function generate(options: GeneratorOptions) {
     if (opts.withMigrations) {
       // Start new ElectricSQL and PostgreSQL containers
       console.log('Starting ElectricSQL and PostgreSQL containers...')
+      // Remove the ELECTRIC_SERVICE and ELECTRIC_PROXY env vars
+      delete process.env.ELECTRIC_SERVICE
+      delete process.env.ELECTRIC_PROXY
+      config = getConfig({
+        ...config,
+        SERVICE: undefined,
+        PROXY: undefined,
+        ...(await withMigrationsConfig(config.CONTAINER_NAME)),
+      })
+      opts.config = config
       await start({
-        config: opts.config,
+        config,
         withPostgres: true,
         detach: true,
         exitOnDetached: false,
@@ -83,6 +95,7 @@ export async function generate(options: GeneratorOptions) {
       console.log('Stopping ElectricSQL and PostgreSQL containers...')
       await stop({
         remove: true,
+        config,
       })
       console.log('Done')
     }
@@ -303,7 +316,7 @@ async function createPrismaSchema(folder: string, opts: GeneratorOptions) {
   const proxyUrl = buildDatabaseURL({
     user: 'prisma', // We use the "prisma" user to put the proxy into introspection mode
     password: config.PG_PROXY_PASSWORD,
-    host: config.SERVICE_HOST,
+    host: config.PG_PROXY_HOST,
     port: config.PG_PROXY_PORT,
     dbName: config.DATABASE_NAME,
   })
@@ -684,4 +697,19 @@ async function rewriteImportsForNodeNext(clientDir: string): Promise<void> {
     .replace("from './migrations';", "from './migrations.js';")
     .replace("from './prismaClient';", "from './prismaClient.js';")
   await fs.writeFile(file, newContent)
+}
+
+async function withMigrationsConfig(containerName: string) {
+  return {
+    HTTP_PORT: await getPort(),
+    PG_PROXY_PORT: await getPort(),
+    DATABASE_PORT: await getPort(),
+    SERVICE_HOST: 'localhost',
+    PG_PROXY_HOST: 'localhost',
+    DATABASE_REQUIRE_SSL: false,
+    // Random container name to avoid collisions
+    CONTAINER_NAME: `${containerName}-migrations-${Math.random()
+      .toString(36)
+      .slice(6)}`,
+  }
 }

--- a/clients/typescript/src/cli/utils.ts
+++ b/clients/typescript/src/cli/utils.ts
@@ -130,8 +130,11 @@ export function extractServiceURL(serviceUrl: string) {
 export function parsePgProxyPort(str: string) {
   if (str.includes(':')) {
     const [prefix, port] = str.split(':')
-    return { http: prefix === 'http', port: parsePort(port) }
-  } else if (str === 'http') {
+    return {
+      http: prefix.toLocaleLowerCase() === 'http',
+      port: parsePort(port),
+    }
+  } else if (str.toLocaleLowerCase() === 'http') {
     return { http: true, port: 65432 }
   } else {
     return { http: false, port: parsePort(str) }

--- a/clients/typescript/src/cli/utils.ts
+++ b/clients/typescript/src/cli/utils.ts
@@ -126,3 +126,14 @@ export function extractServiceURL(serviceUrl: string) {
     port: parsed.port ? parseInt(parsed.port) : undefined,
   }
 }
+
+export function parsePgProxyPort(str: string) {
+  if (str.includes(':')) {
+    const [prefix, port] = str.split(':')
+    return { http: prefix === 'http', port: parsePort(port) }
+  } else if (str === 'http') {
+    return { http: true, port: 65432 }
+  } else {
+    return { http: false, port: parsePort(str) }
+  }
+}

--- a/clients/typescript/src/cli/utils.ts
+++ b/clients/typescript/src/cli/utils.ts
@@ -8,7 +8,7 @@ export const appRoot = path.resolve() // path where the user ran `npx electric`
 /**
  * Get the name of the current project.
  */
-export function getAppName() {
+export function getAppName(): string | undefined {
   const packageJsonPath = path.join(appRoot, 'package.json')
   return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).name
 }

--- a/clients/typescript/src/cli/utils.ts
+++ b/clients/typescript/src/cli/utils.ts
@@ -86,12 +86,17 @@ export function buildDatabaseURL(opts: {
   host: string
   port: number
   dbName: string
+  ssl?: boolean
 }) {
   let url = 'postgresql://' + opts.user
   if (opts.password) {
     url += ':' + opts.password
   }
   url += '@' + opts.host + ':' + opts.port + '/' + opts.dbName
+
+  if (opts.ssl === false) {
+    url += '?sslmode=disable'
+  }
   return url
 }
 

--- a/clients/typescript/test/cli/migrations/migrate.test.ts
+++ b/clients/typescript/test/cli/migrations/migrate.test.ts
@@ -132,7 +132,7 @@ const failedGenerate = async (debug = false): Promise<boolean> => {
       // or migrations proxy and fails
       config: getConfig({
         SERVICE_HOST: 'does-not-exist', // Use a non-existent host to force failure
-        PG_PROXY_PORT: 999999,
+        PG_PROXY_PORT: '999999',
       }),
       // prevent process.exit call to perform test
       exitOnError: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       frame-stream:
         specifier: ^3.0.1
         version: 3.0.1
+      get-port:
+        specifier: ^7.0.0
+        version: 7.0.0
       jose:
         specifier: ^4.14.4
         version: 4.14.4
@@ -8585,6 +8588,11 @@ packages:
     resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
     engines: {node: '>=4'}
     dev: true
+
+  /get-port@7.0.0:
+    resolution: {integrity: sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==}
+    engines: {node: '>=16'}
+    dev: false
 
   /get-stream@2.3.1:
     resolution: {integrity: sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==}


### PR DESCRIPTION
Fixes:
- `generate --with-migrations` now runs in a ephemeral container on random ports and random container name
- #825 Correctly handles ssl for db urls
- Allow the pg proxy to be on an alternative host to the sync service (required for the proxy tunnel)
- configurable container name
- correctly handles `PG_PROXY_PORT` with `http` or `http:123` value