### PR TITLE
feat (client): expose isLoading status

### DIFF
--- a/.changeset/brown-files-flash.md
+++ b/.changeset/brown-files-flash.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": minor
+"@electric-sql/react": minor
+---
+
+Expose isLoading status in ShapeStream and Shape classes and in useShape React hook.

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -68,6 +68,8 @@ export interface UseShapeResult<T extends Row = Row> {
    * @type {Shape<T>}
    */
   shape: Shape<T>
+  /** True during initial fetch. False afterwise. */
+  isLoading: boolean
   error: Shape<T>[`error`]
   isError: boolean
 }
@@ -82,6 +84,7 @@ function shapeSubscribe<T extends Row>(shape: Shape<T>, callback: () => void) {
 function parseShapeData<T extends Row>(shape: Shape<T>): UseShapeResult<T> {
   return {
     data: [...shape.valueSync.values()],
+    isLoading: shape.isLoading(),
     isError: shape.error !== false,
     shape,
     error: shape.error,

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -60,6 +60,22 @@ describe(`useShape`, () => {
     )
   })
 
+  it(`should expose isLoading status`, async ({ issuesTableUrl }) => {
+    const { result } = renderHook(() =>
+      useShape({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        fetchClient: async (input, init) => {
+          await sleep(10)
+          return fetch(input, init)
+        },
+      })
+    )
+
+    expect(result.current.isLoading).toBe(true)
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+
   it(`should keep the state value in sync`, async ({
     aborter,
     issuesTableUrl,

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -363,6 +363,11 @@ export class ShapeStream<T extends Row = Row> {
     return this.connected
   }
 
+  /** True during initial fetch. False afterwise.  */
+  isLoading(): boolean {
+    return !this.isUpToDate
+  }
+
   private notifyUpToDateSubscribers() {
     this.upToDateSubscribers.forEach(([callback]) => {
       callback()
@@ -512,6 +517,11 @@ export class Shape<T extends Row = Row> {
 
   isConnected(): boolean {
     return this.stream.isConnected()
+  }
+
+  /** True during initial fetch. False afterwise. */
+  isLoading(): boolean {
+    return this.stream.isLoading()
   }
 
   get value(): Promise<ShapeData<T>> {

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -301,4 +301,20 @@ describe(`Shape`, () => {
     // the initial fetch finished and we've not subscribed to changes
     expect(shapeStream.isConnected()).false
   })
+
+  it(`should expose isLoading status`, async ({ issuesTableUrl }) => {
+    const shapeStream = new ShapeStream({
+      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+      fetchClient: async (input, init) => {
+        await sleep(20)
+        return fetch(input, init)
+      },
+    })
+
+    expect(shapeStream.isLoading()).true
+
+    await sleep(100) // give some time for the initial fetch to complete
+
+    expect(shapeStream.isLoading()).false
+  })
 })

--- a/website/docs/api/integrations/react.md
+++ b/website/docs/api/integrations/react.md
@@ -11,11 +11,11 @@ Example usage in a component.
 import { useShape } from "@electric-sql/react"
 
 export default function MyComponent() {
-  const { isUpToDate, data } = useShape<{ title: string}>({
+  const { isLoading, data } = useShape<{ title: string}>({
     url: `http://localhost:3000/v1/shape/foo`,
   })
 
-  if (!isUpToDate) {
+  if (isLoading) {
     return <div>loading</div>
   }
   


### PR DESCRIPTION
This PR introduces the `isLoading` status on the `ShapeStream` and `Shape` classes and on the `useShape` hook as well. As requested here: https://github.com/electric-sql/electric/issues/1687#issuecomment-2352856430.