### PR TITLE
Fix: `useShape` not correctly updating data when `selector` prop changes

### DIFF
--- a/.changeset/nine-worms-dance.md
+++ b/.changeset/nine-worms-dance.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/react": patch
+---
+
+Fix `useShape` not returning correct data upon changing `selector` prop - see https://github.com/electric-sql/electric/issues/1446.

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://next.electric-sql.com",
   "dependencies": {
-    "use-sync-external-store": "^1.2.2",
-    "@electric-sql/client": "workspace:*"
+    "@electric-sql/client": "workspace:*",
+    "use-sync-external-store": "^1.2.2"
   },
   "devDependencies": {
     "@testing-library/react": "^16.0.0",
@@ -46,7 +46,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "glob": "^10.3.10",
-    "global-jsdom": "24.0.0",
+    "jsdom": "^25.0.0",
     "pg": "^8.12.0",
     "prettier": "^3.3.2",
     "react": "^18.3.1",

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -4,7 +4,7 @@ import {
   ShapeStream,
   ShapeStreamOptions,
 } from '@electric-sql/client'
-import React, { useCallback, useEffect, useRef } from 'react'
+import React from 'react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
 
 const streamCache = new Map<string, ShapeStream>()
@@ -106,27 +106,24 @@ export function useShape<Selection = UseShapeResult>({
   const shapeStream = getShapeStream(options as ShapeStreamOptions)
   const shape = getShape(shapeStream)
 
-  const latestShapeData = useRef(parseShapeData(shape))
+  const useShapeData = React.useMemo(() => {
+    let latestShapeData = parseShapeData(shape)
+    const getSnapshot = () => latestShapeData
+    const subscribe = (onStoreChange: () => void) =>
+      shapeSubscribe(shape, () => {
+        latestShapeData = parseShapeData(shape)
+        onStoreChange()
+      })
 
-  // make sure to reset the data when selector is updated
-  useEffect(() => {
-    latestShapeData.current = parseShapeData(shape)
-  }, [selector])
+    return () => {
+      return useSyncExternalStoreWithSelector(
+        subscribe,
+        getSnapshot,
+        getSnapshot,
+        selector
+      )
+    }
+  }, [shape, selector])
 
-  const getSnapshot = React.useCallback(() => latestShapeData.current, [])
-  const shapeData = useSyncExternalStoreWithSelector(
-    useCallback(
-      (onStoreChange) =>
-        shapeSubscribe(shape, () => {
-          latestShapeData.current = parseShapeData(shape)
-          onStoreChange()
-        }),
-      [shape]
-    ),
-    getSnapshot,
-    getSnapshot,
-    selector
-  )
-
-  return shapeData
+  return useShapeData()
 }

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -4,7 +4,7 @@ import {
   ShapeStream,
   ShapeStreamOptions,
 } from '@electric-sql/client'
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
 
 const streamCache = new Map<string, ShapeStream>()
@@ -107,6 +107,12 @@ export function useShape<Selection = UseShapeResult>({
   const shape = getShape(shapeStream)
 
   const latestShapeData = useRef(parseShapeData(shape))
+
+  // make sure to reset the data when selector is updated
+  useEffect(() => {
+    latestShapeData.current = parseShapeData(shape)
+  }, [selector])
+
   const getSnapshot = React.useCallback(() => latestShapeData.current, [])
   const shapeData = useSyncExternalStoreWithSelector(
     useCallback(

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -1,11 +1,8 @@
-import 'global-jsdom/register'
-// https://react-hooks-testing-library.com/usage/advanced-hooks#context
-
 import { renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, inject, it as bareIt } from 'vitest'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { testWithIssuesTable as it } from './support/test-context'
-import { useShape, sortedOptionsHash } from '../src/react-hooks'
+import { useShape, sortedOptionsHash, UseShapeResult } from '../src/react-hooks'
 import { Shape, Message } from '@electric-sql/client'
 
 const BASE_URL = inject(`baseUrl`)
@@ -124,6 +121,46 @@ describe(`useShape`, () => {
         { id: id, title: `test row` },
         { id: id2, title: `other row` },
       ])
+    )
+  })
+
+  it(`should correctly reaply the selector if it changes`, async ({
+    aborter,
+    issuesTableUrl,
+    insertIssues,
+  }) => {
+    const firstRow = `test row 1`
+    const secondRow = `test row 2`
+    const [id1] = await insertIssues({ title: firstRow })
+    const [id2] = await insertIssues({ title: secondRow })
+
+    const createSelector = (filterVal: string) => (result: UseShapeResult) => {
+      result.data = result.data.filter((row) => row?.title !== filterVal)
+      return result
+    }
+
+    const selectorA = createSelector(firstRow)
+    const selectorB = createSelector(secondRow)
+
+    const { result, rerender } = renderHook(
+      ({ selector }) =>
+        useShape({
+          url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+          signal: aborter.signal,
+          subscribe: true,
+          selector: selector,
+        }),
+      { initialProps: { selector: selectorA } }
+    )
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual([{ id: id2, title: secondRow }])
+    )
+
+    rerender({ selector: selectorB })
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual([{ id: id1, title: firstRow }])
     )
   })
 

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -124,7 +124,7 @@ describe(`useShape`, () => {
     )
   })
 
