### PR TITLE
chore(electric): Refactor CachedWal.EtsBacked to use the new WAL config

### DIFF
--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -1,8 +1,11 @@
 defmodule Electric.Postgres.CachedWal.Api do
   @moduledoc """
-  Behavior for accessing cached wal
+  Behavior for accessing cached WAL.
   """
+
+  alias Electric.Replication.Connectors
   alias Electric.Telemetry.Metrics
+
   @type lsn :: Electric.Postgres.Lsn.t()
 
   @typedoc "Position in the cached write-ahead log"
@@ -21,18 +24,19 @@ defmodule Electric.Postgres.CachedWal.Api do
           cache_memory_total: non_neg_integer()
         }
 
-  @callback lsn_in_cached_window?(wal_pos) :: boolean
-  @callback get_current_position() :: wal_pos | nil
-  @callback next_segment(wal_pos()) ::
+  @callback lsn_in_cached_window?(Connectors.origin(), wal_pos) :: boolean
+  @callback get_current_position(Connectors.origin()) :: wal_pos | nil
+  @callback next_segment(Connectors.origin(), wal_pos()) ::
               {:ok, segment(), new_position :: wal_pos()} | :latest | {:error, term()}
-  @callback request_notification(wal_pos()) :: {:ok, await_ref()} | {:error, term()}
-  @callback cancel_notification_request(await_ref()) :: :ok
+  @callback request_notification(Connectors.origin(), wal_pos()) ::
+              {:ok, await_ref()} | {:error, term()}
+  @callback cancel_notification_request(Connectors.origin(), await_ref()) :: :ok
 
   @callback serialize_wal_position(wal_pos()) :: binary()
   @callback parse_wal_position(binary()) :: {:ok, wal_pos()} | :error
   @callback compare_positions(wal_pos(), wal_pos()) :: :lt | :eq | :gt
 
-  @callback telemetry_stats() :: stats() | nil
+  @callback telemetry_stats(Connectors.origin()) :: stats() | nil
 
   def default_module,
     do: Application.fetch_env!(:electric, __MODULE__) |> Keyword.fetch!(:adapter)
@@ -43,9 +47,9 @@ defmodule Electric.Postgres.CachedWal.Api do
   This checks needs to be done for every client. If their LSN is outside of the caching window, we won't be able to
   guarantee data consistency via the replication stream alone.
   """
-  @spec lsn_in_cached_window?(module(), wal_pos) :: boolean
-  def lsn_in_cached_window?(module \\ default_module(), lsn) do
-    module.lsn_in_cached_window?(lsn)
+  @spec lsn_in_cached_window?(module(), Connectors.origin(), wal_pos) :: boolean
+  def lsn_in_cached_window?(module \\ default_module(), origin, lsn) do
+    module.lsn_in_cached_window?(origin, lsn)
   end
 
   @doc """
@@ -53,9 +57,9 @@ defmodule Electric.Postgres.CachedWal.Api do
 
   Returns nil if the cached WAL hasn't processed any non-empty transactions yet.
   """
-  @spec get_current_position(module()) :: wal_pos | nil
-  def get_current_position(module \\ default_module()) do
-    module.get_current_position()
+  @spec get_current_position(module(), Connectors.origin()) :: wal_pos | nil
+  def get_current_position(module \\ default_module(), origin) do
+    module.get_current_position(origin)
   end
 
   @doc """
@@ -66,10 +70,10 @@ defmodule Electric.Postgres.CachedWal.Api do
   (i.e. out of the cached window), in which case an error will be returned, and the client is expected
   to query source database directly to catch up.
   """
-  @spec next_segment(module(), wal_pos()) ::
+  @spec next_segment(module(), Connectors.origin(), wal_pos()) ::
           {:ok, segment(), new_position :: wal_pos()} | :latest | {:error, :lsn_too_old}
-  def next_segment(module \\ default_module(), wal_pos) do
-    module.next_segment(wal_pos)
+  def next_segment(module \\ default_module(), origin, wal_pos) do
+    module.next_segment(origin, wal_pos)
   end
 
   def compare_positions(module \\ default_module(), wal_pos_1, wal_pos_2),
@@ -106,17 +110,18 @@ defmodule Electric.Postgres.CachedWal.Api do
   `{:cached_wal_notification, ref(), :new_segments_available}`
   as soon as a new segment becomes available in the cache.
   """
