### PR TITLE
fix(cli): Move most of the electric service definition into compose.yaml

### DIFF
--- a/clients/typescript/src/cli/docker-commands/docker/compose-base.yaml
+++ b/clients/typescript/src/cli/docker-commands/docker/compose-base.yaml
@@ -2,27 +2,7 @@ version: '3.8'
 
 services:
   electric-no-postgres:
-    image: '${ELECTRIC_IMAGE:-electricsql/electric:latest}'
     init: true
-    ports:
-      - ${HTTP_PORT:-5133}:${HTTP_PORT:-5133}
-      - ${PG_PROXY_PORT_PARSED:-65432}:${PG_PROXY_PORT_PARSED:-65432}
-    environment:
-      DATABASE_REQUIRE_SSL: ${DATABASE_REQUIRE_SSL:-}
-      DATABASE_URL: ${DATABASE_URL:-}
-      DATABASE_USE_IPV6: ${DATABASE_USE_IPV6:-}
-      ELECTRIC_USE_IPV6: ${ELECTRIC_USE_IPV6:-}
-      HTTP_PORT: ${HTTP_PORT:-5133}
-      LOGICAL_PUBLISHER_HOST: ${LOGICAL_PUBLISHER_HOST:-}
-      LOGICAL_PUBLISHER_PORT: ${LOGICAL_PUBLISHER_PORT:-5433}
-      PG_PROXY_PASSWORD: ${PG_PROXY_PASSWORD:-proxy_password}
-      PG_PROXY_PORT: ${PG_PROXY_PORT:-65432}
-      AUTH_MODE: ${AUTH_MODE:-insecure}
-      AUTH_JWT_ALG: ${AUTH_JWT_ALG:-}
-      AUTH_JWT_AUD: ${AUTH_JWT_AUD:-}
-      AUTH_JWT_ISS: ${AUTH_JWT_ISS:-}
-      AUTH_JWT_KEY: ${AUTH_JWT_KEY:-}
-      AUTH_JWT_NAMESPACE: ${AUTH_JWT_NAMESPACE:-}
 
   electric-with-postgres:
     extends:

--- a/clients/typescript/src/cli/docker-commands/docker/compose.yaml
+++ b/clients/typescript/src/cli/docker-commands/docker/compose.yaml
@@ -40,3 +40,23 @@ services:
     extends:
       file: compose-base.yaml
       service: ${COMPOSE_ELECTRIC_SERVICE:-electric-no-postgres}
+    image: '${ELECTRIC_IMAGE:-electricsql/electric:latest}'
+    ports:
+      - ${HTTP_PORT:-5133}:${HTTP_PORT:-5133}
+      - ${PG_PROXY_PORT_PARSED:-65432}:${PG_PROXY_PORT_PARSED:-65432}
+    environment:
+      DATABASE_REQUIRE_SSL: ${DATABASE_REQUIRE_SSL:-}
+      DATABASE_URL: ${DATABASE_URL:-}
+      DATABASE_USE_IPV6: ${DATABASE_USE_IPV6:-}
+      ELECTRIC_USE_IPV6: ${ELECTRIC_USE_IPV6:-}
+      HTTP_PORT: ${HTTP_PORT:-5133}
+      LOGICAL_PUBLISHER_HOST: ${LOGICAL_PUBLISHER_HOST:-}
+      LOGICAL_PUBLISHER_PORT: ${LOGICAL_PUBLISHER_PORT:-5433}
+      PG_PROXY_PASSWORD: ${PG_PROXY_PASSWORD:-proxy_password}
+      PG_PROXY_PORT: ${PG_PROXY_PORT:-65432}
+      AUTH_MODE: ${AUTH_MODE:-insecure}
+      AUTH_JWT_ALG: ${AUTH_JWT_ALG:-}
+      AUTH_JWT_AUD: ${AUTH_JWT_AUD:-}
+      AUTH_JWT_ISS: ${AUTH_JWT_ISS:-}
+      AUTH_JWT_KEY: ${AUTH_JWT_KEY:-}
+      AUTH_JWT_NAMESPACE: ${AUTH_JWT_NAMESPACE:-}


### PR DESCRIPTION
Fixes VAX-1557.

Trying to run the `start` command was failing with an error from Docker Compose on my machine:
```
$ npx electric-sql start --with-postgres
Starting ElectricSQL sync service with PostgreSQL
Docker compose config: {
[...]
}
service ports services.electric.ports.[0] is missing a target port
```

I traced it to a bug in the latest version of Docker Compose which I had installed - https://github.com/docker/compose/issues/11378.

Now, the upstream issue is slated to be resolved in the next release. But to avoid relying on an upstream fix getting applied to people's installations of Docker Compose and to ensure a smooth onboarding experience for our users, I've created this workaround that moves all service-level definitions that include environment variable interpolation from `compose-base.yaml` to `compose.yaml`.