### PR TITLE
Introducing Electric Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   ext/milestones"><img src="https://img.shields.io/badge/status-alpha-orange" alt="Status - Alpha"></a>
   <a href="https://discord.electric-sql.com"><img src="https://img.shields.io/discord/933657521581858818?color=5969EA&label=discord" alt="Chat - Discord"></a>
   <a href="https://x.com/ElectricSQL" target="_blank"><img src="https://img.shields.io/twitter/follow/ElectricSQL.svg?style=social&label=Follow @ElectricSQL"></a>
+  <a href="https://gurubase.io/g/electric"><img src="https://img.shields.io/badge/Gurubase-Ask%20Electric%20Guru-006BFF" alt="Gurubase - Ask Electric Guru"></a>
 </p>
 
 # Electric


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Electric Guru](https://gurubase.io/g/electric) to Gurubase. Electric Guru uses the data from this repo and data from the [docs](https://electric-sql.com/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Electric Guru", which highlights that Electric now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Electric Guru in Gurubase, just let me know that's totally fine.
