### PR TITLE
fix: Relation handling should match transaction handling

### DIFF
--- a/.changeset/rare-lemons-give.md
+++ b/.changeset/rare-lemons-give.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Handle relations in `ShapeLogCollector` same way that transactions are handled


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1870

With recent changes to the codebase, relation changes are handled by individual shape consumers the same way transactions are, and they trigger cleanups or other processes.

I've made the relation handling match the transaction handling, including the dropping of relation messages if no subscribers are present.