### PR TITLE
Check permissions for incoming operations

### DIFF
--- a/clients/typescript/src/_generated/protocol/satellite.ts
+++ b/clients/typescript/src/_generated/protocol/satellite.ts
@@ -108,6 +108,7 @@ export enum SatErrorResp_ErrorCode {
   INVALID_REQUEST = 4,
   PROTO_VSN_MISMATCH = 5,
   SCHEMA_VSN_MISMATCH = 6,
+  PERMISSION_DENIED = 7,
   UNRECOGNIZED = -1,
 }
 

--- a/clients/typescript/src/util/proto.ts
+++ b/clients/typescript/src/util/proto.ts
@@ -23,6 +23,8 @@ const serverErrorToSatError: Record<
   [Pb.SatErrorResp_ErrorCode.AUTH_REQUIRED]: SatelliteErrorCode.AUTH_REQUIRED,
   [Pb.SatErrorResp_ErrorCode.INVALID_REQUEST]:
     SatelliteErrorCode.INVALID_REQUEST,
+  [Pb.SatErrorResp_ErrorCode.PERMISSION_DENIED]:
+    SatelliteErrorCode.PERMISSION_DENIED,
   [Pb.SatErrorResp_ErrorCode.PROTO_VSN_MISMATCH]:
     SatelliteErrorCode.PROTO_VSN_MISMATCH,
   [Pb.SatErrorResp_ErrorCode.REPLICATION_FAILED]:

--- a/clients/typescript/src/util/types.ts
+++ b/clients/typescript/src/util/types.ts
@@ -90,6 +90,9 @@ export enum SatelliteErrorCode {
 
   // replication transform errors
   REPLICATION_TRANSFORM_ERROR,
+
+  // permissions
+  PERMISSION_DENIED,
 }
 
 export type SocketCloseReason =

--- a/components/electric/config/runtime.exs
+++ b/components/electric/config/runtime.exs
@@ -190,18 +190,15 @@ config :electric,
 # override these using the `ELECTRIC_FEATURES` environment variable, e.g.
 # to add a flag enabling `ELECTRIC GRANT` use:
 #
-#     export ELECTRIC_FEATURES="proxy_ddlx_grant=true:${ELECTRIC_FEATURES:-}"
+#     export ELECTRIC_FEATURES="permissions=true:${ELECTRIC_FEATURES:-}"
 #
 # or if you want to just set flags, ignoring any previous env settings
 #
-#     export ELECTRIC_FEATURES="proxy_ddlx_grant=true:proxy_ddlx_assign=true"
+#     export ELECTRIC_FEATURES="permissions=true:proxy_grant_write_permissions=true"
 #
 config :electric, Electric.Features,
-  read_permissions: false,
-  proxy_ddlx_grant: true,
-  proxy_ddlx_revoke: true,
-  proxy_ddlx_assign: true,
-  proxy_ddlx_unassign: true,
+  permissions: false,
+  proxy_grant_write_permissions: false,
   proxy_ddlx_sqlite: false
 
 {:ok, conn_config} = database_url_config

--- a/components/electric/config/runtime.test.exs
+++ b/components/electric/config/runtime.test.exs
@@ -10,4 +10,7 @@ config :electric, disable_listeners: true
 
 config :electric, Electric.Postgres.Proxy.Handler.Tracing, colour: false
 
-config :electric, Electric.Features, read_permissions: true
+config :electric, Electric.Features,
+  permissions: true,
+  proxy_grant_write_permissions: true,
+  proxy_ddlx_sqlite: true

--- a/components/electric/lib/electric/postgres/proxy/errors.ex
+++ b/components/electric/lib/electric/postgres/proxy/errors.ex
@@ -3,10 +3,10 @@ defmodule Electric.Postgres.Proxy.Errors do
 
   import Electric.Utils, only: [inspect_relation: 1]
 
-  def access_control_not_supported(command, query) do
+  def command_not_supported(command, query) do
     %{
       code: "EX001",
-      message: "#{Electric.DDLX.Command.tag(command)} is currently unsupported",
+      message: "#{Electric.DDLX.Command.tag(command)} `#{query}`is currently unsupported",
       detail:
         "We are working on implementing access controls -- when these features are completed then this command will work",
       query: query

--- a/components/electric/lib/electric/postgres/proxy/injector/operation.ex
+++ b/components/electric/lib/electric/postgres/proxy/injector/operation.ex
@@ -923,6 +923,14 @@ defmodule Operation.Disallowed do
           )
       end
     end
+
+    defp error_response(%{action: {:electric, _command}} = analysis) do
+      %M.ErrorResponse{
+        code: "EX100",
+        severity: "ERROR",
+        message: "Invalid statement: #{analysis.sql}"
+      }
+    end
   end
 end
 

--- a/components/electric/lib/electric/postgres/proxy/query_analyser.ex
+++ b/components/electric/lib/electric/postgres/proxy/query_analyser.ex
@@ -660,7 +660,7 @@ defimpl QueryAnalyser, for: PgQuery.CallStmt do
       %{
         analysis
         | allowed?: false,
-          error: Errors.access_control_not_supported(command, analysis.sql)
+          error: Errors.command_not_supported(command, analysis.sql)
       }
     end
   end

--- a/components/electric/lib/electric/satellite/permissions.ex
+++ b/components/electric/lib/electric/satellite/permissions.ex
@@ -280,7 +280,7 @@ defmodule Electric.Satellite.Permissions do
           triggers: Trigger.triggers()
         }
 
-  @read_feature_flag :read_permissions
+  @feature_flag :permissions
 
   @read_privileges [:SELECT]
   @write_privileges [:INSERT, :UPDATE, :DELETE]
@@ -292,9 +292,9 @@ defmodule Electric.Satellite.Permissions do
 
   def privileges, do: @privileges
 
