### PR TITLE
fix(toolbar): Suppress warning for invalid annotation

### DIFF
--- a/components/toolbar/vite.config.ts
+++ b/components/toolbar/vite.config.ts
@@ -35,5 +35,18 @@ export default defineConfig({
       // the proper extensions will be added
       fileName: 'index',
     },
+    rollupOptions: {
+      onLog: (level, log, handler) => {
+        if (
+          log.code === 'INVALID_ANNOTATION' &&
+          log.message.includes('/*#__PURE__*/')
+        ) {
+          // ignore these, not critical but fails build
+          // https://github.com/vitejs/vite/issues/15100
+          return
+        }
+        handler(level, log)
+      },
+    },
   },
 })


### PR DESCRIPTION
Rollup removes invalid legacy annotations - they are warnings not errors but they fail the build so suppressing them should work for now.