### PR TITLE
feat: Add `columns` API query parameter to filter table columns

### DIFF
--- a/.changeset/large-days-attend.md
+++ b/.changeset/large-days-attend.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": patch
+"@core/sync-service": patch
+---
+
+Implement `columns` query parameter for `GET v1/shapes` API to allow filtering rows for a subset of table columns.

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -101,8 +101,14 @@ defmodule Electric.Plug.ServeShapePlug do
 
     def cast_columns(%Ecto.Changeset{} = changeset) do
       case fetch_field!(changeset, :columns) do
-        nil -> changeset
-        columns -> put_change(changeset, :columns, String.split(columns, ","))
+        nil ->
+          changeset
+
+        columns ->
+          case Electric.Plug.Utils.parse_columns_param(columns) do
+            {:ok, parsed_cols} -> put_change(changeset, :columns, parsed_cols)
+            {:error, reason} -> add_error(changeset, :columns, reason)
+          end
       end
     end
 

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -15,14 +15,14 @@ defmodule Electric.Plug.Utils do
       {:error, "Invalid zero-length delimited identifier"}
       iex> Electric.Plug.Utils.parse_columns_param("id")
       {:ok, ["id"]}
-      iex> Electric.Plug.Utils.parse_columns_param("beta,alpha")
-      {:ok, ["alpha", "beta"]}
+      iex> Electric.Plug.Utils.parse_columns_param("id,name")
+      {:ok, ["id", "name"]}
       iex> Electric.Plug.Utils.parse_columns_param(~S|"PoT@To",PoTaTo|)
       {:ok, ["PoT@To", "potato"]}
       iex> Electric.Plug.Utils.parse_columns_param(~S|"PoTaTo,sunday",foo|)
       {:ok, ["PoTaTo,sunday", "foo"]}
