### PR TITLE
feat(sync-service): Connect shape consumer spans to replication traces and add OTEL metrics

### DIFF
--- a/.changeset/smooth-lions-joke.md
+++ b/.changeset/smooth-lions-joke.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Connect shape consumer spans to replication traces and add OTEL metrics

--- a/packages/sync-service/lib/electric/telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry.ex
@@ -210,6 +210,8 @@ defmodule Electric.Telemetry do
 
   defp otel_metrics() do
     [
+      last_value("electric.storage.used", unit: {:byte, :kilobyte}),
+      last_value("electric.shapes.total_shapes.count"),
       last_value("system.load_percent.avg1"),
       last_value("system.load_percent.avg5"),
       last_value("system.load_percent.avg15"),

--- a/packages/sync-service/test/electric/shapes/dispatcher_test.exs
+++ b/packages/sync-service/test/electric/shapes/dispatcher_test.exs
@@ -65,11 +65,11 @@ defmodule Electric.Shapes.DispatcherTest do
 
     {:ok, [], dispatcher} = D.dispatch([event], 1, dispatcher)
 
-    assert_receive {C, ^ref1, [^event]}
+    assert_receive {C, ^ref1, [{^event, _ctx}]}
     assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
-    assert_receive {C, ^ref2, [^event]}
+    assert_receive {C, ^ref2, [{^event, _ctx}]}
     assert {:ok, 0, dispatcher} = D.ask(1, c2, dispatcher)
-    assert_receive {C, ^ref3, [^event]}
+    assert_receive {C, ^ref3, [{^event, _ctx}]}
     # now that all consumers have received and processed the message we should
     # forward demand onto the producer
     assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
@@ -90,11 +90,11 @@ defmodule Electric.Shapes.DispatcherTest do
 
     {:ok, [], dispatcher} = D.dispatch([event], 1, dispatcher)
 
-    refute_receive {C, ^ref1, [^event]}
+    refute_receive {C, ^ref1, [{^event, _ctx}]}
 
-    assert_receive {C, ^ref2, [^event]}
+    assert_receive {C, ^ref2, [{^event, _ctx}]}
     assert {:ok, 0, dispatcher} = D.ask(1, c2, dispatcher)
-    assert_receive {C, ^ref3, [^event]}
+    assert_receive {C, ^ref3, [{^event, _ctx}]}
     assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
   end
 
@@ -113,14 +113,14 @@ defmodule Electric.Shapes.DispatcherTest do
 
     {:ok, [], dispatcher} = D.dispatch([event], 1, dispatcher)
 
-    assert_receive {C, ^ref1, [^event]}
+    assert_receive {C, ^ref1, [{^event, _ctx}]}
     assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
 
     {:ok, 0, dispatcher} = D.cancel(c1, dispatcher)
 
-    assert_receive {C, ^ref2, [^event]}
+    assert_receive {C, ^ref2, [{^event, _ctx}]}
     assert {:ok, 0, dispatcher} = D.ask(1, c2, dispatcher)
-    assert_receive {C, ^ref3, [^event]}
+    assert_receive {C, ^ref3, [{^event, _ctx}]}
     assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
   end
 
@@ -141,14 +141,14 @@ defmodule Electric.Shapes.DispatcherTest do
 
     {:ok, 0, dispatcher} = D.cancel(c2, dispatcher)
 
-    assert_receive {C, ^ref1, [^event]}
+    assert_receive {C, ^ref1, [{^event, _ctx}]}
     assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
 
     # we've cancelled but haven't killed the pid (and even if we had, it will
     # have likely already sent the confirmation message)
-    assert_receive {C, ^ref2, [^event]}
+    assert_receive {C, ^ref2, [{^event, _ctx}]}
 
-    assert_receive {C, ^ref3, [^event]}
+    assert_receive {C, ^ref3, [{^event, _ctx}]}
     assert {:ok, 1, _dispatcher} = D.ask(1, c3, dispatcher)
   end
 
@@ -168,7 +168,7 @@ defmodule Electric.Shapes.DispatcherTest do
 
     {:ok, [], dispatcher} = D.dispatch([event], 1, dispatcher)
 
-    assert_receive {C, ^ref1, [^event]}
+    assert_receive {C, ^ref1, [{^event, _ctx}]}
     assert {:ok, 0, dispatcher} = D.ask(1, c1, dispatcher)
 
     {:ok, 0, dispatcher} = D.cancel(c2, dispatcher)
@@ -189,9 +189,9 @@ defmodule Electric.Shapes.DispatcherTest do
     event = @transaction
 
     {:ok, [], dispatcher} = D.dispatch([event], 1, dispatcher)
-    refute_receive {C, ^ref1, [^event]}
-    refute_receive {C, ^ref2, [^event]}
-    refute_receive {C, ^ref3, [^event]}
+    refute_receive {C, ^ref1, [{^event, _ctx}]}
+    refute_receive {C, ^ref2, [{^event, _ctx}]}
+    refute_receive {C, ^ref3, [{^event, _ctx}]}
     # none of the subscribers want the event, but we need to simulate the full cycle
     # so the dispatcher should generate some fake demand. This goes to the 
     # last subscriber, which is at the head of the list

--- a/packages/sync-service/test/support/transaction_consumer.ex
+++ b/packages/sync-service/test/support/transaction_consumer.ex
@@ -45,7 +45,7 @@ defmodule Support.TransactionConsumer do
     {:manual, {id, from, parent}}
   end
 
-  def handle_events([txn], _from, {id, subscription, parent}) do
+  def handle_events([{txn, _ctx}], _from, {id, subscription, parent}) do
     send(parent, {__MODULE__, {id, self()}, [txn]})
     GenStage.ask(subscription, 1)
     {:noreply, [], {id, subscription, parent}}


### PR DESCRIPTION
This PR improves observability by:
- Connecting shape consumer spans to replication traces
- Adding `electric.shapes.total_shapes.count` metric to OTEL metrics (Closes #2269 although I have not added "shapes that have an active subscriber" as this information is already available in the traces)
- Adding `electric.storage.used` metric to OTEL metrics
- Adding CPU % utilisation per core telemetry and exposing them to the OTEL metrics. CPU metrics are already available, but % utilisation per core seems a simple one to comprehend and in a form our customers will understand.