### PR TITLE
fix(elixir-client): Fix monitoring registration race condition

### DIFF
--- a/.changeset/beige-mice-notice.md
+++ b/.changeset/beige-mice-notice.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Fix race condition where response comes before listener has monitored itself.

--- a/packages/elixir-client/test/electric/client_test.exs
+++ b/packages/elixir-client/test/electric/client_test.exs
@@ -1,6 +1,8 @@
 defmodule Electric.ClientTest do
   use ExUnit.Case, async: true
 
+  @moduletag :capture_log
+
   import Support.DbSetup
   import Support.ClientHelpers
 


### PR DESCRIPTION
Fixes race condition where the monitoring process would start, initialise the request process, and the request would complete before the listener registered itself with the monitoring process.

This would normally trigger an error and a retry, so overall it's not a critical bug for production, but in our tests where our responses are mocked exactly once, if a response was missed the test would time out.

My approach was to "hold" the response in the monitor until at least one subscriber is present - I don't love it cause then for the monitor to shut down it needs to have something registered to it after initialization, but it felt like a decent fix with the assunmption that each monitor process will be accompanied with a registration.