### PR TITLE
Bring back the inclusion of telemetry_poller in releases

### DIFF
--- a/.changeset/funny-hairs-grab.md
+++ b/.changeset/funny-hairs-grab.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix the startup failure problem caused by broken release packaging.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -41,6 +41,9 @@ if !is_nil(sentry_dsn) do
     dsn: sentry_dsn
 end
 
+# Disable the default telemetry_poller process since we start our own in `Electric.Telemetry`.
+config :telemetry_poller, default: false
+
 service_name = env!("ELECTRIC_SERVICE_NAME", :string, "electric")
 instance_id = env!("ELECTRIC_INSTANCE_ID", :string, Electric.Utils.uuid4())
 version = Electric.version()

--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -107,7 +107,7 @@ defmodule Electric.MixProject do
         {:sentry, "~> 10.0"},
         {:telemetry_metrics_prometheus_core, "~> 1.1"},
         {:telemetry_metrics_statsd, "~> 0.7"},
-        {:telemetry_poller, "~> 1.1", runtime: false},
+        {:telemetry_poller, "~> 1.1"},
         {:tls_certificate_check, "~> 1.23"},
         {:tz, "~> 0.27"}
       ],


### PR DESCRIPTION
The `runtime: false` option in mix.exs was the wrong one to use: it excluded the dependency from release packaging, resulting in the release startup failure when `ELECTRIC_USAGE_REPORTING=true`.

The correct way to make telemetry_poller's default reporting disabled is to configure it as such.

Fixes https://github.com/electric-sql/electric/issues/2323.