### PR TITLE
feat(electric): Try decoding the JWT key using base64 only when the config option is set

### DIFF
--- a/components/electric/config/runtime.exs
+++ b/components/electric/config/runtime.exs
@@ -104,6 +104,8 @@ auth_mode = env!("AUTH_MODE", :string, default_auth_mode)
 auth_opts = [
   alg: {"AUTH_JWT_ALG", env!("AUTH_JWT_ALG", :string, nil)},
   key: {"AUTH_JWT_KEY", env!("AUTH_JWT_KEY", :string, nil)},
+  key_is_base64_encoded:
+    {"AUTH_JWT_KEY_IS_BASE64_ENCODED", env!("AUTH_JWT_KEY_IS_BASE64_ENCODED", :boolean, nil)},
   namespace: {"AUTH_JWT_NAMESPACE", env!("AUTH_JWT_NAMESPACE", :string, nil)},
   iss: {"AUTH_JWT_ISS", env!("AUTH_JWT_ISS", :string, nil)},
   aud: {"AUTH_JWT_AUD", env!("AUTH_JWT_AUD", :string, nil)}

--- a/components/electric/lib/electric/config.ex
+++ b/components/electric/lib/electric/config.ex
@@ -46,11 +46,13 @@ defmodule Electric.Config do
     end
   end
 
+  # Remove unset options and those set to an empty string.
   defp filter_auth_opts(auth_opts) do
-    for {key, {_, val}} <- auth_opts,
-        not is_binary(val) or (is_binary(val) and String.trim(val) != "") do
-      {key, val}
-    end
+    auth_opts
+    |> Enum.map(fn {key, {_, val}} -> {key, val} end)
+    |> Enum.reject(fn {_key, val} ->
+      is_nil(val) or (is_binary(val) and String.trim(val) == "")
+    end)
   end
 
   @spec parse_database_url(maybe_string, :dev | :test | :prod) ::

--- a/components/electric/lib/electric/config.ex
+++ b/components/electric/lib/electric/config.ex
@@ -47,7 +47,8 @@ defmodule Electric.Config do
   end
 
   defp filter_auth_opts(auth_opts) do
-    for {key, {_, val}} <- auth_opts, is_binary(val) and String.trim(val) != "" do
+    for {key, {_, val}} <- auth_opts,
+        not is_binary(val) or (is_binary(val) and String.trim(val) != "") do
       {key, val}
     end
   end

--- a/components/electric/lib/electric/satellite/auth/secure.ex
+++ b/components/electric/lib/electric/satellite/auth/secure.ex
@@ -41,6 +41,8 @@ defmodule Electric.Satellite.Auth.Secure do
 
          "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQY..."
 
+    * `key_is_base64_encoded: <boolean>` - optional flag that indicates whether the key should be base64-decoded.
+
     * `namespace: <string>` - optional namespace under which the "sub" or "user_id" claim will be looked up. If omitted,
       "sub" or "user_id" must be a top-level claim.
 

--- a/components/electric/test/electric/config_test.exs
+++ b/components/electric/test/electric/config_test.exs
@@ -53,6 +53,13 @@ defmodule Electric.ConfigTest do
 
       assert {{Electric.Satellite.Auth.Insecure, %{joken_config: %{}, namespace: "ns"}}, []} =
                validate_auth_config("insecure", namespace: {"AUTH_JWT_NAMESPACE", "ns"})
+
+      # Settings without values are ignored
+      assert {{Electric.Satellite.Auth.Insecure, %{joken_config: %{}, namespace: "ns"}}, []} =
+               validate_auth_config("insecure",
+                 namespace: {"AUTH_JWT_NAMESPACE", "ns"},
+                 key: {"AUTH_JWT_KEY", nil}
+               )
     end
 
     test "validates secure mode" do
@@ -83,6 +90,15 @@ defmodule Electric.ConfigTest do
                  namespace: {"AUTH_JWT_NAMESPACE", "ns"},
                  iss: {"AUTH_JWT_ISS", "foo"},
                  aud: {"AUTH_JWT_AUD", "bar"}
+               )
+    end
+
+    test "complains about invalid key encoding" do
+      assert {nil, [{"AUTH_JWT_KEY", {:error, "has invalid base64 encoding"}}]} ==
+               validate_auth_config("secure",
+                 alg: {"AUTH_JWT_ALG", "HS256"},
+                 key: {"AUTH_JWT_KEY", String.duplicate(".", 32)},
+                 key_is_base64_encoded: {"AUTH_JWT_KEY_IS_BASE64_ENCODED", true}
                )
     end
 

--- a/components/electric/test/electric/config_test.exs
+++ b/components/electric/test/electric/config_test.exs
@@ -62,6 +62,13 @@ defmodule Electric.ConfigTest do
                  key: {"AUTH_JWT_KEY", String.duplicate(".", 32)}
                )
 
+      assert {{Electric.Satellite.Auth.Secure, %{joken_config: %{}, namespace: nil}}, []} =
+               validate_auth_config("secure",
+                 alg: {"AUTH_JWT_ALG", "HS256"},
+                 key: {"AUTH_JWT_KEY", :crypto.strong_rand_bytes(32) |> Base.encode64()},
+                 key_is_base64_encoded: {"AUTH_JWT_KEY_IS_BASE64_ENCODED", true}
+               )
+
       assert {{Electric.Satellite.Auth.Secure,
                %{
                  joken_config: %{},
@@ -72,6 +79,7 @@ defmodule Electric.ConfigTest do
                validate_auth_config("secure",
                  alg: {"AUTH_JWT_ALG", "HS256"},
                  key: {"AUTH_JWT_KEY", String.duplicate(".", 32)},
+                 key_is_base64_encoded: {"AUTH_JWT_KEY_IS_BASE64_ENCODED", false},
                  namespace: {"AUTH_JWT_NAMESPACE", "ns"},
                  iss: {"AUTH_JWT_ISS", "foo"},
                  aud: {"AUTH_JWT_AUD", "bar"}


### PR DESCRIPTION
This reverts [the change](https://github.com/electric-sql/electric/commit/0deba4d79de61a31aa19515d055a2a977a8e1b4e#diff-20b7a1cb738afa77ff1e885426e33a8c92faa3cc84aa9f62fd2f67b217e6f020R102-R113) introduced in the 0.9.3 release where the configured signing key would get automatically decoded if it looked like a valid base64-encoded string. That change has caused unintended problems to arise for users of Supabase Auth since its secret keys are base64-encoded but are meant to be used as is.

This PR introduces a separate configuration option `AUTH_JWT_KEY_IS_BASE64_ENCODED`. Corresponding doc update - https://github.com/electric-sql/electric/pull/1169.