### PR TITLE
Support macOS Big Sur and above

### DIFF
--- a/components/electric/test/electric/postgres/extension/ddl_capture_test.exs
+++ b/components/electric/test/electric/postgres/extension/ddl_capture_test.exs
@@ -7,7 +7,7 @@ defmodule Electric.Postgres.Extension.DDLCaptureTest do
     async: false,
     proxy: [
       listen: [
-        port: 55555
+        port: 55554
       ],
       handler_config: [
         # injector: [capture_mode: Electric.Postgres.Proxy.Injector.Capture.Transparent]


### PR DESCRIPTION
Currently on the latest macOS the tests fail with `eaddrinuse`

This is due to the port being blocked:
- "On MacOS Big Sur and later, port 55555 ... is blocked" - [source](https://docs.solace.com/Software-Broker/SW-Broker-Set-Up/Containers/Set-Up-Docker-Container-macOS.htm#:~:text=On%20MacOS%20Big%20Sur%20and,%22port%20in%20use%22%20error)
- See also: https://forums.developer.apple.com/forums/thread/671197

This PR changes the port number used in the test