### PR TITLE
chore(docs): Add more info to the Supabase IPv4 connectivity notice

### DIFF
--- a/docs/deployment/supabase.md
+++ b/docs/deployment/supabase.md
@@ -11,6 +11,16 @@ We support both the hosted [Supabase Platform](https://supabase.com/docs/guides/
 
 Supabase is an open source Firebase alternative. It provides a Postgres database, authentication, APIs, edge functions, realtime subscriptions, storage and vector embeddings. Supabase is **not** an application or web service host. To use Electric with Supabase, you still need to deploy your own Electric sync service.
 
+:::caution Troubleshooting connectivity issues with Supabase Platform
+Supabase Platform [dropped IPv4 support](https://supabase.com/docs/guides/platform/ipv4-address) for direct database connections on 26 January 2023. Following that, you may see "socket closed" errors in Electric's logs or it may seem like Electric is stuck without producing any log output at all.
+
+The network where Electric is running must support IPv6. If you're running Electric on your own computer, check whether your ISP has IPv6 support on https://test-ipv6.com. If you see "No IPv6 address detected" on that page, consider using a VPN service that works with IPv6 networks, such as Proton VPN.
+
+When running Electric in a Docker container, there's an additional hurdle in that Docker does not enable IPv6 out-of-the-box. Follow the [official guide](https://docs.docker.com/config/daemon/ipv6/#use-ipv6-for-the-default-bridge-network) to configure your Docker daemon for IPv6.
+
+If you are subscribed to the Pro or Team plan on Supabase Platform, you can side-step those hurdles by purchasing the [IPv4 add-on](https://supabase.com/docs/guides/platform/ipv4-address#enabling-the-add-on) from Supabase to make your database host available at an IPv4 address.
+:::
+
 ## How to connect Electric to Supabase Postgres
 
 1. [Setting up a Supabase Postgres](#1-setting-up-a-supabase-postgres)
@@ -53,12 +63,9 @@ Electric needs to establish a replication connection to the database, so it has 
 
 You will use this as the value for the `DATABASE_URL` in your [Electric sync service configuration](../api/service.md).
 
-:::caution Connectivity problems with Supabase Platform
-Supabase Platform [dropped IPv4 support](https://supabase.com/blog/ipv6) for direct database connections on 26 January 2023. Following that, you may see "socket closed" errors in Electric's logs or it may seem like Electric is stuck without producing any log output at all.
+:::caution
 
-The network where Electric is running must support IPv6. If you're running Electric in your own computer, check whether your ISP has IPv6 support on https://test-ipv6.com. If you see "No IPv6 address detected" on that page, consider using a VPN service that works with IPv6 networks.
-
-When running Electric in a Docker container, there's an additional hurdle in that Docker does not enable IPv6 out-of-the-box. Follow the [official guide](https://docs.docker.com/config/daemon/ipv6/#use-ipv6-for-the-default-bridge-network) to configure your Docker daemon for IPv6.
+Make sure you're familiar with Supabase's recent abolition of IPv4 addresses for direct database connections. See the troubleshooting notice [at the top of this page](#) for details.
 :::
 
 ### 3. Retrieving the authentication key


### PR DESCRIPTION
Make the IPv4 notice more prominent on the Supabase page and mention the option of purchasing the IPv4 add-on.

Preview - https://deploy-preview-110--electric-sql-website.netlify.app/docs/deployment/supabase/