### PR TITLE
feat: introduce initial snapshot chunking

### DIFF
--- a/.changeset/polite-frogs-yell.md
+++ b/.changeset/polite-frogs-yell.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+feat: introduce chunked snapshot generation

--- a/packages/elixir-client/lib/electric/client/offset.ex
+++ b/packages/elixir-client/lib/electric/client/offset.ex
@@ -67,6 +67,9 @@ defmodule Electric.Client.Offset do
       iex> from_string("1378734_3")
       {:ok, %#{__MODULE__}{tx: 1378734, op: 3}}
 
+      iex> from_string("0_inf")
+      {:ok, %#{__MODULE__}{tx: 0, op: :infinity}}
+
       iex> from_string("not a real offset")
       {:error, "has invalid format"}
 

--- a/packages/elixir-client/lib/electric/client/offset.ex
+++ b/packages/elixir-client/lib/electric/client/offset.ex
@@ -78,13 +78,16 @@ defmodule Electric.Client.Offset do
     else
       with [tx_offset_str, op_offset_str] <- :binary.split(str, "_"),
            {tx_offset, ""} <- Integer.parse(tx_offset_str),
-           {op_offset, ""} <- Integer.parse(op_offset_str) do
+           {op_offset, ""} <- parse_int_or_inf(op_offset_str) do
         {:ok, %__MODULE__{tx: tx_offset, op: op_offset}}
       else
         _ -> {:error, "has invalid format"}
       end
     end
   end
+
+  defp parse_int_or_inf("inf"), do: {:infinity, ""}
+  defp parse_int_or_inf(int), do: Integer.parse(int)
 
   @doc """
   Create a new #{__MODULE__} struct from the given LSN and operation
@@ -115,7 +118,7 @@ defmodule Electric.Client.Offset do
   end
 
   def to_string(%__MODULE__{tx: tx, op: op}) do
-    "#{Integer.to_string(tx)}_#{Integer.to_string(op)}"
+    "#{Integer.to_string(tx)}_#{if op == :infinity, do: "inf", else: Integer.to_string(op)}"
   end
 
   @spec to_tuple(t()) :: {tx_offset(), op_offset()}

--- a/packages/elixir-client/test/electric/client/mock_test.exs
+++ b/packages/elixir-client/test/electric/client/mock_test.exs
@@ -42,7 +42,7 @@ defmodule Electric.Client.MockTest do
       Client.Mock.response(client,
         status: 200,
         schema: %{id: %{type: "int8"}},
-        last_offset: Offset.new(0, 0),
+        last_offset: Offset.new(0, 1),
         shape_handle: "my-shape",
         body: [
           Client.Mock.change(value: %{id: "4444"}),
@@ -60,7 +60,7 @@ defmodule Electric.Client.MockTest do
              %ChangeMessage{value: %{"id" => 2222}},
              %ChangeMessage{value: %{"id" => 3333}},
              %ChangeMessage{value: %{"id" => 4444}},
-             up_to_date0()
+             up_to_date()
            ] = events
   end
 end

--- a/packages/elixir-client/test/support/client_helpers.ex
+++ b/packages/elixir-client/test/support/client_helpers.ex
@@ -4,7 +4,7 @@ defmodule Support.ClientHelpers do
 
   defmacro offset(tx, op), do: quote(do: %Offset{tx: unquote(tx), op: unquote(op)})
 
-  defmacro offset0, do: quote(do: offset(0, 0))
+  defmacro offset0, do: quote(do: offset(0, :infinity))
 
   defmacro up_to_date() do
     quote(do: %ControlMessage{control: :up_to_date, offset: %Offset{tx: _, op: _}})
@@ -19,5 +19,5 @@ defmodule Support.ClientHelpers do
     )
   end
 
-  defmacro up_to_date0(), do: quote(do: up_to_date(0, 0))
+  defmacro up_to_date0(), do: quote(do: up_to_date(0, :infinity))
 end

--- a/packages/sync-service/lib/electric/replication/log_offset.ex
+++ b/packages/sync-service/lib/electric/replication/log_offset.ex
@@ -47,7 +47,8 @@ defmodule Electric.Replication.LogOffset do
       ** (FunctionClauseError) no function clause matching in Electric.Replication.LogOffset.new/2
   """
   def new(tx_offset, op_offset)
-      when is_integer(tx_offset) and tx_offset >= 0 and is_integer(op_offset) and op_offset >= 0 do
+      when is_integer(tx_offset) and tx_offset >= 0 and is_integer(op_offset) and op_offset >= 0
+      when is_integer(tx_offset) and tx_offset >= 0 and op_offset == :infinity do
     %LogOffset{tx_offset: tx_offset, op_offset: op_offset}
   end
 
@@ -99,6 +100,10 @@ defmodule Electric.Replication.LogOffset do
                   (offset1.tx_offset == offset2.tx_offset and
                      offset1.op_offset < offset2.op_offset)
 
+  defguard is_min_offset(offset) when offset.tx_offset == -1
+
+  defguard is_snapshot_offset(offset) when offset.tx_offset == 0
+
   @doc """
   An offset that is smaller than all offsets in the log.
 
@@ -129,6 +134,12 @@ defmodule Electric.Replication.LogOffset do
   """
   @spec last() :: t
   def last(), do: %LogOffset{tx_offset: 0xFFFFFFFFFFFFFFFF, op_offset: :infinity}
+
+  @doc """
+  The last possible offset for the "virtual" part of the log - i.e. snapshots.
+  """
+  @spec last_before_real_offsets() :: t()
+  def last_before_real_offsets(), do: %LogOffset{tx_offset: 0, op_offset: :infinity}
 
   @doc """
   Increments the offset of the change inside the transaction.
@@ -184,6 +195,10 @@ defmodule Electric.Replication.LogOffset do
     [Integer.to_string(-1)]
   end
 
+  def to_iolist(%LogOffset{tx_offset: tx_offset, op_offset: :infinity}) do
+    [Integer.to_string(tx_offset), ?_, "inf"]
+  end
+
   def to_iolist(%LogOffset{tx_offset: tx_offset, op_offset: op_offset}) do
     [Integer.to_string(tx_offset), ?_, Integer.to_string(op_offset)]
   end
@@ -205,6 +220,9 @@ defmodule Electric.Replication.LogOffset do
       iex> from_string("0_02")
       {:ok, %LogOffset{tx_offset: 0, op_offset: 2}}
 
+      iex> from_string("0_inf")
+      {:ok, %LogOffset{tx_offset: 0, op_offset: :infinity}}
+
       iex> from_string("1_2_3")
       {:error, "has invalid format"}
 
@@ -224,7 +242,7 @@ defmodule Electric.Replication.LogOffset do
     else
       with [tx_offset_str, op_offset_str] <- String.split(str, "_"),
            {tx_offset, ""} <- Integer.parse(tx_offset_str),
-           {op_offset, ""} <- Integer.parse(op_offset_str),
+           {op_offset, ""} <- parse_int_or_inf(op_offset_str),
            offset <- new(tx_offset, op_offset) do
         {:ok, offset}
       else
@@ -233,9 +251,20 @@ defmodule Electric.Replication.LogOffset do
     end
   end
 
+  defp parse_int_or_inf("inf"), do: {:infinity, ""}
+  defp parse_int_or_inf(int), do: Integer.parse(int)
+
   defimpl Inspect do
     def inspect(%LogOffset{tx_offset: -1, op_offset: 0}, _opts) do
       "LogOffset.before_all()"
+    end
+
+    def inspect(%LogOffset{tx_offset: 0xFFFFFFFFFFFFFFFF, op_offset: :infinity}, _opts) do
+      "LogOffset.last()"
+    end
+
+    def inspect(%LogOffset{tx_offset: 0, op_offset: :infinity}, _opts) do
+      "LogOffset.last_before_real_offsets()"
     end
 
     def inspect(%LogOffset{tx_offset: tx, op_offset: op}, _opts) do

--- a/packages/sync-service/lib/electric/replication/log_offset.ex
+++ b/packages/sync-service/lib/electric/replication/log_offset.ex
@@ -102,7 +102,7 @@ defmodule Electric.Replication.LogOffset do
 
   defguard is_min_offset(offset) when offset.tx_offset == -1
 
-  defguard is_snapshot_offset(offset) when offset.tx_offset == 0
+  defguard is_virtual_offset(offset) when offset.tx_offset == 0
 
   @doc """
   An offset that is smaller than all offsets in the log.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -97,7 +97,7 @@ defmodule Electric.ShapeCache do
 
   @impl Electric.ShapeCacheBehaviour
   def get_shape(shape, opts \\ []) do
-    table = get_shape_meta_table(opts |> dbg)
+    table = get_shape_meta_table(opts)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
     shape_status.get_existing_shape(table, shape)
   end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -60,8 +60,8 @@ defmodule Electric.ShapeCache do
             ],
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
-              type: {:fun, 6},
-              default: &Shapes.Consumer.Snapshotter.query_in_readonly_txn/6
+              type: {:fun, 7},
+              default: &Shapes.Consumer.Snapshotter.query_in_readonly_txn/7
             ],
             purge_all_shapes?: [type: :boolean, required: false]
           )
