### PR TITLE
fix typo: "cloud-first" instead of "client-first"

### DIFF
--- a/examples/introduction/src/demos/local-first/instant.jsx
+++ b/examples/introduction/src/demos/local-first/instant.jsx
@@ -80,7 +80,7 @@ const LocalFirst = () => {
   )
 }
 
-// The client-first component talks to the backend using an API client and
+// The cloud-first component talks to the backend using an API client and
 // manually updates the local state (if the request is successful).
 const CloudFirst = () => {
   const { demo } = useDemoContext()


### PR DESCRIPTION
I think you meant to write "cloud-first" since this is the local- vs cloud-first intro.