### PR TITLE
fix(cli): Redact passwords in docker compose config CLI printout

### DIFF
--- a/.changeset/flat-terms-shake.md
+++ b/.changeset/flat-terms-shake.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Redact secrets from CLI Docker configuration printout.

--- a/clients/typescript/src/cli/config-options.ts
+++ b/clients/typescript/src/cli/config-options.ts
@@ -142,6 +142,7 @@ export const configOptions: Record<string, any> = {
     valueType: String,
     inferVal: (options: ConfigMap) => inferDbUrlPart('password', options),
     defaultVal: 'db_password',
+    confidential: true,
     groups: ['database'],
   },
   DATABASE_NAME: {
@@ -249,6 +250,7 @@ export const configOptions: Record<string, any> = {
       Password to use when connecting to the Postgres proxy via psql or any other 
       Postgres client.
     `,
+    confidential: true,
     groups: ['electric', 'client', 'proxy'],
   },
   AUTH_MODE: {

--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -16,6 +16,7 @@ export interface AnyConfigOption {
     | boolean
     | ((options: ConfigMap) => string | number | boolean)
   constructedDefault?: string
+  confidential?: true
   groups?: Readonly<string[]>
 }
 
@@ -203,15 +204,16 @@ function redactConfigValue(config: Config, stringToRedact: string): Config {
  * Redacts sensitive information like secrets and passwords from the
  * config and returns a separate, redacted version.
  *
- * Redaction is done based on keys that contain "PASSWORD" or "SECRET".
+ * Redaction is done based on the `confidential` property of the
+ * configuration option.
  */
 export function redactConfigSecrets(config: Config): Config {
-  const passKeys = Object.keys(config).filter(
-    (k) => k.includes('PASSWORD') || k.includes('SECRET')
+  const keysToRedact = Object.keys(config).filter(
+    (k) => configOptions[k].confidential
   )
   let redactedConfig = { ...config }
-  for (const passKey of passKeys) {
-    redactedConfig = redactConfigValue(redactedConfig, config[passKey])
+  for (const keyToRedact of keysToRedact) {
+    redactedConfig = redactConfigValue(redactedConfig, config[keyToRedact])
   }
   return redactedConfig
 }

--- a/clients/typescript/src/cli/docker-commands/command-start.ts
+++ b/clients/typescript/src/cli/docker-commands/command-start.ts
@@ -1,6 +1,11 @@
 import { Command } from 'commander'
 import { dedent, parsePgProxyPort } from '../util'
-import { addOptionGroupToCommand, getConfig, Config } from '../config'
+import {
+  addOptionGroupToCommand,
+  getConfig,
+  Config,
+  redactConfigSecrets,
+} from '../config'
 import { dockerCompose } from './docker-utils'
 
 export function makeStartCommand() {
@@ -77,7 +82,7 @@ export function start(options: StartSettings) {
           }
         : {}),
     }
-    console.log('Docker compose config:', dockerConfig)
+    console.log('Docker compose config:', redactConfigSecrets(dockerConfig))
 
     const proc = dockerCompose(
       'up',

--- a/clients/typescript/src/cli/docker-commands/docker/compose-with-postgres.yaml
+++ b/clients/typescript/src/cli/docker-commands/docker/compose-with-postgres.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 configs:
   postgres_config:
     file: './postgres.conf'

--- a/clients/typescript/src/cli/docker-commands/docker/compose.yaml
+++ b/clients/typescript/src/cli/docker-commands/docker/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 configs:
   postgres_config:
     file: './postgres.conf'

--- a/clients/typescript/test/cli/config.test.ts
+++ b/clients/typescript/test/cli/config.test.ts
@@ -20,7 +20,6 @@ test('redactConfigValue redacts value in all of the config', (t) => {
     ELECTRIC_WRITE_TO_PG_MODE: 'test',
     DATABASE_URL: 'postgresql://postgres:db_password@postgres:5432/test',
     DATABASE_PASSWORD: 'db_password',
-    RANDOM_SECRET: 'whatever_this_might_be',
   }
   t.deepEqual(redactConfigSecrets(config), {
     ...config,
@@ -29,6 +28,5 @@ test('redactConfigValue redacts value in all of the config', (t) => {
     DATABASE_PASSWORD: '******',
     PROXY: 'postgresql://postgres:******@localhost:65432/test?sslmode=disable',
     PG_PROXY_PASSWORD: '******',
-    RANDOM_SECRET: '******',
   })
 })


### PR DESCRIPTION
Redacts any value marked as confidential in the configuration options from the config.

I've also removed the version from the docker compose files as it is deprecated and shows warnings any time we use them - I'd also collapse them in one as @alco did but it can wait until https://github.com/electric-sql/electric/pull/1299 is merged