### PR TITLE
fix(client): Provide crypto API implementation for op-sqlite driver

### DIFF
--- a/clients/typescript/src/drivers/op-sqlite/index.ts
+++ b/clients/typescript/src/drivers/op-sqlite/index.ts
@@ -1,5 +1,8 @@
 import { DbName } from '../../util/types'
 
+// Provide implementation for crypto.getRandomValues
+import 'react-native-get-random-values'
+
 import {
   ElectrifyOptions,
   electrify as baseElectrify,


### PR DESCRIPTION
Self explanatory - op-sqlite needs to provide a `getRandomValues` impl like the other react-native drivers.