### PR TITLE
fix(docs): Fix Vue syntax highlighting in the Vue docs

### DIFF
--- a/docs/integrations/frontend/vue.md
+++ b/docs/integrations/frontend/vue.md
@@ -35,7 +35,7 @@ We provide this dynamic API rather than static `provideElectric` and `injectElec
 
 `provideElectric` is a [provider](https://vuejs.org/api/composition-api-dependency-injection.html#provide) method that injects the Electric [Client](../../usage/data-access/client.md) instance to the rest of the app under an Electric-specific symbol key, so it will never clash with other dependency injections. You can call it within the context of a provider-like component, e.g.:
 
-```vue
+```html
 // ElectricProvider.vue
 <script lang="ts" setup>
 import { onMounted, shallowRef } from 'vue'
@@ -70,7 +70,7 @@ provideElectric(electric)
 
 With a `provideElectric` call in a parent component in place, you can then access the `electric` client instance using the `injectElectric` method, e.g.:
 
-```vue
+```html
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { injectElectric } from './electric'
@@ -100,7 +100,7 @@ const generate = async () => {
 
 `useLiveQuery` sets up a live query (aka a dynamic or reactive query). This takes query function returned by one of the `db.live*` methods and keeps the results in sync whenever the relevant data changes.
 
-```vue
+```html
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { useLiveQuery } from 'electric-sql/vuejs'


### PR DESCRIPTION
The [Vue docs](https://electric-sql.com/docs/integrations/frontend/vue) were using the `vue` syntax highlighting language, which is [not supported by Prism](https://prismjs.com/#supported-languages).

There's open issues to support SFC syntax (see https://github.com/PrismJS/prism/issues/1665) but until then using `html` syntax highlighting seems to do a relatively decent job as a workaround.


before and after pics:
<img width="500" alt="Screenshot 2024-02-28 at 17 29 12" src="https://github.com/electric-sql/electric/assets/12274098/be726ef6-dd83-493c-b459-7b4081094f2e">
<img width="500" alt="Screenshot 2024-02-28 at 17 29 00" src="https://github.com/electric-sql/electric/assets/12274098/dec91b38-cef8-4ea3-9af5-ca362f394905">

