### PR TITLE
refactor(ts client): remove url object usage in fetch.ts

### DIFF
--- a/packages/typescript-client/package.json
+++ b/packages/typescript-client/package.json
@@ -29,7 +29,9 @@
     "url": "https://github.com/electric-sql/electric/issues"
   },
   "homepage": "https://electric-sql.com",
-  "dependencies": {},
+  "dependencies": {
+    "urlite": "^3.1.0"
+  },
   "devDependencies": {
     "@types/pg": "^8.11.6",
     "@types/uuid": "^10.0.0",

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -12,6 +12,8 @@ import {
   MissingHeadersError,
 } from './error'
 
+import url from 'urlite/extra'
+
 // Some specific 4xx and 5xx HTTP status codes that we definitely
 // want to retry
 const HTTP_RETRY_STATUS_CODES = [429]
@@ -176,15 +178,16 @@ export function createFetchWithResponseHeadersCheck(
 
       const input = args[0]
       const urlString = input.toString()
-      const url = new URL(urlString)
-      if (url.searchParams.get(LIVE_QUERY_PARAM) === `true`) {
+      const parsedUrl = url.parse(urlString)
+
+      const liveConnection = parsedUrl.search.live === 'true'
+      const notLiveConnection = !liveConnection
+
+      if (liveConnection) {
         addMissingHeaders(requiredLiveResponseHeaders)
       }
 
-      if (
-        !url.searchParams.has(LIVE_QUERY_PARAM) ||
-        url.searchParams.get(LIVE_QUERY_PARAM) === `false`
-      ) {
+      if (notLiveConnection) {
         addMissingHeaders(requiredNonLiveResponseHeaders)
       }
 

--- a/packages/typescript-client/tsconfig.json
+++ b/packages/typescript-client/tsconfig.json
@@ -33,7 +33,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": [ "urlite/types" ], /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "resolveJsonModule": true,                        /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -744,6 +744,10 @@ importers:
   packages/sync-service: {}
 
   packages/typescript-client:
+    dependencies:
+      urlite:
+        specifier: ^3.1.0
+        version: 3.1.0
     optionalDependencies:
       '@rollup/rollup-darwin-arm64':
         specifier: ^4.18.1
@@ -7631,13 +7635,8 @@ packages:
 
   tsx@4.19.2:
     resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
-    dependencies:
-      esbuild: 0.23.1
-      get-tsconfig: 4.8.1
     engines: {node: '>=18.0.0'}
     hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.3
 
   turbo-stream@2.4.0:
     resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
@@ -7779,6 +7778,9 @@ packages:
 
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
+  urlite@3.1.0:
+    resolution: {integrity: sha512-cn0EC//oggnAKXZDwED2gPZ9DwZgtK5LIedMd+RlKuadzDU/dXUYSqjHohGVj35qJBFFdjIhSoG6PvuFKsE6dQ==}
 
   use-callback-ref@1.3.2:
     resolution: {integrity: sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==}
@@ -15812,7 +15814,12 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.19.2: {}
+  tsx@4.19.2:
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.8.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo-stream@2.4.0: {}
 
@@ -15977,6 +15984,8 @@ snapshots:
       punycode: 2.3.1
 
   url-template@2.0.8: {}
+
+  urlite@3.1.0: {}
 
   use-callback-ref@1.3.2(@types/react@18.3.12)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
This PR removes the use of URL object from the typscript client to avoid compatibility issues with react-native
https://github.com/electric-sql/electric/issues/2072 and adds a generic check with urlite