### PR TITLE
Feat!: remove shapes provider

### DIFF
--- a/.changeset/neat-bikes-trade.md
+++ b/.changeset/neat-bikes-trade.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/react": patch
+---
+
+Remove obsolete ShapesProvider.

--- a/.changeset/neat-bikes-trade.md
+++ b/.changeset/neat-bikes-trade.md
@@ -1,5 +1,5 @@
 ---
-"@electric-sql/react": patch
+"@electric-sql/react": minor
 ---
 
 Remove obsolete ShapesProvider.

--- a/examples/auth/app/layout.tsx
+++ b/examples/auth/app/layout.tsx
@@ -1,6 +1,5 @@
 import "./style.css"
 import "./App.css"
-import { Providers } from "./providers"
 
 export const metadata = {
   title: `Electric Auth Example`,
@@ -18,7 +17,7 @@ export default function RootLayout({
         <div className="App">
           <header className="App-header">
             <img src="/logo.svg" className="App-logo" alt="logo" />
-            <Providers>{children}</Providers>
+            {children}
           </header>
         </div>
       </body>

--- a/examples/auth/app/providers.tsx
+++ b/examples/auth/app/providers.tsx
@@ -1,8 +1,0 @@
-"use client"
-
-import { ShapesProvider } from "@electric-sql/react"
-import { ReactNode } from "react"
-
-export function Providers({ children }: { children: ReactNode }) {
-  return <ShapesProvider>{children}</ShapesProvider>
-}

--- a/examples/basic-example/src/App.tsx
+++ b/examples/basic-example/src/App.tsx
@@ -3,16 +3,13 @@ import './App.css'
 import './style.css'
 
 import { Example } from './Example'
-import { ShapesProvider } from '@electric-sql/react'
 
 export default function App() {
   return (
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
-        <ShapesProvider>
-          <Example />
-        </ShapesProvider>
+        <Example />
       </header>
     </div>
   )

--- a/examples/linearlite/src/App.tsx
+++ b/examples/linearlite/src/App.tsx
@@ -6,7 +6,7 @@ import 'react-toastify/dist/ReactToastify.css'
 import List from './pages/List'
 import Root from './pages/root'
 import Issue from './pages/Issue'
-import { ShapesProvider, preloadShape } from '@electric-sql/react'
+import { preloadShape } from '@electric-sql/react'
 import { issueShape } from './shapes'
 
 interface MenuContextInterface {
@@ -51,11 +51,9 @@ const App = () => {
   const [showMenu, setShowMenu] = useState(false)
 
   return (
-    <ShapesProvider>
-      <MenuContext.Provider value={{ showMenu, setShowMenu }}>
-        <RouterProvider router={router} />
-      </MenuContext.Provider>
-    </ShapesProvider>
+    <MenuContext.Provider value={{ showMenu, setShowMenu }}>
+      <RouterProvider router={router} />
+    </MenuContext.Provider>
   )
 }
 

--- a/examples/nextjs-example/app/layout.tsx
+++ b/examples/nextjs-example/app/layout.tsx
@@ -1,6 +1,5 @@
 import "./style.css"
 import "./App.css"
-import { Providers } from "./providers"
 
 export const metadata = {
   title: `Next.js Forms Example`,
@@ -18,7 +17,7 @@ export default function RootLayout({
         <div className="App">
           <header className="App-header">
             <img src="/logo.svg" className="App-logo" alt="logo" />
-            <Providers>{children}</Providers>
+            {children}
           </header>
         </div>
       </body>

--- a/examples/nextjs-example/app/providers.tsx
+++ b/examples/nextjs-example/app/providers.tsx
@@ -1,8 +1,0 @@
-"use client"
-
-import { ShapesProvider } from "@electric-sql/react"
-import { ReactNode } from "react"
-
-export function Providers({ children }: { children: ReactNode }) {
-  return <ShapesProvider>{children}</ShapesProvider>
-}

--- a/examples/remix-basic/app/root.tsx
+++ b/examples/remix-basic/app/root.tsx
@@ -8,8 +8,6 @@ import {
   ScrollRestoration,
 } from "@remix-run/react"
 
-import { ShapesProvider } from "@electric-sql/react"
-
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
@@ -33,9 +31,7 @@ export default function App() {
     <div className="App">
       <header className="App-header">
         <img src="/logo.svg" className="App-logo" alt="logo" />
-        <ShapesProvider>
-          <Outlet />
-        </ShapesProvider>
+        <Outlet />
       </header>
     </div>
   )

--- a/examples/todo-app/src/routes/root.tsx
+++ b/examples/todo-app/src/routes/root.tsx
@@ -1,12 +1,7 @@
 import { Outlet } from "react-router-dom"
-import { ShapesProvider } from "@electric-sql/react"
 
 export default function Root() {
   return (
-    <>
-      <ShapesProvider>
-        <Outlet />
-      </ShapesProvider>
-    </>
+    <Outlet />
   )
 }

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -4,16 +4,8 @@ import {
   ShapeStream,
   ShapeStreamOptions,
 } from '@electric-sql/client'
-import React, { createContext, useCallback, useContext, useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
-
-interface ShapeContextType {
-  getShape: (shapeStream: ShapeStream) => Shape
-  getShapeStream: (options: ShapeStreamOptions) => ShapeStream
-}
-
-// Create a Context
-const ShapesContext = createContext<ShapeContextType | null>(null)
 
 const streamCache = new Map<string, ShapeStream>()
 const shapeCache = new Map<ShapeStream, Shape>()
@@ -63,28 +55,6 @@ export function getShape(shapeStream: ShapeStream): Shape {
   }
 }
 
-interface ShapeProviderProps {
-  children: React.ReactNode
-}
-
-// Shapes Provider Component
-export function ShapesProvider({ children }: ShapeProviderProps): JSX.Element {
-  // Provide the context value
-  return (
-    <ShapesContext.Provider value={{ getShape, getShapeStream }}>
-      {children}
-    </ShapesContext.Provider>
-  )
-}
-
-export function useShapeContext() {
-  const context = useContext(ShapesContext)
-  if (!context) {
-    throw new Error(`useShapeContext must be used within a ShapeProvider`)
-  }
-  return context
-}
-
 interface UseShapeResult {
   /**
    * The array of rows that make up the Shape.
@@ -131,7 +101,6 @@ export function useShape<Selection = UseShapeResult>({
   selector = identity as never,
   ...options
 }: UseShapeOptions<Selection>): Selection {
-  const { getShape, getShapeStream } = useShapeContext()
   const shapeStream = getShapeStream(options as ShapeStreamOptions)
   const shape = getShape(shapeStream)
 

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -1,15 +1,13 @@
 import 'global-jsdom/register'
 // https://react-hooks-testing-library.com/usage/advanced-hooks#context
 
-import React from 'react'
 import { renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, inject, it as bareIt } from 'vitest'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { testWithIssuesTable as it } from './support/test-context'
-import { useShape, ShapesProvider, sortedOptionsHash } from '../src/react-hooks'
+import { useShape, sortedOptionsHash } from '../src/react-hooks'
 import { Shape, Message } from '@electric-sql/client'
 
-type FC = React.FC<React.PropsWithChildren>
 const BASE_URL = inject(`baseUrl`)
 
 describe(`sortedOptionsHash`, () => {
@@ -31,18 +29,12 @@ describe(`sortedOptionsHash`, () => {
 
 describe(`useShape`, () => {
   it(`should sync an empty shape`, async ({ aborter, issuesTableUrl }) => {
-    const wrapper: FC = ({ children }) => {
-      return <ShapesProvider>{children}</ShapesProvider>
-    }
-
-    const { result } = renderHook(
-      () =>
-        useShape({
-          url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-          signal: aborter.signal,
-          subscribe: false,
-        }),
-      { wrapper }
+    const { result } = renderHook(() =>
+      useShape({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter.signal,
+        subscribe: false,
+      })
     )
 
     await waitFor(() => expect(result.current.isUpToDate).toEqual(true))
@@ -59,18 +51,12 @@ describe(`useShape`, () => {
   }) => {
     const [id] = await insertIssues({ title: `test row` })
 
-    const wrapper: FC = ({ children }) => {
-      return <ShapesProvider>{children}</ShapesProvider>
-    }
-
-    const { result } = renderHook(
-      () =>
-        useShape({
-          url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-          signal: aborter?.signal,
-          subscribe: false,
-        }),
-      { wrapper }
+    const { result } = renderHook(() =>
+      useShape({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter?.signal,
+        subscribe: false,
+      })
     )
 
     await waitFor(() =>
@@ -85,18 +71,12 @@ describe(`useShape`, () => {
   }) => {
     const [id] = await insertIssues({ title: `test row` })
 
-    const wrapper: FC = ({ children }) => {
-      return <ShapesProvider>{children}</ShapesProvider>
-    }
-
-    const { result } = renderHook(
-      () =>
-        useShape({
-          url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-          signal: aborter.signal,
-          subscribe: true,
-        }),
-      { wrapper }
+    const { result } = renderHook(() =>
+      useShape({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter.signal,
+        subscribe: true,
+      })
     )
 
     await waitFor(() => expect(result.current.data).not.toEqual([]))
@@ -120,24 +100,16 @@ describe(`useShape`, () => {
     const [id] = await insertIssues({ title: `test row` })
     await insertIssues({ title: `test row2` })
 
-    const wrapper: FC = ({ children }) => {
-      return <ShapesProvider>{children}</ShapesProvider>
-    }
-
-    const { result } = renderHook(
-      () =>
-        useShape({
-          url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-          signal: aborter.signal,
-          subscribe: true,
-          selector: (result) => {
-            result.data = result.data.filter(
-              (row) => row?.title !== `test row2`
-            )
-            return result
-          },
-        }),
-      { wrapper }
+    const { result } = renderHook(() =>
+      useShape({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter.signal,
+        subscribe: true,
+        selector: (result) => {
+          result.data = result.data.filter((row) => row?.title !== `test row2`)
+          return result
+        },
+      })
     )
 
     await waitFor(() =>
@@ -162,18 +134,12 @@ describe(`useShape`, () => {
   }) => {
     await insertIssues({ title: `test row` })
 
-    const wrapper: FC = ({ children }) => {
-      return <ShapesProvider>{children}</ShapesProvider>
-    }
-
-    const { result, unmount } = renderHook(
-      () =>
-        useShape({
-          url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-          signal: aborter.signal,
-          subscribe: true,
-        }),
-      { wrapper }
+    const { result, unmount } = renderHook(() =>
+      useShape({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter.signal,
+        subscribe: true,
+      })
     )
 
     await waitFor(() => expect(result.current.data).not.toEqual([]))


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1571.
Removes the `ShapesProvider` and also updates the examples.

This is a breaking change since old applications use this `ShapesProvider` which no longer exists. Luckily, the fix is simple, just remove the `ShapesProvider` altogether.