### PR TITLE
feat(sync-service): Support missing comparison predicates

### DIFF
--- a/.changeset/dull-islands-join.md
+++ b/.changeset/dull-islands-join.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Support BETWEEN, BETWEEN SYMMETRIC and IS UNKNOWN comparison predicates

--- a/packages/sync-service/lib/electric/replication/eval/env/explicit_casts.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env/explicit_casts.ex
@@ -6,54 +6,52 @@ defmodule Electric.Replication.Eval.Env.ExplicitCasts do
 
   ## List of explicit casts
 
-  | source    | target         | function name   |
-  | --------- | -------------- | ----------------|
-  | bool      | int4           | bool_to_int4    |
-  | char      | int4           |                 |
-  | int8      | bit            |                 |
-  | int4      | bit            |                 |
-  | int4      | bool           | int4_to_bool    |
-  | int4      | char           |                 |
-  | text      | xml            |                 |
-  | lseg      | point          |                 |
-  | box       | point          |                 |
-  | box       | lseg           |                 |
-  | box       | circle         |                 |
-  | polygon   | box            |                 |
-  | polygon   | circle         |                 |
-  | polygon   | point          |                 |
-  | circle    | box            |                 |
-  | circle    | point          |                 |
-  | circle    | polygon        |                 |
-  | bpchar    | xml            |                 |
-  | varchar   | xml            |                 |
-  | bit       | int4           |                 |
-  | bit       | int8           |                 |
-  | jsonb     | bool           |                 |
-  | jsonb     | int8           |                 |
-  | jsonb     | int2           |                 |
-  | jsonb     | int4           |                 |
-  | jsonb     | float4         |                 |
-  | jsonb     | float8         |                 |
-  | jsonb     | numeric        |                 |
-  | int4range | int4multirange |                 |
-  | numrange  | nummultirange  |                 |
-  | tsrange   | tsmultirange   |                 |
-  | tstzrange | tstzmultirange |                 |
-  | daterange | datemultirange |                 |
-  | int8range | int8multirange |                 |
-  | xid8      | xid            |                 |
-  | unknown   | bool           | unknown_to_bool |
+  | source    | target         | function name |
+  | --------- | -------------- | ------------- |
+  | bool      | int4           | bool_to_int4  |
+  | char      | int4           |               |
+  | int8      | bit            |               |
+  | int4      | bit            |               |
+  | int4      | bool           | int4_to_bool  |
+  | int4      | char           |               |
+  | text      | xml            |               |
+  | lseg      | point          |               |
+  | box       | point          |               |
+  | box       | lseg           |               |
+  | box       | circle         |               |
+  | polygon   | box            |               |
+  | polygon   | circle         |               |
+  | polygon   | point          |               |
+  | circle    | box            |               |
+  | circle    | point          |               |
+  | circle    | polygon        |               |
+  | bpchar    | xml            |               |
+  | varchar   | xml            |               |
+  | bit       | int4           |               |
+  | bit       | int8           |               |
+  | jsonb     | bool           |               |
+  | jsonb     | int8           |               |
+  | jsonb     | int2           |               |
+  | jsonb     | int4           |               |
+  | jsonb     | float4         |               |
+  | jsonb     | float8         |               |
+  | jsonb     | numeric        |               |
+  | int4range | int4multirange |               |
+  | numrange  | nummultirange  |               |
+  | tsrange   | tsmultirange   |               |
+  | tstzrange | tstzmultirange |               |
+  | daterange | datemultirange |               |
+  | int8range | int8multirange |               |
+  | xid8      | xid            |               |
   """
 
   def bool_to_int4(true), do: 1
   def bool_to_int4(false), do: 0
   def int4_to_bool(0), do: false
   def int4_to_bool(x) when is_integer(x) and x > 0, do: true
-  def unknown_to_bool(nil), do: nil
 
   # Convert the table from moduledoc into a map
-  @implicit_casts @moduledoc
+  @explicit_casts @moduledoc
                   |> Electric.Utils.parse_md_table(after: "## List of explicit casts")
                   |> Enum.flat_map(fn
                     [_, _, ""] ->
@@ -67,5 +65,5 @@ defmodule Electric.Replication.Eval.Env.ExplicitCasts do
                   end)
                   |> Map.new()
 
-  def known, do: @implicit_casts
+  def known, do: @explicit_casts
 end

--- a/packages/sync-service/lib/electric/replication/eval/env/explicit_casts.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env/explicit_casts.ex
@@ -6,49 +6,51 @@ defmodule Electric.Replication.Eval.Env.ExplicitCasts do
 
   ## List of explicit casts
 
-  | source    | target         | function name |
-  | --------- | -------------- | ------------- |
-  | bool      | int4           | bool_to_int4  |
-  | char      | int4           |               |
-  | int8      | bit            |               |
-  | int4      | bit            |               |
-  | int4      | bool           | int4_to_bool  |
-  | int4      | char           |               |
-  | text      | xml            |               |
-  | lseg      | point          |               |
-  | box       | point          |               |
-  | box       | lseg           |               |
-  | box       | circle         |               |
-  | polygon   | box            |               |
-  | polygon   | circle         |               |
-  | polygon   | point          |               |
-  | circle    | box            |               |
-  | circle    | point          |               |
-  | circle    | polygon        |               |
-  | bpchar    | xml            |               |
-  | varchar   | xml            |               |
-  | bit       | int4           |               |
-  | bit       | int8           |               |
-  | jsonb     | bool           |               |
-  | jsonb     | int8           |               |
-  | jsonb     | int2           |               |
-  | jsonb     | int4           |               |
-  | jsonb     | float4         |               |
-  | jsonb     | float8         |               |
-  | jsonb     | numeric        |               |
-  | int4range | int4multirange |               |
-  | numrange  | nummultirange  |               |
-  | tsrange   | tsmultirange   |               |
-  | tstzrange | tstzmultirange |               |
-  | daterange | datemultirange |               |
-  | int8range | int8multirange |               |
-  | xid8      | xid            |               |
+  | source    | target         | function name   |
+  | --------- | -------------- | ----------------|
+  | bool      | int4           | bool_to_int4    |
+  | char      | int4           |                 |
+  | int8      | bit            |                 |
+  | int4      | bit            |                 |
+  | int4      | bool           | int4_to_bool    |
+  | int4      | char           |                 |
+  | text      | xml            |                 |
+  | lseg      | point          |                 |
+  | box       | point          |                 |
+  | box       | lseg           |                 |
+  | box       | circle         |                 |
+  | polygon   | box            |                 |
+  | polygon   | circle         |                 |
+  | polygon   | point          |                 |
+  | circle    | box            |                 |
+  | circle    | point          |                 |
+  | circle    | polygon        |                 |
+  | bpchar    | xml            |                 |
+  | varchar   | xml            |                 |
+  | bit       | int4           |                 |
+  | bit       | int8           |                 |
+  | jsonb     | bool           |                 |
+  | jsonb     | int8           |                 |
+  | jsonb     | int2           |                 |
+  | jsonb     | int4           |                 |
+  | jsonb     | float4         |                 |
+  | jsonb     | float8         |                 |
+  | jsonb     | numeric        |                 |
+  | int4range | int4multirange |                 |
+  | numrange  | nummultirange  |                 |
+  | tsrange   | tsmultirange   |                 |
+  | tstzrange | tstzmultirange |                 |
+  | daterange | datemultirange |                 |
+  | int8range | int8multirange |                 |
+  | xid8      | xid            |                 |
+  | unknown   | bool           | unknown_to_bool |
   """
 
   def bool_to_int4(true), do: 1
   def bool_to_int4(false), do: 0
   def int4_to_bool(0), do: false
   def int4_to_bool(x) when is_integer(x) and x > 0, do: true
