### PR TITLE
sync-service: make configuration easier and more accessible 

### DIFF
--- a/.changeset/brown-plants-count.md
+++ b/.changeset/brown-plants-count.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Make configuration easier and more accessible to external applications

--- a/packages/elixir-client/config/runtime.exs
+++ b/packages/elixir-client/config/runtime.exs
@@ -23,6 +23,7 @@ if config_env() == :test do
     client: Electric.Telemetry.SentryReqHTTPClient
 
   config :electric,
+    start_in_library_mode: false,
     connection_opts: Electric.Utils.obfuscate_password(connection_opts),
     # enable the http api so that the client tests against a real endpoint can
     # run against our embedded electric instance.

--- a/packages/sync-service/config/config.exs
+++ b/packages/sync-service/config/config.exs
@@ -5,3 +5,6 @@ import Config
 config :sentry,
   enable_source_code_context: true,
   root_source_code_paths: [File.cwd!()]
+
+config :electric,
+  start_in_library_mode: false

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -1,73 +1,36 @@
 defmodule Electric.Application do
   use Application
 
-  require Config
-
-  @doc """
-  This callback starts the entire application, but is configured to run only when
-  this app is started on it's own, not as a library. As such, this should be the only
-  place that actually reads from `Application.get_env/2`, because it's the only context
-  where the `config/runtime.exs` is executed.
-  """
   @impl true
   def start(_type, _args) do
-    :erlang.system_flag(:backtrace_depth, 50)
-
-    Electric.Config.ensure_instance_id()
-    Electric.Telemetry.Sentry.add_logger_handler()
-
-    # We have "instance id" identifier as the node ID, however that's generated every runtime,
-    # so isn't stable across restarts. Our storages however scope themselves based on this stack ID
-    # so we're just hardcoding it here.
-    stack_id = Electric.Config.get_env(:provided_database_id)
-
-    storage = Electric.Config.get_env(:storage)
-
-    {kv_module, kv_fun, kv_params} =
-      Electric.Config.get_env(:persistent_kv)
-
-    persistent_kv = apply(kv_module, kv_fun, [kv_params])
-
-    router_opts =
-      Electric.Shapes.Api.plug_opts(
-        [
-          long_poll_timeout: 20_000,
-          max_age: Electric.Config.get_env(:cache_max_age),
-          stale_age: Electric.Config.get_env(:cache_stale_age),
-          allow_shape_deletion: Electric.Config.get_env(:allow_shape_deletion?)
-        ] ++
-          Electric.StackSupervisor.build_shared_opts(
-            stack_id: stack_id,
-            stack_events_registry: Registry.StackEvents,
-            storage: storage,
-            persistent_kv: persistent_kv
-          )
-      )
-
-    replication_stream_id = Electric.Config.get_env(:replication_stream_id)
-    publication_name = "electric_publication_#{replication_stream_id}"
-    slot_name = "electric_slot_#{replication_stream_id}"
-
-    api_server =
-      if Electric.Config.get_env(:enable_http_api) do
-        [
-          {Bandit,
-           plug: {Electric.Plug.Router, router_opts},
-           port: Electric.Config.get_env(:service_port),
-           thousand_island_options: http_listener_options()}
-        ]
+    children =
+      if Application.get_env(:electric, :start_in_library_mode, true) do
+        children_library()
       else
-        []
+        children_application()
       end
 
