### PR TITLE
feat: move JSON serialization at snapshot creation to PostgreSQL query

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -350,12 +350,12 @@ defmodule Electric.ShapeCache do
         # formatting between snapshot and live log entries.
         Enum.each(Electric.Postgres.display_settings(), &Postgrex.query!(conn, &1, []))
 
-        {query, stream} = Querying.stream_initial_data(conn, shape)
+        stream = Querying.stream_initial_data(conn, shape)
         GenServer.cast(parent, {:snapshot_started, shape_id})
 
         # could pass the shape and then make_new_snapshot! can pass it to row_to_snapshot_item
         # that way it has the relation, but it is still missing the pk_cols
-        Storage.make_new_snapshot!(shape_id, shape, query, stream, storage)
+        Storage.make_new_snapshot!(shape_id, stream, storage)
       end)
     end)
   end

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -1,6 +1,5 @@
 defmodule Electric.ShapeCache.CubDbStorage do
   alias Electric.ConcurrentStream
-  alias Electric.LogItems
   alias Electric.Replication.LogOffset
   alias Electric.Telemetry.OpenTelemetry
   @behaviour Electric.ShapeCache.Storage
@@ -112,7 +111,6 @@ defmodule Electric.ShapeCache.CubDbStorage do
         end
       )
       |> Stream.flat_map(fn {_, items} -> items end)
-      |> Stream.map(fn {_, item} -> item end)
 
     # FIXME: this is naive while we don't have snapshot metadata to get real offset
     {@snapshot_offset, stream}
@@ -141,16 +139,14 @@ defmodule Electric.ShapeCache.CubDbStorage do
     CubDB.put(opts.db, snapshot_start(shape_id), 0)
   end
 
