### PR TITLE
Use exponential backoff when restoring a crashed replication connection

### DIFF
--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -369,7 +369,9 @@ defmodule Electric.Connection.Manager do
       "Handling the exit of the replication client #{inspect(pid)} with reason #{inspect(reason)}"
     )
 
-    {:noreply, %{state | replication_client_pid: nil}, {:continue, :start_replication_client}}
+    state = %{state | replication_client_pid: nil}
+    state = schedule_reconnection(:start_replication_client, state)
+    {:noreply, state}
   end
 
   # The most likely reason for the lock connection or the DB pool to exit is the database


### PR DESCRIPTION
Fixes #1960.

I have manually verified that attempts to restore the replication connection now respect exponential backoff and that it eventually connects if I stop the other Electric instance that was holding the replication slot.