### PR TITLE
feat(electric): Persist client reconnection info to the database to enable non-disruptive server restarts

### DIFF
--- a/.changeset/fifty-knives-compete.md
+++ b/.changeset/fifty-knives-compete.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Persist client reconnection info to the database. This allows the sync service to restore its caches after a restart to be able to resume client replication streams and avoid resetting their local databases.

--- a/components/electric/lib/electric/application.ex
+++ b/components/electric/lib/electric/application.ex
@@ -15,7 +15,6 @@ defmodule Electric.Application do
         Electric.Features,
         Electric.Postgres.OidDatabase,
         Electric.Postgres.Proxy.SASL.SCRAMLockedCache,
-        Electric.Satellite.ClientReconnectionInfo,
         Electric.Satellite.ClientManager,
         Electric.Replication.Connectors
       ]

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -27,6 +27,7 @@ defmodule Electric.Postgres.Extension do
   @electrified_tracking_relation "electrified"
   @transaction_marker_relation "transaction_marker"
   @acked_client_lsn_relation "acknowledged_client_lsns"
+  @client_shape_subscriptions_relation "client_shape_subscriptions"
 
   @grants_relation "grants"
   @roles_relation "roles"
@@ -41,6 +42,7 @@ defmodule Electric.Postgres.Extension do
   @electrified_tracking_table electric.(@electrified_tracking_relation)
   @transaction_marker_table electric.(@transaction_marker_relation)
   @acked_client_lsn_table electric.(@acked_client_lsn_relation)
+  @client_shape_subscriptions_table electric.(@client_shape_subscriptions_relation)
 
   @grants_table electric.(@grants_relation)
   @roles_table electric.(@roles_relation)
@@ -109,6 +111,7 @@ defmodule Electric.Postgres.Extension do
   def electrified_tracking_table, do: @electrified_tracking_table
   def transaction_marker_table, do: @transaction_marker_table
   def acked_client_lsn_table, do: @acked_client_lsn_table
+  def client_shape_subscriptions_table, do: @client_shape_subscriptions_table
 
   def grants_table, do: @grants_table
   def roles_table, do: @roles_table
@@ -362,7 +365,8 @@ defmodule Electric.Postgres.Extension do
       Migrations.Migration_20231206130400_ConvertReplicaTriggersToAlways,
       Migrations.Migration_20240110110200_DropUnusedFunctions,
       Migrations.Migration_20240205141200_ReinstallTriggerFunctionWriteCorrectMaxTag,
-      Migrations.Migration_20240213160300_DropGenerateElectrifiedSqlFunction
+      Migrations.Migration_20240213160300_DropGenerateElectrifiedSqlFunction,
+      Migrations.Migration_20240401134100_ClientReconnectionInfoTables
     ]
   end
 

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -30,6 +30,7 @@ defmodule Electric.Postgres.Extension do
   @client_actions_relation "client_actions"
   @client_shape_subscriptions_relation "client_shape_subscriptions"
   @client_checkpoints_relation "client_checkpoints"
+  @client_additional_data_relation "client_additional_data"
 
   @grants_relation "grants"
   @roles_relation "roles"
@@ -47,10 +48,13 @@ defmodule Electric.Postgres.Extension do
   @client_actions_table electric.(@client_actions_relation)
   @client_shape_subscriptions_table electric.(@client_shape_subscriptions_relation)
   @client_checkpoints_table electric.(@client_checkpoints_relation)
+  @client_additional_data_table electric.(@client_additional_data_relation)
 
   @grants_table electric.(@grants_relation)
   @roles_table electric.(@roles_relation)
   @assignments_table electric.(@assignments_relation)
+
+  @client_additional_data_subject_type electric.("client_additional_data_subject")
 
   @all_schema_query ~s(SELECT "schema", "version", "migration_ddl" FROM #{@schema_table} ORDER BY "version" ASC)
   @current_schema_query ~s(SELECT "schema", "version" FROM #{@schema_table} ORDER BY "id" DESC LIMIT 1)
@@ -118,6 +122,7 @@ defmodule Electric.Postgres.Extension do
   def client_actions_table, do: @client_actions_table
   def client_shape_subscriptions_table, do: @client_shape_subscriptions_table
   def client_checkpoints_table, do: @client_checkpoints_table
+  def client_additional_data_table, do: @client_additional_data_table
 
   def grants_table, do: @grants_table
   def roles_table, do: @roles_table
@@ -132,6 +137,8 @@ defmodule Electric.Postgres.Extension do
   def publication_name, do: @publication_name
   def slot_name, do: @slot_name
   def subscription_name, do: @subscription_name
+
+  def client_additional_data_subject_type, do: @client_additional_data_subject_type
 
   defguard is_extension_relation(relation) when elem(relation, 0) == @schema
 

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -28,6 +28,7 @@ defmodule Electric.Postgres.Extension do
   @transaction_marker_relation "transaction_marker"
   @acked_client_lsn_relation "acknowledged_client_lsns"
   @client_shape_subscriptions_relation "client_shape_subscriptions"
+  @client_checkpoints_relation "client_checkpoints"
 
   @grants_relation "grants"
   @roles_relation "roles"
@@ -43,6 +44,7 @@ defmodule Electric.Postgres.Extension do
   @transaction_marker_table electric.(@transaction_marker_relation)
   @acked_client_lsn_table electric.(@acked_client_lsn_relation)
   @client_shape_subscriptions_table electric.(@client_shape_subscriptions_relation)
+  @client_checkpoints_table electric.(@client_checkpoints_relation)
 
   @grants_table electric.(@grants_relation)
   @roles_table electric.(@roles_relation)
@@ -112,6 +114,7 @@ defmodule Electric.Postgres.Extension do
   def transaction_marker_table, do: @transaction_marker_table
   def acked_client_lsn_table, do: @acked_client_lsn_table
   def client_shape_subscriptions_table, do: @client_shape_subscriptions_table
+  def client_checkpoints_table, do: @client_checkpoints_table
 
   def grants_table, do: @grants_table
   def roles_table, do: @roles_table

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -379,7 +379,7 @@ defmodule Electric.Postgres.Extension do
       Migrations.Migration_20240110110200_DropUnusedFunctions,
       Migrations.Migration_20240205141200_ReinstallTriggerFunctionWriteCorrectMaxTag,
       Migrations.Migration_20240213160300_DropGenerateElectrifiedSqlFunction,
-      Migrations.Migration_20240401134100_ClientReconnectionInfoTables
+      Migrations.Migration_20240417131000_ClientReconnectionInfoTables
     ]
   end
 

--- a/components/electric/lib/electric/postgres/extension.ex
+++ b/components/electric/lib/electric/postgres/extension.ex
@@ -27,6 +27,7 @@ defmodule Electric.Postgres.Extension do
   @electrified_tracking_relation "electrified"
   @transaction_marker_relation "transaction_marker"
   @acked_client_lsn_relation "acknowledged_client_lsns"
+  @client_actions_relation "client_actions"
   @client_shape_subscriptions_relation "client_shape_subscriptions"
   @client_checkpoints_relation "client_checkpoints"
 
@@ -43,6 +44,7 @@ defmodule Electric.Postgres.Extension do
   @electrified_tracking_table electric.(@electrified_tracking_relation)
   @transaction_marker_table electric.(@transaction_marker_relation)
   @acked_client_lsn_table electric.(@acked_client_lsn_relation)
+  @client_actions_table electric.(@client_actions_relation)
   @client_shape_subscriptions_table electric.(@client_shape_subscriptions_relation)
   @client_checkpoints_table electric.(@client_checkpoints_relation)
 
@@ -113,6 +115,7 @@ defmodule Electric.Postgres.Extension do
   def electrified_tracking_table, do: @electrified_tracking_table
   def transaction_marker_table, do: @transaction_marker_table
   def acked_client_lsn_table, do: @acked_client_lsn_table
+  def client_actions_table, do: @client_actions_table
   def client_shape_subscriptions_table, do: @client_shape_subscriptions_table
   def client_checkpoints_table, do: @client_checkpoints_table
 

--- a/components/electric/lib/electric/postgres/extension/migrations/20240401134100_client_reconnection_info_tables.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240401134100_client_reconnection_info_tables.ex
@@ -20,6 +20,13 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20240401134100_Client
         shape_requests BYTEA NOT NULL,
         PRIMARY KEY (client_id, subscription_id)
       )
