### PR TITLE
fix (client): fix snapshot query that sets the cleartags

### DIFF
--- a/.changeset/smooth-seals-design.md
+++ b/.changeset/smooth-seals-design.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixes bug that would cause deleted rows to re-appear under specific conditions.

--- a/clients/typescript/test/satellite/process.tags.test.ts
+++ b/clients/typescript/test/satellite/process.tags.test.ts
@@ -79,6 +79,118 @@ test('basic rules for setting tags', async (t) => {
   t.not(txDate3, txDate4)
 })
 
+test('Tags are correctly set on subsequent operations in a TX', async (t) => {
+  const { adapter, runMigrations, satellite, authState } = t.context
+
+  await runMigrations()
+
+  await adapter.run({
+    sql: `INSERT INTO parent(id, value) VALUES (1,'val1')`,
+  })
+
+  // Since no snapshot was made yet
+  // the timestamp in the oplog is not yet set
+  const insertEntry = await adapter.query({
+    sql: `SELECT timestamp, clearTags FROM _electric_oplog WHERE rowid = 1`,
+  })
+  t.is(insertEntry[0].timestamp, null)
+  t.deepEqual(JSON.parse(insertEntry[0].clearTags as string), [])
+
+  await satellite._setAuthState(authState)
+  await satellite._performSnapshot()
+
+  const parseDate = (date: string) => new Date(date).getTime()
+
+  // Now the timestamp is set
+  const insertEntryAfterSnapshot = await adapter.query({
+    sql: `SELECT timestamp, clearTags FROM _electric_oplog WHERE rowid = 1`,
+  })
+  t.assert(insertEntryAfterSnapshot[0].timestamp != null)
+  const insertTimestamp = parseDate(
+    insertEntryAfterSnapshot[0].timestamp as string
+  )
+  t.deepEqual(JSON.parse(insertEntryAfterSnapshot[0].clearTags as string), [])
+
+  // Now update the entry, then delete it, and then insert it again
+  await adapter.run({
+    sql: `UPDATE parent SET value = 'val2' WHERE id=1`,
+  })
+
+  await adapter.run({
+    sql: `DELETE FROM parent WHERE id=1`,
+  })
+
+  await adapter.run({
+    sql: `INSERT INTO parent(id, value) VALUES (1,'val3')`,
+  })
+
+  // Since no snapshot has been taken for these operations
+  // their timestamp and clearTags should not be set
+  const updateEntry = await adapter.query({
+    sql: `SELECT timestamp, clearTags FROM _electric_oplog WHERE rowid = 2`,
+  })
+
+  t.is(updateEntry[0].timestamp, null)
+  t.deepEqual(JSON.parse(updateEntry[0].clearTags as string), [])
+
+  const deleteEntry = await adapter.query({
+    sql: `SELECT timestamp, clearTags FROM _electric_oplog WHERE rowid = 3`,
+  })
+
+  t.is(deleteEntry[0].timestamp, null)
+  t.deepEqual(JSON.parse(deleteEntry[0].clearTags as string), [])
+
+  const reinsertEntry = await adapter.query({
+    sql: `SELECT timestamp, clearTags FROM _electric_oplog WHERE rowid = 4`,
+  })
+
+  t.is(reinsertEntry[0].timestamp, null)
+  t.deepEqual(JSON.parse(reinsertEntry[0].clearTags as string), [])
+
+  // Now take a snapshot for these operations
+  await satellite._performSnapshot()
+
+  // Now the timestamps should be set
+  // The first operation (update) should override
+  // the original insert (i.e. clearTags must contain the timestamp of the insert)
+  const updateEntryAfterSnapshot = await adapter.query({
+    sql: `SELECT timestamp, clearTags FROM _electric_oplog WHERE rowid = 2`,
+  })
+
+  const rawTimestampTx2 = updateEntryAfterSnapshot[0].timestamp
+  t.assert(rawTimestampTx2 != null)
+  const timestampTx2 = parseDate(rawTimestampTx2 as string)
+
+  t.is(
+    updateEntryAfterSnapshot[0].clearTags,
+    genEncodedTags(authState.clientId, [insertTimestamp])
+  )
+
+  // The second operation (delete) should have the same timestamp
+  // and should contain the tag of the TX in its clearTags
+  const deleteEntryAfterSnapshot = await adapter.query({
+    sql: `SELECT timestamp, clearTags FROM _electric_oplog WHERE rowid = 3`,
+  })
+
+  t.assert(deleteEntryAfterSnapshot[0].timestamp === rawTimestampTx2)
+  t.is(
+    deleteEntryAfterSnapshot[0].clearTags,
+    genEncodedTags(authState.clientId, [timestampTx2])
+  )
+
+  // The third operation (reinsert) should have the same timestamp
+  // and should contain the tag of the TX in its clearTags
+  const reinsertEntryAfterSnapshot = await adapter.query({
+    sql: `SELECT timestamp, clearTags FROM _electric_oplog WHERE rowid = 4`,
+  })
+
+  t.assert(reinsertEntryAfterSnapshot[0].timestamp === rawTimestampTx2)
+  t.is(
+    reinsertEntryAfterSnapshot[0].clearTags,
+    genEncodedTags(authState.clientId, [timestampTx2])
+  )
+})
+
 test('TX1=INSERT, TX2=DELETE, TX3=INSERT, ack TX1', async (t) => {
   const { adapter, runMigrations, satellite, tableInfo, authState } = t.context
   await runMigrations()
@@ -569,7 +681,7 @@ test('origin tx (INSERT) concurrently with local txses (INSERT -> DELETE)', asyn
     entries[0].tablename,
     OPTYPES.insert,
     electricEntrySameTs,
-    genEncodedTags(clientId, [txDate1]),
+    '[]',
     JSON.parse(entries[0].newRow!),
     undefined
   )
@@ -583,10 +695,7 @@ test('origin tx (INSERT) concurrently with local txses (INSERT -> DELETE)', asyn
     entries[1].tablename,
     OPTYPES.insert,
     electricEntryConflictTs,
-    encodeTags([
-      generateTag(clientId, txDate1),
-      generateTag('remote', txDate1),
-    ]),
+    encodeTags([generateTag('remote', txDate1)]),
     JSON.parse(entries[1].newRow!),
     undefined
   )


### PR DESCRIPTION
This PR fixes a problem with `performSnapshot` which caused a deleted row to re-appear in the following scenario:
TX1: `insert row`
TX2 (causally after TX1): `update row; delete row`

After TX2 the deleted row would re-appear with the value of the update.
This occurs because `performSnapshot` would only set the clearTags on the first operation in each transaction which caused the `delete` not to override the `update`. As discussed with @icehaunter, the solution is to modify `performSnapshot` such that it sets the clearTags of all operations in a TX (except the first) to the tag of that transaction.

This PR applies the above fix and i can confirm that the anomaly is gone. I have added a unit test that checks this specific case. **However, another unit test**, called "origin tx (INSERT) concurrently with local txses (INSERT -> DELETE)" in `process.tags.test.ts` **started failing**. I investigated a bit further but that unit test seems weird to me because on line 564 it says "For this key we receive transaction which was older" and it contains a tag that keeps the row alive (but our own, later tx already deleted that row, see L554). So i'm not sure if it makes sense that the server would ever send us this old transaction. I don't know if it was meant like this or it was meant to send the ack of our original tx in which case the tags should be empty because we deleted that row (L572, and also delete L587).

I have modified the tags in that failing unit test according to what i believe the server would send. @icehaunter if you could take a look at that test to see if the original is indeed wrong and whether my fix is correct.