-  @spec request_notification(module(), wal_pos()) :: {:ok, await_ref()} | {:error, term()}
-  def request_notification(module \\ default_module(), wal_pos) do
-    module.request_notification(wal_pos)
+  @spec request_notification(module(), Connectors.origin(), wal_pos()) ::
+          {:ok, await_ref()} | {:error, term()}
+  def request_notification(module \\ default_module(), origin, wal_pos) do
+    module.request_notification(origin, wal_pos)
   end
 
   @doc """
   Cancel a notification request issued previously by `request_notification/2`.
   """
-  @spec cancel_notification_request(module(), await_ref()) :: :ok
-  def cancel_notification_request(module \\ default_module(), await_ref) do
-    module.cancel_notification_request(await_ref)
+  @spec cancel_notification_request(module(), Connectors.origin(), await_ref()) :: :ok
+  def cancel_notification_request(module \\ default_module(), origin, await_ref) do
+    module.cancel_notification_request(origin, await_ref)
   end
 
   @spec parse_wal_position(module(), binary()) :: {:ok, wal_pos()} | :error
@@ -129,11 +134,15 @@ defmodule Electric.Postgres.CachedWal.Api do
     module.serialize_wal_position(wal_pos)
   end
 
-  @spec emit_telemetry_stats(module()) :: :ok
+  @spec emit_telemetry_stats(module(), Electric.Telemetry.Metrics.span_name()) :: :ok
   def emit_telemetry_stats(module \\ default_module(), event) do
-    case module.telemetry_stats() do
-      nil -> :ok
-      stats -> Metrics.non_span_event(event, stats)
-    end
+    module
+    |> Electric.reg_names()
+    |> Enum.each(fn origin ->
+      case module.telemetry_stats(origin) do
+        nil -> :ok
+        stats -> Metrics.non_span_event(event, stats)
+      end
+    end)
   end
 end

--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -79,11 +79,14 @@ defmodule Electric.Postgres.CachedWal.Api do
   def compare_positions(module \\ default_module(), wal_pos_1, wal_pos_2),
     do: module.compare_positions(wal_pos_1, wal_pos_2)
 
-  @spec stream_transactions([{:from, any()} | {:to, any()}, ...]) ::
+  @spec stream_transactions(module(), Connectors.origin(), [{:from, any()} | {:to, any()}, ...]) ::
           Enumerable.t({segment(), wal_pos()})
