### PR TITLE
chore (e2e tests): fix flaky test

### DIFF
--- a/e2e/tests/03.10_node_satellite_can_resume_replication_on_reconnect.lux
+++ b/e2e/tests/03.10_node_satellite_can_resume_replication_on_reconnect.lux
@@ -30,7 +30,6 @@
   # Verify that the client retrieves previously stored LSN when it reestablishes the replication connection.
   [progress resuming client]
   [invoke electrify_db "originalDb" "electric_1" 5133 "[]"]
-  ?$node
 
   -no previous LSN
 


### PR DESCRIPTION
This PR modifies e2e test 03.10 which is flaky and regularly fails on CI.
I figured out that we were matching the Node repl before matching some expected string:

```
[invoke electrify_db "originalDb" "electric_1" 5133 "[]"]
?$node # <-- this match is causing trouble and not needed
-no previous LSN
?starting replication with lsn:
?\[rpc\] send: #SatInStartReplicationReq\{lsn: [a-zA-Z0-9=]+,
??[rpc] recv: #SatInStartReplicationResp
```

But sometimes NodeJS print the expected string before returning so after matching `?$node` it can't match `?starting replication with lsn:` anymore as it was already printed. I mainly had this issue on the CI. Let's see if this fixes it.