### PR TITLE
chore(electric): Change the default PG_PROXY_PASSWORD to match web-wa-sqlite

### DIFF
--- a/components/electric/.env.dev
+++ b/components/electric/.env.dev
@@ -4,4 +4,4 @@ DATABASE_URL=postgresql://postgres:password@localhost:54321/electric
 ELECTRIC_TELEMETRY=0
 LOG_LEVEL=debug
 LOGICAL_PUBLISHER_HOST=host.docker.internal
-PG_PROXY_PASSWORD=password
+PG_PROXY_PASSWORD=proxy_password


### PR DESCRIPTION
This removes the only hurdle that was preventing the stock code for examples/web-wa-sqlite from working with the locally running sync service started with `iex -S mix`.