### PR TITLE
fix: fix package.json names that were duplicated

### DIFF
--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@electric-examples/basic-example",
+  "name": "@electric-examples/nextjs-example",
   "private": true,
   "version": "0.0.1",
   "author": "ElectricSQL",

--- a/examples/remix-basic/package.json
+++ b/examples/remix-basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@electric-examples/basic-example",
+  "name": "@electric-examples/remix-basic",
   "private": true,
   "version": "0.0.1",
   "author": "ElectricSQL",

--- a/examples/tanstack-example/package.json
+++ b/examples/tanstack-example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@electric-examples/basic-example",
+  "name": "@electric-examples/tanstack-example",
   "private": true,
   "version": "0.0.1",
   "author": "ElectricSQL",


### PR DESCRIPTION
Duplicated package names causes problems with various monorepo tools.  The package names now match the folder name.