### PR TITLE
Fix transaction filtering by taking into account snapshot's xmax and xip_list

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
@@ -15,7 +15,7 @@ defmodule Electric.ShapeCache.CrashingFileStorage do
   defdelegate get_all_stored_shapes(opts), to: FileStorage
   defdelegate get_total_disk_usage(opts), to: FileStorage
   defdelegate get_current_position(opts), to: FileStorage
-  defdelegate set_snapshot_xmin(xmin, opts), to: FileStorage
+  defdelegate set_pg_snapshot(pg_snapshot, opts), to: FileStorage
   defdelegate snapshot_started?(opts), to: FileStorage
   defdelegate make_new_snapshot!(data_stream, opts), to: FileStorage
   defdelegate mark_snapshot_as_started(opts), to: FileStorage

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -250,7 +250,7 @@ defmodule Electric.ShapeCache.FileStorage do
     # Temporary fallback to @xmin_key until we do a breaking release that drops that key entirely.
     with nil <- CubDB.get(opts.db, @pg_snapshot_key),
          xmin when not is_nil(xmin) <- CubDB.get(opts.db, @xmin_key) do
-      %{xmin: xmin, xmax: nil, xip_list: nil}
+      %{xmin: xmin, xmax: xmin + 1, xip_list: [xmin], filter_txns?: true}
     end
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -11,7 +11,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
 
   @snapshot_start_index 0
   @snapshot_end_index :end
-  @xmin_key :xmin
+  @pg_snapshot_key :pg_snapshot
 
   defstruct [
     :table_base_name,
@@ -85,16 +85,13 @@ defmodule Electric.ShapeCache.InMemoryStorage do
 
   @impl Electric.ShapeCache.Storage
   def get_current_position(%MS{} = opts) do
-    {:ok, current_offset(opts), current_xmin(opts)}
+    {:ok, current_offset(opts), pg_snapshot(opts)}
   end
 
-  defp current_xmin(opts) do
-    case :ets.lookup(opts.snapshot_table, @xmin_key) do
-      [] ->
-        nil
-
-      [{@xmin_key, xmin}] ->
-        xmin
+  defp pg_snapshot(opts) do
+    case :ets.lookup(opts.snapshot_table, @pg_snapshot_key) do
+      [{@pg_snapshot_key, pg_snapshot}] -> pg_snapshot
+      [] -> nil
     end
   end
 
@@ -103,8 +100,8 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def set_snapshot_xmin(xmin, %MS{} = opts) do
-    :ets.insert(opts.snapshot_table, {@xmin_key, xmin})
+  def set_pg_snapshot(pg_snapshot, %MS{} = opts) do
+    :ets.insert(opts.snapshot_table, {@pg_snapshot_key, pg_snapshot})
     :ok
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -7,7 +7,12 @@ defmodule Electric.ShapeCache.Storage do
 
   @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
   @type xmin :: Electric.ShapeCacheBehaviour.xmin()
-  @type pg_snapshot :: %{xmin: pos_integer(), xmax: pos_integer, xip_list: [pos_integer]}
+  @type pg_snapshot :: %{
+          xmin: pos_integer(),
+          xmax: pos_integer(),
+          xip_list: [pos_integer()],
+          filter_txns?: boolean()
+        }
   @type offset :: LogOffset.t()
 
   @type compiled_opts :: term()

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -7,6 +7,7 @@ defmodule Electric.ShapeCache.Storage do
 
   @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
   @type xmin :: Electric.ShapeCacheBehaviour.xmin()
+  @type pg_snapshot :: %{xmin: pos_integer(), xmax: pos_integer, xip_list: [pos_integer]}
   @type offset :: LogOffset.t()
 
   @type compiled_opts :: term()
@@ -47,13 +48,14 @@ defmodule Electric.ShapeCache.Storage do
   @callback get_total_disk_usage(compiled_opts()) :: non_neg_integer()
 
   @doc """
-  Get the current xmin and offset for the shape storage.
+  Get the current pg_snapshot and offset for the shape storage.
 
   If the instance is new, then it MUST return `{LogOffset.first(), nil}`.
   """
-  @callback get_current_position(shape_opts()) :: {:ok, offset(), xmin() | nil} | {:error, term()}
+  @callback get_current_position(shape_opts()) ::
+              {:ok, offset(), pg_snapshot() | nil} | {:error, term()}
 
-  @callback set_snapshot_xmin(xmin(), shape_opts()) :: :ok
+  @callback set_pg_snapshot(pg_snapshot(), shape_opts()) :: :ok
 
   @doc "Check if snapshot for a given shape handle already exists"
   @callback snapshot_started?(shape_opts()) :: boolean()
@@ -159,8 +161,8 @@ defmodule Electric.ShapeCache.Storage do
   end
 
   @impl __MODULE__
-  def set_snapshot_xmin(xmin, {mod, shape_opts}) do
-    mod.set_snapshot_xmin(xmin, shape_opts)
+  def set_pg_snapshot(pg_snapshot, {mod, shape_opts}) do
+    mod.set_pg_snapshot(pg_snapshot, shape_opts)
   end
 
   @impl __MODULE__

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -130,16 +130,22 @@ defmodule Electric.Shapes.Consumer do
   end
 
   def handle_cast(
-        {:pg_snapshot_known, shape_handle,
-         %{xmin: xmin, xmax: xmax, xip_list: xip_list} = pg_snapshot},
+        {:pg_snapshot_known, shape_handle, {xmin, xmax, xip_list}},
         %{shape_handle: shape_handle} = state
       ) do
     Logger.debug(
       "Snapshot known for shape_handle: #{shape_handle} xmin: #{xmin}, xmax: #{xmax}, xip_list: #{Enum.join(xip_list, ",")}"
     )
 
-    pg_snapshot = Map.put(pg_snapshot, :filter_txns?, true)
-    state = set_pg_snapshot(pg_snapshot, state)
+    state =
+      %{
+        xmin: xmin,
+        xmax: xmax,
+        xip_list: xip_list,
+        filter_txns?: true
+      }
+      |> set_pg_snapshot(state)
+
     handle_txns(state.buffer, %{state | buffer: []})
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -149,19 +149,19 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
               stack_id
             )
 
