### PR TITLE
Clarify actual limitations on adding not-null constraints

### DIFF
--- a/docs/usage/data-modelling/constraints.md
+++ b/docs/usage/data-modelling/constraints.md
@@ -55,19 +55,20 @@ CREATE TABLE items (
 Adding a column with a not-null constraint is supported, but **not advisable** until default values are implemented:
 
 ```sql
+  -- Unsafe additive migration, requires the table to be empty
 ALTER TABLE items
-  -- Additive migration, supported
   ADD COLUMN baz TEXT NOT NULL;
 
-   -- Possible substitute for default values
-  SET baz = "fie";
+  -- Safe additive migration, but default values are not yet supported
+ALTER TABLE items
+  ADD COLUMN fie TEXT NOT NULL DEFAULT 'some_value';
 ```
 
-Adding a column with not-null constraints after the table is electrified is *technically* possible because it's an [additive migration](./migrations.md#limitations). However, since ElectricSQL does not yet support default values, the migration itself would need to supply non-null values for each existing row for the constraint to be fulfilled.
+Adding a column with not-null constraints after the table is electrified is *technically* possible because it's an [additive migration](./migrations.md#limitations) as long as the table is empty or a default value is provided.
 
-In theory, this is possible to do if you can guarantee that no new rows are in-flight, pending locally on a client or will be added by a client not yet updated. This is not a guarantee that can normally be made.
+ElectricSQL does not yet support default values and you can only consider the table empty if you can *guarantee* that no new rows are in-flight, pending locally on a client or will be added by a client not yet updated.
 
-Without it, writes that were accepted locally with implicit null values in the new column would need to be rejected, which would violate the [finality of local writes](../../reference/architecture.md#local-writes).
+This is not a guarantee that can normally be made and without it, writes that were accepted locally with implicit null values in the new column would need to be rejected, which would violate the [finality of local writes](../../reference/architecture.md#local-writes).
 
 Constraining an existing column by adding a not-null constraint to it is **not supported**:
 
@@ -77,7 +78,7 @@ ALTER TABLE items
   ALTER COLUMN bar TEXT NOT NULL;
 ```
 
-This type of migration is not supported since it isn't *additive*. The same reasoning about *finality of local writes* applies here.
+This type of migration is not supported since it is not *additive*. The same reasoning about *finality of local writes* applies here.
 
 ## Unsupported
 

--- a/docs/usage/data-modelling/constraints.md
+++ b/docs/usage/data-modelling/constraints.md
@@ -37,39 +37,47 @@ Electric currently does not allow adding a new foreign key column with `ALTER TA
 
 ### Not-null constraints
 
-ElectricSQL supports [not-null constraints](https://www.postgresql.org/docs/current/ddl-constraints.html#id-1.5.4.6.6) as long as the constraint is defined when creating the column.
-
-I.e.: the not-null constraint must be defined in an [additive migration](./migrations.md#limitations). So the following is supported because creating the table with new columns is *additive*:
+ElectricSQL supports [not-null constraints](https://www.postgresql.org/docs/current/ddl-constraints.html#id-1.5.4.6.6) as long as the constraint is defined when creating the table or before the table is electrified.
 
 ```sql
 CREATE TABLE items (
-  -- implicit non null constraint
+  -- Implicit non null constraint
   id UUID PRIMARY KEY
 
-  -- explicit non null constraint
+  -- Explicit non null constraint
   foo TEXT NOT NULL
 
-  -- can be null
+  -- Can be null
   bar TEXT
 )
 ```
 
-Adding a column with a not-null constraint is supported because it's *additive*:
+Adding a column with a not-null constraint is supported, but **not advisable** until default values are implemented:
 
 ```sql
 ALTER TABLE items
+  -- Additive migration, supported
   ADD COLUMN baz TEXT NOT NULL;
+
+   -- Possible substitute for default values
+  SET baz = "fie";
 ```
+
+Adding a column with not-null constraints after the table is electrified is *technically* possible because it's an [additive migration](./migrations.md#limitations). However, since ElectricSQL does not yet support default values, the migration itself would need to supply non-null values for each existing row for the constraint to be fulfilled.
+
+In theory, this is possible to do if you can guarantee that no new rows are in-flight, pending locally on a client or will be added by a client not yet updated. This is not a guarantee that can normally be made.
+
+Without it, writes that were accepted locally with implicit null values in the new column would need to be rejected, which would violate the [finality of local writes](../../reference/architecture.md#local-writes).
 
 Constraining an existing column by adding a not-null constraint to it is **not supported**:
 
 ```sql
--- Not supported
 ALTER TABLE items
+  -- Not additive, not supported
   ALTER COLUMN bar TEXT NOT NULL;
 ```
 
-This is not supported because it may invalidate concurrent, in-flight operations. Specifically, writes that were accepted locally with null values would need to be rejected, which would violate the [finality of local writes](../../reference/architecture.md#local-writes).
+This type of migration is not supported since it isn't *additive*. The same reasoning about *finality of local writes* applies here.
 
 ## Unsupported
 


### PR DESCRIPTION
@balegas & @thruflo : This is my attempt at clarifying the limitations of adding not-null constrained columns, as per the Discord discussion.

I tried my best to make the text as short as possible without loosing out on details _why_ it isn't really supported.