### PR TITLE
feat: Restoring shapes only through the `Storage` interface

### DIFF
--- a/.changeset/weak-chairs-type.md
+++ b/.changeset/weak-chairs-type.md
@@ -2,4 +2,4 @@
 "@core/sync-service": minor
 ---
 
-[BREAKING] Store shape definitions along with shape data and use that to restore them instead of persisted cached metadata.
+[BREAKING] Store shape definitions along with shape data and use that to restore them instead of persisted cached metadata. This removes the unified serilization and persistence of all shape metadata and allows better scaling of speed of shape creation.

--- a/.changeset/weak-chairs-type.md
+++ b/.changeset/weak-chairs-type.md
@@ -1,5 +1,5 @@
 ---
-"@core/sync-service": minor
+"@core/sync-service": patch
 ---
 
-[BREAKING] Store shape definitions along with shape data and use that to restore them instead of persisted cached metadata. This removes the unified serilization and persistence of all shape metadata and allows better scaling of speed of shape creation.
+Store shape definitions along with shape data and use that to restore them instead of persisted cached metadata. This removes the unified serilization and persistence of all shape metadata and allows better scaling of speed of shape creation.

--- a/.changeset/weak-chairs-type.md
+++ b/.changeset/weak-chairs-type.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": minor
+---
+
+[BREAKING] Store shape definitions along with shape data and use that to restore them instead of persisted cached metadata.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -188,7 +188,8 @@ defmodule Electric.ShapeCache do
     {:ok, persistent_state} =
       opts.shape_status.initialise(
         persistent_kv: opts.persistent_kv,
-        shape_meta_table: opts.shape_meta_table
+        shape_meta_table: opts.shape_meta_table,
+        storage: opts.storage
       )
 
     state = %{

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -131,6 +131,10 @@ defmodule Electric.ShapeCache.FileStorage do
         end)
         |> then(&{:ok, &1})
 
+      {:error, :enoent} ->
+        # if not present, there's no stored shapes
+        {:ok, %{}}
+
       {:error, reason} ->
         {:error, reason}
     end

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -10,13 +10,23 @@ defmodule Electric.ShapeCache.FileStorage do
   @version 2
   @version_key :version
 
+  @shape_definition_file_name "shape_defintion.json"
+
   @xmin_key :snapshot_xmin
   @snapshot_meta_key :snapshot_meta
   @snapshot_started_key :snapshot_started
 
   @behaviour Electric.ShapeCache.Storage
 
-  defstruct [:base_path, :shape_id, :db, :cubdb_dir, :snapshot_dir, version: @version]
+  defstruct [
+    :base_path,
+    :shape_id,
+    :db,
+    :cubdb_dir,
+    :shape_definition_dir,
+    :snapshot_dir,
+    version: @version
+  ]
 
   @impl Electric.ShapeCache.Storage
   def shared_opts(opts) do
@@ -37,7 +47,8 @@ defmodule Electric.ShapeCache.FileStorage do
       shape_id: shape_id,
       db: name(electric_instance_id, shape_id),
       cubdb_dir: Path.join([base_path, shape_id, "cubdb"]),
-      snapshot_dir: Path.join([base_path, shape_id, "snapshots"])
+      snapshot_dir: Path.join([base_path, shape_id, "snapshots"]),
+      shape_definition_dir: Path.join([base_path, shape_id, "shape_definition"])
     }
   end
 
@@ -62,7 +73,8 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   defp initialise_filesystem(opts) do
-    with :ok <- File.mkdir_p(opts.cubdb_dir),
+    with :ok <- File.mkdir_p(opts.shape_definition_dir),
+         :ok <- File.mkdir_p(opts.cubdb_dir),
          :ok <- File.mkdir_p(opts.snapshot_dir) do
       :ok
     end
@@ -73,11 +85,31 @@ defmodule Electric.ShapeCache.FileStorage do
     stored_version = stored_version(opts)
 
     if stored_version != opts.version || snapshot_xmin(opts) == nil ||
+         not File.exists?(shape_definition_path(opts)) ||
          not CubDB.has_key?(opts.db, @snapshot_meta_key) do
       cleanup!(opts)
     end
 
     CubDB.put(opts.db, @version_key, @version)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def set_shape_definition(shape, %FS{} = opts) do
+    file_path = shape_definition_path(opts)
+    encoded_shape = Jason.encode!(shape)
+
+    case File.write(file_path, encoded_shape, [:exclusive]) do
+      :ok ->
+        :ok
+
+      {:error, :eexist} ->
+        # file already exists - by virtue of the shape ID being the hash of the
+        # definition we do not need to compare them
+        :ok
+
+      {:error, reason} ->
+        raise "Failed to write shape definition to file: #{reason}"
+    end
   end
 
   @impl Electric.ShapeCache.Storage
