### PR TITLE
feat(sync-service): index for array contains

### DIFF
--- a/.changeset/mean-lies-kiss.md
+++ b/.changeset/mean-lies-kiss.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Allow multiple conditions in a where clause to be optimised (not just one)

--- a/.changeset/twelve-jeans-admire.md
+++ b/.changeset/twelve-jeans-admire.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Optimise where clauses that have a condition in the form 'array_field @> array_const'

--- a/packages/sync-service/lib/electric/shapes/filter.ex
+++ b/packages/sync-service/lib/electric/shapes/filter.ex
@@ -45,9 +45,9 @@ defmodule Electric.Shapes.Filter do
         Map.update(
           tables,
           shape.root_table,
-          WhereCondition.add_shape(WhereCondition.new(), {shape_id, shape}),
+          WhereCondition.add_shape(WhereCondition.new(), {shape_id, shape}, shape.where),
           fn condition ->
-            WhereCondition.add_shape(condition, {shape_id, shape})
+            WhereCondition.add_shape(condition, {shape_id, shape}, shape.where)
           end
         )
     }

--- a/packages/sync-service/lib/electric/shapes/filter/index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/index.ex
@@ -5,9 +5,10 @@ defmodule Electric.Shapes.Filter.Index do
   Each type of operation that has been optimised such as `=` or `@>` will have it's own index module that implements the `Protocol` for this module.
   """
   alias Electric.Shapes.Filter.Index.Protocol
-  alias Electric.Shapes.Filter.Indexes.EqualityIndex
+  alias Electric.Shapes.Filter.Indexes
 
-  def new("=", type), do: EqualityIndex.new(type)
+  def new("=", type), do: Indexes.EqualityIndex.new(type)
+  def new("@>", type), do: Indexes.InclusionIndex.new(type)
 
   defdelegate empty?(index), to: Protocol
   defdelegate add_shape(index, value, shape_instance, and_where), to: Protocol

--- a/packages/sync-service/lib/electric/shapes/filter/index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/index.ex
@@ -1,82 +1,25 @@
 defmodule Electric.Shapes.Filter.Index do
   @moduledoc """
-  Responsible for knowing which shapes are affected by a change to a specific field.
+  Efficiently finds shapes that are affected by a change, specifically for a particular operation in where clause.
 
