### PR TITLE
feat: Log chunking

### DIFF
--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -66,6 +66,11 @@ else
   config :electric, connection_opts: connection_opts
 end
 
+config :electric,
+  log_chunking_opts: [
+    chunk_bytes_threshold: env!("LOG_CHUNK_BYTES_THREHSOLD", :integer, 10_000)
+  ]
+
 enable_integration_testing = env!("ENABLE_INTEGRATION_TESTING", :boolean, false)
 cache_max_age = env!("CACHE_MAX_AGE", :integer, 60)
 cache_stale_age = env!("CACHE_STALE_AGE", :integer, 60 * 5)

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -66,11 +66,6 @@ else
   config :electric, connection_opts: connection_opts
 end
 
-config :electric,
-  log_chunking_opts: [
-    chunk_bytes_threshold: env!("LOG_CHUNK_BYTES_THREHSOLD", :integer, 10_000)
-  ]
-
 enable_integration_testing = env!("ENABLE_INTEGRATION_TESTING", :boolean, false)
 cache_max_age = env!("CACHE_MAX_AGE", :integer, 60)
 cache_stale_age = env!("CACHE_STALE_AGE", :integer, 60 * 5)
@@ -97,22 +92,30 @@ persistent_kv =
     {Electric.PersistentKV.Filesystem, :new!, root: persistent_state_path}
   )
 
+storage_opts = %{
+  chunk_bytes_threshold: env!("LOG_CHUNK_BYTES_THREHSOLD", :integer, 10_000)
+}
+
+cub_db_opts = %{
+  file_path: cubdb_file_path
+}
+
 storage =
   env!(
     "STORAGE",
     fn storage ->
       case String.downcase(storage) do
         "memory" ->
-          {Electric.ShapeCache.InMemoryStorage, []}
+          {Electric.ShapeCache.InMemoryStorage, storage_opts}
 
         "cubdb" ->
-          {Electric.ShapeCache.CubDbStorage, file_path: cubdb_file_path}
+          {Electric.ShapeCache.CubDbStorage, Map.merge(cub_db_opts, storage_opts)}
 
         _ ->
           raise Dotenvy.Error, message: "storage must be one of: MEMORY, CUBDB"
       end
     end,
-    {Electric.ShapeCache.CubDbStorage, file_path: cubdb_file_path}
+    {Electric.ShapeCache.CubDbStorage, Map.merge(cub_db_opts, storage_opts)}
   )
 
 config :electric,

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -15,21 +15,13 @@ defmodule Electric.Application do
     {storage_module, storage_opts} = Application.fetch_env!(:electric, :storage)
     {kv_module, kv_fun, kv_params} = Application.fetch_env!(:electric, :persistent_kv)
 
-    {chunking_module, chunking_opts} =
-      {Electric.ShapeCache.LogChunker, Application.fetch_env!(:electric, :log_chunking_opts)}
-
     persistent_kv = apply(kv_module, kv_fun, [kv_params])
 
     publication_name = "electric_publication"
     slot_name = "electric_slot"
 
     with {:ok, storage_opts} <- storage_module.shared_opts(storage_opts) do
-      storage =
-        {storage_module,
-         %{
-           storage_opts
-           | log_chunking: {chunking_module, chunking_module.shared_opts(chunking_opts)}
-         }}
+      storage = {storage_module, storage_opts}
 
       prepare_tables_fn =
         {Electric.Postgres.Configuration, :configure_tables_for_replication!, [publication_name]}

--- a/packages/sync-service/lib/electric/plug/delete_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/delete_shape_plug.ex
@@ -49,7 +49,7 @@ defmodule Electric.Plug.DeleteShapePlug do
       # FIXME: This has a race condition where we accidentally create a snapshot & shape id, but clean
       #        it before snapshot is actually made.
       with {shape_id, _} <-
-             Shapes.get_or_create_shape_id(conn.assigns.shape_definition, conn.assigns.config),
+             Shapes.get_or_create_shape_id(conn.assigns.config, conn.assigns.shape_definition),
            :ok <- Shapes.clean_shape(shape_id, conn.assigns.config) do
         send_resp(conn, 202, "")
       end

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -121,7 +121,7 @@ defmodule Electric.Plug.ServeShapePlug do
   # We're starting listening as soon as possible to not miss stuff that was added since we've asked for last offset
   plug :listen_for_new_changes
   plug :validate_shape_offset
-  plug :maybe_use_log_chunk
+  plug :determine_log_chunk_offset
   plug :generate_etag
   plug :validate_and_put_etag
   plug :put_resp_cache_headers
@@ -203,7 +203,10 @@ defmodule Electric.Plug.ServeShapePlug do
 
   # If chunk offsets are available, use those instead of the latest available offset
   # to optimize for cache hits and response sizes
-  defp maybe_use_log_chunk(%Conn{assigns: %{offset: offset, active_shape_id: shape_id}} = conn, _) do
+  defp determine_log_chunk_offset(
+         %Conn{assigns: %{offset: offset, active_shape_id: shape_id}} = conn,
+         _
+       ) do
     chunk_end_offset =
       Shapes.get_chunk_end_log_offset(conn.assigns.config, shape_id, offset)
 

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -158,7 +158,7 @@ defmodule Electric.ShapeCache.CubDbStorage do
       max_key: chunk_checkpoint_end(shape_id),
       min_key_inclusive: false
     )
-    |> Stream.map(fn {{key}, _} -> offset(key) end)
+    |> Stream.map(fn {key, _} -> offset(key) end)
     |> Enum.take(1)
     |> Enum.at(0)
   end

