### PR TITLE
fix(sync-service): Fix a division-by-zero error in a unit test

### DIFF
--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -26,13 +26,18 @@ defmodule Electric.Plug.ServeShapePlug do
   defmodule TimeUtils do
     @oct9th2024 DateTime.from_naive!(~N[2024-10-09 00:00:00], "Etc/UTC")
     def seconds_since_oct9th_2024_next_interval(conn) do
-      long_poll_timeout = floor(conn.assigns.config[:long_poll_timeout] / 1000)
-      now = DateTime.utc_now()
+      case div(conn.assigns.config[:long_poll_timeout], 1000) do
+        0 ->
+          0
 
-      diff_in_seconds = DateTime.diff(now, @oct9th2024, :second)
-      next_interval = ceil(diff_in_seconds / long_poll_timeout) * long_poll_timeout
+        long_poll_timeout_sec ->
+          now = DateTime.utc_now()
 
-      next_interval
+          diff_in_seconds = DateTime.diff(now, @oct9th2024, :second)
+          next_interval = ceil(diff_in_seconds / long_poll_timeout_sec) * long_poll_timeout_sec
+
+          next_interval
+      end
     end
   end
 


### PR DESCRIPTION
I saw a test failure in `main` due to the long poll timeout being set to 100 millisec in one of the tests, resulting in a division-by-zero error in ServeShapePlug:
```
  1) test ServeShapePlug sends an up-to-date response after a timeout if no changes are observed (Electric.Plug.ServeShapePlugTest)
     test/electric/plug/serve_shape_plug_test.exs:472
     ** (ArithmeticError) bad argument in arithmetic expression
     code: |> ServeShapePlug.call([])
     stacktrace:
       (electric 0.7.2) lib/electric/plug/serve_shape_plug.ex:33: Electric.Plug.ServeShapePlug.TimeUtils.seconds_since_oct9th_2024_next_interval/1
       (electric 0.7.2) lib/electric/plug/serve_shape_plug.ex:354: Electric.Plug.ServeShapePlug.put_resp_cache_headers/2
       (electric 0.7.2) lib/electric/plug/serve_shape_plug.ex:1: Electric.Plug.ServeShapePlug.plug_builder_call/2
       (electric 0.7.2) deps/plug/lib/plug/error_handler.ex:80: Electric.Plug.ServeShapePlug.call/2
       test/electric/plug/serve_shape_plug_test.exs:495: (test)

     The following output was logged:
     
     17:04:52.501 [info] Query String: live=true&offset=100_0&root_table=public.users&shape_id=test-shape-id
```

I don't know what is the significance of 9 Oct 2024. I wonder if it could be better documented in the code to remove any guesswork.