### PR TITLE
feat!: remove `offset` and add `lsn` header on the wire

### DIFF
--- a/.changeset/brown-poems-watch.md
+++ b/.changeset/brown-poems-watch.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+feat: add a special header to last operation in transaction for a given shape

--- a/.changeset/sixty-queens-agree.md
+++ b/.changeset/sixty-queens-agree.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+feat: replace `txid` with `txids` header

--- a/.changeset/sweet-yaks-jog.md
+++ b/.changeset/sweet-yaks-jog.md
@@ -1,0 +1,8 @@
+---
+"@electric-sql/client": minor
+"@core/elixir-client": minor
+"@core/sync-service": minor
+"@electric-sql/docs": patch
+---
+
+feat!: change the wire protocol to remove `offset` and add an explicit `lsn` header. Only valid offset now is the one provided in headers

--- a/packages/elixir-client/lib/electric/client/message.ex
+++ b/packages/elixir-client/lib/electric/client/message.ex
@@ -57,7 +57,7 @@ defmodule Electric.Client.Message do
   end
 
   defmodule ChangeMessage do
-    defstruct [:key, :value, :headers, :offset, :request_timestamp]
+    defstruct [:key, :value, :headers, :request_timestamp]
 
     @type key :: String.t()
     @type value :: %{String.t() => binary()}
@@ -65,7 +65,6 @@ defmodule Electric.Client.Message do
             key: key(),
             value: value(),
             headers: Headers.t(),
-            offset: Offset.t(),
             request_timestamp: DateTime.t()
           }
 
@@ -74,7 +73,6 @@ defmodule Electric.Client.Message do
     def from_message(msg, handle, value_mapping_fun) do
       %{
         "headers" => headers,
-        "offset" => offset,
         "value" => raw_value
       } = msg
 
@@ -92,7 +90,6 @@ defmodule Electric.Client.Message do
 
       %__MODULE__{
         key: msg["key"],
-        offset: Client.Offset.from_string!(offset),
         headers: Headers.from_message(headers, handle),
         value: value
       }

--- a/packages/elixir-client/test/electric/client/value_mapper_test.exs
+++ b/packages/elixir-client/test/electric/client/value_mapper_test.exs
@@ -101,8 +101,7 @@ defmodule Electric.Client.ValueMapperTest do
                  },
                  headers: %Message.Headers{
                    operation: :insert
-                 },
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 }
                },
                %Message.ControlMessage{control: :up_to_date}
              ] = stream(ctx, 2)

--- a/packages/elixir-client/test/electric/client_test.exs
+++ b/packages/elixir-client/test/electric/client_test.exs
@@ -215,18 +215,15 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  headers: %{operation: :insert, relation: ["public", ^table]},
-                 value: %{"id" => ^id1},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 value: %{"id" => ^id1}
                },
                %ChangeMessage{
                  headers: %{operation: :insert, relation: ["public", ^table]},
-                 value: %{"id" => ^id2},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 value: %{"id" => ^id2}
                },
                %ChangeMessage{
                  headers: %{operation: :insert, relation: ["public", ^table]},
-                 value: %{"id" => ^id3},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 value: %{"id" => ^id3}
                },
                up_to_date0()
              ] = msgs
@@ -248,18 +245,15 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  headers: %{operation: :insert, relation: ["public", ^table]},
-                 value: %{"id" => ^id1},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 value: %{"id" => ^id1}
                },
                %ChangeMessage{
                  headers: %{operation: :insert, relation: ["public", ^table]},
-                 value: %{"id" => ^id2},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 value: %{"id" => ^id2}
                },
                %ChangeMessage{
                  headers: %{operation: :insert, relation: ["public", ^table]},
-                 value: %{"id" => ^id3},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 value: %{"id" => ^id3}
                },
                up_to_date0()
              ] = Client.stream(ctx.client, table) |> Enum.take(4)
