### PR TITLE
fix: Clean up shape folders and remove unrecoverable shapes

### DIFF
--- a/.changeset/hungry-apples-sell.md
+++ b/.changeset/hungry-apples-sell.md
@@ -1,0 +1,6 @@
+---
+"@core/sync-service": patch
+---
+
+Clean up directories when removing shapes.
+Remove corrupted shapes from store when recovery fails.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -324,7 +324,7 @@ defmodule Electric.ShapeCache do
         e ->
           Logger.error("Failed to recover shape #{shape_handle}: #{inspect(e)}")
           shape_opts = Electric.ShapeCache.Storage.for_shape(shape_handle, state.storage)
-          Electric.ShapeCache.Storage.force_cleanup!({state.storage, shape_opts})
+          Electric.ShapeCache.Storage.unsafe_cleanup!({state.storage, shape_opts})
       end
     end)
   end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -321,7 +321,10 @@ defmodule Electric.ShapeCache do
       try do
         {:ok, _pid, _snapshot_xmin, _latest_offset} = start_shape(shape_handle, shape, state)
       rescue
-        e -> Logger.error("Failed to recover shape #{shape_handle}: #{inspect(e)}")
+        e ->
+          Logger.error("Failed to recover shape #{shape_handle}: #{inspect(e)}")
+          shape_opts = Electric.ShapeCache.Storage.for_shape(shape_handle, state.storage)
+          Electric.ShapeCache.Storage.force_cleanup!({state.storage, shape_opts})
       end
     end)
   end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -323,8 +323,10 @@ defmodule Electric.ShapeCache do
       rescue
         e ->
           Logger.error("Failed to recover shape #{shape_handle}: #{inspect(e)}")
-          shape_opts = Electric.ShapeCache.Storage.for_shape(shape_handle, state.storage)
-          Electric.ShapeCache.Storage.unsafe_cleanup!({state.storage, shape_opts})
+
+          # clean up corrupted data to avoid persisting bad state
+          Electric.ShapeCache.Storage.for_shape(shape_handle, state.storage)
+          |> Electric.ShapeCache.Storage.unsafe_cleanup!()
       end
     end)
   end

--- a/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
@@ -22,7 +22,7 @@ defmodule Electric.ShapeCache.CrashingFileStorage do
   defdelegate get_log_stream(offset, max_offset, opts), to: FileStorage
   defdelegate get_chunk_end_log_offset(offset, opts), to: FileStorage
   defdelegate cleanup!(opts), to: FileStorage
-  defdelegate force_cleanup!(opts), to: FileStorage
+  defdelegate unsafe_cleanup!(opts), to: FileStorage
 
   def shared_opts(opts) do
     opts

--- a/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
@@ -22,6 +22,7 @@ defmodule Electric.ShapeCache.CrashingFileStorage do
   defdelegate get_log_stream(offset, max_offset, opts), to: FileStorage
   defdelegate get_chunk_end_log_offset(offset, opts), to: FileStorage
   defdelegate cleanup!(opts), to: FileStorage
+  defdelegate force_cleanup!(opts), to: FileStorage
 
   def shared_opts(opts) do
     opts

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -97,7 +97,7 @@ defmodule Electric.ShapeCache.FileStorage do
     if stored_version != opts.version || snapshot_xmin(opts) == nil ||
          not File.exists?(shape_definition_path(opts)) ||
          not CubDB.has_key?(opts.db, @snapshot_meta_key) do
-      cleanup!(opts)
+      cleanup_internals!(opts)
     end
 
     CubDB.put(opts.db, @version_key, @version)
@@ -314,8 +314,7 @@ defmodule Electric.ShapeCache.FileStorage do
     |> Enum.at(0)
   end
 
