### PR TITLE
chode(docs): Update docs to use optional wa-sqlite distribution path

### DIFF
--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -34,7 +34,7 @@ const config = {
     clientId: 'dummy client id'
   }
 }
-const conn = await ElectricDatabase.init('electric.db', '')
+const conn = await ElectricDatabase.init('electric.db')
 const electric = await electrify(conn, schema, config)
 const token = insecureAuthToken({user_id: 'dummy'})
 await electric.connect(token)

--- a/docs/deployment/concepts.md
+++ b/docs/deployment/concepts.md
@@ -162,7 +162,7 @@ const config = {
 }
 
 const init = async () => {
-  const conn = await ElectricDatabase.init('my.db', '/')
+  const conn = await ElectricDatabase.init('my.db')
   const electric = await electrify(conn, schema, config)
   await electric.connect('your token')
   return electric

--- a/docs/deployment/supabase.md
+++ b/docs/deployment/supabase.md
@@ -182,7 +182,7 @@ const config = {
 }
 
 // Initiate your Electric database
-const conn = await ElectricDatabase.init('myApp.db', '')
+const conn = await ElectricDatabase.init('myApp.db')
 const electric = await electrify(conn, schema, config)
 const token = data.session.access_token
 await electric.connect(token)

--- a/docs/integrations/drivers/web/wa-sqlite.md
+++ b/docs/integrations/drivers/web/wa-sqlite.md
@@ -41,7 +41,7 @@ const config = {
 // is your database name. Changing this will create/use a new
 // local database file. The second argument is the public URL
 // path to use when loading the wa-sqlite WASM files.
-const conn = await ElectricDatabase.init('electric.db', '')
+const conn = await ElectricDatabase.init('electric.db')
 
 // Instantiate your electric client.
 const electric = await electrify(conn, schema, config)

--- a/docs/integrations/frontend/react.md
+++ b/docs/integrations/frontend/react.md
@@ -49,7 +49,7 @@ export const ElectricWrapper = ({ children }) => {
     const isMounted = true
 
     const init = async () => {
-      const conn = await ElectricDatabase.init('electric.db', '')
+      const conn = await ElectricDatabase.init('electric.db')
       const electric = await electrify(conn, schema)
       const token = insecureAuthToken({user_id: 'dummy'})
       await electric.connect(token)

--- a/docs/integrations/frontend/vue.md
+++ b/docs/integrations/frontend/vue.md
@@ -49,9 +49,9 @@ import { Electric, schema } from './generated/client'
 const electric = shallowRef<Electric>()
 
 onMounted(async () => {
-  const config = { auth: { token: insecureAuthToken() } }
   const conn = await ElectricDatabase.init('electric.db')
-  const client = await electrify(conn, schema, config)
+  const client = await electrify(conn, schema)
+  await client.connect(insecureAuthToken())
 
   // update the reference with client instance
   electric.value = client

--- a/docs/integrations/frontend/vue.md
+++ b/docs/integrations/frontend/vue.md
@@ -51,7 +51,7 @@ const electric = shallowRef<Electric>()
 onMounted(async () => {
   const conn = await ElectricDatabase.init('electric.db')
   const client = await electrify(conn, schema)
-  await client.connect(insecureAuthToken())
+  await client.connect(insecureAuthToken({ sub: 'dummy' }))
 
   // update the reference with client instance
   electric.value = client

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -85,7 +85,7 @@ import { schema } from './generated/client'
 const config = {
   url: "http://localhost:5133"
 }
-const conn = await ElectricDatabase.init('my.db', '')
+const conn = await ElectricDatabase.init('my.db')
 const electric = await electrify(conn, schema, config)
 ```
 

--- a/docs/usage/data-access/client.md
+++ b/docs/usage/data-access/client.md
@@ -41,7 +41,7 @@ const config = {
 }
 
 const init = async () => {
-  const conn = await ElectricDatabase.init('my.db', '/')
+  const conn = await ElectricDatabase.init('my.db')
   const electric = await electrify(conn, schema, config)
   await electric.connect('your token')
   return electric


### PR DESCRIPTION
Doc examples still used an empty string as the wa-sqlite distribution path which is now optional with the new release.

Also added a small update to the Vue docs with the Auth API as I somehow missed that.