@@ -97,7 +97,7 @@ defmodule Electric.ShapeCache do
 
   @impl Electric.ShapeCacheBehaviour
   def get_shape(shape, opts \\ []) do
-    table = get_shape_meta_table(opts)
+    table = get_shape_meta_table(opts |> dbg)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
     shape_status.get_existing_shape(table, shape)
   end

--- a/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
@@ -17,7 +17,6 @@ defmodule Electric.ShapeCache.CrashingFileStorage do
   defdelegate get_current_position(opts), to: FileStorage
   defdelegate set_snapshot_xmin(xmin, opts), to: FileStorage
   defdelegate snapshot_started?(opts), to: FileStorage
-  defdelegate get_snapshot(opts), to: FileStorage
   defdelegate make_new_snapshot!(data_stream, opts), to: FileStorage
   defdelegate mark_snapshot_as_started(opts), to: FileStorage
   defdelegate get_log_stream(offset, max_offset, opts), to: FileStorage

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -479,7 +479,7 @@ defmodule Electric.ShapeCache.FileStorage do
     do: snapshot_offset(0)
 
   # If the current offset is one of the "real" chunks, then next chunk is the boundary
-  def get_chunk_end_log_offset(offset, %FS{} = opts) when is_snapshot_offset(offset) do
+  def get_chunk_end_log_offset(offset, %FS{} = opts) when is_virtual_offset(offset) do
     case get_last_snapshot_offset(%FS{} = opts) do
       # We don't have the "last one", so optimistically give the next chunk pointer.
       # If it turns out we're actually done, then this pointer will give beginning of txn log when requested with.

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -3,6 +3,7 @@ defmodule Electric.ShapeCache.FileStorage do
 
   alias Electric.Telemetry.OpenTelemetry
   alias Electric.Replication.LogOffset
+  alias Electric.ShapeCache.LogChunker
   alias __MODULE__, as: FS
 
   # If the storage format changes, increase `@version` to prevent
@@ -196,6 +197,7 @@ defmodule Electric.ShapeCache.FileStorage do
         offset(key)
 
       _ ->
+        # FIXME: Should use actual on-disk offset
         LogOffset.first()
     end
   end

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -309,6 +309,7 @@ defmodule Electric.ShapeCache.FileStorage do
       shape_handle: opts.shape_handle,
       stack_id: opts.stack_id
     )
+
     File.open!(snapshot_chunk_path(opts, chunk_number), [:write, :raw])
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -3,6 +3,7 @@ defmodule Electric.ShapeCache.FileStorage do
 
   alias Electric.Telemetry.OpenTelemetry
   alias Electric.Replication.LogOffset
+  import Electric.Replication.LogOffset, only: :macros
   alias Electric.ShapeCache.LogChunker
   alias __MODULE__, as: FS
 
@@ -101,7 +102,19 @@ defmodule Electric.ShapeCache.FileStorage do
       cleanup_internals!(opts)
     end
 
+    if File.exists?(old_snapshot_path(opts)) do
+      # This shape has had the snapshot written before we started using the new format.
+      # We need to move the old snapshot into the new format and store correct metadata
+      # so that we know it's complete.
+      File.rename(old_snapshot_path(opts), snapshot_chunk_path(opts, 0))
+      CubDB.put(opts.db, @snapshot_meta_key, LogOffset.new(0, 0))
+    end
+
     CubDB.put(opts.db, @version_key, @version)
+  end
+
+  defp old_snapshot_path(opts) do
+    Path.join([opts.snapshot_dir, "snapshot.jsonl"])
   end
 
   @impl Electric.ShapeCache.Storage
@@ -163,13 +176,20 @@ defmodule Electric.ShapeCache.FileStorage do
         |> Enum.map(&for_shape(&1, opts))
         |> Enum.map(fn fs ->
           maybe_get_size(shape_definition_path(fs)) +
-            maybe_get_size(shape_snapshot_path(fs)) +
+            get_all_chunk_sizes(fs) +
             maybe_get_size(CubDB.current_db_file(fs.db))
         end)
         |> Enum.sum()
 
       _ ->
         0
+    end
+  end
+
+  defp get_all_chunk_sizes(%FS{} = opts) do
+    case File.ls(opts.snapshot_dir) do
+      {:ok, chunk_files} -> chunk_files |> Enum.map(&maybe_get_size/1) |> Enum.sum()
+      _ -> 0
     end
   end
 
@@ -186,6 +206,17 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   defp latest_offset(opts) do
+    with nil <- get_latest_txn_log_offset(opts),
+         nil <- get_last_snapshot_offset(opts) do
+      # We're returning this very fake offset here due to our system's limitation: for ongoing log, we read "latest offset"
+      # from an ETS table in the shape cache, that's updated by the consumer as it consumes the log. I don't want to introduce
+      # any responsibility to chat to the consumer into the storage, so this gives the logic in the plug a good reference point
+      # to compare snapshot offsets to. They are always going to be smaller than this, so we will be able to go through the chunks.
+      LogOffset.last_before_real_offsets()
+    end
+  end
+
+  defp get_latest_txn_log_offset(opts) do
     case CubDB.select(opts.db,
            min_key: log_start(),
            max_key: log_end(),
@@ -193,12 +224,8 @@ defmodule Electric.ShapeCache.FileStorage do
            reverse: true
          )
          |> Enum.take(1) do
