### PR TITLE
feat(sync-service): Streaming the response to the client without waiting for the snapshot to finish

### DIFF
--- a/.changeset/kind-starfishes-tap.md
+++ b/.changeset/kind-starfishes-tap.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Support larger shapes (1 million row, 170MB +) and faster time to first byte

--- a/packages/sync-service/lib/electric/concurrent_stream.ex
+++ b/packages/sync-service/lib/electric/concurrent_stream.ex
@@ -1,6 +1,18 @@
 defmodule Electric.ConcurrentStream do
   @default_poll_time 10
 
+  @doc """
+  Allows concurrent reading while writing of a stream.
+  There can be mutiple reading processes however there must be only one writing process.
+
+  The writing process must append an end marker to the end of the stream when it has finished
+  to signal to the reading processes that the stream has ended.
+
+  If a read process runs out of data to read before the end marker has been written
+  it waits the `poll_time_in_ms` for more data to be written, then resumes the stream
+  with the `stream_fun`.
+  """
+
   def stream_to_end(opts) do
     excluded_start_key = Keyword.fetch!(opts, :excluded_start_key)
     end_marker_key = Keyword.fetch!(opts, :end_marker_key)

--- a/packages/sync-service/lib/electric/concurrent_stream.ex
+++ b/packages/sync-service/lib/electric/concurrent_stream.ex
@@ -1,0 +1,39 @@
+defmodule Electric.ConcurrentStream do
+  @default_poll_time 10
+
+  def stream_to_end(opts) do
+    excluded_start_key = Keyword.fetch!(opts, :excluded_start_key)
+    end_marker_key = Keyword.fetch!(opts, :end_marker_key)
+    stream_fun = Keyword.fetch!(opts, :stream_fun)
+
+    stream_fun.(excluded_start_key, end_marker_key)
+    |> continue_if_not_ended(excluded_start_key, opts)
+  end
+
+  defp continue_if_not_ended(stream, latest_key, opts) do
+    end_marker_key = Keyword.fetch!(opts, :end_marker_key)
+    stream_fun = Keyword.fetch!(opts, :stream_fun)
+    poll_time_in_ms = Keyword.get(opts, :poll_time_in_ms, @default_poll_time)
+
+    [stream, [:premature_end]]
+    |> Stream.concat()
+    |> Stream.transform(latest_key, fn
+      :premature_end, latest_key ->
+        # Wait for more items to be added
+        Process.sleep(poll_time_in_ms)
+
+        # Continue from the latest_key
+        stream =
+          stream_fun.(latest_key, end_marker_key)
+          |> continue_if_not_ended(latest_key, opts)
+
+        {stream, latest_key}
+
+      {^end_marker_key, _}, _latest_key ->
+        {:halt, :end_marker_seen}
+
+      {key, _value} = item, _latest_key ->
+        {[item], key}
+    end)
+  end
+end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -237,6 +237,7 @@ defmodule Electric.ShapeCache do
 
   def handle_cast({:snapshot_started, shape_id}, state) do
     Logger.debug("Snapshot for #{shape_id} is ready")
+    Storage.mark_snapshot_as_started(shape_id, state.storage)
     {waiting, state} = pop_in(state, [:awaiting_snapshot_start, shape_id])
     for client <- List.wrap(waiting), not is_nil(client), do: GenServer.reply(client, :started)
     {:noreply, state}

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -235,7 +235,7 @@ defmodule Electric.ShapeCache do
     {:noreply, state}
   end
 
-  def handle_cast({:snapshot_ready, shape_id}, state) do
+  def handle_cast({:snapshot_started, shape_id}, state) do
     Logger.debug("Snapshot for #{shape_id} is ready")
     {waiting, state} = pop_in(state, [:awaiting_snapshot_start, shape_id])
     for client <- List.wrap(waiting), not is_nil(client), do: GenServer.reply(client, :started)
@@ -298,12 +298,11 @@ defmodule Electric.ShapeCache do
         fn ->
           try do
             Utils.apply_fn_or_mfa(prepare_tables_fn_or_mfa, [pool, affected_tables])
-
-            apply(create_snapshot_fn, [parent, shape_id, shape, pool, storage])
-            GenServer.cast(parent, {:snapshot_ready, shape_id})
           rescue
             error -> GenServer.cast(parent, {:snapshot_failed, shape_id, error, __STACKTRACE__})
           end
+
+          apply(create_snapshot_fn, [parent, shape_id, shape, pool, storage])
         end
       )
       |> Task.start()
