### PR TITLE
fix: don't check for exact log offset existence

### DIFF
--- a/.changeset/wicked-bottles-attack.md
+++ b/.changeset/wicked-bottles-attack.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Don't search for exact log entry with provided offset. Fixes a bug that caused an infinite loop of initial syncs followed by 409s.

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -179,14 +179,14 @@ defmodule Electric.Plug.ServeShapePlug do
     conn
   end
 
-  # If the offset requested is not found, returns 409 along with a location redirect for clients to
+  # If the requested shape_id is not found, returns 409 along with a location redirect for clients to
   # re-request the shape from scratch with the new shape id which acts as a consistent cache buster
   # e.g. GET /v1/shape/{root_table}?shape_id={new_shape_id}&offset=-1
-  def validate_shape_offset(%Conn{assigns: %{offset: offset}} = conn, _) do
+  def validate_shape_offset(%Conn{} = conn, _) do
     shape_id = conn.assigns.shape_id
     active_shape_id = conn.assigns.active_shape_id
 
-    if !Shapes.has_log_entry?(conn.assigns.config, shape_id, offset) do
+    if !Shapes.has_shape?(conn.assigns.config, shape_id) do
       # TODO: discuss returning a 307 redirect rather than a 409, the client
       # will have to detect this and throw out old data
       conn

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -132,10 +132,9 @@ defmodule Electric.ShapeCache.CubDbStorage do
     |> Stream.map(fn {_, item} -> item end)
   end
 
-  def has_log_entry?(shape_id, offset, opts) do
-    # FIXME: this is naive while we don't have snapshot metadata to get real offsets
-    CubDB.has_key?(opts.db, log_key(shape_id, offset)) or
-      (snapshot_started?(shape_id, opts) and offset == @snapshot_offset)
+  def has_shape?(shape_id, opts) do
+    entry_stream = keys_from_range(log_start(shape_id), log_end(shape_id), opts)
+    !Enum.empty?(entry_stream) or snapshot_started?(shape_id, opts)
   end
 
   def mark_snapshot_as_started(shape_id, opts) do

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -89,13 +89,12 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     end)
   end
 
-  def has_log_entry?(shape_id, offset, opts) do
+  def has_shape?(shape_id, opts) do
     case :ets.select(opts.log_ets_table, [
-           {{{shape_id, storage_offset(offset)}, :_}, [], [true]}
+           {{{shape_id, :_}, :_}, [], [true]}
          ]) do
       [true] -> true
-      # FIXME: this is naive while we don't have snapshot metadata to get real offset
-      [] -> snapshot_started?(shape_id, opts) and offset == @snapshot_offset
+      [] -> snapshot_started?(shape_id, opts)
     end
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -67,8 +67,8 @@ defmodule Electric.ShapeCache.Storage do
   @doc "Get stream of the log for a shape since a given offset"
   @callback get_log_stream(shape_id(), LogOffset.t(), LogOffset.t(), compiled_opts()) ::
               Enumerable.t()
-  @doc "Check if log entry for given shape ID and offset exists"
-  @callback has_log_entry?(shape_id(), LogOffset.t(), compiled_opts()) :: boolean()
+  @doc "Check if log entries for given shape ID exist"
+  @callback has_shape?(shape_id(), compiled_opts()) :: boolean()
   @doc "Store a relation containing information about the schema of a table"
   @callback store_relation(Relation.t(), compiled_opts()) :: :ok
   @doc "Get all stored relations"
@@ -138,10 +138,10 @@ defmodule Electric.ShapeCache.Storage do
       when max_offset == :infinity or not is_log_offset_lt(max_offset, offset),
       do: mod.get_log_stream(shape_id, offset, max_offset, opts)
 
-  @doc "Check if log entry for given shape ID and offset exists"
-  @spec has_log_entry?(shape_id(), LogOffset.t(), storage()) :: boolean()
-  def has_log_entry?(shape_id, offset, {mod, opts}),
-    do: mod.has_log_entry?(shape_id, offset, opts)
+  @doc "Check if log entries for given shape ID exist"
+  @spec has_shape?(shape_id(), storage()) :: boolean()
+  def has_shape?(shape_id, {mod, opts}),
+    do: mod.has_shape?(shape_id, opts)
 
   @doc "Store a relation containing information about the schema of a table"
   @spec store_relation(Relation.t(), storage()) :: :ok

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -41,13 +41,12 @@ defmodule Electric.Shapes do
   end
 
   @doc """
-  Check whether the log has an entry for a given shape ID and offset
+  Check whether the log has an entry for a given shape ID
   """
-  @spec has_log_entry?(keyword(), Storage.shape_id(), LogOffset.t()) ::
-          boolean()
-  def has_log_entry?(config, shape_id, offset) do
+  @spec has_shape?(keyword(), Storage.shape_id()) :: boolean()
+  def has_shape?(config, shape_id) do
     storage = Access.fetch!(config, :storage)
