### PR TITLE
fix(e2e): Use connect/disconnect instead of `connectivityStateChanged` in e2e test.

### DIFF
--- a/e2e/tests/03.11_node_satellite_compensations_work.lux
+++ b/e2e/tests/03.11_node_satellite_compensations_work.lux
@@ -41,7 +41,7 @@
     ??[proto] recv: #SatOpLog
 
     # Disconnect the client
-    !db.notifier.connectivityStateChanged(db.notifier.dbName, { status: 'disconnected' })
+    !db.disconnect()
 
 [shell pg_1]
     # Concurrently, update and then delete the referenced row on the server
@@ -64,7 +64,7 @@
 
 [shell satellite_1]
     # Reconnect the client, expecting no errors to show up
-    !db.notifier.connectivityStateChanged(db.notifier.dbName, { status: 'available' })
+    !db.connect()
     ??[proto] send: #SatOpLog
     ??[proto] recv: #SatOpLog
 


### PR DESCRIPTION
After the recent changes to the client connectiviy, we can use connect and disconnect. The status `available` doesn't exist anymore.