-  def stream_transactions(module \\ default_module(), from: from_pos, to: to_pos) do
+  def stream_transactions(module \\ default_module(), origin, opts) do
+    from_pos = Keyword.fetch!(opts, :from)
+    to_pos = Keyword.fetch!(opts, :to)
+
     Stream.unfold(from_pos, fn from_pos ->
-      case next_segment(module, from_pos) do
+      case next_segment(module, origin, from_pos) do
         {:ok, segment, new_pos} ->
           if module.compare_positions(new_pos, to_pos) != :gt, do: {segment, new_pos}, else: nil
 

--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -16,8 +16,8 @@ defmodule Electric.Postgres.CachedWal.Api do
 
   @type stats :: %{
           transaction_count: non_neg_integer(),
-          max_transaction_count: pos_integer(),
           oldest_transaction_timestamp: DateTime.t() | nil,
+          max_cache_size: pos_integer(),
           cache_memory_total: non_neg_integer()
         }
 

--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -71,23 +71,13 @@ defmodule Electric.Postgres.CachedWal.Api do
   to query source database directly to catch up.
   """
   @spec next_segment(module(), Connectors.origin(), wal_pos()) ::
-          {:ok, segment(), new_position :: wal_pos()} | :latest | {:error, :lsn_too_old}
+          {:ok, segment(), new_position :: wal_pos()} | :latest
   def next_segment(module \\ default_module(), origin, wal_pos) do
     module.next_segment(origin, wal_pos)
   end
 
   def compare_positions(module \\ default_module(), wal_pos_1, wal_pos_2),
     do: module.compare_positions(wal_pos_1, wal_pos_2)
-
-  @spec get_transactions(module(), from: wal_pos(), to: wal_pos()) ::
-          {:ok, [{segment(), wal_pos()}]} | {:error, :lsn_too_old}
-  def get_transactions(module \\ default_module(), from: from_pos, to: to_pos) do
-    if lsn_in_cached_window?(module, from_pos) do
-      {:ok, Enum.to_list(stream_transactions(module, from: from_pos, to: to_pos))}
-    else
-      {:error, :lsn_too_old}
-    end
-  end
 
   @spec stream_transactions([{:from, any()} | {:to, any()}, ...]) ::
           Enumerable.t({segment(), wal_pos()})

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -24,6 +24,7 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   @behaviour Electric.Postgres.CachedWal.Api
 
   @typep state :: %{
+           origin: Connectors.origin(),
            notification_requests: %{optional(reference()) => {Api.wal_pos(), pid()}},
            table: :ets.table(),
            last_seen_wal_pos: Api.wal_pos(),
@@ -124,9 +125,10 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     origin = Keyword.fetch!(opts, :origin)
 
     table = :ets.new(ets_table_name(origin), [:named_table, :ordered_set])
-    Logger.metadata(component: "CachedWal.EtsBacked")
+    Logger.metadata(origin: origin, component: "CachedWal.EtsBacked")
 
     state = %{
+      origin: origin,
       notification_requests: %{},
       table: table,
       last_seen_wal_pos: 0,

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -12,12 +12,14 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     removing oldest entries (FIFO)
   """
 
-  require Logger
+  use GenStage
+
   alias Electric.Replication.Changes.Transaction
   alias Electric.Postgres.Lsn
   alias Electric.Postgres.CachedWal.Api
 
-  use GenStage
+  require Logger
+
   @behaviour Electric.Postgres.CachedWal.Api
 
   @ets_table_name :ets_backed_cached_wal
@@ -26,8 +28,8 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
            notification_requests: %{optional(reference()) => {Api.wal_pos(), pid()}},
            table: ETS.Set.t(),
            last_seen_wal_pos: Api.wal_pos(),
-           current_cache_count: non_neg_integer(),
-           max_cache_count: non_neg_integer()
+           current_tx_count: non_neg_integer(),
+           wal_window_size: non_neg_integer()
          }
 
   # Public API
@@ -120,8 +122,8 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
       notification_requests: %{},
       table: set,
       last_seen_wal_pos: 0,
-      current_cache_count: 0,
-      max_cache_count: Keyword.get(opts, :max_cache_count, 10000)
+      current_tx_count: 0,
+      wal_window_size: Keyword.fetch!(opts, :wal_window_size)
     }
 
     case Keyword.get(opts, :subscribe_to) do
@@ -142,14 +144,12 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     {:reply, {:ok, ref}, [], state}
   end
 
-  @impl GenStage
   def handle_call({:cancel_notification, ref}, _, state) do
     state = Map.update!(state, :notification_requests, &Map.delete(&1, ref))
 
     {:reply, :ok, [], state}
   end
 
-  @impl GenStage
   def handle_call(:telemetry_stats, _from, state) do
     oldest_timestamp =
       with {:ok, key} <- ETS.Set.first(state.table),
@@ -160,9 +160,9 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
       end
 
     stats = %{
-      transaction_count: state.current_cache_count,
-      max_transaction_count: state.max_cache_count,
+      transaction_count: state.current_tx_count,
       oldest_transaction_timestamp: oldest_timestamp,
+      max_cache_size: state.wal_window_size,
       cache_memory_total:
         ETS.Set.info!(state.table, true)[:memory] * :erlang.system_info(:wordsize)
     }
@@ -175,12 +175,14 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     ETS.Set.delete_all!(state.table)
 
     # This doesn't do anything with notification requests, but this function is not meant to be used in production
-    {:noreply, [], %{state | current_cache_count: 0, last_seen_wal_pos: 0}}
+    {:noreply, [], %{state | current_tx_count: 0, last_seen_wal_pos: 0}}
   end
 
   @impl GenStage
   @spec handle_events([Transaction.t()], term(), state()) :: {:noreply, [], any}
   def handle_events(events, _, state) do
+    # TODO: Make sure that when this process crashes, LogicalReplicationProducer is restarted as well
+    # in order to fill up the in-memory cache.
     events
     # TODO: We're currently storing & streaming empty transactions to Satellite, which is not ideal, but we need
     #       to be aware of all transaction IDs and LSNs that happen, otherwise flakiness begins. I don't like that,
