### PR TITLE
fix: make sure PKs in any positions work with compensations

### DIFF
--- a/.changeset/rare-dogs-cheat.md
+++ b/.changeset/rare-dogs-cheat.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+fix: non-leading primary key columns should no longer break replication

--- a/components/electric/priv/sql_function_templates/perform_reordered_op_installer_function.sql.eex
+++ b/components/electric/priv/sql_function_templates/perform_reordered_op_installer_function.sql.eex
@@ -81,7 +81,8 @@ BEGIN
         $function$
         DECLARE
             built_row %4$s%%ROWTYPE;
-            current_row %4$s%%ROWTYPE;
+            -- Must be a `RECORD`, because `%%ROWTYPE` respects column order instead of column names when doing `SELECT INTO`.
+            current_row RECORD;
             tombstone_row <%= schema() %>.%3$I%%ROWTYPE;
             old_row_found boolean;
         BEGIN

--- a/e2e/tests/03.26_node_pk_position_does_not_matter_for_compensations.lux
+++ b/e2e/tests/03.26_node_pk_position_does_not_matter_for_compensations.lux
@@ -75,8 +75,8 @@
 
 [shell pg_1]
     # and expect the previously deleted row to be present
+    [invoke wait-for "SELECT id, content FROM public.items;" "00000000-0000-0000-0000-000000000001 \| hello world" 10 $psql]
     !\x
-    [invoke wait-for "SELECT content FROM public.items;" "content \| hello world" 10 $psql]
     [invoke wait-for "SELECT COUNT(*) FROM public.other_items;" "count \| 1" 10 $psql]
 
 [shell satellite_1]

--- a/e2e/tests/03.26_node_pk_position_does_not_matter_for_compensations.lux
+++ b/e2e/tests/03.26_node_pk_position_does_not_matter_for_compensations.lux
@@ -1,0 +1,88 @@
+[doc NodeJS Satellite uses compensations, and column order does not matter]
+[include _shared.luxinc]
+[include _satellite_macros.luxinc]
+
+[invoke setup]
+
+[invoke setup_client 1 "electric_1" 5133]
+
+# PREPARATION: Set up dependent tables and add a row that will be referenced
+
+[shell proxy_1]
+    [local sql=
+        """
+        CREATE TABLE public.items (
+            content VARCHAR NOT NULL,
+            id UUID PRIMARY KEY,
+            content_text_null VARCHAR,
+            content_text_null_default VARCHAR,
+            intvalue_null integer,
+            intvalue_null_default integer
+        );
+        ALTER TABLE public.items ENABLE ELECTRIC;
+        CREATE TABLE public.other_items (
+            content TEXT NOT NULL,
+            id TEXT PRIMARY KEY,
+            item_id UUID REFERENCES public.items(id)
+        );
+        ALTER TABLE public.other_items ENABLE ELECTRIC;
+        """]
+    [invoke migrate_pg "001" $sql]
+
+[shell satellite_1]
+    ??[rpc] recv: #SatInStartReplicationResp
+    [invoke node_sync_other_items ""]
+    ??[proto] recv: #SatSubsDataEnd
+    ?$node
+
+    """!await db.db.items.create({
+      data: {
+        id: "00000000-0000-0000-0000-000000000001",
+        content: "hello world"
+      }
+    })
+    """
+    ??[proto] send: #SatOpLog
+    ??[proto] recv: #SatOpLog
+
+    # Disconnect the client
+    !db.disconnect()
+
+[shell pg_1]
+    # Concurrently, update and then delete the referenced row on the server
+    !DELETE FROM public.items WHERE id = '00000000-0000-0000-0000-000000000001';
+    ?$psql
+
+[shell satellite_1]
+    # On a disconnected client, insert a dependent row
+    ?$node
+    """!await db.db.other_items.create({
+      data: {
+        id: "other_test_id_1",
+        content: "",
+        item_id: "00000000-0000-0000-0000-000000000001"
+      }
+    })
+    """
+    ?$node
+
+
+[shell satellite_1]
+    # Reconnect the client, expecting no errors to show up
+    !db.connect()
+    ??[proto] send: #SatOpLog
+    ??[proto] recv: #SatOpLog
+
+[shell pg_1]
+    # and expect the previously deleted row to be present
+    !\x
+    [invoke wait-for "SELECT content FROM public.items;" "content \| hello world" 10 $psql]
+    [invoke wait-for "SELECT COUNT(*) FROM public.other_items;" "count \| 1" 10 $psql]
+
+[shell satellite_1]
+    # and the client should have the same view of the data
+    [invoke node_await_get "hello world"]
+
+
+[cleanup]
+   [invoke teardown]


### PR DESCRIPTION
Original bug was that values from PKs were put in different columns. Reason for that bug is sneaky: I used a `%ROWTYPE` variable to store results of a `SELECT`, but `SELECT` selected PKs of the table first, and then all other columns. I assumed that `SELECT ... INTO` would fill the variable based on the column names, given that they match column names on the `%ROWTYPE` variable, but instead it used a column order to fill the fields of the variable, so PK values got into first columns of the table, and all columns up to PK were "moved" one over.

The solution here is to use a generic `RECORD` variable instead, because we're referring to columns by name later, and the way `SELECT` is built, it guarantees that every column of the original table is present.