-  it(`should correctly reaply the selector if it changes`, async ({
+  it(`should correctly reapply the selector to the data if it changes`, async ({
     aborter,
     issuesTableUrl,
     insertIssues,

--- a/packages/react-hooks/test/support/react-setup.ts
+++ b/packages/react-hooks/test/support/react-setup.ts
@@ -1,0 +1,6 @@
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})

--- a/packages/react-hooks/vitest.config.ts
+++ b/packages/react-hooks/vitest.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     globalSetup: `test/support/global-setup.ts`,
+    setupFiles: [`test/support/react-setup.ts`],
+    environment: 'jsdom',
     typecheck: { enabled: true },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,9 +695,9 @@ importers:
       glob:
         specifier: ^10.3.10
         version: 10.4.5
-      global-jsdom:
-        specifier: 24.0.0
-        version: 24.0.0(jsdom@24.1.0)
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.0
       pg:
         specifier: ^8.12.0
         version: 8.12.0
@@ -721,7 +721,7 @@ importers:
         version: 10.0.0
       vitest:
         specifier: ^2.0.2
-        version: 2.0.3(@types/node@20.14.11)(jsdom@24.1.0)
+        version: 2.0.3(@types/node@20.14.11)(jsdom@25.0.0)
 
   packages/sync-service: {}
 
@@ -781,7 +781,7 @@ importers:
         version: 10.0.0
       vitest:
         specifier: ^2.0.2
-        version: 2.0.3(@types/node@20.14.11)(jsdom@24.1.0)
+        version: 2.0.3(@types/node@20.14.11)(jsdom@25.0.0)
 
 packages:
 
@@ -5122,12 +5122,6 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
-  global-jsdom@24.0.0:
-    resolution: {integrity: sha512-CARBUWkqZ3O9VOc2PIVE5kQpdQeJh9eF9kQ7zSeNtmqx5vAFDKMr9XnDt1epVMMrz1s9uK/yFCa4HLwpa6TcPA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      jsdom: '>=24 <25'
-
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -5642,8 +5636,8 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
-  jsdom@24.1.0:
-    resolution: {integrity: sha512-6gpM7pRXCwIOKxX47cgOyvyQDN/Eh0f1MeKySBV2xGdKtqJBLj8P25eY3EVCWo2mglDDzozR2r2MW4T+JiNUZA==}
+  jsdom@25.0.0:
+    resolution: {integrity: sha512-OhoFVT59T7aEq75TVw9xxEfkXgacpqAhQaYgP9y/fDqWQCMB/b1H66RfmPm/MaeaAIU9nDwMOVTlPN51+ao6CQ==}
     engines: {node: '>=18'}
     peerDependencies:
       canvas: ^2.11.2
@@ -13514,10 +13508,6 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  global-jsdom@24.0.0(jsdom@24.1.0):
-    dependencies:
-      jsdom: 24.1.0
-
   globals@11.12.0: {}
 
   globals@13.24.0:
@@ -14026,7 +14016,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@24.1.0:
+  jsdom@25.0.0:
     dependencies:
       cssstyle: 4.0.1
       data-urls: 5.0.0
@@ -17100,7 +17090,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@2.0.3(@types/node@20.14.11)(jsdom@24.1.0):
+  vitest@2.0.3(@types/node@20.14.11)(jsdom@25.0.0):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@vitest/expect': 2.0.3
@@ -17123,7 +17113,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.14.11
-      jsdom: 24.1.0
+      jsdom: 25.0.0
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/1446

There is some weirdness with the `useSyncExternalStoreWithSelector` hook when passed a ref w.r.t. to selector changing - need to look into this deeper, I suspect memoization is using referential equality checks which is messing things up.