### PR TITLE
feat (sync service): support qualified schema and table names

### DIFF
--- a/.changeset/curvy-tables-smash.md
+++ b/.changeset/curvy-tables-smash.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Support quoted schema and table names

--- a/packages/react-hooks/test/support/test-context.ts
+++ b/packages/react-hooks/test/support/test-context.ts
@@ -80,7 +80,7 @@ export const testWithIssuesTable = testWithDbClient.extend<{
     await dbClient.query(`DROP TABLE ${tableName}`)
   },
   issuesTableUrl: async ({ issuesTableSql, pgSchema, clearShape }, use) => {
-    const urlAppropriateTable = pgSchema + `.` + issuesTableSql.slice(1, -1)
+    const urlAppropriateTable = pgSchema + `.` + issuesTableSql
     await use(urlAppropriateTable)
     try {
       await clearShape(urlAppropriateTable)

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -85,30 +85,18 @@ defmodule Electric.Shapes.Shape do
 
     case Regex.run(regex, definition, capture: :all_names) do
       ["", table_name] when table_name != "" ->
-        table_name = parse_name(table_name)
+        table_name = parse_quoted_name(table_name)
         IO.puts("table: public.#{table_name}")
         {:ok, {"public", table_name}}
 
       [schema_name, table_name] when table_name != "" ->
-        schema_name = parse_name(schema_name)
-        table_name = parse_name(table_name)
+        schema_name = parse_quoted_name(schema_name)
+        table_name = parse_quoted_name(table_name)
         IO.puts("table: #{schema_name}.#{table_name}")
         {:ok, {schema_name, table_name}}
 
       _ ->
         {:error, ["table name does not match expected format"]}
-    end
-  end
-
-  # Parses Postgres schema and table names
-  defp parse_name(str) do
-    if String.first(str) == ~s(") && String.last(str) == ~s(") do
-      # Remove the surrounding quotes and also unescape any escaped quotes
-      str
-      |> String.slice(1..-2//1)
-      |> String.replace(~r/""/, ~s("))
-    else
-      str
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -7,6 +7,7 @@ defmodule Electric.Shapes.Shape do
   alias Electric.Replication.Eval.Parser
   alias Electric.Replication.Eval.Runner
   alias Electric.Replication.Changes
+  alias Electric.Utils
 
   @enforce_keys [:root_table]
   defstruct [:root_table, :table_info, :where]
@@ -85,13 +86,13 @@ defmodule Electric.Shapes.Shape do
 
     case Regex.run(regex, definition, capture: :all_names) do
       ["", table_name] when table_name != "" ->
-        table_name = parse_quoted_name(table_name)
+        table_name = Utils.parse_quoted_name(table_name)
         IO.puts("table: public.#{table_name}")
         {:ok, {"public", table_name}}
 
       [schema_name, table_name] when table_name != "" ->
-        schema_name = parse_quoted_name(schema_name)
-        table_name = parse_quoted_name(table_name)
+        schema_name = Utils.parse_quoted_name(schema_name)
+        table_name = Utils.parse_quoted_name(table_name)
         IO.puts("table: #{schema_name}.#{table_name}")
         {:ok, {schema_name, table_name}}
 

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -87,13 +87,11 @@ defmodule Electric.Shapes.Shape do
     case Regex.run(regex, definition, capture: :all_names) do
       ["", table_name] when table_name != "" ->
         table_name = Utils.parse_quoted_name(table_name)
-        IO.puts("table: public.#{table_name}")
         {:ok, {"public", table_name}}
 
       [schema_name, table_name] when table_name != "" ->
         schema_name = Utils.parse_quoted_name(schema_name)
         table_name = Utils.parse_quoted_name(table_name)
-        IO.puts("table: #{schema_name}.#{table_name}")
         {:ok, {schema_name, table_name}}
 
       _ ->

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -200,6 +200,30 @@ defmodule Electric.Utils do
   def escape_quotes(text), do: :binary.replace(text, ~S|"|, ~S|""|, [:global])
 
   @doc """
+  Parses quoted names.
+
+  ## Examples
+      iex> parse_quoted_name("foo")
+      "foo"
+
+      iex> parse_quoted_name(~S|"foo"|)
+      "foo"
+
+      iex> parse_quoted_name(~S|"fo""o"|)
+      ~S|fo\"o|
+  """
+  def parse_quoted_name(str) do
+    if String.first(str) == ~s(") && String.last(str) == ~s(") do
+      # Remove the surrounding quotes and also unescape any escaped quotes
+      str
+      |> String.slice(1..-2//1)
+      |> String.replace(~r/""/, ~s("))
+    else
+      str
+    end
+  end
+
+  @doc """
   Applies either an anonymous function or a MFA tuple, prepending the given arguments
   in case of an MFA.
 

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -210,7 +210,7 @@ defmodule Electric.Utils do
       "foo"
 
       iex> parse_quoted_name(~S|"fo""o"|)
-      ~S|fo\"o|
+      ~S|fo"o|
   """
   def parse_quoted_name(str) do
     if String.first(str) == ~s(") && String.last(str) == ~s(") do

--- a/packages/typescript-client/test/support/test-context.ts
+++ b/packages/typescript-client/test/support/test-context.ts
@@ -80,7 +80,7 @@ export const testWithIssuesTable = testWithDbClient.extend<{
     await dbClient.query(`DROP TABLE ${tableName}`)
   },
   issuesTableUrl: async ({ issuesTableSql, pgSchema, clearShape }, use) => {
-    const urlAppropriateTable = pgSchema + `.` + issuesTableSql.slice(1, -1)
+    const urlAppropriateTable = pgSchema + `.` + issuesTableSql
     await use(urlAppropriateTable)
     try {
       await clearShape(urlAppropriateTable)
@@ -168,7 +168,7 @@ export const testWithMultitypeTable = testWithDbClient.extend<{
     `)
   },
   tableUrl: async ({ tableSql, clearShape, pgSchema }, use) => {
-    const urlAppropriateTable = pgSchema + `.` + tableSql.slice(1, -1)
+    const urlAppropriateTable = pgSchema + `.` + tableSql
     await use(urlAppropriateTable)
     try {
       await clearShape(urlAppropriateTable)


### PR DESCRIPTION
This PR addresses https://github.com/electric-sql/electric/issues/1449 as it adds support for qualified schema and table names. To this end, i modified `validate_table` to parse (quoted) schema and table names.