### PR TITLE
docs: update shape definitions to use new `params` key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ import { useShape } from '@electric-sql/react'
 function Component() {
   const { data } = useShape({
     url: `http://localhost:3000/v1/shape`,
-    table: `foo`,
-    where: `title LIKE 'foo%'`,
+    params: {
+      table: `foo`,
+      where: `title LIKE 'foo%'`
+    }
   })
 
   return JSON.stringify(data)

--- a/examples/remix-basic/app/routes/_index.tsx
+++ b/examples/remix-basic/app/routes/_index.tsx
@@ -9,8 +9,8 @@ const itemShape = () => {
   return {
     url: new URL(`/shape-proxy`, window.location.origin).href,
     params: {
-      table: `items`
-    }
+      table: `items`,
+    },
   }
 }
 

--- a/examples/remix-basic/app/routes/_index.tsx
+++ b/examples/remix-basic/app/routes/_index.tsx
@@ -8,7 +8,9 @@ import { matchStream } from "../match-stream"
 const itemShape = () => {
   return {
     url: new URL(`/shape-proxy`, window.location.origin).href,
-    table: `items`,
+    params: {
+      table: `items`
+    }
   }
 }
 

--- a/examples/tanstack-example/src/Example.tsx
+++ b/examples/tanstack-example/src/Example.tsx
@@ -15,7 +15,9 @@ const baseApiUrl = `http://localhost:3001`
 
 const itemShape = () => ({
   url: new URL(`/v1/shape`, baseUrl).href,
-  table: `items`,
+  params: {
+    table: `items`,
+  },
 })
 
 async function createItem(newId: string) {

--- a/website/docs/guides/deployment.md
+++ b/website/docs/guides/deployment.md
@@ -151,7 +151,9 @@ You can then connect your app to Electric [over HTTP](/docs/api/http). Typically
 ```ts
 const stream = new ShapeStream({
   url: `https://your-electric-service.example.com/v1/shape`,
-  table: 'foo'
+  params: {
+    table: `foo`
+  }
 })
 const shape = new Shape(stream)
 ```

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -124,7 +124,9 @@ import { ShapeStream, Shape } from '@electric-sql/client'
 
 const stream = new ShapeStream({
   url: `http://localhost:3000/v1/shape`,
-  table: `foo`,
+  params: {
+    table: `foo`
+  }
 })
 const shape = new Shape(stream)
 

--- a/website/docs/integrations/cloudflare.md
+++ b/website/docs/integrations/cloudflare.md
@@ -82,7 +82,9 @@ export default {
 
     const stream = new ShapeStream({
       url: `${ELECTRIC_URL}/v1/shape`,
-      table: 'routes'
+      params: {
+        table: 'routes'
+      }
     })
     const shape = new Shape(stream)
     const routes = await shape.value

--- a/website/docs/integrations/expo.md
+++ b/website/docs/integrations/expo.md
@@ -35,7 +35,9 @@ const ELECTRIC_URL = 'https://my-electric-sync-service.example.com'
 export default function HomeScreen() {
   const { isLoading, data } = useShape({
     url: `${ELECTRIC_URL}/v1/shape`,
-    table: 'items'
+    params: {
+      table: 'items'
+    }
   })
 
   if (isLoading) {

--- a/website/docs/integrations/netlify.md
+++ b/website/docs/integrations/netlify.md
@@ -39,7 +39,9 @@ const ELECTRIC_URL = process.env.ELECTRIC_URL
 
 const stream = new ShapeStream({
   url: `${ELECTRIC_URL}/v1/shape`,
-  table: 'items'
+  params: {
+    table: 'items'
+  }
 })
 ```
 

--- a/website/docs/integrations/supabase.md
+++ b/website/docs/integrations/supabase.md
@@ -93,7 +93,9 @@ import { Shape, ShapeStream } from 'npm:@electric-sql/client'
 Deno.serve(async (req) => {
   const stream = new ShapeStream({
     url: '[YOUR_ELECTRIC_URL]/v1/shape',
-    table: 'items'
+    params: {
+      table: 'items'
+    }
   })
   const shape = new Shape(stream)
   const items = [...await shape.value]

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -167,7 +167,9 @@ import { useShape } from '@electric-sql/react'
 function Component() {
   const { data } = useShape({
     url: `http://localhost:3000/v1/shape`,
-    table: `foo`
+    params: {
+      table: `foo`
+    }
   })
 
   return (

--- a/website/src/partials/home-cta.md
+++ b/website/src/partials/home-cta.md
@@ -25,7 +25,9 @@ import { useShape } from '@electric-sql/react'
 const Component = () => {
   const { data } = useShape({
     url: `${BASE_URL}/v1/shape`,
-    table: `items`
+    params: {
+      table: `items`
+    }
   })
 
   return (

--- a/website/use-cases/state-transfer.md
+++ b/website/use-cases/state-transfer.md
@@ -89,7 +89,9 @@ import { useShape } from '@electric-sql/react'
 const Component = () => {
   const { data } = useShape({
     url: `${BASE_URL}/v1/shape`,
-    table: `items`
+    params: {
+      table: `items`
+    }
   })
 
   return (


### PR DESCRIPTION
Missed a few places where we need to update the switch to put the shape definition in the `params` key from https://github.com/electric-sql/electric/pull/2081