### PR TITLE
fix(docs): Fix small typo in ELECTRIC_IMAGE CLI docs

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -375,7 +375,7 @@ import EnvVarConfig from '@site/src/components/EnvVarConfig'
 #### ELECTRIC_IMAGE
 
 <EnvVarConfig
-    name="ELECTRIC_PG_PROXY_PASSWORD"
+    name="ELECTRIC_IMAGE"
     defaultValue="electricsql/electric:{version-tag}"
     example="electricsql/electric:0.8"
 >


### PR DESCRIPTION
The `ELECTRIC_IMAGE` env var in the CLI docs was referring to the `ELECTRIC_PG_PROXY_PASSWORD` variable instead.