### PR TITLE
fix(starter): Actually include all template files in `create-electric-app` package

### DIFF
--- a/.changeset/brave-humans-own.md
+++ b/.changeset/brave-humans-own.md
@@ -1,0 +1,5 @@
+---
+"create-electric-app": patch
+---
+
+Add contents of template folders to package

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -8,7 +8,7 @@
   "platform": "node",
   "files": [
     "dist",
-    "template-!(overlay)*"
+    "template-!(overlay)*/**"
   ],
   "bin": {
     "create-electric-app": "dist/index.js"


### PR DESCRIPTION
Turns out `pnpm pack` and `npm pack` read the `package.json` file inclusion globs differently.

This time tested with `npm publish --dry-run` and `npm pack` to ensure all relevant files are included.