### PR TITLE
fix(client): Fix attempts to query for null FKs when dealing with nullable FK models

### DIFF
--- a/.changeset/ninety-spoons-sneeze.md
+++ b/.changeset/ninety-spoons-sneeze.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix queries trying to retrieve relations using `null` foreign keys.

--- a/clients/typescript/src/client/model/table.ts
+++ b/clients/typescript/src/client/model/table.ts
@@ -720,7 +720,9 @@ export class Table<
     const otherTable = this._tables.get(relatedTable)!
     const args = includeArg === true ? {} : includeArg
     const where = typeof args.where === 'undefined' ? {} : args.where
-    const foreignKeys = rows.map((row) => row[fromField as keyof typeof row])
+    const foreignKeys = rows
+      .map((row) => row[fromField as keyof typeof row])
+      .filter((fk) => fk !== null && fk !== undefined)
     otherTable._findMany(
       {
         ...args,

--- a/clients/typescript/test/cli/migrations/migrate.generation.test.ts
+++ b/clients/typescript/test/cli/migrations/migrate.generation.test.ts
@@ -167,7 +167,7 @@ test.before(() => {
   }
 })
 
-test.after(() => {
+test.after.always(() => {
   // avoid deleting whole temp directory as it might be used by
   // other tests as well
   const files = fs.readdirSync(tempDir)

--- a/clients/typescript/test/client/generateTestClient.ts
+++ b/clients/typescript/test/client/generateTestClient.ts
@@ -37,6 +37,14 @@ model Profile {
   meta   Json?
   userId Int    @unique
   user   User?  @relation(fields: [userId], references: [id])
+  imageId  String? @unique
+  image    ProfileImage? @relation(fields: [imageId], references: [id])
+}
+
+model ProfileImage {
+  id        String    @id
+  image     Bytes
+  profile   Profile?
 }
 
 model DataTypes {

--- a/clients/typescript/test/client/generated/index.ts
+++ b/clients/typescript/test/client/generated/index.ts
@@ -57,7 +57,9 @@ export const NullableJsonNullValueInputSchema = z.enum(['DbNull','JsonNull',])
 
 export const PostScalarFieldEnumSchema = z.enum(['id','title','contents','nbr','authorId']);
 
-export const ProfileScalarFieldEnumSchema = z.enum(['id','bio','meta','userId']);
+export const ProfileImageScalarFieldEnumSchema = z.enum(['id','image']);
+
+export const ProfileScalarFieldEnumSchema = z.enum(['id','bio','meta','userId','imageId']);
 
 export const QueryModeSchema = z.enum(['default','insensitive']);
 
@@ -116,9 +118,21 @@ export const ProfileSchema = z.object({
   bio: z.string(),
   meta: NullableJsonValue.optional(),
   userId: z.number().int().gte(-2147483648).lte(2147483647),
+  imageId: z.string().nullable(),
 })
 
 export type Profile = z.infer<typeof ProfileSchema>
+
+/////////////////////////////////////////
+// PROFILE IMAGE SCHEMA
+/////////////////////////////////////////
+
+export const ProfileImageSchema = z.object({
+  id: z.string(),
+  image: z.instanceof(Uint8Array),
+})
+
+export type ProfileImage = z.infer<typeof ProfileImageSchema>
 
 /////////////////////////////////////////
 // DATA TYPES SCHEMA
@@ -225,6 +239,7 @@ export const PostSelectSchema: z.ZodType<Prisma.PostSelect> = z.object({
 
 export const ProfileIncludeSchema: z.ZodType<Prisma.ProfileInclude> = z.object({
   user: z.union([z.boolean(),z.lazy(() => UserArgsSchema)]).optional(),
+  image: z.union([z.boolean(),z.lazy(() => ProfileImageArgsSchema)]).optional(),
 }).strict()
 
 export const ProfileArgsSchema: z.ZodType<Prisma.ProfileArgs> = z.object({
@@ -238,6 +253,26 @@ export const ProfileSelectSchema: z.ZodType<Prisma.ProfileSelect> = z.object({
   meta: z.boolean().optional(),
   userId: z.boolean().optional(),
   user: z.union([z.boolean(),z.lazy(() => UserArgsSchema)]).optional(),
+  imageId: z.boolean().optional(),
+  image: z.union([z.boolean(),z.lazy(() => ProfileImageArgsSchema)]).optional(),
+}).strict()
+
+// PROFILE IMAGE
+//------------------------------------------------------
+
+export const ProfileImageIncludeSchema: z.ZodType<Prisma.ProfileImageInclude> = z.object({
+  profile: z.union([z.boolean(),z.lazy(() => ProfileArgsSchema)]).optional(),
+}).strict()
+
+export const ProfileImageArgsSchema: z.ZodType<Prisma.ProfileImageArgs> = z.object({
+  select: z.lazy(() => ProfileImageSelectSchema).optional(),
+  include: z.lazy(() => ProfileImageIncludeSchema).optional(),
+}).strict();
+
+export const ProfileImageSelectSchema: z.ZodType<Prisma.ProfileImageSelect> = z.object({
+  id: z.boolean().optional(),
+  image: z.boolean().optional(),
+  profile: z.union([z.boolean(),z.lazy(() => ProfileArgsSchema)]).optional(),
 }).strict()
 
 // DATA TYPES
@@ -442,6 +477,8 @@ export const ProfileWhereInputSchema: z.ZodType<Prisma.ProfileWhereInput> = z.ob
   meta: z.lazy(() => JsonNullableFilterSchema).optional(),
   userId: z.union([ z.lazy(() => IntFilterSchema),z.number() ]).optional(),
   user: z.union([ z.lazy(() => UserRelationFilterSchema),z.lazy(() => UserWhereInputSchema) ]).optional().nullable(),
+  imageId: z.union([ z.lazy(() => StringNullableFilterSchema),z.string() ]).optional().nullable(),
+  image: z.union([ z.lazy(() => ProfileImageRelationFilterSchema),z.lazy(() => ProfileImageWhereInputSchema) ]).optional().nullable(),
 }).strict();
 
 export const ProfileOrderByWithRelationInputSchema: z.ZodType<Prisma.ProfileOrderByWithRelationInput> = z.object({
@@ -449,12 +486,15 @@ export const ProfileOrderByWithRelationInputSchema: z.ZodType<Prisma.ProfileOrde
   bio: z.lazy(() => SortOrderSchema).optional(),
   meta: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
-  user: z.lazy(() => UserOrderByWithRelationInputSchema).optional()
+  user: z.lazy(() => UserOrderByWithRelationInputSchema).optional(),
+  imageId: z.lazy(() => SortOrderSchema).optional(),
+  image: z.lazy(() => ProfileImageOrderByWithRelationInputSchema).optional()
 }).strict();
 
 export const ProfileWhereUniqueInputSchema: z.ZodType<Prisma.ProfileWhereUniqueInput> = z.object({
   id: z.number().int().gte(-2147483648).lte(2147483647).optional(),
-  userId: z.number().int().gte(-2147483648).lte(2147483647).optional()
+  userId: z.number().int().gte(-2147483648).lte(2147483647).optional(),
+  imageId: z.string().optional()
 }).strict();
 
 export const ProfileOrderByWithAggregationInputSchema: z.ZodType<Prisma.ProfileOrderByWithAggregationInput> = z.object({
@@ -462,6 +502,7 @@ export const ProfileOrderByWithAggregationInputSchema: z.ZodType<Prisma.ProfileO
   bio: z.lazy(() => SortOrderSchema).optional(),
   meta: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
+  imageId: z.lazy(() => SortOrderSchema).optional(),
   _count: z.lazy(() => ProfileCountOrderByAggregateInputSchema).optional(),
   _avg: z.lazy(() => ProfileAvgOrderByAggregateInputSchema).optional(),
   _max: z.lazy(() => ProfileMaxOrderByAggregateInputSchema).optional(),
@@ -477,6 +518,42 @@ export const ProfileScalarWhereWithAggregatesInputSchema: z.ZodType<Prisma.Profi
   bio: z.union([ z.lazy(() => StringWithAggregatesFilterSchema),z.string() ]).optional(),
   meta: z.lazy(() => JsonNullableWithAggregatesFilterSchema).optional(),
   userId: z.union([ z.lazy(() => IntWithAggregatesFilterSchema),z.number() ]).optional(),
+  imageId: z.union([ z.lazy(() => StringNullableWithAggregatesFilterSchema),z.string() ]).optional().nullable(),
+}).strict();
+
+export const ProfileImageWhereInputSchema: z.ZodType<Prisma.ProfileImageWhereInput> = z.object({
+  AND: z.union([ z.lazy(() => ProfileImageWhereInputSchema),z.lazy(() => ProfileImageWhereInputSchema).array() ]).optional(),
+  OR: z.lazy(() => ProfileImageWhereInputSchema).array().optional(),
+  NOT: z.union([ z.lazy(() => ProfileImageWhereInputSchema),z.lazy(() => ProfileImageWhereInputSchema).array() ]).optional(),
+  id: z.union([ z.lazy(() => StringFilterSchema),z.string() ]).optional(),
+  image: z.union([ z.lazy(() => BytesFilterSchema),z.instanceof(Uint8Array) ]).optional(),
+  profile: z.union([ z.lazy(() => ProfileRelationFilterSchema),z.lazy(() => ProfileWhereInputSchema) ]).optional().nullable(),
+}).strict();
+
+export const ProfileImageOrderByWithRelationInputSchema: z.ZodType<Prisma.ProfileImageOrderByWithRelationInput> = z.object({
+  id: z.lazy(() => SortOrderSchema).optional(),
+  image: z.lazy(() => SortOrderSchema).optional(),
+  profile: z.lazy(() => ProfileOrderByWithRelationInputSchema).optional()
+}).strict();
+
+export const ProfileImageWhereUniqueInputSchema: z.ZodType<Prisma.ProfileImageWhereUniqueInput> = z.object({
+  id: z.string().optional()
+}).strict();
+
+export const ProfileImageOrderByWithAggregationInputSchema: z.ZodType<Prisma.ProfileImageOrderByWithAggregationInput> = z.object({
+  id: z.lazy(() => SortOrderSchema).optional(),
+  image: z.lazy(() => SortOrderSchema).optional(),
+  _count: z.lazy(() => ProfileImageCountOrderByAggregateInputSchema).optional(),
+  _max: z.lazy(() => ProfileImageMaxOrderByAggregateInputSchema).optional(),
+  _min: z.lazy(() => ProfileImageMinOrderByAggregateInputSchema).optional()
+}).strict();
+
+export const ProfileImageScalarWhereWithAggregatesInputSchema: z.ZodType<Prisma.ProfileImageScalarWhereWithAggregatesInput> = z.object({
+  AND: z.union([ z.lazy(() => ProfileImageScalarWhereWithAggregatesInputSchema),z.lazy(() => ProfileImageScalarWhereWithAggregatesInputSchema).array() ]).optional(),
+  OR: z.lazy(() => ProfileImageScalarWhereWithAggregatesInputSchema).array().optional(),
+  NOT: z.union([ z.lazy(() => ProfileImageScalarWhereWithAggregatesInputSchema),z.lazy(() => ProfileImageScalarWhereWithAggregatesInputSchema).array() ]).optional(),
+  id: z.union([ z.lazy(() => StringWithAggregatesFilterSchema),z.string() ]).optional(),
+  image: z.union([ z.lazy(() => BytesWithAggregatesFilterSchema),z.instanceof(Uint8Array) ]).optional(),
 }).strict();
 
 export const DataTypesWhereInputSchema: z.ZodType<Prisma.DataTypesWhereInput> = z.object({
@@ -754,21 +831,24 @@ export const ProfileCreateInputSchema: z.ZodType<Prisma.ProfileCreateInput> = z.
   id: z.number().int().gte(-2147483648).lte(2147483647),
   bio: z.string(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
-  user: z.lazy(() => UserCreateNestedOneWithoutProfileInputSchema).optional()
+  user: z.lazy(() => UserCreateNestedOneWithoutProfileInputSchema).optional(),
+  image: z.lazy(() => ProfileImageCreateNestedOneWithoutProfileInputSchema).optional()
 }).strict();
 
 export const ProfileUncheckedCreateInputSchema: z.ZodType<Prisma.ProfileUncheckedCreateInput> = z.object({
   id: z.number().int().gte(-2147483648).lte(2147483647),
   bio: z.string(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
-  userId: z.number().int().gte(-2147483648).lte(2147483647)
+  userId: z.number().int().gte(-2147483648).lte(2147483647),
+  imageId: z.string().optional().nullable()
 }).strict();
 
 export const ProfileUpdateInputSchema: z.ZodType<Prisma.ProfileUpdateInput> = z.object({
   id: z.union([ z.number().int().gte(-2147483648).lte(2147483647),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
-  user: z.lazy(() => UserUpdateOneWithoutProfileNestedInputSchema).optional()
+  user: z.lazy(() => UserUpdateOneWithoutProfileNestedInputSchema).optional(),
+  image: z.lazy(() => ProfileImageUpdateOneWithoutProfileNestedInputSchema).optional()
 }).strict();
 
 export const ProfileUncheckedUpdateInputSchema: z.ZodType<Prisma.ProfileUncheckedUpdateInput> = z.object({
@@ -776,13 +856,15 @@ export const ProfileUncheckedUpdateInputSchema: z.ZodType<Prisma.ProfileUnchecke
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
   userId: z.union([ z.number().int().gte(-2147483648).lte(2147483647),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
+  imageId: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
 }).strict();
 
 export const ProfileCreateManyInputSchema: z.ZodType<Prisma.ProfileCreateManyInput> = z.object({
   id: z.number().int().gte(-2147483648).lte(2147483647),
   bio: z.string(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
-  userId: z.number().int().gte(-2147483648).lte(2147483647)
+  userId: z.number().int().gte(-2147483648).lte(2147483647),
+  imageId: z.string().optional().nullable()
 }).strict();
 
 export const ProfileUpdateManyMutationInputSchema: z.ZodType<Prisma.ProfileUpdateManyMutationInput> = z.object({
@@ -796,6 +878,46 @@ export const ProfileUncheckedUpdateManyInputSchema: z.ZodType<Prisma.ProfileUnch
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
   userId: z.union([ z.number().int().gte(-2147483648).lte(2147483647),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
+  imageId: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
+}).strict();
+
+export const ProfileImageCreateInputSchema: z.ZodType<Prisma.ProfileImageCreateInput> = z.object({
+  id: z.string(),
+  image: z.instanceof(Uint8Array),
+  profile: z.lazy(() => ProfileCreateNestedOneWithoutImageInputSchema).optional()
+}).strict();
+
+export const ProfileImageUncheckedCreateInputSchema: z.ZodType<Prisma.ProfileImageUncheckedCreateInput> = z.object({
+  id: z.string(),
+  image: z.instanceof(Uint8Array),
+  profile: z.lazy(() => ProfileUncheckedCreateNestedOneWithoutImageInputSchema).optional()
+}).strict();
+
+export const ProfileImageUpdateInputSchema: z.ZodType<Prisma.ProfileImageUpdateInput> = z.object({
+  id: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  image: z.union([ z.instanceof(Uint8Array),z.lazy(() => BytesFieldUpdateOperationsInputSchema) ]).optional(),
+  profile: z.lazy(() => ProfileUpdateOneWithoutImageNestedInputSchema).optional()
+}).strict();
+
+export const ProfileImageUncheckedUpdateInputSchema: z.ZodType<Prisma.ProfileImageUncheckedUpdateInput> = z.object({
+  id: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  image: z.union([ z.instanceof(Uint8Array),z.lazy(() => BytesFieldUpdateOperationsInputSchema) ]).optional(),
+  profile: z.lazy(() => ProfileUncheckedUpdateOneWithoutImageNestedInputSchema).optional()
+}).strict();
+
+export const ProfileImageCreateManyInputSchema: z.ZodType<Prisma.ProfileImageCreateManyInput> = z.object({
+  id: z.string(),
+  image: z.instanceof(Uint8Array)
+}).strict();
+
+export const ProfileImageUpdateManyMutationInputSchema: z.ZodType<Prisma.ProfileImageUpdateManyMutationInput> = z.object({
+  id: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  image: z.union([ z.instanceof(Uint8Array),z.lazy(() => BytesFieldUpdateOperationsInputSchema) ]).optional(),
+}).strict();
+
+export const ProfileImageUncheckedUpdateManyInputSchema: z.ZodType<Prisma.ProfileImageUncheckedUpdateManyInput> = z.object({
+  id: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  image: z.union([ z.instanceof(Uint8Array),z.lazy(() => BytesFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const DataTypesCreateInputSchema: z.ZodType<Prisma.DataTypesCreateInput> = z.object({
@@ -1210,11 +1332,17 @@ export const JsonNullableFilterSchema: z.ZodType<Prisma.JsonNullableFilter> = z.
   not: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
 }).strict();
 
+export const ProfileImageRelationFilterSchema: z.ZodType<Prisma.ProfileImageRelationFilter> = z.object({
+  is: z.lazy(() => ProfileImageWhereInputSchema).optional().nullable(),
+  isNot: z.lazy(() => ProfileImageWhereInputSchema).optional().nullable()
+}).strict();
+
 export const ProfileCountOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileCountOrderByAggregateInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   bio: z.lazy(() => SortOrderSchema).optional(),
   meta: z.lazy(() => SortOrderSchema).optional(),
-  userId: z.lazy(() => SortOrderSchema).optional()
+  userId: z.lazy(() => SortOrderSchema).optional(),
+  imageId: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const ProfileAvgOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileAvgOrderByAggregateInput> = z.object({
@@ -1225,13 +1353,15 @@ export const ProfileAvgOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileAvgO
 export const ProfileMaxOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileMaxOrderByAggregateInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   bio: z.lazy(() => SortOrderSchema).optional(),
-  userId: z.lazy(() => SortOrderSchema).optional()
+  userId: z.lazy(() => SortOrderSchema).optional(),
+  imageId: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const ProfileMinOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileMinOrderByAggregateInput> = z.object({
   id: z.lazy(() => SortOrderSchema).optional(),
   bio: z.lazy(() => SortOrderSchema).optional(),
-  userId: z.lazy(() => SortOrderSchema).optional()
+  userId: z.lazy(() => SortOrderSchema).optional(),
+  imageId: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const ProfileSumOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileSumOrderByAggregateInput> = z.object({
@@ -1256,6 +1386,38 @@ export const JsonNullableWithAggregatesFilterSchema: z.ZodType<Prisma.JsonNullab
   _count: z.lazy(() => NestedIntNullableFilterSchema).optional(),
   _min: z.lazy(() => NestedJsonNullableFilterSchema).optional(),
   _max: z.lazy(() => NestedJsonNullableFilterSchema).optional()
+}).strict();
+
+export const BytesFilterSchema: z.ZodType<Prisma.BytesFilter> = z.object({
+  equals: z.instanceof(Uint8Array).optional(),
+  in: z.instanceof(Uint8Array).array().optional(),
+  notIn: z.instanceof(Uint8Array).array().optional(),
+  not: z.union([ z.instanceof(Uint8Array),z.lazy(() => NestedBytesFilterSchema) ]).optional(),
+}).strict();
+
+export const ProfileImageCountOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileImageCountOrderByAggregateInput> = z.object({
+  id: z.lazy(() => SortOrderSchema).optional(),
+  image: z.lazy(() => SortOrderSchema).optional()
+}).strict();
+
+export const ProfileImageMaxOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileImageMaxOrderByAggregateInput> = z.object({
+  id: z.lazy(() => SortOrderSchema).optional(),
+  image: z.lazy(() => SortOrderSchema).optional()
+}).strict();
+
+export const ProfileImageMinOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileImageMinOrderByAggregateInput> = z.object({
+  id: z.lazy(() => SortOrderSchema).optional(),
+  image: z.lazy(() => SortOrderSchema).optional()
+}).strict();
+
+export const BytesWithAggregatesFilterSchema: z.ZodType<Prisma.BytesWithAggregatesFilter> = z.object({
+  equals: z.instanceof(Uint8Array).optional(),
+  in: z.instanceof(Uint8Array).array().optional(),
+  notIn: z.instanceof(Uint8Array).array().optional(),
+  not: z.union([ z.instanceof(Uint8Array),z.lazy(() => NestedBytesWithAggregatesFilterSchema) ]).optional(),
+  _count: z.lazy(() => NestedIntFilterSchema).optional(),
+  _min: z.lazy(() => NestedBytesFilterSchema).optional(),
+  _max: z.lazy(() => NestedBytesFilterSchema).optional()
 }).strict();
 
 export const DateTimeNullableFilterSchema: z.ZodType<Prisma.DateTimeNullableFilter> = z.object({
@@ -1627,6 +1789,12 @@ export const UserCreateNestedOneWithoutProfileInputSchema: z.ZodType<Prisma.User
   connect: z.lazy(() => UserWhereUniqueInputSchema).optional()
 }).strict();
 
+export const ProfileImageCreateNestedOneWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageCreateNestedOneWithoutProfileInput> = z.object({
+  create: z.union([ z.lazy(() => ProfileImageCreateWithoutProfileInputSchema),z.lazy(() => ProfileImageUncheckedCreateWithoutProfileInputSchema) ]).optional(),
+  connectOrCreate: z.lazy(() => ProfileImageCreateOrConnectWithoutProfileInputSchema).optional(),
+  connect: z.lazy(() => ProfileImageWhereUniqueInputSchema).optional()
+}).strict();
+
 export const UserUpdateOneWithoutProfileNestedInputSchema: z.ZodType<Prisma.UserUpdateOneWithoutProfileNestedInput> = z.object({
   create: z.union([ z.lazy(() => UserCreateWithoutProfileInputSchema),z.lazy(() => UserUncheckedCreateWithoutProfileInputSchema) ]).optional(),
   connectOrCreate: z.lazy(() => UserCreateOrConnectWithoutProfileInputSchema).optional(),
@@ -1635,6 +1803,52 @@ export const UserUpdateOneWithoutProfileNestedInputSchema: z.ZodType<Prisma.User
   delete: z.boolean().optional(),
   connect: z.lazy(() => UserWhereUniqueInputSchema).optional(),
   update: z.union([ z.lazy(() => UserUpdateWithoutProfileInputSchema),z.lazy(() => UserUncheckedUpdateWithoutProfileInputSchema) ]).optional(),
+}).strict();
+
+export const ProfileImageUpdateOneWithoutProfileNestedInputSchema: z.ZodType<Prisma.ProfileImageUpdateOneWithoutProfileNestedInput> = z.object({
+  create: z.union([ z.lazy(() => ProfileImageCreateWithoutProfileInputSchema),z.lazy(() => ProfileImageUncheckedCreateWithoutProfileInputSchema) ]).optional(),
+  connectOrCreate: z.lazy(() => ProfileImageCreateOrConnectWithoutProfileInputSchema).optional(),
+  upsert: z.lazy(() => ProfileImageUpsertWithoutProfileInputSchema).optional(),
+  disconnect: z.boolean().optional(),
+  delete: z.boolean().optional(),
+  connect: z.lazy(() => ProfileImageWhereUniqueInputSchema).optional(),
+  update: z.union([ z.lazy(() => ProfileImageUpdateWithoutProfileInputSchema),z.lazy(() => ProfileImageUncheckedUpdateWithoutProfileInputSchema) ]).optional(),
+}).strict();
+
+export const ProfileCreateNestedOneWithoutImageInputSchema: z.ZodType<Prisma.ProfileCreateNestedOneWithoutImageInput> = z.object({
+  create: z.union([ z.lazy(() => ProfileCreateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedCreateWithoutImageInputSchema) ]).optional(),
+  connectOrCreate: z.lazy(() => ProfileCreateOrConnectWithoutImageInputSchema).optional(),
+  connect: z.lazy(() => ProfileWhereUniqueInputSchema).optional()
+}).strict();
+
+export const ProfileUncheckedCreateNestedOneWithoutImageInputSchema: z.ZodType<Prisma.ProfileUncheckedCreateNestedOneWithoutImageInput> = z.object({
+  create: z.union([ z.lazy(() => ProfileCreateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedCreateWithoutImageInputSchema) ]).optional(),
+  connectOrCreate: z.lazy(() => ProfileCreateOrConnectWithoutImageInputSchema).optional(),
+  connect: z.lazy(() => ProfileWhereUniqueInputSchema).optional()
+}).strict();
+
+export const BytesFieldUpdateOperationsInputSchema: z.ZodType<Prisma.BytesFieldUpdateOperationsInput> = z.object({
+  set: z.instanceof(Uint8Array).optional()
+}).strict();
+
+export const ProfileUpdateOneWithoutImageNestedInputSchema: z.ZodType<Prisma.ProfileUpdateOneWithoutImageNestedInput> = z.object({
+  create: z.union([ z.lazy(() => ProfileCreateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedCreateWithoutImageInputSchema) ]).optional(),
+  connectOrCreate: z.lazy(() => ProfileCreateOrConnectWithoutImageInputSchema).optional(),
+  upsert: z.lazy(() => ProfileUpsertWithoutImageInputSchema).optional(),
+  disconnect: z.boolean().optional(),
+  delete: z.boolean().optional(),
+  connect: z.lazy(() => ProfileWhereUniqueInputSchema).optional(),
+  update: z.union([ z.lazy(() => ProfileUpdateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedUpdateWithoutImageInputSchema) ]).optional(),
+}).strict();
+
+export const ProfileUncheckedUpdateOneWithoutImageNestedInputSchema: z.ZodType<Prisma.ProfileUncheckedUpdateOneWithoutImageNestedInput> = z.object({
+  create: z.union([ z.lazy(() => ProfileCreateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedCreateWithoutImageInputSchema) ]).optional(),
+  connectOrCreate: z.lazy(() => ProfileCreateOrConnectWithoutImageInputSchema).optional(),
+  upsert: z.lazy(() => ProfileUpsertWithoutImageInputSchema).optional(),
+  disconnect: z.boolean().optional(),
+  delete: z.boolean().optional(),
+  connect: z.lazy(() => ProfileWhereUniqueInputSchema).optional(),
+  update: z.union([ z.lazy(() => ProfileUpdateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedUpdateWithoutImageInputSchema) ]).optional(),
 }).strict();
 
 export const DummyCreateNestedOneWithoutDatatypeInputSchema: z.ZodType<Prisma.DummyCreateNestedOneWithoutDatatypeInput> = z.object({
@@ -1877,6 +2091,23 @@ export const NestedJsonNullableFilterSchema: z.ZodType<Prisma.NestedJsonNullable
   not: z.union([ InputJsonValue,z.lazy(() => JsonNullValueFilterSchema) ]).optional(),
 }).strict();
 
+export const NestedBytesFilterSchema: z.ZodType<Prisma.NestedBytesFilter> = z.object({
+  equals: z.instanceof(Uint8Array).optional(),
+  in: z.instanceof(Uint8Array).array().optional(),
+  notIn: z.instanceof(Uint8Array).array().optional(),
+  not: z.union([ z.instanceof(Uint8Array),z.lazy(() => NestedBytesFilterSchema) ]).optional(),
+}).strict();
+
+export const NestedBytesWithAggregatesFilterSchema: z.ZodType<Prisma.NestedBytesWithAggregatesFilter> = z.object({
+  equals: z.instanceof(Uint8Array).optional(),
+  in: z.instanceof(Uint8Array).array().optional(),
+  notIn: z.instanceof(Uint8Array).array().optional(),
+  not: z.union([ z.instanceof(Uint8Array),z.lazy(() => NestedBytesWithAggregatesFilterSchema) ]).optional(),
+  _count: z.lazy(() => NestedIntFilterSchema).optional(),
+  _min: z.lazy(() => NestedBytesFilterSchema).optional(),
+  _max: z.lazy(() => NestedBytesFilterSchema).optional()
+}).strict();
+
 export const NestedDateTimeNullableFilterSchema: z.ZodType<Prisma.NestedDateTimeNullableFilter> = z.object({
   equals: z.coerce.date().optional().nullable(),
   in: z.coerce.date().array().optional().nullable(),
@@ -2028,12 +2259,14 @@ export const ProfileCreateWithoutUserInputSchema: z.ZodType<Prisma.ProfileCreate
   id: z.number(),
   bio: z.string(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
+  image: z.lazy(() => ProfileImageCreateNestedOneWithoutProfileInputSchema).optional()
 }).strict();
 
 export const ProfileUncheckedCreateWithoutUserInputSchema: z.ZodType<Prisma.ProfileUncheckedCreateWithoutUserInput> = z.object({
   id: z.number(),
   bio: z.string(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
+  imageId: z.string().optional().nullable()
 }).strict();
 
 export const ProfileCreateOrConnectWithoutUserInputSchema: z.ZodType<Prisma.ProfileCreateOrConnectWithoutUserInput> = z.object({
@@ -2077,12 +2310,14 @@ export const ProfileUpdateWithoutUserInputSchema: z.ZodType<Prisma.ProfileUpdate
   id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
+  image: z.lazy(() => ProfileImageUpdateOneWithoutProfileNestedInputSchema).optional()
 }).strict();
 
 export const ProfileUncheckedUpdateWithoutUserInputSchema: z.ZodType<Prisma.ProfileUncheckedUpdateWithoutUserInput> = z.object({
   id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
   bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
+  imageId: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
 }).strict();
 
 export const UserCreateWithoutPostsInputSchema: z.ZodType<Prisma.UserCreateWithoutPostsInput> = z.object({
@@ -2142,6 +2377,21 @@ export const UserCreateOrConnectWithoutProfileInputSchema: z.ZodType<Prisma.User
   create: z.union([ z.lazy(() => UserCreateWithoutProfileInputSchema),z.lazy(() => UserUncheckedCreateWithoutProfileInputSchema) ]),
 }).strict();
 
+export const ProfileImageCreateWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageCreateWithoutProfileInput> = z.object({
+  id: z.string(),
+  image: z.instanceof(Uint8Array)
+}).strict();
+
+export const ProfileImageUncheckedCreateWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageUncheckedCreateWithoutProfileInput> = z.object({
+  id: z.string(),
+  image: z.instanceof(Uint8Array)
+}).strict();
+
+export const ProfileImageCreateOrConnectWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageCreateOrConnectWithoutProfileInput> = z.object({
+  where: z.lazy(() => ProfileImageWhereUniqueInputSchema),
+  create: z.union([ z.lazy(() => ProfileImageCreateWithoutProfileInputSchema),z.lazy(() => ProfileImageUncheckedCreateWithoutProfileInputSchema) ]),
+}).strict();
+
 export const UserUpsertWithoutProfileInputSchema: z.ZodType<Prisma.UserUpsertWithoutProfileInput> = z.object({
   update: z.union([ z.lazy(() => UserUpdateWithoutProfileInputSchema),z.lazy(() => UserUncheckedUpdateWithoutProfileInputSchema) ]),
   create: z.union([ z.lazy(() => UserCreateWithoutProfileInputSchema),z.lazy(() => UserUncheckedCreateWithoutProfileInputSchema) ]),
@@ -2159,6 +2409,59 @@ export const UserUncheckedUpdateWithoutProfileInputSchema: z.ZodType<Prisma.User
   name: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   meta: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   posts: z.lazy(() => PostUncheckedUpdateManyWithoutAuthorNestedInputSchema).optional()
+}).strict();
+
+export const ProfileImageUpsertWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageUpsertWithoutProfileInput> = z.object({
+  update: z.union([ z.lazy(() => ProfileImageUpdateWithoutProfileInputSchema),z.lazy(() => ProfileImageUncheckedUpdateWithoutProfileInputSchema) ]),
+  create: z.union([ z.lazy(() => ProfileImageCreateWithoutProfileInputSchema),z.lazy(() => ProfileImageUncheckedCreateWithoutProfileInputSchema) ]),
+}).strict();
+
+export const ProfileImageUpdateWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageUpdateWithoutProfileInput> = z.object({
+  id: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  image: z.union([ z.instanceof(Uint8Array),z.lazy(() => BytesFieldUpdateOperationsInputSchema) ]).optional(),
+}).strict();
+
+export const ProfileImageUncheckedUpdateWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageUncheckedUpdateWithoutProfileInput> = z.object({
+  id: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  image: z.union([ z.instanceof(Uint8Array),z.lazy(() => BytesFieldUpdateOperationsInputSchema) ]).optional(),
+}).strict();
+
+export const ProfileCreateWithoutImageInputSchema: z.ZodType<Prisma.ProfileCreateWithoutImageInput> = z.object({
+  id: z.number(),
+  bio: z.string(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
+  user: z.lazy(() => UserCreateNestedOneWithoutProfileInputSchema).optional()
+}).strict();
+
+export const ProfileUncheckedCreateWithoutImageInputSchema: z.ZodType<Prisma.ProfileUncheckedCreateWithoutImageInput> = z.object({
+  id: z.number(),
+  bio: z.string(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
+  userId: z.number()
+}).strict();
+
+export const ProfileCreateOrConnectWithoutImageInputSchema: z.ZodType<Prisma.ProfileCreateOrConnectWithoutImageInput> = z.object({
+  where: z.lazy(() => ProfileWhereUniqueInputSchema),
+  create: z.union([ z.lazy(() => ProfileCreateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedCreateWithoutImageInputSchema) ]),
+}).strict();
+
+export const ProfileUpsertWithoutImageInputSchema: z.ZodType<Prisma.ProfileUpsertWithoutImageInput> = z.object({
+  update: z.union([ z.lazy(() => ProfileUpdateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedUpdateWithoutImageInputSchema) ]),
+  create: z.union([ z.lazy(() => ProfileCreateWithoutImageInputSchema),z.lazy(() => ProfileUncheckedCreateWithoutImageInputSchema) ]),
+}).strict();
+
+export const ProfileUpdateWithoutImageInputSchema: z.ZodType<Prisma.ProfileUpdateWithoutImageInput> = z.object({
+  id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
+  bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
+  user: z.lazy(() => UserUpdateOneWithoutProfileNestedInputSchema).optional()
+}).strict();
+
+export const ProfileUncheckedUpdateWithoutImageInputSchema: z.ZodType<Prisma.ProfileUncheckedUpdateWithoutImageInput> = z.object({
+  id: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
+  bio: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
+  meta: z.union([ z.lazy(() => NullableJsonNullValueInputSchema),InputJsonValue ]).optional(),
+  userId: z.union([ z.number(),z.lazy(() => IntFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const DummyCreateWithoutDatatypeInputSchema: z.ZodType<Prisma.DummyCreateWithoutDatatypeInput> = z.object({
@@ -2622,6 +2925,68 @@ export const ProfileFindUniqueOrThrowArgsSchema: z.ZodType<Prisma.ProfileFindUni
   where: ProfileWhereUniqueInputSchema,
 }).strict() as z.ZodType<Prisma.ProfileFindUniqueOrThrowArgs>
 
+export const ProfileImageFindFirstArgsSchema: z.ZodType<Prisma.ProfileImageFindFirstArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  where: ProfileImageWhereInputSchema.optional(),
+  orderBy: z.union([ ProfileImageOrderByWithRelationInputSchema.array(),ProfileImageOrderByWithRelationInputSchema ]).optional(),
+  cursor: ProfileImageWhereUniqueInputSchema.optional(),
+  take: z.number().optional(),
+  skip: z.number().optional(),
+  distinct: ProfileImageScalarFieldEnumSchema.array().optional(),
+}).strict() as z.ZodType<Prisma.ProfileImageFindFirstArgs>
+
+export const ProfileImageFindFirstOrThrowArgsSchema: z.ZodType<Prisma.ProfileImageFindFirstOrThrowArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  where: ProfileImageWhereInputSchema.optional(),
+  orderBy: z.union([ ProfileImageOrderByWithRelationInputSchema.array(),ProfileImageOrderByWithRelationInputSchema ]).optional(),
+  cursor: ProfileImageWhereUniqueInputSchema.optional(),
+  take: z.number().optional(),
+  skip: z.number().optional(),
+  distinct: ProfileImageScalarFieldEnumSchema.array().optional(),
+}).strict() as z.ZodType<Prisma.ProfileImageFindFirstOrThrowArgs>
+
+export const ProfileImageFindManyArgsSchema: z.ZodType<Prisma.ProfileImageFindManyArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  where: ProfileImageWhereInputSchema.optional(),
+  orderBy: z.union([ ProfileImageOrderByWithRelationInputSchema.array(),ProfileImageOrderByWithRelationInputSchema ]).optional(),
+  cursor: ProfileImageWhereUniqueInputSchema.optional(),
+  take: z.number().optional(),
+  skip: z.number().optional(),
+  distinct: ProfileImageScalarFieldEnumSchema.array().optional(),
+}).strict() as z.ZodType<Prisma.ProfileImageFindManyArgs>
+
+export const ProfileImageAggregateArgsSchema: z.ZodType<Prisma.ProfileImageAggregateArgs> = z.object({
+  where: ProfileImageWhereInputSchema.optional(),
+  orderBy: z.union([ ProfileImageOrderByWithRelationInputSchema.array(),ProfileImageOrderByWithRelationInputSchema ]).optional(),
+  cursor: ProfileImageWhereUniqueInputSchema.optional(),
+  take: z.number().optional(),
+  skip: z.number().optional(),
+}).strict() as z.ZodType<Prisma.ProfileImageAggregateArgs>
+
+export const ProfileImageGroupByArgsSchema: z.ZodType<Prisma.ProfileImageGroupByArgs> = z.object({
+  where: ProfileImageWhereInputSchema.optional(),
+  orderBy: z.union([ ProfileImageOrderByWithAggregationInputSchema.array(),ProfileImageOrderByWithAggregationInputSchema ]).optional(),
+  by: ProfileImageScalarFieldEnumSchema.array(),
+  having: ProfileImageScalarWhereWithAggregatesInputSchema.optional(),
+  take: z.number().optional(),
+  skip: z.number().optional(),
+}).strict() as z.ZodType<Prisma.ProfileImageGroupByArgs>
+
+export const ProfileImageFindUniqueArgsSchema: z.ZodType<Prisma.ProfileImageFindUniqueArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  where: ProfileImageWhereUniqueInputSchema,
+}).strict() as z.ZodType<Prisma.ProfileImageFindUniqueArgs>
+
+export const ProfileImageFindUniqueOrThrowArgsSchema: z.ZodType<Prisma.ProfileImageFindUniqueOrThrowArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  where: ProfileImageWhereUniqueInputSchema,
+}).strict() as z.ZodType<Prisma.ProfileImageFindUniqueOrThrowArgs>
+
 export const DataTypesFindFirstArgsSchema: z.ZodType<Prisma.DataTypesFindFirstArgs> = z.object({
   select: DataTypesSelectSchema.optional(),
   include: DataTypesIncludeSchema.optional(),
@@ -2906,6 +3271,47 @@ export const ProfileDeleteManyArgsSchema: z.ZodType<Prisma.ProfileDeleteManyArgs
   where: ProfileWhereInputSchema.optional(),
 }).strict() as z.ZodType<Prisma.ProfileDeleteManyArgs>
 
+export const ProfileImageCreateArgsSchema: z.ZodType<Prisma.ProfileImageCreateArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  data: z.union([ ProfileImageCreateInputSchema,ProfileImageUncheckedCreateInputSchema ]),
+}).strict() as z.ZodType<Prisma.ProfileImageCreateArgs>
+
+export const ProfileImageUpsertArgsSchema: z.ZodType<Prisma.ProfileImageUpsertArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  where: ProfileImageWhereUniqueInputSchema,
+  create: z.union([ ProfileImageCreateInputSchema,ProfileImageUncheckedCreateInputSchema ]),
+  update: z.union([ ProfileImageUpdateInputSchema,ProfileImageUncheckedUpdateInputSchema ]),
+}).strict() as z.ZodType<Prisma.ProfileImageUpsertArgs>
+
+export const ProfileImageCreateManyArgsSchema: z.ZodType<Prisma.ProfileImageCreateManyArgs> = z.object({
+  data: ProfileImageCreateManyInputSchema.array(),
+  skipDuplicates: z.boolean().optional(),
+}).strict() as z.ZodType<Prisma.ProfileImageCreateManyArgs>
+
+export const ProfileImageDeleteArgsSchema: z.ZodType<Prisma.ProfileImageDeleteArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  where: ProfileImageWhereUniqueInputSchema,
+}).strict() as z.ZodType<Prisma.ProfileImageDeleteArgs>
+
+export const ProfileImageUpdateArgsSchema: z.ZodType<Prisma.ProfileImageUpdateArgs> = z.object({
+  select: ProfileImageSelectSchema.optional(),
+  include: ProfileImageIncludeSchema.optional(),
+  data: z.union([ ProfileImageUpdateInputSchema,ProfileImageUncheckedUpdateInputSchema ]),
+  where: ProfileImageWhereUniqueInputSchema,
+}).strict() as z.ZodType<Prisma.ProfileImageUpdateArgs>
+
+export const ProfileImageUpdateManyArgsSchema: z.ZodType<Prisma.ProfileImageUpdateManyArgs> = z.object({
+  data: z.union([ ProfileImageUpdateManyMutationInputSchema,ProfileImageUncheckedUpdateManyInputSchema ]),
+  where: ProfileImageWhereInputSchema.optional(),
+}).strict() as z.ZodType<Prisma.ProfileImageUpdateManyArgs>
+
+export const ProfileImageDeleteManyArgsSchema: z.ZodType<Prisma.ProfileImageDeleteManyArgs> = z.object({
+  where: ProfileImageWhereInputSchema.optional(),
+}).strict() as z.ZodType<Prisma.ProfileImageDeleteManyArgs>
+
 export const DataTypesCreateArgsSchema: z.ZodType<Prisma.DataTypesCreateArgs> = z.object({
   select: DataTypesSelectSchema.optional(),
   include: DataTypesIncludeSchema.optional(),
@@ -3006,6 +3412,11 @@ interface PostGetPayload extends HKT {
 interface ProfileGetPayload extends HKT {
   readonly _A?: boolean | null | undefined | Prisma.ProfileArgs
   readonly type: Omit<Prisma.ProfileGetPayload<this['_A']>, "Please either choose `select` or `include`">
+}
+
+interface ProfileImageGetPayload extends HKT {
+  readonly _A?: boolean | null | undefined | Prisma.ProfileImageArgs
+  readonly type: Omit<Prisma.ProfileImageGetPayload<this['_A']>, "Please either choose `select` or `include`">
 }
 
 interface DataTypesGetPayload extends HKT {
@@ -3166,10 +3577,15 @@ export const tableSchemas = {
       [
         "userId",
         "INT4"
+      ],
+      [
+        "imageId",
+        "TEXT"
       ]
     ]),
     relations: [
       new Relation("user", "userId", "id", "User", "ProfileToUser", "one"),
+      new Relation("image", "imageId", "id", "ProfileImage", "ProfileToProfileImage", "one"),
     ],
     modelSchema: (ProfileCreateInputSchema as any)
       .partial()
@@ -3194,6 +3610,44 @@ export const tableSchemas = {
     Prisma.ProfileFindFirstArgs['orderBy'],
     Prisma.ProfileScalarFieldEnum,
     ProfileGetPayload
+  >,
+  ProfileImage: {
+    fields: new Map([
+      [
+        "id",
+        "TEXT"
+      ],
+      [
+        "image",
+        "BYTEA"
+      ]
+    ]),
+    relations: [
+      new Relation("profile", "", "", "Profile", "ProfileToProfileImage", "one"),
+    ],
+    modelSchema: (ProfileImageCreateInputSchema as any)
+      .partial()
+      .or((ProfileImageUncheckedCreateInputSchema as any).partial()),
+    createSchema: ProfileImageCreateArgsSchema,
+    createManySchema: ProfileImageCreateManyArgsSchema,
+    findUniqueSchema: ProfileImageFindUniqueArgsSchema,
+    findSchema: ProfileImageFindFirstArgsSchema,
+    updateSchema: ProfileImageUpdateArgsSchema,
+    updateManySchema: ProfileImageUpdateManyArgsSchema,
+    upsertSchema: ProfileImageUpsertArgsSchema,
+    deleteSchema: ProfileImageDeleteArgsSchema,
+    deleteManySchema: ProfileImageDeleteManyArgsSchema
+  } as TableSchema<
+    z.infer<typeof ProfileImageCreateInputSchema>,
+    Prisma.ProfileImageCreateArgs['data'],
+    Prisma.ProfileImageUpdateArgs['data'],
+    Prisma.ProfileImageFindFirstArgs['select'],
+    Prisma.ProfileImageFindFirstArgs['where'],
+    Prisma.ProfileImageFindUniqueArgs['where'],
+    Omit<Prisma.ProfileImageInclude, '_count'>,
+    Prisma.ProfileImageFindFirstArgs['orderBy'],
+    Prisma.ProfileImageScalarFieldEnum,
+    ProfileImageGetPayload
   >,
   DataTypes: {
     fields: new Map([

--- a/clients/typescript/test/client/generated/prismaClient.d.ts
+++ b/clients/typescript/test/client/generated/prismaClient.d.ts
@@ -73,6 +73,16 @@ export type Profile = {
    * @zod.number.int().gte(-2147483648).lte(2147483647)
    */
   userId: number
+  imageId: string | null
+}
+
+/**
+ * Model ProfileImage
+ * 
+ */
+export type ProfileImage = {
+  id: string
+  image: Buffer
 }
 
 /**
@@ -288,6 +298,16 @@ export class PrismaClient<
     * ```
     */
   get profile(): Prisma.ProfileDelegate<GlobalReject>;
+
+  /**
+   * `prisma.profileImage`: Exposes CRUD operations for the **ProfileImage** model.
+    * Example usage:
+    * ```ts
+    * // Fetch zero or more ProfileImages
+    * const profileImages = await prisma.profileImage.findMany()
+    * ```
+    */
+  get profileImage(): Prisma.ProfileImageDelegate<GlobalReject>;
 
   /**
    * `prisma.dataTypes`: Exposes CRUD operations for the **DataTypes** model.
@@ -796,6 +816,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     User: 'User',
     Post: 'Post',
     Profile: 'Profile',
+    ProfileImage: 'ProfileImage',
     DataTypes: 'DataTypes',
     Dummy: 'Dummy'
   };
@@ -4089,12 +4110,14 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     id: number | null
     bio: string | null
     userId: number | null
+    imageId: string | null
   }
 
   export type ProfileMaxAggregateOutputType = {
     id: number | null
     bio: string | null
     userId: number | null
+    imageId: string | null
   }
 
   export type ProfileCountAggregateOutputType = {
@@ -4102,6 +4125,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio: number
     meta: number
     userId: number
+    imageId: number
     _all: number
   }
 
@@ -4120,12 +4144,14 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     id?: true
     bio?: true
     userId?: true
+    imageId?: true
   }
 
   export type ProfileMaxAggregateInputType = {
     id?: true
     bio?: true
     userId?: true
+    imageId?: true
   }
 
   export type ProfileCountAggregateInputType = {
@@ -4133,6 +4159,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio?: true
     meta?: true
     userId?: true
+    imageId?: true
     _all?: true
   }
 
@@ -4233,6 +4260,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio: string
     meta: JsonValue | null
     userId: number
+    imageId: string | null
     _count: ProfileCountAggregateOutputType | null
     _avg: ProfileAvgAggregateOutputType | null
     _sum: ProfileSumAggregateOutputType | null
@@ -4260,11 +4288,14 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     meta?: boolean
     userId?: boolean
     user?: boolean | UserArgs
+    imageId?: boolean
+    image?: boolean | ProfileImageArgs
   }
 
 
   export type ProfileInclude = {
     user?: boolean | UserArgs
+    image?: boolean | ProfileImageArgs
   } 
 
   export type ProfileGetPayload<S extends boolean | null | undefined | ProfileArgs> =
@@ -4274,12 +4305,14 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     S extends { include: any } & (ProfileArgs | ProfileFindManyArgs)
     ? Profile  & {
     [P in TruthyKeys<S['include']>]:
-        P extends 'user' ? UserGetPayload<S['include'][P]> | null :  never
+        P extends 'user' ? UserGetPayload<S['include'][P]> | null :
+        P extends 'image' ? ProfileImageGetPayload<S['include'][P]> | null :  never
   } 
     : S extends { select: any } & (ProfileArgs | ProfileFindManyArgs)
       ? {
     [P in TruthyKeys<S['select']>]:
-        P extends 'user' ? UserGetPayload<S['select'][P]> | null :  P extends keyof Profile ? Profile[P] : never
+        P extends 'user' ? UserGetPayload<S['select'][P]> | null :
+        P extends 'image' ? ProfileImageGetPayload<S['select'][P]> | null :  P extends keyof Profile ? Profile[P] : never
   } 
       : Profile
 
@@ -4654,6 +4687,8 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     readonly [Symbol.toStringTag]: 'PrismaClientPromise';
 
     user<T extends UserArgs= {}>(args?: Subset<T, UserArgs>): Prisma__UserClient<UserGetPayload<T> | Null>;
+
+    image<T extends ProfileImageArgs= {}>(args?: Subset<T, ProfileImageArgs>): Prisma__ProfileImageClient<ProfileImageGetPayload<T> | Null>;
 
     private get _document();
     /**
@@ -5072,6 +5107,970 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
      * 
     **/
     include?: ProfileInclude | null
+  }
+
+
+
+  /**
+   * Model ProfileImage
+   */
+
+
+  export type AggregateProfileImage = {
+    _count: ProfileImageCountAggregateOutputType | null
+    _min: ProfileImageMinAggregateOutputType | null
+    _max: ProfileImageMaxAggregateOutputType | null
+  }
+
+  export type ProfileImageMinAggregateOutputType = {
+    id: string | null
+    image: Buffer | null
+  }
+
+  export type ProfileImageMaxAggregateOutputType = {
+    id: string | null
+    image: Buffer | null
+  }
+
+  export type ProfileImageCountAggregateOutputType = {
+    id: number
+    image: number
+    _all: number
+  }
+
+
+  export type ProfileImageMinAggregateInputType = {
+    id?: true
+    image?: true
+  }
+
+  export type ProfileImageMaxAggregateInputType = {
+    id?: true
+    image?: true
+  }
+
+  export type ProfileImageCountAggregateInputType = {
+    id?: true
+    image?: true
+    _all?: true
+  }
+
+  export type ProfileImageAggregateArgs = {
+    /**
+     * Filter which ProfileImage to aggregate.
+     * 
+    **/
+    where?: ProfileImageWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ProfileImages to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<ProfileImageOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     * 
+    **/
+    cursor?: ProfileImageWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` ProfileImages from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` ProfileImages.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned ProfileImages
+    **/
+    _count?: true | ProfileImageCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: ProfileImageMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: ProfileImageMaxAggregateInputType
+  }
+
+  export type GetProfileImageAggregateType<T extends ProfileImageAggregateArgs> = {
+        [P in keyof T & keyof AggregateProfileImage]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateProfileImage[P]>
+      : GetScalarType<T[P], AggregateProfileImage[P]>
+  }
+
+
+
+
+  export type ProfileImageGroupByArgs = {
+    where?: ProfileImageWhereInput
+    orderBy?: Enumerable<ProfileImageOrderByWithAggregationInput>
+    by: Array<ProfileImageScalarFieldEnum>
+    having?: ProfileImageScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: ProfileImageCountAggregateInputType | true
+    _min?: ProfileImageMinAggregateInputType
+    _max?: ProfileImageMaxAggregateInputType
+  }
+
+
+  export type ProfileImageGroupByOutputType = {
+    id: string
+    image: Buffer
+    _count: ProfileImageCountAggregateOutputType | null
+    _min: ProfileImageMinAggregateOutputType | null
+    _max: ProfileImageMaxAggregateOutputType | null
+  }
+
+  type GetProfileImageGroupByPayload<T extends ProfileImageGroupByArgs> = PrismaPromise<
+    Array<
+      PickArray<ProfileImageGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof ProfileImageGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], ProfileImageGroupByOutputType[P]>
+            : GetScalarType<T[P], ProfileImageGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type ProfileImageSelect = {
+    id?: boolean
+    image?: boolean
+    profile?: boolean | ProfileArgs
+  }
+
+
+  export type ProfileImageInclude = {
+    profile?: boolean | ProfileArgs
+  } 
+
+  export type ProfileImageGetPayload<S extends boolean | null | undefined | ProfileImageArgs> =
+    S extends { select: any, include: any } ? 'Please either choose `select` or `include`' :
+    S extends true ? ProfileImage :
+    S extends undefined ? never :
+    S extends { include: any } & (ProfileImageArgs | ProfileImageFindManyArgs)
+    ? ProfileImage  & {
+    [P in TruthyKeys<S['include']>]:
+        P extends 'profile' ? ProfileGetPayload<S['include'][P]> | null :  never
+  } 
+    : S extends { select: any } & (ProfileImageArgs | ProfileImageFindManyArgs)
+      ? {
+    [P in TruthyKeys<S['select']>]:
+        P extends 'profile' ? ProfileGetPayload<S['select'][P]> | null :  P extends keyof ProfileImage ? ProfileImage[P] : never
+  } 
+      : ProfileImage
+
+
+  type ProfileImageCountArgs = Merge<
+    Omit<ProfileImageFindManyArgs, 'select' | 'include'> & {
+      select?: ProfileImageCountAggregateInputType | true
+    }
+  >
+
+  export interface ProfileImageDelegate<GlobalRejectSettings extends Prisma.RejectOnNotFound | Prisma.RejectPerOperation | false | undefined> {
+    /**
+     * Find zero or one ProfileImage that matches the filter.
+     * @param {ProfileImageFindUniqueArgs} args - Arguments to find a ProfileImage
+     * @example
+     * // Get one ProfileImage
+     * const profileImage = await prisma.profileImage.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUnique<T extends ProfileImageFindUniqueArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args: SelectSubset<T, ProfileImageFindUniqueArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findUnique', 'ProfileImage'> extends True ? Prisma__ProfileImageClient<ProfileImageGetPayload<T>> : Prisma__ProfileImageClient<ProfileImageGetPayload<T> | null, null>
+
+    /**
+     * Find one ProfileImage that matches the filter or throw an error  with `error.code='P2025'` 
+     *     if no matches were found.
+     * @param {ProfileImageFindUniqueOrThrowArgs} args - Arguments to find a ProfileImage
+     * @example
+     * // Get one ProfileImage
+     * const profileImage = await prisma.profileImage.findUniqueOrThrow({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findUniqueOrThrow<T extends ProfileImageFindUniqueOrThrowArgs>(
+      args?: SelectSubset<T, ProfileImageFindUniqueOrThrowArgs>
+    ): Prisma__ProfileImageClient<ProfileImageGetPayload<T>>
+
+    /**
+     * Find the first ProfileImage that matches the filter.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ProfileImageFindFirstArgs} args - Arguments to find a ProfileImage
+     * @example
+     * // Get one ProfileImage
+     * const profileImage = await prisma.profileImage.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirst<T extends ProfileImageFindFirstArgs,  LocalRejectSettings = T["rejectOnNotFound"] extends RejectOnNotFound ? T['rejectOnNotFound'] : undefined>(
+      args?: SelectSubset<T, ProfileImageFindFirstArgs>
+    ): HasReject<GlobalRejectSettings, LocalRejectSettings, 'findFirst', 'ProfileImage'> extends True ? Prisma__ProfileImageClient<ProfileImageGetPayload<T>> : Prisma__ProfileImageClient<ProfileImageGetPayload<T> | null, null>
+
+    /**
+     * Find the first ProfileImage that matches the filter or
+     * throw `NotFoundError` if no matches were found.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ProfileImageFindFirstOrThrowArgs} args - Arguments to find a ProfileImage
+     * @example
+     * // Get one ProfileImage
+     * const profileImage = await prisma.profileImage.findFirstOrThrow({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+    **/
+    findFirstOrThrow<T extends ProfileImageFindFirstOrThrowArgs>(
+      args?: SelectSubset<T, ProfileImageFindFirstOrThrowArgs>
+    ): Prisma__ProfileImageClient<ProfileImageGetPayload<T>>
+
+    /**
+     * Find zero or more ProfileImages that matches the filter.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ProfileImageFindManyArgs=} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all ProfileImages
+     * const profileImages = await prisma.profileImage.findMany()
+     * 
+     * // Get first 10 ProfileImages
+     * const profileImages = await prisma.profileImage.findMany({ take: 10 })
+     * 
+     * // Only select the `id`
+     * const profileImageWithIdOnly = await prisma.profileImage.findMany({ select: { id: true } })
+     * 
+    **/
+    findMany<T extends ProfileImageFindManyArgs>(
+      args?: SelectSubset<T, ProfileImageFindManyArgs>
+    ): PrismaPromise<Array<ProfileImageGetPayload<T>>>
+
+    /**
+     * Create a ProfileImage.
+     * @param {ProfileImageCreateArgs} args - Arguments to create a ProfileImage.
+     * @example
+     * // Create one ProfileImage
+     * const ProfileImage = await prisma.profileImage.create({
+     *   data: {
+     *     // ... data to create a ProfileImage
+     *   }
+     * })
+     * 
+    **/
+    create<T extends ProfileImageCreateArgs>(
+      args: SelectSubset<T, ProfileImageCreateArgs>
+    ): Prisma__ProfileImageClient<ProfileImageGetPayload<T>>
+
+    /**
+     * Create many ProfileImages.
+     *     @param {ProfileImageCreateManyArgs} args - Arguments to create many ProfileImages.
+     *     @example
+     *     // Create many ProfileImages
+     *     const profileImage = await prisma.profileImage.createMany({
+     *       data: {
+     *         // ... provide data here
+     *       }
+     *     })
+     *     
+    **/
+    createMany<T extends ProfileImageCreateManyArgs>(
+      args?: SelectSubset<T, ProfileImageCreateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Delete a ProfileImage.
+     * @param {ProfileImageDeleteArgs} args - Arguments to delete one ProfileImage.
+     * @example
+     * // Delete one ProfileImage
+     * const ProfileImage = await prisma.profileImage.delete({
+     *   where: {
+     *     // ... filter to delete one ProfileImage
+     *   }
+     * })
+     * 
+    **/
+    delete<T extends ProfileImageDeleteArgs>(
+      args: SelectSubset<T, ProfileImageDeleteArgs>
+    ): Prisma__ProfileImageClient<ProfileImageGetPayload<T>>
+
+    /**
+     * Update one ProfileImage.
+     * @param {ProfileImageUpdateArgs} args - Arguments to update one ProfileImage.
+     * @example
+     * // Update one ProfileImage
+     * const profileImage = await prisma.profileImage.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    update<T extends ProfileImageUpdateArgs>(
+      args: SelectSubset<T, ProfileImageUpdateArgs>
+    ): Prisma__ProfileImageClient<ProfileImageGetPayload<T>>
+
+    /**
+     * Delete zero or more ProfileImages.
+     * @param {ProfileImageDeleteManyArgs} args - Arguments to filter ProfileImages to delete.
+     * @example
+     * // Delete a few ProfileImages
+     * const { count } = await prisma.profileImage.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+    **/
+    deleteMany<T extends ProfileImageDeleteManyArgs>(
+      args?: SelectSubset<T, ProfileImageDeleteManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more ProfileImages.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ProfileImageUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many ProfileImages
+     * const profileImage = await prisma.profileImage.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+    **/
+    updateMany<T extends ProfileImageUpdateManyArgs>(
+      args: SelectSubset<T, ProfileImageUpdateManyArgs>
+    ): PrismaPromise<BatchPayload>
+
+    /**
+     * Create or update one ProfileImage.
+     * @param {ProfileImageUpsertArgs} args - Arguments to update or create a ProfileImage.
+     * @example
+     * // Update or create a ProfileImage
+     * const profileImage = await prisma.profileImage.upsert({
+     *   create: {
+     *     // ... data to create a ProfileImage
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the ProfileImage we want to update
+     *   }
+     * })
+    **/
+    upsert<T extends ProfileImageUpsertArgs>(
+      args: SelectSubset<T, ProfileImageUpsertArgs>
+    ): Prisma__ProfileImageClient<ProfileImageGetPayload<T>>
+
+    /**
+     * Count the number of ProfileImages.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ProfileImageCountArgs} args - Arguments to filter ProfileImages to count.
+     * @example
+     * // Count the number of ProfileImages
+     * const count = await prisma.profileImage.count({
+     *   where: {
+     *     // ... the filter for the ProfileImages we want to count
+     *   }
+     * })
+    **/
+    count<T extends ProfileImageCountArgs>(
+      args?: Subset<T, ProfileImageCountArgs>,
+    ): PrismaPromise<
+      T extends _Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], ProfileImageCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a ProfileImage.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ProfileImageAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends ProfileImageAggregateArgs>(args: Subset<T, ProfileImageAggregateArgs>): PrismaPromise<GetProfileImageAggregateType<T>>
+
+    /**
+     * Group by ProfileImage.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ProfileImageGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends ProfileImageGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: ProfileImageGroupByArgs['orderBy'] }
+        : { orderBy?: ProfileImageGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends TupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? `Error: "by" must not be empty.`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? `Error: Field "${P}" used in "having" needs to be provided in "by".`
+            : [
+                Error,
+                'Field ',
+                P,
+                ` in "having" needs to be provided in "by"`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, ProfileImageGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetProfileImageGroupByPayload<T> : PrismaPromise<InputErrors>
+
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for ProfileImage.
+   * Why is this prefixed with `Prisma__`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export class Prisma__ProfileImageClient<T, Null = never> implements PrismaPromise<T> {
+    [prisma]: true;
+    private readonly _dmmf;
+    private readonly _fetcher;
+    private readonly _queryType;
+    private readonly _rootField;
+    private readonly _clientMethod;
+    private readonly _args;
+    private readonly _dataPath;
+    private readonly _errorFormat;
+    private readonly _measurePerformance?;
+    private _isList;
+    private _callsite;
+    private _requestPromise?;
+    constructor(_dmmf: runtime.DMMFClass, _fetcher: PrismaClientFetcher, _queryType: 'query' | 'mutation', _rootField: string, _clientMethod: string, _args: any, _dataPath: string[], _errorFormat: ErrorFormat, _measurePerformance?: boolean | undefined, _isList?: boolean);
+    readonly [Symbol.toStringTag]: 'PrismaClientPromise';
+
+    profile<T extends ProfileArgs= {}>(args?: Subset<T, ProfileArgs>): Prisma__ProfileClient<ProfileGetPayload<T> | Null>;
+
+    private get _document();
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+  }
+
+
+
+  // Custom InputTypes
+
+  /**
+   * ProfileImage base type for findUnique actions
+   */
+  export type ProfileImageFindUniqueArgsBase = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * Filter, which ProfileImage to fetch.
+     * 
+    **/
+    where: ProfileImageWhereUniqueInput
+  }
+
+  /**
+   * ProfileImage findUnique
+   */
+  export interface ProfileImageFindUniqueArgs extends ProfileImageFindUniqueArgsBase {
+   /**
+    * Throw an Error if query returns no results
+    * @deprecated since 4.0.0: use `findUniqueOrThrow` method instead
+    */
+    rejectOnNotFound?: RejectOnNotFound
+  }
+      
+
+  /**
+   * ProfileImage findUniqueOrThrow
+   */
+  export type ProfileImageFindUniqueOrThrowArgs = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * Filter, which ProfileImage to fetch.
+     * 
+    **/
+    where: ProfileImageWhereUniqueInput
+  }
+
+
+  /**
+   * ProfileImage base type for findFirst actions
+   */
+  export type ProfileImageFindFirstArgsBase = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * Filter, which ProfileImage to fetch.
+     * 
+    **/
+    where?: ProfileImageWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ProfileImages to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<ProfileImageOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for ProfileImages.
+     * 
+    **/
+    cursor?: ProfileImageWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` ProfileImages from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` ProfileImages.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of ProfileImages.
+     * 
+    **/
+    distinct?: Enumerable<ProfileImageScalarFieldEnum>
+  }
+
+  /**
+   * ProfileImage findFirst
+   */
+  export interface ProfileImageFindFirstArgs extends ProfileImageFindFirstArgsBase {
+   /**
+    * Throw an Error if query returns no results
+    * @deprecated since 4.0.0: use `findFirstOrThrow` method instead
+    */
+    rejectOnNotFound?: RejectOnNotFound
+  }
+      
+
+  /**
+   * ProfileImage findFirstOrThrow
+   */
+  export type ProfileImageFindFirstOrThrowArgs = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * Filter, which ProfileImage to fetch.
+     * 
+    **/
+    where?: ProfileImageWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ProfileImages to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<ProfileImageOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for ProfileImages.
+     * 
+    **/
+    cursor?: ProfileImageWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` ProfileImages from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` ProfileImages.
+     * 
+    **/
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of ProfileImages.
+     * 
+    **/
+    distinct?: Enumerable<ProfileImageScalarFieldEnum>
+  }
+
+
+  /**
+   * ProfileImage findMany
+   */
+  export type ProfileImageFindManyArgs = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * Filter, which ProfileImages to fetch.
+     * 
+    **/
+    where?: ProfileImageWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ProfileImages to fetch.
+     * 
+    **/
+    orderBy?: Enumerable<ProfileImageOrderByWithRelationInput>
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing ProfileImages.
+     * 
+    **/
+    cursor?: ProfileImageWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` ProfileImages from the position of the cursor.
+     * 
+    **/
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` ProfileImages.
+     * 
+    **/
+    skip?: number
+    distinct?: Enumerable<ProfileImageScalarFieldEnum>
+  }
+
+
+  /**
+   * ProfileImage create
+   */
+  export type ProfileImageCreateArgs = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * The data needed to create a ProfileImage.
+     * 
+    **/
+    data: XOR<ProfileImageCreateInput, ProfileImageUncheckedCreateInput>
+  }
+
+
+  /**
+   * ProfileImage createMany
+   */
+  export type ProfileImageCreateManyArgs = {
+    /**
+     * The data used to create many ProfileImages.
+     * 
+    **/
+    data: Enumerable<ProfileImageCreateManyInput>
+    skipDuplicates?: boolean
+  }
+
+
+  /**
+   * ProfileImage update
+   */
+  export type ProfileImageUpdateArgs = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * The data needed to update a ProfileImage.
+     * 
+    **/
+    data: XOR<ProfileImageUpdateInput, ProfileImageUncheckedUpdateInput>
+    /**
+     * Choose, which ProfileImage to update.
+     * 
+    **/
+    where: ProfileImageWhereUniqueInput
+  }
+
+
+  /**
+   * ProfileImage updateMany
+   */
+  export type ProfileImageUpdateManyArgs = {
+    /**
+     * The data used to update ProfileImages.
+     * 
+    **/
+    data: XOR<ProfileImageUpdateManyMutationInput, ProfileImageUncheckedUpdateManyInput>
+    /**
+     * Filter which ProfileImages to update
+     * 
+    **/
+    where?: ProfileImageWhereInput
+  }
+
+
+  /**
+   * ProfileImage upsert
+   */
+  export type ProfileImageUpsertArgs = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * The filter to search for the ProfileImage to update in case it exists.
+     * 
+    **/
+    where: ProfileImageWhereUniqueInput
+    /**
+     * In case the ProfileImage found by the `where` argument doesn't exist, create a new ProfileImage with this data.
+     * 
+    **/
+    create: XOR<ProfileImageCreateInput, ProfileImageUncheckedCreateInput>
+    /**
+     * In case the ProfileImage was found with the provided `where` argument, update it with this data.
+     * 
+    **/
+    update: XOR<ProfileImageUpdateInput, ProfileImageUncheckedUpdateInput>
+  }
+
+
+  /**
+   * ProfileImage delete
+   */
+  export type ProfileImageDeleteArgs = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
+    /**
+     * Filter which ProfileImage to delete.
+     * 
+    **/
+    where: ProfileImageWhereUniqueInput
+  }
+
+
+  /**
+   * ProfileImage deleteMany
+   */
+  export type ProfileImageDeleteManyArgs = {
+    /**
+     * Filter which ProfileImages to delete
+     * 
+    **/
+    where?: ProfileImageWhereInput
+  }
+
+
+  /**
+   * ProfileImage without action
+   */
+  export type ProfileImageArgs = {
+    /**
+     * Select specific fields to fetch from the ProfileImage
+     * 
+    **/
+    select?: ProfileImageSelect | null
+    /**
+     * Choose, which related nodes to fetch as well.
+     * 
+    **/
+    include?: ProfileImageInclude | null
   }
 
 
@@ -7304,11 +8303,20 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
   export type PostScalarFieldEnum = (typeof PostScalarFieldEnum)[keyof typeof PostScalarFieldEnum]
 
 
+  export const ProfileImageScalarFieldEnum: {
+    id: 'id',
+    image: 'image'
+  };
+
+  export type ProfileImageScalarFieldEnum = (typeof ProfileImageScalarFieldEnum)[keyof typeof ProfileImageScalarFieldEnum]
+
+
   export const ProfileScalarFieldEnum: {
     id: 'id',
     bio: 'bio',
     meta: 'meta',
-    userId: 'userId'
+    userId: 'userId',
+    imageId: 'imageId'
   };
 
   export type ProfileScalarFieldEnum = (typeof ProfileScalarFieldEnum)[keyof typeof ProfileScalarFieldEnum]
@@ -7491,6 +8499,8 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     meta?: JsonNullableFilter
     userId?: IntFilter | number
     user?: XOR<UserRelationFilter, UserWhereInput> | null
+    imageId?: StringNullableFilter | string | null
+    image?: XOR<ProfileImageRelationFilter, ProfileImageWhereInput> | null
   }
 
   export type ProfileOrderByWithRelationInput = {
@@ -7499,11 +8509,14 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     meta?: SortOrder
     userId?: SortOrder
     user?: UserOrderByWithRelationInput
+    imageId?: SortOrder
+    image?: ProfileImageOrderByWithRelationInput
   }
 
   export type ProfileWhereUniqueInput = {
     id?: number
     userId?: number
+    imageId?: string
   }
 
   export type ProfileOrderByWithAggregationInput = {
@@ -7511,6 +8524,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio?: SortOrder
     meta?: SortOrder
     userId?: SortOrder
+    imageId?: SortOrder
     _count?: ProfileCountOrderByAggregateInput
     _avg?: ProfileAvgOrderByAggregateInput
     _max?: ProfileMaxOrderByAggregateInput
@@ -7526,6 +8540,42 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio?: StringWithAggregatesFilter | string
     meta?: JsonNullableWithAggregatesFilter
     userId?: IntWithAggregatesFilter | number
+    imageId?: StringNullableWithAggregatesFilter | string | null
+  }
+
+  export type ProfileImageWhereInput = {
+    AND?: Enumerable<ProfileImageWhereInput>
+    OR?: Enumerable<ProfileImageWhereInput>
+    NOT?: Enumerable<ProfileImageWhereInput>
+    id?: StringFilter | string
+    image?: BytesFilter | Buffer
+    profile?: XOR<ProfileRelationFilter, ProfileWhereInput> | null
+  }
+
+  export type ProfileImageOrderByWithRelationInput = {
+    id?: SortOrder
+    image?: SortOrder
+    profile?: ProfileOrderByWithRelationInput
+  }
+
+  export type ProfileImageWhereUniqueInput = {
+    id?: string
+  }
+
+  export type ProfileImageOrderByWithAggregationInput = {
+    id?: SortOrder
+    image?: SortOrder
+    _count?: ProfileImageCountOrderByAggregateInput
+    _max?: ProfileImageMaxOrderByAggregateInput
+    _min?: ProfileImageMinOrderByAggregateInput
+  }
+
+  export type ProfileImageScalarWhereWithAggregatesInput = {
+    AND?: Enumerable<ProfileImageScalarWhereWithAggregatesInput>
+    OR?: Enumerable<ProfileImageScalarWhereWithAggregatesInput>
+    NOT?: Enumerable<ProfileImageScalarWhereWithAggregatesInput>
+    id?: StringWithAggregatesFilter | string
+    image?: BytesWithAggregatesFilter | Buffer
   }
 
   export type DataTypesWhereInput = {
@@ -7804,6 +8854,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio: string
     meta?: NullableJsonNullValueInput | InputJsonValue
     user?: UserCreateNestedOneWithoutProfileInput
+    image?: ProfileImageCreateNestedOneWithoutProfileInput
   }
 
   export type ProfileUncheckedCreateInput = {
@@ -7811,6 +8862,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio: string
     meta?: NullableJsonNullValueInput | InputJsonValue
     userId: number
+    imageId?: string | null
   }
 
   export type ProfileUpdateInput = {
@@ -7818,6 +8870,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio?: StringFieldUpdateOperationsInput | string
     meta?: NullableJsonNullValueInput | InputJsonValue
     user?: UserUpdateOneWithoutProfileNestedInput
+    image?: ProfileImageUpdateOneWithoutProfileNestedInput
   }
 
   export type ProfileUncheckedUpdateInput = {
@@ -7825,6 +8878,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio?: StringFieldUpdateOperationsInput | string
     meta?: NullableJsonNullValueInput | InputJsonValue
     userId?: IntFieldUpdateOperationsInput | number
+    imageId?: NullableStringFieldUpdateOperationsInput | string | null
   }
 
   export type ProfileCreateManyInput = {
@@ -7832,6 +8886,7 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio: string
     meta?: NullableJsonNullValueInput | InputJsonValue
     userId: number
+    imageId?: string | null
   }
 
   export type ProfileUpdateManyMutationInput = {
@@ -7845,6 +8900,46 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     bio?: StringFieldUpdateOperationsInput | string
     meta?: NullableJsonNullValueInput | InputJsonValue
     userId?: IntFieldUpdateOperationsInput | number
+    imageId?: NullableStringFieldUpdateOperationsInput | string | null
+  }
+
+  export type ProfileImageCreateInput = {
+    id: string
+    image: Buffer
+    profile?: ProfileCreateNestedOneWithoutImageInput
+  }
+
+  export type ProfileImageUncheckedCreateInput = {
+    id: string
+    image: Buffer
+    profile?: ProfileUncheckedCreateNestedOneWithoutImageInput
+  }
+
+  export type ProfileImageUpdateInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    image?: BytesFieldUpdateOperationsInput | Buffer
+    profile?: ProfileUpdateOneWithoutImageNestedInput
+  }
+
+  export type ProfileImageUncheckedUpdateInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    image?: BytesFieldUpdateOperationsInput | Buffer
+    profile?: ProfileUncheckedUpdateOneWithoutImageNestedInput
+  }
+
+  export type ProfileImageCreateManyInput = {
+    id: string
+    image: Buffer
+  }
+
+  export type ProfileImageUpdateManyMutationInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    image?: BytesFieldUpdateOperationsInput | Buffer
+  }
+
+  export type ProfileImageUncheckedUpdateManyInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    image?: BytesFieldUpdateOperationsInput | Buffer
   }
 
   export type DataTypesCreateInput = {
@@ -8265,11 +9360,17 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     not?: InputJsonValue | JsonNullValueFilter
   }
 
+  export type ProfileImageRelationFilter = {
+    is?: ProfileImageWhereInput | null
+    isNot?: ProfileImageWhereInput | null
+  }
+
   export type ProfileCountOrderByAggregateInput = {
     id?: SortOrder
     bio?: SortOrder
     meta?: SortOrder
     userId?: SortOrder
+    imageId?: SortOrder
   }
 
   export type ProfileAvgOrderByAggregateInput = {
@@ -8281,12 +9382,14 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     id?: SortOrder
     bio?: SortOrder
     userId?: SortOrder
+    imageId?: SortOrder
   }
 
   export type ProfileMinOrderByAggregateInput = {
     id?: SortOrder
     bio?: SortOrder
     userId?: SortOrder
+    imageId?: SortOrder
   }
 
   export type ProfileSumOrderByAggregateInput = {
@@ -8317,6 +9420,38 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     _count?: NestedIntNullableFilter
     _min?: NestedJsonNullableFilter
     _max?: NestedJsonNullableFilter
+  }
+
+  export type BytesFilter = {
+    equals?: Buffer
+    in?: Enumerable<Buffer>
+    notIn?: Enumerable<Buffer>
+    not?: NestedBytesFilter | Buffer
+  }
+
+  export type ProfileImageCountOrderByAggregateInput = {
+    id?: SortOrder
+    image?: SortOrder
+  }
+
+  export type ProfileImageMaxOrderByAggregateInput = {
+    id?: SortOrder
+    image?: SortOrder
+  }
+
+  export type ProfileImageMinOrderByAggregateInput = {
+    id?: SortOrder
+    image?: SortOrder
+  }
+
+  export type BytesWithAggregatesFilter = {
+    equals?: Buffer
+    in?: Enumerable<Buffer>
+    notIn?: Enumerable<Buffer>
+    not?: NestedBytesWithAggregatesFilter | Buffer
+    _count?: NestedIntFilter
+    _min?: NestedBytesFilter
+    _max?: NestedBytesFilter
   }
 
   export type DateTimeNullableFilter = {
@@ -8688,6 +9823,12 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     connect?: UserWhereUniqueInput
   }
 
+  export type ProfileImageCreateNestedOneWithoutProfileInput = {
+    create?: XOR<ProfileImageCreateWithoutProfileInput, ProfileImageUncheckedCreateWithoutProfileInput>
+    connectOrCreate?: ProfileImageCreateOrConnectWithoutProfileInput
+    connect?: ProfileImageWhereUniqueInput
+  }
+
   export type UserUpdateOneWithoutProfileNestedInput = {
     create?: XOR<UserCreateWithoutProfileInput, UserUncheckedCreateWithoutProfileInput>
     connectOrCreate?: UserCreateOrConnectWithoutProfileInput
@@ -8696,6 +9837,52 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     delete?: boolean
     connect?: UserWhereUniqueInput
     update?: XOR<UserUpdateWithoutProfileInput, UserUncheckedUpdateWithoutProfileInput>
+  }
+
+  export type ProfileImageUpdateOneWithoutProfileNestedInput = {
+    create?: XOR<ProfileImageCreateWithoutProfileInput, ProfileImageUncheckedCreateWithoutProfileInput>
+    connectOrCreate?: ProfileImageCreateOrConnectWithoutProfileInput
+    upsert?: ProfileImageUpsertWithoutProfileInput
+    disconnect?: boolean
+    delete?: boolean
+    connect?: ProfileImageWhereUniqueInput
+    update?: XOR<ProfileImageUpdateWithoutProfileInput, ProfileImageUncheckedUpdateWithoutProfileInput>
+  }
+
+  export type ProfileCreateNestedOneWithoutImageInput = {
+    create?: XOR<ProfileCreateWithoutImageInput, ProfileUncheckedCreateWithoutImageInput>
+    connectOrCreate?: ProfileCreateOrConnectWithoutImageInput
+    connect?: ProfileWhereUniqueInput
+  }
+
+  export type ProfileUncheckedCreateNestedOneWithoutImageInput = {
+    create?: XOR<ProfileCreateWithoutImageInput, ProfileUncheckedCreateWithoutImageInput>
+    connectOrCreate?: ProfileCreateOrConnectWithoutImageInput
+    connect?: ProfileWhereUniqueInput
+  }
+
+  export type BytesFieldUpdateOperationsInput = {
+    set?: Buffer
+  }
+
+  export type ProfileUpdateOneWithoutImageNestedInput = {
+    create?: XOR<ProfileCreateWithoutImageInput, ProfileUncheckedCreateWithoutImageInput>
+    connectOrCreate?: ProfileCreateOrConnectWithoutImageInput
+    upsert?: ProfileUpsertWithoutImageInput
+    disconnect?: boolean
+    delete?: boolean
+    connect?: ProfileWhereUniqueInput
+    update?: XOR<ProfileUpdateWithoutImageInput, ProfileUncheckedUpdateWithoutImageInput>
+  }
+
+  export type ProfileUncheckedUpdateOneWithoutImageNestedInput = {
+    create?: XOR<ProfileCreateWithoutImageInput, ProfileUncheckedCreateWithoutImageInput>
+    connectOrCreate?: ProfileCreateOrConnectWithoutImageInput
+    upsert?: ProfileUpsertWithoutImageInput
+    disconnect?: boolean
+    delete?: boolean
+    connect?: ProfileWhereUniqueInput
+    update?: XOR<ProfileUpdateWithoutImageInput, ProfileUncheckedUpdateWithoutImageInput>
   }
 
   export type DummyCreateNestedOneWithoutDatatypeInput = {
@@ -8944,6 +10131,23 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     not?: InputJsonValue | JsonNullValueFilter
   }
 
+  export type NestedBytesFilter = {
+    equals?: Buffer
+    in?: Enumerable<Buffer>
+    notIn?: Enumerable<Buffer>
+    not?: NestedBytesFilter | Buffer
+  }
+
+  export type NestedBytesWithAggregatesFilter = {
+    equals?: Buffer
+    in?: Enumerable<Buffer>
+    notIn?: Enumerable<Buffer>
+    not?: NestedBytesWithAggregatesFilter | Buffer
+    _count?: NestedIntFilter
+    _min?: NestedBytesFilter
+    _max?: NestedBytesFilter
+  }
+
   export type NestedDateTimeNullableFilter = {
     equals?: Date | string | null
     in?: Enumerable<Date> | Enumerable<string> | null
@@ -9095,12 +10299,14 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     id: number
     bio: string
     meta?: NullableJsonNullValueInput | InputJsonValue
+    image?: ProfileImageCreateNestedOneWithoutProfileInput
   }
 
   export type ProfileUncheckedCreateWithoutUserInput = {
     id: number
     bio: string
     meta?: NullableJsonNullValueInput | InputJsonValue
+    imageId?: string | null
   }
 
   export type ProfileCreateOrConnectWithoutUserInput = {
@@ -9144,12 +10350,14 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     id?: IntFieldUpdateOperationsInput | number
     bio?: StringFieldUpdateOperationsInput | string
     meta?: NullableJsonNullValueInput | InputJsonValue
+    image?: ProfileImageUpdateOneWithoutProfileNestedInput
   }
 
   export type ProfileUncheckedUpdateWithoutUserInput = {
     id?: IntFieldUpdateOperationsInput | number
     bio?: StringFieldUpdateOperationsInput | string
     meta?: NullableJsonNullValueInput | InputJsonValue
+    imageId?: NullableStringFieldUpdateOperationsInput | string | null
   }
 
   export type UserCreateWithoutPostsInput = {
@@ -9209,6 +10417,21 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     create: XOR<UserCreateWithoutProfileInput, UserUncheckedCreateWithoutProfileInput>
   }
 
+  export type ProfileImageCreateWithoutProfileInput = {
+    id: string
+    image: Buffer
+  }
+
+  export type ProfileImageUncheckedCreateWithoutProfileInput = {
+    id: string
+    image: Buffer
+  }
+
+  export type ProfileImageCreateOrConnectWithoutProfileInput = {
+    where: ProfileImageWhereUniqueInput
+    create: XOR<ProfileImageCreateWithoutProfileInput, ProfileImageUncheckedCreateWithoutProfileInput>
+  }
+
   export type UserUpsertWithoutProfileInput = {
     update: XOR<UserUpdateWithoutProfileInput, UserUncheckedUpdateWithoutProfileInput>
     create: XOR<UserCreateWithoutProfileInput, UserUncheckedCreateWithoutProfileInput>
@@ -9226,6 +10449,59 @@ export type InputJsonValue = null | string | number | boolean | InputJsonObject 
     name?: NullableStringFieldUpdateOperationsInput | string | null
     meta?: NullableStringFieldUpdateOperationsInput | string | null
     posts?: PostUncheckedUpdateManyWithoutAuthorNestedInput
+  }
+
+  export type ProfileImageUpsertWithoutProfileInput = {
+    update: XOR<ProfileImageUpdateWithoutProfileInput, ProfileImageUncheckedUpdateWithoutProfileInput>
+    create: XOR<ProfileImageCreateWithoutProfileInput, ProfileImageUncheckedCreateWithoutProfileInput>
+  }
+
+  export type ProfileImageUpdateWithoutProfileInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    image?: BytesFieldUpdateOperationsInput | Buffer
+  }
+
+  export type ProfileImageUncheckedUpdateWithoutProfileInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    image?: BytesFieldUpdateOperationsInput | Buffer
+  }
+
+  export type ProfileCreateWithoutImageInput = {
+    id: number
+    bio: string
+    meta?: NullableJsonNullValueInput | InputJsonValue
+    user?: UserCreateNestedOneWithoutProfileInput
+  }
+
+  export type ProfileUncheckedCreateWithoutImageInput = {
+    id: number
+    bio: string
+    meta?: NullableJsonNullValueInput | InputJsonValue
+    userId: number
+  }
+
+  export type ProfileCreateOrConnectWithoutImageInput = {
+    where: ProfileWhereUniqueInput
+    create: XOR<ProfileCreateWithoutImageInput, ProfileUncheckedCreateWithoutImageInput>
+  }
+
+  export type ProfileUpsertWithoutImageInput = {
+    update: XOR<ProfileUpdateWithoutImageInput, ProfileUncheckedUpdateWithoutImageInput>
+    create: XOR<ProfileCreateWithoutImageInput, ProfileUncheckedCreateWithoutImageInput>
+  }
+
+  export type ProfileUpdateWithoutImageInput = {
+    id?: IntFieldUpdateOperationsInput | number
+    bio?: StringFieldUpdateOperationsInput | string
+    meta?: NullableJsonNullValueInput | InputJsonValue
+    user?: UserUpdateOneWithoutProfileNestedInput
+  }
+
+  export type ProfileUncheckedUpdateWithoutImageInput = {
+    id?: IntFieldUpdateOperationsInput | number
+    bio?: StringFieldUpdateOperationsInput | string
+    meta?: NullableJsonNullValueInput | InputJsonValue
+    userId?: IntFieldUpdateOperationsInput | number
   }
 
   export type DummyCreateWithoutDatatypeInput = {

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -296,6 +296,28 @@ test.serial('create query with nested objects for incoming FK', async (t) => {
   clear()
 })
 
+test.serial('create query with nullable FK', async (t) => {
+  const res = await profileTable.create({
+    data: {
+      id: 1094,
+      bio: 'whatever',
+      userId: 1,
+      imageId: null,
+    },
+    include: { image: true },
+  })
+
+  t.deepEqual(res, {
+    id: 1094,
+    bio: 'whatever',
+    meta: null,
+    imageId: null,
+    userId: 1,
+  })
+
+  clear()
+})
+
 // Test that we can make a create query
 test.serial('create query', async (t) => {
   const res = await tbl.create({

--- a/clients/typescript/test/client/model/table.test.ts
+++ b/clients/typescript/test/client/model/table.test.ts
@@ -31,11 +31,15 @@ const tbl = electric.db.Post
 const postTable = tbl
 const userTable = electric.db.User
 const profileTable = electric.db.Profile
+const imageTable = electric.db.ProfileImage
 
 // Sync all shapes such that we don't get warnings on every query
-await postTable.sync()
-await userTable.sync()
-await profileTable.sync()
+await Promise.all([
+  postTable.sync(),
+  userTable.sync(),
+  profileTable.sync(),
+  imageTable.sync(),
+])
 
 const post1 = {
   id: 1,
@@ -74,6 +78,7 @@ const profile1 = {
   bio: 'bio 1',
   meta: null,
   userId: 1,
+  imageId: null,
 }
 
 const author2 = {
@@ -82,11 +87,17 @@ const author2 = {
   meta: 'information',
 }
 
+const image1 = {
+  id: 'image-1',
+  image: new Uint8Array([1, 2, 3]),
+}
+
 const profile2 = {
   id: 2,
   bio: 'bio 2',
   meta: { foo: 3 },
   userId: 2,
+  imageId: image1.id,
 }
 
 // An invalid JSON that will throw if `JSON.parse()` is called
@@ -108,7 +119,11 @@ function clear() {
   )
   db.exec('DROP TABLE IF EXISTS Profile')
   db.exec(
-    "CREATE TABLE IF NOT EXISTS Profile('id' int PRIMARY KEY, 'bio' varchar, 'meta' json, 'userId' int);"
+    "CREATE TABLE IF NOT EXISTS Profile('id' int PRIMARY KEY, 'bio' varchar, 'meta' json, 'userId' int, 'imageId' varchar);"
+  )
+  db.exec('DROP TABLE IF EXISTS ProfileImage')
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS ProfileImage('id' varchar PRIMARY KEY, 'image' blob);"
   )
 }
 
@@ -323,6 +338,7 @@ test.serial(
         name: 'kevin',
         meta: invalidJson,
       },
+      imageId: null,
     })
 
     clear()
@@ -1110,6 +1126,10 @@ async function populate() {
   await profileTable.createMany({
     data: [profile1, profile2],
   })
+
+  await imageTable.createMany({
+    data: [image1],
+  })
 }
 
 test.serial(
@@ -1117,7 +1137,7 @@ test.serial(
   async (t) => {
     await populate()
     const res = await profileTable.findMany({
-      where: { id: 2 },
+      where: { id: profile2.id },
       include: { user: true },
     })
 
@@ -1129,6 +1149,15 @@ test.serial(
     ])
   }
 )
+
+test.serial('findMany can handle nullable foreign keys', async (t) => {
+  await populate()
+  const res = await profileTable.findMany({
+    include: { image: true },
+  })
+
+  t.deepEqual(res, [profile1, { ...profile2, image: image1 }])
+})
 
 test.serial(
   'update query can handle related objects with fields of same name and different type',


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1097

The queries were attempting to retrieve relations for null foreign keys and failing the subsequent schema validation - the suggested fix is to filter out `undefined` or `null` foreign keys when retrieving relations.

I've added two failing tests for `findMany` and `create` queries that are fixed through by this PR.