### PR TITLE
chore (sync service): probablistic sampling of transaction spans

### DIFF
--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -86,7 +86,18 @@ otel_sampling_ratio = env!("ELECTRIC_OTEL_SAMPLING_RATIO", :float, 0.01)
 
 config :opentelemetry,
   processors: [otel_batch_processor, otel_simple_processor] |> Enum.reject(&is_nil/1),
-  sampler: {Electric.Telemetry.Sampler, %{ratio: otel_sampling_ratio}}
+  # sampler: {Electric.Telemetry.Sampler, %{ratio: otel_sampling_ratio}}
+  # Sample root spans based on our custom sampler
+  # and inherit sampling decision from remote parents
+  sampler:
+    {:parent_based,
+     %{
+       root: {Electric.Telemetry.Sampler, %{ratio: otel_sampling_ratio}},
+       remote_parent_sampled: :always_on,
+       remote_parent_not_sampled: :always_off,
+       local_parent_sampled: :always_on,
+       local_parent_not_sampled: :always_off
+     }}
 
 database_url = env!("DATABASE_URL", :string!)
 

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -82,8 +82,11 @@ otel_simple_processor =
     {:otel_simple_processor, %{exporter: {:otel_exporter_stdout, []}}}
   end
 
+otel_sampling_ratio = env!("ELECTRIC_OTEL_SAMPLING_RATIO", :float, 0.01)
+
 config :opentelemetry,
-  processors: [otel_batch_processor, otel_simple_processor] |> Enum.reject(&is_nil/1)
+  processors: [otel_batch_processor, otel_simple_processor] |> Enum.reject(&is_nil/1),
+  sampler: {Electric.Telemetry.Sampler, %{ratio: otel_sampling_ratio}}
 
 database_url = env!("DATABASE_URL", :string!)
 

--- a/packages/sync-service/lib/electric/telemetry/sampler.ex
+++ b/packages/sync-service/lib/electric/telemetry/sampler.ex
@@ -8,11 +8,8 @@ defmodule Electric.Telemetry.Sampler do
   @behaviour :otel_sampler
 
   # Span names that are sampled probabilistically
-  @ratio_span_names [
-    "pg_txn.replication_client.decode_message",
-    "pg_txn.replication_client.process_x_log_data",
-    "pg_txn.replication_client.transaction_received",
-    "shape_write.log_collector.handle_txn"
+  @probabilistic_span_names [
+    "pg_txn.replication_client.process_x_log_data"
   ]
 
   @impl :otel_sampler
@@ -31,7 +28,7 @@ defmodule Electric.Telemetry.Sampler do
       }) do
     tracestate = Tracer.current_span_ctx(ctx) |> OpenTelemetry.Span.tracestate()
 
-    if span_name in @ratio_span_names do
+    if span_name in @probabilistic_span_names do
       if :rand.uniform() <= sampling_probability do
         {:record_and_sample, [], tracestate}
       else

--- a/packages/sync-service/lib/electric/telemetry/sampler.ex
+++ b/packages/sync-service/lib/electric/telemetry/sampler.ex
@@ -1,0 +1,45 @@
+defmodule Electric.Telemetry.Sampler do
+  @moduledoc """
+  Custom sampler that samples all spans except for specifically configured spans for which a given ratio is sampled.
+  """
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  @behaviour :otel_sampler
+
+  # Span names that are sampled probabilistically
+  @ratio_span_names [
+    "pg_txn.replication_client.decode_message",
+    "pg_txn.replication_client.process_x_log_data",
+    "pg_txn.replication_client.transaction_received",
+    "shape_write.log_collector.handle_txn"
+  ]
+
+  @impl :otel_sampler
+  def setup(%{ratio: ratio}) do
+    %{sampling_probability: ratio}
+  end
+
+  @impl :otel_sampler
+  def description(%{sampling_probability: sampling_probability}) do
+    "Custom sampler that samples all spans except for specifically configured spans for which #{sampling_probability * 100}% are sampled."
+  end
+
+  @impl true
+  def should_sample(ctx, _trace_id, _links, span_name, _span_kind, _attributes, %{
+        sampling_probability: sampling_probability
+      }) do
+    tracestate = Tracer.current_span_ctx(ctx) |> OpenTelemetry.Span.tracestate()
+
+    if span_name in @ratio_span_names do
+      if :rand.uniform() <= sampling_probability do
+        {:record_and_sample, [], tracestate}
+      else
+        {:drop, [], tracestate}
+      end
+    else
+      # Always sample other spans
+      {:record_and_sample, [], tracestate}
+    end
+  end
+end


### PR DESCRIPTION
Part of https://github.com/electric-sql/electric/issues/2032.

We noticed that most spans are descendants of the `pg_txn.replication_client.process_x_log_data` root span.
Therefore, we decided to only sample a portion of those spans.

This PR introduces a custom sampler that works as follows:
- Samples a configurable ratio of `pg_txn.replication_client.process_x_log_data` root spans
- Samples all other root spans
- Child spans are sampled if their parent is sampled

### Problem

We would like to sample all errors.
To do this we need to make the sampling decision at the end of the span when we have all attributes and events because errors are recorded using an "exception" event, this is known as tail sampling. However, the Erlang opentelemetry library only seems to support head sampling:
> Sampling is performed at span creation time by the Sampler configured on the Tracer

cf. https://docs.honeycomb.io/manage-data-volume/sample/techniques/ if you're not familiar with head vs tail sampling.

EDIT: solving this problem may require using HoneyComb's "Refinery" mechanism. So Electric would sample all traces and we would setup Refinery with custom tail sampling logic. However, this requires extra infrastructure to set up.