-      [{key, _}] ->
-        offset(key)
-
-      _ ->
-        # FIXME: Should use actual on-disk offset
-        LogOffset.first()
+      [{key, _}] -> offset(key)
+      _ -> nil
     end
   end
 
@@ -241,7 +268,7 @@ defmodule Electric.ShapeCache.FileStorage do
   defp write_stream_to_chunk_files(data_stream, opts) do
     data_stream
     |> Stream.transform(
-      {0, nil},
+      fn -> {0, nil} end,
       fn line, {chunk_num, file} ->
         file = file || File.open!(snapshot_chunk_path(opts, chunk_num), [:write, :raw])
 
@@ -260,7 +287,10 @@ defmodule Electric.ShapeCache.FileStorage do
         end
       end,
       fn {_chunk_num, file} ->
-        if file, do: File.close(file)
+        if file do
+          IO.binwrite(file, <<4::utf8>>)
+          File.close(file)
+        end
       end
     )
     |> Enum.reduce(0, fn chunk_num, _ -> chunk_num end)
@@ -268,7 +298,7 @@ defmodule Electric.ShapeCache.FileStorage do
 
   defp snapshot_chunk_path(opts, chunk_number)
        when is_integer(chunk_number) and chunk_number >= 0 do
-    Path.join([opts.snapshot_dir, "#{chunk_number}.snapshot_chunk.jsonl"])
+    Path.join([opts.snapshot_dir, "snapshot_chunk.#{chunk_number}.jsonl"])
   end
 
   @impl Electric.ShapeCache.Storage
@@ -354,16 +384,92 @@ defmodule Electric.ShapeCache.FileStorage do
         %FS{} = opts
       )
       when tx_offset <= 0 do
-    # If snapshot wasn't even started, return an error
-    # If snapshot is complete, as indicated by presence of `@snapshot_meta_key` in CubDB, then see how the `op_offset` compares to the one stored under that key:
-    #   If `tx_offset` == -1, then open then open the file with name `snapshot_chunk_path(opts, 0)`
-    #   If `op_offset` >= the stored one, then stream from CubDB log, as we're done streaming the snapshot
-    #   If `op_offset` < the stored one, then open the file with name `snapshot_chunk_path(opts, op_offset + 1)`
-    # If previous step opened a file, then stream out it's contents line by line until `<<4::utf8>>` byte is encountered
+    unless snapshot_started?(opts), do: raise("Snapshot not started")
+
+    case {CubDB.get(opts.db, @snapshot_meta_key), offset} do
+      # Snapshot is complete
+      {%LogOffset{}, offset} when is_min_offset(offset) ->
+        # Stream first chunk of snapshot
+        stream_snapshot_chunk!(opts, 0)
+
+      {%LogOffset{} = latest, offset} when is_log_offset_lt(offset, latest) ->
+        # Stream next chunk of snapshot
+        stream_snapshot_chunk!(opts, op_offset + 1)
+
+      {%LogOffset{}, offset} ->
+        stream_log_chunk(offset, max_offset, opts)
+
+      # Snapshot is incomplete
+      {nil, offset} when is_min_offset(offset) ->
+        stream_snapshot_chunk!(opts, 0)
+
+      {nil, _offset} ->
+        # Try streaming the next chunk if the file already exists, otherwise wait for the file or end of snapshot to be announced
+        # where either event should happen shortly, we just either hit a file switch or just before CubDB was updatred
+        wait_for_chunk_file_or_snapshot_end(opts, op_offset + 1)
+    end
   end
 
