### PR TITLE
fix: Adjust chunk size to 10 MB

### DIFF
--- a/.changeset/hot-otters-crash.md
+++ b/.changeset/hot-otters-crash.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Change default chunk size to ~10MB uncompressed.

--- a/packages/sync-service/.env.dev
+++ b/packages/sync-service/.env.dev
@@ -2,3 +2,4 @@ DATABASE_URL=postgresql://postgres:password@localhost:54321/electric?sslmode=dis
 ENABLE_INTEGRATION_TESTING=true
 CACHE_MAX_AGE=1
 CACHE_STALE_AGE=3
+LOG_CHUNK_BYTES_THRESHOLD=10000

--- a/packages/sync-service/.env.dev
+++ b/packages/sync-service/.env.dev
@@ -2,4 +2,5 @@ DATABASE_URL=postgresql://postgres:password@localhost:54321/electric?sslmode=dis
 ENABLE_INTEGRATION_TESTING=true
 CACHE_MAX_AGE=1
 CACHE_STALE_AGE=3
+# using a small chunk size of 10kB for dev to speed up tests
 LOG_CHUNK_BYTES_THRESHOLD=10000

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -117,7 +117,12 @@ persistent_kv =
     {Electric.PersistentKV.Filesystem, :new!, root: persistent_state_path}
   )
 
-chunk_bytes_threshold = env!("LOG_CHUNK_BYTES_THRESHOLD", :integer, 10_000)
+chunk_bytes_threshold =
+  env!(
+    "LOG_CHUNK_BYTES_THRESHOLD",
+    :integer,
+    Electric.ShapeCache.LogChunker.default_chunk_size_threshold()
+  )
 
 {storage_mod, storage_opts} =
   env!(

--- a/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
+++ b/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
@@ -1,5 +1,5 @@
 defmodule Electric.ShapeCache.LogChunker do
-  @default_threshold 10_000
+  @default_threshold 10_000_000
 
   @doc """
   Add bytes to the current chunk of a given shape - if the chunk exceeds the specified

--- a/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
+++ b/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
@@ -1,5 +1,5 @@
 defmodule Electric.ShapeCache.LogChunker do
-  @default_threshold 10_000_000
+  @default_threshold 10 * 1024 * 1024
 
   @doc """
   Add bytes to the current chunk of a given shape - if the chunk exceeds the specified

--- a/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
+++ b/packages/sync-service/lib/electric/shape_cache/log_chunker.ex
@@ -1,4 +1,6 @@
 defmodule Electric.ShapeCache.LogChunker do
+  # Default chunk size of 10 MB to ensure caches accept them
+  # see: https://github.com/electric-sql/electric/issues/1581
   @default_threshold 10 * 1024 * 1024
 
   @doc """

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -55,7 +55,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       shape_cache_opts =
         [
           storage: {Mock.Storage, []},
-          chunk_bytes_threshold: 10_000,
+          chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
           inspector: {Mock.Inspector, []},
           shape_status: Mock.ShapeStatus,
           shape_meta_table: shape_meta_table,

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -130,7 +130,8 @@ defmodule Electric.Shapes.ConsumerTest do
                registry: registry_name,
                shape_cache: {Mock.ShapeCache, []},
                storage: storage,
-               chunk_bytes_threshold: 10_000,
+               chunk_bytes_threshold:
+                 Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
                prepare_tables_fn: &prepare_tables_fn/2},
               id: {Shapes.Consumer.Supervisor, shape_id}
             )
@@ -674,7 +675,7 @@ defmodule Electric.Shapes.ConsumerTest do
           persistent_kv: ctx.persistent_kv,
           registry: ctx.registry,
           inspector: ctx.inspector,
-          chunk_bytes_threshold: 10_000,
+          chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
           log_producer: ShapeLogCollector.name(ctx.electric_instance_id),
           consumer_supervisor: Electric.Shapes.ConsumerSupervisor.name(ctx.electric_instance_id),
           prepare_tables_fn: {

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -48,7 +48,7 @@ defmodule Support.ComponentSetup do
   end
 
   def with_log_chunking(_ctx) do
-    %{chunk_bytes_threshold: 10_000}
+    %{chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold()}
   end
 
   def with_shape_cache(ctx, additional_opts \\ []) do

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -294,7 +294,11 @@ describe(`HTTP Sync`, () => {
         ]
       )
 
-      await sleep(100)
+      await vi.waitFor(async () => {
+        const res = await fetch(`${BASE_URL}/v1/shape/${tableUrl}?offset=-1`)
+        const body = (await res.json()) as Message[]
+        expect(body.length).greaterThan(2)
+      })
       const updatedData = client.valueSync
 
       expect([...updatedData.values()]).toMatchObject([
@@ -720,7 +724,7 @@ describe(`HTTP Sync`, () => {
       // before any subsequent requests after the initial one, ensure
       // that the existing shape is deleted and some more data is inserted
       if (statusCodesReceived.length === 1 && statusCodesReceived[0] === 200) {
-        await clearIssuesShape()
+        await clearIssuesShape(issueStream.shapeId)
         await insertIssues({ id: secondRowId, title: `foo2` })
       }
 


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/1667

We were using  10kB chunks rather than 10MB chunks - whoops!

This is still the uncompressed threshold, if gzip is added the chunks should be _significantly_ smaller, but we need some work on estimating that (generally speaking for json it could be 90-95% size reduction, but it's hard to tell if some rows contain large items that are not easily compressable)

I've kept the dev environment chunk size to 10kB such that integration tests can work with small chunks and still be fast (i.e. we don't have to load PG with hundreds of MB of data to test chunking)