### PR TITLE
chore: Add pg17 to test matrix

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: packages/sync-service
     strategy:
       matrix:
-        postgres_version: [14, 15]
+        postgres_version: [14, 15, 17]
     env:
       MIX_ENV: test
       POSTGRES_VERSION: "${{ matrix.postgres_version }}0000"

--- a/packages/sync-service/dev/docker-compose.yml
+++ b/packages/sync-service/dev/docker-compose.yml
@@ -3,7 +3,7 @@ name: "electric_dev"
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     environment:
       POSTGRES_DB: electric
       POSTGRES_USER: postgres
@@ -21,7 +21,7 @@ services:
       - -c
       - config_file=/etc/postgresql.conf
   postgres2:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     environment:
       POSTGRES_DB: electric
       POSTGRES_USER: postgres

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -13,7 +13,14 @@ defmodule Support.DbSetup do
     {:ok, utility_pool} = start_db_pool(base_config)
     Process.unlink(utility_pool)
 
-    db_name = to_string(ctx.test)
+    full_db_name = to_string(ctx.test)
+
+    db_name_hash =
+      full_db_name |> :erlang.phash2(9999) |> to_string() |> String.pad_leading(4, "0")
+
+    # Truncate the database name to 63 characters, use hash to guarantee uniqueness
+    db_name = "#{db_name_hash} ~ #{String.slice(full_db_name, 0..54)}"
+
     escaped_db_name = :binary.replace(db_name, ~s'"', ~s'""', [:global])
 
     Postgrex.query!(utility_pool, "DROP DATABASE IF EXISTS \"#{escaped_db_name}\"", [])

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -16,7 +16,7 @@ defmodule Support.DbSetup do
     full_db_name = to_string(ctx.test)
 
     db_name_hash =
-      full_db_name |> :erlang.phash2(99_999_999) |> to_string() |> String.pad_leading(6, "0")
+      full_db_name |> :erlang.phash2(99_999_999) |> to_string() |> String.pad_leading(8, "0")
 
     # Truncate the database name to 63 characters, use hash to guarantee uniqueness
     db_name = "#{db_name_hash} ~ #{String.slice(full_db_name, 0..50)}"

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -16,10 +16,10 @@ defmodule Support.DbSetup do
     full_db_name = to_string(ctx.test)
 
     db_name_hash =
-      full_db_name |> :erlang.phash2(9999) |> to_string() |> String.pad_leading(4, "0")
+      full_db_name |> :erlang.phash2(99_999_999) |> to_string() |> String.pad_leading(6, "0")
 
     # Truncate the database name to 63 characters, use hash to guarantee uniqueness
-    db_name = "#{db_name_hash} ~ #{String.slice(full_db_name, 0..54)}"
+    db_name = "#{db_name_hash} ~ #{String.slice(full_db_name, 0..50)}"
 
     escaped_db_name = :binary.replace(db_name, ~s'"', ~s'""', [:global])
 

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -20,6 +20,7 @@ defmodule Support.DbSetup do
       |> :erlang.phash2(64 ** 5)
       |> :binary.encode_unsigned()
       |> Base.encode64()
+      |> String.replace_trailing("==","")
 
     # Truncate the database name to 63 characters, use hash to guarantee uniqueness
     db_name = "#{db_name_hash} ~ #{String.slice(full_db_name, 0..50)}"

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -16,7 +16,10 @@ defmodule Support.DbSetup do
     full_db_name = to_string(ctx.test)
 
     db_name_hash =
-      full_db_name |> :erlang.phash2(99_999_999) |> to_string() |> String.pad_leading(8, "0")
+      full_db_name
+      |> :erlang.phash2(64 ** 5)
+      |> :binary.encode_unsigned()
+      |> Base.encode64()
 
     # Truncate the database name to 63 characters, use hash to guarantee uniqueness
     db_name = "#{db_name_hash} ~ #{String.slice(full_db_name, 0..50)}"

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -20,7 +20,7 @@ defmodule Support.DbSetup do
       |> :erlang.phash2(64 ** 5)
       |> :binary.encode_unsigned()
       |> Base.encode64()
-      |> String.replace_trailing("==","")
+      |> String.replace_trailing("==", "")
 
     # Truncate the database name to 63 characters, use hash to guarantee uniqueness
     db_name = "#{db_name_hash} ~ #{String.slice(full_db_name, 0..50)}"


### PR DESCRIPTION
Had to trim the unique test db names, for some reason Postgrex was failing otherwise with pg17 (used short hashes to improve uniqueness guarantee)