-  # Any offsets with tx offset > 0 are not part of the initial snapshot.
-  def get_log_stream(%LogOffset{} = offset, max_offset, %FS{} = opts) do
+  # Any offsets with tx offset > 0 are not part of the initial snapshot, no need for additional checks.
+  def get_log_stream(%LogOffset{} = offset, max_offset, %FS{} = opts),
+    do: stream_log_chunk(offset, max_offset, opts)
+
+  # This function raises if the chunk file doesn't exist.
+  defp stream_snapshot_chunk!(%FS{} = opts, chunk_number) do
+    Stream.resource(
+      fn -> {open_snapshot_chunk(opts, chunk_number), nil} end,
+      fn {file, eof_seen} ->
+        case IO.binread(file, :line) do
+          {:error, reason} ->
+            raise IO.StreamError, reason: reason
+
+          :eof ->
+            cond do
+              is_nil(eof_seen) ->
+                # First time we see eof after any valid lines, we store a timestamp
+                {[], {file, System.monotonic_time(:millisecond)}}
+
+              # If it's been 60s without any new lines, and also we've not seen <<4>>,
+              # then likely something is wrong
+              System.monotonic_time(:millisecond) - eof_seen > 60_000 ->
+                raise "Snapshot hasn't updated in 60s"
+
+              true ->
+                # Sleep a little and check for new lines
+                Process.sleep(20)
+                {[], {file, eof_seen}}
+            end
+
+          # The 4 byte marker (ASCII "end of transmission") indicates the end of the snapshot file.
+          <<4::utf8>> ->
+            {:halt, {file, nil}}
+
+          line ->
+            {[line], {file, nil}}
+        end
+      end,
+      fn {file, _} -> File.close(file) end
+    )
+  end
+
+  defp open_snapshot_chunk(opts, chunk_num, attempts_left \\ 100)
+  defp open_snapshot_chunk(_, _, 0), do: raise(IO.StreamError, reason: :enoent)
+
+  defp open_snapshot_chunk(opts, chunk_num, attempts_left) do
+    case File.open(snapshot_chunk_path(opts, chunk_num), [:read, :raw, read_ahead: 1024]) do
+      {:ok, file} ->
+        file
+
+      {:error, :enoent} ->
+        Process.sleep(10)
+        open_snapshot_chunk(opts, chunk_num, attempts_left - 1)
+
+      {:error, reason} ->
+        raise IO.StreamError, reason: reason
+    end
+  end
+
+  defp stream_log_chunk(%LogOffset{} = offset, max_offset, %FS{} = opts) do
     opts.db
     |> CubDB.select(
       min_key: log_key(offset),
@@ -373,8 +479,65 @@ defmodule Electric.ShapeCache.FileStorage do
     |> Stream.map(fn {_, item} -> item end)
   end
 
+  defp wait_for_chunk_file_or_snapshot_end(
+         opts,
+         chunk_number,
+         max_wait_time \\ 60_000,
+         total_wait_time \\ 0
+       )
+
+  defp wait_for_chunk_file_or_snapshot_end(_, _, max, total) when total >= max,
+    do: raise("Snapshot hasn't updated in #{max}ms")
+
+  defp wait_for_chunk_file_or_snapshot_end(
+         %FS{} = opts,
+         chunk_number,
+         max_wait_time,
+         total_wait_time
+       ) do
+    path = snapshot_chunk_path(opts, chunk_number)
+
+    cond do
+      File.exists?(path, [:raw]) ->
+        stream_snapshot_chunk!(opts, chunk_number)
+
+      CubDB.has_key?(opts.db, @snapshot_meta_key) ->
+        []
+
+      true ->
+        Process.sleep(50)
+
+        wait_for_chunk_file_or_snapshot_end(
+          opts,
+          chunk_number,
+          max_wait_time,
+          total_wait_time + 50
+        )
+    end
+  end
+
   @impl Electric.ShapeCache.Storage
-  def get_chunk_end_log_offset(offset, %FS{} = opts) do
+  # If min offset was requested, then next chunk boundary is first snapshot chunk
+  def get_chunk_end_log_offset(offset, _) when is_min_offset(offset),
+    do: snapshot_offset(0)
+
+  # If the current offset is one of the "real" chunks, then next chunk is the boundary
+  def get_chunk_end_log_offset(offset, %FS{} = opts) when is_snapshot_offset(offset) do
+    case get_last_snapshot_offset(%FS{} = opts) do
+      # We don't have the "last one", so optimistically give the next chunk pointer.
+      # If it turns out we're actually done, then this pointer will give beginning of txn log when requested with.
+      nil -> LogOffset.increment(offset)
+      # This is easy - we want to read next chunk and we know we can
+      last when is_log_offset_lt(offset, last) -> LogOffset.increment(offset)
+      # Requested chunk is at the end or beyond the end of the snapshot, serve from txn log. If no chunk is yet present, get end of log
+      _ -> get_chunk_end_for_log(offset, opts)
+    end
+  end
+
+  # Current offset is in txn log, serve from there.
+  def get_chunk_end_log_offset(offset, %FS{} = opts), do: get_chunk_end_for_log(offset, opts)
+
+  defp get_chunk_end_for_log(offset, %FS{} = opts) do
     CubDB.select(opts.db,
       min_key: chunk_checkpoint_key(offset),
       max_key: chunk_checkpoint_end(),
@@ -383,6 +546,10 @@ defmodule Electric.ShapeCache.FileStorage do
     |> Stream.map(fn {key, _} -> offset(key) end)
     |> Enum.take(1)
     |> Enum.at(0)
+  end
+
+  defp get_last_snapshot_offset(%FS{} = opts) do
+    CubDB.get(opts.db, @snapshot_meta_key)
   end
 
   defp cleanup_internals!(%FS{} = opts) do
@@ -395,7 +562,7 @@ defmodule Electric.ShapeCache.FileStorage do
     |> Enum.concat(keys_from_range(chunk_checkpoint_start(), chunk_checkpoint_end(), opts))
     |> then(&CubDB.delete_multi(opts.db, &1))
 
-    {:ok, _} = File.rm_rf(shape_snapshot_path(opts))
+    {:ok, _} = File.rm_rf(opts.snapshot_dir)
 
     {:ok, _} = File.rm_rf(shape_definition_path(opts))
 
@@ -423,13 +590,11 @@ defmodule Electric.ShapeCache.FileStorage do
     |> Stream.map(&elem(&1, 0))
   end
 
-  defp shape_snapshot_path(opts) do
-    Path.join([opts.snapshot_dir, "snapshot.jsonl"])
-  end
-
   defp stored_version(opts) do
     CubDB.get(opts.db, @version_key)
   end
+
+  defp snapshot_offset(chunk_number), do: LogOffset.new(0, chunk_number)
 
   # Key helpers
   defp log_key(offset), do: {:log, LogOffset.to_tuple(offset)}

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -2,6 +2,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   use Agent
   alias Electric.ConcurrentStream
   alias Electric.Replication.LogOffset
+  import Electric.Replication.LogOffset, only: :macros
   alias Electric.Telemetry.OpenTelemetry
 
   alias __MODULE__, as: MS
@@ -99,7 +100,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   end
 
   defp current_offset(_opts) do
-    LogOffset.first()
+    LogOffset.last_before_real_offsets()
   end
 
   @impl Electric.ShapeCache.Storage
@@ -138,34 +139,42 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     end
   end
 
-  defp snapshot_key(index) do
-    {:data, index}
+  defp snapshot_key(chunk_key, index) do
+    {chunk_key, index}
   end
 
-  defp snapshot_start, do: snapshot_key(@snapshot_start_index)
-  defp snapshot_end, do: snapshot_key(@snapshot_end_index)
+  defp snapshot_chunk_start(chunk_key), do: snapshot_key(chunk_key, @snapshot_start_index)
+  defp snapshot_chunk_end(chunk_key), do: snapshot_key(chunk_key, @snapshot_end_index)
 
-  @impl Electric.ShapeCache.Storage
-  def get_snapshot(%MS{} = opts) do
-    stream =
-      ConcurrentStream.stream_to_end(
-        excluded_start_key: @snapshot_start_index,
-        end_marker_key: @snapshot_end_index,
-        poll_time_in_ms: 10,
-        stream_fun: fn excluded_start_key, included_end_key ->
-          if !snapshot_started?(opts), do: raise("Snapshot no longer available")
+  defp snapshot_start(), do: snapshot_chunk_start(storage_offset(LogOffset.before_all()))
 
-          :ets.select(opts.snapshot_table, [
-            {{snapshot_key(:"$1"), :"$2"},
-             [{:andalso, {:>, :"$1", excluded_start_key}, {:"=<", :"$1", included_end_key}}],
-             [{{:"$1", :"$2"}}]}
-          ])
-        end
-      )
-      |> Stream.map(fn {_, item} -> item end)
+  defp snapshot_end(),
+    do: snapshot_chunk_end(storage_offset(LogOffset.last_before_real_offsets()))
 
-    {@snapshot_offset, stream}
-  end
+  # defp snapshot_start, do: snapshot_key(@snapshot_start_index)
+  # defp snapshot_end, do: snapshot_key(@snapshot_end_index)
+
+  # @impl Electric.ShapeCache.Storage
+  # def get_snapshot(%MS{} = opts) do
+  #   stream =
+  #     ConcurrentStream.stream_to_end(
+  #       excluded_start_key: @snapshot_start_index,
+  #       end_marker_key: @snapshot_end_index,
+  #       poll_time_in_ms: 10,
+  #       stream_fun: fn excluded_start_key, included_end_key ->
+  #         if !snapshot_started?(opts), do: raise("Snapshot no longer available")
+
+  #         :ets.select(opts.snapshot_table, [
+  #           {{snapshot_key(:"$1"), :"$2"},
+  #            [{:andalso, {:>, :"$1", excluded_start_key}, {:"=<", :"$1", included_end_key}}],
+  #            [{{:"$1", :"$2"}}]}
+  #         ])
+  #       end
+  #     )
+  #     |> Stream.map(fn {_, item} -> item end)
+
+  #   {@snapshot_offset, stream}
+  # end
 
   defp get_offset_indexed_stream(offset, max_offset, offset_indexed_table) do
     offset = storage_offset(offset)
@@ -185,12 +194,52 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     end)
   end
 
+  @snapshot_boundary_offset LogOffset.last_before_real_offsets()
   @impl Electric.ShapeCache.Storage
+  def get_log_stream(offset, max_offset, %MS{} = opts)
+      when is_log_offset_lt(offset, @snapshot_boundary_offset) do
+    case :ets.lookup_element(opts.snapshot_table, snapshot_end(), 2, nil) do
+      nil -> stream_from_snapshot(offset, max_offset, opts)
+      max when is_log_offset_lt(offset, max) -> stream_from_snapshot(offset, max_offset, opts)
+      _ -> get_offset_indexed_stream(offset, max_offset, opts.log_table)
+    end
+  end
+
   def get_log_stream(offset, max_offset, %MS{} = opts) do
     get_offset_indexed_stream(offset, max_offset, opts.log_table)
   end
 
+  defp stream_from_snapshot(offset, max_offset, %MS{} = opts) do
+    ConcurrentStream.stream_to_end(
+      excluded_start_key: snapshot_chunk_end(storage_offset(offset)),
+      end_marker_key: snapshot_chunk_end(storage_offset(max_offset)),
+      poll_time_in_ms: 10,
+      stream_fun: fn excluded_start_key, included_end_key ->
+        dbg(excluded_start_key)
+        dbg(included_end_key)
+        if !snapshot_started?(opts), do: raise("Snapshot no longer available")
+
+        :ets.select(
+          opts.snapshot_table,
+          [
+            {{:"$1", :"$2"},
+             [
+               {:andalso, {:>, :"$1", {:const, excluded_start_key}},
+                {:"=<", :"$1", {:const, included_end_key}}}
+             ], [{{:"$1", :"$2"}}]}
+          ]
+          |> dbg()
+        )
+      end
+    )
+    |> Stream.map(fn {_, item} -> item end)
+    |> Stream.reject(&is_nil/1)
+  end
+
   @impl Electric.ShapeCache.Storage
+  def get_chunk_end_log_offset(offset, _) when is_min_offset(offset),
+    do: LogOffset.first()
+
   def get_chunk_end_log_offset(offset, %MS{} = opts) do
     case :ets.next_lookup(opts.chunk_checkpoint_table, storage_offset(offset)) do
       :"$end_of_table" ->
@@ -209,15 +258,44 @@ defmodule Electric.ShapeCache.InMemoryStorage do
       stack_id,
       fn ->
         table = opts.snapshot_table
+        chunk_checkpoint_table = opts.chunk_checkpoint_table
 
         data_stream
         |> Stream.with_index(1)
-        |> Stream.map(fn {log_item, index} -> {snapshot_key(index), log_item} end)
-        |> Stream.chunk_every(500)
-        |> Stream.each(fn chunk -> :ets.insert(table, chunk) end)
-        |> Stream.run()
+        |> Stream.transform(
+          fn -> 0 end,
+          fn
+            {:chunk_boundary, _}, chunk_num ->
+              chunk_offset = storage_offset(LogOffset.new(0, chunk_num))
 
-        :ets.insert(table, {snapshot_end(), 0})
+              {[
+                 {chunk_offset, :snapshot_checkpoint},
+                 {snapshot_chunk_end(chunk_offset), nil}
+               ], chunk_num + 1}
+
+            {line, index}, chunk_num ->
+              chunk_offset = storage_offset(LogOffset.new(0, chunk_num))
+              {[{snapshot_key(chunk_offset, index), line}], chunk_num}
+          end,
+          fn chunk_num ->
+            chunk_offset = storage_offset(LogOffset.new(0, chunk_num))
+
+            {[{chunk_offset, :snapshot_checkpoint}, {snapshot_chunk_end(chunk_offset), nil}],
+             chunk_num}
+          end,
+          fn _ -> nil end
+        )
+        |> Stream.chunk_every(500)
+        |> Stream.flat_map(fn chunk ->
+          {checkpoints, data} = Enum.split_with(chunk, &match?({_, :snapshot_checkpoint}, &1))
+
+          :ets.insert(chunk_checkpoint_table, checkpoints)
+          :ets.insert(table, data)
+          Enum.map(checkpoints, &elem(&1, 0))
+        end)
+        |> Enum.max()
+        |> then(fn max_chunk -> :ets.insert(table, {snapshot_end(), LogOffset.new(max_chunk)}) end)
+
         :ok
       end
     )

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -205,7 +205,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     ])
   end
 
