### PR TITLE
fix: refactor out JSON serialization

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -388,12 +388,12 @@ defmodule Electric.ShapeCache do
         # formatting between snapshot and live log entries.
         Enum.each(Electric.Postgres.display_settings(), &Postgrex.query!(conn, &1, []))
 
-        {query, stream} = Querying.stream_initial_data(conn, shape)
+        stream = Querying.stream_initial_data(conn, shape)
         GenServer.cast(parent, {:snapshot_started, shape_id})
 
         # could pass the shape and then make_new_snapshot! can pass it to row_to_snapshot_item
         # that way it has the relation, but it is still missing the pk_cols
-        Storage.make_new_snapshot!(shape_id, shape, query, stream, storage)
+        Storage.make_new_snapshot!(shape_id, stream, storage)
       end)
     end)
   end

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -1,6 +1,6 @@
 defmodule Electric.ShapeCache.InMemoryStorage do
+  alias Electric.Shapes.Querying
   alias Electric.ConcurrentStream
-  alias Electric.LogItems
   alias Electric.Replication.LogOffset
   alias Electric.Replication.Changes.Relation
   alias Electric.Telemetry.OpenTelemetry
@@ -101,25 +101,21 @@ defmodule Electric.ShapeCache.InMemoryStorage do
 
   def mark_snapshot_as_started(shape_id, opts) do
     :ets.insert(opts.snapshot_ets_table, {snapshot_start(shape_id), 0})
+    :ok
   end
 
   @spec make_new_snapshot!(
           String.t(),
-          Electric.Shapes.Shape.t(),
-          Postgrex.Query.t(),
-          Enumerable.t(),
+          Querying.json_result_stream(),
           map()
         ) :: :ok
