### PR TITLE
feat(electric): Resume client's replication stream from the on-disk WAL window

### DIFF
--- a/components/electric/lib/electric/postgres/cached_wal/api.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/api.ex
@@ -30,7 +30,7 @@ defmodule Electric.Postgres.CachedWal.Api do
   @callback request_notification(Connectors.origin(), wal_pos()) ::
               {:ok, await_ref()} | {:error, term()}
   @callback cancel_notification_request(Connectors.origin(), await_ref()) :: :ok
-  @callback reserve_wal_position(Connectors.origin(), binary(), wal_pos()) ::
+  @callback reserve_wal_position(Connectors.origin(), binary(), wal_pos() | :oldest) ::
               {:ok, wal_pos()} | :error
   @callback cancel_reservation(Connectors.origin(), binary()) :: :ok
 
@@ -115,7 +115,12 @@ defmodule Electric.Postgres.CachedWal.Api do
 
   If `wal_pos` is behind the cached window, `:error` is returned.
   """
+<<<<<<< HEAD
   @spec reserve_wal_position(module(), Connectors.origin(), binary(), wal_pos()) :: :ok | :error
+=======
+  @spec reserve_wal_position(module(), Connectors.origin(), binary(), wal_pos() | :oldest) ::
+          {:ok, wal_pos()} | :error
+>>>>>>> e6f66bb2 (Stream WAL records from the replication slot)
   def reserve_wal_position(module \\ default_module(), origin, client_id, wal_pos) do
     module.reserve_wal_position(origin, client_id, wal_pos)
   end

--- a/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
+++ b/components/electric/lib/electric/postgres/cached_wal/ets_backed.ex
@@ -26,11 +26,15 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   @typep state :: %{
            origin: Connectors.origin(),
            notification_requests: %{optional(reference()) => {Api.wal_pos(), pid()}},
+           reservations: %{binary() => {Api.wal_pos(), integer() | nil}},
            table: :ets.table(),
+           first_wal_pos: Api.wal_pos(),
            last_seen_wal_pos: Api.wal_pos(),
            current_tx_count: non_neg_integer(),
            wal_window_size: non_neg_integer()
          }
+
+  @reservation_expiration_s 30
 
   # Public API
 
@@ -49,25 +53,6 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
 
   def clear_cache(stage) do
     GenStage.cast(stage, :clear_cache)
-  end
-
-  @impl Api
-  def lsn_in_cached_window?(origin, client_wal_pos) do
-    table = ets_table_name(origin)
-
-    case :ets.first(table) do
-      :"$end_of_table" ->
-        false
-
-      first_position ->
-        case :ets.last(table) do
-          :"$end_of_table" ->
-            false
-
-          last_position ->
-            first_position <= client_wal_pos and client_wal_pos <= last_position
-        end
-    end
   end
 
   @impl Api
@@ -93,6 +78,22 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   @impl Api
   def cancel_notification_request(origin, ref) do
     GenStage.call(name(origin), {:cancel_notification, ref})
+  end
+
+  @impl Api
+  def reserve_wal_position(origin, client_id, wal_pos) do
+    with last_position when is_integer(last_position) <- :ets.last(ets_table_name(origin)),
+         # Sanity check to make sure client is not "in the future" relative to the cached WAL.
+         true <- wal_pos <= last_position do
+      GenStage.call(name(origin), {:reserve_wal_position, client_id, wal_pos})
+    else
+      _ -> :error
+    end
+  end
+
+  @impl Api
+  def cancel_reservation(origin, client_id) do
+    GenStage.cast(name(origin), {:cancel_reservation, client_id})
   end
 
   @impl Api
@@ -130,7 +131,9 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     state = %{
       origin: origin,
       notification_requests: %{},
+      reservations: %{},
       table: table,
+      first_wal_pos: nil,
       last_seen_wal_pos: 0,
       current_tx_count: 0,
       wal_window_size: Keyword.fetch!(opts, :wal_window_size)
@@ -164,6 +167,15 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
     {:reply, :ok, [], state}
   end
 
+  def handle_call({:reserve_wal_position, client_id, wal_pos}, _from, state) do
+    if wal_pos >= state.first_wal_pos do
+      state = Map.update!(state, :reservations, &Map.put(&1, client_id, {wal_pos, nil}))
+      {:reply, :ok, [], state}
+    else
+      {:reply, :error, [], state}
+    end
+  end
+
   def handle_call(:telemetry_stats, _from, state) do
     oldest_timestamp =
       if tx = lookup_oldest_transaction(state.table) do
@@ -181,6 +193,21 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
   end
 
   @impl GenStage
+  def handle_cast({:cancel_reservation, client_id}, %{reservations: reservations} = state) do
+    # Retain client's reservation long enough for the client to consume cached
+    # transactions before they are removed during a cache cleanup pass.
+    reservations =
+      if Map.has_key?(reservations, client_id) do
+        Map.update!(reservations, client_id, fn {wal_pos, ts} ->
+          {wal_pos, ts || System.monotonic_time()}
+        end)
+      else
+        reservations
+      end
+
+    {:noreply, [], %{state | reservations: reservations}}
+  end
+
   def handle_cast(:clear_cache, state) do
     :ets.delete_all_objects(state.table)
 
@@ -230,6 +257,7 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
         state =
           state
           |> Map.put(:last_seen_wal_pos, position)
+          |> Map.update!(:first_wal_pos, &min(&1, position))
           |> fulfill_notification_requests()
           |> trim_cache()
 
@@ -257,23 +285,54 @@ defmodule Electric.Postgres.CachedWal.EtsBacked do
 
   def lsn_to_position(lsn), do: Lsn.to_integer(lsn)
 
-  # Drop all transactions from the cache whose position is less than the last transaction's
-  # position minus in-memory WAL window size.
-  #
-  # TODO: make sure we're not removing transactions that are about to be requested by a newly
-  # connected client.
+  # Drop all transactions from the cache whose position falls out of the cached window. The
+  # cached window's low bound is calculated by subtracting the configured in-memory WAL window
+  # size from the most recent cached transaction's position.
   #
   # NOTE(optimization): clean the cache up after every N new transactions.
   @spec trim_cache(state()) :: state()
   defp trim_cache(state) do
     first_in_window_pos = state.last_seen_wal_pos - state.wal_window_size
+    {min_reserved_pos, reservations} = prune_reservations(state.reservations)
 
-    :ets.select_delete(state.table, [
-      {{:"$1", :_}, [{:<, :"$1", first_in_window_pos}], [true]}
-    ])
+    # Note that `min_pos_to_keep` may be less than the calculated low bound of the cached
+    # window. That's exactly the point of reservations: letting clients hold on to a
+    # transaction that would have been removed from the cache otherwise.
+    min_pos_to_keep = min(first_in_window_pos, min_reserved_pos)
 
-    %{state | current_tx_count: :ets.info(state.table, :size)}
+    state =
+      if min_pos_to_keep > state.first_wal_pos do
+        :ets.select_delete(state.table, [
+          {{:"$1", :_}, [{:<, :"$1", min_pos_to_keep}], [true]}
+        ])
+
+        %{state | current_tx_count: :ets.info(state.table, :size), first_wal_pos: min_pos_to_keep}
+      else
+        state
+      end
+
+    %{state | reservations: reservations}
   end
+
+  # Remove reservations who 1) already have a timestamp and 2) whose timestamp is old enough to
+  # be expired.
+  defp prune_reservations(reservations) do
+    current_time = System.monotonic_time()
+
+    Enum.reduce(reservations, {nil, reservations}, fn
+      {_client_id, {wal_pos, nil}}, {min_wal_pos, reservations} ->
+        {min(wal_pos, min_wal_pos), reservations}
+
+      {client_id, {wal_pos, ts}}, {min_wal_pos, reservations} ->
+        if diff_seconds(current_time, ts) < @reservation_expiration_s do
+          {min(wal_pos, min_wal_pos), reservations}
+        else
+          {min_wal_pos, Map.delete(reservations, client_id)}
+        end
+    end)
+  end
+
+  defp diff_seconds(ts1, ts2), do: System.convert_time_unit(abs(ts1 - ts2), :native, :second)
 
   defp lookup_oldest_transaction(ets_table) do
     case :ets.match(ets_table, {:_, :"$1"}, 1) do

--- a/components/electric/lib/electric/replication/postgres/logical_messages.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_messages.ex
@@ -1,0 +1,186 @@
+defmodule Electric.Replication.Postgres.LogicalMessages do
+  alias Electric.Postgres.LogicalReplication.Messages
+
+  alias Electric.Postgres.LogicalReplication.Messages.{
+    Begin,
+    Commit,
+    Delete,
+    Insert,
+    Message,
+    Origin,
+    Relation,
+    Truncate,
+    Type,
+    Update
+  }
+
+  alias Electric.Postgres.ShadowTableTransformation
+
+  alias Electric.Replication.Changes.{
+    Transaction,
+    NewRecord,
+    UpdatedRecord,
+    DeletedRecord,
+    TruncatedRelation,
+    ReferencedRecord
+  }
+
+  require Logger
+
+  defmodule Context do
+    defstruct origin: "",
+              publication: "",
+              commit_lsn: nil,
+              wip_transaction: nil,
+              transaction: nil,
+              relations: %{}
+
+    @type t :: %__MODULE__{
+            origin: binary(),
+            publication: binary(),
+            commit_lsn: Electric.Postgres.Lsn.t() | nil,
+            wip_transaction: Transaction.t() | nil,
+            transaction: Transaction.t() | nil,
+            relations: %{Messages.relation_id() => Relation.t()}
+          }
+
+    def reset_tx(context) do
+      %{context | commit_lsn: nil, transaction: nil, wip_transaction: nil}
+    end
+  end
+
+  @type message ::
+          Begin.t()
+          | Commit.t()
+          | Delete.t()
+          | Insert.t()
+          | Message.t()
+          | Origin.t()
+          | Relation.t()
+          | Truncate.t()
+          | Type.t()
+          | Update.t()
+
+  @spec process(message(), Context.t()) :: Context.t()
+  def process(
+        %Message{transactional?: true, prefix: "electric.fk_chain_touch", content: content},
+        context
+      ) do
+    received = Jason.decode!(content)
+
+    referenced = %ReferencedRecord{
+      relation: {received["schema"], received["table"]},
+      record: received["data"],
+      pk: received["pk"],
+      tags:
+        ShadowTableTransformation.convert_tag_list_pg_to_satellite(
+          received["tags"],
+          context.origin
+        )
+    }
+
+    update_in(context.wip_transaction, &Transaction.add_referenced_record(&1, referenced))
+  end
+
+  def process(%Message{} = msg, context) do
+    Logger.info("Got a message from PG via logical replication: #{inspect(msg)}")
+    context
+  end
+
+  def process(%Begin{} = msg, %{wip_transaction: nil} = context) do
+    tx = %Transaction{
+      xid: msg.xid,
+      changes: [],
+      commit_timestamp: msg.commit_timestamp,
+      origin_type: :postgresql,
+      origin: context.origin,
+      publication: context.publication
+    }
+
+    %{context | commit_lsn: msg.final_lsn, wip_transaction: tx}
+  end
+
+  def process(%Origin{} = msg, context) do
+    # If we got the "origin" message, it means that the Postgres sending back the transaction we sent from Electric
+    # We ignored those previously, when Vaxine was the source of truth, but now we need to fan out those processed messages
+    # to all the Satellites as their write has been "accepted"
+    Logger.debug("origin: #{inspect(msg.name)}")
+    context
+  end
+
+  def process(%Type{}, context), do: context
+
+  def process(%Relation{} = rel, context) do
+    update_in(context.relations, &Map.put(&1, rel.id, rel))
+  end
+
+  def process(%Insert{} = msg, context) do
+    relation = Map.fetch!(context.relations, msg.relation_id)
+    data = data_tuple_to_map(relation.columns, msg.tuple_data)
+    new_record = %NewRecord{relation: {relation.namespace, relation.name}, record: data}
+    update_in(context.wip_transaction.changes, &[new_record | &1])
+  end
+
+  def process(%Update{} = msg, context) do
+    relation = Map.fetch!(context.relations, msg.relation_id)
+    old_data = data_tuple_to_map(relation.columns, msg.old_tuple_data)
+    data = data_tuple_to_map(relation.columns, msg.tuple_data)
+
+    updated_record =
+      UpdatedRecord.new(
+        relation: {relation.namespace, relation.name},
+        old_record: old_data,
+        record: data
+      )
+
+    update_in(context.wip_transaction.changes, &[updated_record | &1])
+  end
+
+  def process(%Delete{} = msg, context) do
+    relation = Map.fetch!(context.relations, msg.relation_id)
+
+    data =
+      data_tuple_to_map(
+        relation.columns,
+        msg.old_tuple_data || msg.changed_key_tuple_data
+      )
+
+    deleted_record = %DeletedRecord{
+      relation: {relation.namespace, relation.name},
+      old_record: data
+    }
+
+    update_in(context.wip_transaction.changes, &[deleted_record | &1])
+  end
+
+  def process(%Truncate{} = msg, context) do
+    truncated_relations =
+      for truncated_relation <- Enum.reverse(msg.truncated_relations) do
+        relation = Map.fetch!(context.relations, truncated_relation)
+
+        %TruncatedRelation{relation: {relation.namespace, relation.name}}
+      end
+
+    update_in(context.wip_transaction.changes, &(truncated_relations ++ &1))
+  end
+
+  def process(
+        %Commit{lsn: commit_lsn, end_lsn: end_lsn},
+        %Context{commit_lsn: commit_lsn, wip_transaction: tx} = context
+      ) do
+    tx = ShadowTableTransformation.enrich_tx_from_shadow_ops(tx)
+    tx = %{tx | lsn: end_lsn}
+    %{context | transaction: tx, wip_transaction: nil, commit_lsn: nil}
+  end
+
+  ###
+
+  @spec data_tuple_to_map([Relation.Column.t()], list()) :: map()
+  defp data_tuple_to_map(_columns, nil), do: %{}
+
+  defp data_tuple_to_map(columns, tuple_data) do
+    columns
+    |> Enum.zip(tuple_data)
+    |> Map.new(fn {column, data} -> {column.name, data} end)
+  end
+end

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -11,9 +11,14 @@ defmodule Electric.Satellite.Protocol do
 
   alias Electric.Postgres.CachedWal
   alias Electric.Postgres.Extension.SchemaCache
+  alias Electric.Postgres.Lsn
   alias Electric.Postgres.Schema
   alias Electric.Replication.Changes
   alias Electric.Replication.Changes.Transaction
+  alias Electric.Replication.Connectors
+  alias Electric.Replication.Postgres.Client
+  alias Electric.Replication.Postgres.LogicalMessages
+  alias Electric.Replication.Postgres.LogicalReplicationProducer
   alias Electric.Replication.Shapes
   alias Electric.Replication.Shapes.ShapeRequest
   alias Electric.Satellite.Serialization
@@ -23,7 +28,7 @@ defmodule Electric.Satellite.Protocol do
   alias Electric.Telemetry.Metrics
   alias Electric.Utils
 
-  alias Electric.Satellite.Protocol.{State, InRep, OutRep, Telemetry}
+  alias Electric.Satellite.Protocol.{State, InRep, OutRep, ResumeRep, Telemetry}
   import Electric.Satellite.Protocol.State, only: :macros
 
   require Logger
@@ -522,43 +527,117 @@ defmodule Electric.Satellite.Protocol do
   end
 
   defp handle_start_replication_request(msg, client_pos, state) do
-    case reserve_wal_position(state.origin, state.client_id, client_pos) do
-      :cached ->
-        # Fast path: the client can resume replication by consuming transactions cached in main memory.
-        with {:ok, state} <-
-               restore_client_state(
-                 msg.subscription_ids,
-                 msg.observed_transaction_data,
-                 client_pos,
-                 state
-               ) do
-          state =
-            state
-            |> Telemetry.start_replication_span(subscriptions: length(msg.subscription_ids))
-            |> subscribe_client_to_replication_stream(client_pos)
+    r1 =
+      restore_client_state(msg.subscription_ids, msg.observed_transaction_data, client_pos, state)
 
-          {:reply,
-           %SatInStartReplicationResp{unacked_window_size: state.out_rep.allowed_unacked_txs},
-           state}
-        end
+    r2 = reserve_wal_position(state.origin, state.client_id, client_pos)
 
-      :behind_window ->
-        # Once the client is outside the WAL window, we are assuming the client will reset
-        # its local state, so we will too.
-        ClientReconnectionInfo.clear_all_data!(state.origin, state.client_id)
+    result =
+      case {r1, r2} do
+        {{:ok, state}, :cached} ->
+          # Fast path: the client can resume replication using WAL records cached in main memory.
+          {:ok, subscribe_client_to_replication_stream(state, client_pos)}
 
-        {:error,
-         start_replication_error(:BEHIND_WINDOW, "Cannot catch up to the server's current state")}
+        {{:ok, state}, :resumable} ->
+          # Slow path: stream missed WAL records from the database before subscribing the client to the stream.
+          client_lsn = CachedWal.EtsBacked.position_to_lsn(client_pos)
+          stream_transactions_from_wal(state, client_lsn)
+
+        {{:ok, _state}, :behind_window} ->
+          # Once the client is outside the WAL window, we are assuming the client will reset its local state, so we will too.
+          ClientReconnectionInfo.clear_all_data!(state.origin, state.client_id)
+
+          {:error,
+           start_replication_error(
+             :BEHIND_WINDOW,
+             "Cannot catch up to the server's current state"
+           )}
+
+        {:error, _} = error ->
+          error
+      end
+
+    with {:ok, state} <- result do
+      state = Telemetry.start_replication_span(state, subscriptions: length(msg.subscription_ids))
+
+      {:reply, %SatInStartReplicationResp{unacked_window_size: state.out_rep.allowed_unacked_txs},
+       state}
     end
   end
 
   defp reserve_wal_position(origin, client_id, client_pos) do
+    client_lsn = CachedWal.EtsBacked.position_to_lsn(client_pos)
+
     cond do
       CachedWal.Api.reserve_wal_position(origin, client_id, client_pos) == :ok ->
         :cached
 
+      LogicalReplicationProducer.reserve_wal_lsn(origin, client_id, client_lsn) == :ok ->
+        :resumable
+
       true ->
         :behind_window
+    end
+  end
+
+  defp stream_transactions_from_wal(%{connector_config: connector_config} = state, client_lsn) do
+    main_slot = Connectors.get_replication_opts(connector_config).slot
+    tmp_slot = "electric_r_" <> String.replace(state.client_id, "-", "")
+
+    {:ok, first_cached_wal_pos} =
+      CachedWal.Api.reserve_wal_position(state.origin, state.client_id, :oldest)
+
+    conn_opts = Connectors.get_connection_opts(connector_config, replication: true)
+    publication = Connectors.get_replication_opts(connector_config).publication
+
+    with {:ok, conn} <- Client.connect(conn_opts),
+         {:ok, _slot_name, _slot_lsn} <-
+           Client.create_temporary_slot(conn, main_slot, tmp_slot),
+         :ok <- Client.set_display_settings_for_replication(conn),
+         :ok <- Client.start_replication(conn, publication, tmp_slot, client_lsn, self()) do
+      # Now that replication has started from the desired LSN, we can remove the reservation
+      # that was made made earlier.
+      LogicalReplicationProducer.cancel_reservation(state.origin, state.client_id)
+
+      repl_context = %LogicalMessages.Context{
+        origin: state.origin,
+        publication: publication
+      }
+
+      resume_rep = %ResumeRep{
+        repl_conn: conn,
+        repl_context: repl_context,
+        end_lsn: CachedWal.EtsBacked.position_to_lsn(first_cached_wal_pos)
+      }
+
+      {:ok, %{state | resume_rep: resume_rep}}
+    end
+  end
+
+  def handle_x_log_data(binary_msg, state) do
+    {tx, resume_rep} = ResumeRep.process_message(binary_msg, state.resume_rep)
+    state = %{state | resume_rep: resume_rep}
+
+    case tx do
+      nil ->
+        {[], state}
+
+      %Transaction{} = tx ->
+        reached_cached_lsn? = Lsn.compare(tx.lsn, resume_rep.end_lsn) in [:eq, :gt]
+
+        state =
+          if reached_cached_lsn? do
+            # This is the last transaction we wanted to stream from WAL.
+            Client.close(resume_rep.repl_conn)
+
+            start_wal_pos = CachedWal.EtsBacked.lsn_to_position(resume_rep.end_lsn)
+            subscribe_client_to_replication_stream(%{state | resume_rep: nil}, start_wal_pos)
+          else
+            state
+          end
+
+        wal_pos = CachedWal.EtsBacked.lsn_to_position(tx.lsn)
+        handle_outgoing_txs([{tx, wal_pos}], state)
     end
   end
 

--- a/components/electric/lib/electric/satellite/protocol/resume_rep.ex
+++ b/components/electric/lib/electric/satellite/protocol/resume_rep.ex
@@ -1,0 +1,32 @@
+defmodule Electric.Satellite.Protocol.ResumeRep do
+  alias Electric.Postgres.LogicalReplication
+  alias Electric.Postgres.Lsn
+  alias Electric.Replication.Changes.Transaction
+  alias Electric.Replication.Postgres.LogicalMessages
+
+  defstruct [:repl_conn, :repl_context, :end_lsn]
+
+  @type t :: %__MODULE__{
+          repl_conn: :epgsql.connection(),
+          repl_context: LogicalMessages.Context.t(),
+          end_lsn: Lsn.t()
+        }
+
+  def process_message(binary_msg, %__MODULE__{} = rep) do
+    rep =
+      update_in(rep.repl_context, fn context ->
+        binary_msg
+        |> LogicalReplication.decode_message()
+        |> LogicalMessages.process(context)
+      end)
+
+    case rep.repl_context.transaction do
+      nil -> {nil, rep}
+      %Transaction{} = tx -> {tx, reset_tx(rep)}
+    end
+  end
+
+  defp reset_tx(%__MODULE__{} = rep) do
+    update_in(rep.repl_context, &LogicalMessages.Context.reset_tx/1)
+  end
+end

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -210,12 +210,12 @@ defmodule Electric.Satellite.WebsocketServer do
     # migrations_since() but before the client subscribes to the replication stream. If the migration was immediately
     # followed by another write in PG, we could have fetched the LSN of this last write with get_current_position() and
     # thus miss the migration committed just before it.
-    lsn = CachedWal.Api.get_current_position(origin)
+    client_pos = CachedWal.Api.get_current_position(origin)
 
-    _ = maybe_pause(origin, lsn)
+    _ = maybe_pause(origin, client_pos)
 
     %SatInStartReplicationReq{schema_version: schema_version} = msg
-    migrations = InitialSync.migrations_since(schema_version, origin, lsn)
+    migrations = InitialSync.migrations_since(schema_version, origin, client_pos)
 
     # We're ignoring actions here since we've "manufactured" migration events
     # which by definition aren't shape-dependent, so actions are always empty
@@ -229,14 +229,13 @@ defmodule Electric.Satellite.WebsocketServer do
     ClientReconnectionInfo.store_initial_checkpoint!(
       state.origin,
       state.client_id,
-      lsn,
+      client_pos,
       state.out_rep.sent_rows_graph
     )
 
     state =
-      state
-      |> Protocol.subscribe_client_to_replication_stream(lsn)
-      |> Map.update!(:out_rep, &%{&1 | last_migration_xid_at_initial_sync: max_txid})
+      update_in(state.out_rep, &%{&1 | last_migration_xid_at_initial_sync: max_txid})
+      |> Protocol.subscribe_client_to_replication_stream(client_pos)
 
     push({msgs, state})
   end

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -267,6 +267,22 @@ defmodule Electric.Satellite.WebsocketServer do
     |> push()
   end
 
+  def handle_info(
+        {:epgsql, _pid, {:x_log_data, _start_lsn, _end_lsn, _binary_msg}},
+        %{resume_rep: nil} = state
+      ) do
+    # By this point, we have already stopped expecting replication messages from Postgres and
+    # the replication connection should have been closed.  This must be a leftover message that
+    # managed to slip in just before the connection closure.
+    {:ok, state}
+  end
+
+  def handle_info({:epgsql, _pid, {:x_log_data, _start_lsn, _end_lsn, binary_msg}}, state) do
+    binary_msg
+    |> Protocol.handle_x_log_data(state)
+    |> push()
+  end
+
   if Mix.env() == :test do
     def handle_info({:pause_during_initial_sync, ref, client_pid}, state) do
       Process.put(:pause_during_initial_sync, {ref, client_pid})

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -92,9 +92,14 @@ defmodule Electric.Satellite.WebsocketServerTest do
       Electric.Postgres.CachedWal.Api,
       [:passthrough],
       get_current_position: fn _ -> @current_wal_pos end,
-      lsn_in_cached_window?: fn _origin, pos when is_integer(pos) ->
-        pos > @current_wal_pos
+      reserve_wal_position: fn "fake_origin", _client_id, wal_pos ->
+        if wal_pos > @current_wal_pos + 10 do
+          :error
+        else
+          :ok
+        end
       end,
+      cancel_reservation: fn "fake_origin", _client_id -> :ok end,
       stream_transactions: fn _, _, _ -> [] end
     }
   ]) do
@@ -803,12 +808,12 @@ defmodule Electric.Satellite.WebsocketServerTest do
       end)
     end
 
-    test "results in an error response when the client is outside of the cached WAL window",
+    test "results in an error response when the client is outside of the resumable WAL window",
          ctx do
       with_connect([auth: ctx, id: ctx.client_id, port: ctx.port], fn conn ->
         assert {:ok, %SatInStartReplicationResp{err: error}} =
                  MockClient.make_rpc_call(conn, "startReplication", %SatInStartReplicationReq{
-                   lsn: "1"
+                   lsn: "13"
                  })
 
         assert %SatInStartReplicationResp.ReplicationError{code: :BEHIND_WINDOW} = error


### PR DESCRIPTION
This PR makes it possible to resume the replication stream for clients whose position in the replication stream is outside of the in-memory cached WAL window. This is done by streaming transactions directly from the replication slot. Assuming the slot's start position goes back further than the in-memory cache can fit, this effectively extends the resumable WAL window that the sync service can use before having to ask clients to reset their local state.

This implementation builds on the primitives introduced in https://github.com/electric-sql/electric/pull/1119.