### PR TITLE
fix: only clear the React stream/shape cache when the previous stream/shape was aborted

### DIFF
--- a/.changeset/young-falcons-rest.md
+++ b/.changeset/young-falcons-rest.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/react": patch
+---
+
+fix: only clear the React stream/shape cache when the previous stream/shape was aborted

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -54,17 +54,16 @@ export function getShapeStream<T extends Row<unknown>>(
   // If the stream is already cached, return it if valid
   if (streamCache.has(shapeHash)) {
     const stream = streamCache.get(shapeHash)! as ShapeStream<T>
-    if (!stream.error && !stream.options.signal?.aborted) {
+    if (!stream.options.signal?.aborted) {
       return stream
     }
 
-    // if stream is cached but errored/aborted, remove it and related shapes
+    // if stream is aborted, remove it and related shapes
     streamCache.delete(shapeHash)
     shapeCache.delete(stream)
   }
 
   const newShapeStream = new ShapeStream<T>(options)
-
   streamCache.set(shapeHash, newShapeStream)
 
   // Return the created shape
@@ -76,17 +75,16 @@ export function getShape<T extends Row<unknown>>(
 ): Shape<T> {
   // If the stream is already cached, return it if valid
   if (shapeCache.has(shapeStream)) {
-    if (!shapeStream.error && !shapeStream.options.signal?.aborted) {
+    if (!shapeStream.options.signal?.aborted) {
       return shapeCache.get(shapeStream)! as Shape<T>
     }
 
-    // if stream is cached but errored/aborted, remove it and related shapes
+    // if stream is aborted, remove it and related shapes
     streamCache.delete(sortedOptionsHash(shapeStream.options))
     shapeCache.delete(shapeStream)
   }
 
   const newShape = new Shape<T>(shapeStream)
-
   shapeCache.set(shapeStream, newShape)
 
   // Return the created shape


### PR DESCRIPTION
The current behavior also clears them when there's an error which leads to an infinite loop with a bad stream being recreated over and over.