### PR TITLE
chore(e2e): Add a new E2E test for client reconnection info peristence 

### DIFF
--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -790,6 +790,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       end)
 
     :ets.insert(checkpoint_table, checkpoints)
+    Logger.debug("Cached #{length(checkpoints)} client_checkpoints from the DB")
   end
 
   defp restore_subscriptions_cache(subscriptions_table) do
@@ -802,6 +803,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       end)
 
     :ets.insert(subscriptions_table, subscriptions)
+    Logger.debug("Cached #{length(subscriptions)} client_shape_subscriptions from the DB")
   end
 
   defp restore_additional_data_cache(additional_data_table) do
@@ -822,6 +824,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       end)
 
     :ets.insert(additional_data_table, records)
+    Logger.debug("Cached #{length(records)} client_additional_data records from the DB")
   end
 
   defp restore_actions_cache(actions_table) do
@@ -833,6 +836,7 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       end)
 
     :ets.insert(actions_table, actions)
+    Logger.debug("Cached #{length(actions)} client_actions from the DB")
   end
 
   # The encode_uuid() and decode_uuid() functions are needed here due to incomplete adoption

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -508,6 +508,7 @@ defmodule Electric.Satellite.Protocol do
     #
     # Sending a message to self() here ensures that the SatInStartReplicationResp message is delivered to the
     # client first, followed by the initial migrations.
