### PR TITLE
Fix incorrect LSN comparisons

### DIFF
--- a/.changeset/lazy-carrots-guess.md
+++ b/.changeset/lazy-carrots-guess.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix incorrect LSN comparisons leading to dropped transactions.

--- a/packages/sync-service/lib/electric/postgres/lsn.ex
+++ b/packages/sync-service/lib/electric/postgres/lsn.ex
@@ -136,6 +136,40 @@ defmodule Electric.Postgres.Lsn do
   def compare(%Lsn{offset: o1}, %Lsn{offset: o2}) when o1 > o2, do: :gt
   def compare(%Lsn{offset: o1}, %Lsn{offset: o2}) when o1 == o2, do: :eq
 
+  @doc """
+  Determine if the first Lsn is larger than the second.
+
+  ## Examples
+
+    iex> lsn1 = %Lsn{segment: 2, offset: 10}
+    iex> lsn2 = %Lsn{segment: 1, offset: 50}
+    iex> is_larger(lsn1, lsn2)
+    true
+
+    iex> lsn1 = %Lsn{segment: 3, offset: 5}
+    iex> lsn2 = %Lsn{segment: 3, offset: 4}
+    iex> is_larger(lsn1, lsn2)
+    true
+
+    iex> lsn1 = Lsn.from_string("166A/91FDFDE8")
+    iex> lsn2 = Lsn.from_string("1667/FFFFFCC8")
+    iex> is_larger(lsn1, lsn2)
+    true
+
+    iex> lsn1 = %{segment: 2, offset: 100}
+    iex> lsn2 = %{segment: 2, offset: 200}
+    iex> is_larger(lsn1, lsn2)
+    false
+
+    iex> lsn1 = %{segment: 1, offset: 30}
+    iex> lsn2 = %{segment: 1, offset: 30}
+    iex> is_larger(lsn1, lsn2)
+    false
+  """
+  defguard is_larger(lsn1, lsn2)
+           when lsn1.segment > lsn2.segment or
+                  (lsn1.segment == lsn2.segment and lsn1.offset > lsn2.offset)
+
   @max_offset 0xFFFFFFFF
 
   @doc """

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -149,8 +149,8 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
     test "drops transactions if already processed", ctx do
       xid = 150
-      prev_lsn = Lsn.from_string("0/10")
-      lsn = Lsn.increment(prev_lsn, 1)
+      prev_lsn = Lsn.from_string("1667/FFFFFCC8")
+      lsn = Lsn.from_string("166A/91FDFDE8")
 
       Mock.Inspector
       |> stub(:load_relation, fn
@@ -177,14 +177,14 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         %Transaction{xid: xid, lsn: lsn, last_log_offset: LogOffset.new(lsn, 0)}
         |> Transaction.prepend_change(%Changes.NewRecord{
           relation: {"public", "test_table"},
-          record: %{"id" => "3", "name" => "foo"}
+          record: %{"id" => "2", "name" => "foo"}
         })
 
       txn3 =
         %Transaction{xid: xid - 1, lsn: prev_lsn, last_log_offset: LogOffset.new(prev_lsn, 0)}
         |> Transaction.prepend_change(%Changes.NewRecord{
           relation: {"public", "test_table"},
-          record: %{"id" => "4", "name" => "foo"}
+          record: %{"id" => "2", "name" => "foo"}
         })
 
       assert :ok = ShapeLogCollector.store_transaction(txn2, ctx.server)

--- a/packages/sync-service/test/support/transaction_consumer.ex
+++ b/packages/sync-service/test/support/transaction_consumer.ex
@@ -32,7 +32,7 @@ defmodule Support.TransactionConsumer do
   end
 
   def refute_consume(consumers, timeout \\ 100) do
-    for consumer <- consumers, into: MapSet.new() do
+    for consumer <- consumers do
       refute_receive {Support.TransactionConsumer, ^consumer, _}, timeout
     end
   end


### PR DESCRIPTION
Fixes transactions getting dropped incorrectly because of invalid LSN comparisons, introduced in https://github.com/electric-sql/electric/pull/2382