### PR TITLE
docs: document shape deletion on table drop

### DIFF
--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -173,3 +173,8 @@ You can upvote and discuss adding support for mutable shapes here:
 ... add links to benchmarks here ...
 
 -->
+
+### Dropping tables
+
+When dropping a table from Postgres you need to *manually* delete all shapes that are defined on that table.
+Electric doesn't automatically delete the shape because Postgres does not stream DDL statements (such as `DROP TABLE`) on the logical replication stream that Electric uses to detect changes.

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -177,4 +177,7 @@ You can upvote and discuss adding support for mutable shapes here:
 ### Dropping tables
 
 When dropping a table from Postgres you need to *manually* delete all shapes that are defined on that table.
-Electric doesn't automatically delete those shapes because Postgres does not stream DDL statements (such as `DROP TABLE`) on the logical replication stream that Electric uses to detect changes.
+This is especially important if you intend to recreate the table afterwards (possibly with a different schema) as the shape will still contain stale data from the old table.
+Therefore, recreating the table will only work if you first delete the shape.
+
+Electric does not yet automatically delete shapes when tables are dropped because Postgres does not stream DDL statements (such as `DROP TABLE`) on the logical replication stream that Electric uses to detect changes. However, we are actively exploring approaches for automated shape deletion in this [GitHub issue](https://github.com/electric-sql/electric/issues/1733).

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -177,7 +177,7 @@ You can upvote and discuss adding support for mutable shapes here:
 ### Dropping tables
 
 When dropping a table from Postgres you need to *manually* delete all shapes that are defined on that table.
-This is especially important if you intend to recreate the table afterwards (possibly with a different schema) as the shape will still contain stale data from the old table.
-Therefore, recreating the table will only work if you first delete the shape.
+This is especially important if you intend to recreate the table afterwards (possibly with a different schema) as the shape will contain stale data from the old table.
+Therefore, recreating the table only works if you first delete the shape.
 
 Electric does not yet automatically delete shapes when tables are dropped because Postgres does not stream DDL statements (such as `DROP TABLE`) on the logical replication stream that Electric uses to detect changes. However, we are actively exploring approaches for automated shape deletion in this [GitHub issue](https://github.com/electric-sql/electric/issues/1733).

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -177,4 +177,4 @@ You can upvote and discuss adding support for mutable shapes here:
 ### Dropping tables
 
 When dropping a table from Postgres you need to *manually* delete all shapes that are defined on that table.
-Electric doesn't automatically delete the shape because Postgres does not stream DDL statements (such as `DROP TABLE`) on the logical replication stream that Electric uses to detect changes.
+Electric doesn't automatically delete those shapes because Postgres does not stream DDL statements (such as `DROP TABLE`) on the logical replication stream that Electric uses to detect changes.

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -302,8 +302,7 @@ paths:
         This clears the shape log and forces any clients requesting the shape
         to create a new shape and resync from scratch.
 
-        **WARNING** Delete shape should only be used in development and only works
-        if Electric is configured to `allow_shape_deletion`.
+        **NOTE** Delete shape only works if Electric is configured to `allow_shape_deletion`.
       parameters:
         # Path parameters
         - name: root_table


### PR DESCRIPTION
Extend the shape docs to explain that shapes are not deleted automatically when tables are dropped.
Fixes https://github.com/electric-sql/electric/issues/1706.