### PR TITLE
fix: Handle replication slot conflicts

### DIFF
--- a/.changeset/poor-candles-fly.md
+++ b/.changeset/poor-candles-fly.md
@@ -1,0 +1,6 @@
+---
+"@core/sync-service": patch
+---
+
+- Wait for advisory lock on replication slot to enable rolling deploys.
+- Configurable replication slot and publication name using `REPLICATION_STREAM_ID` environment variable.

--- a/.changeset/poor-candles-fly.md
+++ b/.changeset/poor-candles-fly.md
@@ -4,4 +4,4 @@
 
 - Wait for advisory lock on replication slot to enable rolling deploys.
 - Configurable replication slot and publication name using `REPLICATION_STREAM_ID` environment variable.
-- Add `HealthCheckPlug` API endopint at `v1/health` that returns `waiting`, `starting`, `active`, and `stopping` statuses.
+- Add `HealthCheckPlug` API endopint at `v1/health` that returns `waiting`, `starting`,and `active` statuses.

--- a/.changeset/poor-candles-fly.md
+++ b/.changeset/poor-candles-fly.md
@@ -4,3 +4,4 @@
 
 - Wait for advisory lock on replication slot to enable rolling deploys.
 - Configurable replication slot and publication name using `REPLICATION_STREAM_ID` environment variable.
+- Add `HealthCheckPlug` API endopint at `v1/health` that returns `waiting`, `starting`, `active`, and `stopping` statuses.

--- a/integration-tests/tests/crash-recovery.lux
+++ b/integration-tests/tests/crash-recovery.lux
@@ -1,0 +1,67 @@
+[doc Verify handling of an Electric crash recovery]
+
+[include macros.luxinc]
+
+[global pg_container_name=crash-recovery__pg]
+
+###
+
+## Start a new Postgres cluster
+[invoke setup_pg "" ""]
+
+## Add some data
+[invoke start_psql]
+[shell psql]
+  """!
+  CREATE TABLE items (
+    id UUID PRIMARY KEY,
+    val TEXT
+  );
+  """
+  ??CREATE TABLE
+
+  """!
+  INSERT INTO
+    items (id, val)
+  SELECT
+    gen_random_uuid(),
+    '#' || generate_series || ' test val'
+  FROM
+    generate_series(1, 10);
+  """
+  ??INSERT 0 10
+
+## Start the sync service.
+[invoke setup_electric]
+
+[shell electric]
+  ??[info] Starting replication from postgres
+  
+# Initialize a shape and collect the offset
+[shell client]
+  # strip ANSI codes from response for easier matching
+  !curl -I http://localhost:3000/v1/shape/items?offset=-1 | sed 's/\x1b\[[0-9;]*m//g'
+  ?electric-shape-id: ([\d-]+)
+  [local shape_id=$1]
+  ?electric-chunk-last-offset: ([\w\d_]+)
+  [local last_offset=$1]
+
+## Terminate electric after giving it some time to create the shape
+[shell electric]
+  ?Txn received
+  [sleep 2]
+  !System.halt()
+  ??$PS1
+
+## Start the sync service again.
+[invoke setup_electric]
+[shell electric]
+  ??[info] Starting replication from postgres
+
+# Client should be able to continue same shape
+[shell client]
+  !curl -I "http://localhost:3000/v1/shape/items?offset=$last_offset&shape_id=$shape_id"
+  ??HTTP/1.1 200 OK
+
+[cleanup]
+  [invoke teardown]

--- a/integration-tests/tests/crash-recovery.lux
+++ b/integration-tests/tests/crash-recovery.lux
@@ -40,16 +40,14 @@
 # Initialize a shape and collect the offset
 [shell client]
   # strip ANSI codes from response for easier matching
-  !curl -I http://localhost:3000/v1/shape/items?offset=-1 | sed 's/\x1b\[[0-9;]*m//g'
+  !curl -v -X GET http://localhost:3000/v1/shape/items?offset=-1
   ?electric-shape-id: ([\d-]+)
   [local shape_id=$1]
   ?electric-chunk-last-offset: ([\w\d_]+)
   [local last_offset=$1]
 
-## Terminate electric after giving it some time to create the shape
+## Terminate electric
 [shell electric]
-  ?Txn received
-  [sleep 2]
   !System.halt()
   ??$PS1
 
@@ -60,7 +58,7 @@
 
 # Client should be able to continue same shape
 [shell client]
-  !curl -I "http://localhost:3000/v1/shape/items?offset=$last_offset&shape_id=$shape_id"
+  !curl -v -X GET "http://localhost:3000/v1/shape/items?offset=$last_offset&shape_id=$shape_id"
   ??HTTP/1.1 200 OK
 
 [cleanup]

--- a/integration-tests/tests/invalidated-replication-slot.lux
+++ b/integration-tests/tests/invalidated-replication-slot.lux
@@ -7,7 +7,7 @@
 [my invalidated_slot_error=
   """
   [error] GenServer Electric.ConnectionManager terminating
-  ** (Postgrex.Error) ERROR 55000 (object_not_in_prerequisite_state) cannot read from logical replication slot "electric_slot"
+  ** (Postgrex.Error) ERROR 55000 (object_not_in_prerequisite_state) cannot read from logical replication slot "electric_slot_default"
 
   This slot has been invalidated because it exceeded the maximum reserved size.
   """]
@@ -34,7 +34,7 @@
 
 ## Confirm slot invalidation in Postgres.
 [shell pg]
-  ?invalidating slot "electric_slot" because its restart_lsn \d+/\d+ exceeds max_slot_wal_keep_size
+  ?invalidating slot "electric_slot_default" because its restart_lsn [\d\w]+/[\d\w]+ exceeds max_slot_wal_keep_size
 
 ## Observe the fatal connection error.
 [shell electric]

