### PR TITLE
fix(client): Reintroduce global emitter

### DIFF
--- a/.changeset/grumpy-years-cheer.md
+++ b/.changeset/grumpy-years-cheer.md
@@ -2,4 +2,4 @@
 "electric-sql": patch
 ---
 
-Remove global `EventEmitter` and remove max listener warning.
+Remove max listener warning on `EventNotifier`'s event emitter.

--- a/clients/typescript/src/notifiers/event.ts
+++ b/clients/typescript/src/notifiers/event.ts
@@ -29,6 +29,12 @@ export const EVENT_NAMES = {
   connectivityStateChange: 'network:connectivity:changed',
 }
 
+// Initialise global emitter to be shared between all
+// electric instances (unless emitter is passed in)
+// Remove warning as we don't want to limit the number
+// of subscribers
+const globalEmitter = new EventEmitter().setMaxListeners(Infinity)
+
 export class EventNotifier implements Notifier {
   dbName: DbName
 
@@ -50,12 +56,7 @@ export class EventNotifier implements Notifier {
       byName: {},
     }
 
-    this.events =
-      eventEmitter !== undefined
-        ? eventEmitter
-        : // initialise emitter with no limit to listeners as
-          // we don't want to limit the number of subscribers
-          new EventEmitter().setMaxListeners(Infinity)
+    this.events = eventEmitter !== undefined ? eventEmitter : globalEmitter
   }
 
   attach(dbName: DbName, dbAlias: string): void {


### PR DESCRIPTION
See https://github.com/electric-sql/electric/pull/1191 for description of issues that arose from removing the global emitter.

I'm opening this PR in the case we decide that we want to reintroduce it as it ensures that all instantiated electric clients will share notifications between them.