-      iex> Electric.Plug.Utils.parse_columns_param(~S|\"fo\"\"o\",bar|)
-      {:ok, ["bar", ~S|fo"o|]}
+      iex> Electric.Plug.Utils.parse_columns_param(~S|"fo""o",bar|)
+      {:ok, [~S|fo"o|, "bar"]}
       iex> Electric.Plug.Utils.parse_columns_param(~S|"id,"name"|)
       {:error, ~S|Invalid unquoted identifier contains special characters: "id|}
   """
@@ -40,9 +40,8 @@ defmodule Electric.Plug.Utils do
     end)
     |> then(fn result ->
       case result do
-        # sort to keep selected columns identical
         # TODO: convert output to MapSet?
-        parsed_cols when is_list(parsed_cols) -> {:ok, Enum.sort(parsed_cols)}
+        parsed_cols when is_list(parsed_cols) -> {:ok, Enum.reverse(parsed_cols)}
         {:error, reason} -> {:error, reason}
       end
     end)

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -1,0 +1,60 @@
+defmodule Electric.Plug.Utils do
+  @moduledoc """
+  Utility functions for Electric endpoints, e.g. for parsing and validating
+  path and query parameters.
+  """
+
+  @doc """
+  Parse columns parameter from a string consisting of a comma separated list
+  of potentially quoted column names into a sorted list of strings.
+
+  ## Examples
+      iex> Electric.Plug.Utils.parse_columns_param("")
+      {:ok, MapSet.new([""])}
+      iex> Electric.Plug.Utils.parse_columns_param("id")
+      {:ok, MapSet.new(["id"])}
+      iex> Electric.Plug.Utils.parse_columns_param("beta,alpha")
+      {:ok, MapSet.new(["alpha", "beta"])}
+      iex> Electric.Plug.Utils.parse_columns_param(~S|"PoTaTo,sunday",foo|)
+      {:ok, MapSet.new(["PoTaTo,sunday", "foo"])}
+      iex> Electric.Plug.Utils.parse_columns_param(~S|\"fo\"\"o\",bar|)
+      {:ok, MapSet.new(["bar", ~S|fo"o|])}
+      iex> Electric.Plug.Utils.parse_columns_param(~S|"id,"name"|)
+      {:error, ~S|Invalid column, unmatched quote: "id|}
+  """
+  @spec parse_columns_param(binary()) :: {:ok, MapSet.t(String.t())} | {:error, term()}
+  def parse_columns_param(columns) when is_binary(columns) do
+    columns
+    # Split by commas that are not inside quotes
+    |> String.split(~r/,(?=(?:[^"]*"[^"]*")*[^"]*$)/)
+    |> Enum.reduce_while(MapSet.new([]), fn column, acc ->
+      casted_column = remove_surrounding_quotes(column)
+
+      if contains_unescaped_quote?(casted_column) do
+        {:halt, {:error, "Invalid column, unmatched quote: #{casted_column}"}}
+      else
+        {:cont, acc |> MapSet.put(unescape_quotes(casted_column))}
+      end
+    end)
+    |> then(fn result ->
+      case result do
+        parsed_cols when is_map(parsed_cols) -> {:ok, parsed_cols}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
+  end
+
+  defp contains_unescaped_quote?(string) do
+    Regex.match?(~r/(?<!")"(?!")/, string)
+  end
+
+  defp remove_surrounding_quotes(string) do
+    string
+    |> String.replace(~r/^"(.*)"$/, "\\1")
+  end
+
+  defp unescape_quotes(string) do
+    string
+    |> String.replace(~r/""/, "\"")
+  end
+end

--- a/packages/sync-service/lib/electric/postgres/identifiers.ex
+++ b/packages/sync-service/lib/electric/postgres/identifiers.ex
@@ -61,7 +61,7 @@ defmodule Electric.Postgres.Identifiers do
 
   defp unescape_quotes(string) do
     string
-    |> String.replace(~r/""/, "\"")
+    |> String.replace(~r/""/, ~S|"|)
   end
 
   defp valid_unquoted_identifier?(identifier) do
@@ -104,8 +104,7 @@ defmodule Electric.Postgres.Identifiers do
 
     truncated_ident =
       if String.length(ident) >= @namedatalen do
-        result = String.slice(downcased_ident, 0, @namedatalen)
-        result
+        String.slice(downcased_ident, 0, @namedatalen)
       else
         downcased_ident
       end

--- a/packages/sync-service/lib/electric/postgres/identifiers.ex
+++ b/packages/sync-service/lib/electric/postgres/identifiers.ex
@@ -1,0 +1,61 @@
+defmodule Electric.Postgres.Identifiers do
+  @namedatalen 63
+  @ascii_downcase ?a - ?A
+
+  @doc """
+  Downcase the identifier and truncate if necessary, using
+  PostgreSQL's algorithm for downcasing.
+
+  Setting `truncate` to `true` will truncate the identifier to 63 characters
+
+  Setting `single_byte_encoding` to `true` will downcase the identifier
+  using single byte encoding
+
+  See:
+  https://github.com/postgres/postgres/blob/259a0a99fe3d45dcf624788c1724d9989f3382dc/src/backend/parser/scansup.c#L46-L80
+
+  ## Examples
+
+      iex> Electric.Postgres.Identifiers.downcase("FooBar")
+      "foobar"
+      iex> Electric.Postgres.Identifiers.downcase(String.duplicate("a", 100), true)
+      String.duplicate("a", 63)
+  """
+  def downcase(ident, truncate \\ false, single_byte_encoding \\ false)
+
+  def downcase(ident, false, single_byte_encoding) do
+    downcased_ident =
+      ident
+      |> String.to_charlist()
+      |> Enum.map(&downcase_char(&1, single_byte_encoding))
+      |> List.to_string()
+
+    downcased_ident
+  end
+
+  def downcase(ident, true, single_byte_encoding) do
+    downcased_ident = downcase(ident, false, single_byte_encoding)
+
+    truncated_ident =
+      if String.length(ident) >= @namedatalen do
+        result = String.slice(downcased_ident, 0, @namedatalen)
+        result
+      else
+        downcased_ident
+      end
+
+    truncated_ident
+  end
+
+  # Helper function to downcase a character
+  defp downcase_char(ch, _) when ch in ?A..?Z, do: ch + @ascii_downcase
+
+  defp downcase_char(ch, true) when ch > 127,
+    do:
+      if(ch == Enum.at(:unicode_util.uppercase(ch), 0),
+        do: Enum.at(:unicode_util.lowercase(ch), 0),
+        else: ch
+      )
+
+  defp downcase_char(ch, _), do: ch
+end

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -71,9 +71,8 @@ defmodule Electric.Shapes.Querying do
     |> Enum.map(& &1.name)
   end
 
-  defp get_column_names(table_info, root_table, selected_columns) do
-    get_column_names(table_info, root_table, nil)
-    |> Enum.filter(&(&1 in selected_columns))
+  defp get_column_names(_table_info, _root_table, selected_columns) do
+    selected_columns
   end
 
   defp build_headers_part(root_table) do

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -12,14 +12,14 @@ defmodule Electric.Shapes.Querying do
   @type json_result_stream :: Enumerable.t(json_iodata())
 
   @spec stream_initial_data(DBConnection.t(), Shape.t()) :: json_result_stream()
-  def stream_initial_data(conn, %Shape{root_table: root_table, table_info: table_info} = shape) do
+  def stream_initial_data(conn, %Shape{root_table: root_table} = shape) do
     OpenTelemetry.with_span("shape_read.stream_initial_data", [], fn ->
       table = Utils.relation_to_sql(root_table)
 
       where =
         if not is_nil(shape.where), do: " WHERE " <> shape.where.query, else: ""
 
-      {json_like_select, params} = json_like_select(table_info, root_table, Shape.pk(shape))
+      {json_like_select, params} = json_like_select(shape)
 
       query =
         Postgrex.prepare!(conn, table, ~s|SELECT #{json_like_select} FROM #{table} #{where}|)
@@ -30,8 +30,15 @@ defmodule Electric.Shapes.Querying do
     end)
   end
 
-  defp json_like_select(table_info, root_table, pk_cols) do
-    columns = get_column_names(table_info, root_table)
+  defp json_like_select(
+         %Shape{
+           table_info: table_info,
+           root_table: root_table,
+           selected_columns: selected_columns
+         } = shape
+       ) do
+    pk_cols = Shape.pk(shape)
+    columns = get_column_names(table_info, root_table, selected_columns)
 
     key_part = build_key_part(root_table, pk_cols)
     value_part = build_value_part(columns)
@@ -57,11 +64,16 @@ defmodule Electric.Shapes.Querying do
     {query, []}
   end
 
-  defp get_column_names(table_info, root_table) do
+  defp get_column_names(table_info, root_table, nil) do
     table_info
     |> Map.fetch!(root_table)
     |> Map.fetch!(:columns)
     |> Enum.map(& &1.name)
+  end
+
+  defp get_column_names(table_info, root_table, selected_columns) do
+    get_column_names(table_info, root_table, nil)
+    |> Enum.filter(&(&1 in selected_columns))
   end
 
   defp build_headers_part(root_table) do

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -95,8 +95,12 @@ defmodule Electric.Shapes.Shape do
     end
   end
 
-  @spec validate_selected_columns([Inspector.column_info()], [String.t()], [String.t()] | nil) ::
-          {:ok, [String.t(), ...]} | {:error, [String.t()]}
+  @spec validate_selected_columns(
+          [Inspector.column_info()],
+          [String.t()],
+          [String.t(), ...] | nil
+        ) ::
+          {:ok, [String.t(), ...]} | {:error, {:columns, [String.t()]}}
   defp validate_selected_columns(_column_info, _pk_cols, nil) do
     {:ok, nil}
   end

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -218,12 +218,7 @@ defmodule Electric.Shapes.Shape do
 
     converted_changes
     |> Enum.map(&filter_change_columns(selected_columns, &1))
-    |> Enum.filter(
-      &case &1 do
-        %Changes.UpdatedRecord{old_record: old_record, record: record} -> old_record != record
-        _ -> true
-      end
-    )
+    |> Enum.filter(&filtered_columns_changed/1)
   end
 
   defp filter_change_columns(nil, change), do: change
@@ -231,6 +226,11 @@ defmodule Electric.Shapes.Shape do
   defp filter_change_columns(selected_columns, change) do
     Changes.filter_columns(change, selected_columns)
   end
+
+  defp filtered_columns_changed(%Changes.UpdatedRecord{old_record: record, record: record}),
+    do: false
+
+  defp filtered_columns_changed(_), do: true
 
   defp record_in_shape?(nil, _record), do: true
 

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -125,7 +125,7 @@ defmodule Electric.Shapes.Shape do
           ]}}
 
       true ->
-        {:ok, columns_to_select}
+        {:ok, Enum.sort(columns_to_select)}
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -208,12 +208,15 @@ defmodule Electric.Shapes.Shape do
     old_record_in_shape = record_in_shape?(where, old_record)
     new_record_in_shape = record_in_shape?(where, record)
 
-    case {old_record_in_shape, new_record_in_shape} do
-      {true, true} -> [change]
-      {true, false} -> [Changes.convert_update(change, to: :deleted_record)]
-      {false, true} -> [Changes.convert_update(change, to: :new_record)]
-      {false, false} -> []
-    end
+    converted_changes =
+      case {old_record_in_shape, new_record_in_shape} do
+        {true, true} -> [change]
+        {true, false} -> [Changes.convert_update(change, to: :deleted_record)]
+        {false, true} -> [Changes.convert_update(change, to: :new_record)]
+        {false, false} -> []
+      end
+
+    converted_changes
     |> Enum.map(&filter_change_columns(selected_columns, &1))
     |> Enum.filter(
       &case &1 do

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -100,7 +100,7 @@ defmodule Electric.Shapes.Shape do
           [String.t()],
           [String.t(), ...] | nil
         ) ::
-          {:ok, [String.t(), ...]} | {:error, {:columns, [String.t()]}}
+          {:ok, [String.t(), ...] | nil} | {:error, {:columns, [String.t()]}}
   defp validate_selected_columns(_column_info, _pk_cols, nil) do
     {:ok, nil}
   end

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -1,0 +1,5 @@
+defmodule Electric.Plug.UtilsTest do
+  alias Electric.Plug.Utils
+  use ExUnit.Case, async: true
+  doctest Utils, import: true
+end

--- a/packages/sync-service/test/electric/postgres/identifiers_test.exs
+++ b/packages/sync-service/test/electric/postgres/identifiers_test.exs
@@ -1,0 +1,5 @@
+defmodule Electric.Postgres.IdentifiersTest do
+  alias Electric.Postgres.Identifiers
+  use ExUnit.Case, async: true
+  doctest Identifiers, import: true
+end

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -205,7 +205,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
       ) {
         const fetchUrl = new URL(url)
         if (where) fetchUrl.searchParams.set(WHERE_QUERY_PARAM, where)
-        if (columns)
+        if (columns && columns.length > 0)
           fetchUrl.searchParams.set(COLUMNS_QUERY_PARAM, columns.join(`,`))
         fetchUrl.searchParams.set(OFFSET_QUERY_PARAM, this.#lastOffset)
 

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -19,6 +19,7 @@ import {
   CHUNK_LAST_OFFSET_HEADER,
   LIVE_CACHE_BUSTER_HEADER,
   LIVE_CACHE_BUSTER_QUERY_PARAM,
+  COLUMNS_QUERY_PARAM,
   LIVE_QUERY_PARAM,
   OFFSET_QUERY_PARAM,
   SHAPE_ID_HEADER,
@@ -37,9 +38,16 @@ export interface ShapeStreamOptions<T = never> {
    */
   url: string
   /**
-   * where clauses for the shape.
+   * The where clauses for the shape.
    */
   where?: string
+
+  /**
+   * The columns to include in the shape.
+   * Must include primary keys, and can only inlude valid columns.
+   */
+  columns?: string[]
+
   /**
    * The "offset" on the shape log. This is typically not set as the ShapeStream
    * will handle this automatically. A common scenario where you might pass an offset
@@ -188,7 +196,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
   async start() {
     this.#isUpToDate = false
 
-    const { url, where, signal } = this.options
+    const { url, where, columns, signal } = this.options
 
     try {
       while (
@@ -197,6 +205,8 @@ export class ShapeStream<T extends Row<unknown> = Row>
       ) {
         const fetchUrl = new URL(url)
         if (where) fetchUrl.searchParams.set(WHERE_QUERY_PARAM, where)
+        if (columns)
+          fetchUrl.searchParams.set(COLUMNS_QUERY_PARAM, columns.join(`,`))
         fetchUrl.searchParams.set(OFFSET_QUERY_PARAM, this.#lastOffset)
 
         if (this.#isUpToDate) {

--- a/packages/typescript-client/src/constants.ts
+++ b/packages/typescript-client/src/constants.ts
@@ -7,4 +7,5 @@ export const SHAPE_SCHEMA_HEADER = `electric-schema`
 export const SHAPE_ID_QUERY_PARAM = `shape_id`
 export const OFFSET_QUERY_PARAM = `offset`
 export const WHERE_QUERY_PARAM = `where`
+export const COLUMNS_QUERY_PARAM = `columns`
 export const LIVE_QUERY_PARAM = `live`

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -129,11 +129,17 @@ paths:
             Optional list of columns to include in the rows from the `root_table`.
 
             They should always include the primary key columns, and should be formed
-            as a comma separated list of column names exactly as they are on the database schema.
+            as a comma separated list of column names exactly as they are in the database schema.
+
+            If the identifier was defined as case sensitive and/or with special characters, then\
+            you must quote it in the `columns` parameter as well.
           examples:
             select_columns:
               value: "id,title,status"
-              summary: Only include the id, title, and status columns'.
+              summary: Only include the id, title, and status columns.
+            select_columns_special:
+              value: 'id,"Status-Check"'
+              summary: Only include id and Status-Check columns, quoting the identifiers where necessary.
         # Headers
         - name: If-None-Match
           in: header

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -120,6 +120,20 @@ paths:
             status_filter:
               value: '"status IN (''backlog'', ''todo'')"'
               summary: Only include rows whose status is either 'backlog' or 'todo'.
+
+        - name: columns
+          in: query
+          schema:
+            type: string
+          description: |-
+            Optional list of columns to include in the rows from the `root_table`.
+
+            They should always include the primary key columns, and should be formed
+            as a comma separated list of column names exactly as they are on the database schema.
+          examples:
+            select_columns:
+              value: "id,title,status"
+              summary: Only include the id, title, and status columns'.
         # Headers
         - name: If-None-Match
           in: header


### PR DESCRIPTION
Implements https://github.com/electric-sql/electric/issues/1804


### Overview
- I've picked `columns` as the query parameter name, as `select` might confuse people and get compared to SQL `SELECT`s, and `filter` is too close to what the `where` parameter does.
- The columns are comma separated column names, parsed at the validation stage
- If the parameter is specified, it *has to include* the primary key columns
  - We could make it such that the PK is always included, but it feels like it might be confusing - explicit is better?
  - For tables without a primary key, we treat _all_ columns as primary keys - we might want to revisit that w.r.t. to this feature
- Columns are validated also by ensuring that all specified column names match the ones in the schema
- The selected columns are stored in the `Shape` definition as an array of column names
  - We had the choice of potentially filtering the `table_info` data based on the selection of columns instead of storing them separately, but this might cause issues with relation change handling and generally I prefer the definition of the shape to contain all information related to it (i.e. the schema at the time of creation + what column filters where applied, rather than compacting the two)
- I modified `Shape` related APIs for converting changes etc to also apply the column filtering - this is all we need to ensure it works correctly for replication stream log entries
- In the `Snapshotter`, I modified a `get_column_names` method to also apply the filtering if present, which takes care of the snapshot log entries.

### Other changes
- I've changed `Shapes.new` to return the errors along with the field they are associated with (`:root_table` or `:where` or `:columns`) in order to return correct validation errors, since all of the stronger validation occrus at `cast_root_table` when the shape is created and PG is used but it really validates more than just `root_table`.
- I've updated the client to accept a `columns` argument which is a list of strings
- I've updated the OpenAPI spec to include the `columns` parameter

### Things to consider
- How do we want to handle column names with special names (quoted)? In my opinion the client needs to type them exactly as they are on postgres, otherwise they get a 400 validation error back telling them which columns are invalid, so it should be fairly easy to fix.
- Replication publication filtering of columns is available, but [updating it might cause errors](https://www.postgresql.org/docs/15/logical-replication-col-lists.html#LOGICAL-REPLICATION-COL-LIST-COMBINING) according to the PG docs, so I'm not sure if that's something we want to consider