### PR TITLE
chore(sync-service): Set default log level to 'info' in production

### DIFF
--- a/packages/sync-service/.env.dev
+++ b/packages/sync-service/.env.dev
@@ -1,3 +1,4 @@
+LOG_LEVEL=debug
 DATABASE_URL=postgresql://postgres:password@localhost:54321/electric?sslmode=disable
 ENABLE_INTEGRATION_TESTING=true
 CACHE_MAX_AGE=1

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -3,8 +3,12 @@ import Dotenvy
 
 config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
+if config_env() in [:dev, :test] do
+  source!([".env.#{config_env()}", ".env.#{config_env()}.local", System.get_env()])
+end
+
 log_level_config =
-  env!("LOG_LEVEL", :string, "debug")
+  env!("LOG_LEVEL", :string, "info")
   |> Electric.Config.parse_log_level()
 
 case log_level_config do
@@ -23,10 +27,6 @@ end
 if config_env() == :test do
   config(:logger, level: :info)
   config(:electric, pg_version_for_tests: env!("POSTGRES_VERSION", :integer, 150_001))
-end
-
-if config_env() in [:dev, :test] do
-  source!([".env.#{config_env()}", ".env.#{config_env()}.local", System.get_env()])
 end
 
 electric_instance_id = :default


### PR DESCRIPTION
We have detailed debug logs that log every transaction incoming from Postgres, including its every change. This is not a good default for a production environment where the rate of writes may easily spam the logs, drawing them almost useless.

We leave debug as the default for the dev env.