-            %{rows: [[pg_snapshot_str]]} =
+            %{rows: [[pg_snapshot]]} =
               query_span!(
                 conn,
                 "shape_snapshot.get_pg_snapshot",
                 shape_attrs,
-                "SELECT pg_current_snapshot()::text",
+                "SELECT pg_current_snapshot()",
                 [],
                 stack_id
               )
 
             GenServer.cast(
               parent,
-              {:pg_snapshot_known, shape_handle, parse_pg_snapshot_str(pg_snapshot_str)}
+              {:pg_snapshot_known, shape_handle, pg_snapshot}
             )
 
             # Enforce display settings *before* querying initial data to maintain consistent
@@ -204,15 +204,5 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
       "shape.root_table": shape.root_table,
       "shape.where": shape.where
     ]
-  end
-
-  defp parse_pg_snapshot_str(str) do
-    [xmin, xmax, xip_list_str] = String.split(str, ":")
-
-    [xmin, xmax | xip_list] =
-      [xmin, xmax | String.split(xip_list_str, ",", trim: true)]
-      |> Enum.map(&String.to_integer/1)
-
-    %{xmin: xmin, xmax: xmax, xip_list: xip_list}
   end
 end

--- a/packages/sync-service/lib/pg_interop/postgrex/extensions/pg_snapshot.ex
+++ b/packages/sync-service/lib/pg_interop/postgrex/extensions/pg_snapshot.ex
@@ -1,0 +1,19 @@
+defmodule PgInterop.Postgrex.Extensions.PgSnapshot do
+  use Postgrex.BinaryExtension, send: "pg_snapshot_send"
+  import Postgrex.BinaryUtils, warn: false
+
+  def encode(_state) do
+    quote location: :keep do
+      _ -> raise DBConnection.EncodeError, "encoding of type pg_snapshot not implemented"
+    end
+  end
+
+  def decode(_) do
+    quote location: :keep do
+      <<len::int32(), nxip::int32(), xmin::uint64(), xmax::uint64(), rest::binary-size(len - 20)>> ->
+        xip_list = for <<xid::uint64() <- rest>>, do: xid
+        true = nxip == length(xip_list)
+        {xmin, xmax, xip_list}
+    end
+  end
+end