--- a/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
+++ b/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
@@ -1,0 +1,49 @@
+defmodule Electric.ShapeCache.LogChunker do
+  @size_key :chunk_size
+  @chunk_signature <<32, 32, 32>>
+  @default_threshold 10_000
+
+  defp name(shape_id) when is_binary(shape_id) do
+    Electric.Application.process_name(__MODULE__, shape_id)
+  end
+
+  defp table_name(shape_id) when is_binary(shape_id) do
+    :"chunk_size_ets_table-#{shape_id}"
+  end
+
+  def start_link(shape_id) when is_binary(shape_id) do
+    Agent.start_link(
+      fn ->
+        %{
+          chunk_size_ets_table: :ets.new(table_name(shape_id), [:public, :named_table, :set])
+        }
+      end,
+      name: name(shape_id)
+    )
+  end
+
+  def add_to_chunk(shape_id, chunk_bytes, byte_threshold \\ @default_threshold)
+  def add_to_chunk(_shape_id, _chunk_bytes = <<>>, _threshold), do: :ok
+
+  def add_to_chunk(shape_id, chunk_bytes, byte_threshold) do
+    chunk_bytes_size = byte_size(chunk_bytes)
+
+    new_size =
+      :ets.update_counter(
+        table_name(shape_id),
+        @size_key,
+        {2, chunk_bytes_size, byte_threshold, chunk_bytes_size},
+        {@size_key, -1}
+      )
+
+    if(new_size === chunk_bytes_size) do
+      :threshold_exceeded
+    else
+      :ok
+    end
+  end
+
+  defmacro chunk_signature() do
+    @chunk_signature
+  end
+end

--- a/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
+++ b/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
@@ -1,49 +1,111 @@
 defmodule Electric.ShapeCache.LogChunker do
+  use Agent
+  alias Electric.ShapeCache.ShapeStatus
   @size_key :chunk_size
-  @chunk_signature <<32, 32, 32>>
+  @chunk_boundary_bytes <<0, 255, 0, 123>>
+  @chunk_boundary :chunk_boundary
   @default_threshold 10_000
+
+  @type chunk_boundary :: :chunk_boundary
 
   defp name(shape_id) when is_binary(shape_id) do
     Electric.Application.process_name(__MODULE__, shape_id)
   end
 
-  defp table_name(shape_id) when is_binary(shape_id) do
-    :"chunk_size_ets_table-#{shape_id}"
+  def shared_opts(opts \\ %{}) do
+    chunk_size_ets_table_name = Access.get(opts, :chunk_size_ets_table, :chunk_size_ets_table)
+    chunk_bytes_threshold = Access.get(opts, :chunk_bytes_threshold, @default_threshold)
+
+    {:ok,
+     %{
+       chunk_size_ets_table_base: chunk_size_ets_table_name,
+       chunk_size_ets_table: nil,
+       chunk_bytes_threshold: chunk_bytes_threshold,
+       shape_id: nil
+     }}
   end
 
-  def start_link(shape_id) when is_binary(shape_id) do
+  def for_shape(shape_id, %{shape_id: shape_id} = compiled_opts) do
+    compiled_opts
+  end
+
+  def for_shape(shape_id, compiled_opts) do
+    chunk_size_ets_table_name = Map.fetch!(compiled_opts, :chunk_size_ets_table_base)
+
+    %{
+      compiled_opts
+      | shape_id: shape_id,
+        chunk_size_ets_table: :"#{chunk_size_ets_table_name}-#{shape_id}"
+    }
+  end
+
+  def start_link(%{shape_id: shape_id, chunk_size_ets_table: table_name} = _compiled_opts)
+      when is_binary(shape_id) do
+    # NOTE: perhaps unnecessary as we know that this will always run along the
+    # storage processes?
     Agent.start_link(
       fn ->
         %{
-          chunk_size_ets_table: :ets.new(table_name(shape_id), [:public, :named_table, :set])
+          chunk_size_ets_table: :ets.new(table_name, [:public, :named_table, :set])
         }
       end,
       name: name(shape_id)
     )
   end
 
-  def add_to_chunk(shape_id, chunk_bytes, byte_threshold \\ @default_threshold)
-  def add_to_chunk(_shape_id, _chunk_bytes = <<>>, _threshold), do: :ok
+  @spec add_to_chunk(ShapeStatus.shape_id(), bitstring(), non_neg_integer()) ::
+          {:ok | :threshold_exceeded, bitstring()}
+  def add_to_chunk(shape_id, chunk_bytes, opts)
 
-  def add_to_chunk(shape_id, chunk_bytes, byte_threshold) do
+  def add_to_chunk(_shape_id, chunk_bytes = <<>>, _opts), do: {:ok, chunk_bytes}
+
+  def add_to_chunk(shape_id, chunk_bytes, %{
+        chunk_size_ets_table: table_name,
+        chunk_bytes_threshold: byte_threshold
+      }) do
     chunk_bytes_size = byte_size(chunk_bytes)
+    shape_chunk_size_key = {@size_key, shape_id}
 
     new_size =
       :ets.update_counter(
-        table_name(shape_id),
-        @size_key,
+        table_name,
+        shape_chunk_size_key,
         {2, chunk_bytes_size, byte_threshold, chunk_bytes_size},
-        {@size_key, -1}
+        {shape_chunk_size_key, -1}
       )
 
     if(new_size === chunk_bytes_size) do
-      :threshold_exceeded
+      {:threshold_exceeded, prefix_with_chunk_boundary(chunk_bytes)}
     else
-      :ok
+      {:ok, chunk_bytes}
     end
   end
 
