### PR TITLE
POC: pgvector support

### DIFF
--- a/components/electric/dev/compose.yaml
+++ b/components/electric/dev/compose.yaml
@@ -3,7 +3,7 @@ name: "electric_dev"
 
 services:
   postgres:
-    image: postgres:14-alpine
+    image: pgvector/pgvector:pg14
     environment:
       POSTGRES_DB: electric
       POSTGRES_USER: postgres

--- a/components/electric/lib/electric/postgres.ex
+++ b/components/electric/lib/electric/postgres.ex
@@ -92,6 +92,7 @@ defmodule Electric.Postgres do
       timestamp timestamptz
       uuid
       varchar
+      vector
     ]a
   end
 end

--- a/components/electric/lib/electric/postgres/oid_database.ex
+++ b/components/electric/lib/electric/postgres/oid_database.ex
@@ -26,6 +26,7 @@ defmodule Electric.Postgres.OidDatabase do
     end
   end
 
+  # TODO: Save the public.vector type.
   def save_oids(server \\ __MODULE__, values) do
     GenServer.call(server, {:save_oids, Enum.map(values, &pg_type_from_tuple/1)})
   end

--- a/components/electric/test/electric/postgres/extension_test.exs
+++ b/components/electric/test/electric/postgres/extension_test.exs
@@ -423,8 +423,10 @@ defmodule Electric.Postgres.ExtensionTest do
     end
 
     test_tx "successfully validates column types", fn conn ->
