### PR TITLE
fix: set `Postgrex` SSL mode based on the connection by `:epgsql`

### DIFF
--- a/.changeset/odd-bulldogs-move.md
+++ b/.changeset/odd-bulldogs-move.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+fix: set `Postgrex` SSL mode based on the connection by `:epgsql` to keep `sslmode=prefer` behaviour when `DATABASE_REQUIRE_SSL` is not `true`.


### PR DESCRIPTION
`Postgrex` connector doesn't support a behaviour equivalent to `sslmode=prefer` like `:epgsql` does, which we made use of when `DATABASE_REQUIRE_SSL=false`. To emulate support for that, after we make the first connection with `:epgsql`, we update the config to either force SSL or disable SSL based on how `:epgsql` connected.