### PR TITLE
chore(docs): Update driver docs to use async call for `findMany` query

### DIFF
--- a/docs/integrations/drivers/mobile/react-native.md
+++ b/docs/integrations/drivers/mobile/react-native.md
@@ -56,7 +56,7 @@ You can now use the client to read, write and sync data, e.g.:
 ```tsx
 const { db } = electric
 
-const results = db.projects.findMany()
+const results = await db.projects.findMany()
 console.log(results)
 ```
 

--- a/docs/integrations/drivers/server/node.md
+++ b/docs/integrations/drivers/server/node.md
@@ -48,7 +48,7 @@ You can now use the client to read, write and sync data, e.g.:
 ```tsx
 const { db } = electric
 
-const results = db.projects.findMany()
+const results = await db.projects.findMany()
 console.log(results)
 ```
 

--- a/docs/integrations/drivers/web/wa-sqlite.md
+++ b/docs/integrations/drivers/web/wa-sqlite.md
@@ -55,7 +55,7 @@ You can now use the client to read, write and sync data, e.g.:
 ```tsx
 const { db } = electric
 
-const results = db.projects.findMany()
+const results = await db.projects.findMany()
 console.log(results)
 ```
 


### PR DESCRIPTION
In driver docs, some async query calls were not awaited - might look confusing.