### PR TITLE
chore (sync service): add replication lag to current span

### DIFF
--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -434,12 +434,6 @@ defmodule Electric.Shapes.Consumer do
     now = DateTime.utc_now()
     lag = Kernel.max(0, DateTime.diff(now, commit_timestamp, :millisecond))
 
-    OpenTelemetry.with_span(
-      "shape_write.consumer.do_handle_txn.report_replication_lag",
-      [lag: lag],
-      fn ->
-        lag
-      end
-    )
+    OpenTelemetry.add_span_attributes(lag: lag)
   end
 end

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -434,6 +434,6 @@ defmodule Electric.Shapes.Consumer do
     now = DateTime.utc_now()
     lag = Kernel.max(0, DateTime.diff(now, commit_timestamp, :millisecond))
 
-    OpenTelemetry.add_span_attributes(lag: lag)
+    OpenTelemetry.add_span_attributes(replication_lag: lag)
   end
 end


### PR DESCRIPTION
This PR addresses [Kyle's comment](https://github.com/electric-sql/electric/pull/2043#pullrequestreview-2461985569) and adds the replication lag to the current span instead of creating a new span.