### PR TITLE
Fix null value parsing

### DIFF
--- a/.changeset/large-cherries-lick.md
+++ b/.changeset/large-cherries-lick.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Fix parsing issue of a column named "value" with a null value.

--- a/.changeset/large-cherries-lick.md
+++ b/.changeset/large-cherries-lick.md
@@ -2,4 +2,4 @@
 "@electric-sql/client": patch
 ---
 
-Fix parsing issue of a column named "value" with a null value.
+Fix bug that occured when parsing column named "value" with a null value.

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -93,7 +93,7 @@ export class MessageParser<T extends Row> {
       // typeof value === `object` is needed because
       // there could be a column named `value`
       // and the value associated to that column will be a string
-      if (key === `value` && typeof value === `object` && value != null) {
+      if (key === `value` && typeof value === `object` && value !== null) {
         // Parse the row values
         const row = value as Record<string, Value>
         Object.keys(row).forEach((key) => {

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -93,6 +93,7 @@ export class MessageParser<T extends Row> {
       // typeof value === `object` is needed because
       // there could be a column named `value`
       // and the value associated to that column will be a string
+      // Also check if the value is not `null` because `typeof null === 'object'`
       if (key === `value` && typeof value === `object` && value !== null) {
         // Parse the row values
         const row = value as Record<string, Value>

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -93,7 +93,7 @@ export class MessageParser<T extends Row> {
       // typeof value === `object` is needed because
       // there could be a column named `value`
       // and the value associated to that column will be a string
-      if (key === `value` && typeof value === `object`) {
+      if (key === `value` && typeof value === `object` && value != null) {
         // Parse the row values
         const row = value as Record<string, Value>
         Object.keys(row).forEach((key) => {

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -90,10 +90,10 @@ export class MessageParser<T extends Row> {
 
   parse(messages: string, schema: Schema): Message<T>[] {
     return JSON.parse(messages, (key, value) => {
-      // typeof value === `object` is needed because
-      // there could be a column named `value`
-      // and the value associated to that column will be a string
-      // Also check if the value is not `null` because `typeof null === 'object'`
+      // typeof value === `object` && value !== null
+      // is needed because there could be a column named `value`
+      // and the value associated to that column will be a string or null.
+      // But `typeof null === 'object'` so we need to make an explicit check.
       if (key === `value` && typeof value === `object` && value !== null) {
         // Parse the row values
         const row = value as Record<string, Value>

--- a/packages/typescript-client/test/parser.test.ts
+++ b/packages/typescript-client/test/parser.test.ts
@@ -214,11 +214,11 @@ describe(`Message parser`, () => {
 
   it(`should parse null value on column named value`, () => {
     const schema = {
-      a: { type: `text`, dims: 1 },
+      value: { type: `text`, dims: 1 },
     }
 
-    expect(parser.parse(`[ { "value": null } ]`, schema)).toEqual([
-      { value: null },
+    expect(parser.parse(`[ { "value": {"value": null} } ]`, schema)).toEqual([
+      { value: { value: null } },
     ])
   })
 })

--- a/packages/typescript-client/test/parser.test.ts
+++ b/packages/typescript-client/test/parser.test.ts
@@ -211,4 +211,14 @@ describe(`Message parser`, () => {
       parser.parse(`[ { "value": { "a": "{1,2,NULL,4,5}" } } ]`, schema)
     ).toEqual([{ value: { a: [1, 2, null, 4, 5] } }])
   })
+
+  it(`should parse null value on column named value`, () => {
+    const schema = {
+      a: { type: `text`, dims: 1 },
+    }
+
+    expect(parser.parse(`[ { "value": null } ]`, schema)).toEqual([
+      { value: null },
+    ])
+  })
 })


### PR DESCRIPTION
Hi there,

first of all, I really like your project! Amazing work! 🚀 
Thank you!

While integrating it I found a bug:
When a shape includes a column, that is nullable and currently null or set to null, the typescript client is crashing:

<img width="637" alt="Screenshot 2024-09-11 at 07 20 16" src="https://github.com/user-attachments/assets/0667fcc4-aa32-4a2f-9d29-3866fc1e53bc">

The code is checking if the `typeof value` is `object` and is then trying to iterate over it's keys.
However, `typeof null` is also `object`. This is why it crashes here, as it cannot iterate over null.
This PR fixes https://github.com/electric-sql/electric/issues/1673.

A simple check for `null` fixes this as proposed in this PR.

Could you please merge it? Or is there anything I've overseen?
Thanks!