+      """,
+      """
+      CREATE TABLE #{Extension.client_checkpoints_table()} (
+        client_id VARCHAR(64) PRIMARY KEY,
+        pg_wal_pos BIGINT NOT NULL,
+        sent_rows_graph BYTEA NOT NULL
+      )
       """
     ]
   end

--- a/components/electric/lib/electric/postgres/extension/migrations/20240401134100_client_reconnection_info_tables.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240401134100_client_reconnection_info_tables.ex
@@ -27,6 +27,14 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20240401134100_Client
         pg_wal_pos BIGINT NOT NULL,
         sent_rows_graph BYTEA NOT NULL
       )
+      """,
+      """
+      CREATE TABLE #{Extension.client_actions_table()} (
+        client_id VARCHAR(64),
+        txid #{txid_type} NOT NULL,
+        subquery_actions BYTEA NOT NULL,
+        PRIMARY KEY (client_id, txid)
+      )
       """
     ]
   end

--- a/components/electric/lib/electric/postgres/extension/migrations/20240401134100_client_reconnection_info_tables.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240401134100_client_reconnection_info_tables.ex
@@ -1,0 +1,29 @@
+defmodule Electric.Postgres.Extension.Migrations.Migration_20240401134100_ClientReconnectionInfoTables do
+  alias Electric.Postgres.Extension
+
+  @behaviour Extension.Migration
+
+  @impl true
+  def version, do: 2024_04_01_13_41_00
+
+  @impl true
+  def up(_schema) do
+    txid_type = Extension.txid_type()
+
+    [
+      """
+      CREATE TABLE #{Extension.client_shape_subscriptions_table()} (
+        client_id VARCHAR(64),
+        subscription_id UUID,
+        min_txid #{txid_type} NOT NULL,
+        ord BIGINT NOT NULL,
+        shape_requests BYTEA NOT NULL,
+        PRIMARY KEY (client_id, subscription_id)
+      )
+      """
+    ]
+  end
+
+  @impl true
+  def down(_), do: []
+end

--- a/components/electric/lib/electric/postgres/extension/migrations/20240401134100_client_reconnection_info_tables.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240401134100_client_reconnection_info_tables.ex
@@ -8,6 +8,7 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20240401134100_Client
 
   @impl true
   def up(_schema) do
+    additional_data_subject_enum = Extension.client_additional_data_subject_type()
     txid_type = Extension.txid_type()
 
     [
@@ -34,6 +35,24 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20240401134100_Client
         txid #{txid_type} NOT NULL,
         subquery_actions BYTEA NOT NULL,
         PRIMARY KEY (client_id, txid)
+      )
+      """,
+      """
+      CREATE TYPE #{additional_data_subject_enum} AS ENUM (
+        'transaction',
+        'subscription'
+      )
+      """,
+      """
+      CREATE TABLE #{Extension.client_additional_data_table()} (
+        client_id VARCHAR(64),
+        min_txid #{txid_type} NOT NULL,
+        ord BIGINT NOT NULL,
+        subject #{additional_data_subject_enum} NOT NULL,
+        subscription_id UUID,
+        graph_diff BYTEA NOT NULL,
+        included_txns BIGINT[] NOT NULL,
+        PRIMARY KEY (client_id, ord)
       )
       """
     ]

--- a/components/electric/lib/electric/postgres/extension/migrations/20240417131000_client_reconnection_info_tables.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240417131000_client_reconnection_info_tables.ex
@@ -1,10 +1,10 @@
-defmodule Electric.Postgres.Extension.Migrations.Migration_20240401134100_ClientReconnectionInfoTables do
+defmodule Electric.Postgres.Extension.Migrations.Migration_20240417131000_ClientReconnectionInfoTables do
   alias Electric.Postgres.Extension
 
   @behaviour Extension.Migration
 
   @impl true
-  def version, do: 2024_04_01_13_41_00
+  def version, do: 2024_04_17_13_10_00
 
   @impl true
   def up(_schema) do

--- a/components/electric/lib/electric/postgres/extension/migrations/20240417131000_client_reconnection_info_tables.ex
+++ b/components/electric/lib/electric/postgres/extension/migrations/20240417131000_client_reconnection_info_tables.ex
@@ -52,7 +52,7 @@ defmodule Electric.Postgres.Extension.Migrations.Migration_20240417131000_Client
         subscription_id UUID,
         graph_diff BYTEA NOT NULL,
         included_txns BIGINT[] NOT NULL,
-        PRIMARY KEY (client_id, ord)
+        PRIMARY KEY (client_id, min_txid, ord)
       )
       """
     ]

--- a/components/electric/lib/electric/postgres/repo.ex
+++ b/components/electric/lib/electric/postgres/repo.ex
@@ -1,0 +1,38 @@
+defmodule Electric.Postgres.Repo do
+  @moduledoc """
+  Ecto repo for managing a pool of DB connections.
+
+  This repo must be started as part of a `PostgresConnectorSup` supervision tree, configured
+  with the same `connector_config` that its siblings use. Under the hood, it will start a
+  dynamic Ecto repo that can be looked up by the name returned from `name/1`.
+
+  Connections in the pool will use SSL if the Postgres connector is configured with
+  `DATABASE_REQUIRE_SSL=true`. This is different from `epgsql`'s default behaviour where it
+  tries to use SSL first and only falls back to using plain TCP if that fails.
+  """
+
+  use Ecto.Repo, otp_app: :electric, adapter: Ecto.Adapters.Postgres
+
+  alias Electric.Replication.Connectors
+
+  @default_pool_size 10
+
+  def config(connector_config, opts) do
+    origin = Connectors.origin(connector_config)
+    conn_opts = Connectors.get_connection_opts(connector_config)
+
+    [
+      name: name(origin),
+      hostname: conn_opts.host,
+      port: conn_opts.port,
+      username: conn_opts.username,
+      password: conn_opts.password,
+      database: conn_opts.database,
+      ssl: conn_opts.ssl == :required,
+      pool_size: Keyword.get(opts, :pool_size, @default_pool_size),
+      log: false
+    ]
+  end
+
+  def name(origin), do: :"#{inspect(__MODULE__)}:#{origin}"
+end

