### PR TITLE
fix(client): Add COMPENSATION to the OpType type

### DIFF
--- a/clients/typescript/src/satellite/oplog.ts
+++ b/clients/typescript/src/satellite/oplog.ts
@@ -76,7 +76,7 @@ export interface PendingChanges {
   }
 }
 
-export type OpType = 'DELETE' | 'INSERT' | 'UPDATE' | 'GONE'
+export type OpType = 'DELETE' | 'INSERT' | 'UPDATE' | 'COMPENSATION' | 'GONE'
 
 export type ChangesOpType = 'DELETE' | 'UPSERT' | 'GONE'
 
@@ -85,12 +85,14 @@ export const OPTYPES: {
   update: 'UPDATE'
   delete: 'DELETE'
   upsert: 'UPSERT'
+  compensation: 'COMPENSATION'
   gone: 'GONE'
 } = {
   insert: 'INSERT',
   update: 'UPDATE',
   delete: 'DELETE',
   upsert: 'UPSERT',
+  compensation: 'COMPENSATION',
   gone: 'GONE',
 }
 
@@ -111,6 +113,8 @@ export const stringToOpType = (opTypeStr: string): OpType => {
       return OPTYPES.update
     case 'DELETE':
       return OPTYPES.delete
+    case 'COMPENSATION':
+      return OPTYPES.compensation
     case 'GONE':
       return OPTYPES.gone
   }
@@ -205,6 +209,8 @@ function optypeToShadow(optype: OpType): ChangesOpType {
     case 'INSERT':
     case 'UPDATE':
       return 'UPSERT'
+    default:
+      throw new Error(`Unexpected optype: ${optype}`)
   }
 }
 


### PR DESCRIPTION
The OpType sealed type was missing the COMPENSATION value.
The COMPENSATION value was implicitly being used when casting the op logs table rows to the OplogEntry type.

https://github.com/electric-sql/electric/blob/fd35035763c7e0193ce27700559dd72d3b1c3929/clients/typescript/src/satellite/oplog.ts#L28

By including the value we are also forced to handle it everywhere, like in the function `optypeToShadow`. I don't know what's expected to happen there, so I included an Error.

If this change is fine there might not be a need for the type `DataChangeType` https://github.com/electric-sql/electric/blob/fd35035763c7e0193ce27700559dd72d3b1c3929/clients/typescript/src/util/types.ts#L136