-  defmacro chunk_signature() do
-    @chunk_signature
+  defp prefix_with_chunk_boundary(item) when is_binary(item) do
+    <<@chunk_boundary_bytes::binary, item::binary>>
+  end
+
+  @spec materialise_chunk_boundaries(Enumerable.t(iodata())) ::
+          Enumerable.t(iodata() | chunk_boundary())
+  def materialise_chunk_boundaries(stream) do
+    stream
+    |> Stream.flat_map(fn item ->
+      case item do
+        <<@chunk_boundary_bytes::binary, rest::binary>> -> [@chunk_boundary, rest]
+        _ -> [item]
+      end
+    end)
+  end
+
+  @spec dissolve_chunks(Enumerable.t(any() | chunk_boundary())) :: Enumerable.t(any())
+  def dissolve_chunks(stream) do
+    stream
+    |> Stream.filter(fn item -> item !== @chunk_boundary end)
+  end
+
+  @spec take_chunk(Enumerable.t(any() | chunk_boundary())) :: Enumerable.t(any())
+  def take_chunk(stream) do
+    stream
+    |> Stream.take_while(fn item -> item !== @chunk_boundary end)
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
+++ b/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
@@ -16,13 +16,12 @@ defmodule Electric.ShapeCache.LogChunker do
     chunk_size_ets_table_name = Access.get(opts, :chunk_size_ets_table, :chunk_size_ets_table)
     chunk_bytes_threshold = Access.get(opts, :chunk_bytes_threshold, @default_threshold)
 
-    {:ok,
-     %{
-       chunk_size_ets_table_base: chunk_size_ets_table_name,
-       chunk_size_ets_table: nil,
-       chunk_bytes_threshold: chunk_bytes_threshold,
-       shape_id: nil
-     }}
+    %{
+      chunk_size_ets_table_base: chunk_size_ets_table_name,
+      chunk_size_ets_table: nil,
+      chunk_bytes_threshold: chunk_bytes_threshold,
+      shape_id: nil
+    }
   end
 
   def for_shape(shape_id, %{shape_id: shape_id} = compiled_opts) do

--- a/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
+++ b/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
@@ -1,82 +1,28 @@
 defmodule Electric.ShapeCache.LogChunker do
-  use Agent
-  alias Electric.ShapeCache.ShapeStatus
-
-  @size_key :chunk_size
   @default_threshold 10_000
-
-  defp name(shape_id) when is_binary(shape_id) do
-    Electric.Application.process_name(__MODULE__, shape_id)
-  end
-
-  def shared_opts(opts \\ %{}) do
-    chunk_size_ets_table_name = Access.get(opts, :chunk_size_ets_table, :chunk_size_ets_table)
-    chunk_bytes_threshold = Access.get(opts, :chunk_bytes_threshold, @default_threshold)
-
-    %{
-      chunk_size_ets_table_base: chunk_size_ets_table_name,
-      chunk_size_ets_table: nil,
-      chunk_bytes_threshold: chunk_bytes_threshold,
-      shape_id: nil
-    }
-  end
-
-  def for_shape(shape_id, %{shape_id: shape_id} = compiled_opts) do
-    compiled_opts
-  end
-
-  def for_shape(shape_id, compiled_opts) when is_binary(shape_id) do
-    chunk_size_ets_table_name = Map.fetch!(compiled_opts, :chunk_size_ets_table_base)
-
-    %{
-      compiled_opts
-      | shape_id: shape_id,
-        chunk_size_ets_table: :"#{chunk_size_ets_table_name}-#{shape_id}"
-    }
-  end
-
-  def start_link(%{shape_id: shape_id, chunk_size_ets_table: table_name} = _compiled_opts)
-      when is_binary(shape_id) do
-    # NOTE: perhaps unnecessary as we know that this will always run along the
-    # storage processes?
-    Agent.start_link(
-      fn ->
-        %{
-          chunk_size_ets_table: :ets.new(table_name, [:public, :named_table, :set])
-        }
-      end,
-      name: name(shape_id)
-    )
-  end
 
   @doc """
   Add bytes to the current chunk of a given shape - if the chunk exceeds the specified
   byte size threshold, a new chunk is reset and `:threshold_exceeded` is returned.
   """
-  @spec add_to_chunk(ShapeStatus.shape_id(), bitstring(), non_neg_integer()) ::
-          :ok | :threshold_exceeded
-  def add_to_chunk(shape_id, chunk_bytes, opts)
+  @spec add_to_chunk(bitstring(), non_neg_integer(), non_neg_integer()) ::
+          {:ok | :threshold_exceeded, non_neg_integer()}
+  def add_to_chunk(chunk_bytes, total_chunk_size, chunk_bytes_threshold \\ @default_threshold)
 
   # Ignore zero-length bytestrings - they can always be "added" to an existing chunk
-  def add_to_chunk(_shape_id, _chunk_bytes = <<>>, _opts), do: :ok
+  def add_to_chunk(_chunk_bytes = <<>>, total_chunk_byte_size, _chunk_bytes_threshold),
+    do: {:ok, total_chunk_byte_size}
 
-  def add_to_chunk(shape_id, chunk_bytes, %{
-        chunk_size_ets_table: table_name,
-        chunk_bytes_threshold: byte_threshold
-      }) do
+  def add_to_chunk(chunk_bytes, total_chunk_byte_size, chunk_bytes_threshold)
+      when is_number(chunk_bytes_threshold) do
     chunk_bytes_size = byte_size(chunk_bytes)
-    shape_chunk_size_key = {@size_key, shape_id}
+    total_chunk_byte_size = total_chunk_byte_size + chunk_bytes_size
 
-    new_size =
-      :ets.update_counter(
-        table_name,
-        shape_chunk_size_key,
-        {2, chunk_bytes_size, byte_threshold, 0},
-        {shape_chunk_size_key, 0}
-      )
-
-    # if size is reset to 0 it can only mean that the chunk has
-    # filled up - since 0-length bytestrings do not get counted
-    if new_size === 0, do: :threshold_exceeded, else: :ok
+    if total_chunk_byte_size >= chunk_bytes_threshold,
+      do: {:threshold_exceeded, 0},
+      else: {:ok, total_chunk_byte_size}
   end
+
+  @spec default_chunk_size_threshold() :: non_neg_integer()
+  defmacro default_chunk_size_threshold(), do: @default_threshold
 end

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -30,7 +30,7 @@ defmodule Electric.ShapeCache.Storage do
   @type row :: list()
 
   @doc "Initialise shape-specific opts from the shared, global, configuration"
