### PR TITLE
fix: Completely disable ReplicationClient's auto-reconnection logic

### DIFF
--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -142,10 +142,6 @@ defmodule Electric.ConnectionManager do
   end
 
   defp start_replication_client(connection_opts, replication_opts) do
-    # Disable the reconnection logic in Postgex.ReplicationConnection to force it to exit with
-    # the connection error.
-    connection_opts = [auto_reconnect: false] ++ connection_opts
-
     case Electric.Postgres.ReplicationClient.start_link(connection_opts, replication_opts) do
       {:ok, pid} ->
         {:ok, pid, connection_opts}

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -80,6 +80,10 @@ defmodule Electric.Postgres.ReplicationClient do
   @repl_msg_standby_status_update ?r
 
   def start_link(connection_opts, replication_opts) do
+    # Disable the reconnection logic in Postgex.ReplicationConnection to force it to exit with
+    # the connection error. Without this, we may observe undesirable restarts in tests between
+    # one test process exiting and the next one starting.
+    connection_opts = [auto_reconnect: false] ++ connection_opts
     Postgrex.ReplicationConnection.start_link(__MODULE__, replication_opts, connection_opts)
   end
 

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -150,7 +150,7 @@ defmodule Electric.Postgres.ReplicationClient do
       ) do
     Logger.debug("XLogData: wal_start=#{wal_start}, wal_end=#{wal_end}")
 
-    state = update_received_wal(state, wal_end)
+    state = update_received_wal(:xlog_data, state, wal_start, wal_end)
 
     rest
     |> Decoder.decode()
@@ -185,7 +185,9 @@ defmodule Electric.Postgres.ReplicationClient do
   end
 
   def handle_data(<<@repl_msg_primary_keepalive, wal_end::64, _clock::64, reply>>, state) do
-    state = update_received_wal(state, wal_end)
+    Logger.debug("Primary Keepalive: wal_end=#{wal_end} reply=#{reply}")
+
+    state = update_received_wal(:keepalive, state, nil, wal_end)
 
     messages =
       case reply do
@@ -220,11 +222,11 @@ defmodule Electric.Postgres.ReplicationClient do
   defp current_time(), do: System.os_time(:microsecond) - @epoch
 
   # wal can be 0 if the incoming logical message is e.g. Relation.
-  defp update_received_wal(state, 0), do: state
+  defp update_received_wal(_step, state, _, 0), do: state
 
-  defp update_received_wal(%{received_wal: wal} = state, wal), do: state
+  defp update_received_wal(_step, %{received_wal: wal} = state, _, wal), do: state
 
-  defp update_received_wal(state, wal) when wal > state.received_wal,
+  defp update_received_wal(_step, state, _, wal) when wal > state.received_wal,
     do: %{state | received_wal: wal}
 
   defp update_applied_wal(state, wal) when wal > state.applied_wal,


### PR DESCRIPTION
Some changes to make some types of test failure less likely.

Recent example - https://github.com/electric-sql/electric-next/actions/runs/10256059321/job/28374360808?pr=254. These happen occasionally but are impossible to reproduce deliberately. I suspect the issue is related to the use of persistent slot and auto-reconnection logic that results Postgres delivering a logical message with a lower WAL offset than the one in `ReplicationClient`'s state.