### PR TITLE
feat(client): Add expo-sqlite/next driver

### DIFF
--- a/.changeset/brave-dolls-count.md
+++ b/.changeset/brave-dolls-count.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Add expo-sqlite/next driver to client

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -52,6 +52,7 @@
     "./cordova": "./dist/drivers/cordova-sqlite-storage/index.js",
     "./capacitor": "./dist/drivers/capacitor-sqlite/index.js",
     "./expo": "./dist/drivers/expo-sqlite/index.js",
+    "./expo-next": "./dist/drivers/expo-sqlite-next/index.js",
     "./generic": "./dist/drivers/generic/index.js",
     "./node": "./dist/drivers/better-sqlite3/index.js",
     "./react": "./dist/frameworks/react/index.js",
@@ -77,6 +78,9 @@
       ],
       "expo": [
         "./dist/drivers/expo-sqlite/index.d.ts"
+      ],
+      "expo-next": [
+        "./dist/drivers/expo-sqlite-next/index.d.ts"
       ],
       "generic": [
         "./dist/drivers/generic/index.d.ts"
@@ -203,7 +207,7 @@
     "ava": "^4.3.1",
     "concurrently": "^8.2.2",
     "eslint": "^8.22.0",
-    "expo-sqlite": "^11.7.0",
+    "expo-sqlite": "^13.0.0",
     "glob": "^10.3.10",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
@@ -225,7 +229,7 @@
   "peerDependencies": {
     "@capacitor-community/sqlite": ">= 5.4.1",
     "cordova-sqlite-storage": ">= 5.0.0",
-    "expo-sqlite": ">= 11.7.0",
+    "expo-sqlite": ">= 13.0.0",
     "react": ">= 16.8.0",
     "react-dom": ">= 16.8.0",
     "react-native": ">= 0.68.0",

--- a/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
@@ -1,15 +1,35 @@
 import { Row, SqlValue } from '../../util/types'
 import { Statement } from '../../util'
-import { SerialDatabaseAdapter as GenericDatabaseAdapter } from '../generic'
+import {
+  DatabaseAdapter as DatabaseAdapterInterface,
+  RunResult,
+  TableNameImpl,
+  Transaction as Tx,
+} from '../../electric/adapter'
 import { Database } from './database'
-import { RunResult } from '../../electric/adapter'
+import { Mutex } from 'async-mutex'
 
-export class DatabaseAdapter extends GenericDatabaseAdapter {
+export class DatabaseAdapter
+  extends TableNameImpl
+  implements DatabaseAdapterInterface
+{
   readonly db: Database
+  protected txMutex: Mutex
 
   constructor(db: Database) {
     super()
     this.db = db
+    this.txMutex = new Mutex()
+  }
+
+  async run(statement: Statement): Promise<RunResult> {
+    await this.txMutex.waitForUnlock()
+    return this._run(statement)
+  }
+
+  async query(statement: Statement): Promise<Row[]> {
+    await this.txMutex.waitForUnlock()
+    return this._query(statement)
   }
 
   async _run(statement: Statement): Promise<RunResult> {
@@ -26,5 +46,80 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
   async _query(statement: Statement): Promise<Row[]> {
     const { sql: source, args: params = [] } = statement
     return await this.db.getAllAsync(source, params as Omit<SqlValue, 'bigint'>)
+  }
+
+  async runInTransaction(...statements: Statement[]): Promise<RunResult> {
+    const release = await this.txMutex.acquire()
+    return new Promise<RunResult>((resolve, reject) => {
+      this.db
+        .withTransactionAsync(async () => {
+          const results = await Promise.all(
+            statements.map(this._run.bind(this))
+          )
+          const runResult = results.reduce((resA, resB) => ({
+            rowsAffected: resA.rowsAffected + resB.rowsAffected,
+          }))
+          resolve(runResult)
+        })
+        .catch(reject)
+    }).finally(release)
+  }
+
+  async transaction<T>(
+    f: (_tx: Tx, setResult: (res: T) => void) => void
+  ): Promise<T> {
+    const release = await this.txMutex.acquire()
+    return new Promise<T>((resolve, reject) => {
+      this.db
+        .withTransactionAsync(
+          () =>
+            new Promise((txnResolve, txnReject) => {
+              const adaptedTxn = new WrappedTx(this, txnReject)
+              f(adaptedTxn, (res) => {
+                txnResolve()
+                resolve(res)
+              })
+            })
+        )
+        .catch(reject)
+    }).finally(release)
+  }
+}
+
+class WrappedTx implements Tx {
+  constructor(
+    private tx: DatabaseAdapter,
+    private signalFailure: (err: any) => void
+  ) {}
+  run(
+    statement: Statement,
+    successCallback?: (tx: Tx, res: RunResult) => void,
+    errorCallback?: (error: any) => void
+  ): void {
+    this.tx
+      ._run(statement)
+      .then((res) => {
+        successCallback?.(this, res)
+      })
+      .catch((err) => {
+        errorCallback?.(err)
+        this.signalFailure(err)
+      })
+  }
+
+  query(
+    statement: Statement,
+    successCallback: (tx: Tx, res: Row[]) => void,
+    errorCallback?: (error: any) => void
+  ): void {
+    this.tx
+      ._query(statement)
+      .then((res) => {
+        successCallback?.(this, res)
+      })
+      .catch((err) => {
+        errorCallback?.(err)
+        this.signalFailure(err)
+      })
   }
 }

--- a/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
@@ -1,0 +1,30 @@
+import { Row, SqlValue } from '../../util/types'
+import { Statement } from '../../util'
+import { SerialDatabaseAdapter as GenericDatabaseAdapter } from '../generic'
+import { Database } from './database'
+import { RunResult } from '../../electric/adapter'
+
+export class DatabaseAdapter extends GenericDatabaseAdapter {
+  readonly db: Database
+
+  constructor(db: Database) {
+    super()
+    this.db = db
+  }
+
+  async _run(statement: Statement): Promise<RunResult> {
+    const { sql: source, args: params = [] } = statement
+    const result = await this.db.runAsync(
+      source,
+      params as Omit<SqlValue, 'bigint'>
+    )
+    return {
+      rowsAffected: result.changes,
+    }
+  }
+
+  async _query(statement: Statement): Promise<Row[]> {
+    const { sql: source, args: params = [] } = statement
+    return await this.db.getAllAsync(source, params as Omit<SqlValue, 'bigint'>)
+  }
+}

--- a/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
@@ -4,8 +4,7 @@ import { RunResult } from '../../electric/adapter'
 import { Database } from './database'
 import { SerialDatabaseAdapter } from '../generic'
 
-export class DatabaseAdapter extends SerialDatabaseAdapter
-{
+export class DatabaseAdapter extends SerialDatabaseAdapter {
   readonly db: Database
   constructor(db: Database) {
     super()

--- a/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
@@ -23,13 +23,11 @@ export class DatabaseAdapter
   }
 
   async run(statement: Statement): Promise<RunResult> {
-    await this.txMutex.waitForUnlock()
-    return this._run(statement)
+    return this.txMutex.runExclusive(() => this._run(statement))
   }
 
   async query(statement: Statement): Promise<Row[]> {
-    await this.txMutex.waitForUnlock()
-    return this._query(statement)
+    return this.txMutex.runExclusive(() => this._query(statement))
   }
 
   async _run(statement: Statement): Promise<RunResult> {

--- a/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/adapter.ts
@@ -1,33 +1,15 @@
 import { Row, SqlValue } from '../../util/types'
 import { Statement } from '../../util'
-import {
-  DatabaseAdapter as DatabaseAdapterInterface,
-  RunResult,
-  TableNameImpl,
-  Transaction as Tx,
-} from '../../electric/adapter'
+import { RunResult } from '../../electric/adapter'
 import { Database } from './database'
-import { Mutex } from 'async-mutex'
+import { SerialDatabaseAdapter } from '../generic'
 
-export class DatabaseAdapter
-  extends TableNameImpl
-  implements DatabaseAdapterInterface
+export class DatabaseAdapter extends SerialDatabaseAdapter
 {
   readonly db: Database
-  protected txMutex: Mutex
-
   constructor(db: Database) {
     super()
     this.db = db
-    this.txMutex = new Mutex()
-  }
-
-  async run(statement: Statement): Promise<RunResult> {
-    return this.txMutex.runExclusive(() => this._run(statement))
-  }
-
-  async query(statement: Statement): Promise<Row[]> {
-    return this.txMutex.runExclusive(() => this._query(statement))
   }
 
   async _run(statement: Statement): Promise<RunResult> {
@@ -44,80 +26,5 @@ export class DatabaseAdapter
   async _query(statement: Statement): Promise<Row[]> {
     const { sql: source, args: params = [] } = statement
     return await this.db.getAllAsync(source, params as Omit<SqlValue, 'bigint'>)
-  }
-
-  async runInTransaction(...statements: Statement[]): Promise<RunResult> {
-    const release = await this.txMutex.acquire()
-    return new Promise<RunResult>((resolve, reject) => {
-      this.db
-        .withTransactionAsync(async () => {
-          const results = await Promise.all(
-            statements.map(this._run.bind(this))
-          )
-          const runResult = results.reduce((resA, resB) => ({
-            rowsAffected: resA.rowsAffected + resB.rowsAffected,
-          }))
-          resolve(runResult)
-        })
-        .catch(reject)
-    }).finally(release)
-  }
-
-  async transaction<T>(
-    f: (_tx: Tx, setResult: (res: T) => void) => void
-  ): Promise<T> {
-    const release = await this.txMutex.acquire()
-    return new Promise<T>((resolve, reject) => {
-      this.db
-        .withTransactionAsync(
-          () =>
-            new Promise((txnResolve, txnReject) => {
-              const adaptedTxn = new WrappedTx(this, txnReject)
-              f(adaptedTxn, (res) => {
-                txnResolve()
-                resolve(res)
-              })
-            })
-        )
-        .catch(reject)
-    }).finally(release)
-  }
-}
-
-class WrappedTx implements Tx {
-  constructor(
-    private tx: DatabaseAdapter,
-    private signalFailure: (err: any) => void
-  ) {}
-  run(
-    statement: Statement,
-    successCallback?: (tx: Tx, res: RunResult) => void,
-    errorCallback?: (error: any) => void
-  ): void {
-    this.tx
-      ._run(statement)
-      .then((res) => {
-        successCallback?.(this, res)
-      })
-      .catch((err) => {
-        errorCallback?.(err)
-        this.signalFailure(err)
-      })
-  }
-
-  query(
-    statement: Statement,
-    successCallback: (tx: Tx, res: Row[]) => void,
-    errorCallback?: (error: any) => void
-  ): void {
-    this.tx
-      ._query(statement)
-      .then((res) => {
-        successCallback?.(this, res)
-      })
-      .catch((err) => {
-        errorCallback?.(err)
-        this.signalFailure(err)
-      })
   }
 }

--- a/clients/typescript/src/drivers/expo-sqlite-next/database.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/database.ts
@@ -2,5 +2,5 @@ import { SQLiteDatabase } from 'expo-sqlite/next'
 
 export type Database = Pick<
   SQLiteDatabase,
-  'getAllAsync' | 'runAsync' | 'databaseName'
+  'getAllAsync' | 'withTransactionAsync' | 'runAsync' | 'databaseName'
 >

--- a/clients/typescript/src/drivers/expo-sqlite-next/database.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/database.ts
@@ -2,5 +2,5 @@ import { SQLiteDatabase } from 'expo-sqlite/next'
 
 export type Database = Pick<
   SQLiteDatabase,
-  'getAllAsync' | 'withTransactionAsync' | 'runAsync' | 'databaseName'
+  'getAllAsync' | 'runAsync' | 'databaseName'
 >

--- a/clients/typescript/src/drivers/expo-sqlite-next/database.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/database.ts
@@ -1,0 +1,6 @@
+import { SQLiteDatabase } from 'expo-sqlite/next'
+
+export type Database = Pick<
+  SQLiteDatabase,
+  'getAllAsync' | 'runAsync' | 'databaseName'
+>

--- a/clients/typescript/src/drivers/expo-sqlite-next/index.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/index.ts
@@ -1,0 +1,50 @@
+// N.b.: importing this module is an entrypoint that imports the React Native
+// environment dependencies. Specifically `react-native-fs`. You can use the
+// alternative entrypoint in `./test` to avoid importing this.
+import { DbName } from '../../util/types'
+
+import {
+  ElectrifyOptions,
+  electrify as baseElectrify,
+} from '../../electric/index'
+
+import { DatabaseAdapter } from './adapter'
+import { ElectricConfig } from '../../config'
+import { Database } from './database'
+import { setUUIDImpl } from '../../util/common'
+
+// Provide implementation for TextEncoder/TextDecoder
+import 'fastestsmallesttextencoderdecoder'
+
+// Provide implementation for uuid()
+import uuid from 'react-native-uuid'
+setUUIDImpl(uuid.v4 as () => string)
+
+import { ElectricClient } from '../../client/model/client'
+import { DbSchema } from '../../client/model/schema'
+import { WebSocketReactNative } from '../../sockets/react-native'
+
+export { DatabaseAdapter }
+export type { Database }
+
+export const electrify = async <T extends Database, DB extends DbSchema<any>>(
+  db: T,
+  dbDescription: DB,
+  config: ElectricConfig,
+  opts?: ElectrifyOptions
+): Promise<ElectricClient<DB>> => {
+  const dbName: DbName = db.databaseName
+  const adapter = opts?.adapter || new DatabaseAdapter(db)
+  const socketFactory = opts?.socketFactory || WebSocketReactNative
+
+  const namespace = await baseElectrify(
+    dbName,
+    dbDescription,
+    adapter,
+    socketFactory,
+    config,
+    opts
+  )
+
+  return namespace
+}

--- a/clients/typescript/src/drivers/expo-sqlite-next/mock.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/mock.ts
@@ -1,0 +1,30 @@
+import { Database } from './database'
+import {
+  SQLiteBindParams,
+  SQLiteVariadicBindParams,
+  SQLiteRunResult,
+} from 'expo-sqlite/next'
+
+export class MockDatabase implements Database {
+  constructor(public databaseName: string) {}
+  getAllAsync<T>(source: string, params: SQLiteBindParams): Promise<T[]>
+  getAllAsync<T>(
+    source: string,
+    ...params: SQLiteVariadicBindParams
+  ): Promise<T[]>
+  getAllAsync(_source: unknown, _params?: unknown): Promise<any[]> {
+    return Promise.resolve([{ i: 0 }])
+  }
+
+  runAsync(source: string, params: SQLiteBindParams): Promise<SQLiteRunResult>
+  runAsync(
+    source: string,
+    ...params: SQLiteVariadicBindParams
+  ): Promise<SQLiteRunResult>
+  runAsync(_source: unknown, _params?: unknown): Promise<SQLiteRunResult> {
+    return Promise.resolve({
+      lastInsertRowId: 0,
+      changes: 0,
+    })
+  }
+}

--- a/clients/typescript/src/drivers/expo-sqlite-next/mock.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/mock.ts
@@ -12,8 +12,8 @@ export class MockDatabase implements Database {
     source: string,
     ...params: SQLiteVariadicBindParams
   ): Promise<T[]>
-  getAllAsync(_source: unknown, _params?: unknown): Promise<any[]> {
-    return Promise.resolve([{ i: 0 }])
+  getAllAsync<T>(_source: string, _params?: unknown): Promise<T[]> {
+    return Promise.resolve([{ i: 0 } as T])
   }
 
   runAsync(source: string, params: SQLiteBindParams): Promise<SQLiteRunResult>
@@ -21,7 +21,7 @@ export class MockDatabase implements Database {
     source: string,
     ...params: SQLiteVariadicBindParams
   ): Promise<SQLiteRunResult>
-  runAsync(_source: unknown, _params?: unknown): Promise<SQLiteRunResult> {
+  runAsync(_source: string, _params?: unknown): Promise<SQLiteRunResult> {
     return Promise.resolve({
       lastInsertRowId: 0,
       changes: 0,

--- a/clients/typescript/src/drivers/expo-sqlite-next/mock.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/mock.ts
@@ -7,9 +7,6 @@ import {
 
 export class MockDatabase implements Database {
   constructor(public databaseName: string, public fail?: Error) {}
-  withTransactionAsync(task: () => Promise<void>): Promise<void> {
-    return task()
-  }
 
   getAllAsync<T>(source: string, params: SQLiteBindParams): Promise<T[]>
   getAllAsync<T>(

--- a/clients/typescript/src/drivers/expo-sqlite-next/mock.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/mock.ts
@@ -6,14 +6,18 @@ import {
 } from 'expo-sqlite/next'
 
 export class MockDatabase implements Database {
-  constructor(public databaseName: string) {}
+  constructor(public databaseName: string, public fail?: Error) {}
+  withTransactionAsync(task: () => Promise<void>): Promise<void> {
+    return task()
+  }
+
   getAllAsync<T>(source: string, params: SQLiteBindParams): Promise<T[]>
   getAllAsync<T>(
     source: string,
     ...params: SQLiteVariadicBindParams
   ): Promise<T[]>
   getAllAsync<T>(_source: string, _params?: unknown): Promise<T[]> {
-    return Promise.resolve([{ i: 0 } as T])
+    return this.resolveIfNotFail([{ i: 0 } as T])
   }
 
   runAsync(source: string, params: SQLiteBindParams): Promise<SQLiteRunResult>
@@ -22,9 +26,14 @@ export class MockDatabase implements Database {
     ...params: SQLiteVariadicBindParams
   ): Promise<SQLiteRunResult>
   runAsync(_source: string, _params?: unknown): Promise<SQLiteRunResult> {
-    return Promise.resolve({
+    return this.resolveIfNotFail({
       lastInsertRowId: 0,
       changes: 0,
     })
+  }
+
+  private resolveIfNotFail<T>(value: T): Promise<T> {
+    if (typeof this.fail !== 'undefined') return Promise.reject(this.fail)
+    else return Promise.resolve(value)
   }
 }

--- a/clients/typescript/src/drivers/expo-sqlite-next/test.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/test.ts
@@ -1,0 +1,87 @@
+// Safe entrypoint for tests that avoids importing the React Native
+// specific dependencies.
+import { DbName } from '../../util/types'
+
+import { ElectrifyOptions, electrify } from '../../electric/index'
+
+import { MockMigrator } from '../../migrators/mock'
+import { Notifier } from '../../notifiers/index'
+import { MockNotifier } from '../../notifiers/mock'
+import { MockRegistry } from '../../satellite/mock'
+
+import { DatabaseAdapter } from './adapter'
+import { Database } from './database'
+import { MockDatabase } from './mock'
+import { MockSocket } from '../../sockets/mock'
+import { ElectricConfig } from '../../config'
+import { ElectricClient } from '../../client/model/client'
+import { DbSchema } from '../../client/model'
+
+const testConfig = {
+  auth: {
+    token: 'test-token',
+  },
+}
+
+type RetVal<
+  S extends DbSchema<any>,
+  N extends Notifier,
+  D extends Database = Database
+> = Promise<[D, N, ElectricClient<S>]>
+
+export async function initTestable<
+  S extends DbSchema<any>,
+  N extends Notifier = MockNotifier
+>(name: DbName, dbDescription: S): RetVal<S, N, MockDatabase>
+export async function initTestable<
+  S extends DbSchema<any>,
+  N extends Notifier = MockNotifier
+>(
+  name: DbName,
+  dbDescription: S,
+  webSql: false,
+  config?: ElectricConfig,
+  opts?: ElectrifyOptions
+): RetVal<S, N, MockDatabase>
+export async function initTestable<
+  S extends DbSchema<any>,
+  N extends Notifier = MockNotifier
+>(
+  name: DbName,
+  dbDescription: S,
+  webSql: true,
+  config?: ElectricConfig,
+  opts?: ElectrifyOptions
+): RetVal<S, N, MockDatabase>
+export async function initTestable<
+  S extends DbSchema<any>,
+  N extends Notifier = MockNotifier
+>(
+  dbName: DbName,
+  dbDescription: S,
+  _useWebSQLDatabase = false,
+  config: ElectricConfig = testConfig,
+  opts?: ElectrifyOptions
+): RetVal<S, N> {
+  const db = new MockDatabase(dbName)
+
+  const adapter = opts?.adapter || new DatabaseAdapter(db)
+  const migrator = opts?.migrator || new MockMigrator()
+  const notifier = (opts?.notifier as N) || new MockNotifier(dbName)
+  const socketFactory = opts?.socketFactory || MockSocket
+  const registry = opts?.registry || new MockRegistry()
+
+  const dal = await electrify(
+    dbName,
+    dbDescription,
+    adapter,
+    socketFactory,
+    config,
+    {
+      notifier: notifier,
+      migrator: migrator,
+      registry: registry,
+    }
+  )
+  return [db, notifier, dal]
+}

--- a/clients/typescript/src/drivers/index.ts
+++ b/clients/typescript/src/drivers/index.ts
@@ -4,6 +4,8 @@ import { Database as CordovaSQLiteStorageDatabase } from './cordova-sqlite-stora
 
 import { Database as ExpoSQLiteDatabase } from './expo-sqlite/database'
 
+import { Database as ExpoSQLiteNextDatabase } from './expo-sqlite-next/database'
+
 import { Database as WASQLiteDatabase } from './wa-sqlite/database'
 
 import { Database as ReactNativeSQLiteStorageDatabase } from './react-native-sqlite-storage/database'
@@ -14,6 +16,7 @@ export type AnyDatabase =
   | BetterSQLite3Database
   | CordovaSQLiteStorageDatabase
   | ExpoSQLiteDatabase
+  | ExpoSQLiteNextDatabase
   | ReactNativeSQLiteStorageDatabase
   | WASQLiteDatabase
   | CapacitorSQLiteDatabase

--- a/clients/typescript/test/drivers/expo-next.test.ts
+++ b/clients/typescript/test/drivers/expo-next.test.ts
@@ -1,0 +1,35 @@
+import test from 'ava'
+
+import { MockDatabase } from '../../src/drivers/expo-sqlite-next/mock'
+import { DatabaseAdapter } from '../../src/drivers/expo-sqlite-next'
+import { QualifiedTablename } from '../../src/util'
+
+test('database adapter run works', async (t) => {
+  const db = new MockDatabase('test.db')
+  const adapter = new DatabaseAdapter(db)
+
+  const sql = 'drop table badgers'
+  const result = await adapter.run({ sql })
+
+  t.is(result.rowsAffected, 0)
+})
+
+test('database adapter query works', async (t) => {
+  const db = new MockDatabase('test.db')
+  const adapter = new DatabaseAdapter(db)
+
+  const sql = 'select foo from bars'
+  const result = await adapter.query({ sql })
+
+  t.deepEqual(result, [{ i: 0 }])
+})
+
+test('database adapter tableNames works', async (t) => {
+  const db = new MockDatabase('test.db')
+  const adapter = new DatabaseAdapter(db)
+
+  const sql = 'select foo from bar'
+  const r1 = adapter.tableNames({ sql })
+
+  t.deepEqual(r1, [new QualifiedTablename('main', 'bar')])
+})

--- a/clients/typescript/test/drivers/expo-next.test.ts
+++ b/clients/typescript/test/drivers/expo-next.test.ts
@@ -2,7 +2,6 @@ import test from 'ava'
 
 import { MockDatabase } from '../../src/drivers/expo-sqlite-next/mock'
 import { DatabaseAdapter } from '../../src/drivers/expo-sqlite-next'
-import { QualifiedTablename } from '../../src/util'
 
 test('database adapter run works', async (t) => {
   const db = new MockDatabase('test.db')
@@ -15,21 +14,90 @@ test('database adapter run works', async (t) => {
 })
 
 test('database adapter query works', async (t) => {
-  const db = new MockDatabase('test.db')
+  const dbName = 'test.db'
+  const db = new MockDatabase(dbName)
   const adapter = new DatabaseAdapter(db)
 
-  const sql = 'select foo from bars'
+  const sql = 'select * from bars;'
   const result = await adapter.query({ sql })
 
   t.deepEqual(result, [{ i: 0 }])
 })
 
-test('database adapter tableNames works', async (t) => {
+test('database adapter runInTransaction works', async (t) => {
   const db = new MockDatabase('test.db')
   const adapter = new DatabaseAdapter(db)
 
-  const sql = 'select foo from bar'
-  const r1 = adapter.tableNames({ sql })
+  const sql = 'select * from bars'
+  const res = await adapter.runInTransaction({ sql }, { sql }, { sql })
 
-  t.deepEqual(r1, [new QualifiedTablename('main', 'bar')])
+  t.assert(res.rowsAffected == 0)
+})
+
+test('database adapter interactive transaction works', async (t) => {
+  const dbName = 'test.db'
+  const db = new MockDatabase(dbName)
+  const adapter = new DatabaseAdapter(db)
+
+  const sql = 'select * from bars;'
+  const res = await adapter.transaction<number>((tx, setResult) => {
+    tx.run({ sql }, (tx, res) => {
+      t.assert(res.rowsAffected == 0)
+      tx.query({ sql }, (_tx, res) => {
+        t.deepEqual(res, [{ i: 0 }])
+
+        setResult(5)
+      })
+    })
+  })
+
+  t.assert(res == 5)
+})
+
+test('database adapter run, query, runInTransaction reject promise on failure', async (t) => {
+  const err = new Error('Test failure')
+  const db = new MockDatabase('test.db', err)
+  const adapter = new DatabaseAdapter(db)
+
+  const sql = 'select * from bars'
+
+  const assertFailure = async (prom: Promise<any>) => {
+    await t.throwsAsync(prom, { instanceOf: Error, message: err.message })
+  }
+
+  await assertFailure(adapter.run({ sql }))
+  await assertFailure(adapter.query({ sql }))
+  await assertFailure(adapter.runInTransaction({ sql }, { sql }))
+})
+
+test('database adapter transaction rejects promise on failure', async (t) => {
+  const err = new Error('Test failure')
+  const db = new MockDatabase('test.db', err)
+  const adapter = new DatabaseAdapter(db)
+
+  const sql = 'select * from bars'
+
+  const assertFailure = async (prom: Promise<any>) => {
+    await t.throwsAsync(prom, { instanceOf: Error, message: err.message })
+  }
+
+  await assertFailure(
+    adapter.transaction((tx, setResult) => {
+      tx.run({ sql }, () => {
+        setResult(5)
+      })
+    })
+  )
+})
+
+test('database adapter interactive transaction rejects promise on failure', async (t) => {
+  const db = new MockDatabase('test.db')
+  const adapter = new DatabaseAdapter(db)
+
+  await t.throwsAsync(
+    adapter.transaction((_tx, _setResult) => {
+      throw Error('Oops')
+    }),
+    { instanceOf: Error, message: 'Oops' }
+  )
 })

--- a/docs/integrations/drivers/mobile/expo.md
+++ b/docs/integrations/drivers/mobile/expo.md
@@ -3,7 +3,7 @@ title: Expo
 sidebar_position: 10
 ---
 
-ElectricSQL supports [Expo](https://expo.dev) via both [expo-sqlite](https://docs.expo.dev/versions/latest/sdk/sqlite/) and [expo-sqlite/next](https://docs.expo.dev/versions/latest/sdk/sqlite-next/).
+ElectricSQL supports [Expo](https://expo.dev) via [expo-sqlite](https://docs.expo.dev/versions/latest/sdk/sqlite/).
 
 ## Dependencies
 
@@ -13,13 +13,13 @@ Add `expo-sqlite` as a dependency to your app, e.g.:
 npx expo install expo-sqlite
 ```
 
-This package includes both the regular and `next` drivers. See the [expo-sqlite docs](https://docs.expo.dev/versions/latest/sdk/sqlite/) or [expo-sqlite/next docs](https://docs.expo.dev/versions/latest/sdk/sqlite-next/) for more information.
+See the [expo-sql docs](https://docs.expo.dev/versions/latest/sdk/sqlite/) for more information.
 
 ## Usage
 
 ```tsx
-import * as SQLite from 'expo-sqlite' // or 'expo-sqlite/next'
-import { electrify } from 'electric-sql/expo' // or 'electric-sql/expo-next' 
+import * as SQLite from 'expo-sqlite'
+import { electrify } from 'electric-sql/expo'
 
 // Import your generated database schema.
 import { schema } from './generated/client'
@@ -35,8 +35,6 @@ const config = {
 // Create the expo-sqlite database connection. The first argument
 // is your database name. Changing this will create/use a new
 // local database file.
-//
-// When using expo-sqlite/next, use SQLite.openDatabaseSync('electric.db')
 const conn = SQLite.openDatabase('electric.db')
 
 // Instantiate your electric client.

--- a/docs/integrations/drivers/mobile/expo.md
+++ b/docs/integrations/drivers/mobile/expo.md
@@ -3,7 +3,7 @@ title: Expo
 sidebar_position: 10
 ---
 
-ElectricSQL supports [Expo](https://expo.dev) via [expo-sqlite](https://docs.expo.dev/versions/latest/sdk/sqlite/).
+ElectricSQL supports [Expo](https://expo.dev) via both [expo-sqlite](https://docs.expo.dev/versions/latest/sdk/sqlite/) and [expo-sqlite/next](https://docs.expo.dev/versions/latest/sdk/sqlite-next/).
 
 ## Dependencies
 
@@ -13,13 +13,13 @@ Add `expo-sqlite` as a dependency to your app, e.g.:
 npx expo install expo-sqlite
 ```
 
-See the [expo-sql docs](https://docs.expo.dev/versions/latest/sdk/sqlite/) for more information.
+This package includes both the regular and `next` drivers. See the [expo-sqlite docs](https://docs.expo.dev/versions/latest/sdk/sqlite/) or [expo-sqlite/next docs](https://docs.expo.dev/versions/latest/sdk/sqlite-next/) for more information.
 
 ## Usage
 
 ```tsx
-import * as SQLite from 'expo-sqlite'
-import { electrify } from 'electric-sql/expo'
+import * as SQLite from 'expo-sqlite' // or 'expo-sqlite/next'
+import { electrify } from 'electric-sql/expo' // or 'electric-sql/expo-next' 
 
 // Import your generated database schema.
 import { schema } from './generated/client'
@@ -35,6 +35,8 @@ const config = {
 // Create the expo-sqlite database connection. The first argument
 // is your database name. Changing this will create/use a new
 // local database file.
+//
+// When using expo-sqlite/next, use SQLite.openDatabaseSync('electric.db')
 const conn = SQLite.openDatabase('electric.db')
 
 // Instantiate your electric client.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,8 +220,8 @@ importers:
         specifier: ^8.22.0
         version: 8.41.0
       expo-sqlite:
-        specifier: ^11.7.0
-        version: 11.7.0(expo@48.0.19)
+        specifier: ^13.0.0
+        version: 13.2.1(expo@48.0.19)
       glob:
         specifier: ^10.3.10
         version: 10.3.10
@@ -8026,8 +8026,8 @@ packages:
       invariant: 2.2.4
     dev: true
 
-  /expo-sqlite@11.7.0(expo@48.0.19):
-    resolution: {integrity: sha512-z/YudIROUJFO46TWCyEqrWH31o17xMO0ALEobsIovBk6oM/HZmWXUdEKJeWvrdM1fBvoBZ8mVa//n3B5qBLdtQ==}
+  /expo-sqlite@13.2.1(expo@48.0.19):
+    resolution: {integrity: sha512-wYPCXygwRIDlU7qkqVCW78ExVk5lBRipZwfVyHpjNWPldt3U2ijvHvRtu+24eL7Xij1HS7R3yAuSLu4ZkPc4MA==}
     peerDependencies:
       expo: '*'
     dependencies:


### PR DESCRIPTION
Adds the [expo-sqlite (next)](https://docs.expo.dev/versions/latest/sdk/sqlite-next/) driver on top of the regular one.

I can update the docs as well but I was unsure if we wanted it as a separate entry to the regular Expo one or if I should just add an additional section for using `next` instead of the regular one.

Also, is there a process/tooling in place for us to do a proper test for some of these drivers (e.g. spin up android/ios machines in CI and run basic e2e tests) to ensure they work?