### PR TITLE
feat(sync-service): Add option to send memory metrics per process type

### DIFF
--- a/.changeset/modern-chicken-juggle.md
+++ b/.changeset/modern-chicken-juggle.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add option to send memory metrics per process type

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -214,6 +214,13 @@ system_metrics_poll_interval =
     nil
   )
 
+otel_export_period =
+  env!(
+    "ELECTRIC_OTEL_EXPORT_PERIOD",
+    &Electric.Config.parse_human_readable_time!/1,
+    nil
+  )
+
 # The provided database id is relevant if you had used v0.8 and want to keep the storage
 # instead of having hanging files. We use a provided value as stack id, but nothing else.
 provided_database_id = env!("ELECTRIC_DATABASE_ID", :string, nil)
@@ -229,6 +236,9 @@ config :electric,
   call_home_telemetry?: env!("ELECTRIC_USAGE_REPORTING", :boolean, config_env() == :prod),
   telemetry_url: call_home_telemetry_url,
   system_metrics_poll_interval: system_metrics_poll_interval,
+  otel_export_period: otel_export_period,
+  otel_per_process_metrics?: env!("ELECTRIC_OTEL_PER_PROCESS_METRICS", :boolean, nil),
+  telemetry_top_process_count: env!("ELECTRIC_TELEMETRY_TOP_PROCESS_COUNT", :integer, nil),
   telemetry_statsd_host: statsd_host,
   prometheus_port: prometheus_port,
   db_pool_size: env!("ELECTRIC_DB_POOL_SIZE", :integer, nil),

--- a/packages/sync-service/lib/debug/process.ex
+++ b/packages/sync-service/lib/debug/process.ex
@@ -1,0 +1,67 @@
+defmodule Debug.Process do
+  def top_memory_by_type(count \\ 5) do
+    Process.list()
+    |> Enum.map(&type_and_memory/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.group_by(& &1.type, & &1.memory)
+    |> Enum.map(fn {type, memory} -> %{type: type, memory: Enum.sum(memory)} end)
+    |> Enum.sort_by(&(-&1.memory))
+    |> Enum.take(count)
+  end
+
+  defp type_and_memory(pid) do
+    with [memory: memory] <- Process.info(pid, [:memory]),
+         type when type != :dead <- type(pid) do
+      %{type: type, memory: memory}
+    end
+  end
+
+  def type(pid) do
+    with :error <- process_type_if_dead(pid),
+         :error <- process_label(pid),
+         :error <- initial_module(pid) do
+      :unknown
+    end
+  end
+
+  defp process_type_if_dead(pid) do
+    if Process.alive?(pid) do
+      :error
+    else
+      :dead
+    end
+  end
+
+  defp process_label(pid) do
+    case :proc_lib.get_label(pid) do
+      :undefined -> :error
+      {name, _} -> name
+      {name, _, _} -> name
+      name when is_atom(name) -> name
+      name when is_binary(name) -> name
+      _ -> :error
+    end
+  end
+
+  defp initial_module(pid) do
+    [dictionary: dictionary] = Process.info(pid, [:dictionary])
+
+    dictionary
+    |> Map.new()
+    |> Map.get(:"$initial_call")
+    |> case do
+      {module, _function, _arg_count} ->
+        module
+
+      _ ->
+        initial_module_from_info(pid)
+    end
+  end
+
+  defp initial_module_from_info(pid) do
+    case Process.info(pid, [:initial_call]) do
+      [initial_call: {module, _function, _arg_count}] -> module
+      nil -> :error
+    end
+  end
+end

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -254,7 +254,10 @@ defmodule Electric.Application do
       statsd_host: get_env(opts, :telemetry_statsd_host),
       prometheus?: not is_nil(get_env(opts, :prometheus_port)),
       call_home_telemetry?: get_env(opts, :call_home_telemetry?),
-      otel_metrics?: not is_nil(Application.get_env(:otel_metric_exporter, :otlp_endpoint))
+      otel_metrics?: not is_nil(Application.get_env(:otel_metric_exporter, :otlp_endpoint)),
+      otel_export_period: get_env(opts, :otel_export_period),
+      otel_per_process_metrics?: get_env(opts, :otel_per_process_metrics?),
+      top_process_count: get_env(opts, :telemetry_top_process_count)
     ]
   end
 end

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -59,6 +59,9 @@ defmodule Electric.Config do
     telemetry_statsd_host: nil,
     telemetry_url: URI.new!("https://checkpoint.electric-sql.com"),
     system_metrics_poll_interval: :timer.seconds(5),
+    otel_export_period: :timer.seconds(30),
+    otel_per_process_metrics?: false,
+    telemetry_top_process_count: 5,
     ## Memory
     shape_hibernate_after: :timer.seconds(30)
   ]

--- a/packages/sync-service/lib/electric/telemetry/opts.ex
+++ b/packages/sync-service/lib/electric/telemetry/opts.ex
@@ -6,7 +6,10 @@ defmodule Electric.Telemetry.Opts do
       statsd_host: [type: {:or, [:string, nil]}, default: nil],
       prometheus?: [type: :boolean, default: false],
       call_home_telemetry?: [type: :boolean, default: false],
-      otel_metrics?: [type: :boolean, default: false]
+      otel_metrics?: [type: :boolean, default: false],
+      otel_export_period: [type: :integer, default: :timer.seconds(30)],
+      otel_per_process_metrics?: [type: :boolean, default: false],
+      top_process_count: [type: :integer, default: 5]
     ]
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
@@ -70,7 +70,7 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
       {OtelMetricExporter,
        name: :"stack_otel_telemetry_#{opts.stack_id}",
        metrics: otel_metrics(opts),
-       export_period: :timer.seconds(30),
+       export_period: opts.otel_export_period,
        resource: %{stack_id: opts.stack_id}}
     end
 


### PR DESCRIPTION
Adds ability to send metrics to Honeycomb that break down process memory use by process type. 

This is optional telemetry as it creates a significant amount of extra chargeable metric units in Honeycomb. It's off by default but can be turned on with `ELECTRIC_OTEL_PER_PROCESS_METRICS=true` and the amount of chargeable metric units reduced by reducing `ELECTRIC_OTEL_EXPORT_PERIOD` and `ELECTRIC_TELEMETRY_TOP_PROCESS_COUNT`.

<img width="911" alt="Screenshot 2025-03-03 at 13 37 45" src="https://github.com/user-attachments/assets/d51d2819-763e-48ce-8a75-f07391773383" />
