### PR TITLE
feat: update package name for typescript client to @electric-sql/client

### DIFF
--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -16,10 +16,10 @@ The TypeScript client helps ease reading Shapes from the HTTP API in the browser
 
 ## Install
 
-The client is published on NPM as [`@electric-sql/next`](https://www.npmjs.com/package/@electric-sql/next):
+The client is published on NPM as [`@electric-sql/client`](https://www.npmjs.com/package/@electric-sql/client):
 
 ```sh
-npm i @electric-sql/next
+npm i @electric-sql/client
 ```
 
 ## How to use
@@ -29,7 +29,7 @@ The client exports a `ShapeStream` class for getting updates to shapes on a row-
 ### `ShapeStream`
 
 ```tsx
-import { ShapeStream } from '@electric-sql/next'
+import { ShapeStream } from '@electric-sql/client'
 
 // Passes subscribers rows as they're inserted, updated, or deleted
 const stream = new ShapeStream({
@@ -65,7 +65,7 @@ const stream = new ShapeStream({
 ### `Shape`
 
 ```tsx
-import { ShapeStream, Shape } from '@electric-sql/next'
+import { ShapeStream, Shape } from '@electric-sql/client'
 
 const stream = new ShapeStream({
   url: `http://localhost:3000/v1/shape/foo`,

--- a/examples/linearlite/package.json
+++ b/examples/linearlite/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.5.1",
     "dayjs": "^1.11.11",
     "dotenv": "^16.4.5",
-    "@electric-sql/next": "workspace:*",
+    "@electric-sql/client": "workspace:*",
     "fractional-indexing": "^3.2.0",
     "jsonwebtoken": "^9.0.2",
     "lodash.debounce": "^4.0.8",

--- a/examples/nextjs-example/app/match-stream.ts
+++ b/examples/nextjs-example/app/match-stream.ts
@@ -1,4 +1,4 @@
-import { ShapeStream, ChangeMessage } from "@electric-sql/next"
+import { ShapeStream, ChangeMessage } from "@electric-sql/client"
 
 export async function matchStream<T>({
   stream,

--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@electric-sql/next": "workspace:*",
+    "@electric-sql/client": "workspace:*",
     "@electric-sql/react": "workspace:*",
     "next": "^14.2.5",
     "pg": "^8.12.0",

--- a/examples/redis-client/package.json
+++ b/examples/redis-client/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/electric-sql/electric-next#readme",
   "dependencies": {
-    "@electric-sql/next": "workspace:*",
+    "@electric-sql/client": "workspace:*",
     "redis": "^4.6.14"
   },
   "devDependencies": {

--- a/examples/redis-client/src/index.ts
+++ b/examples/redis-client/src/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from 'redis'
-import { ShapeStream, Message } from '@electric-sql/next'
+import { ShapeStream, Message } from '@electric-sql/client'
 
 // Create a Redis client
 const REDIS_HOST = `localhost`

--- a/examples/remix-basic/app/match-stream.ts
+++ b/examples/remix-basic/app/match-stream.ts
@@ -1,4 +1,4 @@
-import { ShapeStream, ChangeMessage } from "@electric-sql/next"
+import { ShapeStream, ChangeMessage } from "@electric-sql/client"
 
 export async function matchStream({
   stream,

--- a/examples/remix-basic/package.json
+++ b/examples/remix-basic/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@electric-sql/next": "workspace:*",
+    "@electric-sql/client": "workspace:*",
     "@electric-sql/react": "workspace:*",
     "@remix-run/dev": "^2.11.0",
     "@remix-run/node": "^2.11.0",

--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 - Updated dependencies [06e843c]
 - Updated dependencies [22f388f]
-  - @electric-sql/next@0.2.2
+  - @electric-sql/client@0.2.2
 
 ## 0.1.1
 
 ### Patch Changes
 
 - Updated dependencies [5c43a31]
-  - @electric-sql/next@0.2.1
+  - @electric-sql/client@0.2.1
 
 ## 0.1.0
 
@@ -24,7 +24,7 @@
 ### Patch Changes
 
 - Updated dependencies [1ca40a7]
-  - @electric-sql/next@0.2.0
+  - @electric-sql/client@0.2.0
 
 ## 0.0.10
 
@@ -32,14 +32,14 @@
 
 - c3aafda: fix: add prepack script so typescript gets compiled before publishing
 - Updated dependencies [c3aafda]
-  - @electric-sql/next@0.1.1
+  - @electric-sql/client@0.1.1
 
 ## 0.0.9
 
 ### Patch Changes
 
 - Updated dependencies [36b9ab5]
-  - @electric-sql/next@0.1.0
+  - @electric-sql/client@0.1.0
 
 ## 0.0.8
 
@@ -47,7 +47,7 @@
 
 - fedf95c: fix: make packaging work in Remix, etc.
 - Updated dependencies [fedf95c]
-  - @electric-sql/next@0.0.8
+  - @electric-sql/client@0.0.8
 
 ## 0.0.7
 
@@ -55,28 +55,28 @@
 
 - 4ce7634: useShape now uses useSyncExternalStoreWithSelector for better integration with React's rendering lifecycle
 - Updated dependencies [4ce7634]
-  - @electric-sql/next@0.0.7
+  - @electric-sql/client@0.0.7
 
 ## 0.0.6
 
 ### Patch Changes
 
 - Updated dependencies [324effc]
-  - @electric-sql/next@0.0.6
+  - @electric-sql/client@0.0.6
 
 ## 0.0.5
 
 ### Patch Changes
 
 - Updated dependencies [7208887]
-  - @electric-sql/next@0.0.5
+  - @electric-sql/client@0.0.5
 
 ## 0.0.4
 
 ### Patch Changes
 
 - Updated dependencies [958cc0c]
-  - @electric-sql/next@0.0.4
+  - @electric-sql/client@0.0.4
 
 ## 0.0.3
 
@@ -87,7 +87,7 @@
 - Updated dependencies [af3452a]
 - Updated dependencies [cf3b3bb]
 - Updated dependencies [6fdb1b2]
-  - @electric-sql/next@0.0.3
+  - @electric-sql/client@0.0.3
 
 ## 0.0.2
 
@@ -95,4 +95,4 @@
 
 - 3656959: Fixed publishing to include built code
 - Updated dependencies [3656959]
-  - @electric-sql/next@0.0.2
+  - @electric-sql/client@0.0.2

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://next.electric-sql.com",
   "dependencies": {
     "use-sync-external-store": "^1.2.2",
-    "@electric-sql/next": "workspace:*"
+    "@electric-sql/client": "workspace:*"
   },
   "devDependencies": {
     "@testing-library/react": "^16.0.0",

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -3,7 +3,7 @@ import {
   Shape,
   ShapeStream,
   ShapeStreamOptions,
-} from '@electric-sql/next'
+} from '@electric-sql/client'
 import React, { createContext, useCallback, useContext, useRef } from 'react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
 

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, inject, it as bareIt } from 'vitest'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { testWithIssuesTable as it } from './support/test-context'
 import { useShape, ShapesProvider, sortedOptionsHash } from '../src/react-hooks'
-import { Shape, Message } from '@electric-sql/next'
+import { Shape, Message } from '@electric-sql/client'
 
 type FC = React.FC<React.PropsWithChildren>
 const BASE_URL = inject(`baseUrl`)

--- a/packages/react-hooks/test/support/global-setup.ts
+++ b/packages/react-hooks/test/support/global-setup.ts
@@ -1,5 +1,5 @@
 import type { GlobalSetupContext } from 'vitest/node'
-import { FetchError } from '@electric-sql/next'
+import { FetchError } from '@electric-sql/client'
 import { makePgClient } from './test-helpers'
 
 const url = process.env.ELECTRIC_URL ?? `http://localhost:3000`

--- a/packages/react-hooks/test/support/test-context.ts
+++ b/packages/react-hooks/test/support/test-context.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { Client, QueryResult } from 'pg'
 import { inject, test } from 'vitest'
 import { makePgClient } from './test-helpers'
-import { FetchError } from '@electric-sql/next'
+import { FetchError } from '@electric-sql/client'
 
 export type IssueRow = { id: string; title: string }
 export type GeneratedIssueRow = { id?: string; title: string }

--- a/packages/react-hooks/test/support/test-helpers.ts
+++ b/packages/react-hooks/test/support/test-helpers.ts
@@ -1,4 +1,4 @@
-import { ShapeStream, Value, Message } from '@electric-sql/next'
+import { ShapeStream, Value, Message } from '@electric-sql/client'
 import { Client, ClientConfig } from 'pg'
 
 export function makePgClient(overrides: ClientConfig = {}) {

--- a/packages/typescript-client/CHANGELOG.md
+++ b/packages/typescript-client/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @electric-sql/next
+# @electric-sql/client
 
 ## 0.2.2
 

--- a/packages/typescript-client/README.md
+++ b/packages/typescript-client/README.md
@@ -33,10 +33,10 @@ The TypeScript client helps ease reading Shapes from the HTTP API in the browser
 
 ## Install
 
-The client is published on NPM as [`@electric-sql/next`](https://www.npmjs.com/package/@electric-sql/next):
+The client is published on NPM as [`@electric-sql/client`](https://www.npmjs.com/package/@electric-sql/client):
 
 ```sh
-npm i @electric-sql/next
+npm i @electric-sql/client
 ```
 
 ## How to use

--- a/packages/typescript-client/package.json
+++ b/packages/typescript-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@electric-sql/next",
+  "name": "@electric-sql/client",
   "version": "0.2.2",
   "description": "Postgres everywhere - your data, in sync, wherever you need it.",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
 
   examples/linearlite:
     dependencies:
-      '@electric-sql/next':
+      '@electric-sql/client':
         specifier: workspace:*
         version: link:../../packages/typescript-client
       '@electric-sql/react':
@@ -249,7 +249,7 @@ importers:
 
   examples/nextjs-example:
     dependencies:
-      '@electric-sql/next':
+      '@electric-sql/client':
         specifier: workspace:*
         version: link:../../packages/typescript-client
       '@electric-sql/react':
@@ -307,7 +307,7 @@ importers:
 
   examples/redis-client:
     dependencies:
-      '@electric-sql/next':
+      '@electric-sql/client':
         specifier: workspace:*
         version: link:../../packages/typescript-client
       redis:
@@ -354,7 +354,7 @@ importers:
 
   examples/remix-basic:
     dependencies:
-      '@electric-sql/next':
+      '@electric-sql/client':
         specifier: workspace:*
         version: link:../../packages/typescript-client
       '@electric-sql/react':
@@ -518,7 +518,7 @@ importers:
 
   packages/react-hooks:
     dependencies:
-      '@electric-sql/next':
+      '@electric-sql/client':
         specifier: workspace:*
         version: link:../typescript-client
       use-sync-external-store:


### PR DESCRIPTION
We're going to deprecate `electric-sql` and just keep all npm packages under the `@electric-sql` namespace.