### PR TITLE
docs: switch config examples to use direct writes mode.

### DIFF
--- a/docs/api/service.md
+++ b/docs/api/service.md
@@ -16,7 +16,7 @@ Configuration options are passed as environment variables, e.g.:
 ```shell
 docker run \
     -e "DATABASE_URL=postgresql://..." \
-    -e "LOGICAL_PUBLISHER_HOST=..." \
+    -e "ELECTRIC_WRITE_TO_PG_MODE=direct_writes" \
     -e "PG_PROXY_PASSWORD=..." \
     -e "AUTH_JWT_ALG=HS512" \
     -e "AUTH_JWT_KEY=..." \

--- a/docs/deployment/_render.md
+++ b/docs/deployment/_render.md
@@ -51,16 +51,8 @@ services:
       value: "..."
     - key: DATABASE_URL
       value: "postgresql://..."
-    - key: LOGICAL_PUBLISHER_HOST
-      fromService:
-        type: web
-        name: tcp-proxy
-        property: host
-    - key: LOGICAL_PUBLISHER_PORT
-      fromService:
-        type: web
-        name: tcp-proxy
-        property: port
+    - key: ELECTRIC_WRITE_TO_PG_MODE
+      value: "direct_writes"
 - type: web
   name: http-proxy
   runtime: image

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -12,7 +12,7 @@ See <DocPageLink path="usage/installation/service" /> to get familiar with confi
 ```shell
 docker run \
     -e "DATABASE_URL=postgresql://..." \
-    -e "LOGICAL_PUBLISHER_HOST=..." \
+    -e "ELECTRIC_WRITE_TO_PG_MODE=direct_writes" \
     -e "PG_PROXY_PASSWORD=..." \
     -e "AUTH_JWT_ALG=HS512" \
     -e "AUTH_JWT_KEY=..." \

--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -35,8 +35,8 @@ spec:
         env:
         - name: DATABASE_URL
           value: "postgresql://..."
-        - name: LOGICAL_PUBLISHER_HOST
-          value: "..."
+        - name: ELECTRIC_WRITE_TO_PG_MODE
+          value: "direct_writes"
         - name: PG_PROXY_PASSWORD
           value: "..."
         - name: AUTH_JWT_ALG

--- a/docs/examples/notes/running.md
+++ b/docs/examples/notes/running.md
@@ -47,9 +47,9 @@ npm run dev
 
 ### Connecting Electric to Postgres
 
