### PR TITLE
feat: support array functions in where clauses

### DIFF
--- a/.changeset/sweet-papayas-shake.md
+++ b/.changeset/sweet-papayas-shake.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Implement support for array columns and operations over those in where clauses

--- a/packages/sync-service/lib/electric/replication/eval/env.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env.ex
@@ -33,7 +33,7 @@ defmodule Electric.Replication.Eval.Env do
   #   General info: https://www.postgresql.org/docs/current/extend-type-system.html#EXTEND-TYPES-POLYMORPHIC
   #   Example of why only hardcoded types are respected: https://github.com/postgres/postgres/blob/e8c334c47abb6c8f648cb50241c2cd65c9e4e6dc/src/backend/parser/parse_coerce.c#L1702
   @simple_polymorphic_types ~w|anyelement anyarray anynonarray anyenum anyrange anymultirange|a
-  @common_polymorphic_types ~w|anycompatible anycompatiblearray anycompatiblenonarray anycompatiblerange anycompatiblemultirange|
+  @common_polymorphic_types ~w|anycompatible anycompatiblearray anycompatiblenonarray anycompatiblerange anycompatiblemultirange|a
 
   ### Types
   @type flat_pg_type :: basic_type() | {:composite, map()} | :record | {:enum, term()}
@@ -120,6 +120,8 @@ defmodule Electric.Replication.Eval.Env do
     end)
   end
 
+  @text_types ~w|text varchar name bpchar|a
+
   @doc """
   Parse an unknown value constant as a known type in the current environment.
   """
@@ -127,10 +129,29 @@ defmodule Electric.Replication.Eval.Env do
   # Any type can be nullable in general
   def parse_const(%__MODULE__{}, nil, _), do: {:ok, nil}
   # Text is special-cased as never needing parsing
-  def parse_const(%__MODULE__{}, value, :text), do: {:ok, value}
-  def parse_const(%__MODULE__{}, value, :varchar), do: {:ok, value}
-  def parse_const(%__MODULE__{}, value, :name), do: {:ok, value}
-  def parse_const(%__MODULE__{}, value, :bpchar), do: {:ok, value}
+  def parse_const(%__MODULE__{}, value, x) when x in @text_types, do: {:ok, value}
+
+  def parse_const(%__MODULE__{}, value, {:array, subtype}) when subtype in @text_types do
+    {:ok, PgInterop.Array.parse(value)}
+  rescue
+    _ -> :error
+  end
+
+  def parse_const(%__MODULE__{funcs: funcs}, value, {:array, subtype}) do
+    with {:ok, overloads} <- Map.fetch(funcs, {to_string(subtype), 1}),
+         %{implementation: impl} <- Enum.find(overloads, &(&1.args == [:text])) do
+      try do
+        case impl do
+          {module, fun} -> {:ok, PgInterop.Array.parse(value, &apply(module, fun, [&1]))}
+          fun -> {:ok, PgInterop.Array.parse(value, &apply(fun, [&1]))}
+        end
+      rescue
+        _ -> :error
+      end
+    else
+      _ -> :error
+    end
+  end
 
   def parse_const(%__MODULE__{funcs: funcs}, value, type) do
     with {:ok, overloads} <- Map.fetch(funcs, {to_string(type), 1}),
@@ -183,14 +204,8 @@ defmodule Electric.Replication.Eval.Env do
   def is_preferred?(%__MODULE__{known_basic_types: types}, type),
     do: get_in(types, [type, :preferred?]) || false
 
-  @doc """
-  Check if a list of inputs can be implicitly coerced to a list of targets.
-
-  Note that other functions may not exactly support all of types
-  """
-  @spec can_implicitly_coerce_types?(t(), list(pg_type()), list(pg_type())) :: boolean()
   # This function implements logic from https://github.com/postgres/postgres/blob/e8c334c47abb6c8f648cb50241c2cd65c9e4e6dc/src/backend/parser/parse_coerce.c#L556
-  def can_implicitly_coerce_types?(%__MODULE__{} = env, inputs, targets) do
+  def get_unified_coercion_targets(%__MODULE__{} = env, inputs, targets, return_type \\ nil) do
     # PG has two "groups" of polymorphic types, that need to agree within themselves, but not across
     polymorphic_agg = %{simple: [], common: []}
 
@@ -200,6 +215,9 @@ defmodule Electric.Replication.Eval.Env do
       {input, input}, agg ->
         {:cont, agg}
 
