### PR TITLE
Add partitioned tables support

### DIFF
--- a/.changeset/ten-socks-promise.md
+++ b/.changeset/ten-socks-promise.md
@@ -1,0 +1,6 @@
+---
+"@core/sync-service": patch
+"@electric-sql/docs": patch
+---
+
+Add support for shapes on partitioned tables

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -546,7 +546,7 @@ defmodule Electric.Plug.ServeShapePlug do
         conn
         |> assign(:ot_is_shape_rotated, true)
         |> assign(:ot_is_empty_response, true)
-        |> send_resp(200, ["[", @up_to_date, "]"])
+        |> send_resp(204, ["[", @up_to_date, "]"])
     after
       # If we timeout, return an empty body and 204 as there's no response body.
       long_poll_timeout ->

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -127,8 +127,7 @@ defmodule Electric.Plug.Utils do
     stack_ready_timeout = Access.get(conn.assigns.config, :stack_ready_timeout, 5_000)
     stack_events_registry = conn.assigns.config[:stack_events_registry]
 
-    ref = make_ref()
-    Electric.StackSupervisor.subscribe_to_stack_events(stack_events_registry, stack_id, ref)
+    ref = Electric.StackSupervisor.subscribe_to_stack_events(stack_events_registry, stack_id)
 
     if Electric.ProcessRegistry.alive?(stack_id, Electric.Replication.Supervisor) do
       conn

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -211,7 +211,7 @@ defmodule Electric.Postgres.Configuration do
     FROM input_relations ir
     JOIN pg_class pc ON pc.relname = ir.tablename
     JOIN pg_namespace pn ON pn.oid = pc.relnamespace
-    WHERE pn.nspname = ir.schemaname AND pc.relkind = 'r';
+    WHERE pn.nspname = ir.schemaname AND pc.relkind IN ('r', 'p');
     """
 
     relations = Map.keys(filters)

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -156,10 +156,27 @@ defmodule Electric.Postgres.Configuration do
   end
 
   @spec get_publication_tables(Postgrex.conn(), String.t()) :: list(Electric.relation())
-  defp get_publication_tables(conn, publication) do
+  def get_publication_tables(conn, publication) do
+    # `pg_publication_tables` is too clever for us -- if you add a partitioned
+    # table to the publication `pg_publication_tables` lists all the partitions
+    # as members, not the actual partitioned table. `pg_publication_rel`
+    # doesn't do this, it returns a direct list of the tables that were added
+    # using `ALTER PUBLICATION` and doesn't expand a partitioned table into its
+    # partitions.
     Postgrex.query!(
       conn,
-      "SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = $1",
+      """
+      SELECT pn.nspname, pc.relname
+        FROM pg_publication_rel ppr
+        JOIN pg_publication pp
+          ON ppr.prpubid = pp.oid
+        JOIN pg_class pc
+          ON pc.oid = ppr.prrelid
+        JOIN pg_namespace pn
+          ON pc.relnamespace = pn.oid
+        WHERE pp.pubname = $1
+        ORDER BY pn.nspname, pc.relname;
+      """,
       [publication]
     )
     |> Map.fetch!(:rows)
@@ -176,10 +193,15 @@ defmodule Electric.Postgres.Configuration do
         DECLARE
             tables TEXT;
         BEGIN
-            SELECT string_agg(format('%I.%I', schemaname, tablename), ', ')
-            INTO tables
-            FROM pg_publication_tables
-            WHERE pubname = '#{publication_name}' ;
+            SELECT string_agg(format('%I.%I', pn.nspname, pc.relname), ', ') INTO tables
+              FROM pg_publication_rel ppr
+              JOIN pg_publication pp
+                ON ppr.prpubid = pp.oid
+              JOIN pg_class pc
+                ON pc.oid = ppr.prrelid
+              JOIN pg_namespace pn
+                ON pc.relnamespace = pn.oid
+              WHERE pp.pubname = '#{publication_name}';
 
             IF tables IS NOT NULL THEN
                 EXECUTE format('ALTER PUBLICATION #{Utils.quote_name(publication_name)} DROP TABLE %s', tables);

--- a/packages/sync-service/lib/electric/postgres/inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector.ex
@@ -31,7 +31,6 @@ defmodule Electric.Postgres.Inspector do
   @callback load_column_info(relation(), opts :: term()) ::
               {:ok, [column_info()]} | :table_not_found
 
-  # @callback introspect_relation()
   @callback clean(relation(), opts :: term()) :: true
 
   @type inspector :: {module(), opts :: term()}
@@ -66,7 +65,6 @@ defmodule Electric.Postgres.Inspector do
   @doc """
   Clean up all information about a given relation using a provided inspector.
   """
-
   @spec clean(relation(), inspector()) :: true
   def clean(relation, {module, opts}), do: module.clean(relation, opts)
 

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -4,29 +4,78 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
   @doc """
   Returns the PG relation from the table name.
   """
-  def load_relation(table, conn) do
+  def load_relation(table, conn) when is_binary(table) do
     # The extra cast from $1 to text is needed because of Postgrex' OID type encoding
     # see: https://github.com/elixir-ecto/postgrex#oid-type-encoding
-    query = """
-    SELECT nspname, relname, pg_class.oid
-    FROM pg_class
-    JOIN pg_namespace ON relnamespace = pg_namespace.oid
-    WHERE
-      relkind = 'r' AND
-      pg_class.oid = $1::text::regclass
-    """
+    query = load_relation_query("$1::text::regclass")
+    do_load_relation(conn, query, [table])
+  end
 
-    case Postgrex.query(conn, query, [table]) do
+  def load_relation({schema, name}, conn) when is_binary(schema) and is_binary(name) do
+    query = load_relation_query("format('%I.%I', $1::text, $2::text)::regclass")
+    do_load_relation(conn, query, [schema, name])
+  end
+
+  defp do_load_relation(conn, query, params) do
+    case Postgrex.query(conn, query, params) do
       {:ok, result} ->
         # We expect exactly one row because the query didn't fail
         # so the relation exists since we could cast it to a regclass
-        [[schema, table, oid]] = result.rows
-        {:ok, %{relation_id: oid, relation: {schema, table}}}
+        [[schema, table, oid, kind, parent, children]] = result.rows
+
+        {:ok,
+         %{
+           relation_id: oid,
+           relation: {schema, table},
+           kind: resolve_kind(kind),
+           parent: map_relations(parent),
+           children: map_relations(children)
+         }}
 
       {:error, err} ->
         {:error, Exception.message(err)}
     end
   end
+
+  defp load_relation_query(match) do
+    # partitions can live in other namespaces from the parent/root table, so we
+    # need to keep track of them
+    [
+      """
+      SELECT pn.nspname, pc.relname, pc.oid, pc.relkind, pi_parent.parent, pi_children.children
+        FROM pg_catalog.pg_class pc
+        JOIN pg_catalog.pg_namespace pn ON pc.relnamespace = pn.oid
+        LEFT OUTER JOIN ( -- get schema and name of parent table (if any)
+          SELECT pi.inhrelid, ARRAY[pn.nspname, pc.relname] parent
+            FROM pg_catalog.pg_inherits pi
+            JOIN pg_catalog.pg_class pc ON pi.inhparent = pc.oid
+            JOIN pg_catalog.pg_namespace pn ON pc.relnamespace = pn.oid
+        ) pi_parent ON pc.oid = pi_parent.inhrelid
+        LEFT OUTER JOIN ( -- get list of child partitions (if any)
+          SELECT pi.inhparent, ARRAY_AGG(ARRAY[pn.nspname, pc.relname]) AS children
+            FROM pg_catalog.pg_inherits pi
+            JOIN pg_catalog.pg_class pc ON pi.inhrelid = pc.oid
+            JOIN pg_catalog.pg_namespace pn ON pc.relnamespace = pn.oid
+            GROUP BY pi.inhparent
+        ) pi_children ON pc.oid = pi_children.inhparent
+        WHERE
+          pc.relkind IN ('r', 'p') AND
+      """,
+      "pc.oid = ",
+      match
+    ]
+  end
+
+  defp resolve_kind("r"), do: :ordinary_table
+  defp resolve_kind("p"), do: :partitioned_table
+
+  defp map_relations(nil), do: nil
+
+  defp map_relations([schema, name]) when is_binary(schema) and is_binary(name),
+    do: {schema, name}
+
+  defp map_relations(relations) when is_list(relations),
+    do: Enum.map(relations, &map_relations/1)
 
   @doc """
   Load table information (refs) from the database
@@ -49,7 +98,7 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
     JOIN pg_type ON atttypid = pg_type.oid
     LEFT JOIN pg_index ON indrelid = pg_class.oid AND indisprimary
     LEFT JOIN pg_type AS elem_pg_type ON pg_type.typelem = elem_pg_type.oid