-The Electric sync service connects to Postgres using the `DATABASE_URL` environment variable. Depending on your choice of write mode, Postgres may also need to connect to Electric to consume a logical replication publication.
+The Electric sync service connects to Postgres using the `DATABASE_URL` environment variable. Depending on your [choice of write mode](../../api/service#write-to-pg-mode), Postgres may also need to connect to Electric to consume a logical replication publication.
 
-This is configured using the `LOGICAL_PUBLISHER_HOST` (and `LOGICAL_PUBLISHER_PORT`) environment variables:
+If so, this is configured using the `LOGICAL_PUBLISHER_HOST` (and `LOGICAL_PUBLISHER_PORT`) environment variables:
 
 ```
          |<--------DATABASE_URL----------|

--- a/docs/quickstart/_setup_manual.md
+++ b/docs/quickstart/_setup_manual.md
@@ -23,7 +23,7 @@ docker pull electricsql/electric:latest
 docker run \
     -e "DATABASE_URL=postgresql://..." \
     -e "DATABASE_REQUIRE_SSL=false \
-    -e "LOGICAL_PUBLISHER_HOST=..." \
+    -e "ELECTRIC_WRITE_TO_PG_MODE=direct_writes" \
     -e "PG_PROXY_PASSWORD=..." \
     -e "AUTH_MODE=insecure" \
     -p 5133:5133 \

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -92,18 +92,15 @@ ElectricSQL aims to provide **finality** of local writes. That is to say: valid 
 
 Whilst local writes are final, they are still subject to concurrent merge semantics. One way to understand this is that writes are always *factored in* to the history, even if their operations are actually overridden by the semantics of the conflict resolution logic.
 
-
 ### Streaming into Electric
 
-When the local database migrations are generated from the Postgres DDL changes, triggers are added that automatically copy insert, update and delete operations on the tables to the "oplog" table. The satellite process then processes these operations by sending them to the Electric server over the Satellite protocol. Electric then applies server-side validation and authorisation before sending on to Postgres over the incoming logical-replication stream.
+When the local database migrations are generated from the Postgres DDL changes, triggers are added that automatically copy insert, update and delete operations on the tables to the "oplog" table. The satellite process then processes these operations by sending them to the Electric server over the Satellite protocol.
 
-:::note
-Electric acts as a [logical replication publisher](https://www.postgresql.org/docs/current/logical-replication.html). This is why you configure a `LOGICAL_PUBLISHER_HOST` when deploying the Electric sync service -- so that Postgres can connect to consume inbound logical replication.
-:::
+Electric then applies server-side validation and authorisation before writing into Postgres using the [`ELECTRIC_WRITE_TO_PG_MODE`](../api/service#write-to-pg-mode).
 
 ### Streaming into Postgres
 
-When you electrify a table in the Postgres DDL schema, this installs triggers that handle insert, update and delete operations. When Postgres applies the operations from the inbound logical replication stream, these triggers fire and run database-side merge logic.
+When you electrify a table in the Postgres DDL schema, this installs triggers that handle insert, update and delete operations. When Postgres applies writes from the Electric sync service, these triggers fire and run database-side merge logic.
 
 ### Direct writes to Postgres
 

--- a/docs/usage/installation/service.md
+++ b/docs/usage/installation/service.md
@@ -14,12 +14,12 @@ You can run the [pre-packaged Docker images](#images) published on Docker Hub, o
 The Electric sync service is configured using environment variables. The three required variables are:
 
 - `DATABASE_URL` in the format of a Postgres [Connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS)
-- `LOGICAL_PUBLISHER_HOST` that the sync service is running on (must be accessible from the Postgres instance to establish an inbound replication subscription)
+- either `LOGICAL_PUBLISHER_HOST` that the sync service is running on (must be accessible from the Postgres instance to establish an inbound replication subscription) or set `ELECTRIC_WRITE_TO_PG_MODE=direct_writes`
 - `PG_PROXY_PASSWORD` to safe-guard access to the [Migrations proxy](../data-modelling/migrations.md#migrations-proxy)
 
 ```shell
 DATABASE_URL="postgresql://user:password@localhost:5432/electric"
-LOGICAL_PUBLISHER_HOST="localhost"
+ELECTRIC_WRITE_TO_PG_MODE="direct_writes"
 PG_PROXY_PASSWORD="..."
 ```
 
@@ -34,7 +34,7 @@ Pre-packaged images are available on Docker Hub at [electricsql/electric](https:
 ```shell
 docker run \
     -e "DATABASE_URL=postgresql://..." \
-    -e "LOGICAL_PUBLISHER_HOST=..." \
+    -e "ELECTRIC_WRITE_TO_PG_MODE=direct_writes" \
     -e "PG_PROXY_PASSWORD=..." \
     -e "AUTH_MODE=insecure" \
     -p 5133:5133 \
@@ -75,7 +75,7 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:pg_password@pg/postgres
       DATABASE_REQUIRE_SSL: false
-      LOGICAL_PUBLISHER_HOST: electric
+      ELECTRIC_WRITE_TO_PG_MODE: direct_writes
       PG_PROXY_PASSWORD: proxy_password
       AUTH_MODE: insecure
     ports:
@@ -103,7 +103,7 @@ Then run:
 ```shell
 docker run \
     -e "DATABASE_URL=postgresql://..." \
-    -e "LOGICAL_PUBLISHER_HOST=..." \
+    -e "ELECTRIC_WRITE_TO_PG_MODE=direct_writes" \
     -e "PG_PROXY_PASSWORD=..." \
     -e "AUTH_MODE=insecure" \
     -p 5133:5133 \

--- a/docs/usage/installation/service.md
+++ b/docs/usage/installation/service.md
@@ -11,11 +11,17 @@ You can run the [pre-packaged Docker images](#images) published on Docker Hub, o
 
 ## Configuration
 
-The Electric sync service is configured using environment variables. The three required variables are:
+The Electric sync service is configured using environment variables. The required variables are:
 
 - `DATABASE_URL` in the format of a Postgres [Connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS)
-- either `LOGICAL_PUBLISHER_HOST` that the sync service is running on (must be accessible from the Postgres instance to establish an inbound replication subscription) or set `ELECTRIC_WRITE_TO_PG_MODE=direct_writes`
 - `PG_PROXY_PASSWORD` to safe-guard access to the [Migrations proxy](../data-modelling/migrations.md#migrations-proxy)
+
+Plus depending on your [Write to PG mode](../../api/service#write-to-pg-mode) you must either:
+
+- set `ELECTRIC_WRITE_TO_PG_MODE=direct_writes`; or
+- set `LOGICAL_PUBLISHER_HOST` to a hostname that the Postgres can connect to the sync service on
+
+For example:
 
 ```shell
 DATABASE_URL="postgresql://user:password@localhost:5432/electric"


### PR DESCRIPTION
Recommending setting a `LOGICAL_PUBLISHER_HOST` complicates the examples compared with just setting `ELECTRIC_WRITE_TO_PG_MODE=direct_writes` because this way you don't need to worry about having your docker electric addressable from Postgres.