### PR TITLE
Disable granting write permissions

### DIFF
--- a/components/electric/config/runtime.exs
+++ b/components/electric/config/runtime.exs
@@ -190,18 +190,15 @@ config :electric,
 # override these using the `ELECTRIC_FEATURES` environment variable, e.g.
 # to add a flag enabling `ELECTRIC GRANT` use:
 #
-#     export ELECTRIC_FEATURES="proxy_ddlx_grant=true:${ELECTRIC_FEATURES:-}"
+#     export ELECTRIC_FEATURES="permissions=true:${ELECTRIC_FEATURES:-}"
 #
 # or if you want to just set flags, ignoring any previous env settings
 #
-#     export ELECTRIC_FEATURES="proxy_ddlx_grant=true:proxy_ddlx_assign=true"
+#     export ELECTRIC_FEATURES="permissions=true:proxy_grant_write_permissions=true"
 #
 config :electric, Electric.Features,
-  read_permissions: false,
-  proxy_ddlx_grant: true,
-  proxy_ddlx_revoke: true,
-  proxy_ddlx_assign: true,
-  proxy_ddlx_unassign: true,
+  permissions: false,
+  proxy_grant_write_permissions: false,
   proxy_ddlx_sqlite: false
 
 {:ok, conn_config} = database_url_config

--- a/components/electric/config/runtime.test.exs
+++ b/components/electric/config/runtime.test.exs
@@ -10,4 +10,7 @@ config :electric, disable_listeners: true
 
 config :electric, Electric.Postgres.Proxy.Handler.Tracing, colour: false
 
-config :electric, Electric.Features, read_permissions: true
+config :electric, Electric.Features,
+  permissions: true,
+  proxy_grant_write_permissions: true,
+  proxy_ddlx_sqlite: true

--- a/components/electric/lib/electric/postgres/proxy/errors.ex
+++ b/components/electric/lib/electric/postgres/proxy/errors.ex
@@ -3,10 +3,10 @@ defmodule Electric.Postgres.Proxy.Errors do
 
   import Electric.Utils, only: [inspect_relation: 1]
 
-  def access_control_not_supported(command, query) do
+  def command_not_supported(command, query) do
     %{
       code: "EX001",
-      message: "#{Electric.DDLX.Command.tag(command)} is currently unsupported",
+      message: "#{Electric.DDLX.Command.tag(command)} `#{query}`is currently unsupported",
       detail:
         "We are working on implementing access controls -- when these features are completed then this command will work",
       query: query

--- a/components/electric/lib/electric/postgres/proxy/injector/operation.ex
+++ b/components/electric/lib/electric/postgres/proxy/injector/operation.ex
@@ -923,6 +923,14 @@ defmodule Operation.Disallowed do
           )
       end
     end
+
+    defp error_response(%{action: {:electric, _command}} = analysis) do
+      %M.ErrorResponse{
+        code: "EX100",
+        severity: "ERROR",
+        message: "Invalid statement: #{analysis.sql}"
+      }
+    end
   end
 end
 

--- a/components/electric/lib/electric/postgres/proxy/query_analyser.ex
+++ b/components/electric/lib/electric/postgres/proxy/query_analyser.ex
@@ -660,7 +660,7 @@ defimpl QueryAnalyser, for: PgQuery.CallStmt do
       %{
         analysis
         | allowed?: false,
-          error: Errors.access_control_not_supported(command, analysis.sql)
+          error: Errors.command_not_supported(command, analysis.sql)
       }
     end
   end

--- a/components/electric/lib/electric/satellite/permissions.ex
+++ b/components/electric/lib/electric/satellite/permissions.ex
@@ -280,7 +280,7 @@ defmodule Electric.Satellite.Permissions do
           triggers: Trigger.triggers()
         }
 
-  @read_feature_flag :read_permissions
+  @feature_flag :permissions
 
   @read_privileges [:SELECT]
   @write_privileges [:INSERT, :UPDATE, :DELETE]
@@ -292,9 +292,9 @@ defmodule Electric.Satellite.Permissions do
 
   def privileges, do: @privileges
 
