### PR TITLE
feat!: unify storage location for configuration ease

### DIFF
--- a/.changeset/poor-turtles-double.md
+++ b/.changeset/poor-turtles-double.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": minor
+---
+
+Replace individual persistence location configuration with a single `STORAGE_DIR` environment variable, that should be bound to a volume to survive Electric restarts. If you were using `CUBDB_FILE_PATH`, you should move that folder into a subdirectory named `shapes` and configure `STORAGE_DIR` to the previous directory.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -71,9 +71,11 @@ cache_max_age = env!("CACHE_MAX_AGE", :integer, 60)
 cache_stale_age = env!("CACHE_STALE_AGE", :integer, 60 * 5)
 statsd_host = env!("STATSD_HOST", :string?, nil)
 
-cubdb_file_path = env!("CUBDB_FILE_PATH", :string, "./shapes")
-mixed_file_path = env!("MIXED_STORAGE_DIR", :string, "./shapes_mixed")
-persistent_state_path = env!("PERSISTENT_STATE_FILE_PATH", :string, "./state")
+storage_dir = env!("STORAGE_DIR", :string, "./persistent")
+
+cubdb_file_path = Path.join(storage_dir, "./shapes")
+mixed_file_path = Path.join(storage_dir, "./shapes_mixed")
+persistent_state_path = Path.join(storage_dir, "./state")
 
 persistent_kv =
   env!(


### PR DESCRIPTION
Replace individual persistence location configuration with a single `STORAGE_DIR` environment variable, that should be bound to a volume to survive Electric restarts. If you were using `CUBDB_FILE_PATH`, you should move that folder into a subdirectory named `shapes` and configure `STORAGE_DIR` to the previous directory.