### PR TITLE
Resume crashed consumers at a consistent point

### DIFF
--- a/.changeset/rotten-tigers-peel.md
+++ b/.changeset/rotten-tigers-peel.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Improve consistency of shape consumers after storage error

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ caching/nginx_cache
 build
 tsconfig.tsbuildinfo
 **/*.vitest-temp.json
+/packages/sync-service/state/

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -4,6 +4,11 @@ import Dotenvy
 config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 config :logger, level: :debug
 
+# uncomment if you need to track process creation and destruction
+# config :logger,
+#   handle_otp_reports: true,
+#   handle_sasl_reports: true
+
 if config_env() == :test, do: config(:logger, level: :info)
 
 if config_env() in [:dev, :test] do

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -3,6 +3,11 @@ defmodule Electric.Application do
 
   @process_registry_name Electric.Registry.Processes
 
+  @spec process_name(atom()) :: {:via, atom(), atom()}
+  def process_name(module) when is_atom(module) do
+    {:via, Registry, {@process_registry_name, module}}
+  end
+
   @spec process_name(atom(), term()) :: {:via, atom(), {atom(), term()}}
   def process_name(module, id) when is_atom(module) do
     {:via, Registry, {@process_registry_name, {module, id}}}
@@ -42,8 +47,26 @@ defmodule Electric.Application do
 
       core_processes = [
         {Registry,
-         name: @process_registry_name, keys: :unique, partitions: System.schedulers_online()},
-        {Electric.ShapeCache.ShapeSupervisor, []}
+         name: @process_registry_name, keys: :unique, partitions: System.schedulers_online()}
+      ]
+
+      connection_manager_opts = [
+        connection_opts: Application.fetch_env!(:electric, :connection_opts),
+        replication_opts: [
+          publication_name: publication_name,
+          try_creating_publication?: true,
+          slot_name: slot_name,
+          transaction_received: {Electric.Replication.ShapeLogCollector, :store_transaction, []},
+          relation_received:
+            {Electric.ShapeCache, :handle_relation_msg, [[server: Electric.ShapeCache]]}
+        ],
+        pool_opts: [
+          name: Electric.DbPool,
+          pool_size: Application.fetch_env!(:electric, :db_pool_size),
+          types: PgInterop.Postgrex.Types
+        ],
+        log_collector: {Electric.Replication.ShapeLogCollector, inspector: inspector},
+        shape_cache: shape_cache
       ]
 
       per_env_processes =
@@ -52,24 +75,7 @@ defmodule Electric.Application do
             Electric.Telemetry,
             {Registry,
              name: Registry.ShapeChanges, keys: :duplicate, partitions: System.schedulers_online()},
-            {Electric.Replication.ShapeLogCollector, inspector: inspector},
-            {Electric.ConnectionManager,
-             connection_opts: Application.fetch_env!(:electric, :connection_opts),
-             replication_opts: [
-               publication_name: publication_name,
-               try_creating_publication?: true,
-               slot_name: slot_name,
-               transaction_received:
-                 {Electric.Replication.ShapeLogCollector, :store_transaction, []},
-               relation_received:
-                 {Electric.Replication.ShapeLogCollector, :handle_relation_msg, []}
-             ],
-             pool_opts: [
-               name: Electric.DbPool,
-               pool_size: Application.fetch_env!(:electric, :db_pool_size),
-               types: PgInterop.Postgrex.Types
-             ]},
-            shape_cache,
+            {Electric.ConnectionManager, connection_manager_opts},
             {Electric.Postgres.Inspector.EtsInspector, pool: Electric.DbPool},
             {Bandit,
              plug:

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -57,8 +57,7 @@ defmodule Electric.Application do
           try_creating_publication?: true,
           slot_name: slot_name,
           transaction_received: {Electric.Replication.ShapeLogCollector, :store_transaction, []},
-          relation_received:
-            {Electric.ShapeCache, :handle_relation_msg, [[server: Electric.ShapeCache]]}
+          relation_received: {Electric.Replication.ShapeLogCollector, :handle_relation_msg, []}
         ],
         pool_opts: [
           name: Electric.DbPool,

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -223,7 +223,7 @@ defmodule Electric.ConnectionManager do
          state,
          mode
        ) do
-    handle_connection_error(error, state)
+    handle_connection_error(error, state, mode)
   end
 
   defp handle_connection_error(error, state, mode) do

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -99,9 +99,9 @@ defmodule Electric.Postgres.ReplicationClient do
     # Disable the reconnection logic in Postgex.ReplicationConnection to force it to exit with
     # the connection error. Without this, we may observe undesirable restarts in tests between
     # one test process exiting and the next one starting.
-    connection_opts = [auto_reconnect: false] ++ connection_opts
+    connect_opts = [auto_reconnect: false] ++ connection_opts
 
-    case Postgrex.ReplicationConnection.start_link(__MODULE__, replication_opts, connection_opts) do
+    case Postgrex.ReplicationConnection.start_link(__MODULE__, replication_opts, connect_opts) do
       {:ok, pid} ->
         if is_pid(connection_manager),
           do: GenServer.cast(connection_manager, {:connection_opts, pid, connection_opts})

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -77,18 +77,56 @@ defmodule Electric.Postgres.ReplicationClient do
     end
   end
 
+  def child_spec(opts) do
+    connection_opts = Keyword.fetch!(opts, :connection_opts)
+    replication_opts = Keyword.fetch!(opts, :replication_opts)
+    connection_manager = Keyword.fetch!(opts, :connection_manager)
+
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [connection_opts, replication_opts, connection_manager]},
+      restart: :permanent
+    }
+  end
+
   # @type state :: State.t()
 
   @repl_msg_x_log_data ?w
   @repl_msg_primary_keepalive ?k
   @repl_msg_standby_status_update ?r
 
-  def start_link(connection_opts, replication_opts) do
+  def start_link(connection_opts, replication_opts, connection_manager \\ nil) do
     # Disable the reconnection logic in Postgex.ReplicationConnection to force it to exit with
     # the connection error. Without this, we may observe undesirable restarts in tests between
     # one test process exiting and the next one starting.
     connection_opts = [auto_reconnect: false] ++ connection_opts
-    Postgrex.ReplicationConnection.start_link(__MODULE__, replication_opts, connection_opts)
+
+    case Postgrex.ReplicationConnection.start_link(__MODULE__, replication_opts, connection_opts) do
+      {:ok, pid} ->
+        if is_pid(connection_manager),
+          do: GenServer.cast(connection_manager, {:connection_opts, pid, connection_opts})
+
+        {:ok, pid}
+
+      {:error, %Postgrex.Error{message: "ssl not available"}} = error ->
+        if connection_opts[:sslmode] == :require do
+          error
+        else
+          if connection_opts[:sslmode] do
+            # Only log a warning when there's an explicit sslmode parameter in the database
+            # config, meaning the user has requested a certain sslmode.
+            Logger.warning(
+              "Failed to connect to the database using SSL. Trying again, using an unencrypted connection."
+            )
+          end
+
+          connection_opts = Keyword.put(connection_opts, :ssl, false)
+          start_link(connection_opts, replication_opts, connection_manager)
+        end
+
+      error ->
+        error
+    end
   end
 
   def start_streaming(client) do
@@ -96,7 +134,7 @@ defmodule Electric.Postgres.ReplicationClient do
   end
 
   # The `Postgrex.ReplicationConnection` behaviour does not adhere to gen server conventions and
-  # establishes its own. Unless the `sync_connet: false` option is passed to `start_link()`, the
+  # establishes its own. Unless the `sync_connect: false` option is passed to `start_link()`, the
   # connection process will try opening a replication connection to Postgres before returning
   # from its `init()` callback.
   #
@@ -179,6 +217,13 @@ defmodule Electric.Postgres.ReplicationClient do
 
         {m, f, args} = state.transaction_received
 
+        # this will block until all the consumers have processed the transaction because
+        # the log collector uses manual demand, and only replies to the `call` once it
+        # receives more demand.
+        # The timeout for any call here is important. Different storage
+        # backends will require different timeouts and the timeout will need to
+        # accomodate varying number of shape consumers. The default of 5_000 ms
+        # should work for our file-based storage backends, for now.
         case apply(m, f, [txn | args]) do
           :ok ->
             # We currently process incoming replication messages sequentially, persisting each

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -63,7 +63,6 @@ defmodule Electric.Replication.ShapeLogCollector do
     {:noreply, [], %{state | producer: nil}}
   end
 
-  # GenStage.cancel/3
   def handle_cancel({:cancel, _}, from, state) do
     {:noreply, [], remove_subscription(from, state)}
   end

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -30,6 +30,13 @@ defmodule Electric.Replication.ShapeLogCollector do
     end
   end
 
+  # use `GenStage.call/2` here to make the event processing synchronous.
+  #
+  # Because `Electric.Shapes.Dispatcher` only sends demand to this producer
+  # when all consumers have processed the last event, we can save the `from`
+  # clause in the matching `handle_call/3` function and then use
+  # `GenServer.reply/2` in the `demand/2` callback to inform the replication
+  # client that the replication message has been processed.
   def store_transaction(%Transaction{} = txn, server \\ __MODULE__) do
     GenStage.call(server, {:new_txn, txn})
   end

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -109,7 +109,7 @@ defmodule Electric.Replication.ShapeLogCollector do
     Logger.info("Received Relation #{inspect(rel.schema)}.#{inspect(rel.table)}")
     Logger.debug(fn -> "Relation received: #{inspect(rel)}" end)
 
-    {:noreply, [{:relation, rel}], %{state | producer: from}}
+    {:noreply, [rel], %{state | producer: from}}
   end
 
   # If no-one is listening to the replication stream, then just return without
@@ -138,7 +138,7 @@ defmodule Electric.Replication.ShapeLogCollector do
 
     # we don't reply to this call. we only reply when we receive demand from
     # the consumers, signifying that every one has processed this txn
-    {:noreply, [{:transaction, txn}], %{state | producer: from}}
+    {:noreply, [txn], %{state | producer: from}}
   end
 
   defp remove_subscription(from, %{subscriptions: {count, set}} = state) do

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -7,7 +7,7 @@ defmodule Electric.Replication.ShapeLogCollector do
 
   alias Electric.Postgres.Inspector
   alias Electric.Replication.Changes
-  alias Electric.Replication.Changes.{Transaction, Relation}
+  alias Electric.Replication.Changes.Transaction
 
   require Logger
 
@@ -17,7 +17,9 @@ defmodule Electric.Replication.ShapeLogCollector do
               type: @genserver_name_schema,
               default: __MODULE__
             ],
-            inspector: [type: :mod_arg, required: true]
+            inspector: [type: :mod_arg, required: true],
+            # see https://hexdocs.pm/gen_stage/GenStage.html#c:init/1-options
+            demand: [type: {:in, [:forward, :accumulate]}, default: :accumulate]
           )
 
   def start_link(opts) do
@@ -30,26 +32,82 @@ defmodule Electric.Replication.ShapeLogCollector do
     GenStage.call(server, {:new_txn, txn})
   end
 
-  def handle_relation_msg(%Relation{} = rel, server \\ __MODULE__) do
-    GenStage.call(server, {:relation_msg, rel})
-  end
-
   def init(opts) do
-    {:producer, opts, dispatcher: GenStage.BroadcastDispatcher}
+    state = Map.merge(opts, %{producer: nil, subscriptions: {0, MapSet.new()}})
+    # start in demand: :accumulate mode so that the ShapeCache is able to start
+    # all active consumers before we start sending transactions
+    {:producer, state, dispatcher: GenStage.BroadcastDispatcher, demand: opts.demand}
   end
 
-  def handle_demand(_demand, state) do
+  def handle_subscribe(:consumer, _opts, from, state) do
+    {
+      :automatic,
+      Map.update!(state, :subscriptions, fn {count, set} ->
+        {count + 1, MapSet.put(set, from)}
+      end)
+      |> log_subscription_status()
+    }
+  end
+
+  # initial subscription before any transactions have been sent
+  def handle_demand(_demand, %{producer: nil} = state) do
     {:noreply, [], state}
   end
 
-  def handle_call({:relation_msg, rel}, _from, state) do
-    {:reply, :ok, [rel], state}
+  # The BroadcastDispatcher only sends demand when all the consumers have
+  # demand, so if we are receiving demand then all consumers have processed the
+  # last transaction and we can reply to the call and unblock the replication
+  # client.
+  def handle_demand(_demand, %{producer: producer} = state) do
+    GenServer.reply(producer, :ok)
+    {:noreply, [], %{state | producer: nil}}
   end
 
-  def handle_call({:new_txn, %Transaction{xid: xid, lsn: lsn} = txn}, _from, state) do
+  # GenStage.cancel/3
+  def handle_cancel({:cancel, _}, from, state) do
+    {:noreply, [], remove_subscription(from, state)}
+  end
+
+  def handle_cancel({:down, reason}, from, state) do
+    # See: https://hexdocs.pm/elixir/Supervisor.html#module-exit-reasons-and-restarts
+    # If the consumer's shutdown is unexpected, due to some error, then exit with
+    # this error and let the supervisor bring us back up.
+    state = remove_subscription(from, state)
+
+    case reason do
+      {:shutdown, _} ->
+        {:noreply, [], state}
+
+      :shutdown ->
+        {:noreply, [], state}
+
+      :normal ->
+        {:noreply, [], state}
+
+      error ->
+        Logger.warning("Terminating LogCollector due to error from consumer: #{inspect(error)}")
+        {:stop, {:error, error}, state}
+    end
+  end
+
+  def handle_call({:new_txn, %Transaction{xid: xid, lsn: lsn} = txn}, from, state) do
     Logger.info("Received transaction #{xid} from Postgres at #{lsn}")
     Logger.debug(fn -> "Txn received: #{inspect(txn)}" end)
+    handle_transaction(txn, from, state)
+  end
 
+  # If no-one is listening to the replication stream, then just return without
+  # emitting the transaction.
+  # We could emit the transaction and let GenStage buffer it, but I don't think
+  # this is necessary. We do definitely need to reply though, because without
+  # any consumers we'll never get the demand message from the dispatcher that
+  # will prompt the `GenServer.reply/2` call.
+  defp handle_transaction(txn, _from, %{subscriptions: {0, _}} = state) do
+    Logger.debug(fn -> "Dropping transaction #{txn.xid}: no active consumers" end)
+    {:reply, :ok, [], state}
+  end
+
+  defp handle_transaction(txn, from, state) do
     pk_cols_of_relations =
       for relation <- txn.affected_relations, into: %{} do
         {:ok, info} = Inspector.load_column_info(relation, state.inspector)
@@ -62,6 +120,31 @@ defmodule Electric.Replication.ShapeLogCollector do
         Enum.map(changes, &Changes.fill_key(&1, pk_cols_of_relations[&1.relation]))
       end)
 
-    {:reply, :ok, [txn], state}
+    # we don't reply to this call. we only reply when we receive demand from
+    # the consumers, signifying that every one has processed this txn
+    {:noreply, [txn], %{state | producer: from}}
+  end
+
+  defp remove_subscription(from, %{subscriptions: {count, set}} = state) do
+    subscriptions =
+      if MapSet.member?(set, from) do
+        {count - 1, MapSet.delete(set, from)}
+      else
+        Logger.error(
+          "Received unsubscribe from unknown consumer: #{inspect(from)}; known: #{inspect(set)}"
+        )
+
+        {count, set}
+      end
+
+    log_subscription_status(%{state | subscriptions: subscriptions})
+  end
+
+  defp log_subscription_status(%{subscriptions: {active, _set}} = state) do
+    Logger.debug(fn ->
+      "#{active} consumers of replication stream"
+    end)
+
+    state
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -280,7 +280,7 @@ defmodule Electric.ShapeCache do
         {:reply, {:error, :unknown}, state}
 
       shape_status.snapshot_xmin?(state.persistent_state, shape_id) ->
-        {:reply, :started, [], state}
+        {:reply, :started, state}
 
       true ->
         Logger.debug("Starting a wait on the snapshot #{shape_id} for #{inspect(from)}}")

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -199,7 +199,9 @@ defmodule Electric.ShapeCache do
 
     recover_shapes(state)
 
-    send(self(), :start_log_producer)
+    # do this after finishing this function so that we're subscribed to the
+    # producer before it starts forwarding its demand
+    send(self(), :consumers_ready)
 
     {:consumer, state,
      subscribe_to: [
@@ -208,7 +210,7 @@ defmodule Electric.ShapeCache do
   end
 
   @impl GenStage
-  def handle_info(:start_log_producer, state) do
+  def handle_info(:consumers_ready, state) do
     :ok = GenStage.demand(state.log_producer, :forward)
     {:noreply, [], state}
   end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -201,7 +201,10 @@ defmodule Electric.ShapeCache do
 
     send(self(), :start_log_producer)
 
-    {:consumer, state, subscribe_to: [{opts.log_producer, max_demand: 1, partition: :relation}]}
+    {:consumer, state,
+     subscribe_to: [
+       {opts.log_producer, max_demand: 1, selector: &is_struct(&1, Changes.Relation)}
+     ]}
   end
 
   @impl GenStage

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -70,7 +70,7 @@ defmodule Electric.ShapeCache do
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
               type: {:fun, 5},
-              default: &Shapes.Snapshotter.query_in_readonly_txn/5
+              default: &Shapes.Consumer.Snapshotter.query_in_readonly_txn/5
             ]
           )
 

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -8,8 +8,8 @@ defmodule Electric.ShapeCache.ShapeStatusBehaviour do
   alias Electric.Replication.Changes.Relation
   alias Electric.Replication.LogOffset
 
-  @type shape_id() :: Electric.ShapeCache.shape_id()
-  @type xmin() :: Electric.ShapeCache.xmin()
+  @type shape_id() :: Electric.ShapeCacheBehaviour.shape_id()
+  @type xmin() :: Electric.ShapeCacheBehaviour.xmin()
 
   @callback initialise(ShapeStatus.options()) :: {:ok, ShapeStatus.t()} | {:error, term()}
   @callback list_shapes(ShapeStatus.t()) :: [{shape_id(), Shape.t()}]
@@ -56,8 +56,8 @@ defmodule Electric.ShapeCache.ShapeStatus do
 
   defstruct [:persistent_kv, :root, :shape_meta_table]
 
-  @type shape_id() :: Electric.ShapeCache.shape_id()
-  @type xmin() :: Electric.ShapeCache.xmin()
+  @type shape_id() :: Electric.ShapeCacheBehaviour.shape_id()
+  @type xmin() :: Electric.ShapeCacheBehaviour.xmin()
   @type table() :: atom() | reference()
   @type t() :: %__MODULE__{
           persistent_kv: PersistentKV.t(),

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -13,7 +13,7 @@ defmodule Electric.ShapeCache.ShapeStatusBehaviour do
 
   @callback initialise(ShapeStatus.options()) :: {:ok, ShapeStatus.t()} | {:error, term()}
   @callback list_shapes(ShapeStatus.t()) :: [{shape_id(), Shape.t()}]
-  @callback existing_shape(ShapeStatus.t(), Shape.t() | shape_id()) ::
+  @callback get_existing_shape(ShapeStatus.t(), Shape.t() | shape_id()) ::
               {shape_id(), LogOffset.t()} | nil
   @callback add_shape(ShapeStatus.t(), Shape.t()) ::
               {:ok, shape_id()} | {:error, term()}
@@ -160,13 +160,13 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
-  @spec existing_shape(t(), shape_id() | Shape.t()) :: nil | {shape_id(), LogOffset.t()}
-  def existing_shape(%__MODULE__{shape_meta_table: table}, shape_or_id) do
-    existing_shape(table, shape_or_id)
+  @spec get_existing_shape(t(), shape_id() | Shape.t()) :: nil | {shape_id(), LogOffset.t()}
+  def get_existing_shape(%__MODULE__{shape_meta_table: table}, shape_or_id) do
+    get_existing_shape(table, shape_or_id)
   end
 
-  @spec existing_shape(table(), Shape.t()) :: nil | {shape_id(), LogOffset.t()}
-  def existing_shape(meta_table, %Shape{} = shape) do
+  @spec get_existing_shape(table(), Shape.t()) :: nil | {shape_id(), LogOffset.t()}
+  def get_existing_shape(meta_table, %Shape{} = shape) do
     hash = Shape.hash(shape)
 
     case :ets.select(meta_table, [{{{@shape_hash_lookup, hash}, :"$1"}, [true], [:"$1"]}]) do
@@ -178,8 +178,8 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
-  @spec existing_shape(table(), shape_id()) :: nil | {shape_id(), LogOffset.t()}
-  def existing_shape(meta_table, shape_id) when is_binary(shape_id) do
+  @spec get_existing_shape(table(), shape_id()) :: nil | {shape_id(), LogOffset.t()}
+  def get_existing_shape(meta_table, shape_id) when is_binary(shape_id) do
     case :ets.lookup(meta_table, {@shape_meta_data, shape_id}) do
       [] -> nil
       [{_, _shape, _xmin, offset}] -> {shape_id, offset}

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -5,7 +5,7 @@ defmodule Electric.ShapeCache.Storage do
   alias Electric.Shapes.Shape
   alias Electric.Replication.LogOffset
 
-  @type shape_id :: String.t()
+  @type shape_id :: Electric.ShapeCacheBehaviour.shape_id()
   @type compiled_opts :: term()
   @type storage :: {module(), compiled_opts()}
 

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -30,8 +30,10 @@ defmodule Electric.Shapes do
     max_offset = Access.get(opts, :up_to, LogOffset.last())
     storage = shape_storage(config, shape_id)
 
-    with true <- shape_cache.has_shape?(shape_id, shape_cache_opts) do
+    if shape_cache.has_shape?(shape_id, shape_cache_opts) do
       Storage.get_log_stream(shape_id, offset, max_offset, storage)
+    else
+      raise "Unknown shape: #{shape_id}"
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -76,7 +76,7 @@ defmodule Electric.Shapes.Consumer do
         monitors: []
       })
 
-    {:consumer, state, subscribe_to: [{producer, [max_demand: 1, partition: :transaction]}]}
+    {:consumer, state, subscribe_to: [{producer, [max_demand: 1, selector: nil]}]}
   end
 
   def handle_call(:initial_state, _from, %{snapshot_xmin: xmin, latest_offset: offset} = state) do

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -1,4 +1,4 @@
-defmodule Electric.Shapes.Snapshotter do
+defmodule Electric.Shapes.Consumer.Snapshotter do
   use GenServer, restart: :temporary
 
   alias Electric.ShapeCache.Storage

--- a/packages/sync-service/lib/electric/shapes/consumer/supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/supervisor.ex
@@ -1,4 +1,4 @@
-defmodule Electric.Shapes.ShapeSupervisor do
+defmodule Electric.Shapes.Consumer.Supervisor do
   use Supervisor, restart: :transient
 
   require Logger
@@ -16,7 +16,7 @@ defmodule Electric.Shapes.ShapeSupervisor do
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
               type: {:fun, 5},
-              default: &Electric.Shapes.Snapshotter.query_in_readonly_txn/5
+              default: &Electric.Shapes.Consumer.Snapshotter.query_in_readonly_txn/5
             ]
           )
 
@@ -46,7 +46,7 @@ defmodule Electric.Shapes.ShapeSupervisor do
     children = [
       {Electric.ShapeCache.Storage, shape_storage},
       {Electric.Shapes.Consumer, shape_config},
-      {Electric.Shapes.Snapshotter, shape_config}
+      {Electric.Shapes.Consumer.Snapshotter, shape_config}
     ]
 
     Supervisor.init(children, strategy: :one_for_one, auto_shutdown: :any_significant)

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -1,4 +1,4 @@
-defmodule Electric.ShapeCache.ShapeSupervisor do
+defmodule Electric.Shapes.ConsumerSupervisor do
   @moduledoc """
   Responsible for managing shape consumer processes
   """
@@ -13,12 +13,12 @@ defmodule Electric.ShapeCache.ShapeSupervisor do
   def start_shape_consumer(config) do
     DynamicSupervisor.start_child(
       @name,
-      {Electric.Shapes.Supervisor, config}
+      {Electric.Shapes.ShapeSupervisor, config}
     )
   end
 
   def stop_shape_consumer(shape_id) do
-    case GenServer.whereis(Electric.Shapes.Supervisor.name(shape_id)) do
+    case GenServer.whereis(Electric.Shapes.ShapeSupervisor.name(shape_id)) do
       nil ->
         {:error, "no consumer for shape id #{inspect(shape_id)}"}
 

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -4,6 +4,8 @@ defmodule Electric.Shapes.ConsumerSupervisor do
   """
   use DynamicSupervisor
 
+  alias Electric.Shapes.Consumer
+
   require Logger
 
   @name Electric.Application.process_name(__MODULE__)
@@ -23,14 +25,11 @@ defmodule Electric.Shapes.ConsumerSupervisor do
   def start_shape_consumer(name \\ @name, config) do
     Logger.debug(fn -> "Starting consumer for #{Access.fetch!(config, :shape_id)}" end)
 
-    DynamicSupervisor.start_child(
-      name,
-      {Electric.Shapes.ShapeSupervisor, config}
-    )
+    DynamicSupervisor.start_child(name, {Consumer.Supervisor, config})
   end
 
   def stop_shape_consumer(name \\ @name, shape_id) do
-    case GenServer.whereis(Electric.Shapes.ShapeSupervisor.name(shape_id)) do
+    case GenServer.whereis(Consumer.Supervisor.name(shape_id)) do
       nil ->
         {:error, "no consumer for shape id #{inspect(shape_id)}"}
 

--- a/packages/sync-service/lib/electric/shapes/dispatcher.ex
+++ b/packages/sync-service/lib/electric/shapes/dispatcher.ex
@@ -1,0 +1,138 @@
+defmodule Electric.Shapes.Dispatcher do
+  @moduledoc """
+  Dispatches transactions and relations to consumers
+
+  Has two kinds of subscribers:
+
+  - shape consumers which receive both transaction and relation/metadata
+    messages
+  - shape cache consumers which only receive metadata messages
+
+
+  The essential behaviour is that the dispatcher only asks the producer for
+  more demand once all relevant subscribers have processed the last message and
+  asked for the next.
+
+  Demand is always `1` -- consumers should only ever ask for a single message
+  from the producer, the dispatcher should only ever send 1 message from the
+  producer.
+  """
+
+  require Logger
+
+  @behaviour GenStage.Dispatcher
+
+  @impl GenStage.Dispatcher
+  def init(_opts) do
+    {:ok, {0, 0, nil, %{}, %{}}}
+  end
+
+  @impl GenStage.Dispatcher
+  def subscribe(opts, {pid, _ref} = from, {n, count, pending, subs, pids}) do
+    if Map.has_key?(pids, pid) do
+      Logger.error(fn ->
+        "#{inspect(pid)} is already registered with #{inspect(self())}. " <>
+          "This subscription has been discarded."
+      end)
+
+      {:error, :already_subscribed}
+    else
+      case Keyword.fetch(opts, :partition) do
+        {:ok, partition} when partition in [:transaction, :relation] ->
+          partitions =
+            case partition do
+              :transaction -> [:transaction, :relation]
+              :relation -> [:relation]
+            end
+
+          subs =
+            Enum.reduce(partitions, subs, fn partition, subs ->
+              Map.update(subs, partition, [from], &[from | &1])
+            end)
+
+          demand = if n == 0, do: 1, else: 0
+
+          {:ok, demand, {n + 1, count, pending, subs, Map.put(pids, pid, partitions)}}
+
+        {:ok, unknown_partition} ->
+          Logger.error(fn ->
+            ":partition should be one of [:relation, :all], got: #{inspect(unknown_partition)}"
+          end)
+
+          {:error, :invalid_partition}
+
+        :error ->
+          {:error, :missing_partition}
+      end
+    end
+  end
+
+  @impl GenStage.Dispatcher
+  def cancel({pid, _ref} = from, {n, count, pending, subs, pids}) do
+    if partitions = Map.get(pids, pid, nil) do
+      subs =
+        Enum.reduce(partitions, subs, fn partition, subs ->
+          Map.update!(subs, partition, &List.delete(&1, from))
+        end)
+
+      if pending && MapSet.member?(pending, from) do
+        case count - 1 do
+          0 ->
+            {:ok, 1, {n - 1, 0, nil, subs, Map.delete(pids, pid)}}
+
+          new_count ->
+            {:ok, 0,
+             {n - 1, new_count, MapSet.delete(pending, from), subs, Map.delete(pids, pid)}}
+        end
+      else
+        {:ok, 0, {n - 1, count, pending, subs, Map.delete(pids, pid)}}
+      end
+    else
+      {:ok, 0, {n, count, pending, subs, pids}}
+    end
+  end
+
+  @impl GenStage.Dispatcher
+  # consumers sending demand before we have produced a message just ignore as
+  # we have already sent initial demand of 1 to the producer when the first
+  # consumer subscribed.
+  def ask(1, {_pid, _ref}, {n, 0, nil, subs, pids}) do
+    {:ok, 0, {n, 0, nil, subs, pids}}
+  end
+
+  def ask(1, {_pid, _ref}, {n, 1, _pending, subs, pids}) do
+    {:ok, 1, {n, 0, nil, subs, pids}}
+  end
+
+  def ask(1, from, {n, count, pending, subs, pids}) when count > 1 do
+    {:ok, 0, {n, count - 1, MapSet.delete(pending, from), subs, pids}}
+  end
+
+  @impl GenStage.Dispatcher
+  def dispatch([{partition, event}], _length, {n, 0, _pending, subs, pids})
+      when partition in [:transaction, :relation] do
+    subscriptions = Map.get(subs, partition, [])
+
+    {count, pending} =
+      subscriptions
+      |> Enum.reduce({0, MapSet.new()}, fn {pid, ref} = sub, {count, pending} ->
+        Process.send(pid, {:"$gen_consumer", {self(), ref}, [event]}, [:noconnect])
+        {count + 1, MapSet.put(pending, sub)}
+      end)
+      |> case do
+        {0, _pending} ->
+          {0, nil}
+
+        {count, pending} ->
+          {count, pending}
+      end
+
+    {:ok, [], {n, count, pending, subs, pids}}
+  end
+
+  @impl GenStage.Dispatcher
+  def info(msg, state) do
+    send(self(), msg)
+    {:ok, state}
+  end
+end

--- a/packages/sync-service/lib/electric/shapes/shape_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/shape_supervisor.ex
@@ -1,4 +1,4 @@
-defmodule Electric.Shapes.Supervisor do
+defmodule Electric.Shapes.ShapeSupervisor do
   use Supervisor, restart: :transient
 
   require Logger

--- a/packages/sync-service/lib/electric/shapes/shape_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/shape_supervisor.ex
@@ -43,12 +43,11 @@ defmodule Electric.Shapes.ShapeSupervisor do
 
     shape_config = %{config | storage: shape_storage}
 
-    children =
-      [
-        {Electric.ShapeCache.Storage, shape_storage},
-        {Electric.Shapes.Consumer, shape_config},
-        {Electric.Shapes.Snapshotter, shape_config}
-      ]
+    children = [
+      {Electric.ShapeCache.Storage, shape_storage},
+      {Electric.Shapes.Consumer, shape_config},
+      {Electric.Shapes.Snapshotter, shape_config}
+    ]
 
     Supervisor.init(children, strategy: :one_for_one, auto_shutdown: :any_significant)
   end

--- a/packages/sync-service/lib/electric/shapes/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/snapshotter.ex
@@ -29,9 +29,7 @@ defmodule Electric.Shapes.Snapshotter do
   def handle_continue(:start_snapshot, state) do
     %{shape_id: shape_id, shape: shape} = state
 
-    consumer = Shapes.Consumer.name(shape_id)
-
-    case GenServer.whereis(consumer) do
+    case Shapes.Consumer.whereis(shape_id) do
       parent when is_pid(parent) ->
         if not Storage.snapshot_started?(state.shape_id, state.storage) do
           %{

--- a/packages/sync-service/lib/electric/shapes/supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/supervisor.ex
@@ -1,0 +1,31 @@
+defmodule Electric.Shapes.Supervisor do
+  use Supervisor
+
+  require Logger
+
+  def start_link(opts) do
+    name = Access.get(opts, :name, __MODULE__)
+
+    Supervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl Supervisor
+  def init(opts) do
+    Logger.info("Starting shape replication pipeline")
+
+    replication_client = Keyword.fetch!(opts, :replication_client)
+    shape_cache = Keyword.fetch!(opts, :shape_cache)
+    log_collector = Keyword.fetch!(opts, :log_collector)
+
+    consumer_supervisor =
+      Keyword.get(opts, :consumer_supervisor, {Electric.Shapes.ConsumerSupervisor, []})
+
+    children =
+      Enum.reject(
+        [consumer_supervisor, log_collector, shape_cache, replication_client],
+        &is_nil/1
+      )
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+end

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -46,10 +46,12 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       # Start the ShapeLogCollector process
       opts = [
         name: __MODULE__.ShapeLogCollector,
-        inspector: {Mock.Inspector, []}
+        inspector: {Mock.Inspector, []},
+        demand: :forward
       ]
 
       {:ok, pid} = start_supervised({ShapeLogCollector, opts})
+
       parent = self()
 
       consumers =

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -77,61 +77,61 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     assert [{^shape_id_2, ^shape_2}] = ShapeStatus.list_shapes(state)
   end
 
-  test "existing_shape/2 with %Shape{}", ctx do
+  test "get_existing_shape/2 with %Shape{}", ctx do
     {:ok, state, []} = new_state(ctx)
     shape = shape!()
 
-    refute ShapeStatus.existing_shape(state, shape)
+    refute ShapeStatus.get_existing_shape(state, shape)
 
     assert {:ok, shape_id} = ShapeStatus.add_shape(state, shape)
-    assert {^shape_id, _} = ShapeStatus.existing_shape(state, shape)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape)
 
     {:ok, state, []} = new_state(ctx)
-    assert {^shape_id, _} = ShapeStatus.existing_shape(state, shape)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape)
 
     assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_id)
-    refute ShapeStatus.existing_shape(state, shape)
+    refute ShapeStatus.get_existing_shape(state, shape)
   end
 
-  test "existing_shape/2 with shape_id", ctx do
+  test "get_existing_shape/2 with shape_id", ctx do
     shape = shape!()
     {:ok, state, [shape_id]} = new_state(ctx, shapes: [shape])
 
-    refute ShapeStatus.existing_shape(state, "1234")
+    refute ShapeStatus.get_existing_shape(state, "1234")
 
-    assert {^shape_id, _} = ShapeStatus.existing_shape(state, shape)
-    assert {^shape_id, _} = ShapeStatus.existing_shape(state, shape_id)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape_id)
 
     {:ok, state, []} = new_state(ctx)
-    assert {^shape_id, _} = ShapeStatus.existing_shape(state, shape)
-    assert {^shape_id, _} = ShapeStatus.existing_shape(state, shape_id)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape_id)
 
     assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_id)
-    refute ShapeStatus.existing_shape(state, shape)
-    refute ShapeStatus.existing_shape(state, shape_id)
+    refute ShapeStatus.get_existing_shape(state, shape)
+    refute ShapeStatus.get_existing_shape(state, shape_id)
   end
 
-  test "existing_shape/2 public api", ctx do
+  test "get_existing_shape/2 public api", ctx do
     shape = shape!()
     table = table_name()
 
     {:ok, _state, [shape_id]} = new_state(ctx, table: table, shapes: [shape])
 
-    refute ShapeStatus.existing_shape(table, "1234")
+    refute ShapeStatus.get_existing_shape(table, "1234")
 
-    assert {^shape_id, _} = ShapeStatus.existing_shape(table, shape)
-    assert {^shape_id, _} = ShapeStatus.existing_shape(table, shape_id)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(table, shape)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(table, shape_id)
 
     table = table_name()
 
     {:ok, state, []} = new_state(ctx, table: table)
 
-    assert {^shape_id, _} = ShapeStatus.existing_shape(table, shape)
-    assert {^shape_id, _} = ShapeStatus.existing_shape(table, shape_id)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(table, shape)
+    assert {^shape_id, _} = ShapeStatus.get_existing_shape(table, shape_id)
 
     assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_id)
-    refute ShapeStatus.existing_shape(table, shape)
-    refute ShapeStatus.existing_shape(table, shape_id)
+    refute ShapeStatus.get_existing_shape(table, shape)
+    refute ShapeStatus.get_existing_shape(table, shape_id)
   end
 
   test "latest_offset", ctx do

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -1,6 +1,5 @@
 defmodule Electric.ShapeCache.StorageImplimentationsTest do
   use ExUnit.Case, async: true
-  import Support.TestUtils
 
   alias Electric.ShapeCache.FileStorage
   alias Electric.Postgres.Lsn
@@ -9,6 +8,9 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   alias Electric.ShapeCache.InMemoryStorage
   alias Electric.Shapes.Shape
   alias Electric.Utils
+
+  import Support.TestUtils
+
   @moduletag :tmp_dir
 
   @shape_id "the-shape-id"

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -880,7 +880,7 @@ defmodule Electric.ShapeCacheTest do
 
     defp stop_shape_cache(%{storage: {_, _}, shape_cache_opts: shape_cache_opts}) do
       stop_processes([shape_cache_opts[:server]])
-      ShapeCache.ShapeSupervisor.stop_all_consumers()
+      Shapes.ConsumerSupervisor.stop_all_consumers()
     end
 
     defp stop_processes(process_names) do

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -107,7 +107,7 @@ defmodule Electric.Shapes.ConsumerTest do
       consumers =
         for {shape_id, shape} <- ctx.shapes do
           allow(Mock.Storage, self(), fn ->
-            Shapes.ShapeSupervisor.name(shape_id) |> GenServer.whereis()
+            Shapes.Consumer.Supervisor.name(shape_id) |> GenServer.whereis()
           end)
 
           allow(Mock.Storage, self(), fn ->
@@ -115,12 +115,12 @@ defmodule Electric.Shapes.ConsumerTest do
           end)
 
           allow(Mock.Storage, self(), fn ->
-            Shapes.Snapshotter.name(shape_id) |> GenServer.whereis()
+            Shapes.Consumer.Snapshotter.name(shape_id) |> GenServer.whereis()
           end)
 
           {:ok, consumer} =
             start_supervised(
-              {Shapes.ShapeSupervisor,
+              {Shapes.Consumer.Supervisor,
                shape_id: shape_id,
                shape: shape,
                log_producer: producer,
@@ -129,7 +129,7 @@ defmodule Electric.Shapes.ConsumerTest do
                storage: {Mock.Storage, []},
                chunk_bytes_threshold: 10_000,
                prepare_tables_fn: &prepare_tables_fn/2},
-              id: {Shapes.ShapeSupervisor, shape_id}
+              id: {Shapes.Consumer.Supervisor, shape_id}
             )
 
           consumer
@@ -301,9 +301,9 @@ defmodule Electric.Shapes.ConsumerTest do
     defp assert_consumer_shutdown(shape_id, fun) do
       monitors =
         for name <- [
-              Shapes.ShapeSupervisor.name(shape_id),
+              Shapes.Consumer.Supervisor.name(shape_id),
               Shapes.Consumer.name(shape_id),
-              Shapes.Snapshotter.name(shape_id)
+              Shapes.Consumer.Snapshotter.name(shape_id)
             ],
             pid = GenServer.whereis(name) do
           ref = Process.monitor(pid)

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -660,6 +660,7 @@ defmodule Electric.Shapes.ConsumerTest do
           db_pool: ctx.pool,
           persistent_kv: ctx.persistent_kv,
           registry: ctx.registry,
+          inspector: ctx.inspector,
           log_producer: __MODULE__.LogCollector,
           consumer_supervisor: __MODULE__.ConsumerSupervisor,
           prepare_tables_fn: {

--- a/packages/sync-service/test/electric/shapes/dispatcher_test.exs
+++ b/packages/sync-service/test/electric/shapes/dispatcher_test.exs
@@ -1,0 +1,186 @@
+defmodule Electric.Shapes.DispatcherTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Shapes.Dispatcher, as: D
+
+  defp dispatcher(opts \\ []) do
+    {:ok, state} = D.init(opts)
+    state
+  end
+
+  defmodule C do
+    def child_spec({id, a}) do
+      %{
+        id: {__MODULE__, id},
+        start: {Task, :start_link, [__MODULE__, :consume, a]}
+      }
+    end
+
+    def consume(parent, subscription) do
+      receive do
+        {:"$gen_consumer", {producer, ref}, events} ->
+          Process.sleep(Enum.random(10..100))
+          send(producer, {C, ref, events})
+          consume(parent, subscription)
+      end
+    end
+  end
+
+  defp consumer(id) do
+    ref = make_ref()
+    {:ok, pid} = start_supervised({C, {id, [self(), ref]}})
+    {pid, ref}
+  end
+
+  test "demand is only sent to producer once all subscribers have processed the message" do
+    dispatcher = dispatcher()
+
+    c1 = {_pid1, ref1} = consumer(1)
+    c2 = {_pid2, ref2} = consumer(2)
+    c3 = {_pid3, ref3} = consumer(3)
+
+    # we only want to send a single event for any number of consumers
+    {:ok, 1, dispatcher} = D.subscribe([partition: :transaction], c1, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c2, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c3, dispatcher)
+
+    event = make_ref()
+
+    {:ok, [], dispatcher} = D.dispatch([{:transaction, event}], 1, dispatcher)
+
+    assert_receive {C, ^ref1, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
+    assert_receive {C, ^ref2, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c2, dispatcher)
+    assert_receive {C, ^ref3, [^event]}
+    # now that all consumers have received and processed the message we should
+    # forward demand onto the producer
+    assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
+  end
+
+  test "relation subscribers only receive relations" do
+    dispatcher = dispatcher()
+
+    c1 = {_pid1, ref1} = consumer(1)
+    c2 = {_pid2, ref2} = consumer(2)
+    c3 = {_pid3, ref3} = consumer(3)
+
+    {:ok, 1, dispatcher} = D.subscribe([partition: :relation], c1, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c2, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c3, dispatcher)
+
+    event = make_ref()
+
+    {:ok, [], dispatcher} = D.dispatch([{:transaction, event}], 1, dispatcher)
+
+    refute_receive {C, ^ref1, [^event]}
+
+    assert_receive {C, ^ref2, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c2, dispatcher)
+    assert_receive {C, ^ref3, [^event]}
+    assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
+  end
+
+  test "transaction subscribers receive relations and transactions" do
+    dispatcher = dispatcher()
+
+    c1 = {_pid1, ref1} = consumer(1)
+    c2 = {_pid2, ref2} = consumer(2)
+    c3 = {_pid3, ref3} = consumer(3)
+
+    # we only want to send a single event for any number of consumers
+    {:ok, 1, dispatcher} = D.subscribe([partition: :relation], c1, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c2, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c3, dispatcher)
+
+    event = make_ref()
+
+    {:ok, [], dispatcher} = D.dispatch([{:relation, event}], 1, dispatcher)
+
+    assert_receive {C, ^ref1, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
+    assert_receive {C, ^ref2, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c2, dispatcher)
+    assert_receive {C, ^ref3, [^event]}
+    assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
+  end
+
+  test "cancelling an acked consumer does not affect pending acks" do
+    dispatcher = dispatcher()
+
+    c1 = {_pid1, ref1} = consumer(1)
+    c2 = {_pid2, ref2} = consumer(2)
+    c3 = {_pid3, ref3} = consumer(3)
+
+    # we only want to send a single event for any number of consumers
+    {:ok, 1, dispatcher} = D.subscribe([partition: :relation], c1, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c2, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c3, dispatcher)
+
+    event = make_ref()
+
+    {:ok, [], dispatcher} = D.dispatch([{:relation, event}], 1, dispatcher)
+
+    assert_receive {C, ^ref1, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
+
+    {:ok, 0, dispatcher} = D.cancel(c1, dispatcher)
+
+    assert_receive {C, ^ref2, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c2, dispatcher)
+    assert_receive {C, ^ref3, [^event]}
+    assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
+  end
+
+  test "cancelling an unacked consumer decrements pending acks" do
+    dispatcher = dispatcher()
+
+    c1 = {_pid1, ref1} = consumer(1)
+    c2 = {_pid2, ref2} = consumer(2)
+    c3 = {_pid3, ref3} = consumer(3)
+
+    # we only want to send a single event for any number of consumers
+    {:ok, 1, dispatcher} = D.subscribe([partition: :relation], c1, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c2, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c3, dispatcher)
+
+    event = make_ref()
+
+    {:ok, [], dispatcher} = D.dispatch([{:relation, event}], 1, dispatcher)
+
+    {:ok, 0, dispatcher} = D.cancel(c2, dispatcher)
+
+    assert_receive {C, ^ref1, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
+
+    # we've cancelled but haven't killed the pid (and even if we had, it will
+    # have likely already sent the confirmation message)
+    assert_receive {C, ^ref2, [^event]}
+
+    assert_receive {C, ^ref3, [^event]}
+    assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
+  end
+
+  test "cancelling the last unacked consumer generates demand" do
+    dispatcher = dispatcher()
+
+    c1 = {_pid1, ref1} = consumer(1)
+    c2 = {_pid2, _ref2} = consumer(2)
+    c3 = {_pid3, _ref3} = consumer(3)
+
+    # we only want to send a single event for any number of consumers
+    {:ok, 1, dispatcher} = D.subscribe([partition: :relation], c1, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c2, dispatcher)
+    {:ok, 0, dispatcher} = D.subscribe([partition: :transaction], c3, dispatcher)
+
+    event = make_ref()
+
+    {:ok, [], dispatcher} = D.dispatch([{:relation, event}], 1, dispatcher)
+
+    assert_receive {C, ^ref1, [^event]}
+    assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
+
+    {:ok, 0, dispatcher} = D.cancel(c2, dispatcher)
+    {:ok, 1, _dispatcher} = D.cancel(c3, dispatcher)
+  end
+end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -47,7 +47,10 @@ defmodule Support.ComponentSetup do
 
   def with_shape_cache(ctx, additional_opts \\ []) do
     shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
-    server = :"shape_cache_#{full_test_name(ctx)}"
+
+    server =
+      Keyword.get(additional_opts, :name, :"shape_cache_#{full_test_name(ctx)}")
+
     consumer_supervisor = :"consumer_supervisor_#{full_test_name(ctx)}"
 
     start_opts =
@@ -81,6 +84,7 @@ defmodule Support.ComponentSetup do
     %{
       shape_cache_opts: shape_cache_opts,
       shape_cache: {ShapeCache, shape_cache_opts},
+      shape_cache_server: server,
       consumer_supervisor: consumer_supervisor
     }
   end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -48,6 +48,7 @@ defmodule Support.ComponentSetup do
   def with_shape_cache(ctx, additional_opts \\ []) do
     shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
     server = :"shape_cache_#{full_test_name(ctx)}"
+    consumer_supervisor = :"consumer_supervisor_#{full_test_name(ctx)}"
 
     start_opts =
       [
@@ -59,7 +60,8 @@ defmodule Support.ComponentSetup do
         db_pool: ctx.pool,
         persistent_kv: ctx.persistent_kv,
         registry: ctx.registry,
-        log_producer: ctx.shape_log_collector
+        log_producer: ctx.shape_log_collector,
+        consumer_supervisor: consumer_supervisor
       ]
       |> Keyword.merge(additional_opts)
       |> Keyword.put_new_lazy(:prepare_tables_fn, fn ->
@@ -67,6 +69,7 @@ defmodule Support.ComponentSetup do
          [ctx.publication_name]}
       end)
 
+    {:ok, _pid} = Electric.Shapes.ConsumerSupervisor.start_link(name: consumer_supervisor)
     {:ok, _pid} = ShapeCache.start_link(start_opts)
 
     shape_cache_opts = [

--- a/packages/sync-service/test/support/mocks.ex
+++ b/packages/sync-service/test/support/mocks.ex
@@ -2,4 +2,5 @@ defmodule Support.Mock do
   Mox.defmock(Support.Mock.Storage, for: Electric.ShapeCache.Storage)
   Mox.defmock(Support.Mock.ShapeCache, for: Electric.ShapeCacheBehaviour)
   Mox.defmock(Support.Mock.Inspector, for: Electric.Postgres.Inspector)
+  Mox.defmock(Support.Mock.ShapeStatus, for: Electric.ShapeCache.ShapeStatusBehaviour)
 end

--- a/packages/sync-service/test/support/transaction_consumer.ex
+++ b/packages/sync-service/test/support/transaction_consumer.ex
@@ -29,8 +29,9 @@ defmodule Support.TransactionConsumer do
     {:ok, producer} = Keyword.fetch(opts, :producer)
     {:ok, parent} = Keyword.fetch(opts, :parent)
     {:ok, id} = Keyword.fetch(opts, :id)
+    partition = Keyword.get(opts, :partition, :transaction)
 
-    {:consumer, {id, nil, parent}, subscribe_to: [{producer, []}]}
+    {:consumer, {id, nil, parent}, subscribe_to: [{producer, [partition: partition]}]}
   end
 
   def handle_subscribe(:producer, _options, from, {id, _, parent}) do

--- a/packages/sync-service/test/support/transaction_producer.ex
+++ b/packages/sync-service/test/support/transaction_producer.ex
@@ -12,13 +12,13 @@ defmodule Support.TransactionProducer do
     GenStage.start_link(__MODULE__, args, opts)
   end
 
-  def emit(pid, changes) do
-    GenStage.call(pid, {:emit, changes})
+  def emit(pid, [change], partition \\ :transaction) do
+    GenStage.call(pid, {:emit, [{partition, change}]})
   end
 
   @impl true
   def init(_args) do
-    {:producer, [], dispatcher: GenStage.BroadcastDispatcher}
+    {:producer, [], dispatcher: Electric.Shapes.Dispatcher}
   end
 
   @impl true

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -263,7 +263,7 @@ describe(`HTTP Sync`, () => {
         `
       UPDATE ${tableSql}
       SET
-        txt = 'changed',        
+        txt = 'changed',
         i4 = 20,
         i8 = 30,
         f8 = 40.5,

--- a/packages/typescript-client/test/support/global-setup.ts
+++ b/packages/typescript-client/test/support/global-setup.ts
@@ -41,7 +41,7 @@ export default async function ({ provide }: GlobalSetupContext) {
   provide(`proxyCachePath`, proxyCachePath)
 
   return async () => {
-    await client.query(`DROP SCHEMA electric_test`)
+    await client.query(`DROP SCHEMA electric_test CASCADE`)
     await client.end()
   }
 }


### PR DESCRIPTION
Fixes #1585

Firstly this moves the replication client, shape cache, consumer supervisor and log  collector under a supervisor with strategy :one_for_all.               
                                                                       
Then a crashing client triggers the `handle_cancel/3` callback in the log  collector which terminates and causes the entire supervision tree to  restart.

The log collector uses a custom `GenStage.Dispatcher` implementation that enables us to make the  `store_transaction/2` callback to be synchronous: it will only return when all consumers have processed/stored the transaction. This works because demand is only signalled to the producer when all dispatchers who wanted a given event have processed it so we can use the `GenStage.demand/2` callback to reply to the replication client calling into the `ShapeLogCollector` process.

As a side effect, this does make the connection and error handling logic in `ConnectionManager` much more fiddly, which isn't ideal. I'm going to work on a restructure to clean that up with @alco's input.             