### PR TITLE
fix: Looser `react` peer dependency versions

### DIFF
--- a/.changeset/shy-bags-deliver.md
+++ b/.changeset/shy-bags-deliver.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/react": patch
+---
+
+Loosen `react` peer dependency to prevent conflict warnings.

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -56,7 +56,7 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/index.legacy-esm.js",
   "peerDependencies": {
-    "react": "^18.3.1"
+    "react": ">=18.3.1 <20.0.0"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2315

Looser requirement for the peer dependency to avoid the reported warnings with v19 react. We ideally want to be testing it with multiple major react versions though to make sure we actually support them.