### PR TITLE
fix: Clean shape data when individual shape is cleaned up

### DIFF
--- a/.changeset/wicked-beds-play.md
+++ b/.changeset/wicked-beds-play.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Clean up underlying shape data when cleaning up shape.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -365,8 +365,10 @@ defmodule Electric.ShapeCache do
   end
 
   defp clean_up_shape(state, shape_id) do
-    shape_opts = Electric.ShapeCache.Storage.for_shape(shape_id, state.storage)
-    Electric.ShapeCache.Storage.cleanup!(shape_opts)
+    if state.shape_status.get_existing_shape(state.persistent_state, shape_id) !== nil do
+      shape_opts = Electric.ShapeCache.Storage.for_shape(shape_id, state.storage)
+      Electric.ShapeCache.Storage.cleanup!(shape_opts)
+    end
 
     Electric.Shapes.ConsumerSupervisor.stop_shape_consumer(
       state.consumer_supervisor,

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -365,6 +365,9 @@ defmodule Electric.ShapeCache do
   end
 
   defp clean_up_shape(state, shape_id) do
+    shape_opts = Electric.ShapeCache.Storage.for_shape(shape_id, state.storage)
+    Electric.ShapeCache.Storage.cleanup!(shape_opts)
+
     Electric.Shapes.ConsumerSupervisor.stop_shape_consumer(
       state.consumer_supervisor,
       state.electric_instance_id,

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -761,7 +761,7 @@ defmodule Electric.ShapeCacheTest do
 
       assert_raise ArgumentError,
                    ~r"the table identifier does not refer to an existing ETS table",
-                   fn -> Enum.count(Storage.get_log_stream(@zero_offset, storage)) end
+                   fn -> Stream.run(Storage.get_log_stream(@zero_offset, storage)) end
 
       assert_raise RuntimeError,
                    ~r"Snapshot no longer available",

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -759,6 +759,14 @@ defmodule Electric.ShapeCacheTest do
 
       assert_receive {:DOWN, ^ref, :process, _pid, _reason}
 
+      assert_raise ArgumentError,
+                   ~r"the table identifier does not refer to an existing ETS table",
+                   fn -> Enum.count(Storage.get_log_stream(@zero_offset, storage)) end
+
+      assert_raise RuntimeError,
+                   ~r"Snapshot no longer available",
+                   fn -> Storage.get_snapshot(storage) end
+
       {shape_id2, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
       assert shape_id != shape_id2
     end

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -724,8 +724,8 @@ describe(`HTTP Sync`, () => {
       // before any subsequent requests after the initial one, ensure
       // that the existing shape is deleted and some more data is inserted
       if (statusCodesReceived.length === 1 && statusCodesReceived[0] === 200) {
-        await clearIssuesShape(issueStream.shapeId)
         await insertIssues({ id: secondRowId, title: `foo2` })
+        await clearIssuesShape(issueStream.shapeId)
       }
 
       const response = await fetch(...args)


### PR DESCRIPTION
Cleans up the underlying data for the shape, not only the metadata.

I'm not entirely sure if this is the best approach or if there's a cleaner way @robacourt ?

(also fixed an integration test that was causing issues)