### PR TITLE
chore(linearlite): Fix linearlite deps

### DIFF
--- a/.changeset/forty-tables-study.md
+++ b/.changeset/forty-tables-study.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/debug-toolbar": patch
+---
+
+Use looser peer dependencies for electric packages

--- a/components/toolbar/package.json
+++ b/components/toolbar/package.json
@@ -31,7 +31,7 @@
     "sql-formatter": "^15.3.1"
   },
   "devDependencies": {
-    "@electric-sql/drivers": "workspace:*",
+    "@electric-sql/drivers": "workspace:~",
     "@electric-sql/pglite": "^0.1.5",
     "@types/better-sqlite3": "7.6.3",
     "@types/node": "^20.12.7",
@@ -41,7 +41,7 @@
     "@typescript-eslint/parser": "^7.14.1",
     "@vitejs/plugin-react": "^4.2.1",
     "better-sqlite3": "^11.0.0",
-    "electric-sql": "workspace:*",
+    "electric-sql": "workspace:~",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
     "happy-dom": "^14.10.2",
@@ -52,8 +52,8 @@
     "vitest": "^1.5.0"
   },
   "peerDependencies": {
-    "@electric-sql/drivers": "workspace:*",
-    "electric-sql": "workspace:*"
+    "@electric-sql/drivers": "workspace:~",
+    "electric-sql": "workspace:~"
   },
   "files": [
     "dist",

--- a/examples/linearlite/package-lock.json
+++ b/examples/linearlite/package-lock.json
@@ -46,7 +46,7 @@
       "devDependencies": {
         "@databases/pg": "^5.4.1",
         "@databases/pg-migrations": "^5.0.2",
-        "@electric-sql/debug-toolbar": "^2.0.0",
+        "@electric-sql/debug-toolbar": "^2.0.1",
         "@tailwindcss/typography": "^0.5.10",
         "@types/jest": "^29.5.4",
         "@types/lodash.debounce": "^4.0.7",
@@ -728,9 +728,9 @@
       "license": "MIT"
     },
     "node_modules/@electric-sql/debug-toolbar": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@electric-sql/debug-toolbar/-/debug-toolbar-2.0.0.tgz",
-      "integrity": "sha512-8NYlBsbysiL22gLGdRgIohtsdpNbHUI6TgF3GaGzm9g8dyfHLMYF0F8bMfXJTS4gLUTbX/YaxLCIlS7EbQVjjg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/debug-toolbar/-/debug-toolbar-2.0.1.tgz",
+      "integrity": "sha512-CCS5GLIHsIKM7tkJgVS52gL08n7+8qe8TzR45fO/fIRlPlOCVWtEN/EKN/Y37wQ0dojPwq6lXlhfu2YLZJTILQ==",
       "dev": true,
       "dependencies": {
         "@glideapps/glide-data-grid": "^6.0.4-alpha8",
@@ -749,7 +749,7 @@
         "node": ">=16.11.0"
       },
       "peerDependencies": {
-        "electric-sql": "0.12.0"
+        "electric-sql": "0.12.1"
       }
     },
     "node_modules/@electric-sql/pglite": {

--- a/examples/linearlite/package.json
+++ b/examples/linearlite/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@databases/pg": "^5.4.1",
     "@databases/pg-migrations": "^5.0.2",
-    "@electric-sql/debug-toolbar": "^2.0.0",
+    "@electric-sql/debug-toolbar": "^2.0.1",
     "@tailwindcss/typography": "^0.5.10",
     "@types/jest": "^29.5.4",
     "@types/lodash.debounce": "^4.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,7 +423,7 @@ importers:
         version: 15.3.1
     devDependencies:
       '@electric-sql/drivers':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../drivers
       '@electric-sql/pglite':
         specifier: ^0.1.5
@@ -453,7 +453,7 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       electric-sql:
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../../clients/typescript
       eslint:
         specifier: ^8.57.0


### PR DESCRIPTION
I've updated the linearlite dependency as it was failing to build and also modified the toolbar workspace dependencies to allow for the closest patch version rather than the exact one.

We might want to do something similar for the CLI and Drivers packages but since they are more tightly coupled we can keep them as `workspace:*` rather than `workspace:~` - once we move to v1 we might want `worksapce:^`