### PR TITLE
fix: Clean up chained abort signal listener

### DIFF
--- a/.changeset/blue-pears-worry.md
+++ b/.changeset/blue-pears-worry.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Cleanup `AbortSignal` chained listeners to avoid memory leaks.


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2334

Listener gets cleaned up if:
- Parent signal is aborted (because of the `once: true` setting)
- Chained abort controller calls `abort` (because of the `signal: aborter.signal` setting)
- The `cleanup` callback is used, which we do at the end of the request that uses this chaining

This should take care of any potential leaks due to listeners.