### PR TITLE
fix(cli): Fix cli config redact not redacting everywhere and throwing for unknown keys

### DIFF
--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -205,7 +205,7 @@ function redactConfigValue(config: Config, stringToRedact: string): void {
  */
 export function redactConfigSecrets(config: Config): Config {
   const valuesToRedact = Object.keys(config)
-    .filter((k) => configOptions[k].secret)
+    .filter((k) => configOptions[k]?.secret)
     .map((k) => config[k])
   const redactedConfig = { ...config }
   valuesToRedact.forEach((v) => redactConfigValue(redactedConfig, v))

--- a/clients/typescript/src/cli/config.ts
+++ b/clients/typescript/src/cli/config.ts
@@ -212,6 +212,14 @@ export function redactConfigSecrets(config: Config): Config {
   return redactedConfig
 }
 
+/**
+ * Prints the provided `config` taking care to redact any
+ * sensitive values
+ */
+export function printConfig(config: Config): void {
+  console.log(redactConfigSecrets(config))
+}
+
 function snakeToCamel(s: string) {
   return s
     .toLocaleLowerCase()

--- a/clients/typescript/src/cli/configure/command-show-config.ts
+++ b/clients/typescript/src/cli/configure/command-show-config.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { getConfig } from '../config'
+import { getConfig, printConfig } from '../config'
 
 export function makeShowConfigCommand() {
   return new Command('show-config')
@@ -9,5 +9,5 @@ export function makeShowConfigCommand() {
 
 export function showConfig() {
   const config = getConfig()
-  console.log(config)
+  printConfig(config)
 }

--- a/clients/typescript/test/cli/config.test.ts
+++ b/clients/typescript/test/cli/config.test.ts
@@ -20,6 +20,7 @@ test('redactConfigValue redacts value in all of the config', (t) => {
     ELECTRIC_WRITE_TO_PG_MODE: 'test',
     DATABASE_URL: 'postgresql://postgres:db_password@postgres:5432/test',
     DATABASE_PASSWORD: 'db_password',
+    RANDOM_KEY_NOT_IN_CONFIG: 'foo',
   }
   t.deepEqual(redactConfigSecrets(config), {
     ...config,
@@ -28,5 +29,8 @@ test('redactConfigValue redacts value in all of the config', (t) => {
     DATABASE_PASSWORD: '******',
     PROXY: 'postgresql://postgres:******@localhost:65432/test?sslmode=disable',
     PG_PROXY_PASSWORD: '******',
+
+    // should still include value outside of the config
+    RANDOM_KEY_NOT_IN_CONFIG: 'foo',
   })
 })


### PR DESCRIPTION
Add print utility that redacts config and use that instead of console.log (for easier search later and modifying redaction logic if necessary without missing anything)

Also don't throw for unknown keys outside of the `Config` spec to allow flexibility

Finally build DB url for postgres option with the url building utility