+      {:unknown, _}, agg ->
+        {:cont, agg}
+
       {input, target}, agg when target in @simple_polymorphic_types ->
         {:cont, Map.update!(agg, :simple, &[{input, target} | &1])}
 
@@ -207,9 +225,6 @@ defmodule Electric.Replication.Eval.Env do
         {:cont, Map.update!(agg, :common, &[{input, target} | &1])}
 
       {_, :any}, agg ->
-        {:cont, agg}
-
-      {:unknown, _}, agg ->
         {:cont, agg}
 
       {:record, {:composite, _}}, agg ->
@@ -229,90 +244,143 @@ defmodule Electric.Replication.Eval.Env do
     end)
     |> case do
       :error ->
-        false
+        :error
 
       %{simple: [], common: []} ->
-        true
+        {:ok,
+         {replace_all_polymorphics(targets, :text, :text),
+          replace_polymorphics(return_type, :text, :text)}}
 
       %{simple: simple, common: common} ->
-        simple_polymorphics_agree?(simple) and common_polymorphics_agree?(common, env)
+        with {:ok, simple_consensus} <- simple_polymorphics_consensus(simple),
+             {:ok, common_consensus} <- common_polymorphics_consensus(common, env) do
+          {:ok,
+           {replace_all_polymorphics(targets, simple_consensus, common_consensus),
+            replace_polymorphics(return_type, simple_consensus, common_consensus)}}
+        end
     end
   end
 
-  defp simple_polymorphics_agree?(args, consensus \\ nil)
-  defp simple_polymorphics_agree?([], _), do: true
+  defp replace_all_polymorphics(types, simple, common),
+    do: Enum.map(types, &replace_polymorphics(&1, simple, common))
+
+  defp replace_polymorphics(type, simple_consensus, _) when type in [:anyelement, :anynonarray],
+    do: simple_consensus
+
+  defp replace_polymorphics(:anyarray, simple_consensus, _), do: {:array, simple_consensus}
+  defp replace_polymorphics(:anyenum, simple_consensus, _), do: {:enum, simple_consensus}
+  defp replace_polymorphics(:anyrange, simple_consensus, _), do: {:range, simple_consensus}
+
+  defp replace_polymorphics(:anymultirange, simple_consensus, _),
+    do: {:multirange, simple_consensus}
+
+  defp replace_polymorphics(type, _, common_consensus)
+       when type in [:anycompatible, :anycompatiblenonarray],
+       do: common_consensus
+
+  defp replace_polymorphics(:anycompatiblearray, _, common_consensus),
+    do: {:array, common_consensus}
+
+  defp replace_polymorphics(:anycompatiblerange, _, common_consensus),
+    do: {:range, common_consensus}
+
+  defp replace_polymorphics(:anycompatiblemultirange, _, common_consensus),
+    do: {:multirange, common_consensus}
+
+  defp replace_polymorphics(target, _, _), do: target
+
+  @doc """
+  Check if a list of inputs can be implicitly coerced to a list of targets.
+
+  Note that other functions may not exactly support all of types
+  """
+  @spec can_implicitly_coerce_types?(t(), list(pg_type()), list(pg_type())) :: boolean()
+  # This function implements logic from https://github.com/postgres/postgres/blob/e8c334c47abb6c8f648cb50241c2cd65c9e4e6dc/src/backend/parser/parse_coerce.c#L556
+  def can_implicitly_coerce_types?(%__MODULE__{} = env, inputs, targets) do
+    get_unified_coercion_targets(env, inputs, targets) != :error
+  end
+
+  defp simple_polymorphics_consensus(args, consensus \\ nil)
+  defp simple_polymorphics_consensus([], consensus), do: {:ok, consensus}
 
   # Check both that the element can satisfy the container limitation, and that the contained type matches
-  defp simple_polymorphics_agree?([{{:array, elem}, :anyarray} | tail], x)
+  defp simple_polymorphics_consensus([{{:array, elem}, :anyarray} | tail], x)
        when is_nil(x) or x == elem,
-       do: simple_polymorphics_agree?(tail, elem)
+       do: simple_polymorphics_consensus(tail, elem)
 
-  defp simple_polymorphics_agree?([{{:range, elem}, :anyrange} | tail], x)
+  defp simple_polymorphics_consensus([{{:range, elem}, :anyrange} | tail], x)
        when is_nil(x) or x == elem,
-       do: simple_polymorphics_agree?(tail, elem)
+       do: simple_polymorphics_consensus(tail, elem)
 
