### PR TITLE
Fix: lock version of pnpm that we're using

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1102,6 +1102,9 @@ importers:
       nodemon:
         specifier: ^3.1.4
         version: 3.1.7
+      pnpm:
+        specifier: ^9.15.0
+        version: 9.15.0
       vitepress:
         specifier: ^1.3.1
         version: 1.5.0(@algolia/client-search@5.13.0)(@types/node@20.17.6)(@types/react@18.3.12)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.6.3)
@@ -7365,6 +7368,11 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pnpm@9.15.0:
+    resolution: {integrity: sha512-duI3l2CkMo7EQVgVvNZije5yevN3mqpMkU45RBVsQpmSGon5djge4QfUHxLPpLZmgcqccY8GaPoIMe1MbYulbA==}
+    engines: {node: '>=18.12'}
+    hasBin: true
 
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -16426,6 +16434,8 @@ snapshots:
       pathe: 1.1.2
 
   pluralize@8.0.0: {}
+
+  pnpm@9.15.0: {}
 
   polished@4.3.1:
     dependencies:

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/website/package.json
+++ b/website/package.json
@@ -8,9 +8,11 @@
     "dev": "vitepress dev .",
     "preview": "vitepress preview ."
   },
+  "engineManager": "^pnpm@9.15.0",
   "devDependencies": {
     "@redocly/cli": "^1.18.0",
     "nodemon": "^3.1.4",
+    "pnpm": "^9.15.0",
     "vitepress": "^1.3.1",
     "vitepress-plugin-tabs": "^0.5.0",
     "vue-tweet": "^2.3.1",


### PR DESCRIPTION
I've noticed that the lock file sometimes flops between different versions.

This should lock (haha) that down.