### PR TITLE
fix: Nullable arrays not being parsed as `null`

### DIFF
--- a/.changeset/sharp-icons-serve.md
+++ b/.changeset/sharp-icons-serve.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Fix nullable array fields not being parsed as `null`.

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -3,8 +3,12 @@ import { ColumnInfo, Message, Schema, Value } from './types'
 type NullToken = null | `NULL`
 type Token = Exclude<string, NullToken>
 type NullableToken = Token | NullToken
-export type ParseFunction<T extends Token | NullableToken = Token> = (
-  value: T,
+export type ParseFunction = (
+  value: Token,
+  additionalInfo?: Omit<ColumnInfo, `type` | `dims`>
+) => Value
+type NullableParseFunction = (
+  value: NullableToken,
   additionalInfo?: Omit<ColumnInfo, `type` | `dims`>
 ) => Value
 export type Parser = { [key: string]: ParseFunction }
@@ -136,7 +140,7 @@ function makeNullableParser(
   parser: ParseFunction,
   columnInfo: ColumnInfo,
   columnName?: string
-): ParseFunction<NullableToken> {
+): NullableParseFunction {
   const isNullable = !(columnInfo.not_null ?? false)
   // The sync service contains `null` value for a column whose value is NULL
   // but if the column value is an array that contains a NULL value

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -117,9 +117,9 @@ export class MessageParser {
     // Pick the right parser for the type
     // and support parsing null values if needed
     // if no parser is provided for the given type, just return the value as is
-    const identityParser = (v: Value) => v
-    const typParser = this.parser[typ] ?? identityParser
-    const parser = makeNullableParser(typParser, columnInfo.not_null)
+    const identityParser: ParseFunction = (v: string | null) => v
+    const typeParser: ParseFunction = this.parser[typ] ?? identityParser
+    const parser = makeNullableParser(typeParser, columnInfo.not_null)
 
     if (dimensions && dimensions > 0) {
       // It's an array

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -177,8 +177,8 @@ describe(`HTTP Sync`, () => {
       VALUES (
         'test',
         1,
-        2,
-        3,
+        2147483647,
+        9223372036854775807,
         4.5,
         TRUE,
         '{"foo": "bar"}',
@@ -230,8 +230,8 @@ describe(`HTTP Sync`, () => {
         {
           txt: `test`,
           i2: 1,
-          i4: 2,
-          i8: BigInt(3),
+          i4: 2147483647,
+          i8: BigInt(`9223372036854775807`),
           f8: 4.5,
           b: true,
           json: { foo: `bar` },

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -633,7 +633,10 @@ describe(`HTTP Sync`, () => {
       }
 
       const response = await fetch(...args)
-      statusCodesReceived.push(response.status)
+      if (response.status < 500) {
+        statusCodesReceived.push(response.status)
+      }
+
       return response
     }
 

--- a/packages/typescript-client/test/parser.test.ts
+++ b/packages/typescript-client/test/parser.test.ts
@@ -165,12 +165,12 @@ describe(`Message parser`, () => {
 
     const sampleDims = [undefined, 1, 2]
 
-    // If it's not nullable it should parse as a number
-    expect(
-      parser.parse(messages, { a: { type: `int2`, not_null: true } })
-    ).toEqual([{ value: { a: 0 } }])
-
     for (const dims of sampleDims) {
+      // If it's not nullable it should throw
+      expect(() =>
+        parser.parse(messages, { a: { type: `int2`, dims, not_null: true } })
+      ).toThrowError(`Column a is not nullable`)
+
       // Otherwise, it should parse as null
       expect(parser.parse(messages, { a: { type: `int2`, dims } })).toEqual(
         expectedParsedMessages

--- a/packages/typescript-client/test/parser.test.ts
+++ b/packages/typescript-client/test/parser.test.ts
@@ -163,40 +163,48 @@ describe(`Message parser`, () => {
     const messages = `[ { "value": { "a": null } } ]`
     const expectedParsedMessages = [{ value: { a: null } }]
 
+    const sampleDims = [undefined, 1, 2]
+
     // If it's not nullable it should parse as a number
     expect(
       parser.parse(messages, { a: { type: `int2`, not_null: true } })
     ).toEqual([{ value: { a: 0 } }])
-    // Otherwise, it should parse as null
-    expect(parser.parse(messages, { a: { type: `int2` } })).toEqual(
-      expectedParsedMessages
-    )
-    expect(parser.parse(messages, { a: { type: `int4` } })).toEqual(
-      expectedParsedMessages
-    )
-    expect(parser.parse(messages, { a: { type: `int8` } })).toEqual(
-      expectedParsedMessages
-    )
-    expect(parser.parse(messages, { a: { type: `bool` } })).toEqual(
-      expectedParsedMessages
-    )
-    expect(parser.parse(messages, { a: { type: `float4` } })).toEqual(
-      expectedParsedMessages
-    )
-    expect(parser.parse(messages, { a: { type: `float8` } })).toEqual(
-      expectedParsedMessages
-    )
-    expect(parser.parse(messages, { a: { type: `json` } })).toEqual(
-      expectedParsedMessages
-    )
-    expect(parser.parse(messages, { a: { type: `jsonb` } })).toEqual(
-      expectedParsedMessages
-    )
+
+    for (const dims of sampleDims) {
+      // Otherwise, it should parse as null
+      expect(parser.parse(messages, { a: { type: `int2`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+      expect(parser.parse(messages, { a: { type: `int4`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+      expect(parser.parse(messages, { a: { type: `int8`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+      expect(parser.parse(messages, { a: { type: `bool`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+      expect(parser.parse(messages, { a: { type: `float4`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+      expect(parser.parse(messages, { a: { type: `float8`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+      expect(parser.parse(messages, { a: { type: `json`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+      expect(parser.parse(messages, { a: { type: `jsonb`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+      expect(parser.parse(messages, { a: { type: `text`, dims } })).toEqual(
+        expectedParsedMessages
+      )
+    }
   })
 
   it(`should parse arrays including null values`, () => {
     const schema = {
-      a: { type: `int2`, dims: 1, nullable: true },
+      a: { type: `int2`, dims: 1 },
     }
 
     expect(


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/1597

I also made the types include the possibility of `null` being a value that needs to be parsed and changed the parsers accordingly.

I don't love that currently if a field is not nullable and `null` is received it tries to force it to a field (like `null` to `0` if it's a number), and this logic definitely does not work on arrays marked as `NOT NULL` that are `null`. Are we against throwing for those cases?