### PR TITLE
feat: include nullability in schema and parse null values on client

### DIFF
--- a/.changeset/loud-roses-fetch.md
+++ b/.changeset/loud-roses-fetch.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": patch
+"@core/sync-service": patch
+---
+
+Include nullability information in schema. Also parse null values in the JS client.

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -11,6 +11,7 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
       (atttypid, atttypmod) as type_id,
       attndims as array_dimensions,
       atttypmod as type_mod,
+      attnotnull as not_null,
       pg_type.typname as type,
       elem_pg_type.typname as array_type, -- type of the element inside the array or nil if it's not an array
       format_type(pg_attribute.atttypid, pg_attribute.atttypmod) AS formatted_type,

--- a/packages/sync-service/lib/electric/schema.ex
+++ b/packages/sync-service/lib/electric/schema.ex
@@ -52,6 +52,7 @@ defmodule Electric.Schema do
     %{type: type(col_info)}
     |> add_dims(col_info)
     |> add_pk(col_info)
+    |> add_nullability(col_info)
     |> add_modifier(col_info)
   end
 
@@ -69,6 +70,9 @@ defmodule Electric.Schema do
   defp add_pk(schema, %{pk_position: idx}) do
     Map.put(schema, :pk_index, idx)
   end
+
+  defp add_nullability(schema, %{not_null: true}), do: Map.put(schema, :not_null, true)
+  defp add_nullability(schema, _), do: schema
 
   defp add_modifier(%{type: type} = schema, %{type_mod: type_mod})
        when type_mod > 0 and type in @variable_length_character_types do

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -113,20 +113,14 @@ export class MessageParser {
 
     // Pick the right parser for the type
     // and support parsing null values if needed
-    const parser = makeNullableParser(this.parser[typ], columnInfo.not_null)
+    // if no parser is provided for the given type, just return the value as is
+    const identityParser = (v: string) => v
+    const typParser = this.parser[typ] ?? identityParser
+    const parser = makeNullableParser(typParser, columnInfo.not_null)
 
     if (dimensions && dimensions > 0) {
       // It's an array
-      const identityParser = makeNullableParser(
-        (v: string) => v,
-        columnInfo.not_null
-      )
-      return pgArrayParser(value, parser ?? identityParser)
-    }
-
-    if (!parser) {
-      // No parser was provided for this type of values
-      return value
+      return pgArrayParser(value, parser)
     }
 
     return parser(value, additionalInfo)

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -108,15 +108,19 @@ export class MessageParser {
       return value
     }
 
-    // Pick the right parser for the type
-    const parser = this.parser[columnInfo.type]
-
     // Copy the object but don't include `dimensions` and `type`
-    const { type: _typ, dims: dimensions, ...additionalInfo } = columnInfo
+    const { type: typ, dims: dimensions, ...additionalInfo } = columnInfo
 
-    if (dimensions > 0) {
+    // Pick the right parser for the type
+    // and support parsing null values if needed
+    const parser = makeNullableParser(this.parser[typ], columnInfo.not_null)
+
+    if (dimensions && dimensions > 0) {
       // It's an array
-      const identityParser = (v: string) => v
+      const identityParser = makeNullableParser(
+        (v: string) => v,
+        columnInfo.not_null
+      )
       return pgArrayParser(value, parser ?? identityParser)
     }
 
@@ -127,4 +131,19 @@ export class MessageParser {
 
     return parser(value, additionalInfo)
   }
+}
+
+function makeNullableParser(
+  parser: ParseFunction,
+  notNullable?: boolean
+): ParseFunction {
+  const isNullable = !(notNullable ?? false)
+  if (isNullable) {
+    // The sync service contains `null` value for a column whose value is NULL
+    // but if the column value is an array that contains a NULL value
+    // then it will be included in the array string as `NULL`, e.g.: `"{1,NULL,3}"`
+    return (value: string) =>
+      value === null || value === `NULL` ? null : parser(value)
+  }
+  return parser
 }

--- a/packages/typescript-client/src/types.ts
+++ b/packages/typescript-client/src/types.ts
@@ -29,9 +29,14 @@ export type Message<T extends Value = { [key: string]: Value }> =
   | ControlMessage
   | ChangeMessage<T>
 
+/**
+ * Common properties for all columns.
+ * `dims` is the number of dimensions of the column. Only provided if the column is an array.
+ * `not_null` is true if the column has a `NOT NULL` constraint and is omitted otherwise.
+ */
 export type CommonColumnProps = {
-  dims?: number // only provided if the column is an array
-  not_null?: boolean // assumed to be false if not provided
+  dims?: number
+  not_null?: boolean
 }
 
 export type RegularColumn = {

--- a/packages/typescript-client/src/types.ts
+++ b/packages/typescript-client/src/types.ts
@@ -29,32 +29,32 @@ export type Message<T extends Value = { [key: string]: Value }> =
   | ControlMessage
   | ChangeMessage<T>
 
+export type CommonColumnProps = {
+  dims?: number // only provided if the column is an array
+  not_null?: boolean // assumed to be false if not provided
+}
+
 export type RegularColumn = {
   type: string
-  dims: number
-}
+} & CommonColumnProps
 
 export type VarcharColumn = {
   type: `varchar`
-  dims: number
   max_length?: number
-}
+} & CommonColumnProps
 
 export type BpcharColumn = {
   type: `bpchar`
-  dims: number
   length?: number
-}
+} & CommonColumnProps
 
 export type TimeColumn = {
   type: `time` | `timetz` | `timestamp` | `timestamptz`
-  dims: number
   precision?: number
-}
+} & CommonColumnProps
 
 export type IntervalColumn = {
   type: `interval`
-  dims: number
   fields?:
     | `YEAR`
     | `MONTH`
@@ -68,27 +68,24 @@ export type IntervalColumn = {
     | `HOUR TO MINUTE`
     | `HOUR TO SECOND`
     | `MINUTE TO SECOND`
-}
+} & CommonColumnProps
 
 export type IntervalColumnWithPrecision = {
   type: `interval`
-  dims: number
   precision?: 0 | 1 | 2 | 3 | 4 | 5 | 6
   fields?: `SECOND`
-}
+} & CommonColumnProps
 
 export type BitColumn = {
   type: `bit`
-  dims: number
   length: number
-}
+} & CommonColumnProps
 
 export type NumericColumn = {
   type: `numeric`
-  dims: number
   precision?: number
   scale?: number
-}
+} & CommonColumnProps
 
 export type ColumnInfo =
   | RegularColumn