-  @callback for_shape(shape_id(), term()) :: storage()
+  @callback for_shape(shape_id(), compiled_opts()) :: compiled_opts()
 
   @doc "Start any processes required to run the storage backend"
   @callback start_link(storage()) :: GenServer.on_start()
@@ -96,19 +96,10 @@ defmodule Electric.ShapeCache.Storage do
   end
 
   def for_shape(shape_id, {mod, opts}) do
-    {chunking_module, chunking_opts} = Access.fetch!(opts, :log_chunking)
-
-    {mod,
-     %{
-       apply(mod, :for_shape, [shape_id, opts])
-       | log_chunking:
-           {chunking_module, apply(chunking_module, :for_shape, [shape_id, chunking_opts])}
-     }}
+    {mod, apply(mod, :for_shape, [shape_id, opts])}
   end
 
   def start_link({mod, opts}) do
-    {chunking_module, chunking_opts} = Access.fetch!(opts, :log_chunking)
-    apply(chunking_module, :start_link, [chunking_opts])
     apply(mod, :start_link, [opts])
   end
 

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -36,22 +36,25 @@ defmodule Electric.Shapes do
   end
 
   @doc """
-  Get or create a shape ID and return it along with the end offset of the first chunk
+  Get or create a shape ID and return it along with the latest offset of the shape
   """
-  @spec get_or_create_shape_id(Shape.t(), keyword()) :: {Storage.shape_id(), LogOffset.t()}
-  def get_or_create_shape_id(shape_def, opts \\ []) do
-    {shape_cache, opts} = Access.get(opts, :shape_cache, {ShapeCache, []})
+  @spec get_or_create_shape_id(keyword(), Shape.t()) :: {Storage.shape_id(), LogOffset.t()}
+  def get_or_create_shape_id(config, shape_def) do
+    {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
 
-    {shape_id, latest_shape_offset} = shape_cache.get_or_create_shape_id(shape_def, opts)
+    shape_cache.get_or_create_shape_id(shape_def, opts)
+  end
 
-    chunk_end_offset =
-      Storage.get_chunk_end_log_offset(
-        shape_id,
-        LogOffset.before_all(),
-        shape_storage(opts, shape_id)
-      )
+  @doc """
+  Get the last exclusive offset of the chunk starting from the given offset
 
-    {shape_id, chunk_end_offset || latest_shape_offset}
+  If `nil` is returned, chunk is not complete and the shape's latest offset should be used
+  """
+  @spec get_chunk_end_log_offset(keyword(), Storage.shape_id(), LogOffset.t()) ::
+          LogOffset.t() | nil
+  def get_chunk_end_log_offset(config, shape_id, offset) do
+    storage = shape_storage(config, shape_id)
+    Storage.get_chunk_end_log_offset(shape_id, offset, storage)
   end
 
   @doc """

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -27,6 +27,7 @@ defmodule Electric.Shapes do
   """
   def get_log_stream(config, shape_id, opts) do
     {shape_cache, shape_cache_opts} = Access.get(config, :shape_cache, {ShapeCache, []})
+    {log_chunker, _} = Access.get(config, :log_chunker, {LogChunker, []})
     offset = Access.get(opts, :since, LogOffset.before_all())
     max_offset = Access.get(opts, :up_to, LogOffset.last())
     take_chunk = Access.get(opts, :take_chunk, false)
@@ -38,9 +39,9 @@ defmodule Electric.Shapes do
       end
 
     if take_chunk do
-      chunked_log_stream |> LogChunker.take_chunk()
+      chunked_log_stream |> log_chunker.take_chunk()
     else
-      chunked_log_stream |> LogChunker.dissolve_chunks()
+      chunked_log_stream |> log_chunker.dissolve_chunks()
     end
   end
 

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -620,9 +620,11 @@ defmodule Electric.Plug.RouterTest do
       opts: opts,
       db_conn: db_conn
     } do
-      first_val = String.duplicate("a", 5_000)
-      second_val = String.duplicate("a", 7_000)
-      third_val = String.duplicate("a", 3_000)
+      {_, %{chunk_bytes_threshold: threshold}} = Access.fetch!(opts, :storage)
+
+      first_val = String.duplicate("a", round(threshold * 0.6))
+      second_val = String.duplicate("b", round(threshold * 0.7))
+      third_val = String.duplicate("c", round(threshold * 0.4))
 
       conn = conn("GET", "/v1/shape/large_rows_table?offset=-1") |> Router.call(opts)
       assert %{status: 200} = conn

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -612,6 +612,71 @@ defmodule Electric.Plug.RouterTest do
       # into two operations when the PK changes. Hence the distance of 2 between op1 and op2.
       assert op2_log_offset == LogOffset.increment(op1_log_offset, 2)
     end