@@ -331,25 +330,39 @@ defmodule Electric.ShapeCache do
   def query_in_readonly_txn(parent, shape_id, shape, db_pool, storage) do
     Postgrex.transaction(db_pool, fn conn ->
       OpenTelemetry.with_span("shape_cache.query_in_readonly_txn", [], fn ->
-        Postgrex.query!(
-          conn,
-          "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
-          []
-        )
+        try do
+          Postgrex.query!(
+            conn,
+            "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+            []
+          )
 
-        %{rows: [[xmin]]} =
-          Postgrex.query!(conn, "SELECT pg_snapshot_xmin(pg_current_snapshot())", [])
+          %{rows: [[xmin]]} =
+            Postgrex.query!(conn, "SELECT pg_snapshot_xmin(pg_current_snapshot())", [])
 
-        # Enforce display settings *before* querying initial data to maintain consistent
-        # formatting between snapshot and live log entries.
-        Enum.each(Electric.Postgres.display_settings(), &Postgrex.query!(conn, &1, []))
+          GenServer.cast(parent, {:snapshot_xmin_known, shape_id, xmin})
 
-        GenServer.cast(parent, {:snapshot_xmin_known, shape_id, xmin})
-        {query, stream} = Querying.stream_initial_data(conn, shape)
+          # Enforce display settings *before* querying initial data to maintain consistent
+          # formatting between snapshot and live log entries.
+          Enum.each(Electric.Postgres.display_settings(), &Postgrex.query!(conn, &1, []))
 
-        # could pass the shape and then make_new_snapshot! can pass it to row_to_snapshot_item
-        # that way it has the relation, but it is still missing the pk_cols
-        Storage.make_new_snapshot!(shape_id, shape, query, stream, storage)
+          {query, stream} = Querying.stream_initial_data(conn, shape)
+          GenServer.cast(parent, {:snapshot_started, shape_id})
+          {:ok, {query, stream}}
+        rescue
+          error ->
+            GenServer.cast(parent, {:snapshot_failed, shape_id, error, __STACKTRACE__})
+            error
+        end
+        |> case do
+          {:ok, {query, stream}} ->
+            # could pass the shape and then make_new_snapshot! can pass it to row_to_snapshot_item
+            # that way it has the relation, but it is still missing the pk_cols
+            Storage.make_new_snapshot!(shape_id, shape, query, stream, storage)
+
+          error ->
+            error
+        end
       end)
     end)
   end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -361,7 +361,7 @@ defmodule Electric.ShapeCache do
   end
 
   defp recover_shapes(state) do
-    Storage.cleanup_shapes_without_xmins(state.storage)
+    Storage.initialise(state.storage)
 
     state.storage
     |> Storage.list_shapes()

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -193,7 +193,7 @@ defmodule Electric.ShapeCache do
       not is_known_shape_id?(state, shape_id) ->
         {:reply, {:error, :unknown}, state}
 
-      Storage.snapshot_exists?(shape_id, state.storage) ->
+      Storage.snapshot_started?(shape_id, state.storage) ->
         {:reply, :started, state}
 
       true ->
@@ -280,7 +280,7 @@ defmodule Electric.ShapeCache do
        do: state
 
   defp maybe_start_snapshot(state, shape_id, shape) do
