### PR TITLE
Include wx and observer in the extra_application list

### DIFF
--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -58,7 +58,14 @@ defmodule Electric.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :tls_certificate_check, :os_mon, :runtime_tools],
+      extra_applications: [
+        :logger,
+        :tls_certificate_check,
+        :os_mon,
+        :runtime_tools,
+        :wx,
+        :observer
+      ],
       # Using a compile-time flag to select the application module or lack thereof allows
       # using this app as a dependency with this additional flag
       mod:


### PR DESCRIPTION
Without it, in recent versions of Elixir, evaluating `:observer.start` doesn't work because the `:observer` module cannot be found.