+
+    @tag with_sql: [
+           "CREATE TABLE large_rows_table (id BIGINT PRIMARY KEY, value TEXT NOT NULL)"
+         ]
+    test "GET receives chunked results based on size", %{
+      opts: opts,
+      db_conn: db_conn
+    } do
+      first_val = String.duplicate("a", 5_000)
+      second_val = String.duplicate("a", 7_000)
+      third_val = String.duplicate("a", 3_000)
+
+      conn = conn("GET", "/v1/shape/large_rows_table?offset=-1") |> Router.call(opts)
+      assert %{status: 200} = conn
+      [shape_id] = Plug.Conn.get_resp_header(conn, "x-electric-shape-id")
+      [next_offset] = Plug.Conn.get_resp_header(conn, "x-electric-chunk-last-offset")
+
+      assert [_] = Jason.decode!(conn.resp_body)
+
+      Postgrex.query!(db_conn, "INSERT INTO large_rows_table VALUES (1, $1), (2, $2), (3, $3)", [
+        first_val,
+        second_val,
+        third_val
+      ])
+
+      Process.sleep(1000)
+
+      conn =
+        conn("GET", "/v1/shape/large_rows_table?offset=#{next_offset}&shape_id=#{shape_id}")
+        |> Router.call(opts)
+
+      assert %{status: 200} = conn
+
+      assert [
+               %{
+                 "headers" => %{"operation" => "insert"},
+                 "value" => %{"id" => "1", "value" => ^first_val},
+                 "key" => _
+               },
+               %{
+                 "headers" => %{"operation" => "insert"},
+                 "value" => %{"id" => "2", "value" => ^second_val},
+                 "key" => _
+               }
+             ] = Jason.decode!(conn.resp_body)
+
+      [next_offset] = Plug.Conn.get_resp_header(conn, "x-electric-chunk-last-offset")
+
+      conn =
+        conn("GET", "/v1/shape/large_rows_table?offset=#{next_offset}&shape_id=#{shape_id}")
+        |> Router.call(opts)
+
+      assert %{status: 200} = conn
+
+      assert [
+               %{
+                 "headers" => %{"operation" => "insert"},
+                 "value" => %{"id" => "3", "value" => ^third_val},
+                 "key" => _
+               },
+               %{
+                 "headers" => %{"control" => "up-to-date"}
+               }
+             ] = Jason.decode!(conn.resp_body)
+    end
   end
 
   defp get_resp_shape_id(conn), do: get_resp_header(conn, "x-electric-shape-id")

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -141,8 +141,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
                  "value" => "foo",
                  "headers" => %{},
                  "offset" => "#{next_offset}"
-               },
-               %{"headers" => %{"control" => "up-to-date"}}
+               }
              ]
 
       assert Plug.Conn.get_resp_header(conn, "etag") == [
@@ -265,8 +264,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
                  "value" => "bar",
                  "headers" => %{},
                  "offset" => "#{next_next_offset}"
-               },
-               %{"headers" => %{"control" => "up-to-date"}}
+               }
              ]
 
       assert Plug.Conn.get_resp_header(conn, "etag") == [

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -45,14 +45,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     # Pass mock dependencies to the plug
     config = %{
       shape_cache: {Mock.ShapeCache, []},
-      storage:
-        {Mock.Storage,
-         %{
-           log_chunking: {
-             Electric.ShapeCache.LogChunker,
-             Electric.ShapeCache.LogChunker.shared_opts()
-           }
-         }},
+      storage: {Mock.Storage, []},
       inspector: {__MODULE__, []},
       registry: @registry,
       long_poll_timeout: 20_000,

--- a/packages/sync-service/test/electric/shape_cache/log_chunker.exs
+++ b/packages/sync-service/test/electric/shape_cache/log_chunker.exs
@@ -5,44 +5,45 @@ defmodule Electric.ShapeCache.LogChunkerTest do
   @test_shape_id "test_shape_id"
 
   describe "add_chunk/3" do
-    setup %{} do
-      shared_opts = LogChunker.shared_opts()
-      opts = LogChunker.for_shape(@test_shape_id, shared_opts)
-      LogChunker.start_link(opts)
-      opts
-    end
-
-    test "should reset counter upon exceeding threshold", opts do
+    test "should reset counter upon exceeding threshold", _ do
       chunk_bytes = "test"
-      threshold = 3 * byte_size(chunk_bytes) - 1
-      threshold_opts = Map.put(opts, :chunk_bytes_threshold, threshold)
+      chunk_byte_size = byte_size(chunk_bytes)
+      threshold = 3 * chunk_byte_size
 
-      # try as many times as the threshold bytes to ensure no cyclical offset gets added
-      for _ <- 1..threshold do
-        assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
-        assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+      assert {:ok, new_size} = LogChunker.add_to_chunk(chunk_bytes, 0, threshold)
+      assert new_size == chunk_byte_size
 
-        assert :threshold_exceeded =
-                 LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
-      end
+      assert {:ok, new_size} = LogChunker.add_to_chunk(chunk_bytes, chunk_byte_size, threshold)
+      assert new_size == 2 * chunk_byte_size
+
+      assert {:threshold_exceeded, 0} =
+               LogChunker.add_to_chunk(chunk_bytes, 2 * chunk_byte_size, threshold)
     end
 
-    test "should ignore zero length bytestrings", opts do
+    test "should ignore zero length bytestrings", _ do
       threshold = 10
-      large_string = String.duplicate("a", threshold)
+      just_below_threshold = threshold - 1
+      # large_string = String.duplicate("a", threshold)
 
-      threshold_opts = Map.put(opts, :chunk_bytes_threshold, threshold)
-
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, large_string, threshold_opts)
+      # assert :ok = LogChunker.add_to_chunk(large_string, threshold)
 
       # despite next chunk already being full from the large string, if not
       # bytes are added we should not exceed the threshold
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, "", threshold_opts)
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, <<>>, threshold_opts)
+      assert {:ok, ^just_below_threshold} =
+               LogChunker.add_to_chunk("", just_below_threshold, threshold)
+
+      assert {:ok, ^just_below_threshold} =
+               LogChunker.add_to_chunk(<<>>, just_below_threshold, threshold)
 
       # adding a single byte should make it exceed
-      assert :threshold_exceeded =
-               LogChunker.add_to_chunk(@test_shape_id, <<0>>, threshold_opts)
+      assert {:threshold_exceeded, 0} =
+               LogChunker.add_to_chunk(<<0>>, threshold - 1, threshold)
+    end
+
+    test "should reset threshold with single very large values", _ do
+      threshold = 10
+      large_string = String.duplicate("a", threshold * 2)
+      assert {:threshold_exceeded, 0} = LogChunker.add_to_chunk(large_string, 0, threshold)
     end
   end
 end

--- a/packages/sync-service/test/electric/shape_cache/log_chunker.exs
+++ b/packages/sync-service/test/electric/shape_cache/log_chunker.exs
@@ -23,9 +23,6 @@ defmodule Electric.ShapeCache.LogChunkerTest do
     test "should ignore zero length bytestrings", _ do
       threshold = 10
       just_below_threshold = threshold - 1
