### PR TITLE
fix(electric): Add :runtime_tools to enable the use of :observer running on a remote node

### DIFF
--- a/components/electric/mix.exs
+++ b/components/electric/mix.exs
@@ -32,7 +32,7 @@ defmodule Electric.MixProject do
   def application do
     [
       mod: {Electric.Application, []},
-      extra_applications: [:logger, :os_mon]
+      extra_applications: [:logger, :os_mon, :runtime_tools]
     ]
   end
 


### PR DESCRIPTION
This dependency is required for Observer to work at all. We're not including :wx as a dependency here because it's caused us problems in the past and it's not needed when connecting to a running Electric node from another Elixir shell. That other shell should itself have all of the dependencies needed to run Observer installed.

This is a new attempt to make Electric observer-enabled. The first (failed) attempt was https://github.com/electric-sql/electric/pull/467.