### PR TITLE
fix: Fix registry alive call

### DIFF
--- a/.changeset/silly-shoes-appear.md
+++ b/.changeset/silly-shoes-appear.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Assume process is not alive if registry is not alive.

--- a/packages/sync-service/lib/electric/process_registry.ex
+++ b/packages/sync-service/lib/electric/process_registry.ex
@@ -27,5 +27,9 @@ defmodule Electric.ProcessRegistry do
       nil -> false
       _ -> true
     end
+  rescue
+    # if the registry is not started, whereis will raise - we can
+    # assume that the process is not alive
+    ArgumentError -> false
   end
 end

--- a/packages/sync-service/test/electric/process_registry_test.exs
+++ b/packages/sync-service/test/electric/process_registry_test.exs
@@ -1,0 +1,23 @@
+defmodule Electric.ProcessRegistryTest do
+  use ExUnit.Case, async: true
+  alias Electric.ProcessRegistry
+
+  @stack_id "foo"
+
+  describe "alive?/2" do
+    test "should return false for inexistent process" do
+      {:ok, _} =
+        ProcessRegistry.start_link(
+          name: ProcessRegistry.registry_name(@stack_id),
+          keys: :duplicate,
+          stack_id: @stack_id
+        )
+
+      assert false == ProcessRegistry.alive?(@stack_id, "bar")
+    end
+
+    test "should return false for any process if registry not started" do
+      assert false == ProcessRegistry.alive?(@stack_id, "bar")
+    end
+  end
+end


### PR DESCRIPTION
Ensures that we can hold connections when electric is not ready even if it is not started (useful in multi tenant)