### PR TITLE
feat(sync-service): Encode JSON encode on write rather than read

### DIFF
--- a/.changeset/eight-dragons-brake.md
+++ b/.changeset/eight-dragons-brake.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+JSON encoding on write rather than read to reduce memory footprint. For example the memory use of an initial sync of a 35MB/200k row table has been reduced from 50MB to 25MB on the first initial sync (which includes the encoding and the writing to storage) and to 6MB on subsequent initial syncs (where we just read from storage and there's no encoding).

--- a/packages/sync-service/lib/electric/log_items.ex
+++ b/packages/sync-service/lib/electric/log_items.ex
@@ -1,0 +1,121 @@
+defmodule Electric.LogItems do
+  alias Electric.Replication.Changes
+  alias Electric.Replication.LogOffset
+  alias Electric.Shapes.Shape
+  alias Electric.Utils
+
+  @moduledoc """
+  Defines the structure and how to create the items in the log that the electric client reads.
+
+  The log_item() data structure is a map for ease of consumption in the Elixir code, 
+  however when JSON encoded it's the format that the electric client accepts.  
+  """
+
+  @type log_item :: %{
+          key: String.t(),
+          value: map(),
+          headers: map(),
+          offset: LogOffset.t()
+        }
+
+  @spec from_change(
+          Changes.data_change(),
+          txid :: non_neg_integer() | nil,
+          pk_cols :: [String.t()]
+        ) :: [log_item(), ...]
+  def from_change(%Changes.NewRecord{} = change, txid, _) do
+    [
+      %{
+        key: change.key,
+        value: change.record,
+        headers: %{action: :insert, txid: txid, relation: Tuple.to_list(change.relation)},
+        offset: change.log_offset
+      }
+    ]
+  end
+
+  def from_change(%Changes.DeletedRecord{} = change, txid, pk_cols) do
+    [
+      %{
+        key: change.key,
+        value: take_pks_or_all(change.old_record, pk_cols),
+        headers: %{action: :delete, txid: txid, relation: Tuple.to_list(change.relation)},
+        offset: change.log_offset
+      }
+    ]
+  end
+
+  # `old_key` is nil when it's unchanged. This is not possible when there is no PK defined.
+  def from_change(%Changes.UpdatedRecord{old_key: nil} = change, txid, pk_cols) do
+    [
+      %{
+        key: change.key,
+        value: Map.take(change.record, Enum.concat(pk_cols, change.changed_columns)),
+        headers: %{action: :update, txid: txid, relation: Tuple.to_list(change.relation)},
+        offset: change.log_offset
+      }
+    ]
+  end
+
+  def from_change(%Changes.UpdatedRecord{} = change, txid, pk_cols) do
+    [
+      %{
+        key: change.old_key,
+        value: take_pks_or_all(change.old_record, pk_cols),
+        headers: %{
+          action: :delete,
+          txid: txid,
+          relation: Tuple.to_list(change.relation),
+          key_change_to: change.key
+        },
+        offset: change.log_offset
+      },
+      %{
+        key: change.key,
+        value: change.record,
+        headers: %{
+          action: :insert,
+          txid: txid,
+          relation: Tuple.to_list(change.relation),
+          key_change_from: change.old_key
+        },
+        offset: LogOffset.increment(change.log_offset)
+      }
+    ]
+  end
+
+  defp take_pks_or_all(record, []), do: record
+  defp take_pks_or_all(record, pks), do: Map.take(record, pks)
+
+  @spec from_snapshot_row_stream(
+          row_stream :: Stream.t(list()),
+          offset :: LogOffset.t(),
+          shape :: Shape.t(),
+          query_info :: %Postgrex.Query{}
+        ) :: log_item()
+  def from_snapshot_row_stream(row_stream, offset, shape, query_info) do
+    Stream.map(row_stream, &from_snapshot_row(&1, offset, shape, query_info))
+  end
+
+  defp from_snapshot_row(row, offset, shape, query_info) do
+    value = value(row, query_info)
+
+    key = Changes.build_key(shape.root_table, value, Shape.pk(shape))
+
+    %{
+      key: key,
+      value: value,
+      headers: %{action: :insert},
+      offset: offset
+    }
+  end
+
+  defp value(row, %Postgrex.Query{columns: columns, result_types: types}) do
+    [columns, types, row]
+    |> Enum.zip_with(fn
+      [col, Postgrex.Extensions.UUID, val] -> {col, Utils.encode_uuid(val)}
+      [col, _, val] -> {col, to_string(val)}
+    end)
+    |> Map.new()
+  end
+end

--- a/packages/sync-service/lib/electric/log_items.ex
+++ b/packages/sync-service/lib/electric/log_items.ex
@@ -8,7 +8,8 @@ defmodule Electric.LogItems do
   Defines the structure and how to create the items in the log that the electric client reads.
 
   The log_item() data structure is a map for ease of consumption in the Elixir code, 
-  however when JSON encoded it's the format that the electric client accepts.  
+  however when JSON encoded (not done in this module) it's the format that the electric
+  client accepts.
   """
 
   @type log_item :: %{

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -11,7 +11,7 @@ defmodule Electric.Plug.ServeShapePlug do
 
   # Control messages
   @up_to_date [Jason.encode!(%{headers: %{control: "up-to-date"}})]
-  @must_refetch [%{headers: %{control: "must-refetch"}}]
+  @must_refetch Jason.encode!([%{headers: %{control: "must-refetch"}}])
 
   defmodule Params do
     use Ecto.Schema
@@ -194,10 +194,7 @@ defmodule Electric.Plug.ServeShapePlug do
         "location",
         "#{conn.request_path}?shape_id=#{active_shape_id}&offset=-1"
       )
-      |> send_resp(
-        409,
-        Jason.encode_to_iodata!(@must_refetch)
-      )
+      |> send_resp(409, @must_refetch)
       |> halt()
     else
       conn

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -1,12 +1,11 @@
 defmodule Electric.ShapeCache.CubDbStorage do
+  alias Electric.LogItems
   alias Electric.Replication.LogOffset
-  alias Electric.Replication.Changes
-  alias Electric.Utils
-  alias Electric.Shapes.Shape
   @behaviour Electric.ShapeCache.Storage
 
   @snapshot_key_type 0
   @log_key_type 1
+  @snapshot_offset LogOffset.first()
 
   def shared_opts(opts) do
     file_path = Access.get(opts, :file_path, "./shapes")
@@ -93,7 +92,7 @@ defmodule Electric.ShapeCache.CubDbStorage do
       |> Stream.map(fn {_, item} -> item end)
 
     # FIXME: this is naive while we don't have snapshot metadata to get real offset
-    {LogOffset.first(), stream}
+    {@snapshot_offset, stream}
   end
 
   def get_log_stream(shape_id, offset, max_offset, opts) do
@@ -112,14 +111,16 @@ defmodule Electric.ShapeCache.CubDbStorage do
   def has_log_entry?(shape_id, offset, opts) do
     # FIXME: this is naive while we don't have snapshot metadata to get real offsets
     CubDB.has_key?(opts.db, log_key(shape_id, offset)) or
-      (snapshot_exists?(shape_id, opts) and offset == LogOffset.first())
+      (snapshot_exists?(shape_id, opts) and offset == @snapshot_offset)
   end
 
   def make_new_snapshot!(shape_id, shape, query_info, data_stream, opts) do
     data_stream
+    |> LogItems.from_snapshot_row_stream(@snapshot_offset, shape, query_info)
     |> Stream.with_index()
-    |> Stream.map(&row_to_snapshot_item(&1, shape_id, shape, query_info))
-    |> Stream.map(&storage_item_to_log_item/1)
+    |> Stream.map(fn {log_item, index} ->
+      {snapshot_key(shape_id, index), Jason.encode!(log_item)}
+    end)
     |> Stream.chunk_every(500)
     |> Stream.each(fn [{key, _} | _] = chunk -> CubDB.put(opts.db, key, chunk) end)
     |> Stream.run()
@@ -127,12 +128,9 @@ defmodule Electric.ShapeCache.CubDbStorage do
     CubDB.put(opts.db, snapshot_meta_key(shape_id), 0)
   end
 
-  def append_to_log!(shape_id, changes, opts) do
-    changes
-    |> Enum.map(fn {offset, key, action, value, header_data} ->
-      {log_key(shape_id, offset), {key, action, value, header_data}}
-    end)
-    |> Enum.map(&storage_item_to_log_item/1)
+  def append_to_log!(shape_id, log_items, opts) do
+    log_items
+    |> Enum.map(fn log_item -> {log_key(shape_id, log_item.offset), Jason.encode!(log_item)} end)
     |> then(&CubDB.put_multi(opts.db, &1))
 
     :ok
@@ -178,7 +176,7 @@ defmodule Electric.ShapeCache.CubDbStorage do
   defp shapes_end, do: shape_key("zzz-end")
 
   # FIXME: this is naive while we don't have snapshot metadata to get real offsets
-  defp offset({_shape_id, @snapshot_key_type, _index}), do: LogOffset.first()
+  defp offset({_shape_id, @snapshot_key_type, _index}), do: @snapshot_offset
 
   defp offset({_shape_id, @log_key_type, tuple_offset}),
     do: LogOffset.new(tuple_offset)
@@ -188,32 +186,4 @@ defmodule Electric.ShapeCache.CubDbStorage do
 
   defp snapshot_start(shape_id), do: snapshot_key(shape_id, 0)
   defp snapshot_end(shape_id), do: snapshot_key(shape_id, :end)
-
-  defp row_to_snapshot_item({row, index}, shape_id, shape, %Postgrex.Query{
-         columns: columns,
-         result_types: types
-       }) do
-    serialized_row =
-      [columns, types, row]
-      |> Enum.zip_with(fn
-        [col, Postgrex.Extensions.UUID, val] -> {col, Utils.encode_uuid(val)}
-        [col, _, val] -> {col, val}
-      end)
-      |> Map.new()
-
-    change_key = Changes.build_key(shape.root_table, serialized_row, Shape.pk(shape))
-
-    {snapshot_key(shape_id, index), {change_key, :insert, serialized_row, %{}}}
-  end
-
-  defp storage_item_to_log_item({key, {change_key, action, value, header_data}})
-       when is_binary(change_key) do
-    {key,
-     Jason.encode!(%{
-       key: change_key,
-       value: value,
-       headers: Map.put(header_data, :action, action),
-       offset: offset(key)
-     })}
-  end
 end

--- a/packages/sync-service/test/electric/log_item_test.exs
+++ b/packages/sync-service/test/electric/log_item_test.exs
@@ -1,0 +1,173 @@
+defmodule Electric.LogItemsTest do
+  use ExUnit.Case, async: true
+  alias Electric.LogItems
+  alias Electric.Replication.LogOffset
+  alias Electric.Replication.Changes
+
+  describe "from_change/3" do
+    test "stores an entire `NewRecord` value" do
+      record = %Changes.NewRecord{
+        key: "my_key",
+        record: %{"pk" => "10", "hello" => "world"},
+        log_offset: LogOffset.first(),
+        relation: {"public", "test"}
+      }
+
+      assert LogItems.from_change(record, 1, ["pk"]) ==
+               [
+                 %{
+                   offset: LogOffset.new(0, 0),
+                   value: %{"hello" => "world", "pk" => "10"},
+                   key: "my_key",
+                   headers: %{relation: ["public", "test"], action: :insert, txid: 1}
+                 }
+               ]
+
+      # And with empty PK
+      assert LogItems.from_change(record, 1, []) ==
+               [
+                 %{
+                   offset: LogOffset.new(0, 0),
+                   value: %{"hello" => "world", "pk" => "10"},
+                   key: "my_key",
+                   headers: %{relation: ["public", "test"], action: :insert, txid: 1}
+                 }
+               ]
+    end
+
+    test "stores only PK of a `DeletedRecord` value" do
+      record = %Changes.DeletedRecord{
+        key: "my_key",
+        old_record: %{"pk" => "10", "hello" => "world"},
+        log_offset: LogOffset.first(),
+        relation: {"public", "test"}
+      }
+
+      assert LogItems.from_change(record, 1, ["pk"]) ==
+               [
+                 %{
+                   offset: LogOffset.new(0, 0),
+                   value: %{"pk" => "10"},
+                   key: "my_key",
+                   headers: %{relation: ["public", "test"], action: :delete, txid: 1}
+                 }
+               ]
+    end
+
+    test "stores entire `DeletedRecord` value if table has no PK" do
+      record = %Changes.DeletedRecord{
+        key: "my_key",
+        old_record: %{"value" => "10", "hello" => "world"},
+        log_offset: LogOffset.first(),
+        relation: {"public", "test"}
+      }
+
+      assert LogItems.from_change(record, 1, []) ==
+               [
+                 %{
+                   offset: LogOffset.new(0, 0),
+                   value: %{"hello" => "world", "value" => "10"},
+                   key: "my_key",
+                   headers: %{relation: ["public", "test"], action: :delete, txid: 1}
+                 }
+               ]
+    end
+
+    test "stores any changed columns and PK of an `UpdatedRecord` value" do
+      record =
+        Changes.UpdatedRecord.new(%{
+          key: "my_key",
+          old_record: %{"pk" => "10", "hello" => "world", "test" => "me"},
+          record: %{"pk" => "10", "hello" => "world", "test" => "new"},
+          log_offset: LogOffset.first(),
+          relation: {"public", "test"}
+        })
+
+      assert LogItems.from_change(record, 1, ["pk"]) ==
+               [
+                 %{
+                   offset: LogOffset.new(0, 0),
+                   value: %{"pk" => "10", "test" => "new"},
+                   key: "my_key",
+                   headers: %{relation: ["public", "test"], action: :update, txid: 1}
+                 }
+               ]
+    end
+
+    test "splits up the `UpdatedRecord` if a key was changed, adding a reference to both" do
+      record =
+        Changes.UpdatedRecord.new(%{
+          old_key: "old_key",
+          key: "new_key",
+          old_record: %{"pk" => "9", "hello" => "world", "test" => "me"},
+          record: %{"pk" => "10", "hello" => "world", "test" => "new"},
+          log_offset: LogOffset.first(),
+          relation: {"public", "test"}
+        })
+
+      assert LogItems.from_change(record, 1, ["pk"]) ==
+               [
+                 %{
+                   offset: LogOffset.new(0, 0),
+                   value: %{"pk" => "9"},
+                   key: "old_key",
+                   headers: %{
+                     relation: ["public", "test"],
+                     action: :delete,
+                     txid: 1,
+                     key_change_to: "new_key"
+                   }
+                 },
+                 %{
+                   offset: LogOffset.new(0, 1),
+                   value: %{"hello" => "world", "pk" => "10", "test" => "new"},
+                   key: "new_key",
+                   headers: %{
+                     relation: ["public", "test"],
+                     action: :insert,
+                     txid: 1,
+                     key_change_from: "old_key"
+                   }
+                 }
+               ]
+    end
+
+    test "splits up the `UpdatedRecord` if a key was changed, adding a reference to both when no PK is defined" do
+      record =
+        Changes.UpdatedRecord.new(%{
+          old_key: "old_key",
+          key: "new_key",
+          old_record: %{"hello" => "world", "test" => "me"},
+          record: %{"hello" => "world", "test" => "new"},
+          log_offset: LogOffset.first(),
+          relation: {"public", "test"}
+        })
+
+      assert LogItems.from_change(record, 1, []) ==
+               [
+                 %{
+                   offset: LogOffset.new(0, 0),
+                   value: %{"hello" => "world", "test" => "me"},
+                   key: "old_key",
+                   headers: %{
+                     relation: ["public", "test"],
+                     action: :delete,
+                     txid: 1,
+                     key_change_to: "new_key"
+                   }
+                 },
+                 %{
+                   offset: LogOffset.new(0, 1),
+                   value: %{"hello" => "world", "test" => "new"},
+                   key: "new_key",
+                   headers: %{
+                     relation: ["public", "test"],
+                     action: :insert,
+                     txid: 1,
+                     key_change_from: "old_key"
+                   }
+                 }
+               ]
+    end
+  end
+end

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -105,10 +105,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       MockStorage
       |> expect(:get_snapshot, fn @test_shape_id, _opts ->
-        {@first_offset, [%{key: "snapshot"}]}
+        {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
       end)
       |> expect(:get_log_stream, fn @test_shape_id, @first_offset, _, _opts ->
-        [%{key: "log", value: "foo", headers: %{}, offset: next_offset}]
+        [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
       conn =
@@ -146,10 +146,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       MockStorage
       |> expect(:get_snapshot, fn @test_shape_id, _opts ->
-        {@first_offset, [%{key: "snapshot"}]}
+        {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
       end)
       |> expect(:get_log_stream, fn @test_shape_id, @first_offset, _, _opts ->
-        [%{key: "log", value: "foo", headers: %{}, offset: next_offset}]
+        [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
       max_age = 62
@@ -179,10 +179,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       MockStorage
       |> expect(:get_snapshot, fn @test_shape_id, _opts ->
-        {@first_offset, [%{key: "snapshot"}]}
+        {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
       end)
       |> expect(:get_log_stream, fn @test_shape_id, @first_offset, _, _opts ->
-        [%{key: "log", value: "foo", headers: %{}, offset: next_offset}]
+        [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
       conn =
@@ -205,8 +205,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       MockStorage
       |> expect(:get_log_stream, fn @test_shape_id, @start_offset_50, _, _opts ->
         [
-          %{key: "log1", value: "foo", headers: %{}, offset: next_offset},
-          %{key: "log2", value: "bar", headers: %{}, offset: next_next_offset}
+          Jason.encode!(%{key: "log1", value: "foo", headers: %{}, offset: next_offset}),
+          Jason.encode!(%{key: "log2", value: "bar", headers: %{}, offset: next_next_offset})
         ]
       end)
       |> expect(:has_log_entry?, fn @test_shape_id, @start_offset_50, _ -> true end)
@@ -283,7 +283,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         []
       end)
       |> expect(:get_log_stream, fn @test_shape_id, @test_offset, ^next_offset, _opts ->
-        ["test result"]
+        [Jason.encode!("test result")]
       end)
 
       task =

--- a/packages/sync-service/test/electric/replication/log_offset_test.exs
+++ b/packages/sync-service/test/electric/replication/log_offset_test.exs
@@ -19,9 +19,9 @@ defmodule Electric.Replication.LogOffsetTest do
   end
 
   test "LogOffset implements `Json.Encoder` protocol" do
-    assert {:ok, "\"0_0\""} = Jason.encode(LogOffset.new(0, 0))
-    assert {:ok, "\"10_2\""} = Jason.encode(LogOffset.new(10, 2))
-    assert {:ok, "\"-1\""} = Jason.encode(LogOffset.before_all())
+    assert {:ok, ~s|"0_0"|} = Jason.encode(LogOffset.new(0, 0))
+    assert {:ok, ~s|"10_2"|} = Jason.encode(LogOffset.new(10, 2))
+    assert {:ok, ~s|"-1"|} = Jason.encode(LogOffset.before_all())
   end
 
   test "LogOffset implements `String.Chars` protocol" do

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -252,11 +252,11 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
           {shape2, @other_shape, xmin}
         ]
       end)
-      |> expect(:append_to_log!, fn ^shape1, ^last_log_offset, [{_, _, _, record, _}], _ ->
+      |> expect(:append_to_log!, fn ^shape1, ^last_log_offset, [%{value: record}], _ ->
         assert record["id"] == "1"
         :ok
       end)
-      |> expect(:append_to_log!, fn ^shape2, ^last_log_offset, [{_, _, _, record, _}], _ ->
+      |> expect(:append_to_log!, fn ^shape2, ^last_log_offset, [%{value: record}], _ ->
         assert record["id"] == "2"
         :ok
       end)

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -22,7 +22,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
     }
   }
   @snapshot_offset LogOffset.first()
-  @snapshot_offset_encoded @snapshot_offset |> LogOffset.to_iolist() |> :erlang.iolist_to_binary()
+  @snapshot_offset_encoded to_string(@snapshot_offset)
   @zero_offset LogOffset.first()
   @query_info %Postgrex.Query{
     name: "the-table",
@@ -34,8 +34,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
     [<<2::128>>, "row2"]
   ]
 
-  for module <- [CubDbStorage] do
-    # for module <- [InMemoryStorage, CubDbStorage] do
+  for module <- [InMemoryStorage, CubDbStorage] do
     module_name = module |> Module.split() |> List.last()
 
     doctest module, import: true

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -89,18 +89,18 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
         assert [
                  %{
-                   "offset" => @snapshot_offset_encoded,
-                   "value" => %{"id" => "00000000-0000-0000-0000-000000000001", "title" => "row1"},
-                   "key" => ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000001"|,
-                   "headers" => %{"action" => "insert"}
+                   offset: @snapshot_offset_encoded,
+                   value: %{id: "00000000-0000-0000-0000-000000000001", title: "row1"},
+                   key: ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000001"|,
+                   headers: %{action: "insert"}
                  },
                  %{
-                   "offset" => @snapshot_offset_encoded,
-                   "value" => %{"id" => "00000000-0000-0000-0000-000000000002", "title" => "row2"},
-                   "key" => ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000002"|,
-                   "headers" => %{"action" => "insert"}
+                   offset: @snapshot_offset_encoded,
+                   value: %{id: "00000000-0000-0000-0000-000000000002", title: "row2"},
+                   key: ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000002"|,
+                   headers: %{action: "insert"}
                  }
-               ] = Enum.map(stream, &Jason.decode!/1)
+               ] = Enum.map(stream, &Jason.decode!(&1, keys: :atoms))
       end
 
       test "does not leak results from other snapshots", %{module: storage, opts: opts} do
@@ -123,18 +123,18 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
         assert [
                  %{
-                   "offset" => @snapshot_offset_encoded,
-                   "value" => %{"id" => "00000000-0000-0000-0000-000000000001", "title" => "row1"},
-                   "key" => ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000001"|,
-                   "headers" => %{"action" => "insert"}
+                   offset: @snapshot_offset_encoded,
+                   value: %{id: "00000000-0000-0000-0000-000000000001", title: "row1"},
+                   key: ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000001"|,
+                   headers: %{action: "insert"}
                  },
                  %{
-                   "offset" => @snapshot_offset_encoded,
-                   "value" => %{"id" => "00000000-0000-0000-0000-000000000002", "title" => "row2"},
-                   "key" => ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000002"|,
-                   "headers" => %{"action" => "insert"}
+                   offset: @snapshot_offset_encoded,
+                   value: %{id: "00000000-0000-0000-0000-000000000002", title: "row2"},
+                   key: ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000002"|,
+                   headers: %{action: "insert"}
                  }
-               ] = Enum.map(stream, &Jason.decode!/1)
+               ] = Enum.map(stream, &Jason.decode!(&1, keys: :atoms))
       end
 
       test "returns snapshot offset when shape does exist", %{module: storage, opts: opts} do
@@ -188,16 +188,16 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
         assert [
                  %{
-                   "key" => ~S|"public"."test_table"/"123"|,
-                   "value" => %{"id" => "123", "name" => "Test"},
-                   "offset" => offset |> LogOffset.to_iolist() |> :erlang.iolist_to_binary(),
-                   "headers" => %{
-                     "action" => "insert",
-                     "txid" => 1,
-                     "relation" => ["public", "test_table"]
+                   key: ~S|"public"."test_table"/"123"|,
+                   value: %{id: "123", name: "Test"},
+                   offset: offset |> LogOffset.to_iolist() |> :erlang.iolist_to_binary(),
+                   headers: %{
+                     action: "insert",
+                     txid: 1,
+                     relation: ["public", "test_table"]
                    }
                  }
-               ] == Enum.map(stream, &Jason.decode!/1)
+               ] == Enum.map(stream, &Jason.decode!(&1, keys: :atoms))
       end
     end
 
@@ -243,12 +243,12 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         :ok = storage.append_to_log!(shape_id, log_items2, opts)
 
         stream = storage.get_log_stream(shape_id, LogOffset.first(), LogOffset.last(), opts)
-        entries = Enum.map(stream, &Jason.decode!/1)
+        entries = Enum.map(stream, &Jason.decode!(&1, keys: :atoms))
 
         assert [
-                 %{"headers" => %{"action" => "insert"}},
-                 %{"headers" => %{"action" => "update"}},
-                 %{"headers" => %{"action" => "delete"}}
+                 %{headers: %{action: "insert"}},
+                 %{headers: %{action: "update"}},
+                 %{headers: %{action: "delete"}}
                ] = entries
       end
 
@@ -288,11 +288,11 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         stream =
           storage.get_log_stream(@shape_id, LogOffset.new(lsn1, 0), LogOffset.last(), opts)
 
-        entries = Enum.map(stream, &Jason.decode!/1)
+        entries = Enum.map(stream, &Jason.decode!(&1, keys: :atoms))
 
         assert [
-                 %{"headers" => %{"action" => "update"}},
-                 %{"headers" => %{"action" => "delete"}}
+                 %{headers: %{action: "update"}},
+                 %{headers: %{action: "delete"}}
                ] = entries
       end
 
@@ -340,9 +340,9 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
             opts
           )
 
-        entries = Enum.map(stream, &Jason.decode!/1)
+        entries = Enum.map(stream, &Jason.decode!(&1, keys: :atoms))
 
-        assert [%{"headers" => %{"action" => "update"}}] = entries
+        assert [%{headers: %{action: "update"}}] = entries
       end
 
       test "returns only logs for the requested shape_id", %{module: storage, opts: opts} do
@@ -374,9 +374,9 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         :ok = storage.append_to_log!(shape_id1, log_items1, opts)
         :ok = storage.append_to_log!(shape_id2, log_items2, opts)
 
-        assert [%{"value" => %{"name" => "Test A"}}] =
+        assert [%{value: %{name: "Test A"}}] =
                  storage.get_log_stream(shape_id1, LogOffset.first(), LogOffset.last(), opts)
-                 |> Enum.map(&Jason.decode!/1)
+                 |> Enum.map(&Jason.decode!(&1, keys: :atoms))
       end
     end
 

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -3,7 +3,6 @@ defmodule Electric.ShapeCache.StorageTest do
   alias Electric.ShapeCache.Storage
   alias Electric.ShapeCache.MockStorage
   alias Electric.Replication.LogOffset
-  alias Electric.Replication.Changes
 
   import Mox
 
@@ -44,119 +43,6 @@ defmodule Electric.ShapeCache.StorageTest do
 
     assert_raise FunctionClauseError, fn ->
       Storage.get_log_stream("test", l2, l1, storage)
-    end
-  end
-
-  describe "prepare_change_for_storage/3" do
-    test "stores an entire `NewRecord` value" do
-      record = %Changes.NewRecord{
-        key: "my_key",
-        record: %{"pk" => "10", "hello" => "world"},
-        log_offset: LogOffset.first(),
-        relation: {"public", "test"}
-      }
-
-      assert Storage.prepare_change_for_storage(record, 1, ["pk"]) ==
-               [
-                 {LogOffset.first(), "my_key", :insert, %{"pk" => "10", "hello" => "world"},
-                  %{txid: 1, relation: ["public", "test"]}}
-               ]
-
-      # And with empty PK
-      assert Storage.prepare_change_for_storage(record, 1, []) ==
-               [
-                 {LogOffset.first(), "my_key", :insert, %{"pk" => "10", "hello" => "world"},
-                  %{txid: 1, relation: ["public", "test"]}}
-               ]
-    end
-
-    test "stores only PK of a `DeletedRecord` value" do
-      record = %Changes.DeletedRecord{
-        key: "my_key",
-        old_record: %{"pk" => "10", "hello" => "world"},
-        log_offset: LogOffset.first(),
-        relation: {"public", "test"}
-      }
-
-      assert Storage.prepare_change_for_storage(record, 1, ["pk"]) ==
-               [
-                 {LogOffset.first(), "my_key", :delete, %{"pk" => "10"},
-                  %{txid: 1, relation: ["public", "test"]}}
-               ]
-    end
-
-    test "stores entire `DeletedRecord` value if table has no PK" do
-      record = %Changes.DeletedRecord{
-        key: "my_key",
-        old_record: %{"value" => "10", "hello" => "world"},
-        log_offset: LogOffset.first(),
-        relation: {"public", "test"}
-      }
-
-      assert Storage.prepare_change_for_storage(record, 1, []) ==
-               [
-                 {LogOffset.first(), "my_key", :delete, %{"value" => "10", "hello" => "world"},
-                  %{txid: 1, relation: ["public", "test"]}}
-               ]
-    end
-
-    test "stores any changed columns and PK of an `UpdatedRecord` value" do
-      record =
-        Changes.UpdatedRecord.new(%{
-          key: "my_key",
-          old_record: %{"pk" => "10", "hello" => "world", "test" => "me"},
-          record: %{"pk" => "10", "hello" => "world", "test" => "new"},
-          log_offset: LogOffset.first(),
-          relation: {"public", "test"}
-        })
-
-      assert Storage.prepare_change_for_storage(record, 1, ["pk"]) ==
-               [
-                 {LogOffset.first(), "my_key", :update, %{"pk" => "10", "test" => "new"},
-                  %{txid: 1, relation: ["public", "test"]}}
-               ]
-    end
-
-    test "splits up the `UpdatedRecord` if a key was changed, adding a reference to both" do
-      record =
-        Changes.UpdatedRecord.new(%{
-          old_key: "old_key",
-          key: "new_key",
-          old_record: %{"pk" => "9", "hello" => "world", "test" => "me"},
-          record: %{"pk" => "10", "hello" => "world", "test" => "new"},
-          log_offset: LogOffset.first(),
-          relation: {"public", "test"}
-        })
-
-      assert Storage.prepare_change_for_storage(record, 1, ["pk"]) ==
-               [
-                 {LogOffset.first(), "old_key", :delete, %{"pk" => "9"},
-                  %{txid: 1, relation: ["public", "test"], key_change_to: "new_key"}},
-                 {LogOffset.increment(LogOffset.first()), "new_key", :insert,
-                  %{"pk" => "10", "hello" => "world", "test" => "new"},
-                  %{txid: 1, relation: ["public", "test"], key_change_from: "old_key"}}
-               ]
-    end
-
-    test "splits up the `UpdatedRecord` if a key was changed, adding a reference to both when no PK is defined" do
-      record =
-        Changes.UpdatedRecord.new(%{
-          old_key: "old_key",
-          key: "new_key",
-          old_record: %{"hello" => "world", "test" => "me"},
-          record: %{"hello" => "world", "test" => "new"},
-          log_offset: LogOffset.first(),
-          relation: {"public", "test"}
-        })
-
-      assert Storage.prepare_change_for_storage(record, 1, []) ==
-               [
-                 {LogOffset.first(), "old_key", :delete, %{"hello" => "world", "test" => "me"},
-                  %{txid: 1, relation: ["public", "test"], key_change_to: "new_key"}},
-                 {LogOffset.increment(LogOffset.first()), "new_key", :insert,
-                  %{"hello" => "world", "test" => "new"},
-                  %{txid: 1, relation: ["public", "test"], key_change_from: "old_key"}}
-               ]
     end
   end
 end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -206,7 +206,7 @@ defmodule Electric.ShapeCacheTest do
       assert Storage.snapshot_exists?(shape_id, storage)
       assert {@zero_offset, stream} = Storage.get_snapshot(shape_id, storage)
 
-      assert [%{value: %{"value" => "test1"}}, %{value: %{"value" => "test2"}}] =
+      assert [%{"value" => %{"value" => "test1"}}, %{"value" => %{"value" => "test2"}}] =
                stream_to_list(stream)
     end
 
@@ -268,7 +268,11 @@ defmodule Electric.ShapeCacheTest do
       assert :ready = ShapeCache.wait_for_snapshot(opts[:server], shape_id)
       assert {@zero_offset, stream} = Storage.get_snapshot(shape_id, storage)
 
-      assert [%{value: map}, %{value: %{"value" => "test1"}}, %{value: %{"value" => "test2"}}] =
+      assert [
+               %{"value" => map},
+               %{"value" => %{"value" => "test1"}},
+               %{"value" => %{"value" => "test2"}}
+             ] =
                stream_to_list(stream)
 
       assert %{
@@ -700,6 +704,9 @@ defmodule Electric.ShapeCacheTest do
 
   def prepare_tables_noop(_, _), do: :ok
 
-  defp stream_to_list(stream),
-    do: Enum.sort_by(stream, fn %{value: %{"value" => val}} -> val end)
+  defp stream_to_list(stream) do
+    stream
+    |> Enum.map(&Jason.decode!/1)
+    |> Enum.sort_by(fn %{"value" => %{"value" => val}} -> val end)
+  end
 end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -25,17 +25,17 @@ defmodule Electric.ShapeCacheTest do
   @basic_query_meta %Postgrex.Query{columns: ["id"], result_types: [:text], name: "key_prefix"}
   @change_offset LogOffset.new(13, 2)
   @xid 99
-  @changes preprocess_changes(
-             [
-               %Changes.NewRecord{
-                 relation: {"public", "test_table"},
-                 record: %{"id" => "123", "value" => "Test"},
-                 log_offset: @change_offset
-               }
-             ],
-             ["id"],
-             @xid
-           )
+  @log_items changes_to_log_items(
+               [
+                 %Changes.NewRecord{
+                   relation: {"public", "test_table"},
+                   record: %{"id" => "123", "value" => "Test"},
+                   log_offset: @change_offset
+                 }
+               ],
+               ["id"],
+               @xid
+             )
 
   @zero_offset LogOffset.first()
 
@@ -298,7 +298,7 @@ defmodule Electric.ShapeCacheTest do
         ShapeCache.append_to_log!(
           shape_id,
           expected_offset_after_log_entry,
-          @changes,
+          @log_items,
           opts
         )
 
@@ -315,7 +315,7 @@ defmodule Electric.ShapeCacheTest do
       log_offset = LogOffset.new(1000, 0)
 
       {:error, log} =
-        with_log(fn -> ShapeCache.append_to_log!(shape_id, log_offset, @changes, opts) end)
+        with_log(fn -> ShapeCache.append_to_log!(shape_id, log_offset, @log_items, opts) end)
 
       assert log =~ "Tried to update latest offset for shape #{shape_id} which doesn't exist"
     end
@@ -520,7 +520,7 @@ defmodule Electric.ShapeCacheTest do
 
       Storage.append_to_log!(
         shape_id,
-        preprocess_changes([
+        changes_to_log_items([
           %Electric.Replication.Changes.NewRecord{
             relation: {"public", "items"},
             record: %{"id" => "1", "value" => "Alice"},
@@ -567,7 +567,7 @@ defmodule Electric.ShapeCacheTest do
 
       Storage.append_to_log!(
         shape_id,
-        preprocess_changes([
+        changes_to_log_items([
           %Electric.Replication.Changes.NewRecord{
             relation: {"public", "items"},
             record: %{"id" => "1", "value" => "Alice"},
@@ -654,7 +654,7 @@ defmodule Electric.ShapeCacheTest do
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
       :ready = ShapeCache.wait_for_snapshot(opts[:server], shape_id)
 
-      :ok = ShapeCache.append_to_log!(shape_id, offset, @changes, opts)
+      :ok = ShapeCache.append_to_log!(shape_id, offset, @log_items, opts)
 
       {^shape_id, ^offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
       restart_shape_cache(context)

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -1,14 +1,14 @@
 defmodule Support.TestUtils do
-  alias Electric.ShapeCache.Storage
+  alias Electric.LogItems
   alias Electric.Replication.Changes
 
   @doc """
   Preprocess a list of `Changes.data_change()` structs in the same way they
   are preprocessed before reaching storage.
   """
-  def preprocess_changes(changes, pk \\ ["id"], xid \\ 1) do
+  def changes_to_log_items(changes, pk \\ ["id"], xid \\ 1) do
     changes
     |> Enum.map(&Changes.fill_key(&1, pk))
-    |> Enum.flat_map(&Storage.prepare_change_for_storage(&1, xid, pk))
+    |> Enum.flat_map(&LogItems.from_change(&1, xid, pk))
   end
 end


### PR DESCRIPTION
JSON encoding on write rather than read to reduce memory footprint. For example the memory use of an initial sync of a 35MB/200k row table can be reduced from 50MB to 25MB on the first initial sync (which includes the encoding and the writing to storage) and to 6MB on subsequent initial syncs (where we just read from storage and there's no encoding).

This change also allows some simplifications, so I have included them as refactoring in this PR:
- Logic to do with the structure and how to create Log Items has been consolidated to a new module `LogItems`
- The `prepared_change` intermediate state has been removed. The transformation `Changes > list(prepared_change) > LogItems` now is simply `Changes > LogItems` which makes the code more readable ( `prepared_change` was a 5 tuple rather than a nicely labeled map) and easier to reason about (since there's one less data structure to worry about)
- The snapshot row intermediate state has a few less references, ideally I'd like to get encapsulate it into a single module, but for now it's mainly `Shapes.Querying` that creates it and `LogItems.from_snapshot_row/4` that reads it.
-  Some logic duplicated in InMemoryStorage and CubDbStorage has been consolidated.

I've rebased this PR into 2 commits, the functional change and the refactoring, to aid with reviewing.