### PR TITLE
chore: Refactor shape_id -> shape_handle for clearer name

### DIFF
--- a/integration-tests/tests/crash-recovery.lux
+++ b/integration-tests/tests/crash-recovery.lux
@@ -42,7 +42,7 @@
   # strip ANSI codes from response for easier matching
   !curl -v -X GET http://localhost:3000/v1/shape/items?offset=-1
   ?electric-shape-id: ([\d-]+)
-  [local shape_id=$1]
+  [local shape_handle=$1]
   ?electric-chunk-last-offset: ([\w\d_]+)
   [local last_offset=$1]
 
@@ -58,7 +58,7 @@
 
 # Client should be able to continue same shape
 [shell client]
-  !curl -v -X GET "http://localhost:3000/v1/shape/items?offset=$last_offset&shape_id=$shape_id"
+  !curl -v -X GET "http://localhost:3000/v1/shape/items?offset=$last_offset&shape_handle=$shape_handle"
   ??HTTP/1.1 200 OK
 
 [cleanup]

--- a/packages/react-hooks/test/support/test-context.ts
+++ b/packages/react-hooks/test/support/test-context.ts
@@ -38,7 +38,7 @@ export const testWithDbClient = test.extend<{
     use(async (table: string, shapeId?: string) => {
       const baseUrl = inject(`baseUrl`)
       const resp = await fetch(
-        `${baseUrl}/v1/shape/${table}${shapeId ? `?shape_id=${shapeId}` : ``}`,
+        `${baseUrl}/v1/shape/${table}${shapeId ? `?shape_handle=${shapeId}` : ``}`,
         {
           method: `DELETE`,
         }

--- a/packages/sync-service/lib/electric/plug/delete_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/delete_shape_plug.ex
@@ -26,7 +26,7 @@ defmodule Electric.Plug.DeleteShapePlug do
   defp validate_query_params(%Plug.Conn{} = conn, _) do
     all_params =
       Map.merge(conn.query_params, conn.path_params)
-      |> Map.take(["root_table", "shape_id"])
+      |> Map.take(["root_table", "shape_handle"])
       |> Map.put("offset", "-1")
 
     case Params.validate(all_params, inspector: conn.assigns.config[:inspector]) do
@@ -41,16 +41,16 @@ defmodule Electric.Plug.DeleteShapePlug do
   end
 
   defp truncate_or_delete_shape(%Plug.Conn{} = conn, _) do
-    if conn.assigns.shape_id !== nil do
-      with :ok <- Shapes.clean_shape(conn.assigns.shape_id, conn.assigns.config) do
+    if conn.assigns.shape_handle !== nil do
+      with :ok <- Shapes.clean_shape(conn.assigns.shape_handle, conn.assigns.config) do
         send_resp(conn, 202, "")
       end
     else
       # FIXME: This has a race condition where we accidentally create a snapshot & shape id, but clean
       #        it before snapshot is actually made.
-      with {shape_id, _} <-
-             Shapes.get_or_create_shape_id(conn.assigns.config, conn.assigns.shape_definition),
-           :ok <- Shapes.clean_shape(shape_id, conn.assigns.config) do
+      with {shape_handle, _} <-
+             Shapes.get_or_create_shape_handle(conn.assigns.config, conn.assigns.shape_definition),
+           :ok <- Shapes.clean_shape(shape_handle, conn.assigns.config) do
         send_resp(conn, 202, "")
       end
     end

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -32,7 +32,7 @@ defmodule Electric.Plug.ServeShapePlug do
     embedded_schema do
       field(:root_table, :string)
       field(:offset, :string)
-      field(:shape_id, :string)
+      field(:shape_handle, :string)
       field(:live, :boolean, default: false)
       field(:where, :string)
       field(:shape_definition, :string)
@@ -45,7 +45,7 @@ defmodule Electric.Plug.ServeShapePlug do
       )
       |> validate_required([:root_table, :offset])
       |> cast_offset()
-      |> validate_shape_id_with_offset()
+      |> validate_shape_handle_with_offset()
       |> validate_live_with_offset()
       |> cast_root_table(opts)
       |> apply_action(:validate)
@@ -77,15 +77,15 @@ defmodule Electric.Plug.ServeShapePlug do
       end
     end
 
-    def validate_shape_id_with_offset(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+    def validate_shape_handle_with_offset(%Ecto.Changeset{valid?: false} = changeset), do: changeset
 
-    def validate_shape_id_with_offset(%Ecto.Changeset{} = changeset) do
+    def validate_shape_handle_with_offset(%Ecto.Changeset{} = changeset) do
       offset = fetch_change!(changeset, :offset)
 
       if offset == LogOffset.before_all() do
         changeset
       else
-        validate_required(changeset, [:shape_id], message: "can't be blank when offset != -1")
+        validate_required(changeset, [:shape_handle], message: "can't be blank when offset != -1")
       end
     end
 
@@ -164,28 +164,28 @@ defmodule Electric.Plug.ServeShapePlug do
 
   defp load_shape_info(%Conn{} = conn, _) do
     OpenTelemetry.with_span("shape_get.plug.load_shape_info", [], fn ->
-      shape_info = get_or_create_shape_id(conn.assigns)
+      shape_info = get_or_create_shape_handle(conn.assigns)
       handle_shape_info(conn, shape_info)
     end)
   end
 
-  # No shape_id is provided so we can get the existing one for this shape
+  # No shape_handle is provided so we can get the existing one for this shape
   # or create a new shape if it does not yet exist
-  defp get_or_create_shape_id(%{shape_definition: shape, config: config, shape_id: nil}) do
-    Shapes.get_or_create_shape_id(config, shape)
+  defp get_or_create_shape_handle(%{shape_definition: shape, config: config, shape_handle: nil}) do
+    Shapes.get_or_create_shape_handle(config, shape)
   end
 
   # A shape ID is provided so we need to return the shape that matches the shape ID and the shape definition
-  defp get_or_create_shape_id(%{shape_definition: shape, config: config}) do
+  defp get_or_create_shape_handle(%{shape_definition: shape, config: config}) do
     Shapes.get_shape(config, shape)
   end
 
   defp handle_shape_info(
-         %Conn{assigns: %{shape_definition: shape, config: config, shape_id: shape_id}} = conn,
+         %Conn{assigns: %{shape_definition: shape, config: config, shape_handle: shape_handle}} = conn,
          nil
        ) do
     # There is no shape that matches the shape definition (because shape info is `nil`)
-    if shape_id != nil && Shapes.has_shape?(config, shape_id) do
+    if shape_handle != nil && Shapes.has_shape?(config, shape_handle) do
       # but there is a shape that matches the shape ID
       # thus the shape ID does not match the shape definition
       # and we return a 400 bad request status code
@@ -198,29 +198,29 @@ defmodule Electric.Plug.ServeShapePlug do
       # Hence, create a new shape for this shape definition
       # and return a 409 with a redirect to the newly created shape.
       # (will be done by the recursive `handle_shape_info` call)
-      shape_info = Shapes.get_or_create_shape_id(config, shape)
+      shape_info = Shapes.get_or_create_shape_handle(config, shape)
       handle_shape_info(conn, shape_info)
     end
   end
 
   defp handle_shape_info(
-         %Conn{assigns: %{shape_id: shape_id}} = conn,
-         {active_shape_id, last_offset}
+         %Conn{assigns: %{shape_handle: shape_handle}} = conn,
+         {active_shape_handle, last_offset}
        )
-       when is_nil(shape_id) or shape_id == active_shape_id do
+       when is_nil(shape_handle) or shape_handle == active_shape_handle do
     # We found a shape that matches the shape definition
     # and the shape has the same ID as the shape ID provided by the user
     conn
-    |> assign(:active_shape_id, active_shape_id)
+    |> assign(:active_shape_handle, active_shape_handle)
     |> assign(:last_offset, last_offset)
-    |> put_resp_header("electric-shape-id", active_shape_id)
+    |> put_resp_header("electric-shape-id", active_shape_handle)
   end
 
   defp handle_shape_info(
-         %Conn{assigns: %{shape_id: shape_id, config: config}} = conn,
-         {active_shape_id, _}
+         %Conn{assigns: %{shape_handle: shape_handle, config: config}} = conn,
+         {active_shape_handle, _}
        ) do
-    if Shapes.has_shape?(config, shape_id) do
+    if Shapes.has_shape?(config, shape_handle) do
       # The shape with the provided ID exists but does not match the shape definition
       # otherwise we would have found it and it would have matched the previous function clause
       IO.puts("400 - SHAPE ID NOT FOUND")
@@ -229,17 +229,17 @@ defmodule Electric.Plug.ServeShapePlug do
       |> send_resp(400, @must_refetch)
       |> halt()
     else
-      # The requested shape_id is not found, returns 409 along with a location redirect for clients to
+      # The requested shape_handle is not found, returns 409 along with a location redirect for clients to
       # re-request the shape from scratch with the new shape id which acts as a consistent cache buster
-      # e.g. GET /v1/shape/{root_table}?shape_id={new_shape_id}&offset=-1
+      # e.g. GET /v1/shape/{root_table}?shape_handle={new_shape_handle}&offset=-1
 
       # TODO: discuss returning a 307 redirect rather than a 409, the client
       # will have to detect this and throw out old data
       conn
-      |> put_resp_header("electric-shape-id", active_shape_id)
+      |> put_resp_header("electric-shape-id", active_shape_handle)
       |> put_resp_header(
         "location",
-        "#{conn.request_path}?shape_id=#{active_shape_id}&offset=-1"
+        "#{conn.request_path}?shape_handle=#{active_shape_handle}&offset=-1"
       )
       |> send_resp(409, @must_refetch)
       |> halt()
@@ -265,10 +265,10 @@ defmodule Electric.Plug.ServeShapePlug do
   # If chunk offsets are available, use those instead of the latest available offset
   # to optimize for cache hits and response sizes
   defp determine_log_chunk_offset(%Conn{assigns: assigns} = conn, _) do
-    %{config: config, active_shape_id: shape_id, offset: offset} = assigns
+    %{config: config, active_shape_handle: shape_handle, offset: offset} = assigns
 
     chunk_end_offset =
-      Shapes.get_chunk_end_log_offset(config, shape_id, offset) || assigns.last_offset
+      Shapes.get_chunk_end_log_offset(config, shape_handle, offset) || assigns.last_offset
 
     conn
     |> assign(:chunk_end_offset, chunk_end_offset)
@@ -297,14 +297,14 @@ defmodule Electric.Plug.ServeShapePlug do
   defp generate_etag(%Conn{} = conn, _) do
     %{
       offset: offset,
-      active_shape_id: active_shape_id,
+      active_shape_handle: active_shape_handle,
       chunk_end_offset: chunk_end_offset
     } = conn.assigns
 
     conn
     |> assign(
       :etag,
-      "#{active_shape_id}:#{offset}:#{chunk_end_offset}"
+      "#{active_shape_handle}:#{offset}:#{chunk_end_offset}"
     )
   end
 
@@ -366,15 +366,15 @@ defmodule Electric.Plug.ServeShapePlug do
          %Conn{
            assigns: %{
              chunk_end_offset: chunk_end_offset,
-             active_shape_id: shape_id,
+             active_shape_handle: shape_handle,
              up_to_date: maybe_up_to_date
            }
          } = conn
        ) do
-    case Shapes.get_snapshot(conn.assigns.config, shape_id) do
+    case Shapes.get_snapshot(conn.assigns.config, shape_handle) do
       {:ok, {offset, snapshot}} ->
         log =
-          Shapes.get_log_stream(conn.assigns.config, shape_id,
+          Shapes.get_log_stream(conn.assigns.config, shape_handle,
             since: offset,
             up_to: chunk_end_offset
           )
@@ -404,13 +404,13 @@ defmodule Electric.Plug.ServeShapePlug do
            assigns: %{
              offset: offset,
              chunk_end_offset: chunk_end_offset,
-             active_shape_id: shape_id,
+             active_shape_handle: shape_handle,
              up_to_date: maybe_up_to_date
            }
          } = conn
        ) do
     log =
-      Shapes.get_log_stream(conn.assigns.config, shape_id,
+      Shapes.get_log_stream(conn.assigns.config, shape_handle,
         since: offset,
         up_to: chunk_end_offset
       )
@@ -418,7 +418,7 @@ defmodule Electric.Plug.ServeShapePlug do
     if Enum.take(log, 1) == [] and conn.assigns.live do
       conn
       |> assign(:ot_is_immediate_response, false)
-      |> hold_until_change(shape_id)
+      |> hold_until_change(shape_handle)
     else
       [log, maybe_up_to_date]
       |> Stream.concat()
@@ -473,12 +473,12 @@ defmodule Electric.Plug.ServeShapePlug do
   defp listen_for_new_changes(%Conn{assigns: assigns} = conn, _) do
     # Only start listening when we know there is a possibility that nothing is going to be returned
     if LogOffset.compare(assigns.offset, assigns.last_offset) != :lt do
-      shape_id = assigns.shape_id
+      shape_handle = assigns.shape_handle
 
       ref = make_ref()
       registry = conn.assigns.config[:registry]
-      Registry.register(registry, shape_id, ref)
-      Logger.debug("Client #{inspect(self())} is registered for changes to #{shape_id}")
+      Registry.register(registry, shape_handle, ref)
+      Logger.debug("Client #{inspect(self())} is registered for changes to #{shape_handle}")
 
       assign(conn, :new_changes_ref, ref)
     else
@@ -486,9 +486,9 @@ defmodule Electric.Plug.ServeShapePlug do
     end
   end
 
-  def hold_until_change(conn, shape_id) do
+  def hold_until_change(conn, shape_handle) do
     long_poll_timeout = conn.assigns.config[:long_poll_timeout]
-    Logger.debug("Client #{inspect(self())} is waiting for changes to #{shape_id}")
+    Logger.debug("Client #{inspect(self())} is waiting for changes to #{shape_handle}")
     ref = conn.assigns.new_changes_ref
 
     receive do
@@ -520,11 +520,11 @@ defmodule Electric.Plug.ServeShapePlug do
   end
 
   defp open_telemetry_attrs(%Conn{assigns: assigns} = conn) do
-    shape_id =
+    shape_handle =
       if is_struct(conn.query_params, Plug.Conn.Unfetched) do
-        assigns[:active_shape_id] || assigns[:shape_id]
+        assigns[:active_shape_handle] || assigns[:shape_handle]
       else
-        conn.query_params["shape_id"] || assigns[:active_shape_id] || assigns[:shape_id]
+        conn.query_params["shape_handle"] || assigns[:active_shape_handle] || assigns[:shape_handle]
       end
 
     query_params_map =
@@ -537,7 +537,7 @@ defmodule Electric.Plug.ServeShapePlug do
     maybe_up_to_date = if up_to_date = assigns[:up_to_date], do: up_to_date != []
 
     %{
-      "shape.id" => shape_id,
+      "shape.id" => shape_handle,
       "shape.where" => assigns[:where],
       "shape.root_table" => assigns[:root_table],
       "shape.definition" => assigns[:shape_definition],

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -6,25 +6,25 @@ defmodule Electric.ShapeCacheBehaviour do
   alias Electric.Replication.Changes
   alias Electric.Replication.LogOffset
 
-  @type shape_id :: String.t()
+  @type shape_handle :: String.t()
   @type shape_def :: Shape.t()
   @type xmin :: non_neg_integer()
 
   @doc "Update a shape's status with a new log offset"
-  @callback update_shape_latest_offset(shape_id(), LogOffset.t(), keyword()) :: :ok
+  @callback update_shape_latest_offset(shape_handle(), LogOffset.t(), keyword()) :: :ok
 
   @callback get_shape(shape_def(), opts :: keyword()) ::
-              {shape_id(), current_snapshot_offset :: LogOffset.t()}
-  @callback get_or_create_shape_id(shape_def(), opts :: keyword()) ::
-              {shape_id(), current_snapshot_offset :: LogOffset.t()}
+              {shape_handle(), current_snapshot_offset :: LogOffset.t()}
+  @callback get_or_create_shape_handle(shape_def(), opts :: keyword()) ::
+              {shape_handle(), current_snapshot_offset :: LogOffset.t()}
 
   @callback get_relation(Messages.relation_id(), opts :: keyword()) :: Changes.Relation.t() | nil
-  @callback list_shapes(Electric.ShapeCache.ShapeStatus.t()) :: [{shape_id(), Shape.t()}]
-  @callback await_snapshot_start(shape_id(), opts :: keyword()) :: :started | {:error, term()}
-  @callback handle_truncate(shape_id(), keyword()) :: :ok
-  @callback clean_shape(shape_id(), keyword()) :: :ok
+  @callback list_shapes(Electric.ShapeCache.ShapeStatus.t()) :: [{shape_handle(), Shape.t()}]
+  @callback await_snapshot_start(shape_handle(), opts :: keyword()) :: :started | {:error, term()}
+  @callback handle_truncate(shape_handle(), keyword()) :: :ok
+  @callback clean_shape(shape_handle(), keyword()) :: :ok
   @callback clean_all_shapes(GenServer.name()) :: :ok
-  @callback has_shape?(shape_id(), keyword()) :: boolean()
+  @callback has_shape?(shape_handle(), keyword()) :: boolean()
   @callback cast(term(), keyword()) :: :ok
 end
 
@@ -40,7 +40,7 @@ defmodule Electric.ShapeCache do
 
   @behaviour Electric.ShapeCacheBehaviour
 
-  @type shape_id :: Electric.ShapeCacheBehaviour.shape_id()
+  @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
 
   @default_shape_meta_table :shape_meta_table
 
@@ -92,33 +92,33 @@ defmodule Electric.ShapeCache do
   end
 
   @impl Electric.ShapeCacheBehaviour
-  def get_or_create_shape_id(shape, opts \\ []) do
+  def get_or_create_shape_handle(shape, opts \\ []) do
     # Get or create the shape ID and fire a snapshot if necessary
     if shape_state = get_shape(shape, opts) do
       shape_state
     else
       server = Access.get(opts, :server, __MODULE__)
-      GenStage.call(server, {:create_or_wait_shape_id, shape})
+      GenStage.call(server, {:create_or_wait_shape_handle, shape})
     end
   end
 
   @impl Electric.ShapeCacheBehaviour
-  @spec update_shape_latest_offset(shape_id(), LogOffset.t(), opts :: keyword()) ::
+  @spec update_shape_latest_offset(shape_handle(), LogOffset.t(), opts :: keyword()) ::
           :ok | {:error, term()}
-  def update_shape_latest_offset(shape_id, latest_offset, opts) do
+  def update_shape_latest_offset(shape_handle, latest_offset, opts) do
     meta_table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
-    if shape_status.set_latest_offset(meta_table, shape_id, latest_offset) do
+    if shape_status.set_latest_offset(meta_table, shape_handle, latest_offset) do
       :ok
     else
-      Logger.warning("Tried to update latest offset for shape #{shape_id} which doesn't exist")
+      Logger.warning("Tried to update latest offset for shape #{shape_handle} which doesn't exist")
       :error
     end
   end
 
   @impl Electric.ShapeCacheBehaviour
-  @spec list_shapes(Electric.ShapeCache.ShapeStatus.t()) :: [{shape_id(), Shape.t()}]
+  @spec list_shapes(Electric.ShapeCache.ShapeStatus.t()) :: [{shape_handle(), Shape.t()}]
   def list_shapes(opts) do
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
     shape_status.list_shapes(opts)
@@ -133,10 +133,10 @@ defmodule Electric.ShapeCache do
   end
 
   @impl Electric.ShapeCacheBehaviour
-  @spec clean_shape(shape_id(), keyword()) :: :ok
-  def clean_shape(shape_id, opts) do
+  @spec clean_shape(shape_handle(), keyword()) :: :ok
+  def clean_shape(shape_handle, opts) do
     server = Access.get(opts, :server, __MODULE__)
-    GenStage.call(server, {:clean, shape_id})
+    GenStage.call(server, {:clean, shape_handle})
   end
 
   @impl Electric.ShapeCacheBehaviour
@@ -147,36 +147,36 @@ defmodule Electric.ShapeCache do
   end
 
   @impl Electric.ShapeCacheBehaviour
-  @spec handle_truncate(shape_id(), keyword()) :: :ok
-  def handle_truncate(shape_id, opts \\ []) do
+  @spec handle_truncate(shape_handle(), keyword()) :: :ok
+  def handle_truncate(shape_handle, opts \\ []) do
     server = Access.get(opts, :server, __MODULE__)
-    GenStage.call(server, {:truncate, shape_id})
+    GenStage.call(server, {:truncate, shape_handle})
   end
 
   @impl Electric.ShapeCacheBehaviour
-  @spec await_snapshot_start(shape_id(), keyword()) :: :started | {:error, term()}
-  def await_snapshot_start(shape_id, opts \\ []) when is_binary(shape_id) do
+  @spec await_snapshot_start(shape_handle(), keyword()) :: :started | {:error, term()}
+  def await_snapshot_start(shape_handle, opts \\ []) when is_binary(shape_handle) do
     table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
-    if shape_status.snapshot_started?(table, shape_id) do
+    if shape_status.snapshot_started?(table, shape_handle) do
       :started
     else
       server = Access.get(opts, :server, __MODULE__)
-      GenStage.call(server, {:await_snapshot_start, shape_id})
+      GenStage.call(server, {:await_snapshot_start, shape_handle})
     end
   end
 
   @impl Electric.ShapeCacheBehaviour
-  def has_shape?(shape_id, opts \\ []) do
+  def has_shape?(shape_handle, opts \\ []) do
     table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
-    if shape_status.get_existing_shape(table, shape_id) do
+    if shape_status.get_existing_shape(table, shape_handle) do
       true
     else
       server = Access.get(opts, :server, __MODULE__)
-      GenStage.call(server, {:wait_shape_id, shape_id})
+      GenStage.call(server, {:wait_shape_handle, shape_handle})
     end
   end
 
@@ -249,7 +249,7 @@ defmodule Electric.ShapeCache do
       |> shape_status.list_shapes()
       |> Enum.filter(&Shape.is_affected_by_relation_change?(&1, change))
       |> Enum.map(&elem(&1, 0))
-      |> Enum.each(fn shape_id -> clean_up_shape(state, shape_id) end)
+      |> Enum.each(fn shape_handle -> clean_up_shape(state, shape_handle) end)
     end
 
     if old_rel != relation do
@@ -268,56 +268,56 @@ defmodule Electric.ShapeCache do
   end
 
   @impl GenStage
-  def handle_call({:create_or_wait_shape_id, shape}, _from, %{shape_status: shape_status} = state) do
-    {{shape_id, latest_offset}, state} =
+  def handle_call({:create_or_wait_shape_handle, shape}, _from, %{shape_status: shape_status} = state) do
+    {{shape_handle, latest_offset}, state} =
       if shape_state = shape_status.get_existing_shape(state.persistent_state, shape) do
         {shape_state, state}
       else
-        {:ok, shape_id} = shape_status.add_shape(state.persistent_state, shape)
+        {:ok, shape_handle} = shape_status.add_shape(state.persistent_state, shape)
 
-        {:ok, _pid, _snapshot_xmin, latest_offset} = start_shape(shape_id, shape, state)
-        {{shape_id, latest_offset}, state}
+        {:ok, _pid, _snapshot_xmin, latest_offset} = start_shape(shape_handle, shape, state)
+        {{shape_handle, latest_offset}, state}
       end
 
-    Logger.debug("Returning shape id #{shape_id} for shape #{inspect(shape)}")
+    Logger.debug("Returning shape id #{shape_handle} for shape #{inspect(shape)}")
 
-    {:reply, {shape_id, latest_offset}, [], state}
+    {:reply, {shape_handle, latest_offset}, [], state}
   end
 
-  def handle_call({:await_snapshot_start, shape_id}, from, %{shape_status: shape_status} = state) do
+  def handle_call({:await_snapshot_start, shape_handle}, from, %{shape_status: shape_status} = state) do
     cond do
-      not is_known_shape_id?(state, shape_id) ->
+      not is_known_shape_handle?(state, shape_handle) ->
         {:reply, {:error, :unknown}, [], state}
 
-      shape_status.snapshot_started?(state.persistent_state, shape_id) ->
+      shape_status.snapshot_started?(state.persistent_state, shape_handle) ->
         {:reply, :started, [], state}
 
       true ->
-        Logger.debug("Starting a wait on the snapshot #{shape_id} for #{inspect(from)}}")
+        Logger.debug("Starting a wait on the snapshot #{shape_handle} for #{inspect(from)}}")
 
-        {:noreply, [], add_waiter(state, shape_id, from)}
+        {:noreply, [], add_waiter(state, shape_handle, from)}
     end
   end
 
-  def handle_call({:wait_shape_id, shape_id}, _from, %{shape_status: shape_status} = state) do
-    {:reply, !is_nil(shape_status.get_existing_shape(state.persistent_state, shape_id)), [],
+  def handle_call({:wait_shape_handle, shape_handle}, _from, %{shape_status: shape_status} = state) do
+    {:reply, !is_nil(shape_status.get_existing_shape(state.persistent_state, shape_handle)), [],
      state}
   end
 
-  def handle_call({:truncate, shape_id}, _from, state) do
-    with {:ok, cleaned_up_shape} <- clean_up_shape(state, shape_id) do
+  def handle_call({:truncate, shape_handle}, _from, state) do
+    with {:ok, cleaned_up_shape} <- clean_up_shape(state, shape_handle) do
       Logger.info(
-        "Truncating and rotating shape id, previous shape id #{shape_id}, definition: #{inspect(cleaned_up_shape)}"
+        "Truncating and rotating shape id, previous shape id #{shape_handle}, definition: #{inspect(cleaned_up_shape)}"
       )
     end
 
     {:reply, :ok, [], state}
   end
 
-  def handle_call({:clean, shape_id}, _from, state) do
+  def handle_call({:clean, shape_handle}, _from, state) do
     # ignore errors when cleaning up non-existant shape id
-    with {:ok, cleaned_up_shape} <- clean_up_shape(state, shape_id) do
-      Logger.info("Cleaning up shape #{shape_id}, definition: #{inspect(cleaned_up_shape)}")
+    with {:ok, cleaned_up_shape} <- clean_up_shape(state, shape_handle) do
+      Logger.info("Cleaning up shape #{shape_handle}, definition: #{inspect(cleaned_up_shape)}")
     end
 
     {:reply, :ok, [], state}
@@ -330,31 +330,31 @@ defmodule Electric.ShapeCache do
   end
 
   @impl GenStage
-  def handle_cast({:snapshot_xmin_known, shape_id, xmin}, %{shape_status: shape_status} = state) do
-    unless shape_status.set_snapshot_xmin(state.persistent_state, shape_id, xmin) do
+  def handle_cast({:snapshot_xmin_known, shape_handle, xmin}, %{shape_status: shape_status} = state) do
+    unless shape_status.set_snapshot_xmin(state.persistent_state, shape_handle, xmin) do
       Logger.warning(
-        "Got snapshot information for a #{shape_id}, that shape id is no longer valid. Ignoring."
+        "Got snapshot information for a #{shape_handle}, that shape id is no longer valid. Ignoring."
       )
     end
 
     {:noreply, [], state}
   end
 
-  def handle_cast({:snapshot_started, shape_id}, %{shape_status: shape_status} = state) do
-    Logger.debug("Snapshot for #{shape_id} is ready")
-    :ok = shape_status.mark_snapshot_started(state.persistent_state, shape_id)
-    {waiting, state} = pop_in(state, [:awaiting_snapshot_start, shape_id])
+  def handle_cast({:snapshot_started, shape_handle}, %{shape_status: shape_status} = state) do
+    Logger.debug("Snapshot for #{shape_handle} is ready")
+    :ok = shape_status.mark_snapshot_started(state.persistent_state, shape_handle)
+    {waiting, state} = pop_in(state, [:awaiting_snapshot_start, shape_handle])
     for client <- List.wrap(waiting), not is_nil(client), do: GenStage.reply(client, :started)
     {:noreply, [], state}
   end
 
-  def handle_cast({:snapshot_failed, shape_id, error, _stacktrace}, state) do
+  def handle_cast({:snapshot_failed, shape_handle, error, _stacktrace}, state) do
     Logger.error(
-      "Removing shape #{shape_id} due to #{Exception.format_banner(:error, error, [])}"
+      "Removing shape #{shape_handle} due to #{Exception.format_banner(:error, error, [])}"
     )
 
-    clean_up_shape(state, shape_id)
-    {waiting, state} = pop_in(state, [:awaiting_snapshot_start, shape_id])
+    clean_up_shape(state, shape_handle)
+    {waiting, state} = pop_in(state, [:awaiting_snapshot_start, shape_handle])
 
     # waiting may nil here if :snapshot_failed happens after :snapshot_started
     if waiting do
@@ -364,54 +364,54 @@ defmodule Electric.ShapeCache do
     {:noreply, [], state}
   end
 
-  defp clean_up_shape(state, shape_id) do
-    if state.shape_status.get_existing_shape(state.persistent_state, shape_id) !== nil do
-      shape_opts = Electric.ShapeCache.Storage.for_shape(shape_id, state.storage)
+  defp clean_up_shape(state, shape_handle) do
+    if state.shape_status.get_existing_shape(state.persistent_state, shape_handle) !== nil do
+      shape_opts = Electric.ShapeCache.Storage.for_shape(shape_handle, state.storage)
       Electric.ShapeCache.Storage.cleanup!(shape_opts)
     end
 
     Electric.Shapes.ConsumerSupervisor.stop_shape_consumer(
       state.consumer_supervisor,
       state.electric_instance_id,
-      shape_id
+      shape_handle
     )
 
-    state.shape_status.remove_shape(state.persistent_state, shape_id)
+    state.shape_status.remove_shape(state.persistent_state, shape_handle)
   end
 
   defp clean_up_all_shapes(state) do
-    shape_ids =
+    shape_handles =
       state.persistent_state |> state.shape_status.list_shapes() |> Enum.map(&elem(&1, 0))
 
-    for shape_id <- shape_ids do
-      clean_up_shape(state, shape_id)
+    for shape_handle <- shape_handles do
+      clean_up_shape(state, shape_handle)
     end
   end
 
-  defp is_known_shape_id?(state, shape_id) do
-    !!state.shape_status.get_existing_shape(state.persistent_state, shape_id)
+  defp is_known_shape_handle?(state, shape_handle) do
+    !!state.shape_status.get_existing_shape(state.persistent_state, shape_handle)
   end
 
-  defp add_waiter(%{awaiting_snapshot_start: waiters} = state, shape_id, waiter),
+  defp add_waiter(%{awaiting_snapshot_start: waiters} = state, shape_handle, waiter),
     do: %{
       state
-      | awaiting_snapshot_start: Map.update(waiters, shape_id, [waiter], &[waiter | &1])
+      | awaiting_snapshot_start: Map.update(waiters, shape_handle, [waiter], &[waiter | &1])
     }
 
   defp recover_shapes(state) do
     state.persistent_state
     |> state.shape_status.list_shapes()
-    |> Enum.each(fn {shape_id, shape} ->
-      {:ok, _pid, _snapshot_xmin, _latest_offset} = start_shape(shape_id, shape, state)
+    |> Enum.each(fn {shape_handle, shape} ->
+      {:ok, _pid, _snapshot_xmin, _latest_offset} = start_shape(shape_handle, shape, state)
     end)
   end
 
-  defp start_shape(shape_id, shape, state) do
+  defp start_shape(shape_handle, shape, state) do
     with {:ok, pid} <-
            Electric.Shapes.ConsumerSupervisor.start_shape_consumer(
              state.consumer_supervisor,
              electric_instance_id: state.electric_instance_id,
-             shape_id: shape_id,
+             shape_handle: shape_handle,
              shape: shape,
              storage: state.storage,
              chunk_bytes_threshold: state.chunk_bytes_threshold,
@@ -423,14 +423,14 @@ defmodule Electric.ShapeCache do
              prepare_tables_fn: state.prepare_tables_fn,
              create_snapshot_fn: state.create_snapshot_fn
            ) do
-      consumer = Shapes.Consumer.name(state.electric_instance_id, shape_id)
+      consumer = Shapes.Consumer.name(state.electric_instance_id, shape_handle)
 
       {:ok, snapshot_xmin, latest_offset} = Shapes.Consumer.initial_state(consumer)
 
       :ok =
         state.shape_status.initialise_shape(
           state.persistent_state,
-          shape_id,
+          shape_handle,
           snapshot_xmin,
           latest_offset
         )

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -16,7 +16,7 @@ defmodule Electric.ShapeCache.FileStorage do
 
   @behaviour Electric.ShapeCache.Storage
 
-  defstruct [:base_path, :shape_id, :db, :cubdb_dir, :snapshot_dir, version: @version]
+  defstruct [:base_path, :shape_handle, :db, :cubdb_dir, :snapshot_dir, version: @version]
 
   @impl Electric.ShapeCache.Storage
   def shared_opts(opts) do
@@ -27,22 +27,22 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def for_shape(shape_id, %FS{shape_id: shape_id} = opts) do
+  def for_shape(shape_handle, %FS{shape_handle: shape_handle} = opts) do
     opts
   end
 
-  def for_shape(shape_id, %{base_path: base_path, electric_instance_id: electric_instance_id}) do
+  def for_shape(shape_handle, %{base_path: base_path, electric_instance_id: electric_instance_id}) do
     %FS{
       base_path: base_path,
-      shape_id: shape_id,
-      db: name(electric_instance_id, shape_id),
-      cubdb_dir: Path.join([base_path, shape_id, "cubdb"]),
-      snapshot_dir: Path.join([base_path, shape_id, "snapshots"])
+      shape_handle: shape_handle,
+      db: name(electric_instance_id, shape_handle),
+      cubdb_dir: Path.join([base_path, shape_handle, "cubdb"]),
+      snapshot_dir: Path.join([base_path, shape_handle, "snapshots"])
     }
   end
 
-  defp name(electric_instance_id, shape_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_id)
+  defp name(electric_instance_id, shape_handle) do
+    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_handle)
   end
 
   def child_spec(%FS{} = opts) do
@@ -126,7 +126,7 @@ defmodule Electric.ShapeCache.FileStorage do
   def make_new_snapshot!(data_stream, %FS{} = opts) do
     OpenTelemetry.with_span(
       "storage.make_new_snapshot",
-      [storage_impl: "mixed_disk", "shape.id": opts.shape_id],
+      [storage_impl: "mixed_disk", "shape.id": opts.shape_handle],
       fn ->
         data_stream
         |> Stream.map(&[&1, ?\n])

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -18,7 +18,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     :snapshot_table,
     :log_table,
     :chunk_checkpoint_table,
-    :shape_id,
+    :shape_handle,
     :electric_instance_id
   ]
 
@@ -30,26 +30,26 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     {:ok, %{table_base_name: table_base_name, electric_instance_id: electric_instance_id}}
   end
 
-  def name(electric_instance_id, shape_id) when is_binary(shape_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_id)
+  def name(electric_instance_id, shape_handle) when is_binary(shape_handle) do
+    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_handle)
   end
 
   @impl Electric.ShapeCache.Storage
-  def for_shape(shape_id, %{shape_id: shape_id} = opts) do
+  def for_shape(shape_handle, %{shape_handle: shape_handle} = opts) do
     opts
   end
 
-  def for_shape(shape_id, %{
+  def for_shape(shape_handle, %{
         table_base_name: table_base_name,
         electric_instance_id: electric_instance_id
       }) do
-    snapshot_table_name = :"#{table_base_name}.Snapshot_#{shape_id}"
-    log_table_name = :"#{table_base_name}.Log_#{shape_id}"
-    chunk_checkpoint_table_name = :"#{table_base_name}.ChunkCheckpoint_#{shape_id}"
+    snapshot_table_name = :"#{table_base_name}.Snapshot_#{shape_handle}"
+    log_table_name = :"#{table_base_name}.Log_#{shape_handle}"
+    chunk_checkpoint_table_name = :"#{table_base_name}.ChunkCheckpoint_#{shape_handle}"
 
     %__MODULE__{
       table_base_name: table_base_name,
-      shape_id: shape_id,
+      shape_handle: shape_handle,
       snapshot_table: snapshot_table_name,
       log_table: log_table_name,
       chunk_checkpoint_table: chunk_checkpoint_table_name,
@@ -59,7 +59,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
 
   @impl Electric.ShapeCache.Storage
   def start_link(%MS{} = opts) do
-    if is_nil(opts.shape_id), do: raise("cannot start an un-attached storage instance")
+    if is_nil(opts.shape_handle), do: raise("cannot start an un-attached storage instance")
     if is_nil(opts.electric_instance_id), do: raise("electric_instance_id cannot be nil")
 
     Agent.start_link(
@@ -70,7 +70,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
           chunk_checkpoint_table: storage_table(opts.chunk_checkpoint_table)
         }
       end,
-      name: name(opts.electric_instance_id, opts.shape_id)
+      name: name(opts.electric_instance_id, opts.shape_handle)
     )
   end
 
@@ -180,7 +180,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   def make_new_snapshot!(data_stream, %MS{} = opts) do
     OpenTelemetry.with_span(
       "storage.make_new_snapshot",
-      [storage_impl: "in_memory", "shape.id": opts.shape_id],
+      [storage_impl: "in_memory", "shape.id": opts.shape_handle],
       fn ->
         table = opts.snapshot_table
 

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -8,19 +8,19 @@ defmodule Electric.ShapeCache.ShapeStatusBehaviour do
   alias Electric.Replication.Changes.Relation
   alias Electric.Replication.LogOffset
 
-  @type shape_id() :: Electric.ShapeCacheBehaviour.shape_id()
+  @type shape_handle() :: Electric.ShapeCacheBehaviour.shape_handle()
   @type xmin() :: Electric.ShapeCacheBehaviour.xmin()
 
   @callback initialise(ShapeStatus.options()) :: {:ok, ShapeStatus.t()} | {:error, term()}
-  @callback list_shapes(ShapeStatus.t()) :: [{shape_id(), Shape.t()}]
-  @callback get_existing_shape(ShapeStatus.t(), Shape.t() | shape_id()) ::
-              {shape_id(), LogOffset.t()} | nil
+  @callback list_shapes(ShapeStatus.t()) :: [{shape_handle(), Shape.t()}]
+  @callback get_existing_shape(ShapeStatus.t(), Shape.t() | shape_handle()) ::
+              {shape_handle(), LogOffset.t()} | nil
   @callback add_shape(ShapeStatus.t(), Shape.t()) ::
-              {:ok, shape_id()} | {:error, term()}
-  @callback initialise_shape(ShapeStatus.t(), shape_id(), xmin(), LogOffset.t()) ::
+              {:ok, shape_handle()} | {:error, term()}
+  @callback initialise_shape(ShapeStatus.t(), shape_handle(), xmin(), LogOffset.t()) ::
               :ok
-  @callback snapshot_started?(ShapeStatus.t(), shape_id()) :: boolean()
-  @callback remove_shape(ShapeStatus.t(), shape_id()) ::
+  @callback snapshot_started?(ShapeStatus.t(), shape_handle()) :: boolean()
+  @callback remove_shape(ShapeStatus.t(), shape_handle()) ::
               {:ok, Shape.t()} | {:error, term()}
   @callback get_relation(ShapeStatus.t(), Messages.relation_id()) :: Relation.t() | nil
   @callback store_relation(ShapeStatus.t(), Relation.t()) :: :ok
@@ -31,11 +31,11 @@ defmodule Electric.ShapeCache.ShapeStatus do
   Keeps track of shape state.
 
   Serializes just enough to some persistent storage to bootstrap the
-  ShapeCache by writing the mapping of `shape_id => %Shape{}` to
+  ShapeCache by writing the mapping of `shape_handle => %Shape{}` to
   storage.
 
   The shape cache then loads this and starts processes (storage and consumer)
-  for each `{shape_id, %Shape{}}` pair. These then use their attached storage
+  for each `{shape_handle, %Shape{}}` pair. These then use their attached storage
   to recover the status information for the shape (snapshot xmin and latest
   offset).
 
@@ -56,7 +56,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
 
   defstruct [:persistent_kv, :root, :shape_meta_table]
 
-  @type shape_id() :: Electric.ShapeCacheBehaviour.shape_id()
+  @type shape_handle() :: Electric.ShapeCacheBehaviour.shape_handle()
   @type xmin() :: Electric.ShapeCacheBehaviour.xmin()
   @type table() :: atom() | reference()
   @type t() :: %__MODULE__{
@@ -98,9 +98,9 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
-  @spec add_shape(t(), Shape.t()) :: {:ok, shape_id(), LogOffset.t()} | {:error, term()}
+  @spec add_shape(t(), Shape.t()) :: {:ok, shape_handle(), LogOffset.t()} | {:error, term()}
   def add_shape(state, shape) do
-    {hash, shape_id} = Shape.generate_id(shape)
+    {hash, shape_handle} = Shape.generate_id(shape)
     # fresh snapshots always start with a zero offset - only once they
     # are folded into the log do we have non-zero offsets
     offset = LogOffset.first()
@@ -109,17 +109,17 @@ defmodule Electric.ShapeCache.ShapeStatus do
       :ets.insert_new(
         state.shape_meta_table,
         [
-          {{@shape_hash_lookup, hash}, shape_id},
-          {{@shape_meta_data, shape_id}, shape, nil, offset}
+          {{@shape_hash_lookup, hash}, shape_handle},
+          {{@shape_meta_data, shape_handle}, shape, nil, offset}
         ]
       )
 
     with :ok <- save(state) do
-      {:ok, shape_id}
+      {:ok, shape_handle}
     end
   end
 
-  @spec list_shapes(t()) :: [{shape_id(), Shape.t()}]
+  @spec list_shapes(t()) :: [{shape_handle(), Shape.t()}]
   def list_shapes(state) do
     :ets.select(state.shape_meta_table, [
       {
@@ -130,21 +130,21 @@ defmodule Electric.ShapeCache.ShapeStatus do
     ])
   end
 
-  @spec remove_shape(t(), shape_id()) :: {:ok, t()} | {:error, term()}
-  def remove_shape(state, shape_id) do
+  @spec remove_shape(t(), shape_handle()) :: {:ok, t()} | {:error, term()}
+  def remove_shape(state, shape_handle) do
     try do
       shape =
         :ets.lookup_element(
           state.shape_meta_table,
-          {@shape_meta_data, shape_id},
+          {@shape_meta_data, shape_handle},
           @shape_meta_shape_pos
         )
 
       :ets.select_delete(
         state.shape_meta_table,
         [
-          {{{@shape_meta_data, shape_id}, :_, :_, :_}, [], [true]},
-          {{{@shape_hash_lookup, :_}, shape_id}, [], [true]}
+          {{{@shape_meta_data, shape_handle}, :_, :_, :_}, [], [true]},
+          {{{@shape_hash_lookup, :_}, shape_handle}, [], [true]}
         ]
       )
 
@@ -157,16 +157,16 @@ defmodule Electric.ShapeCache.ShapeStatus do
       # keys, so we're doing our best to just delete everything without
       # crashing
       ArgumentError ->
-        {:error, "No shape matching #{inspect(shape_id)}"}
+        {:error, "No shape matching #{inspect(shape_handle)}"}
     end
   end
 
-  @spec get_existing_shape(t(), shape_id() | Shape.t()) :: nil | {shape_id(), LogOffset.t()}
+  @spec get_existing_shape(t(), shape_handle() | Shape.t()) :: nil | {shape_handle(), LogOffset.t()}
   def get_existing_shape(%__MODULE__{shape_meta_table: table}, shape_or_id) do
     get_existing_shape(table, shape_or_id)
   end
 
-  @spec get_existing_shape(table(), Shape.t()) :: nil | {shape_id(), LogOffset.t()}
+  @spec get_existing_shape(table(), Shape.t()) :: nil | {shape_handle(), LogOffset.t()}
   def get_existing_shape(meta_table, %Shape{} = shape) do
     hash = Shape.hash(shape)
 
@@ -174,22 +174,22 @@ defmodule Electric.ShapeCache.ShapeStatus do
       [] ->
         nil
 
-      [shape_id] ->
-        {shape_id, latest_offset!(meta_table, shape_id)}
+      [shape_handle] ->
+        {shape_handle, latest_offset!(meta_table, shape_handle)}
     end
   end
 
-  @spec get_existing_shape(table(), shape_id()) :: nil | {shape_id(), LogOffset.t()}
-  def get_existing_shape(meta_table, shape_id) when is_binary(shape_id) do
-    case :ets.lookup(meta_table, {@shape_meta_data, shape_id}) do
+  @spec get_existing_shape(table(), shape_handle()) :: nil | {shape_handle(), LogOffset.t()}
+  def get_existing_shape(meta_table, shape_handle) when is_binary(shape_handle) do
+    case :ets.lookup(meta_table, {@shape_meta_data, shape_handle}) do
       [] -> nil
-      [{_, _shape, _xmin, offset}] -> {shape_id, offset}
+      [{_, _shape, _xmin, offset}] -> {shape_handle, offset}
     end
   end
 
-  @spec initialise_shape(t(), shape_id(), xmin(), LogOffset.t()) :: :ok
-  def initialise_shape(state, shape_id, snapshot_xmin, latest_offset) do
-    :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_id}, [
+  @spec initialise_shape(t(), shape_handle(), xmin(), LogOffset.t()) :: :ok
+  def initialise_shape(state, shape_handle, snapshot_xmin, latest_offset) do
+    :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_handle}, [
       {@shape_meta_xmin_pos, snapshot_xmin},
       {@shape_meta_latest_offset_pos, latest_offset}
     ])
@@ -197,75 +197,75 @@ defmodule Electric.ShapeCache.ShapeStatus do
     :ok
   end
 
-  def set_snapshot_xmin(state, shape_id, snapshot_xmin) do
-    :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_id}, [
+  def set_snapshot_xmin(state, shape_handle, snapshot_xmin) do
+    :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_handle}, [
       {@shape_meta_xmin_pos, snapshot_xmin}
     ])
   end
 
-  def set_latest_offset(%__MODULE__{shape_meta_table: table} = _state, shape_id, latest_offset) do
-    set_latest_offset(table, shape_id, latest_offset)
+  def set_latest_offset(%__MODULE__{shape_meta_table: table} = _state, shape_handle, latest_offset) do
+    set_latest_offset(table, shape_handle, latest_offset)
   end
 
-  def set_latest_offset(meta_table, shape_id, latest_offset) do
-    :ets.update_element(meta_table, {@shape_meta_data, shape_id}, [
+  def set_latest_offset(meta_table, shape_handle, latest_offset) do
+    :ets.update_element(meta_table, {@shape_meta_data, shape_handle}, [
       {@shape_meta_latest_offset_pos, latest_offset}
     ])
   end
 
-  def latest_offset!(%__MODULE__{shape_meta_table: table} = _state, shape_id) do
-    latest_offset(table, shape_id)
+  def latest_offset!(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
+    latest_offset(table, shape_handle)
   end
 
-  def latest_offset!(meta_table, shape_id) do
+  def latest_offset!(meta_table, shape_handle) do
     :ets.lookup_element(
       meta_table,
-      {@shape_meta_data, shape_id},
+      {@shape_meta_data, shape_handle},
       @shape_meta_latest_offset_pos
     )
   end
 
-  def latest_offset(%__MODULE__{shape_meta_table: table} = _state, shape_id) do
-    latest_offset(table, shape_id)
+  def latest_offset(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
+    latest_offset(table, shape_handle)
   end
 
-  def latest_offset(meta_table, shape_id) do
+  def latest_offset(meta_table, shape_handle) do
     turn_raise_into_error(fn ->
       :ets.lookup_element(
         meta_table,
-        {@shape_meta_data, shape_id},
+        {@shape_meta_data, shape_handle},
         @shape_meta_latest_offset_pos
       )
     end)
   end
 
-  def snapshot_xmin(%__MODULE__{shape_meta_table: table} = _state, shape_id) do
-    snapshot_xmin(table, shape_id)
+  def snapshot_xmin(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
+    snapshot_xmin(table, shape_handle)
   end
 
-  def snapshot_xmin(meta_table, shape_id) when is_atom(meta_table) do
+  def snapshot_xmin(meta_table, shape_handle) when is_atom(meta_table) do
     turn_raise_into_error(fn ->
       :ets.lookup_element(
         meta_table,
-        {@shape_meta_data, shape_id},
+        {@shape_meta_data, shape_handle},
         @shape_meta_xmin_pos
       )
     end)
   end
 
-  def snapshot_started?(%__MODULE__{shape_meta_table: table} = _state, shape_id) do
-    snapshot_started?(table, shape_id)
+  def snapshot_started?(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
+    snapshot_started?(table, shape_handle)
   end
 
-  def snapshot_started?(meta_table, shape_id) do
-    case :ets.lookup(meta_table, {@snapshot_started, shape_id}) do
+  def snapshot_started?(meta_table, shape_handle) do
+    case :ets.lookup(meta_table, {@snapshot_started, shape_handle}) do
       [] -> false
-      [{{@snapshot_started, ^shape_id}, true}] -> true
+      [{{@snapshot_started, ^shape_handle}, true}] -> true
     end
   end
 
-  def mark_snapshot_started(%__MODULE__{shape_meta_table: table} = _state, shape_id) do
-    :ets.insert(table, {{@snapshot_started, shape_id}, true})
+  def mark_snapshot_started(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
+    :ets.insert(table, {{@snapshot_started, shape_handle}, true})
     :ok
   end
 
@@ -340,12 +340,12 @@ defmodule Electric.ShapeCache.ShapeStatus do
       :ets.insert(
         state.shape_meta_table,
         Enum.concat([
-          Enum.flat_map(shapes, fn {shape_id, shape} ->
+          Enum.flat_map(shapes, fn {shape_handle, shape} ->
             hash = Shape.hash(shape)
 
             [
-              {{@shape_hash_lookup, hash}, shape_id},
-              {{@shape_meta_data, shape_id}, shape, nil, LogOffset.first()}
+              {{@shape_hash_lookup, hash}, shape_handle},
+              {{@shape_meta_data, shape_handle}, shape, nil, LogOffset.first()}
             ]
           end),
           Enum.flat_map(relations, fn {relation_id, relation} ->

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -4,7 +4,7 @@ defmodule Electric.ShapeCache.Storage do
   alias Electric.Shapes.Querying
   alias Electric.Replication.LogOffset
 
-  @type shape_id :: Electric.ShapeCacheBehaviour.shape_id()
+  @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
   @type xmin :: Electric.ShapeCacheBehaviour.xmin()
   @type offset :: LogOffset.t()
 
@@ -24,7 +24,7 @@ defmodule Electric.ShapeCache.Storage do
   @callback shared_opts(Keyword.t()) :: {:ok, compiled_opts()} | {:error, term()}
 
   @doc "Initialise shape-specific opts from the shared, global, configuration"
-  @callback for_shape(shape_id(), compiled_opts()) :: shape_opts()
+  @callback for_shape(shape_handle(), compiled_opts()) :: shape_opts()
 
   @doc "Start any processes required to run the storage backend"
   @callback start_link(shape_opts()) :: GenServer.on_start()
@@ -107,8 +107,8 @@ defmodule Electric.ShapeCache.Storage do
   end
 
   @impl __MODULE__
-  def for_shape(shape_id, {mod, opts}) do
-    {mod, mod.for_shape(shape_id, opts)}
+  def for_shape(shape_handle, {mod, opts}) do
+    {mod, mod.for_shape(shape_handle, opts)}
   end
 
   @impl __MODULE__

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -5,44 +5,44 @@ defmodule Electric.Shapes do
   alias Electric.Shapes.Shape
   require Logger
 
-  @type shape_id :: Electric.ShapeCacheBehaviour.shape_id()
+  @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
 
   @doc """
   Get snapshot for the shape ID
   """
-  def get_snapshot(config, shape_id) do
+  def get_snapshot(config, shape_handle) do
     {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
-    storage = shape_storage(config, shape_id)
+    storage = shape_storage(config, shape_handle)
 
-    if shape_cache.has_shape?(shape_id, opts) do
-      with :started <- shape_cache.await_snapshot_start(shape_id, opts) do
+    if shape_cache.has_shape?(shape_handle, opts) do
+      with :started <- shape_cache.await_snapshot_start(shape_handle, opts) do
         {:ok, Storage.get_snapshot(storage)}
       end
     else
-      {:error, "invalid shape_id #{inspect(shape_id)}"}
+      {:error, "invalid shape_handle #{inspect(shape_handle)}"}
     end
   end
 
   @doc """
   Get stream of the log since a given offset
   """
-  def get_log_stream(config, shape_id, opts) do
+  def get_log_stream(config, shape_handle, opts) do
     {shape_cache, shape_cache_opts} = Access.get(config, :shape_cache, {ShapeCache, []})
     offset = Access.get(opts, :since, LogOffset.before_all())
     max_offset = Access.get(opts, :up_to, LogOffset.last())
-    storage = shape_storage(config, shape_id)
+    storage = shape_storage(config, shape_handle)
 
-    if shape_cache.has_shape?(shape_id, shape_cache_opts) do
+    if shape_cache.has_shape?(shape_handle, shape_cache_opts) do
       Storage.get_log_stream(offset, max_offset, storage)
     else
-      raise "Unknown shape: #{shape_id}"
+      raise "Unknown shape: #{shape_handle}"
     end
   end
 
   @doc """
   Get the shape that corresponds to this shape definition and return it along with the latest offset of the shape
   """
-  @spec get_shape(keyword(), Shape.t()) :: {shape_id(), LogOffset.t()}
+  @spec get_shape(keyword(), Shape.t()) :: {shape_handle(), LogOffset.t()}
   def get_shape(config, shape_def) do
     {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
 
@@ -52,11 +52,11 @@ defmodule Electric.Shapes do
   @doc """
   Get or create a shape ID and return it along with the latest offset of the shape
   """
-  @spec get_or_create_shape_id(keyword(), Shape.t()) :: {shape_id(), LogOffset.t()}
-  def get_or_create_shape_id(config, shape_def) do
+  @spec get_or_create_shape_handle(keyword(), Shape.t()) :: {shape_handle(), LogOffset.t()}
+  def get_or_create_shape_handle(config, shape_def) do
     {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
 
-    shape_cache.get_or_create_shape_id(shape_def, opts)
+    shape_cache.get_or_create_shape_handle(shape_def, opts)
   end
 
   @doc """
@@ -64,45 +64,45 @@ defmodule Electric.Shapes do
 
   If `nil` is returned, chunk is not complete and the shape's latest offset should be used
   """
-  @spec get_chunk_end_log_offset(keyword(), shape_id(), LogOffset.t()) ::
+  @spec get_chunk_end_log_offset(keyword(), shape_handle(), LogOffset.t()) ::
           LogOffset.t() | nil
-  def get_chunk_end_log_offset(config, shape_id, offset) do
-    storage = shape_storage(config, shape_id)
+  def get_chunk_end_log_offset(config, shape_handle, offset) do
+    storage = shape_storage(config, shape_handle)
     Storage.get_chunk_end_log_offset(offset, storage)
   end
 
   @doc """
   Check whether the log has an entry for a given shape ID
   """
-  @spec has_shape?(keyword(), shape_id()) :: boolean()
-  def has_shape?(config, shape_id) do
+  @spec has_shape?(keyword(), shape_handle()) :: boolean()
+  def has_shape?(config, shape_handle) do
     {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
 
-    shape_cache.has_shape?(shape_id, opts)
+    shape_cache.has_shape?(shape_handle, opts)
   end
 
   @doc """
   Clean up all data (meta data and shape log + snapshot) associated with the given shape ID
   """
-  @spec clean_shape(shape_id(), keyword()) :: :ok
-  def clean_shape(shape_id, opts \\ []) do
+  @spec clean_shape(shape_handle(), keyword()) :: :ok
+  def clean_shape(shape_handle, opts \\ []) do
     {shape_cache, opts} = Access.get(opts, :shape_cache, {ShapeCache, []})
-    shape_cache.clean_shape(shape_id, opts)
+    shape_cache.clean_shape(shape_handle, opts)
     :ok
   end
 
-  @spec clean_shapes([shape_id()], keyword()) :: :ok
-  def clean_shapes(shape_ids, opts \\ []) do
+  @spec clean_shapes([shape_handle()], keyword()) :: :ok
+  def clean_shapes(shape_handles, opts \\ []) do
     {shape_cache, opts} = Access.get(opts, :shape_cache, {ShapeCache, []})
 
-    for shape_id <- shape_ids do
-      shape_cache.clean_shape(shape_id, opts)
+    for shape_handle <- shape_handles do
+      shape_cache.clean_shape(shape_handle, opts)
     end
 
     :ok
   end
 
-  defp shape_storage(config, shape_id) do
-    Storage.for_shape(shape_id, Access.fetch!(config, :storage))
+  defp shape_storage(config, shape_handle) do
+    Storage.for_shape(shape_handle, Access.fetch!(config, :storage))
   end
 end

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -15,12 +15,12 @@ defmodule Electric.Shapes.Consumer do
 
   @initial_log_state %{current_chunk_byte_size: 0}
 
-  def name(%{electric_instance_id: electric_instance_id, shape_id: shape_id} = _config) do
-    name(electric_instance_id, shape_id)
+  def name(%{electric_instance_id: electric_instance_id, shape_handle: shape_handle} = _config) do
+    name(electric_instance_id, shape_handle)
   end
 
-  def name(electric_instance_id, shape_id) when is_binary(shape_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_id)
+  def name(electric_instance_id, shape_handle) when is_binary(shape_handle) do
+    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_handle)
   end
 
   def initial_state(consumer) do
@@ -29,18 +29,18 @@ defmodule Electric.Shapes.Consumer do
 
   @doc false
   # use in tests to avoid race conditions. registers `pid` to be notified
-  # when the `shape_id` consumer has processed every transaction.
+  # when the `shape_handle` consumer has processed every transaction.
   # Transactions that we skip because of xmin logic do not generate
   # a notification
-  @spec monitor(atom(), ShapeCache.shape_id(), pid()) :: reference()
-  def monitor(electric_instance_id, shape_id, pid \\ self()) do
-    GenStage.call(name(electric_instance_id, shape_id), {:monitor, pid})
+  @spec monitor(atom(), ShapeCache.shape_handle(), pid()) :: reference()
+  def monitor(electric_instance_id, shape_handle, pid \\ self()) do
+    GenStage.call(name(electric_instance_id, shape_handle), {:monitor, pid})
   end
 
-  @spec whereis(atom(), ShapeCache.shape_id()) :: pid() | nil
-  def whereis(electric_instance_id, shape_id) do
+  @spec whereis(atom(), ShapeCache.shape_handle()) :: pid() | nil
+  def whereis(electric_instance_id, shape_handle) do
     electric_instance_id
-    |> name(shape_id)
+    |> name(shape_handle)
     |> GenServer.whereis()
   end
 
@@ -51,7 +51,7 @@ defmodule Electric.Shapes.Consumer do
   def init(config) do
     %{log_producer: producer, storage: storage} = config
 
-    Logger.metadata(shape_id: config.shape_id)
+    Logger.metadata(shape_handle: config.shape_handle)
 
     :ok = ShapeCache.Storage.initialise(storage)
 
@@ -78,36 +78,36 @@ defmodule Electric.Shapes.Consumer do
     {:reply, ref, [], %{state | monitors: [{pid, ref} | monitors]}}
   end
 
-  def handle_cast({:snapshot_xmin_known, shape_id, xmin}, %{shape_id: shape_id} = state) do
+  def handle_cast({:snapshot_xmin_known, shape_handle, xmin}, %{shape_handle: shape_handle} = state) do
     ShapeCache.Storage.set_snapshot_xmin(xmin, state.storage)
 
-    cast_shape_cache({:snapshot_xmin_known, shape_id, xmin}, state)
+    cast_shape_cache({:snapshot_xmin_known, shape_handle, xmin}, state)
 
     handle_txns(state.buffer, %{state | snapshot_xmin: xmin, buffer: []})
   end
 
-  def handle_cast({:snapshot_started, shape_id}, %{shape_id: shape_id} = state) do
+  def handle_cast({:snapshot_started, shape_handle}, %{shape_handle: shape_handle} = state) do
     ShapeCache.Storage.mark_snapshot_as_started(state.storage)
-    cast_shape_cache({:snapshot_started, shape_id}, state)
+    cast_shape_cache({:snapshot_started, shape_handle}, state)
 
     {:noreply, [], state}
   end
 
-  def handle_cast({:snapshot_failed, shape_id, error, stacktrace}, state) do
+  def handle_cast({:snapshot_failed, shape_handle, error, stacktrace}, state) do
     Logger.error(
-      "Snapshot creation failed for #{shape_id} because of:\n#{Exception.format(:error, error, stacktrace)}"
+      "Snapshot creation failed for #{shape_handle} because of:\n#{Exception.format(:error, error, stacktrace)}"
     )
 
-    cast_shape_cache({:snapshot_failed, shape_id, error, stacktrace}, state)
+    cast_shape_cache({:snapshot_failed, shape_handle, error, stacktrace}, state)
 
     {:noreply, [], state}
   end
 
-  def handle_cast({:snapshot_exists, shape_id}, %{shape_id: shape_id} = state) do
+  def handle_cast({:snapshot_exists, shape_handle}, %{shape_handle: shape_handle} = state) do
     %{snapshot_xmin: xmin} = state
 
-    cast_shape_cache({:snapshot_xmin_known, shape_id, xmin}, state)
-    cast_shape_cache({:snapshot_started, shape_id}, state)
+    cast_shape_cache({:snapshot_xmin_known, shape_handle, xmin}, state)
+    cast_shape_cache({:snapshot_started, shape_handle}, state)
 
     {:noreply, [], state}
   end
@@ -121,7 +121,7 @@ defmodule Electric.Shapes.Consumer do
   # Buffer incoming transactions until we know our xmin
   def handle_events([%Transaction{xid: xid}] = txns, _from, %{snapshot_xmin: nil} = state) do
     Logger.debug(fn ->
-      "Consumer for #{state.shape_id} buffering 1 transaction with xid #{xid}"
+      "Consumer for #{state.shape_handle} buffering 1 transaction with xid #{xid}"
     end)
 
     {:noreply, [], %{state | buffer: state.buffer ++ txns}}
@@ -151,7 +151,7 @@ defmodule Electric.Shapes.Consumer do
 
   defp handle_txn(%Transaction{} = txn, state) do
     ot_attrs =
-      [xid: txn.xid, num_changes: length(txn.changes)] ++ shape_attrs(state.shape_id, state.shape)
+      [xid: txn.xid, num_changes: length(txn.changes)] ++ shape_attrs(state.shape_handle, state.shape)
 
     OpenTelemetry.with_span("shape_write.consumer.handle_txn", ot_attrs, fn ->
       do_handle_txn(txn, state)
@@ -161,7 +161,7 @@ defmodule Electric.Shapes.Consumer do
   defp do_handle_txn(%Transaction{} = txn, state) do
     %{
       shape: shape,
-      shape_id: shape_id,
+      shape_handle: shape_handle,
       log_state: log_state,
       chunk_bytes_threshold: chunk_bytes_threshold,
       shape_cache: {shape_cache, shape_cache_opts},
@@ -181,10 +181,10 @@ defmodule Electric.Shapes.Consumer do
         #       present in the transaction, we're considering the whole transaction empty, and
         #       just rotate the shape id. "Correct" way to handle truncates is to be designed.
         Logger.warning(
-          "Truncate operation encountered while processing txn #{txn.xid} for #{shape_id}"
+          "Truncate operation encountered while processing txn #{txn.xid} for #{shape_handle}"
         )
 
-        :ok = shape_cache.handle_truncate(shape_id, shape_cache_opts)
+        :ok = shape_cache.handle_truncate(shape_handle, shape_cache_opts)
 
         :ok = ShapeCache.Storage.cleanup!(storage)
 
@@ -198,9 +198,9 @@ defmodule Electric.Shapes.Consumer do
         #       Right now we'll just fail everything
         :ok = ShapeCache.Storage.append_to_log!(log_entries, storage)
 
-        shape_cache.update_shape_latest_offset(shape_id, last_log_offset, shape_cache_opts)
+        shape_cache.update_shape_latest_offset(shape_handle, last_log_offset, shape_cache_opts)
 
-        notify_listeners(registry, :new_changes, shape_id, last_log_offset)
+        notify_listeners(registry, :new_changes, shape_handle, last_log_offset)
 
         {:cont, notify(txn, %{state | log_state: new_log_state})}
 
@@ -213,10 +213,10 @@ defmodule Electric.Shapes.Consumer do
     end
   end
 
-  defp notify_listeners(registry, :new_changes, shape_id, latest_log_offset) do
-    Registry.dispatch(registry, shape_id, fn registered ->
+  defp notify_listeners(registry, :new_changes, shape_handle, latest_log_offset) do
+    Registry.dispatch(registry, shape_handle, fn registered ->
       Logger.debug(fn ->
-        "Notifying ~#{length(registered)} clients about new changes to #{shape_id}"
+        "Notifying ~#{length(registered)} clients about new changes to #{shape_handle}"
       end)
 
       for {pid, ref} <- registered,
@@ -274,7 +274,7 @@ defmodule Electric.Shapes.Consumer do
     {log_items, new_log_state}
   end
 
-  defp shape_attrs(shape_id, shape) do
-    ["shape.id": shape_id, "shape.root_table": shape.root_table, "shape.where": shape.where]
+  defp shape_attrs(shape_handle, shape) do
+    ["shape.id": shape_handle, "shape.root_table": shape.root_table, "shape.where": shape.where]
   end
 end

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -10,12 +10,12 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
   require Logger
 
-  def name(%{electric_instance_id: electric_instance_id, shape_id: shape_id}) do
-    name(electric_instance_id, shape_id)
+  def name(%{electric_instance_id: electric_instance_id, shape_handle: shape_handle}) do
+    name(electric_instance_id, shape_handle)
   end
 
-  def name(electric_instance_id, shape_id) when is_binary(shape_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_id)
+  def name(electric_instance_id, shape_handle) when is_binary(shape_handle) do
+    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_handle)
   end
 
   def start_link(config) do
@@ -27,9 +27,9 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
   end
 
   def handle_continue(:start_snapshot, state) do
-    %{shape_id: shape_id, shape: shape, electric_instance_id: electric_instance_id} = state
+    %{shape_handle: shape_handle, shape: shape, electric_instance_id: electric_instance_id} = state
 
-    case Shapes.Consumer.whereis(electric_instance_id, shape_id) do
+    case Shapes.Consumer.whereis(electric_instance_id, shape_handle) do
       consumer when is_pid(consumer) ->
         if not Storage.snapshot_started?(state.storage) do
           %{
@@ -43,14 +43,14 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
           OpenTelemetry.with_span(
             "shape_snapshot.create_snapshot_task",
-            shape_attrs(shape_id, shape),
+            shape_attrs(shape_handle, shape),
             fn ->
               try do
                 Utils.apply_fn_or_mfa(prepare_tables_fn_or_mfa, [pool, affected_tables])
-                apply(create_snapshot_fn, [consumer, shape_id, shape, pool, storage])
+                apply(create_snapshot_fn, [consumer, shape_handle, shape, pool, storage])
               rescue
                 error ->
-                  GenServer.cast(consumer, {:snapshot_failed, shape_id, error, __STACKTRACE__})
+                  GenServer.cast(consumer, {:snapshot_failed, shape_handle, error, __STACKTRACE__})
               end
             end
           )
@@ -61,7 +61,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
           # storage does some clean up on start, e.g. in the case of a format
           # upgrade, we only know the actual on-disk state of the shape data
           # once things are running.
-          GenServer.cast(consumer, {:snapshot_exists, shape_id})
+          GenServer.cast(consumer, {:snapshot_exists, shape_handle})
         end
 
         {:stop, :normal, state}
@@ -76,20 +76,20 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
   end
 
   @doc false
-  def query_in_readonly_txn(parent, shape_id, shape, db_pool, storage) do
+  def query_in_readonly_txn(parent, shape_handle, shape, db_pool, storage) do
     Postgrex.transaction(
       db_pool,
       fn conn ->
         OpenTelemetry.with_span(
           "shape_snapshot.query_in_readonly_txn",
-          shape_attrs(shape_id, shape),
+          shape_attrs(shape_handle, shape),
           fn ->
             Postgrex.query!(conn, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY", [])
 
             %{rows: [[xmin]]} =
               Postgrex.query!(conn, "SELECT pg_snapshot_xmin(pg_current_snapshot())", [])
 
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, xmin})
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, xmin})
 
             # Enforce display settings *before* querying initial data to maintain consistent
             # formatting between snapshot and live log entries.
@@ -97,7 +97,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
             stream = Querying.stream_initial_data(conn, shape)
 
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
 
             # could pass the shape and then make_new_snapshot! can pass it to row_to_snapshot_item
             # that way it has the relation, but it is still missing the pk_cols
@@ -109,7 +109,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
     )
   end
 
-  defp shape_attrs(shape_id, shape) do
-    ["shape.id": shape_id, "shape.root_table": shape.root_table, "shape.where": shape.where]
+  defp shape_attrs(shape_handle, shape) do
+    ["shape.id": shape_handle, "shape.root_table": shape.root_table, "shape.where": shape.where]
   end
 end

--- a/packages/sync-service/lib/electric/shapes/consumer/supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/supervisor.ex
@@ -6,7 +6,7 @@ defmodule Electric.Shapes.Consumer.Supervisor do
   @genserver_name_schema {:or, [:atom, {:tuple, [:atom, :atom, :any]}]}
   # TODO: unify these with ShapeCache
   @schema NimbleOptions.new!(
-            shape_id: [type: :string, required: true],
+            shape_handle: [type: :string, required: true],
             shape: [type: {:struct, Electric.Shapes.Shape}, required: true],
             electric_instance_id: [type: :atom, required: true],
             log_producer: [type: @genserver_name_schema, required: true],
@@ -22,12 +22,12 @@ defmodule Electric.Shapes.Consumer.Supervisor do
             ]
           )
 
-  def name(electric_instance_id, shape_id) when is_binary(shape_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_id)
+  def name(electric_instance_id, shape_handle) when is_binary(shape_handle) do
+    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_handle)
   end
 
-  def name(%{electric_instance_id: electric_instance_id, shape_id: shape_id}) do
-    name(electric_instance_id, shape_id)
+  def name(%{electric_instance_id: electric_instance_id, shape_handle: shape_handle}) do
+    name(electric_instance_id, shape_handle)
   end
 
   def start_link(opts) do
@@ -38,10 +38,10 @@ defmodule Electric.Shapes.Consumer.Supervisor do
   end
 
   def init(config) when is_map(config) do
-    %{shape_id: shape_id, storage: {_, _} = storage} =
+    %{shape_handle: shape_handle, storage: {_, _} = storage} =
       config
 
-    shape_storage = Electric.ShapeCache.Storage.for_shape(shape_id, storage)
+    shape_storage = Electric.ShapeCache.Storage.for_shape(shape_handle, storage)
 
     shape_config = %{config | storage: shape_storage}
 

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -22,15 +22,15 @@ defmodule Electric.Shapes.ConsumerSupervisor do
   end
 
   def start_shape_consumer(name, config) do
-    Logger.debug(fn -> "Starting consumer for #{Access.fetch!(config, :shape_id)}" end)
+    Logger.debug(fn -> "Starting consumer for #{Access.fetch!(config, :shape_handle)}" end)
 
     DynamicSupervisor.start_child(name, {Consumer.Supervisor, config})
   end
 
-  def stop_shape_consumer(name, electric_instance_id, shape_id) do
-    case GenServer.whereis(Consumer.Supervisor.name(electric_instance_id, shape_id)) do
+  def stop_shape_consumer(name, electric_instance_id, shape_handle) do
+    case GenServer.whereis(Consumer.Supervisor.name(electric_instance_id, shape_handle)) do
       nil ->
-        {:error, "no consumer for shape id #{inspect(shape_id)}"}
+        {:error, "no consumer for shape id #{inspect(shape_handle)}"}
 
       pid when is_pid(pid) ->
         DynamicSupervisor.terminate_child(name, pid)

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -23,7 +23,7 @@ defmodule Electric.Plug.DeleteShapePlugTest do
       }
     }
   }
-  @test_shape_id "test-shape-id"
+  @test_shape_handle "test-shape-id"
 
   def load_column_info({"public", "users"}, _),
     do: {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
@@ -76,8 +76,8 @@ defmodule Electric.Plug.DeleteShapePlugTest do
 
     test "should clean shape based on shape definition" do
       Mock.ShapeCache
-      |> expect(:get_or_create_shape_id, fn @test_shape, _opts -> {@test_shape_id, 0} end)
-      |> expect(:clean_shape, fn @test_shape_id, _ -> :ok end)
+      |> expect(:get_or_create_shape_handle, fn @test_shape, _opts -> {@test_shape_handle, 0} end)
+      |> expect(:clean_shape, fn @test_shape_handle, _ -> :ok end)
 
       conn =
         conn(:delete, "?root_table=public.users")
@@ -86,12 +86,12 @@ defmodule Electric.Plug.DeleteShapePlugTest do
       assert conn.status == 202
     end
 
-    test "should clean shape based on shape_id" do
+    test "should clean shape based on shape_handle" do
       Mock.ShapeCache
-      |> expect(:clean_shape, fn @test_shape_id, _ -> :ok end)
+      |> expect(:clean_shape, fn @test_shape_handle, _ -> :ok end)
 
       conn =
-        conn(:delete, "?root_table=public.users&shape_id=#{@test_shape_id}")
+        conn(:delete, "?root_table=public.users&shape_handle=#{@test_shape_handle}")
         |> DeleteShapePlug.call([])
 
       assert conn.status == 202

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -116,10 +116,10 @@ defmodule Electric.Plug.RouterTest do
         []
       )
 
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
 
       conn =
-        conn("GET", "/v1/shape/items?shape_id=#{shape_id}&offset=0_0&live") |> Router.call(opts)
+        conn("GET", "/v1/shape/items?shape_handle=#{shape_handle}&offset=0_0&live") |> Router.call(opts)
 
       assert [%{"value" => %{"num" => "2"}}, _] = Jason.decode!(conn.resp_body)
     end
@@ -134,13 +134,13 @@ defmodule Electric.Plug.RouterTest do
         |> Router.call(opts)
 
       assert %{status: 200} = conn
-      shape1_id = get_resp_shape_id(conn)
+      shape1_id = get_resp_shape_handle(conn)
 
       assert [%{"value" => %{"value" => "test value 1"}}, %{"headers" => _}] =
                Jason.decode!(conn.resp_body)
 
       assert %{status: 202} =
-               conn("DELETE", "/v1/shape/items?shape_id=#{shape1_id}")
+               conn("DELETE", "/v1/shape/items?shape_handle=#{shape1_id}")
                |> Router.call(opts)
 
       Postgrex.query!(db_conn, "DELETE FROM items", [])
@@ -151,7 +151,7 @@ defmodule Electric.Plug.RouterTest do
         |> Router.call(opts)
 
       assert %{status: 200} = conn
-      shape2_id = get_resp_shape_id(conn)
+      shape2_id = get_resp_shape_handle(conn)
       assert shape1_id != shape2_id
 
       assert [%{"value" => %{"value" => "test value 2"}}, %{"headers" => _}] =
@@ -172,7 +172,7 @@ defmodule Electric.Plug.RouterTest do
         |> Router.call(opts)
 
       assert %{status: 200} = conn
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
 
       key =
         Changes.build_key({"public", "foo"}, %{"first" => "a", "second" => "b", "third" => "c"}, [
@@ -198,7 +198,7 @@ defmodule Electric.Plug.RouterTest do
 
       task =
         Task.async(fn ->
-          conn("GET", "/v1/shape/foo?offset=#{@first_offset}&shape_id=#{shape_id}&live")
+          conn("GET", "/v1/shape/foo?offset=#{@first_offset}&shape_handle=#{shape_handle}&live")
           |> Router.call(opts)
         end)
 
@@ -243,7 +243,7 @@ defmodule Electric.Plug.RouterTest do
     test "GET received only a diff when receiving updates", %{opts: opts, db_conn: db_conn} do
       conn = conn("GET", "/v1/shape/wide_table?offset=-1") |> Router.call(opts)
       assert %{status: 200} = conn
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
 
       assert [
                %{
@@ -255,7 +255,7 @@ defmodule Electric.Plug.RouterTest do
 
       task =
         Task.async(fn ->
-          conn("GET", "/v1/shape/wide_table?offset=0_0&shape_id=#{shape_id}&live")
+          conn("GET", "/v1/shape/wide_table?offset=0_0&shape_handle=#{shape_handle}&live")
           |> Router.call(opts)
         end)
 
@@ -278,7 +278,7 @@ defmodule Electric.Plug.RouterTest do
     } do
       conn = conn("GET", "/v1/shape/wide_table?offset=-1") |> Router.call(opts)
       assert %{status: 200} = conn
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
 
       assert [
                %{
@@ -290,7 +290,7 @@ defmodule Electric.Plug.RouterTest do
 
       task =
         Task.async(fn ->
-          conn("GET", "/v1/shape/wide_table?offset=0_0&shape_id=#{shape_id}&live")
+          conn("GET", "/v1/shape/wide_table?offset=0_0&shape_handle=#{shape_handle}&live")
           |> Router.call(opts)
         end)
 
@@ -342,14 +342,14 @@ defmodule Electric.Plug.RouterTest do
          %{opts: opts, db_conn: db_conn} do
       conn = conn("GET", "/v1/shape/test_table?offset=-1") |> Router.call(opts)
       assert %{status: 200} = conn
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
 
       assert [%{"value" => %{"col1" => "test1", "col2" => "test2"}, "key" => key}, _] =
                Jason.decode!(conn.resp_body)
 
       task =
         Task.async(fn ->
-          conn("GET", "/v1/shape/test_table?offset=0_0&shape_id=#{shape_id}&live")
+          conn("GET", "/v1/shape/test_table?offset=0_0&shape_handle=#{shape_handle}&live")
           |> Router.call(opts)
         end)
 
@@ -396,7 +396,7 @@ defmodule Electric.Plug.RouterTest do
         |> Router.call(opts)
 
       assert %{status: 200} = conn
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
 
       assert [_] = Jason.decode!(conn.resp_body)
 
@@ -404,7 +404,7 @@ defmodule Electric.Plug.RouterTest do
         Task.async(fn ->
           conn("GET", "/v1/shape/items", %{
             offset: "0_0",
-            shape_id: shape_id,
+            shape_handle: shape_handle,
             where: where,
             live: true
           })
@@ -426,7 +426,7 @@ defmodule Electric.Plug.RouterTest do
                conn =
                conn("GET", "/v1/shape/items", %{
                  offset: new_offset,
-                 shape_id: shape_id,
+                 shape_handle: shape_handle,
                  where: where
                })
                |> Router.call(opts)
@@ -448,7 +448,7 @@ defmodule Electric.Plug.RouterTest do
         |> Router.call(opts)
 
       assert %{status: 200} = conn
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
       assert [op, @up_to_date] = Jason.decode!(conn.resp_body)
 
       assert op == %{
@@ -465,7 +465,7 @@ defmodule Electric.Plug.RouterTest do
         Task.async(fn ->
           conn("GET", "/v1/shape/serial_ids", %{
             offset: "0_0",
-            shape_id: shape_id,
+            shape_handle: shape_handle,
             where: where,
             live: true
           })
@@ -495,7 +495,7 @@ defmodule Electric.Plug.RouterTest do
         Task.async(fn ->
           conn("GET", "/v1/shape/serial_ids", %{
             offset: new_offset,
-            shape_id: shape_id,
+            shape_handle: shape_handle,
             where: where,
             live: true
           })
@@ -556,7 +556,7 @@ defmodule Electric.Plug.RouterTest do
         |> Router.call(opts)
 
       assert %{status: 200} = conn
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
       assert [op1, op2, @up_to_date] = Jason.decode!(conn.resp_body)
 
       assert [op1, op2] == [
@@ -579,7 +579,7 @@ defmodule Electric.Plug.RouterTest do
         Task.async(fn ->
           conn("GET", "/v1/shape/serial_ids", %{
             offset: "0_0",
-            shape_id: shape_id,
+            shape_handle: shape_handle,
             where: where,
             live: true
           })
@@ -641,7 +641,7 @@ defmodule Electric.Plug.RouterTest do
 
       conn = conn("GET", "/v1/shape/large_rows_table?offset=-1") |> Router.call(opts)
       assert %{status: 200} = conn
-      [shape_id] = Plug.Conn.get_resp_header(conn, "electric-shape-id")
+      [shape_handle] = Plug.Conn.get_resp_header(conn, "electric-shape-id")
       [next_offset] = Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset")
 
       assert [_] = Jason.decode!(conn.resp_body)
@@ -651,7 +651,7 @@ defmodule Electric.Plug.RouterTest do
         Task.async(fn ->
           conn(
             "GET",
-            "/v1/shape/large_rows_table?offset=#{next_offset}&shape_id=#{shape_id}&live"
+            "/v1/shape/large_rows_table?offset=#{next_offset}&shape_handle=#{shape_handle}&live"
           )
           |> Router.call(opts)
         end)
@@ -665,7 +665,7 @@ defmodule Electric.Plug.RouterTest do
       assert %{status: 200} = Task.await(task)
 
       conn =
-        conn("GET", "/v1/shape/large_rows_table?offset=#{next_offset}&shape_id=#{shape_id}")
+        conn("GET", "/v1/shape/large_rows_table?offset=#{next_offset}&shape_handle=#{shape_handle}")
         |> Router.call(opts)
 
       assert %{status: 200} = conn
@@ -686,7 +686,7 @@ defmodule Electric.Plug.RouterTest do
       [next_offset] = Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset")
 
       conn =
-        conn("GET", "/v1/shape/large_rows_table?offset=#{next_offset}&shape_id=#{shape_id}")
+        conn("GET", "/v1/shape/large_rows_table?offset=#{next_offset}&shape_handle=#{shape_handle}")
         |> Router.call(opts)
 
       assert %{status: 200} = conn
@@ -717,12 +717,12 @@ defmodule Electric.Plug.RouterTest do
       assert %{status: 200} = conn
       assert conn.resp_body != ""
 
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
       [next_offset] = Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset")
 
       # Make the next request but forget to include the where clause
       conn =
-        conn("GET", "/v1/shape/items", %{offset: next_offset, shape_id: shape_id})
+        conn("GET", "/v1/shape/items", %{offset: next_offset, shape_handle: shape_handle})
         |> Router.call(opts)
 
       assert %{status: 400} = conn
@@ -735,15 +735,15 @@ defmodule Electric.Plug.RouterTest do
          } do
       # Make the next request but forget to include the where clause
       conn =
-        conn("GET", "/v1/shape/items", %{offset: "0_0", shape_id: "nonexistent"})
+        conn("GET", "/v1/shape/items", %{offset: "0_0", shape_handle: "nonexistent"})
         |> Router.call(opts)
 
       assert %{status: 409} = conn
       assert conn.resp_body == Jason.encode!([%{headers: %{control: "must-refetch"}}])
-      new_shape_id = get_resp_header(conn, "electric-shape-id")
+      new_shape_handle = get_resp_header(conn, "electric-shape-id")
 
       assert get_resp_header(conn, "location") ==
-               "/v1/shape/items?shape_id=#{new_shape_id}&offset=-1"
+               "/v1/shape/items?shape_handle=#{new_shape_handle}&offset=-1"
     end
 
     test "GET receives 409 when shape ID is not found but there is another shape matching the definition",
@@ -761,15 +761,15 @@ defmodule Electric.Plug.RouterTest do
       assert %{status: 200} = conn
       assert conn.resp_body != ""
 
-      shape_id = get_resp_shape_id(conn)
+      shape_handle = get_resp_shape_handle(conn)
 
-      # Request the same shape definition but with invalid shape_id
+      # Request the same shape definition but with invalid shape_handle
       conn =
-        conn("GET", "/v1/shape/items", %{offset: "0_0", shape_id: "nonexistent", where: where})
+        conn("GET", "/v1/shape/items", %{offset: "0_0", shape_handle: "nonexistent", where: where})
         |> Router.call(opts)
 
       assert %{status: 409} = conn
-      [^shape_id] = Plug.Conn.get_resp_header(conn, "electric-shape-id")
+      [^shape_handle] = Plug.Conn.get_resp_header(conn, "electric-shape-id")
     end
 
     @tag with_sql: [
@@ -820,7 +820,7 @@ defmodule Electric.Plug.RouterTest do
     end
   end
 
-  defp get_resp_shape_id(conn), do: get_resp_header(conn, "electric-shape-id")
+  defp get_resp_shape_handle(conn), do: get_resp_header(conn, "electric-shape-id")
   defp get_resp_last_offset(conn), do: get_resp_header(conn, "electric-chunk-last-offset")
 
   defp get_resp_header(conn, header) do

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -26,7 +26,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       }
     }
   }
-  @test_shape_id "test-shape-id"
+  @test_shape_handle "test-shape-id"
   @test_opts %{foo: "bar"}
   @before_all_offset LogOffset.before_all()
   @first_offset LogOffset.first()
@@ -71,7 +71,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              }
     end
 
-    test "returns 400 for missing shape_id when offset != -1" do
+    test "returns 400 for missing shape_handle when offset != -1" do
       conn =
         conn(:get, %{"root_table" => "public.users"}, "?offset=#{LogOffset.first()}")
         |> ServeShapePlug.call([])
@@ -79,7 +79,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert conn.status == 400
 
       assert Jason.decode!(conn.resp_body) == %{
-               "shape_id" => ["can't be blank when offset != -1"]
+               "shape_handle" => ["can't be blank when offset != -1"]
              }
     end
 
@@ -101,16 +101,16 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "returns snapshot when offset is -1" do
       Mock.ShapeCache
-      |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+      |> expect(:get_or_create_shape_handle, fn @test_shape, _opts ->
+        {@test_shape_handle, @test_offset}
       end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
-      |> expect(:await_snapshot_start, fn @test_shape_id, _ -> :started end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> expect(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
       next_offset = LogOffset.increment(@first_offset)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
@@ -138,24 +138,24 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert Plug.Conn.get_resp_header(conn, "etag") == [
-               "#{@test_shape_id}:-1:#{next_offset}"
+               "#{@test_shape_handle}:-1:#{next_offset}"
              ]
 
-      assert Plug.Conn.get_resp_header(conn, "electric-shape-id") == [@test_shape_id]
+      assert Plug.Conn.get_resp_header(conn, "electric-shape-id") == [@test_shape_handle]
     end
 
     test "snapshot has correct cache control headers" do
       Mock.ShapeCache
-      |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+      |> expect(:get_or_create_shape_handle, fn @test_shape, _opts ->
+        {@test_shape_handle, @test_offset}
       end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
-      |> expect(:await_snapshot_start, fn @test_shape_id, _ -> :started end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> expect(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
       next_offset = LogOffset.increment(@first_offset)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
@@ -184,16 +184,16 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "response has correct schema header" do
       Mock.ShapeCache
-      |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+      |> expect(:get_or_create_shape_handle, fn @test_shape, _opts ->
+        {@test_shape_handle, @test_offset}
       end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
-      |> expect(:await_snapshot_start, fn @test_shape_id, _ -> :started end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> expect(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
       next_offset = LogOffset.increment(@first_offset)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
@@ -216,15 +216,15 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "returns log when offset is >= 0" do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+        {@test_shape_handle, @test_offset}
       end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
 
       next_offset = LogOffset.increment(@start_offset_50)
       next_next_offset = LogOffset.increment(next_offset)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @start_offset_50, _ ->
         next_next_offset
       end)
@@ -239,7 +239,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         conn(
           :get,
           %{"root_table" => "public.users"},
-          "?offset=#{@start_offset_50}&shape_id=#{@test_shape_id}"
+          "?offset=#{@start_offset_50}&shape_handle=#{@test_shape_handle}"
         )
         |> ServeShapePlug.call([])
 
@@ -261,10 +261,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert Plug.Conn.get_resp_header(conn, "etag") == [
-               "#{@test_shape_id}:#{@start_offset_50}:#{next_next_offset}"
+               "#{@test_shape_handle}:#{@start_offset_50}:#{next_next_offset}"
              ]
 
-      assert Plug.Conn.get_resp_header(conn, "electric-shape-id") == [@test_shape_id]
+      assert Plug.Conn.get_resp_header(conn, "electric-shape-id") == [@test_shape_handle]
 
       assert Plug.Conn.get_resp_header(conn, "electric-chunk-last-offset") == [
                "#{next_next_offset}"
@@ -276,12 +276,12 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "returns 304 Not Modified when If-None-Match matches ETag" do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+        {@test_shape_handle, @test_offset}
       end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @start_offset_50, _ ->
         @test_offset
       end)
@@ -290,11 +290,11 @@ defmodule Electric.Plug.ServeShapePlugTest do
         conn(
           :get,
           %{"root_table" => "public.users"},
-          "?offset=#{@start_offset_50}&shape_id=#{@test_shape_id}"
+          "?offset=#{@start_offset_50}&shape_handle=#{@test_shape_handle}"
         )
         |> put_req_header(
           "if-none-match",
-          ~s("#{@test_shape_id}:#{@start_offset_50}:#{@test_offset}")
+          ~s("#{@test_shape_handle}:#{@start_offset_50}:#{@test_offset}")
         )
         |> ServeShapePlug.call([])
 
@@ -305,16 +305,16 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "handles live updates" do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+        {@test_shape_handle, @test_offset}
       end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
 
       test_pid = self()
       next_offset = LogOffset.increment(@test_offset)
       next_offset_str = "#{next_offset}"
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
@@ -331,7 +331,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
           conn(
             :get,
             %{"root_table" => "public.users"},
-            "?offset=#{@test_offset}&shape_id=#{@test_shape_id}&live=true"
+            "?offset=#{@test_offset}&shape_handle=#{@test_shape_handle}&live=true"
           )
           |> ServeShapePlug.call([])
         end)
@@ -341,7 +341,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       Process.sleep(50)
 
       # Simulate new changes arriving
-      Registry.dispatch(@registry, @test_shape_id, fn [{pid, ref}] ->
+      Registry.dispatch(@registry, @test_shape_handle, fn [{pid, ref}] ->
         send(pid, {ref, :new_changes, next_offset})
       end)
 
@@ -367,14 +367,14 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "handles shape rotation" do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+        {@test_shape_handle, @test_offset}
       end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
 
       test_pid = self()
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
@@ -388,7 +388,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
           conn(
             :get,
             %{"root_table" => "public.users"},
-            "?offset=#{@test_offset}&shape_id=#{@test_shape_id}&live=true"
+            "?offset=#{@test_offset}&shape_handle=#{@test_shape_handle}&live=true"
           )
           |> ServeShapePlug.call([])
         end)
@@ -398,7 +398,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       Process.sleep(50)
 
       # Simulate shape rotation
-      Registry.dispatch(@registry, @test_shape_id, fn [{pid, ref}] ->
+      Registry.dispatch(@registry, @test_shape_handle, fn [{pid, ref}] ->
         send(pid, {ref, :shape_rotation})
       end)
 
@@ -415,12 +415,12 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "sends an up-to-date response after a timeout if no changes are observed" do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+        {@test_shape_handle, @test_offset}
       end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
@@ -432,7 +432,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         conn(
           :get,
           %{"root_table" => "public.users"},
-          "?offset=#{@test_offset}&shape_id=#{@test_shape_id}&live=true"
+          "?offset=#{@test_offset}&shape_handle=#{@test_shape_handle}&live=true"
         )
         |> put_in_config(:long_poll_timeout, 100)
         |> ServeShapePlug.call([])
@@ -451,7 +451,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "sends 409 with a redirect to existing shape when requested shape ID does not exist" do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_id, @test_offset}
+        {@test_shape_handle, @test_offset}
       end)
       |> stub(:has_shape?, fn "foo", _opts -> false end)
 
@@ -462,58 +462,58 @@ defmodule Electric.Plug.ServeShapePlugTest do
         conn(
           :get,
           %{"root_table" => "public.users"},
-          "?offset=#{"50_12"}&shape_id=foo"
+          "?offset=#{"50_12"}&shape_handle=foo"
         )
         |> ServeShapePlug.call([])
 
       assert conn.status == 409
 
       assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "must-refetch"}}]
-      assert get_resp_header(conn, "electric-shape-id") == [@test_shape_id]
-      assert get_resp_header(conn, "location") == ["/?shape_id=#{@test_shape_id}&offset=-1"]
+      assert get_resp_header(conn, "electric-shape-id") == [@test_shape_handle]
+      assert get_resp_header(conn, "location") == ["/?shape_handle=#{@test_shape_handle}&offset=-1"]
     end
 
     test "creates a new shape when shape ID does not exist and sends a 409 redirecting to the newly created shape" do
-      new_shape_id = "new-shape-id"
+      new_shape_handle = "new-shape-id"
 
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts -> nil end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> false end)
-      |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
-        {new_shape_id, @test_offset}
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> false end)
+      |> expect(:get_or_create_shape_handle, fn @test_shape, _opts ->
+        {new_shape_handle, @test_offset}
       end)
 
       Mock.Storage
-      |> stub(:for_shape, fn new_shape_id, opts -> {new_shape_id, opts} end)
+      |> stub(:for_shape, fn new_shape_handle, opts -> {new_shape_handle, opts} end)
 
       conn =
         conn(
           :get,
           %{"root_table" => "public.users"},
-          "?offset=#{"50_12"}&shape_id=#{@test_shape_id}"
+          "?offset=#{"50_12"}&shape_handle=#{@test_shape_handle}"
         )
         |> ServeShapePlug.call([])
 
       assert conn.status == 409
 
       assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "must-refetch"}}]
-      assert get_resp_header(conn, "electric-shape-id") == [new_shape_id]
-      assert get_resp_header(conn, "location") == ["/?shape_id=#{new_shape_id}&offset=-1"]
+      assert get_resp_header(conn, "electric-shape-id") == [new_shape_handle]
+      assert get_resp_header(conn, "location") == ["/?shape_handle=#{new_shape_handle}&offset=-1"]
     end
 
     test "sends 400 when shape ID does not match shape definition" do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts -> nil end)
-      |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, opts -> {@test_shape_id, opts} end)
+      |> stub(:for_shape, fn @test_shape_handle, opts -> {@test_shape_handle, opts} end)
 
       conn =
         conn(
           :get,
           %{"root_table" => "public.users"},
-          "?offset=#{"50_12"}&shape_id=#{@test_shape_id}"
+          "?offset=#{"50_12"}&shape_handle=#{@test_shape_handle}"
         )
         |> ServeShapePlug.call([])
 

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -34,13 +34,13 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
 
     shapes = Keyword.get(opts, :shapes, [])
 
-    shape_ids =
+    shape_handles =
       for shape <- shapes do
-        {:ok, shape_id} = ShapeStatus.add_shape(state, shape)
-        shape_id
+        {:ok, shape_handle} = ShapeStatus.add_shape(state, shape)
+        shape_handle
       end
 
-    {:ok, state, shape_ids}
+    {:ok, state, shape_handles}
   end
 
   test "starts empty", ctx do
@@ -51,30 +51,30 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
   test "can add and retain shapes", ctx do
     {:ok, state, []} = new_state(ctx)
     shape = shape!()
-    assert {:ok, shape_id} = ShapeStatus.add_shape(state, shape)
-    assert [{^shape_id, ^shape}] = ShapeStatus.list_shapes(state)
+    assert {:ok, shape_handle} = ShapeStatus.add_shape(state, shape)
+    assert [{^shape_handle, ^shape}] = ShapeStatus.list_shapes(state)
 
     {:ok, state, []} = new_state(ctx)
-    assert [{^shape_id, ^shape}] = ShapeStatus.list_shapes(state)
+    assert [{^shape_handle, ^shape}] = ShapeStatus.list_shapes(state)
   end
 
   test "can delete shape instances", ctx do
     {:ok, state, []} = new_state(ctx)
     shape_1 = shape!()
-    assert {:ok, shape_id_1} = ShapeStatus.add_shape(state, shape_1)
+    assert {:ok, shape_handle_1} = ShapeStatus.add_shape(state, shape_1)
 
     shape_2 = shape2!()
 
-    assert {:ok, shape_id_2} = ShapeStatus.add_shape(state, shape_2)
+    assert {:ok, shape_handle_2} = ShapeStatus.add_shape(state, shape_2)
 
-    assert Enum.sort_by([{shape_id_1, shape_1}, {shape_id_2, shape_2}], &elem(&1, 0)) ==
+    assert Enum.sort_by([{shape_handle_1, shape_1}, {shape_handle_2, shape_2}], &elem(&1, 0)) ==
              ShapeStatus.list_shapes(state) |> Enum.sort_by(&elem(&1, 0))
 
-    assert {:ok, ^shape_1} = ShapeStatus.remove_shape(state, shape_id_1)
-    assert [{^shape_id_2, ^shape_2}] = ShapeStatus.list_shapes(state)
+    assert {:ok, ^shape_1} = ShapeStatus.remove_shape(state, shape_handle_1)
+    assert [{^shape_handle_2, ^shape_2}] = ShapeStatus.list_shapes(state)
 
     {:ok, state, []} = new_state(ctx)
-    assert [{^shape_id_2, ^shape_2}] = ShapeStatus.list_shapes(state)
+    assert [{^shape_handle_2, ^shape_2}] = ShapeStatus.list_shapes(state)
   end
 
   test "get_existing_shape/2 with %Shape{}", ctx do
@@ -83,108 +83,108 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
 
     refute ShapeStatus.get_existing_shape(state, shape)
 
-    assert {:ok, shape_id} = ShapeStatus.add_shape(state, shape)
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape)
+    assert {:ok, shape_handle} = ShapeStatus.add_shape(state, shape)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(state, shape)
 
     {:ok, state, []} = new_state(ctx)
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(state, shape)
 
-    assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_id)
+    assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_handle)
     refute ShapeStatus.get_existing_shape(state, shape)
   end
 
-  test "get_existing_shape/2 with shape_id", ctx do
+  test "get_existing_shape/2 with shape_handle", ctx do
     shape = shape!()
-    {:ok, state, [shape_id]} = new_state(ctx, shapes: [shape])
+    {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape])
 
     refute ShapeStatus.get_existing_shape(state, "1234")
 
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape)
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape_id)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(state, shape)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(state, shape_handle)
 
     {:ok, state, []} = new_state(ctx)
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape)
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(state, shape_id)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(state, shape)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(state, shape_handle)
 
-    assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_id)
+    assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_handle)
     refute ShapeStatus.get_existing_shape(state, shape)
-    refute ShapeStatus.get_existing_shape(state, shape_id)
+    refute ShapeStatus.get_existing_shape(state, shape_handle)
   end
 
   test "get_existing_shape/2 public api", ctx do
     shape = shape!()
     table = table_name()
 
-    {:ok, _state, [shape_id]} = new_state(ctx, table: table, shapes: [shape])
+    {:ok, _state, [shape_handle]} = new_state(ctx, table: table, shapes: [shape])
 
     refute ShapeStatus.get_existing_shape(table, "1234")
 
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(table, shape)
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(table, shape_id)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(table, shape)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(table, shape_handle)
 
     table = table_name()
 
     {:ok, state, []} = new_state(ctx, table: table)
 
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(table, shape)
-    assert {^shape_id, _} = ShapeStatus.get_existing_shape(table, shape_id)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(table, shape)
+    assert {^shape_handle, _} = ShapeStatus.get_existing_shape(table, shape_handle)
 
-    assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_id)
+    assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_handle)
     refute ShapeStatus.get_existing_shape(table, shape)
-    refute ShapeStatus.get_existing_shape(table, shape_id)
+    refute ShapeStatus.get_existing_shape(table, shape_handle)
   end
 
   test "latest_offset", ctx do
-    {:ok, state, [shape_id]} = new_state(ctx, shapes: [shape!()])
+    {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape!()])
     assert :error = ShapeStatus.latest_offset(state, "sdfsodf")
-    assert ShapeStatus.latest_offset(state, shape_id) == {:ok, LogOffset.first()}
+    assert ShapeStatus.latest_offset(state, shape_handle) == {:ok, LogOffset.first()}
     offset = LogOffset.new(100, 3)
-    assert ShapeStatus.set_latest_offset(state, shape_id, offset)
+    assert ShapeStatus.set_latest_offset(state, shape_handle, offset)
     refute ShapeStatus.set_latest_offset(state, "not my shape", offset)
-    assert ShapeStatus.latest_offset(state, shape_id) == {:ok, offset}
+    assert ShapeStatus.latest_offset(state, shape_handle) == {:ok, offset}
   end
 
   test "latest_offset public api", ctx do
     table_name = table_name()
-    {:ok, _state, [shape_id]} = new_state(ctx, table: table_name, shapes: [shape!()])
+    {:ok, _state, [shape_handle]} = new_state(ctx, table: table_name, shapes: [shape!()])
     assert :error = ShapeStatus.latest_offset(table_name, "sdfsodf")
-    assert ShapeStatus.latest_offset(table_name, shape_id) == {:ok, LogOffset.first()}
+    assert ShapeStatus.latest_offset(table_name, shape_handle) == {:ok, LogOffset.first()}
     offset = LogOffset.new(100, 3)
     refute ShapeStatus.set_latest_offset(table_name, "not my shape", offset)
-    assert ShapeStatus.set_latest_offset(table_name, shape_id, offset)
-    assert ShapeStatus.latest_offset(table_name, shape_id) == {:ok, offset}
+    assert ShapeStatus.set_latest_offset(table_name, shape_handle, offset)
+    assert ShapeStatus.latest_offset(table_name, shape_handle) == {:ok, offset}
   end
 
   test "initialise_shape/4", ctx do
-    {:ok, state, [shape_id]} = new_state(ctx, shapes: [shape!()])
+    {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape!()])
     offset = LogOffset.new(100, 3)
-    assert :ok = ShapeStatus.initialise_shape(state, shape_id, 1234, offset)
-    assert ShapeStatus.latest_offset(state, shape_id) == {:ok, offset}
-    assert ShapeStatus.snapshot_xmin(state, shape_id) == {:ok, 1234}
+    assert :ok = ShapeStatus.initialise_shape(state, shape_handle, 1234, offset)
+    assert ShapeStatus.latest_offset(state, shape_handle) == {:ok, offset}
+    assert ShapeStatus.snapshot_xmin(state, shape_handle) == {:ok, 1234}
   end
 
   test "snapshot_xmin/2", ctx do
-    {:ok, state, [shape_id]} = new_state(ctx, shapes: [shape!()])
+    {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape!()])
 
     refute ShapeStatus.set_snapshot_xmin(state, "sdfsodf", 1234)
 
     assert :error = ShapeStatus.snapshot_xmin(state, "sdfsodf")
-    assert {:ok, nil} == ShapeStatus.snapshot_xmin(state, shape_id)
-    assert ShapeStatus.set_snapshot_xmin(state, shape_id, 1234)
-    assert {:ok, 1234} == ShapeStatus.snapshot_xmin(state, shape_id)
+    assert {:ok, nil} == ShapeStatus.snapshot_xmin(state, shape_handle)
+    assert ShapeStatus.set_snapshot_xmin(state, shape_handle, 1234)
+    assert {:ok, 1234} == ShapeStatus.snapshot_xmin(state, shape_handle)
   end
 
   test "snapshot_started?/2", ctx do
-    {:ok, state, [shape_id]} = new_state(ctx, shapes: [shape!()])
+    {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape!()])
 
     refute ShapeStatus.snapshot_started?(state, "sdfsodf")
     refute ShapeStatus.snapshot_started?(state.shape_meta_table, "sdfsodf")
-    refute ShapeStatus.snapshot_started?(state, shape_id)
+    refute ShapeStatus.snapshot_started?(state, shape_handle)
 
-    ShapeStatus.mark_snapshot_started(state, shape_id)
+    ShapeStatus.mark_snapshot_started(state, shape_handle)
 
-    assert ShapeStatus.snapshot_started?(state, shape_id)
-    assert ShapeStatus.snapshot_started?(state.shape_meta_table, shape_id)
+    assert ShapeStatus.snapshot_started?(state, shape_handle)
+    assert ShapeStatus.snapshot_started?(state.shape_meta_table, shape_handle)
   end
 
   test "relation data", ctx do

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -13,7 +13,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
   @moduletag :tmp_dir
 
-  @shape_id "the-shape-id"
+  @shape_handle "the-shape-id"
 
   @snapshot_offset LogOffset.first()
   @snapshot_offset_encoded to_string(@snapshot_offset)
@@ -479,7 +479,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   defp start_storage(%{module: module} = context) do
     {:ok, opts} = module |> opts(context) |> module.shared_opts()
 
-    shape_opts = module.for_shape(@shape_id, opts)
+    shape_opts = module.for_shape(@shape_handle, opts)
 
     {:ok, _} = module.start_link(shape_opts)
 

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -11,17 +11,17 @@ defmodule Electric.ShapeCache.StorageTest do
 
   test "should pass through the calls to the storage module" do
     storage = {Mock.Storage, :opts}
-    shape_id = "test"
+    shape_handle = "test"
 
     Mock.Storage
-    |> Mox.stub(:for_shape, fn ^shape_id, :opts -> {shape_id, :opts} end)
-    |> Mox.expect(:make_new_snapshot!, fn _, {^shape_id, :opts} -> :ok end)
-    |> Mox.expect(:snapshot_started?, fn {^shape_id, :opts} -> true end)
-    |> Mox.expect(:get_snapshot, fn {^shape_id, :opts} -> {1, []} end)
-    |> Mox.expect(:append_to_log!, fn _, {^shape_id, :opts} -> :ok end)
-    |> Mox.expect(:get_log_stream, fn _, _, {^shape_id, :opts} -> [] end)
+    |> Mox.stub(:for_shape, fn ^shape_handle, :opts -> {shape_handle, :opts} end)
+    |> Mox.expect(:make_new_snapshot!, fn _, {^shape_handle, :opts} -> :ok end)
+    |> Mox.expect(:snapshot_started?, fn {^shape_handle, :opts} -> true end)
+    |> Mox.expect(:get_snapshot, fn {^shape_handle, :opts} -> {1, []} end)
+    |> Mox.expect(:append_to_log!, fn _, {^shape_handle, :opts} -> :ok end)
+    |> Mox.expect(:get_log_stream, fn _, _, {^shape_handle, :opts} -> [] end)
 
-    shape_storage = Storage.for_shape(shape_id, storage)
+    shape_storage = Storage.for_shape(shape_handle, storage)
 
     Storage.make_new_snapshot!([], shape_storage)
     Storage.snapshot_started?(shape_storage)
@@ -34,8 +34,8 @@ defmodule Electric.ShapeCache.StorageTest do
     storage = {Mock.Storage, :opts}
 
     Mock.Storage
-    |> Mox.stub(:for_shape, fn shape_id, :opts -> {shape_id, :opts} end)
-    |> Mox.expect(:get_log_stream, fn _, _, {_shape_id, :opts} -> [] end)
+    |> Mox.stub(:for_shape, fn shape_handle, :opts -> {shape_handle, :opts} end)
+    |> Mox.expect(:get_log_stream, fn _, _, {_shape_handle, :opts} -> [] end)
 
     l1 = LogOffset.new(26_877_408, 10)
     l2 = LogOffset.new(26_877_648, 0)

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -60,7 +60,7 @@ defmodule Electric.ShapeCacheTest do
     %{inspector: @stub_inspector}
   end
 
-  describe "get_or_create_shape_id/2" do
+  describe "get_or_create_shape_handle/2" do
     setup [
       :with_electric_instance_id,
       :with_in_memory_storage,
@@ -79,19 +79,19 @@ defmodule Electric.ShapeCacheTest do
       )
     end
 
-    test "creates a new shape_id", %{shape_cache_opts: opts} do
-      {shape_id, @zero_offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert is_binary(shape_id)
+    test "creates a new shape_handle", %{shape_cache_opts: opts} do
+      {shape_handle, @zero_offset} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert is_binary(shape_handle)
     end
 
-    test "returns existing shape_id", %{shape_cache_opts: opts} do
-      {shape_id1, @zero_offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      {shape_id2, @zero_offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert shape_id1 == shape_id2
+    test "returns existing shape_handle", %{shape_cache_opts: opts} do
+      {shape_handle1, @zero_offset} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      {shape_handle2, @zero_offset} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert shape_handle1 == shape_handle2
     end
   end
 
-  describe "get_or_create_shape_id/2 shape initialization" do
+  describe "get_or_create_shape_handle/2 shape initialization" do
     setup [
       :with_electric_instance_id,
       :with_in_memory_storage,
@@ -105,18 +105,18 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {shape_id, offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {shape_handle, offset} = ShapeCache.get_or_create_shape_handle(@shape, opts)
       assert offset == @zero_offset
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
       Process.sleep(100)
-      shape_storage = Storage.for_shape(shape_id, storage)
+      shape_storage = Storage.for_shape(shape_handle, storage)
       assert Storage.snapshot_started?(shape_storage)
     end
 
@@ -128,20 +128,20 @@ defmodule Electric.ShapeCacheTest do
           prepare_tables_fn: fn nil, [{{"public", "items"}, nil}] ->
             send(test_pid, {:called, :prepare_tables_fn})
           end,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
             send(test_pid, {:called, :create_snapshot_fn})
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
 
-      # subsequent calls return the same shape_id
-      for _ <- 1..10, do: assert({^shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts))
+      # subsequent calls return the same shape_handle
+      for _ <- 1..10, do: assert({^shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts))
 
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
 
       assert_received {:called, :prepare_tables_fn}
       assert_received {:called, :create_snapshot_fn}
@@ -154,11 +154,11 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
             send(test_pid, {:called, :create_snapshot_fn})
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
@@ -169,34 +169,34 @@ defmodule Electric.ShapeCacheTest do
 
       create_call_1 =
         Task.async(fn ->
-          {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-          shape_id
+          {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+          shape_handle
         end)
 
       create_call_2 =
         Task.async(fn ->
-          {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-          shape_id
+          {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+          shape_handle
         end)
 
-      # resume the genserver and assert both queued tasks return the same shape_id
+      # resume the genserver and assert both queued tasks return the same shape_handle
       :sys.resume(link_pid)
-      shape_id = Task.await(create_call_1)
-      assert shape_id == Task.await(create_call_2)
+      shape_handle = Task.await(create_call_1)
+      assert shape_handle == Task.await(create_call_2)
 
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
 
-      # any queued calls should still return the existing shape_id
+      # any queued calls should still return the existing shape_handle
       # after the snapshot has been created (simulated by directly
       # calling GenServer)
-      assert {^shape_id, _} =
-               GenServer.call(link_pid, {:create_or_wait_shape_id, @shape})
+      assert {^shape_handle, _} =
+               GenServer.call(link_pid, {:create_or_wait_shape_handle, @shape})
 
       assert_received {:called, :create_snapshot_fn}
     end
 
-    test "no-ops and warns if snapshot xmin is assigned to unknown shape_id", ctx do
-      shape_id = "foo"
+    test "no-ops and warns if snapshot xmin is assigned to unknown shape_handle", ctx do
+      shape_handle = "foo"
 
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
@@ -207,19 +207,19 @@ defmodule Electric.ShapeCacheTest do
 
       log =
         capture_log(fn ->
-          GenServer.cast(Process.whereis(opts[:server]), {:snapshot_xmin_known, shape_id, 10})
+          GenServer.cast(Process.whereis(opts[:server]), {:snapshot_xmin_known, shape_handle, 10})
           Process.sleep(10)
         end)
 
       assert log =~
-               "Got snapshot information for a #{shape_id}, that shape id is no longer valid. Ignoring."
+               "Got snapshot information for a #{shape_handle}, that shape id is no longer valid. Ignoring."
 
       # should have nothing in the meta table
       assert :ets.next_lookup(shape_meta_table, :_) == :"$end_of_table"
     end
   end
 
-  describe "get_or_create_shape_id/2 against real db" do
+  describe "get_or_create_shape_handle/2 against real db" do
     setup [
       :with_electric_instance_id,
       :with_in_memory_storage,
@@ -246,9 +246,9 @@ defmodule Electric.ShapeCacheTest do
     end
 
     test "creates initial snapshot from DB data", %{storage: storage, shape_cache_opts: opts} do
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
-      storage = Storage.for_shape(shape_id, storage)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+      storage = Storage.for_shape(shape_handle, storage)
       assert {@zero_offset, stream} = Storage.get_snapshot(storage)
 
       assert [%{"value" => %{"value" => "test1"}}, %{"value" => %{"value" => "test2"}}] =
@@ -309,9 +309,9 @@ defmodule Electric.ShapeCacheTest do
         ]
       )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(shape, opts)
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
-      storage = Storage.for_shape(shape_id, storage)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(shape, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+      storage = Storage.for_shape(shape_handle, storage)
       assert {@zero_offset, stream} = Storage.get_snapshot(storage)
 
       assert [
@@ -331,18 +331,18 @@ defmodule Electric.ShapeCacheTest do
     end
 
     test "updates latest offset correctly", %{shape_cache_opts: opts, storage: storage} do
-      {shape_id, initial_offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      {shape_handle, initial_offset} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
 
-      assert {^shape_id, offset_after_snapshot} =
-               ShapeCache.get_or_create_shape_id(@shape, opts)
+      assert {^shape_handle, offset_after_snapshot} =
+               ShapeCache.get_or_create_shape_handle(@shape, opts)
 
       expected_offset_after_log_entry =
         LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
 
-      :ok = ShapeCache.update_shape_latest_offset(shape_id, expected_offset_after_log_entry, opts)
+      :ok = ShapeCache.update_shape_latest_offset(shape_handle, expected_offset_after_log_entry, opts)
 
-      assert {^shape_id, offset_after_log_entry} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      assert {^shape_handle, offset_after_log_entry} = ShapeCache.get_or_create_shape_handle(@shape, opts)
 
       assert initial_offset == @zero_offset
       assert initial_offset == offset_after_snapshot
@@ -350,35 +350,35 @@ defmodule Electric.ShapeCacheTest do
       assert offset_after_log_entry == expected_offset_after_log_entry
 
       # Stop snapshot process gracefully to prevent errors being logged in the test
-      storage = Storage.for_shape(shape_id, storage)
+      storage = Storage.for_shape(shape_handle, storage)
       {_, stream} = Storage.get_snapshot(storage)
       Stream.run(stream)
     end
 
-    test "errors if appending to untracked shape_id", %{shape_cache_opts: opts} do
-      shape_id = "foo"
+    test "errors if appending to untracked shape_handle", %{shape_cache_opts: opts} do
+      shape_handle = "foo"
       log_offset = LogOffset.new(1000, 0)
 
       {:error, log} =
-        with_log(fn -> ShapeCache.update_shape_latest_offset(shape_id, log_offset, opts) end)
+        with_log(fn -> ShapeCache.update_shape_latest_offset(shape_handle, log_offset, opts) end)
 
-      assert log =~ "Tried to update latest offset for shape #{shape_id} which doesn't exist"
+      assert log =~ "Tried to update latest offset for shape #{shape_handle} which doesn't exist"
     end
 
     test "correctly propagates the error", %{shape_cache_opts: opts} do
       shape = %Shape{root_table: {"public", "nonexistent"}}
 
-      {shape_id, log} =
+      {shape_handle, log} =
         with_log(fn ->
-          {shape_id, _} = ShapeCache.get_or_create_shape_id(shape, opts)
+          {shape_handle, _} = ShapeCache.get_or_create_shape_handle(shape, opts)
 
           assert {:error, %Postgrex.Error{postgres: %{code: :undefined_table}}} =
-                   ShapeCache.await_snapshot_start(shape_id, opts)
+                   ShapeCache.await_snapshot_start(shape_handle, opts)
 
-          shape_id
+          shape_handle
         end)
 
-      log =~ "Snapshot creation failed for #{shape_id}"
+      log =~ "Snapshot creation failed for #{shape_handle}"
 
       log =~
         ~S|** (Postgrex.Error) ERROR 42P01 (undefined_table) relation "public.nonexistent" does not exist|
@@ -410,18 +410,18 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
       meta_table = Keyword.fetch!(opts, :shape_meta_table)
-      assert [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
-      assert {:ok, 10} = ShapeStatus.snapshot_xmin(meta_table, shape_id)
+      assert [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
+      assert {:ok, 10} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
     end
 
     test "lists the shape even if we don't know xmin", ctx do
@@ -430,28 +430,28 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
 
       # Wait until we get to the waiting point in the snapshot
       assert_receive {:waiting_point, ref, pid}
 
       meta_table = Keyword.fetch!(opts, :shape_meta_table)
-      assert [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
+      assert [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
 
       send(pid, {:continue, ref})
 
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
-      assert [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+      assert [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
     end
   end
 
@@ -469,30 +469,30 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 100})
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+          create_snapshot_fn: fn parent, shape_handle, _, _, _ ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
       refute ShapeCache.has_shape?("some-random-id", opts)
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert ShapeCache.has_shape?(shape_id, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert ShapeCache.has_shape?(shape_handle, opts)
     end
 
     test "works with slow snapshot generation", ctx do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _, _, _ ->
+          create_snapshot_fn: fn parent, shape_handle, _, _, _ ->
             Process.sleep(100)
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 100})
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert ShapeCache.has_shape?(shape_id, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert ShapeCache.has_shape?(shape_handle, opts)
     end
   end
 
@@ -510,33 +510,33 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 100})
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+          create_snapshot_fn: fn parent, shape_handle, _, _, _ ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
 
-      assert ShapeCache.await_snapshot_start(shape_id, opts) == :started
+      assert ShapeCache.await_snapshot_start(shape_handle, opts) == :started
     end
 
     test "returns an error if waiting is for an unknown shape id", ctx do
-      shape_id = "orphaned_id"
+      shape_handle = "orphaned_id"
 
-      storage = Storage.for_shape(shape_id, ctx.storage)
+      storage = Storage.for_shape(shape_handle, ctx.storage)
 
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      assert {:error, :unknown} = ShapeCache.await_snapshot_start(shape_id, opts)
+      assert {:error, :unknown} = ShapeCache.await_snapshot_start(shape_handle, opts)
 
       refute Storage.snapshot_started?(storage)
     end
@@ -547,28 +547,28 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
 
             # Sometimes only some tasks subscribe before reaching this point, and then hang
             # if we don't actually have a snapshot. This is kind of part of the test, because
             # `await_snapshot_start/3` should always resolve to `:started` in concurrent situations
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
             Storage.make_new_snapshot!([[1], [2]], storage)
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
 
-      storage = Storage.for_shape(shape_id, ctx.storage)
+      storage = Storage.for_shape(shape_handle, ctx.storage)
 
       tasks =
         for _id <- 1..10 do
           Task.async(fn ->
-            assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
+            assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
             {_, stream} = Storage.get_snapshot(storage)
             assert Enum.count(stream) == 2
           end)
@@ -595,22 +595,22 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
 
             Storage.make_new_snapshot!(stream_from_database, storage)
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
 
-      storage = Storage.for_shape(shape_id, ctx.storage)
+      storage = Storage.for_shape(shape_handle, ctx.storage)
 
       tasks =
         for _ <- 1..10 do
           Task.async(fn ->
-            :started = ShapeCache.await_snapshot_start(shape_id, opts)
+            :started = ShapeCache.await_snapshot_start(shape_handle, opts)
             {_, stream} = Storage.get_snapshot(storage)
 
             assert_raise RuntimeError, fn -> Stream.run(stream) end
@@ -626,21 +626,21 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, _storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, _storage ->
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
 
             GenServer.cast(
               parent,
-              {:snapshot_failed, shape_id, %RuntimeError{message: "expected error"}, []}
+              {:snapshot_failed, shape_handle, %RuntimeError{message: "expected error"}, []}
             )
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      task = Task.async(fn -> ShapeCache.await_snapshot_start(shape_id, opts) end)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      task = Task.async(fn -> ShapeCache.await_snapshot_start(shape_handle, opts) end)
 
       log =
         capture_log(fn ->
@@ -651,7 +651,7 @@ defmodule Electric.ShapeCacheTest do
                    Task.await(task)
         end)
 
-      assert log =~ "Snapshot creation failed for #{shape_id}"
+      assert log =~ "Snapshot creation failed for #{shape_handle}"
     end
   end
 
@@ -669,18 +669,18 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
       Process.sleep(50)
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
 
-      storage = Storage.for_shape(shape_id, ctx.storage)
+      storage = Storage.for_shape(shape_handle, ctx.storage)
 
       Storage.append_to_log!(
         changes_to_log_items([
@@ -696,9 +696,9 @@ defmodule Electric.ShapeCacheTest do
       assert Storage.snapshot_started?(storage)
       assert Enum.count(Storage.get_log_stream(@zero_offset, storage)) == 1
 
-      ref = ctx.electric_instance_id |> Shapes.Consumer.whereis(shape_id) |> Process.monitor()
+      ref = ctx.electric_instance_id |> Shapes.Consumer.whereis(shape_handle) |> Process.monitor()
 
-      log = capture_log(fn -> ShapeCache.handle_truncate(shape_id, opts) end)
+      log = capture_log(fn -> ShapeCache.handle_truncate(shape_handle, opts) end)
       assert log =~ "Truncating and rotating shape id"
 
       assert_receive {:DOWN, ^ref, :process, _pid, _}
@@ -722,18 +722,18 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
       Process.sleep(50)
-      assert :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
 
-      storage = Storage.for_shape(shape_id, ctx.storage)
+      storage = Storage.for_shape(shape_handle, ctx.storage)
 
       Storage.append_to_log!(
         changes_to_log_items([
@@ -752,9 +752,9 @@ defmodule Electric.ShapeCacheTest do
       {module, _} = storage
 
       ref =
-        Process.monitor(module.name(ctx.electric_instance_id, shape_id) |> GenServer.whereis())
+        Process.monitor(module.name(ctx.electric_instance_id, shape_handle) |> GenServer.whereis())
 
-      log = capture_log(fn -> :ok = ShapeCache.clean_shape(shape_id, opts) end)
+      log = capture_log(fn -> :ok = ShapeCache.clean_shape(shape_handle, opts) end)
       assert log =~ "Cleaning up shape"
 
       assert_receive {:DOWN, ^ref, :process, _pid, _reason}
@@ -767,24 +767,24 @@ defmodule Electric.ShapeCacheTest do
                    ~r"Snapshot no longer available",
                    fn -> Storage.get_snapshot(storage) end
 
-      {shape_id2, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert shape_id != shape_id2
+      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert shape_handle != shape_handle2
     end
 
     test "cleans up shape swallows error if no shape to clean up", ctx do
-      shape_id = "foo"
+      shape_handle = "foo"
 
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
-      {:ok, _} = with_log(fn -> ShapeCache.clean_shape(shape_id, opts) end)
+      {:ok, _} = with_log(fn -> ShapeCache.clean_shape(shape_handle, opts) end)
     end
   end
 
@@ -817,42 +817,42 @@ defmodule Electric.ShapeCacheTest do
       do:
         with_shape_cache(Map.put(ctx, :inspector, @stub_inspector),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, @snapshot_xmin})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
     )
 
-    test "restores shape_ids", %{shape_cache_opts: opts} = context do
-      {shape_id1, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      :started = ShapeCache.await_snapshot_start(shape_id1, opts)
+    test "restores shape_handles", %{shape_cache_opts: opts} = context do
+      {shape_handle1, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      :started = ShapeCache.await_snapshot_start(shape_handle1, opts)
       restart_shape_cache(context)
-      {shape_id2, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      assert shape_id1 == shape_id2
+      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert shape_handle1 == shape_handle2
     end
 
     test "restores snapshot xmins", %{shape_cache_opts: opts} = context do
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      :started = ShapeCache.await_snapshot_start(shape_handle, opts)
       meta_table = Keyword.fetch!(opts, :shape_meta_table)
-      [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
-      {:ok, @snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_id)
+      [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
+      {:ok, @snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
 
       restart_shape_cache(context)
-      :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      :started = ShapeCache.await_snapshot_start(shape_handle, opts)
 
-      assert [{^shape_id, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
-      {:ok, @snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_id)
+      assert [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
+      {:ok, @snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
     end
 
     test "restores latest offset", %{shape_cache_opts: opts} = context do
       offset = @change_offset
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape, opts)
-      :started = ShapeCache.await_snapshot_start(shape_id, opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      :started = ShapeCache.await_snapshot_start(shape_handle, opts)
 
-      ref = Shapes.Consumer.monitor(context.electric_instance_id, shape_id)
+      ref = Shapes.Consumer.monitor(context.electric_instance_id, shape_handle)
 
       ShapeLogCollector.store_transaction(
         %Changes.Transaction{
@@ -867,7 +867,7 @@ defmodule Electric.ShapeCacheTest do
 
       assert_receive {Shapes.Consumer, ^ref, @xid}
 
-      {^shape_id, ^offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      {^shape_handle, ^offset} = ShapeCache.get_or_create_shape_handle(@shape, opts)
 
       # without this sleep, this test becomes unreliable. I think maybe due to
       # delays in actually writing the data to cubdb/fsyncing the tx. I've
@@ -877,8 +877,8 @@ defmodule Electric.ShapeCacheTest do
 
       restart_shape_cache(context)
 
-      :started = ShapeCache.await_snapshot_start(shape_id, opts)
-      assert {^shape_id, ^offset} = ShapeCache.get_or_create_shape_id(@shape, opts)
+      :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+      assert {^shape_handle, ^offset} = ShapeCache.get_or_create_shape_handle(@shape, opts)
     end
 
     test "restores relations", ctx do
@@ -913,10 +913,10 @@ defmodule Electric.ShapeCacheTest do
 
       with_shape_cache(Map.put(context, :inspector, @stub_inspector),
         prepare_tables_fn: @prepare_tables_noop,
-        create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-          GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})
+        create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, @snapshot_xmin})
           Storage.make_new_snapshot!([["test"]], storage)
-          GenServer.cast(parent, {:snapshot_started, shape_id})
+          GenServer.cast(parent, {:snapshot_started, shape_handle})
         end
       )
     end
@@ -925,8 +925,8 @@ defmodule Electric.ShapeCacheTest do
       %{shape_cache: {shape_cache, shape_cache_opts}} = ctx
 
       consumers =
-        for {shape_id, _} <- shape_cache.list_shapes(Map.new(shape_cache_opts)) do
-          pid = Shapes.Consumer.whereis(ctx.electric_instance_id, shape_id)
+        for {shape_handle, _} <- shape_cache.list_shapes(Map.new(shape_cache_opts)) do
+          pid = Shapes.Consumer.whereis(ctx.electric_instance_id, shape_handle)
           {pid, Process.monitor(pid)}
         end
 
@@ -979,18 +979,18 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(
           Map.merge(ctx, %{inspector: {Mock.Inspector, []}}),
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, @snapshot_xmin})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
       ctx
     end
 
-    defp monitor_consumer(electric_instance_id, shape_id) do
-      electric_instance_id |> Shapes.Consumer.whereis(shape_id) |> Process.monitor()
+    defp monitor_consumer(electric_instance_id, shape_handle) do
+      electric_instance_id |> Shapes.Consumer.whereis(shape_handle) |> Process.monitor()
     end
 
     defp shapes do
@@ -1019,22 +1019,22 @@ defmodule Electric.ShapeCacheTest do
          }) do
       [shape1, shape2, shape3] = shapes()
 
-      {shape_id1, _} = shape_cache.get_or_create_shape_id(shape1, opts)
-      {shape_id2, _} = shape_cache.get_or_create_shape_id(shape2, opts)
-      {shape_id3, _} = shape_cache.get_or_create_shape_id(shape3, opts)
+      {shape_handle1, _} = shape_cache.get_or_create_shape_handle(shape1, opts)
+      {shape_handle2, _} = shape_cache.get_or_create_shape_handle(shape2, opts)
+      {shape_handle3, _} = shape_cache.get_or_create_shape_handle(shape3, opts)
 
-      :started = shape_cache.await_snapshot_start(shape_id1, opts)
-      :started = shape_cache.await_snapshot_start(shape_id2, opts)
-      :started = shape_cache.await_snapshot_start(shape_id3, opts)
+      :started = shape_cache.await_snapshot_start(shape_handle1, opts)
+      :started = shape_cache.await_snapshot_start(shape_handle2, opts)
+      :started = shape_cache.await_snapshot_start(shape_handle3, opts)
 
-      ref1 = monitor_consumer(electric_instance_id, shape_id1)
-      ref2 = monitor_consumer(electric_instance_id, shape_id2)
-      ref3 = monitor_consumer(electric_instance_id, shape_id3)
+      ref1 = monitor_consumer(electric_instance_id, shape_handle1)
+      ref2 = monitor_consumer(electric_instance_id, shape_handle2)
+      ref3 = monitor_consumer(electric_instance_id, shape_handle3)
 
       [
-        {shape_id1, ref1},
-        {shape_id2, ref2},
-        {shape_id3, ref3}
+        {shape_handle1, ref1},
+        {shape_handle2, ref2},
+        {shape_handle3, ref3}
       ]
     end
 
@@ -1069,9 +1069,9 @@ defmodule Electric.ShapeCacheTest do
           inspector: StubInspector.new([%{name: "id", type: :int8}])
         )
 
-      {shape_id, _} = shape_cache.get_or_create_shape_id(shape, opts)
+      {shape_handle, _} = shape_cache.get_or_create_shape_handle(shape, opts)
 
-      ref = monitor_consumer(ctx.electric_instance_id, shape_id)
+      ref = monitor_consumer(ctx.electric_instance_id, shape_handle)
 
       rel = %Relation{
         id: relation_id,
@@ -1101,9 +1101,9 @@ defmodule Electric.ShapeCacheTest do
       relation_id = "rel1"
 
       [
-        {_shape_id1, _ref1},
-        {_shape_id2, _ref2},
-        {_shape_id3, _ref3}
+        {_shape_handle1, _ref1},
+        {_shape_handle2, _ref2},
+        {_shape_handle3, _ref3}
       ] = start_shapes(ctx)
 
       rel = %Relation{
@@ -1126,9 +1126,9 @@ defmodule Electric.ShapeCacheTest do
       relation_id = "rel1"
 
       [
-        {_shape_id1, ref1},
-        {_shape_id2, ref2},
-        {_shape_id3, ref3}
+        {_shape_handle1, ref1},
+        {_shape_handle2, ref2},
+        {_shape_handle3, ref3}
       ] = start_shapes(ctx)
 
       old_rel = %Relation{
@@ -1172,9 +1172,9 @@ defmodule Electric.ShapeCacheTest do
       relation_id = "rel1"
 
       [
-        {_shape_id1, ref1},
-        {_shape_id2, ref2},
-        {_shape_id3, ref3}
+        {_shape_handle1, ref1},
+        {_shape_handle2, ref2},
+        {_shape_handle3, ref3}
       ] = start_shapes(ctx)
 
       old_rel = %Relation{

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -21,22 +21,22 @@ defmodule Electric.Shapes.ConsumerTest do
 
   import Mox
 
-  @shape_id1 "#{__MODULE__}-shape1"
+  @shape_handle1 "#{__MODULE__}-shape1"
   @shape1 Shape.new!("public.test_table",
             inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
           )
 
-  @shape_id2 "#{__MODULE__}-shape2"
+  @shape_handle2 "#{__MODULE__}-shape2"
   @shape2 Shape.new!("public.other_table",
             inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
           )
 
   @shape_position %{
-    @shape_id1 => %{
+    @shape_handle1 => %{
       latest_offset: LogOffset.new(Lsn.from_string("0/10"), 0),
       snapshot_xmin: 100
     },
-    @shape_id2 => %{
+    @shape_handle2 => %{
       latest_offset: LogOffset.new(Lsn.from_string("0/50"), 0),
       snapshot_xmin: 120
     }
@@ -52,22 +52,22 @@ defmodule Electric.Shapes.ConsumerTest do
   setup :set_mox_from_context
   setup :verify_on_exit!
 
-  defp shape_status(shape_id, ctx) do
-    get_in(ctx, [:shape_position, shape_id]) || raise "invalid shape_id #{shape_id}"
+  defp shape_status(shape_handle, ctx) do
+    get_in(ctx, [:shape_position, shape_handle]) || raise "invalid shape_handle #{shape_handle}"
   end
 
-  defp log_offset(shape_id, ctx) do
-    get_in(ctx, [:shape_position, shape_id, :latest_offset]) ||
-      raise "invalid shape_id #{shape_id}"
+  defp log_offset(shape_handle, ctx) do
+    get_in(ctx, [:shape_position, shape_handle, :latest_offset]) ||
+      raise "invalid shape_handle #{shape_handle}"
   end
 
-  defp snapshot_xmin(shape_id, ctx) do
-    get_in(ctx, [:shape_position, shape_id, :snapshot_xmin]) ||
-      raise "invalid shape_id #{shape_id}"
+  defp snapshot_xmin(shape_handle, ctx) do
+    get_in(ctx, [:shape_position, shape_handle, :snapshot_xmin]) ||
+      raise "invalid shape_handle #{shape_handle}"
   end
 
-  defp lsn(shape_id, ctx) do
-    %{tx_offset: offset} = log_offset(shape_id, ctx)
+  defp lsn(shape_handle, ctx) do
+    %{tx_offset: offset} = log_offset(shape_handle, ctx)
     Lsn.from_integer(offset)
   end
 
@@ -77,7 +77,7 @@ defmodule Electric.Shapes.ConsumerTest do
     setup :with_in_memory_storage
 
     setup(ctx) do
-      shapes = Map.get(ctx, :shapes, %{@shape_id1 => @shape1, @shape_id2 => @shape2})
+      shapes = Map.get(ctx, :shapes, %{@shape_handle1 => @shape1, @shape_handle2 => @shape2})
       shape_position = Map.get(ctx, :shape_position, @shape_position)
       [shape_position: shape_position, shapes: shapes]
     end
@@ -86,16 +86,16 @@ defmodule Electric.Shapes.ConsumerTest do
       registry_name = Module.concat(__MODULE__, Registry)
       start_link_supervised!({Registry, keys: :duplicate, name: registry_name})
 
-      %{latest_offset: _offset1, snapshot_xmin: xmin1} = shape_status(@shape_id1, ctx)
-      %{latest_offset: _offset2, snapshot_xmin: xmin2} = shape_status(@shape_id2, ctx)
+      %{latest_offset: _offset1, snapshot_xmin: xmin1} = shape_status(@shape_handle1, ctx)
+      %{latest_offset: _offset2, snapshot_xmin: xmin2} = shape_status(@shape_handle2, ctx)
 
       storage =
         Support.TestStorage.wrap(ctx.storage, %{
-          @shape_id1 => [
+          @shape_handle1 => [
             {:mark_snapshot_as_started, []},
             {:set_snapshot_xmin, [xmin1]}
           ],
-          @shape_id2 => [
+          @shape_handle2 => [
             {:mark_snapshot_as_started, []},
             {:set_snapshot_xmin, [xmin2]}
           ]
@@ -115,15 +115,15 @@ defmodule Electric.Shapes.ConsumerTest do
       |> stub(:cast, fn _msg, _ -> :ok end)
 
       consumers =
-        for {shape_id, shape} <- ctx.shapes do
+        for {shape_handle, shape} <- ctx.shapes do
           allow(Mock.ShapeCache, self(), fn ->
-            Shapes.Consumer.whereis(ctx.electric_instance_id, shape_id)
+            Shapes.Consumer.whereis(ctx.electric_instance_id, shape_handle)
           end)
 
           {:ok, consumer} =
             start_supervised(
               {Shapes.Consumer.Supervisor,
-               shape_id: shape_id,
+               shape_handle: shape_handle,
                shape: shape,
                electric_instance_id: ctx.electric_instance_id,
                log_producer: ShapeLogCollector.name(ctx.electric_instance_id),
@@ -133,7 +133,7 @@ defmodule Electric.Shapes.ConsumerTest do
                chunk_bytes_threshold:
                  Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
                prepare_tables_fn: &prepare_tables_fn/2},
-              id: {Shapes.Consumer.Supervisor, shape_id}
+              id: {Shapes.Consumer.Supervisor, shape_handle}
             )
 
           consumer
@@ -148,16 +148,16 @@ defmodule Electric.Shapes.ConsumerTest do
 
     test "appends to log when xid >= xmin", ctx do
       xid = 150
-      xmin = snapshot_xmin(@shape_id1, ctx)
-      last_log_offset = log_offset(@shape_id1, ctx)
-      lsn = lsn(@shape_id1, ctx)
+      xmin = snapshot_xmin(@shape_handle1, ctx)
+      last_log_offset = log_offset(@shape_handle1, ctx)
+      lsn = lsn(@shape_handle1, ctx)
 
       Mock.ShapeCache
-      |> expect(:update_shape_latest_offset, 2, fn @shape_id1, ^last_log_offset, _ -> :ok end)
+      |> expect(:update_shape_latest_offset, 2, fn @shape_handle1, ^last_log_offset, _ -> :ok end)
 
       ref = make_ref()
 
-      Registry.register(ctx.registry, @shape_id1, ref)
+      Registry.register(ctx.registry, @shape_handle1, ref)
 
       txn =
         %Transaction{xid: xmin, lsn: lsn, last_log_offset: last_log_offset}
@@ -169,36 +169,36 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
       assert_receive {^ref, :new_changes, ^last_log_offset}, 1000
-      assert_receive {Support.TestStorage, :append_to_log!, @shape_id1, _}
-      refute_receive {Support.TestStorage, :append_to_log!, @shape_id2, _}
+      assert_receive {Support.TestStorage, :append_to_log!, @shape_handle1, _}
+      refute_receive {Support.TestStorage, :append_to_log!, @shape_handle2, _}
 
       txn2 = %{txn | xid: xid}
 
       assert :ok = ShapeLogCollector.store_transaction(txn2, ctx.producer)
       assert_receive {^ref, :new_changes, ^last_log_offset}, 1000
-      assert_receive {Support.TestStorage, :append_to_log!, @shape_id1, _}
-      refute_receive {Support.TestStorage, :append_to_log!, @shape_id2, _}
+      assert_receive {Support.TestStorage, :append_to_log!, @shape_handle1, _}
+      refute_receive {Support.TestStorage, :append_to_log!, @shape_handle2, _}
     end
 
     test "correctly writes only relevant changes to multiple shape logs", ctx do
-      last_log_offset = log_offset(@shape_id1, ctx)
-      lsn = lsn(@shape_id1, ctx)
+      last_log_offset = log_offset(@shape_handle1, ctx)
+      lsn = lsn(@shape_handle1, ctx)
 
       xid = 150
 
       Mock.ShapeCache
       |> expect(:update_shape_latest_offset, 2, fn
-        @shape_id1, ^last_log_offset, _ -> :ok
-        @shape_id2, ^last_log_offset, _ -> :ok
+        @shape_handle1, ^last_log_offset, _ -> :ok
+        @shape_handle2, ^last_log_offset, _ -> :ok
       end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id1))
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id2))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_handle1))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_handle2))
 
       ref1 = make_ref()
       ref2 = make_ref()
 
-      Registry.register(ctx.registry, @shape_id1, ref1)
-      Registry.register(ctx.registry, @shape_id2, ref2)
+      Registry.register(ctx.registry, @shape_handle1, ref1)
+      Registry.register(ctx.registry, @shape_handle2, ref2)
 
       txn =
         %Transaction{xid: xid, lsn: lsn, last_log_offset: last_log_offset}
@@ -223,21 +223,21 @@ defmodule Electric.Shapes.ConsumerTest do
       assert_receive {^ref1, :new_changes, ^last_log_offset}, 1000
       assert_receive {^ref2, :new_changes, ^last_log_offset}, 1000
 
-      assert_receive {Support.TestStorage, :append_to_log!, @shape_id1,
+      assert_receive {Support.TestStorage, :append_to_log!, @shape_handle1,
                       [{_offset, serialized_record}]}
 
       assert %{"value" => %{"id" => "1"}} = Jason.decode!(serialized_record)
 
-      assert_receive {Support.TestStorage, :append_to_log!, @shape_id2,
+      assert_receive {Support.TestStorage, :append_to_log!, @shape_handle2,
                       [{_offset, serialized_record}]}
 
       assert %{"value" => %{"id" => "2"}} = Jason.decode!(serialized_record)
     end
 
     @tag shapes: %{
-           @shape_id1 =>
+           @shape_handle1 =>
              Shape.new!("public.test_table", where: "id != 1", inspector: {Mock.Inspector, []}),
-           @shape_id2 =>
+           @shape_handle2 =>
              Shape.new!("public.test_table", where: "id = 1", inspector: {Mock.Inspector, []})
          }
     test "doesn't append to log when change is irrelevant for active shapes", ctx do
@@ -245,12 +245,12 @@ defmodule Electric.Shapes.ConsumerTest do
       lsn = Lsn.from_string("0/10")
       last_log_offset = LogOffset.new(lsn, 0)
 
-      ref1 = Shapes.Consumer.monitor(ctx.electric_instance_id, @shape_id1)
-      ref2 = Shapes.Consumer.monitor(ctx.electric_instance_id, @shape_id2)
+      ref1 = Shapes.Consumer.monitor(ctx.electric_instance_id, @shape_handle1)
+      ref2 = Shapes.Consumer.monitor(ctx.electric_instance_id, @shape_handle2)
 
       Mock.ShapeCache
-      |> expect(:update_shape_latest_offset, fn @shape_id2, _offset, _ -> :ok end)
-      |> allow(self(), Shapes.Consumer.name(ctx.electric_instance_id, @shape_id2))
+      |> expect(:update_shape_latest_offset, fn @shape_handle2, _offset, _ -> :ok end)
+      |> allow(self(), Shapes.Consumer.name(ctx.electric_instance_id, @shape_handle2))
 
       txn =
         %Transaction{xid: xid, lsn: lsn, last_log_offset: last_log_offset}
@@ -262,8 +262,8 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
 
-      assert_receive {Support.TestStorage, :append_to_log!, @shape_id2, _}
-      refute_receive {Support.TestStorage, :append_to_log!, @shape_id1, _}
+      assert_receive {Support.TestStorage, :append_to_log!, @shape_handle2, _}
+      refute_receive {Support.TestStorage, :append_to_log!, @shape_handle1, _}
 
       refute_receive {Shapes.Consumer, ^ref1, 150}
       assert_receive {Shapes.Consumer, ^ref2, 150}
@@ -275,8 +275,8 @@ defmodule Electric.Shapes.ConsumerTest do
       last_log_offset = LogOffset.new(lsn, 0)
 
       Mock.ShapeCache
-      |> expect(:handle_truncate, fn @shape_id1, _ -> :ok end)
-      |> allow(self(), Shapes.Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> expect(:handle_truncate, fn @shape_handle1, _ -> :ok end)
+      |> allow(self(), Shapes.Consumer.name(ctx.electric_instance_id, @shape_handle1))
 
       txn =
         %Transaction{xid: xid, lsn: lsn, last_log_offset: last_log_offset}
@@ -284,20 +284,20 @@ defmodule Electric.Shapes.ConsumerTest do
           relation: {"public", "test_table"}
         })
 
-      assert_consumer_shutdown(ctx.electric_instance_id, @shape_id1, fn ->
+      assert_consumer_shutdown(ctx.electric_instance_id, @shape_handle1, fn ->
         assert :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
       end)
 
-      assert_receive {Support.TestStorage, :cleanup!, @shape_id1}
-      refute_receive {Support.TestStorage, :cleanup!, @shape_id2}
+      assert_receive {Support.TestStorage, :cleanup!, @shape_handle1}
+      refute_receive {Support.TestStorage, :cleanup!, @shape_handle2}
     end
 
-    defp assert_consumer_shutdown(electric_instance_id, shape_id, fun) do
+    defp assert_consumer_shutdown(electric_instance_id, shape_handle, fun) do
       monitors =
         for name <- [
-              Shapes.Consumer.Supervisor.name(electric_instance_id, shape_id),
-              Shapes.Consumer.name(electric_instance_id, shape_id),
-              Shapes.Consumer.Snapshotter.name(electric_instance_id, shape_id)
+              Shapes.Consumer.Supervisor.name(electric_instance_id, shape_handle),
+              Shapes.Consumer.name(electric_instance_id, shape_handle),
+              Shapes.Consumer.Snapshotter.name(electric_instance_id, shape_handle)
             ],
             pid = GenServer.whereis(name) do
           ref = Process.monitor(pid)
@@ -313,7 +313,7 @@ defmodule Electric.Shapes.ConsumerTest do
     end
 
     @tag shapes: %{
-           @shape_id1 =>
+           @shape_handle1 =>
              Shape.new!("test_table",
                where: "id LIKE 'test'",
                inspector: StubInspector.new([%{pk_position: 0, name: "id"}])
@@ -325,8 +325,8 @@ defmodule Electric.Shapes.ConsumerTest do
       last_log_offset = LogOffset.new(lsn, 0)
 
       Mock.ShapeCache
-      |> expect(:handle_truncate, fn @shape_id1, _ -> :ok end)
-      |> allow(self(), Shapes.Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> expect(:handle_truncate, fn @shape_handle1, _ -> :ok end)
+      |> allow(self(), Shapes.Consumer.name(ctx.electric_instance_id, @shape_handle1))
 
       txn =
         %Transaction{xid: xid, lsn: lsn, last_log_offset: last_log_offset}
@@ -334,13 +334,13 @@ defmodule Electric.Shapes.ConsumerTest do
           relation: {"public", "test_table"}
         })
 
-      assert_consumer_shutdown(ctx.electric_instance_id, @shape_id1, fn ->
+      assert_consumer_shutdown(ctx.electric_instance_id, @shape_handle1, fn ->
         assert :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
       end)
 
-      refute_receive {Support.TestStorage, :append_to_log!, @shape_id1, _}
-      assert_receive {Support.TestStorage, :cleanup!, @shape_id1}
-      refute_receive {Support.TestStorage, :cleanup!, @shape_id2}
+      refute_receive {Support.TestStorage, :append_to_log!, @shape_handle1, _}
+      assert_receive {Support.TestStorage, :cleanup!, @shape_handle1}
+      refute_receive {Support.TestStorage, :cleanup!, @shape_handle2}
     end
 
     test "notifies listeners of new changes", ctx do
@@ -349,11 +349,11 @@ defmodule Electric.Shapes.ConsumerTest do
       last_log_offset = LogOffset.new(lsn, 0)
 
       Mock.ShapeCache
-      |> expect(:update_shape_latest_offset, fn @shape_id1, ^last_log_offset, _ -> :ok end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> expect(:update_shape_latest_offset, fn @shape_handle1, ^last_log_offset, _ -> :ok end)
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_handle1))
 
       ref = make_ref()
-      Registry.register(ctx.registry, @shape_id1, ref)
+      Registry.register(ctx.registry, @shape_handle1, ref)
 
       txn =
         %Transaction{xid: xid, lsn: lsn, last_log_offset: last_log_offset}
@@ -364,7 +364,7 @@ defmodule Electric.Shapes.ConsumerTest do
         })
 
       assert :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
-      assert_receive {Support.TestStorage, :append_to_log!, @shape_id1, _}
+      assert_receive {Support.TestStorage, :append_to_log!, @shape_handle1, _}
       assert_receive {^ref, :new_changes, ^last_log_offset}, 1000
     end
   end
@@ -393,11 +393,11 @@ defmodule Electric.Shapes.ConsumerTest do
           }),
           log_producer: ctx.shape_log_collector,
           prepare_tables_fn: fn _, _ -> :ok end,
-          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
             if is_integer(snapshot_delay), do: Process.sleep(snapshot_delay)
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 10})
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
 
@@ -413,17 +413,17 @@ defmodule Electric.Shapes.ConsumerTest do
         shape_cache_opts: shape_cache_opts
       } = ctx
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape1, shape_cache_opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, shape_cache_opts)
 
       :started =
         ShapeCache.await_snapshot_start(
-          shape_id,
+          shape_handle,
           shape_cache_opts
         )
 
       lsn = Lsn.from_integer(10)
 
-      ref = Shapes.Consumer.monitor(ctx.electric_instance_id, shape_id)
+      ref = Shapes.Consumer.monitor(ctx.electric_instance_id, shape_handle)
 
       txn =
         %Transaction{xid: 11, lsn: lsn, last_log_offset: LogOffset.new(lsn, 2)}
@@ -442,7 +442,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert_receive {Shapes.Consumer, ^ref, 11}
 
-      shape_storage = Storage.for_shape(shape_id, storage)
+      shape_storage = Storage.for_shape(shape_handle, storage)
 
       assert [op1, op2] =
                Storage.get_log_stream(LogOffset.before_all(), shape_storage)
@@ -465,12 +465,12 @@ defmodule Electric.Shapes.ConsumerTest do
         shape_cache_opts: shape_cache_opts
       } = ctx
 
-      {shape_id, _} = ShapeCache.get_or_create_shape_id(@shape1, shape_cache_opts)
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, shape_cache_opts)
 
       lsn1 = Lsn.from_integer(9)
       lsn2 = Lsn.from_integer(10)
 
-      ref = Shapes.Consumer.monitor(ctx.electric_instance_id, shape_id)
+      ref = Shapes.Consumer.monitor(ctx.electric_instance_id, shape_handle)
 
       txn1 =
         %Transaction{xid: 9, lsn: lsn1, last_log_offset: LogOffset.new(lsn1, 2)}
@@ -501,11 +501,11 @@ defmodule Electric.Shapes.ConsumerTest do
       assert :ok = ShapeLogCollector.store_transaction(txn1, ctx.producer)
       assert :ok = ShapeLogCollector.store_transaction(txn2, ctx.producer)
 
-      :started = ShapeCache.await_snapshot_start(shape_id, shape_cache_opts)
+      :started = ShapeCache.await_snapshot_start(shape_handle, shape_cache_opts)
 
       assert_receive {Shapes.Consumer, ^ref, 10}
 
-      shape_storage = Storage.for_shape(shape_id, storage)
+      shape_storage = Storage.for_shape(shape_handle, storage)
 
       assert [_op1, _op2] =
                Storage.get_log_stream(LogOffset.before_all(), shape_storage)
@@ -522,45 +522,45 @@ defmodule Electric.Shapes.ConsumerTest do
       GenServer.start_link(__MODULE__, [], name: __MODULE__)
     end
 
-    def crash_once(pid, shape_id) do
-      GenServer.call(pid, {:crash_once, shape_id})
+    def crash_once(pid, shape_handle) do
+      GenServer.call(pid, {:crash_once, shape_handle})
     end
 
-    def crash?(pid, shape_id) do
-      GenServer.call(pid, {:crash?, shape_id})
+    def crash?(pid, shape_handle) do
+      GenServer.call(pid, {:crash?, shape_handle})
     end
 
     def init(_opts) do
       {:ok, %{shapes: %{}, crashing: %{}}}
     end
 
-    def handle_call({:crash_once, shape_id}, _from, state) do
-      {:reply, :ok, Map.update!(state, :crashing, &Map.put(&1, shape_id, true))}
+    def handle_call({:crash_once, shape_handle}, _from, state) do
+      {:reply, :ok, Map.update!(state, :crashing, &Map.put(&1, shape_handle, true))}
     end
 
-    def handle_call({:crash?, shape_id}, _from, state) do
-      {crash?, crashing} = Map.pop(state.crashing, shape_id, false)
+    def handle_call({:crash?, shape_handle}, _from, state) do
+      {crash?, crashing} = Map.pop(state.crashing, shape_handle, false)
 
       {:reply, crash?, %{state | crashing: crashing}}
     end
 
-    def handle_call({:get_current_position, shape_id}, _from, state) do
+    def handle_call({:get_current_position, shape_handle}, _from, state) do
       %{latest_offset: offset, snapshot_xmin: xmin} =
-        Map.get(state.shapes, shape_id, %{latest_offset: LogOffset.first(), snapshot_xmin: nil})
+        Map.get(state.shapes, shape_handle, %{latest_offset: LogOffset.first(), snapshot_xmin: nil})
 
       {:reply, {:ok, offset, xmin}, state}
     end
 
-    def handle_call({:snapshot_started?, shape_id}, _from, state) do
-      {:reply, Map.has_key?(state.shapes, shape_id), state}
+    def handle_call({:snapshot_started?, shape_handle}, _from, state) do
+      {:reply, Map.has_key?(state.shapes, shape_handle), state}
     end
 
-    def handle_call({:set_snapshot_xmin, shape_id, xmin}, _from, state) do
+    def handle_call({:set_snapshot_xmin, shape_handle, xmin}, _from, state) do
       {:reply, :ok,
        %{
          state
          | shapes:
-             Map.put(state.shapes, shape_id, %{
+             Map.put(state.shapes, shape_handle, %{
                snapshot_xmin: xmin,
                latest_offset: LogOffset.first()
              })
@@ -572,15 +572,15 @@ defmodule Electric.Shapes.ConsumerTest do
     # Between this module and the CrashingStorageBackend above, implement
     # enough of the storage api to:
     #
-    # 1. Only snapshot a given shape_id once
+    # 1. Only snapshot a given shape_handle once
     # 2. Allow for writing to the tx log of a given shape to crash
 
     def start_link(%{} = _opts) do
       :ignore
     end
 
-    def for_shape(shape_id, opts) do
-      Map.put(opts, :shape_id, shape_id)
+    def for_shape(shape_handle, opts) do
+      Map.put(opts, :shape_handle, shape_handle)
     end
 
     def initialise(_opts) do
@@ -588,20 +588,20 @@ defmodule Electric.Shapes.ConsumerTest do
     end
 
     def snapshot_started?(opts) do
-      GenServer.call(opts.backend, {:snapshot_started?, opts.shape_id})
+      GenServer.call(opts.backend, {:snapshot_started?, opts.shape_handle})
     end
 
     def get_current_position(opts) do
-      GenServer.call(opts.backend, {:get_current_position, opts.shape_id})
+      GenServer.call(opts.backend, {:get_current_position, opts.shape_handle})
     end
 
-    def append_to_log!(log_items, %{shape_id: shape_id} = opts) do
-      if CrashingStorageBackend.crash?(opts.backend, shape_id) do
-        send(opts.parent, {CrashingStorage, :crash, shape_id})
-        raise "crash from #{shape_id}"
+    def append_to_log!(log_items, %{shape_handle: shape_handle} = opts) do
+      if CrashingStorageBackend.crash?(opts.backend, shape_handle) do
+        send(opts.parent, {CrashingStorage, :crash, shape_handle})
+        raise "crash from #{shape_handle}"
       else
         for {offset, _data} <- log_items do
-          send(opts.parent, {CrashingStorage, :append_to_log, shape_id, offset})
+          send(opts.parent, {CrashingStorage, :append_to_log, shape_handle, offset})
         end
       end
 
@@ -609,7 +609,7 @@ defmodule Electric.Shapes.ConsumerTest do
     end
 
     def set_snapshot_xmin(xmin, opts) do
-      GenServer.call(opts.backend, {:set_snapshot_xmin, opts.shape_id, xmin})
+      GenServer.call(opts.backend, {:set_snapshot_xmin, opts.shape_handle, xmin})
     end
 
     def mark_snapshot_as_started(_opts) do
@@ -638,7 +638,7 @@ defmodule Electric.Shapes.ConsumerTest do
     test "crashing consumer resumes at a consistent point", ctx do
       {:ok, pid} = start_supervised(CrashingStorageBackend)
       parent = self()
-      storage = {CrashingStorage, %{backend: pid, parent: parent, shape_id: nil}}
+      storage = {CrashingStorage, %{backend: pid, parent: parent, shape_handle: nil}}
 
       shape_cache_name = __MODULE__.ShapeCache
 
@@ -683,9 +683,9 @@ defmodule Electric.Shapes.ConsumerTest do
             :configure_tables_for_replication!,
             [get_pg_version, ctx.publication_name]
           },
-          create_snapshot_fn: fn parent, shape_id, _shape, _, _storage ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, 0})
-            GenServer.cast(parent, {:snapshot_started, shape_id})
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, _storage ->
+            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 0})
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         ]
 
@@ -712,30 +712,30 @@ defmodule Electric.Shapes.ConsumerTest do
       shape2 =
         Shape.new!("public.items", where: "value != 'invalid'", inspector: ctx.inspector)
 
-      assert {shape_id1, _} =
-               Electric.ShapeCache.get_or_create_shape_id(shape1, shape_cache_opts)
+      assert {shape_handle1, _} =
+               Electric.ShapeCache.get_or_create_shape_handle(shape1, shape_cache_opts)
 
-      assert {shape_id2, _} =
-               Electric.ShapeCache.get_or_create_shape_id(shape2, shape_cache_opts)
+      assert {shape_handle2, _} =
+               Electric.ShapeCache.get_or_create_shape_handle(shape2, shape_cache_opts)
 
-      assert :started = Electric.ShapeCache.await_snapshot_start(shape_id1, shape_cache_opts)
-      assert :started = Electric.ShapeCache.await_snapshot_start(shape_id2, shape_cache_opts)
+      assert :started = Electric.ShapeCache.await_snapshot_start(shape_handle1, shape_cache_opts)
+      assert :started = Electric.ShapeCache.await_snapshot_start(shape_handle2, shape_cache_opts)
 
       insert_item(conn, "value 1")
 
-      assert_receive {CrashingStorage, :append_to_log, ^shape_id1, offset1}
-      assert_receive {CrashingStorage, :append_to_log, ^shape_id2, ^offset1}
+      assert_receive {CrashingStorage, :append_to_log, ^shape_handle1, offset1}
+      assert_receive {CrashingStorage, :append_to_log, ^shape_handle2, ^offset1}
 
-      :ok = CrashingStorageBackend.crash_once(pid, shape_id2)
+      :ok = CrashingStorageBackend.crash_once(pid, shape_handle2)
 
       insert_item(conn, "value 2")
 
-      assert_receive {CrashingStorage, :append_to_log, ^shape_id1, offset2}
-      assert_receive {CrashingStorage, :crash, ^shape_id2}
+      assert_receive {CrashingStorage, :append_to_log, ^shape_handle1, offset2}
+      assert_receive {CrashingStorage, :crash, ^shape_handle2}
 
       # the whole stack has restarted, but we still get this message
-      assert_receive {CrashingStorage, :append_to_log, ^shape_id1, ^offset2}, 5000
-      assert_receive {CrashingStorage, :append_to_log, ^shape_id2, ^offset2}
+      assert_receive {CrashingStorage, :append_to_log, ^shape_handle1, ^offset2}, 5000
+      assert_receive {CrashingStorage, :append_to_log, ^shape_handle2, ^offset2}
     end
 
     defp insert_item(conn, val) do

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -38,20 +38,20 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def for_shape(shape_id, {parent, init, storage}) do
-    send(parent, {__MODULE__, :for_shape, shape_id})
-    shape_init = Map.get(init, shape_id, [])
-    {parent, shape_id, shape_init, Storage.for_shape(shape_id, storage)}
+  def for_shape(shape_handle, {parent, init, storage}) do
+    send(parent, {__MODULE__, :for_shape, shape_handle})
+    shape_init = Map.get(init, shape_handle, [])
+    {parent, shape_handle, shape_init, Storage.for_shape(shape_handle, storage)}
   end
 
   @impl Electric.ShapeCache.Storage
-  def start_link({_parent, _shape_id, _shape_init, storage}) do
+  def start_link({_parent, _shape_handle, _shape_init, storage}) do
     Storage.start_link(storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def initialise({parent, shape_id, init, storage}) do
-    send(parent, {__MODULE__, :initialise, shape_id})
+  def initialise({parent, shape_handle, init, storage}) do
+    send(parent, {__MODULE__, :initialise, shape_handle})
 
     {module, opts} = storage
 
@@ -65,62 +65,62 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def get_current_position({parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :get_current_position, shape_id})
+  def get_current_position({parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :get_current_position, shape_handle})
     Storage.get_current_position(storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def set_snapshot_xmin(xmin, {parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :set_snapshot_xmin, shape_id, xmin})
+  def set_snapshot_xmin(xmin, {parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :set_snapshot_xmin, shape_handle, xmin})
     Storage.set_snapshot_xmin(xmin, storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def snapshot_started?({parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :snapshot_started?, shape_id})
+  def snapshot_started?({parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :snapshot_started?, shape_handle})
     Storage.snapshot_started?(storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def get_snapshot({parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :get_snapshot, shape_id})
+  def get_snapshot({parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :get_snapshot, shape_handle})
     Storage.get_snapshot(storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def get_log_stream(offset, max_offset, {parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :get_log_stream, shape_id, offset, max_offset})
+  def get_log_stream(offset, max_offset, {parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :get_log_stream, shape_handle, offset, max_offset})
     Storage.get_log_stream(offset, max_offset, storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def get_chunk_end_log_offset(offset, {parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :get_chunk_end_log_offset, shape_id, offset})
+  def get_chunk_end_log_offset(offset, {parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :get_chunk_end_log_offset, shape_handle, offset})
     Storage.get_chunk_end_log_offset(offset, storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def make_new_snapshot!(data_stream, {parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :make_new_snapshot!, shape_id, data_stream})
+  def make_new_snapshot!(data_stream, {parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :make_new_snapshot!, shape_handle, data_stream})
     Storage.make_new_snapshot!(data_stream, storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def mark_snapshot_as_started({parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :mark_snapshot_as_started, shape_id})
+  def mark_snapshot_as_started({parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :mark_snapshot_as_started, shape_handle})
     Storage.mark_snapshot_as_started(storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def append_to_log!(log_items, {parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :append_to_log!, shape_id, log_items})
+  def append_to_log!(log_items, {parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :append_to_log!, shape_handle, log_items})
     Storage.append_to_log!(log_items, storage)
   end
 
   @impl Electric.ShapeCache.Storage
-  def cleanup!({parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :cleanup!, shape_id})
+  def cleanup!({parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :cleanup!, shape_handle})
     Storage.cleanup!(storage)
   end
 end

--- a/packages/typescript-client/CHANGELOG.md
+++ b/packages/typescript-client/CHANGELOG.md
@@ -130,7 +130,7 @@
 
 ### Patch Changes
 
-- 958cc0c: Respect 409 errors by restarting the stream with the new `shape_id`.
+- 958cc0c: Respect 409 errors by restarting the stream with the new `shape_handle`.
 
 ## 0.0.3
 

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -12,8 +12,8 @@ import {
   CHUNK_LAST_OFFSET_HEADER,
   LIVE_QUERY_PARAM,
   OFFSET_QUERY_PARAM,
-  SHAPE_ID_HEADER,
-  SHAPE_ID_QUERY_PARAM,
+  SHAPE_HANDLE_HEADER,
+  SHAPE_HANDLE_QUERY_PARAM,
   SHAPE_SCHEMA_HEADER,
   WHERE_QUERY_PARAM,
 } from './constants'
@@ -187,7 +187,7 @@ export class ShapeStream<T extends Row = Row>
 
         if (this.#shapeId) {
           // This should probably be a header for better cache breaking?
-          fetchUrl.searchParams.set(SHAPE_ID_QUERY_PARAM, this.#shapeId!)
+          fetchUrl.searchParams.set(SHAPE_HANDLE_QUERY_PARAM, this.#shapeId!)
         }
 
         let response!: Response
@@ -206,7 +206,7 @@ export class ShapeStream<T extends Row = Row>
           } else if (e.status == 409) {
             // Upon receiving a 409, we should start from scratch
             // with the newly provided shape ID
-            const newShapeId = e.headers[SHAPE_ID_HEADER]
+            const newShapeId = e.headers[SHAPE_HANDLE_HEADER]
             this.#reset(newShapeId)
             await this.#publish(e.json as Message<T>[])
             continue
@@ -221,7 +221,7 @@ export class ShapeStream<T extends Row = Row>
         }
 
         const { headers, status } = response
-        const shapeId = headers.get(SHAPE_ID_HEADER)
+        const shapeId = headers.get(SHAPE_HANDLE_HEADER)
         if (shapeId) {
           this.#shapeId = shapeId
         }

--- a/packages/typescript-client/src/constants.ts
+++ b/packages/typescript-client/src/constants.ts
@@ -1,8 +1,8 @@
-export const SHAPE_ID_HEADER = `electric-shape-id`
+export const SHAPE_HANDLE_HEADER = `electric-shape-id`
 export const CHUNK_LAST_OFFSET_HEADER = `electric-chunk-last-offset`
 export const CHUNK_UP_TO_DATE_HEADER = `electric-chunk-up-to-date`
 export const SHAPE_SCHEMA_HEADER = `electric-schema`
-export const SHAPE_ID_QUERY_PARAM = `shape_id`
+export const SHAPE_HANDLE_QUERY_PARAM = `shape_handle`
 export const OFFSET_QUERY_PARAM = `offset`
 export const WHERE_QUERY_PARAM = `where`
 export const LIVE_QUERY_PARAM = `live`

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -3,8 +3,8 @@ import {
   CHUNK_UP_TO_DATE_HEADER,
   LIVE_QUERY_PARAM,
   OFFSET_QUERY_PARAM,
-  SHAPE_ID_HEADER,
-  SHAPE_ID_QUERY_PARAM,
+  SHAPE_HANDLE_HEADER,
+  SHAPE_HANDLE_QUERY_PARAM,
 } from './constants'
 import { FetchError, FetchBackoffAbortError } from './error'
 
@@ -234,7 +234,7 @@ class PrefetchQueue {
  * Generate the next chunk's URL if the url and response are valid
  */
 function getNextChunkUrl(url: string, res: Response): string | void {
-  const shapeId = res.headers.get(SHAPE_ID_HEADER)
+  const shapeId = res.headers.get(SHAPE_HANDLE_HEADER)
   const lastOffset = res.headers.get(CHUNK_LAST_OFFSET_HEADER)
   const isUpToDate = res.headers.has(CHUNK_UP_TO_DATE_HEADER)
 
@@ -248,7 +248,7 @@ function getNextChunkUrl(url: string, res: Response): string | void {
   // potentially miss more recent data
   if (nextUrl.searchParams.has(LIVE_QUERY_PARAM)) return
 
-  nextUrl.searchParams.set(SHAPE_ID_QUERY_PARAM, shapeId)
+  nextUrl.searchParams.set(SHAPE_HANDLE_QUERY_PARAM, shapeId)
   nextUrl.searchParams.set(OFFSET_QUERY_PARAM, lastOffset)
   return nextUrl.toString()
 }

--- a/packages/typescript-client/test/cache.test.ts
+++ b/packages/typescript-client/test/cache.test.ts
@@ -82,7 +82,7 @@ describe(`HTTP Proxy Cache`, { timeout: 30000 }, () => {
     await insertIssues({ title: `foo` })
     const searchParams = new URLSearchParams({
       offset: initialRes.headers.get(`electric-chunk-last-offset`)!,
-      shape_id: initialRes.headers.get(`electric-shape-id`)!,
+      shape_handle: initialRes.headers.get(`electric-shape-id`)!,
       live: `true`,
     })
 
@@ -246,7 +246,7 @@ describe(`HTTP Initial Data Caching`, { timeout: 30000 }, () => {
     // should tell you to go back to initial sync
     // because the shape is out of scope
     const liveRes = await fetch(
-      `${proxyCacheBaseUrl}/v1/shape/${issuesTableUrl}?offset=${latestOffset}&shape_id=${originalShapeId}&live`,
+      `${proxyCacheBaseUrl}/v1/shape/${issuesTableUrl}?offset=${latestOffset}&shape_handle=${originalShapeId}&live`,
       {}
     )
     expect(liveRes.status).toBe(409)

--- a/packages/typescript-client/test/fetch.test.ts
+++ b/packages/typescript-client/test/fetch.test.ts
@@ -6,7 +6,7 @@ import {
   BackoffDefaults,
   createFetchWithChunkBuffer,
 } from '../src/fetch'
-import { CHUNK_LAST_OFFSET_HEADER, SHAPE_ID_HEADER } from '../src/constants'
+import { CHUNK_LAST_OFFSET_HEADER, SHAPE_HANDLE_HEADER } from '../src/constants'
 
 describe(`createFetchWithBackoff`, () => {
   const initialDelay = 10
@@ -181,7 +181,7 @@ describe(`createFetchWithChunkBuffer`, () => {
     const initialResponse = new Response(`initial chunk`, {
       status: 200,
       headers: responseHeaders({
-        [SHAPE_ID_HEADER]: `123`,
+        [SHAPE_HANDLE_HEADER]: `123`,
         [CHUNK_LAST_OFFSET_HEADER]: `456`,
       }),
     })
@@ -197,7 +197,7 @@ describe(`createFetchWithChunkBuffer`, () => {
     expect(result).toBe(initialResponse)
 
     // Check if the next chunk was prefetched
-    const nextUrl = `${baseUrl}?shape_id=123&offset=456`
+    const nextUrl = `${baseUrl}?shape_handle=123&offset=456`
     expect(mockFetch).toHaveBeenCalledWith(nextUrl, expect.anything())
   })
 
@@ -214,7 +214,7 @@ describe(`createFetchWithChunkBuffer`, () => {
         new Response(`next chunk`, {
           status: 200,
           headers: responseHeaders({
-            [SHAPE_ID_HEADER]: `123`,
+            [SHAPE_HANDLE_HEADER]: `123`,
             [CHUNK_LAST_OFFSET_HEADER]: `${idx}`,
           }),
         })
@@ -229,23 +229,23 @@ describe(`createFetchWithChunkBuffer`, () => {
     expect(mockFetch).toHaveBeenCalledTimes(1 + maxPrefetchNum)
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
-      `${baseUrl}?shape_id=123&offset=0`,
+      `${baseUrl}?shape_handle=123&offset=0`,
       expect.anything()
     )
     expect(mockFetch).toHaveBeenNthCalledWith(
       3,
-      `${baseUrl}?shape_id=123&offset=1`,
+      `${baseUrl}?shape_handle=123&offset=1`,
       expect.anything()
     )
 
     // Second request consumes one of the prefetched responses and
     // next one fires up
-    await fetchWrapper(`${baseUrl}?shape_id=123&offset=0`)
+    await fetchWrapper(`${baseUrl}?shape_handle=123&offset=0`)
     await sleep()
     expect(mockFetch).toHaveBeenCalledTimes(1 + maxPrefetchNum + 1)
     expect(mockFetch).toHaveBeenNthCalledWith(
       4,
-      `${baseUrl}?shape_id=123&offset=2`,
+      `${baseUrl}?shape_handle=123&offset=2`,
       expect.anything()
     )
   })
@@ -271,7 +271,7 @@ describe(`createFetchWithChunkBuffer`, () => {
     const initialResponse = new Response(`initial chunk`, {
       status: 200,
       headers: responseHeaders({
-        [SHAPE_ID_HEADER]: `123`,
+        [SHAPE_HANDLE_HEADER]: `123`,
         [CHUNK_LAST_OFFSET_HEADER]: `456`,
       }),
     })
@@ -283,7 +283,7 @@ describe(`createFetchWithChunkBuffer`, () => {
     expect(result).toBe(initialResponse)
 
     // Prefetch should have been attempted but failed
-    const nextUrl = `${baseUrl}?shape_id=123&offset=456`
+    const nextUrl = `${baseUrl}?shape_handle=123&offset=456`
     expect(mockFetch).toHaveBeenCalledWith(nextUrl, expect.anything())
 
     // One for the main request, one for the prefetch
@@ -301,7 +301,7 @@ describe(`createFetchWithChunkBuffer`, () => {
         return new Response(`chunk`, {
           status: 200,
           headers: responseHeaders({
-            [SHAPE_ID_HEADER]: `123`,
+            [SHAPE_HANDLE_HEADER]: `123`,
             [CHUNK_LAST_OFFSET_HEADER]: `${idx}`,
           }),
         })
@@ -325,7 +325,7 @@ describe(`createFetchWithChunkBuffer`, () => {
     expect(mockFetch).toHaveBeenNthCalledWith(1, baseUrl)
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
-      `${baseUrl}?shape_id=123&offset=0`,
+      `${baseUrl}?shape_handle=123&offset=0`,
       expect.anything()
     )
 
@@ -333,12 +333,12 @@ describe(`createFetchWithChunkBuffer`, () => {
     expect(mockFetch).toHaveBeenNthCalledWith(3, altUrl)
     expect(mockFetch).toHaveBeenNthCalledWith(
       4,
-      `${altUrl}?shape_id=123&offset=2`,
+      `${altUrl}?shape_handle=123&offset=2`,
       expect.anything()
     )
     expect(mockFetch).toHaveBeenNthCalledWith(
       5,
-      `${altUrl}?shape_id=123&offset=3`,
+      `${altUrl}?shape_handle=123&offset=3`,
       expect.anything()
     )
   })
@@ -354,7 +354,7 @@ describe(`createFetchWithChunkBuffer`, () => {
         return new Response(`chunk`, {
           status: 200,
           headers: responseHeaders({
-            [SHAPE_ID_HEADER]: `123`,
+            [SHAPE_HANDLE_HEADER]: `123`,
             [CHUNK_LAST_OFFSET_HEADER]: `${idx}`,
           }),
         })

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -597,7 +597,7 @@ describe(`HTTP Sync`, () => {
 
     // Get etag for catchup
     const catchupEtagRes = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=${midOffset}&shape_id=${shapeId}`,
+      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=${midOffset}&shape_handle=${shapeId}`,
       {}
     )
     const catchupEtag = catchupEtagRes.headers.get(`etag`)
@@ -606,7 +606,7 @@ describe(`HTTP Sync`, () => {
     // Catch-up offsets should also use the same etag as they're
     // also working through the end of the current log.
     const catchupEtagValidation = await fetch(
-      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=${midOffset}&shape_id=${shapeId}`,
+      `${BASE_URL}/v1/shape/${issuesTableUrl}?offset=${midOffset}&shape_handle=${shapeId}`,
       {
         headers: { 'If-None-Match': catchupEtag },
       }

--- a/packages/typescript-client/test/support/test-context.ts
+++ b/packages/typescript-client/test/support/test-context.ts
@@ -38,7 +38,7 @@ export const testWithDbClient = test.extend<{
     await use(async (table: string, shapeId?: string) => {
       const baseUrl = inject(`baseUrl`)
       const resp = await fetch(
-        `${baseUrl}/v1/shape/${table}${shapeId ? `?shape_id=${shapeId}` : ``}`,
+        `${baseUrl}/v1/shape/${table}${shapeId ? `?shape_handle=${shapeId}` : ``}`,
         {
           method: `DELETE`,
         }

--- a/website/docs/api/http.md
+++ b/website/docs/api/http.md
@@ -84,10 +84,10 @@ Note that the other control message is `must-refetch` which indicates that the c
 
 ### Live mode
 
-Once a client is up-to-date, it can switch to live mode to receive real-time updates, by making requests with `live=true`, an `offset` and a `shape_id`, e.g.:
+Once a client is up-to-date, it can switch to live mode to receive real-time updates, by making requests with `live=true`, an `offset` and a `shape_handle`, e.g.:
 
 ```sh
-curl -i 'http://localhost:3000/v1/shape/foo?live=true&offset=0_0&shape_id=3833821-1721812114261'
+curl -i 'http://localhost:3000/v1/shape/foo?live=true&offset=0_0&shape_handle=3833821-1721812114261'
 ```
 
 The `live` parameter puts the server into live mode, where it will hold open the connection, waiting for new data arrive. This allows you to implement a long-polling strategy to consume real-time updates.

--- a/website/docs/guides/auth.md
+++ b/website/docs/guides/auth.md
@@ -90,10 +90,10 @@ export async function GET(
   // Construct the upstream URL
   const originUrl = new URL(`http://localhost:3000/v1/shape/${table}`)
 
-  // Copy over the shape_id & offset query params that the
+  // Copy over the shape_handle & offset query params that the
   // Electric client adds so we return the right part of the Shape log.
   url.searchParams.forEach((value, key) => {
-    if ([`shape_id`, `offset`].includes(key)) {
+    if ([`shape_handle`, `offset`].includes(key)) {
       originUrl.searchParams.set(key, value)
     }
   })

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -87,7 +87,7 @@ curl -i 'http://localhost:3000/v1/shape/foo?offset=-1'
 Then switch into a live mode to use long-polling to receive real-time updates:
 
 ```sh
-curl -i 'http://localhost:3000/v1/shape/foo?live=true&offset=...&shape_id=...'
+curl -i 'http://localhost:3000/v1/shape/foo?live=true&offset=...&shape_handle=...'
 ```
 
 These requests both return an array of [Shape Log](/docs/api/http#shape-log) entries. You can process these manually, or use a higher-level client.

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -70,7 +70,7 @@ paths:
             in the stream.
 
             Note that when `offset` is not `-1` then you must also provide
-            a `shape_id`.
+            a `shape_handle`.
         - name: live
           in: query
           schema:
@@ -88,7 +88,7 @@ paths:
 
             This allows you to implement a long-polling strategy to consume
             real-time updates.
-        - name: shape_id
+        - name: shape_handle
           in: query
           schema:
             type: string
@@ -139,7 +139,7 @@ paths:
               description: |-
                 Etag header specifying the shape ID and offset for efficient caching.
 
-                In the format `{shape_id}:{start_offset}:{end_offset}`.
+                In the format `{shape_handle}:{start_offset}:{end_offset}`.
             x-electric-chunk-last-offset:
               schema:
                 type: string
@@ -158,7 +158,7 @@ paths:
               description: |-
                 The shape ID.
 
-                Must be provided as the `shape_id` parameter when making
+                Must be provided as the `shape_handle` parameter when making
                 subsequent requests where `offset` is not `-1`.
             x-electric-schema:
               schema:
@@ -284,15 +284,15 @@ paths:
                   message:
                     type: string
                     description: Error message
-                  shape_id:
+                  shape_handle:
                     type: string
                     description: The latest shape ID the client should sync.
                   offset:
                     type: string
-                    description: The offset from where to sync the given shape_id.
+                    description: The offset from where to sync the given shape_handle.
                 example:
-                  message: "The shape associated with this shape_id and offset was not found. Resync to fetch the latest shape"
-                  shape_id: "2494_84241"
+                  message: "The shape associated with this shape_handle and offset was not found. Resync to fetch the latest shape"
+                  shape_handle: "2494_84241"
                   offset: "-1"
     delete:
       summary: Delete Shape
@@ -322,13 +322,13 @@ paths:
 
             Can be qualified by the schema name.
         # Query parameters
-        - name: shape_id
+        - name: shape_handle
           in: query
           schema:
             type: string
           example: "3833821-1721812114261"
           description:
-            Optional, deletes the current shape if it matches the shape_id.
+            Optional, deletes the current shape if it matches the shape_handle.
             If not provided, deletes the current shape.
       responses:
         '202':


### PR DESCRIPTION
Addresses one of the renames proposed in https://github.com/electric-sql/electric/issues/1771