### PR TITLE
chore: Add Node update changeset

### DIFF
--- a/.changeset/curly-cheetahs-mix.md
+++ b/.changeset/curly-cheetahs-mix.md
@@ -1,0 +1,6 @@
+---
+"electric-sql": patch
+"@electric-sql/debug-toolbar": patch
+---
+
+Update `better-sqlite3` dependency, dropping Node v16 support and adding Node v22 support, see [relevant PR](https://github.com/electric-sql/electric/pull/1378).

--- a/.github/workflows/examples_e2e.yml
+++ b/.github/workflows/examples_e2e.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
           cache: npm
           cache-dependency-path: |
             ${{ matrix.example_dir }}/package-lock.json
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
           cache: yarn
           cache-dependency-path: examples/introduction/yarn.lock
       - name: Install dependencies


### PR DESCRIPTION
Forgot to add a changeset for https://github.com/electric-sql/electric/pull/1378

Also the examples are using a fixed version of electric so until the update makes it to the examples they cannot be ran at Node v22 so rolling that back