### PR TITLE
fix (client): don't delay initial snapshot to next tick

### DIFF
--- a/.changeset/spicy-shirts-smoke.md
+++ b/.changeset/spicy-shirts-smoke.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Ensure no snapshot is taken after closing the Satellite process.

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -260,7 +260,7 @@ export class SatelliteProcess implements Satellite {
     )
 
     // Starting now!
-    setTimeout(this._throttledSnapshot, 0)
+    await this._throttledSnapshot()
 
     // Need to reload primary keys after schema migration
     this.relations = await this._getLocalRelations()

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -2262,3 +2262,27 @@ test("don't leave a snapshot running when stopping", async (t) => {
 
   t.pass()
 })
+
+test("don't snapshot after closing satellite process", async (t) => {
+  // open and then immediately close
+  // check that no snapshot is called after close
+  const { satellite, authState, token } = t.context
+  const { connectionPromise } = await startSatellite(
+    satellite,
+    authState,
+    token
+  )
+
+  await connectionPromise
+  await satellite.stop()
+
+  satellite._performSnapshot = () => {
+    t.fail('Snapshot was called')
+    return Promise.resolve(new Date())
+  }
+
+  // wait some time to see that mutexSnapshot is not called
+  await sleepAsync(50)
+
+  t.pass()
+})


### PR DESCRIPTION
This PR modifies the Satellite process' `start` method in order not to delay the initial snapshot to the next tick because that could cause the snapshot to be ran after the process was closed, e.g. if someone starts the process and immediately closes it. I also added a corresponding unit test for this.