-    if not Storage.snapshot_exists?(shape_id, state.storage) do
+    if not Storage.snapshot_started?(shape_id, state.storage) do
       parent = self()
 
       %{

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -22,7 +22,7 @@ defmodule Electric.ShapeCacheBehaviour do
               {shape_id(), current_snapshot_offset :: LogOffset.t()}
 
   @callback list_active_shapes(opts :: keyword()) :: [{shape_id(), shape_def(), xmin()}]
-  @callback await_snapshot_start(GenServer.name(), shape_id()) :: :ready | {:error, term()}
+  @callback await_snapshot_start(GenServer.name(), shape_id()) :: :started | {:error, term()}
   @callback handle_truncate(GenServer.name(), shape_id()) :: :ok
   @callback clean_shape(GenServer.name(), shape_id()) :: :ok
 end
@@ -136,7 +136,7 @@ defmodule Electric.ShapeCache do
     GenServer.call(server, {:truncate, shape_id})
   end
 
-  @spec await_snapshot_start(GenServer.name(), String.t()) :: :ready | {:error, term()}
+  @spec await_snapshot_start(GenServer.name(), String.t()) :: :started | {:error, term()}
   def await_snapshot_start(server \\ __MODULE__, shape_id) when is_binary(shape_id) do
     GenServer.call(server, {:await_snapshot_start, shape_id})
   end
@@ -194,7 +194,7 @@ defmodule Electric.ShapeCache do
         {:reply, {:error, :unknown}, state}
 
       Storage.snapshot_exists?(shape_id, state.storage) ->
-        {:reply, :ready, state}
+        {:reply, :started, state}
 
       true ->
         Logger.debug("Starting a wait on the snapshot #{shape_id} for #{inspect(from)}}")
@@ -238,7 +238,7 @@ defmodule Electric.ShapeCache do
   def handle_cast({:snapshot_ready, shape_id}, state) do
     Logger.debug("Snapshot for #{shape_id} is ready")
     {waiting, state} = pop_in(state, [:waiting_for_creation, shape_id])
-    for client <- List.wrap(waiting), not is_nil(client), do: GenServer.reply(client, :ready)
+    for client <- List.wrap(waiting), not is_nil(client), do: GenServer.reply(client, :started)
     {:noreply, state}
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -127,7 +127,7 @@ defmodule Electric.ShapeCache.CubDbStorage do
     OpenTelemetry.with_span("storage.make_new_snapshot", [storage_impl: "cub_db"], fn ->
       data_stream
       |> LogItems.from_snapshot_row_stream(@snapshot_offset, shape, query_info)
-      |> Stream.with_index(1)
+      |> Stream.with_index()
       |> Stream.map(fn {log_item, index} ->
         {snapshot_key(shape_id, index), Jason.encode!(log_item)}
       end)
@@ -190,6 +190,6 @@ defmodule Electric.ShapeCache.CubDbStorage do
   defp log_start(shape_id), do: log_key(shape_id, LogOffset.first())
   defp log_end(shape_id), do: log_key(shape_id, LogOffset.last())
 
-  defp snapshot_start(shape_id), do: snapshot_key(shape_id, 0)
+  defp snapshot_start(shape_id), do: snapshot_key(shape_id, -1)
   defp snapshot_end(shape_id), do: snapshot_key(shape_id, :end)
 end

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -42,7 +42,8 @@ defmodule Electric.ShapeCache.CubDbStorage do
     |> Stream.map(fn {{:shapes, shape_id}, _} -> shape_id end)
     |> Stream.filter(fn shape_id ->
       stored_version != opts.version ||
-        snapshot_xmin(shape_id, opts) == nil
+        snapshot_xmin(shape_id, opts) == nil ||
+        CubDB.has_key?(opts.db, snapshot_end(shape_id)) == false
     end)
     |> Enum.each(&cleanup!(&1, opts))
 

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -78,8 +78,8 @@ defmodule Electric.ShapeCache.CubDbStorage do
     end
   end
 
-  @spec snapshot_exists?(any(), any()) :: false
-  def snapshot_exists?(shape_id, opts) do
+  @spec snapshot_started?(any(), any()) :: false
+  def snapshot_started?(shape_id, opts) do
     CubDB.has_key?(opts.db, snapshot_end(shape_id))
   end
 
@@ -120,7 +120,7 @@ defmodule Electric.ShapeCache.CubDbStorage do
   def has_log_entry?(shape_id, offset, opts) do
     # FIXME: this is naive while we don't have snapshot metadata to get real offsets
     CubDB.has_key?(opts.db, log_key(shape_id, offset)) or
-      (snapshot_exists?(shape_id, opts) and offset == @snapshot_offset)
+      (snapshot_started?(shape_id, opts) and offset == @snapshot_offset)
   end
 
   def make_new_snapshot!(shape_id, shape, query_info, data_stream, opts) do

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -80,7 +80,7 @@ defmodule Electric.ShapeCache.CubDbStorage do
 
   @spec snapshot_started?(any(), any()) :: false
   def snapshot_started?(shape_id, opts) do
-    CubDB.has_key?(opts.db, snapshot_end(shape_id))
+    CubDB.has_key?(opts.db, snapshot_start(shape_id))
   end
 
   def get_snapshot(shape_id, opts) do
@@ -121,6 +121,10 @@ defmodule Electric.ShapeCache.CubDbStorage do
     # FIXME: this is naive while we don't have snapshot metadata to get real offsets
     CubDB.has_key?(opts.db, log_key(shape_id, offset)) or
       (snapshot_started?(shape_id, opts) and offset == @snapshot_offset)
+  end
+
+  def mark_snapshot_as_started(shape_id, opts) do
+    CubDB.put(opts.db, snapshot_start(shape_id), 0)
   end
 
   def make_new_snapshot!(shape_id, shape, query_info, data_stream, opts) do

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -90,6 +90,8 @@ defmodule Electric.ShapeCache.CubDbStorage do
         end_marker_key: snapshot_end(shape_id),
         poll_time_in_ms: 10,
         stream_fun: fn excluded_start_key, included_end_key ->
+          if !snapshot_started?(shape_id, opts), do: raise("Snapshot no longer available")
+
           CubDB.select(opts.db,
             min_key: excluded_start_key,
             max_key: included_end_key,

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -34,7 +34,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   def cleanup_shapes_without_xmins(_opts), do: :ok
 
   def snapshot_started?(shape_id, opts) do
-    case :ets.match(opts.snapshot_ets_table, {snapshot_end(shape_id), :_}, 1) do
+    case :ets.match(opts.snapshot_ets_table, {snapshot_start(shape_id), :_}, 1) do
       {[_], _} -> true
       :"$end_of_table" -> false
     end
@@ -46,6 +46,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
 
   @snapshot_start_index 0
   @snapshot_end_index :end
+  defp snapshot_start(shape_id), do: snapshot_key(shape_id, @snapshot_start_index)
   defp snapshot_end(shape_id), do: snapshot_key(shape_id, @snapshot_end_index)
 
   def get_snapshot(shape_id, opts) do
@@ -96,6 +97,10 @@ defmodule Electric.ShapeCache.InMemoryStorage do
       # FIXME: this is naive while we don't have snapshot metadata to get real offset
       [] -> snapshot_started?(shape_id, opts) and offset == @snapshot_offset
     end
+  end
+
+  def mark_snapshot_as_started(shape_id, opts) do
+    :ets.insert(opts.snapshot_ets_table, {snapshot_start(shape_id), 0})
   end
 
   @spec make_new_snapshot!(

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -33,7 +33,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   def set_snapshot_xmin(_shape_id, _xmin, _opts), do: :ok
   def cleanup_shapes_without_xmins(_opts), do: :ok
 
-  def snapshot_exists?(shape_id, opts) do
+  def snapshot_started?(shape_id, opts) do
     case :ets.match(opts.snapshot_ets_table, {snapshot_end(shape_id), :_}, 1) do
       {[_], _} -> true
       :"$end_of_table" -> false
@@ -94,7 +94,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
          ]) do
       [true] -> true
       # FIXME: this is naive while we don't have snapshot metadata to get real offset
-      [] -> snapshot_exists?(shape_id, opts) and offset == @snapshot_offset
+      [] -> snapshot_started?(shape_id, opts) and offset == @snapshot_offset
     end
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -31,7 +31,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   def list_shapes(_opts), do: []
   def add_shape(_shape_id, _shape, _opts), do: :ok
   def set_snapshot_xmin(_shape_id, _xmin, _opts), do: :ok
-  def cleanup_shapes_without_xmins(_opts), do: :ok
+  def initialise(_opts), do: :ok
 
   def snapshot_started?(shape_id, opts) do
     :ets.member(opts.snapshot_ets_table, snapshot_start(shape_id))

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -41,7 +41,7 @@ defmodule Electric.ShapeCache.Storage do
   @callback add_shape(shape_id(), Shape.t(), storage()) :: :ok
   @callback set_snapshot_xmin(shape_id(), non_neg_integer(), storage()) :: :ok
   @doc "Check if snapshot for a given shape id already exists"
-  @callback snapshot_exists?(shape_id(), compiled_opts()) :: boolean()
+  @callback snapshot_started?(shape_id(), compiled_opts()) :: boolean()
   @doc "Get the full snapshot for a given shape, also returning the offset this snapshot includes"
   @callback get_snapshot(shape_id(), compiled_opts()) :: {offset :: LogOffset.t(), log()}
   @doc """
@@ -94,8 +94,8 @@ defmodule Electric.ShapeCache.Storage do
     do: apply(mod, :set_snapshot_xmin, [shape_id, xmin, opts])
 
   @doc "Check if snapshot for a given shape id already exists"
-  @spec snapshot_exists?(shape_id(), storage()) :: boolean()
-  def snapshot_exists?(shape_id, {mod, opts}), do: mod.snapshot_exists?(shape_id, opts)
+  @spec snapshot_started?(shape_id(), storage()) :: boolean()
+  def snapshot_started?(shape_id, {mod, opts}), do: mod.snapshot_started?(shape_id, opts)
   @doc "Get the full snapshot for a given shape, also returning the offset this snapshot includes"
   @spec get_snapshot(shape_id(), storage()) :: {offset :: LogOffset.t(), log()}
   def get_snapshot(shape_id, {mod, opts}), do: mod.get_snapshot(shape_id, opts)

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -57,6 +57,7 @@ defmodule Electric.ShapeCache.Storage do
               Enumerable.t(row()),
               compiled_opts()
             ) :: :ok
+  @callback mark_snapshot_as_started(shape_id, compiled_opts()) :: :ok
   @doc "Append log items from one transaction to the log"
   @callback append_to_log!(
               shape_id(),
@@ -113,6 +114,10 @@ defmodule Electric.ShapeCache.Storage do
         ) :: :ok
   def make_new_snapshot!(shape_id, shape, meta, stream, {mod, opts}),
     do: mod.make_new_snapshot!(shape_id, shape, meta, stream, opts)
+
+  @spec mark_snapshot_as_started(shape_id, compiled_opts()) :: :ok
+  def mark_snapshot_as_started(shape_id, {mod, opts}),
+    do: mod.mark_snapshot_as_started(shape_id, opts)
 
   @doc """
   Append log items from one transaction to the log

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -31,7 +31,7 @@ defmodule Electric.ShapeCache.Storage do
   @callback shared_opts(term()) :: {:ok, compiled_opts()} | {:error, term()}
   @doc "Start any processes required to run the storage backend"
   @callback start_link(compiled_opts()) :: GenServer.on_start()
-  @callback cleanup_shapes_without_xmins(storage()) :: :ok
+  @callback initialise(storage()) :: :ok
   @callback list_shapes(storage()) :: [
               shape_id: shape_id(),
               shape: Shape.t(),
@@ -74,9 +74,9 @@ defmodule Electric.ShapeCache.Storage do
 
   @type storage() :: {module(), compiled_opts()}
 
-  @spec cleanup_shapes_without_xmins(storage()) :: :ok
-  def cleanup_shapes_without_xmins({mod, opts}),
-    do: apply(mod, :cleanup_shapes_without_xmins, [opts])
+  @spec initialise(storage()) :: :ok
+  def initialise({mod, opts}),
+    do: apply(mod, :initialise, [opts])
 
   @spec list_shapes(storage()) :: [
           shape_id: shape_id(),

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -13,7 +13,7 @@ defmodule Electric.Shapes do
     storage = Access.fetch!(config, :storage)
     server = Access.get(opts, :server, shape_cache)
 
-    with :ready <- shape_cache.await_snapshot_start(server, shape_id) do
+    with :started <- shape_cache.await_snapshot_start(server, shape_id) do
       {:ok, Storage.get_snapshot(shape_id, storage)}
     end
   end

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -13,7 +13,7 @@ defmodule Electric.Shapes do
     storage = Access.fetch!(config, :storage)
     server = Access.get(opts, :server, shape_cache)
 
-    with :ready <- shape_cache.wait_for_snapshot(server, shape_id) do
+    with :ready <- shape_cache.await_snapshot_start(server, shape_id) do
       {:ok, Storage.get_snapshot(shape_id, storage)}
     end
   end

--- a/packages/sync-service/test/electric/concurrent_stream_test.exs
+++ b/packages/sync-service/test/electric/concurrent_stream_test.exs
@@ -1,0 +1,50 @@
+defmodule Electric.ConcurrentStreamTest do
+  use ExUnit.Case, async: true
+  alias Electric.ConcurrentStream
+
+  describe "stream_to_end/2" do
+    @tag :tmp_dir
+    test "returns complete stream from CubDB when it's being written to concurrently", ctx do
+      item_count = 10
+      end_marker_key = item_count + 1
+      db = :"cubdb_#{ctx.test}"
+      CubDB.start_link(data_dir: ctx.tmp_dir, name: db)
+
+      stream =
+        ConcurrentStream.stream_to_end(
+          excluded_start_key: 0,
+          end_marker_key: end_marker_key,
+          stream_fun: fn excluded_start_key, included_end_key ->
+            CubDB.select(db,
+              min_key: excluded_start_key,
+              end_key: included_end_key,
+              min_key_inclusive: false
+            )
+          end
+        )
+
+      read_task =
+        Task.async(fn ->
+          items = Enum.to_list(stream)
+
+          assert Enum.count(items) == item_count
+
+          for i <- 1..item_count do
+            assert Enum.at(items, i - 1) == {i, "item_#{i}"}
+          end
+        end)
+
+      # Write the stream concurrently
+      for i <- 1..item_count do
+        CubDB.put(db, i, "item_#{i}")
+        # Sleep to give the read process time to run
+        Process.sleep(1)
+      end
+
+      # Write the end marker to let the read process that the stream has ended
+      CubDB.put(db, end_marker_key, "ended")
+
+      Task.await(read_task)
+    end
+  end
+end

--- a/packages/sync-service/test/electric/concurrent_stream_test.exs
+++ b/packages/sync-service/test/electric/concurrent_stream_test.exs
@@ -1,19 +1,22 @@
 defmodule Electric.ConcurrentStreamTest do
   use ExUnit.Case, async: true
   alias Electric.ConcurrentStream
+  @item_count 10
+  @end_marker_key @item_count + 1
 
   describe "stream_to_end/2" do
-    @tag :tmp_dir
-    test "returns complete stream from CubDB when it's being written to concurrently", ctx do
-      item_count = 10
-      end_marker_key = item_count + 1
-      db = :"cubdb_#{ctx.test}"
-      CubDB.start_link(data_dir: ctx.tmp_dir, name: db)
+    setup %{tmp_dir: tmp_dir, test: test} do
+      db = :"cubdb_#{test}"
+      CubDB.start_link(data_dir: tmp_dir, name: db)
+      {:ok, %{db: db}}
+    end
 
+    @tag :tmp_dir
+    test "returns complete stream from CubDB when it's being written to concurrently", %{db: db} do
       stream =
         ConcurrentStream.stream_to_end(
           excluded_start_key: 0,
-          end_marker_key: end_marker_key,
+          end_marker_key: @end_marker_key,
           stream_fun: fn excluded_start_key, included_end_key ->
             CubDB.select(db,
               min_key: excluded_start_key,
@@ -23,28 +26,30 @@ defmodule Electric.ConcurrentStreamTest do
           end
         )
 
-      read_task =
-        Task.async(fn ->
-          items = Enum.to_list(stream)
+      read_tasks =
+        for _ <- 1..10 do
+          Task.async(fn ->
+            items = Enum.to_list(stream)
 
-          assert Enum.count(items) == item_count
+            assert Enum.count(items) == @item_count
 
-          for i <- 1..item_count do
-            assert Enum.at(items, i - 1) == {i, "item_#{i}"}
-          end
-        end)
+            for i <- 1..@item_count do
+              assert Enum.at(items, i - 1) == {i, "item_#{i}"}
+            end
+          end)
+        end
 
       # Write the stream concurrently
-      for i <- 1..item_count do
+      for i <- 1..@item_count do
         CubDB.put(db, i, "item_#{i}")
         # Sleep to give the read process time to run
         Process.sleep(1)
       end
 
       # Write the end marker to let the read process that the stream has ended
-      CubDB.put(db, end_marker_key, "ended")
+      CubDB.put(db, @end_marker_key, "ended")
 
-      Task.await(read_task)
+      Task.await_many(read_tasks)
     end
   end
 end

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -99,7 +99,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
       end)
-      |> expect(:wait_for_snapshot, fn _, @test_shape_id -> :ready end)
+      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :ready end)
 
       next_offset = LogOffset.increment(@first_offset)
 
@@ -140,7 +140,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
       end)
-      |> expect(:wait_for_snapshot, fn _, @test_shape_id -> :ready end)
+      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :ready end)
 
       next_offset = LogOffset.increment(@first_offset)
 
@@ -173,7 +173,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
       end)