-  def latest_offset!(%__MODULE__{shape_meta_table: table} = state, shape_handle) do
+  def latest_offset!(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
     latest_offset(table, shape_handle)
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -92,9 +92,10 @@ defmodule Electric.ShapeCache.ShapeStatus do
   @spec add_shape(t(), Shape.t()) :: {:ok, shape_handle()} | {:error, term()}
   def add_shape(state, shape) do
     {hash, shape_handle} = Shape.generate_id(shape)
-    # fresh snapshots always start with a zero offset - only once they
-    # are folded into the log do we have non-zero offsets
-    offset = %LogOffset{LogOffset.last() | tx_offset: 0}
+    # For fresh snapshots we're setting "latest" offset to be a highest possible virtual offset,
+    # which is needed because while the snapshot is being made we DON'T update this ETS table.
+    # We could, but that would required making the Storage know about this module and I don't like that.
+    offset = LogOffset.last_before_real_offsets()
 
     true =
       :ets.insert_new(

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -94,7 +94,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     {hash, shape_handle} = Shape.generate_id(shape)
     # fresh snapshots always start with a zero offset - only once they
     # are folded into the log do we have non-zero offsets
-    offset = LogOffset.first()
+    offset = %LogOffset{LogOffset.last() | tx_offset: 0}
 
     true =
       :ets.insert_new(
@@ -205,7 +205,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     ])
   end
 
-  def latest_offset!(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
+  def latest_offset!(%__MODULE__{shape_meta_table: table} = state, shape_handle) do
     latest_offset(table, shape_handle)
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -54,9 +54,6 @@ defmodule Electric.ShapeCache.Storage do
   @doc "Check if snapshot for a given shape handle already exists"
   @callback snapshot_started?(shape_opts()) :: boolean()
 
-  @doc "Get the full snapshot for a given shape, also returning the offset this snapshot includes"
-  @callback get_snapshot(shape_opts()) :: {offset :: LogOffset.t(), log()}
-
   @doc """
   Make a new snapshot for a shape handle based on the meta information about the table and a stream of plain string rows
 
@@ -165,11 +162,6 @@ defmodule Electric.ShapeCache.Storage do
   @impl __MODULE__
   def snapshot_started?({mod, shape_opts}) do
     mod.snapshot_started?(shape_opts)
-  end
-
-  @impl __MODULE__
-  def get_snapshot({mod, shape_opts}) do
-    mod.get_snapshot(shape_opts)
   end
 
   @impl __MODULE__

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -8,21 +8,8 @@ defmodule Electric.Shapes do
   @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
 
   @doc """
-  Get snapshot for the shape handle
+  Get the snapshot followed by the log.
   """
-  def get_snapshot(config, shape_handle) do
-    {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
-    storage = shape_storage(config, shape_handle)
-
-    if shape_cache.has_shape?(shape_handle, opts) do
-      with :started <- shape_cache.await_snapshot_start(shape_handle, opts) do
-        {:ok, Storage.get_snapshot(storage)}
-      end
-    else
-      {:error, "invalid shape_handle #{inspect(shape_handle)}"}
-    end
-  end
-
   def get_merged_log_stream(config, shape_handle, opts) do
     {shape_cache, shape_cache_opts} = Access.get(config, :shape_cache, {ShapeCache, []})
     storage = shape_storage(config, shape_handle)
@@ -33,22 +20,6 @@ defmodule Electric.Shapes do
       with :started <- shape_cache.await_snapshot_start(shape_handle, shape_cache_opts) do
         Storage.get_log_stream(offset, max_offset, storage)
       end
-    else
-      raise "Unknown shape: #{shape_handle}"
-    end
-  end
-
-  @doc """
-  Get stream of the log since a given offset
-  """
-  def get_log_stream(config, shape_handle, opts) do
-    {shape_cache, shape_cache_opts} = Access.get(config, :shape_cache, {ShapeCache, []})
-    offset = Access.get(opts, :since, LogOffset.before_all())
-    max_offset = Access.get(opts, :up_to, LogOffset.last())
-    storage = shape_storage(config, shape_handle)
-
-    if shape_cache.has_shape?(shape_handle, shape_cache_opts) do
-      Storage.get_log_stream(offset, max_offset, storage)
     else
       raise "Unknown shape: #{shape_handle}"
     end

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -42,7 +42,7 @@ defmodule Electric.Shapes do
   def get_or_create_shape_handle(config, shape_def) do
     {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
 
-    shape_cache.get_or_create_shape_handle(shape_def, opts) |> dbg
+    shape_cache.get_or_create_shape_handle(shape_def, opts)
   end
 
   @doc """

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -49,7 +49,8 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
             run_with_conn_fn: run_with_conn_fn,
             create_snapshot_fn: create_snapshot_fn,
             prepare_tables_fn: prepare_tables_fn_or_mfa,
-            stack_id: stack_id
+            stack_id: stack_id,
+            chunk_bytes_threshold: chunk_bytes_threshold
           } = state
 
           affected_tables = Shape.affected_tables(shape)
@@ -83,7 +84,8 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
                       shape,
                       pool_conn,
                       storage,
-                      stack_id
+                      stack_id,
+                      chunk_bytes_threshold
                     ])
                   end
                 ])
