### PR TITLE
feat: Serialise and persist shape metadata individually

### DIFF
--- a/.changeset/warm-cycles-live.md
+++ b/.changeset/warm-cycles-live.md
@@ -1,5 +1,5 @@
 ---
-"@core/sync-service": patch
+"@core/sync-service": minor
 ---
 
-Make `PersistentKV` store metadata in individual files on a per-shape basis.
+[BREAKING] Make `PersistentKV` store metadata in individual files on a per-shape basis.

--- a/.changeset/warm-cycles-live.md
+++ b/.changeset/warm-cycles-live.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Make `PersistentKV` store metadata in individual files on a per-shape basis.

--- a/packages/sync-service/lib/electric/persistent_kv.ex
+++ b/packages/sync-service/lib/electric/persistent_kv.ex
@@ -1,4 +1,6 @@
 defprotocol Electric.PersistentKV do
   def get(kv, key)
+  def get_all(kv)
   def set(kv, key, value)
+  def delete(kv, key)
 end

--- a/packages/sync-service/lib/electric/persistent_kv/memory.ex
+++ b/packages/sync-service/lib/electric/persistent_kv/memory.ex
@@ -48,6 +48,20 @@ defmodule Electric.PersistentKV.Memory do
       end
     end
 
+    def get_all(memory) do
+      data = Agent.get(memory.pid, & &1)
+      {:ok, data}
+    end
+
+    def delete(memory, key) do
+      Agent.update(memory.pid, fn data ->
+        notify(memory, {:delete, key})
+        Map.delete(data, key)
+      end)
+
+      :ok
+    end
+
     defp notify(%{parent: parent}, msg) when is_pid(parent) do
       send(parent, {Electric.PersistentKV.Memory, msg})
     end

--- a/packages/sync-service/lib/electric/persistent_kv/mock.ex
+++ b/packages/sync-service/lib/electric/persistent_kv/mock.ex
@@ -16,5 +16,13 @@ defmodule Electric.PersistentKV.Mock do
     def get(_memory, _key) do
       {:ok, 42}
     end
+
+    def get_all(_memory) do
+      {:ok, %{"foo" => 42}}
+    end
+
+    def delete(_memory, _key) do
+      :ok
+    end
   end
 end

--- a/packages/sync-service/lib/electric/persistent_kv/serialized.ex
+++ b/packages/sync-service/lib/electric/persistent_kv/serialized.ex
@@ -23,6 +23,24 @@ defmodule Electric.PersistentKV.Serialized do
       end
     end
 
+    def get_all(kv) do
+      with {:ok, data} <- PersistentKV.get_all(kv.backend) do
+        Enum.reduce_while(data, {:ok, %{}}, fn {k, v}, {:ok, acc} ->
+          case decode(kv, v) do
+            {:ok, decoded_v} ->
+              {:cont, {:ok, Map.put(acc, k, decoded_v)}}
+
+            {:error, reason} ->
+              {:halt, {:error, reason}}
+          end
+        end)
+      end
+    end
+
+    def delete(kv, key) do
+      PersistentKV.delete(kv.backend, key)
+    end
+
     defp encode(%{encoder: {m, f, a}}, term) do
       apply(m, f, [term | a])
     end


### PR DESCRIPTION
Addresses https://github.com/electric-sql/electric/issues/1802

Now the serialisation cost and perhaps other resource contention should not be as high since each shape and relation is serialised individually and stored in a separate file.

I doubt this is the optimal solution, but it should remove the scaling cost of adding more shapes and make that more predictable.

Main concern I suppose is that each shape requires creating a new file, and that operation is in the critical request path for creating a shape.

Ultimately I think it might be better to store metadata as part of the storage interface, and recover shapes similarly to how I do here (listing the directory where shapes are stored and iterating over that).

NOTE: this is a breaking change as electric will no longer be able to resume from its previous `PersistentKV` format - not sure if we want to address that as a minor patch or do anything about it