-  @impl Electric.ShapeCache.Storage
-  def cleanup!(%FS{} = opts) do
+  defp cleanup_internals!(%FS{} = opts) do
     [
       @snapshot_meta_key,
       @xmin_key,
@@ -332,6 +331,14 @@ defmodule Electric.ShapeCache.FileStorage do
     :ok
   end
 
+  @impl Electric.ShapeCache.Storage
+  def cleanup!(%FS{} = opts) do
+    :ok = cleanup_internals!(opts)
+    {:ok, _} = File.rm_rf(opts.data_dir)
+    :ok
+  end
+
+  @impl Electric.ShapeCache.Storage
   def force_cleanup!(%FS{} = opts) do
     {:ok, _} = File.rm_rf(opts.data_dir)
   end

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -339,7 +339,7 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def force_cleanup!(%FS{} = opts) do
+  def unsafe_cleanup!(%FS{} = opts) do
     {:ok, _} = File.rm_rf(opts.data_dir)
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -22,8 +22,8 @@ defmodule Electric.ShapeCache.FileStorage do
     :base_path,
     :shape_handle,
     :db,
+    :data_dir,
     :cubdb_dir,
-    :shape_definition_dir,
     :snapshot_dir,
     :stack_id,
     :extra_opts,
@@ -48,13 +48,15 @@ defmodule Electric.ShapeCache.FileStorage do
         shape_handle,
         %{base_path: base_path, stack_id: stack_id} = opts
       ) do
+    data_dir = Path.join([base_path, shape_handle])
+
     %FS{
       base_path: base_path,
       shape_handle: shape_handle,
       db: name(stack_id, shape_handle),
-      cubdb_dir: Path.join([base_path, shape_handle, "cubdb"]),
-      snapshot_dir: Path.join([base_path, shape_handle, "snapshots"]),
-      shape_definition_dir: Path.join([base_path, shape_handle]),
+      data_dir: data_dir,
+      cubdb_dir: Path.join([data_dir, "cubdb"]),
+      snapshot_dir: Path.join([data_dir, "snapshots"]),
       stack_id: stack_id,
       extra_opts: Map.get(opts, :extra_opts, %{})
     }
@@ -81,7 +83,7 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   defp initialise_filesystem(opts) do
-    with :ok <- File.mkdir_p(opts.shape_definition_dir),
+    with :ok <- File.mkdir_p(opts.data_dir),
          :ok <- File.mkdir_p(opts.cubdb_dir),
          :ok <- File.mkdir_p(opts.snapshot_dir) do
       :ok