-      |> expect(:wait_for_snapshot, fn _, @test_shape_id -> :ready end)
+      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :ready end)
 
       next_offset = LogOffset.increment(@first_offset)
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -99,7 +99,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
       end)
-      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :ready end)
+      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :started end)
 
       next_offset = LogOffset.increment(@first_offset)
 
@@ -140,7 +140,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
       end)
-      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :ready end)
+      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :started end)
 
       next_offset = LogOffset.increment(@first_offset)
 
@@ -173,7 +173,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
       end)
-      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :ready end)
+      |> expect(:await_snapshot_start, fn _, @test_shape_id -> :started end)
 
       next_offset = LogOffset.increment(@first_offset)
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -306,7 +306,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
           create_snapshot_fn: fn parent, shape_id, shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
             Storage.make_new_snapshot!(shape_id, shape, @basic_query_meta, [["test"]], storage)
-            GenServer.cast(parent, {:snapshot_ready, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_id})
           end
         )
 
@@ -333,7 +333,9 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       shape_cache_opts: shape_cache_opts
     } do
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, shape_cache_opts)
-      :ready = ShapeCache.wait_for_snapshot(Keyword.fetch!(shape_cache_opts, :server), shape_id)
+
+      :started =
+        ShapeCache.await_snapshot_start(Keyword.fetch!(shape_cache_opts, :server), shape_id)
 
       lsn = Lsn.from_integer(10)
 

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -617,12 +617,35 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         storage.mark_snapshot_as_started("shape-1", opts)
         storage.mark_snapshot_as_started("shape-2", opts)
         storage.mark_snapshot_as_started("shape-3", opts)
