### PR TITLE
feat (client): flag to disable FKs on incoming TXs in SQLite

### DIFF
--- a/.changeset/clean-singers-eat.md
+++ b/.changeset/clean-singers-eat.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Flag to disable FKs checks on incoming TXs in SQLite.

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -66,7 +66,7 @@ export type HydratedConfig = {
   debug: boolean
   connectionBackOffOptions: ConnectionBackOffOptions
   namespace: string
-  disableFKs: boolean
+  disableFKs: boolean | undefined
 }
 
 export type InternalElectricConfig = {
@@ -88,7 +88,6 @@ export const hydrateConfig = (
   const auth = config.auth ?? {}
 
   const debug = config.debug ?? false
-  const disableFKs = config.disableFKs ?? false
   const url = new URL(config.url ?? 'http://localhost:5133')
 
   const isSecureProtocol = url.protocol === 'https:' || url.protocol === 'wss:'
@@ -134,6 +133,6 @@ export const hydrateConfig = (
     debug,
     connectionBackOffOptions,
     namespace: defaultNamespace,
-    disableFKs,
+    disableFKs: config.disableFKs,
   }
 }

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -43,10 +43,10 @@ export interface ElectricConfig {
    */
   connectionBackOffOptions?: ConnectionBackOffOptions
   /**
-   * Whether to disable FK checks when applying incoming (i.e. remote) transactions to the local SQLite database.
+   * Whether to disable FK checks when applying downstream (i.e. incoming) transactions to the local SQLite database.
    * When using Postgres, this is the default behavior and can't be changed.
    */
-  disableFKs?: boolean
+  disableForeignKeysDownstream?: boolean
 }
 
 export type ElectricConfigWithDialect = ElectricConfig & {
@@ -133,6 +133,6 @@ export const hydrateConfig = (
     debug,
     connectionBackOffOptions,
     namespace: defaultNamespace,
-    disableFKs: config.disableFKs,
+    disableFKs: config.disableForeignKeysDownstream,
   }
 }

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -42,6 +42,8 @@ export interface ElectricConfig {
    * Optional backoff options for connecting with Electric
    */
   connectionBackOffOptions?: ConnectionBackOffOptions
+  /** Whether to disable FK checks when applying incoming (i.e. remote) transactions. */
+  disableFKs?: boolean
 }
 
 export type ElectricConfigWithDialect = ElectricConfig & {
@@ -61,6 +63,7 @@ export type HydratedConfig = {
   debug: boolean
   connectionBackOffOptions: ConnectionBackOffOptions
   namespace: string
+  disableFKs: boolean
 }
 
 export type InternalElectricConfig = {
@@ -73,6 +76,7 @@ export type InternalElectricConfig = {
   }
   debug?: boolean
   connectionBackOffOptions?: ConnectionBackOffOptions
+  disableFKs?: boolean
 }
 
 export const hydrateConfig = (
@@ -81,6 +85,7 @@ export const hydrateConfig = (
   const auth = config.auth ?? {}
 
   const debug = config.debug ?? false
+  const disableFKs = config.disableFKs ?? false
   const url = new URL(config.url ?? 'http://localhost:5133')
 
   const isSecureProtocol = url.protocol === 'https:' || url.protocol === 'wss:'
@@ -126,5 +131,6 @@ export const hydrateConfig = (
     debug,
     connectionBackOffOptions,
     namespace: defaultNamespace,
+    disableFKs,
   }
 }

--- a/clients/typescript/src/config/index.ts
+++ b/clients/typescript/src/config/index.ts
@@ -42,7 +42,10 @@ export interface ElectricConfig {
    * Optional backoff options for connecting with Electric
    */
   connectionBackOffOptions?: ConnectionBackOffOptions
-  /** Whether to disable FK checks when applying incoming (i.e. remote) transactions. */
+  /**
+   * Whether to disable FK checks when applying incoming (i.e. remote) transactions to the local SQLite database.
+   * When using Postgres, this is the default behavior and can't be changed.
+   */
   disableFKs?: boolean
 }
 

--- a/clients/typescript/src/drivers/better-sqlite3/adapter.ts
+++ b/clients/typescript/src/drivers/better-sqlite3/adapter.ts
@@ -76,9 +76,9 @@ export class DatabaseAdapter
     return stmt.all(...wrapBindParams(args))
   }
 
-  async _group(
-    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<void> | void
-  ): Promise<void> {
+  async _group<T>(
+    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
+  ): Promise<T> {
     // We create an adapter that does not go through the mutex
     // when used by the function`f`, since we already take the mutex here
     const adapter = {
@@ -117,9 +117,9 @@ export class DatabaseAdapter
     })
   }
 
-  async group(
-    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<void> | void
-  ): Promise<void> {
+  async group<T>(
+    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
+  ): Promise<T> {
     return this.txMutex.runExclusive(() => {
       return this._group(f)
     })

--- a/clients/typescript/src/drivers/better-sqlite3/adapter.ts
+++ b/clients/typescript/src/drivers/better-sqlite3/adapter.ts
@@ -86,7 +86,6 @@ export class DatabaseAdapter
       query: this._query.bind(this),
       transaction: this._transaction.bind(this),
       runInTransaction: this._runInTransaction.bind(this),
-      group: this._group.bind(this),
     }
     return f(adapter)
   }

--- a/clients/typescript/src/drivers/better-sqlite3/adapter.ts
+++ b/clients/typescript/src/drivers/better-sqlite3/adapter.ts
@@ -76,7 +76,7 @@ export class DatabaseAdapter
     return stmt.all(...wrapBindParams(args))
   }
 
-  async _group<T>(
+  async _runExclusively<T>(
     f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
   ): Promise<T> {
     // We create an adapter that does not go through the mutex
@@ -116,11 +116,11 @@ export class DatabaseAdapter
     })
   }
 
