### PR TITLE
Clean up storage API

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -2,41 +2,50 @@ defmodule Electric.ShapeCache.Storage do
   import Electric.Replication.LogOffset, only: [is_log_offset_lt: 2]
 
   alias Electric.Shapes.Querying
-  alias Electric.Shapes.Shape
   alias Electric.Replication.LogOffset
 
   @type shape_id :: Electric.ShapeCacheBehaviour.shape_id()
+  @type xmin :: Electric.ShapeCacheBehaviour.xmin()
+  @type offset :: LogOffset.t()
+
   @type compiled_opts :: term()
+  @type shape_opts :: term()
+
   @type storage :: {module(), compiled_opts()}
+  @type shape_storage :: {module(), shape_opts()}
 
   @type log_item :: {LogOffset.t(), Querying.json_iodata()} | {:chunk_boundary | LogOffset.t()}
-  @type log_state :: %{
-          current_chunk_byte_size: non_neg_integer()
-        }
+  @type log_state :: %{current_chunk_byte_size: non_neg_integer()}
   @type log :: Enumerable.t(Querying.json_iodata())
 
   @type row :: list()
 
+  @doc "Validate and initialise storage base configuration from application configuration"
+  @callback shared_opts(Keyword.t()) :: {:ok, compiled_opts()} | {:error, term()}
+
   @doc "Initialise shape-specific opts from the shared, global, configuration"
-  @callback for_shape(shape_id(), compiled_opts()) :: compiled_opts()
+  @callback for_shape(shape_id(), compiled_opts()) :: shape_opts()
 
   @doc "Start any processes required to run the storage backend"
-  @callback start_link(compiled_opts()) :: GenServer.on_start()
-  @callback initialise(compiled_opts()) :: :ok
-  @callback list_shapes(compiled_opts()) :: [
-              shape_id: shape_id(),
-              shape: Shape.t(),
-              latest_offset: LogOffset.t(),
-              snapshot_xmin: non_neg_integer()
-            ]
-  @callback add_shape(shape_id(), Shape.t(), compiled_opts()) :: :ok
-  @callback set_snapshot_xmin(shape_id(), non_neg_integer(), compiled_opts()) :: :ok
+  @callback start_link(shape_opts()) :: GenServer.on_start()
+
+  @doc "Run any initial setup tasks"
+  @callback initialise(shape_opts()) :: :ok
+
+  @doc """
+  Get the current xmin and offset for the shape storage.
+
+  If the instance is new, then it MUST return `{LogOffset.first(), nil}`.
+  """
+  @callback get_current_position(shape_opts()) :: {:ok, offset(), xmin() | nil} | {:error, term()}
+
+  @callback set_snapshot_xmin(xmin(), shape_opts()) :: :ok
 
   @doc "Check if snapshot for a given shape id already exists"
-  @callback snapshot_started?(shape_id(), compiled_opts()) :: boolean()
+  @callback snapshot_started?(shape_opts()) :: boolean()
 
   @doc "Get the full snapshot for a given shape, also returning the offset this snapshot includes"
-  @callback get_snapshot(shape_id(), compiled_opts()) :: {offset :: LogOffset.t(), log()}
+  @callback get_snapshot(shape_opts()) :: {offset :: LogOffset.t(), log()}
 
   @doc """
   Make a new snapshot for a shape ID based on the meta information about the table and a stream of plain string rows
@@ -44,18 +53,17 @@ defmodule Electric.ShapeCache.Storage do
   Should raise an error if making the snapshot had failed for any reason.
   """
   @callback make_new_snapshot!(
-              shape_id(),
               Querying.json_result_stream(),
-              compiled_opts()
+              shape_opts()
             ) :: :ok
 
-  @callback mark_snapshot_as_started(shape_id, compiled_opts()) :: :ok
+  @callback mark_snapshot_as_started(shape_opts()) :: :ok
 
   @doc "Append log items from one transaction to the log"
-  @callback append_to_log!(shape_id(), Enumerable.t(log_item()), storage()) :: :ok
+  @callback append_to_log!(Enumerable.t(log_item()), shape_opts()) :: :ok
 
   @doc "Get stream of the log for a shape since a given offset"
