### PR TITLE
Fix sporadic tests erroring with :already_started

### DIFF
--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -953,12 +953,9 @@ defmodule Electric.ShapeCacheTest do
     ]
 
     setup(ctx) do
-      shape_cache_server = __MODULE__.ShapeCache
-
       ctx =
         with_shape_cache(
           Map.merge(ctx, %{inspector: {Mock.Inspector, []}}),
-          name: shape_cache_server,
           prepare_tables_fn: @prepare_tables_noop,
           create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -47,10 +47,7 @@ defmodule Support.ComponentSetup do
 
   def with_shape_cache(ctx, additional_opts \\ []) do
     shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
-
-    server =
-      Keyword.get(additional_opts, :name, :"shape_cache_#{full_test_name(ctx)}")
-
+    server = :"shape_cache_#{full_test_name(ctx)}"
     consumer_supervisor = :"consumer_supervisor_#{full_test_name(ctx)}"
 
     start_opts =


### PR DESCRIPTION
Some tests would sporadically fail `:already_started` due to multiple tests using the same name for the ShapeCache process. This PR ensures each test has it's own unique name.