### PR TITLE
sync-service: only include telemetry dependencies and processes in application target build

### DIFF
--- a/.changeset/few-trains-kick.md
+++ b/.changeset/few-trains-kick.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Only include telemetry in docker build

--- a/packages/sync-service/Dockerfile
+++ b/packages/sync-service/Dockerfile
@@ -4,18 +4,21 @@ ARG DEBIAN_VERSION=bookworm-20241223-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+ARG MIX_TARGET=application
 
 FROM ${BUILDER_IMAGE} AS builder
 LABEL maintainer="info@electric-sql.com"
 
 RUN apt-get update -y && \
-    apt-get install -y build-essential git curl && \
-    apt-get clean && \
-    rm -f /var/lib/apt/lists/*_*
+  apt-get install -y build-essential git curl && \
+  apt-get clean && \
+  rm -f /var/lib/apt/lists/*_*
 
 RUN mix local.hex --force && mix local.rebar --force
 
-ENV MIX_ENV=prod
+ARG MIX_ENV=prod
+ARG ELECTRIC_VERSION
+ARG MIX_TARGET
 
 WORKDIR /app
 
@@ -30,38 +33,45 @@ COPY lib /app/lib/
 COPY package.json /app/
 COPY config/*.exs /app/config/
 
-ARG ELECTRIC_VERSION
 
 RUN mix compile
 RUN mix sentry.package_source_code
 RUN mix release
 
+RUN ls -l /app/_build
+
 FROM ${RUNNER_IMAGE} AS runner_setup
 
 RUN apt-get update -y && \
-    apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates curl && \
-    apt-get clean && \
-    rm -f /var/lib/apt/lists/*_*
+  apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates curl && \
+  apt-get clean && \
+  rm -f /var/lib/apt/lists/*_*
 
 # Set the locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US:en
-ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+  LANGUAGE=en_US:en \
+  LC_ALL=en_US.UTF-8 \
+  MIX_ENV=prod \
+  MIX_TARGET=application
 
 WORKDIR "/app"
+
 RUN chown nobody /app
 
 FROM runner_setup AS runner
 
+ARG MIX_TARGET
 ARG RELEASE_NAME=electric
-## Vaxine configuration via environment variables
-COPY --from=builder /app/_build/prod/rel/${RELEASE_NAME} ./
-RUN mv /app/bin/${RELEASE_NAME} /app/bin/entrypoint
 
+
+COPY --from=builder "/app/_build/${MIX_TARGET}_prod/rel/${RELEASE_NAME}" ./
+
+RUN mv /app/bin/${RELEASE_NAME} /app/bin/entrypoint
 
 HEALTHCHECK --start-period=10s CMD curl --fail http://localhost:${ELECTRIC_PORT-3000}/v1/health || exit 1
 
 ENTRYPOINT ["/app/bin/entrypoint"]
+
 CMD ["start"]

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -1,6 +1,10 @@
 defmodule Electric.Plug.Router do
   use Plug.Router, copy_opts_to_assign: :config
-  use Sentry.PlugCapture
+  use Electric.Telemetry
+
+  with_telemetry Sentry.PlugCapture do
+    use Sentry.PlugCapture
+  end
 
   alias Electric.Plug.Utils.CORSHeaderPlug
   alias Electric.Plug.Utils.PassAssignToOptsPlug
@@ -16,7 +20,11 @@ defmodule Electric.Plug.Router do
   plug Electric.Plug.TraceContextPlug
   plug Plug.Telemetry, event_prefix: [:electric, :routing]
   plug Plug.Logger
-  plug Sentry.PlugContext
+
+  with_telemetry Sentry.PlugCapture do
+    plug Sentry.PlugContext
+  end
+
   plug :put_cors_headers
   plug :dispatch
 

--- a/packages/sync-service/lib/electric/plug/utility_router.ex
+++ b/packages/sync-service/lib/electric/plug/utility_router.ex
@@ -1,8 +1,13 @@
 defmodule Electric.Plug.UtilityRouter do
   use Plug.Router
+  use Electric.Telemetry
 
   plug :match
   plug :dispatch
 
-  get "/metrics", do: resp(conn, 200, TelemetryMetricsPrometheus.Core.scrape())
+  with_telemetry TelemetryMetricsPrometheus.Core do
+    get "/metrics", do: resp(conn, 200, TelemetryMetricsPrometheus.Core.scrape())
+  else
+    get "/metrics", do: resp(conn, 200, "[]")
+  end
 end

--- a/packages/sync-service/lib/electric/telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry.ex
@@ -1,0 +1,46 @@
+defmodule Electric.Telemetry do
+  require Logger
+
+  # We need to test first if we're in the telemetry-enabled target
+  @telemetry_enabled? Mix.env() == :test || Mix.target() == Electric.MixProject.telemetry_target()
+
+  Logger.info(
+    "Compiling electric with telemetry #{if(@telemetry_enabled?, do: "ON", else: "OFF")}"
+  )
+
+  defmacro __using__(_opts) do
+    quote do
+      import Electric.Telemetry
+    end
+  end
+
+  defmacro with_telemetry(module, do: block, else: else_block) do
+    include_wity_telemetry(__ENV__, module, block, else_block)
+  end
+
+  defmacro with_telemetry(module, do: block) do
+    include_wity_telemetry(__ENV__, module, block, nil)
+  end
+
+  if @telemetry_enabled? do
+    defp include_wity_telemetry(env, module, block, else_block) do
+      modules = List.wrap(module) |> Enum.map(&Macro.expand(&1, env))
+      available? = Enum.all?(modules, &Code.ensure_loaded?/1)
+
+      if available? do
+        quote(do: unquote(block))
+      else
+        if else_block, do: quote(do: unquote(else_block))
+      end
+    end
+  else
+    defp include_wity_telemetry(_env, _module, _block, else_block) do
+      if else_block, do: quote(do: unquote(else_block))
+    end
+  end
+
+  @spec enabled?() :: boolean()
+  def enabled? do
+    @telemetry_enabled?
+  end
+end

--- a/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
@@ -1,381 +1,385 @@
-defmodule Electric.Telemetry.ApplicationTelemetry do
-  @moduledoc """
-  Collects and exports application level telemetry such as CPU, memory and BEAM metrics.
+use Electric.Telemetry
 
-  See also StackTelemetry for stack specific telemetry.
-  """
-  use Supervisor
+with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
+  defmodule Electric.Telemetry.ApplicationTelemetry do
+    @moduledoc """
+    Collects and exports application level telemetry such as CPU, memory and BEAM metrics.
 
-  import Telemetry.Metrics
+    See also StackTelemetry for stack specific telemetry.
+    """
+    use Supervisor
 
-  require Logger
+    import Telemetry.Metrics
 
-  @opts_schema NimbleOptions.new!(Electric.Telemetry.Opts.schema())
+    require Logger
 
-  def start_link(opts) do
-    with {:ok, opts} <- NimbleOptions.validate(opts, @opts_schema) do
-      if telemetry_export_enabled?(Map.new(opts)) do
-        Supervisor.start_link(__MODULE__, Map.new(opts), name: __MODULE__)
-      else
-        # Avoid starting the telemetry supervisor and its telemetry_poller child if we're not
-        # intending to export periodic measurements metrics anywhere.
-        :ignore
+    @opts_schema NimbleOptions.new!(Electric.Telemetry.Opts.schema())
+
+    def start_link(opts) do
+      with {:ok, opts} <- NimbleOptions.validate(opts, @opts_schema) do
+        if telemetry_export_enabled?(Map.new(opts)) do
+          Supervisor.start_link(__MODULE__, Map.new(opts), name: __MODULE__)
+        else
+          # Avoid starting the telemetry supervisor and its telemetry_poller child if we're not
+          # intending to export periodic measurements metrics anywhere.
+          :ignore
+        end
       end
     end
-  end
 
-  def init(opts) do
-    Process.set_label(:application_telemetry_supervisor)
+    def init(opts) do
+      Process.set_label(:application_telemetry_supervisor)
 
-    [telemetry_poller_child_spec(opts) | exporter_child_specs(opts)]
-    |> Supervisor.init(strategy: :one_for_one)
-  end
+      [telemetry_poller_child_spec(opts) | exporter_child_specs(opts)]
+      |> Supervisor.init(strategy: :one_for_one)
+    end
 
-  defp telemetry_poller_child_spec(opts) do
-    # The telemetry_poller application starts its own poller by default but we disable that
-    # and add its default measurements to the list of our custom ones. This allows for all
-    # periodic measurements to be defined in one place.
-    {:telemetry_poller,
-     measurements: periodic_measurements(),
-     period: opts.system_metrics_poll_interval,
-     init_delay: :timer.seconds(5)}
-  end
+    defp telemetry_poller_child_spec(opts) do
+      # The telemetry_poller application starts its own poller by default but we disable that
+      # and add its default measurements to the list of our custom ones. This allows for all
+      # periodic measurements to be defined in one place.
+      {:telemetry_poller,
+       measurements: periodic_measurements(),
+       period: opts.system_metrics_poll_interval,
+       init_delay: :timer.seconds(5)}
+    end
 
-  defp telemetry_export_enabled?(opts) do
-    exporter_child_specs(opts) != []
-  end
+    defp telemetry_export_enabled?(opts) do
+      exporter_child_specs(opts) != []
+    end
 
-  defp exporter_child_specs(opts) do
-    [
-      statsd_reporter_child_spec(opts),
-      prometheus_reporter_child_spec(opts),
-      call_home_reporter_child_spec(opts),
-      otel_reporter_child_spec(opts)
-    ]
-    |> Enum.reject(&is_nil/1)
-  end
-
-  defp otel_reporter_child_spec(%{otel_metrics?: true}) do
-    {OtelMetricExporter, metrics: otel_metrics(), export_period: :timer.seconds(30)}
-  end
-
-  defp otel_reporter_child_spec(_), do: nil
-
-  defp call_home_reporter_child_spec(%{call_home_telemetry?: true}) do
-    {Electric.Telemetry.CallHomeReporter,
-     static_info: static_info(),
-     metrics: call_home_metrics(),
-     first_report_in: {2, :minute},
-     reporting_period: {30, :minute}}
-  end
-
-  defp call_home_reporter_child_spec(_), do: nil
-
-  def static_info() do
-    {total_mem, _, _} = :memsup.get_memory_data()
-    processors = :erlang.system_info(:logical_processors)
-    {os_family, os_name} = :os.type()
-    arch = :erlang.system_info(:system_architecture)
-
-    %{
-      electric_version: to_string(Electric.version()),
-      environment: %{
-        os: %{family: os_family, name: os_name},
-        arch: to_string(arch),
-        cores: processors,
-        ram: total_mem,
-        electric_instance_id: Electric.instance_id()
-      }
-    }
-  end
-
-  # IMPORTANT: these metrics are validated on the receiver side, so if you change them,
-  #            make sure you also change the receiver
-  def call_home_metrics() do
-    [
-      resources: [
-        uptime:
-          last_value("vm.uptime.total",
-            unit: :second,
-            measurement: &:erlang.convert_time_unit(&1.total, :native, :second)
-          ),
-        used_memory: summary("vm.memory.total", unit: :byte),
-        run_queue_total: summary("vm.total_run_queue_lengths.total"),
-        run_queue_cpu: summary("vm.total_run_queue_lengths.cpu"),
-        run_queue_io: summary("vm.total_run_queue_lengths.io")
-      ],
-      system: [
-        load_avg1: last_value("system.load_percent.avg1"),
-        load_avg5: last_value("system.load_percent.avg5"),
-        load_avg15: last_value("system.load_percent.avg15"),
-        memory_free: last_value("system.memory.free_memory"),
-        memory_used: last_value("system.memory.used_memory"),
-        memory_free_percent: last_value("system.memory_percent.free_memory"),
-        memory_used_percent: last_value("system.memory_percent.used_memory"),
-        swap_free: last_value("system.swap.free"),
-        swap_used: last_value("system.swap.used"),
-        swap_free_percent: last_value("system.swap_percent.free"),
-        swap_used_percent: last_value("system.swap_percent.used")
+    defp exporter_child_specs(opts) do
+      [
+        statsd_reporter_child_spec(opts),
+        prometheus_reporter_child_spec(opts),
+        call_home_reporter_child_spec(opts),
+        otel_reporter_child_spec(opts)
       ]
-    ]
-  end
+      |> Enum.reject(&is_nil/1)
+    end
 
-  defp statsd_reporter_child_spec(%{statsd_host: host} = opts) when host != nil do
-    {TelemetryMetricsStatsd,
-     host: host,
-     formatter: :datadog,
-     global_tags: [instance_id: opts.instance_id],
-     metrics: statsd_metrics()}
-  end
+    defp otel_reporter_child_spec(%{otel_metrics?: true}) do
+      {OtelMetricExporter, metrics: otel_metrics(), export_period: :timer.seconds(30)}
+    end
 
-  defp statsd_reporter_child_spec(_), do: nil
+    defp otel_reporter_child_spec(_), do: nil
 
-  defp prometheus_reporter_child_spec(%{prometheus?: true}) do
-    {TelemetryMetricsPrometheus.Core, metrics: prometheus_metrics()}
-  end
+    defp call_home_reporter_child_spec(%{call_home_telemetry?: true}) do
+      {Electric.Telemetry.CallHomeReporter,
+       static_info: static_info(),
+       metrics: call_home_metrics(),
+       first_report_in: {2, :minute},
+       reporting_period: {30, :minute}}
+    end
 
-  defp prometheus_reporter_child_spec(_), do: nil
+    defp call_home_reporter_child_spec(_), do: nil
 
-  defp statsd_metrics() do
-    [
-      last_value("vm.memory.total", unit: :byte),
-      last_value("vm.memory.processes_used", unit: :byte),
-      last_value("vm.memory.binary", unit: :byte),
-      last_value("vm.memory.ets", unit: :byte),
-      last_value("vm.total_run_queue_lengths.total"),
-      last_value("vm.total_run_queue_lengths.cpu"),
-      last_value("vm.total_run_queue_lengths.io"),
-      last_value("system.load_percent.avg1"),
-      last_value("system.load_percent.avg5"),
-      last_value("system.load_percent.avg15"),
-      last_value("system.memory.free_memory"),
-      last_value("system.memory.used_memory"),
-      last_value("system.swap.free"),
-      last_value("system.swap.used")
-    ]
-    |> Enum.map(&%{&1 | tags: [:instance_id | &1.tags]})
-  end
+    def static_info() do
+      {total_mem, _, _} = :memsup.get_memory_data()
+      processors = :erlang.system_info(:logical_processors)
+      {os_family, os_name} = :os.type()
+      arch = :erlang.system_info(:system_architecture)
 
-  defp prometheus_metrics() do
-    [
-      last_value("system.cpu.core_count"),
-      last_value("system.cpu.utilization.total"),
-      last_value("vm.memory.processes_used", unit: :byte),
-      last_value("vm.memory.binary", unit: :byte),
-      last_value("vm.memory.ets", unit: :byte),
-      last_value("vm.system_counts.process_count"),
-      last_value("vm.system_counts.atom_count"),
-      last_value("vm.system_counts.port_count"),
-      last_value("vm.total_run_queue_lengths.total"),
-      last_value("vm.total_run_queue_lengths.cpu"),
-      last_value("vm.total_run_queue_lengths.io"),
-      last_value("vm.uptime.total",
-        unit: :second,
-        measurement: &:erlang.convert_time_unit(&1.total, :native, :second)
-      ),
-      last_value("vm.memory.total", unit: :byte)
-    ] ++
-      Enum.map(
-        # Add "system.cpu.utilization.core_*" but since there's no wildcard support we
-        # explicitly add the cores here.
-        0..(:erlang.system_info(:logical_processors) - 1),
-        &last_value("system.cpu.utilization.core_#{&1}")
+      %{
+        electric_version: to_string(Electric.version()),
+        environment: %{
+          os: %{family: os_family, name: os_name},
+          arch: to_string(arch),
+          cores: processors,
+          ram: total_mem,
+          electric_instance_id: Electric.instance_id()
+        }
+      }
+    end
+
+    # IMPORTANT: these metrics are validated on the receiver side, so if you change them,
+    #            make sure you also change the receiver
+    def call_home_metrics() do
+      [
+        resources: [
+          uptime:
+            last_value("vm.uptime.total",
+              unit: :second,
+              measurement: &:erlang.convert_time_unit(&1.total, :native, :second)
+            ),
+          used_memory: summary("vm.memory.total", unit: :byte),
+          run_queue_total: summary("vm.total_run_queue_lengths.total"),
+          run_queue_cpu: summary("vm.total_run_queue_lengths.cpu"),
+          run_queue_io: summary("vm.total_run_queue_lengths.io")
+        ],
+        system: [
+          load_avg1: last_value("system.load_percent.avg1"),
+          load_avg5: last_value("system.load_percent.avg5"),
+          load_avg15: last_value("system.load_percent.avg15"),
+          memory_free: last_value("system.memory.free_memory"),
+          memory_used: last_value("system.memory.used_memory"),
+          memory_free_percent: last_value("system.memory_percent.free_memory"),
+          memory_used_percent: last_value("system.memory_percent.used_memory"),
+          swap_free: last_value("system.swap.free"),
+          swap_used: last_value("system.swap.used"),
+          swap_free_percent: last_value("system.swap_percent.free"),
+          swap_used_percent: last_value("system.swap_percent.used")
+        ]
+      ]
+    end
+
+    defp statsd_reporter_child_spec(%{statsd_host: host} = opts) when host != nil do
+      {TelemetryMetricsStatsd,
+       host: host,
+       formatter: :datadog,
+       global_tags: [instance_id: opts.instance_id],
+       metrics: statsd_metrics()}
+    end
+
+    defp statsd_reporter_child_spec(_), do: nil
+
+    defp prometheus_reporter_child_spec(%{prometheus?: true}) do
+      {TelemetryMetricsPrometheus.Core, metrics: prometheus_metrics()}
+    end
+
+    defp prometheus_reporter_child_spec(_), do: nil
+
+    defp statsd_metrics() do
+      [
+        last_value("vm.memory.total", unit: :byte),
+        last_value("vm.memory.processes_used", unit: :byte),
+        last_value("vm.memory.binary", unit: :byte),
+        last_value("vm.memory.ets", unit: :byte),
+        last_value("vm.total_run_queue_lengths.total"),
+        last_value("vm.total_run_queue_lengths.cpu"),
+        last_value("vm.total_run_queue_lengths.io"),
+        last_value("system.load_percent.avg1"),
+        last_value("system.load_percent.avg5"),
+        last_value("system.load_percent.avg15"),
+        last_value("system.memory.free_memory"),
+        last_value("system.memory.used_memory"),
+        last_value("system.swap.free"),
+        last_value("system.swap.used")
+      ]
+      |> Enum.map(&%{&1 | tags: [:instance_id | &1.tags]})
+    end
+
+    defp prometheus_metrics() do
+      [
+        last_value("system.cpu.core_count"),
+        last_value("system.cpu.utilization.total"),
+        last_value("vm.memory.processes_used", unit: :byte),
+        last_value("vm.memory.binary", unit: :byte),
+        last_value("vm.memory.ets", unit: :byte),
+        last_value("vm.system_counts.process_count"),
+        last_value("vm.system_counts.atom_count"),
+        last_value("vm.system_counts.port_count"),
+        last_value("vm.total_run_queue_lengths.total"),
+        last_value("vm.total_run_queue_lengths.cpu"),
+        last_value("vm.total_run_queue_lengths.io"),
+        last_value("vm.uptime.total",
+          unit: :second,
+          measurement: &:erlang.convert_time_unit(&1.total, :native, :second)
+        ),
+        last_value("vm.memory.total", unit: :byte)
+      ] ++
+        Enum.map(
+          # Add "system.cpu.utilization.core_*" but since there's no wildcard support we
+          # explicitly add the cores here.
+          0..(:erlang.system_info(:logical_processors) - 1),
+          &last_value("system.cpu.utilization.core_#{&1}")
+        )
+    end
+
+    defp otel_metrics() do
+      [
+        last_value("system.load_percent.avg1"),
+        last_value("system.load_percent.avg5"),
+        last_value("system.load_percent.avg15")
+      ] ++ prometheus_metrics()
+    end
+
+    defp periodic_measurements() do
+      [
+        # Default measurements included with the telemetry_poller application:
+        :memory,
+        :total_run_queue_lengths,
+        :system_counts,
+
+        # Our custom measurements:
+        {__MODULE__, :uptime_event, []},
+        {__MODULE__, :cpu_utilization, []},
+        {__MODULE__, :get_system_load_average, []},
+        {__MODULE__, :get_system_memory_usage, []}
+      ]
+    end
+
+    def uptime_event do
+      :telemetry.execute([:vm, :uptime], %{
+        total: :erlang.monotonic_time() - :erlang.system_info(:start_time)
+      })
+    end
+
+    def cpu_utilization do
+      cores =
+        :cpu_sup.util([:per_cpu])
+        |> Map.new(fn {cpu_index, busy, _free, _misc} -> {:"core_#{cpu_index}", busy} end)
+
+      cores
+      |> Map.put(:total, cores |> Map.values() |> mean())
+      |> then(&:telemetry.execute([:system, :cpu, :utilization], &1))
+
+      :telemetry.execute([:system, :cpu], %{core_count: Enum.count(cores)})
+    end
+
+    def get_system_load_average do
+      cores = :erlang.system_info(:logical_processors)
+
+      # > The load values are proportional to how long time a runnable Unix
+      # > process has to spend in the run queue before it is scheduled.
+      # > Accordingly, higher values mean more system load. The returned value
+      # > divided by 256 produces the figure displayed by rup and top.
+      #
+      # I'm going one step further and dividing by the number of CPUs so in a 4
+      # core system, a load of 4.0 (in top) will show as 100%.
+      # Since load can go above num cores, we can to 200%, 300% but
+      # I think this makes sense.
+      #
+      # Certainly the formula in the erlang docs:
+      #
+      # > the following simple mathematical transformation can produce the load
+      # > value as a percentage:
+      # >
+      # >   PercentLoad = 100 * (1 - D/(D + Load))
+      # >
+      # > D determines which load value should be associated with which
+      # > percentage. Choosing D = 50 means that 128 is 60% load, 256 is 80%, 512
+      # > is 90%, and so on.
+      #
+      # Makes little sense. Setting `D` as they say and plugging in a avg1 value
+      # of 128 does not give 60% so I'm not sure how to square what they say with
+      # the numbers...
+      #
+      # e.g. my machine currently has a cpu util (:cpu_sup.util()) of 4% and an
+      # avg1() of 550 ish across 24 cores (so doing very little) but that formula
+      # would give a `PercentLoad` of ~92%.
+      #
+      # My version would give value of 550 / 256 / 24 = 9%
+      [:avg1, :avg5, :avg15]
+      |> Map.new(fn probe ->
+        {probe, 100 * (apply(:cpu_sup, probe, []) / 256 / cores)}
+      end)
+      |> then(&:telemetry.execute([:system, :load_percent], &1))
+    end
+
+    @required_system_memory_keys ~w[system_total_memory free_memory]a
+
+    def get_system_memory_usage() do
+      system_memory = Map.new(:memsup.get_system_memory_data())
+
+      # Sanity-check that all the required keys are present before doing any arithmetic on them
+      missing_system_memory_keys =
+        Enum.reject(@required_system_memory_keys, &Map.has_key?(system_memory, &1))
+
+      mem_stats =
+        cond do
+          missing_system_memory_keys != [] ->
+            Logger.warning(
+              "Error gathering system memory stats: " <>
+                "missing data points #{Enum.join(missing_system_memory_keys, ", ")}"
+            )
+
+            %{}
+
+          system_memory.system_total_memory == 0 ->
+            Logger.warning("Error gathering system memory stats: zero total memory reported")
+            %{}
+
+          true ->
+            total = system_memory.system_total_memory
+
+            used = total - system_memory.free_memory
+
+            mem_stats =
+              system_memory
+              |> Map.take(~w[available_memory free_memory buffered_memory cached_memory]a)
+              |> Map.put(:used_memory, used)
+              |> Map.merge(resident_memory(system_memory))
+
+            mem_percent_stats = Map.new(mem_stats, fn {k, v} -> {k, 100 * v / total} end)
+
+            mem_stats = Map.put(mem_stats, :total_memory, total)
+
+            :telemetry.execute([:system, :memory], mem_stats)
+            :telemetry.execute([:system, :memory_percent], mem_percent_stats)
+
+            mem_stats
+        end
+
+      Map.merge(mem_stats, swap_stats(:os.type(), system_memory))
+    end
+
+    defp resident_memory(%{available_memory: available_memory}) do
+      %{resident_memory: available_memory}
+    end
+
+    defp resident_memory(%{
+           free_memory: free,
+           buffered_memory: buffered,
+           cached_memory: cached,
+           system_total_memory: total
+         }) do
+      %{resident_memory: total - (free + buffered + cached)}
+    end
+
+    @resident_memory_keys ~w[available_memory free_memory buffered_memory cached_memory]a
+    defp resident_memory(system_memory) do
+      missing_keys =
+        @resident_memory_keys
+        |> Enum.reject(&Map.has_key?(system_memory, &1))
+
+      Logger.warning(
+        "Error gathering resident memory stats: " <>
+          "missing data points #{Enum.join(missing_keys, ", ")}"
       )
-  end
 
-  defp otel_metrics() do
-    [
-      last_value("system.load_percent.avg1"),
-      last_value("system.load_percent.avg5"),
-      last_value("system.load_percent.avg15")
-    ] ++ prometheus_metrics()
-  end
+      %{}
+    end
 
-  defp periodic_measurements() do
-    [
-      # Default measurements included with the telemetry_poller application:
-      :memory,
-      :total_run_queue_lengths,
-      :system_counts,
+    defp swap_stats({:unix, :darwin}, _system_memory) do
+      # On macOS, swap stats are not available
+      %{}
+    end
 
-      # Our custom measurements:
-      {__MODULE__, :uptime_event, []},
-      {__MODULE__, :cpu_utilization, []},
-      {__MODULE__, :get_system_load_average, []},
-      {__MODULE__, :get_system_memory_usage, []}
-    ]
-  end
+    defp swap_stats(_os_type, %{total_swap: total, free_swap: free}) do
+      used = total - free
 
-  def uptime_event do
-    :telemetry.execute([:vm, :uptime], %{
-      total: :erlang.monotonic_time() - :erlang.system_info(:start_time)
-    })
-  end
+      swap_stats = %{total_swap: total, free_swap: free, used_swap: used}
 
-  def cpu_utilization do
-    cores =
-      :cpu_sup.util([:per_cpu])
-      |> Map.new(fn {cpu_index, busy, _free, _misc} -> {:"core_#{cpu_index}", busy} end)
+      swap_percent_stats =
+        if total > 0 do
+          %{free_swap: 100 * free / total, used_swap: 100 * used / total}
+        else
+          %{free_swap: 0, used_swap: 0}
+        end
 
-    cores
-    |> Map.put(:total, cores |> Map.values() |> mean())
-    |> then(&:telemetry.execute([:system, :cpu, :utilization], &1))
+      :telemetry.execute([:system, :swap], swap_stats)
+      :telemetry.execute([:system, :swap_percent], swap_percent_stats)
 
-    :telemetry.execute([:system, :cpu], %{core_count: Enum.count(cores)})
-  end
+      swap_stats
+    end
 
-  def get_system_load_average do
-    cores = :erlang.system_info(:logical_processors)
+    @required_swap_keys ~w[total_swap free_swap]a
+    defp swap_stats(_os_type, system_memory) do
+      missing_swap_keys = Enum.reject(@required_swap_keys, &Map.has_key?(system_memory, &1))
 
-    # > The load values are proportional to how long time a runnable Unix
-    # > process has to spend in the run queue before it is scheduled.
-    # > Accordingly, higher values mean more system load. The returned value
-    # > divided by 256 produces the figure displayed by rup and top.
-    #
-    # I'm going one step further and dividing by the number of CPUs so in a 4
-    # core system, a load of 4.0 (in top) will show as 100%.
-    # Since load can go above num cores, we can to 200%, 300% but
-    # I think this makes sense.
-    #
-    # Certainly the formula in the erlang docs:
-    #
-    # > the following simple mathematical transformation can produce the load
-    # > value as a percentage:
-    # >
-    # >   PercentLoad = 100 * (1 - D/(D + Load))
-    # >
-    # > D determines which load value should be associated with which
-    # > percentage. Choosing D = 50 means that 128 is 60% load, 256 is 80%, 512
-    # > is 90%, and so on.
-    #
-    # Makes little sense. Setting `D` as they say and plugging in a avg1 value
-    # of 128 does not give 60% so I'm not sure how to square what they say with
-    # the numbers...
-    #
-    # e.g. my machine currently has a cpu util (:cpu_sup.util()) of 4% and an
-    # avg1() of 550 ish across 24 cores (so doing very little) but that formula
-    # would give a `PercentLoad` of ~92%.
-    #
-    # My version would give value of 550 / 256 / 24 = 9%
-    [:avg1, :avg5, :avg15]
-    |> Map.new(fn probe ->
-      {probe, 100 * (apply(:cpu_sup, probe, []) / 256 / cores)}
-    end)
-    |> then(&:telemetry.execute([:system, :load_percent], &1))
-  end
+      Logger.warning(
+        "Error gathering system swap stats: " <>
+          "missing data points #{Enum.join(missing_swap_keys, ", ")}"
+      )
 
-  @required_system_memory_keys ~w[system_total_memory free_memory]a
+      %{}
+    end
 
-  def get_system_memory_usage() do
-    system_memory = Map.new(:memsup.get_system_memory_data())
+    defp mean([]), do: nil
 
-    # Sanity-check that all the required keys are present before doing any arithmetic on them
-    missing_system_memory_keys =
-      Enum.reject(@required_system_memory_keys, &Map.has_key?(system_memory, &1))
-
-    mem_stats =
-      cond do
-        missing_system_memory_keys != [] ->
-          Logger.warning(
-            "Error gathering system memory stats: " <>
-              "missing data points #{Enum.join(missing_system_memory_keys, ", ")}"
-          )
-
-          %{}
-
-        system_memory.system_total_memory == 0 ->
-          Logger.warning("Error gathering system memory stats: zero total memory reported")
-          %{}
-
-        true ->
-          total = system_memory.system_total_memory
-
-          used = total - system_memory.free_memory
-
-          mem_stats =
-            system_memory
-            |> Map.take(~w[available_memory free_memory buffered_memory cached_memory]a)
-            |> Map.put(:used_memory, used)
-            |> Map.merge(resident_memory(system_memory))
-
-          mem_percent_stats = Map.new(mem_stats, fn {k, v} -> {k, 100 * v / total} end)
-
-          mem_stats = Map.put(mem_stats, :total_memory, total)
-
-          :telemetry.execute([:system, :memory], mem_stats)
-          :telemetry.execute([:system, :memory_percent], mem_percent_stats)
-
-          mem_stats
-      end
-
-    Map.merge(mem_stats, swap_stats(:os.type(), system_memory))
-  end
-
-  defp resident_memory(%{available_memory: available_memory}) do
-    %{resident_memory: available_memory}
-  end
-
-  defp resident_memory(%{
-         free_memory: free,
-         buffered_memory: buffered,
-         cached_memory: cached,
-         system_total_memory: total
-       }) do
-    %{resident_memory: total - (free + buffered + cached)}
-  end
-
-  @resident_memory_keys ~w[available_memory free_memory buffered_memory cached_memory]a
-  defp resident_memory(system_memory) do
-    missing_keys =
-      @resident_memory_keys
-      |> Enum.reject(&Map.has_key?(system_memory, &1))
-
-    Logger.warning(
-      "Error gathering resident memory stats: " <>
-        "missing data points #{Enum.join(missing_keys, ", ")}"
-    )
-
-    %{}
-  end
-
-  defp swap_stats({:unix, :darwin}, _system_memory) do
-    # On macOS, swap stats are not available
-    %{}
-  end
-
-  defp swap_stats(_os_type, %{total_swap: total, free_swap: free}) do
-    used = total - free
-
-    swap_stats = %{total_swap: total, free_swap: free, used_swap: used}
-
-    swap_percent_stats =
-      if total > 0 do
-        %{free_swap: 100 * free / total, used_swap: 100 * used / total}
-      else
-        %{free_swap: 0, used_swap: 0}
-      end
-
-    :telemetry.execute([:system, :swap], swap_stats)
-    :telemetry.execute([:system, :swap_percent], swap_percent_stats)
-
-    swap_stats
-  end
-
-  @required_swap_keys ~w[total_swap free_swap]a
-  defp swap_stats(_os_type, system_memory) do
-    missing_swap_keys = Enum.reject(@required_swap_keys, &Map.has_key?(system_memory, &1))
-
-    Logger.warning(
-      "Error gathering system swap stats: " <>
-        "missing data points #{Enum.join(missing_swap_keys, ", ")}"
-    )
-
-    %{}
-  end
-
-  defp mean([]), do: nil
-
-  defp mean(list) when is_list(list) do
-    Enum.sum(list) / Enum.count(list)
+    defp mean(list) when is_list(list) do
+      Enum.sum(list) / Enum.count(list)
+    end
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/call_home_reporter.ex
+++ b/packages/sync-service/lib/electric/telemetry/call_home_reporter.ex
@@ -1,329 +1,336 @@
-defmodule Electric.Telemetry.CallHomeReporter do
-  @moduledoc """
-  Reporter that collects runtime telemetry information and sends it to a configured
-  home server once in a while. The information is aggregated over a period of time,
-  with percentile values calculated for the metrics that have them.
-  """
+use Electric.Telemetry
 
-  use GenServer
-  require Logger
-  alias Telemetry.Metrics
+with_telemetry Telemetry.Metrics do
+  defmodule Electric.Telemetry.CallHomeReporter do
+    @moduledoc """
+    Reporter that collects runtime telemetry information and sends it to a configured
+    home server once in a while. The information is aggregated over a period of time,
+    with percentile values calculated for the metrics that have them.
+    """
 
-  @type metric :: Telemetry.Metrics.t()
-  @type report_format :: keyword(metric() | report_format())
+    use GenServer
 
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    metrics = Keyword.fetch!(opts, :metrics)
-    static_info = Keyword.get(opts, :static_info, %{})
-    first_report_in = cast_time_to_ms(Keyword.fetch!(opts, :first_report_in))
-    reporting_period = cast_time_to_ms(Keyword.fetch!(opts, :reporting_period))
-    reporter_fn = Keyword.get(opts, :reporter_fn, &report_home/1)
+    require Logger
 
-    GenServer.start_link(
-      __MODULE__,
-      {metrics, first_report_in, reporting_period, name, static_info, reporter_fn},
-      name: name
-    )
-  end
+    alias Telemetry.Metrics
 
-  def report_home(results) do
-    Req.post!(telemetry_url(), json: results, retry: :transient)
-    :ok
-  end
+    @type metric :: Telemetry.Metrics.t()
+    @type report_format :: keyword(metric() | report_format())
 
-  defp telemetry_url, do: Electric.Config.get_env(:telemetry_url)
+    def start_link(opts) do
+      name = Keyword.get(opts, :name, __MODULE__)
+      metrics = Keyword.fetch!(opts, :metrics)
+      static_info = Keyword.get(opts, :static_info, %{})
+      first_report_in = cast_time_to_ms(Keyword.fetch!(opts, :first_report_in))
+      reporting_period = cast_time_to_ms(Keyword.fetch!(opts, :reporting_period))
+      reporter_fn = Keyword.get(opts, :reporter_fn, &report_home/1)
 
-  def print_stats(name \\ __MODULE__) do
-    GenServer.call(name, :print_stats)
-  end
+      GenServer.start_link(
+        __MODULE__,
+        {metrics, first_report_in, reporting_period, name, static_info, reporter_fn},
+        name: name
+      )
+    end
 
-  defp cast_time_to_ms({time, :minute}), do: time * 60 * 1000
-  defp cast_time_to_ms({time, :second}), do: time * 1000
+    def report_home(results) do
+      Req.post!(telemetry_url(), json: results, retry: :transient)
+      :ok
+    end
 
-  @impl GenServer
-  def init({metrics, first_report_in, reporting_period, name, static_info, reporter_fn}) do
-    # We need to trap exits here so that `terminate/2` callback has more chances to run
-    # and send data before crash/shutdown
-    Process.flag(:trap_exit, true)
-    Process.set_label({:call_home_reporter, name})
+    defp telemetry_url, do: Electric.Config.get_env(:telemetry_url)
 
-    Logger.notice(
-      "Starting telemetry reporter. Electric will send anonymous usage data to #{telemetry_url()}. " <>
-        "You can configure this with `ELECTRIC_USAGE_REPORTING` environment variable, " <>
-        "see https://electric-sql.com/docs/reference/telemetry for more information."
-    )
+    def print_stats(name \\ __MODULE__) do
+      GenServer.call(name, :print_stats)
+    end
 
-    metrics = save_target_path_to_options(metrics)
+    defp cast_time_to_ms({time, :minute}), do: time * 60 * 1000
+    defp cast_time_to_ms({time, :second}), do: time * 1000
 
-    groups = Enum.group_by(metrics, & &1.event_name)
+    @impl GenServer
+    def init({metrics, first_report_in, reporting_period, name, static_info, reporter_fn}) do
+      # We need to trap exits here so that `terminate/2` callback has more chances to run
+      # and send data before crash/shutdown
+      Process.flag(:trap_exit, true)
+      Process.set_label({:call_home_reporter, name})
 
-    aggregates_table = create_table(name, :set)
-    summary_table = create_table(String.to_atom("#{name}_summary"), :duplicate_bag)
+      Logger.notice(
+        "Starting telemetry reporter. Electric will send anonymous usage data to #{telemetry_url()}. " <>
+          "You can configure this with `ELECTRIC_USAGE_REPORTING` environment variable, " <>
+          "see https://electric-sql.com/docs/reference/telemetry for more information."
+      )
 
-    context = %{
-      table: aggregates_table,
-      summary_table: summary_table
+      metrics = save_target_path_to_options(metrics)
+
+      groups = Enum.group_by(metrics, & &1.event_name)
+
+      aggregates_table = create_table(name, :set)
+      summary_table = create_table(String.to_atom("#{name}_summary"), :duplicate_bag)
+
+      context = %{
+        table: aggregates_table,
+        summary_table: summary_table
+      }
+
+      # Attach a listener per event
+      for {event, metrics} <- groups do
+        id = {__MODULE__, event, self()}
+        :telemetry.attach(id, event, &__MODULE__.handle_event/4, {metrics, context})
+      end
+
+      # Save some information about the metrics to use when building an output object
+      summary_types =
+        metrics
+        |> Enum.flat_map(fn
+          %Metrics.Summary{unit: :unique} = m -> [{get_result_path(m), :count_unique}]
+          %Metrics.Summary{} = m -> [{get_result_path(m), :summary}]
+          _ -> []
+        end)
+
+      all_paths = Enum.map(metrics, &get_result_path/1)
+
+      persisted_paths =
+        metrics
+        |> Enum.filter(&Keyword.get(&1.reporter_options, :persist_between_sends, false))
+        |> Enum.map(&get_result_path/1)
+
+      Process.send_after(self(), :report, first_report_in)
+
+      {:ok,
+       Map.merge(context, %{
+         event_ids: Map.keys(groups),
+         summary_types: summary_types,
+         all_paths: all_paths,
+         reporting_period: reporting_period,
+         static_info: static_info,
+         persisted_paths: persisted_paths,
+         reporter_fn: reporter_fn,
+         last_reported: DateTime.utc_now()
+       })}
+    end
+
+    @impl GenServer
+    def terminate(_, state) do
+      for id <- state.event_ids do
+        :telemetry.detach(id)
+      end
+
+      # On shutdown try to push all the data we still can.
+      state.reporter_fn.(build_report(state))
+    end
+
+    @empty_summary %{
+      min: 0,
+      max: 0,
+      mean: 0,
+      median: 0,
+      mode: nil
     }
 
-    # Attach a listener per event
-    for {event, metrics} <- groups do
-      id = {__MODULE__, event, self()}
-      :telemetry.attach(id, event, &__MODULE__.handle_event/4, {metrics, context})
+    @impl GenServer
+    def handle_call(:print_stats, _from, state) do
+      {:reply, build_stats(state), state}
     end
 
-    # Save some information about the metrics to use when building an output object
-    summary_types =
-      metrics
-      |> Enum.flat_map(fn
-        %Metrics.Summary{unit: :unique} = m -> [{get_result_path(m), :count_unique}]
-        %Metrics.Summary{} = m -> [{get_result_path(m), :summary}]
-        _ -> []
-      end)
+    @impl GenServer
+    def handle_info(:report, state) do
+      full_report = build_report(state)
 
-    all_paths = Enum.map(metrics, &get_result_path/1)
+      state =
+        try do
+          :ok = state.reporter_fn.(full_report)
+          clear_stats(%{state | last_reported: full_report.timestamp})
+        rescue
+          e ->
+            Logger.warning(
+              "Reporter function failed while trying to send telemetry data.\nError: #{Exception.format(:error, e, __STACKTRACE__)}"
+            )
 
-    persisted_paths =
-      metrics
-      |> Enum.filter(&Keyword.get(&1.reporter_options, :persist_between_sends, false))
-      |> Enum.map(&get_result_path/1)
+            state
+        end
 
-    Process.send_after(self(), :report, first_report_in)
-
-    {:ok,
-     Map.merge(context, %{
-       event_ids: Map.keys(groups),
-       summary_types: summary_types,
-       all_paths: all_paths,
-       reporting_period: reporting_period,
-       static_info: static_info,
-       persisted_paths: persisted_paths,
-       reporter_fn: reporter_fn,
-       last_reported: DateTime.utc_now()
-     })}
-  end
-
-  @impl GenServer
-  def terminate(_, state) do
-    for id <- state.event_ids do
-      :telemetry.detach(id)
-    end
-
-    # On shutdown try to push all the data we still can.
-    state.reporter_fn.(build_report(state))
-  end
-
-  @empty_summary %{
-    min: 0,
-    max: 0,
-    mean: 0,
-    median: 0,
-    mode: nil
-  }
-
-  @impl GenServer
-  def handle_call(:print_stats, _from, state) do
-    {:reply, build_stats(state), state}
-  end
-
-  @impl GenServer
-  def handle_info(:report, state) do
-    full_report = build_report(state)
-
-    state =
-      try do
-        :ok = state.reporter_fn.(full_report)
-        clear_stats(%{state | last_reported: full_report.timestamp})
-      rescue
-        e ->
-          Logger.warning(
-            "Reporter function failed while trying to send telemetry data.\nError: #{Exception.format(:error, e, __STACKTRACE__)}"
-          )
-
+      # If we've failed to send the results for more than 24 hours, then drop current stats
+      # to save memory
+      state =
+        if DateTime.diff(DateTime.utc_now(), state.last_reported, :hour) >= 24 do
+          clear_stats(%{state | last_reported: DateTime.utc_now()})
+        else
           state
-      end
+        end
 
-    # If we've failed to send the results for more than 24 hours, then drop current stats
-    # to save memory
-    state =
-      if DateTime.diff(DateTime.utc_now(), state.last_reported, :hour) >= 24 do
-        clear_stats(%{state | last_reported: DateTime.utc_now()})
-      else
-        state
-      end
-
-    Process.send_after(self(), :report, state.reporting_period)
-    {:noreply, state}
-  end
-
-  defp build_report(state) do
-    %{
-      last_reported: state.last_reported,
-      timestamp: DateTime.utc_now(),
-      report_version: 2,
-      data: build_stats(state)
-    }
-  end
-
-  defp build_stats(state) do
-    result = empty_result(state.all_paths, Map.new(state.summary_types))
-
-    result =
-      :ets.tab2list(state.table)
-      |> fill_map_from_path_tuples(result)
-
-    result =
-      state.summary_types
-      |> Enum.map(&{elem(&1, 0), calculate_summary(&1, state.summary_table)})
-      |> fill_map_from_path_tuples(result)
-
-    deep_merge(result, state.static_info)
-  end
-
-  defp clear_stats(state) do
-    for key <- state.all_paths -- state.persisted_paths do
-      table =
-        if(is_map_key(Map.new(state.summary_types), key),
-          do: state.summary_table,
-          else: state.table
-        )
-
-      :ets.delete(table, key)
+      Process.send_after(self(), :report, state.reporting_period)
+      {:noreply, state}
     end
 
-    state
-  end
-
-  defp calculate_summary({path, :count_unique}, table) do
-    :ets.lookup_element(table, path, 2)
-    |> Enum.uniq()
-    |> Enum.count()
-  rescue
-    ArgumentError -> 0
-  end
-
-  defp calculate_summary({path, :summary}, table) do
-    items = :ets.lookup_element(table, path, 2)
-
-    length = length(items)
-
-    {min, max} = Enum.min_max(items)
-
-    %{
-      min: min,
-      max: max,
-      mean: mean(items, length),
-      median: median(items, length),
-      mode: mode(items)
-    }
-  rescue
-    [ArgumentError, Enum.EmptyError, ArithmeticError] ->
-      # Enum.EmptyError may be raised when there are no elements in the ETS table under the key `path`
-      # ArithmeticError may be raised when an element in the ETS table is `nil`
-      @empty_summary
-  end
-
-  defp mean(elements, length), do: Enum.sum(elements) / length
-
-  defp median(elements, length) when rem(length, 2) == 1 do
-    Enum.at(elements, div(length, 2))
-  end
-
-  defp median(elements, length) when rem(length, 2) == 0 do
-    Enum.slice(elements, div(length, 2) - 1, 2) |> mean(length)
-  end
-
-  defp mode(elements), do: Enum.frequencies(elements) |> Enum.max_by(&elem(&1, 1)) |> elem(0)
-
-  defp empty_result(all_paths, summary_types) do
-    all_paths
-    |> Enum.map(fn path ->
-      case summary_types do
-        %{^path => :summary} -> {path, @empty_summary}
-        %{^path => :unique_count} -> {path, 0}
-        _ -> {path, 0}
-      end
-    end)
-    |> fill_map_from_path_tuples()
-  end
-
-  @spec fill_map_from_path_tuples([{tuple(), term()}], map()) :: map()
-  defp fill_map_from_path_tuples(tuples, into \\ %{}) do
-    Enum.reduce(tuples, into, fn {path, val}, acc ->
-      path = path |> Tuple.to_list() |> Enum.map(&Access.key(&1, %{}))
-      put_in(acc, path, val)
-    end)
-  end
-
-  @spec create_table(name :: atom, type :: atom) :: :ets.tid() | atom
-  defp create_table(name, type) do
-    :ets.new(name, [:named_table, :public, type, {:write_concurrency, true}])
-  end
-
-  def handle_event(_event_name, measurements, metadata, {metrics, context}) do
-    for %{reporter_options: opts} = metric <- metrics, keep?(metric, metadata) do
-      path = Keyword.fetch!(opts, :result_path)
-      measurement = extract_measurement(metric, measurements, metadata)
-
-      case metric do
-        %Metrics.Counter{} ->
-          :ets.update_counter(context.table, path, 1, {path, 0})
-
-        %Metrics.Sum{} ->
-          :ets.update_counter(context.table, path, measurement, {path, 0})
-
-        %Metrics.LastValue{} ->
-          :ets.insert(context.table, {path, measurement})
-
-        %Metrics.Summary{unit: :unique} ->
-          add_to_summary(path, context, metadata[Keyword.fetch!(opts, :count_unique)])
-
-        %Metrics.Summary{} ->
-          add_to_summary(path, context, measurement)
-      end
+    defp build_report(state) do
+      %{
+        last_reported: state.last_reported,
+        timestamp: DateTime.utc_now(),
+        report_version: 2,
+        data: build_stats(state)
+      }
     end
-  end
 
-  defp add_to_summary(path, %{summary_table: tbl}, value) do
-    :ets.insert(tbl, {path, value})
-  end
+    defp build_stats(state) do
+      result = empty_result(state.all_paths, Map.new(state.summary_types))
 
-  defp keep?(%{keep: nil}, _metadata), do: true
-  defp keep?(metric, metadata), do: metric.keep.(metadata)
+      result =
+        :ets.tab2list(state.table)
+        |> fill_map_from_path_tuples(result)
 
-  defp extract_measurement(metric, measurements, metadata) do
-    case metric.measurement do
-      fun when is_function(fun, 2) -> fun.(measurements, metadata)
-      fun when is_function(fun, 1) -> fun.(measurements)
-      key -> measurements[key]
+      result =
+        state.summary_types
+        |> Enum.map(&{elem(&1, 0), calculate_summary(&1, state.summary_table)})
+        |> fill_map_from_path_tuples(result)
+
+      deep_merge(result, state.static_info)
     end
-  end
 
-  @spec save_target_path_to_options(report_format()) :: [metric()]
-  defp save_target_path_to_options(report, prefix \\ []) when is_list(report) do
-    Enum.flat_map(report, fn
-      {k, v} when is_list(v) ->
-        save_target_path_to_options(v, prefix ++ [k])
-
-      {k, v} ->
-        if v.tags != [], do: raise("Call home reporter doesn't support splitting metrics by tags")
-
-        [
-          Map.update!(
-            v,
-            :reporter_options,
-            &Keyword.put(&1, :result_path, List.to_tuple(prefix ++ [k]))
+    defp clear_stats(state) do
+      for key <- state.all_paths -- state.persisted_paths do
+        table =
+          if(is_map_key(Map.new(state.summary_types), key),
+            do: state.summary_table,
+            else: state.table
           )
-        ]
-    end)
-  end
 
-  defp get_result_path(%{reporter_options: opts}), do: Keyword.fetch!(opts, :result_path)
+        :ets.delete(table, key)
+      end
 
-  def deep_merge(left, right) do
-    Map.merge(left, right, fn
-      _, %{} = l, %{} = r -> deep_merge(l, r)
-      _, _, r -> r
-    end)
+      state
+    end
+
+    defp calculate_summary({path, :count_unique}, table) do
+      :ets.lookup_element(table, path, 2)
+      |> Enum.uniq()
+      |> Enum.count()
+    rescue
+      ArgumentError -> 0
+    end
+
+    defp calculate_summary({path, :summary}, table) do
+      items = :ets.lookup_element(table, path, 2)
+
+      length = length(items)
+
+      {min, max} = Enum.min_max(items)
+
+      %{
+        min: min,
+        max: max,
+        mean: mean(items, length),
+        median: median(items, length),
+        mode: mode(items)
+      }
+    rescue
+      [ArgumentError, Enum.EmptyError, ArithmeticError] ->
+        # Enum.EmptyError may be raised when there are no elements in the ETS table under the key `path`
+        # ArithmeticError may be raised when an element in the ETS table is `nil`
+        @empty_summary
+    end
+
+    defp mean(elements, length), do: Enum.sum(elements) / length
+
+    defp median(elements, length) when rem(length, 2) == 1 do
+      Enum.at(elements, div(length, 2))
+    end
+
+    defp median(elements, length) when rem(length, 2) == 0 do
+      Enum.slice(elements, div(length, 2) - 1, 2) |> mean(length)
+    end
+
+    defp mode(elements), do: Enum.frequencies(elements) |> Enum.max_by(&elem(&1, 1)) |> elem(0)
+
+    defp empty_result(all_paths, summary_types) do
+      all_paths
+      |> Enum.map(fn path ->
+        case summary_types do
+          %{^path => :summary} -> {path, @empty_summary}
+          %{^path => :unique_count} -> {path, 0}
+          _ -> {path, 0}
+        end
+      end)
+      |> fill_map_from_path_tuples()
+    end
+
+    @spec fill_map_from_path_tuples([{tuple(), term()}], map()) :: map()
+    defp fill_map_from_path_tuples(tuples, into \\ %{}) do
+      Enum.reduce(tuples, into, fn {path, val}, acc ->
+        path = path |> Tuple.to_list() |> Enum.map(&Access.key(&1, %{}))
+        put_in(acc, path, val)
+      end)
+    end
+
+    @spec create_table(name :: atom, type :: atom) :: :ets.tid() | atom
+    defp create_table(name, type) do
+      :ets.new(name, [:named_table, :public, type, {:write_concurrency, true}])
+    end
+
+    def handle_event(_event_name, measurements, metadata, {metrics, context}) do
+      for %{reporter_options: opts} = metric <- metrics, keep?(metric, metadata) do
+        path = Keyword.fetch!(opts, :result_path)
+        measurement = extract_measurement(metric, measurements, metadata)
+
+        case metric do
+          %Metrics.Counter{} ->
+            :ets.update_counter(context.table, path, 1, {path, 0})
+
+          %Metrics.Sum{} ->
+            :ets.update_counter(context.table, path, measurement, {path, 0})
+
+          %Metrics.LastValue{} ->
+            :ets.insert(context.table, {path, measurement})
+
+          %Metrics.Summary{unit: :unique} ->
+            add_to_summary(path, context, metadata[Keyword.fetch!(opts, :count_unique)])
+
+          %Metrics.Summary{} ->
+            add_to_summary(path, context, measurement)
+        end
+      end
+    end
+
+    defp add_to_summary(path, %{summary_table: tbl}, value) do
+      :ets.insert(tbl, {path, value})
+    end
+
+    defp keep?(%{keep: nil}, _metadata), do: true
+    defp keep?(metric, metadata), do: metric.keep.(metadata)
+
+    defp extract_measurement(metric, measurements, metadata) do
+      case metric.measurement do
+        fun when is_function(fun, 2) -> fun.(measurements, metadata)
+        fun when is_function(fun, 1) -> fun.(measurements)
+        key -> measurements[key]
+      end
+    end
+
+    @spec save_target_path_to_options(report_format()) :: [metric()]
+    defp save_target_path_to_options(report, prefix \\ []) when is_list(report) do
+      Enum.flat_map(report, fn
+        {k, v} when is_list(v) ->
+          save_target_path_to_options(v, prefix ++ [k])
+
+        {k, v} ->
+          if v.tags != [],
+            do: raise("Call home reporter doesn't support splitting metrics by tags")
+
+          [
+            Map.update!(
+              v,
+              :reporter_options,
+              &Keyword.put(&1, :result_path, List.to_tuple(prefix ++ [k]))
+            )
+          ]
+      end)
+    end
+
+    defp get_result_path(%{reporter_options: opts}), do: Keyword.fetch!(opts, :result_path)
+
+    def deep_merge(left, right) do
+      Map.merge(left, right, fn
+        _, %{} = l, %{} = r -> deep_merge(l, r)
+        _, _, r -> r
+      end)
+    end
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/sampler.ex
+++ b/packages/sync-service/lib/electric/telemetry/sampler.ex
@@ -1,45 +1,50 @@
-defmodule Electric.Telemetry.Sampler do
-  @moduledoc """
-  Custom sampler that samples all spans except for specifically configured spans for which a given ratio is sampled.
-  """
+use Electric.Telemetry
 
-  require OpenTelemetry.Tracer, as: Tracer
+with_telemetry :otel_sampler do
+  defmodule Electric.Telemetry.Sampler do
+    @moduledoc """
+    Custom sampler that samples all spans except for specifically configured
+    spans for which a given ratio is sampled.
+    """
 
-  @behaviour :otel_sampler
+    require OpenTelemetry.Tracer, as: Tracer
 
-  # Span names that are sampled probabilistically
-  @probabilistic_span_names [
-    "pg_txn.replication_client.process_x_log_data"
-  ]
+    @behaviour :otel_sampler
 
-  @impl :otel_sampler
-  def setup(%{ratio: ratio}) do
-    %{sampling_probability: ratio}
-  end
+    # Span names that are sampled probabilistically
+    @probabilistic_span_names [
+      "pg_txn.replication_client.process_x_log_data"
+    ]
 
-  @impl :otel_sampler
-  def description(%{sampling_probability: sampling_probability}) do
-    "Custom sampler that samples all spans except for specifically configured spans for which #{sampling_probability * 100}% are sampled."
-  end
-
-  @impl true
-  def should_sample(ctx, _, _, span_name, _, _, state)
-      when span_name in @probabilistic_span_names do
-    if :rand.uniform() <= state.sampling_probability do
-      {:record_and_sample, [], tracestate(ctx)}
-    else
-      {:drop, [], tracestate(ctx)}
+    @impl :otel_sampler
+    def setup(%{ratio: ratio}) do
+      %{sampling_probability: ratio}
     end
-  end
 
-  @impl true
-  def should_sample(ctx, _trace_id, _links, _span_name, _span_kind, _attributes, _) do
-    {:record_and_sample, [], tracestate(ctx)}
-  end
+    @impl :otel_sampler
+    def description(%{sampling_probability: sampling_probability}) do
+      "Custom sampler that samples all spans except for specifically configured spans for which #{sampling_probability * 100}% are sampled."
+    end
 
-  defp tracestate(ctx) do
-    ctx
-    |> Tracer.current_span_ctx()
-    |> OpenTelemetry.Span.tracestate()
+    @impl true
+    def should_sample(ctx, _, _, span_name, _, _, state)
+        when span_name in @probabilistic_span_names do
+      if :rand.uniform() <= state.sampling_probability do
+        {:record_and_sample, [], tracestate(ctx)}
+      else
+        {:drop, [], tracestate(ctx)}
+      end
+    end
+
+    @impl true
+    def should_sample(ctx, _trace_id, _links, _span_name, _span_kind, _attributes, _) do
+      {:record_and_sample, [], tracestate(ctx)}
+    end
+
+    defp tracestate(ctx) do
+      ctx
+      |> Tracer.current_span_ctx()
+      |> OpenTelemetry.Span.tracestate()
+    end
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/sentry.ex
+++ b/packages/sync-service/lib/electric/telemetry/sentry.ex
@@ -1,12 +1,23 @@
 defmodule Electric.Telemetry.Sentry do
-  def add_logger_handler do
-    :logger.add_handler(:electric_sentry_handler, Sentry.LoggerHandler, %{
-      config: %{metadata: :all, capture_log_messages: true, level: :error}
-    })
+  use Electric.Telemetry
+
+  with_telemetry Sentry.LoggerHandler do
+    def add_logger_handler do
+      :logger.add_handler(:electric_sentry_handler, Sentry.LoggerHandler, %{
+        config: %{metadata: :all, capture_log_messages: true, level: :error}
+      })
+    end
+  else
+    def add_logger_handler, do: :ok
   end
 
   @spec set_tags_context(keyword()) :: :ok
-  def set_tags_context(tags) do
-    Sentry.Context.set_tags_context(Map.new(tags))
+
+  with_telemetry Sentry.Context do
+    def set_tags_context(tags) do
+      Sentry.Context.set_tags_context(Map.new(tags))
+    end
+  else
+    def set_tags_context(_tags), do: :ok
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/sentry_req_http_client.ex
+++ b/packages/sync-service/lib/electric/telemetry/sentry_req_http_client.ex
@@ -1,17 +1,21 @@
-defmodule Electric.Telemetry.SentryReqHTTPClient do
-  @moduledoc """
-  A custom Sentry HTTP client implementation using Req.
-  """
-  @behaviour Sentry.HTTPClient
+use Electric.Telemetry
 
-  @impl true
-  def post(url, headers, body) do
-    case Req.post(url, headers: headers, body: body, decode_body: false) do
-      {:ok, %Req.Response{status: status, headers: headers, body: body}} ->
-        {:ok, status, headers |> Enum.into([], fn {k, [v]} -> {k, v} end), body}
+with_telemetry Sentry.HTTPClient do
+  defmodule Electric.Telemetry.SentryReqHTTPClient do
+    @moduledoc """
+    A custom Sentry HTTP client implementation using Req.
+    """
+    @behaviour Sentry.HTTPClient
 
-      {:error, error} ->
-        {:error, error}
+    @impl true
+    def post(url, headers, body) do
+      case Req.post(url, headers: headers, body: body, decode_body: false) do
+        {:ok, %Req.Response{status: status, headers: headers, body: body}} ->
+          {:ok, status, headers |> Enum.into([], fn {k, [v]} -> {k, v} end), body}
+
+        {:error, error} ->
+          {:error, error}
+      end
     end
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
@@ -1,278 +1,286 @@
-defmodule Electric.Telemetry.StackTelemetry do
-  @moduledoc """
-  Collects and exports stack level telemetry such as database and shape metrics.
+use Electric.Telemetry
 
-  If multiple databases are used, each database will have it's own stack and it's own StackTelemetry.
+with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
+  defmodule Electric.Telemetry.StackTelemetry do
+    @moduledoc """
+    Collects and exports stack level telemetry such as database and shape metrics.
 
-  See also ApplicationTelemetry for application/system level specific telemetry.
-  """
-  use Supervisor
+    If multiple databases are used, each database will have it's own stack and it's own StackTelemetry.
 
-  import Telemetry.Metrics
+    See also ApplicationTelemetry for application/system level specific telemetry.
+    """
+    use Supervisor
 
-  require Logger
+    import Telemetry.Metrics
 
-  @opts_schema NimbleOptions.new!(
-                 Electric.Telemetry.Opts.schema() ++
-                   [
-                     stack_id: [type: :string, required: true],
-                     storage: [type: :mod_arg, required: true]
-                   ]
-               )
+    require Logger
 
-  def start_link(opts) do
-    with {:ok, opts} <- NimbleOptions.validate(opts, @opts_schema) do
-      if telemetry_export_enabled?(Map.new(opts)) do
-        Supervisor.start_link(__MODULE__, Map.new(opts))
-      else
-        # Avoid starting the telemetry supervisor and its telemetry_poller child if we're not
-        # intending to export periodic measurements metrics anywhere.
-        :ignore
+    @opts_schema NimbleOptions.new!(
+                   Electric.Telemetry.Opts.schema() ++
+                     [
+                       stack_id: [type: :string, required: true],
+                       storage: [type: :mod_arg, required: true]
+                     ]
+                 )
+
+    def start_link(opts) do
+      with {:ok, opts} <- NimbleOptions.validate(opts, @opts_schema) do
+        if telemetry_export_enabled?(Map.new(opts)) do
+          Supervisor.start_link(__MODULE__, Map.new(opts))
+        else
+          # Avoid starting the telemetry supervisor and its telemetry_poller child if we're not
+          # intending to export periodic measurements metrics anywhere.
+          :ignore
+        end
       end
     end
-  end
 
-  def init(opts) do
-    Process.set_label({:stack_telemetry_supervisor, opts.stack_id})
+    def init(opts) do
+      Process.set_label({:stack_telemetry_supervisor, opts.stack_id})
 
-    [telemetry_poller_child_spec(opts) | exporter_child_specs(opts)]
-    |> Supervisor.init(strategy: :one_for_one)
-  end
+      [telemetry_poller_child_spec(opts) | exporter_child_specs(opts)]
+      |> Supervisor.init(strategy: :one_for_one)
+    end
 
-  defp telemetry_poller_child_spec(opts) do
-    # The telemetry_poller application starts its own poller by default but we disable that
-    # and add its default measurements to the list of our custom ones. This allows for all
-    # periodic measurements to be defined in one place.
-    {:telemetry_poller,
-     measurements: periodic_measurements(opts),
-     period: opts.system_metrics_poll_interval,
-     init_delay: :timer.seconds(3)}
-  end
+    defp telemetry_poller_child_spec(opts) do
+      # The telemetry_poller application starts its own poller by default but we disable that
+      # and add its default measurements to the list of our custom ones. This allows for all
+      # periodic measurements to be defined in one place.
+      {:telemetry_poller,
+       measurements: periodic_measurements(opts),
+       period: opts.system_metrics_poll_interval,
+       init_delay: :timer.seconds(3)}
+    end
 
-  defp telemetry_export_enabled?(opts) do
-    exporter_child_specs(opts) != []
-  end
+    defp telemetry_export_enabled?(opts) do
+      exporter_child_specs(opts) != []
+    end
 
-  defp exporter_child_specs(opts) do
-    [
-      statsd_reporter_child_spec(opts),
-      prometheus_reporter_child_spec(opts),
-      call_home_reporter_child_spec(opts),
-      otel_reporter_child_spec(opts)
-    ]
-    |> Enum.reject(&is_nil/1)
-  end
-
-  defp otel_reporter_child_spec(%{otel_metrics?: true} = opts) do
-    {OtelMetricExporter,
-     name: :"stack_otel_telemetry_#{opts.stack_id}",
-     metrics: otel_metrics(opts),
-     export_period: :timer.seconds(30),
-     resource: %{source_id: opts.stack_id}}
-  end
-
-  defp otel_reporter_child_spec(_), do: nil
-
-  defp call_home_reporter_child_spec(%{call_home_telemetry?: true} = opts) do
-    {Electric.Telemetry.CallHomeReporter,
-     name: :"stack_call_home_telemetry_#{opts.stack_id}",
-     static_info: static_info(opts),
-     metrics: call_home_metrics(opts),
-     first_report_in: {2, :minute},
-     reporting_period: {30, :minute}}
-  end
-
-  defp call_home_reporter_child_spec(_), do: nil
-
-  def static_info(opts) do
-    {total_mem, _, _} = :memsup.get_memory_data()
-    processors = :erlang.system_info(:logical_processors)
-    {os_family, os_name} = :os.type()
-    arch = :erlang.system_info(:system_architecture)
-
-    %{
-      electric_version: to_string(Electric.version()),
-      environment: %{
-        os: %{family: os_family, name: os_name},
-        arch: to_string(arch),
-        cores: processors,
-        ram: total_mem,
-        electric_instance_id: Electric.instance_id(),
-        stack_id: opts.stack_id
-      }
-    }
-  end
-
-  # IMPORTANT: these metrics are validated on the receiver side, so if you change them,
-  #            make sure you also change the receiver
-  def call_home_metrics(opts) do
-    for_stack = for_stack(opts)
-
-    [
-      environment: [
-        pg_version:
-          last_value("electric.postgres.info_looked_up.pg_version",
-            reporter_options: [persist_between_sends: true],
-            keep: for_stack
-          )
-      ],
-      usage: [
-        inbound_bytes:
-          sum("electric.postgres.replication.transaction_received.bytes",
-            unit: :byte,
-            keep: for_stack
-          ),
-        inbound_transactions:
-          sum("electric.postgres.replication.transaction_received.count", keep: for_stack),
-        inbound_operations:
-          sum("electric.postgres.replication.transaction_received.operations", keep: for_stack),
-        stored_bytes:
-          sum("electric.storage.transaction_stored.bytes", unit: :byte, keep: for_stack),
-        stored_transactions: sum("electric.storage.transaction_stored.count", keep: for_stack),
-        stored_operations: sum("electric.storage.transaction_stored.operations", keep: for_stack),
-        total_used_storage_kb:
-          last_value("electric.storage.used", unit: {:byte, :kilobyte}, keep: for_stack),
-        total_shapes: last_value("electric.shapes.total_shapes.count", keep: for_stack),
-        active_shapes:
-          summary("electric.plug.serve_shape.monotonic_time",
-            unit: :unique,
-            reporter_options: [count_unique: :shape_handle],
-            keep: &(&1.status < 300 && for_stack.(&1))
-          ),
-        unique_clients:
-          summary("electric.plug.serve_shape.monotonic_time",
-            unit: :unique,
-            reporter_options: [count_unique: :client_ip],
-            keep: &(&1.status < 300 && for_stack.(&1))
-          ),
-        sync_requests:
-          counter("electric.plug.serve_shape.monotonic_time",
-            keep: &(&1[:live] != true && for_stack.(&1))
-          ),
-        live_requests:
-          counter("electric.plug.serve_shape.monotonic_time",
-            keep: &(&1[:live] && for_stack.(&1))
-          ),
-        served_bytes: sum("electric.plug.serve_shape.bytes", unit: :byte, keep: for_stack),
-        wal_size: summary("electric.postgres.replication.wal_size", unit: :byte, keep: for_stack)
+    defp exporter_child_specs(opts) do
+      [
+        statsd_reporter_child_spec(opts),
+        prometheus_reporter_child_spec(opts),
+        call_home_reporter_child_spec(opts),
+        otel_reporter_child_spec(opts)
       ]
-    ]
-  end
+      |> Enum.reject(&is_nil/1)
+    end
 
-  defp statsd_reporter_child_spec(%{statsd_host: host} = opts) when host != nil do
-    {TelemetryMetricsStatsd,
-     host: host,
-     formatter: :datadog,
-     global_tags: [instance_id: opts.instance_id],
-     metrics: statsd_metrics(opts)}
-  end
+    defp otel_reporter_child_spec(%{otel_metrics?: true} = opts) do
+      {OtelMetricExporter,
+       name: :"stack_otel_telemetry_#{opts.stack_id}",
+       metrics: otel_metrics(opts),
+       export_period: :timer.seconds(30),
+       resource: %{stack_id: opts.stack_id}}
+    end
 
-  defp statsd_reporter_child_spec(_), do: nil
+    defp otel_reporter_child_spec(_), do: nil
 
-  defp prometheus_reporter_child_spec(%{prometheus?: true} = opts) do
-    {TelemetryMetricsPrometheus.Core,
-     name: :"stack_prometheus_telemetry_#{opts.stack_id}", metrics: prometheus_metrics(opts)}
-  end
+    defp call_home_reporter_child_spec(%{call_home_telemetry?: true} = opts) do
+      {Electric.Telemetry.CallHomeReporter,
+       name: :"stack_call_home_telemetry_#{opts.stack_id}",
+       static_info: static_info(opts),
+       metrics: call_home_metrics(opts),
+       first_report_in: {2, :minute},
+       reporting_period: {30, :minute}}
+    end
 
-  defp prometheus_reporter_child_spec(_), do: nil
+    defp call_home_reporter_child_spec(_), do: nil
 
-  defp statsd_metrics(opts) do
-    [
-      summary("plug.router_dispatch.stop.duration",
-        tags: [:route],
-        unit: {:native, :millisecond},
-        keep: for_stack(opts)
-      ),
-      summary("plug.router_dispatch.exception.duration",
-        tags: [:route],
-        unit: {:native, :millisecond},
-        keep: for_stack(opts)
-      ),
-      summary("electric.shape_cache.create_snapshot_task.stop.duration",
-        unit: {:native, :millisecond},
-        keep: for_stack(opts)
-      ),
-      summary("electric.storage.make_new_snapshot.stop.duration",
-        unit: {:native, :millisecond},
-        keep: for_stack(opts)
-      ),
-      summary("electric.querying.stream_initial_data.stop.duration",
-        unit: {:native, :millisecond},
-        keep: for_stack(opts)
+    def static_info(opts) do
+      {total_mem, _, _} = :memsup.get_memory_data()
+      processors = :erlang.system_info(:logical_processors)
+      {os_family, os_name} = :os.type()
+      arch = :erlang.system_info(:system_architecture)
+
+      %{
+        electric_version: to_string(Electric.version()),
+        environment: %{
+          os: %{family: os_family, name: os_name},
+          arch: to_string(arch),
+          cores: processors,
+          ram: total_mem,
+          electric_instance_id: Electric.instance_id(),
+          stack_id: opts.stack_id
+        }
+      }
+    end
+
+    # IMPORTANT: these metrics are validated on the receiver side, so if you change them,
+    #            make sure you also change the receiver
+    def call_home_metrics(opts) do
+      for_stack = for_stack(opts)
+
+      [
+        environment: [
+          pg_version:
+            last_value("electric.postgres.info_looked_up.pg_version",
+              reporter_options: [persist_between_sends: true],
+              keep: for_stack
+            )
+        ],
+        usage: [
+          inbound_bytes:
+            sum("electric.postgres.replication.transaction_received.bytes",
+              unit: :byte,
+              keep: for_stack
+            ),
+          inbound_transactions:
+            sum("electric.postgres.replication.transaction_received.count", keep: for_stack),
+          inbound_operations:
+            sum("electric.postgres.replication.transaction_received.operations", keep: for_stack),
+          stored_bytes:
+            sum("electric.storage.transaction_stored.bytes", unit: :byte, keep: for_stack),
+          stored_transactions: sum("electric.storage.transaction_stored.count", keep: for_stack),
+          stored_operations:
+            sum("electric.storage.transaction_stored.operations", keep: for_stack),
+          total_used_storage_kb:
+            last_value("electric.storage.used", unit: {:byte, :kilobyte}, keep: for_stack),
+          total_shapes: last_value("electric.shapes.total_shapes.count", keep: for_stack),
+          active_shapes:
+            summary("electric.plug.serve_shape.monotonic_time",
+              unit: :unique,
+              reporter_options: [count_unique: :shape_handle],
+              keep: &(&1.status < 300 && for_stack.(&1))
+            ),
+          unique_clients:
+            summary("electric.plug.serve_shape.monotonic_time",
+              unit: :unique,
+              reporter_options: [count_unique: :client_ip],
+              keep: &(&1.status < 300 && for_stack.(&1))
+            ),
+          sync_requests:
+            counter("electric.plug.serve_shape.monotonic_time",
+              keep: &(&1[:live] != true && for_stack.(&1))
+            ),
+          live_requests:
+            counter("electric.plug.serve_shape.monotonic_time",
+              keep: &(&1[:live] && for_stack.(&1))
+            ),
+          served_bytes: sum("electric.plug.serve_shape.bytes", unit: :byte, keep: for_stack),
+          wal_size:
+            summary("electric.postgres.replication.wal_size", unit: :byte, keep: for_stack)
+        ]
+      ]
+    end
+
+    defp statsd_reporter_child_spec(%{statsd_host: host} = opts) when host != nil do
+      {TelemetryMetricsStatsd,
+       host: host,
+       formatter: :datadog,
+       global_tags: [instance_id: opts.instance_id],
+       metrics: statsd_metrics(opts)}
+    end
+
+    defp statsd_reporter_child_spec(_), do: nil
+
+    defp prometheus_reporter_child_spec(%{prometheus?: true} = opts) do
+      {TelemetryMetricsPrometheus.Core,
+       name: :"stack_prometheus_telemetry_#{opts.stack_id}", metrics: prometheus_metrics(opts)}
+    end
+
+    defp prometheus_reporter_child_spec(_), do: nil
+
+    defp statsd_metrics(opts) do
+      [
+        summary("plug.router_dispatch.stop.duration",
+          tags: [:route],
+          unit: {:native, :millisecond},
+          keep: for_stack(opts)
+        ),
+        summary("plug.router_dispatch.exception.duration",
+          tags: [:route],
+          unit: {:native, :millisecond},
+          keep: for_stack(opts)
+        ),
+        summary("electric.shape_cache.create_snapshot_task.stop.duration",
+          unit: {:native, :millisecond},
+          keep: for_stack(opts)
+        ),
+        summary("electric.storage.make_new_snapshot.stop.duration",
+          unit: {:native, :millisecond},
+          keep: for_stack(opts)
+        ),
+        summary("electric.querying.stream_initial_data.stop.duration",
+          unit: {:native, :millisecond},
+          keep: for_stack(opts)
+        )
+      ]
+      |> Enum.map(&%{&1 | tags: [:instance_id | &1.tags]})
+    end
+
+    defp prometheus_metrics(opts) do
+      [
+        last_value("electric.postgres.replication.wal_size", unit: :byte, keep: for_stack(opts)),
+        last_value("electric.storage.used", unit: {:byte, :kilobyte}, keep: for_stack(opts)),
+        last_value("electric.shapes.total_shapes.count", keep: for_stack(opts)),
+        last_value("electric.postgres.replication.wal_size", unit: :byte, keep: for_stack(opts)),
+        counter("electric.postgres.replication.transaction_received.count", keep: for_stack(opts)),
+        sum("electric.postgres.replication.transaction_received.bytes",
+          unit: :byte,
+          keep: for_stack(opts)
+        ),
+        sum("electric.storage.transaction_stored.bytes", unit: :byte, keep: for_stack(opts))
+      ]
+    end
+
+    defp otel_metrics(opts) do
+      for_stack = for_stack(opts)
+
+      [
+        distribution("electric.plug.serve_shape.duration",
+          keep: &(&1[:live] != true && for_stack.(&1))
+        ),
+        distribution("electric.shape_cache.create_snapshot_task.stop.duration",
+          unit: {:native, :millisecond},
+          keep: for_stack
+        ),
+        distribution("electric.storage.make_new_snapshot.stop.duration",
+          unit: {:native, :millisecond},
+          keep: for_stack
+        )
+      ] ++ prometheus_metrics(opts)
+    end
+
+    defp periodic_measurements(opts) do
+      [
+        {__MODULE__, :count_shapes, [opts.stack_id]},
+        {__MODULE__, :get_total_disk_usage, [opts]},
+        {Electric.Connection.Manager, :report_retained_wal_size,
+         [Electric.Connection.Manager.name(opts.stack_id)]}
+      ]
+    end
+
+    def count_shapes(stack_id) do
+      Electric.ShapeCache.list_shapes(stack_id: stack_id)
+      |> length()
+      |> then(
+        &:telemetry.execute([:electric, :shapes, :total_shapes], %{count: &1}, %{
+          stack_id: stack_id
+        })
       )
-    ]
-    |> Enum.map(&%{&1 | tags: [:instance_id | &1.tags]})
-  end
+    end
 
-  defp prometheus_metrics(opts) do
-    [
-      last_value("electric.postgres.replication.wal_size", unit: :byte, keep: for_stack(opts)),
-      last_value("electric.storage.used", unit: {:byte, :kilobyte}, keep: for_stack(opts)),
-      last_value("electric.shapes.total_shapes.count", keep: for_stack(opts)),
-      last_value("electric.postgres.replication.wal_size", unit: :byte, keep: for_stack(opts)),
-      counter("electric.postgres.replication.transaction_received.count", keep: for_stack(opts)),
-      sum("electric.postgres.replication.transaction_received.bytes",
-        unit: :byte,
-        keep: for_stack(opts)
-      ),
-      sum("electric.storage.transaction_stored.bytes", unit: :byte, keep: for_stack(opts))
-    ]
-  end
+    def get_total_disk_usage(opts) do
+      storage = Electric.StackSupervisor.storage_mod_arg(opts)
 
-  defp otel_metrics(opts) do
-    for_stack = for_stack(opts)
-
-    [
-      distribution("electric.plug.serve_shape.duration",
-        keep: &(&1[:live] != true && for_stack.(&1))
-      ),
-      distribution("electric.shape_cache.create_snapshot_task.stop.duration",
-        unit: {:native, :millisecond},
-        keep: for_stack
-      ),
-      distribution("electric.storage.make_new_snapshot.stop.duration",
-        unit: {:native, :millisecond},
-        keep: for_stack
+      Electric.ShapeCache.Storage.get_total_disk_usage(storage)
+      |> then(
+        &:telemetry.execute([:electric, :storage], %{used: &1}, %{
+          stack_id: opts[:stack_id]
+        })
       )
-    ] ++ prometheus_metrics(opts)
-  end
+    catch
+      :exit, {:noproc, _} ->
+        :ok
+    end
 
-  defp periodic_measurements(opts) do
-    [
-      {__MODULE__, :count_shapes, [opts.stack_id]},
-      {__MODULE__, :get_total_disk_usage, [opts]},
-      {Electric.Connection.Manager, :report_retained_wal_size,
-       [Electric.Connection.Manager.name(opts.stack_id)]}
-    ]
-  end
+    def for_stack(opts) do
+      stack_id = opts.stack_id
 
-  def count_shapes(stack_id) do
-    Electric.ShapeCache.list_shapes(stack_id: stack_id)
-    |> length()
-    |> then(
-      &:telemetry.execute([:electric, :shapes, :total_shapes], %{count: &1}, %{stack_id: stack_id})
-    )
-  end
-
-  def get_total_disk_usage(opts) do
-    storage = Electric.StackSupervisor.storage_mod_arg(opts)
-
-    Electric.ShapeCache.Storage.get_total_disk_usage(storage)
-    |> then(
-      &:telemetry.execute([:electric, :storage], %{used: &1}, %{
-        stack_id: opts[:stack_id]
-      })
-    )
-  catch
-    :exit, {:noproc, _} ->
-      :ok
-  end
-
-  def for_stack(opts) do
-    stack_id = opts.stack_id
-
-    fn metadata ->
-      metadata[:stack_id] == stack_id
+      fn metadata ->
+        metadata[:stack_id] == stack_id
+      end
     end
   end
 end


### PR DESCRIPTION

configure telemetry dependencies to only be included when building the `application` target and do compile-time checks to exclude certain modules when compiling without telemetry

uses both checks against Mix.target() and checks for the presence of dependent modules to make compilation and runtime robust when running as docker application, local dev server and when used as a dependency

having said that, a better solution would be to move the telemetry to a separate library and have it included when needed but this solves the main problem of un-wanted telemetry dependencies being included (and needing configuration) when electric is included as a dependency