-  defp simple_polymorphics_agree?([{{:multirange, elem}, :anymultirange} | tail], x)
+  defp simple_polymorphics_consensus([{{:multirange, elem}, :anymultirange} | tail], x)
        when is_nil(x) or x == elem,
-       do: simple_polymorphics_agree?(tail, elem)
+       do: simple_polymorphics_consensus(tail, elem)
 
   # `:anyarray`, `:anyrange`, and `:anymultirange` basically "unwrap" values, but anything else doesn't
-  defp simple_polymorphics_agree?([{{:array, _}, :anynonarray} | _], _), do: false
-  defp simple_polymorphics_agree?([{_, :anynonarray} | _], {:array, _}), do: false
+  defp simple_polymorphics_consensus([{{:array, _}, :anynonarray} | _], _), do: :error
+  defp simple_polymorphics_consensus([{_, :anynonarray} | _], {:array, _}), do: :error
 
-  defp simple_polymorphics_agree?([{elem, :anynonarray} | tail], x)
+  defp simple_polymorphics_consensus([{elem, :anynonarray} | tail], x)
        when is_nil(x) or elem == x,
-       do: simple_polymorphics_agree?(tail, elem)
+       do: simple_polymorphics_consensus(tail, elem)
 
-  defp simple_polymorphics_agree?([{{:enum, _} = elem, :anyenum} | tail], x)
+  defp simple_polymorphics_consensus([{{:enum, _} = elem, :anyenum} | tail], x)
        when is_nil(x) or elem == x,
-       do: simple_polymorphics_agree?(tail, elem)
+       do: simple_polymorphics_consensus(tail, elem)
 
-  defp simple_polymorphics_agree?([{elem, :anyelement} | tail], x) when is_nil(x) or elem == x,
-    do: simple_polymorphics_agree?(tail, elem)
+  defp simple_polymorphics_consensus([{elem, :anyelement} | tail], x) when is_nil(x) or elem == x,
+    do: simple_polymorphics_consensus(tail, elem)
 
   # If all guards failed, then we bail
-  defp simple_polymorphics_agree?(_, _), do: false
+  defp simple_polymorphics_consensus(_, _), do: :error
 
-  defp common_polymorphics_agree?([], _), do: true
+  defp common_polymorphics_consensus([], _), do: {:ok, nil}
 
-  defp common_polymorphics_agree?(args, env) do
+  defp common_polymorphics_consensus(args, env) do
     # Logic in this loop tries to find common supertype for provided inputs, following same logic as
     # https://github.com/postgres/postgres/blob/e8c334c47abb6c8f648cb50241c2cd65c9e4e6dc/src/backend/parser/parse_coerce.c#L1443
 
     {{consensus, _, _}, seen_nonarray?} =
-      for {input, target} <- args,
-          input = unwrap(input, target),
-          category = get_type_category(env, input),
-          preferred? = is_preferred?(env, input),
-          nonarray? = target == :anycompatiblenonarray,
-          reduce: {{nil, nil, false}, false} do
-        {{nil, _, _}, _} ->
-          {{input, category, preferred?}, nonarray?}
+      Enum.reduce(args, {{nil, nil, false}, false}, fn {input, target}, acc ->
+        input = unwrap(input, target)
+        category = get_type_category(env, input)
+        preferred? = is_preferred?(env, input)
+        nonarray? = target == :anycompatiblenonarray
 
-        # Same category, keep preferred
-        {{_, ^category, true} = old, seen_nonarray?} ->
-          {old, seen_nonarray? or nonarray?}
+        case acc do
+          {{nil, _, _}, _} ->
+            {{input, category, preferred?}, nonarray?}
 
-        {{cur_type, ^category, _} = old, seen_nonarray?} ->
-          # Take new type if can coerce to it but not the other way
-          if implicitly_castable?(env, cur_type, input) and
-               not implicitly_castable?(env, input, cur_type) do
-            {{input, category, preferred?}, seen_nonarray? or nonarray?}
-          else
+          {{_, ^category, true} = old, seen_nonarray?} ->
             {old, seen_nonarray? or nonarray?}
-          end
 
-        # Differing category, irreconcilable
-        {_, _} ->
-          throw(:unsatisfied_polymorphic_constraint)
-      end
+          {{cur_type, ^category, _} = old, seen_nonarray?} ->
+            # Take new type if can coerce to it but not the other way
+            if implicitly_castable?(env, cur_type, input) and
+                 not implicitly_castable?(env, input, cur_type) do
+              {{input, category, preferred?}, seen_nonarray? or nonarray?}
+            else
+              {old, seen_nonarray? or nonarray?}
+            end
+
+          # Differing category, irreconcilable
+          {_, _} ->
+            throw(:unsatisfied_polymorphic_constraint)
+        end
+      end)
 
     # If any of polymorphic variables are `nonarray`, then consensus cannot be array
     # and all inputs have to be actually castable to the consensus
