### PR TITLE
Change the way electrify() captures DDL statements

### DIFF
--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -320,7 +320,8 @@ defmodule Electric.Postgres.Extension do
       Migrations.Migration_20231016141000_ConvertFunctionToProcedure,
       Migrations.Migration_20231206130400_ConvertReplicaTriggersToAlways,
       Migrations.Migration_20240110110200_DropUnusedFunctions,
-      Migrations.Migration_20240205141200_ReinstallTriggerFunctionWriteCorrectMaxTag
+      Migrations.Migration_20240205141200_ReinstallTriggerFunctionWriteCorrectMaxTag,
+      Migrations.Migration_20240213160300_DropGenerateElectrifiedSqlFunction
     ]
   end
 

--- a/components/electric/lib/electric/postgres/extension/migrations/20240213160300_drop_generate_electrified_sql_function.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240213160300_drop_generate_electrified_sql_function.ex
@@ -1,0 +1,22 @@
+defmodule Electric.Postgres.Extension.Migrations.Migration_20240213160300_DropGenerateElectrifiedSqlFunction do
+  alias Electric.Postgres.Extension
+
+  @behaviour Extension.Migration
+
+  @impl true
+  def version, do: 2024_02_13_16_03_00
+
+  @impl true
+  def up(schema) do
+    [
+      # We've changed the return type of this function so it needs to be dropped before the new definition can be
+      # applied.
+      "DROP ROUTINE IF EXISTS #{schema}.generate_electrified_sql(regclass)"
+    ]
+  end
+
+  @impl true
+  def down(_schema) do
+    []
+  end
+end

--- a/components/electric/priv/sql_function_templates/electrify.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify.sql.eex
@@ -6,7 +6,8 @@ DECLARE
     _schema name;
     _table text;
     _oid regclass;
-    _create_sql text;
+    _ddl_statement text;
+    _ddl_statements text[];
 BEGIN
     SELECT
         schema_name, table_name, table_oid
@@ -29,11 +30,14 @@ BEGIN
         CALL <%= schema() %>.__validate_table_constraints(_oid);
 
         -- insert the required ddl into the migrations table
-        SELECT <%= schema() %>.generate_electrified_sql(_oid) INTO _create_sql;
+        SELECT <%= schema() %>.generate_electrified_sql(_oid) INTO _ddl_statements;
 
-        RAISE DEBUG '%', _create_sql;
+        RAISE DEBUG '%', _ddl_statements;
 
-        CALL <%= schema() %>.capture_ddl(_create_sql);
+        FOREACH _ddl_statement IN ARRAY _ddl_statements
+        LOOP
+            CALL <%= schema() %>.capture_ddl(_ddl_statement);
+        END LOOP;
 
         EXECUTE format('ALTER TABLE %I.%I REPLICA IDENTITY FULL;', _schema, _table);
 

--- a/components/electric/priv/sql_function_templates/electrify/generate_electrified_sql.sql.eex
+++ b/components/electric/priv/sql_function_templates/electrify/generate_electrified_sql.sql.eex
@@ -1,27 +1,18 @@
 CREATE OR REPLACE FUNCTION <%= schema() %>.generate_electrified_sql(table_oid regclass)
-RETURNS text
+RETURNS text[]
 SECURITY DEFINER
 AS $function$
 DECLARE
     _col_type regtype;
-    _ddlgen_sql text;
-    _result_sql text := '';
+    _ddl_statements text[];
 BEGIN
-    FOR _col_type IN
-        SELECT atttypid
-            FROM pg_attribute
-            JOIN pg_type on atttypid = pg_type.oid
-            WHERE attrelid = table_oid AND attnum > 0 AND NOT attisdropped AND typtype = 'e'
-            ORDER BY attnum
-    LOOP
-        SELECT <%= schema() %>.ddlgen_create(_col_type) INTO _ddlgen_sql;
-        _result_sql := _result_sql || _ddlgen_sql;
-    END LOOP;
+    SELECT array_agg(<%= schema() %>.ddlgen_create(atttypid) ORDER BY attnum)
+        FROM pg_attribute
+        JOIN pg_type on atttypid = pg_type.oid
+        WHERE attrelid = table_oid AND attnum > 0 AND NOT attisdropped AND typtype = 'e'
+    INTO _ddl_statements;
 
-    SELECT <%= schema() %>.ddlgen_create(table_oid) INTO _ddlgen_sql;
-    _result_sql := _result_sql || _ddlgen_sql;
-
-    RETURN _result_sql;
+    RETURN array_append(_ddl_statements, (SELECT <%= schema() %>.ddlgen_create(table_oid)));
 END;
 $function$
 LANGUAGE PLPGSQL;

--- a/components/electric/test/electric/postgres/extension/ddl_capture_test.exs
+++ b/components/electric/test/electric/postgres/extension/ddl_capture_test.exs
@@ -289,13 +289,19 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
       {:ok, [], []} = :epgsql.squery(conn, sql)
     end
 
-    assert {:ok, [%{"id" => 1, "query" => query}]} = Extension.ddl_history(conn)
-    stmts = String.split(query, "\n\n\n", trim: true)
+    assert {:ok,
+            [
+              %{"id" => 1, "query" => query1},
+              %{"id" => 2, "query" => query2},
+              %{"id" => 3, "query" => query3}
+            ]} = Extension.ddl_history(conn)
 
-    assert [
-             "CREATE TABLE funny_table (" <> _,
-             "CREATE TYPE colors AS ENUM (\n 'red',\n 'turqoise',\n 'energizing_yellow'\n);",
-             "CREATE TYPE states AS ENUM (\n 'foo',\n 'bar'\n);"
-           ] = Enum.sort(stmts)
+    assert "CREATE TYPE states AS ENUM (\n 'foo',\n 'bar'\n);\n\n\n" == query1
+
+    assert "CREATE TYPE colors AS ENUM (\n 'red',\n 'turqoise',\n 'energizing_yellow'\n);\n\n\n" ==
+             query2
+
+    assert "CREATE TABLE funny_table (\n    id uuid NOT NULL,\n    s states,\n    c colors NOT NULL,\n    CONSTRAINT funny_table_pkey PRIMARY KEY (id)\n);\n\n\n" ==
+             query3
   end
 end


### PR DESCRIPTION
The old implementation incorrectly stores both the CREATE TYPE and CREATE TABLE statements in a single string. This was causing issues with translating those statements into SQLite dialect for the purpose of including them in SatOpMigrate messages.

There's no provision for users who already have electrified enums. We will ask them to reset their DB and start from scratch once this change is released.