### PR TITLE
fix(e2e): Improve E2E Satellite client Dockerfile build performance

### DIFF
--- a/e2e/satellite_client/Dockerfile
+++ b/e2e/satellite_client/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine AS workspace
 
 RUN apk update && apk add git
-RUN corepack enable && corepack prepare pnpm@8.6.0 --activate
+RUN corepack enable && corepack prepare pnpm@8.15.3 --activate
 
 RUN mkdir /app
 WORKDIR /app
@@ -9,19 +9,23 @@ WORKDIR /app
 COPY pnpm-lock.yaml ./
 RUN pnpm fetch
 
-
 COPY pnpm-workspace.yaml ./
+
+# E2E Client deps install + build
 COPY clients/typescript ./clients/typescript
 COPY generator ./generator
 COPY e2e/satellite_client/package.json  ./e2e/satellite_client/
-
-RUN pnpm install -r --filter @internal/satellite-client^...
+RUN pnpm install -r --offline --filter @internal/satellite-client^...
 RUN pnpm run -r --filter @internal/satellite-client^... build
-RUN pnpm install -r --filter @internal/satellite-client
+RUN pnpm install --offline --filter @internal/satellite-client
+
+# E2E Client build
 COPY e2e/satellite_client/src  ./e2e/satellite_client/src
 COPY e2e/satellite_client/tsconfig.json  ./e2e/satellite_client
-RUN pnpm run -r --filter @internal/satellite-client build
+RUN pnpm run --filter @internal/satellite-client build
 
+# Deploy an isolated node_modules + src in which the E2E Client will be run
+# Otherwise the pnpm node_modules links won't work in the runner Docker stage
 RUN pnpm --filter @internal/satellite-client --prod deploy output
 
 FROM node:18-alpine AS runner


### PR DESCRIPTION
One thing we noted when building the satellite_client Dockerfile to run the E2E tests locally is that any slight change in the Electric client source code was invalidating most of the install and build work in Docker.
After some investigation we found out that latest PNPM version is much more performant in the docker build.

I also took the chance to add some comments to the Dockerfile to better understand the multiple steps.

Here is a comparison between the main branch and this PR. As you can see, the times are much faster, so when debugging E2E tests for the client the DX improves.

### Main branch

* Full docker build (--no-cache): 3m 24s
* After some edit in the Electric client: 2m 56s

### This PR

* Full docker build (--no-cache): 1 min 3 s
* After some edit in the Electric client: 30s