### PR TITLE
chore!: remove x- prefix from custom HTTP headers

### DIFF
--- a/.changeset/lucky-crabs-lie.md
+++ b/.changeset/lucky-crabs-lie.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": minor
+"@core/sync-service": minor
+---
+
+Rename Electric's custom HTTP headers to remove the x- prefix.

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -202,7 +202,7 @@ defmodule Electric.Plug.ServeShapePlug do
     conn
     |> assign(:active_shape_id, active_shape_id)
     |> assign(:last_offset, last_offset)
-    |> put_resp_header("x-electric-shape-id", active_shape_id)
+    |> put_resp_header("electric-shape-id", active_shape_id)
   end
 
   defp handle_shape_info(
@@ -225,7 +225,7 @@ defmodule Electric.Plug.ServeShapePlug do
       # TODO: discuss returning a 307 redirect rather than a 409, the client
       # will have to detect this and throw out old data
       conn
-      |> put_resp_header("x-electric-shape-id", active_shape_id)
+      |> put_resp_header("electric-shape-id", active_shape_id)
       |> put_resp_header(
         "location",
         "#{conn.request_path}?shape_id=#{active_shape_id}&offset=-1"
@@ -246,7 +246,7 @@ defmodule Electric.Plug.ServeShapePlug do
   # Only adds schema header when not in live mode
   defp put_schema_header(conn, _) when not conn.assigns.live do
     shape = conn.assigns.shape_definition
-    put_resp_header(conn, "x-electric-schema", schema(shape))
+    put_resp_header(conn, "electric-schema", schema(shape))
   end
 
   defp put_schema_header(conn, _), do: conn
@@ -261,7 +261,7 @@ defmodule Electric.Plug.ServeShapePlug do
 
     conn
     |> assign(:chunk_end_offset, chunk_end_offset)
-    |> put_resp_header("x-electric-chunk-last-offset", "#{chunk_end_offset}")
+    |> put_resp_header("electric-chunk-last-offset", "#{chunk_end_offset}")
   end
 
   defp generate_etag(%Conn{} = conn, _) do
@@ -477,7 +477,7 @@ defmodule Electric.Plug.ServeShapePlug do
         |> assign(:last_offset, latest_log_offset)
         |> assign(:chunk_end_offset, latest_log_offset)
         # update last offset header
-        |> put_resp_header("x-electric-chunk-last-offset", "#{latest_log_offset}")
+        |> put_resp_header("electric-chunk-last-offset", "#{latest_log_offset}")
         |> serve_log_or_snapshot([])
 
       {^ref, :shape_rotation} ->

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -618,8 +618,8 @@ defmodule Electric.Plug.RouterTest do
 
       conn = conn("GET", "/v1/shape/large_rows_table?offset=-1") |> Router.call(opts)
       assert %{status: 200} = conn
-      [shape_id] = Plug.Conn.get_resp_header(conn, "x-electric-shape-id")
-      [next_offset] = Plug.Conn.get_resp_header(conn, "x-electric-chunk-last-offset")
+      [shape_id] = Plug.Conn.get_resp_header(conn, "electric-shape-id")
+      [next_offset] = Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset")
 
       assert [_] = Jason.decode!(conn.resp_body)
 
@@ -660,7 +660,7 @@ defmodule Electric.Plug.RouterTest do
                }
              ] = Jason.decode!(conn.resp_body)
 
-      [next_offset] = Plug.Conn.get_resp_header(conn, "x-electric-chunk-last-offset")
+      [next_offset] = Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset")
 
       conn =
         conn("GET", "/v1/shape/large_rows_table?offset=#{next_offset}&shape_id=#{shape_id}")
@@ -695,7 +695,7 @@ defmodule Electric.Plug.RouterTest do
       assert conn.resp_body != ""
 
       shape_id = get_resp_shape_id(conn)
-      [next_offset] = Plug.Conn.get_resp_header(conn, "x-electric-chunk-last-offset")
+      [next_offset] = Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset")
 
       # Make the next request but forget to include the where clause
       conn =
@@ -717,7 +717,7 @@ defmodule Electric.Plug.RouterTest do
 
       assert %{status: 409} = conn
       assert conn.resp_body == Jason.encode!([%{headers: %{control: "must-refetch"}}])
-      new_shape_id = get_resp_header(conn, "x-electric-shape-id")
+      new_shape_id = get_resp_header(conn, "electric-shape-id")
 
       assert get_resp_header(conn, "location") ==
                "/v1/shape/items?shape_id=#{new_shape_id}&offset=-1"
