### PR TITLE
chore(electric): Load and clear client reconnection info per client

### DIFF
--- a/components/electric/lib/electric/replication/postgres/client.ex
+++ b/components/electric/lib/electric/replication/postgres/client.ex
@@ -20,7 +20,7 @@ defmodule Electric.Replication.Postgres.Client do
   @spec connect(Connectors.connection_opts()) ::
           {:ok, connection :: pid()} | {:error, reason :: :epgsql.connect_error()}
   def connect(conn_opts) do
-    Logger.debug("#{inspect(__MODULE__)}.connect(#{inspect(sanitize_conn_opts(conn_opts))})")
+    Logger.debug("Postgres.Client.connect(#{inspect(sanitize_conn_opts(conn_opts))})")
 
     {%{ip_addr: ip_addr}, %{username: username, password: password} = epgsql_conn_opts} =
       Connectors.pop_extraneous_conn_opts(conn_opts)
@@ -42,7 +42,7 @@ defmodule Electric.Replication.Postgres.Client do
       end
     end
 
-    Logger.info("#{inspect(__MODULE__)}.with_conn(#{inspect(sanitize_conn_opts(conn_opts))})")
+    Logger.info("Postgres.Client.with_conn(#{inspect(sanitize_conn_opts(conn_opts))})")
 
     {:ok, conn} = :epgsql_sock.start_link()
 
@@ -149,7 +149,7 @@ defmodule Electric.Replication.Postgres.Client do
   end
 
   defp squery(conn, query) do
-    Logger.debug("#{__MODULE__}: #{query}")
+    Logger.debug("Postgres.Client: #{query}")
     :epgsql.squery(conn, query)
   end
 

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -187,12 +187,6 @@ defmodule Electric.Satellite.WebsocketServer do
     end
   end
 
-  def handle_info(:load_client_reconnection_info, state) do
-    :ok = ClientReconnectionInfo.restore_cache_for_client(state.origin, state.client_id)
-    Logger.debug("Successfully loaded client reconnection info")
-    {:ok, state}
-  end
-
   def handle_info({:jwt_expired, ref}, %{expiration_timer: {_timer, ref}} = state) do
     Logger.warning("JWT token expired, disconnecting")
     {:stop, :normal, {4000, "JWT-expired"}, state}

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -197,7 +197,7 @@ defmodule Electric.Satellite.WebsocketServer do
       "Received JWT expiration message #{inspect(ref)} for an already cancelled timer"
     )
 
-    {:noreply, state}
+    {:ok, state}
   end
 
   # While processing the SatInStartReplicationReq message, Protocol has determined that a new

--- a/components/electric/lib/electric/satellite/ws_server.ex
+++ b/components/electric/lib/electric/satellite/ws_server.ex
@@ -187,6 +187,12 @@ defmodule Electric.Satellite.WebsocketServer do
     end
   end
 
+  def handle_info(:load_client_reconnection_info, state) do
+    :ok = ClientReconnectionInfo.restore_cache_for_client(state.origin, state.client_id)
+    Logger.debug("Successfully loaded client reconnection info")
+    {:ok, state}
+  end
+
   def handle_info({:jwt_expired, ref}, %{expiration_timer: {_timer, ref}} = state) do
     Logger.warning("JWT token expired, disconnecting")
     {:stop, :normal, {4000, "JWT-expired"}, state}

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -41,6 +41,17 @@ defmodule Electric.Satellite.WebsocketServerTest do
 
   import Mock
 
+  setup_with_mocks([
+    {Electric.Postgres.Repo, [:passthrough],
+     checkout: fn fun -> fun.() end,
+     transaction: fn fun -> fun.() end,
+     checked_out?: fn -> true end,
+     query: fn _, _ -> {:ok, %Postgrex.Result{columns: nil, rows: []}} end,
+     query!: fn _, _ -> %Postgrex.Result{columns: nil, rows: []} end}
+  ]) do
+    %{}
+  end
+
   setup ctx do
     ctx =
       ctx
