### PR TITLE
fix(client): Use `execute` Capacitor driver API to fix parsing issue

### DIFF
--- a/.changeset/early-schools-taste.md
+++ b/.changeset/early-schools-taste.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix Capacitor driver issue where `BEGIN` statements failed to run on Android by using driver's `execute` API.

--- a/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/adapter.ts
@@ -26,11 +26,12 @@ export class DatabaseAdapter extends GenericDatabaseAdapter {
 
   async _run(statement: Statement): Promise<RunResult> {
     const wrapInTransaction = false
-    const result = await this.db.run(
-      statement.sql,
-      statement.args,
-      wrapInTransaction
-    )
+
+    // if no bind values are provided, use `execute` API which
+    // has less overhead and native side pre-processing
+    const result = await (statement.args && statement.args.length > 0
+      ? this.db.run(statement.sql, statement.args, wrapInTransaction)
+      : this.db.execute(statement.sql, wrapInTransaction))
 
     const rowsAffected = result.changes?.changes ?? 0
     return { rowsAffected: rowsAffected }

--- a/clients/typescript/src/drivers/capacitor-sqlite/database.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/database.ts
@@ -7,6 +7,6 @@ type OriginalDatabase = SQLiteDBConnection
 // The relevant subset of the SQLitePlugin database client API
 // that we need to ensure the client we're electrifying provides.
 export interface Database
-  extends Pick<OriginalDatabase, 'executeSet' | 'run' | 'query'> {
+  extends Pick<OriginalDatabase, 'executeSet' | 'execute' | 'run' | 'query'> {
   dbname?: DbName
 }

--- a/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
+++ b/clients/typescript/src/drivers/capacitor-sqlite/mock.ts
@@ -17,6 +17,10 @@ export class MockDatabase implements Database {
     })
   }
 
+  execute(): Promise<capSQLiteChanges> {
+    return this.run()
+  }
+
   query(): Promise<DBSQLiteValues> {
     return this.resolveIfNotFail({
       values: [


### PR DESCRIPTION
Using the `execute` API rather than the `run` one for when no bind values are provided as it has less pre-processing and solves a parsing issue that `run` has for statements like `BEGIN` and `ROLLBACK`.

Not strictly necessary but provides an immediate solution to a bug that is blocking the use of this driver on Android without requiring changes from the driver side.

See this issue: https://github.com/capacitor-community/sqlite/issues/526