-  @callback get_log_stream(shape_id(), LogOffset.t(), LogOffset.t(), compiled_opts()) ::
+  @callback get_log_stream(offset :: LogOffset.t(), max_offset :: LogOffset.t(), shape_opts()) ::
               log()
 
   @doc """
@@ -65,129 +73,94 @@ defmodule Electric.ShapeCache.Storage do
 
   If chunk has finished accumulating, the last offset of the chunk is returned.
   """
-  @callback get_chunk_end_log_offset(shape_id(), LogOffset.t(), compiled_opts()) ::
-              LogOffset.t() | nil
+  @callback get_chunk_end_log_offset(LogOffset.t(), shape_opts()) :: LogOffset.t() | nil
 
   @doc "Clean up snapshots/logs for a shape id"
-  @callback cleanup!(shape_id(), compiled_opts()) :: :ok
+  @callback cleanup!(shape_opts()) :: :ok
 
-  @spec child_spec(storage()) :: Supervisor.child_spec()
-  def child_spec({module, opts}) do
+  @behaviour __MODULE__
+
+  @last_log_offset LogOffset.last()
+
+  @spec child_spec(shape_storage()) :: Supervisor.child_spec()
+  def child_spec({module, shape_opts}) do
     %{
       id: module,
-      start: {module, :start_link, [opts]},
+      start: {module, :start_link, [shape_opts]},
       restart: :transient
     }
   end
 
+  @impl __MODULE__
+  def shared_opts({module, opts}) do
+    with {:ok, compiled_opts} <- module.shared_opts(opts) do
+      {:ok, {module, compiled_opts}}
+    end
+  end
+
+  @impl __MODULE__
   def for_shape(shape_id, {mod, opts}) do
-    {mod, apply(mod, :for_shape, [shape_id, opts])}
+    {mod, mod.for_shape(shape_id, opts)}
   end
 
-  def start_link({mod, opts}) do
-    apply(mod, :start_link, [opts])
+  @impl __MODULE__
+  def start_link({mod, shape_opts}) do
+    mod.start_link(shape_opts)
   end
 
-  @last_log_offset LogOffset.last()
-
-  @spec initialise(storage()) :: :ok
-  def initialise({mod, opts}),
-    do: apply(mod, :initialise, [opts])
-
-  @spec list_shapes(storage()) :: [
-          shape_id: shape_id(),
-          shape: Shape.t(),
-          latest_offset: non_neg_integer(),
-          snapshot_xmin: non_neg_integer()
-        ]
-  # TODO: remove this
-  def list_shapes({mod, shape_opts}) do
-    apply(mod, :list_shapes, [shape_opts])
+  @impl __MODULE__
+  def initialise({mod, shape_opts}) do
+    mod.initialise(shape_opts)
   end
 
