### PR TITLE
fix(client): Fix incorrect field transformation in queries including related tables

### DIFF
--- a/.changeset/quick-cooks-accept.md
+++ b/.changeset/quick-cooks-accept.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fixed incorrect field transformation for queries with included relations

--- a/clients/typescript/src/client/execution/db.ts
+++ b/clients/typescript/src/client/execution/db.ts
@@ -2,6 +2,7 @@ import { RunResult } from '../../electric/adapter'
 import { QueryBuilder } from 'squel'
 import * as z from 'zod'
 import { Row, Statement } from '../../util'
+import { Fields } from '../model/schema'
 
 /**
  * Interface that must be implemented by DB implementations.
@@ -28,4 +29,10 @@ export interface DB {
     successCallback: (tx: DB, res: Row[]) => void,
     errorCallback?: (error: any) => void
   ): void
+
+  /**
+   * Get instance with provided table schema for field
+   * transformation and validation purposes
+   */
+  withTableSchema(fields: Fields): DB
 }

--- a/clients/typescript/src/client/execution/nonTransactionalDB.ts
+++ b/clients/typescript/src/client/execution/nonTransactionalDB.ts
@@ -9,6 +9,10 @@ import { Fields } from '../model/schema'
 export class NonTransactionalDB implements DB {
   constructor(private _adapter: DatabaseAdapter, private _fields: Fields) {}
 
+  withTableSchema(fields: Fields) {
+    return new NonTransactionalDB(this._adapter, fields)
+  }
+
   run(
     statement: QueryBuilder,
     successCallback?: (db: DB, res: RunResult) => void,

--- a/clients/typescript/src/client/execution/transactionalDB.ts
+++ b/clients/typescript/src/client/execution/transactionalDB.ts
@@ -8,6 +8,10 @@ import { Transformation, transformFields } from '../conversions/input'
 
 export class TransactionalDB implements DB {
   constructor(private _tx: Transaction, private _fields: Fields) {}
+
+  withTableSchema(fields: Fields) {
+    return new TransactionalDB(this._tx, fields)
+  }
   run(
     statement: QueryBuilder,
     successCallback?: (db: DB, res: RunResult) => void,

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -450,7 +450,7 @@ export class Table<
         const relatedTbl = this._tables.get(relatedTable)!
         relatedTbl._create(
           { data: relatedObject },
-          db,
+          db.withTableSchema(relatedTbl._fields),
           (createdRelatedObject) => {
             delete data[relationField] // remove the relation field
             data[fromField] = createdRelatedObject[toField] // fill in the FK
@@ -502,7 +502,7 @@ export class Table<
             relatedObject[fromField] = obj[toField] // fill in FK
             relatedTbl._create(
               { data: relatedObject },
-              db,
+              db.withTableSchema(relatedTbl._fields),
               () => {
                 oldMakeRelatedObjects(obj, cont)
               },
@@ -731,7 +731,7 @@ export class Table<
           },
         },
       },
-      db,
+      db.withTableSchema(otherTable._fields),
       (relatedRows: object[]) => {
         // Now, join the original `rows` with the `relatedRows`
         // where `row.fromField == relatedRow.toField`
@@ -966,7 +966,7 @@ export class Table<
             data: obj.data,
             where: whereArg,
           },
-          db,
+          db.withTableSchema(relatedTbl._fields),
           cont,
           onError
         )
@@ -981,7 +981,7 @@ export class Table<
               [toField]: fromFieldValue,
             },
           },
-          db,
+          db.withTableSchema(relatedTbl._fields),
           cont,
           onError
         )
@@ -1049,7 +1049,7 @@ export class Table<
                   [fromField]: originalObject[toField],
                 },
               },
-              db,
+              db.withTableSchema(relatedTable._fields),
               cont,
               onError
             )

