### PR TITLE
fix: Remove invalid assumption about cross-transaction LSN monotonicity

### DIFF
--- a/.changeset/sour-oranges-clap.md
+++ b/.changeset/sour-oranges-clap.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix a bug in ReplicationClient caused by an invalid assumption about cross-transaction operation LSN ordering.

--- a/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
@@ -177,8 +177,8 @@ defmodule Electric.Postgres.ReplicationClient.Collector do
     #
     # [1]: https://github.com/postgres/postgres/blob/c671e142bf4b568434eb8559baff34d32eed5b29/src/include/replication/reorderbuffer.h#L276-L296
     #
-    # For our purposes, we're setting transaction's LSN to `end_lsn` which seems like a more
-    # stable value based on the above comments.
+    # For our purposes, we're setting transaction's LSN to `end_lsn` so that each successive
+    # incoming transaction's LSN is part of a strictly monotonically increasing number series.
     {%Transaction{
        txn
        | lsn: end_lsn,

--- a/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
@@ -144,45 +144,11 @@ defmodule Electric.Postgres.ReplicationClient.Collector do
     |> Enum.reduce(state, &prepend_change/2)
   end
 
-  def handle_message(
-        %LR.Commit{lsn: commit_lsn, end_lsn: end_lsn},
-        %__MODULE__{transaction: txn} = state
-      )
+  def handle_message(%LR.Commit{lsn: commit_lsn}, %__MODULE__{transaction: txn} = state)
       when not is_nil(txn) and commit_lsn == txn.lsn do
-    # Here, `commit_lsn` is the same value as `final_lsn` on the Begin message that preceded
-    # this Commit.  To better understand the difference between `commit_lsn` and `end_lsn`,
-    # let's consult Postgres' source code[1]:
-    #
-    #     /* ----
-    #      * LSN of the record that lead to this xact to be prepared or committed or
-    #      * aborted. This can be a
-    #      * * plain commit record
-    #      * * plain commit record, of a parent transaction
-    #      * * prepared transaction
-    #      * * prepared transaction commit
-    #      * * plain abort record
-    #      * * prepared transaction abort
-    #      *
-    #      * This can also become set to earlier values than transaction end when
-    #      * a transaction is spilled to disk; specifically it's set to the LSN of
-    #      * the latest change written to disk so far.
-    #      * ----
-    #      */
-    #     XLogRecPtr  final_lsn;
-    #
-    #     /*
-    #      * LSN pointing to the end of the commit record + 1.
-    #      */
-    #     XLogRecPtr  end_lsn;
-    #
-    # [1]: https://github.com/postgres/postgres/blob/c671e142bf4b568434eb8559baff34d32eed5b29/src/include/replication/reorderbuffer.h#L276-L296
-    #
-    # For our purposes, we're setting transaction's LSN to `end_lsn` so that each successive
-    # incoming transaction's LSN is part of a strictly monotonically increasing number series.
     {%Transaction{
        txn
-       | lsn: end_lsn,
-         changes: Enum.reverse(txn.changes),
+       | changes: Enum.reverse(txn.changes),
          last_log_offset: LogOffset.new(txn.lsn, max(0, state.tx_op_index - 2))
      }, %__MODULE__{state | transaction: nil, tx_op_index: nil}}
   end

--- a/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
@@ -227,7 +227,7 @@ defmodule Electric.Postgres.ReplicationClient.CollectorTest do
 
     {completed_txn, updated_collector} = Collector.handle_message(commit_msg, collector)
 
-    assert %Transaction{xid: 456, lsn: @test_end_lsn, last_log_offset: @test_log_offset} =
+    assert %Transaction{xid: 456, lsn: @test_lsn, last_log_offset: @test_log_offset} =
              completed_txn
 
     assert %Collector{transaction: nil, tx_op_index: nil} = updated_collector

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -154,7 +154,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
       num_txn = 2
       num_ops = 8
       max_sleep = 20
-      receive_timeout = (num_txn + num_ops) * max_sleep
+      receive_timeout = (num_txn + num_ops) * max_sleep * 2
 
       # Insert `num_txn` transactions, each in a separate process. Every transaction has
       # `num_ops` INSERTs with a random delay between each operation.


### PR DESCRIPTION
`ReplicationClient` was trying to be strict about LSN ordering of operations it was receiving from Postgres. But since LSNs of operations belonging to different concurrent transactions may be interleaved in the WAL, we should only make assumptions about ordering between complete transactions.

This change fixes #1548.