### PR TITLE
feat(electric): Use two replications slots to allow clients to resume replication after Electric restarts

### DIFF
--- a/.changeset/shaggy-keys-retire.md
+++ b/.changeset/shaggy-keys-retire.md
@@ -1,0 +1,13 @@
+---
+"@core/electric": patch
+---
+
+Introduce the concept of "WAL window" that Electric can keep around to enable it to recover already-seen transactions after a restart.
+
+Where previously Electric was acknowledging transactions as soon as it was
+receiving them from Postgres, now it will manually advance its replication's
+slot starting position when needed to keep the overall disk usage within the
+configurable limit. This allows Electric to replay some transactions it
+previously consumed from the logical replication stream after a restart and
+repopulate its in-memory cache of transactions that it uses to resume clients'
+replication streams.

--- a/components/electric/config/runtime.exs
+++ b/components/electric/config/runtime.exs
@@ -200,13 +200,13 @@ config :electric, Electric.Features,
   proxy_ddlx_assign: false,
   proxy_ddlx_unassign: false
 
-{:ok, conn_params} = database_url_config
+{:ok, conn_config} = database_url_config
 
 connector_config =
-  if conn_params do
+  if conn_config do
     require_ssl_config = env!("DATABASE_REQUIRE_SSL", :boolean, nil)
 
-    # In Electric, we only support two ways of using SSL when connecting to the database:
+    # In Electric, we only support two ways of using SSL for database connections:
     #
     #   1. It is either required, in which case a failure to establish a secure connection to the
     #      database will be treated as a fatal error.
@@ -214,9 +214,9 @@ connector_config =
     #   2. Or it is not required, in which case Electric will still try connecting with SSL first
     #      and will only fallback to using unencrypted connection if that fails.
     #
-    # When DATABASE_REQUIRE_SSL is set by the user, the sslmode query option in DATABASE_URL is ignored.
+    # When DATABASE_REQUIRE_SSL is set by the user, the sslmode query parameter in DATABASE_URL is ignored.
     require_ssl? =
-      case {require_ssl_config, conn_params[:sslmode]} do
+      case {require_ssl_config, conn_config[:sslmode]} do
         {nil, :require} -> true
         {nil, _} -> false
         {nil, nil} -> default_database_require_ssl
@@ -224,10 +224,10 @@ connector_config =
         {false, _} -> false
       end
 
-    # When require_ssl?=true, :epgsql will try to connect using SSL and fail if the server does not accept encrypted
+    # When require_ssl?=true, epgsql will try to connect using SSL and fail if the server does not accept encrypted
     # connections.
     #
-    # When require_ssl?=false, :epgsql will try to connect using SSL first, then fallback to an unencrypted connection
+    # When require_ssl?=false, epgsql will try to connect using SSL first, then fallback to an unencrypted connection
     # if that fails.
     use_ssl? =
       if require_ssl? do
@@ -238,8 +238,8 @@ connector_config =
 
     use_ipv6? = env!("DATABASE_USE_IPV6", :boolean, default_database_use_ipv6)
 
-    conn_params =
-      conn_params
+    conn_config =
+      conn_config
       |> Keyword.put(:ssl, use_ssl?)
       |> Keyword.put(:ipv6, use_ipv6?)
       |> Keyword.put(:replication, "database")
@@ -248,6 +248,7 @@ connector_config =
     {:ok, pg_server_host} = logical_publisher_host_config
 
     {:ok, proxy_port} = pg_proxy_port_config
+    {:ok, proxy_password} = pg_proxy_password_config
 
     proxy_listener_opts =
       if listen_on_ipv6? do
@@ -256,18 +257,16 @@ connector_config =
         []
       end
 