--- a/components/electric/lib/electric/postgres/repo/client.ex
+++ b/components/electric/lib/electric/postgres/repo/client.ex
@@ -6,6 +6,7 @@ defmodule Electric.Postgres.Repo.Client do
   """
 
   alias Electric.Postgres.Repo
+  alias Electric.Replication.Connectors
 
   @type row :: [term]
 

--- a/components/electric/lib/electric/postgres/repo/client.ex
+++ b/components/electric/lib/electric/postgres/repo/client.ex
@@ -1,0 +1,60 @@
+defmodule Electric.Postgres.Repo.Client do
+  @moduledoc """
+  Postgres database client that relies on `Electric.Postgres.Repo`.
+
+  Uses the repo to check out connections from the pool and execute queries on them.
+  """
+
+  alias Electric.Postgres.Repo
+
+  @type row :: [term]
+
+  @doc """
+  Execute the given function using a pooled DB connection.
+
+  The pool is managed by `Electric.Postgres.Repo` and so the passed function should use the
+  repo module's API for querying and executing SQL statements instead of `epgsql`. See
+  `pooled_query!/3` and `query!/2` below for a high-level API built on top of the Ecto repo.
+  """
+  @spec checkout_from_pool(Connectors.origin(), (-> any)) :: any
+  def checkout_from_pool(origin, fun) when is_binary(origin) and is_function(fun, 0) do
+    Repo.put_dynamic_repo(Repo.name(origin))
+    Repo.checkout(fun)
+  end
+
+  @doc """
+  Execute the given function in a single transaction using a pooled DB connection.
+
+  The pool is managed by `Electric.Postgres.Repo`, see `checkout/2` for more info.
+  """
+  def pooled_transaction(origin, fun) when is_binary(origin) and is_function(fun, 0) do
+    Repo.put_dynamic_repo(Repo.name(origin))
+    Repo.transaction(fun)
+  end
+
+  @doc """
+  Execute the given SQL query/statement using a pooled DB connection.
+
+  The pool is managed by `Electric.Postgres.Repo` and the query is executed by invoking `query!/2`.
+  """
+  @spec pooled_query!(Connectors.origin(), String.t(), [term]) :: {[String.t()], [tuple()]}
+  def pooled_query!(origin, query_str, params) when is_binary(origin) do
+    checkout_from_pool(origin, fn -> query!(query_str, params) end)
+  end
+
+  @doc """
+  Execute the given SQL query/statement in the context of a checked-out DB connection.
+
+  This function assumes a connection has been checked out from a pool managed by
+  `Electric.Postgres.Repo` and will fail if that's not the case. Use this to issue multiple
+  queries/statements on a single DB connection by wrapping them in an anonymous function and
+  passing it to `checkout_from_pool/2` or `pooled_transaction/2`.
+  """
+  @spec query!(String.t(), [term]) :: {[String.t()], [row]}
+  def query!(query_str, params \\ []) when is_binary(query_str) and is_list(params) do
+    true = Repo.checked_out?()
+
+    %Postgrex.Result{columns: columns, rows: rows} = Repo.query!(query_str, params)
+    {columns, rows}
+  end
+end

--- a/components/electric/lib/electric/replication/postgres/client.ex
+++ b/components/electric/lib/electric/replication/postgres/client.ex
@@ -8,15 +8,14 @@ defmodule Electric.Replication.Postgres.Client do
 
   import Electric.Postgres.Dialect.Postgresql, only: [quote_ident: 1]
 
-  alias Electric.Postgres.{Extension, Lsn, Repo}
+  alias Electric.Postgres.Extension
+  alias Electric.Postgres.Lsn
   alias Electric.Replication.Connectors
 
   require Logger
 
   @type connection :: pid
   @type publication :: String.t()
-
-  @type row :: [term]
 
   @spec connect(Connectors.connection_opts()) ::
           {:ok, connection :: pid()} | {:error, reason :: :epgsql.connect_error()}
@@ -27,55 +26,6 @@ defmodule Electric.Replication.Postgres.Client do
       Connectors.pop_extraneous_conn_opts(conn_opts)
 
     :epgsql.connect(ip_addr, username, password, epgsql_conn_opts)
-  end
-
-  @doc """
-  Execute the given function using a pooled DB connection.
-
-  The pool is managed by `Electric.Postgres.Repo` and so the passed function should use the
-  repo module's API for querying and executing SQL statements instead of `epgsql`. See
-  `pooled_query!/3` and `query!/2` below for a high-level API built on top of the Ecto repo.
-  """
-  @spec checkout_from_pool(Connectors.origin(), (-> any)) :: any
-  def checkout_from_pool(origin, fun) when is_binary(origin) and is_function(fun, 0) do
-    Repo.put_dynamic_repo(Repo.name(origin))
-    Repo.checkout(fun)
-  end
-
-  @doc """
-  Execute the given function in a single transaction using a pooled DB connection.
-
-  The pool is managed by `Electric.Postgres.Repo`, see `checkout/2` for more info.
-  """
-  def pooled_transaction(origin, fun) when is_binary(origin) and is_function(fun, 0) do
-    Repo.put_dynamic_repo(Repo.name(origin))
-    Repo.transaction(fun)
-  end
-
-  @doc """
-  Execute the given SQL query/statement using a pooled DB connection.
-
-  The pool is managed by `Electric.Postgres.Repo` and the query is executed by invoking `query!/2`.
-  """
-  @spec pooled_query!(Connectors.origin(), String.t(), [term]) :: {[String.t()], [tuple()]}
-  def pooled_query!(origin, query_str, params) when is_binary(origin) do
-    checkout_from_pool(origin, fn -> query!(query_str, params) end)
-  end
-
-  @doc """
-  Execute the given SQL query/statement in the context of a checked-out DB connection.
-
-  This function assumes a connection has been checked out from a pool managed by
-  `Electric.Postgres.Repo` and will fail if that's not the case. Use this to issue multiple
-  queries/statements on a single DB connection by wrapping them in an anonymous function and
-  passing it to `checkout_from_pool/2` or `pooled_transaction/2`.
-  """
-  @spec query!(String.t(), [term]) :: {[String.t()], [row]}
-  def query!(query_str, params \\ []) when is_binary(query_str) and is_list(params) do
-    true = Repo.checked_out?()
-
-    %Postgrex.Result{columns: columns, rows: rows} = Repo.query!(query_str, params)
-    {columns, rows}
   end
 
   @spec with_conn(Connectors.connection_opts(), fun()) :: term() | {:error, term()}

--- a/components/electric/lib/electric/replication/postgres/client.ex
+++ b/components/electric/lib/electric/replication/postgres/client.ex
@@ -16,6 +16,8 @@ defmodule Electric.Replication.Postgres.Client do
   @type connection :: pid
   @type publication :: String.t()
 
+  @type row :: [term]
+
   @spec connect(Connectors.connection_opts()) ::
           {:ok, connection :: pid()} | {:error, reason :: :epgsql.connect_error()}
   def connect(conn_opts) do
@@ -58,7 +60,7 @@ defmodule Electric.Replication.Postgres.Client do
   queries/statements on a single DB connection by wrapping them in an anonymous function and
   passing it to `with_pool/2`.
   """
-  @spec query!(String.t(), [term]) :: {[String.t()], [tuple()]}
+  @spec query!(String.t(), [term]) :: {[String.t()], [row]}
   def query!(query_str, params \\ []) when is_binary(query_str) and is_list(params) do
     true = Repo.checked_out?()
 

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -40,6 +40,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
     ]
 
     children = [
+      {Electric.Postgres.Repo, Electric.Postgres.Repo.config(connector_config, [])},
       {Electric.Satellite.ClientReconnectionInfo, connector_config},
       {SchemaCache, connector_config},
       {SatelliteCollectorProducer, connector_config},

--- a/components/electric/lib/electric/replication/postgres_connector_sup.ex
+++ b/components/electric/lib/electric/replication/postgres_connector_sup.ex
@@ -40,6 +40,7 @@ defmodule Electric.Replication.PostgresConnectorSup do
     ]
 
     children = [
+      {Electric.Satellite.ClientReconnectionInfo, connector_config},
       {SchemaCache, connector_config},
       {SatelliteCollectorProducer, connector_config},
       {Postgres.LogicalReplicationProducer, connector_config},

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -765,9 +765,9 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       Client.query!("SELECT * FROM #{Extension.client_checkpoints_table()}")
 
     checkpoints =
-      for {client_id, wal_pos, sent_rows_graph} <- rows do
+      Enum.map(rows, fn [client_id, wal_pos, sent_rows_graph] ->
         {client_id, wal_pos, :erlang.binary_to_term(sent_rows_graph)}
-      end
+      end)
 
     :ets.insert(checkpoint_table, checkpoints)
   end
@@ -777,10 +777,10 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       Client.query!("SELECT * FROM #{Extension.client_shape_subscriptions_table()}")
 
     subscriptions =
-      for {client_id, subscription_id, xmin, pos, shape_requests_bin} <- rows do
-        {{client_id, decode_uuid(subscription_id)}, String.to_integer(xmin),
+      Enum.map(rows, fn [client_id, subscription_id, xmin, pos, shape_requests_bin] ->
+        {{client_id, decode_uuid(subscription_id)}, xmin,
          :erlang.binary_to_term(shape_requests_bin), pos}
-      end
+      end)
 
     :ets.insert(subscriptions_table, subscriptions)
   end
@@ -797,10 +797,18 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
      ], rows} = Client.query!("SELECT * FROM #{Extension.client_additional_data_table()}")
 
     records =
-      for {client_id, xmin, pos, subject, subscription_id, graph_diff, included_txns} <- rows do
-        {{client_id, String.to_integer(xmin), pos, String.to_existing_atom(subject),
-          decode_uuid(subscription_id)}, :erlang.binary_to_term(graph_diff), included_txns}
-      end
+      Enum.map(rows, fn [
+                          client_id,
+                          xmin,
+                          pos,
+                          subject,
+                          subscription_id,
+                          graph_diff,
+                          included_txns
+                        ] ->
+        {{client_id, xmin, pos, String.to_existing_atom(subject), decode_uuid(subscription_id)},
+         :erlang.binary_to_term(graph_diff), included_txns}
+      end)
 
     :ets.insert(additional_data_table, records)
   end
@@ -810,9 +818,9 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       Client.query!("SELECT * FROM #{Extension.client_actions_table()}")
 
     actions =
-      for {client_id, txid, actions_bin} <- rows do
-        {{client_id, String.to_integer(txid)}, :erlang.binary_to_term(actions_bin)}
-      end
+      Enum.map(rows, fn [client_id, txid, actions_bin] ->
+        {{client_id, txid}, :erlang.binary_to_term(actions_bin)}
+      end)
 
     :ets.insert(actions_table, actions)
   end

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -247,7 +247,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
   Once the client acknowledges a transaction, we can advance the graph, deleting the previous
   version. We may have sent additional data to the client (both as subscription data and as
   additional data for transactions), and that was stored using `store_subscription_data/3`