@@ -253,7 +285,13 @@ defmodule Electric.ShapeCache.FileStorage do
 
     {:ok, _} = File.rm_rf(shape_snapshot_path(opts))
 
+    {:ok, _} = File.rm_rf(shape_definition_path(opts))
+
     :ok
+  end
+
+  defp shape_definition_path(%FS{shape_definition_dir: shape_definition_dir} = _opts) do
+    Path.join(shape_definition_dir, @shape_definition_file_name)
   end
 
   defp keys_from_range(min_key, max_key, opts) do

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -107,6 +107,12 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   def initialise(%MS{} = _opts), do: :ok
 
   @impl Electric.ShapeCache.Storage
+  def set_shape_definition(_shape, %MS{} = _opts) do
+    # no-op - only used to restore shapes between sessions
+    :ok
+  end
+
+  @impl Electric.ShapeCache.Storage
   def snapshot_started?(%MS{} = opts) do
     try do
       :ets.member(opts.snapshot_table, snapshot_start())

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -113,6 +113,12 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   end
 
   @impl Electric.ShapeCache.Storage
+  def get_all_stored_shapes(_opts) do
+    # shapes not stored, empty map returned
+    {:ok, %{}}
+  end
+
+  @impl Electric.ShapeCache.Storage
   def snapshot_started?(%MS{} = opts) do
     try do
       :ets.member(opts.snapshot_table, snapshot_start())

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -67,7 +67,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
   @type t() :: %__MODULE__{
           persistent_kv: PersistentKV.t(),
           root: String.t(),
-          storage: Storage.t(),
+          storage: Storage.storage(),
           shape_meta_table: table()
         }
   @type option() :: unquote(NimbleOptions.option_typespec(@schema))

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -36,6 +36,10 @@ defmodule Electric.ShapeCache.Storage do
   @doc "Store the shape definition"
   @callback set_shape_definition(Shape.t(), shape_opts()) :: :ok
 
+  @doc "Retrieve all stored shapes"
+  @callback get_all_stored_shapes(compiled_opts()) ::
+              {:ok, %{shape_id() => Shape.t()}} | {:error, term()}
+
   @doc """
   Get the current xmin and offset for the shape storage.
 

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -135,6 +135,11 @@ defmodule Electric.ShapeCache.Storage do
   end
 
   @impl __MODULE__
+  def get_all_stored_shapes({mod, opts}) do
+    mod.get_all_stored_shapes(opts)
+  end
+
+  @impl __MODULE__
   def get_current_position({mod, shape_opts}) do
     mod.get_current_position(shape_opts)
   end

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -1,6 +1,7 @@
 defmodule Electric.ShapeCache.Storage do
   import Electric.Replication.LogOffset, only: [is_log_offset_lt: 2]
 
+  alias Electric.Shapes.Shape
   alias Electric.Shapes.Querying
   alias Electric.Replication.LogOffset
 
@@ -31,6 +32,9 @@ defmodule Electric.ShapeCache.Storage do
 
   @doc "Run any initial setup tasks"
   @callback initialise(shape_opts()) :: :ok
+
+  @doc "Store the shape definition"
+  @callback set_shape_definition(Shape.t(), shape_opts()) :: :ok
 
   @doc """
   Get the current xmin and offset for the shape storage.
@@ -119,6 +123,11 @@ defmodule Electric.ShapeCache.Storage do
   @impl __MODULE__
   def initialise({mod, shape_opts}) do
     mod.initialise(shape_opts)
+  end
+
+  @impl __MODULE__
+  def set_shape_definition(shape, {mod, shape_opts}) do
+    mod.set_shape_definition(shape, shape_opts)
   end
 
   @impl __MODULE__

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -58,6 +58,9 @@ defmodule Electric.Shapes.Consumer do
 
     :ok = ShapeCache.Storage.initialise(storage)
 
+    # Store the shape definition to ensure we can restore it
+    :ok = ShapeCache.Storage.set_shape_definition(config.shape, storage)
+
     {:ok, latest_offset, snapshot_xmin} = ShapeCache.Storage.get_current_position(storage)
 
     :ok =

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -32,7 +32,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     {:ok, pid} = start_supervised({ShapeLogCollector, opts})
 
     Mock.ShapeStatus
