### PR TITLE
fix (generator): fix type error with `WhereUniqueInput` schemas

### DIFF
--- a/.changeset/yellow-knives-itch.md
+++ b/.changeset/yellow-knives-itch.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixes type errors with WhereUniqueInputSchema in generated client.


### PR DESCRIPTION
This PR fixes type errors in the generated client with `WhereUniqueInput` schemas, as reported in: https://discord.com/channels/933657521581858818/1211387122351870072.
The type errors come from the fact that we are now using Prisma v5 for generating the Prisma client but in Prisma v5 the type for `WhereUniqueInput` schemas is now wrapped in an `AtLeast<..., ...>` type which is a breaking type change compared to the generated type in v4. Since our Zod schemas are generated using v4 the types are incompatible. This PR patches the `AtLeast` type such that the resulting type is equivalent to the type in v4.