### PR TITLE
fix(electric): Fix temporary replication slot going over character limit

### DIFF
--- a/.changeset/yellow-geckos-mix.md
+++ b/.changeset/yellow-geckos-mix.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Truncate temporary replication slot name to always fit within Postgres' limit of 63 chars

--- a/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
+++ b/components/electric/lib/electric/replication/postgres/logical_replication_producer.ex
@@ -111,7 +111,8 @@ defmodule Electric.Replication.Postgres.LogicalReplicationProducer do
 
     publication = repl_opts.publication
     main_slot = repl_opts.slot
-    tmp_slot = main_slot <> "_rc"
+    # Ensure temporary slot name fits within Postgres' limit of 63 chars
+    tmp_slot = String.slice(main_slot, 0..59) <> "_rc"
 
     Logger.metadata(pg_producer: origin)
 


### PR DESCRIPTION
Addresses [this issue](https://linear.app/electric-sql/issue/VAX-1888/temporary-replication-slot-name-too-long-crashes-electric)

This is a quick fix to avoid failures because of long names but the longer term solution is to ensure the replication slot names are smaller in general, see issue description for suggestions.