### PR TITLE
chore(docs): Remove backwards compatibility claim for `user_id` in token claims

### DIFF
--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -36,7 +36,7 @@ const config = {
 }
 const conn = await ElectricDatabase.init('electric.db', '')
 const electric = await electrify(conn, schema, config)
-const token = insecureAuthToken({user_id: 'dummy'})
+const token = insecureAuthToken({sub: 'dummy'})
 await electric.connect(token)
 ```
 

--- a/docs/integrations/frontend/react.md
+++ b/docs/integrations/frontend/react.md
@@ -51,7 +51,7 @@ export const ElectricWrapper = ({ children }) => {
     const init = async () => {
       const conn = await ElectricDatabase.init('electric.db', '')
       const electric = await electrify(conn, schema)
-      const token = insecureAuthToken({user_id: 'dummy'})
+      const token = insecureAuthToken({sub: 'dummy'})
       await electric.connect(token)
 
       if (!isMounted) {

--- a/docs/usage/auth/token.md
+++ b/docs/usage/auth/token.md
@@ -11,6 +11,10 @@ Authentication uses JSON Web Tokens, a [standard method](https://tools.ietf.org/
 
 A valid authentication JWT must contain a `sub` claim (formerly `user_id`). This must be a non-empty string, which should correspond to the primary key UUID of the authenticated app user.
 
+:::note
+Since version 0.8.0, the `sub` claim replaces the `user_id` as the standard "subject" designator in JWT tokens. However, Electric still validates tokens that have the `user_id` claim for backwards compatibility with old clients.
+:::
+
 ## Validated claims
 
 If you are using [insecure mode](./insecure.md) any other claims are optional and unvalidated.

--- a/docs/usage/auth/token.md
+++ b/docs/usage/auth/token.md
@@ -11,10 +11,6 @@ Authentication uses JSON Web Tokens, a [standard method](https://tools.ietf.org/
 
 A valid authentication JWT must contain a `sub` claim (formerly `user_id`). This must be a non-empty string, which should correspond to the primary key UUID of the authenticated app user.
 
-:::note
-Since version 0.8.0, the `sub` claim replaces the `user_id` as the standard "subject" designator in JWT tokens. However, Electric still validates tokens that have the `user_id` claim for backwards compatibility with old clients.
-:::
-
 ## Validated claims
 
 If you are using [insecure mode](./insecure.md) any other claims are optional and unvalidated.


### PR DESCRIPTION

Breaking change to the Auth APIs also removed the backwards compatibility for the token to have a `user_id` as claim instead of `sub.

https://github.com/electric-sql/electric/pull/828/files#diff-6f5e692c874649d2aee74958b2c1369a83d09ec9be84e60330f8eaf5ec4fc023R37-R43

```ts
export function decodeToken(token: string): JWTPayload & { sub: string } {
  const decoded = decodeJwt(token)
  if (typeof decoded.sub === 'undefined') {
    throw new InvalidArgumentError('Token does not contain a sub claim')
  }
  return decoded as JWTPayload & { sub: string }
}
```

We also say "`sub` (formerly `user_id`)" everywhere in the docs - should we still keep that or remove it entirely and use just `sub` going forwards?