### PR TITLE
fix: Handle 400 errors as unrecoverable

### DIFF
--- a/.changeset/pretty-scissors-search.md
+++ b/.changeset/pretty-scissors-search.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": patch
+"@core/sync-service": patch
+---
+
+Handle 400 errors as unrecoverable rather than `must-refetch` cases

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -771,7 +771,12 @@ defmodule Electric.Plug.RouterTest do
         |> Router.call(opts)
 
       assert %{status: 400} = conn
-      assert conn.resp_body == Jason.encode!([%{headers: %{control: "must-refetch"}}])
+
+      assert conn.resp_body ==
+               Jason.encode!(%{
+                 message:
+                   "The specified shape definition and ID do not match. Please ensure the shape definition is correct or omit the shape ID from the request to obtain a new one."
+               })
     end
 
     test "GET receives 409 to a newly created shape when shape ID is not found and no shape matches the shape definition",

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -603,7 +603,12 @@ defmodule Electric.Plug.ServeShapePlugTest do
         |> ServeShapePlug.call([])
 
       assert conn.status == 400
-      assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "must-refetch"}}]
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "message" =>
+                 "The specified shape definition and ID do not match." <>
+                   " Please ensure the shape definition is correct or omit the shape ID from the request to obtain a new one."
+             }
     end
 
     test "sends 400 when omitting primary key columns in selection" do


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1876

The issue was that we were sending `must-refetch` messages with some of our 400s, although they were unrecoverable and re-fetching would trigger an infinite loop.

I've made the server send 400 errors for the cases where the `shape_id` and `shape_definition` do not match, with an explanatory message, and I've made the client terminate when receiving such an error.

As a temporary measure, the error is not thrown into the ether but stored in the `ShapeStream` (accessible via `stream.error`).

We have had some discussions with @balegas about making errors more "handleable" by changing our approach to the `ShapeStream` instantiation. I think this warrants opening a new issue and corresponding PR to discuss more thoroughly.