### PR TITLE
chore (ts-client): validate required Electric headers on response

### DIFF
--- a/.changeset/shiny-rules-drive.md
+++ b/.changeset/shiny-rules-drive.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Verify that fetch response contains required Electric headers.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -8,12 +8,17 @@ import {
 } from './types'
 import { MessageParser, Parser } from './parser'
 import { isUpToDateMessage } from './helpers'
-import { FetchError, FetchBackoffAbortError } from './error'
+import {
+  FetchError,
+  FetchBackoffAbortError,
+  MissingHeadersError,
+} from './error'
 import {
   BackoffDefaults,
   BackoffOptions,
   createFetchWithBackoff,
   createFetchWithChunkBuffer,
+  createFetchWithResponseHeadersCheck,
 } from './fetch'
 import {
   CHUNK_LAST_OFFSET_HEADER,
@@ -218,7 +223,9 @@ export class ShapeStream<T extends Row<unknown> = Row>
       },
     })
 
-    this.#fetchClient = createFetchWithChunkBuffer(fetchWithBackoffClient)
+    this.#fetchClient = createFetchWithResponseHeadersCheck(
+      createFetchWithChunkBuffer(fetchWithBackoffClient)
+    )
 
     this.start()
   }
@@ -288,6 +295,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
           this.#connected = true
         } catch (e) {
           if (e instanceof FetchBackoffAbortError) break // interrupted
+          if (e instanceof MissingHeadersError) throw e
           if (!(e instanceof FetchError)) throw e // should never happen
           if (e.status == 409) {
             // Upon receiving a 409, we should start from scratch

--- a/packages/typescript-client/src/error.ts
+++ b/packages/typescript-client/src/error.ts
@@ -48,3 +48,14 @@ export class FetchBackoffAbortError extends Error {
     super(`Fetch with backoff aborted`)
   }
 }
+
+export class MissingHeadersError extends Error {
+  constructor(url: string, missingHeaders: Array<string>) {
+    let msg = `The response for the shape request to ${url} didn't include the following required headers:\n`
+    missingHeaders.forEach((h) => {
+      msg += `- ${h}\n`
+    })
+    msg += `\nThis is often due to a proxy not allowing all headers to be returned.`
+    super(msg)
+  }
+}

--- a/packages/typescript-client/src/error.ts
+++ b/packages/typescript-client/src/error.ts
@@ -55,7 +55,7 @@ export class MissingHeadersError extends Error {
     missingHeaders.forEach((h) => {
       msg += `- ${h}\n`
     })
-    msg += `\nThis is often due to a proxy not allowing all headers to be returned.`
+    msg += `\nThis is often due to a proxy not setting CORS correctly so that all Electric headers can be read by the client.`
     super(msg)
   }
 }

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -175,7 +175,8 @@ export function createFetchWithResponseHeadersCheck(
       addMissingHeaders(requiredElectricResponseHeaders)
 
       const input = args[0]
-      const url = new URL(input.toString())
+      const urlString = input.toString()
+      const url = new URL(urlString)
       if (url.searchParams.has(LIVE_QUERY_PARAM, `true`)) {
         addMissingHeaders(requiredLiveResponseHeaders)
       }
@@ -188,7 +189,7 @@ export function createFetchWithResponseHeadersCheck(
       }
 
       if (missingHeaders.length > 0) {
-        throw new MissingHeadersError(args[0].toString(), missingHeaders)
+        throw new MissingHeadersError(urlString, missingHeaders)
       }
     }
 

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -168,6 +168,17 @@ export function createFetchWithResponseHeadersCheck(
       const missingHeaders = requiredElectricResponseHeaders.filter(
         (h) => !headers.has(h)
       )
+
+      const input = args[0]
+      const url = new URL(input)
+      if (
+        url.searchParams.has(LIVE_QUERY_PARAM, `true`) &&
+        !headers.has(`electric-cursor`)
+      ) {
+        // response to live queries should also contain a cursor
+        missingHeaders.push(`electric-cursor`)
+      }
+
       if (missingHeaders.length > 0) {
         throw new MissingHeadersError(args[0].toString(), missingHeaders)
       }

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -153,7 +153,6 @@ export function createFetchWithChunkBuffer(
 export const requiredElectricResponseHeaders = [
   `electric-offset`,
   `electric-handle`,
-  `electric-schema`,
 ]
 
 export function createFetchWithResponseHeadersCheck(
@@ -170,13 +169,20 @@ export function createFetchWithResponseHeadersCheck(
       )
 
       const input = args[0]
-      const url = new URL(input)
+      const url = new URL(input.toString())
       if (
         url.searchParams.has(LIVE_QUERY_PARAM, `true`) &&
         !headers.has(`electric-cursor`)
       ) {
         // response to live queries should also contain a cursor
         missingHeaders.push(`electric-cursor`)
+      } else if (
+        (!url.searchParams.has(LIVE_QUERY_PARAM) ||
+          url.searchParams.has(LIVE_QUERY_PARAM, `false`)) &&
+        !headers.has(`electric-schema`)
+      ) {
+        // response to non-live queries should also contain the schema
+        missingHeaders.push(`electric-schema`)
       }
 
       if (missingHeaders.length > 0) {

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -4,6 +4,8 @@ import { setTimeout as sleep } from 'node:timers/promises'
 import { testWithIssuesTable as it } from './support/test-context'
 import { ShapeStream, Shape, FetchError } from '../src'
 import { Message, Row, ChangeMessage } from '../src/types'
+import { requiredElectricResponseHeaders } from '../src/fetch'
+import { MissingHeadersError } from '../src/error'
 
 const BASE_URL = inject(`baseUrl`)
 
@@ -304,6 +306,32 @@ describe(`Shape`, () => {
     await sleep(200)
 
     expect(shapeStream.isConnected()).true
+  })
+
+  it(`should stop fetching and report an error if response is missing required headers`, async ({
+    issuesTableUrl,
+  }) => {
+    let url: string = ``
+    const shapeStream = new ShapeStream({
+      url: `${BASE_URL}/v1/shape`,
+      table: issuesTableUrl,
+      fetchClient: async (input, _init) => {
+        url = input.toString()
+        const headers = new Headers()
+        headers.set(`electric-offset`, `0_0`)
+        return new Response(undefined, { status: 200, headers })
+      },
+    })
+
+    await sleep(10) // give some time for the initial fetch to complete
+    expect(shapeStream.isConnected()).false
+
+    const missingHeaders = requiredElectricResponseHeaders.filter(
+      (h) => h !== `electric-offset`
+    )
+    const expectedErrorMessage = new MissingHeadersError(url, missingHeaders)
+      .message
+    expect((shapeStream.error as Error).message === expectedErrorMessage)
   })
 
   it(`should set isConnected to false after fetch if not subscribed`, async ({

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -289,7 +289,14 @@ describe(`Shape`, () => {
             undefined
           )
         await sleep(50)
-        return new Response(undefined, { status: 204 })
+        return new Response(undefined, {
+          status: 204,
+          headers: new Headers({
+            [`electric-offset`]: `0_0`,
+            [`electric-handle`]: `foo`,
+            [`electric-schema`]: ``,
+          }),
+        })
       },
     })
 

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -229,8 +229,9 @@ paths:
             electric-schema:
               schema:
                 type: string
-                example: '":0},"status":{"type":"text","dimensions":0,"max_length":8}}'
+                example: '{"id":{"type":"int4","dimensions":0},"title":{"type":"text","dimensions":0},"status":{"type":"text","dimensions":0,"max_length":8}}'
                 description: |-
+                  Only present on responses to non-live requests.
                   A JSON string of an object that maps column names to the corresponding schema object.
                   The schema object contains the type of the column, the number of dimensions, and possibly additional properties.
                   Non-array types have a dimension of `0`, while array types have a dimension of 1 or more.


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1950

Questions:
- Are the headers only required on 2XX responses or also on other responses?
   They are currently only being checked on 2XX responses.
- Are we checking *all* required headers?
   Currently we check `electric-offset`, `electric-handle`, and `electric-schema`