### PR TITLE
fix(typescript-client): Replace the `while(true)` in createFetchWithBackoff with a run closure + setTimeout

### DIFF
--- a/.changeset/six-apes-push.md
+++ b/.changeset/six-apes-push.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Fix an issue on iOS where a shape would silently stop updating if the tab was moved into the background then back into the foreground. #2364


### PR DESCRIPTION
This replaces the `while (true)` with an explicit call to a `run` closure. It *should* fix the issue seeing in #2364 but will **probably need testing on an actual iOS device** to try and replicate.

iOS Safari tabs goes into a kind of hibernated mode when they are in the background. This throttles `setTimeout`s, and appears to cancel the `while (true)` task. By replacing the `while (true)` with an explicit call to a `run` closure in a `setTimeout` I'm hopeful we just see the next tick of the recursive timeout be throttled, paused and then restarted when the tab come back to the foreground.