### PR TITLE
feat: clean shapes affected by relation changes

### DIFF
--- a/.changeset/clever-parents-fail.md
+++ b/.changeset/clever-parents-fail.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+clean shapes affected by migrations

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -39,7 +39,9 @@ defmodule Electric.Application do
                try_creating_publication?: true,
                slot_name: slot_name,
                transaction_received:
-                 {Electric.Replication.ShapeLogCollector, :store_transaction, []}
+                 {Electric.Replication.ShapeLogCollector, :store_transaction, []},
+               relation_received:
+                 {Electric.Replication.ShapeLogCollector, :handle_relation_change, []}
              ],
              pool_opts: [
                name: Electric.DbPool,

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -41,7 +41,7 @@ defmodule Electric.Application do
                transaction_received:
                  {Electric.Replication.ShapeLogCollector, :store_transaction, []},
                relation_received:
-                 {Electric.Replication.ShapeLogCollector, :handle_relation_change, []}
+                 {Electric.Replication.ShapeLogCollector, :handle_relation_msg, []}
              ],
              pool_opts: [
                name: Electric.DbPool,

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -7,7 +7,7 @@ defmodule Electric.Postgres.ReplicationClient do
   alias Electric.Postgres.LogicalReplication.Decoder
   alias Electric.Postgres.ReplicationClient.Collector
   alias Electric.Postgres.ReplicationClient.ConnectionSetup
-  alias Electric.Replication.Changes.RelationChange
+  alias Electric.Replication.Changes.Relation
 
   require Logger
 
@@ -163,7 +163,7 @@ defmodule Electric.Postgres.ReplicationClient do
       %Collector{} = txn_collector ->
         {:noreply, %{state | txn_collector: txn_collector}}
 
-      {%RelationChange{} = rel, %Collector{} = txn_collector} ->
+      {%Relation{} = rel, %Collector{} = txn_collector} ->
         {m, f, args} = state.relation_received
         apply(m, f, [rel | args])
         {:noreply, %{state | txn_collector: txn_collector}}

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -7,6 +7,7 @@ defmodule Electric.Postgres.ReplicationClient do
   alias Electric.Postgres.LogicalReplication.Decoder
   alias Electric.Postgres.ReplicationClient.Collector
   alias Electric.Postgres.ReplicationClient.ConnectionSetup
+  alias Electric.Replication.Changes.RelationChange
 
   require Logger
 
@@ -20,9 +21,10 @@ defmodule Electric.Postgres.ReplicationClient do
           | :streaming
 
   defmodule State do
-    @enforce_keys [:transaction_received, :publication_name]
+    @enforce_keys [:transaction_received, :relation_received, :publication_name]
     defstruct [
       :transaction_received,
+      :relation_received,
       :publication_name,
       :try_creating_publication?,
       :start_streaming?,
@@ -44,6 +46,7 @@ defmodule Electric.Postgres.ReplicationClient do
 
     @type t() :: %__MODULE__{
             transaction_received: {module(), atom(), [term()]},
+            relation_received: {module(), atom(), [term()]},
             publication_name: String.t(),
             try_creating_publication?: boolean(),
             start_streaming?: boolean(),
@@ -58,6 +61,7 @@ defmodule Electric.Postgres.ReplicationClient do
 
     @opts_schema NimbleOptions.new!(
                    transaction_received: [required: true, type: :mfa],
+                   relation_received: [required: true, type: :mfa],
                    publication_name: [required: true, type: :string],
                    try_creating_publication?: [required: true, type: :boolean],
                    start_streaming?: [type: :boolean, default: true],
@@ -157,6 +161,11 @@ defmodule Electric.Postgres.ReplicationClient do
     |> Collector.handle_message(state.txn_collector)
     |> case do
       %Collector{} = txn_collector ->
+        {:noreply, %{state | txn_collector: txn_collector}}
+
+      {%RelationChange{} = rel, %Collector{} = txn_collector} ->
+        {m, f, args} = state.relation_received
+        apply(m, f, [rel | args])
         {:noreply, %{state | txn_collector: txn_collector}}
 
       {txn, %Collector{} = txn_collector} ->

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -18,8 +18,6 @@ defmodule Electric.Replication.Changes do
   @type db_identifier() :: String.t()
   @type xid() :: non_neg_integer()
   @type relation_name() :: {schema :: db_identifier(), table :: db_identifier()}
-  @type column() :: {name :: db_identifier(), type_oid :: pos_integer()}
-  @type relation() :: {schema :: db_identifier(), table :: db_identifier(), columns :: [column()]}
   @type record() :: %{(column_name :: db_identifier()) => column_data :: binary()}
   @type relation_id() :: non_neg_integer
 
@@ -164,12 +162,32 @@ defmodule Electric.Replication.Changes do
           }
   end
 
+  defmodule Column do
+    defstruct [:name, :type_oid]
+
+    @type t() :: %__MODULE__{
+            name: Changes.db_identifier(),
+            type_oid: pos_integer()
+          }
+  end
+
+  defmodule Relation do
+    defstruct [:id, :schema, :table, :columns]
+
+    @type t() :: %__MODULE__{
+            id: Changes.relation_id(),
+            schema: Changes.db_identifier(),
+            table: Changes.db_identifier(),
+            columns: [Column.t()]
+          }
+  end
+
   defmodule RelationChange do
     defstruct [:old_relation, :new_relation]
 
     @type t() :: %__MODULE__{
-            old_relation: Changes.relation(),
-            new_relation: Changes.relation()
+            old_relation: Relation.t(),
+            new_relation: Relation.t()
           }
   end
 

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -427,6 +427,3 @@ defmodule Electric.ShapeCache do
     |> Enum.each(&store_relation_ets(&1, state))
   end
 end
-
-# TODO:
-# - Write tests to check that shape cache recovers relations on restart

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -132,8 +132,6 @@ defmodule Electric.ShapeCache do
     ])
   end
 
-  # TODO: introduce a recover_relations similar to recover_shapes
-  #       and call it in `init` to recover relations
   @spec store_relation(Relation.t(), keyword()) :: :ok
   def store_relation(%Relation{} = rel, opts) do
     store_relation_ets(rel, opts)
@@ -424,7 +422,11 @@ defmodule Electric.ShapeCache do
   end
 
   defp recover_relations(state) do
-    Storage.get_relations(state.storage)
-    |> Stream.each(&store_relation_ets(&1, state))
+    state.storage
+    |> Storage.get_relations()
+    |> Enum.each(&store_relation_ets(&1, state))
   end
 end
+
+# TODO:
+# - Write tests to check that shape cache recovers relations on restart

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -207,15 +207,19 @@ defmodule Electric.ShapeCache.CubDbStorage do
   end
 
   defp relations_start, do: relation_key(0)
-  # We use the fact that 2-element tuples are always smaller than 3-element tuples
-  defp relations_end, do: {:relations, 0, 0}
+  # Atoms are always bigger than numbers
+  # Thus this key is bigger than any possible relation key
+  defp relations_end, do: relation_key(:max)
 
   def xmin_key(shape_id) do
     {:snapshot_xmin, shape_id}
   end
 
-  defp shapes_start, do: shape_key(0)
-  defp shapes_end, do: shape_key("zzz-end")
+  defp shapes_start, do: shape_key("")
+  # Since strings in Elixir are encoded using UTF-8,
+  # it is impossible for any valid string to contain byte value 255.
+  # Thus any key will be smaller than this one.
+  defp shapes_end, do: shape_key(<<255>>)
 
   # FIXME: this is naive while we don't have snapshot metadata to get real offsets
   defp offset({_shape_id, @snapshot_key_type, _index}), do: @snapshot_offset

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -2,6 +2,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   alias Electric.ConcurrentStream
   alias Electric.LogItems
   alias Electric.Replication.LogOffset
+  alias Electric.Replication.Changes.Relation
   alias Electric.Telemetry.OpenTelemetry
   use Agent
 
@@ -139,6 +140,15 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     |> then(&:ets.insert(ets_table, &1))
 
     :ok
+  end
+
+  def store_relation(%Relation{}, _opts) do
+    # Relations are already stored in memory by the shape cache
+    # so no need to do anything here
+  end
+
+  def get_relations(_opts) do
+    []
   end
 
   def cleanup!(shape_id, opts) do

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -69,6 +69,10 @@ defmodule Electric.ShapeCache.Storage do
               Enumerable.t()
   @doc "Check if log entry for given shape ID and offset exists"
   @callback has_log_entry?(shape_id(), LogOffset.t(), compiled_opts()) :: boolean()
+  @doc "Store a relation containing information about the schema of a table"
+  @callback store_relation(Relation.t(), compiled_opts()) :: :ok
+  @doc "Get all stored relations"
+  @callback get_relations(compiled_opts()) :: Enumerable.t(Relation.t())
   @doc "Clean up snapshots/logs for a shape id"
   @callback cleanup!(shape_id(), compiled_opts()) :: :ok
 
@@ -138,6 +142,15 @@ defmodule Electric.ShapeCache.Storage do
   @spec has_log_entry?(shape_id(), LogOffset.t(), storage()) :: boolean()
   def has_log_entry?(shape_id, offset, {mod, opts}),
     do: mod.has_log_entry?(shape_id, offset, opts)
+
+  @doc "Store a relation containing information about the schema of a table"
+  @spec store_relation(Relation.t(), storage()) :: :ok
+  def store_relation(relation, {mod, opts}),
+    do: mod.store_relation(relation, opts)
+
+  @doc "Get all stored relations"
+  @spec get_relations(storage()) :: Enumerable.t(Relation.t())
+  def get_relations({mod, opts}), do: mod.get_relations(opts)
 
   @doc "Clean up snapshots/logs for a shape id"
   @spec cleanup!(shape_id(), storage()) :: :ok

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -60,4 +60,16 @@ defmodule Electric.Shapes do
     shape_cache.clean_shape(server, shape_id)
     :ok
   end
+
+  @spec clean_shapes([Storage.shape_id()], keyword()) :: :ok
+  def clean_shapes(shape_ids, opts \\ []) do
+    {shape_cache, opts} = Access.get(opts, :shape_cache, {ShapeCache, []})
+    server = Access.get(opts, :server, shape_cache)
+
+    for shape_id <- shape_ids do
+      shape_cache.clean_shape(server, shape_id)
+    end
+
+    :ok
+  end
 end

--- a/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
@@ -63,18 +63,6 @@ defmodule Electric.Postgres.ReplicationClient.CollectorTest do
     assert %Collector{relations: %{1 => @relation, 2 => ^new_relation}} = updated_collector
   end
 
-  # TODO: move this test to the shape log collector tests
-  # test "collector logs a warning when receiving a new relation message that doesn't match the previous one",
-  #     %{collector: collector} do
-  #  new_relation = %{
-  #    @relation
-  #    | columns: [%LR.Relation.Column{name: "id", flags: [:key], type_oid: 20, type_modifier: -1}]
-  #  }
-  #
-  #  log = capture_log(fn -> Collector.handle_message(new_relation, collector) end)
-  #  assert log =~ "Schema for the table public.users had changed"
-  # end
-
   test "collector logs information when receiving a generic message",
        %{collector: collector} do
     message = %LR.Message{prefix: "test", content: "hello world"}

--- a/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
@@ -31,7 +31,7 @@ defmodule Electric.Postgres.ReplicationClient.CollectorTest do
 
   setup do
     collector = %Collector{}
-    collector = Collector.handle_message(@relation, collector)
+    {_relation, collector} = Collector.handle_message(@relation, collector)
     {:ok, collector: collector}
   end
 
@@ -58,21 +58,22 @@ defmodule Electric.Postgres.ReplicationClient.CollectorTest do
       columns: [%LR.Relation.Column{name: "id", flags: [:key], type_oid: 23, type_modifier: -1}]
     }
 
