### PR TITLE
fix (client): pass correct dialect spelling to migrations endpoint

### DIFF
--- a/.changeset/fast-boats-check.md
+++ b/.changeset/fast-boats-check.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix CLI bug for fetching migrations


### PR DESCRIPTION
This PR fixes the CLI to pass the right dialect argument to the migrations endpoint and also error if the status code indicates a failure.