### PR TITLE
fix: Passthrough errors to avoid infinite loop when falling back to IPv4

### DIFF
--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -528,7 +528,7 @@ defmodule Electric.Connection.Manager do
   end
 
   defp handle_connection_error(
-         %DBConnection.ConnectionError{message: message, severity: :error} = error,
+         %DBConnection.ConnectionError{message: message, severity: :error},
          %State{connection_opts: connection_opts, ipv6_enabled: true} = state,
          mode
        ) do

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -550,7 +550,7 @@ defmodule Electric.Connection.Manager do
       step = current_connection_step(state)
       handle_continue(step, state)
     else
-      handle_connection_error(error, state, mode)
+      handle_connection_error({:passthrough, message}, state, mode)
     end
   end
 
@@ -567,6 +567,9 @@ defmodule Electric.Connection.Manager do
 
         %Postgrex.Error{postgres: %{message: message} = pg_error} ->
           message <> pg_error_extra_info(pg_error)
+
+        {:passthrough, message} ->
+          message
       end
 
     Logger.warning("Database connection in #{mode} mode failed: #{message}")

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -528,14 +528,16 @@ defmodule Electric.Connection.Manager do
   end
 
   defp handle_connection_error(
-         %DBConnection.ConnectionError{message: message} = error,
+         %DBConnection.ConnectionError{message: message, severity: :error} = error,
          %State{connection_opts: connection_opts, ipv6_enabled: true} = state,
          mode
        ) do
+    # If network is unreachable, IPv6 is not enabled on the machine
     # If domain cannot be resolved, assume there is no AAAA record for it
-    # and fall back to IPv4 and regular A records
+    # Fall back to IPv4 for these cases
     if String.starts_with?(message, "tcp connect (") and
-         String.ends_with?(message, "): non-existing domain - :nxdomain") do
+         (String.ends_with?(message, "): non-existing domain - :nxdomain") or
+            String.ends_with?(message, "): network is unreachable - :enetunreach")) do
       Logger.warning(
         "Database connection in #{mode} mode failed to find valid IPv6 address for #{connection_opts[:hostname]} - falling back to IPv4"
       )
@@ -550,6 +552,7 @@ defmodule Electric.Connection.Manager do
       step = current_connection_step(state)
       handle_continue(step, state)
     else
+      # Pass through other errors to avoid infinite loop
       handle_connection_error({:passthrough, message}, state, mode)
     end
   end


### PR DESCRIPTION
Fixes issue introduced in https://github.com/electric-sql/electric/pull/2283

The passthrough would not work and if an error came through that wasn't `:nxdomain` it would enter an infinite loop (whoops).

I've added the case of an error where network is unreachable that @samwillis run into, assuming it's because IPv6 is not enabled on the machine, but am reluctant on disabling IPv6 on _all_ `DBConnection` errors or tcp errors.

We definitely do not want to make IPv6 enabled by default until we sort this out.