### PR TITLE
chore: fixed website builds

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -54,7 +54,8 @@ export default defineConfig({
     ]
   },
   rewrites: {
-    'blog/posts/:year-:month-:day-:slug.md': 'blog/:year/:month/:day/:slug.md'
+    'blog/posts/:year(\\d{4})-:month(\\d{2})-:day(\\d{2})-:slug([^/]+).md':
+      'blog/:year/:month/:day/:slug.md'
   },
   sitemap: {
     hostname: 'https://electric-sql.com'

--- a/website/data/activeJobs.data.ts
+++ b/website/data/activeJobs.data.ts
@@ -1,20 +1,23 @@
 import fs from 'node:fs'
-import { parse } from 'yaml'
+import path from "node:path"
+import { parse } from "yaml"
 
 export default {
-  watch: ['../about/jobs/*.md'],
+  watch: ["../about/jobs/*.md"],
 
-  load (files) {
-    return files.map((file) => {
-      const slug = file.split('/about/jobs/')[1].split('.')[0]
+  load(files) {
+    return files
+      .map((file) => {
+        const slug = path.basename(file, ".md")
 
-      const contents = fs.readFileSync(file, 'utf-8')
-      const frontmatter = contents.split('---\n')[1]
+        const contents = fs.readFileSync(file, "utf-8")
+        const frontmatter = contents.split("---\n")[1]
 
-      const data = parse(frontmatter)
-      data.link = `/about/jobs/${slug}`
+        const data = parse(frontmatter)
+        data.link = `/about/jobs/${slug}`
 
-      return data
-    }).filter(x => x.active)
-  }
+        return data
+      })
+      .filter((x) => x.active)
+  },
 }

--- a/website/data/use-cases.data.ts
+++ b/website/data/use-cases.data.ts
@@ -1,23 +1,26 @@
 import fs from 'node:fs'
-import { parse } from 'yaml'
+import path from "node:path"
+import { parse } from "yaml"
 
 export default {
-  watch: ['../use-cases/*.md'],
+  watch: ["../use-cases/*.md"],
 
-  load (files) {
-    return files.map((file) => {
-      const slug = file.split('/use-cases/')[1].split('.')[0]
+  load(files) {
+    return files
+      .map((file) => {
+        const slug = path.basename(file, ".md")
 
-      const contents = fs.readFileSync(file, 'utf-8')
-      const frontmatter = contents.split('---\n')[1]
+        const contents = fs.readFileSync(file, "utf-8")
+        const frontmatter = contents.split("---\n")[1]
 
-      const data = parse(frontmatter)
-      data.link = `/use-cases/${slug}`
+        const data = parse(frontmatter)
+        data.link = `/use-cases/${slug}`
 
-      return data
-    }).filter(x => x.homepage)
+        return data
+      })
+      .filter((x) => x.homepage)
       .sort((a, b) => {
         return parseInt(a.homepage_order) - parseInt(b.homepage_order)
       })
-  }
+  },
 }

--- a/website/src/partials/sync-into-pglite.tsx
+++ b/website/src/partials/sync-into-pglite.tsx
@@ -34,7 +34,5 @@ const Component = () => {
     `SELECT * FROM items;`
   )
 
-  return (
-    <pre>{JSON.stringify(items)}<pre>
-      )
+  return <pre>{JSON.stringify(items)}</pre>
 }


### PR DESCRIPTION
Previous matching was generating wrong blog structure (paths were split on arbitrary `-`), which led to "dead link" complaints. Also the `.split` of the path was wrong because preceding slash is not part of the file, but maybe that's incosistent between mac & linux so I replaced it with a definitely crossplatform call