### PR TITLE
Add a missing end tag in Configuration documentation

### DIFF
--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -347,3 +347,5 @@ These environment variables allow configuration of anonymous usage data reportin
     example="true">
 
 Configure anonymous usage data about the instance being sent to a central checkpoint service. Collected information is anonymised and doesn't contain any information from the replicated data. You can read more about it in our [telemetry docs](../reference/telemetry.md#anonymous-usage-data).
+
+</EnvVarConfig>


### PR DESCRIPTION
It got lost in the rebase/merging of two commits affecting the same file.