### PR TITLE
Simplify configuration of the electric app

### DIFF
--- a/packages/sync-service/README.md
+++ b/packages/sync-service/README.md
@@ -68,10 +68,10 @@ reuse that configuration if you want:
 
 Or if you're getting your db connection from an environment variable, then you
 can use
-[`Electric.ConfigParser.parse_postgresql_uri!/1`](https://hexdocs.pm/electric/Electric.ConfigParser.html#parse_postgresql_uri!/1):
+[`Electric.Config.parse_postgresql_uri!/1`](https://hexdocs.pm/electric/Electric.Config.html#parse_postgresql_uri!/1):
 
     # config/*.exs
-    {:ok, database_config} = Electric.ConfigParser.parse_postgresql_uri(System.fetch_env!("DATABASE_URL"))
+    {:ok, database_config} = Electric.Config.parse_postgresql_uri(System.fetch_env!("DATABASE_URL"))
 
     config :electric,
       connection_opts: Electric.Utils.obfuscate_password(database_config)

--- a/packages/sync-service/README.md
+++ b/packages/sync-service/README.md
@@ -15,7 +15,7 @@ Electric Sync is powered by an Elixir-based application that connects to your Po
 
 For a quick setup and examples, refer to the [Quickstart guide](https://electric-sql.com/docs/quickstart).
 
-## Running
+## Running as a Standalone HTTP Endpoint
 
 Run Postgres:
 
@@ -36,3 +36,48 @@ Run the Elixir app:
 mix deps.get
 iex -S mix
 ```
+
+## Embedding into another Elixir Application
+
+Include `:electric` into your dependencies:
+
+    # mix.exs
+    defp deps do
+      [
+      {:electric, ">= 1.0.0-beta-1"}
+      ]
+    end
+
+Add the Postgres db connection configuration to your application's config.
+Electric accepts the same configuration format as
+[Ecto](https://hexdocs.pm/ecto/Ecto.html) (and
+[Postgrex](https://hexdocs.pm/postgrex/Postgrex.html#start_link/1)) so you can
+reuse that configuration if you want:
+
+    # config/*.exs
+    database_config = [
+      database: "ecto_simple",
+      username: "postgres",
+      password: "postgres",
+      hostname: "localhost"
+    ]
+    config :my_app, Repo, database_config
+
+    config :electric,
+      connection_opts: Electric.Utils.obfuscate_password(database_config)
+
+Or if you're getting your db connection from an environment variable, then you
+can use
+[`Electric.ConfigParser.parse_postgresql_uri!/1`](https://hexdocs.pm/electric/Electric.ConfigParser.html#parse_postgresql_uri!/1):
+
+    # config/*.exs
+    {:ok, database_config} = Electric.ConfigParser.parse_postgresql_uri(System.fetch_env!("DATABASE_URL"))
+
+    config :electric,
+      connection_opts: Electric.Utils.obfuscate_password(database_config)
+
+The Electric app will startup along with the rest of your Elixir app.
+
+Beyond the required database connection configuration there are a lot of other
+optional configuration parameters. See the [`Electric` docs for more
+information](https://hexdocs.pm/electric/Electric.html).

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -115,9 +115,9 @@ connection_opts = database_url_config ++ [ipv6: database_ipv6_config]
 
 config :electric, connection_opts: Electric.Utils.obfuscate_password(connection_opts)
 
-enable_integration_testing = env!("ELECTRIC_ENABLE_INTEGRATION_TESTING", :boolean, false)
-cache_max_age = env!("ELECTRIC_CACHE_MAX_AGE", :integer, 60)
-cache_stale_age = env!("ELECTRIC_CACHE_STALE_AGE", :integer, 60 * 5)
+enable_integration_testing = env!("ELECTRIC_ENABLE_INTEGRATION_TESTING", :boolean, nil)
+cache_max_age = env!("ELECTRIC_CACHE_MAX_AGE", :integer, nil)
+cache_stale_age = env!("ELECTRIC_CACHE_STALE_AGE", :integer, nil)
 statsd_host = env!("ELECTRIC_STATSD_HOST", :string?, nil)
 
 storage_dir = env!("ELECTRIC_STORAGE_DIR", :string, "./persistent")
@@ -140,17 +140,12 @@ persistent_kv =
           raise Dotenvy.Error, message: "ELECTRIC_PERSISTENT_STATE must be one of: MEMORY, FILE"
       end
     end,
-    {Electric.PersistentKV.Filesystem, :new!, root: persistent_state_path}
+    nil
   )
 
-chunk_bytes_threshold =
-  env!(
-    "ELECTRIC_SHAPE_CHUNK_BYTES_THRESHOLD",
-    :integer,
-    Electric.ShapeCache.LogChunker.default_chunk_size_threshold()
-  )
+chunk_bytes_threshold = env!("ELECTRIC_SHAPE_CHUNK_BYTES_THRESHOLD", :integer, nil)
 
-{storage_mod, storage_opts} =
+storage =
   env!(
     "ELECTRIC_STORAGE",
     fn storage ->
@@ -172,7 +167,7 @@ chunk_bytes_threshold =
           raise Dotenvy.Error, message: "storage must be one of: MEMORY, FILE"
       end
     end,
-    {Electric.ShapeCache.FileStorage, storage_dir: shape_path}
+    nil
   )
 
 replication_stream_id =
@@ -185,10 +180,8 @@ replication_stream_id =
 
       parsed_id
     end,
-    "default"
+    nil
   )
-
-storage = {storage_mod, storage_opts}
 
 prometheus_port = env!("ELECTRIC_PROMETHEUS_PORT", :integer, nil)
 
@@ -196,19 +189,19 @@ call_home_telemetry_url =
   env!(
     "ELECTRIC_TELEMETRY_URL",
     &ConfigParser.parse_telemetry_url!/1,
-    "https://checkpoint.electric-sql.com"
+    nil
   )
 
 system_metrics_poll_interval =
   env!(
     "ELECTRIC_SYSTEM_METRICS_POLL_INTERVAL",
     &ConfigParser.parse_human_readable_time!/1,
-    :timer.seconds(5)
+    nil
   )
 
 # The provided database id is relevant if you had used v0.8 and want to keep the storage
 # instead of having hanging files. We use a provided value as stack id, but nothing else.
-provided_database_id = env!("ELECTRIC_DATABASE_ID", :string, "single_stack")
+provided_database_id = env!("ELECTRIC_DATABASE_ID", :string, nil)
 
 config :electric,
   provided_database_id: provided_database_id,
@@ -223,10 +216,10 @@ config :electric,
   system_metrics_poll_interval: system_metrics_poll_interval,
   telemetry_statsd_host: statsd_host,
   prometheus_port: prometheus_port,
-  db_pool_size: env!("ELECTRIC_DB_POOL_SIZE", :integer, 20),
+  db_pool_size: env!("ELECTRIC_DB_POOL_SIZE", :integer, nil),
   replication_stream_id: replication_stream_id,
-  replication_slot_temporary?: env!("CLEANUP_REPLICATION_SLOTS_ON_SHUTDOWN", :boolean, false),
-  service_port: env!("ELECTRIC_PORT", :integer, 3000),
+  replication_slot_temporary?: env!("CLEANUP_REPLICATION_SLOTS_ON_SHUTDOWN", :boolean, nil),
+  service_port: env!("ELECTRIC_PORT", :integer, nil),
   storage: storage,
   persistent_kv: persistent_kv,
-  listen_on_ipv6?: env!("ELECTRIC_LISTEN_ON_IPV6", :boolean, false)
+  listen_on_ipv6?: env!("ELECTRIC_LISTEN_ON_IPV6", :boolean, nil)

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -1,15 +1,13 @@
 import Config
 import Dotenvy
 
-alias Electric.ConfigParser
-
 config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
 if config_env() in [:dev, :test] do
   source!([".env.#{config_env()}", ".env.#{config_env()}.local", System.get_env()])
 end
 
-config :logger, level: env!("ELECTRIC_LOG_LEVEL", &ConfigParser.parse_log_level!/1, :info)
+config :logger, level: env!("ELECTRIC_LOG_LEVEL", &Electric.Config.parse_log_level!/1, :info)
 
 config :logger, :default_formatter,
   # Doubled line breaks serve as long message boundaries
@@ -106,7 +104,7 @@ config :opentelemetry,
        local_parent_not_sampled: :always_off
      }}
 
-database_url_config = env!("DATABASE_URL", &ConfigParser.parse_postgresql_uri!/1)
+database_url_config = env!("DATABASE_URL", &Electric.Config.parse_postgresql_uri!/1)
 
 database_ipv6_config =
   env!("ELECTRIC_DATABASE_USE_IPV6", :boolean, false)
@@ -115,7 +113,7 @@ connection_opts = database_url_config ++ [ipv6: database_ipv6_config]
 
 config :electric, connection_opts: Electric.Utils.obfuscate_password(connection_opts)
 
-enable_integration_testing = env!("ELECTRIC_ENABLE_INTEGRATION_TESTING", :boolean, nil)
+enable_integration_testing? = env!("ELECTRIC_ENABLE_INTEGRATION_TESTING", :boolean, nil)
 cache_max_age = env!("ELECTRIC_CACHE_MAX_AGE", :integer, nil)
 cache_stale_age = env!("ELECTRIC_CACHE_STALE_AGE", :integer, nil)
 statsd_host = env!("ELECTRIC_STATSD_HOST", :string?, nil)
@@ -188,14 +186,14 @@ prometheus_port = env!("ELECTRIC_PROMETHEUS_PORT", :integer, nil)
 call_home_telemetry_url =
   env!(
     "ELECTRIC_TELEMETRY_URL",
-    &ConfigParser.parse_telemetry_url!/1,
+    &Electric.Config.parse_telemetry_url!/1,
     nil
   )
 
 system_metrics_poll_interval =
   env!(
     "ELECTRIC_SYSTEM_METRICS_POLL_INTERVAL",
-    &ConfigParser.parse_human_readable_time!/1,
+    &Electric.Config.parse_human_readable_time!/1,
     nil
   )
 
@@ -205,7 +203,7 @@ provided_database_id = env!("ELECTRIC_DATABASE_ID", :string, nil)
 
 config :electric,
   provided_database_id: provided_database_id,
-  allow_shape_deletion: enable_integration_testing,
+  allow_shape_deletion?: enable_integration_testing?,
   cache_max_age: cache_max_age,
   cache_stale_age: cache_stale_age,
   chunk_bytes_threshold: chunk_bytes_threshold,

--- a/packages/sync-service/lib/electric.ex
+++ b/packages/sync-service/lib/electric.ex
@@ -1,12 +1,147 @@
 defmodule Electric do
-  @doc """
-  Every electric cluster belongs to a particular console database instance
+  @connection_opts [
+    hostname: [type: :string, required: true, doc: "Server hostname"],
+    port: [type: :integer, required: true, doc: "Server port"],
+    database: [type: :string, required: true, doc: "Database"],
+    username: [type: :string, required: true, doc: "Username"],
+    password: [
+      type: {:fun, 0},
+      required: true,
+      doc:
+        "User password. To prevent leaking of the Pg password in logs and stack traces, you **must** wrap the password with a function." <>
+          " We provide `Electric.Utils.obfuscate_password/1` which will return the `connection_opts` with a wrapped password value.\n\n" <>
+          "    config :electric, connection_opts: Electric.Utils.obfuscate_password(connection_opts)"
+    ],
+    sslmode: [
+      type: {:in, [:disable, :allow, :prefer, :require]},
+      required: false,
+      default: :disable,
+      doc:
+        "Connection SSL configuration. See https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS",
+      type_spec: quote(do: :disable | :allow | :prefer | :require)
+    ],
+    ipv6: [
+      type: :boolean,
+      required: false,
+      default: false,
+      doc: "Whether to use IPv6 for database connections"
+    ]
+  ]
+  opts_schema = NimbleOptions.new!(@connection_opts)
 
-  This is that database instance id
+  @type pg_connection_opts :: [unquote(NimbleOptions.option_typespec(opts_schema))]
+
+  @moduledoc """
+
+  ## Configuration options
+
+  When embedding Electric, the following options are available:
+
+      config :electric,
+        connection_opts: nil
+        provided_database_id: nil,
+        allow_shape_deletion: false,
+        cache_max_age: 60,
+        cache_stale_age: 300,
+        chunk_bytes_threshold: 10 * 1024 * 1024,
+        instance_id: nil,
+        telemetry_statsd_host: nil,
+        db_pool_size: 20
+        replication_stream_id: "default",
+        replication_slot_temporary?: false
+        service_port: 3000,
+        prometheus_port: nil,
+        storage_dir: "./persistent",
+        storage: {Electric.ShapeCache.FileStorage, storage_dir: "./persistent/shapes"},
+        persistent_kv: {Electric.PersistentKV.Filesystem, :new!, root: "./persistent/state"},
+        listen_on_ipv6?: false,
+        call_home_telemetry: true,
+        telemetry_url: "https://checkpoint.electric-sql.com"
+
+  Only the `connection_opts` are required.
+
+  ### Database
+
+  - `connection_opts` - **Required**
+     #{NimbleOptions.docs(opts_schema, nest_level: 1)}.
+  - `db_pool_size` - How many connections Electric opens as a pool for handling shape queries (default: `20`)
+  - `replication_stream_id` - Suffix for the logical replication publication and slot name (default: `"default"`)
+
+  ### HTTP API
+
+  - `service_port` - Port that the [HTTP API](https://electric-sql.com/docs/api/http) is exposed on (default: `3000`)
+  - `allow_shape_deletion` - Whether to allow deletion of Shapes via the HTTP API (default: `false`)
+  - `cache_max_age` - Default `max-age` for the cache headers of the HTTP API in seconds (default: `60`s)
+  - `cache_stale_age` - Default `stale-age` for the cache headers of the HTTP API in seconds (default: `300`s)
+  - `chunk_bytes_threshold` - Limit the maximum size in bytes of a shape log response,
+    to ensure they are cached by upstream caches. (default: `10 * 1024 *
+    1024` (10MiB)).
+  - `listen_on_ipv6?` - Whether the HTTP API should listen on IPv6 as well as IPv4 (default: `false`)
+
+  ### Storage
+
+  - `storage_dir` - Path to root folder for storing data on the filesystem (default: `"./persistent"`)
+  - `storage` - Where to store shape logs. Must be a 2-tuple of `{module(),
+    term()}` where `module` points to an implementation of the
+    `Electric.ShapeCache.Storage` behaviour. (default:
+    `{Electric.ShapeCache.FileStorage, storage_dir: "./persistent/shapes"}`)
+  - `persistent_kv` - A mfa that when called constructs an implementation of
+    the `Electric.PersistentKV` behaviour, used to store system state (defau7lt:
+    `{Electric.PersistentKV.Filesystem, :new!, root: "./persistent/state"}`)
+
+  ### Telemetry
+
+  - `instance_id` - A unique identifier for the Electric instance (default: a
+    randomly generated UUID). Set this to enable tracking of instance usage
+    metrics across restarts.
+  - `telemetry_statsd_host` - If set, send telemetry data to the given StatsD reporting endpoint (default: `nil`)
+  - `prometheus_port` -If set, expose a prometheus reporter for telemetry data on the specified port (default: `nil`)
+  - `call_home_telemetry` - Allow [anonymous usage
+    data](https://electric-sql.com/docs/reference/telemetry#anonymous-usage-data)
+    about the instance being sent to a central checkpoint service (default: `true`)
+  - `telemetry_url` - Where to send the usage data (default: `"https://checkpoint.electric-sql.com"`)
+
+  ### Deprecated
+
+  - `provided_database_id` - The provided database id is relevant if you had
+    used v0.8 and want to keep the storage instead of having hanging files. We
+    use a provided value as stack id, but nothing else.
+  """
+
+  require Logger
+
+  @doc false
+  def connection_opts_schema do
+    @connection_opts
+  end
+
+  @doc false
+  @spec ensure_instance_id() :: :ok
+  # the instance id needs to be consistent across calls, so we do need to have
+  # a value in the config, even if it's not configured by the user.
+  def ensure_instance_id do
+    case get_env(:instance_id, nil) do
+      nil ->
+        instance_id = generate_instance_id()
+
+        Logger.info("Setting electric instance_id: #{instance_id}")
+        Application.put_env(:electric, :instance_id, instance_id)
+
+      id when is_binary(id) ->
+        :ok
+    end
+  end
+
+  defp generate_instance_id do
+    Electric.Utils.uuid4()
+  end
+
+  @doc """
+  `instance_id` is used to track a particular server's telemetry metrics.
   """
   @spec instance_id() :: binary | no_return
   def instance_id do
-    Application.fetch_env!(:electric, :instance_id)
+    fetch_env!(:instance_id)
   end
 
   @type relation :: {schema :: String.t(), table :: String.t()}
@@ -15,5 +150,33 @@ defmodule Electric do
   @current_vsn Mix.Project.config()[:version]
   def version do
     @current_vsn
+  end
+
+  @spec get_env(atom(), term()) :: term()
+  def get_env(key, default) do
+    # use the `||` as well as the get_env default because it allows us to
+    # remove the defaults from the runtime.exs file env var retrieval and only
+    # hard-code the default values once where they're used.
+    Application.get_env(:electric, key, default) || default
+  end
+
+  def fetch_env!(key) do
+    Application.fetch_env!(:electric, key)
+  end
+
+  def default_storage do
+    {Electric.ShapeCache.FileStorage, storage_dir: storage_dir("shapes")}
+  end
+
+  def default_persistent_kv do
+    {Electric.PersistentKV.Filesystem, :new!, root: storage_dir("state")}
+  end
+
+  defp storage_dir(sub_dir) do
+    Path.join(storage_dir(), sub_dir)
+  end
+
+  defp storage_dir do
+    get_env(:storage_dir, "./persistent")
   end
 end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -38,15 +38,7 @@ defmodule Electric.StackSupervisor do
                  connection_opts: [
                    type: :keyword_list,
                    required: true,
-                   keys: [
-                     hostname: [type: :string, required: true],
-                     port: [type: :integer, required: true],
-                     database: [type: :string, required: true],
-                     username: [type: :string, required: true],
-                     password: [type: {:fun, 0}, required: true],
-                     sslmode: [type: :atom, required: false],
-                     ipv6: [type: :boolean, required: false]
-                   ]
+                   keys: Electric.connection_opts_schema()
                  ],
                  replication_opts: [
                    type: :keyword_list,

--- a/packages/sync-service/lib/electric/telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry.ex
@@ -3,16 +3,19 @@ defmodule Electric.Telemetry do
 
   import Telemetry.Metrics
 
+  @build_env Mix.env()
+
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
   def init(opts) do
-    system_metrics_poll_interval = Application.get_env(:electric, :system_metrics_poll_interval)
+    system_metrics_poll_interval =
+      Electric.get_env(:system_metrics_poll_interval, :timer.seconds(5))
 
-    statsd_host = Application.fetch_env!(:electric, :telemetry_statsd_host)
-    prometheus? = not is_nil(Application.fetch_env!(:electric, :prometheus_port))
-    call_home_telemetry? = Application.fetch_env!(:electric, :call_home_telemetry?)
+    statsd_host = Electric.get_env(:telemetry_statsd_host, nil)
+    prometheus? = not is_nil(Electric.get_env(:prometheus_port, nil))
+    call_home_telemetry? = Electric.get_env(:call_home_telemetry?, @build_env == :prod)
 
     [
       {:telemetry_poller,

--- a/packages/sync-service/lib/electric/telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry.ex
@@ -3,19 +3,17 @@ defmodule Electric.Telemetry do
 
   import Telemetry.Metrics
 
-  @build_env Mix.env()
-
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
   def init(opts) do
     system_metrics_poll_interval =
-      Electric.get_env(:system_metrics_poll_interval, :timer.seconds(5))
+      Electric.Config.get_env(:system_metrics_poll_interval)
 
-    statsd_host = Electric.get_env(:telemetry_statsd_host, nil)
-    prometheus? = not is_nil(Electric.get_env(:prometheus_port, nil))
-    call_home_telemetry? = Electric.get_env(:call_home_telemetry?, @build_env == :prod)
+    statsd_host = Electric.Config.get_env(:telemetry_statsd_host)
+    prometheus? = not is_nil(Electric.Config.get_env(:prometheus_port))
+    call_home_telemetry? = Electric.Config.get_env(:call_home_telemetry?)
 
     [
       {:telemetry_poller,

--- a/packages/sync-service/lib/electric/telemetry/call_home_reporter.ex
+++ b/packages/sync-service/lib/electric/telemetry/call_home_reporter.ex
@@ -12,6 +12,8 @@ defmodule Electric.Telemetry.CallHomeReporter do
   @type metric :: Telemetry.Metrics.t()
   @type report_format :: keyword(metric() | report_format())
 
+  @telemetry_url URI.new!("https://checkpoint.electric-sql.com")
+
   def start_link(opts) do
     name = Keyword.get(opts, :name, __MODULE__)
     metrics = Keyword.fetch!(opts, :metrics)
@@ -32,7 +34,7 @@ defmodule Electric.Telemetry.CallHomeReporter do
     :ok
   end
 
-  defp telemetry_url, do: Application.fetch_env!(:electric, :telemetry_url)
+  defp telemetry_url, do: Electric.get_env(:telemetry_url, @telemetry_url)
 
   def print_stats(name \\ __MODULE__) do
     GenServer.call(name, :print_stats)

--- a/packages/sync-service/lib/electric/telemetry/call_home_reporter.ex
+++ b/packages/sync-service/lib/electric/telemetry/call_home_reporter.ex
@@ -12,8 +12,6 @@ defmodule Electric.Telemetry.CallHomeReporter do
   @type metric :: Telemetry.Metrics.t()
   @type report_format :: keyword(metric() | report_format())
 
-  @telemetry_url URI.new!("https://checkpoint.electric-sql.com")
-
   def start_link(opts) do
     name = Keyword.get(opts, :name, __MODULE__)
     metrics = Keyword.fetch!(opts, :metrics)
@@ -34,7 +32,7 @@ defmodule Electric.Telemetry.CallHomeReporter do
     :ok
   end
 
-  defp telemetry_url, do: Electric.get_env(:telemetry_url, @telemetry_url)
+  defp telemetry_url, do: Electric.Config.get_env(:telemetry_url)
 
   def print_stats(name \\ __MODULE__) do
     GenServer.call(name, :print_stats)

--- a/packages/sync-service/test/electric/config_parser_test.exs
+++ b/packages/sync-service/test/electric/config_parser_test.exs
@@ -1,5 +1,0 @@
-defmodule Electric.ConfigParserTest do
-  use ExUnit.Case, async: true
-
-  doctest Electric.ConfigParser, import: true
-end

--- a/packages/sync-service/test/electric/config_test.exs
+++ b/packages/sync-service/test/electric/config_test.exs
@@ -1,0 +1,5 @@
+defmodule Electric.ConfigTest do
+  use ExUnit.Case, async: true
+
+  doctest Electric.Config, import: true
+end


### PR DESCRIPTION
Refactor app config to make most values optional.

Except for connection_opts, all the config settings have defaults. When embedding electric inside another elixir app, our runtime.exs won't be sourced so the developer would be forced to unnecessarily set all these configuration values.

Moves the default values from runtime.exs to the point of usage so we don't have defaults in two places.