@@ -465,13 +459,11 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  headers: @insert,
-                 offset: offset(1, 0),
                  value: %{"id" => "1111"}
                },
                up_to_date(1, 0),
                %ChangeMessage{
                  headers: @insert,
-                 offset: offset(2, 0),
                  value: %{"id" => "2222"}
                },
                up_to_date(2, 0)
@@ -547,13 +539,11 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  headers: @insert,
-                 offset: offset(1, 0),
                  value: %{"id" => "1111"}
                },
                up_to_date(1, 0),
                %ChangeMessage{
                  headers: @insert,
-                 offset: offset(2, 0),
                  value: %{"id" => "2222"}
                },
                up_to_date(2, 0)
@@ -649,13 +639,11 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  headers: @insert,
-                 offset: offset(1, 0),
                  value: %{"id" => "1111"}
                },
                up_to_date(1, 0),
                %ChangeMessage{
                  headers: @insert,
-                 offset: offset(2, 0),
                  value: %{"id" => "2222"}
                },
                up_to_date(2, 0)
@@ -724,14 +712,12 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  headers: @insert,
-                 offset: offset(1, 0),
                  value: %{"id" => "1111"}
                },
                up_to_date(1, 0),
                %ControlMessage{control: :must_refetch, offset: offset(1, 0)},
                %ChangeMessage{
                  headers: ^headers,
-                 offset: offset(1, 0),
                  value: %{"id" => "1111"}
                },
                up_to_date(1, 0)
@@ -855,13 +841,11 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  value: %{"id" => "1111"},
-                 headers: %Headers{operation: :insert},
-                 offset: %Electric.Client.Offset{tx: 1, op: 0}
+                 headers: %Headers{operation: :insert}
                },
                %ChangeMessage{
                  value: %{"id" => "2222"},
-                 headers: %Headers{operation: :insert},
-                 offset: %Electric.Client.Offset{tx: 2, op: 0}
+                 headers: %Headers{operation: :insert}
                },
                up_to_date(2, 0),
                %ResumeMessage{
@@ -924,13 +908,11 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  value: %{"id" => "3333"},
-                 headers: %Headers{operation: :insert},
-                 offset: %Electric.Client.Offset{tx: 3, op: 0}
+                 headers: %Headers{operation: :insert}
                },
                %ChangeMessage{
                  value: %{"id" => "4444"},
-                 headers: %Headers{operation: :insert},
-                 offset: %Electric.Client.Offset{tx: 4, op: 0}
+                 headers: %Headers{operation: :insert}
                },
                up_to_date(4, 0)
              ] = events
