### PR TITLE
Alco/vax 1686 resume clients from wal

### DIFF
--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -30,7 +30,7 @@ defmodule Electric.Postgres.CachedWal.Api do
   @callback request_notification(Connectors.origin(), wal_pos()) ::
               {:ok, await_ref()} | {:error, term()}
   @callback cancel_notification_request(Connectors.origin(), await_ref()) :: :ok
-  @callback reserve_wal_position(Connectors.origin(), binary(), wal_pos()) ::
+  @callback reserve_wal_position(Connectors.origin(), binary(), wal_pos() | :oldest) ::
               {:ok, wal_pos()} | :error
   @callback cancel_reservation(Connectors.origin(), binary()) :: :ok
 
@@ -115,7 +115,12 @@ defmodule Electric.Postgres.CachedWal.Api do
 
   If `wal_pos` is behind the cached window, `:error` is returned.
   """
+<<<<<<< HEAD
   @spec reserve_wal_position(module(), Connectors.origin(), binary(), wal_pos()) :: :ok | :error
+=======
+  @spec reserve_wal_position(module(), Connectors.origin(), binary(), wal_pos() | :oldest) ::
+          {:ok, wal_pos()} | :error
+>>>>>>> e6f66bb2 (Stream WAL records from the replication slot)
   def reserve_wal_position(module \\ default_module(), origin, client_id, wal_pos) do
     module.reserve_wal_position(origin, client_id, wal_pos)
   end

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -167,8 +167,13 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     {:reply, :ok, [], state}
   end
 
+<<<<<<< HEAD
   def handle_call({:reserve_wal_position, client_id, wal_pos}, _from, state) do
     if wal_pos >= state.first_wal_pos do
+=======
+  def handle_call({:reserve_wal_position, client_id, client_wal_pos}, _from, state) do
+    if wal_pos = wal_pos_to_reserve(client_wal_pos, state.first_wal_pos) do
+>>>>>>> e6f66bb2 (Stream WAL records from the replication slot)
       state = Map.update!(state, :reservations, &Map.put(&1, client_id, {wal_pos, nil}))
       {:reply, :ok, [], state}
     else
@@ -273,6 +278,7 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   def lsn_to_position(lsn), do: Lsn.to_integer(lsn)
+  def position_to_lsn(wal_pos), do: Lsn.from_integer(wal_pos)
 
   # Drop all transactions from the cache whose position falls out of the cached window. The
   # cached window's low bound is calculated by subtracting the configured in-memory WAL window
@@ -322,6 +328,12 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   defp diff_seconds(ts1, ts2), do: System.convert_time_unit(abs(ts1 - ts2), :native, :second)
+
+  defp wal_pos_to_reserve(:oldest, first_wal_pos), do: first_wal_pos
+
+  defp wal_pos_to_reserve(wal_pos, first_wal_pos) do
+    if wal_pos >= first_wal_pos, do: wal_pos
+  end
 
   defp lookup_oldest_transaction(ets_table) do
     case :ets.match(ets_table, {:_, :"$1"}, 1) do

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -26,11 +26,15 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   @typep state :: %{
            origin: Connectors.origin(),
            notification_requests: %{optional(reference()) => {Api.wal_pos(), pid()}},
+           reservations: %{binary() => {Api.wal_pos(), integer() | nil}},
            table: :ets.table(),
+           first_wal_pos: Api.wal_pos(),
            last_seen_wal_pos: Api.wal_pos(),
            current_tx_count: non_neg_integer(),
            wal_window_size: non_neg_integer()
          }
+
+  @reservation_expiration_s 30
 
   # Public API
 
@@ -49,25 +53,6 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
 
   def clear_cache(stage) do
     GenStage.cast(stage, :clear_cache)
-  end
-
-  @impl Api
-  def lsn_in_cached_window?(origin, client_wal_pos) do
-    table = ets_table_name(origin)
-
-    case :ets.first(table) do
-      :"$end_of_table" ->
-        false
-
-      first_position ->
-        case :ets.last(table) do
-          :"$end_of_table" ->
-            false
-
-          last_position ->
-            first_position <= client_wal_pos and client_wal_pos <= last_position
-        end
-    end
   end
 
   @impl Api
@@ -93,6 +78,22 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   @impl Api
   def cancel_notification_request(origin, ref) do
     GenStage.call(name(origin), {:cancel_notification, ref})
+  end
+
+  @impl Api
+  def reserve_wal_position(origin, client_id, wal_pos) do
+    with last_position when is_integer(last_position) <- :ets.last(ets_table_name(origin)),
+         # Sanity check to make sure client is not "in the future" relative to the cached WAL.
+         true <- wal_pos <= last_position do
+      GenStage.call(name(origin), {:reserve_wal_position, client_id, wal_pos})
+    else
+      _ -> :error
+    end
+  end
+
+  @impl Api
+  def cancel_reservation(origin, client_id) do
+    GenStage.cast(name(origin), {:cancel_reservation, client_id})
   end
 
   @impl Api
@@ -130,7 +131,9 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     state = %{
       origin: origin,
       notification_requests: %{},
+      reservations: %{},
       table: table,
+      first_wal_pos: nil,
       last_seen_wal_pos: 0,
       current_tx_count: 0,
       wal_window_size: Keyword.fetch!(opts, :wal_window_size)
@@ -164,6 +167,15 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     {:reply, :ok, [], state}
   end
 
+  def handle_call({:reserve_wal_position, client_id, wal_pos}, _from, state) do
+    if wal_pos >= state.first_wal_pos do
+      state = Map.update!(state, :reservations, &Map.put(&1, client_id, {wal_pos, nil}))
+      {:reply, :ok, [], state}
+    else
+      {:reply, :error, [], state}
+    end
+  end
+
   def handle_call(:telemetry_stats, _from, state) do
     oldest_timestamp =
       if tx = lookup_oldest_transaction(state.table) do
@@ -181,6 +193,21 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   @impl GenStage
+  def handle_cast({:cancel_reservation, client_id}, %{reservations: reservations} = state) do
+    # Retain client's reservation long enough for the client to consume cached
+    # transactions before they are removed during a cache cleanup pass.
+    reservations =
+      if Map.has_key?(reservations, client_id) do
+        Map.update!(reservations, client_id, fn {wal_pos, nil} ->
+          {wal_pos, System.monotonic_time()}
+        end)
+      else
+        reservations
+      end
+
+    {:noreply, [], %{state | reservations: reservations}}
+  end
+
   def handle_cast(:clear_cache, state) do
     :ets.delete_all_objects(state.table)
 
@@ -219,6 +246,7 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
         state =
           state
           |> Map.put(:last_seen_wal_pos, position)
+          |> Map.update!(:first_wal_pos, &min(&1, position))
           |> fulfill_notification_requests()
           |> trim_cache()
 
@@ -246,23 +274,54 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
 
   def lsn_to_position(lsn), do: Lsn.to_integer(lsn)
 
-  # Drop all transactions from the cache whose position is less than the last transaction's
-  # position minus in-memory WAL window size.
-  #
-  # TODO: make sure we're not removing transactions that are about to be requested by a newly
-  # connected client.
+  # Drop all transactions from the cache whose position falls out of the cached window. The
+  # cached window's low bound is calculated by subtracting the configured in-memory WAL window
+  # size from the most recent cached transaction's position.
   #
   # NOTE(optimization): clean the cache up after every N new transactions.
   @spec trim_cache(state()) :: state()
   defp trim_cache(state) do
     first_in_window_pos = state.last_seen_wal_pos - state.wal_window_size
+    {min_reserved_pos, reservations} = prune_reservations(state.reservations)
 
-    :ets.select_delete(state.table, [
-      {{:"$1", :_}, [{:<, :"$1", first_in_window_pos}], [true]}
-    ])
+    # Note that `min_pos_to_keep` may be less than the calculated low bound of the cached
+    # window. That's exactly the point of reservations: letting clients hold on to a
+    # transaction that would have been removed from the cache otherwise.
+    min_pos_to_keep = min(first_in_window_pos, min_reserved_pos)
 
-    %{state | current_tx_count: :ets.info(state.table, :size)}
+    state =
+      if min_pos_to_keep > state.first_wal_pos do
+        :ets.select_delete(state.table, [
+          {{:"$1", :_}, [{:<, :"$1", min_pos_to_keep}], [true]}
+        ])
+
+        %{state | current_tx_count: :ets.info(state.table, :size), first_wal_pos: min_pos_to_keep}
+      else
+        state
+      end
+
+    %{state | reservations: reservations}
   end
+
+  # Remove reservations who 1) already have a timestamp and 2) whose timestamp is old enough to
+  # be expired.
+  defp prune_reservations(reservations) do
+    current_time = System.monotonic_time()
+
+    Enum.reduce(reservations, {nil, reservations}, fn
+      {_client_id, {wal_pos, nil}}, {min_wal_pos, reservations} ->
+        {min(wal_pos, min_wal_pos), reservations}
+
+      {client_id, {wal_pos, ts}}, {min_wal_pos, reservations} ->
+        if diff_seconds(current_time, ts) < @reservation_expiration_s do
+          {min(wal_pos, min_wal_pos), reservations}
+        else
+          {min_wal_pos, Map.delete(reservations, client_id)}
+        end
+    end)
+  end
+
+  defp diff_seconds(ts1, ts2), do: System.convert_time_unit(abs(ts1 - ts2), :native, :second)
 
   defp lookup_oldest_transaction(ets_table) do
     case :ets.match(ets_table, {:_, :"$1"}, 1) do

--- a/components/electric/lib/electric/replication/postgres/logical_messages.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_messages.ex
@@ -1,0 +1,186 @@
+defmodule Electric.Replication.Postgres.LogicalMessages do
+  alias Electric.Postgres.LogicalReplication.Messages
+
+  alias Electric.Postgres.LogicalReplication.Messages.{
+    Begin,
+    Commit,
+    Delete,
+    Insert,
+    Message,
+    Origin,
+    Relation,
+    Truncate,
+    Type,
+    Update
+  }
+
+  alias Electric.Postgres.ShadowTableTransformation
+
+  alias Electric.Replication.Changes.{
+    Transaction,
+    NewRecord,
+    UpdatedRecord,
+    DeletedRecord,
+    TruncatedRelation,
+    ReferencedRecord
+  }
+
+  require Logger
+
+  defmodule Context do
+    defstruct origin: "",
+              publication: "",
+              commit_lsn: nil,
+              wip_transaction: nil,
+              transaction: nil,
+              relations: %{}
+
+    @type t :: %__MODULE__{
+            origin: binary(),
+            publication: binary(),
+            commit_lsn: Electric.Postgres.Lsn.t() | nil,
+            wip_transaction: Transaction.t() | nil,
+            transaction: Transaction.t() | nil,
+            relations: %{Messages.relation_id() => Relation.t()}
+          }
+
+    def reset_tx(context) do
+      %{context | commit_lsn: nil, transaction: nil, wip_transaction: nil}
+    end
+  end
+
+  @type message ::
+          Begin.t()
+          | Commit.t()
+          | Delete.t()
+          | Insert.t()
+          | Message.t()
+          | Origin.t()
+          | Relation.t()
+          | Truncate.t()
+          | Type.t()
+          | Update.t()
+
+  @spec process(message(), Context.t()) :: Context.t()
+  def process(
+        %Message{transactional?: true, prefix: "electric.fk_chain_touch", content: content},
+        context
+      ) do
+    received = Jason.decode!(content)
+
+    referenced = %ReferencedRecord{
+      relation: {received["schema"], received["table"]},
+      record: received["data"],
+      pk: received["pk"],
+      tags:
+        ShadowTableTransformation.convert_tag_list_pg_to_satellite(
+          received["tags"],
+          context.origin
+        )
+    }
+
+    update_in(context.wip_transaction, &Transaction.add_referenced_record(&1, referenced))
+  end
+
+  def process(%Message{} = msg, context) do
+    Logger.info("Got a message from PG via logical replication: #{inspect(msg)}")
+    context
+  end
+
+  def process(%Begin{} = msg, %{wip_transaction: nil} = context) do
+    tx = %Transaction{
+      xid: msg.xid,
+      changes: [],
+      commit_timestamp: msg.commit_timestamp,
+      origin_type: :postgresql,
+      origin: context.origin,
+      publication: context.publication
+    }
+
+    %{context | commit_lsn: msg.final_lsn, wip_transaction: tx}
+  end
+
+  def process(%Origin{} = msg, context) do
+    # If we got the "origin" message, it means that the Postgres sending back the transaction we sent from Electric
+    # We ignored those previously, when Vaxine was the source of truth, but now we need to fan out those processed messages
+    # to all the Satellites as their write has been "accepted"
+    Logger.debug("origin: #{inspect(msg.name)}")
+    context
+  end
+
+  def process(%Type{}, context), do: context
+
+  def process(%Relation{} = rel, context) do
+    update_in(context.relations, &Map.put(&1, rel.id, rel))
+  end
+
+  def process(%Insert{} = msg, context) do
+    relation = Map.fetch!(context.relations, msg.relation_id)
+    data = data_tuple_to_map(relation.columns, msg.tuple_data)
+    new_record = %NewRecord{relation: {relation.namespace, relation.name}, record: data}
+    update_in(context.wip_transaction.changes, &[new_record | &1])
+  end
+
+  def process(%Update{} = msg, context) do
+    relation = Map.fetch!(context.relations, msg.relation_id)
+    old_data = data_tuple_to_map(relation.columns, msg.old_tuple_data)
+    data = data_tuple_to_map(relation.columns, msg.tuple_data)
+
+    updated_record =
+      UpdatedRecord.new(
+        relation: {relation.namespace, relation.name},
+        old_record: old_data,
+        record: data
+      )
+
+    update_in(context.wip_transaction.changes, &[updated_record | &1])
+  end
+
+  def process(%Delete{} = msg, context) do
+    relation = Map.fetch!(context.relations, msg.relation_id)
+
+    data =
+      data_tuple_to_map(
+        relation.columns,
+        msg.old_tuple_data || msg.changed_key_tuple_data
+      )
+
+    deleted_record = %DeletedRecord{
+      relation: {relation.namespace, relation.name},
+      old_record: data
+    }
+
+    update_in(context.wip_transaction.changes, &[deleted_record | &1])
+  end
+
+  def process(%Truncate{} = msg, context) do
+    truncated_relations =
+      for truncated_relation <- Enum.reverse(msg.truncated_relations) do
+        relation = Map.fetch!(context.relations, truncated_relation)
+
+        %TruncatedRelation{relation: {relation.namespace, relation.name}}
+      end
+
+    update_in(context.wip_transaction.changes, &(truncated_relations ++ &1))
+  end
+
+  def process(
+        %Commit{lsn: commit_lsn, end_lsn: end_lsn},
+        %Context{commit_lsn: commit_lsn, wip_transaction: tx} = context
+      ) do
+    tx = ShadowTableTransformation.enrich_tx_from_shadow_ops(tx)
+    tx = %{tx | lsn: end_lsn}
+    %{context | transaction: tx, wip_transaction: nil, commit_lsn: nil}
+  end
+
+  ###
+
+  @spec data_tuple_to_map([Relation.Column.t()], list()) :: map()
+  defp data_tuple_to_map(_columns, nil), do: %{}
+
+  defp data_tuple_to_map(columns, tuple_data) do
+    columns
+    |> Enum.zip(tuple_data)
+    |> Map.new(fn {column, data} -> {column.name, data} end)
+  end
+end

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -1,52 +1,29 @@
 defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   use GenStage
-  require Logger
 
-  alias Electric.Postgres.ShadowTableTransformation
   alias Electric.Postgres.Extension.SchemaLoader
   alias Electric.Postgres.Extension.SchemaCache
   alias Electric.Telemetry.Metrics
 
   alias Electric.Postgres.LogicalReplication
-  alias Electric.Postgres.LogicalReplication.Messages
-
-  alias Electric.Postgres.LogicalReplication.Messages.{
-    Begin,
-    Origin,
-    Commit,
-    Relation,
-    Insert,
-    Update,
-    Delete,
-    Truncate,
-    Type,
-    Message
-  }
-
   alias Electric.Postgres.Lsn
 
-  alias Electric.Replication.Changes.{
-    Transaction,
-    NewRecord,
-    UpdatedRecord,
-    DeletedRecord,
-    TruncatedRelation,
-    ReferencedRecord
-  }
-
+  alias Electric.Replication.Changes.Transaction
   alias Electric.Replication.Connectors
   alias Electric.Replication.Postgres.Client
+  alias Electric.Replication.Postgres.LogicalMessages
+
+  require Logger
 
   defmodule State do
     defstruct repl_conn: nil,
               svc_conn: nil,
               demand: 0,
               queue: nil,
-              relations: %{},
-              transaction: nil,
-              publication: nil,
+              replication_context: %LogicalMessages.Context{},
               client: nil,
               origin: nil,
+              publication: nil,
               types: %{},
               span: nil,
               advance_timer: nil,
@@ -59,10 +36,9 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
             svc_conn: pid(),
             demand: non_neg_integer(),
             queue: :queue.queue(),
-            relations: %{Messages.relation_id() => %Relation{}},
-            transaction: {Lsn.t(), %Transaction{}},
-            publication: binary(),
+            replication_context: LogicalMessages.Context.t(),
             origin: Connectors.origin(),
+            publication: binary(),
             types: %{},
             span: Metrics.t() | nil,
             advance_timer: reference() | nil,
@@ -154,13 +130,18 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
           repl_conn: repl_conn,
           svc_conn: svc_conn,
           queue: :queue.new(),
-          publication: publication,
           origin: origin,
+          publication: publication,
+          replication_context: %LogicalMessages.Context{
+            origin: origin,
+            publication: publication
+          },
           span: span,
           main_slot: main_slot,
           main_slot_lsn: main_slot_lsn,
           resumable_wal_window: wal_window_opts.resumable_size
         }
+        |> reset_replication_context()
         |> schedule_main_slot_advance()
 
       {:producer, state}
@@ -186,6 +167,15 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     main_slot_lsn
   end
 
+  defp reset_replication_context(state) do
+    update_in(state.replication_context, &LogicalMessages.Context.reset_tx/1)
+  end
+
+  defp schedule_main_slot_advance(state) do
+    tref = :erlang.start_timer(@advance_timeout, self(), @advance_msg)
+    %State{state | advance_timer: tref}
+  end
+
   @impl true
   def terminate(_reason, state) do
     Metrics.stop_span(state.span)
@@ -193,9 +183,21 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
 
   @impl true
   def handle_info({:epgsql, _pid, {:x_log_data, _start_lsn, _end_lsn, binary_msg}}, state) do
-    binary_msg
-    |> LogicalReplication.decode_message()
-    |> process_message(state)
+    context =
+      binary_msg
+      |> LogicalReplication.decode_message()
+      |> LogicalMessages.process(state.replication_context)
+
+    case context.transaction do
+      nil ->
+        {:noreply, [], %{state | replication_context: context}}
+
+      %Transaction{} = tx ->
+        # When we have a new transaction, enqueue it and see if there's any
+        # pending demand we can meet by dispatching events.
+        tx = finalize_transaction(tx, state)
+        enqueue_transaction(tx, state)
+    end
   end
 
   def handle_info({:DOWN, _, :process, conn, reason}, %State{repl_conn: conn} = state) do
@@ -217,149 +219,6 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
   def handle_info(msg, state) do
     Logger.debug("Unexpected message #{inspect(msg)}")
     {:noreply, [], state}
-  end
-
-  defp process_message(
-         %Message{transactional?: true, prefix: "electric.fk_chain_touch", content: content},
-         state
-       ) do
-    received = Jason.decode!(content)
-
-    referenced = %ReferencedRecord{
-      relation: {received["schema"], received["table"]},
-      record: received["data"],
-      pk: received["pk"],
-      tags:
-        ShadowTableTransformation.convert_tag_list_pg_to_satellite(received["tags"], state.origin)
-    }
-
-    {lsn, txn} = state.transaction
-
-    {:noreply, [],
-     %{state | transaction: {lsn, Transaction.add_referenced_record(txn, referenced)}}}
-  end
-
-  defp process_message(%Message{} = msg, state) do
-    Logger.info("Got a message from PG via logical replication: #{inspect(msg)}")
-
-    {:noreply, [], state}
-  end
-
-  defp process_message(%Begin{} = msg, %State{} = state) do
-    tx = %Transaction{
-      xid: msg.xid,
-      changes: [],
-      commit_timestamp: msg.commit_timestamp,
-      origin: state.origin,
-      origin_type: :postgresql,
-      publication: state.publication
-    }
-
-    {:noreply, [], %{state | transaction: {msg.final_lsn, tx}}}
-  end
-
-  defp process_message(%Origin{} = msg, state) do
-    # If we got the "origin" message, it means that the Postgres sending back the transaction we sent from Electric
-    # We ignored those previously, when Vaxine was the source of truth, but now we need to fan out those processed messages
-    # to all the Satellites as their write has been "accepted"
-    Logger.debug("origin: #{inspect(msg.name)}")
-    {:noreply, [], state}
-  end
-
-  defp process_message(%Type{}, state), do: {:noreply, [], state}
-
-  defp process_message(%Relation{} = rel, state) do
-    state = Map.update!(state, :relations, &Map.put(&1, rel.id, rel))
-    {:noreply, [], state}
-  end
-
-  defp process_message(%Insert{} = msg, %State{} = state) do
-    relation = Map.get(state.relations, msg.relation_id)
-
-    data = data_tuple_to_map(relation.columns, msg.tuple_data)
-
-    new_record = %NewRecord{relation: {relation.namespace, relation.name}, record: data}
-
-    {lsn, txn} = state.transaction
-    txn = %{txn | changes: [new_record | txn.changes]}
-
-    {:noreply, [], %{state | transaction: {lsn, txn}}}
-  end
-
-  defp process_message(%Update{} = msg, %State{} = state) do
-    relation = Map.get(state.relations, msg.relation_id)
-
-    old_data = data_tuple_to_map(relation.columns, msg.old_tuple_data)
-    data = data_tuple_to_map(relation.columns, msg.tuple_data)
-
-    updated_record =
-      UpdatedRecord.new(
-        relation: {relation.namespace, relation.name},
-        old_record: old_data,
-        record: data
-      )
-
-    {lsn, txn} = state.transaction
-    txn = %{txn | changes: [updated_record | txn.changes]}
-
-    {:noreply, [], %{state | transaction: {lsn, txn}}}
-  end
-
-  defp process_message(%Delete{} = msg, %State{} = state) do
-    relation = Map.get(state.relations, msg.relation_id)
-
-    data =
-      data_tuple_to_map(
-        relation.columns,
-        msg.old_tuple_data || msg.changed_key_tuple_data
-      )
-
-    deleted_record = %DeletedRecord{
-      relation: {relation.namespace, relation.name},
-      old_record: data
-    }
-
-    {lsn, txn} = state.transaction
-    txn = %{txn | changes: [deleted_record | txn.changes]}
-
-    {:noreply, [], %{state | transaction: {lsn, txn}}}
-  end
-
-  defp process_message(%Truncate{} = msg, state) do
-    truncated_relations =
-      for truncated_relation <- msg.truncated_relations do
-        relation = Map.get(state.relations, truncated_relation)
-
-        %TruncatedRelation{
-          relation: {relation.namespace, relation.name}
-        }
-      end
-
-    {lsn, txn} = state.transaction
-    txn = %{txn | changes: Enum.reverse(truncated_relations) ++ txn.changes}
-
-    {:noreply, [], %{state | transaction: {lsn, txn}}}
-  end
-
-  # When we have a new event, enqueue it and see if there's any
-  # pending demand we can meet by dispatching events.
-
-  defp process_message(
-         %Commit{lsn: commit_lsn, end_lsn: end_lsn},
-         %State{transaction: {current_txn_lsn, txn}, queue: queue} = state
-       )
-       when commit_lsn == current_txn_lsn do
-    event =
-      txn
-      |> ShadowTableTransformation.enrich_tx_from_shadow_ops()
-      |> build_message(end_lsn, state)
-
-    Metrics.span_event(state.span, :transaction, Transaction.count_operations(event))
-
-    queue = :queue.in(event, queue)
-    state = %{state | queue: queue, transaction: nil}
-
-    dispatch_events(state, [])
   end
 
   # When we have new demand, add it to any pending demand and see if we can
@@ -401,32 +260,29 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     {:noreply, Enum.reverse(events), state}
   end
 
-  @spec data_tuple_to_map([Relation.Column.t()], list()) :: term()
-  defp data_tuple_to_map(_columns, nil), do: %{}
-
-  defp data_tuple_to_map(columns, tuple_data) do
-    columns
-    |> Enum.zip(tuple_data)
-    |> Map.new(fn {column, data} -> {column.name, data} end)
-  end
-
-  defp build_message(%Transaction{} = transaction, end_lsn, %State{} = state) do
+  defp finalize_transaction(%Transaction{} = tx, %State{} = state) do
+    # Make sure not to pass state.field into ack function, as this
+    # would create a copy of the whole state in memory when sending a message
     repl_conn = state.repl_conn
     origin = state.origin
-
-    %Transaction{
-      transaction
-      | lsn: end_lsn,
-        # Make sure not to pass state.field into ack function, as this
-        # will create a copy of the whole state in memory when sending a message
-        ack_fn: fn -> ack(repl_conn, origin, end_lsn) end
-    }
+    lsn = tx.lsn
+    %{tx | ack_fn: fn -> ack(repl_conn, origin, lsn) end}
   end
 
   @spec ack(pid(), Connectors.origin(), Lsn.t()) :: :ok
   def ack(repl_conn, origin, lsn) do
     Logger.debug("Acknowledging #{lsn}", origin: origin)
     Client.acknowledge_lsn(repl_conn, lsn)
+  end
+
+  defp enqueue_transaction(%Transaction{} = tx, %State{} = state) do
+    Metrics.span_event(state.span, :transaction, Transaction.count_operations(tx))
+
+    %{state | queue: :queue.in(tx, state.queue)}
+    |> reset_replication_context()
+    |> set_current_lsn(tx.lsn)
+    |> advance_main_slot()
+    |> dispatch_events([])
   end
 
   # Advance the replication slot to let Postgres discard old WAL records.
@@ -446,10 +302,5 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
     else
       state
     end
-  end
-
-  defp schedule_main_slot_advance(state) do
-    tref = :erlang.start_timer(@advance_timeout, self(), @advance_msg)
-    %State{state | advance_timer: tref}
   end
 end

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -28,7 +28,6 @@ defmodule Electric.Satellite.Protocol do
 
   require Logger
 
-  @type lsn() :: non_neg_integer
   @type deep_msg_list() :: PB.sq_pb_msg() | [deep_msg_list()]
   @type actions() :: {Shapes.subquery_actions(), [non_neg_integer()]}
   @type outgoing() :: {deep_msg_list(), State.t()} | {:error, deep_msg_list(), State.t()}
@@ -121,16 +120,16 @@ defmodule Electric.Satellite.Protocol do
 
   # Satellite client request replication
   def handle_rpc_request(
-        %SatInStartReplicationReq{lsn: client_lsn, options: opts} = msg,
+        %SatInStartReplicationReq{lsn: client_pos, options: opts} = msg,
         %State{} = state
       ) do
     Logger.debug(
-      "Received start replication request lsn: #{inspect(client_lsn)} with options: #{inspect(opts)}"
+      "Received start replication request at client_pos: #{inspect(client_pos)} with options: #{inspect(opts)}"
     )
 
     with :ok <- validate_schema_version(msg.schema_version),
-         {:ok, lsn} <- validate_lsn(client_lsn) do
-      handle_start_replication_request(msg, lsn, state)
+         {:ok, client_pos} <- validate_client_pos(client_pos) do
+      handle_start_replication_request(msg, client_pos, state)
     else
       {:error, :bad_schema_version} ->
         Logger.warning("Unknown client schema version: #{inspect(msg.schema_version)}")
@@ -141,8 +140,8 @@ defmodule Electric.Satellite.Protocol do
            "Unknown schema version: #{inspect(msg.schema_version)}"
          )}
 
-      {:error, {:malformed_lsn, client_lsn}} ->
-        Logger.warning("Client has supplied invalid LSN in the request: #{inspect(client_lsn)}")
+      {:error, {:malformed_pos, client_pos}} ->
+        Logger.warning("Client has supplied invalid LSN in the request: #{inspect(client_pos)}")
 
         {:error,
          start_replication_error(:MALFORMED_LSN, "Could not validate start replication request")}
@@ -522,28 +521,44 @@ defmodule Electric.Satellite.Protocol do
      )}
   end
 
-  defp handle_start_replication_request(msg, lsn, state) do
-    if CachedWal.Api.lsn_in_cached_window?(state.origin, lsn) do
-      case restore_client_state(msg.subscription_ids, msg.observed_transaction_data, lsn, state) do
-        {:ok, state} ->
+  defp handle_start_replication_request(msg, client_pos, state) do
+    case reserve_wal_position(state.origin, state.client_id, client_pos) do
+      :cached ->
+        # Fast path: the client can resume replication by consuming transactions cached in main memory.
+        with {:ok, state} <-
+               restore_client_state(
+                 msg.subscription_ids,
+                 msg.observed_transaction_data,
+                 client_pos,
+                 state
+               ) do
           state =
             state
             |> Telemetry.start_replication_span(subscriptions: length(msg.subscription_ids))
-            |> subscribe_client_to_replication_stream(lsn)
+            |> subscribe_client_to_replication_stream(client_pos)
 
           {:reply,
            %SatInStartReplicationResp{unacked_window_size: state.out_rep.allowed_unacked_txs},
            state}
+        end
 
-        error ->
-          error
-      end
-    else
-      # Once the client is outside the WAL window, we are assuming the client will reset its local state, so we will too.
-      ClientReconnectionInfo.clear_all_data(state.client_id)
+      :behind_window ->
+        # Once the client is outside the WAL window, we are assuming the client will reset
+        # its local state, so we will too.
+        ClientReconnectionInfo.clear_all_data(state.client_id)
 
-      {:error,
-       start_replication_error(:BEHIND_WINDOW, "Cannot catch up to the server's current state")}
+        {:error,
+         start_replication_error(:BEHIND_WINDOW, "Cannot catch up to the server's current state")}
+    end
+  end
+
+  defp reserve_wal_position(origin, client_id, client_pos) do
+    cond do
+      CachedWal.Api.reserve_wal_position(origin, client_id, client_pos) == :ok ->
+        :cached
+
+      true ->
+        :behind_window
     end
   end
 
@@ -658,26 +673,28 @@ defmodule Electric.Satellite.Protocol do
     {serialize_unknown_relations(unknown_relations), serialized_log, out_rep}
   end
 
-  @spec subscribe_client_to_replication_stream(State.t(), any()) :: State.t()
-  def subscribe_client_to_replication_stream(%State{out_rep: out_rep} = state, lsn) do
+  @spec subscribe_client_to_replication_stream(State.t(), non_neg_integer()) :: State.t()
+  def subscribe_client_to_replication_stream(%State{out_rep: out_rep} = state, client_pos) do
     Metrics.satellite_replication_event(%{started: 1})
 
     {pid, ref} =
       Utils.GenStageHelpers.gproc_subscribe_self!(
         to: CachedWal.Producer.name(state.client_id),
-        start_subscription: lsn,
+        start_subscription: client_pos,
         min_demand: 5,
         max_demand: 10
       )
 
     Utils.GenStageHelpers.ask({pid, ref}, @producer_demand)
 
+    CachedWal.Api.cancel_reservation(state.origin, state.client_id)
+
     out_rep = %OutRep{
       out_rep
       | pid: pid,
         status: :active,
         stage_sub: ref,
-        last_seen_wal_pos: lsn
+        last_seen_wal_pos: client_pos
     }
 
     %State{state | out_rep: out_rep}
@@ -979,12 +996,12 @@ defmodule Electric.Satellite.Protocol do
     end
   end
 
-  defp validate_lsn(""), do: {:ok, :initial_sync}
+  defp validate_client_pos(""), do: {:ok, :initial_sync}
 
-  defp validate_lsn(client_lsn) do
-    case CachedWal.Api.parse_wal_position(client_lsn) do
+  defp validate_client_pos(client_pos) do
+    case CachedWal.Api.parse_wal_position(client_pos) do
       {:ok, value} -> {:ok, value}
-      :error -> {:error, {:malformed_lsn, client_lsn}}
+      :error -> {:error, {:malformed_pos, client_pos}}
     end
   end
 
@@ -1128,15 +1145,15 @@ defmodule Electric.Satellite.Protocol do
     )
   end
 
-  defp restore_client_state(subscription_ids, observed_txn_data, lsn, %State{} = state) do
+  defp restore_client_state(subscription_ids, observed_txn_data, client_pos, %State{} = state) do
     with {:ok, state} <- restore_subscriptions(subscription_ids, state) do
-      restore_graph(lsn, observed_txn_data, state)
+      restore_graph(client_pos, observed_txn_data, state)
     end
   end
 
-  defp restore_graph(lsn, observed_txn_data, %State{} = state) do
+  defp restore_graph(client_pos, observed_txn_data, %State{} = state) do
     ClientReconnectionInfo.advance_on_reconnection(state.client_id,
-      ack_point: lsn,
+      ack_point: client_pos,
       including_data: observed_txn_data,
       including_subscriptions: Map.keys(state.subscriptions),
       cached_wal_impl: CachedWal.EtsBacked,

--- a/components/electric/lib/electric/satellite/protocol/resume_rep.ex
+++ b/components/electric/lib/electric/satellite/protocol/resume_rep.ex
@@ -1,0 +1,32 @@
+defmodule Electric.Satellite.Protocol.ResumeRep do
+  alias Electric.Postgres.LogicalReplication
+  alias Electric.Postgres.Lsn
+  alias Electric.Replication.Changes.Transaction
+  alias Electric.Replication.Postgres.LogicalMessages
+
+  defstruct [:repl_conn, :repl_context, :end_lsn]
+
+  @type t :: %__MODULE__{
+          repl_conn: :epgsql.connection(),
+          repl_context: LogicalMessages.Context.t(),
+          end_lsn: Lsn.t()
+        }
+
+  def process_message(binary_msg, %__MODULE__{} = rep) do
+    rep =
+      update_in(rep.repl_context, fn context ->
+        binary_msg
+        |> LogicalReplication.decode_message()
+        |> LogicalMessages.process(context)
+      end)
+
+    case rep.repl_context.transaction do
+      nil -> {nil, rep}
+      %Transaction{} = tx -> {tx, reset_tx(rep)}
+    end
+  end
+
+  defp reset_tx(%__MODULE__{} = rep) do
+    update_in(rep.repl_context, &LogicalMessages.Context.reset_tx/1)
+  end
+end


### PR DESCRIPTION
This PR makes it possible to resume clients whose position in the replication stream is outside of the in-memory cached WAL window. This is done by streaming transactions directly from the replication slot. Assuming the slot's start position go back further than the in-memory cache can fit, this effectively extends the resumable WAL window that the sync service can use to avoid asking clients to reset their local state.

This implementation builds on the primitives introduced in https://github.com/electric-sql/electric/pull/1119.