### PR TITLE
feat(sync-service): Add telemetry to time various parts of the WAL processing

### DIFF
--- a/.changeset/strange-snails-hug.md
+++ b/.changeset/strange-snails-hug.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add telemetry to time various parts of the WAL processing

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -125,7 +125,9 @@ defmodule Electric.Replication.ShapeLogCollector do
     Logger.info("Received transaction #{xid} from Postgres at #{lsn}")
     Logger.debug(fn -> "Txn received in ShapeLogCollector: #{inspect(txn)}" end)
 
-    handle_transaction(txn, from, state)
+    OpenTelemetry.timed_fun("shape_log_collector.handle_transaction.duration_µs", fn ->
+      handle_transaction(txn, from, state)
+    end)
   end
 
   def handle_call({:relation_msg, %Relation{} = rel, trace_context}, from, state) do

--- a/packages/sync-service/lib/electric/shapes/dispatcher.ex
+++ b/packages/sync-service/lib/electric/shapes/dispatcher.ex
@@ -134,30 +134,35 @@ defmodule Electric.Shapes.Dispatcher do
   end
 
   def dispatch([event], _length, %State{waiting: 0, subscribers: subscribers} = state) do
-    {partitions, event} = Partitions.handle_event(state.partitions, event)
-
-    context = OpenTelemetry.get_current_context()
-
-    {waiting, pending} =
-      state.filter
-      |> Filter.affected_shapes(event)
-      |> Enum.reduce({0, MapSet.new()}, fn {pid, ref} = subscriber, {waiting, pending} ->
-        Process.send(pid, {:"$gen_consumer", {self(), ref}, [{event, context}]}, [:noconnect])
-        {waiting + 1, MapSet.put(pending, subscriber)}
+    {partitions, event} =
+      OpenTelemetry.timed_fun("partitions.handle_event.duration_µs", fn ->
+        Partitions.handle_event(state.partitions, event)
       end)
-      |> case do
-        {0, _pending} ->
-          # even though no subscriber wants the event, we still need to generate demand
-          # so that we can complete the loop in the log collector
-          [{subscriber, _selector} | _] = subscribers
-          send(self(), {:"$gen_producer", subscriber, {:ask, 1}})
-          {1, MapSet.new([subscriber])}
 
-        {waiting, pending} ->
-          {waiting, pending}
-      end
+    OpenTelemetry.timed_fun("dispatcher.dispatch.duration_µs", fn ->
+      context = OpenTelemetry.get_current_context()
 
-    {:ok, [], %State{state | partitions: partitions, waiting: waiting, pending: pending}}
+      {waiting, pending} =
+        state.filter
+        |> Filter.affected_shapes(event)
+        |> Enum.reduce({0, MapSet.new()}, fn {pid, ref} = subscriber, {waiting, pending} ->
+          Process.send(pid, {:"$gen_consumer", {self(), ref}, [{event, context}]}, [:noconnect])
+          {waiting + 1, MapSet.put(pending, subscriber)}
+        end)
+        |> case do
+          {0, _pending} ->
+            # even though no subscriber wants the event, we still need to generate demand
+            # so that we can complete the loop in the log collector
+            [{subscriber, _selector} | _] = subscribers
+            send(self(), {:"$gen_producer", subscriber, {:ask, 1}})
+            {1, MapSet.new([subscriber])}
+
+          {waiting, pending} ->
+            {waiting, pending}
+        end
+
+      {:ok, [], %State{state | partitions: partitions, waiting: waiting, pending: pending}}
+    end)
   end
 
   @impl GenStage.Dispatcher

--- a/packages/sync-service/lib/electric/shapes/filter.ex
+++ b/packages/sync-service/lib/electric/shapes/filter.ex
@@ -19,6 +19,7 @@ defmodule Electric.Shapes.Filter do
   alias Electric.Shapes.Filter
   alias Electric.Shapes.Filter.WhereCondition
   alias Electric.Shapes.Shape
+  alias Electric.Telemetry.OpenTelemetry
 
   require Logger
 
@@ -75,7 +76,9 @@ defmodule Electric.Shapes.Filter do
   """
   @spec affected_shapes(Filter.t(), Transaction.t() | Relation.t()) :: MapSet.t(shape_id())
   def affected_shapes(%Filter{} = filter, change) do
-    shapes_affected_by_change(filter, change)
+    OpenTelemetry.timed_fun("filter.affected_shapes.duration_µs", fn ->
+      shapes_affected_by_change(filter, change)
+    end)
   rescue
     error ->
       Logger.error("""


### PR DESCRIPTION
Trigger.dev is getting WAL lag due to electric's replication stream processing being slow, we know it's inside the `pg_txn.replication_client.transaction_received` span but it's not where clause filtering or anything on the shape specific processes (e.g. writing to disk). This PR adds attributes to the `pg_txn.replication_client.transaction_received` span that time various parts of that processing to pintpoint the area of slowness. 
<img width="405" alt="Screenshot 2025-03-06 at 09 02 05" src="https://github.com/user-attachments/assets/58e92980-3ca9-4994-8a60-dd4c85983c08" />
