### PR TITLE
fix: clean cached column information on delete

### DIFF
--- a/.changeset/soft-gifts-watch.md
+++ b/.changeset/soft-gifts-watch.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Clean cached column info on relation changes.

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -28,7 +28,7 @@ defmodule Electric.Application do
 
       inspector =
         {Electric.Postgres.Inspector.EtsInspector,
-          server: Electric.Postgres.Inspector.EtsInspector}
+         server: Electric.Postgres.Inspector.EtsInspector}
 
       shape_cache =
         {Electric.ShapeCache,

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -26,17 +26,18 @@ defmodule Electric.Application do
       prepare_tables_fn =
         {Electric.Postgres.Configuration, :configure_tables_for_replication!, [publication_name]}
 
+      inspector =
+        {Electric.Postgres.Inspector.EtsInspector,
+          server: Electric.Postgres.Inspector.EtsInspector}
+
       shape_cache =
         {Electric.ShapeCache,
          storage: storage,
+         inspector: inspector,
          prepare_tables_fn: prepare_tables_fn,
          log_producer: Electric.Replication.ShapeLogCollector,
          persistent_kv: persistent_kv,
          registry: Registry.ShapeChanges}
-
-      inspector =
-        {Electric.Postgres.Inspector.EtsInspector,
-         server: Electric.Postgres.Inspector.EtsInspector}
 
       core_processes = [
         {Registry,

--- a/packages/sync-service/lib/electric/persistent_kv/mock.ex
+++ b/packages/sync-service/lib/electric/persistent_kv/mock.ex
@@ -1,0 +1,20 @@
+defmodule Electric.PersistentKV.Mock do
+  defstruct []
+
+  @type t() :: %__MODULE__{}
+
+  @spec new() :: t()
+  def new() do
+    %__MODULE__{}
+  end
+
+  defimpl Electric.PersistentKV do
+    def set(_memory, _key, _value) do
+      :ok
+    end
+
+    def get(_memory, _key) do
+      {:ok, 42}
+    end
+  end
+end

--- a/packages/sync-service/lib/electric/postgres/inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector.ex
@@ -26,6 +26,12 @@ defmodule Electric.Postgres.Inspector do
   def load_column_info(relation, {module, opts}), do: module.load_column_info(relation, opts)
 
   @doc """
+  Clean up column information about a given table using a provided inspector.
+  """
+  @spec clean_column_info(relation(), inspector()) :: true
+  def clean_column_info(relation, {module, opts}), do: module.clean_column_info(relation, opts)
+
+  @doc """
   Get columns that should be considered a PK for table. If the table
   has no PK, then we're considering all columns as identifying.
   """

--- a/packages/sync-service/lib/electric/postgres/inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector.ex
@@ -17,6 +17,8 @@ defmodule Electric.Postgres.Inspector do
   @callback load_column_info(relation(), opts :: term()) ::
               {:ok, [column_info()]} | :table_not_found
 
+  @callback clean_column_info(relation(), opts :: term()) :: true
+
   @type inspector :: {module(), opts :: term()}
 
   @doc """

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -36,4 +36,6 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
       {:ok, rows}
     end
   end
+
+  def clean_column_info(_, _), do: true
 end

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -29,6 +29,7 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     end
   end
 
+  @impl Electric.Postgres.Inspector
   def clean_column_info(table, opts_or_state) do
     ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
 

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -29,6 +29,12 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     end
   end
 
+  def clean_column_info(table, opts_or_state) do
+    ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
+
+    :ets.delete(ets_table, {table, :columns})
+  end
+
   ## Internal API
 
   @impl GenServer

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -17,6 +17,7 @@ defmodule Electric.ShapeCacheBehaviour do
               {shape_id(), current_snapshot_offset :: LogOffset.t()}
 
   @callback list_active_shapes(opts :: keyword()) :: [{shape_id(), shape_def(), xmin()}]
+  @callback get_relation(Messages.relation_id(), opts :: keyword()) :: Changes.Relation.t() | nil
   @callback await_snapshot_start(shape_id(), opts :: keyword()) :: :started | {:error, term()}
   @callback handle_truncate(shape_id(), keyword()) :: :ok
   @callback clean_shape(shape_id(), keyword()) :: :ok
@@ -56,6 +57,7 @@ defmodule Electric.ShapeCache do
             ],
             storage: [type: :mod_arg, required: true],
             inspector: [type: :mod_arg, required: true],
+            shape_status: [type: :atom, default: Electric.ShapeCache.ShapeStatus],
             registry: [type: {:or, [:atom, :pid]}, required: true],
             # NimbleOptions has no "implementation of protocol" type
             persistent_kv: [type: :any, required: true],
@@ -82,9 +84,10 @@ defmodule Electric.ShapeCache do
   @impl Electric.ShapeCacheBehaviour
   def get_or_create_shape_id(shape, opts \\ []) do
     table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
     # Get or create the shape ID and fire a snapshot if necessary
-    if shape_state = ShapeStatus.existing_shape(table, shape) do
+    if shape_state = shape_status.existing_shape(table, shape) do
       shape_state
     else
       server = Access.get(opts, :server, __MODULE__)
@@ -97,8 +100,9 @@ defmodule Electric.ShapeCache do
           :ok | {:error, term()}
   def update_shape_latest_offset(shape_id, latest_offset, opts) do
     meta_table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
-    if ShapeStatus.set_latest_offset(meta_table, shape_id, latest_offset) do
+    if shape_status.set_latest_offset(meta_table, shape_id, latest_offset) do
       :ok
     else
       Logger.warning("Tried to update latest offset for shape #{shape_id} which doesn't exist")
@@ -109,14 +113,17 @@ defmodule Electric.ShapeCache do
   @impl Electric.ShapeCacheBehaviour
   def list_active_shapes(opts \\ []) do
     table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
-    ShapeStatus.list_active_shapes(table)
+    shape_status.list_active_shapes(table)
   end
 
+  @impl Electric.ShapeCacheBehaviour
   @spec get_relation(Messages.relation_id(), opts :: keyword()) :: Changes.Relation.t() | nil
   def get_relation(relation_id, opts) do
     meta_table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
-    ShapeStatus.get_relation(meta_table, relation_id)
+    shape_status = Access.get(opts, :shape_status, ShapeStatus)
+    shape_status.get_relation(meta_table, relation_id)
   end
 
   @impl Electric.ShapeCacheBehaviour
@@ -137,8 +144,9 @@ defmodule Electric.ShapeCache do
   @spec await_snapshot_start(shape_id(), keyword()) :: :started | {:error, term()}
   def await_snapshot_start(shape_id, opts \\ []) when is_binary(shape_id) do
     table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
-    if ShapeStatus.snapshot_xmin?(table, shape_id) do
+    if shape_status.snapshot_xmin?(table, shape_id) do
       :started
     else
       server = Access.get(opts, :server, __MODULE__)
@@ -149,8 +157,9 @@ defmodule Electric.ShapeCache do
   @impl Electric.ShapeCacheBehaviour
   def has_shape?(shape_id, opts \\ []) do
     table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
-    if ShapeStatus.existing_shape(table, shape_id) do
+    if shape_status.existing_shape(table, shape_id) do
       true
     else
       server = Access.get(opts, :server, __MODULE__)
@@ -161,7 +170,7 @@ defmodule Electric.ShapeCache do
   @impl GenStage
   def init(opts) do
     {:ok, persistent_state} =
-      ShapeStatus.initialise(
+      opts.shape_status.initialise(
         persistent_kv: opts.persistent_kv,
         meta_table: opts.shape_meta_table
       )
@@ -169,7 +178,9 @@ defmodule Electric.ShapeCache do
     state = %{
       name: opts.name,
       storage: opts.storage,
+      inspector: opts.inspector,
       shape_meta_table: opts.shape_meta_table,
+      shape_status: opts.shape_status,
       awaiting_snapshot_start: %{},
       db_pool: opts.db_pool,
       persistent_state: persistent_state,
@@ -187,7 +198,7 @@ defmodule Electric.ShapeCache do
 
   @impl GenStage
   def handle_events(relations, _from, state) do
-    %{persistent_state: persistent_state} = state
+    %{persistent_state: persistent_state, shape_status: shape_status} = state
     # NOTE: [@magnetised] this manages cleaning up shapes after a relation
     # change. it's not doing it in a consistent way, as the shape consumers
     # could still be receiving txns after a relation message that requires them
@@ -210,10 +221,10 @@ defmodule Electric.ShapeCache do
     # replication stream, it knows that it can just continue.
 
     Enum.each(relations, fn relation ->
-      old_rel = ShapeStatus.get_relation(persistent_state, relation.id)
+      old_rel = shape_status.get_relation(persistent_state, relation.id)
 
       if is_nil(old_rel) || old_rel != relation do
-        :ok = ShapeStatus.store_relation(persistent_state, relation)
+        :ok = shape_status.store_relation(persistent_state, relation)
       end
 
       if !is_nil(old_rel) && old_rel != relation do
@@ -223,7 +234,7 @@ defmodule Electric.ShapeCache do
 
         # Fetch all shapes that are affected by the relation change and clean them up
         persistent_state
-        |> ShapeStatus.list_active_shapes()
+        |> shape_status.list_active_shapes()
         |> Enum.filter(&Shape.is_affected_by_relation_change?(&1, change))
         |> Enum.map(&elem(&1, 0))
         |> Enum.each(fn shape_id -> clean_up_shape(state, shape_id) end)
@@ -246,12 +257,12 @@ defmodule Electric.ShapeCache do
   end
 
   @impl GenStage
-  def handle_call({:create_or_wait_shape_id, shape}, _from, state) do
+  def handle_call({:create_or_wait_shape_id, shape}, _from, %{shape_status: shape_status} = state) do
     {{shape_id, latest_offset}, state} =
-      if shape_state = ShapeStatus.existing_shape(state.persistent_state, shape) do
+      if shape_state = shape_status.existing_shape(state.persistent_state, shape) do
         {shape_state, state}
       else
-        {:ok, shape_id} = ShapeStatus.add_shape(state.persistent_state, shape)
+        {:ok, shape_id} = shape_status.add_shape(state.persistent_state, shape)
 
         {:ok, _snapshot_xmin, latest_offset} = start_shape(shape_id, shape, state)
         {{shape_id, latest_offset}, state}
@@ -262,12 +273,12 @@ defmodule Electric.ShapeCache do
     {:reply, {shape_id, latest_offset}, [], state}
   end
 
-  def handle_call({:await_snapshot_start, shape_id}, from, state) do
+  def handle_call({:await_snapshot_start, shape_id}, from, %{shape_status: shape_status} = state) do
     cond do
       not is_known_shape_id?(state, shape_id) ->
         {:reply, {:error, :unknown}, [], state}
 
-      ShapeStatus.snapshot_xmin?(state.persistent_state, shape_id) ->
+      shape_status.snapshot_xmin?(state.persistent_state, shape_id) ->
         {:reply, :started, [], state}
 
       true ->
@@ -277,8 +288,8 @@ defmodule Electric.ShapeCache do
     end
   end
 
-  def handle_call({:wait_shape_id, shape_id}, _from, state) do
-    {:reply, !is_nil(ShapeStatus.existing_shape(state.persistent_state, shape_id)), [], state}
+  def handle_call({:wait_shape_id, shape_id}, _from, %{shape_status: shape_status} = state) do
+    {:reply, !is_nil(shape_status.existing_shape(state.persistent_state, shape_id)), [], state}
   end
 
   def handle_call({:truncate, shape_id}, _from, state) do
@@ -301,8 +312,8 @@ defmodule Electric.ShapeCache do
   end
 
   @impl GenStage
-  def handle_cast({:snapshot_xmin_known, shape_id, xmin}, state) do
-    unless ShapeStatus.set_snapshot_xmin(state.persistent_state, shape_id, xmin) do
+  def handle_cast({:snapshot_xmin_known, shape_id, xmin}, %{shape_status: shape_status} = state) do
+    unless shape_status.set_snapshot_xmin(state.persistent_state, shape_id, xmin) do
       Logger.warning(
         "Got snapshot information for a #{shape_id}, that shape id is no longer valid. Ignoring."
       )
@@ -337,11 +348,11 @@ defmodule Electric.ShapeCache do
   defp clean_up_shape(state, shape_id) do
     Electric.ShapeCache.ShapeSupervisor.stop_shape_consumer(shape_id)
 
-    ShapeStatus.remove_shape(state.persistent_state, shape_id)
+    state.shape_status.remove_shape(state.persistent_state, shape_id)
   end
 
   defp is_known_shape_id?(state, shape_id) do
-    if ShapeStatus.existing_shape(state.persistent_state, shape_id) do
+    if state.shape_status.existing_shape(state.persistent_state, shape_id) do
       true
     else
       false
@@ -356,7 +367,7 @@ defmodule Electric.ShapeCache do
 
   defp recover_shapes(state) do
     state.persistent_state
-    |> ShapeStatus.list_shapes()
+    |> state.shape_status.list_shapes()
     |> Enum.each(fn {shape_id, shape} ->
       {:ok, _snapshot_xmin, _latest_offset} = start_shape(shape_id, shape, state)
     end)
@@ -381,7 +392,7 @@ defmodule Electric.ShapeCache do
       {:ok, snapshot_xmin, latest_offset} = Shapes.Consumer.initial_state(consumer)
 
       :ok =
-        ShapeStatus.initialise_shape(
+        state.shape_status.initialise_shape(
           state.persistent_state,
           shape_id,
           snapshot_xmin,

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -1,9 +1,29 @@
+defmodule Electric.ShapeCache.ShapeStatusBehaviour do
+  @moduledoc """
+  Behaviour defining the ShapeStatus functions to be used in mocks
+  """
+  alias Electric.Shapes.Shape
+  alias Electric.ShapeCache.ShapeStatus
+  alias Electric.Postgres.LogicalReplication.Messages
+  alias Electric.Replication.Changes.Relation
+
+  @callback initialise(ShapeStatus.options()) :: {:ok, ShapeStatus.t()} | {:error, term()}
+  @callback list_shapes(ShapeStatus.t()) :: [{ShapeStatus.shape_id(), Shape.t()}]
+  @callback list_active_shapes(opts :: keyword()) :: [
+              {ShapeStatus.shape_id(), ShapeStatus.shape_def(), ShapeStatus.xmin()}
+            ]
+  @callback get_relation(ShapeStatus.t(), Messages.relation_id()) :: Relation.t() | nil
+  @callback store_relation(ShapeStatus.t(), Relation.t()) :: :ok
+  @callback remove_shape(ShapeStatus.t(), ShapeStatus.shape_id()) ::
+              {:ok, ShapeStatus.t()} | {:error, term()}
+end
+
 defmodule Electric.ShapeCache.ShapeStatus do
   @moduledoc """
   Keeps track of shape state.
 
   Serializes just enough to some persistent storage to bootstrap the
-  ShapeCache by writing the mapping of `shape_id => %Shape{}` to 
+  ShapeCache by writing the mapping of `shape_id => %Shape{}` to
   storage.
 
   The shape cache then loads this and starts processes (storage and consumer)

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -87,7 +87,7 @@ defmodule Electric.Shapes.Shape do
 
       {:ok, column_info} ->
         # %{["column_name"] => :type}
-        Logger.debug("Table #{inspect(table)} found with #{length(column_info)} columns")
+        Logger.debug("Table #{inspect(table)} found with #{length(column_info)} columnss")
 
         pk_cols = Inspector.get_pk_cols(column_info)
 

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -87,7 +87,7 @@ defmodule Electric.Shapes.Shape do
 
       {:ok, column_info} ->
         # %{["column_name"] => :type}
-        Logger.debug("Table #{inspect(table)} found with #{length(column_info)} columnss")
+        Logger.debug("Table #{inspect(table)} found with #{length(column_info)} columns")
 
         pk_cols = Inspector.get_pk_cols(column_info)
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -5,7 +5,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
   alias Electric.Postgres.Lsn
   alias Electric.Replication.ShapeLogCollector
-  alias Electric.Replication.Changes.Transaction
+  alias Electric.Replication.Changes.{Transaction, Relation}
   alias Electric.Replication.Changes
   alias Electric.Replication.LogOffset
 
@@ -79,6 +79,219 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       xids = Support.TransactionConsumer.assert_consume(ctx.consumers, [txn2])
 
       assert xids == [xid]
+    end
+
+    test "stores relation if it is not known", %{server: server} do
+      relation_id = "rel1"
+
+      rel = %Relation{
+        id: relation_id,
+        schema: "public",
+        table: "test_table",
+        columns: []
+      }
+
+      MockShapeCache
+      |> expect(:get_relation, 1, fn ^relation_id, _ -> nil end)
+      |> expect(:store_relation, 1, fn ^rel, _ -> :ok end)
+      |> allow(self(), server)
+
+      MockInspector
+      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> allow(self(), server)
+
+      assert :ok = ShapeLogCollector.handle_relation_msg(rel, server)
+    end
+
+    test "does not clean shapes if relation didn't change", %{server: server} do
+      relation_id = "rel1"
+
+      rel = %Relation{
+        id: relation_id,
+        schema: "public",
+        table: "test_table",
+        columns: []
+      }
+
+      MockShapeCache
+      |> expect(:get_relation, 1, fn ^relation_id, _ -> rel end)
+      |> expect(:clean_shape, 0, fn _, _ -> :ok end)
+      |> allow(self(), server)
+
+      MockInspector
+      |> expect(:clean_column_info, 0, fn _, _ -> true end)
+      |> allow(self(), server)
+
+      assert :ok = ShapeLogCollector.handle_relation_msg(rel, server)
+    end
+
+    test "cleans shapes affected by table renaming and logs a warning", %{server: server} do
+      relation_id = "rel1"
+
+      shape_id1 = "shape1"
+      shape1 = @shape
+
+      shape_id2 = "shape2"
+      shape2 = @similar_shape
+
+      shape_id3 = "shape3"
+      shape3 = @other_shape
+
+      # doesn't matter, isn't used for this test
+      xmin = 100
+
+      old_rel = %Relation{
+        id: relation_id,
+        schema: "public",
+        table: "test_table",
+        columns: []
+      }
+
+      new_rel = %Relation{
+        id: relation_id,
+        schema: "public",
+        table: "renamed_test_table",
+        columns: []
+      }
+
+      MockShapeCache
+      |> expect(:get_relation, 1, fn ^relation_id, _ -> old_rel end)
+      |> expect(:store_relation, 1, fn ^new_rel, _ -> :ok end)
+      |> expect(:list_active_shapes, 1, fn _ ->
+        [{shape_id1, shape1, xmin}, {shape_id2, shape2, xmin}, {shape_id3, shape3, xmin}]
+      end)
+      |> expect(:clean_shape, 1, fn _, ^shape_id1 -> :ok end)
+      |> expect(:clean_shape, 1, fn _, ^shape_id2 -> :ok end)
+      |> allow(self(), server)
+
+      MockInspector
+      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> allow(self(), server)
+
+      log = capture_log(fn -> ShapeLogCollector.handle_relation_msg(new_rel, server) end)
+      assert log =~ "Schema for the table public.test_table changed"
+    end
+
+    test "cleans shapes affected by a relation change", %{server: server} do
+      relation_id = "rel1"
+
+      shape_id1 = "shape1"
+      shape1 = @shape
+
+      shape_id2 = "shape2"
+      shape2 = @similar_shape
+
+      shape_id3 = "shape3"
+      shape3 = @other_shape
+
+      # doesn't matter, isn't used for this test
+      xmin = 100
+
+      old_rel = %Relation{
+        id: relation_id,
+        schema: "public",
+        table: "test_table",
+        columns: [{"id", "float4"}]
+      }
+
+      new_rel = %Relation{
+        id: relation_id,
+        schema: "public",
+        table: "test_table",
+        columns: [{"id", "int8"}]
+      }
+
+      MockShapeCache
+      |> expect(:get_relation, 1, fn ^relation_id, _ -> old_rel end)
+      |> expect(:store_relation, 1, fn ^new_rel, _ -> :ok end)
+      |> expect(:list_active_shapes, fn _ ->
+        [{shape_id1, shape1, xmin}, {shape_id2, shape2, xmin}, {shape_id3, shape3, xmin}]
+      end)
+      |> expect(:clean_shape, 1, fn _, ^shape_id1 -> :ok end)
+      |> expect(:clean_shape, 1, fn _, ^shape_id2 -> :ok end)
+      |> allow(self(), server)
+
+      MockInspector
+      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> allow(self(), server)
+
+      assert :ok = ShapeLogCollector.handle_relation_msg(new_rel, server)
+    end
+  end
+
+  @basic_query_meta %Postgrex.Query{columns: ["id"], result_types: [:text], name: "key_prefix"}
+
+  describe "store_transaction/2 with real storage" do
+    setup [
+      {Support.ComponentSetup, :with_registry},
+      {Support.ComponentSetup, :with_in_memory_storage}
+    ]
+
+    setup %{registry: registry} = ctx do
+      %{shape_cache: shape_cache, shape_cache_opts: shape_cache_opts} =
+        Support.ComponentSetup.with_shape_cache(Map.put(ctx, :pool, nil),
+          prepare_tables_fn: fn _, _ -> :ok end,
+          create_snapshot_fn: fn parent, shape_id, shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+            Storage.make_new_snapshot!(shape_id, shape, @basic_query_meta, [["test"]], storage)
+            GenServer.cast(parent, {:snapshot_started, shape_id})
+          end
+        )
+
+      {:ok, server} =
+        ShapeLogCollector.start_link(
+          name: :test_shape_log_storage,
+          registry: registry,
+          shape_cache: shape_cache,
+          inspector: {MockInspector, []}
+        )
+
+      MockInspector
+      |> stub(:load_column_info, fn {"public", "test_table"}, _ ->
+        {:ok, [%{pk_position: 0, name: "id"}]}
+      end)
+      |> allow(self(), server)
+
+      %{server: server, shape_cache_opts: shape_cache_opts}
+    end
+
+    test "duplicate transactions storage is idempotent", %{
+      server: server,
+      storage: storage,
+      shape_cache_opts: shape_cache_opts
+    } do
+      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, shape_cache_opts)
+
+      :started =
+        ShapeCache.await_snapshot_start(Keyword.fetch!(shape_cache_opts, :server), shape_id)
+
+      lsn = Lsn.from_integer(10)
+
+      txn =
+        %Transaction{xid: 11, lsn: lsn, last_log_offset: LogOffset.new(lsn, 2)}
+        |> Transaction.prepend_change(%Changes.NewRecord{
+          relation: {"public", "test_table"},
+          record: %{"id" => "2"},
+          log_offset: LogOffset.new(lsn, 2)
+        })
+        |> Transaction.prepend_change(%Changes.NewRecord{
+          relation: {"public", "test_table"},
+          record: %{"id" => "1"},
+          log_offset: LogOffset.new(lsn, 0)
+        })
+
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
+
+      assert [op1, op2] =
+               Storage.get_log_stream(shape_id, LogOffset.before_all(), storage)
+               |> Enum.map(&:json.decode/1)
+
+      # If we encounter & store the same transaction, log stream should be stable
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
+
+      assert [^op1, ^op2] =
+               Storage.get_log_stream(shape_id, LogOffset.before_all(), storage)
+               |> Enum.map(&:json.decode/1)
     end
   end
 end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -46,6 +46,11 @@ defmodule Electric.ShapeCacheTest do
 
   @prepare_tables_noop {__MODULE__, :prepare_tables_noop, []}
 
+  @stub_inspector StubInspector.new([
+                    %{name: "id", type: "int8", pk_position: 0},
+                    %{name: "value", type: "text"}
+                  ])
+
   describe "get_or_create_shape_id/2" do
     setup [
       :with_in_memory_storage,
@@ -56,7 +61,8 @@ defmodule Electric.ShapeCacheTest do
     ]
 
     setup ctx do
-      with_shape_cache(ctx,
+      with_shape_cache(
+        Map.put(ctx, :inspector, @stub_inspector),
         create_snapshot_fn: fn _, _, _, _, _ -> nil end,
         prepare_tables_fn: @prepare_tables_noop
       )
@@ -84,7 +90,7 @@ defmodule Electric.ShapeCacheTest do
 
     test "creates initial snapshot if one doesn't exist", %{storage: storage} = ctx do
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
@@ -104,7 +110,7 @@ defmodule Electric.ShapeCacheTest do
       test_pid = self()
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: fn nil, [{"public", "items"}] ->
             send(test_pid, {:called, :prepare_tables_fn})
           end,
@@ -132,7 +138,7 @@ defmodule Electric.ShapeCacheTest do
       test_pid = self()
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             send(test_pid, {:called, :create_snapshot_fn})
@@ -179,7 +185,9 @@ defmodule Electric.ShapeCacheTest do
       shape_id = "foo"
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil), prepare_tables_fn: @prepare_tables_noop)
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+          prepare_tables_fn: @prepare_tables_noop
+        )
 
       shape_meta_table = Access.get(opts, :shape_meta_table)
 
