### PR TITLE
feat!: add mixed storage

### DIFF
--- a/.changeset/mean-wombats-search.md
+++ b/.changeset/mean-wombats-search.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": minor
+---
+
+Introduce and enable by default a new iteration of the storage engine, which is more optimal when creating new shapes. If you need to continue using the old shapes without interruption, set `STORAGE=cubdb` environment variable.

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -1,5 +1,4 @@
 defmodule Electric.ShapeCache.CubDbStorage do
-  require Electric.ShapeCache.LogChunker
   alias Electric.ShapeCache.LogChunker
   alias Electric.ConcurrentStream
   alias Electric.Replication.LogOffset

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -1,7 +1,5 @@
 defmodule Electric.ShapeCache.InMemoryStorage do
   use Agent
-
-  require Electric.ShapeCache.LogChunker
   alias Electric.ShapeCache.LogChunker
   alias Electric.ConcurrentStream
   alias Electric.Replication.LogOffset

--- a/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
+++ b/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
@@ -24,5 +24,5 @@ defmodule Electric.ShapeCache.LogChunker do
   end
 
   @spec default_chunk_size_threshold() :: non_neg_integer()
-  defmacro default_chunk_size_threshold(), do: @default_threshold
+  def default_chunk_size_threshold(), do: @default_threshold
 end

