### PR TITLE
fix(electric): Filter out dropped columns in `electric.lookup_columns()`

### DIFF
--- a/.changeset/silly-seals-crash.md
+++ b/.changeset/silly-seals-crash.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fix electrification of tables with previously dropped columns.

--- a/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/shadow_table_creation_and_update.sql
+++ b/components/electric/lib/electric/postgres/extension/migrations/20230512000000_conflict_resolution_triggers/shadow_table_creation_and_update.sql
@@ -1,29 +1,3 @@
-
--- This function returns information about columns of the table based on it's oid, skipping any columns starting with an underscore
-CREATE OR REPLACE FUNCTION electric.lookup_columns(search_oid oid, include_hidden_columns boolean DEFAULT false)
-    RETURNS TABLE (col_name name, col_type text, col_not_null boolean, col_default text, col_primary boolean)
-    STABLE PARALLEL SAFE
-    RETURNS NULL ON NULL INPUT
-    ROWS 10
-    LANGUAGE SQL AS $$
-        SELECT
-            attname AS col_name,
-            pg_catalog.format_type(atttypid, atttypmod) AS col_type,
-            attnotnull AS col_not_null,
-            pg_get_expr(adbin, adrelid) AS col_default,
-            indexrelid IS NOT NULL AS col_primary
-        FROM pg_attribute
-        LEFT JOIN pg_attrdef
-            ON attrelid = adrelid AND attnum = adnum
-        LEFT JOIN pg_index
-            ON attrelid = indrelid AND attnum = ANY(indkey) AND indisprimary
-        WHERE
-            attrelid = search_oid
-            AND attnum > 0
-            AND (include_hidden_columns OR attname NOT LIKE '\_%')
-        ORDER BY attnum
-    $$;
-
 -- This function creates or updates shadow tables for conflict resolution
 CREATE OR REPLACE FUNCTION electric.ddlx_make_or_update_shadow_tables(tag text, schema_name text, target_oid oid)
     RETURNS VOID

