### PR TITLE
fix(electric): Handle Changes.TruncatedRelation in telemetry metrics

### DIFF
--- a/components/electric/lib/electric/replication/changes.ex
+++ b/components/electric/lib/electric/replication/changes.ex
@@ -57,7 +57,7 @@ defmodule Electric.Replication.Changes do
     ]
 
     def count_operations(%__MODULE__{changes: changes}) do
-      base = %{operations: 0, inserts: 0, updates: 0, deletes: 0, compensations: 0}
+      base = %{operations: 0, inserts: 0, updates: 0, deletes: 0, compensations: 0, truncates: 0}
 
       Enum.reduce(changes, base, fn %module{}, acc ->
         key =
@@ -66,6 +66,7 @@ defmodule Electric.Replication.Changes do
             Changes.UpdatedRecord -> :updates
             Changes.DeletedRecord -> :deletes
             Changes.Compensation -> :compensations
+            Changes.TruncatedRelation -> :truncates
           end
 
         Map.update!(%{acc | operations: acc.operations + 1}, key, &(&1 + 1))


### PR DESCRIPTION
This fixes a crash that was taking LogicalReplicationProducer down repeatedly, even after restarting Electric:

```
** (CaseClauseError) no case clause matching: Electric.Replication.Changes.TruncatedRelation
    (electric 0.8.1) lib/electric/replication/changes.ex:64: anonymous fn/2 in Electric
.Replication.Changes.Transaction.count_operations/1
    (elixir 1.15.4) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
    (electric 0.8.1) lib/electric/replication/postgres/logical_replication_producer.ex:
260: Electric.Replication.Postgres.LogicalReplicationProducer.process_message/2
    (gen_stage 1.2.1) lib/gen_stage.ex:2206: GenStage.noreply_callback/3
    (stdlib 4.3.1.2) gen_server.erl:1123: :gen_server.try_dispatch/4
    (stdlib 4.3.1.2) gen_server.erl:1200: :gen_server.handle_msg/6
    (stdlib 4.3.1.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

The discussion on supporting `TRUNCATE` in https://github.com/electric-sql/electric/issues/858 obscured the fact that this is a bug in a metric processing function that was causing Electric's read replication stream to break permanently after a single `TRUNCATE` statement on an electrified table.