### PR TITLE
fix(client): Better throttle snapshot stop strategy 

### DIFF
--- a/.changeset/red-insects-provide.md
+++ b/.changeset/red-insects-provide.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Better throttle snapshot stop strategy

--- a/clients/typescript/src/drivers/node-postgres/database.ts
+++ b/clients/typescript/src/drivers/node-postgres/database.ts
@@ -64,10 +64,6 @@ export async function createEmbeddedPostgres(
   // because it uniquely identifies the DB
   return {
     db,
-    stop: () => {
-      if (stopPromise) return stopPromise
-      stopPromise = pg.stop()
-      return stopPromise
-    },
+    stop: () => (stopPromise ??= pg.stop()),
   }
 }

--- a/clients/typescript/src/drivers/node-postgres/database.ts
+++ b/clients/typescript/src/drivers/node-postgres/database.ts
@@ -58,10 +58,16 @@ export async function createEmbeddedPostgres(
   const db = pg.getPgClient()
   await db.connect()
 
+  let stopPromise: Promise<void>
+
   // We use the database directory as the name
   // because it uniquely identifies the DB
   return {
     db,
-    stop: () => pg.stop(),
+    stop: () => {
+      if (stopPromise) return stopPromise
+      stopPromise = pg.stop()
+      return stopPromise
+    },
   }
 }

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -208,6 +208,8 @@ export class MockSatelliteClient
   transactionsCb?: TransactionCallback
   additionalDataCb?: AdditionalDataCallback
 
+  outboundStartedCallback?: OutboundStartedCallback
+
   relationData: Record<string, DataRecord[]> = {}
 
   deliverFirst = false
