### PR TITLE
chore(electric): Improve error messages when the replication slot is already in use

### DIFF
--- a/components/electric/lib/electric/replication/postgres_connector.ex
+++ b/components/electric/lib/electric/replication/postgres_connector.ex
@@ -100,7 +100,31 @@ defmodule Electric.Replication.PostgresConnector do
       Failed to establish replication connection to Postgres:
         #{msg}
       """,
-      "Another instance of Electric appears to be connected to this database."
+      """
+      Another instance of Electric appears to be connected to this database.
+      Refer to https://github.com/electric-sql/electric/issues/971 for additional info.
+      """
+    )
+  end
+
+  defp log_child_error(
+         LogicalReplicationProducer,
+         {:bad_return_value,
+          {:error,
+           {:error, :error, "42710", :duplicate_object, "replication slot " <> _ = msg,
+            _c_stacktrace}}},
+         _connector_config
+       ) do
+    Electric.Errors.print_error(
+      :conn,
+      """
+      Failed to establish replication connection to Postgres:
+        #{msg}
+      """,
+      """
+      Another instance of Electric appears to be connected to this database.
+      Refer to https://github.com/electric-sql/electric/issues/971 for additional info.
+      """
     )
   end
 

--- a/components/electric/lib/electric/replication/postgres_connector.ex
+++ b/components/electric/lib/electric/replication/postgres_connector.ex
@@ -4,6 +4,7 @@ defmodule Electric.Replication.PostgresConnector do
   require Logger
 
   alias Electric.Replication.Connectors
+  alias Electric.Replication.Postgres.LogicalReplicationProducer
   alias Electric.Replication.PostgresConnectorMng
   alias Electric.Replication.PostgresConnectorSup
 
@@ -87,7 +88,7 @@ defmodule Electric.Replication.PostgresConnector do
   end
 
   defp log_child_error(
-         :postgres_producer,
+         LogicalReplicationProducer,
          {:bad_return_value,
           {:error,
            {:error, :error, "55006", :object_in_use, "replication slot" <> _ = msg, _c_stacktrace}}},
@@ -104,7 +105,7 @@ defmodule Electric.Replication.PostgresConnector do
   end
 
   defp log_child_error(
-         :postgres_producer,
+         LogicalReplicationProducer,
          {:bad_return_value, {:error, :wal_level_not_logical}},
          _connector_config
        ) do
@@ -119,7 +120,7 @@ defmodule Electric.Replication.PostgresConnector do
   end
 
   defp log_child_error(
-         :postgres_producer,
+         LogicalReplicationProducer,
          {:bad_return_value, {:error, {:create_replication_slot_syntax_error, msg}}},
          _connector_config
        ) do


### PR DESCRIPTION
Related: https://github.com/electric-sql/electric/issues/971.