### PR TITLE
chore (sync service): store OTEL attributes per stack in a persistent term

### DIFF
--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -594,7 +594,7 @@ defmodule Electric.Plug.ServeShapePlug do
 
     maybe_up_to_date = if up_to_date = assigns[:up_to_date], do: up_to_date != []
 
-    Electric.Telemetry.OpenTelemetry.get_stack_telemetry_span_attrs(assigns.config[:stack_id])
+    Electric.Telemetry.OpenTelemetry.get_stack_span_attrs(assigns.config[:stack_id])
     |> Map.merge(Electric.Plug.Utils.common_open_telemetry_attrs(conn))
     |> Map.merge(%{
       "shape.handle" => shape_handle,

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -594,7 +594,7 @@ defmodule Electric.Plug.ServeShapePlug do
 
     maybe_up_to_date = if up_to_date = assigns[:up_to_date], do: up_to_date != []
 
-    Electric.StackSupervisor.get_telemetry_span_attrs(assigns.config[:stack_id])
+    Electric.Telemetry.OpenTelemetry.get_stack_telemetry_span_attrs(assigns.config[:stack_id])
     |> Map.merge(Electric.Plug.Utils.common_open_telemetry_attrs(conn))
     |> Map.merge(%{
       "shape.handle" => shape_handle,

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -192,8 +192,8 @@ defmodule Electric.Plug.ServeShapePlug do
     end
   end
 
-  defp load_shape_info(%Conn{} = conn, _) do
-    OpenTelemetry.with_span("shape_get.plug.load_shape_info", [], fn ->
+  defp load_shape_info(%Conn{assigns: %{config: config}} = conn, _) do
+    OpenTelemetry.with_span("shape_get.plug.load_shape_info", [], config[:stack_id], fn ->
       shape_info = get_or_create_shape_handle(conn.assigns)
       handle_shape_info(conn, shape_info)
     end)
@@ -403,13 +403,20 @@ defmodule Electric.Plug.ServeShapePlug do
       )
 
   # If offset is -1, we're serving a snapshot
-  defp serve_log_or_snapshot(%Conn{assigns: %{offset: @before_all_offset}} = conn, _) do
-    OpenTelemetry.with_span("shape_get.plug.serve_snapshot", [], fn -> serve_snapshot(conn) end)
+  defp serve_log_or_snapshot(
+         %Conn{assigns: %{offset: @before_all_offset, config: config}} = conn,
+         _
+       ) do
+    OpenTelemetry.with_span("shape_get.plug.serve_snapshot", [], config[:stack_id], fn ->
+      serve_snapshot(conn)
+    end)
   end
 
   # Otherwise, serve log since that offset
-  defp serve_log_or_snapshot(conn, _) do
-    OpenTelemetry.with_span("shape_get.plug.serve_shape_log", [], fn -> serve_shape_log(conn) end)
+  defp serve_log_or_snapshot(%Conn{assigns: %{config: config}} = conn, _) do
+    OpenTelemetry.with_span("shape_get.plug.serve_shape_log", [], config[:stack_id], fn ->
+      serve_shape_log(conn)
+    end)
   end
 
   defp serve_snapshot(
@@ -495,29 +502,35 @@ defmodule Electric.Plug.ServeShapePlug do
   end
 
   defp send_stream(stream, conn, status) do
+    stack_id = conn.assigns.config[:stack_id]
     conn = send_chunked(conn, status)
 
     {conn, bytes_sent} =
       Enum.reduce_while(stream, {conn, 0}, fn chunk, {conn, bytes_sent} ->
         chunk_size = IO.iodata_length(chunk)
 
-        OpenTelemetry.with_span("shape_get.plug.stream_chunk", [chunk_size: chunk_size], fn ->
-          case chunk(conn, chunk) do
-            {:ok, conn} ->
-              {:cont, {conn, bytes_sent + chunk_size}}
+        OpenTelemetry.with_span(
+          "shape_get.plug.stream_chunk",
+          [chunk_size: chunk_size],
+          stack_id,
+          fn ->
+            case chunk(conn, chunk) do
+              {:ok, conn} ->
+                {:cont, {conn, bytes_sent + chunk_size}}
 
-            {:error, "closed"} ->
-              error_str = "Connection closed unexpectedly while streaming response"
-              conn = assign(conn, :error_str, error_str)
-              {:halt, {conn, bytes_sent}}
+              {:error, "closed"} ->
+                error_str = "Connection closed unexpectedly while streaming response"
+                conn = assign(conn, :error_str, error_str)
+                {:halt, {conn, bytes_sent}}
 
-            {:error, reason} ->
-              error_str = "Error while streaming response: #{inspect(reason)}"
-              Logger.error(error_str)
-              conn = assign(conn, :error_str, error_str)
-              {:halt, {conn, bytes_sent}}
+              {:error, reason} ->
+                error_str = "Error while streaming response: #{inspect(reason)}"
+                Logger.error(error_str)
+                conn = assign(conn, :error_str, error_str)
+                {:halt, {conn, bytes_sent}}
+            end
           end
-        end)
+        )
       end)
 
     assign(conn, :streaming_bytes_sent, bytes_sent)
@@ -581,7 +594,8 @@ defmodule Electric.Plug.ServeShapePlug do
 
     maybe_up_to_date = if up_to_date = assigns[:up_to_date], do: up_to_date != []
 
-    Electric.Plug.Utils.common_open_telemetry_attrs(conn)
+    Electric.StackSupervisor.get_telemetry_span_attrs(assigns.config[:stack_id])
+    |> Map.merge(Electric.Plug.Utils.common_open_telemetry_attrs(conn))
     |> Map.merge(%{
       "shape.handle" => shape_handle,
       "shape.where" => assigns[:where],

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -221,7 +221,7 @@ defmodule Electric.Postgres.ReplicationClient do
     end
   end
 
-  defp process_x_log_data(data, wal_end, %State{} = state) do
+  defp process_x_log_data(data, wal_end, %State{stack_id: stack_id} = state) do
     OpenTelemetry.timed_fun("decode_message_duration", fn -> decode_message(data) end)
     # # Useful for debugging:
     # |> tap(fn %struct{} = msg ->

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -111,7 +111,7 @@ defmodule Electric.Postgres.ReplicationClient do
 
     Postgrex.ReplicationConnection.start_link(
       __MODULE__,
-      config.replication_opts ++ [stack_id: config.stack_id],
+      config.replication_opts,
       start_opts
     )
   end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -60,8 +60,8 @@ defmodule Electric.ShapeCache do
             ],
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
-              type: {:fun, 5},
-              default: &Shapes.Consumer.Snapshotter.query_in_readonly_txn/5
+              type: {:fun, 6},
+              default: &Shapes.Consumer.Snapshotter.query_in_readonly_txn/6
             ],
             purge_all_shapes?: [type: :boolean, required: false]
           )

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -222,10 +222,11 @@ defmodule Electric.ShapeCache.FileStorage do
   defp offset({_, tuple_offset}), do: LogOffset.new(tuple_offset)
 
   @impl Electric.ShapeCache.Storage
-  def make_new_snapshot!(data_stream, %FS{} = opts) do
+  def make_new_snapshot!(data_stream, %FS{stack_id: stack_id} = opts) do
     OpenTelemetry.with_span(
       "storage.make_new_snapshot",
       [storage_impl: "mixed_disk", "shape.handle": opts.shape_handle],
+      stack_id,
       fn ->
         data_stream
         |> Stream.map(&[&1, ?\n])

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -202,10 +202,11 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def make_new_snapshot!(data_stream, %MS{} = opts) do
+  def make_new_snapshot!(data_stream, %MS{stack_id: stack_id} = opts) do
     OpenTelemetry.with_span(
       "storage.make_new_snapshot",
       [storage_impl: "in_memory", "shape.handle": opts.shape_handle],
+      stack_id,
       fn ->
         table = opts.snapshot_table
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -216,6 +216,7 @@ defmodule Electric.Shapes.Consumer do
     OpenTelemetry.with_span(
       "shape_write.consumer.handle_txns",
       [snapshot_xmin: state.snapshot_xmin],
+      state.stack_id,
       fn -> handle_txns(txns, state) end
     )
   end
@@ -239,7 +240,7 @@ defmodule Electric.Shapes.Consumer do
       [xid: txn.xid, total_num_changes: txn.num_changes] ++
         shape_attrs(state.shape_handle, state.shape)
 
-    OpenTelemetry.with_span("shape_write.consumer.handle_txn", ot_attrs, fn ->
+    OpenTelemetry.with_span("shape_write.consumer.handle_txn", ot_attrs, state.stack_id, fn ->
       do_handle_txn(txn, state)
     end)
   end

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -21,8 +21,8 @@ defmodule Electric.Shapes.ConsumerSupervisor do
             db_pool: [type: {:or, [:atom, :pid, @name_schema_tuple]}, required: true],
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
-              type: {:fun, 5},
-              default: &Electric.Shapes.Consumer.Snapshotter.query_in_readonly_txn/5
+              type: {:fun, 6},
+              default: &Electric.Shapes.Consumer.Snapshotter.query_in_readonly_txn/6
             ]
           )
 

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -11,9 +11,9 @@ defmodule Electric.Shapes.Querying do
 
   @type json_result_stream :: Enumerable.t(json_iodata())
 
-  @spec stream_initial_data(DBConnection.t(), Shape.t()) :: json_result_stream()
-  def stream_initial_data(conn, %Shape{root_table: root_table} = shape) do
-    OpenTelemetry.with_span("shape_read.stream_initial_data", [], fn ->
+  @spec stream_initial_data(DBConnection.t(), String.t(), Shape.t()) :: json_result_stream()
+  def stream_initial_data(conn, stack_id, %Shape{root_table: root_table} = shape) do
+    OpenTelemetry.with_span("shape_read.stream_initial_data", [], stack_id, fn ->
       table = Utils.relation_to_sql(root_table)
 
       where =

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -138,7 +138,7 @@ defmodule Electric.StackSupervisor do
   end
 
   @doc false
-  defp storage_mod_arg(%{stack_id: stack_id, storage: {mod, arg}}) do
+  def storage_mod_arg(%{stack_id: stack_id, storage: {mod, arg}}) do
     {mod, arg |> Keyword.put(:stack_id, stack_id) |> mod.shared_opts()}
   end
 

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -231,7 +231,7 @@ defmodule Electric.StackSupervisor do
 
     if telemetry_span_attrs != %{},
       do:
-        Electric.Telemetry.OpenTelemetry.set_stack_telemetry_span_attrs(
+        Electric.Telemetry.OpenTelemetry.set_stack_span_attrs(
           stack_id,
           telemetry_span_attrs
         )

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -49,7 +49,7 @@ defmodule Electric.Telemetry.OpenTelemetry do
   @spec with_span(span_name(), span_attrs(), String.t(), (-> t)) :: t when t: term
   def with_span(name, attributes, stack_id, fun)
       when is_binary(name) and (is_list(attributes) or is_map(attributes)) do
-    stack_attributes = Electric.StackSupervisor.get_telemetry_span_attrs(stack_id)
+    stack_attributes = get_stack_telemetry_span_attrs(stack_id)
     all_attributes = stack_attributes |> Map.merge(Map.new(attributes))
 
     # This map is populated with default values that `:otel_tracer.with_span()` whould have set
@@ -109,6 +109,22 @@ defmodule Electric.Telemetry.OpenTelemetry do
   def add_span_attributes(span_ctx \\ nil, attributes) do
     span_ctx = span_ctx || get_current_context()
     :otel_span.set_attributes(span_ctx, attributes)
+  end
+
+  @doc """
+  Store the telemetry span attributes in the persistent term for this stack.
+  """
+  @spec set_stack_telemetry_span_attrs(String.t(), span_attrs()) :: :ok
+  def set_stack_telemetry_span_attrs(stack_id, attrs) do
+    :persistent_term.put(:"electric_otel_attributes_#{stack_id}", Map.new(attrs))
+  end
+
+  @doc """
+  Retrieve the telemetry span attributes from the persistent term for this stack.
+  """
+  @spec get_stack_telemetry_span_attrs(String.t()) :: map()
+  def get_stack_telemetry_span_attrs(stack_id) do
+    :persistent_term.get(:"electric_otel_attributes_#{stack_id}", %{})
   end
 
   @doc """

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -49,7 +49,7 @@ defmodule Electric.Telemetry.OpenTelemetry do
   @spec with_span(span_name(), span_attrs(), String.t(), (-> t)) :: t when t: term
   def with_span(name, attributes, stack_id, fun)
       when is_binary(name) and (is_list(attributes) or is_map(attributes)) do
-    stack_attributes = get_stack_telemetry_span_attrs(stack_id)
+    stack_attributes = get_stack_span_attrs(stack_id)
     all_attributes = stack_attributes |> Map.merge(Map.new(attributes))
 
     # This map is populated with default values that `:otel_tracer.with_span()` whould have set
@@ -114,16 +114,16 @@ defmodule Electric.Telemetry.OpenTelemetry do
   @doc """
   Store the telemetry span attributes in the persistent term for this stack.
   """
-  @spec set_stack_telemetry_span_attrs(String.t(), span_attrs()) :: :ok
-  def set_stack_telemetry_span_attrs(stack_id, attrs) do
+  @spec set_stack_span_attrs(String.t(), span_attrs()) :: :ok
+  def set_stack_span_attrs(stack_id, attrs) do
     :persistent_term.put(:"electric_otel_attributes_#{stack_id}", Map.new(attrs))
   end
 
   @doc """
   Retrieve the telemetry span attributes from the persistent term for this stack.
   """
-  @spec get_stack_telemetry_span_attrs(String.t()) :: map()
-  def get_stack_telemetry_span_attrs(stack_id) do
+  @spec get_stack_span_attrs(String.t()) :: map()
+  def get_stack_span_attrs(stack_id) do
     :persistent_term.get(:"electric_otel_attributes_#{stack_id}", %{})
   end
 

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -40,6 +40,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
     test "creates an empty publication on startup if requested",
          %{db_conn: conn, dummy_pid: dummy_pid} = ctx do
       replication_opts = [
+        stack_id: ctx.stack_id,
         publication_name: @publication_name,
         try_creating_publication?: true,
         slot_name: @slot_name,
@@ -346,6 +347,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
   defp with_replication_opts(ctx) do
     %{
       replication_opts: [
+        stack_id: ctx.stack_id,
         publication_name: @publication_name,
         try_creating_publication?: false,
         slot_name: @slot_name,

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -75,7 +75,7 @@ defmodule Electric.ShapeCacheTest do
     setup ctx do
       with_shape_cache(
         Map.put(ctx, :inspector, @stub_inspector),
-        create_snapshot_fn: fn _, _, _, _, _ -> nil end,
+        create_snapshot_fn: fn _, _, _, _, _, _ -> nil end,
         prepare_tables_fn: @prepare_tables_noop
       )
     end
@@ -106,7 +106,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -130,7 +130,7 @@ defmodule Electric.ShapeCacheTest do
           prepare_tables_fn: fn nil, [{{"public", "items"}, nil}] ->
             send(test_pid, {:called, :prepare_tables_fn})
           end,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             send(test_pid, {:called, :create_snapshot_fn})
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
@@ -158,7 +158,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             send(test_pid, {:called, :create_snapshot_fn})
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
@@ -396,7 +396,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -417,7 +417,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
@@ -456,7 +456,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _, _, _ ->
+          create_snapshot_fn: fn parent, shape_handle, _, _, _, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -472,7 +472,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _, _, _ ->
+          create_snapshot_fn: fn parent, shape_handle, _, _, _, _ ->
             Process.sleep(100)
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
             GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -498,7 +498,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _, _, _ ->
+          create_snapshot_fn: fn parent, shape_handle, _, _, _, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -518,7 +518,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -537,7 +537,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
@@ -586,7 +586,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             GenServer.cast(parent, {:snapshot_started, shape_handle})
 
@@ -618,7 +618,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, _storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, _storage, _ ->
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
@@ -661,7 +661,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -716,7 +716,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -775,7 +775,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -813,7 +813,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.put(ctx, :inspector, @stub_inspector),
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: @prepare_tables_noop,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, @snapshot_xmin})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -887,7 +887,7 @@ defmodule Electric.ShapeCacheTest do
 
       with_shape_cache(Map.put(context, :inspector, @stub_inspector),
         prepare_tables_fn: @prepare_tables_noop,
-        create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+        create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
           GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, @snapshot_xmin})
           Storage.make_new_snapshot!([["test"]], storage)
           GenServer.cast(parent, {:snapshot_started, shape_handle})

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -624,7 +624,7 @@ defmodule Electric.Shapes.ConsumerTest do
           log_producer: ctx.shape_log_collector,
           run_with_conn_fn: &run_with_conn_noop/2,
           prepare_tables_fn: fn _, _ -> :ok end,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage ->
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _ ->
             if is_integer(snapshot_delay), do: Process.sleep(snapshot_delay)
             GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
             Storage.make_new_snapshot!([["test"]], storage)

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -51,7 +51,7 @@ defmodule Electric.Shapes.QueryingTest do
                headers: %{operation: "insert", relation: ["public", "items"]},
                offset: "0_0"
              }
-           ] == decode_stream(Querying.stream_initial_data(conn, shape))
+           ] == decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
   end
 
   test "respects the where clauses", %{db_conn: conn} do
@@ -72,7 +72,7 @@ defmodule Electric.Shapes.QueryingTest do
     assert [
              %{key: ~S["public"."items"/"4"], value: %{value: "4"}},
              %{key: ~S["public"."items"/"5"], value: %{value: "5"}}
-           ] = decode_stream(Querying.stream_initial_data(conn, shape))
+           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
   end
 
   test "allows column names to have special characters", %{db_conn: conn} do
@@ -97,7 +97,7 @@ defmodule Electric.Shapes.QueryingTest do
 
     assert [
              %{key: ~S["public"."items"/"1"], value: %{"col with \"' in it": "1"}}
-           ] = decode_stream(Querying.stream_initial_data(conn, shape))
+           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
   end
 
   test "works with composite PKs", %{db_conn: conn} do
@@ -125,7 +125,7 @@ defmodule Electric.Shapes.QueryingTest do
     assert [
              %{key: ~S["public"."items"/"1"/"2"], value: %{test: "1"}},
              %{key: ~S["public"."items"/"3"/"4"], value: %{test: "2"}}
-           ] = decode_stream(Querying.stream_initial_data(conn, shape))
+           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
   end
 
   test "works with null values & values with special characters", %{db_conn: conn} do
@@ -152,7 +152,7 @@ defmodule Electric.Shapes.QueryingTest do
              %{key: ~S["public"."items"/"1"], value: %{value: "1"}},
              %{key: ~S["public"."items"/"2"], value: %{value: nil}},
              %{key: ~S["public"."items"/"3"], value: %{value: ~s["test\\x0001\n"]}}
-           ] = decode_stream(Querying.stream_initial_data(conn, shape))
+           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
   end
 
   defp decode_stream(stream),


### PR DESCRIPTION
This PR is an alternative to https://github.com/electric-sql/electric/pull/2077.
Instead of injecting the OTEL attributes and passing them around everywhere, we store each stack's OTEL attributes in a dedicated persistent term. When creating a span we lookup the OTEL attributes for that stack and add them to the span.