### PR TITLE
feat(experimental): MultiShapeStream and TransactionalMultiShapeStream APIs

### DIFF
--- a/.changeset/old-tigers-collect.md
+++ b/.changeset/old-tigers-collect.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Correctly set the cache busting url param when using `forceDisconnectAndRefresh`

--- a/.changeset/serious-clouds-thank.md
+++ b/.changeset/serious-clouds-thank.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/experimental": patch
+---
+
+New experimental MultiShapeStream and TransactionalMultiShapeStream APIs that combine multiple shapes streams into a single stream. Note: these two APIs are experimental and are likely to change in a future version of the package.

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -6,10 +6,8 @@
   "bugs": {
     "url": "https://github.com/electric-sql/electric/issues"
   },
-  "dependencies": {
-    "@electric-sql/client": "workspace:*"
-  },
   "devDependencies": {
+    "@electric-sql/client": "workspace:*",
     "@types/pg": "^8.11.6",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
@@ -26,6 +24,14 @@
     "typescript": "^5.5.2",
     "uuid": "^10.0.0",
     "vitest": "^2.0.2"
+  },
+  "peerDependencies": {
+    "@electric-sql/client": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@electric-sql/client": {
+      "optional": false
+    }
   },
   "exports": {
     "./package.json": "./package.json",

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -1,1 +1,2 @@
 export * from './match'
+export * from './multi-shape-stream'

--- a/packages/experimental/src/multi-shape-stream.ts
+++ b/packages/experimental/src/multi-shape-stream.ts
@@ -1,0 +1,270 @@
+import { ShapeStream } from '@electric-sql/client'
+import type {
+  ChangeMessage,
+  ControlMessage,
+  FetchError,
+  MaybePromise,
+  Row,
+  ShapeStreamOptions,
+} from '@electric-sql/client'
+
+type InferShapeTypes<T> = {
+  [K in keyof T]: T[K] extends ShapeStreamOptions<infer R extends Row<unknown>>
+    ? R
+    : T[K] extends ShapeStream<infer R extends Row<unknown>>
+      ? R
+      : never
+}
+
+interface MultiShapeStreamOptions<
+  TShapes extends {
+    [K: string]: ShapeStreamOptions<Row<unknown>> | ShapeStream<Row<unknown>>
+  } = {
+    [K: string]: ShapeStreamOptions<Row<unknown>> | ShapeStream<Row<unknown>>
+  },
+> {
+  shapes: TShapes
+  start?: boolean
+  checkForUpdatesAfter?: number // milliseconds
+}
+
+interface MultiShapeChangeMessage<
+  T extends Row<unknown>,
+  ShapeNames extends string,
+> extends ChangeMessage<T> {
+  shape: ShapeNames
+}
+
+interface MultiShapeControlMessage<ShapeNames extends string>
+  extends ControlMessage {
+  shape: ShapeNames
+}
+
+type MultiShapeMessage<T extends Row<unknown>, ShapeNames extends string> =
+  | MultiShapeChangeMessage<T, ShapeNames>
+  | MultiShapeControlMessage<ShapeNames>
+
+type MultiShapeMessages<
+  TShapes extends {
+    [K: string]: ShapeStreamOptions<Row<unknown>> | ShapeStream<Row<unknown>>
+  },
+> = {
+  [K in keyof TShapes & string]: MultiShapeMessage<
+    InferShapeTypes<TShapes>[K],
+    K
+  >
+}
+
+interface MultiShapeStreamInterface<
+  TShapes extends {
+    [K: string]: ShapeStreamOptions<Row<unknown>> | ShapeStream<Row<unknown>>
+  },
+> {
+  shapes: { [K in keyof TShapes]: ShapeStream<InferShapeTypes<TShapes>[K]> }
+  checkForUpdatesAfter?: number
+
+  subscribe(
+    callback: (messages: MultiShapeMessages<TShapes>[]) => MaybePromise<void>,
+    onError?: (error: FetchError | Error) => void
+  ): () => void
+  unsubscribeAll(): void
+
+  lastSyncedAt(): number | undefined
+  lastSynced(): number
+  isConnected(): boolean
+  isLoading(): boolean
+
+  isUpToDate: boolean
+}
+
+/**
+ * A multi-shape stream is a stream that can subscribe to multiple shapes.
+ * It ensures that all shapes will receive at least an `up-to-date` message from
+ * Electric within the `checkForUpdatesAfter` interval.
+ *
+ * @constructor
+ * @param {MultiShapeStreamOptions} options - configure the multi-shape stream
+ * @example
+ * ```ts
+ * const multiShapeStream = new MultiShapeStream({
+ *   shapes: {
+ *     shape1: {
+ *       url: 'http://localhost:3000/v1/shape1',
+ *     },
+ *     shape2: {
+ *       url: 'http://localhost:3000/v1/shape2',
+ *     },
+ *   },
+ * })
+ * ```
+ */
+
+export class MultiShapeStream<
+  TShapes extends {
+    [K: string]: ShapeStreamOptions<Row<unknown>> | ShapeStream<Row<unknown>>
+  },
+> implements MultiShapeStreamInterface<TShapes>
+{
+  #shapes: { [K in keyof TShapes]: ShapeStream<InferShapeTypes<TShapes>[K]> }
+  #started = false
+  checkForUpdatesAfter?: number
+
+  #checkForUpdatesTimeout?: ReturnType<typeof setTimeout> | undefined
+  #shapesToSkipCheckForUpdates = new Set<keyof TShapes>()
+
+  readonly #subscribers = new Map<
+    number,
+    [
+      (messages: MultiShapeMessages<TShapes>[]) => MaybePromise<void>,
+      ((error: Error) => void) | undefined,
+    ]
+  >()
+
+  constructor(options: MultiShapeStreamOptions<TShapes>) {
+    const {
+      start = true, // By default we start the multi-shape stream
+      checkForUpdatesAfter = 100, // Force a check for updates after 100ms
+      shapes,
+    } = options
+    this.checkForUpdatesAfter = checkForUpdatesAfter
+    this.#shapes = Object.fromEntries(
+      Object.entries(shapes).map(([key, shape]) => [
+        key,
+        shape instanceof ShapeStream
+          ? shape
+          : new ShapeStream<InferShapeTypes<TShapes>[typeof key]>(shape as any),
+      ])
+    ) as { [K in keyof TShapes]: ShapeStream<InferShapeTypes<TShapes>[K]> }
+    if (start) this.#start()
+  }
+
+  #start() {
+    if (this.#started) throw new Error(`Cannot start multi-shape stream twice`)
+    for (const [key, shape] of this.#shapeEntries()) {
+      if (shape.hasStarted()) {
+        // The multi-shape stream needs to be started together as a whole, and so we
+        // have to check that a shape is not already started.
+        throw new Error(`Shape ${key} already started`)
+      }
+      shape.subscribe(
+        async (messages) => {
+          this.#scheduleCheckForUpdates(key)
+          const multiShapeMessages = messages.map(
+            (message) =>
+              ({
+                ...message,
+                shape: key,
+              }) as MultiShapeMessages<TShapes>
+          )
+          await this.#publish(multiShapeMessages)
+        },
+        (error) => this.#onError(error)
+      )
+    }
+  }
+
+  #scheduleCheckForUpdates(fromShape: keyof TShapes) {
+    this.#shapesToSkipCheckForUpdates.add(fromShape)
+    this.#checkForUpdatesTimeout ??= setTimeout(() => {
+      this.#checkForUpdates()
+      this.#checkForUpdatesTimeout = undefined
+    }, this.checkForUpdatesAfter)
+  }
+
+  async #checkForUpdates() {
+    const refreshPromises = this.#shapeEntries()
+      .filter(([key]) => !this.#shapesToSkipCheckForUpdates.has(key))
+      .map(([_, shape]) => {
+        return shape.forceDisconnectAndRefresh()
+      })
+    this.#shapesToSkipCheckForUpdates.clear()
+    await Promise.all(refreshPromises)
+  }
+
+  #onError(error: Error) {
+    // TODO: we probably want to disconnect all shapes here on the first error
+    this.#subscribers.forEach(([_, errorFn]) => {
+      errorFn?.(error)
+    })
+  }
+
+  async #publish(messages: MultiShapeMessages<TShapes>[]): Promise<void> {
+    await Promise.all(
+      Array.from(this.#subscribers.values()).map(async ([callback, __]) => {
+        try {
+          await callback(messages)
+        } catch (err) {
+          queueMicrotask(() => {
+            throw err
+          })
+        }
+      })
+    )
+  }
+
+  /**
+   * Returns an array of the shape entries.
+   * Ensures that the shape entries are typed, as `Object.entries`
+   * will not type the entries correctly.
+   */
+  #shapeEntries() {
+    return Object.entries(this.#shapes) as [
+      keyof TShapes & string,
+      ShapeStream<InferShapeTypes<TShapes>[string]>,
+    ][]
+  }
+
+  /**
+   * The ShapeStreams that are being subscribed to.
+   */
+  get shapes() {
+    return this.#shapes
+  }
+
+  subscribe(
+    callback: (messages: MultiShapeMessages<TShapes>[]) => MaybePromise<void>,
+    onError?: (error: FetchError | Error) => void
+  ) {
+    const subscriptionId = Math.random()
+
+    this.#subscribers.set(subscriptionId, [callback, onError])
+    if (!this.#started) this.#start()
+
+    return () => {
+      this.#subscribers.delete(subscriptionId)
+    }
+  }
+
+  unsubscribeAll(): void {
+    this.#subscribers.clear()
+  }
+
+  /** Unix time at which we last synced. Undefined when `isLoading` is true. */
+  lastSyncedAt(): number | undefined {
+    // Min of all the lastSyncedAt values
+    return Math.min(
+      ...this.#shapeEntries().map(([_, shape]) => shape.lastSyncedAt() ?? Infinity)
+    )
+  }
+
+  /** Time elapsed since last sync (in ms). Infinity if we did not yet sync. */
+  lastSynced(): number {
+    const lastSyncedAt = this.lastSyncedAt()
+    if (lastSyncedAt === undefined) return Infinity
+    return Date.now() - lastSyncedAt
+  }
+
+  /** Indicates if we are connected to the Electric sync service. */
+  isConnected(): boolean {
+    return this.#shapeEntries().every(([_, shape]) => shape.isConnected())
+  }
+
+  /** True during initial fetch. False afterwise. */
+  isLoading(): boolean {
+    return this.#shapeEntries().some(([_, shape]) => shape.isLoading())
+  }
+
+  get isUpToDate() {
+    return this.#shapeEntries().every(([_, shape]) => shape.isUpToDate)
+  }
+}