--- a/integration-tests/tests/macros.luxinc
+++ b/integration-tests/tests/macros.luxinc
@@ -68,10 +68,14 @@
 [endmacro]
 
 [macro setup_electric]
-  [shell electric]
+  [invoke setup_electric_shell "electric" "3000"]
+[endmacro]
+
+[macro setup_electric_shell shell_name port]
+  [shell $shell_name]
     -$fail_pattern
   
-    !DATABASE_URL=$database_url ../electric_dev.sh
+    !DATABASE_URL=$database_url PORT=$port ../electric_dev.sh
 [endmacro]
 
 [macro teardown]

--- a/integration-tests/tests/macros.luxinc
+++ b/integration-tests/tests/macros.luxinc
@@ -41,6 +41,11 @@
     ??database system is ready to accept connections
 [endmacro]
 
+[macro start_psql]
+  [shell psql]
+    !docker exec -u postgres -it $pg_container_name psql
+[endmacro]
+
 [macro seed_pg]
   [shell psql]
     !docker exec -u postgres -it $pg_container_name psql

--- a/integration-tests/tests/postgres-disconnection.lux
+++ b/integration-tests/tests/postgres-disconnection.lux
@@ -22,7 +22,7 @@
 
 ## Observe the connection error.
 [shell electric]
-  ??[warning] Database connection in replication mode failed
+  ??[warning] Database connection in lock_connection mode failed
   ??[warning] Reconnecting in 
 
 ## Start the Postgres container back up.

--- a/integration-tests/tests/rolling-deploy.lux
+++ b/integration-tests/tests/rolling-deploy.lux
@@ -1,0 +1,42 @@
+[doc Verify handling of an Electric rolling deploy]
+
+[include macros.luxinc]
+
+[global pg_container_name=rolling-deploy__pg]
+
+###
+
+## Start a new Postgres cluster
+[invoke setup_pg "" ""]
+
+## Start the first sync service.
+[invoke setup_electric_shell "electric_1" "3000"]
+
+[shell electric_1]
+  ??[info] Acquiring lock from postgres with name electric_slot_default
+  ??[info] Lock acquired from postgres with name electric_slot_default
+  ??[info] Starting replication from postgres
+  
+
+## Start the second sync service.
+[invoke setup_electric_shell "electric_2" "3001"]
+
+## Assert that the lock is not acquired and replication does not start
+## in the second electric
+[shell electric_2]
+  -Lock acquired from postgres|Starting replication from postgres|$fail_pattern
+  ??[info] Acquiring lock from postgres with name electric_slot_default
+  [sleep 2]
+
+## Terminate first electric
+[shell electric_1]
+  !System.halt()
+
+## Lock should now be acquired and replication starting
+[shell electric_2]
+  -$fail_pattern
+  ??[info] Lock acquired from postgres with name electric_slot_default
+  ??[info] Starting replication from postgres
+
+[cleanup]
+  [invoke teardown]

--- a/integration-tests/tests/rolling-deploy.lux
+++ b/integration-tests/tests/rolling-deploy.lux
@@ -43,6 +43,9 @@
 ## Terminate first electric
 [shell electric_1]
   !System.halt()
+  
+  # Confirm Electric process exit.
+  ??$PS1
 
 ## Lock should now be acquired and replication starting
 [shell electric_2]

--- a/integration-tests/tests/rolling-deploy.lux
+++ b/integration-tests/tests/rolling-deploy.lux
@@ -17,6 +17,10 @@
   ??[info] Lock acquired from postgres with name electric_slot_default
   ??[info] Starting replication from postgres
   
+# First service should be health and active
+[shell orchestator]
+  !curl -X GET http://localhost:3000/v1/health
+  ??{"status":"active"}
 
 ## Start the second sync service.
 [invoke setup_electric_shell "electric_2" "3001"]
@@ -28,6 +32,14 @@
   ??[info] Acquiring lock from postgres with name electric_slot_default
   [sleep 2]
 
+
+# Second service should be in waiting state, ready to take over
+[shell orchestator]
+  !curl -X GET http://localhost:3000/v1/health
+  ??{"status":"active"}
+  !curl -X GET http://localhost:3001/v1/health
+  ??{"status":"waiting"}
+
 ## Terminate first electric
 [shell electric_1]
   !System.halt()
@@ -37,6 +49,11 @@
   -$fail_pattern
   ??[info] Lock acquired from postgres with name electric_slot_default
   ??[info] Starting replication from postgres
+
+# Second service is now healthy and active
+[shell orchestator]
+  !curl -X GET http://localhost:3001/v1/health
+  ??{"status":"active"}
 
 [cleanup]
   [invoke teardown]

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -161,6 +161,7 @@ config :electric,
   instance_id: instance_id,
   telemetry_statsd_host: statsd_host,
   db_pool_size: env!("DB_POOL_SIZE", :integer, 50),
+  replication_stream_id: env!("REPLICATION_STREAM_ID", :string, "default"),
   prometheus_port: prometheus_port,
   storage: storage,
   persistent_kv: persistent_kv

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -162,6 +162,7 @@ config :electric,
   telemetry_statsd_host: statsd_host,
   db_pool_size: env!("DB_POOL_SIZE", :integer, 50),
   replication_stream_id: env!("REPLICATION_STREAM_ID", :string, "default"),
+  service_port: env!("PORT", :integer, 3000),
   prometheus_port: prometheus_port,
   storage: storage,
   persistent_kv: persistent_kv

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -33,6 +33,14 @@ defmodule Electric.Application do
         Electric.ConnectionManager.get_pg_version(Electric.ConnectionManager)
       end
 
