### PR TITLE
chore: changeset for multi tenancy

### DIFF
--- a/.changeset/eighty-apples-sniff.md
+++ b/.changeset/eighty-apples-sniff.md
@@ -1,0 +1,6 @@
+---
+"@core/sync-service": patch
+"@electric-sql/client": patch
+---
+
+Support for managing multiple databases on one Electric (multi tenancy).


### PR DESCRIPTION
The multi tenancy PR was committed without a changeset.