--- a/components/electric/lib/electric/postgres/extension/migrations/20240205141200_reinstall_trigger_function__write_correct_max_tag.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240205141200_reinstall_trigger_function__write_correct_max_tag.ex
@@ -9,6 +9,7 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20240205141200_Reinst
   @impl true
   def up(schema) do
     [
+      Extension.Functions.by_name(:lookup_columns),
       Extension.Functions.by_name(:"function_installers.reinstall_trigger_function"),
       Extension.Functions.by_name(:"function_installers.utils"),
       Extension.Functions.by_name(:install_function__write_correct_max_tag),

--- a/components/electric/priv/sql_function_templates/alter_shadow_table.sql.eex
+++ b/components/electric/priv/sql_function_templates/alter_shadow_table.sql.eex
@@ -41,7 +41,7 @@ BEGIN
     SELECT <%= schema() %>.__primary_key_list(table_oid) INTO primary_key_list;
 
     SELECT array_agg(c.col_name) INTO non_pk_column_list
-        FROM electric.lookup_columns(table_oid) c WHERE NOT col_primary;
+        FROM <%= schema() %>.lookup_columns(table_oid) c WHERE NOT col_primary;
 
     /*
     We regenerate column-dependent functions, but not the triggers themselves

--- a/components/electric/priv/sql_function_templates/lookup_columns.sql.eex
+++ b/components/electric/priv/sql_function_templates/lookup_columns.sql.eex
@@ -26,5 +26,6 @@ LANGUAGE SQL AS $$
         attrelid = search_oid
         AND attnum > 0
         AND (include_hidden_columns OR attname NOT LIKE '\_%')
+        AND NOT attisdropped
     ORDER BY attnum
 $$;

--- a/components/electric/priv/sql_function_templates/lookup_columns.sql.eex
+++ b/components/electric/priv/sql_function_templates/lookup_columns.sql.eex
@@ -1,0 +1,30 @@
+-- This function returns information about columns of the table based on it's oid, skipping any columns starting with an underscore
+CREATE OR REPLACE FUNCTION <%= schema() %>.lookup_columns(search_oid oid, include_hidden_columns boolean DEFAULT false)
+RETURNS TABLE (
+  col_name name,
+  col_type text,
+  col_not_null boolean,
+  col_default text,
+  col_primary boolean
+)
+STABLE PARALLEL SAFE
+RETURNS NULL ON NULL INPUT
+ROWS 10
+LANGUAGE SQL AS $$
+    SELECT
+        attname AS col_name,
+        pg_catalog.format_type(atttypid, atttypmod) AS col_type,
+        attnotnull AS col_not_null,
+        pg_get_expr(adbin, adrelid) AS col_default,
+        indexrelid IS NOT NULL AS col_primary
+    FROM pg_attribute
+    LEFT JOIN pg_attrdef
+        ON attrelid = adrelid AND attnum = adnum
+    LEFT JOIN pg_index
+        ON attrelid = indrelid AND attnum = ANY(indkey) AND indisprimary
+    WHERE
+        attrelid = search_oid
+        AND attnum > 0
+        AND (include_hidden_columns OR attname NOT LIKE '\_%')
+    ORDER BY attnum
+$$;

--- a/e2e/tests/01.02_electrification.lux
+++ b/e2e/tests/01.02_electrification.lux
@@ -8,5 +8,16 @@
     !\dt electric.*
     ??electric | shadow__public__entries
 
+[shell pg_1]
+    # Verify column structure of the shadow table:
+    !SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'electric' AND table_name = 'shadow__public__entries';
+    ??        column_name         |     data_type
+    ??----------------------------+-------------------
+    ?? __reordered_content        | character varying
+    ?? __reordered_content_b      | text
+    ?? id                         | uuid
+    ?? _tag_content               | USER-DEFINED
+    ?? _tag_content_b             | USER-DEFINED
+
 [cleanup]
     [invoke teardown]

--- a/e2e/tests/01.07_postgres_dropped_columns_are_not_electrified.lux
+++ b/e2e/tests/01.07_postgres_dropped_columns_are_not_electrified.lux
@@ -1,0 +1,86 @@
+[doc Electrifying a table with dropped columns ignores said columns]
+[include _shared.luxinc]
+[include _satellite_macros.luxinc]
+
+[invoke setup]
+
+[shell pg_1]
+    !ALTER TABLE entries DROP COLUMN content_b;
+    ??ALTER TABLE
+    ??electric=#
+
+    -$fail_pattern|content_b|dropped
+
+[shell electric]
+    -$fail_pattern|content_b|dropped
+
+[shell proxy_1]
+    -$fail_pattern|content_b|dropped
+
+    !ALTER TABLE entries ENABLE ELECTRIC;
+    ??ELECTRIC ENABLE
+    ??electric=#
+
+[shell pg_1]
+    !\dt electric.*
+    ??electric | shadow__public__entries
+
+    # Verify column structure of the shadow table:
+    !SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'electric' AND table_name = 'shadow__public__entries';
+    ??        column_name         |     data_type
+    ??----------------------------+-------------------
+    ?? __reordered_content        | character varying
+    ?? id                         | uuid
+    ?? _tag_content               | USER-DEFINED
+
+# Start two clients and make conflicting writes on both to verify correct conflict resolution
+# that's not affected by the dropped column content_b.
+[invoke setup_client 1 "electric_1" 5133]
+[shell satellite_1]
+    ?send: #SatAuthReq\{id: ([a-f0-9-]{36})
+    [global client_1_id=$1]
+
+    [invoke node_sync_table "entries"]
+    [invoke client_disconnect]
+
+[invoke setup_client 2 "electric_1" 5133]
+[shell satellite_2]
+    ?send: #SatAuthReq\{id: ([a-f0-9-]{36})
+    [global client_2_id=$1]
+
+    [invoke node_sync_table "entries"]
+    [invoke client_disconnect]
+
+[shell satellite_1]
+    [invoke node_await_insert_extended_into "entries" "{id: '00000000-0000-0000-0000-000000000001', content: 'sat1'}"]
+
+[shell satellite_2]
+    [invoke node_await_insert_extended_into "entries" "{id: '00000000-0000-0000-0000-000000000001', content: 'sat2'}"]
+
+# Now reconnect both clients and verify the convergence between all three nodes.
+[shell satellite_1]
+    [invoke client_reconnect]
+    ?recv: #SatOpLog\{.*#Insert\{.*new: \["00000000-0000-0000-0000-000000000001", "sat
+
+[shell satellite_2]
+    [invoke client_reconnect]
+    ?recv: #SatOpLog\{.*#Insert\{.*new: \["00000000-0000-0000-0000-000000000001", "sat
+
+[shell pg_1]
+    !SELECT *, (CASE WHEN content = 'sat1' THEN '$client_1_id' ELSE '$client_2_id' END) FROM entries;
+    ?00000000-0000-0000-0000-000000000001 \| (sat(1|2))    \| ([a-f0-9-]{36})
+    [global lww_val=$1]
+    [global lww_client=$3]
+
+    !SELECT id, _tag_content FROM electric.shadow__public__entries;
+    ?00000000-0000-0000-0000-000000000001 \| \("[0-9-:.+ ]+",$lww_client\)
+
+[shell satellite_1]
+    [invoke node_await_get_from_table "entries" "$lww_val"]
+
+[shell satellite_2]
+    [invoke node_await_get_from_table "entries" "$lww_val"]
+
+[cleanup]
+    [invoke teardown]
+

--- a/e2e/tests/01.07_postgres_dropped_columns_are_not_electrified.lux
+++ b/e2e/tests/01.07_postgres_dropped_columns_are_not_electrified.lux
@@ -4,6 +4,30 @@
 
 [invoke setup]
 
+# When a table column is dropped, Postgres keeps some information about it in the
+# "pg_attribute" system catalog. Because Electric relies on information in that catalog, this
+# test verifies that dropped columns do not have adverse effects on normal functioning of the sync
+# service.
+#
+# You can see what it looks like for yourself by creating the "entries" table, dropping its
+# "content_b" column and then running the following query via psql:
+#
+#     SELECT
+#       attname, atttypid, format_type(atttypid, atttypmod)
+#     FROM
+#       pg_attribute
+#     WHERE
+#       attrelid = 'entries'::regclass AND attnum > 0;
+#
+# That should produce the following output:
+#
+#                attname            │ atttypid │    format_type
+#     ──────────────────────────────┼──────────┼───────────────────
+#      id                           │     2950 │ uuid
+#      content                      │     1043 │ character varying
+#      ........pg.dropped.3........ │        0 │ -
+#     (3 rows)
+
 [shell pg_1]
     !ALTER TABLE entries DROP COLUMN content_b;
     ??ALTER TABLE


### PR DESCRIPTION
Fixes #1085.