### PR TITLE
fix(recipes): Disable simulating high cpu load by default

### DIFF
--- a/examples/recipes/backend/demo-server/src/app.ts
+++ b/examples/recipes/backend/demo-server/src/app.ts
@@ -24,7 +24,7 @@ async function main(): Promise<void> {
   await waitForPostgresConnection(pgPool)
   void startListeningToPgRequests(pgPool, API_PORT)
   void startGeneratingWebServerLogs(pgPool)
-  void startGeneratingMonitoringMetrics(pgPool)
+  void startGeneratingMonitoringMetrics(pgPool, false)
   void startProcessingBackgroundJobs(pgPool)
   void startGeneratingChatLogBotMessages(pgPool)
   void startGeneratingActivityEvents(pgPool)

--- a/examples/recipes/backend/demo-server/src/monitoring-metrics.ts
+++ b/examples/recipes/backend/demo-server/src/monitoring-metrics.ts
@@ -43,7 +43,10 @@ function simulateHighCpuLoadOverTime({
   simulate()
 }
 
-export async function startGeneratingMonitoringMetrics(pgPool: Pool): Promise<void> {
+export async function startGeneratingMonitoringMetrics(
+  pgPool: Pool,
+  simulateHighCpuLoad: boolean = false,
+): Promise<void> {
   await startGeneratingData({
     pgPool: pgPool,
     tableName: 'monitoring',
@@ -53,6 +56,5 @@ export async function startGeneratingMonitoringMetrics(pgPool: Pool): Promise<vo
       return [uuidv4(), new Date(), 'CPU', cpuUsage]
     },
   })
-
-  simulateHighCpuLoadOverTime({})
+  if (simulateHighCpuLoad) simulateHighCpuLoadOverTime({})
 }


### PR DESCRIPTION
For the sake of deploying the backend to a VM, I'd rather not have artificial CPU loads inserted, natural fluctuations are enough to highlight the pattern.