### PR TITLE
Fix file corruption in Electric.Utils.external_merge_sort()

### DIFF
--- a/.changeset/fuzzy-dingos-doubt.md
+++ b/.changeset/fuzzy-dingos-doubt.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: Fix file corruption when doing external sort during compaction

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -532,9 +532,7 @@ defmodule Electric.Utils do
   def merge_sorted_files(paths, target_path, reader, sorter \\ &<=/2)
 
   def merge_sorted_files([path], target_path, _reader, _sorter) do
-    File.stream!(path)
-    |> Stream.into(File.stream!(target_path))
-    |> Stream.run()
+    File.copy!(path, target_path)
   end
 
   def merge_sorted_files(paths, target_path, reader, sorter) do


### PR DESCRIPTION
When the input file is small enough to fit into a single chunk. The problem is that `File.stream!`, by default, looks for line break characters and normalizes any `\r\n` into `\n` when reading from the file. So the data it writes into the target file is different from the one it read from chunk_0 if it so happens that the latter has the sequence of bytes `<<13, 10>>` in it.