### PR TITLE
feat! (ts client): Remove subscribeOnceToUpToDate from shape stream

### DIFF
--- a/.changeset/grumpy-cougars-cheat.md
+++ b/.changeset/grumpy-cougars-cheat.md
@@ -2,4 +2,4 @@
 "@electric-sql/client": minor
 ---
 
-Remove subscribeOnceToUpToDate method from ShapeStream. Instead, you should subscribe to the stream and check for the up-to-date control message.
+[BREAKING] Remove subscribeOnceToUpToDate method from ShapeStream. Instead, you should subscribe to the stream and check for the up-to-date control message.

--- a/.changeset/grumpy-cougars-cheat.md
+++ b/.changeset/grumpy-cougars-cheat.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": minor
+---
+
+Remove subscribeOnceToUpToDate method from ShapeStream. Instead, you should subscribe to the stream and check for the up-to-date control message.

--- a/packages/typescript-client/src/shape.ts
+++ b/packages/typescript-client/src/shape.ts
@@ -55,15 +55,6 @@ export class Shape<T extends Row<unknown> = Row> {
       this.#process.bind(this),
       this.#handleError.bind(this)
     )
-    const unsubscribe = this.#stream.subscribeOnceToUpToDate(
-      () => {
-        unsubscribe()
-      },
-      (e) => {
-        this.#handleError(e)
-        throw e
-      }
-    )
   }
 
   get isUpToDate(): boolean {

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -848,12 +848,8 @@ describe(`HTTP Sync`, () => {
     const errorSubscriberPromise = new Promise((_, reject) =>
       invalidIssueStream.subscribe(() => {}, reject)
     )
-    const errorUpToDateSubscriberPromise = new Promise((_, reject) =>
-      invalidIssueStream.subscribeOnceToUpToDate(() => {}, reject)
-    )
 
     await expect(errorSubscriberPromise).rejects.toThrow(FetchError)
-    await expect(errorUpToDateSubscriberPromise).rejects.toThrow(FetchError)
     expect(invalidIssueStream.error).instanceOf(FetchError)
     expect((invalidIssueStream.error! as FetchError).status).toBe(400)
     expect(invalidIssueStream.isConnected()).false


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/1996.

We remove `subscribeOnceToUpToDate` in favor of subscribing to the stream and "waiting" for the first `up-to-date` control message. **This is a breaking change.**