### PR TITLE
fix(client): Don't leave a snapshot running when stopping the Satellite process

### DIFF
--- a/.changeset/chilly-masks-prove.md
+++ b/.changeset/chilly-masks-prove.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Don't leave a snapshot running when stopping the Satellite process

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -40,6 +40,7 @@ import {
   relations,
   cleanAndStopSatellite,
   ContextType,
+  clean,
 } from './common'
 import {
   DEFAULT_LOG_POS,
@@ -2225,5 +2226,39 @@ test('(regression) performSnapshot handles exceptions gracefully', async (t) => 
   }
 
   await satellite._performSnapshot()
+  t.pass()
+})
+
+test('don\'t leave a snapshot running when stopping', async (t) => {
+  const { adapter, runMigrations, satellite, authState } = t.context
+  await runMigrations()
+  await satellite._setAuthState(authState)
+
+  // Make the adapter slower, to interleave stopping the process and closing the db with a snapshot
+  const transaction = satellite.adapter.transaction.bind(satellite.adapter)
+  satellite.adapter.transaction = (f) =>
+    new Promise((res) => {
+      setTimeout(() => transaction(f).then(res), 500)
+    })
+
+  // Add something to the oplog
+  await adapter.run({
+    sql: `INSERT INTO parent(id, value) VALUES (1,'val1')`,
+  })
+
+  // // Perform snapshot with the mutex, to emulate a real scenario
+  const snapshotPromise = satellite._mutexSnapshot()
+  // Give some time to start the "slow" snapshot
+  await sleepAsync(100)
+  
+  // Stop the process while the snapshot is being performed
+  await satellite.stop()
+  
+  // Remove/close the database connection
+  await clean(t)
+  
+  // Wait for the snapshot to finish to consider the test successful
+  await snapshotPromise
+
   t.pass()
 })

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -2229,7 +2229,7 @@ test('(regression) performSnapshot handles exceptions gracefully', async (t) => 
   t.pass()
 })
 
-test('don\'t leave a snapshot running when stopping', async (t) => {
+test("don't leave a snapshot running when stopping", async (t) => {
   const { adapter, runMigrations, satellite, authState } = t.context
   await runMigrations()
   await satellite._setAuthState(authState)
@@ -2250,13 +2250,13 @@ test('don\'t leave a snapshot running when stopping', async (t) => {
   const snapshotPromise = satellite._mutexSnapshot()
   // Give some time to start the "slow" snapshot
   await sleepAsync(100)
-  
+
   // Stop the process while the snapshot is being performed
   await satellite.stop()
-  
+
   // Remove/close the database connection
   await clean(t)
-  
+
   // Wait for the snapshot to finish to consider the test successful
   await snapshotPromise
 


### PR DESCRIPTION
This race condition was discovered on https://github.com/SkillDevs/electric_dart/issues/21
A unit test is running, and it can happen that electric and the database connection are closed, while a `performSnapshot` call is scheduled/already running. An error is thrown when the snapshot tries to operate with the closed database.

The easy fix would be to "wait" for the snapshot mutix after cancelling the throttle, to ensure that it has ended to gracefully stop.

Another thing discovered is that `stop` was not returning a Promise, just calling `_stop` under the hood.