--- a/packages/sync-service/lib/electric/shape_cache/mixed_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/mixed_storage.ex
@@ -1,0 +1,321 @@
+defmodule Electric.ShapeCache.MixedDiskStorage do
+  alias Electric.ShapeCache.LogChunker
+  alias Electric.Telemetry.OpenTelemetry
+  alias Electric.Replication.LogOffset
+  @behaviour Electric.ShapeCache.Storage
+
+  @version 1
+  @version_key :version
+
+  def shared_opts(opts) do
+    storage_dir = Access.get(opts, :storage_dir, "./shapes")
+
+    chunk_bytes_threshold =
+      Access.get(opts, :chunk_bytes_threshold, LogChunker.default_chunk_size_threshold())
+
+    {:ok,
+     %{
+       base_path: storage_dir,
+       shape_id: nil,
+       db: nil,
+       version: @version,
+       chunk_bytes_threshold: chunk_bytes_threshold,
+       cubdb_dir: nil,
+       snapshot_dir: nil
+     }}
+  end
+
+  def for_shape(shape_id, %{shape_id: shape_id} = opts), do: opts
+
+  def for_shape(shape_id, %{base_path: base_path} = opts) do
+    %{
+      opts
+      | shape_id: shape_id,
+        db: name(shape_id),
+        cubdb_dir: Path.join([base_path, shape_id, "cubdb"]),
+        snapshot_dir: Path.join([base_path, shape_id, "snapshots"])
+    }
+  end
+
+  defp name(shape_id) do
+    Electric.Application.process_name(__MODULE__, shape_id)
+  end
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent
+    }
+  end
+
+  def start_link(opts) do
+    with :ok <- initialise_filesystem(opts) do
+      CubDB.start_link(data_dir: opts.cubdb_dir, name: opts.db)
+    end
+  end
+
+  defp initialise_filesystem(opts) do
+    with :ok <- File.mkdir_p(opts.cubdb_dir),
+         :ok <- File.mkdir_p(opts.snapshot_dir) do
+      :ok
+    end
+  end
+
+  def initialise(opts) do
+    stored_version = stored_version(opts)
+
+    opts.db
+    |> CubDB.select(min_key: shapes_start(), max_key: shapes_end())
+    |> Stream.map(fn {{:shapes, shape_id}, _} -> shape_id end)
+    |> Stream.filter(fn shape_id ->
+      stored_version != opts.version ||
+        snapshot_xmin(shape_id, opts) == nil ||
+        not CubDB.has_key?(opts.db, snapshot_meta_key(shape_id))
+    end)
+    |> Enum.each(&cleanup!(&1, opts))
+
+    CubDB.put(opts.db, @version_key, @version)
+  end
+
+  def list_shapes(opts) do
+    opts.db
+    |> CubDB.select(min_key: shapes_start(), max_key: shapes_end())
+    |> Enum.map(fn {{:shapes, shape_id}, shape} ->
+      %{
+        shape_id: shape_id,
+        shape: shape,
+        latest_offset: latest_offset(shape_id, opts),
+        snapshot_xmin: snapshot_xmin(shape_id, opts)
+      }
+    end)
+  end
+
+  def add_shape(shape_id, shape, opts) do
+    CubDB.put(opts.db, shape_key(shape_id), shape)
+  end
+
+  def set_snapshot_xmin(shape_id, xmin, opts) do
+    CubDB.put(opts.db, xmin_key(shape_id), xmin)
+  end
+
+  defp snapshot_xmin(shape_id, opts) do
+    CubDB.get(opts.db, xmin_key(shape_id))
+  end
+
+  defp latest_offset(shape_id, opts) do
+    case CubDB.select(opts.db,
+           min_key: log_start(shape_id),
+           max_key: log_end(shape_id),
+           min_key_inclusive: true,
+           reverse: true
+         )
+         |> Enum.take(1) do
+      [{key, _}] ->
+        offset(key)
+
+      _ ->
+        LogOffset.first()
+    end
+  end
+
+  def snapshot_started?(shape_id, opts) do
+    CubDB.has_key?(opts.db, snapshot_started_key(shape_id))
+  end
+
+  def mark_snapshot_as_started(shape_id, opts) do
+    CubDB.put(opts.db, snapshot_started_key(shape_id), true)
+  end
+
+  defp offset({_shape_id, :log, tuple_offset}), do: LogOffset.new(tuple_offset)
+
+  def make_new_snapshot!(shape_id, data_stream, opts) do
+    OpenTelemetry.with_span("storage.make_new_snapshot", [storage_impl: "mixed_disk"], fn ->
+      data_stream
+      |> Stream.map(&[&1, ?\n])
+      # Use the 4 byte marker (ASCII "end of transmission") to indicate the end of the snapshot,
+      # so that concurrent readers can detect that the snapshot has been completed.
+      |> Stream.concat([<<4::utf8>>])
+      |> Stream.into(File.stream!(shape_snapshot_path(shape_id, opts), [:append, :delayed_write]))
+      |> Stream.run()
+
+      CubDB.put(opts.db, snapshot_meta_key(shape_id), LogOffset.first())
+    end)
+  end
+
+  def snapshot_exists?(shape_id, opts) do
+    CubDB.has_key?(opts.db, snapshot_meta_key(shape_id))
+  end
+
+  def get_snapshot(shape_id, opts) do
+    if snapshot_started?(shape_id, opts) do
+      {LogOffset.first(),
+       Stream.resource(
+         fn -> {open_snapshot_file(shape_id, opts), nil} end,
+         fn {file, eof_seen} ->
+           case IO.binread(file, :line) do
+             {:error, reason} ->
+               raise IO.StreamError, reason: reason
+
+             :eof ->
+               cond do
+                 is_nil(eof_seen) ->
+                   # First time we see eof after any valid lines, we store a timestamp
+                   {[], {file, System.monotonic_time(:millisecond)}}
+
+                 # If it's been 60s without any new lines, and also we've not seen <<4>>,
+                 # then likely something is wrong
+                 System.monotonic_time(:millisecond) - eof_seen > 60_000 ->
+                   raise "Snapshot hasn't updated in 60s"
+
+                 true ->
+                   # Sleep a little and check for new lines
+                   Process.sleep(20)
+                   {[], {file, eof_seen}}
+               end
+
+             # The 4 byte marker (ASCII "end of transmission") indicates the end of the snapshot file.
+             <<4::utf8>> ->
+               {:halt, {file, nil}}
+
+             line ->
+               {[line], {file, nil}}
+           end
+         end,
+         fn {file, _} -> File.close(file) end
+       )}
+    else
+      raise "Snapshot no longer available"
+    end
+  end
+
+  defp open_snapshot_file(shape_id, opts, attempts_left \\ 100)
+  defp open_snapshot_file(_, _, 0), do: raise(IO.StreamError, reason: :enoent)
+
+  defp open_snapshot_file(shape_id, opts, attempts_left) do
+    case File.open(shape_snapshot_path(shape_id, opts), [:read, :raw, read_ahead: 1024]) do
+      {:ok, file} ->
+        file
+
+      {:error, :enoent} ->
+        Process.sleep(10)
+        open_snapshot_file(shape_id, opts, attempts_left - 1)
+
+      {:error, reason} ->
+        raise IO.StreamError, reason: reason
+    end
+  end
+
+  def append_to_log!(shape_id, log_items, log_state, opts) do
+    chunk_bytes_threshold = Access.fetch!(opts, :chunk_bytes_threshold)
+
+    log_items
+    |> Enum.flat_map_reduce(log_state, fn log_item, log_state ->
+      json_log_item = Jason.encode!(log_item)
+      log_key = log_key(shape_id, log_item.offset)
+      current_chunk_size = log_state.current_chunk_byte_size
+
+      case LogChunker.add_to_chunk(json_log_item, current_chunk_size, chunk_bytes_threshold) do
+        {:ok, new_chunk_size} ->
+          {
+            [{log_key, json_log_item}],
+            %{log_state | current_chunk_byte_size: new_chunk_size}
+          }
+
+        {:threshold_exceeded, new_chunk_size} ->
+          {
+            [
+              {log_key, json_log_item},
+              {chunk_checkpoint_key(shape_id, log_item.offset), nil}
+            ],
+            %{log_state | current_chunk_byte_size: new_chunk_size}
+          }
+      end
+    end)
+    |> then(fn {items, log_state} ->
+      CubDB.put_multi(opts.db, items)
+      log_state
+    end)
+  end
+
+  def get_log_stream(shape_id, offset, max_offset, opts) do
+    max_key =
+      if max_offset == :infinity, do: log_end(shape_id), else: log_key(shape_id, max_offset)
+
+    opts.db
+    |> CubDB.select(
+      min_key: log_key(shape_id, offset),
+      max_key: max_key,
+      min_key_inclusive: false
+    )
+    |> Stream.map(fn {_, item} -> item end)
+  end
+
+  def get_chunk_end_log_offset(shape_id, offset, opts) do
+    CubDB.select(opts.db,
+      min_key: chunk_checkpoint_key(shape_id, offset),
+      max_key: chunk_checkpoint_end(shape_id),
+      min_key_inclusive: false
+    )
+    |> Stream.map(fn {key, _} -> offset(key) end)
+    |> Enum.take(1)
+    |> Enum.at(0)
+  end
+
+  def has_log_entry?(shape_id, offset, opts) do
+    # FIXME: this is naive while we don't have snapshot metadata to get real offsets
+    CubDB.has_key?(opts.db, log_key(shape_id, offset)) or
+      (snapshot_started?(shape_id, opts) and offset == LogOffset.first())
+  end
+
+  def has_shape?(shape_id, opts) do
+    entry_stream = keys_from_range(log_start(shape_id), log_end(shape_id), opts)
+    !Enum.empty?(entry_stream) or snapshot_started?(shape_id, opts)
+  end
+
+  def cleanup!(shape_id, opts) do
+    [
+      snapshot_meta_key(shape_id),
+      shape_key(shape_id),
+      xmin_key(shape_id),
+      snapshot_started_key(shape_id)
+    ]
+    |> Enum.concat(keys_from_range(log_start(shape_id), log_end(shape_id), opts))
+    |> Enum.concat(
+      keys_from_range(chunk_checkpoint_start(shape_id), chunk_checkpoint_end(shape_id), opts)
+    )
+    |> then(&CubDB.delete_multi(opts.db, &1))
+
+    File.rm_rf(shape_snapshot_path(shape_id, opts))
+
+    :ok
+  end
+
+  defp keys_from_range(min_key, max_key, opts) do
+    CubDB.select(opts.db, min_key: min_key, max_key: max_key)
+    |> Stream.map(&elem(&1, 0))
+  end
+
+  defp shape_snapshot_path(shape_id, opts) do
+    Path.join([opts.snapshot_dir, "#{shape_id}_snapshot.jsonl"])
+  end
+
+  defp stored_version(opts) do
+    CubDB.get(opts.db, @version_key)
+  end
+
+  # Key helpers
+  defp shape_key(shape_id), do: {:shapes, shape_id}
+  defp xmin_key(shape_id), do: {:snapshot_xmin, shape_id}
+  defp snapshot_meta_key(shape_id), do: {:snapshot_meta, shape_id}
+  defp log_key(shape_id, offset), do: {shape_id, :log, LogOffset.to_tuple(offset)}
+  defp log_start(shape_id), do: log_key(shape_id, LogOffset.first())
+  defp log_end(shape_id), do: log_key(shape_id, LogOffset.last())
+  defp shapes_start, do: shape_key(0)
+  defp shapes_end, do: shape_key(<<255>>)
+  defp snapshot_started_key(shape_id), do: {:snapshot_started, shape_id}
+  defp chunk_checkpoint_key(shape_id, offset), do: {shape_id, :chunk, LogOffset.to_tuple(offset)}
+  defp chunk_checkpoint_start(shape_id), do: chunk_checkpoint_key(shape_id, LogOffset.first())
+  defp chunk_checkpoint_end(shape_id), do: chunk_checkpoint_key(shape_id, LogOffset.last())
+end

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -19,16 +19,16 @@ defmodule Electric.ShapeCache.Storage do
   @callback for_shape(shape_id(), compiled_opts()) :: compiled_opts()
 
   @doc "Start any processes required to run the storage backend"
