### PR TITLE
chore(sync-service): Move queries that query Postgres for a bunch of info into ReplicationClient's connection setup phase

### DIFF
--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -73,10 +73,15 @@ defmodule Electric.ConnectionManager do
 
   @lock_status_logging_interval 10_000
 
+  @spec start_link(options) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: @name)
+  end
+
   @doc """
   Returns the version of the PostgreSQL server.
   """
-  @spec get_pg_version(GenServer.server()) :: float()
+  @spec get_pg_version(GenServer.server()) :: integer()
   def get_pg_version(server) do
     GenServer.call(server, :get_pg_version)
   end
@@ -89,9 +94,12 @@ defmodule Electric.ConnectionManager do
     GenServer.call(server, :get_status)
   end
 
-  @spec start_link(options) :: GenServer.on_start()
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: @name)
+  def exclusive_connection_lock_acquired(server) do
+    GenServer.cast(server, :exclusive_connection_lock_acquired)
+  end
+
+  def pg_version_looked_up(server, pg_version) do
+    GenServer.cast(server, {:pg_version_looked_up, pg_version})
   end
 
   @impl true
@@ -111,6 +119,7 @@ defmodule Electric.ConnectionManager do
       opts
       |> Keyword.fetch!(:replication_opts)
       |> Keyword.put(:start_streaming?, false)
+      |> Keyword.put(:connection_manager, self())
 
     pool_opts = Keyword.fetch!(opts, :pool_opts)
 
@@ -293,15 +302,15 @@ defmodule Electric.ConnectionManager do
   end
 
   @impl true
-  def handle_cast({:pg_version, pg_version}, state) do
-    {:noreply, %{state | pg_version: pg_version}}
-  end
-
-  def handle_cast(:lock_connection_acquired, %{pg_lock_acquired: false} = state) do
+  def handle_cast(:exclusive_connection_lock_acquired, %{pg_lock_acquired: false} = state) do
     # As soon as we acquire the connection lock, we try to start the replication connection
     # first because it requires additional privileges compared to regular "pooled" connections,
     # so failure to open a replication connection should be reported ASAP.
     {:noreply, %{state | pg_lock_acquired: true}, {:continue, :start_replication_client}}
+  end
+
+  def handle_cast({:pg_version_looked_up, pg_version}, state) do
+    {:noreply, %{state | pg_version: pg_version}}
   end
 
   defp start_replication_client(electric_instance_id, connection_opts, replication_opts) do

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -219,10 +219,7 @@ defmodule Electric.ConnectionManager do
 
         # Now that we have a ShapeCache process running under Shapes.Supervisor, we can run the
         # timeline check.
-        Electric.Timeline.check(
-          {get_pg_id(pool_pid), get_pg_timeline(pool_pid)},
-          state.timeline_opts
-        )
+        Electric.Timeline.check(get_pg_timeline(pool_pid), state.timeline_opts)
 
         # Everything is ready to start accepting and processing logical messages from Postgres.
         Electric.Postgres.ReplicationClient.start_streaming(state.replication_client_pid)
@@ -501,16 +498,19 @@ defmodule Electric.ConnectionManager do
     Keyword.put(connection_opts, :socket_options, tcp_opts)
   end
 
-  defp get_pg_id(conn) do
-    case Postgrex.query!(conn, "SELECT system_identifier FROM pg_control_system()", []) do
-      %Postgrex.Result{rows: [[system_identifier]]} -> system_identifier
-    end
-  end
-
   defp get_pg_timeline(conn) do
-    case Postgrex.query!(conn, "SELECT timeline_id FROM pg_control_checkpoint()", []) do
-      %Postgrex.Result{rows: [[timeline_id]]} -> timeline_id
-    end
+    %Postgrex.Result{rows: [[system_identifier, timeline_id]]} =
+      Postgrex.query!(
+        conn,
+        """
+        SELECT
+          (pg_control_system()).system_identifier,
+          (pg_control_checkpoint()).timeline_id
+        """,
+        []
+      )
+
+    {system_identifier, timeline_id}
   end
 
   defp lookup_log_collector_pid(shapes_supervisor) do

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -28,29 +28,34 @@ defmodule Electric.ConnectionManager do
 
   defmodule State do
     defstruct [
-      # Database connection opts to be passed to Postgrex modules.
+      # Database connection opts to be passed to Postgrex modules
       :connection_opts,
-      # Replication options specific to `Electric.Postgres.ReplicationClient`.
+      # Replication options specific to `Electric.Postgres.ReplicationClient`
       :replication_opts,
-      # Database connection pool options.
+      # Database connection pool options
       :pool_opts,
-      # Options specific to `Electric.Timeline`.
+      # Options specific to `Electric.Timeline`
       :timeline_opts,
-      # PID of the replication client.
+      # PID of the replication client
       :replication_client_pid,
-      # PID of the Postgres connection lock.
+      # PID of the Postgres connection lock
       :lock_connection_pid,
-      # PID of the database connection pool (a `Postgrex` process).
+      # PID of the database connection pool
       :pool_pid,
       # PID of the shape log collector
       :shape_log_collector_pid,
-      # Backoff term used for reconnection with exponential back-off.
+      # Backoff term used for reconnection with exponential back-off
       :backoff,
-      # Flag indicating whether the lock on the replication has been acquired.
+      # Flag indicating whether the lock on the replication has been acquired
       :pg_lock_acquired,
       # PostgreSQL server version
       :pg_version,
-      :electric_instance_id
+      # Electric instance ID is used for connection process labeling
+      :electric_instance_id,
+      # PostgreSQL system identifier
+      :pg_system_identifier,
+      # PostgreSQL timeline ID
+      :pg_timeline_id
     ]
   end
 
