### PR TITLE
feat(sync-service): Move WHERE clause evaluation to single process

### DIFF
--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -91,11 +91,7 @@ defmodule Electric.Shapes.Consumer do
   defp selector(%Transaction{changes: changes}, shape) do
     changes
     |> Stream.flat_map(&Shape.convert_change(shape, &1))
-    |> Enum.take(1)
-    |> case do
-      [] -> false
-      [_] -> true
-    end
+    |> Enum.any?()
   end
 
   defp selector(_, _), do: false


### PR DESCRIPTION
This is the simplest change to meet the criteria of #1744 .

It's faster and uses less memory:
<img width="795" alt="Screenshot 2024-10-10 at 13 48 21" src="https://github.com/user-attachments/assets/a508d078-9cbd-4610-babb-909d66de682e">

Than our current version:
<img width="790" alt="Screenshot 2024-10-10 at 13 48 38" src="https://github.com/user-attachments/assets/a1a0d0da-39fd-4201-b468-5aa64a649120">

Because of the reduction in memory use it can handle bigger transactions at 100k shapes:
<img width="824" alt="Screenshot 2024-10-10 at 13 36 12" src="https://github.com/user-attachments/assets/da0a62f8-97c6-4dee-b63b-a8222ed54856">

vs our la
<img width="822" alt="Screenshot 2024-10-10 at 13 35 59" src="https://github.com/user-attachments/assets/2f7aec8b-e840-49ba-b4b7-2d4733b264f9">
test version:
