### PR TITLE
chore(docs): Replace `yarn` with `npm` in the Expo demo README

### DIFF
--- a/examples/expo/README.md
+++ b/examples/expo/README.md
@@ -32,7 +32,7 @@ cd electric/examples/expo
 Install the dependencies:
 
 ```sh
-yarn
+npm install
 ```
 
 ## Setup
@@ -40,27 +40,27 @@ yarn
 Start Postgres and Electric using Docker (see [running the examples](https://electric-sql.com/docs/examples/notes/running) for more options):
 
 ```shell
-yarn backend:up
-# Or `yarn backend:start` to foreground
+npm run backend:up
+# Or `npm run backend:start` to foreground
 ```
 
 Note that, if useful, you can connect to Postgres using:
 
 ```shell
-yarn db:psql
+npm run db:psql
 ```
 
 Setup your [database schema](https://electric-sql.com/docs/usage/data-modelling):
 
 ```shell
-yarn db:migrate
+npm run db:migrate
 ```
 
 Generate your [type-safe client](https://electric-sql.com/docs/usage/data-access/client):
 
 ```shell
-yarn client:generate
-# or `yarn client:watch`` to re-generate whenever the DB schema changes
+npm run client:generate
+# or `npm run client:watch`` to re-generate whenever the DB schema changes
 ```
 
 ## Run
@@ -68,7 +68,7 @@ yarn client:generate
 Run in the iOS simulator:
 
 ```shell
-yarn start:ios
+npm run start:ios
 ```
 
 ## More information


### PR DESCRIPTION
We've started using npm for all our examples and including the package-lock.json as well, so doing this for consistency.