-  def make_new_snapshot!(shape_id, shape, query_info, data_stream, opts) do
+  def make_new_snapshot!(shape_id, data_stream, opts) do
     OpenTelemetry.with_span("storage.make_new_snapshot", [storage_impl: "in_memory"], fn ->
       ets_table = opts.snapshot_ets_table
 
       data_stream
-      |> LogItems.from_snapshot_row_stream(@snapshot_offset, shape, query_info)
       |> Stream.with_index(1)
-      |> Stream.map(fn {log_item, index} ->
-        {snapshot_key(shape_id, index), Jason.encode!(log_item)}
-      end)
+      |> Stream.map(fn {log_item, index} -> {snapshot_key(shape_id, index), log_item} end)
       |> Stream.chunk_every(500)
       |> Stream.each(fn chunk -> :ets.insert(ets_table, chunk) end)
       |> Stream.run()

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -1,4 +1,5 @@
 defmodule Electric.ShapeCache.Storage do
+  alias Electric.Shapes.Querying
   alias Electric.LogItems
   alias Electric.Shapes.Shape
   alias Electric.Replication.LogOffset
@@ -49,12 +50,9 @@ defmodule Electric.ShapeCache.Storage do
 
   Should raise an error if making the snapshot had failed for any reason.
   """
-  @doc unstable: "The meta information about the single table is subject to change"
   @callback make_new_snapshot!(
               shape_id(),
-              Electric.Shapes.Shape.t(),
-              Postgrex.Query.t(),
-              Enumerable.t(row()),
+              Querying.json_result_stream(),
               compiled_opts()
             ) :: :ok
   @callback mark_snapshot_as_started(shape_id, compiled_opts()) :: :ok
@@ -108,16 +106,9 @@ defmodule Electric.ShapeCache.Storage do
   @doc """
   Make a new snapshot for a shape ID based on the meta information about the table and a stream of plain string rows
   """
-  @doc unstable: "The meta information about the single table is subject to change"
-  @spec make_new_snapshot!(
-          shape_id(),
-          Electric.Shapes.Shape.t(),
-          Postgrex.Query.t(),
-          Enumerable.t(row()),
-          storage()
-        ) :: :ok
-  def make_new_snapshot!(shape_id, shape, meta, stream, {mod, opts}),
-    do: mod.make_new_snapshot!(shape_id, shape, meta, stream, opts)
+  @spec make_new_snapshot!(shape_id(), Querying.json_result_stream(), storage()) :: :ok
+  def make_new_snapshot!(shape_id, stream, {mod, opts}),
+    do: mod.make_new_snapshot!(shape_id, stream, opts)
 
   @spec mark_snapshot_as_started(shape_id, compiled_opts()) :: :ok
   def mark_snapshot_as_started(shape_id, {mod, opts}),

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -1,12 +1,20 @@
 defmodule Electric.Shapes.Querying do
+  alias Electric.Replication.LogOffset
+  alias Electric.LogItems
   alias Electric.Utils
   alias Electric.Shapes.Shape
   alias Electric.Telemetry.OpenTelemetry
 
   @type row :: [term()]
 
-  @spec stream_initial_data(DBConnection.t(), Shape.t()) ::
-          {Postgrex.Query.t(), Enumerable.t(row())}
+  @typedoc """
+  Postgres row, serialized to JSON log format, in `iodata` form for ease of writing to files.
+  """
+  @type json_iodata :: iodata()
+
+  @type json_result_stream :: Enumerable.t(json_iodata())
+
+  @spec stream_initial_data(DBConnection.t(), Shape.t()) :: json_result_stream()
   def stream_initial_data(conn, %Shape{root_table: root_table, table_info: table_info} = shape) do
     OpenTelemetry.with_span("querying.stream_initial_data", [], fn ->
       table = Utils.relation_to_sql(root_table)
@@ -21,11 +29,10 @@ defmodule Electric.Shapes.Querying do
           ~s|SELECT #{columns(table_info, root_table)} FROM #{table} #{where}|
         )
 
-      stream =
-        Postgrex.stream(conn, query, [])
-        |> Stream.flat_map(& &1.rows)
-
-      {query, stream}
+      Postgrex.stream(conn, query, [])
+      |> Stream.flat_map(& &1.rows)
+      |> LogItems.from_snapshot_row_stream(LogOffset.first(), shape, query)
+      |> Stream.map(&Jason.encode_to_iodata!/1)
     end)
   end
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -437,8 +437,6 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     end
   end
 
-  @basic_query_meta %Postgrex.Query{columns: ["id"], result_types: [:text], name: "key_prefix"}
-
   describe "store_transaction/2 with real storage" do
     setup [
       {Support.ComponentSetup, :with_registry},
@@ -449,9 +447,9 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       %{shape_cache: shape_cache, shape_cache_opts: shape_cache_opts} =
         Support.ComponentSetup.with_shape_cache(Map.put(ctx, :pool, nil),
           prepare_tables_fn: fn _, _ -> :ok end,
-          create_snapshot_fn: fn parent, shape_id, shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
-            Storage.make_new_snapshot!(shape_id, shape, @basic_query_meta, [["test"]], storage)
+            Storage.make_new_snapshot!(shape_id, [["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_id})
           end
         )

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -13,7 +13,7 @@ defmodule Electric.ShapeCache.StorageTest do
     shape_id = "test"
 
     MockStorage
-    |> Mox.expect(:make_new_snapshot!, fn _, _, _, _, :opts -> :ok end)
+    |> Mox.expect(:make_new_snapshot!, fn _, _, :opts -> :ok end)
     |> Mox.expect(:snapshot_started?, fn _, :opts -> true end)
     |> Mox.expect(:get_snapshot, fn _, :opts -> {1, []} end)
     |> Mox.expect(:append_to_log!, fn _, _, :opts -> :ok end)
@@ -21,7 +21,7 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.expect(:has_log_entry?, fn _, _, :opts -> [] end)
     |> Mox.expect(:cleanup!, fn _, :opts -> :ok end)
 
-    Storage.make_new_snapshot!(shape_id, %{}, %{}, [], storage)
+    Storage.make_new_snapshot!(shape_id, [], storage)
     Storage.snapshot_started?(shape_id, storage)
     Storage.get_snapshot(shape_id, storage)
     Storage.append_to_log!(shape_id, [], storage)

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -20,10 +20,38 @@ defmodule Electric.Shapes.QueryingTest do
     Postgrex.query!(conn, "INSERT INTO items (value) VALUES (1), (2), (3), (4), (5)", [])
     shape = Shape.new!("items", inspector: {DirectInspector, conn})
 
-    assert {query_info, stream} = Querying.stream_initial_data(conn, shape)
-
-    assert %{columns: ["id", "value"]} = query_info
-    assert [[_, "1"], [_, "2"], [_, "3"], [_, "4"], [_, "5"]] = Enum.to_list(stream)
+    assert [
+             %{
+               key: ~S["public"."items"/"1"],
+               value: %{id: "1", value: "1"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             },
+             %{
+               key: ~S["public"."items"/"2"],
+               value: %{id: "2", value: "2"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             },
+             %{
+               key: ~S["public"."items"/"3"],
+               value: %{id: "3", value: "3"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             },
+             %{
+               key: ~S["public"."items"/"4"],
+               value: %{id: "4", value: "4"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             },
+             %{
+               key: ~S["public"."items"/"5"],
+               value: %{id: "5", value: "5"},
+               headers: %{operation: "insert", relation: ["public", "items"]},
+               offset: "0_0"
+             }
+           ] == decode_stream(Querying.stream_initial_data(conn, shape))
   end
 
   test "respects the where clauses", %{db_conn: conn} do
@@ -41,10 +69,10 @@ defmodule Electric.Shapes.QueryingTest do
     Postgrex.query!(conn, "INSERT INTO items (value) VALUES (1), (2), (3), (4), (5)", [])
     shape = Shape.new!("items", where: "value > 3", inspector: {DirectInspector, conn})
 
-    assert {query_info, stream} = Querying.stream_initial_data(conn, shape)
-
-    assert %{columns: ["id", "value"]} = query_info
-    assert [[_, "4"], [_, "5"]] = Enum.to_list(stream)
+    assert [
+             %{key: ~S["public"."items"/"4"], value: %{value: "4"}},
+             %{key: ~S["public"."items"/"5"], value: %{value: "5"}}
+           ] = decode_stream(Querying.stream_initial_data(conn, shape))
   end
 
   test "allows column names to have special characters", %{db_conn: conn} do
@@ -53,7 +81,7 @@ defmodule Electric.Shapes.QueryingTest do
       """
       CREATE TABLE items (
         id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        "col with "" in it" INTEGER
+        "col with ""' in it" INTEGER
       )
       """,
       []
@@ -61,15 +89,72 @@ defmodule Electric.Shapes.QueryingTest do
 
     Postgrex.query!(
       conn,
-      ~s|INSERT INTO items ("col with "" in it") VALUES (1), (2), (3), (4), (5)|,
+      ~s|INSERT INTO items ("col with ""' in it") VALUES (1)|,
       []
     )
 
     shape = Shape.new!("items", inspector: {DirectInspector, conn})
 
-    assert {query_info, stream} = Querying.stream_initial_data(conn, shape)
-
-    assert %{columns: ["id", ~s(col with " in it)]} = query_info
-    assert [[_, "1"], [_, "2"], [_, "3"], [_, "4"], [_, "5"]] = Enum.to_list(stream)
+    assert [
+             %{key: ~S["public"."items"/"1"], value: %{"col with \"' in it": "1"}}
+           ] = decode_stream(Querying.stream_initial_data(conn, shape))
   end
+
+  test "works with composite PKs", %{db_conn: conn} do
+    Postgrex.query!(
+      conn,
+      """
+      CREATE TABLE items (
+        id1 INTEGER,
+        id2 INTEGER,
+        "test" INTEGER,
+        PRIMARY KEY (id1, id2)
+      )
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      ~s|INSERT INTO items (id1, id2, "test") VALUES (1, 2, 1), (3,4, 2)|,
+      []
+    )
+
+    shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+    assert [
+             %{key: ~S["public"."items"/"1"/"2"], value: %{test: "1"}},
+             %{key: ~S["public"."items"/"3"/"4"], value: %{test: "2"}}
+           ] = decode_stream(Querying.stream_initial_data(conn, shape))
+  end
+
+  test "works with null values & values with special characters", %{db_conn: conn} do
+    Postgrex.query!(
+      conn,
+      """
+      CREATE TABLE items (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        value TEXT
+      )
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      ~s|INSERT INTO items (value) VALUES ('1'), (NULL), ('"test\\x0001\n"')|,
+      []
+    )
+
+    shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+    assert [
+             %{key: ~S["public"."items"/"1"], value: %{value: "1"}},
+             %{key: ~S["public"."items"/"2"], value: %{value: nil}},
+             %{key: ~S["public"."items"/"3"], value: %{value: ~s["test\\x0001\n"]}}
+           ] = decode_stream(Querying.stream_initial_data(conn, shape))
+  end
+
+  defp decode_stream(stream),
+    do: stream |> Enum.to_list() |> Enum.map(&Jason.decode!(&1, keys: :atoms))
 end


### PR DESCRIPTION
Closes #1536, pulls out the JSON-ification responsibility out of storage and into querying for easier iteration over that responsibility.