@@ -988,23 +970,19 @@ defmodule Electric.ClientTest do
       assert [
                %ChangeMessage{
                  value: %{"id" => "1111", "value" => "original 1111"},
-                 headers: %Headers{operation: :insert},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 headers: %Headers{operation: :insert}
                },
                %ChangeMessage{
                  value: %{"id" => "2222", "value" => "original 2222"},
-                 headers: %Headers{operation: :insert},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 headers: %Headers{operation: :insert}
                },
                %ChangeMessage{
                  value: %{"id" => "3333", "value" => "original 3333"},
-                 headers: %Headers{operation: :insert},
-                 offset: %Electric.Client.Offset{tx: 0, op: 0}
+                 headers: %Headers{operation: :insert}
                },
                %ChangeMessage{
                  value: %{"id" => "2222", "value" => "updated 2222"},
-                 headers: %Headers{operation: :update},
-                 offset: %Electric.Client.Offset{tx: 1234, op: 0}
+                 headers: %Headers{operation: :update}
                },
                %ResumeMessage{
                  shape_handle: "my-shape",

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -10,7 +10,7 @@ defmodule Electric.ShapeCache.FileStorage do
 
   # If the storage format changes, increase `@version` to prevent
   # the incompatable older versions being read
-  @version 2
+  @version 3
   @version_key :version
 
   @shape_definition_file_name "shape_defintion.json"

--- a/packages/sync-service/lib/electric/shape_cache/file_storage/log_file.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage/log_file.ex
@@ -293,7 +293,7 @@ defmodule Electric.ShapeCache.FileStorage.LogFile do
   defp process_json(json) do
     json
     |> Jason.decode!()
-    |> update_in(["headers"], &Map.drop(&1 || %{}, ["txid"]))
+    |> LogItems.keep_generic_headers()
     |> Jason.encode!()
   end
 end

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -1,5 +1,4 @@
 defmodule Electric.Shapes.Querying do
-  alias Electric.Replication.LogOffset
   alias Electric.ShapeCache.LogChunker
   alias Electric.Utils
   alias Electric.Shapes.Shape
@@ -63,7 +62,6 @@ defmodule Electric.Shapes.Querying do
     key_part = build_key_part(root_table, pk_cols)
     value_part = build_value_part(columns)
     headers_part = build_headers_part(root_table)
-    offset_part = ~s['"offset":"#{LogOffset.first()}"']
 
     # We're building a JSON string that looks like this:
     #
@@ -75,11 +73,10 @@ defmodule Electric.Shapes.Querying do
     #     "email": "john.doe@example.com",
     #     "nullable": null
     #   },
-    #   "headers": {"operation": "insert", "relation": ["public", "test_table"]},
-    #   "offset": "0_0"
+    #   "headers": {"operation": "insert", "relation": ["public", "test_table"]}
     # }
     query =
-      ~s['{' || #{key_part} || ',' || #{value_part} || ',' || #{headers_part} || ',' || #{offset_part} || '}']
+      ~s['{' || #{key_part} || ',' || #{value_part} || ',' || #{headers_part} || '}']
 
     {query, []}
   end

--- a/packages/sync-service/test/electric/log_item_test.exs
+++ b/packages/sync-service/test/electric/log_item_test.exs
@@ -15,23 +15,35 @@ defmodule Electric.LogItemsTest do
 
       assert LogItems.from_change(record, 1, ["pk"], :default) ==
                [
-                 %{
-                   offset: LogOffset.new(0, 0),
-                   value: %{"hello" => "world", "pk" => "10"},
-                   key: "my_key",
-                   headers: %{relation: ["public", "test"], operation: :insert, txid: 1}
-                 }
+                 {LogOffset.new(0, 0),
+                  %{
+                    value: %{"hello" => "world", "pk" => "10"},
+                    key: "my_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :insert,
+                      txid: 1,
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }}
                ]
 
       # And with empty PK
       assert LogItems.from_change(record, 1, [], :default) ==
                [
-                 %{
-                   offset: LogOffset.new(0, 0),
-                   value: %{"hello" => "world", "pk" => "10"},
-                   key: "my_key",
-                   headers: %{relation: ["public", "test"], operation: :insert, txid: 1}
-                 }
+                 {LogOffset.new(0, 0),
+                  %{
+                    value: %{"hello" => "world", "pk" => "10"},
+                    key: "my_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :insert,
+                      txid: 1,
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }}
                ]
     end
 
@@ -45,12 +57,18 @@ defmodule Electric.LogItemsTest do
 
       assert LogItems.from_change(record, 1, ["pk"], :default) ==
                [
-                 %{
-                   offset: LogOffset.new(0, 0),
-                   value: %{"pk" => "10"},
-                   key: "my_key",
-                   headers: %{relation: ["public", "test"], operation: :delete, txid: 1}
-                 }
+                 {LogOffset.new(0, 0),
+                  %{
+                    value: %{"pk" => "10"},
+                    key: "my_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :delete,
+                      txid: 1,
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }}
                ]
     end
 
@@ -64,12 +82,18 @@ defmodule Electric.LogItemsTest do
 
       assert LogItems.from_change(record, 1, [], :default) ==
                [
-                 %{
-                   offset: LogOffset.new(0, 0),
-                   value: %{"hello" => "world", "value" => "10"},
-                   key: "my_key",
-                   headers: %{relation: ["public", "test"], operation: :delete, txid: 1}
-                 }
+                 {LogOffset.new(0, 0),
+                  %{
+                    value: %{"hello" => "world", "value" => "10"},
+                    key: "my_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :delete,
+                      txid: 1,
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }}
                ]
     end
 
@@ -85,12 +109,18 @@ defmodule Electric.LogItemsTest do
 
       assert LogItems.from_change(record, 1, ["pk"], :default) ==
                [
-                 %{
-                   offset: LogOffset.new(0, 0),
-                   value: %{"pk" => "10", "test" => "new"},
-                   key: "my_key",
-                   headers: %{relation: ["public", "test"], operation: :update, txid: 1}
-                 }
+                 {LogOffset.new(0, 0),
+                  %{
+                    value: %{"pk" => "10", "test" => "new"},
+                    key: "my_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :update,
+                      txid: 1,
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }}
                ]
     end
 
@@ -106,12 +136,18 @@ defmodule Electric.LogItemsTest do
 
       assert LogItems.from_change(record, 1, ["pk"], :full) ==
                [
-                 %{
-                   offset: LogOffset.first(),
-                   value: %{"pk" => "10", "hello" => "world", "test" => "new"},
-                   key: "my_key",
-                   headers: %{relation: ["public", "test"], operation: :update, txid: 1}
-                 }
+                 {LogOffset.first(),
+                  %{
+                    value: %{"pk" => "10", "hello" => "world", "test" => "new"},
+                    key: "my_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :update,
+                      txid: 1,
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }}
                ]
     end
 
@@ -126,12 +162,18 @@ defmodule Electric.LogItemsTest do
 
       assert LogItems.from_change(record, 1, ["pk"], :full) ==
                [
-                 %{
-                   offset: LogOffset.first(),
-                   value: %{"pk" => "10", "hello" => "world", "test" => "me"},
-                   key: "my_key",
-                   headers: %{relation: ["public", "test"], operation: :delete, txid: 1}
-                 }
+                 {LogOffset.first(),
+                  %{
+                    value: %{"pk" => "10", "hello" => "world", "test" => "me"},
+                    key: "my_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :delete,
+                      txid: 1,
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }}
                ]
     end
 
@@ -148,28 +190,32 @@ defmodule Electric.LogItemsTest do
 
       assert LogItems.from_change(record, 1, ["pk"], :default) ==
                [
-                 %{
-                   offset: LogOffset.new(0, 0),
-                   value: %{"pk" => "9"},
-                   key: "old_key",
-                   headers: %{
-                     relation: ["public", "test"],
-                     operation: :delete,
-                     txid: 1,
-                     key_change_to: "new_key"
-                   }
-                 },
-                 %{
-                   offset: LogOffset.new(0, 1),
-                   value: %{"hello" => "world", "pk" => "10", "test" => "new"},
-                   key: "new_key",
-                   headers: %{
-                     relation: ["public", "test"],
-                     operation: :insert,
-                     txid: 1,
-                     key_change_from: "old_key"
-                   }
-                 }
+                 {LogOffset.new(0, 0),
+                  %{
+                    value: %{"pk" => "9"},
+                    key: "old_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :delete,
+                      txid: 1,
+                      key_change_to: "new_key",
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }},
+                 {LogOffset.new(0, 1),
+                  %{
+                    value: %{"hello" => "world", "pk" => "10", "test" => "new"},
+                    key: "new_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :insert,
+                      txid: 1,
+                      key_change_from: "old_key",
+                      lsn: 0,
+                      op_position: 1
+                    }
+                  }}
                ]
     end
 
@@ -186,28 +232,32 @@ defmodule Electric.LogItemsTest do
 
       assert LogItems.from_change(record, 1, [], :default) ==
                [
-                 %{
-                   offset: LogOffset.new(0, 0),
-                   value: %{"hello" => "world", "test" => "me"},
-                   key: "old_key",
-                   headers: %{
-                     relation: ["public", "test"],
-                     operation: :delete,
-                     txid: 1,
-                     key_change_to: "new_key"
-                   }
-                 },
-                 %{
-                   offset: LogOffset.new(0, 1),
-                   value: %{"hello" => "world", "test" => "new"},
-                   key: "new_key",
-                   headers: %{
-                     relation: ["public", "test"],
-                     operation: :insert,
-                     txid: 1,
-                     key_change_from: "old_key"
-                   }
-                 }
+                 {LogOffset.new(0, 0),
+                  %{
+                    value: %{"hello" => "world", "test" => "me"},
+                    key: "old_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :delete,
+                      txid: 1,
+                      key_change_to: "new_key",
+                      lsn: 0,
+                      op_position: 0
+                    }
+                  }},
+                 {LogOffset.new(0, 1),
+                  %{
+                    value: %{"hello" => "world", "test" => "new"},
+                    key: "new_key",
+                    headers: %{
+                      relation: ["public", "test"],
+                      operation: :insert,
+                      txid: 1,
+                      key_change_from: "old_key",
+                      lsn: 0,
+                      op_position: 1
+                    }
+                  }}
                ]
     end
   end

--- a/packages/sync-service/test/electric/log_item_test.exs
+++ b/packages/sync-service/test/electric/log_item_test.exs
@@ -22,7 +22,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :insert,
-                      txid: 1,
+                      txids: [1],
                       lsn: 0,
                       op_position: 0
                     }
@@ -39,7 +39,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :insert,
-                      txid: 1,
+                      txids: [1],
                       lsn: 0,
                       op_position: 0
                     }