-    telemetry_opts = [
-      instance_id: Electric.instance_id(),
-      system_metrics_poll_interval: Electric.Config.get_env(:system_metrics_poll_interval),
-      statsd_host: Electric.Config.get_env(:telemetry_statsd_host),
-      prometheus?: not is_nil(Electric.Config.get_env(:prometheus_port)),
-      call_home_telemetry?: Electric.Config.get_env(:call_home_telemetry?),
-      otel_metrics?: not is_nil(Application.get_env(:otel_metric_exporter, :otlp_endpoint))
+    Supervisor.start_link(children, strategy: :one_for_one, name: Electric.Supervisor)
+  end
+
+  def children_library do
+    [
+      {Registry, name: Registry.StackEvents, keys: :duplicate}
     ]
+  end
+
+  # This is only called if :start_in_library_mode is false, which is basically
+  # only for our own Docker image, using the files in `./config`.
+  #
+  # This should be the only place that actually reads from
+  # `Application.get_env/2`, because it's the only context where the
+  # `config/runtime.exs` is executed
+  def children_application do
+    :erlang.system_flag(:backtrace_depth, 50)
+
+    if Code.ensure_loaded?(Electric.Telemetry.Sentry) do
+      Electric.Telemetry.Sentry.add_logger_handler()
+    end
 
     # The root application supervisor starts the core global processes, including the HTTP
     # server and the database connection manager. The latter is responsible for establishing
@@ -79,62 +42,138 @@ defmodule Electric.Application do
     # and individual shape consumer process trees.
     #
     # See the moduledoc in `Electric.Connection.Supervisor` for more info.
-    children =
-      Enum.concat([
-        [
-          {Registry, name: Registry.StackEvents, keys: :duplicate},
-          {
-            Electric.StackSupervisor,
-            stack_id: stack_id,
-            stack_events_registry: Registry.StackEvents,
-            connection_opts: Electric.Config.fetch_env!(:connection_opts),
-            persistent_kv: persistent_kv,
-            replication_opts: [
-              publication_name: publication_name,
-              slot_name: slot_name,
-              slot_temporary?: Electric.Config.get_env(:replication_slot_temporary?)
-            ],
-            pool_opts: [pool_size: Electric.Config.get_env(:db_pool_size)],
-            storage: storage,
-            chunk_bytes_threshold: Electric.Config.get_env(:chunk_bytes_threshold),
-            name: Electric.StackSupervisor,
-            telemetry_opts: telemetry_opts
-          },
-          {Electric.Telemetry.ApplicationTelemetry, telemetry_opts}
-        ],
-        api_server,
-        prometheus_endpoint(Electric.Config.get_env(:prometheus_port))
-      ])
-
-    Supervisor.start_link(children, strategy: :one_for_one, name: Electric.Supervisor)
+    Enum.concat([
+      children_library(),
+      [
+        {Electric.StackSupervisor, Keyword.put(configuration(), :name, Electric.StackSupervisor)}
+      ],
+      application_telemetry(),
+      api_server(),
+      prometheus_endpoint(Electric.Config.get_env(:prometheus_port))
+    ])
   end
 
   @doc """
   Returns a configured Electric.Shapes.Api instance
   """
-  def api(overrides \\ []) do
-    config =
-      Enum.reduce(
-        [
-          Electric.StackSupervisor.build_shared_opts(
-            stack_id: Electric.Config.get_env(:provided_database_id),
-            stack_events_registry: Registry.StackEvents,
-            storage: Electric.Config.get_env(:storage),
-            persistent_kv: Electric.Config.get_env(:persistent_kv)
-          ),
-          [
-            long_poll_timeout: 20_000,
-            max_age: Electric.Config.get_env(:cache_max_age),
-            stale_age: Electric.Config.get_env(:cache_stale_age),
-            allow_shape_deletion: Electric.Config.get_env(:allow_shape_deletion?)
-          ],
-          overrides
-        ],
-        [],
-        &Keyword.merge(&2, &1)
-      )
+  def api(opts \\ []) do
+    opts
+    |> api_configuration()
+    |> Electric.Shapes.Api.configure!()
+  end
 
-    Electric.Shapes.Api.configure!(config)
+  @doc false
+  def api_plug_opts(opts \\ []) do
+    opts
+    |> api_configuration()
+    |> Electric.Shapes.Api.plug_opts()
+  end
+
+  @doc false
+  # Gets a complete configuration for the `StackSupervisor` based on the passed opts
+  # plus the application configuration and the defaults.
+  def configuration(opts \\ []) do
+    Electric.Config.ensure_instance_id()
+
+    replication_stream_id = get_env(opts, :replication_stream_id)
+
+    publication_name =
+      Keyword.get(opts, :publication_name, "electric_publication_#{replication_stream_id}")
+
+    slot_name = Keyword.get(opts, :slot_name, "electric_slot_#{replication_stream_id}")
+
+    telemetry_opts = [
+      instance_id: Electric.instance_id(),
+      system_metrics_poll_interval: Electric.Config.get_env(:system_metrics_poll_interval),
+      statsd_host: Electric.Config.get_env(:telemetry_statsd_host),
+      prometheus?: not is_nil(Electric.Config.get_env(:prometheus_port)),
+      call_home_telemetry?: Electric.Config.get_env(:call_home_telemetry?),
+      otel_metrics?: not is_nil(Application.get_env(:otel_metric_exporter, :otlp_endpoint))
+    ]
+
+    Keyword.merge(
+      core_configuration(opts),
+      connection_opts: get_env!(opts, :connection_opts),
+      replication_opts: [
+        publication_name: publication_name,
+        slot_name: slot_name,
+        slot_temporary?: get_env(opts, :replication_slot_temporary?)
+      ],
+      pool_opts: [pool_size: get_env(opts, :db_pool_size)],
+      chunk_bytes_threshold: get_env(opts, :chunk_bytes_threshold),
+      telemetry_opts: telemetry_opts
+    )
+  end
+
+  # Gets the API-side configuration based on the same opts + application config
+  # used for `configuration/1`
+  defp api_configuration(opts) do
+    Electric.StackSupervisor.build_shared_opts(core_configuration(opts))
+    |> Keyword.merge(
+      long_poll_timeout: get_env(opts, :long_poll_timeout),
+      max_age: get_env(opts, :cache_max_age),
+      stale_age: get_env(opts, :cache_stale_age),
+      allow_shape_deletion: get_env(opts, :allow_shape_deletion?)
+    )
+    |> Keyword.merge(Keyword.take(opts, [:encoder]))
+  end
+
+  defp core_configuration(opts) do
+    # We have "instance id" identifier as the node ID, however that's generated every runtime,
+    # so isn't stable across restarts. Our storages however scope themselves based on this stack ID
+    # so we're just hardcoding it here.
+    stack_id = get_env(opts, :stack_id, :provided_database_id)
+
+    # Use this lazy-eval technique rather than just rely on the Electric.Config.Defaults
+    # system so that a `storage_dir` passed in opts can configure the root path
+    # for both the file storage and persistent kv. This means we can allow the
+    # user to easily set the root path for the electric data without having to
+    # get into the nitty-gritty of full storage and persistent kv
+    # configuration.
+    {kv_module, kv_fun, kv_params} =
+      get_env_lazy(opts, :persistent_kv, fn ->
+        Electric.Config.Defaults.persistent_kv(Keyword.take(opts, [:storage_dir]))
+      end)
+
+    persistent_kv = apply(kv_module, kv_fun, [kv_params])
+
+    storage =
+      get_env_lazy(opts, :storage, fn ->
+        Electric.Config.Defaults.storage(Keyword.take(opts, [:storage_dir]))
+      end)
+
+    [
+      stack_id: stack_id,
+      stack_events_registry: Registry.StackEvents,
+      persistent_kv: persistent_kv,
+      storage: storage
+    ]
+  end
+
+  defp get_env(opts, key) do
+    get_env(opts, key, key)
+  end
+
+  defp get_env(opts, overrides_key, config_key) do
+    Keyword.get_lazy(opts, overrides_key, fn -> Electric.Config.get_env(config_key) end)
+  end
+
+  defp get_env!(opts, key) do
+    Keyword.get_lazy(opts, key, fn ->
+      Electric.Config.fetch_env!(key)
+    end)
+  end
+
+  defp get_env_lazy(opts, key, fun) do
+    Keyword.get_lazy(opts, key, fun)
+  end
+
+  defp application_telemetry do
+    if Code.ensure_loaded?(Electric.Telemetry.ApplicationTelemetry) do
+      [{Electric.Telemetry.ApplicationTelemetry, []}]
+    else
+      []
+    end
   end
 
   defp prometheus_endpoint(nil), do: []
@@ -148,6 +187,21 @@ defmodule Electric.Application do
         thousand_island_options: http_listener_options()
       }
     ]