-  The `%Table{}` struct contains `values` a map of values for a specific field to shapes that are affected by that field value.
-  This acts as an index for the shapes, providing a fast way to know which shapes have been affected without having to
-  iterate over all the shapes.
-
-  Currently only `=` operations are indexed.
+  Each type of operation that has been optimised such as `=` or `@>` will have it's own index module that implements the `Protocol` for this module.
   """
+  alias Electric.Shapes.Filter.Index.Protocol
+  alias Electric.Shapes.Filter.Indexes.EqualityIndex
 
-  alias Electric.Replication.Eval.Env
-  alias Electric.Shapes.Filter.Index
-  alias Electric.Shapes.Filter.WhereCondition
-  alias Electric.Telemetry.OpenTelemetry
-  require Logger
+  def new("=", type), do: EqualityIndex.new(type)
 
-  defstruct [:type, :values]
+  defdelegate empty?(index), to: Protocol
+  defdelegate add_shape(index, value, shape_instance, and_where), to: Protocol
+  defdelegate remove_shape(index, shape_id), to: Protocol
+  defdelegate affected_shapes(index, field, record), to: Protocol
+  defdelegate all_shapes(index), to: Protocol
+end
 
-  def new(type), do: %Index{type: type, values: %{}}
-
-  def empty?(%Index{values: values}), do: values == %{}
-
-  def add_shape(%Index{} = index, value, {shape_id, shape}, and_where) do
-    %{
-      index
-      | values:
-          Map.update(
-            index.values,
-            value,
-            WhereCondition.add_shape(WhereCondition.new(), {shape_id, shape}, and_where),
-            fn condition ->
-              WhereCondition.add_shape(condition, {shape_id, shape}, and_where)
-            end
-          )
-    }
-  end
-
-  def remove_shape(%Index{} = index, shape_id) do
-    %{
-      index
-      | values:
-          index.values
-          |> Map.new(fn {value, condition} ->
-            {value, WhereCondition.remove_shape(condition, shape_id)}
-          end)
-          |> Enum.reject(fn {_table, condition} -> WhereCondition.empty?(condition) end)
-          |> Map.new()
-    }
-  end
-
-  def affected_shapes(%Index{values: values, type: type}, field, record) do
-    case Map.get(values, value_from_record(record, field, type)) do
-      nil ->
-        MapSet.new()
-
-      condition ->
-        OpenTelemetry.add_span_attributes(field: field)
-        WhereCondition.affected_shapes(condition, record)
-    end
-  end
-
-  @env Env.new()
-  defp value_from_record(record, field, type) do
-    case Env.parse_const(@env, record[field], type) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        raise RuntimeError,
-          message: "Could not parse value for field #{inspect(field)} of type #{inspect(type)}"
-    end
-  end
-
-  def all_shapes(%Index{values: values}) do
-    for {_value, condition} <- values,
-        {shape_id, shape} <- WhereCondition.all_shapes(condition),
-        into: %{} do
-      {shape_id, shape}
-    end
-  end
+defprotocol Electric.Shapes.Filter.Index.Protocol do
+  def empty?(index)
+  def add_shape(index, value, shape_instance, and_where)
+  def remove_shape(index, shape_id)
+  def affected_shapes(index, field, record)
+  def all_shapes(index)
 end

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/equality_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/equality_index.ex
@@ -11,7 +11,6 @@ defmodule Electric.Shapes.Filter.Indexes.EqualityIndex do
   alias Electric.Shapes.Filter.Index
   alias Electric.Shapes.Filter.Indexes.EqualityIndex
   alias Electric.Shapes.Filter.WhereCondition
-  alias Electric.Telemetry.OpenTelemetry
   require Logger
 
   defstruct [:type, :values]
@@ -55,7 +54,6 @@ defmodule Electric.Shapes.Filter.Indexes.EqualityIndex do
           MapSet.new()
 
         condition ->
-          OpenTelemetry.add_span_attributes(field: field)
           WhereCondition.affected_shapes(condition, record)
       end
     end

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/equality_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/equality_index.ex
@@ -1,0 +1,83 @@
+defmodule Electric.Shapes.Filter.Indexes.EqualityIndex do
+  @moduledoc """
+  Efficiently finds shapes that are affected by a change when the shape's where clause has `field = const` in it.
+
+  The index maps the values to the shapes that have that value as it's const in the `field = const` condition.
+
+  Rather than directly adding shapes, shapes are added to a `%WhereCondition{}` which represents can contain multiple
+  shapes and allows for further optimisations of other conditions in the shape's where clause.
+  """
+  alias Electric.Replication.Eval.Env
+  alias Electric.Shapes.Filter.Index
+  alias Electric.Shapes.Filter.Indexes.EqualityIndex
+  alias Electric.Shapes.Filter.WhereCondition
+  alias Electric.Telemetry.OpenTelemetry
+  require Logger
+
+  defstruct [:type, :values]
+
+  def new(type), do: %EqualityIndex{type: type, values: %{}}
+
+  defimpl Index.Protocol, for: EqualityIndex do
+    def empty?(%EqualityIndex{values: values}), do: values == %{}
+
+    def add_shape(%EqualityIndex{} = index, value, {shape_id, shape}, and_where) do
+      %{
+        index
+        | values:
+            Map.update(
+              index.values,
+              value,
+              WhereCondition.add_shape(WhereCondition.new(), {shape_id, shape}, and_where),
+              fn condition ->
+                WhereCondition.add_shape(condition, {shape_id, shape}, and_where)
+              end
+            )
+      }
+    end
+
+    def remove_shape(%EqualityIndex{} = index, shape_id) do
+      %{
+        index
+        | values:
+            index.values
+            |> Map.new(fn {value, condition} ->
+              {value, WhereCondition.remove_shape(condition, shape_id)}
+            end)
+            |> Enum.reject(fn {_table, condition} -> WhereCondition.empty?(condition) end)
+            |> Map.new()
+      }
+    end
+
+    def affected_shapes(%EqualityIndex{values: values, type: type}, field, record) do
+      case Map.get(values, value_from_record(record, field, type)) do
+        nil ->
+          MapSet.new()
+
+        condition ->
+          OpenTelemetry.add_span_attributes(field: field)
+          WhereCondition.affected_shapes(condition, record)
+      end
+    end
+
+    @env Env.new()
+    defp value_from_record(record, field, type) do
+      case Env.parse_const(@env, record[field], type) do
+        {:ok, value} ->
+          value
+
+        :error ->
+          raise RuntimeError,
+            message: "Could not parse value for field #{inspect(field)} of type #{inspect(type)}"
+      end
+    end
+
+    def all_shapes(%EqualityIndex{values: values}) do
+      for {_value, condition} <- values,
+          {shape_id, shape} <- WhereCondition.all_shapes(condition),
+          into: %{} do
+        {shape_id, shape}
+      end
+    end
+  end
+end

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/equality_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/equality_index.ex
@@ -21,31 +21,20 @@ defmodule Electric.Shapes.Filter.Indexes.EqualityIndex do
     def empty?(%EqualityIndex{values: values}), do: values == %{}
 
     def add_shape(%EqualityIndex{} = index, value, {shape_id, shape}, and_where) do
-      %{
-        index
-        | values:
-            Map.update(
-              index.values,
-              value,
-              WhereCondition.add_shape(WhereCondition.new(), {shape_id, shape}, and_where),
-              fn condition ->
-                WhereCondition.add_shape(condition, {shape_id, shape}, and_where)
-              end
-            )
-      }
+      index.values
+      |> Map.put_new(value, WhereCondition.new())
+      |> Map.update!(value, &WhereCondition.add_shape(&1, {shape_id, shape}, and_where))
+      |> then(&%{index | values: &1})
     end
 
     def remove_shape(%EqualityIndex{} = index, shape_id) do
-      %{
-        index
-        | values:
-            index.values
-            |> Map.new(fn {value, condition} ->
-              {value, WhereCondition.remove_shape(condition, shape_id)}
-            end)
-            |> Enum.reject(fn {_table, condition} -> WhereCondition.empty?(condition) end)
-            |> Map.new()
-      }
+      index.values
+      |> Enum.map(fn {value, condition} ->
+        {value, WhereCondition.remove_shape(condition, shape_id)}
+      end)
+      |> Enum.reject(fn {_table, condition} -> WhereCondition.empty?(condition) end)
+      |> Map.new()
+      |> then(&%{index | values: &1})
     end
 
     def affected_shapes(%EqualityIndex{values: values, type: type}, field, record) do

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/inclusion_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/inclusion_index.ex
@@ -1,0 +1,206 @@
+defmodule Electric.Shapes.Filter.Indexes.InclusionIndex do
+  @moduledoc """
+  Efficiently finds shapes that are affected by a change when the shape's where clause has `array_field @> const_array` in it.
+
+  The index is a tree. Each node in the tree represents a value in the array.
+
+  When adding a shape to the tree, the shape's array is sorted and deduplicated, then first value is used to find the child node of the root node.
+  The child to that node is then found using the next value and so on. When there are no values left, the shape is then added to the last node.
+  Adding the shape to the last node is done by adding the shape the node's `WhereCondition` which represents the rest of the where
+  clause of the shape (the `@>` comparison may be only part of the where clause) and can also contain many shapes.
+
+  To find the shapes affected by a change, the values of the array in the change are sorted and deduplicated. The tree is then traversed using the values
+  and any nodes that contain shapes on the way are added to the result set, because if the node has been reached the shape's array must be a subset of the change's array.
+
+  A futher optimisation is we keep a sorted list of keys of the children in each node. In `shapes_affected_by_children/3` we have to check the values against the keys.
+  We may have more keys or more values, keeping this sorted list of keys allows up to only do min(key_count, value_count) comparisons for the node.
+  """
+  alias Electric.Replication.Eval.Env
+  alias Electric.Shapes.Filter.Index
+  alias Electric.Shapes.Filter.Indexes.InclusionIndex
+  alias Electric.Shapes.Filter.WhereCondition
+  require Logger
+
+  empty_node = %{keys: []}
+  @empty_node empty_node
+
+  defstruct [:type, :value_tree]
+
+  def new(type), do: %InclusionIndex{type: type, value_tree: @empty_node}
+
+  defimpl Index.Protocol, for: InclusionIndex do
+    @empty_node empty_node
+
+    def empty?(%InclusionIndex{value_tree: value_tree}), do: node_empty?(value_tree)
+
+    def add_shape(%InclusionIndex{} = index, array, {shape_id, shape}, and_where) do
+      ordered = array |> Enum.sort() |> Enum.dedup()
+
+      %{
+        index
+        | value_tree:
+            add_shape_to_node(index.value_tree, ordered, %{
+              shape_id: shape_id,
+              shape: shape,
+              and_where: and_where
+            })
+      }
+    end
+
+    defp add_shape_to_node(node, [value | values], shape_info) do
+      # There are still array values left so don't add the shape to this node, add it a child or descendent node instead
+      case Map.get(node, value) do
+        nil ->
+          # child for the value does not exist so create one
+          child =
+            @empty_node
+            # add the shape to the child with the remaining values
+            |> add_shape_to_node(values, shape_info)
+
+          node
+          |> Map.put(value, child)
+          # Also add to the sorted list of keys
+          # This helps to make `shapes_affected_by_children/3` more efficient
+          |> Map.put(:keys, Enum.sort([value | node.keys]))
+
+        child ->
+          # Child for the value exists so add the shape to it with the remaining values
+          node
+          |> Map.put(value, add_shape_to_node(child, values, shape_info))
+      end
+    end
+
+    defp add_shape_to_node(node, [] = _values, shape_info) do
+      # There are no more arry values left so add the shape to the node
+      Map.put(
+        node,
+        :condition,
+        WhereCondition.add_shape(
+          node[:condition] || WhereCondition.new(),
+          {shape_info.shape_id, shape_info.shape},
+          shape_info.and_where
+        )
+      )
+    end
+
+    def remove_shape(%InclusionIndex{} = index, shape_id) do
+      %{index | value_tree: remove_shape_from_tree(index.value_tree, shape_id)}
+    end
+
+    defp remove_shape_from_tree(node, shape_id) do
+      node
+      |> remove_shape_from_node(shape_id)
+      |> remove_shape_from_children(shape_id)
+    end
+
+    defp remove_shape_from_node(%{condition: condition} = node, shape_id) do
+      condition = WhereCondition.remove_shape(condition, shape_id)
+
+      if condition == WhereCondition.new() do
+        Map.delete(node, :condition)
+      else
+        %{node | condition: condition}
+      end
+    end
+
+    defp remove_shape_from_node(node, _shape_id), do: node
+
+    defp remove_shape_from_children(node, shape_id) do
+      Enum.reduce(node.keys, node, fn key, node ->
+        child = remove_shape_from_tree(node[key], shape_id)
+
+        if node_empty?(child) do
+          node
+          |> Map.delete(key)
+          |> Map.put(:keys, List.delete(node.keys, key))
+        else
+          Map.put(node, key, child)
+        end
+      end)
+    end
+
+    defp node_empty?(%{condition: _}), do: false
+    defp node_empty?(%{keys: []}), do: true
+    defp node_empty?(_), do: false
+
+    def affected_shapes(%InclusionIndex{} = index, field, record) do
+      values =
+        record
+        |> value_from_record(field, index.type)
+        |> Enum.sort()
+        |> Enum.dedup()
+
+      shapes_affected_by_tree(index.value_tree, values, record) || MapSet.new()
+    end
+
+    defp shapes_affected_by_tree(node, values, record) do
+      union(
+        shapes_affected_by_node(node, record),
+        shapes_affected_by_children(node, values, record)
+      )
+    end
+
+    defp shapes_affected_by_node(%{condition: condition}, record) do
+      WhereCondition.affected_shapes(condition, record)
+    end
+
+    defp shapes_affected_by_node(_, _), do: nil
+
+    defp shapes_affected_by_children(%{keys: [value | keys]} = node, [value | values], record) do
+      # key matches value, so add the child then continue with the rest of the values
+      union(
+        shapes_affected_by_tree(node[value], values, record),
+        shapes_affected_by_children(%{node | keys: keys}, values, record)
+      )
+    end
+
+    defp shapes_affected_by_children(%{keys: [key | keys]} = node, [value | _] = values, record)
+         when key < value do
+      # key can be discarded as it's not in the list of values
+      shapes_affected_by_children(%{node | keys: keys}, values, record)
+    end
+
+    defp shapes_affected_by_children(node, [_value | values], record) do
+      # value can be discarded as it's not in the list of keys
+      shapes_affected_by_children(node, values, record)
+    end
+
+    defp shapes_affected_by_children(%{keys: []}, _values, _record) do
+      # No more keys to process, so no more shapes to find
+      nil
+    end
+
+    defp shapes_affected_by_children(%{keys: _keys}, [], _record) do
+      # No more values to process, so no more shapes to find
+      nil
+    end
+
+    @env Env.new()
+    defp value_from_record(record, field, type) do
+      case Env.parse_const(@env, record[field], type) do
+        {:ok, value} ->
+          value
+
+        :error ->
+          raise RuntimeError,
+            message: "Could not parse value for field #{inspect(field)} of type #{inspect(type)}"
+      end
+    end
+
+    def all_shapes(%InclusionIndex{}) do
+      # for {_value, condition} <- values,
+      #     {shape_id, shape} <- WhereCondition.all_shapes(condition),
+      #     into: %{} do
+      #   {shape_id, shape}
+      # end
+    end
+
+    # Union two sets, treating `nil` as an empty set.
+    # This allows us to use `nil` rather than `MapSet.new()`
+    # and avoid many calls to `MapSet.union/2` which
+    # makes `affected_shapes/3` ~20% faster.
+    defp union(nil, set), do: set
+    defp union(set, nil), do: set
+    defp union(set1, set2), do: MapSet.union(set1, set2)
+  end
+end

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/inclusion_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/inclusion_index.ex
@@ -187,12 +187,19 @@ defmodule Electric.Shapes.Filter.Indexes.InclusionIndex do
       end
     end
 
-    def all_shapes(%InclusionIndex{}) do
-      # for {_value, condition} <- values,
-      #     {shape_id, shape} <- WhereCondition.all_shapes(condition),
-      #     into: %{} do
-      #   {shape_id, shape}
-      # end
+    def all_shapes(%InclusionIndex{value_tree: value_tree}), do: all_shapes_in_tree(value_tree)
+
+    defp all_shapes_in_tree(node) do
+      Map.merge(all_shapes_in_node(node), all_shapes_in_children(node))
+    end
+
+    defp all_shapes_in_node(%{condition: condition}), do: WhereCondition.all_shapes(condition)
+    defp all_shapes_in_node(_), do: %{}
+
+    defp all_shapes_in_children(node) do
+      Enum.reduce(node.keys, %{}, fn key, shapes ->
+        Map.merge(shapes, all_shapes_in_tree(node[key]))
+      end)
     end
 
     # Union two sets, treating `nil` as an empty set.

--- a/packages/sync-service/lib/electric/shapes/filter/table.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/table.ex
@@ -19,9 +19,9 @@ defmodule Electric.Shapes.Filter.Table do
 
   require Logger
 
-  defstruct name: nil, indexes: %{}, other_shapes: %{}
+  defstruct indexes: %{}, other_shapes: %{}
 
-  def new({schema, table}), do: %Table{name: "#{schema}.#{table}"}
+  def new(), do: %Table{}
 
   def empty?(%Table{indexes: indexes, other_shapes: other_shapes}) do
     indexes == %{} && other_shapes == %{}
@@ -130,7 +130,7 @@ defmodule Electric.Shapes.Filter.Table do
   defp indexed_shapes_affected(table, record) do
     OpenTelemetry.with_span(
       "filter.filter_using_indexes",
-      [table: table.name, index_count: map_size(table.indexes)],
+      [index_count: map_size(table.indexes)],
       fn ->
         table.indexes
         |> Enum.map(fn {field, index} -> Index.affected_shapes(index, field, record) end)
@@ -142,7 +142,7 @@ defmodule Electric.Shapes.Filter.Table do
   defp other_shapes_affected(table, record) do
     OpenTelemetry.with_span(
       "filter.filter_other_shapes",
-      [table: table.name, shape_count: map_size(table.other_shapes)],
+      [shape_count: map_size(table.other_shapes)],
       fn ->
         for {shape_id, shape} <- table.other_shapes,
             WhereClause.includes_record?(shape.where, record),

--- a/packages/sync-service/lib/electric/shapes/filter/where_condition.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/where_condition.ex
@@ -80,6 +80,22 @@ defmodule Electric.Shapes.Filter.WhereCondition do
     %{operation: "=", field: field, type: type, value: value, and_where: nil}
   end
 
+  defp optimise_where(%Func{
+         name: ~s("@>"),
+         args: [%Ref{path: [field], type: type}, %Const{value: value}]
+       })
+       when is_list(value) do
+    %{operation: "@>", field: field, type: type, value: value, and_where: nil}
+  end
+
+  defp optimise_where(%Func{
+         name: ~s("<@"),
+         args: [%Const{value: value}, %Ref{path: [field], type: type}]
+       })
+       when is_list(value) do
+    %{operation: "@>", field: field, type: type, value: value, and_where: nil}
+  end
+
   defp optimise_where(%Func{name: "and", args: [arg1, arg2]}) do
     case {optimise_where(arg1), optimise_where(arg2)} do
       {%{operation: "=", and_where: nil} = params, _} ->

--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -123,7 +123,7 @@ defmodule Electric.MixProject do
       {:excoveralls, "~> 0.18", only: [:test], runtime: false},
       {:mox, "~> 1.1", only: [:test]},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:stream_data, "~> 1.0", only: [:test]}
+      {:stream_data, "~> 1.0", only: [:dev, :test]}
     ]
   end
 

--- a/packages/sync-service/test/electric/shapes/filter_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter_test.exs
@@ -92,14 +92,19 @@ defmodule Electric.Shapes.FilterTest do
         |> Filter.add_shape("s2", Shape.new!("t1", where: "id = 2", inspector: @inspector))
         |> Filter.add_shape("s3", Shape.new!("t1", where: "id > 7", inspector: @inspector))
         |> Filter.add_shape("s4", Shape.new!("t1", where: "id > 8", inspector: @inspector))
-        |> Filter.add_shape("s5", Shape.new!("t2", where: "id = 1", inspector: @inspector))
-        |> Filter.add_shape("s6", Shape.new!("t2", where: "id = 2", inspector: @inspector))
-        |> Filter.add_shape("s7", Shape.new!("t2", where: "id > 7", inspector: @inspector))
-        |> Filter.add_shape("s8", Shape.new!("t2", where: "id > 8", inspector: @inspector))
+        |> Filter.add_shape(
+          "s5",
+          Shape.new!("t1", where: "an_array @> '{1,2}'", inspector: @inspector)
+        )
+        |> Filter.add_shape("s6", Shape.new!("t2", where: "id = 1", inspector: @inspector))
+        |> Filter.add_shape("s7", Shape.new!("t2", where: "id = 2", inspector: @inspector))
+        |> Filter.add_shape("s8", Shape.new!("t2", where: "id > 7", inspector: @inspector))
+        |> Filter.add_shape("s9", Shape.new!("t2", where: "id > 8", inspector: @inspector))
 
       relation = %Relation{schema: "public", table: "t1"}
 
-      assert Filter.affected_shapes(filter, relation) == MapSet.new(["s1", "s2", "s3", "s4"])
+      assert Filter.affected_shapes(filter, relation) ==
+               MapSet.new(["s1", "s2", "s3", "s4", "s5"])
     end
 
     test "returns shapes affected by relation rename" do

--- a/packages/sync-service/test/electric/shapes/filter_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter_test.exs
@@ -195,6 +195,15 @@ defmodule Electric.Shapes.FilterTest do
         end)
         |> Enum.take(shape_count)
 
+      where_clause = fn shape_array ->
+        # Randomly choose between `@>` and `<@` to test both forms
+        if Enum.random(0..1) == 0 do
+          "an_array @> '{#{Enum.join(shape_array, ",")}}'"
+        else
+          "'{#{Enum.join(shape_array, ",")}}' <@ an_array"
+        end
+      end
+
       filter =
         shape_arrays
         |> Enum.reduce(Filter.new(), fn shape_array, filter ->
@@ -202,7 +211,7 @@ defmodule Electric.Shapes.FilterTest do
             filter,
             shape_array,
             Shape.new!("t1",
-              where: "an_array @> '{#{Enum.join(shape_array, ",")}}'",
+              where: where_clause.(shape_array),
               inspector: @inspector
             )
           )

--- a/packages/sync-service/test/electric/shapes/filter_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter_test.exs
@@ -416,8 +416,8 @@ defmodule Electric.Shapes.FilterTest do
       # The optimisation for `@>` is less performant than the other optimisations,
       # however it performs well with lots of shapes. While it can't do
       # `@shape_count` shapes in < `@max_reductions` reductions, it can do
-      # `@shape_count * 4` shapes in < `@max_reductions * 4` reductions.
-      multiplier = 4
+      # `@shape_count * 5` shapes in < `@max_reductions * 5` reductions.
+      multiplier = 5
       shape_count = @shape_count * multiplier
       max_reductions = @max_reductions * multiplier
 


### PR DESCRIPTION
This PR seeks to address trigger.dev's WAL lag issues by adding two optimisations to where clause filtering:
- Allow multiple conditions in a where clause to be optimised (not just one)
- Optimise where clauses that have a condition in the form 'array_field @> array_const'

## Allow multiple conditions in a where clause to be optimised (not just one)

This feature alone should halve the processing time for trigger.dev as they have many where clauses in the form `WHERE runtimeEnvironmentId = ? AND batchId = ?` where if a change matched the `runtimeEnvironmentId` it would then have to iterate through the `batchId`s. Now it doesn't - the `batchId` condition is indexed as well.

## Optimise where clauses that have a condition in the form 'array_field @> array_const'

Trigger.dev's other problematic where clauses are in the form `WHERE runtimeEnvironmentId = ? AND runTags @> ?` and this feature optimises the `@>` operation. The algorithm for this optimisation can be seen in the [InclusionIndex module](https://github.com/electric-sql/electric/pull/2359/files#diff-44c9f3ec68658f9ea6690a7608b99ad0463d7dcc8f1c95e9a2617e1d3d30a3d2).

Comparing the performance of this index against the current method shows quite a dramatic difference:
<img width="707" alt="Screenshot 2025-02-19 at 19 42 59" src="https://github.com/user-attachments/assets/ea9de81c-50e7-45d1-a81f-d5a21c36daeb" />

Here you can see it performs well with 100k shapes (which for trigger.dev would be 100k shapes with the same `runtimeEnvironmentId`, in other words 100k shapes per user)
<img width="692" alt="Screenshot 2025-02-19 at 19 43 47" src="https://github.com/user-attachments/assets/e2fde600-6c0f-4606-ac93-18daa8e50438" />

Both of the charts above are based on a shape array size of 3 and a change array size of 10 which is typical for trigger.dev.

The algorithm seems to scale roughly linearly with change array size:
<img width="714" alt="Screenshot 2025-02-24 at 16 12 34" src="https://github.com/user-attachments/assets/ce1703c1-9eea-4d19-bc44-8c92615f8da4" />

The algorithm seems to scale well with shape array size for a fixed change array size (10):
<img width="714" alt="Screenshot 2025-02-24 at 16 14 35" src="https://github.com/user-attachments/assets/fcd6f956-8c01-4580-8e55-4b0eeb17e86f" />
