### PR TITLE
fix(client): Delay incoming messages when subscribing.

### DIFF
--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -468,9 +468,13 @@ export class SatelliteClient implements Client {
 
     this.subscriptionsDataCache.subscriptionRequest(request)
 
-    return this.service
-      .subscribe(request)
-      .then(this.handleSubscription.bind(this))
+    return this.delayIncomingMessages(
+      async () => {
+        const resp = await this.service.subscribe(request)
+        return this.handleSubscription(resp)
+      },
+      { allowedRpcResponses: ['subscribe'] }
+    )
   }
 
   unsubscribe(subscriptionIds: string[]): Promise<UnsubscribeResponse> {


### PR DESCRIPTION
Related to: https://github.com/electric-sql/electric/issues/426

When porting the latest changes from v0.9.3 to the Dart client we started experiencing a race condition when a new client subscribes to a shape. It looks like the RPC SatSubsResp message comes after SatSubsDataEnd, causing the error "Received subscribe response for unknown subscription (some_id)"

With the PR change this doesn't happen anymore and it's how it's done in startReplication to avoid race conditions

Without delayMessages:
![image](https://github.com/electric-sql/electric/assets/22084723/dc7003c5-20fd-4ce1-b9c1-09e6d67376b9)

With delayMessages:
![image](https://github.com/electric-sql/electric/assets/22084723/d11e8a0e-05bd-4766-9cf8-76658cca8414)

cc @icehaunter 

Would this be the correct approach? Dart and JS have slight differences in the event loop, so sometimes a race condition is easier to catch in some language or in the other