### PR TITLE
fix (CLI): fix generator engine library issue

### DIFF
--- a/.changeset/afraid-keys-begin.md
+++ b/.changeset/afraid-keys-begin.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Modified the CLI's generate command to fix issues with the generator when user projects include Prisma v5.

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -137,7 +137,7 @@
   },
   "dependencies": {
     "@electric-sql/prisma-generator": "workspace:*",
-    "@prisma/client": "5.2.0",
+    "@prisma/client": "4.8.1",
     "async-mutex": "^0.4.0",
     "base-64": "^1.0.0",
     "better-sqlite3": "^8.4.0",
@@ -163,7 +163,8 @@
     "long": "^5.2.0",
     "object.hasown": "^1.1.2",
     "ohash": "^1.1.2",
-    "prisma": "5.2.0",
+    "prisma": "4.8.1",
+    "prisma-v5": "npm:prisma@5.9.0",
     "prompts": "^2.4.2",
     "protobufjs": "^7.1.1",
     "react-native-uuid": "^2.0.1",

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -26,6 +26,7 @@ import { withConfig } from '../configure/command-with-config'
 // We use the same method to resolve the path to `@electric-sql/prisma-generator`.
 const require = Module.createRequire(import.meta.url)
 const prismaPath = require.resolve('prisma')
+const prismaV5Path = require.resolve('prisma-v5')
 const generatorPath = path.join(
   path.dirname(require.resolve('@electric-sql/prisma-generator')),
   'bin.js'
@@ -250,7 +251,7 @@ async function _generate(opts: Omit<GeneratorOptions, 'watch'>) {
     // Fetch the migrations from Electric endpoint and write them into `tmpFolder`
     await fetchMigrations(migrationEndpoint, migrationsFolder, tmpFolder)
 
-    const prismaSchema = await createPrismaSchema(tmpFolder, opts)
+    const prismaSchema = await createIntrospectionSchema(tmpFolder, opts)
 
     // Introspect the created DB to update the Prisma schema
     await introspectDB(prismaSchema)
@@ -261,8 +262,21 @@ async function _generate(opts: Omit<GeneratorOptions, 'watch'>) {
     // Modify snake_case table names to PascalCase
     await capitaliseTableNames(prismaSchema)
 
-    // Generate a client from the Prisma schema
+    // Read the contents of the Prisma schema
+    const introspectedSchema = await fs.readFile(prismaSchema, 'utf8')
+
+    // Add a generator for the Electric client to the Prisma schema
+    await createElectricClientSchema(introspectedSchema, prismaSchema, opts)
+
+    // Generate the Electric client from the Prisma schema
     await generateElectricClient(prismaSchema)
+
+    // Add a generator for the Prisma client to the Prisma schema
+    await createPrismaClientSchema(introspectedSchema, prismaSchema, opts)
+
+    // Generate the Prisma client from the Prisma schema
+    await generatePrismaClient(prismaSchema)
+
     const relativePath = path.relative(appRoot, config.CLIENT_PATH)
     // Modify the type of JSON input values in the generated Prisma client
     // because we deviate from Prisma's typing for JSON values
@@ -326,29 +340,75 @@ function buildProxyUrlForIntrospection(config: Config) {
  * Creates a fresh Prisma schema in the provided folder.
  * The Prisma schema is initialised with a generator and a datasource.
  */
-async function createPrismaSchema(folder: string, opts: GeneratorOptions) {
+async function createIntrospectionSchema(
+  folder: string,
+  opts: GeneratorOptions
+) {
   const config = opts.config
   const prismaDir = path.join(folder, 'prisma')
   const prismaSchemaFile = path.join(prismaDir, 'schema.prisma')
   await fs.mkdir(prismaDir)
-  const output = path.resolve(config.CLIENT_PATH)
   const proxyUrl = buildProxyUrlForIntrospection(config)
+  const schema = dedent`
+    datasource db {
+      provider = "postgresql"
+      url      = "${proxyUrl}"
+    }`
+  await fs.writeFile(prismaSchemaFile, schema)
+  return prismaSchemaFile
+}
+
+/**
+ * Takes the Prisma schema that results from introspecting the DB
+ * and extends it with a generator for the Electric client.
+ * @param introspectedSchema The Prisma schema that results from introspecting the DB.
+ * @param prismaSchemaFile Path to the Prisma schema file.
+ * @returns The path to the Prisma schema file.
+ */
+async function createElectricClientSchema(
+  introspectedSchema: string,
+  prismaSchemaFile: string,
+  opts: GeneratorOptions
+) {
+  const config = opts.config
+  const output = path.resolve(config.CLIENT_PATH)
+
   const schema = dedent`
     generator electric {
       provider      = "node ${escapePathForString(generatorPath)}"
       output        = "${escapePathForString(output)}"
       relationModel = "false"
     }
+    
+    ${introspectedSchema}`
 
+  await fs.writeFile(prismaSchemaFile, schema)
+  return prismaSchemaFile
+}
+
+/**
+ * Takes the Prisma schema that results from introspecting the DB
+ * and extends it with a generator for the Prisma client.
+ * @param introspectedSchema The Prisma schema that results from introspecting the DB.
+ * @param prismaSchemaFile Path to the Prisma schema file.
+ * @returns The path to the Prisma schema file.
+ */
+async function createPrismaClientSchema(
+  introspectedSchema: string,
+  prismaSchemaFile: string,
+  opts: GeneratorOptions
+) {
+  const config = opts.config
+  const output = path.resolve(config.CLIENT_PATH)
+
+  const schema = dedent`
     generator client {
       provider = "prisma-client-js"
       output   = "${escapePathForString(output)}"
     }
+    
+    ${introspectedSchema}`
 
-    datasource db {
-      provider = "postgresql"
-      url      = "${proxyUrl}"
-    }`
   await fs.writeFile(prismaSchemaFile, schema)
   return prismaSchemaFile
 }
@@ -523,6 +583,17 @@ function addValidator(ln: string): string {
 async function generateElectricClient(prismaSchema: string): Promise<void> {
   await executeShellCommand(
     `node ${prismaPath} generate --schema="${prismaSchema}"`,
+    'Generator script exited with error code: '
+  )
+}
+
+async function generatePrismaClient(prismaSchema: string): Promise<void> {
+  // Uses Prisma v5 to generate the Prisma client
+  // because of a bug in Prisma v4 that causes the Prisma client generator to crash
+  // if there is also a Prisma v5 in the node_modules folder
+  // (e.g. if the user's project includes Prisma v5)
+  await executeShellCommand(
+    `node ${prismaV5Path} generate --schema="${prismaSchema}"`,
     'Generator script exited with error code: '
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:../../generator
       '@prisma/client':
-        specifier: 5.2.0
-        version: 5.2.0(prisma@5.2.0)
+        specifier: 4.8.1
+        version: 4.8.1(prisma@5.9.0)
       async-mutex:
         specifier: ^0.4.0
         version: 0.4.0
@@ -102,8 +102,11 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       prisma:
-        specifier: 5.2.0
-        version: 5.2.0
+        specifier: 4.8.1
+        version: 4.8.1
+      prisma-v5:
+        specifier: npm:prisma@5.9.0
+        version: /prisma@5.9.0
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -269,7 +272,7 @@ importers:
         version: 5.3.3
       wa-sqlite:
         specifier: rhashimoto/wa-sqlite#semver:^0.9.8
-        version: github.com/rhashimoto/wa-sqlite/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a
+        version: github.com/rhashimoto/wa-sqlite/390744d41c61aa0bbd53d3c738abef5e23f71cc4
       web-worker:
         specifier: ^1.2.0
         version: 1.2.0
@@ -3572,9 +3575,9 @@ packages:
       config-chain: 1.1.13
     dev: true
 
-  /@prisma/client@5.2.0(prisma@5.2.0):
-    resolution: {integrity: sha512-AiTjJwR4J5Rh6Z/9ZKrBBLel3/5DzUNntMohOy7yObVnVoTNVFi2kvpLZlFuKO50d7yDspOtW6XBpiAd0BVXbQ==}
-    engines: {node: '>=16.13'}
+  /@prisma/client@4.8.1(prisma@5.9.0):
+    resolution: {integrity: sha512-d4xhZhETmeXK/yZ7K0KcVOzEfI5YKGGEr4F5SBV04/MU4ncN/HcE28sy3e4Yt8UFW0ZuImKFQJE+9rWt9WbGSQ==}
+    engines: {node: '>=14.17'}
     requiresBuild: true
     peerDependencies:
       prisma: '*'
@@ -3582,8 +3585,8 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f
-      prisma: 5.2.0
+      '@prisma/engines-version': 4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe
+      prisma: 5.9.0
     dev: false
 
   /@prisma/debug@4.15.0:
@@ -3595,8 +3598,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@prisma/engines-version@5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f:
-    resolution: {integrity: sha512-jsnKT5JIDIE01lAeCj2ghY9IwxkedhKNvxQeoyLs6dr4ZXynetD0vTy7u6wMJt8vVPv8I5DPy/I4CFaoXAgbtg==}
+  /@prisma/debug@5.9.0:
+    resolution: {integrity: sha512-3Uhj5YSPqaIfzJQ6JQzCNBXeBTy0x803fGIoo2tvP/KIEd+o4o49JxCQtKtP8aeef5iNh5Nn9Z25wDrdLjS80A==}
+    dev: false
+
+  /@prisma/engines-version@4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe:
+    resolution: {integrity: sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw==}
+    dev: false
+
+  /@prisma/engines-version@5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64:
+    resolution: {integrity: sha512-HFl7275yF0FWbdcNvcSRbbu9JCBSLMcurYwvWc8WGDnpu7APxQo2ONtZrUggU3WxLxUJ2uBX+0GOFIcJeVeOOQ==}
     dev: false
 
   /@prisma/engines@4.15.0:
@@ -3604,9 +3615,19 @@ packages:
     requiresBuild: true
     dev: true
 
-  /@prisma/engines@5.2.0:
-    resolution: {integrity: sha512-dT7FOLUCdZmq+AunLqB1Iz+ZH/IIS1Fz2THmKZQ6aFONrQD/BQ5ecJ7g2wGS2OgyUFf4OaLam6/bxmgdOBDqig==}
+  /@prisma/engines@4.8.1:
+    resolution: {integrity: sha512-93tctjNXcIS+i/e552IO6tqw17sX8liivv8WX9lDMCpEEe3ci+nT9F+1oHtAafqruXLepKF80i/D20Mm+ESlOw==}
     requiresBuild: true
+    dev: false
+
+  /@prisma/engines@5.9.0:
+    resolution: {integrity: sha512-BH1fpXbMH09TwfZH5FVMJwRp6afEhKzqwebbCLdaEkJDuhxA//iwbILLqGFtGTgZbdBNUOThIK+UC3++5kWMTg==}
+    requiresBuild: true
+    dependencies:
+      '@prisma/debug': 5.9.0
+      '@prisma/engines-version': 5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64
+      '@prisma/fetch-engine': 5.9.0
+      '@prisma/get-platform': 5.9.0
     dev: false
 
   /@prisma/fetch-engine@4.15.0:
@@ -3634,6 +3655,14 @@ packages:
       - supports-color
     dev: true
 
+  /@prisma/fetch-engine@5.9.0:
+    resolution: {integrity: sha512-NL8Vm8Vl2d6NOSkkPGN5TTTz4s6cyCleXOzqtOFWzfKFJ4wtN2Shu7llOT+ykf6nDzh1lCN2JHUt1S6FGFZGig==}
+    dependencies:
+      '@prisma/debug': 5.9.0
+      '@prisma/engines-version': 5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64
+      '@prisma/get-platform': 5.9.0
+    dev: false
+
   /@prisma/generator-helper@4.15.0:
     resolution: {integrity: sha512-JVHNgXr0LrcqXqmFrs+BzxfyRL6cFD5GLTMVWfCLU7kqSJdWuZxfoZW995tg6mOXnBgPTf6Ocv3RY4RLQq8k4g==}
     dependencies:
@@ -3660,6 +3689,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@prisma/get-platform@5.9.0:
+    resolution: {integrity: sha512-8CatX+E6eZxcOjJZe5hF8EXxdb5GsQTA/u7pdmUJSxGLacW9K3r5vDdgV8s22PubObQQ6979/rkCMItbCrG4Yg==}
+    dependencies:
+      '@prisma/debug': 5.9.0
+    dev: false
 
   /@prisma/internals@4.15.0:
     resolution: {integrity: sha512-bmgn1GX74RfjBRVMV4oJknZJOHmXcO9lh0VbwWKXp1zXvjumQCGeBOmLdzkp4SnvIrpkpXQf9JGbmOTKpVsvRw==}
@@ -12263,13 +12298,22 @@ packages:
       parse-ms: 2.1.0
     dev: true
 
-  /prisma@5.2.0:
-    resolution: {integrity: sha512-FfFlpjVCkZwrqxDnP4smlNYSH1so+CbfjgdpioFzGGqlQAEm6VHAYSzV7jJgC3ebtY9dNOhDMS2+4/1DDSM7bQ==}
+  /prisma@4.8.1:
+    resolution: {integrity: sha512-ZMLnSjwulIeYfaU1O6/LF6PEJzxN5par5weykxMykS9Z6ara/j76JH3Yo2AH3bgJbPN4Z6NeCK9s5fDkzf33cg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@prisma/engines': 4.8.1
+    dev: false
+
+  /prisma@5.9.0:
+    resolution: {integrity: sha512-0UcOofjNuAnd227JMaPqZvP01dsUXw9EXB9iC8fyoZtfv7zkQ0ozxyjY1g+vcjFPOnNLICMnLHx+lM5BJZYqOQ==}
     engines: {node: '>=16.13'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 5.2.0
+      '@prisma/engines': 5.9.0
     dev: false
 
   /process-nextick-args@2.0.1:
@@ -15394,8 +15438,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/rhashimoto/wa-sqlite/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a:
-    resolution: {tarball: https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/5266fd8cdb4b3ced41352ba7b1f0e919ac37027a}
+  github.com/rhashimoto/wa-sqlite/390744d41c61aa0bbd53d3c738abef5e23f71cc4:
+    resolution: {tarball: https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/390744d41c61aa0bbd53d3c738abef5e23f71cc4}
     name: wa-sqlite
-    version: 0.9.9
+    version: 0.9.11
     dev: true


### PR DESCRIPTION
This PR fixes an issue with the CLI's generate command and fixes missing schemas in the generated client (fixes VAX-1580).
Our typescript client uses Prisma v4 to introspect the Postgres DB and to generate the Prisma and Electric clients.
However, if a user project includes Prisma v5 (e.g. to manage migrations using Prisma), then the generator crashed with the following error:
```
Error: Command failed: node /home/alco/code/electric-sql/electric/examples/nextjs-electric/node_modules/electric-sql/node_modules/prisma/build/index.js generate --schema=".electric_migrations_tmp_oM5W7E/prisma/schema.prisma"
Error: (query-engine-node-api library)
Details: NodeAPIQueryEngineLibrary.dmmf is not a function
[Context: getDmmf]

Prisma CLI Version : 4.8.1

    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:526:35)
    at maybeClose (node:internal/child_process:1105:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'node /home/alco/code/tmp/nextjs-electric/node_modules/electric-sql/node_modules/prisma/build/index.js generate --schema=".electric_migrations_tmp_sYnULy/prisma/schema.prisma"'
}
generate command failed: Generator script exited with error code: 1
```

After tracing down the problem i found that the crash happens when generating the Prisma client using Prisma v4 when the user's project has Prisma v5 installed. However, if we use Prisma v5 to generate the Prisma client then there is no problem. We cannot use Prisma v5 for everything because:
- the proxy only works up till Prisma v5.2
- our Electric client generator requires Prisma v4 beause it was forked from a Zod generator which at the time only supported Prisma v4

So this PR solves the problem by splitting the generation of the Prisma client and the Electric client in 2 passes. For the generation of the Prisma client it uses v5 and for the Electric client it uses v4. We could also use v5.2 for introspection and for generating the Prisma client and use v4 only for generating the Electric client.

### Testing

To test this PR, create a fresh Electric project `npx create-electric-app@latest test`.
Then add Prisma v5 and @prisma/client dependencies:
```sh
yarn add @prisma/client
yarn add prisma -D
```

Start Electric and migrate the DB:
```sh
yarn backend:start
# in another tab
yarn db:migrate
```

Now check that you can reproduce the issue:
```sh
yarn client:generate
# this should crash with the error from above
```

Now replace the electric-sql dependency by an npm pack-ed version of the ts-client in this PR.
Then:
```sh
yarn
yarn client:generate
```

That should have worked.
You can now run the app:
```sh
yarn dev
```