### PR TITLE
docs: Fix caddy reverse proxy docs

### DIFF
--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -34,7 +34,7 @@ npx @radically-straightforward/caddy run \
     --config - \
     --adapter caddyfile \
     <<EOF
-:3001 {
+localhost:3001 {
   reverse_proxy localhost:3000
   encode {
     gzip


### PR DESCRIPTION
It appears that you now (at least on my machine) need to specify the `localhost` host name in the caddy file to get it to properly enable tls.