+      get_service_status = fn ->
+        Electric.ServiceStatus.check(%{
+          get_replication_status: fn ->
+            Electric.ConnectionManager.get_replication_status(Electric.ConnectionManager)
+          end
+        })
+      end
+
       prepare_tables_fn =
         {Electric.Postgres.Configuration, :configure_tables_for_replication!,
          [get_pg_version, publication_name]}
@@ -104,6 +112,7 @@ defmodule Electric.Application do
                 storage: storage,
                 registry: Registry.ShapeChanges,
                 shape_cache: {Electric.ShapeCache, []},
+                get_service_status: get_service_status,
                 inspector: inspector,
                 long_poll_timeout: 20_000,
                 max_age: Application.fetch_env!(:electric, :cache_max_age),

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -34,11 +34,11 @@ defmodule Electric.Application do
       end
 
       get_service_status = fn ->
-        Electric.ServiceStatus.check(%{
-          get_replication_status: fn ->
-            Electric.ConnectionManager.get_replication_status(Electric.ConnectionManager)
+        Electric.ServiceStatus.check(
+          get_connection_status: fn ->
+            Electric.ConnectionManager.get_status(Electric.ConnectionManager)
           end
-        })
+        )
       end
 
       prepare_tables_fn =

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -22,8 +22,9 @@ defmodule Electric.Application do
 
     persistent_kv = apply(kv_module, kv_fun, [kv_params])
 
-    publication_name = "electric_publication"
-    slot_name = "electric_slot"
+    replication_stream_id = Application.fetch_env!(:electric, :replication_stream_id)
+    publication_name = "electric_publication_#{replication_stream_id}"
+    slot_name = "electric_slot_#{replication_stream_id}"
 
     with {:ok, storage_opts} <- storage_module.shared_opts(storage_opts) do
       storage = {storage_module, storage_opts}

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -118,7 +118,7 @@ defmodule Electric.Application do
                 max_age: Application.fetch_env!(:electric, :cache_max_age),
                 stale_age: Application.fetch_env!(:electric, :cache_stale_age),
                 allow_shape_deletion: Application.get_env(:electric, :allow_shape_deletion, false)},
-             port: 3000,
+             port: Application.fetch_env!(:electric, :service_port),
              thousand_island_options: http_listener_options()}
           ]
           |> add_prometheus_router(Application.fetch_env!(:electric, :prometheus_port))

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -161,9 +161,9 @@ defmodule Electric.ConnectionManager do
 
   def handle_continue(:start_lock_connection, state) do
     case Electric.LockConnection.start_link(
-           state.connection_opts,
-           self(),
-           Keyword.fetch!(state.replication_opts, :slot_name)
+           connection_opts: state.connection_opts,
+           connection_manager: self(),
+           lock_name: Keyword.fetch!(state.replication_opts, :slot_name)
          ) do
       {:ok, lock_connection_pid} ->
         {:noreply, %{state | lock_connection_pid: lock_connection_pid}}

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -267,7 +267,7 @@ defmodule Electric.ConnectionManager do
     end
   end
 
-  def handle_cast(:connection_lock_acquired, state) do
+  def handle_cast(:lock_connection_acquired, state) do
     # As soon as we acquire the connection lock, we try to start the replication connection
     # first because it requires additional privileges compared to regular "pooled" connections,
     # so failure to open a replication connection should be reported ASAP.

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -160,7 +160,7 @@ defmodule Electric.ConnectionManager do
   end
 
   def handle_continue(:start_lock_connection, state) do
