### PR TITLE
Ensure that the maximum path length is sufficient

### DIFF
--- a/clients/typescript/src/drivers/wa-sqlite/database.ts
+++ b/clients/typescript/src/drivers/wa-sqlite/database.ts
@@ -101,7 +101,13 @@ export class ElectricDatabase {
     const sqlite3 = SQLite.Factory(SQLiteAsyncModule)
 
     // Register a Virtual File System with the SQLite runtime
-    sqlite3.vfs_register(new IDBBatchAtomicVFS(dbName))
+    const vfs = new IDBBatchAtomicVFS(dbName)
+    // Ensure that the maximum path length is sufficient for the database name.
+    // The default maximum path length is 64 bytes, see: 'wa-sqlite/src/VFS.js'.
+    // N.B. SQLite adds 8 bytes to the length of the database name, see:
+    // https://github.com/sqlite/sqlite/blob/254729edb7b7e704b95af059e91bc4b3e11e9e4e/src/main.c#L3205
+    vfs.mxPathName = dbName.length + 8
+    sqlite3.vfs_register(vfs)
 
     // Open the DB connection
     // see: https://rhashimoto.github.io/wa-sqlite/docs/interfaces/SQLiteAPI.html#open_v2


### PR DESCRIPTION
As indicated in the code comment, `IDBBatchAtomicVFS`'s default for `mxPathName` is 64.
SQLite allocates memory for the file name length **plus 8 bytes**, so file names longer than 56 bytes cause SQLite `open` commands to fail.

N.B. This change alone is not sufficient to resolve the problem.

There is an underlying problem caused by a bug in wa-sqlite that causes `mxPathName` to be ignored. The fix is in [PR 163](https://github.com/rhashimoto/wa-sqlite/pull/163).