### PR TITLE
fix (sync-service): query PG version number using PG's `server_version_num` setting

### DIFF
--- a/.changeset/four-chicken-crash.md
+++ b/.changeset/four-chicken-crash.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix how Electric reads PG's version number.

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: packages/sync-service
     env:
       MIX_ENV: test
-      POSTGRES_MAJOR_VERSION: 14
+      POSTGRES_VERSION: 140006
     services:
       postgres:
         image: postgres:14-alpine
@@ -74,7 +74,7 @@ jobs:
         working-directory: packages/sync-service
     env:
       MIX_ENV: test
-      POSTGRES_MAJOR_VERSION: 15
+      POSTGRES_VERSION: 150001
     services:
       postgres:
         image: postgres:15-alpine

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -11,7 +11,7 @@ config :logger, level: :debug
 
 if config_env() == :test do
   config(:logger, level: :info)
-  config(:electric, major_pg_version_for_tests: env!("POSTGRES_MAJOR_VERSION", :integer, 15))
+  config(:electric, pg_version_for_tests: env!("POSTGRES_VERSION", :integer, 150_001))
 end
 
 if config_env() in [:dev, :test] do

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -159,7 +159,7 @@ defmodule Electric.ConnectionManager do
       {:ok, pid} ->
         Electric.Timeline.check({get_pg_id(pid), get_pg_timeline(pid)}, state.timeline_opts)
 
-        pg_version = query_pg_major_version(pid)
+        pg_version = query_pg_version(pid)
 
         # Now we have everything ready to start accepting and processing logical messages from
         # Postgres.
@@ -402,11 +402,11 @@ defmodule Electric.ConnectionManager do
     end
   end
 
-  def query_pg_major_version(conn) do
+  def query_pg_version(conn) do
     [[setting]] =
       Postgrex.query!(
         conn,
-        "SELECT floor(setting::numeric)::integer FROM pg_settings WHERE name = 'server_version'",
+        "SELECT current_setting('server_version_num')",
         []
       )
       |> Map.fetch!(:rows)

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -406,7 +406,7 @@ defmodule Electric.ConnectionManager do
     [[setting]] =
       Postgrex.query!(
         conn,
-        "SELECT current_setting('server_version_num')",
+        "SELECT current_setting('server_version_num')::integer",
         []
       )
       |> Map.fetch!(:rows)

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -10,6 +10,8 @@ defmodule Electric.Postgres.Configuration do
   @type maybe_filter() :: filter() | :relation_not_found
   @type filters() :: %{Electric.relation() => filter()}
 
+  @pg_15 150_000
+
   @doc """
   Ensure that all tables are configured for replication.
 
@@ -38,7 +40,7 @@ defmodule Electric.Postgres.Configuration do
   end
 
   defp configure_tables_for_replication_internal!(pool, relations, pg_version, publication_name)
-       when pg_version <= 14 do
+       when pg_version < @pg_15 do
     Postgrex.transaction(pool, fn conn ->
       set_replica_identity!(conn, relations)
 

--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -3,6 +3,8 @@ defmodule Electric.Postgres.ConfigurationTest do
 
   alias Electric.Postgres.Configuration
 
+  @pg_15 150_000
+
   setup {Support.DbSetup, :with_unique_db}
   setup {Support.DbSetup, :with_publication}
   setup {Support.DbSetup, :with_pg_version}
@@ -235,11 +237,11 @@ defmodule Electric.Postgres.ConfigurationTest do
   end
 
   defp list_tables_in_publication(conn, publication) do
-    pg_version = Electric.ConnectionManager.query_pg_major_version(conn)
+    pg_version = Electric.ConnectionManager.query_pg_version(conn)
     list_tables_in_pub(conn, publication, pg_version)
   end
 
-  defp list_tables_in_pub(conn, publication, pg_version) when pg_version <= 14 do
+  defp list_tables_in_pub(conn, publication, pg_version) when pg_version < @pg_15 do
     Postgrex.query!(
       conn,
       "SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = $1 ORDER BY tablename",
@@ -259,7 +261,7 @@ defmodule Electric.Postgres.ConfigurationTest do
     |> Enum.map(&List.to_tuple/1)
   end
 
-  defp expected_filters(filters, pg_version) when pg_version <= 14 do
+  defp expected_filters(filters, pg_version) when pg_version < @pg_15 do
     Enum.map(filters, fn {schema, table, _filter} -> {schema, table} end)
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -663,7 +663,7 @@ defmodule Electric.Shapes.ConsumerTest do
         }
       ]
 
-      get_pg_version = fn -> Application.fetch_env!(:electric, :major_pg_version_for_tests) end
+      get_pg_version = fn -> Application.fetch_env!(:electric, :pg_version_for_tests) end
 
       shape_cache_config =
         [

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -55,7 +55,7 @@ defmodule Support.ComponentSetup do
     shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
     server = :"shape_cache_#{full_test_name(ctx)}"
     consumer_supervisor = :"consumer_supervisor_#{full_test_name(ctx)}"
-    get_pg_version = fn -> Application.fetch_env!(:electric, :major_pg_version_for_tests) end
+    get_pg_version = fn -> Application.fetch_env!(:electric, :pg_version_for_tests) end
 
     start_opts =
       [

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -49,7 +49,7 @@ defmodule Support.DbSetup do
   end
 
   def with_pg_version(ctx) do
-    pg_version = Electric.ConnectionManager.query_pg_major_version(ctx.db_conn)
+    pg_version = Electric.ConnectionManager.query_pg_version(ctx.db_conn)
     {:ok, %{get_pg_version: fn -> pg_version end}}
   end
 


### PR DESCRIPTION
This PR fixes https://github.com/electric-sql/electric/issues/1712.
We were previously reading out `server_version` which is a string and were casting it to an integer in order to get PG's major version number. However, casting to integer does not work when the `server_version` is set to e.g. `16.4 (Debian 16.4-1.pgdg1123+1)` which some providers do. This PR changes this such that we no longer cast the string but instead read the version number from the `server_version_num` setting which is an integer (cf. https://pgpedia.info/s/server_version_num.html and https://pgpedia.info/s/server_version_num.html). 