### PR TITLE
Add config option to disable cache headers

### DIFF
--- a/.changeset/smart-apples-stare.md
+++ b/.changeset/smart-apples-stare.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add configuration flag to disable HTTP cache headers

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -104,7 +104,9 @@ defmodule Electric.Application do
       long_poll_timeout: get_env(opts, :long_poll_timeout),
       max_age: get_env(opts, :cache_max_age),
       stale_age: get_env(opts, :cache_stale_age),
-      allow_shape_deletion: get_env(opts, :allow_shape_deletion?)
+      allow_shape_deletion: get_env(opts, :allow_shape_deletion?),
+      stack_ready_timeout: get_env(opts, :stack_ready_timeout),
+      send_cache_headers?: get_env(opts, :send_cache_headers?)
     )
     |> Keyword.merge(Keyword.take(opts, [:encoder]))
   end

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -48,6 +48,8 @@ defmodule Electric.Config do
     allow_shape_deletion?: false,
     service_port: 3000,
     listen_on_ipv6?: false,
+    stack_ready_timeout: 5_000,
+    send_cache_headers?: true,
     ## Storage
     storage_dir: "./persistent",
     storage: &Electric.Config.Defaults.storage/0,

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -28,6 +28,7 @@ defmodule Electric.Shapes.Api do
     max_age: [type: :integer],
     stack_ready_timeout: [type: :integer],
     stale_age: [type: :integer],
+    send_cache_headers?: [type: :boolean],
     encoder: [type: :atom]
   ]
   @schema NimbleOptions.new!(@options)
@@ -48,8 +49,9 @@ defmodule Electric.Shapes.Api do
     allow_shape_deletion: false,
     long_poll_timeout: 20_000,
     max_age: 60,
-    stack_ready_timeout: 100,
+    stack_ready_timeout: 5_000,
     stale_age: 300,
+    send_cache_headers?: true,
     encoder: Electric.Shapes.Api.Encoder.JSON,
     configured: false
   ]
@@ -583,7 +585,7 @@ defmodule Electric.Shapes.Api do
 
   @spec stack_id(Api.t() | Request.t()) :: String.t()
   def stack_id(%Api{stack_id: stack_id}), do: stack_id
-  def stack_id(%Request{api: %{stack_id: stack_id}}), do: stack_id
+  def stack_id(%{api: %{stack_id: stack_id}}), do: stack_id
 
   defp encode_log(%Request{api: api}, stream) do
     encode(api, :log, stream)

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -515,6 +515,12 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Plug.Conn.get_resp_header(conn, "electric-offset") == [next_offset_str]
       assert Plug.Conn.get_resp_header(conn, "electric-up-to-date") == [""]
       assert Plug.Conn.get_resp_header(conn, "electric-schema") == []
+
+      expected_cursor =
+        Electric.Plug.Utils.get_next_interval_timestamp(long_poll_timeout(ctx), nil)
+        |> to_string()
+
+      assert {"electric-cursor", expected_cursor} in conn.resp_headers
     end
 
     test "handles shape rotation", ctx do


### PR DESCRIPTION
for embedded electric, in dev mode we don't want the browser to cache responses because it causes problems with restarts/migrations etc, so add a flag to just turn them off.

also includes allowing configuration of the stack_ready_timeout and a higher default for that (was 100ms which is a bit harsh)