--- a/packages/experimental/test/multi-shape-stream.test-d.ts
+++ b/packages/experimental/test/multi-shape-stream.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, expectTypeOf, test } from 'vitest'
+import { describe, expectTypeOf, test } from 'vitest'
 import { Row, ShapeStream, ShapeStreamOptions } from '@electric-sql/client'
 import { MultiShapeStream } from '../src/multi-shape-stream'
 

--- a/packages/experimental/test/multi-shape-stream.test-d.ts
+++ b/packages/experimental/test/multi-shape-stream.test-d.ts
@@ -1,0 +1,51 @@
+import { assertType, describe, expectTypeOf, test } from 'vitest'
+import { Row, ShapeStream, ShapeStreamOptions } from '@electric-sql/client'
+import { MultiShapeStream } from '../src/multi-shape-stream'
+
+interface UserRow extends Row {
+  id: string
+  name: string
+}
+
+interface PostRow extends Row {
+  id: string
+  content: string
+}
+
+describe('MultiShapeStream', () => {
+  test('type inference with ShapeStream instances', () => {
+    const stream = new MultiShapeStream({
+      shapes: {
+        users: new ShapeStream<UserRow>({ url: 'users' }),
+        posts: new ShapeStream<PostRow>({ url: 'posts' })
+      }
+    })
+
+    expectTypeOf(stream.shapes.users).toEqualTypeOf<ShapeStream<UserRow>>()
+    expectTypeOf(stream.shapes.posts).toEqualTypeOf<ShapeStream<PostRow>>()
+  })
+
+  test('type inference with ShapeStreamOptions', () => {
+    const stream = new MultiShapeStream({
+      shapes: {
+        users: { url: 'users' } as ShapeStreamOptions<UserRow>,
+        posts: { url: 'posts' } as ShapeStreamOptions<PostRow>
+      }
+    })
+
+    expectTypeOf(stream.shapes.users).toEqualTypeOf<ShapeStream<UserRow>>()
+    expectTypeOf(stream.shapes.posts).toEqualTypeOf<ShapeStream<PostRow>>()
+  })
+
+  test('type inference with mixed ShapeStream and ShapeStreamOptions', () => {
+    const stream = new MultiShapeStream({
+      shapes: {
+        users: new ShapeStream<UserRow>({ url: 'users' }),
+        posts: { url: 'posts' } as ShapeStreamOptions<PostRow>
+      }
+    })
+
+    expectTypeOf(stream.shapes.users).toEqualTypeOf<ShapeStream<UserRow>>()
+    expectTypeOf(stream.shapes.posts).toEqualTypeOf<ShapeStream<PostRow>>()
+  })
+}) 

