### PR TITLE
chore(ci): Drop the use of GitHub Actions variables

### DIFF
--- a/.github/workflows/components_electric_tests.yml
+++ b/.github/workflows/components_electric_tests.yml
@@ -10,8 +10,8 @@ on:
       - "!components/electric/**README.md"
 
 env:
-  OTP_VERSION: ${{ vars.OTP_VERSION }}
-  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
+  OTP_VERSION: "25.3.2.8"
+  ELIXIR_VERSION: "1.16.1-otp-25"
 
 concurrency:
   group: components-electric-${{ github.ref }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,8 +14,8 @@ on:
       - "docs/**"
 
 env:
-  OTP_VERSION: ${{ vars.OTP_VERSION }}
-  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
+  OTP_VERSION: "25.3.2.8"
+  ELIXIR_VERSION: "1.16.1-otp-25"
 
 concurrency:
   group: e2e-${{ github.ref }}

--- a/.github/workflows/satellite_proto.yml
+++ b/.github/workflows/satellite_proto.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  OTP_VERSION: ${{ vars.OTP_VERSION }}
-  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
+  OTP_VERSION: "25.3.2.8"
+  ELIXIR_VERSION: "1.16.1-otp-25"
 
 jobs:
   verify_proto:


### PR DESCRIPTION
Their usage makes it impossible to run actions for pull requests from forks.