### PR TITLE
Allow for configuration of non-standard API endpoints

### DIFF
--- a/.changeset/bright-melons-pay.md
+++ b/.changeset/bright-melons-pay.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Add ability to configure custom endpoint for Elixir client

--- a/.changeset/bright-melons-pay.md
+++ b/.changeset/bright-melons-pay.md
@@ -2,4 +2,4 @@
 "@core/elixir-client": patch
 ---
 
-Add ability to configure custom endpoint for Elixir client
+Add :endpoint configuration for Elixir client for non-standard API URLs

--- a/packages/elixir-client/lib/electric/client.ex
+++ b/packages/elixir-client/lib/electric/client.ex
@@ -307,6 +307,11 @@ defmodule Electric.Client do
     end
   end
 
+  # pass through a pre-configured ShapeDefinition as-is so that this is idempotent
+  def shape!(%ShapeDefinition{} = shape) do
+    shape
+  end
+
   @doc """
   A shortcut to [`ShapeDefinition.new!/2`](`Electric.Client.ShapeDefinition.new!/2`).
   """

--- a/packages/elixir-client/test/electric/client_test.exs
+++ b/packages/elixir-client/test/electric/client_test.exs
@@ -36,6 +36,40 @@ defmodule Electric.ClientTest do
   end
 
   describe "new" do
+    test ":url is used as the base of the endpoint" do
+      endpoint = URI.new!("http://localhost:3000/v1/shape")
+
+      {:ok, %Client{endpoint: ^endpoint}} =
+        Client.new(base_url: "http://localhost:3000")
+
+      {:ok, %Client{endpoint: ^endpoint}} =
+        Client.new(base_url: "http://localhost:3000/v1/shape")
+
+      {:ok, %Client{endpoint: ^endpoint}} =
+        Client.new(base_url: "http://localhost:3000/some/random/path")
+    end
+
+    test ":endpoint is used as-is" do
+      endpoint = URI.new!("http://localhost:3000")
+
+      {:ok, %Client{endpoint: ^endpoint}} =
+        Client.new(endpoint: "http://localhost:3000")
+
+      endpoint = URI.new!("http://localhost:3000/v1/shape")
+
+      {:ok, %Client{endpoint: ^endpoint}} =
+        Client.new(endpoint: "http://localhost:3000/v1/shape")
+
+      endpoint = URI.new!("http://localhost:3000/some/random/path")
+
+      {:ok, %Client{endpoint: ^endpoint}} =
+        Client.new(endpoint: "http://localhost:3000/some/random/path")
+    end
+
+    test "returns an error if neither :base_url or :endpoint is given" do
+      assert {:error, _} = Client.new([])
+    end
+
     test "database_id is correctly assigned" do
       {:ok, %Client{database_id: "1234"}} =
         Client.new(base_url: "http://localhost:3000", database_id: "1234")

--- a/packages/elixir-client/test/electric/client_test.exs
+++ b/packages/elixir-client/test/electric/client_test.exs
@@ -207,12 +207,12 @@ defmodule Electric.ClientTest do
       {:ok, id2} = insert_item(ctx)
       {:ok, id3} = insert_item(ctx)
 
-      assert_receive {:stream, 1, %ChangeMessage{value: %{"id" => ^id2}}}, 500
-      assert_receive {:stream, 1, %ChangeMessage{value: %{"id" => ^id3}}}, 500
+      assert_receive {:stream, 1, %ChangeMessage{value: %{"id" => ^id2}}}, 5000
+      assert_receive {:stream, 1, %ChangeMessage{value: %{"id" => ^id3}}}, 5000
       assert_receive {:stream, 1, up_to_date()}
 
-      assert_receive {:stream, 2, %ChangeMessage{value: %{"id" => ^id2}}}, 500
-      assert_receive {:stream, 2, %ChangeMessage{value: %{"id" => ^id3}}}, 500
+      assert_receive {:stream, 2, %ChangeMessage{value: %{"id" => ^id2}}}, 5000
+      assert_receive {:stream, 2, %ChangeMessage{value: %{"id" => ^id3}}}, 5000
       assert_receive {:stream, 2, up_to_date()}
     end
 


### PR DESCRIPTION
use `base_url` for the old behaviour of automatically appending `/v1/shape` and `endpoint` to explictly set the full URL of the shape api

Fixes #1992