-    updated_collector = Collector.handle_message(new_relation, collector)
+    {_rel, updated_collector} = Collector.handle_message(new_relation, collector)
 
     assert %Collector{relations: %{1 => @relation, 2 => ^new_relation}} = updated_collector
   end
 
-  test "collector logs a warning when receiving a new relation message that doesn't match the previous one",
-       %{collector: collector} do
-    new_relation = %{
-      @relation
-      | columns: [%LR.Relation.Column{name: "id", flags: [:key], type_oid: 20, type_modifier: -1}]
-    }
-
-    log = capture_log(fn -> Collector.handle_message(new_relation, collector) end)
-    assert log =~ "Schema for the table public.users had changed"
-  end
+  # TODO: move this test to the shape log collector tests
+  # test "collector logs a warning when receiving a new relation message that doesn't match the previous one",
+  #     %{collector: collector} do
+  #  new_relation = %{
+  #    @relation
+  #    | columns: [%LR.Relation.Column{name: "id", flags: [:key], type_oid: 20, type_modifier: -1}]
+  #  }
+  #
+  #  log = capture_log(fn -> Collector.handle_message(new_relation, collector) end)
+  #  assert log =~ "Schema for the table public.users had changed"
+  # end
 
   test "collector logs information when receiving a generic message",
        %{collector: collector} do

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -29,7 +29,8 @@ defmodule Electric.Postgres.ReplicationClientTest do
         publication_name: @publication_name,
         try_creating_publication?: true,
         slot_name: @slot_name,
