### PR TITLE
feat: Convert `waiting` and `starting` status to 202

### DIFF
--- a/.changeset/lucky-cats-teach.md
+++ b/.changeset/lucky-cats-teach.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Return `202` for `waiting` and `starting` health status - accepts requests but will fail to service them.

--- a/packages/sync-service/Dockerfile
+++ b/packages/sync-service/Dockerfile
@@ -60,5 +60,8 @@ ARG RELEASE_NAME=electric
 COPY --from=builder /app/_build/prod/rel/${RELEASE_NAME} ./
 RUN mv /app/bin/${RELEASE_NAME} /app/bin/entrypoint
 
+
+HEALTHCHECK --interval=15s --start-interval=5s CMD curl --fail http://localhost:${ELECTRIC_PORT-3000}/v1/health || exit 1
+
 ENTRYPOINT ["/app/bin/entrypoint"]
 CMD ["start"]

--- a/packages/sync-service/Dockerfile
+++ b/packages/sync-service/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=builder /app/_build/prod/rel/${RELEASE_NAME} ./
 RUN mv /app/bin/${RELEASE_NAME} /app/bin/entrypoint
 
 
-HEALTHCHECK --interval=15s --start-interval=5s CMD curl --fail http://localhost:${ELECTRIC_PORT-3000}/v1/health || exit 1
+HEALTHCHECK --start-interval=2s --start-period=10s CMD curl --fail http://localhost:${ELECTRIC_PORT-3000}/v1/health || exit 1
 
 ENTRYPOINT ["/app/bin/entrypoint"]
 CMD ["start"]

--- a/packages/sync-service/lib/electric/plug/health_check_plug.ex
+++ b/packages/sync-service/lib/electric/plug/health_check_plug.ex
@@ -16,8 +16,8 @@ defmodule Electric.Plug.HealthCheckPlug do
 
     {status_code, status_text} =
       case get_service_status.() do
-        :waiting -> {503, "waiting"}
-        :starting -> {503, "starting"}
+        :waiting -> {202, "waiting"}
+        :starting -> {202, "starting"}
         :active -> {200, "active"}
         :stopping -> {503, "stopping"}
       end

--- a/packages/sync-service/test/electric/plug/health_check_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/health_check_plug_test.exs
@@ -30,22 +30,22 @@ defmodule Electric.Plug.HealthCheckPlugTest do
     end
 
     @tag connection_status: :waiting
-    test "returns 503 when in waiting mode", ctx do
+    test "returns 202 when in waiting mode", ctx do
       conn =
         conn(ctx)
         |> HealthCheckPlug.call([])
 
-      assert conn.status == 503
+      assert conn.status == 202
       assert Jason.decode!(conn.resp_body) == %{"status" => "waiting"}
     end
 
     @tag connection_status: :starting
-    test "returns 503 when in starting mode", ctx do
+    test "returns 202 when in starting mode", ctx do
       conn =
         conn(ctx)
         |> HealthCheckPlug.call([])
 
-      assert conn.status == 503
+      assert conn.status == 202
       assert Jason.decode!(conn.resp_body) == %{"status" => "starting"}
     end
 


### PR DESCRIPTION
Before we were returning 503s for anything other than `active` status - for some health check services (like AWS Fargate) you can only rely on the status code, and technically Electric in `waiting` and `active` status is ready to accept requests, just not service them.

I've changed it so that:
- `waiting` and `starting` return 202, requests are accepted and held but failed after a timeout if not activated
- `active` returns 200
- `stopping` returns 503, we haven't implemented it yet anyway

Not sure if we should consider this a breaking change and how we handle releases at the moment @KyleAMathews .