### PR TITLE
chore(docs): Add BYTEA as supported type and note driver support

### DIFF
--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -48,7 +48,7 @@ We are actively working on building out data type support. If you need a type we
 
 - `boolean`
 - `enum` (any user-defined [enumerated type](https://www.postgresql.org/docs/current/datatype-enum.html))
-- `bytea` (see [supported SQLite drivers](#bytea-driver-support))
+- `bytea` / `blob` (see [supported SQLite drivers](#bytea-driver-support))
 - `jsonb`
 - `uuid`
 

--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -61,7 +61,7 @@ In future we plan to support more fine grained merge strategies for JSON data.
 :::info BYTEA support
 ElectricSQL supports storing and syncing `bytea` data but not all SQLite drivers are capable of reading/writing blobs - see table below:
 
-| [wa-sqlite](../../integrations/drivers/web/wa-sqlite.md) | [better-sqlite3](../../integrations/drivers/server/node.md) | [expo-sqlite](../../integrations/drivers/mobile/expo.md) | [expo-sqlite/next](../../integrations/drivers/mobile/expo.md)| [op-sqlite](../../integrations/drivers/mobile/react-native.md) |
+| [wa-sqlite](../../integrations/drivers/web/wa-sqlite.md) | [better-sqlite3](../../integrations/drivers/server/node.md) | [expo-sqlite](../../integrations/drivers/mobile/expo.md?usage=expo-sqlite) | [expo-sqlite/next](../../integrations/drivers/mobile/expo.md?usage=expo-sqlite-next)| [op-sqlite](../../integrations/drivers/mobile/react-native.md) |
 |-----------|----------------|-------------|------------------|-----------|
 | ✅︎*       | ✅︎             | ❌          | ✅︎*              | ✅︎        |
 

--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -48,7 +48,7 @@ We are actively working on building out data type support. If you need a type we
 
 - `boolean`
 - `enum` (any user-defined [enumerated type](https://www.postgresql.org/docs/current/datatype-enum.html))
-- `bytea`
+- `bytea` (see [supported SQLite drivers](#bytea-driver-support))
 - `jsonb`
 - `uuid`
 
@@ -58,14 +58,14 @@ Electric defaults to a Last-Writer-Wins strategy. For JSON this is across the wh
 In future we plan to support more fine grained merge strategies for JSON data.
 :::
 
-:::info BYTEA support
-ElectricSQL supports storing and syncing `bytea` data but not all SQLite drivers are capable of reading/writing blobs - see table below:
+:::info BYTEA support <a name="bytea-driver-support"></a>
+ElectricSQL supports `bytea` data but not all SQLite drivers are capable of reading/writing blobs - see table below:
 
 | [wa-sqlite](../../integrations/drivers/web/wa-sqlite.md) | [better-sqlite3](../../integrations/drivers/server/node.md) | [expo-sqlite](../../integrations/drivers/mobile/expo.md?usage=expo-sqlite) | [expo-sqlite/next](../../integrations/drivers/mobile/expo.md?usage=expo-sqlite-next)| [op-sqlite](../../integrations/drivers/mobile/react-native.md) |
-|-----------|----------------|-------------|------------------|-----------|
-| ✅︎*       | ✅︎             | ❌          | ✅︎*              | ✅︎        |
+|:---------:|:--------------:|:-----------:|:----------------:|:---------:|
+| ✅︎†       | ✅︎             | ❌          | ✅︎†              | ✅︎        |
 
-\* Does not support reading/writing empty byte arrays, e.g. `new Uint8Array([])`
+† Does not support reading/writing empty byte arrays, e.g. `new Uint8Array([])`
 :::
 
 :::caution Enum type caveats

--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -48,6 +48,7 @@ We are actively working on building out data type support. If you need a type we
 
 - `boolean`
 - `enum` (any user-defined [enumerated type](https://www.postgresql.org/docs/current/datatype-enum.html))
+- `bytea`
 - `jsonb`
 - `uuid`
 

--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -58,6 +58,16 @@ Electric defaults to a Last-Writer-Wins strategy. For JSON this is across the wh
 In future we plan to support more fine grained merge strategies for JSON data.
 :::
 
+:::info BYTEA support
+ElectricSQL supports storing and syncing `bytea` data but not all SQLite drivers are capable of reading/writing blobs - see table below:
+
+| [wa-sqlite](../../integrations/drivers/web/wa-sqlite.md) | [better-sqlite3](../../integrations/drivers/server/node.md) | [expo-sqlite](../../integrations/drivers/mobile/expo.md) | [expo-sqlite/next](../../integrations/drivers/mobile/expo.md)| [op-sqlite](../../integrations/drivers/mobile/react-native.md) |
+|-----------|----------------|-------------|------------------|-----------|
+| ✅︎*       | ✅︎             | ❌          | ✅︎*              | ✅︎        |
+
+\* Does not support reading/writing empty byte arrays, e.g. `new Uint8Array([])`
+:::
+
 :::caution Enum type caveats
 Each enum label (aka enum value) must match the regular expression `^[a-zA-Z][a-zA-Z0-9_]*$`. In other words, it should look like a valid identifier.
 


### PR DESCRIPTION
Followup to https://github.com/electric-sql/electric/pull/1101

Adds `bytea` as a supported type (without caveats, at least for now :))

Also adds info block with table of driver support for byte arrays.

Deploy preview PR https://github.com/electric-sql/website/pull/119
Deploy preview: https://deploy-preview-119--electric-sql-website.netlify.app/docs/usage/data-modelling/types#supported-data-types

![image](https://github.com/electric-sql/electric/assets/12274098/44e0147f-1557-4d01-b1f5-3d6818770862)
