### PR TITLE
feat (sync-service)!: clean all shapes when switching to a different DB

### DIFF
--- a/.changeset/thick-experts-call.md
+++ b/.changeset/thick-experts-call.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Detect when Electric is connected to a different Postgres DB than before and clean all shapes.

--- a/.changeset/thick-experts-call.md
+++ b/.changeset/thick-experts-call.md
@@ -1,5 +1,5 @@
 ---
-"@core/sync-service": patch
+"@core/sync-service": minor
 ---
 
 Detect when Electric is connected to a different Postgres DB than before and clean all shapes.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -146,7 +146,7 @@ defmodule Electric.ShapeCache do
   @spec clean_all_shapes(keyword()) :: :ok
   def clean_all_shapes(opts) do
     server = Access.get(opts, :server, __MODULE__)
-    GenServer.call(server, {:clean_all})
+    GenStage.call(server, {:clean_all})
   end
 
   @impl Electric.ShapeCacheBehaviour
@@ -329,7 +329,7 @@ defmodule Electric.ShapeCache do
   def handle_call({:clean_all}, _from, state) do
     Logger.info("Cleaning up all shapes")
     clean_up_all_shapes(state)
-    {:reply, :ok, state}
+    {:reply, :ok, [], state}
   end
 
   @impl GenStage

--- a/packages/sync-service/test/electric/timeline_test.exs
+++ b/packages/sync-service/test/electric/timeline_test.exs
@@ -12,8 +12,22 @@ defmodule Electric.TimelineTest do
       %{kv: Electric.PersistentKV.Filesystem.new!(root: context.tmp_dir)}
     end
 
-    test "returns nil when no timeline ID is available", %{kv: kv} do
+    test "returns nil when no timeline is available", %{kv: kv} do
       assert Timeline.load_timeline(persistent_kv: kv) == nil
+    end
+  end
+
+  describe "store_timeline/2" do
+    @moduletag :tmp_dir
+
+    setup context do
+      %{opts: [persistent_kv: Electric.PersistentKV.Filesystem.new!(root: context.tmp_dir)]}
+    end
+
+    test "stores the timeline", %{opts: opts} do
+      timeline = {1, 2}
+      Timeline.store_timeline(timeline, opts)
+      assert ^timeline = Timeline.load_timeline(opts)
     end
   end
 
@@ -24,44 +38,59 @@ defmodule Electric.TimelineTest do
       timeline = context[:electric_timeline]
       kv = Electric.PersistentKV.Filesystem.new!(root: context.tmp_dir)
       opts = [persistent_kv: kv, shape_cache: {ShapeCache, []}]
+
+      if timeline != nil do
+        Timeline.store_timeline(timeline, opts)
+      end
+
       {:ok, [timeline: timeline, opts: opts]}
     end
 
     @tag electric_timeline: nil
-    test "stores the Postgres timeline if Electric has no timeline yet", %{opts: opts} do
-      timeline = 5
+    test "stores the timeline if Electric has no timeline yet", %{opts: opts} do
+      assert Timeline.load_timeline(opts) == nil
+
+      timeline = {2, 5}
+
       assert :ok = Timeline.check(timeline, opts)
       assert ^timeline = Timeline.load_timeline(opts)
     end
 
-    @tag electric_timeline: 3
+    @tag electric_timeline: {1, 2}
     test "proceeds without changes if Postgres' timeline matches Electric's timeline", %{
       timeline: timeline,
       opts: opts
     } do
+      expect(ShapeCache, :clean_all_shapes, 0, fn _ -> :ok end)
+      assert ^timeline = Timeline.load_timeline(opts)
       assert :ok = Timeline.check(timeline, opts)
       assert ^timeline = Timeline.load_timeline(opts)
     end
 
-    @tag electric_timeline: 3
-    test "cleans all shapes if Postgres' timeline does not match Electric's timeline", %{
+    @tag electric_timeline: {1, 3}
+    test "cleans all shapes on Point In Time Recovery (PITR)", %{
+      timeline: timeline,
       opts: opts
     } do
-      ShapeCache
-      |> expect(:clean_all_shapes, fn _ -> :ok end)
+      expect(ShapeCache, :clean_all_shapes, 1, fn _ -> :ok end)
+      assert ^timeline = Timeline.load_timeline(opts)
 
-      pg_timeline = 2
+      pg_timeline = {1, 2}
       assert :ok = Timeline.check(pg_timeline, opts)
+
       assert ^pg_timeline = Timeline.load_timeline(opts)
     end
 
-    @tag electric_timeline: 3
-    test "cleans all shapes if Postgres' timeline is unknown", %{opts: opts} do
-      ShapeCache
-      |> expect(:clean_all_shapes, fn _ -> :ok end)
+    # TODO: add log output checks
 
-      assert :ok = Timeline.check(nil, opts)
-      assert Timeline.load_timeline(opts) == nil
+    @tag electric_timeline: {1, 3}
+    test "cleans all shapes when Postgres DB changed", %{timeline: timeline, opts: opts} do
+      expect(ShapeCache, :clean_all_shapes, 1, fn _ -> :ok end)
+      assert ^timeline = Timeline.load_timeline(opts)
+
+      pg_timeline = {2, 3}
+      assert :ok = Timeline.check(pg_timeline, opts)
+      assert ^pg_timeline = Timeline.load_timeline(opts)
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1689.
This PR uses Postgres' `system_identifier` to detect when Electric is connected to a different Postgres database than before. When that is the case, we log a warning and clean all shapes. Cleaning all shapes is consistent with how we handle Point In Time Recoveries (where we also clean all shapes).

Note: this is a breaking change because we modify the structure of the timeline we store persistently. We used to just store the timeline ID, but now we store a list `[pg_id, timeline_id]` so we can't read out old persisted timeline information as we are expecting the new structure.