### PR TITLE
fix(sync-server): Fix error that occurs when `/shape` response stream is closed before it is complete

### DIFF
--- a/.changeset/fifty-frogs-warn.md
+++ b/.changeset/fifty-frogs-warn.md
@@ -1,0 +1,6 @@
+---
+"@core/sync-service": patch
+---
+
+Fix error that occurs when a `/shape` response stream is closed before it is complete,
+for example when `curl --head` is used to call the endpoint.

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -330,12 +330,6 @@ defmodule Electric.Plug.ServeShapePlug do
         {:ok, conn} ->
           {:cont, conn}
 
-        # The documented way to handle closed connections
-        # See https://hexdocs.pm/plug/Plug.Conn.html#chunk/2
-        {:error, :closed} ->
-          {:halt, conn}
-
-        # This also occurs, for example when `curl --head` is used to call the endpoint
         {:error, "closed"} ->
           {:halt, conn}
       end

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -332,6 +332,10 @@ defmodule Electric.Plug.ServeShapePlug do
 
         {:error, "closed"} ->
           {:halt, conn}
+
+        {:error, reason} ->
+          Logger.error("Error while streaming response: #{inspect(reason)}")
+          {:halt, conn}
       end
     end)
   end

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -330,7 +330,13 @@ defmodule Electric.Plug.ServeShapePlug do
         {:ok, conn} ->
           {:cont, conn}
 
+        # The documented way to handle closed connections
+        # See https://hexdocs.pm/plug/Plug.Conn.html#chunk/2
         {:error, :closed} ->
+          {:halt, conn}
+
+        # This also occurs, for example when `curl --head` is used to call the endpoint
+        {:error, "closed"} ->
           {:halt, conn}
       end
     end)


### PR DESCRIPTION
This closes #1440 