-        storage.make_new_snapshot!("shape-2", @shape, @query_info, @data_stream, opts)
-        storage.make_new_snapshot!("shape-3", @shape, @query_info, @data_stream, opts)
         storage.make_new_snapshot!("shape-1", @shape, @query_info, @data_stream, opts)
         storage.make_new_snapshot!("shape-2", @shape, @query_info, @data_stream, opts)
         storage.make_new_snapshot!("shape-3", @shape, @query_info, @data_stream, opts)
         storage.set_snapshot_xmin("shape-1", 11, opts)
+        storage.set_snapshot_xmin("shape-3", 33, opts)
+
+        storage.initialise(opts)
+
+        assert storage.snapshot_started?("shape-1", opts) == true
+        assert storage.snapshot_started?("shape-2", opts) == false
+        assert storage.snapshot_started?("shape-3", opts) == true
+      end
+
+      test "removes the shape if the snapshot has not finished", %{
+        module: storage,
+        opts: opts
+      } do
+        storage.initialise(opts)
+
+        storage.add_shape("shape-1", @shape, opts)
+        storage.add_shape("shape-2", @shape, opts)
+        storage.add_shape("shape-3", @shape, opts)
+        storage.mark_snapshot_as_started("shape-1", opts)
+        storage.mark_snapshot_as_started("shape-2", opts)
+        storage.mark_snapshot_as_started("shape-3", opts)
+        storage.make_new_snapshot!("shape-1", @shape, @query_info, @data_stream, opts)
+        storage.make_new_snapshot!("shape-3", @shape, @query_info, @data_stream, opts)
+        storage.set_snapshot_xmin("shape-1", 11, opts)
+        storage.set_snapshot_xmin("shape-2", 22, opts)
         storage.set_snapshot_xmin("shape-3", 33, opts)
 
         storage.initialise(opts)

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -39,7 +39,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
     doctest module, import: true
 