-    case Electric.LockConnection.start_link(
+    case Electric.Postgres.LockConnection.start_link(
            connection_opts: state.connection_opts,
            connection_manager: self(),
            lock_name: Keyword.fetch!(state.replication_opts, :slot_name)

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -148,8 +148,8 @@ defmodule Electric.ConnectionManager do
         not pg_lock_acquired ->
           :waiting
 
-        is_nil(state.replication_client_pid) || is_nil(state.pool_id) ||
-            not Process.alive?(state.pool_id) ->
+        is_nil(state.replication_client_pid) || is_nil(state.pool_pid) ||
+            not Process.alive?(state.pool_pid) ->
           :starting
 
         true ->

--- a/packages/sync-service/lib/electric/lock_connection.ex
+++ b/packages/sync-service/lib/electric/lock_connection.ex
@@ -5,7 +5,7 @@ defmodule Electric.LockConnection do
   replication slot at any given time.
 
   The connection attempts to grab the lock and waits on it until it acquires it.
-  When it does, it fires off a :connection_lock_acquired message to the specified
+  When it does, it fires off a :lock_connection_acquired message to the specified
   `Electric.ConnectionManager` such that the required setup can acquired now that
   the service is sure to be the only one operating on this replication stream.
   """
@@ -82,7 +82,7 @@ defmodule Electric.LockConnection do
   end
 
   defp notify_lock_acquired(%State{connection_manager: connection_manager} = _state) do
-    GenServer.cast(connection_manager, :connection_lock_acquired)
+    GenServer.cast(connection_manager, :lock_connection_acquired)
   end
 
   defp lock_query(%State{lock_name: name} = _state) do

--- a/packages/sync-service/lib/electric/lock_connection.ex
+++ b/packages/sync-service/lib/electric/lock_connection.ex
@@ -21,19 +21,20 @@ defmodule Electric.LockConnection do
     ]
   end
 
-  @spec start_link(Keyword.t(), GenServer.server(), String.t()) :: {:ok, pid()} | {:error, any()}
+  @spec start_link(Keyword.t(), GenServer.server(), String.t()) ::
+          {:ok, pid()} | {:error, Postgrex.Error.t() | term()}
   def start_link(connection_opts, connection_manager, lock_name) do
     case Postgrex.SimpleConnection.start_link(
            __MODULE__,
            [connection_manager: connection_manager, lock_name: lock_name],
-           connection_opts ++ [timeout: :infinity]
+           connection_opts ++ [timeout: :infinity, auto_reconnect: false]
          ) do
       {:ok, pid} ->
         send(pid, :acquire_lock)
         {:ok, pid}
 
       {:error, error} ->
-        raise error
+        {:error, error}
     end
   end
 

--- a/packages/sync-service/lib/electric/lock_connection.ex
+++ b/packages/sync-service/lib/electric/lock_connection.ex
@@ -12,6 +12,13 @@ defmodule Electric.LockConnection do
   require Logger
   @behaviour Postgrex.SimpleConnection
 
+  @type option ::
+          {:connection_opts, Keyword.t()}
+          | {:connection_manager, GenServer.server()}
+          | {:lock_name, String.t()}
+
+  @type options :: [option]
+
   defmodule State do
     defstruct [
       :connection_manager,
@@ -21,9 +28,12 @@ defmodule Electric.LockConnection do
     ]
   end
 
-  @spec start_link(Keyword.t(), GenServer.server(), String.t()) ::
-          {:ok, pid()} | {:error, Postgrex.Error.t() | term()}
-  def start_link(connection_opts, connection_manager, lock_name) do
+  @spec start_link(options()) :: {:ok, pid()} | {:error, Postgrex.Error.t() | term()}
+  def start_link(
+        connection_opts: connection_opts,
+        connection_manager: connection_manager,
+        lock_name: lock_name
+      ) do
     case Postgrex.SimpleConnection.start_link(
            __MODULE__,
            [connection_manager: connection_manager, lock_name: lock_name],

--- a/packages/sync-service/lib/electric/lock_connection.ex
+++ b/packages/sync-service/lib/electric/lock_connection.ex
@@ -1,0 +1,82 @@
+defmodule Electric.LockConnection do
+  @moduledoc """
+  A Postgres connection that ensures an advisory lock is held for its entire duration,
+  useful for ensuring only a single sync service instance can be using a single
+  replication slot at any given time.
+
+  The connection attempts to grab the lock and waits on it until it acquires it.
+  When it does, it fires off a :connection_lock_acquired message to the specified
+  `Electric.ConnectionManager` such that the required setup can acquired now that
+  the service is sure to be the only one operating on this replication stream.
+  """
+  require Logger
+  @behaviour Postgrex.SimpleConnection
+
+  defmodule State do
+    defstruct [
+      :connection_manager,
+      :lock_acquired,
+      :lock_name
+    ]
+  end
+
+  @spec start_link(Keyword.t(), GenServer.server(), String.t()) :: {:ok, pid()} | {:error, any()}
+  def start_link(connection_opts, connection_manager, lock_name) do
+    case Postgrex.SimpleConnection.start_link(
+           __MODULE__,
+           [connection_manager: connection_manager, lock_name: lock_name],
+           connection_opts ++ [timeout: :infinity]
+         ) do
+      {:ok, pid} ->
+        send(pid, :acquire_lock)
+        {:ok, pid}
+
+      {:error, error} ->
+        raise error
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok,
+     %State{
+       connection_manager: Keyword.fetch!(opts, :connection_manager),
+       lock_name: Keyword.fetch!(opts, :lock_name),
+       lock_acquired: false
+     }}
+  end
+
+  @impl true
+  def handle_info(:acquire_lock, state) do
+    if(state.lock_acquired) do
+      notify_lock_acquired(state)
+      {:noreply, state}
+    else
+      {:query, lock_query(state), state}
+    end
+  end
+
+  @impl true
+  def handle_result(results, state) when is_list(results) do
+    notify_lock_acquired(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_result(%Postgrex.Error{} = _error, state) do
+    {:query, lock_query(state), %{state | lock_acquired: false}}
+  end
+
+  defp notify_lock_acquired(%State{connection_manager: connection_manager} = _state) do
+    GenServer.cast(connection_manager, :connection_lock_acquired)
+  end
+
+  defp lock_query(%State{lock_name: name} = _state) do
+    "SELECT pg_advisory_lock(hashtext('#{name}'))"
+  end
+
+  @impl true
+  def notify(_channel, _payload, _state) do
+    :ok
+  end
+end

--- a/packages/sync-service/lib/electric/lock_connection.ex
+++ b/packages/sync-service/lib/electric/lock_connection.ex
@@ -55,6 +55,7 @@ defmodule Electric.LockConnection do
       notify_lock_acquired(state)
       {:noreply, state}
     else
+      Logger.info("Acquiring lock from postgres with name #{state.lock_name}")
       {:query, lock_query(state), state}
     end
   end
@@ -64,9 +65,10 @@ defmodule Electric.LockConnection do
   end
 
   @impl true
-  def handle_result(results, state) when is_list(results) do
+  def handle_result([%Postgrex.Result{}] = _results, state) do
+    Logger.info("Lock acquired from postgres with name #{state.lock_name}")
     notify_lock_acquired(state)
-    {:noreply, state}
+    {:noreply, %{state | lock_acquired: true}}
   end
 
   @impl true

--- a/packages/sync-service/lib/electric/lock_connection.ex
+++ b/packages/sync-service/lib/electric/lock_connection.ex
@@ -51,7 +51,7 @@ defmodule Electric.LockConnection do
 
   @impl true
   def handle_info(:acquire_lock, state) do
-    if(state.lock_acquired) do
+    if state.lock_acquired do
       notify_lock_acquired(state)
       {:noreply, state}
     else

--- a/packages/sync-service/lib/electric/plug/health_check_plug.ex
+++ b/packages/sync-service/lib/electric/plug/health_check_plug.ex
@@ -1,0 +1,25 @@
+defmodule Electric.Plug.HealthCheckPlug do
+  alias Plug.Conn
+  require Logger
+  use Plug.Builder
+
+  plug :check_service_status
+  plug :send_response
+
+  defp check_service_status(conn, _) do
+    get_service_status = Access.fetch!(conn.assigns.config, :get_service_status)
+
+    status_text =
+      case get_service_status.() do
+        :starting -> "starting"
+        :ready -> "ready"
+        :active -> "active"
+        :stopping -> "stopping"
+      end
+
+    conn |> assign(:status_text, status_text)
+  end
+
+  defp send_response(%Conn{assigns: %{status_text: status_text}} = conn, _),
+    do: send_resp(conn, 200, Jason.encode!(%{status: status_text}))
+end

--- a/packages/sync-service/lib/electric/plug/health_check_plug.ex
+++ b/packages/sync-service/lib/electric/plug/health_check_plug.ex
@@ -7,6 +7,9 @@ defmodule Electric.Plug.HealthCheckPlug do
   plug :put_relevant_headers
   plug :send_response
 
+  # Match service status to a status code and status message,
+  # keeping the message name decoupled from the internal representation
+  # of the status to ensure the API is stable
   defp check_service_status(conn, _) do
     get_service_status = Access.fetch!(conn.assigns.config, :get_service_status)
 

--- a/packages/sync-service/lib/electric/plug/health_check_plug.ex
+++ b/packages/sync-service/lib/electric/plug/health_check_plug.ex
@@ -4,22 +4,32 @@ defmodule Electric.Plug.HealthCheckPlug do
   use Plug.Builder
 
   plug :check_service_status
+  plug :put_relevant_headers
   plug :send_response
 
   defp check_service_status(conn, _) do
     get_service_status = Access.fetch!(conn.assigns.config, :get_service_status)
 
-    status_text =
+    {status_code, status_text} =
       case get_service_status.() do
-        :starting -> "starting"
-        :ready -> "ready"
-        :active -> "active"
-        :stopping -> "stopping"
+        :waiting -> {200, "waiting"}
+        :starting -> {200, "starting"}
+        :active -> {200, "active"}
+        :stopping -> {500, "stopping"}
       end
 
-    conn |> assign(:status_text, status_text)
+    conn |> assign(:status_text, status_text) |> assign(:status_code, status_code)
   end
 
-  defp send_response(%Conn{assigns: %{status_text: status_text}} = conn, _),
-    do: send_resp(conn, 200, Jason.encode!(%{status: status_text}))
+  defp put_relevant_headers(conn, _),
+    do:
+      conn
+      |> put_resp_header("content-type", "application/json")
+      |> put_resp_header("cache-control", "no-cache, no-store, must-revalidate")
+
+  defp send_response(
+         %Conn{assigns: %{status_text: status_text, status_code: status_code}} = conn,
+         _
+       ),
+       do: send_resp(conn, status_code, Jason.encode!(%{status: status_text}))
 end

--- a/packages/sync-service/lib/electric/plug/health_check_plug.ex
+++ b/packages/sync-service/lib/electric/plug/health_check_plug.ex
@@ -15,7 +15,7 @@ defmodule Electric.Plug.HealthCheckPlug do
         :waiting -> {200, "waiting"}
         :starting -> {200, "starting"}
         :active -> {200, "active"}
-        :stopping -> {500, "stopping"}
+        :stopping -> {503, "stopping"}
       end
 
     conn |> assign(:status_text, status_text) |> assign(:status_code, status_code)

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -18,6 +18,8 @@ defmodule Electric.Plug.Router do
   delete "/v1/shape/:root_table", to: Electric.Plug.DeleteShapePlug
   match "/v1/shape/:root_table", via: :options, to: Electric.Plug.OptionsShapePlug
 
+  get "/v1/health", to: Electric.Plug.HealthCheckPlug
+
   match _ do
     send_resp(conn, 404, "Not found")
   end

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -123,6 +123,28 @@ defmodule Electric.Postgres.Configuration do
     |> Map.new()
   end
 
+  @doc """
+  Drops all tables from the given publication.
+  """
+  @spec drop_all_publication_tables(Postgrex.conn(), String.t()) :: Postgrex.Result.t()
+  def drop_all_publication_tables(conn, publication_name) do
+    Postgrex.query!(
+      conn,
+      "
+      DO $$
+      DECLARE
+        r RECORD;
+      BEGIN
+        FOR r IN (SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = '#{publication_name}')
+        LOOP
+          EXECUTE 'ALTER PUBLICATION #{Utils.quote_name(publication_name)} DROP TABLE ' || r.schemaname || '.' || r.tablename || ';';
+        END LOOP;
+      END $$;
+      ",
+      []
+    )
+  end
+
   # Joins the existing filter for the table with the where clause for the table.
   # If one of them is `nil` (i.e. no filter) then the resulting filter is `nil`.
   @spec extend_where_clause(maybe_filter(), filter()) :: filter()

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -29,14 +29,12 @@ defmodule Electric.Postgres.LockConnection do
   end
 
   @spec start_link(options()) :: {:ok, pid()} | {:error, Postgrex.Error.t() | term()}
-  def start_link(
-        connection_opts: connection_opts,
-        connection_manager: connection_manager,
-        lock_name: lock_name
-      ) do
+  def start_link(opts) do
+    {connection_opts, init_opts} = Keyword.pop(opts, :connection_opts)
+
     case Postgrex.SimpleConnection.start_link(
            __MODULE__,
-           [connection_manager: connection_manager, lock_name: lock_name],
+           init_opts,
            connection_opts ++ [timeout: :infinity, auto_reconnect: false]
          ) do
       {:ok, pid} ->

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -75,7 +75,7 @@ defmodule Electric.Postgres.LockConnection do
   end
 
   @impl true
-  def handle_result([%Postgrex.Result{}] = _results, state) do
+  def handle_result([_] = _results, state) do
     Logger.info("Lock acquired from postgres with name #{state.lock_name}")
     notify_lock_acquired(state)
     {:noreply, %{state | lock_acquired: true}}

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -1,4 +1,4 @@
-defmodule Electric.LockConnection do
+defmodule Electric.Postgres.LockConnection do
   @moduledoc """
   A Postgres connection that ensures an advisory lock is held for its entire duration,
   useful for ensuring only a single sync service instance can be using a single

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -18,6 +18,7 @@ defmodule Electric.Postgres.ReplicationClient do
           | :connected
           | :create_publication
           | :create_slot
+          | :waiting_for_lock
           | :set_display_setting
           | :ready_to_stream
           | :streaming

--- a/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
@@ -118,13 +118,10 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   ###
 
   # Start a long query that will block until the lock becomes available, based
-  # on the OID of the replication slot - such that if the slot is dropped and recreated
-  # this lock will no longer sto
+  # on a hash of the slot name to ensure lock is held even if slot is recreated.
   # NOTE: alternatively use pg_try_advisory_lock and retry with exponential backoff
   defp waiting_for_lock_query(state) do
-    query =
-      "SELECT pg_advisory_lock(datoid::bigint) FROM pg_replication_slots WHERE slot_name = '#{Utils.quote_name(state.slot_name)}'"
-
+    query = "SELECT pg_advisory_lock(hashtext('#{state.slot_name}'))"
     {:query, query, state}
   end
 

--- a/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
@@ -114,6 +114,28 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
 
   ###
 
+  # Start a long query that will block until the lock becomes available.
+  # NOTE: alternatively use pg_try_advisory_lock and retry with exponential backoff
+  defp waiting_for_lock_query(state) do
+    query =
+      "SELECT pg_advisory_lock(datoid::bigint) FROM pg_replication_slots WHERE slot_name = '#{state.slot_name}'"
+
+    {:query, query, state}
+  end
+
+  # Sucessfully acquired the lock for the replication slot.
+  defp waiting_for_lock_result([%Postgrex.Result{} = _result], state) do
+    Logger.debug("Acquired advisory lock on replication slot")
+    state
+  end
+
+  defp waiting_for_lock_result(%Postgrex.Error{} = error, _state) do
+    # Unexpected error, fail loudly.
+    raise error
+  end
+
+  ###
+
   defp set_display_setting_query(%{display_settings: [query | rest]} = state) do
     {:query, query, %{state | display_settings: rest}}
   end
@@ -162,7 +184,8 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   defp next_step(%{step: :connected, try_creating_publication?: true}), do: :create_publication
   defp next_step(%{step: :connected}), do: :create_slot
   defp next_step(%{step: :create_publication}), do: :create_slot
-  defp next_step(%{step: :create_slot}), do: :set_display_setting
+  defp next_step(%{step: :create_slot}), do: :waiting_for_lock
+  defp next_step(%{step: :waiting_for_lock}), do: :set_display_setting
 
   defp next_step(%{step: :set_display_setting, display_settings: queries}) when queries != [],
     do: :set_display_setting
@@ -179,6 +202,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
 
   defp query_for_step(:create_publication, state), do: create_publication_query(state)
   defp query_for_step(:create_slot, state), do: create_slot_query(state)
+  defp query_for_step(:waiting_for_lock, state), do: waiting_for_lock_query(state)
   defp query_for_step(:set_display_setting, state), do: set_display_setting_query(state)
   defp query_for_step(:ready_to_stream, state), do: ready_to_stream(state)
   defp query_for_step(:streaming, state), do: start_replication_slot_query(state)
@@ -194,6 +218,9 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
 
   defp dispatch_query_result(:create_slot, result, state),
     do: create_slot_result(result, state)
+
+  defp dispatch_query_result(:waiting_for_lock, result, state),
+    do: waiting_for_lock_result(result, state)
 
   defp dispatch_query_result(:set_display_setting, result, state),
     do: set_display_setting_result(result, state)

--- a/packages/sync-service/lib/electric/service_status.ex
+++ b/packages/sync-service/lib/electric/service_status.ex
@@ -7,8 +7,8 @@ defmodule Electric.ServiceStatus do
   @type options :: [option]
 
   @spec check(options()) :: status()
-  def check(opts) do
-    with connection_status <- opts.get_connection_status.() do
+  def check(get_connection_status: get_connection_status) do
+    with connection_status <- get_connection_status.() do
       # Match the connection status ot a service status - currently
       # they are one and the same but keeping this decoupled for future
       # additions to conditions that determine service status

--- a/packages/sync-service/lib/electric/service_status.ex
+++ b/packages/sync-service/lib/electric/service_status.ex
@@ -1,0 +1,17 @@
+defmodule Electric.ServiceStatus do
+  @type status() :: :starting | :ready | :active | :stopping
+
+  @type opts() ::
+          Keyword.t(get_replication_status: (-> Electric.Postgres.ReplicationClient.status()))
+
+  @spec check(opts()) :: status()
+  def check(opts) do
+    with replication_status <- opts.get_replication_status.() do
+      case replication_status do
+        :starting -> :starting
+        :waiting -> :ready
+        :active -> :active
+      end
+    end
+  end
+end

--- a/packages/sync-service/lib/electric/service_status.ex
+++ b/packages/sync-service/lib/electric/service_status.ex
@@ -7,16 +7,16 @@ defmodule Electric.ServiceStatus do
   @type options :: [option]
 
   @spec check(options()) :: status()
-  def check(get_connection_status: get_connection_status) do
-    with connection_status <- get_connection_status.() do
-      # Match the connection status ot a service status - currently
-      # they are one and the same but keeping this decoupled for future
-      # additions to conditions that determine service status
-      case connection_status do
-        :waiting -> :waiting
-        :starting -> :starting
-        :active -> :active
-      end
+  def check(opts) do
+    get_connection_status_fun = Keyword.fetch!(opts, :get_connection_status)
+
+    # Match the connection status ot a service status - currently
+    # they are one and the same but keeping this decoupled for future
+    # additions to conditions that determine service status
+    case get_connection_status_fun.() do
+      :waiting -> :waiting
+      :starting -> :starting
+      :active -> :active
     end
   end
 end

--- a/packages/sync-service/lib/electric/service_status.ex
+++ b/packages/sync-service/lib/electric/service_status.ex
@@ -9,6 +9,9 @@ defmodule Electric.ServiceStatus do
   @spec check(options()) :: status()
   def check(opts) do
     with connection_status <- opts.get_connection_status.() do
+      # Match the connection status ot a service status - currently
+      # they are one and the same but keeping this decoupled for future
+      # additions to conditions that determine service status
       case connection_status do
         :waiting -> :waiting
         :starting -> :starting

--- a/packages/sync-service/lib/electric/service_status.ex
+++ b/packages/sync-service/lib/electric/service_status.ex
@@ -1,15 +1,17 @@
 defmodule Electric.ServiceStatus do
   @type status() :: :starting | :ready | :active | :stopping
 
-  @type opts() ::
-          Keyword.t(get_replication_status: (-> Electric.Postgres.ReplicationClient.status()))
+  @type option ::
+          {:get_connection_status, (-> Electric.ConnectionManager.status())}
 
-  @spec check(opts()) :: status()
+  @type options :: [option]
+
+  @spec check(options()) :: status()
   def check(opts) do
-    with replication_status <- opts.get_replication_status.() do
-      case replication_status do
+    with connection_status <- opts.get_connection_status.() do
+      case connection_status do
+        :waiting -> :waiting
         :starting -> :starting
-        :waiting -> :ready
         :active -> :active
       end
     end

--- a/packages/sync-service/lib/electric/service_status.ex
+++ b/packages/sync-service/lib/electric/service_status.ex
@@ -1,5 +1,5 @@
 defmodule Electric.ServiceStatus do
-  @type status() :: :starting | :ready | :active | :stopping
+  @type status() :: :waiting | :starting | :active | :stopping
 
   @type option ::
           {:get_connection_status, (-> Electric.ConnectionManager.status())}

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -200,6 +200,22 @@ defmodule Electric.Utils do
   def escape_quotes(text), do: :binary.replace(text, ~S|"|, ~S|""|, [:global])
 
   @doc """
+  Quote a string for use in SQL queries.
+
+  ## Examples
+      iex> quote_name("foo")
+      ~S|"foo"|
+
+      iex> quote_name(~S|"foo"|)
+      ~S|"foo"|
+
+      iex> quote_name(~S|"fo""o"|)
+      ~S|"fo""o"|
+  """
+  @spec quote_name(String.t()) :: String.t()
+  def quote_name(str), do: ~s|"#{escape_quotes(str)}"|
+
+  @doc """
   Parses quoted names.
 
   ## Examples

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -206,10 +206,7 @@ defmodule Electric.Utils do
       iex> quote_name("foo")
       ~S|"foo"|
 
-      iex> quote_name(~S|"foo"|)
-      ~S|"foo"|
-
-      iex> quote_name(~S|"fo""o"|)
+      iex> quote_name(~S|fo"o|)
       ~S|"fo""o"|
   """
   @spec quote_name(String.t()) :: String.t()

--- a/packages/sync-service/test/electric/plug/health_check_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/health_check_plug_test.exs
@@ -1,0 +1,76 @@
+defmodule Electric.Plug.HealthCheckPlugTest do
+  use ExUnit.Case, async: true
+  import Plug.Conn
+  alias Plug.Conn
+
+  alias Electric.Plug.HealthCheckPlug
+
+  @moduletag :capture_log
+
+  @registry Registry.HealthCheckPlugTest
+
+  setup do
+    start_link_supervised!({Registry, keys: :duplicate, name: @registry})
+    :ok
+  end
+
+  def conn(%{connection_status: connection_status} = _config) do
+    # Pass mock dependencies to the plug
+    config = %{
+      get_service_status: fn -> connection_status end
+    }
+
+    Plug.Test.conn("GET", "/")
+    |> assign(:config, config)
+  end
+
+  describe "HealthCheckPlug" do
+    test "has appropriate content and cache headers" do
+      conn =
+        conn(%{connection_status: :waiting})
+        |> HealthCheckPlug.call([])
+
+      assert Conn.get_resp_header(conn, "content-type") == ["application/json"]
+
+      assert Conn.get_resp_header(conn, "cache-control") == [
+               "no-cache, no-store, must-revalidate"
+             ]
+    end
+
+    test "returns 200 when in waiting mode" do
+      conn =
+        conn(%{connection_status: :waiting})
+        |> HealthCheckPlug.call([])
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body) == %{"status" => "waiting"}
+    end
+
+    test "returns 200 when in starting mode" do
+      conn =
+        conn(%{connection_status: :starting})
+        |> HealthCheckPlug.call([])
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body) == %{"status" => "starting"}
+    end
+
+    test "returns 200 when in active mode" do
+      conn =
+        conn(%{connection_status: :active})
+        |> HealthCheckPlug.call([])
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body) == %{"status" => "active"}
+    end
+
+    test "returns 500 when stopping" do
+      conn =
+        conn(%{connection_status: :stopping})
+        |> HealthCheckPlug.call([])
+
+      assert conn.status == 500
+      assert Jason.decode!(conn.resp_body) == %{"status" => "stopping"}
+    end
+  end
+end

