### PR TITLE
Rename "replication lag" to "retained WAL size"

### DIFF
--- a/packages/sync-service/lib/electric/telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry.ex
@@ -93,7 +93,7 @@ defmodule Electric.Telemetry do
     [
       # A module, function and arguments to be invoked periodically.
       {__MODULE__, :uptime_event, []},
-      {Electric.Connection.Manager, :query_replication_lag,
+      {Electric.Connection.Manager, :report_retained_wal_size,
        [Electric.Connection.Manager.name(stack_id)]}
     ]
   end


### PR DESCRIPTION
The thing being measured here is the size of the WAL that Electric's replication slot retains, so I think the new name describes it better.

This change also restructures the code a bit to make the dependency on the DB connection pool crystal clear.