-    WHERE relname = $1 AND nspname = $2 AND relkind = 'r'
+    WHERE relname = $1 AND nspname = $2 AND relkind IN ('r', 'p')
     ORDER BY pg_class.oid, attnum
     """
 

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -177,11 +177,8 @@ defmodule Electric.Replication.ShapeLogCollector do
         end
 
       {:ok, _} ->
-        # probably a malformed value from a test inspector
-        :ok
-
-      {:error, _} ->
-        # just ignore errors here, they're unlikely anyway
+        # probably a malformed value from a mock test inspector that isn't
+        # returning the full inspector result with a `:parent` key
         :ok
     end
   end

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -5,11 +5,12 @@ defmodule Electric.Shapes.Consumer do
 
   import Electric.Postgres.Xid, only: [xid_lt_xid8: 2]
 
-  alias Electric.ShapeCache.LogChunker
   alias Electric.LogItems
+  alias Electric.Postgres.Inspector
   alias Electric.Replication.Changes
   alias Electric.Replication.Changes.Transaction
   alias Electric.ShapeCache
+  alias Electric.ShapeCache.LogChunker
   alias Electric.Shapes.Shape
   alias Electric.Telemetry.OpenTelemetry
   alias Electric.Utils
@@ -184,25 +185,51 @@ defmodule Electric.Shapes.Consumer do
 
   # `Shapes.Dispatcher` only works with single-events, so we can safely assert
   # that here
-  def handle_events([%Changes.Relation{}], _from, state) do
-    %{shape: %{root_table: root_table}, inspector: {inspector, inspector_opts}} = state
+  def handle_events([%Changes.Relation{} = relation], _from, state) do
+    %{shape: %{root_table: root_table} = shape, inspector: inspector} = state
 
-    Logger.info(
-      "Schema for the table #{Utils.inspect_relation(root_table)} changed - terminating shape #{state.shape_handle}"
-    )
-
-    # We clean up the relation info from ETS as it has changed and we want
-    # to source the fresh info from postgres for the next shape creation
-    inspector.clean(root_table, inspector_opts)
-
-    state =
-      reply_to_snapshot_waiters(
-        {:error, "Shape relation changed before snapshot was ready"},
-        state
+    # we now recelve relation messages from partitions, as well as ones
+    # affecting our root table so we need to be clear what we're getting -- if
+    # the relation message refers to our root table then we need to drop the
+    # shape as something has changed. if the relation is a new partition, so
+    # it's parent is our root table, then we need to just add that partition to
+    # our shape so txns from the new partition are properly mapped to our root
+    # table.
+    if relation.id == shape.root_table_id do
+      Logger.info(
+        "Schema for the table #{Utils.inspect_relation(root_table)} changed - terminating shape #{state.shape_handle}"
       )
 
-    cleanup(state)
-    {:stop, :normal, state}
+      # We clean up the relation info from ETS as it has changed and we want
+      # to source the fresh info from postgres for the next shape creation
+      Inspector.clean(root_table, inspector)
+
+      state =
+        reply_to_snapshot_waiters(
+          {:error, "Shape relation changed before snapshot was ready"},
+          state
+        )
+
+      cleanup(state)
+
+      {:stop, :normal, state}
+    else
+      # if we're receiving this relation message but the relation doesn't refer
+      # to the root table for the shape, then it **must** be because of the addition of a partition
+      # to the root table
+
+      {:ok, %{parent: ^root_table, relation: table}} =
+        Inspector.load_relation({relation.schema, relation.table}, inspector)
+
+      # a new partition has been added
+      Logger.info(
+        "New partition #{Utils.inspect_relation(table)} for table #{Utils.inspect_relation(root_table)}"
+      )
+
+      shape = Shape.add_partition(shape, root_table, table)
+
+      {:noreply, [], %{state | shape: shape}}
+    end
   end
 
   # Buffer incoming transactions until we know our xmin

--- a/packages/sync-service/lib/electric/shapes/dispatcher.ex
+++ b/packages/sync-service/lib/electric/shapes/dispatcher.ex
@@ -24,9 +24,10 @@ defmodule Electric.Shapes.Dispatcher do
   require Logger
 
   alias Electric.Shapes.Filter
+  alias Electric.Shapes.Partitions
 
   defmodule State do
-    defstruct [:waiting, :pending, :subscribers, :filter, :pids]
+    defstruct [:waiting, :pending, :subscribers, :filter, :partitions, :pids]
   end
 
   @behaviour GenStage.Dispatcher
@@ -40,6 +41,7 @@ defmodule Electric.Shapes.Dispatcher do
        pending: nil,
        subscribers: [],
        filter: Filter.new(opts),
+       partitions: Partitions.new(opts),
        pids: MapSet.new()
      }}
   end
@@ -60,6 +62,7 @@ defmodule Electric.Shapes.Dispatcher do
 
       subscribers = [{from, shape} | state.subscribers]
 
+      partitions = Partitions.add_shape(state.partitions, from, shape)
       filter = Filter.add_shape(state.filter, from, shape)
 
       {:ok, demand,
@@ -67,6 +70,7 @@ defmodule Electric.Shapes.Dispatcher do
          state
          | subscribers: subscribers,
            filter: filter,
+           partitions: partitions,
            pids: MapSet.put(state.pids, pid)
        }}
     end
@@ -78,41 +82,28 @@ defmodule Electric.Shapes.Dispatcher do
       subscribers = List.keydelete(state.subscribers, from, 0)
 
       filter = Filter.remove_shape(state.filter, from)
+      partitions = Partitions.remove_shape(state.partitions, from)
+
+      state = %{
+        state
+        | subscribers: subscribers,
+          filter: filter,
+          partitions: partitions,
+          pids: MapSet.delete(state.pids, pid)
+      }
 
       if pending && MapSet.member?(pending, from) do
         case waiting - 1 do
           0 ->
             # the only remaining unacked subscriber has cancelled, so we
             # return some demand
-            {:ok, 1,
-             %State{
-               state
-               | waiting: 0,
-                 pending: nil,
-                 subscribers: subscribers,
-                 filter: filter,
-                 pids: MapSet.delete(state.pids, pid)
-             }}
+            {:ok, 1, %State{state | waiting: 0, pending: nil}}
 
           new_waiting ->
-            {:ok, 0,
-             %State{
-               state
-               | waiting: new_waiting,
-                 pending: MapSet.delete(pending, from),
-                 subscribers: subscribers,
-                 filter: filter,
-                 pids: MapSet.delete(state.pids, pid)
-             }}
+            {:ok, 0, %State{state | waiting: new_waiting, pending: MapSet.delete(pending, from)}}
         end
       else
-        {:ok, 0,
-         %State{
-           state
-           | subscribers: subscribers,
-             filter: filter,
-             pids: MapSet.delete(state.pids, pid)
-         }}
+        {:ok, 0, state}
       end
     else
       {:ok, 0, state}
@@ -142,14 +133,11 @@ defmodule Electric.Shapes.Dispatcher do
   end
 
   def dispatch([event], _length, %State{waiting: 0, subscribers: subscribers} = state) do
-    {filter, affected_shapes} =
-      Filter.affected_shapes(
-        state.filter,
-        event
-      )
+    {partitions, event} = Partitions.handle_event(state.partitions, event)
 
     {waiting, pending} =
-      affected_shapes
+      state.filter
+      |> Filter.affected_shapes(event)
       |> Enum.reduce({0, MapSet.new()}, fn {pid, ref} = subscriber, {waiting, pending} ->
         Process.send(pid, {:"$gen_consumer", {self(), ref}, [event]}, [:noconnect])
         {waiting + 1, MapSet.put(pending, subscriber)}
@@ -166,7 +154,7 @@ defmodule Electric.Shapes.Dispatcher do
           {waiting, pending}
       end
 
-    {:ok, [], %State{state | filter: filter, waiting: waiting, pending: pending}}
+    {:ok, [], %State{state | partitions: partitions, waiting: waiting, pending: pending}}
   end
 
   @impl GenStage.Dispatcher

--- a/packages/sync-service/lib/electric/shapes/filter.ex
+++ b/packages/sync-service/lib/electric/shapes/filter.ex
@@ -10,6 +10,7 @@ defmodule Electric.Shapes.Filter do
   the table specific logic to the `Filter.Table` module.
   """
 
+  alias Electric.Postgres.Inspector
   alias Electric.Replication.Changes
   alias Electric.Replication.Changes.DeletedRecord
   alias Electric.Replication.Changes.NewRecord
@@ -20,15 +21,20 @@ defmodule Electric.Shapes.Filter do
   alias Electric.Shapes.Filter
   alias Electric.Shapes.Filter.Table
   alias Electric.Shapes.Shape
+
   require Logger
 
-  defstruct tables: %{}
+  @enforce_keys [:inspector]
+  defstruct [:inspector, tables: %{}, partitions: %{}, partition_ownership: %{}]
 
   @type t :: %Filter{}
   @type shape_id :: any()
 
-  @spec new() :: Filter.t()
-  def new, do: %Filter{}
+  @spec new(keyword()) :: Filter.t()
+  def new(opts) do
+    {:ok, inspector} = Keyword.fetch(opts, :inspector)
+    %Filter{inspector: inspector}
+  end
 
   @doc """
   Add a shape for the filter to track.
@@ -37,41 +43,79 @@ defmodule Electric.Shapes.Filter do
   by `affected_shapes/2` when the shape is affected by a change.
   """
   @spec add_shape(Filter.t(), shape_id(), Shape.t()) :: Filter.t()
-  def add_shape(%Filter{tables: tables}, shape_id, shape) do
-    %Filter{
-      tables:
+  def add_shape(%Filter{} = filter, shape_id, shape) do
+    filter
+    |> Map.update!(:tables, fn tables ->
+      Map.update(
+        tables,
+        shape.root_table,
+        Table.add_shape(Table.new(), {shape_id, shape}),
+        fn table ->
+          Table.add_shape(table, {shape_id, shape})
+        end
+      )
+    end)
+    |> Map.update!(:partitions, fn partitions ->
+      shape
+      |> Shape.partition_tables()
+      |> Enum.reduce(partitions, fn child, partitions ->
+        Map.put(partitions, child, [shape.root_table])
+      end)
+    end)
+    |> Map.update!(:partition_ownership, fn ownership ->
+      shape
+      |> Shape.affected_tables()
+      |> Enum.reduce(ownership, fn relation, relation_ownership ->
         Map.update(
-          tables,
-          shape.root_table,
-          Table.add_shape(Table.new(), {shape_id, shape}),
-          fn table ->
-            Table.add_shape(table, {shape_id, shape})
-          end
+          relation_ownership,
+          relation,
+          MapSet.new([shape_id]),
+          &MapSet.put(&1, shape_id)
         )
-    }
+      end)
+    end)
   end
 
   @doc """
   Remove a shape from the filter.
   """
   @spec remove_shape(Filter.t(), shape_id()) :: Filter.t()
