### PR TITLE
fix(client_tests): Fix port collisions

### DIFF
--- a/.changeset/lemon-buttons-warn.md
+++ b/.changeset/lemon-buttons-warn.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix port collisions in client tests

--- a/clients/typescript/test/satellite/client.test.ts
+++ b/clients/typescript/test/satellite/client.test.ts
@@ -42,13 +42,13 @@ interface Context extends AuthState {
 
 const test = anyTest as TestFn<Context>
 
-test.beforeEach((t) => {
+test.beforeEach(async (t) => {
   const server = new SatelliteWSServerStub(t)
-  server.start()
+  const port = await server.start()
 
   const client = new SatelliteClient(dbDescription, WebSocketNode, {
     host: '127.0.0.1',
-    port: 30002,
+    port: port,
     timeout: 10000,
     ssl: false,
     pushPeriod: 100,

--- a/clients/typescript/test/satellite/merge.test.ts
+++ b/clients/typescript/test/satellite/merge.test.ts
@@ -193,7 +193,7 @@ const setupSqlite: SetupFn = (t: ExecutionContext<unknown>) => {
   return [new SQLiteDatabaseAdapter(db), sqliteBuilder, namespace, defaults]
 }
 
-let port = 4800
+let port = 4700
 const setupPG: SetupFn = async (t: ExecutionContext<unknown>) => {
   const dbName = `merge-test-${randomValue()}`
   const { db, stop } = await makePgDatabase(dbName, port++)

--- a/clients/typescript/test/satellite/server_ws_stub.ts
+++ b/clients/typescript/test/satellite/server_ws_stub.ts
@@ -15,9 +15,7 @@ import {
 import { toMessage } from '../../src/satellite/client'
 import { ExecutionContext } from 'ava'
 import { sleepAsync } from '../../src/util'
-
-const PORT = 30002
-const IP = '127.0.0.1'
+import { AddressInfo } from 'net'
 
 type NonRpcMessage = Exclude<SatPbMsg, SatRpcRequest>
 
@@ -123,8 +121,13 @@ export class SatelliteWSServerStub {
       }
     }
   }
-  start() {
-    this.httpServer.listen(PORT, IP)
+  async start(): Promise<number> {
+    return new Promise((res) => {
+      this.httpServer.listen(() => {
+        const address = this.httpServer.address()
+        res((address as AddressInfo).port)
+      })
+    })
   }
 
   closeSocket(reason?: string) {


### PR DESCRIPTION
We found that the PG ports can collide in 2 of the tests.
We've also included a way to automatically assign a port to the client tests http server, as we've sometimes found some flakiness with the fixed port being used already.