### PR TITLE
fix(sync-service): Fix a crash caused by incorrect conversion of an UPDATE into an INSERT or a DELETE depending on whether it is a shape move-in or a shape move-out case

### DIFF
--- a/.changeset/kind-crabs-study.md
+++ b/.changeset/kind-crabs-study.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix a crash caused by incorrect conversion of an UPDATE into an INSERT or a DELETE depending on whether it is a shape move-in or a shape move-out case.

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -275,11 +275,22 @@ defmodule Electric.Replication.Changes do
       %UpdatedRecord{record: %{id: 1}}
   """
   def convert_update(%UpdatedRecord{} = change, to: :new_record) do
-    %NewRecord{relation: change.relation, record: change.record}
+    %NewRecord{
+      relation: change.relation,
+      record: change.record,
+      key: change.key,
+      log_offset: change.log_offset
+    }
   end
 
   def convert_update(%UpdatedRecord{} = change, to: :deleted_record) do
-    %DeletedRecord{relation: change.relation, old_record: change.old_record}
+    %DeletedRecord{
+      relation: change.relation,
+      old_record: change.old_record,
+      key: change.key,
+      log_offset: change.log_offset,
+      tags: change.tags
+    }
   end
 
   def convert_update(%UpdatedRecord{} = change, to: :updated_record), do: change

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -287,7 +287,7 @@ defmodule Electric.Replication.Changes do
     %DeletedRecord{
       relation: change.relation,
       old_record: change.old_record,
-      key: change.key,
+      key: change.old_key || change.key,
       log_offset: change.log_offset,
       tags: change.tags
     }

--- a/packages/sync-service/lib/electric/replication/log_offset.ex
+++ b/packages/sync-service/lib/electric/replication/log_offset.ex
@@ -140,9 +140,15 @@ defmodule Electric.Replication.LogOffset do
 
       iex> compare(new(10, 5) |> increment, new(10, 5))
       :gt
+
+      iex> increment(new(10, 5), 5)
+      %LogOffset{tx_offset: 10, op_offset: 10}
+
+      iex> compare(new(10, 1) |> increment(4), new(10, 5))
+      :eq
   """