-  def remove_shape(%Filter{tables: tables}, shape_id) do
-    %Filter{
-      tables:
-        tables
-        |> Enum.map(fn {table_name, table} ->
-          {table_name, Table.remove_shape(table, shape_id)}
-        end)
-        |> Enum.reject(fn {_table, table} -> Table.empty?(table) end)
-        |> Map.new()
-    }
+  def remove_shape(%Filter{} = filter, shape_id) do
+    Map.update!(filter, :tables, fn tables ->
+      tables
+      |> Enum.map(fn {table_name, table} ->
+        {table_name, Table.remove_shape(table, shape_id)}
+      end)
+      |> Enum.reject(fn {_table, table} -> Table.empty?(table) end)
+      |> Map.new()
+    end)
+    |> Map.update!(:partition_ownership, fn ownership ->
+      Map.new(ownership, fn {relation, shape_ids} ->
+        {relation, MapSet.delete(shape_ids, shape_id)}
+      end)
+    end)
+    |> clean_up_partitions()
+  end
+
+  defp clean_up_partitions(filter) do
+    {empty, full} =
+      Enum.split_with(filter.partition_ownership, fn {_relation, shape_ids} ->
+        Enum.empty?(shape_ids)
+      end)
+
+    remove_relations = Enum.map(empty, &elem(&1, 0))
+
+    %{filter | partition_ownership: Map.new(full)}
+    |> Map.update!(:partitions, fn partitions ->
+      Enum.reduce(remove_relations, partitions, &Map.delete(&2, &1))
+    end)
   end
 
   @doc """
   Returns the shape IDs for all shapes that have been added to the filter
   that are affected by the given change.
   """
-  @spec affected_shapes(Filter.t(), Changes.change()) :: MapSet.t(shape_id())
+  @spec affected_shapes(Filter.t(), Changes.change()) :: {t(), MapSet.t(shape_id())}
   def affected_shapes(%Filter{} = filter, change) do
     shapes_affected_by_change(filter, change)
   rescue
@@ -82,24 +126,43 @@ defmodule Electric.Shapes.Filter do
       """)
 
       # We can't tell which shapes are affected, the safest thing to do is return all shapes
-      filter
-      |> all_shapes()
-      |> MapSet.new(fn {shape_id, _shape} -> shape_id end)
+      {
+        filter,
+        filter
+        |> all_shapes()
+        |> MapSet.new(fn {shape_id, _shape} -> shape_id end)
+      }
   end
 
   defp shapes_affected_by_change(%Filter{} = filter, %Relation{} = relation) do
+    table = {relation.schema, relation.table}
+
+    filter = update_partitions(filter, table)
+
     # Check all shapes is all tables becuase the table may have been renamed
-    for {shape_id, shape} <- all_shapes(filter),
-        Shape.is_affected_by_relation_change?(shape, relation),
-        into: MapSet.new() do
-      shape_id
-    end
+    affected =
+      for {shape_id, shape} <- all_shapes(filter),
+          relation <- [relation | Map.get(filter.partitions, table, [])],
+          Shape.is_affected_by_relation_change?(shape, relation),
+          into: MapSet.new() do
+        shape_id
+      end
+
+    {
+      filter,
+      affected
+    }
   end
 
-  defp shapes_affected_by_change(%Filter{} = filter, %Transaction{changes: changes}) do
-    changes
-    |> Enum.map(&affected_shapes(filter, &1))
-    |> Enum.reduce(MapSet.new(), &MapSet.union(&1, &2))
+  defp shapes_affected_by_change(%Filter{} = filter, %Transaction{} = tx) do
+    %{changes: changes} = tx
+
+    {
+      filter,
+      changes
+      |> Enum.map(&affected_shapes(filter, &1))
+      |> Enum.reduce(MapSet.new(), &MapSet.union(&1, &2))
+    }
   end
 
   defp shapes_affected_by_change(%Filter{} = filter, %NewRecord{
@@ -130,11 +193,15 @@ defmodule Electric.Shapes.Filter do
     end
   end
 
-  defp shapes_affected_by_record(filter, table_name, record) do
-    case Map.get(filter.tables, table_name) do
-      nil -> MapSet.new()
-      table -> Table.affected_shapes(table, record)
-    end
+  defp shapes_affected_by_record(filter, relation, record) do
+    relations = [relation | Map.get(filter.partitions, relation, [])]
+
+    Enum.reduce(relations, MapSet.new(), fn relation, affected ->
+      case Map.get(filter.tables, relation) do
+        nil -> affected
+        table -> MapSet.union(affected, Table.affected_shapes(table, record))
+      end
+    end)
   end
 
   defp all_shapes(%Filter{} = filter) do
@@ -149,6 +216,16 @@ defmodule Electric.Shapes.Filter do
     case Map.get(filter.tables, table_name) do
       nil -> %{}
       table -> Table.all_shapes(table)
+    end
+  end
+
+  defp update_partitions(filter, relation) do
+    case Inspector.load_relation(relation, filter.inspector) do
+      {:ok, %{parent: {_, _} = parent}} ->
+        Map.update!(filter, :partitions, &Map.put(&1, relation, [parent]))
+
+      _ ->
+        filter
     end
   end
 end

--- a/packages/sync-service/lib/electric/shapes/partitions.ex
+++ b/packages/sync-service/lib/electric/shapes/partitions.ex
@@ -1,0 +1,161 @@
+defmodule Electric.Shapes.Partitions do
+  @moduledoc ~S"""
+  Keeps track of shapes defined on partitioned tables and re-writes
+  transactions to send an equivalent change on the root partitioned table for
+  every change to a partition of that table.
+  """
+  alias Electric.Postgres.Inspector
+  alias Electric.Replication.Changes.Relation
+  alias Electric.Replication.Changes.Transaction
+
+  defstruct [:inspector, active: 0, partitions: %{}, partition_ownership: %{}]
+
+  @type partition_table :: Electric.relation()
+  @type root_table :: Electric.relation()
+  @type shape_id :: term()
+  @type t :: %__MODULE__{
+          inspector: Inspector.inspector(),
+          active: non_neg_integer(),
+          partitions: %{partition_table() => root_table()},
+          partition_ownership: %{Electric.relation() => MapSet.t(shape_id())}
+        }
+  @type options :: [{:inspector, Inspector.inspector()}]
+
+  @spec new(options()) :: t()
+  def new(opts) when is_list(opts) do
+    {:ok, inspector} = Keyword.fetch(opts, :inspector)
+    %__MODULE__{inspector: inspector}
+  end
+
+  @doc """
+  Update the partition information table with the given shape.
+
+  If the shape is  defined on a partitioned table (not a partition of that
+  table) then this will expand the mapping function to add a change to the
+  partition root for every change to a partition of that root.
+  """
+  @spec add_shape(t(), shape_id(), Electric.Shapes.Shape.t()) :: t()
+  def add_shape(%__MODULE__{} = transformer, shape_id, shape) do
+    case Inspector.load_relation(shape.root_table, transformer.inspector) do
+      {:ok, relation} ->
+        children = List.wrap(Map.get(relation, :children, []))
+
+        transformer
+        |> Map.update!(:partitions, fn partitions ->
+          Enum.reduce(children, partitions, fn child, partitions ->
+            Map.put(partitions, child, [shape.root_table])
+          end)
+        end)
+        |> Map.update!(:partition_ownership, fn ownership ->
+          [shape.root_table | children]
+          |> Enum.reduce(ownership, fn relation, relation_ownership ->
+            Map.update(
+              relation_ownership,
+              relation,
+              MapSet.new([shape_id]),
+              &MapSet.put(&1, shape_id)
+            )
+          end)
+        end)
+        |> update_active()
+
+      {:error, "ERROR 42P01 " <> _} ->
+        # https://www.postgresql.org/docs/current/errcodes-appendix.html
+        # 42P01 : undefined_table
+        # tables that don't exist will be caught later in the stack (hard to
+        # run a snapshot against a non-existent table)
+        transformer
+
+      {:error, reason} ->
+        raise RuntimeError,
+          message:
+            "Unable to introspect table #{Electric.Utils.inspect_relation(shape.root_table)}: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Remove a shape that was previously added under the given id.
+
+  If that shape was defined on a partitioned table, this will clean up the
+  partition mapping table.
+  """
+  @spec remove_shape(t(), shape_id()) :: t()
+  def remove_shape(%__MODULE__{} = transformer, shape_id) do
+    transformer
+    |> Map.update!(:partition_ownership, fn ownership ->
+      Map.new(ownership, fn {relation, shape_ids} ->
+        {relation, MapSet.delete(shape_ids, shape_id)}
+      end)
+    end)
+    |> clean_up_partitions()
+  end
+
+  defp clean_up_partitions(transformer) do
+    {empty, full} =
+      Enum.split_with(transformer.partition_ownership, fn {_relation, shape_ids} ->
+        Enum.empty?(shape_ids)
+      end)
+
+    remove_relations = Enum.map(empty, &elem(&1, 0))
+
+    %{transformer | partition_ownership: Map.new(full)}
+    |> Map.update!(:partitions, fn partitions ->
+      Enum.reduce(remove_relations, partitions, &Map.delete(&2, &1))
+    end)
+    |> update_active()
+  end
+
+  defp update_active(transformer) do
+    %{transformer | active: map_size(transformer.partitions)}
+  end
+
+  @doc """
+  Utility function to update the partition map with the given relation.
+  """
+  @spec handle_relation(t(), Relation.t()) :: t()
+  def handle_relation(%__MODULE__{} = transformer, %Relation{} = relation) do
+    table = table(relation)
+
+    case Inspector.load_relation(table, transformer.inspector) do
+      {:ok, %{parent: {_, _} = parent}} ->
+        Map.update!(transformer, :partitions, &Map.put(&1, table, [parent]))
+
+      {:ok, _} ->
+        transformer
+    end
+  end
+
+  @doc """
+  Handle events from the replication stream, updating the partition mapping or
+  expanding changes to partitions into the partition root as appropriate.
+  """
+  @spec handle_event(t(), Transaction.t() | Relation.t()) :: {t(), Transaction.t() | Relation.t()}
+  def handle_event(%__MODULE__{} = transformer, %Relation{} = relation) do
+    {handle_relation(transformer, relation), relation}
+  end
+
+  # no shapes on partitioned tables is probably the overwhelming majority of
+  # cases, so let's shortcut to avoid churn
+  def handle_event(%__MODULE__{active: 0} = transformer, %Transaction{} = transaction) do
+    {transformer, transaction}
+  end
+
+  def handle_event(%__MODULE__{} = transformer, %Transaction{changes: changes} = transaction) do
+    {transformer, %{transaction | changes: expand_changes(changes, transformer)}}
+  end
+
+  defp expand_changes(changes, %__MODULE__{} = transformer) do
+    Enum.flat_map(changes, &expand_change(&1, transformer))
+  end
+
+  defp expand_change(%{relation: relation} = change, transformer) do
+    [
+      change
+      | transformer.partitions
+        |> Map.get(relation, [])
+        |> Enum.map(&%{change | relation: &1})
+    ]
+  end
+
+  defp table(%{schema: schema, table: table}), do: {schema, table}
+end

