### PR TITLE
fix(starter): Include template folders in `create-electric-app` NPM package

### DIFF
--- a/.changeset/pink-books-obey.md
+++ b/.changeset/pink-books-obey.md
@@ -1,0 +1,5 @@
+---
+"create-electric-app": patch
+---
+
+Include template folders in starter app CLI distribution

--- a/examples/starter/package-lock.json
+++ b/examples/starter/package-lock.json
@@ -1,0 +1,322 @@
+{
+  "name": "create-electric-app",
+  "version": "0.2.6",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "create-electric-app",
+      "version": "0.2.6",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ora": "^7.0.1",
+        "prompt": "^1.3.0",
+        "shelljs": "^0.8.5",
+        "tcp-port-used": "^1.0.2"
+      },
+      "bin": {
+        "create-electric-app": "dist/index.js"
+      },
+      "devDependencies": {
+        "@tsmodule/tsmodule": "42",
+        "@types/node": "^18.8.4",
+        "@types/shelljs": "^0.8.12",
+        "@types/tcp-port-used": "^1.0.2",
+        "prettier": "2.8.2",
+        "shx": "^0.3.4",
+        "typescript": "^5.1.3"
+      }
+    },
+    "../../node_modules/.pnpm/@tsmodule+tsmodule@42.6.0/node_modules/@tsmodule/tsmodule": {
+      "version": "42.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.17.8",
+        "pkg": "^5.8.0",
+        "typescript": "^4.9.3"
+      },
+      "bin": {
+        "tsmodule": "dist/bin.js"
+      },
+      "devDependencies": {
+        "@tsmodule/log": "^2.2.1",
+        "@types/node": "^18.11.9",
+        "@typescript-eslint/eslint-plugin": "^5.44.0",
+        "@typescript-eslint/parser": "^5.44.0",
+        "assert": "^2.0.0",
+        "ava": "^5.2.0",
+        "chalk": "^5.1.2",
+        "commander": "^10.0.0",
+        "debug-logging": "^4.1.2",
+        "es-module-lexer": "^1.1.0",
+        "eslint": "^8.28.0",
+        "eslint-config-next": "^13.0.5",
+        "fast-glob": "^3.2.12",
+        "get-tsconfig": "^4.4.0",
+        "node-watch": "^0.7.3",
+        "ora": "^6.1.2",
+        "path": "^0.12.7",
+        "release-it": "^15.5.0",
+        "universal-shell": "^35.0.11"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "../../node_modules/.pnpm/@types+node@18.16.16/node_modules/@types/node": {
+      "version": "18.16.16",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/.pnpm/@types+shelljs@0.8.12/node_modules/@types/shelljs": {
+      "version": "0.8.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "~7.2.0",
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/.pnpm/@types+tcp-port-used@1.0.2/node_modules/@types/tcp-port-used": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/.pnpm/ora@7.0.1/node_modules/ora": {
+      "version": "7.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.9.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.3.0",
+        "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
+        "string-width": "^6.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.4.5",
+        "ava": "^5.3.1",
+        "get-stream": "^7.0.1",
+        "transform-tty": "^1.0.11",
+        "tsd": "^0.28.1",
+        "xo": "^0.55.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/.pnpm/prettier@2.8.2/node_modules/prettier": {
+      "version": "2.8.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "../../node_modules/.pnpm/prompt@1.3.0/node_modules/prompt": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "async": "3.2.3",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "winston": "2.x"
+      },
+      "devDependencies": {
+        "eslint": "^7.32.0",
+        "vows": "^0.7.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/shelljs@0.8.5/node_modules/shelljs": {
+      "version": "0.8.5",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "devDependencies": {
+        "ava": "^0.21.0",
+        "chalk": "^1.1.3",
+        "codecov": "^3.0.2",
+        "coffee-script": "^1.10.0",
+        "eslint": "^2.0.0",
+        "eslint-config-airbnb-base": "^3.0.0",
+        "eslint-plugin-import": "^1.11.1",
+        "nyc": "^11.3.0",
+        "shelljs-changelog": "^0.2.0",
+        "shelljs-release": "^0.3.0",
+        "shx": "^0.2.0",
+        "travis-check-changes": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/.pnpm/shx@0.3.4/node_modules/shx": {
+      "version": "0.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.6.5",
+        "babel-preset-env": "^1.7.0",
+        "babel-register": "^6.7.2",
+        "codecov": "^3.0.2",
+        "concurrently": "^2.1.0",
+        "eslint": "^5.16.0",
+        "eslint-config-airbnb-base": "^13.1.0",
+        "eslint-plugin-import": "^2.17.3",
+        "js-yaml": "^3.12.0",
+        "mocha": "^6.1.4",
+        "nyc": "^14.1.1",
+        "rimraf": "^2.5.2",
+        "shelljs-changelog": "^0.2.6",
+        "shelljs-plugin-open": "^0.2.1",
+        "shelljs-release": "^0.5.1",
+        "should": "^13.2.3",
+        "watch": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/.pnpm/tcp-port-used@1.0.2/node_modules/tcp-port-used": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.3.1",
+        "is2": "^2.0.6"
+      },
+      "devDependencies": {
+        "mocha": "^8.2.1"
+      }
+    },
+    "../../node_modules/.pnpm/typescript@5.1.3/node_modules/typescript": {
+      "version": "5.1.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "devDependencies": {
+        "@esfx/canceltoken": "^1.0.0",
+        "@octokit/rest": "latest",
+        "@types/chai": "^4.3.4",
+        "@types/fs-extra": "^9.0.13",
+        "@types/glob": "^8.1.0",
+        "@types/microsoft__typescript-etw": "^0.1.1",
+        "@types/minimist": "^1.2.2",
+        "@types/mocha": "^10.0.1",
+        "@types/ms": "^0.7.31",
+        "@types/node": "latest",
+        "@types/source-map-support": "^0.5.6",
+        "@types/which": "^2.0.1",
+        "@typescript-eslint/eslint-plugin": "^5.33.1",
+        "@typescript-eslint/parser": "^5.33.1",
+        "@typescript-eslint/utils": "^5.33.1",
+        "azure-devops-node-api": "^12.0.0",
+        "chai": "^4.3.7",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "del": "^6.1.1",
+        "diff": "^5.1.0",
+        "esbuild": "^0.17.2",
+        "eslint": "^8.22.0",
+        "eslint-formatter-autolinkable-stylish": "^1.2.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-local": "^1.0.0",
+        "eslint-plugin-no-null": "^1.0.2",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
+        "fast-xml-parser": "^4.0.11",
+        "fs-extra": "^9.1.0",
+        "glob": "^8.1.0",
+        "hereby": "^1.6.4",
+        "jsonc-parser": "^3.2.0",
+        "minimist": "^1.2.8",
+        "mocha": "^10.2.0",
+        "mocha-fivemat-progress-reporter": "^0.1.0",
+        "ms": "^2.1.3",
+        "node-fetch": "^3.2.10",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.5.0",
+        "typescript": "^5.0.2",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@tsmodule/tsmodule": {
+      "resolved": "../../node_modules/.pnpm/@tsmodule+tsmodule@42.6.0/node_modules/@tsmodule/tsmodule",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "resolved": "../../node_modules/.pnpm/@types+node@18.16.16/node_modules/@types/node",
+      "link": true
+    },
+    "node_modules/@types/shelljs": {
+      "resolved": "../../node_modules/.pnpm/@types+shelljs@0.8.12/node_modules/@types/shelljs",
+      "link": true
+    },
+    "node_modules/@types/tcp-port-used": {
+      "resolved": "../../node_modules/.pnpm/@types+tcp-port-used@1.0.2/node_modules/@types/tcp-port-used",
+      "link": true
+    },
+    "node_modules/ora": {
+      "resolved": "../../node_modules/.pnpm/ora@7.0.1/node_modules/ora",
+      "link": true
+    },
+    "node_modules/prettier": {
+      "resolved": "../../node_modules/.pnpm/prettier@2.8.2/node_modules/prettier",
+      "link": true
+    },
+    "node_modules/prompt": {
+      "resolved": "../../node_modules/.pnpm/prompt@1.3.0/node_modules/prompt",
+      "link": true
+    },
+    "node_modules/shelljs": {
+      "resolved": "../../node_modules/.pnpm/shelljs@0.8.5/node_modules/shelljs",
+      "link": true
+    },
+    "node_modules/shx": {
+      "resolved": "../../node_modules/.pnpm/shx@0.3.4/node_modules/shx",
+      "link": true
+    },
+    "node_modules/tcp-port-used": {
+      "resolved": "../../node_modules/.pnpm/tcp-port-used@1.0.2/node_modules/tcp-port-used",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "resolved": "../../node_modules/.pnpm/typescript@5.1.3/node_modules/typescript",
+      "link": true
+    }
+  }
+}

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -8,7 +8,7 @@
   "platform": "node",
   "files": [
     "dist",
-    "template"
+    "template-!(overlay)*"
   ],
   "bin": {
     "create-electric-app": "dist/index.js"


### PR DESCRIPTION
The current version is broken (see https://github.com/electric-sql/electric/issues/982) because the template folders are not being included, this is a hotfix to make it work again.

Will see to adding some tests for this so it doesn't slip through.