### PR TITLE
fix: remove deprecated "version" attribute from docker compose files

### DIFF
--- a/.support/docker-compose.yml
+++ b/.support/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 name: "electric_example-${PROJECT_NAME:-default}"
 
 services:

--- a/packages/sync-service/dev/docker-compose-otel.yml
+++ b/packages/sync-service/dev/docker-compose-otel.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 name: "electric_dev_otel"
 
 services:

--- a/packages/sync-service/dev/docker-compose.yml
+++ b/packages/sync-service/dev/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 name: "electric_dev"
 
 services:

--- a/website/public/docker-compose.yaml
+++ b/website/public/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 name: "electric_quickstart"
 
 services:


### PR DESCRIPTION
Seems safe to remove according to warning:
```console
% docker compose -f .support/docker-compose.yml up
WARN[0000] .../.support/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```