### PR TITLE
fix(electric): Sync rows that were in the table prior to electrification

### DIFF
--- a/.changeset/real-snakes-drum.md
+++ b/.changeset/real-snakes-drum.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fix the issue where the sync service would not sync any rows that had been present in a table before it was electrified.

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -507,9 +507,16 @@ defmodule Electric.Postgres.Extension do
   @tombstone_prefix "tombstone__"
 
   @doc """
-  Returns a relation that is the shadow table of the passed-in relation.
+  Returns a relation that is the shadow table of the given relation.
   """
+  @spec shadow_of({binary, binary}) :: {binary, binary}
   def shadow_of({schema, table}), do: {@schema, @shadow_prefix <> schema <> "__" <> table}
+
+  @doc """
+  Returns a relation that is the tombstone table of the given relation.
+  """
+  @spec tombstone_of({binary, binary}) :: {binary, binary}
+  def tombstone_of({schema, table}), do: {@schema, @tombstone_prefix <> schema <> "__" <> table}
 
   @doc """
   Returns true if a given relation is a shadow table under current naming convention.

--- a/components/electric/lib/electric/postgres/schema.ex
+++ b/components/electric/lib/electric/postgres/schema.ex
@@ -32,19 +32,6 @@ defmodule Electric.Postgres.Schema do
     end)
   end
 
-  def name(%{name: name}) when is_binary(name) do
-    name(name)
-  end
-
-  # don't double quote things
-  def name("\"" <> _rest = name) when is_binary(name) do
-    name
-  end
-
-  def name(name) when is_binary(name) do
-    "\"" <> name <> "\""
-  end
-
   def num_electrified_tables(schema) do
     Enum.count(schema.tables, fn %{name: name} ->
       not is_extension_relation({name.schema, name.name})

--- a/components/electric/priv/sql_function_templates/install_function__send_self.sql.eex
+++ b/components/electric/priv/sql_function_templates/install_function__send_self.sql.eex
@@ -53,7 +53,7 @@ CREATE OR REPLACE FUNCTION <%= schema() %>.install_function__send_self_and_refer
 
                 PERFORM <%= schema() %>.__tx_store_touched_row('%3$s', '%4$s', __serialized_pk);
 
-                __message := json_build_object('schema', '%3$s', 'table', '%4$s', 'tags', __tags::text, 'data', json_build_object(%9$s), 'pk', array_to_json(%5$s))::text;
+                __message := json_build_object('schema', '%3$s', 'table', '%4$s', 'tags', coalesce(__tags, '{"(epoch,)"}'::electric.tag[])::text, 'data', json_build_object(%9$s), 'pk', array_to_json(%5$s))::text;
 
                 PERFORM pg_logical_emit_message(true, '<%= schema() %>.fk_chain_touch', __message);
                 -- RAISE NOTICE '%%', format('%3$I.%4$I:%%s', row_to_json(__this_row)::text);

--- a/components/electric/test/electric/postgres/extension/alter_shadow_tables_test.exs
+++ b/components/electric/test/electric/postgres/extension/alter_shadow_tables_test.exs
@@ -2,7 +2,7 @@ defmodule Electric.Postgres.Extension.AlterShadowTablesTest do
   use Electric.Extension.Case,
     async: false
 
-  alias Electric.Postgres.Schema
+  alias Electric.Postgres.Extension
 
   require Record
 
@@ -30,12 +30,12 @@ defmodule Electric.Postgres.Extension.AlterShadowTablesTest do
   )
 
   def get_tombstone_schema(conn, schema, table) do
-    {tombstone_schema, tombstone_table} = Schema.tombstone_table_name(schema, table)
+    {tombstone_schema, tombstone_table} = Extension.tombstone_of({schema, table})
     get_table_schema(conn, tombstone_schema, tombstone_table)
   end
 
   def get_shadow_schema(conn, schema, table) do
-    {shadow_schema, shadow_table} = Schema.shadow_table_name(schema, table)
+    {shadow_schema, shadow_table} = Extension.shadow_of({schema, table})
     get_table_schema(conn, shadow_schema, shadow_table)
   end
 

--- a/components/electric/test/support/postgres_test_connection.ex
+++ b/components/electric/test/support/postgres_test_connection.ex
@@ -91,7 +91,7 @@ defmodule Electric.Postgres.TestConnection do
   end
 
   def setup_replicated_db(context) do
-    context = Map.put_new(context, :origin, "tmp-test-subscription")
+    context = Map.put_new(context, :origin, "test-origin")
     origin = Map.fetch!(context, :origin)
 
     # Initialize the test DB to the state which Electric can work with.

--- a/components/electric/test/support/sql_generator.ex
+++ b/components/electric/test/support/sql_generator.ex
@@ -6,11 +6,12 @@ defmodule Electric.Postgres.SQLGenerator do
 
   defmacro __using__(_opts \\ []) do
     quote do
+      import Electric.Postgres.Dialect.Postgresql, only: [quote_ident: 1]
+      import Electric.Postgres.SQLGenerator
+      import StreamData
+
       alias Electric.Postgres.{AST, Schema, Schema.Proto}
       alias Electric.Postgres.SQLGenerator.Table
-
-      import StreamData
-      import Electric.Postgres.SQLGenerator
     end
   end
 

--- a/components/electric/test/support/sql_generator/column.ex
+++ b/components/electric/test/support/sql_generator/column.ex
@@ -1,5 +1,7 @@
 defmodule Electric.Postgres.SQLGenerator.Column do
   use Electric.Postgres.SQLGenerator
+
+  import Electric.Postgres.Dialect.Postgresql, only: [quote_ident: 1]
   import Electric.Postgres.Schema.Proto, only: [is_unique_constraint: 1]
 
   @classes [:int, :str, :bit, :byte, :float, :date, :time, :timestamp, :timetz, :timestamptz]
@@ -496,7 +498,7 @@ defmodule Electric.Postgres.SQLGenerator.Column do
 
       cols ->
         bind(member_of(cols), fn {table_name, column} ->
-          table_reference_to(table_name, Schema.name(column))
+          table_reference_to(table_name, quote_ident(column.name))
         end)
     end
   end

--- a/components/electric/test/support/sql_generator/index.ex
+++ b/components/electric/test/support/sql_generator/index.ex
@@ -64,7 +64,7 @@ defmodule Electric.Postgres.SQLGenerator.Index do
           stmt([
             "ALTER INDEX",
             optional("IF EXISTS"),
-            Schema.name(index),
+            quoted_index_name(index),
             stmt(["RENAME TO", name()])
           ])
         else
@@ -132,7 +132,7 @@ defmodule Electric.Postgres.SQLGenerator.Index do
           # "drop index concurrently does not support cascade"
           if(opts[:cascade], do: nil, else: optional("CONCURRENTLY")),
           optional("IF EXISTS"),
-          Schema.name(index),
+          quoted_index_name(index),
           if(opts[:cascade], do: "CASCADE", else: optional(["CASCADE", "RESTRICT"]))
         ])
     end)
@@ -254,4 +254,7 @@ defmodule Electric.Postgres.SQLGenerator.Index do
       )
     ])
   end
+
+  defp quoted_index_name(%{name: name}), do: quote_ident(name)
+  defp quoted_index_name(name) when is_binary(name), do: quote_ident(name)
 end

--- a/e2e/tests/01.06_replication_of_rows_that_predate_electrification.lux
+++ b/e2e/tests/01.06_replication_of_rows_that_predate_electrification.lux
@@ -1,0 +1,42 @@
+[doc Correct processing of FK relationships for rows insert into the table prior to electrification]
+[include _shared.luxinc]
+
+[invoke setup]
+
+[global project_id=99adf0a5-b3c6-45d7-9986-582e76db4556]
+[global member_id=c197a4ef-0f22-4af1-acb1-bf7200e64900]
+
+[shell proxy_1]
+    # When a row is inserted into the "project_memberships" table further down, that
+    # causes an "electric.fk_chain_touch" message to be sent from Postgres to Electric over the
+    # logical replication stream, with the "tags" field containing tags from the referenced
+    # relation's shadow row. For that reason, it is key to have the INSERT executed before
+    # electrifying the "projects" table in the migration below. This is how we verify that the
+    # message includes valid (default) "tags" even in the absence of a corresponding shadow row.
+    [local sql=
+        """
+        CREATE TABLE projects (
+            id uuid NOT NULL PRIMARY KEY
+        );
+        CREATE TABLE project_memberships (
+            id uuid NOT NULL PRIMARY KEY,
+            project_id uuid NOT NULL REFERENCES projects (id)
+        );
+
+        INSERT INTO projects (id) VALUES ('$project_id');
+
+        ALTER TABLE projects ENABLE ELECTRIC;
+        ALTER TABLE project_memberships ENABLE ELECTRIC;
+        """]
+    [invoke migrate_pg 001 $sql]
+
+[shell pg_1]
+    !INSERT INTO project_memberships (id, project_id) VALUES ('$member_id', '$project_id');
+    ??INSERT 0 1
+
+[shell electric]
+    ??%Electric.Replication.Changes.NewRecord{relation: {"public", "project_memberships"}, \
+       record: %{"id" => "$member_id", "project_id" => "$project_id"
+
+[cleanup]
+   [invoke teardown]


### PR DESCRIPTION
When a table is electrified, its newly created shadow table is empty. If the user table had any rows prior to electrification, they would remain invisible to Electric due to the JOIN between the user table and its shadow table performed when querying for initial subscription data.

Fixes #1106, VAX-1750.