### PR TITLE
fix: run dist-tag after changeset publish to set latest tag on npm

### DIFF
--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -38,3 +38,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+      - name: Add latest tag to published packages
+        if: steps.changesets.outputs.published == 'true'
+        run: node scripts/tag-latest.mjs
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,11 +14,14 @@
     "ci:publish": "pnpm '/^ci:publish:.+/'",
     "ci:publish:hex-electric": "pnpm run --dir packages/sync-service publish:hex",
     "ci:publish:hex-electric-client": "pnpm run --dir packages/elixir-client publish:hex",
-    "ci:publish:npm": "pnpm changeset publish --tag latest",
+    "ci:publish:npm": "pnpm changeset publish",
     "ci:version": "pnpm exec changeset version",
     "example-backend:down": "dotenv  -e .env.dev -- docker compose -f .support/docker-compose.yml down --volumes",
     "example-backend:just_up": "dotenv -e .env.dev -- docker compose -f ./.support/docker-compose.yml up -d",
     "example-backend:up": "pnpm example-backend:down && pnpm example-backend:just_up",
     "stylecheck-all": "pnpm --if-present --recursive run stylecheck"
+  },
+  "devDependencies": {
+    "glob": "^10.3.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,10 @@ importers:
       dotenv-cli:
         specifier: ^7.4.2
         version: 7.4.2
+    devDependencies:
+      glob:
+        specifier: ^10.3.10
+        version: 10.4.5
 
   examples/bash: {}
 
@@ -741,7 +745,7 @@ importers:
         version: 0.3.4
       tsup:
         specifier: ^8.0.1
-        version: 8.3.5(@swc/core@1.9.1)(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
+        version: 8.3.5(@swc/core@1.9.1(@swc/helpers@0.5.5))(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
       tsx:
         specifier: ^4.19.1
         version: 4.19.2
@@ -1194,7 +1198,7 @@ importers:
         version: 0.3.4
       tsup:
         specifier: ^8.0.1
-        version: 8.3.5(@swc/core@1.9.1)(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
+        version: 8.3.5(@swc/core@1.9.1(@swc/helpers@0.5.5))(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
       typescript:
         specifier: ^5.5.2
         version: 5.6.3
@@ -1270,7 +1274,7 @@ importers:
         version: 0.3.4
       tsup:
         specifier: ^8.0.1
-        version: 8.3.5(@swc/core@1.9.1)(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
+        version: 8.3.5(@swc/core@1.9.1(@swc/helpers@0.5.5))(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
       typescript:
         specifier: ^5.5.2
         version: 5.6.3
@@ -1330,7 +1334,7 @@ importers:
         version: 0.3.4
       tsup:
         specifier: ^8.0.1
-        version: 8.3.5(@swc/core@1.9.1)(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
+        version: 8.3.5(@swc/core@1.9.1(@swc/helpers@0.5.5))(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
       typescript:
         specifier: ^5.5.2
         version: 5.6.3
@@ -15768,7 +15772,7 @@ snapshots:
 
   foreground-child@3.3.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
   form-data@4.0.1:
@@ -19081,7 +19085,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.5(@swc/core@1.9.1)(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0):
+  tsup@8.3.5(@swc/core@1.9.1(@swc/helpers@0.5.5))(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.24.0)
       cac: 6.7.14

--- a/scripts/tag-latest.mjs
+++ b/scripts/tag-latest.mjs
@@ -1,28 +1,30 @@
-import { glob } from 'glob';
-import { readFileSync } from 'fs';
-import { execSync } from 'child_process';
+import { glob } from "glob"
+import { readFileSync } from "fs"
+import { execSync } from "child_process"
 
 async function tagLatest() {
   // Find all package.json files in the packages directory
-  const packageFiles = glob.sync('./packages/*/package.json');
-  
+  const packageFiles = glob.sync("./packages/*/package.json")
+
   for (const file of packageFiles) {
-    const pkg = JSON.parse(readFileSync(file));
-    const { name, version, private: isPrivate } = pkg;
-    
-    if (!name || !version || isPrivate) continue;
-    
-    console.log(`Tagging ${name}@${version} as latest`);
+    const pkg = JSON.parse(readFileSync(file))
+    const { name, version, private: isPrivate } = pkg
+
+    if (!name || !version || isPrivate) continue
+
+    console.log(`Tagging ${name}@${version} as latest`)
     try {
-      execSync(`npm dist-tag add ${name}@${version} latest`, { stdio: 'inherit' });
+      execSync(`npm dist-tag add ${name}@${version} latest`, {
+        stdio: "inherit",
+      })
     } catch (e) {
-      console.error(`Failed to tag ${name}@${version}:`, e);
-      process.exit(1);
+      console.error(`Failed to tag ${name}@${version}:`, e)
+      process.exit(1)
     }
   }
 }
 
-tagLatest().catch(e => {
-  console.error(e);
-  process.exit(1);
-});
+tagLatest().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/tag-latest.mjs
+++ b/scripts/tag-latest.mjs
@@ -1,0 +1,28 @@
+import { glob } from 'glob';
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+
+async function tagLatest() {
+  // Find all package.json files in the packages directory
+  const packageFiles = glob.sync('./packages/*/package.json');
+  
+  for (const file of packageFiles) {
+    const pkg = JSON.parse(readFileSync(file));
+    const { name, version, private: isPrivate } = pkg;
+    
+    if (!name || !version || isPrivate) continue;
+    
+    console.log(`Tagging ${name}@${version} as latest`);
+    try {
+      execSync(`npm dist-tag add ${name}@${version} latest`, { stdio: 'inherit' });
+    } catch (e) {
+      console.error(`Failed to tag ${name}@${version}:`, e);
+      process.exit(1);
+    }
+  }
+}
+
+tagLatest().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/tag-latest.mjs
+++ b/scripts/tag-latest.mjs
@@ -16,6 +16,7 @@ async function tagLatest() {
     try {
       execSync(`npm dist-tag add ${name}@${version} latest`, {
         stdio: "inherit",
+        env: { ...process.env },
       })
     } catch (e) {
       console.error(`Failed to tag ${name}@${version}:`, e)


### PR DESCRIPTION
Changeset doesn't allow custom tags with prereleases 🤷 https://github.com/changesets/changesets/issues/546