@@ -746,7 +746,7 @@ defmodule Electric.Plug.RouterTest do
         |> Router.call(opts)
 
       assert %{status: 409} = conn
-      [^shape_id] = Plug.Conn.get_resp_header(conn, "x-electric-shape-id")
+      [^shape_id] = Plug.Conn.get_resp_header(conn, "electric-shape-id")
     end
 
     @tag with_sql: [
@@ -797,8 +797,8 @@ defmodule Electric.Plug.RouterTest do
     end
   end
 
-  defp get_resp_shape_id(conn), do: get_resp_header(conn, "x-electric-shape-id")
-  defp get_resp_last_offset(conn), do: get_resp_header(conn, "x-electric-chunk-last-offset")
+  defp get_resp_shape_id(conn), do: get_resp_header(conn, "electric-shape-id")
+  defp get_resp_last_offset(conn), do: get_resp_header(conn, "electric-chunk-last-offset")
 
   defp get_resp_header(conn, header) do
     assert [val] = Plug.Conn.get_resp_header(conn, header)

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -141,7 +141,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
                "#{@test_shape_id}:-1:#{next_offset}"
              ]
 
-      assert Plug.Conn.get_resp_header(conn, "x-electric-shape-id") == [@test_shape_id]
+      assert Plug.Conn.get_resp_header(conn, "electric-shape-id") == [@test_shape_id]
     end
 
     test "snapshot has correct cache control headers" do
@@ -208,7 +208,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         conn(:get, %{"root_table" => "public.users"}, "?offset=-1")
         |> ServeShapePlug.call([])
 
-      assert Plug.Conn.get_resp_header(conn, "x-electric-schema") == [
+      assert Plug.Conn.get_resp_header(conn, "electric-schema") == [
                ~s|{"id":{"type":"int8","pk_index":0}}|
              ]
     end
@@ -264,9 +264,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
                "#{@test_shape_id}:#{@start_offset_50}:#{next_next_offset}"
              ]
 
-      assert Plug.Conn.get_resp_header(conn, "x-electric-shape-id") == [@test_shape_id]
+      assert Plug.Conn.get_resp_header(conn, "electric-shape-id") == [@test_shape_id]
 
-      assert Plug.Conn.get_resp_header(conn, "x-electric-chunk-last-offset") == [
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset") == [
                "#{next_next_offset}"
              ]
     end
@@ -357,8 +357,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
                "max-age=5, stale-while-revalidate=5"
              ]
 
-      assert Plug.Conn.get_resp_header(conn, "x-electric-chunk-last-offset") == [next_offset_str]
-      assert Plug.Conn.get_resp_header(conn, "x-electric-schema") == []
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset") == [next_offset_str]
+      assert Plug.Conn.get_resp_header(conn, "electric-schema") == []
     end
 
     test "handles shape rotation" do
@@ -463,7 +463,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert conn.status == 409
 
       assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "must-refetch"}}]
-      assert get_resp_header(conn, "x-electric-shape-id") == [@test_shape_id]
+      assert get_resp_header(conn, "electric-shape-id") == [@test_shape_id]
       assert get_resp_header(conn, "location") == ["/?shape_id=#{@test_shape_id}&offset=-1"]
     end
 
@@ -491,7 +491,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert conn.status == 409
 
       assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "must-refetch"}}]
-      assert get_resp_header(conn, "x-electric-shape-id") == [new_shape_id]
+      assert get_resp_header(conn, "electric-shape-id") == [new_shape_id]
       assert get_resp_header(conn, "location") == ["/?shape_id=#{new_shape_id}&offset=-1"]
     end
 

--- a/packages/typescript-client/src/constants.ts
+++ b/packages/typescript-client/src/constants.ts
@@ -1,6 +1,6 @@
-export const SHAPE_ID_HEADER = `x-electric-shape-id`
-export const CHUNK_LAST_OFFSET_HEADER = `x-electric-chunk-last-offset`
-export const SHAPE_SCHEMA_HEADER = `x-electric-schema`
+export const SHAPE_ID_HEADER = `electric-shape-id`
+export const CHUNK_LAST_OFFSET_HEADER = `electric-chunk-last-offset`
+export const SHAPE_SCHEMA_HEADER = `electric-schema`
 export const SHAPE_ID_QUERY_PARAM = `shape_id`
 export const OFFSET_QUERY_PARAM = `offset`
 export const WHERE_QUERY_PARAM = `where`

