### PR TITLE
chore (sync-service): unique publication and slot names per tenant

### DIFF
--- a/.changeset/fluffy-eagles-fly.md
+++ b/.changeset/fluffy-eagles-fly.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Make publication and slot names unique per tenant.

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -110,7 +110,7 @@
   [invoke setup_electric_shell $shell_name $port "ELECTRIC_DATABASE_ID=integration_test_tenant DATABASE_URL=$database_url"]
 [endmacro]
 
-[macro add_tenant tenant_id electric_port]
+[macro add_tenant tenant_id electric_port database_url]
   [shell $tenant_id]
     !curl -X POST http://localhost:$electric_port/v1/admin/database \
       -H "Content-Type: application/json" \

--- a/integration-tests/tests/invalidated-replication-slot.lux
+++ b/integration-tests/tests/invalidated-replication-slot.lux
@@ -7,7 +7,7 @@
 [my invalidated_slot_error=
   """
   [error] :gen_statem {Electric.Registry.Processes, {Electric.Postgres.ReplicationClient, :default, "integration_test_tenant"}} terminating
-  ** (Postgrex.Error) ERROR 55000 (object_not_in_prerequisite_state) cannot read from logical replication slot "electric_slot_integration"
+  ** (Postgrex.Error) ERROR 55000 (object_not_in_prerequisite_state) cannot read from logical replication slot "electric_slot_integration_47439671"
 
   This slot has been invalidated because it exceeded the maximum reserved size.
   """]
@@ -34,7 +34,7 @@
 
 ## Confirm slot invalidation in Postgres.
 [shell pg]
-  ?invalidating slot "electric_slot_integration" because its restart_lsn [\d\w]+/[\d\w]+ exceeds max_slot_wal_keep_size
+  ?invalidating slot "electric_slot_integration_47439671" because its restart_lsn [\d\w]+/[\d\w]+ exceeds max_slot_wal_keep_size
 
 ## Observe the fatal connection error.
 [shell electric]

