### PR TITLE
fix (sync-service): let Postgres handle user-provided root table name

### DIFF
--- a/.changeset/metal-rocks-type.md
+++ b/.changeset/metal-rocks-type.md
@@ -1,0 +1,6 @@
+---
+"@core/sync-service": minor
+---
+
+Lets Postgres validate user-provided table identifier.
+This means identifiers are now case insensitive unless you explitictly quote them.

--- a/packages/sync-service/lib/electric/postgres/inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector.ex
@@ -19,19 +19,39 @@ defmodule Electric.Postgres.Inspector do
 
   @callback clean_column_info(relation(), opts :: term()) :: true
 
+  @callback get_namespace_and_tablename(relation(), opts :: term()) ::
+              {:ok, relation()} | :table_not_found
+
   @type inspector :: {module(), opts :: term()}
 
   @doc """
   Load column information about a given table using a provided inspector.
   """
   @spec load_column_info(relation(), inspector()) :: {:ok, [column_info()]} | :table_not_found
-  def load_column_info(relation, {module, opts}), do: module.load_column_info(relation, opts)
+  def load_column_info(relation, {module, opts}) do
+    module.load_column_info(relation, opts)
+  end
 
   @doc """
   Clean up column information about a given table using a provided inspector.
   """
   @spec clean_column_info(relation(), inspector()) :: true
   def clean_column_info(relation, {module, opts}), do: module.clean_column_info(relation, opts)
+
+  @doc """
+  Expects the table name provided by the user
+  and validates that the table exists and returns the namespace and table name.
+
+  The table name can be quoted or unquoted and can optionally be qualified,
+  e.g. `users` would return `{"public", "users"}`,
+       `usErs` would return `{"public", "users"}`,
+       `"Users"` would return `{"public", "Users"}`,
+       `some_schema.users` would return `{"some_schema", "users"}`.
+  """
+  @spec get_namespace_and_tablename(String.t(), inspector()) ::
+          relation() | {:error, String.t()}
+  def get_namespace_and_tablename(table, {module, opts}),
+    do: module.get_namespace_and_tablename(table, opts)
 
   @doc """
   Get columns that should be considered a PK for table. If the table

--- a/packages/sync-service/lib/electric/postgres/inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector.ex
@@ -14,15 +14,40 @@ defmodule Electric.Postgres.Inspector do
           array_type: String.t()
         }
 
+  @callback load_relation(String.t(), opts :: term()) ::
+              {:ok, relation()} | {:error, String.t()}
+
+  @callback clean_relation(relation(), opts :: term()) :: true
+
   @callback load_column_info(relation(), opts :: term()) ::
               {:ok, [column_info()]} | :table_not_found
 
   @callback clean_column_info(relation(), opts :: term()) :: true
 
-  @callback get_namespace_and_tablename(relation(), opts :: term()) ::
-              {:ok, relation()} | :table_not_found
+  @callback clean(relation(), opts :: term()) :: true
 
   @type inspector :: {module(), opts :: term()}
+
+  @doc """
+  Expects the table name provided by the user
+  and validates that the table exists and returns the relation.
+
+  The table name can be quoted or unquoted and can optionally be qualified,
+  e.g. `users` would return `{"public", "users"}`,
+       `usErs` would return `{"public", "users"}`,
+       `"Users"` would return `{"public", "Users"}`,
+       `some_schema.users` would return `{"some_schema", "users"}`.
+  """
+  @spec load_relation(String.t(), inspector()) :: {:ok, relation()} | {:error, String.t()}
+  def load_relation(table, {module, opts}),
+    do: module.load_relation(table, opts)
+
+  @doc """
+  Clean up relation information about a given table using a provided inspector.
+  """
+  @spec clean_relation(relation(), inspector()) :: true
+  def clean_relation(rel, {module, opts}),
+    do: module.clean_relation(rel, opts)
 
   @doc """
   Load column information about a given table using a provided inspector.
@@ -39,19 +64,10 @@ defmodule Electric.Postgres.Inspector do
   def clean_column_info(relation, {module, opts}), do: module.clean_column_info(relation, opts)
 
   @doc """
-  Expects the table name provided by the user
-  and validates that the table exists and returns the namespace and table name.
-
-  The table name can be quoted or unquoted and can optionally be qualified,
-  e.g. `users` would return `{"public", "users"}`,
-       `usErs` would return `{"public", "users"}`,
-       `"Users"` would return `{"public", "Users"}`,
-       `some_schema.users` would return `{"some_schema", "users"}`.
+  Clean up all information about a given relation using a provided inspector.
   """
