### PR TITLE
fix(client): Fix URL parsing in the CLI

### DIFF
--- a/.changeset/nasty-buses-wink.md
+++ b/.changeset/nasty-buses-wink.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Consistently use `URL` API for parsing and constructing URLs in CLI.

--- a/.changeset/pretty-zoos-mate.md
+++ b/.changeset/pretty-zoos-mate.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Ensure default port numbers are used when starting Electric with CLI.

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -122,7 +122,7 @@ export const configOptions: Record<string, any> = {
   DATABASE_PORT: {
     doc: 'Port number of the database server.',
     valueType: Number,
-    inferVal: (options: ConfigMap) => inferDbUrlPart('port', options),
+    inferVal: (options: ConfigMap) => inferDbUrlPart('port', options, 5432),
     defaultVal: 5432,
     groups: ['database'],
   },
@@ -229,7 +229,7 @@ export const configOptions: Record<string, any> = {
   },
   PG_PROXY_PORT: {
     inferVal: (options: ConfigMap) =>
-      inferProxyUrlPart('port', options)?.toString(),
+      inferProxyUrlPart('port', options, 65432)?.toString(),
     defaultVal: '65432',
     valueType: String,
     valueTypeName: 'port',

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -6,7 +6,7 @@ import {
   getConfigValue,
   type ConfigMap,
 } from './config'
-import { dedent, getAppName, buildDatabaseURL, parsePgProxyPort } from './utils'
+import { dedent, getAppName, buildDatabaseURL, parsePgProxyPort } from './util'
 import { LIB_VERSION } from '../version'
 
 const minorVersion = LIB_VERSION.split('.').slice(0, 2).join('.')

--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander'
-import { extractDatabaseURL, extractServiceURL } from './utils'
+import { extractDatabaseURL, extractServiceURL } from './util'
 import { configOptions } from './config-options'
 
 export type ConfigMap = Record<string, string | number | boolean>

--- a/clients/typescript/src/cli/docker-commands/command-psql.ts
+++ b/clients/typescript/src/cli/docker-commands/command-psql.ts
@@ -4,7 +4,7 @@ import {
   getConfig,
   GetConfigOptionsForGroup,
 } from '../config'
-import { buildDatabaseURL, parsePgProxyPort } from '../utils'
+import { buildDatabaseURL, parsePgProxyPort } from '../util'
 import { dockerCompose } from './docker-utils'
 
 export function makePsqlCommand() {

--- a/clients/typescript/src/cli/docker-commands/command-start.ts
+++ b/clients/typescript/src/cli/docker-commands/command-start.ts
@@ -60,7 +60,7 @@ export function start(options: StartSettings) {
     // PG_PROXY_PORT can have a 'http:' prefix, which we need to remove
     // for port mapping to work.
     env.PG_PROXY_PORT_PARSED = parsePgProxyPort(
-      env.PG_PROXY_PORT
+      env.PG_PROXY_PORT as `${number}` | `http` | `http:${number}`
     ).port.toString()
 
     const dockerConfig = {

--- a/clients/typescript/src/cli/docker-commands/command-start.ts
+++ b/clients/typescript/src/cli/docker-commands/command-start.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { dedent, parsePgProxyPort } from '../utils'
+import { dedent, parsePgProxyPort } from '../util'
 import { addOptionGroupToCommand, getConfig, Config } from '../config'
 import { dockerCompose } from './docker-utils'
 

--- a/clients/typescript/src/cli/migrations/command-generate.ts
+++ b/clients/typescript/src/cli/migrations/command-generate.ts
@@ -1,5 +1,5 @@
 import { Command, InvalidArgumentError } from 'commander'
-import { dedent } from '../utils'
+import { dedent } from '../util'
 import {
   generate,
   type GeneratorOptions,

--- a/clients/typescript/src/cli/migrations/migrate.ts
+++ b/clients/typescript/src/cli/migrations/migrate.ts
@@ -9,7 +9,7 @@ import http from 'node:http'
 import https from 'node:https'
 import Module from 'node:module'
 import path from 'path'
-import { buildDatabaseURL, parsePgProxyPort } from '../utils'
+import { buildDatabaseURL, parsePgProxyPort, appRoot } from '../util'
 import { buildMigrations, getMigrationNames } from './builder'
 import { findAndReplaceInFile } from '../util'
 import { getConfig, type Config } from '../config'
@@ -33,7 +33,6 @@ const generatorPath = path.join(
   'bin.js'
 )
 
-const appRoot = path.resolve() // path where the user ran `npx electric migrate`
 const sqliteMigrationsFileName = 'migrations.ts'
 const pgMigrationsFileName = 'pg-migrations.ts'
 

--- a/clients/typescript/src/cli/tunnel/command-proxy-tunnel.ts
+++ b/clients/typescript/src/cli/tunnel/command-proxy-tunnel.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander'
 import net from 'net'
 import { WebSocket, createWebSocketStream } from 'ws'
 import { addOptionGroupToCommand, getConfig } from '../config'
-import { parsePort } from '../utils'
+import { parsePort } from '../util'
 
 export function makeProxyTunnelCommand() {
   const command = new Command('proxy-tunnel')

--- a/clients/typescript/src/cli/util/index.ts
+++ b/clients/typescript/src/cli/util/index.ts
@@ -1,1 +1,4 @@
 export * from './io'
+export * from './parse'
+export * from './string'
+export * from './paths'

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -1,6 +1,5 @@
 import fs from 'fs'
 import path from 'path'
-import url from 'url'
 import { InvalidArgumentError } from 'commander'
 import { appRoot } from './paths'
 
@@ -45,7 +44,7 @@ export function extractDatabaseURL(url: string) {
 }
 
 export function extractServiceURL(serviceUrl: string) {
-  const parsed = url.parse(serviceUrl)
+  const parsed = new URL(serviceUrl)
   if (!parsed.hostname) {
     throw new Error(`Invalid service URL: ${serviceUrl}`)
   }

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -2,8 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import url from 'url'
 import { InvalidArgumentError } from 'commander'
-
-export const appRoot = path.resolve() // path where the user ran `npx electric`
+import { appRoot } from './paths'
 
 /**
  * Get the name of the current project.
@@ -11,55 +10,6 @@ export const appRoot = path.resolve() // path where the user ran `npx electric`
 export function getAppName(): string | undefined {
   const packageJsonPath = path.join(appRoot, 'package.json')
   return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).name
-}
-
-/**
- * Tagged template literal dedent function that also unwraps lines.
- * Double newlines become a single newline.
- */
-export function dedent(
-  strings: TemplateStringsArray,
-  ...values: unknown[]
-): string {
-  let str = strings[0]
-  for (let i = 0; i < values.length; i++) {
-    str += String(values[i]) + strings[i + 1]
-  }
-
-  const lines = str.split('\n')
-
-  const minIndent = lines
-    .filter((line) => line.trim())
-    .reduce((minIndent, line) => {
-      const indent = line.match(/^\s*/)![0].length
-      return indent < minIndent ? indent : minIndent
-    }, Infinity)
-
-  if (lines[0] === '') {
-    // if first line is empty, remove it
-    lines.shift()
-  }
-  if (lines[lines.length - 1] === '') {
-    // if last line is empty, remove it
-    lines.pop()
-  }
-
-  return lines
-    .map((line) => {
-      line = line.slice(minIndent)
-      if (/^\s/.test(line)) {
-        // if line starts with whitespace, prefix it with a newline
-        // to preserve the indentation
-        return '\n' + line
-      } else if (line === '') {
-        // if line is empty, we want a newline here
-        return '\n'
-      } else {
-        return line.trim() + ' '
-      }
-    })
-    .join('')
-    .trim()
 }
 
 export function parsePort(str: string) {
@@ -80,26 +30,6 @@ export function parseTimeout(str: string) {
   return parsed
 }
 
-export function buildDatabaseURL(opts: {
-  user: string
-  password: string
-  host: string
-  port: number
-  dbName: string
-  ssl?: boolean
-}) {
-  let url = 'postgresql://' + opts.user
-  if (opts.password) {
-    url += ':' + opts.password
-  }
-  url += '@' + opts.host + ':' + opts.port + '/' + opts.dbName
-
-  if (opts.ssl === false) {
-    url += '?sslmode=disable'
-  }
-  return url
-}
-
 export function extractDatabaseURL(url: string) {
   const parsed = new URL(url)
   if (!(parsed.protocol == 'postgres:' || parsed.protocol == 'postgresql:')) {
@@ -110,7 +40,7 @@ export function extractDatabaseURL(url: string) {
     password: decodeURIComponent(parsed.password),
     host: decodeURIComponent(parsed.hostname),
     port: parsed.port != '' ? parseInt(parsed.port) : null,
-    dbName: decodeURIComponent(parsed.pathname.slice(1))
+    dbName: decodeURIComponent(parsed.pathname.slice(1)),
   }
 }
 

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -38,14 +38,20 @@ export function extractDatabaseURL(url: string): {
 } {
   const parsed = new URL(url)
   if (!(parsed.protocol == 'postgres:' || parsed.protocol == 'postgresql:')) {
-    throw new Error(`Invalid database URL: ${url}`)
+    throw new Error(`Invalid database URL scheme: ${url}`)
   }
+
+  const user = decodeURIComponent(parsed.username)
+  if (!user) {
+    throw new Error(`Invalid or missing username: ${url}`)
+  }
+
   return {
-    user: decodeURIComponent(parsed.username),
+    user: user,
     password: decodeURIComponent(parsed.password),
     host: decodeURIComponent(parsed.hostname),
     port: parsed.port ? parseInt(parsed.port) : null,
-    dbName: decodeURIComponent(parsed.pathname.slice(1)),
+    dbName: decodeURIComponent(parsed.pathname.slice(1)) || user,
   }
 }
 

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -49,8 +49,8 @@ export function extractServiceURL(serviceUrl: string) {
     throw new Error(`Invalid service URL: ${serviceUrl}`)
   }
   return {
-    host: parsed.hostname,
-    port: parsed.port ? parseInt(parsed.port) : undefined,
+    host: decodeURIComponent(parsed.hostname),
+    port: parsed.port ? parseInt(parsed.port) : null,
   }
 }
 

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -1,14 +1,12 @@
 import fs from 'fs'
-import path from 'path'
 import { InvalidArgumentError } from 'commander'
-import { appRoot } from './paths'
+import { appPackageJsonPath } from './paths'
 
 /**
  * Get the name of the current project.
  */
 export function getAppName(): string | undefined {
-  const packageJsonPath = path.join(appRoot, 'package.json')
-  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).name
+  return JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8')).name
 }
 
 export function parsePort(str: string): number {

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -9,22 +9,27 @@ export function getAppName(): string | undefined {
   return JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8')).name
 }
 
-export function parsePort(str: string): number {
+/**
+ * Parse an integer from a string and throw the given error
+ * if parsing fails
+ */
+function parseIntOrFail(str: string, error: string) {
   const parsed = parseInt(str)
   if (isNaN(parsed)) {
-    throw new InvalidArgumentError(`Invalid port: ${str}.`)
+    throw new InvalidArgumentError(error)
   }
   return parsed
 }
 
+export function parsePort(str: string): number {
+  return parseIntOrFail(
+    str,
+    `Invalid port: ${str}. Must be integer between 1 and 65535.`
+  )
+}
+
 export function parseTimeout(str: string): number {
-  const parsed = parseInt(str)
-  if (isNaN(parsed)) {
-    throw new InvalidArgumentError(
-      `Invalid timeout: ${str}. Must be an integer.`
-    )
-  }
-  return parsed
+  return parseIntOrFail(str, `Invalid timeout: ${str}. Must be an integer.`)
 }
 
 export function extractDatabaseURL(url: string): {

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -11,7 +11,7 @@ export function getAppName(): string | undefined {
   return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).name
 }
 
-export function parsePort(str: string) {
+export function parsePort(str: string): number {
   const parsed = parseInt(str)
   if (isNaN(parsed)) {
     throw new InvalidArgumentError(`Invalid port: ${str}.`)
@@ -19,7 +19,7 @@ export function parsePort(str: string) {
   return parsed
 }
 
-export function parseTimeout(str: string) {
+export function parseTimeout(str: string): number {
   const parsed = parseInt(str)
   if (isNaN(parsed)) {
     throw new InvalidArgumentError(
@@ -29,7 +29,13 @@ export function parseTimeout(str: string) {
   return parsed
 }
 
-export function extractDatabaseURL(url: string) {
+export function extractDatabaseURL(url: string): {
+  user: string
+  password: string
+  host: string
+  port: number | null
+  dbName: string
+} {
   const parsed = new URL(url)
   if (!(parsed.protocol == 'postgres:' || parsed.protocol == 'postgresql:')) {
     throw new Error(`Invalid database URL: ${url}`)
@@ -43,7 +49,10 @@ export function extractDatabaseURL(url: string) {
   }
 }
 
-export function extractServiceURL(serviceUrl: string) {
+export function extractServiceURL(serviceUrl: string): {
+  host: string
+  port: number | null
+} {
   const parsed = new URL(serviceUrl)
   if (!parsed.hostname) {
     throw new Error(`Invalid service URL: ${serviceUrl}`)
@@ -54,7 +63,10 @@ export function extractServiceURL(serviceUrl: string) {
   }
 }
 
-export function parsePgProxyPort(str: string | number) {
+export function parsePgProxyPort(str: string | number): {
+  http: boolean
+  port: number
+} {
   if (typeof str === 'number') {
     return { http: false, port: str }
   } else if (str.includes(':')) {

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -38,7 +38,7 @@ export function extractDatabaseURL(url: string) {
     user: decodeURIComponent(parsed.username),
     password: decodeURIComponent(parsed.password),
     host: decodeURIComponent(parsed.hostname),
-    port: parsed.port != '' ? parseInt(parsed.port) : null,
+    port: parsed.port ? parseInt(parsed.port) : null,
     dbName: decodeURIComponent(parsed.pathname.slice(1)),
   }
 }

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -40,7 +40,7 @@ export function extractDatabaseURL(url: string): {
   dbName: string
 } {
   const parsed = new URL(url)
-  if (!(parsed.protocol == 'postgres:' || parsed.protocol == 'postgresql:')) {
+  if (!(parsed.protocol === 'postgres:' || parsed.protocol === 'postgresql:')) {
     throw new Error(`Invalid database URL scheme: ${url}`)
   }
 

--- a/clients/typescript/src/cli/util/parse.ts
+++ b/clients/typescript/src/cli/util/parse.ts
@@ -72,7 +72,19 @@ export function extractServiceURL(serviceUrl: string): {
   }
 }
 
-export function parsePgProxyPort(str: string | number): {
+/**
+ * Parse the given string or number into a port number and whether
+ * it uses the HTTP proxy or not.
+ * @example
+ * ```
+ * parsePgProxyPort('65432') // { http: false, port: 65432 }
+ * parsePgProxyPort('http:5123') // { http: true, port: 5123 }
+ * parsePgProxyPort('http') // { http: true, port: 65432 }
+ * ```
+ */
+export function parsePgProxyPort(
+  str: number | `${number}` | `http` | `http:${number}`
+): {
   http: boolean
   port: number
 } {

--- a/clients/typescript/src/cli/util/paths.ts
+++ b/clients/typescript/src/cli/util/paths.ts
@@ -1,0 +1,6 @@
+import path from 'path'
+
+/**
+ * Path where the user ran `npx electric`
+ */
+export const appRoot = path.resolve()

--- a/clients/typescript/src/cli/util/paths.ts
+++ b/clients/typescript/src/cli/util/paths.ts
@@ -4,3 +4,8 @@ import path from 'path'
  * Path where the user ran `npx electric`
  */
 export const appRoot = path.resolve()
+
+/**
+ * Path to the package.json of the user app
+ */
+export const appPackageJsonPath = path.join(appRoot, 'package.json')

--- a/clients/typescript/src/cli/util/string.ts
+++ b/clients/typescript/src/cli/util/string.ts
@@ -1,0 +1,68 @@
+/**
+ * Tagged template literal dedent function that also unwraps lines.
+ * Double newlines become a single newline.
+ */
+export function dedent(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): string {
+  let str = strings[0]
+  for (let i = 0; i < values.length; i++) {
+    str += String(values[i]) + strings[i + 1]
+  }
+
+  const lines = str.split('\n')
+
+  const minIndent = lines
+    .filter((line) => line.trim())
+    .reduce((minIndent, line) => {
+      const indent = line.match(/^\s*/)?.[0].length ?? 0
+      return indent < minIndent ? indent : minIndent
+    }, Infinity)
+
+  if (lines[0] === '') {
+    // if first line is empty, remove it
+    lines.shift()
+  }
+  if (lines[lines.length - 1] === '') {
+    // if last line is empty, remove it
+    lines.pop()
+  }
+
+  return lines
+    .map((line) => {
+      line = line.slice(minIndent)
+      if (/^\s/.test(line)) {
+        // if line starts with whitespace, prefix it with a newline
+        // to preserve the indentation
+        return '\n' + line
+      } else if (line === '') {
+        // if line is empty, we want a newline here
+        return '\n'
+      } else {
+        return line.trim() + ' '
+      }
+    })
+    .join('')
+    .trim()
+}
+
+export function buildDatabaseURL(opts: {
+  user: string
+  password: string
+  host: string
+  port: number
+  dbName: string
+  ssl?: boolean
+}) {
+  let url = 'postgresql://' + opts.user
+  if (opts.password) {
+    url += ':' + opts.password
+  }
+  url += '@' + opts.host + ':' + opts.port + '/' + opts.dbName
+
+  if (opts.ssl === false) {
+    url += '?sslmode=disable'
+  }
+  return url
+}

--- a/clients/typescript/src/cli/util/string.ts
+++ b/clients/typescript/src/cli/util/string.ts
@@ -54,15 +54,15 @@ export function buildDatabaseURL(opts: {
   port: number
   dbName: string
   ssl?: boolean
-}) {
-  let url = 'postgresql://' + opts.user
-  if (opts.password) {
-    url += ':' + opts.password
+}): string {
+  const base = new URL(`postgresql://${opts.host}`)
+  base.username = opts.user
+  base.password = opts.password
+  base.port = opts.port.toString()
+  base.pathname = opts.dbName
+  if (opts.ssl !== undefined) {
+    base.searchParams.set('sslmode', opts.ssl ? 'require' : 'disable')
   }
-  url += '@' + opts.host + ':' + opts.port + '/' + opts.dbName
 
-  if (opts.ssl === false) {
-    url += '?sslmode=disable'
-  }
-  return url
+  return base.toString()
 }

--- a/clients/typescript/src/cli/util/string.ts
+++ b/clients/typescript/src/cli/util/string.ts
@@ -47,6 +47,9 @@ export function dedent(
     .trim()
 }
 
+/**
+ * Builds the Postgres database URL for the given parameters.
+ */
 export function buildDatabaseURL(opts: {
   user: string
   password: string

--- a/clients/typescript/src/cli/utils.ts
+++ b/clients/typescript/src/cli/utils.ts
@@ -101,18 +101,16 @@ export function buildDatabaseURL(opts: {
 }
 
 export function extractDatabaseURL(url: string) {
-  const match = url.match(
-    /^postgres(ql)?:\/\/([^:]+)(?::([^@]+))?@([^:]+):(\d+)\/(.+)$/
-  )
-  if (!match) {
+  const parsed = new URL(url)
+  if (!(parsed.protocol == 'postgres:' || parsed.protocol == 'postgresql:')) {
     throw new Error(`Invalid database URL: ${url}`)
   }
   return {
-    user: match[2],
-    password: match[3] ?? '',
-    host: match[4],
-    port: parseInt(match[5]),
-    dbName: match[6],
+    user: decodeURIComponent(parsed.username),
+    password: decodeURIComponent(parsed.password),
+    host: decodeURIComponent(parsed.hostname),
+    port: parsed.port != '' ? parseInt(parsed.port) : null,
+    dbName: decodeURIComponent(parsed.pathname.slice(1))
   }
 }
 

--- a/clients/typescript/test/cli/config-options.test.ts
+++ b/clients/typescript/test/cli/config-options.test.ts
@@ -96,4 +96,54 @@ test('assert database name is correctly inferred', (t) => {
     }),
     'db_name'
   )
+
+  // ignores query parameters in the URL
+  t.is(
+    configOptions['DATABASE_NAME'].inferVal({
+      databaseUrl: 'postgres://db_user:db_password@db_host:123/db_name?sslmode=disable',
+    }),
+    'db_name'
+  )
+
+  t.is(
+    configOptions['DATABASE_NAME'].inferVal({
+      proxy: 'postgres://db_user:db_password@db_host:123/db_name?sslmode=require',
+    }),
+    'db_name'
+  )
+
+  // correctly decodes encoded characters
+  t.is(
+    configOptions['DATABASE_NAME'].inferVal({
+      databaseUrl: 'postgres://db_user:db_password@db_host:123/odd%3Adb%2Fname',
+    }),
+    'odd:db/name'
+  )
+
+  t.is(
+    configOptions['DATABASE_NAME'].inferVal({
+      proxy: 'postgres://db_user:db_password@db_host:123/odd%3Adb%2Fname',
+    }),
+    'odd:db/name'
+  )
+})
+
+test('assert DATABASE_URL may contain percent-encoded characters', (t) => {
+  const dbUrl = 'postgresql://test%2Bemail%40example.com:12%2B34@example.%63om/odd%3Adb%2Fname'
+
+  t.is(configOptions['DATABASE_HOST'].inferVal({ databaseUrl: dbUrl }), 'example.com')
+  t.is(configOptions['DATABASE_USER'].inferVal({ databaseUrl: dbUrl }), 'test+email@example.com')
+  t.is(configOptions['DATABASE_PASSWORD'].inferVal({ databaseUrl: dbUrl }), '12+34')
+})
+
+test('assert DATABASE_PORT is inferred to the default value when not present in the URL', (t) => {
+  const dbUrl = 'postgresql://user:@example.com/db'
+
+  t.is(configOptions['DATABASE_PORT'].inferVal({ databaseUrl: dbUrl }), 5432)
+  t.is(configOptions['DATABASE_PORT'].inferVal({ proxy: dbUrl }), 5432)
+})
+
+test('assert PG_PROXY_PORT is inferred to the default value when not present in the URL', (t) => {
+  const proxyUrl = 'postgresql://user:@example.com/db'
+  t.is(configOptions['PG_PROXY_PORT'].inferVal({ proxy: proxyUrl }), '65432')
 })

--- a/clients/typescript/test/cli/config-options.test.ts
+++ b/clients/typescript/test/cli/config-options.test.ts
@@ -100,14 +100,16 @@ test('assert database name is correctly inferred', (t) => {
   // ignores query parameters in the URL
   t.is(
     configOptions['DATABASE_NAME'].inferVal({
-      databaseUrl: 'postgres://db_user:db_password@db_host:123/db_name?sslmode=disable',
+      databaseUrl:
+        'postgres://db_user:db_password@db_host:123/db_name?sslmode=disable',
     }),
     'db_name'
   )
 
   t.is(
     configOptions['DATABASE_NAME'].inferVal({
-      proxy: 'postgres://db_user:db_password@db_host:123/db_name?sslmode=require',
+      proxy:
+        'postgres://db_user:db_password@db_host:123/db_name?sslmode=require',
     }),
     'db_name'
   )
@@ -129,11 +131,21 @@ test('assert database name is correctly inferred', (t) => {
 })
 
 test('assert DATABASE_URL may contain percent-encoded characters', (t) => {
-  const dbUrl = 'postgresql://test%2Bemail%40example.com:12%2B34@example.%63om/odd%3Adb%2Fname'
+  const dbUrl =
+    'postgresql://test%2Bemail%40example.com:12%2B34@example.%63om/odd%3Adb%2Fname'
 
-  t.is(configOptions['DATABASE_HOST'].inferVal({ databaseUrl: dbUrl }), 'example.com')
-  t.is(configOptions['DATABASE_USER'].inferVal({ databaseUrl: dbUrl }), 'test+email@example.com')
-  t.is(configOptions['DATABASE_PASSWORD'].inferVal({ databaseUrl: dbUrl }), '12+34')
+  t.is(
+    configOptions['DATABASE_HOST'].inferVal({ databaseUrl: dbUrl }),
+    'example.com'
+  )
+  t.is(
+    configOptions['DATABASE_USER'].inferVal({ databaseUrl: dbUrl }),
+    'test+email@example.com'
+  )
+  t.is(
+    configOptions['DATABASE_PASSWORD'].inferVal({ databaseUrl: dbUrl }),
+    '12+34'
+  )
 })
 
 test('assert DATABASE_PORT is inferred to the default value when not present in the URL', (t) => {

--- a/clients/typescript/test/cli/util/parse.test.ts
+++ b/clients/typescript/test/cli/util/parse.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { extractServiceURL } from '../../../src/cli/util'
+import { extractDatabaseURL, extractServiceURL } from '../../../src/cli/util'
 
 test('extractServiceURL decomposes electric URL', async (t) => {
   t.deepEqual(extractServiceURL('http://localhost:5133'), {
@@ -15,5 +15,93 @@ test('extractServiceURL decomposes electric URL', async (t) => {
   t.deepEqual(extractServiceURL('https://www.my-website.com:8132'), {
     host: 'www.my-website.com',
     port: 8132,
+  })
+})
+
+const postgresUrlExamples = {
+  'postgresql://postgres:password@example.com:5432/app-db': {
+    user: 'postgres',
+    password: 'password',
+    host: 'example.com',
+    port: 5432,
+    dbName: 'app-db',
+  },
+  'postgresql://electric@192.168.111.33:81/__shadow': {
+    user: 'electric',
+    password: '',
+    host: '192.168.111.33',
+    port: 81,
+    dbName: '__shadow',
+  },
+  'postgresql://pg@[2001:db8::1234]:4321': {
+    user: 'pg',
+    password: '',
+    host: '[2001:db8::1234]',
+    port: 4321,
+    dbName: 'pg',
+  },
+  'postgresql://user@localhost:5433/': {
+    user: 'user',
+    password: '',
+    host: 'localhost',
+    port: 5433,
+    dbName: 'user',
+  },
+  'postgresql://user%2Btesting%40gmail.com:weird%2Fpassword@localhost:5433/my%2Bdb%2Bname':
+    {
+      user: 'user+testing@gmail.com',
+      password: 'weird/password',
+      host: 'localhost',
+      port: 5433,
+      dbName: 'my+db+name',
+    },
+  'postgres://super_user@localhost:7801/postgres': {
+    user: 'super_user',
+    password: '',
+    host: 'localhost',
+    port: 7801,
+    dbName: 'postgres',
+  },
+}
+
+test('extractDatabaseURL should parse valid URLs', (t) => {
+  for (const [url, expected] of Object.entries(postgresUrlExamples)) {
+    t.deepEqual(extractDatabaseURL(url), expected)
+  }
+})
+
+test('extractDatabaseURL throws for invalid URL scheme', (t) => {
+  const url = 'postgrex://localhost'
+  t.throws(() => extractDatabaseURL(url), {
+    instanceOf: Error,
+    message: `Invalid database URL scheme: ${url}`,
+  })
+})
+
+test('extractDatabaseURL throws for missing username', (t) => {
+  const url1 = 'postgresql://localhost'
+  t.throws(() => extractDatabaseURL(url1), {
+    instanceOf: Error,
+    message: `Invalid or missing username: ${url1}`,
+  })
+
+  const url2 = 'postgresql://:@localhost'
+  t.throws(() => extractDatabaseURL(url2), {
+    instanceOf: Error,
+    message: `Invalid or missing username: ${url2}`,
+  })
+
+  const url3 = 'postgresql://:password@localhost'
+  t.throws(() => extractDatabaseURL(url3), {
+    instanceOf: Error,
+    message: `Invalid or missing username: ${url3}`,
+  })
+})
+
+test('extractDatabaseURL throws for missing host', (t) => {
+  const url = 'postgresql://user:password@'
+  t.throws(() => extractDatabaseURL(url), {
+    instanceOf: Error,
+    message: `Invalid URL`,
   })
 })

--- a/clients/typescript/test/cli/util/parse.test.ts
+++ b/clients/typescript/test/cli/util/parse.test.ts
@@ -9,7 +9,7 @@ test('extractServiceURL decomposes electric URL', async (t) => {
 
   t.deepEqual(extractServiceURL('https://www.my-website.com'), {
     host: 'www.my-website.com',
-    port: undefined,
+    port: null,
   })
 
   t.deepEqual(extractServiceURL('https://www.my-website.com:8132'), {

--- a/clients/typescript/test/cli/util/parse.test.ts
+++ b/clients/typescript/test/cli/util/parse.test.ts
@@ -1,0 +1,19 @@
+import test from 'ava'
+import { extractServiceURL } from '../../../src/cli/util'
+
+test('extractServiceURL decomposes electric URL', async (t) => {
+  t.deepEqual(extractServiceURL('http://localhost:5133'), {
+    host: 'localhost',
+    port: 5133,
+  })
+
+  t.deepEqual(extractServiceURL('https://www.my-website.com'), {
+    host: 'www.my-website.com',
+    port: undefined,
+  })
+
+  t.deepEqual(extractServiceURL('https://www.my-website.com:8132'), {
+    host: 'www.my-website.com',
+    port: 8132,
+  })
+})

--- a/clients/typescript/test/cli/util/parse.test.ts
+++ b/clients/typescript/test/cli/util/parse.test.ts
@@ -1,5 +1,9 @@
 import test from 'ava'
-import { extractDatabaseURL, extractServiceURL } from '../../../src/cli/util'
+import {
+  extractDatabaseURL,
+  extractServiceURL,
+  parsePgProxyPort,
+} from '../../../src/cli/util'
 
 test('extractServiceURL decomposes electric URL', async (t) => {
   t.deepEqual(extractServiceURL('http://localhost:5133'), {
@@ -104,4 +108,39 @@ test('extractDatabaseURL throws for missing host', (t) => {
     instanceOf: Error,
     message: `Invalid URL`,
   })
+})
+
+test('parsePgProxyPort parses regular port number', async (t) => {
+  t.deepEqual(parsePgProxyPort(5133), {
+    http: false,
+    port: 5133,
+  })
+
+  t.deepEqual(parsePgProxyPort('65432'), {
+    http: false,
+    port: 65432,
+  })
+})
+
+test('parsePgProxyPort http proxy port', async (t) => {
+  t.deepEqual(parsePgProxyPort('http:5133'), {
+    http: true,
+    port: 5133,
+  })
+
+  // @ts-expect-error invalid port prefix
+  t.deepEqual(parsePgProxyPort('random:5133'), {
+    http: false,
+    port: 5133,
+  })
+})
+
+test('parsePgProxyPort http proxy with default port', async (t) => {
+  t.deepEqual(parsePgProxyPort('http'), {
+    http: true,
+    port: 65432,
+  })
+
+  // @ts-expect-error invalid port prefix
+  t.throws(() => parsePgProxyPort('test'))
 })

--- a/clients/typescript/test/cli/util/string.test.ts
+++ b/clients/typescript/test/cli/util/string.test.ts
@@ -1,0 +1,82 @@
+import test from 'ava'
+import { buildDatabaseURL } from '../../../src/cli/util'
+
+test('buildDatabaseURL should compose valid URL', (t) => {
+  const url = buildDatabaseURL({
+    user: 'admin',
+    password: 'adminpass',
+    host: '192.168.1.1',
+    port: 3306,
+    dbName: 'mydatabase',
+  })
+
+  t.is(url, 'postgresql://admin:adminpass@192.168.1.1:3306/mydatabase')
+})
+
+test('buildDatabaseURL without password', (t) => {
+  const url = buildDatabaseURL({
+    user: 'user',
+    password: '',
+    host: 'example.com',
+    port: 5432,
+    dbName: 'sampledb',
+  })
+
+  t.is(url, 'postgresql://user@example.com:5432/sampledb')
+})
+
+test('buildDatabaseURL with complex password', (t) => {
+  const url = buildDatabaseURL({
+    user: 'user',
+    password: 'p@$$w0rd!',
+    host: 'example.com',
+    port: 5432,
+    dbName: 'sampledb',
+  })
+
+  t.is(url, 'postgresql://user:p%40$$w0rd!@example.com:5432/sampledb')
+})
+
+test('buildDatabaseURL without SSL', (t) => {
+  const url = buildDatabaseURL({
+    user: 'testuser',
+    password: 'testpass',
+    host: 'localhost',
+    port: 5432,
+    dbName: 'testdb',
+  })
+
+  t.is(url, 'postgresql://testuser:testpass@localhost:5432/testdb')
+})
+
+test('buildDatabaseURL with SSL required', (t) => {
+  const url = buildDatabaseURL({
+    user: 'testuser',
+    password: 'testpass',
+    host: 'localhost',
+    port: 5432,
+    dbName: 'testdb',
+    ssl: true,
+  })
+
+  t.is(
+    url,
+    'postgresql://testuser:testpass@localhost:5432/testdb?sslmode=require'
+  )
+})
+
+test('buildDatabaseURL with SSL disabled', (t) => {
+  const url = buildDatabaseURL({
+    user: 'testuser',
+    password: 'testpass',
+    host: 'localhost',
+    port: 5432,
+    dbName: 'testdb',
+    ssl: false,
+  })
+
+  t.is(
+    url,
+    'postgresql://testuser:testpass@localhost:5432/testdb?sslmode=disable'
+  )
+})

--- a/clients/typescript/test/cli/util/string.test.ts
+++ b/clients/typescript/test/cli/util/string.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { buildDatabaseURL } from '../../../src/cli/util'
+import { buildDatabaseURL, dedent } from '../../../src/cli/util'
 
 test('buildDatabaseURL should compose valid URL', (t) => {
   const url = buildDatabaseURL({
@@ -79,4 +79,13 @@ test('buildDatabaseURL with SSL disabled', (t) => {
     url,
     'postgresql://testuser:testpass@localhost:5432/testdb?sslmode=disable'
   )
+})
+
+test('dedent removes indentation and newlines from multiline strings', (t) => {
+  const result = dedent`
+    This is a
+    multiline
+    string
+  `
+  t.is(result, 'This is a multiline string')
 })


### PR DESCRIPTION
This is just to demonstrate the direction in which URL parsing can be improved in the CLI.

First, more test coverage is needed for some not-too-uncommon edge cases.

Second, more uniformunity is needed in the parsing code. Currently, in `src/cli/utils.ts` alone the database URL is parsed using a regexp, the service URL is parsed using the deprecated `url.parse()` method. All of this can be replaced with the built-in `URL` class and its properties/method. That class can also be used for building URLs, instead of ad-hoc string concatenation that doesn't escape URL components.