### PR TITLE
fix(proxy): Correcly coalesce command complete messages

### DIFF
--- a/.changeset/gorgeous-parents-flow.md
+++ b/.changeset/gorgeous-parents-flow.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+[VAX-1664] Fix for prisma database introspection

--- a/components/electric/test/support/injector_test/test_scenario.ex
+++ b/components/electric/test/support/injector_test/test_scenario.ex
@@ -169,6 +169,18 @@ defmodule Electric.Postgres.Proxy.TestScenario do
     ]
   end
 
+  def close do
+    %M.Close{}
+  end
+
+  def close_complete do
+    %M.CloseComplete{}
+  end
+
+  def sync do
+    %M.Sync{}
+  end
+
   def bind_execute() do
     bind_execute("", [])
   end


### PR DESCRIPTION
A query with multiple statements expects multiple command complete messages with a single closing ReadyForQuery message. This fixes incorrect handling of that situation within the prisma shadow handler

Hopefully fixes #955 and #939