### PR TITLE
Update flutter integration docs

### DIFF
--- a/docs/integrations/frontend/flutter.md
+++ b/docs/integrations/frontend/flutter.md
@@ -13,4 +13,6 @@ See the #dart-client channel [on Discord](https://discord.electric-sql.com) for 
 
 ## Community bindings
 
-See the [electric_dart](httpshttps://github.com/SkillDevs/electric_dart) package developed by the team at [@SkillDevs](https://github.com/SkillDevs).
+See the [electric_dart](https://github.com/SkillDevs/electric_dart) package developed by the team at [@SkillDevs](https://github.com/SkillDevs).
+
+`pub.dev` package: [electricsql](https://pub.dev/packages/electricsql)


### PR DESCRIPTION
Hello! We just noticed the new docs for the Flutter integration. Thanks for the shout-out!
This PR fixes the http link to the repo and adds the link to the package in the NPM equivalent for Dart/Flutter, https://pub.dev