### PR TITLE
fix: Fallback to IPv4 from IPv6

### DIFF
--- a/.changeset/curly-horses-hear.md
+++ b/.changeset/curly-horses-hear.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fallback to IPv4 if `DATABASE_USE_IPV6` is enabled but an IPv6 address could not be resolved.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -543,7 +543,8 @@ defmodule Electric.Connection.Manager do
       # disable IPv6 and retry immediately
       state = %{
         state
-        | connection_opts: connection_opts |> Keyword.put(:ipv6, false) |> update_tcp_opts()
+        | ipv6_enabled: false,
+          connection_opts: connection_opts |> Keyword.put(:ipv6, false) |> update_tcp_opts()
       }
 
       step = current_connection_step(state)


### PR DESCRIPTION
When `DATABASE_USE_IPV6` is enabled, but the provided DB URL has no resolvable IPv6 address (no AAAA record), naively fallback to IPv4.

A more general discussion on this fallback behaviour for Erlang's networking stack can be found here https://github.com/erlang/otp/issues/8548

Ideally we would be able to handle this sort of fallback directly with Postgrex, and it used to have the possibility to specify multiple endpoints with different options that it would try sequentially, but it is no longer supported.

I have opened an issue to see if there is a potential solution to this that can be supported by Postgrex directly https://github.com/elixir-ecto/postgrex/issues/730

Perhaps once we are happy with both IPv6 and IPv4 being supported out of the box we can remove the `DATABASE_USE_IPV6` option and always default to supporting it, but I think it's safer to explore this a bit further. This PR introduces a naive fix that does not cover all possible failure and fallback cases, but unblocks the basic case of AAAA records missing while also supporting IPv6.