### PR TITLE
chore: make sure .tool-versions matches package.json

### DIFF
--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: "package.json"
+          node-version-file: ".tool-versions"
           cache: pnpm
       - uses: erlef/setup-beam@v1
         with:

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: "package.json"
+          node-version-file: ".tool-versions"
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/teardown_examples_pr_stack.yml
+++ b/.github/workflows/teardown_examples_pr_stack.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          node-version-file: ".tool-versions"
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: "package.json"
+          node-version-file: ".tool-versions"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r --filter "$(jq '.name' -r package.json)^..." build
@@ -80,7 +80,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: "package.json"
+          node-version-file: ".tool-versions"
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
@@ -151,7 +151,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: "package.json"
+          node-version-file: ".tool-versions"
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r --filter "$(jq '.name' -r package.json)^..." build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 elixir 1.17.2-otp-27
 erlang 27.0.1
-nodejs 20.2.0
-pnpm 9.4.0
+nodejs 20.18.1
+pnpm 9.15.0

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,3 +1,5 @@
 [build.environment]
   # Environment variables are set here
+
+  # Node version here should match the one in .tool-versions - that's the authoritative source
   NODE_VERSION = "20.18.1"


### PR DESCRIPTION
We always should use `.tool-versions` as the authoritative source across the toolchain