### PR TITLE
chore: remove list_active_shapes

### DIFF
--- a/.changeset/perfect-moons-end.md
+++ b/.changeset/perfect-moons-end.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Remove list_active_shapes and replace it by list_shapes.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -233,7 +233,7 @@ defmodule Electric.ShapeCache do
 
         # Fetch all shapes that are affected by the relation change and clean them up
         persistent_state
-        |> ShapeStatus.list_shapes()
+        |> shape_status.list_shapes()
         |> Enum.filter(&Shape.is_affected_by_relation_change?(&1, change))
         |> Enum.map(&elem(&1, 0))
         |> Enum.each(fn shape_id -> clean_up_shape(state, shape_id) end)

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -16,8 +16,8 @@ defmodule Electric.ShapeCacheBehaviour do
   @callback get_or_create_shape_id(shape_def(), opts :: keyword()) ::
               {shape_id(), current_snapshot_offset :: LogOffset.t()}
 
-  @callback list_active_shapes(opts :: keyword()) :: [{shape_id(), shape_def(), xmin()}]
   @callback get_relation(Messages.relation_id(), opts :: keyword()) :: Changes.Relation.t() | nil
+  @callback list_shapes(Electric.ShapeCache.ShapeStatus.t()) :: [{shape_id(), Shape.t()}]
   @callback await_snapshot_start(shape_id(), opts :: keyword()) :: :started | {:error, term()}
   @callback handle_truncate(shape_id(), keyword()) :: :ok
   @callback clean_shape(shape_id(), keyword()) :: :ok
@@ -111,11 +111,10 @@ defmodule Electric.ShapeCache do
   end
 
   @impl Electric.ShapeCacheBehaviour
-  def list_active_shapes(opts \\ []) do
-    table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+  @spec list_shapes(Electric.ShapeCache.ShapeStatus.t()) :: [{shape_id(), Shape.t()}]
+  def list_shapes(opts) do
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
-
-    shape_status.list_active_shapes(table)
+    shape_status.list_shapes(opts)
   end
 
   @impl Electric.ShapeCacheBehaviour
@@ -172,7 +171,7 @@ defmodule Electric.ShapeCache do
     {:ok, persistent_state} =
       opts.shape_status.initialise(
         persistent_kv: opts.persistent_kv,
-        meta_table: opts.shape_meta_table
+        shape_meta_table: opts.shape_meta_table
       )
 
     state = %{
@@ -234,7 +233,7 @@ defmodule Electric.ShapeCache do
 
         # Fetch all shapes that are affected by the relation change and clean them up
         persistent_state
-        |> shape_status.list_active_shapes()
+        |> ShapeStatus.list_shapes()
         |> Enum.filter(&Shape.is_affected_by_relation_change?(&1, change))
         |> Enum.map(&elem(&1, 0))
         |> Enum.each(fn shape_id -> clean_up_shape(state, shape_id) end)

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -9,9 +9,6 @@ defmodule Electric.ShapeCache.ShapeStatusBehaviour do
 
   @callback initialise(ShapeStatus.options()) :: {:ok, ShapeStatus.t()} | {:error, term()}
   @callback list_shapes(ShapeStatus.t()) :: [{ShapeStatus.shape_id(), Shape.t()}]
-  @callback list_active_shapes(opts :: keyword()) :: [
-              {ShapeStatus.shape_id(), ShapeStatus.shape_def(), ShapeStatus.xmin()}
-            ]
   @callback get_relation(ShapeStatus.t(), Messages.relation_id()) :: Relation.t() | nil
   @callback store_relation(ShapeStatus.t(), Relation.t()) :: :ok
   @callback remove_shape(ShapeStatus.t(), ShapeStatus.shape_id()) ::

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -183,7 +183,7 @@ defmodule Electric.Shapes.Shape do
     shape_matches?(shape, schema, table)
   end
 
-  defp shape_matches?({_, %__MODULE__{root_table: {schema, table}}, _}, schema, table), do: true
+  defp shape_matches?({_, %__MODULE__{root_table: {schema, table}}}, schema, table), do: true
   defp shape_matches?(_, _, _), do: false
 
   @spec from_json_safe!(t()) :: json_safe()

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -30,7 +30,7 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
   defp new_state(ctx, opts \\ []) do
     table = Keyword.get(opts, :table, table_name())
 
-    {:ok, state} = ShapeStatus.initialise(persistent_kv: ctx.kv, meta_table: table)
+    {:ok, state} = ShapeStatus.initialise(persistent_kv: ctx.kv, shape_meta_table: table)
 
     shapes = Keyword.get(opts, :shapes, [])
 
@@ -182,11 +182,11 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     refute ShapeStatus.set_snapshot_xmin(state, "sdfsodf", 1234)
 
     refute ShapeStatus.snapshot_xmin?(state, "sdfsodf")
-    refute ShapeStatus.snapshot_xmin?(state.meta_table, "sdfsodf")
+    refute ShapeStatus.snapshot_xmin?(state.shape_meta_table, "sdfsodf")
     refute ShapeStatus.snapshot_xmin?(state, shape_id)
     assert ShapeStatus.set_snapshot_xmin(state, shape_id, 1234)
     assert ShapeStatus.snapshot_xmin?(state, shape_id)
-    assert ShapeStatus.snapshot_xmin?(state.meta_table, shape_id)
+    assert ShapeStatus.snapshot_xmin?(state.shape_meta_table, shape_id)
   end
 
   test "relation data", ctx do

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -11,7 +11,7 @@ defmodule Electric.ShapeCacheTest do
   alias Electric.Replication.Changes.{Relation, Column}
   alias Electric.Replication.LogOffset
   alias Electric.ShapeCache
-  alias Electric.ShapeCache.Storage
+  alias Electric.ShapeCache.{Storage, ShapeStatus}
   alias Electric.Shapes
   alias Electric.Shapes.Shape
 
@@ -366,7 +366,7 @@ defmodule Electric.ShapeCacheTest do
     end
   end
 
-  describe "list_active_shapes/1" do
+  describe "list_shapes/1" do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
@@ -380,7 +380,9 @@ defmodule Electric.ShapeCacheTest do
           prepare_tables_fn: @prepare_tables_noop
         )
 
