### PR TITLE
fix(client): Fix duplicate rollback issue in adapter

### DIFF
--- a/.changeset/strange-rabbits-compete.md
+++ b/.changeset/strange-rabbits-compete.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix duplicate `ROLLBACK`s when using interactive transactions through the adapter's `transaction` API.

--- a/clients/typescript/src/drivers/generic/adapter.ts
+++ b/clients/typescript/src/drivers/generic/adapter.ts
@@ -62,7 +62,11 @@ abstract class DatabaseAdapter
         // Commit the transaction when the user sets the result.
         // This assumes that the user does not execute any more queries after setting the result.
         this._run({ sql: 'COMMIT' })
-          .then(() => resolve(res))
+          .then(() => {
+            // Release early if commit succeeded
+            release()
+            resolve(res)
+          })
           // Failed to commit
           .catch(reject)
       })

--- a/clients/typescript/test/drivers/generic-adapters.test.ts
+++ b/clients/typescript/test/drivers/generic-adapters.test.ts
@@ -139,7 +139,7 @@ test('interactive transactions roll back if an error in between statements is th
   t.false(adapter.isLocked)
 })
 
-test.only('interactive transactions roll back once if an error in transaction is thrown', async (t) => {
+test('interactive transactions roll back once if an error in transaction is thrown', async (t) => {
   const adapter = new MockDatabaseAdapter()
 
   const sql = 'INSERT INTO items VALUES (1);'

--- a/clients/typescript/test/drivers/generic-adapters.test.ts
+++ b/clients/typescript/test/drivers/generic-adapters.test.ts
@@ -177,6 +177,56 @@ test('interactive transactions roll back once if an error in transaction is thro
   t.false(adapter.isLocked)
 })
 
+test('interactive transactions hold lock until end of rollback', async (t) => {
+  const adapter = new MockDatabaseAdapter()
+
+  const sql = 'INSERT INTO items VALUES (1);'
+  const insert = { sql }
+  const nextStatement = { sql: 'NEXT STATEMENT' }
+
+  t.plan(6)
+
+  adapter.mockRun(async (stmt) => {
+    // First statement is `BEGIN`
+    t.deepEqual(stmt, { sql: 'BEGIN' })
+    // Next statement should be our insert
+    adapter.mockRun(async (stmt) => {
+      t.deepEqual(stmt, insert)
+
+      // Next statement should be `ROLLBACK`, only once
+      adapter.mockRun(async (stmt) => {
+        t.deepEqual(stmt, { sql: 'ROLLBACK' })
+
+        // _After_ rollback is done, then next statemnet is run
+        adapter.mockRun(async (stmt) => {
+          t.deepEqual(stmt, nextStatement)
+          return { rowsAffected: 0 }
+        })
+
+        return { rowsAffected: 0 }
+      })
+
+      throw new Error('mocked failure')
+    })
+    return { rowsAffected: 1 }
+  })
+
+  await t.throwsAsync(
+    async () => {
+      const prom1 = adapter.transaction((tx, res) => {
+        tx.run(insert, (_, r) => res(r))
+      })
+      const prom2 = adapter.run(nextStatement)
+      return Promise.all([prom1, prom2])
+    },
+    {
+      message: 'mocked failure',
+    }
+  )
+
+  t.false(adapter.isLocked)
+})
+
 test('interactive transactions roll back if commit fails', async (t) => {
   const adapter = new MockDatabaseAdapter()
 


### PR DESCRIPTION
Fixes:
1) Duplicate rollbacks in interactive transactions, as a failing statement within a transaction would first trigger a rollback from within the `Transaction` object and then trigger a second one from the adapter's `transaction` API (see [discord chat](https://discord.com/channels/933657521581858818/1224163932630159461))
2) Interleaving of statements before a rollback occurs, as a failing statement within an interactive transaction would release the adapter's lock _before_ running `ROLLBACK` and thus lead to interleaving of statements run.

I've added failing tests for both cases and subsequently a fix for both.

I've kept multiple lock `release` calls to maintain the performance optimization of calling `release` _immediately_ after a commit is successful to avoid another event loop cycle blocking other adapter tasks, but if we believe that is a minimal improvement we could just keep the `release` call in the `finally` clause for clarity.

