### PR TITLE
fix: psql utility

### DIFF
--- a/clients/typescript/src/cli/docker-commands/command-psql.ts
+++ b/clients/typescript/src/cli/docker-commands/command-psql.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import { spawn } from 'node:child_process'
 import {
   addOptionGroupToCommand,
   getConfig,
@@ -31,9 +32,20 @@ export function psql(opts: GetConfigOptionsForGroup<'proxy' | 'electric'>) {
     port: parsePgProxyPort(config.PG_PROXY_PORT).port,
     dbName: config.DATABASE_NAME,
   })
-  dockerCompose(
+  const proc = dockerCompose(
     'exec',
     ['-it', 'postgres', 'psql', containerDbUrl],
     config.CONTAINER_NAME
   )
+
+  proc.on('exit', (code) => {
+	if (code != 0) {
+	  const proxyUrl = config.PROXY
+	  spawn(
+		'psql',
+		[proxyUrl], {
+		  stdio: 'inherit',
+	  })
+	}
+  })
 }

--- a/clients/typescript/src/cli/docker-commands/command-psql.ts
+++ b/clients/typescript/src/cli/docker-commands/command-psql.ts
@@ -41,10 +41,8 @@ export function psql(opts: GetConfigOptionsForGroup<'proxy' | 'electric'>) {
   proc.on('exit', (code) => {
 	if (code != 0) {
 	  const proxyUrl = config.PROXY
-	  spawn(
-		'psql',
-		[proxyUrl], {
-		  stdio: 'inherit',
+	  spawn('psql', [proxyUrl], {
+		stdio: 'inherit',
 	  })
 	}
   })


### PR DESCRIPTION
As reported to @samwillis through electrify discord I discovered a problem with `electric-sql psql` utility that, if you didn't start the proxy with `electric-sql start --with-postgres` the `electric-sql psql` utility would fail to connect to the database. This PR adds a fallback that forces runs the connection using the host machine, still need to check if the host machine has `psql` installed to perform the connection, but I tested like this and it worked just fine. Before actually making that check I want to see the opinion of the owners of the project about this solution.