--- a/packages/sync-service/lib/pg_interop/postgrex/types.ex
+++ b/packages/sync-service/lib/pg_interop/postgrex/types.ex
@@ -1,1 +1,4 @@
-Postgrex.Types.define(PgInterop.Postgrex.Types, [PgInterop.Postgrex.Extensions.PgLsn])
+Postgrex.Types.define(PgInterop.Postgrex.Types, [
+  PgInterop.Postgrex.Extensions.PgLsn,
+  PgInterop.Postgrex.Extensions.PgSnapshot
+])

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -594,7 +594,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         # storage.set_shape_definition(@shape, opts)
         storage.mark_snapshot_as_started(opts)
         storage.make_new_snapshot!(@data_stream, opts)
-        storage.set_snapshot_xmin(11, opts)
+        storage.set_pg_snapshot(%{xmin: 11, xmax: 12, xip_list: []}, opts)
         assert storage.snapshot_started?(opts)
 
         storage.initialise(opts)
@@ -602,7 +602,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         refute storage.snapshot_started?(opts)
       end
 
-      test "removes the shape if the snapshot_xmin has not been set", %{
+      test "removes the shape if pg_snapshot has not been set", %{
         module: storage,
         opts: opts
       } do
@@ -611,7 +611,6 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         storage.set_shape_definition(@shape, opts)
         storage.mark_snapshot_as_started(opts)
         storage.make_new_snapshot!(@data_stream, opts)
-        # storage.set_snapshot_xmin(11, opts)
         assert storage.snapshot_started?(opts)
 
         storage.initialise(opts)
@@ -627,7 +626,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
 
         storage.set_shape_definition(@shape, opts)
         storage.mark_snapshot_as_started(opts)
-        storage.set_snapshot_xmin(22, opts)
+        storage.set_pg_snapshot(%{xmin: 22, xmax: 23, xip_list: []}, opts)
 
         storage.initialise(opts)
 
@@ -643,7 +642,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         storage.set_shape_definition(@shape, opts)
         storage.mark_snapshot_as_started(opts)
         storage.make_new_snapshot!(@data_stream, opts)
-        storage.set_snapshot_xmin(11, opts)
+        storage.set_pg_snapshot(%{xmin: 11, xmax: 12, xip_list: []}, opts)
 
         storage.initialise(%{opts | version: "new-version"})
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -55,6 +55,9 @@ defmodule Electric.ShapeCacheTest do
                     %{name: "value", type: "text", type_id: {25, 1}}
                   ])
 
+  @pg_snapshot_xmin_10 %{xmin: 10, xmax: 11, xip_list: [10]}
+  @pg_snapshot_xmin_100 %{xmin: 100, xmax: 101, xip_list: [100]}
+
   defmodule TempPubManager do
     def add_shape(_, opts) do
       send(opts[:test_pid], {:called, :prepare_tables_fn})
@@ -116,7 +119,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -139,7 +142,7 @@ defmodule Electric.ShapeCacheTest do
           publication_manager: {TempPubManager, [test_pid: test_pid]},
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
             send(test_pid, {:called, :create_snapshot_fn})
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -166,7 +169,7 @@ defmodule Electric.ShapeCacheTest do
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
             send(test_pid, {:called, :create_snapshot_fn})
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -427,7 +430,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -450,7 +453,7 @@ defmodule Electric.ShapeCacheTest do
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -486,7 +489,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _, _, _, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_100})
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
@@ -502,7 +505,7 @@ defmodule Electric.ShapeCacheTest do
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _, _, _, _, _ ->
             Process.sleep(100)
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_100})
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
@@ -527,7 +530,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _, _, _, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 100})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_100})
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
         )
