### PR TITLE
fix(electric): Skip loading cacerts

### DIFF
--- a/components/electric/lib/electric/replication/postgres_manager.ex
+++ b/components/electric/lib/electric/replication/postgres_manager.ex
@@ -389,7 +389,10 @@ defmodule Electric.Replication.PostgresConnectorMng do
   #
   # As explained in https://github.com/erlang/otp/issues/8604, the function spec of
   # `:public_key.cacerts_load()` is incorrect.
-  @dialyzer {:nowarn_function, load_cacerts: 0}
+  #
+  # ssl_verify_opts also needs to have its warnings ignored due to the hacky nature of below
+  # code.
+  @dialyzer {:nowarn_function, load_cacerts: 0, ssl_verify_opts: 0}
 
   defp load_cacerts, do: :error
 

--- a/components/electric/lib/electric/replication/postgres_manager.ex
+++ b/components/electric/lib/electric/replication/postgres_manager.ex
@@ -391,20 +391,26 @@ defmodule Electric.Replication.PostgresConnectorMng do
   # `:public_key.cacerts_load()` is incorrect.
   @dialyzer {:nowarn_function, load_cacerts: 0}
 
-  defp load_cacerts do
-    case :public_key.cacerts_load() do
-      :ok ->
-        cacerts = :public_key.cacerts_get()
-        Logger.info("Successfully loaded #{length(cacerts)} cacerts from the OS")
-        {:ok, cacerts}
+  defp load_cacerts, do: :error
 
-      {:error, reason} ->
-        Logger.warning("Failed to load cacerts from the OS: #{inspect(reason)}")
-        :error
+  # Skip loading cacerts because managed database providers tend to have certificate issues
+  # that we haven't yet decided how to deal with.
+  if false do
+    defp load_cacerts do
+      case :public_key.cacerts_load() do
+        :ok ->
+          cacerts = :public_key.cacerts_get()
+          Logger.info("Successfully loaded #{length(cacerts)} cacerts from the OS")
+          {:ok, cacerts}
 
-      :undefined ->
-        Logger.warning("Failed to load cacerts from the OS.")
-        :error
+        {:error, reason} ->
+          Logger.warning("Failed to load cacerts from the OS: #{inspect(reason)}")
+          :error
+
+        :undefined ->
+          Logger.warning("Failed to load cacerts from the OS.")
+          :error
+      end
     end
   end
 


### PR DESCRIPTION
Merging https://github.com/electric-sql/electric/pull/1370 into `main` inadvertently broke the fix that had been introduced in https://github.com/electric-sql/electric/pull/1396. That latter PR's description goes into detail about why we are not ready to validate server certificates.