### PR TITLE
The child_spec() function should not contain any logic

### DIFF
--- a/packages/sync-service/lib/electric/process_registry.ex
+++ b/packages/sync-service/lib/electric/process_registry.ex
@@ -1,19 +1,21 @@
 defmodule Electric.ProcessRegistry do
   @spec child_spec([Registry.start_option()]) :: Supervisor.child_spec()
   def child_spec(options) do
-    options =
-      options
-      |> Keyword.put_new(:name, registry_name(Keyword.fetch!(options, :stack_id)))
-      |> Keyword.put(:keys, :unique)
-
     %{
-      id: Keyword.get(options, :name, Registry),
+      id: __MODULE__,
       start: {__MODULE__, :start_link, [options]},
       type: :supervisor
     }
   end
 
-  def start_link(opts), do: Registry.start_link(opts)
+  def start_link(opts) do
+    opts =
+      opts
+      |> Keyword.put_new(:name, registry_name(Keyword.fetch!(opts, :stack_id)))
+      |> Keyword.put(:keys, :unique)
+
+    Registry.start_link(opts)
+  end
 
   def registry_name(stack_id) when is_atom(stack_id) or is_binary(stack_id),
     do: :"#{__MODULE__}:#{stack_id}"


### PR DESCRIPTION
By massaging options inside child_spec's definition we make the module behave differently when its start_link() function is called directly (during manual or automated testing) compared to when it's started by a supervisor.