-        transaction_received: nil
+        transaction_received: nil,
+        relation_received: nil
       ]
 
       assert {:ok, _} = ReplicationClient.start_link(config, replication_opts)
@@ -278,6 +279,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
     state =
       ReplicationClient.State.new(
         transaction_received: nil,
+        relation_received: nil,
         publication_name: "",
         try_creating_publication?: false,
         slot_name: ""
@@ -312,7 +314,8 @@ defmodule Electric.Postgres.ReplicationClientTest do
         publication_name: @publication_name,
         try_creating_publication?: false,
         slot_name: @slot_name,
-        transaction_received: {__MODULE__, :test_transaction_received, [self()]}
+        transaction_received: {__MODULE__, :test_transaction_received, [self()]},
+        relation_received: {__MODULE__, :test_relation_received, [self()]}
       ]
     }
   end
@@ -345,6 +348,10 @@ defmodule Electric.Postgres.ReplicationClientTest do
 
   def test_transaction_received(transaction, test_pid) do
     send(test_pid, {:from_replication, transaction})
+    :ok
+  end
+
+  def test_relation_received(_change, _test_pid) do
     :ok
   end
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -345,6 +345,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
       MockShapeCache
       |> expect(:get_relation, 1, fn ^relation_id, _ -> rel end)
