### PR TITLE
fix(client_test): Improve flakyness of shape lifecycle test 

### DIFF
--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -329,9 +329,7 @@ export class MockSatelliteClient
         setTimeout(resolveProm, 1)
       } else {
         // Otherwise, we resolve the promise before delivering the subscription.
-        // Give enough time for the `Process.subscribe` promise to fully resolve before
-        // delivering the subscription.
-        if (!this.doSkipNextEmit) setTimeout(emit, 50)
+        if (!this.doSkipNextEmit) setTimeout(emit, 1)
         else this.doSkipNextEmit = false
         resolveProm()
       }

--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -329,7 +329,9 @@ export class MockSatelliteClient
         setTimeout(resolveProm, 1)
       } else {
         // Otherwise, we resolve the promise before delivering the subscription.
-        if (!this.doSkipNextEmit) setTimeout(emit, 1)
+        // Give enough time for the `Process.subscribe` promise to fully resolve before
+        // delivering the subscription.
+        if (!this.doSkipNextEmit) setTimeout(emit, 50)
         else this.doSkipNextEmit = false
         resolveProm()
       }

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -2684,10 +2684,13 @@ export const processTests = (test: TestFn<ContextType>) => {
       [{ tablename: 'parent' }],
       shapeSubKey
     )
+    
+    await syncedFirst
+    
+    // 'establishing' and 'active'
+    t.is(shapeNotifications().length, 2)
 
     // first one is establishing
-
-    t.is(shapeNotifications().length, 1)
     const firstNotification = shapeNotifications()[0]
     t.is(firstNotification.key, shapeSubKey)
     t.is(firstNotification.status.status, 'establishing')
@@ -2695,10 +2698,7 @@ export const processTests = (test: TestFn<ContextType>) => {
     const firstServerId = firstNotification.status.serverId
     t.true(typeof firstServerId === 'string')
 
-    await syncedFirst
-
     // second one is active
-    t.is(shapeNotifications().length, 2)
     const secondNotification = shapeNotifications()[1]
     t.is(secondNotification.key, shapeSubKey)
     t.is(secondNotification.status.status, 'active')

--- a/clients/typescript/test/satellite/process.ts
+++ b/clients/typescript/test/satellite/process.ts
@@ -2684,9 +2684,9 @@ export const processTests = (test: TestFn<ContextType>) => {
       [{ tablename: 'parent' }],
       shapeSubKey
     )
-    
+
     await syncedFirst
-    
+
     // 'establishing' and 'active'
     t.is(shapeNotifications().length, 2)
 


### PR DESCRIPTION
It looks like the new test `notifies for shape lifecycle` can fail with the postgres driver. When expecting 1 notifications, 2 were sent instead. This seems to be because the subscription data is emitted before the `Process.subscribe` ends (there is an `await setMeta` that can take a bit longer than the 1 ms delay the mock uses, when using the Postgres driver. 

I don't know if there is better way to solve this.

cc @msfstef 