### PR TITLE
feat(client): Log the origin of the notified changes

### DIFF
--- a/clients/typescript/src/notifiers/event.ts
+++ b/clients/typescript/src/notifiers/event.ts
@@ -135,7 +135,7 @@ export class EventNotifier implements Notifier {
       ),
     ]
 
-    Log.info(`actually changed notifier. Changed tables: [${tables}]`)
+    Log.info(`notifying client of database changes. Changed tables: [${tables}]. Origin: ${origin}`)
 
     this._emitActualChange(dbName, changes, origin)
   }

--- a/clients/typescript/src/notifiers/event.ts
+++ b/clients/typescript/src/notifiers/event.ts
@@ -135,7 +135,9 @@ export class EventNotifier implements Notifier {
       ),
     ]
 
-    Log.info(`notifying client of database changes. Changed tables: [${tables}]. Origin: ${origin}`)
+    Log.info(
+      `notifying client of database changes. Changed tables: [${tables}]. Origin: ${origin}`
+    )
 
     this._emitActualChange(dbName, changes, origin)
   }

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -1088,7 +1088,6 @@ export class SatelliteProcess implements Satellite {
     results: OplogEntry[],
     origin: ChangeOrigin
   ): Promise<void> {
-    Log.info('notify changes')
     const acc: ChangeAccumulator = {}
 
     // Would it be quicker to do this using a second SQL query that


### PR DESCRIPTION
I think it would be convenient to log the origin of the changes now that the changed tables are logged too.
In the process we can also remove the INFO `notify changes` log, which was superfluous because an `actuallyChanged` call is always executed after it.