### PR TITLE
fix linearlite loading if issue url is opened directly with no synced issue database

### DIFF
--- a/examples/linearlite/src/App.tsx
+++ b/examples/linearlite/src/App.tsx
@@ -116,6 +116,7 @@ async function issueLoader({
   params: Params
   request: Request
 }) {
+  await waitForInitialSyncDone()
   const pg = await pgPromise
   const liveIssue = await pg.live.query<IssueType>({
     query: `SELECT * FROM issue WHERE id = $1`,

--- a/examples/linearlite/src/pages/Issue/index.tsx
+++ b/examples/linearlite/src/pages/Issue/index.tsx
@@ -63,8 +63,6 @@ function IssuePage() {
   )
 
   if (issue === undefined) {
-    return <div className="p-8 w-full text-center">Loading...</div>
-  } else if (issue === null) {
     return <div className="p-8 w-full text-center">Issue not found</div>
   }
 


### PR DESCRIPTION
I was trying to debug something unrelated and found that the IssuePage was getting into a bad state if you browsed directly to it in an incognito tab without visiting the main page first.

The fix is reasonably trivial: delay all rendering queries until the initial db dump in synced, like how the rest of the example works.

I also fixed the "not found" rendering. I don't think that `useLiveQuery(liveIssue).rows[0]` can ever be `null`: it will always be `Item | undefined` (typescript types it as `Item` unless you turn on noUncheckedIndexedAccess).

# steps to test

* check that navigating to issue with no synced issue database works
  * open http://localhost:5173/ and click on an issue to get issue url (it will look like http://localhost:5173/issue/d8af89e7-d1cf-4488-8b1b-424f120d0aa6)
  * open a new incognito window (⌘⇧N) and go to that url
    * in main, you would get `Loading...` forever (it would fix itself if you refresh the page)
    * on this branch, it should load correctly
* check that navigating to a nonexistent issue tells you "not found"
  * open an issue that doesn't exist (e.g. http://localhost:5173/issue/00000000-0000-0000-0000-000000000000)
    * on main, you would get `Loading...`
    * on this branch, you should get `Issue not found`