### PR TITLE
chore (sync service): refactor tenant manager to store tenant info in ETS table

### DIFF
--- a/.changeset/funny-spoons-trade.md
+++ b/.changeset/funny-spoons-trade.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Refactored the tenant manager to store tenant information in an ETS table for improved read performance.

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -28,7 +28,7 @@
 [endmacro]
 
 [macro setup_pg initdb_args config_opts]
-  [invoke setup_pg "pg" $initdb_args $config_opts]
+  [invoke setup_pg_with_name "pg" $initdb_args $config_opts]
 [endmacro]
 
 [macro stop_pg]

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -106,6 +106,10 @@
     !ELECTRIC_PORT=$port $env ../scripts/electric_dev.sh
 [endmacro]
 
+[macro setup_electric_shell_with_tenant shell_name port]
+  [invoke setup_electric_shell $shell_name $port "ELECTRIC_DATABASE_ID=integration_test_tenant DATABASE_URL=$database_url"]
+[endmacro]
+
 [macro add_tenant tenant_id electric_port]
   [shell $tenant_id]
     !curl -X POST http://localhost:$electric_port/v1/admin/database \

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -28,7 +28,7 @@
 [endmacro]
 
 [macro setup_pg initdb_args config_opts]
-  [invoke setup_pg_with_name "pg" $initdb_args $config_opts]
+  [invoke setup_pg "pg" $initdb_args $config_opts]
 [endmacro]
 
 [macro stop_pg]
@@ -106,10 +106,6 @@
     !ELECTRIC_PORT=$port $env ../scripts/electric_dev.sh
 [endmacro]
 
-[macro setup_electric_shell_with_tenant shell_name port]
-  [invoke setup_electric_shell $shell_name $port "ELECTRIC_DATABASE_ID=integration_test_tenant DATABASE_URL=$database_url"]
-[endmacro]
-
 [macro add_tenant tenant_id electric_port]
   [shell $tenant_id]
     !curl -X POST http://localhost:$electric_port/v1/admin/database \
@@ -121,12 +117,6 @@
 [macro check_tenant_status tenant_id expected_status electric_port]
   [shell $tenant_id]
     [invoke wait-for "curl -X GET http://localhost:$electric_port/v1/health?database_id=$tenant_id" "\{\"status\":\"$expected_status\"\}" 10 $PS1]
-[endmacro]
-
-[macro teardown_container container_name]
-  -$fail_pattern
-  !docker rm -f -v $container_name
-  ?$PS1
 [endmacro]
 
 [macro teardown]

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -119,6 +119,12 @@
     [invoke wait-for "curl -X GET http://localhost:$electric_port/v1/health?database_id=$tenant_id" "\{\"status\":\"$expected_status\"\}" 10 $PS1]
 [endmacro]
 
+[macro teardown_container container_name]
+  -$fail_pattern
+  !docker rm -f -v $container_name
+  ?$PS1
+[endmacro]
+
 [macro teardown]
   [invoke teardown_container $pg_container_name]
   !../scripts/clean_up.sh

--- a/integration-tests/tests/multi-tenancy.lux
+++ b/integration-tests/tests/multi-tenancy.lux
@@ -22,11 +22,7 @@
 [invoke setup_multi_tenant_electric]
 
 [shell electric]
