### PR TITLE
feat: Add `headers` utility option to `ShapeStream` API

### DIFF
--- a/.changeset/chilly-carpets-compare.md
+++ b/.changeset/chilly-carpets-compare.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Implement utility `headers` option on `ShapeStream` to pass headers to attach to all requests, like authorization.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -53,6 +53,13 @@ export interface ShapeStreamOptions<T = never> {
    */
   shapeId?: string
   backoffOptions?: BackoffOptions
+
+  /**
+   * HTTP headers to attach to requests made by the client.
+   * Can be used for adding authentication headers.
+   */
+  headers?: { [key: string]: string }
+
   /**
    * Automatically fetch updates to the Shape. If you just want to sync the current
    * shape and stop, pass false.
@@ -199,7 +206,10 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
         let response!: Response
         try {
-          response = await this.#fetchClient(fetchUrl.toString(), { signal })
+          response = await this.#fetchClient(fetchUrl.toString(), {
+            signal,
+            headers: this.options.headers,
+          })
           this.#connected = true
         } catch (e) {
           if (e instanceof FetchBackoffAbortError) break // interrupted

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -58,7 +58,7 @@ export interface ShapeStreamOptions<T = never> {
    * HTTP headers to attach to requests made by the client.
    * Can be used for adding authentication headers.
    */
-  headers?: { [key: string]: string }
+  headers?: Record<string, string>
 
   /**
    * Automatically fetch updates to the Shape. If you just want to sync the current

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ShapeStream } from '../src'
+
+describe(`ShapeStream`, () => {
+  const shapeUrl = `https://example.com/v1/shape/foo`
+  let aborter: AbortController
+
+  beforeEach(() => {
+    aborter = new AbortController()
+  })
+
+  afterEach(() => aborter.abort())
+
+  it(`should attach specified headers to requests`, async () => {
+    const eventTarget = new EventTarget()
+    const requestArgs: Array<RequestInit | undefined> = []
+    const fetchWrapper = (
+      ...args: Parameters<typeof fetch>
+    ): Promise<Response> => {
+      requestArgs.push(args[1])
+      eventTarget.dispatchEvent(new Event(`fetch`))
+      return Promise.resolve(Response.error())
+    }
+
+    const aborter = new AbortController()
+    new ShapeStream({
+      url: shapeUrl,
+      signal: aborter.signal,
+      fetchClient: fetchWrapper,
+      headers: {
+        Authorization: `my-token`,
+        'X-Custom-Header': `my-value`,
+      },
+    })
+
+    await new Promise((resolve) =>
+      eventTarget.addEventListener(`fetch`, resolve, { once: true })
+    )
+
+    expect(requestArgs[0]).toMatchObject({
+      headers: {
+        Authorization: `my-token`,
+        'X-Custom-Header': `my-value`,
+      },
+    })
+  })
+})


### PR DESCRIPTION
Implements feature described in https://github.com/electric-sql/electric/issues/1748

Attaches headers to all requests - figured we'd go with the simple route of static dictionary of headers to add, we can always enhance it with a function dependent on the state of the stream and even potentially make it an async function that waits for the headers to be provided before making the next request - but KISS