### PR TITLE
fix(sync-service): Fix the start order of OT apps for real this time

### DIFF
--- a/.changeset/curly-terms-sparkle.md
+++ b/.changeset/curly-terms-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix the configuration of OpenTelemetry libraries, removing the "inets_not_started" warning from log output.

--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -23,8 +23,10 @@ defmodule Electric.MixProject do
         electric: [
           applications: [
             electric: :permanent,
-            opentelemetry: :temporary,
-            opentelemetry_exporter: :permanent
+            # This order of application is important to ensure proper startup sequence of
+            # application dependencies, namely, inets.
+            opentelemetry_exporter: :permanent,
+            opentelemetry: :temporary
           ],
           include_executables_for: [:unix]
         ]


### PR DESCRIPTION
Another fix on top of https://github.com/electric-sql/electric/pull/1713.

This is the correct stanza. Taken from https://github.com/electric-sql/electric-old/blob/b4da7af0e45ed7c34a5069640922ab8acca389bd/components/electric/mix.exs#L21-L27.