### PR TITLE
Add polyfills section to expo documentation

### DIFF
--- a/docs/integrations/drivers/mobile/expo.md
+++ b/docs/integrations/drivers/mobile/expo.md
@@ -18,6 +18,79 @@ npx expo install expo-sqlite
 
 This package includes both the regular and `next` drivers. See the [expo-sqlite docs](https://docs.expo.dev/versions/latest/sdk/sqlite/) or [expo-sqlite/next docs](https://docs.expo.dev/versions/latest/sdk/sqlite-next/) for more information.
 
+## Polyfills
+
+ElectricSQL uses the [Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Crypto), base64 and text encoding / decoding, all of which are not available in React Native. To make ElectricSQL work, you need to polyfill these missing functions. 
+
+```shell
+npx expo install expo-crypto fastestsmallesttextencoderdecoder base-64
+```
+
+Create file for initializing the polyfills:
+
+```typescript
+// polyfills.ts
+import "fastestsmallesttextencoderdecoder";
+import * as Crypto from "expo-crypto";
+import { decode, encode } from "base-64";
+
+declare const global: {
+  crypto: {
+    getRandomValues(array: Uint8Array): Uint8Array;
+    randomUUID(): string;
+  };
+  btoa: (input: string) => string;
+  atob: (input: string) => string;
+};
+
+if (!global.btoa) {
+  global.btoa = encode;
+}
+
+if (!global.atob) {
+  global.atob = decode;
+}
+
+if (!global.crypto) {
+  global.crypto = {
+    getRandomValues(array: Uint8Array) {
+      return Crypto.getRandomValues(array);
+    },
+    randomUUID() {
+      return Crypto.randomUUID();
+    },
+  };
+}
+
+// @ts-expect-error
+if (!global.window) {
+  // @ts-expect-error
+  global.window = {
+    addEventListener: () => {},
+  };
+}
+```
+
+And load it before all other imports, either in your root `App.(js/ts)` or in your `_layout.(ts/js)`, if you are using expo-router.
+
+```typescript
+// _layout.ts
+// !THIS NEEDS TO BE THE FIRST IMPORT!
+import "./polyfills";
+
+// all other imports, e.g. import * from ...
+import { Stack } from "expo-router";
+
+export default function AppLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen />
+    </Stack>
+  )
+}
+
+```
+
 ## Usage
 
 <Tabs groupId="usage" queryString>


### PR DESCRIPTION
When using ElectricSQL with react native, the build fails because electric is using some browser APIs that are not available in  react native / expo. To get it to compile, you need to polyfill the missing function calls. This is definitely not the only way to do this, but the only one I got working. This should also work for react native without expo, but I don't have this set up to test it properly right now.