### PR TITLE
feat(client): Use `json_each` for batch insert of subscription data

### DIFF
--- a/.changeset/fair-ravens-chew.md
+++ b/.changeset/fair-ravens-chew.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Use `json_each` for bulk loading initial synced data

--- a/clients/typescript/src/util/statements.ts
+++ b/clients/typescript/src/util/statements.ts
@@ -24,9 +24,9 @@ export function prepareInsertJsonBatchedStatement(
   return {
     sql: dedent`
     ${insertCommand} INTO ${tablename} (${columns.join(', ')})
-    SELECT ${columns.map(
-      (cn) => `json_extract(json_each.value, '$.${cn}')`
-    ).join(', ')}
+    SELECT ${columns
+      .map((cn) => `json_extract(json_each.value, '$.${cn}')`)
+      .join(', ')}
     FROM json_each(?);`,
     args: [JSON.stringify(records)],
   }


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/616

I've benchmarked the difference for our `_applySubscriptionData` method as a whole, below you can see a small bar chart for results using better_sqlite3 in Node where the difference between the previous and new method is within +-2% of each other across all ranges (and that is inserting simple child and parent records).

![image](https://github.com/electric-sql/electric/assets/12274098/a6f133b8-9b01-43b9-b742-26db23260aeb)


I've also benchmarked it using wa-sqlite with our canonical items example, and at 50-100k items the initial sync with the new `json_each` approach was consistently ~10% faster. For small numbers of records the JSON serialization and deserialization might be a small overhead but with larger numbers of records I suspect we gain speed because there's fewer back and forths with sqlite.

Overall my main argument for opting for this method over the previous one is that it requires fewer magic numbers and `maxSqlParameters` configurations and is relatively easy to understand and relies more on SQLite than it does on client code.