--- a/packages/experimental/test/multi-shape-stream.test-d.ts
+++ b/packages/experimental/test/multi-shape-stream.test-d.ts
@@ -12,40 +12,40 @@ interface PostRow extends Row {
   content: string
 }
 
-describe('MultiShapeStream', () => {
-  test('type inference with ShapeStream instances', () => {
+describe(`MultiShapeStream`, () => {
+  test(`type inference with ShapeStream instances`, () => {
     const stream = new MultiShapeStream({
       shapes: {
-        users: new ShapeStream<UserRow>({ url: 'users' }),
-        posts: new ShapeStream<PostRow>({ url: 'posts' })
-      }
+        users: new ShapeStream<UserRow>({ url: `users` }),
+        posts: new ShapeStream<PostRow>({ url: `posts` }),
+      },
     })
 
     expectTypeOf(stream.shapes.users).toEqualTypeOf<ShapeStream<UserRow>>()
     expectTypeOf(stream.shapes.posts).toEqualTypeOf<ShapeStream<PostRow>>()
   })
 
-  test('type inference with ShapeStreamOptions', () => {
+  test(`type inference with ShapeStreamOptions`, () => {
     const stream = new MultiShapeStream({
       shapes: {
-        users: { url: 'users' } as ShapeStreamOptions<UserRow>,
-        posts: { url: 'posts' } as ShapeStreamOptions<PostRow>
-      }
+        users: { url: `users` } as ShapeStreamOptions<UserRow>,
+        posts: { url: `posts` } as ShapeStreamOptions<PostRow>,
+      },
     })
 
     expectTypeOf(stream.shapes.users).toEqualTypeOf<ShapeStream<UserRow>>()
     expectTypeOf(stream.shapes.posts).toEqualTypeOf<ShapeStream<PostRow>>()
   })
 
-  test('type inference with mixed ShapeStream and ShapeStreamOptions', () => {
+  test(`type inference with mixed ShapeStream and ShapeStreamOptions`, () => {
     const stream = new MultiShapeStream({
       shapes: {
-        users: new ShapeStream<UserRow>({ url: 'users' }),
-        posts: { url: 'posts' } as ShapeStreamOptions<PostRow>
-      }
+        users: new ShapeStream<UserRow>({ url: `users` }),
+        posts: { url: `posts` } as ShapeStreamOptions<PostRow>,
+      },
     })
 
     expectTypeOf(stream.shapes.users).toEqualTypeOf<ShapeStream<UserRow>>()
     expectTypeOf(stream.shapes.posts).toEqualTypeOf<ShapeStream<PostRow>>()
   })
-}) 
+})

--- a/packages/experimental/test/multi-shape-stream.test.ts
+++ b/packages/experimental/test/multi-shape-stream.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, inject, vi } from 'vitest'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { testWithIssuesTable as it } from './support/test-context'
+import { MultiShapeStream } from '../src/multi-shape-stream'
+import { Row } from '@electric-sql/client'
+import type { MultiShapeMessages } from '../src/multi-shape-stream'
+
+const BASE_URL = inject(`baseUrl`)
+
+interface IssueRow extends Row {
+  id: string
+  title: string
+  priority: number
+}
+
+describe(`MultiShapeStream`, () => {
+  it(`should sync multiple empty shapes`, async ({
+    issuesTableUrl,
+    clearIssuesShape,
+  }) => {
+    const start = Date.now()
+    const multiShapeStream = new MultiShapeStream<{
+      shape1: IssueRow
+      shape2: IssueRow
+    }>({
+      shapes: {
+        shape1: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority <= 10`,
+          },
+        },
+        shape2: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority > 10`,
+          },
+        },
+      },
+    })
+
+    // Subscribe to start the stream
+    const hasNotified = new Promise((resolve) => {
+      multiShapeStream.subscribe(resolve)
+    })
+
+    await hasNotified
+    await clearIssuesShape(multiShapeStream.shapes.shape2.shapeHandle)
+    await clearIssuesShape(multiShapeStream.shapes.shape1.shapeHandle)
+
+    expect(multiShapeStream.lastSyncedAt()).toBeGreaterThanOrEqual(start)
+    expect(multiShapeStream.lastSyncedAt()).toBeLessThanOrEqual(Date.now())
+    expect(multiShapeStream.lastSynced()).toBeLessThanOrEqual(
+      Date.now() - start
+    )
+    expect(multiShapeStream.isConnected()).toBe(true)
+  })
+
+  it(`should notify with initial values from multiple shapes`, async ({
+    issuesTableUrl,
+    insertIssues,
+    aborter,
+  }) => {
+    const [id1] = await insertIssues({ title: `test title 1`, priority: 5 })
+    const [id2] = await insertIssues({ title: `test title 2`, priority: 15 })
+
+    const start = Date.now()
+    type ShapeConfig = {
+      lowPriority: IssueRow
+      highPriority: IssueRow
+    }
+
+    const multiShapeStream = new MultiShapeStream<ShapeConfig>({
+      shapes: {
+        lowPriority: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority <= 10`,
+          },
+          signal: aborter.signal,
+        },
+        highPriority: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority > 10`,
+          },
+          signal: aborter.signal,
+        },
+      },
+    })
+
+    const messages: MultiShapeMessages<ShapeConfig>[] = []
+
+    await new Promise<void>((resolve) => {
+      multiShapeStream.subscribe((msgs) => {
+        messages.push(...msgs)
+        if (multiShapeStream.isUpToDate) {
+          resolve()
+        }
+      })
+    })
+
+    // Verify we get messages from both shapes with correct shape names
+    expect(messages.length).toBeGreaterThan(0)
+    const changeMessages = messages.filter(
+      (msg): msg is MultiShapeMessages<ShapeConfig> & { value: IssueRow } =>
+        'value' in msg
+    )
+
+    // Find messages for each shape
+    const lowPriorityMsg = changeMessages.find(
+      (msg) => msg.shape === 'lowPriority'
+    )
+    const highPriorityMsg = changeMessages.find(
+      (msg) => msg.shape === 'highPriority'
+    )
+
+    expect(lowPriorityMsg?.value).toEqual({
+      id: id1,
+      title: `test title 1`,
+      priority: 5,
+    })
+
+    expect(highPriorityMsg?.value).toEqual({
+      id: id2,
+      title: `test title 2`,
+      priority: 15,
+    })
+
+    expect(multiShapeStream.lastSyncedAt()).toBeGreaterThanOrEqual(start)
+    expect(multiShapeStream.lastSyncedAt()).toBeLessThanOrEqual(Date.now())
+    expect(multiShapeStream.lastSynced()).toBeLessThanOrEqual(
+      Date.now() - start
+    )
+  })
+
+  it(`should continually sync multiple shapes`, async ({
+    issuesTableUrl,
+    insertIssues,
+    updateIssue,
+    aborter,
+  }) => {
+    const [id1] = await insertIssues({ title: `test title 1`, priority: 5 })
+    const [id2] = await insertIssues({ title: `test title 2`, priority: 15 })
+
+    const start = Date.now()
+    type ShapeConfig = {
+      lowPriority: IssueRow
+      highPriority: IssueRow
+    }
+
+    const multiShapeStream = new MultiShapeStream<ShapeConfig>({
+      shapes: {
+        lowPriority: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority <= 10`,
+          },
+          signal: aborter.signal,
+        },
+        highPriority: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority > 10`,
+          },
+          signal: aborter.signal,
+        },
+      },
+    })
+
+    const messages: MultiShapeMessages<ShapeConfig>[] = []
+
+    await new Promise<void>((resolve) => {
+      multiShapeStream.subscribe((msgs) => {
+        messages.push(...msgs)
+        if (multiShapeStream.isUpToDate) {
+          resolve()
+        }
+      })
+    })
+
+    // Update that moves an issue from low to high priority
+    await updateIssue({ id: id1, title: 'low priority', priority: 20 })
+    // Update that moves an issue from high to low priority
+    await updateIssue({ id: id2, title: 'high priority', priority: 5 })
+
+    await sleep(200) // some time for electric to catch up
+
+    // Verify we got update messages for both shapes
+    const changeMessages = (
+      messages as MultiShapeMessages<ShapeConfig>[]
+    ).filter(
+      (msg): msg is MultiShapeMessages<ShapeConfig> & { value: IssueRow } =>
+        'value' in msg
+    )
+
+    // Should have updates in both shapes
+    const lowPriorityMsgs = changeMessages.filter(
+      (msg) => msg.shape === 'lowPriority'
+    )
+    const highPriorityMsgs = changeMessages.filter(
+      (msg) => msg.shape === 'highPriority'
+    )
+
+    expect(lowPriorityMsgs.length).toBe(3)
+    expect(highPriorityMsgs.length).toBe(3)
+
+    expect(
+      lowPriorityMsgs.filter((msg) => msg.headers.operation === 'insert').length
+    ).toBe(2)
+    expect(
+      lowPriorityMsgs.filter((msg) => msg.headers.operation === 'delete').length
+    ).toBe(1)
+
+    expect(
+      highPriorityMsgs.filter((msg) => msg.headers.operation === 'insert')
+        .length
+    ).toBe(2)
+    expect(
+      highPriorityMsgs.filter((msg) => msg.headers.operation === 'delete')
+        .length
+    ).toBe(1)
+  })
+
+  it(`should support unsubscribe`, async ({ issuesTableUrl }) => {
+    const multiShapeStream = new MultiShapeStream<{
+      shape1: IssueRow
+    }>({
+      shapes: {
+        shape1: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+          },
+        },
+      },
+    })
+
+    const subFn = vi.fn((_) => void 0)
+    const unsubscribeFn = multiShapeStream.subscribe(subFn)
+
+    // Wait for initial sync
+    await sleep(100)
+
+    unsubscribeFn()
+    multiShapeStream.unsubscribeAll()
+
+    // Make a change and verify callback isn't called
+    await sleep(100)
+    expect(subFn).toHaveBeenCalledTimes(1) // Only the initial sync
+  })
+
+  it(`should expose connection status for all shapes`, async ({ issuesTableUrl }) => {
+    const aborter = new AbortController()
+    const multiShapeStream = new MultiShapeStream<{
+      shape1: IssueRow
+      shape2: IssueRow
+    }>({
+      shapes: {
+        shape1: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+          },
+          signal: aborter.signal,
+        },
+        shape2: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority > '10'`,
+          },
+          signal: aborter.signal,
+        },
+      },
+    })
+
+    // Wait for initial sync
+    await new Promise<void>((resolve) => {
+      multiShapeStream.subscribe(() => resolve())
+    })
+
+    expect(multiShapeStream.isConnected()).toBe(true)
+
+    // Abort the shape stream and check connectivity status
+    aborter.abort()
+    await sleep(100) // give some time for the shape stream to abort
+
+    expect(multiShapeStream.isConnected()).toBe(false)
+  })
+})

--- a/packages/experimental/test/multi-shape-stream.test.ts
+++ b/packages/experimental/test/multi-shape-stream.test.ts
@@ -108,15 +108,15 @@ describe(`MultiShapeStream`, () => {
     expect(messages.length).toBeGreaterThan(0)
     const changeMessages = messages.filter(
       (msg): msg is MultiShapeMessages<ShapeConfig> & { value: IssueRow } =>
-        'value' in msg
+        `value` in msg
     )
 
     // Find messages for each shape
     const lowPriorityMsg = changeMessages.find(
-      (msg) => msg.shape === 'lowPriority'
+      (msg) => msg.shape === `lowPriority`
     )
     const highPriorityMsg = changeMessages.find(
-      (msg) => msg.shape === 'highPriority'
+      (msg) => msg.shape === `highPriority`
     )
 
     expect(lowPriorityMsg?.value).toEqual({
@@ -186,9 +186,9 @@ describe(`MultiShapeStream`, () => {
     })
 
     // Update that moves an issue from low to high priority
-    await updateIssue({ id: id1, title: 'low priority', priority: 20 })
+    await updateIssue({ id: id1, title: `low priority`, priority: 20 })
     // Update that moves an issue from high to low priority
-    await updateIssue({ id: id2, title: 'high priority', priority: 5 })
+    await updateIssue({ id: id2, title: `high priority`, priority: 5 })
 
     await sleep(200) // some time for electric to catch up
 
@@ -197,33 +197,33 @@ describe(`MultiShapeStream`, () => {
       messages as MultiShapeMessages<ShapeConfig>[]
     ).filter(
       (msg): msg is MultiShapeMessages<ShapeConfig> & { value: IssueRow } =>
-        'value' in msg
+        `value` in msg
     )
 
     // Should have updates in both shapes
     const lowPriorityMsgs = changeMessages.filter(
-      (msg) => msg.shape === 'lowPriority'
+      (msg) => msg.shape === `lowPriority`
     )
     const highPriorityMsgs = changeMessages.filter(
-      (msg) => msg.shape === 'highPriority'
+      (msg) => msg.shape === `highPriority`
     )
 
     expect(lowPriorityMsgs.length).toBe(3)
     expect(highPriorityMsgs.length).toBe(3)
 
     expect(
-      lowPriorityMsgs.filter((msg) => msg.headers.operation === 'insert').length
+      lowPriorityMsgs.filter((msg) => msg.headers.operation === `insert`).length
     ).toBe(2)
     expect(
-      lowPriorityMsgs.filter((msg) => msg.headers.operation === 'delete').length
+      lowPriorityMsgs.filter((msg) => msg.headers.operation === `delete`).length
     ).toBe(1)
 
     expect(
-      highPriorityMsgs.filter((msg) => msg.headers.operation === 'insert')
+      highPriorityMsgs.filter((msg) => msg.headers.operation === `insert`)
         .length
     ).toBe(2)
     expect(
-      highPriorityMsgs.filter((msg) => msg.headers.operation === 'delete')
+      highPriorityMsgs.filter((msg) => msg.headers.operation === `delete`)
         .length
     ).toBe(1)
   })
@@ -256,7 +256,9 @@ describe(`MultiShapeStream`, () => {
     expect(subFn).toHaveBeenCalledTimes(1) // Only the initial sync
   })
 
-  it(`should expose connection status for all shapes`, async ({ issuesTableUrl }) => {
+  it(`should expose connection status for all shapes`, async ({
+    issuesTableUrl,
+  }) => {
     const aborter = new AbortController()
     const multiShapeStream = new MultiShapeStream<{
       shape1: IssueRow

--- a/packages/experimental/test/multi-shape-stream.test.ts
+++ b/packages/experimental/test/multi-shape-stream.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, inject, vi } from 'vitest'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { testWithIssuesTable as it } from './support/test-context'
-import { MultiShapeStream } from '../src/multi-shape-stream'
+import {
+  MultiShapeStream,
+  TransactionalMultiShapeStream,
+} from '../src/multi-shape-stream'
 import { Row } from '@electric-sql/client'
 import type { MultiShapeMessages } from '../src/multi-shape-stream'
+import { v4 as uuidv4 } from 'uuid'
 
 const BASE_URL = inject(`baseUrl`)
 
@@ -55,7 +59,6 @@ describe(`MultiShapeStream`, () => {
     expect(multiShapeStream.lastSynced()).toBeLessThanOrEqual(
       Date.now() - start
     )
-    expect(multiShapeStream.isConnected()).toBe(true)
   })
 
   it(`should notify with initial values from multiple shapes`, async ({
@@ -147,7 +150,6 @@ describe(`MultiShapeStream`, () => {
     const [id1] = await insertIssues({ title: `test title 1`, priority: 5 })
     const [id2] = await insertIssues({ title: `test title 2`, priority: 15 })
 
-    const start = Date.now()
     type ShapeConfig = {
       lowPriority: IssueRow
       highPriority: IssueRow
@@ -255,45 +257,254 @@ describe(`MultiShapeStream`, () => {
     await sleep(100)
     expect(subFn).toHaveBeenCalledTimes(1) // Only the initial sync
   })
+})
 
-  it(`should expose connection status for all shapes`, async ({
+describe(`TransactionalMultiShapeStream`, () => {
+  it(`should group changes from the same transaction together`, async ({
     issuesTableUrl,
+    insertIssues,
+    updateIssue,
+    beginTransaction,
+    commitTransaction,
+    aborter,
   }) => {
-    const aborter = new AbortController()
-    const multiShapeStream = new MultiShapeStream<{
-      shape1: IssueRow
-      shape2: IssueRow
-    }>({
+    // Create initial data
+    const id1 = uuidv4()
+    const id2 = uuidv4()
+    const id3 = uuidv4()
+    await insertIssues({ id: id1, title: `test title 1`, priority: 5 })
+    await insertIssues({ id: id2, title: `test title 2`, priority: 15 })
+
+    type ShapeConfig = {
+      lowPriority: IssueRow
+      highPriority: IssueRow
+    }
+
+    const multiShapeStream = new TransactionalMultiShapeStream<ShapeConfig>({
       shapes: {
-        shape1: {
+        lowPriority: {
           url: `${BASE_URL}/v1/shape`,
           params: {
             table: issuesTableUrl,
+            where: `priority <= 10`,
           },
           signal: aborter.signal,
         },
-        shape2: {
+        highPriority: {
           url: `${BASE_URL}/v1/shape`,
           params: {
             table: issuesTableUrl,
-            where: `priority > '10'`,
+            where: `priority > 10`,
           },
           signal: aborter.signal,
         },
       },
     })
 
-    // Wait for initial sync
+    const messageGroups: MultiShapeMessages<ShapeConfig>[][] = []
+
+    // Subscribe and wait for initial sync
     await new Promise<void>((resolve) => {
-      multiShapeStream.subscribe(() => resolve())
+      multiShapeStream.subscribe((msgs: MultiShapeMessages<ShapeConfig>[]) => {
+        messageGroups.push(msgs)
+        if (multiShapeStream.isUpToDate) {
+          console.log(`multiShapeStream.isUpToDate`)
+          resolve()
+        }
+      })
     })
 
-    expect(multiShapeStream.isConnected()).toBe(true)
+    // We should get one message group containing all changes from the initial sync
+    expect(messageGroups.length).toBe(1)
+    const initialSyncGroup = messageGroups[0]
+    expect(initialSyncGroup.length).toBe(2)
+    expect(initialSyncGroup.every((msg) => `value` in msg)).toBe(true)
 
-    // Abort the shape stream and check connectivity status
-    aborter.abort()
-    await sleep(100) // give some time for the shape stream to abort
+    // Clear initial sync messages
+    messageGroups.length = 0
 
-    expect(multiShapeStream.isConnected()).toBe(false)
+    // Transaction that will affect both shapes
+    await beginTransaction()
+    await updateIssue({ id: id1, title: `moved to high`, priority: 20 })
+    await updateIssue({ id: id2, title: `moved to low`, priority: 5 })
+    await insertIssues({ id: id3, title: `test title 3`, priority: 20 })
+    await commitTransaction()
+
+    // Wait for changes to be processed
+    await sleep(200)
+
+    // We should get one message group containing all changes from the transaction
+    expect(messageGroups.length).toBe(1)
+
+    // Find the message group containing our changes
+    const changeGroup = messageGroups.find((group) =>
+      group.some(
+        (msg) =>
+          `value` in msg && (msg.value.id === id1 || msg.value.id === id2)
+      )
+    )
+
+    expect(changeGroup).toBeDefined()
+    expect(changeGroup!.length).toBe(5)
+    // 2 deletes + 2 inserts for the moves
+    // + 1 insert for the new issue
+
+    // Verify the operations are in the correct order based on op_position
+    const operations = changeGroup!
+      .filter(
+        (msg): msg is MultiShapeMessages<ShapeConfig> & { value: IssueRow } =>
+          `value` in msg
+      )
+      .map((msg) => ({
+        operation: msg.headers.operation,
+        shape: msg.shape,
+        id: msg.value.id,
+      }))
+
+    // Verify we have the expected sequence of operations
+    expect(operations).toContainEqual({
+      operation: `delete`,
+      shape: `lowPriority`,
+      id: id1,
+    })
+    expect(operations).toContainEqual({
+      operation: `insert`,
+      shape: `highPriority`,
+      id: id1,
+    })
+    expect(operations).toContainEqual({
+      operation: `delete`,
+      shape: `highPriority`,
+      id: id2,
+    })
+    expect(operations).toContainEqual({
+      operation: `insert`,
+      shape: `lowPriority`,
+      id: id2,
+    })
+    expect(operations).toContainEqual({
+      operation: `insert`,
+      shape: `highPriority`,
+      id: id3,
+    })
+
+    // Verify the operations are ordered by op_position
+    const opPositions = changeGroup!.map(
+      (msg) => msg.headers.op_position as number
+    )
+    expect(opPositions).toEqual([...opPositions].sort((a, b) => a - b))
+  })
+
+  it(`should maintain transaction boundaries across multiple transactions`, async ({
+    issuesTableUrl,
+    insertIssues,
+    updateIssue,
+    beginTransaction,
+    commitTransaction,
+    aborter,
+  }) => {
+    // Create initial data
+    const id1 = uuidv4()
+    const id2 = uuidv4()
+    await insertIssues({ id: id1, title: `test title 1`, priority: 5 })
+    await insertIssues({ id: id2, title: `test title 2`, priority: 15 })
+
+    type ShapeConfig = {
+      lowPriority: IssueRow
+      highPriority: IssueRow
+    }
+
+    const multiShapeStream = new TransactionalMultiShapeStream<ShapeConfig>({
+      shapes: {
+        lowPriority: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority <= 10`,
+          },
+          signal: aborter.signal,
+        },
+        highPriority: {
+          url: `${BASE_URL}/v1/shape`,
+          params: {
+            table: issuesTableUrl,
+            where: `priority > 10`,
+          },
+          signal: aborter.signal,
+        },
+      },
+    })
+
+    const messageGroups: MultiShapeMessages<ShapeConfig>[][] = []
+
+    // Subscribe and wait for initial sync
+    await new Promise<void>((resolve) => {
+      multiShapeStream.subscribe((msgs: MultiShapeMessages<ShapeConfig>[]) => {
+        messageGroups.push(msgs)
+        if (multiShapeStream.isUpToDate) {
+          resolve()
+        }
+      })
+    })
+
+    // Clear initial sync messages
+    messageGroups.length = 0
+
+    // Perform two separate transactions
+    // Transaction 1: Move id1 to high priority
+    await beginTransaction()
+    await updateIssue({ id: id1, title: `moved to high`, priority: 20 })
+    await commitTransaction()
+
+    await sleep(50)
+
+    // Transaction 2: Move id2 to low priority
+    await beginTransaction()
+    await updateIssue({ id: id2, title: `moved to low`, priority: 5 })
+    await commitTransaction()
+
+    // Wait for changes to be processed
+    await sleep(200)
+
+    // Find message groups containing our changes
+    const changeGroups = messageGroups.filter((group) =>
+      group.some(
+        (msg) =>
+          `value` in msg && (msg.value.id === id1 || msg.value.id === id2)
+      )
+    )
+
+    // We should have two separate transaction groups
+    expect(changeGroups.length).toBe(2)
+
+    // First transaction group should contain operations for id1
+    const transaction1 = changeGroups[0]
+    expect(transaction1.length).toBe(2) // 1 delete + 1 insert
+    expect(
+      transaction1.every((msg) => !(`value` in msg) || msg.value.id === id1)
+    ).toBe(true)
+
+    // Second transaction group should contain operations for id2
+    const transaction2 = changeGroups[1]
+    expect(transaction2.length).toBe(2) // 1 delete + 1 insert
+    expect(
+      transaction2.every((msg) => !(`value` in msg) || msg.value.id === id2)
+    ).toBe(true)
+
+    // Verify LSNs are different between transactions
+    const lsn1 = transaction1[0].headers.lsn
+    const lsn2 = transaction2[0].headers.lsn
+    expect(lsn1).not.toBe(lsn2)
+
+    // Verify operations within each transaction are ordered by op_position
+    const verifyOpPositionOrder = (
+      group: MultiShapeMessages<ShapeConfig>[]
+    ) => {
+      const opPositions = group.map((msg) => msg.headers.op_position as number)
+      expect(opPositions).toEqual([...opPositions].sort((a, b) => a - b))
+    }
+
+    verifyOpPositionOrder(transaction1)
+    verifyOpPositionOrder(transaction2)
   })
 })