-  @callback start_link(storage()) :: GenServer.on_start()
-  @callback initialise(storage()) :: :ok
-  @callback list_shapes(storage()) :: [
+  @callback start_link(compiled_opts()) :: GenServer.on_start()
+  @callback initialise(compiled_opts()) :: :ok
+  @callback list_shapes(compiled_opts()) :: [
               shape_id: shape_id(),
               shape: Shape.t(),
               latest_offset: LogOffset.t(),
               snapshot_xmin: non_neg_integer()
             ]
-  @callback add_shape(shape_id(), Shape.t(), storage()) :: :ok
-  @callback set_snapshot_xmin(shape_id(), non_neg_integer(), storage()) :: :ok
+  @callback add_shape(shape_id(), Shape.t(), compiled_opts()) :: :ok
+  @callback set_snapshot_xmin(shape_id(), non_neg_integer(), compiled_opts()) :: :ok
 
   @doc "Check if snapshot for a given shape id already exists"
   @callback snapshot_started?(shape_id(), compiled_opts()) :: boolean()

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -2,6 +2,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   use ExUnit.Case, async: true
   import Support.TestUtils
 
+  alias Electric.ShapeCache.MixedDiskStorage
   alias Electric.LogItems
   alias Electric.Postgres.Lsn
   alias Electric.Replication.LogOffset
@@ -41,7 +42,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
                ]
                |> Enum.map(&Jason.encode_to_iodata!/1)
 
