### PR TITLE
fix: Remove `--start-interval` as it is a relatively recent docker feature

### DIFF
--- a/packages/sync-service/Dockerfile
+++ b/packages/sync-service/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=builder /app/_build/prod/rel/${RELEASE_NAME} ./
 RUN mv /app/bin/${RELEASE_NAME} /app/bin/entrypoint
 
 
-HEALTHCHECK --start-interval=2s --start-period=10s CMD curl --fail http://localhost:${ELECTRIC_PORT-3000}/v1/health || exit 1
+HEALTHCHECK --start-period=10s CMD curl --fail http://localhost:${ELECTRIC_PORT-3000}/v1/health || exit 1
 
 ENTRYPOINT ["/app/bin/entrypoint"]
 CMD ["start"]


### PR DESCRIPTION
It means it will be slightly slower to turn `healthy` but that's ok