@@ -423,7 +425,7 @@ export class MockSatelliteClient
   }
 
   unsubscribeToTransactions(): void {
-    throw new Error('Method not implemented.')
+    this.transactionsCb = undefined
   }
 
   subscribeToAdditionalData(callback: AdditionalDataCallback): void {
@@ -431,7 +433,7 @@ export class MockSatelliteClient
   }
 
   unsubscribeToAdditionalData(_cb: AdditionalDataCallback): void {
-    throw new Error('Method not implemented.')
+    this.additionalDataCb = undefined
   }
 
   enqueueTransaction(transaction: DataTransaction): void {
@@ -448,10 +450,13 @@ export class MockSatelliteClient
 
   subscribeToOutboundStarted(callback: OutboundStartedCallback): void {
     this.on('outbound_started', callback)
+    this.outboundStartedCallback = callback
   }
 
   unsubscribeToOutboundStarted(): void {
-    throw new Error('Method not implemented.')
+    if (!this.outboundStartedCallback) return
+    this.removeListener('outbound_started', this.outboundStartedCallback)
+    this.outboundStartedCallback = undefined
   }
 
   sendErrorAfterTimeout(subscriptionId: string, timeout: number): void {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -132,7 +132,6 @@ export class SatelliteProcess implements Satellite {
   _pollingInterval?: any
   _unsubscribeFromPotentialDataChanges?: UnsubscribeFunction
   _throttledSnapshot: ThrottleFunction
-  _startProcessPromise?: Promise<void>
 
   _lsn?: LSN
 
@@ -210,12 +209,6 @@ export class SatelliteProcess implements Satellite {
   }
 
   async start(authConfig?: AuthConfig): Promise<void> {
-    this._startProcessPromise = this._startProcess(authConfig)
-    await this._startProcessPromise
-    this._startProcessPromise = undefined
-  }
-
-  private async _startProcess(authConfig?: AuthConfig): Promise<void> {
     if (this.opts.debug) {
       await this.logDatabaseVersion()
     }
@@ -380,13 +373,6 @@ export class SatelliteProcess implements Satellite {
   }
 
   private async _stop(shutdown?: boolean): Promise<void> {
-    // Wait for the start promise to finish first
-    // This would only happen if we stop the process too soon and the process
-    // hasn't finished starting yet
-    if (this._startProcessPromise) {
-      await Promise.allSettled([this._startProcessPromise])
-    }
-
     // Stop snapshot polling
     if (this._pollingInterval !== undefined) {
       clearInterval(this._pollingInterval)

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -261,6 +261,7 @@ export class SatelliteProcess implements Satellite {
       this.notifier.subscribeToPotentialDataChanges(this._throttledSnapshot)
 
     // Start polling to request a snapshot every `pollingInterval` ms.
+    clearInterval(this._pollingInterval)
     this._pollingInterval = setInterval(
       this._throttledSnapshot,
       this.opts.pollingInterval

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -318,7 +318,8 @@ export class SatelliteProcess implements Satellite {
     await this.adapter.runInTransaction(...stmtsWithTriggers)
   }
 
-  // Returns a function that removes the listeners
+  // Adds all the necessary listeners to the satellite client
+  // They can be cleared up by calling the function `_removeClientListeners`
   setClientListeners(): void {
     // Remove any existing listeners
     if (this._removeClientListeners) {

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -130,7 +130,7 @@ export class SatelliteProcess implements Satellite {
 
   _pollingInterval?: any
   _unsubscribeFromPotentialDataChanges?: UnsubscribeFunction
-  _throttledSnapshot: ThrottleFunction
+  _throttledSnapshot?: ThrottleFunction
 
   _lsn?: LSN
 
@@ -177,22 +177,14 @@ export class SatelliteProcess implements Satellite {
     this.subscriptions = new InMemorySubscriptionsManager(
       this._garbageCollectShapeHandler.bind(this)
     )
-    this._throttledSnapshot = throttle(
-      this._mutexSnapshot.bind(this),
-      opts.minSnapshotWindow,
-      {
-        leading: true,
-        trailing: true,
-      }
-    )
+    this._throttledSnapshot = this._createThrottledSnapshotFun()
+
     this.subscriptionNotifiers = {}
 
     this.subscriptionIdGenerator = () => genUUID()
     this.shapeRequestIdGenerator = this.subscriptionIdGenerator
 
     this._connectRetryHandler = connectRetryHandler
-
-    this.setClientListeners()
   }
 
   /**
@@ -211,6 +203,11 @@ export class SatelliteProcess implements Satellite {
     if (this.opts.debug) {
       await this.logDatabaseVersion()
     }
+
+    if (!this._throttledSnapshot) {
+      this._throttledSnapshot = this._createThrottledSnapshotFun()
+    }
+    this.setClientListeners()
 
     await this.migrator.up()
 
@@ -248,16 +245,18 @@ export class SatelliteProcess implements Satellite {
 
     // Request a snapshot whenever the data in our database potentially changes.
     this._unsubscribeFromPotentialDataChanges =
-      this.notifier.subscribeToPotentialDataChanges(this._throttledSnapshot)
+      this.notifier.subscribeToPotentialDataChanges(() =>
+        this._throttledSnapshot?.()
+      )
 
     // Start polling to request a snapshot every `pollingInterval` ms.
     this._pollingInterval = setInterval(
-      this._throttledSnapshot,
+      () => this._throttledSnapshot?.(),
       this.opts.pollingInterval
     )
 
     // Starting now!
-    await this._throttledSnapshot()
+    await this._throttledSnapshot?.()
 
     // Need to reload primary keys after schema migration
     this.relations = await this._getLocalRelations()
@@ -275,6 +274,17 @@ export class SatelliteProcess implements Satellite {
     if (subscriptionsState) {
       this.subscriptions.setState(subscriptionsState)
     }
+  }
+
+  private _createThrottledSnapshotFun(): ThrottleFunction {
+    return throttle(
+      this._mutexSnapshot.bind(this),
+      this.opts.minSnapshotWindow,
+      {
+        leading: true,
+        trailing: true,
+      }
+    )
   }
 
   private async logDatabaseVersion(): Promise<void> {
@@ -319,7 +329,7 @@ export class SatelliteProcess implements Satellite {
     this.client.subscribeToRelations(this._updateRelations.bind(this))
     this.client.subscribeToTransactions(this._applyTransaction.bind(this))
     this.client.subscribeToAdditionalData(this._applyAdditionalData.bind(this))
-    this.client.subscribeToOutboundStarted(this._throttledSnapshot.bind(this))
+    this.client.subscribeToOutboundStarted(() => this._throttledSnapshot?.())
 
     this.client.subscribeToSubscriptionEvents(
       this._handleSubscriptionData.bind(this),
@@ -334,7 +344,8 @@ export class SatelliteProcess implements Satellite {
 
   private async _stop(shutdown?: boolean): Promise<void> {
     // Stop snapshotting and polling for changes.
-    this._throttledSnapshot.cancel()
+    this._throttledSnapshot?.cancel()
+    this._throttledSnapshot = undefined
 
     // Ensure that no snapshot is left running in the background
     // by acquiring the mutex and releasing it immediately.

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -375,11 +375,8 @@ export class SatelliteProcess implements Satellite {
 
   private async _stop(shutdown?: boolean): Promise<void> {
     // Stop snapshot polling
-    if (this._pollingInterval !== undefined) {
-      clearInterval(this._pollingInterval)
-
-      this._pollingInterval = undefined
-    }
+    clearInterval(this._pollingInterval)
+    this._pollingInterval = undefined
 
     // Unsubscribe all listeners and remove them
     const unsubscribers = [

--- a/clients/typescript/test/satellite/process.timing.ts
+++ b/clients/typescript/test/satellite/process.timing.ts
@@ -33,13 +33,13 @@ export const processTimingTests = (test: TestFn<ContextType>) => {
 
     await satellite._setAuthState(authState)
 
-    await satellite._throttledSnapshot!()
+    await satellite._throttledSnapshot()
 
     const numNotifications = notifier.notifications.length
 
     const sql = `INSERT INTO parent(id) VALUES ('1'),('2')`
     await adapter.run({ sql })
-    await satellite._throttledSnapshot!()
+    await satellite._throttledSnapshot()
 
     t.is(notifier.notifications.length, numNotifications)
 

--- a/clients/typescript/test/satellite/process.timing.ts
+++ b/clients/typescript/test/satellite/process.timing.ts
@@ -33,13 +33,13 @@ export const processTimingTests = (test: TestFn<ContextType>) => {
 
     await satellite._setAuthState(authState)
 
-    await satellite._throttledSnapshot()
+    await satellite._throttledSnapshot!()
 
     const numNotifications = notifier.notifications.length
 
     const sql = `INSERT INTO parent(id) VALUES ('1'),('2')`
     await adapter.run({ sql })
-    await satellite._throttledSnapshot()
+    await satellite._throttledSnapshot!()
 
     t.is(notifier.notifications.length, numNotifications)
 

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -282,10 +282,10 @@ export const processTests = (test: TestFn<ContextType>) => {
     satellite.adapter.run = (stmt) =>
       new Promise((res) => setTimeout(() => run(stmt).then(res), 100))
 
-    const p1 = satellite._throttledSnapshot!()
+    const p1 = satellite._throttledSnapshot()
     const p2 = new Promise<Date>((res) => {
       // call snapshot after throttle time has expired
-      setTimeout(() => satellite._throttledSnapshot!()?.then(res), 50)
+      setTimeout(() => satellite._throttledSnapshot()?.then(res), 50)
     })
 
     await t.notThrowsAsync(async () => {

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -282,10 +282,10 @@ export const processTests = (test: TestFn<ContextType>) => {
     satellite.adapter.run = (stmt) =>
       new Promise((res) => setTimeout(() => run(stmt).then(res), 100))
 
-    const p1 = satellite._throttledSnapshot()
+    const p1 = satellite._throttledSnapshot!()
     const p2 = new Promise<Date>((res) => {
       // call snapshot after throttle time has expired
-      setTimeout(() => satellite._throttledSnapshot()?.then(res), 50)
+      setTimeout(() => satellite._throttledSnapshot!()?.then(res), 50)
     })
 
     await t.notThrowsAsync(async () => {

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -1565,16 +1565,17 @@ export const processTests = (test: TestFn<ContextType>) => {
     // we're expecting 2 assertions
     t.plan(4)
 
-    const unsubConnectivityChanges = notifier.subscribeToConnectivityStateChanges(
-      (notification: ConnectivityStateChangeNotification) => {        
-        t.is(notification.dbName, dbName)
-        t.is(notification.connectivityState.status, 'disconnected')
-        t.is(
-          notification.connectivityState.reason?.code,
-          SatelliteErrorCode.AUTH_EXPIRED
-        )
-      }
-    )
+    const unsubConnectivityChanges =
+      notifier.subscribeToConnectivityStateChanges(
+        (notification: ConnectivityStateChangeNotification) => {
+          t.is(notification.dbName, dbName)
+          t.is(notification.connectivityState.status, 'disconnected')
+          t.is(
+            notification.connectivityState.reason?.code,
+            SatelliteErrorCode.AUTH_EXPIRED
+          )
+        }
+      )
     t.teardown(unsubConnectivityChanges)
 
     // mock JWT expiration
@@ -2585,36 +2586,6 @@ export const processTests = (test: TestFn<ContextType>) => {
 
     // Wait for the snapshot to finish to consider the test successful
     await sleepAsync(1000)
-
-    t.pass()
-  })
-
-  test('wait for initial snapshot to end if stopping too soon', async (t) => {
-    const { adapter, runMigrations, satellite, authState, builder } = t.context
-
-    await runMigrations()
-
-    // Replace the snapshot function to simulate a slow snapshot
-    // that access the database after closing
-    satellite._performSnapshot = async () => {
-      try {
-        await sleepAsync(500)
-        await adapter.query(builder.getLocalTableNames())
-        return new Date()
-      } catch (e) {
-        t.fail()
-        throw e
-      }
-    }
-
-    const startPromise = satellite.start(authState)
-
-    await satellite.stop()
-
-    // Remove/close the database connection
-    await cleanAndStopDb(t)
-
-    await startPromise
 
     t.pass()
   })

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -39,7 +39,6 @@ import {
   relations,
   ContextType as CommonContextType,
   cleanAndStopDb,
-  cleanAndStopSatellite,
 } from './common'
 
 import { numberToBytes, base64, blobToHexString } from '../../src/util/encoders'

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -2603,7 +2603,7 @@ export const processTests = (test: TestFn<ContextType>) => {
     }
 
     const startPromise = satellite.start(authState)
-    
+
     await satellite.stop()
 
     // Remove/close the database connection

--- a/clients/typescript/test/satellite/sqlite/process.timing.test.ts
+++ b/clients/typescript/test/satellite/sqlite/process.timing.test.ts
@@ -1,9 +1,9 @@
 import anyTest, { TestFn } from 'ava'
 import { processTimingTests } from '../process.timing'
-import { makeContext, clean, ContextType } from '../common'
+import { makeContext, cleanAndStopDb, ContextType } from '../common'
 
 const test = anyTest as TestFn<ContextType>
 test.beforeEach(async (t) => makeContext(t, 'main'))
-test.afterEach.always(clean)
+test.afterEach.always(cleanAndStopDb)
 
 processTimingTests(test)


### PR DESCRIPTION
We've encountered a race condition that can occurr if, after cancelling the throttle when stopping the process, some other piece of code calls throttlesnapshot. That's because cancelling the throttle doesn't prevent from scheduling new ones.

The proposed solution is to assign undefined to the function, so places that would normally trigger a snapshot, like the poll interval, would just do nothing until properly closed.

On top of this, we found that `setClientListeners` is only called when instantiating the process, but it's cleaned up when calling `stop` with the `disconnect` function. This makes it so that stopping and then starting the process won't have some of the client listeners properly set up. The proposed solution is to just move the client listeners intialization to the `start` function.

I'm not sure how to test this. It would probably need some way to mock client events after a stop and a start.