### PR TITLE
(chore) Add curl to Dockerfile to allow benchmarking to do health-checks

### DIFF
--- a/packages/sync-service/Dockerfile
+++ b/packages/sync-service/Dockerfile
@@ -38,7 +38,7 @@ RUN mix release
 FROM ${RUNNER_IMAGE} AS runner_setup
 
 RUN apt-get update -y && \
-    apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates && \
+    apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates curl && \
     apt-get clean && \
     rm -f /var/lib/apt/lists/*_*
 


### PR DESCRIPTION
Running the benchmarks should only happen once the ./health endpoint has returned `active`. To do this we add a health-check when running the docker image that uses curl:
```
if [[ "`curl localhost:3000/v1/health`" != '{"status":"active"}' ]]; then exit 1; fi
```

This PR adds curl to the docker image to allow this health check to work.