### PR TITLE
Fix: prevent the server from returning the same cursor as it received

### DIFF
--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -36,6 +36,18 @@ defmodule Electric.Plug.ServeShapePlug do
           diff_in_seconds = DateTime.diff(now, @oct9th2024, :second)
           next_interval = ceil(diff_in_seconds / long_poll_timeout_sec) * long_poll_timeout_sec
 
+          # Check if the generated cursor is the same as what's passed in.
+          cursor = conn.query_params["cursor"]
+
+          next_interval =
+            if cursor && "#{next_interval}" == cursor do
+              # Generate a random integer between 0 and 99999
+              random_integer = :rand.uniform(100_000)
+              next_interval + random_integer
+            else
+              next_interval
+            end
+
           next_interval
       end
     end

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -71,7 +71,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "seconds_since_oct9th_2024_next_interval" do
       # Mock the conn struct with assigns
       # 20 seconds
-      conn = %Plug.Conn{assigns: %{config: %{long_poll_timeout: 20000}}}
+      conn = %Plug.Conn{
+        assigns: %{config: %{long_poll_timeout: 20000}},
+        query_params: %{"cursor" => nil}
+      }
 
       # Calculate the expected next interval
       now = DateTime.utc_now()
@@ -87,7 +90,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "seconds_since_oct9th_2024_next_interval with different timeout" do
       # Mock the conn struct with a different timeout
       # 30 seconds
-      conn = %Plug.Conn{assigns: %{config: %{long_poll_timeout: 30000}}}
+      conn = %Plug.Conn{
+        assigns: %{config: %{long_poll_timeout: 30000}},
+        query_params: %{"cursor" => nil}
+      }
 
       # Calculate the expected next interval
       now = DateTime.utc_now()

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -100,6 +100,27 @@ defmodule Electric.Plug.ServeShapePlugTest do
                expected_interval
     end
 
+    test "seconds_since_oct9th_2024_next_interval with different timeout and cursor collision" do
+      # Mock the conn struct with a different timeout (30 seconds)
+      conn = %Plug.Conn{
+        assigns: %{config: %{long_poll_timeout: 30000}},
+        query_params: %{"cursor" => nil}
+      }
+
+      # Calculate the expected next interval
+      now = DateTime.utc_now()
+      oct9th2024 = DateTime.from_naive!(~N[2024-10-09 00:00:00], "Etc/UTC")
+      diff_in_seconds = DateTime.diff(now, oct9th2024, :second)
+      expected_interval = ceil(diff_in_seconds / 30) * 30
+
+      # Simulate a cursor collision
+      conn = %{conn | query_params: %{"cursor" => "#{expected_interval}"}}
+
+      # Assert that the function returns a DIFFERENT value due to collision
+      assert Electric.Plug.ServeShapePlug.TimeUtils.seconds_since_oct9th_2024_next_interval(conn) !=
+               expected_interval
+    end
+
     test "returns 400 for invalid params" do
       conn =
         conn(:get, %{"root_table" => ".invalid_shape"}, "?offset=invalid")


### PR DESCRIPTION
Fix https://github.com/electric-sql/electric/issues/1837