### PR TITLE
jobs: close PGlite Engineer and make listings dynamic.

### DIFF
--- a/website/about/jobs/index.md
+++ b/website/about/jobs/index.md
@@ -7,6 +7,12 @@ image: /img/about/villa-discussion.jpg
 outline: deep
 ---
 
+<script setup>
+import { data as activeJobs } from '../../data/activeJobs.data.ts'
+
+const currentlyHiring = activeJobs.length > 0
+</script>
+
 <figure class="page-image">
   <a href="/img/about/villa-discussion.jpg" class="no-visual">
     <img src="/img/about/villa-discussion.jpg" />
@@ -17,10 +23,14 @@ outline: deep
 
 We're a [small, technical team](/about/team) that's passionate about our work, our product and our culture. We work remote-first, on European time, with a four day week.
 
+<div v-if="currentlyHiring">
+
 ## Active roles
 
-> [!TIP] We're hiring!
-> - [PGlite Engineer](/about/jobs/pglite-engineer)
+> [!Tip] We're hiring!
+> <ul><li v-for="job in activeJobs"><a :href="job.link">{{ job.title }}</a></li></ul>
+
+</div>
 
 ## Stage
 
@@ -43,3 +53,12 @@ So far places we've met up in include Amsterdam, Dublin, Istanbul, Istria, Lisbo
 We especially welcome female applicants, applicants from ethnic groups that are under represented in tech and LGBTQ+ applicants.
 
 We're happy for you to fit work around your children or other life commitments.
+
+<div v-if="!currentlyHiring">
+
+## Active roles
+
+> [!Warning] No active roles
+> Sorry, we don't have any roles open at the moment. If you're interested in joining the team, you can keep an eye out for [hiring announcements on Discord](https://discord.electric-sql.com).
+
+</div>

--- a/website/about/jobs/pglite-engineer.md
+++ b/website/about/jobs/pglite-engineer.md
@@ -5,7 +5,16 @@ description: >-
   working mainly in Typescript, Rust and C++.
 image: /img/icons/pglite.svg
 outline: deep
+application_form: https://airtable.com/appNnEkluhSOHeyQ1/pagm3FNVgH4DOVhUO/form
+active: false
 ---
+
+<div v-if="!$frontmatter.active">
+
+> [!Danger] Sorry, this role is now closed.
+> We are no longer accepting applications for this role. If you're interested in future opportunities like this, keep an eye on [hiring announcements on the Discord](https://discord.electric-sql.com).
+
+</div>
 
 # PGlite Engineer
 
@@ -53,12 +62,22 @@ You need to be able to write your own requirement docs and move between research
 
 ### How to apply
 
+<div v-if="$frontmatter.active">
+
 Apply using the form linked below:
 
 <VPButton
-    href="https://airtable.com/appNnEkluhSOHeyQ1/pagm3FNVgH4DOVhUO/form"
+    :href="$frontmatter.application_form"
     text="View application form"
     target="_blank"
 />
 
 The first step is a 45 minute call. After that, the process is personalised but we strive to keep it as efficient as possible and move swiftly to an offer.
+
+</div>
+<div v-else>
+
+> [!Danger] This role is closed.
+> We are no longer accepting applications.
+
+</div>

--- a/website/about/team.md
+++ b/website/about/team.md
@@ -8,8 +8,11 @@ outline: deep
 <script setup>
 import TeamMembers from '../src/components/TeamMembers.vue'
 import { data } from '../data/team.data.ts'
+import { data as activeJobs } from '../data/activeJobs.data.ts'
 
 const { advisors, angels, team, vcs } = data
+
+const currentlyHiring = activeJobs.length > 0
 </script>
 
 <style scoped>
@@ -20,8 +23,12 @@ const { advisors, angels, team, vcs } = data
 
 # Team
 
+<div v-if="currentlyHiring">
+
 > [!TIP] We're hiring!
 > See the [jobs page](/about/jobs/) for active roles.
+
+</div>
 
 ## Core team
 

--- a/website/data/activeJobs.data.ts
+++ b/website/data/activeJobs.data.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs'
+import { parse } from 'yaml'
+
+export default {
+  watch: ['../about/jobs/*.md'],
+
+  load (files) {
+    return files.map((file) => {
+      const slug = file.split('/about/jobs/')[1].split('.')[0]
+
+      const contents = fs.readFileSync(file, 'utf-8')
+      const frontmatter = contents.split('---\n')[1]
+
+      const data = parse(frontmatter)
+      data.link = `/about/jobs/${slug}`
+
+      return data
+    }).filter(x => x.active)
+  }
+}


### PR DESCRIPTION
Jobs now have an `active: true | false` flag. Active: false but published means the job page is still visible for applicants to read.

I've also just unpublished the Airtable application form for the PGlite Engineer role.