### PR TITLE
(chore) Rename ConsumerSupervisor and Consumer.Supervisor

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -55,7 +55,7 @@ defmodule Electric.ShapeCache do
               type: {:or, [:atom, :pid]},
               default: Electric.Replication.ShapeLogCollector
             ],
-            consumer_supervisor: [
+            consumer_group_supervisor: [
               type: @genserver_name_schema,
               default: Electric.Shapes.ConsumerGroupSupervisor.name()
             ],
@@ -193,7 +193,7 @@ defmodule Electric.ShapeCache do
       prepare_tables_fn: opts.prepare_tables_fn,
       log_producer: opts.log_producer,
       registry: opts.registry,
-      consumer_supervisor: opts.consumer_supervisor,
+      consumer_group_supervisor: opts.consumer_group_supervisor,
       subscription: nil
     }
 
@@ -349,7 +349,7 @@ defmodule Electric.ShapeCache do
 
   defp clean_up_shape(state, shape_id) do
     Electric.Shapes.ConsumerGroupSupervisor.stop_shape_consumer(
-      state.consumer_supervisor,
+      state.consumer_group_supervisor,
       shape_id
     )
 
@@ -381,7 +381,7 @@ defmodule Electric.ShapeCache do
   defp start_shape(shape_id, shape, state) do
     with {:ok, pid} <-
            Electric.Shapes.ConsumerGroupSupervisor.start_shape_consumer(
-             state.consumer_supervisor,
+             state.consumer_group_supervisor,
              shape_id: shape_id,
              shape: shape,
              storage: state.storage,

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -57,7 +57,7 @@ defmodule Electric.ShapeCache do
             ],
             consumer_supervisor: [
               type: @genserver_name_schema,
-              default: Electric.Shapes.ConsumerSupervisor.name()
+              default: Electric.Shapes.ConsumerGroupSupervisor.name()
             ],
             storage: [type: :mod_arg, required: true],
             chunk_bytes_threshold: [type: :non_neg_integer, required: true],
@@ -348,7 +348,7 @@ defmodule Electric.ShapeCache do
   end
 
   defp clean_up_shape(state, shape_id) do
-    Electric.Shapes.ConsumerSupervisor.stop_shape_consumer(state.consumer_supervisor, shape_id)
+    Electric.Shapes.ConsumerGroupSupervisor.stop_shape_consumer(state.consumer_supervisor, shape_id)
 
     state.shape_status.remove_shape(state.persistent_state, shape_id)
   end
@@ -377,7 +377,7 @@ defmodule Electric.ShapeCache do
 
   defp start_shape(shape_id, shape, state) do
     with {:ok, pid} <-
