### PR TITLE
fix(electric): Implement support for AuthenticationMD5Password upstream auth method

### DIFF
--- a/.changeset/blue-snakes-jog.md
+++ b/.changeset/blue-snakes-jog.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+[VAX-1553] Add support for AuthenticationMD5Password upstream auth method in the Migrations proxy. This fixes a connectivity issue between Electric and DigitalOcean Managed PostgreSQL.

--- a/components/electric/lib/electric/errors.ex
+++ b/components/electric/lib/electric/errors.ex
@@ -105,6 +105,14 @@ defmodule Electric.Errors do
     """
   end
 
+  defp format_header(:not_implemented) do
+    """
+    ┌─────────────────────────┐
+    │  NOT IMPLEMENTED ERROR  │
+    ┕━━━━━━━━━━━━━━━━━━━━━━━━━┙
+    """
+  end
+
   defp format_header(module_alias) do
     module_line = "  MODULE ERROR: " <> inspect(module_alias) <> "  "
     n = byte_size(module_line)

--- a/components/electric/lib/electric/postgres/proxy/upstream_connection.ex
+++ b/components/electric/lib/electric/postgres/proxy/upstream_connection.ex
@@ -187,6 +187,15 @@ defmodule Electric.Postgres.Proxy.UpstreamConnection do
     %{state | sasl: nil}
   end
 
+  defp handle_backend_msg(%msg_type{} = msg, _state)
+       when msg_type in [M.AuthenticationKerberosV5, M.AuthenticationGSS, M.AuthenticationSSPI] do
+    error_msg = "Proxy's upstream connection requested unsupported authentication method:"
+    error_val = inspect(msg, pretty: true)
+
+    Electric.Errors.print_error(:not_implemented, error_msg <> "\n\n    " <> error_val)
+    exit(error_msg <> " " <> error_val)
+  end
+
   defp handle_backend_msg(msg, state) do
     %{state | pending: [msg | state.pending]}
   end

--- a/components/electric/lib/electric/postgres/proxy/upstream_connection.ex
+++ b/components/electric/lib/electric/postgres/proxy/upstream_connection.ex
@@ -228,15 +228,6 @@ defmodule Electric.Postgres.Proxy.UpstreamConnection do
   end
 
   defp md5_hex_digest(iodata) do
-    :crypto.hash(:md5, iodata) |> bin_to_hex()
+    :crypto.hash(:md5, iodata) |> Base.encode16(case: :lower)
   end
-
-  defp bin_to_hex(""), do: ""
-
-  defp bin_to_hex(<<hi::4, lo::4>> <> rest) do
-    <<hex_char(hi), hex_char(lo)>> <> bin_to_hex(rest)
-  end
-
-  defp hex_char(num) when num in 0..9, do: ?0 + num
-  defp hex_char(num) when num in 10..15, do: ?a + num - 10
 end

--- a/components/electric/test/electric/postgres/proxy_test.exs
+++ b/components/electric/test/electric/postgres/proxy_test.exs
@@ -100,8 +100,6 @@ defmodule Electric.Postgres.ProxyTest do
       # Verify that both upstream connections have shut down without errors.
       assert_receive {:DOWN, ^mon1, :process, ^pid1, :normal}
       assert_receive {:DOWN, ^mon2, :process, ^pid2, :normal}
-
-      Process.sleep(1000)
     end)
   end
 end


### PR DESCRIPTION
Fixes VAX-1553.

@magnetised I would appreciate any guidance on how to best test support for specific upstream messages in the proxy. Maybe we should also unit-test the SSL upgrade that I recently implemented there.