+    Logger.debug("Performing initial sync for client #{state.client_id}")
     send(self(), {:perform_initial_sync_and_subscribe, msg})
 
     {:reply, %SatInStartReplicationResp{unacked_window_size: state.out_rep.allowed_unacked_txs},

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -35,13 +35,17 @@ export const electrify_db = async (
   schema.migrations = migrations
   const result = await electrify(db, schema, config)
   const token = await mockSecureAuthToken(exp)
-  
+
   result.notifier.subscribeToConnectivityStateChanges((x: any) => console.log(`Connectivity state changed: ${x.connectivityState.status}`))
   if (connectToElectric) {
     await result.connect(token) // connect to Electric
   }
 
   return result
+}
+
+export const disconnect = async (electric: Electric) => {
+  await electric.disconnect()
 }
 
 // reconnects with Electric, e.g. after expiration of the JWT
@@ -98,8 +102,8 @@ export const syncTable = async (table: string) => {
 }
 
 export const lowLevelSubscribe = async (electric: Electric, shape: Shape) => {
-    const { synced } = await electric.satellite.subscribe([shape])
-    return await synced
+  const { synced } = await electric.satellite.subscribe([shape])
+  return await synced
 }
 
 export const get_tables = (electric: Electric) => {
@@ -111,7 +115,7 @@ export const get_columns = (electric: Electric, table: string) => {
 }
 
 export const get_rows = (electric: Electric, table: string) => {
-  return electric.db.rawQuery({sql: `SELECT * FROM ${table};`})
+  return electric.db.rawQuery({ sql: `SELECT * FROM ${table};` })
 }
 
 export const get_timestamps = (electric: Electric) => {
@@ -374,7 +378,7 @@ export const insert_extended_into = async (electric: Electric, table: string, va
   const columnNames = columns.join(", ")
   const placeHolders = Array(columns.length).fill("?")
   const args = Object.values(values)
-  
+
   await electric.db.unsafeExec({
     sql: `INSERT INTO ${table} (${columnNames}) VALUES (${placeHolders}) RETURNING *;`,
     args: args,

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -403,13 +403,6 @@ export const insert_other_item = async (electric: Electric, keys: [string]) => {
     }
   })
 
-  await electric.db.items.create({
-    data: {
-      id: "test_id_1",
-      content: ""
-    }
-  })
-
   await electric.db.other_items.createMany({
     data: items
   })

--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -81,15 +81,20 @@ export const set_subscribers = (db: Electric) => {
   })
 }
 
-export const syncTable = async (electric: Electric, table: string) => {
-  if (table === 'other_items') {
-    const { synced } = await electric.db.other_items.sync()
-    return await synced
-  } else {
-    const satellite = globalRegistry.satellites[dbName]
-    const { synced } = await satellite.subscribe([{tablename: table}])
-    return await synced
-  }
+export const syncItemsTable = async (electric: Electric, shapeFilter: string) => {
+  const { synced } = await electric.db.items.sync({ where: shapeFilter })
+  return await synced
+}
+
+export const syncOtherItemsTable = async (electric: Electric, shapeFilter: string) => {
+  const { synced } = await electric.db.other_items.sync({ where: shapeFilter })
+  return await synced
+}
+
+export const syncTable = async (table: string) => {
+  const satellite = globalRegistry.satellites[dbName]
+  const { synced } = await satellite.subscribe([{ tablename: table }])
+  return await synced
 }
 
 export const lowLevelSubscribe = async (electric: Electric, shape: Shape) => {

--- a/e2e/tests/01.05_electric_can_recreate_publication.lux
+++ b/e2e/tests/01.05_electric_can_recreate_publication.lux
@@ -57,10 +57,9 @@
 
 [shell electric]
     [invoke start_electric 1]
+    ??Successfully initialized Postgres connector "postgres_1"
 
 [shell pg_1]
-    !SELECT * FROM electric.schema;
-
     !SELECT schemaname, tablename FROM pg_publication_tables \
          WHERE pubname = 'electric_publication' ORDER BY tablename;
     ??electric   | acknowledged_client_lsns

--- a/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
+++ b/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
@@ -12,10 +12,10 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [invoke log "PG & Satellites migrated and ready"]
 

--- a/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
+++ b/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
@@ -12,11 +12,9 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [invoke log "PG & Satellites migrated and ready"]

--- a/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
+++ b/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
@@ -18,11 +18,9 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [invoke log "PG & Satellites migrated and ready"]

--- a/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
+++ b/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
@@ -18,10 +18,10 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [invoke log "PG & Satellites migrated and ready"]
 

--- a/e2e/tests/03.06_node_satellite_does_sync_on_subscribe.lux
+++ b/e2e/tests/03.06_node_satellite_does_sync_on_subscribe.lux
@@ -22,7 +22,7 @@
 
 [shell satellite_1]
     -$fail_pattern
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
     # As soon as sync is done, we expect to see the row in the database
     !await client.get_items(db)
     ??hello from pg

--- a/e2e/tests/03.07_node_satellite_can_delete_freshly_synced_rows.lux
+++ b/e2e/tests/03.07_node_satellite_can_delete_freshly_synced_rows.lux
@@ -26,7 +26,7 @@
 
 [shell satellite_1]
     -$fail_pattern
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
     # As soon as sync it done, we expect to see the row in the database
     !await client.get_items(db)
     ??hello from pg

--- a/e2e/tests/03.08_node_satellite_can_resume_subscriptions_on_reconnect.lux
+++ b/e2e/tests/03.08_node_satellite_can_resume_subscriptions_on_reconnect.lux
@@ -22,7 +22,7 @@
 
 [shell satellite_1]
     -$fail_pattern
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
     # As soon as sync is done, we expect to see the row in the database
     !await client.get_items(db)
     ??hello from pg

--- a/e2e/tests/03.11_node_satellite_compensations_work.lux
+++ b/e2e/tests/03.11_node_satellite_compensations_work.lux
@@ -14,7 +14,7 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "other_items"]
+    [invoke node_sync_other_items ""]
     ??[proto] recv: #SatSubsDataEnd
     !await db.db.unsafeExec({sql: "UPDATE _electric_meta SET value = 1 WHERE key = 'compensations' RETURNING *"})
     ?$node

--- a/e2e/tests/03.11_node_satellite_compensations_work.lux
+++ b/e2e/tests/03.11_node_satellite_compensations_work.lux
@@ -10,21 +10,10 @@
 
 [shell proxy_1]
     [invoke migrate_items_table 001]
-
-    [local sql=
-        """
-        CREATE TABLE public.other_items (
-            id TEXT PRIMARY KEY,
-            content TEXT NOT NULL,
-            item_id UUID REFERENCES public.items(id)
-        );
-        ALTER TABLE public.other_items ENABLE ELECTRIC;
-        """]
-    [invoke migrate_pg 002 $sql]
+    [invoke migrate_other_items_table 002]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "other_items"]
     [invoke node_sync_table "other_items"]
     ??[proto] recv: #SatSubsDataEnd
     !await db.db.unsafeExec({sql: "UPDATE _electric_meta SET value = 1 WHERE key = 'compensations' RETURNING *"})

--- a/e2e/tests/03.12_server_correctly_continues_the_replication.lux
+++ b/e2e/tests/03.12_server_correctly_continues_the_replication.lux
@@ -11,7 +11,7 @@
 
 [shell satellite_1]
   ??[rpc] recv: #SatInStartReplicationResp
-  [invoke node_sync_table "items"]
+  [invoke node_sync_items ""]
 
   # First write gets propagated
   [invoke node_await_insert "['hello from satellite - first']"]
@@ -29,7 +29,7 @@
 
 [shell satellite_2]
   ??[rpc] recv: #SatInStartReplicationResp
-  [invoke node_sync_table "items"]
+  [invoke node_sync_items ""]
 
   # Perform multiple writes to bump the LSN repeatedly
   [invoke node_await_insert "['hello from satellite - client 2 - a']"]

--- a/e2e/tests/03.12_server_correctly_continues_the_replication.lux
+++ b/e2e/tests/03.12_server_correctly_continues_the_replication.lux
@@ -11,7 +11,7 @@
 
 [shell satellite_1]
   ??[rpc] recv: #SatInStartReplicationResp
-  [invoke node_await_table "items"]
+  [invoke node_sync_table "items"]
 
   # First write gets propagated
   [invoke node_await_insert "['hello from satellite - first']"]
@@ -29,7 +29,7 @@
 
 [shell satellite_2]
   ??[rpc] recv: #SatInStartReplicationResp
-  [invoke node_await_table "items"]
+  [invoke node_sync_table "items"]
 
   # Perform multiple writes to bump the LSN repeatedly
   [invoke node_await_insert "['hello from satellite - client 2 - a']"]

--- a/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
+++ b/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
@@ -12,10 +12,10 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [invoke log "PG & Satellites migrated and ready"]
 

--- a/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
+++ b/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
@@ -12,11 +12,9 @@
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [invoke log "PG & Satellites migrated and ready"]

--- a/e2e/tests/03.24_node_satellite_can_transform_at_replication_boundary.lux
+++ b/e2e/tests/03.24_node_satellite_can_transform_at_replication_boundary.lux
@@ -13,13 +13,11 @@
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
     [invoke node_set_item_replication_transform]
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
     
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
     [invoke node_set_item_replication_transform]
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [shell satellite_1]

--- a/e2e/tests/03.25_node_satellite_can_resume_replication_after_server_restart.lux
+++ b/e2e/tests/03.25_node_satellite_can_resume_replication_after_server_restart.lux
@@ -1,0 +1,211 @@
+[doc NodeJS Satellite can resume replication after the sync service restarts]
+
+# The focus in this test is the correct state restoration on the server when it restarts.
+#
+# The test scenario implemented below can be summarized as follows:
+#
+# - Create two tables with a foreign-key relationship "other_items" -> "items".
+# - Insert rows into both tables, some connected via an FK, others standalone.
+# - Start two clients that initiate different subscriptions.
+# - Verify that actions such as disconnecting one of the clients, stopping and starting the
+#   server do not lead to clients resetting their local state and that both clients don't miss
+#   transactions that are visible under their subscribed shapes.
+
+[include _shared.luxinc]
+[include _satellite_macros.luxinc]
+
+[invoke setup]
+
+[shell proxy_1]
+    [invoke migrate_items_table 001]
+    [invoke migrate_other_items_table 002]
+
+[invoke setup_client 1 electric_1 5133]
+
+[shell satellite_1]
+    ?\[rpc\] send: #SatAuthReq\{id: ([a-f0-9-]{36})
+    [global client_1_id=$1]
+
+[shell electric]
+    ??initial sync for client $client_1_id
+
+[shell pg_1]
+    !INSERT INTO items (id, content) VALUES \
+       ('00000000-0000-0000-0000-000000000001', 'items-1'), \
+       ('00000000-0000-0000-0000-000000000002', 'items-2-'), \
+       ('00000000-0000-0000-0000-000000000003', 'items-3-');
+    ??INSERT 0 3
+
+    !INSERT INTO other_items VALUES \
+       ('1', 'first', '00000000-0000-0000-0000-000000000001'), \
+       ('2', 'second', '00000000-0000-0000-0000-000000000002'), \
+       ('3', '', NULL);
+    ??INSERT 0 3
+
+[shell satellite_1]
+    # Subscribe to "other_items"
+    [invoke node_sync_other_items "this.content not like ''"]
+
+    ?send: #SatSubsReq\{id: ([a-f0-9-]{36})
+    [global client_1_subs_id=$1]
+
+[shell electric]
+    ??Received initial data for subscription $client_1_subs_id
+
+[shell satellite_1]
+    # Wait for the rows from "other_items" to arrive
+    [invoke node_await_get_from_table "other_items" "first"]
+    [invoke node_await_get_from_table "other_items" "second"]
+
+    # Wait for the rows from "items" to arrive, via an FK link
+    [invoke node_await_get "items-1"]
+    [invoke node_await_get "items-2"]
+
+# Start a new Satellite client that has a different set of subscriptions
+[invoke setup_client 2 electric_1 5133]
+
+[shell satellite_2]
+    ?\[rpc\] send: #SatAuthReq\{id: ([a-f0-9-]{36})
+    [global client_2_id=$1]
+
+[shell electric]
+    ??initial sync for client $client_2_id
+
+[shell satellite_2]
+    # Subscribe to "items" and include "other_items"
+    !const { synced } = await db.db.items.sync({ \
+       where: "this.content like 'items-_-'", \
+       include: { other_items: true } \
+     }); await synced
+
+    ?send: #SatSubsReq\{id: ([a-f0-9-]{36})
+    [global client_2_subs_id=$1]
+
+[shell electric]
+    ??Received initial data for subscription $client_2_subs_id
+
+[shell satellite_2]
+    # Wait for the rows from "items" to arrive
+    [invoke node_await_get "items-2-"]
+    [invoke node_await_get "items-3-"]
+
+    # Wait for the rows from "other_items" to arrive, via an FK link
+    [invoke node_await_get_from_table "other_items" "second"]
+
+    # Disconnect the client so that it does not see the next batch of updates
+    [invoke client_disconnect]
+
+[shell pg_1]
+    !INSERT INTO items (id, content) VALUES \
+       ('00000000-0000-0000-0000-000000000004', 'items-4'), \
+       ('00000000-0000-0000-0000-000000000005', 'items-5-'), \
+       ('00000000-0000-0000-0000-000000000006', 'items-6');
+    ??INSERT 0 3
+
+    !INSERT INTO other_items VALUES \
+       ('4', '', NULL), \
+       ('5', '', NULL), \
+       ('6', '', NULL), \
+       ('7', '', NULL);
+    ??INSERT 0 4
+
+[shell satellite_1]
+    [invoke node_await_insert_extended "{content: 'items-a-', id: '10000000-0000-0000-0000-000000000001'}"]
+
+    ?send: #SatOpLog\{ops: \[#Begin\{[^}]+\}, \
+       #Insert\{[^}]*new: \["10000000-0000-0000-0000-000000000001", "items-a-"
+
+    # Reset the failure pattern
+    -resetting client state
+
+[shell satellite_2]
+    # Reset the failure pattern
+    -resetting client state
+
+# Stop the server to restart it later.
+[shell log]
+    [invoke stop_electric 1]
+
+[shell satellite_1]
+    [invoke node_await_insert_extended "{content: 'items-b-', id: '10000000-0000-0000-0000-000000000002'}"]
+
+[shell pg_1]
+    !UPDATE items SET content = 'items-1-' WHERE id = '00000000-0000-0000-0000-000000000001';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'third', item_id = '10000000-0000-0000-0000-000000000001' WHERE id = '3';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'fourth', item_id = '00000000-0000-0000-0000-000000000004' WHERE id = '4';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'fifth', item_id = '00000000-0000-0000-0000-000000000005' WHERE id = '5';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'sixth', item_id = '00000000-0000-0000-0000-000000000006' WHERE id = '6';
+    ??UPDATE 1
+    !UPDATE other_items SET content = 'seventh', item_id = '00000000-0000-0000-0000-000000000005' WHERE id = '7';
+    ??UPDATE 1
+
+# Now restart the server, verify that both clients reconnect and are able to
+# to catch up to the latest server state.
+[shell electric]
+    [invoke start_electric 1]
+
+    ??Cached 2 client_checkpoints from the DB
+    ??Cached 2 client_shape_subscriptions from the DB
+    ??Cached 0 client_additional_data records from the DB
+    ??Cached 0 client_actions from the DB
+
+[shell satellite_1]
+    ??Connectivity state changed: connected
+
+    [invoke node_await_get_from_table "other_items" "fourth"]
+    [invoke node_await_get_from_table "other_items" "fifth"]
+    [invoke node_await_get_from_table "other_items" "sixth"]
+    [invoke node_await_get_from_table "other_items" "seventh"]
+
+[shell satellite_2]
+    [invoke client_reconnect]
+
+    ??Connectivity state changed: connected
+
+    [invoke node_await_get "items-1-"]
+    [invoke node_await_get "items-a-"]
+    [invoke node_await_get "items-b-"]
+    [invoke node_await_get_from_table "other_items" "first"]
+    [invoke node_await_get_from_table "other_items" "third"]
+
+# Stop the server and verify that it persists client_actions and client_additional_data.
+[shell log]
+    [invoke stop_electric 1]
+
+[shell pg_1]
+    !SELECT * FROM electric.client_actions;
+    ?$client_2_id \|  \d+ \| \\x
+
+    !SELECT * FROM electric.client_additional_data;
+    ?$client_2_id \|      \d+ \|   1 \| transaction \| <NULL>          \| \\x
+
+# Restart the server and verify that it cleans up client_actions and client_additional_data.
+[shell electric]
+    -initial sync|initial data
+
+    [invoke start_electric 1]
+
+    ??Cached 2 client_checkpoints from the DB
+    ??Cached 2 client_shape_subscriptions from the DB
+    ??Cached 1 client_additional_data records from the DB
+    ??Cached 1 client_actions from the DB
+
+[shell satellite_1]
+    ??Connectivity state changed: connected
+
+[shell satellite_2]
+    ??Connectivity state changed: connected
+
+[shell pg_1]
+    !SELECT * FROM electric.client_actions;
+    ??(0 rows)
+
+    !SELECT * FROM electric.client_additional_data;
+    ??(0 rows)
+
+[cleanup]
+  [invoke teardown]

--- a/e2e/tests/03.xx_node_satellite_authentication.lux.disabled
+++ b/e2e/tests/03.xx_node_satellite_authentication.lux.disabled
@@ -21,12 +21,10 @@
     # Wait for the items table migration and sync the table
     ??[rpc] recv: #SatInStartReplicationResp
     ??Connectivity state changed: connected
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_await_table "items"]
     [invoke node_sync_table "items"]
 
 [invoke log "PG & Satellites migrated and ready"]

--- a/e2e/tests/03.xx_node_satellite_authentication.lux.disabled
+++ b/e2e/tests/03.xx_node_satellite_authentication.lux.disabled
@@ -21,11 +21,11 @@
     # Wait for the items table migration and sync the table
     ??[rpc] recv: #SatInStartReplicationResp
     ??Connectivity state changed: connected
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
-    [invoke node_sync_table "items"]
+    [invoke node_sync_items ""]
 
 [invoke log "PG & Satellites migrated and ready"]
 

--- a/e2e/tests/05.05_compensations_within_same_tx_are_fine.lux
+++ b/e2e/tests/05.05_compensations_within_same_tx_are_fine.lux
@@ -7,19 +7,14 @@
     [local sql=
         """
         CREATE TABLE public.items (
-            id TEXT PRIMARY KEY,
+            id UUID PRIMARY KEY,
             content TEXT NOT NULL
         );
-        CREATE TABLE public.other_items (
-            id TEXT PRIMARY KEY,
-            content TEXT NOT NULL,
-            item_id TEXT REFERENCES public.items(id)
-        );
         ALTER TABLE public.items ENABLE ELECTRIC;
-        ALTER TABLE public.other_items ENABLE ELECTRIC;
         """]
-    [invoke migrate_pg 11111 $sql]
+    [invoke migrate_pg 001 $sql]
 
+    [invoke migrate_other_items_table 002]
 
 [newshell user_1_ws1]
     -$fail_pattern

--- a/e2e/tests/_satellite_macros.luxinc
+++ b/e2e/tests/_satellite_macros.luxinc
@@ -210,8 +210,16 @@
     ??$node
 [endmacro]
 
+[macro node_sync_items filter]
+    !await client.syncItemsTable(db, "${filter}")
+[endmacro]
+
+[macro node_sync_other_items filter]
+    !await client.syncOtherItemsTable(db, "${filter}")
+[endmacro]
+
 [macro node_sync_table table]
-    !await client.syncTable(db, "${table}")
+    !await client.syncTable("${table}")
 [endmacro]
 
 # Makes both satellites and PG write rows

--- a/e2e/tests/_satellite_macros.luxinc
+++ b/e2e/tests/_satellite_macros.luxinc
@@ -34,6 +34,15 @@
     [invoke connect_to_electric $electric $port $migrations $connectToElectric]
 [endmacro]
 
+[macro client_disconnect]
+    !await client.disconnect(db)
+    ??$node
+[endmacro]
+
+[macro client_reconnect]
+    !await client.reconnect(db)
+[endmacro]
+
 [macro setup_client satellite_number electric port]
     [invoke setup_client_with_migrations $satellite_number $electric $port "[]" "true"]
 [endmacro]
@@ -186,13 +195,13 @@
     ??$node
 [endmacro]
 
-[macro node_await_insert_extended keys]
-    !await client.insert_extended_item(db, ${keys})
+[macro node_await_insert_extended obj]
+    !await client.insert_extended_item(db, ${obj})
     ??$node
 [endmacro]
 
-[macro node_await_insert_extended_into table keys]
-    !await client.insert_extended_into(db, '${table}', ${keys})
+[macro node_await_insert_extended_into table obj]
+    !await client.insert_extended_into(db, '${table}', ${obj})
     ??$node
 [endmacro]
 
@@ -201,12 +210,12 @@
 [endmacro]
 
 [macro node_await_insert_other keys]
-    !client.insert_other_item(db, ${keys})
+    !await client.insert_other_item(db, ${keys})
     ??$node
 [endmacro]
 
 [macro node_set_item_replication_transform]
-    !client.set_item_replication_transform(db)
+    !await client.set_item_replication_transform(db)
     ??$node
 [endmacro]
 

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -143,3 +143,16 @@
         """]
     [invoke migrate_pg $version $sql]
 [endmacro]
+
+[macro migrate_other_items_table version]
+    [local sql=
+        """
+        CREATE TABLE public.other_items (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            item_id UUID REFERENCES public.items(id)
+        );
+        ALTER TABLE public.other_items ENABLE ELECTRIC;
+        """]
+    [invoke migrate_pg $version $sql]
+[endmacro]

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -17,6 +17,7 @@
 
     [newshell electric]
         [invoke start_electric 1]
+        ??Successfully initialized Postgres connector "postgres_1"
         [progress setup finished]
 
     [shell postgres_logs]
@@ -36,7 +37,6 @@
 [macro start_electric n]
     !make start_electric_${n}
     -$fail_pattern
-    ??Successfully initialized Postgres connector "postgres_1"
 [endmacro]
 
 [macro stop_electric n]

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -41,6 +41,7 @@
 
 [macro stop_electric n]
     !make stop_electric_${n}
+    ??Stopped
     [invoke ok]
 [endmacro]
 


### PR DESCRIPTION
This PR introduces a bunch of simple refactorings in our e2e test harness, plus a new e2e test is added to validate ClientReconnectionInfo persistence implemented in https://github.com/electric-sql/electric/pull/1116.