### PR TITLE
fix(starter): Bring back the .gitignore template file

### DIFF
--- a/.changeset/breezy-trees-own.md
+++ b/.changeset/breezy-trees-own.md
@@ -1,0 +1,5 @@
+---
+"create-electric-app": patch
+---
+
+Add a .gitignore file to newly created apps such that running `git init` in them will ignore the `node_modules/` and other ephemeral directories/files by default.

--- a/examples/starter/make-templates.js
+++ b/examples/starter/make-templates.js
@@ -3,6 +3,7 @@ import {
   stat,
   copyFile,
   mkdir,
+  rename,
   rm,
   writeFile,
   readFile,
@@ -53,6 +54,7 @@ try {
 await mkdir(templateDir, { recursive: true })
 await copyFiles(exampleDir, templateDir)
 await copyFiles(templateOverlayDir, templateDir)
+await rename(join(templateDir, '.gitignore'), join(templateDir, 'dot_gitignore'))
 
 // change package name and version
 const packageJsonPath = join(templateDir, 'package.json')

--- a/examples/starter/make-templates.js
+++ b/examples/starter/make-templates.js
@@ -54,6 +54,9 @@ try {
 await mkdir(templateDir, { recursive: true })
 await copyFiles(exampleDir, templateDir)
 await copyFiles(templateOverlayDir, templateDir)
+
+// npmjs.com seems to be removing .gitignore files from published packages.
+// Hance this renaming operation and a reverse operation in src/index.ts.
 await rename(join(templateDir, '.gitignore'), join(templateDir, 'dot_gitignore'))
 
 // change package name and version

--- a/examples/starter/src/index.ts
+++ b/examples/starter/src/index.ts
@@ -135,6 +135,7 @@ await fs.mkdir(projectDir, { recursive: true })
 const thisDir = path.dirname(fileURLToPath(import.meta.url))
 const templateDir = path.resolve(thisDir, '..', 'template')
 await fs.cp(templateDir, projectDir, { recursive: true })
+await fs.rename(path.join(projectDir, 'dot_gitignore'), path.join(projectDir, '.gitignore'))
 
 // read package.json file and parse it as JSON
 // we could import it but then we get a warning


### PR DESCRIPTION
It was unintentionally removed in https://github.com/electric-sql/electric/pull/676.

Fixes VAX-1591.