### PR TITLE
fix(cli) Split inferred values from default values - Fixes VAX-1569

### DIFF
--- a/.changeset/gold-horses-crash.md
+++ b/.changeset/gold-horses-crash.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+CLI - Split inferred values from default values (VAX-1569)

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -1,7 +1,8 @@
 import path from 'path'
 import {
-  defaultDbUrlPart,
-  defaultServiceUrlPart,
+  inferDbUrlPart,
+  inferProxyUrlPart,
+  inferServiceUrlPart,
   getConfigValue,
   type ConfigMap,
 } from './config'
@@ -59,7 +60,8 @@ export const configOptions = {
     valueTypeName: 'hostname',
     doc: 'Hostname the Electric service is running on.',
     groups: ['client', 'proxy'],
-    defaultVal: () => defaultServiceUrlPart('host', 'localhost'),
+    inferVal: (options: ConfigMap) => inferServiceUrlPart('host', options),
+    defaultVal: 'localhost',
   },
   PG_PROXY_HOST: {
     valueType: String,
@@ -71,6 +73,7 @@ export const configOptions = {
       If using the proxy-tunnel, this should be the hostname of the tunnel.
     `,
     groups: ['client', 'proxy'],
+    inferVal: (options: ConfigMap) => inferProxyUrlPart('host', options),
     defaultVal: (options: ConfigMap) => getConfigValue('SERVICE_HOST', options),
   },
   MODULE_RESOLUTION: {
@@ -111,31 +114,36 @@ export const configOptions = {
   DATABASE_HOST: {
     doc: 'Hostname of the database server.',
     valueType: String,
-    defaultVal: () => defaultDbUrlPart('host', 'localhost'),
+    inferVal: (options: ConfigMap) => inferDbUrlPart('host', options),
+    defaultVal: 'localhost',
     groups: ['database'],
   },
   DATABASE_PORT: {
     doc: 'Port number of the database server.',
     valueType: Number,
-    defaultVal: () => defaultDbUrlPart('port', 5432),
+    inferVal: (options: ConfigMap) => inferDbUrlPart('port', options),
+    defaultVal: 5432,
     groups: ['database'],
   },
   DATABASE_USER: {
     doc: 'Username to connect to the database with.',
     valueType: String,
-    defaultVal: () => defaultDbUrlPart('user', 'postgres'),
+    inferVal: (options: ConfigMap) => inferDbUrlPart('user', options),
+    defaultVal: 'postgres',
     groups: ['database'],
   },
   DATABASE_PASSWORD: {
     doc: 'Password to connect to the database with.',
     valueType: String,
-    defaultVal: () => defaultDbUrlPart('password', 'db_password'),
+    inferVal: (options: ConfigMap) => inferDbUrlPart('password', options),
+    defaultVal: 'db_password',
     groups: ['database'],
   },
   DATABASE_NAME: {
     doc: 'Name of the database to connect to.',
     valueType: String,
-    defaultVal: () => defaultDbUrlPart('dbName', getAppName() ?? 'electric'),
+    inferVal: (options: ConfigMap) => inferDbUrlPart('dbName', options),
+    defaultVal: () => getAppName() ?? 'electric',
     groups: ['database', 'client', 'proxy'],
   },
 
@@ -179,7 +187,8 @@ export const configOptions = {
     groups: ['electric'],
   },
   HTTP_PORT: {
-    defaultVal: () => defaultServiceUrlPart('port', 5133),
+    inferVal: (options: ConfigMap) => inferServiceUrlPart('port', options),
+    defaultVal: '5133',
     valueType: Number,
     valueTypeName: 'port',
     doc: dedent`
@@ -189,13 +198,15 @@ export const configOptions = {
     groups: ['electric', 'client'],
   },
   PG_PROXY_PORT: {
-    defaultVal: '65432',
+    inferVal: (options: ConfigMap) => inferProxyUrlPart('port', options),
+    defaultVal: 65432,
     valueType: String,
     valueTypeName: 'port',
     doc: 'Port number for connections to the Postgres migration proxy.',
     groups: ['electric', 'client', 'proxy'],
   },
   PG_PROXY_PASSWORD: {
+    inferVal: (options: ConfigMap) => inferProxyUrlPart('password', options),
     defaultVal: 'proxy_password',
     valueType: String,
     valueTypeName: 'password',

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -199,7 +199,7 @@ export const configOptions = {
   },
   PG_PROXY_PORT: {
     inferVal: (options: ConfigMap) => inferProxyUrlPart('port', options),
-    defaultVal: 65432,
+    defaultVal: '65432',
     valueType: String,
     valueTypeName: 'port',
     doc: 'Port number for connections to the Postgres migration proxy.',

--- a/clients/typescript/src/cli/utils.ts
+++ b/clients/typescript/src/cli/utils.ts
@@ -127,8 +127,10 @@ export function extractServiceURL(serviceUrl: string) {
   }
 }
 
-export function parsePgProxyPort(str: string) {
-  if (str.includes(':')) {
+export function parsePgProxyPort(str: string | number) {
+  if (typeof str === 'number') {
+    return { http: false, port: str }
+  } else if (str.includes(':')) {
     const [prefix, port] = str.split(':')
     return {
       http: prefix.toLocaleLowerCase() === 'http',


### PR DESCRIPTION
This splits inferring config values from defaults.

This fixes VAX-1569 (#871), the bug was due to the proxy url being constructed from it's parts, but the parts were not inferred from command line args, only env vars.