### PR TITLE
chore: Externalize log chunking from storage to `ShapeConsumer`

### DIFF
--- a/.changeset/lemon-countries-own.md
+++ b/.changeset/lemon-countries-own.md
@@ -1,5 +1,0 @@
----
-"@core/sync-service": patch
----
-
-Move log chunking to `ShapeConsumer` to reduce the storage layer's responsibility.

--- a/.changeset/lemon-countries-own.md
+++ b/.changeset/lemon-countries-own.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Move log chunking to `ShapeConsumer` to reduce the storage layer's responsibility.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -93,9 +93,7 @@ persistent_kv =
     {Electric.PersistentKV.Filesystem, :new!, root: persistent_state_path}
   )
 
-common_storage_opts = [
-  chunk_bytes_threshold: env!("LOG_CHUNK_BYTES_THRESHOLD", :integer, 10_000)
-]
+chunk_bytes_threshold = env!("LOG_CHUNK_BYTES_THRESHOLD", :integer, 10_000)
 
 {storage_mod, storage_opts} =
   env!(
@@ -118,12 +116,13 @@ common_storage_opts = [
     {Electric.ShapeCache.MixedDiskStorage, storage_dir: mixed_file_path}
   )
 
-storage = {storage_mod, storage_opts ++ common_storage_opts}
+storage = {storage_mod, storage_opts}
 
 config :electric,
   allow_shape_deletion: enable_integration_testing,
   cache_max_age: cache_max_age,
   cache_stale_age: cache_stale_age,
+  chunk_bytes_threshold: chunk_bytes_threshold,
   # Used in telemetry
   environment: config_env(),
   instance_id: instance_id,

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -35,6 +35,7 @@ defmodule Electric.Application do
          storage: storage,
          inspector: inspector,
          prepare_tables_fn: prepare_tables_fn,
+         chunk_bytes_threshold: Application.fetch_env!(:electric, :chunk_bytes_threshold),
          log_producer: Electric.Replication.ShapeLogCollector,
          persistent_kv: persistent_kv,
          registry: Registry.ShapeChanges}

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -56,6 +56,7 @@ defmodule Electric.ShapeCache do
               default: Electric.Replication.ShapeLogCollector
             ],
             storage: [type: :mod_arg, required: true],
+            chunk_bytes_threshold: [type: :non_neg_integer, required: true],
             inspector: [type: :mod_arg, required: true],
             shape_status: [type: :atom, default: Electric.ShapeCache.ShapeStatus],
             registry: [type: {:or, [:atom, :pid]}, required: true],
@@ -177,6 +178,7 @@ defmodule Electric.ShapeCache do
     state = %{
       name: opts.name,
       storage: opts.storage,
+      chunk_bytes_threshold: opts.chunk_bytes_threshold,
       inspector: opts.inspector,
       shape_meta_table: opts.shape_meta_table,
       shape_status: opts.shape_status,
@@ -378,6 +380,7 @@ defmodule Electric.ShapeCache do
              shape_id: shape_id,
              shape: shape,
              storage: state.storage,
+             chunk_bytes_threshold: state.chunk_bytes_threshold,
              log_producer: state.log_producer,
              shape_cache:
                {__MODULE__, %{server: state.name, shape_meta_table: state.shape_meta_table}},

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -1,5 +1,4 @@
 defmodule Electric.ShapeCache.CubDbStorage do
-  alias Electric.ShapeCache.LogChunker
   alias Electric.ConcurrentStream
   alias Electric.Replication.LogOffset
   alias Electric.Telemetry.OpenTelemetry
@@ -18,16 +17,12 @@ defmodule Electric.ShapeCache.CubDbStorage do
   def shared_opts(opts) do
     base_path = Access.get(opts, :file_path, "./shapes")
 
-    chunk_bytes_threshold =
-      Access.get(opts, :chunk_bytes_threshold, LogChunker.default_chunk_size_threshold())
-
     {:ok,
      %{
        base_path: base_path,
        shape_id: nil,
        db: nil,
-       version: @version,
-       chunk_bytes_threshold: chunk_bytes_threshold
+       version: @version
      }}
   end
 
@@ -188,36 +183,15 @@ defmodule Electric.ShapeCache.CubDbStorage do
     end)
   end
 
-  def append_to_log!(shape_id, log_items, log_state, opts) do
-    chunk_bytes_threshold = Access.fetch!(opts, :chunk_bytes_threshold)
-
+  def append_to_log!(shape_id, log_items, opts) do
     log_items