@@ -208,18 +210,17 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     |> Stream.map(fn %Transaction{} = tx -> {lsn_to_position(tx.lsn), tx} end)
     |> Enum.to_list()
     |> tap(&ETS.Set.put(state.table, &1))
-    |> Electric.Utils.list_last_and_length()
+    |> List.last()
     |> case do
-      {_, 0} ->
+      nil ->
         # All transactions were empty
         {:noreply, [], state}
 
-      {{position, _}, total} ->
+      {position, _} ->
         state =
           state
           |> Map.put(:last_seen_wal_pos, position)
           |> fulfill_notification_requests()
-          |> Map.update!(:current_cache_count, &(&1 + total))
           |> trim_cache()
 
         {:noreply, [], state}
@@ -246,19 +247,21 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
 
   def lsn_to_position(lsn), do: Lsn.to_integer(lsn)
 
+  # Drop all transactions from the cache whose position is less than the last transaction's
+  # position minus in-memory WAL window size.
+  #
+  # TODO: make sure we're not removing transactions that are about to be requested by a newly
+  # connected client.
+  #
+  # NOTE(optimization): clean the cache up after every N new transactions.
   @spec trim_cache(state()) :: state()
-  defp trim_cache(%{current_cache_count: current, max_cache_count: max} = state)
-       when current <= max,
-       do: state
-
   defp trim_cache(state) do
-    to_trim = state.current_cache_count - state.max_cache_count
+    first_in_window_pos = state.last_seen_wal_pos - state.wal_window_size
 
-    state.table
-    # `match/3` works here because it's an ordered set, which guarantees traversal from the beginning
-    |> ETS.Set.match({:"$1", :_}, to_trim)
-    |> Enum.each(fn [key] -> ETS.Set.delete!(state.table, key) end)
+    ETS.Set.select_delete!(state.table, [
+      {{:"$1", :_}, [{:<, :"$1", first_in_window_pos}], [true]}
+    ])
 
-    Map.update!(state, :current_cache_count, &(&1 - to_trim))
+    %{state | current_tx_count: ETS.Set.info!(state.table, :size)}
   end
 end

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -56,8 +56,8 @@ defmodule Electric.Replication.PostgresConnectorSup do
       else
         {Postgres.Writer, writer_config}
       end,
-      # Uses a globally registered name
       {CachedWal.EtsBacked,
+       origin: origin,
        subscribe_to: [{postgres_producer_consumer, []}],
        wal_window_size: Connectors.get_wal_window_opts(connector_config).in_memory_size},
       {Proxy, connector_config: connector_config}

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -57,7 +57,9 @@ defmodule Electric.Replication.PostgresConnectorSup do
         {Postgres.Writer, writer_config}
       end,
       # Uses a globally registered name
-      {CachedWal.EtsBacked, subscribe_to: [{postgres_producer_consumer, []}]},
+      {CachedWal.EtsBacked,
+       subscribe_to: [{postgres_producer_consumer, []}],
+       wal_window_size: Connectors.get_wal_window_opts(connector_config).in_memory_size},
       {Proxy, connector_config: connector_config}
     ]
 

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -265,6 +265,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
         txn_id_list = Keyword.fetch!(opts, :including_data)
         subscription_id_list = Keyword.fetch!(opts, :including_subscriptions)
         cached_wal_impl = Keyword.get(opts, :cached_wal_impl, CachedWal.EtsBacked)
+        origin = Keyword.fetch!(opts, :origin)
         advance_graph_fn = Keyword.fetch!(opts, :advance_graph_using)
 
         if CachedWal.Api.compare_positions(cached_wal_impl, acked_lsn, new_lsn) != :gt do