@@ -368,14 +376,16 @@ defmodule Electric.ShapeCacheTest do
 
     test "returns empty list initially", ctx do
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil), prepare_tables_fn: @prepare_tables_noop)
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+          prepare_tables_fn: @prepare_tables_noop
+        )
 
       assert ShapeCache.list_active_shapes(opts) == []
     end
 
     test "lists the shape as active once there is a snapshot", ctx do
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
@@ -393,7 +403,7 @@ defmodule Electric.ShapeCacheTest do
       test_pid = self()
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             ref = make_ref()
@@ -429,7 +439,7 @@ defmodule Electric.ShapeCacheTest do
 
     test "returns true for known shape id", ctx do
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _, _, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 100})
@@ -444,7 +454,7 @@ defmodule Electric.ShapeCacheTest do
 
     test "works with slow snapshot generation", ctx do
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _, _, _ ->
             Process.sleep(100)
@@ -468,7 +478,7 @@ defmodule Electric.ShapeCacheTest do
 
     test "returns :started for snapshots that have started", ctx do
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _, _, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 100})
@@ -487,7 +497,7 @@ defmodule Electric.ShapeCacheTest do
       storage = Storage.for_shape(shape_id, ctx.storage)
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
@@ -505,7 +515,7 @@ defmodule Electric.ShapeCacheTest do
       test_pid = self()
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             ref = make_ref()
@@ -553,7 +563,7 @@ defmodule Electric.ShapeCacheTest do
         end)
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
@@ -584,7 +594,7 @@ defmodule Electric.ShapeCacheTest do
       test_pid = self()
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, _storage ->
             ref = make_ref()
