### PR TITLE
fix(electric): Include Server Name Indication in database connection SSL options

### DIFF
--- a/components/electric/lib/electric/replication/postgres_manager.ex
+++ b/components/electric/lib/electric/replication/postgres_manager.ex
@@ -276,6 +276,7 @@ defmodule Electric.Replication.PostgresConnectorMng do
       conn_opts
       |> Keyword.put(:nulls, [nil, :null, :undefined])
       |> Keyword.put(:ip_addr, ip_addr)
+      |> maybe_put_sni()
       |> maybe_put_inet6(ip_addr)
     end)
   end
@@ -284,6 +285,15 @@ defmodule Electric.Replication.PostgresConnectorMng do
     do: Keyword.put(conn_opts, :tcp_opts, [:inet6])
 
   defp maybe_put_inet6(conn_opts, _), do: conn_opts
+
+  defp maybe_put_sni(conn_opts) do
+    if conn_opts[:ssl] do
+      sni_opt = {:server_name_indication, String.to_charlist(conn_opts[:host])}
+      update_in(conn_opts, [:ssl_opts], &[sni_opt | List.wrap(&1)])
+    else
+      conn_opts
+    end
+  end
 
   # Perform a DNS lookup for an IPv6 IP address, followed by a lookup for an IPv4 address in case the first one fails.
   #

--- a/components/electric/lib/electric/replication/postgres_manager.ex
+++ b/components/electric/lib/electric/replication/postgres_manager.ex
@@ -276,14 +276,14 @@ defmodule Electric.Replication.PostgresConnectorMng do
       conn_opts
       |> Keyword.put(:nulls, [nil, :null, :undefined])
       |> Keyword.put(:ip_addr, ip_addr)
-      |> maybe_add_inet6(ip_addr)
+      |> maybe_put_inet6(ip_addr)
     end)
   end
 
-  defp maybe_add_inet6(conn_opts, {_, _, _, _, _, _, _, _}),
+  defp maybe_put_inet6(conn_opts, {_, _, _, _, _, _, _, _}),
     do: Keyword.put(conn_opts, :tcp_opts, [:inet6])
 
-  defp maybe_add_inet6(conn_opts, _), do: conn_opts
+  defp maybe_put_inet6(conn_opts, _), do: conn_opts
 
   # Perform a DNS lookup for an IPv6 IP address, followed by a lookup for an IPv4 address in case the first one fails.
   #

--- a/components/electric/lib/electric/utils.ex
+++ b/components/electric/lib/electric/utils.ex
@@ -203,19 +203,4 @@ defmodule Electric.Utils do
   def inspect_relation({schema, name}) do
     "#{inspect(schema)}.#{inspect(name)}"
   end
-
-  def epgsql_config(config) do
-    config
-    |> Map.new()
-    |> Map.put(:nulls, [nil, :null, :undefined])
-    |> maybe_add_inet6()
-  end
-
-  defp maybe_add_inet6(config) do
-    with %{ipv6: true} <- config do
-      config
-      |> Map.delete(:ipv6)
-      |> Map.put(:tcp_opts, [:inet6])
-    end
-  end
 end


### PR DESCRIPTION
Fixes VAX-1457.