### PR TITLE
feat: Chunk prefetching in `ShapeStream`

### DIFF
--- a/.changeset/metal-horses-call.md
+++ b/.changeset/metal-horses-call.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add `electric-chunk-up-to-date` header to up-to-date responses for optimizing caching and prefetching.

--- a/.changeset/warm-grapes-brush.md
+++ b/.changeset/warm-grapes-brush.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Implement configurable chunk prefetching to `ShapeStream` to accelerate stream consumption.

--- a/.support/docker-compose.yml
+++ b/.support/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - config_file=/etc/postgresql/postgresql.conf
 
   backend:
-    image: electricsql/electric:latest
+    image: electricsql/electric:canary
     environment:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/electric
     ports:

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -274,6 +274,8 @@ defmodule Electric.Plug.ServeShapePlug do
     if LogOffset.compare(chunk_end_offset, last_offset) == :lt do
       conn
       |> assign(:up_to_date, [])
+      # header might have been added on first pass but no longer valid
+      # if listening to live changes and an incomplete chunk is formed
       |> delete_resp_header("electric-chunk-up-to-date")
     else
       conn

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -128,6 +128,7 @@ defmodule Electric.Plug.ServeShapePlug do
   # asked for last offset
   plug :listen_for_new_changes
   plug :determine_log_chunk_offset
+  plug :determine_up_to_date
   plug :generate_etag
   plug :validate_and_put_etag
   plug :put_resp_cache_headers
@@ -264,6 +265,23 @@ defmodule Electric.Plug.ServeShapePlug do
     |> put_resp_header("electric-chunk-last-offset", "#{chunk_end_offset}")
   end
 
+  defp determine_up_to_date(
+         %Conn{
+           assigns: %{chunk_end_offset: chunk_end_offset, last_offset: last_offset}
+         } = conn,
+         _
+       ) do
+    if LogOffset.compare(chunk_end_offset, last_offset) == :lt do
+      conn
+      |> assign(:up_to_date, [])
+      |> delete_resp_header("electric-chunk-up-to-date")
+    else
+      conn
+      |> assign(:up_to_date, [@up_to_date])
+      |> put_resp_header("electric-chunk-up-to-date", "true")
+    end
+  end
+
   defp generate_etag(%Conn{} = conn, _) do
     %{
       offset: offset,
@@ -328,7 +346,8 @@ defmodule Electric.Plug.ServeShapePlug do
            assigns: %{
              offset: @before_all_offset,
              chunk_end_offset: chunk_end_offset,
-             active_shape_id: shape_id
+             active_shape_id: shape_id,
+             up_to_date: maybe_up_to_date
            }
          } = conn,
          _
@@ -346,7 +365,7 @@ defmodule Electric.Plug.ServeShapePlug do
                   up_to: chunk_end_offset
                 )
 
-              [snapshot, log, maybe_up_to_date(conn)]
+              [snapshot, log, maybe_up_to_date]
               |> Stream.concat()
               |> to_json_stream()
               |> Stream.chunk_every(500)
@@ -372,7 +391,8 @@ defmodule Electric.Plug.ServeShapePlug do
            assigns: %{
              offset: offset,
              chunk_end_offset: chunk_end_offset,
-             active_shape_id: shape_id
+             active_shape_id: shape_id,
+             up_to_date: maybe_up_to_date
            }
          } = conn,
          _
@@ -390,7 +410,7 @@ defmodule Electric.Plug.ServeShapePlug do
         if Enum.take(log, 1) == [] and conn.assigns.live do
           hold_until_change(conn, shape_id)
         else
-          [log, maybe_up_to_date(conn)]
+          [log, maybe_up_to_date]
           |> Stream.concat()
           |> to_json_stream()
           |> Stream.chunk_every(500)
@@ -437,16 +457,6 @@ defmodule Electric.Plug.ServeShapePlug do
     end)
   end
 
