### PR TITLE
chore(electric): Docker-related cleanups

### DIFF
--- a/clients/typescript/src/cli/docker-commands/docker/compose-base.yaml
+++ b/clients/typescript/src/cli/docker-commands/docker/compose-base.yaml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   electric-no-postgres:
     init: true
+    stop_signal: SIGINT # use SIGINT as the more speedy alternative to SIGTERM
 
   electric-with-postgres:
     extends:

--- a/components/electric/dev/compose.yaml
+++ b/components/electric/dev/compose.yaml
@@ -16,6 +16,5 @@ services:
       - docker-entrypoint.sh
       - -c
       - config_file=/etc/postgresql.conf
-    privileged: true
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/e2e/services_templates.yaml
+++ b/e2e/services_templates.yaml
@@ -10,7 +10,6 @@ services:
       PG_PROXY_PORT:
       ELECTRIC_FEATURES:
     init: true
-    privileged: true
 
   sysbench:
     image: "${SYSBENCH_IMAGE}"
@@ -36,7 +35,6 @@ services:
       - config_file=/etc/postgresql.conf
     cap_add:
       - SYS_PTRACE
-    privileged: true
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U electric"]
     extra_hosts:
@@ -53,9 +51,7 @@ services:
       NODE_REPL_HISTORY: ""
     tmpfs:
       - /var/lib/satellite/data
-    privileged: true
 
   elixir_client:
     image: ${ELECTRIC_CLIENT_IMAGE}
     command: start_iex
-    privileged: true

--- a/e2e/services_templates.yaml
+++ b/e2e/services_templates.yaml
@@ -10,6 +10,7 @@ services:
       PG_PROXY_PORT:
       ELECTRIC_FEATURES:
     init: true
+    stop_signal: SIGINT  # use SIGINT as the more speedy alternative to SIGTERM
 
   sysbench:
     image: "${SYSBENCH_IMAGE}"


### PR DESCRIPTION
This PR makes two changes:
* remove `privileged: true` from services defined in several `compose.yaml` files
* use `SIGINT` as the default stop signal for the Electric service. This results in faster shutdown after pressing Ctrl-C or stopping all services with `docker compose stop/down`.