### PR TITLE
fix(electric): Add all published tables to the Electric publication when it's recreated

### DIFF
--- a/.changeset/warm-carrots-promise.md
+++ b/.changeset/warm-carrots-promise.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Include all publishable tables in the publication that Electric creates at startup.

--- a/components/electric/lib/electric/replication/postgres/migration_consumer.ex
+++ b/components/electric/lib/electric/replication/postgres/migration_consumer.ex
@@ -112,11 +112,6 @@ defmodule Electric.Replication.Postgres.MigrationConsumer do
           Logger.debug("---- Filtering #{inspect(change)}")
           false
 
-        # TODO: VAX-680 remove this special casing of schema_migrations table
-        # once we are selectivley replicating tables
-        %{relation: {"public", "schema_migrations"}} ->
-          false
-
         _change ->
           true
       end)

--- a/components/electric/lib/electric/replication/postgres_manager.ex
+++ b/components/electric/lib/electric/replication/postgres_manager.ex
@@ -257,9 +257,9 @@ defmodule Electric.Replication.PostgresConnectorMng do
 
     Client.with_conn(conn_opts, fn conn ->
       with {:ok, versions} <- Extension.migrate(conn),
-           {:ok, electrified_tables} <- Extension.electrified_tables(conn),
+           {:ok, published_tables} <- Extension.published_tables(conn),
            {:ok, _name} <-
-             Client.create_publication(conn, Extension.publication_name(), electrified_tables),
+             Client.create_publication(conn, Extension.publication_name(), published_tables),
            :ok <- maybe_create_subscription(conn, state.write_to_pg_mode, state.repl_opts),
            :ok <- OidDatabase.update_oids(conn) do
         Logger.info(

--- a/e2e/common.mk
+++ b/e2e/common.mk
@@ -66,8 +66,7 @@ log_dev_env:
 	docker compose -f ${DOCKER_COMPOSE_FILE} logs --no-color --follow pg_1
 
 start_electric_%:
-	docker compose -f ${DOCKER_COMPOSE_FILE} up --no-color --no-log-prefix -d electric_$*
-	docker compose -f ${DOCKER_COMPOSE_FILE} logs --no-color --follow electric_$*
+	docker compose -f ${DOCKER_COMPOSE_FILE} up --no-color --no-log-prefix electric_$*
 
 stop_electric_%:
 	docker compose -f ${DOCKER_COMPOSE_FILE} stop electric_$*

--- a/e2e/tests/01.05_electric_can_recreate_publication.lux
+++ b/e2e/tests/01.05_electric_can_recreate_publication.lux
@@ -1,0 +1,82 @@
+[doc Electric correctly recreates the publication at startup if it was deleted]
+[include _shared.luxinc]
+
+[invoke setup]
+
+[shell proxy_1]
+    [invoke migrate_items_table 001]
+
+    [local sql=
+        """
+        CREATE TABLE foo(id TEXT PRIMARY KEY);
+        CREATE TABLE bar(id TEXT PRIMARY KEY);
+        CREATE TABLE baz(id TEXT PRIMARY KEY);
+
+        ALTER TABLE foo ENABLE ELECTRIC;
+        """]
+    [invoke migrate_pg 002 $sql]
+    [invoke migrate_pg 003 "ALTER TABLE baz ENABLE ELECTRIC;"]
+
+[shell pg_1]
+    !SELECT schemaname, tablename FROM pg_publication_tables \
+         WHERE pubname = 'electric_publication' ORDER BY tablename;
+    ??electric   | acknowledged_client_lsns
+    ??electric   | assignments
+    ??public     | baz
+    ??electric   | ddl_commands
+    ??electric   | electrified
+    ??public     | foo
+    ??electric   | grants
+    ??public     | items
+    ??electric   | roles
+    ??electric   | shadow__public__baz
+    ??electric   | shadow__public__foo
+    ??electric   | shadow__public__items
+    ??electric   | transaction_marker
+    ??(13 rows)
+
+# Make sure Electric consumes all migrations from the replication stream before stopping it.
+[shell electric]
+    ?component=CachedWal.EtsBacked \[debug\] Saving transaction\
+       .+ with changes \[%Electric.Replication.Changes.NewRecord\{\
+       relation: \{"electric", "ddl_commands"\}, \
+       record: %\{.*"query" => "CREATE TABLE baz
+
+[shell log]
+    [invoke stop_electric 1]
+
+[shell pg_1]
+    !DROP PUBLICATION electric_publication;
+    ??DROP PUBLICATION
+
+    !SELECT * FROM pg_publication;
+    ??(0 rows)
+
+    !SELECT * FROM pg_publication_tables;
+    ??(0 rows)
+
+[shell electric]
+    [invoke start_electric 1]
+
+[shell pg_1]
+    !SELECT * FROM electric.schema;
+
+    !SELECT schemaname, tablename FROM pg_publication_tables \
+         WHERE pubname = 'electric_publication' ORDER BY tablename;
+    ??electric   | acknowledged_client_lsns
+    ??electric   | assignments
+    ??public     | baz
+    ??electric   | ddl_commands
+    ??electric   | electrified
+    ??public     | foo
+    ??electric   | grants
+    ??public     | items
+    ??electric   | roles
+    ??electric   | shadow__public__baz
+    ??electric   | shadow__public__foo
+    ??electric   | shadow__public__items
+    ??electric   | transaction_marker
+    ??(13 rows)
+
+[cleanup]
+    [invoke teardown]

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -16,9 +16,7 @@
         -$fail_pattern
 
     [newshell electric]
-        !make start_electric_1
-        -$fail_pattern
-        ??Successfully initialized Postgres connector "postgres_1"
+        [invoke start_electric 1]
         [progress setup finished]
 
     [shell postgres_logs]
@@ -33,6 +31,17 @@
         [invoke start_proxy pg_1 electric_1]
         -$fail_pattern
 
+[endmacro]
+
+[macro start_electric n]
+    !make start_electric_${n}
+    -$fail_pattern
+    ??Successfully initialized Postgres connector "postgres_1"
+[endmacro]
+
+[macro stop_electric n]
+    !make stop_electric_${n}
+    [invoke ok]
 [endmacro]
 
 [macro teardown]


### PR DESCRIPTION
This is a follow-up to https://github.com/electric-sql/electric/pull/1049 which was an incomplete solution for VAX-1465.

- [x] add changelog
- [x] write a test