### PR TITLE
feat(sync-service): Add optional where clause filtering tracing

### DIFF
--- a/packages/sync-service/.env.dev
+++ b/packages/sync-service/.env.dev
@@ -7,3 +7,6 @@ ELECTRIC_CACHE_STALE_AGE=3
 ELECTRIC_SHAPE_CHUNK_BYTES_THRESHOLD=10000
 # configuring a second database for multi-tenancy integration testing
 OTHER_DATABASE_URL=postgresql://postgres:password@localhost:54322/electric?sslmode=disable
+ELECTRIC_PROFILE_WHERE_CLAUSES=false
+ELECTRIC_OTEL_SAMPLING_RATIO=1
+ELECTRIC_OTEL_DEBUG=false

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -230,5 +230,6 @@ config :electric,
   service_port: env!("ELECTRIC_PORT", :integer, nil),
   shape_hibernate_after: shape_hibernate_after,
   storage: storage,
+  profile_where_clauses?: env!("ELECTRIC_PROFILE_WHERE_CLAUSES", :boolean, false),
   persistent_kv: persistent_kv,
   listen_on_ipv6?: env!("ELECTRIC_LISTEN_ON_IPV6", :boolean, nil)

--- a/packages/sync-service/lib/electric/shapes/filter.ex
+++ b/packages/sync-service/lib/electric/shapes/filter.ex
@@ -45,7 +45,7 @@ defmodule Electric.Shapes.Filter do
         Map.update(
           tables,
           shape.root_table,
-          Table.add_shape(Table.new(), {shape_id, shape}),
+          Table.add_shape(Table.new(shape.root_table), {shape_id, shape}),
           fn table ->
             Table.add_shape(table, {shape_id, shape})
           end

--- a/packages/sync-service/lib/electric/telemetry/optional_spans.ex
+++ b/packages/sync-service/lib/electric/telemetry/optional_spans.ex
@@ -1,0 +1,4 @@
+defmodule Electric.Telemetry.OptionalSpans do
+  def include?("filter." <> _), do: Application.get_env(:electric, :profile_where_clauses?)
+  def include?(_), do: true
+end

--- a/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
+++ b/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
@@ -1,0 +1,20 @@
+defmodule Electric.Telemetry.OpenTelemetryTest do
+  alias Electric.Telemetry.OpenTelemetry
+
+  use ExUnit.Case
+
+  test "baggage is propagated to new processes when the context is carried over" do
+    OpenTelemetry.with_span("test", %{}, "stack_id", fn ->
+      OpenTelemetry.set_in_baggage("some_key", "some_value")
+
+      context = OpenTelemetry.get_current_context()
+
+      Task.async(fn ->
+        OpenTelemetry.set_current_context(context)
+
+        assert OpenTelemetry.get_from_baggage("some_key") == "some_value"
+      end)
+      |> Task.await()
+    end)
+  end
+end


### PR DESCRIPTION
To diagnose slow where clause filtering this PR introduces 3 new optional filter spans:
- `filter.filter_using_indexes` - how long index based filtering takes. Attributes: table and index count
- `filter.filter_other_shapes` - how long non-index based filtering takes. Attributes: table and shape count
- `filter.index.filter_matched_shapes` - how long filtering the matched shapes takes after the change has matched an index. Attributes: field, matched_shape_count

In order to do this, this PR also introduces:
- Optional spans (see the `OptionalSpans` module)
- Open Telemetry Baggage propagation between processes. This reduces noise in the code by not requiring `stack_id` to be passed around to everywhere we do tracing.
- Changed the shapes collection in the index from a list to a map, this allows us to efficiently get the number of shapes without having to transverse the list 