### PR TITLE
feat: add cache max-age of 5 seconds to ?live requests so request collapsing works

### DIFF
--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -251,10 +251,11 @@ defmodule Electric.Plug.ServeShapePlug do
 
   defp put_resp_cache_headers(%Conn{} = conn, _) do
     if conn.assigns.live do
-      conn
-      |> put_resp_header("cache-control", "no-store, no-cache, must-revalidate, max-age=0")
-      |> put_resp_header("pragma", "no-cache")
-      |> put_resp_header("expires", "0")
+      put_resp_header(
+        conn,
+        "cache-control",
+        "max-age=5, stale-while-revalidate=5"
+      )
     else
       put_resp_header(
         conn,


### PR DESCRIPTION
We need a short max-age cache on ?live responses so http proxies will collapse long-polling requests.

The time is a bit arbitrary but two considerations:
- it's shorter than 20 seconds (our long-polling timeout) — which is necessary as otherwise clients would just poll the cached response over and over until the cache expired.
- it's long enough to ensure the vast majority of clients all request within the same five second window. Live clients all get responses at the same time so all request again at the same time. So even accounting for world-wide spread of clients, five seconds should collect pretty much everyone.