-    not (seen_nonarray? and match?({:array, _}, consensus)) and
-      Enum.all?(args, fn {input, _} -> implicitly_castable?(env, input, consensus) end)
+    if not (seen_nonarray? and match?({:array, _}, consensus)) and
+         Enum.all?(args, fn {input, target} ->
+           implicitly_castable?(env, unwrap(input, target), consensus)
+         end) do
+      {:ok, consensus}
+    else
+      :error
+    end
   catch
-    :unsatisfied_polymorphic_constraint -> false
+    :unsatisfied_polymorphic_constraint -> :error
   end
 
   defp unwrap({:array, value}, :anycompatiblearray), do: value

--- a/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
@@ -141,4 +141,55 @@ defmodule Electric.Replication.Eval.Env.KnownFunctions do
     def naive_from_timestamptz(tz, datetime),
       do: datetime |> DateTime.shift_zone!(tz) |> DateTime.to_naive()
   end
+
+  ## Array functions
+  defpostgres("anyarray = anyarray -> bool", delegate: &Kernel.==/2)
+  defpostgres("anyarray <> anyarray -> bool", delegate: &Kernel.!=/2)
+
+  defpostgres("anycompatiblearray || anycompatiblearray -> anycompatiblearray",
+    delegate: &PgInterop.Array.concat_arrays/2
+  )
+
+  defpostgres("array_cat(anycompatiblearray, anycompatiblearray) -> anycompatiblearray",
+    delegate: &PgInterop.Array.concat_arrays/2
+  )
+
+  defpostgres("anycompatible || anycompatiblearray -> anycompatiblearray",
+    delegate: &PgInterop.Array.array_prepend/2
+  )
+
+  defpostgres("array_prepend(anycompatible, anycompatiblearray) -> anycompatiblearray",
+    delegate: &PgInterop.Array.array_prepend/2
+  )
+
+  defpostgres("anycompatiblearray || anycompatible -> anycompatiblearray",
+    delegate: &PgInterop.Array.array_append/2
+  )
+
+  defpostgres("array_append(anycompatiblearray, anycompatible) -> anycompatiblearray",
+    delegate: &PgInterop.Array.array_append/2
+  )
+
+  defpostgres("array_ndims(anyarray) -> int4", delegate: &PgInterop.Array.get_array_dim/1)
+
+  defpostgres "anyarray @> anyarray -> bool" do
+    def left_array_contains_right?(left, right) do
+      MapSet.subset?(MapSet.new(right), MapSet.new(left))
+    end
+  end
+
+  defpostgres "anyarray <@ anyarray -> bool" do
+    def right_array_contains_left?(left, right) do
+      MapSet.subset?(MapSet.new(left), MapSet.new(right))
+    end
+  end
+
+  defpostgres "anyarray && anyarray -> bool" do
+    def arrays_overlap?(left, right) when left == [] or right == [], do: false
+
+    def arrays_overlap?(left, right) do
+      left_mapset = MapSet.new(left)
+      Enum.any?(right, &MapSet.member?(left_mapset, &1))
+    end
+  end
 end

--- a/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
@@ -15,6 +15,7 @@ defmodule Electric.Replication.Eval.Env.KnownFunctions do
   defpostgres("numeric(text) -> numeric", delegate: &Casting.parse_float8/1)
   defpostgres("bool(text) -> bool", delegate: &Casting.parse_bool/1)
   defpostgres("uuid(text) -> uuid", delegate: &Casting.parse_uuid/1)
+  defpostgres("text(text) -> text", delegate: &BasicTypes.noop/1)
   defpostgres("date(text) -> date", delegate: &Casting.parse_date/1)
   defpostgres("time(text) -> time", delegate: &Casting.parse_time/1)
   defpostgres("timestamp(text) -> timestamp", delegate: &Casting.parse_timestamp/1)

