### PR TITLE
fix(client) Correctly pass the CONTAINER_NAME to the cli "status" command

### DIFF
--- a/.changeset/five-beds-taste.md
+++ b/.changeset/five-beds-taste.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Correctly pass the CONTAINER_NAME to the cli "status" command

--- a/clients/typescript/src/cli/docker-commands/command-status.ts
+++ b/clients/typescript/src/cli/docker-commands/command-status.ts
@@ -7,7 +7,7 @@ export function makeStatusCommand() {
     .description(
       'Show status of the ElectricSQL sync service docker containers'
     )
-    .action(async () => {
+    .action(() => {
       const config = getConfig()
       status({ config })
     })

--- a/clients/typescript/src/cli/docker-commands/command-status.ts
+++ b/clients/typescript/src/cli/docker-commands/command-status.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import { getConfig, Config } from '../config'
 import { dockerCompose } from './docker-utils'
 
 export function makeStatusCommand() {
@@ -6,9 +7,12 @@ export function makeStatusCommand() {
     .description(
       'Show status of the ElectricSQL sync service docker containers'
     )
-    .action(status)
+    .action(async () => {
+      const config = getConfig()
+      status({ config })
+    })
 }
 
-export function status() {
-  dockerCompose('ps', [])
+export function status({ config }: { config: Config }) {
+  dockerCompose('ps', [], config.CONTAINER_NAME)
 }


### PR DESCRIPTION
This ensures the status command correctly shows the containers for the current project.