### PR TITLE
website: rename `Sync` product to `Electric`.

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -73,7 +73,7 @@ export default defineConfig({
     },
     logo: '/img/brand/logo.svg',
     nav: [
-      { text: 'Product', link: '/product/sync', activeMatch: '/product/' },
+      { text: 'Product', link: '/product/electric', activeMatch: '/product/' },
       { text: 'Use cases', link: '/use-cases/state-transfer', activeMatch: '/use-cases/' },
       { text: 'Docs', link: '/docs/intro', activeMatch: '/docs/'},
       { text: 'Blog', link: '/blog', activeMatch: '/blog/'},
@@ -87,7 +87,7 @@ export default defineConfig({
         {
           text: 'Product',
           items: [
-            { text: 'Sync', link: '/product/sync' },
+            { text: 'Electric', link: '/product/electric' },
             { text: 'Cloud', link: '/product/cloud', items: [
                 { text: 'Sign-up', link: '/product/cloud/sign-up' }
               ]

--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -569,7 +569,7 @@ iframe {
 .VPFeature h2.title {
   font-size: 20px;
 }
-.VPFeature.link[href="/product/sync"]:hover {
+.VPFeature.link[href="/product/electric"]:hover {
   border-color: var(--electric-color);
 }
 .VPFeature.link[href="/product/pglite"]:hover {

--- a/website/blog/posts/2024-07-17-electric-next.md
+++ b/website/blog/posts/2024-07-17-electric-next.md
@@ -107,13 +107,13 @@ So, hopefully now our motivation is clear. We needed to find a way to simplify E
 
 ## What's changed?
 
-Electric Next is a [sync engine](/product/sync), not a local-first software platform.
+Electric Next is a [sync engine](/product/electric), not a local-first software platform.
 
 It can be used for a wide range of [use cases](/use-cases/state-transfer), syncing data into apps, workers, services, agents and environments. These include but are not limited to local-first software development.
 
 ### Sync engine
 
-When we look at our stack, the part that we see as most core is the [sync engine](/product/sync).
+When we look at our stack, the part that we see as most core is the [sync engine](/product/electric).
 
 This is the component of Electric that syncs data between Postgres and local clients. Consuming Postgres logical replication, managing partial replication using Shapes and syncing data to and from clients over a replication protocol. It’s where there’s the most complexity. Where we can add the most value and is hardest to develop yourself.
 

--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -11,7 +11,7 @@ import EnvVarConfig from '../../src/components/EnvVarConfig.vue'
 
 # Sync service configuration
 
-This page documents the config options for [self-hosting](/docs/guides/deployment) the [Electric sync engine](/product/sync).
+This page documents the config options for [self-hosting](/docs/guides/deployment) the [Electric sync engine](/product/electric).
 
 > [!Warning] Advanced only
 > You don't need to worry about this if you're using [Electric Cloud](/product/cloud).

--- a/website/docs/guides/deployment.md
+++ b/website/docs/guides/deployment.md
@@ -7,7 +7,7 @@ outline: [2, 3]
 
 # Deployment
 
-How to deploy the [Electric sync engine](/product/sync), with links to integration docs for specific platforms like [Supabase](/docs/integrations/supabase), [Neon](/docs/integrations/neon), [Render](/docs/integrations/render) and [AWS](/docs/integrations/aws).
+How to deploy the [Electric sync engine](/product/electric), with links to integration docs for specific platforms like [Supabase](/docs/integrations/supabase), [Neon](/docs/integrations/neon), [Render](/docs/integrations/render) and [AWS](/docs/integrations/aws).
 
 > [!TIP] Electric Cloud &ndash; the simplest way to use Electric
 > The simplest way to use Electric is via the [Electric Cloud](/product/cloud), which is a simple, scalable, <span class="no-wrap">low-cost</span>, managed Electric hosting service.
@@ -94,7 +94,7 @@ When running, Electric also keeps a pool of active database connections open. Th
 
 ## 2. Running Electric
 
-The [Electric sync engine](/product/sync) is an Elixir web service, packaged using Docker.
+The [Electric sync engine](/product/electric) is an Elixir web service, packaged using Docker.
 
 You can deploy it anywhere you can run a container with a filesystem and exposed HTTP port. This includes cloud and application hosting platforms like:
 

--- a/website/docs/guides/installation.md
+++ b/website/docs/guides/installation.md
@@ -7,7 +7,7 @@ outline: [2, 3]
 
 # Installation
 
-You need to have a [Postgres](https://www.postgresql.org) database and to run the [Electric sync service](/product/sync) in front of it.
+You need to have a [Postgres](https://www.postgresql.org) database and to run the [Electric sync service](/product/electric) in front of it.
 
 ## How to run Electric
 

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -84,7 +84,7 @@ You can use logical operators like `AND` and `OR` to group multiple conditions, 
 
 ## Subscribing to shapes
 
-Local clients establish shape subscriptions, typically using [client libraries](/docs/api/clients/typescript). These sync data from the [Electric sync engine](/product/sync) into the client using the [HTTP API](/docs/api/http).
+Local clients establish shape subscriptions, typically using [client libraries](/docs/api/clients/typescript). These sync data from the [Electric sync engine](/product/electric) into the client using the [HTTP API](/docs/api/http).
 
 The sync service maintains shape subscriptions and streams any new data and data changes to the local client. In the client, shapes can be held as objects in memory, for example using a [`useShape`](/docs/integrations/react) hook, or in a normalised store or database like [PGlite](/product/pglite).
 

--- a/website/docs/guides/writing-your-own-client.md
+++ b/website/docs/guides/writing-your-own-client.md
@@ -25,7 +25,7 @@ You can create a client for Electric by:
 
 ## Consume the HTTP API
 
-The [Electric sync service](/product/sync) syncs data over an [HTTP API](/docs/api/http). The primary job of a client is to consume this API using HTTP requests.
+The [Electric sync service](/product/electric) syncs data over an [HTTP API](/docs/api/http). The primary job of a client is to consume this API using HTTP requests.
 
 The HTTP API exposes [Shapes](/docs/guides/shapes). There are two phases to syncing a shape:
 

--- a/website/docs/integrations/phoenix.md
+++ b/website/docs/integrations/phoenix.md
@@ -18,7 +18,7 @@ image: /img/integrations/electric-phoenix.jpg
 
 ## Electric and Phoenix
 
-Electric is [developed in Elixir](/product/sync#how-does-it-work) and provides [an Elixir client](/docs/api/clients/elixir). We've leveraged this to develop a batteries-included Phoenix integration for:
+Electric is [developed in Elixir](/product/electric#how-does-it-work) and provides [an Elixir client](/docs/api/clients/elixir). We've leveraged this to develop a batteries-included Phoenix integration for:
 
 - [front-end sync](#front-end-sync): into a front-end client from a Postgres-backed Phoenix application
 - [LiveView sync](#liveview-sync): into Phoenix LiveView from Postgres in realtime via [Phoenix.Streams](/docs/integrations/phoenix#liveview-sync)

--- a/website/docs/reference/alternatives.md
+++ b/website/docs/reference/alternatives.md
@@ -25,7 +25,7 @@ We list a selection of projects below, including for example:
 
 ### Real-time and sync
 
-[Electric](/product/sync) is a sync-engine. It syncs subsets of data from Postgres, in real-time, into local apps and services. Other real-time streaming systems and sync engines include:
+[Electric](/product/electric) is a sync-engine. It syncs subsets of data from Postgres, in real-time, into local apps and services. Other real-time streaming systems and sync engines include:
 
 - [Ably](https://ably.com)
 - [Ampli-sync](https://ampliapps.com/sqlite-sync)

--- a/website/index.md
+++ b/website/index.md
@@ -21,7 +21,7 @@ hero:
       target: '_blank'
       link: https://github.com/electric-sql/electric
 features:
-  - title: Sync
+  - title: Electric
     details: >-
       <span class="para">
         Sync subsets of your Postgres data into
@@ -31,7 +31,7 @@ features:
       </span>
     icon:
       src: '/img/icons/electric.svg'
-    link: '/product/sync'
+    link: '/product/electric'
   - title: Cloud
     details: >-
       <span class="para">

--- a/website/product/cloud.md
+++ b/website/product/cloud.md
@@ -46,7 +46,7 @@ and scales to millions of users
 
 ## Hosted Electric
 
-Electric Cloud is a hosted Electric service. It provisions, runs and operates the [Electric sync engine](/product/sync) for you.
+Electric Cloud is a hosted Electric service. It provisions, runs and operates the [Electric sync engine](/product/electric) for you.
 
 ## Data delivery network
 

--- a/website/product/electric.md
+++ b/website/product/electric.md
@@ -1,5 +1,5 @@
 ---
-title: Sync
+title: Electric
 description: >-
   Sync little subsets of your Postgres data into
   local apps and services.
@@ -43,7 +43,7 @@ onMounted(async () => {
 
 <img src="/img/icons/electric.svg" class="product-icon" />
 
-# Sync
+# Electric
 
 Sync little subsets of your Postgres data into
 local apps and services.

--- a/website/product/pglite.md
+++ b/website/product/pglite.md
@@ -87,7 +87,7 @@ It can be used as an ephemeral [in-memory database](https://pglite.dev/docs/file
 
 ### Syncing into PGlite
 
-You can use [Electric](/product/sync) to sync between a cloud Postgres and an embedded PGlite instance. For example, to sync an `items` [Shape](/docs/guides/shapes) into an `items` table:
+You can use [Electric](/product/electric) to sync between a cloud Postgres and an embedded PGlite instance. For example, to sync an `items` [Shape](/docs/guides/shapes) into an `items` table:
 
 <<< @/src/partials/sync-into-pglite.tsx
 

--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -82,5 +82,5 @@ https://next.electric-sql.com/* https://electric-sql.com/:splat 301!
 
 # Renamed pages on new site
 /product/ddn                    /product/cloud
-/product/electric               /product/sync
+/product/sync                   /product/electric
 /docs/api/integrations/react    /docs/integrations/react


### PR DESCRIPTION
Less confusing -- we are ElectricSQL and our product is the Electric sync engine. Both "Electric" for short. Using the product title "Sync" was silly and confusing.