+  def unknown_to_bool(nil), do: nil
 
   # Convert the table from moduledoc into a map
   @implicit_casts @moduledoc

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -391,16 +391,16 @@ defmodule Electric.Replication.Eval.Parser do
         between(expr, left_bound, right_bound, refs, env)
 
       :AEXPR_NOT_BETWEEN ->
-        with {:ok, reduced} <- between(expr, left_bound, right_bound, refs, env) do
-          negate(reduced)
+        with {:ok, comparison} <- between(expr, left_bound, right_bound, refs, env) do
+          negate(comparison)
         end
 
       :AEXPR_BETWEEN_SYM ->
         between_sym(expr, left_bound, right_bound, refs, env)
 
       :AEXPR_NOT_BETWEEN_SYM ->
-        with {:ok, reduced} <- between_sym(expr, left_bound, right_bound, refs, env) do
-          negate(reduced)
+        with {:ok, comparison} <- between_sym(expr, left_bound, right_bound, refs, env) do
+          negate(comparison)
         end
     end
   end

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -269,6 +269,8 @@ defmodule Electric.Replication.Eval.Parser do
             :IS_NOT_TRUE -> &(&1 != true)
             :IS_FALSE -> &(&1 == false)
             :IS_NOT_FALSE -> &(&1 != false)
