### PR TITLE
fix: Log error without falling over for failed recovery

### DIFF
--- a/.changeset/warm-brooms-approve.md
+++ b/.changeset/warm-brooms-approve.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Log error but don't fall over if failing to initialise recovered shape

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -318,7 +318,11 @@ defmodule Electric.ShapeCache do
     state.shape_status_state
     |> state.shape_status.list_shapes()
     |> Enum.each(fn {shape_handle, shape} ->
-      {:ok, _pid, _snapshot_xmin, _latest_offset} = start_shape(shape_handle, shape, state)
+      try do
+        {:ok, _pid, _snapshot_xmin, _latest_offset} = start_shape(shape_handle, shape, state)
+      rescue
+        e -> Logger.error("Failed to recover shape #{shape_handle}: #{inspect(e)}")
+      end
     end)
   end
 


### PR DESCRIPTION
We have seen some issues related to https://github.com/lucaong/cubdb/issues/71 come up during recovery, and it currently causes issues with the whole electric.

Initially my thought was to delete the shape entirely if it fails, but perhaps as an initial workaround we might just want to log the error and continue recovery without the problematic shape?