### PR TITLE
chore (sync-service): run filter logic for PG version 15 in unit tests

### DIFF
--- a/.changeset/rare-cooks-marry.md
+++ b/.changeset/rare-cooks-marry.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Run filter logic for PG version 15 in unit tests.

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -17,12 +17,12 @@ jobs:
         working-directory: packages/sync-service
     env:
       MIX_ENV: test
+      POSTGRES_MAJOR_VERSION: 14
     services:
       postgres:
         image: postgres:14-alpine
         env:
           POSTGRES_PASSWORD: password
-          POSTGRES_MAJOR_VERSION: 14
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -74,12 +74,12 @@ jobs:
         working-directory: packages/sync-service
     env:
       MIX_ENV: test
+      POSTGRES_MAJOR_VERSION: 15
     services:
       postgres:
         image: postgres:15-alpine
         env:
           POSTGRES_PASSWORD: password
-          POSTGRES_MAJOR_VERSION: 15
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -22,6 +22,7 @@ jobs:
         image: postgres:14-alpine
         env:
           POSTGRES_PASSWORD: password
+          POSTGRES_MAJOR_VERSION: 14
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -78,6 +79,7 @@ jobs:
         image: postgres:15-alpine
         env:
           POSTGRES_PASSWORD: password
+          POSTGRES_MAJOR_VERSION: 15
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -9,7 +9,10 @@ config :logger, level: :debug
 #   handle_otp_reports: true,
 #   handle_sasl_reports: true
 
-if config_env() == :test, do: config(:logger, level: :info)
+if config_env() == :test do
+  config(:logger, level: :info)
+  config(:electric, major_pg_version_for_tests: env!("POSTGRES_MAJOR_VERSION", :integer, 15))
+end
 
 if config_env() in [:dev, :test] do
   source!([".env.#{config_env()}", ".env.#{config_env()}.local", System.get_env()])

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -667,7 +667,7 @@ defmodule Electric.Shapes.ConsumerTest do
         }
       ]
 
-      get_pg_version = fn -> 14 end
+      get_pg_version = fn -> 15 end
 
       shape_cache_config =
         [

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -667,7 +667,7 @@ defmodule Electric.Shapes.ConsumerTest do
         }
       ]
 
-      get_pg_version = fn -> 15 end
+      get_pg_version = fn -> Application.fetch_env!(:electric, :major_pg_version_for_tests) end
 
       shape_cache_config =
         [

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -55,7 +55,7 @@ defmodule Support.ComponentSetup do
     shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
     server = :"shape_cache_#{full_test_name(ctx)}"
     consumer_supervisor = :"consumer_supervisor_#{full_test_name(ctx)}"
-    get_pg_version = fn -> 15 end
+    get_pg_version = fn -> Application.fetch_env!(:electric, :major_pg_version_for_tests) end
 
     start_opts =
       [

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -76,7 +76,6 @@ defmodule Support.ComponentSetup do
         {
           Electric.Postgres.Configuration,
           :configure_tables_for_replication!,
-          # TODO: can pass PG version here, then in Application also pass it there, or pass a function that returns the version
           [get_pg_version, ctx.publication_name]
         }
       end)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -55,7 +55,7 @@ defmodule Support.ComponentSetup do
     shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
     server = :"shape_cache_#{full_test_name(ctx)}"
     consumer_supervisor = :"consumer_supervisor_#{full_test_name(ctx)}"
-    get_pg_version = fn -> 14 end
+    get_pg_version = fn -> 15 end
 
     start_opts =
       [


### PR DESCRIPTION
This modifies the unit tests to use the publication filter logic for PG 15 as that is more advanced than the logic for version 14 and below.