### PR TITLE
Issue client reset message when permissions change

### DIFF
--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -1422,7 +1422,6 @@ export class SatelliteProcess implements Satellite {
       await this._resetClientState({
         keepSubscribedShapes: true,
       })
-      this._subscribePreviousShapeRequests()
     }
   }
 

--- a/clients/typescript/test/satellite/process.test.ts
+++ b/clients/typescript/test/satellite/process.test.ts
@@ -2312,6 +2312,8 @@ test('SatClientCommand.ResetDatabase clears all data', async (t) => {
   const { synced } = await satellite.subscribe([shapeDef])
   await synced
   await satellite._performSnapshot()
+  const subscriptionCount =
+    satellite.subscriptions.getFulfilledSubscriptions().length
 
   await client.commandCb!(
     SatClientCommand.fromPartial({
@@ -2326,4 +2328,7 @@ test('SatClientCommand.ResetDatabase clears all data', async (t) => {
   })
 
   t.deepEqual(results, [])
+
+  // make sure our existing subscriptions have been saved
+  t.assert(satellite.previousShapeSubscriptions.length == subscriptionCount)
 })

--- a/components/electric/lib/electric/satellite/permissions/state.ex
+++ b/components/electric/lib/electric/satellite/permissions/state.ex
@@ -11,6 +11,8 @@ defmodule Electric.Satellite.Permissions.State do
   alias Electric.Postgres.Extension
   alias Electric.Satellite.Permissions.Trigger
 
+  require Logger
+
   @electric_ddlx Extension.ddlx_relation()
 
   @enforce_keys [:rules, :schema]
@@ -98,6 +100,7 @@ defmodule Electric.Satellite.Permissions.State do
         {[], {state, loader}}
 
       {rules, _count} ->
+        Logger.debug(fn -> "Updated global permissions id: #{rules.id}" end)
         {:ok, loader} = SchemaLoader.save_global_permissions(loader, rules)
 
         {
@@ -181,6 +184,10 @@ defmodule Electric.Satellite.Permissions.State do
       if modified? do
         with {:ok, loader, perms} <-
                SchemaLoader.save_user_permissions(loader, role.user_id, roles) do
+          Logger.debug(fn -> "Updated user permissions id: #{perms.id}" end,
+            user_id: role.user_id
+          )
+
           {:ok, loader, [updated_user_permissions(role.user_id, perms)]}
         end
       else

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -33,7 +33,10 @@ defmodule Electric.Satellite.Protocol do
   @type lsn() :: non_neg_integer
   @type deep_msg_list() :: PB.sq_pb_msg() | [deep_msg_list()]
   @type actions() :: {Shapes.subquery_actions(), [non_neg_integer()]}
-  @type outgoing() :: {deep_msg_list(), State.t()} | {:error, deep_msg_list(), State.t()}
+  @type outgoing() ::
+          {deep_msg_list(), State.t()}
+          | {:error, deep_msg_list(), State.t()}
+          | {:close, deep_msg_list(), State.t()}
   @type txn_processing() :: {deep_msg_list(), actions(), State.t()}
 
   @producer_demand 5
@@ -650,7 +653,7 @@ defmodule Electric.Satellite.Protocol do
             schema: migration.schema
           )
 
-        {[migration], after_permissions_change(state)}
+        {[migration], state}
 
       change, state ->
         {[change], state}
@@ -704,8 +707,16 @@ defmodule Electric.Satellite.Protocol do
   end
 
   defp after_permissions_change(state) do
-    # TODO(magnetised): updated permissions must be applied to the shapes
-    state
+    if Permissions.filter_reads_enabled?() do
+      command =
+        %SatClientCommand{
+          command: {:reset_database, %SatClientCommand.ResetDatabase{reason: :PERMISSIONS_CHANGE}}
+        }
+
+      throw({:close, [command], state})
+    else
+      state
+    end
   end
 
   # If the client received at least one migration during the initial sync, the value of
@@ -1353,6 +1364,8 @@ defmodule Electric.Satellite.Protocol do
     # TODO(magnetised): load specific permissions version
     {:ok, schema_loader, sat_perms} =
       SchemaLoader.user_permissions(state.schema_loader, State.user_id(state))
+
+    Logger.debug(fn -> "Loaded user permissions id: #{sat_perms.id}" end)
 
     perms =
       state.auth

--- a/components/electric/test/electric/satellite/subscriptions_test.exs
+++ b/components/electric/test/electric/satellite/subscriptions_test.exs
@@ -20,8 +20,8 @@ defmodule Electric.Satellite.SubscriptionsTest do
       :setup_replicated_db,
       :setup_electrified_tables,
       :setup_open_permissions,
-      :setup_with_sql_execute,
-      :setup_with_ddlx
+      :setup_with_ddlx,
+      :setup_with_sql_execute
     ]
 
     setup ctx do

--- a/e2e/tests/02.02_migrations_get_streamed_to_satellite.lux
+++ b/e2e/tests/02.02_migrations_get_streamed_to_satellite.lux
@@ -18,7 +18,6 @@
     CALL electric.migration_version('$migration_version');
     CREATE TABLE mtable1 (id uuid PRIMARY KEY);
     ALTER TABLE mtable1 ENABLE ELECTRIC;
-    ELECTRIC GRANT ALL ON mtable1 TO AUTHENTICATED;
     COMMIT;
     """
     ?$psql

--- a/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
+++ b/e2e/tests/03.03_node_satellite_sends_and_recieves_data.lux
@@ -4,15 +4,17 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-[invoke setup_client 2 "electric_1" 5133]
-
 [shell proxy_1]
     [invoke migrate_items_table 20230504114018]
 
+[invoke setup_client 1 "electric_1" 5133]
+[invoke setup_client 2 "electric_1" 5133]
+
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp
+    ??Connectivity state changed: connected
     [invoke node_sync_items ""]
+
 [shell satellite_2]
     ??[rpc] recv: #SatInStartReplicationResp
     [invoke node_sync_items ""]

--- a/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
+++ b/e2e/tests/03.04_node_satellite_correctly_updates_serialization_caches.lux
@@ -4,8 +4,6 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-[invoke setup_client 2 "electric_1" 5133]
 
 [global migration_version_1=20230504114018]
 [global migration_version_2=20230505100008]
@@ -15,6 +13,9 @@
     [invoke migrate_items_table 20230504114018]
     !\d electric.shadow__public__items
     !\d items
+
+[invoke setup_client 1 "electric_1" 5133]
+[invoke setup_client 2 "electric_1" 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.06_node_satellite_does_sync_on_subscribe.lux
+++ b/e2e/tests/03.06_node_satellite_does_sync_on_subscribe.lux
@@ -4,10 +4,10 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-
 [shell proxy_1]
     [invoke migrate_items_table 20230504114018]
+
+[invoke setup_client 1 "electric_1" 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.07_node_satellite_can_delete_freshly_synced_rows.lux
+++ b/e2e/tests/03.07_node_satellite_can_delete_freshly_synced_rows.lux
@@ -4,10 +4,10 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-
 [shell proxy_1]
     [invoke migrate_items_table 20230504114018]
+
+[invoke setup_client 1 "electric_1" 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.08_node_satellite_can_resume_subscriptions_on_reconnect.lux
+++ b/e2e/tests/03.08_node_satellite_can_resume_subscriptions_on_reconnect.lux
@@ -4,10 +4,10 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-
 [shell proxy_1]
     [invoke migrate_items_table 20230504114018]
+
+[invoke setup_client 1 "electric_1" 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.11_node_satellite_compensations_work.lux
+++ b/e2e/tests/03.11_node_satellite_compensations_work.lux
@@ -4,13 +4,13 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-
 # PREPARATION: Set up dependent tables and add a row that will be referenced
 
 [shell proxy_1]
     [invoke migrate_items_table 001]
     [invoke migrate_other_items_table 002]
+
+[invoke setup_client 1 "electric_1" 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.12_server_correctly_continues_the_replication.lux
+++ b/e2e/tests/03.12_server_correctly_continues_the_replication.lux
@@ -4,10 +4,10 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-
 [shell proxy_1]
   [invoke migrate_items_table 20230504114018]
+
+[invoke setup_client 1 "electric_1" 5133]
 
 [shell satellite_1]
   ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.21_node_satellite_correctly_handles_move_in_move_out.lux
+++ b/e2e/tests/03.21_node_satellite_correctly_handles_move_in_move_out.lux
@@ -4,8 +4,6 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-
 [shell proxy_1]
     [local sql=
         """
@@ -35,6 +33,8 @@
         ELECTRIC GRANT ALL ON public.comments TO AUTHENTICATED;
         """]
     [invoke migrate_pg 20240130000000 $sql]
+
+[invoke setup_client 1 "electric_1" 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
+++ b/e2e/tests/03.22_node_satellite_can_disconnect_and_reconnect.lux
@@ -4,11 +4,11 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
-[invoke setup_client 2 "electric_1" 5133]
-
 [shell proxy_1]
     [invoke migrate_items_table 20230504114018]
+
+[invoke setup_client 1 "electric_1" 5133]
+[invoke setup_client 2 "electric_1" 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.24_node_satellite_can_transform_at_replication_boundary.lux
+++ b/e2e/tests/03.24_node_satellite_can_transform_at_replication_boundary.lux
@@ -4,11 +4,11 @@
 
 [invoke setup]
 
-[invoke setup_client 1 electric_1 5133]
-[invoke setup_client 2 electric_1 5133]
-
 [shell proxy_1]
     [invoke migrate_items_table 20230504114018]
+
+[invoke setup_client 1 electric_1 5133]
+[invoke setup_client 2 electric_1 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/03.27_postgres_dropped_columns_are_not_electrified.lux
+++ b/e2e/tests/03.27_postgres_dropped_columns_are_not_electrified.lux
@@ -41,8 +41,13 @@
 [shell proxy_1]
     -$fail_pattern|content_b|dropped
 
+    !BEGIN;
+    ?electric=\*#
     !ALTER TABLE entries ENABLE ELECTRIC;
     ??ELECTRIC ENABLE
+    !ELECTRIC GRANT ALL on entries TO AUTHENTICATED;
+    ?electric=\*#
+    !COMMIT;
     ??electric=#
 
 [shell pg_1]
@@ -60,6 +65,7 @@
 # Start two clients and make conflicting writes on both to verify correct conflict resolution
 # that's not affected by the dropped column content_b.
 [invoke setup_client 1 "electric_1" 5133]
+
 [shell satellite_1]
     ?send: #SatAuthReq\{id: ([a-f0-9-]{36})
     [global client_1_id=$1]

--- a/e2e/tests/06.02_permissions_change_propagation.lux
+++ b/e2e/tests/06.02_permissions_change_propagation.lux
@@ -10,7 +10,6 @@
 [global session_id=001]
 [global project_id=99adf0a5-b3c6-45d7-9986-582e76db4556]
 
-
 [shell proxy_1]
     [invoke log "run migration $migration_version_1 on postgres"]
     """!
@@ -76,6 +75,18 @@
 
 [shell electric]
     ?user_id=$user_id1 .+ Global permissions updated for connection
+
+# TODO: permissions-change: perms change should not drop connection
+#       currently a perms change drops the connection to force
+#       a re-subscribe with updated perms
+
+[shell user_1_ws1]
+    ?SatClientCommand\{command: .+ResetDatabase\{reason: :PERMISSIONS_CHANGE
+    ?Server closed the websocket connection
+
+    -$fail_pattern
+
+    [invoke client_session $user_id1 $session_id]
 
 [shell pg_1]
     !INSERT INTO project_memberships (id, project_id, user_id, role) VALUES ('c197a4ef-0f22-4af1-acb1-bf7200e64900', '$project_id', '$user_id1', 'member');

--- a/e2e/tests/06.04_permissions_changes_resubscribe.lux
+++ b/e2e/tests/06.04_permissions_changes_resubscribe.lux
@@ -148,5 +148,45 @@
 [shell user_2_ws1]
     ?SatOpInsert\{.+values: \["c2b114a3-9527-4f3c-8863-b0dc7c85ec76", "$project_id2", "Project 2/Issue 4"\]
 
+# add user 1 to project 2
+[shell pg_1]
+    """!
+    BEGIN;
+    INSERT INTO project_memberships (id, project_id, user_id, role) VALUES
+      ('943fcfde-cd15-4eb8-9cae-89fa07db55c8', '$project_id2', '$user_id1', 'member');
+    COMMIT;
+    """
+    ?$psql
+
+# TODO: permissions-change: perms change should not drop connection
+
+[shell user_1_ws1]
+    ?SatClientCommand\{command: .+ResetDatabase\{reason: :PERMISSIONS_CHANGE
+    ?Server closed the websocket connection
+
+    -$fail_pattern
+
+    [invoke client_session $user_id1 $session_id]
+    [invoke subscribe_tables "f624382d-b14c-424a-8836-b042bb12f65a" "issues"]
+
+    ?+SatOpInsert\{.+values: \["$issue_id1", "$project_id1", "Project 1/Issue 1"\]
+    ?+SatOpInsert\{.+values: \["$issue_id2", "$project_id1", "Project 1/Issue 2"\]
+    ?SatOpInsert\{.+values: \["$issue_id3", "$project_id2", "Project 2/Issue 3"\]
+
+[shell pg_1]
+    """!
+    BEGIN;
+    INSERT INTO issues (id, project_id, name) VALUES
+      ('12c078a1-bb7f-4b13-a415-a50f9f4c5cdc', '$project_id2', 'Project 2/Issue 5');
+    COMMIT;
+    """
+    ?$psql
+
+[shell user_1_ws1]
+    ?SatOpInsert\{.+values: \["12c078a1-bb7f-4b13-a415-a50f9f4c5cdc", "$project_id2", "Project 2/Issue 5"\]
+
+[shell user_2_ws1]
+    ?SatOpInsert\{.+values: \["12c078a1-bb7f-4b13-a415-a50f9f4c5cdc", "$project_id2", "Project 2/Issue 5"\]
+
 [cleanup]
    [invoke teardown]

--- a/e2e/tests/_shared.luxinc
+++ b/e2e/tests/_shared.luxinc
@@ -144,6 +144,10 @@
         ELECTRIC GRANT ALL ON public.items TO AUTHENTICATED;
         """]
     [invoke migrate_pg $version $sql]
+    [my old=$LUX_SHELLNAME]
+    [shell electric]
+        ??Updated global permissions
+    [shell $old]
 [endmacro]
 
 [macro migrate_other_items_table version]
@@ -158,4 +162,8 @@
         ELECTRIC GRANT ALL ON public.other_items TO AUTHENTICATED;
         """]
     [invoke migrate_pg $version $sql]
+    [my old=$LUX_SHELLNAME]
+    [shell electric]
+        ??Updated global permissions
+    [shell $old]
 [endmacro]


### PR DESCRIPTION
Rather than attempt to reset the server connection's state after we've asked the client to reset itself, we just close the connection. The client will then re-connect automatically and, since it's had its state reset, the server will treat it as a first connection (including dropping all client reconnection state).

Since this is intended as an enabling simplification to maintain consistency between client and server in the simplest way possible, pending a more efficient, less brutal but much more complicated solution, I've tried to keep the changes to the protocol as small as possible. 

Hence the use of `throw` -- it's either that or restructure all the message handling on the server side to be more of a `reduce_while` style.