### PR TITLE
chore (sync service): track logged errors with Sentry

### DIFF
--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -159,6 +159,7 @@ defmodule Electric.Connection.Manager do
 
     Process.set_label({:connection_manager, opts[:stack_id]})
     Logger.metadata(stack_id: opts[:stack_id])
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
 
     connection_opts =
       opts

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -31,6 +31,7 @@ defmodule Electric.Connection.Supervisor do
   def init(opts) do
     Process.set_label({:connection_supervisor, opts[:stack_id]})
     Logger.metadata(stack_id: opts[:stack_id])
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
     Supervisor.init([{Electric.Connection.Manager, opts}], strategy: :rest_for_one)
   end
 

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -47,6 +47,7 @@ defmodule Electric.Plug.Router do
 
   def add_stack_id_to_metadata(conn, _) do
     Logger.metadata(stack_id: conn.assigns.config[:stack_id])
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: conn.assigns.config[:stack_id])
     conn
   end
 end

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -86,6 +86,7 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
 
     Process.set_label({:ets_inspector, opts.stack_id})
     Logger.metadata(stack_id: opts.stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts.stack_id)
 
     # Name needs to be an atom but we don't want to dynamically create atoms.
     # Instead, we will use the reference to the table that is returned by `:ets.new`

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -44,10 +44,13 @@ defmodule Electric.Postgres.LockConnection do
   def init(opts) do
     send(self(), :acquire_lock)
 
-    Logger.metadata(
+    metadata = [
       lock_name: Keyword.fetch!(opts, :lock_name),
       stack_id: Keyword.fetch!(opts, :stack_id)
-    )
+    ]
+
+    Logger.metadata(metadata)
+    Electric.Telemetry.Sentry.set_tags_context(metadata)
 
     {:ok,
      %State{

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -145,6 +145,7 @@ defmodule Electric.Postgres.ReplicationClient do
     Process.set_label(:replication_client)
     state = State.new(replication_opts)
     Logger.metadata(stack_id: state.stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: state.stack_id)
 
     {:ok, state}
   end

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -54,6 +54,7 @@ defmodule Electric.Replication.ShapeLogCollector do
   def init(opts) do
     Process.set_label({:shape_log_collector, opts.stack_id})
     Logger.metadata(stack_id: opts.stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts.stack_id)
     state = Map.merge(opts, %{producer: nil, subscriptions: {0, MapSet.new()}})
     # start in demand: :accumulate mode so that the ShapeCache is able to start
     # all active consumers before we start sending transactions

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -18,6 +18,7 @@ defmodule Electric.Replication.Supervisor do
   def init(opts) do
     Process.set_label({:replication_supervisor, opts[:stack_id]})
     Logger.metadata(stack_id: opts[:stack_id])
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
     Logger.info("Starting shape replication pipeline")
 
     # TODO: weird to have these without defaults but `consumer_supervisor` with a default

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -201,6 +201,7 @@ defmodule Electric.ShapeCache do
 
     Process.set_label({:shape_cache, stack_id})
     Logger.metadata(stack_id: stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
 
     {:ok, shape_status_state} =
       opts.shape_status.initialise(

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -60,7 +60,9 @@ defmodule Electric.Shapes.Consumer do
     %{log_producer: producer, storage: storage, shape_status: {shape_status, shape_status_state}} =
       config
 
-    Logger.metadata(shape_handle: config.shape_handle, stack_id: config.stack_id)
+    metadata = [shape_handle: config.shape_handle, stack_id: config.stack_id]
+    Logger.metadata(metadata)
+    Electric.Telemetry.Sentry.set_tags_context(metadata)
 
     Process.flag(:trap_exit, true)
 

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -27,7 +27,9 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
   def init(config) do
     Process.set_label({:snapshotter, config.shape_handle})
-    Logger.metadata(stack_id: config.stack_id, shape_handle: config.shape_handle)
+    metadata = [stack_id: config.stack_id, shape_handle: config.shape_handle]
+    Logger.metadata(metadata)
+    Electric.Telemetry.Sentry.set_tags_context(metadata)
 
     {:ok, config, {:continue, :start_snapshot}}
   end

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -62,7 +62,9 @@ defmodule Electric.Shapes.ConsumerSupervisor do
       config
 
     Process.set_label({:consumer_supervisor, shape_handle})
-    Logger.metadata(stack_id: config.stack_id, shape_handle: shape_handle)
+    metadata = [stack_id: config.stack_id, shape_handle: shape_handle]
+    Logger.metadata(metadata)
+    Electric.Telemetry.Sentry.set_tags_context(metadata)
 
     shape_storage = Electric.ShapeCache.Storage.for_shape(shape_handle, storage)
 

--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -54,6 +54,7 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
   def init(stack_id: stack_id) do
     Process.set_label({:dynamic_consumer_supervisor, stack_id})
     Logger.metadata(stack_id: stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
     Logger.debug(fn -> "Starting #{__MODULE__}" end)
     DynamicSupervisor.init(strategy: :one_for_one)
   end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -177,6 +177,7 @@ defmodule Electric.StackSupervisor do
   def init(%{stack_id: stack_id} = config) do
     Process.set_label({:stack_supervisor, stack_id})
     Logger.metadata(stack_id: stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
 
     inspector =
       Access.get(

--- a/packages/sync-service/lib/electric/telemetry/sentry.ex
+++ b/packages/sync-service/lib/electric/telemetry/sentry.ex
@@ -4,4 +4,9 @@ defmodule Electric.Telemetry.Sentry do
       config: %{metadata: :all}
     })
   end
+
+  @spec set_tags_context(keyword()) :: :ok
+  def set_tags_context(tags) do
+    Sentry.Context.set_tags_context(Map.new(tags))
+  end
 end


### PR DESCRIPTION
This PR modifies Sentry configuration to also track logged errors, not only process crashes.