### PR TITLE
fix(electric): Override display settings for any new DB connections

### DIFF
--- a/.changeset/tender-garlics-fetch.md
+++ b/.changeset/tender-garlics-fetch.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fix data encoding issues caused by unexpected cluster-wide or database-specific configuration in Postgres. Electric now overrides certain settings it is sensitive to when opening a new connection to the database.

--- a/components/electric/lib/electric/postgres.ex
+++ b/components/electric/lib/electric/postgres.ex
@@ -97,4 +97,32 @@ defmodule Electric.Postgres do
   end
 
   def supported_types_only_in_functions, do: ~w|interval|a
+
+  @display_settings [
+    "SET bytea_output = 'hex'",
+    "SET DateStyle = 'ISO, DMY'",
+    "SET TimeZone = 'UTC'",
+    "SET extra_float_digits = 1"
+  ]
+
+  @doc """
+  Configuration settings that affect formatting of values of certain types.
+
+  These settings should be set for the current session before executing any queries or
+  statements to safe-guard against non-standard configuration being used in the Postgres
+  database cluster or even the specific database Electric is configured to connect to.
+
+  The settings Electric is sensitive to are:
+
+    * `bytea_output`       - determines how Postgres encodes bytea values. It can use either Hex- or
+                             Escape-based encoding.
+
+    * `DateStyle`          - determines how Postgres interprets date values.
+
+    * `TimeZone`           - affects the time zone offset Postgres uses for timestamptz and timetz values.
+
+    * `extra_float_digits` - determines whether floating-point values are rounded or are encoded precisely.
+  """
+  @spec display_settings :: [String.t()]
+  def display_settings, do: @display_settings
 end

--- a/components/electric/lib/electric/postgres/repo.ex
+++ b/components/electric/lib/electric/postgres/repo.ex
@@ -30,9 +30,21 @@ defmodule Electric.Postgres.Repo do
       database: conn_opts.database,
       ssl: conn_opts.ssl == :required,
       pool_size: Keyword.get(opts, :pool_size, @default_pool_size),
-      log: false
+      log: false,
+      after_connect: {__MODULE__, :set_display_settings, []}
     ]
   end
 
   def name(origin), do: :"#{inspect(__MODULE__)}:#{origin}"
+
+  # Explicitly set those configuration parameters that affect formatting of values of certain
+  # types.
+  #
+  # This function is automatically invoked for any new connection that gets added to the pool
+  # managed by this repo.
+  #
+  # See `Electric.Postgres.display_settings/0` for more info.
+  def set_display_settings(conn) do
+    :ok = Enum.each(Electric.Postgres.display_settings(), &Postgrex.query!(conn, &1, []))
+  end
 end

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -131,7 +131,6 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
          {:ok, _slot_name} <- Client.create_main_slot(repl_conn, main_slot),
          {:ok, _slot_name, main_slot_lsn} <-
            Client.create_temporary_slot(repl_conn, main_slot, tmp_slot),
-         :ok <- Client.set_display_settings_for_replication(repl_conn),
          {:ok, {short, long, cluster}} <- Client.get_server_versions(repl_conn),
          {:ok, table_count} <- SchemaLoader.count_electrified_tables({SchemaCache, origin}),
          {:ok, current_lsn} <- Client.current_lsn(repl_conn),

--- a/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
+++ b/components/electric/test/electric/replication/postgres/logical_replication_producer_test.exs
@@ -25,7 +25,6 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducerTest do
        create_temporary_slot: fn :conn, _main_name, tmp_name -> {:ok, tmp_name, %Lsn{}} end,
        current_lsn: fn :conn -> {:ok, %Lsn{}} end,
        advance_replication_slot: fn _, _, _ -> :ok end,
-       set_display_settings_for_replication: fn _ -> :ok end,
        get_server_versions: fn :conn -> {:ok, {"", "", ""}} end
      ]},
     {Connectors, [:passthrough],

--- a/components/electric/test/electric/satellite/subscriptions_test.exs
+++ b/components/electric/test/electric/satellite/subscriptions_test.exs
@@ -150,6 +150,7 @@ defmodule Electric.Satellite.SubscriptionsTest do
       end)
     end
 
+    @tag setup_fun: &__MODULE__.db_setup_for_display_settings_test/2
     @tag with_sql: """
          CREATE TABLE public.appointments (
            id TEXT PRIMARY KEY,
@@ -1348,5 +1349,20 @@ defmodule Electric.Satellite.SubscriptionsTest do
         refute_received {^conn, %SatOpLog{ops: [%{op: {:additional_begin, _}} | _]}}
       end)
     end
+  end
+
+  # Here we intentionally set display settings to unsupported values on the database, so that
+  # new connections inherit this settings by default. This will allow us to verify that the
+  # connections we open override any defaults with our own settings.
+  def db_setup_for_display_settings_test(conn, dbname) do
+    :epgsql.squery(
+      conn,
+      """
+      ALTER DATABASE #{dbname} SET bytea_output = 'escape';
+      ALTER DATABASE #{dbname} SET DateStyle = 'SQL, YMD';
+      ALTER DATABASE #{dbname} SET TimeZone = +3;
+      ALTER DATABASE #{dbname} SET extra_float_digits = -1;
+      """
+    )
   end
 end


### PR DESCRIPTION
We already set display settings for the logical replication connection that Electric opens to Postgres, in order to ensure deterministic date-time, bytea, and float formatting. However, we don't do that for ad-hoc or pooled connections which are opened when needed, such as during the initial shape sync and when fetching additional shape data. As a result, trying to serialize initial or additional data that contains timestamps or bytea values formatted using configuration Electric doesn't expect leads to errors.

In this PR, we ensure that the same display settings get set for all DB connections Electric opens.