### PR TITLE
Use stage for database name in examples

### DIFF
--- a/examples/nextjs-example/sst.config.ts
+++ b/examples/nextjs-example/sst.config.ts
@@ -25,8 +25,12 @@ export default $config({
       branchId: project.defaultBranchId,
     }
 
-    const db = new neon.Database(`nextjs-example`, {
+    const db = new neon.Database(`nextjs`, {
       ...base,
+      name:
+        $app.stage === `Production`
+          ? `nextjs-production`
+          : `nextjs-${$app.stage}`,
       ownerName: `neondb_owner`,
     })
 


### PR DESCRIPTION
This allows easier identifications of the database for an app in the different stages. We're already doing this for Linearlite.