### PR TITLE
fix: Return chunked responses to live requesters

### DIFF
--- a/.changeset/dirty-humans-press.md
+++ b/.changeset/dirty-humans-press.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Return chunked repsonses to live requesters if new changes large enough.

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -520,8 +520,8 @@ defmodule Electric.Shapes.Api do
     receive do
       {^ref, :new_changes, latest_log_offset} ->
         # Stream new log since currently "held" offset
-        %{request | last_offset: latest_log_offset, chunk_end_offset: latest_log_offset}
-        |> Request.update_response(&%{&1 | offset: latest_log_offset})
+        %{request | last_offset: latest_log_offset}
+        |> determine_log_chunk_offset()
         |> determine_up_to_date()
         |> do_serve_shape_log()
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -471,6 +471,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
         send(test_pid, :got_log_stream)
         []
       end)
+      |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
+        nil
+      end)
       |> expect(:get_log_stream, fn @test_offset, ^next_offset, @test_opts ->
         [Jason.encode!("test result")]
       end)

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -641,6 +641,9 @@ defmodule Electric.Shapes.ApiTest do
         send(test_pid, :got_log_stream)
         []
       end)
+      |> expect(:get_chunk_end_log_offset, fn @test_offset, _ ->
+        nil
+      end)
       |> expect(:get_log_stream, fn @test_offset, ^next_offset, @test_opts ->
         [Jason.encode!("test result")]
       end)

--- a/packages/typescript-client/test/support/test-helpers.ts
+++ b/packages/typescript-client/test/support/test-helpers.ts
@@ -23,10 +23,11 @@ export function forEachMessage<T extends Row<unknown>>(
     nthDataMessage: number
   ) => Promise<void> | void
 ) {
+  let unsub = () => {}
   return new Promise<void>((resolve, reject) => {
     let messageIdx = 0
 
-    stream.subscribe(async (messages) => {
+    unsub = stream.subscribe(async (messages) => {
       for (const message of messages) {
         try {
           await handler(
@@ -44,5 +45,5 @@ export function forEachMessage<T extends Row<unknown>>(
         }
       }
     }, reject)
-  })
+  }).finally(unsub)
 }


### PR DESCRIPTION
Found out that live requesters would get the _entire_ transaction regardless of its size while I was working on making the TS tests less flaky.

I've modified the TS chunk test to test chunking both of the initial snapshot and subsequent transactions, without arbitrary `sleep` calls, so it was ending up doing a live request and noticed I was getting a single >40kb response unless I "slept" a bit before requesting such that it was not a live request.


The required change is really small, we just look for the chunk log offset once we receive new changes.