-    Storage.has_log_entry?(shape_id, offset, storage)
+    Storage.has_shape?(shape_id, storage)
   end
 
   @doc """

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -362,5 +362,46 @@ defmodule Electric.Plug.RouterTest do
       assert key3 != key2
       assert key3 != key
     end
+
+    test "GET works when there are changes not related to the shape in the same txn", %{
+      opts: opts,
+      db_conn: db_conn
+    } do
+      params = %{offset: "-1", where: "value ILIKE 'yes%'"}
+
+      conn =
+        conn("GET", "/v1/shape/items", params)
+        |> Router.call(opts)
+
+      assert %{status: 200} = conn
+      [shape_id] = Plug.Conn.get_resp_header(conn, "x-electric-shape-id")
+
+      assert [_] = Jason.decode!(conn.resp_body)
+
+      params = Map.merge(params, %{offset: "0_0", shape_id: shape_id, live: true})
+
+      task =
+        Task.async(fn -> conn("GET", "/v1/shape/items", params) |> Router.call(opts) end)
+
+      Postgrex.query!(
+        db_conn,
+        "INSERT INTO items (id, value) VALUES (gen_random_uuid(), $1), (gen_random_uuid(), $2)",
+        ["yes!", "no :("]
+      )
+
+      assert %{status: 200} = conn = Task.await(task)
+
+      assert [%{"value" => %{"value" => "yes!"}}, _] = Jason.decode!(conn.resp_body)
+      assert [new_offset] = Plug.Conn.get_resp_header(conn, "x-electric-chunk-last-offset")
+
+      params = params |> Map.put(:offset, new_offset) |> Map.delete(:live)
+
+      assert %{status: 200} =
+               conn =
+               conn("GET", "/v1/shape/items", params)
+               |> Router.call(opts)
+
+      assert [_] = Jason.decode!(conn.resp_body)
+    end
   end
 end

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -480,14 +480,14 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
       end
     end
 
-    describe "#{module_name}.has_log_entry?/3" do
+    describe "#{module_name}.has_shape?/2" do
       setup do
         {:ok, %{module: unquote(module)}}
       end
 
       setup :start_storage
 
-      test "returns a boolean indicating whether there is a log entry with such an offset", %{
+      test "returns a boolean indicating whether the shape ID is known", %{
         module: storage,
         opts: opts
       } do
@@ -505,22 +505,8 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
         :ok = storage.append_to_log!(@shape_id, log_items, opts)
 
-        assert storage.has_log_entry?(@shape_id, LogOffset.new(lsn, 0), opts)
-        refute storage.has_log_entry?(@shape_id, LogOffset.new(lsn, 1), opts)
-        refute storage.has_log_entry?(@shape_id, LogOffset.new(1001, 0), opts)
-      end
-
-      test "should detect whether there is a snapshot with given offset", %{
-        module: storage,
-        opts: opts
-      } do
-        refute storage.has_log_entry?(@shape_id, @snapshot_offset, opts)
-        storage.mark_snapshot_as_started(@shape_id, opts)
-        assert storage.has_log_entry?(@shape_id, @snapshot_offset, opts)
-      end
-
-      test "should return false when there is no log", %{module: storage, opts: opts} do
-        refute storage.has_log_entry?("another_shape_id", LogOffset.new(1001, 0), opts)
+        assert storage.has_shape?(@shape_id, opts)
+        refute storage.has_shape?("another_shape_id", opts)
       end
     end
   end

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -18,7 +18,7 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.expect(:get_snapshot, fn _, :opts -> {1, []} end)
     |> Mox.expect(:append_to_log!, fn _, _, :opts -> :ok end)
     |> Mox.expect(:get_log_stream, fn _, _, _, :opts -> [] end)
-    |> Mox.expect(:has_log_entry?, fn _, _, :opts -> [] end)
+    |> Mox.expect(:has_shape?, fn _, :opts -> [] end)
     |> Mox.expect(:cleanup!, fn _, :opts -> :ok end)
 
     Storage.make_new_snapshot!(shape_id, %{}, %{}, [], storage)
@@ -26,7 +26,7 @@ defmodule Electric.ShapeCache.StorageTest do
     Storage.get_snapshot(shape_id, storage)
     Storage.append_to_log!(shape_id, [], storage)
     Storage.get_log_stream(shape_id, LogOffset.first(), storage)
-    Storage.has_log_entry?(shape_id, 1, storage)
+    Storage.has_shape?(shape_id, storage)
     Storage.cleanup!(shape_id, storage)
   end
 


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1552.
This PR addresses a bug that caused an infinite loop of failing requests.
The root cause for the bug is that we were always using the offset of the last change in a transaction but a shape may not be affected by all changes in the transaction (in which case the real latest offset would be the offset of the latest relevant change for that shape in the transaction). Because of that, when the shape plug checks if we have a log entry for the given offset, it may not exist and return a 409.

As a result of not finding an entry for the exact offset, Electric responds with a 409. The client thus comes back with an initial sync request (offset -1) and then Electric sends the latest offset it knows about which is again the commit offset. And thus we do a request with that offset and get again a 409. Then we do again an initial sync request and we are in this loop forever.

We should note that although the commit offset of the transaction may be bigger than the offset of the real latest change, it is still valid to use the commit offset because Postgres linearizes concurrent transactions. So we can be sure that the next relevant changes will happen in a subsequent transaction which will have offsets that are bigger than this offset (because the next transaction's commit LSN will be bigger than this transaction's commit LSN which is used as the transaction ID which is part of the offset of the changes in the transaction (offset = `{ <tx_id>, <op_index> }`).

We solve the problem by no longer looking for an entry for the exact log offset. We now only check that the `shape_id` exists. If the `shape_id` exists then we know that we have the full log for that shape (because we don't do any compaction at the moment). And thus we are able to resume from any point in the shape (doesn't need to be an exact point as we do range queries).