-    |> expect(:initialise, 1, fn opts -> Electric.ShapeCache.ShapeStatus.initialise(opts) end)
+    |> expect(:initialise, 1, fn _opts -> {:ok, %{}} end)
     |> expect(:list_shapes, 1, fn _ -> [] end)
     # allow the ShapeCache to call this mock
     |> allow(self(), fn -> GenServer.whereis(Electric.ShapeCache) end)

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -8,14 +8,14 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   alias Electric.Replication.LogOffset
 
   alias Support.Mock
-  import Support.ComponentSetup, only: [with_electric_instance_id: 1]
+  import Support.ComponentSetup, only: [with_electric_instance_id: 1, with_in_memory_storage: 1]
 
   import Mox
 
   @moduletag :capture_log
 
   setup :verify_on_exit!
-  setup :with_electric_instance_id
+  setup [:with_electric_instance_id, :with_in_memory_storage]
 
   setup(ctx) do
     # Start a test Registry

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -150,6 +150,8 @@ defmodule Electric.Shapes.ConsumerTest do
               id: {Shapes.Consumer.Supervisor, shape_id}
             )
 
+            assert_receive {Support.TestStorage, :set_shape_definition, ^shape_id, ^shape}
+
           consumer
         end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -150,7 +150,7 @@ defmodule Electric.Shapes.ConsumerTest do
               id: {Shapes.Consumer.Supervisor, shape_id}
             )
 
-            assert_receive {Support.TestStorage, :set_shape_definition, ^shape_id, ^shape}
+          assert_receive {Support.TestStorage, :set_shape_definition, ^shape_id, ^shape}
 
           consumer
         end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -547,7 +547,7 @@ defmodule Electric.Shapes.ConsumerTest do
     end
 
     def init(_opts) do
-      {:ok, %{shapes: %{}, crashing: %{}}}
+      {:ok, %{shapes: %{}, crashing: %{}, stored_shapes: %{}}}
     end
 
     def handle_call({:crash_once, shape_id}, _from, state) do
@@ -558,6 +558,14 @@ defmodule Electric.Shapes.ConsumerTest do
       {crash?, crashing} = Map.pop(state.crashing, shape_id, false)
 
       {:reply, crash?, %{state | crashing: crashing}}
+    end
+
+    def handle_call({:set_shape_definition, shape_id, shape}, _from, state) do
+      {:reply, :ok, %{state | stored_shapes: Map.put(state.stored_shapes, shape_id, shape)}}
+    end
+
+    def handle_call({:get_all_stored_shapes}, _from, state) do
+      {:reply, {:ok, state.stored_shapes}, state}
     end
 
     def handle_call({:get_current_position, shape_id}, _from, state) do
@@ -601,6 +609,14 @@ defmodule Electric.Shapes.ConsumerTest do
 
     def initialise(_opts) do
       :ok
+    end
+
+    def get_all_stored_shapes(opts) do
+      GenServer.call(opts.backend, {:get_all_stored_shapes})
+    end
+
+    def set_shape_definition(shape, opts) do
+      GenServer.call(opts.backend, {:set_shape_definition, opts.shape_id, shape})
     end
 
     def snapshot_started?(opts) do

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -66,7 +66,7 @@ defmodule Support.TestStorage do
 
   @impl Electric.ShapeCache.Storage
   def set_shape_definition(shape, {parent, shape_id, _, storage}) do
-    send(parent, {__MODULE__, :set_shape_definition, shape_id})
+    send(parent, {__MODULE__, :set_shape_definition, shape_id, shape})
     Storage.set_shape_definition(shape, storage)
   end
 

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -65,6 +65,18 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
+  def set_shape_definition(shape, {parent, shape_id, _, storage}) do
+    send(parent, {__MODULE__, :set_shape_definition, shape_id})
+    Storage.set_shape_definition(shape, storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def get_all_stored_shapes({parent, _init, storage}) do
+    send(parent, {__MODULE__, :get_all_stored_shapes})
+    Storage.get_all_stored_shapes(storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
   def get_current_position({parent, shape_id, _, storage}) do
     send(parent, {__MODULE__, :get_current_position, shape_id})
     Storage.get_current_position(storage)


### PR DESCRIPTION
More radical alternative to https://github.com/electric-sql/electric/pull/1805

Addresses https://github.com/electric-sql/electric/issues/1802

Moves the shape definition to the `Storage` interface.

I've started with just making `ShapeStatus` use the `Storage` for recovering shapes - but if we also store OIDs of the relation we can also do away with storing relations and get rid of any persistence in `ShapeStatus`

I believe this is mergeable if we want to move at least shape definitions to the storage and think about relations in a separate PR