-           Electric.Shapes.ConsumerSupervisor.start_shape_consumer(
+           Electric.Shapes.ConsumerGroupSupervisor.start_shape_consumer(
              state.consumer_supervisor,
              shape_id: shape_id,
              shape: shape,

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -348,7 +348,10 @@ defmodule Electric.ShapeCache do
   end
 
   defp clean_up_shape(state, shape_id) do
-    Electric.Shapes.ConsumerGroupSupervisor.stop_shape_consumer(state.consumer_supervisor, shape_id)
+    Electric.Shapes.ConsumerGroupSupervisor.stop_shape_consumer(
+      state.consumer_supervisor,
+      shape_id
+    )
 
     state.shape_status.remove_shape(state.persistent_state, shape_id)
   end

--- a/packages/sync-service/lib/electric/shapes/consumer_group_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_group_supervisor.ex
@@ -1,4 +1,4 @@
-defmodule Electric.Shapes.ConsumerSupervisor do
+defmodule Electric.Shapes.ConsumerGroupSupervisor do
   @moduledoc """
   Responsible for managing shape consumer processes
   """

--- a/packages/sync-service/lib/electric/shapes/consumer_group_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_group_supervisor.ex
@@ -4,7 +4,7 @@ defmodule Electric.Shapes.ConsumerGroupSupervisor do
   """
   use DynamicSupervisor
 
-  alias Electric.Shapes.Consumer
+  alias Electric.Shapes.IndividualConsumerSupervisor
 
   require Logger
 
@@ -25,11 +25,11 @@ defmodule Electric.Shapes.ConsumerGroupSupervisor do
   def start_shape_consumer(name \\ @name, config) do
     Logger.debug(fn -> "Starting consumer for #{Access.fetch!(config, :shape_id)}" end)
 
-    DynamicSupervisor.start_child(name, {Consumer.Supervisor, config})
+    DynamicSupervisor.start_child(name, {IndividualConsumerSupervisor, config})
   end
 
   def stop_shape_consumer(name \\ @name, shape_id) do
-    case GenServer.whereis(Consumer.Supervisor.name(shape_id)) do
+    case GenServer.whereis(IndividualConsumerSupervisor.name(shape_id)) do
       nil ->
         {:error, "no consumer for shape id #{inspect(shape_id)}"}
 

--- a/packages/sync-service/lib/electric/shapes/individual_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/individual_consumer_supervisor.ex
@@ -1,4 +1,4 @@
-defmodule Electric.Shapes.Consumer.Supervisor do
+defmodule Electric.Shapes.IndividualConsumerSupervisor do
   use Supervisor, restart: :transient
 
   require Logger

--- a/packages/sync-service/lib/electric/shapes/supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/supervisor.ex
@@ -17,12 +17,12 @@ defmodule Electric.Shapes.Supervisor do
     shape_cache = Keyword.fetch!(opts, :shape_cache)
     log_collector = Keyword.fetch!(opts, :log_collector)
 
-    consumer_supervisor =
-      Keyword.get(opts, :consumer_supervisor, {Electric.Shapes.ConsumerGroupSupervisor, []})
+    consumer_group_supervisor =
+      Keyword.get(opts, :consumer_group_supervisor, {Electric.Shapes.ConsumerGroupSupervisor, []})
 
     children =
       Enum.reject(
-        [consumer_supervisor, log_collector, shape_cache, replication_client],
+        [consumer_group_supervisor, log_collector, shape_cache, replication_client],
         &is_nil/1
       )
 

--- a/packages/sync-service/lib/electric/shapes/supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/supervisor.ex
@@ -18,7 +18,7 @@ defmodule Electric.Shapes.Supervisor do
     log_collector = Keyword.fetch!(opts, :log_collector)
 
     consumer_supervisor =
-      Keyword.get(opts, :consumer_supervisor, {Electric.Shapes.ConsumerSupervisor, []})
+      Keyword.get(opts, :consumer_supervisor, {Electric.Shapes.ConsumerGroupSupervisor, []})
 
     children =
       Enum.reject(

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -911,7 +911,7 @@ defmodule Electric.ShapeCacheTest do
           {pid, Process.monitor(pid)}
         end
 
-      Shapes.ConsumerSupervisor.stop_all_consumers(ctx.consumer_supervisor)
+      Shapes.ConsumerGroupSupervisor.stop_all_consumers(ctx.consumer_supervisor)
 
       for {pid, ref} <- consumers do
         assert_receive {:DOWN, ^ref, :process, ^pid, _}

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -911,13 +911,13 @@ defmodule Electric.ShapeCacheTest do
           {pid, Process.monitor(pid)}
         end
 
-      Shapes.ConsumerGroupSupervisor.stop_all_consumers(ctx.consumer_supervisor)
+      Shapes.ConsumerGroupSupervisor.stop_all_consumers(ctx.consumer_group_supervisor)
 
       for {pid, ref} <- consumers do
         assert_receive {:DOWN, ^ref, :process, ^pid, _}
       end
 
-      stop_processes([shape_cache_opts[:server], ctx.consumer_supervisor])
+      stop_processes([shape_cache_opts[:server], ctx.consumer_group_supervisor])
     end
 
     defp stop_processes(process_names) do

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -686,7 +686,7 @@ defmodule Electric.Shapes.ConsumerTest do
           inspector: ctx.inspector,
           chunk_bytes_threshold: 10_000,
           log_producer: __MODULE__.LogCollector,
-          consumer_supervisor: __MODULE__.ConsumerSupervisor,
+          consumer_supervisor: __MODULE__.ConsumerGroupSupervisor,
           prepare_tables_fn: {
             Electric.Postgres.Configuration,
             :configure_tables_for_replication!,
@@ -710,7 +710,7 @@ defmodule Electric.Shapes.ConsumerTest do
              connection_manager: nil},
           shape_cache: {Electric.ShapeCache, shape_cache_config},
           consumer_supervisor:
-            {Electric.Shapes.ConsumerSupervisor, name: __MODULE__.ConsumerSupervisor}
+            {Electric.Shapes.ConsumerGroupSupervisor, name: __MODULE__.ConsumerGroupSupervisor}
         )
 
       %{db_conn: conn} = ctx

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -686,7 +686,7 @@ defmodule Electric.Shapes.ConsumerTest do
           inspector: ctx.inspector,
           chunk_bytes_threshold: 10_000,
           log_producer: __MODULE__.LogCollector,
-          consumer_supervisor: __MODULE__.ConsumerGroupSupervisor,
+          consumer_group_supervisor: __MODULE__.ConsumerGroupSupervisor,
           prepare_tables_fn: {
             Electric.Postgres.Configuration,
             :configure_tables_for_replication!,
@@ -709,7 +709,7 @@ defmodule Electric.Shapes.ConsumerTest do
              replication_opts: replication_opts,
              connection_manager: nil},
           shape_cache: {Electric.ShapeCache, shape_cache_config},
-          consumer_supervisor:
+          consumer_group_supervisor:
             {Electric.Shapes.ConsumerGroupSupervisor, name: __MODULE__.ConsumerGroupSupervisor}
         )
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -109,7 +109,7 @@ defmodule Electric.Shapes.ConsumerTest do
       consumers =
         for {shape_id, shape} <- ctx.shapes do
           allow(Mock.Storage, self(), fn ->
-            Shapes.Consumer.Supervisor.name(shape_id) |> GenServer.whereis()
+            Shapes.IndividualConsumerSupervisor.name(shape_id) |> GenServer.whereis()
           end)
 
           allow(Mock.Storage, self(), fn ->
@@ -122,7 +122,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
           {:ok, consumer} =
             start_supervised(
-              {Shapes.Consumer.Supervisor,
+              {Shapes.IndividualConsumerSupervisor,
                shape_id: shape_id,
                shape: shape,
                log_producer: producer,
@@ -131,7 +131,7 @@ defmodule Electric.Shapes.ConsumerTest do
                storage: {Mock.Storage, []},
                chunk_bytes_threshold: 10_000,
                prepare_tables_fn: &prepare_tables_fn/2},
-              id: {Shapes.Consumer.Supervisor, shape_id}
+              id: {Shapes.IndividualConsumerSupervisor, shape_id}
             )
 
           consumer
@@ -303,7 +303,7 @@ defmodule Electric.Shapes.ConsumerTest do
     defp assert_consumer_shutdown(shape_id, fun) do
       monitors =
         for name <- [
-              Shapes.Consumer.Supervisor.name(shape_id),
+              Shapes.IndividualConsumerSupervisor.name(shape_id),
               Shapes.Consumer.name(shape_id),
               Shapes.Consumer.Snapshotter.name(shape_id)
             ],

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -65,7 +65,7 @@ defmodule Support.ComponentSetup do
          [ctx.publication_name]}
       end)
 
-    {:ok, _pid} = Electric.Shapes.ConsumerSupervisor.start_link(name: consumer_supervisor)
+    {:ok, _pid} = Electric.Shapes.ConsumerGroupSupervisor.start_link(name: consumer_supervisor)
     {:ok, _pid} = ShapeCache.start_link(start_opts)
 
     shape_cache_opts = [

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -65,7 +65,9 @@ defmodule Support.ComponentSetup do
          [ctx.publication_name]}
       end)
 
-    {:ok, _pid} = Electric.Shapes.ConsumerGroupSupervisor.start_link(name: consumer_group_supervisor)
+    {:ok, _pid} =
+      Electric.Shapes.ConsumerGroupSupervisor.start_link(name: consumer_group_supervisor)
+
     {:ok, _pid} = ShapeCache.start_link(start_opts)
 
     shape_cache_opts = [

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -44,7 +44,7 @@ defmodule Support.ComponentSetup do
   def with_shape_cache(ctx, additional_opts \\ []) do
     shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
     server = :"shape_cache_#{full_test_name(ctx)}"
-    consumer_supervisor = :"consumer_supervisor_#{full_test_name(ctx)}"
+    consumer_group_supervisor = :"consumer_group_supervisor_#{full_test_name(ctx)}"
 
     start_opts =
       [
@@ -57,7 +57,7 @@ defmodule Support.ComponentSetup do
         persistent_kv: ctx.persistent_kv,
         registry: ctx.registry,
         log_producer: ctx.shape_log_collector,
-        consumer_supervisor: consumer_supervisor
+        consumer_group_supervisor: consumer_group_supervisor
       ]
       |> Keyword.merge(additional_opts)
       |> Keyword.put_new_lazy(:prepare_tables_fn, fn ->
@@ -65,7 +65,7 @@ defmodule Support.ComponentSetup do
          [ctx.publication_name]}
       end)
 
-    {:ok, _pid} = Electric.Shapes.ConsumerGroupSupervisor.start_link(name: consumer_supervisor)
+    {:ok, _pid} = Electric.Shapes.ConsumerGroupSupervisor.start_link(name: consumer_group_supervisor)
     {:ok, _pid} = ShapeCache.start_link(start_opts)
 
     shape_cache_opts = [
@@ -78,7 +78,7 @@ defmodule Support.ComponentSetup do
       shape_cache_opts: shape_cache_opts,
       shape_cache: {ShapeCache, shape_cache_opts},
       shape_cache_server: server,
-      consumer_supervisor: consumer_supervisor
+      consumer_group_supervisor: consumer_group_supervisor
     }
   end
 


### PR DESCRIPTION
This PR renames two supervisors with very similar names to avoid confusion:
-  `ConsumerSupervisor` is now `ConsumerGroupSupervisor`
- `Consumer.Supervisor` is now `IndividualConsumerSupervisor`