-    |> Enum.flat_map_reduce(log_state, fn log_item, log_state ->
-      json_log_item = Jason.encode!(log_item)
-      log_key = log_key(shape_id, log_item.offset)
-      current_chunk_size = log_state.current_chunk_byte_size
-
-      case LogChunker.add_to_chunk(json_log_item, current_chunk_size, chunk_bytes_threshold) do
-        {:ok, new_chunk_size} ->
-          {
-            [{log_key, json_log_item}],
-            %{log_state | current_chunk_byte_size: new_chunk_size}
-          }
-
-        {:threshold_exceeded, new_chunk_size} ->
-          {
-            [
-              {log_key, json_log_item},
-              {chunk_checkpoint_key(shape_id, log_item.offset), nil}
-            ],
-            %{log_state | current_chunk_byte_size: new_chunk_size}
-          }
-      end
+    |> Enum.map(fn
+      {:chunk_boundary, offset} -> {chunk_checkpoint_key(shape_id, offset), nil}
+      {offset, json_log_item} -> {log_key(shape_id, offset), json_log_item}
     end)
-    |> then(fn {items, log_state} ->
-      CubDB.put_multi(opts.db, items)
-      log_state
-    end)
+    |> then(&CubDB.put_multi(opts.db, &1))
+
+    :ok
   end
 
   def cleanup!(shape_id, opts) do

--- a/packages/sync-service/lib/electric/shapes/supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/supervisor.ex
@@ -11,6 +11,7 @@ defmodule Electric.Shapes.Supervisor do
             shape_cache: [type: :mod_arg, required: true],
             registry: [type: :atom, required: true],
             storage: [type: :mod_arg, required: true],
+            chunk_bytes_threshold: [type: :non_neg_integer, required: true],
             db_pool: [type: {:or, [:atom, :pid]}, default: Electric.DbPool],
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
@@ -35,7 +36,8 @@ defmodule Electric.Shapes.Supervisor do
   end
 
   def init(config) when is_map(config) do
-    %{shape_id: shape_id, storage: {_, _} = storage} = config
+    %{shape_id: shape_id, storage: {_, _} = storage} =
+      config
 
     shape_storage = Electric.ShapeCache.Storage.for_shape(shape_id, storage)
 

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -620,7 +620,7 @@ defmodule Electric.Plug.RouterTest do
       opts: opts,
       db_conn: db_conn
     } do
-      {_, %{chunk_bytes_threshold: threshold}} = Access.fetch!(opts, :storage)
+      threshold = Access.fetch!(opts, :chunk_bytes_threshold)
 
       first_val = String.duplicate("a", round(threshold * 0.6))
       second_val = String.duplicate("b", round(threshold * 0.7))

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -73,6 +73,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       shape_cache_opts =
         [
           storage: {MockStorage, []},
+          chunk_bytes_threshold: 10_000,
           inspector: {MockInspector, []},
           shape_status: MockShapeStatus,
           shape_meta_table: shape_meta_table,

--- a/packages/sync-service/test/electric/shape_cache/log_chunker.exs
+++ b/packages/sync-service/test/electric/shape_cache/log_chunker.exs
@@ -2,8 +2,6 @@ defmodule Electric.ShapeCache.LogChunkerTest do
   use ExUnit.Case, async: true
   alias Electric.ShapeCache.LogChunker
 
-  @test_shape_id "test_shape_id"
-
   describe "add_chunk/3" do
     test "should reset counter upon exceeding threshold", _ do
       chunk_bytes = "test"

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -18,14 +18,14 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.expect(:make_new_snapshot!, fn _, _, {^shape_id, :opts} -> :ok end)
     |> Mox.expect(:snapshot_started?, fn _, {^shape_id, :opts} -> true end)
     |> Mox.expect(:get_snapshot, fn _, {^shape_id, :opts} -> {1, []} end)
-    |> Mox.expect(:append_to_log!, fn _, _, _, {^shape_id, :opts} -> :ok end)
+    |> Mox.expect(:append_to_log!, fn _, _, {^shape_id, :opts} -> :ok end)
     |> Mox.expect(:get_log_stream, fn _, _, _, {^shape_id, :opts} -> [] end)
     |> Mox.expect(:cleanup!, fn _, {^shape_id, :opts} -> :ok end)
 
     Storage.make_new_snapshot!(shape_id, [], storage)
     Storage.snapshot_started?(shape_id, storage)
     Storage.get_snapshot(shape_id, storage)
-    Storage.append_to_log!(shape_id, [], %{}, storage)
+    Storage.append_to_log!(shape_id, [], storage)
     Storage.get_log_stream(shape_id, LogOffset.first(), storage)
     Storage.cleanup!(shape_id, storage)
   end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -28,7 +28,6 @@ defmodule Electric.ShapeCacheTest do
       }
     }
   }
