### PR TITLE
fix(sync-service): Fix bug with logical operators with 3 or more arguments

### DIFF
--- a/.changeset/stale-bats-tickle.md
+++ b/.changeset/stale-bats-tickle.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix bug with WHERE clauses with logical operators (AND, OR, etc.) with 3 or more conditions chained together

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -62,6 +62,13 @@ defmodule Electric.Replication.Eval.RunnerTest do
                |> Runner.execute(%{["test"] => "test"})
     end
 
+    test "can evaluate AND expression with multiple conditions" do
+      assert {:ok, true} =
+               ~S|test > 1 AND (test = 2 AND test < 3)|
+               |> Parser.parse_and_validate_expression!(%{["test"] => :int4})
+               |> Runner.execute(%{["test"] => 2})
+    end
+
     test "should work with array types" do
       assert {:ok, [[1, 2], [3, 4]]} =
                ~S|ARRAY[ARRAY[1, x], ARRAY['3', 2 + 2]]|

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -64,7 +64,7 @@ defmodule Electric.Replication.Eval.RunnerTest do
 
     test "can evaluate AND expression with multiple conditions" do
       assert {:ok, true} =
-               ~S|test > 1 AND (test = 2 AND test < 3)|
+               ~S|test > 1 AND test = 2 AND test < 3|
                |> Parser.parse_and_validate_expression!(%{["test"] => :int4})
                |> Runner.execute(%{["test"] => 2})
     end


### PR DESCRIPTION
Fix for #2224 