### PR TITLE
fix: Parse and validate `REPLICATION_STREAM_ID`

### DIFF
--- a/.changeset/tasty-carpets-accept.md
+++ b/.changeset/tasty-carpets-accept.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Parse and validate `REPLICATION_STREAM_ID` as it cannot include special characters

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -165,8 +165,7 @@ replication_stream_id =
     fn replication_stream_id ->
       {:ok, parsed_id} =
         replication_stream_id
-        |> String.trim(~S|"|)
-        |> Electric.Postgres.Identifiers.parse()
+        |> Electric.Postgres.Identifiers.parse_unquoted_identifier()
 
       parsed_id
     end,

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -168,9 +168,6 @@ replication_stream_id =
         |> String.trim(~S|"|)
         |> Electric.Postgres.Identifiers.parse()
 
-      IO.puts(replication_stream_id)
-      IO.puts(parsed_id)
-
       parsed_id
     end,
     "default"

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -159,6 +159,23 @@ chunk_bytes_threshold =
      storage_dir: shape_path, electric_instance_id: electric_instance_id}
   )
 
+replication_stream_id =
+  env!(
+    "REPLICATION_STREAM_ID",
+    fn replication_stream_id ->
+      {:ok, parsed_id} =
+        replication_stream_id
+        |> String.trim(~S|"|)
+        |> Electric.Postgres.Identifiers.parse()
+
+      IO.puts(replication_stream_id)
+      IO.puts(parsed_id)
+
+      parsed_id
+    end,
+    "default"
+  )
+
 storage = {storage_mod, storage_opts}
 
 prometheus_port = env!("PROMETHEUS_PORT", :integer, nil)
@@ -174,7 +191,7 @@ config :electric,
   electric_instance_id: electric_instance_id,
   telemetry_statsd_host: statsd_host,
   db_pool_size: env!("DB_POOL_SIZE", :integer, 20),
-  replication_stream_id: env!("REPLICATION_STREAM_ID", :string, "default"),
+  replication_stream_id: replication_stream_id,
   service_port: env!("PORT", :integer, 3000),
   prometheus_port: prometheus_port,
   storage: storage,

--- a/packages/sync-service/lib/electric/postgres/identifiers.ex
+++ b/packages/sync-service/lib/electric/postgres/identifiers.ex
@@ -47,9 +47,9 @@ defmodule Electric.Postgres.Identifiers do
       else: {:ok, unescape_quotes(ident)}
   end
 
-  defp parse_unquoted_identifier("", _, _), do: parse_quoted_identifier("")
+  def parse_unquoted_identifier("", _, _), do: parse_quoted_identifier("")
 
-  defp parse_unquoted_identifier(ident, truncate, single_byte_encoding) do
+  def parse_unquoted_identifier(ident, truncate, single_byte_encoding) do
     unless valid_unquoted_identifier?(ident),
       do: {:error, "Invalid unquoted identifier contains special characters: #{ident}"},
       else: {:ok, downcase(ident, truncate, single_byte_encoding)}


### PR DESCRIPTION
While setting up another project, I noticed that replication slots _cannot_ contain special characters, so parsing and validating the provided id early will prevent unnecessary headaches.