### PR TITLE
Fix: only try to add comment to PR thread if we're on a PR

### DIFF
--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -74,6 +74,7 @@ jobs:
           fi
 
       - name: Add comment to PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This prevent the action from failing on main.