@@ -64,7 +64,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :delete,
-                      txid: 1,
+                      txids: [1],
                       lsn: 0,
                       op_position: 0
                     }
@@ -89,7 +89,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :delete,
-                      txid: 1,
+                      txids: [1],
                       lsn: 0,
                       op_position: 0
                     }
@@ -116,7 +116,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :update,
-                      txid: 1,
+                      txids: [1],
                       lsn: 0,
                       op_position: 0
                     }
@@ -143,7 +143,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :update,
-                      txid: 1,
+                      txids: [1],
                       lsn: 0,
                       op_position: 0
                     }
@@ -169,7 +169,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :delete,
-                      txid: 1,
+                      txids: [1],
                       lsn: 0,
                       op_position: 0
                     }
@@ -197,7 +197,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :delete,
-                      txid: 1,
+                      txids: [1],
                       key_change_to: "new_key",
                       lsn: 0,
                       op_position: 0
@@ -210,7 +210,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :insert,
-                      txid: 1,
+                      txids: [1],
                       key_change_from: "old_key",
                       lsn: 0,
                       op_position: 1
@@ -239,7 +239,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :delete,
-                      txid: 1,
+                      txids: [1],
                       key_change_to: "new_key",
                       lsn: 0,
                       op_position: 0
@@ -252,7 +252,7 @@ defmodule Electric.LogItemsTest do
                     headers: %{
                       relation: ["public", "test"],
                       operation: :insert,
-                      txid: 1,
+                      txids: [1],
                       key_change_from: "old_key",
                       lsn: 0,
                       op_position: 1

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -606,7 +606,8 @@ defmodule Electric.Plug.RouterTest do
                    "operation" => "delete",
                    "relation" => ["public", "serial_ids"],
                    "lsn" => op2_lsn,
-                   "op_position" => op2_op_position
+                   "op_position" => op2_op_position,
+                   "last" => true
                  },
                  "key" => ~s|"public"."serial_ids"/"3"|,
                  "value" => %{"id" => "3"}

