### PR TITLE
fix: Remove incorrect uses of :infinity where LogOffset.t is expected

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -140,13 +140,10 @@ defmodule Electric.ShapeCache.CubDbStorage do
   end
 
   def get_log_stream(shape_id, offset, max_offset, opts) do
-    max_key =
-      if max_offset == :infinity, do: log_end(shape_id), else: log_key(shape_id, max_offset)
-
     opts.db
     |> CubDB.select(
       min_key: log_key(shape_id, offset),
-      max_key: max_key,
+      max_key: log_key(shape_id, max_offset),
       min_key_inclusive: false
     )
     |> Stream.map(fn {_, item} -> item end)

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -1,4 +1,6 @@
 defmodule Electric.ShapeCache.Storage do
+  import Electric.Replication.LogOffset, only: [is_log_offset_lt: 2]
+
   alias Electric.Shapes.Querying
   alias Electric.Shapes.Shape
   alias Electric.Replication.LogOffset
@@ -153,7 +155,6 @@ defmodule Electric.ShapeCache.Storage do
     mod.append_to_log!(shape_id, log_items, shape_opts)
   end
 
-  import LogOffset, only: :macros
   @doc "Get stream of the log for a shape since a given offset"
   @spec get_log_stream(shape_id(), LogOffset.t(), LogOffset.t(), storage()) :: log()
   def get_log_stream(shape_id, offset, max_offset \\ @last_log_offset, {mod, opts})

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -86,6 +86,8 @@ defmodule Electric.ShapeCache.Storage do
     apply(mod, :start_link, [opts])
   end
 
+  @last_log_offset LogOffset.last()
+
   @spec initialise(storage()) :: :ok
   def initialise({mod, opts}),
     do: apply(mod, :initialise, [opts])
@@ -154,8 +156,8 @@ defmodule Electric.ShapeCache.Storage do
   import LogOffset, only: :macros
   @doc "Get stream of the log for a shape since a given offset"
   @spec get_log_stream(shape_id(), LogOffset.t(), LogOffset.t(), storage()) :: log()
-  def get_log_stream(shape_id, offset, max_offset \\ LogOffset.last(), {mod, opts})
-      when max_offset == :infinity or not is_log_offset_lt(max_offset, offset) do
+  def get_log_stream(shape_id, offset, max_offset \\ @last_log_offset, {mod, opts})
+      when max_offset == @last_log_offset or not is_log_offset_lt(max_offset, offset) do
     shape_opts = mod.for_shape(shape_id, opts)
 
     mod.get_log_stream(shape_id, offset, max_offset, shape_opts)


### PR DESCRIPTION
These should have been updated in c3a7beb but were overlooked.

The previous guard `max_offset == :infinity` would always evaluate to `false` and the `not is_log_offset_lt(...)` guard would always be used. The fixed version, i.e. `max_offset == @last_log_offset`, adds a micro-optimisation that can sometimes skip the comparison. No new test here because I haven't come up with a way to challenge the invariant that is asserted by this function's guards.