--- a/packages/experimental/test/support/test-context.ts
+++ b/packages/experimental/test/support/test-context.ts
@@ -17,6 +17,8 @@ export type UpdateIssueFn = (row: IssueRow) => Promise<QueryResult<IssueRow>>
 export type DeleteIssueFn = (row: IssueRow) => Promise<QueryResult<IssueRow>>
 export type InsertIssuesFn = (...rows: GeneratedIssueRow[]) => Promise<string[]>
 export type ClearIssuesShapeFn = (handle?: string) => Promise<void>
+export type BeginTransactionFn = () => Promise<void>
+export type CommitTransactionFn = () => Promise<void>
 export type ClearShapeFn = (
   table: string,
   options?: { handle?: string }
@@ -87,6 +89,8 @@ export const testWithIssuesTable = testWithDbClient.extend<{
   deleteIssue: DeleteIssueFn
   insertIssues: InsertIssuesFn
   clearIssuesShape: ClearIssuesShapeFn
+  beginTransaction: BeginTransactionFn
+  commitTransaction: CommitTransactionFn
 }>({
   issuesTableSql: async ({ dbClient, task }, use) => {
     const tableName = `"issues for ${task.id}_${Math.random().toString(16)}"`
@@ -142,6 +146,14 @@ export const testWithIssuesTable = testWithDbClient.extend<{
         rows.flatMap((x) => [x.id ?? uuidv4(), x.title, x.priority ?? 10])
       )
       return rows_1.map((x) => x.id)
+    }),
+  beginTransaction: ({ dbClient }, use) =>
+    use(async () => {
+      await dbClient.query(`BEGIN`)
+    }),
+  commitTransaction: ({ dbClient }, use) =>
+    use(async () => {
+      await dbClient.query(`COMMIT`)
     }),
 
   clearIssuesShape: async ({ clearShape, issuesTableUrl }, use) => {

--- a/packages/experimental/test/support/test-context.ts
+++ b/packages/experimental/test/support/test-context.ts
@@ -117,16 +117,15 @@ export const testWithIssuesTable = testWithDbClient.extend<{
   updateIssue: ({ issuesTableSql, dbClient }, use) =>
     use(({ id, title, priority }) => {
       if (priority) {
-        return dbClient.query(`UPDATE ${issuesTableSql} SET title = $2, priority = $3 WHERE id = $1`, [
-          id,
-          title,
-          priority,
-        ])
+        return dbClient.query(
+          `UPDATE ${issuesTableSql} SET title = $2, priority = $3 WHERE id = $1`,
+          [id, title, priority]
+        )
       } else {
-        return dbClient.query(`UPDATE ${issuesTableSql} SET title = $2 WHERE id = $1`, [
-          id,
-          title,
-        ])
+        return dbClient.query(
+          `UPDATE ${issuesTableSql} SET title = $2 WHERE id = $1`,
+          [id, title]
+        )
       }
     }),
   deleteIssue: ({ issuesTableSql, dbClient }, use) =>

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -255,6 +255,7 @@ export interface ShapeStreamInterface<T extends Row<unknown> = Row> {
   lastSyncedAt(): number | undefined
   lastSynced(): number
   isConnected(): boolean
+  hasStarted(): boolean
 
   isUpToDate: boolean
   lastOffset: Offset
@@ -616,6 +617,10 @@ export class ShapeStream<T extends Row<unknown> = Row>
   /** True during initial fetch. False afterwise.  */
   isLoading(): boolean {
     return !this.#isUpToDate
+  }
+
+  hasStarted(): boolean {
+    return this.#started
   }
 
   /** Await the next tick of the request loop */

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -427,8 +427,10 @@ export class ShapeStream<T extends Row<unknown> = Row>
         // Add Electric's internal parameters
         fetchUrl.searchParams.set(OFFSET_QUERY_PARAM, this.#lastOffset)
 
-        if (this.#isUpToDate && !this.#isRefreshing) {
-          fetchUrl.searchParams.set(LIVE_QUERY_PARAM, `true`)
+        if (this.#isUpToDate) {
+          if (!this.#isRefreshing) {
+            fetchUrl.searchParams.set(LIVE_QUERY_PARAM, `true`)
+          }
           fetchUrl.searchParams.set(
             LIVE_CACHE_BUSTER_QUERY_PARAM,
             this.#liveCacheBuster

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1181,15 +1181,14 @@ importers:
   packages/elixir-client: {}
 
   packages/experimental:
-    dependencies:
-      '@electric-sql/client':
-        specifier: workspace:*
-        version: link:../typescript-client
     optionalDependencies:
       '@rollup/rollup-darwin-arm64':
         specifier: ^4.18.1
         version: 4.24.4
     devDependencies:
+      '@electric-sql/client':
+        specifier: workspace:*
+        version: link:../typescript-client
       '@types/pg':
         specifier: ^8.11.6
         version: 8.11.10


### PR DESCRIPTION
This adds two new APIs to the @electric-sql/experimental package:

## `MultiShapeStream`

A multi-shape stream is a stream that can subscribe to multiple shapes. It ensures that all shapes will receive at least an `up-to-date` message from Electric within the `checkForUpdatesAfter` interval.

The emitted messages have an additional `shape` prop that is the name of the shape provided in the shapes object when constructing the `MultiShapeStream`.

```ts
const multiShapeStream = new MultiShapeStream({
  shapes: {
    shape1: {
      url: 'http://localhost:3000/v1/shape1',
    },
    shape2: {
      url: 'http://localhost:3000/v1/shape2',
    },
  },
})

multiShapeStream.subscribe((msgs) => {
  console.log(msgs)
})

// or with ShapeStream instances
const multiShapeStream = new MultiShapeStream({
  shapes: {
    shape1: new ShapeStream({ url: 'http://localhost:3000/v1/shape1' }),
    shape2: new ShapeStream({ url: 'http://localhost:3000/v1/shape2' }),
  },
})
```

## `TransactionalMultiShapeStream`

A transactional multi-shape stream is a multi-shape stream that emits the messages in transactional batches.
It uses the `lsn` metadata to infer transaction boundaries, and the `op_position` metadata to sort the messages within a transaction.

Note that you will only receive change massages on the main subscription (in transactional batches), and not any control massages.

```ts
const transactionalMultiShapeStream = new TransactionalMultiShapeStream({
  shapes: {
    shape1: {
      url: 'http://localhost:3000/v1/shape1',
    },
    shape2: {
      url: 'http://localhost:3000/v1/shape2',
    },
  },
})

transactionalMultiShapeStream.subscribe((msgs) => {
  console.log(msgs)
})

// or with ShapeStream instances
const transactionalMultiShapeStream = new TransactionalMultiShapeStream({
  shapes: {
    shape1: new ShapeStream({ url: 'http://localhost:3000/v1/shape1' }),
    shape2: new ShapeStream({ url: 'http://localhost:3000/v1/shape2' }),
  },
})
```
