### PR TITLE
fix race condition when using mock backend

### DIFF
--- a/.changeset/mighty-monkeys-marry.md
+++ b/.changeset/mighty-monkeys-marry.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Fix race condition when using mock backend


### PR DESCRIPTION
rather than complex logic around subscriber vs response ordering (which was fallible), simply don't launch the request until we have at least one subscriber

@msfstef this was causing flaky tests in the cloud repo