-      # large_string = String.duplicate("a", threshold)
-
-      # assert :ok = LogChunker.add_to_chunk(large_string, threshold)
 
       # despite next chunk already being full from the large string, if not
       # bytes are added we should not exceed the threshold

--- a/packages/sync-service/test/electric/shape_cache/log_chunker.exs
+++ b/packages/sync-service/test/electric/shape_cache/log_chunker.exs
@@ -7,7 +7,7 @@ defmodule Electric.ShapeCache.LogChunkerTest do
 
   describe "add_chunk/3" do
     setup %{} do
-      {:ok, shared_opts} = LogChunker.shared_opts()
+      shared_opts = LogChunker.shared_opts()
       opts = LogChunker.for_shape(@test_shape_id, shared_opts)
       LogChunker.start_link(opts)
       opts

--- a/packages/sync-service/test/electric/shape_cache/log_chunker.exs
+++ b/packages/sync-service/test/electric/shape_cache/log_chunker.exs
@@ -3,39 +3,59 @@ defmodule Electric.ShapeCache.LogChunkerTest do
   alias Electric.ShapeCache.LogChunker
 
   @test_shape_id "test_shape_id"
+  @chunk_boundary_bytes <<0, 255, 0, 123>>
 
   describe "add_chunk/3" do
     setup %{} do
-      LogChunker.start_link(@test_shape_id)
-      :ok
+      {:ok, shared_opts} = LogChunker.shared_opts()
+      opts = LogChunker.for_shape(@test_shape_id, shared_opts)
+      LogChunker.start_link(opts)
+      opts
     end
 
-    test "should reset counter upon exceeding threshold", %{} do
+    test "should reset counter upon exceeding threshold", opts do
       chunk_bytes = "test"
       threshold = 3 * byte_size(chunk_bytes) - 2
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
-      assert :threshold_exceeded = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
-      assert :threshold_exceeded = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
-      assert :threshold_exceeded = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
+      threshold_opts = Map.put(opts, :chunk_bytes_threshold, threshold)
+
+      assert {:ok, ^chunk_bytes} =
+               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+
+      assert {:ok, ^chunk_bytes} =
+               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+
+      assert {:threshold_exceeded, <<@chunk_boundary_bytes, ^chunk_bytes::binary>>} =
+               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+
+      assert {:ok, ^chunk_bytes} =
+               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+
+      assert {:threshold_exceeded, <<@chunk_boundary_bytes, ^chunk_bytes::binary>>} =
+               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+
+      assert {:ok, ^chunk_bytes} =
+               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+
+      assert {:threshold_exceeded, <<@chunk_boundary_bytes, ^chunk_bytes::binary>>} =
+               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
     end
 
-    test "should ignore zero length bytestrings", %{} do
+    test "should ignore zero length bytestrings", opts do
       large_string = String.duplicate("a", 100)
       threshold = 10
+      threshold_opts = Map.put(opts, :chunk_bytes_threshold, threshold)
 
-      assert :threshold_exceeded =
-               LogChunker.add_to_chunk(@test_shape_id, large_string, threshold)
+      assert {:threshold_exceeded, <<@chunk_boundary_bytes, ^large_string::binary>>} =
+               LogChunker.add_to_chunk(@test_shape_id, large_string, threshold_opts)
 
       # despite next chunk already being full from the large string, if not
       # bytes are added we should not exceed the threshold
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, "", threshold)
-      assert :ok = LogChunker.add_to_chunk(@test_shape_id, <<>>, threshold)
+      assert {:ok, ""} = LogChunker.add_to_chunk(@test_shape_id, "", threshold_opts)
+      assert {:ok, <<>>} = LogChunker.add_to_chunk(@test_shape_id, <<>>, threshold_opts)
 
       # adding a single byte should make it exceed
-      assert :threshold_exceeded = LogChunker.add_to_chunk(@test_shape_id, <<0>>, threshold)
+      assert {:threshold_exceeded, <<@chunk_boundary_bytes, 0>>} =
+               LogChunker.add_to_chunk(@test_shape_id, <<0>>, threshold_opts)
     end
   end
 end

--- a/packages/sync-service/test/electric/shape_cache/log_chunker.exs
+++ b/packages/sync-service/test/electric/shape_cache/log_chunker.exs
@@ -3,7 +3,6 @@ defmodule Electric.ShapeCache.LogChunkerTest do
   alias Electric.ShapeCache.LogChunker
 
   @test_shape_id "test_shape_id"
-  @chunk_boundary_bytes <<0, 255, 0, 123>>
 
   describe "add_chunk/3" do
     setup %{} do
@@ -15,46 +14,34 @@ defmodule Electric.ShapeCache.LogChunkerTest do
 
     test "should reset counter upon exceeding threshold", opts do
       chunk_bytes = "test"
-      threshold = 3 * byte_size(chunk_bytes) - 2
+      threshold = 3 * byte_size(chunk_bytes) - 1
       threshold_opts = Map.put(opts, :chunk_bytes_threshold, threshold)
 
-      assert {:ok, ^chunk_bytes} =
-               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+      # try as many times as the threshold bytes to ensure no cyclical offset gets added
+      for _ <- 1..threshold do
+        assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+        assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
 
-      assert {:ok, ^chunk_bytes} =
-               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
-
-      assert {:threshold_exceeded, <<@chunk_boundary_bytes, ^chunk_bytes::binary>>} =
-               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
-
-      assert {:ok, ^chunk_bytes} =
-               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
-
-      assert {:threshold_exceeded, <<@chunk_boundary_bytes, ^chunk_bytes::binary>>} =
-               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
-
-      assert {:ok, ^chunk_bytes} =
-               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
-
-      assert {:threshold_exceeded, <<@chunk_boundary_bytes, ^chunk_bytes::binary>>} =
-               LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+        assert :threshold_exceeded =
+                 LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold_opts)
+      end
     end
 
     test "should ignore zero length bytestrings", opts do