--- a/clients/typescript/test/client/generated/client/index.d.ts
+++ b/clients/typescript/test/client/generated/client/index.d.ts
@@ -30,6 +30,7 @@ export type Items = {
 export type User = {
   id: number
   name: string | null
+  meta: string | null
 }
 
 /**
@@ -51,6 +52,7 @@ export type Post = {
 export type Profile = {
   id: number
   bio: string
+  meta: Prisma.JsonValue | null
   userId: number
 }
 
@@ -1987,16 +1989,19 @@ export namespace Prisma {
   export type UserMinAggregateOutputType = {
     id: number | null
     name: string | null
+    meta: string | null
   }
 
   export type UserMaxAggregateOutputType = {
     id: number | null
     name: string | null
+    meta: string | null
   }
 
   export type UserCountAggregateOutputType = {
     id: number
     name: number
+    meta: number
     _all: number
   }
 
@@ -2012,16 +2017,19 @@ export namespace Prisma {
   export type UserMinAggregateInputType = {
     id?: true
     name?: true
+    meta?: true
   }
 
   export type UserMaxAggregateInputType = {
     id?: true
     name?: true
+    meta?: true
   }
 
   export type UserCountAggregateInputType = {
     id?: true
     name?: true
+    meta?: true
     _all?: true
   }
 
@@ -2120,6 +2128,7 @@ export namespace Prisma {
   export type UserGroupByOutputType = {
     id: number
     name: string | null
+    meta: string | null
     _count: UserCountAggregateOutputType | null
     _avg: UserAvgAggregateOutputType | null
     _sum: UserSumAggregateOutputType | null
@@ -2144,6 +2153,7 @@ export namespace Prisma {
   export type UserSelect = {
     id?: boolean
     name?: boolean
+    meta?: boolean
     posts?: boolean | User$postsArgs
     profile?: boolean | ProfileArgs
     _count?: boolean | UserCountOutputTypeArgs
@@ -4062,6 +4072,7 @@ export namespace Prisma {
   export type ProfileCountAggregateOutputType = {
     id: number
     bio: number
+    meta: number
     userId: number
     _all: number
   }
@@ -4092,6 +4103,7 @@ export namespace Prisma {
   export type ProfileCountAggregateInputType = {
     id?: true
     bio?: true
+    meta?: true
     userId?: true
     _all?: true
   }
@@ -4191,6 +4203,7 @@ export namespace Prisma {
   export type ProfileGroupByOutputType = {
     id: number
     bio: string
+    meta: JsonValue | null
     userId: number
     _count: ProfileCountAggregateOutputType | null
     _avg: ProfileAvgAggregateOutputType | null
@@ -4216,6 +4229,7 @@ export namespace Prisma {
   export type ProfileSelect = {
     id?: boolean
     bio?: boolean
+    meta?: boolean
     userId?: boolean
     user?: boolean | UserArgs
   }
@@ -7265,6 +7279,7 @@ export namespace Prisma {
   export const ProfileScalarFieldEnum: {
     id: 'id',
     bio: 'bio',
+    meta: 'meta',
     userId: 'userId'
   };
 
@@ -7299,7 +7314,8 @@ export namespace Prisma {
 
   export const UserScalarFieldEnum: {
     id: 'id',
-    name: 'name'
+    name: 'name',
+    meta: 'meta'
   };
 
   export type UserScalarFieldEnum = (typeof UserScalarFieldEnum)[keyof typeof UserScalarFieldEnum]
@@ -7351,6 +7367,7 @@ export namespace Prisma {
     NOT?: Enumerable<UserWhereInput>
     id?: IntFilter | number
     name?: StringNullableFilter | string | null
+    meta?: StringNullableFilter | string | null
     posts?: PostListRelationFilter
     profile?: XOR<ProfileRelationFilter, ProfileWhereInput> | null
   }
@@ -7358,6 +7375,7 @@ export namespace Prisma {
   export type UserOrderByWithRelationInput = {
     id?: SortOrder
     name?: SortOrder
+    meta?: SortOrder
     posts?: PostOrderByRelationAggregateInput
     profile?: ProfileOrderByWithRelationInput
   }
@@ -7369,6 +7387,7 @@ export namespace Prisma {
   export type UserOrderByWithAggregationInput = {
     id?: SortOrder
     name?: SortOrder
+    meta?: SortOrder
     _count?: UserCountOrderByAggregateInput
     _avg?: UserAvgOrderByAggregateInput
     _max?: UserMaxOrderByAggregateInput
@@ -7382,6 +7401,7 @@ export namespace Prisma {
     NOT?: Enumerable<UserScalarWhereWithAggregatesInput>
     id?: IntWithAggregatesFilter | number
     name?: StringNullableWithAggregatesFilter | string | null
+    meta?: StringNullableWithAggregatesFilter | string | null
   }
 
   export type PostWhereInput = {
@@ -7440,6 +7460,7 @@ export namespace Prisma {
     NOT?: Enumerable<ProfileWhereInput>
     id?: IntFilter | number
     bio?: StringFilter | string
+    meta?: JsonNullableFilter
     userId?: IntFilter | number
     user?: XOR<UserRelationFilter, UserWhereInput> | null
   }
@@ -7447,6 +7468,7 @@ export namespace Prisma {
   export type ProfileOrderByWithRelationInput = {
     id?: SortOrder
     bio?: SortOrder
+    meta?: SortOrder
     userId?: SortOrder
     user?: UserOrderByWithRelationInput
   }
@@ -7459,6 +7481,7 @@ export namespace Prisma {
   export type ProfileOrderByWithAggregationInput = {
     id?: SortOrder
     bio?: SortOrder
+    meta?: SortOrder
     userId?: SortOrder
     _count?: ProfileCountOrderByAggregateInput
     _avg?: ProfileAvgOrderByAggregateInput
@@ -7473,6 +7496,7 @@ export namespace Prisma {
     NOT?: Enumerable<ProfileScalarWhereWithAggregatesInput>
     id?: IntWithAggregatesFilter | number
     bio?: StringWithAggregatesFilter | string
+    meta?: JsonNullableWithAggregatesFilter
     userId?: IntWithAggregatesFilter | number
   }
 
@@ -7645,6 +7669,7 @@ export namespace Prisma {
   export type UserCreateInput = {
     id: number
     name?: string | null
+    meta?: string | null
     posts?: PostCreateNestedManyWithoutAuthorInput
     profile?: ProfileCreateNestedOneWithoutUserInput
   }
@@ -7652,6 +7677,7 @@ export namespace Prisma {
   export type UserUncheckedCreateInput = {
     id: number
     name?: string | null
+    meta?: string | null
     posts?: PostUncheckedCreateNestedManyWithoutAuthorInput
     profile?: ProfileUncheckedCreateNestedOneWithoutUserInput
   }
@@ -7659,6 +7685,7 @@ export namespace Prisma {
   export type UserUpdateInput = {
     id?: IntFieldUpdateOperationsInput | number
     name?: NullableStringFieldUpdateOperationsInput | string | null
+    meta?: NullableStringFieldUpdateOperationsInput | string | null
     posts?: PostUpdateManyWithoutAuthorNestedInput
     profile?: ProfileUpdateOneWithoutUserNestedInput
   }
@@ -7666,6 +7693,7 @@ export namespace Prisma {
   export type UserUncheckedUpdateInput = {
     id?: IntFieldUpdateOperationsInput | number
     name?: NullableStringFieldUpdateOperationsInput | string | null
+    meta?: NullableStringFieldUpdateOperationsInput | string | null
     posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput
     profile?: ProfileUncheckedUpdateOneWithoutUserNestedInput
   }
@@ -7673,16 +7701,19 @@ export namespace Prisma {
   export type UserCreateManyInput = {
     id: number
     name?: string | null
+    meta?: string | null
   }
 
   export type UserUpdateManyMutationInput = {
     id?: IntFieldUpdateOperationsInput | number
     name?: NullableStringFieldUpdateOperationsInput | string | null
+    meta?: NullableStringFieldUpdateOperationsInput | string | null
   }
 
   export type UserUncheckedUpdateManyInput = {
     id?: IntFieldUpdateOperationsInput | number
     name?: NullableStringFieldUpdateOperationsInput | string | null
+    meta?: NullableStringFieldUpdateOperationsInput | string | null
   }
 
   export type PostCreateInput = {
@@ -7743,41 +7774,48 @@ export namespace Prisma {
   export type ProfileCreateInput = {
     id: number
     bio: string
+    meta?: NullableJsonNullValueInput | InputJsonValue
     user?: UserCreateNestedOneWithoutProfileInput
   }
 
   export type ProfileUncheckedCreateInput = {
     id: number
     bio: string
+    meta?: NullableJsonNullValueInput | InputJsonValue
     userId: number
   }
 
   export type ProfileUpdateInput = {
     id?: IntFieldUpdateOperationsInput | number
     bio?: StringFieldUpdateOperationsInput | string
+    meta?: NullableJsonNullValueInput | InputJsonValue
     user?: UserUpdateOneWithoutProfileNestedInput
   }
 
   export type ProfileUncheckedUpdateInput = {
     id?: IntFieldUpdateOperationsInput | number
     bio?: StringFieldUpdateOperationsInput | string
+    meta?: NullableJsonNullValueInput | InputJsonValue
     userId?: IntFieldUpdateOperationsInput | number
   }
 
   export type ProfileCreateManyInput = {
     id: number
     bio: string
+    meta?: NullableJsonNullValueInput | InputJsonValue
     userId: number
   }
 
   export type ProfileUpdateManyMutationInput = {
     id?: IntFieldUpdateOperationsInput | number
     bio?: StringFieldUpdateOperationsInput | string
+    meta?: NullableJsonNullValueInput | InputJsonValue
   }
 
   export type ProfileUncheckedUpdateManyInput = {
     id?: IntFieldUpdateOperationsInput | number
     bio?: StringFieldUpdateOperationsInput | string
+    meta?: NullableJsonNullValueInput | InputJsonValue
     userId?: IntFieldUpdateOperationsInput | number
   }
 
@@ -8079,6 +8117,7 @@ export namespace Prisma {
   export type UserCountOrderByAggregateInput = {
     id?: SortOrder
     name?: SortOrder
+    meta?: SortOrder
   }
 
   export type UserAvgOrderByAggregateInput = {
@@ -8088,11 +8127,13 @@ export namespace Prisma {
   export type UserMaxOrderByAggregateInput = {
     id?: SortOrder
     name?: SortOrder
+    meta?: SortOrder
   }
 
   export type UserMinOrderByAggregateInput = {
     id?: SortOrder
     name?: SortOrder
+    meta?: SortOrder
   }
 
   export type UserSumOrderByAggregateInput = {
@@ -8173,10 +8214,33 @@ export namespace Prisma {
     nbr?: SortOrder
     authorId?: SortOrder
   }
+  export type JsonNullableFilter = 
+    | PatchUndefined<
+        Either<Required<JsonNullableFilterBase>, Exclude<keyof Required<JsonNullableFilterBase>, 'path'>>,
+        Required<JsonNullableFilterBase>
+      >
+    | OptionalFlat<Omit<Required<JsonNullableFilterBase>, 'path'>>
+
+  export type JsonNullableFilterBase = {
+    equals?: InputJsonValue | JsonNullValueFilter
+    path?: Array<string>
+    string_contains?: string
+    string_starts_with?: string
+    string_ends_with?: string
+    array_contains?: InputJsonValue | null
+    array_starts_with?: InputJsonValue | null
+    array_ends_with?: InputJsonValue | null
+    lt?: InputJsonValue
+    lte?: InputJsonValue
+    gt?: InputJsonValue
+    gte?: InputJsonValue
+    not?: InputJsonValue | JsonNullValueFilter
+  }
 
   export type ProfileCountOrderByAggregateInput = {
     id?: SortOrder
     bio?: SortOrder
+    meta?: SortOrder
     userId?: SortOrder
   }
 
@@ -8200,6 +8264,31 @@ export namespace Prisma {
   export type ProfileSumOrderByAggregateInput = {
     id?: SortOrder
     userId?: SortOrder
+  }
+  export type JsonNullableWithAggregatesFilter = 
+    | PatchUndefined<
+        Either<Required<JsonNullableWithAggregatesFilterBase>, Exclude<keyof Required<JsonNullableWithAggregatesFilterBase>, 'path'>>,
+        Required<JsonNullableWithAggregatesFilterBase>
+      >
+    | OptionalFlat<Omit<Required<JsonNullableWithAggregatesFilterBase>, 'path'>>
+
+  export type JsonNullableWithAggregatesFilterBase = {
+    equals?: InputJsonValue | JsonNullValueFilter
+    path?: Array<string>
+    string_contains?: string
+    string_starts_with?: string
+    string_ends_with?: string
+    array_contains?: InputJsonValue | null
+    array_starts_with?: InputJsonValue | null
+    array_ends_with?: InputJsonValue | null
+    lt?: InputJsonValue
+    lte?: InputJsonValue
+    gt?: InputJsonValue
+    gte?: InputJsonValue
+    not?: InputJsonValue | JsonNullValueFilter
+    _count?: NestedIntNullableFilter
+    _min?: NestedJsonNullableFilter
+    _max?: NestedJsonNullableFilter
   }
 
   export type DateTimeNullableFilter = {
@@ -8250,28 +8339,6 @@ export namespace Prisma {
     gt?: number
     gte?: number
     not?: NestedFloatNullableFilter | number | null
-  }
-  export type JsonNullableFilter = 
-    | PatchUndefined<
-        Either<Required<JsonNullableFilterBase>, Exclude<keyof Required<JsonNullableFilterBase>, 'path'>>,
-        Required<JsonNullableFilterBase>
-      >
-    | OptionalFlat<Omit<Required<JsonNullableFilterBase>, 'path'>>
-
-  export type JsonNullableFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: Array<string>
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
   }
 
   export type BytesNullableFilter = {
@@ -8428,31 +8495,6 @@ export namespace Prisma {
     _sum?: NestedFloatNullableFilter
     _min?: NestedFloatNullableFilter
     _max?: NestedFloatNullableFilter
-  }
-  export type JsonNullableWithAggregatesFilter = 
-    | PatchUndefined<
-        Either<Required<JsonNullableWithAggregatesFilterBase>, Exclude<keyof Required<JsonNullableWithAggregatesFilterBase>, 'path'>>,
-        Required<JsonNullableWithAggregatesFilterBase>
-      >
-    | OptionalFlat<Omit<Required<JsonNullableWithAggregatesFilterBase>, 'path'>>
-
-  export type JsonNullableWithAggregatesFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: Array<string>
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
-    _count?: NestedIntNullableFilter
-    _min?: NestedJsonNullableFilter
-    _max?: NestedJsonNullableFilter
   }
 
   export type BytesNullableWithAggregatesFilter = {
@@ -8851,6 +8893,28 @@ export namespace Prisma {
     _min?: NestedStringNullableFilter
     _max?: NestedStringNullableFilter
   }
+  export type NestedJsonNullableFilter = 
+    | PatchUndefined<
+        Either<Required<NestedJsonNullableFilterBase>, Exclude<keyof Required<NestedJsonNullableFilterBase>, 'path'>>,
+        Required<NestedJsonNullableFilterBase>
+      >
+    | OptionalFlat<Omit<Required<NestedJsonNullableFilterBase>, 'path'>>
+
+  export type NestedJsonNullableFilterBase = {
+    equals?: InputJsonValue | JsonNullValueFilter
+    path?: Array<string>
+    string_contains?: string
+    string_starts_with?: string
+    string_ends_with?: string
+    array_contains?: InputJsonValue | null
+    array_starts_with?: InputJsonValue | null
+    array_ends_with?: InputJsonValue | null
+    lt?: InputJsonValue
+    lte?: InputJsonValue
+    gt?: InputJsonValue
+    gte?: InputJsonValue
+    not?: InputJsonValue | JsonNullValueFilter
+  }
 
   export type NestedDateTimeNullableFilter = {
     equals?: Date | string | null
@@ -8964,28 +9028,6 @@ export namespace Prisma {
     _min?: NestedFloatNullableFilter
     _max?: NestedFloatNullableFilter
   }
-  export type NestedJsonNullableFilter = 
-    | PatchUndefined<
-        Either<Required<NestedJsonNullableFilterBase>, Exclude<keyof Required<NestedJsonNullableFilterBase>, 'path'>>,
-        Required<NestedJsonNullableFilterBase>
-      >
-    | OptionalFlat<Omit<Required<NestedJsonNullableFilterBase>, 'path'>>
-
-  export type NestedJsonNullableFilterBase = {
-    equals?: InputJsonValue | JsonNullValueFilter
-    path?: Array<string>
-    string_contains?: string
-    string_starts_with?: string
-    string_ends_with?: string
-    array_contains?: InputJsonValue | null
-    array_starts_with?: InputJsonValue | null
-    array_ends_with?: InputJsonValue | null
-    lt?: InputJsonValue
-    lte?: InputJsonValue
-    gt?: InputJsonValue
-    gte?: InputJsonValue
-    not?: InputJsonValue | JsonNullValueFilter
-  }
 
   export type NestedBytesNullableWithAggregatesFilter = {
     equals?: Buffer | null
@@ -9024,11 +9066,13 @@ export namespace Prisma {
   export type ProfileCreateWithoutUserInput = {
     id: number
     bio: string
+    meta?: NullableJsonNullValueInput | InputJsonValue
   }
 
   export type ProfileUncheckedCreateWithoutUserInput = {
     id: number
     bio: string
+    meta?: NullableJsonNullValueInput | InputJsonValue
   }
 
   export type ProfileCreateOrConnectWithoutUserInput = {
@@ -9071,22 +9115,26 @@ export namespace Prisma {
   export type ProfileUpdateWithoutUserInput = {
     id?: IntFieldUpdateOperationsInput | number
     bio?: StringFieldUpdateOperationsInput | string
+    meta?: NullableJsonNullValueInput | InputJsonValue
   }
 
   export type ProfileUncheckedUpdateWithoutUserInput = {
     id?: IntFieldUpdateOperationsInput | number
     bio?: StringFieldUpdateOperationsInput | string
+    meta?: NullableJsonNullValueInput | InputJsonValue
   }
 
   export type UserCreateWithoutPostsInput = {
     id: number
     name?: string | null
+    meta?: string | null
     profile?: ProfileCreateNestedOneWithoutUserInput
   }
 
   export type UserUncheckedCreateWithoutPostsInput = {
     id: number
     name?: string | null
+    meta?: string | null
     profile?: ProfileUncheckedCreateNestedOneWithoutUserInput
   }
 
@@ -9103,24 +9151,28 @@ export namespace Prisma {
   export type UserUpdateWithoutPostsInput = {
     id?: IntFieldUpdateOperationsInput | number
     name?: NullableStringFieldUpdateOperationsInput | string | null
+    meta?: NullableStringFieldUpdateOperationsInput | string | null
     profile?: ProfileUpdateOneWithoutUserNestedInput
   }
 
   export type UserUncheckedUpdateWithoutPostsInput = {
     id?: IntFieldUpdateOperationsInput | number
     name?: NullableStringFieldUpdateOperationsInput | string | null
+    meta?: NullableStringFieldUpdateOperationsInput | string | null
     profile?: ProfileUncheckedUpdateOneWithoutUserNestedInput
   }
 
   export type UserCreateWithoutProfileInput = {
     id: number
     name?: string | null
+    meta?: string | null
     posts?: PostCreateNestedManyWithoutAuthorInput
   }
 
   export type UserUncheckedCreateWithoutProfileInput = {
     id: number
     name?: string | null
+    meta?: string | null
     posts?: PostUncheckedCreateNestedManyWithoutAuthorInput
   }
 
@@ -9137,12 +9189,14 @@ export namespace Prisma {
   export type UserUpdateWithoutProfileInput = {
     id?: IntFieldUpdateOperationsInput | number
     name?: NullableStringFieldUpdateOperationsInput | string | null
+    meta?: NullableStringFieldUpdateOperationsInput | string | null
     posts?: PostUpdateManyWithoutAuthorNestedInput
   }
 
   export type UserUncheckedUpdateWithoutProfileInput = {
     id?: IntFieldUpdateOperationsInput | number
     name?: NullableStringFieldUpdateOperationsInput | string | null
+    meta?: NullableStringFieldUpdateOperationsInput | string | null
     posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput
   }
 

--- a/clients/typescript/test/client/generated/index.ts
+++ b/clients/typescript/test/client/generated/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import type { Prisma } from './prismaClient';
-import { type TableSchema, DbSchema, Relation, ElectricClient, type HKT } from 'electric-sql/client/model';
+import type { Prisma } from '../generated/client';
+import { type TableSchema, DbSchema, Relation, ElectricClient, type HKT } from '../../../src/client/model';
 
 /////////////////////////////////////////
 // HELPER FUNCTIONS

--- a/clients/typescript/test/client/generated/index.ts
+++ b/clients/typescript/test/client/generated/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import type { Prisma } from '../generated/client';
-import { type TableSchema, DbSchema, Relation, ElectricClient, type HKT } from '../../../src/client/model';
+import type { Prisma } from './prismaClient';
+import { type TableSchema, DbSchema, Relation, ElectricClient, type HKT } from 'electric-sql/client/model';
 
 /////////////////////////////////////////
 // HELPER FUNCTIONS
@@ -56,7 +56,7 @@ export const NullableJsonNullValueInputSchema = z.enum(['DbNull','JsonNull',])
 
 export const PostScalarFieldEnumSchema = z.enum(['id','title','contents','nbr','authorId']);
 
-export const ProfileScalarFieldEnumSchema = z.enum(['id','bio','userId']);
+export const ProfileScalarFieldEnumSchema = z.enum(['id','bio','meta','userId']);
 
 export const QueryModeSchema = z.enum(['default','insensitive']);
 
@@ -64,7 +64,7 @@ export const SortOrderSchema = z.enum(['asc','desc']);
 
 export const TransactionIsolationLevelSchema = z.enum(['ReadUncommitted','ReadCommitted','RepeatableRead','Serializable']);
 
-export const UserScalarFieldEnumSchema = z.enum(['id','name']);
+export const UserScalarFieldEnumSchema = z.enum(['id','name','meta']);
 /////////////////////////////////////////
 // MODELS
 /////////////////////////////////////////
@@ -87,6 +87,7 @@ export type Items = z.infer<typeof ItemsSchema>
 export const UserSchema = z.object({
   id: z.number().int(),
   name: z.string().nullish(),
+  meta: z.string().nullish(),
 })
 
 export type User = z.infer<typeof UserSchema>
@@ -112,6 +113,7 @@ export type Post = z.infer<typeof PostSchema>
 export const ProfileSchema = z.object({
   id: z.number().int(),
   bio: z.string(),
+  meta: NullableJsonValue.optional(),
   userId: z.number().int(),
 })
 
@@ -190,6 +192,7 @@ export const UserCountOutputTypeSelectSchema: z.ZodType<Prisma.UserCountOutputTy
 export const UserSelectSchema: z.ZodType<Prisma.UserSelect> = z.object({
   id: z.boolean().optional(),
   name: z.boolean().optional(),
+  meta: z.boolean().optional(),
   posts: z.union([z.boolean(),z.lazy(() => PostFindManyArgsSchema)]).optional(),
   profile: z.union([z.boolean(),z.lazy(() => ProfileArgsSchema)]).optional(),
   _count: z.union([z.boolean(),z.lazy(() => UserCountOutputTypeArgsSchema)]).optional(),
@@ -231,6 +234,7 @@ export const ProfileArgsSchema: z.ZodType<Prisma.ProfileArgs> = z.object({
 export const ProfileSelectSchema: z.ZodType<Prisma.ProfileSelect> = z.object({
   id: z.boolean().optional(),
   bio: z.boolean().optional(),
+  meta: z.boolean().optional(),
   userId: z.boolean().optional(),
   user: z.union([z.boolean(),z.lazy(() => UserArgsSchema)]).optional(),
 }).strict()
@@ -341,6 +345,7 @@ export const UserWhereInputSchema: z.ZodType<Prisma.UserWhereInput> = z.object({
   NOT: z.union([ z.lazy(() => UserWhereInputSchema),z.lazy(() => UserWhereInputSchema).array() ]).optional(),
   id: z.union([ z.lazy(() => IntFilterSchema),z.number() ]).optional(),
   name: z.union([ z.lazy(() => StringNullableFilterSchema),z.string() ]).optional().nullable(),
+  meta: z.union([ z.lazy(() => StringNullableFilterSchema),z.string() ]).optional().nullable(),
   posts: z.lazy(() => PostListRelationFilterSchema).optional(),
   profile: z.union([ z.lazy(() => ProfileRelationFilterSchema),z.lazy(() => ProfileWhereInputSchema) ]).optional().nullable(),
 }).strict();
@@ -348,6 +353,7 @@ export const UserWhereInputSchema: z.ZodType<Prisma.UserWhereInput> = z.object({
 export const UserOrderByWithRelationInputSchema: z.ZodType<Prisma.UserOrderByWithRelationInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   name: z.lazy(() => SortOrderSchema).optional(),
+  meta: z.lazy(() => SortOrderSchema).optional(),
   posts: z.lazy(() => PostOrderByRelationAggregateInputSchema).optional(),
   profile: z.lazy(() => ProfileOrderByWithRelationInputSchema).optional()
 }).strict();
@@ -359,6 +365,7 @@ export const UserWhereUniqueInputSchema: z.ZodType<Prisma.UserWhereUniqueInput> 
 export const UserOrderByWithAggregationInputSchema: z.ZodType<Prisma.UserOrderByWithAggregationInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   name: z.lazy(() => SortOrderSchema).optional(),
+  meta: z.lazy(() => SortOrderSchema).optional(),
   _count: z.lazy(() => UserCountOrderByAggregateInputSchema).optional(),
   _avg: z.lazy(() => UserAvgOrderByAggregateInputSchema).optional(),
   _max: z.lazy(() => UserMaxOrderByAggregateInputSchema).optional(),
@@ -372,6 +379,7 @@ export const UserScalarWhereWithAggregatesInputSchema: z.ZodType<Prisma.UserScal
   NOT: z.union([ z.lazy(() => UserScalarWhereWithAggregatesInputSchema),z.lazy(() => UserScalarWhereWithAggregatesInputSchema).array() ]).optional(),
   id: z.union([ z.lazy(() => IntWithAggregatesFilterSchema),z.number() ]).optional(),
   name: z.union([ z.lazy(() => StringNullableWithAggregatesFilterSchema),z.string() ]).optional().nullable(),
+  meta: z.union([ z.lazy(() => StringNullableWithAggregatesFilterSchema),z.string() ]).optional().nullable(),
 }).strict();
 
 export const PostWhereInputSchema: z.ZodType<Prisma.PostWhereInput> = z.object({
@@ -430,6 +438,7 @@ export const ProfileWhereInputSchema: z.ZodType<Prisma.ProfileWhereInput> = z.ob
   NOT: z.union([ z.lazy(() => ProfileWhereInputSchema),z.lazy(() => ProfileWhereInputSchema).array() ]).optional(),
   id: z.union([ z.lazy(() => IntFilterSchema),z.number() ]).optional(),
   bio: z.union([ z.lazy(() => StringFilterSchema),z.string() ]).optional(),
+  meta: z.lazy(() => JsonNullableFilterSchema).optional(),
   userId: z.union([ z.lazy(() => IntFilterSchema),z.number() ]).optional(),
   user: z.union([ z.lazy(() => UserRelationFilterSchema),z.lazy(() => UserWhereInputSchema) ]).optional().nullable(),
 }).strict();
@@ -437,6 +446,7 @@ export const ProfileWhereInputSchema: z.ZodType<Prisma.ProfileWhereInput> = z.ob
 export const ProfileOrderByWithRelationInputSchema: z.ZodType<Prisma.ProfileOrderByWithRelationInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   bio: z.lazy(() => SortOrderSchema).optional(),
+  meta: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
   user: z.lazy(() => UserOrderByWithRelationInputSchema).optional()
 }).strict();
@@ -449,6 +459,7 @@ export const ProfileWhereUniqueInputSchema: z.ZodType<Prisma.ProfileWhereUniqueI
 export const ProfileOrderByWithAggregationInputSchema: z.ZodType<Prisma.ProfileOrderByWithAggregationInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   bio: z.lazy(() => SortOrderSchema).optional(),
+  meta: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
   _count: z.lazy(() => ProfileCountOrderByAggregateInputSchema).optional(),
   _avg: z.lazy(() => ProfileAvgOrderByAggregateInputSchema).optional(),
@@ -463,6 +474,7 @@ export const ProfileScalarWhereWithAggregatesInputSchema: z.ZodType<Prisma.Profi
   NOT: z.union([ z.lazy(() => ProfileScalarWhereWithAggregatesInputSchema),z.lazy(() => ProfileScalarWhereWithAggregatesInputSchema).array() ]).optional(),
   id: z.union([ z.lazy(() => IntWithAggregatesFilterSchema),z.number() ]).optional(),
   bio: z.union([ z.lazy(() => StringWithAggregatesFilterSchema),z.string() ]).optional(),
+  meta: z.lazy(() => JsonNullableWithAggregatesFilterSchema).optional(),
   userId: z.union([ z.lazy(() => IntWithAggregatesFilterSchema),z.number() ]).optional(),
 }).strict();
 
@@ -635,6 +647,7 @@ export const ItemsUncheckedUpdateManyInputSchema: z.ZodType<Prisma.ItemsUnchecke
 export const UserCreateInputSchema: z.ZodType<Prisma.UserCreateInput> = z.object({
   id: z.number().int(),
   name: z.string().optional().nullable(),
+  meta: z.string().optional().nullable(),
   posts: z.lazy(() => PostCreateNestedManyWithoutAuthorInputSchema).optional(),
   profile: z.lazy(() => ProfileCreateNestedOneWithoutUserInputSchema).optional()
 }).strict();
@@ -642,6 +655,7 @@ export const UserCreateInputSchema: z.ZodType<Prisma.UserCreateInput> = z.object
 export const UserUncheckedCreateInputSchema: z.ZodType<Prisma.UserUncheckedCreateInput> = z.object({
   id: z.number().int(),
   name: z.string().optional().nullable(),
+  meta: z.string().optional().nullable(),
   posts: z.lazy(() => PostUncheckedCreateNestedManyWithoutAuthorInputSchema).optional(),
   profile: z.lazy(() => ProfileUncheckedCreateNestedOneWithoutUserInputSchema).optional()
 }).strict();
@@ -649,6 +663,7 @@ export const UserUncheckedCreateInputSchema: z.ZodType<Prisma.UserUncheckedCreat
 export const UserUpdateInputSchema: z.ZodType<Prisma.UserUpdateInput> = z.object({
   id: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+  meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   posts: z.lazy(() => PostUpdateManyWithoutAuthorNestedInputSchema).optional(),
   profile: z.lazy(() => ProfileUpdateOneWithoutUserNestedInputSchema).optional()
 }).strict();
@@ -656,23 +671,27 @@ export const UserUpdateInputSchema: z.ZodType<Prisma.UserUpdateInput> = z.object
 export const UserUncheckedUpdateInputSchema: z.ZodType<Prisma.UserUncheckedUpdateInput> = z.object({
   id: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+  meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   posts: z.lazy(() => PostUncheckedUpdateManyWithoutAuthorNestedInputSchema).optional(),
   profile: z.lazy(() => ProfileUncheckedUpdateOneWithoutUserNestedInputSchema).optional()
 }).strict();
 
 export const UserCreateManyInputSchema: z.ZodType<Prisma.UserCreateManyInput> = z.object({
   id: z.number().int(),
-  name: z.string().optional().nullable()
+  name: z.string().optional().nullable(),
+  meta: z.string().optional().nullable()
 }).strict();
 
 export const UserUpdateManyMutationInputSchema: z.ZodType<Prisma.UserUpdateManyMutationInput> = z.object({
   id: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+  meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
 }).strict();
 
 export const UserUncheckedUpdateManyInputSchema: z.ZodType<Prisma.UserUncheckedUpdateManyInput> = z.object({
   id: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+  meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
 }).strict();
 
 export const PostCreateInputSchema: z.ZodType<Prisma.PostCreateInput> = z.object({
@@ -733,41 +752,48 @@ export const PostUncheckedUpdateManyInputSchema: z.ZodType<Prisma.PostUncheckedU
 export const ProfileCreateInputSchema: z.ZodType<Prisma.ProfileCreateInput> = z.object({
   id: z.number().int(),
   bio: z.string(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
   user: z.lazy(() => UserCreateNestedOneWithoutProfileInputSchema).optional()
 }).strict();
 
 export const ProfileUncheckedCreateInputSchema: z.ZodType<Prisma.ProfileUncheckedCreateInput> = z.object({
   id: z.number().int(),
   bio: z.string(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
   userId: z.number().int()
 }).strict();
 
 export const ProfileUpdateInputSchema: z.ZodType<Prisma.ProfileUpdateInput> = z.object({
   id: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
   user: z.lazy(() => UserUpdateOneWithoutProfileNestedInputSchema).optional()
 }).strict();
 
 export const ProfileUncheckedUpdateInputSchema: z.ZodType<Prisma.ProfileUncheckedUpdateInput> = z.object({
   id: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
   userId: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const ProfileCreateManyInputSchema: z.ZodType<Prisma.ProfileCreateManyInput> = z.object({
   id: z.number().int(),
   bio: z.string(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
   userId: z.number().int()
 }).strict();
 
 export const ProfileUpdateManyMutationInputSchema: z.ZodType<Prisma.ProfileUpdateManyMutationInput> = z.object({
   id: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
 }).strict();
 
 export const ProfileUncheckedUpdateManyInputSchema: z.ZodType<Prisma.ProfileUncheckedUpdateManyInput> = z.object({
   id: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
   userId: z.union([ z.number().int(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
@@ -1068,7 +1094,8 @@ export const PostOrderByRelationAggregateInputSchema: z.ZodType<Prisma.PostOrder
 
 export const UserCountOrderByAggregateInputSchema: z.ZodType<Prisma.UserCountOrderByAggregateInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
-  name: z.lazy(() => SortOrderSchema).optional()
+  name: z.lazy(() => SortOrderSchema).optional(),
+  meta: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const UserAvgOrderByAggregateInputSchema: z.ZodType<Prisma.UserAvgOrderByAggregateInput> = z.object({
@@ -1077,12 +1104,14 @@ export const UserAvgOrderByAggregateInputSchema: z.ZodType<Prisma.UserAvgOrderBy
 
 export const UserMaxOrderByAggregateInputSchema: z.ZodType<Prisma.UserMaxOrderByAggregateInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
-  name: z.lazy(() => SortOrderSchema).optional()
+  name: z.lazy(() => SortOrderSchema).optional(),
+  meta: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const UserMinOrderByAggregateInputSchema: z.ZodType<Prisma.UserMinOrderByAggregateInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
-  name: z.lazy(() => SortOrderSchema).optional()
+  name: z.lazy(() => SortOrderSchema).optional(),
+  meta: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const UserSumOrderByAggregateInputSchema: z.ZodType<Prisma.UserSumOrderByAggregateInput> = z.object({
@@ -1164,9 +1193,26 @@ export const PostSumOrderByAggregateInputSchema: z.ZodType<Prisma.PostSumOrderBy
   authorId: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
+export const JsonNullableFilterSchema: z.ZodType<Prisma.JsonNullableFilter> = z.object({
+  equals: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
+  path: z.string().array().optional(),
+  string_contains: z.string().optional(),
+  string_starts_with: z.string().optional(),
+  string_ends_with: z.string().optional(),
+  array_contains: InputJsonValue.optional().nullable(),
+  array_starts_with: InputJsonValue.optional().nullable(),
+  array_ends_with: InputJsonValue.optional().nullable(),
+  lt: InputJsonValue.optional(),
+  lte: InputJsonValue.optional(),
+  gt: InputJsonValue.optional(),
+  gte: InputJsonValue.optional(),
+  not: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
+}).strict();
+
 export const ProfileCountOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileCountOrderByAggregateInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   bio: z.lazy(() => SortOrderSchema).optional(),
+  meta: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
@@ -1190,6 +1236,25 @@ export const ProfileMinOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileMinO
 export const ProfileSumOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileSumOrderByAggregateInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional()
+}).strict();
+
+export const JsonNullableWithAggregatesFilterSchema: z.ZodType<Prisma.JsonNullableWithAggregatesFilter> = z.object({
+  equals: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
+  path: z.string().array().optional(),
+  string_contains: z.string().optional(),
+  string_starts_with: z.string().optional(),
+  string_ends_with: z.string().optional(),
+  array_contains: InputJsonValue.optional().nullable(),
+  array_starts_with: InputJsonValue.optional().nullable(),
+  array_ends_with: InputJsonValue.optional().nullable(),
+  lt: InputJsonValue.optional(),
+  lte: InputJsonValue.optional(),
+  gt: InputJsonValue.optional(),
+  gte: InputJsonValue.optional(),
+  not: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
+  _count: z.lazy(() => NestedIntNullableFilterSchema).optional(),
+  _min: z.lazy(() => NestedJsonNullableFilterSchema).optional(),
+  _max: z.lazy(() => NestedJsonNullableFilterSchema).optional()
 }).strict();
 
 export const DateTimeNullableFilterSchema: z.ZodType<Prisma.DateTimeNullableFilter> = z.object({
@@ -1240,22 +1305,6 @@ export const FloatNullableFilterSchema: z.ZodType<Prisma.FloatNullableFilter> = 
   gt: z.number().optional(),
   gte: z.number().optional(),
   not: z.union([ z.number(),z.lazy(() => NestedFloatNullableFilterSchema) ]).optional().nullable(),
-}).strict();
-
-export const JsonNullableFilterSchema: z.ZodType<Prisma.JsonNullableFilter> = z.object({
-  equals: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
-  path: z.string().array().optional(),
-  string_contains: z.string().optional(),
-  string_starts_with: z.string().optional(),
-  string_ends_with: z.string().optional(),
-  array_contains: InputJsonValue.optional().nullable(),
-  array_starts_with: InputJsonValue.optional().nullable(),
-  array_ends_with: InputJsonValue.optional().nullable(),
-  lt: InputJsonValue.optional(),
-  lte: InputJsonValue.optional(),
-  gt: InputJsonValue.optional(),
-  gte: InputJsonValue.optional(),
-  not: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
 }).strict();
 
 export const BytesNullableFilterSchema: z.ZodType<Prisma.BytesNullableFilter> = z.object({
@@ -1412,25 +1461,6 @@ export const FloatNullableWithAggregatesFilterSchema: z.ZodType<Prisma.FloatNull
   _sum: z.lazy(() => NestedFloatNullableFilterSchema).optional(),
   _min: z.lazy(() => NestedFloatNullableFilterSchema).optional(),
   _max: z.lazy(() => NestedFloatNullableFilterSchema).optional()
-}).strict();
-
-export const JsonNullableWithAggregatesFilterSchema: z.ZodType<Prisma.JsonNullableWithAggregatesFilter> = z.object({
-  equals: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
-  path: z.string().array().optional(),
-  string_contains: z.string().optional(),
-  string_starts_with: z.string().optional(),
-  string_ends_with: z.string().optional(),
-  array_contains: InputJsonValue.optional().nullable(),
-  array_starts_with: InputJsonValue.optional().nullable(),
-  array_ends_with: InputJsonValue.optional().nullable(),
-  lt: InputJsonValue.optional(),
-  lte: InputJsonValue.optional(),
-  gt: InputJsonValue.optional(),
-  gte: InputJsonValue.optional(),
-  not: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
-  _count: z.lazy(() => NestedIntNullableFilterSchema).optional(),
-  _min: z.lazy(() => NestedJsonNullableFilterSchema).optional(),
-  _max: z.lazy(() => NestedJsonNullableFilterSchema).optional()
 }).strict();
 
 export const BytesNullableWithAggregatesFilterSchema: z.ZodType<Prisma.BytesNullableWithAggregatesFilter> = z.object({
@@ -1830,6 +1860,22 @@ export const NestedStringNullableWithAggregatesFilterSchema: z.ZodType<Prisma.Ne
   _max: z.lazy(() => NestedStringNullableFilterSchema).optional()
 }).strict();
 
+export const NestedJsonNullableFilterSchema: z.ZodType<Prisma.NestedJsonNullableFilter> = z.object({
+  equals: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
+  path: z.string().array().optional(),
+  string_contains: z.string().optional(),
+  string_starts_with: z.string().optional(),
+  string_ends_with: z.string().optional(),
+  array_contains: InputJsonValue.optional().nullable(),
+  array_starts_with: InputJsonValue.optional().nullable(),
+  array_ends_with: InputJsonValue.optional().nullable(),
+  lt: InputJsonValue.optional(),
+  lte: InputJsonValue.optional(),
+  gt: InputJsonValue.optional(),
+  gte: InputJsonValue.optional(),
+  not: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
+}).strict();
+
 export const NestedDateTimeNullableFilterSchema: z.ZodType<Prisma.NestedDateTimeNullableFilter> = z.object({
   equals: z.coerce.date().optional().nullable(),
   in: z.coerce.date().array().optional().nullable(),
@@ -1943,22 +1989,6 @@ export const NestedFloatNullableWithAggregatesFilterSchema: z.ZodType<Prisma.Nes
   _max: z.lazy(() => NestedFloatNullableFilterSchema).optional()
 }).strict();
 
-export const NestedJsonNullableFilterSchema: z.ZodType<Prisma.NestedJsonNullableFilter> = z.object({
-  equals: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
-  path: z.string().array().optional(),
-  string_contains: z.string().optional(),
-  string_starts_with: z.string().optional(),
-  string_ends_with: z.string().optional(),
-  array_contains: InputJsonValue.optional().nullable(),
-  array_starts_with: InputJsonValue.optional().nullable(),
-  array_ends_with: InputJsonValue.optional().nullable(),
-  lt: InputJsonValue.optional(),
-  lte: InputJsonValue.optional(),
-  gt: InputJsonValue.optional(),
-  gte: InputJsonValue.optional(),
-  not: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
-}).strict();
-
 export const NestedBytesNullableWithAggregatesFilterSchema: z.ZodType<Prisma.NestedBytesNullableWithAggregatesFilter> = z.object({
   equals: z.instanceof(Uint8Array).optional().nullable(),
   in: z.instanceof(Uint8Array).array().optional().nullable(),
@@ -1995,12 +2025,14 @@ export const PostCreateManyAuthorInputEnvelopeSchema: z.ZodType<Prisma.PostCreat
 
 export const ProfileCreateWithoutUserInputSchema: z.ZodType<Prisma.ProfileCreateWithoutUserInput> = z.object({
   id: z.number(),
-  bio: z.string()
+  bio: z.string(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
 }).strict();
 
 export const ProfileUncheckedCreateWithoutUserInputSchema: z.ZodType<Prisma.ProfileUncheckedCreateWithoutUserInput> = z.object({
   id: z.number(),
-  bio: z.string()
+  bio: z.string(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
 }).strict();
 
 export const ProfileCreateOrConnectWithoutUserInputSchema: z.ZodType<Prisma.ProfileCreateOrConnectWithoutUserInput> = z.object({
@@ -2043,22 +2075,26 @@ export const ProfileUpsertWithoutUserInputSchema: z.ZodType<Prisma.ProfileUpsert
 export const ProfileUpdateWithoutUserInputSchema: z.ZodType<Prisma.ProfileUpdateWithoutUserInput> = z.object({
   id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
 }).strict();
 
 export const ProfileUncheckedUpdateWithoutUserInputSchema: z.ZodType<Prisma.ProfileUncheckedUpdateWithoutUserInput> = z.object({
   id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
 }).strict();
 
 export const UserCreateWithoutPostsInputSchema: z.ZodType<Prisma.UserCreateWithoutPostsInput> = z.object({
   id: z.number(),
   name: z.string().optional().nullable(),
+  meta: z.string().optional().nullable(),
   profile: z.lazy(() => ProfileCreateNestedOneWithoutUserInputSchema).optional()
 }).strict();
 
 export const UserUncheckedCreateWithoutPostsInputSchema: z.ZodType<Prisma.UserUncheckedCreateWithoutPostsInput> = z.object({
   id: z.number(),
   name: z.string().optional().nullable(),
+  meta: z.string().optional().nullable(),
   profile: z.lazy(() => ProfileUncheckedCreateNestedOneWithoutUserInputSchema).optional()
 }).strict();
 
@@ -2075,24 +2111,28 @@ export const UserUpsertWithoutPostsInputSchema: z.ZodType<Prisma.UserUpsertWitho
 export const UserUpdateWithoutPostsInputSchema: z.ZodType<Prisma.UserUpdateWithoutPostsInput> = z.object({
   id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+  meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   profile: z.lazy(() => ProfileUpdateOneWithoutUserNestedInputSchema).optional()
 }).strict();
 
 export const UserUncheckedUpdateWithoutPostsInputSchema: z.ZodType<Prisma.UserUncheckedUpdateWithoutPostsInput> = z.object({
   id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+  meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   profile: z.lazy(() => ProfileUncheckedUpdateOneWithoutUserNestedInputSchema).optional()
 }).strict();
 
 export const UserCreateWithoutProfileInputSchema: z.ZodType<Prisma.UserCreateWithoutProfileInput> = z.object({
   id: z.number(),
   name: z.string().optional().nullable(),
+  meta: z.string().optional().nullable(),
   posts: z.lazy(() => PostCreateNestedManyWithoutAuthorInputSchema).optional()
 }).strict();
 
 export const UserUncheckedCreateWithoutProfileInputSchema: z.ZodType<Prisma.UserUncheckedCreateWithoutProfileInput> = z.object({
   id: z.number(),
   name: z.string().optional().nullable(),
+  meta: z.string().optional().nullable(),
   posts: z.lazy(() => PostUncheckedCreateNestedManyWithoutAuthorInputSchema).optional()
 }).strict();
 
@@ -2109,12 +2149,14 @@ export const UserUpsertWithoutProfileInputSchema: z.ZodType<Prisma.UserUpsertWit
 export const UserUpdateWithoutProfileInputSchema: z.ZodType<Prisma.UserUpdateWithoutProfileInput> = z.object({
   id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+  meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   posts: z.lazy(() => PostUpdateManyWithoutAuthorNestedInputSchema).optional()
 }).strict();
 
 export const UserUncheckedUpdateWithoutProfileInputSchema: z.ZodType<Prisma.UserUncheckedUpdateWithoutProfileInput> = z.object({
   id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+  meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   posts: z.lazy(() => PostUncheckedUpdateManyWithoutAuthorNestedInputSchema).optional()
 }).strict();
 
@@ -3022,6 +3064,10 @@ export const tableSchemas = {
       [
         "name",
         "TEXT"
+      ],
+      [
+        "meta",
+        "TEXT"
       ]
     ]),
     relations: [
@@ -3111,6 +3157,10 @@ export const tableSchemas = {
       [
         "bio",
         "TEXT"
+      ],
+      [
+        "meta",
+        "JSONB"
       ],
       [
         "userId",

--- a/clients/typescript/test/client/model/table.errors.test.ts
+++ b/clients/typescript/test/client/model/table.errors.test.ts
@@ -31,7 +31,7 @@ test.beforeEach((_t) => {
   )
   db.exec('DROP TABLE IF EXISTS User')
   db.exec(
-    "CREATE TABLE IF NOT EXISTS User('id' int PRIMARY KEY, 'name' varchar);"
+    "CREATE TABLE IF NOT EXISTS User('id' int PRIMARY KEY, 'name' varchar, 'meta' varchar);"
   )
 })
 

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -89,6 +89,10 @@ const profile2 = {
   userId: 2,
 }
 
+// An invalid JSON that will throw if `JSON.parse()` is called
+// on it - the valid string literal would be "'invalid json"'
+const invalidJson = 'invalid json'
+
 const sortById = <T extends { id: number }>(arr: Array<T>) =>
   arr.sort((a, b) => b.id - a.id)
 
@@ -300,7 +304,7 @@ test.serial(
           create: {
             id: 4013,
             name: 'kevin',
-            meta: 'invalid json',
+            meta: invalidJson,
           },
         },
       },
@@ -317,7 +321,7 @@ test.serial(
       user: {
         id: 4013,
         name: 'kevin',
-        meta: 'invalid json',
+        meta: invalidJson,
       },
     })
 
@@ -1136,7 +1140,7 @@ test.serial(
         meta: { bar: 3 },
         user: {
           update: {
-            meta: 'invalid json',
+            meta: invalidJson,
           },
         },
       },
@@ -1150,7 +1154,7 @@ test.serial(
       meta: { bar: 3 },
       user: {
         ...author2,
-        meta: 'invalid json',
+        meta: invalidJson,
       },
     })
   }

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -66,22 +66,26 @@ const post3 = {
 const author1 = {
   id: 1,
   name: 'alice',
+  meta: null,
 }
 
 const profile1 = {
   id: 1,
   bio: 'bio 1',
+  meta: null,
   userId: 1,
 }
 
 const author2 = {
   id: 2,
   name: 'bob',
+  meta: 'information',
 }
 
 const profile2 = {
   id: 2,
   bio: 'bio 2',
+  meta: { foo: 3 },
   userId: 2,
 }
 
@@ -96,11 +100,11 @@ function clear() {
   )
   db.exec('DROP TABLE IF EXISTS User')
   db.exec(
-    "CREATE TABLE IF NOT EXISTS User('id' int PRIMARY KEY, 'name' varchar);"
+    "CREATE TABLE IF NOT EXISTS User('id' int PRIMARY KEY, 'name' varchar, 'meta' varchar);"
   )
   db.exec('DROP TABLE IF EXISTS Profile')
   db.exec(
-    "CREATE TABLE IF NOT EXISTS Profile('id' int PRIMARY KEY, 'bio' varchar, 'userId' int);"
+    "CREATE TABLE IF NOT EXISTS Profile('id' int PRIMARY KEY, 'bio' varchar, 'meta' json, 'userId' int);"
   )
 }
 
@@ -208,6 +212,7 @@ test.serial('create query with nested object for outgoing FK', async (t) => {
   t.deepEqual(relatedUser, {
     id: 1094,
     name: 'kevin',
+    meta: null,
   })
 
   clear()
@@ -238,6 +243,7 @@ test.serial('create query with nested objects for incoming FK', async (t) => {
   t.deepEqual(res, {
     id: 1094,
     name: 'kevin',
+    meta: null,
   })
 
   const relatedPost1 = await postTable.findUnique({
@@ -1064,6 +1070,24 @@ async function populate() {
     data: [profile1, profile2],
   })
 }
+
+test.serial(
+  'findMany can handle related objects with fields of same name and different type',
+  async (t) => {
+    await populate()
+    const res = await profileTable.findMany({
+      where: { id: 2 },
+      include: { user: true },
+    })
+
+    t.deepEqual(res, [
+      {
+        ...profile2,
+        user: author2,
+      },
+    ])
+  }
+)
 
 test.serial(
   'update query can update related object for outgoing FK',

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -288,6 +288,43 @@ test.serial('create query', async (t) => {
   clear()
 })
 
+test.serial(
+  'create query supports nested objects with same column names different types',
+  async (t) => {
+    const res = await profileTable.create({
+      data: {
+        id: 4012,
+        bio: 'test',
+        meta: { bar: 'test' },
+        user: {
+          create: {
+            id: 4013,
+            name: 'kevin',
+            meta: 'invalid json',
+          },
+        },
+      },
+      include: {
+        user: true,
+      },
+    })
+
+    t.deepEqual(res, {
+      id: 4012,
+      bio: 'test',
+      meta: { bar: 'test' },
+      userId: 4013,
+      user: {
+        id: 4013,
+        name: 'kevin',
+        meta: 'invalid json',
+      },
+    })
+
+    clear()
+  }
+)
+
 test.serial('create query supports include argument', async (t) => {
   await userTable.createMany({
     data: [author1, author2],
@@ -1086,6 +1123,36 @@ test.serial(
         user: author2,
       },
     ])
+  }
+)
+
+test.serial(
+  'update query can handle related objects with fields of same name and different type',
+  async (t) => {
+    await populate()
+    const res = await profileTable.update({
+      where: { id: 2 },
+      data: {
+        meta: { bar: 3 },
+        user: {
+          update: {
+            meta: 'invalid json',
+          },
+        },
+      },
+      include: {
+        user: true,
+      },
+    })
+
+    t.deepEqual(res, {
+      ...profile2,
+      meta: { bar: 3 },
+      user: {
+        ...author2,
+        meta: 'invalid json',
+      },
+    })
   }
 )
 

--- a/clients/typescript/test/client/prisma/schema.prisma
+++ b/clients/typescript/test/client/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Items {
 model User {
   id      Int      @id
   name    String?
+  meta    String?
   posts   Post[]
   profile Profile?
 }
@@ -39,6 +40,7 @@ model Post {
 model Profile {
   id     Int    @id
   bio    String
+  meta   Json?
   userId Int    @unique
   user   User?  @relation(fields: [userId], references: [id])
 }


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1095

All operations must remain synchronous and use callbacks and continuations due to some driver limitations, which led to the passing around of `DB` instances that had field transformation and validation incorporated for a specific table.

This was not an issue for most cases as either related tables won't have shared column names, or if they do they are likely to also share the type and thus the field transformation worked.

In cases where a related table might have a column with the same name as the source table but a different type, the `DB` instance would try to validate/transform the related table column with the assumption that it is of the type of the source table column, leading to either 1) incorrect transformations (like stringified jsons) or 2) errors in attempts to transform (like strings being parsed as jsons)

I've added a few tests for this case and a workaround by allowing the DB instances to be cloned with a different table schema. I'd prefer a cleaner solution but it might require significant refactoring so I think this will do the trick for now - the bug is serious enough that I think we should take care of it ASAP.