### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/.support/docker-compose.yml
+++ b/.support/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   backend:
     image: electricsql/electric:canary
     environment:
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/electric
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/electric?sslmode=disable
     ports:
       - 3000:3000
     build:

--- a/website/public/docker-compose.yaml
+++ b/website/public/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
   electric:
     image: electricsql/electric
     environment:
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/electric
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/electric?sslmode=disable
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
With current docker-compose without ssl mode enabled, electric wont connect to local postgresql started by docker-compose. This PR disable sslmode in the url

```
 [warning]  Database connection in lock_connection mode failed: ssl not available
```