### PR TITLE
Wrap more steps in snapshot with telemetry spans

### DIFF
--- a/.changeset/chatty-adults-heal.md
+++ b/.changeset/chatty-adults-heal.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add tracing of snapshot creation and more logging of postgres connection status. Prevent connection timeouts when writing snapshot data. Add `LOG_OTP_REPORTS` environment variable to enable OTP SASL reporting at runtime.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -19,10 +19,14 @@ case log_level_config do
     raise message
 end
 
-# uncomment if you need to track process creation and destruction
-# config :logger,
-#   handle_otp_reports: true,
-#   handle_sasl_reports: true
+# Enable this to get **very noisy** but useful messages from BEAM about
+# processes being started, stopped and crashes.
+# https://www.erlang.org/doc/apps/sasl/error_logging#sasl-reports
+sasl? = env!("LOG_OTP_REPORTS", :boolean, false)
+
+config :logger,
+  handle_otp_reports: sasl?,
+  handle_sasl_reports: sasl?
 
 if config_env() == :test do
   config(:logger, level: :info)

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -241,8 +241,13 @@ defmodule Electric.Postgres.ReplicationClient do
         # receives more demand.
         # The timeout for any call here is important. Different storage
         # backends will require different timeouts and the timeout will need to
-        # accomodate varying number of shape consumers. The default of 5_000 ms
-        # should work for our file-based storage backends, for now.
+        # accomodate varying number of shape consumers.
+        #
+        # The current solution is to set timeout: :infinity for the call that
+        # sends the txn message to the consumers and waits for them all to
+        # write to storage, but crash individual consumers if the write takes
+        # too long. So it doesn't matter how many consumers we have but an
+        # individual storage write can timeout the entire batch.
         OpenTelemetry.with_span(
           "pg_txn.replication_client.transaction_received",
           [num_changes: length(txn.changes), num_relations: MapSet.size(txn.affected_relations)],

--- a/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
@@ -41,12 +41,15 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   # streaming mode.
   @spec start_streaming(state) :: callback_return
   def start_streaming(%{step: :ready_to_stream} = state) do
+    Logger.debug("ReplicationClient step: start_streaming")
     query_for_step(:streaming, %{state | step: :streaming})
   end
 
   ###
 
   defp pg_info_query(state) do
+    Logger.debug("ReplicationClient step: pg_info_query")
+
     query = """
     SELECT
       current_setting('server_version_num') server_version_num,
@@ -75,6 +78,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   end
 
   defp create_publication_query(state) do
+    Logger.debug("ReplicationClient step: create_publication_query")
     # We're creating an "empty" publication because first snapshot creation should add the table
     query = "CREATE PUBLICATION #{Utils.quote_name(state.publication_name)}"
     {:query, query, state}
@@ -109,6 +113,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   end
 
   defp create_slot_query(%State{slot_name: slot_name} = state) do
+    Logger.debug("ReplicationClient step: create_slot")
     query = "CREATE_REPLICATION_SLOT #{Utils.quote_name(slot_name)} #{@slot_options}"
 
     {:query, query, state}
@@ -153,6 +158,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   ###
 
   defp set_display_setting_query(%{display_settings: [query | rest]} = state) do
+    Logger.debug("ReplicationClient step: set_display_setting")
     {:query, query, %{state | display_settings: rest}}
   end
 
@@ -181,6 +187,8 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   # streaming mode. That's why this function must return a `{:stream, ...}` and no queries
   # will be executed after this.
   defp start_replication_slot_query(state) do
+    Logger.debug("ReplicationClient step: start_replication_slot")
+
     query =
       "START_REPLICATION SLOT #{Utils.quote_name(state.slot_name)} LOGICAL 0/0 (proto_version '1', publication_names '#{state.publication_name}')"
 

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -59,7 +59,10 @@ defmodule Electric.ShapeCache do
             shape_status: [type: :atom, default: Electric.ShapeCache.ShapeStatus],
             registry: [type: {:or, [:atom, :pid]}, required: true],
             db_pool: [type: {:or, [:atom, :pid]}, default: Electric.DbPool],
-            run_with_conn_fn: [type: {:fun, 2}, default: &DBConnection.run/2],
+            run_with_conn_fn: [
+              type: {:fun, 2},
+              default: &Shapes.Consumer.Snapshotter.run_with_conn/2
+            ],
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
               type: {:fun, 5},

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -128,11 +128,13 @@ defmodule Electric.Shapes.Consumer do
   end
 
   def handle_cast({:snapshot_xmin_known, shape_id, xmin}, %{shape_id: shape_id} = state) do
+    Logger.debug("Snapshot xmin known shape_id: #{shape_id} xmin: #{xmin}")
     state = set_snapshot_xmin(xmin, state)
     handle_txns(state.buffer, %{state | buffer: []})
   end
 
   def handle_cast({:snapshot_started, shape_id}, %{shape_id: shape_id} = state) do
+    Logger.debug("Snapshot started shape_id: #{shape_id}")
     state = set_snapshot_started(state)
     {:noreply, [], state}
   end

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -94,6 +94,13 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
   end
 
   @doc false
+  # wrap DBConnection.run/2 with an infinite timeout. Required because you
+  # can't pass captures in NimbleOptions schemas.
+  def run_with_conn(conn, fun) do
+    DBConnection.run(conn, fun, timeout: :infinity)
+  end
+
+  @doc false
   def query_in_readonly_txn(parent, shape_id, shape, db_pool, storage) do
     shape_attrs = shape_attrs(shape_id, shape)
 

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -76,6 +76,21 @@ defmodule Electric.Replication.Eval.RunnerTest do
                })
                |> Runner.execute(%{["y"] => 1, ["x"] => [1, 2]})
 
+      assert {:ok, nil} =
+               ~S|x @> ARRAY['value']|
+               |> Parser.parse_and_validate_expression!(%{
+                 ["x"] => {:array, :text}
+               })
+               |> Runner.execute(%{["x"] => nil})
+
+      assert {:ok, nil} =
+               ~S|x @> ARRAY[y]|
+               |> Parser.parse_and_validate_expression!(%{
+                 ["x"] => {:array, :int4},
+                 ["y"] => :int4
+               })
+               |> Runner.execute(%{["y"] => 1, ["x"] => nil})
+
       assert {:ok, true} =
                ~S|x::float[] = y::int4[]::float[]|
                |> Parser.parse_and_validate_expression!(%{


### PR DESCRIPTION
Plus:

- set the db connection pool timeout to `:infinity` for snapshot creation (large datasets can timeout when writing the snapshot otherwise)
- set `LOG_OTP_REPORTS=true` to turn on SASL reporting at runtime
- add some more fine-grained log messages
- include some tests that validate our handling of nulls when evaluating array comparisons in where clauses