-  @spec filter_reads_enabled?() :: boolean()
-  def filter_reads_enabled?() do
-    Electric.Features.enabled?(@read_feature_flag)
+  @spec enabled?() :: boolean()
+  def enabled? do
+    Electric.Features.enabled?(@feature_flag)
   end
 
   @doc """

--- a/components/electric/lib/electric/satellite/permissions.ex
+++ b/components/electric/lib/electric/satellite/permissions.ex
@@ -650,6 +650,9 @@ defmodule Electric.Satellite.Permissions do
       {:ok, write_buffer},
       fn change, {:ok, write_buffer} ->
         case verify_write(change, perms, write_buffer, xid) do
+          :skip ->
+            {:cont, {:ok, write_buffer}}
+
           {:error, _} = error ->
             {:halt, error}
 
@@ -708,7 +711,12 @@ defmodule Electric.Satellite.Permissions do
     end
   end
 
-  @spec verify_write(change(), t(), Graph.impl(), xid()) :: RoleGrant.t() | {:error, String.t()}
+  @spec verify_write(change(), t(), Graph.impl(), xid()) ::
+          RoleGrant.t() | :skip | {:error, String.t()}
+  defp verify_write(%Changes.Compensation{}, _, _, _) do
+    :skip
+  end
+
   defp verify_write(change, perms, graph, xid) do
     action = required_permission(change)
 

--- a/components/electric/lib/electric/satellite/permissions/write.ex
+++ b/components/electric/lib/electric/satellite/permissions/write.ex
@@ -1,0 +1,59 @@
+defmodule Electric.Satellite.Permissions.Write do
+  alias Electric.Replication.Changes
+  alias Electric.Satellite.Permissions
+  alias Electric.Satellite.Protocol
+
+  defmodule Error do
+    defstruct [:reason, :tx]
+
+    @type t() :: %__MODULE__{reason: String.t(), tx: Changes.Transaction.t()}
+
+    def error_response(%__MODULE__{} = error) do
+      %Electric.Satellite.SatErrorResp{
+        error_type: :PERMISSION_DENIED,
+        lsn: error.tx.lsn,
+        message: error.reason
+      }
+    end
+
+    defimpl String.Chars do
+      def to_string(error) do
+        "Changes in transaction [LSN #{error.tx.lsn || "?"}] " <>
+          "were refused for the following reason: " <>
+          error.reason
+      end
+    end
+  end
+
+  def validate(txns, %Protocol.State{} = state) when is_list(txns) do
+    if Permissions.filter_reads_enabled?() do
+      %{permissions: permissions, out_rep: %{sent_rows_graph: srg}} = state
+      graph_impl = Electric.Replication.ScopeGraph.impl(srg)
+      validate_txns(txns, permissions, graph_impl, [])
+    else
+      {:ok, state.permissions}
+    end
+  end
+
+  def error_response(%{message: message, tx: tx}) do
+    %Electric.Satellite.SatErrorResp{
+      error_type: :PERMISSION_DENIED,
+      lsn: tx.lsn,
+      message: message
+    }
+  end
+
+  defp validate_txns([], permissions, _graph, _acc) do
+    {:ok, permissions}
+  end
+
+  defp validate_txns([tx | txns], permissions, graph, acc) do
+    case Permissions.validate_write(permissions, graph, tx) do
+      {:ok, permissions} ->
+        validate_txns(txns, permissions, graph, [tx | acc])
+
+      {:error, reason} ->
+        {:error, %Error{reason: reason, tx: tx}, permissions, Enum.reverse(acc), txns}
+    end
+  end
+end

--- a/components/electric/lib/electric/satellite/permissions/write.ex
+++ b/components/electric/lib/electric/satellite/permissions/write.ex
@@ -26,7 +26,7 @@ defmodule Electric.Satellite.Permissions.Write do
   end
 
   def validate(txns, %Protocol.State{} = state) when is_list(txns) do
-    if Permissions.filter_reads_enabled?() do
+    if Permissions.enabled?() do
       %{permissions: permissions, out_rep: %{sent_rows_graph: srg}} = state
       graph_impl = Electric.Replication.ScopeGraph.impl(srg)
       validate_txns(txns, permissions, graph_impl, [])

--- a/components/electric/lib/electric/satellite/protobuf_messages.ex
+++ b/components/electric/lib/electric/satellite/protobuf_messages.ex
@@ -194,6 +194,15 @@
           def encode("SCHEMA_VSN_MISMATCH") do
             6
           end
+        ),
+        (
+          def encode(:PERMISSION_DENIED) do
+            7
+          end
+
+          def encode("PERMISSION_DENIED") do
+            7
+          end
         )
       ]
 
@@ -223,6 +232,9 @@
         end,
         def decode(6) do
           :SCHEMA_VSN_MISMATCH
+        end,
+        def decode(7) do
+          :PERMISSION_DENIED
         end
       ]
 
@@ -239,7 +251,8 @@
           {3, :REPLICATION_FAILED},
           {4, :INVALID_REQUEST},
           {5, :PROTO_VSN_MISMATCH},
-          {6, :SCHEMA_VSN_MISMATCH}
+          {6, :SCHEMA_VSN_MISMATCH},
+          {7, :PERMISSION_DENIED}
         ]
       end
 
@@ -265,6 +278,9 @@
             true
           end,
           def has_constant?(:SCHEMA_VSN_MISMATCH) do
+            true
+          end,
+          def has_constant?(:PERMISSION_DENIED) do
             true
           end
         ]

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -693,7 +693,7 @@ defmodule Electric.Satellite.Protocol do
       process_transaction(tx, state.out_rep.sent_rows_graph, state)
 
     state =
-      if Permissions.filter_reads_enabled?(),
+      if Permissions.enabled?(),
         do: Map.update!(state, :permissions, &Permissions.receive_transaction(&1, tx)),
         else: state
 
@@ -825,7 +825,7 @@ defmodule Electric.Satellite.Protocol do
   end
 
   defp after_permissions_change(state) do
-    if Permissions.filter_reads_enabled?() do
+    if Permissions.enabled?() do
       command =
         %SatClientCommand{
           command: {:reset_database, %SatClientCommand.ResetDatabase{reason: :PERMISSIONS_CHANGE}}
@@ -919,7 +919,7 @@ defmodule Electric.Satellite.Protocol do
 
     {filtered_graph, _, _} =
       filtered_results =
-      if Permissions.filter_reads_enabled?() do
+      if Permissions.enabled?() do
         {accepted_data, filtered_graph} =
           state.permissions
           |> Permissions.Read.filter_shape_data(graph, data, xmin)
@@ -1008,7 +1008,7 @@ defmodule Electric.Satellite.Protocol do
       SentRowsGraph.pop_by_request_ids(graph_diff, gone_request_ids, root_vertex: :fake_root)
 
     {accepted_changes, filtered_graph_diff} =
-      if Permissions.filter_reads_enabled?() do
+      if Permissions.enabled?() do
         state.permissions
         |> Permissions.Read.filter_move_in_data(
           state.out_rep.sent_rows_graph,
@@ -1297,7 +1297,7 @@ defmodule Electric.Satellite.Protocol do
 
   defp apply_permissions_and_shapes(tx, graph, shapes, permissions) do
     {filtered_tx, _rejected_changes, moves_out} =
-      if Permissions.filter_reads_enabled?() do
+      if Permissions.enabled?() do
         Permissions.Read.filter_transaction(permissions, graph, tx)
       else
         {Changes.filter_changes_belonging_to_user(tx, Permissions.user_id(permissions)), [], []}

--- a/components/electric/lib/electric/satellite/write_validation.ex
+++ b/components/electric/lib/electric/satellite/write_validation.ex
@@ -66,9 +66,9 @@ defmodule Electric.Satellite.WriteValidation do
     end
   end
 
-  @spec validate_transactions!(txns(), SchemaLoader.t()) ::
-          {:ok, txns()} | {:error, term()} | {:error, txns(), Error.t(), txns()}
-  def validate_transactions!(txns, schema_loader) do
+  @spec validate_transactions(txns(), SchemaLoader.t()) ::
+          {:ok, txns()} | {:error, term()} | {:error, Error.t(), txns(), txns()}
+  def validate_transactions(txns, schema_loader) do
     with {:ok, schema_version} <- SchemaLoader.load(schema_loader) do
       take_while_ok(txns, &is_valid_tx?(&1, schema_version), [])
     end
@@ -123,7 +123,7 @@ defmodule Electric.Satellite.WriteValidation do
         take_while_ok(tail, fun, [tx | acc])
 
       {:error, error} ->
-        {:error, :lists.reverse(acc), error, tail}
+        {:error, error, :lists.reverse(acc), tail}
     end
   end
 

--- a/components/electric/test/electric/postgres/proxy/injector/electric_test.exs
+++ b/components/electric/test/electric/postgres/proxy/injector/electric_test.exs
@@ -95,10 +95,7 @@ defmodule Electric.Postgres.Proxy.Injector.ElectricTest do
       # all ddlx features are enabled, so we need tests that validate 
       # the behaviour when the features are disabled
       Electric.Features.process_override(
-        proxy_ddlx_grant: false,
-        proxy_ddlx_revoke: false,
-        proxy_ddlx_assign: false,
-        proxy_ddlx_unassign: false,
+        proxy_grant_write_permissions: false,
         proxy_ddlx_sqlite: false
       )
 
@@ -140,27 +137,26 @@ defmodule Electric.Postgres.Proxy.Injector.ElectricTest do
         end
       end
 
-      test "#{scenario.description()} ELECTRIC GRANT", cxt do
+      test "#{scenario.description()} ELECTRIC GRANT READ", cxt do
+        query =
+          "ELECTRIC GRANT READ ON public.items TO (projects, 'house.admin') WHERE (name = Paul);"
+
+        for framework <- TestScenario.frameworks() do
+          cxt.scenario.assert_valid_electric_command(cxt.injector, framework, query, ddl: cxt.ddl)
+        end
+      end
+
+      test "#{scenario.description()} ELECTRIC GRANT WRITE", cxt do
         query =
           "ELECTRIC GRANT UPDATE ON public.items TO (projects, 'house.admin') WHERE (name = Paul);"
 
         cxt.scenario.assert_injector_error(cxt.injector, query, code: "EX900")
       end
 
-      test "#{scenario.description()} ELECTRIC REVOKE", cxt do
+      test "#{scenario.description()} ELECTRIC SQLITE", cxt do
         query =
-          ~s[ELECTRIC REVOKE UPDATE (status, name) ON truths FROM (projects, 'house.admin');]
+          "ELECTRIC SQLITE $$create table local_table (id text primary key)$$;"
 
-        cxt.scenario.assert_injector_error(cxt.injector, query, code: "EX900")
-      end
-
-      test "#{scenario.description()} ELECTRIC ASSIGN", cxt do
-        query = "ELECTRIC ASSIGN (NULL, user_roles.role_name) TO user_roles.user_id;"
-        cxt.scenario.assert_injector_error(cxt.injector, query, code: "EX900")
-      end
-
-      test "#{scenario.description()} ELECTRIC UNASSIGN", cxt do
-        query = "ELECTRIC UNASSIGN 'record.reader' FROM user_permissions.user_id;"
         cxt.scenario.assert_injector_error(cxt.injector, query, code: "EX900")
       end
     end

--- a/components/electric/test/electric/postgres/proxy/injector_test.exs
+++ b/components/electric/test/electric/postgres/proxy/injector_test.exs
@@ -11,10 +11,7 @@ defmodule Electric.Postgres.Proxy.InjectorTest do
   setup do
     # enable all the optional ddlx features
     Electric.Features.process_override(
-      proxy_ddlx_grant: true,
-      proxy_ddlx_revoke: true,
-      proxy_ddlx_assign: true,
-      proxy_ddlx_unassign: true,
+      proxy_grant_write_permissions: true,
       proxy_ddlx_sqlite: true
     )
 

--- a/components/electric/test/electric/postgres/proxy/query_analyser_test.exs
+++ b/components/electric/test/electric/postgres/proxy/query_analyser_test.exs
@@ -29,10 +29,7 @@ defmodule Electric.Postgres.Proxy.QueryAnalyserTest do
     setup(cxt) do
       # enable all the optional ddlx features
       Electric.Features.process_override(
-        proxy_ddlx_grant: true,
-        proxy_ddlx_revoke: true,
-        proxy_ddlx_assign: true,
-        proxy_ddlx_unassign: true,
+        proxy_grant_write_permissions: true,
         proxy_ddlx_sqlite: true
       )
 

--- a/components/electric/test/electric/postgres/proxy/schema_validation_test.exs
+++ b/components/electric/test/electric/postgres/proxy/schema_validation_test.exs
@@ -151,10 +151,7 @@ defmodule Electric.Postgres.Proxy.SchemaValidationTest do
   setup do
     # enable all the optional ddlx features
     Electric.Features.process_override(
-      proxy_ddlx_grant: true,
-      proxy_ddlx_revoke: true,
-      proxy_ddlx_assign: true,
-      proxy_ddlx_unassign: true,
+      proxy_grant_write_permissions: true,
       proxy_ddlx_sqlite: true
     )
 

--- a/components/electric/test/electric/satellite/write_validation_test.exs
+++ b/components/electric/test/electric/satellite/write_validation_test.exs
@@ -67,7 +67,7 @@ defmodule Electric.Satellite.WriteValidationTest do
     }
   end
 
-  describe "validate_transactions!/3" do
+  describe "validate_transactions/3" do
     setup do
       migrations = [
         {"001",
@@ -117,7 +117,7 @@ defmodule Electric.Satellite.WriteValidationTest do
         valid_tx("003")
       ]
 
-      assert {:ok, ^txns} = WriteValidation.validate_transactions!(txns, cxt.loader)
+      assert {:ok, ^txns} = WriteValidation.validate_transactions(txns, cxt.loader)
     end
 
     test "splits valid and invalid with an error", cxt do
@@ -135,8 +135,8 @@ defmodule Electric.Satellite.WriteValidationTest do
 
       txns = pre ++ [invalid] ++ post
 
-      assert {:error, ^pre, error, ^post} =
-               WriteValidation.validate_transactions!(txns, cxt.loader)
+      assert {:error, error, ^pre, ^post} =
+               WriteValidation.validate_transactions(txns, cxt.loader)
 
       assert %{
                tx: ^invalid,

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -375,7 +375,7 @@ defmodule Electric.Satellite.WebsocketServerTest do
     end
 
     @tag with_migrations: [@test_fk_migration],
-         with_features: [read_permissions: false]
+         with_features: [permissions: false]
     test "compensations are filtered based on electric_user_id", ctx do
       with_connect([port: ctx.port, auth: ctx, id: ctx.client_id], fn conn ->
         rel_map = start_replication_and_assert_response(conn, 2)

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -1,9 +1,9 @@
 defmodule Electric.Satellite.WebsocketServerTest do
   use ExUnit.Case, async: false
   use Electric.Satellite.Protobuf
+  use ElectricTest.Satellite.WsServerHelpers
 
   alias Electric.Postgres.CachedWal.Producer
-  alias Electric.Replication.SatelliteConnector
   alias Electric.Replication.Changes
 
   alias Electric.Replication.Changes.{
@@ -41,24 +41,7 @@ defmodule Electric.Satellite.WebsocketServerTest do
                            "CREATE TABLE public.test_child (id TEXT PRIMARY KEY, parent_id TEXT NOT NULL REFERENCES test1 (id), some_flag BOOLEAN NOT NULL)"
                          ]}
 
-  @current_wal_pos 1
-
-  import Mock
-
-  setup_with_mocks([
-    {Electric.Postgres.Repo, [:passthrough],
-     checkout: fn fun -> fun.() end,
-     transaction: fn fun -> fun.() end,
-     checked_out?: fn -> true end,
-     query: fn _, _ -> {:ok, %Postgrex.Result{columns: nil, rows: []}} end,
-     query!: fn _, _ -> %Postgrex.Result{columns: nil, rows: []} end}
-  ]) do
-    %{}
-  end
-
   setup ctx do
-    test_pid = self()
-
     case Map.get(ctx, :with_features, []) do
       [] ->
         nil
@@ -71,22 +54,6 @@ defmodule Electric.Satellite.WebsocketServerTest do
           Electric.Features.enable(feature_state)
         end)
     end
-
-    ctx =
-      ctx
-      |> Map.update(
-        :subscription_data_fun,
-        &mock_data_function/2,
-        fn {name, opts} -> &apply(__MODULE__, name, [&1, &2, opts]) end
-      )
-      |> Map.put_new(:move_in_data_fun, {:mock_move_in_data_fn, []})
-      |> Map.update!(
-        :move_in_data_fun,
-        fn {name, opts} ->
-          &apply(__MODULE__, name, [&1, &2, &3, &4, [{:test_pid, test_pid} | opts]])
-        end
-      )
-      |> Map.put_new(:allowed_unacked_txs, 30)
 
     origin = "test-origin"
     connector_config = [origin: origin, connection: []]
@@ -108,47 +75,6 @@ defmodule Electric.Satellite.WebsocketServerTest do
     start_link_supervised!({Electric.Satellite.ClientReconnectionInfo, connector_config})
 
     %{port: port, server_id: server_id, origin: origin}
-  end
-
-  setup_with_mocks([
-    {SatelliteConnector, [:passthrough],
-     [
-       start_link: fn %{name: name, producer: producer} ->
-         Supervisor.start_link(
-           [
-             {Electric.DummyConsumer, subscribe_to: [{producer, []}], name: :dummy_consumer},
-             {DownstreamProducerMock, Producer.name(name)}
-           ],
-           strategy: :one_for_one
-         )
-       end
-     ]},
-    {
-      Electric.Postgres.CachedWal.Api,
-      [:passthrough],
-      get_current_position: fn _ -> @current_wal_pos end,
-      lsn_in_cached_window?: fn _origin, pos when is_integer(pos) ->
-        pos > @current_wal_pos
-      end,
-      stream_transactions: fn _, _, _ -> [] end
-    }
-  ]) do
-    %{}
-  end
-
-  # make sure server is cleaning up connections
-  setup _cxt do
-    on_exit(fn -> clean_connections() end)
-
-    user_id = "a5408365-7bf4-48b1-afe2-cb8171631d7c"
-    client_id = "device-id-#{Enum.random(100_000..999_999)}"
-    token = Auth.Secure.create_token(user_id)
-
-    {:ok, user_id: user_id, client_id: client_id, token: token}
-  end
-
-  setup ctx do
-    start_schema_cache(ctx[:with_migrations] || [])
   end
 
   describe "resource related check" do
@@ -991,6 +917,7 @@ defmodule Electric.Satellite.WebsocketServerTest do
           start_replication_and_assert_response(conn, 1)
 
           columns = [
+            %SatRelationColumn{name: "id", type: "text"},
             %SatRelationColumn{name: "satellite-column-1", type: "text"},
             %SatRelationColumn{name: "satellite-column-2", type: "varchar"}
           ]
@@ -1003,10 +930,11 @@ defmodule Electric.Satellite.WebsocketServerTest do
             columns: columns
           }
 
-          serialize = fn [a, b] ->
-            map = %{"satellite-column-1" => a, "satellite-column-2" => b}
+          serialize = fn [a, b, c] ->
+            map = %{"id" => a, "satellite-column-1" => b, "satellite-column-2" => c}
 
             Electric.Satellite.Serialization.map_to_row(map, [
+              %{name: "id", type: :text},
               %{name: "satellite-column-1", type: :text},
               %{name: "satellite-column-2", type: :text}
             ])
@@ -1020,12 +948,12 @@ defmodule Electric.Satellite.WebsocketServerTest do
           op_log1 =
             build_op_log([
               %SatOpBegin{commit_timestamp: ct, lsn: client_lsn},
-              %SatOpInsert{relation_id: @test_oid, row_data: serialize.([<<"a">>, <<"b">>])}
+              %SatOpInsert{relation_id: @test_oid, row_data: serialize.(["1", "a", "b"])}
             ])
 
           op_log2 =
             build_op_log([
-              %SatOpInsert{relation_id: @test_oid, row_data: serialize.([<<"c">>, <<"d">>])},
+              %SatOpInsert{relation_id: @test_oid, row_data: serialize.(["2", "c", "d"])},
               %SatOpCommit{}
             ])
 
@@ -1040,11 +968,19 @@ defmodule Electric.Satellite.WebsocketServerTest do
           assert tx.changes == [
                    %NewRecord{
                      relation: {@test_schema, @test_table},
-                     record: %{"satellite-column-1" => "a", "satellite-column-2" => "b"}
+                     record: %{
+                       "id" => "1",
+                       "satellite-column-1" => "a",
+                       "satellite-column-2" => "b"
+                     }
                    },
                    %NewRecord{
                      relation: {@test_schema, @test_table},
-                     record: %{"satellite-column-1" => "c", "satellite-column-2" => "d"}
+                     record: %{
+                       "id" => "2",
+                       "satellite-column-1" => "c",
+                       "satellite-column-2" => "d"
+                     }
                    }
                  ]
 
@@ -1078,172 +1014,5 @@ defmodule Electric.Satellite.WebsocketServerTest do
         assert %SatInStartReplicationResp.ReplicationError{code: :BEHIND_WINDOW} = error
       end)
     end
-  end
-
-  # -------------------------------------------------------------------------------
-  def mock_data_function(
-        {id, requests, _context},
-        [reply_to: {ref, pid}, connection: _, telemetry_span: _, relation_loader: _],
-        opts \\ []
-      ) do
-    insertion_point = Keyword.get(opts, :insertion_point, 0)
-    data_delay_ms = Keyword.get(opts, :data_delay_ms, 0)
-    send(pid, {:data_insertion_point, ref, insertion_point})
-
-    Process.send_after(
-      pid,
-      {:subscription_data, id, insertion_point, {Graph.new(), %{}, Enum.map(requests, & &1.id)}},
-      data_delay_ms
-    )
-  end
-
-  def mock_move_in_data_fn(
-        move_in_ref,
-        {subquery_map, affected_txs},
-        _context,
-        [reply_to: {ref, pid}, connection: _, relation_loader: _],
-        opts \\ []
-      ) do
-    test_pid = Keyword.fetch!(opts, :test_pid)
-    test_ref = make_ref()
-
-    send(test_pid, {:mock_move_in, {self(), test_ref}, move_in_ref, subquery_map})
-
-    {insertion_point, graph_updates, changes} =
-      receive do
-        {:mock_move_in_data, ^test_ref, value} ->
-          value
-      end
-
-    send(pid, {:data_insertion_point, ref, insertion_point})
-
-    request_ids = MapSet.new(Map.keys(subquery_map), & &1.request_id)
-
-    receive do
-      {:mock_move_in_trigger, ^test_ref} ->
-        send(
-          pid,
-          {:move_in_query_data, move_in_ref, insertion_point,
-           {request_ids, graph_updates, changes}, affected_txs}
-        )
-    end
-  end
-
-  def clean_connections() do
-    :ok = drain_pids(active_clients())
-    :ok = drain_active_resources(connectors())
-  end
-
-  defp connectors() do
-    for {mod, pid} <- Electric.Replication.Connectors.status(:raw),
-        mod !== Electric.Replication.PostgresConnectorSup,
-        do: {mod, pid}
-  end
-
-  defp drain_active_resources([]) do
-    :ok
-  end
-
-  defp drain_active_resources([{Electric.Replication.SatelliteConnector, _} | _] = list) do
-    drain_pids(list)
-  end
-
-  defp drain_pids([]) do
-    :ok
-  end
-
-  defp drain_pids([{_client_name, client_pid} | list]) do
-    ref = Process.monitor(client_pid)
-
-    receive do
-      {:DOWN, ^ref, :process, ^client_pid, _} ->
-        drain_pids(list)
-    after
-      1000 ->
-        flunk("tcp client process didn't termivate")
-    end
-  end
-
-  defp consume_till_stop(lsn) do
-    receive do
-      {_, %SatOpLog{} = op_log} ->
-        lsn = get_lsn(op_log)
-        # Logger.warning("consumed: #{inspect(lsn)}")
-        consume_till_stop(lsn)
-
-      {_, %SatRpcResponse{method: "stopReplication"}} ->
-        lsn
-    after
-      @default_wait ->
-        flunk("Timeout while waiting for SatInStopReplicationResp")
-    end
-  end
-
-  defp receive_trans() do
-    receive do
-      {_, %SatOpLog{} = op_log} -> op_log
-    after
-      @default_wait ->
-        flunk("timeout")
-    end
-  end
-
-  defp get_lsn(%SatOpLog{ops: ops}) do
-    assert [%SatTransOp{op: begin} | _] = ops
-    assert {:begin, %SatOpBegin{lsn: lsn}} = begin
-    lsn
-  end
-
-  defp active_clients() do
-    Electric.Satellite.ClientManager.get_clients()
-    |> Enum.flat_map(fn {client_name, client_pid} ->
-      if Process.alive?(client_pid) do
-        [{client_name, client_pid}]
-      else
-        []
-      end
-    end)
-  end
-
-  defp build_events(changes, lsn, origin \\ nil) do
-    [
-      {%Changes.Transaction{
-         changes: List.wrap(changes),
-         commit_timestamp: DateTime.utc_now(),
-         origin: origin,
-         # The LSN here is faked and a number, so we're using the same monotonically growing value as xid to emulate PG
-         xid: lsn
-       }, lsn}
-    ]
-  end
-
-  defp simple_transes(user_id, n, lim \\ 0) do
-    simple_trans(user_id, n, lim, [])
-  end
-
-  defp simple_trans(user_id, n, lim, acc) when n >= lim do
-    [trans] =
-      %Changes.NewRecord{
-        record: %{"content" => "a", "id" => "fakeid", "electric_user_id" => user_id},
-        relation: {@test_schema, @test_table}
-      }
-      |> build_events(n)
-
-    simple_trans(user_id, n - 1, lim, [trans | acc])
-  end
-
-  defp simple_trans(_user_id, _n, _lim, acc) do
-    acc
-  end
-
-  def build_changes(%SatOpBegin{} = op), do: %SatTransOp{op: {:begin, op}}
-  def build_changes(%SatOpInsert{} = op), do: %SatTransOp{op: {:insert, op}}
-  def build_changes(%SatOpUpdate{} = op), do: %SatTransOp{op: {:update, op}}
-  def build_changes(%SatOpDelete{} = op), do: %SatTransOp{op: {:delete, op}}
-  def build_changes(%SatOpCommit{} = op), do: %SatTransOp{op: {:commit, op}}
-
-  defp build_op_log(changes) do
-    ops = Enum.map(changes, fn change -> build_changes(change) end)
-    %SatOpLog{ops: ops}
   end
 end

--- a/components/electric/test/electric/satellite/ws_write_permissions_test.exs
+++ b/components/electric/test/electric/satellite/ws_write_permissions_test.exs
@@ -1,0 +1,331 @@
+defmodule Electric.Satellite.WsWritePermissionsTest do
+  use ExUnit.Case, async: false
+  use Electric.Satellite.Protobuf
+  use Electric.Postgres.MockSchemaLoader
+  use ElectricTest.Satellite.WsServerHelpers
+
+  alias Electric.Postgres.CachedWal.Producer
+
+  alias Electric.Replication.Changes.{
+    NewRecord,
+    Transaction
+  }
+
+  alias Electric.Satellite.Auth
+
+  alias Satellite.TestWsClient, as: MockClient
+
+  import ElectricTest.SetupHelpers
+  import ElectricTest.SatelliteHelpers
+  import Electric.Postgres.TestConnection
+
+  require Logger
+
+  @user_table "users"
+  @user_oid 100_005
+
+  setup ctx do
+    case Map.get(ctx, :with_features, []) do
+      [] ->
+        nil
+
+      feature_overrides ->
+        feature_state = Electric.Features.list()
+        Electric.Features.enable(feature_overrides)
+
+        on_exit(fn ->
+          Electric.Features.enable(feature_state)
+        end)
+    end
+
+    origin = "test-origin"
+    connector_config = [origin: origin, connection: []]
+    port = 55133
+
+    ddlx = ElectricTest.PermissionsHelpers.Perms.to_rules(ctx.ddlx)
+
+    loader_spec = MockSchemaLoader.backend_spec(migrations: ctx.migrations, rules: ddlx)
+
+    plug =
+      {Electric.Plug.SatelliteWebsocketPlug,
+       auth_provider: Auth.provider(),
+       connector_config: connector_config,
+       subscription_data_fun: ctx.subscription_data_fun,
+       move_in_data_fun: ctx.move_in_data_fun,
+       allowed_unacked_txs: ctx.allowed_unacked_txs,
+       schema_loader: loader_spec}
+
+    start_link_supervised!({Bandit, port: port, plug: plug})
+
+    server_id = Electric.instance_id()
+
+    start_link_supervised!({Electric.Satellite.ClientReconnectionInfo, connector_config})
+
+    %{port: port, server_id: server_id, origin: origin}
+  end
+
+  setup [
+    :setup_with_ddlx
+  ]
+
+  @migrations [
+    {"20230815",
+     [
+       ~s'CREATE TABLE #{@test_schema}.#{@user_table} (id text PRIMARY KEY, role text)',
+       ~s'CREATE TABLE #{@test_schema}.#{@test_table} (id text PRIMARY KEY, "satellite-column-1" TEXT, "satellite-column-2" VARCHAR, user_id uuid)'
+     ]}
+  ]
+  @ddlx [
+    "GRANT READ ON #{@test_schema}.#{@test_table} TO AUTHENTICATED",
+    "GRANT WRITE ON #{@test_schema}.#{@test_table} TO AUTHENTICATED WHERE (user_id = auth.user_id)"
+  ]
+
+  describe "Incoming replication (Satellite -> PG)" do
+    @tag migrations: @migrations, ddlx: @ddlx
+    test "permissions allow valid writes", ctx do
+      self = self()
+      client_lsn = <<0, 1, 2, 3>>
+
+      with_mock Electric.DummyConsumer, [:passthrough],
+        notify: fn _, ws_pid, events -> send(self, {:dummy_consumer, ws_pid, events}) end do
+        with_connect([auth: ctx, id: ctx.client_id, port: ctx.port, auto_in_sub: true], fn conn ->
+          start_replication_and_assert_response(conn, 0)
+          send_relation(conn, {@test_schema, @test_table})
+
+          dt = DateTime.truncate(DateTime.utc_now(), :millisecond)
+          ct = DateTime.to_unix(dt, :millisecond)
+
+          op_log1 =
+            build_op_log([
+              %SatOpBegin{commit_timestamp: ct, lsn: client_lsn},
+              %SatOpInsert{
+                relation_id: @test_oid,
+                row_data: serialize(["1", "a", "b", ctx.user_id])
+              }
+            ])
+
+          op_log2 =
+            build_op_log([
+              %SatOpInsert{
+                relation_id: @test_oid,
+                row_data: serialize(["2", "c", "d", ctx.user_id])
+              },
+              %SatOpCommit{}
+            ])
+
+          MockClient.send_data(conn, op_log1)
+          MockClient.send_data(conn, op_log2)
+
+          assert_receive {:dummy_consumer, _, [%Transaction{} = tx]}
+
+          assert tx.lsn == client_lsn
+          assert tx.commit_timestamp == dt
+
+          assert tx.changes == [
+                   %NewRecord{
+                     relation: {@test_schema, @test_table},
+                     record: %{
+                       "id" => "1",
+                       "satellite-column-1" => "a",
+                       "satellite-column-2" => "b",
+                       "user_id" => ctx.user_id
+                     }
+                   },
+                   %NewRecord{
+                     relation: {@test_schema, @test_table},
+                     record: %{
+                       "id" => "2",
+                       "satellite-column-1" => "c",
+                       "satellite-column-2" => "d",
+                       "user_id" => ctx.user_id
+                     }
+                   }
+                 ]
+
+          assert tx.origin !== ""
+        end)
+      end
+    end
+
+    @tag migrations: @migrations, ddlx: @ddlx
+    test "permissions reject invalid writes", ctx do
+      self = self()
+      client_lsn = <<0, 1, 2, 3>>
+      other_user_id = "a9aa6991-a18e-4da9-888e-0412d37c4460"
+
+      with_mock Electric.DummyConsumer, [:passthrough],
+        notify: fn _, ws_pid, events -> send(self, {:dummy_consumer, ws_pid, events}) end do
+        with_connect([auth: ctx, id: ctx.client_id, port: ctx.port, auto_in_sub: true], fn conn ->
+          start_replication_and_assert_response(conn, 0)
+
+          send_relation(conn, {@test_schema, @test_table})
+
+          dt = DateTime.truncate(DateTime.utc_now(), :millisecond)
+          ct = DateTime.to_unix(dt, :millisecond)
+
+          op_log1 =
+            build_op_log([
+              %SatOpBegin{commit_timestamp: ct, lsn: client_lsn},
+              %SatOpInsert{
+                relation_id: @test_oid,
+                row_data: serialize(["1", "a", "b", other_user_id])
+              },
+              %SatOpCommit{}
+            ])
+
+          MockClient.send_data(conn, op_log1)
+
+          refute_receive {:dummy_consumer, _, [%Transaction{}]}
+        end)
+      end
+    end
+
+    @tag migrations: @migrations,
+         ddlx: [
+           "GRANT WRITE ON #{@test_schema}.#{@user_table} TO AUTHENTICATED",
+           "ASSIGN users.role TO users.id",
+           "GRANT READ ON #{@test_schema}.#{@test_table} TO AUTHENTICATED",
+           "GRANT WRITE ON #{@test_schema}.#{@test_table} TO 'admin'"
+         ]
+    test "dynamic role assignment is accepted", ctx do
+      self = self()
+      client_lsn = <<0, 1, 2, 3>>
+
+      with_mock Electric.DummyConsumer, [:passthrough],
+        notify: fn _, ws_pid, events -> send(self, {:dummy_consumer, ws_pid, events}) end do
+        with_connect([auth: ctx, id: ctx.client_id, port: ctx.port, auto_in_sub: true], fn conn ->
+          start_replication_and_assert_response(conn, 0)
+
+          send_relation(conn, {@test_schema, @test_table})
+          send_relation(conn, {@test_schema, @user_table})
+
+          dt = DateTime.truncate(DateTime.utc_now(), :millisecond)
+          ct = DateTime.to_unix(dt, :millisecond)
+
+          op_log1 =
+            build_op_log([
+              %SatOpBegin{commit_timestamp: ct, lsn: client_lsn},
+              %SatOpInsert{
+                relation_id: @test_oid,
+                row_data: serialize(["1", "a", "b", @user_id])
+              },
+              %SatOpCommit{}
+            ])
+
+          MockClient.send_data(conn, op_log1)
+
+          refute_receive {:dummy_consumer, _, [%Transaction{} = _tx]}
+        end)
+      end
+
+      with_mock Electric.DummyConsumer, [:passthrough],
+        notify: fn _, ws_pid, events -> send(self, {:dummy_consumer, ws_pid, events}) end do
+        with_connect([auth: ctx, id: ctx.client_id, port: ctx.port, auto_in_sub: true], fn conn ->
+          start_replication_and_assert_response(conn, 0)
+
+          send_relation(conn, {@test_schema, @test_table})
+          send_relation(conn, {@test_schema, @user_table})
+
+          dt = DateTime.truncate(DateTime.utc_now(), :millisecond)
+          ct = DateTime.to_unix(dt, :millisecond)
+
+          op_log1 =
+            build_op_log([
+              %SatOpBegin{commit_timestamp: ct, lsn: client_lsn},
+              %SatOpInsert{
+                relation_id: @user_oid,
+                row_data: serialize([@user_id, "admin"])
+              },
+              %SatOpInsert{
+                relation_id: @test_oid,
+                row_data: serialize(["1", "a", "b", @user_id])
+              },
+              %SatOpCommit{}
+            ])
+
+          MockClient.send_data(conn, op_log1)
+
+          assert_receive {:dummy_consumer, _, [%Transaction{} = tx]}
+
+          assert tx.lsn == client_lsn
+          assert tx.commit_timestamp == dt
+
+          assert tx.changes == [
+                   %NewRecord{
+                     relation: {@test_schema, @user_table},
+                     record: %{
+                       "id" => @user_id,
+                       "role" => "admin"
+                     }
+                   },
+                   %NewRecord{
+                     relation: {@test_schema, @test_table},
+                     record: %{
+                       "id" => "1",
+                       "satellite-column-1" => "a",
+                       "satellite-column-2" => "b",
+                       "user_id" => @user_id
+                     }
+                   }
+                 ]
+        end)
+      end
+    end
+  end
+
+  def send_relation(conn, {@test_schema, @test_table}) do
+    columns = [
+      %SatRelationColumn{name: "id", type: "text"},
+      %SatRelationColumn{name: "satellite-column-1", type: "text"},
+      %SatRelationColumn{name: "satellite-column-2", type: "varchar"},
+      %SatRelationColumn{name: "user_id", type: "uuid"}
+    ]
+
+    relation = %SatRelation{
+      schema_name: @test_schema,
+      table_type: :TABLE,
+      table_name: @test_table,
+      relation_id: @test_oid,
+      columns: columns
+    }
+
+    MockClient.send_data(conn, relation)
+  end
+
+  def send_relation(conn, {@test_schema, @user_table}) do
+    columns = [
+      %SatRelationColumn{name: "id", type: "text"},
+      %SatRelationColumn{name: "role", type: "text"}
+    ]
+
+    relation = %SatRelation{
+      schema_name: @test_schema,
+      table_type: :TABLE,
+      table_name: @user_table,
+      relation_id: @user_oid,
+      columns: columns
+    }
+
+    MockClient.send_data(conn, relation)
+  end
+
+  def serialize([id, role]) do
+    map = %{"id" => id, "role" => role}
+
+    Electric.Satellite.Serialization.map_to_row(map, [
+      %{name: "id", type: :text},
+      %{name: "role", type: :text}
+    ])
+  end
+
+  def serialize([id, a, b, c]) do
+    map = %{"id" => id, "satellite-column-1" => a, "satellite-column-2" => b, "user_id" => c}
+
+    Electric.Satellite.Serialization.map_to_row(map, [
+      %{name: "id", type: :text},
+      %{name: "satellite-column-1", type: :text},
+      %{name: "satellite-column-2", type: :text},
+      %{name: "user_id", type: :uuid}
+    ])
+  end
+end

--- a/components/electric/test/support/mock_schema_loader.ex
+++ b/components/electric/test/support/mock_schema_loader.ex
@@ -90,6 +90,8 @@ defmodule Electric.Postgres.MockSchemaLoader do
     indexes = Keyword.get(opts, :indexes, %{})
     tables = Keyword.get(opts, :tables, %{})
 
+    rules = Keyword.get(opts, :rules, [])
+
     {__MODULE__,
      [
        parent: parent,
@@ -98,7 +100,8 @@ defmodule Electric.Postgres.MockSchemaLoader do
        pks: pks,
        txids: txids,
        indexes: indexes,
-       tables: tables
+       tables: tables,
+       rules: List.wrap(rules)
      ]}
   end
 
@@ -209,13 +212,12 @@ defmodule Electric.Postgres.MockSchemaLoader do
   end
 
   def connect(opts, conn_config) do
-    {versions, opts} =
-      opts
-      |> Map.new()
-      |> Map.pop(:versions, [])
+    opts = Map.new(opts)
+    {versions, opts} = Map.pop(opts, :versions, [])
+    {rules, opts} = Map.pop(opts, :rules, [])
 
     notify(opts, {:connect, conn_config})
-    {:ok, %__MODULE__{versions: versions, opts: opts}}
+    {:ok, %__MODULE__{versions: versions, opts: opts, global_perms: rules}}
   end
 
   @impl SchemaLoader

--- a/components/electric/test/support/satellite/ws_server_helpers.ex
+++ b/components/electric/test/support/satellite/ws_server_helpers.ex
@@ -1,0 +1,273 @@
+defmodule ElectricTest.Satellite.WsServerHelpers do
+  use Electric.Satellite.Protobuf
+
+  alias Electric.Replication.Changes
+  alias __MODULE__
+
+  import ExUnit.Assertions
+
+  @default_wait 5_000
+  @test_schema "public"
+  @test_table "sqlite_server_test"
+
+  defmacro __using__(_opts \\ []) do
+    test_schema = @test_schema
+    test_table = @test_table
+
+    quote do
+      alias Electric.Postgres.CachedWal.Producer
+      alias Satellite.ProtocolHelpers
+      alias Satellite.TestWsClient, as: MockClient
+
+      import ElectricTest.SetupHelpers
+      import ElectricTest.SatelliteHelpers
+      import ElectricTest.Satellite.WsServerHelpers
+      import Mock
+
+      @test_schema unquote(test_schema)
+      @test_table unquote(test_table)
+      @test_oid 100_004
+      @current_wal_pos 1
+      @user_id "a5408365-7bf4-48b1-afe2-cb8171631d7c"
+
+      setup_with_mocks([
+        {Electric.Postgres.Repo, [:passthrough],
+         checkout: fn fun -> fun.() end,
+         transaction: fn fun -> fun.() end,
+         checked_out?: fn -> true end,
+         query: fn _, _ -> {:ok, %Postgrex.Result{columns: nil, rows: []}} end,
+         query!: fn _, _ -> %Postgrex.Result{columns: nil, rows: []} end}
+      ]) do
+        %{}
+      end
+
+      setup ctx do
+        test_pid = self()
+
+        ctx
+        |> Map.update(
+          :subscription_data_fun,
+          &WsServerHelpers.mock_data_function/2,
+          fn
+            {module, name, opts} -> &apply(module, name, [&1, &2, opts])
+            {name, opts} -> &apply(WsServerHelpers, name, [&1, &2, opts])
+          end
+        )
+        |> Map.put_new(:move_in_data_fun, {WsServerHelpers, :mock_move_in_data_fn, []})
+        |> Map.update!(
+          :move_in_data_fun,
+          fn {module, name, opts} ->
+            &apply(module, name, [&1, &2, &3, &4, [{:test_pid, test_pid} | opts]])
+          end
+        )
+        |> Map.put_new(:allowed_unacked_txs, 30)
+      end
+
+      setup_with_mocks([
+        {Electric.Replication.SatelliteConnector, [:passthrough],
+         [
+           start_link: fn %{name: name, producer: producer} ->
+             Supervisor.start_link(
+               [
+                 {Electric.DummyConsumer, subscribe_to: [{producer, []}], name: :dummy_consumer},
+                 {DownstreamProducerMock, Producer.name(name)}
+               ],
+               strategy: :one_for_one
+             )
+           end
+         ]},
+        {
+          Electric.Postgres.CachedWal.Api,
+          [:passthrough],
+          get_current_position: fn _ -> @current_wal_pos end,
+          lsn_in_cached_window?: fn _origin, pos when is_integer(pos) ->
+            pos > @current_wal_pos
+          end,
+          stream_transactions: fn _, _, _ -> [] end
+        }
+      ]) do
+        %{}
+      end
+
+      # make sure server is cleaning up connections
+      setup _cxt do
+        on_exit(fn -> clean_connections() end)
+
+        client_id = "device-id-#{Enum.random(100_000..999_999)}"
+        token = Electric.Satellite.Auth.Secure.create_token(@user_id)
+
+        {:ok, user_id: @user_id, client_id: client_id, token: token}
+      end
+
+      setup ctx do
+        start_schema_cache(ctx[:with_migrations] || [])
+      end
+    end
+  end
+
+  def mock_data_function(
+        {id, requests, _context},
+        [reply_to: {ref, pid}, connection: _, telemetry_span: _, relation_loader: _],
+        opts \\ []
+      ) do
+    insertion_point = Keyword.get(opts, :insertion_point, 0)
+    data_delay_ms = Keyword.get(opts, :data_delay_ms, 0)
+    send(pid, {:data_insertion_point, ref, insertion_point})
+
+    Process.send_after(
+      pid,
+      {:subscription_data, id, insertion_point, {Graph.new(), %{}, Enum.map(requests, & &1.id)}},
+      data_delay_ms
+    )
+  end
+
+  def mock_move_in_data_fn(
+        move_in_ref,
+        {subquery_map, affected_txs},
+        _context,
+        [reply_to: {ref, pid}, connection: _, relation_loader: _],
+        opts \\ []
+      ) do
+    test_pid = Keyword.fetch!(opts, :test_pid)
+    test_ref = make_ref()
+
+    send(test_pid, {:mock_move_in, {self(), test_ref}, move_in_ref, subquery_map})
+
+    {insertion_point, graph_updates, changes} =
+      receive do
+        {:mock_move_in_data, ^test_ref, value} ->
+          value
+      end
+
+    send(pid, {:data_insertion_point, ref, insertion_point})
+
+    request_ids = MapSet.new(Map.keys(subquery_map), & &1.request_id)
+
+    receive do
+      {:mock_move_in_trigger, ^test_ref} ->
+        send(
+          pid,
+          {:move_in_query_data, move_in_ref, insertion_point,
+           {request_ids, graph_updates, changes}, affected_txs}
+        )
+    end
+  end
+
+  def clean_connections() do
+    :ok = drain_pids(active_clients())
+    :ok = drain_active_resources(connectors())
+  end
+
+  def connectors() do
+    for {mod, pid} <- Electric.Replication.Connectors.status(:raw),
+        mod !== Electric.Replication.PostgresConnectorSup,
+        do: {mod, pid}
+  end
+
+  def drain_active_resources([]) do
+    :ok
+  end
+
+  def drain_active_resources([{Electric.Replication.SatelliteConnector, _} | _] = list) do
+    drain_pids(list)
+  end
+
+  defp drain_pids([]) do
+    :ok
+  end
+
+  defp drain_pids([{_client_name, client_pid} | list]) do
+    ref = Process.monitor(client_pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^client_pid, _} ->
+        drain_pids(list)
+    after
+      1000 ->
+        flunk("tcp client process didn't termivate")
+    end
+  end
+
+  def consume_till_stop(lsn) do
+    receive do
+      {_, %SatOpLog{} = op_log} ->
+        lsn = get_lsn(op_log)
+        # Logger.warning("consumed: #{inspect(lsn)}")
+        consume_till_stop(lsn)
+
+      {_, %SatRpcResponse{method: "stopReplication"}} ->
+        lsn
+    after
+      @default_wait ->
+        flunk("Timeout while waiting for SatInStopReplicationResp")
+    end
+  end
+
+  def receive_trans() do
+    receive do
+      {_, %SatOpLog{} = op_log} -> op_log
+    after
+      @default_wait ->
+        flunk("timeout")
+    end
+  end
+
+  def get_lsn(%SatOpLog{ops: ops}) do
+    assert [%SatTransOp{op: begin} | _] = ops
+    assert {:begin, %SatOpBegin{lsn: lsn}} = begin
+    lsn
+  end
+
+  def active_clients() do
+    Electric.Satellite.ClientManager.get_clients()
+    |> Enum.flat_map(fn {client_name, client_pid} ->
+      if Process.alive?(client_pid) do
+        [{client_name, client_pid}]
+      else
+        []
+      end
+    end)
+  end
+
+  def build_events(changes, lsn, origin \\ nil) do
+    [
+      {%Changes.Transaction{
+         changes: List.wrap(changes),
+         commit_timestamp: DateTime.utc_now(),
+         origin: origin,
+         # The LSN here is faked and a number, so we're using the same monotonically growing value as xid to emulate PG
+         xid: lsn
+       }, lsn}
+    ]
+  end
+
+  def simple_transes(user_id, n, lim \\ 0) do
+    simple_trans(user_id, n, lim, [])
+  end
+
+  defp simple_trans(user_id, n, lim, acc) when n >= lim do
+    [trans] =
+      %Changes.NewRecord{
+        record: %{"content" => "a", "id" => "fakeid", "electric_user_id" => user_id},
+        relation: {@test_schema, @test_table}
+      }
+      |> build_events(n)
+
+    simple_trans(user_id, n - 1, lim, [trans | acc])
+  end
+
+  defp simple_trans(_user_id, _n, _lim, acc) do
+    acc
+  end
+
+  def build_changes(%SatOpBegin{} = op), do: %SatTransOp{op: {:begin, op}}
+  def build_changes(%SatOpInsert{} = op), do: %SatTransOp{op: {:insert, op}}
+  def build_changes(%SatOpUpdate{} = op), do: %SatTransOp{op: {:update, op}}
+  def build_changes(%SatOpDelete{} = op), do: %SatTransOp{op: {:delete, op}}
+  def build_changes(%SatOpCommit{} = op), do: %SatTransOp{op: {:commit, op}}
+
+  def build_op_log(changes) do
+    ops = Enum.map(changes, fn change -> build_changes(change) end)
+    %SatOpLog{ops: ops}
+  end
+end

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -13,7 +13,9 @@ APIs are not guaranteed to be stable. Backwards incompatible changes may (and wi
 Key aspects of the system are not fully implemented yet:
 
 1. [Data modelling](#data-modelling) &mdash; remove constraints and ensure migrations are additive
-2. [DDLX rules](#ddlx-rules) &mdash; limited to electrification
+2. [DDLX rules](#ddlx-rules) &mdash; `ELECTRIC ENABLE` fully supported.
+   Read-only permissions available using the feature flag
+   `ELECTRIC_FEATURES=permissions=true`.
 3. [Shapes](#shapes) &mdash; support following relations and partial sync, but with some limitations
 
 Plus you may encounter [failure modes](#failure-modes) that you need to work around in development
@@ -38,6 +40,8 @@ The DDLX rules for permissions, roles, validation or local SQLite commands docum
 
 - **ELECTRIC GRANT**:
 
+  - Limited to read-only permissions. Attempting to grant `INSERT`, `UPDATE`,
+    or `DELETE` privileges will be rejected by the proxy.
   - Column based partial replication of tables is currently not supported
   - Limiting `INSERT`s to a column subset is currently not supported
 

--- a/docs/usage/data-modelling/permissions.md
+++ b/docs/usage/data-modelling/permissions.md
@@ -10,7 +10,17 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 Once you've [electrified](./electrification.md) a table, you can grant and assign permissions to read and write the data in it using the [`GRANT`](../../api/ddlx.md#grant) and [`ASSIGN`](../../api/ddlx.md#assign) DDLX statements.
 
 :::caution Work in progress
-Permissions are not yet implemented. See the [Roadmap](../../reference/roadmap.md#ddlx-rules) for more information.
+Permissions are not yet fully implemented. See the [Roadmap](../../reference/roadmap.md#ddlx-rules) for more information.
+
+A partial implementation for read-only permissions is available behind a
+feature flag. Run the electric sync-service docker image with the environment
+variable `ELECTRIC_FEATURES=permissions=true` to enable the current permissions
+implementation.
+
+With this set, `ELECTRIC ASSIGN...` and `ELECTRIC GRANT (SELECT | READ)...`
+will work, and the declared permissions will be enforced by the server, but
+attempting to grant write permissions (e.g. `ELECTRIC GRANT UPDATE` etc.) will
+be rejected.
 :::
 
 ## 1. Grant permissions to roles

--- a/e2e/tests/02.03_partial_replication_based_on_user_id.lux
+++ b/e2e/tests/02.03_partial_replication_based_on_user_id.lux
@@ -4,7 +4,7 @@
 
 # disable read permissions for this test only. dockerfile is configured to prioritise the 
 # features set in the local env, so this flag takes precedence over the default
-[invoke setup_with_environment "ELECTRIC_FEATURES=read_permissions=false"]
+[invoke setup_with_environment "ELECTRIC_FEATURES=permissions=false"]
 
 [invoke electrify_table owned_entries]
 

--- a/e2e/tests/03.25_node_pk_position_does_not_matter_for_compensations.lux
+++ b/e2e/tests/03.25_node_pk_position_does_not_matter_for_compensations.lux
@@ -4,7 +4,6 @@
 
 [invoke setup]
 
-[invoke setup_client 1 "electric_1" 5133]
 
 # PREPARATION: Set up dependent tables and add a row that will be referenced
 
@@ -19,15 +18,24 @@
             intvalue_null integer,
             intvalue_null_default integer
         );
-        ALTER TABLE public.items ENABLE ELECTRIC;
         CREATE TABLE public.other_items (
             content TEXT NOT NULL,
             id TEXT PRIMARY KEY,
             item_id UUID REFERENCES public.items(id)
         );
+
+        ALTER TABLE public.items ENABLE ELECTRIC;
         ALTER TABLE public.other_items ENABLE ELECTRIC;
+
+        ELECTRIC GRANT ALL ON public.other_items TO AUTHENTICATED;
+        ELECTRIC GRANT ALL ON public.items TO AUTHENTICATED;
         """]
     [invoke migrate_pg "001" $sql]
