### PR TITLE
fix(client_tests): Run the migrate.generation test as serial

### DIFF
--- a/clients/typescript/test/cli/migrations/migrate.generation.test.ts
+++ b/clients/typescript/test/cli/migrations/migrate.generation.test.ts
@@ -169,7 +169,10 @@ test.before(() => {
 
 // This test runs the prisma generator under the hood, which can
 // cause issues when running concurrently, so we run them with serial
-const generatorTest = (testName: string, fn: (t: ExecutionContext<unknown>) => void) => {
+const generatorTest = (
+  testName: string,
+  fn: (t: ExecutionContext<unknown>) => void
+) => {
   return test.serial(testName, fn)
 }
 
@@ -184,13 +187,16 @@ test.after.always(() => {
   }
 })
 
-generatorTest('should generate valid TS client for simple schema', async (t) => {
-  const clientPath = await generateClientFromPrismaSchema(
-    simpleSchema,
-    'simple'
-  )
-  t.true(checkGeneratedClientCompiles(clientPath))
-})
+generatorTest(
+  'should generate valid TS client for simple schema',
+  async (t) => {
+    const clientPath = await generateClientFromPrismaSchema(
+      simpleSchema,
+      'simple'
+    )
+    t.true(checkGeneratedClientCompiles(clientPath))
+  }
+)
 
 generatorTest(
   'should generate valid TS client for relational schema',

--- a/clients/typescript/test/cli/migrations/migrate.generation.test.ts
+++ b/clients/typescript/test/cli/migrations/migrate.generation.test.ts
@@ -178,7 +178,7 @@ test.after.always(() => {
   }
 })
 
-test('should generate valid TS client for simple schema', async (t) => {
+test.serial('should generate valid TS client for simple schema', async (t) => {
   const clientPath = await generateClientFromPrismaSchema(
     simpleSchema,
     'simple'
@@ -186,18 +186,24 @@ test('should generate valid TS client for simple schema', async (t) => {
   t.true(checkGeneratedClientCompiles(clientPath))
 })
 
-test('should generate valid TS client for relational schema', async (t) => {
-  const clientPath = await generateClientFromPrismaSchema(
-    relationalSchema,
-    'relational'
-  )
-  t.true(checkGeneratedClientCompiles(clientPath))
-})
+test.serial(
+  'should generate valid TS client for relational schema',
+  async (t) => {
+    const clientPath = await generateClientFromPrismaSchema(
+      relationalSchema,
+      'relational'
+    )
+    t.true(checkGeneratedClientCompiles(clientPath))
+  }
+)
 
-test('should generate valid TS client for schema with all data types', async (t) => {
-  const clientPath = await generateClientFromPrismaSchema(
-    dataTypesSchema,
-    'datatypes'
-  )
-  t.true(checkGeneratedClientCompiles(clientPath))
-})
+test.serial(
+  'should generate valid TS client for schema with all data types',
+  async (t) => {
+    const clientPath = await generateClientFromPrismaSchema(
+      dataTypesSchema,
+      'datatypes'
+    )
+    t.true(checkGeneratedClientCompiles(clientPath))
+  }
+)

--- a/clients/typescript/test/cli/migrations/migrate.generation.test.ts
+++ b/clients/typescript/test/cli/migrations/migrate.generation.test.ts
@@ -1,4 +1,4 @@
-import test from 'ava'
+import test, { ExecutionContext } from 'ava'
 import fs from 'fs'
 import ts from 'typescript'
 import { generateClient } from '../../../src/cli/migrations/migrate'
@@ -167,6 +167,12 @@ test.before(() => {
   }
 })
 
+// This test runs the prisma generator under the hood, which can
+// cause issues when running concurrently, so we run them with serial
+const generatorTest = (testName: string, fn: (t: ExecutionContext<unknown>) => void) => {
+  return test.serial(testName, fn)
+}
+
 test.after.always(() => {
   // avoid deleting whole temp directory as it might be used by
   // other tests as well
@@ -178,7 +184,7 @@ test.after.always(() => {
   }
 })
 
-test.serial('should generate valid TS client for simple schema', async (t) => {
+generatorTest('should generate valid TS client for simple schema', async (t) => {
   const clientPath = await generateClientFromPrismaSchema(
     simpleSchema,
     'simple'
@@ -186,7 +192,7 @@ test.serial('should generate valid TS client for simple schema', async (t) => {
   t.true(checkGeneratedClientCompiles(clientPath))
 })
 
-test.serial(
+generatorTest(
   'should generate valid TS client for relational schema',
   async (t) => {
     const clientPath = await generateClientFromPrismaSchema(
@@ -197,7 +203,7 @@ test.serial(
   }
 )
 
-test.serial(
+generatorTest(
   'should generate valid TS client for schema with all data types',
   async (t) => {
     const clientPath = await generateClientFromPrismaSchema(


### PR DESCRIPTION
There have been some instances of the CI for the client tests failing in the new migrate.generation.test.ts file.
https://github.com/electric-sql/electric/actions/runs/8630646197
https://github.com/electric-sql/electric/actions/runs/8615651764

I believe this is because there are multiple prisma generates running at the same time, which can cause issues: 
https://github.com/prisma/prisma/issues/19124#issuecomment-1753187096

This is a simple attempt to fix it, and easy to revert if it's not entirely the root of the problem.

cc @msfstef 