### PR TITLE
feat: make DB pool size configurable with default of 50

### DIFF
--- a/.changeset/metal-flowers-share.md
+++ b/.changeset/metal-flowers-share.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+feat: make DB pool size configurable via `DB_POOL_SIZE` environment variable & raise the default to 50

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -99,5 +99,6 @@ config :electric,
   environment: config_env(),
   instance_id: instance_id,
   telemetry_statsd_host: statsd_host,
+  db_pool_size: env!("DB_POOL_SIZE", :integer, 50),
   prometheus_port: prometheus_port,
   storage: storage

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -43,7 +43,7 @@ defmodule Electric.Application do
              ],
              pool_opts: [
                name: Electric.DbPool,
-               pool_size: 10,
+               pool_size: Application.fetch_env!(:electric, :db_pool_size),
                types: PgInterop.Postgrex.Types
              ]},
             {Electric.Postgres.Inspector.EtsInspector, pool: Electric.DbPool},

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -136,7 +136,7 @@ defmodule Electric.ShapeCache do
 
   @spec wait_for_snapshot(GenServer.name(), String.t()) :: :ready | {:error, term()}
   def wait_for_snapshot(server \\ __MODULE__, shape_id) when is_binary(shape_id) do
-    GenServer.call(server, {:wait_for_snapshot, shape_id})
+    GenServer.call(server, {:wait_for_snapshot, shape_id}, 30_000)
   end
 
   def init(opts) do


### PR DESCRIPTION
On out-of-the-box PostgreSQL the default connection maximum is 100, and you have to restart the server to raise that. This makes 50 a sane default, leaving enough headroom for other backends to connect to the same PG. Users that have a different connection limit on their PG can raise their pool size accordingly.