### PR TITLE
Drop replication slot on database delete

### DIFF
--- a/packages/cloud-sync-service/lib/cloud_electric/tenant_manager.ex
+++ b/packages/cloud-sync-service/lib/cloud_electric/tenant_manager.ex
@@ -122,7 +122,7 @@ defmodule CloudElectric.TenantManager do
         :ets.delete(tenants, tenant_id)
         state = %{state | dbs: MapSet.delete(dbs, pg_id)}
 
-        drop_replication_slot(tenant_id)
+        drop_replication_slot_on_stop(tenant_id)
 
         # TODO: This leaves orphaned shapes with data on disk
         :ok = DynamicTenantSupervisor.stop_tenant(tenant_id)
@@ -137,10 +137,10 @@ defmodule CloudElectric.TenantManager do
     end
   end
 
-  defp drop_replication_slot(tenant_id) do
+  defp drop_replication_slot_on_stop(tenant_id) do
     tenant_id
     |> Electric.Connection.Manager.name()
-    |> Electric.Connection.Manager.drop_replication_slot()
+    |> Electric.Connection.Manager.drop_replication_slot_on_stop()
   end
 
   defp do_create_tenant(

--- a/packages/cloud-sync-service/test/cloud_electric/plug/delete_database_plug_test.exs
+++ b/packages/cloud-sync-service/test/cloud_electric/plug/delete_database_plug_test.exs
@@ -49,6 +49,14 @@ defmodule CloudElectric.Plugs.DeleteDatabasePlugTest do
       assert conn.status == 200
       assert Jason.decode!(conn.resp_body) == ctx.tenant_id
 
+      # Ensure the replication slot has been dropped
+      assert %{rows: []} =
+               Postgrex.query!(
+                 ctx.db_conn,
+                 "SELECT slot_name FROM pg_replication_slots where slot_name=$1",
+                 [ctx.slot_name]
+               )
+
       # Ensure the publication has been dropped
       assert %{rows: []} = Postgrex.query!(db_conn, "SELECT pubname FROM pg_publication", [])
     end


### PR DESCRIPTION
Following on from #1965 this drops the replication slot as well as the publication.