--- a/packages/typescript-client/test/cache.test.ts
+++ b/packages/typescript-client/test/cache.test.ts
@@ -81,8 +81,8 @@ describe(`HTTP Proxy Cache`, { timeout: 30000 }, () => {
     // add some data and follow with live request
     await insertIssues({ title: `foo` })
     const searchParams = new URLSearchParams({
-      offset: initialRes.headers.get(`x-electric-chunk-last-offset`)!,
-      shape_id: initialRes.headers.get(`x-electric-shape-id`)!,
+      offset: initialRes.headers.get(`electric-chunk-last-offset`)!,
+      shape_id: initialRes.headers.get(`electric-shape-id`)!,
       live: `true`,
     })
 
@@ -215,7 +215,7 @@ describe(`HTTP Initial Data Caching`, { timeout: 30000 }, () => {
     )
     expect(client1Res.status).toBe(200)
     const originalShapeId =
-      client1Res.headers.get(`x-electric-shape-id`) ?? undefined
+      client1Res.headers.get(`electric-shape-id`) ?? undefined
     assert(originalShapeId, `Should have shape ID`)
     expect(getCacheStatus(client1Res)).toBe(CacheStatus.MISS)
     //const messages = client1Res.status === 204 ? [] : await client1Res.json()
@@ -227,7 +227,7 @@ describe(`HTTP Initial Data Caching`, { timeout: 30000 }, () => {
       {}
     )
     expect(client2Res.status).toBe(200)
-    const shapeId2 = client2Res.headers.get(`x-electric-shape-id`) ?? undefined
+    const shapeId2 = client2Res.headers.get(`electric-shape-id`) ?? undefined
 
     expect(
       originalShapeId,
@@ -236,7 +236,7 @@ describe(`HTTP Initial Data Caching`, { timeout: 30000 }, () => {
 
     expect(getCacheStatus(client2Res)).toBe(CacheStatus.HIT)
 
-    const latestOffset = client2Res.headers.get(`x-electric-chunk-last-offset`)
+    const latestOffset = client2Res.headers.get(`electric-chunk-last-offset`)
     assert(latestOffset, `latestOffset should be defined`)
 
     // Now GC the shape
@@ -261,7 +261,7 @@ describe(`HTTP Initial Data Caching`, { timeout: 30000 }, () => {
     expect(newCacheIgnoredSyncRes.status).toBe(200)
     expect(getCacheStatus(newCacheIgnoredSyncRes)).toBe(CacheStatus.MISS)
     const cacheBustedShapeId =
-      newCacheIgnoredSyncRes.headers.get(`x-electric-shape-id`)
+      newCacheIgnoredSyncRes.headers.get(`electric-shape-id`)
     assert(cacheBustedShapeId)
     expect(cacheBustedShapeId).not.toBe(originalShapeId)
 
@@ -271,7 +271,7 @@ describe(`HTTP Initial Data Caching`, { timeout: 30000 }, () => {
       {}
     )
     const cachedShapeId =
-      newInitialSyncRes.headers.get(`x-electric-shape-id`) ?? undefined
+      newInitialSyncRes.headers.get(`electric-shape-id`) ?? undefined
     expect(newInitialSyncRes.status).toBe(200)
     expect(getCacheStatus(newInitialSyncRes)).toBe(CacheStatus.HIT)
     expect(cachedShapeId, `Got old shape id that is out of scope`).not.toBe(

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -115,7 +115,7 @@ describe(`HTTP Sync`, () => {
       `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
       {}
     )
-    const shapeId = res.headers.get(`x-electric-shape-id`)
+    const shapeId = res.headers.get(`electric-shape-id`)
     expect(shapeId).to.exist
   })
 
@@ -126,7 +126,7 @@ describe(`HTTP Sync`, () => {
       `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=-1`,
       {}
     )
-    const lastOffset = res.headers.get(`x-electric-chunk-last-offset`)
+    const lastOffset = res.headers.get(`electric-chunk-last-offset`)
     expect(lastOffset).to.exist
   })
 
@@ -537,7 +537,7 @@ describe(`HTTP Sync`, () => {
     const midMessage = messages.slice(-6)[0]
     assert(`offset` in midMessage)
     const midOffset = midMessage.offset
-    const shapeId = res.headers.get(`x-electric-shape-id`)
+    const shapeId = res.headers.get(`electric-shape-id`)
     const etag = res.headers.get(`etag`)
     assert(etag !== null, `Response should have etag header`)
 


### PR DESCRIPTION
This PR removes the x- prefix from Electric's custom headers, as essentially the x- prefix has been deprecated for a while. **This is a breaking change** as it changes the names of the headers. Fixes https://github.com/electric-sql/electric/issues/1737.