### PR TITLE
fix(client): Fix `upsert` transforming inputs twice

### DIFF
--- a/clients/typescript/src/client/conversions/input.ts
+++ b/clients/typescript/src/client/conversions/input.ts
@@ -14,7 +14,6 @@ type UpdateInput = { data: object; where: object }
 type UpdateManyInput = { data: object; where?: object }
 type CreateInput = { data: object }
 type CreateManyInput = { data: Array<object> }
-type UpsertInput = { update: object; create: object; where: object }
 type WhereUniqueInput = { where: object }
 type WhereInput = { where?: object }
 

--- a/clients/typescript/src/client/conversions/input.ts
+++ b/clients/typescript/src/client/conversions/input.ts
@@ -95,25 +95,6 @@ export function transformUpdateMany<T extends UpdateManyInput>(
 }
 
 /**
- * Takes the data input of an `upsert` operation and
- * converts the JS values to their corresponding SQLite values.
- * @param i The validated input of the `upsert` operation.
- * @param fields The table's fields.
- * @returns The transformed input.
- */
-export function transformUpsert<T extends UpsertInput>(
-  i: T,
-  fields: Fields
-): Swap<T, UpsertInput, 'update' | 'create' | 'where'> {
-  return {
-    ...i,
-    update: transformFields(i.update, fields),
-    create: transformFields(i.create, fields),
-    where: transformWhere(i.where, fields),
-  }
-}
-
-/**
  * Takes the data input of a `delete` operation and
  * converts the JS values to their corresponding SQLite values.
  */

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -48,7 +48,6 @@ import {
   transformFindUnique,
   transformUpdate,
   transformUpdateMany,
-  transformUpsert,
 } from '../conversions/input'
 
 type AnyTable = Table<any, any, any, any, any, any, any, any, any, HKT>

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -1443,7 +1443,10 @@ export class Table<
     continuation: (res: Kind<GetPayload, T>) => void,
     onError: (err: any) => void
   ) {
-    const data = transformUpsert(validate(i, this.upsertSchema), this._fields)
+    // validate but do not transform - upsert will call either
+    // create or update that will perform the appropriate transforms
+    validate(i, this.upsertSchema)
+
     // Check if the record exists
     this._findUnique(
       { where: i.where } as any,
@@ -1453,10 +1456,10 @@ export class Table<
           // Create the record
           return this._create(
             {
-              data: data.create,
-              select: data.select,
-              ...(notNullNotUndefined(data.include) && {
-                include: data.include,
+              data: i.create,
+              select: i.select,
+              ...(notNullNotUndefined(i.include) && {
+                include: i.include,
               }), // only add `include` property if it is defined
             } as any,
             db,
@@ -1467,11 +1470,11 @@ export class Table<
           // Update the record
           return this._update(
             {
-              data: data.update,
-              where: data.where,
-              select: data.select,
-              ...(notNullNotUndefined(data.include) && {
-                include: data.include,
+              data: i.update,
+              where: i.where,
+              select: i.select,
+              ...(notNullNotUndefined(i.include) && {
+                include: i.include,
               }), // only add `include` property if it is defined
             } as any,
             db,

--- a/clients/typescript/test/client/conversions/input.test.ts
+++ b/clients/typescript/test/client/conversions/input.test.ts
@@ -481,6 +481,52 @@ test.serial('upsert transforms JS objects to SQLite', async (t) => {
   t.deepEqual(fetchRes, expected)
 })
 
+test.serial('upsert transforms JS JSON objects to SQLite', async (t) => {
+  const json1 = { test1: 1 }
+  const json2 = { test2: 2 }
+
+  // check upsert creation correctly serialises json
+  const upsertFirstCallRes = await tbl.upsert({
+    create: {
+      id: 1,
+      json: json1,
+    },
+    update: {
+      json: json2,
+    },
+    where: {
+      id: 1,
+    },
+  })
+
+  t.deepEqual(upsertFirstCallRes.json, json1)
+
+  // check upsert update correctly serialises json
+  const upsertSecondCallRes = await tbl.upsert({
+    create: {
+      id: 1,
+      json: json1,
+    },
+    update: {
+      json: json2,
+    },
+    where: {
+      id: 1,
+    },
+  })
+
+  t.deepEqual(upsertSecondCallRes.json, json2)
+
+  // check upsert has left json in de-serialisable state
+  const fetchRes = await tbl.findUnique({
+    where: {
+      id: 1,
+    },
+  })
+
+  t.deepEqual((fetchRes as any).json, json2)
+})
+
 test.serial('delete transforms JS objects to SQLite', async (t) => {
   const date1 = new Date('2023-09-13 23:33:04.271')
   const date2 = new Date('2023-09-12 23:33:04.271')


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/938

The `upsert` operation validated _and transformed_ its inputs, but then subsequently called either `create` or `update` which re-transformed the already transformed inputs.

For most types its fine as the transform is idempotent, but for JSON we either need to check if the input is "deserializable" and assume it does not need to be re-serialized, or make sure we don't attempt to transform it more than once.

I might be wrong, but if we use the first approach there are cases where people might insert already serialized JSON values, leading to potential missed serialization (and then to an incorrect or failed deserialization).

Therefore I've made `upsert` only validate its inputs, and relegate the transformation to the `create` or `update` calls that follow.