### PR TITLE
Fix snapshot race condition

### DIFF
--- a/.changeset/odd-trees-deny.md
+++ b/.changeset/odd-trees-deny.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix initial snapshot race condition

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -102,6 +102,15 @@ defmodule Electric.Shapes.Consumer do
     {:noreply, [], state}
   end
 
+  def handle_cast({:snapshot_exists, shape_id}, %{shape_id: shape_id} = state) do
+    %{snapshot_xmin: xmin} = state
+
+    cast_shape_cache({:snapshot_xmin_known, shape_id, xmin}, state)
+    cast_shape_cache({:snapshot_started, shape_id}, state)
+
+    {:noreply, [], state}
+  end
+
   # `Shapes.Dispatcher` only works with single-events, so we can safely assert
   # that here
   def handle_events([%Changes.Relation{}], _from, state) do

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -172,21 +172,19 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     assert {:ok, nil} == ShapeStatus.snapshot_xmin(state, shape_id)
     assert ShapeStatus.set_snapshot_xmin(state, shape_id, 1234)
     assert {:ok, 1234} == ShapeStatus.snapshot_xmin(state, shape_id)
-
-    refute ShapeStatus.snapshot_xmin?(state, "sdfsodf")
   end
 
-  test "snapshot_xmin?/2", ctx do
+  test "snapshot_started?/2", ctx do
     {:ok, state, [shape_id]} = new_state(ctx, shapes: [shape!()])
 
-    refute ShapeStatus.set_snapshot_xmin(state, "sdfsodf", 1234)
+    refute ShapeStatus.snapshot_started?(state, "sdfsodf")
+    refute ShapeStatus.snapshot_started?(state.shape_meta_table, "sdfsodf")
+    refute ShapeStatus.snapshot_started?(state, shape_id)
 
-    refute ShapeStatus.snapshot_xmin?(state, "sdfsodf")
-    refute ShapeStatus.snapshot_xmin?(state.shape_meta_table, "sdfsodf")
-    refute ShapeStatus.snapshot_xmin?(state, shape_id)
-    assert ShapeStatus.set_snapshot_xmin(state, shape_id, 1234)
-    assert ShapeStatus.snapshot_xmin?(state, shape_id)
-    assert ShapeStatus.snapshot_xmin?(state.shape_meta_table, shape_id)
+    ShapeStatus.mark_snapshot_started(state, shape_id)
+
+    assert ShapeStatus.snapshot_started?(state, shape_id)
+    assert ShapeStatus.snapshot_started?(state.shape_meta_table, shape_id)
   end
 
   test "relation data", ctx do

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -1,0 +1,126 @@
+defmodule Support.TestStorage do
+  @moduledoc """
+  Wraps a "real" storage backend with a notification system so that tests can
+  assert calls to the storage backend.
+
+  This is useful when mocking the storage doesn't work for some reason.
+
+  You can initialise the backing storage for a given shape id by passing a list
+  of `{function_name :: atom(), args :: []}` calls to make against it after the
+  `initialise/1` call.
+
+  e.g.
+
+      backing_storage = {Electric.ShapeCache.InMemoryStorage, []}
+      # setup "shape-1" with a snapshot
+      init = %{
+        "shape-1" => [
+          {:set_snapshot_xmin, [123]},
+          {:mark_snapshot_as_started, []},
+          {:make_new_snapshot!, [
+            # snapshot entries
+          ]}
+        ]
+      }
+      storage = Support.TestStorage.wrap(backing_storage, init)
+  """
+  alias Electric.ShapeCache.Storage
+
+  @behaviour Electric.ShapeCache.Storage
+
+  def wrap(storage, init, parent \\ self()) do
+    {__MODULE__, {parent, init, storage}}
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def shared_opts(_opts) do
+    raise "don't use this, initialise the memory opts directly"
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def for_shape(shape_id, {parent, init, storage}) do
+    send(parent, {__MODULE__, :for_shape, shape_id})
+    shape_init = Map.get(init, shape_id, [])
+    {parent, shape_id, shape_init, Storage.for_shape(shape_id, storage)}
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def start_link({_parent, _shape_id, _shape_init, storage}) do
+    Storage.start_link(storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def initialise({parent, shape_id, init, storage}) do
+    send(parent, {__MODULE__, :initialise, shape_id})
+
+    {module, opts} = storage
+
+    with :ok <- Storage.initialise(storage) do
+      for {name, args} <- init do
+        apply(module, name, args ++ [opts])
+      end
+
+      :ok
+    end
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def get_current_position({parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :get_current_position, shape_id})
+    Storage.get_current_position(storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def set_snapshot_xmin(xmin, {parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :set_snapshot_xmin, shape_id, xmin})
+    Storage.set_snapshot_xmin(xmin, storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def snapshot_started?({parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :snapshot_started?, shape_id})
+    Storage.snapshot_started?(storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def get_snapshot({parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :get_snapshot, shape_id})
+    Storage.get_snapshot(storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def get_log_stream(offset, max_offset, {parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :get_log_stream, shape_id, offset, max_offset})
+    Storage.get_log_stream(offset, max_offset, storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def get_chunk_end_log_offset(offset, {parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :get_chunk_end_log_offset, shape_id, offset})
+    Storage.get_chunk_end_log_offset(offset, storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def make_new_snapshot!(data_stream, {parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :make_new_snapshot!, shape_id, data_stream})
+    Storage.make_new_snapshot!(data_stream, storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def mark_snapshot_as_started({parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :mark_snapshot_as_started, shape_id})
+    Storage.mark_snapshot_as_started(storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def append_to_log!(log_items, {parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :append_to_log!, shape_id, log_items})
+    Storage.append_to_log!(log_items, storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def cleanup!({parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :cleanup!, shape_id})
+    Storage.cleanup!(storage)
+  end
+end


### PR DESCRIPTION
Snapshot initialisation is done in two steps, set xmin and mark the snapshot started.

The `ShapeCache.await_snapshot_start/2` function was using the presence of an xmin for the given shape to determine if the snapshot was running. This would lead to occasional errors ("snapshot no longer available") if await_snapshot_start was called after the xmin call but before the snapshot was marked as started. 

This PR fixes this by using the snapshot start marker test in the await_snapshot_start function.

Unfortunately, despite a lot of hair tearing, I couldn't get the consumer_test.exs tests to pass using any combination of `Mox.allow/4`. I don't know if it's a problem with our particular setup of a bug in Mox itself, but the `ShapeCache.cast` call would inevitably be rejected by Mox. I could get it to pass in a single test but then it would fail (randomly on some subset of tests) when running the full suite.

So I replaced mocking the storage implementation with a `Support.TestStorage` implementation which wraps some storage backend with a `send` call, so the test process can assert that functions were/were not called.