### PR TITLE
feat(electric): Validate signing keys at startup

### DIFF
--- a/.changeset/metal-bats-worry.md
+++ b/.changeset/metal-bats-worry.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Validate public signing keys at startup. This allows for catching invalid key configuration early as opposed to getting an "invalid token signature" error when a client tries to authenticate.

--- a/.changeset/tall-stingrays-change.md
+++ b/.changeset/tall-stingrays-change.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Accept base64-encoded symmetric signing keys. Electric will detect and decode such keys automatically. Binary keys are also accepted as before.

--- a/components/electric/lib/electric/satellite/auth/secure.ex
+++ b/components/electric/lib/electric/satellite/auth/secure.ex
@@ -100,6 +100,9 @@ defmodule Electric.Satellite.Auth.Secure do
   end
 
   defp validate_key(key, "HS" <> _ = alg) do
+    # Try decoding the user-provided key as base64. If that fails, assume the key is a raw
+    # binary and use it verbatim.
+    # The `padding: false` is required to accept keys that are base64-encoded without padding.
     raw_key =
       case Base.decode64(key, padding: false) do
         {:ok, raw_key} -> raw_key

--- a/components/electric/test/electric/satellite/auth/secure_test.exs
+++ b/components/electric/test/electric/satellite/auth/secure_test.exs
@@ -6,7 +6,7 @@ defmodule Electric.Satellite.Auth.SecureTest do
   alias Electric.Satellite.Auth
 
   @namespace "https://electric-sql.com/jwt/claims"
-  @signing_key ~c"abcdefghijklmnopqrstuvwxyz012345" |> Enum.shuffle() |> List.to_string()
+  @signing_key ~c"abcdefghijklmnopqrstuvwxyz01234_" |> Enum.shuffle() |> List.to_string()
 
   describe "build_config()" do
     test "returns a clean map when all checks pass" do
@@ -34,6 +34,22 @@ defmodule Electric.Satellite.Auth.SecureTest do
              } = config
     end
 
+    test "accepts a base64-encoded symmetric key" do
+      options = [
+        [],
+        [padding: true],
+        [padding: false]
+      ]
+
+      Enum.each(options, fn opts ->
+        raw_key = String.duplicate(<<1, 2, 3, 4, 5, 6, 7, 8>>, 4)
+        opts = [alg: "HS256", key: Base.encode64(raw_key, opts)]
+
+        assert {:ok, config} = build_config(opts)
+        assert is_map(config)
+      end)
+    end
+
     test "checks for missing 'alg'" do
       assert {:error, :alg, "not set"} == build_config([])
     end
@@ -55,6 +71,33 @@ defmodule Electric.Satellite.Auth.SecureTest do
 
       assert {:error, :key, "has to be at least 64 bytes long for HS512"} ==
                build_config(alg: "HS512", key: "key")
+    end
+
+    test "validates the base64-encoded key length" do
+      raw_key = String.duplicate("_", 31)
+      key = Base.encode64(raw_key)
+      assert byte_size(key) >= 32
+
+      assert {:error, :key, "has to be at least 32 bytes long for HS256"} ==
+               build_config(alg: "HS256", key: key)
+
+      ###
+
+      raw_key = String.duplicate("_", 47)
+      key = Base.encode64(raw_key)
+      assert byte_size(key) >= 48
+
+      assert {:error, :key, "has to be at least 48 bytes long for HS384"} ==
+               build_config(alg: "HS384", key: key)
+
+      ###
+
+      raw_key = String.duplicate("_", 63)
+      key = Base.encode64(raw_key)
+      assert byte_size(key) >= 64
+
+      assert {:error, :key, "has to be at least 64 bytes long for HS512"} ==
+               build_config(alg: "HS512", key: key)
     end
 
     test "validates the public key format" do

--- a/components/electric/test/fixtures/keys/README.md
+++ b/components/electric/test/fixtures/keys/README.md
@@ -13,8 +13,8 @@ One RSA key pair can be used for all `RS*` signing algorithms, namely, `RS256`, 
 as follows:
 
 ```
-$ openssl genrsa -out rsa.pem 4096
-$ openssl rsa -in rsa.pem -pubout -out rsa_pub.pem
+openssl genrsa -out rsa.pem 4096
+openssl rsa -in rsa.pem -pubout -out rsa_pub.pem
 ```
 
 ## ECC
@@ -25,20 +25,20 @@ variation. Here's how the `ecc*.pem` keys in this directory have been created.
 ### `ES256`
 
 ```
-$ openssl ecparam -name prime256v1 -genkey -noout -out ecc256.pem
-$ openssl ec -in ecc256.pem -pubout -out ecc256_pub.pem
+openssl ecparam -name prime256v1 -genkey -noout -out ecc256.pem
+openssl ec -in ecc256.pem -pubout -out ecc256_pub.pem
 ```
 
 ### `ES384`
 
 ```
-$ openssl ecparam -name secp384r1 -genkey -noout -out ecc384.pem
-$ openssl ec -in ecc384.pem -pubout -out ecc384_pub.pem
+openssl ecparam -name secp384r1 -genkey -noout -out ecc384.pem
+openssl ec -in ecc384.pem -pubout -out ecc384_pub.pem
 ```
 
 ### `ES512`
 
 ```
-$ openssl ecparam -name secp521r1 -genkey -noout -out ecc512.pem
-$ openssl ec -in ecc512.pem -pubout -out ecc512_pub.pem
+openssl ecparam -name secp521r1 -genkey -noout -out ecc512.pem
+openssl ec -in ecc512.pem -pubout -out ecc512_pub.pem
 ```


### PR DESCRIPTION
This PR adds validation for public keys and makes it possible to use base64-encoded symmetric keys.

Fixes VAX-1584:
Validating public keys at startup provides early feedback to the developer about misconfigured auth.

Fixes VAX-1583:
Pasting a key used for token signature verification verbatim into the AUTH_JWT_KEY configuration option is problematic for binary symmetric keys.

Online JWT tools, such as jwt.io and token.dev, take base64-encoded keys by default. So newcomers to Electric get confused when they try to use their base64-encoded key with it and see signature verification errors logged by Electric.

We can detect if the value configured for AUTH_JWT_KEY is base64-encoded since the encoding has a limited set of characters.