### PR TITLE
Do not start telemetry_poller when no metric exports are configured

### DIFF
--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -109,6 +109,18 @@ defmodule Electric.Config do
     Application.fetch_env!(:electric, key)
   end
 
+  @doc """
+  True when at least one metric exporter is enabled.
+
+  This function is used to skip starting the Electric.Telemetry supervisor when there's no need
+  to capture periodic measurements. Useful in the dev and test environments.
+  """
+  def telemetry_export_enabled? do
+    not is_nil(Electric.Config.get_env(:telemetry_statsd_host)) or
+      not is_nil(Electric.Config.get_env(:prometheus_port)) or
+      Electric.Config.get_env(:call_home_telemetry?)
+  end
+
   @doc ~S"""
   Parse a PostgreSQL URI into a keyword list.
 


### PR DESCRIPTION
While I was testing the shut down of `Electric.Connection.Supervisor`, I saw errors getting logged when one of telemetry_poller's probes timed out on a `GenServer.call()` to the connection manager. The thing is, we didn't even need telemetry poller running in that scenario.