### PR TITLE
chore(client): Log the LSN as base64 instead of bytes

### DIFF
--- a/.changeset/breezy-dancers-complain.md
+++ b/.changeset/breezy-dancers-complain.md
@@ -1,0 +1,5 @@
+---
+"electric-sql": patch
+---
+
+Log the LSN as base64 instead of bytes

--- a/clients/typescript/src/satellite/process.ts
+++ b/clients/typescript/src/satellite/process.ts
@@ -285,7 +285,7 @@ export class SatelliteProcess implements Satellite {
     const lsnBase64 = await this._getMeta('lsn')
     if (lsnBase64 && lsnBase64.length > 0) {
       this._lsn = base64.toBytes(lsnBase64)
-      Log.info(`retrieved lsn ${this._lsn}`)
+      Log.info(`retrieved lsn ${lsnBase64}`)
     } else {
       Log.info(`no lsn retrieved from store`)
     }


### PR DESCRIPTION
This is a minor change but it can end up being helpful during debugging. It will display the LSN in the base64 version instead of an array of numbers. There are other places in the client that log it as base64, and this one seems to be the only one that displays it as bytes.