### PR TITLE
feat (client): modified shapes to adhere to new protocol format

### DIFF
--- a/clients/typescript/src/client/input/syncInput.ts
+++ b/clients/typescript/src/client/input/syncInput.ts
@@ -1,3 +1,4 @@
-export interface SyncInput<Include> {
+export interface SyncInput<Include, Where> {
   include?: Include
+  where?: Where
 }

--- a/clients/typescript/src/client/model/model.ts
+++ b/clients/typescript/src/client/model/model.ts
@@ -24,7 +24,7 @@ export interface Model<
   ScalarFieldEnum,
   GetPayload extends HKT
 > {
-  sync<T extends SyncInput<Include>>(i?: T): Promise<ShapeSubscription>
+  sync<T extends SyncInput<Include, Where>>(i?: T): Promise<ShapeSubscription>
 
   /**
    * Creates a unique record in the DB.

--- a/clients/typescript/src/client/model/schema.ts
+++ b/clients/typescript/src/client/model/schema.ts
@@ -203,6 +203,18 @@ export class DbSchema<T extends TableSchemas> {
     return relation.relatedTable
   }
 
+  getForeignKey(table: TableName, field: FieldName): FieldName {
+    const relationName = this.getRelationName(table, field)
+    const relation = this.getRelation(table, relationName)
+    if (relation.isOutgoingRelation()) {
+      return relation.fromField
+    }
+    // it's an incoming relation
+    // we need to fetch the `fromField` from the outgoing relation
+    const oppositeRelation = relation.getOppositeRelation(this)
+    return oppositeRelation.fromField
+  }
+
   // Profile.post <-> Post.profile (from: profileId, to: id)
   getRelations(table: TableName): Relation[] {
     return this.extendedTables[table].relations

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -18,7 +18,7 @@ import {
   OutboundStartedCallback,
 } from '../util/types'
 import {
-  ClientShapeDefinition,
+  Shape,
   ShapeRequest,
   SubscribeResponse,
   SubscriptionDeliveredCallback,
@@ -69,9 +69,7 @@ export interface Satellite {
 
   start(authConfig: AuthConfig): Promise<ConnectionWrapper>
   stop(shutdown?: boolean): Promise<void>
-  subscribe(
-    shapeDefinitions: ClientShapeDefinition[]
-  ): Promise<ShapeSubscription>
+  subscribe(shapeDefinitions: Shape[]): Promise<ShapeSubscription>
   unsubscribe(shapeUuid: string): Promise<void>
 }
 

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -33,7 +33,7 @@ import {
 import { bytesToNumber, uuid } from '../util/common'
 import { generateTag } from './oplog'
 import {
-  ClientShapeDefinition,
+  Shape,
   InitialDataChange,
   SUBSCRIPTION_DELIVERED,
   SUBSCRIPTION_ERROR,
@@ -79,9 +79,7 @@ export class MockSatelliteProcess implements Satellite {
     this.socketFactory = socketFactory
     this.opts = opts
   }
-  subscribe(
-    _shapeDefinitions: ClientShapeDefinition[]
-  ): Promise<ShapeSubscription> {
+  subscribe(_shapeDefinitions: Shape[]): Promise<ShapeSubscription> {
     return Promise.resolve({
       synced: Promise.resolve(),
     })
@@ -196,32 +194,31 @@ export class MockSatelliteClient
     const shapeReqToUuid: Record<string, string> = {}
 
     for (const shape of shapes) {
-      for (const { tablename } of shape.definition.selects) {
-        if (tablename === 'failure' || tablename === 'Items') {
-          return Promise.resolve({
+      const { tablename } = shape.definition
+      if (tablename === 'failure' || tablename === 'Items') {
+        return Promise.resolve({
+          subscriptionId,
+          error: new SatelliteError(SatelliteErrorCode.TABLE_NOT_FOUND),
+        })
+      }
+      if (tablename === 'another' || tablename === 'User') {
+        return new Promise((resolve) => {
+          this.sendErrorAfterTimeout(subscriptionId, 1)
+          resolve({
             subscriptionId,
-            error: new SatelliteError(SatelliteErrorCode.TABLE_NOT_FOUND),
           })
-        }
-        if (tablename === 'another' || tablename === 'User') {
-          return new Promise((resolve) => {
-            this.sendErrorAfterTimeout(subscriptionId, 1)
-            resolve({
-              subscriptionId,
-            })
-          })
-        } else {
-          shapeReqToUuid[shape.requestId] = uuid()
-          const records: DataRecord[] = this.relationData[tablename] ?? []
+        })
+      } else {
+        shapeReqToUuid[shape.requestId] = uuid()
+        const records: DataRecord[] = this.relationData[tablename] ?? []
 
-          for (const record of records) {
-            const dataChange: InitialDataChange = {
-              relation: this.relations[tablename],
-              record,
-              tags: [generateTag('remote', new Date())],
-            }
-            data.push(dataChange)
+        for (const record of records) {
+          const dataChange: InitialDataChange = {
+            relation: this.relations[tablename],
+            record,
+            tags: [generateTag('remote', new Date())],
           }
+          data.push(dataChange)
         }
       }
     }

--- a/clients/typescript/src/satellite/shapes/index.ts
+++ b/clients/typescript/src/satellite/shapes/index.ts
@@ -1,5 +1,5 @@
 import {
-  ClientShapeDefinition,
+  Shape,
   ShapeDefinition,
   ShapeRequest,
   SubscriptionData,
@@ -49,7 +49,7 @@ export interface SubscriptionsManager {
    * @param shapes Shapes for a potential request
    */
   getDuplicatingSubscription(
-    shapes: ClientShapeDefinition[]
+    shapes: Shape[]
   ): null | { inFlight: string } | { fulfilled: string }
 
   /**

--- a/clients/typescript/src/satellite/shapes/manager.ts
+++ b/clients/typescript/src/satellite/shapes/manager.ts
@@ -2,7 +2,7 @@ import { SatelliteError, SatelliteErrorCode } from '../../util/types'
 
 import EventEmitter from 'events'
 import {
-  ClientShapeDefinition,
+  Shape,
   ShapeDefinition,
   ShapeRequest,
   ShapeRequestOrDefinition,
@@ -96,7 +96,7 @@ export class InMemorySubscriptionsManager
   }
 
   getDuplicatingSubscription(
-    shapes: ClientShapeDefinition[]
+    shapes: Shape[]
   ): null | { inFlight: string } | { fulfilled: string } {
     const subId = this.shapeRequestHashmap.get(computeClientDefsHash(shapes))
     if (subId) {
@@ -158,6 +158,6 @@ function computeRequestsHash(requests: ShapeRequestOrDefinition[]): string {
   return computeClientDefsHash(requests.map((x) => x.definition))
 }
 
-function computeClientDefsHash(requests: ClientShapeDefinition[]): string {
+function computeClientDefsHash(requests: Shape[]): string {
   return hash(requests)
 }

--- a/clients/typescript/src/satellite/shapes/types.ts
+++ b/clients/typescript/src/satellite/shapes/types.ts
@@ -5,6 +5,8 @@ export const SUBSCRIPTION_DELIVERED = 'subscription_delivered'
 export const SUBSCRIPTION_ERROR = 'subscription_error'
 
 export type SubscriptionId = string
+export type TableName = string
+export type ColumnName = string
 
 export type SubscriptionDeliveredCallback = (data: SubscriptionData) => void
 export type SubscriptionErrorCallback = (
@@ -19,23 +21,25 @@ export type SubscribeResponse = {
 
 export type UnsubscribeResponse = Record<string, never>
 
-export type ClientShapeDefinition = {
-  selects: ShapeSelect[]
+export type Shape = {
+  tablename: TableName
+  include?: Array<Rel>
+}
+
+export type Rel = {
+  fk: Array<ColumnName> // allows composite FKs
+  select: Shape
 }
 
 export type ShapeRequest = {
   requestId: string
-  definition: ClientShapeDefinition
+  definition: Shape
 }
 export type ShapeDefinition = {
   uuid: string
-  definition: ClientShapeDefinition
+  definition: Shape
 }
 export type ShapeRequestOrDefinition = ShapeRequest | ShapeDefinition
-
-export type ShapeSelect = {
-  tablename: string
-}
 
 export type SubscriptionData = {
   subscriptionId: SubscriptionId

--- a/clients/typescript/src/util/proto.ts
+++ b/clients/typescript/src/util/proto.ts
@@ -307,14 +307,11 @@ export function shapeRequestToSatShapeReq(
   const shapeReqs: Pb.SatShapeReq[] = []
   for (const sr of shapeRequests) {
     const requestId = sr.requestId
-    const selects = sr.definition.selects.map((s) => ({
-      tablename: s.tablename,
-    }))
-    const shapeDefinition = { selects }
-
     const req = Pb.SatShapeReq.fromPartial({
       requestId,
-      shapeDefinition,
+      shapeDefinition: {
+        selects: [sr.definition],
+      },
     })
     shapeReqs.push(req)
   }

--- a/clients/typescript/test/client/model/builder.test.ts
+++ b/clients/typescript/test/client/model/builder.test.ts
@@ -15,7 +15,7 @@ const tbl = new Builder(
 )
 
 // Sync all shapes such that we don't get warnings on every query
-shapeManager.sync({ tables: ['Post'] })
+shapeManager.sync({ tablename: 'Post' })
 
 const post1 = {
   id: 'i1',

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -321,3 +321,42 @@ test.serial('synced promise is rejected on invalid shape', async (t) => {
     t.pass()
   }
 })
+
+test.serial('nested shape is constructed', async (t) => {
+  const { satellite, client } = t.context as ContextType
+  await satellite.start(config.auth)
+
+  client.setRelations(relations)
+
+  const { Post } = t.context as ContextType
+  const input = {
+    include: {
+      author: {
+        include: {
+          profile: true,
+        },
+      },
+    },
+  }
+  // @ts-ignore `computeShape` is a protected method
+  const shape = Post.computeShape(input)
+  t.deepEqual(shape, {
+    tablename: 'Post',
+    include: [
+      {
+        fk: ['authorId'],
+        select: {
+          tablename: 'User',
+          include: [
+            {
+              fk: ['userId'],
+              select: {
+                tablename: 'Profile',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  })
+})

--- a/clients/typescript/test/client/model/shapes.test.ts
+++ b/clients/typescript/test/client/model/shapes.test.ts
@@ -330,6 +330,13 @@ test.serial('nested shape is constructed', async (t) => {
 
   const { Post } = t.context as ContextType
   const input = {
+    where: {
+      OR: [{ id: 5 }, { id: 42 }],
+      NOT: [{ id: 1 }, { id: 2 }],
+      AND: [{ nbr: 6 }, { nbr: 7 }],
+      title: 'foo',
+      contents: 'bar',
+    },
     include: {
       author: {
         include: {
@@ -338,10 +345,13 @@ test.serial('nested shape is constructed', async (t) => {
       },
     },
   }
+
   // @ts-ignore `computeShape` is a protected method
   const shape = Post.computeShape(input)
   t.deepEqual(shape, {
     tablename: 'Post',
+    where:
+      "title = 'foo' AND contents = 'bar' AND nbr = 6 AND nbr = 7 AND ((id = 5) OR (id = 42)) AND NOT ((id = 1) OR (id = 2))",
     include: [
       {
         fk: ['authorId'],

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -730,7 +730,7 @@ test.serial('subscription succesful', async (t) => {
   const shapeReq: ShapeRequest = {
     requestId: 'fake',
     definition: {
-      selects: [{ tablename: 'fake' }],
+      tablename: 'fake',
     },
   }
 
@@ -752,14 +752,14 @@ test.serial(
     const shapeReq1: ShapeRequest = {
       requestId: 'fake1',
       definition: {
-        selects: [{ tablename: 'fake1' }],
+        tablename: 'fake1',
       },
     }
 
     const shapeReq2: ShapeRequest = {
       requestId: 'fake2',
       definition: {
-        selects: [{ tablename: 'fake2' }],
+        tablename: 'fake2',
       },
     }
 
@@ -801,7 +801,7 @@ test.serial('listen to subscription events: error', async (t) => {
   const shapeReq: ShapeRequest = {
     requestId: 'fake',
     definition: {
-      selects: [{ tablename: 'fake' }],
+      tablename: 'fake',
     },
   }
 
@@ -839,7 +839,7 @@ test.serial('subscription incorrect protocol sequence', async (t) => {
   const shapeReq: ShapeRequest = {
     requestId,
     definition: {
-      selects: [{ tablename }],
+      tablename,
     },
   }
 
@@ -985,14 +985,14 @@ test.serial('subscription correct protocol sequence with data', async (t) => {
   const shapeReq1: ShapeRequest = {
     requestId: requestId1,
     definition: {
-      selects: [{ tablename }],
+      tablename,
     },
   }
 
   const shapeReq2: ShapeRequest = {
     requestId: requestId2,
     definition: {
-      selects: [{ tablename }],
+      tablename,
     },
   }
 

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -43,10 +43,7 @@ import {
 } from './common'
 import { DEFAULT_LOG_POS, numberToBytes, base64 } from '../../src/util/common'
 
-import {
-  ClientShapeDefinition,
-  SubscriptionData,
-} from '../../src/satellite/shapes/types'
+import { Shape, SubscriptionData } from '../../src/satellite/shapes/types'
 import { mergeEntries } from '../../src/satellite/merge'
 
 const parentRecord = {
@@ -1328,8 +1325,8 @@ test('apply shape data and persist subscription', async (t) => {
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef: ClientShapeDefinition = {
-    selects: [{ tablename }],
+  const shapeDef: Shape = {
+    tablename,
   }
 
   satellite!.relations = relations
@@ -1381,8 +1378,8 @@ test('(regression) shape subscription succeeds even if subscription data is deli
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef: ClientShapeDefinition = {
-    selects: [{ tablename }],
+  const shapeDef: Shape = {
+    tablename,
   }
 
   satellite!.relations = relations
@@ -1413,8 +1410,8 @@ test('multiple subscriptions for the same shape are deduplicated', async (t) => 
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef: ClientShapeDefinition = {
-    selects: [{ tablename }],
+  const shapeDef: Shape = {
+    tablename,
   }
 
   satellite!.relations = relations
@@ -1455,8 +1452,8 @@ test('applied shape data will be acted upon correctly', async (t) => {
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef: ClientShapeDefinition = {
-    selects: [{ tablename }],
+  const shapeDef: Shape = {
+    tablename,
   }
 
   satellite!.relations = relations
@@ -1507,8 +1504,8 @@ test('a subscription that failed to apply because of FK constraint triggers GC',
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef1: ClientShapeDefinition = {
-    selects: [{ tablename }],
+  const shapeDef1: Shape = {
+    tablename,
   }
 
   satellite!.relations = relations
@@ -1541,11 +1538,11 @@ test('a second successful subscription', async (t) => {
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef1: ClientShapeDefinition = {
-    selects: [{ tablename: 'parent' }],
+  const shapeDef1: Shape = {
+    tablename: 'parent',
   }
-  const shapeDef2: ClientShapeDefinition = {
-    selects: [{ tablename: tablename }],
+  const shapeDef2: Shape = {
+    tablename,
   }
 
   satellite!.relations = relations
@@ -1587,11 +1584,11 @@ test('a single subscribe with multiple tables with FKs', async (t) => {
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef1: ClientShapeDefinition = {
-    selects: [{ tablename: 'child' }],
+  const shapeDef1: Shape = {
+    tablename: 'child',
   }
-  const shapeDef2: ClientShapeDefinition = {
-    selects: [{ tablename: 'parent' }],
+  const shapeDef2: Shape = {
+    tablename: 'parent',
   }
 
   satellite!.relations = relations
@@ -1641,11 +1638,11 @@ test.serial('a shape delivery that triggers garbage collection', async (t) => {
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef1: ClientShapeDefinition = {
-    selects: [{ tablename: 'parent' }],
+  const shapeDef1: Shape = {
+    tablename: 'parent',
   }
-  const shapeDef2: ClientShapeDefinition = {
-    selects: [{ tablename: 'another' }],
+  const shapeDef2: Shape = {
+    tablename: 'another',
   }
 
   satellite!.relations = relations
@@ -1692,12 +1689,12 @@ test('a subscription request failure does not clear the manager state', async (t
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef1: ClientShapeDefinition = {
-    selects: [{ tablename: tablename }],
+  const shapeDef1: Shape = {
+    tablename: tablename,
   }
 
-  const shapeDef2: ClientShapeDefinition = {
-    selects: [{ tablename: 'failure' }],
+  const shapeDef2: Shape = {
+    tablename: 'failure',
   }
 
   satellite!.relations = relations
@@ -1730,7 +1727,7 @@ test("Garbage collecting the subscription doesn't generate oplog entries", async
   t.is((await satellite._getEntries(0)).length, 0)
 
   satellite._garbageCollectShapeHandler([
-    { uuid: '', definition: { selects: [{ tablename: 'parent' }] } },
+    { uuid: '', definition: { tablename: 'parent' } },
   ])
 
   await satellite._performSnapshot()
@@ -1753,8 +1750,8 @@ test('snapshots: generated oplog entries have the correct tags', async (t) => {
   const conn = await satellite.start(authState)
   await conn.connectionPromise
 
-  const shapeDef: ClientShapeDefinition = {
-    selects: [{ tablename }],
+  const shapeDef: Shape = {
+    tablename,
   }
 
   satellite!.relations = relations

--- a/clients/typescript/test/util/subscriptions.test.ts
+++ b/clients/typescript/test/util/subscriptions.test.ts
@@ -32,11 +32,7 @@ test('some tests', (t) => {
 
   // the shape
   const definition = {
-    selects: [
-      {
-        tablename,
-      },
-    ],
+    tablename,
   }
 
   const shapeRequest = {


### PR DESCRIPTION
This PR modifies the shapes on the client to adhere to the new protocol format for shapes.
It also introduces support for `where` clauses at the **top-level** of a shape.
Those where clauses support:

```ts
where: {
  name: 'Kevin',
  OR: [
    { age: 28 },
    { age: 29 }
  ],
  NOT: [
    { country: 'France' }
  ]
  // AND is also supported but is redundant
}
```

**BEWARE:** `where` support is experimental and is not yet finished: typings and Zod schemas are too permissive and we don't support `where` clauses in nested `include`. One should not use relation fields in the shape and only check field values (no nested objects).