--- a/packages/sync-service/test/electric/plug/health_check_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/health_check_plug_test.exs
@@ -64,12 +64,12 @@ defmodule Electric.Plug.HealthCheckPlugTest do
       assert Jason.decode!(conn.resp_body) == %{"status" => "active"}
     end
 
-    test "returns 500 when stopping" do
+    test "returns 503 when stopping" do
       conn =
         conn(%{connection_status: :stopping})
         |> HealthCheckPlug.call([])
 
-      assert conn.status == 500
+      assert conn.status == 503
       assert Jason.decode!(conn.resp_body) == %{"status" => "stopping"}
     end
   end

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -33,6 +33,29 @@ defmodule Electric.Plug.RouterTest do
     end
   end
 
+  describe "/v1/health" do
+    setup [:with_unique_db]
+
+    setup do
+      %{publication_name: "electric_test_publication", slot_name: "electric_test_slot"}
+    end
+
+    setup :with_complete_stack
+
+    setup(ctx,
+      do: %{opts: Router.init(build_router_opts(ctx, get_service_status: fn -> :active end))}
+    )
+
+    test "GET returns health status of service", %{opts: opts} do
+      conn =
+        conn("GET", "/v1/health")
+        |> Router.call(opts)
+
+      assert %{status: 200} = conn
+      assert Jason.decode!(conn.resp_body) == %{"status" => "active"}
+    end
+  end
+
   describe "/v1/shapes" do
     setup [:with_unique_db, :with_basic_tables, :with_sql_execute]
 

