### PR TITLE
fix(cli) Silent dot-env warning when there are no .env files

### DIFF
--- a/.changeset/stale-taxis-protect.md
+++ b/.changeset/stale-taxis-protect.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+CLI - Silent dot-env warning when there are no .env files

--- a/clients/typescript/src/cli/main.ts
+++ b/clients/typescript/src/cli/main.ts
@@ -2,7 +2,7 @@
 
 import dotenvFlow from 'dotenv-flow'
 dotenvFlow.config({
-  silent: true
+  silent: true,
 })
 
 import { Command } from 'commander'

--- a/clients/typescript/src/cli/main.ts
+++ b/clients/typescript/src/cli/main.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import dotenvFlow from 'dotenv-flow'
-dotenvFlow.config()
+dotenvFlow.config({
+  silent: true
+})
 
 import { Command } from 'commander'
 import { LIB_VERSION } from '../version/index'


### PR DESCRIPTION
Fixes #870 (VAX-1568)