@@ -71,12 +82,6 @@ defmodule Electric.Satellite.WebsocketServerTest do
   end
 
   setup_with_mocks([
-    {Electric.Postgres.Repo, [:passthrough],
-     checkout: fn fun -> fun.() end,
-     transaction: fn fun -> fun.() end,
-     checked_out?: fn -> true end,
-     query: fn _, _ -> {:ok, %Postgrex.Result{columns: nil, rows: []}} end,
-     query!: fn _, _ -> %Postgrex.Result{columns: nil, rows: []} end},
     {Electric.Satellite.ClientReconnectionInfo, [:passthrough],
      restore_cache_for_client: fn _, _ -> :ok end},
     {SatelliteConnector, [:passthrough],

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -41,17 +41,6 @@ defmodule Electric.Satellite.WebsocketServerTest do
 
   import Mock
 
-  setup_with_mocks([
-    {Electric.Postgres.Repo, [:passthrough],
-     checkout: fn fun -> fun.() end,
-     transaction: fn fun -> fun.() end,
-     checked_out?: fn -> true end,
-     query: fn _, _ -> {:ok, %Postgrex.Result{columns: nil, rows: []}} end,
-     query!: fn _, _ -> %Postgrex.Result{columns: nil, rows: []} end}
-  ]) do
-    %{}
-  end
-
   setup ctx do
     ctx =
       ctx
@@ -82,6 +71,12 @@ defmodule Electric.Satellite.WebsocketServerTest do
   end
 
   setup_with_mocks([
+    {Electric.Postgres.Repo, [:passthrough],
+     checkout: fn fun -> fun.() end,
+     transaction: fn fun -> fun.() end,
+     checked_out?: fn -> true end,
+     query: fn _, _ -> {:ok, %Postgrex.Result{columns: nil, rows: []}} end,
+     query!: fn _, _ -> %Postgrex.Result{columns: nil, rows: []} end},
     {Electric.Satellite.ClientReconnectionInfo, [:passthrough],
      restore_cache_for_client: fn _, _ -> :ok end},
     {SatelliteConnector, [:passthrough],

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -46,9 +46,8 @@ defmodule Electric.Satellite.WebsocketServerTest do
      checkout: fn fun -> fun.() end,
      transaction: fn fun -> fun.() end,
      checked_out?: fn -> true end,
-     query!: fn _, _ ->
-       %Postgrex.Result{columns: nil, rows: []}
-     end}
+     query: fn _, _ -> {:ok, %Postgrex.Result{columns: nil, rows: []}} end,
+     query!: fn _, _ -> %Postgrex.Result{columns: nil, rows: []} end}
   ]) do
     %{}
   end
@@ -83,6 +82,8 @@ defmodule Electric.Satellite.WebsocketServerTest do
   end
 
   setup_with_mocks([
+    {Electric.Satellite.ClientReconnectionInfo, [:passthrough],
+     restore_cache_for_client: fn _, _ -> :ok end},
     {SatelliteConnector, [:passthrough],
      [
        start_link: fn %{name: name, producer: producer} ->

--- a/e2e/tests/03.26_node_satellite_can_resume_replication_after_server_restart.lux
+++ b/e2e/tests/03.26_node_satellite_can_resume_replication_after_server_restart.lux
@@ -198,10 +198,8 @@
 
     ??Restored 2 cached client_checkpoints
     ??Restored 2 cached client_shape_subscriptions
-    ?+Restored 1 cached client_additional_data records
-    ?+Restored 1 cached client_actions
-    ?+client_id=$client_1_id .+ Successfully loaded client reconnection info
-    ?client_id=$client_2_id .+ Successfully loaded client reconnection info
+    ??Restored 1 cached client_additional_data records
+    ??Restored 1 cached client_actions
 
 [shell satellite_1]
     ??Connectivity state changed: connected
@@ -210,9 +208,8 @@
     ??Connectivity state changed: connected
 
 [shell electric]
-    # ?+ matches the two lines in any order
-    ?+Continuing sync for client $client_1_id from
-    ?Continuing sync for client $client_2_id from
+    ?client_id=$client_2_id .+ Successfully loaded client reconnection info
+    ??Continuing sync for client $client_2_id from
 
 [shell pg_1]
     !SELECT * FROM electric.client_actions;

--- a/e2e/tests/03.26_node_satellite_can_resume_replication_after_server_restart.lux
+++ b/e2e/tests/03.26_node_satellite_can_resume_replication_after_server_restart.lux
@@ -148,11 +148,6 @@
 [shell electric]
     [invoke start_electric 1]
 
-    ??Cached 2 client_checkpoints from the DB
-    ??Cached 2 client_shape_subscriptions from the DB
-    ??Cached 0 client_additional_data records from the DB
-    ??Cached 0 client_actions from the DB
-
 [shell satellite_1]
     ??Connectivity state changed: connected
 
@@ -160,6 +155,13 @@
     [invoke node_await_get_from_table "other_items" "fifth"]
     [invoke node_await_get_from_table "other_items" "sixth"]
     [invoke node_await_get_from_table "other_items" "seventh"]
+
+[shell electric]
+    ??Restored 1 cached client_checkpoints
+    ??Restored 1 cached client_shape_subscriptions
+    ??Restored 0 cached client_additional_data records
+    ??Restored 0 cached client_actions
+    ?client_id=$client_1_id .+ Successfully loaded client reconnection info
 
 [shell satellite_2]
     [invoke client_reconnect]
@@ -171,6 +173,13 @@
     [invoke node_await_get "items-b-"]
     [invoke node_await_get_from_table "other_items" "first"]
     [invoke node_await_get_from_table "other_items" "third"]
+
+[shell electric]
+    ??Restored 1 cached client_checkpoints
+    ??Restored 1 cached client_shape_subscriptions
+    ??Restored 0 cached client_additional_data records
+    ??Restored 0 cached client_actions
+    ?client_id=$client_2_id .+ Successfully loaded client reconnection info
 
 # Stop the server and verify that it persists client_actions and client_additional_data.
 [shell log]
@@ -191,10 +200,10 @@
 
     [invoke start_electric 1]
 
-    ??Cached 2 client_checkpoints from the DB
-    ??Cached 2 client_shape_subscriptions from the DB
-    ??Cached 1 client_additional_data records from the DB
-    ??Cached 1 client_actions from the DB
+    ?+Restored 1 cached client_additional_data records
+    ?+Restored 1 cached client_actions
+    ?+client_id=$client_1_id .+ Successfully loaded client reconnection info
+    ?client_id=$client_2_id .+ Successfully loaded client reconnection info
 
 [shell satellite_1]
     ??Connectivity state changed: connected

--- a/e2e/tests/03.26_node_satellite_can_resume_replication_after_server_restart.lux
+++ b/e2e/tests/03.26_node_satellite_can_resume_replication_after_server_restart.lux
@@ -157,8 +157,8 @@
     [invoke node_await_get_from_table "other_items" "seventh"]
 
 [shell electric]
-    ??Restored 1 cached client_checkpoints
-    ??Restored 1 cached client_shape_subscriptions
+    ??Restored 2 cached client_checkpoints
+    ??Restored 2 cached client_shape_subscriptions
     ??Restored 0 cached client_additional_data records
     ??Restored 0 cached client_actions
     ?client_id=$client_1_id .+ Successfully loaded client reconnection info
@@ -175,10 +175,6 @@
     [invoke node_await_get_from_table "other_items" "third"]
 
 [shell electric]
-    ??Restored 1 cached client_checkpoints
-    ??Restored 1 cached client_shape_subscriptions
-    ??Restored 0 cached client_additional_data records
-    ??Restored 0 cached client_actions
     ?client_id=$client_2_id .+ Successfully loaded client reconnection info
 
 # Stop the server and verify that it persists client_actions and client_additional_data.
@@ -200,6 +196,8 @@
 
     [invoke start_electric 1]
 
+    ??Restored 2 cached client_checkpoints
+    ??Restored 2 cached client_shape_subscriptions
     ?+Restored 1 cached client_additional_data records
     ?+Restored 1 cached client_actions
     ?+client_id=$client_1_id .+ Successfully loaded client reconnection info


### PR DESCRIPTION
This is a follow-up to https://github.com/electric-sql/electric/pull/1116, specifically addressing [Ilia's request](https://github.com/electric-sql/electric/pull/1116#discussion_r1568646066).

Client reconnection info is now reloaded from the database at client connection time. This way we can ensure consistency between the data cached in ETS and data stored in the database.