### PR TITLE
docs: fix offset formatting in OpenAPI spec

### DIFF
--- a/docs/electric-api.yaml
+++ b/docs/electric-api.yaml
@@ -255,7 +255,7 @@ paths:
                 example:
                   - headers:
                       operation: insert
-                    offset: 0/0
+                    offset: 0_0
                     key: issue-1
                     value:
                       id: issue-1
@@ -264,7 +264,7 @@ paths:
                   - headers:
                       operation: insert
                       control: up-to-date
-                    offset: 1934/0
+                    offset: 1934_0
                     key: issue-2
                     value:
                       id: issue-2


### PR DESCRIPTION
Some examples in the OpenAPI spec were still using the old `number/number` format for log offsets instead of `number_number`. This fixes those occurences as per https://github.com/electric-sql/electric/issues/1452.