-    {:ok, proxy_password} = pg_proxy_password_config
-
     [
       postgres_1: [
         producer: Electric.Replication.Postgres.LogicalReplicationProducer,
-        connection: conn_params,
+        connection: conn_config,
         replication: [
           electric_connection: [
             host: pg_server_host,
             port: pg_server_port,
             dbname: "electric",
-            connect_timeout: conn_params[:timeout]
+            connect_timeout: conn_config[:timeout]
           ]
         ],
         proxy: [

--- a/components/electric/lib/electric/config.ex
+++ b/components/electric/lib/electric/config.ex
@@ -3,6 +3,12 @@ defmodule Electric.Config do
 
   @spec format_required_config_error(list) :: maybe_string
   def format_required_config_error(potential_errors) when is_list(potential_errors) do
+    format_invalid_config_error(potential_errors, true)
+  end
+
+  @spec format_invalid_config_error(list) :: maybe_string
+  @spec format_invalid_config_error(list, boolean) :: maybe_string
+  def format_invalid_config_error(potential_errors, required? \\ false) do
     errors =
       for {varname, {:error, str}} <- potential_errors do
         "  * #{varname} " <> str
@@ -12,7 +18,7 @@ defmodule Electric.Config do
       Electric.Errors.format_error(
         :conf,
         """
-        The following required configuration options have invalid or missing values:
+        The following#{if required?, do: " required"} configuration options have invalid or missing values:
 
         #{Enum.join(errors, "\n\n")}
         """,
@@ -313,4 +319,63 @@ defmodule Electric.Config do
   defp parse_database(nil, username), do: username
   defp parse_database("/", username), do: username
   defp parse_database("/" <> dbname, _username), do: dbname
+
+  @doc """
+  Parse human-readable memory/storage size string into bytes.
+
+  ## Examples
+
+    iex> parse_human_readable_size("1G", 1)
+    {:ok, #{1024 * 1024 * 1024}}
+
+    iex> parse_human_readable_size("2.23g", 1)
+    {:ok, 2_230_000_000}
+
+    iex> parse_human_readable_size("256M", 1)
+    {:ok, #{256 * 1024 * 1024}}
+
+    iex> parse_human_readable_size("377m", 1)
+    {:ok, 377_000_000}
+
+    iex> parse_human_readable_size("430K", 1)
+    {:ok, #{430 * 1024}}
+
+    iex> parse_human_readable_size("142888k", 1)
+    {:ok, 142_888_000}
+
+    iex> parse_human_readable_size("123456789", 1)
+    {:ok, 123_456_789}
+
+    iex> parse_human_readable_size(nil, 111222333)
+    {:ok, 111_222_333}
+
+    iex> parse_human_readable_size("", 1)
+    {:error, "has invalid value: \\"\\""}
+
+    iex> parse_human_readable_size("foo", 1)
+    {:error, "has invalid value: \\"foo\\""}
+  """
+  @spec parse_human_readable_size(binary | nil, pos_integer) ::
+          {:ok, pos_integer} | {:error, binary}
+
+  def parse_human_readable_size(nil, default), do: {:ok, default}
+
+  def parse_human_readable_size(str, _) do
+    with {num, suffix} <- Float.parse(str),
+         true <- num > 0,
+         suffix = String.trim(suffix),
+         true <- suffix == "" or suffix in ~w[G M K g m k] do
+      {:ok, trunc(num * size_multiplier(suffix))}
+    else
+      _ -> {:error, "has invalid value: #{inspect(str)}"}
+    end
+  end
+
+  defp size_multiplier(""), do: 1
+  defp size_multiplier("k"), do: 1_000
+  defp size_multiplier("K"), do: 1024
+  defp size_multiplier("m"), do: 1_000_000
+  defp size_multiplier("M"), do: 1024 * 1024
+  defp size_multiplier("g"), do: 1_000_000_000
+  defp size_multiplier("G"), do: 1024 * 1024 * 1024
 end

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -187,6 +187,20 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     #       to be aware of all transaction IDs and LSNs that happen, otherwise flakiness begins. I don't like that,
     #       so we probably want to be able to store a shallower pair than a full transaction object and handle that
     #       appropriately in the consumers. Or something else.
+    #
+    #
+    # 9 Apr 2024. ALCO's UPDATE TO THE ABOVE NOTE FROM ILIA:
+    #
+    # Versions of Postgres before 15 include all transactions in the logical replication
+    # stream, even those that touched tables not included in electric_publication. That is the
+    # source of empty transactions Electric sees on the replication stream. I'm not aware of
+    # other sources of such transactions that have an empty list of changes.
+    #
+    # Since version 15.0, Postgres no longer sends such empty transactions. It stands to reason
+    # that this whole comment blob can be removed for good.
+    #
+    # Here's the relevant change in Postgres' source tree -
+    # https://www.postgresql.org/message-id/E1nZNz3-001zFN-UA%40gemulon.postgresql.org
     |> Stream.each(
       &Logger.debug(
         "Saving transaction #{&1.xid} at #{&1.lsn} with changes #{inspect(&1.changes)}"

--- a/components/electric/lib/electric/postgres/logical_replication/decoder.ex
+++ b/components/electric/lib/electric/postgres/logical_replication/decoder.ex
@@ -275,6 +275,5 @@ defmodule Electric.Postgres.LogicalReplication.Decoder do
     DateTime.add(@pg_epoch, microsecond_offset, :microsecond)
   end
 
-  defp decode_lsn(<<segment::integer-32, offset::integer-32>>),
-    do: %Lsn{segment: segment, offset: offset}
+  defp decode_lsn(bin), do: Lsn.decode_bin(bin)
 end

--- a/components/electric/lib/electric/postgres/logical_replication/encoder.ex
+++ b/components/electric/lib/electric/postgres/logical_replication/encoder.ex
@@ -167,9 +167,7 @@ defmodule Electric.Postgres.LogicalReplication.Encoder do
     data
   end
 
-  defp encode_lsn(%Lsn{segment: segment, offset: offset}) do
-    <<segment::integer-32, offset::integer-32>>
-  end
+  defp encode_lsn(lsn), do: Lsn.encode_bin(lsn)
 
   @pg_epoch DateTime.from_iso8601("2000-01-01T00:00:00.000000Z") |> elem(1)
   defp timestamp_to_pgtimestamp(datetime) when is_struct(datetime, DateTime) do

--- a/components/electric/lib/electric/postgres/lsn.ex
+++ b/components/electric/lib/electric/postgres/lsn.ex
@@ -1,62 +1,194 @@
 defmodule Electric.Postgres.Lsn do
   @moduledoc """
-  Representation of the Postgres log sequence number.
+  Encoding, decoding and helper functions for the pg_lsn type.
   """
-  defstruct [:segment, :offset]
+
+  import Kernel, except: [to_charlist: 1, to_string: 1]
+
+  alias __MODULE__, as: Lsn
+
+  defstruct segment: 0, offset: 0
 
   @type int32 :: 0..0xFFFFFFFF
-  @type t :: %__MODULE__{
+  @type t :: %Lsn{
           segment: int32(),
           offset: int32()
         }
 
-  @spec to_string(t()) :: String.t()
-  def to_string(%__MODULE__{segment: segment, offset: offset}),
-    do: Integer.to_string(segment, 16) <> "/" <> Integer.to_string(offset, 16)
+  @doc """
+  Format Lsn to its text representation in an iolist.
 
-  @spec from_string(binary) :: t()
-  def from_string(x) when is_binary(x) do
-    [segment, offset] = String.split(x, "/")
-    %__MODULE__{segment: String.to_integer(segment, 16), offset: String.to_integer(offset, 16)}
+  ## Examples
+
+      iex> to_iolist(%#{Lsn}{segment: 0, offset: 0})
+      ["0", ?/, "0"]
+
+      iex> to_iolist(%#{Lsn}{segment: 127, offset: 1024})
+      ["7F", ?/, "400"]
+  """
+  @spec to_iolist(t) :: iolist
+  def to_iolist(%Lsn{segment: segment, offset: offset}) do
+    [Integer.to_string(segment, 16), ?/, Integer.to_string(offset, 16)]
   end
 
-  @spec from_integer(integer) :: t()
-  def from_integer(x) when is_integer(x) do
-    <<segment::32, offset::32>> = <<x::64>>
-    %__MODULE__{segment: segment, offset: offset}
+  @doc """
+  Parse the given string as a pg_lsn value.
+
+  ## Examples
+
+      iex> from_string("0/0")
+      %#{Lsn}{segment: 0, offset: 0}
+
+      iex> from_string("7F/400")
+      %#{Lsn}{segment: 127, offset: 1024}
+  """
+  @spec from_string(String.t()) :: t
+  def from_string(str) when is_binary(str) do
+    [segment, offset] = String.split(str, "/")
+    %Lsn{segment: String.to_integer(segment, 16), offset: String.to_integer(offset, 16)}
   end
 
-  @spec to_integer(t()) :: non_neg_integer
-  def to_integer(%__MODULE__{segment: s, offset: o}) do
-    <<i::64>> = <<s::32, o::32>>
-    i
+  @doc """
+  Convert the non-negative byte offset into Lsn.
+
+  ## Examples
+
+      iex> from_integer(0)
+      %#{Lsn}{segment: 0, offset: 0}
+
+      iex> from_integer(1_000_000)
+      %#{Lsn}{segment: 0, offset: 1_000_000}
+
+      iex> from_integer(0xFFFFFFFF)
+      %#{Lsn}{segment: 0, offset: 4294967295}
+
+      iex> from_integer(0xFFFFFFFFF)
+      %#{Lsn}{segment: 15, offset: 4294967295}
+
+      iex> from_integer(-1)
+      ** (FunctionClauseError) no function clause matching in Electric.Postgres.Lsn.from_integer/1
+  """
+  @spec from_integer(non_neg_integer) :: t
+  def from_integer(int) when is_integer(int) and int >= 0 do
+    <<segment::32, offset::32>> = <<int::64>>
+    %Lsn{segment: segment, offset: offset}
   end
 
-  @spec compare(t(), t()) :: :eq | :gt | :lt
-  def compare(%{segment: s1}, %{segment: s2}) when s1 < s2, do: :lt
-  def compare(%{segment: s1}, %{segment: s2}) when s1 > s2, do: :gt
-  def compare(%{offset: o1}, %{offset: o2}) when o1 < o2, do: :lt
-  def compare(%{offset: o1}, %{offset: o2}) when o1 > o2, do: :gt
-  def compare(%{offset: o1}, %{offset: o2}) when o1 == o2, do: :eq
+  @doc """
+  Convert the Lsn into an equivalent byte offset.
 
-  def increment(lsn, step \\ 10)
+  ## Examples
 
-  def increment(%__MODULE__{segment: s, offset: o}, step) when o + step < 0xFFFFFFFF,
-    do: %__MODULE__{segment: s, offset: o + step}
+      iex> to_integer(%#{Lsn}{segment: 0, offset: 0})
+      0
 
-  def increment(%__MODULE__{segment: s, offset: o}, step),
-    do: %__MODULE__{segment: s + 1, offset: rem(o + step, 0xFFFFFFFF)}
+      iex> to_integer(%#{Lsn}{segment: 0, offset: 1_000_000})
+      1_000_000
+
+      iex> to_integer(%#{Lsn}{segment: 0, offset: 4294967295})
+      0xFFFFFFFF
+
+      iex> to_integer(%#{Lsn}{segment: 15, offset: 4294967295})
+      0xFFFFFFFFF
+  """
+  @spec to_integer(t) :: non_neg_integer
+  def to_integer(%Lsn{segment: segment, offset: offset}) do
+    <<int::64>> = <<segment::32, offset::32>>
+    int
+  end
+
+  @spec decode_bin(binary) :: t
+  def decode_bin(<<segment::32, offset::32>>), do: %Lsn{segment: segment, offset: offset}
+
+  @spec encode_bin(t) :: binary
+  def encode_bin(%Lsn{segment: segment, offset: offset}), do: <<segment::32, offset::32>>
+
+  @doc """
+  Compare two Lsns and determine if one is less or greater or both are equal.
+
+  ## Examples
+
+      iex> compare(from_integer(0), from_integer(1))
+      :lt
+
+      iex> compare(from_integer(99), from_integer(98))
+      :gt
+
+      iex> compare(from_integer(127_000_256), from_string("0/791DEC0"))
+      :eq
+  """
+  @spec compare(t, t) :: :eq | :gt | :lt
+  def compare(%Lsn{segment: s1}, %Lsn{segment: s2}) when s1 < s2, do: :lt
+  def compare(%Lsn{segment: s1}, %Lsn{segment: s2}) when s1 > s2, do: :gt
+  def compare(%Lsn{offset: o1}, %Lsn{offset: o2}) when o1 < o2, do: :lt
+  def compare(%Lsn{offset: o1}, %Lsn{offset: o2}) when o1 > o2, do: :gt
+  def compare(%Lsn{offset: o1}, %Lsn{offset: o2}) when o1 == o2, do: :eq
+
+  @max_offset 0xFFFFFFFF
+
+  @doc """
+  Add the given byte offset to the Lsn value.
+
+  The result is capped at the bottom to not go below #Lsn<0/0>.
+
+  ## Examples
+
+      iex> increment(from_integer(0), 8_000_000)
+      %#{Lsn}{segment: 0, offset: 8_000_000}
+
+      iex> increment(from_integer(4_000_000_000), 1_000_000_000)
+      %#{Lsn}{segment: 1, offset: 705_032_704}
+
+      iex> to_integer(%#{Lsn}{segment: 1, offset: 705_032_704})
+      5_000_000_000
+
+      iex> increment(from_integer(4_000_000_000), 10_000_000_000)
+      %#{Lsn}{segment: 3, offset: 1_115_098_112}
+
+      iex> to_integer(%#{Lsn}{segment: 3, offset: 1_115_098_112})
+      14_000_000_000
+
+      iex> increment(from_integer(14_000_000_000), -8_000_000_000)
+      %#{Lsn}{segment: 1, offset: 1_705_032_704}
+
+      iex> increment(from_integer(100), -99)
+      %#{Lsn}{segment: 0, offset: 1}
+
+      iex> increment(from_integer(100), -100)
+      %#{Lsn}{segment: 0, offset: 0}
+
+      iex> increment(from_integer(100), -101)
+      %#{Lsn}{segment: 0, offset: 0}
+  """
+  @spec increment(t, integer) :: t
+  def increment(%Lsn{segment: segment, offset: offset}, incr)
+      when (offset + incr) in 0..@max_offset,
+      do: %Lsn{segment: segment, offset: offset + incr}
+
+  def increment(%Lsn{segment: segment, offset: offset}, incr) when offset + incr > @max_offset do
+    sum = offset + incr
+    %Lsn{segment: segment + div(sum, @max_offset + 1), offset: rem(sum, @max_offset + 1)}
+  end
+
+  def increment(%Lsn{} = lsn, incr) do
+    lsn
+    |> to_integer()
+    |> Kernel.+(incr)
+    |> max(0)
+    |> from_integer()
+  end
 
   defimpl Inspect do
-    alias Electric.Postgres.Lsn
-
-    def inspect(%Lsn{segment: segment, offset: offset}, _opts) do
-      "#Lsn<#{Integer.to_string(segment, 16)}/#{Integer.to_string(offset, 16)}>"
+    def inspect(lsn, _opts) do
+      "#Lsn<#{Electric.Postgres.Lsn.to_iolist(lsn)}>"
     end
   end
 
   defimpl String.Chars do
-    alias Electric.Postgres.Lsn
-    def to_string(lsn), do: Lsn.to_string(lsn)
+    def to_string(lsn), do: "#{Electric.Postgres.Lsn.to_iolist(lsn)}"
+  end
+
+  defimpl List.Chars do
+    def to_charlist(lsn), do: ~c'#{Electric.Postgres.Lsn.to_iolist(lsn)}'
   end
 end

--- a/components/electric/lib/electric/replication/changes.ex
+++ b/components/electric/lib/electric/replication/changes.ex
@@ -50,7 +50,6 @@ defmodule Electric.Replication.Changes do
             origin_type: :postgresql | :satellite,
             publication: String.t(),
             lsn: Electric.Postgres.Lsn.t(),
-            ack_fn: (-> :ok | {:error, term()}),
             additional_data_ref: non_neg_integer()
           }
 
@@ -61,7 +60,6 @@ defmodule Electric.Replication.Changes do
       :origin,
       :publication,
       :lsn,
-      :ack_fn,
       :origin_type,
       referenced_records: %{},
       additional_data_ref: 0

--- a/components/electric/lib/electric/replication/connectors.ex
+++ b/components/electric/lib/electric/replication/connectors.ex
@@ -3,13 +3,23 @@ defmodule Electric.Replication.Connectors do
 
   @type origin() :: binary()
 
-  @type connection_config() :: :epgsql.connect_opts()
+  @type connection_config_opt() :: :epgsql.connect_option() | {:ipv6, boolean()}
+  @type connection_config() :: [connection_config_opt(), ...]
+
   @type electric_connection_opt() ::
-          {:host, binary()} | {:port, pos_integer()} | {:dbname, binary()}
-  @type electric_connection_opts() :: [electric_connection_opt()]
-  @type replication_config_opt() ::
-          {:slot, binary()} | {:electric_connection, electric_connection_opts()}
-  @type replication_config() :: [replication_config_opt(), ...]
+          {:host, binary()}
+          | {:port, pos_integer()}
+          | {:dbname, binary()}
+          | {:connect_timeout, non_neg_integer()}
+  @type replication_config() :: [{:electric_connection, [electric_connection_opt(), ...]}]
+
+  @type proxy_listen_opts() :: ThousandIsland.options()
+  @type proxy_config_opt() ::
+          {:listen, proxy_listen_opts()}
+          | {:use_http_tunnel?, boolean()}
+          | {:password, binary()}
+          | {:log_level, Logger.level()}
+  @type proxy_config() :: [proxy_config_opt(), ...]
 
   @type wal_window_config_opt() ::
           {:resumable_size, pos_integer()}
@@ -17,20 +27,26 @@ defmodule Electric.Replication.Connectors do
   @type wal_window_config() :: [wal_window_config_opt(), ...]
 
   @type config_opt() ::
-          {:connection, connection_config()}
+          {:origin, origin()}
+          | {:connection, connection_config()}
           | {:replication, replication_config()}
-          | {:origin, origin()}
+          | {:proxy, proxy_config()}
           | {:wal_window, wal_window_config()}
 
   @type config() :: [config_opt(), ...]
 
   @type replication_opts() :: %{
-          publication: String.t(),
           slot: String.t(),
+          publication: String.t(),
           subscription: String.t(),
-          electric_connection: %{host: String.t(), port: pos_integer, dbname: String.t()},
-          opts: Keyword.t()
+          electric_connection: %{
+            host: String.t(),
+            port: pos_integer(),
+            dbname: String.t(),
+            connect_timeout: non_neg_integer()
+          }
         }
+
   @type connection_opts() :: %{
           host: charlist(),
           port: :inet.port_number(),
@@ -38,17 +54,17 @@ defmodule Electric.Replication.Connectors do
           username: charlist(),
           password: charlist(),
           replication: charlist(),
-          ssl: boolean(),
+          ssl: :required | boolean(),
           ipv6: boolean(),
+          timeout: non_neg_integer(),
           ip_addr: :inet.ip_address(),
-          tcp_opts: [:gen_tcp.connect_option()]
+          tcp_opts: [:gen_tcp.connect_option(), ...]
         }
 
-  @type proxy_listen_opts() :: ThousandIsland.options()
   @type proxy_opts() :: %{
           listen: proxy_listen_opts(),
           use_http_tunnel?: boolean,
-          password: String.t(),
+          password: binary(),
           log_level: Logger.level()
         }
 
@@ -125,7 +141,22 @@ defmodule Electric.Replication.Connectors do
     config
     |> Keyword.fetch!(:connection)
     |> new_map_with_charlists()
-    |> set_replication(replication?)
+    |> maybe_keep_replication(replication?)
+  end
+
+  defp new_map_with_charlists(list) do
+    Map.new(list, fn
+      {k, v} when is_binary(v) -> {k, String.to_charlist(v)}
+      {k, v} -> {k, v}
+    end)
+  end
+
+  defp maybe_keep_replication(opts, false) do
+    Map.delete(opts, :replication)
+  end
+
+  defp maybe_keep_replication(opts, true) do
+    opts
   end
 
   @spec get_proxy_opts(config()) :: proxy_opts()
@@ -151,20 +182,5 @@ defmodule Electric.Replication.Connectors do
   @spec pop_extraneous_conn_opts(connection_opts()) :: {map, :epgsql.connect_opts_map()}
   def pop_extraneous_conn_opts(conn_opts) do
     Map.split(conn_opts, [:ipv6, :ip_addr])
-  end
-
-  defp new_map_with_charlists(list) do
-    Map.new(list, fn
-      {k, v} when is_binary(v) -> {k, String.to_charlist(v)}
-      {k, v} -> {k, v}
-    end)
-  end
-
-  defp set_replication(opts, false) do
-    Map.delete(opts, :replication)
-  end
-
-  defp set_replication(opts, true) do
-    opts
   end
 end

--- a/components/electric/lib/electric/replication/connectors.ex
+++ b/components/electric/lib/electric/replication/connectors.ex
@@ -11,10 +11,16 @@ defmodule Electric.Replication.Connectors do
           {:slot, binary()} | {:electric_connection, electric_connection_opts()}
   @type replication_config() :: [replication_config_opt(), ...]
 
+  @type wal_window_config_opt() ::
+          {:resumable_size, pos_integer()}
+          | {:in_memory_size, pos_integer()}
+  @type wal_window_config() :: [wal_window_config_opt(), ...]
+
   @type config_opt() ::
           {:connection, connection_config()}
           | {:replication, replication_config()}
           | {:origin, origin()}
+          | {:wal_window, wal_window_config()}
 
   @type config() :: [config_opt(), ...]
 
@@ -44,6 +50,11 @@ defmodule Electric.Replication.Connectors do
           use_http_tunnel?: boolean,
           password: String.t(),
           log_level: Logger.level()
+        }
+
+  @type wal_window_opts() :: %{
+          resumable_size: pos_integer(),
+          in_memory_size: pos_integer()
         }
 
   alias Electric.Postgres.Extension
@@ -121,6 +132,13 @@ defmodule Electric.Replication.Connectors do
   def get_proxy_opts(config) do
     config
     |> Keyword.fetch!(:proxy)
+    |> Map.new()
+  end
+
+  @spec get_wal_window_opts(config()) :: wal_window_opts()
+  def get_wal_window_opts(config) do
+    config
+    |> Keyword.fetch!(:wal_window)
     |> Map.new()
   end
 

--- a/components/electric/lib/electric/replication/initial_sync.ex
+++ b/components/electric/lib/electric/replication/initial_sync.ex
@@ -52,8 +52,7 @@ defmodule Electric.Replication.InitialSync do
         commit_timestamp: migration.timestamp,
         origin: origin,
         publication: publication,
-        lsn: lsn,
-        ack_fn: fn -> :ok end
+        lsn: lsn
       }
     end
   end

--- a/components/electric/lib/electric/replication/postgres/client.ex
+++ b/components/electric/lib/electric/replication/postgres/client.ex
@@ -309,6 +309,19 @@ defmodule Electric.Replication.Postgres.Client do
     end
   end
 
+  @doc """
+  Advance the earliest accessible lsn of the given slot to `to_lsn`.
+
+  After a slot is advanced there is no way for it to be rewound back to an earlier lsn.
+  """
+  @spec advance_replication_slot(connection, String.t(), Lsn.t()) :: :ok | {:error, term}
+  def advance_replication_slot(conn, slot_name, to_lsn) do
+    with {:ok, _, _} <-
+           squery(conn, "SELECT pg_replication_slot_advance('#{slot_name}', '#{to_lsn}')") do
+      :ok
+    end
+  end
+
   @relkind %{table: ["r"], index: ["i"], view: ["v", "m"]}
 
   @pg_class_query """

--- a/components/electric/lib/electric/replication/postgres/client.ex
+++ b/components/electric/lib/electric/replication/postgres/client.ex
@@ -8,7 +8,7 @@ defmodule Electric.Replication.Postgres.Client do
 
   import Electric.Postgres.Dialect.Postgresql, only: [quote_ident: 1]
 
-  alias Electric.Postgres.Extension
+  alias Electric.Postgres.{Extension, Lsn}
   alias Electric.Replication.Connectors
 
   require Logger
@@ -264,10 +264,9 @@ defmodule Electric.Replication.Postgres.Client do
 
   Returns `:ok` on success.
   """
-  def acknowledge_lsn(conn, %{segment: segment, offset: offset}) do
-    <<decimal_lsn::integer-64>> = <<segment::integer-32, offset::integer-32>>
-
-    :epgsql.standby_status_update(conn, decimal_lsn, decimal_lsn)
+  def acknowledge_lsn(conn, lsn) do
+    wal_offset = Lsn.to_integer(lsn)
+    :epgsql.standby_status_update(conn, wal_offset, wal_offset)
   end
 
   @relkind %{table: ["r"], index: ["i"], view: ["v", "m"]}

--- a/components/electric/lib/electric/replication/postgres/client.ex
+++ b/components/electric/lib/electric/replication/postgres/client.ex
@@ -155,8 +155,17 @@ defmodule Electric.Replication.Postgres.Client do
     {:ok, system_id}
   end
 
-  @spec create_slot(connection(), String.t()) :: {:ok, String.t()}
-  def create_slot(conn, slot_name) do
+  @doc """
+  Create the main replication slot to maintain a resumable window of WAL records in Postgres.
+
+  This slot should be used as a source for pg_copy_logical_replication() to create a new,
+  temporary replication slot for the replication connection.
+
+  Note that unless manually moved forward with pg_replication_slot_advance(), it will prevent
+  Postgres from discarding old WAL records, leading to unbounded disk usage growth.
+  """
+  @spec create_main_slot(connection(), String.t()) :: {:ok, String.t()}
+  def create_main_slot(conn, slot_name) do
     case squery(
            conn,
            ~s|CREATE_REPLICATION_SLOT "#{slot_name}" LOGICAL pgoutput NOEXPORT_SNAPSHOT|
@@ -201,6 +210,26 @@ defmodule Electric.Replication.Postgres.Client do
     end
   end
 
+  @doc """
+  Create a temporary slot as a copy of the main one.
+
+  Its lsn matches that of the main slot at the time of the copy. This temporary slot should be
+  used for starting a new replication connection, at which point a later lsn can be specified
+  as a starting point for the replication stream.
+
+  Postgres will automatically delete the temporary slot when the connection that created it closes.
+  """
+  @spec create_temporary_slot(connection(), String.t(), String.t()) ::
+          {:ok, String.t(), Lsn.t()} | {:error, term}
+  def create_temporary_slot(conn, source_slot_name, tmp_slot_name) do
+    sql =
+      "SELECT * FROM pg_copy_logical_replication_slot('#{source_slot_name}', '#{tmp_slot_name}', true)"
+
+    with {:ok, _, [{^tmp_slot_name, lsn_str}]} <- squery(conn, sql) do
+      {:ok, tmp_slot_name, Lsn.from_string(lsn_str)}
+    end
+  end
+
   def create_subscription(conn, name, publication_name, connection_params) do
     connection_string = Enum.map_join(connection_params, " ", fn {k, v} -> "#{k}=#{v}" end)
 
@@ -215,20 +244,21 @@ defmodule Electric.Replication.Postgres.Client do
   end
 
   @doc """
-  Start consuming logical replication feed using a given `publication` and `slot`.
+  Start consuming the logical replication stream using given `publication` and `slot`.
 
-  The handler can be a pid or a module implementing the `handle_x_log_data` callback.
-
-  Returns `:ok` on success.
+  The handler can be a pid or a module implementing epgsql's `handle_x_log_data` callback.
   """
-  def start_replication(conn, publication, slot, handler) do
+  @spec start_replication(connection, String.t(), String.t(), Lsn.t(), module | pid) ::
+          :ok | {:error, term}
+  def start_replication(conn, publication, slot, lsn, handler) do
     Logger.debug(
       "#{__MODULE__} start_replication: slot: '#{slot}', publication: '#{publication}'"
     )
 
-    slot = String.to_charlist(slot)
+    slot = to_charlist(slot)
+    lsn = to_charlist(lsn)
     opts = ~c"proto_version '1', publication_names '#{publication}', messages"
-    :epgsql.start_replication(conn, slot, handler, [], ~c"0/0", opts)
+    :epgsql.start_replication(conn, slot, handler, [], lsn, opts)
   end
 
   @doc """
@@ -267,6 +297,16 @@ defmodule Electric.Replication.Postgres.Client do
   def acknowledge_lsn(conn, lsn) do
     wal_offset = Lsn.to_integer(lsn)
     :epgsql.standby_status_update(conn, wal_offset, wal_offset)
+  end
+
+  @doc """
+  Fetch the current lsn from Postgres.
+  """
+  @spec current_lsn(connection) :: {:ok, Lsn.t()} | {:error, term}
+  def current_lsn(conn) do
+    with {:ok, _, [{lsn_str}]} <- squery(conn, "SELECT pg_current_wal_lsn()") do
+      {:ok, Lsn.from_string(lsn_str)}
+    end
   end
 
   @relkind %{table: ["r"], index: ["i"], view: ["v", "m"]}

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -408,6 +408,13 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   end
 
   @spec ack(Transaction.t(), State.t()) :: :ok
+
+  if Mix.env() == :test do
+    def ack(%Transaction{}, %State{repl_conn: :conn}) do
+      :ok
+    end
+  end
+
   def ack(%Transaction{lsn: lsn}, state) do
     Logger.debug("Acknowledging #{lsn}", origin: state.origin)
     Client.acknowledge_lsn(state.repl_conn, lsn)

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -9,8 +9,6 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
 
   alias Electric.Postgres.LogicalReplication
   alias Electric.Postgres.LogicalReplication.Messages
-  alias Electric.Replication.Postgres.Client
-  alias Electric.Replication.Connectors
 
   alias Electric.Postgres.LogicalReplication.Messages.{
     Begin,
@@ -25,6 +23,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     Message
   }
 
+  alias Electric.Postgres.Lsn
+
   alias Electric.Replication.Changes.{
     Transaction,
     NewRecord,
@@ -33,6 +33,9 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     TruncatedRelation,
     ReferencedRecord
   }
+
+  alias Electric.Replication.Connectors
+  alias Electric.Replication.Postgres.Client
 
   defmodule State do
     defstruct repl_conn: nil,
@@ -46,7 +49,10 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
               origin: nil,
               types: %{},
               span: nil,
-              magic_write_timer: nil
+              magic_write_timer: nil,
+              main_slot: "",
+              main_slot_lsn: %Lsn{},
+              resumable_wal_window: 1
 
     @type t() :: %__MODULE__{
             repl_conn: pid(),
@@ -54,12 +60,15 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
             demand: non_neg_integer(),
             queue: :queue.queue(),
             relations: %{Messages.relation_id() => %Relation{}},
-            transaction: {Electric.Postgres.Lsn.t(), %Transaction{}},
-            publication: String.t(),
+            transaction: {Lsn.t(), %Transaction{}},
+            publication: binary(),
             origin: Connectors.origin(),
             types: %{},
             span: Metrics.t() | nil,
-            magic_write_timer: reference() | nil
+            magic_write_timer: reference() | nil,
+            main_slot: binary(),
+            main_slot_lsn: Lsn.t(),
+            resumable_wal_window: pos_integer()
           }
   end
 
@@ -77,16 +86,17 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
 
   @spec start_link(Connectors.config()) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(connector_config) do
-    GenStage.start_link(__MODULE__, connector_config)
+    GenStage.start_link(__MODULE__, connector_config, name: name(connector_config))
   end
 
-  @spec get_name(Connectors.origin()) :: Electric.reg_name()
-  def get_name(name) do
-    {:via, :gproc, name(name)}
+  @spec name(Connectors.config()) :: Electric.reg_name()
+  def name(connector_config) when is_list(connector_config) do
+    name(Connectors.origin(connector_config))
   end
 
-  defp name(name) do
-    {:n, :l, {__MODULE__, name}}
+  @spec name(Connectors.origin()) :: Electric.reg_name()
+  def name(origin) when is_binary(origin) do
+    Electric.name(__MODULE__, origin)
   end
 
   @impl true
@@ -95,36 +105,42 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     conn_opts = Connectors.get_connection_opts(connector_config)
     repl_conn_opts = Connectors.get_connection_opts(connector_config, replication: true)
     repl_opts = Connectors.get_replication_opts(connector_config)
-
-    :gproc.reg(name(origin))
+    wal_window_opts = Connectors.get_wal_window_opts(connector_config)
 
     publication = repl_opts.publication
-    slot = repl_opts.slot
+    main_slot = repl_opts.slot
+    tmp_slot = main_slot <> "_rc"
 
-    Logger.debug("#{__MODULE__}.init: publication: '#{publication}', slot: '#{slot}'")
-
-    Logger.info("Starting replication from #{origin}")
+    Logger.metadata(pg_producer: origin)
 
     Logger.info(
-      "#{inspect(__MODULE__)}.init(#{inspect(Client.sanitize_conn_opts(repl_conn_opts))})"
+      "Starting replication with publication=#{publication} and slots=#{main_slot},#{tmp_slot}}"
     )
 
     # The replication connection is used to consumer the logical replication stream from
     # Postgres and to send acknowledgements about received transactions back to Postgres,
     # allowing it to advance the replication slot forward and discard obsolete WAL records.
     with {:ok, repl_conn} <- Client.connect(repl_conn_opts),
-         {:ok, _} <- Client.create_slot(repl_conn, slot),
+         # Refactoring note: make sure that both slots are created first thing after a
+         # connection is opened. In particular, trying to call `Client.get_server_versions()` before
+         # creating the main slot results in the replication stream not delivering transactions from
+         # Postgres when Electric is running in the direct_writes mode, which manifests as a
+         # failure of e2e/tests/02.02_migrations_get_streamed_to_satellite.lux.
+         {:ok, _slot_name} <- Client.create_main_slot(repl_conn, main_slot),
+         {:ok, _slot_name, main_slot_lsn} <-
+           Client.create_temporary_slot(repl_conn, main_slot, tmp_slot),
          :ok <- Client.set_display_settings_for_replication(repl_conn),
          {:ok, {short, long, cluster}} <- Client.get_server_versions(repl_conn),
          {:ok, table_count} <- SchemaLoader.count_electrified_tables({SchemaCache, origin}),
-         :ok <- Client.start_replication(repl_conn, publication, slot, self()),
+         {:ok, current_lsn} <- Client.current_lsn(repl_conn),
+         start_lsn = start_lsn(main_slot_lsn, current_lsn, wal_window_opts),
+         :ok <- Client.start_replication(repl_conn, publication, tmp_slot, start_lsn, self()),
          # The service connection is opened alongside the replication connection to execute
          # maintenance statements. It is needed because Postgres does not allow regular
          # statements and queries on a replication connection once the replication has started.
          {:ok, svc_conn} <- Client.connect(conn_opts) do
+      # Monitor the connection process to know when to stop the telemetry span created on the next line.
       Process.monitor(repl_conn)
-
-      Logger.metadata(pg_producer: origin)
 
       span =
         Metrics.start_span([:postgres, :replication_from], %{electrified_tables: table_count}, %{
@@ -140,7 +156,10 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
           queue: :queue.new(),
           publication: publication,
           origin: origin,
-          span: span
+          span: span,
+          main_slot: main_slot,
+          main_slot_lsn: main_slot_lsn,
+          resumable_wal_window: wal_window_opts.resumable_size
         }
         # The replication slot used by the replication connection prevents Postgres from
         # discarding old WAL records until Electric sees a write to an electrified table.
@@ -153,6 +172,25 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
 
       {:producer, state}
     end
+  end
+
+  # The current implementation is trivial for one reason: we don't know how many transactions
+  # that touch electrified tables ("etxns" from now on) there are between `main_slot_lsn` and
+  # `current_lsn`. As an extreme example, there could be one such transaction among thousands
+  # of transactions that Electric won't see. So there's no sensible way of choosing the start LSN
+  # such that we would stream in precisely as many etxns as can fit into the in-memory cache.
+  #
+  # Right now, the only way to preload all recent etxns into memory is to start streaming from
+  # the slot's starting point and rely on the in-memory cache's garbage collection to discard
+  # old transactions when it overflows.
+  #
+  # Going forward, we should look into writing etxns to a custom file format on disk as we
+  # are reading them from the logical replication stream. That will allow us to start
+  # replication from the last observed LSN, stream transactions until we reach the current LSN
+  # in Postgres and then fill the remaining cache space with older transactions from the file
+  # on disk.
+  defp start_lsn(main_slot_lsn, _current_lsn, _wal_window_opts) do
+    main_slot_lsn
   end
 
   @impl true
@@ -394,7 +432,7 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     }
   end
 
-  @spec ack(pid(), Connectors.origin(), Electric.Postgres.Lsn.t()) :: :ok
+  @spec ack(pid(), Connectors.origin(), Lsn.t()) :: :ok
   def ack(repl_conn, origin, lsn) do
     Logger.debug("Acknowledging #{lsn}", origin: origin)
     Client.acknowledge_lsn(repl_conn, lsn)

--- a/components/electric/lib/electric/replication/postgres/migration_consumer.ex
+++ b/components/electric/lib/electric/replication/postgres/migration_consumer.ex
@@ -123,11 +123,13 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
     change
   end
 
-  defp process_migrations(transactions, state) do
+  defp process_migrations(transactions, %{loader: loader} = state) do
+    {:ok, %{version: schema_version}} = SchemaLoader.load(loader)
+
     {state, num_applied_migrations} =
       transactions
-      |> Enum.flat_map(&transaction_changes_to_migrations(&1, state))
-      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+      |> transactions_to_migrations(state)
+      |> skip_applied_migrations(schema_version)
       |> Enum.reduce({state, 0}, fn migration, {state, num_applied} ->
         {perform_migration(migration, state), num_applied + 1}
       end)
@@ -139,12 +141,22 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
     end
   end
 
+  defp transactions_to_migrations(transactions, state) do
+    transactions
+    |> Enum.flat_map(&transaction_changes_to_migrations(&1, state))
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+  end
+
   defp transaction_changes_to_migrations(%Transaction{changes: changes}, state) do
     for %NewRecord{record: record, relation: relation} <- changes, is_ddl_relation(relation) do
       {:ok, version} = SchemaLoader.tx_version(state.loader, record)
       {:ok, sql} = Extension.extract_ddl_sql(record)
       {version, sql}
     end
+  end
+
+  defp skip_applied_migrations(migrations, schema_version) do
+    Enum.drop_while(migrations, fn {version, _stmts} -> version <= schema_version end)
   end
 
   defp perform_migration({version, stmts}, state) do

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -24,7 +24,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
     name = name(origin)
     Electric.reg(name)
 
-    postgres_producer = Postgres.LogicalReplicationProducer.get_name(origin)
+    postgres_producer = Postgres.LogicalReplicationProducer.name(origin)
     postgres_producer_consumer = Postgres.MigrationConsumer.name(origin)
     write_to_pg_mode = Connectors.write_to_pg_mode(connector_config)
 

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -390,8 +390,7 @@ defmodule Electric.Satellite.Protocol do
              state.client_id,
              msg,
              in_rep.incomplete_trans,
-             in_rep.relations,
-             fn _lsn -> nil end
+             in_rep.relations
            ) do
         {incomplete, []} ->
           {nil, %State{state | in_rep: %InRep{in_rep | incomplete_trans: incomplete}}}

--- a/components/electric/lib/electric/satellite/serialization.ex
+++ b/components/electric/lib/electric/satellite/serialization.ex
@@ -366,28 +366,22 @@ defmodule Electric.Satellite.Serialization do
   @doc """
   Deserialize from Satellite PB format to internal format
   """
-  @spec deserialize_trans(
-          String.t(),
-          %SatOpLog{},
-          %Transaction{} | nil,
-          cached_relations(),
-          (term -> any)
-        ) ::
+  @spec deserialize_trans(String.t(), %SatOpLog{}, %Transaction{} | nil, cached_relations()) ::
           {
             incomplete :: %Transaction{} | nil,
             # Complete transactions are send in reverse order
             complete :: [%Transaction{} | additional_data()]
           }
-  def deserialize_trans(origin, %SatOpLog{} = op_log, nil, relations, ack_fun) do
-    deserialize_op_log(origin, op_log, {nil, []}, relations, ack_fun)
+  def deserialize_trans(origin, %SatOpLog{} = op_log, nil, relations) do
+    deserialize_op_log(origin, op_log, {nil, []}, relations)
   end
 
-  def deserialize_trans(origin, %SatOpLog{} = op_log, %Transaction{} = trans, relations, ack_fun)
+  def deserialize_trans(origin, %SatOpLog{} = op_log, %Transaction{} = trans, relations)
       when origin !== "" do
-    deserialize_op_log(origin, op_log, {trans, []}, relations, ack_fun)
+    deserialize_op_log(origin, op_log, {trans, []}, relations)
   end
 
-  defp deserialize_op_log(origin, %SatOpLog{} = msg, incomplete, relations, ack_fun) do
+  defp deserialize_op_log(origin, %SatOpLog{} = msg, incomplete, relations) do
     Enum.reduce(msg.ops, incomplete, fn
       %SatTransOp{op: {:additional_begin, %SatOpAdditionalBegin{}}}, {nil, complete} ->
         {{:additional_data, []}, complete}
@@ -411,7 +405,6 @@ defmodule Electric.Satellite.Serialization do
           publication: "",
           commit_timestamp: dt,
           lsn: op.lsn,
-          ack_fn: fn -> ack_fun.(op.lsn) end,
           additional_data_ref: op.additional_data_ref
         }
 

--- a/components/electric/test/electric/postgres/lsn_test.exs
+++ b/components/electric/test/electric/postgres/lsn_test.exs
@@ -1,0 +1,5 @@
+defmodule Electric.Postgres.LsnTest do
+  use ExUnit.Case, async: true
+
+  doctest Electric.Postgres.Lsn, import: true
+end

--- a/components/electric/test/electric/replication/electrification_test.exs
+++ b/components/electric/test/electric/replication/electrification_test.exs
@@ -7,7 +7,7 @@ defmodule Electric.Replication.ElectrificationTest do
   alias Electric.Replication.Changes.{NewRecord, Transaction}
 
   @origin "electrification-test"
-  @next_cached_tx_timeout 5000
+  @sleep_timeout 5000
 
   setup ctx, do: Map.put(ctx, :origin, @origin)
   setup :setup_replicated_db
@@ -83,24 +83,13 @@ defmodule Electric.Replication.ElectrificationTest do
     :ok
   end
 
-  defp wait_for_next_cached_wal_tx(lsn, ts \\ System.monotonic_time()) do
-    with :ok <- check_remaining_time(ts, @next_cached_tx_timeout),
-         :ok <- wait_until_cached_wal_advances(lsn),
+  defp wait_for_next_cached_wal_tx(lsn) do
+    with :ok <- wait_until_cached_wal_advances(lsn),
          {:ok, %Transaction{changes: [_ | _]} = tx, new_lsn} <- CachedWal.Api.next_segment(lsn) do
       {:ok, new_lsn, tx}
     else
-      {:ok, %Transaction{changes: []}, new_lsn} -> wait_for_next_cached_wal_tx(new_lsn, ts)
+      {:ok, %Transaction{changes: []}, new_lsn} -> wait_for_next_cached_wal_tx(new_lsn)
       :timeout -> :timeout
-    end
-  end
-
-  defp check_remaining_time(ts, timeout) do
-    elapsed_time = System.convert_time_unit(System.monotonic_time() - ts, :native, :millisecond)
-
-    if elapsed_time < timeout do
-      :ok
-    else
-      :timeout
     end
   end
 
@@ -110,6 +99,8 @@ defmodule Electric.Replication.ElectrificationTest do
     receive do
       {:cached_wal_notification, ^ref, :new_segments_available} ->
         :ok
+    after
+      @sleep_timeout -> :timeout
     end
   end
 end

--- a/components/electric/test/electric/replication/initial_sync_test.exs
+++ b/components/electric/test/electric/replication/initial_sync_test.exs
@@ -118,7 +118,7 @@ defmodule Electric.Replication.InitialSyncTest do
 
   defp fetch_current_lsn(conn) do
     {:ok, _, [{lsn_str}]} = :epgsql.squery(conn, "SELECT pg_current_wal_lsn()")
-    Lsn.from_string(lsn_str) |> Lsn.to_integer()
+    lsn_str |> Lsn.from_string() |> Lsn.to_integer()
   end
 
   defp electrify_table(conn, name, version) do

--- a/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
+++ b/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
@@ -110,9 +110,9 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
            ] = transaction.changes
   end
 
-  test "Producer schedules the magic write timer" do
-    %LogicalReplicationProducer.State{magic_write_timer: tref} = initialize_producer()
-    assert_receive {:timeout, ^tref, :magic_write}, 2_000
+  test "Producer schedules a timer for advancing the main slot" do
+    %LogicalReplicationProducer.State{advance_timer: tref} = initialize_producer()
+    assert_receive {:timeout, ^tref, :advance_main_slot}, 2_000
   end
 
   def initialize_producer(demand \\ 100) do

--- a/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
+++ b/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
@@ -18,9 +18,13 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
   setup_with_mocks([
     {Client, [:passthrough],
      [
+       with_conn: fn _, fun -> fun.(:conn) end,
        connect: fn _ -> {:ok, :conn} end,
-       start_replication: fn :conn, _, _, _ -> :ok end,
-       create_slot: fn :conn, name -> {:ok, name} end,
+       start_replication: fn :conn, _, _, _, _ -> :ok end,
+       create_main_slot: fn :conn, name -> {:ok, name} end,
+       create_temporary_slot: fn :conn, _main_name, tmp_name -> {:ok, tmp_name, %Lsn{}} end,
+       current_lsn: fn :conn -> {:ok, %Lsn{}} end,
+       advance_replication_slot: fn _, _, _ -> :ok end,
        set_display_settings_for_replication: fn _ -> :ok end,
        get_server_versions: fn :conn -> {:ok, {"", "", ""}} end
      ]},
@@ -112,7 +116,13 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
   end
 
   def initialize_producer(demand \\ 100) do
-    {:producer, state} = LogicalReplicationProducer.init(origin: "mock_postgres")
+    {:producer, state} =
+      LogicalReplicationProducer.init(
+        origin: "mock_postgres",
+        wal_window: [in_memory_size: 1, resumable_size: 1],
+        connection: %{}
+      )
+
     {_, _, state} = LogicalReplicationProducer.handle_demand(demand, state)
     state
   end

--- a/components/electric/test/electric/replication/satellite_collector_producer_test.exs
+++ b/components/electric/test/electric/replication/satellite_collector_producer_test.exs
@@ -86,7 +86,6 @@ defmodule Electric.Replication.SatelliteCollectorProducerTest do
 
   defp tx() do
     %Transaction{
-      ack_fn: fn -> nil end,
       changes: ["change 1"],
       origin: "client_id",
       lsn: <<0, 0, 0, 1>>

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -66,10 +66,7 @@ defmodule Electric.Satellite.WebsocketServerTest do
        start_link: fn %{name: name, producer: producer} ->
          Supervisor.start_link(
            [
-             {Electric.DummyConsumer,
-              subscribe_to: [{producer, []}],
-              run_on_each_event: & &1.ack_fn.(),
-              name: :dummy_consumer},
+             {Electric.DummyConsumer, subscribe_to: [{producer, []}], name: :dummy_consumer},
              {DownstreamProducerMock, Producer.name(name)}
            ],
            strategy: :one_for_one

--- a/components/electric/test/support/dummy_consumer.ex
+++ b/components/electric/test/support/dummy_consumer.ex
@@ -6,11 +6,7 @@ defmodule Electric.DummyConsumer do
   end
 
   def init(opts) do
-    {:consumer,
-     %{
-       notify: Keyword.get(opts, :notify),
-       run_on_each_event: Keyword.get(opts, :run_on_each_event, & &1)
-     }, Keyword.take(opts, [:subscribe_to])}
+    {:consumer, %{notify: Keyword.get(opts, :notify)}, Keyword.take(opts, [:subscribe_to])}
   end
 
   def notify(%{notify: nil}, _, _), do: :ok
@@ -21,8 +17,6 @@ defmodule Electric.DummyConsumer do
   def handle_events(events, {pid, _}, state) do
     # The __MODULE__ here is to allow mocking out the `notify` function at the place of call to "inject" test's pid
     __MODULE__.notify(state, pid, events)
-
-    Enum.each(events, state.run_on_each_event)
 
     {:noreply, [], state}
   end

--- a/components/electric/test/support/satellite_helpers.ex
+++ b/components/electric/test/support/satellite_helpers.ex
@@ -92,7 +92,7 @@ defmodule ElectricTest.SatelliteHelpers do
     assert_receive {^conn, %SatOpLog{} = oplog}, timeout
 
     assert {nil, [%Transaction{} = txn]} =
-             Serialization.deserialize_trans("postgres_1", oplog, nil, cached_relations, & &1)
+             Serialization.deserialize_trans("postgres_1", oplog, nil, cached_relations)
 
     %{txn | changes: Enum.sort_by(txn.changes, &{&1.__struct__, &1.relation})}
   end
@@ -104,7 +104,7 @@ defmodule ElectricTest.SatelliteHelpers do
     assert_receive {^conn, %SatOpLog{} = oplog}, timeout
 
     assert {nil, [{:additional_data, ref, changes}]} =
-             Serialization.deserialize_trans("postgres_1", oplog, nil, cached_relations, & &1)
+             Serialization.deserialize_trans("postgres_1", oplog, nil, cached_relations)
 
     assert is_integer(ref)
 


### PR DESCRIPTION
Continuing on from https://github.com/electric-sql/electric/pull/1099, this PR introduces the concept of a "persistent replication slot". Now, instead of having an auto-advancing replication slot, Electric can keep around WAL records that contain transactions it has already seen and acknowledged previously. As a result, when Electric restarts, it can repopulate its in-memory cache of transactions and be able to resume clients' replication streams.

New configuration options `ELECTRIC_TXN_CACHE_SIZE` and `ELECTRIC_RESUMABLE_WAL_WINDOW` have been added. The relevant docs are updated in https://github.com/electric-sql/electric/pull/1050.