### PR TITLE
chore(client): Add missing optional flag for peer dpeendencies

### DIFF
--- a/.changeset/five-humans-ring.md
+++ b/.changeset/five-humans-ring.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Add `react-dom` and `@tauri-apps/plugin-sql` as optiomal peer dependencies.

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -272,22 +272,28 @@
     "@capacitor-community/sqlite": {
       "optional": true
     },
-    "expo-sqlite": {
+    "@tauri-apps/plugin-sql": {
       "optional": true
     },
-    "vue": {
+    "expo-sqlite": {
       "optional": true
     },
     "react": {
       "optional": true
     },
+    "react-dom": {
+      "optional": true
+    },
     "react-native": {
       "optional": true
     },
-    "wa-sqlite": {
+    "typeorm": {
       "optional": true
     },
-    "typeorm": {
+    "vue": {
+      "optional": true
+    },
+    "wa-sqlite": {
       "optional": true
     }
   }


### PR DESCRIPTION
Adds peer dependency optional flags that are missing (also reordered to match peer dep order).

Relevant PR: https://github.com/electric-sql/electric/pull/1187