### PR TITLE
Use "get" instead of "has" for checking searchParams

### DIFF
--- a/.changeset/modern-poets-film.md
+++ b/.changeset/modern-poets-film.md
@@ -1,0 +1,7 @@
+---
+"@electric-sql/client": patch
+---
+
+Use "get" instead of "has" for checking searchParams
+
+Not all implementations of JS have the has(name, value) syntax e.g. Expo.

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -177,13 +177,13 @@ export function createFetchWithResponseHeadersCheck(
       const input = args[0]
       const urlString = input.toString()
       const url = new URL(urlString)
-      if (url.searchParams.has(LIVE_QUERY_PARAM, `true`)) {
+      if (url.searchParams.has(LIVE_QUERY_PARAM)) {
         addMissingHeaders(requiredLiveResponseHeaders)
       }
 
       if (
         !url.searchParams.has(LIVE_QUERY_PARAM) ||
-        url.searchParams.has(LIVE_QUERY_PARAM, `false`)
+        url.searchParams.get(LIVE_QUERY_PARAM) === 'false'
       ) {
         addMissingHeaders(requiredNonLiveResponseHeaders)
       }

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -177,13 +177,13 @@ export function createFetchWithResponseHeadersCheck(
       const input = args[0]
       const urlString = input.toString()
       const url = new URL(urlString)
-      if (url.searchParams.has(LIVE_QUERY_PARAM)) {
+      if (url.searchParams.get(LIVE_QUERY_PARAM) === `true`) {
         addMissingHeaders(requiredLiveResponseHeaders)
       }
 
       if (
         !url.searchParams.has(LIVE_QUERY_PARAM) ||
-        url.searchParams.get(LIVE_QUERY_PARAM) === 'false'
+        url.searchParams.get(LIVE_QUERY_PARAM) === `false`
       ) {
         addMissingHeaders(requiredNonLiveResponseHeaders)
       }


### PR DESCRIPTION
Fix https://github.com/electric-sql/electric/issues/2072

Not all implementations of JS have the `has(name, value)` syntax