### PR TITLE
fix(client): Remove `react-native-get-random` values dependency

### DIFF
--- a/.changeset/green-lemons-rescue.md
+++ b/.changeset/green-lemons-rescue.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Remove `react-native-get-random-values` as included dependency - waring fired instead and polyfill left to library user

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -189,7 +189,6 @@
     "prisma": "4.8.1",
     "prompts": "^2.4.2",
     "protobufjs": "^7.1.1",
-    "react-native-get-random-values": "^1.0.0",
     "squel": "^5.13.0",
     "tcp-port-used": "^1.0.2",
     "text-encoder-lite": "^2.0.0",

--- a/clients/typescript/src/drivers/expo-sqlite-next/index.ts
+++ b/clients/typescript/src/drivers/expo-sqlite-next/index.ts
@@ -3,9 +3,6 @@
 // alternative entrypoint in `./test` to avoid importing this.
 import { DbName } from '../../util/types'
 
-// Provide implementation for crypto.getRandomValues
-import 'react-native-get-random-values'
-
 import {
   ElectrifyOptions,
   electrify as baseElectrify,

--- a/clients/typescript/src/drivers/expo-sqlite/index.ts
+++ b/clients/typescript/src/drivers/expo-sqlite/index.ts
@@ -3,9 +3,6 @@
 // alternative entrypoint in `./test` to avoid importing this.
 import { DbName } from '../../util/types'
 
-// Provide implementation for crypto.getRandomValues
-import 'react-native-get-random-values'
-
 import {
   ElectrifyOptions,
   electrify as baseElectrify,

--- a/clients/typescript/src/drivers/op-sqlite/index.ts
+++ b/clients/typescript/src/drivers/op-sqlite/index.ts
@@ -1,8 +1,5 @@
 import { DbName } from '../../util/types'
 
-// Provide implementation for crypto.getRandomValues
-import 'react-native-get-random-values'
-
 import {
   ElectrifyOptions,
   electrify as baseElectrify,

--- a/clients/typescript/src/util/random.ts
+++ b/clients/typescript/src/util/random.ts
@@ -1,4 +1,5 @@
 import { Uuid } from './types'
+import Log from 'loglevel'
 
 export const randomValue = (): string => {
   return Math.random().toString(16).substring(2)
@@ -21,7 +22,7 @@ export const genUUID = (): Uuid => {
   } else {
     // fallback to Math.random, if the Crypto API is completely missing
     if (!unsafeRandomWarned) {
-      console.warn(
+      Log.debug(
         'Crypto API is not available. ' +
           'Falling back to Math.random for UUID generation ' +
           'with weak uniqueness guarantees. ' +

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,9 +107,6 @@ importers:
       react-native:
         specifier: '>= 0.68.0'
         version: 0.68.0(@babel/core@7.23.9)(@babel/preset-env@7.22.4)(react@18.2.0)
-      react-native-get-random-values:
-        specifier: ^1.0.0
-        version: 1.10.0(react-native@0.68.0)
       squel:
         specifier: ^5.13.0
         version: 5.13.0
@@ -8929,10 +8926,6 @@ packages:
     engines: {node: '> 0.1.90'}
     dev: false
 
-  /fast-base64-decode@1.0.0:
-    resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
-    dev: false
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -13318,15 +13311,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
-
-  /react-native-get-random-values@1.10.0(react-native@0.68.0):
-    resolution: {integrity: sha512-gZ1zbXhbb8+Jy9qYTV8c4Nf45/VB4g1jmXuavY5rPfUn7x3ok9Vl3FTl0dnE92Z4FFtfbUNNwtSfcmomdtWg+A==}
-    peerDependencies:
-      react-native: '>=0.56'
-    dependencies:
-      fast-base64-decode: 1.0.0
-      react-native: 0.68.0(@babel/core@7.23.9)(@babel/preset-env@7.22.4)(react@18.2.0)
-    dev: false
 
   /react-native-gradle-plugin@0.0.5(@babel/preset-env@7.22.4):
     resolution: {integrity: sha512-kGupXo+pD2mB6Z+Oyowor3qlCroiS32FNGoiGQdwU19u8o+NNhEZKwoKfC5Qt03bMZSmFlcAlTyf79vrS2BZKQ==}


### PR DESCRIPTION
Transitive depedencies don't install the corresponding pods in projects and thus the polyfill fails unless its included in the root project.

We will fire a warning and add docs explaining that this polyfill ensures better uniquness guarantees for UUID generation.