### PR TITLE
fix: useShape re-renders on where state change

### DIFF
--- a/.changeset/seven-forks-happen.md
+++ b/.changeset/seven-forks-happen.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/react": patch
+---
+
+add test that useShape re-renders on where state change

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -66,7 +66,6 @@ export interface UseShapeResult {
    * @type(Shape)
    */
   shape: Shape
-  shapeHash: string
   error: Shape[`error`]
   isError: boolean
   /**
@@ -82,13 +81,12 @@ function shapeSubscribe(shape: Shape, callback: () => void) {
   }
 }
 
-function parseShapeData(shape: Shape, shapeHash: string): UseShapeResult {
+function parseShapeData(shape: Shape): UseShapeResult {
   return {
     data: [...shape.valueSync.values()],
     isUpToDate: shape.isUpToDate,
     isError: shape.error !== false,
     shape,
-    shapeHash,
     error: shape.error,
   }
 }
@@ -105,7 +103,6 @@ export function useShape<Selection = UseShapeResult>({
   selector = identity as (arg: UseShapeResult) => Selection,
   ...options
 }: UseShapeOptions<Selection>): Selection {
-  const shapeHash = sortedOptionsHash(options)
   const shapeStream = getShapeStream(options as ShapeStreamOptions)
   const shape = getShape(shapeStream)
 

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -92,6 +92,39 @@ describe(`useShape`, () => {
     )
   })
 
+  it.only(`should let you change the shape definition (and clear the internal cache between)`, async ({
+    aborter,
+    issuesTableUrl,
+    insertIssues,
+  }) => {
+    const [id] = await insertIssues({ title: `test row` })
+    const [id2] = await insertIssues({ title: `test row2` })
+
+    const { result, rerender } = renderHook((options) => useShape(options), {
+      initialProps: {
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        where: `id = '${id}'`,
+        signal: aborter.signal,
+        subscribe: true,
+      },
+    })
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual([{ id: id, title: `test row` }])
+    )
+
+    rerender({
+      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+      where: `id = '${id2}'`,
+      signal: aborter.signal,
+      subscribe: true,
+    })
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual([{ id: id2, title: `test row2` }])
+    )
+  })
+
   it(`should allow use of the "selector" api from useSyncExternalStoreWithSelector`, async ({
     aborter,
     issuesTableUrl,

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -89,7 +89,7 @@ describe(`useShape`, () => {
     )
   })
 
-  it.only(`should let you change the shape definition (and clear the internal cache between)`, async ({
+  it(`should let you change the shape definition (and clear the internal cache between)`, async ({
     aborter,
     issuesTableUrl,
     insertIssues,


### PR DESCRIPTION
The `useShape` hook is behaving strangely when switching between different `where` conditions. I noticed that the `const latestShapeData = useRef(parseShapeData(shape))` was not updating when the underlying `where` parameters changed, while the other values within the useShape hook like `shape`, `shapeStream`, etc. were updating correctly. I propose adding the `shapeHash` in the `UseShapeResult`, as well as as a second argument to `parseShapeData`, so when the `useShape` is rendered we can determine wether we need to reset the `UseShapeResult`/`parseShapeData` reference.

nice work on this project all!