--- a/packages/sync-service/test/electric/postgres/lock_connection_test.exs
+++ b/packages/sync-service/test/electric/postgres/lock_connection_test.exs
@@ -1,0 +1,83 @@
+defmodule Electric.Postgres.LockConnectionTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  import Support.DbSetup, except: [with_publication: 1]
+
+  alias Electric.Postgres.LockConnection
+
+  @moduletag :capture_log
+  @lock_name "test_electric_slot"
+
+  describe "LockConnection init" do
+    setup [:with_unique_db]
+
+    test "should acquire an advisory lock on startup", %{db_config: config, db_conn: conn} do
+      log =
+        capture_log(fn ->
+          assert {:ok, _pid} =
+                   LockConnection.start_link(
+                     connection_opts: config,
+                     connection_manager: self(),
+                     lock_name: @lock_name
+                   )
+
+          assert_lock_acquired()
+        end)
+
+      # should have logged lock acquisition process
+      assert log =~ "Acquiring lock from postgres with name #{@lock_name}"
+      assert log =~ "Lock acquired from postgres with name #{@lock_name}"
+
+      # should have acquired an advisory lock on PG
+      assert %Postgrex.Result{rows: [[false]]} =
+               Postgrex.query!(
+                 conn,
+                 "SELECT pg_try_advisory_lock(hashtext('#{@lock_name}'))",
+                 []
+               )
+    end
+
+    test "should wait if lock is already acquired", %{db_config: config} do
+      # grab lock with one connection
+      {pid1, _} =
+        with_log(fn ->
+          assert {:ok, pid} =
+                   LockConnection.start_link(
+                     connection_opts: config,
+                     connection_manager: self(),
+                     lock_name: @lock_name
+                   )
+
+          assert_lock_acquired()
+          pid
+        end)
+
+      # try to grab the same with another
+      _ =
+        capture_log(fn ->
+          assert {:ok, pid} =
+                   LockConnection.start_link(
+                     connection_opts: config,
+                     connection_manager: self(),
+                     lock_name: @lock_name
+                   )
+
+          # should fail to grab it
+          refute_lock_acquired()
+
+          # should immediately grab it once previous lock is released
+          GenServer.stop(pid1)
+          assert_lock_acquired()
+          pid
+        end)
+    end
+  end
+
+  defp assert_lock_acquired do
+    assert_receive {_, :lock_connection_acquired}
+  end
+
+  defp refute_lock_acquired do
+    refute_receive {_, :lock_connection_acquired}, 1000
+  end
+end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -162,6 +162,7 @@ defmodule Support.ComponentSetup do
       long_poll_timeout: Access.get(overrides, :long_poll_timeout, 5_000),
       max_age: Access.get(overrides, :max_age, 60),
       stale_age: Access.get(overrides, :stale_age, 300),
