### PR TITLE
fix(electric): Limit the number of Erlang ports at startup

### DIFF
--- a/.changeset/green-hornets-know.md
+++ b/.changeset/green-hornets-know.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Reduce baseline memory usage by limiting the maximum number of open file descriptors.

--- a/components/electric/Dockerfile
+++ b/components/electric/Dockerfile
@@ -25,10 +25,14 @@ RUN mix deps.get
 RUN mix deps.compile
 
 RUN mix run --no-compile --no-start -e "Application.ensure_all_started(:tzdata); Tzdata.ReleaseUpdater.poll_for_update()"
-COPY config/*runtime.exs /app/config/
-COPY lib /app/lib/
-COPY priv /app/priv
+
+# These are ordered by change frequency, with the least frequently changing dir first.
+COPY rel /app/rel
 COPY src /app/src/
+COPY priv /app/priv
+COPY lib /app/lib/
+
+COPY config/*runtime.exs /app/config/
 
 ARG ELECTRIC_VERSION=local
 ARG MAKE_RELEASE_TASK=release

--- a/components/electric/rel/vm.args.eex
+++ b/components/electric/rel/vm.args.eex
@@ -1,0 +1,14 @@
+# Use the default number of ports regardless of the `OPEN_MAX` limit configured in the OS.
+#
+# In recent versions of Linux kernel and/or Docker, the OPEN_MAX limit is set to an
+# astronomically high value of 1073741816. Erlang picks that value to set its maximum number of
+# ports. When the number is so high, the memory taken up by the port tables ends up dominating
+# the total memory usage of the VM, and it doesn't even show up in Observer stats.
+#
+# Anecdotally, I have seen the memory usage of a Docker container running an Electric release
+# doing nothing go from 1.8GB down to 176MB with this setting.
+#
+# See also:
+# - https://elixirforum.com/t/elixir-erlang-docker-containers-ram-usage-on-different-oss-kernels
+# - https://elixirforum.com/t/beam-vm-consumes-big-amounts-of-memory-virt-vs-erlang-memory-total
++Q 1024


### PR DESCRIPTION
As explained in the newly added `rel/vm.args.eex` file, not doing this may lead to excessive memory usage of BEAM's OS process.

Specific comment on the Elixir Forum confirming that trying to limit the Docker container memory causes beam to get killed with an OOM error without this fix - https://elixirforum.com/t/elixir-erlang-docker-containers-ram-usage-on-different-oss-kernels/57251/15.