### PR TITLE
fix(client): Make the throttle skip a snapshot if one is already running

### DIFF
--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -181,7 +181,7 @@ export class SatelliteProcess implements Satellite {
       this._garbageCollectShapeHandler.bind(this)
     )
     this._throttledSnapshot = throttle(
-      this._mutexSnapshot.bind(this),
+      this._onSnapshotThrottleTick.bind(this),
       opts.minSnapshotWindow,
       {
         leading: true,
@@ -194,6 +194,13 @@ export class SatelliteProcess implements Satellite {
     this.shapeRequestIdGenerator = this.subscriptionIdGenerator
 
     this._connectRetryHandler = connectRetryHandler
+  }
+
+  _onSnapshotThrottleTick() {
+    if (this.snapshotMutex.isLocked()) {
+      return
+    }
+    return this._mutexSnapshot()
   }
 
   /**

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -229,12 +229,12 @@ export const processTests = (test: TestFn<ContextType>) => {
 
     await adapter.run({ sql: `INSERT INTO parent(id) VALUES ('1'),('2')` })
 
-    let snapshotTimestamp = await satellite._performSnapshot()
+    const snapshotTimestamp = await satellite._performSnapshot()
 
     const clientId = satellite._authState!.clientId
-    let shadowTags = encodeTags([generateTag(clientId, snapshotTimestamp)])
+    const shadowTags = encodeTags([generateTag(clientId, snapshotTimestamp)])
 
-    var shadowRows = await adapter.query({
+    const shadowRows = await adapter.query({
       sql: `SELECT tags FROM _electric_shadow`,
     })
     t.is(shadowRows.length, 2)
@@ -293,7 +293,7 @@ export const processTests = (test: TestFn<ContextType>) => {
     const p1 = satellite._throttledSnapshot()
     const p2 = new Promise<Date>((res) => {
       // call snapshot after throttle time has expired
-      setTimeout(() => satellite._throttledSnapshot()?.then(res), 50)
+      setTimeout(() => satellite._throttledSnapshot()?.then((r) => res(r!)), 50)
     })
 
     await t.notThrowsAsync(async () => {

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -2595,29 +2595,39 @@ export const processTests = (test: TestFn<ContextType>) => {
 
     await runMigrations()
 
+    // Shouldn't do more than this number of snapshots. Because we are mocking a slow snaphot
+    // and the polling interval shouldn't schedule snapshots if one is running already, this is a
+    // reasonable number. If snapshots were added to the queue, this number would be higher,
+    // approximately the scheduled polls (6-7)
+    const maxSnapshots = 2
+
+    let shouldCountSnapshots = false
+    let snapshotsCount = 0
+
     // Replace the snapshot function to simulate a slow snapshot
     satellite._performSnapshot = async () => {
+      if (!shouldCountSnapshots) return new Date()
       await sleepAsync(2000)
+      snapshotsCount++
       return new Date()
     }
 
     const conn = await startSatellite(satellite, authState, token)
     await conn.connectionPromise
 
-    const startMs = new Date().getTime()
+    shouldCountSnapshots = true
+
     // Let the process poll multiple times
-    await sleepAsync(opts.pollingInterval * 3)
+    await sleepAsync(opts.pollingInterval * 6)
 
     await satellite.stop()
-    const endMs = new Date().getTime()
-    const ellapsedMs = endMs - startMs
 
-    // Shouldn't take more than 2 + 1 second. If snapshots were added to the queue,
-    // it would be much longer, because while a snapshot is running, the poll would
-    // be scheduling new ones
-    t.assert(ellapsedMs < 3000)
-
-    await cleanAndStopDb(t)
+    // Fail if an unexpected number of snapshots were taken
+    if (snapshotsCount > maxSnapshots) {
+      t.fail(
+        `Too many snapshots: ${snapshotsCount}, expected <= ${maxSnapshots}`
+      )
+    }
 
     t.pass()
   })


### PR DESCRIPTION
This is a behavior we've seen when creating the test for the last PR (#1251). If you add a log to the mock snapshot function, you will see that when stopping, the process waits for a large amount of snapshots to finish before stopping completely.
This is because when polling, they are added to a queue due to the snapshot mutex. 

Is this intentional? Or should the throttle just skip the call if the lock is taken?

cc @kevin-dp @msfstef 