@@ -125,7 +127,15 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
   end
 
   @doc false
-  def query_in_readonly_txn(parent, shape_handle, shape, db_pool, storage, stack_id) do
+  def query_in_readonly_txn(
+        parent,
+        shape_handle,
+        shape,
+        db_pool,
+        storage,
+        stack_id,
+        chunk_bytes_threshold
+      ) do
     shape_attrs = shape_attrs(shape_handle, shape)
 
     Postgrex.transaction(
@@ -168,7 +178,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
               end
             )
 
-            stream = Querying.stream_initial_data(conn, stack_id, shape)
+            stream = Querying.stream_initial_data(conn, stack_id, shape, chunk_bytes_threshold)
 
             GenServer.cast(parent, {:snapshot_started, shape_handle})
 

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -21,8 +21,8 @@ defmodule Electric.Shapes.ConsumerSupervisor do
             db_pool: [type: {:or, [:atom, :pid, @name_schema_tuple]}, required: true],
             prepare_tables_fn: [type: {:or, [:mfa, {:fun, 2}]}, required: true],
             create_snapshot_fn: [
-              type: {:fun, 6},
-              default: &Electric.Shapes.Consumer.Snapshotter.query_in_readonly_txn/6
+              type: {:fun, 7},
+              default: &Electric.Shapes.Consumer.Snapshotter.query_in_readonly_txn/7
             ]
           )
 

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -18,7 +18,7 @@ defmodule Electric.Shapes.Querying do
         conn,
         stack_id,
         %Shape{root_table: root_table} = shape,
-        chunk_bytes_threshold
+        chunk_bytes_threshold \\ LogChunker.default_chunk_size_threshold()
       ) do
     OpenTelemetry.with_span("shape_read.stream_initial_data", [], stack_id, fn ->
       table = Utils.relation_to_sql(root_table)

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -44,7 +44,7 @@ defmodule Electric.Shapes.Querying do
             {[line], new_chunk_size}
 
           {:threshold_exceeded, new_chunk_size} ->
-            {[:chunk_boundary, line], new_chunk_size}
+            {[line, :chunk_boundary], new_chunk_size}
         end
       end)
     end)

--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -116,8 +116,8 @@ defmodule Electric.MixProject do
     [
       start_dev: "cmd --cd dev docker compose up -d",
       stop_dev: "cmd --cd dev docker compose down -v",
-      clean_persistant: "cmd rm -rf perisistent",
-      reset: "do clean_persistant, stop_dev, start_dev"
+      clean_persistent: "cmd rm -rf persistent",
+      reset: "do clean_persistent, stop_dev, start_dev"
     ]
   end
 

--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -115,7 +115,9 @@ defmodule Electric.MixProject do
   defp aliases() do
     [
       start_dev: "cmd --cd dev docker compose up -d",
-      stop_dev: "cmd --cd dev docker compose down -v"
+      stop_dev: "cmd --cd dev docker compose down -v",
+      clean_persistant: "cmd rm -rf perisistent",
+      reset: "do clean_persistant, stop_dev, start_dev"
     ]
   end
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -206,12 +206,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
-        next_offset
+        @first_offset
       end)
