### PR TITLE
fix: address deadlock with concurrent snapshot creation

### DIFF
--- a/.changeset/tall-chairs-punch.md
+++ b/.changeset/tall-chairs-punch.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix a possible deadlock issue when creating or updating multiple where-claused shapes that occured while updating the Postgres publication (only on PG 15+). Fix a possible race condition between reading the existing publication and writing the updated version.


### PR DESCRIPTION
This commit addresses 2 issues:

First, the deadlock occurred when trying to add where clauses to existing tables - we executed `ALTER TABLE` that took out an exclusive access lock over one table definition, then executed `SET TABLES` on a publication that requested shared access lock over all tables mentioned in the publication which includes tables that are already exclusively locked by another concurrent shape creation. This caused a deadlock. This was addressed by switching the order of alter table and alter publication.

Second, there was a race condition when 2 new shapes tried updating the publication where clause and because it's done in a read-then-update way, not as a single statement, the read might have missed the concurrent update and the resulting state was wrong. This was addressed by a lock.