### PR TITLE
fix(sync-service): Query Postgres server version at the start of connection setup

### DIFF
--- a/.changeset/dry-buses-fail.md
+++ b/.changeset/dry-buses-fail.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Query Postgres server version as early as possible so that it is available throughout the whole connection initialization process.

--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -237,7 +237,9 @@ defmodule Electric.Postgres.ConfigurationTest do
   end
 
   defp list_tables_in_publication(conn, publication) do
-    pg_version = Electric.ConnectionManager.query_pg_version(conn)
+    %{rows: [[pg_version]]} =
+      Postgrex.query!(conn, "SELECT current_setting('server_version_num')::integer", [])
+
     list_tables_in_pub(conn, publication, pg_version)
   end
 

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -49,7 +49,9 @@ defmodule Support.DbSetup do
   end
 
   def with_pg_version(ctx) do
-    pg_version = Electric.ConnectionManager.query_pg_version(ctx.db_conn)
+    %{rows: [[pg_version]]} =
+      Postgrex.query!(ctx.db_conn, "SELECT current_setting('server_version_num')::integer", [])
+
     {:ok, %{get_pg_version: fn -> pg_version end}}
   end
 


### PR DESCRIPTION
We were querying it after starting the replication client before, which was too late, because by that time the shape recovery process might have already reached `Electric.Postgres.Configuration.configure_tables_for_replication!()` where the version is used to branch the control flow. This was causing flake in integration tests due to the version not always being there and the unsupported query being issue against Postgres version 14.

In short, this PR resolves the flakiness in integration tests, they should be consistently green from now on. 

The choice of augmenting the `LockConnection` module with version querying and a crude state machine might seem dubious but the end result is simpler this way, compared to adding version querying to the replication client, for example.