--- a/packages/sync-service/lib/electric/replication/eval/lookups.ex
+++ b/packages/sync-service/lib/electric/replication/eval/lookups.ex
@@ -3,6 +3,67 @@ defmodule Electric.Replication.Eval.Lookups do
   alias Electric.Replication.Eval.Env
 
   @doc """
+  Given a list of types, get a candidate type that best represents the union of all types.
+
+  Algorithm implements Postgres type resolution for `UNION`, `CASE`, and related constructs, like
+  `ARRAY[]` constructor syntax. They are outlined in
+  [documentation](https://www.postgresql.org/docs/current/typeconv-union-case.html).
+
+  1. If all inputs are of the same type, and it is not unknown, resolve as that type.
+  2. If any input is of a domain type, treat it as being of the domain's base type for all subsequent steps.
+  3. If all inputs are of type unknown, resolve as type text (the preferred type of the string category).
+     Otherwise, unknown inputs are ignored for the purposes of the remaining rules.
+  4. If the non-unknown inputs are not all of the same type category, fail.
+  5. Select the first non-unknown input type as the candidate type, then consider each other non-unknown input type, left to right.
+     If the candidate type can be implicitly converted to the other type but not vice-versa, select the other type as the new
+     candidate type. Then continue considering the remaining inputs.
+     If, at any stage of this process, a preferred type is selected, stop considering additional inputs.
+  6. Convert all inputs to the final candidate type. Fail if there is not an implicit conversion from a given input type to the candidate type.
+  """
+  def pick_union_type(args, env) do
+    Enum.reduce_while(args, {:ok, :unknown}, fn
+      # Skip unknowns
+      x, state when is_map_key(x, :type) and x.type == :unknown or not is_map_key(x, :type) ->
+        {:cont, state}
+
+      # Take the first non-unknown type
+      %{type: type}, {:ok, :unknown} ->
+        {:cont, {:ok, type}}
+
+      # Skip duplicates
+      %{type: type}, {:ok, candidate} when type == candidate ->
+        {:cont, {:ok, candidate}}
+
+      %{type: type}, {:ok, candidate} ->
+        cond do
+          # Fail if categories differ
+          Env.get_type_category(env, type) != Env.get_type_category(env, candidate) ->
+            {:halt, {:error, type, candidate}}
+
+          # Preferred type wins, but keep going to check for errors
+          Env.is_preferred?(env, type) ->
+            {:cont, {:ok, type}}
+
+          # Preferred type wins, but keep going to check for errors
+          Env.is_preferred?(env, candidate) ->
+            {:cont, {:ok, candidate}}
+
+          # If implicit coercion is possible in one direction, pick that type
+          Env.can_implicitly_coerce_types?(env, [candidate], [type]) and
+              not Env.can_implicitly_coerce_types?(env, [type], [candidate]) ->
+            {:cont, {:ok, type}}
+
+          true ->
+            {:cont, {:ok, type}}
+        end
+    end)
+    |> case do
+      {:ok, :unknown} -> {:ok, :text}
+      result -> result
+    end
+  end
+
+  @doc """
   Given multiple possible operator overloads (same name and arity), try to
   find a concrete implementation that matches the argument types.
 

--- a/packages/sync-service/lib/electric/replication/eval/runner.ex
+++ b/packages/sync-service/lib/electric/replication/eval/runner.ex
@@ -1,5 +1,6 @@
 defmodule Electric.Replication.Eval.Runner do
   require Logger
+  alias Electric.Utils
   alias Electric.Replication.Eval.Expr
   alias Electric.Replication.Eval.Env
   alias Electric.Replication.Eval.Parser.{Const, Func, Ref}
@@ -81,8 +82,8 @@ defmodule Electric.Replication.Eval.Runner do
     case {impl, applied_to_array?} do
       {{module, fun}, false} -> apply(module, fun, args)
       {fun, false} -> apply(fun, args)
-      {{module, fun}, true} -> Utils.deep_map(hd(args), &apply(module, fun, [&1]))
-      {fun, true} -> Utils.deep_map(hd(args), &apply(fun, [&1]))
+      {{module, fun}, true} -> Utils.deep_map(hd(args), &apply(module, fun, tl(args) ++ [&1]))
+      {fun, true} -> Utils.deep_map(hd(args), &apply(fun, tl(args) ++ [&1]))
     end
   rescue
     _ ->

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -93,6 +93,20 @@ defmodule Electric.Utils do
   end
 
   @doc """
