### PR TITLE
fix(elixir-client): Should terminate on 400s

### DIFF
--- a/.changeset/nasty-emus-rule.md
+++ b/.changeset/nasty-emus-rule.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Fix mishandling of 400s - should terminate

--- a/packages/elixir-client/lib/electric/client/stream.ex
+++ b/packages/elixir-client/lib/electric/client/stream.ex
@@ -19,7 +19,7 @@ defmodule Electric.Client.Stream do
     replica: :default,
     offset: Offset.before_all(),
     shape_handle: nil,
-    next_cursor: System.os_time(),
+    next_cursor: nil,
     state: :init,
     opts: %{}
   ]

--- a/packages/elixir-client/lib/electric/client/stream.ex
+++ b/packages/elixir-client/lib/electric/client/stream.ex
@@ -19,7 +19,7 @@ defmodule Electric.Client.Stream do
     replica: :default,
     offset: Offset.before_all(),
     shape_handle: nil,
-    next_cursor: nil,
+    next_cursor: System.os_time(),
     state: :init,
     opts: %{}
   ]
@@ -168,13 +168,10 @@ defmodule Electric.Client.Stream do
     |> dispatch()
   end
 
-  # 400: The request is invalid, most likely because the shape has been
-  #      deleted. We should start from scratch, this will force the shape to be
-  #      recreated
   # 409: Upon receiving a 409, we should start from scratch with the newly
   #      provided shape handle
   defp handle_response({:error, %Fetch.Response{status: status} = resp}, stream)
-       when status in [400, 409] do
+       when status in [409] do
     %{value_mapper_fun: value_mapper_fun} = stream
     offset = last_offset(resp, stream.offset)
 


### PR DESCRIPTION
Ignore the branch name - 400s are terminal errors indicating a malformed request and should not trigger restarts.