+      get_service_status: Access.get(overrides, :get_service_status, fn -> :active end),
       chunk_bytes_threshold:
         Access.get(overrides, :chunk_bytes_threshold, ctx.chunk_bytes_threshold),
       allow_shape_deletion: Access.get(overrides, :allow_shape_deletion, true)


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/1749

- Makes publication and slot names configurable via a `REPLICATION_STREAM_ID` env variable, which can ultimately be used for multiple electric deploys
- Quotes all publication and slot names to address potential issues with configurable names (alternative is to force downcase them when initialised to avoid nasty case-sensitive bugs)
- Waits for a message from `Electric.LockConnection` that the lock is acquired before initialising `ConnectionManager` with the replication stream and shapes.
  - If more than one Electric tries to connect to the same replication slot (with the same `REPLICATION_STREAM_ID`), it will make a blocking query to acquire the lock that will resolve once the previous Electric using that slot releases it - this addresses rolling deploys, and ensures resources are initialised only once the previous Electric has released them
  - Could potentially switch to `pg_try_advisory_lock` that is not a blocking query but immediately returns whether the lock could be acquired and implement retries with backoff, but since using `pg_advisory_lock` simplifies the implementation I decided to start with that and see what people think.
 

Things that I still need to address:
- Currently the publication gets altered when a shape is created (adds a table and potentially a row filter) but no cleanup occurs - so the publication can potentially grow to include everything between restarts and deploys even if it is not being used.
  - The way I want to address this is to change the `Electric.Postgres.Configuration` to alter the publication based on _all_ active shapes rather than based on each individual one, in that case every call will update the publication as necessary and resuming/cleaning can be a matter of calling this every time a shape is deleted and once upon starting (with recovered shapes or no shapes). Can be a separate PR.
  - Created https://github.com/electric-sql/electric/issues/1774 to address this separately
