### PR TITLE
fix: Avoid long-lived listeners for changes due to connection process reuse

### DIFF
--- a/.changeset/chilled-papayas-draw.md
+++ b/.changeset/chilled-papayas-draw.md
@@ -2,4 +2,4 @@
 "@core/sync-service": patch
 ---
 
-Listen to new changes through separate, ephemeral task.
+Ensure request-scoped new changes listener is clenaed up when request ends.

--- a/.changeset/chilled-papayas-draw.md
+++ b/.changeset/chilled-papayas-draw.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Listen to new changes through separate, ephemeral task.

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -544,14 +544,10 @@ defmodule Electric.Shapes.Api do
     end
   end
 
-  defp clean_up_change_listener(%Request{new_changes_ref: ref} = request)
-       when is_reference(ref) do
-    %{
-      handle: shape_handle,
-      api: %{registry: registry}
-    } = request
-
-    Registry.unregister_match(registry, shape_handle, ref)
+  defp clean_up_change_listener(%Request{handle: shape_handle} = request)
+       when not is_nil(shape_handle) do
+    %{api: %{registry: registry}} = request
+    Registry.unregister(registry, shape_handle)
     request
   end
 

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -410,7 +410,9 @@ defmodule Electric.Shapes.Api do
     validate_serve_usage!(request)
 
     with_span(request, "shape_get.plug.serve_shape_log", fn ->
-      do_serve_shape_log(request)
+      response = do_serve_shape_log(request)
+      clean_up_change_listener(request)
+      response
     end)
   end
 

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -658,7 +658,11 @@ defmodule Electric.Shapes.ApiTest do
                      }
                    )
 
-          Api.serve_shape_log(request)
+          response = Api.serve_shape_log(request)
+
+          # Ensure registered listener is cleaned up
+          assert [] == Registry.lookup(@registry, @test_shape_handle)
+          response
         end)
 
       assert_receive :got_log_stream, @receive_timeout


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2289

It seems that connections are being handled by a process pool of sorts, which means that they are never removed from the registry.

>Within a Bandit server, an HTTP/1 connection is modeled as a single process. This process is tied to the lifecycle of the underlying TCP connection; **in the case of an HTTP client which makes use of HTTP's keep-alive feature** to make multiple requests on the same connection, **all of these requests will be serviced by this same process**.

This is from [Bandit's docs](https://github.com/mtrudel/bandit/blob/main/lib/bandit/http1/README.md) and I've verified it by reproducing @magnetised 's situation described in the issue.

I initially used an approach where an ephemeral process/`Task` is the one registering for notifications and forwards them, so that it gets automatically cleaned up by the registry, but I ended up using `Registry.unregister` - it just gets a bit more complicated to ensure that we unregister in all code paths for the request, since it might exit early, and the registration occurs on the `validate` step of the API, and the cleanup on the separate `serve_shape_log` step.

So either we spawn an ephemeral process and let it get cleaned up automatically, or we have to ensure the cleanup is called despite it being split across API calls. Perhaps we would need a `cleanup` API method?