### PR TITLE
fix (client): clear all subscriptions from the DB in 1 transaction

### DIFF
--- a/.changeset/hot-phones-wash.md
+++ b/.changeset/hot-phones-wash.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix clearing local state to avoid FK violations.

--- a/clients/typescript/src/satellite/shapes/index.ts
+++ b/clients/typescript/src/satellite/shapes/index.ts
@@ -53,10 +53,12 @@ export interface SubscriptionsManager {
   ): null | { inFlight: string } | { fulfilled: string }
 
   /**
-   * Deletes the subscription from the manager.
-   * @param subId the identifier of the subscription
+   * Deletes the subscription(s) from the manager.
+   * @param subId the identifier of the subscription or an array of subscription identifiers
    */
-  unsubscribe(subId: string): Promise<void>
+  unsubscribe(
+    subId: SubscriptionId | SubscriptionId[]
+  ): Promise<SubscriptionId[]>
 
   /**
    * Deletes all subscriptions from the manager. Useful to


### PR DESCRIPTION
When a client reconnects to Electric and can't resume it resets its local state (i.e. unsubscribes all subscriptions) and starts from scratch. Currently, we unsubscribe subscription per subscription. For each subscription, we delete the contents of the shapes from the DB. However, this can lead to FK violations. e.g.:

- Table User
- Table Post has a FK to user
- Subscription 1 subscribes to user table
- Subscription 2 subscribes to post and user table

When clearing all subscriptions, if we first unsubscribe from subscription 1, we are deleting the contents of the user table and thereby violating any FKs that are in the post table.

This PR avoids this problem by clearing all subscriptions within a single database transaction that defers the foreign keys until the end of the transaction. Also introduced a unit test that reproduces the FK violation and is gone with this fix.