@@ -129,7 +131,7 @@ defmodule Electric.ShapeCache.FileStorage do
         Enum.reduce(shape_handles, %{}, fn shape_handle, acc ->
           shape_def_path =
             shape_definition_path(%{
-              shape_definition_dir: Path.join([opts.base_path, shape_handle])
+              data_dir: Path.join([opts.base_path, shape_handle])
             })
 
           with {:ok, shape_def_encoded} <- File.read(shape_def_path),
@@ -330,8 +332,12 @@ defmodule Electric.ShapeCache.FileStorage do
     :ok
   end
 
-  defp shape_definition_path(%{shape_definition_dir: shape_definition_dir} = _opts) do
-    Path.join(shape_definition_dir, @shape_definition_file_name)
+  def force_cleanup!(%FS{} = opts) do
+    {:ok, _} = File.rm_rf(opts.data_dir)
+  end
+
+  defp shape_definition_path(%{data_dir: data_dir} = _opts) do
+    Path.join(data_dir, @shape_definition_file_name)
   end
 
   defp keys_from_range(min_key, max_key, opts) do

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -252,7 +252,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def force_cleanup!(%MS{} = opts), do: cleanup!(opts)
+  def unsafe_cleanup!(%MS{} = opts), do: cleanup!(opts)
 
   # Turns a LogOffset into a tuple representation
   # for storing in the ETS table

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -251,6 +251,9 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     :ok
   end
 
+  @impl Electric.ShapeCache.Storage
+  def force_cleanup!(%MS{} = opts), do: cleanup!(opts)
+
   # Turns a LogOffset into a tuple representation
   # for storing in the ETS table
   defp storage_offset(offset) do

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -94,8 +94,13 @@ defmodule Electric.ShapeCache.Storage do
   @doc "Clean up snapshots/logs for a shape handle"
   @callback cleanup!(shape_opts()) :: :ok
 
-  @doc "Clean up snapshots/logs for a shape handle by deleting whole directory"
-  @callback force_cleanup!(shape_opts()) :: :ok
+  @doc """
+  Clean up snapshots/logs for a shape handle by deleting whole directory.
+
+  Does not require any extra storage processes to be running, but should only
+  be used if the shape is known to not be in use to avoid concurrency issues.
+  """
+  @callback unsafe_cleanup!(shape_opts()) :: :ok
 
   @behaviour __MODULE__
 
@@ -192,7 +197,7 @@ defmodule Electric.ShapeCache.Storage do
   end
 
   @impl __MODULE__
-  def force_cleanup!({mod, shape_opts}) do
-    mod.force_cleanup!(shape_opts)
+  def unsafe_cleanup!({mod, shape_opts}) do
+    mod.unsafe_cleanup!(shape_opts)
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -94,6 +94,9 @@ defmodule Electric.ShapeCache.Storage do
   @doc "Clean up snapshots/logs for a shape handle"
   @callback cleanup!(shape_opts()) :: :ok
 
+  @doc "Clean up snapshots/logs for a shape handle by deleting whole directory"
+  @callback force_cleanup!(shape_opts()) :: :ok
+
   @behaviour __MODULE__
 
   @last_log_offset LogOffset.last()
@@ -186,5 +189,10 @@ defmodule Electric.ShapeCache.Storage do
   @impl __MODULE__
   def cleanup!({mod, shape_opts}) do
     mod.cleanup!(shape_opts)
+  end
+
+  @impl __MODULE__
+  def force_cleanup!({mod, shape_opts}) do
+    mod.force_cleanup!(shape_opts)
   end
 end

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -51,6 +51,7 @@ defmodule Electric.Shapes.Shape do
 
   def generate_id(%__MODULE__{} = shape) do
     hash = hash(shape)
+
     {hash, "#{hash}-#{DateTime.utc_now() |> DateTime.to_unix(:millisecond)}"}
   end
 

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -51,7 +51,6 @@ defmodule Electric.Shapes.Shape do
 
   def generate_id(%__MODULE__{} = shape) do
     hash = hash(shape)
-
     {hash, "#{hash}-#{DateTime.utc_now() |> DateTime.to_unix(:millisecond)}"}
   end
 

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -99,7 +99,7 @@ defmodule Electric.Plug.UtilsTest do
           |> Electric.Plug.Utils.hold_conn_until_stack_ready([])
         end)
 
-      Process.sleep(50)
+      Process.sleep(100)
 
       Electric.StackSupervisor.dispatch_stack_event(Registry.StackEvents, ctx.stack_id, :ready)
 

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -137,8 +137,8 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def force_cleanup!({parent, shape_handle, _, storage}) do
-    send(parent, {__MODULE__, :force_cleanup!, shape_handle})
-    Storage.force_cleanup!(storage)
+  def unsafe_cleanup!({parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :unsafe_cleanup!, shape_handle})
+    Storage.unsafe_cleanup!(storage)
   end
 end

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -135,4 +135,10 @@ defmodule Support.TestStorage do
     send(parent, {__MODULE__, :cleanup!, shape_handle})
     Storage.cleanup!(storage)
   end
+
+  @impl Electric.ShapeCache.Storage
+  def force_cleanup!({parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :force_cleanup!, shape_handle})
+    Storage.force_cleanup!(storage)
+  end
 end


### PR DESCRIPTION
Followup to https://github.com/electric-sql/electric/pull/2049

We are currently leaving folders behind when deleting shapes, which do take up a little bit of space and eventually could be a bit of an issue. This PR takes care of removing everything.

Additionally, when a shape fails to recover by not being able to start the consumer at all (see CubDB issue), the shape data is removed using a new method called `unsafe_cleanup!` which simply `rm -rf`s the shape directory. Not great to use while the shape is active as it can cause various bugs, but great for cleaning up.