### PR TITLE
feat: configure logging to be more explicit

### DIFF
--- a/packages/sync-service/.env.dev
+++ b/packages/sync-service/.env.dev
@@ -1,4 +1,4 @@
-ELECTRIC_LOGGING_LEVEL=debug
+ELECTRIC_LOG_LEVEL=debug
 DATABASE_URL=postgresql://postgres:password@localhost:54321/electric?sslmode=disable
 ELECTRIC_ENABLE_INTEGRATION_TESTING=true
 ELECTRIC_CACHE_MAX_AGE=1

--- a/packages/sync-service/.env.test
+++ b/packages/sync-service/.env.test
@@ -1,2 +1,2 @@
-ELECTRIC_LOGGING_LEVEL=info
+ELECTRIC_LOG_LEVEL=info
 DATABASE_URL=postgresql://postgres:password@localhost:54321/postgres?sslmode=disable

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -7,21 +7,14 @@ if config_env() in [:dev, :test] do
   source!([".env.#{config_env()}", ".env.#{config_env()}.local", System.get_env()])
 end
 
-log_level_config =
-  env!("ELECTRIC_LOGGING_LEVEL", :string, "info")
-  |> Electric.ConfigParser.parse_log_level()
+config :logger,
+  level: env!("ELECTRIC_LOG_LEVEL", &Electric.ConfigParser.parse_log_level!/1, :info)
 
-case log_level_config do
-  {:ok, log_level} ->
-    config :logger, level: log_level
-
-  {:error, message} ->
-    raise message
-end
-
-if !env!("ELECTRIC_LOG_COLORS", :boolean, true) do
-  config :logger, :default_formatter, colors: [enabled: false]
-end
+config :logger, :default_formatter,
+  # Doubled line breaks serve as long message boundaries
+  format: "\n$time $metadata[$level] $message\n",
+  metadata: [:pid, :shape_handle, :request_id],
+  colors: [enabled: env!("ELECTRIC_LOG_COLORS", :boolean!, true)]
 
 # Enable this to get **very noisy** but useful messages from BEAM about
 # processes being started, stopped and crashes.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -158,6 +158,7 @@ defmodule Electric.Connection.Manager do
     Process.flag(:trap_exit, true)
 
     Process.set_label({:connection_manager, opts[:stack_id]})
+    Logger.metadata(stack_id: opts[:stack_id])
 
     connection_opts =
       opts
@@ -245,7 +246,8 @@ defmodule Electric.Connection.Manager do
     opts = [
       connection_opts: state.connection_opts,
       connection_manager: self(),
-      lock_name: Keyword.fetch!(state.replication_opts, :slot_name)
+      lock_name: Keyword.fetch!(state.replication_opts, :slot_name),
+      stack_id: state.stack_id
     ]
 
     case start_lock_connection(opts) do

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -30,6 +30,7 @@ defmodule Electric.Connection.Supervisor do
 
   def init(opts) do
     Process.set_label({:connection_supervisor, opts[:stack_id]})
+    Logger.metadata(stack_id: opts[:stack_id])
     Supervisor.init([{Electric.Connection.Manager, opts}], strategy: :rest_for_one)
   end
 

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -6,6 +6,7 @@ defmodule Electric.Plug.Router do
 
   plug Plug.RequestId, assign_as: :plug_request_id
   plug :server_header, Electric.version()
+  plug :add_stack_id_to_metadata
   # converts HEAD requests to GET requests
   plug Plug.Head
   plug RemoteIp
@@ -41,4 +42,9 @@ defmodule Electric.Plug.Router do
 
   def put_cors_headers(conn, _opts),
     do: CORSHeaderPlug.call(conn, %{methods: ["GET", "HEAD"]})
+
+  def add_stack_id_to_metadata(conn, _) do
+    Logger.metadata(stack_id: conn.assigns.config[:stack_id])
+    conn
+  end
 end

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -85,6 +85,7 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     Process.flag(:trap_exit, true)
 
     Process.set_label({:ets_inspector, opts.stack_id})
+    Logger.metadata(stack_id: opts.stack_id)
 
     # Name needs to be an atom but we don't want to dynamically create atoms.
     # Instead, we will use the reference to the table that is returned by `:ets.new`

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -44,6 +44,11 @@ defmodule Electric.Postgres.LockConnection do
   def init(opts) do
     send(self(), :acquire_lock)
 
