### PR TITLE
fix(cli): Fix CLI `PROXY` option to correctly infer DB name and not print introspection URL

### DIFF
--- a/.changeset/grumpy-ears-sort.md
+++ b/.changeset/grumpy-ears-sort.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix CLI `PROXY` option to correctly infer database name and not print introspection url.

--- a/.changeset/rich-peaches-cover.md
+++ b/.changeset/rich-peaches-cover.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix `ELECTRIC_` options not working as CLI arguments

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -143,7 +143,8 @@ export const configOptions: Record<string, any> = {
   DATABASE_NAME: {
     doc: 'Name of the database to connect to.',
     valueType: String,
-    inferVal: (options: ConfigMap) => inferDbUrlPart('dbName', options),
+    inferVal: (options: ConfigMap) =>
+      inferDbUrlPart('dbName', options, inferProxyUrlPart('dbName', options)),
     defaultVal: () => getAppName() ?? 'electric',
     groups: ['database', 'client', 'proxy'],
   },

--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -83,7 +83,10 @@ export function getConfigValue<K extends ConfigOptionName>(
 ): ConfigOptionValue<K> {
   // First check if the option was passed as a command line argument
   if (options) {
-    const optName = snakeToCamel(name.toLocaleLowerCase())
+    const strippedName = name.startsWith('ELECTRIC_')
+      ? name.slice('ELECTRIC_'.length)
+      : name
+    const optName = snakeToCamel(strippedName.toLocaleLowerCase())
     if (options[optName] !== undefined) {
       return options[optName] as ConfigOptionValue<K>
     } else if (options[name] !== undefined) {

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -88,7 +88,7 @@ export async function generate(options: GeneratorOptions) {
       }
     }
     console.log('Service URL: ' + opts.config.SERVICE)
-    console.log('Proxy URL: ' + stripPasswordFromUrl(opts.config['PROXY']))
+    console.log('Proxy URL: ' + stripPasswordFromUrl(opts.config.PROXY))
     // Generate the client
     if (opts.watch) {
       watchMigrations(opts)

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -88,9 +88,7 @@ export async function generate(options: GeneratorOptions) {
       }
     }
     console.log('Service URL: ' + opts.config.SERVICE)
-    console.log(
-      'Proxy URL: ' + stripPasswordFromUrl(buildProxyUrl(opts.config))
-    )
+    console.log('Proxy URL: ' + stripPasswordFromUrl(opts.config['PROXY']))
     // Generate the client
     if (opts.watch) {
       watchMigrations(opts)
@@ -348,16 +346,6 @@ function escapePathForString(inputPath: string): string {
   return process.platform === 'win32'
     ? inputPath.replace(/\\/g, '\\\\')
     : inputPath
-}
-
-function buildProxyUrl(config: Config) {
-  return buildDatabaseURL({
-    user: config.DATABASE_USER,
-    password: config.PG_PROXY_PASSWORD,
-    host: config.PG_PROXY_HOST,
-    port: parsePgProxyPort(config.PG_PROXY_PORT).port,
-    dbName: config.DATABASE_NAME,
-  })
 }
 
 function buildProxyUrlForIntrospection(config: Config) {

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -89,8 +89,7 @@ export async function generate(options: GeneratorOptions) {
     }
     console.log('Service URL: ' + opts.config.SERVICE)
     console.log(
-      'Proxy URL: ' +
-        stripPasswordFromUrl(buildProxyUrlForIntrospection(opts.config))
+      'Proxy URL: ' + stripPasswordFromUrl(buildProxyUrl(opts.config))
     )
     // Generate the client
     if (opts.watch) {
@@ -349,6 +348,16 @@ function escapePathForString(inputPath: string): string {
   return process.platform === 'win32'
     ? inputPath.replace(/\\/g, '\\\\')
     : inputPath
+}
+
+function buildProxyUrl(config: Config) {
+  return buildDatabaseURL({
+    user: config.DATABASE_USER,
+    password: config.PG_PROXY_PASSWORD,
+    host: config.PG_PROXY_HOST,
+    port: parsePgProxyPort(config.PG_PROXY_PORT).port,
+    dbName: config.DATABASE_NAME,
+  })
 }
 
 function buildProxyUrlForIntrospection(config: Config) {

--- a/clients/typescript/test/cli/config-options.test.ts
+++ b/clients/typescript/test/cli/config-options.test.ts
@@ -70,3 +70,30 @@ test('assert SSL is disabled by default', (t) => {
 test('assert authentication mode is insecure by default', (t) => {
   t.is(configOptions['AUTH_MODE'].defaultVal, 'insecure')
 })
+
+test('assert database name is correctly inferred', (t) => {
+  // infer from db url
+  t.is(
+    configOptions['DATABASE_NAME'].inferVal({
+      databaseUrl: 'postgres://db_user:db_password@db_host:123/db_name',
+    }),
+    'db_name'
+  )
+
+  // infer from proxy url if db url missing
+  t.is(
+    configOptions['DATABASE_NAME'].inferVal({
+      proxy: 'postgres://db_user:db_password@db_host:123/db_name',
+    }),
+    'db_name'
+  )
+
+  // prefer db over proxy for name
+  t.is(
+    configOptions['DATABASE_NAME'].inferVal({
+      databaseUrl: 'postgres://db_user:db_password@db_host:123/db_name',
+      proxy: 'postgres://db_user:db_password@db_host:123/proxy_db_name',
+    }),
+    'db_name'
+  )
+})

--- a/clients/typescript/test/cli/config.test.ts
+++ b/clients/typescript/test/cli/config.test.ts
@@ -1,0 +1,12 @@
+import test from 'ava'
+import { getConfigValue } from '../../src/cli/config'
+
+test('getConfigValue can capture `ELECTRIC_` prefixed CLI opitons', async (t) => {
+  const image = getConfigValue('ELECTRIC_IMAGE', { image: 'electric:test' })
+  const writeToPgMode = getConfigValue('ELECTRIC_WRITE_TO_PG_MODE', {
+    writeToPgMode: 'test',
+  })
+
+  t.is(image, 'electric:test')
+  t.is(writeToPgMode, 'test')
+})


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/911

As per the title, we fallback to the proxy URL to infer the database name if the database URL is not specified, and we print the proper proxy url as the proxy url rather than the Prisma introspection one to avoid confusing users.