### PR TITLE
chore(electric): Fetch and delete client subscriptions in bulk

### DIFF
--- a/components/electric/lib/electric/satellite/client_reconnection_info.ex
+++ b/components/electric/lib/electric/satellite/client_reconnection_info.ex
@@ -241,13 +241,15 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
     :ets.delete(@checkpoint_ets, client_id)
   end
 
-  def fetch_subscriptions(client_id, subscription_ids) do
+  def fetch_subscriptions(client_id, subscription_ids)
+      when is_list(subscription_ids) and subscription_ids != [] do
     :ets.select(@subscriptions_ets, [
       {{{client_id, :"$1"}, :_, :"$2", :_}, [ids_ms_guard(subscription_ids)], [{{:"$1", :"$2"}}]}
     ])
   end
 
-  def delete_subscriptions(origin, client_id, subscription_ids) do
+  def delete_subscriptions(origin, client_id, subscription_ids)
+      when is_list(subscription_ids) and subscription_ids != [] do
     ms_guard = ids_ms_guard(subscription_ids)
 
     :ets.select_delete(@subscriptions_ets, [
@@ -279,7 +281,9 @@ defmodule Electric.Satellite.ClientReconnectionInfo do
       reraise exception, __STACKTRACE__
   end
 
-  defp ids_ms_guard(ids) do
+  defp ids_ms_guard([id]), do: {:"=:=", :"$1", id}
+
+  defp ids_ms_guard([_id1, _id2 | _] = ids) do
     id_matches = Enum.map(ids, &{:"=:=", :"$1", &1})
     List.to_tuple([:or | id_matches])
   end

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -260,7 +260,7 @@ defmodule Electric.Satellite.Protocol do
       |> Map.put(:out_rep, out_rep)
       |> Map.update!(:subscriptions, &Map.drop(&1, ids))
 
-    Enum.each(ids, &ClientReconnectionInfo.delete_subscription(state.origin, state.client_id, &1))
+    ClientReconnectionInfo.delete_subscriptions(state.origin, state.client_id, ids)
 
     if needs_unpausing? do
       {:force_unpause, %SatUnsubsResp{}, state}

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -1147,6 +1147,8 @@ defmodule Electric.Satellite.Protocol do
     end
   end
 
+  defp restore_subscriptions([], %State{} = state), do: {:ok, state}
+
   defp restore_subscriptions(subscription_ids, %State{} = state) do
     subscription_data =
       ClientReconnectionInfo.fetch_subscriptions(state.client_id, subscription_ids)

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -1148,20 +1148,21 @@ defmodule Electric.Satellite.Protocol do
   end
 
   defp restore_subscriptions(subscription_ids, %State{} = state) do
-    Enum.reduce_while(subscription_ids, {:ok, state}, fn id, {:ok, state} ->
-      case ClientReconnectionInfo.fetch_subscription(state.client_id, id) do
-        {:ok, results} ->
-          state = Map.update!(state, :subscriptions, &Map.put(&1, id, results))
-          {:cont, {:ok, state}}
+    subscription_data =
+      ClientReconnectionInfo.fetch_subscriptions(state.client_id, subscription_ids)
+      |> Map.new()
 
-        :error ->
-          id = if String.length(id) > 128, do: String.slice(id, 0..125) <> "...", else: id
+    case Enum.find(subscription_ids, &(not Map.has_key?(subscription_data, &1))) do
+      nil ->
+        state = Map.update!(state, :subscriptions, &Map.merge(&1, subscription_data))
+        {:ok, state}
 
-          {:halt,
-           {:error,
-            start_replication_error(:SUBSCRIPTION_NOT_FOUND, "Unknown subscription: #{id}")}}
-      end
-    end)
+      id ->
+        id = if String.length(id) > 128, do: String.slice(id, 0..125) <> "...", else: id
+
+        {:halt,
+         {:error, start_replication_error(:SUBSCRIPTION_NOT_FOUND, "Unknown subscription: #{id}")}}
+    end
   end
 
   defp restore_graph(lsn, observed_txn_data, %State{} = state) do

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -82,8 +82,6 @@ defmodule Electric.Satellite.WebsocketServerTest do
   end
 
   setup_with_mocks([
-    {Electric.Satellite.ClientReconnectionInfo, [:passthrough],
-     restore_cache_for_client: fn _, _ -> :ok end},
     {SatelliteConnector, [:passthrough],
      [
        start_link: fn %{name: name, producer: producer} ->


### PR DESCRIPTION
`fetch_subscription()` and `delete_subscription()` were only used when iterating over a list of subcription IDs. This PR changes those functions to issue bulk ETS and database calls that operate on the whole list of subscription IDs at once.