-      assert ShapeCache.list_active_shapes(opts) == []
+      meta_table = Keyword.fetch!(opts, :shape_meta_table)
+
+      assert ShapeCache.list_shapes(%{shape_meta_table: meta_table}) == []
     end
 
     test "lists the shape as active once there is a snapshot", ctx do
@@ -399,7 +401,7 @@ defmodule Electric.ShapeCacheTest do
       assert [{^shape_id, @shape, 10}] = ShapeCache.list_active_shapes(opts)
     end
 
-    test "doesn't list the shape as active until we know xmin", ctx do
+    test "lists the shape even if we don't know xmin", ctx do
       test_pid = self()
 
       %{shape_cache_opts: opts} =
@@ -420,12 +422,13 @@ defmodule Electric.ShapeCacheTest do
       # Wait until we get to the waiting point in the snapshot
       assert_receive {:waiting_point, ref, pid}
 
-      assert ShapeCache.list_active_shapes(opts) == []
+      meta_table = Keyword.fetch!(opts, :shape_meta_table)
+      assert [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
 
       send(pid, {:continue, ref})
 
       assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
-      assert [{^shape_id, @shape, 10}] = ShapeCache.list_active_shapes(opts)
+      assert [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
     end
   end
 
@@ -784,12 +787,15 @@ defmodule Electric.ShapeCacheTest do
     test "restores snapshot xmins", %{shape_cache_opts: opts} = context do
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
       :started = ShapeCache.await_snapshot_start(shape_id, opts)
-      [{^shape_id, @shape, @snapshot_xmin}] = ShapeCache.list_active_shapes(opts)
+      meta_table = Keyword.fetch!(opts, :shape_meta_table)
+      [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
+      {:ok, @snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_id)
 
       restart_shape_cache(context)
       :started = ShapeCache.await_snapshot_start(shape_id, opts)
 
-      assert [{^shape_id, @shape, @snapshot_xmin}] = ShapeCache.list_active_shapes(opts)
+      assert [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
+      {:ok, @snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_id)
     end
 
     test "restores latest offset", %{shape_cache_opts: opts} = context do

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -398,7 +398,9 @@ defmodule Electric.ShapeCacheTest do
 
       {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
       assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
-      assert [{^shape_id, @shape, 10}] = ShapeCache.list_active_shapes(opts)
+      meta_table = Keyword.fetch!(opts, :shape_meta_table)
+      assert [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
+      assert {:ok, 10} = ShapeStatus.snapshot_xmin(meta_table, shape_id)
     end
 
     test "lists the shape even if we don't know xmin", ctx do

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -152,7 +152,7 @@ defmodule Support.ComponentSetup do
     |> Keyword.merge(overrides)
   end
 
-  defp full_test_name(ctx) do
+  def full_test_name(ctx) do
     "#{ctx.module} #{ctx.test}"
   end
 end


### PR DESCRIPTION
This PR removes the `list_active_shapes` function and replaces its usages by `list_shapes`.
Also renames the `meta_table` field in `ShapeStatus` to `shape_meta_table` in order to be consistent with the naming throughout the rest of the codebase.