-    describe "#{module_name}.snapshot_exists?/2" do
+    describe "#{module_name}.snapshot_started?/2" do
       setup do
         {:ok, %{module: unquote(module)}}
       end
@@ -47,13 +47,13 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
       setup :start_storage
 
       test "returns false when shape does not exist", %{module: storage, opts: opts} do
-        assert storage.snapshot_exists?(@shape_id, opts) == false
+        assert storage.snapshot_started?(@shape_id, opts) == false
       end
 
       test "returns true when shape does exist", %{module: storage, opts: opts} do
         storage.make_new_snapshot!(@shape_id, @shape, @query_info, @data_stream, opts)
 
-        assert storage.snapshot_exists?(@shape_id, opts) == true
+        assert storage.snapshot_started?(@shape_id, opts) == true
       end
 
       test "returns true when shape does exist even from empty query results", %{
@@ -62,7 +62,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
       } do
         storage.make_new_snapshot!(@shape_id, @shape, @query_info, [], opts)
 
-        assert storage.snapshot_exists?(@shape_id, opts) == true
+        assert storage.snapshot_started?(@shape_id, opts) == true
       end
     end
 
@@ -439,12 +439,12 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
       setup :start_storage
 
-      test "causes snapshot_exists?/2 to return false", %{module: storage, opts: opts} do
+      test "causes snapshot_started?/2 to return false", %{module: storage, opts: opts} do
         storage.make_new_snapshot!(@shape_id, @shape, @query_info, @data_stream, opts)
 
         storage.cleanup!(@shape_id, opts)
 
-        assert storage.snapshot_exists?(@shape_id, opts) == false
+        assert storage.snapshot_started?(@shape_id, opts) == false
       end
 
       test "causes get_snapshot/2 to return a zero offset", %{module: storage, opts: opts} do
@@ -618,9 +618,9 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
         storage.cleanup_shapes_without_xmins(opts)
 
-        assert storage.snapshot_exists?("shape-1", opts) == true
-        assert storage.snapshot_exists?("shape-2", opts) == false
-        assert storage.snapshot_exists?("shape-3", opts) == true
+        assert storage.snapshot_started?("shape-1", opts) == true
+        assert storage.snapshot_started?("shape-2", opts) == false
+        assert storage.snapshot_started?("shape-3", opts) == true
       end
     end
   end

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -50,17 +50,8 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         assert storage.snapshot_started?(@shape_id, opts) == false
       end
 
-      test "returns true when shape does exist", %{module: storage, opts: opts} do
-        storage.make_new_snapshot!(@shape_id, @shape, @query_info, @data_stream, opts)
-
-        assert storage.snapshot_started?(@shape_id, opts) == true
-      end
-
-      test "returns true when shape does exist even from empty query results", %{
-        module: storage,
-        opts: opts
-      } do
-        storage.make_new_snapshot!(@shape_id, @shape, @query_info, [], opts)
+      test "returns true when snapshot has started", %{module: storage, opts: opts} do
+        storage.mark_snapshot_as_started(@shape_id, opts)
 
         assert storage.snapshot_started?(@shape_id, opts) == true
       end
