### PR TITLE
fix(electric): Use the same TCP options for epgsql and Ecto connections

### DIFF
--- a/.changeset/thin-impalas-bathe.md
+++ b/.changeset/thin-impalas-bathe.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Use the same TCP options for database connections regardless of whether they are initiated by epgsql or the Ecto repo.

--- a/components/electric/lib/electric/postgres/repo.ex
+++ b/components/electric/lib/electric/postgres/repo.ex
@@ -29,6 +29,9 @@ defmodule Electric.Postgres.Repo do
       password: conn_opts.password,
       database: conn_opts.database,
       ssl: conn_opts.ssl == :required,
+      # Pass TCP options to the Postgrex adapter. This is used to let the adapter know to
+      # connect to the DB using IPv6, for example.
+      socket_options: Map.get(conn_opts, :tcp_opts, []),
       pool_size: Keyword.get(opts, :pool_size, @default_pool_size),
       log: false,
       after_connect: {__MODULE__, :set_display_settings, []}


### PR DESCRIPTION
Fixes #1278.

I have verified this fix by building a custom Docker image for this commit and deploying it to a DigitalOcean droplet that has IPv6 connectivity. The sync service connected to Supabase, the Ecto repo pool initialized successfully.