### PR TITLE
chore(electric): Make sure AUTH_MODE=secure when secure auth options are used

### DIFF
--- a/.changeset/funny-lions-provide.md
+++ b/.changeset/funny-lions-provide.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Electric will now fail to start when a secure auth setting is used with AUTH_MODE=insecure.

--- a/components/electric/lib/electric/config.ex
+++ b/components/electric/lib/electric/config.ex
@@ -28,7 +28,7 @@ defmodule Electric.Config do
   @spec validate_auth_config(binary, keyword) ::
           {Electric.Satellite.Auth.provider() | nil, [{binary, {:error, binary}}]}
   def validate_auth_config(auth_mode, auth_opts) do
-    auth_mode_opts = for {key, {_, val}} <- auth_opts, do: {key, val}
+    auth_mode_opts = filter_auth_opts(auth_opts)
 
     case Electric.Satellite.Auth.build_provider(auth_mode, auth_mode_opts) do
       {:ok, provider} ->
@@ -43,6 +43,12 @@ defmodule Electric.Config do
       {:error, key, reason} ->
         {varname, _} = Keyword.fetch!(auth_opts, key)
         {nil, [{varname, {:error, reason}}]}
+    end
+  end
+
+  defp filter_auth_opts(auth_opts) do
+    for {key, {_, val}} <- auth_opts, is_binary(val) and String.trim(val) != "" do
+      {key, val}
     end
   end
 

--- a/components/electric/lib/electric/satellite/auth/secure.ex
+++ b/components/electric/lib/electric/satellite/auth/secure.ex
@@ -50,7 +50,7 @@ defmodule Electric.Satellite.Auth.Secure do
     * `aud: <string>` - optional audience string to check all auth tokens with. If this is configured, JWTs without an
       "aud" claim will be considered invalid.
   """
-  @spec build_config(Access.t()) :: {:ok, map} | {:error, atom, binary}
+  @spec build_config(keyword) :: {:ok, map} | {:error, atom, binary}
   def build_config(opts) do
     with {:ok, alg} <- validate_alg(opts),
          {:ok, key} <- validate_key(alg, opts) do

--- a/components/electric/test/electric/config_test.exs
+++ b/components/electric/test/electric/config_test.exs
@@ -102,6 +102,19 @@ defmodule Electric.ConfigTest do
                  key: {"AUTH_JWT_KEY", "..."}
                )
     end
+
+    test "complains about secure auth opts in insecure mode" do
+      error_msg = "is not valid in Insecure auth mode. Did you forget to set AUTH_MODE=secure?"
+
+      assert {nil, [{"AUTH_JWT_ALG", {:error, error_msg}}]} ==
+               validate_auth_config("insecure", alg: {"AUTH_JWT_ALG", "HS256"})
+
+      assert {nil, [{"AUTH_JWT_KEY", {:error, error_msg}}]} ==
+               validate_auth_config("insecure",
+                 key: {"AUTH_JWT_KEY", "..."},
+                 alg: {"AUTH_JWT_ALG", "HS256"}
+               )
+    end
   end
 
   describe "parse_pg_proxy_port" do

--- a/components/electric/test/electric/satellite/auth/insecure_test.exs
+++ b/components/electric/test/electric/satellite/auth/insecure_test.exs
@@ -181,6 +181,7 @@ defmodule Electric.Satellite.Auth.InsecureTest do
   end
 
   defp config(opts) do
-    Auth.Insecure.build_config(opts)
+    {:ok, config} = Auth.Insecure.build_config(opts)
+    config
   end
 end


### PR DESCRIPTION
Fixes VAX-1589.

I can configure Electric with AUTH_MODE=insecure and AUTH_JWT_ALG=RS256 and it'll run just fine. This is dangerous because 1) I forgot to configure the signing key, 2) it doesn't matter anyway because the token signatures won't be validated in the insecure mode.

This PR makes it so that if any secure auth settings are used together with AUTH_MODE=insecure, Electric will fail to start and will log an error.