-  @spec add_shape(shape_id(), Shape.t(), storage()) :: :ok
-  def add_shape(shape_id, shape, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    apply(mod, :add_shape, [shape_id, shape, shape_opts])
+  @impl __MODULE__
+  def get_current_position({mod, shape_opts}) do
+    mod.get_current_position(shape_opts)
   end
 
-  @spec set_snapshot_xmin(shape_id(), non_neg_integer(), storage()) :: :ok
-  def set_snapshot_xmin(shape_id, xmin, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    apply(mod, :set_snapshot_xmin, [shape_id, xmin, shape_opts])
+  @impl __MODULE__
+  def set_snapshot_xmin(xmin, {mod, shape_opts}) do
+    mod.set_snapshot_xmin(xmin, shape_opts)
   end
 
-  @doc "Check if snapshot for a given shape id already exists"
-  @spec snapshot_started?(shape_id(), storage()) :: boolean()
-  def snapshot_started?(shape_id, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    mod.snapshot_started?(shape_id, shape_opts)
+  @impl __MODULE__
+  def snapshot_started?({mod, shape_opts}) do
+    mod.snapshot_started?(shape_opts)
   end
 
-  @doc "Get the full snapshot for a given shape, also returning the offset this snapshot includes"
-  @spec get_snapshot(shape_id(), storage()) :: {offset :: LogOffset.t(), log()}
-  def get_snapshot(shape_id, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    mod.get_snapshot(shape_id, shape_opts)
+  @impl __MODULE__
+  def get_snapshot({mod, shape_opts}) do
+    mod.get_snapshot(shape_opts)
   end
 
-  @doc """
-  Make a new snapshot for a shape ID based on the meta information about the table and a stream of plain string rows
-  """
-  @spec make_new_snapshot!(shape_id(), Querying.json_result_stream(), storage()) :: :ok
-  def make_new_snapshot!(shape_id, stream, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    mod.make_new_snapshot!(shape_id, stream, shape_opts)
+  @impl __MODULE__
+  def make_new_snapshot!(stream, {mod, shape_opts}) do
+    mod.make_new_snapshot!(stream, shape_opts)
   end
 
-  @spec mark_snapshot_as_started(shape_id, compiled_opts()) :: :ok
-  def mark_snapshot_as_started(shape_id, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    mod.mark_snapshot_as_started(shape_id, shape_opts)
+  @impl __MODULE__
+  def mark_snapshot_as_started({mod, shape_opts}) do
+    mod.mark_snapshot_as_started(shape_opts)
   end
 
-  @doc """
-  Append log items from one transaction to the log
-  """
-  @spec append_to_log!(shape_id(), Enumerable.t(log_item()), storage()) :: :ok
-  def append_to_log!(shape_id, log_items, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    mod.append_to_log!(shape_id, log_items, shape_opts)
+  @impl __MODULE__
+  def append_to_log!(log_items, {mod, shape_opts}) do
+    mod.append_to_log!(log_items, shape_opts)
   end
 
-  @doc "Get stream of the log for a shape since a given offset"
-  @spec get_log_stream(shape_id(), LogOffset.t(), LogOffset.t(), storage()) :: log()
-  def get_log_stream(shape_id, offset, max_offset \\ @last_log_offset, {mod, opts})
+  @impl __MODULE__
+  def get_log_stream(offset, max_offset \\ @last_log_offset, {mod, shape_opts})
       when max_offset == @last_log_offset or not is_log_offset_lt(max_offset, offset) do
-    shape_opts = mod.for_shape(shape_id, opts)
-
-    mod.get_log_stream(shape_id, offset, max_offset, shape_opts)
+    mod.get_log_stream(offset, max_offset, shape_opts)
   end
 
-  @doc """
-  Get the last exclusive offset of the chunk starting from the given offset.
-
-  If chunk has not finished accumulating, `nil` is returned.
-
-  If chunk has finished accumulating, the last offset of the chunk is returned.
-  """
-  @spec get_chunk_end_log_offset(shape_id(), LogOffset.t(), storage()) :: LogOffset.t() | nil
-  def get_chunk_end_log_offset(shape_id, offset, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    mod.get_chunk_end_log_offset(shape_id, offset, shape_opts)
+  @impl __MODULE__
+  def get_chunk_end_log_offset(offset, {mod, shape_opts}) do
+    mod.get_chunk_end_log_offset(offset, shape_opts)
   end
 
-  @doc "Check if log entry for given shape ID and offset exists"
-  @spec has_log_entry?(shape_id(), LogOffset.t(), storage()) :: boolean()
-  def has_log_entry?(shape_id, offset, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    mod.has_log_entry?(shape_id, offset, shape_opts)
-  end
-
-  @doc "Clean up snapshots/logs for a shape id"
-  @spec cleanup!(shape_id(), storage()) :: :ok
-  def cleanup!(shape_id, {mod, opts}) do
-    shape_opts = mod.for_shape(shape_id, opts)
-    mod.cleanup!(shape_id, shape_opts)
+  @impl __MODULE__
+  def cleanup!({mod, shape_opts}) do
+    mod.cleanup!(shape_opts)
   end
 end

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -31,7 +31,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
     case Shapes.Consumer.whereis(shape_id) do
       parent when is_pid(parent) ->
-        if not Storage.snapshot_started?(state.shape_id, state.storage) do
+        if not Storage.snapshot_started?(state.storage) do
           %{
             db_pool: pool,
             storage: storage,
@@ -90,7 +90,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
           # could pass the shape and then make_new_snapshot! can pass it to row_to_snapshot_item
           # that way it has the relation, but it is still missing the pk_cols
-          Storage.make_new_snapshot!(shape_id, stream, storage)
+          Storage.make_new_snapshot!(stream, storage)
         end)
       end,
       timeout: :infinity

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -111,13 +111,13 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
-      |> expect(:get_chunk_end_log_offset, fn @test_shape_id, @before_all_offset, _ ->
+      |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
-      |> expect(:get_snapshot, fn @test_shape_id, @test_opts ->
+      |> expect(:get_snapshot, fn @test_opts ->
         {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
       end)
-      |> expect(:get_log_stream, fn @test_shape_id, @first_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @first_offset, _, @test_opts ->
         [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
@@ -156,13 +156,13 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
-      |> expect(:get_chunk_end_log_offset, fn @test_shape_id, @before_all_offset, _ ->
+      |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
-      |> expect(:get_snapshot, fn @test_shape_id, @test_opts ->
+      |> expect(:get_snapshot, fn @test_opts ->
         {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
       end)
-      |> expect(:get_log_stream, fn @test_shape_id, @first_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @first_offset, _, @test_opts ->
         [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
@@ -194,13 +194,13 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
-      |> expect(:get_chunk_end_log_offset, fn @test_shape_id, @before_all_offset, _ ->
+      |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
-      |> expect(:get_snapshot, fn @test_shape_id, @test_opts ->
+      |> expect(:get_snapshot, fn @test_opts ->
         {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
       end)
-      |> expect(:get_log_stream, fn @test_shape_id, @first_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @first_offset, _, @test_opts ->
         [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
@@ -225,10 +225,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
-      |> expect(:get_chunk_end_log_offset, fn @test_shape_id, @start_offset_50, _ ->
+      |> expect(:get_chunk_end_log_offset, fn @start_offset_50, _ ->
         next_next_offset
       end)
-      |> expect(:get_log_stream, fn @test_shape_id, @start_offset_50, _, @test_opts ->
+      |> expect(:get_log_stream, fn @start_offset_50, _, @test_opts ->
         [
           Jason.encode!(%{key: "log1", value: "foo", headers: %{}, offset: next_offset}),
           Jason.encode!(%{key: "log2", value: "bar", headers: %{}, offset: next_next_offset})
@@ -280,7 +280,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
-      |> expect(:get_chunk_end_log_offset, fn @test_shape_id, @start_offset_50, _ ->
+      |> expect(:get_chunk_end_log_offset, fn @start_offset_50, _ ->
         @test_offset
       end)
 
@@ -313,14 +313,14 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
-      |> expect(:get_chunk_end_log_offset, fn @test_shape_id, @test_offset, _ ->
+      |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
-      |> expect(:get_log_stream, fn @test_shape_id, @test_offset, @test_offset, @test_opts ->
+      |> expect(:get_log_stream, fn @test_offset, @test_offset, @test_opts ->
         send(test_pid, :got_log_stream)
         []
       end)
-      |> expect(:get_log_stream, fn @test_shape_id, @test_offset, ^next_offset, @test_opts ->
+      |> expect(:get_log_stream, fn @test_offset, ^next_offset, @test_opts ->
         [Jason.encode!("test result")]
       end)
 
@@ -374,10 +374,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
-      |> expect(:get_chunk_end_log_offset, fn @test_shape_id, @test_offset, _ ->
+      |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
-      |> expect(:get_log_stream, fn @test_shape_id, @test_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @test_offset, _, @test_opts ->
         send(test_pid, :got_log_stream)
         []
       end)
@@ -419,10 +419,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
-      |> expect(:get_chunk_end_log_offset, fn @test_shape_id, @test_offset, _ ->
+      |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
-      |> expect(:get_log_stream, fn @test_shape_id, @test_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @test_offset, _, @test_opts ->
         []
       end)
 

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -16,11 +16,7 @@ defmodule Support.ComponentSetup do
 
   def with_in_memory_storage(ctx) do
     {:ok, storage_opts} =
-      InMemoryStorage.shared_opts(
-        snapshot_ets_table: :"snapshot_ets_#{full_test_name(ctx)}",
-        log_ets_table: :"log_ets_#{full_test_name(ctx)}",
-        chunk_checkpoint_ets_table: :"chunk_checkpoint_ets_#{full_test_name(ctx)}"
-      )
+      InMemoryStorage.shared_opts(table_base_name: :"in_memory_storage_#{full_test_name(ctx)}")
 
     %{storage: {InMemoryStorage, storage_opts}}
   end


### PR DESCRIPTION
Fixes #1563

With the new single-shape storage implementation, we can remove the `shape_id` param from almost all the Storage behaviour calls and also remove it from the actual db keys.

Some of the callbacks are also unecessary, such as `list_shapes` and `add_shape`. Instead we need a simple way to get a shapes current offset and snapshot xmin