### PR TITLE
chore: Fix integration test storage isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ caching/nginx_cache
 file.jsonl
 integration-tests/lux_logs/
 integration-tests/lux/
+integration-tests/_storage
 json_files
 node_modules
 shape-data.json

--- a/integration-tests/scripts/clean_up.sh
+++ b/integration-tests/scripts/clean_up.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+rm -rf "$SCRIPT_DIR/../_storage"

--- a/integration-tests/scripts/electric_dev.sh
+++ b/integration-tests/scripts/electric_dev.sh
@@ -4,5 +4,5 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
-cd "$SCRIPT_DIR"/../packages/sync-service
-iex -S mix
+cd "$SCRIPT_DIR"/../../packages/sync-service
+STORAGE_DIR="$SCRIPT_DIR/../_storage" iex -S mix

--- a/integration-tests/tests/macros.luxinc
+++ b/integration-tests/tests/macros.luxinc
@@ -80,11 +80,13 @@
   [shell $shell_name]
     -$fail_pattern
   
-    !DATABASE_URL=$database_url PORT=$port ../electric_dev.sh
+    !DATABASE_URL=$database_url PORT=$port ../scripts/electric_dev.sh
 [endmacro]
 
 [macro teardown]
   -$fail_pattern
-
   !docker rm -f -v $pg_container_name
+  ?$PS1
+  !../scripts/clean_up.sh
+  ?$PS1
 [endmacro]


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1820

We specify the storage directory as being within the integration test folder, and after every test the storage is deleted.