+    Logger.metadata(
+      lock_name: Keyword.fetch!(opts, :lock_name),
+      stack_id: Keyword.fetch!(opts, :stack_id)
+    )
+
     {:ok,
      %State{
        connection_manager: Keyword.fetch!(opts, :connection_manager),

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -143,8 +143,10 @@ defmodule Electric.Postgres.ReplicationClient do
   @impl true
   def init(replication_opts) do
     Process.set_label(:replication_client)
+    state = State.new(replication_opts)
+    Logger.metadata(stack_id: state.stack_id)
 
-    {:ok, State.new(replication_opts)}
+    {:ok, state}
   end
 
   # `Postgrex.ReplicationConnection` opens a new replication connection to Postgres and then

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -53,6 +53,7 @@ defmodule Electric.Replication.ShapeLogCollector do
 
   def init(opts) do
     Process.set_label({:shape_log_collector, opts.stack_id})
+    Logger.metadata(stack_id: opts.stack_id)
     state = Map.merge(opts, %{producer: nil, subscriptions: {0, MapSet.new()}})
     # start in demand: :accumulate mode so that the ShapeCache is able to start
     # all active consumers before we start sending transactions

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -17,6 +17,7 @@ defmodule Electric.Replication.Supervisor do
   @impl Supervisor
   def init(opts) do
     Process.set_label({:replication_supervisor, opts[:stack_id]})
+    Logger.metadata(stack_id: opts[:stack_id])
     Logger.info("Starting shape replication pipeline")
 
     # TODO: weird to have these without defaults but `consumer_supervisor` with a default

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -199,6 +199,9 @@ defmodule Electric.ShapeCache do
     stack_id = opts[:stack_id]
     meta_table = :ets.new(:"#{stack_id}:shape_meta_table", [:named_table, :public, :ordered_set])
 
+    Process.set_label({:shape_cache, stack_id})
+    Logger.metadata(stack_id: stack_id)
+
     {:ok, shape_status_state} =
       opts.shape_status.initialise(
         shape_meta_table: meta_table,

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -25,9 +25,9 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
     GenServer.start_link(__MODULE__, config, name: name(config))
   end
 
-  def init(%{stack_id: stack_id} = config) do
+  def init(config) do
     Process.set_label({:snapshotter, config.shape_handle})
-    Logger.metadata(stack_id: stack_id)
+    Logger.metadata(stack_id: config.stack_id, shape_handle: config.shape_handle)
 
     {:ok, config, {:continue, :start_snapshot}}
   end

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -62,6 +62,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
       config
 
     Process.set_label({:consumer_supervisor, shape_handle})
+    Logger.metadata(stack_id: config.stack_id, shape_handle: shape_handle)
 
     shape_storage = Electric.ShapeCache.Storage.for_shape(shape_handle, storage)
 

--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -53,6 +53,7 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
   @impl true
   def init(stack_id: stack_id) do
     Process.set_label({:dynamic_consumer_supervisor, stack_id})
+    Logger.metadata(stack_id: stack_id)
     Logger.debug(fn -> "Starting #{__MODULE__}" end)
     DynamicSupervisor.init(strategy: :one_for_one)
   end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -145,6 +145,7 @@ defmodule Electric.StackSupervisor do
   @impl true
   def init(%{stack_id: stack_id} = config) do
     Process.set_label({:stack_supervisor, stack_id})
+    Logger.metadata(stack_id: stack_id)
 
     inspector =
       Access.get(

--- a/packages/sync-service/test/electric/postgres/lock_connection_test.exs
+++ b/packages/sync-service/test/electric/postgres/lock_connection_test.exs
@@ -18,7 +18,8 @@ defmodule Electric.Postgres.LockConnectionTest do
                    LockConnection.start_link(
                      connection_opts: config,
                      connection_manager: self(),
-                     lock_name: @lock_name
+                     lock_name: @lock_name,
+                     stack_id: "irrelevant"
                    )
 
           assert_lock_acquired()
@@ -45,7 +46,8 @@ defmodule Electric.Postgres.LockConnectionTest do
                    LockConnection.start_link(
                      connection_opts: config,
                      connection_manager: self(),
-                     lock_name: @lock_name
+                     lock_name: @lock_name,
+                     stack_id: "irrelevant"
                    )
 
           assert_lock_acquired()
@@ -59,7 +61,8 @@ defmodule Electric.Postgres.LockConnectionTest do
                    LockConnection.start_link(
                      connection_opts: config,
                      connection_manager: self(),
-                     lock_name: @lock_name
+                     lock_name: @lock_name,
+                     stack_id: "irrelevant"
                    )
 
           # should fail to grab it

--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -293,10 +293,10 @@ Enable sending telemetry data to a StatsD reporting endpoint.
 
 ## Logging
 
-### ELECTRIC_LOGGING_LEVEL
+### ELECTRIC_LOG_LEVEL
 
 <EnvVarConfig
-    name="ELECTRIC_LOGGING_LEVEL"
+    name="ELECTRIC_LOG_LEVEL"
     optional="true"
     example="debug">
 


### PR DESCRIPTION
Adds stack id & other useful metadata to all processes we spawn, and configures logger to actually print it