@@ -98,8 +103,8 @@ defmodule Electric.ConnectionManager do
     GenServer.cast(server, :exclusive_connection_lock_acquired)
   end
 
-  def pg_version_looked_up(server, pg_version) do
-    GenServer.cast(server, {:pg_version_looked_up, pg_version})
+  def pg_info_looked_up(server, pg_info) do
+    GenServer.cast(server, {:pg_info_looked_up, pg_info})
   end
 
   @impl true
@@ -219,7 +224,10 @@ defmodule Electric.ConnectionManager do
 
         # Now that we have a ShapeCache process running under Shapes.Supervisor, we can run the
         # timeline check.
-        Electric.Timeline.check(get_pg_timeline(pool_pid), state.timeline_opts)
+        Electric.Timeline.check(
+          {state.pg_system_identifier, state.pg_timeline_id},
+          state.timeline_opts
+        )
 
         # Everything is ready to start accepting and processing logical messages from Postgres.
         Electric.Postgres.ReplicationClient.start_streaming(state.replication_client_pid)
@@ -306,8 +314,14 @@ defmodule Electric.ConnectionManager do
     {:noreply, %{state | pg_lock_acquired: true}, {:continue, :start_replication_client}}
   end
 
-  def handle_cast({:pg_version_looked_up, pg_version}, state) do
-    {:noreply, %{state | pg_version: pg_version}}
+  def handle_cast({:pg_info_looked_up, {server_version, system_identifier, timeline_id}}, state) do
+    {:noreply,
+     %{
+       state
+       | pg_version: server_version,
+         pg_system_identifier: system_identifier,
+         pg_timeline_id: timeline_id
+     }}
   end
 
   defp start_replication_client(electric_instance_id, connection_opts, replication_opts) do
@@ -496,21 +510,6 @@ defmodule Electric.ConnectionManager do
       end
 
     Keyword.put(connection_opts, :socket_options, tcp_opts)
-  end
-
-  defp get_pg_timeline(conn) do
-    %Postgrex.Result{rows: [[system_identifier, timeline_id]]} =
-      Postgrex.query!(
-        conn,
-        """
-        SELECT
-          (pg_control_system()).system_identifier,
-          (pg_control_checkpoint()).timeline_id
-        """,
-        []
-      )
-
-    {system_identifier, timeline_id}
   end
 
   defp lookup_log_collector_pid(shapes_supervisor) do

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -16,6 +16,7 @@ defmodule Electric.Postgres.ReplicationClient do
   @type step ::
           :disconnected
           | :connected
+          | :query_pg_version
           | :create_publication
           | :create_slot
           | :set_display_setting
@@ -25,6 +26,7 @@ defmodule Electric.Postgres.ReplicationClient do
   defmodule State do
     @enforce_keys [:transaction_received, :relation_received, :publication_name]
     defstruct [
+      :connection_manager,
       :transaction_received,
       :relation_received,
       :publication_name,
@@ -47,6 +49,7 @@ defmodule Electric.Postgres.ReplicationClient do
     ]
 
     @type t() :: %__MODULE__{
+            connection_manager: pid(),
             transaction_received: {module(), atom(), [term()]},
             relation_received: {module(), atom(), [term()]},
             publication_name: String.t(),
@@ -61,6 +64,7 @@ defmodule Electric.Postgres.ReplicationClient do
           }
 
     @opts_schema NimbleOptions.new!(
+                   connection_manager: [required: true, type: :pid],
                    transaction_received: [required: true, type: :mfa],
                    relation_received: [required: true, type: :mfa],
                    publication_name: [required: true, type: :string],

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -16,7 +16,7 @@ defmodule Electric.Postgres.ReplicationClient do
   @type step ::
           :disconnected
           | :connected
-          | :query_pg_version
+          | :query_pg_info
           | :create_publication
           | :create_slot
           | :set_display_setting

--- a/packages/sync-service/test/electric/postgres/lock_connection_test.exs
+++ b/packages/sync-service/test/electric/postgres/lock_connection_test.exs
@@ -74,10 +74,10 @@ defmodule Electric.Postgres.LockConnectionTest do
   end
 
   defp assert_lock_acquired do
-    assert_receive {_, :lock_connection_acquired}
+    assert_receive {_, :exclusive_connection_lock_acquired}
   end
 
   defp refute_lock_acquired do
-    refute_receive {_, :lock_connection_acquired}, 1000
+    refute_receive {_, :exclusive_connection_lock_acquired}, 1000
   end
 end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -119,7 +119,8 @@ defmodule Support.ComponentSetup do
       transaction_received:
         {Electric.Replication.ShapeLogCollector, :store_transaction, [ctx.shape_log_collector]},
       relation_received:
-        {Electric.Replication.ShapeLogCollector, :handle_relation_msg, [ctx.shape_log_collector]}
+        {Electric.Replication.ShapeLogCollector, :handle_relation_msg, [ctx.shape_log_collector]},
+      connection_manager: self()
     ]
 
     {:ok, pid} =


### PR DESCRIPTION
PR chain: #1842 ← #1841 ← **#​1845** ← #1846 ← #1862

Basically, cleaning up ad-hoc queries by performing them in the dedicated connection setup phase, prior to switching the replication connection into logical message streaming mode.