### PR TITLE
elixir-client: Revert change to way base_url is used

### DIFF
--- a/packages/elixir-client/lib/electric/client.ex
+++ b/packages/elixir-client/lib/electric/client.ex
@@ -218,8 +218,7 @@ defmodule Electric.Client do
   If you configure your client using e.g. `base_url: "http://localhost:3000"`
   Electric will append the default shape API path
   `#{inspect(@api_endpoint_path)}` to create the final endpoint configuration,
-  in this case `"http://localhost:3000#{@api_endpoint_path}"`. Note that any
-  trailing path in the `base_url` is ignored.
+  in this case `"http://localhost:3000#{@api_endpoint_path}"`.
 
   If you wish to use a non-standard endpoint path because, for example, you wrap your Shape
   API calls in an [authentication
@@ -246,7 +245,7 @@ defmodule Electric.Client do
         case Map.fetch(attrs, :base_url) do
           {:ok, url} ->
             with {:ok, uri} <- URI.new(url) do
-              {:ok, %{uri | path: @api_endpoint_path}}
+              {:ok, URI.append_path(uri, @api_endpoint_path)}
             end
 
           :error ->

--- a/packages/elixir-client/test/electric/client_test.exs
+++ b/packages/elixir-client/test/electric/client_test.exs
@@ -36,14 +36,18 @@ defmodule Electric.ClientTest do
   end
 
   describe "new" do
-    test ":url is used as the base of the endpoint" do
+    test ":base_url is used as the base of the endpoint" do
       endpoint = URI.new!("http://localhost:3000/v1/shape")
 
       {:ok, %Client{endpoint: ^endpoint}} =
         Client.new(base_url: "http://localhost:3000")
 
+      endpoint = URI.new!("http://localhost:3000/proxy/v1/shape")
+
       {:ok, %Client{endpoint: ^endpoint}} =
-        Client.new(base_url: "http://localhost:3000/v1/shape")
+        Client.new(base_url: "http://localhost:3000/proxy")
+
+      endpoint = URI.new!("http://localhost:3000/some/random/path/v1/shape")
 
       {:ok, %Client{endpoint: ^endpoint}} =
         Client.new(base_url: "http://localhost:3000/some/random/path")


### PR DESCRIPTION
Originally the /v1/shape path was appended  onto the `base_url` path, but #1994 changed that to ignore any path elements in the base_url.

This change un-does that and reverts back to appending the /v1/shape path onto the base_url.

(no changeset included as the one in #1994 covers this)