### PR TITLE
Fix timestampz typo

### DIFF
--- a/packages/typescript-client/test/client.test-d.ts
+++ b/packages/typescript-client/test/client.test-d.ts
@@ -46,7 +46,7 @@ describe(`client`, () => {
           table: ``,
         },
         parser: {
-          timestampz: (date: string) => {
+          timestamptz: (date: string) => {
             return new Date(date)
           },
         },
@@ -124,7 +124,7 @@ describe(`client`, () => {
           table: ``,
         },
         parser: {
-          timestampz: (date: string) => {
+          timestamptz: (date: string) => {
             return new Date(date)
           },
         },

--- a/website/docs/api/clients/typescript.md
+++ b/website/docs/api/clients/typescript.md
@@ -298,7 +298,7 @@ const stream = new ShapeStream<CustomRow>({
   },
   parser: {
     // Parse timestamp columns into JavaScript Date objects
-    timestampz: (date: string) => new Date(date)
+    timestamptz: (date: string) => new Date(date)
   }
 })
 


### PR DESCRIPTION
I copy/pasted this from the docs and was stumped for a while why things weren't working