### PR TITLE
feat (sync-service): multi tenancy support

### DIFF
--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -64,6 +64,8 @@ jobs:
     defaults:
       run:
         working-directory: ${{ matrix.package_dir }}
+    env:
+      TENANT_ID: ci_test_tenant
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -107,7 +107,7 @@ jobs:
             mix run --no-halt &
 
           wait-on: |
-            http://localhost:3000
+            http-get://localhost:3000/v1/health
 
           tail: true
           log-output-resume: stderr

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -85,7 +85,7 @@
   [shell $shell_name]
     -$fail_pattern
   
-    !DATABASE_URL=$database_url PORT=$port $env ../scripts/electric_dev.sh
+    !TENANT_ID=integration_test_tenant DATABASE_URL=$database_url PORT=$port $env ../scripts/electric_dev.sh
 [endmacro]
 
 [macro teardown]

--- a/integration-tests/tests/invalidated-replication-slot.lux
+++ b/integration-tests/tests/invalidated-replication-slot.lux
@@ -6,7 +6,7 @@
 
 [my invalidated_slot_error=
   """
-  [error] GenServer Electric.Connection.Manager terminating
+  [error] :gen_statem {Electric.Registry.Processes, {Electric.Postgres.ReplicationClient, :default, "integration_test_tenant"}} terminating
   ** (Postgrex.Error) ERROR 55000 (object_not_in_prerequisite_state) cannot read from logical replication slot "electric_slot_default"
 
   This slot has been invalidated because it exceeded the maximum reserved size.

--- a/integration-tests/tests/resuming-replication-at-consistent-point.lux
+++ b/integration-tests/tests/resuming-replication-at-consistent-point.lux
@@ -75,15 +75,15 @@
   ?Txn received in Shapes.Consumer: %Electric.Replication.Changes.Transaction{xid: $xid
 
   # Both consumers hit their call limit and exit with simulated storage failures.
-  ?\[error\] GenServer {Electric\.Registry\.Processes, {Electric\.Shapes\.Consumer, :default, "[0-9-]+"}} terminating
+  ?\[error\] GenServer {Electric\.Registry\.Processes, {Electric\.Shapes\.Consumer, :default, "integration_test_tenant", "[0-9-]+"}} terminating
   ??Simulated storage failure
-  ?\[error\] GenServer {Electric\.Registry\.Processes, {Electric\.Shapes\.Consumer, :default, "[0-9-]+"}} terminating
+  ?\[error\] GenServer {Electric\.Registry\.Processes, {Electric\.Shapes\.Consumer, :default, "integration_test_tenant", "[0-9-]+"}} terminating
   ??Simulated storage failure
 
   # The log collector process and the replication client both exit, as their lifetimes are tied
   # together by the supervision tree design.
-  ??[error] GenServer {Electric.Registry.Processes, {Electric.Replication.ShapeLogCollector, :default}} terminating
-  ??[error] :gen_statem {Electric.Registry.Processes, {Electric.Postgres.ReplicationClient, :default}} terminating
+  ??[error] GenServer {Electric.Registry.Processes, {Electric.Replication.ShapeLogCollector, :default, "integration_test_tenant"}} terminating
+  ??[error] :gen_statem {Electric.Registry.Processes, {Electric.Postgres.ReplicationClient, :default, "integration_test_tenant"}} terminating
 
   # Observe that both shape consumers and the replication client have restarted.
   ??[debug] Found existing replication slot

--- a/packages/sync-service/.env.dev
+++ b/packages/sync-service/.env.dev
@@ -5,3 +5,4 @@ CACHE_MAX_AGE=1
 CACHE_STALE_AGE=3
 # using a small chunk size of 10kB for dev to speed up tests
 LOG_CHUNK_BYTES_THRESHOLD=10000
+TENANT_ID=test_tenant

--- a/packages/sync-service/.env.test
+++ b/packages/sync-service/.env.test
@@ -1,0 +1,3 @@
+LOG_LEVEL=info
+DATABASE_URL=postgresql://postgres:password@localhost:54321/postgres?sslmode=disable
+TENANT_ID=test_tenant

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -26,6 +26,7 @@ end
 
 if config_env() == :test do
   config(:logger, level: :info)
+  config(:electric, test_mode: true)
   config(:electric, pg_version_for_tests: env!("POSTGRES_VERSION", :integer, 150_001))
 end
 
@@ -33,6 +34,8 @@ electric_instance_id = :default
 service_name = env!("ELECTRIC_SERVICE_NAME", :string, "electric")
 instance_id = env!("ELECTRIC_INSTANCE_ID", :string, Electric.Utils.uuid4())
 version = Electric.version()
+
+test_tenant = "test_tenant"
 
 config :telemetry_poller, :default, period: 500
 
@@ -81,28 +84,21 @@ otel_simple_processor =
 config :opentelemetry,
   processors: [otel_batch_processor, otel_simple_processor] |> Enum.reject(&is_nil/1)
 
-connection_opts =
-  if Config.config_env() == :test do
-    [
-      hostname: "localhost",
-      port: 54321,
-      username: "postgres",
-      password: "password",
-      database: "postgres",
-      sslmode: :disable
-    ]
-  else
-    {:ok, database_url_config} =
-      env!("DATABASE_URL", :string)
-      |> Electric.ConfigParser.parse_postgresql_uri()
+if Config.config_env() == :test do
+  config :electric,
+    connection_opts:
+      [
+        hostname: "localhost",
+        port: 54321,
+        username: "postgres",
+        password: "password",
+        database: "postgres",
+        sslmode: :disable
+      ]
+      |> Electric.Utils.obfuscate_password()
 
-    database_ipv6_config =
-      env!("DATABASE_USE_IPV6", :boolean, false)
-
-    database_url_config ++ [ipv6: database_ipv6_config]
-  end
-
-config :electric, connection_opts: Electric.Utils.obfuscate_password(connection_opts)
+  config :electric, test_tenant: test_tenant
+end
 
 enable_integration_testing = env!("ENABLE_INTEGRATION_TESTING", :boolean, false)
 cache_max_age = env!("CACHE_MAX_AGE", :integer, 60)

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -86,10 +86,6 @@ defmodule Electric.Application do
   defp configure do
     electric_instance_id = Application.fetch_env!(:electric, :electric_instance_id)
 
-    {storage_module, storage_in_opts} = Application.fetch_env!(:electric, :storage)
-    storage_opts = storage_module.shared_opts(storage_in_opts)
-    storage = {storage_module, storage_opts}
-
     {kv_module, kv_fun, kv_params} = Application.fetch_env!(:electric, :persistent_kv)
     persistent_kv = apply(kv_module, kv_fun, [kv_params])
 
@@ -99,7 +95,6 @@ defmodule Electric.Application do
 
     config = %Electric.Application.Configuration{
       electric_instance_id: electric_instance_id,
-      storage: storage,
       persistent_kv: persistent_kv,
       connection_opts: Application.fetch_env!(:electric, :connection_opts),
       replication_opts: %{

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -19,7 +19,7 @@ defmodule Electric.Application do
   def start(_type, _args) do
     :erlang.system_flag(:backtrace_depth, 50)
 
-    config = configure()
+    configure()
 
     # The root application supervisor starts the core global processes, including the HTTP
     # server and the database connection manager. The latter is responsible for establishing
@@ -42,9 +42,7 @@ defmodule Electric.Application do
           Electric.TenantSupervisor,
           Electric.TenantManager,
           {Bandit,
-           plug:
-             {Electric.Plug.Router,
-              storage: config.storage, tenant_manager: Electric.TenantManager},
+           plug: {Electric.Plug.Router, tenant_manager: Electric.TenantManager},
            port: Application.fetch_env!(:electric, :service_port),
            thousand_island_options: http_listener_options()}
           # {Bandit,
@@ -96,7 +94,6 @@ defmodule Electric.Application do
     config = %Electric.Application.Configuration{
       electric_instance_id: electric_instance_id,
       persistent_kv: persistent_kv,
-      connection_opts: Application.fetch_env!(:electric, :connection_opts),
       replication_opts: %{
         stream_id: replication_stream_id,
         publication_name: publication_name,

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -25,7 +25,13 @@ defmodule Electric.Application do
 
     router_opts =
       Enum.concat([
-        [tanent_manager: Electric.TenantManager],
+        [
+          tanent_manager: Electric.TenantManager,
+          long_poll_timeout: 20_000,
+          max_age: Application.fetch_env!(:electric, :cache_max_age),
+          stale_age: Application.fetch_env!(:electric, :cache_stale_age),
+          allow_shape_deletion: Application.get_env(:electric, :allow_shape_deletion, false)
+        ],
         get_service_status_option(config.electric_instance_id, tenant_id)
       ])
 
@@ -53,20 +59,6 @@ defmodule Electric.Application do
            plug: {Electric.Plug.Router, router_opts},
            port: Application.fetch_env!(:electric, :service_port),
            thousand_island_options: http_listener_options()}
-          # {Bandit,
-          #  plug:
-          #    {Electric.Plug.Router,
-          #     storage: config.storage,
-          #     registry: Registry.ShapeChanges,
-          #     shape_cache: {Electric.ShapeCache, config.shape_cache_opts},
-          #     get_service_status: &Electric.ServiceStatus.check/0,
-          #     inspector: config.inspector,
-          #     long_poll_timeout: 20_000,
-          #     max_age: Application.fetch_env!(:electric, :cache_max_age),
-          #     stale_age: Application.fetch_env!(:electric, :cache_stale_age),
-          #     allow_shape_deletion: Application.get_env(:electric, :allow_shape_deletion, false)},
-          #  port: Application.fetch_env!(:electric, :service_port),
-          #  thousand_island_options: http_listener_options()}
         ],
         prometheus_endpoint(Application.fetch_env!(:electric, :prometheus_port))
       ])

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -19,7 +19,15 @@ defmodule Electric.Application do
   def start(_type, _args) do
     :erlang.system_flag(:backtrace_depth, 50)
 
-    configure()
+    config = configure()
+
+    tenant_id = Application.get_env(:electric, :default_tenant)
+
+    router_opts =
+      Enum.concat([
+        [tanent_manager: Electric.TenantManager],
+        get_service_status_option(config.electric_instance_id, tenant_id)
+      ])
 
     # The root application supervisor starts the core global processes, including the HTTP
     # server and the database connection manager. The latter is responsible for establishing
@@ -42,7 +50,7 @@ defmodule Electric.Application do
           Electric.TenantSupervisor,
           Electric.TenantManager,
           {Bandit,
-           plug: {Electric.Plug.Router, tenant_manager: Electric.TenantManager},
+           plug: {Electric.Plug.Router, router_opts},
            port: Application.fetch_env!(:electric, :service_port),
            thousand_island_options: http_listener_options()}
           # {Bandit,
@@ -69,10 +77,9 @@ defmodule Electric.Application do
         name: Electric.Supervisor
       )
 
-    if Application.get_env(:electric, :test_mode, false) do
-      test_tenant = Application.fetch_env!(:electric, :test_tenant)
-      connection_opts = Application.fetch_env!(:electric, :connection_opts)
-      Electric.TenantManager.create_tenant(test_tenant, connection_opts)
+    if tenant_id do
+      connection_opts = Application.fetch_env!(:electric, :default_connection_opts)
+      Electric.TenantManager.create_tenant(tenant_id, connection_opts)
     end
 
     {:ok, sup_pid}
@@ -127,4 +134,11 @@ defmodule Electric.Application do
       []
     end
   end
+
+  defp get_service_status_option(_, nil), do: []
+
+  defp get_service_status_option(electric_instance_id, tenant_id),
+    do: [
+      get_service_status: fn -> Electric.ServiceStatus.check(electric_instance_id, tenant_id) end
+    ]
 end

--- a/packages/sync-service/lib/electric/application/configuration.ex
+++ b/packages/sync-service/lib/electric/application/configuration.ex
@@ -11,8 +11,6 @@ defmodule Electric.Application.Configuration do
     connection_opts
     replication_opts
     pool_opts
-    inspector
-    shape_cache_opts
   ]a
 
   @type t :: %__MODULE__{}

--- a/packages/sync-service/lib/electric/application/configuration.ex
+++ b/packages/sync-service/lib/electric/application/configuration.ex
@@ -7,7 +7,6 @@ defmodule Electric.Application.Configuration do
   defstruct ~w[
     electric_instance_id
     persistent_kv
-    connection_opts
     replication_opts
     pool_opts
   ]a

--- a/packages/sync-service/lib/electric/application/configuration.ex
+++ b/packages/sync-service/lib/electric/application/configuration.ex
@@ -6,7 +6,6 @@ defmodule Electric.Application.Configuration do
 
   defstruct ~w[
     electric_instance_id
-    storage
     persistent_kv
     connection_opts
     replication_opts

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -32,6 +32,7 @@ defmodule Electric.Connection.Supervisor do
 
   def start_shapes_supervisor(opts) do
     electric_instance_id = Keyword.fetch!(opts, :electric_instance_id)
+    tenant_id = Keyword.fetch!(opts, :tenant_id)
     shape_cache_opts = Keyword.fetch!(opts, :shape_cache_opts)
     inspector = Keyword.fetch!(shape_cache_opts, :inspector)
 
@@ -39,14 +40,14 @@ defmodule Electric.Connection.Supervisor do
 
     shape_log_collector_spec =
       {Electric.Replication.ShapeLogCollector,
-       electric_instance_id: electric_instance_id, inspector: inspector}
+       electric_instance_id: electric_instance_id, tenant_id: tenant_id, inspector: inspector}
 
     child_spec =
       Supervisor.child_spec(
         {
           Electric.Shapes.Supervisor,
           electric_instance_id: electric_instance_id,
-          tenant_id: Keyword.fetch!(opts, :tenant_id),
+          tenant_id: tenant_id,
           shape_cache: shape_cache_spec,
           log_collector: shape_log_collector_spec
         },

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -31,20 +31,22 @@ defmodule Electric.Connection.Supervisor do
   end
 
   def start_shapes_supervisor(opts) do
-    app_config = Electric.Application.Configuration.get()
+    electric_instance_id = Keyword.fetch!(opts, :electric_instance_id)
+    shape_cache_opts = Keyword.fetch!(opts, :shape_cache_opts)
+    inspector = Keyword.fetch!(shape_cache_opts, :inspector)
 
-    shape_cache_opts = app_config.shape_cache_opts ++ Keyword.take(opts, [:purge_all_shapes?])
     shape_cache_spec = {Electric.ShapeCache, shape_cache_opts}
 
     shape_log_collector_spec =
       {Electric.Replication.ShapeLogCollector,
-       electric_instance_id: app_config.electric_instance_id, inspector: app_config.inspector}
+       electric_instance_id: electric_instance_id, inspector: inspector}
 
     child_spec =
       Supervisor.child_spec(
         {
           Electric.Shapes.Supervisor,
-          electric_instance_id: app_config.electric_instance_id,
+          electric_instance_id: electric_instance_id,
+          tenant_id: Keyword.fetch!(opts, :tenant_id),
           shape_cache: shape_cache_spec,
           log_collector: shape_log_collector_spec
         },

--- a/packages/sync-service/lib/electric/plug/create_database_plug.ex
+++ b/packages/sync-service/lib/electric/plug/create_database_plug.ex
@@ -1,0 +1,214 @@
+defmodule Electric.Plug.AddDatabasePlug do
+  use Plug.Builder
+  use Plug.ErrorHandler
+
+  # The halt/1 function is redefined further down below
+  import Plug.Conn, except: [halt: 1]
+
+  alias OpenTelemetry.SemanticConventions, as: SC
+
+  alias Electric.Telemetry.OpenTelemetry
+  alias Plug.Conn
+
+  alias Electric.TenantManager
+
+  require Logger
+  require SC.Trace
+
+  defmodule Params do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @primary_key false
+    embedded_schema do
+      field(:DATABASE_URL, :string)
+      field(:DATABASE_USE_IPV6, :boolean, default: false)
+      field(:id, :string, autogenerate: {Electric.Utils, :uuid4, []})
+    end
+
+    def validate(params) do
+      %__MODULE__{}
+      |> cast(params, __schema__(:fields), message: fn _, _ -> "must be %{type}" end)
+      |> validate_required([:DATABASE_URL, :id])
+      |> apply_action(:validate)
+      |> case do
+        {:ok, params} ->
+          {:ok, Map.from_struct(params)}
+
+        {:error, changeset} ->
+          {:error,
+           Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+             Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+               opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+             end)
+           end)}
+      end
+    end
+  end
+
+  plug Plug.Parsers,
+    parsers: [:json],
+    json_decoder: Jason
+
+  # start_telemetry_span needs to always be the first plug after fetching query params.
+  plug :start_telemetry_span
+
+  plug :cors
+  plug :put_resp_content_type, "application/json"
+  plug :validate_body
+  plug :create_tenant
+
+  # end_telemetry_span needs to always be the last plug here.
+  plug :end_telemetry_span
+
+  defp validate_body(%Conn{body_params: params} = conn, _) do
+    case Params.validate(params) do
+      {:ok, params} ->
+        %{conn | assigns: Map.merge(conn.assigns, params)}
+
+      {:error, error_map} ->
+        conn
+        |> send_resp(400, Jason.encode_to_iodata!(error_map))
+        |> halt()
+    end
+  end
+
+  defp create_tenant(%Conn{assigns: %{id: tenant_id} = assigns} = conn, _) do
+    %{DATABASE_URL: db_url, DATABASE_USE_IPV6: use_ipv6?} = assigns
+
+    OpenTelemetry.with_span("add_db.plug.create_tenant", [], fn ->
+      {:ok, database_url_config} = Electric.ConfigParser.parse_postgresql_uri(db_url)
+
+      database_ipv6_config =
+        if use_ipv6? do
+          [ipv6: true]
+        else
+          []
+        end
+
+      connection_opts =
+        Electric.Utils.obfuscate_password(database_url_config ++ database_ipv6_config)
+
+      :ok = TenantManager.create_tenant(tenant_id, connection_opts, conn.assigns.config)
+
+      conn
+      |> send_resp(200, Jason.encode_to_iodata!(tenant_id))
+      |> halt()
+    end)
+  end
+
+  def cors(conn, _opts) do
+    conn
+    |> put_resp_header("access-control-allow-origin", "*")
+    |> put_resp_header("access-control-expose-headers", "*")
+    |> put_resp_header("access-control-allow-methods", "GET, POST, DELETE")
+  end
+
+  defp open_telemetry_attrs(%Conn{assigns: assigns} = conn) do
+    %{
+      "tenant.id" => assigns[:id],
+      "tenant.DATABASE_URL" => assigns[:DATABASE_URL],
+      "error.type" => assigns[:error_str],
+      "http.request_id" => assigns[:plug_request_id],
+      "http.query_string" => conn.query_string,
+      SC.Trace.http_client_ip() => client_ip(conn),
+      SC.Trace.http_scheme() => conn.scheme,
+      SC.Trace.net_peer_name() => conn.host,
+      SC.Trace.net_peer_port() => conn.port,
+      SC.Trace.http_target() => conn.request_path,
+      SC.Trace.http_method() => conn.method,
+      SC.Trace.http_status_code() => conn.status,
+      SC.Trace.http_response_content_length() => assigns[:streaming_bytes_sent],
+      SC.Trace.net_transport() => :"IP.TCP",
+      SC.Trace.http_user_agent() => user_agent(conn),
+      SC.Trace.http_url() =>
+        %URI{
+          scheme: to_string(conn.scheme),
+          host: conn.host,
+          port: conn.port,
+          path: conn.request_path,
+          query: conn.query_string
+        }
+        |> to_string()
+    }
+    |> Map.filter(fn {_k, v} -> not is_nil(v) end)
+    |> Map.merge(Map.new(conn.req_headers, fn {k, v} -> {"http.request.header.#{k}", v} end))
+    |> Map.merge(Map.new(conn.resp_headers, fn {k, v} -> {"http.response.header.#{k}", v} end))
+  end
+
+  # TODO: move these functions into a shared module or a trait that we can mix in here and in the other plugs?
+  defp client_ip(%Conn{remote_ip: remote_ip} = conn) do
+    case get_req_header(conn, "x-forwarded-for") do
+      [] ->
+        remote_ip
+        |> :inet_parse.ntoa()
+        |> to_string()
+
+      [ip_address | _] ->
+        ip_address
+    end
+  end
+
+  defp user_agent(%Conn{} = conn) do
+    case get_req_header(conn, "user-agent") do
+      [] -> ""
+      [head | _] -> head
+    end
+  end
+
+  #
+  ### Telemetry
+  #
+
+  # Below, OpentelemetryTelemetry does the heavy lifting of setting up the span context in the
+  # current Elixir process to correctly attribute subsequent calls to OpenTelemetry.with_span()
+  # in this module as descendants of the root span, as they are all invoked in the same process
+  # unless a new process is spawned explicitly.
+
+  # Start the root span for the shape request, serving as an ancestor for any subsequent
+  # sub-span.
+  defp start_telemetry_span(conn, _) do
+    OpentelemetryTelemetry.start_telemetry_span(OpenTelemetry, "Plug_shape_get", %{}, %{})
+    add_span_attrs_from_conn(conn)
+    conn
+  end
+
+  # Assign root span attributes based on the latest state of Plug.Conn and end the root span.
+  #
+  # We want to have all the relevant HTTP and shape request attributes on the root span. This
+  # is the place to assign them because we keep this plug last in the "plug pipeline" defined
+  # in this module.
+  defp end_telemetry_span(conn, _ \\ nil) do
+    add_span_attrs_from_conn(conn)
+    OpentelemetryTelemetry.end_telemetry_span(OpenTelemetry, %{})
+    conn
+  end
+
+  defp add_span_attrs_from_conn(conn) do
+    conn
+    |> open_telemetry_attrs()
+    |> OpenTelemetry.add_span_attributes()
+  end
+
+  # This overrides Plug.Conn.halt/1 (which is deliberately "unimported" at the top of this
+  # module) so that we can record the response status in the OpenTelemetry span for this
+  # request.
+  defp halt(conn) do
+    conn
+    |> end_telemetry_span()
+    |> Plug.Conn.halt()
+  end
+
+  @impl Plug.ErrorHandler
+  def handle_errors(conn, error) do
+    OpenTelemetry.record_exception(error.reason, error.stack)
+
+    error_str = Exception.format(error.kind, error.reason)
+
+    conn
+    |> assign(:error_str, error_str)
+    |> end_telemetry_span()
+
+    conn
+  end
+end

--- a/packages/sync-service/lib/electric/plug/health_check_plug.ex
+++ b/packages/sync-service/lib/electric/plug/health_check_plug.ex
@@ -15,8 +15,8 @@ defmodule Electric.Plug.HealthCheckPlug do
 
     {status_code, status_text} =
       case get_service_status.() do
-        :waiting -> {200, "waiting"}
-        :starting -> {200, "starting"}
+        :waiting -> {503, "waiting"}
+        :starting -> {503, "starting"}
         :active -> {200, "active"}
         :stopping -> {503, "stopping"}
       end

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -19,6 +19,8 @@ defmodule Electric.Plug.Router do
 
   get "/v1/health", to: Electric.Plug.HealthCheckPlug
 
+  post "/v1/admin/database", to: Electric.Plug.AddDatabasePlug
+
   match _ do
     send_resp(conn, 404, "Not found")
   end

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -9,6 +9,7 @@ defmodule Electric.Plug.ServeShapePlug do
 
   alias Electric.Shapes
   alias Electric.Schema
+  alias Electric.TenantManager
   alias Electric.Replication.LogOffset
   alias Electric.Telemetry.OpenTelemetry
   alias Plug.Conn
@@ -63,6 +64,7 @@ defmodule Electric.Plug.ServeShapePlug do
       field(:root_table, :string)
       field(:offset, :string)
       field(:shape_id, :string)
+      field(:database_id, :string)
       field(:live, :boolean, default: false)
       field(:where, :string)
       field(:columns, :string)
@@ -176,6 +178,8 @@ defmodule Electric.Plug.ServeShapePlug do
 
   plug :cors
   plug :put_resp_content_type, "application/json"
+  plug :validate_tenant_id
+  plug :load_tenant
   plug :validate_query_params
   plug :load_shape_info
   plug :put_schema_header
@@ -191,6 +195,51 @@ defmodule Electric.Plug.ServeShapePlug do
 
   # end_telemetry_span needs to always be the last plug here.
   plug :end_telemetry_span
+
+  defp validate_tenant_id(%Conn{} = conn, _) do
+    case Map.get(conn.query_params, "database_id", :not_found) do
+      :not_found ->
+        conn
+
+      id when is_binary(id) ->
+        assign(conn, :database_id, id)
+
+      _ ->
+        conn
+        |> send_resp(400, Jason.encode_to_iodata!("database_id should be a connection string"))
+        |> halt()
+    end
+  end
+
+  defp load_tenant(%Conn{assigns: %{database_id: tenant_id}} = conn, _) do
+    {:ok, tenant_config} = TenantManager.get_tenant(tenant_id, conn.assigns.config)
+    assign_tenant(conn, tenant_config)
+  end
+
+  defp load_tenant(%Conn{} = conn, _) do
+    # Tenant ID is not specified
+    # ask the tenant manager for the only tenant
+    # if there's more than one tenant we reply with an error
+    case TenantManager.get_only_tenant(conn.assigns.config) do
+      {:ok, tenant_config} ->
+        assign_tenant(conn, tenant_config)
+
+      {:error, :not_found} ->
+        conn
+        |> send_resp(400, Jason.encode_to_iodata!("No database found"))
+        |> halt()
+
+      {:error, :several_tenants} ->
+        conn
+        |> send_resp(
+          400,
+          Jason.encode_to_iodata!(
+            "Database ID was not provided and there are multiple databases. Please specify a database ID using the `database_id` query parameter."
+          )
+        )
+        |> halt()
+    end
+  end
 
   defp validate_query_params(%Conn{} = conn, _) do
     Logger.info("Query String: #{conn.query_string}")
@@ -208,6 +257,14 @@ defmodule Electric.Plug.ServeShapePlug do
         |> send_resp(400, Jason.encode_to_iodata!(error_map))
         |> halt()
     end
+  end
+
+  defp assign_tenant(%Conn{} = conn, tenant_config) do
+    id = tenant_config[:tenant_id]
+
+    conn
+    |> assign(:config, tenant_config)
+    |> assign(:tenant_id, id)
   end
 
   defp load_shape_info(%Conn{} = conn, _) do
@@ -313,10 +370,10 @@ defmodule Electric.Plug.ServeShapePlug do
   # If chunk offsets are available, use those instead of the latest available offset
   # to optimize for cache hits and response sizes
   defp determine_log_chunk_offset(%Conn{assigns: assigns} = conn, _) do
-    %{config: config, active_shape_id: shape_id, offset: offset} = assigns
+    %{config: config, active_shape_id: shape_id, offset: offset, tenant_id: tenant_id} = assigns
 
     chunk_end_offset =
-      Shapes.get_chunk_end_log_offset(config, shape_id, offset) || assigns.last_offset
+      Shapes.get_chunk_end_log_offset(config, shape_id, offset, tenant_id) || assigns.last_offset
 
     conn
     |> assign(:chunk_end_offset, chunk_end_offset)
@@ -419,14 +476,15 @@ defmodule Electric.Plug.ServeShapePlug do
            assigns: %{
              chunk_end_offset: chunk_end_offset,
              active_shape_id: shape_id,
+             tenant_id: tenant_id,
              up_to_date: maybe_up_to_date
            }
          } = conn
        ) do
-    case Shapes.get_snapshot(conn.assigns.config, shape_id) do
+    case Shapes.get_snapshot(conn.assigns.config, shape_id, tenant_id) do
       {:ok, {offset, snapshot}} ->
         log =
-          Shapes.get_log_stream(conn.assigns.config, shape_id,
+          Shapes.get_log_stream(conn.assigns.config, shape_id, tenant_id,
             since: offset,
             up_to: chunk_end_offset
           )
@@ -462,12 +520,13 @@ defmodule Electric.Plug.ServeShapePlug do
              offset: offset,
              chunk_end_offset: chunk_end_offset,
              active_shape_id: shape_id,
+             tenant_id: tenant_id,
              up_to_date: maybe_up_to_date
            }
          } = conn
        ) do
     log =
-      Shapes.get_log_stream(conn.assigns.config, shape_id,
+      Shapes.get_log_stream(conn.assigns.config, shape_id, tenant_id,
         since: offset,
         up_to: chunk_end_offset
       )
@@ -534,8 +593,12 @@ defmodule Electric.Plug.ServeShapePlug do
 
       ref = make_ref()
       registry = conn.assigns.config[:registry]
-      Registry.register(registry, shape_id, ref)
-      Logger.debug("Client #{inspect(self())} is registered for changes to #{shape_id}")
+      tenant = conn.assigns.tenant_id
+      Registry.register(registry, {tenant, shape_id}, ref)
+
+      Logger.debug(
+        "[Tenant #{tenant}]: Client #{inspect(self())} is registered for changes to #{shape_id}"
+      )
 
       assign(conn, :new_changes_ref, ref)
     else

--- a/packages/sync-service/lib/electric/postgres/inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector.ex
@@ -56,7 +56,7 @@ defmodule Electric.Postgres.Inspector do
   Clean up all information about a given relation using a provided inspector.
   """
   @spec clean(relation(), inspector()) :: true
-  def clean(relation, {module, opts}), do: module.clean_column_info(relation, opts)
+  def clean(relation, {module, opts}), do: module.clean(relation, opts)
 
   @doc """
   Get columns that should be considered a PK for table. If the table

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -8,15 +8,28 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
 
   ## Public API
 
-  def start_link(opts),
-    do:
+  def name(electric_instance_id, tenant_id) do
+    Electric.Application.process_name(electric_instance_id, tenant_id, __MODULE__)
+  end
+
+  def name(opts) do
+    electric_instance_id = Keyword.fetch!(opts, :electric_instance_id)
+    tenant_id = Keyword.fetch!(opts, :tenant_id)
+    name(electric_instance_id, tenant_id)
+  end
+
+  def start_link(opts) do
+    {:ok, pid} =
       GenServer.start_link(
         __MODULE__,
         Map.new(opts)
         |> Map.put_new(:pg_info_table, @default_pg_info_table)
         |> Map.put_new(:pg_relation_table, @default_pg_relation_table),
-        name: Access.get(opts, :name, __MODULE__)
+        name: Keyword.get_lazy(opts, :name, fn -> name(opts) end)
       )
+
+    {:ok, pid}
+  end
 
   @impl Electric.Postgres.Inspector
   def load_relation(table, opts) do
@@ -30,10 +43,8 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   end
 
   defp clean_relation(rel, opts_or_state) do
-    pg_relation_ets_table =
-      Access.get(opts_or_state, :pg_relation_table, @default_pg_relation_table)
-
-    pg_info_ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
+    pg_relation_ets_table = get_relation_table(opts_or_state)
+    pg_info_ets_table = get_column_info_table(opts_or_state)
 
     # Delete all tables that are associated with the relation
     tables_from_ets(rel, opts_or_state)
@@ -58,7 +69,7 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   end
 
   defp clean_column_info(table, opts_or_state) do
-    ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
+    ets_table = get_column_info_table(opts_or_state)
 
     :ets.delete(ets_table, {table, :columns})
   end
@@ -73,8 +84,11 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
 
   @impl GenServer
   def init(opts) do
-    pg_info_table = :ets.new(opts.pg_info_table, [:named_table, :public, :set])
-    pg_relation_table = :ets.new(opts.pg_relation_table, [:named_table, :public, :bag])
+    # Each tenant creates its own ETS table.
+    # Name needs to be an atom but we don't want to dynamically create atoms.
+    # Instead, we will use the reference to the table that is returned by `:ets.new`
+    pg_info_table = :ets.new(opts.pg_info_table, [:public, :set])
+    pg_relation_table = :ets.new(opts.pg_relation_table, [:public, :bag])
 
     state = %{
       pg_info_table: pg_info_table,
@@ -120,7 +134,6 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     end
   end
 
-  @impl GenServer
   def handle_call({:load_column_info, table}, _from, state) do
     case column_info_from_ets(table, state) do
       :not_found ->
@@ -141,16 +154,24 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     e -> {:reply, {:error, e, __STACKTRACE__}, state}
   end
 
+  def handle_call(:get_column_info_table, _from, state) do
+    {:reply, state.pg_info_table, state}
+  end
+
+  def handle_call(:get_relation_table, _from, state) do
+    {:reply, state.pg_relation_table, state}
+  end
+
   @pg_rel_position 2
   defp relation_from_ets(table, opts_or_state) do
-    ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
+    ets_table = get_column_info_table(opts_or_state)
 
     :ets.lookup_element(ets_table, {table, :table_to_relation}, @pg_rel_position, :not_found)
   end
 
   @pg_table_idx 1
   defp tables_from_ets(relation, opts_or_state) do
-    ets_table = Access.get(opts_or_state, :pg_relation_table, @default_pg_relation_table)
+    ets_table = get_relation_table(opts_or_state)
 
     :ets.lookup(ets_table, {relation, :relation_to_table})
     |> Enum.map(&elem(&1, @pg_table_idx))
@@ -158,8 +179,18 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
 
   @column_info_position 2
   defp column_info_from_ets(table, opts_or_state) do
-    ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
+    ets_table = get_column_info_table(opts_or_state)
 
     :ets.lookup_element(ets_table, {table, :columns}, @column_info_position, :not_found)
   end
+
+  # When called from within the GenServer it is passed the state
+  # which contains the reference to the ETS table.
+  # When called from outside the GenServer it is passed the opts keyword list
+  # which contains a reference to the GenServer.
+  defp get_column_info_table(%{pg_info_table: ets_table}), do: ets_table
+  defp get_column_info_table(opts), do: GenServer.call(opts[:server], :get_column_info_table)
+
+  defp get_relation_table(%{pg_relation_table: ets_table}), do: ets_table
+  defp get_relation_table(opts), do: GenServer.call(opts[:server], :get_relation_table)
 end

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -14,6 +14,7 @@ defmodule Electric.Replication.ShapeLogCollector do
 
   @schema NimbleOptions.new!(
             electric_instance_id: [type: :atom, required: true],
+            tenant_id: [type: :string, required: true],
             inspector: [type: :mod_arg, required: true],
             # see https://hexdocs.pm/gen_stage/GenStage.html#c:init/1-options
             demand: [type: {:in, [:forward, :accumulate]}, default: :accumulate],
@@ -23,12 +24,14 @@ defmodule Electric.Replication.ShapeLogCollector do
 
   def start_link(opts) do
     with {:ok, opts} <- NimbleOptions.validate(opts, @schema) do
-      GenStage.start_link(__MODULE__, Map.new(opts), name: name(opts[:electric_instance_id]))
+      GenStage.start_link(__MODULE__, Map.new(opts),
+        name: name(opts[:electric_instance_id], opts[:tenant_id])
+      )
     end
   end
 
-  def name(electric_instance_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__)
+  def name(electric_instance_id, tenant_id) do
+    Electric.Application.process_name(electric_instance_id, tenant_id, __MODULE__)
   end
 
   # use `GenStage.call/2` here to make the event processing synchronous.

--- a/packages/sync-service/lib/electric/service_status.ex
+++ b/packages/sync-service/lib/electric/service_status.ex
@@ -1,12 +1,14 @@
 defmodule Electric.ServiceStatus do
   @type status() :: :waiting | :starting | :active | :stopping
 
-  @spec check() :: status()
-  def check() do
+  @spec check(atom | String.t(), String.t()) :: status()
+  def check(electric_instance_id, tenant_id) do
     # Match the connection status ot a service status - currently
     # they are one and the same but keeping this decoupled for future
     # additions to conditions that determine service status
-    case Electric.Connection.Manager.get_status(Electric.Connection.Manager) do
+    conn_mgr = Electric.Connection.Manager.name(electric_instance_id, tenant_id)
+
+    case Electric.Connection.Manager.get_status(conn_mgr) do
       :waiting -> :waiting
       :starting -> :starting
       :active -> :active

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -38,19 +38,15 @@ defmodule Electric.ShapeCache do
 
   @type shape_id :: Electric.ShapeCacheBehaviour.shape_id()
 
-  @default_shape_meta_table :shape_meta_table
-
-  @genserver_name_schema {:or, [:atom, {:tuple, [:atom, :atom, :any]}]}
+  @name_schema_tuple {:tuple, [:atom, :atom, :any]}
+  @genserver_name_schema {:or, [:atom, @name_schema_tuple]}
   @schema NimbleOptions.new!(
             name: [
               type: @genserver_name_schema,
-              default: __MODULE__
+              required: false
             ],
             electric_instance_id: [type: :atom, required: true],
-            shape_meta_table: [
-              type: :atom,
-              default: @default_shape_meta_table
-            ],
+            tenant_id: [type: :string, required: true],
             log_producer: [type: @genserver_name_schema, required: true],
             consumer_supervisor: [type: @genserver_name_schema, required: true],
             storage: [type: :mod_arg, required: true],
@@ -58,7 +54,7 @@ defmodule Electric.ShapeCache do
             inspector: [type: :mod_arg, required: true],
             shape_status: [type: :atom, default: Electric.ShapeCache.ShapeStatus],
             registry: [type: {:or, [:atom, :pid]}, required: true],
-            db_pool: [type: {:or, [:atom, :pid]}, default: Electric.DbPool],
+            db_pool: [type: {:or, [:atom, :pid, @name_schema_tuple]}],
             run_with_conn_fn: [type: {:fun, 2}, default: &DBConnection.run/2],
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
@@ -68,15 +64,44 @@ defmodule Electric.ShapeCache do
             purge_all_shapes?: [type: :boolean, required: false]
           )
 
+  def name(electric_instance_id, tenant_id) do
+    Electric.Application.process_name(electric_instance_id, tenant_id, __MODULE__)
+  end
+
+  def name(opts) do
+    electric_instance_id = Access.fetch!(opts, :electric_instance_id)
+    tenant_id = Access.fetch!(opts, :tenant_id)
+    name(electric_instance_id, tenant_id)
+  end
+
   def start_link(opts) do
     with {:ok, opts} <- NimbleOptions.validate(opts, @schema) do
-      GenServer.start_link(__MODULE__, Map.new(opts), name: opts[:name])
+      electric_instance_id = Keyword.fetch!(opts, :electric_instance_id)
+      tenant_id = Keyword.fetch!(opts, :tenant_id)
+      name = Keyword.get(opts, :name, name(electric_instance_id, tenant_id))
+
+      db_pool =
+        Keyword.get(
+          opts,
+          :db_pool,
+          Electric.Application.process_name(
+            Keyword.fetch!(opts, :electric_instance_id),
+            Keyword.fetch!(opts, :tenant_id),
+            Electric.DbPool
+          )
+        )
+
+      GenServer.start_link(
+        __MODULE__,
+        Map.new(opts) |> Map.put(:db_pool, db_pool) |> Map.put(:name, name),
+        name: name
+      )
     end
   end
 
   @impl Electric.ShapeCacheBehaviour
   def get_shape(shape, opts \\ []) do
-    table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    table = get_shape_meta_table(opts)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
     shape_status.get_existing_shape(table, shape)
   end
@@ -87,7 +112,7 @@ defmodule Electric.ShapeCache do
     if shape_state = get_shape(shape, opts) do
       shape_state
     else
-      server = Access.get(opts, :server, __MODULE__)
+      server = Access.get(opts, :server, name(opts))
       GenServer.call(server, {:create_or_wait_shape_id, shape})
     end
   end
@@ -96,7 +121,7 @@ defmodule Electric.ShapeCache do
   @spec update_shape_latest_offset(shape_id(), LogOffset.t(), opts :: keyword()) ::
           :ok | {:error, term()}
   def update_shape_latest_offset(shape_id, latest_offset, opts) do
-    meta_table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    meta_table = get_shape_meta_table(opts)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
     if shape_status.set_latest_offset(meta_table, shape_id, latest_offset) do
@@ -117,30 +142,31 @@ defmodule Electric.ShapeCache do
   @impl Electric.ShapeCacheBehaviour
   @spec clean_shape(shape_id(), keyword()) :: :ok
   def clean_shape(shape_id, opts) do
-    server = Access.get(opts, :server, __MODULE__)
+    server = Access.get(opts, :server, name(opts))
     GenServer.call(server, {:clean, shape_id})
   end
 
   @impl Electric.ShapeCacheBehaviour
   @spec clean_all_shapes(keyword()) :: :ok
   def clean_all_shapes(opts) do
-    server = Access.get(opts, :server, __MODULE__)
+    server = Access.get(opts, :server, name(opts))
     GenServer.call(server, {:clean_all})
   end
 
   @impl Electric.ShapeCacheBehaviour
   @spec handle_truncate(shape_id(), keyword()) :: :ok
   def handle_truncate(shape_id, opts \\ []) do
-    server = Access.get(opts, :server, __MODULE__)
+    server = Access.get(opts, :server, name(opts))
     GenServer.call(server, {:truncate, shape_id})
   end
 
   @impl Electric.ShapeCacheBehaviour
   @spec await_snapshot_start(shape_id(), keyword()) :: :started | {:error, term()}
   def await_snapshot_start(shape_id, opts \\ []) when is_binary(shape_id) do
-    table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    table = get_shape_meta_table(opts)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
     electric_instance_id = Access.fetch!(opts, :electric_instance_id)
+    tenant_id = Access.fetch!(opts, :tenant_id)
 
     cond do
       shape_status.snapshot_started?(table, shape_id) ->
@@ -150,39 +176,46 @@ defmodule Electric.ShapeCache do
         {:error, :unknown}
 
       true ->
-        server = Electric.Shapes.Consumer.name(electric_instance_id, shape_id)
+        server = Electric.Shapes.Consumer.name(electric_instance_id, tenant_id, shape_id)
         GenServer.call(server, :await_snapshot_start)
     end
   end
 
   @impl Electric.ShapeCacheBehaviour
   def has_shape?(shape_id, opts \\ []) do
-    table = Access.get(opts, :shape_meta_table, @default_shape_meta_table)
+    table = get_shape_meta_table(opts)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
     if shape_status.get_existing_shape(table, shape_id) do
       true
     else
-      server = Access.get(opts, :server, __MODULE__)
+      server = Access.get(opts, :server, name(opts))
       GenServer.call(server, {:wait_shape_id, shape_id})
     end
   end
 
   @impl GenServer
   def init(opts) do
+    # Each tenant creates its own ETS table for storing shape meta data.
+    # We don't use a named table to avoid creating atoms dynamically for each tenant.
+    # Instead, we use the reference to the table that is returned by `:ets.new`.
+    # This requires storing the reference in the GenServer and exposing it through a `get_shape_meta_table` method.
+    meta_table = :ets.new(:shape_meta_table, [:public, :ordered_set])
+
     {:ok, shape_status_state} =
       opts.shape_status.initialise(
-        shape_meta_table: opts.shape_meta_table,
+        shape_meta_table: meta_table,
         storage: opts.storage
       )
 
     state = %{
       name: opts.name,
       electric_instance_id: opts.electric_instance_id,
+      tenant_id: opts.tenant_id,
       storage: opts.storage,
       chunk_bytes_threshold: opts.chunk_bytes_threshold,
       inspector: opts.inspector,
-      shape_meta_table: opts.shape_meta_table,
+      shape_meta_table: meta_table,
       shape_status: opts.shape_status,
       db_pool: opts.db_pool,
       shape_status_state: shape_status_state,
@@ -258,10 +291,16 @@ defmodule Electric.ShapeCache do
     {:reply, :ok, state}
   end
 
+  # Returns a reference to the ETS table that stores shape meta data for this tenant
+  def handle_call(:get_shape_meta_table, _from, %{shape_meta_table: table} = state) do
+    {:reply, table, state}
+  end
+
   defp clean_up_shape(state, shape_id) do
     Electric.Shapes.ConsumerSupervisor.stop_shape_consumer(
       state.consumer_supervisor,
       state.electric_instance_id,
+      state.tenant_id,
       shape_id
     )
 
@@ -291,6 +330,7 @@ defmodule Electric.ShapeCache do
              state.consumer_supervisor,
              electric_instance_id: state.electric_instance_id,
              inspector: state.inspector,
+             tenant_id: state.tenant_id,
              shape_id: shape_id,
              shape: shape,
              shape_status: {state.shape_status, state.shape_status_state},
@@ -298,18 +338,29 @@ defmodule Electric.ShapeCache do
              chunk_bytes_threshold: state.chunk_bytes_threshold,
              log_producer: state.log_producer,
              shape_cache:
-               {__MODULE__, %{server: state.name, shape_meta_table: state.shape_meta_table}},
+               {__MODULE__,
+                %{
+                  server: state.name,
+                  shape_meta_table: state.shape_meta_table,
+                  electric_instance_id: state.electric_instance_id,
+                  tenant_id: state.tenant_id
+                }},
              registry: state.registry,
              db_pool: state.db_pool,
              run_with_conn_fn: state.run_with_conn_fn,
              prepare_tables_fn: state.prepare_tables_fn,
              create_snapshot_fn: state.create_snapshot_fn
            ) do
-      consumer = Shapes.Consumer.name(state.electric_instance_id, shape_id)
+      consumer = Shapes.Consumer.name(state.electric_instance_id, state.tenant_id, shape_id)
 
       {:ok, snapshot_xmin, latest_offset} = Shapes.Consumer.initial_state(consumer)
 
       {:ok, pid, snapshot_xmin, latest_offset}
     end
+  end
+
+  defp get_shape_meta_table(opts) do
+    server = Access.get(opts, :server, name(opts))
+    GenStage.call(server, :get_shape_meta_table)
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
@@ -9,7 +9,7 @@ defmodule Electric.ShapeCache.CrashingFileStorage do
 
   @num_calls_until_crash_key :num_calls_until_crash
 
-  defdelegate for_shape(shape_id, opts), to: FileStorage
+  defdelegate for_shape(shape_id, tenant_id, opts), to: FileStorage
   defdelegate start_link(opts), to: FileStorage
   defdelegate set_shape_definition(shape, opts), to: FileStorage
   defdelegate get_all_stored_shapes(opts), to: FileStorage

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -26,6 +26,7 @@ defmodule Electric.ShapeCache.FileStorage do
     :shape_definition_dir,
     :snapshot_dir,
     :electric_instance_id,
+    :tenant_id,
     :extra_opts,
     version: @version
   ]
@@ -34,8 +35,9 @@ defmodule Electric.ShapeCache.FileStorage do
   def shared_opts(opts) do
     storage_dir = Keyword.get(opts, :storage_dir, "./shapes")
     electric_instance_id = Keyword.fetch!(opts, :electric_instance_id)
+    tenant_id = Keyword.fetch!(opts, :tenant_id)
 
-    %{base_path: storage_dir, electric_instance_id: electric_instance_id}
+    %{base_path: storage_dir, electric_instance_id: electric_instance_id, tenant_id: tenant_id}
   end
 
   @impl Electric.ShapeCache.Storage
@@ -56,6 +58,7 @@ defmodule Electric.ShapeCache.FileStorage do
       snapshot_dir: Path.join([base_path, tenant_id, shape_id, "snapshots"]),
       shape_definition_dir: Path.join([base_path, tenant_id, shape_id]),
       electric_instance_id: electric_instance_id,
+      tenant_id: tenant_id,
       extra_opts: Map.get(opts, :extra_opts, %{})
     }
   end

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -39,28 +39,29 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def for_shape(shape_id, %FS{shape_id: shape_id} = opts) do
+  def for_shape(shape_id, _tenant_id, %FS{shape_id: shape_id} = opts) do
     opts
   end
 
   def for_shape(
         shape_id,
+        tenant_id,
         %{base_path: base_path, electric_instance_id: electric_instance_id} = opts
       ) do
     %FS{
       base_path: base_path,
       shape_id: shape_id,
-      db: name(electric_instance_id, shape_id),
-      cubdb_dir: Path.join([base_path, shape_id, "cubdb"]),
-      snapshot_dir: Path.join([base_path, shape_id, "snapshots"]),
-      shape_definition_dir: Path.join([base_path, shape_id]),
+      db: name(electric_instance_id, tenant_id, shape_id),
+      cubdb_dir: Path.join([base_path, tenant_id, shape_id, "cubdb"]),
+      snapshot_dir: Path.join([base_path, tenant_id, shape_id, "snapshots"]),
+      shape_definition_dir: Path.join([base_path, tenant_id, shape_id]),
       electric_instance_id: electric_instance_id,
       extra_opts: Map.get(opts, :extra_opts, %{})
     }
   end
 
-  def name(electric_instance_id, shape_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_id)
+  defp name(electric_instance_id, tenant_id, shape_id) do
+    Electric.Application.process_name(electric_instance_id, tenant_id, __MODULE__, shape_id)
   end
 
   def child_spec(%FS{} = opts) do

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -124,12 +124,16 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def get_all_stored_shapes(%{base_path: base_path}) do
-    case File.ls(base_path) do
+  def get_all_stored_shapes(opts) do
+    shapes_dir = Path.join([opts.base_path, opts.tenant_id])
+
+    case File.ls(shapes_dir) do
       {:ok, shape_ids} ->
         Enum.reduce(shape_ids, %{}, fn shape_id, acc ->
           shape_def_path =
-            shape_definition_path(%{shape_definition_dir: Path.join(base_path, shape_id)})
+            shape_definition_path(%{
+              shape_definition_dir: Path.join([opts.base_path, opts.tenant_id, shape_id])
+            })
 
           with {:ok, shape_def_encoded} <- File.read(shape_def_path),
                {:ok, shape_def_json} <- Jason.decode(shape_def_encoded),

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -27,8 +27,13 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   def shared_opts(opts) do
     table_base_name = Access.get(opts, :table_base_name, __MODULE__)
     electric_instance_id = Keyword.fetch!(opts, :electric_instance_id)
+    tenant_id = Keyword.fetch!(opts, :tenant_id)
 
-    %{table_base_name: table_base_name, electric_instance_id: electric_instance_id}
+    %{
+      table_base_name: table_base_name,
+      electric_instance_id: electric_instance_id,
+      tenant_id: tenant_id
+    }
   end
 
   def name(electric_instance_id, tenant_id, shape_id) when is_binary(shape_id) do

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -74,10 +74,8 @@ defmodule Electric.ShapeCache.ShapeStatus do
   @spec initialise(options()) :: {:ok, t()} | {:error, term()}
   def initialise(opts) do
     with {:ok, config} <- NimbleOptions.validate(opts, @schema),
-         {:ok, table_name} = Access.fetch(config, :shape_meta_table),
+         {:ok, meta_table} = Access.fetch(config, :shape_meta_table),
          {:ok, storage} = Access.fetch(config, :storage) do
-      meta_table = :ets.new(table_name, [:named_table, :public, :ordered_set])
-
       state =
         struct(
           __MODULE__,
@@ -232,7 +230,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     snapshot_xmin(table, shape_id)
   end
 
-  def snapshot_xmin(meta_table, shape_id) when is_atom(meta_table) do
+  def snapshot_xmin(meta_table, shape_id) when is_reference(meta_table) do
     turn_raise_into_error(fn ->
       :ets.lookup_element(
         meta_table,

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -5,6 +5,7 @@ defmodule Electric.ShapeCache.Storage do
   alias Electric.Shapes.Querying
   alias Electric.Replication.LogOffset
 
+  @type tenant_id :: String.t()
   @type shape_id :: Electric.ShapeCacheBehaviour.shape_id()
   @type xmin :: Electric.ShapeCacheBehaviour.xmin()
   @type offset :: LogOffset.t()
@@ -25,7 +26,7 @@ defmodule Electric.ShapeCache.Storage do
   @callback shared_opts(Keyword.t()) :: compiled_opts()
 
   @doc "Initialise shape-specific opts from the shared, global, configuration"
-  @callback for_shape(shape_id(), compiled_opts()) :: shape_opts()
+  @callback for_shape(shape_id(), tenant_id(), compiled_opts()) :: shape_opts()
 
   @doc "Start any processes required to run the storage backend"
   @callback start_link(shape_opts()) :: GenServer.on_start()
@@ -113,8 +114,8 @@ defmodule Electric.ShapeCache.Storage do
   end
 
   @impl __MODULE__
-  def for_shape(shape_id, {mod, opts}) do
-    {mod, mod.for_shape(shape_id, opts)}
+  def for_shape(shape_id, tenant_id, {mod, opts}) do
+    {mod, mod.for_shape(shape_id, tenant_id, opts)}
   end
 
   @impl __MODULE__

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -10,9 +10,9 @@ defmodule Electric.Shapes do
   @doc """
   Get snapshot for the shape ID
   """
-  def get_snapshot(config, shape_id) do
+  def get_snapshot(config, shape_id, tenant_id) do
     {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
-    storage = shape_storage(config, shape_id)
+    storage = shape_storage(config, shape_id, tenant_id)
 
     if shape_cache.has_shape?(shape_id, opts) do
       with :started <- shape_cache.await_snapshot_start(shape_id, opts) do
@@ -26,11 +26,11 @@ defmodule Electric.Shapes do
   @doc """
   Get stream of the log since a given offset
   """
-  def get_log_stream(config, shape_id, opts) do
+  def get_log_stream(config, shape_id, tenant_id, opts) do
     {shape_cache, shape_cache_opts} = Access.get(config, :shape_cache, {ShapeCache, []})
     offset = Access.get(opts, :since, LogOffset.before_all())
     max_offset = Access.get(opts, :up_to, LogOffset.last())
-    storage = shape_storage(config, shape_id)
+    storage = shape_storage(config, shape_id, tenant_id)
 
     if shape_cache.has_shape?(shape_id, shape_cache_opts) do
       Storage.get_log_stream(offset, max_offset, storage)
@@ -64,10 +64,10 @@ defmodule Electric.Shapes do
 
   If `nil` is returned, chunk is not complete and the shape's latest offset should be used
   """
-  @spec get_chunk_end_log_offset(keyword(), shape_id(), LogOffset.t()) ::
+  @spec get_chunk_end_log_offset(keyword(), shape_id(), LogOffset.t(), String.t()) ::
           LogOffset.t() | nil
-  def get_chunk_end_log_offset(config, shape_id, offset) do
-    storage = shape_storage(config, shape_id)
+  def get_chunk_end_log_offset(config, shape_id, offset, tenant_id) do
+    storage = shape_storage(config, shape_id, tenant_id)
     Storage.get_chunk_end_log_offset(offset, storage)
   end
 
@@ -102,7 +102,7 @@ defmodule Electric.Shapes do
     :ok
   end
 
-  defp shape_storage(config, shape_id) do
-    Storage.for_shape(shape_id, Access.fetch!(config, :storage))
+  defp shape_storage(config, shape_id, tenant_id) do
+    Storage.for_shape(shape_id, tenant_id, Access.fetch!(config, :storage))
   end
 end

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -10,12 +10,12 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
   require Logger
 
-  def name(%{electric_instance_id: electric_instance_id, shape_id: shape_id}) do
-    name(electric_instance_id, shape_id)
+  def name(%{electric_instance_id: electric_instance_id, tenant_id: tenant_id, shape_id: shape_id}) do
+    name(electric_instance_id, tenant_id, shape_id)
   end
 
-  def name(electric_instance_id, shape_id) when is_binary(shape_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_id)
+  def name(electric_instance_id, tenant_id, shape_id) when is_binary(shape_id) do
+    Electric.Application.process_name(electric_instance_id, tenant_id, __MODULE__, shape_id)
   end
 
   def start_link(config) do
@@ -27,9 +27,14 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
   end
 
   def handle_continue(:start_snapshot, state) do
-    %{shape_id: shape_id, shape: shape, electric_instance_id: electric_instance_id} = state
+    %{
+      shape_id: shape_id,
+      shape: shape,
+      electric_instance_id: electric_instance_id,
+      tenant_id: tenant_id
+    } = state
 
-    case Shapes.Consumer.whereis(electric_instance_id, shape_id) do
+    case Shapes.Consumer.whereis(electric_instance_id, tenant_id, shape_id) do
       consumer when is_pid(consumer) ->
         if not Storage.snapshot_started?(state.storage) do
           %{

--- a/packages/sync-service/lib/electric/shapes/consumer/supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/supervisor.ex
@@ -3,21 +3,23 @@ defmodule Electric.Shapes.Consumer.Supervisor do
 
   require Logger
 
-  @genserver_name_schema {:or, [:atom, {:tuple, [:atom, :atom, :any]}]}
+  @name_schema_tuple {:tuple, [:atom, :atom, :any]}
+  @genserver_name_schema {:or, [:atom, @name_schema_tuple]}
   # TODO: unify these with ShapeCache
   @schema NimbleOptions.new!(
             shape_id: [type: :string, required: true],
             shape: [type: {:struct, Electric.Shapes.Shape}, required: true],
             electric_instance_id: [type: :atom, required: true],
             inspector: [type: :mod_arg, required: true],
+            tenant_id: [type: :string, required: true],
             log_producer: [type: @genserver_name_schema, required: true],
             shape_cache: [type: :mod_arg, required: true],
             registry: [type: :atom, required: true],
             shape_status: [type: :mod_arg, required: true],
             storage: [type: :mod_arg, required: true],
             chunk_bytes_threshold: [type: :non_neg_integer, required: true],
-            db_pool: [type: {:or, [:atom, :pid]}, default: Electric.DbPool],
             run_with_conn_fn: [type: {:fun, 2}, default: &DBConnection.run/2],
+            db_pool: [type: {:or, [:atom, :pid, @name_schema_tuple]}, required: true],
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
               type: {:fun, 5},
@@ -25,12 +27,12 @@ defmodule Electric.Shapes.Consumer.Supervisor do
             ]
           )
 
-  def name(electric_instance_id, shape_id) when is_binary(shape_id) do
-    Electric.Application.process_name(electric_instance_id, __MODULE__, shape_id)
+  def name(electric_instance_id, tenant_id, shape_id) when is_binary(shape_id) do
+    Electric.Application.process_name(electric_instance_id, tenant_id, __MODULE__, shape_id)
   end
 
-  def name(%{electric_instance_id: electric_instance_id, shape_id: shape_id}) do
-    name(electric_instance_id, shape_id)
+  def name(%{electric_instance_id: electric_instance_id, tenant_id: tenant_id, shape_id: shape_id}) do
+    name(electric_instance_id, tenant_id, shape_id)
   end
 
   def start_link(opts) do
@@ -40,19 +42,25 @@ defmodule Electric.Shapes.Consumer.Supervisor do
     end
   end
 
-  def clean_and_stop(%{electric_instance_id: electric_instance_id, shape_id: shape_id}) do
+  def clean_and_stop(%{
+        electric_instance_id: electric_instance_id,
+        tenant_id: tenant_id,
+        shape_id: shape_id
+      }) do
     # if consumer is present, terminate it gracefully, otherwise terminate supervisor
-    case GenServer.whereis(Electric.Shapes.Consumer.name(electric_instance_id, shape_id)) do
-      nil -> Supervisor.stop(name(electric_instance_id, shape_id))
+    case GenServer.whereis(
+           Electric.Shapes.Consumer.name(electric_instance_id, tenant_id, shape_id)
+         ) do
+      nil -> Supervisor.stop(name(electric_instance_id, tenant_id, shape_id))
       consumer_pid when is_pid(consumer_pid) -> GenServer.call(consumer_pid, :clean_and_stop)
     end
   end
 
   def init(config) when is_map(config) do
-    %{shape_id: shape_id, storage: {_, _} = storage} =
+    %{shape_id: shape_id, tenant_id: tenant_id, storage: {_, _} = storage} =
       config
 
-    shape_storage = Electric.ShapeCache.Storage.for_shape(shape_id, storage)
+    shape_storage = Electric.ShapeCache.Storage.for_shape(shape_id, tenant_id, storage)
 
     shape_config = %{config | storage: shape_storage}
 

--- a/packages/sync-service/lib/electric/shapes/supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/supervisor.ex
@@ -3,8 +3,18 @@ defmodule Electric.Shapes.Supervisor do
 
   require Logger
 
+  def name(electric_instance_id, tenant_id) do
+    Electric.Application.process_name(electric_instance_id, tenant_id, __MODULE__)
+  end
+
+  def name(opts) do
+    electric_instance_id = Access.fetch!(opts, :electric_instance_id)
+    tenant_id = Access.fetch!(opts, :tenant_id)
+    name(electric_instance_id, tenant_id)
+  end
+
   def start_link(opts) do
-    name = Access.get(opts, :name, __MODULE__)
+    name = Access.get(opts, :name, name(opts))
 
     Supervisor.start_link(__MODULE__, opts, name: name)
   end
@@ -16,12 +26,14 @@ defmodule Electric.Shapes.Supervisor do
     shape_cache = Keyword.fetch!(opts, :shape_cache)
     log_collector = Keyword.fetch!(opts, :log_collector)
     electric_instance_id = Keyword.fetch!(opts, :electric_instance_id)
+    tenant_id = Keyword.fetch!(opts, :tenant_id)
 
     consumer_supervisor =
       Keyword.get(
         opts,
         :consumer_supervisor,
-        {Electric.Shapes.ConsumerSupervisor, [electric_instance_id: electric_instance_id]}
+        {Electric.Shapes.ConsumerSupervisor,
+         [electric_instance_id: electric_instance_id, tenant_id: tenant_id]}
       )
 
     children = [consumer_supervisor, log_collector, shape_cache]

--- a/packages/sync-service/lib/electric/tenant/dynamic_supervisor.ex
+++ b/packages/sync-service/lib/electric/tenant/dynamic_supervisor.ex
@@ -1,0 +1,27 @@
+defmodule Electric.TenantSupervisor do
+  @moduledoc """
+  Responsible for managing tenant processes
+  """
+  use DynamicSupervisor
+
+  alias Electric.Tenant
+
+  require Logger
+
+  @name Electric.DynamicTenantSupervisor
+
+  def start_link(_opts) do
+    DynamicSupervisor.start_link(__MODULE__, [], name: @name)
+  end
+
+  def start_tenant(opts) do
+    Logger.debug(fn -> "Starting tenant for #{Access.fetch!(opts, :tenant_id)}" end)
+    DynamicSupervisor.start_child(@name, {Tenant.Supervisor, opts})
+  end
+
+  @impl true
+  def init(_opts) do
+    Logger.debug(fn -> "Starting #{__MODULE__}" end)
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/packages/sync-service/lib/electric/tenant/supervisor.ex
+++ b/packages/sync-service/lib/electric/tenant/supervisor.ex
@@ -1,0 +1,90 @@
+defmodule Electric.Tenant.Supervisor do
+  use Supervisor, restart: :transient
+
+  require Logger
+
+  def name(electric_instance_id, tenant_id) do
+    Electric.Application.process_name(electric_instance_id, tenant_id, __MODULE__)
+  end
+
+  def name(%{electric_instance_id: electric_instance_id, tenant_id: tenant_id}) do
+    name(electric_instance_id, tenant_id)
+  end
+
+  def start_link(opts) do
+    config = Map.new(opts)
+    Supervisor.start_link(__MODULE__, config, name: name(config))
+  end
+
+  @impl true
+  def init(%{
+        app_config: app_config,
+        tenant_id: tenant_id,
+        connection_opts: connection_opts,
+        inspector: inspector
+      }) do
+    %{electric_instance_id: electric_instance_id} = app_config
+
+    get_pg_version_fn = fn ->
+      server = Electric.Connection.Manager.name(electric_instance_id, tenant_id)
+      Electric.Connection.Manager.get_pg_version(server)
+    end
+
+    prepare_tables_mfa =
+      {Electric.Postgres.Configuration, :configure_tables_for_replication!,
+       [get_pg_version_fn, app_config.replication_opts.publication_name]}
+
+    shape_log_collector =
+      Electric.Replication.ShapeLogCollector.name(electric_instance_id, tenant_id)
+
+    db_pool =
+      Electric.Application.process_name(electric_instance_id, tenant_id, Electric.DbPool)
+
+    shape_cache_opts = [
+      electric_instance_id: electric_instance_id,
+      tenant_id: tenant_id,
+      storage: app_config.storage,
+      inspector: inspector,
+      prepare_tables_fn: prepare_tables_mfa,
+      # TODO: move this to config
+      chunk_bytes_threshold: Application.fetch_env!(:electric, :chunk_bytes_threshold),
+      log_producer: shape_log_collector,
+      consumer_supervisor:
+        Electric.Shapes.ConsumerSupervisor.name(electric_instance_id, tenant_id),
+      registry: Registry.ShapeChanges
+    ]
+
+    connection_manager_opts = [
+      electric_instance_id: electric_instance_id,
+      tenant_id: tenant_id,
+      connection_opts: connection_opts,
+      replication_opts: [
+        publication_name: app_config.replication_opts.publication_name,
+        try_creating_publication?: true,
+        slot_name: app_config.replication_opts.slot_name,
+        transaction_received:
+          {Electric.Replication.ShapeLogCollector, :store_transaction, [shape_log_collector]},
+        relation_received:
+          {Electric.Replication.ShapeLogCollector, :handle_relation_msg, [shape_log_collector]}
+      ],
+      pool_opts: [
+        name: db_pool,
+        pool_size: app_config.pool_opts.size,
+        types: PgInterop.Postgrex.Types
+      ],
+      timeline_opts: [
+        tenant_id: tenant_id,
+        persistent_kv: app_config.persistent_kv
+      ],
+      shape_cache_opts: shape_cache_opts
+    ]
+
+    children = [
+      {Electric.Postgres.Inspector.EtsInspector,
+       pool: db_pool, electric_instance_id: electric_instance_id, tenant_id: tenant_id},
+      {Electric.Connection.Supervisor, connection_manager_opts}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one, auto_shutdown: :any_significant)
+  end
+end

--- a/packages/sync-service/lib/electric/tenant/supervisor.ex
+++ b/packages/sync-service/lib/electric/tenant/supervisor.ex
@@ -19,12 +19,12 @@ defmodule Electric.Tenant.Supervisor do
   @impl true
   def init(%{
         app_config: app_config,
+        electric_instance_id: electric_instance_id,
         tenant_id: tenant_id,
         connection_opts: connection_opts,
-        inspector: inspector
+        inspector: inspector,
+        storage: storage
       }) do
-    %{electric_instance_id: electric_instance_id} = app_config
-
     get_pg_version_fn = fn ->
       server = Electric.Connection.Manager.name(electric_instance_id, tenant_id)
       Electric.Connection.Manager.get_pg_version(server)
@@ -43,7 +43,7 @@ defmodule Electric.Tenant.Supervisor do
     shape_cache_opts = [
       electric_instance_id: electric_instance_id,
       tenant_id: tenant_id,
-      storage: app_config.storage,
+      storage: storage,
       inspector: inspector,
       prepare_tables_fn: prepare_tables_mfa,
       # TODO: move this to config

--- a/packages/sync-service/lib/electric/tenant_manager.ex
+++ b/packages/sync-service/lib/electric/tenant_manager.ex
@@ -1,0 +1,182 @@
+defmodule Electric.TenantManager do
+  use GenServer
+
+  # Public API
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: Access.get(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  Retrieves the only tenant in the system.
+  If there are no tenants, it returns `{:error, :not_found}`.
+  If there are several tenants, it returns `{:error, :several_tenants}`
+  and we should use `get_tenant` instead.
+  """
+  @spec get_only_tenant(Keyword.t()) ::
+          {:ok, Keyword.t()} | {:error, :not_found} | {:error, :several_tenants}
+  def get_only_tenant(opts \\ []) do
+    server = Keyword.get(opts, :tenant_manager, __MODULE__)
+    GenServer.call(server, :get_only_tenant)
+  end
+
+  @doc """
+  Retrieves a tenant by its ID.
+  """
+  @spec get_tenant(String.t(), Keyword.t()) :: {:ok, Keyword.t()} | {:error, :not_found}
+  def get_tenant(tenant_id, opts \\ []) do
+    server = Keyword.get(opts, :tenant_manager, __MODULE__)
+    GenServer.call(server, {:get_tenant, tenant_id})
+  end
+
+  @doc """
+  Creates a new tenant for the provided database URL.
+  """
+  @spec create_tenant(String.t(), Keyword.t(), Keyword.t()) ::
+          :ok | {:error, atom()}
+  def create_tenant(tenant_id, connection_opts, opts \\ []) do
+    app_config =
+      %{electric_instance_id: electric_instance_id} = Electric.Application.Configuration.get()
+
+    inspector =
+      Access.get(
+        opts,
+        :inspector,
+        {Electric.Postgres.Inspector.EtsInspector,
+         electric_instance_id: electric_instance_id,
+         tenant_id: tenant_id,
+         server:
+           Electric.Postgres.Inspector.EtsInspector.name(
+             electric_instance_id,
+             tenant_id
+           )}
+      )
+
+    {:ok, _} =
+      Electric.TenantSupervisor.start_tenant(
+        app_config: app_config,
+        tenant_id: tenant_id,
+        connection_opts: app_config.connection_opts,
+        inspector: inspector
+      )
+
+    # Can't load pg_id here because the connection manager may still be busy
+    # connecting to the DB so it might not be known yet
+    # {pg_id, _} = Electric.Timeline.load_timeline(persistent_kv: persistent_kv)
+    hostname = Access.fetch!(connection_opts, :hostname)
+    port = Access.fetch!(connection_opts, :port)
+    pg_id = hostname <> ":" <> to_string(port)
+
+    tenant = [
+      electric_instance_id: electric_instance_id,
+      tenant_id: tenant_id,
+      pg_id: pg_id,
+      registry: Registry.ShapeChanges,
+      storage: app_config.storage,
+      shape_cache:
+        {Electric.ShapeCache,
+         electric_instance_id: electric_instance_id,
+         tenant_id: tenant_id,
+         server: Electric.ShapeCache.name(electric_instance_id, tenant_id)},
+      get_service_status: fn -> Electric.ServiceStatus.check(electric_instance_id, tenant_id) end,
+      inspector: inspector,
+      long_poll_timeout: 20_000,
+      max_age: Application.fetch_env!(:electric, :cache_max_age),
+      stale_age: Application.fetch_env!(:electric, :cache_stale_age),
+      allow_shape_deletion: Application.get_env(:electric, :allow_shape_deletion, false)
+    ]
+
+    # Store the tenant in the tenant manager
+    store_tenant(tenant, opts)
+  end
+
+  @doc """
+  Stores the provided tenant in the tenant manager.
+  """
+  @spec store_tenant(Keyword.t(), Keyword.t()) :: :ok | {:error, atom()}
+  def store_tenant(tenant, opts \\ []) do
+    server = Keyword.get(opts, :tenant_manager, __MODULE__)
+
+    case GenServer.call(server, {:store_tenant, tenant}) do
+      :tenant_already_exists -> {:error, :tenant_already_exists}
+      :db_already_in_use -> {:error, :db_already_in_use}
+      :ok -> :ok
+    end
+  end
+
+  @doc """
+  Deletes a tenant by its ID.
+  """
+  @spec delete_tenant(String.t(), Keyword.t()) :: :ok
+  def delete_tenant(tenant_id, opts \\ []) do
+    server = Keyword.get(opts, :tenant_manager, __MODULE__)
+
+    case GenServer.call(server, {:get_tenant, tenant_id}) do
+      {:ok, tenant} ->
+        pg_id = Access.fetch!(tenant, :pg_id)
+        GenServer.call(server, {:delete_tenant, tenant_id, pg_id})
+
+      {:error, :not_found} ->
+        :ok
+    end
+  end
+
+  ## Internal API
+
+  @impl GenServer
+  def init(_opts) do
+    # state contains an index `tenants` of tenant_id -> tenant
+    # and a set `dbs` of PG identifiers used by tenants
+    {:ok, %{tenants: Map.new(), dbs: MapSet.new()}}
+  end
+
+  @impl GenServer
+  def handle_call(
+        {:store_tenant, tenant},
+        _from,
+        %{tenants: tenants, dbs: dbs} = state
+      ) do
+    tenant_id = tenant[:tenant_id]
+    pg_id = tenant[:pg_id]
+
+    if Map.has_key?(tenants, tenant_id) do
+      {:reply, :tenant_already_exists, state}
+    else
+      if MapSet.member?(dbs, pg_id) do
+        {:reply, :db_already_in_use, state}
+      else
+        {:reply, :ok,
+         %{tenants: Map.put(tenants, tenant_id, tenant), dbs: MapSet.put(dbs, pg_id)}}
+      end
+    end
+  end
+
+  @impl GenServer
+  def handle_call(:get_only_tenant, _from, %{tenants: tenants} = state) do
+    case map_size(tenants) do
+      1 ->
+        tenant = tenants |> Map.values() |> Enum.at(0)
+        {:reply, {:ok, tenant}, state}
+
+      0 ->
+        {:reply, {:error, :not_found}, state}
+
+      _ ->
+        {:reply, {:error, :several_tenants}, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:get_tenant, tenant_id}, _from, %{tenants: tenants} = state) do
+    if Map.has_key?(tenants, tenant_id) do
+      {:reply, {:ok, Map.get(tenants, tenant_id)}, state}
+    else
+      {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:delete_tenant, tenant_id, pg_id}, _from, %{tenants: tenants, dbs: dbs}) do
+    {:reply, :ok, %{tenants: Map.delete(tenants, tenant_id), dbs: MapSet.delete(dbs, pg_id)}}
+  end
+end

--- a/packages/sync-service/lib/electric/tenant_manager.ex
+++ b/packages/sync-service/lib/electric/tenant_manager.ex
@@ -67,12 +67,19 @@ defmodule Electric.TenantManager do
     port = Access.fetch!(connection_opts, :port)
     pg_id = hostname <> ":" <> to_string(port)
 
+    {storage_module, storage_in_opts} = Application.fetch_env!(:electric, :storage)
+
+    storage_opts =
+      storage_module.shared_opts(storage_in_opts |> Keyword.put(:tenant_id, tenant_id))
+
+    storage = {storage_module, storage_opts}
+
     tenant = [
       electric_instance_id: electric_instance_id,
       tenant_id: tenant_id,
       pg_id: pg_id,
       registry: Registry.ShapeChanges,
-      storage: app_config.storage,
+      storage: storage,
       shape_cache:
         {Electric.ShapeCache,
          electric_instance_id: electric_instance_id,

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -4,6 +4,10 @@ defmodule Electric.Plug.DeleteShapePlugTest do
 
   alias Electric.Plug.DeleteShapePlug
   alias Electric.Shapes.Shape
+  alias Electric.TenantManager
+
+  import Support.ComponentSetup
+  import Support.TestUtils, only: [with_electric_instance_id: 1]
 
   alias Support.Mock
 
@@ -25,6 +29,7 @@ defmodule Electric.Plug.DeleteShapePlugTest do
     }
   }
   @test_shape_id "test-shape-id"
+  @test_pg_id "12345"
 
   def load_column_info({"public", "users"}, _),
     do: {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
@@ -37,26 +42,42 @@ defmodule Electric.Plug.DeleteShapePlugTest do
     :ok
   end
 
-  def conn(method, "?" <> _ = query_string, allow \\ true) do
+  def conn(ctx, method, "?" <> _ = query_string, allow \\ true) do
     # Pass mock dependencies to the plug
-    config = %{
+    tenant = [
+      electric_instance_id: ctx.electric_instance_id,
+      tenant_id: ctx.tenant_id,
+      pg_id: @test_pg_id,
       shape_cache: {Mock.ShapeCache, []},
+      storage: {Mock.Storage, []},
       inspector: {__MODULE__, []},
       registry: @registry,
-      long_poll_timeout: 20_000,
-      max_age: 60,
-      stale_age: 300,
+      long_poll_timeout: Access.get(ctx, :long_poll_timeout, 20_000),
+      max_age: Access.get(ctx, :max_age, 60),
+      stale_age: Access.get(ctx, :stale_age, 300)
+    ]
+
+    # because test mode creates a tenant by default
+    TenantManager.delete_tenant(ctx.tenant_id)
+    :ok = TenantManager.store_tenant(tenant)
+
+    config = [
+      storage: {Mock.Storage, []},
+      tenant_manager: Electric.TenantManager,
       allow_shape_deletion: allow
-    }
+    ]
 
     Plug.Test.conn(method, "/" <> query_string)
     |> assign(:config, config)
   end
 
   describe "DeleteShapePlug" do
-    test "returns 404 if shape deletion is not allowed" do
+    setup [:with_electric_instance_id, :with_tenant_id]
+
+    test "returns 404 if shape deletion is not allowed", ctx do
       conn =
-        conn("DELETE", "?root_table=.invalid_shape", false)
+        ctx
+        |> conn("DELETE", "?root_table=.invalid_shape", false)
         |> DeleteShapePlug.call([])
 
       assert conn.status == 404
@@ -66,9 +87,10 @@ defmodule Electric.Plug.DeleteShapePlugTest do
              }
     end
 
-    test "returns 400 for invalid params" do
+    test "returns 400 for invalid params", ctx do
       conn =
-        conn("DELETE", "?root_table=.invalid_shape")
+        ctx
+        |> conn("DELETE", "?root_table=.invalid_shape")
         |> DeleteShapePlug.call([])
 
       assert conn.status == 400
@@ -80,24 +102,26 @@ defmodule Electric.Plug.DeleteShapePlugTest do
              }
     end
 
-    test "should clean shape based on shape definition" do
+    test "should clean shape based on shape definition", ctx do
       Mock.ShapeCache
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts -> {@test_shape_id, 0} end)
       |> expect(:clean_shape, fn @test_shape_id, _ -> :ok end)
 
       conn =
-        conn(:delete, "?root_table=public.users")
+        ctx
+        |> conn(:delete, "?root_table=public.users")
         |> DeleteShapePlug.call([])
 
       assert conn.status == 202
     end
 
-    test "should clean shape based on shape_id" do
+    test "should clean shape based on shape_id", ctx do
       Mock.ShapeCache
       |> expect(:clean_shape, fn @test_shape_id, _ -> :ok end)
 
       conn =
-        conn(:delete, "?root_table=public.users&shape_id=#{@test_shape_id}")
+        ctx
+        |> conn(:delete, "?root_table=public.users&shape_id=#{@test_shape_id}")
         |> DeleteShapePlug.call([])
 
       assert conn.status == 202

--- a/packages/sync-service/test/electric/plug/health_check_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/health_check_plug_test.exs
@@ -37,21 +37,21 @@ defmodule Electric.Plug.HealthCheckPlugTest do
              ]
     end
 
-    test "returns 200 when in waiting mode" do
+    test "returns 503 when in waiting mode" do
       conn =
         conn(%{connection_status: :waiting})
         |> HealthCheckPlug.call([])
 
-      assert conn.status == 200
+      assert conn.status == 503
       assert Jason.decode!(conn.resp_body) == %{"status" => "waiting"}
     end
 
-    test "returns 200 when in starting mode" do
+    test "returns 503 when in starting mode" do
       conn =
         conn(%{connection_status: :starting})
         |> HealthCheckPlug.call([])
 
-      assert conn.status == 200
+      assert conn.status == 503
       assert Jason.decode!(conn.resp_body) == %{"status" => "starting"}
     end
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -6,6 +6,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
   alias Electric.Replication.LogOffset
   alias Electric.Plug.ServeShapePlug
   alias Electric.Shapes.Shape
+  alias Electric.TenantManager
+
+  import Support.ComponentSetup
 
   alias Support.Mock
 
@@ -36,6 +39,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
   @first_offset LogOffset.first()
   @test_offset LogOffset.new(Lsn.from_integer(100), 0)
   @start_offset_50 LogOffset.new(Lsn.from_integer(50), 0)
+  @test_pg_id "12345"
 
   def load_column_info({"public", "users"}, _),
     do: {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
@@ -51,17 +55,29 @@ defmodule Electric.Plug.ServeShapePlugTest do
     :ok
   end
 
-  def conn(method, params, "?" <> _ = query_string) do
+  def conn(ctx, method, params, "?" <> _ = query_string) do
     # Pass mock dependencies to the plug
-    config = %{
+    tenant = [
+      electric_instance_id: ctx.electric_instance_id,
+      tenant_id: ctx.tenant_id,
+      pg_id: @test_pg_id,
       shape_cache: {Mock.ShapeCache, []},
       storage: {Mock.Storage, []},
       inspector: {__MODULE__, []},
       registry: @registry,
-      long_poll_timeout: 20_000,
-      max_age: 60,
-      stale_age: 300
-    }
+      long_poll_timeout: Access.get(ctx, :long_poll_timeout, 20_000),
+      max_age: Access.get(ctx, :max_age, 60),
+      stale_age: Access.get(ctx, :stale_age, 300)
+    ]
+
+    # because test mode creates a tenant by default
+    TenantManager.delete_tenant(ctx.tenant_id)
+    :ok = TenantManager.store_tenant(tenant)
+
+    config = [
+      storage: {Mock.Storage, []},
+      tenant_manager: Electric.TenantManager
+    ]
 
     Plug.Test.conn(method, "/" <> query_string, params)
     |> assign(:config, config)
@@ -126,10 +142,16 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Electric.Plug.ServeShapePlug.TimeUtils.seconds_since_oct9th_2024_next_interval(conn) !=
                expected_interval
     end
+  end
 
-    test "returns 400 for invalid params" do
+  describe "serving shape" do
+    setup :with_electric_instance_id
+    setup :with_tenant_id
+
+    test "returns 400 for invalid params", ctx do
       conn =
-        conn(:get, %{"root_table" => ".invalid_shape"}, "?offset=invalid")
+        ctx
+        |> conn(:get, %{"root_table" => ".invalid_shape"}, "?offset=invalid")
         |> ServeShapePlug.call([])
 
       assert conn.status == 400
@@ -142,11 +164,12 @@ defmodule Electric.Plug.ServeShapePlugTest do
              }
     end
 
-    test "returns 400 when table does not exist" do
+    test "returns 400 when table does not exist", ctx do
       # this will pass table name validation
       # but will fail to find the table
       conn =
-        conn(:get, %{"root_table" => "_val1d_schëmaΦ$.Φtàble"}, "?offset=-1")
+        ctx
+        |> conn(:get, %{"root_table" => "_val1d_schëmaΦ$.Φtàble"}, "?offset=-1")
         |> ServeShapePlug.call([])
 
       assert conn.status == 400
@@ -156,9 +179,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
              }
     end
 
-    test "returns 400 for missing shape_id when offset != -1" do
+    test "returns 400 for missing shape_id when offset != -1", ctx do
       conn =
-        conn(:get, %{"root_table" => "public.users"}, "?offset=#{LogOffset.first()}")
+        ctx
+        |> conn(:get, %{"root_table" => "public.users"}, "?offset=#{LogOffset.first()}")
         |> ServeShapePlug.call([])
 
       assert conn.status == 400
@@ -168,9 +192,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
              }
     end
 
-    test "returns 400 for live request when offset == -1" do
+    test "returns 400 for live request when offset == -1", ctx do
       conn =
-        conn(
+        ctx
+        |> conn(
           :get,
           %{"root_table" => "public.users"},
           "?offset=#{LogOffset.before_all()}&live=true"
@@ -184,7 +209,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              }
     end
 
-    test "returns snapshot when offset is -1" do
+    test "returns snapshot when offset is -1", %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -195,7 +220,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       next_offset = LogOffset.increment(@first_offset)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
@@ -207,7 +232,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       end)
 
       conn =
-        conn(:get, %{"root_table" => "public.users"}, "?offset=-1")
+        ctx
+        |> conn(:get, %{"root_table" => "public.users"}, "?offset=-1")
         |> ServeShapePlug.call([])
 
       assert conn.status == 200
@@ -229,7 +255,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Plug.Conn.get_resp_header(conn, "electric-shape-id") == [@test_shape_id]
     end
 
-    test "snapshot has correct cache control headers" do
+    test "snapshot has correct cache control headers", %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -240,7 +266,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       next_offset = LogOffset.increment(@first_offset)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
@@ -255,9 +281,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
       stale_age = 312
 
       conn =
-        conn(:get, %{"root_table" => "public.users"}, "?offset=-1")
-        |> put_in_config(:max_age, max_age)
-        |> put_in_config(:stale_age, stale_age)
+        ctx
+        |> Map.put(:max_age, max_age)
+        |> Map.put(:stale_age, stale_age)
+        |> conn(:get, %{"root_table" => "public.users"}, "?offset=-1")
         |> ServeShapePlug.call([])
 
       assert conn.status == 200
@@ -267,7 +294,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
     end
 
-    test "response has correct schema header" do
+    test "response has correct schema header", %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_or_create_shape_id, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -278,7 +305,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       next_offset = LogOffset.increment(@first_offset)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
@@ -290,7 +317,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       end)
 
       conn =
-        conn(:get, %{"root_table" => "public.users"}, "?offset=-1")
+        ctx
+        |> conn(:get, %{"root_table" => "public.users"}, "?offset=-1")
         |> ServeShapePlug.call([])
 
       assert Plug.Conn.get_resp_header(conn, "electric-schema") == [
@@ -298,7 +326,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
     end
 
-    test "returns log when offset is >= 0" do
+    test "returns log when offset is >= 0", %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -309,7 +337,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       next_next_offset = LogOffset.increment(next_offset)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @start_offset_50, _ ->
         next_next_offset
       end)
@@ -321,7 +349,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       end)
 
       conn =
-        conn(
+        ctx
+        |> conn(
           :get,
           %{"root_table" => "public.users"},
           "?offset=#{@start_offset_50}&shape_id=#{@test_shape_id}"
@@ -358,7 +387,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == []
     end
 
-    test "returns 304 Not Modified when If-None-Match matches ETag" do
+    test "returns 304 Not Modified when If-None-Match matches ETag",
+         %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -366,13 +396,14 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @start_offset_50, _ ->
         @test_offset
       end)
 
       conn =
-        conn(
+        ctx
+        |> conn(
           :get,
           %{"root_table" => "public.users"},
           "?offset=#{@start_offset_50}&shape_id=#{@test_shape_id}"
@@ -387,7 +418,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert conn.resp_body == ""
     end
 
-    test "handles live updates" do
+    test "handles live updates", %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -399,7 +430,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       next_offset_str = "#{next_offset}"
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
@@ -413,7 +444,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       task =
         Task.async(fn ->
-          conn(
+          ctx
+          |> conn(
             :get,
             %{"root_table" => "public.users"},
             "?offset=#{@test_offset}&shape_id=#{@test_shape_id}&live=true"
@@ -426,7 +458,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       Process.sleep(50)
 
       # Simulate new changes arriving
-      Registry.dispatch(@registry, @test_shape_id, fn [{pid, ref}] ->
+      Registry.dispatch(@registry, {ctx.tenant_id, @test_shape_id}, fn [{pid, ref}] ->
         send(pid, {ref, :new_changes, next_offset})
       end)
 
@@ -449,7 +481,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Plug.Conn.get_resp_header(conn, "electric-schema") == []
     end
 
-    test "handles shape rotation" do
+    test "handles shape rotation", %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -459,7 +491,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       test_pid = self()
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
@@ -470,7 +502,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       task =
         Task.async(fn ->
-          conn(
+          ctx
+          |> conn(
             :get,
             %{"root_table" => "public.users"},
             "?offset=#{@test_offset}&shape_id=#{@test_shape_id}&live=true"
@@ -483,7 +516,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       Process.sleep(50)
 
       # Simulate shape rotation
-      Registry.dispatch(@registry, @test_shape_id, fn [{pid, ref}] ->
+      Registry.dispatch(@registry, {ctx.tenant_id, @test_shape_id}, fn [{pid, ref}] ->
         send(pid, {ref, :shape_rotation})
       end)
 
@@ -497,7 +530,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == [""]
     end
 
-    test "sends an up-to-date response after a timeout if no changes are observed" do
+    test "sends an up-to-date response after a timeout if no changes are observed",
+         %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -505,7 +539,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, _opts -> @test_opts end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
         nil
       end)
@@ -514,12 +548,13 @@ defmodule Electric.Plug.ServeShapePlugTest do
       end)
 
       conn =
-        conn(
+        ctx
+        |> Map.put(:long_poll_timeout, 100)
+        |> conn(
           :get,
           %{"root_table" => "public.users"},
           "?offset=#{@test_offset}&shape_id=#{@test_shape_id}&live=true"
         )
-        |> put_in_config(:long_poll_timeout, 100)
         |> ServeShapePlug.call([])
 
       assert conn.status == 204
@@ -533,7 +568,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Plug.Conn.get_resp_header(conn, "electric-chunk-up-to-date") == [""]
     end
 
-    test "sends 409 with a redirect to existing shape when requested shape ID does not exist" do
+    test "sends 409 with a redirect to existing shape when requested shape ID does not exist",
+         %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->
         {@test_shape_id, @test_offset}
@@ -541,10 +577,11 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> stub(:has_shape?, fn "foo", _opts -> false end)
 
       Mock.Storage
-      |> stub(:for_shape, fn "foo", opts -> {"foo", opts} end)
+      |> stub(:for_shape, fn "foo", ^tenant_id, opts -> {"foo", opts} end)
 
       conn =
-        conn(
+        ctx
+        |> conn(
           :get,
           %{"root_table" => "public.users"},
           "?offset=#{"50_12"}&shape_id=foo"
@@ -558,7 +595,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert get_resp_header(conn, "location") == ["/?shape_id=#{@test_shape_id}&offset=-1"]
     end
 
-    test "creates a new shape when shape ID does not exist and sends a 409 redirecting to the newly created shape" do
+    test "creates a new shape when shape ID does not exist and sends a 409 redirecting to the newly created shape",
+         %{tenant_id: tenant_id} = ctx do
       new_shape_id = "new-shape-id"
 
       Mock.ShapeCache
@@ -569,10 +607,11 @@ defmodule Electric.Plug.ServeShapePlugTest do
       end)
 
       Mock.Storage
-      |> stub(:for_shape, fn new_shape_id, opts -> {new_shape_id, opts} end)
+      |> stub(:for_shape, fn new_shape_id, ^tenant_id, opts -> {new_shape_id, opts} end)
 
       conn =
-        conn(
+        ctx
+        |> conn(
           :get,
           %{"root_table" => "public.users"},
           "?offset=#{"50_12"}&shape_id=#{@test_shape_id}"
@@ -586,16 +625,18 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert get_resp_header(conn, "location") == ["/?shape_id=#{new_shape_id}&offset=-1"]
     end
 
-    test "sends 400 when shape ID does not match shape definition" do
+    test "sends 400 when shape ID does not match shape definition",
+         %{tenant_id: tenant_id} = ctx do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts -> nil end)
       |> stub(:has_shape?, fn @test_shape_id, _opts -> true end)
 
       Mock.Storage
-      |> stub(:for_shape, fn @test_shape_id, opts -> {@test_shape_id, opts} end)
+      |> stub(:for_shape, fn @test_shape_id, ^tenant_id, opts -> {@test_shape_id, opts} end)
 
       conn =
-        conn(
+        ctx
+        |> conn(
           :get,
           %{"root_table" => "public.users"},
           "?offset=#{"50_12"}&shape_id=#{@test_shape_id}"
@@ -638,7 +679,4 @@ defmodule Electric.Plug.ServeShapePlugTest do
              }
     end
   end
-
-  defp put_in_config(%Plug.Conn{assigns: assigns} = conn, key, value),
-    do: %{conn | assigns: put_in(assigns, [:config, key], value)}
 end

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -9,6 +9,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
   alias Electric.TenantManager
 
   import Support.ComponentSetup
+  import Support.TestUtils, only: [with_electric_instance_id: 1]
 
   alias Support.Mock
 
@@ -145,8 +146,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
   end
 
   describe "serving shape" do
-    setup :with_electric_instance_id
-    setup :with_tenant_id
+    setup [:with_electric_instance_id, :with_tenant_id]
 
     test "returns 400 for invalid params", ctx do
       conn =
@@ -647,13 +647,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "must-refetch"}}]
     end
 
-    test "sends 400 when omitting primary key columns in selection" do
+    test "sends 400 when omitting primary key columns in selection", ctx do
       conn =
-        conn(
-          :get,
-          %{"root_table" => "public.users", "columns" => "value"},
-          "?offset=-1"
-        )
+        ctx
+        |> conn(:get, %{"root_table" => "public.users", "columns" => "value"}, "?offset=-1")
         |> ServeShapePlug.call([])
 
       assert conn.status == 400
@@ -663,13 +660,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
              }
     end
 
-    test "sends 400 when selecting invalid columns" do
+    test "sends 400 when selecting invalid columns", ctx do
       conn =
-        conn(
-          :get,
-          %{"root_table" => "public.users", "columns" => "id,invalid"},
-          "?offset=-1"
-        )
+        ctx
+        |> conn(:get, %{"root_table" => "public.users", "columns" => "id,invalid"}, "?offset=-1")
         |> ServeShapePlug.call([])
 
       assert conn.status == 400

--- a/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
+++ b/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
@@ -57,15 +57,13 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
     setup [:with_inspector, :with_basic_tables, :with_sql_execute]
 
     setup %{
-      inspector: {EtsInspector, opts},
-      pg_info_table: pg_info_table,
-      pg_relation_table: pg_relation_table
+      inspector: {EtsInspector, opts}
     } do
       {:ok,
        %{
          opts: opts,
-         pg_info_table: pg_info_table,
-         pg_relation_table: pg_relation_table,
+         pg_info_table: GenServer.call(opts[:server], :get_column_info_table),
+         pg_relation_table: GenServer.call(opts[:server], :get_relation_table),
          table: {"public", "items"}
        }}
     end

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -1,6 +1,7 @@
 defmodule Electric.Postgres.ReplicationClientTest do
   use ExUnit.Case, async: true
 
+  import Support.ComponentSetup, only: [with_tenant_id: 1]
   import Support.DbSetup, except: [with_publication: 1]
   import Support.DbStructureSetup
   import Support.TestUtils, only: [with_electric_instance_id: 1]
@@ -32,7 +33,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
     %{dummy_pid: pid}
   end
 
-  setup :with_electric_instance_id
+  setup [:with_electric_instance_id, :with_tenant_id]
 
   describe "ReplicationClient init" do
     setup [:with_unique_db, :with_basic_tables]
@@ -436,6 +437,11 @@ defmodule Electric.Postgres.ReplicationClientTest do
     ctx = Enum.into(overrides, ctx)
 
     {:ok, _pid} =
-      ReplicationClient.start_link(ctx.electric_instance_id, ctx.db_config, ctx.replication_opts)
+      ReplicationClient.start_link(
+        electric_instance_id: ctx.electric_instance_id,
+        tenant_id: ctx.tenant_id,
+        connection_opts: ctx.db_config,
+        replication_opts: ctx.replication_opts
+      )
   end
 end

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -9,14 +9,14 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
   alias Support.Mock
   import Support.ComponentSetup, only: [with_in_memory_storage: 1, with_tenant_id: 1]
-  import Support.TestUtils, only: [with_electric_instance_id: 1, full_test_name: 1]
+  import Support.TestUtils, only: [with_electric_instance_id: 1]
 
   import Mox
 
   @moduletag :capture_log
 
   setup :verify_on_exit!
-  setup [:with_electric_instance_id, :with_in_memory_storage, :with_tenant_id]
+  setup [:with_electric_instance_id, :with_tenant_id, :with_in_memory_storage]
 
   setup(ctx) do
     # Start a test Registry

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -8,7 +8,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   alias Electric.Replication.LogOffset
 
   alias Support.Mock
-  import Support.ComponentSetup, only: [with_in_memory_storage: 1]
+  import Support.ComponentSetup, only: [with_in_memory_storage: 1, with_tenant_id: 1]
   import Support.TestUtils, only: [with_electric_instance_id: 1, full_test_name: 1]
 
   import Mox
@@ -16,7 +16,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   @moduletag :capture_log
 
   setup :verify_on_exit!
-  setup [:with_electric_instance_id, :with_in_memory_storage]
+  setup [:with_electric_instance_id, :with_in_memory_storage, :with_tenant_id]
 
   setup(ctx) do
     # Start a test Registry
@@ -26,6 +26,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     # Start the ShapeLogCollector process
     opts = [
       electric_instance_id: ctx.electric_instance_id,
+      tenant_id: ctx.tenant_id,
       inspector: {Mock.Inspector, []},
       demand: :forward
     ]
@@ -36,11 +37,9 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     |> expect(:initialise, 1, fn _opts -> {:ok, %{}} end)
     |> expect(:list_shapes, 1, fn _ -> [] end)
     # allow the ShapeCache to call this mock
-    |> allow(self(), fn -> GenServer.whereis(Electric.ShapeCache) end)
-
-    # We need a ShapeCache process because it is a GenStage consumer
-    # that handles the Relation events produced by ShapeLogCollector
-    shape_meta_table = :"shape_meta_#{full_test_name(ctx)}"
+    |> allow(self(), fn ->
+      GenServer.whereis(Electric.ShapeCache.name(ctx.electric_instance_id, ctx.tenant_id))
+    end)
 
     shape_cache_opts =
       [
@@ -48,11 +47,12 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
         inspector: {Mock.Inspector, []},
         shape_status: Mock.ShapeStatus,
-        shape_meta_table: shape_meta_table,
         prepare_tables_fn: fn _, _ -> {:ok, [:ok]} end,
-        log_producer: ShapeLogCollector.name(ctx.electric_instance_id),
+        log_producer: ShapeLogCollector.name(ctx.electric_instance_id, ctx.tenant_id),
         electric_instance_id: ctx.electric_instance_id,
-        consumer_supervisor: Electric.Shapes.ConsumerSupervisor.name(ctx.electric_instance_id),
+        tenant_id: ctx.tenant_id,
+        consumer_supervisor:
+          Electric.Shapes.ConsumerSupervisor.name(ctx.electric_instance_id, ctx.tenant_id),
         registry: registry_name
       ]
 

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -25,7 +25,12 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     shape
   end
 
-  defp table_name, do: :"#{__MODULE__}-#{System.unique_integer([:positive, :monotonic])}"
+  defp table_name,
+    do:
+      :ets.new(:"#{__MODULE__}-#{System.unique_integer([:positive, :monotonic])}", [
+        :public,
+        :ordered_set
+      ])
 
   defp new_state(_ctx, opts \\ []) do
     table = Keyword.get(opts, :table, table_name())

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -24,6 +24,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
       }
     }
   }
+  @tenant_id "test_tenant"
 
   @snapshot_offset LogOffset.first()
   @snapshot_offset_encoded to_string(@snapshot_offset)
@@ -534,7 +535,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
   defp start_storage(%{module: module} = context) do
     opts = module |> opts(context) |> module.shared_opts()
-    shape_opts = module.for_shape(@shape_id, opts)
+    shape_opts = module.for_shape(@shape_id, @tenant_id, opts)
     {:ok, _} = module.start_link(shape_opts)
     {:ok, %{module: module, opts: shape_opts}}
   end

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -545,7 +545,8 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
       snapshot_ets_table: String.to_atom("snapshot_ets_table_#{Utils.uuid4()}"),
       log_ets_table: String.to_atom("log_ets_table_#{Utils.uuid4()}"),
       chunk_checkpoint_ets_table: String.to_atom("chunk_checkpoint_ets_table_#{Utils.uuid4()}"),
-      electric_instance_id: electric_instance_id
+      electric_instance_id: electric_instance_id,
+      tenant_id: @tenant_id
     ]
   end
 
@@ -553,7 +554,8 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
     [
       db: String.to_atom("shape_mixed_disk_#{Utils.uuid4()}"),
       storage_dir: tmp_dir,
-      electric_instance_id: electric_instance_id
+      electric_instance_id: electric_instance_id,
+      tenant_id: @tenant_id
     ]
   end
 end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -199,29 +199,30 @@ defmodule Electric.ShapeCacheTest do
 
       assert_received {:called, :create_snapshot_fn}
     end
-#
-#    test "no-ops and warns if snapshot xmin is assigned to unknown shape_id", ctx do
-#      shape_id = "foo"
-#
-#      %{shape_cache_opts: opts} =
-#        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
-#          prepare_tables_fn: @prepare_tables_noop
-#        )
-#
-#      shape_meta_table = Access.fetch!(opts, :shape_meta_table)
-#
-#      log =
-#        capture_log(fn ->
-#          GenServer.cast(Process.whereis(opts[:server]), {:snapshot_xmin_known, shape_id, 10})
-#          Process.sleep(10)
-#        end)
-#
-#      assert log =~
-#               "Got snapshot information for a #{shape_id}, that shape id is no longer valid. Ignoring."
-#
-#      # should have nothing in the meta table
-#      assert :ets.next_lookup(shape_meta_table, :_) == :"$end_of_table"
-#    end
+
+    #
+    #    test "no-ops and warns if snapshot xmin is assigned to unknown shape_id", ctx do
+    #      shape_id = "foo"
+    #
+    #      %{shape_cache_opts: opts} =
+    #        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+    #          prepare_tables_fn: @prepare_tables_noop
+    #        )
+    #
+    #      shape_meta_table = Access.fetch!(opts, :shape_meta_table)
+    #
+    #      log =
+    #        capture_log(fn ->
+    #          GenServer.cast(Process.whereis(opts[:server]), {:snapshot_xmin_known, shape_id, 10})
+    #          Process.sleep(10)
+    #        end)
+    #
+    #      assert log =~
+    #               "Got snapshot information for a #{shape_id}, that shape id is no longer valid. Ignoring."
+    #
+    #      # should have nothing in the meta table
+    #      assert :ets.next_lookup(shape_meta_table, :_) == :"$end_of_table"
+    #    end
   end
 
   describe "get_or_create_shape_id/2 against real db" do
@@ -968,262 +969,262 @@ defmodule Electric.ShapeCacheTest do
     end
   end
 
-#  describe "relation handling" do
-#    @describetag capture_log: true
-#
-#    @describetag :tmp_dir
-#    @snapshot_xmin 10
-#
-#    setup [
-#      :with_electric_instance_id,
-#      :with_tenant_id,
-#      :with_in_memory_storage,
-#      :with_persistent_kv,
-#      :with_log_chunking,
-#      :with_registry,
-#      :with_shape_log_collector,
-#      :with_no_pool
-#    ]
-#
-#    setup(ctx) do
-#      ctx =
-#        with_shape_cache(
-#          Map.merge(ctx, %{inspector: {Mock.Inspector, []}}),
-#          prepare_tables_fn: @prepare_tables_noop,
-#          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
-#            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})
-#            Storage.make_new_snapshot!([["test"]], storage)
-#            GenServer.cast(parent, {:snapshot_started, shape_id})
-#          end
-#        )
-#
-#      ctx
-#    end
-#
-#    defp monitor_consumer(electric_instance_id, tenant_id, shape_id) do
-#      Process.monitor(Shapes.Consumer.whereis(electric_instance_id, tenant_id, shape_id))
-#    end
-#
-#    defp shapes do
-#      shape1 =
-#        Shape.new!("public.test_table",
-#          inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
-#        )
-#
-#      shape2 =
-#        Shape.new!("public.test_table",
-#          inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}]),
-#          where: "id > 5"
-#        )
-#
-#      shape3 =
-#        Shape.new!("public.other_table",
-#          inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
-#        )
-#
-#      [shape1, shape2, shape3]
-#    end
-#
-#    defp start_shapes(%{
-#           shape_cache: {shape_cache, opts},
-#           electric_instance_id: electric_instance_id,
-#           tenant_id: tenant_id
-#         }) do
-#      [shape1, shape2, shape3] = shapes()
-#
-#      {shape_id1, _} = shape_cache.get_or_create_shape_id(shape1, opts)
-#      {shape_id2, _} = shape_cache.get_or_create_shape_id(shape2, opts)
-#      {shape_id3, _} = shape_cache.get_or_create_shape_id(shape3, opts)
-#
-#      :started = shape_cache.await_snapshot_start(shape_id1, opts)
-#      :started = shape_cache.await_snapshot_start(shape_id2, opts)
-#      :started = shape_cache.await_snapshot_start(shape_id3, opts)
-#
-#      ref1 = monitor_consumer(electric_instance_id, tenant_id, shape_id1)
-#      ref2 = monitor_consumer(electric_instance_id, tenant_id, shape_id2)
-#      ref3 = monitor_consumer(electric_instance_id, tenant_id, shape_id3)
-#
-#      [
-#        {shape_id1, ref1},
-#        {shape_id2, ref2},
-#        {shape_id3, ref3}
-#      ]
-#    end
-#
-#    test "stores relation if it is not known", ctx do
-#      %{shape_cache: {_shape_cache, opts}} = ctx
-#
-#      relation_id = "rel1"
-#
-#      rel = %Relation{
-#        id: relation_id,
-#        schema: "public",
-#        table: "test_table",
-#        columns: []
-#      }
-#
-#      Mock.Inspector
-#      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
-#      |> allow(self(), opts[:server])
-#
-#      assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
-#
-#      assert {:ok, ^rel} = wait_for_relation(ctx, relation_id)
-#    end
-#
-#    test "does not clean shapes if relation didn't change", ctx do
-#      %{shape_cache: {shape_cache, opts}} = ctx
-#
-#      relation_id = "rel1"
-#
-#      shape =
-#        Shape.new!("public.test_table",
-#          inspector: StubInspector.new([%{name: "id", type: :int8}])
-#        )
-#
-#      {shape_id, _} = shape_cache.get_or_create_shape_id(shape, opts)
-#
-#      ref = monitor_consumer(ctx.electric_instance_id, ctx.tenant_id, shape_id)
-#
-#      rel = %Relation{
-#        id: relation_id,
-#        schema: "public",
-#        table: "test_table",
-#        columns: []
-#      }
-#
-#      Mock.Inspector
-#      |> expect(:clean_column_info, 1, fn _, _ -> true end)
-#      |> allow(self(), opts[:server])
-#
-#      assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
-#
-#      Mock.Inspector
-#      |> expect(:clean_column_info, 0, fn _, _ -> true end)
-#      |> allow(self(), opts[:server])
-#
-#      assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
-#
-#      refute_receive {:DOWN, ^ref, :process, _, _}
-#    end
-#
-#    test "cleans inspector cache for new relations", ctx do
-#      %{shape_cache: {_shape_cache, opts}} = ctx
-#
-#      relation_id = "rel1"
-#
-#      [
-#        {_shape_id1, _ref1},
-#        {_shape_id2, _ref2},
-#        {_shape_id3, _ref3}
-#      ] = start_shapes(ctx)
-#
-#      rel = %Relation{
-#        id: relation_id,
-#        schema: "public",
-#        table: "test_table",
-#        columns: []
-#      }
-#
-#      Mock.Inspector
-#      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
-#      |> allow(self(), opts[:server])
-#
-#      assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
-#    end
-#
-#    test "cleans shapes affected by table renaming and logs a warning", ctx do
-#      %{shape_cache: {_shape_cache, opts}} = ctx
-#
-#      relation_id = "rel1"
-#
-#      [
-#        {_shape_id1, ref1},
-#        {_shape_id2, ref2},
-#        {_shape_id3, ref3}
-#      ] = start_shapes(ctx)
-#
-#      old_rel = %Relation{
-#        id: relation_id,
-#        schema: "public",
-#        table: "test_table",
-#        columns: []
-#      }
-#
-#      new_rel = %Relation{
-#        id: relation_id,
-#        schema: "public",
-#        table: "renamed_test_table",
-#        columns: []
-#      }
-#
-#      Mock.Inspector
-#      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
-#      |> allow(self(), opts[:server])
-#
-#      assert :ok = ShapeLogCollector.handle_relation_msg(old_rel, ctx.shape_log_collector)
-#
-#      Mock.Inspector
-#      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
-#      |> allow(self(), opts[:server])
-#
-#      log =
-#        capture_log(fn ->
-#          assert :ok = ShapeLogCollector.handle_relation_msg(new_rel, ctx.shape_log_collector)
-#          assert_receive {:DOWN, ^ref1, :process, _, _}
-#          assert_receive {:DOWN, ^ref2, :process, _, _}
-#          refute_receive {:DOWN, ^ref3, :process, _, _}
-#        end)
-#
-#      assert log =~ "Schema for the table public.test_table changed"
-#    end
-#
-#    test "cleans shapes affected by a relation change", ctx do
-#      %{shape_cache: {_shape_cache, opts}} = ctx
-#
-#      relation_id = "rel1"
-#
-#      [
-#        {_shape_id1, ref1},
-#        {_shape_id2, ref2},
-#        {_shape_id3, ref3}
-#      ] = start_shapes(ctx)
-#
-#      old_rel = %Relation{
-#        id: relation_id,
-#        schema: "public",
-#        table: "test_table",
-#        columns: [%Column{name: "id", type_oid: 901}]
-#      }
-#
-#      new_rel = %Relation{
-#        id: relation_id,
-#        schema: "public",
-#        table: "test_table",
-#        columns: [%Column{name: "id", type_oid: 123}]
-#      }
-#
-#      Mock.Inspector
-#      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
-#      |> allow(self(), opts[:server])
-#
-#      assert :ok = ShapeLogCollector.handle_relation_msg(old_rel, ctx.shape_log_collector)
-#
-#      Mock.Inspector
-#      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
-#      |> allow(self(), opts[:server])
-#
-#      log =
-#        capture_log(fn ->
-#          assert :ok = ShapeLogCollector.handle_relation_msg(new_rel, ctx.shape_log_collector)
-#          assert_receive {:DOWN, ^ref1, :process, _, _}
-#          assert_receive {:DOWN, ^ref2, :process, _, _}
-#          refute_receive {:DOWN, ^ref3, :process, _, _}
-#        end)
-#
-#      assert log =~ "Schema for the table public.test_table changed"
-#    end
-#  end
+  #  describe "relation handling" do
+  #    @describetag capture_log: true
+  #
+  #    @describetag :tmp_dir
+  #    @snapshot_xmin 10
+  #
+  #    setup [
+  #      :with_electric_instance_id,
+  #      :with_tenant_id,
+  #      :with_in_memory_storage,
+  #      :with_persistent_kv,
+  #      :with_log_chunking,
+  #      :with_registry,
+  #      :with_shape_log_collector,
+  #      :with_no_pool
+  #    ]
+  #
+  #    setup(ctx) do
+  #      ctx =
+  #        with_shape_cache(
+  #          Map.merge(ctx, %{inspector: {Mock.Inspector, []}}),
+  #          prepare_tables_fn: @prepare_tables_noop,
+  #          create_snapshot_fn: fn parent, shape_id, _shape, _, storage ->
+  #            GenServer.cast(parent, {:snapshot_xmin_known, shape_id, @snapshot_xmin})
+  #            Storage.make_new_snapshot!([["test"]], storage)
+  #            GenServer.cast(parent, {:snapshot_started, shape_id})
+  #          end
+  #        )
+  #
+  #      ctx
+  #    end
+  #
+  #    defp monitor_consumer(electric_instance_id, tenant_id, shape_id) do
+  #      Process.monitor(Shapes.Consumer.whereis(electric_instance_id, tenant_id, shape_id))
+  #    end
+  #
+  #    defp shapes do
+  #      shape1 =
+  #        Shape.new!("public.test_table",
+  #          inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
+  #        )
+  #
+  #      shape2 =
+  #        Shape.new!("public.test_table",
+  #          inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}]),
+  #          where: "id > 5"
+  #        )
+  #
+  #      shape3 =
+  #        Shape.new!("public.other_table",
+  #          inspector: StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
+  #        )
+  #
+  #      [shape1, shape2, shape3]
+  #    end
+  #
+  #    defp start_shapes(%{
+  #           shape_cache: {shape_cache, opts},
+  #           electric_instance_id: electric_instance_id,
+  #           tenant_id: tenant_id
+  #         }) do
+  #      [shape1, shape2, shape3] = shapes()
+  #
+  #      {shape_id1, _} = shape_cache.get_or_create_shape_id(shape1, opts)
+  #      {shape_id2, _} = shape_cache.get_or_create_shape_id(shape2, opts)
+  #      {shape_id3, _} = shape_cache.get_or_create_shape_id(shape3, opts)
+  #
+  #      :started = shape_cache.await_snapshot_start(shape_id1, opts)
+  #      :started = shape_cache.await_snapshot_start(shape_id2, opts)
+  #      :started = shape_cache.await_snapshot_start(shape_id3, opts)
+  #
+  #      ref1 = monitor_consumer(electric_instance_id, tenant_id, shape_id1)
+  #      ref2 = monitor_consumer(electric_instance_id, tenant_id, shape_id2)
+  #      ref3 = monitor_consumer(electric_instance_id, tenant_id, shape_id3)
+  #
+  #      [
+  #        {shape_id1, ref1},
+  #        {shape_id2, ref2},
+  #        {shape_id3, ref3}
+  #      ]
+  #    end
+  #
+  #    test "stores relation if it is not known", ctx do
+  #      %{shape_cache: {_shape_cache, opts}} = ctx
+  #
+  #      relation_id = "rel1"
+  #
+  #      rel = %Relation{
+  #        id: relation_id,
+  #        schema: "public",
+  #        table: "test_table",
+  #        columns: []
+  #      }
+  #
+  #      Mock.Inspector
+  #      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+  #      |> allow(self(), opts[:server])
+  #
+  #      assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
+  #
+  #      assert {:ok, ^rel} = wait_for_relation(ctx, relation_id)
+  #    end
+  #
+  #    test "does not clean shapes if relation didn't change", ctx do
+  #      %{shape_cache: {shape_cache, opts}} = ctx
+  #
+  #      relation_id = "rel1"
+  #
+  #      shape =
+  #        Shape.new!("public.test_table",
+  #          inspector: StubInspector.new([%{name: "id", type: :int8}])
+  #        )
+  #
+  #      {shape_id, _} = shape_cache.get_or_create_shape_id(shape, opts)
+  #
+  #      ref = monitor_consumer(ctx.electric_instance_id, ctx.tenant_id, shape_id)
+  #
+  #      rel = %Relation{
+  #        id: relation_id,
+  #        schema: "public",
+  #        table: "test_table",
+  #        columns: []
+  #      }
+  #
+  #      Mock.Inspector
+  #      |> expect(:clean_column_info, 1, fn _, _ -> true end)
+  #      |> allow(self(), opts[:server])
+  #
+  #      assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
+  #
+  #      Mock.Inspector
+  #      |> expect(:clean_column_info, 0, fn _, _ -> true end)
+  #      |> allow(self(), opts[:server])
+  #
+  #      assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
+  #
+  #      refute_receive {:DOWN, ^ref, :process, _, _}
+  #    end
+  #
+  #    test "cleans inspector cache for new relations", ctx do
+  #      %{shape_cache: {_shape_cache, opts}} = ctx
+  #
+  #      relation_id = "rel1"
+  #
+  #      [
+  #        {_shape_id1, _ref1},
+  #        {_shape_id2, _ref2},
+  #        {_shape_id3, _ref3}
+  #      ] = start_shapes(ctx)
+  #
+  #      rel = %Relation{
+  #        id: relation_id,
+  #        schema: "public",
+  #        table: "test_table",
+  #        columns: []
+  #      }
+  #
+  #      Mock.Inspector
+  #      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+  #      |> allow(self(), opts[:server])
+  #
+  #      assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.shape_log_collector)
+  #    end
+  #
+  #    test "cleans shapes affected by table renaming and logs a warning", ctx do
+  #      %{shape_cache: {_shape_cache, opts}} = ctx
+  #
+  #      relation_id = "rel1"
+  #
+  #      [
+  #        {_shape_id1, ref1},
+  #        {_shape_id2, ref2},
+  #        {_shape_id3, ref3}
+  #      ] = start_shapes(ctx)
+  #
+  #      old_rel = %Relation{
+  #        id: relation_id,
+  #        schema: "public",
+  #        table: "test_table",
+  #        columns: []
+  #      }
+  #
+  #      new_rel = %Relation{
+  #        id: relation_id,
+  #        schema: "public",
+  #        table: "renamed_test_table",
+  #        columns: []
+  #      }
+  #
+  #      Mock.Inspector
+  #      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+  #      |> allow(self(), opts[:server])
+  #
+  #      assert :ok = ShapeLogCollector.handle_relation_msg(old_rel, ctx.shape_log_collector)
+  #
+  #      Mock.Inspector
+  #      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+  #      |> allow(self(), opts[:server])
+  #
+  #      log =
+  #        capture_log(fn ->
+  #          assert :ok = ShapeLogCollector.handle_relation_msg(new_rel, ctx.shape_log_collector)
+  #          assert_receive {:DOWN, ^ref1, :process, _, _}
+  #          assert_receive {:DOWN, ^ref2, :process, _, _}
+  #          refute_receive {:DOWN, ^ref3, :process, _, _}
+  #        end)
+  #
+  #      assert log =~ "Schema for the table public.test_table changed"
+  #    end
+  #
+  #    test "cleans shapes affected by a relation change", ctx do
+  #      %{shape_cache: {_shape_cache, opts}} = ctx
+  #
+  #      relation_id = "rel1"
+  #
+  #      [
+  #        {_shape_id1, ref1},
+  #        {_shape_id2, ref2},
+  #        {_shape_id3, ref3}
+  #      ] = start_shapes(ctx)
+  #
+  #      old_rel = %Relation{
+  #        id: relation_id,
+  #        schema: "public",
+  #        table: "test_table",
+  #        columns: [%Column{name: "id", type_oid: 901}]
+  #      }
+  #
+  #      new_rel = %Relation{
+  #        id: relation_id,
+  #        schema: "public",
+  #        table: "test_table",
+  #        columns: [%Column{name: "id", type_oid: 123}]
+  #      }
+  #
+  #      Mock.Inspector
+  #      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+  #      |> allow(self(), opts[:server])
+  #
+  #      assert :ok = ShapeLogCollector.handle_relation_msg(old_rel, ctx.shape_log_collector)
+  #
+  #      Mock.Inspector
+  #      |> expect(:clean_column_info, 1, fn {"public", "test_table"}, _ -> true end)
+  #      |> allow(self(), opts[:server])
+  #
+  #      log =
+  #        capture_log(fn ->
+  #          assert :ok = ShapeLogCollector.handle_relation_msg(new_rel, ctx.shape_log_collector)
+  #          assert_receive {:DOWN, ^ref1, :process, _, _}
+  #          assert_receive {:DOWN, ^ref2, :process, _, _}
+  #          refute_receive {:DOWN, ^ref3, :process, _, _}
+  #        end)
+  #
+  #      assert log =~ "Schema for the table public.test_table changed"
+  #    end
+  #  end
 
   def prepare_tables_noop(_, _), do: :ok
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -179,7 +179,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       Mock.ShapeCache
       |> expect(:update_shape_latest_offset, 2, fn @shape_id1, ^last_log_offset, _ -> :ok end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
 
       ref = make_ref()
 
@@ -407,16 +407,20 @@ defmodule Electric.Shapes.ConsumerTest do
       }
 
       ref1 =
-        Process.monitor(GenServer.whereis(Consumer.name(ctx.electric_instance_id, @shape_id1)))
+        Process.monitor(
+          GenServer.whereis(Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
+        )
 
       ref2 =
-        Process.monitor(GenServer.whereis(Consumer.name(ctx.electric_instance_id, @shape_id2)))
+        Process.monitor(
+          GenServer.whereis(Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id2))
+        )
 
       Mock.ShapeStatus
       |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
       |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id2))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id2))
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.producer)
 
@@ -435,23 +439,27 @@ defmodule Electric.Shapes.ConsumerTest do
       }
 
       ref1 =
-        Process.monitor(GenServer.whereis(Consumer.name(ctx.electric_instance_id, @shape_id1)))
+        Process.monitor(
+          GenServer.whereis(Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
+        )
 
       ref2 =
-        Process.monitor(GenServer.whereis(Consumer.name(ctx.electric_instance_id, @shape_id2)))
+        Process.monitor(
+          GenServer.whereis(Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id2))
+        )
 
       # also cleans up inspector cache and shape status cache
       Mock.Inspector
       |> expect(:clean, 1, fn _, _ -> true end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
       |> expect(:clean, 0, fn _, _ -> true end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id2))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id2))
 
       Mock.ShapeStatus
       |> expect(:remove_shape, 1, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
       |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id2))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id2))
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.producer)
 
@@ -473,23 +481,27 @@ defmodule Electric.Shapes.ConsumerTest do
       }
 
       ref1 =
-        Process.monitor(GenServer.whereis(Consumer.name(ctx.electric_instance_id, @shape_id1)))
+        Process.monitor(
+          GenServer.whereis(Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
+        )
 
       ref2 =
-        Process.monitor(GenServer.whereis(Consumer.name(ctx.electric_instance_id, @shape_id2)))
+        Process.monitor(
+          GenServer.whereis(Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id2))
+        )
 
       # also cleans up inspector cache and shape status cache
       Mock.Inspector
       |> expect(:clean, 1, fn _, _ -> true end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
       |> expect(:clean, 0, fn _, _ -> true end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id2))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id2))
 
       Mock.ShapeStatus
       |> expect(:remove_shape, 1, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id1))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id1))
       |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.name(ctx.electric_instance_id, @shape_id2))
+      |> allow(self(), Consumer.name(ctx.electric_instance_id, ctx.tenant_id, @shape_id2))
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.producer)
 

--- a/packages/sync-service/test/electric/timeline_test.exs
+++ b/packages/sync-service/test/electric/timeline_test.exs
@@ -3,91 +3,97 @@ defmodule Electric.TimelineTest do
 
   alias Electric.Timeline
 
-  describe "load_timeline/1" do
-    @moduletag :tmp_dir
+  @moduletag :tmp_dir
+  @tenant_id "test_tenant"
 
+  describe "load_timeline/1" do
     setup context do
-      %{kv: Electric.PersistentKV.Filesystem.new!(root: context.tmp_dir)}
+      %{
+        opts: [
+          persistent_kv: Electric.PersistentKV.Filesystem.new!(root: context.tmp_dir),
+          tenant_id: @tenant_id
+        ]
+      }
     end
 
-    test "returns nil when no timeline is available", %{kv: kv} do
-      assert Timeline.load_timeline(kv) == nil
+    test "returns nil when no timeline is available", %{opts: opts} do
+      assert Timeline.load_timeline(opts) == nil
     end
   end
 
   describe "store_timeline/2" do
-    @moduletag :tmp_dir
-
     setup context do
-      %{persistent_kv: Electric.PersistentKV.Filesystem.new!(root: context.tmp_dir)}
+      %{
+        opts: [
+          persistent_kv: Electric.PersistentKV.Filesystem.new!(root: context.tmp_dir),
+          tenant_id: @tenant_id
+        ]
+      }
     end
 
-    test "stores the timeline", %{persistent_kv: persistent_kv} do
+    test "stores the timeline", %{opts: opts} do
       timeline = {1, 2}
-      Timeline.store_timeline(timeline, persistent_kv)
-      assert ^timeline = Timeline.load_timeline(persistent_kv)
+      Timeline.store_timeline(timeline, opts)
+      assert ^timeline = Timeline.load_timeline(opts)
     end
   end
 
   describe "check/2" do
-    @moduletag :tmp_dir
-
     setup context do
       timeline = context[:electric_timeline]
       kv = Electric.PersistentKV.Filesystem.new!(root: context.tmp_dir)
+      opts = [persistent_kv: kv, shape_cache: {ShapeCache, []}, tenant_id: @tenant_id]
 
       if timeline != nil do
-        Timeline.store_timeline(timeline, kv)
+        Timeline.store_timeline(timeline, opts)
       end
 
-      {:ok, [timeline: timeline, persistent_kv: kv]}
+      {:ok, [timeline: timeline, opts: opts]}
     end
 
     @tag electric_timeline: nil
-    test "stores the timeline if Electric has no timeline yet", %{persistent_kv: kv} do
-      assert Timeline.load_timeline(kv) == nil
+    test "stores the timeline if Electric has no timeline yet", %{opts: opts} do
+      assert Timeline.load_timeline(opts) == nil
 
       timeline = {2, 5}
 
-      assert :ok = Timeline.check(timeline, kv)
-      assert ^timeline = Timeline.load_timeline(kv)
+      assert :ok = Timeline.check(timeline, opts)
+      assert ^timeline = Timeline.load_timeline(opts)
     end
 
     @tag electric_timeline: {1, 2}
     test "proceeds without changes if Postgres' timeline matches Electric's timeline", %{
       timeline: timeline,
-      persistent_kv: kv
+      opts: opts
     } do
-      assert ^timeline = Timeline.load_timeline(kv)
-      assert :ok = Timeline.check(timeline, kv)
-      assert ^timeline = Timeline.load_timeline(kv)
+      assert ^timeline = Timeline.load_timeline(opts)
+      assert :ok = Timeline.check(timeline, opts)
+      assert ^timeline = Timeline.load_timeline(opts)
     end
 
     @tag electric_timeline: {1, 3}
     test "returns :timeline_changed on Point In Time Recovery (PITR)", %{
       timeline: timeline,
-      persistent_kv: kv
+      opts: opts
     } do
-      assert ^timeline = Timeline.load_timeline(kv)
+      assert ^timeline = Timeline.load_timeline(opts)
 
       pg_timeline = {1, 2}
-      assert :timeline_changed = Timeline.check(pg_timeline, kv)
+      assert :timeline_changed = Timeline.check(pg_timeline, opts)
 
-      assert ^pg_timeline = Timeline.load_timeline(kv)
+      assert ^pg_timeline = Timeline.load_timeline(opts)
     end
-
-    # TODO: add log output checks
 
     @tag electric_timeline: {1, 3}
     test "returns :timeline_changed when Postgres DB changed", %{
       timeline: timeline,
-      persistent_kv: kv
+      opts: opts
     } do
-      assert ^timeline = Timeline.load_timeline(kv)
+      assert ^timeline = Timeline.load_timeline(opts)
 
       pg_timeline = {2, 3}
-      assert :timeline_changed = Timeline.check(pg_timeline, kv)
-      assert ^pg_timeline = Timeline.load_timeline(kv)
+      assert :timeline_changed = Timeline.check(pg_timeline, opts)
+      assert ^pg_timeline = Timeline.load_timeline(opts)
     end
   end
 end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -159,7 +159,12 @@ defmodule Support.ComponentSetup do
     ]
 
     {:ok, pid} =
-      ReplicationClient.start_link(ctx.electric_instance_id, ctx.db_config, replication_opts)
+      ReplicationClient.start_link(
+        electric_instance_id: ctx.electric_instance_id,
+        tenant_id: ctx.tenant_id,
+        connection_opts: ctx.db_config,
+        replication_opts: replication_opts
+      )
 
     %{replication_client: pid}
   end
@@ -199,7 +204,7 @@ defmodule Support.ComponentSetup do
       Keyword.get(opts, :shape_cache, &with_shape_cache/1),
       Keyword.get(opts, :replication_client, &with_replication_client/1),
       Keyword.get(opts, :tenant_manager, &with_tenant_manager/1),
-      Keyword.get(opts, :tenant_manager, &with_tenant/1)
+      Keyword.get(opts, :tenant, &with_tenant/1)
     ]
     |> Enum.reduce(ctx, &Map.merge(&2, apply(&1, [&2])))
   end

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -9,7 +9,7 @@ defmodule Support.DbSetup do
   ]
 
   def with_unique_db(ctx) do
-    base_config = Application.fetch_env!(:electric, :connection_opts)
+    base_config = Application.fetch_env!(:electric, :default_connection_opts)
     {:ok, utility_pool} = start_db_pool(base_config)
     Process.unlink(utility_pool)
 
@@ -56,7 +56,7 @@ defmodule Support.DbSetup do
   end
 
   def with_shared_db(_ctx) do
-    config = Application.fetch_env!(:electric, :connection_opts)
+    config = Application.fetch_env!(:electric, :default_connection_opts)
     {:ok, pool} = start_db_pool(config)
     {:ok, %{pool: pool, db_config: config, db_conn: pool}}
   end

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -38,10 +38,10 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def for_shape(shape_id, {parent, init, storage}) do
-    send(parent, {__MODULE__, :for_shape, shape_id})
+  def for_shape(shape_id, tenant_id, {parent, init, storage}) do
+    send(parent, {__MODULE__, :for_shape, shape_id, tenant_id})
     shape_init = Map.get(init, shape_id, [])
-    {parent, shape_id, shape_init, Storage.for_shape(shape_id, storage)}
+    {parent, shape_id, shape_init, Storage.for_shape(shape_id, tenant_id, storage)}
   end
 
   @impl Electric.ShapeCache.Storage

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -4,4 +4,9 @@
 # supervision tree in the test environment.
 Registry.start_link(name: Electric.Application.process_registry(), keys: :unique)
 
+# A tenant supervisor and tenant manager are needed for the test tenant that gets created in
+# Electric.Application.start() callback.
+Electric.TenantSupervisor.start_link([])
+Electric.TenantManager.start_link([])
+
 ExUnit.start(assert_receive_timeout: 400)


### PR DESCRIPTION
_Supersedes #1844. I kept that PR up to consult its diff until all the issues have been resolved here._

This PR implements #1591.
It enables Electric to work with multiple databases (i.e. tenants).

TODO:

- [x] rebase on top of main
- [ ] review commented out code and either remove it or make sure the place it had been moved to has been updated for multitenancy
- [ ] Implement a two-tier ETS storage for column info and relation data. In this PR we replace two named tables with anonymous ones, necessitating a roundtrip to a single gen server just to fetch the table handle. This gen server becomes a bottleneck. We should either create another static ETS table to lookup individual ETS table handles in or store all column info and relation info in two static (named) tables, ensuring they don't trump each other via proper key design.
- [ ] make unit tests for multi tenancy
- [ ] add a diagram explaining the new architecture
- [ ] update the open API spec