@@ -277,6 +278,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
             |> advance_up_to_new_lsn(
               client_id,
               cached_wal_impl,
+              origin,
               advance_graph_fn,
               acked_lsn,
               new_lsn
@@ -340,6 +342,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
          graph,
          client_id,
          cached_wal_impl,
+         origin,
          advance_graph_fn,
          full_acked_lsn,
          new_lsn
@@ -350,7 +353,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
 
     {graph, pending_actions, count} =
       cached_wal_impl
-      |> CachedWal.Api.stream_transactions(from: full_acked_lsn, to: new_lsn)
+      |> CachedWal.Api.stream_transactions(origin, from: full_acked_lsn, to: new_lsn)
       |> Enum.reduce(state, fn %Transaction{} = txn, {graph, pending_actions, count} ->
         {graph, pending_actions} =
           client_id

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -53,9 +53,11 @@ defmodule Electric.Satellite.Protocol do
     # succeed as well
     reg_name = Electric.Satellite.WebsocketServer.reg_name(client_id)
 
+    origin = Connectors.origin(state.connector_config)
+
     with {:ok, auth} <- Electric.Satellite.Auth.validate_token(token, state.auth_provider),
          true <- Electric.safe_reg(reg_name, 1000),
-         :ok <- ClientManager.register_client(client_id, reg_name) do
+         :ok <- ClientManager.register_client(client_id, reg_name, origin) do
       Logger.metadata(user_id: auth.user_id)
       Logger.info("Successfully authenticated the client")
       Metrics.satellite_connection_event(%{authorized_connection: 1})
@@ -525,7 +527,9 @@ defmodule Electric.Satellite.Protocol do
   end
 
   defp handle_start_replication_request(msg, lsn, state) do
-    if CachedWal.Api.lsn_in_cached_window?(lsn) do
+    origin = Connectors.origin(state.connector_config)
+
+    if CachedWal.Api.lsn_in_cached_window?(origin, lsn) do
       case restore_client_state(msg.subscription_ids, msg.observed_transaction_data, lsn, state) do
         {:ok, state} ->
           state =

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -458,6 +458,7 @@ defmodule Electric.Satellite.Protocol do
             including_data: msg.additional_data_source_ids,
             including_subscriptions: msg.subscription_ids,
             cached_wal_impl: CachedWal.EtsBacked,
+            origin: Connectors.origin(state.connector_config),
             advance_graph_using: {&advance_graph_by_tx/4, [state.auth.user_id]}
           )
 
@@ -1146,6 +1147,7 @@ defmodule Electric.Satellite.Protocol do
       including_data: observed_txn_data,
       including_subscriptions: Map.keys(state.subscriptions),
       cached_wal_impl: CachedWal.EtsBacked,
+      origin: Connectors.origin(state.connector_config),
       advance_graph_using: {&advance_graph_by_tx/4, [state.auth.user_id]}
     )
     |> case do

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -200,18 +200,19 @@ defmodule Electric.Satellite.WebsocketServer do
   # client has connected which needs to perform the initial sync of migrations and the current database state before
   # subscribing to the replication stream.
   def handle_info({:perform_initial_sync_and_subscribe, msg}, %State{} = state) do
+    origin = Electric.Replication.Connectors.origin(state.connector_config)
+
     # Fetch the latest observed LSN from the cached WAL. We have to do it before fetching migrations.
     #
     # If we were to do it the other way around, we could miss a migration that is committed right after the call to
     # migrations_since() but before the client subscribes to the replication stream. If the migration was immediately
     # followed by another write in PG, we could have fetched the LSN of this last write with get_current_position() and
     # thus miss the migration committed just before it.
-    lsn = CachedWal.Api.get_current_position()
+    lsn = CachedWal.Api.get_current_position(origin)
 
-    _ = maybe_pause(lsn)
+    _ = maybe_pause(origin, lsn)
 
     %SatInStartReplicationReq{schema_version: schema_version} = msg
-    origin = Electric.Replication.Connectors.origin(state.connector_config)
     migrations = InitialSync.migrations_since(schema_version, origin, lsn)
 
     # We're ignoring actions here since we've "manufactured" migration events
@@ -421,12 +422,12 @@ defmodule Electric.Satellite.WebsocketServer do
   end
 
   if Mix.env() == :test do
-    defp maybe_pause(lsn) do
+    defp maybe_pause(origin, lsn) do
       with {client_ref, client_pid} <- Process.get(:pause_during_initial_sync) do
         Logger.debug("WebsocketServer pausing")
         send(client_pid, {client_ref, :server_paused})
 
-        {:ok, request_ref} = CachedWal.Api.request_notification(lsn)
+        {:ok, request_ref} = CachedWal.Api.request_notification(origin, lsn)
 
         receive do
           {:cached_wal_notification, ^request_ref, :new_segments_available} ->
@@ -441,7 +442,7 @@ defmodule Electric.Satellite.WebsocketServer do
 
     defp fetch_last_acked_client_lsn(_state), do: {:ok, nil}
   else
