### PR TITLE
fix(client): Fix text encoding polyfill being fed numbers

### DIFF
--- a/.changeset/two-ties-scream.md
+++ b/.changeset/two-ties-scream.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix TextEncoder polyfill being fed numbers rather than strings and breaking replication of number types

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -1410,6 +1410,9 @@ function serializeColumnData(
     case PgBasicType.PG_BYTEA:
       return columnValue as Uint8Array
     default:
+      if (typeof columnValue === 'number') {
+        return typeEncoder.text('' + columnValue)
+      }
       return typeEncoder.text(columnValue as string)
   }
 }

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -1410,10 +1410,9 @@ function serializeColumnData(
     case PgBasicType.PG_BYTEA:
       return columnValue as Uint8Array
     default:
-      if (typeof columnValue === 'number') {
-        return typeEncoder.text('' + columnValue)
-      }
-      return typeEncoder.text(columnValue as string)
+      return typeEncoder.text(
+        typeof columnValue === 'string' ? columnValue : '' + columnValue
+      )
   }
 }
 

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -1410,9 +1410,7 @@ function serializeColumnData(
     case PgBasicType.PG_BYTEA:
       return columnValue as Uint8Array
     default:
-      return typeEncoder.text(
-        typeof columnValue === 'string' ? columnValue : '' + columnValue
-      )
+      return typeEncoder.text(String(columnValue))
   }
 }
 


### PR DESCRIPTION
Addressing issue [raised in discord](https://discord.com/channels/933657521581858818/1231997358133477477)

The `TextEncoderLite` polyfill for the TextEncoder does not coerce its input to a string, and we force cast numbers with `as string` in the encoding stage, resulting in the input being encoded as an empty bytearray.

This does mean that the polyfill does not have the _exact_ same behaviour as the original (which it should), but the immediate solution is to respect types and not force cast to a string when it isn't.