### PR TITLE
Fix version format in README.md

### DIFF
--- a/packages/sync-service/README.md
+++ b/packages/sync-service/README.md
@@ -44,7 +44,7 @@ Include `:electric` into your dependencies:
     # mix.exs
     defp deps do
       [
-      {:electric, ">= 1.0.0-beta.1"}
+      {:electric, ">= 1.0.0-beta.18"}
       ]
     end
 

--- a/packages/sync-service/README.md
+++ b/packages/sync-service/README.md
@@ -44,7 +44,7 @@ Include `:electric` into your dependencies:
     # mix.exs
     defp deps do
       [
-      {:electric, ">= 1.0.0-beta-1"}
+      {:electric, ">= 1.0.0-beta.1"}
       ]
     end
 


### PR DESCRIPTION
The format for the version couldn't resolve:

> Because your app depends on electric >= 1.0.0-beta-1 which doesn't match any versions, version solving failed.
> ** (Mix) Hex dependency resolution failed

