### PR TITLE
fix: Do not await full setup to configure dropping replication slot

### DIFF
--- a/.changeset/healthy-comics-heal.md
+++ b/.changeset/healthy-comics-heal.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Do not await full setup for configuring replication slot drop.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -134,7 +134,6 @@ defmodule Electric.Connection.Manager do
   end
 
   def drop_replication_slot_on_stop(server) do
-    await_active(server)
     GenServer.call(server, :drop_replication_slot_on_stop)
   end
 
@@ -410,7 +409,7 @@ defmodule Electric.Connection.Manager do
       drop_slot(state)
     end
 
-    {:noreply, %{state | shape_log_collector_pid: nil}}
+    {:noreply, %{state | shape_log_collector_pid: nil, replication_client_pid: nil}}
   end
 
   # Periodically log the status of the lock connection until it is acquired for
@@ -666,6 +665,10 @@ defmodule Electric.Connection.Manager do
       |> List.keyfind(Electric.Replication.ShapeLogCollector, 0)
 
     log_collector_pid
+  end
+
+  defp drop_slot(%{pool_pid: nil} = state) do
+    Logger.warning("Skipping slot drop, pool connection not available")
   end
 
   defp drop_slot(%{pool_pid: pool} = state) do


### PR DESCRIPTION
Encountered an error in cloud work where the call to configure dropping the replication slot would time out because the connection manager would not become `active` - since this call only sets a configuration parameter, I think that the connection manager should handle the slot drop internally.

I've unblocked the configuration call, and made it so that it just logs a warning if a connection pool is not available to drop the slot.