+  Apply a function to each element of an enumerable, recursively if the element is an enumerable itself.
+
+  ## Examples
+
+      iex> deep_map([1, [2, [3]], 4], &(&1 * 2))
+      [2, [4, [6]], 8]
+  """
+  @spec deep_map(Enumerable.t(elem), (elem -> result)) :: list(result)
+        when elem: var, result: var
+  def deep_map(enum, fun) when is_function(fun, 1) do
+    Enum.map(enum, &if(Enumerable.impl_for(&1), do: deep_map(&1, fun), else: fun.(&1)))
+  end
+
+  @doc """
   Return a list of values from `enum` that are the maximal elements as calculated
   by the given `fun`.
 

--- a/packages/sync-service/lib/pg_interop/array.ex
+++ b/packages/sync-service/lib/pg_interop/array.ex
@@ -5,7 +5,7 @@ defmodule PgInterop.Array do
   Parse a Postgres string-serialized array into a list of strings, unwrapping the escapes. Parses nested arrays.
   If a casting function is provided, it will be applied to each element.
 
-  Parsing follows SOME ofthe same rules as the postgres parser, in particular:
+  Parsing follows SOME of the same rules as the postgres parser, in particular:
   1. at most 6 nesting levels are allowed,
   2. arrays must be of uniform dimension, i.e. all sub-arrays must have the same number of elements if at the same depth.
 

--- a/packages/sync-service/lib/pg_interop/array.ex
+++ b/packages/sync-service/lib/pg_interop/array.ex
@@ -5,9 +5,14 @@ defmodule PgInterop.Array do
   Parse a Postgres string-serialized array into a list of strings, unwrapping the escapes. Parses nested arrays.
   If a casting function is provided, it will be applied to each element.
 
-  Parsing follows the same rules as the postgres parser, in particular:
+  Parsing follows SOME ofthe same rules as the postgres parser, in particular:
   1. at most 6 nesting levels are allowed,
   2. arrays must be of uniform dimension, i.e. all sub-arrays must have the same number of elements if at the same depth.
+
+  This implementation also breaks away from the postgres parser in that some bugs are NOT reimplemented:
+  - `select '{{1},{{2}}}'::text[];` yields `{{{1}},{{2}}}` in PG, we raise an error
+  - `select '{{{1}},{2}}'::text[];` yields `{}` in PG, we raise an error
+  - `select '{{{1}},{2},{{3}}}::text[];` yields `{{{1}},{{NULL}},{{3}}}` in PG, we raise an error
 
   ## Examples
 

