### PR TITLE
Use `unsafe_cleanup!/1` to delete data after consumer has stopped

### DIFF
--- a/.changeset/seven-files-thank.md
+++ b/.changeset/seven-files-thank.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Use `Storage.unsafe_cleanup!/1` to delete data after a shape has been removed

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -294,6 +294,10 @@ defmodule Electric.ShapeCache do
       shape_handle
     )
 
+    shape_handle
+    |> Electric.ShapeCache.Storage.for_shape(state.storage)
+    |> Electric.ShapeCache.Storage.unsafe_cleanup!()
+
     :ok
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -536,13 +536,16 @@ defmodule Electric.ShapeCache.FileStorage do
 
   @impl Electric.ShapeCache.Storage
   def cleanup!(%FS{} = opts) do
+    # can't delete the data_dir here because the CubDb instance is still running,
+    # and trying to delete the parent directory will fail since the files inside
+    # are still in use
     :ok = cleanup_internals!(opts)
-    {:ok, _} = File.rm_rf(opts.data_dir)
-    :ok
   end
 
   @impl Electric.ShapeCache.Storage
   def unsafe_cleanup!(%FS{} = opts) do
+    {:ok, _} = File.rm_rf(opts.snapshot_dir)
+    {:ok, _} = File.rm_rf(shape_definition_path(opts))
     {:ok, _} = File.rm_rf(opts.data_dir)
     :ok
   end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -41,6 +41,10 @@ defmodule Support.ComponentSetup do
     %{storage: {InMemoryStorage, storage_opts}}
   end
 
+  def with_tracing_storage(%{storage: storage}) do
+    [storage: Support.TestStorage.wrap(storage, %{})]
+  end
+
   def with_no_pool(_ctx) do
     %{pool: :no_pool}
   end

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -32,6 +32,8 @@ defmodule Support.TestStorage do
     {__MODULE__, {parent, init, storage}}
   end
 
+  def backing_storage({__MODULE__, {_parent, _init, storage}}), do: storage
+
   @impl Electric.ShapeCache.Storage
   def shared_opts(_opts) do
     raise "don't use this, initialise the memory opts directly"


### PR DESCRIPTION
When cleaning up a shape we call `cleanup!` and (in the case of FileStorage) attempt to remove the data directory while the CubDb process is still running.

This fails (`File.rm_rf/1` returns `{:error, :eexist, _}`) because the files are still in use. 

Instead of removing the directory on `cleanup!` while the process(es) are still running, instead teardown the consumer supervision tree and use `unsafe_cleanup!/1` do remove the directories. 

`unsafe_cleanup!` is already documented as something that should be runnable without any active processes, so this is an ideal use.

Fixes problems with https://github.com/electric-sql/stratovolt/pull/243