--- a/packages/sync-service/test/electric/shape_cache/file_storage/compaction_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/file_storage/compaction_test.exs
@@ -14,11 +14,11 @@ defmodule Electric.ShapeCache.FileStorage.CompactionTest do
 
       log_stream = [
         {%LogOffset{tx_offset: 1, op_offset: 1}, "key1", :insert,
-         ~S|{"value":"v1","headers":{"operation": "insert", "txid":123}}|},
+         ~S|{"value":"v1","headers":{"operation": "insert", "txids":[123]}}|},
         {%LogOffset{tx_offset: 2, op_offset: 1}, "key1", :update,
-         ~S|{"value":"v2","headers":{"operation": "update", "txid":124}}|},
+         ~S|{"value":"v2","headers":{"operation": "update", "txids":[124]}}|},
         {%LogOffset{tx_offset: 3, op_offset: 1}, "key2", :delete,
-         ~S|{"value":"v3","headers":{"operation": "delete", "txid":125}}|}
+         ~S|{"value":"v3","headers":{"operation": "delete", "txids":[125]}}|}
       ]
 
       paths = LogFile.write_log_file(log_stream, log_file_path)

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -102,7 +102,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
                    value: %{id: "123", name: "Test"},
                    headers: %{
                      operation: "insert",
-                     txid: 1,
+                     txids: [1],
                      relation: ["public", "test_table"],
                      lsn: 1000,
                      op_position: 0

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -100,11 +100,12 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
                  %{
                    key: ~S|"public"."test_table"/"123"|,
                    value: %{id: "123", name: "Test"},
-                   offset: offset |> LogOffset.to_iolist() |> :erlang.iolist_to_binary(),
                    headers: %{
                      operation: "insert",
                      txid: 1,
-                     relation: ["public", "test_table"]
+                     relation: ["public", "test_table"],
+                     lsn: 1000,
+                     op_position: 0
                    }
                  }
                ] == Enum.map(stream, &Jason.decode!(&1, keys: :atoms))
