### PR TITLE
fix(electric): Fix unbounded WAL size growth on disk

### DIFF
--- a/.changeset/stupid-fishes-warn.md
+++ b/.changeset/stupid-fishes-warn.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fix unbounded disk usage growth caused by the WAL records retained by Electric's replication slot.

--- a/components/electric/lib/electric/replication/initial_sync.ex
+++ b/components/electric/lib/electric/replication/initial_sync.ex
@@ -75,23 +75,13 @@ defmodule Electric.Replication.InitialSync do
      at the end, we might have already skipped the point where the data is relevant.
   2. `{:subscription_data, subscription_id, data}` is when we've collected all the data.
 
-  One more thing this function is expected to do is to record any write to Postgres in a table that is a part
-  of our publication (i.e. the Electric will see it) and the table should probably be part of the `electric` schema.
+  If an error occurs while collecting the data, this function is expected to send the following message:
 
-  Since the insertion point for this data is first observed transaction with xid >= xmin, if we receive this data
-  and no writes come in after (e.g. when no writes are going on in PG), for example if there are no new writes
-  coming, then it's essentially impossible to know whether we are still waiting for any transactions from PG or
-  we should send the data immediately. LSNs are unstable, transaction ids can be skipped in cases of transaction
-  rollbacks. The only reliable way to have an insertion point is to observe the transaction with xid >= xmin, then
-  we can insert the data right before that. We ensure we do observe it by doing a magic no-op write to a special
-  table under a special key. Since we are doing this write after starting the REPEATABLE READ transaction, xid for
-  the write will definitely be >= xmin, so even in absence of "real" writes to electrified tables, we'll at least
-  observe this magic write.
+      {:subscription_init_failed, subscription_id, reason}
 