@@ -512,7 +503,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         opts: opts
       } do
         refute storage.has_log_entry?(@shape_id, @snapshot_offset, opts)
-        storage.make_new_snapshot!(@shape_id, @shape, @query_info, @data_stream, opts)
+        storage.mark_snapshot_as_started(@shape_id, opts)
         assert storage.has_log_entry?(@shape_id, @snapshot_offset, opts)
       end
 
@@ -610,6 +601,11 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         storage.add_shape("shape-1", @shape, opts)
         storage.add_shape("shape-2", @shape, opts)
         storage.add_shape("shape-3", @shape, opts)
+        storage.mark_snapshot_as_started("shape-1", opts)
+        storage.mark_snapshot_as_started("shape-2", opts)
+        storage.mark_snapshot_as_started("shape-3", opts)
+        storage.make_new_snapshot!("shape-2", @shape, @query_info, @data_stream, opts)
+        storage.make_new_snapshot!("shape-3", @shape, @query_info, @data_stream, opts)
         storage.make_new_snapshot!("shape-1", @shape, @query_info, @data_stream, opts)
         storage.make_new_snapshot!("shape-2", @shape, @query_info, @data_stream, opts)
         storage.make_new_snapshot!("shape-3", @shape, @query_info, @data_stream, opts)

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -14,7 +14,7 @@ defmodule Electric.ShapeCache.StorageTest do
 
     MockStorage
     |> Mox.expect(:make_new_snapshot!, fn _, _, _, _, :opts -> :ok end)
-    |> Mox.expect(:snapshot_exists?, fn _, :opts -> true end)
+    |> Mox.expect(:snapshot_started?, fn _, :opts -> true end)
     |> Mox.expect(:get_snapshot, fn _, :opts -> {1, []} end)
     |> Mox.expect(:append_to_log!, fn _, _, :opts -> :ok end)
     |> Mox.expect(:get_log_stream, fn _, _, _, :opts -> [] end)
@@ -22,7 +22,7 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.expect(:cleanup!, fn _, :opts -> :ok end)
 
     Storage.make_new_snapshot!(shape_id, %{}, %{}, [], storage)
-    Storage.snapshot_exists?(shape_id, storage)
+    Storage.snapshot_started?(shape_id, storage)
     Storage.get_snapshot(shape_id, storage)
     Storage.append_to_log!(shape_id, [], storage)
     Storage.get_log_stream(shape_id, LogOffset.first(), storage)

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -283,7 +283,7 @@ defmodule Electric.ShapeCacheTest do
              } = map
     end
 