+
+[shell electric]
+    ??[debug] Updated global permissions
+
+[invoke setup_client 1 "electric_1" 5133]
 
 [shell satellite_1]
     ??[rpc] recv: #SatInStartReplicationResp

--- a/e2e/tests/compose.yaml
+++ b/e2e/tests/compose.yaml
@@ -20,7 +20,7 @@ services:
       LOGICAL_PUBLISHER_HOST: electric_1
       PG_PROXY_LOG_LEVEL: info
       # prioritise per-test settings
-      ELECTRIC_FEATURES: "${ELECTRIC_FEATURES:-}:read_permissions=true"
+      ELECTRIC_FEATURES: "${ELECTRIC_FEATURES:-}:proxy_grant_write_permissions=true:permissions=true"
     ports:
       - "5133:5133"
       # proxy access

--- a/protocol/satellite.proto
+++ b/protocol/satellite.proto
@@ -96,6 +96,7 @@ message SatErrorResp {
         INVALID_REQUEST = 4;
         PROTO_VSN_MISMATCH = 5;
         SCHEMA_VSN_MISMATCH = 6;
+        PERMISSION_DENIED = 7;
     }
 
     ErrorCode error_type = 1;


### PR DESCRIPTION
As part of the move to read-only permissions this adds in permissions checks for writes from the clients. With this in place and a later pr to disable GRANTing write permissions, we can enable read-only permissions without needing to do the full implementation of scoped write permissions (which we need to figure out). If you can't grant write perms then we don't need to resolve them.

Note for reviewers: The permissions feature flag naming ceases to make sense with this pr, but that's all sorted in the next one, #1347 