### PR TITLE
include MIX_ENV in cache keys

### DIFF
--- a/.github/workflows/elixir_client_tests.yml
+++ b/.github/workflows/elixir_client_tests.yml
@@ -71,9 +71,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/sync-service/deps
-          key: "${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-deps-
 
       - name: Cache sync-service compiled code
@@ -82,10 +83,11 @@ jobs:
           path: |
             packages/sync-service/_build/*/lib
             !packages/sync-service/_build/*/lib/electric
-          key: "${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-${{ github.sha }}"
+          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-${{ github.sha }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-${{ github.sha }}
-            ${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-${{ github.sha }}
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-build-
 
       - name: Install dependencies
@@ -127,6 +129,8 @@ jobs:
     defaults:
       run:
         working-directory: packages/elixir-client
+    env:
+      MIX_ENV: test
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -56,9 +56,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/sync-service/deps
-          key: "${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-deps-
 
       - name: Cache compiled code
@@ -67,10 +68,11 @@ jobs:
           path: |
             packages/sync-service/_build/*/lib
             !packages/sync-service/_build/*/lib/electric
-          key: "${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-${{ github.sha }}"
+          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-${{ github.sha }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-${{ github.sha }}
-            ${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-${{ github.sha }}
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-build-
 
       - name: Install dependencies
@@ -88,6 +90,8 @@ jobs:
     defaults:
       run:
         working-directory: packages/sync-service
+    env:
+      MIX_ENV: test
     steps:
       - uses: actions/checkout@v4
 
@@ -100,9 +104,10 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: packages/sync-service/deps
-          key: "${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-deps-
 
       - run: mix deps.get

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -21,6 +21,8 @@ jobs:
     defaults:
       run:
         working-directory: integration-tests
+    env:
+      MIX_ENV: dev
     steps:
       - uses: actions/checkout@v4
 
@@ -33,9 +35,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/sync-service/deps
-          key: "${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-deps-
 
       - name: Cache compiled code
@@ -44,10 +47,11 @@ jobs:
           path: |
             packages/sync-service/_build/*/lib
             !packages/sync-service/_build/*/lib/electric
-          key: "${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-${{ github.sha }}"
+          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-${{ github.sha }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-${{ github.sha }}
-            ${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-${{ github.sha }}
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-build-
 
       - name: Install dependencies

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -72,6 +72,7 @@ jobs:
         working-directory: ${{ matrix.package_dir }}
     env:
       ELECTRIC_DATABASE_ID: ci_test_tenant
+      MIX_ENV: dev
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
@@ -91,9 +92,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/sync-service/deps
-          key: "${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-deps-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-deps-
 
       - name: Cache compiled code
@@ -102,18 +104,21 @@ jobs:
           path: |
             packages/sync-service/_build/*/lib
             !packages/sync-service/_build/*/lib/electric
-          key: "${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-${{ github.sha }}"
+          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-${{ github.sha }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-${{ github.sha }}
-            ${{ runner.os }}-sync-service-build-[${{ github.ref_name }}]-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-${{ github.sha }}
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-[${{ github.ref_name }}]-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-
             ${{ runner.os }}-sync-service-build-
 
       - name: Install dependencies
         run: mix deps.get && mix deps.compile
         working-directory: packages/sync-service
-      - name: Compiles without warnings
-        run: mix compile --force --all-warnings --warnings-as-errors
+
+      - name: Compile sync-service
+        run: mix compile
         working-directory: packages/sync-service
+
       - uses: JarvusInnovations/background-action@v1
         name: Bootstrap System Under Test (SUT)
         with:


### PR DESCRIPTION
Currently we are successfully caching the MIX_ENV=test version, but some tests run with electric with MIX_ENV=dev, which results in a recompilation of deps and code.