### PR TITLE
use <Link/> in lineralite list view; fix priority/status assignment ui

### DIFF
--- a/examples/linearlite/src/pages/List/IssueRow.tsx
+++ b/examples/linearlite/src/pages/List/IssueRow.tsx
@@ -70,7 +70,7 @@ function IssueRow({ issue, style }: Props) {
       </div>
       <Link
         to={`/issue/${issue.id}`}
-        className="flex items-center flex-grow min-w-0"
+        className="flex items-center flex-grow min-w-0 h-full"
       >
         <div className="flex-wrap flex-shrink ml-3 overflow-hidden font-medium line-clamp-1 overflow-ellipsis">
           {issue.title.slice(0, 3000) || ``}


### PR DESCRIPTION
this is related to https://github.com/electric-sql/electric/pull/2238 in that it allows you to reproduce the issue a bit better

Probably easier to review with whitespace turned off - https://github.com/electric-sql/electric/pull/2239/files?w=1

# steps to test:

* Check that "open in a new tab" and "open in an incognito tab" work
  * open http://localhost:5173/ 
  * right click on an issue title
    * on main, this is not a link, so nothing useful is in the context menu
    * on this branch, this is a `<Link >` (an `<a>` with a click handler that does the preventDefault() + redirect dance), so you get the following context menu:
      * ![Screenshot 2025-01-22 at 12 20 38](https://github.com/user-attachments/assets/84e12497-c436-40d6-8fb3-e59b03dba38e)
      * [ ] I have no idea why right-clicking on the text causes the title + time + opener (everything in the <Link> to be selected.  If you are fine with this, please check this box)
      * Note that "open in incognito window" will not work until #2238 is merged
      * check that ⌘+click works too, and check that clicking around normally works
      * check that the click target for the <Link> is the full height of the row (not just the height of the text)
* Check that PriorityMenu and StatusMenu now work
  * click on PriorityMenu
    * on main this click is sometimes swallowed by the reroute to the item page, depending on whether you tap super-quickly on your touchpad or click a bit harder. I thought about trying to work out where to put the stopPropagation() or whatever to protect these menu clicks, but in the end I decided to move them outside the `<Link>`.
    * on this branch it should look like this always: 
![Screenshot 2025-01-22 at 12 38 35](https://github.com/user-attachments/assets/d3024982-db27-44da-9584-861991050e91)
    * updates should be immediately reflected in the UI
      * [ ] sometimes the thing seems to get wedged and the ui updates don't happen, but it fixes itself on refresh and ui updates happen instantly again (I think this is related the issue that I was trying to debug when I started this whole journey. Something to do with stack overflow in wasm somewhere? I will make an issue for this when I have a reliable reproduction and then I will check this box).
      * [ ] I seem to always have the broken cloud icon on rows that I have changed. I think this is either normal or unrelated though? Please check this box if this is fine, otherwise leave a comment and I will look into it further.
   * same for StatusMenu
