### PR TITLE
fix: do validation for params off constructor so it can throw before starting

### DIFF
--- a/examples/nextjs-example/.sst/platform/config.d.ts
+++ b/examples/nextjs-example/.sst/platform/config.d.ts
@@ -2,22 +2,22 @@ import "./src/global.d.ts"
 import "../types.generated"
 import { AppInput, App, Config } from "./src/config"
 import * as _neon from "@sst-provider/neon";
-import * as _cloudflare from "@pulumi/cloudflare";
 import * as _aws from "@pulumi/aws";
+import * as _cloudflare from "@pulumi/cloudflare";
 
 
 declare global {
   // @ts-expect-error
   export import neon = _neon
   // @ts-expect-error
-  export import cloudflare = _cloudflare
-  // @ts-expect-error
   export import aws = _aws
+  // @ts-expect-error
+  export import cloudflare = _cloudflare
   interface Providers {
     providers?: {
       "neon"?:  (_neon.ProviderArgs & { version?: string }) | boolean | string;
-      "cloudflare"?:  (_cloudflare.ProviderArgs & { version?: string }) | boolean | string;
       "aws"?:  (_aws.ProviderArgs & { version?: string }) | boolean | string;
+      "cloudflare"?:  (_cloudflare.ProviderArgs & { version?: string }) | boolean | string;
     }
   }
   export const $config: (

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -535,8 +535,8 @@ function validateOptions<T>(options: Partial<ShapeStreamOptions<T>>): void {
 
   // Check for reserved parameter names
   if (options.params) {
-    const reservedParams = Object.keys(options.params).filter(
-      (key) => RESERVED_PARAMS.has(key)
+    const reservedParams = Object.keys(options.params).filter((key) =>
+      RESERVED_PARAMS.has(key)
     )
     if (reservedParams.length > 0) {
       throw new Error(

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -45,6 +45,19 @@ const RESERVED_PARAMS = new Set([
 
 type Replica = `full` | `default`
 
+type ReservedParamKeys =
+  | typeof DATABASE_ID_QUERY_PARAM
+  | typeof COLUMNS_QUERY_PARAM
+  | typeof LIVE_CACHE_BUSTER_QUERY_PARAM
+  | typeof SHAPE_HANDLE_QUERY_PARAM
+  | typeof LIVE_QUERY_PARAM
+  | typeof OFFSET_QUERY_PARAM
+  | typeof TABLE_QUERY_PARAM
+  | typeof WHERE_QUERY_PARAM
+  | typeof REPLICA_PARAM
+
+type ParamsRecord = Omit<Record<string, string>, ReservedParamKeys>
+
 /**
  * Options for constructing a ShapeStream.
  */
@@ -113,8 +126,10 @@ export interface ShapeStreamOptions<T = never> {
   /**
    * Additional request parameters to attach to the URL.
    * These will be merged with Electric's standard parameters.
+   * Note: You cannot use Electric's reserved parameter names
+   * (table, where, columns, offset, handle, live, cursor, database_id, replica).
    */
-  params?: Record<string, string>
+  params?: ParamsRecord
 
   /**
    * Automatically fetch updates to the Shape. If you just want to sync the current
@@ -516,6 +531,18 @@ function validateOptions<T>(options: Partial<ShapeStreamOptions<T>>): void {
     throw new Error(
       `shapeHandle is required if this isn't an initial fetch (i.e. offset > -1)`
     )
+  }
+
+  // Check for reserved parameter names
+  if (options.params) {
+    const reservedParams = Object.keys(options.params).filter(
+      (key) => RESERVED_PARAMS.has(key)
+    )
+    if (reservedParams.length > 0) {
+      throw new Error(
+        `Cannot use reserved Electric parameter names in custom params: ${reservedParams.join(`, `)}`
+      )
+    }
   }
   return
 }

--- a/packages/typescript-client/test/__snapshots__/client.test.ts.snap
+++ b/packages/typescript-client/test/__snapshots__/client.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Shape > should throw on a reserved parameter 1`] = `[Error: Cannot use reserved Electric parameter names in custom params: database_id]`;

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -23,6 +23,20 @@ describe(`Shape`, () => {
     expect(shape.lastSynced()).toBeLessThanOrEqual(Date.now() - start)
   })
 
+  it.only(`should throw on a reserved parameter`, async () => {
+    console.log(`hi`)
+    expect(() => {
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        table: `foo`,
+        params: {
+          database_id: `foo`,
+        },
+      })
+      new Shape(shapeStream)
+    }).toThrowErrorMatchingSnapshot()
+  })
+
   it(`should notify with the initial value`, async ({
     issuesTableUrl,
     insertIssues,

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -23,8 +23,7 @@ describe(`Shape`, () => {
     expect(shape.lastSynced()).toBeLessThanOrEqual(Date.now() - start)
   })
 
-  it.only(`should throw on a reserved parameter`, async () => {
-    console.log(`hi`)
+  it(`should throw on a reserved parameter`, async () => {
     expect(() => {
       const shapeStream = new ShapeStream({
         url: `${BASE_URL}/v1/shape`,


### PR DESCRIPTION
did this wrong in #1978 so that combined with #1983, passing a reserved parameter just means it silently fails atm.