-  If an error occurs while collecting the data, this function is expected to send the message like this:
-  ```elixir
-  {:subscription_init_failed, subscription_id, reason}
-  ```
+  Sidenote: since the insertion point for initial data is the first observed transaction that has
+  xid >= xmin, we make sure there is one even in the absence of user writes to Postgres. See
+  `perform_magic_write/2` below for details.
   """
   def query_subscription_data({subscription_id, requests, context},
         reply_to: {ref, parent},
@@ -102,7 +92,7 @@ defmodule Electric.Replication.InitialSync do
     origin = Connectors.origin(opts)
     {:ok, schema_version} = Extension.SchemaCache.load(origin)
 
-    start_readonly_txn_with_checkpoint(opts, {ref, parent}, marker, fn conn, _ ->
+    run_in_readonly_txn_with_checkpoint(opts, {ref, parent}, marker, fn conn, _ ->
       Enum.reduce_while(requests, {Graph.new(), %{}, []}, fn request,
                                                              {acc_graph, results, req_ids} ->
         start = System.monotonic_time()
@@ -149,7 +139,7 @@ defmodule Electric.Replication.InitialSync do
     origin = Connectors.origin(opts)
     {:ok, schema_version} = Extension.SchemaCache.load(origin)
 
-    start_readonly_txn_with_checkpoint(opts, {ref, parent}, marker, fn conn, xmin ->
+    run_in_readonly_txn_with_checkpoint(opts, {ref, parent}, marker, fn conn, xmin ->
       Enum.reduce_while(subquery_map, {Graph.new(), %{}}, fn {layer, changes},
                                                              {acc_graph, results} ->
         case Shapes.ShapeRequest.query_moved_in_layer_data(
@@ -179,35 +169,46 @@ defmodule Electric.Replication.InitialSync do
     end)
   end
 
-  defp start_readonly_txn_with_checkpoint(opts, {ref, parent}, marker, fun)
+  defp run_in_readonly_txn_with_checkpoint(opts, {ref, parent}, marker, fun)
        when is_function(fun, 2) do
-    Client.with_conn(Connectors.get_connection_opts(opts), fn conn ->
+    conn_opts = Connectors.get_connection_opts(opts)
+
+    Client.with_conn(conn_opts, fn conn ->
       Client.with_transaction(
         "ISOLATION LEVEL REPEATABLE READ READ ONLY",
         conn,
         fn conn ->
-          # Do the magic write described in the function docs. It's important that this is
-          # 1. after the transaction had started, and
-          # 2. in a separate transaction (thus on a different connection), and
-          # 3. before the potentially big read queries to ensure this arrives ASAP on any data size
-          Task.start(fn -> perform_magic_write(opts, marker) end)
+          # It's important that this magic write
+          # 1. is made after the current transaction has started
+          # 2. is in a separate transaction (thus on a different connection)
+          # 3. is before the potentially big read queries to ensure this arrives ASAP on any data size
+          Task.start(fn -> perform_magic_write(conn_opts, marker) end)
 
-          {:ok, _, [{xmin}]} =
-            :epgsql.squery(
-              conn,
-              "SELECT pg_snapshot_xmin(pg_current_snapshot());"
-            )
+          {:ok, _, [{xmin_str}]} =
+            :epgsql.squery(conn, "SELECT pg_snapshot_xmin(pg_current_snapshot())")
 
-          send(parent, {:data_insertion_point, ref, String.to_integer(xmin)})
-          fun.(conn, String.to_integer(xmin))
+          xmin = String.to_integer(xmin_str)
+          send(parent, {:data_insertion_point, ref, xmin})
+          fun.(conn, xmin)
         end
       )
     end)
   end
 
-  defp perform_magic_write(opts, marker) do
-    opts
-    |> Connectors.get_connection_opts()
-    |> Client.with_conn(&Extension.update_transaction_marker(&1, marker))
+  # Commit a write transaction to ensure Electric sees one even in the absence of user writes
+  # to Postgres.
+  #
+  # When fetching initial data or additional data for a transaction from Postgres, we need to
+  # identify the correct insertion point for it to maintain consistency. The only reliable way
+  # to have an insertion point is to observe a transaction with xid >= xmin where xmin is
+  # greater than all transaction IDs that are either committed and visible to the current
+  # transaction.
+  #
+  # This magic write to a special table under a special key has to be made immediately after
+  # starting a REPEATABLE READ transaction. xid for this write transaction will definitely be
+  # >= xmin, so even in the absence of user writes to electrified tables, Electric will at
+  # least observe this magic write.
+  defp perform_magic_write(conn_opts, marker) do
+    Client.with_conn(conn_opts, &Extension.update_transaction_marker(&1, marker))
   end
 end

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -60,8 +60,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   end
 
   @spec start_link(Connectors.config()) :: :ignore | {:error, any} | {:ok, pid}
-  def start_link(conn_config) do
-    GenStage.start_link(__MODULE__, conn_config)
+  def start_link(connector_config) do
+    GenStage.start_link(__MODULE__, connector_config)
   end
 
   @spec get_name(Connectors.origin()) :: Electric.reg_name()
@@ -74,10 +74,10 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   end
 
   @impl true
-  def init(conn_config) do
-    origin = Connectors.origin(conn_config)
-    conn_opts = Connectors.get_connection_opts(conn_config, replication: true)
-    repl_opts = Connectors.get_replication_opts(conn_config)
+  def init(connector_config) do
+    origin = Connectors.origin(connector_config)
+    conn_opts = Connectors.get_connection_opts(connector_config, replication: true)
+    repl_opts = Connectors.get_replication_opts(connector_config)
 
     :gproc.reg(name(origin))
 

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -35,7 +35,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   }
 
   defmodule State do
-    defstruct conn: nil,
+    defstruct repl_conn: nil,
+              svc_conn: nil,
               demand: 0,
               queue: nil,
               relations: %{},
@@ -47,7 +48,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
               span: nil
 
     @type t() :: %__MODULE__{
-            conn: pid(),
+            repl_conn: pid(),
+            svc_conn: pid(),
             demand: non_neg_integer(),
             queue: :queue.queue(),
             relations: %{Messages.relation_id() => %Relation{}},
@@ -76,7 +78,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   @impl true
   def init(connector_config) do
     origin = Connectors.origin(connector_config)
-    conn_opts = Connectors.get_connection_opts(connector_config, replication: true)
+    conn_opts = Connectors.get_connection_opts(connector_config)
+    repl_conn_opts = Connectors.get_connection_opts(connector_config, replication: true)
     repl_opts = Connectors.get_replication_opts(connector_config)
 
     :gproc.reg(name(origin))
@@ -87,15 +90,25 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     Logger.debug("#{__MODULE__}.init: publication: '#{publication}', slot: '#{slot}'")
 
     Logger.info("Starting replication from #{origin}")
-    Logger.info("#{inspect(__MODULE__)}.init(#{inspect(Client.sanitize_conn_opts(conn_opts))})")
 
-    with {:ok, conn} <- Client.connect(conn_opts),
-         {:ok, _} <- Client.create_slot(conn, slot),
-         :ok <- Client.set_display_settings_for_replication(conn),
-         {:ok, {short, long, cluster}} <- Client.get_server_versions(conn),
+    Logger.info(
+      "#{inspect(__MODULE__)}.init(#{inspect(Client.sanitize_conn_opts(repl_conn_opts))})"
+    )
+
+    # The replication connection is used to consumer the logical replication stream from
+    # Postgres and to send acknowledgements about received transactions back to Postgres,
+    # allowing it to advance the replication slot forward and discard obsolete WAL records.
+    with {:ok, repl_conn} <- Client.connect(repl_conn_opts),
+         {:ok, _} <- Client.create_slot(repl_conn, slot),
+         :ok <- Client.set_display_settings_for_replication(repl_conn),
+         {:ok, {short, long, cluster}} <- Client.get_server_versions(repl_conn),
          {:ok, table_count} <- SchemaLoader.count_electrified_tables({SchemaCache, origin}),
-         :ok <- Client.start_replication(conn, publication, slot, self()) do
-      Process.monitor(conn)
+         :ok <- Client.start_replication(repl_conn, publication, slot, self()),
+         # The service connection is opened alongside the replication connection to execute
+         # maintenance statements. It is needed because Postgres does not allow regular
+         # statements and queries on a replication connection once the replication has started.
+         {:ok, svc_conn} <- Client.connect(conn_opts) do
+      Process.monitor(repl_conn)
 
       Logger.metadata(pg_producer: origin)
 
@@ -108,7 +121,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
 
       {:producer,
        %State{
-         conn: conn,
+         repl_conn: repl_conn,
+         svc_conn: svc_conn,
          queue: :queue.new(),
          publication: publication,
          origin: origin,
@@ -129,14 +143,18 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     |> process_message(state)
   end
 
-  def handle_info({:DOWN, _, :process, conn, reason}, %State{conn: conn} = state) do
+  def handle_info({:DOWN, _, :process, conn, reason}, %State{repl_conn: conn} = state) do
     Logger.warning("PostgreSQL closed the replication connection")
     Metrics.stop_span(state.span)
-
     {:stop, reason, state}
   end
 
-  @impl true
+  def handle_info({:DOWN, _, :process, conn, reason}, %State{svc_conn: conn} = state) do
+    Logger.warning("PostgreSQL closed the persistent connection")
+    Metrics.stop_span(state.span)
+    {:stop, reason, state}
+  end
+
   def handle_info(msg, state) do
     Logger.debug("Unexpected message #{inspect(msg)}")
     {:noreply, [], state}
@@ -334,7 +352,7 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   end
 
   defp build_message(%Transaction{} = transaction, end_lsn, %State{} = state) do
-    conn = state.conn
+    repl_conn = state.repl_conn
     origin = state.origin
 
     %Transaction{
@@ -342,13 +360,13 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
       | lsn: end_lsn,
         # Make sure not to pass state.field into ack function, as this
         # will create a copy of the whole state in memory when sending a message
-        ack_fn: fn -> ack(conn, origin, end_lsn) end
+        ack_fn: fn -> ack(repl_conn, origin, end_lsn) end
     }
   end
 
   @spec ack(pid(), Connectors.origin(), Electric.Postgres.Lsn.t()) :: :ok
-  def ack(conn, origin, lsn) do
+  def ack(repl_conn, origin, lsn) do
     Logger.debug("Acknowledging #{lsn}", origin: origin)
-    Client.acknowledge_lsn(conn, lsn)
+    Client.acknowledge_lsn(repl_conn, lsn)
   end
 end

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -71,6 +71,10 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   @magic_write_timeout 30_000
   @magic_write_msg :magic_write
 
+  if Mix.env() == :test do
+    @magic_write_timeout 1_000
+  end
+
   @spec start_link(Connectors.config()) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(connector_config) do
     GenStage.start_link(__MODULE__, connector_config)

--- a/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
+++ b/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
@@ -106,6 +106,11 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
            ] = transaction.changes
   end
 
+  test "Producer schedules the magic write timer" do
+    %LogicalReplicationProducer.State{magic_write_timer: tref} = initialize_producer()
+    assert_receive {:timeout, ^tref, :magic_write}, 2_000
+  end
+
   def initialize_producer(demand \\ 100) do
     {:producer, state} = LogicalReplicationProducer.init(origin: "mock_postgres")
     {_, _, state} = LogicalReplicationProducer.handle_demand(demand, state)

--- a/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
+++ b/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
@@ -27,7 +27,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
     {Connectors, [:passthrough],
      [
        get_replication_opts: fn _ -> %{publication: "mock_pub", slot: "mock_slot"} end,
-       get_connection_opts: fn _, _ -> %{ip_addr: {0, 0, 0, 1}} end
+       get_connection_opts: fn _ -> %{ip_addr: {0, 0, 0, 1}} end,
+       get_connection_opts: fn _, _ -> %{ip_addr: {0, 0, 0, 2}} end
      ]},
     {SchemaLoader, [:passthrough],
      [


### PR DESCRIPTION
As explained in https://github.com/electric-sql/electric/issues/1083#issuecomment-2015354293, Electric cannot let Postgres know it can discard obsolete WAL records until it sees a write to an electrified table.

Here we issue such writes on a regular basis even if there are no user writes being performed by the clients or directly in the database.

Fixes #1083.

- [x] add changelog
- [x] add a test that confirms that periodic writes are happening