### PR TITLE
fix(electric): Update SSL logic after upgrading to OTP 27.0

### DIFF
--- a/.changeset/warm-months-explain.md
+++ b/.changeset/warm-months-explain.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fix a bug that first appeared in v0.12.1 and prevented Electric from establishing SSL connections to the database.

--- a/components/electric/lib/electric/postgres/repo.ex
+++ b/components/electric/lib/electric/postgres/repo.ex
@@ -28,7 +28,7 @@ defmodule Electric.Postgres.Repo do
       username: conn_opts.username,
       password: conn_opts.password,
       database: conn_opts.database,
-      ssl: conn_opts.ssl == :required,
+      ssl: conn_opts[:ssl_opts] || false,
       # Pass TCP options to the Postgrex adapter. This is used to let the adapter know to
       # connect to the DB using IPv6, for example.
       socket_options: Map.get(conn_opts, :tcp_opts, []),


### PR DESCRIPTION
When we upgraded the sync service to OTP 27.0, we missed the changed default from `verify_none` to `verify_peer` in SSL connections.

We now explicitly set `verify` to `verify_none` because it's currently the only way to ensure encrypted connections work even when a faulty certificate chain is presented by the PG host. This behaviour matches that of `psql <DATABASE_URL>?sslmode=require`.

Here's an example of connecting to DigitalOcean's Managed PostgreSQL to illustrate the point:
```
$ psql 'postgresql://...?sslmode=require'
Null display is "∅".
Output format is aligned.
Expanded display is used automatically.
Line style is unicode.
Border style is 1.
psql (16.1, server 16.3)
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

[db-postgresql-do-user-13160360-0] doadmin:defaultdb=> \q
```
```
$ psql 'postgresql://...?sslmode=verify-full'
psql: error: connection to server at "***.db.ondigitalocean.com" (167.99.250.38), port 25060 failed: root certificate file "/home/alco/.postgresql/root.crt" does not exist
Either provide the file, use the system's trusted roots with sslrootcert=system, or change sslmode to disable server certificate verification.

$ psql 'sslrootcert=system sslmode=verify-full host=***.db.ondigitalocean.com ...'
psql: error: connection to server at "***.db.ondigitalocean.com" (167.99.250.38), port 25060 failed: SSL error: certificate verify failed
```

```
$ openssl s_client -starttls postgres -showcerts -connect ***.db.ondigitalocean.com:25060 -CApath /etc/ssl/certs/
[...]
SSL handshake has read 3990 bytes and written 885 bytes
Verification error: self-signed certificate in certificate chain
```
Fix #1395.