### PR TITLE
Add elixir client request pool behaviour

### DIFF
--- a/.changeset/fresh-beers-allow.md
+++ b/.changeset/fresh-beers-allow.md
@@ -2,4 +2,4 @@
 "@core/elixir-client": patch
 ---
 
-Add un-pooled connection behaviour for the Elixir client
+Add pool behaviour for the Elixir client to allow for per-client persistent connections. Add request timestamp and shape handle to replication stream messages.

--- a/.changeset/fresh-beers-allow.md
+++ b/.changeset/fresh-beers-allow.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Add un-pooled connection behaviour for the Elixir client

--- a/packages/elixir-client/lib/electric/client.ex
+++ b/packages/elixir-client/lib/electric/client.ex
@@ -153,7 +153,8 @@ defmodule Electric.Client do
     :endpoint,
     :database_id,
     :fetch,
-    :authenticator
+    :authenticator,
+    :pool
   ]
 
   @api_endpoint_path "/v1/shape"
@@ -177,6 +178,11 @@ defmodule Electric.Client do
                    authenticator: [
                      type: :mod_arg,
                      default: {Client.Authenticator.Unauthenticated, []},
+                     doc: false
+                   ],
+                   pool: [
+                     type: :mod_arg,
+                     default: {Electric.Client.Fetch.Pool, []},
                      doc: false
                    ]
                  )
