### PR TITLE
config: candidate implementation of `ELECTRIC_PORT=PORT`.

### DIFF
--- a/.changeset/kind-lizards-work.md
+++ b/.changeset/kind-lizards-work.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Enable binding to a system provided `PORT` environment variable by setting the newly namespaced `ELECTRIC_PORT` to the special string "PORT", i.e.: `ELECTRIC_PORT=PORT`.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -203,6 +203,7 @@ prometheus_port = env!("ELECTRIC_PROMETHEUS_PORT", :integer, nil)
 # `ELECTRIC_PORT` env var by default and only reading `PORT` if
 # explicitly configured to (to avoid unexpected behaviour).
 default_service_port = 3000
+
 service_port =
   case env!("ELECTRIC_PORT", :string, :not_set) do
     :not_set ->

--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -165,6 +165,14 @@ Enable [OTP SASL](https://www.erlang.org/doc/apps/sasl/sasl_app.html) reporting 
 
 Port that the [HTTP API](/docs/api/http) is exposed on.
 
+> ![Tip] Binding to `PORT`
+> Some deployment environments expect web services to bind to a system provided
+> `PORT` environment variable.
+>
+> You can enable support for this by explicitly setting `ELECTRIC_PORT=PORT`.
+> This tells Electric to read the port from the `PORT` variable. (Still falling
+> back on the default value of `3000` if `PORT` is not set).
+
 </EnvVarConfig>
 
 ## Caching


### PR DESCRIPTION
As per https://github.com/electric-sql/electric/issues/1933#issuecomment-2459319372