### PR TITLE
examples: always start clean and update running instructions.

### DIFF
--- a/examples/basic-example/README.md
+++ b/examples/basic-example/README.md
@@ -1,22 +1,46 @@
 # Basic example
 
+This is an example of a basic ElectricSQL app using React. The Electric-specific code is in [`./src/Example.tsx`](./src/Example.tsx).
+
 ## Setup
 
-1. Make sure you've installed all dependencies for the monorepo and built packages
+This example is part of the [ElectricSQL monorepo](../..) and is designed to be built and run as part of the [pnpm workspace](https://pnpm.io/workspaces) defined in [`../../pnpm-workspace.yaml`](../../pnpm-workspace.yaml).
 
-From the root directory:
+Navigate to the root directory of the monorepo, e.g.:
 
-- `pnpm i`
-- `pnpm run -r build`
+```shell
+cd ../../
+```
 
-2. Start the docker containers
+Install and build all of the workspace packages and examples:
 
-`pnpm run backend:up`
+```shell
+pnpm install
+pnpm run -r build
+```
 
-3. Start the dev server
+Navigate back to this directory:
 
-`pnpm run dev`
+```shell
+cd examples/basic-example
+```
 
-4. When done, tear down the backend containers so you can run other examples
+Start the example backend services using [Docker Compose](https://docs.docker.com/compose/):
 
-`pnpm run backend:down`
+```shell
+pnpm backend:up
+```
+
+> Note that this always stops and deletes the volumes mounted by any other example backend containers that are running or have been run before. This ensures that the example always starts with a clean database and clean disk.
+
+Now start the dev server:
+
+```shell
+pnpm dev
+```
+
+When you're done, stop the backend services using:
+
+```shell
+pnpm backend:down
+```

--- a/examples/basic-example/README.md
+++ b/examples/basic-example/README.md
@@ -39,6 +39,20 @@ Now start the dev server:
 pnpm dev
 ```
 
+You should see three items listed in the page. These are created when first running the [`./db/migrations`](./db/migrations).
+
+Now let's connect to Postgres, e.g.: using `psql`:
+
+```shell
+psql "postgresql://postgres:password@localhost:54321/electric"
+```
+
+Insert new data and watch it sync into the page in real time:
+
+```sql
+insert into items (id) values (gen_random_uuid());
+```
+
 When you're done, stop the backend services using:
 
 ```shell

--- a/examples/basic-example/db/migrations/01-create_items_table.sql
+++ b/examples/basic-example/db/migrations/01-create_items_table.sql
@@ -3,11 +3,11 @@ CREATE TABLE IF NOT EXISTS items (
   id TEXT PRIMARY KEY NOT NULL
 );
 
--- Populate the table with 10 items.
+-- Populate the table with 3 items.
 -- FIXME: Remove this once writing out of band is implemented
 WITH generate_series AS (
     SELECT gen_random_uuid()::text AS id
-    FROM generate_series(1, 10)
+    FROM generate_series(1, 3)
 )
 INSERT INTO items (id)
 SELECT id

--- a/examples/basic-example/package.json
+++ b/examples/basic-example/package.json
@@ -11,6 +11,7 @@
     "db:migrate": "dotenv -e ../../.env.dev -- pnpm exec pg-migrations apply --directory ./db/migrations",
     "dev": "vite",
     "build": "vite build",
+    "format": "eslint . --ext ts,tsx --fix",
     "stylecheck": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"

--- a/examples/basic-example/src/Example.tsx
+++ b/examples/basic-example/src/Example.tsx
@@ -1,14 +1,14 @@
-import { useShape } from '@electric-sql/react'
-import './Example.css'
+import { useShape } from "@electric-sql/react"
+import "./Example.css"
 
 type Item = { id: string }
 
-const baseUrl = import.meta.env.ELECTRIC_URL ?? 'http://localhost:3000'
+const baseUrl = import.meta.env.ELECTRIC_URL ?? `http://localhost:3000`
 
 export const Example = () => {
   const { data: items } = useShape<Item>({
     url: `${baseUrl}/v1/shape`,
-    table: 'items',
+    table: `items`,
   })
 
   return (

--- a/examples/basic-example/src/Example.tsx
+++ b/examples/basic-example/src/Example.tsx
@@ -1,34 +1,16 @@
-import { useShape } from "@electric-sql/react"
-import "./Example.css"
+import { useShape } from '@electric-sql/react'
+import './Example.css'
 
 type Item = { id: string }
 
-const baseUrl = import.meta.env.ELECTRIC_URL ?? `http://localhost:3000`
+const baseUrl = import.meta.env.ELECTRIC_URL ?? 'http://localhost:3000'
 
 export const Example = () => {
   const { data: items } = useShape<Item>({
     url: `${baseUrl}/v1/shape`,
-    table: `items`,
+    table: 'items',
   })
 
-  /*
-  const addItem = async () => {
-    console.log(`'addItem' is not implemented`)
-  }
-
-  const clearItems = async () => {
-    console.log(`'clearItems' is not implemented`)
-  }
-
-      <div className="controls">
-        <button className="button" onClick={addItem}>
-          Add
-        </button>
-        <button className="button" onClick={clearItems}>
-          Clear
-        </button>
-      </div>
-      */
   return (
     <div>
       {items.map((item: Item, index: number) => (

--- a/examples/gatekeeper-auth/README.md
+++ b/examples/gatekeeper-auth/README.md
@@ -84,6 +84,12 @@ Build the local API image:
 docker compose build api
 ```
 
+Make sure you're starting with a clean slate:
+
+```shell
+docker compose down --volumes
+```
+
 Run `postgres`, `electric` and the `api` services:
 
 ```console
@@ -209,6 +215,12 @@ Build the local docker images:
 docker compose build api caddy
 ```
 
+Make sure you're starting with a clean slate:
+
+```shell
+docker compose down --volumes
+```
+
 Run `postgres`, `electric`, `api` and `caddy` services with the `.env.caddy` env file:
 
 ```shell
@@ -277,6 +289,14 @@ It's often better (faster, more scalable and a more natural topology) to run you
 The example in the [`./edge`](./edge) folder contains a small [Deno HTTP server](https://docs.deno.com/runtime/fundamentals/http_server/) in the [`index.ts`](./edge/index.ts) file that's designed to work as a [Supabase Edge Function](https://supabase.com/docs/guides/functions/quickstart). See the README in the folder for more information about deploying to Supabase.
 
 Here, we'll run it locally using Docker in order to demonstrate it working with the other services:
+
+Make sure you're starting with a clean slate:
+
+```shell
+docker compose down --volumes
+```
+
+Then:
 
 ```shell
 docker compose --env-file .env.edge up postgres electric api edge

--- a/examples/linearlite/README.md
+++ b/examples/linearlite/README.md
@@ -1,22 +1,46 @@
 # Linearlite
 
+This is an example Linear clone developed using ElectricSQL.
+
 ## Setup
 
-1. Make sure you've installed all dependencies for the monorepo and built packages
+This example is part of the [ElectricSQL monorepo](../..) and is designed to be built and run as part of the [pnpm workspace](https://pnpm.io/workspaces) defined in [`../../pnpm-workspace.yaml`](../../pnpm-workspace.yaml).
 
-From the root directory:
+Navigate to the root directory of the monorepo, e.g.:
 
-- `pnpm i`
-- `pnpm run -r build`
+```shell
+cd ../../
+```
 
-2. Start the docker containers
+Install and build all of the workspace packages and examples:
 
-`pnpm run backend:up`
+```shell
+pnpm install
+pnpm run -r build
+```
 
-3. Start the dev server
+Navigate back to this directory:
 
-`pnpm run dev`
+```shell
+cd examples/linearlite
+```
 
-4. When done, tear down the backend containers so you can run other examples
+Start the example backend services using [Docker Compose](https://docs.docker.com/compose/):
 
-`pnpm run backend:down`
+```shell
+pnpm backend:up
+```
+
+> Note that this always stops and deletes the volumes mounted by any other example backend containers that are running or have been run before. This ensures that the example always starts with a clean database and clean disk.
+
+Now start the dev server:
+
+```shell
+pnpm dev
+```
+
+When you're done, stop the backend services using:
+
+```shell
+pnpm backend:down
+```

--- a/examples/nextjs-example/README.md
+++ b/examples/nextjs-example/README.md
@@ -1,22 +1,46 @@
 # Basic Next.js example
 
+This is an example Next.js application developed using ElectricSQL.
+
 ## Setup
 
-1. Make sure you've installed all dependencies for the monorepo and built packages
+This example is part of the [ElectricSQL monorepo](../..) and is designed to be built and run as part of the [pnpm workspace](https://pnpm.io/workspaces) defined in [`../../pnpm-workspace.yaml`](../../pnpm-workspace.yaml).
 
-From the root directory:
+Navigate to the root directory of the monorepo, e.g.:
 
-- `pnpm i`
-- `pnpm run -r build`
+```shell
+cd ../../
+```
 
-2. Start the docker containers
+Install and build all of the workspace packages and examples:
 
-`pnpm run backend:up`
+```shell
+pnpm install
+pnpm run -r build
+```
 
-3. Start the dev server
+Navigate back to this directory:
 
-`pnpm run dev`
+```shell
+cd examples/nextjs-example
+```
 
-4. When done, tear down the backend containers so you can run other examples
+Start the example backend services using [Docker Compose](https://docs.docker.com/compose/):
 
-`pnpm run backend:down`
+```shell
+pnpm backend:up
+```
+
+> Note that this always stops and deletes the volumes mounted by any other example backend containers that are running or have been run before. This ensures that the example always starts with a clean database and clean disk.
+
+Now start the dev server:
+
+```shell
+pnpm dev
+```
+
+When you're done, stop the backend services using:
+
+```shell
+pnpm backend:down
+```

--- a/examples/proxy-auth/README.md
+++ b/examples/proxy-auth/README.md
@@ -15,21 +15,43 @@ https://github.com/user-attachments/assets/eab62c23-513c-4ed8-a6fa-249b761f8667
 
 ## Setup
 
-1. Make sure you've installed all dependencies for the monorepo and built packages
+This example is part of the [ElectricSQL monorepo](../..) and is designed to be built and run as part of the [pnpm workspace](https://pnpm.io/workspaces) defined in [`../../pnpm-workspace.yaml`](../../pnpm-workspace.yaml).
 
-From the root directory:
+Navigate to the root directory of the monorepo, e.g.:
 
-- `pnpm i`
-- `pnpm run -r build`
+```shell
+cd ../../
+```
 
-2. Start the docker containers
+Install and build all of the workspace packages and examples:
 
-`pnpm run backend:up`
+```shell
+pnpm install
+pnpm run -r build
+```
 
-3. Start the dev server
+Navigate back to this directory:
 
-`pnpm run dev`
+```shell
+cd examples/proxy-auth
+```
 
-4. When done, tear down the backend containers so you can run other examples
+Start the example backend services using [Docker Compose](https://docs.docker.com/compose/):
 
-`pnpm run backend:down`
+```shell
+pnpm backend:up
+```
+
+> Note that this always stops and deletes the volumes mounted by any other example backend containers that are running or have been run before. This ensures that the example always starts with a clean database and clean disk.
+
+Now start the dev server:
+
+```shell
+pnpm dev
+```
+
+When you're done, stop the backend services using:
+
+```shell
+pnpm backend:down
+```

--- a/examples/redis-sync/README.md
+++ b/examples/redis-sync/README.md
@@ -6,27 +6,79 @@ You don't need to manage cache invalidation seperately or set expiry dates of TT
 
 ## Setup
 
-1. Make sure you've installed all dependencies for the monorepo and built packages
+This example is part of the [ElectricSQL monorepo](../..) and is designed to be built and run as part of the [pnpm workspace](https://pnpm.io/workspaces) defined in [`../../pnpm-workspace.yaml`](../../pnpm-workspace.yaml).
 
-From the root directory:
+Navigate to the root directory of the monorepo, e.g.:
 
-- `pnpm i`
-- `pnpm run -r build`
+```shell
+cd ../../
+```
 
-2. Start the docker containers
+Install and build all of the workspace packages and examples:
 
-`pnpm run backend:up`
+```shell
+pnpm install
+pnpm run -r build
+```
 
-3. Start the dev server
+Navigate back to this directory:
 
-`pnpm run dev`
+```shell
+cd examples/redis-sync
+```
 
-4. Connect a redis client to see the data in redis:
-- `hkeys items` — see all the keys
-- `kgetall items` — see keys/values
-- `monitor` — run this to see updates as they come in. Try running this while making changes
-to the items table in Postgres.
+Start the example backend services using [Docker Compose](https://docs.docker.com/compose/):
 
-5. When done, tear down the backend containers so you can run other examples
+```shell
+pnpm backend:up
+```
 
-`pnpm run backend:down`
+> Note that this always stops and deletes the volumes mounted by any other example backend containers that are running or have been run before. This ensures that the example always starts with a clean database and clean disk.
+
+Now start the dev server:
+
+```shell
+pnpm dev
+```
+
+Connect a redis client to see the data in redis, e.g.:
+
+```shell
+redis-cli -h 127.0.0.1 -p 6379
+```
+
+To see all the keys:
+
+```console
+redis> HKEYS items
+```
+
+See all the keys and values:
+
+```console
+redis> KGETALL items
+```
+
+See all updates as they come in:
+
+```console
+MONITOR
+```
+
+Try running this while making changes to the items table in Postgres, e.g. using `psql`:
+
+```shell
+psql "postgresql://postgres:password@localhost:54321/electric"
+```
+
+Insert new data and watch it sync into Redis in real time:
+
+```sql
+insert into items (id, title) values (gen_random_uuid(), 'foo');
+```
+
+When you're done, stop the backend services using:
+
+```shell
+pnpm backend:down
+```

--- a/examples/remix-basic/README.md
+++ b/examples/remix-basic/README.md
@@ -1,22 +1,46 @@
 # Basic Remix example
 
+This is an example Remix app developed using ElectricSQL.
+
 ## Setup
 
-1. Make sure you've installed all dependencies for the monorepo and built packages
+This example is part of the [ElectricSQL monorepo](../..) and is designed to be built and run as part of the [pnpm workspace](https://pnpm.io/workspaces) defined in [`../../pnpm-workspace.yaml`](../../pnpm-workspace.yaml).
 
-From the root directory:
+Navigate to the root directory of the monorepo, e.g.:
 
-- `pnpm i`
-- `pnpm run -r build`
+```shell
+cd ../../
+```
 
-2. Start the docker containers
+Install and build all of the workspace packages and examples:
 
-`pnpm run backend:up`
+```shell
+pnpm install
+pnpm run -r build
+```
 
-3. Start the dev server
+Navigate back to this directory:
 
-`pnpm run dev`
+```shell
+cd examples/remix-basic
+```
 
-4. When done, tear down the backend containers so you can run other examples
+Start the example backend services using [Docker Compose](https://docs.docker.com/compose/):
 
-`pnpm run backend:down`
+```shell
+pnpm backend:up
+```
+
+> Note that this always stops and deletes the volumes mounted by any other example backend containers that are running or have been run before. This ensures that the example always starts with a clean database and clean disk.
+
+Now start the dev server:
+
+```shell
+pnpm dev
+```
+
+When you're done, stop the backend services using:
+
+```shell
+pnpm backend:down
+```

--- a/examples/tanstack-example/README.md
+++ b/examples/tanstack-example/README.md
@@ -1,24 +1,48 @@
 # Basic Tanstack Query example
 
-[demo](https://x.com/msfstef/status/1828763769498952173)
+This is an example TanStack application developed using ElectricSQL for read path sync, together with Tanstack Query for local writes with optimistic state.
+
+See the [Electric <> Tanstack integration docs](https://electric-sql.com/docs/integrations/tanstack) for more context and a [video of the example running here](https://x.com/msfstef/status/1828763769498952173).
 
 ## Setup
 
-1. Make sure you've installed all dependencies for the monorepo and built packages
+This example is part of the [ElectricSQL monorepo](../..) and is designed to be built and run as part of the [pnpm workspace](https://pnpm.io/workspaces) defined in [`../../pnpm-workspace.yaml`](../../pnpm-workspace.yaml).
 
-From the root directory:
+Navigate to the root directory of the monorepo, e.g.:
 
-- `pnpm i`
-- `pnpm run -r build`
+```shell
+cd ../../
+```
 
-2. Start the docker containers
+Install and build all of the workspace packages and examples:
 
-`pnpm run backend:up`
+```shell
+pnpm install
+pnpm run -r build
+```
 
-3. Start the dev server
+Navigate back to this directory:
 
-`pnpm run dev`
+```shell
+cd examples/tanstack-example
+```
 
-4. When done, tear down the backend containers so you can run other examples
+Start the example backend services using [Docker Compose](https://docs.docker.com/compose/):
 
-`pnpm run backend:down`
+```shell
+pnpm backend:up
+```
+
+> Note that this always stops and deletes the volumes mounted by any other example backend containers that are running or have been run before. This ensures that the example always starts with a clean database and clean disk.
+
+Now start the dev server:
+
+```shell
+pnpm dev
+```
+
+When you're done, stop the backend services using:
+
+```shell
+pnpm backend:down
+```

--- a/examples/todo-app/README.md
+++ b/examples/todo-app/README.md
@@ -1,22 +1,46 @@
 # Todo example
 
+This is a classic TodoMVC example app, developed using ElectricSQL.
+
 ## Setup
 
-1. Make sure you've installed all dependencies for the monorepo and built packages
+This example is part of the [ElectricSQL monorepo](../..) and is designed to be built and run as part of the [pnpm workspace](https://pnpm.io/workspaces) defined in [`../../pnpm-workspace.yaml`](../../pnpm-workspace.yaml).
 
-From the root directory:
+Navigate to the root directory of the monorepo, e.g.:
 
-- `pnpm i`
-- `pnpm run -r build`
+```shell
+cd ../../
+```
 
-2. Start the docker containers
+Install and build all of the workspace packages and examples:
 
-`pnpm run backend:up`
+```shell
+pnpm install
+pnpm run -r build
+```
 
-3. Start the dev server
+Navigate back to this directory:
 
-`pnpm run dev`
+```shell
+cd examples/todo-app
+```
 
-4. When done, tear down the backend containers so you can run other examples
+Start the example backend services using [Docker Compose](https://docs.docker.com/compose/):
 
-`pnpm run backend:down`
+```shell
+pnpm backend:up
+```
+
+> Note that this always stops and deletes the volumes mounted by any other example backend containers that are running or have been run before. This ensures that the example always starts with a clean database and clean disk.
+
+Now start the dev server:
+
+```shell
+pnpm dev
+```
+
+When you're done, stop the backend services using:
+
+```shell
+pnpm backend:down
+```

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "dotenv-cli": "^7.4.2"
   },
   "scripts": {
-    "example-backend:up": "dotenv -e .env.dev -- docker compose -f ./.support/docker-compose.yml up -d ",
     "example-backend:down": "dotenv  -e .env.dev -- docker compose -f .support/docker-compose.yml down --volumes",
+    "example-backend:just_up": "dotenv -e .env.dev -- docker compose -f ./.support/docker-compose.yml up -d",
+    "example-backend:up": "pnpm example-backend:down && pnpm example-backend:just_up",
     "stylecheck-all": "pnpm --if-present --recursive run stylecheck",
     "ci:version": "pnpm exec changeset version",
     "ci:publish": "pnpm '/^ci:publish:.+/'",


### PR DESCRIPTION
I've been working with the examples quite a lot and I've commonly experienced stale database and disk state from running `docker compose up` in the foreground followed by `ctl+c` to stop and also from forgetting to run `pnpm backend:down`.

So ... as a systemic solution, I've updated the `example-backend:up` script in the root package.json to always run `example-backend:down` first. This means that examples always start with a clean slate and no weird / stuck table and or disk state.

I also then did a pass through the example READMEs, explaining this and re-formatting the instructions a touch.