### PR TITLE
Generate and store installation_id to maintain metric continuity between restarts

### DIFF
--- a/integration-tests/scripts/electric_dev.sh
+++ b/integration-tests/scripts/electric_dev.sh
@@ -5,4 +5,12 @@ set -e
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 cd "$SCRIPT_DIR"/../../packages/sync-service
-ELECTRIC_STORAGE_DIR="$SCRIPT_DIR/../_storage" ELECTRIC_REPLICATION_STREAM_ID=integration iex -S mix
+
+# Until https://github.com/electric-sql/electric/issues/2415 is fixed,
+# both ELECTRIC_PERSISTENT_STATE and ELECTRIC_STORAGE configs must be set explicitly
+# for Electric to use the configured ELECTRIC_STORAGE_DIR.
+ELECTRIC_STORAGE_DIR="$SCRIPT_DIR/../_storage" \
+ELECTRIC_PERSISTENT_STATE=file \
+ELECTRIC_STORAGE=file \
+ELECTRIC_REPLICATION_STREAM_ID=integration \
+iex -S mix

--- a/integration-tests/tests/installation-id-persistence.lux
+++ b/integration-tests/tests/installation-id-persistence.lux
@@ -1,0 +1,57 @@
+[doc Verify that an installation ID is generate on first launch and is then persisted across service restarts]
+
+[include _macros.luxinc]
+
+[global pg_container_name=installation-id-persistence__pg]
+
+###
+
+# Start a new Postgres cluster
+[invoke setup_pg "" ""]
+
+# Start the sync service.
+[invoke setup_electric]
+
+[shell electric]
+  ??[info] Starting replication from postgres
+
+  !instance_id = Electric.instance_id()
+  ?"([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})"
+  [my instance_id=$1]
+
+  !{m, f, a} = Electric.Config.get_env(:persistent_kv)
+  !kv = apply(m, f, [a])
+  !installation_id = Electric.Config.installation_id!(kv)
+  ?"([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})"
+  [my installation_id=$1]
+
+  !instance_id == installation_id
+  ??true
+
+# Terminate electric
+[shell electric]
+  !System.halt()
+  ??$PS1
+
+# Start the sync service again.
+[invoke setup_electric]
+
+[shell electric]
+  ??[info] Starting replication from postgres
+
+  # Verify the same installation ID is retained, even though the instance ID has changed
+  !{m, f, a} = Electric.Config.get_env(:persistent_kv)
+  !kv = apply(m, f, [a])
+  !installation_id = Electric.Config.installation_id!(kv)
+
+  !">> installation_id = #{installation_id}"
+  ??>> installation_id = $installation_id
+
+  !Electric.instance_id() == installation_id
+  ??false
+
+  !Electric.instance_id() == "$instance_id"
+  ??false
+
+[cleanup]
+  [invoke teardown]

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -41,7 +41,8 @@ if !is_nil(sentry_dsn) do
     dsn: sentry_dsn
 end
 
-# Disable the default telemetry_poller process since we start our own in `Electric.Telemetry`.
+# Disable the default telemetry_poller process since we start our own in
+# `Electric.Telemetry.{ApplicationTelemetry, StackTelemetry}`.
 config :telemetry_poller, default: false
 
 service_name = env!("ELECTRIC_SERVICE_NAME", :string, "electric")

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -66,6 +66,8 @@ defmodule Electric.Config do
     shape_hibernate_after: :timer.seconds(30)
   ]
 
+  @installation_id_key "electric_installation_id"
+
   def default(key) do
     case Keyword.fetch!(@defaults, key) do
       fun when is_function(fun, 0) -> fun.()
@@ -85,13 +87,39 @@ defmodule Electric.Config do
         Logger.info("Setting electric instance_id: #{instance_id}")
         Application.put_env(:electric, :instance_id, instance_id)
 
+        instance_id
+
       id when is_binary(id) ->
-        :ok
+        id
     end
   end
 
   defp generate_instance_id do
     Electric.Utils.uuid4()
