### PR TITLE
chore(client): Add client to patch message for `WITHOUT ROWID` update

### DIFF
--- a/.changeset/khaki-needles-dream.md
+++ b/.changeset/khaki-needles-dream.md
@@ -1,5 +1,6 @@
 ---
+"electric-sql": patch
 "@core/electric": patch
 ---
 
-Remove `WITHOUT ROWID` specification on SQLite migrations for improved performance.
+Remove `WITHOUT ROWID` specification on SQLite migrations for improved performance (see https://github.com/electric-sql/electric/pull/1349).


### PR DESCRIPTION
Added a link to the PR for the change to circumvent the issue of the patch being assigned to the wrong commit, as I think it's useful for anyone wanting to figure out why the change was made to be able to see the description on the PR.