### PR TITLE
chore(docs): Remove note about binding empty blobs

### DIFF
--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -64,6 +64,8 @@ ElectricSQL supports `bytea` data but not all SQLite drivers are capable of read
 | [wa-sqlite](../../integrations/drivers/web/wa-sqlite.md) | [better-sqlite3](../../integrations/drivers/server/node.md) | [expo-sqlite](../../integrations/drivers/mobile/expo.md?usage=expo-sqlite) | [expo-sqlite/next](../../integrations/drivers/mobile/expo.md?usage=expo-sqlite-next)| [op-sqlite](../../integrations/drivers/mobile/react-native.md) |
 |:---------:|:--------------:|:-----------:|:----------------:|:---------:|
 | ✅︎       | ✅︎             | ❌          | ✅︎              | ✅︎        |
+
+Note that reading/writing empty byte arrays might produce [different results depending on the driver](https://github.com/electric-sql/electric/pull/1156).
 :::
 
 :::caution Enum type caveats

--- a/docs/usage/data-modelling/types.md
+++ b/docs/usage/data-modelling/types.md
@@ -63,9 +63,7 @@ ElectricSQL supports `bytea` data but not all SQLite drivers are capable of read
 
 | [wa-sqlite](../../integrations/drivers/web/wa-sqlite.md) | [better-sqlite3](../../integrations/drivers/server/node.md) | [expo-sqlite](../../integrations/drivers/mobile/expo.md?usage=expo-sqlite) | [expo-sqlite/next](../../integrations/drivers/mobile/expo.md?usage=expo-sqlite-next)| [op-sqlite](../../integrations/drivers/mobile/react-native.md) |
 |:---------:|:--------------:|:-----------:|:----------------:|:---------:|
-| ✅︎†       | ✅︎             | ❌          | ✅︎†              | ✅︎        |
-
-† Does not support reading/writing empty byte arrays, e.g. `new Uint8Array([])`
+| ✅︎       | ✅︎             | ❌          | ✅︎              | ✅︎        |
 :::
 
 :::caution Enum type caveats


### PR DESCRIPTION
After going down a rabbit-hole in SQLite-land, my conclusion is that even though inserting empty blobs as string literals works seamlessly, the issue of not being able to bind "empty blobs" (0-length byte arrays) is an issue with the SQLite C API itself and is not wrapper-specific.

SQLite wrappers can implement a "work around" the `sqlite3_bind_blob` C API to enable empty blob binding but because the fundamental issue is with the underlying API there will always be inconsistency between wrappers when it comes to binding empty blobs.

Ultimately being able to differentiate between a `NULL` and a 0-length byte-array is an edge case, even though the two are semantically different and the SQLite C API can already do that for blob literals, and given that this is not a wrapper issue as much as it is a general SQLite issue I think it's unnecessary to draw attention to it in our docs.

Since we also transform values going in and out of SQLite through our TS client, we _could_ technically always convert empty byte arrays to `NULL` for consistency, but I think it's probably better to accept that this inconsistency is going to be present until (and if) the SQLite project does something about it.

You can follow along these discussions for more details:
PR I initially opened to "fix" `wa-sqlite`: https://github.com/rhashimoto/wa-sqlite/pull/167
Thread I started on the SQLite forums: https://sqlite.org/forum/forumpost/aac9343c98

@balegas what are your thoughts?

Also, after fixing this we see that only one driver we have does not support blobs (the expo-sqlite one), we might eventually want to deprecate that and recommend the `expo-sqlite/next` only but I suppose Expo will do that themselves at some point.