### PR TITLE
feat: let users pass sync/async functions for resolving option values for headers/params

### DIFF
--- a/.changeset/wicked-papayas-tease.md
+++ b/.changeset/wicked-papayas-tease.md
@@ -1,0 +1,26 @@
+---
+"@electric-sql/client": patch
+"@electric-sql/docs": patch
+---
+
+This PR adds support for function-based options in the TypeScript client's params and headers. Functions can be either synchronous or asynchronous and are resolved in parallel when needed.
+
+```typescript
+const stream = new ShapeStream({
+  url: 'http://localhost:3000/v1/shape',
+  params: {
+    table: 'items',
+    userId: () => getCurrentUserId(),
+    filter: async () => await getUserPreferences()
+  },
+  headers: {
+    'Authorization': async () => `Bearer ${await getAccessToken()}`
+  }
+})
+```
+
+## Common Use Cases
+- Authentication tokens that need to be refreshed
+- User-specific parameters that may change
+- Dynamic filtering based on current state
+- Multi-tenant applications where context determines the request

--- a/packages/typescript-client/README.md
+++ b/packages/typescript-client/README.md
@@ -29,7 +29,7 @@ Real-time Postgres sync for modern apps.
 
 Electric provides an [HTTP interface](https://electric-sql.com/docs/api/http) to Postgres to enable a massive number of clients to query and get real-time updates to subsets of the database, called [Shapes](https://electric-sql.com//docs/guides/shapes). In this way, Electric turns Postgres into a real-time database.
 
-The TypeScript client helps ease reading Shapes from the HTTP API in the browser and other JavaScript environments, such as edge functions and server-side Node/Bun/Deno applications. It supports both fine-grained and coarse-grained reactivity patterns &mdash; you can subscribe to see every row that changes, or you can just subscribe to get the whole shape whenever it changes.
+The TypeScript client helps ease reading Shapes from the HTTP API in the browser and other JavaScript environments, such as edge functions and server-side Node/Bun/Deno applications. It supports both fine-grained and coarse-grained reactivity patterns &mdash; you can subscribe to see every row that changes, or you can just subscribe to get the whole shape whenever it changes. The client also supports dynamic options through function-based params and headers, making it easy to handle auth tokens, user context, and other runtime values.
 
 ## Install
 

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -213,11 +213,11 @@ export interface ShapeStreamOptions<T = never> {
    * Values can be strings, string arrays, or functions (sync or async) that return these types.
    * Function values are resolved in parallel when needed, making this useful
    * for user-specific parameters or dynamic filters.
-   * 
+   *
    * These will be merged with Electric's standard parameters.
    * Note: You cannot use Electric's reserved parameter names
    * (offset, handle, live, cursor).
-   * 
+   *
    * PostgreSQL-specific options like table, where, columns, and replica
    * should be specified here.
    */

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -117,7 +117,9 @@ type InternalParamsRecord = {
 /**
  * Helper function to resolve a function or value to its final value
  */
-export async function resolveValue<T>(value: T | (() => T | Promise<T>)): Promise<T> {
+export async function resolveValue<T>(
+  value: T | (() => T | Promise<T>)
+): Promise<T> {
   if (typeof value === `function`) {
     return (value as () => T | Promise<T>)()
   }

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -38,7 +38,7 @@ import {
   REPLICA_PARAM,
 } from './constants'
 
-const RESERVED_PARAMS = new Set([
+const RESERVED_PARAMS: Set<ReservedParamKeys> = new Set([
   LIVE_CACHE_BUSTER_QUERY_PARAM,
   SHAPE_HANDLE_QUERY_PARAM,
   LIVE_QUERY_PARAM,
@@ -50,7 +50,7 @@ type Replica = `full` | `default`
 /**
  * PostgreSQL-specific shape parameters that can be provided externally
  */
-type PostgresParams = {
+export interface PostgresParams {
   /** The root table for the shape. Not required if you set the table in your proxy. */
   table?: string
 
@@ -76,27 +76,21 @@ type PostgresParams = {
   replica?: Replica
 }
 
+type ParamValue = string | string[] | (() => string | string[] | Promise<string | string[]>)
+
+/**
+ * External params type - what users provide.
+ * Excludes reserved parameters to prevent dynamic variations that could cause stream shape changes.
+ */
+export type ExternalParamsRecord = {
+  [K in string as K extends ReservedParamKeys ? never : K]: ParamValue | undefined
+} & Partial<PostgresParams>
+
 type ReservedParamKeys =
-  | typeof COLUMNS_QUERY_PARAM
   | typeof LIVE_CACHE_BUSTER_QUERY_PARAM
   | typeof SHAPE_HANDLE_QUERY_PARAM
   | typeof LIVE_QUERY_PARAM
   | typeof OFFSET_QUERY_PARAM
-  | typeof TABLE_QUERY_PARAM
-  | typeof WHERE_QUERY_PARAM
-  | typeof REPLICA_PARAM
-
-/**
- * External params type - what users provide.
- * Includes documented PostgreSQL params and allows string, string[], or function values for any additional params.
- */
-export type ExternalParamsRecord = PostgresParams & {
-  [key: string]:
-    | string
-    | string[]
-    | (() => string | string[] | Promise<string | string[]>)
-    | undefined
-}
 
 /**
  * External headers type - what users provide.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -202,16 +202,22 @@ export interface ShapeStreamOptions<T = never> {
 
   /**
    * HTTP headers to attach to requests made by the client.
-   * Can be used for adding authentication headers.
+   * Values can be strings or functions (sync or async) that return strings.
+   * Function values are resolved in parallel when needed, making this useful
+   * for authentication tokens or other dynamic headers.
    */
   headers?: ExternalHeadersRecord
 
   /**
    * Additional request parameters to attach to the URL.
+   * Values can be strings, string arrays, or functions (sync or async) that return these types.
+   * Function values are resolved in parallel when needed, making this useful
+   * for user-specific parameters or dynamic filters.
+   * 
    * These will be merged with Electric's standard parameters.
    * Note: You cannot use Electric's reserved parameter names
    * (offset, handle, live, cursor).
-   *
+   * 
    * PostgreSQL-specific options like table, where, columns, and replica
    * should be specified here.
    */

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -76,14 +76,19 @@ export interface PostgresParams {
   replica?: Replica
 }
 
-type ParamValue = string | string[] | (() => string | string[] | Promise<string | string[]>)
+type ParamValue =
+  | string
+  | string[]
+  | (() => string | string[] | Promise<string | string[]>)
 
 /**
  * External params type - what users provide.
  * Excludes reserved parameters to prevent dynamic variations that could cause stream shape changes.
  */
 export type ExternalParamsRecord = {
-  [K in string as K extends ReservedParamKeys ? never : K]: ParamValue | undefined
+  [K in string as K extends ReservedParamKeys ? never : K]:
+    | ParamValue
+    | undefined
 } & Partial<PostgresParams>
 
 type ReservedParamKeys =
@@ -373,7 +378,9 @@ export class ShapeStream<T extends Row<unknown> = Row>
         // Resolve headers and params in parallel
         const [requestHeaders, params] = await Promise.all([
           resolveHeaders(this.options.headers),
-          this.options.params ? toInternalParams(this.options.params) : undefined,
+          this.options.params
+            ? toInternalParams(this.options.params)
+            : undefined,
         ])
 
         // Validate params after resolution
@@ -629,6 +636,6 @@ function validateOptions<T>(options: Partial<ShapeStreamOptions<T>>): void {
   }
 
   validateParams(options.params)
-  
+
   return
 }

--- a/packages/typescript-client/test/client.test-d.ts
+++ b/packages/typescript-client/test/client.test-d.ts
@@ -60,25 +60,25 @@ describe(`client`, () => {
       })
     })
 
-    describe('params validation', () => {
-      it('should allow valid params', () => {
+    describe(`params validation`, () => {
+      it(`should allow valid params`, () => {
         const validParams: ExternalParamsRecord = {
           // PostgreSQL params
-          table: 'users',
-          columns: ['id', 'name'],
-          where: 'id > 0',
-          replica: 'full',
-          
+          table: `users`,
+          columns: [`id`, `name`],
+          where: `id > 0`,
+          replica: `full`,
+
           // Custom params
-          customParam: 'value',
-          customArrayParam: ['value1', 'value2'],
-          customFunctionParam: () => 'value',
-          customAsyncFunctionParam: async () => ['value1', 'value2'],
+          customParam: `value`,
+          customArrayParam: [`value1`, `value2`],
+          customFunctionParam: () => `value`,
+          customAsyncFunctionParam: async () => [`value1`, `value2`],
         }
         expectTypeOf(validParams).toEqualTypeOf<ExternalParamsRecord>()
       })
 
-      it('should not allow reserved params', () => {
+      it(`should not allow reserved params`, () => {
         // Test that reserved parameters are not allowed in ExternalParamsRecord
         type WithReservedParam1 = { [COLUMNS_QUERY_PARAM]: string[] }
         type WithReservedParam2 = { [LIVE_CACHE_BUSTER_QUERY_PARAM]: string }

--- a/packages/typescript-client/test/client.test-d.ts
+++ b/packages/typescript-client/test/client.test-d.ts
@@ -6,7 +6,15 @@ import {
   Message,
   isChangeMessage,
   ShapeData,
+  ExternalParamsRecord,
 } from '../src'
+import {
+  COLUMNS_QUERY_PARAM,
+  LIVE_CACHE_BUSTER_QUERY_PARAM,
+  SHAPE_HANDLE_QUERY_PARAM,
+  LIVE_QUERY_PARAM,
+  OFFSET_QUERY_PARAM,
+} from '../src/constants'
 
 type CustomRow = {
   foo: number
@@ -49,6 +57,41 @@ describe(`client`, () => {
         if (isChangeMessage(msgs[0])) {
           expectTypeOf(msgs[0].value).toEqualTypeOf<CustomRow>()
         }
+      })
+    })
+
+    describe('params validation', () => {
+      it('should allow valid params', () => {
+        const validParams: ExternalParamsRecord = {
+          // PostgreSQL params
+          table: 'users',
+          columns: ['id', 'name'],
+          where: 'id > 0',
+          replica: 'full',
+          
+          // Custom params
+          customParam: 'value',
+          customArrayParam: ['value1', 'value2'],
+          customFunctionParam: () => 'value',
+          customAsyncFunctionParam: async () => ['value1', 'value2'],
+        }
+        expectTypeOf(validParams).toEqualTypeOf<ExternalParamsRecord>()
+      })
+
+      it('should not allow reserved params', () => {
+        // Test that reserved parameters are not allowed in ExternalParamsRecord
+        type WithReservedParam1 = { [COLUMNS_QUERY_PARAM]: string[] }
+        type WithReservedParam2 = { [LIVE_CACHE_BUSTER_QUERY_PARAM]: string }
+        type WithReservedParam3 = { [SHAPE_HANDLE_QUERY_PARAM]: string }
+        type WithReservedParam4 = { [LIVE_QUERY_PARAM]: string }
+        type WithReservedParam5 = { [OFFSET_QUERY_PARAM]: string }
+
+        // These should all not be equal to ExternalParamsRecord (not assignable)
+        expectTypeOf<WithReservedParam1>().not.toEqualTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam2>().not.toEqualTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam3>().not.toEqualTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam4>().not.toEqualTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam5>().not.toEqualTypeOf<ExternalParamsRecord>()
       })
     })
   })

--- a/website/docs/api/clients/typescript.md
+++ b/website/docs/api/clients/typescript.md
@@ -340,9 +340,11 @@ const stream = new ShapeStream({
   },
   onError: async (error) => {
     if (error instanceof FetchError && error.status === 401) {
-      // Force token refresh or handle specific auth errors
+      // Force token refresh
       await refreshToken()
-      // The next request will automatically get a fresh token via the function-based header
+      // Return empty object to trigger a retry with the new token
+      // that will be fetched by our function-based header
+      return {}
     }
     // Rethrow errors we can't handle
     throw error

--- a/website/docs/api/clients/typescript.md
+++ b/website/docs/api/clients/typescript.md
@@ -233,6 +233,31 @@ const stream = new ShapeStream({
 })
 ```
 
+#### Dynamic Options
+
+Both `params` and `headers` support function options that are resolved when needed. These functions can be synchronous or asynchronous:
+
+```typescript
+const stream = new ShapeStream({
+  url: 'http://localhost:3000/v1/shape',
+  params: {
+    table: 'items',
+    userId: () => getCurrentUserId(),
+    filter: async () => await getUserPreferences()
+  },
+  headers: {
+    'Authorization': async () => `Bearer ${await getAccessToken()}`,
+    'X-Tenant-Id': () => getCurrentTenant()
+  }
+})
+```
+
+Function options are resolved in parallel, making this pattern efficient for multiple async operations like fetching auth tokens and user context. Common use cases include:
+- Authentication tokens that need to be refreshed
+- User-specific parameters that may change
+- Dynamic filtering based on current state
+- Multi-tenant applications where context determines the request
+
 #### Messages
 
 A `ShapeStream` consumes and emits a stream of messages. These messages can either be a `ChangeMessage` representing a change to the shape data:

--- a/website/docs/guides/auth.md
+++ b/website/docs/guides/auth.md
@@ -226,6 +226,28 @@ See the [./client](https://github.com/electric-sql/electric/tree/main/examples/g
 
 <<< @../../examples/gatekeeper-auth/client/index.ts{typescript}
 
+### Dynamic Auth Options
+
+The TypeScript client supports function-based options for headers and params, making it easy to handle dynamic auth tokens:
+
+```typescript
+const stream = new ShapeStream({
+  url: 'http://localhost:3000/v1/shape',
+  headers: {
+    // Token will be refreshed on each request
+    'Authorization': async () => `Bearer ${await getAccessToken()}`
+  }
+})
+```
+
+This pattern is particularly useful when:
+- Your auth tokens need periodic refreshing
+- You're using session-based authentication
+- You need to fetch tokens from a secure storage
+- You want to handle token rotation automatically
+
+The function is called when needed and its value is resolved in parallel with other dynamic options, making it efficient for real-world auth scenarios.
+
 ## Notes
 
 ### External services


### PR DESCRIPTION
Fix https://github.com/electric-sql/electric/issues/2181

This PR adds support for function-based options in the TypeScript client's params and headers. Functions can be either synchronous or asynchronous and are resolved in parallel when needed.

```typescript
const stream = new ShapeStream({
  url: 'http://localhost:3000/v1/shape',
  params: {
    table: 'items',
    userId: () => getCurrentUserId(),
    filter: async () => await getUserPreferences()
  },
  headers: {
    'Authorization': async () => `Bearer ${await getAccessToken()}`
  }
})
```

## Common Use Cases
- Authentication tokens that need to be refreshed
- User-specific parameters that may change
- Dynamic filtering based on current state
- Multi-tenant applications where context determines the request

## Design Decision
We chose to implement this using direct function values rather than a middleware/interceptor pattern (as seen in libraries like Axios or ky) for several reasons:

- Simplicity: Direct function values in config objects are more intuitive than middleware chains. There's a clear 1:1 relationship between the option and its value resolution.
- Granularity: Each param/header can be individually dynamic. No need to set up middleware just to make a single value dynamic.
- Performance: All async functions are resolved in parallel by default, which isn't always the case with sequential middleware chains.
- Focused API Surface: As we're not a general-purpose HTTP client, we don't need the complexity of a full middleware system. This approach keeps our API surface smaller and more focused on Electric's specific needs.