-      assert [{:ok, [], []}, {:ok, [], []}, {:ok, [], []}] ==
+      assert [{:ok, [], []}, {:ok, [], []}, {:ok, [], []}, {:ok, [], []}] ==
                :epgsql.squery(conn, """
+               CREATE EXTENSION vector;
+
                CREATE TYPE shapes AS ENUM ('circle', 'square', 'diamond');
 
                CREATE TABLE public.t1 (
@@ -448,7 +450,9 @@ defmodule Electric.Postgres.ExtensionTest do
                  t TIME,
                  flag BOOLEAN,
                  jb JSONB,
-                 shape shapes
+                 shape shapes,
+                 v VECTOR,
+                 v3 VECTOR(3)
                );
 
                CALL electric.electrify('public.t1');

--- a/components/electric/test/electric/satellite/serialization_test.exs
+++ b/components/electric/test/electric/satellite/serialization_test.exs
@@ -24,7 +24,8 @@ defmodule Electric.Satellite.SerializationTest do
         "id" => uuid,
         "date" => "2024-12-24",
         "time" => "12:01:00.123",
-        "bool" => "t"
+        "bool" => "t",
+        "vec" => "[1,2,4.333]"
       }
 
       columns = [
@@ -37,7 +38,8 @@ defmodule Electric.Satellite.SerializationTest do
         %{name: "real", type: :float8},
         %{name: "date", type: :date},
         %{name: "time", type: :time},
-        %{name: "bool", type: :bool}
+        %{name: "bool", type: :bool},
+        %{name: "vec", type: :vector}
       ]
 
       assert %SatOpRow{
@@ -51,7 +53,8 @@ defmodule Electric.Satellite.SerializationTest do
                  "-3.14",
                  "2024-12-24",
                  "12:01:00.123",
-                 "t"
+                 "t",
+                 "[1,2,4.333]"
                ],
                nulls_bitmask: <<0b11000000, 0>>
              } == Serialization.map_to_row(data, columns)
@@ -96,7 +99,8 @@ defmodule Electric.Satellite.SerializationTest do
           "",
           "0400-02-29",
           "03:59:59",
-          "f"
+          "f",
+          "[-1.0,+1.0]"
         ]
       }
 
@@ -111,7 +115,8 @@ defmodule Electric.Satellite.SerializationTest do
         %{name: "x", type: :float4, nullable?: true},
         %{name: "date", type: :date},
         %{name: "time", type: :time},
-        %{name: "bool", type: :bool}
+        %{name: "bool", type: :bool},
+        %{name: "vec", type: :vector}
       ]
 
       assert %{
@@ -125,7 +130,8 @@ defmodule Electric.Satellite.SerializationTest do
                "x" => nil,
                "date" => "0400-02-29",
                "time" => "03:59:59",
-               "bool" => "f"
+               "bool" => "f",
+               "vec" => "[-1.0,+1.0]"
              } == Serialization.decode_record!(row, columns)
     end
 

--- a/components/electric/test/support/postgres_test_connection.ex
+++ b/components/electric/test/support/postgres_test_connection.ex
@@ -95,7 +95,9 @@ defmodule Electric.Postgres.TestConnection do
     origin = Map.fetch!(context, :origin)
 
     # Initialize the test DB to the state which Electric can work with.
-    setup_fun = fn _conn -> nil end
+    setup_fun = fn conn ->
+      :epgsql.squery(conn, "CREATE EXTENSION vector")
+    end
 
     # Dropping the subscription is necessary before the test DB can be removed.
     teardown_fun = fn conn ->

--- a/examples/web-wa-sqlite/db/migrations/01-create_items_table.sql
+++ b/examples/web-wa-sqlite/db/migrations/01-create_items_table.sql
@@ -1,19 +1,46 @@
-/* This is an example of an SQL DDL migration. It creates an `items` table and
- * then calls an `electric.electrify` procedure to expose the table to the
- * ElectricSQL replication machinery.
- *
- * Note that these statements are applied directly to the *Postgres* database.
- * Electric then handles keeping the local SQLite database schema in sync with
- * the electrified subset of your Postgres database schema.
- *
- * See https://electric-sql.com/docs/usage/data-modelling for more information.
- */
+BEGIN;
 
--- Create a simple items table.
-CREATE TABLE IF NOT EXISTS items (
-  value TEXT PRIMARY KEY NOT NULL
+CREATE EXTENSION vector;
+
+-- Pin the migration version
+CALL electric.migration_version('20240129154650_919');
+
+-- Create the tables for the linearlite example
+CREATE TABLE IF NOT EXISTS "issue" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "priority" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "modified" TEXT NOT NULL,
+    "created" TEXT NOT NULL,
+    "kanbanorder" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    -- "embeddings" TEXT NOT NULL, -- Embeddings, for the tauri demo
+    "embeddings" vector(768), -- Embeddings, for the tauri demo
+    CONSTRAINT "issue_pkey" PRIMARY KEY ("id")
+);
+
+-- CREATE TABLE IF NOT EXISTS "user" (
+--     "username" TEXT NOT NULL,
+--     "avatar" TEXT,
+--     CONSTRAINT "user_pkey" PRIMARY KEY ("username")
+-- );
+
+CREATE TABLE  IF NOT EXISTS "comment" (
+    "id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "issue_id" TEXT NOT NULL,
+    "created_at" TEXT NOT NULL,
+    CONSTRAINT "comment_pkey" PRIMARY KEY ("id")
+    -- FOREIGN KEY (username) REFERENCES "user"(username),
+    -- FOREIGN KEY (issue_id) REFERENCES issue(id) -- Disable for the tauri demo
 );
 
 -- ⚡
--- Electrify the items table
-ALTER TABLE items ENABLE ELECTRIC;
+-- Electrify the tables
+ALTER TABLE issue ENABLE ELECTRIC;
+ALTER TABLE comment ENABLE ELECTRIC;
+
+COMMIT;

--- a/examples/web-wa-sqlite/src/Example.tsx
+++ b/examples/web-wa-sqlite/src/Example.tsx
@@ -6,14 +6,14 @@ import { genUUID, uniqueTabId } from 'electric-sql/util'
 import { ElectricDatabase, electrify } from 'electric-sql/wa-sqlite'
 
 import { authToken } from './auth'
-import { Electric, Items as Item, schema } from './generated/client'
+import { Electric, Issue, schema } from './generated/client'
 
 import './Example.css'
 
 const { ElectricProvider, useElectric } = makeElectricContext<Electric>()
 
 export const Example = () => {
-  const [ electric, setElectric ] = useState<Electric>()
+  const [electric, setElectric] = useState<Electric>()
 
   useEffect(() => {
     let isMounted = true
@@ -30,7 +30,7 @@ export const Example = () => {
       const { tabId } = uniqueTabId()
       const scopedDbName = `basic-${LIB_VERSION}-${tabId}.db`
 
-      const conn = await ElectricDatabase.init(scopedDbName) 
+      const conn = await ElectricDatabase.init(scopedDbName)
       const electric = await electrify(conn, schema, config)
 
       if (!isMounted) {
@@ -60,49 +60,58 @@ export const Example = () => {
 
 const ExampleComponent = () => {
   const { db } = useElectric()!
+  window.db = db
   const { results } = useLiveQuery(
-    db.items.liveMany()
+    db.issue.liveMany()
   )
 
   useEffect(() => {
-    const syncItems = async () => {
+    const syncIssues = async () => {
       // Resolves when the shape subscription has been established.
-      const shape = await db.items.sync()
+      const shape = await db.issue.sync()
 
       // Resolves when the data has been synced into the local database.
       await shape.synced
     }
 
-    syncItems()
+    syncIssues()
   }, [])
 
-  const addItem = async () => {
-    await db.items.create({
+  const addIssue = async () => {
+    await db.issue.create({
       data: {
-        value: genUUID(),
+        id: genUUID(),
+        title: "foo title",
+        description: "...",
+        priority: "1",
+        status: "(no status)",
+        modified: "" + new Date(),
+        created: "" + new Date(),
+        kanbanorder: "4",
+        username: genUUID(),
       }
     })
   }
 
-  const clearItems = async () => {
-    await db.items.deleteMany()
+  const clearIssues = async () => {
+    await db.issue.deleteMany()
   }
 
-  const items: Item[] = results ?? []
+  const issues: Issue[] = results ?? []
 
   return (
     <div>
       <div className="controls">
-        <button className="button" onClick={ addItem }>
+        <button className="button" onClick={addIssue}>
           Add
         </button>
-        <button className="button" onClick={ clearItems }>
+        <button className="button" onClick={clearIssues}>
           Clear
         </button>
       </div>
-      {items.map((item: Item, index: number) => (
-        <p key={ index } className="item">
-          <code>{ item.value }</code>
+      {issues.map((issue: Issue, index: number) => (
+        <p key={index} className="item">
+          <code>{issue.username}</code>
         </p>
       ))}
     </div>


### PR DESCRIPTION
Limitations of this POC:

* The serevr translates the type `vector(N)` to `TEXT(N)` when building SQLite migrations from the Postgres schema.

* It doesn't validate dimensions for incoming values. So if the PG type is `vector(3)` but the client sends a vector of different dimension, this will result in a failed write to PG.

* Vectors are only supported in the `direct_writes` mode.

To see a working example in action, navigate to `examples/web-wa-sqlite`, apply the migration and generate the client. You'll notice that the generated Zod schema for the `issue` table is missing the `embeddings` field. I think it's a consequence of the fact that Prisma does not support the `vector` type and generates the `Unsupported("vector(768)")` Prisma type for it. We can work around this by migrating off Prisma introspection and generating the Prisma schema ourselves, as shown in https://github.com/electric-sql/electric/pull/872.

Nevertheless, it allows you to create new issues on the client (those will have `embeddings` set to `NULL`) and on the server. In the latter case, `embeddings` get synced to the client database.

In the screenshot below you can see the outcome of the following sequences of actions:
* Create an issue in the web app by clicking on the Add button.
* Insert a new row directly into Postgres:
    ```
	=# select * from issue;
	─[ RECORD 1 ]───────────────────────────────────────────────────────────────────
	id          │ b8a5741b-2192-4ab3-a01c-f9152cf71122
	title       │ foo title
	description │ ...
	priority    │ 1
	status      │ (no status)
	modified    │ Wed Feb 07 2024 17:44:18 GMT+0200 (Eastern European Standard Time)
	created     │ Wed Feb 07 2024 17:44:18 GMT+0200 (Eastern European Standard Time)
	kanbanorder │ 4
	username    │ ddab6602-25fb-4815-acdc-66dc3d28c44f
	embeddings  │ ∅
	
	=# insert into issue values (
		gen_random_uuid(), 
		'bar title', 
		'...', 
		'2', 
		'(no status)', 
		now(), 
		now(), 
		'2', 
		'placeholder username', 
		(select 
		   array_agg(random()::real * (1 - -1) + -1)
		 from
		   generate_series (1, 768)
		)::vector(768)
	);
	INSERT 0 1
    ```

![Screenshot from 2024-02-07 17-50-04](https://github.com/electric-sql/electric/assets/207748/10d47813-8afb-4536-8e71-378007b7a9b0)

The `SatRelation` messages exchanged between the client and the server currently look as follows:
```
[proto] send: #SatRelation{for: public.issue, as: 0, cols: [id: TEXT, title: TEXT, description: TEXT, priority: TEXT, status: TEXT, modified: TEXT, created: TEXT, kanbanorder: TEXT, username: TEXT, embeddings: TEXT(768)]} [client.ts:993:33](http://localhost:5173/node_modules/electric-sql/src/satellite/client.ts)

[proto] send: #SatOpLog{ops: [#Begin{lsn: AAAAAQ==, ts: 1707320659007, isMigration: false}, #Insert{for: 0, tags: [], new: ["b8a5741b-2192-4ab3-a01c-f9152cf71122", "foo title", "...", "1", "(no status)", "Wed Feb 07 2024 17:44:18 GMT+0200 (Eastern European Standard Time)", "Wed Feb 07 2024 17:44:18 GMT+0200 (Eastern European Standard Time)", "4", "ddab6602-25fb-4815-acdc-66dc3d28c44f", ∅]}, #Commit{lsn: }]} [client.ts:993:33](http://localhost:5173/node_modules/electric-sql/src/satellite/client.ts)

[proto] recv: #SatRelation{for: public.issue, as: 16891, cols: [id: text PK, title: text, description: text, priority: text, status: text, modified: text, created: text, kanbanorder: text, username: text, embeddings: vector]} [client.ts:852:12](http://localhost:5173/node_modules/electric-sql/src/satellite/client.ts)

[proto] recv: #SatOpLog{ops: [#Begin{lsn: MjY3ODAxMzY=, ts: 1707320659007, isMigration: false}, #Insert{for: 16891, tags: [ff5e935c-a73f-4b97-bc2d-1f2b07b87bcb@1707320659007], new: ["b8a5741b-2192-4ab3-a01c-f9152cf71122", "foo title", "...", "1", "(no status)", "Wed Feb 07 2024 17:44:18 GMT+0200 (Eastern European Standard Time)", "Wed Feb 07 2024 17:44:18 GMT+0200 (Eastern European Standard Time)", "4", "ddab6602-25fb-4815-acdc-66dc3d28c44f", ∅]}, #Commit{lsn: MjY3ODAxMzY=}]}
```