-  defp maybe_up_to_date(%Conn{
-         assigns: %{chunk_end_offset: chunk_end_offset, last_offset: last_offset}
-       }) do
-    if LogOffset.compare(chunk_end_offset, last_offset) == :lt do
-      []
-    else
-      [@up_to_date]
-    end
-  end
-
   defp listen_for_new_changes(%Conn{} = conn, _) when not conn.assigns.live, do: conn
 
   defp listen_for_new_changes(%Conn{assigns: assigns} = conn, _) do
@@ -478,6 +488,7 @@ defmodule Electric.Plug.ServeShapePlug do
         |> assign(:chunk_end_offset, latest_log_offset)
         # update last offset header
         |> put_resp_header("electric-chunk-last-offset", "#{latest_log_offset}")
+        |> determine_up_to_date([])
         |> serve_log_or_snapshot([])
 
       {^ref, :shape_rotation} ->

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -280,7 +280,7 @@ defmodule Electric.Plug.ServeShapePlug do
     else
       conn
       |> assign(:up_to_date, [@up_to_date])
-      |> put_resp_header("electric-chunk-up-to-date", "true")
+      |> put_resp_header("electric-chunk-up-to-date", "")
     end
   end
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -269,6 +269,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset") == [
                "#{next_next_offset}"
              ]
+
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == []
     end
 
     test "returns 304 Not Modified when If-None-Match matches ETag" do
@@ -358,6 +360,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset") == [next_offset_str]
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == ["true"]
       assert Plug.Conn.get_resp_header(conn, "electric-schema") == []
     end
 
@@ -406,6 +409,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       assert conn.status == 200
       assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "up-to-date"}}]
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == ["true"]
     end
 
     test "sends an up-to-date response after a timeout if no changes are observed" do
@@ -440,6 +444,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Plug.Conn.get_resp_header(conn, "cache-control") == [
                "max-age=5, stale-while-revalidate=5"
              ]
+
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == ["true"]
     end
 
     test "sends 409 with a redirect to existing shape when requested shape ID does not exist" do

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -360,7 +360,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset") == [next_offset_str]
-      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == ["true"]
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == [""]
       assert Plug.Conn.get_resp_header(conn, "electric-schema") == []
     end
 
@@ -409,7 +409,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       assert conn.status == 200
       assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "up-to-date"}}]
-      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == ["true"]
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == [""]
     end
 
     test "sends an up-to-date response after a timeout if no changes are observed" do
@@ -445,7 +445,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
                "max-age=5, stale-while-revalidate=5"
              ]
 
-      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == ["true"]
+      assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == [""]
     end
 
     test "sends 409 with a redirect to existing shape when requested shape ID does not exist" do

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -154,11 +154,7 @@ export class ShapeStream<T extends Row = Row>
       },
     })
 
-    const fetchWithPrefetchAndBAckoffClient = createFetchWithChunkBuffer(
-      fetchWithBackoffClient
-    )
-
-    this.#fetchClient = fetchWithPrefetchAndBAckoffClient
+    this.#fetchClient = createFetchWithChunkBuffer(fetchWithBackoffClient)
 
     this.start()
   }

--- a/packages/typescript-client/src/constants.ts
+++ b/packages/typescript-client/src/constants.ts
@@ -1,5 +1,6 @@
 export const SHAPE_ID_HEADER = `electric-shape-id`
 export const CHUNK_LAST_OFFSET_HEADER = `electric-chunk-last-offset`