-  @spec get_namespace_and_tablename(String.t(), inspector()) ::
-          relation() | {:error, String.t()}
-  def get_namespace_and_tablename(table, {module, opts}),
-    do: module.get_namespace_and_tablename(table, opts)
+  @spec clean(relation(), inspector()) :: true
+  def clean(relation, {module, opts}), do: module.clean_column_info(relation, opts)
 
   @doc """
   Get columns that should be considered a PK for table. If the table

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -20,8 +20,8 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
       {:ok, result} ->
         # We expect exactly one row because the query didn't fail
         # so the relation exists since we could cast it to a regclass
-        info = Enum.at(result.rows, 0)
-        {:ok, {Enum.at(info, 0), Enum.at(info, 1)}}
+        [[schema, table]] = result.rows
+        {:ok, {schema, table}}
 
       {:error, err} ->
         {:error, Exception.message(err)}

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -29,6 +29,7 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
     result = Postgrex.query!(conn, query, [tbl, namespace])
 
     if Enum.empty?(result.rows) do
+      # Fixme: this is not necessarily true. The table might exist but have no columns.
       :table_not_found
     else
       columns = Enum.map(result.columns, &String.to_atom/1)
@@ -38,4 +39,28 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
   end
 
   def clean_column_info(_, _), do: true
+
+  def get_namespace_and_tablename(table, conn) do
+    # The extra cast from $1 to text is needed because of Postgrex' OID type encoding
+    # see: https://github.com/elixir-ecto/postgrex#oid-type-encoding
+    query = """
+    SELECT nspname, relname
+    FROM pg_class
+    JOIN pg_namespace ON relnamespace = pg_namespace.oid
+    WHERE
+      relkind = 'r' AND
+      pg_class.oid = $1::text::regclass
+    """
+
+    case Postgrex.query(conn, query, [table]) do
+      {:ok, result} ->
+        # We expect exactly one row because the query didn't fail
+        # so the relation exists since we could cast it to a regclass
+        info = Enum.at(result.rows, 0)
+        {Enum.at(info, 0), Enum.at(info, 1)}
+
+      {:error, err} ->
+        {:error, Exception.message(err)}
+    end
+  end
 end

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -4,6 +4,7 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   @behaviour Electric.Postgres.Inspector
 
   @default_pg_info_table :pg_info_table
+  @default_pg_relation_table :pg_relation_table
 
   ## Public API
 
@@ -11,9 +12,37 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     do:
       GenServer.start_link(
         __MODULE__,
-        Map.new(opts) |> Map.put_new(:pg_info_table, @default_pg_info_table),
+        Map.new(opts)
+        |> Map.put_new(:pg_info_table, @default_pg_info_table)
+        |> Map.put_new(:pg_relation_table, @default_pg_relation_table),
         name: Access.get(opts, :name, __MODULE__)
       )
+
+  @impl Electric.Postgres.Inspector
+  def load_relation(table, opts) do
+    case relation_from_ets(table, opts) do
+      :not_found ->
+        GenServer.call(opts[:server], {:load_relation, table})
+
+      rel ->
+        {:ok, rel}
+    end
+  end
+
+  @impl Electric.Postgres.Inspector
+  def clean_relation(rel, opts_or_state) do
+    pg_relation_ets_table =
+      Access.get(opts_or_state, :pg_relation_table, @default_pg_relation_table)
+
+    pg_info_ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
+
+    # Delete all tables that are associated with the relation
+    tables_from_ets(rel, opts_or_state)
+    |> Enum.each(fn table -> :ets.delete(pg_info_ets_table, {table, :table_to_relation}) end)
+
+    # Delete the relation itself
+    :ets.delete(pg_relation_ets_table, {rel, :relation_to_table})
+  end
 
   @impl Electric.Postgres.Inspector
   def load_column_info({_namespace, _table_name} = table, opts) do
@@ -37,8 +66,9 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   end
 
   @impl Electric.Postgres.Inspector
-  def get_namespace_and_tablename(table, opts) do
-    GenServer.call(opts[:server], {:get_namespace_and_tablename, table})
+  def clean(relation, opts_or_state) do
+    clean_column_info(relation, opts_or_state)
+    clean_relation(relation, opts_or_state)
   end
 
   ## Internal API
@@ -46,13 +76,50 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   @impl GenServer
   def init(opts) do
     pg_info_table = :ets.new(opts.pg_info_table, [:named_table, :public, :set])
+    pg_relation_table = :ets.new(opts.pg_relation_table, [:named_table, :public, :bag])
 
     state = %{
       pg_info_table: pg_info_table,
+      pg_relation_table: pg_relation_table,
       pg_pool: opts.pool
     }
 
     {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:load_relation, table}, _from, state) do
+    # This serves as a write-through cache for caching
+    # the namespace and tablename as they occur in PG.
+    # Note that if users create shapes for the same table but spelled differently,
+    # e.g. `~s|public.users|`, `~s|users|`, `~s|Users|`, and `~s|USERS|`
+    # then there will be 4 entries in the cache each of which maps to `{~s|public|, ~s|users|}`.
+    # If they create a shape for a different table `~s|"Users"|`, then there will be another entry
+    # in ETS for `~s|"Users"|` that maps to `{~s|public|, ~s|"Users"|}`.
+    case relation_from_ets(table, state) do
+      :not_found ->
+        case DirectInspector.load_relation(table, state.pg_pool) do
+          {:error, err} ->
+            {:reply, {:error, err}, state}
+
+          {:ok, relation} ->
+            # We keep the mapping in both directions:
+            # - Forward: user-provided table name -> PG relation (many-to-one)
+            #     e.g. `~s|users|` -> `{"public", "users"}`
+            #          `~s|USERS|` -> `{"public", "users"}`
+            # - Backward: and PG relation -> user-provided table names (one-to-many)
+            #     e.g. `{"public", "users"}` -> `[~s|users|, ~s|USERS|]`
+            #
+            # The forward direction allows for efficient lookup (based on user-provided table name)
+            # the backward direction allows for efficient cleanup (based on PG relation)
+            :ets.insert(state.pg_info_table, {{table, :table_to_relation}, relation})
+            :ets.insert(state.pg_relation_table, {{relation, :relation_to_table}, table})
+            {:reply, {:ok, relation}, state}
+        end
+
+      relation ->
+        {:reply, {:ok, relation}, state}
+    end
   end
 
   @impl GenServer
@@ -76,8 +143,19 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     e -> {:reply, {:error, e, __STACKTRACE__}, state}
   end
 
-  def handle_call({:get_namespace_and_tablename, table}, _from, state) do
-    {:reply, DirectInspector.get_namespace_and_tablename(table, state.pg_pool), state}
+  @pg_rel_position 2
+  defp relation_from_ets(table, opts_or_state) do
+    ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
+
+    :ets.lookup_element(ets_table, {table, :table_to_relation}, @pg_rel_position, :not_found)
+  end
+
+  @pg_table_idx 1
+  defp tables_from_ets(relation, opts_or_state) do
+    ets_table = Access.get(opts_or_state, :pg_relation_table, @default_pg_relation_table)
+
+    :ets.lookup(ets_table, {relation, :relation_to_table})
+    |> Enum.map(&elem(&1, @pg_table_idx))
   end
 
   @column_info_position 2

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -36,6 +36,11 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     :ets.delete(ets_table, {table, :columns})
   end
 
+  @impl Electric.Postgres.Inspector
+  def get_namespace_and_tablename(table, opts) do
+    GenServer.call(opts[:server], {:get_namespace_and_tablename, table})
+  end
+
   ## Internal API
 
   @impl GenServer
@@ -69,6 +74,10 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     end
   rescue
     e -> {:reply, {:error, e, __STACKTRACE__}, state}
+  end
+
+  def handle_call({:get_namespace_and_tablename, table}, _from, state) do
+    {:reply, DirectInspector.get_namespace_and_tablename(table, state.pg_pool), state}
   end
 
   @column_info_position 2

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -261,7 +261,7 @@ defmodule Electric.ShapeCache do
       # because the table name may have changed in the new relation
       # if there is no old relation, we use the new one
       rel = old_rel || relation
-      inspector.clean_column_info({rel.schema, rel.table}, inspector_opts)
+      inspector.clean({rel.schema, rel.table}, inspector_opts)
     end
 
     {:noreply, [], state}

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -100,7 +100,16 @@ defmodule Electric.Shapes.Shape do
   defp validate_table(table, inspector) when is_binary(table) do
     case Inspector.load_relation(table, inspector) do
       {:error, err} ->
-        {:error, [err]}
+        case Regex.run(~r/.+ relation "(?<name>.+)" does not exist/, err, capture: :all_names) do
+          [table_name] ->
+            {:error,
+             [
+               ~s|Table "#{table_name}" does not exist. If the table name contains capitals or special characters you must quote it.|
+             ]}
+
+          _ ->
+            {:error, [err]}
+        end
 
       {:ok, rel} ->
         {:ok, rel}

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -99,7 +99,7 @@ defmodule Electric.Shapes.Shape do
 
   defp validate_table(definition) when is_binary(definition) do
     regex =
-      ~r/^((?<schema>([a-z_][a-zA-Z0-9_]*|"(""|[^"])+"))\.)?(?<table>([a-z_][a-zA-Z0-9_]*|"(""|[^"])+"))$/
+      ~r/^((?<schema>([\p{L}_][\p{L}0-9_$]*|"(""|[^"])+"))\.)?(?<table>([\p{L}_][\p{L}0-9_$]*|"(""|[^"])+"))$/u
 
     case Regex.run(regex, definition, capture: :all_names) do
       ["", table_name] when table_name != "" ->

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -97,13 +97,13 @@ defmodule Electric.Shapes.Shape do
     end
   end
 
-  defp validate_table(root_table, inspector) when is_binary(root_table) do
-    case Inspector.get_namespace_and_tablename(root_table, inspector) do
+  defp validate_table(table, inspector) when is_binary(table) do
+    case Inspector.load_relation(table, inspector) do
       {:error, err} ->
         {:error, [err]}
 
-      table ->
-        {:ok, table}
+      {:ok, rel} ->
+        {:ok, rel}
     end
   end
 

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -217,7 +217,7 @@ defmodule Electric.Utils do
       ~S|FooBar|
 
       iex> parse_quoted_name(~S|FooBar|)
-      ~S|foobar|
+      ~S|FooBar|
   """
   def parse_quoted_name(str) do
     if String.first(str) == ~s(") && String.last(str) == ~s(") do
