### PR TITLE
chore (sync service): track errors with Sentry

### DIFF
--- a/packages/sync-service/lib/electric/telemetry/sentry.ex
+++ b/packages/sync-service/lib/electric/telemetry/sentry.ex
@@ -1,7 +1,7 @@
 defmodule Electric.Telemetry.Sentry do
   def add_logger_handler do
     :logger.add_handler(:electric_sentry_handler, Sentry.LoggerHandler, %{
-      config: %{metadata: :all}
+      config: %{metadata: :all, capture_log_messages: true, level: :error}
     })
   end
 


### PR DESCRIPTION
This PR configures Sentry to also track logged errors and not only process crashes.