### PR TITLE
feat(sync-service): Support listening on IPv6 network interfaces

### DIFF
--- a/.changeset/kind-turkeys-reply.md
+++ b/.changeset/kind-turkeys-reply.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add LISTEN_ON_IPV6=true|false configuration option to support IPv6 network interfaces.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -92,6 +92,8 @@ else
   config :electric, connection_opts: connection_opts, electric_instance_id: electric_instance_id
 end
 
+config :electric, listen_on_ipv6?: env!("LISTEN_ON_IPV6", :boolean, false)
+
 enable_integration_testing = env!("ENABLE_INTEGRATION_TESTING", :boolean, false)
 cache_max_age = env!("CACHE_MAX_AGE", :integer, 60)
 cache_stale_age = env!("CACHE_STALE_AGE", :integer, 60 * 5)

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -108,7 +108,8 @@ defmodule Electric.Application do
                 max_age: Application.fetch_env!(:electric, :cache_max_age),
                 stale_age: Application.fetch_env!(:electric, :cache_stale_age),
                 allow_shape_deletion: Application.get_env(:electric, :allow_shape_deletion, false)},
-             port: 3000}
+             port: 3000,
+             thousand_island_options: http_listener_options()}
           ]
           |> add_prometheus_router(Application.fetch_env!(:electric, :prometheus_port))
         else
@@ -129,8 +130,18 @@ defmodule Electric.Application do
       [
         {
           Bandit,
-          plug: {Electric.Plug.UtilityRouter, []}, port: port
+          plug: {Electric.Plug.UtilityRouter, []},
+          port: port,
+          thousand_island_options: http_listener_options()
         }
       ]
+  end
+
+  defp http_listener_options do
+    if Application.get_env(:electric, :listen_on_ipv6?, false) do
+      [transport_options: [:inet6]]
+    else
+      []
+    end
   end
 end


### PR DESCRIPTION
Closes #1751.

Electric can be configured to listen on the `:::` IPv6 address, as opposed to the default `0.0.0.0` IPv4 one, by configuring it with `LISTEN_ON_IPV6=true`.