--- a/packages/typescript-client/test/parser.test.ts
+++ b/packages/typescript-client/test/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { defaultParser, pgArrayParser } from '../src/parser'
+import { MessageParser, defaultParser, pgArrayParser } from '../src/parser'
 
 describe(`Default parser`, () => {
   it(`should parse integers`, () => {
@@ -153,5 +153,54 @@ describe(`Postgres array parser`, () => {
       [Infinity, -Infinity, NaN],
       [NaN, Infinity, -Infinity],
     ])
+  })
+})
+
+describe(`Message parser`, () => {
+  const parser = new MessageParser()
+
+  it(`should parse null values`, () => {
+    const messages = `[ { "value": { "a": null } } ]`
+    const expectedParsedMessages = [{ value: { a: null } }]
+
+    // If it's not nullable it should parse as a number
+    expect(
+      parser.parse(messages, { a: { type: `int2`, not_null: true } })
+    ).toEqual([{ value: { a: 0 } }])
+    // Otherwise, it should parse as null
+    expect(parser.parse(messages, { a: { type: `int2` } })).toEqual(
+      expectedParsedMessages
+    )
+    expect(parser.parse(messages, { a: { type: `int4` } })).toEqual(
+      expectedParsedMessages
+    )
+    expect(parser.parse(messages, { a: { type: `int8` } })).toEqual(
+      expectedParsedMessages
+    )
+    expect(parser.parse(messages, { a: { type: `bool` } })).toEqual(
+      expectedParsedMessages
+    )
+    expect(parser.parse(messages, { a: { type: `float4` } })).toEqual(
+      expectedParsedMessages
+    )
+    expect(parser.parse(messages, { a: { type: `float8` } })).toEqual(
+      expectedParsedMessages
+    )
+    expect(parser.parse(messages, { a: { type: `json` } })).toEqual(
+      expectedParsedMessages
+    )
+    expect(parser.parse(messages, { a: { type: `jsonb` } })).toEqual(
+      expectedParsedMessages
+    )
+  })
+
+  it(`should parse arrays including null values`, () => {
+    const schema = {
+      a: { type: `int2`, dims: 1, nullable: true },
+    }
+
+    expect(
+      parser.parse(`[ { "value": { "a": "{1,2,NULL,4,5}" } } ]`, schema)
+    ).toEqual([{ value: { a: [1, 2, null, 4, 5] } }])
   })
 })


### PR DESCRIPTION
This PR addresses https://github.com/electric-sql/electric/issues/1507.
The sync service is modified to include a `not_null: true` field on columns that have a `NOT NULL` constraint. For nullable columns we do not include this information as it is assumed to be nullable by default (consistent with Postgres).

The TypeScript client parses Database NULL values into JavaScript `null` only if the column is nullable.