### PR TITLE
fix(toolbar): Remount toolbar rather than block it

### DIFF
--- a/.changeset/polite-donkeys-reflect.md
+++ b/.changeset/polite-donkeys-reflect.md
@@ -2,4 +2,4 @@
 "@electric-sql/debug-toolbar": patch
 ---
 
-Guard against adding toolbar to DOM twice
+Allow toolbar to remount properly on consecutive `addToolbar` calls

--- a/components/toolbar/src/index.tsx
+++ b/components/toolbar/src/index.tsx
@@ -103,11 +103,12 @@ export function clientApi(registry: GlobalRegistry | Registry) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function addToolbar(electric: ElectricClient<any>) {
-  if (document.getElementById(TOOLBAR_CONTAINER_ID)) {
+  const existingToolbar = document.getElementById(TOOLBAR_CONTAINER_ID)
+  if (existingToolbar !== null) {
     console.warn(
-      '[@electric-sql/debug-toolbar] Toolbar has already been added.',
+      '[@electric-sql/debug-toolbar] Toolbar has already been added - remounting.',
     )
-    return
+    existingToolbar.remove()
   }
 
   const toolbarApi = clientApi(electric.registry)
@@ -124,7 +125,7 @@ export function addToolbar(electric: ElectricClient<any>) {
 
   // add styles to shadow dom
   const template = getToolbarTemplate()
-  shadow.appendChild(template.content)
+  shadow.appendChild(template.content.cloneNode(true))
 
   // render toolbar to shadow dom
   const toolbarDiv = document.createElement('div')


### PR DESCRIPTION
Instead of guarding against remounting the toolbar, clean it up by removing the whole shadow dom root and remount it.

Main modification required was to deep clone the style from the template rather than just import it.

Alternative fix to https://github.com/electric-sql/electric/pull/1280