### PR TITLE
feat: Fallback to include whole table in replication if where clauses unsupported

### DIFF
--- a/.changeset/lazy-cameras-clap.md
+++ b/.changeset/lazy-cameras-clap.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fallback to replicating whole relations if publication row filtering cannot support given where clauses.

--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -294,28 +294,44 @@ defmodule Electric.Postgres.ConfigurationTest do
 
     test "fails with invalid where clause error when unsupported clause provided",
          %{pool: conn, publication_name: publication, pg_version: pg_version} do
-      error =
-        assert_raise Postgrex.Error, fn ->
-          Configuration.configure_tables_for_replication!(
-            conn,
-            %{
-              {"public", "items"} => %RelationFilter{
-                relation: {"public", "items"},
-                where_clauses: [%Eval.Expr{query: "(value_c in ('a','b'))"}]
-              }
-            },
-            pg_version,
-            publication
-          )
-        end
+      if pg_version >= @pg_15 do
+        error =
+          assert_raise Postgrex.Error, fn ->
+            Configuration.configure_tables_for_replication!(
+              conn,
+              %{
+                {"public", "items"} => %RelationFilter{
+                  relation: {"public", "items"},
+                  where_clauses: [%Eval.Expr{query: "(value_c in ('a','b'))"}]
+                }
+              },
+              pg_version,
+              publication
+            )
+          end
 
-      assert %Postgrex.Error{
-               postgres: %{
-                 code: :feature_not_supported,
-                 detail:
-                   "Only columns, constants, built-in operators, built-in data types, built-in collations, and immutable built-in functions are allowed."
-               }
-             } = error
+        assert %Postgrex.Error{
+                 postgres: %{
+                   code: :feature_not_supported,
+                   detail:
+                     "Only columns, constants, built-in operators, built-in data types, built-in collations, and immutable built-in functions are allowed."
+                 }
+               } = error
+      else
+        # pg versions without row filtering should just accept this
+        assert _ =
+                 Configuration.configure_tables_for_replication!(
+                   conn,
+                   %{
+                     {"public", "items"} => %RelationFilter{
+                       relation: {"public", "items"},
+                       where_clauses: [%Eval.Expr{query: "(value_c in ('a','b'))"}]
+                     }
+                   },
+                   pg_version,
+                   publication
+                 )
+      end
     end
 
     test "fails when a publication doesn't exist", %{pool: conn, pg_version: pg_version} do


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/2360

This will make the running Electric fallback to replicating whole tables if it receives any shapes with unsupported where clauses (e.g. enums, varchar with `IN` checks, user-defined data types in general, and who knows what else).

There is no "recovery" mechanism to return to row-filtering as the Postgres error does not allow for an easy way to check which where clause caused the issue - once we go to relation-only filtering we stay there, like we would if an active shape had no where clause or if we were in PG14.

Ideally we would detect where clauses that are unsupported at the relation filter processing level, so we can fine tune that, but until then this fallback makes sure that Electric works even if an unsupported where clause is provided.

As discussed in [this Discord thread](https://discord.com/channels/933657521581858818/1341967559758581921), we could also have a configuration flag and better errors to avoid this sort of radical fallback, but we opted for an "always works" approach here. IIRC some benchmarking had shown that our filtering is fast enough that the PG level filtering might not be as important anyway, although the limiting of transmitted data is definitely nice (despite several issues we have with not being able to limit columns replicated etc).

This is related with https://github.com/electric-sql/electric/issues/1778 , and I'm also referencing https://github.com/electric-sql/electric/issues/1831 as we had encountered many limitations to row filtering which has led to this proposed change.

We can definitely improve this by detecting unsupported where clauses, checking filter diffs to know what caused the issue and reverting back after, periodically attempting to revert back to row-filtering, and an array of different approaches, but this allows all where clauses to be accepted and Electric to adjust accordingly.