### PR TITLE
feat(ts-client): Start stream after subscribe

### DIFF
--- a/.changeset/mean-humans-clean.md
+++ b/.changeset/mean-humans-clean.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Start streaming only after at least one subscriber is present.

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -83,4 +83,41 @@ describe(`ShapeStream`, () => {
       `columns=id&handle=potato&offset=-1&table=foo&where=a%3D1`
     )
   })
+
+  it(`should start requesting only after first subscription`, async () => {
+    const eventTarget = new EventTarget()
+    const fetchWrapper = (): Promise<Response> => {
+      eventTarget.dispatchEvent(new Event(`fetch`))
+      return Promise.resolve(Response.error())
+    }
+
+    const aborter = new AbortController()
+    const stream = new ShapeStream({
+      url: shapeUrl,
+      params: {
+        table: `foo`,
+        where: `a=1`,
+        columns: [`id`],
+      },
+      handle: `potato`,
+      signal: aborter.signal,
+      fetchClient: fetchWrapper,
+    })
+
+    // should not fire any fetch requests
+    await new Promise<void>((resolve, reject) => {
+      eventTarget.addEventListener(`fetch`, reject, { once: true })
+      setTimeout(() => resolve(), 100)
+    })
+
+    // should fire fetch immediately after subbing
+    const startedStreaming = new Promise<void>((resolve, reject) => {
+      eventTarget.addEventListener(`fetch`, () => resolve(), {
+        once: true,
+      })
+      setTimeout(() => reject(`timed out`), 100)
+    })
+    const unsub = stream.subscribe(() => unsub())
+    await startedStreaming
+  })
 })

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -23,7 +23,7 @@ describe(`ShapeStream`, () => {
     }
 
     const aborter = new AbortController()
-    new ShapeStream({
+    const stream = new ShapeStream({
       url: shapeUrl,
       params: {
         table: `foo`,
@@ -35,6 +35,7 @@ describe(`ShapeStream`, () => {
         'X-Custom-Header': `my-value`,
       },
     })
+    const unsub = stream.subscribe(() => unsub())
 
     await new Promise((resolve) =>
       eventTarget.addEventListener(`fetch`, resolve, { once: true })
@@ -60,7 +61,7 @@ describe(`ShapeStream`, () => {
     }
 
     const aborter = new AbortController()
-    new ShapeStream({
+    const stream = new ShapeStream({
       url: shapeUrl,
       params: {
         table: `foo`,
@@ -71,6 +72,8 @@ describe(`ShapeStream`, () => {
       signal: aborter.signal,
       fetchClient: fetchWrapper,
     })
+
+    const unsub = stream.subscribe(() => unsub())
 
     await new Promise((resolve) =>
       eventTarget.addEventListener(`fetch`, resolve, { once: true })


### PR DESCRIPTION
Addresses part of https://github.com/electric-sql/electric/issues/1997

Had to change some tests around - obviously this is not a full move towards the desired behaviour, e.g. we might even want for the stream to stop when it has _no_ subscribers, but I think this provides some beneficial properties to the stream (e.g. if subscribing to it after async gap no messages lost)

If we think this just complicates the client and that if we want to address the issue we should do it in one comprehensive go, I'm happy to close this as well