### PR TITLE
Add parameter to API to send entire row on update

### DIFF
--- a/.changeset/sharp-moons-provide.md
+++ b/.changeset/sharp-moons-provide.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": patch
+"@core/sync-service": patch
+---
+
+Add `replica` parameter to change the behaviour for updates to include the full row, not just the modified columns

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -70,6 +70,7 @@ defmodule Electric.Plug.ServeShapePlug do
       field(:where, :string)
       field(:columns, :string)
       field(:shape_definition, :string)
+      field(:replica, Ecto.Enum, values: [:default, :full], default: :default)
     end
 
     def validate(params, opts) do
@@ -156,8 +157,12 @@ defmodule Electric.Plug.ServeShapePlug do
       table = fetch_change!(changeset, :table)
       where = fetch_field!(changeset, :where)
       columns = get_change(changeset, :columns, nil)
+      replica = fetch_field!(changeset, :replica)
 
-      case Shapes.Shape.new(table, opts ++ [where: where, columns: columns]) do
+      case Shapes.Shape.new(
+             table,
+             opts ++ [where: where, columns: columns, replica: replica]
+           ) do
         {:ok, result} ->
           put_change(changeset, :shape_definition, result)
 
@@ -615,6 +620,7 @@ defmodule Electric.Plug.ServeShapePlug do
       "shape.where" => assigns[:where],
       "shape.root_table" => assigns[:table],
       "shape.definition" => assigns[:shape_definition],
+      "shape.replica" => assigns[:replica],
       "shape_req.is_live" => assigns[:live],
       "shape_req.offset" => assigns[:offset],
       "shape_req.is_shape_rotated" => assigns[:ot_is_shape_rotated] || false,

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -375,7 +375,9 @@ defmodule Electric.Shapes.Consumer do
        ) do
     {log_items, new_log_state} =
       changes
-      |> Stream.flat_map(&LogItems.from_change(&1, xid, Shape.pk(shape, &1.relation)))
+      |> Stream.flat_map(
+        &LogItems.from_change(&1, xid, Shape.pk(shape, &1.relation), shape.replica)
+      )
       |> Enum.flat_map_reduce(log_state, fn log_item,
                                             %{current_chunk_byte_size: chunk_size} = state ->
         json_log_item = Jason.encode!(log_item)

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -6,10 +6,10 @@ defmodule Support.TestUtils do
   Preprocess a list of `Changes.data_change()` structs in the same way they
   are preprocessed before reaching storage.
   """
-  def changes_to_log_items(changes, pk \\ ["id"], xid \\ 1) do
+  def changes_to_log_items(changes, pk \\ ["id"], xid \\ 1, replica \\ :default) do
     changes
     |> Enum.map(&Changes.fill_key(&1, pk))
-    |> Enum.flat_map(&LogItems.from_change(&1, xid, pk))
+    |> Enum.flat_map(&LogItems.from_change(&1, xid, pk, replica))
     |> Enum.map(fn item -> {item.offset, Jason.encode!(item)} end)
   end
 

--- a/packages/typescript-client/src/constants.ts
+++ b/packages/typescript-client/src/constants.ts
@@ -11,3 +11,4 @@ export const LIVE_QUERY_PARAM = `live`
 export const OFFSET_QUERY_PARAM = `offset`
 export const TABLE_QUERY_PARAM = `table`
 export const WHERE_QUERY_PARAM = `where`
+export const REPLICA_PARAM = `replica`

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { testWithIssuesTable as it } from './support/test-context'
 import { ShapeStream, Shape, FetchError } from '../src'
+import { Message, Row, ChangeMessage } from '../src/types'
 
 const BASE_URL = inject(`baseUrl`)
 
@@ -336,5 +337,49 @@ describe(`Shape`, () => {
     await sleep(200) // give some time for the initial fetch to complete
 
     expect(shapeStream.isLoading()).false
+  })
+
+  it(`should honour replica: full`, async ({
+    insertIssues,
+    updateIssue,
+    issuesTableUrl,
+    clearIssuesShape,
+    aborter,
+  }) => {
+    const [id] = await insertIssues({ title: `first title` })
+
+    const shapeStream = new ShapeStream({
+      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+      replica: `full`,
+      signal: aborter.signal,
+    })
+    try {
+      await new Promise((resolve) => {
+        shapeStream.subscribe(resolve)
+      })
+
+      await sleep(200)
+      await updateIssue({ id: id, title: `updated title` })
+
+      const msgs: Message<Row>[] = await new Promise((resolve) => {
+        shapeStream.subscribe(resolve)
+      })
+
+      const expectedValue = {
+        id: id,
+        title: `updated title`,
+        // because we're sending the full row, the update will include the
+        // unchanged `priority` column
+        priority: 10,
+      }
+
+      const changeMsg: ChangeMessage<Row> = msgs[0] as ChangeMessage<Row>
+      expect(changeMsg.headers.operation).toEqual(`update`)
+      expect(changeMsg.value).toEqual(expectedValue)
+    } finally {
+      // the normal cleanup doesn't work because our shape definition is
+      // changed by the updates: 'full' param
+      await clearIssuesShape(shapeStream.shapeId)
+    }
   })
 })

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -349,7 +349,8 @@ describe(`Shape`, () => {
     const [id] = await insertIssues({ title: `first title` })
 
     const shapeStream = new ShapeStream({
-      url: `${BASE_URL}/v1/shape/${issuesTableUrl}`,
+      url: `${BASE_URL}/v1/shape`,
+      table: issuesTableUrl,
       replica: `full`,
       signal: aborter.signal,
     })
@@ -379,7 +380,7 @@ describe(`Shape`, () => {
     } finally {
       // the normal cleanup doesn't work because our shape definition is
       // changed by the updates: 'full' param
-      await clearIssuesShape(shapeStream.shapeId)
+      await clearIssuesShape(shapeStream.shapeHandle)
     }
   })
 })


### PR DESCRIPTION
With `replica=full` update messages include the full row, not just
the changed columns.

Phoenix.LiveView Stream integration requires the full row to perform an
update, not just the changed values. This adds a parameter to the shape
definition that turns off the column diffing for updates.

Since we were just dropping unchanged values this is a minor change to
the wiring. Most of the work here is adding the configuration.