-  for module <- [InMemoryStorage, CubDbStorage] do
+  for module <- [InMemoryStorage, CubDbStorage, MixedDiskStorage] do
     module_name = module |> Module.split() |> List.last()
 
     doctest module, import: true
@@ -526,7 +527,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   end
 
   # Tests for storage implementations that are recoverable
-  for module <- [CubDbStorage] do
+  for module <- [CubDbStorage, MixedDiskStorage] do
     module_name = module |> Module.split() |> List.last()
 
     describe "#{module_name}.list_shapes/1" do
@@ -706,6 +707,13 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
     [
       db: String.to_atom("shape_cubdb_#{Utils.uuid4()}"),
       file_path: tmp_dir
+    ]
+  end
+
+  defp opts(MixedDiskStorage, %{tmp_dir: tmp_dir}) do
+    [
+      db: String.to_atom("shape_mixed_disk_#{Utils.uuid4()}"),
+      storage_dir: tmp_dir
     ]
   end
 end


### PR DESCRIPTION
This introduces a new storage backend, that's build as a plain file for snapshots, and CubDB for any metadata and ongoing logs. The benefit here is that we don't have to close the file while processing the results coming from the PostgreSQL query, unlike with batched CubDB writes. The result is that we're writing the snapshot roughly at the same rate as PostgreSQL generates query results.

This storage greatly improves initial snapshot performance (about triples the speed of snapshot creation), as well as RAM usage of Electric (benchmark made with 15s connection checkout timeout, hence the cutoff):
![image](https://github.com/user-attachments/assets/40135602-ab52-4e4b-80c2-e949b4bf0a8c)