-  def increment(%LogOffset{tx_offset: tx_offset, op_offset: op_offset}) do
-    %LogOffset{tx_offset: tx_offset, op_offset: op_offset + 1}
+  def increment(%LogOffset{op_offset: op_offset} = log_offset, increment \\ 1) do
+    %LogOffset{log_offset | op_offset: op_offset + increment}
   end
 
   @doc """

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -411,5 +411,126 @@ defmodule Electric.Plug.RouterTest do
 
       assert [_] = Jason.decode!(conn.resp_body)
     end
+
+    @tag additional_fields: "num INTEGER NOT NULL"
+    @tag with_sql: [
+           "INSERT INTO serial_ids (id, num) VALUES (1, 1), (2, 10)"
+         ]
+    test "GET returns correct INSERT and DELETE operations that have been converted from UPDATEs",
+         %{opts: opts, db_conn: db_conn} do
+      where = "num > 5"
+
+      # Verify that a single row is in-shape initially.
+      conn =
+        conn("GET", "/v1/shape/serial_ids", %{offset: "-1", where: where})
+        |> Router.call(opts)
+
+      assert %{status: 200} = conn
+      shape_id = get_resp_shape_id(conn)
+
+      assert [op, %{"headers" => %{"control" => "up-to-date"}}] = Jason.decode!(conn.resp_body)
+
+      assert op == %{
+               "headers" => %{"operation" => "insert", "relation" => ["public", "serial_ids"]},
+               "key" => ~s|"public"."serial_ids"/"2"|,
+               "offset" => "0_0",
+               "value" => %{"id" => "2", "num" => "10"}
+             }
+
+      # Insert more rows and verify their delivery to a live shape subscriber.
+      Postgrex.query!(db_conn, "INSERT INTO serial_ids(id, num) VALUES (3, 8), (4, 9)", [])
+
+      task =
+        Task.async(fn ->
+          conn("GET", "/v1/shape/serial_ids", %{
+            offset: "0_0",
+            shape_id: shape_id,
+            where: where,
+            live: true
+          })
+          |> Router.call(opts)
+        end)
+
+      assert %{status: 200} = conn = Task.await(task)
+      new_offset = get_resp_last_offset(conn)
+
+      assert [op1, op2, %{"headers" => %{"control" => "up-to-date"}}] =
+               Jason.decode!(conn.resp_body)
+
+      assert [
+               %{
+                 "headers" => %{"operation" => "insert", "relation" => ["public", "serial_ids"]},
+                 "key" => ~s|"public"."serial_ids"/"3"|,
+                 "value" => %{"id" => "3", "num" => "8"}
+               },
+               %{
+                 "headers" => %{"operation" => "insert", "relation" => ["public", "serial_ids"]},
+                 "key" => ~s|"public"."serial_ids"/"4"|,
+                 "value" => %{"id" => "4", "num" => "9"}
+               }
+             ] = [op1, op2]
+
+      # Simulate a move-in and a move-out and verify their correct delivery as INSERT and
+      # DELETE operations, respectively.
+      task =
+        Task.async(fn ->
+          conn("GET", "/v1/shape/serial_ids", %{
+            offset: new_offset,
+            shape_id: shape_id,
+            where: where,
+            live: true
+          })
+          |> Router.call(opts)
+        end)
+
+      Postgrex.transaction(db_conn, fn conn ->
+        Postgrex.query!(conn, "UPDATE serial_ids SET num = 6 WHERE id = 1", [])
+        Postgrex.query!(conn, "UPDATE serial_ids SET num = 5 WHERE id = 3", [])
+      end)
+
+      assert %{status: 200} = conn = Task.await(task)
+
+      assert [op1, op2, %{"headers" => %{"control" => "up-to-date"}}] =
+               Jason.decode!(conn.resp_body)
+
+      assert [
+               %{
+                 "headers" => %{"operation" => "insert", "relation" => ["public", "serial_ids"]},
+                 "key" => ~s|"public"."serial_ids"/"1"|,
+                 "value" => %{"id" => "1", "num" => "6"},
+                 "offset" => op1_offset
+               },
+               %{
+                 "headers" => %{"operation" => "delete", "relation" => ["public", "serial_ids"]},
+                 "key" => ~s|"public"."serial_ids"/"3"|,
+                 "value" => %{"id" => "3"},
+                 "offset" => op2_offset
+               }
+             ] = [op1, op2]
+
+      last_offset = get_resp_last_offset(conn)
+
+      # Verify that both ops share the same tx offset and differ in their op offset by a known
+      # amount.
+      [op1_log_offset, op2_log_offset, last_log_offset] =
+        Enum.map([op1_offset, op2_offset, last_offset], fn offset ->
+          {:ok, log_offset} = LogOffset.from_string(offset)
+          log_offset
+        end)
+
+      assert op2_log_offset == last_log_offset
+
+      # An UPDATE op always increments the log offset by two to accommodate a possible split
+      # into two operations when the PK changes. Hence the distance of 2 between op1 and op2.
+      assert op2_log_offset == LogOffset.increment(op1_log_offset, 2)
+    end
+  end
+
+  defp get_resp_shape_id(conn), do: get_resp_header(conn, "x-electric-shape-id")
+  defp get_resp_last_offset(conn), do: get_resp_header(conn, "x-electric-chunk-last-offset")
+
+  defp get_resp_header(conn, header) do
+    assert [val] = Plug.Conn.get_resp_header(conn, header)
+    val
   end
 end

--- a/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
+++ b/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
@@ -7,8 +7,8 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
   describe "load_column_info/2" do
     setup [:with_inspector, :with_basic_tables]
 
-    setup %{tables: [table | _], inspector: {EtsInspector, opts}} do
-      {:ok, %{opts: opts, table: table}}
+    setup %{inspector: {EtsInspector, opts}} do
+      {:ok, %{opts: opts, table: {"public", "items"}}}
     end
 
     test "returns column info for the table", %{opts: opts, table: table} do

--- a/packages/sync-service/test/support/db_structure_setup.ex
+++ b/packages/sync-service/test/support/db_structure_setup.ex
@@ -1,18 +1,24 @@
 defmodule Support.DbStructureSetup do
   def with_basic_tables(%{db_conn: conn} = context) do
-    Postgrex.query!(
-      conn,
+    statements = [
+      """
+      CREATE TABLE serial_ids (
+        id BIGSERIAL PRIMARY KEY
+        #{additional_fields(context)}
+      );
+      """,
       """
       CREATE TABLE items (
         id UUID PRIMARY KEY,
         value TEXT NOT NULL
         #{additional_fields(context)}
       )
-      """,
-      []
-    )
+      """
+    ]
 
-    {:ok, tables: [{"public", "items"}]}
+    Enum.each(statements, &Postgrex.query!(conn, &1, []))
+
+    %{tables: [{"public", "serial_ids"}, {"public", "items"}]}
   end
 
   def with_sql_execute(%{db_conn: conn, with_sql: sql}) do
@@ -26,7 +32,7 @@ defmodule Support.DbStructureSetup do
         end)
       end)
 
-    {:ok, %{sql_execute: results}}
+    %{sql_execute: results}
   end
 
   def with_sql_execute(_), do: :ok


### PR DESCRIPTION
Fixes #1588.