--- a/packages/sync-service/lib/electric/shapes/partitions.ex
+++ b/packages/sync-service/lib/electric/shapes/partitions.ex
@@ -36,12 +36,12 @@ defmodule Electric.Shapes.Partitions do
   partition root for every change to a partition of that root.
   """
   @spec add_shape(t(), shape_id(), Electric.Shapes.Shape.t()) :: t()
-  def add_shape(%__MODULE__{} = transformer, shape_id, shape) do
-    case Inspector.load_relation(shape.root_table, transformer.inspector) do
+  def add_shape(%__MODULE__{} = state, shape_id, shape) do
+    case Inspector.load_relation(shape.root_table, state.inspector) do
       {:ok, relation} ->
         children = List.wrap(Map.get(relation, :children, []))
 
-        transformer
+        state
         |> Map.update!(:partitions, fn partitions ->
           Enum.reduce(children, partitions, fn child, partitions ->
             Map.put(partitions, child, [shape.root_table])
@@ -65,7 +65,7 @@ defmodule Electric.Shapes.Partitions do
         # 42P01 : undefined_table
         # tables that don't exist will be caught later in the stack (hard to
         # run a snapshot against a non-existent table)
-        transformer
+        state
 
       {:error, reason} ->
         raise RuntimeError,
@@ -81,8 +81,8 @@ defmodule Electric.Shapes.Partitions do
   partition mapping table.
   """
   @spec remove_shape(t(), shape_id()) :: t()
