### PR TITLE
(chore): Fix sporadically failing test due to capture_log

### DIFF
--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -96,7 +96,7 @@ defmodule Electric.Postgres.ConfigurationTest do
                  pg_version,
                  publication
                )
-             end) =~ "Altering identity"
+             end) =~ ~r"#{:erlang.pid_to_list(self())}.*Altering identity"
 
       assert get_table_identity(conn, {"public", "items"}) == "f"
 
@@ -112,7 +112,10 @@ defmodule Electric.Postgres.ConfigurationTest do
                  pg_version,
                  publication
                )
-             end) =~ "Altering identity"
+             end) =~ ~r"#{:erlang.pid_to_list(self())}.*Altering identity"
+
+      # Above we include the pid in the regex to ensure that the log message is from this test's process
+      # otherwise this test can sporadically fail when run concurrently with other tests that log that message
     end
 
     test "works with multiple tables", %{


### PR DESCRIPTION
This PR fixes the sporadic test that can be seen failing here:
https://github.com/electric-sql/electric/actions/runs/12934429277/job/36075427601

I've also added the cause to slab so that we can hopefully prevent this kind of issue in the future:
https://electric-sql.slab.com/posts/sporadically-failing-elixir-tests-pfyia5on?shr=vrDh-k20QJMXaygzaPfMu4J4