### PR TITLE
Add support for ?dialect=postgresql to /api/migrations

### DIFF
--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -383,11 +383,15 @@ export interface SatOpMigrate_PgColumnType {
   size: number[];
 }
 
+/** reserved 2, 3; */
 export interface SatOpMigrate_Column {
   $type: "Electric.Satellite.SatOpMigrate.Column";
-  name: string;
+  /** deprecated */
   sqliteType: string;
+  /** deprecated */
   pgType: SatOpMigrate_PgColumnType | undefined;
+  name: string;
+  typeInfo: SatOpMigrate_PgColumnType | undefined;
 }
 
 export interface SatOpMigrate_ForeignKey {
@@ -2462,21 +2466,30 @@ export const SatOpMigrate_PgColumnType = {
 messageTypeRegistry.set(SatOpMigrate_PgColumnType.$type, SatOpMigrate_PgColumnType);
 
 function createBaseSatOpMigrate_Column(): SatOpMigrate_Column {
-  return { $type: "Electric.Satellite.SatOpMigrate.Column", name: "", sqliteType: "", pgType: undefined };
+  return {
+    $type: "Electric.Satellite.SatOpMigrate.Column",
+    sqliteType: "",
+    pgType: undefined,
+    name: "",
+    typeInfo: undefined,
+  };
 }
 
 export const SatOpMigrate_Column = {
   $type: "Electric.Satellite.SatOpMigrate.Column" as const,
 
   encode(message: SatOpMigrate_Column, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.name !== "") {
-      writer.uint32(10).string(message.name);
-    }
     if (message.sqliteType !== "") {
       writer.uint32(18).string(message.sqliteType);
     }
     if (message.pgType !== undefined) {
       SatOpMigrate_PgColumnType.encode(message.pgType, writer.uint32(26).fork()).ldelim();
+    }
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.typeInfo !== undefined) {
+      SatOpMigrate_PgColumnType.encode(message.typeInfo, writer.uint32(34).fork()).ldelim();
     }
     return writer;
   },
@@ -2488,13 +2501,6 @@ export const SatOpMigrate_Column = {
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        case 1:
-          if (tag !== 10) {
-            break;
-          }
-
-          message.name = reader.string();
-          continue;
         case 2:
           if (tag !== 18) {
             break;
@@ -2508,6 +2514,20 @@ export const SatOpMigrate_Column = {
           }
 
           message.pgType = SatOpMigrate_PgColumnType.decode(reader, reader.uint32());
+          continue;
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        case 4:
+          if (tag !== 34) {
+            break;
+          }
+
+          message.typeInfo = SatOpMigrate_PgColumnType.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -2524,10 +2544,13 @@ export const SatOpMigrate_Column = {
 
   fromPartial<I extends Exact<DeepPartial<SatOpMigrate_Column>, I>>(object: I): SatOpMigrate_Column {
     const message = createBaseSatOpMigrate_Column();
-    message.name = object.name ?? "";
     message.sqliteType = object.sqliteType ?? "";
     message.pgType = (object.pgType !== undefined && object.pgType !== null)
       ? SatOpMigrate_PgColumnType.fromPartial(object.pgType)
+      : undefined;
+    message.name = object.name ?? "";
+    message.typeInfo = (object.typeInfo !== undefined && object.typeInfo !== null)
+      ? SatOpMigrate_PgColumnType.fromPartial(object.typeInfo)
       : undefined;
     return message;
   },

--- a/clients/typescript/src/migrators/triggers.ts
+++ b/clients/typescript/src/migrators/triggers.ts
@@ -8,12 +8,7 @@ type ForeignKey = {
 }
 
 type ColumnName = string
-type SQLiteType = string
-type PgType = string
-type ColumnType = {
-  sqliteType: SQLiteType
-  pgType: PgType
-}
+type ColumnType = string
 type ColumnTypes = Record<ColumnName, ColumnType>
 
 export type Table = {
@@ -282,10 +277,8 @@ function joinColsForJSON(
   // casts the value to TEXT if it is of type REAL
   // to work around the bug in SQLite's `json_object` function
   const castIfNeeded = (col: string, targettedCol: string) => {
-    const tpes = colTypes[col]
-    const sqliteType = tpes.sqliteType
-    const pgType = tpes.pgType
-    if (sqliteType === 'REAL' || pgType === 'INT8' || pgType === 'BIGINT') {
+    const colType = colTypes[col]
+    if (colType === 'FLOAT4' || colType === 'REAL' || colType === 'INT8' || colType === 'BIGINT') {
       return `cast(${targettedCol} as TEXT)`
     } else {
       return targettedCol

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -1613,10 +1613,7 @@ export function generateTriggersForTable(tbl: MigrationTable): Statement[] {
     columnTypes: Object.fromEntries(
       tbl.columns.map((col) => [
         col.name,
-        {
-          sqliteType: col.sqliteType.toUpperCase(),
-          pgType: col.pgType!.name.toUpperCase(),
-        },
+        col.typeInfo.name.toUpperCase(),
       ])
     ),
   }

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -138,6 +138,7 @@ export type DataChange = {
   tags: Tag[]
 }
 
+// TODO: Update this to use either typeInfo or pgType.
 export type SatOpMigrate_Col = Omit<SatOpMigrate_Column, '$type' | 'pgType'> & {
   pgType: Omit<SatOpMigrate_PgColumnType, '$type'> | undefined
 }

--- a/components/electric/lib/electric/plug/migrations.ex
+++ b/components/electric/lib/electric/plug/migrations.ex
@@ -46,6 +46,7 @@ defmodule Electric.Plug.Migrations do
   defp get_dialect(%{query_params: %{"dialect" => dialect_name}}) do
     case dialect_name do
       "sqlite" -> {:ok, Electric.Postgres.Dialect.SQLite}
+      "postgresql" -> {:ok, Electric.Postgres.Dialect.Postgresql}
       _ -> {:error, "unsupported dialect #{inspect(dialect_name)}"}
     end
   end

--- a/components/electric/lib/electric/postgres/replication.ex
+++ b/components/electric/lib/electric/postgres/replication.ex
@@ -69,7 +69,7 @@ defmodule Electric.Postgres.Replication do
         {:ok, [], []}
 
       propagate_ast ->
-        {msg, relations} = build_replication_msg(propagate_ast, schema_version, dialect)
+        {msg, relations} = build_replication_msg(propagate_ast, stmt, schema_version, dialect)
 
         {:ok, [msg], relations}
     end
@@ -89,6 +89,9 @@ defmodule Electric.Postgres.Replication do
         :ALTER_ADD_COLUMN
     end
   end
+
+  defp to_sql(_ast, stmt, Dialect.Postgresql), do: stmt
+  defp to_sql(ast, _stmt, dialect), do: Dialect.to_sql(ast, dialect)
 
   def affected_tables(stmts, dialect \\ @default_dialect) when is_list(stmts) do
     stmts
@@ -112,7 +115,7 @@ defmodule Electric.Postgres.Replication do
     []
   end
 
-  defp build_replication_msg(ast, schema_version, dialect) do
+  defp build_replication_msg(ast, stmt, schema_version, dialect) do
     affected_tables = affected_tables(ast, dialect)
 
     relations = Enum.map(affected_tables, &{&1.schema, &1.name})
@@ -133,7 +136,7 @@ defmodule Electric.Postgres.Replication do
         ast,
         &%SatOpMigrate.Stmt{
           type: stmt_type(&1),
-          sql: Dialect.to_sql(&1, dialect)
+          sql: to_sql(&1, stmt, dialect)
         }
       )
 
@@ -168,17 +171,17 @@ defmodule Electric.Postgres.Replication do
   defp replication_msg_table(%Proto.Table{} = table, dialect) do
     %SatOpMigrate.Table{
       name: Dialect.table_name(table.name, dialect),
-      columns: Enum.map(table.columns, &replication_msg_table_col(&1, dialect)),
+      columns: Enum.map(table.columns, &replication_msg_table_col(&1)),
       fks: Enum.flat_map(table.constraints, &replication_msg_table_fk(&1, dialect)),
-      pks: Enum.flat_map(table.constraints, &replication_msg_table_pk(&1, dialect))
+      pks: Enum.flat_map(table.constraints, &replication_msg_table_pk(&1))
     }
   end
 
-  defp replication_msg_table_col(%Proto.Column{} = column, dialect) do
+  defp replication_msg_table_col(%Proto.Column{} = column) do
     %SatOpMigrate.Column{
       name: column.name,
       pg_type: replication_msg_table_col_type(column.type),
-      sqlite_type: Dialect.type_name(column.type, dialect)
+      sqlite_type: Dialect.type_name(column.type, Dialect.SQLite)
     }
   end
 
@@ -190,13 +193,8 @@ defmodule Electric.Postgres.Replication do
     }
   end
 
-  defp replication_msg_table_pk(%Proto.Constraint{constraint: {:primary, pk}}, _dialect) do
-    pk.keys
-  end
-
-  defp replication_msg_table_pk(_constraint, _dialect) do
-    []
-  end
+  defp replication_msg_table_pk(%Proto.Constraint{constraint: {:primary, pk}}), do: pk.keys
+  defp replication_msg_table_pk(_constraint), do: []
 
   defp replication_msg_table_fk(%Proto.Constraint{constraint: {:foreign, fk}}, dialect) do
     [

--- a/components/electric/lib/electric/postgres/replication.ex
+++ b/components/electric/lib/electric/postgres/replication.ex
@@ -180,6 +180,7 @@ defmodule Electric.Postgres.Replication do
   defp replication_msg_table_col(%Proto.Column{} = column) do
     %SatOpMigrate.Column{
       name: column.name,
+      type_info: replication_msg_table_col_type(column.type),
       pg_type: replication_msg_table_col_type(column.type),
       sqlite_type: Dialect.type_name(column.type, Dialect.SQLite)
     }

--- a/components/electric/lib/electric/postgres/schema/proto/messages.ex
+++ b/components/electric/lib/electric/postgres/schema/proto/messages.ex
@@ -805,7 +805,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -1201,7 +1201,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, 2, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -2399,7 +2399,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -3169,7 +3169,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_bool(bytes)
@@ -3209,7 +3209,7 @@
               {8, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[fk_cols: msg.fk_cols ++ [delimited]], rest}
+                {[fk_cols: msg.fk_cols ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {9, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -3226,7 +3226,7 @@
               {10, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[pk_cols: msg.pk_cols ++ [delimited]], rest}
+                {[pk_cols: msg.pk_cols ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -3914,7 +3914,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {value, rest} =
@@ -4451,7 +4451,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_bool(bytes)
@@ -4849,17 +4849,17 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[keys: msg.keys ++ [delimited]], rest}
+                {[keys: msg.keys ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[including: msg.including ++ [delimited]], rest}
+                {[including: msg.including ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {5, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_bool(bytes)
@@ -5343,17 +5343,17 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[keys: msg.keys ++ [delimited]], rest}
+                {[keys: msg.keys ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[including: msg.including ++ [delimited]], rest}
+                {[including: msg.including ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {5, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_bool(bytes)
@@ -5800,7 +5800,7 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[values: msg.values ++ [delimited]], rest}
+                {[values: msg.values ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -7010,7 +7010,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -7984,7 +7984,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -8477,7 +8477,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -9168,7 +9168,7 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[value: delimited], rest}
+                {[value: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -9472,7 +9472,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -9873,7 +9873,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -9904,7 +9904,7 @@
               {5, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[including: msg.including ++ [delimited]], rest}
+                {[including: msg.including ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {6, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -9921,7 +9921,7 @@
               {7, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[using: delimited], rest}
+                {[using: Protox.Decode.validate_string(delimited)], rest}
 
               {8, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_int32(bytes)
@@ -10525,12 +10525,12 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[collation: delimited], rest}
+                {[collation: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -11008,17 +11008,17 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[schema: delimited], rest}
+                {[schema: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[alias: delimited], rest}
+                {[alias: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)

--- a/components/electric/lib/electric/satellite/protobuf_messages.ex
+++ b/components/electric/lib/electric/satellite/protobuf_messages.ex
@@ -1735,7 +1735,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[tablename: delimited], rest}
+                {[tablename: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -2172,12 +2172,12 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[message: delimited], rest}
+                {[message: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[request_id: delimited], rest}
+                {[request_id: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -2556,12 +2556,12 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[message: delimited], rest}
+                {[message: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[request_id: delimited], rest}
+                {[request_id: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -2994,12 +2994,16 @@
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[subscription_ids: msg.subscription_ids ++ [delimited]], rest}
+
+                {[
+                   subscription_ids:
+                     msg.subscription_ids ++ [Protox.Decode.validate_string(delimited)]
+                 ], rest}
 
               {5, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[schema_version: delimited], rest}
+                {[schema_version: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -3417,12 +3421,12 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[id: delimited], rest}
+                {[id: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[token: delimited], rest}
+                {[token: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -3774,7 +3778,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[subscription_id: delimited], rest}
+                {[subscription_id: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -4145,12 +4149,12 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[message: delimited], rest}
+                {[message: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[subscription_id: delimited], rest}
+                {[subscription_id: Protox.Decode.validate_string(delimited)], rest}
 
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -4610,7 +4614,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -4632,7 +4636,7 @@
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[pks: msg.pks ++ [delimited]], rest}
+                {[pks: msg.pks ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -5035,17 +5039,17 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[fk_cols: msg.fk_cols ++ [delimited]], rest}
+                {[fk_cols: msg.fk_cols ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[pk_table: delimited], rest}
+                {[pk_table: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[pk_cols: msg.pk_cols ++ [delimited]], rest}
+                {[pk_cols: msg.pk_cols ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -5477,7 +5481,7 @@
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[tags: msg.tags ++ [delimited]], rest}
+                {[tags: msg.tags ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -5905,7 +5909,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[version: delimited], rest}
+                {[version: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -6310,7 +6314,7 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[trans_id: delimited], rest}
+                {[trans_id: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -6320,7 +6324,7 @@
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[origin: delimited], rest}
+                {[origin: Protox.Decode.validate_string(delimited)], rest}
 
               {5, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_bool(bytes)
@@ -7000,7 +7004,7 @@
   end,
   defmodule Electric.Satellite.SatOpMigrate.Column do
     @moduledoc false
-    defstruct name: "", sqlite_type: "", pg_type: nil
+    defstruct name: "", sqlite_type: "", pg_type: nil, type_info: nil
 
     (
       (
@@ -7015,7 +7019,11 @@
 
         @spec encode!(struct) :: iodata | no_return
         def encode!(msg) do
-          [] |> encode_name(msg) |> encode_sqlite_type(msg) |> encode_pg_type(msg)
+          []
+          |> encode_name(msg)
+          |> encode_sqlite_type(msg)
+          |> encode_pg_type(msg)
+          |> encode_type_info(msg)
         end
       )
 
@@ -7058,6 +7066,18 @@
             ArgumentError ->
               reraise Protox.EncodingError.new(:pg_type, "invalid field value"), __STACKTRACE__
           end
+        end,
+        defp encode_type_info(acc, msg) do
+          try do
+            if msg.type_info == nil do
+              acc
+            else
+              [acc, "\"", Protox.Encode.encode_message(msg.type_info)]
+            end
+          rescue
+            ArgumentError ->
+              reraise Protox.EncodingError.new(:type_info, "invalid field value"), __STACKTRACE__
+          end
         end
       ]
 
@@ -7099,12 +7119,12 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[sqlite_type: delimited], rest}
+                {[sqlite_type: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -7114,6 +7134,18 @@
                    pg_type:
                      Protox.MergeMessage.merge(
                        msg.pg_type,
+                       Electric.Satellite.SatOpMigrate.PgColumnType.decode!(delimited)
+                     )
+                 ], rest}
+
+              {4, _, bytes} ->
+                {len, bytes} = Protox.Varint.decode(bytes)
+                {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
+
+                {[
+                   type_info:
+                     Protox.MergeMessage.merge(
+                       msg.type_info,
                        Electric.Satellite.SatOpMigrate.PgColumnType.decode!(delimited)
                      )
                  ], rest}
@@ -7178,7 +7210,9 @@
           1 => {:name, {:scalar, ""}, :string},
           2 => {:sqlite_type, {:scalar, ""}, :string},
           3 =>
-            {:pg_type, {:scalar, nil}, {:message, Electric.Satellite.SatOpMigrate.PgColumnType}}
+            {:pg_type, {:scalar, nil}, {:message, Electric.Satellite.SatOpMigrate.PgColumnType}},
+          4 =>
+            {:type_info, {:scalar, nil}, {:message, Electric.Satellite.SatOpMigrate.PgColumnType}}
         }
       end
 
@@ -7190,7 +7224,8 @@
         %{
           name: {1, {:scalar, ""}, :string},
           pg_type: {3, {:scalar, nil}, {:message, Electric.Satellite.SatOpMigrate.PgColumnType}},
-          sqlite_type: {2, {:scalar, ""}, :string}
+          sqlite_type: {2, {:scalar, ""}, :string},
+          type_info: {4, {:scalar, nil}, {:message, Electric.Satellite.SatOpMigrate.PgColumnType}}
         }
       end
     )
@@ -7224,6 +7259,15 @@
             label: :optional,
             name: :pg_type,
             tag: 3,
+            type: {:message, Electric.Satellite.SatOpMigrate.PgColumnType}
+          },
+          %{
+            __struct__: Protox.Field,
+            json_name: "typeInfo",
+            kind: {:scalar, nil},
+            label: :optional,
+            name: :type_info,
+            tag: 4,
             type: {:message, Electric.Satellite.SatOpMigrate.PgColumnType}
           }
         ]
@@ -7340,6 +7384,46 @@
              }}
           end
         ),
+        (
+          def field_def(:type_info) do
+            {:ok,
+             %{
+               __struct__: Protox.Field,
+               json_name: "typeInfo",
+               kind: {:scalar, nil},
+               label: :optional,
+               name: :type_info,
+               tag: 4,
+               type: {:message, Electric.Satellite.SatOpMigrate.PgColumnType}
+             }}
+          end
+
+          def field_def("typeInfo") do
+            {:ok,
+             %{
+               __struct__: Protox.Field,
+               json_name: "typeInfo",
+               kind: {:scalar, nil},
+               label: :optional,
+               name: :type_info,
+               tag: 4,
+               type: {:message, Electric.Satellite.SatOpMigrate.PgColumnType}
+             }}
+          end
+
+          def field_def("type_info") do
+            {:ok,
+             %{
+               __struct__: Protox.Field,
+               json_name: "typeInfo",
+               kind: {:scalar, nil},
+               label: :optional,
+               name: :type_info,
+               tag: 4,
+               type: {:message, Electric.Satellite.SatOpMigrate.PgColumnType}
+             }}
+          end
+        ),
         def field_def(_) do
           {:error, :no_such_field}
         end
@@ -7371,6 +7455,9 @@
         {:ok, ""}
       end,
       def default(:pg_type) do
+        {:ok, nil}
+      end,
+      def default(:type_info) do
         {:ok, nil}
       end,
       def default(_) do
@@ -7508,7 +7595,7 @@
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[message: delimited], rest}
+                {[message: Protox.Decode.validate_string(delimited)], rest}
 
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -7914,7 +8001,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, 2, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -8266,12 +8353,12 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[request_id: delimited], rest}
+                {[request_id: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[uuid: delimited], rest}
+                {[uuid: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -8568,7 +8655,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[subscription_id: delimited], rest}
+                {[subscription_id: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -8895,7 +8982,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[method: delimited], rest}
+                {[method: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_uint32(bytes)
@@ -9338,7 +9425,7 @@
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[message: delimited], rest}
+                {[message: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -9742,7 +9829,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[schema_name: delimited], rest}
+                {[schema_name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {value, rest} =
@@ -9753,7 +9840,7 @@
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[table_name: delimited], rest}
+                {[table_name: Protox.Decode.validate_string(delimited)], rest}
 
               {4, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_uint32(bytes)
@@ -10415,7 +10502,7 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[message: delimited], rest}
+                {[message: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -10727,7 +10814,7 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[trans_id: delimited], rest}
+                {[trans_id: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -11089,7 +11176,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[request_id: delimited], rest}
+                {[request_id: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -11443,12 +11530,12 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[name: delimited], rest}
+                {[name: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[type: delimited], rest}
+                {[type: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_bool(bytes)
@@ -12010,7 +12097,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[subscription_id: delimited], rest}
+                {[subscription_id: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -12326,7 +12413,11 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[subscription_ids: msg.subscription_ids ++ [delimited]], rest}
+
+                {[
+                   subscription_ids:
+                     msg.subscription_ids ++ [Protox.Decode.validate_string(delimited)]
+                 ], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -13026,7 +13117,7 @@
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[tags: msg.tags ++ [delimited]], rest}
+                {[tags: msg.tags ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -13585,7 +13676,7 @@
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[tags: msg.tags ++ [delimited]], rest}
+                {[tags: msg.tags ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -13977,7 +14068,7 @@
               {4, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[tags: msg.tags ++ [delimited]], rest}
+                {[tags: msg.tags ++ [Protox.Decode.validate_string(delimited)]], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -14836,7 +14927,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[id: delimited], rest}
+                {[id: Protox.Decode.validate_string(delimited)], rest}
 
               {3, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
@@ -15148,7 +15239,7 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[sql: delimited], rest}
+                {[sql: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -15449,7 +15540,7 @@
               {2, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[value: delimited], rest}
+                {[value: Protox.Decode.validate_string(delimited)], rest}
 
               {tag, wire_type, rest} ->
                 {_, rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
@@ -15752,7 +15843,7 @@
               {1, _, bytes} ->
                 {len, bytes} = Protox.Varint.decode(bytes)
                 {delimited, rest} = Protox.Decode.parse_delimited(bytes, len)
-                {[method: delimited], rest}
+                {[method: Protox.Decode.validate_string(delimited)], rest}
 
               {2, _, bytes} ->
                 {value, rest} = Protox.Decode.parse_uint32(bytes)

--- a/components/electric/test/electric/plug_test.exs
+++ b/components/electric/test/electric/plug_test.exs
@@ -122,12 +122,14 @@ defmodule Electric.PlugTest do
                     %SatOpMigrate.Column{
                       name: "id",
                       sqlite_type: "TEXT",
-                      pg_type: %SatOpMigrate.PgColumnType{name: "uuid"}
+                      pg_type: %SatOpMigrate.PgColumnType{name: "uuid"},
+                      type_info: %SatOpMigrate.PgColumnType{name: "uuid"}
                     },
                     %SatOpMigrate.Column{
                       name: "value",
                       sqlite_type: "TEXT",
-                      pg_type: %SatOpMigrate.PgColumnType{name: "text"}
+                      pg_type: %SatOpMigrate.PgColumnType{name: "text"},
+                      type_info: %SatOpMigrate.PgColumnType{name: "text"}
                     }
                   ],
                   fks: [],
@@ -200,12 +202,14 @@ defmodule Electric.PlugTest do
                     %SatOpMigrate.Column{
                       name: "id",
                       sqlite_type: "TEXT",
-                      pg_type: %SatOpMigrate.PgColumnType{name: "uuid"}
+                      pg_type: %SatOpMigrate.PgColumnType{name: "uuid"},
+                      type_info: %SatOpMigrate.PgColumnType{name: "uuid"}
                     },
                     %SatOpMigrate.Column{
                       name: "value",
                       sqlite_type: "TEXT",
-                      pg_type: %SatOpMigrate.PgColumnType{name: "text"}
+                      pg_type: %SatOpMigrate.PgColumnType{name: "text"},
+                      type_info: %SatOpMigrate.PgColumnType{name: "text"}
                     }
                   ],
                   fks: [],

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -340,9 +340,15 @@ message SatOpMigrate {
         repeated int32 size = 3;
     }
     message Column {
-        string name = 1;
-        string sqlite_type = 2;
+        //reserved 2, 3;
+
+        // deprecated
+        string sqlite_type = 2;    
+        // deprecated
         PgColumnType pg_type = 3;
+
+        string name = 1;
+        PgColumnType type_info = 4;
     }
     message ForeignKey {
         // the columns in the child table that point to the parent


### PR DESCRIPTION
Closes VAX-1659.

Passing `?dialect=postgresql` to `/api/migrations` will now result in the returned migrations to have the original Postgres DDL.