-  @initial_log_state %{current_chunk_byte_size: 0}
   @lsn Electric.Postgres.Lsn.from_integer(13)
   @change_offset LogOffset.new(@lsn, 2)
   @xid 99
@@ -56,6 +55,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_no_pool,
       :with_registry,
       :with_transaction_producer
@@ -85,6 +85,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_transaction_producer
     ]
@@ -210,6 +211,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_unique_db,
       :with_publication,
@@ -371,6 +373,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_transaction_producer
     ]
@@ -439,6 +442,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_transaction_producer
     ]
@@ -478,6 +482,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_transaction_producer
     ]
@@ -635,6 +640,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_transaction_producer
     ]
@@ -665,7 +671,6 @@ defmodule Electric.ShapeCacheTest do
             log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
           }
         ]),
-        @initial_log_state,
         storage
       )
 
@@ -688,6 +693,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_transaction_producer
     ]
@@ -718,7 +724,6 @@ defmodule Electric.ShapeCacheTest do
             log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
           }
         ]),
-        @initial_log_state,
         storage
       )
 
@@ -764,6 +769,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_cub_db_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_transaction_producer,
       :with_no_pool
@@ -905,6 +911,7 @@ defmodule Electric.ShapeCacheTest do
     setup [
       :with_in_memory_storage,
       :with_persistent_kv,
+      :with_log_chunking,
       :with_registry,
       :with_transaction_producer,
       :with_no_pool

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -44,6 +44,10 @@ defmodule Support.ComponentSetup do
     %{persistent_kv: kv}
   end
 
+  def with_log_chunking(_ctx) do
+    %{chunk_bytes_threshold: 10_000}
+  end
+
   def with_shape_cache(ctx, additional_opts \\ []) do
     shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
     server = :"shape_cache_#{full_test_name(ctx)}"
@@ -54,6 +58,7 @@ defmodule Support.ComponentSetup do
         shape_meta_table: shape_meta_table,
         inspector: ctx.inspector,
         storage: ctx.storage,
+        chunk_bytes_threshold: ctx.chunk_bytes_threshold,
         db_pool: ctx.pool,
         persistent_kv: ctx.persistent_kv,
         registry: ctx.registry,
@@ -131,6 +136,7 @@ defmodule Support.ComponentSetup do
       &with_registry/1,
       &with_inspector/1,
       &with_persistent_kv/1,
+      &with_log_chunking/1,
       &with_cub_db_storage/1,
       &with_shape_log_collector/1,
       &with_shape_cache/1,
@@ -148,6 +154,8 @@ defmodule Support.ComponentSetup do
       long_poll_timeout: Access.get(overrides, :long_poll_timeout, 5_000),
       max_age: Access.get(overrides, :max_age, 60),
       stale_age: Access.get(overrides, :stale_age, 300),
+      chunk_bytes_threshold:
+        Access.get(overrides, :chunk_bytes_threshold, ctx.chunk_bytes_threshold),
       allow_shape_deletion: Access.get(overrides, :allow_shape_deletion, true)
     ]
     |> Keyword.merge(overrides)

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -10,5 +10,6 @@ defmodule Support.TestUtils do
     changes
     |> Enum.map(&Changes.fill_key(&1, pk))
     |> Enum.flat_map(&LogItems.from_change(&1, xid, pk))
+    |> Enum.map(fn item -> {item.offset, Jason.encode!(item)} end)
   end
 end


### PR DESCRIPTION
Based on feedback from @icehaunter - moving the chunking to the `ShapeConsumer` to reduce duplication and limit the storage layer's responsibility (as well as splitting IO from processing/preparing).

The JSON serializing and chunking of the log is now handled by the `ShapeConsumer` (see `prepare_log_entries` method), so storage only needs to distinguish between actual log items and chunk boundaries. That's perhaps the main coupling point/interface change that is noteworthy.

I've also moved the `chunk_byte_threshold` config outside of storage as it is no longer its responsibility, which meant threading it through a bunch of places. I'm happy to change that if there's a better pattern to do that.