-      |> expect(:get_snapshot, fn @test_opts ->
-        {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
-      end)
-      |> expect(:get_log_stream, fn @first_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @before_all_offset, @first_offset, @test_opts ->
         [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
@@ -223,7 +220,6 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert conn.status == 200
 
       assert Jason.decode!(conn.resp_body) == [
-               %{"key" => "snapshot"},
                %{
                  "key" => "log",
                  "value" => "foo",
@@ -233,7 +229,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert Plug.Conn.get_resp_header(conn, "etag") == [
-               "#{@test_shape_handle}:-1:#{next_offset}"
+               "#{@test_shape_handle}:-1:#{@first_offset}"
              ]
 
       assert Plug.Conn.get_resp_header(conn, "electric-handle") == [@test_shape_handle]
@@ -254,10 +250,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
-      |> expect(:get_snapshot, fn @test_opts ->
-        {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
-      end)
-      |> expect(:get_log_stream, fn @first_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @before_all_offset, _, @test_opts ->
         [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
@@ -296,10 +289,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
-      |> expect(:get_snapshot, fn @test_opts ->
-        {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
-      end)
-      |> expect(:get_log_stream, fn @first_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @before_all_offset, _, @test_opts ->
         [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
@@ -319,6 +309,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         {@test_shape_handle, @test_offset}
       end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
       next_offset = LogOffset.increment(@start_offset_50)
       next_next_offset = LogOffset.increment(next_offset)
@@ -432,6 +423,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         {@test_shape_handle, @test_offset}
       end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
       test_pid = self()
       next_offset = LogOffset.increment(@test_offset)
@@ -495,6 +487,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         {@test_shape_handle, @test_offset}
       end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
       test_pid = self()
 
@@ -545,6 +538,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         {@test_shape_handle, @test_offset}
       end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
@@ -712,10 +706,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       |> expect(:get_chunk_end_log_offset, fn @before_all_offset, _ ->
         next_offset
       end)
-      |> expect(:get_snapshot, fn @test_opts ->
-        {@first_offset, [Jason.encode!(%{key: "snapshot"})]}
-      end)
-      |> expect(:get_log_stream, fn @first_offset, _, @test_opts ->
+      |> expect(:get_log_stream, fn @before_all_offset, _, @test_opts ->
         [Jason.encode!(%{key: "log", value: "foo", headers: %{}, offset: next_offset})]
       end)
 
@@ -727,7 +718,6 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert conn.status == 200
 
       assert Jason.decode!(conn.resp_body) == [
-               %{"key" => "snapshot"},
                %{
                  "key" => "log",
                  "value" => "foo",

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -145,7 +145,10 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
   test "latest_offset", ctx do
     {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape!()])
     assert :error = ShapeStatus.latest_offset(state, "sdfsodf")
-    assert ShapeStatus.latest_offset(state, shape_handle) == {:ok, LogOffset.first()}
+
+    assert ShapeStatus.latest_offset(state, shape_handle) ==
+             {:ok, LogOffset.last_before_real_offsets()}
+
     offset = LogOffset.new(100, 3)
     assert ShapeStatus.set_latest_offset(state, shape_handle, offset)
     refute ShapeStatus.set_latest_offset(state, "not my shape", offset)
@@ -156,7 +159,10 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     table_name = table_name()
     {:ok, _state, [shape_handle]} = new_state(ctx, table: table_name, shapes: [shape!()])
     assert :error = ShapeStatus.latest_offset(table_name, "sdfsodf")
-    assert ShapeStatus.latest_offset(table_name, shape_handle) == {:ok, LogOffset.first()}
+
+    assert ShapeStatus.latest_offset(table_name, shape_handle) ==
+             {:ok, LogOffset.last_before_real_offsets()}
+
     offset = LogOffset.new(100, 3)
     refute ShapeStatus.set_latest_offset(table_name, "not my shape", offset)
     assert ShapeStatus.set_latest_offset(table_name, shape_handle, offset)

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -17,7 +17,6 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.stub(:for_shape, fn ^shape_handle, :opts -> {shape_handle, :opts} end)
     |> Mox.expect(:make_new_snapshot!, fn _, {^shape_handle, :opts} -> :ok end)
     |> Mox.expect(:snapshot_started?, fn {^shape_handle, :opts} -> true end)
-    |> Mox.expect(:get_snapshot, fn {^shape_handle, :opts} -> {1, []} end)
     |> Mox.expect(:append_to_log!, fn _, {^shape_handle, :opts} -> :ok end)
     |> Mox.expect(:get_total_disk_usage, fn :opts -> 0 end)
     |> Mox.expect(:get_log_stream, fn _, _, {^shape_handle, :opts} -> [] end)
@@ -26,7 +25,6 @@ defmodule Electric.ShapeCache.StorageTest do
 
     Storage.make_new_snapshot!([], shape_storage)
     Storage.snapshot_started?(shape_storage)
-    Storage.get_snapshot(shape_storage)
     Storage.append_to_log!([], shape_storage)
     Storage.get_log_stream(LogOffset.first(), shape_storage)
     Storage.get_total_disk_usage(storage)

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -155,6 +155,39 @@ defmodule Electric.Shapes.QueryingTest do
            ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
   end
 
+  test "splits the result into chunks according to the chunk size threshold", %{db_conn: conn} do
+    Postgrex.query!(
+      conn,
+      """
+      CREATE TABLE items (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        value TEXT
+      )
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      ~s|INSERT INTO items (value) VALUES ('1'), (NULL), ('"test\\x0001\n"')|,
+      []
+    )
+
+    shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+    assert [
+             %{key: ~S["public"."items"/"1"], value: %{value: "1"}},
+             :chunk_boundary,
+             %{key: ~S["public"."items"/"2"], value: %{value: nil}},
+             :chunk_boundary,
+             %{key: ~S["public"."items"/"3"], value: %{value: ~s["test\\x0001\n"]}},
+             :chunk_boundary
+           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape, 10))
+  end
+
   defp decode_stream(stream),
-    do: stream |> Enum.to_list() |> Enum.map(&Jason.decode!(&1, keys: :atoms))
+    do: stream |> Enum.to_list() |> Enum.map(fn
+      :chunk_boundary -> :chunk_boundary
+      json_item -> Jason.decode!(json_item, keys: :atoms)
+    end)
 end

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -186,8 +186,11 @@ defmodule Electric.Shapes.QueryingTest do
   end
 
   defp decode_stream(stream),
-    do: stream |> Enum.to_list() |> Enum.map(fn
-      :chunk_boundary -> :chunk_boundary
-      json_item -> Jason.decode!(json_item, keys: :atoms)
-    end)
+    do:
+      stream
+      |> Enum.to_list()
+      |> Enum.map(fn
+        :chunk_boundary -> :chunk_boundary
+        json_item -> Jason.decode!(json_item, keys: :atoms)
+      end)
 end

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -101,12 +101,6 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def get_snapshot({parent, shape_handle, _, storage}) do
-    send(parent, {__MODULE__, :get_snapshot, shape_handle})
-    Storage.get_snapshot(storage)
-  end
-
-  @impl Electric.ShapeCache.Storage
   def get_log_stream(offset, max_offset, {parent, shape_handle, _, storage}) do
     send(parent, {__MODULE__, :get_log_stream, shape_handle, offset, max_offset})
     Storage.get_log_stream(offset, max_offset, storage)

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -1,7 +1,7 @@
 import { parse } from 'cache-control-parser'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { v4 as uuidv4 } from 'uuid'
-import { describe, expect, inject, vi } from 'vitest'
+import { assert, describe, expect, inject, vi } from 'vitest'
 import { FetchError, Shape, ShapeStream } from '../src'
 import { Message, Offset } from '../src/types'
 import { isChangeMessage, isUpToDateMessage } from '../src/helpers'
@@ -307,10 +307,9 @@ describe(`HTTP Sync`, () => {
         ]
       )
 
-      await vi.waitFor(async () => {
-        await sleep(100)
-        return client.isUpToDate
-      })
+      await vi.waitFor(() =>
+        assert(client.isUpToDate && !client.lastOffset.startsWith('0_'))
+      )
       const updatedData = await client.rows
 
       expect(updatedData).toMatchObject([
@@ -528,10 +527,7 @@ describe(`HTTP Sync`, () => {
     )
 
     // And wait until it's definitely seen
-    await vi.waitFor(async () => {
-      await sleep(50)
-      return issueStream.isUpToDate
-    })
+    await sleep(100)
 
     let catchupOpsCount = 0
     const newAborter = new AbortController()
@@ -557,9 +553,7 @@ describe(`HTTP Sync`, () => {
     expect(catchupOpsCount).toBe(9)
   })
 
-  // This test doesn't work anymore because server sends initial snapshot as a complete
-  // stable chunk, so e-tag is the same between requests.
-  it.skip(`should return correct caching headers`, async ({
+  it(`should return correct caching headers`, async ({
     issuesTableUrl,
     insertIssues,
   }) => {
@@ -596,17 +590,24 @@ describe(`HTTP Sync`, () => {
     )
     const etag2Header = res2.headers.get(`etag`)
     expect(etag2Header, `Response should have etag header`).not.toEqual(null)
-    expect(etagHeader).not.toEqual(etag2Header)
+    expect(etagHeader).toEqual(etag2Header)
+
+    // Second chunk is not yet full, so no e-tag yet
+    const res3 = await fetch(
+      `${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=${res2.headers.get(`electric-offset`)}&handle=${res2.headers.get(`electric-handle`)}`
+    )
+    const etag3Header = res3.headers.get(`etag`)
+    expect(etag3Header, `Response should have etag header`).not.toEqual(null)
+    expect(etagHeader).not.toEqual(etag3Header)
   })
 
-  // This test doesn't work anymore because server sends initial snapshot as a complete
-  // stable chunk, so e-tag is the same between requests.
-  it.skip(`should revalidate etags`, async ({
-    issuesTableUrl,
-    insertIssues,
-  }) => {
+  it(`should revalidate etags`, async ({ issuesTableUrl, insertIssues }) => {
     // Start the shape
-    await fetch(`${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=-1`, {})
+    const baseRes = await fetch(
+      `${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=-1`,
+      {}
+    )
+    const handle = baseRes.headers.get(`electric-handle`)
     // Fill it up in separate transactions
     for (const i of [1, 2, 3, 4, 5, 6, 7, 8, 9]) {
       await insertIssues({ title: `foo${i}` })
@@ -615,11 +616,11 @@ describe(`HTTP Sync`, () => {
     await sleep(100)
 
     const res = await fetch(
-      `${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=-1`,
+      `${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=0_0&handle=${handle}`,
       {}
     )
     const messages = (await res.json()) as Message[]
-    expect(messages.length).toEqual(9) // 9 inserts
+    expect(messages.length).toEqual(10) // 9 inserts + up-to-date
     const midMessage = messages.slice(-6)[0]
     expect(midMessage).to.have.own.property(`offset`)
     const midOffset = (midMessage as { offset: string }).offset
@@ -628,7 +629,7 @@ describe(`HTTP Sync`, () => {
     expect(etag, `Response should have etag header`).not.toBe(null)
 
     const etagValidation = await fetch(
-      `${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=-1`,
+      `${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=0_0&handle=${handle}`,
       {
         headers: { 'If-None-Match': etag! },
       }

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -308,11 +308,8 @@ describe(`HTTP Sync`, () => {
       )
 
       await vi.waitFor(async () => {
-        const res = await fetch(
-          `${BASE_URL}/v1/shape?table=${tableUrl}&offset=-1`
-        )
-        const body = (await res.json()) as Message[]
-        expect(body.length).greaterThan(1)
+        await sleep(100)
+        return client.isUpToDate
       })
       const updatedData = await client.rows
 
@@ -532,11 +529,8 @@ describe(`HTTP Sync`, () => {
 
     // And wait until it's definitely seen
     await vi.waitFor(async () => {
-      const res = await fetch(
-        `${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=-1`
-      )
-      const body = (await res.json()) as Message[]
-      expect(body).toHaveLength(12)
+      await sleep(50)
+      return issueStream.isUpToDate
     })
 
     let catchupOpsCount = 0
@@ -563,7 +557,9 @@ describe(`HTTP Sync`, () => {
     expect(catchupOpsCount).toBe(9)
   })
 
-  it(`should return correct caching headers`, async ({
+  // This test doesn't work anymore because server sends initial snapshot as a complete
+  // stable chunk, so e-tag is the same between requests.
+  it.skip(`should return correct caching headers`, async ({
     issuesTableUrl,
     insertIssues,
   }) => {
@@ -603,7 +599,12 @@ describe(`HTTP Sync`, () => {
     expect(etagHeader).not.toEqual(etag2Header)
   })
 
-  it(`should revalidate etags`, async ({ issuesTableUrl, insertIssues }) => {
+  // This test doesn't work anymore because server sends initial snapshot as a complete
+  // stable chunk, so e-tag is the same between requests.
+  it.skip(`should revalidate etags`, async ({
+    issuesTableUrl,
+    insertIssues,
+  }) => {
     // Start the shape
     await fetch(`${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=-1`, {})
     // Fill it up in separate transactions
@@ -794,11 +795,8 @@ describe(`HTTP Sync`, () => {
 
     // And wait until it's definitely seen
     await vi.waitFor(async () => {
-      const res = await fetch(
-        `${BASE_URL}/v1/shape?table=${issuesTableUrl}&offset=-1`
-      )
-      const body = (await res.json()) as Message[]
-      expect(body.length).greaterThan(2)
+      await sleep(50)
+      return issueStream.isUpToDate
     })
 
     const responseSizes: number[] = []

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -308,7 +308,7 @@ describe(`HTTP Sync`, () => {
       )
 
       await vi.waitFor(() =>
-        assert(client.isUpToDate && !client.lastOffset.startsWith('0_'))
+        assert(client.isUpToDate && !client.lastOffset.startsWith(`0_`))
       )
       const updatedData = await client.rows
 


### PR DESCRIPTION
This PR changes the way we write snapshots to disk, the storage API to request them, and some logic around offsets.

1. The `Storage.get_snapshot/1` method is gone. It's now unified under `Storage.get_log_stream/3`, with some caveats.
2. The offsets within the snapshot rows are not updated, so now latest item on the sent log may have mismatching `offset` field to the `electric-offset` header of the same response. All our clients respect the header, and that's the only correct behaviour going forward. There is a decision to remove `offset` from our items entirely, but that's a separate PR.
3. While we're making the snapshot, we cannot know how many chunks are going to be there until we make them. Thus we allow clients to request any chunks up to `LogOffset.new(0, :infinity)`, and consider all offsets at txn 0 to be virtual pointers.
4. The `get_log_stream/3` for the snapshot section ignores the contract a little bit - you cannot request the stream to be up to an arbitrary point, it's always up to the chunk boundary, even when specified otherwise. Since we've moved to "pure" chunking behaviour, it should be enshrined in the `Storage` interface so that reading functions can act optimally and honestly. I'm hoping to address that in a separate PR
5. If the instance is started with the old snapshot already created, we update the naming and metadata to avoid recreating shapes if we can avoid it.