-  async group<T>(
+  async runExclusively<T>(
     f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
   ): Promise<T> {
     return this.txMutex.runExclusive(() => {
-      return this._group(f)
+      return this._runExclusively(f)
     })
   }
 }

--- a/clients/typescript/src/drivers/generic/adapter.ts
+++ b/clients/typescript/src/drivers/generic/adapter.ts
@@ -112,7 +112,6 @@ abstract class DatabaseAdapter
       query: this._query.bind(this),
       transaction: this._transaction.bind(this),
       runInTransaction: this._runInTransaction.bind(this),
-      group: this._group.bind(this),
     }
     return await f(adapter)
   }

--- a/clients/typescript/src/drivers/generic/adapter.ts
+++ b/clients/typescript/src/drivers/generic/adapter.ts
@@ -102,9 +102,9 @@ abstract class DatabaseAdapter
     })
   }
 
-  async _group(
-    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<void> | void
-  ): Promise<void> {
+  async _group<T>(
+    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
+  ): Promise<T> {
     // We create an adapter that does not go through the mutex
     // when used by the function`f`, since we already take the mutex here
     const adapter = {
@@ -117,9 +117,9 @@ abstract class DatabaseAdapter
     return await f(adapter)
   }
 
-  group(
-    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<void> | void
-  ): Promise<void> {
+  group<T>(
+    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
+  ): Promise<T> {
     return this.txMutex.runExclusive(() => {
       return this._group(f)
     })

--- a/clients/typescript/src/drivers/generic/adapter.ts
+++ b/clients/typescript/src/drivers/generic/adapter.ts
@@ -102,7 +102,7 @@ abstract class DatabaseAdapter
     })
   }
 
-  async _group<T>(
+  async _runExclusively<T>(
     f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
   ): Promise<T> {
     // We create an adapter that does not go through the mutex
@@ -116,11 +116,11 @@ abstract class DatabaseAdapter
     return await f(adapter)
   }
 
-  group<T>(
+  runExclusively<T>(
     f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
   ): Promise<T> {
     return this.txMutex.runExclusive(() => {
-      return this._group(f)
+      return this._runExclusively(f)
     })
   }
 

--- a/clients/typescript/src/drivers/generic/adapter.ts
+++ b/clients/typescript/src/drivers/generic/adapter.ts
@@ -3,6 +3,7 @@ import {
   RunResult,
   TableNameImpl,
   Transaction as Tx,
+  UncoordinatedDatabaseAdapter,
 } from '../../electric/adapter'
 import { Row, Statement } from '../../util'
 import { Mutex } from 'async-mutex'
@@ -42,19 +43,12 @@ abstract class DatabaseAdapter
   /**
    * @param statements A list of SQL statements to execute against the DB.
    */
-  abstract runInTransaction(...statements: Statement[]): Promise<RunResult>
+  abstract _runInTransaction(...statements: Statement[]): Promise<RunResult>
 
-  async transaction<T>(
+  async _transaction<T>(
     f: (_tx: Tx, setResult: (res: T) => void) => void
   ): Promise<T> {
-    const release = await this.txMutex.acquire()
-
-    try {
-      await this._run({ sql: 'BEGIN' })
-    } catch (e) {
-      release()
-      throw e
-    }
+    await this._run({ sql: 'BEGIN' })
 
     return new Promise<T>((resolve, reject) => {
       const tx = new Transaction(this, reject)
@@ -64,22 +58,26 @@ abstract class DatabaseAdapter
         // This assumes that the user does not execute any more queries after setting the result.
         this._run({ sql: 'COMMIT' })
           .then(() => {
-            // Release early if commit succeeded
-            release()
             resolve(res)
           })
           // Failed to commit
           .catch(reject)
       })
-    })
-      .catch((err) => {
-        // something went wrong
-        // let's roll back and rethrow
-        return this._run({ sql: 'ROLLBACK' }).then(() => {
-          throw err
-        })
+    }).catch((err) => {
+      // something went wrong
+      // let's roll back and rethrow
+      return this._run({ sql: 'ROLLBACK' }).then(() => {
+        throw err
       })
-      .finally(release)
+    })
+  }
+
+  async transaction<T>(
+    f: (_tx: Tx, setResult: (res: T) => void) => void
+  ): Promise<T> {
+    return this.txMutex.runExclusive(() => {
+      return this._transaction(f)
+    })
   }
 
   run(stmt: Statement): Promise<RunResult> {
@@ -95,6 +93,35 @@ abstract class DatabaseAdapter
     // Because that would make the query part of the transaction which was not the intention.
     return this.txMutex.runExclusive(() => {
       return this._query(stmt)
+    })
+  }
+
+  runInTransaction(...statements: Statement[]): Promise<RunResult> {
+    return this.txMutex.runExclusive(() => {
+      return this._runInTransaction(...statements)
+    })
+  }
+
+  async _group(
+    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<void> | void
+  ): Promise<void> {
+    // We create an adapter that does not go through the mutex
+    // when used by the function`f`, since we already take the mutex here
+    const adapter = {
+      run: this._run.bind(this),
+      query: this._query.bind(this),
+      transaction: this._transaction.bind(this),
+      runInTransaction: this._runInTransaction.bind(this),
+      group: this._group.bind(this),
+    }
+    return await f(adapter)
+  }
+
+  group(
+    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<void> | void
+  ): Promise<void> {
+    return this.txMutex.runExclusive(() => {
+      return this._group(f)
     })
   }
 
@@ -118,11 +145,8 @@ export abstract class BatchDatabaseAdapter
    */
   abstract execBatch(statements: Statement[]): Promise<RunResult>
 
-  async runInTransaction(...statements: Statement[]): Promise<RunResult> {
-    // Uses a mutex to ensure that transactions are not interleaved.
-    return this.txMutex.runExclusive(() => {
-      return this.execBatch(statements)
-    })
+  async _runInTransaction(...statements: Statement[]): Promise<RunResult> {
+    return this.execBatch(statements)
   }
 }
 
@@ -135,9 +159,7 @@ export abstract class SerialDatabaseAdapter
   implements DatabaseAdapterInterface
 {
   abstract readonly defaultNamespace: 'main' | 'public'
-  async runInTransaction(...statements: Statement[]): Promise<RunResult> {
-    // Uses a mutex to ensure that transactions are not interleaved.
-    const release = await this.txMutex.acquire()
+  async _runInTransaction(...statements: Statement[]): Promise<RunResult> {
     let transactionBegan = false
     let rowsAffected = 0
     try {
@@ -156,8 +178,6 @@ export abstract class SerialDatabaseAdapter
         await this._run({ sql: 'ROLLBACK' })
       }
       throw error // rejects the promise with the reason for the rollback
-    } finally {
-      release()
     }
   }
 }

--- a/clients/typescript/src/electric/adapter.ts
+++ b/clients/typescript/src/electric/adapter.ts
@@ -47,9 +47,9 @@ export interface DatabaseAdapter {
    * This snippet above ensures that no other query/transaction will be interleaved when the foreign keys are disabled.
    * @param f Function that is guaranteed to be executed in isolation from other queries/transactions executed by this adapter.
    */
-  group(
-    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<void> | void
-  ): Promise<void>
+  group<T>(
+    f: (adapter: UncoordinatedDatabaseAdapter) => Promise<T> | T
+  ): Promise<T>
 
   // Get the tables potentially used by the query (so that we
   // can re-query if the data in them changes).

--- a/clients/typescript/src/electric/adapter.ts
+++ b/clients/typescript/src/electric/adapter.ts
@@ -4,7 +4,7 @@ import { parseTableNames } from '../util'
 
 export type UncoordinatedDatabaseAdapter = Pick<
   DatabaseAdapter,
-  'run' | 'query' | 'runInTransaction' | 'transaction' | 'group'
+  'run' | 'query' | 'runInTransaction' | 'transaction'
 >
 
 // A `DatabaseAdapter` adapts a database client to provide the

--- a/clients/typescript/src/migrators/bundle.ts
+++ b/clients/typescript/src/migrators/bundle.ts
@@ -133,7 +133,7 @@ export abstract class BundleMigratorBase implements Migrator {
 
   async apply(
     { statements, version }: StmtMigration,
-    disableFKs = false
+    disableFKs?: boolean
   ): Promise<void> {
     if (!VALID_VERSION_EXP.test(version)) {
       throw new Error(
@@ -160,7 +160,7 @@ export abstract class BundleMigratorBase implements Migrator {
    */
   async applyIfNotAlready(
     migration: StmtMigration,
-    disableFKs: boolean
+    disableFKs: boolean | undefined
   ): Promise<boolean> {
     const rows = await this.adapter.query({
       sql: dedent`

--- a/clients/typescript/src/migrators/bundle.ts
+++ b/clients/typescript/src/migrators/bundle.ts
@@ -12,6 +12,7 @@ import { QualifiedTablename, SatelliteError, SatelliteErrorCode } from '../util'
 import { _electric_migrations } from '../satellite/config'
 import { pgBuilder, QueryBuilder, sqliteBuilder } from './query-builder'
 import { dedent } from 'ts-dedent'
+import { runInTransaction } from '../util/transactions'
 
 export const SCHEMA_VSN_ERROR_MSG = `Local schema doesn't match server's. Clear local state through developer tools and retry connection manually. If error persists, re-generate the client. Check documentation (https://electric-sql.com/docs/reference/roadmap) to learn more.`
 
@@ -130,14 +131,17 @@ export abstract class BundleMigratorBase implements Migrator {
     return migrations.slice(existingPrefix.length)
   }
 
-  async apply({ statements, version }: StmtMigration): Promise<void> {
+  async apply(
+    { statements, version }: StmtMigration,
+    disableFKs = false
+  ): Promise<void> {
     if (!VALID_VERSION_EXP.test(version)) {
       throw new Error(
         `Invalid migration version, must match ${VALID_VERSION_EXP}`
       )
     }
 
-    await this.adapter.runInTransaction(...statements, {
+    await runInTransaction(this.adapter, disableFKs, ...statements, {
       sql: dedent`
         INSERT INTO ${this.migrationsTable} (version, applied_at)
         VALUES (${this.queryBuilder.makePositionalParam(
@@ -154,7 +158,10 @@ export abstract class BundleMigratorBase implements Migrator {
    * @returns A promise that resolves to a boolean
    *          that indicates if the migration was applied.
    */
-  async applyIfNotAlready(migration: StmtMigration): Promise<boolean> {
+  async applyIfNotAlready(
+    migration: StmtMigration,
+    disableFKs: boolean
+  ): Promise<boolean> {
     const rows = await this.adapter.query({
       sql: dedent`
         SELECT 1 FROM ${this.migrationsTable}
@@ -168,7 +175,7 @@ export abstract class BundleMigratorBase implements Migrator {
     if (shouldApply) {
       // This is a new migration because its version number
       // is not in our migrations table.
-      await this.apply(migration)
+      await this.apply(migration, disableFKs)
     }
 
     return shouldApply

--- a/clients/typescript/src/migrators/index.ts
+++ b/clients/typescript/src/migrators/index.ts
@@ -29,10 +29,10 @@ export function makeStmtMigration(migration: Migration): StmtMigration {
 
 export interface Migrator {
   up(): Promise<number>
-  apply(migration: StmtMigration): Promise<void>
+  apply(migration: StmtMigration, disableFKs?: boolean): Promise<void>
   applyIfNotAlready(
     migration: StmtMigration,
-    disableFKs: boolean
+    disableFKs: boolean | undefined
   ): Promise<boolean>
   querySchemaVersion(): Promise<string | undefined>
   queryBuilder: QueryBuilder

--- a/clients/typescript/src/migrators/index.ts
+++ b/clients/typescript/src/migrators/index.ts
@@ -30,7 +30,10 @@ export function makeStmtMigration(migration: Migration): StmtMigration {
 export interface Migrator {
   up(): Promise<number>
   apply(migration: StmtMigration): Promise<void>
-  applyIfNotAlready(migration: StmtMigration): Promise<boolean>
+  applyIfNotAlready(
+    migration: StmtMigration,
+    disableFKs: boolean
+  ): Promise<boolean>
   querySchemaVersion(): Promise<string | undefined>
   queryBuilder: QueryBuilder
 }

--- a/clients/typescript/src/migrators/mock.ts
+++ b/clients/typescript/src/migrators/mock.ts
@@ -8,13 +8,13 @@ export class MockMigrator implements Migrator {
     return 1
   }
 
-  async apply(_: StmtMigration): Promise<void> {
+  async apply(_: StmtMigration, _disableFks?: boolean): Promise<void> {
     return
   }
 
   async applyIfNotAlready(
     _: StmtMigration,
-    _disableFks: boolean
+    _disableFks: boolean | undefined
   ): Promise<boolean> {
     return true
   }

--- a/clients/typescript/src/migrators/mock.ts
+++ b/clients/typescript/src/migrators/mock.ts
@@ -12,7 +12,10 @@ export class MockMigrator implements Migrator {
     return
   }
 
-  async applyIfNotAlready(_: StmtMigration): Promise<boolean> {
+  async applyIfNotAlready(
+    _: StmtMigration,
+    _disableFks: boolean
+  ): Promise<boolean> {
     return true
   }
 

--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -27,8 +27,9 @@ export interface SatelliteOpts {
   /**
    * Whether to disable FK checks when applying incoming (i.e. remote) transactions to the local SQLite database.
    * When using Postgres, this is the default behavior and can't be changed.
+   * If this flag is undefined and we're running on SQLite, then the FK pragma is left untouched.
    */
-  disableFKs: boolean
+  disableFKs: boolean | undefined
   /** With debug mode enabled, Satellite can show additional logs. */
   debug: boolean
 }
@@ -75,7 +76,7 @@ export const satelliteDefaults: (namespace: string) => SatelliteOpts = (
       numOfAttempts: 50,
       timeMultiple: 2,
     },
-    disableFKs: false,
+    disableFKs: undefined,
     debug: false,
   }
 }

--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -24,7 +24,10 @@ export interface SatelliteOpts {
   clearOnBehindWindow: boolean
   /** Backoff options for connecting with Electric*/
   connectionBackOffOptions: ConnectionBackoffOptions
-  /** Whether to disable FK checks when applying incoming (i.e. remote) transactions. */
+  /**
+   * Whether to disable FK checks when applying incoming (i.e. remote) transactions to the local SQLite database.
+   * When using Postgres, this is the default behavior and can't be changed.
+   */
   disableFKs: boolean
   /** With debug mode enabled, Satellite can show additional logs. */
   debug: boolean

--- a/clients/typescript/src/satellite/config.ts
+++ b/clients/typescript/src/satellite/config.ts
@@ -20,10 +20,12 @@ export interface SatelliteOpts {
   pollingInterval: number
   /** Throttle snapshotting to once per `minSnapshotWindow` milliseconds. */
   minSnapshotWindow: number
-  /** On reconnect, clear client's state if cannot catch up with Electric buffered WAL*/
+  /** On reconnect, clear client's state if cannot catch up with Electric buffered WAL */
   clearOnBehindWindow: boolean
   /** Backoff options for connecting with Electric*/
   connectionBackOffOptions: ConnectionBackoffOptions
+  /** Whether to disable FK checks when applying incoming (i.e. remote) transactions. */
+  disableFKs: boolean
   /** With debug mode enabled, Satellite can show additional logs. */
   debug: boolean
 }
@@ -70,6 +72,7 @@ export const satelliteDefaults: (namespace: string) => SatelliteOpts = (
       numOfAttempts: 50,
       timeMultiple: 2,
     },
+    disableFKs: false,
     debug: false,
   }
 }

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -125,7 +125,7 @@ export class SatelliteProcess implements Satellite {
   builder: QueryBuilder
 
   opts: SatelliteOpts
-  disableFKs: boolean
+  disableFKs: boolean | undefined
 
   _authState?: AuthState
   _unsubscribeFromAuthState?: UnsubscribeFunction
@@ -175,7 +175,8 @@ export class SatelliteProcess implements Satellite {
     this.builder = this.migrator.queryBuilder
 
     this.opts = opts
-    this.disableFKs = this.builder.dialect === 'SQLite' && this.opts.disableFKs
+    this.disableFKs =
+      this.builder.dialect === 'SQLite' ? this.opts.disableFKs : undefined
     this.relations = {}
 
     this.previousShapeSubscriptions = []

--- a/clients/typescript/src/satellite/registry.ts
+++ b/clients/typescript/src/satellite/registry.ts
@@ -220,6 +220,7 @@ export class GlobalRegistry extends BaseRegistry {
     const satelliteOpts: SatelliteOpts = {
       ...satelliteDefaults(config.namespace),
       connectionBackOffOptions: config.connectionBackOffOptions,
+      disableFKs: config.disableFKs,
       debug: config.debug,
     }
 

--- a/clients/typescript/src/util/transactions.ts
+++ b/clients/typescript/src/util/transactions.ts
@@ -20,7 +20,7 @@ export async function runInTransaction(
 
   const desiredPragma = disableFKs ? 0 : 1
 
-  return adapter.group(async (uncoordinatedAdapter) => {
+  return adapter.runExclusively(async (uncoordinatedAdapter) => {
     const [{ foreign_keys: originalPragma }] = await uncoordinatedAdapter.query(
       {
         sql: 'PRAGMA foreign_keys;',

--- a/clients/typescript/src/util/transactions.ts
+++ b/clients/typescript/src/util/transactions.ts
@@ -3,37 +3,49 @@ import { DatabaseAdapter, RunResult } from '../electric'
 
 /**
  * Runs the provided statements in a transaction and disables FK checks if `disableFKs` is true.
+ * FK checks are enabled if `disableFKs` is false.
+ * FK checks are left untouched if `disableFKs` is undefined.
  * `disableFKs` should only be set to true when using SQLite as we already disable FK checks for incoming TXs when using Postgres,
  * so the executed SQL code to disable FKs is for SQLite dialect only.
- * @param adapter
- * @param disableFKs
- * @param stmts
- * @returns
  */
 export async function runInTransaction(
   adapter: DatabaseAdapter,
-  disableFKs: boolean,
+  disableFKs: boolean | undefined,
   ...stmts: Statement[]
 ): Promise<RunResult> {
+  if (disableFKs === undefined) {
+    // don't touch the FK pragma
+    return adapter.runInTransaction(...stmts)
+  }
+
+  const desiredPragma = disableFKs ? 0 : 1
+
   return adapter.group(async (uncoordinatedAdapter) => {
-    let enableFKs = false
-    if (disableFKs) {
-      // Check if FKs are enabled
-      const [{ foreign_keys }] = await uncoordinatedAdapter.query({
+    const [{ foreign_keys: originalPragma }] = await uncoordinatedAdapter.query(
+      {
         sql: 'PRAGMA foreign_keys;',
+      }
+    )
+
+    if (originalPragma !== desiredPragma) {
+      // set the pragma to the desired value
+      await uncoordinatedAdapter.run({
+        sql: `PRAGMA foreign_keys = ${desiredPragma};`,
       })
-      if (foreign_keys === 1) {
-        // Disable FKs
-        await uncoordinatedAdapter.run({ sql: 'PRAGMA foreign_keys = OFF;' })
-        // Remember to enable FKs after TX
-        enableFKs = foreign_keys === 1
+    }
+
+    try {
+      // apply the statements in a TX
+      const res = await uncoordinatedAdapter.runInTransaction(...stmts)
+      return res
+    } finally {
+      // TX throwed, need to restore the pragma
+      if (originalPragma !== desiredPragma) {
+        // restore the pragma to its original value
+        await uncoordinatedAdapter.run({
+          sql: `PRAGMA foreign_keys = ${originalPragma};`,
+        })
       }
     }
-    const res = await uncoordinatedAdapter.runInTransaction(...stmts)
-    if (enableFKs) {
-      // re-enable FKs
-      await uncoordinatedAdapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
-    }
-    return res
   })
 }

--- a/clients/typescript/src/util/transactions.ts
+++ b/clients/typescript/src/util/transactions.ts
@@ -39,7 +39,7 @@ export async function runInTransaction(
       const res = await uncoordinatedAdapter.runInTransaction(...stmts)
       return res
     } finally {
-      // TX throwed, need to restore the pragma
+      // Need to restore the pragma also if TX throwed
       if (originalPragma !== desiredPragma) {
         // restore the pragma to its original value
         await uncoordinatedAdapter.run({

--- a/clients/typescript/src/util/transactions.ts
+++ b/clients/typescript/src/util/transactions.ts
@@ -1,0 +1,39 @@
+import { Statement } from '.'
+import { DatabaseAdapter, RunResult } from '../electric'
+
+/**
+ * Runs the provided statements in a transaction and disables FK checks if `disableFKs` is true.
+ * `disableFKs` should only be set to true when using SQLite as we already disable FK checks for incoming TXs when using Postgres,
+ * so the executed SQL code to disable FKs is for SQLite dialect only.
+ * @param adapter
+ * @param disableFKs
+ * @param stmts
+ * @returns
+ */
+export async function runInTransaction(
+  adapter: DatabaseAdapter,
+  disableFKs: boolean,
+  ...stmts: Statement[]
+): Promise<RunResult> {
+  return adapter.group(async (uncoordinatedAdapter) => {
+    let enableFKs = false
+    if (disableFKs) {
+      // Check if FKs are enabled
+      const [{ foreign_keys }] = await uncoordinatedAdapter.query({
+        sql: 'PRAGMA foreign_keys;',
+      })
+      if (foreign_keys === 1) {
+        // Disable FKs
+        await uncoordinatedAdapter.run({ sql: 'PRAGMA foreign_keys = OFF;' })
+        // Remember to enable FKs after TX
+        enableFKs = foreign_keys === 1
+      }
+    }
+    const res = await uncoordinatedAdapter.runInTransaction(...stmts)
+    if (enableFKs) {
+      // re-enable FKs
+      await uncoordinatedAdapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
+    }
+    return res
+  })
+}

--- a/clients/typescript/test/drivers/better-sqlite3.test.ts
+++ b/clients/typescript/test/drivers/better-sqlite3.test.ts
@@ -189,7 +189,7 @@ test('adapter isolates grouped queries from other queries/transactions', async (
     return 7
   }
 
-  const prom1 = adapter.group(slowQuery)
+  const prom1 = adapter.runExclusively(slowQuery)
   const prom2 = adapter.transaction(async (_tx, setResult) => {
     t.true(query1Finished)
     setResult(5)

--- a/clients/typescript/test/drivers/better-sqlite3.test.ts
+++ b/clients/typescript/test/drivers/better-sqlite3.test.ts
@@ -5,6 +5,7 @@ import Database from 'better-sqlite3'
 import { DatabaseAdapter } from '../../src/drivers/better-sqlite3/adapter'
 import { MockDatabase } from '../../src/drivers/better-sqlite3/mock'
 import { QualifiedTablename } from '../../src/util/tablename'
+import { UncoordinatedDatabaseAdapter } from '../../src/electric'
 
 test('database adapter run works', async (t) => {
   const db = new MockDatabase('test.db')
@@ -173,4 +174,25 @@ test('adapter rolls back dependent queries on conflict', async (t) => {
     const res = await adapter.query({ sql: selectAll })
     t.deepEqual(res, [])
   }
+})
+
+test('adapter isolates grouped queries from other queries/transactions', async (t) => {
+  const adapter = await makeAdapter()
+
+  let query1Finished = false
+
+  // Make a slow grouped query and check that it is not interleaved with other queries/transactions
+  const slowQuery = async (adapter: UncoordinatedDatabaseAdapter) => {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    await adapter.query({ sql: 'SELECT 1' })
+    query1Finished = true
+  }
+
+  const prom1 = adapter.group(slowQuery)
+  const prom2 = adapter.transaction(async (_tx, setResult) => {
+    t.true(query1Finished)
+    setResult(5)
+  })
+
+  return Promise.all([prom1, prom2])
 })

--- a/clients/typescript/test/drivers/better-sqlite3.test.ts
+++ b/clients/typescript/test/drivers/better-sqlite3.test.ts
@@ -186,6 +186,7 @@ test('adapter isolates grouped queries from other queries/transactions', async (
     await new Promise((resolve) => setTimeout(resolve, 100))
     await adapter.query({ sql: 'SELECT 1' })
     query1Finished = true
+    return 7
   }
 
   const prom1 = adapter.group(slowQuery)
@@ -194,5 +195,6 @@ test('adapter isolates grouped queries from other queries/transactions', async (
     setResult(5)
   })
 
-  return Promise.all([prom1, prom2])
+  const results = await Promise.all([prom1, prom2])
+  t.deepEqual(results, [7, 5])
 })

--- a/clients/typescript/test/drivers/generic-adapters.test.ts
+++ b/clients/typescript/test/drivers/generic-adapters.test.ts
@@ -282,6 +282,7 @@ test('grouped queries are isolated from other queries/transactions', async (t) =
     await new Promise((resolve) => setTimeout(resolve, 100))
     await adapter.query({ sql: 'SELECT 1' })
     query1Finished = true
+    return 7
   }
 
   const prom1 = adapter.group(slowQuery)
@@ -290,5 +291,6 @@ test('grouped queries are isolated from other queries/transactions', async (t) =
     setResult(5)
   })
 
-  return Promise.all([prom1, prom2])
+  const results = await Promise.all([prom1, prom2])
+  t.deepEqual(results, [7, 5])
 })

--- a/clients/typescript/test/drivers/generic-adapters.test.ts
+++ b/clients/typescript/test/drivers/generic-adapters.test.ts
@@ -285,7 +285,7 @@ test('grouped queries are isolated from other queries/transactions', async (t) =
     return 7
   }
 
-  const prom1 = adapter.group(slowQuery)
+  const prom1 = adapter.runExclusively(slowQuery)
   const prom2 = adapter.transaction(async (_tx, setResult) => {
     t.true(query1Finished)
     setResult(5)

--- a/clients/typescript/test/util/transactions.test.ts
+++ b/clients/typescript/test/util/transactions.test.ts
@@ -1,0 +1,249 @@
+import t, { TestFn } from 'ava'
+import Database from 'better-sqlite3'
+import type { Database as DB } from 'better-sqlite3'
+import { DatabaseAdapter } from '../../src/drivers/better-sqlite3/adapter'
+import { DatabaseAdapter as DatabaseAdapterInterface } from '../../src/electric'
+import { runInTransaction } from '../../src/util/transactions'
+
+interface Context {
+  adapter: DatabaseAdapterInterface
+  db: DB
+}
+
+const test = t as TestFn<Context>
+
+test.beforeEach(async (t) => {
+  const db = new Database(':memory:')
+  const adapter = new DatabaseAdapter(db)
+
+  await adapter.runInTransaction(
+    {
+      sql: "CREATE TABLE IF NOT EXISTS parent('pid' TEXT NOT NULL PRIMARY KEY);",
+    },
+    {
+      sql: "CREATE TABLE IF NOT EXISTS child('cid' TEXT NOT NULL PRIMARY KEY, 'p' TEXT NOT NULL REFERENCES parent(pid));",
+    }
+  )
+
+  t.context = {
+    adapter,
+    db,
+  }
+})
+
+test.afterEach.always(async (t) => {
+  const { db } = t.context
+  db.close()
+})
+
+test('runInTransaction disables FK checks when flag is set to true', async (t) => {
+  const { adapter } = t.context
+
+  adapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
+
+  // Should succeed even though the FK is not valid
+  // because we pass `true` for the `disableFKs` flag
+  const res = await runInTransaction(adapter, true, {
+    sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');",
+  })
+
+  t.is(res.rowsAffected, 1)
+
+  // Check that the row is in the database
+  const childRow = await adapter.query({ sql: 'SELECT * FROM child;' })
+  t.is(childRow.length, 1)
+  t.deepEqual(childRow[0], { cid: 'c1', p: 'p1' })
+
+  // Check that the FK pragma is re-enabled
+  const [{ foreign_keys }] = await adapter.query({
+    sql: 'PRAGMA foreign_keys;',
+  })
+  t.is(foreign_keys, 1)
+})
+
+test('runInTransaction disables FK checks when flag is set to true and FK pragma is already disabled', async (t) => {
+  const { adapter } = t.context
+
+  adapter.run({ sql: 'PRAGMA foreign_keys = OFF;' })
+
+  // Should succeed even though the FK is not valid
+  // because we pass `true` for the `disableFKs` flag
+  const res = await runInTransaction(adapter, true, {
+    sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');",
+  })
+
+  t.is(res.rowsAffected, 1)
+
+  // Check that the row is in the database
+  const childRows = await adapter.query({ sql: 'SELECT * FROM child;' })
+  t.is(childRows.length, 1)
+  t.deepEqual(childRows[0], { cid: 'c1', p: 'p1' })
+
+  // Check that the FK pragma is still disabled
+  const [{ foreign_keys }] = await adapter.query({
+    sql: 'PRAGMA foreign_keys;',
+  })
+  t.is(foreign_keys, 0)
+})
+
+test('runInTransaction enables FK checks when flag is set to false', async (t) => {
+  const { adapter } = t.context
+
+  adapter.run({ sql: 'PRAGMA foreign_keys = OFF;' })
+
+  // Should fail because the FK is not valid
+  // because we pass `false` for the `disableFKs` flag
+  await t.throwsAsync(
+    runInTransaction(adapter, false, {
+      sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');",
+    }),
+    { message: /FOREIGN KEY constraint failed/ }
+  )
+
+  const childRows = await adapter.query({ sql: 'SELECT * FROM child;' })
+  t.is(childRows.length, 0)
+
+  // Now insert a parent row and a child row pointing to the parent
+  await runInTransaction(
+    adapter,
+    false,
+    { sql: "INSERT INTO parent (pid) VALUES ('p1');" },
+    { sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');" }
+  )
+
+  // Check that the rows are in the database
+  const parentRows = await adapter.query({ sql: 'SELECT * FROM parent;' })
+  t.is(parentRows.length, 1)
+  t.deepEqual(parentRows[0], { pid: 'p1' })
+
+  const childRowsAfterInsert = await adapter.query({
+    sql: 'SELECT * FROM child;',
+  })
+  t.is(childRowsAfterInsert.length, 1)
+  t.deepEqual(childRowsAfterInsert[0], { cid: 'c1', p: 'p1' })
+
+  // Check that the FK pragma is re-disabled
+  const [{ foreign_keys }] = await adapter.query({
+    sql: 'PRAGMA foreign_keys;',
+  })
+  t.is(foreign_keys, 0)
+})
+
+test('runInTransaction enables FK checks when flag is set to false and pragma is already enabled', async (t) => {
+  const { adapter } = t.context
+
+  adapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
+
+  // Should fail because the FK is not valid
+  // because we pass `false` for the `disableFKs` flag
+  await t.throwsAsync(
+    runInTransaction(adapter, false, {
+      sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');",
+    }),
+    { message: /FOREIGN KEY constraint failed/ }
+  )
+
+  const childRows = await adapter.query({ sql: 'SELECT * FROM child;' })
+  t.is(childRows.length, 0)
+
+  // Now insert a parent row and a child row pointing to the parent
+  await runInTransaction(
+    adapter,
+    false,
+    { sql: "INSERT INTO parent (pid) VALUES ('p1');" },
+    { sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');" }
+  )
+
+  // Check that the rows are in the database
+  const parentRows = await adapter.query({ sql: 'SELECT * FROM parent;' })
+  t.is(parentRows.length, 1)
+  t.deepEqual(parentRows[0], { pid: 'p1' })
+
+  const childRowsAfterInsert = await adapter.query({
+    sql: 'SELECT * FROM child;',
+  })
+  t.is(childRowsAfterInsert.length, 1)
+  t.deepEqual(childRowsAfterInsert[0], { cid: 'c1', p: 'p1' })
+
+  // Check that the FK pragma is re-enabled
+  const [{ foreign_keys }] = await adapter.query({
+    sql: 'PRAGMA foreign_keys;',
+  })
+  t.is(foreign_keys, 1)
+})
+
+test('runInTransaction does not touch enabled FK pragma when flag is undefined', async (t) => {
+  const { adapter } = t.context
+
+  adapter.run({ sql: 'PRAGMA foreign_keys = ON;' })
+
+  // Should fail because the FK is not valid
+  // because we pass `false` for the `disableFKs` flag
+  await t.throwsAsync(
+    runInTransaction(adapter, undefined, {
+      sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');",
+    }),
+    { message: /FOREIGN KEY constraint failed/ }
+  )
+
+  const childRows = await adapter.query({ sql: 'SELECT * FROM child;' })
+  t.is(childRows.length, 0)
+
+  // Check that the FK pragma is left untouched
+  const [{ foreign_keys: fk1 }] = await adapter.query({
+    sql: 'PRAGMA foreign_keys;',
+  })
+  t.is(fk1, 1)
+
+  // Now insert a parent row and a child row pointing to the parent
+  await runInTransaction(
+    adapter,
+    undefined,
+    { sql: "INSERT INTO parent (pid) VALUES ('p1');" },
+    { sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');" }
+  )
+
+  // Check that the rows are in the database
+  const parentRows = await adapter.query({ sql: 'SELECT * FROM parent;' })
+  t.is(parentRows.length, 1)
+  t.deepEqual(parentRows[0], { pid: 'p1' })
+
+  const childRowsAfterInsert = await adapter.query({
+    sql: 'SELECT * FROM child;',
+  })
+  t.is(childRowsAfterInsert.length, 1)
+  t.deepEqual(childRowsAfterInsert[0], { cid: 'c1', p: 'p1' })
+
+  // Check that the FK pragma is left untouched
+  const [{ foreign_keys: fk2 }] = await adapter.query({
+    sql: 'PRAGMA foreign_keys;',
+  })
+  t.is(fk2, 1)
+})
+
+test('runInTransaction does not touch disabled FK pragma when flag is undefined', async (t) => {
+  const { adapter } = t.context
+
+  adapter.run({ sql: 'PRAGMA foreign_keys = OFF;' })
+
+  // Should succeed even though the FK is not valid
+  // because we disabled the FK pragma
+  // and passed `undefined` for the `disableFKs` flag
+  // which means the FK pragma is used as is
+  const res = await runInTransaction(adapter, undefined, {
+    sql: "INSERT INTO child (cid, p) VALUES ('c1', 'p1');",
+  })
+
+  t.is(res.rowsAffected, 1)
+
+  // Check that the row is in the database
+  const childRow = await adapter.query({ sql: 'SELECT * FROM child;' })
+  t.is(childRow.length, 1)
+  t.deepEqual(childRow[0], { cid: 'c1', p: 'p1' })
+
+  // Check that the FK pragma is still disabled
+  const [{ foreign_keys }] = await adapter.query({
+    sql: 'PRAGMA foreign_keys;',
+  })
+  t.is(foreign_keys, 0)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10640,6 +10640,7 @@ packages:
 
   /glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
+    deprecated: Glob versions prior to v9 are no longer supported
     requiresBuild: true
     dependencies:
       inflight: 1.0.6
@@ -10652,6 +10653,7 @@ packages:
 
   /glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -13623,6 +13625,7 @@ packages:
 
   /osenv@0.1.5:
     resolution: {integrity: sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==}
+    deprecated: This package is no longer supported.
     dependencies:
       os-homedir: 1.0.2
       os-tmpdir: 1.0.2
@@ -15137,6 +15140,7 @@ packages:
 
   /rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     requiresBuild: true
     dependencies:
@@ -15152,6 +15156,7 @@ packages:
 
   /rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     dependencies:
       glob: 7.2.3


### PR DESCRIPTION
This PR introduces an additional flag that can be enabled when electrifying a SQLite database. When the flag is enabled, the Satellite process disables FK checks on incoming transactions. This flag is useful for performance reasons as skipping FK checks greatly speeds up initial data sync when there is a lot of data.

Note that disabling FK checks can't be done transactionally so we have to disable FKs, apply the TX, and then re-enable FKs. Therefore, it is important that no transactions are ran concurrently (this is ensured by the mutex that our drivers hold).
We assume that Electric exlusively owns the DB connection and thus that nobody executes a concurrent TX directly on the DB connection.