-<<<<<<< HEAD
   ???[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
-=======
-  ??[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
->>>>>>> 2a1540a8 (e2e test for multi tenancy)
 
 ## Create tenant 1
 [invoke add_tenant "tenant1" 3000]
@@ -137,33 +133,18 @@
   # Re-enable fail pattern for Electric
   -$fail_pattern
   [invoke setup_multi_tenant_electric]
-<<<<<<< HEAD
   ???Reloading tenant tenant1 from storage
   ???Reloading tenant tenant2 from storage
   ???[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
 
 ## Make a query to check that they still see their data
 [shell tenant1]
-=======
-  ?? Reloading tenant tenant1 from storage
-  ?? Reloading tenant tenant2 from storage
-
-## Make a query to check that they still see their data
-[shell tenant1]
-  # wait for Electric to start
-  [invoke wait-for "lsof -Pi :3000 -sTCP:LISTEN" "TCP \*:3000" 10 $PS1]
->>>>>>> 2a1540a8 (e2e test for multi tenancy)
   # Query the shape
   !curl -i -X GET "http://localhost:3000/v1/shape?table=items&offset=${offset}&handle=${shape_id}&database_id=tenant1"
   ???[{"headers":{"control":"up-to-date"}}]
   ??$PS1
   
 [shell tenant2]
-<<<<<<< HEAD
-=======
-  # wait for Electric to start
-  [invoke wait-for "lsof -Pi :3000 -sTCP:LISTEN" "TCP \*:3000" 10 $PS1]
->>>>>>> 2a1540a8 (e2e test for multi tenancy)
   # Query the shape
   !curl -i -X GET "http://localhost:3000/v1/shape?table=items&offset=${offset}&handle=${shape_id}&database_id=tenant2"
   ???[{"headers":{"control":"up-to-date"}}]
@@ -233,7 +214,6 @@
   # Set fail pattern to fail if tenant 2 is reloaded
   -Reloading tenant tenant2 from storage
   !PORT=3000 ../scripts/electric_dev.sh
-<<<<<<< HEAD
   ???Reloading tenant tenant1 from storage
   ???[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
 
@@ -241,7 +221,3 @@
   [invoke teardown]
   # Also tear down the first tenant
   [invoke teardown_container $tenant1_pg_container_name]
-=======
-  ?? Reloading tenant tenant1 from storage
-  ??[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
->>>>>>> 2a1540a8 (e2e test for multi tenancy)

--- a/integration-tests/tests/multi-tenancy.lux
+++ b/integration-tests/tests/multi-tenancy.lux
@@ -22,7 +22,11 @@
 [invoke setup_multi_tenant_electric]
 
 [shell electric]
+<<<<<<< HEAD
   ???[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
+=======
+  ??[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
+>>>>>>> 2a1540a8 (e2e test for multi tenancy)
 
 ## Create tenant 1
 [invoke add_tenant "tenant1" 3000]
@@ -133,18 +137,33 @@
   # Re-enable fail pattern for Electric
   -$fail_pattern
   [invoke setup_multi_tenant_electric]
+<<<<<<< HEAD
   ???Reloading tenant tenant1 from storage
   ???Reloading tenant tenant2 from storage
   ???[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
 
 ## Make a query to check that they still see their data
 [shell tenant1]
+=======
+  ?? Reloading tenant tenant1 from storage
+  ?? Reloading tenant tenant2 from storage
+
+## Make a query to check that they still see their data
+[shell tenant1]
+  # wait for Electric to start
+  [invoke wait-for "lsof -Pi :3000 -sTCP:LISTEN" "TCP \*:3000" 10 $PS1]
+>>>>>>> 2a1540a8 (e2e test for multi tenancy)
   # Query the shape
   !curl -i -X GET "http://localhost:3000/v1/shape?table=items&offset=${offset}&handle=${shape_id}&database_id=tenant1"
   ???[{"headers":{"control":"up-to-date"}}]
   ??$PS1
   
 [shell tenant2]
+<<<<<<< HEAD
+=======
+  # wait for Electric to start
+  [invoke wait-for "lsof -Pi :3000 -sTCP:LISTEN" "TCP \*:3000" 10 $PS1]
+>>>>>>> 2a1540a8 (e2e test for multi tenancy)
   # Query the shape
   !curl -i -X GET "http://localhost:3000/v1/shape?table=items&offset=${offset}&handle=${shape_id}&database_id=tenant2"
   ???[{"headers":{"control":"up-to-date"}}]
@@ -214,6 +233,7 @@
   # Set fail pattern to fail if tenant 2 is reloaded
   -Reloading tenant tenant2 from storage
   !PORT=3000 ../scripts/electric_dev.sh
+<<<<<<< HEAD
   ???Reloading tenant tenant1 from storage
   ???[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
 
@@ -221,3 +241,7 @@
   [invoke teardown]
   # Also tear down the first tenant
   [invoke teardown_container $tenant1_pg_container_name]
+=======
+  ?? Reloading tenant tenant1 from storage
+  ??[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
+>>>>>>> 2a1540a8 (e2e test for multi tenancy)

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -59,6 +59,7 @@ defmodule Electric.Plug.DeleteShapePlugTest do
     store_tenant(tenant, ctx)
 
     config = [
+      electric_instance_id: ctx.electric_instance_id,
       storage: {Mock.Storage, []},
       tenant_manager: ctx.tenant_manager,
       allow_shape_deletion: allow

--- a/packages/sync-service/test/electric/plug/health_check_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/health_check_plug_test.exs
@@ -38,6 +38,7 @@ defmodule Electric.Plug.HealthCheckPlugTest do
   def conn(ctx) do
     # Pass mock dependencies to the plug
     config = [
+      electric_instance_id: ctx.electric_instance_id,
       tenant_manager: ctx.tenant_manager
     ]
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -73,6 +73,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     store_tenant(tenant, ctx)
 
     config = [
+      electric_instance_id: ctx.electric_instance_id,
       storage: {Mock.Storage, []},
       tenant_manager: ctx.tenant_manager
     ]

--- a/packages/sync-service/test/electric/tenant_manager_test.exs
+++ b/packages/sync-service/test/electric/tenant_manager_test.exs
@@ -38,6 +38,7 @@ defmodule Electric.TenantManagerTest do
       # Check that it recreated the tenant
       {:ok, tenant} =
         TenantManager.get_tenant(@tenant_id,
+          electric_instance_id: ctx.electric_instance_id,
           tenant_manager: ctx.tenant_manager,
           tenant_tables_name: ctx.tenant_tables_name
         )
@@ -142,12 +143,18 @@ defmodule Electric.TenantManagerTest do
 
     test "get_only_tenant/1 complains if there are no tenants", ctx do
       assert {:error, :not_found} =
-               TenantManager.get_only_tenant(tenant_manager: ctx.tenant_manager)
+               TenantManager.get_only_tenant(
+                 tenant_manager: ctx.tenant_manager,
+                 electric_instance_id: ctx.electric_instance_id
+               )
     end
 
     test "get_tenant/2 complains if the tenant does not exist", ctx do
       assert {:error, :not_found} =
-               TenantManager.get_tenant("non-existing tenant", tenant_manager: ctx.tenant_manager)
+               TenantManager.get_tenant("non-existing tenant",
+                 tenant_manager: ctx.tenant_manager,
+                 electric_instance_id: ctx.electric_instance_id
+               )
     end
   end
 
@@ -162,14 +169,20 @@ defmodule Electric.TenantManagerTest do
 
     test "get_only_tenant/1 returns the only tenant", ctx do
       {:ok, tenant_config} =
-        TenantManager.get_only_tenant(tenant_manager: ctx.tenant_manager)
+        TenantManager.get_only_tenant(
+          tenant_manager: ctx.tenant_manager,
+          electric_instance_id: ctx.electric_instance_id
+        )
 
       assert tenant_config[:tenant_id] == ctx.tenant_id
     end
 
     test "get_tenant/2 returns the requested tenant", ctx do
       {:ok, tenant_config} =
-        TenantManager.get_tenant(ctx.tenant_id, tenant_manager: ctx.tenant_manager)
+        TenantManager.get_tenant(ctx.tenant_id,
+          tenant_manager: ctx.tenant_manager,
+          electric_instance_id: ctx.electric_instance_id
+        )
 
       assert tenant_config[:tenant_id] == ctx.tenant_id
     end
@@ -194,12 +207,18 @@ defmodule Electric.TenantManagerTest do
 
     test "get_only_tenant/1 complains if there are several tenants", ctx do
       assert {:error, :several_tenants} =
-               TenantManager.get_only_tenant(tenant_manager: ctx.tenant_manager)
+               TenantManager.get_only_tenant(
+                 tenant_manager: ctx.tenant_manager,
+                 electric_instance_id: ctx.electric_instance_id
+               )
     end
 
     test "get_tenant/2 returns the requested tenant", ctx do
       {:ok, tenant_config} =
-        TenantManager.get_tenant("another_tenant", tenant_manager: ctx.tenant_manager)
+        TenantManager.get_tenant("another_tenant",
+          tenant_manager: ctx.tenant_manager,
+          electric_instance_id: ctx.electric_instance_id
+        )
 
       assert tenant_config[:tenant_id] == "another_tenant"
     end
@@ -247,7 +266,10 @@ defmodule Electric.TenantManagerTest do
       # Check that the tenant is now unknown to the tenant manager
       # and that it is fully shut down and removed from the ETS table
       assert {:error, :not_found} =
-               TenantManager.get_tenant(tenant_id, tenant_manager: tenant_manager)
+               TenantManager.get_tenant(tenant_id,
+                 tenant_manager: tenant_manager,
+                 electric_instance_id: electric_instance_id
+               )
 
       # Verify process was terminated
       refute Process.alive?(tenant_supervisor_pid)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -344,6 +344,7 @@ defmodule Support.ComponentSetup do
 
   def build_router_opts(ctx, overrides \\ []) do
     [
+      electric_instance_id: ctx.electric_instance_id,
       tenant_manager: ctx.tenant_manager,
       storage: ctx.storage,
       registry: ctx.registry,


### PR DESCRIPTION
This PR applies the refactoring proposed by @icehaunter which consists of storing the tenant information in a protected ETS table. Any process can read the tenant information from the ETS table.

#### Concurrent reads
On every shape request the tenant information is loaded from the ETS table.
Concurrent shape requests can read this information from the ETS table concurrently.

#### Serialised writes
Writes to the ETS table are less frequent (only when adding or removing tenants) and are still serialised through the tenant manager's genserver and thus are not prone to race conditions.