-    test "updates latest offset correctly", %{shape_cache_opts: opts} do
+    test "updates latest offset correctly", %{shape_cache_opts: opts, storage: storage} do
       {shape_id, initial_offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
       assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       assert {^shape_id, offset_after_snapshot} = ShapeCache.get_or_create_shape_id(@shape, opts)
@@ -306,9 +306,8 @@ defmodule Electric.ShapeCacheTest do
       assert offset_after_log_entry > offset_after_snapshot
       assert offset_after_log_entry == expected_offset_after_log_entry
 
-      # Sleep to allow snapshot process to finish rather than it erroring
-      # TODO: Find a better way than to sleep
-      Process.sleep(1_000)
+      # Stop snapshot process gracefully to prevent errors being logged in the test
+      Storage.get_snapshot(shape_id, storage)
     end
 
     test "errors if appending to untracked shape_id", %{shape_cache_opts: opts} do

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -79,7 +79,7 @@ defmodule Electric.ShapeCacheTest do
 
       {shape_id, offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
       assert offset == @zero_offset
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       assert Storage.snapshot_exists?(shape_id, storage)
     end
 
@@ -104,7 +104,7 @@ defmodule Electric.ShapeCacheTest do
       # subsequent calls return the same shape_id
       for _ <- 1..10, do: assert({^shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts))
 
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
 
       assert_received {:called, :prepare_tables_fn}
       assert_received {:called, :create_snapshot_fn}
@@ -147,7 +147,7 @@ defmodule Electric.ShapeCacheTest do
       shape_id = Task.await(create_call_1)
       assert shape_id == Task.await(create_call_2)
 
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
 
       # any queued calls should still return the existing shape_id
       # after the snapshot has been created (simulated by directly
@@ -202,7 +202,7 @@ defmodule Electric.ShapeCacheTest do
 
     test "creates initial snapshot from DB data", %{storage: storage, shape_cache_opts: opts} do
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       assert Storage.snapshot_exists?(shape_id, storage)
       assert {@zero_offset, stream} = Storage.get_snapshot(shape_id, storage)
 
@@ -265,7 +265,7 @@ defmodule Electric.ShapeCacheTest do
       )
 
       {shape_id, _} = ShapeCache.get_or_create_shape_id(shape, opts)
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       assert {@zero_offset, stream} = Storage.get_snapshot(shape_id, storage)
 
       assert [
@@ -287,7 +287,7 @@ defmodule Electric.ShapeCacheTest do
     test "updates latest offset correctly",
          %{storage: storage, shape_cache_opts: opts} do
       {shape_id, initial_offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       assert Storage.snapshot_exists?(shape_id, storage)
       assert {^shape_id, offset_after_snapshot} = ShapeCache.get_or_create_shape_id(@shape, opts)
 
@@ -362,7 +362,7 @@ defmodule Electric.ShapeCacheTest do
         )
 
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       assert [{^shape_id, @shape, 10}] = ShapeCache.list_active_shapes(opts)
     end
 
@@ -391,7 +391,7 @@ defmodule Electric.ShapeCacheTest do
 
       send(pid, {:continue, ref})
 
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       assert [{^shape_id, @shape, 10}] = ShapeCache.list_active_shapes(opts)
     end
   end
@@ -399,7 +399,7 @@ defmodule Electric.ShapeCacheTest do
   describe "await_snapshot_start/4" do
     setup :with_in_memory_storage
 
-    test "returns :ready for existing snapshot", %{storage: storage} = ctx do
+    test "returns :started for existing snapshot", %{storage: storage} = ctx do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.put(ctx, :pool, nil),
           prepare_tables_fn: @prepare_tables_noop,
@@ -411,7 +411,7 @@ defmodule Electric.ShapeCacheTest do
       # Manually create a snapshot
       Storage.make_new_snapshot!(shape_id, @shape, @basic_query_meta, [["test"]], storage)
 
-      assert ShapeCache.await_snapshot_start(opts[:server], shape_id) == :ready
+      assert ShapeCache.await_snapshot_start(opts[:server], shape_id) == :started
     end
 
     test "returns an error if waiting is for an unknown shape id",
@@ -447,7 +447,7 @@ defmodule Electric.ShapeCacheTest do
 
             # Sometimes only some tasks subscribe before reaching this point, and then hang
             # if we don't actually have a snapshot. This is kind of part of the test, because
-            # `await_snapshot_start/3` should always resolve to `:ready` in concurrent situations
+            # `await_snapshot_start/3` should always resolve to `:started` in concurrent situations
             Storage.make_new_snapshot!(shape_id, shape, @basic_query_meta, [["test"]], storage)
             GenServer.cast(parent, {:snapshot_ready, shape_id})
           end
@@ -461,7 +461,7 @@ defmodule Electric.ShapeCacheTest do
       assert_receive {:waiting_point, ref, pid}
       send(pid, {:continue, ref})
 
-      assert Enum.all?(Task.await_many(tasks), &(&1 == :ready))
+      assert Enum.all?(Task.await_many(tasks), &(&1 == :started))
     end
 
     test "propagates error in snapshot creation to listeners", ctx do
@@ -516,7 +516,7 @@ defmodule Electric.ShapeCacheTest do
 
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
       Process.sleep(50)
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
 
       Storage.append_to_log!(
         shape_id,
@@ -563,7 +563,7 @@ defmodule Electric.ShapeCacheTest do
 
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
       Process.sleep(50)
-      assert :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      assert :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
 
       Storage.append_to_log!(
         shape_id,
@@ -632,7 +632,7 @@ defmodule Electric.ShapeCacheTest do
 
     test "restores shape_ids", %{shape_cache_opts: opts} = context do
       {shape_id1, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id1)
+      :started = ShapeCache.await_snapshot_start(opts[:server], shape_id1)
       restart_shape_cache(context)
       {shape_id2, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
       assert shape_id1 == shape_id2
@@ -640,11 +640,11 @@ defmodule Electric.ShapeCacheTest do
 
     test "restores snapshot xmins", %{shape_cache_opts: opts} = context do
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       [{^shape_id, @shape, @snapshot_xmin}] = ShapeCache.list_active_shapes(opts)
 
       restart_shape_cache(context)
-      :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
 
       assert [{^shape_id, @shape, @snapshot_xmin}] = ShapeCache.list_active_shapes(opts)
     end
@@ -652,13 +652,13 @@ defmodule Electric.ShapeCacheTest do
     test "restores latest offset", %{shape_cache_opts: opts} = context do
       offset = @change_offset
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
 
       :ok = ShapeCache.append_to_log!(shape_id, offset, @log_items, opts)
 
       {^shape_id, ^offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
       restart_shape_cache(context)
-      :ready = ShapeCache.await_snapshot_start(opts[:server], shape_id)
+      :started = ShapeCache.await_snapshot_start(opts[:server], shape_id)
       assert {^shape_id, ^offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
     end
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -400,7 +400,7 @@ defmodule Electric.ShapeCacheTest do
   describe "await_snapshot_start/4" do
     setup :with_in_memory_storage
 
-    test "returns :started for existing snapshot", %{storage: storage} = ctx do
+    test "returns :started for snapshots that have started", %{storage: storage} = ctx do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.put(ctx, :pool, nil),
           prepare_tables_fn: @prepare_tables_noop,
@@ -409,8 +409,7 @@ defmodule Electric.ShapeCacheTest do
 
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
 
-      # Manually create a snapshot
-      Storage.make_new_snapshot!(shape_id, @shape, @basic_query_meta, [["test"]], storage)
+      Storage.mark_snapshot_as_started(shape_id, storage)
 
       assert ShapeCache.await_snapshot_start(opts[:server], shape_id) == :started
     end


### PR DESCRIPTION
Previously shapes with one million rows or more (170MB+) would timeout waiting for the snapshot to be created. Now the snapshot is streamed from the database into storage while simultaneously being streamed from storage to the client. This means the first packets of the response can be sent without waiting for the snapshot to finish. This means we now support tables with over a million rows. Ilia is currently benchmarking this branch to see what the new limits are. 

This PR addresses #1438 and #1444

I think there are quite a few simplifications that could happen off the back of this change, but I have kept the refactoring to a minimum in this PR and will instead address the simplifications in separate PRs.