### PR TITLE
Format quickstart output

### DIFF
--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -162,7 +162,7 @@ function Component() {
   })
 
   return (
-    <pre>{ JSON.stringify(data) }</pre>
+    <pre>{ JSON.stringify(data, null, 2) }</pre>
   )
 }
 


### PR DESCRIPTION
Just a little docs thing...
The JSON output in the quickstart example isn't formatted as stated/expected.