### PR TITLE
Fix license name in package.json(s)

### DIFF
--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -51,7 +51,7 @@
     "src"
   ],
   "homepage": "https://electric-sql.com",
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs",
   "module": "dist/index.legacy-esm.js",
   "optionalDependencies": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -52,7 +52,7 @@
     "src"
   ],
   "homepage": "https://electric-sql.com",
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs",
   "module": "dist/index.legacy-esm.js",
   "peerDependencies": {

--- a/packages/typescript-client/package.json
+++ b/packages/typescript-client/package.json
@@ -45,7 +45,7 @@
     "src"
   ],
   "homepage": "https://electric-sql.com",
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/index.legacy-esm.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The license management tool, [License Finder](https://github.com/pivotal/LicenseFinder), fails to detect the license, so could you please include the correct license name in package.json?