-      large_string = String.duplicate("a", 100)
       threshold = 10
+      large_string = String.duplicate("a", threshold)
+
       threshold_opts = Map.put(opts, :chunk_bytes_threshold, threshold)
 
-      assert {:threshold_exceeded, <<@chunk_boundary_bytes, ^large_string::binary>>} =
-               LogChunker.add_to_chunk(@test_shape_id, large_string, threshold_opts)
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, large_string, threshold_opts)
 
       # despite next chunk already being full from the large string, if not
       # bytes are added we should not exceed the threshold
-      assert {:ok, ""} = LogChunker.add_to_chunk(@test_shape_id, "", threshold_opts)
-      assert {:ok, <<>>} = LogChunker.add_to_chunk(@test_shape_id, <<>>, threshold_opts)
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, "", threshold_opts)
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, <<>>, threshold_opts)
 
       # adding a single byte should make it exceed
-      assert {:threshold_exceeded, <<@chunk_boundary_bytes, 0>>} =
+      assert :threshold_exceeded =
                LogChunker.add_to_chunk(@test_shape_id, <<0>>, threshold_opts)
     end
   end

--- a/packages/sync-service/test/electric/shape_cache/log_chunker.exs
+++ b/packages/sync-service/test/electric/shape_cache/log_chunker.exs
@@ -1,0 +1,41 @@
+defmodule Electric.ShapeCache.LogChunkerTest do
+  use ExUnit.Case, async: true
+  alias Electric.ShapeCache.LogChunker
+
+  @test_shape_id "test_shape_id"
+
+  describe "add_chunk/3" do
+    setup %{} do
+      LogChunker.start_link(@test_shape_id)
+      :ok
+    end
+
+    test "should reset counter upon exceeding threshold", %{} do
+      chunk_bytes = "test"
+      threshold = 3 * byte_size(chunk_bytes) - 2
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
+      assert :threshold_exceeded = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
+      assert :threshold_exceeded = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
+      assert :threshold_exceeded = LogChunker.add_to_chunk(@test_shape_id, chunk_bytes, threshold)
+    end
+
+    test "should ignore zero length bytestrings", %{} do
+      large_string = String.duplicate("a", 100)
+      threshold = 10
+
+      assert :threshold_exceeded =
+               LogChunker.add_to_chunk(@test_shape_id, large_string, threshold)
+
+      # despite next chunk already being full from the large string, if not
+      # bytes are added we should not exceed the threshold
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, "", threshold)
+      assert :ok = LogChunker.add_to_chunk(@test_shape_id, <<>>, threshold)
+
+      # adding a single byte should make it exceed
+      assert :threshold_exceeded = LogChunker.add_to_chunk(@test_shape_id, <<0>>, threshold)
+    end
+  end
+end

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -2,6 +2,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   use ExUnit.Case, async: true
   import Support.TestUtils
 
+  alias Electric.ShapeCache.LogChunker
   alias Electric.LogItems
   alias Electric.Postgres.Lsn
   alias Electric.Replication.LogOffset
@@ -684,7 +685,14 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
   defp start_storage(%{module: module} = context) do
     {:ok, opts} = module |> opts(context) |> module.shared_opts()
-    shape_opts = module.for_shape(@shape_id, opts)
+    {:ok, chunking_opts} = LogChunker.shared_opts()
+
+    shape_opts =
+      Map.merge(
+        module.for_shape(@shape_id, opts),
+        LogChunker.for_shape(@shape_id, chunking_opts)
+      )
+
     {:ok, _} = module.start_link(shape_opts)
 
     {:ok, %{module: module, opts: shape_opts}}

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -684,22 +684,22 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   end
 
   defp start_storage(%{module: module} = context) do
-    {:ok, opts} = module |> opts(context) |> module.shared_opts()
+    {:ok, opts} =
+      module
+      |> opts(context)
+      |> module.shared_opts()
 
-    # TODO: perhaps provide mock for this?
-    chunking_shape_opts =
-      LogChunker.for_shape(
-        @shape_id,
-        LogChunker.shared_opts(%{
-          chunk_size_ets_table: String.to_atom("chunk_size_ets_table_#{Utils.uuid4()}")
-        })
+    opts =
+      opts
+      |> Map.put(
+        :log_chunking,
+        {LogChunker,
+         LogChunker.shared_opts(%{
+           chunk_size_ets_table: String.to_atom("chunk_size_ets_table_#{Utils.uuid4()}")
+         })}
       )
 
-    LogChunker.start_link(chunking_shape_opts)
-
-    shape_opts =
-      module.for_shape(@shape_id, opts)
-      |> Map.put(:log_chunking, {LogChunker, chunking_shape_opts})
+    shape_opts = module.for_shape(@shape_id, opts)
 
     {:ok, _} = module.start_link(shape_opts)
 

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -709,7 +709,8 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   defp opts(InMemoryStorage, _context) do
     [
       snapshot_ets_table: String.to_atom("snapshot_ets_table_#{Utils.uuid4()}"),
-      log_ets_table: String.to_atom("log_ets_table_#{Utils.uuid4()}")
+      log_ets_table: String.to_atom("log_ets_table_#{Utils.uuid4()}"),
+      chunk_checkpoint_ets_table: String.to_atom("chunk_checkpoint_ets_table_#{Utils.uuid4()}")
     ]
   end
 

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -18,14 +18,14 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.expect(:make_new_snapshot!, fn _, _, {^shape_id, :opts} -> :ok end)
     |> Mox.expect(:snapshot_started?, fn _, {^shape_id, :opts} -> true end)
     |> Mox.expect(:get_snapshot, fn _, {^shape_id, :opts} -> {1, []} end)
-    |> Mox.expect(:append_to_log!, fn _, _, {^shape_id, :opts} -> :ok end)
+    |> Mox.expect(:append_to_log!, fn _, _, _, {^shape_id, :opts} -> :ok end)
     |> Mox.expect(:get_log_stream, fn _, _, _, {^shape_id, :opts} -> [] end)
     |> Mox.expect(:cleanup!, fn _, {^shape_id, :opts} -> :ok end)
 
     Storage.make_new_snapshot!(shape_id, [], storage)
     Storage.snapshot_started?(shape_id, storage)
     Storage.get_snapshot(shape_id, storage)
-    Storage.append_to_log!(shape_id, [], storage)
+    Storage.append_to_log!(shape_id, [], %{}, storage)
     Storage.get_log_stream(shape_id, LogOffset.first(), storage)
     Storage.cleanup!(shape_id, storage)
   end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -28,6 +28,7 @@ defmodule Electric.ShapeCacheTest do
       }
     }
   }