@@ -226,7 +226,7 @@ defmodule Electric.Utils do
       |> String.slice(1..-2//1)
       |> String.replace(~r/""/, ~s("))
     else
-      String.downcase(str)
+      str
     end
   end
 

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -201,6 +201,7 @@ defmodule Electric.Utils do
 
   @doc """
   Parses quoted names.
+  Lowercases unquoted names to match Postgres' case insensitivity.
 
   ## Examples
       iex> parse_quoted_name("foo")
@@ -211,6 +212,12 @@ defmodule Electric.Utils do
 
       iex> parse_quoted_name(~S|"fo""o"|)
       ~S|fo"o|
+
+      iex> parse_quoted_name(~S|"FooBar"|)
+      ~S|FooBar|
+
+      iex> parse_quoted_name(~S|FooBar|)
+      ~S|foobar|
   """
   def parse_quoted_name(str) do
     if String.first(str) == ~s(") && String.last(str) == ~s(") do
@@ -219,7 +226,7 @@ defmodule Electric.Utils do
       |> String.slice(1..-2//1)
       |> String.replace(~r/""/, ~s("))
     else
-      str
+      String.downcase(str)
     end
   end
 

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -28,6 +28,9 @@ defmodule Electric.Plug.DeleteShapePlugTest do
   def load_column_info({"public", "users"}, _),
     do: {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
 
+  def get_namespace_and_tablename(tbl, _),
+    do: Support.StubInspector.get_namespace_and_tablename(tbl, nil)
+
   setup do
     start_link_supervised!({Registry, keys: :duplicate, name: @registry})
     :ok
@@ -70,7 +73,9 @@ defmodule Electric.Plug.DeleteShapePlugTest do
       assert conn.status == 400
 
       assert Jason.decode!(conn.resp_body) == %{
-               "root_table" => ["table name does not match expected format"]
+               "root_table" => [
+                 "invalid name syntax"
+               ]
              }
     end
 

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -28,8 +28,8 @@ defmodule Electric.Plug.DeleteShapePlugTest do
   def load_column_info({"public", "users"}, _),
     do: {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
 
-  def get_namespace_and_tablename(tbl, _),
-    do: Support.StubInspector.get_namespace_and_tablename(tbl, nil)
+  def load_relation(tbl, _),
+    do: Support.StubInspector.load_relation(tbl, nil)
 
   setup do
     start_link_supervised!({Registry, keys: :duplicate, name: @registry})

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -75,7 +75,11 @@ defmodule Electric.Plug.RouterTest do
 
       assert %{status: 400} = conn
 
-      assert %{"root_table" => ["table not found"]} = Jason.decode!(conn.resp_body)
+      assert %{
+               "root_table" => [
+                 "ERROR 42P01 (undefined_table) relation \"nonexistent\" does not exist"
+               ]
+             } = Jason.decode!(conn.resp_body)
     end
 
     @tag additional_fields: "num INTEGER NOT NULL"

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -77,7 +77,7 @@ defmodule Electric.Plug.RouterTest do
 
       assert %{
                "root_table" => [
-                 "ERROR 42P01 (undefined_table) relation \"nonexistent\" does not exist"
+                 ~s|Table "nonexistent" does not exist. If the table name contains capitals or special characters you must quote it.|
                ]
              } = Jason.decode!(conn.resp_body)
     end

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -39,8 +39,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
   def load_column_info(_, _),
     do: :table_not_found
 
-  def get_namespace_and_tablename(tbl, _),
-    do: Support.StubInspector.get_namespace_and_tablename(tbl, nil)
+  def load_relation(tbl, _),
+    do: Support.StubInspector.load_relation(tbl, nil)
 
   setup do
     start_link_supervised!({Registry, keys: :duplicate, name: @registry})

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -39,6 +39,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
   def load_column_info(_, _),
     do: :table_not_found
 
+  def get_namespace_and_tablename(tbl, _),
+    do: Support.StubInspector.get_namespace_and_tablename(tbl, nil)
+
   setup do
     start_link_supervised!({Registry, keys: :duplicate, name: @registry})
     :ok
@@ -70,37 +73,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       assert Jason.decode!(conn.resp_body) == %{
                "offset" => ["has invalid format"],
-               "root_table" => ["table name does not match expected format"]
-             }
-
-      conn =
-        conn(:get, %{"root_table" => "1nvalid"}, "?offset=-1")
-        |> ServeShapePlug.call([])
-
-      assert conn.status == 400
-
-      assert Jason.decode!(conn.resp_body) == %{
-               "root_table" => ["table name does not match expected format"]
-             }
-
-      conn =
-        conn(:get, %{"root_table" => "$invalid"}, "?offset=-1")
-        |> ServeShapePlug.call([])
-
-      assert conn.status == 400
-
-      assert Jason.decode!(conn.resp_body) == %{
-               "root_table" => ["table name does not match expected format"]
-             }
-
-      conn =
-        conn(:get, %{"root_table" => "inval!d"}, "?offset=-1")
-        |> ServeShapePlug.call([])
-
-      assert conn.status == 400
-
-      assert Jason.decode!(conn.resp_body) == %{
-               "root_table" => ["table name does not match expected format"]
+               "root_table" => [
+                 "invalid name syntax"
+               ]
              }
     end
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -36,6 +36,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
   def load_column_info({"public", "users"}, _),
     do: {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
 
+  def load_column_info(_, _),
+    do: :table_not_found
+
   setup do
     start_link_supervised!({Registry, keys: :duplicate, name: @registry})
     :ok
@@ -68,6 +71,50 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Jason.decode!(conn.resp_body) == %{
                "offset" => ["has invalid format"],
                "root_table" => ["table name does not match expected format"]
+             }
+
+      conn =
+        conn(:get, %{"root_table" => "1nvalid"}, "?offset=-1")
+        |> ServeShapePlug.call([])
+
+      assert conn.status == 400
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "root_table" => ["table name does not match expected format"]
+             }
+
+      conn =
+        conn(:get, %{"root_table" => "$invalid"}, "?offset=-1")
+        |> ServeShapePlug.call([])
+
+      assert conn.status == 400
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "root_table" => ["table name does not match expected format"]
+             }
+
+      conn =
+        conn(:get, %{"root_table" => "inval!d"}, "?offset=-1")
+        |> ServeShapePlug.call([])
+
+      assert conn.status == 400
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "root_table" => ["table name does not match expected format"]
+             }
+    end
+
+    test "returns 400 when table does not exist" do
+      # this will pass table name validation
+      # but will fail to find the table
+      conn =
+        conn(:get, %{"root_table" => "_val1d_schëmaΦ$.Φtàble"}, "?offset=-1")
+        |> ServeShapePlug.call([])
+
+      assert conn.status == 400
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "root_table" => ["table not found"]
              }
     end
 

--- a/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
+++ b/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
@@ -4,6 +4,124 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
   import Support.DbStructureSetup
   alias Electric.Postgres.Inspector.EtsInspector
 
+  describe "load_relation/2" do
+    setup [:with_inspector, :with_basic_tables, :with_sql_execute]
+
+    setup %{inspector: {EtsInspector, opts}} do
+      {:ok, %{opts: opts, table: {"public", "items"}}}
+    end
+
+    test "returns relation from table name", %{opts: opts, table: table} do
+      assert {:ok, ^table} = EtsInspector.load_relation("PuBliC.ItEmS", opts)
+    end
+
+    test "returns same value from ETS cache as the original call", %{opts: opts, table: table} do
+      original = EtsInspector.load_relation("PuBliC.ItEmS", opts)
+      from_cache = EtsInspector.load_relation("PuBliC.ItEmS", opts)
+      assert original == from_cache
+      assert {:ok, ^table} = original
+    end
+
+    test "returns same value from ETS cache as the original call with concurrent calls", %{
+      opts: opts,
+      table: table
+    } do
+      task = Task.async(fn -> EtsInspector.load_relation("PuBliC.ItEmS", opts) end)
+      original = EtsInspector.load_relation("PuBliC.ItEmS", opts)
+      from_cache = Task.await(task)
+      assert original == from_cache
+      assert {:ok, ^table} = original
+    end
+
+    @tag with_sql: [
+           ~s|CREATE TABLE "ITEMS" (a INT PRIMARY KEY)|
+         ]
+    test "is case insensitive when unquoted and case sensitive when quoted", %{
+      opts: opts,
+      table: table
+    } do
+      original1 = EtsInspector.load_relation("PuBliC.ITEMS", opts)
+      from_cache1 = EtsInspector.load_relation("PuBliC.ITEMS", opts)
+      assert original1 == from_cache1
+      assert {:ok, ^table} = original1
+
+      original2 = EtsInspector.load_relation(~s|PuBliC."ITEMS"|, opts)
+      from_cache2 = EtsInspector.load_relation(~s|PuBliC."ITEMS"|, opts)
+      assert original2 == from_cache2
+      assert {:ok, {"public", "ITEMS"}} = original2
+    end
+  end
+
+  describe "clean_relation/2" do
+    setup [:with_inspector, :with_basic_tables, :with_sql_execute]
+
+    setup %{
+      inspector: {EtsInspector, opts},
+      pg_info_table: pg_info_table,
+      pg_relation_table: pg_relation_table
+    } do
+      {:ok,
+       %{
+         opts: opts,
+         pg_info_table: pg_info_table,
+         pg_relation_table: pg_relation_table,
+         table: {"public", "items"}
+       }}
+    end
+
+    @tag with_sql: [
+           ~s|CREATE TABLE "ITEMS" (a INT PRIMARY KEY)|
+         ]
+    test "cleans up relation information from ETS cache", %{
+      inspector: {EtsInspector, opts},
+      pg_info_table: pg_info_table,
+      pg_relation_table: pg_relation_table
+    } do
+      # Different spellings of the same table
+      table1 = "public.items"
+      table2 = "PUBLIC.ITEMS"
+
+      # Another table
+      table3 = ~s|"ITEMS"|
+
+      assert {:ok, relation} = EtsInspector.load_relation(table1, opts)
+      assert {:ok, ^relation} = EtsInspector.load_relation(table2, opts)
+      assert {:ok, relation2} = EtsInspector.load_relation(table3, opts)
+      assert relation != relation2
+
+      # Check that the relations are in the ETS cache
+      assert :ets.lookup(pg_relation_table, {relation, :relation_to_table}) == [
+               {{relation, :relation_to_table}, "public.items"},
+               {{relation, :relation_to_table}, "PUBLIC.ITEMS"}
+             ]
+
+      assert :ets.lookup(pg_relation_table, {relation2, :relation_to_table}) == [
+               {{relation2, :relation_to_table}, ~s|"ITEMS"|}
+             ]
+
+      assert :ets.lookup_element(pg_info_table, {table1, :table_to_relation}, 2, :not_found) ==
+               relation
+
+      assert :ets.lookup_element(pg_info_table, {table2, :table_to_relation}, 2, :not_found) ==
+               relation
+
+      assert :ets.lookup_element(pg_info_table, {table3, :table_to_relation}, 2, :not_found) ==
+               relation2
+
+      # Now clean up the relation
+      # and check that it is no longer in the ETS cache
+      assert EtsInspector.clean_relation(relation, opts)
+
+      assert :ets.member(pg_relation_table, {relation, :relation_to_table}) == false
+      assert :ets.member(pg_info_table, {table1, :table_to_relation}) == false
+      assert :ets.member(pg_info_table, {table2, :table_to_relation}) == false
+
+      # relation2 should still be in the cache
+      assert :ets.member(pg_relation_table, {relation2, :relation_to_table}) == true
+      assert :ets.member(pg_info_table, {table3, :table_to_relation}) == true
+    end
+  end
+
   describe "load_column_info/2" do
     setup [:with_inspector, :with_basic_tables]
 

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -6,6 +6,7 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
   alias Electric.Replication.Changes.{Column, Relation}
   alias Electric.ShapeCache.ShapeStatus
   alias Electric.Shapes.Shape
+  alias Support.StubInspector
 
   defp shape! do
     assert {:ok, %Shape{where: %{query: "value = 'test'"}} = shape} =
@@ -250,4 +251,7 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
 
   def load_column_info({"public", "table"}, _),
     do: {:ok, [%{name: "id", type: :int8, pk_position: 0}]}
+
+  def get_namespace_and_tablename(tbl, _),
+    do: StubInspector.get_namespace_and_tablename(tbl, nil)
 end

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -252,6 +252,6 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
   def load_column_info({"public", "table"}, _),
     do: {:ok, [%{name: "id", type: :int8, pk_position: 0}]}
 
-  def get_namespace_and_tablename(tbl, _),
-    do: StubInspector.get_namespace_and_tablename(tbl, nil)
+  def load_relation(tbl, _),
+    do: StubInspector.load_relation(tbl, nil)
 end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1051,7 +1051,7 @@ defmodule Electric.ShapeCacheTest do
       }
 
       Mock.Inspector
-      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> expect(:clean, 1, fn {"public", "test_table"}, _ -> true end)
       |> allow(self(), opts[:server])
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
@@ -1081,13 +1081,13 @@ defmodule Electric.ShapeCacheTest do
       }
 
       Mock.Inspector
-      |> expect(:clean_column_info, 1, fn _, _ -> true end)
+      |> expect(:clean, 1, fn _, _ -> true end)
       |> allow(self(), opts[:server])
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
 
       Mock.Inspector
-      |> expect(:clean_column_info, 0, fn _, _ -> true end)
+      |> expect(:clean, 0, fn _, _ -> true end)
       |> allow(self(), opts[:server])
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
@@ -1114,7 +1114,7 @@ defmodule Electric.ShapeCacheTest do
       }
 
       Mock.Inspector
-      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> expect(:clean, 1, fn {"public", "test_table"}, _ -> true end)
       |> allow(self(), opts[:server])
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
@@ -1146,13 +1146,13 @@ defmodule Electric.ShapeCacheTest do
       }
 
       Mock.Inspector
-      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> expect(:clean, 1, fn {"public", "test_table"}, _ -> true end)
       |> allow(self(), opts[:server])
 
       assert :ok = ShapeLogCollector.handle_relation_msg(old_rel, ctx.shape_log_collector)
 
       Mock.Inspector
-      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> expect(:clean, 1, fn {"public", "test_table"}, _ -> true end)
       |> allow(self(), opts[:server])
 
       log =
@@ -1192,13 +1192,13 @@ defmodule Electric.ShapeCacheTest do
       }
 
       Mock.Inspector
