### PR TITLE
fix(e2e_client): Fixes some typings in the e2e satellite client

### DIFF
--- a/e2e/satellite_client/src/client.ts
+++ b/e2e/satellite_client/src/client.ts
@@ -11,7 +11,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { schema, Electric, ColorType as Color } from './generated/client'
 export { JsonNull } from './generated/client'
 import { globalRegistry } from 'electric-sql/satellite'
-import { SatelliteErrorCode } from 'electric-sql/util'
+import { QualifiedTablename, SatelliteErrorCode } from 'electric-sql/util'
 import { Shape } from 'electric-sql/satellite'
 import { pgBuilder, sqliteBuilder, QueryBuilder } from 'electric-sql/migrators/builder'
 
@@ -143,7 +143,9 @@ export const get_tables = (electric: Electric) => {
 }
 
 export const get_columns = (electric: Electric, table: string) => {
-  return electric.db.rawQuery(builder.getTableInfo(table))
+  const namespace = builder.defaultNamespace
+  const qualifiedTablename = new QualifiedTablename(namespace, table)
+  return electric.db.rawQuery(builder.getTableInfo(qualifiedTablename))
 }
 
 export const get_rows = (electric: Electric, table: string) => {
@@ -378,7 +380,7 @@ export const get_blob = async (electric: Electric, id: string) => {
     }
   })
 
-  if (res.blob) {
+  if (res?.blob) {
     // The PG driver returns a NodeJS Buffer but the e2e test matches on a plain Uint8Array.
     // So we convert the Buffer to a Uint8Array.
     // Note that Buffer is a subclass of Uint8Array.

--- a/e2e/satellite_client/src/prisma/schema.prisma
+++ b/e2e/satellite_client/src/prisma/schema.prisma
@@ -83,6 +83,7 @@ model Jsons {
 model Enums {
   id String @id
   c  Color?
+  @@map("enums")
 }
 
 model Blobs {

--- a/e2e/tests/_satellite_macros.luxinc
+++ b/e2e/tests/_satellite_macros.luxinc
@@ -196,7 +196,7 @@
 [endmacro]
 
 [macro node_await_column table column]
-    [invoke wait-for "await client.get_columns(db, '${table}')" "${column}" 10 $node]
+    [invoke wait-for "await client.get_columns(db, '${table}')" "name: '${column}'" 10 $node]
 [endmacro]
 
 [macro node_await_column_value table column value]


### PR DESCRIPTION
I've looked into why Lux didn't catch this. It appears to be because it was matching the same string that appears async in stdout via a SatOpLog. So I've tweaked the expectation so that it is more strict.

Another minor issue we found in the e2e client is the prisma definition for the enums table. We generate the Dart e2e client from the schema file, and the Enums model didn't include a `@@map`, so the generated table name was uppercase. But the e2e test creates the enums table as lowercase.

There appears to be other typing issues in the client, but I'm not sure how to resolve.

![image](https://github.com/electric-sql/electric/assets/22084723/8185536b-af2b-45b4-a1cf-b32fed1b82b5)

![image](https://github.com/electric-sql/electric/assets/22084723/347f0c8f-b7bd-449f-b381-b2c0b9272a7d)

cc @kevin-dp 