### PR TITLE
fix: make blog post publication date update on navigation

### DIFF
--- a/website/src/components/BlogPostHeader.vue
+++ b/website/src/components/BlogPostHeader.vue
@@ -1,12 +1,15 @@
 <script setup>
 import { useData } from 'vitepress'
+import { computed } from 'vue'
 
 import { data as authors } from '../../data/authors.data.ts'
 
 const { page, frontmatter } = useData()
 
-const parts = page._value.filePath.split('blog/posts/')[1].split('-')
-const postDate = `${parts[0]}-${parts[1]}-${parts[2]}`
+const postDate = computed(() => {
+  const parts = page.value.filePath.split("blog/posts/")[1].split("-")
+  return `${parts[0]}-${parts[1]}-${parts[2]}`
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
I noticed that the publication dates on the blog posts were not updated correctly on navigation.

The date loads correctly on the first page, but is not updated on navigation.

**Reproduction**:

1. Go to https://electric-sql.com/blog/2022/05/03/introducing-rich-crdts
See this:
![image](https://github.com/user-attachments/assets/b8cbe892-45e1-4a80-849e-722cda3f45d3)

2. Navigate to the first blog post in the list, see this:
![image](https://github.com/user-attachments/assets/f73a0708-ea96-4c5d-96c5-b0087dffb7a2)