### PR TITLE
chore (client): add Zod and Prisma as (optional) peer dependencies

### DIFF
--- a/.changeset/four-onions-boil.md
+++ b/.changeset/four-onions-boil.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Add Zod and Prisma to (optional) peer dependencies.

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -258,12 +258,14 @@
     "@op-engineering/op-sqlite": ">= 2.0.16",
     "@tauri-apps/plugin-sql": "2.0.0-alpha.5",
     "expo-sqlite": ">= 13.0.0",
+    "prisma": "^4.0.0",
     "react": ">= 16.8.0",
     "react-dom": ">= 16.8.0",
     "react-native": ">= 0.68.0",
     "typeorm": ">=0.3.0",
     "vue": ">=3.0.0",
-    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8"
+    "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8",
+    "zod": "3.21.1"
   },
   "peerDependenciesMeta": {
     "@op-engineering/op-sqlite": {
@@ -276,6 +278,9 @@
       "optional": true
     },
     "expo-sqlite": {
+      "optional": true
+    },
+    "prisma": {
       "optional": true
     },
     "react": {

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -258,7 +258,7 @@
     "@op-engineering/op-sqlite": ">= 2.0.16",
     "@tauri-apps/plugin-sql": "2.0.0-alpha.5",
     "expo-sqlite": ">= 13.0.0",
-    "prisma": "^4.0.0",
+    "prisma": "4.8.1",
     "react": ">= 16.8.0",
     "react-dom": ">= 16.8.0",
     "react-native": ">= 0.68.0",


### PR DESCRIPTION
Every Electric app needs Zod in order to use the generated client. However, in recent versions of Zod something changed that breaks the types in the generated client (cf. https://github.com/electric-sql/electric/pull/700). Therefore, Electric apps should always use Zod version 3.21.1. Added this as a peer dependency such that npm complains if the app installs a different version. Similarly, added an optional peer dependency for Prisma v4 such that it complains if the app installs another version of Prisma.