### PR TITLE
fix(client): Remove comments from client SQLite trigger migrations

### DIFF
--- a/.changeset/strong-lamps-trade.md
+++ b/.changeset/strong-lamps-trade.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Remove comments from client SQLite trigger migrations for better compatibility with drivers (e.g. see [this driver issue](https://github.com/capacitor-community/sqlite/issues/521)).

--- a/clients/typescript/src/migrators/triggers.ts
+++ b/clients/typescript/src/migrators/triggers.ts
@@ -55,14 +55,13 @@ export function generateOplogTriggers(
   const oldRows = joinColsForJSON(columns, columnTypes, 'old')
 
   return [
+    //`-- Toggles for turning the triggers on and off\n`,
     dedent`
-    -- Toggles for turning the triggers on and off
     INSERT OR IGNORE INTO _electric_trigger_settings(tablename,flag) VALUES ('${tableFullName}', 1);
     `,
+    //`\* Triggers for table ${tableName} *\\n
+    //`-- ensures primary key is immutable\n`
     dedent`
-    /* Triggers for table ${tableName} */
-  
-    -- ensures primary key is immutable
     DROP TRIGGER IF EXISTS update_ensure_${namespace}_${tableName}_primarykey;
     `,
     dedent`
@@ -80,8 +79,8 @@ export function generateOplogTriggers(
         END;
     END;
     `,
+    //`-- Triggers that add INSERT, UPDATE, DELETE operation to the _opslog table\n`
     dedent`
-    -- Triggers that add INSERT, UPDATE, DELETE operation to the _opslog table
     DROP TRIGGER IF EXISTS insert_${namespace}_${tableName}_into_oplog;
     `,
     dedent`
@@ -155,7 +154,8 @@ function generateCompensationTriggers(table: Table): Statement[] {
     })
 
     return [
-      dedent`-- Triggers for foreign key compensations
+      //`-- Triggers for foreign key compensations\n`,
+      dedent`
       DROP TRIGGER IF EXISTS compensation_insert_${namespace}_${tableName}_${childKey}_into_oplog;`,
       // The compensation trigger inserts a row in `_electric_oplog` if the row pointed at by the FK exists
       // The way how this works is that the values for the row are passed to the nested SELECT


### PR DESCRIPTION
We already remove the comments from the actual statements that we run on the drivers in the [schema migrations](https://github.com/electric-sql/electric/blob/main/clients/typescript/src/migrators/schema.ts), so I've made the trigger installation do the same.

Not exactly an issue but there is some inconsistent comment support in some drivers and this at least works around those issues in the initial Electric installation. Reducing the surface of required compliance to the SQLite spec to get Electric to run unblocks the ability to at least try out the client with different drivers.

See [this issue](https://github.com/capacitor-community/sqlite/issues/521) I've opened for the Capacitor driver which motivates this PR.

Removing these comments outside of the executed statements makes our Ionic demo with the Capacitor driver work. 