### PR TITLE
fix(electric): Add python psycopg3 support

### DIFF
--- a/.changeset/wild-buckets-tease.md
+++ b/.changeset/wild-buckets-tease.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Support psycopg3 style transactions in proxy

--- a/components/electric/lib/electric/postgres/proxy/injector/state.ex
+++ b/components/electric/lib/electric/postgres/proxy/injector/state.ex
@@ -72,6 +72,14 @@ defmodule Electric.Postgres.Proxy.Injector.State do
     not is_nil(state.tx)
   end
 
+  def transaction(%__MODULE__{} = state, action) when action in [:begin, :rollback, :commit] do
+    case action do
+      :begin -> begin(state)
+      :rollback -> rollback(state)
+      :commit -> commit(state)
+    end
+  end
+
   @doc """
   Update the transaction status to mark it as affecting electrified tables (or
   not).

--- a/components/electric/lib/electric/postgres/proxy/query_analyser.ex
+++ b/components/electric/lib/electric/postgres/proxy/query_analyser.ex
@@ -257,6 +257,8 @@ defimpl QueryAnalyser, for: PgQuery.TransactionStmt do
         :TRANS_STMT_BEGIN -> :begin
         :TRANS_STMT_COMMIT -> :commit
         :TRANS_STMT_ROLLBACK -> :rollback
+        :TRANS_STMT_SAVEPOINT -> :savepoint
+        :TRANS_STMT_RELEASE -> :release
       end
 
     %{analysis | action: {:tx, kind}}


### PR DESCRIPTION
psycopg sends begin, commit and rollback statements using the extended, parse, bind, execute, protocol, which is... different