### PR TITLE
fix(cli): Fix boolean flag defaults not being respected

### DIFF
--- a/.changeset/blue-dots-rush.md
+++ b/.changeset/blue-dots-rush.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/cli": patch
+---
+
+Fix boolean flag defaults not being respected.

--- a/components/cli/src/config.ts
+++ b/components/cli/src/config.ts
@@ -110,7 +110,7 @@ export function getConfigValue<K extends ConfigOptionName>(
   // Then check if the option was passed as an environment variable
   const envName = name.startsWith('ELECTRIC_') ? name : `ELECTRIC_${name}`
   const envVal = process.env[envName]
-  if (configOptions[name].valueType === Boolean) {
+  if (envName in process.env && configOptions[name].valueType === Boolean) {
     return (!!envVal &&
       !['f', 'false', '0', '', 'no'].includes(
         envVal?.toLocaleLowerCase()

--- a/components/cli/test/config.test.ts
+++ b/components/cli/test/config.test.ts
@@ -1,5 +1,34 @@
 import test from 'ava'
 import { getConfigValue, redactConfigSecrets } from '../src/config'
+import { configOptions } from '../src/config-options'
+
+const origEnv = { ...process.env }
+test.beforeEach(() => {
+  // restore environment
+  process.env = origEnv
+})
+
+test('getConfigValue respects boolean flag defaults', async (t) => {
+  const flagWithTrueDefault = Object.keys(configOptions).find(
+    (key) =>
+      configOptions[key].valueType === Boolean &&
+      configOptions[key].defaultVal === true
+  )!
+  const flagWithFalseDefault = Object.keys(configOptions).find(
+    (key) =>
+      configOptions[key].valueType === Boolean &&
+      configOptions[key].defaultVal === false
+  )!
+
+  t.is(getConfigValue(flagWithTrueDefault), true)
+  t.is(getConfigValue(flagWithFalseDefault), false)
+
+  // ensure environment overrides default
+  process.env[`ELECTRIC_${flagWithTrueDefault}`] = 'false'
+  process.env[`ELECTRIC_${flagWithFalseDefault}`] = 'true'
+  t.is(getConfigValue(flagWithTrueDefault), false)
+  t.is(getConfigValue(flagWithFalseDefault), true)
+})
 
 test('getConfigValue can capture `ELECTRIC_` prefixed CLI opitons', async (t) => {
   const image = getConfigValue('ELECTRIC_IMAGE', { image: 'electric:test' })


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1404

Was overriding default with environment variable value, but not checking if environment variable was actually set