### PR TITLE
fix(client): asyncEventEmitter to not silence unhandled exceptions raised in event handlers

### DIFF
--- a/.changeset/five-rats-shake.md
+++ b/.changeset/five-rats-shake.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix asyncEventEmitter to not silence unhandled exceptions raised in event handlers.

--- a/.changeset/selfish-years-suffer.md
+++ b/.changeset/selfish-years-suffer.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Fix `ShapeManager` bug where manager state gets reset but the Satellite process is still assuming it is accessible.

--- a/clients/typescript/src/satellite/client.ts
+++ b/clients/typescript/src/satellite/client.ts
@@ -354,7 +354,7 @@ export class SatelliteClient implements Client {
     this.socketHandler = undefined
 
     if (this.socket !== undefined) {
-      this.socket!.closeAndRemoveListeners()
+      this.socket.closeAndRemoveListeners()
       this.socket = undefined
     }
   }
@@ -367,9 +367,10 @@ export class SatelliteClient implements Client {
     return this.outbound.isReplicating
   }
 
-  shutdown(): void {
-    this.disconnect()
+  async shutdown(): Promise<void> {
     this.emitter.removeAllListeners()
+    await this.emitter.waitForProcessing()
+    this.disconnect()
     this.isDown = true
   }
 

--- a/clients/typescript/src/satellite/index.ts
+++ b/clients/typescript/src/satellite/index.ts
@@ -91,7 +91,7 @@ export interface Satellite extends IShapeManager {
 export interface Client {
   connect(): Promise<void>
   disconnect(): void
-  shutdown(): void
+  shutdown(): Promise<void>
   authenticate(authState: AuthState): Promise<AuthResponse>
   isConnected(): boolean
   getOutboundReplicationStatus(): ReplicationStatus

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -403,7 +403,8 @@ export class MockSatelliteClient
       : ReplicationStatus.STOPPED
   }
 
-  shutdown(): void {
+  async shutdown(): Promise<void> {
+    await this.waitForProcessing()
     this.isDown = true
   }
 

--- a/clients/typescript/src/util/asyncEventEmitter.ts
+++ b/clients/typescript/src/util/asyncEventEmitter.ts
@@ -161,11 +161,11 @@ export class AsyncEventEmitter<Events extends EventMap> {
         // re-throw any rejected promises such that the global error
         // handler can catch them and log them, otherwise they would
         // be suppressed and bugs may go unnoticed
-        settledPromises
-          .filter((prom) => prom.status === 'rejected')
-          .forEach((rejectedProm) => {
+        settledPromises.forEach((rejectedProm) => {
+          if (rejectedProm.status === 'rejected') {
             throw rejectedProm.reason
-          })
+          }
+        })
       })
     } else {
       // signal that the queue is no longer being processed

--- a/clients/typescript/src/util/encoders/sqliteEncoders.ts
+++ b/clients/typescript/src/util/encoders/sqliteEncoders.ts
@@ -13,7 +13,7 @@ export const sqliteTypeEncoder = {
   json: (string: string) => textEncoder.encode(string),
   timetz: (string: string) =>
     sqliteTypeEncoder.text(stringToTimetzString(string)),
-  bytea: (bytes: Uint8Array) => bytes, // no-op
+  bytea: (bytes: Uint8Array) => bytes,
 }
 
 export const sqliteTypeDecoder = {
@@ -22,7 +22,8 @@ export const sqliteTypeDecoder = {
   json: bytesToString,
   timetz: bytesToTimetzString,
   float: bytesToFloat,
-  bytea: (bytes: Uint8Array) => bytes, // no-op
+  // ensure it is in Uint8Array format and not Buffer etc
+  bytea: (bytes: Uint8Array) => new Uint8Array(bytes),
 }
 
 export function boolToBytes(b: number) {

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -2498,7 +2498,7 @@ export const processTests = (test: TestFn<ContextType>) => {
     t.plan(3)
     const { client, satellite } = t.context
 
-    client.shutdown()
+    await client.shutdown()
 
     const retry = (_e: any, a: number) => {
       if (a > 0) {
@@ -2519,7 +2519,7 @@ export const processTests = (test: TestFn<ContextType>) => {
 
   test.serial('connection cancelled on disconnect', async (t) => {
     const { client, satellite, authState, token } = t.context
-    client.shutdown() // such that satellite can't connect to Electric and will keep retrying
+    await client.shutdown() // such that satellite can't connect to Electric and will keep retrying
     const { connectionPromise } = await startSatellite(
       satellite,
       authState,


### PR DESCRIPTION
Currently if there is an unhandled exception in an event handler of asyncEventEmitter they are silenced and don't make it to a global error handler or console. This changes it to re-throw them async using `queueMicrotask` so that they happen outside of the promise awaited by `allSettled`.