+  end
+
+  @spec ensure_installation_id(keyword, binary) :: :ok
+  # the installation id is persisted to disk to remain the same between restarts of the sync service
+  def ensure_installation_id(config, instance_id)
+      when is_list(config) and is_binary(instance_id) do
+    kv = Keyword.fetch!(config, :persistent_kv)
+
+    case Electric.PersistentKV.get(kv, @installation_id_key) do
+      {:ok, id} when is_binary(id) ->
+        id
+
+      {:error, :not_found} ->
+        :ok = Electric.PersistentKV.set(kv, @installation_id_key, instance_id)
+        instance_id
+    end
+  end
+
+  @spec installation_id!(term) :: binary | no_return
+  def installation_id!(kv) do
+    case Electric.PersistentKV.get(kv, @installation_id_key) do
+      {:ok, id} when is_binary(id) -> id
+      {:error, :not_found} -> raise "Electric's installation_id not set"
+    end
   end
 
   @spec get_env(Application.key()) :: Application.value()

--- a/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
@@ -61,9 +61,9 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
 
     defp otel_reporter_child_spec(_), do: nil
 
-    defp call_home_reporter_child_spec(%{call_home_telemetry?: true}) do
+    defp call_home_reporter_child_spec(%{call_home_telemetry?: true} = opts) do
       {Electric.Telemetry.CallHomeReporter,
-       static_info: static_info(),
+       static_info: static_info(opts),
        metrics: call_home_metrics(),
        first_report_in: {2, :minute},
        reporting_period: {30, :minute}}
@@ -71,7 +71,7 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
 
     defp call_home_reporter_child_spec(_), do: nil
 
-    def static_info() do
+    defp static_info(opts) do
       {total_mem, _, _} = :memsup.get_memory_data()
       processors = :erlang.system_info(:logical_processors)
       {os_family, os_name} = :os.type()
@@ -84,7 +84,8 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
           arch: to_string(arch),
           cores: processors,
           ram: total_mem,
-          electric_instance_id: Electric.instance_id()
+          electric_instance_id: Electric.instance_id(),
+          electric_installation_id: Map.fetch!(opts, :installation_id)
         }
       }
     end

--- a/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
@@ -35,9 +35,6 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
     end
 
     defp telemetry_poller_child_spec(opts) do
-      # The telemetry_poller application starts its own poller by default but we disable that
-      # and add its default measurements to the list of our custom ones. This allows for all
-      # periodic measurements to be defined in one place.
       {:telemetry_poller,
        measurements: periodic_measurements(opts),
        period: opts.system_metrics_poll_interval,
@@ -207,7 +204,12 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
 
     defp periodic_measurements(opts) do
       [
-        # Default measurements included with the telemetry_poller application:
+        # Measurements included with the telemetry_poller application.
+        #
+        # By default, The telemetry_poller application starts its own poller but we disable that
+        # and add its default measurements to the list of our custom ones.
+        #
+        # This allows for all periodic measurements to be defined in one place.
         :memory,
         :total_run_queue_lengths,
         :system_counts,

--- a/packages/sync-service/lib/electric/telemetry/opts.ex
+++ b/packages/sync-service/lib/electric/telemetry/opts.ex
@@ -2,6 +2,7 @@ defmodule Electric.Telemetry.Opts do
   def schema do
     [
       instance_id: [type: :string],
+      installation_id: [type: :string],
       system_metrics_poll_interval: [type: :integer, default: :timer.seconds(5)],
       statsd_host: [type: {:or, [:string, nil]}, default: nil],
       prometheus?: [type: :boolean, default: false],

--- a/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
@@ -43,9 +43,6 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
     end
 
     defp telemetry_poller_child_spec(opts) do
-      # The telemetry_poller application starts its own poller by default but we disable that
-      # and add its default measurements to the list of our custom ones. This allows for all
-      # periodic measurements to be defined in one place.
       {:telemetry_poller,
        measurements: periodic_measurements(opts),
        period: opts.system_metrics_poll_interval,

--- a/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
@@ -98,6 +98,7 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
           cores: processors,
           ram: total_mem,
           electric_instance_id: Electric.instance_id(),
+          electric_installation_id: Map.fetch!(opts, :installation_id),
           stack_id: opts.stack_id
         }
       }


### PR DESCRIPTION
An integration test to verify the persistence and a matching change in cloud are coming up as follow-up PRs.