### PR TITLE
Add JSON output to shape params

### DIFF
--- a/.changeset/light-foxes-shout.md
+++ b/.changeset/light-foxes-shout.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Allow for outputting columns as list in shape parameters

--- a/packages/elixir-client/lib/electric/client/shape_definition.ex
+++ b/packages/elixir-client/lib/electric/client/shape_definition.ex
@@ -121,13 +121,26 @@ defmodule Electric.Client.ShapeDefinition do
   end
 
   @doc false
-  @spec params(t()) :: Electric.Client.Fetch.Request.params()
-  def params(%__MODULE__{} = shape) do
+  @spec params(t(), [{:format, :query | :json}]) :: Electric.Client.Fetch.Request.params()
+  def params(%__MODULE__{} = shape, opts \\ []) do
     %{where: where, columns: columns} = shape
     table_name = url_table_name(shape)
+    format = Keyword.get(opts, :format, :query)
 
-    %{table: table_name}
+    %{"table" => table_name}
     |> Util.map_put_if("where", where, is_binary(where))
-    |> Util.map_put_if("columns", fn -> Enum.join(columns, ",") end, is_list(columns))
+    |> Util.map_put_if(
+      "columns",
+      fn -> params_columns_list(columns, format) end,
+      is_list(columns)
+    )
+  end
+
+  defp params_columns_list(columns, :query) when is_list(columns) do
+    Enum.join(columns, ",")
+  end
+
+  defp params_columns_list(columns, :json) when is_list(columns) do
+    columns
   end
 end

--- a/packages/elixir-client/package.json
+++ b/packages/elixir-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@core/elixir-client",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "publish:hex": "mix do deps.get, hex.publish --yes"
   }

--- a/packages/elixir-client/test/electric/client/shape_definition_test.exs
+++ b/packages/elixir-client/test/electric/client/shape_definition_test.exs
@@ -38,4 +38,29 @@ defmodule Electric.Client.ShapeDefinitionTest do
                )
     end
   end
+
+  describe "params/2" do
+    test "format: :query returns column names joined by comma" do
+      assert {:ok, shape} = ShapeDefinition.new("my_table", columns: ["id", "size", "cost"])
+
+      assert ShapeDefinition.params(shape, format: :query) == %{
+               "columns" => "id,size,cost",
+               "table" => "my_table"
+             }
+
+      assert ShapeDefinition.params(shape) == %{
+               "columns" => "id,size,cost",
+               "table" => "my_table"
+             }
+    end
+
+    test "format: :json returns column names as a list" do
+      assert {:ok, shape} = ShapeDefinition.new("my_table", columns: ["id", "size", "cost"])
+
+      assert ShapeDefinition.params(shape, format: :json) == %{
+               "columns" => ["id", "size", "cost"],
+               "table" => "my_table"
+             }
+    end
+  end
 end


### PR DESCRIPTION
So that the electric phoenix gateway can drop client compatible opts into the front-end