### PR TITLE
feat (client): expose time elapsed since last sync

### DIFF
--- a/.changeset/brown-turtles-listen.md
+++ b/.changeset/brown-turtles-listen.md
@@ -1,5 +1,0 @@
----
-"@electric-sql/client": patch
----
-
-Expose a `lastSynced` field on the `ShapeStream` and `Shape` classes which is the time elapsed since the last sync with Electric (in milliseconds).

--- a/.changeset/brown-turtles-listen.md
+++ b/.changeset/brown-turtles-listen.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Expose a `lastSynced` field on the `ShapeStream` and `Shape` classes which is the time elapsed since the last sync with Electric (in milliseconds).

--- a/.changeset/brown-turtles-listen.md
+++ b/.changeset/brown-turtles-listen.md
@@ -1,5 +1,6 @@
 ---
-"@electric-sql/client": patch
+"@electric-sql/client": minor
 ---
 
 Expose a `lastSyncedAt` field on the `ShapeStream` and `Shape` classes which is the time elapsed since the last sync with Electric (in milliseconds).
+Remove the `isUpToDate` field on the `Shape` class.

--- a/.changeset/brown-turtles-listen.md
+++ b/.changeset/brown-turtles-listen.md
@@ -2,4 +2,4 @@
 "@electric-sql/client": patch
 ---
 
-Expose a `lastSynced` field on the `ShapeStream` and `Shape` classes which is the time elapsed since the last sync with Electric (in milliseconds).
+Expose a `lastSyncedAt` field on the `ShapeStream` and `Shape` classes which is the time elapsed since the last sync with Electric (in milliseconds).

--- a/.changeset/brown-turtles-listen.md
+++ b/.changeset/brown-turtles-listen.md
@@ -2,5 +2,4 @@
 "@electric-sql/client": minor
 ---
 
-Expose a `lastSyncedAt` field on the `ShapeStream` and `Shape` classes which is the time elapsed since the last sync with Electric (in milliseconds).
-Remove the `isUpToDate` field on the `Shape` class.
+Expose a `lastSyncedAt` field on the `ShapeStream` and `Shape` classes which is the time elapsed since the last sync with Electric (in milliseconds). Remove the `isUpToDate` field on the `Shape` class.

--- a/.changeset/funny-houses-remember.md
+++ b/.changeset/funny-houses-remember.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Expose an `isConnected` method on `ShapeStream` and `Shape` classes.

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -70,10 +70,6 @@ export interface UseShapeResult<T extends Row = Row> {
   shape: Shape<T>
   error: Shape<T>[`error`]
   isError: boolean
-  /**
-   * Has the ShapeStream caught up with the replication log from Postgres.
-   */
-  isUpToDate: boolean
 }
 
 function shapeSubscribe<T extends Row>(shape: Shape<T>, callback: () => void) {
@@ -86,7 +82,6 @@ function shapeSubscribe<T extends Row>(shape: Shape<T>, callback: () => void) {
 function parseShapeData<T extends Row>(shape: Shape<T>): UseShapeResult<T> {
   return {
     data: [...shape.valueSync.values()],
-    isUpToDate: shape.isUpToDate,
     isError: shape.error !== false,
     shape,
     error: shape.error,

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -34,7 +34,6 @@ describe(`useShape`, () => {
       })
     )
 
-    await waitFor(() => expect(result.current.isUpToDate).toEqual(true))
     await waitFor(() => expect(result.current.error).toBe(false))
     await waitFor(() => expect(result.current.isError).toEqual(false))
     await waitFor(() => expect(result.current.data).toEqual([]))

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -415,7 +415,9 @@ export class ShapeStream<T extends Row = Row> {
       try {
         const result = await this.fetchClient(url.toString(), { signal })
         if (result.ok) {
-          this.connected = true
+          if (this.options.subscribe) {
+            this.connected = true
+          }
           return result
         } else throw await FetchError.fromResponse(result, url.toString())
       } catch (e) {

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -498,6 +498,10 @@ export class Shape<T extends Row = Row> {
     )
   }
 
+  get isUpToDate(): boolean {
+    return this.stream.isUpToDate
+  }
+
   lastSynced(): number {
     return this.stream.lastSynced()
   }

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -500,10 +500,6 @@ export class Shape<T extends Row = Row> {
     )
   }
 
-  get isUpToDate(): boolean {
-    return this.stream.isUpToDate
-  }
-
   lastSynced(): number {
     return this.stream.lastSynced()
   }

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -286,4 +286,19 @@ describe(`Shape`, () => {
 
     expect(shapeStream.isConnected()).true
   })
+
+  it(`should set isConnected to false after fetch if not subscribed`, async ({
+    issuesTableUrl,
+  }) => {
+    const shapeStream = new ShapeStream({
+      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+      subscribe: false,
+    })
+
+    await sleep(100) // give some time for the fetch to complete
+
+    // We should no longer be connected because
+    // the initial fetch finished and we've not subscribed to changes
+    expect(shapeStream.isConnected()).false
+  })
 })


### PR DESCRIPTION
This PR fixes https://github.com/electric-sql/electric/issues/1468 as it exposes a `lastSynced` getter on the `ShapeStream` and `Shape` classes which is the number of milliseconds since last sync with the server.