### PR TITLE
chore: Fix more Elixir test flakes

### DIFF
--- a/.changeset/breezy-boats-tease.md
+++ b/.changeset/breezy-boats-tease.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Do not trap exits in `Electric.Shapes.Consumer` - not handled.

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -536,6 +536,7 @@ defmodule Electric.ShapeCache.FileStorage do
   @impl Electric.ShapeCache.Storage
   def unsafe_cleanup!(%FS{} = opts) do
     {:ok, _} = File.rm_rf(opts.data_dir)
+    :ok
   end
 
   defp shape_definition_path(%{data_dir: data_dir} = _opts) do

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -64,8 +64,6 @@ defmodule Electric.Shapes.Consumer do
     Logger.metadata(metadata)
     Electric.Telemetry.Sentry.set_tags_context(metadata)
 
-    Process.flag(:trap_exit, true)
-
     :ok = ShapeCache.Storage.initialise(storage)
 
     # Store the shape definition to ensure we can restore it

--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -1,6 +1,7 @@
 defmodule Electric.Postgres.ConfigurationTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureLog
+  import Support.DbSetup
 
   alias Electric.Replication.PublicationManager.RelationFilter
   alias Electric.Replication.Eval
@@ -8,9 +9,9 @@ defmodule Electric.Postgres.ConfigurationTest do
 
   @pg_15 150_000
 
-  setup {Support.DbSetup, :with_unique_db}
-  setup {Support.DbSetup, :with_publication}
-  setup {Support.DbSetup, :with_pg_version}
+  setup :with_unique_db
+  setup :with_publication
+  setup :with_pg_version
 
   setup %{db_conn: conn} do
     Postgrex.query!(

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -208,9 +208,9 @@ defmodule Support.ComponentSetup do
         restart: :temporary
       )
 
-    assert_receive {:stack_status, ^ref, :ready}
-
-    # Process.sleep(100)
+    # allow a reasonable time for full stack setup to account for
+    # potential CI slowness, including PG
+    assert_receive {:stack_status, ^ref, :ready}, 1000
 
     %{
       stack_id: stack_id,

--- a/packages/sync-service/test/support/transaction_case.ex
+++ b/packages/sync-service/test/support/transaction_case.ex
@@ -9,6 +9,6 @@ defmodule Support.TransactionCase do
   use ExUnit.CaseTemplate
   import Support.DbSetup
 
-  setup_all :with_shared_db
+  setup :with_shared_db
   setup :in_transaction
 end


### PR DESCRIPTION
I ran tests individually and in groups with many repetitions until failure to find flaky spots, and also went over the CI logs to see tests that failed, and made some changes to fix that.

Main test changes:
- Unique per-test publication when using `:with_publication` using test name based hash
- Use per test `:with_shared_db` for `TransactionCase` - otherwise connections are not closed in time and we run into too many clients issues
- Longer time to get `:ready` message when spinning up full stack - on CI you can see that sometimes the logs indicate that we're _almost_ ready but it times out with the default

Actual code changes:
- Stop trapping exits in the `Shapes.Consumer`, we don't handle it in `handle_info` and I think it was leftover from when I was doing termination cleanups. I think it's ok to allow cleanups to occur on restore since if it receives an exit there is not guarantee that the storage process is alive to clean things up.
  - Found this while testing `ShapeCache`, where we have tests restarting it and seeing if they are restored correctly and sometimes errors are logged with the consumer faliing to do a cleanup - it led me to try and kill the consumers directly and all signals were getting transformed to `:EXIT` messages, with no handler
- Minor dialyzer fix