### PR TITLE
feat: `PersistedShapeStream` with generic storage interface

### DIFF
--- a/.changeset/friendly-emus-invite.md
+++ b/.changeset/friendly-emus-invite.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Introduce `PersistedShapeStream` API for local caching of the shape stream.

--- a/packages/sync-service/.gitignore
+++ b/packages/sync-service/.gitignore
@@ -28,5 +28,6 @@ electric-*.tar
 # The shape database, created when the Sync Service runs
 /shapes/
 /state/
+/persistent/
 
 .env.dev.local

--- a/packages/typescript-client/package.json
+++ b/packages/typescript-client/package.json
@@ -12,6 +12,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "default": "./dist/cjs/index.cjs"
+    },
+    "./persist": {
+      "types": "./dist/persist.d.ts",
+      "import": "./dist/persist.mjs",
+      "default": "./dist/cjs/persist.cjs"
     }
   },
   "files": [

--- a/packages/typescript-client/src/async-or.ts
+++ b/packages/typescript-client/src/async-or.ts
@@ -1,0 +1,44 @@
+import { PromiseOr } from './types'
+
+export function isPromise<T>(promise: PromiseOr<T>): promise is Promise<T> {
+  return (
+    !!promise &&
+    typeof promise === `object` &&
+    `then` in promise &&
+    typeof promise.then === `function`
+  )
+}
+
+export function asyncOrCall<T>(
+  item: PromiseOr<T>,
+  callback: (item: T) => void,
+  onError?: (error: unknown) => void
+): PromiseOr<void> {
+  if (!isPromise(item)) {
+    try {
+      return callback(item)
+    } catch (err: unknown) {
+      if (onError) return onError(err)
+      throw err
+    }
+  }
+
+  return item.then((item) => callback(item)).catch(onError)
+}
+
+export function asyncOrIterable<T>(
+  iterable: Iterable<T> | AsyncIterable<T>,
+  callback: (item: T) => void
+): PromiseOr<void> {
+  if (Symbol.asyncIterator in iterable) {
+    return (async () => {
+      for await (const item of iterable) {
+        callback(item)
+      }
+    })()
+  }
+
+  for (const item of iterable) {
+    callback(item)
+  }
+}

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1,4 +1,4 @@
-import { Message, Offset, Schema, Row } from './types'
+import { Message, Offset, Schema, Row, PromiseOr } from './types'
 import { MessageParser, Parser } from './parser'
 import { isChangeMessage, isControlMessage } from './helpers'
 
@@ -67,9 +67,9 @@ export interface ShapeStreamOptions {
 class MessageProcessor<T extends Row = Row> {
   private messageQueue: Message<T>[][] = []
   private isProcessing = false
-  private callback: (messages: Message<T>[]) => void | Promise<void>
+  private callback: (messages: Message<T>[]) => PromiseOr<void>
 
-  constructor(callback: (messages: Message<T>[]) => void | Promise<void>) {
+  constructor(callback: (messages: Message<T>[]) => PromiseOr<void>) {
     this.callback = callback
   }
 
@@ -141,13 +141,13 @@ export class FetchError extends Error {
 
 export interface ShapeStreamInterface<T extends Row = Row> {
   subscribe(
-    callback: (messages: Message<T>[]) => void,
+    callback: (messages: Message<T>[]) => PromiseOr<void>,
     onError?: (error: FetchError | Error) => void
   ): void
   unsubscribeAllUpToDateSubscribers(): void
   unsubscribeAll(): void
   subscribeOnceToUpToDate(
-    callback: () => void,
+    callback: () => PromiseOr<void>,
     error: (err: FetchError | Error) => void
   ): () => void
 
@@ -307,7 +307,7 @@ export class ShapeStream<T extends Row = Row>
   }
 
   subscribe(
-    callback: (messages: Message<T>[]) => void | Promise<void>,
+    callback: (messages: Message<T>[]) => PromiseOr<void>,
     onError?: (error: FetchError | Error) => void
   ) {
     const subscriptionId = Math.random()
@@ -337,7 +337,7 @@ export class ShapeStream<T extends Row = Row>
   }
 
   subscribeOnceToUpToDate(
-    callback: () => void | Promise<void>,
+    callback: () => PromiseOr<void>,
     error: (err: FetchError | Error) => void
   ) {
     const subscriptionId = Math.random()

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -140,13 +140,19 @@ export class FetchError extends Error {
 }
 
 export interface ShapeStreamInterface<T extends Row = Row> {
-  subscribe(callback: (messages: Message<T>[]) => void): void
+  subscribe(
+    callback: (messages: Message<T>[]) => void,
+    onError?: (error: FetchError | Error) => void
+  ): void
   unsubscribeAllUpToDateSubscribers(): void
   unsubscribeAll(): void
   subscribeOnceToUpToDate(
     callback: () => void,
     error: (err: FetchError | Error) => void
   ): () => void
+
+  isUpToDate: boolean
+  shapeId?: string
 }
 
 /**
@@ -463,14 +469,14 @@ export class ShapeStream<T extends Row = Row>
  *     })
  */
 export class Shape<T extends Row = Row> {
-  private stream: ShapeStream<T>
+  private stream: ShapeStreamInterface<T>
 
   private data: ShapeData<T> = new Map()
   private subscribers = new Map<number, ShapeChangedCallback<T>>()
   public error: FetchError | false = false
   private hasNotifiedSubscribersUpToDate: boolean = false
 
-  constructor(stream: ShapeStream<T>) {
+  constructor(stream: ShapeStreamInterface<T>) {
     this.stream = stream
     this.stream.subscribe(this.process.bind(this), this.handleError.bind(this))
     const unsubscribe = this.stream.subscribeOnceToUpToDate(

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1,23 +1,14 @@
 import { Message, Offset, Schema, Row, PromiseOr } from './types'
 import { MessageParser, Parser } from './parser'
-import { isChangeMessage, isControlMessage } from './helpers'
-
-export type ShapeData<T extends Row = Row> = Map<string, T>
-export type ShapeChangedCallback<T extends Row = Row> = (
-  value: ShapeData<T>
-) => void
-
-export interface BackoffOptions {
-  initialDelay: number
-  maxDelay: number
-  multiplier: number
-}
-
-export const BackoffDefaults = {
-  initialDelay: 100,
-  maxDelay: 10_000,
-  multiplier: 1.3,
-}
+import { isUpToDateMessage } from './helpers'
+import { MessageProcessor } from './queue'
+import { FetchError, FetchBackoffAbortError } from './error'
+import { BackoffOptions, createFetchWithBackoff } from './fetch'
+import {
+  CHUNK_LAST_OFFSET_HEADER,
+  SHAPE_ID_HEADER,
+  SHAPE_SCHEMA_HEADER,
+} from './constants'
 
 /**
  * Options for constructing a ShapeStream.
@@ -55,88 +46,6 @@ export interface ShapeStreamOptions {
   signal?: AbortSignal
   fetchClient?: typeof fetch
   parser?: Parser
-}
-
-/**
- * Receives batches of `messages`, puts them on a queue and processes
- * them asynchronously by passing to a registered callback function.
- *
- * @constructor
- * @param {(messages: Message[]) => void} callback function
- */
-class MessageProcessor<T extends Row = Row> {
-  private messageQueue: Message<T>[][] = []
-  private isProcessing = false
-  private callback: (messages: Message<T>[]) => PromiseOr<void>
-
-  constructor(callback: (messages: Message<T>[]) => PromiseOr<void>) {
-    this.callback = callback
-  }
-
-  process(messages: Message<T>[]) {
-    this.messageQueue.push(messages)
-
-    if (!this.isProcessing) {
-      this.processQueue()
-    }
-  }
-
-  private async processQueue() {
-    this.isProcessing = true
-
-    while (this.messageQueue.length > 0) {
-      const messages = this.messageQueue.shift()!
-
-      await this.callback(messages)
-    }
-
-    this.isProcessing = false
-  }
-}
-
-export class FetchError extends Error {
-  status: number
-  text?: string
-  json?: object
-  headers: Record<string, string>
-
-  constructor(
-    status: number,
-    text: string | undefined,
-    json: object | undefined,
-    headers: Record<string, string>,
-    public url: string,
-    message?: string
-  ) {
-    super(
-      message ||
-        `HTTP Error ${status} at ${url}: ${text ?? JSON.stringify(json)}`
-    )
-    this.name = `FetchError`
-    this.status = status
-    this.text = text
-    this.json = json
-    this.headers = headers
-  }
-
-  static async fromResponse(
-    response: Response,
-    url: string
-  ): Promise<FetchError> {
-    const status = response.status
-    const headers = Object.fromEntries([...response.headers.entries()])
-    let text: string | undefined = undefined
-    let json: object | undefined = undefined
-
-    const contentType = response.headers.get(`content-type`)
-    if (contentType && contentType.includes(`application/json`)) {
-      json = (await response.json()) as object
-    } else {
-      text = await response.text()
-    }
-
-    return new FetchError(status, text, json, headers, url)
-  }
 }
 
 export interface ShapeStreamInterface<T extends Row = Row> {
@@ -189,79 +98,85 @@ export interface ShapeStreamInterface<T extends Row = Row> {
 export class ShapeStream<T extends Row = Row>
   implements ShapeStreamInterface<T>
 {
-  private options: ShapeStreamOptions
-  private backoffOptions: BackoffOptions
-  private fetchClient: typeof fetch
-  private schema?: Schema
+  readonly #options: ShapeStreamOptions
 
-  private subscribers = new Map<
+  readonly #fetchClient: typeof fetch
+  readonly #messageParser: MessageParser<T>
+
+  readonly #subscribers = new Map<
     number,
-    [MessageProcessor<T>, ((error: Error) => void) | undefined]
+    [MessageProcessor<Message<T>[]>, ((error: Error) => void) | undefined]
   >()
-  private upToDateSubscribers = new Map<
+  readonly #upToDateSubscribers = new Map<
     number,
     [() => void, (error: FetchError | Error) => void]
   >()
 
-  private lastOffset: Offset
-  private messageParser: MessageParser<T>
-  public isUpToDate: boolean = false
-
-  shapeId?: string
+  #lastOffset: Offset
+  #isUpToDate: boolean = false
+  #shapeId?: string
+  #schema?: Schema
 
   constructor(options: ShapeStreamOptions) {
-    this.validateOptions(options)
-    this.options = { subscribe: true, ...options }
-    this.lastOffset = this.options.offset ?? `-1`
-    this.shapeId = this.options.shapeId
-    this.messageParser = new MessageParser<T>(options.parser)
+    validateOptions(options)
+    this.#options = { subscribe: true, ...options }
+    this.#lastOffset = this.#options.offset ?? `-1`
+    this.#shapeId = this.#options.shapeId
+    this.#messageParser = new MessageParser<T>(options.parser)
 
-    this.backoffOptions = options.backoffOptions ?? BackoffDefaults
-    this.fetchClient =
+    this.#fetchClient = createFetchWithBackoff(
       options.fetchClient ??
-      ((...args: Parameters<typeof fetch>) => fetch(...args))
+        ((...args: Parameters<typeof fetch>) => fetch(...args)),
+      options.backoffOptions
+    )
 
     this.start()
   }
 
+  get shapeId() {
+    return this.#shapeId
+  }
+
+  get isUpToDate() {
+    return this.#isUpToDate
+  }
+
   async start() {
-    this.isUpToDate = false
+    this.#isUpToDate = false
 
-    const { url, where, signal } = this.options
+    const { url, where, signal } = this.#options
 
-    while ((!signal?.aborted && !this.isUpToDate) || this.options.subscribe) {
+    while ((!signal?.aborted && !this.#isUpToDate) || this.#options.subscribe) {
       const fetchUrl = new URL(url)
       if (where) fetchUrl.searchParams.set(`where`, where)
-      fetchUrl.searchParams.set(`offset`, this.lastOffset)
+      fetchUrl.searchParams.set(`offset`, this.#lastOffset)
 
-      if (this.isUpToDate) {
+      if (this.#isUpToDate) {
         fetchUrl.searchParams.set(`live`, `true`)
       }
 
-      if (this.shapeId) {
+      if (this.#shapeId) {
         // This should probably be a header for better cache breaking?
-        fetchUrl.searchParams.set(`shape_id`, this.shapeId!)
+        fetchUrl.searchParams.set(`shape_id`, this.#shapeId!)
       }
 
       let response!: Response
-
       try {
-        const maybeResponse = await this.fetchWithBackoff(fetchUrl)
-        if (maybeResponse) response = maybeResponse
-        else break
+        response = await this.#fetchClient(fetchUrl.toString(), { signal })
       } catch (e) {
+        if (e instanceof FetchBackoffAbortError) break // interrupted
         if (!(e instanceof FetchError)) throw e // should never happen
         if (e.status == 409) {
           // Upon receiving a 409, we should start from scratch
           // with the newly provided shape ID
-          const newShapeId = e.headers[`x-electric-shape-id`]
-          this.reset(newShapeId)
-          this.publish(e.json as Message<T>[])
+          const newShapeId = e.headers[SHAPE_ID_HEADER]
+          this.#reset(newShapeId)
+          this.#publish(e.json as Message<T>[])
           continue
         } else if (e.status >= 400 && e.status < 500) {
           // Notify subscribers
-          this.sendErrorToUpToDateSubscribers(e)
-          this.sendErrorToSubscribers(e)
+          this.#sendErrorToUpToDateSubscribers(e)
+          this.#sendErrorToSubscribers(e)
 
           // 400 errors are not actionable without additional user input, so we're throwing them.
           throw e
@@ -269,39 +184,35 @@ export class ShapeStream<T extends Row = Row>
       }
 
       const { headers, status } = response
-      const shapeId = headers.get(`X-Electric-Shape-Id`)
+      const shapeId = headers.get(SHAPE_ID_HEADER)
       if (shapeId) {
-        this.shapeId = shapeId
+        this.#shapeId = shapeId
       }
 
-      const lastOffset = headers.get(`X-Electric-Chunk-Last-Offset`)
+      const lastOffset = headers.get(CHUNK_LAST_OFFSET_HEADER)
       if (lastOffset) {
-        this.lastOffset = lastOffset as Offset
+        this.#lastOffset = lastOffset as Offset
       }
 
       const getSchema = (): Schema => {
-        const schemaHeader = headers.get(`X-Electric-Schema`)
+        const schemaHeader = headers.get(SHAPE_SCHEMA_HEADER)
         return schemaHeader ? JSON.parse(schemaHeader) : {}
       }
-      this.schema = this.schema ?? getSchema()
+      this.#schema = this.#schema ?? getSchema()
 
       const messages = status === 204 ? `[]` : await response.text()
 
-      const batch = this.messageParser.parse(messages, this.schema)
+      const batch = this.#messageParser.parse(messages, this.#schema)
 
       // Update isUpToDate
       if (batch.length > 0) {
         const lastMessage = batch[batch.length - 1]
-        if (
-          isControlMessage(lastMessage) &&
-          lastMessage.headers.control === `up-to-date` &&
-          !this.isUpToDate
-        ) {
-          this.isUpToDate = true
-          this.notifyUpToDateSubscribers()
+        if (isUpToDateMessage(lastMessage) && !this.#isUpToDate) {
+          this.#isUpToDate = true
+          this.#notifyUpToDateSubscribers()
         }
 
-        this.publish(batch)
+        this.#publish(batch)
       }
     }
   }
@@ -313,27 +224,15 @@ export class ShapeStream<T extends Row = Row>
     const subscriptionId = Math.random()
     const subscriber = new MessageProcessor(callback)
 
-    this.subscribers.set(subscriptionId, [subscriber, onError])
+    this.#subscribers.set(subscriptionId, [subscriber, onError])
 
     return () => {
-      this.subscribers.delete(subscriptionId)
+      this.#subscribers.delete(subscriptionId)
     }
   }
 
   unsubscribeAll(): void {
-    this.subscribers.clear()
-  }
-
-  private publish(messages: Message<T>[]) {
-    this.subscribers.forEach(([subscriber, _]) => {
-      subscriber.process(messages)
-    })
-  }
-
-  private sendErrorToSubscribers(error: Error) {
-    this.subscribers.forEach(([_, errorFn]) => {
-      errorFn?.(error)
-    })
+    this.#subscribers.clear()
   }
 
   subscribeOnceToUpToDate(
@@ -342,26 +241,37 @@ export class ShapeStream<T extends Row = Row>
   ) {
     const subscriptionId = Math.random()
 
-    this.upToDateSubscribers.set(subscriptionId, [callback, error])
+    this.#upToDateSubscribers.set(subscriptionId, [callback, error])
 
     return () => {
-      this.upToDateSubscribers.delete(subscriptionId)
+      this.#upToDateSubscribers.delete(subscriptionId)
     }
   }
 
   unsubscribeAllUpToDateSubscribers(): void {
-    this.upToDateSubscribers.clear()
+    this.#upToDateSubscribers.clear()
   }
 
-  private notifyUpToDateSubscribers() {
-    this.upToDateSubscribers.forEach(([callback]) => {
+  #publish(messages: Message<T>[]) {
+    this.#subscribers.forEach(([subscriber, _]) => {
+      subscriber.process(messages)
+    })
+  }
+
+  #sendErrorToSubscribers(error: Error) {
+    this.#subscribers.forEach(([_, errorFn]) => {
+      errorFn?.(error)
+    })
+  }
+
+  #notifyUpToDateSubscribers() {
+    this.#upToDateSubscribers.forEach(([callback]) => {
       callback()
     })
   }
 
-  private sendErrorToUpToDateSubscribers(error: FetchError | Error) {
-    // eslint-disable-next-line
-    this.upToDateSubscribers.forEach(([_, errorCallback]) =>
+  #sendErrorToUpToDateSubscribers(error: FetchError | Error) {
+    this.#upToDateSubscribers.forEach(([_, errorCallback]) =>
       errorCallback(error)
     )
   }
@@ -370,233 +280,34 @@ export class ShapeStream<T extends Row = Row>
    * Resets the state of the stream, optionally with a provided
    * shape ID
    */
-  private reset(shapeId?: string) {
-    this.lastOffset = `-1`
-    this.shapeId = shapeId
-    this.isUpToDate = false
-    this.schema = undefined
-  }
-
-  private validateOptions(options: ShapeStreamOptions): void {
-    if (!options.url) {
-      throw new Error(`Invalid shape option. It must provide the url`)
-    }
-    if (options.signal && !(options.signal instanceof AbortSignal)) {
-      throw new Error(
-        `Invalid signal option. It must be an instance of AbortSignal.`
-      )
-    }
-
-    if (
-      options.offset !== undefined &&
-      options.offset !== `-1` &&
-      !options.shapeId
-    ) {
-      throw new Error(
-        `shapeId is required if this isn't an initial fetch (i.e. offset > -1)`
-      )
-    }
-  }
-
-  private async fetchWithBackoff(url: URL) {
-    const { initialDelay, maxDelay, multiplier } = this.backoffOptions
-    const signal = this.options.signal
-
-    let delay = initialDelay
-    let attempt = 0
-
-    // eslint-disable-next-line no-constant-condition -- we're retrying with a lag until we get a non-500 response or the abort signal is triggered
-    while (true) {
-      try {
-        const result = await this.fetchClient(url.toString(), { signal })
-        if (result.ok) return result
-        else throw await FetchError.fromResponse(result, url.toString())
-      } catch (e) {
-        if (signal?.aborted) {
-          return undefined
-        } else if (
-          e instanceof FetchError &&
-          e.status >= 400 &&
-          e.status < 500
-        ) {
-          // Any client errors cannot be backed off on, leave it to the caller to handle.
-          throw e
-        } else {
-          // Exponentially backoff on errors.
-          // Wait for the current delay duration
-          await new Promise((resolve) => setTimeout(resolve, delay))
-
-          // Increase the delay for the next attempt
-          delay = Math.min(delay * multiplier, maxDelay)
-
-          attempt++
-          console.log(`Retry attempt #${attempt} after ${delay}ms`)
-        }
-      }
-    }
+  #reset(shapeId?: string) {
+    this.#lastOffset = `-1`
+    this.#shapeId = shapeId
+    this.#isUpToDate = false
+    this.#schema = undefined
   }
 }
 
-/**
- * A Shape is an object that subscribes to a shape log,
- * keeps a materialised shape `.value` in memory and
- * notifies subscribers when the value has changed.
- *
- * It can be used without a framework and as a primitive
- * to simplify developing framework hooks.
- *
- * @constructor
- * @param {ShapeStream<T extends Row>} - the underlying shape stream
- * @example
- * ```
- * const shapeStream = new ShapeStream<{ foo: number }>(url: 'http://localhost:3000/v1/shape/foo'})
- * const shape = new Shape(shapeStream)
- * ```
- *
- * `value` returns a promise that resolves the Shape data once the Shape has been
- * fully loaded (and when resuming from being offline):
- *
- *     const value = await shape.value
- *
- * `valueSync` returns the current data synchronously:
- *
- *     const value = shape.valueSync
- *
- *  Subscribe to updates. Called whenever the shape updates in Postgres.
- *
- *     shape.subscribe(shapeData => {
- *       console.log(shapeData)
- *     })
- */
-export class Shape<T extends Row = Row> {
-  private stream: ShapeStreamInterface<T>
-
-  private data: ShapeData<T> = new Map()
-  private subscribers = new Map<number, ShapeChangedCallback<T>>()
-  public error: FetchError | false = false
-  private hasNotifiedSubscribersUpToDate: boolean = false
-
-  constructor(stream: ShapeStreamInterface<T>) {
-    this.stream = stream
-    this.stream.subscribe(this.process.bind(this), this.handleError.bind(this))
-    const unsubscribe = this.stream.subscribeOnceToUpToDate(
-      () => {
-        unsubscribe()
-      },
-      (e) => {
-        this.handleError(e)
-        throw e
-      }
+function validateOptions(
+  options: Partial<ShapeStreamOptions>
+): options is ShapeStreamOptions {
+  if (!options.url) {
+    throw new Error(`Invalid shape option. It must provide the url`)
+  }
+  if (options.signal && !(options.signal instanceof AbortSignal)) {
+    throw new Error(
+      `Invalid signal option. It must be an instance of AbortSignal.`
     )
   }
 
-  get isUpToDate(): boolean {
-    return this.stream.isUpToDate
+  if (
+    options.offset !== undefined &&
+    options.offset !== `-1` &&
+    !options.shapeId
+  ) {
+    throw new Error(
+      `shapeId is required if this isn't an initial fetch (i.e. offset > -1)`
+    )
   }
-
-  get value(): Promise<ShapeData<T>> {
-    return new Promise((resolve) => {
-      if (this.stream.isUpToDate) {
-        resolve(this.valueSync)
-      } else {
-        const unsubscribe = this.stream.subscribeOnceToUpToDate(
-          () => {
-            unsubscribe()
-            resolve(this.valueSync)
-          },
-          (e) => {
-            throw e
-          }
-        )
-      }
-    })
-  }
-
-  get valueSync() {
-    return this.data
-  }
-
-  subscribe(callback: ShapeChangedCallback<T>): () => void {
-    const subscriptionId = Math.random()
-
-    this.subscribers.set(subscriptionId, callback)
-
-    return () => {
-      this.subscribers.delete(subscriptionId)
-    }
-  }
-
-  unsubscribeAll(): void {
-    this.subscribers.clear()
-  }
-
-  get numSubscribers() {
-    return this.subscribers.size
-  }
-
-  private process(messages: Message<T>[]): void {
-    let dataMayHaveChanged = false
-    let isUpToDate = false
-    let newlyUpToDate = false
-
-    messages.forEach((message) => {
-      if (isChangeMessage(message)) {
-        dataMayHaveChanged = [`insert`, `update`, `delete`].includes(
-          message.headers.operation
-        )
-
-        switch (message.headers.operation) {
-          case `insert`:
-            this.data.set(message.key, message.value)
-            break
-          case `update`:
-            this.data.set(message.key, {
-              ...this.data.get(message.key)!,
-              ...message.value,
-            })
-            break
-          case `delete`:
-            this.data.delete(message.key)
-            break
-        }
-      }
-
-      if (isControlMessage(message)) {
-        switch (message.headers.control) {
-          case `up-to-date`:
-            isUpToDate = true
-            if (!this.hasNotifiedSubscribersUpToDate) {
-              newlyUpToDate = true
-            }
-            break
-          case `must-refetch`:
-            this.data.clear()
-            this.error = false
-            isUpToDate = false
-            newlyUpToDate = false
-            break
-        }
-      }
-    })
-
-    // Always notify subscribers when the Shape first is up to date.
-    // FIXME this would be cleaner with a simple state machine.
-    if (newlyUpToDate || (isUpToDate && dataMayHaveChanged)) {
-      this.hasNotifiedSubscribersUpToDate = true
-      this.notify()
-    }
-  }
-
-  private handleError(e: Error): void {
-    if (e instanceof FetchError) {
-      this.error = e
-      this.notify()
-    }
-  }
-
-  private notify(): void {
-    this.subscribers.forEach((callback) => {
-      callback(this.valueSync)
-    })
-  }
+  return true
 }

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -139,6 +139,16 @@ export class FetchError extends Error {
   }
 }
 
+export interface ShapeStreamInterface<T extends Row = Row> {
+  subscribe(callback: (messages: Message<T>[]) => void): void
+  unsubscribeAllUpToDateSubscribers(): void
+  unsubscribeAll(): void
+  subscribeOnceToUpToDate(
+    callback: () => void,
+    error: (err: FetchError | Error) => void
+  ): () => void
+}
+
 /**
  * Reads updates to a shape from Electric using HTTP requests and long polling. Notifies subscribers
  * when new messages come in. Doesn't maintain any history of the
@@ -169,7 +179,10 @@ export class FetchError extends Error {
  * aborter.abort()
  * ```
  */
-export class ShapeStream<T extends Row = Row> {
+
+export class ShapeStream<T extends Row = Row>
+  implements ShapeStreamInterface<T>
+{
   private options: ShapeStreamOptions
   private backoffOptions: BackoffOptions
   private fetchClient: typeof fetch

--- a/packages/typescript-client/src/constants.ts
+++ b/packages/typescript-client/src/constants.ts
@@ -1,0 +1,3 @@
+export const SHAPE_ID_HEADER = `X-Electric-Shape-Id`
+export const CHUNK_LAST_OFFSET_HEADER = `X-Electric-Chunk-Last-Offset`
+export const SHAPE_SCHEMA_HEADER = `X-Electric-Schema`

--- a/packages/typescript-client/src/error.ts
+++ b/packages/typescript-client/src/error.ts
@@ -1,0 +1,50 @@
+export class FetchError extends Error {
+  status: number
+  text?: string
+  json?: object
+  headers: Record<string, string>
+
+  constructor(
+    status: number,
+    text: string | undefined,
+    json: object | undefined,
+    headers: Record<string, string>,
+    public url: string,
+    message?: string
+  ) {
+    super(
+      message ||
+        `HTTP Error ${status} at ${url}: ${text ?? JSON.stringify(json)}`
+    )
+    this.name = `FetchError`
+    this.status = status
+    this.text = text
+    this.json = json
+    this.headers = headers
+  }
+
+  static async fromResponse(
+    response: Response,
+    url: string
+  ): Promise<FetchError> {
+    const status = response.status
+    const headers = Object.fromEntries([...response.headers.entries()])
+    let text: string | undefined = undefined
+    let json: object | undefined = undefined
+
+    const contentType = response.headers.get(`content-type`)
+    if (contentType && contentType.includes(`application/json`)) {
+      json = (await response.json()) as object
+    } else {
+      text = await response.text()
+    }
+
+    return new FetchError(status, text, json, headers, url)
+  }
+}
+
+export class FetchBackoffAbortError extends Error {
+  constructor() {
+    super(`Fetch with backoff aborted`)
+  }
+}

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -1,0 +1,65 @@
+import { FetchError, FetchBackoffAbortError } from './error'
+
+export interface BackoffOptions {
+  initialDelay: number
+  maxDelay: number
+  multiplier: number
+  debug?: boolean
+}
+
+export const BackoffDefaults = {
+  initialDelay: 100,
+  maxDelay: 10_000,
+  multiplier: 1.3,
+}
+
+export function createFetchWithBackoff(
+  fetchClient: typeof fetch,
+  backoffOptions: BackoffOptions = BackoffDefaults
+): typeof fetch {
+  const { initialDelay, maxDelay, multiplier, debug = false } = backoffOptions
+  return async (...args: Parameters<typeof fetch>): Promise<Response> => {
+    const url = args[0]
+    const options = args[1]
+
+    let delay = initialDelay
+    let attempt = 0
+
+    /* eslint-disable no-constant-condition -- we re-fetch the shape log
+     * continuously until we get a non-ok response. For recoverable errors,
+     * we retry the fetch with exponential backoff. Users can pass in an
+     * AbortController to abort the fetching an any point.
+     * */
+    while (true) {
+      /* eslint-enable no-constant-condition */
+      try {
+        const result = await fetchClient(...args)
+        if (result.ok) return result
+        else throw await FetchError.fromResponse(result, url.toString())
+      } catch (e) {
+        if (options?.signal?.aborted) {
+          throw new FetchBackoffAbortError()
+        } else if (
+          e instanceof FetchError &&
+          e.status >= 400 &&
+          e.status < 500
+        ) {
+          // Any client errors cannot be backed off on, leave it to the caller to handle.
+          throw e
+        } else {
+          // Exponentially backoff on errors.
+          // Wait for the current delay duration
+          await new Promise((resolve) => setTimeout(resolve, delay))
+
+          // Increase the delay for the next attempt
+          delay = Math.min(delay * multiplier, maxDelay)
+
+          if (debug) {
+            attempt++
+            console.log(`Retry attempt #${attempt} after ${delay}ms`)
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/typescript-client/src/helpers.ts
+++ b/packages/typescript-client/src/helpers.ts
@@ -45,3 +45,9 @@ export function isControlMessage<T extends Row = Row>(
 ): message is ControlMessage {
   return !isChangeMessage(message)
 }
+
+export function isUpToDateMessage<T extends Row = Row>(
+  message: Message<T>
+): message is ControlMessage & { up_to_date: true } {
+  return isControlMessage(message) && message.headers.control === `up-to-date`
+}

--- a/packages/typescript-client/src/index.ts
+++ b/packages/typescript-client/src/index.ts
@@ -1,3 +1,6 @@
 export * from './client'
+export * from './shape'
 export * from './types'
-export * from './helpers'
+export { isChangeMessage, isControlMessage } from './helpers'
+export { FetchError } from './error'
+export { type BackoffOptions, BackoffDefaults } from './fetch'

--- a/packages/typescript-client/src/offset.ts
+++ b/packages/typescript-client/src/offset.ts
@@ -1,0 +1,26 @@
+import { Offset } from './types'
+
+type ComparableOffset = [number, number]
+
+/**
+ * Compares two offsets and returns appropriate number for sorting
+ * comparisons
+ *
+ * @param offsetA
+ * @param offsetB
+ * @returns -1 if offsetA < offsetB, 1 if offsetA > offsetB, 0 if equal
+ */
+export function compareOffset(offsetA: Offset, offsetB: Offset): 1 | 0 | -1 {
+  const [oAx, oAy] = splitOffset(offsetA)
+  const [oBx, oBy] = splitOffset(offsetB)
+  if (oAx > oBx) return 1
+  if (oAx < oBx) return -1
+  if (oAy > oBy) return 1
+  if (oAy < oBy) return -1
+  return 0
+}
+
+function splitOffset(offset: Offset): ComparableOffset {
+  if (offset === `-1`) return [-1, -1]
+  return offset.split(`_`).map(Number) as ComparableOffset
+}

--- a/packages/typescript-client/src/persist.ts
+++ b/packages/typescript-client/src/persist.ts
@@ -1,0 +1,51 @@
+import {
+  type FetchError,
+  type ShapeStreamInterface,
+  type ShapeStream,
+} from './client'
+import { Message } from './types'
+
+type PromiseOr<T> = T | Promise<T>
+
+export interface ShapeStreamStorage {
+  get: (id: string, row: unknown) => PromiseOr<void>
+  put: (id: string, row: unknown) => PromiseOr<void>
+  delete: (id: string) => PromiseOr<unknown>
+}
+
+export class ShapeStreamPersister implements ShapeStreamInterface {
+  #shapeStream: ShapeStream
+  constructor(shapeStream: ShapeStream) {
+    this.#shapeStream = shapeStream
+  }
+
+  start(): Promise<void> {
+    return this.#shapeStream.start()
+  }
+  subscribe(
+    callback: (messages: Message[]) => void | Promise<void>,
+    onError?: (error: FetchError | Error) => void
+  ): () => void {
+    return this.#shapeStream.subscribe(callback, onError)
+  }
+  unsubscribeAll(): void {
+    return this.#shapeStream.unsubscribeAll()
+  }
+  subscribeOnceToUpToDate(
+    callback: () => void | Promise<void>,
+    error: (err: FetchError | Error) => void
+  ): () => void {
+    return this.#shapeStream.subscribeOnceToUpToDate(callback, error)
+  }
+  unsubscribeAllUpToDateSubscribers(): void {
+    return this.#shapeStream.unsubscribeAllUpToDateSubscribers()
+  }
+
+  get isUpToDate(): boolean {
+    return this.#shapeStream.isUpToDate
+  }
+
+  get shapeId(): string | undefined {
+    return this.#shapeStream.shapeId
+  }
+}

--- a/packages/typescript-client/src/persist.ts
+++ b/packages/typescript-client/src/persist.ts
@@ -1,32 +1,113 @@
 import {
   type FetchError,
   type ShapeStreamInterface,
-  type ShapeStream,
+  ShapeStream,
+  ShapeStreamOptions,
 } from './client'
-import { Message } from './types'
+import { isChangeMessage, isControlMessage } from './helpers'
+import { ChangeMessage, Offset, Value, type Message } from './types'
 
 type PromiseOr<T> = T | Promise<T>
-
-export interface ShapeStreamStorage {
-  get: (id: string, row: unknown) => PromiseOr<void>
-  put: (id: string, row: unknown) => PromiseOr<void>
-  delete: (id: string) => PromiseOr<unknown>
+function isPromise<T>(promise: PromiseOr<T>): promise is Promise<T> {
+  return (
+    !!promise &&
+    typeof promise === `object` &&
+    `then` in promise &&
+    typeof promise.then === `function`
+  )
 }
 
-export class ShapeStreamPersister implements ShapeStreamInterface {
+type StreamStorageItem<T extends Value = Value> = {
+  key: string
+  value: T
+  offset: Offset
+  shapeId?: string
+
+  // NOTE: if we allow comparing offsets on the client we
+  // can avoid having this field
+  insertedAt: number
+}
+
+export type PersistedShapeStreamOptions = Exclude<
+  ShapeStreamOptions,
+  `offset` | `shapeId`
+> & {
+  storage: ShapeStreamStorage
+}
+
+export interface ShapeStreamStorage<T extends Value = Value> {
+  get: (key: string) => PromiseOr<StreamStorageItem<T>>
+  put: (key: string, entry: StreamStorageItem<T>) => PromiseOr<void>
+  delete: (key: string) => PromiseOr<void>
+  getAll: () => PromiseOr<Iterable<PromiseOr<StreamStorageItem<T>>>>
+  clear: () => PromiseOr<void>
+}
+
+export class PersistedShapeStream<T extends Value = Value>
+  implements ShapeStreamInterface
+{
+  readonly #storage: ShapeStreamStorage
+  readonly #hydrationPromise: Promise<ShapeStreamOptions>
+
   #shapeStream: ShapeStream
-  constructor(shapeStream: ShapeStream) {
-    this.#shapeStream = shapeStream
+  #operationChain: Promise<unknown> = Promise.resolve()
+  #hasShapeId: boolean = false
+
+  constructor(options: PersistedShapeStreamOptions) {
+    const shapeStreamOptions = {
+      ...options,
+      offset: undefined,
+      shapeId: undefined,
+    }
+    this.#shapeStream = new ShapeStream(shapeStreamOptions)
+    this.#storage = options.storage
+    this.#hydrationPromise = this.#hydrate(shapeStreamOptions)
   }
 
-  start(): Promise<void> {
+  async #hydrate(options: ShapeStreamOptions): Promise<ShapeStreamOptions> {
+    let shapeId: string | undefined
+    let latestOffset: Offset = `-1`
+    let latestInsertedAt = -1
+
+    // NOTE: this hydration goes through the whole store to retrieve
+    // the shapeId and latestOffset - this is an expensive operation
+    // for very little data, but the alternative complicates the
+    // storage interface required to persist the stream
+    for await (const item of await this.#storage.getAll()) {
+      shapeId ??= item.shapeId
+      if (item.insertedAt > latestInsertedAt) {
+        latestOffset = item.offset
+        latestInsertedAt = item.insertedAt
+      }
+    }
+
+    return {
+      ...options,
+      shapeId,
+      offset: latestOffset,
+    }
+  }
+
+  async start(): Promise<void> {
+    if (!this.#shapeStream) {
+      const options = await this.#hydrationPromise
+      this.#shapeStream = new ShapeStream(options)
+      this.#shapeStream.subscribe(this.#persistStream.bind(this))
+    }
     return this.#shapeStream.start()
   }
+
   subscribe(
-    callback: (messages: Message[]) => void | Promise<void>,
+    callback: (messages: Message<T>[]) => void | Promise<void>,
     onError?: (error: FetchError | Error) => void
   ): () => void {
-    return this.#shapeStream.subscribe(callback, onError)
+    const streamHydrationPromise = this.#chainOperation(
+      this.#hydrateStream(callback)
+    )
+    const hydratedCallback = async (messages: Message<T>[]) =>
+      asyncOrCall(streamHydrationPromise, (_) => callback(messages))
+
+    return this.#shapeStream.subscribe(hydratedCallback, onError)
   }
   unsubscribeAll(): void {
     return this.#shapeStream.unsubscribeAll()
@@ -48,4 +129,113 @@ export class ShapeStreamPersister implements ShapeStreamInterface {
   get shapeId(): string | undefined {
     return this.#shapeStream.shapeId
   }
+
+  #hydrateStream(
+    callback: (messages: Message<T>[]) => void | Promise<void>,
+    onError?: (error: FetchError | Error) => void
+  ): PromiseOr<void> {
+    return asyncOrCall(
+      this.#storage.getAll(),
+      (itemIterable) => {
+        const calls: PromiseOr<void>[] = []
+        for (const item of itemIterable) {
+          calls.push(
+            asyncOrCall(item, (item) =>
+              callback([shapeStreamStorageItemToMessage(item)])
+            )
+          )
+        }
+
+        if (calls.length > 0 && isPromise(calls[0])) {
+          return Promise.all(calls)
+        }
+      },
+      onError !== undefined ? (err) => onError?.(err as Error) : undefined
+    )
+  }
+
+  #chainOperation<T>(operation: PromiseOr<T>): PromiseOr<T> {
+    // no need to chain synchronous operations
+    if (!isPromise(operation)) return operation
+
+    // keep a promise chain to ensure storage operations occur
+    // in the right order
+    this.#operationChain = this.#operationChain.finally(() => operation)
+    return this.#operationChain as Promise<T>
+  }
+
+  #persistStream(messages: Message[]): PromiseOr<void> {
+    let chain: PromiseOr<void> = undefined
+    for (const message of messages) {
+      chain = this.#chainOperation(this.#processMessage(message))
+    }
+    return chain
+  }
+
+  #processMessage(message: Message): PromiseOr<void> {
+    if (isChangeMessage(message)) {
+      switch (message.headers.operation) {
+        case `insert`:
+        case `update`:
+          return this.#storage.put(message.key, {
+            key: message.key,
+            value: message.value,
+            offset: message.offset,
+            shapeId: this.#maybeShapeId(),
+            insertedAt: Date.now(),
+          })
+        case `delete`:
+          return this.#storage.delete(message.key)
+      }
+    }
+    if (isControlMessage(message)) {
+      switch (message.headers.control) {
+        case `up-to-date`:
+          break
+        case `must-refetch`:
+          this.#clearShapeId()
+          return this.#storage.clear()
+      }
+    }
+  }
+
+  #clearShapeId(): void {
+    this.#hasShapeId = false
+  }
+
+  #maybeShapeId(): string | undefined {
+    if (!this.#hasShapeId && this.#shapeStream.shapeId !== undefined) {
+      this.#hasShapeId = true
+      return this.#shapeStream.shapeId
+    }
+    return
+  }
+}
+
+function shapeStreamStorageItemToMessage<T extends Value>(
+  item: StreamStorageItem<T>
+): ChangeMessage<T> {
+  return {
+    headers: { operation: `insert` },
+    key: item.key,
+    value: item.value,
+    offset: item.offset,
+  }
+}
+
+function asyncOrCall<T>(
+  item: PromiseOr<T>,
+  callback: (item: T) => void,
+  onError?: (error: unknown) => void
+): PromiseOr<void> {
+  if (!isPromise(item)) {
+    try {
+      return callback(item)
+    } catch (err: unknown) {
+      if (onError) return onError(err)
+      throw err
+    }
+  }
+
+  return item.then((item) => callback(item)).catch(onError)
 }

--- a/packages/typescript-client/src/persist.ts
+++ b/packages/typescript-client/src/persist.ts
@@ -5,7 +5,7 @@ import {
   ShapeStreamOptions,
 } from './client'
 import { isChangeMessage, isControlMessage } from './helpers'
-import { ChangeMessage, Offset, type Row, type Message } from './types'
+import { ChangeMessage, Offset, type Row, type Message, Value } from './types'
 
 type PromiseOr<T> = T | Promise<T>
 function isPromise<T>(promise: PromiseOr<T>): promise is Promise<T> {
@@ -17,57 +17,53 @@ function isPromise<T>(promise: PromiseOr<T>): promise is Promise<T> {
   )
 }
 
-type StreamStorageItem<T extends Row = Row> = {
+export type StreamStorageItem<T extends Row = Row> = {
   key: string
   value: T
   offset: Offset
   shapeId?: string
-
-  // NOTE: if we allow comparing offsets on the client we
-  // can avoid having this field
-  insertedAt: number
 }
 
-export type PersistedShapeStreamOptions<T extends Row> = Exclude<
-  ShapeStreamOptions,
-  `offset` | `shapeId`
-> & {
-  storage: ShapeStreamStorage<T>
+export interface PersistedShapeStreamOptions
+  extends Omit<ShapeStreamOptions, `offset` | `shapeId`> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  storage: ShapeStreamStorage<any>
 }
 
-export interface ShapeStreamStorage<T extends Row = Row> {
-  get: (key: string) => PromiseOr<StreamStorageItem<T>>
-  put: (key: string, entry: StreamStorageItem<T>) => PromiseOr<void>
+export interface ShapeStreamStorage<T extends Record<string, Value>> {
+  get: (key: string) => PromiseOr<T | void>
+  put: (key: string, entry: T) => PromiseOr<void>
   delete: (key: string) => PromiseOr<void>
-  getAll: () => PromiseOr<Iterable<PromiseOr<StreamStorageItem<T>>>>
+  getAll: () => PromiseOr<Iterable<T> | AsyncIterable<T>>
   clear: () => PromiseOr<void>
 }
 
 export class PersistedShapeStream<T extends Row = Row>
-  implements ShapeStreamInterface
+  implements ShapeStreamInterface<T>
 {
-  readonly #storage: ShapeStreamStorage<T>
+  readonly #storage: ShapeStreamStorage<StreamStorageItem<T>>
   readonly #hydrationPromise: Promise<ShapeStreamOptions>
+  readonly #streamReadyPromise: Promise<ShapeStream<T>>
 
-  #shapeStream: ShapeStream<T>
+  #shapeStream: ShapeStream<T> | undefined
   #operationChain: Promise<unknown> = Promise.resolve()
   #hasShapeId: boolean = false
 
-  constructor(options: PersistedShapeStreamOptions<T>) {
+  constructor(options: PersistedShapeStreamOptions) {
     const shapeStreamOptions = {
       ...options,
       offset: undefined,
       shapeId: undefined,
     }
-    this.#shapeStream = new ShapeStream(shapeStreamOptions)
     this.#storage = options.storage
     this.#hydrationPromise = this.#hydrate(shapeStreamOptions)
+    this.#streamReadyPromise = this.start().then(() => this.#shapeStream!)
   }
 
   async #hydrate(options: ShapeStreamOptions): Promise<ShapeStreamOptions> {
     let shapeId: string | undefined
     let latestOffset: Offset = `-1`
-    let latestInsertedAt = -1
+    let latestComparableOffset: [number, number] = [-1, -1]
 
     // NOTE: this hydration goes through the whole store to retrieve
     // the shapeId and latestOffset - this is an expensive operation
@@ -75,9 +71,19 @@ export class PersistedShapeStream<T extends Row = Row>
     // storage interface required to persist the stream
     for await (const item of await this.#storage.getAll()) {
       shapeId ??= item.shapeId
-      if (item.insertedAt > latestInsertedAt) {
+      const comparableOffset = item.offset.split(`_`).map(Number) as [
+        number,
+        number,
+      ]
+
+      // TODO: implement offset comparison helper
+      if (
+        comparableOffset[0] > latestComparableOffset[0] ||
+        (comparableOffset[0] === latestComparableOffset[0] &&
+          comparableOffset[1] > latestComparableOffset[1])
+      ) {
         latestOffset = item.offset
-        latestInsertedAt = item.insertedAt
+        latestComparableOffset = comparableOffset
       }
     }
 
@@ -94,7 +100,6 @@ export class PersistedShapeStream<T extends Row = Row>
       this.#shapeStream = new ShapeStream(options)
       this.#shapeStream.subscribe(this.#persistStream.bind(this))
     }
-    return this.#shapeStream.start()
   }
 
   subscribe(
@@ -107,27 +112,36 @@ export class PersistedShapeStream<T extends Row = Row>
     const hydratedCallback = async (messages: Message<T>[]) =>
       asyncOrCall(streamHydrationPromise, (_) => callback(messages))
 
-    return this.#shapeStream.subscribe(hydratedCallback, onError)
+    const unsubPromise = this.#streamReadyPromise.then((stream) =>
+      stream.subscribe(hydratedCallback, onError)
+    )
+    return () => unsubPromise.then((unsub) => unsub())
   }
   unsubscribeAll(): void {
-    return this.#shapeStream.unsubscribeAll()
+    this.#streamReadyPromise.then((stream) => stream.unsubscribeAll())
   }
   subscribeOnceToUpToDate(
     callback: () => void | Promise<void>,
     error: (err: FetchError | Error) => void
   ): () => void {
-    return this.#shapeStream.subscribeOnceToUpToDate(callback, error)
+    const unsubPromise = this.#streamReadyPromise.then((stream) =>
+      stream.subscribeOnceToUpToDate(callback, error)
+    )
+    return () => unsubPromise.then((unsub) => unsub())
   }
+
   unsubscribeAllUpToDateSubscribers(): void {
-    return this.#shapeStream.unsubscribeAllUpToDateSubscribers()
+    this.#streamReadyPromise.then((stream) =>
+      stream.unsubscribeAllUpToDateSubscribers()
+    )
   }
 
   get isUpToDate(): boolean {
-    return this.#shapeStream.isUpToDate
+    return this.#shapeStream?.isUpToDate ?? false
   }
 
   get shapeId(): string | undefined {
-    return this.#shapeStream.shapeId
+    return this.#shapeStream?.shapeId
   }
 
   #hydrateStream(
@@ -136,20 +150,10 @@ export class PersistedShapeStream<T extends Row = Row>
   ): PromiseOr<void> {
     return asyncOrCall(
       this.#storage.getAll(),
-      (itemIterable) => {
-        const calls: PromiseOr<void>[] = []
-        for (const item of itemIterable) {
-          calls.push(
-            asyncOrCall(item, (item) =>
-              callback([shapeStreamStorageItemToMessage(item)])
-            )
-          )
-        }
-
-        if (calls.length > 0 && isPromise(calls[0])) {
-          return Promise.all(calls)
-        }
-      },
+      (itemIterable) =>
+        asyncOrIterable(itemIterable, (item) =>
+          callback([shapeStreamStorageItemToMessage(item)])
+        ),
       onError !== undefined ? (err) => onError?.(err as Error) : undefined
     )
   }
@@ -182,7 +186,6 @@ export class PersistedShapeStream<T extends Row = Row>
             value: message.value,
             offset: message.offset,
             shapeId: this.#maybeShapeId(),
-            insertedAt: Date.now(),
           })
         case `delete`:
           return this.#storage.delete(message.key)
@@ -204,7 +207,7 @@ export class PersistedShapeStream<T extends Row = Row>
   }
 
   #maybeShapeId(): string | undefined {
-    if (!this.#hasShapeId && this.#shapeStream.shapeId !== undefined) {
+    if (!this.#hasShapeId && this.#shapeStream?.shapeId !== undefined) {
       this.#hasShapeId = true
       return this.#shapeStream.shapeId
     }
@@ -216,7 +219,7 @@ function shapeStreamStorageItemToMessage<T extends Row>(
   item: StreamStorageItem<T>
 ): ChangeMessage<T> {
   return {
-    headers: { operation: `insert` },
+    headers: { operation: `insert`, localCache: true },
     key: item.key,
     value: item.value,
     offset: item.offset,
@@ -238,4 +241,23 @@ function asyncOrCall<T>(
   }
 
   return item.then((item) => callback(item)).catch(onError)
+}
+
+function asyncOrIterable<T>(
+  iterable: Iterable<T> | AsyncIterable<T>,
+  callback: (item: T) => void
+): PromiseOr<void> {
+  if (Symbol.asyncIterator in iterable) {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise<void>(async (res) => {
+      for await (const item of iterable) {
+        callback(item)
+      }
+      res()
+    })
+  }
+
+  for (const item of iterable) {
+    callback(item)
+  }
 }

--- a/packages/typescript-client/src/persist.ts
+++ b/packages/typescript-client/src/persist.ts
@@ -6,9 +6,15 @@ import {
 } from './client'
 import { isChangeMessage, isControlMessage } from './helpers'
 import { compareOffset } from './offset'
-import { ChangeMessage, Offset, type Row, type Message, Value } from './types'
+import {
+  ChangeMessage,
+  Offset,
+  type Row,
+  type Message,
+  type Value,
+  type PromiseOr,
+} from './types'
 
-type PromiseOr<T> = T | Promise<T>
 function isPromise<T>(promise: PromiseOr<T>): promise is Promise<T> {
   return (
     !!promise &&
@@ -93,7 +99,7 @@ export class PersistedShapeStream<T extends Row = Row>
   }
 
   subscribe(
-    callback: (messages: Message<T>[]) => void | Promise<void>,
+    callback: (messages: Message<T>[]) => PromiseOr<void>,
     onError?: (error: FetchError | Error) => void
   ): () => void {
     const streamHydrationPromise = this.#chainOperation(
@@ -111,7 +117,7 @@ export class PersistedShapeStream<T extends Row = Row>
     this.#streamReadyPromise.then((stream) => stream.unsubscribeAll())
   }
   subscribeOnceToUpToDate(
-    callback: () => void | Promise<void>,
+    callback: () => PromiseOr<void>,
     error: (err: FetchError | Error) => void
   ): () => void {
     const unsubPromise = this.#streamReadyPromise.then((stream) =>
@@ -135,7 +141,7 @@ export class PersistedShapeStream<T extends Row = Row>
   }
 
   #hydrateStream(
-    callback: (messages: Message<T>[]) => void | Promise<void>,
+    callback: (messages: Message<T>[]) => PromiseOr<void>,
     onError?: (error: FetchError | Error) => void
   ): PromiseOr<void> {
     return asyncOrCall(

--- a/packages/typescript-client/src/persist.ts
+++ b/packages/typescript-client/src/persist.ts
@@ -1,12 +1,13 @@
 import { asyncOrCall, asyncOrIterable } from './async-or'
 import {
-  type FetchError,
   type ShapeStreamInterface,
   ShapeStream,
   ShapeStreamOptions,
 } from './client'
+import { type FetchError } from './error'
 import { isChangeMessage, isControlMessage } from './helpers'
 import { compareOffset } from './offset'
+import { AsyncOrProcessingQueue } from './queue'
 import {
   ChangeMessage,
   Offset,
@@ -46,9 +47,9 @@ export class PersistedShapeStream<T extends Row = Row>
   readonly #storage: ShapeStreamStorage<StreamStorageItem<T>>
   readonly #hydrationPromise: Promise<ShapeStreamOptions>
   readonly #streamReadyPromise: Promise<ShapeStream<T>>
+  readonly #operationQueue = new AsyncOrProcessingQueue()
 
   #shapeStream: ShapeStream<T> | undefined
-  #operationChain: PromiseOr<void> = undefined
   #hasShapeId: boolean = false
 
   constructor(options: PersistedShapeStreamOptions) {
@@ -97,7 +98,7 @@ export class PersistedShapeStream<T extends Row = Row>
     callback: (messages: Message<T>[]) => PromiseOr<void>,
     onError?: (error: FetchError | Error) => void
   ): () => void {
-    const streamHydrationPromise = this.#chainOperation(() =>
+    const streamHydrationPromise = this.#operationQueue.process(() =>
       this.#hydrateStream(callback)
     )
     const hydratedCallback = async (messages: Message<T>[]) =>
@@ -136,7 +137,7 @@ export class PersistedShapeStream<T extends Row = Row>
   }
 
   flush(): PromiseOr<void> {
-    return this.#operationChain
+    return this.#operationQueue.waitForProcessing()
   }
 
   #hydrateStream(
@@ -153,17 +154,10 @@ export class PersistedShapeStream<T extends Row = Row>
     )
   }
 
-  #chainOperation<T>(operation: () => PromiseOr<T>): PromiseOr<T> {
-    const result = asyncOrCall(this.#operationChain, operation)
-    this.#operationChain = result
-    return result as PromiseOr<T>
-  }
-
   #persistStream(messages: Message<T>[]): PromiseOr<void> {
     let chain: PromiseOr<void> = undefined
-    // TODO: use MessageProcessor when extracted in other PR
     for (const message of messages) {
-      chain = this.#chainOperation(() => this.#processMessage(message))
+      chain = this.#operationQueue.process(() => this.#processMessage(message))
     }
     return chain
   }

--- a/packages/typescript-client/src/queue.ts
+++ b/packages/typescript-client/src/queue.ts
@@ -1,0 +1,58 @@
+import { asyncOrCall, isPromise } from './async-or'
+import { PromiseOr } from './types'
+
+/**
+ * Processes messages synchronously or asynchronously in
+ * order.
+ */
+export class AsyncOrProcessingQueue {
+  #processingChain: PromiseOr<void> = undefined
+
+  public process(callback: () => PromiseOr<void>): PromiseOr<void> {
+    this.#processingChain = asyncOrCall(
+      this.#processingChain,
+      callback,
+      // TODO: bubble errors up to subscriber or let
+      // client handle it in the provided callback?
+      // swallow errors
+      () => {}
+    )
+
+    return this.#processingChain
+  }
+
+  public async waitForProcessing(): Promise<void> {
+    let currentChain: PromiseOr<void>
+    do {
+      currentChain = this.#processingChain
+      if (!isPromise(currentChain)) break
+      await currentChain
+    } while (this.#processingChain !== currentChain)
+  }
+}
+
+/**
+ * Receives messages, puts them on a queue and processes
+ * them synchronously or asynchronously by passing to a
+ * registered callback function.
+ *
+ * @constructor
+ * @param {(message: T) => PromiseOr<void>} callback function
+ */
+export class MessageProcessor<T> {
+  readonly #queue: AsyncOrProcessingQueue
+  readonly #callback: (messages: T) => PromiseOr<void>
+
+  constructor(callback: (messages: T) => PromiseOr<void>) {
+    this.#queue = new AsyncOrProcessingQueue()
+    this.#callback = callback
+  }
+
+  public process(messages: T): void {
+    this.#queue.process(() => this.#callback(messages))
+  }
+
+  public async waitForProcessing(): Promise<void> {
+    await this.#queue.waitForProcessing()
+  }
+}

--- a/packages/typescript-client/src/shape.ts
+++ b/packages/typescript-client/src/shape.ts
@@ -1,0 +1,181 @@
+import { Message, Row } from './types'
+import { isChangeMessage, isControlMessage } from './helpers'
+import { FetchError } from './error'
+import { ShapeStreamInterface } from './client'
+
+export type ShapeData<T extends Row = Row> = Map<string, T>
+export type ShapeChangedCallback<T extends Row = Row> = (
+  value: ShapeData<T>
+) => void
+
+/**
+ * A Shape is an object that subscribes to a shape log,
+ * keeps a materialised shape `.value` in memory and
+ * notifies subscribers when the value has changed.
+ *
+ * It can be used without a framework and as a primitive
+ * to simplify developing framework hooks.
+ *
+ * @constructor
+ * @param {ShapeStream<T extends Row>} - the underlying shape stream
+ * @example
+ * ```
+ * const shapeStream = new ShapeStream<{ foo: number }>(url: 'http://localhost:3000/v1/shape/foo'})
+ * const shape = new Shape(shapeStream)
+ * ```
+ *
+ * `value` returns a promise that resolves the Shape data once the Shape has been
+ * fully loaded (and when resuming from being offline):
+ *
+ *     const value = await shape.value
+ *
+ * `valueSync` returns the current data synchronously:
+ *
+ *     const value = shape.valueSync
+ *
+ *  Subscribe to updates. Called whenever the shape updates in Postgres.
+ *
+ *     shape.subscribe(shapeData => {
+ *       console.log(shapeData)
+ *     })
+ */
+export class Shape<T extends Row = Row> {
+  readonly #stream: ShapeStreamInterface<T>
+
+  readonly #data: ShapeData<T> = new Map()
+  readonly #subscribers = new Map<number, ShapeChangedCallback<T>>()
+
+  #hasNotifiedSubscribersUpToDate: boolean = false
+  #error: FetchError | false = false
+
+  constructor(stream: ShapeStreamInterface<T>) {
+    this.#stream = stream
+    this.#stream.subscribe(
+      this.#process.bind(this),
+      this.#handleError.bind(this)
+    )
+    const unsubscribe = this.#stream.subscribeOnceToUpToDate(
+      () => {
+        unsubscribe()
+      },
+      (e) => {
+        this.#handleError(e)
+        throw e
+      }
+    )
+  }
+
+  get isUpToDate(): boolean {
+    return this.#stream.isUpToDate
+  }
+
+  get value(): Promise<ShapeData<T>> {
+    return new Promise((resolve) => {
+      if (this.#stream.isUpToDate) {
+        resolve(this.valueSync)
+      } else {
+        const unsubscribe = this.#stream.subscribeOnceToUpToDate(
+          () => {
+            unsubscribe()
+            resolve(this.valueSync)
+          },
+          (e) => {
+            throw e
+          }
+        )
+      }
+    })
+  }
+
+  get valueSync() {
+    return this.#data
+  }
+
+  get error() {
+    return this.#error
+  }
+
+  subscribe(callback: ShapeChangedCallback<T>): () => void {
+    const subscriptionId = Math.random()
+
+    this.#subscribers.set(subscriptionId, callback)
+
+    return () => {
+      this.#subscribers.delete(subscriptionId)
+    }
+  }
+
+  unsubscribeAll(): void {
+    this.#subscribers.clear()
+  }
+
+  get numSubscribers() {
+    return this.#subscribers.size
+  }
+
+  #process(messages: Message<T>[]): void {
+    let dataMayHaveChanged = false
+    let isUpToDate = false
+    let newlyUpToDate = false
+
+    messages.forEach((message) => {
+      if (isChangeMessage(message)) {
+        dataMayHaveChanged = [`insert`, `update`, `delete`].includes(
+          message.headers.operation
+        )
+
+        switch (message.headers.operation) {
+          case `insert`:
+            this.#data.set(message.key, message.value)
+            break
+          case `update`:
+            this.#data.set(message.key, {
+              ...this.#data.get(message.key)!,
+              ...message.value,
+            })
+            break
+          case `delete`:
+            this.#data.delete(message.key)
+            break
+        }
+      }
+
+      if (isControlMessage(message)) {
+        switch (message.headers.control) {
+          case `up-to-date`:
+            isUpToDate = true
+            if (!this.#hasNotifiedSubscribersUpToDate) {
+              newlyUpToDate = true
+            }
+            break
+          case `must-refetch`:
+            this.#data.clear()
+            this.#error = false
+            isUpToDate = false
+            newlyUpToDate = false
+            break
+        }
+      }
+    })
+
+    // Always notify subscribers when the Shape first is up to date.
+    // FIXME this would be cleaner with a simple state machine.
+    if (newlyUpToDate || (isUpToDate && dataMayHaveChanged)) {
+      this.#hasNotifiedSubscribersUpToDate = true
+      this.#notify()
+    }
+  }
+
+  #handleError(e: Error): void {
+    if (e instanceof FetchError) {
+      this.#error = e
+      this.#notify()
+    }
+  }
+
+  #notify(): void {
+    this.#subscribers.forEach((callback) => {
+      callback(this.valueSync)
+    })
+  }
+}

--- a/packages/typescript-client/src/types.ts
+++ b/packages/typescript-client/src/types.ts
@@ -108,3 +108,5 @@ export type TypedMessages<T extends Row = Row> = {
   messages: Array<Message<T>>
   schema: ColumnInfo
 }
+
+export type PromiseOr<T> = T | Promise<T>

--- a/packages/typescript-client/test/async-or.test.ts
+++ b/packages/typescript-client/test/async-or.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { isPromise, asyncOrCall, asyncOrIterable } from '../src/async-or'
+
+describe(`isPromise`, () => {
+  it(`should return true for a Promise object`, () => {
+    const promise = Promise.resolve(42)
+    expect(isPromise(promise)).toBe(true)
+  })
+
+  it(`should return false for non-Promise values`, () => {
+    expect(isPromise(42)).toBe(false)
+    expect(isPromise({})).toBe(false)
+    expect(isPromise(`not a promise`)).toBe(false)
+    expect(isPromise(null)).toBe(false)
+    expect(isPromise(undefined)).toBe(false)
+  })
+
+  it(`should return false for an object without a "then" function`, () => {
+    expect(isPromise({ then: `not a function` })).toBe(false)
+  })
+})
+
+describe(`asyncOrCall`, () => {
+  it(`should call the callback directly for non-Promise values`, () => {
+    const callback = vi.fn()
+    const value = 42
+    asyncOrCall(value, callback)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it(`should return a resolved Promise value and call the callback for Promises`, async () => {
+    const callback = vi.fn()
+    const value = 42
+    const promise = Promise.resolve(value)
+    await asyncOrCall(promise, callback)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it(`should call the onError callback on synchronous errors`, () => {
+    const callback = vi.fn(() => {
+      throw new Error(`Test Error`)
+    })
+    const onError = vi.fn()
+    asyncOrCall(42, callback, onError)
+    expect(onError).toHaveBeenCalledWith(new Error(`Test Error`))
+  })
+
+  it(`should call the onError callback on Promise rejection`, async () => {
+    const callback = vi.fn()
+    const onError = vi.fn()
+    const promise = Promise.reject(new Error(`Test Error`))
+    await asyncOrCall(promise, callback, onError)
+    expect(onError).toHaveBeenCalledWith(new Error(`Test Error`))
+  })
+
+  it(`should throw an error if no onError handler is provided and an error occurs`, () => {
+    const callback = vi.fn(() => {
+      throw new Error(`Test Error`)
+    })
+    expect(() => asyncOrCall(42, callback)).toThrow(`Test Error`)
+  })
+})
+
+describe(`asyncOrIterable`, () => {
+  it(`should iterate over a synchronous iterable and call the callback for each item`, () => {
+    const callback = vi.fn()
+    const iterable = [1, 2, 3]
+    asyncOrIterable(iterable, callback)
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(callback).toHaveBeenCalledWith(1)
+    expect(callback).toHaveBeenCalledWith(2)
+    expect(callback).toHaveBeenCalledWith(3)
+  })
+
+  it(`should iterate over an asynchronous iterable and call the callback for each item`, async () => {
+    const callback = vi.fn()
+    const asyncIterable = {
+      async *[Symbol.asyncIterator]() {
+        yield 1
+        yield 2
+        yield 3
+      },
+    }
+
+    await asyncOrIterable(asyncIterable, callback)
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(callback).toHaveBeenCalledWith(1)
+    expect(callback).toHaveBeenCalledWith(2)
+    expect(callback).toHaveBeenCalledWith(3)
+  })
+})

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, inject, vi } from 'vitest'
 import { v4 as uuidv4 } from 'uuid'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { testWithIssuesTable as it } from './support/test-context'
-import { ShapeStream, Shape } from '../src/client'
+import { ShapeStream, Shape } from '../src'
 
 const BASE_URL = inject(`baseUrl`)
 

--- a/packages/typescript-client/test/error.test.ts
+++ b/packages/typescript-client/test/error.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from 'vitest'
+import { FetchError } from '../src/error'
+
+describe(`FetchError`, () => {
+  it(`should create a FetchError with the correct properties`, () => {
+    const status = 404
+    const text = `Not Found`
+    const json = undefined
+    const headers = { 'content-type': `text/plain` }
+    const url = `https://example.com/notfound`
+
+    const error = new FetchError(status, text, json, headers, url)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.name).toBe(`FetchError`)
+    expect(error.status).toBe(status)
+    expect(error.text).toBe(text)
+    expect(error.json).toBe(json)
+    expect(error.headers).toEqual(headers)
+    expect(error.url).toBe(url)
+    expect(error.message).toBe(
+      `HTTP Error 404 at https://example.com/notfound: Not Found`
+    )
+  })
+
+  it(`should create a FetchError with a JSON response and use the JSON in the message`, () => {
+    const status = 500
+    const text = undefined
+    const json = { error: `Internal Server Error` }
+    const headers = { 'content-type': `application/json` }
+    const url = `https://example.com/servererror`
+
+    const error = new FetchError(status, text, json, headers, url)
+
+    expect(error.status).toBe(status)
+    expect(error.text).toBeUndefined()
+    expect(error.json).toEqual(json)
+    expect(error.headers).toEqual(headers)
+    expect(error.message).toBe(
+      `HTTP Error 500 at https://example.com/servererror: {"error":"Internal Server Error"}`
+    )
+  })
+
+  it(`should create a FetchError with a custom message if provided`, () => {
+    const status = 403
+    const text = `Forbidden`
+    const json = undefined
+    const headers = { 'content-type': `text/plain` }
+    const url = `https://example.com/forbidden`
+    const customMessage = `Custom Error Message`
+
+    const error = new FetchError(
+      status,
+      text,
+      json,
+      headers,
+      url,
+      customMessage
+    )
+
+    expect(error.message).toBe(customMessage)
+  })
+
+  describe(`fromResponse`, () => {
+    it(`should create a FetchError from a text-based response`, async () => {
+      const mockResponse = {
+        status: 404,
+        headers: new Headers({ 'content-type': `text/plain` }),
+        text: vi.fn().mockResolvedValue(`Not Found`),
+      } as unknown as Response
+
+      const url = `https://example.com/notfound`
+      const error = await FetchError.fromResponse(mockResponse, url)
+
+      expect(mockResponse.text).toHaveBeenCalled()
+      expect(error).toBeInstanceOf(FetchError)
+      expect(error.status).toBe(404)
+      expect(error.text).toBe(`Not Found`)
+      expect(error.json).toBeUndefined()
+      expect(error.headers).toEqual({ 'content-type': `text/plain` })
+      expect(error.message).toBe(
+        `HTTP Error 404 at https://example.com/notfound: Not Found`
+      )
+    })
+
+    it(`should create a FetchError from a JSON-based response`, async () => {
+      const mockResponse = {
+        status: 500,
+        headers: new Headers({ 'content-type': `application/json` }),
+        json: vi.fn().mockResolvedValue({ error: `Internal Server Error` }),
+      } as unknown as Response
+
+      const url = `https://example.com/servererror`
+      const error = await FetchError.fromResponse(mockResponse, url)
+
+      expect(mockResponse.json).toHaveBeenCalled()
+      expect(error).toBeInstanceOf(FetchError)
+      expect(error.status).toBe(500)
+      expect(error.text).toBeUndefined()
+      expect(error.json).toEqual({ error: `Internal Server Error` })
+      expect(error.headers).toEqual({ 'content-type': `application/json` })
+      expect(error.message).toBe(
+        `HTTP Error 500 at https://example.com/servererror: {"error":"Internal Server Error"}`
+      )
+    })
+
+    it(`should handle content-type not set in response headers`, async () => {
+      const mockResponse = {
+        status: 500,
+        headers: new Headers(),
+        text: vi.fn().mockResolvedValue(`Server error with no content-type`),
+      } as unknown as Response
+
+      const url = `https://example.com/no-content-type`
+      const error = await FetchError.fromResponse(mockResponse, url)
+
+      expect(mockResponse.text).toHaveBeenCalled()
+      expect(error).toBeInstanceOf(FetchError)
+      expect(error.status).toBe(500)
+      expect(error.text).toBe(`Server error with no content-type`)
+      expect(error.json).toBeUndefined()
+      expect(error.headers).toEqual({})
+      expect(error.message).toBe(
+        `HTTP Error 500 at https://example.com/no-content-type: Server error with no content-type`
+      )
+    })
+  })
+})

--- a/packages/typescript-client/test/fetch.test.ts
+++ b/packages/typescript-client/test/fetch.test.ts
@@ -1,0 +1,146 @@
+import { describe, beforeEach, it, expect, vi, type Mock } from 'vitest'
+import { FetchError, FetchBackoffAbortError } from '../src/error'
+import { createFetchWithBackoff, BackoffDefaults } from '../src/fetch'
+
+describe(`createFetchWithBackoff`, () => {
+  const initialDelay = 10
+  const maxDelay = 100
+  let mockFetchClient: Mock<typeof fetch>
+
+  beforeEach(() => {
+    mockFetchClient = vi.fn()
+  })
+
+  it(`should return a successful response on the first attempt`, async () => {
+    const mockResponse = new Response(null, { status: 200, statusText: `OK` })
+    mockFetchClient.mockResolvedValue(mockResponse)
+
+    const fetchWithBackoff = createFetchWithBackoff(mockFetchClient)
+
+    const result = await fetchWithBackoff(`https://example.com`)
+
+    expect(mockFetchClient).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(true)
+    expect(result).toEqual(mockResponse)
+  })
+
+  it(`should retry the request on a 500 response and succeed after a retry`, async () => {
+    const mockErrorResponse = new Response(null, { status: 500 })
+    const mockSuccessResponse = new Response(null, {
+      status: 200,
+      statusText: `OK`,
+    })
+    mockFetchClient
+      .mockResolvedValueOnce(mockErrorResponse)
+      .mockResolvedValueOnce(mockSuccessResponse)
+
+    const fetchWithBackoff = createFetchWithBackoff(mockFetchClient, {
+      ...BackoffDefaults,
+      initialDelay,
+    })
+
+    const result = await fetchWithBackoff(`https://example.com`)
+
+    expect(mockFetchClient).toHaveBeenCalledTimes(2)
+    expect(result.ok).toBe(true)
+  })
+
+  it(`should apply exponential backoff and retry until maxDelay is reached`, async () => {
+    const mockErrorResponse = new Response(null, { status: 500 })
+    const mockSuccessResponse = new Response(null, {
+      status: 200,
+      statusText: `OK`,
+    })
+    mockFetchClient
+      .mockResolvedValueOnce(mockErrorResponse)
+      .mockResolvedValueOnce(mockErrorResponse)
+      .mockResolvedValueOnce(mockErrorResponse)
+      .mockResolvedValueOnce(mockSuccessResponse)
+
+    const multiplier = 2
+
+    const fetchWithBackoff = createFetchWithBackoff(mockFetchClient, {
+      initialDelay,
+      maxDelay,
+      multiplier,
+    })
+
+    const result = await fetchWithBackoff(`https://example.com`)
+
+    expect(mockFetchClient).toHaveBeenCalledTimes(4)
+    expect(result.ok).toBe(true)
+  })
+
+  it(`should stop retrying and throw an error on a 400 response`, async () => {
+    const mockErrorResponse = new Response(null, {
+      status: 400,
+      statusText: `Bad Request`,
+    })
+    mockFetchClient.mockResolvedValue(mockErrorResponse)
+
+    const fetchWithBackoff = createFetchWithBackoff(mockFetchClient)
+
+    await expect(fetchWithBackoff(`https://example.com`)).rejects.toThrow(
+      FetchError
+    )
+    expect(mockFetchClient).toHaveBeenCalledTimes(1)
+  })
+
+  it(`should throw FetchBackoffAborted if the abort signal is triggered`, async () => {
+    const mockAbortController = new AbortController()
+    const signal = mockAbortController.signal
+    const mockErrorResponse = new Response(null, { status: 500 })
+    mockFetchClient.mockImplementation(
+      () => new Promise((res) => setTimeout(() => res(mockErrorResponse), 10))
+    )
+
+    const fetchWithBackoff = createFetchWithBackoff(mockFetchClient, {
+      ...BackoffDefaults,
+      initialDelay: 1000,
+    })
+
+    setTimeout(() => mockAbortController.abort(), 5)
+
+    await expect(
+      fetchWithBackoff(`https://example.com`, { signal })
+    ).rejects.toThrow(FetchBackoffAbortError)
+
+    expect(mockFetchClient).toHaveBeenCalledTimes(1)
+  })
+
+  it(`should not retry when a client error (4xx) occurs`, async () => {
+    const mockErrorResponse = new Response(null, {
+      status: 403,
+      statusText: `Forbidden`,
+    })
+    mockFetchClient.mockResolvedValue(mockErrorResponse)
+
+    const fetchWithBackoff = createFetchWithBackoff(
+      mockFetchClient,
+      BackoffDefaults
+    )
+
+    await expect(fetchWithBackoff(`https://example.com`)).rejects.toThrow(
+      FetchError
+    )
+    expect(mockFetchClient).toHaveBeenCalledTimes(1)
+  })
+
+  // it(`should retry multiple times and eventually throw if no success`, async () => {
+  //   const mockErrorResponse = new Response(null, { status: 500 })
+  //   mockFetchClient.mockImplementation(
+  //     () => new Promise((res) => setTimeout(() => res(mockErrorResponse), 10))
+  //   )
+
+  //   const fetchWithBackoff = createFetchWithBackoff(mockFetchClient, {
+  //     ...BackoffDefaults,
+  //     initialDelay,
+  //     maxDelay,
+  //   })
+
+  //   await expect(fetchWithBackoff(`https://example.com`)).rejects.toThrow(
+  //     FetchError
+  //   )
+  //   expect(mockFetchClient.mock.calls.length).greaterThan(1)
+  // })
+})

--- a/packages/typescript-client/test/helpers.test.ts
+++ b/packages/typescript-client/test/helpers.test.ts
@@ -1,28 +1,44 @@
 import { describe, expect, it } from 'vitest'
 import { isChangeMessage, isControlMessage, Message } from '../src'
+import { isUpToDateMessage } from '../src/helpers'
 
 describe(`helpers`, () => {
-  it(`should correctly detect ChangeMessages`, () => {
-    const message = {
-      headers: {
-        operation: `insert`,
-      },
-      offset: `-1`,
-      key: `key`,
-      value: { key: `value` },
-    } as Message
+  const changeMsg = {
+    headers: {
+      operation: `insert`,
+    },
+    offset: `-1`,
+    key: `key`,
+    value: { key: `value` },
+  } as Message
 
-    expect(isChangeMessage(message)).toBe(true)
-    expect(isControlMessage(message)).toBe(false)
+  const upToDateMsg = {
+    headers: {
+      control: `up-to-date`,
+    },
+  } as Message
+
+  const mustRefetchMsg = {
+    headers: {
+      control: `must-refetch`,
+    },
+  } as Message
+
+  it(`should correctly detect ChangeMessages`, () => {
+    expect(isChangeMessage(changeMsg)).toBe(true)
+    expect(isControlMessage(changeMsg)).toBe(false)
   })
 
   it(`should correctly detect ControlMessages`, () => {
-    const message = {
-      headers: {
-        control: `up-to-date`,
-      },
-    } as Message
-    expect(isControlMessage(message)).toBe(true)
-    expect(isChangeMessage(message)).toBe(false)
+    expect(isControlMessage(upToDateMsg)).toBe(true)
+    expect(isControlMessage(mustRefetchMsg)).toBe(true)
+    expect(isChangeMessage(upToDateMsg)).toBe(false)
+    expect(isChangeMessage(mustRefetchMsg)).toBe(false)
+  })
+
+  it(`should correctly detect up-to-date message`, () => {
+    expect(isUpToDateMessage(upToDateMsg)).toBe(true)
+    expect(isUpToDateMessage(mustRefetchMsg)).toBe(false)
+    expect(isUpToDateMessage(changeMsg)).toBe(false)
   })
 })

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -7,9 +7,9 @@ import {
   ShapeStream,
   ShapeStreamInterface,
   ShapeStreamOptions,
-} from '../src/client'
+} from '../src'
 import { Message, Offset, Row } from '../src/types'
-import { isChangeMessage, isControlMessage } from '../src'
+import { isChangeMessage, isUpToDateMessage } from '../src/helpers'
 import {
   IssueRow,
   testWithIssuesTable as it,
@@ -24,9 +24,6 @@ import {
 import { InMemoryStorage } from './persisters/in-memory'
 
 const BASE_URL = inject(`baseUrl`)
-
-const isUpToDateMessage = <T extends Row>(msg: Message<T>) =>
-  isControlMessage(msg) && msg.headers.control === `up-to-date`
 
 testShapeStream(
   `PersistedShapeStream`,

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -2,7 +2,12 @@ import { parse } from 'cache-control-parser'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { v4 as uuidv4 } from 'uuid'
 import { assert, describe, expect, inject, vi } from 'vitest'
-import { Shape, ShapeStream } from '../src/client'
+import {
+  Shape,
+  ShapeStream,
+  ShapeStreamInterface,
+  ShapeStreamOptions,
+} from '../src/client'
 import { Message, Offset, Row } from '../src/types'
 import { isChangeMessage, isControlMessage } from '../src'
 import {
@@ -11,168 +16,199 @@ import {
   testWithMultitypeTable as mit,
 } from './support/test-context'
 import * as h from './support/test-helpers'
+import {
+  PersistedShapeStream,
+  PersistedShapeStreamOptions,
+  ShapeStreamStorage,
+} from '../src/persist'
+import { InMemoryStorage } from './persisters/in-memory'
 
 const BASE_URL = inject(`baseUrl`)
 
 const isUpToDateMessage = <T extends Row>(msg: Message<T>) =>
   isControlMessage(msg) && msg.headers.control === `up-to-date`
 
-it(`sanity check`, async ({ dbClient, issuesTableSql }) => {
-  const result = await dbClient.query(`SELECT * FROM ${issuesTableSql}`)
+testShapeStream(
+  `PersistedShapeStream`,
+  <T extends Row>(opts: ShapeStreamOptions) => new ShapeStream<T>(opts)
+)
 
-  expect(result.rows).toEqual([])
-})
-
-describe(`HTTP Sync`, () => {
-  it(`should work with empty shape/table`, async ({
-    issuesTableUrl,
-    aborter,
-  }) => {
-    // Get initial data
-    const shapeData = new Map()
-    const issueStream = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      subscribe: false,
-      signal: aborter.signal,
+testShapeStream(
+  `PersistedShapeStream`,
+  <T extends Row>(
+    opts: ShapeStreamOptions & { storage?: ShapeStreamStorage<T> }
+  ) =>
+    new PersistedShapeStream<T>({
+      ...opts,
+      storage: opts.storage ?? new InMemoryStorage(),
     })
+)
 
-    await new Promise<void>((resolve, reject) => {
-      issueStream.subscribe((messages) => {
-        messages.forEach((message) => {
-          if (isChangeMessage(message)) {
-            shapeData.set(message.key, message.value)
-          }
-          if (isUpToDateMessage(message)) {
-            aborter.abort()
-            return resolve()
-          }
-        })
-      }, reject)
-    })
-    const values = [...shapeData.values()]
+function testShapeStream(
+  shapeStreamImplName: string,
+  shapeStreamFactory: <
+    T extends Row,
+    Options extends ShapeStreamOptions = ShapeStreamOptions,
+  >(
+    options: Options
+  ) => ShapeStreamInterface<T>
+) {
+  it(`sanity check`, async ({ dbClient, issuesTableSql }) => {
+    const result = await dbClient.query(`SELECT * FROM ${issuesTableSql}`)
 
-    expect(values).toHaveLength(0)
+    expect(result.rows).toEqual([])
   })
 
-  it(`should wait properly for updates on an empty shape/table`, async ({
-    issuesTableUrl,
-    aborter,
-  }) => {
-    const urlsRequested: URL[] = []
-    const fetchWrapper = (...args: Parameters<typeof fetch>) => {
-      const url = new URL(args[0])
-      urlsRequested.push(url)
-      return fetch(...args)
-    }
+  describe(`HTTP Sync with ${shapeStreamImplName}`, () => {
+    it(`should work with empty shape/table`, async ({
+      issuesTableUrl,
+      aborter,
+    }) => {
+      // Get initial data
+      const shapeData = new Map()
+      const issueStream = shapeStreamFactory({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        subscribe: false,
+        signal: aborter.signal,
+      })
 
-    // Get initial data
-    const shapeData = new Map()
-    const issueStream = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      signal: aborter.signal,
-      fetchClient: fetchWrapper,
+      await new Promise<void>((resolve, reject) => {
+        issueStream.subscribe((messages) => {
+          messages.forEach((message) => {
+            if (isChangeMessage(message)) {
+              shapeData.set(message.key, message.value)
+            }
+            if (isUpToDateMessage(message)) {
+              aborter.abort()
+              return resolve()
+            }
+          })
+        }, reject)
+      })
+      const values = [...shapeData.values()]
+
+      expect(values).toHaveLength(0)
     })
 
-    let upToDateMessageCount = 0
+    it(`should wait properly for updates on an empty shape/table`, async ({
+      issuesTableUrl,
+      aborter,
+    }) => {
+      const urlsRequested: URL[] = []
+      const fetchWrapper = (...args: Parameters<typeof fetch>) => {
+        const url = new URL(args[0])
+        urlsRequested.push(url)
+        return fetch(...args)
+      }
 
-    await new Promise<void>((resolve, reject) => {
-      issueStream.subscribe((messages) => {
-        messages.forEach((message) => {
-          if (isChangeMessage(message)) {
-            shapeData.set(message.key, message.value)
-          }
-          if (isUpToDateMessage(message)) {
-            upToDateMessageCount += 1
-          }
-        })
-      }, reject)
+      // Get initial data
+      const shapeData = new Map()
+      const issueStream = shapeStreamFactory({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
 
-      // count updates received over 1 second - proper long polling
-      // should wait for far longer than this time period
-      setTimeout(() => {
-        aborter.abort()
-        resolve()
-      }, 1000)
+      let upToDateMessageCount = 0
+
+      await new Promise<void>((resolve, reject) => {
+        issueStream.subscribe((messages) => {
+          messages.forEach((message) => {
+            if (isChangeMessage(message)) {
+              shapeData.set(message.key, message.value)
+            }
+            if (isUpToDateMessage(message)) {
+              upToDateMessageCount += 1
+            }
+          })
+        }, reject)
+
+        // count updates received over 1 second - proper long polling
+        // should wait for far longer than this time period
+        setTimeout(() => {
+          aborter.abort()
+          resolve()
+        }, 1000)
+      })
+
+      // first request was -1, second should be something else
+      expect(urlsRequested).toHaveLength(2)
+      expect(urlsRequested[0].searchParams.get(`offset`)).toBe(`-1`)
+      expect(urlsRequested[0].searchParams.has(`live`)).false
+      expect(urlsRequested[1].searchParams.get(`offset`)).not.toBe(`-1`)
+      expect(urlsRequested[1].searchParams.has(`live`)).true
+
+      // first request comes back immediately and is up to date, second one
+      // should hang while waiting for updates
+      expect(upToDateMessageCount).toBe(1)
+
+      // data should be 0
+      const values = [...shapeData.values()]
+      expect(values).toHaveLength(0)
     })
 
-    // first request was -1, second should be something else
-    expect(urlsRequested).toHaveLength(2)
-    expect(urlsRequested[0].searchParams.get(`offset`)).toBe(`-1`)
-    expect(urlsRequested[0].searchParams.has(`live`)).false
-    expect(urlsRequested[1].searchParams.get(`offset`)).not.toBe(`-1`)
-    expect(urlsRequested[1].searchParams.has(`live`)).true
-
-    // first request comes back immediately and is up to date, second one
-    // should hang while waiting for updates
-    expect(upToDateMessageCount).toBe(1)
-
-    // data should be 0
-    const values = [...shapeData.values()]
-    expect(values).toHaveLength(0)
-  })
-
-  it(`returns a header with the server shape id`, async ({
-    issuesTableUrl,
-  }) => {
-    const res = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
-      {}
-    )
-    const shapeId = res.headers.get(`x-electric-shape-id`)
-    expect(shapeId).to.exist
-  })
-
-  it(`returns a header with the chunk's last offset`, async ({
-    issuesTableUrl,
-  }) => {
-    const res = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
-      {}
-    )
-    const lastOffset = res.headers.get(`x-electric-chunk-last-offset`)
-    expect(lastOffset).to.exist
-  })
-
-  it(`should get initial data`, async ({
-    insertIssues,
-    issuesTableUrl,
-    aborter,
-  }) => {
-    // Add an initial row.
-    const uuid = uuidv4()
-    await insertIssues({ id: uuid, title: `foo + ${uuid}` })
-
-    // Get initial data
-    const shapeData = new Map()
-    const issueStream = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      signal: aborter.signal,
+    it(`returns a header with the server shape id`, async ({
+      issuesTableUrl,
+    }) => {
+      const res = await fetch(
+        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
+        {}
+      )
+      const shapeId = res.headers.get(`x-electric-shape-id`)
+      expect(shapeId).to.exist
     })
 
-    await new Promise<void>((resolve) => {
-      issueStream.subscribe((messages) => {
-        messages.forEach((message) => {
-          if (isChangeMessage(message)) {
-            shapeData.set(message.key, message.value)
-          }
-          if (isUpToDateMessage(message)) {
-            aborter.abort()
-            return resolve()
-          }
+    it(`returns a header with the chunk's last offset`, async ({
+      issuesTableUrl,
+    }) => {
+      const res = await fetch(
+        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
+        {}
+      )
+      const lastOffset = res.headers.get(`x-electric-chunk-last-offset`)
+      expect(lastOffset).to.exist
+    })
+
+    it(`should get initial data`, async ({
+      insertIssues,
+      issuesTableUrl,
+      aborter,
+    }) => {
+      // Add an initial row.
+      const uuid = uuidv4()
+      await insertIssues({ id: uuid, title: `foo + ${uuid}` })
+
+      // Get initial data
+      const shapeData = new Map()
+      const issueStream = shapeStreamFactory({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter.signal,
+      })
+
+      await new Promise<void>((resolve) => {
+        issueStream.subscribe((messages) => {
+          messages.forEach((message) => {
+            if (isChangeMessage(message)) {
+              shapeData.set(message.key, message.value)
+            }
+            if (isUpToDateMessage(message)) {
+              aborter.abort()
+              return resolve()
+            }
+          })
         })
       })
+      const values = [...shapeData.values()]
+
+      expect(values).toMatchObject([{ title: `foo + ${uuid}` }])
     })
-    const values = [...shapeData.values()]
 
-    expect(values).toMatchObject([{ title: `foo + ${uuid}` }])
-  })
-
-  mit(
-    `should parse incoming data`,
-    async ({ dbClient, aborter, tableSql, tableUrl }) => {
-      // Create a table with data we want to be parsed
-      await dbClient.query(
-        `
+    mit(
+      `should parse incoming data`,
+      async ({ dbClient, aborter, tableSql, tableUrl }) => {
+        // Create a table with data we want to be parsed
+        await dbClient.query(
+          `
       INSERT INTO ${tableSql} (txt, i2, i4, i8, f8, b, json, jsonb, ints, ints2, int4s, bools, moods, moods2, complexes, posints, jsons, txts, value, doubles)
       VALUES (
         'test',
@@ -197,70 +233,70 @@ describe(`HTTP Sync`, () => {
         $11
       )
     `,
-        [
           [
+            [
+              [1, 2, 3],
+              [4, 5, 6],
+            ],
             [1, 2, 3],
-            [4, 5, 6],
-          ],
-          [1, 2, 3],
-          [true, false, true],
-          [`sad`, `ok`, `happy`],
-          [
-            [`sad`, `ok`],
-            [`ok`, `happy`],
-          ],
-          [`(1.1, 2.2)`, `(3.3, 4.4)`],
-          [5, 9, 2],
-          [{ foo: `bar` }, { bar: `baz` }],
-          [`foo`, `bar`, `baz`],
-          { a: 5, b: [{ c: `foo` }] },
-          [Infinity, -Infinity, NaN],
-        ]
-      )
+            [true, false, true],
+            [`sad`, `ok`, `happy`],
+            [
+              [`sad`, `ok`],
+              [`ok`, `happy`],
+            ],
+            [`(1.1, 2.2)`, `(3.3, 4.4)`],
+            [5, 9, 2],
+            [{ foo: `bar` }, { bar: `baz` }],
+            [`foo`, `bar`, `baz`],
+            { a: 5, b: [{ c: `foo` }] },
+            [Infinity, -Infinity, NaN],
+          ]
+        )
 
-      // Now fetch the data from the HTTP endpoint
-      const issueStream = new ShapeStream({
-        url: `${BASE_URL}/v1/shape/${tableUrl}`,
-        signal: aborter.signal,
-      })
-      const client = new Shape(issueStream)
-      const data = await client.value
+        // Now fetch the data from the HTTP endpoint
+        const issueStream = shapeStreamFactory({
+          url: `${BASE_URL}/v1/shape/${tableUrl}`,
+          signal: aborter.signal,
+        })
+        const client = new Shape(issueStream)
+        const data = await client.value
 
-      expect([...data.values()]).toMatchObject([
-        {
-          txt: `test`,
-          i2: 1,
-          i4: 2147483647,
-          i8: BigInt(`9223372036854775807`),
-          f8: 4.5,
-          b: true,
-          json: { foo: `bar` },
-          jsonb: { foo: `bar` },
-          ints: [BigInt(1), BigInt(2), BigInt(3)],
-          ints2: [
-            [BigInt(1), BigInt(2), BigInt(3)],
-            [BigInt(4), BigInt(5), BigInt(6)],
-          ],
-          int4s: [1, 2, 3],
-          bools: [true, false, true],
-          moods: [`sad`, `ok`, `happy`],
-          moods2: [
-            [`sad`, `ok`],
-            [`ok`, `happy`],
-          ],
-          // It does not parse composite types and domain types
-          complexes: [`(1.1,2.2)`, `(3.3,4.4)`],
-          posints: [`5`, `9`, `2`],
-          jsons: [{ foo: `bar` }, { bar: `baz` }],
-          txts: [`foo`, `bar`, `baz`],
-          value: { a: 5, b: [{ c: `foo` }] },
-          doubles: [Infinity, -Infinity, NaN],
-        },
-      ])
+        expect([...data.values()]).toMatchObject([
+          {
+            txt: `test`,
+            i2: 1,
+            i4: 2147483647,
+            i8: BigInt(`9223372036854775807`),
+            f8: 4.5,
+            b: true,
+            json: { foo: `bar` },
+            jsonb: { foo: `bar` },
+            ints: [BigInt(1), BigInt(2), BigInt(3)],
+            ints2: [
+              [BigInt(1), BigInt(2), BigInt(3)],
+              [BigInt(4), BigInt(5), BigInt(6)],
+            ],
+            int4s: [1, 2, 3],
+            bools: [true, false, true],
+            moods: [`sad`, `ok`, `happy`],
+            moods2: [
+              [`sad`, `ok`],
+              [`ok`, `happy`],
+            ],
+            // It does not parse composite types and domain types
+            complexes: [`(1.1,2.2)`, `(3.3,4.4)`],
+            posints: [`5`, `9`, `2`],
+            jsons: [{ foo: `bar` }, { bar: `baz` }],
+            txts: [`foo`, `bar`, `baz`],
+            value: { a: 5, b: [{ c: `foo` }] },
+            doubles: [Infinity, -Infinity, NaN],
+          },
+        ])
 
-      // Now update the data
-      await dbClient.query(
-        `
+        // Now update the data
+        await dbClient.query(
+          `
       UPDATE ${tableSql}
       SET
         txt = 'changed',
@@ -284,434 +320,453 @@ describe(`HTTP Sync`, () => {
         doubles = $6
       WHERE i2 = 1
     `,
-        [
-          [false, true, false],
-          [`(2.2,3.3)`, `(4.4,5.5)`],
-          [{}],
-          [`new`, `values`],
-          { a: 6 },
-          [Infinity, NaN, -Infinity],
-        ]
+          [
+            [false, true, false],
+            [`(2.2,3.3)`, `(4.4,5.5)`],
+            [{}],
+            [`new`, `values`],
+            { a: 6 },
+            [Infinity, NaN, -Infinity],
+          ]
+        )
+
+        await sleep(100)
+        const updatedData = client.valueSync
+
+        expect([...updatedData.values()]).toMatchObject([
+          {
+            txt: `changed`,
+            i2: 1,
+            i4: 20,
+            i8: BigInt(30),
+            f8: 40.5,
+            b: false,
+            json: { bar: `foo` },
+            jsonb: { bar: `foo` },
+            ints: [BigInt(4), BigInt(5), BigInt(6)],
+            ints2: [
+              [BigInt(4), BigInt(5), BigInt(6)],
+              [BigInt(7), BigInt(8), BigInt(9)],
+            ],
+            int4s: [4, 5, 6],
+            bools: [false, true, false],
+            moods: [`sad`, `happy`],
+            moods2: [
+              [`sad`, `happy`],
+              [`happy`, `ok`],
+            ],
+            complexes: [`(2.2,3.3)`, `(4.4,5.5)`],
+            posints: [`6`, `10`, `3`],
+            jsons: [{}],
+            txts: [`new`, `values`],
+            value: { a: 6 },
+            doubles: [Infinity, NaN, -Infinity],
+          },
+        ])
+      }
+    )
+
+    it(`should get initial data and then receive updates`, async ({
+      aborter,
+      issuesTableUrl,
+      issuesTableKey,
+      updateIssue,
+      insertIssues,
+    }) => {
+      // With initial data
+      const rowId = uuidv4()
+      await insertIssues({ id: rowId, title: `original insert` })
+
+      const shapeData = new Map()
+      const issueStream = shapeStreamFactory({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter.signal,
+      })
+      let secondRowId = ``
+      await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
+        if (!isChangeMessage(msg)) return
+        shapeData.set(msg.key, msg.value)
+
+        if (nth === 0) {
+          updateIssue({ id: rowId, title: `foo1` })
+        } else if (nth === 1) {
+          ;[secondRowId] = await insertIssues({ title: `foo2` })
+        } else if (nth === 2) {
+          res()
+        }
+      })
+
+      // Only initial insert has the full row, the update contains only PK & changed columns.
+      // This test doesn't merge in updates, so we don't have `priority` on the row.
+      expect(shapeData).toEqual(
+        new Map([
+          [`${issuesTableKey}/"${rowId}"`, { id: rowId, title: `foo1` }],
+          [
+            `${issuesTableKey}/"${secondRowId}"`,
+            { id: secondRowId, title: `foo2`, priority: 10 },
+          ],
+        ])
+      )
+    })
+
+    it(`multiple clients can get the same data in parallel`, async ({
+      issuesTableUrl,
+      updateIssue,
+      insertIssues,
+    }) => {
+      const rowId = uuidv4(),
+        rowId2 = uuidv4()
+      await insertIssues(
+        { id: rowId, title: `first original insert` },
+        { id: rowId2, title: `second original insert` }
       )
 
-      await sleep(100)
-      const updatedData = client.valueSync
+      const shapeData1 = new Map()
+      const aborter1 = new AbortController()
+      const issueStream1 = shapeStreamFactory({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter1.signal,
+      })
 
-      expect([...updatedData.values()]).toMatchObject([
-        {
-          txt: `changed`,
-          i2: 1,
-          i4: 20,
-          i8: BigInt(30),
-          f8: 40.5,
-          b: false,
-          json: { bar: `foo` },
-          jsonb: { bar: `foo` },
-          ints: [BigInt(4), BigInt(5), BigInt(6)],
-          ints2: [
-            [BigInt(4), BigInt(5), BigInt(6)],
-            [BigInt(7), BigInt(8), BigInt(9)],
-          ],
-          int4s: [4, 5, 6],
-          bools: [false, true, false],
-          moods: [`sad`, `happy`],
-          moods2: [
-            [`sad`, `happy`],
-            [`happy`, `ok`],
-          ],
-          complexes: [`(2.2,3.3)`, `(4.4,5.5)`],
-          posints: [`6`, `10`, `3`],
-          jsons: [{}],
-          txts: [`new`, `values`],
-          value: { a: 6 },
-          doubles: [Infinity, NaN, -Infinity],
-        },
-      ])
-    }
-  )
+      const shapeData2 = new Map()
+      const aborter2 = new AbortController()
+      const issueStream2 = shapeStreamFactory({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter2.signal,
+      })
 
-  it(`should get initial data and then receive updates`, async ({
-    aborter,
-    issuesTableUrl,
-    issuesTableKey,
-    updateIssue,
-    insertIssues,
-  }) => {
-    // With initial data
-    const rowId = uuidv4()
-    await insertIssues({ id: rowId, title: `original insert` })
+      const p1 = h.forEachMessage(issueStream1, aborter1, (res, msg, nth) => {
+        if (!isChangeMessage(msg)) return
+        shapeData1.set(msg.key, msg.value)
 
-    const shapeData = new Map()
-    const issueStream = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      signal: aborter.signal,
-    })
-    let secondRowId = ``
-    await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
-      if (!isChangeMessage(msg)) return
-      shapeData.set(msg.key, msg.value)
-
-      if (nth === 0) {
-        updateIssue({ id: rowId, title: `foo1` })
-      } else if (nth === 1) {
-        ;[secondRowId] = await insertIssues({ title: `foo2` })
-      } else if (nth === 2) {
-        res()
-      }
-    })
-
-    // Only initial insert has the full row, the update contains only PK & changed columns.
-    // This test doesn't merge in updates, so we don't have `priority` on the row.
-    expect(shapeData).toEqual(
-      new Map([
-        [`${issuesTableKey}/"${rowId}"`, { id: rowId, title: `foo1` }],
-        [
-          `${issuesTableKey}/"${secondRowId}"`,
-          { id: secondRowId, title: `foo2`, priority: 10 },
-        ],
-      ])
-    )
-  })
-
-  it(`multiple clients can get the same data in parallel`, async ({
-    issuesTableUrl,
-    updateIssue,
-    insertIssues,
-  }) => {
-    const rowId = uuidv4(),
-      rowId2 = uuidv4()
-    await insertIssues(
-      { id: rowId, title: `first original insert` },
-      { id: rowId2, title: `second original insert` }
-    )
-
-    const shapeData1 = new Map()
-    const aborter1 = new AbortController()
-    const issueStream1 = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      signal: aborter1.signal,
-    })
-
-    const shapeData2 = new Map()
-    const aborter2 = new AbortController()
-    const issueStream2 = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      signal: aborter2.signal,
-    })
-
-    const p1 = h.forEachMessage(issueStream1, aborter1, (res, msg, nth) => {
-      if (!isChangeMessage(msg)) return
-      shapeData1.set(msg.key, msg.value)
-
-      if (nth === 1) {
-        setTimeout(() => updateIssue({ id: rowId, title: `foo3` }), 50)
-      } else if (nth === 2) {
-        return res()
-      }
-    })
-
-    const p2 = h.forEachMessage(issueStream2, aborter2, (res, msg, nth) => {
-      if (!isChangeMessage(msg)) return
-      shapeData2.set(msg.key, msg.value)
-
-      if (nth === 2) {
-        return res()
-      }
-    })
-
-    await Promise.all([p1, p2])
-
-    expect(shapeData1).toEqual(shapeData2)
-  })
-
-  it(`can go offline and then catchup`, async ({
-    aborter,
-    issuesTableUrl,
-    insertIssues,
-  }) => {
-    await insertIssues({ title: `foo1` }, { title: `foo2` }, { title: `foo3` })
-    await sleep(50)
-
-    let lastOffset: Offset = `-1`
-    const issueStream = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      signal: aborter.signal,
-      subscribe: false,
-    })
-
-    await h.forEachMessage(issueStream, aborter, (res, msg) => {
-      if (`offset` in msg) {
-        expect(msg.offset).to.not.eq(`0_`)
-        lastOffset = msg.offset
-      } else if (isUpToDateMessage(msg)) {
-        res()
-      }
-    })
-
-    await insertIssues(
-      ...Array.from({ length: 9 }, (_, i) => ({ title: `foo${i + 5}` }))
-    )
-
-    // And wait until it's definitely seen
-    await vi.waitFor(async () => {
-      const res = await fetch(
-        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`
-      )
-      const body = (await res.json()) as Message[]
-      expect(body).toHaveLength(13)
-    })
-
-    let catchupOpsCount = 0
-    const newAborter = new AbortController()
-    const newIssueStream = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      subscribe: false,
-      signal: newAborter.signal,
-      offset: lastOffset,
-      shapeId: issueStream.shapeId,
-    })
-    await h.forEachMessage(newIssueStream, aborter, (res, msg, nth) => {
-      if (isUpToDateMessage(msg)) {
-        res()
-      } else {
-        catchupOpsCount = nth + 1
-      }
-    })
-
-    expect(catchupOpsCount).toBe(9)
-  })
-
-  it(`should return correct caching headers`, async ({
-    issuesTableUrl,
-    insertIssues,
-  }) => {
-    const res = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
-      {}
-    )
-    const cacheHeaders = res.headers.get(`cache-control`)
-    assert(cacheHeaders !== null, `Response should have cache-control header`)
-    const directives = parse(cacheHeaders)
-    expect(directives).toEqual({ 'max-age': 1, 'stale-while-revalidate': 3 })
-    const etagHeader = res.headers.get(`etag`)
-    assert(etagHeader !== null, `Response should have etag header`)
-
-    await insertIssues(
-      { title: `foo4` },
-      { title: `foo5` },
-      { title: `foo6` },
-      { title: `foo7` },
-      { title: `foo8` }
-    )
-    // Wait for server to get all the messages.
-    await sleep(40)
-
-    const res2 = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
-      {}
-    )
-    const etag2Header = res2.headers.get(`etag`)
-    expect(etag2Header !== null, `Response should have etag header`)
-    expect(etagHeader).not.toEqual(etag2Header)
-  })
-
-  it(`should revalidate etags`, async ({ issuesTableUrl, insertIssues }) => {
-    // Start the shape
-    await fetch(`${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`, {})
-    // Fill it up in separate transactions
-    for (const i of [1, 2, 3, 4, 5, 6, 7, 8, 9]) {
-      await insertIssues({ title: `foo${i}` })
-    }
-    // Then wait for them to flow through the system
-    await sleep(100)
-
-    const res = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
-      {}
-    )
-    const messages = (await res.json()) as Message[]
-    expect(messages.length).toEqual(10) // 9 inserts + up-to-date
-    const midMessage = messages.slice(-6)[0]
-    assert(`offset` in midMessage)
-    const midOffset = midMessage.offset
-    const shapeId = res.headers.get(`x-electric-shape-id`)
-    const etag = res.headers.get(`etag`)
-    assert(etag !== null, `Response should have etag header`)
-
-    const etagValidation = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
-      {
-        headers: { 'If-None-Match': etag },
-      }
-    )
-
-    const status = etagValidation.status
-    expect(status).toEqual(304)
-
-    // Get etag for catchup
-    const catchupEtagRes = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=${midOffset}&shape_id=${shapeId}`,
-      {}
-    )
-    const catchupEtag = catchupEtagRes.headers.get(`etag`)
-    assert(catchupEtag !== null, `Response should have catchup etag header`)
-
-    // Catch-up offsets should also use the same etag as they're
-    // also working through the end of the current log.
-    const catchupEtagValidation = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=${midOffset}&shape_id=${shapeId}`,
-      {
-        headers: { 'If-None-Match': catchupEtag },
-      }
-    )
-    const catchupStatus = catchupEtagValidation.status
-    expect(catchupStatus).toEqual(304)
-  })
-
-  it(`should correctly use a where clause for initial sync and updates`, async ({
-    insertIssues,
-    updateIssue,
-    issuesTableUrl,
-    issuesTableKey,
-    clearShape,
-    aborter,
-  }) => {
-    // Add an initial rows
-    const id1 = uuidv4()
-    const id2 = uuidv4()
-
-    await insertIssues({ id: id1, title: `foo` }, { id: id2, title: `bar` })
-
-    // Get initial data
-    const shapeData = new Map()
-    const issueStream = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      where: `title LIKE 'foo%'`,
-      subscribe: true,
-      signal: aborter.signal,
-    })
-
-    await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
-      if (!isChangeMessage(msg)) return
-      shapeData.set(msg.key, msg.value)
-
-      if (nth === 0) {
-        updateIssue({ id: id1, title: `foo1` })
-        updateIssue({ id: id2, title: `bar1` })
-      } else if (nth === 1) {
-        res()
-      }
-    })
-
-    await clearShape(issuesTableUrl, issueStream.shapeId!)
-
-    expect(shapeData).toEqual(
-      new Map([[`${issuesTableKey}/"${id1}"`, { id: id1, title: `foo1` }]])
-    )
-  })
-
-  it(`should detect shape deprecation and restart syncing`, async ({
-    expect,
-    insertIssues,
-    issuesTableUrl,
-    aborter,
-    clearIssuesShape,
-  }) => {
-    // With initial data
-    const rowId = uuidv4()
-    const secondRowId = uuidv4()
-    await insertIssues({ id: rowId, title: `foo1` })
-
-    const statusCodesReceived: number[] = []
-
-    const fetchWrapper = async (...args: Parameters<typeof fetch>) => {
-      // before any subsequent requests after the initial one, ensure
-      // that the existing shape is deleted and some more data is inserted
-      if (statusCodesReceived.length === 1 && statusCodesReceived[0] === 200) {
-        await clearIssuesShape()
-        await insertIssues({ id: secondRowId, title: `foo2` })
-      }
-
-      const response = await fetch(...args)
-      if (response.status < 500) {
-        statusCodesReceived.push(response.status)
-      }
-
-      return response
-    }
-
-    const issueStream = new ShapeStream<IssueRow>({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
-      subscribe: true,
-      signal: aborter.signal,
-      fetchClient: fetchWrapper,
-    })
-
-    expect.assertions(11)
-
-    let originalShapeId: string | undefined
-    let upToDateReachedCount = 0
-    await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
-      // shapeData.set(msg.key, msg.value)
-      if (isUpToDateMessage(msg)) {
-        upToDateReachedCount++
-        if (upToDateReachedCount === 1) {
-          // upon reaching up to date initially, we have one
-          // response with the initial data
-          expect(statusCodesReceived).toHaveLength(1)
-          expect(statusCodesReceived[0]).toBe(200)
-        } else if (upToDateReachedCount === 2) {
-          // the next up to date message should have had
-          // a 409 interleaved before it that instructed the
-          // client to go and fetch data from scratch
-          expect(statusCodesReceived).toHaveLength(3)
-          expect(statusCodesReceived[1]).toBe(409)
-          expect(statusCodesReceived[2]).toBe(200)
+        if (nth === 1) {
+          setTimeout(() => updateIssue({ id: rowId, title: `foo3` }), 50)
+        } else if (nth === 2) {
           return res()
         }
-        return
+      })
+
+      const p2 = h.forEachMessage(issueStream2, aborter2, (res, msg, nth) => {
+        if (!isChangeMessage(msg)) return
+        shapeData2.set(msg.key, msg.value)
+
+        if (nth === 2) {
+          return res()
+        }
+      })
+
+      await Promise.all([p1, p2])
+
+      expect(shapeData1).toEqual(shapeData2)
+    })
+
+    it(`can go offline and then catchup`, async ({
+      aborter,
+      issuesTableUrl,
+      insertIssues,
+    }) => {
+      // initialize storage for the cases where persisted shape streams are tested
+      const storage = new InMemoryStorage()
+      await insertIssues(
+        { title: `foo1` },
+        { title: `foo2` },
+        { title: `foo3` }
+      )
+      await sleep(50)
+
+      let lastOffset: Offset = `-1`
+      const issueStream = shapeStreamFactory<
+        IssueRow,
+        PersistedShapeStreamOptions
+      >({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        signal: aborter.signal,
+        subscribe: false,
+        storage,
+      })
+
+      await h.forEachMessage(issueStream, aborter, (res, msg) => {
+        if (`offset` in msg) {
+          expect(msg.offset).to.not.eq(`0_`)
+          lastOffset = msg.offset
+        } else if (isUpToDateMessage(msg)) {
+          res()
+        }
+      })
+
+      await insertIssues(
+        ...Array.from({ length: 9 }, (_, i) => ({ title: `foo${i + 5}` }))
+      )
+
+      // And wait until it's definitely seen
+      await vi.waitFor(async () => {
+        const res = await fetch(
+          `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`
+        )
+        const body = (await res.json()) as Message[]
+        expect(body).toHaveLength(13)
+      })
+
+      let catchupOpsCount = 0
+      let cachedOpsCount = 0
+      const newAborter = new AbortController()
+      const newIssueStream = shapeStreamFactory({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        subscribe: false,
+        signal: newAborter.signal,
+        offset: lastOffset,
+        shapeId: issueStream.shapeId,
+        storage,
+      })
+
+      await h.forEachMessage(newIssueStream, newAborter, (res, msg, nth) => {
+        if (isUpToDateMessage(msg)) {
+          res()
+        } else if (msg.headers[`localCache`]) {
+          cachedOpsCount++
+        } else {
+          catchupOpsCount = nth + 1 - cachedOpsCount
+        }
+      })
+
+      expect(catchupOpsCount).toBe(9)
+    })
+
+    it(`should return correct caching headers`, async ({
+      issuesTableUrl,
+      insertIssues,
+    }) => {
+      const res = await fetch(
+        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
+        {}
+      )
+      const cacheHeaders = res.headers.get(`cache-control`)
+      assert(cacheHeaders !== null, `Response should have cache-control header`)
+      const directives = parse(cacheHeaders)
+      expect(directives).toEqual({ 'max-age': 1, 'stale-while-revalidate': 3 })
+      const etagHeader = res.headers.get(`etag`)
+      assert(etagHeader !== null, `Response should have etag header`)
+
+      await insertIssues(
+        { title: `foo4` },
+        { title: `foo5` },
+        { title: `foo6` },
+        { title: `foo7` },
+        { title: `foo8` }
+      )
+      // Wait for server to get all the messages.
+      await sleep(40)
+
+      const res2 = await fetch(
+        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
+        {}
+      )
+      const etag2Header = res2.headers.get(`etag`)
+      expect(etag2Header !== null, `Response should have etag header`)
+      expect(etagHeader).not.toEqual(etag2Header)
+    })
+
+    it(`should revalidate etags`, async ({ issuesTableUrl, insertIssues }) => {
+      // Start the shape
+      await fetch(`${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`, {})
+      // Fill it up in separate transactions
+      for (const i of [1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+        await insertIssues({ title: `foo${i}` })
+      }
+      // Then wait for them to flow through the system
+      await sleep(100)
+
+      const res = await fetch(
+        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
+        {}
+      )
+      const messages = (await res.json()) as Message[]
+      expect(messages.length).toEqual(10) // 9 inserts + up-to-date
+      const midMessage = messages.slice(-6)[0]
+      assert(`offset` in midMessage)
+      const midOffset = midMessage.offset
+      const shapeId = res.headers.get(`x-electric-shape-id`)
+      const etag = res.headers.get(`etag`)
+      assert(etag !== null, `Response should have etag header`)
+
+      const etagValidation = await fetch(
+        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
+        {
+          headers: { 'If-None-Match': etag },
+        }
+      )
+
+      const status = etagValidation.status
+      expect(status).toEqual(304)
+
+      // Get etag for catchup
+      const catchupEtagRes = await fetch(
+        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=${midOffset}&shape_id=${shapeId}`,
+        {}
+      )
+      const catchupEtag = catchupEtagRes.headers.get(`etag`)
+      assert(catchupEtag !== null, `Response should have catchup etag header`)
+
+      // Catch-up offsets should also use the same etag as they're
+      // also working through the end of the current log.
+      const catchupEtagValidation = await fetch(
+        `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=${midOffset}&shape_id=${shapeId}`,
+        {
+          headers: { 'If-None-Match': catchupEtag },
+        }
+      )
+      const catchupStatus = catchupEtagValidation.status
+      expect(catchupStatus).toEqual(304)
+    })
+
+    it(`should correctly use a where clause for initial sync and updates`, async ({
+      insertIssues,
+      updateIssue,
+      issuesTableUrl,
+      issuesTableKey,
+      clearShape,
+      aborter,
+    }) => {
+      // Add an initial rows
+      const id1 = uuidv4()
+      const id2 = uuidv4()
+
+      await insertIssues({ id: id1, title: `foo` }, { id: id2, title: `bar` })
+
+      // Get initial data
+      const shapeData = new Map()
+      const issueStream = shapeStreamFactory({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        where: `title LIKE 'foo%'`,
+        subscribe: true,
+        signal: aborter.signal,
+      })
+
+      await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
+        if (!isChangeMessage(msg)) return
+        shapeData.set(msg.key, msg.value)
+
+        if (nth === 0) {
+          updateIssue({ id: id1, title: `foo1` })
+          updateIssue({ id: id2, title: `bar1` })
+        } else if (nth === 1) {
+          res()
+        }
+      })
+
+      await clearShape(issuesTableUrl, issueStream.shapeId!)
+
+      expect(shapeData).toEqual(
+        new Map([[`${issuesTableKey}/"${id1}"`, { id: id1, title: `foo1` }]])
+      )
+    })
+
+    it(`should detect shape deprecation and restart syncing`, async ({
+      expect,
+      insertIssues,
+      issuesTableUrl,
+      aborter,
+      clearIssuesShape,
+    }) => {
+      // With initial data
+      const rowId = uuidv4()
+      const secondRowId = uuidv4()
+      await insertIssues({ id: rowId, title: `foo1` })
+
+      const statusCodesReceived: number[] = []
+
+      const fetchWrapper = async (...args: Parameters<typeof fetch>) => {
+        // before any subsequent requests after the initial one, ensure
+        // that the existing shape is deleted and some more data is inserted
+        if (
+          statusCodesReceived.length === 1 &&
+          statusCodesReceived[0] === 200
+        ) {
+          await clearIssuesShape()
+          await insertIssues({ id: secondRowId, title: `foo2` })
+        }
+
+        const response = await fetch(...args)
+        if (response.status < 500) {
+          statusCodesReceived.push(response.status)
+        }
+
+        return response
       }
 
-      if (!isChangeMessage(msg)) return
+      const issueStream = shapeStreamFactory<IssueRow>({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        subscribe: true,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
 
-      switch (nth) {
-        case 0:
-          // first message is the initial row
-          expect(msg.value).toEqual({
-            id: rowId,
-            title: `foo1`,
-            priority: 10,
-          })
-          expect(issueStream.shapeId).to.exist
-          originalShapeId = issueStream.shapeId
-          break
-        case 1:
-        case 2:
-          // Second snapshot queries PG without `ORDER BY`, so check that it's generally correct.
-          // We're checking that both messages arrive by using `expect.assertions(N)` above.
+      expect.assertions(11)
 
-          if (msg.value.id == rowId) {
-            // message is the initial row again as it is a new shape
-            // with different shape id
+      let originalShapeId: string | undefined
+      let upToDateReachedCount = 0
+      await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
+        // shapeData.set(msg.key, msg.value)
+        if (isUpToDateMessage(msg)) {
+          upToDateReachedCount++
+          if (upToDateReachedCount === 1) {
+            // upon reaching up to date initially, we have one
+            // response with the initial data
+            expect(statusCodesReceived).toHaveLength(1)
+            expect(statusCodesReceived[0]).toBe(200)
+          } else if (upToDateReachedCount === 2) {
+            // the next up to date message should have had
+            // a 409 interleaved before it that instructed the
+            // client to go and fetch data from scratch
+            expect(statusCodesReceived).toHaveLength(3)
+            expect(statusCodesReceived[1]).toBe(409)
+            expect(statusCodesReceived[2]).toBe(200)
+            return res()
+          }
+          return
+        }
+
+        if (!isChangeMessage(msg)) return
+
+        switch (nth) {
+          case 0:
+            // first message is the initial row
             expect(msg.value).toEqual({
               id: rowId,
               title: `foo1`,
               priority: 10,
             })
-            expect(issueStream.shapeId).not.toBe(originalShapeId)
-          } else {
-            // should get the second row as well with the new shape ID
-            expect(msg.value).toEqual({
-              id: secondRowId,
-              title: `foo2`,
-              priority: 10,
-            })
-            expect(issueStream.shapeId).not.toBe(originalShapeId)
-          }
-          break
-        default:
-          expect.unreachable(`Received more messages than expected`)
-      }
+            expect(issueStream.shapeId).to.exist
+            originalShapeId = issueStream.shapeId
+            break
+          case 1:
+          case 2:
+            // Second snapshot queries PG without `ORDER BY`, so check that it's generally correct.
+            // We're checking that both messages arrive by using `expect.assertions(N)` above.
+
+            if (msg.value.id == rowId) {
+              // message is the initial row again as it is a new shape
+              // with different shape id
+              expect(msg.value).toEqual({
+                id: rowId,
+                title: `foo1`,
+                priority: 10,
+              })
+              expect(issueStream.shapeId).not.toBe(originalShapeId)
+            } else {
+              // should get the second row as well with the new shape ID
+              expect(msg.value).toEqual({
+                id: secondRowId,
+                title: `foo2`,
+                priority: 10,
+              })
+              expect(issueStream.shapeId).not.toBe(originalShapeId)
+            }
+            break
+          default:
+            expect.unreachable(`Received more messages than expected`)
+        }
+      })
     })
   })
-})
+}

--- a/packages/typescript-client/test/offset.test.ts
+++ b/packages/typescript-client/test/offset.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { compareOffset } from '../src/offset'
+
+describe(`compareOffset`, () => {
+  it(`should return 1 when the first part of offsetA is greater than offsetB`, () => {
+    expect(compareOffset(`2_5`, `1_8`)).toBe(1)
+  })
+
+  it(`should return -1 when the first part of offsetA is less than offsetB`, () => {
+    expect(compareOffset(`1_5`, `2_8`)).toBe(-1)
+  })
+
+  it(`should return 1 when the first part is equal but second part of offsetA is greater`, () => {
+    expect(compareOffset(`1_9`, `1_5`)).toBe(1)
+  })
+
+  it(`should return -1 when the first part is equal but second part of offsetA is less`, () => {
+    expect(compareOffset(`1_2`, `1_8`)).toBe(-1)
+  })
+
+  it(`should return 0 when both offsets are the same`, () => {
+    expect(compareOffset(`1_5`, `1_5`)).toBe(0)
+  })
+
+  it(`should return 1 when offsetA is non-negative and offsetB is '-1'`, () => {
+    expect(compareOffset(`1_5`, `-1`)).toBe(1)
+  })
+
+  it(`should return -1 when offsetA is '-1' and offsetB is non-negative`, () => {
+    expect(compareOffset(`-1`, `1_5`)).toBe(-1)
+  })
+
+  it(`should return 0 when both offsets are '- 1'`, () => {
+    expect(compareOffset(`-1`, `-1`)).toBe(0)
+  })
+})

--- a/packages/typescript-client/test/persist.test.ts
+++ b/packages/typescript-client/test/persist.test.ts
@@ -2,20 +2,11 @@ import { beforeEach, describe, expect, inject, vi } from 'vitest'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { v4 as uuidv4 } from 'uuid'
 import { testWithIssuesTable as it } from './support/test-context'
-import {
-  isChangeMessage,
-  isControlMessage,
-  Message,
-  Offset,
-  PromiseOr,
-  Row,
-} from '../src'
+import { Offset, PromiseOr } from '../src/types'
+import { isChangeMessage, isUpToDateMessage } from '../src/helpers'
 import { PersistedShapeStream, ShapeStreamStorage } from '../src/persist'
 import { InMemoryStorage } from './persisters/in-memory'
 import { InMemoryAsyncStorage } from './persisters/in-memory-async'
-
-const isUpToDateMessage = <T extends Row>(msg: Message<T>) =>
-  isControlMessage(msg) && msg.headers.control === `up-to-date`
 
 const BASE_URL = inject(`baseUrl`)
 

--- a/packages/typescript-client/test/persist.test.ts
+++ b/packages/typescript-client/test/persist.test.ts
@@ -2,203 +2,226 @@ import { beforeEach, describe, expect, inject, vi } from 'vitest'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { v4 as uuidv4 } from 'uuid'
 import { testWithIssuesTable as it } from './support/test-context'
-import { isChangeMessage, isControlMessage, Message, Offset, Row } from '../src'
-import { PersistedShapeStream } from '../src/persist'
+import {
+  isChangeMessage,
+  isControlMessage,
+  Message,
+  Offset,
+  PromiseOr,
+  Row,
+} from '../src'
+import { PersistedShapeStream, ShapeStreamStorage } from '../src/persist'
 import { InMemoryStorage } from './persisters/in-memory'
+import { InMemoryAsyncStorage } from './persisters/in-memory-async'
 
 const isUpToDateMessage = <T extends Row>(msg: Message<T>) =>
   isControlMessage(msg) && msg.headers.control === `up-to-date`
 
 const BASE_URL = inject(`baseUrl`)
 
-describe(`PersistedShapeStream`, () => {
-  let fetchSpy = vi.spyOn(global, `fetch`)
-  let storage = new InMemoryStorage()
+function flushDbChanges(): Promise<void> {
+  return sleep(100)
+}
 
-  beforeEach(() => {
-    vi.restoreAllMocks()
-    storage = new InMemoryStorage()
-    fetchSpy = vi.spyOn(global, `fetch`)
+testPersistence(`with synchronous storage`, () => new InMemoryStorage())
+testPersistence(`with asynchronous storage`, () => new InMemoryAsyncStorage())
+
+function testPersistence(
+  testSuiteTitle: string,
+  createStorage: () => PromiseOr<ShapeStreamStorage>
+) {
+  describe(`PersistedShapeStream ${testSuiteTitle}`, () => {
+    let fetchSpy = vi.spyOn(global, `fetch`)
+    let storage: ShapeStreamStorage
+
+    beforeEach(async () => {
+      vi.restoreAllMocks()
+      storage = await createStorage()
+      fetchSpy = vi.spyOn(global, `fetch`)
+    })
+
+    it(`should store initial data`, async ({
+      insertIssues,
+      issuesTableUrl,
+      aborter,
+    }) => {
+      // Add an initial row.
+      const uuid = uuidv4()
+      await insertIssues({ id: uuid, title: `foo + ${uuid}` })
+
+      const url = `${BASE_URL}/v1/shape/${issuesTableUrl}`
+
+      // Get initial data
+      const issueStream = new PersistedShapeStream({
+        url,
+        signal: aborter.signal,
+        storage,
+        subscribe: false,
+      })
+
+      let lastOffset: Offset | undefined
+
+      await new Promise<void>((resolve) => {
+        issueStream.subscribe((messages) => {
+          messages.forEach((message) => {
+            if (isChangeMessage(message)) {
+              lastOffset = message.offset
+            }
+            if (isUpToDateMessage(message)) {
+              aborter.abort()
+              return resolve()
+            }
+          })
+        })
+      })
+
+      const shapeId = issueStream.shapeId
+
+      // expect initial request
+      expect(shapeId).toBeTypeOf(`string`)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(fetchSpy).toHaveBeenCalledWith(
+        encodeURI(`${url}?offset=-1`),
+        expect.any(Object)
+      )
+
+      await issueStream.flush()
+
+      // clearing spies and starting new stream with the same
+      // storage should trigger a request for offset 0_0
+      fetchSpy.mockClear()
+      const secondAborter = new AbortController()
+      const restoredIssueStream = new PersistedShapeStream({
+        url: url,
+        signal: secondAborter.signal,
+        storage,
+        subscribe: false,
+      })
+
+      await new Promise<void>((resolve) => {
+        restoredIssueStream.subscribe((messages) => {
+          messages.forEach((message) => {
+            if (isUpToDateMessage(message)) {
+              secondAborter.abort()
+              return resolve()
+            }
+          })
+        })
+      })
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(fetchSpy).toHaveBeenCalledWith(
+        encodeURI(`${url}?offset=${lastOffset}&shape_id=${shapeId}`),
+        expect.any(Object)
+      )
+    })
+
+    it(`should compact operations and restore as inserts`, async ({
+      insertIssues,
+      updateIssue,
+      deleteIssue,
+      issuesTableUrl,
+      aborter,
+    }) => {
+      const url = `${BASE_URL}/v1/shape/${issuesTableUrl}`
+
+      // Add initial rows
+      const rowId = uuidv4(),
+        rowId2 = uuidv4(),
+        rowId3 = uuidv4()
+      await insertIssues(
+        { id: rowId, title: `first original insert` },
+        { id: rowId2, title: `second original insert` }
+      )
+
+      // Get initial data
+      const issueStream = new PersistedShapeStream({
+        url,
+        signal: aborter.signal,
+        storage,
+        subscribe: false,
+      })
+
+      await new Promise<void>((resolve) => {
+        issueStream.subscribe((messages) => {
+          messages.forEach((message) => {
+            if (isUpToDateMessage(message)) {
+              aborter.abort()
+              return resolve()
+            }
+          })
+        })
+      })
+      // expect initial request
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(fetchSpy).toHaveBeenCalledWith(
+        encodeURI(`${url}?offset=-1`),
+        expect.any(Object)
+      )
+
+      await Promise.all([
+        updateIssue({ id: rowId, title: `first updated insert` }),
+        deleteIssue({ id: rowId2, title: `second original insert` }),
+        insertIssues({ id: rowId3, title: `third original insert` }),
+      ])
+      await Promise.all([flushDbChanges(), issueStream.flush()])
+
+      // filling stream with new data
+      const secondAborter = new AbortController()
+      let restoredIssueStream = new PersistedShapeStream({
+        url: url,
+        signal: secondAborter.signal,
+        storage,
+        subscribe: false,
+      })
+
+      let opCount = 0
+      await new Promise<void>((resolve) => {
+        restoredIssueStream.subscribe((messages) => {
+          messages.forEach((message) => {
+            if (isChangeMessage(message)) {
+              opCount++
+            }
+            if (isUpToDateMessage(message)) {
+              secondAborter.abort()
+              return resolve()
+            }
+          })
+        })
+      })
+
+      // should have the 2 original inserts, and then 3 update/delete/inerts
+      expect(opCount).toBe(2 + 3)
+
+      await restoredIssueStream.flush()
+
+      // clearing spies and starting new stream, should have as many updates
+      fetchSpy.mockClear()
+      const thirdAborter = new AbortController()
+      restoredIssueStream = new PersistedShapeStream({
+        url: url,
+        signal: thirdAborter.signal,
+        storage,
+        subscribe: false,
+      })
+
+      opCount = 0
+      await new Promise<void>((resolve) => {
+        restoredIssueStream.subscribe((messages) => {
+          messages.forEach((message) => {
+            if (isChangeMessage(message)) {
+              expect(message.headers.operation).toBe(`insert`)
+              opCount++
+            }
+            if (isUpToDateMessage(message)) {
+              thirdAborter.abort()
+              return resolve()
+            }
+          })
+        })
+      })
+
+      // should have compacted everything to 2 inserts
+      expect(opCount).toBe(2)
+    })
   })
-
-  it(`should store initial data`, async ({
-    insertIssues,
-    issuesTableUrl,
-    aborter,
-  }) => {
-    // Add an initial row.
-    const uuid = uuidv4()
-    await insertIssues({ id: uuid, title: `foo + ${uuid}` })
-
-    const url = `${BASE_URL}/v1/shape/${issuesTableUrl}`
-
-    // Get initial data
-    const issueStream = new PersistedShapeStream({
-      url,
-      signal: aborter.signal,
-      storage,
-      subscribe: false,
-    })
-
-    let lastOffset: Offset | undefined
-
-    await new Promise<void>((resolve) => {
-      issueStream.subscribe((messages) => {
-        messages.forEach((message) => {
-          if (isChangeMessage(message)) {
-            lastOffset = message.offset
-          }
-          if (isUpToDateMessage(message)) {
-            aborter.abort()
-            return resolve()
-          }
-        })
-      })
-    })
-
-    const shapeId = issueStream.shapeId
-
-    // expect initial request
-    expect(shapeId).toBeTypeOf(`string`)
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
-    expect(fetchSpy).toHaveBeenCalledWith(
-      encodeURI(`${url}?offset=-1`),
-      expect.any(Object)
-    )
-
-    // clearing spies and starting new stream with the same
-    // storage should trigger a request for offset 0_0
-    fetchSpy.mockClear()
-    const secondAborter = new AbortController()
-    const restoredIssueStream = new PersistedShapeStream({
-      url: url,
-      signal: secondAborter.signal,
-      storage,
-      subscribe: false,
-    })
-
-    await new Promise<void>((resolve) => {
-      restoredIssueStream.subscribe((messages) => {
-        messages.forEach((message) => {
-          if (isUpToDateMessage(message)) {
-            secondAborter.abort()
-            return resolve()
-          }
-        })
-      })
-    })
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
-    expect(fetchSpy).toHaveBeenCalledWith(
-      encodeURI(`${url}?offset=${lastOffset}&shape_id=${shapeId}`),
-      expect.any(Object)
-    )
-  })
-
-  it(`should compact operations and restore as inserts`, async ({
-    insertIssues,
-    updateIssue,
-    deleteIssue,
-    issuesTableUrl,
-    aborter,
-  }) => {
-    const url = `${BASE_URL}/v1/shape/${issuesTableUrl}`
-
-    // Add initial rows
-    const rowId = uuidv4(),
-      rowId2 = uuidv4(),
-      rowId3 = uuidv4()
-    await insertIssues(
-      { id: rowId, title: `first original insert` },
-      { id: rowId2, title: `second original insert` }
-    )
-
-    // Get initial data
-    const issueStream = new PersistedShapeStream({
-      url,
-      signal: aborter.signal,
-      storage,
-      subscribe: false,
-    })
-
-    await new Promise<void>((resolve) => {
-      issueStream.subscribe((messages) => {
-        messages.forEach((message) => {
-          if (isUpToDateMessage(message)) {
-            aborter.abort()
-            return resolve()
-          }
-        })
-      })
-    })
-    // expect initial request
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
-    expect(fetchSpy).toHaveBeenCalledWith(
-      encodeURI(`${url}?offset=-1`),
-      expect.any(Object)
-    )
-
-    await Promise.all([
-      updateIssue({ id: rowId, title: `first updated insert` }),
-      deleteIssue({ id: rowId2, title: `second original insert` }),
-      insertIssues({ id: rowId3, title: `third original insert` }),
-    ])
-    await sleep(100)
-
-    // filling stream with new data
-    const secondAborter = new AbortController()
-    let restoredIssueStream = new PersistedShapeStream({
-      url: url,
-      signal: secondAborter.signal,
-      storage,
-      subscribe: false,
-    })
-
-    let opCount = 0
-    await new Promise<void>((resolve) => {
-      restoredIssueStream.subscribe((messages) => {
-        messages.forEach((message) => {
-          if (isChangeMessage(message)) {
-            opCount++
-          }
-          if (isUpToDateMessage(message)) {
-            secondAborter.abort()
-            return resolve()
-          }
-        })
-      })
-    })
-
-    // should have the 2 original inserts, and then 3 update/delete/inerts
-    expect(opCount).toBe(2 + 3)
-
-    // clearing spies and starting new stream, should have as many updates
-    fetchSpy.mockClear()
-    const thirdAborter = new AbortController()
-    restoredIssueStream = new PersistedShapeStream({
-      url: url,
-      signal: thirdAborter.signal,
-      storage,
-      subscribe: false,
-    })
-
-    opCount = 0
-    await new Promise<void>((resolve) => {
-      restoredIssueStream.subscribe((messages) => {
-        messages.forEach((message) => {
-          if (isChangeMessage(message)) {
-            expect(message.headers.operation).toBe(`insert`)
-            opCount++
-          }
-          if (isUpToDateMessage(message)) {
-            thirdAborter.abort()
-            return resolve()
-          }
-        })
-      })
-    })
-
-    // should have compacted everything to 2 inserts
-    expect(opCount).toBe(2)
-  })
-})
+}

--- a/packages/typescript-client/test/persist.test.ts
+++ b/packages/typescript-client/test/persist.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, inject, vi } from 'vitest'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { v4 as uuidv4 } from 'uuid'
+import { testWithIssuesTable as it } from './support/test-context'
+import { isChangeMessage, isControlMessage, Message, Offset, Row } from '../src'
+import { PersistedShapeStream } from '../src/persist'
+import { InMemoryStorage } from './persisters/in-memory'
+
+const isUpToDateMessage = <T extends Row>(msg: Message<T>) =>
+  isControlMessage(msg) && msg.headers.control === `up-to-date`
+
+const BASE_URL = inject(`baseUrl`)
+
+describe(`PersistedShapeStream`, () => {
+  let fetchSpy = vi.spyOn(global, `fetch`)
+  let storage = new InMemoryStorage()
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    storage = new InMemoryStorage()
+    fetchSpy = vi.spyOn(global, `fetch`)
+  })
+
+  it(`should store initial data`, async ({
+    insertIssues,
+    issuesTableUrl,
+    aborter,
+  }) => {
+    // Add an initial row.
+    const uuid = uuidv4()
+    await insertIssues({ id: uuid, title: `foo + ${uuid}` })
+
+    const url = `${BASE_URL}/v1/shape/${issuesTableUrl}`
+
+    // Get initial data
+    const issueStream = new PersistedShapeStream({
+      url,
+      signal: aborter.signal,
+      storage,
+      subscribe: false,
+    })
+
+    let lastOffset: Offset | undefined
+
+    await new Promise<void>((resolve) => {
+      issueStream.subscribe((messages) => {
+        messages.forEach((message) => {
+          if (isChangeMessage(message)) {
+            lastOffset = message.offset
+          }
+          if (isUpToDateMessage(message)) {
+            aborter.abort()
+            return resolve()
+          }
+        })
+      })
+    })
+
+    const shapeId = issueStream.shapeId
+
+    // expect initial request
+    expect(shapeId).toBeTypeOf(`string`)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      encodeURI(`${url}?offset=-1`),
+      expect.any(Object)
+    )
+
+    // clearing spies and starting new stream with the same
+    // storage should trigger a request for offset 0_0
+    fetchSpy.mockClear()
+    const secondAborter = new AbortController()
+    const restoredIssueStream = new PersistedShapeStream({
+      url: url,
+      signal: secondAborter.signal,
+      storage,
+      subscribe: false,
+    })
+
+    await new Promise<void>((resolve) => {
+      restoredIssueStream.subscribe((messages) => {
+        messages.forEach((message) => {
+          if (isUpToDateMessage(message)) {
+            secondAborter.abort()
+            return resolve()
+          }
+        })
+      })
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      encodeURI(`${url}?offset=${lastOffset}&shape_id=${shapeId}`),
+      expect.any(Object)
+    )
+  })
+
+  it(`should compact operations and restore as inserts`, async ({
+    insertIssues,
+    updateIssue,
+    deleteIssue,
+    issuesTableUrl,
+    aborter,
+  }) => {
+    const url = `${BASE_URL}/v1/shape/${issuesTableUrl}`
+
+    // Add initial rows
+    const rowId = uuidv4(),
+      rowId2 = uuidv4(),
+      rowId3 = uuidv4()
+    await insertIssues(
+      { id: rowId, title: `first original insert` },
+      { id: rowId2, title: `second original insert` }
+    )
+
+    // Get initial data
+    const issueStream = new PersistedShapeStream({
+      url,
+      signal: aborter.signal,
+      storage,
+      subscribe: false,
+    })
+
+    await new Promise<void>((resolve) => {
+      issueStream.subscribe((messages) => {
+        messages.forEach((message) => {
+          if (isUpToDateMessage(message)) {
+            aborter.abort()
+            return resolve()
+          }
+        })
+      })
+    })
+    // expect initial request
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      encodeURI(`${url}?offset=-1`),
+      expect.any(Object)
+    )
+
+    await Promise.all([
+      updateIssue({ id: rowId, title: `first updated insert` }),
+      deleteIssue({ id: rowId2, title: `second original insert` }),
+      insertIssues({ id: rowId3, title: `third original insert` }),
+    ])
+    await sleep(100)
+
+    // filling stream with new data
+    const secondAborter = new AbortController()
+    let restoredIssueStream = new PersistedShapeStream({
+      url: url,
+      signal: secondAborter.signal,
+      storage,
+      subscribe: false,
+    })
+
+    let opCount = 0
+    await new Promise<void>((resolve) => {
+      restoredIssueStream.subscribe((messages) => {
+        messages.forEach((message) => {
+          if (isChangeMessage(message)) {
+            opCount++
+          }
+          if (isUpToDateMessage(message)) {
+            secondAborter.abort()
+            return resolve()
+          }
+        })
+      })
+    })
+
+    // should have the 2 original inserts, and then 3 update/delete/inerts
+    expect(opCount).toBe(2 + 3)
+
+    // clearing spies and starting new stream, should have as many updates
+    fetchSpy.mockClear()
+    const thirdAborter = new AbortController()
+    restoredIssueStream = new PersistedShapeStream({
+      url: url,
+      signal: thirdAborter.signal,
+      storage,
+      subscribe: false,
+    })
+
+    opCount = 0
+    await new Promise<void>((resolve) => {
+      restoredIssueStream.subscribe((messages) => {
+        messages.forEach((message) => {
+          if (isChangeMessage(message)) {
+            expect(message.headers.operation).toBe(`insert`)
+            opCount++
+          }
+          if (isUpToDateMessage(message)) {
+            thirdAborter.abort()
+            return resolve()
+          }
+        })
+      })
+    })
+
+    // should have compacted everything to 2 inserts
+    expect(opCount).toBe(2)
+  })
+})

--- a/packages/typescript-client/test/persisters/in-memory-async.ts
+++ b/packages/typescript-client/test/persisters/in-memory-async.ts
@@ -1,0 +1,48 @@
+import { Value } from '../../src'
+import { ShapeStreamStorage } from '../../src/persist'
+import { InMemoryStorage } from './in-memory'
+
+export class InMemoryAsyncStorage<T extends Record<string, Value>>
+  implements ShapeStreamStorage<T>
+{
+  readonly #store = new InMemoryStorage<T>()
+  readonly #maxDelayMs: number
+  #operations: Promise<unknown> = Promise.resolve()
+
+  constructor(maxDelayMs: number = 50) {
+    this.#maxDelayMs = maxDelayMs
+  }
+
+  get(key: string): Promise<T | undefined> {
+    return this.#delayRandomly(() => this.#store.get(key))
+  }
+  put(key: string, value: T): Promise<void> {
+    return this.#delayRandomly(() => this.#store.put(key, value))
+  }
+  delete(key: string): Promise<void> {
+    return this.#delayRandomly(() => this.#store.delete(key))
+  }
+
+  clear(): Promise<void> {
+    return this.#delayRandomly(() => this.#store.clear())
+  }
+
+  async *getAll(): AsyncIterable<T> {
+    const iterator = this.#store.getAll()
+    for (const item of iterator) {
+      yield this.#delayRandomly(() => item)
+    }
+  }
+
+  #delayRandomly<T>(cb: () => T): Promise<T> {
+    const op = new Promise<T>((res) => {
+      setTimeout(() => res(cb()), Math.random() * this.#maxDelayMs)
+    })
+    this.#operations = Promise.allSettled([this.#operations, op])
+    return op
+  }
+
+  async flush(): Promise<void> {
+    await this.#operations
+  }
+}

--- a/packages/typescript-client/test/persisters/in-memory-async.ts
+++ b/packages/typescript-client/test/persisters/in-memory-async.ts
@@ -9,7 +9,7 @@ export class InMemoryAsyncStorage<T extends Record<string, Value>>
   readonly #maxDelayMs: number
   #operations: Promise<unknown> = Promise.resolve()
 
-  constructor(maxDelayMs: number = 50) {
+  constructor(maxDelayMs: number = 5) {
     this.#maxDelayMs = maxDelayMs
   }
 

--- a/packages/typescript-client/test/persisters/in-memory.ts
+++ b/packages/typescript-client/test/persisters/in-memory.ts
@@ -1,0 +1,26 @@
+import { Value } from '../../src'
+import { ShapeStreamStorage } from '../../src/persist'
+
+export class InMemoryStorage<T extends Record<string, Value>>
+  implements ShapeStreamStorage<T>
+{
+  #map = new Map<string, T>()
+
+  get(key: string): T | undefined {
+    return this.#map.get(key)
+  }
+  put(key: string, value: T): void {
+    this.#map.set(key, value)
+  }
+  delete(key: string): void {
+    this.#map.delete(key)
+  }
+
+  clear(): void {
+    this.#map.clear()
+  }
+
+  getAll(): Iterable<T> {
+    return this.#map.values()
+  }
+}

--- a/packages/typescript-client/test/queue.test.ts
+++ b/packages/typescript-client/test/queue.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest'
+import { AsyncOrProcessingQueue, MessageProcessor } from '../src/queue'
+
+describe(`AsyncOrProcessingQueue`, () => {
+  it(`should process synchronous callbacks in order`, () => {
+    let last = 0
+    const cb1 = vi.fn().mockImplementationOnce(() => (last = 1))
+    const cb2 = vi.fn().mockImplementationOnce(() => (last = 2))
+    const processor = new AsyncOrProcessingQueue()
+
+    processor.process(cb1)
+    processor.process(cb2)
+
+    expect(cb1).toHaveBeenCalledOnce()
+    expect(cb2).toHaveBeenCalledOnce()
+    expect(last).toBe(2)
+  })
+
+  it(`should process asynchronous callbacks in order`, async () => {
+    let last = 0
+    const cb1 = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise((res) => setTimeout(() => res((last = 1)), 10))
+      )
+    const cb2 = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise((res) => setTimeout(() => res((last = 2)), 5))
+      )
+    const processor = new AsyncOrProcessingQueue()
+
+    processor.process(cb1)
+    processor.process(cb2)
+
+    expect(cb1).toHaveBeenCalledOnce()
+    expect(cb2).not.toHaveBeenCalled()
+
+    await processor.waitForProcessing()
+    expect(cb2).toHaveBeenCalledOnce()
+    expect(last).toBe(2)
+  })
+
+  it(`should process both async and sync callbacks in order`, async () => {
+    let last = 0
+    const cb1 = vi.fn().mockImplementation(() => (last = 1))
+    const cb2 = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise((res) => setTimeout(() => res((last = 2)), 10))
+      )
+    const cb3 = vi.fn().mockImplementation(() => (last = 3))
+    const cb4 = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise((res) => setTimeout(() => res((last = 4)), 5))
+      )
+
+    const processor = new AsyncOrProcessingQueue()
+
+    processor.process(cb1)
+    processor.process(cb2)
+    processor.process(cb3)
+    processor.process(cb4)
+
+    expect(cb1).toHaveBeenCalledOnce()
+    expect(cb2).toHaveBeenCalledOnce()
+    expect(cb3).not.toHaveBeenCalled()
+    expect(cb4).not.toHaveBeenCalled()
+    expect(last).toBe(1) // only sync has been called so far
+
+    await processor.waitForProcessing()
+
+    expect(cb3).toHaveBeenCalledOnce()
+    expect(cb4).toHaveBeenCalledOnce()
+    expect(last).toBe(4)
+  })
+
+  it(`should complete processing when waitForProcessing is called multiple times`, async () => {
+    const cb = vi.fn(() => Promise.resolve())
+    const processor = new AsyncOrProcessingQueue()
+
+    processor.process(cb)
+    await processor.waitForProcessing() // First call
+
+    processor.process(cb)
+    await processor.waitForProcessing() // Second call
+
+    expect(cb).toHaveBeenCalledTimes(2)
+  })
+
+  it(`should not resolve waitForProcessing if calls are added`, async () => {
+    const resolvers: Array<() => void> = []
+    let finishedProcessing = false
+
+    const cb = vi.fn(
+      () => new Promise<void>((resolve) => resolvers.push(resolve))
+    )
+    const processor = new AsyncOrProcessingQueue()
+
+    processor.process(cb)
+    processor.waitForProcessing().then(() => {
+      finishedProcessing = true
+    })
+
+    processor.process(cb)
+    resolvers[0]!()
+    await new Promise((res) => setTimeout(res))
+    expect(finishedProcessing).toBe(false)
+
+    resolvers[1]!()
+    await new Promise((res) => setTimeout(res))
+    expect(finishedProcessing).toBe(true)
+    expect(cb).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe(`MessageProcessor`, () => {
+  it(`should queue up both async and sync processing in order`, async () => {
+    const callback = vi
+      .fn()
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => Promise.resolve())
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => Promise.resolve())
+
+    const processor = new MessageProcessor(callback)
+    const messages1 = [`msg1`]
+    const messages2 = [`msg2`]
+    const messages3 = [`msg3`]
+    const messages4 = [`msg4`]
+
+    processor.process(messages1)
+    processor.process(messages2)
+    processor.process(messages3)
+    processor.process(messages4)
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenNthCalledWith(1, messages1)
+    expect(callback).toHaveBeenNthCalledWith(2, messages2)
+
+    await processor.waitForProcessing()
+
+    expect(callback).toHaveBeenCalledTimes(4)
+    expect(callback).toHaveBeenNthCalledWith(1, messages1)
+    expect(callback).toHaveBeenNthCalledWith(2, messages2)
+    expect(callback).toHaveBeenNthCalledWith(3, messages3)
+    expect(callback).toHaveBeenNthCalledWith(4, messages4)
+  })
+
+  it(`should process messages sequentially with slow asynchronous callbacks`, async () => {
+    const callback = vi.fn(
+      () => new Promise<void>((resolve) => setTimeout(() => resolve(), 50))
+    )
+    const processor = new MessageProcessor(callback)
+    const messages1 = [`msg1`]
+    const messages2 = [`msg2`]
+    const messages3 = [`msg3`]
+
+    processor.process(messages1)
+    processor.process(messages2)
+    processor.process(messages3)
+
+    await processor.waitForProcessing()
+
+    expect(callback).toHaveBeenNthCalledWith(1, messages1)
+    expect(callback).toHaveBeenNthCalledWith(2, messages2)
+    expect(callback).toHaveBeenNthCalledWith(3, messages3)
+  })
+})

--- a/packages/typescript-client/test/support/global-setup.ts
+++ b/packages/typescript-client/test/support/global-setup.ts
@@ -1,5 +1,5 @@
 import type { GlobalSetupContext } from 'vitest/node'
-import { FetchError } from '../../src/client'
+import { FetchError } from '../../src/error'
 import { makePgClient } from './test-helpers'
 
 const url = process.env.ELECTRIC_URL ?? `http://localhost:3000`

--- a/packages/typescript-client/test/support/test-context.ts
+++ b/packages/typescript-client/test/support/test-context.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { Client, QueryResult } from 'pg'
 import { inject, test } from 'vitest'
 import { makePgClient } from './test-helpers'
-import { FetchError } from '../../src/client'
+import { FetchError } from '../../src/error'
 
 export type IssueRow = { id: string; title: string; priority?: string }
 export type GeneratedIssueRow = { id?: string; title: string }

--- a/packages/typescript-client/test/support/test-helpers.ts
+++ b/packages/typescript-client/test/support/test-helpers.ts
@@ -1,4 +1,4 @@
-import { ShapeStream } from '../../src/client'
+import { ShapeStreamInterface } from '../../src/client'
 import { Client, ClientConfig } from 'pg'
 import { Message, Row } from '../../src/types'
 
@@ -15,7 +15,7 @@ export function makePgClient(overrides: ClientConfig = {}) {
 }
 
 export function forEachMessage<T extends Row>(
-  stream: ShapeStream<T>,
+  stream: ShapeStreamInterface<T>,
   controller: AbortController,
   handler: (
     resolve: () => void,

--- a/packages/typescript-client/tsup.config.ts
+++ b/packages/typescript-client/tsup.config.ts
@@ -1,14 +1,16 @@
 import type { Options } from 'tsup'
 import { defineConfig } from 'tsup'
 
-export default defineConfig(options => {
+export default defineConfig((options) => {
+  const entry = {
+    index: 'src/index.ts',
+    persist: 'src/persist.ts',
+  }
   const commonOptions: Partial<Options> = {
-    entry: {
-      index: 'src/index.ts'
-    },
+    entry,
     tsconfig: `./tsconfig.build.json`,
     sourcemap: true,
-    ...options
+    ...options,
   }
 
   return [
@@ -18,7 +20,7 @@ export default defineConfig(options => {
       format: ['esm'],
       outExtension: () => ({ js: '.mjs' }), // Add dts: '.d.ts' when egoist/tsup#1053 lands
       dts: true,
-      clean: true
+      clean: true,
     },
     // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
     {
@@ -27,26 +29,33 @@ export default defineConfig(options => {
       target: 'es2017',
       dts: false,
       outExtension: () => ({ js: '.js' }),
-      entry: { 'index.legacy-esm': 'src/index.ts' }
+      entry: Object.fromEntries(
+        Object.entries(entry).map(([key, value]) => [
+          `${key}.legacy-esm`,
+          value,
+        ])
+      ),
     },
     // Browser-ready ESM, production + minified
     {
       ...commonOptions,
-      entry: {
-        'index.browser': 'src/index.ts'
-      },
+
+      entry: Object.fromEntries(
+        Object.entries(entry).map(([key, value]) => [`${key}.browser`, value])
+      ),
+
       define: {
-        'process.env.NODE_ENV': JSON.stringify('production')
+        'process.env.NODE_ENV': JSON.stringify('production'),
       },
       format: ['esm'],
       outExtension: () => ({ js: '.mjs' }),
-      minify: true
+      minify: true,
     },
     {
       ...commonOptions,
       format: 'cjs',
       outDir: './dist/cjs/',
-      outExtension: () => ({ js: '.cjs' })
-    }
+      outExtension: () => ({ js: '.cjs' }),
+    },
   ]
 })


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/1519

Followed by https://github.com/electric-sql/electric/issues/1519 for more refactoring and improvements, split into two PRs for reviewability

Introduces a `PersistedShapeStream` - follows the newly defined `ShapeStreamInterface` so it can be used interchangeably, but requires:
1. A `storage` option to be provided, implementing the `ShapeStreamStorage` interface, which is a key-value store oriented interface
2. To not provide an `offset` and `shapeId` as the persisted shape stream cannot resume from an arbitrary offset and shapeId, it uses the persisted ones (although I suppose we could make it wipe the underlying store if an `offset` and `shpaeId` are provided to simulate the exact same behaviour)

What it does is it subscribes to the underlying `ShapeStream` and compacts entries to the provided store, very similar to what `Shape` does. When someone subscribes to the `PersistedShapeStream`, it looks into the store and returns the compacted entries as `insert`s and resumes from there.

One tricky bit with a bit of a hacky solution is the persistence of the `offset` and `shapeId`, needed to actually resume the stream. We _could_ store them in a separate `metadata` store entry, but that might require either 1) custom key prefixes on the store to separate metadata and 2) deal with inconsistent state.

For example, if metadata is stored separately from the operations and the store has no transactional guarantees (which the interface assumes), an operation might be stored with offset `10_3`, and the metadata fails to get stored because the app shuts down - so upon resuming the `10_3` operation is fed to the subscriber but then the stream is resumed from the previous latest offset that we managed to persist (e.g. `10_2`), duplicating the change.

The workaround is that the latest stored `offset` can be retrieved by reading into the stored entries and comparing their offsets (assuming the offset is not opaque here, but we can do that by adding a timestamp otherwise) and using the most recent one - has an overhead of needing to read the whole store to resume but is foolproof and can also do consistency checks to decide if it actually _can_ resume.

The `shapeId` I've stored alongside the entries, but really only in one entry stored, such that when we iterate over the data to get the latest offset we will eventually find the `shapeId` as well, but without needing to store it fully in every entry. Depending on the actual storage implementation this approach might be effective or slightly annoying. My main concern was to 1) avoid dealing with consistency with non-transactional stores and 2) not introduce separate storage APIs that people need to conform to.

If someone wants to use a transactional storage engine, they might as well go to `PGlite` with the `sync` plugin - I believe the use case for this is simpler key-value stores like `localStorage` etc.