### PR TITLE
fix(cli): Make `--debug` flag for CLI `generate` command always maintain migrations folders

### DIFF
--- a/.changeset/chatty-lies-impress.md
+++ b/.changeset/chatty-lies-impress.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Make `--debug` flag in CLI `generate` command always retain temporary migrations folders

--- a/clients/typescript/src/cli/migrations/command-generate.ts
+++ b/clients/typescript/src/cli/migrations/command-generate.ts
@@ -60,6 +60,9 @@ export function makeGenerateCommand(): Command {
       '--debug',
       dedent`
         Optional flag to enable debug mode.
+
+        When enabled, the temporary migration files used to generate
+        the client will be retained for inspection.
       `
     )
 

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -302,11 +302,8 @@ async function _generate(opts: Omit<GeneratorOptions, 'watch'>) {
     console.error('generate command failed: ' + e)
     throw e
   } finally {
-    // Delete our temporary directory unless
-    // generation failed in debug mode
-    if (!generationFailed || !opts.debug) {
-      await fs.rm(tmpFolder, { recursive: true })
-    }
+    // Delete our temporary directory unless in debug mode
+    if (!opts.debug) await fs.rm(tmpFolder, { recursive: true })
 
     // In case of process exit, make sure to run after folder removal
     if (generationFailed && opts.exitOnError) process.exit(1)

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -47,26 +47,27 @@ npx electric-sql generate [options]
 
 All arguments are optional. The principal ones are described below:
 
-| Argument or Env var  | Value        | Description                              |
-|----------------------|--------------|------------------------------------------|
-| <span className="no-wrap">`--service`</span><br/><span className="no-wrap">`-s`</span><br/>`ELECTRIC_SERVICE` |`<url>` | Provides the url to connect to the [Electric sync service](./service.md).<br /> Defaults to `http://localhost:5133`. |
-| <span className="no-wrap">`--proxy`</span><br/><span className="no-wrap">`-p`</span><br/>`ELECTRIC_PROXY` | `<url>` | Provides the url to connect to Electric's database proxy.<br /> Defaults to <span class="break-all">`postgresql://postgres:proxy_password@localhost:65432/electric`</span>. |
-| <span className="no-wrap">`--client-path`</span><br /><span className="no-wrap">`-o`</span><br />`ELECTRIC_CLIENT_PATH` | `<path>` | Specifies the output location for the generated client.<br /> Defaults to `./src/generated/client` |
-| <span className="no-wrap">`--watch`</span><br /><span className="no-wrap">`-w`</span> | `<pollingInterval>` | Run the generator in watch mode. Accepts an optional polling interval (in milliseconds) which defines how often to poll Electric for database migrations.<br /> The default polling interval is 1000ms. |
-| <span className="no-wrap">`--with-migrations`</span> | `<command>` | Specify a command to run migrations against an ephemeral postgres in order to create a client. [See details below](#local-only-first-mode) |
-| <span className="no-wrap">`--module-resolution`</span> | `<command>` | The module resolution used for the project. The generated client will be compatible with this resolution scheme, [see notes below](#electric_module_resolution). |
+| Argument or Env var                                                                                                     | Value               | Description                                                                                                                                                                                             |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <span className="no-wrap">`--service`</span><br/><span className="no-wrap">`-s`</span><br/>`ELECTRIC_SERVICE`           | `<url>`             | Provides the url to connect to the [Electric sync service](./service.md).<br /> Defaults to `http://localhost:5133`.                                                                                    |
+| <span className="no-wrap">`--proxy`</span><br/><span className="no-wrap">`-p`</span><br/>`ELECTRIC_PROXY`               | `<url>`             | Provides the url to connect to Electric's database proxy.<br /> Defaults to <span class="break-all">`postgresql://postgres:proxy_password@localhost:65432/electric`</span>.                             |
+| <span className="no-wrap">`--client-path`</span><br /><span className="no-wrap">`-o`</span><br />`ELECTRIC_CLIENT_PATH` | `<path>`            | Specifies the output location for the generated client.<br /> Defaults to `./src/generated/client`                                                                                                      |
+| <span className="no-wrap">`--watch`</span><br /><span className="no-wrap">`-w`</span>                                   | `<pollingInterval>` | Run the generator in watch mode. Accepts an optional polling interval (in milliseconds) which defines how often to poll Electric for database migrations.<br /> The default polling interval is 1000ms. |
+| <span className="no-wrap">`--with-migrations`</span>                                                                    | `<command>`         | Specify a command to run migrations against an ephemeral postgres in order to create a client. [See details below](#local-only-first-mode)                                                              |
+| <span className="no-wrap">`--module-resolution`</span>                                                                  | `<command>`         | The module resolution used for the project. The generated client will be compatible with this resolution scheme, [see notes below](#electric_module_resolution).                                        |
+| <span className="no-wrap">`--debug`</span>                                                                              |                     | Optional flag to enable debug mode. When enabled, the temporary migration files used to generate the client will be retained for inspection.                                                            |
 
 For a full list of arguments run `npx electric-sql help generate` or see the [environment variables](#environment-variables) below.
 
-#### Local-only-first mode  
+#### Local-only-first mode
 
-Normally, when you develop or deploy apps with Electric, you want to run the backend services (Postgres and Electric) in order to sync data. As a result, it's natural that the `generate` command expects you to be running the backend services during your build step.  
+Normally, when you develop or deploy apps with Electric, you want to run the backend services (Postgres and Electric) in order to sync data. As a result, it's natural that the `generate` command expects you to be running the backend services during your build step.
 
-However, it's also quite common in development or with an early version of an app, not to need data sync enabled yet. Either because you're just working on the interface or because your app starts off local-only and you plan to enable sync later. This makes the overhead of running (and potentially deploying) the backend services quite high, given that you're running them just to support the generate command in your build step.  
+However, it's also quite common in development or with an early version of an app, not to need data sync enabled yet. Either because you're just working on the interface or because your app starts off local-only and you plan to enable sync later. This makes the overhead of running (and potentially deploying) the backend services quite high, given that you're running them just to support the generate command in your build step.
 
-As a result, we provide a special `--with-migrations` mode for the generate command that allows you to generate the type safe client just from your migrations, without having to run the backend services yourself. Specifically what the `--with-migrations` option does is it tells the generate command to spin up a temporary Postgres and Electric itself, apply your migrations from scratch, generate the type safe client and then tear Electric and Postgres down. All of which happens automatically in the background for you.  
+As a result, we provide a special `--with-migrations` mode for the generate command that allows you to generate the type safe client just from your migrations, without having to run the backend services yourself. Specifically what the `--with-migrations` option does is it tells the generate command to spin up a temporary Postgres and Electric itself, apply your migrations from scratch, generate the type safe client and then tear Electric and Postgres down. All of which happens automatically in the background for you.
 
-We call this approach "local-only-first", in the sense that it allows you to develop local-only and then progressively enable sync later on, as and when you want to.  
+We call this approach "local-only-first", in the sense that it allows you to develop local-only and then progressively enable sync later on, as and when you want to.
 
 The `--with-migrations` command that takes the same argument form as the [`with-config`](#with-config) command. With this you can run:
 
@@ -83,7 +84,7 @@ npx electric-sql generate
 npx electric-sql stop --remove
 ```
 
-As you can see from the steps above, the backend is started, your migrations are applied, the type-safe client is generated and then everything is torn down and cleaned up for you. Allowing you to develop local-only-first and then run the backend services only when you actually want to enable sync.  
+As you can see from the steps above, the backend is started, your migrations are applied, the type-safe client is generated and then everything is torn down and cleaned up for you. Allowing you to develop local-only-first and then run the backend services only when you actually want to enable sync.
 
 ### proxy-tunnel
 
@@ -119,10 +120,10 @@ npx electric-sql proxy-tunnel [--service <url>] [--local-port <port>]
 
 All arguments are optional and are described below:
 
-| Argument or Env var  | Value        | Description                              |
-|----------------------|--------------|------------------------------------------|
-| <span className="no-wrap">`--service`</span><br/>`ELECTRIC_SERVICE` | `<url>` | Provides the url to connect to the Electric sync service. If not provided it uses the url set in the `ELECTRIC_URL` environment variable. If that variable is not set, it resorts to the default url which is `http://localhost:5133`. |
-| <span className="no-wrap">`--local-port`</span> | `<port>` | The local port to bind to; this will be forwarded to the Electric sync service, and defaults to `65432`. |
+| Argument or Env var                                                 | Value    | Description                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <span className="no-wrap">`--service`</span><br/>`ELECTRIC_SERVICE` | `<url>`  | Provides the url to connect to the Electric sync service. If not provided it uses the url set in the `ELECTRIC_URL` environment variable. If that variable is not set, it resorts to the default url which is `http://localhost:5133`. |
+| <span className="no-wrap">`--local-port`</span>                     | `<port>` | The local port to bind to; this will be forwarded to the Electric sync service, and defaults to `65432`.                                                                                                                               |
 
 ### start
 
@@ -148,15 +149,15 @@ npx electric-sql start [options]
 
 All arguments are optional. The principal ones are described below:
 
-| Argument or Env var  | Value        | Description                              |
-|----------------------|--------------|------------------------------------------|
-| <span className="no-wrap">`--with-postgres`</span> |  | Start a Postgres database along with Electric.
-| <span className="no-wrap">`--detach`</span> |  | Run in the background instead of printing logs to the console.
-| <span className="no-wrap">`--database-url`</span><br/><span className="no-wrap">`-db`</span><br/>`ELECTRIC_DATABASE_URL` | `<url>` | PostgreSQL connection URL for the database you want Electric to connect to. Mutually exclusive with `--with-postgres`. |
-| <span className="no-wrap">`--http-port`</span><br />`ELECTRIC_HTTP_PORT` | `<port>` | The local port to run the sync service on. Defaults to 5133 |
-| <span className="no-wrap">`--pg-proxy-port`</span><br />`ELECTRIC_PG_PROXY_PORT` | `<port>` | The local port to bind the Postgres Proxy port to. Defaults to 65432 |
-| <span className="no-wrap">`--image`</span><br />`ELECTRIC_IMAGE` | `<image>` | The Docker image to use for Electric. |
-| <span className="no-wrap">`--postgresql-image`</span><br />`ELECTRIC_POSTGRESQL_IMAGE` | `<image>` | The Docker image to use for the PostgreSQL database. |
+| Argument or Env var                                                                                                      | Value     | Description                                                                                                            |
+| ------------------------------------------------------------------------------------------------------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------- |
+| <span className="no-wrap">`--with-postgres`</span>                                                                       |           | Start a Postgres database along with Electric.                                                                         |
+| <span className="no-wrap">`--detach`</span>                                                                              |           | Run in the background instead of printing logs to the console.                                                         |
+| <span className="no-wrap">`--database-url`</span><br/><span className="no-wrap">`-db`</span><br/>`ELECTRIC_DATABASE_URL` | `<url>`   | PostgreSQL connection URL for the database you want Electric to connect to. Mutually exclusive with `--with-postgres`. |
+| <span className="no-wrap">`--http-port`</span><br />`ELECTRIC_HTTP_PORT`                                                 | `<port>`  | The local port to run the sync service on. Defaults to 5133                                                            |
+| <span className="no-wrap">`--pg-proxy-port`</span><br />`ELECTRIC_PG_PROXY_PORT`                                         | `<port>`  | The local port to bind the Postgres Proxy port to. Defaults to 65432                                                   |
+| <span className="no-wrap">`--image`</span><br />`ELECTRIC_IMAGE`                                                         | `<image>` | The Docker image to use for Electric.                                                                                  |
+| <span className="no-wrap">`--postgresql-image`</span><br />`ELECTRIC_POSTGRESQL_IMAGE`                                   | `<image>` | The Docker image to use for the PostgreSQL database.                                                                   |
 
 For a full list of arguments run `npx electric-sql help start` or see the [environment variables](#environment-variables) below.
 
@@ -172,9 +173,9 @@ npx electric-sql stop [--remove]
 
 The `stop` command accepts a single argument:
 
-| Argument             | Description                              |
-|----------------------|------------------------------------------|
-| <span className="no-wrap">`--remove`</span> | Remove the Docker containers and volumes previously created by `start`.
+| Argument                                    | Description                                                             |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| <span className="no-wrap">`--remove`</span> | Remove the Docker containers and volumes previously created by `start`. |
 
 ### status
 
@@ -196,9 +197,9 @@ npx electric-sql psql [--proxy <url>]
 
 #### Options
 
-| Argument or Env var  | Value        | Description                              |
-|----------------------|--------------|------------------------------------------|
-| <span className="no-wrap">`--proxy`</span><br /><span className="no-wrap">`-p`</span><br />`ELECTRIC_PROXY` | `<url>` | URL of the Electric service's PostgreSQL proxy.
+| Argument or Env var                                                                                         | Value   | Description                                     |
+| ----------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------- |
+| <span className="no-wrap">`--proxy`</span><br /><span className="no-wrap">`-p`</span><br />`ELECTRIC_PROXY` | `<url>` | URL of the Electric service's PostgreSQL proxy. |
 
 For a full list of arguments run `npx electric-sql help psql` or see the [environment variables](#environment-variables) below.
 
@@ -214,7 +215,7 @@ npx electric-sql show-config
 
 This command allows you to run a subcommand substituting arguments configured with Electric environment variables. It also makes all Electric configuration environment variables available to the subcommand.
 
-One of the main use cases for this command is running migrations against your Migration proxy using the configuration specified locally. 
+One of the main use cases for this command is running migrations against your Migration proxy using the configuration specified locally.
 
 It takes a single string argument, which is the command to run in string form, and substitutes configuration values inside double braces:
 
@@ -258,246 +259,246 @@ import EnvVarConfig from '@site/src/components/EnvVarConfig'
 #### ELECTRIC_CLIENT_PATH
 
 <EnvVarConfig
-    name="ELECTRIC_CLIENT_PATH"
-    defaultValue="./src/generated/client"
-    example="./src/electricClient"
->
-  Path to the directory where the generated client code will be written.
+name="ELECTRIC_CLIENT_PATH"
+defaultValue="./src/generated/client"
+example="./src/electricClient"
 
-  Used by the [`generate`](#generate) command.
+> Path to the directory where the generated client code will be written.
+
+Used by the [`generate`](#generate) command.
 </EnvVarConfig>
 
 #### ELECTRIC_CONTAINER_NAME
 
 <EnvVarConfig
-    name="ELECTRIC_CONTAINER_NAME"
-    defaultValue="electric"
-    example="nodenext"
->
-  This sets the name of the Docker containers when using the start command.
+name="ELECTRIC_CONTAINER_NAME"
+defaultValue="electric"
+example="nodenext"
 
-  It defaults to the `name` in your `packages.json` and falls back to `electric` otherwise.
+> This sets the name of the Docker containers when using the start command.
 
-  Used by the [`start`](#start) command.
+It defaults to the `name` in your `packages.json` and falls back to `electric` otherwise.
+
+Used by the [`start`](#start) command.
 
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_HOST
 
 <EnvVarConfig
-    name="ELECTRIC_DATABASE_HOST"
-    defaultValue="localhost"
-    example="electric.myhost.com"
->
-  Hostname of the database server.
+name="ELECTRIC_DATABASE_HOST"
+defaultValue="localhost"
+example="electric.myhost.com"
 
-  Used by the [`start`](#start) command.
+> Hostname of the database server.
+
+Used by the [`start`](#start) command.
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_NAME
 
 <EnvVarConfig
-    name="ELECTRIC_DATABASE_NAME"
-    defaultValue="electric"
-    example="db_password"
->
-  Name of the database to connect to.
+name="ELECTRIC_DATABASE_NAME"
+defaultValue="electric"
+example="db_password"
 
-  Used by the [`start`](#start) and [`psql`](#psql) commands.
+> Name of the database to connect to.
 
-  Defaults to the project name (i.e. `"name": "my-project-name"`) specified in your `package.json` file, falls back to `electric`.
+Used by the [`start`](#start) and [`psql`](#psql) commands.
+
+Defaults to the project name (i.e. `"name": "my-project-name"`) specified in your `package.json` file, falls back to `electric`.
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_PASSWORD
 
 <EnvVarConfig
-    name="ELECTRIC_DATABASE_PASSWORD"
-    defaultValue="db_password"
-    example="db_password"
->
-  Password to connect to the database with.
+name="ELECTRIC_DATABASE_PASSWORD"
+defaultValue="db_password"
+example="db_password"
 
-  Used by the [`start`](#start) command.
+> Password to connect to the database with.
+
+Used by the [`start`](#start) command.
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_PORT
 
 <EnvVarConfig
-    name="ELECTRIC_DATABASE_PORT"
-    defaultValue="5432"
-    example="5433"
->
-  Port number of the database server.
+name="ELECTRIC_DATABASE_PORT"
+defaultValue="5432"
+example="5433"
 
-  Used by the [`start`](#start) command.
+> Port number of the database server.
+
+Used by the [`start`](#start) command.
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_URL
 
 <EnvVarConfig
-    name="ELECTRIC_DATABASE_URL"
-    defaultValue="postgresql://{ELECTRIC_DATABASE_USER}:{ELECTRIC_DATABASE_PASSWORD}@{ELECTRIC_DATABASE_HOST}:{ELECTRIC_DATABASE_PORT}/{ELECTRIC_DATABASE_NAME}"
-    example="postgresql://postgres:db_password@electric.myhost.com:5432/electric-sql"
->
-  PostgreSQL connection URL for the database.
+name="ELECTRIC_DATABASE_URL"
+defaultValue="postgresql://{ELECTRIC_DATABASE_USER}:{ELECTRIC_DATABASE_PASSWORD}@{ELECTRIC_DATABASE_HOST}:{ELECTRIC_DATABASE_PORT}/{ELECTRIC_DATABASE_NAME}"
+example="postgresql://postgres:db_password@electric.myhost.com:5432/electric-sql"
 
-  Used by the [`start`](#start) command.
+> PostgreSQL connection URL for the database.
 
-  With all defaults, it evaluates to:
-  `postgresql://postgres:db_password@localhost:5432/electric-sql`
+Used by the [`start`](#start) command.
+
+With all defaults, it evaluates to:
+`postgresql://postgres:db_password@localhost:5432/electric-sql`
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_USER
 
 <EnvVarConfig
-    name="ELECTRIC_DATABASE_USER"
-    defaultValue="postgres"
-    example="my_db_user"
->
-  Username to connect to the database with.
+name="ELECTRIC_DATABASE_USER"
+defaultValue="postgres"
+example="my_db_user"
 
-  Used by the [`start`](#start) command.
+> Username to connect to the database with.
+
+Used by the [`start`](#start) command.
 </EnvVarConfig>
 
 #### ELECTRIC_HTTP_PORT
 
 <EnvVarConfig
-    name="ELECTRIC_HTTP_PORT"
-    defaultValue="5133"
-    example="5144"
->
-  Port for HTTP connections.
+name="ELECTRIC_HTTP_PORT"
+defaultValue="5133"
+example="5144"
 
-  Used by the [`start`](#start) command along with connecting to the sync service from your project client.
+> Port for HTTP connections.
+
+Used by the [`start`](#start) command along with connecting to the sync service from your project client.
 </EnvVarConfig>
 
 #### ELECTRIC_IMAGE
 
 <EnvVarConfig
-    name="ELECTRIC_PG_PROXY_PASSWORD"
-    defaultValue="electricsql/electric:{version-tag}"
-    example="electricsql/electric:0.8"
->
-  The Docker image to use for Electric.
+name="ELECTRIC_PG_PROXY_PASSWORD"
+defaultValue="electricsql/electric:{version-tag}"
+example="electricsql/electric:0.8"
 
-  Used by the [`start`](#start) command.
+> The Docker image to use for Electric.
 
-  Defaults to the matching minor version for the installed Electric client, so if you are using `electric-sql@0.8.2` the docker image tagged `electricsql/electric:0.8` (the latest in the `0.8.n` range) will be used.
+Used by the [`start`](#start) command.
+
+Defaults to the matching minor version for the installed Electric client, so if you are using `electric-sql@0.8.2` the docker image tagged `electricsql/electric:0.8` (the latest in the `0.8.n` range) will be used.
 </EnvVarConfig>
 
 #### ELECTRIC_MODULE_RESOLUTION
 
 <EnvVarConfig
-    name="ELECTRIC_MODULE_RESOLUTION"
-    defaultValue="node"
-    example="nodenext"
->
-  The module resolution used for the project. The generated client will be compatible with this resolution scheme.
-  
-  If you are using `nodenext` as your `tsconfig.json` `moduleResolution` then settings this to `nodenext` also will ensure that the generated client is compatible with your TypeScript configuration.
+name="ELECTRIC_MODULE_RESOLUTION"
+defaultValue="node"
+example="nodenext"
 
-  Used by the [`generate`](#generate) command.
+> The module resolution used for the project. The generated client will be compatible with this resolution scheme.
+
+If you are using `nodenext` as your `tsconfig.json` `moduleResolution` then settings this to `nodenext` also will ensure that the generated client is compatible with your TypeScript configuration.
+
+Used by the [`generate`](#generate) command.
 
 </EnvVarConfig>
 
 #### ELECTRIC_PG_PROXY_PASSWORD
 
 <EnvVarConfig
-    name="ELECTRIC_PG_PROXY_PASSWORD"
-    defaultValue="proxy_password"
-    example="my_password"
->
-  Password to use when connecting to the Postgres proxy via psql or any other Postgres client.
+name="ELECTRIC_PG_PROXY_PASSWORD"
+defaultValue="proxy_password"
+example="my_password"
 
-  Used by the [`start`](#start) and [`psql`](#psql) commands.
+> Password to use when connecting to the Postgres proxy via psql or any other Postgres client.
+
+Used by the [`start`](#start) and [`psql`](#psql) commands.
 </EnvVarConfig>
 
 #### ELECTRIC_PG_PROXY_PORT
 
 <EnvVarConfig
-    name="ELECTRIC_PG_PROXY_PORT"
-    defaultValue="65432"
-    example="65433"
->
-  Port number for connections to the Postgres migration proxy.
+name="ELECTRIC_PG_PROXY_PORT"
+defaultValue="65432"
+example="65433"
 
-  Used by the [`start`](#start) and [`psql`](#psql) commands.
+> Port number for connections to the Postgres migration proxy.
+
+Used by the [`start`](#start) and [`psql`](#psql) commands.
 </EnvVarConfig>
 
 #### ELECTRIC_POSTGRESQL_IMAGE
 
 <EnvVarConfig
-    name="ELECTRIC_PG_PROXY_PASSWORD"
-    defaultValue="postgres:14-alpine"
-    example="postgres:16"
->
-  The Docker image to use for the PostgreSQL database.
+name="ELECTRIC_PG_PROXY_PASSWORD"
+defaultValue="postgres:14-alpine"
+example="postgres:16"
 
-  Used by the [`start`](#start) command.
+> The Docker image to use for the PostgreSQL database.
+
+Used by the [`start`](#start) command.
 
 </EnvVarConfig>
 
 #### ELECTRIC_PROXY
 
 <EnvVarConfig
-    name="ELECTRIC_PROXY"
-    defaultValue="postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{ELECTRIC_SERVICE_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}"
-    example="postgresql://postgres:proxy_password@electric.mydomain.com:65432/electric"
->
-  URL of the Electric service's PostgreSQL proxy.
+name="ELECTRIC_PROXY"
+defaultValue="postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{ELECTRIC_SERVICE_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}"
+example="postgresql://postgres:proxy_password@electric.mydomain.com:65432/electric"
 
-  Used by the [`generate`](#generate) and [`psql`](#psql) commands.
+> URL of the Electric service's PostgreSQL proxy.
 
-  With all defaults, it evaluates to:
-  `postgresql://postgres:proxy_password@localhost:65432/electric`
+Used by the [`generate`](#generate) and [`psql`](#psql) commands.
+
+With all defaults, it evaluates to:
+`postgresql://postgres:proxy_password@localhost:65432/electric`
 </EnvVarConfig>
 
 #### ELECTRIC_SERVICE
 
 <EnvVarConfig
-    name="ELECTRIC_SERVICE"
-    defaultValue="http://{ELECTRIC_SERVICE_HOST}:{ELECTRIC_HTTP_PORT}"
-    example="https://electric.mydomain.com"
->
-  URL of the Electric service.
+name="ELECTRIC_SERVICE"
+defaultValue="http://{ELECTRIC_SERVICE_HOST}:{ELECTRIC_HTTP_PORT}"
+example="https://electric.mydomain.com"
 
-  Used by the [`generate`](#generate) command.
+> URL of the Electric service.
 
-  With all defaults, it evaluates to `http://localhost:5133`
+Used by the [`generate`](#generate) command.
+
+With all defaults, it evaluates to `http://localhost:5133`
 </EnvVarConfig>
 
-This `ELECTRIC_SERVICE` variable is perfect for configuring the Electric client in your project. 
+This `ELECTRIC_SERVICE` variable is perfect for configuring the Electric client in your project.
 
 ```typescript
-import { schema } from './generated/client'
+import { schema } from "./generated/client";
 
-const conn = await ElectricDatabase.init(scopedDbName)
+const conn = await ElectricDatabase.init(scopedDbName);
 const electric = await electrify(conn, schema, {
-  url: import.meta.env.ELECTRIC_SERVICE
+  url: import.meta.env.ELECTRIC_SERVICE,
   // ...
-})
+});
 ```
 
 #### ELECTRIC_SERVICE_HOST
 
 <EnvVarConfig
-    name="ELECTRIC_SERVICE_HOST"
-    defaultValue="localhost"
-    example="electric.mydomain.com"
->
-  Hostname the Electric service is running on.
+name="ELECTRIC_SERVICE_HOST"
+defaultValue="localhost"
+example="electric.mydomain.com"
 
-  Used by the [`generate`](#generate) and [`psql`](#psql) commands.
+> Hostname the Electric service is running on.
+
+Used by the [`generate`](#generate) and [`psql`](#psql) commands.
 </EnvVarConfig>
 
 #### ELECTRIC_WITH_POSTGRES
 
 <EnvVarConfig
-    name="ELECTRIC_WITH_POSTGRES"
-    defaultValue="true"
-    example="false"
->
-  Start a PostgreSQL database along with Electric.
+name="ELECTRIC_WITH_POSTGRES"
+defaultValue="true"
+example="false"
 
-  Used by the [`start`](#start) command.
+> Start a PostgreSQL database along with Electric.
+
+Used by the [`start`](#start) command.
 </EnvVarConfig>

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -47,27 +47,26 @@ npx electric-sql generate [options]
 
 All arguments are optional. The principal ones are described below:
 
-| Argument or Env var                                                                                                     | Value               | Description                                                                                                                                                                                             |
-| ----------------------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <span className="no-wrap">`--service`</span><br/><span className="no-wrap">`-s`</span><br/>`ELECTRIC_SERVICE`           | `<url>`             | Provides the url to connect to the [Electric sync service](./service.md).<br /> Defaults to `http://localhost:5133`.                                                                                    |
-| <span className="no-wrap">`--proxy`</span><br/><span className="no-wrap">`-p`</span><br/>`ELECTRIC_PROXY`               | `<url>`             | Provides the url to connect to Electric's database proxy.<br /> Defaults to <span class="break-all">`postgresql://postgres:proxy_password@localhost:65432/electric`</span>.                             |
-| <span className="no-wrap">`--client-path`</span><br /><span className="no-wrap">`-o`</span><br />`ELECTRIC_CLIENT_PATH` | `<path>`            | Specifies the output location for the generated client.<br /> Defaults to `./src/generated/client`                                                                                                      |
-| <span className="no-wrap">`--watch`</span><br /><span className="no-wrap">`-w`</span>                                   | `<pollingInterval>` | Run the generator in watch mode. Accepts an optional polling interval (in milliseconds) which defines how often to poll Electric for database migrations.<br /> The default polling interval is 1000ms. |
-| <span className="no-wrap">`--with-migrations`</span>                                                                    | `<command>`         | Specify a command to run migrations against an ephemeral postgres in order to create a client. [See details below](#local-only-first-mode)                                                              |
-| <span className="no-wrap">`--module-resolution`</span>                                                                  | `<command>`         | The module resolution used for the project. The generated client will be compatible with this resolution scheme, [see notes below](#electric_module_resolution).                                        |
-| <span className="no-wrap">`--debug`</span>                                                                              |                     | Optional flag to enable debug mode. When enabled, the temporary migration files used to generate the client will be retained for inspection.                                                            |
+| Argument or Env var  | Value        | Description                              |
+|----------------------|--------------|------------------------------------------|
+| <span className="no-wrap">`--service`</span><br/><span className="no-wrap">`-s`</span><br/>`ELECTRIC_SERVICE` |`<url>` | Provides the url to connect to the [Electric sync service](./service.md).<br /> Defaults to `http://localhost:5133`. |
+| <span className="no-wrap">`--proxy`</span><br/><span className="no-wrap">`-p`</span><br/>`ELECTRIC_PROXY` | `<url>` | Provides the url to connect to Electric's database proxy.<br /> Defaults to <span class="break-all">`postgresql://postgres:proxy_password@localhost:65432/electric`</span>. |
+| <span className="no-wrap">`--client-path`</span><br /><span className="no-wrap">`-o`</span><br />`ELECTRIC_CLIENT_PATH` | `<path>` | Specifies the output location for the generated client.<br /> Defaults to `./src/generated/client` |
+| <span className="no-wrap">`--watch`</span><br /><span className="no-wrap">`-w`</span> | `<pollingInterval>` | Run the generator in watch mode. Accepts an optional polling interval (in milliseconds) which defines how often to poll Electric for database migrations.<br /> The default polling interval is 1000ms. |
+| <span className="no-wrap">`--with-migrations`</span> | `<command>` | Specify a command to run migrations against an ephemeral postgres in order to create a client. [See details below](#local-only-first-mode) |
+| <span className="no-wrap">`--module-resolution`</span> | `<command>` | The module resolution used for the project. The generated client will be compatible with this resolution scheme, [see notes below](#electric_module_resolution). |
 
 For a full list of arguments run `npx electric-sql help generate` or see the [environment variables](#environment-variables) below.
 
-#### Local-only-first mode
+#### Local-only-first mode  
 
-Normally, when you develop or deploy apps with Electric, you want to run the backend services (Postgres and Electric) in order to sync data. As a result, it's natural that the `generate` command expects you to be running the backend services during your build step.
+Normally, when you develop or deploy apps with Electric, you want to run the backend services (Postgres and Electric) in order to sync data. As a result, it's natural that the `generate` command expects you to be running the backend services during your build step.  
 
-However, it's also quite common in development or with an early version of an app, not to need data sync enabled yet. Either because you're just working on the interface or because your app starts off local-only and you plan to enable sync later. This makes the overhead of running (and potentially deploying) the backend services quite high, given that you're running them just to support the generate command in your build step.
+However, it's also quite common in development or with an early version of an app, not to need data sync enabled yet. Either because you're just working on the interface or because your app starts off local-only and you plan to enable sync later. This makes the overhead of running (and potentially deploying) the backend services quite high, given that you're running them just to support the generate command in your build step.  
 
-As a result, we provide a special `--with-migrations` mode for the generate command that allows you to generate the type safe client just from your migrations, without having to run the backend services yourself. Specifically what the `--with-migrations` option does is it tells the generate command to spin up a temporary Postgres and Electric itself, apply your migrations from scratch, generate the type safe client and then tear Electric and Postgres down. All of which happens automatically in the background for you.
+As a result, we provide a special `--with-migrations` mode for the generate command that allows you to generate the type safe client just from your migrations, without having to run the backend services yourself. Specifically what the `--with-migrations` option does is it tells the generate command to spin up a temporary Postgres and Electric itself, apply your migrations from scratch, generate the type safe client and then tear Electric and Postgres down. All of which happens automatically in the background for you.  
 
-We call this approach "local-only-first", in the sense that it allows you to develop local-only and then progressively enable sync later on, as and when you want to.
+We call this approach "local-only-first", in the sense that it allows you to develop local-only and then progressively enable sync later on, as and when you want to.  
 
 The `--with-migrations` command that takes the same argument form as the [`with-config`](#with-config) command. With this you can run:
 
@@ -84,7 +83,7 @@ npx electric-sql generate
 npx electric-sql stop --remove
 ```
 
-As you can see from the steps above, the backend is started, your migrations are applied, the type-safe client is generated and then everything is torn down and cleaned up for you. Allowing you to develop local-only-first and then run the backend services only when you actually want to enable sync.
+As you can see from the steps above, the backend is started, your migrations are applied, the type-safe client is generated and then everything is torn down and cleaned up for you. Allowing you to develop local-only-first and then run the backend services only when you actually want to enable sync.  
 
 ### proxy-tunnel
 
@@ -120,10 +119,10 @@ npx electric-sql proxy-tunnel [--service <url>] [--local-port <port>]
 
 All arguments are optional and are described below:
 
-| Argument or Env var                                                 | Value    | Description                                                                                                                                                                                                                            |
-| ------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <span className="no-wrap">`--service`</span><br/>`ELECTRIC_SERVICE` | `<url>`  | Provides the url to connect to the Electric sync service. If not provided it uses the url set in the `ELECTRIC_URL` environment variable. If that variable is not set, it resorts to the default url which is `http://localhost:5133`. |
-| <span className="no-wrap">`--local-port`</span>                     | `<port>` | The local port to bind to; this will be forwarded to the Electric sync service, and defaults to `65432`.                                                                                                                               |
+| Argument or Env var  | Value        | Description                              |
+|----------------------|--------------|------------------------------------------|
+| <span className="no-wrap">`--service`</span><br/>`ELECTRIC_SERVICE` | `<url>` | Provides the url to connect to the Electric sync service. If not provided it uses the url set in the `ELECTRIC_URL` environment variable. If that variable is not set, it resorts to the default url which is `http://localhost:5133`. |
+| <span className="no-wrap">`--local-port`</span> | `<port>` | The local port to bind to; this will be forwarded to the Electric sync service, and defaults to `65432`. |
 
 ### start
 
@@ -149,15 +148,15 @@ npx electric-sql start [options]
 
 All arguments are optional. The principal ones are described below:
 
-| Argument or Env var                                                                                                      | Value     | Description                                                                                                            |
-| ------------------------------------------------------------------------------------------------------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------- |
-| <span className="no-wrap">`--with-postgres`</span>                                                                       |           | Start a Postgres database along with Electric.                                                                         |
-| <span className="no-wrap">`--detach`</span>                                                                              |           | Run in the background instead of printing logs to the console.                                                         |
-| <span className="no-wrap">`--database-url`</span><br/><span className="no-wrap">`-db`</span><br/>`ELECTRIC_DATABASE_URL` | `<url>`   | PostgreSQL connection URL for the database you want Electric to connect to. Mutually exclusive with `--with-postgres`. |
-| <span className="no-wrap">`--http-port`</span><br />`ELECTRIC_HTTP_PORT`                                                 | `<port>`  | The local port to run the sync service on. Defaults to 5133                                                            |
-| <span className="no-wrap">`--pg-proxy-port`</span><br />`ELECTRIC_PG_PROXY_PORT`                                         | `<port>`  | The local port to bind the Postgres Proxy port to. Defaults to 65432                                                   |
-| <span className="no-wrap">`--image`</span><br />`ELECTRIC_IMAGE`                                                         | `<image>` | The Docker image to use for Electric.                                                                                  |
-| <span className="no-wrap">`--postgresql-image`</span><br />`ELECTRIC_POSTGRESQL_IMAGE`                                   | `<image>` | The Docker image to use for the PostgreSQL database.                                                                   |
+| Argument or Env var  | Value        | Description                              |
+|----------------------|--------------|------------------------------------------|
+| <span className="no-wrap">`--with-postgres`</span> |  | Start a Postgres database along with Electric.
+| <span className="no-wrap">`--detach`</span> |  | Run in the background instead of printing logs to the console.
+| <span className="no-wrap">`--database-url`</span><br/><span className="no-wrap">`-db`</span><br/>`ELECTRIC_DATABASE_URL` | `<url>` | PostgreSQL connection URL for the database you want Electric to connect to. Mutually exclusive with `--with-postgres`. |
+| <span className="no-wrap">`--http-port`</span><br />`ELECTRIC_HTTP_PORT` | `<port>` | The local port to run the sync service on. Defaults to 5133 |
+| <span className="no-wrap">`--pg-proxy-port`</span><br />`ELECTRIC_PG_PROXY_PORT` | `<port>` | The local port to bind the Postgres Proxy port to. Defaults to 65432 |
+| <span className="no-wrap">`--image`</span><br />`ELECTRIC_IMAGE` | `<image>` | The Docker image to use for Electric. |
+| <span className="no-wrap">`--postgresql-image`</span><br />`ELECTRIC_POSTGRESQL_IMAGE` | `<image>` | The Docker image to use for the PostgreSQL database. |
 
 For a full list of arguments run `npx electric-sql help start` or see the [environment variables](#environment-variables) below.
 
@@ -173,9 +172,9 @@ npx electric-sql stop [--remove]
 
 The `stop` command accepts a single argument:
 
-| Argument                                    | Description                                                             |
-| ------------------------------------------- | ----------------------------------------------------------------------- |
-| <span className="no-wrap">`--remove`</span> | Remove the Docker containers and volumes previously created by `start`. |
+| Argument             | Description                              |
+|----------------------|------------------------------------------|
+| <span className="no-wrap">`--remove`</span> | Remove the Docker containers and volumes previously created by `start`.
 
 ### status
 
@@ -197,9 +196,9 @@ npx electric-sql psql [--proxy <url>]
 
 #### Options
 
-| Argument or Env var                                                                                         | Value   | Description                                     |
-| ----------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------- |
-| <span className="no-wrap">`--proxy`</span><br /><span className="no-wrap">`-p`</span><br />`ELECTRIC_PROXY` | `<url>` | URL of the Electric service's PostgreSQL proxy. |
+| Argument or Env var  | Value        | Description                              |
+|----------------------|--------------|------------------------------------------|
+| <span className="no-wrap">`--proxy`</span><br /><span className="no-wrap">`-p`</span><br />`ELECTRIC_PROXY` | `<url>` | URL of the Electric service's PostgreSQL proxy.
 
 For a full list of arguments run `npx electric-sql help psql` or see the [environment variables](#environment-variables) below.
 
@@ -215,7 +214,7 @@ npx electric-sql show-config
 
 This command allows you to run a subcommand substituting arguments configured with Electric environment variables. It also makes all Electric configuration environment variables available to the subcommand.
 
-One of the main use cases for this command is running migrations against your Migration proxy using the configuration specified locally.
+One of the main use cases for this command is running migrations against your Migration proxy using the configuration specified locally. 
 
 It takes a single string argument, which is the command to run in string form, and substitutes configuration values inside double braces:
 
@@ -259,246 +258,246 @@ import EnvVarConfig from '@site/src/components/EnvVarConfig'
 #### ELECTRIC_CLIENT_PATH
 
 <EnvVarConfig
-name="ELECTRIC_CLIENT_PATH"
-defaultValue="./src/generated/client"
-example="./src/electricClient"
+    name="ELECTRIC_CLIENT_PATH"
+    defaultValue="./src/generated/client"
+    example="./src/electricClient"
+>
+  Path to the directory where the generated client code will be written.
 
-> Path to the directory where the generated client code will be written.
-
-Used by the [`generate`](#generate) command.
+  Used by the [`generate`](#generate) command.
 </EnvVarConfig>
 
 #### ELECTRIC_CONTAINER_NAME
 
 <EnvVarConfig
-name="ELECTRIC_CONTAINER_NAME"
-defaultValue="electric"
-example="nodenext"
+    name="ELECTRIC_CONTAINER_NAME"
+    defaultValue="electric"
+    example="nodenext"
+>
+  This sets the name of the Docker containers when using the start command.
 
-> This sets the name of the Docker containers when using the start command.
+  It defaults to the `name` in your `packages.json` and falls back to `electric` otherwise.
 
-It defaults to the `name` in your `packages.json` and falls back to `electric` otherwise.
-
-Used by the [`start`](#start) command.
+  Used by the [`start`](#start) command.
 
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_HOST
 
 <EnvVarConfig
-name="ELECTRIC_DATABASE_HOST"
-defaultValue="localhost"
-example="electric.myhost.com"
+    name="ELECTRIC_DATABASE_HOST"
+    defaultValue="localhost"
+    example="electric.myhost.com"
+>
+  Hostname of the database server.
 
-> Hostname of the database server.
-
-Used by the [`start`](#start) command.
+  Used by the [`start`](#start) command.
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_NAME
 
 <EnvVarConfig
-name="ELECTRIC_DATABASE_NAME"
-defaultValue="electric"
-example="db_password"
+    name="ELECTRIC_DATABASE_NAME"
+    defaultValue="electric"
+    example="db_password"
+>
+  Name of the database to connect to.
 
-> Name of the database to connect to.
+  Used by the [`start`](#start) and [`psql`](#psql) commands.
 
-Used by the [`start`](#start) and [`psql`](#psql) commands.
-
-Defaults to the project name (i.e. `"name": "my-project-name"`) specified in your `package.json` file, falls back to `electric`.
+  Defaults to the project name (i.e. `"name": "my-project-name"`) specified in your `package.json` file, falls back to `electric`.
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_PASSWORD
 
 <EnvVarConfig
-name="ELECTRIC_DATABASE_PASSWORD"
-defaultValue="db_password"
-example="db_password"
+    name="ELECTRIC_DATABASE_PASSWORD"
+    defaultValue="db_password"
+    example="db_password"
+>
+  Password to connect to the database with.
 
-> Password to connect to the database with.
-
-Used by the [`start`](#start) command.
+  Used by the [`start`](#start) command.
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_PORT
 
 <EnvVarConfig
-name="ELECTRIC_DATABASE_PORT"
-defaultValue="5432"
-example="5433"
+    name="ELECTRIC_DATABASE_PORT"
+    defaultValue="5432"
+    example="5433"
+>
+  Port number of the database server.
 
-> Port number of the database server.
-
-Used by the [`start`](#start) command.
+  Used by the [`start`](#start) command.
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_URL
 
 <EnvVarConfig
-name="ELECTRIC_DATABASE_URL"
-defaultValue="postgresql://{ELECTRIC_DATABASE_USER}:{ELECTRIC_DATABASE_PASSWORD}@{ELECTRIC_DATABASE_HOST}:{ELECTRIC_DATABASE_PORT}/{ELECTRIC_DATABASE_NAME}"
-example="postgresql://postgres:db_password@electric.myhost.com:5432/electric-sql"
+    name="ELECTRIC_DATABASE_URL"
+    defaultValue="postgresql://{ELECTRIC_DATABASE_USER}:{ELECTRIC_DATABASE_PASSWORD}@{ELECTRIC_DATABASE_HOST}:{ELECTRIC_DATABASE_PORT}/{ELECTRIC_DATABASE_NAME}"
+    example="postgresql://postgres:db_password@electric.myhost.com:5432/electric-sql"
+>
+  PostgreSQL connection URL for the database.
 
-> PostgreSQL connection URL for the database.
+  Used by the [`start`](#start) command.
 
-Used by the [`start`](#start) command.
-
-With all defaults, it evaluates to:
-`postgresql://postgres:db_password@localhost:5432/electric-sql`
+  With all defaults, it evaluates to:
+  `postgresql://postgres:db_password@localhost:5432/electric-sql`
 </EnvVarConfig>
 
 #### ELECTRIC_DATABASE_USER
 
 <EnvVarConfig
-name="ELECTRIC_DATABASE_USER"
-defaultValue="postgres"
-example="my_db_user"
+    name="ELECTRIC_DATABASE_USER"
+    defaultValue="postgres"
+    example="my_db_user"
+>
+  Username to connect to the database with.
 
-> Username to connect to the database with.
-
-Used by the [`start`](#start) command.
+  Used by the [`start`](#start) command.
 </EnvVarConfig>
 
 #### ELECTRIC_HTTP_PORT
 
 <EnvVarConfig
-name="ELECTRIC_HTTP_PORT"
-defaultValue="5133"
-example="5144"
+    name="ELECTRIC_HTTP_PORT"
+    defaultValue="5133"
+    example="5144"
+>
+  Port for HTTP connections.
 
-> Port for HTTP connections.
-
-Used by the [`start`](#start) command along with connecting to the sync service from your project client.
+  Used by the [`start`](#start) command along with connecting to the sync service from your project client.
 </EnvVarConfig>
 
 #### ELECTRIC_IMAGE
 
 <EnvVarConfig
-name="ELECTRIC_PG_PROXY_PASSWORD"
-defaultValue="electricsql/electric:{version-tag}"
-example="electricsql/electric:0.8"
+    name="ELECTRIC_PG_PROXY_PASSWORD"
+    defaultValue="electricsql/electric:{version-tag}"
+    example="electricsql/electric:0.8"
+>
+  The Docker image to use for Electric.
 
-> The Docker image to use for Electric.
+  Used by the [`start`](#start) command.
 
-Used by the [`start`](#start) command.
-
-Defaults to the matching minor version for the installed Electric client, so if you are using `electric-sql@0.8.2` the docker image tagged `electricsql/electric:0.8` (the latest in the `0.8.n` range) will be used.
+  Defaults to the matching minor version for the installed Electric client, so if you are using `electric-sql@0.8.2` the docker image tagged `electricsql/electric:0.8` (the latest in the `0.8.n` range) will be used.
 </EnvVarConfig>
 
 #### ELECTRIC_MODULE_RESOLUTION
 
 <EnvVarConfig
-name="ELECTRIC_MODULE_RESOLUTION"
-defaultValue="node"
-example="nodenext"
+    name="ELECTRIC_MODULE_RESOLUTION"
+    defaultValue="node"
+    example="nodenext"
+>
+  The module resolution used for the project. The generated client will be compatible with this resolution scheme.
+  
+  If you are using `nodenext` as your `tsconfig.json` `moduleResolution` then settings this to `nodenext` also will ensure that the generated client is compatible with your TypeScript configuration.
 
-> The module resolution used for the project. The generated client will be compatible with this resolution scheme.
-
-If you are using `nodenext` as your `tsconfig.json` `moduleResolution` then settings this to `nodenext` also will ensure that the generated client is compatible with your TypeScript configuration.
-
-Used by the [`generate`](#generate) command.
+  Used by the [`generate`](#generate) command.
 
 </EnvVarConfig>
 
 #### ELECTRIC_PG_PROXY_PASSWORD
 
 <EnvVarConfig
-name="ELECTRIC_PG_PROXY_PASSWORD"
-defaultValue="proxy_password"
-example="my_password"
+    name="ELECTRIC_PG_PROXY_PASSWORD"
+    defaultValue="proxy_password"
+    example="my_password"
+>
+  Password to use when connecting to the Postgres proxy via psql or any other Postgres client.
 
-> Password to use when connecting to the Postgres proxy via psql or any other Postgres client.
-
-Used by the [`start`](#start) and [`psql`](#psql) commands.
+  Used by the [`start`](#start) and [`psql`](#psql) commands.
 </EnvVarConfig>
 
 #### ELECTRIC_PG_PROXY_PORT
 
 <EnvVarConfig
-name="ELECTRIC_PG_PROXY_PORT"
-defaultValue="65432"
-example="65433"
+    name="ELECTRIC_PG_PROXY_PORT"
+    defaultValue="65432"
+    example="65433"
+>
+  Port number for connections to the Postgres migration proxy.
 
-> Port number for connections to the Postgres migration proxy.
-
-Used by the [`start`](#start) and [`psql`](#psql) commands.
+  Used by the [`start`](#start) and [`psql`](#psql) commands.
 </EnvVarConfig>
 
 #### ELECTRIC_POSTGRESQL_IMAGE
 
 <EnvVarConfig
-name="ELECTRIC_PG_PROXY_PASSWORD"
-defaultValue="postgres:14-alpine"
-example="postgres:16"
+    name="ELECTRIC_PG_PROXY_PASSWORD"
+    defaultValue="postgres:14-alpine"
+    example="postgres:16"
+>
+  The Docker image to use for the PostgreSQL database.
 
-> The Docker image to use for the PostgreSQL database.
-
-Used by the [`start`](#start) command.
+  Used by the [`start`](#start) command.
 
 </EnvVarConfig>
 
 #### ELECTRIC_PROXY
 
 <EnvVarConfig
-name="ELECTRIC_PROXY"
-defaultValue="postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{ELECTRIC_SERVICE_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}"
-example="postgresql://postgres:proxy_password@electric.mydomain.com:65432/electric"
+    name="ELECTRIC_PROXY"
+    defaultValue="postgresql://postgres:{ELECTRIC_PG_PROXY_PASSWORD}@{ELECTRIC_SERVICE_HOST}:{ELECTRIC_PG_PROXY_PORT}/{ELECTRIC_DATABASE_NAME}"
+    example="postgresql://postgres:proxy_password@electric.mydomain.com:65432/electric"
+>
+  URL of the Electric service's PostgreSQL proxy.
 
-> URL of the Electric service's PostgreSQL proxy.
+  Used by the [`generate`](#generate) and [`psql`](#psql) commands.
 
-Used by the [`generate`](#generate) and [`psql`](#psql) commands.
-
-With all defaults, it evaluates to:
-`postgresql://postgres:proxy_password@localhost:65432/electric`
+  With all defaults, it evaluates to:
+  `postgresql://postgres:proxy_password@localhost:65432/electric`
 </EnvVarConfig>
 
 #### ELECTRIC_SERVICE
 
 <EnvVarConfig
-name="ELECTRIC_SERVICE"
-defaultValue="http://{ELECTRIC_SERVICE_HOST}:{ELECTRIC_HTTP_PORT}"
-example="https://electric.mydomain.com"
+    name="ELECTRIC_SERVICE"
+    defaultValue="http://{ELECTRIC_SERVICE_HOST}:{ELECTRIC_HTTP_PORT}"
+    example="https://electric.mydomain.com"
+>
+  URL of the Electric service.
 
-> URL of the Electric service.
+  Used by the [`generate`](#generate) command.
 
-Used by the [`generate`](#generate) command.
-
-With all defaults, it evaluates to `http://localhost:5133`
+  With all defaults, it evaluates to `http://localhost:5133`
 </EnvVarConfig>
 
-This `ELECTRIC_SERVICE` variable is perfect for configuring the Electric client in your project.
+This `ELECTRIC_SERVICE` variable is perfect for configuring the Electric client in your project. 
 
 ```typescript
-import { schema } from "./generated/client";
+import { schema } from './generated/client'
 
-const conn = await ElectricDatabase.init(scopedDbName);
+const conn = await ElectricDatabase.init(scopedDbName)
 const electric = await electrify(conn, schema, {
-  url: import.meta.env.ELECTRIC_SERVICE,
+  url: import.meta.env.ELECTRIC_SERVICE
   // ...
-});
+})
 ```
 
 #### ELECTRIC_SERVICE_HOST
 
 <EnvVarConfig
-name="ELECTRIC_SERVICE_HOST"
-defaultValue="localhost"
-example="electric.mydomain.com"
+    name="ELECTRIC_SERVICE_HOST"
+    defaultValue="localhost"
+    example="electric.mydomain.com"
+>
+  Hostname the Electric service is running on.
 
-> Hostname the Electric service is running on.
-
-Used by the [`generate`](#generate) and [`psql`](#psql) commands.
+  Used by the [`generate`](#generate) and [`psql`](#psql) commands.
 </EnvVarConfig>
 
 #### ELECTRIC_WITH_POSTGRES
 
 <EnvVarConfig
-name="ELECTRIC_WITH_POSTGRES"
-defaultValue="true"
-example="false"
+    name="ELECTRIC_WITH_POSTGRES"
+    defaultValue="true"
+    example="false"
+>
+  Start a PostgreSQL database along with Electric.
 
-> Start a PostgreSQL database along with Electric.
-
-Used by the [`start`](#start) command.
+  Used by the [`start`](#start) command.
 </EnvVarConfig>


### PR DESCRIPTION
As @alco pointed out, the expected behaviour of the `--debug` flag would be to always retain the temporary migrations folder for inspection and debugging regardless of whether the generation succeeds or not.

I've added a few more tests to cover this behaviour for all 4 paths (with/without debug, failure/success).

I've also added the flag to the documentation for the CLI `generate` command and added more info on what the flag does in the CLI help text.