### PR TITLE
fix (client): fix immutable fields in setReplicationTransform

### DIFF
--- a/clients/typescript/src/satellite/mock.ts
+++ b/clients/typescript/src/satellite/mock.ts
@@ -25,6 +25,7 @@ import {
   GoneBatchCallback,
   DataGone,
   DataChangeType,
+  DbRecord,
 } from '../util/types'
 import { ElectricConfig } from '../config/index'
 
@@ -227,6 +228,11 @@ export class MockSatelliteClient
   doSkipNextEmit = false
 
   private startReplicationDelayMs: number | null = null
+
+  private replicationTransforms: Map<
+    string,
+    ReplicatedRowTransformer<DbRecord>
+  > = new Map()
 
   setStartReplicationDelayMs(delayMs: number | null) {
     this.startReplicationDelayMs = delayMs
@@ -534,12 +540,12 @@ export class MockSatelliteClient
   }
 
   setReplicationTransform(
-    _tableName: QualifiedTablename,
-    _transform: ReplicatedRowTransformer<DataRecord>
+    tableName: QualifiedTablename,
+    transform: ReplicatedRowTransformer<DataRecord>
   ): void {
-    throw new Error('Method not implemented.')
+    this.replicationTransforms.set(tableName.tablename, transform)
   }
-  clearReplicationTransform(_tableName: QualifiedTablename): void {
-    throw new Error('Method not implemented.')
+  clearReplicationTransform(tableName: QualifiedTablename): void {
+    this.replicationTransforms.delete(tableName.tablename)
   }
 }


### PR DESCRIPTION
This PR modifies the immutable fields that are checked in `setReplicationTransform` such that it checks for the outgoing FK columns and the PK columns that are being pointed at. Also adds unit tests to check that these are computed correctly and an error is thrown if we try to modify them.