-  def make_new_snapshot!(shape_id, shape, query_info, data_stream, opts) do
+  def make_new_snapshot!(shape_id, data_stream, opts) do
     OpenTelemetry.with_span("storage.make_new_snapshot", [storage_impl: "cub_db"], fn ->
       data_stream
-      |> LogItems.from_snapshot_row_stream(@snapshot_offset, shape, query_info)
-      |> Stream.with_index()
-      |> Stream.map(fn {log_item, index} ->
-        {snapshot_key(shape_id, index), Jason.encode!(log_item)}
-      end)
       |> Stream.chunk_every(500)
-      |> Stream.each(fn [{key, _} | _] = chunk -> CubDB.put(opts.db, key, chunk) end)
+      |> Stream.with_index()
+      |> Stream.each(fn {chunk, index} ->
+        CubDB.put(opts.db, snapshot_key(shape_id, index), chunk)
+      end)
       |> Stream.run()
 
       CubDB.put(opts.db, snapshot_end(shape_id), 0)

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -45,16 +45,13 @@ defmodule Electric.ShapeCache.Storage do
   @doc "Get the full snapshot for a given shape, also returning the offset this snapshot includes"
   @callback get_snapshot(shape_id(), compiled_opts()) :: {offset :: LogOffset.t(), log()}
   @doc """
-  Make a new snapshot for a shape ID based on the meta information about the table and a stream of plain string rows
+  Make a new snapshot for a shape ID based on the meta information about the table and a stream of log entries preformatted as JSON strings.
 
   Should raise an error if making the snapshot had failed for any reason.
   """
-  @doc unstable: "The meta information about the single table is subject to change"
   @callback make_new_snapshot!(
               shape_id(),
-              Electric.Shapes.Shape.t(),
-              Postgrex.Query.t(),
-              Enumerable.t(row()),
+              Enumerable.t(String.t()),
               compiled_opts()
             ) :: :ok
   @callback mark_snapshot_as_started(shape_id, compiled_opts()) :: :ok
@@ -102,18 +99,15 @@ defmodule Electric.ShapeCache.Storage do
   def get_snapshot(shape_id, {mod, opts}), do: mod.get_snapshot(shape_id, opts)
 
   @doc """
-  Make a new snapshot for a shape ID based on the meta information about the table and a stream of plain string rows
+  Make a new snapshot for a shape ID based on the meta information about the table and a stream of log entries preformatted as JSON strings.
   """
-  @doc unstable: "The meta information about the single table is subject to change"
   @spec make_new_snapshot!(
           shape_id(),
-          Electric.Shapes.Shape.t(),
-          Postgrex.Query.t(),
           Enumerable.t(row()),
           storage()
         ) :: :ok
-  def make_new_snapshot!(shape_id, shape, meta, stream, {mod, opts}),
-    do: mod.make_new_snapshot!(shape_id, shape, meta, stream, opts)
+  def make_new_snapshot!(shape_id, stream, {mod, opts}),
+    do: mod.make_new_snapshot!(shape_id, stream, opts)
 
   @spec mark_snapshot_as_started(shape_id, compiled_opts()) :: :ok
   def mark_snapshot_as_started(shape_id, {mod, opts}),

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -1,12 +1,13 @@
 defmodule Electric.Shapes.Querying do
+  alias Electric.Replication.LogOffset
   alias Electric.Utils
   alias Electric.Shapes.Shape
   alias Electric.Telemetry.OpenTelemetry
 
-  @type row :: [term()]
-
-  @spec stream_initial_data(DBConnection.t(), Shape.t()) ::
-          {Postgrex.Query.t(), Enumerable.t(row())}
+  @doc """
+  Streams the initial data for a shape. Query results are returned as a stream of JSON strings, as prepared on PostgreSQL.
+  """
+  @spec stream_initial_data(DBConnection.t(), Shape.t()) :: Enumerable.t(String.t())
   def stream_initial_data(conn, %Shape{root_table: root_table, table_info: table_info} = shape) do
     OpenTelemetry.with_span("querying.stream_initial_data", [], fn ->
       table = Utils.relation_to_sql(root_table)
@@ -14,26 +15,106 @@ defmodule Electric.Shapes.Querying do
       where =
         if not is_nil(shape.where), do: " WHERE " <> shape.where.query, else: ""
 
+      {json_like_select, params} = json_like_select(table_info, root_table, Shape.pk(shape))
+
       query =
-        Postgrex.prepare!(
-          conn,
-          table,
-          ~s|SELECT #{columns(table_info, root_table)} FROM #{table} #{where}|
-        )
+        Postgrex.prepare!(conn, table, ~s|SELECT #{json_like_select} FROM #{table} #{where}|)
 
-      stream =
-        Postgrex.stream(conn, query, [])
-        |> Stream.flat_map(& &1.rows)
-
-      {query, stream}
+      Postgrex.stream(conn, query, params)
+      |> Stream.flat_map(& &1.rows)
+      |> Stream.map(&hd/1)
     end)
   end
 
-  defp columns(table_info, root_table) do
+  defp json_like_select(table_info, root_table, pk_cols) do
+    columns = get_column_names(table_info, root_table)
+
+    key_part = build_key_part(root_table, pk_cols)
+    value_part = build_value_part(columns)
+    headers_part = build_headers_part(root_table)
+    offset_part = ~s['"offset":"#{LogOffset.first()}"']
+
+    # We're building a JSON string that looks like this:
+    #
+    # {
+    #   "key": "\"public\".\"test_table\"/\"1\"",
+    #   "value": {
+    #     "id": "1",
+    #     "name": "John Doe",
+    #     "email": "john.doe@example.com",
+    #     "nullable": null
+    #   },
+    #   "headers": {"operation": "insert", "relation": ["public", "test_table"]},
+    #   "offset": "0_0"
+    # }
+    query =
+      ~s['{' || #{key_part} || ',' || #{value_part} || ',' || #{headers_part} || ',' || #{offset_part} || '}']
+
+    {query, []}
+  end
+
+  defp get_column_names(table_info, root_table) do
     table_info
     |> Map.fetch!(root_table)
     |> Map.fetch!(:columns)
-    |> Enum.map(&~s("#{Utils.escape_quotes(&1.name)}"::text))
-    |> Enum.join(", ")
+    |> Enum.map(& &1.name)
   end
+
+  defp build_headers_part(root_table) do
+    ~s['"headers":{"operation":"insert","relation":#{build_relation_header(root_table)}}']
+  end
+
+  defp build_relation_header({schema, table}) do
+    ~s'["#{escape_sql_json_interpolation(schema)}","#{escape_sql_json_interpolation(table)}"]'
+  end
+
+  defp build_key_part(root_table, pk_cols) do
+    pk_part = join_primary_keys(pk_cols)
+
+    # Because relation part of the key is known at query building time, we can use $1 to inject escaped version of the relation
+    ~s['"key":' || ] <> pg_escape_string_for_json(~s['#{escape_relation(root_table)}' || '/"' || #{pk_part} || '"'])
+  end
+
+  defp join_primary_keys(pk_cols) do
+    pk_cols
+    |> Enum.map(&pg_cast_column_to_text/1)
+    |> Enum.map(&~s[replace(#{&1}, '/', '//')])
+    # NULL values are not allowed in PKs, but they are possible on pk-less tables where we consider all columns to be PKs
+    |> Enum.map(&~s[coalesce(#{&1}, '')])
+    |> Enum.join(~s[ || '"/"' || ])
+  end
+
+  defp build_value_part(columns) do
+    column_parts = Enum.map(columns, &build_column_part/1)
+    ~s['"value":{' || #{Enum.join(column_parts, " || ',' || ")} || '}']
+  end
+
+  defp build_column_part(column) do
+    escaped_name = escape_sql_json_interpolation(column)
+    escaped_value = escape_column_value(column)
+
+    # Since `||` returns NULL if any of the arguments is NULL, we need to use `coalesce` to handle NULL values
+    ~s['"#{escaped_name}":' || #{pg_coalesce_json_string(escaped_value)}]
+  end
+
+  defp escape_sql_json_interpolation(str) do
+    str
+    |> String.replace(~S|"|, ~S|\"|)
+    |> String.replace(~S|'|, ~S|''|)
+  end
+
+  defp escape_relation(relation) do
+    relation |> Utils.relation_to_sql() |> String.replace(~S|'|, ~S|''|)
+  end
+
+  defp escape_column_value(column) do
+    column
+    |> pg_cast_column_to_text()
+    |> pg_escape_string_for_json()
+    |> pg_coalesce_json_string()
+  end
+
+  defp pg_cast_column_to_text(column), do: ~s["#{Utils.escape_quotes(column)}"::text]
+  defp pg_escape_string_for_json(str), do: ~s[to_json(#{str})::text]
+  defp pg_coalesce_json_string(str), do: ~s[coalesce(#{str} , 'null')]
 end

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -72,7 +72,8 @@ defmodule Electric.Shapes.Querying do
     pk_part = join_primary_keys(pk_cols)
 
     # Because relation part of the key is known at query building time, we can use $1 to inject escaped version of the relation
-    ~s['"key":' || ] <> pg_escape_string_for_json(~s['#{escape_relation(root_table)}' || '/"' || #{pk_part} || '"'])
+    ~s['"key":' || ] <>
+      pg_escape_string_for_json(~s['#{escape_relation(root_table)}' || '/"' || #{pk_part} || '"'])
   end
 
   defp join_primary_keys(pk_cols) do

--- a/packages/sync-service/lib/electric/telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry.ex
@@ -53,7 +53,13 @@ defmodule Electric.Telemetry do
         tags: [:route],
         unit: {:native, :millisecond}
       ),
-      summary("electric.shape_cache.create_snapshot_task.stop", unit: {:native, :millisecond})
+      summary("electric.shape_cache.create_snapshot_task.stop.duration",
+        unit: {:native, :millisecond}
+      ),
+      summary("electric.storage.make_new_snapshot.stop.duration", unit: {:native, :millisecond}),
+      summary("electric.querying.stream_initial_data.stop.duration",
+        unit: {:native, :millisecond}
+      )
     ]
     |> Enum.map(&%{&1 | tags: [:instance_id | &1.tags]})
   end

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -291,8 +291,6 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     end
   end
 
-  @basic_query_meta %Postgrex.Query{columns: ["id"], result_types: [:text], name: "key_prefix"}
-
   describe "store_transaction/2 with real storage" do
     setup [
       {Support.ComponentSetup, :with_registry},
@@ -303,9 +301,9 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       %{shape_cache: shape_cache, shape_cache_opts: shape_cache_opts} =
         Support.ComponentSetup.with_shape_cache(Map.put(ctx, :pool, nil),
           prepare_tables_fn: fn _, _ -> :ok end,
-          create_snapshot_fn: fn parent, shape_id, shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_id, _, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
-            Storage.make_new_snapshot!(shape_id, shape, @basic_query_meta, [["test"]], storage)
+            Storage.make_new_snapshot!(shape_id, [["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_id})
           end
         )

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -13,7 +13,7 @@ defmodule Electric.ShapeCache.StorageTest do
     shape_id = "test"
 
     MockStorage
-    |> Mox.expect(:make_new_snapshot!, fn _, _, _, _, :opts -> :ok end)
+    |> Mox.expect(:make_new_snapshot!, fn _, _, :opts -> :ok end)
     |> Mox.expect(:snapshot_started?, fn _, :opts -> true end)
     |> Mox.expect(:get_snapshot, fn _, :opts -> {1, []} end)
     |> Mox.expect(:append_to_log!, fn _, _, :opts -> :ok end)
@@ -21,7 +21,7 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.expect(:has_log_entry?, fn _, _, :opts -> [] end)
     |> Mox.expect(:cleanup!, fn _, :opts -> :ok end)
 
-    Storage.make_new_snapshot!(shape_id, %{}, %{}, [], storage)
+    Storage.make_new_snapshot!(shape_id, [], storage)
     Storage.snapshot_started?(shape_id, storage)
     Storage.get_snapshot(shape_id, storage)
     Storage.append_to_log!(shape_id, [], storage)

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -5,7 +5,7 @@ defmodule Electric.Shapes.QueryingTest do
   alias Electric.Shapes.Shape
   alias Electric.Shapes.Querying
 
-  test "should give information about the table and the result stream", %{db_conn: conn} do
+  test "should give the resulting JSON stream", %{db_conn: conn} do
     Postgrex.query!(
       conn,
       """
@@ -20,10 +20,40 @@ defmodule Electric.Shapes.QueryingTest do
     Postgrex.query!(conn, "INSERT INTO items (value) VALUES (1), (2), (3), (4), (5)", [])
     shape = Shape.new!("items", inspector: {DirectInspector, conn})
 
-    assert {query_info, stream} = Querying.stream_initial_data(conn, shape)
+    assert stream = Querying.stream_initial_data(conn, shape)
 
-    assert %{columns: ["id", "value"]} = query_info
-    assert [[_, "1"], [_, "2"], [_, "3"], [_, "4"], [_, "5"]] = Enum.to_list(stream)
+    assert [
+             %{
+               key: ~S["public"."items"/"1"],
+               value: %{id: "1", value: "1"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             },
+             %{
+               key: ~S["public"."items"/"2"],
+               value: %{id: "2", value: "2"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             },
+             %{
+               key: ~S["public"."items"/"3"],
+               value: %{id: "3", value: "3"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             },
+             %{
+               key: ~S["public"."items"/"4"],
+               value: %{id: "4", value: "4"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             },
+             %{
+               key: ~S["public"."items"/"5"],
+               value: %{id: "5", value: "5"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             }
+           ] == stream |> Enum.to_list() |> Enum.map(&Jason.decode!(&1, keys: :atoms))
   end
 
   test "respects the where clauses", %{db_conn: conn} do
@@ -41,10 +71,12 @@ defmodule Electric.Shapes.QueryingTest do
     Postgrex.query!(conn, "INSERT INTO items (value) VALUES (1), (2), (3), (4), (5)", [])
     shape = Shape.new!("items", where: "value > 3", inspector: {DirectInspector, conn})
 
-    assert {query_info, stream} = Querying.stream_initial_data(conn, shape)
+    assert stream = Querying.stream_initial_data(conn, shape)
 
-    assert %{columns: ["id", "value"]} = query_info
-    assert [[_, "4"], [_, "5"]] = Enum.to_list(stream)
+    assert [
+             %{key: ~S["public"."items"/"4"], value: %{value: "4"}},
+             %{key: ~S["public"."items"/"5"], value: %{value: "5"}}
+           ] = stream |> Enum.to_list() |> Enum.map(&Jason.decode!(&1, keys: :atoms))
   end
 
   test "allows column names to have special characters", %{db_conn: conn} do
@@ -53,7 +85,7 @@ defmodule Electric.Shapes.QueryingTest do
       """
       CREATE TABLE items (
         id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        "col with "" in it" INTEGER
+        "col with ""' in it" INTEGER
       )
       """,
       []
@@ -61,15 +93,76 @@ defmodule Electric.Shapes.QueryingTest do
 
     Postgrex.query!(
       conn,
-      ~s|INSERT INTO items ("col with "" in it") VALUES (1), (2), (3), (4), (5)|,
+      ~s|INSERT INTO items ("col with ""' in it") VALUES (1), (2)|,
       []
     )
 
     shape = Shape.new!("items", inspector: {DirectInspector, conn})
 
-    assert {query_info, stream} = Querying.stream_initial_data(conn, shape)
+    assert stream = Querying.stream_initial_data(conn, shape)
 
-    assert %{columns: ["id", ~s(col with " in it)]} = query_info
-    assert [[_, "1"], [_, "2"], [_, "3"], [_, "4"], [_, "5"]] = Enum.to_list(stream)
+    assert [
+             %{key: ~S["public"."items"/"1"], value: %{"col with \"' in it": "1"}},
+             %{key: ~S["public"."items"/"2"], value: %{"col with \"' in it": "2"}}
+           ] = stream |> Enum.to_list() |> Enum.map(&Jason.decode!(&1, keys: :atoms))
+  end
+
+  test "works with composite PKs", %{db_conn: conn} do
+    Postgrex.query!(
+      conn,
+      """
+      CREATE TABLE items (
+        id1 INTEGER,
+        id2 INTEGER,
+        "test" INTEGER,
+        PRIMARY KEY (id1, id2)
+      )
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      ~s|INSERT INTO items (id1, id2, "test") VALUES (1, 2, 1), (3,4, 2)|,
+      []
+    )
+
+    shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+    assert stream = Querying.stream_initial_data(conn, shape)
+
+    assert [
+             %{key: ~S["public"."items"/"1"/"2"], value: %{test: "1"}},
+             %{key: ~S["public"."items"/"3"/"4"], value: %{test: "2"}}
+           ] = stream |> Enum.to_list() |> Enum.map(&Jason.decode!(&1, keys: :atoms))
+  end
+
+  test "works with null values & values with special characters", %{db_conn: conn} do
+    Postgrex.query!(
+      conn,
+      """
+      CREATE TABLE items (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        value TEXT
+      )
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      ~s|INSERT INTO items (value) VALUES ('1'), (NULL), ('"test\\x0001\n"')|,
+      []
+    )
+
+    shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+    assert stream = Querying.stream_initial_data(conn, shape)
+
+    assert [
+             %{key: ~S["public"."items"/"1"], value: %{value: "1"}},
+             %{key: ~S["public"."items"/"2"], value: %{value: nil}},
+             %{key: ~S["public"."items"/"3"], value: %{value: ~s["test\\x0001\n"]}}
+           ] = stream |> Enum.to_list() |> Enum.map(&Jason.decode!(&1, keys: :atoms))
   end
 end


### PR DESCRIPTION
This moves us building up JSON from Elixir to Postgres Query, which should be faster.