+      |> expect(:clean_shape, 0, fn _, _ -> :ok end)
       |> allow(self(), server)
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, server)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -95,8 +95,7 @@ defmodule Support.ComponentSetup do
       transaction_received:
         {Electric.Replication.ShapeLogCollector, :store_transaction, [ctx.shape_log_collector]},
       relation_received:
-        {Electric.Replication.ShapeLogCollector, :handle_relation_change,
-         [ctx.shape_log_collector]}
+        {Electric.Replication.ShapeLogCollector, :handle_relation_msg, [ctx.shape_log_collector]}
     ]
 
     {:ok, pid} = ReplicationClient.start_link(ctx.db_config, replication_opts)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -93,7 +93,10 @@ defmodule Support.ComponentSetup do
       try_creating_publication?: true,
       slot_name: ctx.slot_name,
       transaction_received:
-        {Electric.Replication.ShapeLogCollector, :store_transaction, [ctx.shape_log_collector]}
+        {Electric.Replication.ShapeLogCollector, :store_transaction, [ctx.shape_log_collector]},
+      relation_received:
+        {Electric.Replication.ShapeLogCollector, :handle_relation_change,
+         [ctx.shape_log_collector]}
     ]
 
     {:ok, pid} = ReplicationClient.start_link(ctx.db_config, replication_opts)


### PR DESCRIPTION
This PR addresses https://github.com/electric-sql/electric/issues/1535 by detecting relation changes and cleaning up the shapes affected by the relation change. Note that Postgres' logical replication stream propagates relation changes lazily. So we won't detect the migration until somebody actually inserts/updates/deletes a row from a migrated table.

This PR is affected by a bug that causes schema information not to be deleted when a shape is cleaned. Because of that, when testing this PR you will notice that if we add a column the shape is cleaned but then if we fetch the shape again the new column is not present in the resulting rows. This should be fixed when the schema information bug is fixed.