+export const CHUNK_UP_TO_DATE_HEADER = `electric-chunk-up-to-date`
 export const SHAPE_SCHEMA_HEADER = `electric-schema`
 export const SHAPE_ID_QUERY_PARAM = `shape_id`
 export const OFFSET_QUERY_PARAM = `offset`

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -205,12 +205,10 @@ class PrefetchQueue {
     const aborter = new AbortController()
 
     try {
-      const request =
-        this.#prefetchQueue.get(url)?.[0] ??
-        this.#fetchClient(url, {
-          ...(args[1] ?? {}),
-          signal: chainAborter(aborter, args[1]?.signal),
-        })
+      const request = this.#fetchClient(url, {
+        ...(args[1] ?? {}),
+        signal: chainAborter(aborter, args[1]?.signal),
+      })
       this.#prefetchQueue.set(url, [request, aborter])
       request
         .then((response) => {

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -154,7 +154,9 @@ class PrefetchQueue {
     maxPrefetchedRequests: number
     fetchClient?: typeof fetch
   }) {
-    this.#fetchClient = options.fetchClient ?? ((...args) => fetch(...args))
+    this.#fetchClient =
+      options.fetchClient ??
+      ((...args: Parameters<typeof fetch>) => fetch(...args))
     this.#maxPrefetchedRequests = options.maxPrefetchedRequests
     this.#queueHeadUrl = options.url.toString()
     this.#queueTailUrl = this.#queueHeadUrl

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -117,8 +117,11 @@ export function createFetchWithChunkBuffer(
     // try to consume from the prefetch queue first, and if request is
     // not present abort the prefetch queue as it must no longer be valid
     const prefetchedRequest = prefetchQueue?.consume(...args)
-    if (prefetchedRequest) return prefetchedRequest
-    else prefetchQueue?.abort()
+    if (prefetchedRequest) {
+      return prefetchedRequest
+    }
+
+    prefetchQueue?.abort()
 
     // perform request and fire off prefetch queue if request is eligible
     const response = await fetchClient(...args)

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -196,6 +196,9 @@ function chainAborter(
 ): AbortSignal {
   if (!sourceSignal) return aborter.signal
   if (sourceSignal.aborted) aborter.abort()
-  else sourceSignal.addEventListener(`abort`, () => aborter.abort())
+  else
+    sourceSignal.addEventListener(`abort`, () => aborter.abort(), {
+      once: true,
+    })
   return aborter.signal
 }

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -172,7 +172,8 @@ export function createFetchWithChunkBuffer(
     }
 
     // otherwise clear current prefetched responses (and abort active requests)
-    // and start again
+    // and start again, as request that came in does not belong on the current
+    // "prefetch chain" and should start a new chain instead (e.g. shape rotation)
     prefetchMap.clear()
     prefetchAborter.abort()
     prefetchAborter = new AbortController()

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -152,8 +152,8 @@ describe(`Shape`, () => {
         rotationTime = Date.now()
       }
 
-      const response = await fetch(...args)
       requestsMade++
+      const response = await fetch(...args)
       return response
     }
 

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -95,7 +95,7 @@ describe(`Shape`, () => {
     await deleteIssue({ id: id3, title: `other title2` })
     // Test an update too because we're sending patches that should be correctly merged in
     await updateIssue({ id: id2, title: `new title` })
-    await sleep(100) // some time for electric to catch up
+    await sleep(200) // some time for electric to catch up
     await hasNotified
 
     expectedValue.set(`${issuesTableKey}/"${id2}"`, {
@@ -325,7 +325,7 @@ describe(`Shape`, () => {
 
     expect(shapeStream.isLoading()).true
 
-    await sleep(100) // give some time for the initial fetch to complete
+    await sleep(200) // give some time for the initial fetch to complete
 
     expect(shapeStream.isLoading()).false
   })

--- a/packages/typescript-client/test/fetch.test.ts
+++ b/packages/typescript-client/test/fetch.test.ts
@@ -173,7 +173,7 @@ describe(`createFetchWithChunkBuffer`, () => {
     const result = await fetchWrapper(baseUrl)
     expect(result).toBe(mockResponse)
     expect(mockFetch).toHaveBeenCalledTimes(1)
-    expect(mockFetch).toHaveBeenCalledWith(baseUrl, expect.anything())
+    expect(mockFetch).toHaveBeenCalledWith(baseUrl)
   })
 
   it(`should prefetch the next chunk when headers are present`, async () => {
@@ -322,7 +322,7 @@ describe(`createFetchWithChunkBuffer`, () => {
     expect(mockFetch).toHaveBeenCalledTimes(5)
 
     // should have called the base + prefetch of base
-    expect(mockFetch).toHaveBeenNthCalledWith(1, baseUrl, expect.anything())
+    expect(mockFetch).toHaveBeenNthCalledWith(1, baseUrl)
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
       `${baseUrl}?shape_id=123&offset=0`,
@@ -330,7 +330,7 @@ describe(`createFetchWithChunkBuffer`, () => {
     )
 
     // once interrupted it should have called the alt + the 2 prefetches
-    expect(mockFetch).toHaveBeenNthCalledWith(3, altUrl, expect.anything())
+    expect(mockFetch).toHaveBeenNthCalledWith(3, altUrl)
     expect(mockFetch).toHaveBeenNthCalledWith(
       4,
       `${altUrl}?shape_id=123&offset=2`,

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -761,16 +761,19 @@ describe(`HTTP Sync`, () => {
     await insertIssues({ id: rowId, title: `foo1` })
 
     const statusCodesReceived: number[] = []
+    let numRequests = 0
 
     const fetchWrapper = async (...args: Parameters<typeof fetch>) => {
       // before any subsequent requests after the initial one, ensure
       // that the existing shape is deleted and some more data is inserted
-      if (statusCodesReceived.length === 1 && statusCodesReceived[0] === 200) {
+      if (numRequests === 1) {
         await insertIssues({ id: secondRowId, title: `foo2` })
         await clearIssuesShape(issueStream.shapeId)
       }
 
+      numRequests++
       const response = await fetch(...args)
+
       if (response.status < 500) {
         statusCodesReceived.push(response.status)
       }

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -396,20 +396,22 @@ describe(`HTTP Sync`, () => {
       fetchClient: fetchWrapper,
     })
 
+    let numFetchCalls = 0
+
     await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
       if (!isChangeMessage(msg)) return
       shapeData.set(msg.key, msg.value)
 
       if (nth === 0) {
-        expect(fetchWrapper).toHaveBeenCalledTimes(1)
+        numFetchCalls = fetchWrapper.mock.calls.length
 
         // ensure fetch has not been called again while
         // waiting for processing
         await insertIssues({ title: `foo1` })
         await sleep(100)
-        expect(fetchWrapper).toHaveBeenCalledTimes(1)
+        expect(fetchWrapper).toHaveBeenCalledTimes(numFetchCalls)
       } else if (nth === 1) {
-        expect(fetchWrapper).toHaveBeenCalledTimes(2)
+        expect(fetchWrapper.mock.calls.length).greaterThan(numFetchCalls)
         res()
       }
     })

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -403,6 +403,7 @@ describe(`HTTP Sync`, () => {
       shapeData.set(msg.key, msg.value)
 
       if (nth === 0) {
+        await sleep(100)
         numFetchCalls = fetchWrapper.mock.calls.length
 
         // ensure fetch has not been called again while


### PR DESCRIPTION
Followup to https://github.com/electric-sql/electric/pull/1731

Implemented a fetch wrapper that does not wait for the chunk bodies to be streamed to the client and processed by the subscribers, and instead prefetches a number of chunks from the network as soon as the available headers to determine the next chunk are available.

I also had to implement another response header on our api called `electric-chunk-up-to-date`, similarly to how we use `electric-chunk-last-offset`, which allows us to know all the necessary chunk metadata without having to read the actual body. If we do not know if a chunk is an `up-to-date` chunk, we don't know whether we should request the next one, and whether its caching policy should be adjusted on the CDN.

I've set the default for prefetching to 2 chunks, but we could increase this to the most commen [maximum browser connections to the same domain](https://www.geeksforgeeks.org/what-are-max-parallel-http-connections-in-a-browser/) in order to maximise parallelization.