@@ -396,7 +402,7 @@ defmodule Electric.Client do
   """
   def delete_shape(%Client{} = client, %ShapeDefinition{} = shape) do
     request = request(client, method: :delete, shape: shape)
-    Electric.Client.Fetch.Request.request(client, request)
+    Electric.Client.Fetch.request(client, request, [])
   end
 
   defp validate_queryable!(queryable) when is_atom(queryable) do

--- a/packages/elixir-client/lib/electric/client/fetch.ex
+++ b/packages/elixir-client/lib/electric/client/fetch.ex
@@ -1,7 +1,18 @@
 defmodule Electric.Client.Fetch do
   alias Electric.Client.Fetch.{Request, Response}
+  alias Electric.Client
 
   @callback fetch(Request.t(), Keyword.t()) ::
               {:ok, Response.t()}
               | {:error, Response.t() | term()}
+
+  @behaviour Electric.Client.Fetch.Pool
+
+  def request(client, request, opts \\ [])
+
+  @impl Electric.Client.Fetch.Pool
+  def request(%Client{} = client, %Request{} = request, _opts) do
+    %{pool: {module, opts}} = client
+    apply(module, :request, [client, request, opts])
+  end
 end

--- a/packages/elixir-client/lib/electric/client/fetch/http.ex
+++ b/packages/elixir-client/lib/electric/client/fetch/http.ex
@@ -31,15 +31,16 @@ defmodule Electric.Client.Fetch.HTTP do
   end
 
   defp request(request) do
-    request |> Req.request() |> wrap_resp()
+    now = DateTime.utc_now()
+    request |> Req.request() |> wrap_resp(now)
   end
 
-  defp wrap_resp({:ok, %Req.Response{} = resp}) do
+  defp wrap_resp({:ok, %Req.Response{} = resp}, timestamp) do
     %{status: status, headers: headers, body: body} = resp
-    {:ok, Fetch.Response.decode!(status, headers, body)}
+    {:ok, Fetch.Response.decode!(status, headers, body, timestamp)}
   end
 
-  defp wrap_resp({:error, _} = error) do
+  defp wrap_resp({:error, _} = error, _timestamp) do
     error
   end
 

--- a/packages/elixir-client/lib/electric/client/fetch/pool.ex
+++ b/packages/elixir-client/lib/electric/client/fetch/pool.ex
@@ -1,0 +1,70 @@
+defmodule Electric.Client.Fetch.Pool do
+  @moduledoc """
+  Coaleses requests so that multiple client instances making the same
+  (potentially long-polling) request will all use the same request process.
+  """
+
+  alias Electric.Client
+  alias Electric.Client.Fetch
+
+  require Logger
+
+  @callback request(Client.t(), Fetch.Request.t(), opts :: Keyword.t()) ::
+              Fetch.Response.t() | {:error, Fetch.Response.t() | term()}
+
+  @behaviour __MODULE__
+
+  @impl Electric.Client.Fetch.Pool
+  def request(%Client{} = client, %Fetch.Request{} = request, opts) do
+    request_id = request_id(client, request)
+
+    # register this pid before making the request to avoid race conditions for
+    # very fast responses
+    {:ok, monitor_pid} = start_monitor(request_id)
+
+    try do
+      ref = Fetch.Monitor.register(monitor_pid, self())
+
+      {:ok, _request_pid} = start_request(request_id, request, client, monitor_pid)
+
+      Fetch.Monitor.wait(ref)
+    catch
+      :exit, {reason, _} ->
+        Logger.debug(fn ->
+          "Request process ended with reason #{inspect(reason)} before we could register. Re-attempting."
+        end)
+
+        request(client, request, opts)
+    end
+  end
+
+  defp start_request(request_id, request, client, monitor_pid) do
+    DynamicSupervisor.start_child(
+      Electric.Client.RequestSupervisor,
+      {Fetch.Request, {request_id, request, client, monitor_pid}}
+    )
+    |> return_existing()
+  end
+
+  defp start_monitor(request_id) do
+    DynamicSupervisor.start_child(
+      Electric.Client.RequestSupervisor,
+      {Electric.Client.Fetch.Monitor, request_id}
+    )
+    |> return_existing()
+  end
+
+  defp return_existing({:ok, pid}), do: {:ok, pid}
+  defp return_existing({:error, {:already_started, pid}}), do: {:ok, pid}
+  defp return_existing(error), do: error
+
+  defp request_id(%Client{fetch: {fetch_impl, _}}, %Fetch.Request{shape_handle: nil} = request) do
+    %{endpoint: endpoint, shape: shape_definition} = request
+    {fetch_impl, URI.to_string(endpoint), shape_definition}
+  end
+
+  defp request_id(%Client{fetch: {fetch_impl, _}}, %Fetch.Request{} = request) do
+    %{endpoint: endpoint, offset: offset, live: live, shape_handle: shape_handle} = request
+    {fetch_impl, URI.to_string(endpoint), shape_handle, Client.Offset.to_tuple(offset), live}
+  end
+end

--- a/packages/elixir-client/lib/electric/client/stream.ex
+++ b/packages/elixir-client/lib/electric/client/stream.ex
@@ -167,7 +167,8 @@ defmodule Electric.Client.Stream do
 
     resp.body
     |> List.wrap()
-    |> Enum.flat_map(&Message.parse(&1, final_offset, value_mapper_fun))
+    |> Enum.flat_map(&Message.parse(&1, shape_handle, final_offset, value_mapper_fun))
+    |> Enum.map(&Map.put(&1, :request_timestamp, resp.request_timestamp))
     |> Enum.reduce_while({start_offset, stream}, &handle_msg/2)
     # don't set the offset until we're done processing the messages. ehis keeps
     # the previous offset reached alive in the stream state
@@ -181,10 +182,11 @@ defmodule Electric.Client.Stream do
        when status in [409] do
     %{value_mapper_fun: value_mapper_fun} = stream
     offset = last_offset(resp, stream.offset)
+    handle = shape_handle(resp)
 
     stream
-    |> reset(shape_handle(resp))
-    |> buffer(Enum.flat_map(resp.body, &Message.parse(&1, offset, value_mapper_fun)))
+    |> reset(handle)
+    |> buffer(Enum.flat_map(resp.body, &Message.parse(&1, handle, offset, value_mapper_fun)))
     |> dispatch()
   end
 
@@ -332,7 +334,11 @@ defmodule Electric.Client.Stream do
   defp resume(%{opts: %{resume: %Message.ResumeMessage{} = resume}} = stream) do
     %{shape_handle: shape_handle, offset: offset, schema: schema} = resume
 
-    generate_value_mapper(schema, %{stream | shape_handle: shape_handle, offset: offset})
+    if schema do
+      generate_value_mapper(schema, %{stream | shape_handle: shape_handle, offset: offset})
+    else
+      %{stream | shape_handle: shape_handle, offset: offset}
+    end
   end
 
   defp resume(stream) do


### PR DESCRIPTION
Allows for a persistent connection per client rather than the default request coalescing behaviour.

Also expand replication stream messages with the timestamp of the actual HTTP request and the handle of the shape.

Basically enhancements for the load generation client to enable stats collection and improve the resume/reconnect behaviour.