### PR TITLE
feat (sync-service): add OTEL_DEBUG environment variable

### DIFF
--- a/.changeset/mean-swans-act.md
+++ b/.changeset/mean-swans-act.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add the OTEL_DEBUG environment variable which is a flag to print Open Telemetry spans to stdout.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -29,45 +29,46 @@ config :opentelemetry,
   resource_detectors: [:otel_resource_env_var, :otel_resource_app_env],
   resource: %{service: %{name: service_name, version: version}, instance: %{id: instance_id}}
 
-otel_debug = env!("OTEL_DEBUG", :integer, 0)
-otel_export = env!("OTEL_EXPORT", :string, nil)
-prometheus_port = env!("PROMETHEUS_PORT", :integer, nil)
+otlp_endpoint = env!("OTLP_ENDPOINT", :string, nil)
+otel_debug = env!("OTEL_DEBUG", :boolean, false)
 
-if otel_debug == 1 do
-  # In this mode, each span is printed to stdout as soon as it ends, without batching.
-  config :opentelemetry, :processors,
-    otel_simple_processor: %{exporter: {:otel_exporter_stdout, []}}
-else
-  config :opentelemetry,
-    processors: [],
-    traces_exporter: :none
+if otlp_endpoint do
+  # Shortcut config for Honeycomb.io:
+  # users may set the optional HNY_API_KEY and HNY_DATASET environment variables
+  # and specify the Honeycomb URL in OTLP_ENDPOINT to export traces directly to
+  # Honeycomb, without the need to run an OpenTelemetry Collector.
+  honeycomb_api_key = env!("HNY_API_KEY", :string, nil)
+  honeycomb_dataset = env!("HNY_DATASET", :string, nil)
+
+  headers =
+    Enum.reject(
+      [
+        {"x-honeycomb-team", honeycomb_api_key},
+        {"x-honeycomb-dataset", honeycomb_dataset}
+      ],
+      fn {_, val} -> is_nil(val) end
+    )
+
+  config :opentelemetry_exporter,
+    otlp_protocol: :http_protobuf,
+    otlp_endpoint: otlp_endpoint,
+    otlp_headers: headers,
+    otlp_compression: :gzip
 end
 
-if otel_export == "otlp" do
-  if endpoint = env!("OTLP_ENDPOINT", :string, nil) do
-    # Shortcut config for Honeycomb.io:
-    # users may set the optional HNY_API_KEY and HNY_DATASET environment variables
-    # and specify the Honeycomb URL in OTLP_ENDPOINT to export traces directly to
-    # Honeycomb, without the need to run an OpenTelemetry Collector.
-    honeycomb_api_key = env!("HNY_API_KEY", :string, nil)
-    honeycomb_dataset = env!("HNY_DATASET", :string, nil)
-
-    headers =
-      Enum.reject(
-        [
-          {"x-honeycomb-team", honeycomb_api_key},
-          {"x-honeycomb-dataset", honeycomb_dataset}
-        ],
-        fn {_, val} -> is_nil(val) end
-      )
-
-    config :opentelemetry_exporter,
-      otlp_protocol: :http_protobuf,
-      otlp_endpoint: endpoint,
-      otlp_headers: headers,
-      otlp_compression: :gzip
+otel_batch_processor =
+  if otlp_endpoint do
+    {:otel_batch_processor, %{}}
   end
-end
+
+otel_simple_processor =
+  if otel_debug do
+    # In this mode, each span is printed to stdout as soon as it ends, without batching.
+    {:otel_simple_processor, %{exporter: {:otel_exporter_stdout, []}}}
+  end
+
+config :opentelemetry,
+  processors: [otel_batch_processor, otel_simple_processor] |> Enum.reject(&is_nil/1)
 
 if Config.config_env() == :test do
   config :electric,
@@ -150,6 +151,8 @@ chunk_bytes_threshold =
   )
 
 storage = {storage_mod, storage_opts}
+
+prometheus_port = env!("PROMETHEUS_PORT", :integer, nil)
 
 config :electric,
   allow_shape_deletion: enable_integration_testing,

--- a/packages/sync-service/dev/docker-compose-otel.yml
+++ b/packages/sync-service/dev/docker-compose-otel.yml
@@ -23,7 +23,6 @@ services:
   electric:
     image: electricsql/electric:latest
     environment:
-      OTEL_EXPORT: ${OTEL_EXPORT:-otlp}
       OTLP_ENDPOINT: http://otel:4318/
       PROMETHEUS_PORT: ${PROMETHEUS_PORT:-4000}
       DATABASE_URL: postgresql://postgres:password@postgres:5432/electric

--- a/packages/sync-service/dev/docker-compose-otel.yml
+++ b/packages/sync-service/dev/docker-compose-otel.yml
@@ -45,8 +45,6 @@ services:
     command: ['--config=/conf/otel-collector-config.yaml']
     volumes:
       - ./otel-collector-honeycomb-config.yaml:/conf/otel-collector-config.yaml
-    depends_on:
-      - electric
   nginx:
     image: nginx:latest
     ports:


### PR DESCRIPTION
This PR fixes https://github.com/electric-sql/electric/issues/1714 by introducing a separate `OTEL_DEBUG` env var to enable printing the spans to stdout while also being able to export the spans using `OTEL_EXPORT`.