### PR TITLE
feat(client): Allow choosing custom `wa-sqlite` VFS

### DIFF
--- a/.changeset/short-mugs-doubt.md
+++ b/.changeset/short-mugs-doubt.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Allow choosing a VFS for `wa-sqlite` driver integration


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/666 (issue of the beast 🤘)

Adds a secondary static initialiser to `ElectricDatabase` to provide custom VFS - we can skip documenting it or add a mention to it to the `wa-sqlite` driver docs, but it addresses the above issue.

We can add a note about not guaranteeing compatibility on that initialiser, but If we don't want to allow this at all then we should probably close the issue?