-    defp maybe_pause(_), do: :ok
+    defp maybe_pause(_, _), do: :ok
 
     def fetch_last_acked_client_lsn(state) do
       state.connector_config

--- a/components/electric/test/electric/satellite/subscriptions_test.exs
+++ b/components/electric/test/electric/satellite/subscriptions_test.exs
@@ -63,12 +63,12 @@ defmodule Electric.Satellite.SubscriptionsTest do
          INSERT INTO public.users (id, name) VALUES ('#{uuid4()}', 'Garry');
          """
     test "The client can connect and immediately gets migrations but gets neither already inserted data, nor new inserts",
-         %{conn: pg_conn} = ctx do
+         %{conn: pg_conn, origin: origin} = ctx do
       MockClient.with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
         start_replication_and_assert_response(conn, ctx.electrified_count)
 
-        position = CachedWal.Api.get_current_position()
-        {:ok, ref} = CachedWal.Api.request_notification(position)
+        position = CachedWal.Api.get_current_position(origin)
+        {:ok, ref} = CachedWal.Api.request_notification(origin, position)
 
         {:ok, 1} =
           :epgsql.equery(pg_conn, "INSERT INTO public.users (id, name) VALUES ($1, $2)", [

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -76,8 +76,10 @@ defmodule Electric.Satellite.WebsocketServerTest do
     {
       Electric.Postgres.CachedWal.Api,
       [:passthrough],
-      get_current_position: fn -> @current_wal_pos end,
-      lsn_in_cached_window?: fn num when is_integer(num) -> num > @current_wal_pos end,
+      get_current_position: fn _ -> @current_wal_pos end,
+      lsn_in_cached_window?: fn _origin, pos when is_integer(pos) ->
+        pos > @current_wal_pos
+      end,
       stream_transactions: fn _, _ -> [] end
     }
   ]) do

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -80,7 +80,7 @@ defmodule Electric.Satellite.WebsocketServerTest do
       lsn_in_cached_window?: fn _origin, pos when is_integer(pos) ->
         pos > @current_wal_pos
       end,
-      stream_transactions: fn _, _ -> [] end
+      stream_transactions: fn _, _, _ -> [] end
     }
   ]) do
     {:ok, %{}}

--- a/components/electric/test/support/postgres_test_connection.ex
+++ b/components/electric/test/support/postgres_test_connection.ex
@@ -136,7 +136,7 @@ defmodule Electric.Postgres.TestConnection do
     |> Electric.Replication.Connectors.get_connection_opts()
   end
 
-  def setup_electrified_tables(%{conn: conn}) do
+  def setup_electrified_tables(%{conn: conn, origin: origin}) do
     {:ok, [], []} =
       :epgsql.squery(conn, """
       CREATE TABLE public.users (
@@ -201,7 +201,7 @@ defmodule Electric.Postgres.TestConnection do
     Stream.resource(
       fn -> 0 end,
       fn pos ->
-        case Electric.Postgres.CachedWal.EtsBacked.next_segment(pos) do
+        case Electric.Postgres.CachedWal.EtsBacked.next_segment(origin, pos) do
           :latest ->
             Process.sleep(100)
             {[], pos}

--- a/e2e/tests/01.03_postgres_writes_propagate_to_electric.lux
+++ b/e2e/tests/01.03_postgres_writes_propagate_to_electric.lux
@@ -15,7 +15,7 @@
     # We shouldn't see a value from an un-electrified table
     -bad sentinel value
     # But we should see a transaction with one change
-    ?component=CachedWal.EtsBacked \[debug\] Saving transaction \d+ at \d+/[0-9A-F]+ with changes \[%Electric.Replication.Changes.NewRecord\{
+    ?component=CachedWal.EtsBacked origin=postgres_1 \[debug\] Saving transaction \d+ at \d+/[0-9A-F]+ with changes \[%Electric.Replication.Changes.NewRecord\{
     ?+relation: \{"public", "entries"\}
     # We also see that the `tags` field has been correctly-ish filled (i.e. not empty and has correct origin)
     ?+tags: \["postgres_1@\d+"\]\}\]

--- a/e2e/tests/01.05_electric_can_recreate_publication.lux
+++ b/e2e/tests/01.05_electric_can_recreate_publication.lux
@@ -37,7 +37,7 @@
 
 # Make sure Electric consumes all migrations from the replication stream before stopping it.
 [shell electric]
-    ?component=CachedWal.EtsBacked \[debug\] Saving transaction\
+    ?component=CachedWal.EtsBacked origin=postgres_1 \[debug\] Saving transaction\
        .+ with changes \[%Electric.Replication.Changes.NewRecord\{\
        relation: \{"electric", "ddl_commands"\}, \
        record: %\{.*"query" => "CREATE TABLE baz

--- a/e2e/tests/02.04_satellite_write_gets_propagated_to_postgres.lux
+++ b/e2e/tests/02.04_satellite_write_gets_propagated_to_postgres.lux
@@ -32,7 +32,7 @@
     ??=postgres_1 [debug] Processed tx changes (# pre:
     ??"content" => "sentinel value"
     # Wait for the roundtrip of the insert back to Electric
-    ?component=CachedWal.EtsBacked \[debug\] Saving transaction \d+ at \d+/[\dA-F]+ with changes \
+    ?component=CachedWal.EtsBacked origin=postgres_1 \[debug\] Saving transaction \d+ at \d+/[\dA-F]+ with changes \
       \[%Electric.Replication.Changes.NewRecord\{\
           relation: \{"public", "entries"\}, \
           record: %\{"content" => "sentinel value", "content_b" => nil, "id" => "00000000-0000-0000-0000-000000000000"\}

--- a/e2e/tests/05.03_postgres_wins_against_concurrent_transactions.lux
+++ b/e2e/tests/05.03_postgres_wins_against_concurrent_transactions.lux
@@ -45,7 +45,7 @@
     ??"content" => "updated on client 1"
 
     # Wait for the roundtrip of the insert back to Electric
-    ?component=CachedWal.EtsBacked \[debug\] Saving transaction \d+ at \d+/[\dA-F]+ with changes \
+    ?component=CachedWal.EtsBacked origin=postgres_1 \[debug\] Saving transaction \d+ at \d+/[\dA-F]+ with changes \
       \[%Electric.Replication.Changes.UpdatedRecord\{\
           relation: \{"public", "entries"\}, \
           old_record: %\{"content" => "original value", "content_b" => nil, "id" => "00000000-0000-0000-0000-000000000000"\}, \

--- a/e2e/tests/05.04_update_that_didnt_see_delete_resurrects.lux
+++ b/e2e/tests/05.04_update_that_didnt_see_delete_resurrects.lux
@@ -48,7 +48,7 @@
     ??"content_b" => "new value"
 
     # Wait for the roundtrip of the insert back to Electric
-    ?component=CachedWal.EtsBacked \[debug\] Saving transaction \d+ at \d+/[\dA-F]+ with changes \
+    ?component=CachedWal.EtsBacked origin=postgres_1 \[debug\] Saving transaction \d+ at \d+/[\dA-F]+ with changes \
       \[%Electric.Replication.Changes.NewRecord\{\
           relation: \{"public", "entries"\}, \
           record: %\{"content" => "updated value", "content_b" => "new value", "id" => "00000000-0000-0000-0000-000000000000"\}

--- a/e2e/tests/05.05_compensations_within_same_tx_are_fine.lux
+++ b/e2e/tests/05.05_compensations_within_same_tx_are_fine.lux
@@ -71,7 +71,7 @@
     ??record: %{"content" => nil, "id" => "00000000-0000-0000-0000-000000000000"}
 
     # Wait for the roundtrip of the insert back to Electric
-    ?component=CachedWal.EtsBacked \[debug\] Saving transaction \d+ at \d+/[\dA-F]+ with changes \
+    ?component=CachedWal.EtsBacked origin=postgres_1 \[debug\] Saving transaction \d+ at \d+/[\dA-F]+ with changes \
       \[%Electric.Replication.Changes.NewRecord\{\
           relation: \{"public", "items"\}, \
           record: %\{"content" => "test_content", "id" => "00000000-0000-0000-0000-000000000000"\}


### PR DESCRIPTION
Follow-up to https://github.com/electric-sql/electric/pull/1043.

This PR makes the Elixir process run by `EtsBacked` scoped under the connector origin, similar to how other Postgres connector processes behave. It also updates telemetry metrics to use more precise names for what the `EtsBacked` cache actually stores: instead of "cache count" it's "transaction count".