### PR TITLE
Fix docker instructions in auth docs

### DIFF
--- a/docs/usage/auth/insecure.md
+++ b/docs/usage/auth/insecure.md
@@ -16,7 +16,7 @@ Insecure mode is convenient to use in development and testing. However, you must
 When starting the Electric server, make the `AUTH_MODE` environment variable with the value `insecure` available to it. For example,
 
 ```shell
-$ docker run -e AUTH_MODE=insecure electric-sql/electric
+$ docker run -e AUTH_MODE=insecure electricsql/electric
 ```
 
 Now, all you need to authenticate your client is a JWT with a `sub` claim (formerly `user_id`). You can use https://token.dev/ to craft a token with static claims and then copy-paste it into your client app. Alternatively, you can use something like the following function to generate JWTs at run time:

--- a/docs/usage/auth/secure.md
+++ b/docs/usage/auth/secure.md
@@ -17,7 +17,7 @@ When starting the Electric server, specify which signature verification algorith
 $ docker run \
     -e AUTH_JWT_ALG=ES256 \
     -e AUTH_JWT_KEY="$(cat public_key.pem)" \
-    electric-sql/electric
+    electricsql/electric
 ```
 
 Now, all you need to authenticate your client is a JWT that includes a `sub` claim (formerly `user_id`) and is signed using the same `ES256` algorithm and the matching private key.


### PR DESCRIPTION
The instructions in the docs under auth for running in docker incorrectly use the image name `electric-sql/electric` rather than the actual image name `electricsql/electric`. This PR fixes this.