### PR TITLE
feat (sync-service): support HTTP HEAD requests

### DIFF
--- a/.changeset/shiny-beans-do.md
+++ b/.changeset/shiny-beans-do.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Support HTTP HEAD requests.

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -3,6 +3,8 @@ defmodule Electric.Plug.Router do
 
   plug Plug.RequestId, assign_as: :plug_request_id
   plug :server_header, Electric.version()
+  # converts HEAD requests to GET requests
+  plug Plug.Head
   plug :match
   plug Electric.Plug.LabelProcessPlug
   plug Plug.Telemetry, event_prefix: [:electric, :routing]

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -708,6 +708,24 @@ defmodule Electric.Plug.RouterTest do
       assert get_response_headers == head_response_headers
       assert conn.resp_body == ""
     end
+
+    test "OPTIONS receives supported methods", %{opts: opts} do
+      conn =
+        conn("OPTIONS", "/v1/shape/items")
+        |> Router.call(opts)
+
+      assert %{status: 204} = conn
+
+      allowed_methods =
+        conn
+        |> Plug.Conn.get_resp_header("access-control-allow-methods")
+        |> List.first("")
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> MapSet.new()
+
+      assert allowed_methods == MapSet.new(["GET", "OPTIONS", "DELETE"])
+    end
   end
 
   defp get_resp_shape_id(conn), do: get_resp_header(conn, "x-electric-shape-id")


### PR DESCRIPTION
This PR fixes https://github.com/electric-sql/electric/issues/1645 by adding support for HTTP HEAD requests.