### PR TITLE
feat(electric): Increase the ping heartbeat to 20 seconds from 5 seconds

### DIFF
--- a/.changeset/poor-deers-marry.md
+++ b/.changeset/poor-deers-marry.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Increase the ping heartbeat to 20 seconds from 5 seconds.


### PR DESCRIPTION
After some discussion with @kevin-dp we are under the assumption that 5 seconds of ping timeout is quite low. Other popular websocket libraries like https://socket.io use a ping interval of 25 seconds and a ping timeout of 20 seconds. The timeout default changed from 5 seconds to 20 seconds over the years.

On top of this change, we noticed that the scheduler can sometimes undershoot. That is, if we schedule after 5000 ms, we could then obtain a `last_msg_diff` of 4999.7 ms, which wouldn't match the `>` operator. Because of that, a small margin error of 500 microseconds is added.
That would prevent obtaining uneven ping durations -> 20s, 20s, 40s, 20s, 40s,... (That's because if it doesn't match, we will schedule for another 20 seconds)