### PR TITLE
fix(client): Fix Postgres introspection subquery to only look at PK constraints

### DIFF
--- a/.changeset/breezy-meals-reflect.md
+++ b/.changeset/breezy-meals-reflect.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix Postgres introspection subquery to only look at PK constraints


### PR DESCRIPTION
Fixes #1238

Old subquery returns multiple rows when there was an index on other columns. This one is limited to `contype = 'p'` for primary key constraints.