-  and `store_additional_tx_data/6`. This is useful in case the client reconnects having seen
+  and `store_additional_txn_data/6`. This is useful in case the client reconnects having seen
   the data - we can correctly advance the graph using both transactions and additional data.
 
   To accommodate a case where the client reconnects **not** having seen data for some transaction,
@@ -495,7 +495,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
   Store graph diff for additional data that was queried from PostgreSQL in
   response to a set of transactions.
   """
-  def store_additional_tx_data(client_id, ref, xmin, pos, included_txns, graph_diff) do
+  def store_additional_txn_data(client_id, ref, xmin, pos, included_txns, graph_diff) do
     :ets.insert(
       @additional_data_ets,
       {{client_id, xmin, pos, :transaction, ref}, graph_diff, included_txns}

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -761,8 +761,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
   end
 
   defp restore_checkpoint_cache(checkpoint_table) do
-    {["client_id", "pg_wal_pos", "sent_rows_graph"], rows} =
-      Client.query!("SELECT * FROM #{Extension.client_checkpoints_table()}")
+    {_cols, rows} = Client.query!("SELECT * FROM #{Extension.client_checkpoints_table()}")
 
     checkpoints =
       Enum.map(rows, fn [client_id, wal_pos, sent_rows_graph] ->
@@ -773,8 +772,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
   end
 
   defp restore_subscriptions_cache(subscriptions_table) do
-    {["client_id", "subscription_id", "min_txid", "ord", "shape_requests"], rows} =
-      Client.query!("SELECT * FROM #{Extension.client_shape_subscriptions_table()}")
+    {_cols, rows} = Client.query!("SELECT * FROM #{Extension.client_shape_subscriptions_table()}")
 
     subscriptions =
       Enum.map(rows, fn [client_id, subscription_id, xmin, pos, shape_requests_bin] ->
@@ -786,15 +784,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
   end
 
   defp restore_additional_data_cache(additional_data_table) do
-    {[
-       "client_id",
-       "min_txid",
-       "ord",
-       "subject",
-       "subscription_id",
-       "graph_diff",
-       "included_txns"
-     ], rows} = Client.query!("SELECT * FROM #{Extension.client_additional_data_table()}")
+    {_cols, rows} = Client.query!("SELECT * FROM #{Extension.client_additional_data_table()}")
 
     records =
       Enum.map(rows, fn [
@@ -814,8 +804,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
   end
 
   defp restore_actions_cache(actions_table) do
-    {["client_id", "txid", "subquery_actions"], rows} =
-      Client.query!("SELECT * FROM #{Extension.client_actions_table()}")
+    {_cols, rows} = Client.query!("SELECT * FROM #{Extension.client_actions_table()}")
 
     actions =
       Enum.map(rows, fn [client_id, txid, actions_bin] ->

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -792,6 +792,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       end)
 
     :ets.insert(checkpoint_table, checkpoints)
+    Logger.debug("Cached #{length(checkpoints)} client_checkpoints from the DB")
   end
 
   defp restore_subscriptions_cache(subscriptions_table) do
@@ -804,6 +805,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       end)
 
     :ets.insert(subscriptions_table, subscriptions)
+    Logger.debug("Cached #{length(subscriptions)} client_shape_subscriptions from the DB")
   end
 
   defp restore_additional_data_cache(additional_data_table) do
@@ -824,6 +826,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       end)
 
     :ets.insert(additional_data_table, records)
+    Logger.debug("Cached #{length(records)} client_additional_data records from the DB")
   end
 
   defp restore_actions_cache(actions_table) do
@@ -835,6 +838,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       end)
 
     :ets.insert(actions_table, actions)
+    Logger.debug("Cached #{length(actions)} client_actions from the DB")
   end
 
   # The encode_uuid() and decode_uuid() functions are needed here due to incomplete adoption

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -605,12 +605,6 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
     )
   VALUES
     ($1, $2, $3, $4, $5)
-  ON CONFLICT
-    (client_id, subscription_id)
-  DO UPDATE SET
-    min_txid = excluded.min_txid,
-    ord = excluded.ord,
-    shape_requests = excluded.shape_requests
   """
 
   @doc """

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -211,7 +211,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
   def clear_all_data(client_id) do
     :ets.match_delete(@actions_ets, {{client_id, :_}, :_})
     :ets.match_delete(@subscriptions_ets, {{client_id, :_}, :_, :_, :_})
-    :ets.match_delete(@additional_data_ets, {{client_id, :_, :_, :_, :_}, :_})
+    :ets.match_delete(@additional_data_ets, {{client_id, :_, :_, :_, :_}, :_, :_})
     :ets.delete(@checkpoint_ets, client_id)
   end
 
@@ -227,7 +227,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
 
     :ets.match_delete(
       @additional_data_ets,
-      {{client_id, :_, :_, :subscription, subscription_id}, :_}
+      {{client_id, :_, :_, :subscription, subscription_id}, :_, :_}
     )
   end
 
@@ -331,7 +331,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       # while additional data diffs are stored as soon as they were received, and
       # acknowledged additional data is removed while advancing. So we can just
       # delete all additional data here and return all the actions.
-      :ets.match_delete(@additional_data_ets, {{client_id, :_, :_, :_, :_}, :_})
+      :ets.match_delete(@additional_data_ets, {{client_id, :_, :_, :_, :_}, :_, :_})
 
       actions =
         @actions_ets

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -151,9 +151,9 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
 
   alias Electric.Postgres.CachedWal
   alias Electric.Postgres.Extension
+  alias Electric.Postgres.Repo.Client
   alias Electric.Replication.Connectors
   alias Electric.Replication.Changes.Transaction
-  alias Electric.Replication.Postgres.Client
   alias Electric.Replication.Shapes
   alias Electric.Replication.Shapes.ShapeRequest
   alias Electric.Utils

--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -375,7 +375,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
 
               {graph, pending_actions}
 
-            {:subscription, _id, diff, _}, {graph, pending_actions} ->
+            {:subscription, _id, diff, []}, {graph, pending_actions} ->
               graph = merge_in_graph_diff(graph, diff)
               {graph, pending_actions}
           end)

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -15,6 +15,7 @@ defmodule Electric.Satellite.Protocol do
   alias Electric.Postgres.Schema
   alias Electric.Postgres.CachedWal
   alias Electric.Replication.Changes
+  alias Electric.Replication.Postgres.Client
   alias Electric.Replication.Shapes
   alias Electric.Replication.Shapes.ShapeRequest
   alias Electric.Satellite.Serialization
@@ -539,7 +540,9 @@ defmodule Electric.Satellite.Protocol do
       end
     else
       # Once the client is outside the WAL window, we are assuming the client will reset its local state, so we will too.
-      ClientReconnectionInfo.clear_all_data(state.origin, state.client_id)
+      Client.with_pool(state.origin, fn ->
+        ClientReconnectionInfo.clear_all_data(state.client_id)
+      end)
 
       {:error,
        start_replication_error(:BEHIND_WINDOW, "Cannot catch up to the server's current state")}

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -9,13 +9,12 @@ defmodule Electric.Satellite.Protocol do
 
   alias SatSubsResp.SatSubsError
 
-  alias Electric.Utils
-  alias Electric.Replication.Changes.Transaction
-  alias Electric.Postgres.Extension.SchemaCache
-  alias Electric.Postgres.Schema
   alias Electric.Postgres.CachedWal
+  alias Electric.Postgres.Extension.SchemaCache
+  alias Electric.Postgres.Repo.Client
+  alias Electric.Postgres.Schema
   alias Electric.Replication.Changes
-  alias Electric.Replication.Postgres.Client
+  alias Electric.Replication.Changes.Transaction
   alias Electric.Replication.Shapes
   alias Electric.Replication.Shapes.ShapeRequest
   alias Electric.Satellite.Serialization
@@ -23,6 +22,7 @@ defmodule Electric.Satellite.Protocol do
   alias Electric.Satellite.WriteValidation
   alias Electric.Satellite.ClientReconnectionInfo
   alias Electric.Telemetry.Metrics
+  alias Electric.Utils
 
   alias Electric.Satellite.Protocol.{State, InRep, OutRep, Telemetry}
   import Electric.Satellite.Protocol.State, only: :macros

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -752,7 +752,7 @@ defmodule Electric.Satellite.Protocol do
     # but more testing is required.
 
     # Store this data in case of disconnect until acknowledged
-    ClientReconnectionInfo.store_additional_tx_data(
+    ClientReconnectionInfo.store_additional_txn_data(
       state.client_id,
       ref,
       xmin,

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -698,7 +698,7 @@ defmodule Electric.Satellite.Protocol do
     {graph_diff, _, _} = data
 
     # Store this data in case of disconnect until acknowledged
-    ClientReconnectionInfo.store_subscription_data(state.client_id, id, graph_diff)
+    ClientReconnectionInfo.store_subscription_data(state.origin, state.client_id, id, graph_diff)
 
     if is_paused_on_subscription(state, id) do
       # We're currently waiting for data from this subscription, we can send it immediately
@@ -753,6 +753,7 @@ defmodule Electric.Satellite.Protocol do
 
     # Store this data in case of disconnect until acknowledged
     ClientReconnectionInfo.store_additional_txn_data(
+      state.origin,
       state.client_id,
       xmin,
       ref,

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -540,7 +540,7 @@ defmodule Electric.Satellite.Protocol do
       end
     else
       # Once the client is outside the WAL window, we are assuming the client will reset its local state, so we will too.
-      Client.checkout_from_pool(state.origin, fn ->
+      Client.pooled_transaction(state.origin, fn ->
         ClientReconnectionInfo.clear_all_data(state.client_id)
       end)
 

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -11,7 +11,6 @@ defmodule Electric.Satellite.Protocol do
 
   alias Electric.Postgres.CachedWal
   alias Electric.Postgres.Extension.SchemaCache
-  alias Electric.Postgres.Repo.Client
   alias Electric.Postgres.Schema
   alias Electric.Replication.Changes
   alias Electric.Replication.Changes.Transaction
@@ -540,9 +539,7 @@ defmodule Electric.Satellite.Protocol do
       end
     else
       # Once the client is outside the WAL window, we are assuming the client will reset its local state, so we will too.
-      Client.pooled_transaction(state.origin, fn ->
-        ClientReconnectionInfo.clear_all_data!(state.client_id)
-      end)
+      ClientReconnectionInfo.clear_all_data!(state.origin, state.client_id)
 
       {:error,
        start_replication_error(:BEHIND_WINDOW, "Cannot catch up to the server's current state")}

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -448,7 +448,7 @@ defmodule Electric.Satellite.Protocol do
         )
 
         {:ok, _} =
-          ClientReconnectionInfo.advance_checkpoint(state.client_id,
+          ClientReconnectionInfo.advance_checkpoint!(state.client_id,
             ack_point: sent_pos,
             including_data: msg.additional_data_source_ids,
             including_subscriptions: msg.subscription_ids,
@@ -541,7 +541,7 @@ defmodule Electric.Satellite.Protocol do
     else
       # Once the client is outside the WAL window, we are assuming the client will reset its local state, so we will too.
       Client.pooled_transaction(state.origin, fn ->
-        ClientReconnectionInfo.clear_all_data(state.client_id)
+        ClientReconnectionInfo.clear_all_data!(state.client_id)
       end)
 
       {:error,
@@ -701,7 +701,7 @@ defmodule Electric.Satellite.Protocol do
     {graph_diff, _, _} = data
 
     # Store this data in case of disconnect until acknowledged
-    ClientReconnectionInfo.store_subscription_data(state.origin, state.client_id, id, graph_diff)
+    ClientReconnectionInfo.store_subscription_data!(state.origin, state.client_id, id, graph_diff)
 
     if is_paused_on_subscription(state, id) do
       # We're currently waiting for data from this subscription, we can send it immediately
@@ -755,7 +755,7 @@ defmodule Electric.Satellite.Protocol do
     # but more testing is required.
 
     # Store this data in case of disconnect until acknowledged
-    ClientReconnectionInfo.store_additional_txn_data(
+    ClientReconnectionInfo.store_additional_txn_data!(
       state.origin,
       state.client_id,
       xmin,
@@ -1043,7 +1043,7 @@ defmodule Electric.Satellite.Protocol do
           "Requested data for subscription #{id}, insertion point is at xmin = #{xmin}"
         )
 
-        ClientReconnectionInfo.store_subscription(
+        ClientReconnectionInfo.store_subscription!(
           state.origin,
           state.client_id,
           id,
@@ -1138,7 +1138,7 @@ defmodule Electric.Satellite.Protocol do
   end
 
   defp restore_graph(lsn, observed_txn_data, %State{} = state) do
-    ClientReconnectionInfo.advance_on_reconnection(state.client_id,
+    ClientReconnectionInfo.advance_on_reconnection!(state.client_id,
       ack_point: lsn,
       including_data: observed_txn_data,
       including_subscriptions: Map.keys(state.subscriptions),

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -754,7 +754,6 @@ defmodule Electric.Satellite.Protocol do
     # Store this data in case of disconnect until acknowledged
     ClientReconnectionInfo.store_additional_txn_data(
       state.client_id,
-      ref,
       xmin,
       ref,
       included_txns,

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -507,6 +507,7 @@ defmodule Electric.Satellite.Protocol do
     #
     # Sending a message to self() here ensures that the SatInStartReplicationResp message is delivered to the
     # client first, followed by the initial migrations.
+    Logger.debug("Performing initial sync for client #{state.client_id}")
     send(self(), {:perform_initial_sync_and_subscribe, msg})
 
     {:reply, %SatInStartReplicationResp{unacked_window_size: state.out_rep.allowed_unacked_txs},

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -540,7 +540,7 @@ defmodule Electric.Satellite.Protocol do
       end
     else
       # Once the client is outside the WAL window, we are assuming the client will reset its local state, so we will too.
-      Client.with_pool(state.origin, fn ->
+      Client.checkout_from_pool(state.origin, fn ->
         ClientReconnectionInfo.clear_all_data(state.client_id)
       end)
 

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -226,7 +226,7 @@ defmodule Electric.Satellite.WebsocketServer do
 
     max_txid = migrations |> Enum.map(& &1.xid) |> Enum.max(fn -> 0 end)
 
-    ClientReconnectionInfo.store_initial_checkpoint(
+    ClientReconnectionInfo.store_initial_checkpoint!(
       state.origin,
       state.client_id,
       lsn,

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -227,6 +227,7 @@ defmodule Electric.Satellite.WebsocketServer do
     max_txid = migrations |> Enum.map(& &1.xid) |> Enum.max(fn -> 0 end)
 
     ClientReconnectionInfo.store_initial_checkpoint(
+      state.origin,
       state.client_id,
       lsn,
       state.out_rep.sent_rows_graph

--- a/components/electric/mix.exs
+++ b/components/electric/mix.exs
@@ -68,8 +68,9 @@ defmodule Electric.MixProject do
       {:req, "~> 0.4"},
       {:pg_protocol, github: "electric-sql/pg_protocol"},
       {:nimble_parsec, "~> 1.4"},
-      {:postgrex, "~> 0.17", only: [:test]},
-      {:ecto_sql, "~> 3.11", only: [:test]},
+      {:postgrex, "~> 0.17"},
+      {:ecto_sql, "~> 3.11"},
+      {:ecto, "~> 3.11"},
       {:dotenvy, "~> 0.8"},
       {:timex, "~> 3.7"}
     ]

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -37,6 +37,7 @@ defmodule Electric.Satellite.WebsocketServerTest do
   setup_with_mocks([
     {Electric.Postgres.Repo, [:passthrough],
      checkout: fn fun -> fun.() end,
+     transaction: fn fun -> fun.() end,
      checked_out?: fn -> true end,
      query!: fn _, _ ->
        %Postgrex.Result{columns: nil, rows: []}

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -35,8 +35,12 @@ defmodule Electric.Satellite.WebsocketServerTest do
   import Mock
 
   setup_with_mocks([
-    {Electric.Replication.Postgres.Client, [:passthrough],
-     with_pool: fn _, _ -> :ok end, pooled_query!: fn _, _, _ -> :ok end}
+    {Electric.Postgres.Repo, [:passthrough],
+     checkout: fn fun -> fun.() end,
+     checked_out?: fn -> true end,
+     query!: fn _, _ ->
+       %Postgrex.Result{columns: nil, rows: []}
+     end}
   ]) do
     %{}
   end

--- a/components/electric/test/support/setup_helpers.ex
+++ b/components/electric/test/support/setup_helpers.ex
@@ -9,7 +9,7 @@ defmodule ElectricTest.SetupHelpers do
   Starts SchemaCache process with a given origin, and
   immediately fills it from given SQL.
   """
