### PR TITLE
chore (examples): update expo-sqlite dependency in expo example app

### DIFF
--- a/examples/expo/package.json
+++ b/examples/expo/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "electric-sql": "^0.7.0",
     "expo": "~49.0.8",
-    "expo-sqlite": "~11.3.3",
+    "expo-sqlite": ">= 11.7.0",
     "expo-status-bar": "~1.6.0",
     "react": "^18.2.0",
     "react-native": "0.72.6",


### PR DESCRIPTION
This PR updates the `expo-sqlite` dependency in the expo example app to be `>= 11.7.0` which is the minimal version that is needed in order for `RETURNING` clauses to work on Android.