### PR TITLE
fix(client): Fix `op-sqlite` driver not returning results

### DIFF
--- a/.changeset/rude-kids-smoke.md
+++ b/.changeset/rude-kids-smoke.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix `op-sqlite` driver integration using HostObjects and failing to return results

--- a/examples/react-native/src/Example.tsx
+++ b/examples/react-native/src/Example.tsx
@@ -102,7 +102,7 @@ const ExampleComponent = () => {
       <View style={styles.items}>
         {items.map((item: Item, index: number) => (
           <Text key={index} style={styles.item}>
-            Item {index + 1}
+            {item.value}
           </Text>
         ))}
       </View>


### PR DESCRIPTION
The op-sqlite driver returns HostObjects that do not behave the same way as regular JS objects and the parsing was failing somewhere in the field transformations where we use Object methods like `Object.entries`.

See https://ospfranco.notion.site/Gotchas-bedf4f3e9dc1444480fc687d8917751a
Also GH issue: https://github.com/OP-Engineering/op-sqlite/issues/65

The fix shallow clones the row fields into a JS object, probably losing some of the performance benefits gained from using these kinds of objects in the first place but we can revisit it in the future if it becomes significant.