### PR TITLE
fix(toolbar): Guard against adding toolbar to DOM twice

### DIFF
--- a/.changeset/polite-donkeys-reflect.md
+++ b/.changeset/polite-donkeys-reflect.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/debug-toolbar": patch
+---
+
+Guard against adding toolbar to DOM twice

--- a/components/toolbar/src/index.tsx
+++ b/components/toolbar/src/index.tsx
@@ -103,6 +103,13 @@ export function clientApi(registry: GlobalRegistry | Registry) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function addToolbar(electric: ElectricClient<any>) {
+  if (document.getElementById(TOOLBAR_CONTAINER_ID)) {
+    console.warn(
+      '[@electric-sql/debug-toolbar] Toolbar has already been added.',
+    )
+    return
+  }
+
   const toolbarApi = clientApi(electric.registry)
 
   const containerDiv = document.createElement('div')


### PR DESCRIPTION
Checks whether container element has already been added before proceeding to add toolbar.

With React's `StrictMode` and other cases the `addToolbar` call might occur twice, handling it with a warning I believe is better than letting it add a broken DOM element.