-  def remove_shape(%__MODULE__{} = transformer, shape_id) do
-    transformer
+  def remove_shape(%__MODULE__{} = state, shape_id) do
+    state
     |> Map.update!(:partition_ownership, fn ownership ->
       Map.new(ownership, fn {relation, shape_ids} ->
         {relation, MapSet.delete(shape_ids, shape_id)}
@@ -91,38 +91,45 @@ defmodule Electric.Shapes.Partitions do
     |> clean_up_partitions()
   end
 
-  defp clean_up_partitions(transformer) do
+  defp clean_up_partitions(state) do
     {empty, full} =
-      Enum.split_with(transformer.partition_ownership, fn {_relation, shape_ids} ->
+      Enum.split_with(state.partition_ownership, fn {_relation, shape_ids} ->
         Enum.empty?(shape_ids)
       end)
 
     remove_relations = Enum.map(empty, &elem(&1, 0))
 
-    %{transformer | partition_ownership: Map.new(full)}
+    %{state | partition_ownership: Map.new(full)}
     |> Map.update!(:partitions, fn partitions ->
       Enum.reduce(remove_relations, partitions, &Map.delete(&2, &1))
     end)
     |> update_active()
   end
 
-  defp update_active(transformer) do
-    %{transformer | active: map_size(transformer.partitions)}
+  defp update_active(state) do
+    %{state | active: map_size(state.partitions)}
   end
 
   @doc """
   Utility function to update the partition map with the given relation.
   """
   @spec handle_relation(t(), Relation.t()) :: t()
-  def handle_relation(%__MODULE__{} = transformer, %Relation{} = relation) do
+  def handle_relation(%__MODULE__{} = state, %Relation{} = relation) do
     table = table(relation)
 
-    case Inspector.load_relation(table, transformer.inspector) do
+    case Inspector.load_relation(table, state.inspector) do
       {:ok, %{parent: {_, _} = parent}} ->
-        Map.update!(transformer, :partitions, &Map.put(&1, table, [parent]))
+        # TODO: we should probabaly have a way to clean the inspector cache
+        # just based on the relation, there's a chance that this results in
+        # a query to pg just to then drop the info
+        with {:ok, parent_info} <- Inspector.load_relation(parent, state.inspector) do
+          Inspector.clean(parent_info, state.inspector)
+        end
+
+        state |> Map.update!(:partitions, &Map.put(&1, table, [parent])) |> update_active()
 
       {:ok, _} ->
-        transformer
+        state
     end
   end
 
@@ -131,22 +138,22 @@ defmodule Electric.Shapes.Partitions do
   expanding changes to partitions into the partition root as appropriate.
   """
   @spec handle_event(t(), Transaction.t() | Relation.t()) :: {t(), Transaction.t() | Relation.t()}
-  def handle_event(%__MODULE__{} = transformer, %Relation{} = relation) do
-    {handle_relation(transformer, relation), relation}
+  def handle_event(%__MODULE__{} = state, %Relation{} = relation) do
+    {handle_relation(state, relation), relation}
   end
 
   # no shapes on partitioned tables is probably the overwhelming majority of
   # cases, so let's shortcut to avoid churn
-  def handle_event(%__MODULE__{active: 0} = transformer, %Transaction{} = transaction) do
-    {transformer, transaction}
+  def handle_event(%__MODULE__{active: 0} = state, %Transaction{} = transaction) do
+    {state, transaction}
   end
 
-  def handle_event(%__MODULE__{} = transformer, %Transaction{changes: changes} = transaction) do
-    {transformer, %{transaction | changes: expand_changes(changes, transformer)}}
+  def handle_event(%__MODULE__{} = state, %Transaction{changes: changes} = transaction) do
+    {state, %{transaction | changes: expand_changes(changes, state)}}
   end
 
-  defp expand_changes(changes, %__MODULE__{} = transformer) do
-    Enum.flat_map(changes, &expand_change(&1, transformer))
+  defp expand_changes(changes, %__MODULE__{} = state) do
+    Enum.flat_map(changes, &expand_change(&1, state))
   end
 
   # Truncate handling:
@@ -157,17 +164,17 @@ defmodule Electric.Shapes.Partitions do
   #   truncating a partition empties it and also invalidates the contents of
   #   any shapes on the root. other partitions are untouched as, by definition,
   #   they don't overlap with the truncated partition.
-  defp expand_change(%TruncatedRelation{relation: relation} = change, transformer) do
+  defp expand_change(%TruncatedRelation{relation: relation} = change, state) do
     [
       change
-      | transformer |> truncation_dependencies(relation) |> Enum.map(&%{change | relation: &1})
+      | state |> truncation_dependencies(relation) |> Enum.map(&%{change | relation: &1})
     ]
   end
 
-  defp expand_change(%{relation: relation} = change, transformer) do
+  defp expand_change(%{relation: relation} = change, state) do
     [
       change
-      | transformer.partitions
+      | state.partitions
         |> Map.get(relation, [])
         |> Enum.map(&%{change | relation: &1})
     ]
@@ -175,12 +182,12 @@ defmodule Electric.Shapes.Partitions do
 
   defp table(%{schema: schema, table: table}), do: {schema, table}
 
-  defp truncation_dependencies(transformer, root_or_partition) do
-    transformer.partitions
+  defp truncation_dependencies(state, root_or_partition) do
+    state.partitions
     |> Map.get(root_or_partition, [])
     |> MapSet.new()
     |> MapSet.union(
-      transformer
+      state
       |> invert_partition_map()
       |> Map.get(root_or_partition, [])
       |> MapSet.new()

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -15,8 +15,7 @@ defmodule Electric.Shapes.Shape do
     :table_info,
     :where,
     :selected_columns,
-    replica: :default,
-    partitions: %{}
+    replica: :default
   ]
 
   @type replica() :: :full | :default
@@ -30,7 +29,6 @@ defmodule Electric.Shapes.Shape do
           table_info: %{
             Electric.relation() => table_info()
           },
-          partitions: %{Electric.relation() => Electric.relation()},
           where: Electric.Replication.Eval.Expr.t() | nil,
           selected_columns: [String.t(), ...] | nil,
           replica: replica()
@@ -88,14 +86,11 @@ defmodule Electric.Shapes.Shape do
            validate_selected_columns(column_info, pk_cols, Access.get(opts, :columns)),
          refs = Inspector.columns_to_expr(column_info),
          {:ok, where} <- maybe_parse_where_clause(Access.get(opts, :where), refs) do
-      children = relation |> Map.get(:children, []) |> List.wrap()
-
       {:ok,
        %__MODULE__{
          root_table: table,
          root_table_id: relation_id,
          table_info: %{table => %{pk: pk_cols, columns: column_info}},
-         partitions: Map.new(children, &{&1, table}),
          where: where,
          selected_columns: selected_columns,
          replica: Access.get(opts, :replica, :default)
@@ -194,25 +189,8 @@ defmodule Electric.Shapes.Shape do
   List tables that are a part of this shape.
   """
   @spec affected_tables(t()) :: [Electric.relation()]
-  def affected_tables(%__MODULE__{root_table: table} = shape) do
-    [table | partition_tables(shape)]
-  end
-
-  @doc """
-  List partitions of this Shape. Will be empty if shape is a partition table
-  itself or a normal, non-partitioned table
-  """
-  @spec partition_tables(t()) :: [Electric.relation()]
-  def partition_tables(%__MODULE__{partitions: partitions}) do
-    Map.keys(partitions)
-  end
-
-  def add_partition(
-        %__MODULE__{partitions: partitions} = shape,
-        {_, _} = root,
-        {_, _} = partition
-      ) do
-    %{shape | partitions: Map.put(partitions, partition, root)}
+  def affected_tables(%__MODULE__{root_table: table}) do
+    [table]
   end
 
   @doc """
@@ -222,22 +200,9 @@ defmodule Electric.Shapes.Shape do
   Updates, on the other hand, may be converted to an "new record" or a "deleted record"
   if the previous/new version of the updated row isn't in the shape.
   """
-  def convert_change(%__MODULE__{root_table: table} = shape, %{relation: relation} = change)
-      when table != relation do
-    %{partitions: partitions} = shape
-
-    # if the change has reached here because its an update to a partition child
-    # on a root table, and the shape is on the root table, then re-write the
-    # change to come from the shape's root table
-    case Map.fetch(partitions, relation) do
-      {:ok, ^table} ->
-        # This does not re-write the change's key. Is that a problem?
-        convert_change(shape, %{change | relation: table})
-
-      _ ->
-        []
-    end
-  end
+  def convert_change(%__MODULE__{root_table: table}, %{relation: relation})
+      when table != relation,
+      do: []
 
   def convert_change(%__MODULE__{where: nil, selected_columns: nil}, change), do: [change]
 
@@ -323,15 +288,6 @@ defmodule Electric.Shapes.Shape do
       )
       when old_id !== new_id,
       do: true
-
-  # the relation in this case is the parent table of a partition and we're
-  # handling the case where a new partition has been added to an existing
-  # partitioned table - the new partition arrives as a relation message and is
-  # handled by the clauses above, but the the link between the new partition
-  # and the partitioned table is handled with raw relation tuples
-  def is_affected_by_relation_change?(%__MODULE__{root_table: relation}, {_, _} = relation) do
-    true
-  end
 
   def is_affected_by_relation_change?(_shape, _relation), do: false
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -525,7 +525,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       # The conn process should exit after sending the response
       refute Process.alive?(conn.owner)
 
-      assert conn.status == 200
+      assert conn.status == 204
       assert Jason.decode!(conn.resp_body) == [%{"headers" => %{"control" => "up-to-date"}}]
       assert Plug.Conn.get_resp_header(conn, "electric-up-to-date") == [""]
     end

--- a/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
+++ b/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
@@ -18,8 +18,16 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
     end
 
     test "returns relation from table name", %{opts: opts, table: table} do
-      assert {:ok, %{relation: ^table, relation_id: _}} =
+      assert {:ok, %{relation: ^table, relation_id: _, kind: :ordinary_table}} =
                EtsInspector.load_relation("PuBliC.ItEmS", opts)
+    end
+
+    test "can reload the info using the relation", %{opts: opts, table: table} do
+      assert {:ok, %{relation: ^table, relation_id: _, kind: :ordinary_table}} =
+               EtsInspector.load_relation("public.items", opts)
+
+      assert {:ok, %{relation: ^table, relation_id: _, kind: :ordinary_table}} =
+               EtsInspector.load_relation(table, opts)
     end
 
     test "returns same value from ETS cache as the original call", %{opts: opts, table: table} do
@@ -57,6 +65,53 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
       assert original2 == from_cache2
       assert {:ok, %{relation: {"public", "ITEMS"}, relation_id: _}} = original2
     end
+
+    @tag with_sql: [
+           ~s|CREATE TABLE "just_normal_john" (a INT PRIMARY KEY)|
+         ]
+    test "returns blank children and parent for non-partitioned tables", %{
+      opts: opts
+    } do
+      assert {:ok, %{relation: {"public", "just_normal_john"}, parent: nil, children: nil}} =
+               EtsInspector.load_relation("public.just_normal_john", opts)
+    end
+
+    @tag with_sql: [
+           ~s|CREATE SCHEMA other|,
+           ~s|CREATE TABLE "partitioned_items" (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (b)|,
+           ~s|CREATE TABLE "partitioned_items_100" PARTITION OF "partitioned_items" FOR VALUES FROM (0) TO (99)|,
+           ~s|CREATE TABLE "partitioned_items_200" PARTITION OF "partitioned_items" FOR VALUES FROM (100) TO (199)|,
+           ~s|CREATE TABLE other."partitioned_items_300" PARTITION OF "partitioned_items" FOR VALUES FROM (200) TO (299)|
+         ]
+    test "returns the partitioned table heirarchy", %{
+      opts: opts
+    } do
+      partitions = [
+        {"public", "partitioned_items_100"},
+        {"public", "partitioned_items_200"},
+        {"other", "partitioned_items_300"}
+      ]
+
+      assert {:ok,
+              %{
+                parent: nil,
+                relation: {"public", "partitioned_items"},
+                relation_id: _,
+                kind: :partitioned_table,
+                children: ^partitions
+              }} = EtsInspector.load_relation("public.partitioned_items", opts)
+
+      for {schema, name} = relation <- partitions do
+        assert {:ok,
+                %{
+                  parent: {"public", "partitioned_items"},
+                  relation: ^relation,
+                  relation_id: _,
+                  kind: :ordinary_table,
+                  children: nil
+                }} = EtsInspector.load_relation("#{schema}.#{name}", opts)
+      end
+    end
   end
 
   describe "clean/2" do
@@ -85,7 +140,7 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
       # Another table
       table3 = ~s|"ITEMS"|
 
-      assert {:ok, relation} = EtsInspector.load_relation(table1, opts)
+      assert {:ok, %{relation: rel} = relation} = EtsInspector.load_relation(table1, opts)
       assert {:ok, ^relation} = EtsInspector.load_relation(table2, opts)
       assert {:ok, relation2} = EtsInspector.load_relation(table3, opts)
       assert relation != relation2
@@ -93,11 +148,13 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
       # Check that the relations are in the ETS cache
       assert :ets.lookup(pg_relation_table, {relation, :relation_to_table}) == [
                {{relation, :relation_to_table}, "public.items"},
+               {{relation, :relation_to_table}, {"public", "items"}},
                {{relation, :relation_to_table}, "PUBLIC.ITEMS"}
              ]
 
       assert :ets.lookup(pg_relation_table, {relation2, :relation_to_table}) == [
-               {{relation2, :relation_to_table}, ~s|"ITEMS"|}
+               {{relation2, :relation_to_table}, ~s|"ITEMS"|},
+               {{relation2, :relation_to_table}, {"public", "ITEMS"}}
              ]
 
       assert :ets.lookup_element(pg_info_table, {table1, :table_to_relation}, 2, :not_found) ==
@@ -116,6 +173,8 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
       assert :ets.member(pg_relation_table, {relation, :relation_to_table}) == false
       assert :ets.member(pg_info_table, {table1, :table_to_relation}) == false
       assert :ets.member(pg_info_table, {table2, :table_to_relation}) == false
+      # we also remove the info cached under the {schema, name} relation
+      assert :ets.member(pg_info_table, {rel, :table_to_relation}) == false
 
       # relation2 should still be in the cache
       assert :ets.member(pg_relation_table, {relation2, :relation_to_table}) == true
@@ -124,7 +183,7 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
   end
 
   describe "load_column_info/2" do
-    setup [:with_inspector, :with_basic_tables]
+    setup [:with_inspector, :with_basic_tables, :with_sql_execute]
 
     setup %{inspector: {EtsInspector, opts}} do
       {:ok, %{opts: opts, table: {"public", "items"}}}
@@ -148,6 +207,23 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
       original = EtsInspector.load_column_info(table, opts)
       from_cache = Task.await(task)
       assert from_cache == original
+    end
+
+    @tag with_sql: [
+           ~s|CREATE TABLE "partitioned_items" (a INT, b INT, c TEXT, PRIMARY KEY (a, b)) PARTITION BY RANGE (b)|
+         ]
+    test "can introspect partitioned tables", %{opts: opts} do
+      assert {:ok, [%{name: "a"}, %{name: "b"}, %{name: "c"}]} =
+               EtsInspector.load_column_info({"public", "partitioned_items"}, opts)
+    end
+
+    @tag with_sql: [
+           ~s|CREATE TABLE "partitioned_items" (a INT, b INT, c TEXT, PRIMARY KEY (a, b)) PARTITION BY RANGE (b)|,
+           ~s|CREATE TABLE "partitioned_items_100" PARTITION OF "partitioned_items" FOR VALUES FROM (0) TO (99)|
+         ]
+    test "can introspect partitions", %{opts: opts} do
+      assert {:ok, [%{name: "a"}, %{name: "b"}, %{name: "c"}]} =
+               EtsInspector.load_column_info({"public", "partitioned_items_100"}, opts)
     end
   end
 end

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -72,6 +72,12 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     setup ctx do
       parent = self()
 
+      Mock.Inspector
+      |> stub(:load_relation, fn {"public", "test_table"}, _ ->
+        {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
+      end)
+      |> allow(self(), ctx.server)
+
       consumers =
         Enum.map(1..3, fn id ->
           {:ok, consumer} =
@@ -95,7 +101,11 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       last_log_offset = LogOffset.new(lsn, 0)
 
       Mock.Inspector
-      |> expect(:load_column_info, 2, fn {"public", "test_table"}, _ ->
+      |> stub(:load_relation, fn
+        {"public", "test_table"}, _ ->
+          {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
+      end)
+      |> stub(:load_column_info, fn {"public", "test_table"}, _ ->
         {:ok, [%{pk_position: 0, name: "id"}]}
       end)
       |> allow(self(), ctx.server)
@@ -133,6 +143,12 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     setup ctx do
       parent = self()
 
+      Mock.Inspector
+      |> stub(:load_relation, fn {"public", "test_table"}, _ ->
+        {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
+      end)
+      |> allow(self(), ctx.server)
+
       consumers =
         Enum.map(1..3, fn id ->
           {:ok, consumer} =
@@ -151,6 +167,16 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
     test "should handle new relations", ctx do
       id = @shape.root_table_id
+
+      Mock.Inspector
+      |> stub(:load_relation, fn
+        {"public", "test_table"}, _ ->
+          {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
+
+        {"public", "bar"}, _ ->
+          {:ok, %{id: 1235, schema: "public", name: "bar", parent: nil, children: nil}}
+      end)
+      |> allow(self(), ctx.server)
 
       relation1 = %Relation{id: id, table: "test_table", schema: "public", columns: []}
 

--- a/packages/sync-service/test/electric/shapes/dispatcher_test.exs
+++ b/packages/sync-service/test/electric/shapes/dispatcher_test.exs
@@ -21,7 +21,7 @@ defmodule Electric.Shapes.DispatcherTest do
   }
 
   defp dispatcher() do
-    {:ok, state} = D.init([])
+    {:ok, state} = D.init(inspector: @inspector)
     state
   end
 

--- a/packages/sync-service/test/electric/shapes/filter_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter_test.exs
@@ -449,7 +449,6 @@ defmodule Electric.Shapes.FilterTest do
       assert_affected(filter, insert, MapSet.new(["s1", "s2"]))
     end
 
-    @tag :wip
     test "root shape is affected by partition addition" do
       filter =
         Filter.new(inspector: @partition_inspector)

--- a/packages/sync-service/test/electric/shapes/partitioned_tables_test.exs
+++ b/packages/sync-service/test/electric/shapes/partitioned_tables_test.exs
@@ -1,0 +1,136 @@
+defmodule Electric.Shapes.PartitionedTablesTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Shapes.Shape
+  alias Electric.ShapeCache
+  alias Electric.Postgres.Inspector
+
+  import Support.ComponentSetup
+  import Support.DbSetup
+  import Support.DbStructureSetup
+
+  @partition_schema [
+    ~s|CREATE TABLE "partitioned_items" (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (b)|,
+    ~s|CREATE TABLE "partitioned_items_100" PARTITION OF "partitioned_items" FOR VALUES FROM (0) TO (99)|,
+    ~s|CREATE TABLE "partitioned_items_200" PARTITION OF "partitioned_items" FOR VALUES FROM (100) TO (199)|
+  ]
+
+  @moduletag :tmp_dir
+  @moduletag with_sql: @partition_schema
+
+  setup [:with_unique_db, :with_complete_stack, :with_sql_execute]
+
+  defp subscribe(shape_handle, ctx) do
+    ref = make_ref()
+
+    Registry.register(ctx.registry, shape_handle, ref)
+    ref
+  end
+
+  test "subscriptions to root shape receive updates", ctx do
+    {:ok, shape} = Shape.new("public.partitioned_items", inspector: ctx.inspector)
+
+    {shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(shape, stack_id: ctx.stack_id)
+
+    :started = ShapeCache.await_snapshot_start(shape_handle, stack_id: ctx.stack_id)
+
+    ref = subscribe(shape_handle, ctx)
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2), ($3, $4), ($5, $6)",
+      [1, 50, 2, 150, 3, 10]
+    )
+
+    assert_receive {^ref, :new_changes, _latest_log_offset}, 5000
+  end
+
+  test "new partition tables are accepted by root", ctx do
+    {:ok, shape} = Shape.new("public.partitioned_items", inspector: ctx.inspector)
+
+    {shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(shape, stack_id: ctx.stack_id)
+
+    :started = ShapeCache.await_snapshot_start(shape_handle, stack_id: ctx.stack_id)
+
+    Postgrex.query!(
+      ctx.db_conn,
+      ~s|CREATE TABLE "partitioned_items_300" PARTITION OF "partitioned_items" FOR VALUES FROM (200) TO (299)|,
+      []
+    )
+
+    ref = subscribe(shape_handle, ctx)
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2), ($3, $4), ($5, $6)",
+      [1, 250, 2, 260, 3, 200]
+    )
+
+    assert_receive {^ref, :new_changes, _latest_log_offset}, 5000
+  end
+
+  test "subscriptions to partitions receive updates", ctx do
+    {:ok, shape} = Shape.new("public.partitioned_items_100", inspector: ctx.inspector)
+
+    {shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(shape, stack_id: ctx.stack_id)
+
+    :started = ShapeCache.await_snapshot_start(shape_handle, stack_id: ctx.stack_id)
+
+    ref = subscribe(shape_handle, ctx)
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2), ($3, $4), ($5, $6)",
+      [1, 50, 2, 150, 3, 10]
+    )
+
+    assert_receive {^ref, :new_changes, _latest_log_offset}, 5000
+  end
+
+  test "new partition tables prompt reload of relation info", ctx do
+    {:ok, shape} = Shape.new("public.partitioned_items", inspector: ctx.inspector)
+
+    {shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(shape, stack_id: ctx.stack_id)
+
+    :started = ShapeCache.await_snapshot_start(shape_handle, stack_id: ctx.stack_id)
+
+    {:ok, relation} = Inspector.load_relation("partitioned_items", ctx.inspector)
+
+    assert %{
+             children: [
+               {"public", "partitioned_items_100"},
+               {"public", "partitioned_items_200"}
+             ]
+           } = relation
+
+    Postgrex.query!(
+      ctx.db_conn,
+      ~s|CREATE TABLE "partitioned_items_300" PARTITION OF "partitioned_items" FOR VALUES FROM (200) TO (299)|,
+      []
+    )
+
+    ref = subscribe(shape_handle, ctx)
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2), ($3, $4), ($5, $6)",
+      [1, 50, 2, 250, 3, 10]
+    )
+
+    assert_receive {^ref, :new_changes, _latest_log_offset}, 5000
+
+    {:ok, relation} = Inspector.load_relation("partitioned_items", ctx.inspector)
+
+    assert %{
+             children: [
+               {"public", "partitioned_items_100"},
+               {"public", "partitioned_items_200"},
+               {"public", "partitioned_items_300"}
+             ]
+           } = relation
+  end
+end

--- a/packages/sync-service/test/electric/shapes/partitioned_tables_test.exs
+++ b/packages/sync-service/test/electric/shapes/partitioned_tables_test.exs
@@ -35,6 +35,11 @@ defmodule Electric.Shapes.PartitionedTablesTest do
 
     :started = ShapeCache.await_snapshot_start(shape_handle, stack_id: ctx.stack_id)
 
+    assert Electric.Postgres.Configuration.get_publication_tables(
+             ctx.db_conn,
+             ctx.publication_name
+           ) == [{"public", "partitioned_items"}]
+
     ref = subscribe(shape_handle, ctx)
 
     Postgrex.query!(
@@ -79,6 +84,11 @@ defmodule Electric.Shapes.PartitionedTablesTest do
 
     :started = ShapeCache.await_snapshot_start(shape_handle, stack_id: ctx.stack_id)
 
+    assert Electric.Postgres.Configuration.get_publication_tables(
+             ctx.db_conn,
+             ctx.publication_name
+           ) == [{"public", "partitioned_items_100"}]
+
     ref = subscribe(shape_handle, ctx)
 
     Postgrex.query!(
@@ -107,18 +117,29 @@ defmodule Electric.Shapes.PartitionedTablesTest do
              ]
            } = relation
 
+    ref = subscribe(shape_handle, ctx)
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2)",
+      [1, 150]
+    )
+
+    assert_receive {^ref, :new_changes, _latest_log_offset}, 5000
+
     Postgrex.query!(
       ctx.db_conn,
       ~s|CREATE TABLE "partitioned_items_300" PARTITION OF "partitioned_items" FOR VALUES FROM (200) TO (299)|,
       []
     )
 
-    ref = subscribe(shape_handle, ctx)
-
+    # inserts into the new partition are received by the shape on the root
+    # which means that the system has added the new parition to the partition
+    # state
     Postgrex.query!(
       ctx.db_conn,
-      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2), ($3, $4), ($5, $6)",
-      [1, 50, 2, 250, 3, 10]
+      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2)",
+      [2, 250]
     )
 
     assert_receive {^ref, :new_changes, _latest_log_offset}, 5000
@@ -132,5 +153,107 @@ defmodule Electric.Shapes.PartitionedTablesTest do
                {"public", "partitioned_items_300"}
              ]
            } = relation
