### PR TITLE
fix(client): Don't notify of actual change if there are no changes

### DIFF
--- a/clients/typescript/src/notifiers/event.ts
+++ b/clients/typescript/src/notifiers/event.ts
@@ -123,6 +123,10 @@ export class EventNotifier implements Notifier {
     changes: Change[],
     origin: ChangeOrigin
   ): void {
+    if (!this._hasDbName(dbName) || !changes.length) {
+      return
+    }
+
     const tables = [
       ...new Set(
         changes.map((e) => {
@@ -132,9 +136,6 @@ export class EventNotifier implements Notifier {
     ]
 
     Log.info(`actually changed notifier. Changed tables: [${tables}]`)
-    if (!this._hasDbName(dbName)) {
-      return
-    }
 
     this._emitActualChange(dbName, changes, origin)
   }


### PR DESCRIPTION
Just a minor fix. There could be instances where `actuallyChanged` is called with an empty array.