### PR TITLE
chore (sync service): improve nimble spec for telemetry span attributes

### DIFF
--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -116,12 +116,8 @@ defmodule Electric.StackSupervisor do
                  ]
                )
 
-  def validate(opts) do
-    NimbleOptions.validate(Map.new(opts), @opts_schema)
-  end
-
   def start_link(opts) do
-    with {:ok, config} <- validate(opts) do
+    with {:ok, config} <- NimbleOptions.validate(Map.new(opts), @opts_schema) do
       Supervisor.start_link(__MODULE__, config, Keyword.take(opts, [:name]))
     end
   end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -80,13 +80,48 @@ defmodule Electric.StackSupervisor do
                    ]
                  ],
                  telemetry_span_attrs: [
-                   type: {:map, :string, {:or, [:string, :integer, :float, :boolean]}},
+                   # Validates the OpenTelemetry.attributes_map() type
+                   # cf. https://github.com/open-telemetry/opentelemetry-erlang/blob/9f7affe630676d2803b04f69d0c759effb6e0245/apps/opentelemetry_api/src/opentelemetry.erl#L118
+                   type:
+                     {:or,
+                      [
+                        {:map, {:or, [:atom, :string]},
+                         {:or,
+                          [
+                            :atom,
+                            :string,
+                            :integer,
+                            :float,
+                            :boolean,
+                            {:list, {:or, [:atom, :string, :integer, :float, :boolean]}},
+                            :map
+                          ]}},
+                        {:list,
+                         {:tuple,
+                          [
+                            {:or, [:atom, :string]},
+                            {:or,
+                             [
+                               :atom,
+                               :string,
+                               :integer,
+                               :float,
+                               :boolean,
+                               {:list, {:or, [:atom, :string, :integer, :float, :boolean]}},
+                               :map
+                             ]}
+                          ]}}
+                      ]},
                    required: false
                  ]
                )
 
+  def validate(opts) do
+    NimbleOptions.validate(Map.new(opts), @opts_schema)
+  end
+
   def start_link(opts) do
-    with {:ok, config} <- NimbleOptions.validate(Map.new(opts), @opts_schema) do
+    with {:ok, config} <- validate(opts) do
       Supervisor.start_link(__MODULE__, config, Keyword.take(opts, [:name]))
     end
   end


### PR DESCRIPTION
This PR improves the nimble spec for validating span attributes.