@@ -459,7 +460,6 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
                  |> Enum.to_list()
 
         assert Jason.decode!(line, keys: :atoms) == %{
-                 offset: "8_0",
                  value: %{id: "sameid", name: "Test8"},
                  key: ~S|"public"."test_table"/"sameid"|,
                  headers: %{operation: "update", relation: ["public", "test_table"]}
@@ -571,7 +571,6 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
                  |> Enum.to_list()
 
         assert Jason.decode!(line, keys: :atoms) == %{
-                 offset: "18_0",
                  value: %{id: "sameid", name: "Test10", other_name: "Test18"},
                  key: ~S|"public"."test_table"/"sameid"|,
                  headers: %{operation: "update", relation: ["public", "test_table"]}

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -24,32 +24,27 @@ defmodule Electric.Shapes.QueryingTest do
              %{
                key: ~S["public"."items"/"1"],
                value: %{id: "1", value: "1"},
-               headers: %{operation: "insert", relation: ["public", "items"]},
-               offset: "0_0"
+               headers: %{operation: "insert", relation: ["public", "items"]}
              },
              %{
                key: ~S["public"."items"/"2"],
                value: %{id: "2", value: "2"},
-               headers: %{operation: "insert", relation: ["public", "items"]},
-               offset: "0_0"
+               headers: %{operation: "insert", relation: ["public", "items"]}
              },
              %{
                key: ~S["public"."items"/"3"],
                value: %{id: "3", value: "3"},
-               headers: %{operation: "insert", relation: ["public", "items"]},
-               offset: "0_0"
+               headers: %{operation: "insert", relation: ["public", "items"]}
              },
              %{
                key: ~S["public"."items"/"4"],
                value: %{id: "4", value: "4"},
-               headers: %{operation: "insert", relation: ["public", "items"]},
-               offset: "0_0"
+               headers: %{operation: "insert", relation: ["public", "items"]}
              },
              %{
                key: ~S["public"."items"/"5"],
                value: %{id: "5", value: "5"},
-               headers: %{operation: "insert", relation: ["public", "items"]},
-               offset: "0_0"
+               headers: %{operation: "insert", relation: ["public", "items"]}
              }
            ] == decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
   end

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -17,8 +17,8 @@ defmodule Support.TestUtils do
     changes
     |> Enum.map(&Changes.fill_key(&1, pk))
     |> Enum.flat_map(&LogItems.from_change(&1, xid, pk, replica))
-    |> Enum.map(fn item ->
-      {item.offset, item.key, item.headers.operation, Jason.encode!(item)}
+    |> Enum.map(fn {offset, item} ->
+      {offset, item.key, item.headers.operation, Jason.encode!(item)}
     end)
     |> Enum.flat_map_reduce(0, fn {offset, _, _, json_log_item} = line, acc ->
       case LogChunker.fit_into_chunk(byte_size(json_log_item), acc, chunk_size) do

--- a/packages/typescript-client/src/types.ts
+++ b/packages/typescript-client/src/types.ts
@@ -33,7 +33,6 @@ export type ChangeMessage<T extends Row<unknown> = Row> = {
   key: string
   value: T
   headers: Header & { operation: Operation }
-  offset: Offset
 }
 
 // Define the type for a record

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -298,6 +298,24 @@ paths:
 
                             Only present on operations that were received from the event stream.
                             It's missing on initial query results and on compacted items.    
+                        last:
+                          type: boolean
+                          description: |-
+                            Whether this is the last operation in the transaction for this shape.
+
+                            Last operation in a transaction for the shape does not mean a last
+                            operation in the transaction for the database.
+
+                            Only present on operations that were received from the event stream.
+                            It's missing on initial query results and on compacted items.
+                        txids:
+                          type: array
+                          description: |-
+                            The list of transaction IDs that this operation was part of.
+
+                            Currently, this will only contain a single transaction ID, but future
+                            stream processors may merge operations from multiple transactions into a single
+                            operation in the event stream.
                     key:
                       type: string
                       description: Row ID

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -214,9 +214,7 @@ paths:
                 The latest offset in the batch of data you have recieved.
 
                 If no data is returned, this will be equal to the `offset` parameter
-                you have provided. This header simplifies client development by
-                avoiding the need to parse the last offset out of the stream of
-                log entries.
+                you have provided.
 
                 Must be used as the value of the `offset` parameter in your
                 next request.
@@ -284,19 +282,22 @@ paths:
                             - update
                             - delete
                           description: The type of operation that is performed on the row of the shape that is identified by the `key`.
-                    offset:
-                      type: string
-                      description: |-
-                        The offset of the row in the shape stream.
-                        This is an opaque identifier.
+                        lsn:
+                          type: string
+                          description: |-
+                            The logical sequence number of the operation.
 
-                        Note that operations with the same offset were commited in the
-                        same transaction. So you can group operations into transactions
-                        using the `offset` property.
+                            Only present on operations that were received from the event stream.
+                            It's missing on initial query results and on compacted items.
+                            Operations with the same LSN were committed in the same transaction and
+                            can be ordered by `op_position` within the same LSN.
+                        op_position:
+                          type: string
+                          description: |-
+                            The position of the operation in the transaction.
 
-                        (Note also that when you recieve an `up-to-date` control message
-                        this indicates that you have recieved all of the operations in
-                        a transaction.)
+                            Only present on operations that were received from the event stream.
+                            It's missing on initial query results and on compacted items.    
                     key:
                       type: string
                       description: Row ID
@@ -322,7 +323,8 @@ paths:
                 example:
                   - headers:
                       operation: insert
-                    offset: 0_0
+                      lsn: 1234
+                      op_position: 0
                     key: issue-1
                     value:
                       id: issue-1
@@ -330,13 +332,15 @@ paths:
                       status: backlog
                   - headers:
                       operation: insert
-                      control: up-to-date
-                    offset: 1934_0
+                      lsn: 1234
+                      op_position: 7
                     key: issue-2
                     value:
                       id: issue-2
                       title: Hello
                       status: backlog
+                  - headers:
+                      control: up-to-date
         "204":
           description: >-
             No content. The `live=true` polling request timed out without


### PR DESCRIPTION
Closes #2214 

Removes `offset` property from all messages going forward. This simplifies the wire protocol as currently we had discrepancies between in-item offsets and header offsets when working with chunked initial snapshot. Now headers are the only correct way to work with the offsets. This is reflected in client libraries.

Adds two headers to *live* (i.e. non-snapshot, not-compacted) changes: `lsn` and `op_position`. The `lsn` marks items in the same transaction and provides a monotonic system-wide value for common prefix calculations. It will be heavily used in further PRs. The `op_position` lists an operation's order in the original transaction, allowing correct operation ordering when merging and applying 2 shape streams together without a need for a topological sort.