### PR TITLE
chore: Add OpenTelemetry spans to ServeShapePlug and ReplicationClient

### DIFF
--- a/.changeset/lovely-rules-argue.md
+++ b/.changeset/lovely-rules-argue.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add OpenTelemetry spans for HTTP request handling and replication message processing.

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -414,6 +414,8 @@ defmodule Electric.Plug.ServeShapePlug do
   defp send_stream(stream, conn, status) do
     conn = Conn.send_chunked(conn, status)
 
+    OpenTelemetry.add_span_attributes(%{SC.Trace.http_status_code() => status})
+
     Enum.reduce_while(stream, conn, fn chunk, conn ->
       OpenTelemetry.with_span(
         "serve_shape_plug.serve_log_or_snapshot.chunk",

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -173,19 +173,23 @@ defmodule Electric.ShapeCache.InMemoryStorage do
 
   @impl Electric.ShapeCache.Storage
   def make_new_snapshot!(data_stream, %MS{} = opts) do
-    OpenTelemetry.with_span("storage.make_new_snapshot", [storage_impl: "in_memory"], fn ->
-      table = opts.snapshot_table
+    OpenTelemetry.with_span(
+      "storage.make_new_snapshot",
+      [storage_impl: "in_memory", "shape.id": opts.shape_id],
+      fn ->
+        table = opts.snapshot_table
 
-      data_stream
-      |> Stream.with_index(1)
-      |> Stream.map(fn {log_item, index} -> {snapshot_key(index), log_item} end)
-      |> Stream.chunk_every(500)
-      |> Stream.each(fn chunk -> :ets.insert(table, chunk) end)
-      |> Stream.run()
+        data_stream
+        |> Stream.with_index(1)
+        |> Stream.map(fn {log_item, index} -> {snapshot_key(index), log_item} end)
+        |> Stream.chunk_every(500)
+        |> Stream.each(fn chunk -> :ets.insert(table, chunk) end)
+        |> Stream.run()
 
-      :ets.insert(table, {snapshot_end(), 0})
-      :ok
-    end)
+        :ets.insert(table, {snapshot_end(), 0})
+        :ok
+      end
+    )
   end
 
   @impl Electric.ShapeCache.Storage

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -44,8 +44,10 @@ defmodule Electric.Telemetry.OpenTelemetry do
   @doc """
   Create a span that starts at the current point in time and ends when `fun` returns.
 
-  Calling this function inside an another span establishes a parent-child relationship between
-  the two, as long as both calls happens within the same Elixir process. See `async_fun/4` for
+  Returns the result of calling the function `fun`.
+
+  Calling this function inside another span establishes a parent-child relationship between
+  the two, as long as both calls happen within the same Elixir process. See `async_fun/4` for
   interprocess progragation of span context.
   """
   @spec with_span(span_name(), span_attrs(), (-> t)) :: t when t: term


### PR DESCRIPTION
Part of #1664.

Below are some trace examples from Honeycomb.

Initial snapshot:
![Screenshot from 2024-09-14 04-28-10](https://github.com/user-attachments/assets/0fde90d8-0623-412a-b4e1-68b77231dc34)

Chunked response to a "GET shape" request:
![Screenshot from 2024-09-14 04-33-23](https://github.com/user-attachments/assets/7dd84bf2-f4fe-496a-9df1-08097725e046)


Transaction processing time in the replication client with the number changes as an attribute:
![Screenshot from 2024-09-14 04-32-29](https://github.com/user-attachments/assets/51ff6ef4-13b5-4e84-8c22-e26069ad1cd5)
![Screenshot from 2024-09-14 04-29-18](https://github.com/user-attachments/assets/e26f3d96-935c-4abb-a99a-de196ba37cd4)
