### PR TITLE
chore: Simpler example stage DB naming

### DIFF
--- a/examples/linearlite-read-only/sst.config.ts
+++ b/examples/linearlite-read-only/sst.config.ts
@@ -22,10 +22,7 @@ export default $config({
   async run() {
     const project = neon.getProjectOutput({ id: process.env.NEON_PROJECT_ID! })
 
-    const dbName =
-      $app.stage === `Production`
-        ? `linearlite-read-only-production`
-        : `linearlite-read-only-${$app.stage}`
+    const dbName = `linearlite-read-only-${$app.stage}`
 
     const { ownerName, dbName: resultingDbName } = createNeonDb({
       projectId: project.id,

--- a/examples/nextjs/sst.config.ts
+++ b/examples/nextjs/sst.config.ts
@@ -22,8 +22,7 @@ export default $config({
   async run() {
     const project = neon.getProjectOutput({ id: process.env.NEON_PROJECT_ID! })
 
-    const dbName =
-      $app.stage === `Production` ? `nextjs-production` : `nextjs-${$app.stage}`
+    const dbName = `nextjs-${$app.stage}`
 
     const { ownerName, dbName: resultingDbName } = createNeonDb({
       projectId: project.id,


### PR DESCRIPTION
Previous was wrong and redundant, as the stage specified in CI is `production` not `Production`