-  def start_schema_cache(origin \\ "fake_origin", migrations) do
+  def start_schema_cache(origin \\ "test-origin", migrations) do
     backend = Electric.Postgres.MockSchemaLoader.start_link(migrations: migrations)
 
     start_supervised!(

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -35,13 +35,17 @@ export const electrify_db = async (
   schema.migrations = migrations
   const result = await electrify(db, schema, config)
   const token = await mockSecureAuthToken(exp)
-  
+
   result.notifier.subscribeToConnectivityStateChanges((x: any) => console.log(`Connectivity state changed: ${x.connectivityState.status}`))
   if (connectToElectric) {
     await result.connect(token) // connect to Electric
   }
 
   return result
+}
+
+export const disconnect = async (electric: Electric) => {
+  await electric.disconnect()
 }
 
 // reconnects with Electric, e.g. after expiration of the JWT
@@ -98,8 +102,8 @@ export const syncTable = async (table: string) => {
 }
 
 export const lowLevelSubscribe = async (electric: Electric, shape: Shape) => {
-    const { synced } = await electric.satellite.subscribe([shape])
-    return await synced
+  const { synced } = await electric.satellite.subscribe([shape])
+  return await synced
 }
 
 export const get_tables = (electric: Electric) => {
@@ -111,7 +115,7 @@ export const get_columns = (electric: Electric, table: string) => {
 }
 
 export const get_rows = (electric: Electric, table: string) => {
-  return electric.db.rawQuery({sql: `SELECT * FROM ${table};`})
+  return electric.db.rawQuery({ sql: `SELECT * FROM ${table};` })
 }
 
 export const get_timestamps = (electric: Electric) => {
@@ -374,7 +378,7 @@ export const insert_extended_into = async (electric: Electric, table: string, va
   const columnNames = columns.join(", ")
   const placeHolders = Array(columns.length).fill("?")
   const args = Object.values(values)
-  
+
   await electric.db.unsafeExec({
     sql: `INSERT INTO ${table} (${columnNames}) VALUES (${placeHolders}) RETURNING *;`,
     args: args,

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -403,13 +403,6 @@ export const insert_other_item = async (electric: Electric, keys: [string]) => {
     }
   })
 
-  await electric.db.items.create({
-    data: {
-      id: "test_id_1",
-      content: ""
-    }
-  })
-
   await electric.db.other_items.createMany({
     data: items
   })

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -81,15 +81,20 @@ export const set_subscribers = (db: Electric) => {
   })
 }
 
-export const syncTable = async (electric: Electric, table: string) => {
-  if (table === 'other_items') {
-    const { synced } = await electric.db.other_items.sync()
-    return await synced
-  } else {
-    const satellite = globalRegistry.satellites[dbName]
-    const { synced } = await satellite.subscribe([{tablename: table}])
-    return await synced
-  }
+export const syncItemsTable = async (electric: Electric, shapeFilter: string) => {
+  const { synced } = await electric.db.items.sync({ where: shapeFilter })
+  return await synced
+}
+
+export const syncOtherItemsTable = async (electric: Electric, shapeFilter: string) => {
+  const { synced } = await electric.db.other_items.sync({ where: shapeFilter })
+  return await synced
+}
+
+export const syncTable = async (table: string) => {
+  const satellite = globalRegistry.satellites[dbName]
+  const { synced } = await satellite.subscribe([{ tablename: table }])
+  return await synced
 }
 
 export const lowLevelSubscribe = async (electric: Electric, shape: Shape) => {

--- a/e2e/tests/01.05_electric_can_recreate_publication.lux
+++ b/e2e/tests/01.05_electric_can_recreate_publication.lux
@@ -57,10 +57,9 @@
 
 [shell electric]
     [invoke start_electric 1]
+    ??Successfully initialized Postgres connector "postgres_1"
 
 [shell pg_1]
-    !SELECT * FROM electric.schema;
-
     !SELECT schemaname, tablename FROM pg_publication_tables \
          WHERE pubname = 'electric_publication' ORDER BY tablename;
     ??electric   | acknowledged_client_lsns

--- a/e2e/tests/02.06_subscriptions_can_be_resumed_on_reconnect.lux
+++ b/e2e/tests/02.06_subscriptions_can_be_resumed_on_reconnect.lux
@@ -10,7 +10,6 @@
     -($fail_pattern|bad sentined value)
     [invoke start_elixir_test 1]
     [invoke client_session $user_id_1 1]
-    [invoke elixir_client_subscribe_with_id "00000000-0000-0000-0000-000000000000" "entries"]
 
 [shell pg_1]
     !BEGIN;
@@ -22,10 +21,13 @@
 
 [shell user_1_ws1]
     # We expect to receive the transaction on Satellite
+    !{:ok, %{err: nil}} = TestWsClient.make_rpc_call(conn,  "subscribe", ProtocolHelpers.subscription_request("00000000-0000-0000-0000-000000000000", request_1: ["entries"]))
     ?rec \[\d+\]: %Electric.Satellite.SatSubsDataBegin\{(?:.*)lsn: "(\d+)"
     [local lsn=$1]
     ??values: ["00000000-0000-0000-0000-000000000000", "sentinel value", ""]
     ?tags: \["postgres_1@\d{13,16}"\]
+    ?rec \[\d+\]: %Electric.Satellite.SatSubsDataEnd\{\}
+
     !TestWsClient.disconnect(conn)
     ?$eprompt
 

--- a/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
+++ b/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
@@ -12,10 +12,10 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [invoke log "PG & Satellites migrated and ready"]
 

--- a/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
+++ b/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
@@ -12,11 +12,9 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [invoke log "PG & Satellites migrated and ready"]

--- a/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
+++ b/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
@@ -18,11 +18,9 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [invoke log "PG & Satellites migrated and ready"]

--- a/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
+++ b/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
@@ -18,10 +18,10 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [invoke log "PG & Satellites migrated and ready"]
 

--- a/e2e/tests/03.06_node_satellite_does_sync_on_subscribe.lux
+++ b/e2e/tests/03.06_node_satellite_does_sync_on_subscribe.lux
@@ -22,7 +22,7 @@
 
 [shell satellite_1]
     -$fail_pattern
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
     # As soon as sync is done, we expect to see the row in the database
     !await client.get_items(db)
     ??hello from pg

--- a/e2e/tests/03.07_node_satellite_can_delete_freshly_synced_rows.lux
+++ b/e2e/tests/03.07_node_satellite_can_delete_freshly_synced_rows.lux
@@ -26,7 +26,7 @@
 
 [shell satellite_1]
     -$fail_pattern
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
     # As soon as sync it done, we expect to see the row in the database
     !await client.get_items(db)
     ??hello from pg

--- a/e2e/tests/03.08_node_satellite_can_resume_subscriptions_on_reconnect.lux
+++ b/e2e/tests/03.08_node_satellite_can_resume_subscriptions_on_reconnect.lux
@@ -22,7 +22,7 @@
 
 [shell satellite_1]
     -$fail_pattern
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
     # As soon as sync is done, we expect to see the row in the database
     !await client.get_items(db)
     ??hello from pg

--- a/e2e/tests/03.11_node_satellite_compensations_work.lux
+++ b/e2e/tests/03.11_node_satellite_compensations_work.lux
@@ -14,7 +14,7 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "other_items"]
+    [invoke node_sync_other_items ""]
     ??[proto] recv: #SatSubsDataEnd
     !await db.db.unsafeExec({sql: "UPDATE _electric_meta SET value = 1 WHERE key = 'compensations' RETURNING *"})
     ?$node

--- a/e2e/tests/03.11_node_satellite_compensations_work.lux
+++ b/e2e/tests/03.11_node_satellite_compensations_work.lux
@@ -10,21 +10,10 @@
 
 [shell proxy_1]
     [invoke migrate_items_table 001]
-
-    [local sql=
-        """
-        CREATE TABLE public.other_items (
-            id TEXT PRIMARY KEY,
-            content TEXT NOT NULL,
-            item_id UUID REFERENCES public.items(id)
-        );
-        ALTER TABLE public.other_items ENABLE ELECTRIC;
-        """]
-    [invoke migrate_pg 002 $sql]
+    [invoke migrate_other_items_table 002]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "other_items"]
     [invoke node_sync_table "other_items"]
     ??[proto] recv: #SatSubsDataEnd
     !await db.db.unsafeExec({sql: "UPDATE _electric_meta SET value = 1 WHERE key = 'compensations' RETURNING *"})

--- a/e2e/tests/03.12_server_correctly_continues_the_replication.lux
+++ b/e2e/tests/03.12_server_correctly_continues_the_replication.lux
@@ -11,7 +11,7 @@
 
 [shell satellite_1]
   ??[rpc] recv: #SatInStartReplicationResp
-  [invoke node_sync_table "items"]
+  [invoke node_sync_items ""]
 
   # First write gets propagated
   [invoke node_await_insert "['hello from satellite - first']"]
@@ -29,7 +29,7 @@
 
 [shell satellite_2]
   ??[rpc] recv: #SatInStartReplicationResp
-  [invoke node_sync_table "items"]
+  [invoke node_sync_items ""]
 
   # Perform multiple writes to bump the LSN repeatedly
   [invoke node_await_insert "['hello from satellite - client 2 - a']"]

--- a/e2e/tests/03.12_server_correctly_continues_the_replication.lux
+++ b/e2e/tests/03.12_server_correctly_continues_the_replication.lux
@@ -11,7 +11,7 @@
 
 [shell satellite_1]
   ??[rpc] recv: #SatInStartReplicationResp
-  [invoke node_await_table "items"]
+  [invoke node_sync_table "items"]
 
   # First write gets propagated
   [invoke node_await_insert "['hello from satellite - first']"]
@@ -29,7 +29,7 @@
 
 [shell satellite_2]
   ??[rpc] recv: #SatInStartReplicationResp
-  [invoke node_await_table "items"]
+  [invoke node_sync_table "items"]
 
   # Perform multiple writes to bump the LSN repeatedly
   [invoke node_await_insert "['hello from satellite - client 2 - a']"]

--- a/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
+++ b/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
@@ -12,10 +12,10 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [invoke log "PG & Satellites migrated and ready"]
 

--- a/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
+++ b/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
@@ -12,11 +12,9 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [invoke log "PG & Satellites migrated and ready"]

--- a/e2e/tests/03.24_node_satellite_can_transform_at_replication_boundary.lux
+++ b/e2e/tests/03.24_node_satellite_can_transform_at_replication_boundary.lux
@@ -13,13 +13,11 @@
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
     [invoke node_set_item_replication_transform]
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
     
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
     [invoke node_set_item_replication_transform]
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [shell satellite_1]

--- a/e2e/tests/03.25_node_satellite_can_resume_replication_after_server_restart.lux
+++ b/e2e/tests/03.25_node_satellite_can_resume_replication_after_server_restart.lux
@@ -1,0 +1,211 @@
+[doc NodeJS Satellite can resume replication after the sync service restarts]
+
+# The focus in this test is the correct state restoration on the server when it restarts.
+#
+# The test scenario implemented below can be summarized as follows:
+#
+# - Create two tables with a foreign-key relationship "other_items" -> "items".
+# - Insert rows into both tables, some connected via an FK, others standalone.
+# - Start two clients that initiate different subscriptions.
+# - Verify that actions such as disconnecting one of the clients, stopping and starting the
+#   server do not lead to clients resetting their local state and that both clients don't miss
+#   transactions that are visible under their subscribed shapes.
+
+[include _shared.luxinc]
+[include _satellite_macros.luxinc]
+
+[invoke setup]
+
+[shell proxy_1]
+    [invoke migrate_items_table 001]
+    [invoke migrate_other_items_table 002]
+
+[invoke setup_client 1 electric_1 5133]
+
+[shell satellite_1]
+    ?\[rpc\] send: #SatAuthReq\{id: ([a-f0-9-]{36})
+    [global client_1_id=$1]
+
+[shell electric]
+    ??initial sync for client $client_1_id
+
+[shell pg_1]
+    !INSERT INTO items (id, content) VALUES \
+       ('00000000-0000-0000-0000-000000000001', 'items-1'), \
+       ('00000000-0000-0000-0000-000000000002', 'items-2-'), \
+       ('00000000-0000-0000-0000-000000000003', 'items-3-');
+    ??INSERT 0 3
+
+    !INSERT INTO other_items VALUES \
+       ('1', 'first', '00000000-0000-0000-0000-000000000001'), \
+       ('2', 'second', '00000000-0000-0000-0000-000000000002'), \
+       ('3', '', NULL);
+    ??INSERT 0 3
+
+[shell satellite_1]
+    # Subscribe to "other_items"
+    [invoke node_sync_other_items "this.content not like ''"]
+
+    ?send: #SatSubsReq\{id: ([a-f0-9-]{36})
+    [global client_1_subs_id=$1]
+
+[shell electric]
+    ??Received initial data for subscription $client_1_subs_id
+
+[shell satellite_1]
+    # Wait for the rows from "other_items" to arrive
+    [invoke node_await_get_from_table "other_items" "first"]
+    [invoke node_await_get_from_table "other_items" "second"]
+
+    # Wait for the rows from "items" to arrive, via an FK link
+    [invoke node_await_get "items-1"]
+    [invoke node_await_get "items-2"]
+
+# Start a new Satellite client that has a different set of subscriptions
+[invoke setup_client 2 electric_1 5133]
+
+[shell satellite_2]
+    ?\[rpc\] send: #SatAuthReq\{id: ([a-f0-9-]{36})
+    [global client_2_id=$1]
+
+[shell electric]
+    ??initial sync for client $client_2_id
+
+[shell satellite_2]
+    # Subscribe to "items" and include "other_items"
+    !const { synced } = await db.db.items.sync({ \
+       where: "this.content like 'items-_-'", \
+       include: { other_items: true } \
+     }); await synced
+
+    ?send: #SatSubsReq\{id: ([a-f0-9-]{36})
+    [global client_2_subs_id=$1]
+
+[shell electric]
+    ??Received initial data for subscription $client_2_subs_id
+
+[shell satellite_2]
+    # Wait for the rows from "items" to arrive
+    [invoke node_await_get "items-2-"]
+    [invoke node_await_get "items-3-"]
+
+    # Wait for the rows from "other_items" to arrive, via an FK link
+    [invoke node_await_get_from_table "other_items" "second"]
+
+    # Disconnect the client so that it does not see the next batch of updates
+    [invoke client_disconnect]
+
+[shell pg_1]
+    !INSERT INTO items (id, content) VALUES \
+       ('00000000-0000-0000-0000-000000000004', 'items-4'), \
+       ('00000000-0000-0000-0000-000000000005', 'items-5-'), \
+       ('00000000-0000-0000-0000-000000000006', 'items-6');
+    ??INSERT 0 3
+
+    !INSERT INTO other_items VALUES \
+       ('4', '', NULL), \
+       ('5', '', NULL), \
+       ('6', '', NULL), \
+       ('7', '', NULL);
+    ??INSERT 0 4
+
+[shell satellite_1]
+    [invoke node_await_insert_extended "{content: 'items-a-', id: '10000000-0000-0000-0000-000000000001'}"]
+
+    ?send: #SatOpLog\{ops: \[#Begin\{[^}]+\}, \
+       #Insert\{[^}]*new: \["10000000-0000-0000-0000-000000000001", "items-a-"
+
+    # Reset the failure pattern
+    -resetting client state
+
+[shell satellite_2]
+    # Reset the failure pattern
+    -resetting client state
+
+# Stop the server to restart it later.
+[shell log]
+    [invoke stop_electric 1]
+
+[shell satellite_1]
+    [invoke node_await_insert_extended "{content: 'items-b-', id: '10000000-0000-0000-0000-000000000002'}"]
+
+[shell pg_1]
+    !UPDATE items SET content = 'items-1-' WHERE id = '00000000-0000-0000-0000-000000000001';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'third', item_id = '10000000-0000-0000-0000-000000000001' WHERE id = '3';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'fourth', item_id = '00000000-0000-0000-0000-000000000004' WHERE id = '4';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'fifth', item_id = '00000000-0000-0000-0000-000000000005' WHERE id = '5';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'sixth', item_id = '00000000-0000-0000-0000-000000000006' WHERE id = '6';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'seventh', item_id = '00000000-0000-0000-0000-000000000005' WHERE id = '7';
+    ??UPDATE 1
+
+# Now restart the server, verify that both clients reconnect and are able to
+# to catch up to the latest server state.
+[shell electric]
+    [invoke start_electric 1]
+
+    ??Cached 2 client_checkpoints from the DB
+    ??Cached 2 client_shape_subscriptions from the DB
+    ??Cached 0 client_additional_data records from the DB
+    ??Cached 0 client_actions from the DB
+
+[shell satellite_1]
+    ??Connectivity state changed: connected
+
+    [invoke node_await_get_from_table "other_items" "fourth"]
+    [invoke node_await_get_from_table "other_items" "fifth"]
+    [invoke node_await_get_from_table "other_items" "sixth"]
+    [invoke node_await_get_from_table "other_items" "seventh"]
+
+[shell satellite_2]
+    [invoke client_reconnect]
+
+    ??Connectivity state changed: connected
+
+    [invoke node_await_get "items-1-"]
+    [invoke node_await_get "items-a-"]
+    [invoke node_await_get "items-b-"]
+    [invoke node_await_get_from_table "other_items" "first"]
+    [invoke node_await_get_from_table "other_items" "third"]
+
+# Stop the server and verify that it persists client_actions and client_additional_data.
+[shell log]
+    [invoke stop_electric 1]
+
+[shell pg_1]
+    !SELECT * FROM electric.client_actions;
+    ?$client_2_id \|  \d+ \| \\x
+
+    !SELECT * FROM electric.client_additional_data;
+    ?$client_2_id \|      \d+ \|   1 \| transaction \| <NULL>          \| \\x
+
+# Restart the server and verify that it cleans up client_actions and client_additional_data.
+[shell electric]
+    -initial sync|initial data
+
+    [invoke start_electric 1]
+
+    ??Cached 2 client_checkpoints from the DB
+    ??Cached 2 client_shape_subscriptions from the DB
+    ??Cached 1 client_additional_data records from the DB
+    ??Cached 1 client_actions from the DB
+
+[shell satellite_1]
+    ??Connectivity state changed: connected
+
+[shell satellite_2]
+    ??Connectivity state changed: connected
+
+[shell pg_1]
+    !SELECT * FROM electric.client_actions;
+    ??(0 rows)
+
+    !SELECT * FROM electric.client_additional_data;
+    ??(0 rows)
+
+[cleanup]
+  [invoke teardown]

--- a/e2e/tests/03.xx_node_satellite_authentication.lux.disabled
+++ b/e2e/tests/03.xx_node_satellite_authentication.lux.disabled
@@ -21,12 +21,10 @@
     # Wait for the items table migration and sync the table
     ??[rpc] recv: #SatInStartReplicationResp
     ??Connectivity state changed: connected
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [invoke log "PG & Satellites migrated and ready"]

--- a/e2e/tests/03.xx_node_satellite_authentication.lux.disabled
+++ b/e2e/tests/03.xx_node_satellite_authentication.lux.disabled
@@ -21,11 +21,11 @@
     # Wait for the items table migration and sync the table
     ??[rpc] recv: #SatInStartReplicationResp
     ??Connectivity state changed: connected
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [invoke log "PG & Satellites migrated and ready"]
 

--- a/e2e/tests/05.04_update_that_didnt_see_delete_resurrects.lux
+++ b/e2e/tests/05.04_update_that_didnt_see_delete_resurrects.lux
@@ -11,7 +11,6 @@
     [invoke elixir_client_subscribe "entries"]
     !TestWsClient.send_data(conn, ProtocolHelpers.relation("public.entries"))
     ?:ok
-    ?rec \[\d+\]: %Electric.Satellite.SatSubsDataEnd\{\}
 
 [shell pg_1]
     !\pset tuples_only

--- a/e2e/tests/05.05_compensations_within_same_tx_are_fine.lux
+++ b/e2e/tests/05.05_compensations_within_same_tx_are_fine.lux
@@ -7,19 +7,14 @@
     [local sql=
         """
         CREATE TABLE public.items (
-            id TEXT PRIMARY KEY,
+            id UUID PRIMARY KEY,
             content TEXT NOT NULL
         );
-        CREATE TABLE public.other_items (
-            id TEXT PRIMARY KEY,
-            content TEXT NOT NULL,
-            item_id TEXT REFERENCES public.items(id)
-        );
         ALTER TABLE public.items ENABLE ELECTRIC;
-        ALTER TABLE public.other_items ENABLE ELECTRIC;
         """]
-    [invoke migrate_pg 11111 $sql]
+    [invoke migrate_pg 001 $sql]
 
+    [invoke migrate_other_items_table 002]
 
 [newshell user_1_ws1]
     -$fail_pattern

--- a/e2e/tests/_satellite_macros.luxinc
+++ b/e2e/tests/_satellite_macros.luxinc
@@ -210,8 +210,16 @@
     ??$node
 [endmacro]
 
+[macro node_sync_items filter]
+    !await client.syncItemsTable(db, "${filter}")
+[endmacro]
+
+[macro node_sync_other_items filter]
+    !await client.syncOtherItemsTable(db, "${filter}")
+[endmacro]
+
 [macro node_sync_table table]
-    !await client.syncTable(db, "${table}")
+    !await client.syncTable("${table}")
 [endmacro]
 
 # Makes both satellites and PG write rows

--- a/e2e/tests/_satellite_macros.luxinc
+++ b/e2e/tests/_satellite_macros.luxinc
@@ -34,6 +34,15 @@
     [invoke connect_to_electric $electric $port $migrations $connectToElectric]
 [endmacro]
 
+[macro client_disconnect]
+    !await client.disconnect(db)
+    ??$node
+[endmacro]
+
+[macro client_reconnect]
+    !await client.reconnect(db)
+[endmacro]
+
 [macro setup_client satellite_number electric port]
     [invoke setup_client_with_migrations $satellite_number $electric $port "[]" "true"]
 [endmacro]
@@ -186,13 +195,13 @@
     ??$node
 [endmacro]
 
-[macro node_await_insert_extended keys]
-    !await client.insert_extended_item(db, ${keys})
+[macro node_await_insert_extended obj]
+    !await client.insert_extended_item(db, ${obj})
     ??$node
 [endmacro]
 
-[macro node_await_insert_extended_into table keys]
-    !await client.insert_extended_into(db, '${table}', ${keys})
+[macro node_await_insert_extended_into table obj]
+    !await client.insert_extended_into(db, '${table}', ${obj})
     ??$node
 [endmacro]
 
@@ -201,12 +210,12 @@
 [endmacro]
 
 [macro node_await_insert_other keys]
-    !client.insert_other_item(db, ${keys})
+    !await client.insert_other_item(db, ${keys})
     ??$node
 [endmacro]
 
 [macro node_set_item_replication_transform]
-    !client.set_item_replication_transform(db)
+    !await client.set_item_replication_transform(db)
     ??$node
 [endmacro]
 

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -143,3 +143,16 @@
         """]
     [invoke migrate_pg $version $sql]
 [endmacro]
+
+[macro migrate_other_items_table version]
+    [local sql=
+        """
+        CREATE TABLE public.other_items (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            item_id UUID REFERENCES public.items(id)
+        );
+        ALTER TABLE public.other_items ENABLE ELECTRIC;
+        """]
+    [invoke migrate_pg $version $sql]
+[endmacro]

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -17,6 +17,7 @@
 
     [newshell electric]
         [invoke start_electric 1]
+        ??Successfully initialized Postgres connector "postgres_1"
         [progress setup finished]
 
     [shell postgres_logs]
@@ -36,7 +37,6 @@
 [macro start_electric n]
     !make start_electric_${n}
     -$fail_pattern
-    ??Successfully initialized Postgres connector "postgres_1"
 [endmacro]
 
 [macro stop_electric n]

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -97,14 +97,14 @@
     """!
     {:ok, %{err: nil}} = TestWsClient.make_rpc_call(conn, "subscribe", ProtocolHelpers.subscription_request(request_1: ~w|$tables|))
     """
-    ?$eprompt
+    ?rec \[\d+\]: %Electric.Satellite.SatSubsDataEnd\{\}
 [endmacro]
 
 [macro elixir_client_subscribe_with_id id tables]
     """!
     {:ok, %{err: nil}} = TestWsClient.make_rpc_call(conn,  "subscribe", ProtocolHelpers.subscription_request("$id", request_1: ~w|$tables|))
     """
-    ?$eprompt
+    ?rec \[\d+\]: %Electric.Satellite.SatSubsDataEnd\{\}
 [endmacro]
 
 

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -41,6 +41,7 @@
 
 [macro stop_electric n]
     !make stop_electric_${n}
+    ??Stopped
     [invoke ok]
 [endmacro]
 


### PR DESCRIPTION
A new E2E test that covers this implementation is added in https://github.com/electric-sql/electric/pull/1135.

* ~[ ] persist `move_in_next_ref` for each client so that it doesn't reset after server restart~
* [x] add changelog