### PR TITLE
chore(toolbar): Remove sourcemap files from published package

### DIFF
--- a/.changeset/sharp-dragons-design.md
+++ b/.changeset/sharp-dragons-design.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/debug-toolbar": patch
+---
+
+Remove source map files from npm package

--- a/components/toolbar/package.json
+++ b/components/toolbar/package.json
@@ -54,6 +54,7 @@
     "electric-sql": "workspace:*"
   },
   "files": [
-    "dist"
+    "dist",
+    "!*.map"
   ]
 }


### PR DESCRIPTION
Removing sourcemap files from published package after a discussion with @balegas - will reduce the package size on NPM significantly, if anyone wants to debug the toolbar they can do that on the project directly.