### PR TITLE
feat (sync-service): Prevent shape consumer errors from affecting other shapes

### DIFF
--- a/.changeset/clever-dots-admire.md
+++ b/.changeset/clever-dots-admire.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Improve reliability: Shapes that error while processing the replication stream will now be removed leaving other shapes unaffected

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -116,7 +116,7 @@ defmodule Electric.Shapes.Consumer do
 
     # TODO: ensure cleanup occurs after snapshot is done/failed/interrupted to avoid
     # any race conditions and leftover data
-    state = cleanup(state)
+    cleanup(state)
     {:stop, :normal, :ok, state}
   end
 
@@ -160,7 +160,7 @@ defmodule Electric.Shapes.Consumer do
         )
 
     state = reply_to_snapshot_waiters({:error, error}, state)
-    state = cleanup(state)
+    cleanup(state)
     {:stop, :normal, state}
   end
 
@@ -183,7 +183,7 @@ defmodule Electric.Shapes.Consumer do
           "Error in Shapes.Consumer.handle_events: #{inspect(error)}\n#{Exception.format(:error, error)}"
         )
 
-        state = cleanup(state)
+        cleanup(state)
         {:stop, :normal, state}
     end
   end
@@ -207,7 +207,7 @@ defmodule Electric.Shapes.Consumer do
         state
       )
 
-    state = cleanup(state)
+    cleanup(state)
     {:stop, :normal, state}
   end
 
@@ -350,7 +350,6 @@ defmodule Electric.Shapes.Consumer do
     %{shape_status: {shape_status, shape_status_state}} = state
     shape_status.remove_shape(shape_status_state, state.shape_handle)
     ShapeCache.Storage.cleanup!(state.storage)
-    state
   end
 
   defp reply_to_snapshot_waiters(_reply, %{awaiting_snapshot_start: []} = state) do

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -91,13 +91,22 @@ defmodule Electric.Shapes.Consumer do
      subscribe_to: [{producer, [max_demand: 1, selector: &selector(&1, config.shape)]}]}
   end
 
-  defp selector(%Transaction{changes: changes}, shape) do
+  defp selector(event, shape) do
+    process_event?(event, shape)
+  rescue
+    # Swallow errors here to avoid crashing the ShapeLogCollector.
+    # Return `true` so the event is processed, which will then error
+    # for the same reason and cleanup the shape.
+    _ -> true
+  end
+
+  defp process_event?(%Transaction{changes: changes}, shape) do
     changes
     |> Stream.flat_map(&Shape.convert_change(shape, &1))
     |> Enum.any?()
   end
 
-  defp selector(%Changes.Relation{} = relation_change, shape) do
+  defp process_event?(%Changes.Relation{} = relation_change, shape) do
     Shape.is_affected_by_relation_change?(shape, relation_change)
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -190,9 +190,11 @@ defmodule Electric.Shapes.Consumer do
     state
   end
 
-  defp is_error?(reason) do
-    reason not in [:normal, :shutdown, {:shutdown, :truncate}, :killed]
-  end
+  defp is_error?(:normal), do: false
+  defp is_error?(:killed), do: false
+  defp is_error?(:shutdown), do: false
+  defp is_error?({:shutdown, _}), do: false
+  defp is_error?(_), do: true
 
   # `Shapes.Dispatcher` only works with single-events, so we can safely assert
   # that here

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -795,8 +795,6 @@ defmodule Electric.ShapeCacheTest do
 
     setup do
       %{
-        # don't crash the log collector when the shape consumers get killed by our tests
-        link_log_collector: false,
         inspector: Support.StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
       }
     end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -105,17 +105,14 @@ defmodule Electric.Shapes.ConsumerTest do
           ]
         })
 
-      producer =
-        start_supervised!(
-          {ShapeLogCollector,
-           [
-             stack_id: ctx.stack_id,
-             demand: :forward,
-             inspector:
-               Support.StubInspector.new([
-                 %{name: "id", type: "int8", pk_position: 0}
-               ])
-           ]}
+      {:ok, producer} =
+        ShapeLogCollector.start_link(
+          stack_id: ctx.stack_id,
+          demand: :forward,
+          inspector:
+            Support.StubInspector.new([
+              %{name: "id", type: "int8", pk_position: 0}
+            ])
         )
 
       consumers =

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -111,8 +111,7 @@ defmodule Support.ComponentSetup do
     {:ok, _} =
       ShapeLogCollector.start_link(
         stack_id: ctx.stack_id,
-        inspector: ctx.inspector,
-        link_consumers: Map.get(ctx, :link_log_collector, true)
+        inspector: ctx.inspector
       )
 
     %{shape_log_collector: ShapeLogCollector.name(ctx.stack_id)}


### PR DESCRIPTION
Fixes #1925 . Errors that occur while consuming the replication stream that are to do with a specific shape, cause that shape's consumer to remove the shape and shut down, leaving the other shapes unaffected.

Errors can occur:
1. In the selector which happens on a process common to all shapes. 
2. On the consumer process.

This PR addresses both types of error. Previous to this PR, these errors would cause the sync service to get into an infinite crash loop and would stop responding to HTTP requests.