### PR TITLE
Obfuscate database password to avoid accidentally leaking it in logs

### DIFF
--- a/.changeset/odd-ants-smell.md
+++ b/.changeset/odd-ants-smell.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Obfuscate database password in the process memory to prevent it from accidentally getting logged in cleartext.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -70,9 +70,9 @@ otel_simple_processor =
 config :opentelemetry,
   processors: [otel_batch_processor, otel_simple_processor] |> Enum.reject(&is_nil/1)
 
-if Config.config_env() == :test do
-  config :electric,
-    connection_opts: [
+connection_opts =
+  if Config.config_env() == :test do
+    [
       hostname: "localhost",
       port: 54321,
       username: "postgres",
@@ -80,20 +80,18 @@ if Config.config_env() == :test do
       database: "postgres",
       sslmode: :disable
     ]
-else
-  {:ok, database_url_config} =
-    env!("DATABASE_URL", :string)
-    |> Electric.Config.parse_postgresql_uri()
+  else
+    {:ok, database_url_config} =
+      env!("DATABASE_URL", :string)
+      |> Electric.Config.parse_postgresql_uri()
 
-  database_ipv6_config =
-    env!("DATABASE_USE_IPV6", :boolean, false)
+    database_ipv6_config =
+      env!("DATABASE_USE_IPV6", :boolean, false)
 
-  connection_opts = [ipv6: database_ipv6_config] ++ database_url_config
+    database_url_config ++ [ipv6: database_ipv6_config]
+  end
 
-  config :electric, connection_opts: connection_opts, electric_instance_id: electric_instance_id
-end
-
-config :electric, listen_on_ipv6?: env!("LISTEN_ON_IPV6", :boolean, false)
+config :electric, connection_opts: Electric.Utils.obfuscate_password(connection_opts)
 
 enable_integration_testing = env!("ENABLE_INTEGRATION_TESTING", :boolean, false)
 cache_max_age = env!("CACHE_MAX_AGE", :integer, 60)
@@ -162,10 +160,12 @@ config :electric,
   # Used in telemetry
   environment: config_env(),
   instance_id: instance_id,
+  electric_instance_id: electric_instance_id,
   telemetry_statsd_host: statsd_host,
   db_pool_size: env!("DB_POOL_SIZE", :integer, 50),
   replication_stream_id: env!("REPLICATION_STREAM_ID", :string, "default"),
   service_port: env!("PORT", :integer, 3000),
   prometheus_port: prometheus_port,
   storage: storage,
-  persistent_kv: persistent_kv
+  persistent_kv: persistent_kv,
+  listen_on_ipv6?: env!("LISTEN_ON_IPV6", :boolean, false)

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -314,7 +314,8 @@ defmodule Electric.ConnectionManager do
     #
     # See https://github.com/electric-sql/electric/issues/1554
     Postgrex.start_link(
-      [backoff_type: :exp, max_restarts: 3, max_seconds: 5] ++ pool_opts ++ connection_opts
+      [backoff_type: :exp, max_restarts: 3, max_seconds: 5] ++
+        pool_opts ++ Electric.Utils.deobfuscate_password(connection_opts)
     )
   end
 

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -36,7 +36,8 @@ defmodule Electric.Postgres.LockConnection do
     Postgrex.SimpleConnection.start_link(
       __MODULE__,
       init_opts,
-      connection_opts ++ [timeout: :infinity, auto_reconnect: false]
+      [timeout: :infinity, auto_reconnect: false] ++
+        Electric.Utils.deobfuscate_password(connection_opts)
     )
   end
 

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -100,7 +100,7 @@ defmodule Electric.Postgres.ReplicationClient do
     # Disable the reconnection logic in Postgex.ReplicationConnection to force it to exit with
     # the connection error. Without this, we may observe undesirable restarts in tests between
     # one test process exiting and the next one starting.
-    connect_opts = [auto_reconnect: false] ++ connection_opts
+    connect_opts = [auto_reconnect: false] ++ Electric.Utils.deobfuscate_password(connection_opts)
 
     case Postgrex.ReplicationConnection.start_link(__MODULE__, replication_opts, connect_opts) do
       {:ok, pid} ->


### PR DESCRIPTION
Fix #1718.

Obfuscation is implemented by wrapping the password in a zero-arity function as early as possible, so that the password is never stored in cleartext in any of our processes' state. The deobfuscation happens right before passing connection options to Postgrex. This creates an explicit point of hand-off where the responsibility for keeping the password from getting leaked is transfered from our code to Postgrex.