### PR TITLE
feat (client): expose time at which client last synced with Electric sync service

### DIFF
--- a/.changeset/tricky-houses-burn.md
+++ b/.changeset/tricky-houses-burn.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": patch
+"@electric-sql/react": patch
+---
+
+Expose lastSyncedAt field in ShapeStream and Shape classes and in the useShape React hook.

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -70,6 +70,8 @@ export interface UseShapeResult<T extends Row = Row> {
   shape: Shape<T>
   /** True during initial fetch. False afterwise. */
   isLoading: boolean
+  /** Unix time at which we last synced. Undefined when `isLoading` is true. */
+  lastSyncedAt?: number
   error: Shape<T>[`error`]
   isError: boolean
 }
@@ -85,6 +87,7 @@ function parseShapeData<T extends Row>(shape: Shape<T>): UseShapeResult<T> {
   return {
     data: [...shape.valueSync.values()],
     isLoading: shape.isLoading(),
+    lastSyncedAt: shape.lastSyncedAt(),
     isError: shape.error !== false,
     shape,
     error: shape.error,

--- a/packages/react-hooks/test/react-hooks.test.tsx
+++ b/packages/react-hooks/test/react-hooks.test.tsx
@@ -76,6 +76,29 @@ describe(`useShape`, () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
   })
 
+  it(`should expose time at which we last synced`, async ({
+    issuesTableUrl,
+  }) => {
+    const { result } = renderHook(() =>
+      useShape({
+        url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+        fetchClient: async (input, init) => {
+          await sleep(50)
+          return fetch(input, init)
+        },
+      })
+    )
+
+    expect(result.current.lastSyncedAt).toBeUndefined()
+    const now = Date.now()
+
+    await sleep(150)
+
+    await waitFor(() => expect(result.current.lastSyncedAt).toBeDefined())
+
+    expect(result.current.lastSyncedAt).toBeGreaterThanOrEqual(now)
+  })
+
   it(`should keep the state value in sync`, async ({
     aborter,
     issuesTableUrl,

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -69,6 +69,7 @@ export interface ShapeStreamInterface<T extends Row = Row> {
   ): () => void
 
   isLoading(): boolean
+  lastSyncedAt(): number | undefined
   lastSynced(): number
   isConnected(): boolean
 
@@ -297,12 +298,18 @@ export class ShapeStream<T extends Row = Row>
     this.#upToDateSubscribers.clear()
   }
 
+  /** Unix time at which we last synced. Undefined when `isLoading` is true. */
+  lastSyncedAt(): number | undefined {
+    return this.#lastSyncedAt
+  }
+
   /** Time elapsed since last sync (in ms). Infinity if we did not yet sync. */
   lastSynced(): number {
     if (this.#lastSyncedAt === undefined) return Infinity
     return Date.now() - this.#lastSyncedAt
   }
 
+  /** Indicates if we are connected to the Electric sync service. */
   isConnected(): boolean {
     return this.#connected
   }

--- a/packages/typescript-client/src/shape.ts
+++ b/packages/typescript-client/src/shape.ts
@@ -91,14 +91,22 @@ export class Shape<T extends Row = Row> {
     return this.#error
   }
 
+  /** Unix time at which we last synced. Undefined when `isLoading` is true. */
+  lastSyncedAt(): number | undefined {
+    return this.#stream.lastSyncedAt()
+  }
+
+  /** Time elapsed since last sync (in ms). Infinity if we did not yet sync. */
   lastSynced() {
     return this.#stream.lastSynced()
   }
 
+  /** True during initial fetch. False afterwise.  */
   isLoading() {
     return this.#stream.isLoading()
   }
 
+  /** Indicates if we are connected to the Electric sync service. */
   isConnected(): boolean {
     return this.#stream.isConnected()
   }

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -16,6 +16,8 @@ describe(`Shape`, () => {
     const map = await shape.value
 
     expect(map).toEqual(new Map())
+    expect(shape.lastSyncedAt()).toBeGreaterThanOrEqual(start)
+    expect(shape.lastSyncedAt()).toBeLessThanOrEqual(Date.now())
     expect(shape.lastSynced()).toBeLessThanOrEqual(Date.now() - start)
   })
 
@@ -46,6 +48,8 @@ describe(`Shape`, () => {
     })
 
     expect(map).toEqual(expectedValue)
+    expect(shape.lastSyncedAt()).toBeGreaterThanOrEqual(start)
+    expect(shape.lastSyncedAt()).toBeLessThanOrEqual(Date.now())
     expect(shape.lastSynced()).toBeLessThanOrEqual(Date.now() - start)
   })
 
@@ -74,6 +78,8 @@ describe(`Shape`, () => {
       priority: 10,
     })
     expect(map).toEqual(expectedValue)
+    expect(shape.lastSyncedAt()).toBeGreaterThanOrEqual(start)
+    expect(shape.lastSyncedAt()).toBeLessThanOrEqual(Date.now())
     expect(shape.lastSynced()).toBeLessThanOrEqual(Date.now() - start)
 
     await sleep(100)
@@ -98,6 +104,8 @@ describe(`Shape`, () => {
       priority: 10,
     })
     expect(shape.valueSync).toEqual(expectedValue)
+    expect(shape.lastSyncedAt()).toBeGreaterThanOrEqual(intermediate)
+    expect(shape.lastSyncedAt()).toBeLessThanOrEqual(Date.now())
     expect(shape.lastSynced()).toBeLessThanOrEqual(Date.now() - intermediate)
 
     shape.unsubscribeAll()
@@ -211,6 +219,8 @@ describe(`Shape`, () => {
       priority: 10,
     })
     expect(value).toEqual(expectedValue)
+    expect(shape.lastSyncedAt()).toBeGreaterThanOrEqual(start)
+    expect(shape.lastSyncedAt()).toBeLessThanOrEqual(Date.now())
     expect(shape.lastSynced()).toBeLessThanOrEqual(Date.now() - start)
 
     shape.unsubscribeAll()

--- a/website/docs/api/integrations/react.md
+++ b/website/docs/api/integrations/react.md
@@ -11,7 +11,7 @@ Example usage in a component.
 import { useShape } from "@electric-sql/react"
 
 export default function MyComponent() {
-  const { isLoading, data } = useShape<{ title: string}>({
+  const { isLoading, lastSyncedAt, data } = useShape<{ title: string}>({
     url: `http://localhost:3000/v1/shape/foo`,
   })
 


### PR DESCRIPTION
This PR extends the client to expose a `lastSyncedAt` field which indicates the last time at which the client synced with Electric.