### PR TITLE
chore (sync service): remove redundant spans

### DIFF
--- a/.changeset/few-gorillas-fetch.md
+++ b/.changeset/few-gorillas-fetch.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Remove redundant spans in open telemetry tracing.


### PR DESCRIPTION
Part of https://github.com/electric-sql/electric/issues/2032.
I removed 2 spans that seem redundant:

- `shape_write.log_collector.handle_txn`: this span wraps the `handle_transaction` function. However, there is already a span `pg_txn.replication_client.transaction_received` that in fact calls into `handle_transaction`.
- `shape_write.log_collector.handle_relation`: this span wraps the handling of relation messages. Similarly to transactions, there is a `pg_txn.replication_client.relation_received` span that ends up calling into the `handle_relation` function.

Here are the relevant code snippets:

`Electric.Postgres.ReplicationClient`:
```ex
{m, f, args} = state.transaction_received

OpenTelemetry.with_span(
  "pg_txn.replication_client.transaction_received",
  [num_changes: length(txn.changes), num_relations: MapSet.size(txn.affected_relations)],
  fn -> apply(m, f, [txn | args]) end
)
```

The call to `apply` is a chain of calls that eventually ends up calling `handle_transaction` (and does nothing more):

`Electric.StackSupervisor`:
```ex
transaction_received: {Electric.Replication.ShapeLogCollector, :store_transaction, [shape_log_collector]}
```

`Electric.Replication.ShapeLogCollector.ex`:
```ex
def store_transaction(%Transaction{} = txn, server) do
  ot_span_ctx = OpenTelemetry.get_current_context()
  GenStage.call(server, {:new_txn, txn, ot_span_ctx}, :infinity)
end

def handle_call({:new_txn, %Transaction{xid: xid, lsn: lsn} = txn, ot_span_ctx}, from, state) do
  OpenTelemetry.set_current_context(ot_span_ctx)
  Logger.info("Received transaction #{xid} from Postgres at #{lsn}")
  Logger.debug(fn -> "Txn received in ShapeLogCollector: #{inspect(txn)}" end)

  OpenTelemetry.with_span("shape_write.log_collector.handle_txn", [], fn ->
    handle_transaction(txn, from, state) 
  end)
end
```

### Question

I removed the spans from `Electric.Replication.ShapeLogCollector`, another option would be to remove the spans from `Electric.Postgres.ReplicationClient`, any preference here?