+            :IS_UNKNOWN -> &(&1 == nil)
+            :IS_NOT_UNKNOWN -> &(&1 != nil)
           end
 
         maybe_reduce(%Func{

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -225,6 +225,7 @@ defmodule Electric.Replication.Eval.Parser do
       {:AEXPR_DISTINCT, _} -> handle_distinct(expr, refs, env)
       {:AEXPR_NOT_DISTINCT, _} -> handle_distinct(expr, refs, env)
       {:AEXPR_IN, _} -> handle_in(expr, refs, env)
+      {:AEXPR_BETWEEN, _} -> handle_between(expr, refs, env)
       _ -> {:error, {loc, "expression #{identifier(expr.name)} is not currently supported"}}
     end
   end
@@ -358,7 +359,8 @@ defmodule Electric.Replication.Eval.Parser do
     # This is "=" if it's `IN`, and "<>" if it's `NOT IN`.
     name = unwrap_node_string(name)
 
-    # It can only be a list here because that's how PG parses SQL. It it's a subquery, then it wouldn't be `A_Expr`.
+    # It can only be a list here because that's how PG parses SQL. It it's a subquery, then it
+    # wouldn't be `A_Expr`.
     {:list, %PgQuery.List{items: items}} = expr.rexpr.node
 
     with {:ok, comparisons} <-
@@ -367,7 +369,8 @@ defmodule Electric.Replication.Eval.Parser do
              &find_operator_func(["="], [expr.lexpr, &1], expr.location, refs, env)
            ),
          {:ok, comparisons} <- Utils.map_while_ok(comparisons, &maybe_reduce/1),
-         {:ok, reduced} <- build_or_chain(comparisons, expr.location) do
+         {:ok, reduced} <-
+           build_bool_chain(%{name: "or", impl: &Kernel.or/2}, comparisons, expr.location) do
       # x NOT IN y is exactly equivalent to NOT (x IN y)
       if name == "=",
         do: {:ok, reduced},
@@ -382,11 +385,28 @@ defmodule Electric.Replication.Eval.Parser do
     end
   end
 
-  defp build_or_chain([head | tail], location) do
+  defp handle_between(%PgQuery.A_Expr{} = expr, refs, env) do
+    # It can only be a list here because that's how PG parses SQL. It it's a subquery, then it
+    # wouldn't be `A_Expr`.
+    {:list, %PgQuery.List{items: [left_bound, right_bound]}} = expr.rexpr.node
+
+    with {:ok, lcmp} <-
+           find_operator_func(["<="], [left_bound, expr.lexpr], expr.location, refs, env),
+         {:ok, rcmp} <-
+           find_operator_func(["<="], [expr.lexpr, right_bound], expr.location, refs, env),
+         comparisons = [lcmp, rcmp],
+         {:ok, comparisons} <- Utils.map_while_ok(comparisons, &maybe_reduce/1),
+         {:ok, reduced} <-
+           build_bool_chain(%{name: "and", impl: &Kernel.and/2}, comparisons, expr.location) do
+      {:ok, reduced}
+    end
+  end
+
+  defp build_bool_chain(op, [head | tail], location) do
     Enum.reduce_while(tail, {:ok, head}, fn comparison, {:ok, acc} ->
       %Func{
-        implementation: &Kernel.or/2,
-        name: "or",
+        implementation: op.impl,
+        name: op.name,
         type: :bool,
         args: [acc, comparison],
         location: location

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -418,6 +418,7 @@ defmodule Electric.Replication.Eval.Parser do
     end
   end
 
+  # This is suboptimal since it has to recalculate the subtree for the two comparisons
   defp between_sym(expr, left_bound, right_bound, refs, env) do
     with {:ok, comparison1} <- between(expr, left_bound, right_bound, refs, env),
          {:ok, comparison2} <- between(expr, right_bound, left_bound, refs, env) do

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -513,12 +513,16 @@ defmodule Electric.Replication.Eval.Parser do
 
       :error ->
         case {from_type, to_type} do
+          {:unknown, _} -> {:ok, {__MODULE__, :cast_null}}
+          {_, :unknown} -> {:ok, {__MODULE__, :cast_null}}
           {:text, to_type} -> find_cast_in_function(env, to_type)
           {from_type, :text} -> find_cast_out_function(env, from_type)
           {from_type, to_type} -> find_explicit_cast(env, from_type, to_type)
         end
     end
   end
+
+  def cast_null(nil), do: nil
 
   defp find_cast_in_function(env, to_type) do
     case Map.fetch(env.funcs, {"#{to_type}", 1}) do

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -375,7 +375,7 @@ defmodule Electric.Replication.Eval.Parser do
       # x NOT IN y is exactly equivalent to NOT (x IN y)
       if name == "=",
         do: {:ok, reduced},
-        else: negate(reduced, expr.location)
+        else: negate(reduced)
     end
   end
 
@@ -394,7 +394,7 @@ defmodule Electric.Replication.Eval.Parser do
            build_bool_chain(%{name: "and", impl: &Kernel.and/2}, comparisons, expr.location) do
       case expr.kind do
         :AEXPR_BETWEEN -> {:ok, reduced}
-        :AEXPR_NOT_BETWEEN -> negate(reduced, expr.location)
+        :AEXPR_NOT_BETWEEN -> negate(reduced)
       end
     end
   end
@@ -704,13 +704,13 @@ defmodule Electric.Replication.Eval.Parser do
   def unwrap_node_string(%PgQuery.Node{node: {:a_const, %PgQuery.A_Const{val: {:sval, sval}}}}),
     do: unwrap_node_string(sval)
 
-  defp negate(arg, location) do
+  defp negate(tree_part) do
     maybe_reduce(%Func{
       implementation: &Kernel.not/1,
       name: "not",
       type: :bool,
-      args: [arg],
-      location: location
+      args: [tree_part],
+      location: tree_part.location
     })
   end
 end

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -298,8 +298,13 @@ defmodule Electric.Replication.Eval.ParserTest do
 
       for {expr, expected} <- [
             {~S|2 BETWEEN 1 AND 3|, true},
+            {~S|2 NOT BETWEEN 1 AND 3|, false},
             {~S|0 BETWEEN 1 AND 3|, false},
-            {~S|'2024-07-31'::date BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, true}
+            {~S|0 NOT BETWEEN 1 AND 3|, true},
+            {~S|'2024-07-31'::date BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, true},
+            {~S|'2024-07-31'::date NOT BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, false},
+            {~S|'2024-06-30'::date BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, false},
+            {~S|'2024-06-30'::date NOT BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, true}
           ] do
         assert {:ok, %Expr{eval: result}} =
                  Parser.parse_and_validate_expression(expr, %{}, env)

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -297,10 +297,16 @@ defmodule Electric.Replication.Eval.ParserTest do
       env = Env.new()
 
       for {expr, expected} <- [
-            {~S|2 BETWEEN 1 AND 3|, true},
-            {~S|2 NOT BETWEEN 1 AND 3|, false},
             {~S|0 BETWEEN 1 AND 3|, false},
-            {~S|0 NOT BETWEEN 1 AND 3|, true},
+            {~S|1 BETWEEN 1 AND 3|, true},
+            {~S|2 BETWEEN 1 AND 3|, true},
+            {~S|3 BETWEEN 1 AND 3|, true},
+            {~S|4 BETWEEN 1 AND 3|, false},
+            {~S|2 NOT BETWEEN 1 AND 3|, false},
+            {~S|1 BETWEEN 3 AND 1|, false},
+            {~S|1 NOT BETWEEN 3 AND 1|, true},
+            {~S|2 BETWEEN SYMMETRIC 3 AND 1|, true},
+            {~S|2 NOT BETWEEN SYMMETRIC 3 AND 1|, false},
             {~S|'2024-07-31'::date BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, true},
             {~S|'2024-07-31'::date NOT BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, false},
             {~S|'2024-06-30'::date BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, false},

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -262,6 +262,22 @@ defmodule Electric.Replication.Eval.ParserTest do
       end
     end
 
+    test "should work with IS [NOT] UNKNOWN" do
+      env = Env.new()
+
+      for {expr, expected} <- [
+            {~S|true IS UNKNOWN|, false},
+            {~S|true IS NOT UNKNOWN|, true},
+            {~S|NULL::boolean IS UNKNOWN|, true},
+            {~S|NULL::boolean IS NOT UNKNOWN|, false}
+          ] do
+        assert {{:ok, %Expr{eval: result}}, ^expr} =
+                 {Parser.parse_and_validate_expression(expr, %{}, env), expr}
+
+        assert {%Const{value: ^expected, type: :bool}, ^expr} = {result, expr}
+      end
+    end
+
     test "should work with LIKE clauses" do
       env =
         Env.new()

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -269,7 +269,9 @@ defmodule Electric.Replication.Eval.ParserTest do
             {~S|true IS UNKNOWN|, false},
             {~S|true IS NOT UNKNOWN|, true},
             {~S|NULL::boolean IS UNKNOWN|, true},
-            {~S|NULL::boolean IS NOT UNKNOWN|, false}
+            {~S|NULL::boolean IS NOT UNKNOWN|, false},
+            {~S|NULL IS UNKNOWN|, true},
+            {~S|NULL IS NOT UNKNOWN|, false}
           ] do
         assert {{:ok, %Expr{eval: result}}, ^expr} =
                  {Parser.parse_and_validate_expression(expr, %{}, env), expr}

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -279,8 +279,7 @@ defmodule Electric.Replication.Eval.ParserTest do
     end
 
     test "should work with LIKE clauses" do
-      env =
-        Env.new()
+      env = Env.new()
 
       assert {:ok, %Expr{eval: result}} =
                Parser.parse_and_validate_expression(
@@ -290,6 +289,21 @@ defmodule Electric.Replication.Eval.ParserTest do
                )
 
       assert %Const{value: true, type: :bool} = result
+    end
+
+    test "should work with BETWEEN clauses" do
+      env = Env.new()
+
+      for {expr, expected} <- [
+            {~S|2 BETWEEN 1 AND 3|, true},
+            {~S|0 BETWEEN 1 AND 3|, false},
+            {~S|'2024-07-31'::date BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, true}
+          ] do
+        assert {:ok, %Expr{eval: result}} =
+                 Parser.parse_and_validate_expression(expr, %{}, env)
+
+        assert %Const{value: ^expected, type: :bool} = result
+      end
     end
 
     test "should work with explicit casts" do

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -310,7 +310,11 @@ defmodule Electric.Replication.Eval.ParserTest do
             {~S|'2024-07-31'::date BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, true},
             {~S|'2024-07-31'::date NOT BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, false},
             {~S|'2024-06-30'::date BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, false},
-            {~S|'2024-06-30'::date NOT BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, true}
+            {~S|'2024-06-30'::date NOT BETWEEN '2024-07-01'::date AND '2024-07-31'::date|, true},
+            {~S|'2024-07-15'::date BETWEEN SYMMETRIC '2024-07-31'::date AND '2024-07-01'::date|,
+             true},
+            {~S|'2024-07-15'::date NOT BETWEEN SYMMETRIC '2024-07-31'::date AND '2024-07-01'::date|,
+             false}
           ] do
         assert {:ok, %Expr{eval: result}} =
                  Parser.parse_and_validate_expression(expr, %{}, env)


### PR DESCRIPTION
Support for the missing comparison predicates in WHERE clauses, as mentioned in #1441:
-  x BETWEEN y AND z
-  x NOT BETWEEN y AND z
-  z BETWEEN SYMMETRIC y AND z
-  z NOT BETWEEN SYMMETRIC y AND z
-  x IS UNKNOWN
-  x IS NOT UNKNOWN