-      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> expect(:clean, 1, fn {"public", "test_table"}, _ -> true end)
       |> allow(self(), opts[:server])
 
       assert :ok = ShapeLogCollector.handle_relation_msg(old_rel, ctx.shape_log_collector)
 
       Mock.Inspector
-      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+      |> expect(:clean, 1, fn {"public", "test_table"}, _ -> true end)
       |> allow(self(), opts[:server])
 
       log =

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -48,6 +48,10 @@ defmodule Electric.Shapes.ConsumerTest do
     {"public", "test_table"}, _ -> {:ok, [%{name: "id", type: "int8", pk_position: 0}]}
   end)
 
+  stub(Mock.Inspector, :get_namespace_and_tablename, fn
+    "public.test_table", _ -> {"public", "test_table"}
+  end)
+
   setup :with_electric_instance_id
   setup :set_mox_from_context
   setup :verify_on_exit!

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -48,8 +48,8 @@ defmodule Electric.Shapes.ConsumerTest do
     {"public", "test_table"}, _ -> {:ok, [%{name: "id", type: "int8", pk_position: 0}]}
   end)
 
-  stub(Mock.Inspector, :get_namespace_and_tablename, fn
-    "public.test_table", _ -> {"public", "test_table"}
+  stub(Mock.Inspector, :load_relation, fn
+    tbl, _ -> StubInspector.load_relation(tbl, nil)
   end)
 
   setup :with_electric_instance_id

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -371,6 +371,6 @@ defmodule Electric.Shapes.ShapeTest do
 
   def load_column_info(_, _), do: :table_not_found
 
-  def get_namespace_and_tablename(tbl, _),
-    do: Support.StubInspector.get_namespace_and_tablename(tbl, nil)
+  def load_relation(tbl, _),
+    do: Support.StubInspector.load_relation(tbl, nil)
 end

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -199,7 +199,10 @@ defmodule Electric.Shapes.ShapeTest do
     end
 
     test "errors when the table doesn't exist", %{inspector: inspector} do
-      {:error, [~S|ERROR 42P01 (undefined_table) relation "nonexistent" does not exist|]} =
+      {:error,
+       [
+         ~S|Table "nonexistent" does not exist. If the table name contains capitals or special characters you must quote it.|
+       ]} =
         Shape.new("nonexistent", inspector: inspector)
     end
 

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -131,11 +131,23 @@ defmodule Support.ComponentSetup do
   def with_inspector(ctx) do
     server = :"inspector #{full_test_name(ctx)}"
     pg_info_table = :"pg_info_table #{full_test_name(ctx)}"
+    pg_relation_table = :"pg_relation_table #{full_test_name(ctx)}"
 
     {:ok, _} =
-      EtsInspector.start_link(pg_info_table: pg_info_table, pool: ctx.db_conn, name: server)
+      EtsInspector.start_link(
+        pg_info_table: pg_info_table,
+        pg_relation_table: pg_relation_table,
+        pool: ctx.db_conn,
+        name: server
+      )
 
-    %{inspector: {EtsInspector, pg_info_table: pg_info_table, server: server}}
+    %{
+      inspector:
+        {EtsInspector,
+         pg_info_table: pg_info_table, pg_relation_table: pg_relation_table, server: server},
+      pg_info_table: pg_info_table,
+      pg_relation_table: pg_relation_table
+    }
   end
 
   def with_complete_stack(ctx, opts \\ []) do

--- a/packages/sync-service/test/support/db_structure_setup.ex
+++ b/packages/sync-service/test/support/db_structure_setup.ex
@@ -27,8 +27,11 @@ defmodule Support.DbStructureSetup do
         sql
         |> List.wrap()
         |> Enum.map(fn
-          stmt when is_binary(stmt) -> Postgrex.query!(conn, stmt, [])
-          {stmt, params} -> Postgrex.query!(conn, stmt, params)
+          stmt when is_binary(stmt) ->
+            Postgrex.query!(conn, stmt, [])
+
+          {stmt, params} ->
+            Postgrex.query!(conn, stmt, params)
         end)
       end)
 

