### PR TITLE
Add an optional DATABASE_POOL_URL config

### DIFF
--- a/.changeset/stupid-weeks-look.md
+++ b/.changeset/stupid-weeks-look.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Restore the automatic fallback to unencrypted database connections when SSL isn't available.

--- a/examples/gatekeeper-auth/README.md
+++ b/examples/gatekeeper-auth/README.md
@@ -157,7 +157,7 @@ $ curl -sv --header "Authorization: Bearer ${AUTH_TOKEN}" \
 Note that we got an empty response when successfully proxied through to Electric above because there are no `items` in the database. If you like, you can create some, e.g. using `psql`:
 
 ```console
-$ psql "postgresql://postgres:password@localhost:54321/electric?sslmode=disable"
+$ psql "postgresql://postgres:password@localhost:54321/electric"
 psql (16.4)
 Type "help" for help.
 

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -105,10 +105,14 @@ database_ipv6_config =
   env!("ELECTRIC_DATABASE_USE_IPV6", :boolean, false)
 
 {:ok, database_url_config} = Electric.ConfigParser.parse_postgresql_uri(database_url)
-
 connection_opts = database_url_config ++ [ipv6: database_ipv6_config]
-
 config :electric, connection_opts: Electric.Utils.obfuscate_password(connection_opts)
+
+if database_pool_url = env!("DATABASE_POOL_URL", :string, nil) do
+  {:ok, database_pool_url_config} = Electric.ConfigParser.parse_postgresql_uri(database_pool_url)
+  connection_opts = database_pool_url_config ++ [ipv6: database_ipv6_config]
+  config :electric, pool_connection_opts: Electric.Utils.obfuscate_password(connection_opts)
+end
 
 enable_integration_testing = env!("ELECTRIC_ENABLE_INTEGRATION_TESTING", :boolean, false)
 cache_max_age = env!("ELECTRIC_CACHE_MAX_AGE", :integer, 60)

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -29,28 +29,31 @@ defmodule Electric.StackSupervisor do
   """
   use Supervisor, restart: :transient
 
+  @connection_opts_schema [
+    type: :keyword_list,
+    required: true,
+    keys: [
+      hostname: [type: :string, required: true],
+      port: [type: :integer, required: true],
+      database: [type: :string, required: true],
+      username: [type: :string, required: true],
+      password: [type: {:fun, 0}, required: true],
+      sslmode: [type: :atom, required: false],
+      ipv6: [type: :boolean, required: false]
+    ]
+  ]
+
   @opts_schema NimbleOptions.new!(
                  name: [type: :any, required: false],
                  stack_id: [type: :string, required: true],
                  persistent_kv: [type: :any, required: true],
                  stack_events_registry: [type: :atom, required: true],
-                 connection_opts: [
-                   type: :keyword_list,
-                   required: true,
-                   keys: [
-                     hostname: [type: :string, required: true],
-                     port: [type: :integer, required: true],
-                     database: [type: :string, required: true],
-                     username: [type: :string, required: true],
-                     password: [type: {:fun, 0}, required: true],
-                     sslmode: [type: :atom, required: false],
-                     ipv6: [type: :boolean, required: false]
-                   ]
-                 ],
+                 connection_opts: @connection_opts_schema,
                  replication_opts: [
                    type: :keyword_list,
                    required: true,
                    keys: [
+                     connection_opts: @connection_opts_schema,
                      publication_name: [type: :string, required: true],
                      slot_name: [type: :string, required: true],
                      slot_temporary?: [type: :boolean, default: false],

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -163,6 +163,7 @@ defmodule Support.ComponentSetup do
          storage: storage,
          connection_opts: ctx.db_config,
          replication_opts: [
+           connection_opts: ctx.db_config,
            slot_name: "electric_test_slot_#{:erlang.phash2(stack_id)}",
            publication_name: "electric_test_pub_#{:erlang.phash2(stack_id)}",
            try_creating_publication?: true,


### PR DESCRIPTION
This implements #1885.

When configured, the lock connection and the database pool will connect to this pooled URL.

By default, when `DATABASE_POOL_URL` is not set, all connections are open using the direct database connection URL configured with `DATABASE_URL`.

Things to add before merging:
- [ ] Changeset
- [ ] Docs
- [ ] A test to check that all DB connections aside from the replication one are using the pool URL