--- a/integration-tests/tests/multi-tenancy-same-db.lux
+++ b/integration-tests/tests/multi-tenancy-same-db.lux
@@ -1,0 +1,112 @@
+[doc Verifies that several tenants can share the same PG instance and their publications and slots do not conflict]
+
+[include _macros.luxinc]
+
+[global pg_container_name=multi-tenancy-same-db__pg]
+
+# Tenant 1 uses the default `postgres` DB
+# Tenant 2 uses the `electric` DB
+[global tenant1_database_url=postgresql://postgres:password@localhost:54331/postgres?sslmode=disable]
+[global tenant2_database_url=postgresql://postgres:password@localhost:54331/electric?sslmode=disable]
+
+###
+
+## Start a new Postgres DB
+[invoke setup_pg_with_name "pg" "" ""]
+
+## Start Electric in multi tenancy mode
+[invoke setup_multi_tenant_electric]
+
+[shell electric]
+  ???[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
+
+## Create tenant 1
+[invoke add_tenant "tenant1" 3000 $tenant1_database_url]
+[invoke check_tenant_status "tenant1" "active" 3000]
+
+
+## Create tenant 2
+[invoke add_tenant "tenant2" 3000 $tenant2_database_url]
+[invoke check_tenant_status "tenant2" "active" 3000]
+
+## Insert some data in both DBs
+[shell tenant1_psql]
+  !docker exec -u postgres -it $pg_container_name psql -d postgres
+  !CREATE TABLE items (id INT PRIMARY KEY, val TEXT);
+  ??CREATE TABLE
+  !INSERT INTO items (id, val) VALUES (1, 'tenant1');
+  ??INSERT 0 1
+
+[shell tenant2_psql]
+  !docker exec -u postgres -it $pg_container_name psql -d electric
+  !CREATE TABLE items (id INT PRIMARY KEY, val TEXT);
+  ??CREATE TABLE
+  !INSERT INTO items (id, val) VALUES (1, 'tenant2');
+  ??INSERT 0 1
+
+## Check that both tenants can query their data
+[shell tenant1]
+  # Chech tenant 1 data
+  !curl -i -X GET "http://localhost:3000/v1/shape?table=items&offset=-1&database_id=tenant1"
+  ?\e\[1melectric-handle\e\[0m: ([\d-]+)
+  [local shape_id=$1]
+  ?\e\[1melectric-offset\e\[0m: ([\d_]+)
+  [local offset=$1]
+  """??
+  [{"key":"\"public\".\"items\"/\"1\"","value":{"id":"1","val":"tenant1"},"headers":{"operation":"insert","relation":["public","items"]},"offset":"$offset"}
+  ]
+  """
+  
+# Check tenant 2 data
+[shell tenant2]
+  !curl -i -X GET "http://localhost:3000/v1/shape?table=items&offset=-1&database_id=tenant2"
+  ?\e\[1melectric-handle\e\[0m: ([\d-]+)
+  [local shape_id=$1]
+  ?\e\[1melectric-offset\e\[0m: ([\d_]+)
+  [local offset=$1]
+  """??
+  [{"key":"\"public\".\"items\"/\"1\"","value":{"id":"1","val":"tenant2"},"headers":{"operation":"insert","relation":["public","items"]},"offset":"$offset"}
+  ]
+  """
+
+## Now do a live query on tenant 1
+[shell tenant1]
+  ??$PS1
+  !curl -i -X GET "localhost:3000/v1/shape?table=items&offset=$offset&handle="$shape_id"&database_id=tenant1&live"
+
+## And a live query on tenant 2
+[shell tenant2]
+  ??$PS1
+  !curl -i -X GET "localhost:3000/v1/shape?table=items&offset=$offset&handle="$shape_id"&database_id=tenant2&live"
+
+## Insert some data in tenant 1
+[shell tenant1_psql]
+  !INSERT INTO items (id, val) VALUES (2, 'tenant1');
+  ??INSERT 0 1
+
+## Insert some data in tenant 2
+[shell tenant2_psql]
+  !INSERT INTO items (id, val) VALUES (2, 'tenant2');
+  ??INSERT 0 1
+
+## Check that tenant 1 sees the new data
+[shell tenant1]
+  # give some time for the data to sync
+  [sleep 1]
+  ?\e\[1melectric-offset\e\[0m: ([\d_]+)
+  [local offset=$1]
+  ??[{"offset":"$offset","value":{"id":"2","val":"tenant1"},"key":"\"public\".\"items\"/\"2\"","headers":{"relation":["public","items"],"operation":"insert","txid":
+  ?[\d+]
+  ??}},{"headers":{"control":"up-to-date"}}]$PS1
+
+## Check that tenant 2 sees the new data
+[shell tenant2]
+  [sleep 1]
+  ?\e\[1melectric-offset\e\[0m: ([\d_]+)
+  [local offset=$1]
+  ??[{"offset":"$offset","value":{"id":"2","val":"tenant2"},"key":"\"public\".\"items\"/\"2\"","headers":{"relation":["public","items"],"operation":"insert","txid":
+  ?[\d+]
+  ??}},{"headers":{"control":"up-to-date"}}]$PS1
+
+[cleanup]
+  [invoke teardown]

--- a/integration-tests/tests/multi-tenancy.lux
+++ b/integration-tests/tests/multi-tenancy.lux
@@ -15,7 +15,6 @@
 ## Start a new Postgres DB
 [global pg_container_name=$tenant1_pg_container_name]
 [global pg_host_port=$tenant1_pg_host_port]
-[global database_url=$tenant1_database_url]
 [invoke setup_pg_with_name "tenant1_pg" "" ""]
 
 ## Start Electric in multi tenancy mode
@@ -25,7 +24,7 @@
   ???[info] Running Electric.Plug.Router with Bandit 1.5.5 at 0.0.0.0:3000 (http)
 
 ## Create tenant 1
-[invoke add_tenant "tenant1" 3000]
+[invoke add_tenant "tenant1" 3000 $tenant1_database_url]
 [invoke check_tenant_status "tenant1" "active" 3000]
 
 ## Setup a second Postgres DB
@@ -35,7 +34,7 @@
 [invoke setup_pg_with_name "tenant2_pg" "" ""]
 
 ## Create tenant 2
-[invoke add_tenant "tenant2" 3000]
+[invoke add_tenant "tenant2" 3000 $tenant2_database_url]
 [invoke check_tenant_status "tenant2" "active" 3000]
 
 ## Insert some data in both DBs

--- a/packages/sync-service/lib/electric/application/configuration.ex
+++ b/packages/sync-service/lib/electric/application/configuration.ex
@@ -1,4 +1,6 @@
 defmodule Electric.Application.Configuration do
+  @behaviour Access
+
   @moduledoc """
   A simple interface to `:persistent_term` that is designed for storing and retrieving the
   global application configuration (stored as a single map).
@@ -30,4 +32,20 @@ defmodule Electric.Application.Configuration do
 
   @spec get :: t
   def get, do: :persistent_term.get(@persistent_key)
+
+  # Implementing the Access behaviour
+  @impl Access
+  def fetch(%__MODULE__{} = config, key) do
+    Map.fetch(config, key)
+  end
+
+  @impl Access
+  def get_and_update(%__MODULE__{} = config, key, fun) do
+    Map.get_and_update(config, key, fun)
+  end
+
+  @impl Access
+  def pop(%__MODULE__{} = config, key) do
+    Map.pop(config, key)
+  end
 end

--- a/packages/sync-service/lib/electric/tenant/supervisor.ex
+++ b/packages/sync-service/lib/electric/tenant/supervisor.ex
@@ -56,22 +56,14 @@ defmodule Electric.Tenant.Supervisor do
       registry: Registry.ShapeChanges
     ]
 
-    # We deliberately don't include the electric instance ID
-    # in the publication and slot name because
-    # those are shared between all Electric instances connected to the same PG DB
-    # and there may be cases where we want one Electric to take over the publication
-    # and slot for a certain tenant of another Electric instance, e.g. during a rolling deploy.
-    # Note that this assumes that tenant IDs are unique across all Electric instances.
-    tenant_hash = tenant_id |> :erlang.phash2() |> Integer.to_string()
-
     connection_manager_opts = [
       electric_instance_id: electric_instance_id,
       tenant_id: tenant_id,
       connection_opts: connection_opts,
       replication_opts: [
-        publication_name: app_config.replication_opts.publication_name <> "_" <> tenant_hash,
+        publication_name: app_config.replication_opts.publication_name,
         try_creating_publication?: true,
-        slot_name: app_config.replication_opts.slot_name <> "_" <> tenant_hash,
+        slot_name: app_config.replication_opts.slot_name,
         slot_temporary?: app_config.replication_opts.slot_temporary?,
         transaction_received:
           {Electric.Replication.ShapeLogCollector, :store_transaction, [shape_log_collector]},

--- a/packages/sync-service/lib/electric/tenant_manager.ex
+++ b/packages/sync-service/lib/electric/tenant_manager.ex
@@ -195,17 +195,13 @@ defmodule Electric.TenantManager do
     # Note that this assumes that tenant IDs are unique across all Electric instances.
     tenant_hash = tenant_id |> :erlang.phash2() |> Integer.to_string()
 
-    updated_app_config =
+    per_tenant_app_config =
       app_config
       |> update_in([:replication_opts, :publication_name], &(&1 <> "_" <> tenant_hash))
       |> update_in([:replication_opts, :slot_name], &(&1 <> "_" <> tenant_hash))
 
-    # tenant_publication_name = app_config.replication_opts.publication_name <> "_" <> tenant_hash
-    # tenant_slot_name = app_config.replication_opts.slot_name <> "_" <> tenant_hash
-    # updated_replication_opts = %{app_config.replication_opts | publication_name: tenant_publication_name, slot_name: tenant_slot_name}
-
     start_tenant_opts = [
-      app_config: updated_app_config,
+      app_config: per_tenant_app_config,
       electric_instance_id: electric_instance_id,
       tenant_id: tenant_id,
       connection_opts: connection_opts,

--- a/packages/sync-service/lib/electric/tenant_manager.ex
+++ b/packages/sync-service/lib/electric/tenant_manager.ex
@@ -187,8 +187,25 @@ defmodule Electric.TenantManager do
           connection_opts: connection_opts
         ]
 
+    # We deliberately don't include the electric instance ID
+    # in the publication and slot name because
+    # those are shared between all Electric instances connected to the same PG DB
+    # and there may be cases where we want one Electric to take over the publication
+    # and slot for a certain tenant of another Electric instance, e.g. during a rolling deploy.
+    # Note that this assumes that tenant IDs are unique across all Electric instances.
+    tenant_hash = tenant_id |> :erlang.phash2() |> Integer.to_string()
+
+    updated_app_config =
+      app_config
+      |> update_in([:replication_opts, :publication_name], &(&1 <> "_" <> tenant_hash))
+      |> update_in([:replication_opts, :slot_name], &(&1 <> "_" <> tenant_hash))
+
+    # tenant_publication_name = app_config.replication_opts.publication_name <> "_" <> tenant_hash
+    # tenant_slot_name = app_config.replication_opts.slot_name <> "_" <> tenant_hash
+    # updated_replication_opts = %{app_config.replication_opts | publication_name: tenant_publication_name, slot_name: tenant_slot_name}
+
     start_tenant_opts = [
-      app_config: app_config,
+      app_config: updated_app_config,
       electric_instance_id: electric_instance_id,
       tenant_id: tenant_id,
       connection_opts: connection_opts,


### PR DESCRIPTION
This PR modifies the publication and slot names such that they contain the hash of the tenant ID.
Since tenant IDs are expected to be unique across all Electric instances this will result in unique publication and slot names. This makes it possible for several Electric instances to connect to the same PG database.