### PR TITLE
sync-service: improve shapes api encapsulation

### DIFF
--- a/.changeset/seven-guests-appear.md
+++ b/.changeset/seven-guests-appear.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Allow for accessing via an api that serves only a pre-configured shape, move all http logic into api

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -95,7 +95,7 @@ defmodule Electric.Plug.RouterTest do
       assert %{
                "errors" => %{
                  "table" => [
-                   ~s|Table "nonexistent" does not exist. If the table name contains capitals or special characters you must quote it.|
+                   ~s|Table "public"."nonexistent" does not exist. If the table name contains capitals or special characters you must quote it.|
                  ]
                }
              } = Jason.decode!(conn.resp_body)

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -262,7 +262,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert Plug.Conn.get_resp_header(conn, "etag") == [
-               "#{@test_shape_handle}:-1:#{@first_offset}"
+               ~s|"#{@test_shape_handle}:-1:#{@first_offset}"|
              ]
 
       assert Plug.Conn.get_resp_header(conn, "electric-handle") == [@test_shape_handle]
@@ -386,7 +386,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert Plug.Conn.get_resp_header(conn, "etag") == [
-               "#{@test_shape_handle}:#{@start_offset_50}:#{next_next_offset}"
+               ~s|"#{@test_shape_handle}:#{@start_offset_50}:#{next_next_offset}"|
              ]
 
       assert Plug.Conn.get_resp_header(conn, "electric-handle") == [@test_shape_handle]
@@ -767,7 +767,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert Plug.Conn.get_resp_header(conn, "etag") == [
-               "#{test_shape_handle}:-1:#{next_offset}"
+               ~s|"#{test_shape_handle}:-1:#{next_offset}"|
              ]
 
       assert Plug.Conn.get_resp_header(conn, "electric-handle") == [test_shape_handle]

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -290,19 +290,19 @@ defmodule Electric.Shapes.ShapeTest do
     end
 
     test "errors on empty table name", %{inspector: inspector} do
-      {:error, {:table, ["Invalid zero-length delimited identifier"]}} =
-        Shape.new("", inspector: inspector)
+      assert {:error, {:table, ["Invalid zero-length delimited identifier"]}} =
+               Shape.new("", inspector: inspector)
     end
 
     test "errors when the table doesn't exist", %{inspector: inspector} do
-      {:error,
-       {
-         :table,
-         [
-           ~S|Table "nonexistent" does not exist. If the table name contains capitals or special characters you must quote it.|
-         ]
-       }} =
-        Shape.new("nonexistent", inspector: inspector)
+      assert {:error,
+              {
+                :table,
+                [
+                  ~S|Table "public"."nonexistent" does not exist. If the table name contains capitals or special characters you must quote it.|
+                ]
+              }} =
+               Shape.new("nonexistent", inspector: inspector)
     end
 
     @tag with_sql: [


### PR DESCRIPTION
- Api.predefined_shape/2 allows for configuring an endpoint with a pre-defined shape
- All http logic is now encapsulated by the api, including not-modified handling and cache-control headers