+  end
+
+  defp api_server do
+    if Electric.Config.get_env(:enable_http_api) do
+      router_opts = api_plug_opts()
+
+      [
+        {Bandit,
+         plug: {Electric.Plug.Router, router_opts},
+         port: Electric.Config.get_env(:service_port),
+         thousand_island_options: http_listener_options()}
+      ]
+    else
+      []
+    end
   end
 
   defp http_listener_options do

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -7,13 +7,15 @@ defmodule Electric.Config.Defaults do
   # functions are used instead.
 
   @doc false
-  def storage do
-    {Electric.ShapeCache.FileStorage, storage_dir: storage_dir("shapes")}
+  def storage(opts \\ []) do
+    storage_dir = Keyword.get_lazy(opts, :storage_dir, fn -> storage_dir("shapes") end)
+    {Electric.ShapeCache.FileStorage, storage_dir: storage_dir}
   end
 
   @doc false
-  def persistent_kv do
-    {Electric.PersistentKV.Filesystem, :new!, root: storage_dir("state")}
+  def persistent_kv(opts \\ []) do
+    storage_dir = Keyword.get_lazy(opts, :storage_dir, fn -> storage_dir("state") end)
+    {Electric.PersistentKV.Filesystem, :new!, root: storage_dir}
   end
 
   defp storage_dir(sub_dir) do
