### PR TITLE
chore(docs): Add sub-header for custom parsing in typescript docs

### DIFF
--- a/website/docs/api/clients/typescript.md
+++ b/website/docs/api/clients/typescript.md
@@ -37,6 +37,8 @@ stream.subscribe(messages => {
 })
 ```
 
+#### Custom parsing
+
 By default, `ShapeStream` parses the following Postgres types into native JavaScript values:
 - `int2`, `int4`, `float4`, and `float8` are parsed into JavaScript `Number`
 - `int8` is parsed into a JavaScript `BigInt`


### PR DESCRIPTION
I went to share it with someone and it took a bit to find it & then I couldn't link directly to the custom parsing.