### PR TITLE
Cache shapes based only on parameters of the shape definition

### DIFF
--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -24,7 +24,14 @@ export async function preloadShape<T extends Row<unknown> = Row>(
 }
 
 export function sortedOptionsHash<T>(options: ShapeStreamOptions<T>): string {
-  return JSON.stringify(options, Object.keys(options).sort())
+  const hashOptions = {
+    url: options.url,
+    where: options.where,
+    columns: options.columns,
+    headers: options.headers,
+  }
+
+  return JSON.stringify(hashOptions, Object.keys(hashOptions).sort())
 }
 
 export function getShapeStream<T extends Row<unknown>>(


### PR DESCRIPTION
`sortedOptionsHash()` uses all `ShapeStreamOptions` option keys, which prevents deduplication of shapes in shape cache if they have different parameters that don't belong to the shape definition.

My case is that I create a top-level shape with `offset` and `shapeId`, but in other places I don't have those parameters and I don't want to thread them through code. 

What do you think?

