### PR TITLE
fix: Unify CORS header handling

### DIFF
--- a/.changeset/flat-melons-attack.md
+++ b/.changeset/flat-melons-attack.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Unify CORS header handling to ensure they are always present

--- a/packages/sync-service/lib/electric/plug/options_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/options_shape_plug.ex
@@ -2,17 +2,12 @@ defmodule Electric.Plug.OptionsShapePlug do
   require Logger
   use Plug.Builder
 
-  plug :add_allowed_methods_header
   plug :add_cache_max_age_header
   plug :filter_cors_headers
-  plug :add_allow_origin_header
   plug :add_keep_alive
   plug :send_options_response
 
   @allowed_headers ["if-none-match"]
-
-  defp add_allowed_methods_header(conn, _),
-    do: Plug.Conn.put_resp_header(conn, "access-control-allow-methods", "GET, OPTIONS, DELETE")
 
   defp add_cache_max_age_header(conn, _) do
     conn
@@ -36,14 +31,6 @@ defmodule Electric.Plug.OptionsShapePlug do
           "" -> conn
           _ -> Plug.Conn.put_resp_header(conn, "access-control-allow-headers", supported_headers)
         end
-    end
-  end
-
-  # Electric currently allows any origin to access the API
-  defp add_allow_origin_header(conn, _) do
-    case Plug.Conn.get_req_header(conn, "origin") do
-      [origin] -> Plug.Conn.put_resp_header(conn, "access-control-allow-origin", origin)
-      _ -> conn
     end
   end
 

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -173,8 +173,6 @@ defmodule Electric.Plug.ServeShapePlug do
 
   # start_telemetry_span needs to always be the first plug after fetching query params.
   plug :start_telemetry_span
-
-  plug :cors
   plug :put_resp_content_type, "application/json"
   plug :validate_query_params
   plug :load_shape_info
@@ -416,13 +414,6 @@ defmodule Electric.Plug.ServeShapePlug do
         "cache-control",
         "public, max-age=#{config[:max_age]}, stale-while-revalidate=#{config[:stale_age]}"
       )
-
-  def cors(conn, _opts) do
-    conn
-    |> put_resp_header("access-control-allow-origin", "*")
-    |> put_resp_header("access-control-expose-headers", "*")
-    |> put_resp_header("access-control-allow-methods", "GET, POST, OPTIONS")
-  end
 
   # If offset is -1, we're serving a snapshot
   defp serve_log_or_snapshot(%Conn{assigns: %{offset: @before_all_offset}} = conn, _) do

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -46,4 +46,20 @@ defmodule Electric.Plug.Utils do
       end
     end)
   end
+
+  defmodule CORSHeaderPlug do
+    @behaviour Plug
+    import Plug.Conn
+    def init(opts), do: opts
+
+    def call(conn, opts),
+      do:
+        conn
+        |> put_resp_header("access-control-allow-origin", Access.get(opts, :origin, "*"))
+        |> put_resp_header("access-control-expose-headers", "*")
+        |> put_resp_header(
+          "access-control-allow-methods",
+          Access.get(opts, :methods, []) |> Enum.join(", ")
+        )
+  end
 end

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -55,11 +55,21 @@ defmodule Electric.Plug.Utils do
     def call(conn, opts),
       do:
         conn
-        |> put_resp_header("access-control-allow-origin", Access.get(opts, :origin, "*"))
+        |> put_resp_header("access-control-allow-origin", get_allowed_origin(conn, opts))
         |> put_resp_header("access-control-expose-headers", "*")
-        |> put_resp_header(
-          "access-control-allow-methods",
-          Access.get(opts, :methods, []) |> Enum.join(", ")
-        )
+        |> put_resp_header("access-control-allow-methods", get_allowed_methods(conn, opts))
+
+    defp get_allowed_methods(_conn, opts), do: Access.get(opts, :methods, []) |> Enum.join(", ")
+
+    defp get_allowed_origin(conn, opts) do
+      Access.get(
+        opts,
+        :origin,
+        case Plug.Conn.get_req_header(conn, "origin") do
+          [origin] -> origin
+          [] -> "*"
+        end
+      )
+    end
   end
 end

--- a/packages/sync-service/test/electric/plug/options_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/options_shape_plug_test.exs
@@ -4,7 +4,6 @@ defmodule Electric.Plug.OptionsShapePlugTest do
   alias Electric.Plug.OptionsShapePlug
 
   @registry Registry.OptionsShapePlugTest
-  @expected_allowed_methods MapSet.new(["GET", "OPTIONS", "DELETE"])
 
   setup do
     start_link_supervised!({Registry, keys: :duplicate, name: @registry})
@@ -12,22 +11,13 @@ defmodule Electric.Plug.OptionsShapePlugTest do
   end
 
   describe "OptionsShapePlug" do
-    test "returns allowed methods" do
+    test "returns relevant headers" do
       conn =
         Plug.Test.conn("OPTIONS", "/?root_table=foo")
         |> OptionsShapePlug.call([])
 
       assert conn.status == 204
 
-      allowed_methods =
-        conn
-        |> Plug.Conn.get_resp_header("access-control-allow-methods")
-        |> List.first("")
-        |> String.split(",")
-        |> Enum.map(&String.trim/1)
-        |> MapSet.new()
-
-      assert allowed_methods == @expected_allowed_methods
       assert Plug.Conn.get_resp_header(conn, "access-control-max-age") == ["86400"]
       assert Plug.Conn.get_resp_header(conn, "connection") == ["keep-alive"]
     end
@@ -42,19 +32,6 @@ defmodule Electric.Plug.OptionsShapePlugTest do
 
       assert conn.status == 204
       assert Plug.Conn.get_resp_header(conn, "access-control-allow-headers") == [header]
-    end
-
-    test "handles origin header" do
-      origin = "https://example.com"
-
-      conn =
-        Plug.Test.conn("OPTIONS", "/?root_table=foo")
-        # also checks that it is case insensitive
-        |> Plug.Conn.put_req_header("origin", origin)
-        |> OptionsShapePlug.call([])
-
-      assert conn.status == 204
-      assert Plug.Conn.get_resp_header(conn, "access-control-allow-origin") == [origin]
     end
   end
 end

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -865,6 +865,26 @@ defmodule Electric.Plug.RouterTest do
     end
   end
 
+  describe "404" do
+    test "GET on invalid path returns 404", _ do
+      conn =
+        conn("GET", "/invalidpath")
+        |> Router.call([])
+
+      assert %{status: 404} = conn
+
+      allowed_methods =
+        conn
+        |> Plug.Conn.get_resp_header("access-control-allow-methods")
+        |> List.first("")
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> MapSet.new()
+
+      assert allowed_methods == MapSet.new(["GET", "HEAD"])
+    end
+  end
+
   defp get_resp_shape_id(conn), do: get_resp_header(conn, "electric-shape-id")
   defp get_resp_last_offset(conn), do: get_resp_header(conn, "electric-chunk-last-offset")
 

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -861,7 +861,7 @@ defmodule Electric.Plug.RouterTest do
         |> Enum.map(&String.trim/1)
         |> MapSet.new()
 
-      assert allowed_methods == MapSet.new(["GET", "OPTIONS", "DELETE"])
+      assert allowed_methods == MapSet.new(["GET", "HEAD", "OPTIONS", "DELETE"])
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1824

Moves the CORS header logic to a utility and at the router level so we can define the allowed methods for each endpoint.

Defining it in each endpoint is counterintuitive as for all `/v1/shape/:root_table` endpoints we should be returning the same allowed headers.