### PR TITLE
chore: Validate table names locally first

### DIFF
--- a/.changeset/slow-panthers-design.md
+++ b/.changeset/slow-panthers-design.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Validate table names locally first before going to PG to save resources

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -75,7 +75,7 @@ defmodule Electric.Plug.DeleteShapePlugTest do
 
       assert Jason.decode!(conn.resp_body) == %{
                "root_table" => [
-                 "invalid name syntax"
+                 "Invalid zero-length delimited identifier"
                ]
              }
     end

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -137,7 +137,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Jason.decode!(conn.resp_body) == %{
                "offset" => ["has invalid format"],
                "root_table" => [
-                 "invalid name syntax"
+                 "Invalid zero-length delimited identifier"
                ]
              }
     end

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -285,7 +285,7 @@ defmodule Electric.Shapes.ShapeTest do
     end
 
     test "errors on empty table name", %{inspector: inspector} do
-      {:error, {:root_table, ["ERROR 42602 (invalid_name) invalid name syntax"]}} =
+      {:error, {:root_table, ["Invalid zero-length delimited identifier"]}} =
         Shape.new("", inspector: inspector)
     end
 


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1814

We still go to PG to validate the table as we need its OID, so this is not strictly necessary, but since we have validation logic we might as well validate things locally to avoid going to PG for clearly invalid table identifiers?

This also fixes the accepted characters by PG for identifiers [based on the docs](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS) as it was excluding some unicode chars and dollar signs before.