### PR TITLE
chore: Reduce flakes in Elixir client tests

### DIFF
--- a/packages/elixir-client/test/electric/client/embedded_test.exs
+++ b/packages/elixir-client/test/electric/client/embedded_test.exs
@@ -111,9 +111,15 @@ defmodule Electric.Client.EmbeddedTest do
     assert_receive {:stream, 1, up_to_date()}
     assert_receive {:stream, 2, %ChangeMessage{value: %{"id" => ^id1}}}, 5000
     assert_receive {:stream, 2, up_to_date()}
+    refute_receive _
 
-    {:ok, id2} = insert_item(ctx)
-    {:ok, id3} = insert_item(ctx)
+
+    {:ok, {id2, id3}} =
+      with_transaction(ctx, fn ctx ->
+        {:ok, id2} = insert_item(ctx)
+        {:ok, id3} = insert_item(ctx)
+        {id2, id3}
+      end)
 
     assert_receive {:stream, 1, %ChangeMessage{value: %{"id" => ^id2}}}, 5000
     assert_receive {:stream, 1, %ChangeMessage{value: %{"id" => ^id3}}}, 5000
@@ -122,6 +128,8 @@ defmodule Electric.Client.EmbeddedTest do
     assert_receive {:stream, 2, %ChangeMessage{value: %{"id" => ^id2}}}, 5000
     assert_receive {:stream, 2, %ChangeMessage{value: %{"id" => ^id3}}}, 5000
     assert_receive {:stream, 2, up_to_date()}
+
+    refute_receive _
   end
 
   test "sends full rows with replica: :full", ctx do
@@ -142,6 +150,7 @@ defmodule Electric.Client.EmbeddedTest do
 
     assert_receive {:stream, 1, %ChangeMessage{value: %{"id" => ^id1}}}, 5000
     assert_receive {:stream, 1, up_to_date()}
+    refute_receive _
 
     :ok = update_item(ctx, id1, value: 999)
 
@@ -152,6 +161,7 @@ defmodule Electric.Client.EmbeddedTest do
                    500
 
     assert_receive {:stream, 1, up_to_date()}
+    refute_receive _
   end
 
   test "supports shapes with where clauses and column lists", ctx do

--- a/packages/elixir-client/test/support/db_setup.ex
+++ b/packages/elixir-client/test/support/db_setup.ex
@@ -47,6 +47,10 @@ defmodule Support.DbSetup do
     %{utility_pool: utility_pool, pool: pool, db_conn: pool, tablename: tablename}
   end
 
+  def with_transaction(%{db_conn: db} = ctx, func) do
+    Postgrex.transaction(db, fn conn -> func.(%{ctx | db_conn: conn}) end)
+  end
+
   def insert_item(%{db_conn: db, tablename: tablename}, opts \\ []) do
     insert_item(db, tablename, opts)
   end


### PR DESCRIPTION
Noticed there were some occasional flakes, most changes were made to make it solid under runs with the `--repeat-until-failure` option. I introduced artificial stress to be closer to CI runs.