-  @spec filter_reads_enabled?() :: boolean()
-  def filter_reads_enabled?() do
-    Electric.Features.enabled?(@read_feature_flag)
+  @spec enabled?() :: boolean()
+  def enabled? do
+    Electric.Features.enabled?(@feature_flag)
   end
 
   @doc """

--- a/components/electric/lib/electric/satellite/permissions/write.ex
+++ b/components/electric/lib/electric/satellite/permissions/write.ex
@@ -26,7 +26,7 @@ defmodule Electric.Satellite.Permissions.Write do
   end
 
   def validate(txns, %Protocol.State{} = state) when is_list(txns) do
-    if Permissions.filter_reads_enabled?() do
+    if Permissions.enabled?() do
       %{permissions: permissions, out_rep: %{sent_rows_graph: srg}} = state
       graph_impl = Electric.Replication.ScopeGraph.impl(srg)
       validate_txns(txns, permissions, graph_impl, [])

--- a/components/electric/lib/electric/satellite/protocol.ex
+++ b/components/electric/lib/electric/satellite/protocol.ex
@@ -693,7 +693,7 @@ defmodule Electric.Satellite.Protocol do
       process_transaction(tx, state.out_rep.sent_rows_graph, state)
 
     state =
-      if Permissions.filter_reads_enabled?(),
+      if Permissions.enabled?(),
         do: Map.update!(state, :permissions, &Permissions.receive_transaction(&1, tx)),
         else: state
 
@@ -825,7 +825,7 @@ defmodule Electric.Satellite.Protocol do
   end
 
   defp after_permissions_change(state) do
-    if Permissions.filter_reads_enabled?() do
+    if Permissions.enabled?() do
       command =
         %SatClientCommand{
           command: {:reset_database, %SatClientCommand.ResetDatabase{reason: :PERMISSIONS_CHANGE}}
@@ -919,7 +919,7 @@ defmodule Electric.Satellite.Protocol do
 
     {filtered_graph, _, _} =
       filtered_results =
-      if Permissions.filter_reads_enabled?() do
+      if Permissions.enabled?() do
         {accepted_data, filtered_graph} =
           state.permissions
           |> Permissions.Read.filter_shape_data(graph, data, xmin)
@@ -1008,7 +1008,7 @@ defmodule Electric.Satellite.Protocol do
       SentRowsGraph.pop_by_request_ids(graph_diff, gone_request_ids, root_vertex: :fake_root)
 
     {accepted_changes, filtered_graph_diff} =
-      if Permissions.filter_reads_enabled?() do
+      if Permissions.enabled?() do
         state.permissions
         |> Permissions.Read.filter_move_in_data(
           state.out_rep.sent_rows_graph,
@@ -1297,7 +1297,7 @@ defmodule Electric.Satellite.Protocol do
 
   defp apply_permissions_and_shapes(tx, graph, shapes, permissions) do
     {filtered_tx, _rejected_changes, moves_out} =
-      if Permissions.filter_reads_enabled?() do
+      if Permissions.enabled?() do
         Permissions.Read.filter_transaction(permissions, graph, tx)
       else
         {Changes.filter_changes_belonging_to_user(tx, Permissions.user_id(permissions)), [], []}

--- a/components/electric/test/electric/postgres/proxy/injector/electric_test.exs
+++ b/components/electric/test/electric/postgres/proxy/injector/electric_test.exs
@@ -95,10 +95,7 @@ defmodule Electric.Postgres.Proxy.Injector.ElectricTest do
       # all ddlx features are enabled, so we need tests that validate 
       # the behaviour when the features are disabled
       Electric.Features.process_override(
-        proxy_ddlx_grant: false,
-        proxy_ddlx_revoke: false,
-        proxy_ddlx_assign: false,
-        proxy_ddlx_unassign: false,
+        proxy_grant_write_permissions: false,
         proxy_ddlx_sqlite: false
       )
 
@@ -140,27 +137,26 @@ defmodule Electric.Postgres.Proxy.Injector.ElectricTest do
         end
       end
 
-      test "#{scenario.description()} ELECTRIC GRANT", cxt do
+      test "#{scenario.description()} ELECTRIC GRANT READ", cxt do
+        query =
+          "ELECTRIC GRANT READ ON public.items TO (projects, 'house.admin') WHERE (name = Paul);"
+
+        for framework <- TestScenario.frameworks() do
+          cxt.scenario.assert_valid_electric_command(cxt.injector, framework, query, ddl: cxt.ddl)
+        end
+      end
+
+      test "#{scenario.description()} ELECTRIC GRANT WRITE", cxt do
         query =
           "ELECTRIC GRANT UPDATE ON public.items TO (projects, 'house.admin') WHERE (name = Paul);"
 
         cxt.scenario.assert_injector_error(cxt.injector, query, code: "EX900")
       end
 
-      test "#{scenario.description()} ELECTRIC REVOKE", cxt do
+      test "#{scenario.description()} ELECTRIC SQLITE", cxt do
         query =
-          ~s[ELECTRIC REVOKE UPDATE (status, name) ON truths FROM (projects, 'house.admin');]
+          "ELECTRIC SQLITE $$create table local_table (id text primary key)$$;"
 
-        cxt.scenario.assert_injector_error(cxt.injector, query, code: "EX900")
-      end
-
-      test "#{scenario.description()} ELECTRIC ASSIGN", cxt do
-        query = "ELECTRIC ASSIGN (NULL, user_roles.role_name) TO user_roles.user_id;"
-        cxt.scenario.assert_injector_error(cxt.injector, query, code: "EX900")
-      end
-
-      test "#{scenario.description()} ELECTRIC UNASSIGN", cxt do
-        query = "ELECTRIC UNASSIGN 'record.reader' FROM user_permissions.user_id;"
         cxt.scenario.assert_injector_error(cxt.injector, query, code: "EX900")
       end
     end

--- a/components/electric/test/electric/postgres/proxy/injector_test.exs
+++ b/components/electric/test/electric/postgres/proxy/injector_test.exs
@@ -11,10 +11,7 @@ defmodule Electric.Postgres.Proxy.InjectorTest do
   setup do
     # enable all the optional ddlx features
     Electric.Features.process_override(
-      proxy_ddlx_grant: true,
-      proxy_ddlx_revoke: true,
-      proxy_ddlx_assign: true,
-      proxy_ddlx_unassign: true,
+      proxy_grant_write_permissions: true,
       proxy_ddlx_sqlite: true
     )
 

--- a/components/electric/test/electric/postgres/proxy/query_analyser_test.exs
+++ b/components/electric/test/electric/postgres/proxy/query_analyser_test.exs
@@ -29,10 +29,7 @@ defmodule Electric.Postgres.Proxy.QueryAnalyserTest do
     setup(cxt) do
       # enable all the optional ddlx features
       Electric.Features.process_override(
-        proxy_ddlx_grant: true,
-        proxy_ddlx_revoke: true,
-        proxy_ddlx_assign: true,
-        proxy_ddlx_unassign: true,
+        proxy_grant_write_permissions: true,
         proxy_ddlx_sqlite: true
       )
 

--- a/components/electric/test/electric/postgres/proxy/schema_validation_test.exs
+++ b/components/electric/test/electric/postgres/proxy/schema_validation_test.exs
@@ -151,10 +151,7 @@ defmodule Electric.Postgres.Proxy.SchemaValidationTest do
   setup do
     # enable all the optional ddlx features
     Electric.Features.process_override(
-      proxy_ddlx_grant: true,
-      proxy_ddlx_revoke: true,
-      proxy_ddlx_assign: true,
-      proxy_ddlx_unassign: true,
+      proxy_grant_write_permissions: true,
       proxy_ddlx_sqlite: true
     )
 

--- a/components/electric/test/electric/satellite/ws_server_test.exs
+++ b/components/electric/test/electric/satellite/ws_server_test.exs
@@ -375,7 +375,7 @@ defmodule Electric.Satellite.WebsocketServerTest do
     end
 
     @tag with_migrations: [@test_fk_migration],
-         with_features: [read_permissions: false]
+         with_features: [permissions: false]
     test "compensations are filtered based on electric_user_id", ctx do
       with_connect([port: ctx.port, auth: ctx, id: ctx.client_id], fn conn ->
         rel_map = start_replication_and_assert_response(conn, 2)

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -13,7 +13,9 @@ APIs are not guaranteed to be stable. Backwards incompatible changes may (and wi
 Key aspects of the system are not fully implemented yet:
 
 1. [Data modelling](#data-modelling) &mdash; remove constraints and ensure migrations are additive
-2. [DDLX rules](#ddlx-rules) &mdash; limited to electrification
+2. [DDLX rules](#ddlx-rules) &mdash; `ELECTRIC ENABLE` fully supported.
+   Read-only permissions available using the feature flag
+   `ELECTRIC_FEATURES=permissions=true`.
 3. [Shapes](#shapes) &mdash; support following relations and partial sync, but with some limitations
 
 Plus you may encounter [failure modes](#failure-modes) that you need to work around in development
@@ -38,6 +40,8 @@ The DDLX rules for permissions, roles, validation or local SQLite commands docum
 
 - **ELECTRIC GRANT**:
 
+  - Limited to read-only permissions. Attempting to grant `INSERT`, `UPDATE`,
+    or `DELETE` privileges will be rejected by the proxy.
   - Column based partial replication of tables is currently not supported
   - Limiting `INSERT`s to a column subset is currently not supported
 

--- a/docs/usage/data-modelling/permissions.md
+++ b/docs/usage/data-modelling/permissions.md
@@ -10,7 +10,17 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 Once you've [electrified](./electrification.md) a table, you can grant and assign permissions to read and write the data in it using the [`GRANT`](../../api/ddlx.md#grant) and [`ASSIGN`](../../api/ddlx.md#assign) DDLX statements.
 
 :::caution Work in progress
-Permissions are not yet implemented. See the [Roadmap](../../reference/roadmap.md#ddlx-rules) for more information.
+Permissions are not yet fully implemented. See the [Roadmap](../../reference/roadmap.md#ddlx-rules) for more information.
+
+A partial implementation for read-only permissions is available behind a
+feature flag. Run the electric sync-service docker image with the environment
+variable `ELECTRIC_FEATURES=permissions=true` to enable the current permissions
+implementation.
+
+With this set, `ELECTRIC ASSIGN...` and `ELECTRIC GRANT (SELECT | READ)...`
+will work, and the declared permissions will be enforced by the server, but
+attempting to grant write permissions (e.g. `ELECTRIC GRANT UPDATE` etc.) will
+be rejected.
 :::
 
 ## 1. Grant permissions to roles

--- a/e2e/tests/02.03_partial_replication_based_on_user_id.lux
+++ b/e2e/tests/02.03_partial_replication_based_on_user_id.lux
@@ -4,7 +4,7 @@
 
 # disable read permissions for this test only. dockerfile is configured to prioritise the 
 # features set in the local env, so this flag takes precedence over the default
-[invoke setup_with_environment "ELECTRIC_FEATURES=read_permissions=false"]
+[invoke setup_with_environment "ELECTRIC_FEATURES=permissions=false"]
 
 [invoke electrify_table owned_entries]
 

--- a/e2e/tests/compose.yaml
+++ b/e2e/tests/compose.yaml
@@ -20,7 +20,7 @@ services:
       LOGICAL_PUBLISHER_HOST: electric_1
       PG_PROXY_LOG_LEVEL: info
       # prioritise per-test settings
-      ELECTRIC_FEATURES: "${ELECTRIC_FEATURES:-}:read_permissions=true"
+      ELECTRIC_FEATURES: "${ELECTRIC_FEATURES:-}:proxy_grant_write_permissions=true:permissions=true"
     ports:
       - "5133:5133"
       # proxy access


### PR DESCRIPTION
- [x] documentation

Adds a feature flag `permissions` which turns on perms for both reads and writes (on the server), and another separate flag which enables granting write permissions.

So enabling `permissions` turns moves electric into a read-only mode using the permissions expressed via the DDLX