### PR TITLE
fix(electric): Support JWTs without a trailing dot in Insecure mode

### DIFF
--- a/.changeset/shaggy-planes-bake.md
+++ b/.changeset/shaggy-planes-bake.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Support JWTs without a trailing dot in the Insecure auth mode. (#900)

--- a/components/electric/lib/electric/satellite/auth/jwt_util.ex
+++ b/components/electric/lib/electric/satellite/auth/jwt_util.ex
@@ -101,9 +101,19 @@ defmodule Electric.Satellite.Auth.JWTUtil do
   @doc false
   def peek_claims(token) do
     try do
-      Joken.peek_claims(token)
+      token
+      |> maybe_add_trailing_dot()
+      |> Joken.peek_claims()
     rescue
       Jason.DecodeError -> {:error, :token_malformed}
+    end
+  end
+
+  defp maybe_add_trailing_dot(token) do
+    case :binary.split(token, ".", [:global]) do
+      [_header, _payload] -> token <> "."
+      [_header, _payload, _signature] -> token
+      _ -> raise Jason.DecodeError
     end
   end
 

--- a/components/electric/test/electric/satellite/auth/insecure_test.exs
+++ b/components/electric/test/electric/satellite/auth/insecure_test.exs
@@ -91,11 +91,6 @@ defmodule Electric.Satellite.Auth.InsecureTest do
     end
 
     defp unsigned_token(claims, opts \\ []) do
-      # With yajwt it was possible to simply call
-      #
-      #     JWT.sign(claims, %{alg: "none"})
-      #
-      # But Joken does not support the "none" signing algorithm. Hence the manual encoding.
       header = encode_part(%{typ: "JWT", alg: "none"})
       payload = encode_part(claims)
 

--- a/components/electric/test/electric/satellite/auth/insecure_test.exs
+++ b/components/electric/test/electric/satellite/auth/insecure_test.exs
@@ -36,6 +36,11 @@ defmodule Electric.Satellite.Auth.InsecureTest do
       claims = %{"user_id" => "0"}
       token = unsigned_token(claims)
       assert {:ok, %Auth{user_id: "0"}} == validate_token(token, config([]))
+
+      ###
+
+      token = unsigned_token(claims, trailing_dot: false)
+      assert {:ok, %Auth{user_id: "0"}} == validate_token(token, config([]))
     end
 
     test "successfully extracts the namespaced user_id claim" do
@@ -85,7 +90,7 @@ defmodule Electric.Satellite.Auth.InsecureTest do
       end
     end
 
-    defp unsigned_token(claims) do
+    defp unsigned_token(claims, opts \\ []) do
       # With yajwt it was possible to simply call
       #
       #     JWT.sign(claims, %{alg: "none"})
@@ -93,7 +98,15 @@ defmodule Electric.Satellite.Auth.InsecureTest do
       # But Joken does not support the "none" signing algorithm. Hence the manual encoding.
       header = encode_part(%{typ: "JWT", alg: "none"})
       payload = encode_part(claims)
-      header <> "." <> payload <> "."
+
+      signature =
+        if Keyword.get(opts, :trailing_dot, true) do
+          "."
+        else
+          ""
+        end
+
+      header <> "." <> payload <> signature
     end
 
     defp encode_part(map) do


### PR DESCRIPTION
Fixes #900.