### PR TITLE
chore(electric): Bundle the latest tzdata database into sync service's Docker image

### DIFF
--- a/components/electric/Dockerfile
+++ b/components/electric/Dockerfile
@@ -24,6 +24,7 @@ COPY mix.* /app/
 RUN mix deps.get
 RUN mix deps.compile
 
+RUN mix run --no-compile --no-start -e "Application.ensure_all_started(:tzdata); Tzdata.ReleaseUpdater.poll_for_update()"
 COPY config/*runtime.exs /app/config/
 COPY lib /app/lib/
 COPY priv /app/priv


### PR DESCRIPTION
Since our Docker-based distribution of the sync service is stateless, every time a Docker container is started, it downloads the same tzdata database from a remote host.

To avoid doing that, we bundle the latest database file with the release.