### PR TITLE
fix(examples): Fix React projects not providing correct client to app

### DIFF
--- a/.changeset/silent-plants-call.md
+++ b/.changeset/silent-plants-call.md
@@ -1,0 +1,5 @@
+---
+"create-electric-app": patch
+---
+
+Update templates to fix incorrect client providers in React projects

--- a/docs/integrations/frontend/react.md
+++ b/docs/integrations/frontend/react.md
@@ -46,25 +46,21 @@ export const ElectricWrapper = ({ children }) => {
   const [ electric, setElectric ] = useState<Electric>()
 
   useEffect(() => {
-    let isMounted = true
+    let client: Electric
 
     const init = async () => {
       const conn = await ElectricDatabase.init('electric.db')
-      const electric = await electrify(conn, schema)
+      client = await electrify(conn, schema)
       const token = insecureAuthToken({sub: 'dummy'})
-      await electric.connect(token)
+      await client.connect(token)
 
-      if (!isMounted) {
-        return
-      }
-
-      setElectric(electric)
+      setElectric(client)
     }
 
     init()
 
     return () => {
-      isMounted = false
+      client?.close()
     }
   }, [])
 

--- a/examples/expo/src/ElectricProvider.tsx
+++ b/examples/expo/src/ElectricProvider.tsx
@@ -18,8 +18,7 @@ const ElectricProviderComponent = ({
   const [electric, setElectric] = useState<Electric>()
 
   useEffect(() => {
-    let isMounted = true
-
+    let client: Electric
     const init = async () => {
       const config = {
         debug: DEBUG_MODE,
@@ -27,12 +26,8 @@ const ElectricProviderComponent = ({
       }
 
       const conn = SQLite.openDatabaseSync('electric.db')
-      const client = await electrify(conn, schema, config)
+      client = await electrify(conn, schema, config)
       await client.connect(authToken())
-
-      if (!isMounted) {
-        return
-      }
 
       setElectric(client)
     }
@@ -40,7 +35,7 @@ const ElectricProviderComponent = ({
     init()
 
     return () => {
-      isMounted = false
+      client?.close()
     }
   }, [])
 

--- a/examples/introduction/src/components/ElectricProvider.tsx
+++ b/examples/introduction/src/components/ElectricProvider.tsx
@@ -15,22 +15,18 @@ const ElectricProvider = ({ children, dbName }: Props) => {
   const [electric, setElectric] = useState<Electric>()
 
   useEffect(() => {
-    let isMounted = true
+    let client: Electric
 
     const init = async () => {
-      const electric = await initElectric(dbName)
+      client = await initElectric(dbName)
 
-      if (!isMounted) {
-        return
-      }
-
-      setElectric(electric)
+      setElectric(client)
     }
 
     init()
 
     return () => {
-      isMounted = false
+      client?.close()
     }
   }, [])
 

--- a/examples/react-native/src/ElectricProvider.tsx
+++ b/examples/react-native/src/ElectricProvider.tsx
@@ -14,7 +14,7 @@ const ElectricProviderComponent = ({children}: {children: React.ReactNode}) => {
   const [electric, setElectric] = useState<Electric>();
 
   useEffect(() => {
-    let isMounted = true;
+    let client: Electric;
 
     const init = async () => {
       const config = {
@@ -24,12 +24,8 @@ const ElectricProviderComponent = ({children}: {children: React.ReactNode}) => {
 
       const dbName = 'electric.db';
       const conn = openSQLiteConnection({name: dbName});
-      const client = await electrify(conn, dbName, schema, config);
+      client = await electrify(conn, dbName, schema, config);
       await client.connect(authToken());
-
-      if (!isMounted) {
-        return;
-      }
 
       setElectric(client);
     };
@@ -37,7 +33,7 @@ const ElectricProviderComponent = ({children}: {children: React.ReactNode}) => {
     init();
 
     return () => {
-      isMounted = false;
+      client?.close();
     };
   }, []);
 

--- a/examples/tauri-sqlite/package-lock.json
+++ b/examples/tauri-sqlite/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@tauri-apps/api": "2.0.0-alpha.14",
         "@tauri-apps/plugin-sql": "^2.0.0-alpha.5",
-        "electric-sql": "file:../../clients/typescript/electric-sql-0.9.2.tgz",
+        "electric-sql": "^0.10.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -701,14 +701,14 @@
       "dev": true
     },
     "node_modules/@electric-sql/prisma-generator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@electric-sql/prisma-generator/-/prisma-generator-1.1.3.tgz",
-      "integrity": "sha512-Tvtdw7Vm3Ggdp35bCWmaYEyGmWeoLxU+g3mdbGNP4PzCq/eqMyO6OCTyZF7bdT+KqO2hEQT+jljsPRA+uUTgrQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@electric-sql/prisma-generator/-/prisma-generator-1.1.4.tgz",
+      "integrity": "sha512-zZQ88uBEKIhf6lKmnzWjOs65V5uVj/i2/N9aU4jpbJIf63n9LUgUh6abv7weFkvJsGddY/6I0bgE4a400FAkxA==",
       "dependencies": {
         "@prisma/generator-helper": "^4.11.0",
         "code-block-writer": "^11.0.3",
         "lodash": "^4.17.21",
-        "zod": "^3.21.1"
+        "zod": "3.21.1"
       },
       "bin": {
         "electric-sql-prisma-generator": "dist/bin.js"
@@ -1468,26 +1468,6 @@
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
       "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
     },
-    "node_modules/@prisma/fetch-engine": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.9.0.tgz",
-      "integrity": "sha512-NL8Vm8Vl2d6NOSkkPGN5TTTz4s6cyCleXOzqtOFWzfKFJ4wtN2Shu7llOT+ykf6nDzh1lCN2JHUt1S6FGFZGig==",
-      "dependencies": {
-        "@prisma/debug": "5.9.0",
-        "@prisma/engines-version": "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64",
-        "@prisma/get-platform": "5.9.0"
-      }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.9.0.tgz",
-      "integrity": "sha512-3Uhj5YSPqaIfzJQ6JQzCNBXeBTy0x803fGIoo2tvP/KIEd+o4o49JxCQtKtP8aeef5iNh5Nn9Z25wDrdLjS80A=="
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/@prisma/engines-version": {
-      "version": "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64.tgz",
-      "integrity": "sha512-HFl7275yF0FWbdcNvcSRbbu9JCBSLMcurYwvWc8WGDnpu7APxQo2ONtZrUggU3WxLxUJ2uBX+0GOFIcJeVeOOQ=="
-    },
     "node_modules/@prisma/generator-helper": {
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.16.2.tgz",
@@ -1498,19 +1478,6 @@
         "cross-spawn": "7.0.3",
         "kleur": "4.1.5"
       }
-    },
-    "node_modules/@prisma/get-platform": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.9.0.tgz",
-      "integrity": "sha512-8CatX+E6eZxcOjJZe5hF8EXxdb5GsQTA/u7pdmUJSxGLacW9K3r5vDdgV8s22PubObQQ6979/rkCMItbCrG4Yg==",
-      "dependencies": {
-        "@prisma/debug": "5.9.0"
-      }
-    },
-    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.9.0.tgz",
-      "integrity": "sha512-3Uhj5YSPqaIfzJQ6JQzCNBXeBTy0x803fGIoo2tvP/KIEd+o4o49JxCQtKtP8aeef5iNh5Nn9Z25wDrdLjS80A=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -2920,12 +2887,11 @@
       "dev": true
     },
     "node_modules/electric-sql": {
-      "version": "0.9.2",
-      "resolved": "file:../../clients/typescript/electric-sql-0.9.2.tgz",
-      "integrity": "sha512-qVkde1iCtlYJj9VOlK2cBe+B+4na67JWeLOTnbgX+nlwwa9ca94/65weZsu414reD38QFQW7kdb9aGZEp1Fp4w==",
-      "license": "Apache-2.0",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/electric-sql/-/electric-sql-0.10.1.tgz",
+      "integrity": "sha512-k/Ctsw7fXV75nao5E5e77Kg0RkLbYN5YgMSNQRGPYdWp5VWX6RnhwQrMm12qhteMFTDNjeVXJD3L/ArHFyWBVw==",
       "dependencies": {
-        "@electric-sql/prisma-generator": "1.1.3",
+        "@electric-sql/prisma-generator": "1.1.4",
         "@prisma/client": "4.8.1",
         "async-mutex": "^0.4.0",
         "base-64": "^1.0.0",
@@ -2936,7 +2902,6 @@
         "dotenv-flow": "^4.1.0",
         "events": "^3.3.0",
         "exponential-backoff": "^3.1.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
         "frame-stream": "^3.0.1",
         "get-port": "^7.0.0",
         "jose": "^4.14.4",
@@ -2948,34 +2913,32 @@
         "lodash.partition": "^4.6.0",
         "lodash.pick": "^4.4.0",
         "lodash.throttle": "^4.1.1",
+        "lodash.uniqwith": "^4.5.0",
         "loglevel": "^1.8.1",
         "long": "^5.2.0",
         "object.hasown": "^1.1.2",
         "ohash": "^1.1.2",
         "prisma": "4.8.1",
-        "prisma-v5": "npm:prisma@5.9.0",
         "prompts": "^2.4.2",
         "protobufjs": "^7.1.1",
-        "react-native-uuid": "^2.0.1",
         "squel": "^5.13.0",
         "tcp-port-used": "^1.0.2",
+        "text-encoder-lite": "^2.0.0",
         "ts-dedent": "^2.2.0",
-        "uuid": "^9.0.0",
         "ws": "^8.8.1",
-        "zod": "^3.20.2"
+        "zod": "3.21.1"
       },
       "bin": {
         "electric-sql": "dist/cli/main.js"
       },
       "peerDependencies": {
-        "@capacitor-community/sqlite": ">= 5.4.1",
+        "@capacitor-community/sqlite": ">= 5.6.2",
+        "@op-engineering/op-sqlite": ">= 2.0.16",
         "@tauri-apps/plugin-sql": "2.0.0-alpha.5",
-        "cordova-sqlite-storage": ">= 5.0.0",
         "expo-sqlite": ">= 13.0.0",
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0",
         "react-native": ">= 0.68.0",
-        "react-native-sqlite-storage": ">= 6.0.0",
         "typeorm": ">=0.3.0",
         "vue": ">=3.0.0",
         "wa-sqlite": "rhashimoto/wa-sqlite#semver:^0.9.8"
@@ -2984,7 +2947,7 @@
         "@capacitor-community/sqlite": {
           "optional": true
         },
-        "cordova-sqlite-storage": {
+        "@op-engineering/op-sqlite": {
           "optional": true
         },
         "expo-sqlite": {
@@ -2994,9 +2957,6 @@
           "optional": true
         },
         "react-native": {
-          "optional": true
-        },
-        "react-native-sqlite-storage": {
           "optional": true
         },
         "typeorm": {
@@ -3490,11 +3450,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "node_modules/fastq": {
       "version": "1.16.0",
@@ -4674,6 +4629,11 @@
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
+    "node_modules/lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -5493,44 +5453,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/prisma-v5": {
-      "name": "prisma",
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.9.0.tgz",
-      "integrity": "sha512-0UcOofjNuAnd227JMaPqZvP01dsUXw9EXB9iC8fyoZtfv7zkQ0ozxyjY1g+vcjFPOnNLICMnLHx+lM5BJZYqOQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@prisma/engines": "5.9.0"
-      },
-      "bin": {
-        "prisma": "build/index.js"
-      },
-      "engines": {
-        "node": ">=16.13"
-      }
-    },
-    "node_modules/prisma-v5/node_modules/@prisma/debug": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.9.0.tgz",
-      "integrity": "sha512-3Uhj5YSPqaIfzJQ6JQzCNBXeBTy0x803fGIoo2tvP/KIEd+o4o49JxCQtKtP8aeef5iNh5Nn9Z25wDrdLjS80A=="
-    },
-    "node_modules/prisma-v5/node_modules/@prisma/engines": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.9.0.tgz",
-      "integrity": "sha512-BH1fpXbMH09TwfZH5FVMJwRp6afEhKzqwebbCLdaEkJDuhxA//iwbILLqGFtGTgZbdBNUOThIK+UC3++5kWMTg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@prisma/debug": "5.9.0",
-        "@prisma/engines-version": "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64",
-        "@prisma/fetch-engine": "5.9.0",
-        "@prisma/get-platform": "5.9.0"
-      }
-    },
-    "node_modules/prisma-v5/node_modules/@prisma/engines-version": {
-      "version": "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64.tgz",
-      "integrity": "sha512-HFl7275yF0FWbdcNvcSRbbu9JCBSLMcurYwvWc8WGDnpu7APxQo2ONtZrUggU3WxLxUJ2uBX+0GOFIcJeVeOOQ=="
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -5660,15 +5582,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-native-uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-uuid/-/react-native-uuid-2.0.1.tgz",
-      "integrity": "sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==",
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -6385,6 +6298,11 @@
         }
       }
     },
+    "node_modules/text-encoder-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/text-encoder-lite/-/text-encoder-lite-2.0.0.tgz",
+      "integrity": "sha512-bo08ND8LlBwPeU23EluRUcO3p2Rsb/eN5EIfOVqfRmblNDEVKK5IzM9Qfidvo+odT0hhV8mpXQcP/M5MMzABXw=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6672,18 +6590,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/vite": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
@@ -6923,9 +6829,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.1.tgz",
+      "integrity": "sha512-+dTu2m6gmCbO9Ahm4ZBDapx2O6ZY9QSPXst2WXjcznPMwf2YNpn3RevLx4KkZp1OPW/ouFcoBtBzFz/LeY69oA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/examples/tauri-sqlite/package.json
+++ b/examples/tauri-sqlite/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@tauri-apps/api": "2.0.0-alpha.14",
     "@tauri-apps/plugin-sql": "^2.0.0-alpha.5",
-    "electric-sql": "^0.9.3",
+    "electric-sql": "^0.10.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Since [removing the global emitter](https://github.com/electric-sql/electric/commit/ec27052cc60bd39939f4924209b894148f9394a6), the web example stopped working, and the issue was that the `isMounted` logic that was placed there to work around [double mounts from React's StrictMode](https://react.dev/reference/react/StrictMode#strictmode) was not doing what it was supposed to.

Effectively an Electric client was initialized and provided to the app, and then a second one was initialized (potentially with a second database as `uniqueTabId` is not guaranteed to provide the same ID for a tab, which is why I also moved that at the top level), but not provided to the app.

Since the registry is global, the second database connection opened is the one that the satellite process used, but the notifier is now separate for each electrified instance.

Perhaps we still want a unified event emitter for all electric instances in a single application, but I suggest we put that in the global registry rather than as a separate top-level global singleton that can't be cleaned up. What do you think @kevin-dp ? (see https://github.com/electric-sql/electric/pull/1192 for reverting the change)