### PR TITLE
Chunk large satellite payloads

### DIFF
--- a/.changeset/rare-dancers-explain.md
+++ b/.changeset/rare-dancers-explain.md
@@ -2,4 +2,4 @@
 "@core/electric": patch
 ---
 
-Fix socket error when initial sync size exceeds 100MB
+Limit the number of changes in a websocket frame to 100 changes to reduce the chance of frame exceeding 100MB limit in the case where there are lots of changes

--- a/.changeset/rare-dancers-explain.md
+++ b/.changeset/rare-dancers-explain.md
@@ -1,0 +1,5 @@
+---
+"@core/electric": patch
+---
+
+Fix socket error when initial sync size exceeds 100MB

--- a/components/electric/lib/electric/satellite/serialization.ex
+++ b/components/electric/lib/electric/satellite/serialization.ex
@@ -93,7 +93,7 @@ defmodule Electric.Satellite.Serialization do
     # The changes cannot be migration relations, so our "state" is limited
     state = Enum.reduce(changes, state, &serialize_change/2)
 
-    {messages_from_ops([begin_op, state.ops]), state.new_relations, state.known_relations}
+    {messages_from_ops([begin_op | state.ops]), state.new_relations, state.known_relations}
   end
 
   def serialize_shape_data_as_tx(changes, known_relations) do

--- a/components/electric/lib/electric/satellite/serialization.ex
+++ b/components/electric/lib/electric/satellite/serialization.ex
@@ -73,12 +73,11 @@ defmodule Electric.Satellite.Serialization do
     begin_op = %SatTransOp{op: {:begin, tx_begin}}
     commit_op = %SatTransOp{op: {:commit, tx_commit}}
 
-    messages =
-      [begin_op | Enum.reverse([commit_op | state.ops])]
-      |> Enum.chunk_every(100)
-      |> Enum.map(&%SatOpLog{ops: &1})
-
-    {messages, state.new_relations, state.known_relations}
+    {
+      messages_from_ops([begin_op | Enum.reverse([commit_op | state.ops])]),
+      state.new_relations,
+      state.known_relations
+    }
   end
 
   def serialize_move_in_data_as_tx(ref, changes, known_relations) do
@@ -94,12 +93,7 @@ defmodule Electric.Satellite.Serialization do
     # The changes cannot be migration relations, so our "state" is limited
     state = Enum.reduce(changes, state, &serialize_change/2)
 
-    messages =
-      [begin_op | state.ops]
-      |> Enum.chunk_every(100)
-      |> Enum.map(&%SatOpLog{ops: &1})
-
-    {messages, state.new_relations, state.known_relations}
+    {messages_from_ops([begin_op, state.ops]), state.new_relations, state.known_relations}
   end
 
   def serialize_shape_data_as_tx(changes, known_relations) do
@@ -112,12 +106,14 @@ defmodule Electric.Satellite.Serialization do
     # The changes cannot be migration relations, so our "state" is limited
     state = Enum.reduce(changes, state, &serialize_change/2)
 
-    messages =
-      state.ops
-      |> Enum.chunk_every(100)
-      |> Enum.map(&%SatOpLog{ops: &1})
+    {messages_from_ops(state.ops), state.new_relations, state.known_relations}
+  end
 
-    {messages, state.new_relations, state.known_relations}
+  @max_ops_per_message 100
+  defp messages_from_ops(ops) do
+    ops
+    |> Enum.chunk_every(@max_ops_per_message)
+    |> Enum.map(&%SatOpLog{ops: &1})
   end
 
   defp serialize_change(record, state) when is_migration_relation(record.relation) do


### PR DESCRIPTION
To prevent the 100MB payload limit:
```
[Symbol(kError)]: RangeError: Max payload size exceeded
      at Receiver.haveLength (/Users/rob/src/electric-sql/electric/node_modules/.pnpm/ws@8.17.0/node_modules/ws/lib/receiver.js:419:28)
      at Receiver.getPayloadLength64 (/Users/rob/src/electric-sql/electric/node_modules/.pnpm/ws@8.17.0/node_modules/ws/lib/receiver.js:406:10)
      at Receiver.startLoop (/Users/rob/src/electric-sql/electric/node_modules/.pnpm/ws@8.17.0/node_modules/ws/lib/receiver.js:161:16)
      at Receiver._write (/Users/rob/src/electric-sql/electric/node_modules/.pnpm/ws@8.17.0/node_modules/ws/lib/receiver.js:94:10)
      at writeOrBuffer (node:internal/streams/writable:564:12)
      at _write (node:internal/streams/writable:493:10)
      at Writable.write (node:internal/streams/writable:502:10)
      at Socket.socketOnData (/Users/rob/src/electric-sql/electric/node_modules/.pnpm/ws@8.17.0/node_modules/ws/lib/websocket.js:1303:35)
      at Socket.emit (node:events:519:28)
      at addChunk (node:internal/streams/readable:559:12) {
    code: 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH',
    [Symbol(status-code)]: 1009
    ```