### PR TITLE
fix(client) Change _applyNonDeleteOperation to use pk column for creating the `ON CONFLICT` statement

### DIFF
--- a/.changeset/spicy-items-poke.md
+++ b/.changeset/spicy-items-poke.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix a bug with Postgres client sync so that pk columns for creating the ON CONFLICT statement are correct when applying an incoming transaction.

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -1621,7 +1621,7 @@ export class SatelliteProcess implements Satellite {
         qualifiedTableName,
         columnNames,
         columnValues,
-        ['id'],
+        Object.keys(primaryKeyCols),
         updateColumnStmts,
         updateColumnStmts.map((col) => fullRow[col])
       )


### PR DESCRIPTION
Previous version prior to PG support didn't reference columns in the `ON CONFLICT`:https://github.com/electric-sql/electric/blame/c8e698148d4082d2c3fc1f081d410434f228b01b/clients/typescript/src/satellite/process.ts#L1631

I suspect this bug was inherited from the Tauri Linearlite demo as it only had PKs as "id"