--- a/packages/sync-service/lib/pg_interop/array.ex
+++ b/packages/sync-service/lib/pg_interop/array.ex
@@ -1,0 +1,130 @@
+defmodule PgInterop.Array do
+  @doc ~S"""
+  Parse a Postgres string-serialized array into a list of strings, unwrapping the escapes. Parses nested arrays.
+  If a casting function is provided, it will be applied to each element.
+
+  ## Examples
+
+      iex> ~S|{"(\"2023-06-15 11:18:05.372698+00\",)"}| |> parse()
+      [~s|("2023-06-15 11:18:05.372698+00",)|]
+
+      iex> ~S|{"(\"2023-06-15 11:18:05.372698+00\",)","(\"2023-06-15 11:18:05.372698+00\",)"}| |> parse()
+      [~s|("2023-06-15 11:18:05.372698+00",)|, ~s|("2023-06-15 11:18:05.372698+00",)|]
+
+      iex> ~S|{"2023-06-15 11:18:05.372698+00",2023-06-15 11:18:05.372698+00}| |> parse(fn x -> {:ok, n, _} = DateTime.from_iso8601(x); n end)
+      [~U[2023-06-15 11:18:05.372698Z], ~U[2023-06-15 11:18:05.372698Z]]
+
+      iex> ~s|{'foo', 'bar{}', "tableName",'{baz,quux}', '}},,,{{',id, ",,\\"{}"}| |> parse()
+      ["'foo'", "'bar{}'", "tableName", "'{baz,quux}'", "'}},,,{{'", "id", ",,\"{}"]
+
+      iex> ~s|{{1},{2},{3}}| |> parse(&String.to_integer/1)
+      [[1], [2], [3]]
+
+      iex> ~s|{1,2,{3}}| |> parse(&String.to_integer/1)
+      ** (RuntimeError) Invalid array syntax at "{3}}"
+
+      iex> ~S|{"(\"2023-06-15 11:18:05.372698+00\",)"}}| |> parse()
+      ** (RuntimeError) Invalid array syntax at "}"
+  """
+  def parse(string, casting_fun \\ & &1) do
+    case parse_with_tail(string, casting_fun) do
+      {result, ""} -> result
+      {_, rest} -> raise("Invalid array syntax at #{inspect(rest)}")
+    end
+  end
+
+  defp parse_with_tail("{}" <> str, _), do: {[], str}
+  defp parse_with_tail("{" <> str, casting_fun), do: parse_pg_array_elem(str, casting_fun)
+  defp parse_with_tail("," <> str, casting_fun), do: parse_pg_array_elem(str, casting_fun)
+  defp parse_with_tail("}" <> str, _), do: {[], str}
+  defp parse_with_tail(str, _), do: {[], str}
+
+  # skip whitespace
+  defp parse_pg_array_elem(<<space>> <> str, casting_fun) when space in [?\s, ?\t, ?\n] do
+    parse_pg_array_elem(str, casting_fun)
+  end
+
+  # quoted element, scan until the next non-escaped quote
+  defp parse_pg_array_elem(<<q>> <> str, casting_fun) when q in [?", ?'] do
+    {elem, rest} = scan_until_quote(str, q, put_single_quote("", q))
+    {result, rest} = parse_with_tail(rest, casting_fun)
+    {[casting_fun.(elem) | result], rest}
+  end
+
+  # a nested array, parse that
+  defp parse_pg_array_elem(<<q>> <> str, casting_fun) when q in [?{] do
+    {elem, rest} = parse_with_tail(<<q>> <> str, casting_fun)
+    {result, rest} = parse_with_tail(rest, casting_fun)
+    {[elem | result], rest}
+  end
+
+  # regular identifier, parse it whole until the next comma or end of the array
+  defp parse_pg_array_elem(str, casting_fun) do
+    {elem, rest} = scan_until_comma_or_end(str, "")
+    {result, rest} = parse_with_tail(rest, casting_fun)
+    {[casting_fun.(elem) | result], rest}
+  end
+
+  # closing quote, return
+  defp scan_until_quote(<<q>> <> rest, q, acc) do
+    {put_single_quote(acc, q), rest}
+  end
+
+  # escaped quote, keep going
+  defp scan_until_quote(<<?\\, q>> <> str, q, acc) do
+    scan_until_quote(str, q, acc <> <<q>>)
+  end
+
+  # escaped backslash, keep going
+  defp scan_until_quote(<<?\\, ?\\>> <> str, q, acc) do
+    scan_until_quote(str, q, acc <> <<?\\>>)
+  end
+
+  # regular character, keep going
+  defp scan_until_quote(<<c>> <> str, q, acc) do
+    scan_until_quote(str, q, acc <> <<c>>)
+  end
+
+  defp scan_until_comma_or_end("}" <> _ = rest, acc) do
+    {acc, rest}
+  end
+
+  defp scan_until_comma_or_end(<<?,>> <> _ = str, acc) do
+    {acc, str}
+  end
+
+  defp scan_until_comma_or_end(<<c>> <> str, acc) do
+    scan_until_comma_or_end(str, acc <> <<c>>)
+  end
+
+  defp put_single_quote(str, ?"), do: str
+  defp put_single_quote(str, ?'), do: str <> <<?'>>
+
+  @doc ~S"""
+  Serialize a list of strings into a postgres string-serialized array into a list of strings, wrapping the contents
+
+  ## Examples
+
+      iex> [~s|("2023-06-15 11:18:05.372698+00",)|] |> serialize()
+      ~S|{"(\"2023-06-15 11:18:05.372698+00\",)"}|
+
+      iex> [~s|("2023-06-15 11:18:05.372698+00",)|, ~s|("2023-06-15 11:18:05.372698+00",)|] |> serialize()
+      ~S|{"(\"2023-06-15 11:18:05.372698+00\",)","(\"2023-06-15 11:18:05.372698+00\",)"}|
+
+      iex> str = ~S|{"(\"2023-06-15 11:18:05.372698+00\",)","(\"2023-06-15 11:18:05.372698+00\",)"}|
+      iex> str |> parse() |> serialize()
+      str
+  """
+  def serialize(array, quote_char \\ ?") when is_list(array) do
+    array
+    |> Enum.map_join(",", fn
+      nil -> "null"
+      val when is_binary(val) -> val |> String.replace(~S|"|, ~S|\"|) |> enclose(<<quote_char>>)
+    end)
+    |> enclose("{", "}")
+  end
+
+  defp enclose(str, left, right \\ nil) do
+    left <> str <> (right || left)
+  end
+end

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -464,9 +464,9 @@ defmodule Electric.Replication.Eval.ParserTest do
       # TODO: Does not support arbitrary bounds input syntax yet,
       #       e.g. '[1:1][-2:-1][3:5]={{{1,2,3},{4,5,6}}}'::int[]
       assert {:ok, %Expr{eval: result}} =
-               Parser.parse_and_validate_expression(~S|'{1,2,{"3"}}'::int[]|)
+               Parser.parse_and_validate_expression(~S|'{{1   },{2},{"3"}}'::int[]|)
 
-      assert %Const{value: [1, 2, [3]], type: {:array, :int4}} = result
+      assert %Const{value: [[1], [2], [3]], type: {:array, :int4}} = result
 
       assert {:ok, %Expr{eval: result}} =
                Parser.parse_and_validate_expression(~S|ARRAY[ARRAY[1, 2], ARRAY['3', 2 + 2]]|)

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -67,6 +67,44 @@ defmodule Electric.Replication.Eval.RunnerTest do
                ~S|ARRAY[ARRAY[1, x], ARRAY['3', 2 + 2]]|
                |> Parser.parse_and_validate_expression!(%{["x"] => :int4})
                |> Runner.execute(%{["x"] => 2})
+
+      assert {:ok, true} =
+               ~S|x @> ARRAY[y]|
+               |> Parser.parse_and_validate_expression!(%{
+                 ["x"] => {:array, :int4},
+                 ["y"] => :int4
+               })
+               |> Runner.execute(%{["y"] => 1, ["x"] => [1, 2]})
+
+      assert {:ok, true} =
+               ~S|x::float[] = y::int4[]::float[]|
+               |> Parser.parse_and_validate_expression!(%{
+                 ["x"] => {:array, :int4},
+                 ["y"] => :text
+               })
+               |> Runner.execute(%{["y"] => "{1,2}", ["x"] => [1, 2]})
+
+      assert {:ok, true} =
+               ~S|y = ANY (x)|
+               |> Parser.parse_and_validate_expression!(%{
+                 ["x"] => {:array, :int4},
+                 ["y"] => :int8
+               })
+               |> Runner.execute(%{["y"] => 1, ["x"] => [1, 2]})
+
+      assert {:ok, [[1, 2], [3, 4]]} =
+               ~S/(ARRAY[1] || ARRAY[2]) || x/
+               |> Parser.parse_and_validate_expression!(%{
+                 ["x"] => {:array, :float8}
+               })
+               |> Runner.execute(%{["x"] => [[3, 4]]})
+
+      assert {:error, _} =
+               ~S/(ARRAY[1] || ARRAY[2]) || x/
+               |> Parser.parse_and_validate_expression!(%{
+                 ["x"] => {:array, :int4}
+               })
+               |> Runner.execute(%{["x"] => [[[3, 4]]]})
     end
   end
 end

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -61,5 +61,12 @@ defmodule Electric.Replication.Eval.RunnerTest do
                |> Parser.parse_and_validate_expression!(%{["test"] => :int4})
                |> Runner.execute(%{["test"] => "test"})
     end
+
+    test "should work with array types" do
+      assert {:ok, [[1, 2], [3, 4]]} =
+               ~S|ARRAY[ARRAY[1, x], ARRAY['3', 2 + 2]]|
+               |> Parser.parse_and_validate_expression!(%{["x"] => :int4})
+               |> Runner.execute(%{["x"] => 2})
+    end
   end
 end

--- a/packages/sync-service/test/pg_interop/array_test.exs
+++ b/packages/sync-service/test/pg_interop/array_test.exs
@@ -1,0 +1,5 @@
+defmodule PgInterop.ArrayTest do
+  use ExUnit.Case
+
+  doctest PgInterop.Array, import: true
+end

--- a/packages/sync-service/test/pg_interop/array_test.exs
+++ b/packages/sync-service/test/pg_interop/array_test.exs
@@ -1,5 +1,5 @@
 defmodule PgInterop.ArrayTest do
   use ExUnit.Case
 
-  doctest PgInterop.Array, import: true
+  doctest PgInterop.Array, import: true, only: [parse: 2]
 end


### PR DESCRIPTION
Adds support for:
1. Usage of array columns in where clauses
2. Base operators for arrays: `@>`, `<@`, `&&`, `||`
3. Validation for polymorphic operators (`anyarray` pseudo-type and others), paving way for other functions that accept arrays 

Closes #1767, #1766 