+  @initial_log_state %{current_chunk_byte_size: 0}
   @lsn Electric.Postgres.Lsn.from_integer(13)
   @change_offset LogOffset.new(@lsn, 2)
   @xid 99
@@ -649,6 +650,7 @@ defmodule Electric.ShapeCacheTest do
             log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
           }
         ]),
+        @initial_log_state,
         storage
       )
 
@@ -701,6 +703,7 @@ defmodule Electric.ShapeCacheTest do
             log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
           }
         ]),
+        @initial_log_state,
         storage
       )
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -140,11 +140,11 @@ defmodule Electric.Shapes.ConsumerTest do
       |> allow(self(), Consumer.name(@shape_id1))
 
       Mock.Storage
-      |> expect(:append_to_log!, 2, fn @shape_id1, _changes, _ -> :ok end)
+      |> expect(:append_to_log!, 2, fn @shape_id1, _changes, _, _ -> :ok end)
       |> allow(self(), Consumer.name(@shape_id1))
 
       Mock.Storage
-      |> expect(:append_to_log!, 0, fn @shape_id2, _changes, _ -> :ok end)
+      |> expect(:append_to_log!, 0, fn @shape_id2, _changes, _, _ -> :ok end)
       |> allow(self(), Consumer.name(@shape_id2))
 
       ref = make_ref()
@@ -183,11 +183,11 @@ defmodule Electric.Shapes.ConsumerTest do
 
       Mock.Storage
       |> expect(:append_to_log!, 2, fn
-        @shape_id1, [%{value: record}], {@shape_id1, _} ->
+        @shape_id1, [%{value: record}], _, {@shape_id1, _} ->
           assert record["id"] == "1"
           :ok
 
-        @shape_id2, [%{value: record}], {@shape_id2, _} ->
+        @shape_id2, [%{value: record}], _, {@shape_id2, _} ->
           assert record["id"] == "2"
           :ok
       end)
@@ -240,7 +240,7 @@ defmodule Electric.Shapes.ConsumerTest do
       |> allow(self(), Shapes.Consumer.name(@shape_id2))
 
       Mock.Storage
-      |> expect(:append_to_log!, fn @shape_id2, _, _ -> :ok end)
+      |> expect(:append_to_log!, fn @shape_id2, _, _, _ -> :ok end)
 
       txn =
         %Transaction{xid: xid, lsn: lsn, last_log_offset: last_log_offset}
@@ -339,7 +339,7 @@ defmodule Electric.Shapes.ConsumerTest do
       |> allow(self(), Consumer.name(@shape_id1))
 
       Mock.Storage
-      |> expect(:append_to_log!, fn @shape_id1, _, _ -> :ok end)
+      |> expect(:append_to_log!, fn @shape_id1, _, _, _ -> :ok end)
 
       ref = make_ref()
       Registry.register(ctx.registry, @shape_id1, ref)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -1,6 +1,5 @@
 defmodule Support.ComponentSetup do
   import ExUnit.Callbacks
-  alias Electric.ShapeCache.LogChunker
   alias Electric.Postgres.ReplicationClient
   alias Electric.Replication.ShapeLogCollector
   alias Electric.ShapeCache
@@ -15,16 +14,6 @@ defmodule Support.ComponentSetup do
     %{registry: registry_name}
   end
 
-  def with_log_chunker(ctx) do
-    opts =
-      LogChunker.shared_opts(%{
-        chunk_bytes_threshold: 10_000,
-        chunk_size_ets_table: :"chunk_size_ets_#{full_test_name(ctx)}"
-      })
-
-    %{log_chunking: {LogChunker, opts}}
-  end
-
   def with_in_memory_storage(ctx) do
     {:ok, storage_opts} =
       InMemoryStorage.shared_opts(
@@ -33,7 +22,7 @@ defmodule Support.ComponentSetup do
         chunk_checkpoint_ets_table: :"chunk_checkpoint_ets_#{full_test_name(ctx)}"
       )
 
-    %{storage: {InMemoryStorage, Map.merge(storage_opts, with_log_chunker(ctx))}}
+    %{storage: {InMemoryStorage, storage_opts}}
   end
 
   def with_no_pool(_ctx) do
@@ -47,7 +36,7 @@ defmodule Support.ComponentSetup do
         file_path: ctx.tmp_dir
       )
 
-    %{storage: {CubDbStorage, Map.merge(storage_opts, with_log_chunker(ctx))}}
+    %{storage: {CubDbStorage, storage_opts}}
   end
 
   def with_persistent_kv(_ctx) do


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/1581

Will outline work done tomorrow, need to add some more tests as well - also I have deviated from the original design due to [this thread](https://electric-sql.slab.com/posts/rfc-chunking-the-log-2zee9qad#thread-xqaece2t).

I have externalised the chunk index from within the log itself but have kept it in storage - this might have a non-trivial impact on performance due to the additional IO involved in 1) storing the checkpoints and 2) reading the checkpoints on every request.

The benefits of externalising the index is that it makes it queriable, so we can still immediately know the end offset of a chunk before actually streaming it, which allows parallelisation of requests etc.