--- a/packages/sync-service/test/support/stub_inspector.ex
+++ b/packages/sync-service/test/support/stub_inspector.ex
@@ -22,19 +22,19 @@ defmodule Support.StubInspector do
   end
 
   @impl true
-  def get_namespace_and_tablename(table, _) do
+  def load_relation(table, _) do
     regex =
       ~r/^((?<schema>([\p{L}_][\p{L}0-9_$]*|"(""|[^"])+"))\.)?(?<table>([\p{L}_][\p{L}0-9_$]*|"(""|[^"])+"))$/u
 
     case Regex.run(regex, table, capture: :all_names) do
       ["", table_name] when table_name != "" ->
         table_name = Utils.parse_quoted_name(table_name)
-        {"public", table_name}
+        {:ok, {"public", table_name}}
 
       [schema_name, table_name] when table_name != "" ->
         schema_name = Utils.parse_quoted_name(schema_name)
         table_name = Utils.parse_quoted_name(table_name)
-        {schema_name, table_name}
+        {:ok, {schema_name, table_name}}
 
       _ ->
         {:error, "invalid name syntax"}
@@ -43,4 +43,10 @@ defmodule Support.StubInspector do
 
   @impl true
   def clean_column_info(_, _), do: true
+
+  @impl true
+  def clean_relation(_, _), do: true
+
+  @impl true
+  def clean(_, _), do: true
 end


### PR DESCRIPTION
This PR fixes https://github.com/electric-sql/electric/issues/1764 according to the approach that was decided by @KyleAMathews, namely to adhere to Postgres' way of handling identifiers. Therefore, this PR modifies Electric such that it passes the user-provided root table to Postgres which then returns the actual relation (i.e. schema and table name). Which we then use throughout the rest of the code as before.

We extended the ETS inspector with a write-through cache that caches the relation. For any incoming request, it tries to fetch the relation for that table from the cache. If not found, it loads it from PG and stores it in the cache. Note that many table name spellings can refer to the same relation, e.g. `users`, `USERS`, `public.users`, etc. all refer to the same relation `{public, users}`. For each different spelling, we will load the relation from PG and store it in the cache. Subsequent requests then load it from cache. We also cache the inverse (mapping relation to the different table names) in order to efficiently clean up.