### PR TITLE
chore(client) Pull latest images for tag when running cli 'start' command

### DIFF
--- a/.changeset/chatty-kings-beg.md
+++ b/.changeset/chatty-kings-beg.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Pull latest images for tag when running cli 'start' command


### PR DESCRIPTION
If the pull fails, for example the user is offline, it will continue anyway.

Thanks to @davidmartos96 for the suggestion.