### PR TITLE
chore(electric): Limit client connections when the sync service's Postgres connection is down

### DIFF
--- a/.changeset/dry-pillows-confess.md
+++ b/.changeset/dry-pillows-confess.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Limit client connections when the sync service's Postgres connection is down.

--- a/components/electric/lib/electric/plug/proxy_websocket_plug.ex
+++ b/components/electric/lib/electric/plug/proxy_websocket_plug.ex
@@ -46,7 +46,7 @@ defmodule Electric.Plug.ProxyWebsocketPlug do
         )
 
       {:error, reason} ->
-        Logger.debug("Client WebSocket connection failed with reason: #{reason}")
+        Logger.warning("Client WebSocket connection failed with reason: #{reason}")
         send_resp(conn, 400, "Bad request")
     end
   end

--- a/components/electric/lib/electric/plug/satellite_websocket_plug.ex
+++ b/components/electric/lib/electric/plug/satellite_websocket_plug.ex
@@ -63,7 +63,7 @@ defmodule Electric.Plug.SatelliteWebsocketPlug do
 
       :error ->
         reason = "Missing satellite websocket subprotocol"
-        Logger.debug("Client WebSocket connection failed with reason: #{reason}")
+        Logger.warning("Client WebSocket connection failed with reason: #{reason}")
         {:error, 400, reason}
     end
   end
@@ -75,7 +75,7 @@ defmodule Electric.Plug.SatelliteWebsocketPlug do
       reason =
         "Cannot connect satellite version #{assigns.satellite_vsn}: this server requires #{requirements}"
 
-      Logger.debug("Client WebSocket connection failed with reason: #{reason}")
+      Logger.warning("Client WebSocket connection failed with reason: #{reason}")
       {:error, 400, reason}
     end
   end

--- a/components/electric/lib/electric/replication/postgres_manager.ex
+++ b/components/electric/lib/electric/replication/postgres_manager.ex
@@ -87,7 +87,7 @@ defmodule Electric.Replication.PostgresConnectorMng do
     Process.flag(:trap_exit, true)
 
     # Use an ETS table to store data that are regularly looked up by other processes.
-    :ets.new(ets_table_name(origin), [:protected, :named_table, :read_concurrency])
+    :ets.new(ets_table_name(origin), [:protected, :named_table, {:read_concurrency, true}])
 
     state =
       %State{origin: origin, connector_config: connector_config}

--- a/components/electric/lib/electric/replication/postgres_manager.ex
+++ b/components/electric/lib/electric/replication/postgres_manager.ex
@@ -87,7 +87,7 @@ defmodule Electric.Replication.PostgresConnectorMng do
     Process.flag(:trap_exit, true)
 
     # Use an ETS table to store data that are regularly looked up by other processes.
-    :ets.new(ets_table_name(origin), [:protected, :named_table, {:read_concurrency, true}])
+    :ets.new(ets_table_name(origin), [:protected, :named_table, read_concurrency: true])
 
     state =
       %State{origin: origin, connector_config: connector_config}


### PR DESCRIPTION
Fixes VAX-1290.

This change also addresses the problem where a request sent to `/api/status` could time out if the Postgres Manager process was itself blocked on an IO call at the time.