### PR TITLE
chore (docs): fix React integration snippet

### DIFF
--- a/docs/api/integrations/react.md
+++ b/docs/api/integrations/react.md
@@ -11,7 +11,7 @@ Example usage in a component.
 import { useShape } from "@electric-sql/react"
 
 export default function MyComponent() {
-  const { isUpToDate, data: fooData } = useShape({
+  const { isUpToDate, data } = useShape({
     url: `http://localhost:3000/v1/shape/foo`,
   })
 


### PR DESCRIPTION
The snippet on the React integration page was renaming `data` to `fooData` but then using `data` which does not exist. Removed the renaming.