@@ -546,7 +549,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -567,7 +570,7 @@ defmodule Electric.ShapeCacheTest do
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
 
             # Sometimes only some tasks subscribe before reaching this point, and then hang
             # if we don't actually have a snapshot. This is kind of part of the test, because
@@ -619,7 +622,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             GenServer.cast(parent, {:snapshot_started, shape_handle})
 
             Storage.make_new_snapshot!(stream_from_database, storage)
@@ -659,7 +662,7 @@ defmodule Electric.ShapeCacheTest do
             ref = make_ref()
             send(test_pid, {:waiting_point, ref, self()})
             receive(do: ({:continue, ^ref} -> :ok))
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
 
             GenServer.cast(
               parent,
@@ -699,7 +702,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -755,7 +758,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -781,7 +784,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -810,7 +813,6 @@ defmodule Electric.ShapeCacheTest do
     @describetag capture_log: true
 
     @describetag :tmp_dir
-    @snapshot_xmin 10
 
     setup do
       %{
@@ -833,7 +835,7 @@ defmodule Electric.ShapeCacheTest do
         with_shape_cache(Map.put(ctx, :inspector, @stub_inspector),
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, @snapshot_xmin})
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
             Storage.make_new_snapshot!([["test"]], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end
@@ -853,14 +855,16 @@ defmodule Electric.ShapeCacheTest do
       :started = ShapeCache.await_snapshot_start(shape_handle, opts)
       meta_table = Keyword.fetch!(opts, :shape_meta_table)
       [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
-      {:ok, @snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
+      {:ok, snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
+      assert snapshot_xmin == @pg_snapshot_xmin_10.xmin
 
       %{shape_cache_opts: opts} = restart_shape_cache(context)
       :started = ShapeCache.await_snapshot_start(shape_handle, opts)
 
       meta_table = Keyword.fetch!(opts, :shape_meta_table)
       assert [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
-      {:ok, @snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
+      {:ok, snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
+      assert snapshot_xmin == @pg_snapshot_xmin_10.xmin
     end
 
     test "restores publication filters", %{shape_cache_opts: opts} = context do
@@ -923,7 +927,7 @@ defmodule Electric.ShapeCacheTest do
 
       with_shape_cache(Map.put(context, :inspector, @stub_inspector),
         create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-          GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, @snapshot_xmin})
+          GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
           Storage.make_new_snapshot!([["test"]], storage)
           GenServer.cast(parent, {:snapshot_started, shape_handle})
         end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -55,8 +55,9 @@ defmodule Electric.ShapeCacheTest do
                     %{name: "value", type: "text", type_id: {25, 1}}
                   ])
 
-  @pg_snapshot_xmin_10 %{xmin: 10, xmax: 11, xip_list: [10]}
-  @pg_snapshot_xmin_100 %{xmin: 100, xmax: 101, xip_list: [100]}
+  # {xmin, xmax, xip_list}
+  @pg_snapshot_xmin_10 {10, 11, [10]}
+  @pg_snapshot_xmin_100 {100, 101, [100]}
 
   defmodule TempPubManager do
     def add_shape(_, opts) do
@@ -856,7 +857,7 @@ defmodule Electric.ShapeCacheTest do
       meta_table = Keyword.fetch!(opts, :shape_meta_table)
       [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
       {:ok, snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
-      assert snapshot_xmin == @pg_snapshot_xmin_10.xmin
+      assert snapshot_xmin == elem(@pg_snapshot_xmin_10, 0)
 
       %{shape_cache_opts: opts} = restart_shape_cache(context)
       :started = ShapeCache.await_snapshot_start(shape_handle, opts)
@@ -864,7 +865,7 @@ defmodule Electric.ShapeCacheTest do
       meta_table = Keyword.fetch!(opts, :shape_meta_table)
       assert [{^shape_handle, @shape}] = ShapeCache.list_shapes(%{shape_meta_table: meta_table})
       {:ok, snapshot_xmin} = ShapeStatus.snapshot_xmin(meta_table, shape_handle)
-      assert snapshot_xmin == @pg_snapshot_xmin_10.xmin
+      assert snapshot_xmin == elem(@pg_snapshot_xmin_10, 0)
     end
 
     test "restores publication filters", %{shape_cache_opts: opts} = context do

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -97,11 +97,11 @@ defmodule Electric.Shapes.ConsumerTest do
         Support.TestStorage.wrap(ctx.storage, %{
           @shape_handle1 => [
             {:mark_snapshot_as_started, []},
-            {:set_snapshot_xmin, [xmin1]}
+            {:set_pg_snapshot, [%{xmin: xmin1, xmax: xmin1 + 1, xip_list: [xmin1]}]}
           ],
           @shape_handle2 => [
             {:mark_snapshot_as_started, []},
-            {:set_snapshot_xmin, [xmin2]}
+            {:set_pg_snapshot, [%{xmin: xmin2, xmax: xmin2 + 1, xip_list: [xmin2]}]}
           ]
         })
 
@@ -669,7 +669,8 @@ defmodule Electric.Shapes.ConsumerTest do
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
             if is_integer(snapshot_delay), do: Process.sleep(snapshot_delay)
-            GenServer.cast(parent, {:snapshot_xmin_known, shape_handle, 10})
+            pg_snapshot = %{xmin: 10, xmax: 11, xip_list: [10]}
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, pg_snapshot})
             Storage.make_new_snapshot!([], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})
           end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -669,7 +669,7 @@ defmodule Electric.Shapes.ConsumerTest do
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
             if is_integer(snapshot_delay), do: Process.sleep(snapshot_delay)
-            pg_snapshot = %{xmin: 10, xmax: 11, xip_list: [10]}
+            pg_snapshot = {10, 11, [10]}
             GenServer.cast(parent, {:pg_snapshot_known, shape_handle, pg_snapshot})
             Storage.make_new_snapshot!([], storage)
             GenServer.cast(parent, {:snapshot_started, shape_handle})

--- a/packages/sync-service/test/pg_interop/postgrex/extensions/pg_snapshot_test.exs
+++ b/packages/sync-service/test/pg_interop/postgrex/extensions/pg_snapshot_test.exs
@@ -31,9 +31,13 @@ defmodule PgInterop.Postgrex.Extensions.PgSnapshotTest do
     assert xmin < xmax
 
     assert is_list(xip_list)
-    assert num_txns == length(xip_list)
     assert Enum.all?(xip_list, &is_integer/1)
     assert Enum.all?(xip_list, &(&1 > 0))
+
+    # Postgres transactions and XIDs are not scoped to any single database. So due to the
+    # concurrent nature of our unit tests, the list of active transactions may include some
+    # started by other tests running in parallel with this one.
+    assert num_txns <= length(xip_list)
 
     assert xmin in xip_list
     assert Enum.max(xip_list) < xmax

--- a/packages/sync-service/test/pg_interop/postgrex/extensions/pg_snapshot_test.exs
+++ b/packages/sync-service/test/pg_interop/postgrex/extensions/pg_snapshot_test.exs
@@ -1,0 +1,72 @@
+defmodule PgInterop.Postgrex.Extensions.PgSnapshotTest do
+  use ExUnit.Case, async: true
+
+  setup do: %{connection_opt_overrides: [pool_size: 4]}
+  setup {Support.DbSetup, :with_unique_db}
+
+  test "can decode pg_snapshot values", %{db_conn: db_pool} do
+    Postgrex.query!(db_pool, "CREATE TABLE foo(id int PRIMARY KEY)", [])
+
+    # Starting a new transaction, followed by a committed write, results in the growth of the
+    # current snapshot's xip_list.
+    num_txns = 3
+
+    Enum.each(1..num_txns, fn i ->
+      spawn_txn(db_pool)
+      Postgrex.query!(db_pool, "INSERT INTO foo VALUES (#{i})", [])
+    end)
+
+    {:ok, result} =
+      Postgrex.transaction(db_pool, fn conn ->
+        Postgrex.query!(conn, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY", [])
+        Postgrex.query!(conn, "SELECT pg_current_snapshot()", [])
+      end)
+
+    assert %Postgrex.Result{rows: [[{xmin, xmax, xip_list}]], num_rows: 1} = result
+
+    assert is_integer(xmin)
+    assert xmin > 0
+    assert is_integer(xmax)
+    assert xmax > 0
+    assert xmin < xmax
+
+    assert is_list(xip_list)
+    assert num_txns == length(xip_list)
+    assert Enum.all?(xip_list, &is_integer/1)
+    assert Enum.all?(xip_list, &(&1 > 0))
+
+    assert xmin in xip_list
+    assert Enum.max(xip_list) < xmax
+  end
+
+  test "encoding of pg_snapshot values is not implemented", %{db_conn: conn} do
+    assert_raise DBConnection.EncodeError,
+                 "encoding of type pg_snapshot not implemented",
+                 fn ->
+                   Postgrex.query(conn, "SELECT $1::pg_snapshot", [{1, 2, [1]}])
+                 end
+  end
+
+  #
+  ## Helper functions
+  #
+
+  defp spawn_txn(conn) do
+    pid = self()
+    ref = make_ref()
+
+    t = Task.async(fn -> Postgrex.transaction(conn, &generic_txn(&1, pid, ref)) end)
+    assert_receive {:inside_transaction, ^ref}
+
+    {t, ref}
+  end
+
+  defp generic_txn(conn, pid, ref) do
+    Postgrex.query!(conn, "SELECT pg_current_xact_id()", [])
+    send(pid, {:inside_transaction, ref})
+
+    receive do
+      {:shutdown, ^ref} -> :ok
+    end
+  end
+end

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -43,7 +43,11 @@ defmodule Support.DbSetup do
       GenServer.stop(utility_pool)
     end)
 
-    updated_config = Keyword.put(base_config, :database, db_name)
+    updated_config =
+      base_config
+      |> Keyword.put(:database, db_name)
+      |> Keyword.merge(List.wrap(ctx[:connection_opt_overrides]))
+
     {:ok, pool} = start_db_pool(updated_config)
 
     {:ok, %{utility_pool: utility_pool, db_config: updated_config, pool: pool, db_conn: pool}}
@@ -128,7 +132,9 @@ defmodule Support.DbSetup do
       |> String.replace_trailing("==", "")
 
   defp start_db_pool(connection_opts) do
-    start_opts = Electric.Utils.deobfuscate_password(connection_opts) ++ @postgrex_start_opts
+    start_opts =
+      Keyword.merge(@postgrex_start_opts, Electric.Utils.deobfuscate_password(connection_opts))
+
     Postgrex.start_link(start_opts)
   end
 end

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -15,7 +15,7 @@ defmodule Support.TestStorage do
       # setup "shape-1" with a snapshot
       init = %{
         "shape-1" => [
-          {:set_snapshot_xmin, [123]},
+          {:set_pg_snapshot, [%{xmin: 123, xmax: 124, xip_list: [123]}]},
           {:mark_snapshot_as_started, []},
           {:make_new_snapshot!, [
             # snapshot entries
@@ -91,9 +91,9 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def set_snapshot_xmin(xmin, {parent, shape_handle, _, storage}) do
-    send(parent, {__MODULE__, :set_snapshot_xmin, shape_handle, xmin})
-    Storage.set_snapshot_xmin(xmin, storage)
+  def set_pg_snapshot(pg_snapshot, {parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :set_pg_snapshot, shape_handle, pg_snapshot})
+    Storage.set_pg_snapshot(pg_snapshot, storage)
   end
 
   @impl Electric.ShapeCache.Storage


### PR DESCRIPTION
Electric now stores the full pg snapshot info in the shape snapshot. Transaction filtering logic is then improved to skip additional transactions that are already included in the snapshot.

This change is backwards-compatible with existing shapes.

Fixes #2313.