@@ -625,7 +635,7 @@ defmodule Electric.ShapeCacheTest do
 
     test "cleans up shape data and rotates the shape id", ctx do
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
@@ -677,7 +687,7 @@ defmodule Electric.ShapeCacheTest do
 
     test "cleans up shape data and rotates the shape id", ctx do
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
@@ -723,7 +733,7 @@ defmodule Electric.ShapeCacheTest do
       shape_id = "foo"
 
       %{shape_cache_opts: opts} =
-        with_shape_cache(Map.put(ctx, :pool, nil),
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
@@ -753,7 +763,7 @@ defmodule Electric.ShapeCacheTest do
 
     setup(ctx,
       do:
-        with_shape_cache(ctx,
+        with_shape_cache(Map.put(ctx, :inspector, @stub_inspector),
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})
@@ -841,7 +851,7 @@ defmodule Electric.ShapeCacheTest do
       Process.sleep(1)
       with_cub_db_storage(context)
 
-      with_shape_cache(context,
+      with_shape_cache(Map.put(context, :inspector, @stub_inspector),
         prepare_tables_fn: @prepare_tables_noop,
         create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
           GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})
@@ -890,7 +900,7 @@ defmodule Electric.ShapeCacheTest do
     ]
 
     setup(ctx) do
-      with_shape_cache(ctx,
+      with_shape_cache(Map.put(ctx, :inspector, @stub_inspector),
         prepare_tables_fn: @prepare_tables_noop,
         create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
           GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -370,7 +370,10 @@ defmodule Electric.Shapes.ConsumerTest do
 
       %{shape_cache_opts: shape_cache_opts} =
         Support.ComponentSetup.with_shape_cache(
-          Map.merge(ctx, %{pool: nil}),
+          Map.merge(ctx, %{
+            pool: nil,
+            inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
+          }),
           log_producer: producer,
           prepare_tables_fn: fn _, _ -> :ok end,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -51,6 +51,7 @@ defmodule Support.ComponentSetup do
       [
         name: server,
         shape_meta_table: shape_meta_table,
+        inspector: ctx.inspector,
         storage: ctx.storage,
         db_pool: ctx.pool,
         persistent_kv: ctx.persistent_kv,

--- a/packages/sync-service/test/support/stub_inspector.ex
+++ b/packages/sync-service/test/support/stub_inspector.ex
@@ -19,4 +19,7 @@ defmodule Support.StubInspector do
     |> Map.fetch!(relation)
     |> then(&load_column_info(relation, &1))
   end
+
+  @impl true
+  def clean_column_info(_, _), do: true
 end


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1550.
This PR extends the shape log collector to also clean the cached column information from ETS when a relation changes. This ensures that when a table is migrated, we don't re-use the old table information from ETS but instead load it from Postgres and re-populate the cache with the new column info.

**There's one corner case that this PR does not address:**
- Create table, insert data
- Sync a shape containing that table
- Drop the table
- Delete the shape
- Recreate the table but with a different schema
- Insert some data into the new table
- Sync a shape containing the newly recreated table

In the above scenario, when syncing the newly recreated table, we get the new data but in the old schema (so we only get the columns that also existed in the old schema). This is because Postgres logical replication stream does not inform us when a table is dropped.

As a result, we can't detect that a table was dropped and thus don't know that we need to clean the cached column information. It's only when we get a Relation message that we know this. But Postgres only sends a Relation message the first time the data in the table changes and **we're subscribed to that table in the replication stream** (and that's only after syncing the shape).

So, the data that was inserted before we synced the table in the last step, does not lead to a Relation message. Only if we insert data into the table after that sync step, will Postgres send a Relation message that will make us clean the cached column information. But note that at that point the row that was inserted in the previous step is already stored in storage in the format of the old schema.