### PR TITLE
feat: enable error handler to recover from failed HTTP requests

### DIFF
--- a/.changeset/loud-peaches-mate.md
+++ b/.changeset/loud-peaches-mate.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Allow error handler to modify HTTP query parameters and headers to retry failed HTTP request.

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -848,7 +848,9 @@ describe(`HTTP Sync`, () => {
       subscribe: true,
       handle: issueStream.shapeHandle,
       where: `1=1`,
-      onError: (err) => (error = err),
+      onError: (err) => {
+        error = err
+      },
     })
 
     const errorSubscriberPromise = new Promise((_, reject) =>


### PR DESCRIPTION
This PR modifies the `onError` handler that is supported by the shape stream such that it can recover from certain HTTP request errors. For example, if the HTTP request fails with a 401 because of an expired token, the handler could fetch a new token, and try again by returning the modified HTTP headers. The shapestream will then retry.

- [x] Should we make the onError handler async such that it can for instance fetch the new token asynchronously?

**Accompanying docs PR: https://github.com/electric-sql/electric/pull/2018**