### PR TITLE
chore(docs): Add a disclaimer to the "Local migrations" section in the docs

### DIFF
--- a/docs/api/ddlx.md
+++ b/docs/api/ddlx.md
@@ -476,6 +476,10 @@ ELECTRIC UNASSIGN 'record.reader'
 
 ## Local migrations
 
+:::caution Not implemented
+The syntax and the overall design of local migrations described below is not yet implemented. This sections describes a planned feature that we intend to implement at some point in the future.
+:::
+
 The `SQLITE` statement provides a mechanism to run DDL statements directly on the local SQLite database. 
 
 ### `SQLITE`


### PR DESCRIPTION
There is a lot of text between the top of the page and the "Local migrations" section. Someone landing on the page scolled down to the section will not see the disclaimer at the top. Moreover, support for local migrations is not even "work in progress" as it's currently only a planned feature.

I think this is sufficient argument to justify a separate disclaimer specifically for this section.

Prompted by a [discussion in Discord](https://discord.com/channels/933657521581858818/1208902100801560676/1226891278180941824).