+  end
+
+  test "truncation of partition truncates the partition root", ctx do
+    {:ok, shape} = Shape.new("public.partitioned_items", inspector: ctx.inspector)
+    {:ok, partition_shape} = Shape.new("public.partitioned_items_100", inspector: ctx.inspector)
+
+    {shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(shape, stack_id: ctx.stack_id)
+
+    {partition_shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(partition_shape, stack_id: ctx.stack_id)
+
+    :started = ShapeCache.await_snapshot_start(shape_handle, stack_id: ctx.stack_id)
+    :started = ShapeCache.await_snapshot_start(partition_shape_handle, stack_id: ctx.stack_id)
+
+    ref = subscribe(shape_handle, ctx)
+    partition_ref = subscribe(partition_shape_handle, ctx)
+
+    assert [_, _] = active_shapes = ShapeCache.list_shapes(stack_id: ctx.stack_id)
+
+    assert MapSet.equal?(
+             MapSet.new(Enum.map(active_shapes, &elem(&1, 0))),
+             MapSet.new([shape_handle, partition_shape_handle])
+           )
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2), ($3, $4), ($5, $6), ($7, $8)",
+      [1, 50, 2, 150, 3, 10, 4, 190]
+    )
+
+    assert_receive {^ref, :new_changes, _latest_log_offset}, 5000
+    assert_receive {^partition_ref, :new_changes, _latest_log_offset}, 5000
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "TRUNCATE partitioned_items_200",
+      []
+    )
+
+    assert_receive {^ref, :shape_rotation}, 5000
+
+    assert [_] = active_shapes = ShapeCache.list_shapes(stack_id: ctx.stack_id)
+
+    assert MapSet.equal?(
+             MapSet.new(Enum.map(active_shapes, &elem(&1, 0))),
+             MapSet.new([partition_shape_handle])
+           )
+
+    assert Electric.Postgres.Configuration.get_publication_tables(
+             ctx.db_conn,
+             ctx.publication_name
+           ) == [{"public", "partitioned_items_100"}]
+  end
+
+  test "truncation of partition root truncates all partitions", ctx do
+    {:ok, shape} = Shape.new("public.partitioned_items", inspector: ctx.inspector)
+    {:ok, partition_shape} = Shape.new("public.partitioned_items_100", inspector: ctx.inspector)
+
+    {shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(shape, stack_id: ctx.stack_id)
+
+    {partition_shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(partition_shape, stack_id: ctx.stack_id)
+
+    :started = ShapeCache.await_snapshot_start(shape_handle, stack_id: ctx.stack_id)
+    :started = ShapeCache.await_snapshot_start(partition_shape_handle, stack_id: ctx.stack_id)
+
+    assert Electric.Postgres.Configuration.get_publication_tables(
+             ctx.db_conn,
+             ctx.publication_name
+           ) == [{"public", "partitioned_items"}, {"public", "partitioned_items_100"}]
+
+    ref = subscribe(shape_handle, ctx)
+    partition_ref = subscribe(partition_shape_handle, ctx)
+
+    assert [_, _] = ShapeCache.list_shapes(stack_id: ctx.stack_id)
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "INSERT INTO partitioned_items (a, b) VALUES ($1, $2), ($3, $4), ($5, $6), ($7, $8)",
+      [1, 50, 2, 150, 3, 10, 4, 190]
+    )
+
+    assert_receive {^ref, :new_changes, _latest_log_offset}, 5000
+    assert_receive {^partition_ref, :new_changes, _latest_log_offset}, 5000
+
+    Postgrex.query!(
+      ctx.db_conn,
+      "TRUNCATE partitioned_items",
+      []
+    )
+
+    assert_receive {^ref, :shape_rotation}, 5000
+    assert_receive {^partition_ref, :shape_rotation}, 5000
+
+    assert [] = ShapeCache.list_shapes(stack_id: ctx.stack_id)
+
+    assert Electric.Postgres.Configuration.get_publication_tables(
+             ctx.db_conn,
+             ctx.publication_name
+           ) == []
   end
 end

--- a/packages/sync-service/test/electric/shapes/partitions_test.exs
+++ b/packages/sync-service/test/electric/shapes/partitions_test.exs
@@ -1,0 +1,175 @@
+defmodule Electric.Shapes.PartitionsTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Replication.Changes.NewRecord
+  alias Electric.Replication.Changes.Relation
+  alias Electric.Replication.Changes.Transaction
+  alias Electric.Shapes.Partitions
+  alias Electric.Shapes.Shape
+
+  alias Support.StubInspector
+
+  @partition_inspector StubInspector.new(%{
+                         {"public", "partitioned"} => %{
+                           relation: %{
+                             children: [
+                               {"public", "partition_01"},
+                               {"public", "partition_02"}
+                             ]
+                           },
+                           columns: [
+                             %{name: "id", type: "int8", pk_position: 0},
+                             %{name: "an_array", array_type: "int8"}
+                           ]
+                         },
+                         {"public", "partition_01"} => %{
+                           relation: %{
+                             children: nil,
+                             parent: {"public", "partitioned"}
+                           },
+                           columns: [
+                             %{name: "id", type: "int8", pk_position: 0},
+                             %{name: "an_array", array_type: "int8"}
+                           ]
+                         },
+                         {"public", "partition_02"} => %{
+                           relation: %{
+                             children: nil,
+                             parent: {"public", "partitioned"}
+                           },
+                           columns: [
+                             %{name: "id", type: "int8", pk_position: 0},
+                             %{name: "an_array", array_type: "int8"}
+                           ]
+                         },
+                         {"public", "partition_03"} => %{
+                           relation: %{
+                             children: nil,
+                             parent: {"public", "partitioned"}
+                           },
+                           columns: [
+                             %{name: "id", type: "int8", pk_position: 0},
+                             %{name: "an_array", array_type: "int8"}
+                           ]
+                         }
+                       })
+
+  test "changes to table partition are sent to root" do
+    partitions =
+      Partitions.new(inspector: @partition_inspector)
+      |> Partitions.add_shape("s1", Shape.new!("partitioned", inspector: @partition_inspector))
+      |> Partitions.add_shape(
+        "s2",
+        Shape.new!("partitioned", where: "id = 2", inspector: @partition_inspector)
+      )
+      |> Partitions.add_shape(
+        "s3",
+        Shape.new!("partitioned", where: "id = 3", inspector: @partition_inspector)
+      )
+
+    new = %NewRecord{
+      relation: {"public", "partition_02"},
+      record: %{"id" => "2"}
+    }
+
+    root = %{new | relation: {"public", "partitioned"}}
+    insert = %Transaction{changes: [new]}
+
+    assert {_, %Transaction{changes: [^new, ^root]}} = Partitions.handle_event(partitions, insert)
+  end
+
+  test "no change expansion is done when no partitioned shapes are active" do
+    partitions =
+      Partitions.new(inspector: @partition_inspector)
+      |> Partitions.add_shape("s1", Shape.new!("partition_01", inspector: @partition_inspector))
+      |> Partitions.add_shape(
+        "s2",
+        Shape.new!("partition_01", where: "id = 2", inspector: @partition_inspector)
+      )
+      |> Partitions.add_shape(
+        "s3",
+        Shape.new!("partition_01", where: "id = 3", inspector: @partition_inspector)
+      )
+
+    insert = %Transaction{
+      changes: [
+        %NewRecord{
+          relation: {"public", "partition_01"},
+          record: %{"id" => "2"}
+        }
+      ]
+    }
+
+    {_, ^insert} = Partitions.handle_event(partitions, insert)
+  end
+
+  test "after addition of new partition, shape receives updates" do
+    partitions =
+      Partitions.new(inspector: @partition_inspector)
+      |> Partitions.add_shape("s1", Shape.new!("partitioned", inspector: @partition_inspector))
+      |> Partitions.add_shape(
+        "s2",
+        Shape.new!("partitioned", where: "id = 2", inspector: @partition_inspector)
+      )
+      |> Partitions.add_shape(
+        "s3",
+        Shape.new!("partition_01", inspector: @partition_inspector)
+      )
+
+    new = %NewRecord{relation: {"public", "partition_03"}, record: %{"id" => "2"}}
+    root = %NewRecord{relation: {"public", "partitioned"}, record: %{"id" => "2"}}
+    insert = %Transaction{changes: [new]}
+
+    {_, ^insert} = Partitions.handle_event(partitions, insert)
+
+    relation = %Relation{schema: "public", table: "partition_03"}
+
+    {partitions, ^relation} = Partitions.handle_event(partitions, relation)
+
+    {_, %Transaction{changes: [^new, ^root]}} = Partitions.handle_event(partitions, insert)
+  end
+
+  test "remove_shape/2 cleans up partition information" do
+    empty = Partitions.new(inspector: @partition_inspector)
+    partition_03 = %Relation{schema: "public", table: "partition_03"}
+
+    partitions =
+      empty
+      |> Partitions.add_shape("s1", Shape.new!("partitioned", inspector: @partition_inspector))
+      |> Partitions.add_shape(
+        "s2",
+        Shape.new!("partitioned", where: "id = 1", inspector: @partition_inspector)
+      )
+      |> Partitions.add_shape(
+        "s3",
+        Shape.new!("partition_01", where: "id = 2", inspector: @partition_inspector)
+      )
+      |> Partitions.add_shape(
+        "s4",
+        Shape.new!("partition_02", where: "id > 2", inspector: @partition_inspector)
+      )
+      |> Partitions.handle_relation(partition_03)
+      |> Partitions.add_shape(
+        "s5",
+        Shape.new!("partition_03", where: "id > 7", inspector: @partition_inspector)
+      )
+
+    new = %NewRecord{relation: {"public", "partition_03"}, record: %{"id" => "2"}}
+    root = %NewRecord{relation: {"public", "partitioned"}, record: %{"id" => "2"}}
+    insert = %Transaction{changes: [new]}
+
+    assert {_, %Transaction{changes: [^new, ^root]}} = Partitions.handle_event(partitions, insert)
+
+    clean_partitions =
+      partitions
+      |> Partitions.remove_shape("s2")
+      |> Partitions.remove_shape("s1")
+      |> Partitions.remove_shape("s4")
+      |> Partitions.remove_shape("s5")
+      |> Partitions.remove_shape("s3")
+
+    assert clean_partitions == empty
+
+    assert {_, %Transaction{changes: [^new]}} = Partitions.handle_event(clean_partitions, insert)
+  end
+end

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -207,6 +207,31 @@ defmodule Electric.Shapes.ShapeTest do
 
       assert Shape.convert_change(shape, non_matching_update) == []
     end
+
+    test "re-writes changes to partition on shape" do
+      shape = %Shape{
+        root_table: {"public", "partition_root"},
+        root_table_id: @relation_id,
+        partitions: %{
+          {"public", "partition_01"} => {"public", "partition_root"},
+          {"public", "partition_02"} => {"public", "partition_root"}
+        }
+      }
+
+      partition_update = %UpdatedRecord{
+        relation: {"public", "partition_02"},
+        old_record: %{"id" => 1, "value" => "same", "other_value" => "old"},
+        record: %{"id" => 1, "value" => "same", "other_value" => "new"}
+      }
+
+      assert Shape.convert_change(shape, partition_update) == [
+               %UpdatedRecord{
+                 relation: {"public", "partition_root"},
+                 old_record: %{"id" => 1, "value" => "same", "other_value" => "old"},
+                 record: %{"id" => 1, "value" => "same", "other_value" => "new"}
+               }
+             ]
+    end
   end
 
   describe "new/2" do

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -207,31 +207,6 @@ defmodule Electric.Shapes.ShapeTest do
 
       assert Shape.convert_change(shape, non_matching_update) == []
     end
-
-    test "re-writes changes to partition on shape" do
-      shape = %Shape{
-        root_table: {"public", "partition_root"},
-        root_table_id: @relation_id,
-        partitions: %{
-          {"public", "partition_01"} => {"public", "partition_root"},
-          {"public", "partition_02"} => {"public", "partition_root"}
-        }
-      }
-
-      partition_update = %UpdatedRecord{
-        relation: {"public", "partition_02"},
-        old_record: %{"id" => 1, "value" => "same", "other_value" => "old"},
-        record: %{"id" => 1, "value" => "same", "other_value" => "new"}
-      }
-
-      assert Shape.convert_change(shape, partition_update) == [
-               %UpdatedRecord{
-                 relation: {"public", "partition_root"},
-                 old_record: %{"id" => 1, "value" => "same", "other_value" => "old"},
-                 record: %{"id" => 1, "value" => "same", "other_value" => "new"}
-               }
-             ]
-    end
   end
 
   describe "new/2" do

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -182,8 +182,7 @@ defmodule Support.ComponentSetup do
 
     stack_events_registry = Registry.StackEvents
 
-    ref = make_ref()
-    Electric.StackSupervisor.subscribe_to_stack_events(stack_events_registry, stack_id, ref)
+    ref = Electric.StackSupervisor.subscribe_to_stack_events(stack_events_registry, stack_id)
 
     stack_supervisor =
       start_supervised!(
@@ -214,10 +213,13 @@ defmodule Support.ComponentSetup do
 
     %{
       stack_id: stack_id,
+      registry: Electric.StackSupervisor.registry_name(stack_id),
       stack_events_registry: stack_events_registry,
+      shape_cache: {ShapeCache, [stack_id: stack_id]},
       persistent_kv: kv,
       stack_supervisor: stack_supervisor,
-      storage: storage
+      storage: storage,
+      inspector: {EtsInspector, stack_id: stack_id, server: EtsInspector.name(stack_id: stack_id)}
     }
   end
 

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -183,6 +183,7 @@ defmodule Support.ComponentSetup do
     stack_events_registry = Registry.StackEvents
 
     ref = Electric.StackSupervisor.subscribe_to_stack_events(stack_events_registry, stack_id)
+    publication_name = "electric_test_pub_#{:erlang.phash2(stack_id)}"
 
     stack_supervisor =
       start_supervised!(
@@ -194,7 +195,7 @@ defmodule Support.ComponentSetup do
          connection_opts: ctx.db_config,
          replication_opts: [
            slot_name: "electric_test_slot_#{:erlang.phash2(stack_id)}",
-           publication_name: "electric_test_pub_#{:erlang.phash2(stack_id)}",
+           publication_name: publication_name,
            try_creating_publication?: true,
            slot_temporary?: true
          ],
@@ -219,7 +220,9 @@ defmodule Support.ComponentSetup do
       persistent_kv: kv,
       stack_supervisor: stack_supervisor,
       storage: storage,
-      inspector: {EtsInspector, stack_id: stack_id, server: EtsInspector.name(stack_id: stack_id)}
+      inspector:
+        {EtsInspector, stack_id: stack_id, server: EtsInspector.name(stack_id: stack_id)},
+      publication_name: publication_name
     }
   end
 

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -209,7 +209,7 @@ defmodule Support.ComponentSetup do
 
     # allow a reasonable time for full stack setup to account for
     # potential CI slowness, including PG
-    assert_receive {:stack_status, ^ref, :ready}, 1000
+    assert_receive {:stack_status, ^ref, :ready}, 2000
 
     %{
       stack_id: stack_id,

--- a/packages/sync-service/test/support/stub_inspector.ex
+++ b/packages/sync-service/test/support/stub_inspector.ex
@@ -1,12 +1,13 @@
 defmodule Support.StubInspector do
-  alias Electric.Utils
   @behaviour Electric.Postgres.Inspector
 
+  # the opts is either a list of column details which will be applied to every table
+  # or a map of %{{schema, name} => [columns: column_info, relation: relation_info]}
   def new(opts), do: {__MODULE__, opts}
 
   @impl true
-  def load_column_info(_relation, column_list) when is_list(column_list) do
-    column_list
+  def load_column_info(_relation, column_info) when is_list(column_info) do
+    column_info
     |> Enum.map(fn column ->
       column
       |> Map.put_new(:pk_position, nil)
@@ -19,31 +20,44 @@ defmodule Support.StubInspector do
   def load_column_info(relation, opts) when is_map(opts) and is_map_key(opts, relation) do
     opts
     |> Map.fetch!(relation)
+    |> Access.fetch!(:columns)
     |> then(&load_column_info(relation, &1))
   end
 
   @impl true
-  def load_relation(table, _) do
-    regex =
-      ~r/^((?<schema>([\p{L}_][\p{L}0-9_$]*|"(""|[^"])+"))\.)?(?<table>([\p{L}_][\p{L}0-9_$]*|"(""|[^"])+"))$/u
+  def load_relation(table, opts) when is_map(opts) do
+    with {:ok, rel} <- parse_relation(table),
+         {:ok, config} <- Map.fetch(opts, rel),
+         {:ok, info} <- Access.fetch(config, :relation) do
+      {:ok,
+       info
+       |> Map.put_new(:relation, rel)
+       |> Map.put_new(:relation_id, :erlang.phash2(rel))
+       |> Map.put_new(:parent, nil)
+       |> Map.put_new(:children, nil)}
+    else
+      :error ->
+        raise "Invalid StubInspector config #{inspect(opts)}"
 
-    case Regex.run(regex, table, capture: :all_names) do
-      ["", table_name] when table_name != "" ->
-        table_name = Utils.parse_quoted_name(table_name)
-        rel = {"public", table_name}
-        {:ok, %{relation: rel, relation_id: :erlang.phash2(rel)}}
+      error ->
+        error
+    end
+  end
 
-      [schema_name, table_name] when table_name != "" ->
-        schema_name = Utils.parse_quoted_name(schema_name)
-        table_name = Utils.parse_quoted_name(table_name)
-        rel = {schema_name, table_name}
-        {:ok, %{relation: rel, relation_id: :erlang.phash2(rel)}}
-
-      _ ->
-        {:error, "invalid name syntax"}
+  def load_relation(table, _opts) do
+    with {:ok, rel} <- parse_relation(table) do
+      {:ok, %{relation: rel, relation_id: :erlang.phash2(rel)}}
     end
   end
 
   @impl true
   def clean(_, _), do: true
+
+  defp parse_relation(table) when is_binary(table) do
+    Electric.Postgres.Identifiers.parse_relation(table)
+  end
+
+  defp parse_relation({_, _} = rel) do
+    {:ok, rel}
+  end
 end

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -84,7 +84,7 @@ curl -i 'http://localhost:3000/v1/shape?table=measurement&offset=-1'
 curl -i 'http://localhost:3000/v1/shape?table=measurement_y2025m03&offset=-1'
 ```
 
-The shape based on the `measurement_y2025m03` partition will only receive writes that fall within the partition range, that is with `logdate >= '2025-02-01' AND  logdate < '2025-03-01'` whereas the shaped based on the root `measurements` table will receive all writes to all partitions.
+The shape based on the `measurement_y2025m03` partition will only receive writes that fall within the partition range, that is with `logdate >= '2025-02-01' AND  logdate < '2025-03-01'` whereas the shape based on the root `measurements` table will receive all writes to all partitions.
 
 ### Where clause
 

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -56,6 +56,36 @@ This is the root table of the shape. All shapes must specify a table and it must
 
 The value can be just a tablename like `projects`, or can be a qualified tablename prefixed by the database schema using a `.` delimiter, such as `foo.projects`. If you don't provide a schema prefix, then the table is assumed to be in the `public.` schema.
 
+#### Partitioned Tables
+
+Electric supports subscribing to [partitioned tables](https://www.postgresql.org/docs/17/ddl-partitioning.html), both individual partitions and the root table of all partitions.
+
+Consider the following partitioned schema:
+
+```sql
+CREATE TABLE measurement (
+    city_id         int not null,
+    logdate         date not null,
+    peaktemp        int,
+    unitsales       int
+) PARTITION BY RANGE (logdate);
+
+CREATE TABLE measurement_y2025m02 PARTITION OF measurement
+    FOR VALUES FROM ('2025-02-01') TO ('2025-03-01');
+
+CREATE TABLE measurement_y2025m03 PARTITION OF measurement
+    FOR VALUES FROM ('2025-03-01') TO ('2025-04-01');
+```
+
+We create 2 shapes, one on the root table `measurement` and one on the `measurement_y2025m03` partition:
+
+```sh
+curl -i 'http://localhost:3000/v1/shape?table=measurement&offset=-1'
+curl -i 'http://localhost:3000/v1/shape?table=measurement_y2025m03&offset=-1'
+```
+
+The shape based on the `measurement_y2025m03` partition will only receive writes that fall within the partition range, that is with `logdate >= '2025-02-01' AND  logdate < '2025-03-01'` whereas the shaped based on the root `measurements` table will receive all writes to all partitions.
+
 ### Where clause
 
 Shapes can define an optional where clause to filter out which rows from the table are included in the shape. Only rows that match the where clause will be included.

--- a/website/docs/guides/shapes.md
+++ b/website/docs/guides/shapes.md
@@ -58,7 +58,7 @@ The value can be just a tablename like `projects`, or can be a qualified tablena
 
 #### Partitioned Tables
 
-Electric supports subscribing to [partitioned tables](https://www.postgresql.org/docs/17/ddl-partitioning.html), both individual partitions and the root table of all partitions.
+Electric supports subscribing to [declaratively partitioned tables](https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE), both individual partitions and the root table of all partitions.
 
 Consider the following partitioned schema:
 


### PR DESCRIPTION
Allows for subscribing to partitions of a partitioned table (which you could already do) but also subscribing to the root, partitioned, table and receiving all updates across all partitions.

Fixes #2118 

Major changes:

- Add support for partitioned table types in the various inspector queries
- Include partition hierarchy information in relation information from pg and in inspector relation info
- Force reload of table information when receiving a new relation that is a partition
- Add partition information to `Filter` so that it can correctly pass on a change on a partition table to a shape on the partition root.
- For a shape subscribed to the partition root, changes coming in on partitions will be re-written so that their relation matches the partition root. The change `key`s are not being re-written - I don't think this is an issue as the keys are guaranteed to be unique and that's enough.
- Relation messages notifying of a new partition table are forwarded onto root-partition consumers so the shape can be updated with knowledge of the new partition (this does not cause the shape to be deleted)
- I've added a full-stack test to verify this stuff so that we're not making assumptions about pg's handling of partitions

Minor:

- support querying the inspector based on the {schema, name} relation tuple, as well as the table name string because I needed to be able to look up table info based
- Filter instances now have an inspector instance so they can do table info lookups to get partition information
- The filter functions used by the dispatcher now return `{filter, shape_ids}` so that the filter's state can be updated
- I've tweaked StubInspector so we can return richer info from the load_relation call
- Added missing serialisation of a shape's replica setting