### PR TITLE
chore(electric): Create publication on startup

### DIFF
--- a/.changeset/thick-bottles-raise.md
+++ b/.changeset/thick-bottles-raise.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Create a publication in Postgres on startup. This would restore the replication stream from Postgres to Electric if the publication got deleted by accident.

--- a/components/electric/lib/electric/postgres/dialect/postgresql.ex
+++ b/components/electric/lib/electric/postgres/dialect/postgresql.ex
@@ -148,4 +148,18 @@ defmodule Electric.Postgres.Dialect.Postgresql do
       unquoted_name(name)
     end
   end
+
+  def quote_ident({schema, name}), do: quote_ident(schema, name)
+
+  def quote_ident(name) do
+    ~s|"#{escape_quotes(name, ?")}"|
+  end
+
+  def quote_ident(schema, name) do
+    ~s|"#{escape_quotes(schema, ?")}"."#{escape_quotes(name, ?")}"|
+  end
+
+  def escape_quotes(str, q) do
+    :binary.replace(str, <<q>>, <<q, q>>, [:global])
+  end
 end

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -262,6 +262,15 @@ defmodule Electric.Postgres.Extension do
     end
   end
 
+  @electrified_tables_query "SELECT schema_name, table_name FROM #{@electrified_tracking_table}"
+
+  @spec electrified_tables(conn()) :: {:ok, [{String.t(), String.t()}]} | {:error, term}
+  def electrified_tables(conn) do
+    with {:ok, _, tables} <- :epgsql.squery(conn, @electrified_tables_query) do
+      {:ok, tables}
+    end
+  end
+
   def create_table_ddl(conn, %Proto.RangeVar{} = table_name) do
     name = to_string(table_name)
 

--- a/components/electric/lib/electric/replication/postgres_manager.ex
+++ b/components/electric/lib/electric/replication/postgres_manager.ex
@@ -240,6 +240,9 @@ defmodule Electric.Replication.PostgresConnectorMng do
 
     Client.with_conn(conn_opts, fn conn ->
       with {:ok, versions} <- Extension.migrate(conn),
+           {:ok, electrified_tables} <- Extension.electrified_tables(conn),
+           {:ok, _name} <-
+             Client.create_publication(conn, Extension.publication_name(), electrified_tables),
            :ok <- maybe_create_subscription(conn, state.write_to_pg_mode, state.repl_opts),
            :ok <- OidDatabase.update_oids(conn) do
         Logger.info(


### PR DESCRIPTION
This helps fix the replication stream from Postgres to Electric if the publication got deleted by accident.