@@ -37,8 +39,9 @@ defmodule Electric.Config do
     replication_stream_id: "default",
     replication_slot_temporary?: false,
     ## HTTP API
-    # set enable_http_api: false to turn of the HTTP server totally
+    # set enable_http_api: false to turn off the HTTP server totally
     enable_http_api: true,
+    long_poll_timeout: 20_000,
     cache_max_age: 60,
     cache_stale_age: 60 * 5,
     chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),

--- a/packages/sync-service/lib/electric/process_registry.ex
+++ b/packages/sync-service/lib/electric/process_registry.ex
@@ -2,7 +2,7 @@ defmodule Electric.ProcessRegistry do
   @spec child_spec([Registry.start_option()]) :: Supervisor.child_spec()
   def child_spec(options) do
     %{
-      id: __MODULE__,
+      id: registry_name(Keyword.fetch!(options, :stack_id)),
       start: {__MODULE__, :start_link, [options]},
       type: :supervisor
     }

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -379,8 +379,12 @@ defmodule Electric.Utils do
   process that implements an OTP behaviour crashes).
   """
   @spec obfuscate_password(Keyword.t()) :: Keyword.t()
-  def obfuscate_password(connection_opts) do
+  def obfuscate_password(connection_opts) when is_list(connection_opts) do
     Keyword.update!(connection_opts, :password, &wrap_in_fun/1)
+  end
+
+  def obfuscate_password(connection_opts) when is_map(connection_opts) do
+    Map.update!(connection_opts, :password, &wrap_in_fun/1)
   end
 
   @doc """
@@ -401,6 +405,7 @@ defmodule Electric.Utils do
   @spec map_values(map(), (term() -> term())) :: map()
   def map_values(map, fun), do: Map.new(map, fn {k, v} -> {k, fun.(v)} end)
 
+  defp wrap_in_fun(val) when is_function(val, 0), do: val
   defp wrap_in_fun(val), do: fn -> val end
 
   @doc """

--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -61,16 +61,9 @@ defmodule Electric.MixProject do
       extra_applications: [:logger, :tls_certificate_check, :os_mon, :runtime_tools],
       # Using a compile-time flag to select the application module or lack thereof allows
       # using this app as a dependency with this additional flag
-      mod:
-        application_mod(Mix.env(), Application.get_env(:electric, :start_in_library_mode, false))
+      mod: {Electric.Application, []}
     ]
   end
-
-  # Empty application module for the test environment because there we skip setting up the root
-  # supervision tree and instead start processes as needed for specific tests.
-  defp application_mod(:test, _), do: []
-  defp application_mod(_, true), do: []
-  defp application_mod(_, _), do: {Electric.Application, []}
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -4,6 +4,4 @@
 # supervision tree in the test environment.
 # Registry.start_link(name: Electric.Application.process_registry(), keys: :unique)
 
-Registry.start_link(name: Registry.StackEvents, keys: :duplicate)
-
 ExUnit.start(assert_receive_timeout: 400)


### PR DESCRIPTION
- remove the requirement to obfuscate db connection passwords in your config. in e.g. dev mode it's common to just have your db creds in config/dev.exs where you don't have access to the functions in electric. so rather than raise in this common scenario, just make the obfuscate_password function idempotent and apply it every time
- make the library mode the default
- add functions to application to get a proper configuration with the possibility of overrides
- make long_poll_timeout configurable because, why not? everything else is....