### PR TITLE
feat: Implement separate, potentially pooled `ELECTRIC_QUERY_DATABASE_URL`

### DIFF
--- a/.changeset/flat-hornets-ring.md
+++ b/.changeset/flat-hornets-ring.md
@@ -1,0 +1,6 @@
+---
+"@core/sync-service": patch
+"@electric-sql/docs": patch
+---
+
+Implement `ELECTRIC_QUERY_DATABASE_URL` optional env var to perform queries with separate, potentially pooled connection string.

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -41,14 +41,17 @@ jobs:
           - 54321:5432
 
       pgbouncer:
-        image: edoburu/pgbouncer:latest
+        image: bitnami/pgbouncer:latest
+        env:
+          PGBOUNCER_AUTH_TYPE: trust
+          PGBOUNCER_DATABASE: "*"
+          PGBOUNCER_POOL_MODE: transaction
+          POSTGRESQL_HOST: postgres
+          POSTGRESQL_DATABASE: electric
+          POSTGRESQL_USERNAME: postgres
+          POSTGRESQL_PASSWORD: password
         ports:
-          - "64321:6432"
-        volumes:
-        - ./dev/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
-        - ./dev/userlist.txt:/etc/pgbouncer/userlist.txt:ro
-        options: >-
-          --entrypoint "pgbouncer /etc/pgbouncer/pgbouncer.ini"
+          - 64321:6432
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -39,6 +39,16 @@ jobs:
           --health-retries 5
         ports:
           - 54321:5432
+
+      pgbouncer:
+        image: edoburu/pgbouncer:latest
+        ports:
+          - "64321:6432"
+        volumes:
+        - ./dev/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
+        - ./dev/userlist.txt:/etc/pgbouncer/userlist.txt:ro
+        options: >-
+          --entrypoint "pgbouncer /etc/pgbouncer/pgbouncer.ini"
     steps:
       - uses: actions/checkout@v4
 

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -3,7 +3,9 @@
 
 [global pg_container_name=]
 [global pg_host_port=54331]
+[global pg_pooler_host_port=64331]
 [global database_url=postgresql://postgres:password@localhost:$pg_host_port/postgres?sslmode=disable]
+[global pooled_database_url=postgresql://postgres:password@localhost:$pg_pooler_host_port/postgres?sslmode=disable]
 
 [macro setup_pg_with_name shell_name initdb_args config_opts]
   [shell $shell_name]
@@ -29,6 +31,27 @@
 
 [macro setup_pg initdb_args config_opts]
   [invoke setup_pg_with_name "pg" $initdb_args $config_opts]
+[endmacro]
+
+[macro setup_pg_with_pooler initdb_args config_opts]
+  [invoke setup_pg_with_name "pg" $initdb_args $config_opts]
+  [shell "pg_pooler"]
+    -$fail_pattern
+
+    !docker run \
+      --name "${pg_container_name}-pooler" \
+      -e PGBOUNCER_AUTH_TYPE=trust \
+      -e PGBOUNCER_DATABASE=* \
+      -e PGBOUNCER_POOL_MODE=transaction \
+      -e POSTGRESQL_HOST=host.docker.internal \
+      -e POSTGRESQL_PORT=$pg_host_port \
+      -e POSTGRESQL_DATABASE=electric \
+      -e POSTGRESQL_USERNAME=postgres \
+      -e POSTGRESQL_PASSWORD=password \
+      -p $pg_pooler_host_port:6432 \
+      bitnami/pgbouncer:latest
+
+    ??LOG process up: PgBouncer
 [endmacro]
 
 [macro stop_pg]
@@ -87,6 +110,10 @@
   [invoke setup_electric_with_env "DATABASE_URL=$database_url"]
 [endmacro]
 
+[macro setup_electric_with_pooler]
+  [invoke setup_electric_with_env "DATABASE_URL=$database_url ELECTRIC_QUERY_DATABASE_URL=$pooled_database_url"]
+[endmacro]
+
 [macro setup_multi_tenant_electric]
   [invoke setup_electric_with_env ""]
 [endmacro]
@@ -125,11 +152,12 @@
 
 [macro teardown_container container_name]
   -$fail_pattern
-  !docker rm -f -v $container_name
+  !docker rm -f -v $container_name 2>/dev/null || true
   ?$PS1
 [endmacro]
 
 [macro teardown]
+  [invoke teardown_container "${pg_container_name}-pooler"]
   [invoke teardown_container $pg_container_name]
   !../scripts/clean_up.sh
   ?$PS1

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -10,9 +10,13 @@
 [macro setup_pg_with_name shell_name initdb_args config_opts]
   [shell $shell_name]
     -$fail_pattern
+
+    # Create network for given contianer to be able to attach pooler
+    !docker network ls | grep ${pg_container_name}-network || docker network create ${pg_container_name}-network
   
     !docker run \
       --name $pg_container_name \
+      --network ${pg_container_name}-network \
       -e POSTGRES_DB=electric \
       -e POSTGRES_USER=postgres \
       -e POSTGRES_PASSWORD=password \
@@ -40,11 +44,11 @@
 
     !docker run \
       --name "${pg_container_name}-pooler" \
+      --network ${pg_container_name}-network \
       -e PGBOUNCER_AUTH_TYPE=trust \
       -e PGBOUNCER_DATABASE=* \
       -e PGBOUNCER_POOL_MODE=transaction \
-      -e POSTGRESQL_HOST=host.docker.internal \
-      -e POSTGRESQL_PORT=$pg_host_port \
+      -e POSTGRESQL_HOST=$pg_container_name \
       -e POSTGRESQL_DATABASE=electric \
       -e POSTGRESQL_USERNAME=postgres \
       -e POSTGRESQL_PASSWORD=password \

--- a/integration-tests/tests/pooled-connections.lux
+++ b/integration-tests/tests/pooled-connections.lux
@@ -1,0 +1,71 @@
+[doc Verify Electric handles data replication with pooled connection]
+
+[include _macros.luxinc]
+
+[global pg_container_name=poold-connections__pg]
+
+###
+
+## Start a new Postgres cluster
+[invoke setup_pg_with_pooler "" ""]
+
+## Add some data
+[invoke start_psql]
+[shell psql]
+  """!
+  CREATE TABLE items (
+    id UUID PRIMARY KEY,
+    val TEXT
+  );
+  """
+  ??CREATE TABLE
+
+  """!
+  INSERT INTO
+    items (id, val)
+  SELECT
+    gen_random_uuid(),
+    '#' || generate_series || ' initial val'
+  FROM
+    generate_series(1, 10);
+  """
+  ??INSERT 0 10
+
+## Start the sync service.
+[invoke setup_electric_with_pooler]
+
+[shell electric]
+  ??[info] Starting replication from postgres
+  
+# Initialize a shape and collect the offset
+[shell client]
+  # strip ANSI codes from response for easier matching
+  !curl -v -X GET "http://localhost:3000/v1/shape?table=items&offset=-1"
+  ?electric-handle: ([\d-]+)
+  [local handle=$1]
+  ?electric-offset: ([\w\d_]+)
+  [local offset=$1]
+  ??"val":"#10 initial val"
+
+## Add some more data
+[shell psql]
+  """!
+  INSERT INTO
+    items (id, val)
+  SELECT
+    gen_random_uuid(),
+    '#' || generate_series || ' new val'
+  FROM
+    generate_series(1, 10);
+  """
+  ??INSERT 0 10
+
+# Client should be able to continue same shape
+[shell client]
+  [sleep 2]
+  !curl -v -X GET "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset"
+  ??HTTP/1.1 200 OK
+  ??"val":"#10 new val"
+
+[cleanup]
+  [invoke teardown]

--- a/packages/sync-service/.env.test
+++ b/packages/sync-service/.env.test
@@ -1,2 +1,3 @@
 ELECTRIC_LOG_LEVEL=info
 DATABASE_URL=postgresql://postgres:password@localhost:54321/postgres?sslmode=disable
+ELECTRIC_QUERY_DATABASE_URL=postgresql://postgres:password@localhost:64321/postgres?sslmode=disable

--- a/packages/sync-service/README.md
+++ b/packages/sync-service/README.md
@@ -64,7 +64,7 @@ reuse that configuration if you want:
     config :my_app, Repo, database_config
 
     config :electric,
-      connection_opts: Electric.Utils.obfuscate_password(database_config)
+      replication_connection_opts: Electric.Utils.obfuscate_password(database_config)
 
 Or if you're getting your db connection from an environment variable, then you
 can use
@@ -74,7 +74,7 @@ can use
     {:ok, database_config} = Electric.Config.parse_postgresql_uri(System.fetch_env!("DATABASE_URL"))
 
     config :electric,
-      connection_opts: Electric.Utils.obfuscate_password(database_config)
+      replication_connection_opts: Electric.Utils.obfuscate_password(database_config)
 
 The Electric app will startup along with the rest of your Elixir app.
 

--- a/packages/sync-service/dev/docker-compose.yml
+++ b/packages/sync-service/dev/docker-compose.yml
@@ -38,6 +38,16 @@ services:
       - docker-entrypoint.sh
       - -c
       - config_file=/etc/postgresql.conf
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    ports:
+      - "64321:6432"
+    depends_on:
+      - postgres
+    volumes:
+    - ./pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
+    - ./userlist.txt:/etc/pgbouncer/userlist.txt:ro
+    command: ["pgbouncer", "/etc/pgbouncer/pgbouncer.ini"]
   nginx:
     image: nginx:latest
     ports:

--- a/packages/sync-service/dev/docker-compose.yml
+++ b/packages/sync-service/dev/docker-compose.yml
@@ -39,15 +39,19 @@ services:
       - -c
       - config_file=/etc/postgresql.conf
   pgbouncer:
-    image: edoburu/pgbouncer:latest
+    image: bitnami/pgbouncer:latest
+    environment:
+      PGBOUNCER_AUTH_TYPE: trust
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_POOL_MODE: transaction
+      POSTGRESQL_HOST: postgres
+      POSTGRESQL_DATABASE: electric
+      POSTGRESQL_USERNAME: postgres
+      POSTGRESQL_PASSWORD: password
     ports:
       - "64321:6432"
     depends_on:
       - postgres
-    volumes:
-    - ./pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
-    - ./userlist.txt:/etc/pgbouncer/userlist.txt:ro
-    command: ["pgbouncer", "/etc/pgbouncer/pgbouncer.ini"]
   nginx:
     image: nginx:latest
     ports:

--- a/packages/sync-service/dev/pgbouncer.ini
+++ b/packages/sync-service/dev/pgbouncer.ini
@@ -1,9 +1,0 @@
-[databases]
-* = host=postgres port=5432 user=postgres password=password
-
-[pgbouncer]
-listen_addr = 0.0.0.0
-listen_port = 6432
-pool_mode = transaction
-auth_type = md5
-auth_file = /etc/pgbouncer/userlist.txt

--- a/packages/sync-service/dev/pgbouncer.ini
+++ b/packages/sync-service/dev/pgbouncer.ini
@@ -1,0 +1,9 @@
+[databases]
+* = host=postgres port=5432 user=postgres password=password
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+pool_mode = transaction
+auth_type = md5
+auth_file = /etc/pgbouncer/userlist.txt

--- a/packages/sync-service/dev/userlist.txt
+++ b/packages/sync-service/dev/userlist.txt
@@ -1,0 +1,1 @@
+"postgres" "md532e12f215ba27cb750c9e093ce4b5127"

--- a/packages/sync-service/dev/userlist.txt
+++ b/packages/sync-service/dev/userlist.txt
@@ -1,1 +1,0 @@
-"postgres" "md532e12f215ba27cb750c9e093ce4b5127"

--- a/packages/sync-service/lib/electric.ex
+++ b/packages/sync-service/lib/electric.ex
@@ -68,7 +68,9 @@ defmodule Electric do
 
   ### Database
 
-  - `connection_opts` - **Required**
+  - `replication_connection_opts` - **Required**
+     #{NimbleOptions.docs(opts_schema, nest_level: 1)}.
+  - `query_connection_opts` - Optional separate connection string that can use a pooler for non-replication queries (default: nil)
      #{NimbleOptions.docs(opts_schema, nest_level: 1)}.
   - `db_pool_size` - How many connections Electric opens as a pool for handling shape queries (default: `#{default.(:db_pool_size)}`)
   - `replication_stream_id` - Suffix for the logical replication publication and slot name (default: `#{default.(:replication_stream_id)}`)

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -84,10 +84,14 @@ defmodule Electric.Application do
 
     slot_name = Keyword.get(opts, :slot_name, "electric_slot_#{replication_stream_id}")
 
+    replication_connection_opts = get_env!(opts, :replication_connection_opts)
+
     Keyword.merge(
       core_config,
-      connection_opts: get_env!(opts, :connection_opts),
+      connection_opts:
+        get_env_with_default(opts, :query_connection_opts, replication_connection_opts),
       replication_opts: [
+        connection_opts: replication_connection_opts,
         publication_name: publication_name,
         slot_name: slot_name,
         slot_temporary?: get_env(opts, :replication_slot_temporary?)

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -524,7 +524,16 @@ defmodule Electric.Connection.Manager do
     # See https://github.com/electric-sql/electric/issues/1554
     Postgrex.start_link(
       pool_opts ++
-        [backoff_type: :exp, max_restarts: 3, max_seconds: 5] ++
+        [
+          backoff_type: :exp,
+          max_restarts: 3,
+          max_seconds: 5,
+          # Assume the manager connection might be pooled, so use unnamed prepared
+          # statements to avoid issues with the pooler
+          #
+          # See https://hexdocs.pm/postgrex/0.19.3/readme.html#pgbouncer
+          prepare: :unnamed
+        ] ++
         Electric.Utils.deobfuscate_password(connection_opts)
     )
   end

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -605,7 +605,7 @@ defmodule Electric.Connection.Manager do
   end
 
   defp handle_connection_error(
-         error,
+         %DBConnection.ConnectionError{severity: :error} = error,
          %State{connection_opts: connection_opts} = state,
          mode
        ) do

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -593,7 +593,7 @@ defmodule Electric.Connection.Manager do
   end
 
   defp handle_connection_error(
-         error,
+         %DBConnection.ConnectionError{severity: :error} = error,
          %State{replication_opts: replication_opts} = state,
          "replication" = mode
        ) do
@@ -632,6 +632,10 @@ defmodule Electric.Connection.Manager do
       {:error, error} ->
         fail_on_error_or_reconnect(error, state, mode)
     end
+  end
+
+  defp handle_connection_error(error, state, mode) do
+    fail_on_error_or_reconnect(error, state, mode)
   end
 
   # This separate function is needed for `handle_connection_error()` not to get stuck in a

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -63,7 +63,6 @@ defmodule Electric.Connection.Manager do
       :stack_events_registry,
       :tweaks,
       :persistent_kv,
-      :ipv6_enabled,
       awaiting_active: [],
       drop_slot_requested: false,
       monitoring_started?: false
@@ -166,12 +165,12 @@ defmodule Electric.Connection.Manager do
     connection_opts =
       opts
       |> Keyword.fetch!(:connection_opts)
-      |> update_ssl_opts()
-      |> update_tcp_opts()
+      |> update_connection_opts()
 
     replication_opts =
       opts
       |> Keyword.fetch!(:replication_opts)
+      |> Keyword.update!(:connection_opts, &update_connection_opts/1)
       |> Keyword.put(:start_streaming?, false)
       |> Keyword.put(:connection_manager, self())
 
@@ -191,8 +190,7 @@ defmodule Electric.Connection.Manager do
         stack_id: Keyword.fetch!(opts, :stack_id),
         stack_events_registry: Keyword.fetch!(opts, :stack_events_registry),
         tweaks: Keyword.fetch!(opts, :tweaks),
-        persistent_kv: Keyword.fetch!(opts, :persistent_kv),
-        ipv6_enabled: connection_opts[:ipv6]
+        persistent_kv: Keyword.fetch!(opts, :persistent_kv)
       }
 
     # Try to acquire the connection lock on the replication slot
@@ -277,15 +275,20 @@ defmodule Electric.Connection.Manager do
   def handle_continue(:start_replication_client, %State{replication_client_pid: nil} = state) do
     opts =
       state
-      |> Map.take([:stack_id, :replication_opts, :connection_opts])
+      |> Map.take([:stack_id, :replication_opts])
       |> Map.to_list()
 
     Logger.debug("Starting replication client for stack #{state.stack_id}")
 
     case start_replication_client(opts) do
-      {:ok, pid, connection_opts} ->
+      {:ok, pid, replication_opts} ->
         state = mark_connection_succeeded(state)
-        state = %State{state | replication_client_pid: pid, connection_opts: connection_opts}
+
+        state = %State{
+          state
+          | replication_client_pid: pid,
+            replication_opts: replication_opts
+        }
 
         if is_nil(state.pool_pid) do
           # This is the case where Connection.Manager starts connections from the initial state.
@@ -484,8 +487,9 @@ defmodule Electric.Connection.Manager do
         {:ok, pid, opts[:connection_opts]}
 
       error ->
-        with {:ok, opts} <- maybe_fallback_to_no_ssl(error, opts) do
-          start_lock_connection(opts)
+        with {:ok, connection_opts} <- maybe_fallback_to_no_ssl(error, opts[:connection_opts]) do
+          Keyword.put(opts, :connection_opts, connection_opts)
+          |> start_lock_connection()
         end
     end
   end
@@ -493,11 +497,20 @@ defmodule Electric.Connection.Manager do
   defp start_replication_client(opts) do
     case Electric.Postgres.ReplicationClient.start_link(opts) do
       {:ok, pid} ->
-        {:ok, pid, opts[:connection_opts]}
+        {:ok, pid, opts[:replication_opts]}
 
       error ->
-        with {:ok, opts} <- maybe_fallback_to_no_ssl(error, opts) do
-          start_replication_client(opts)
+        with {:ok, connection_opts} <-
+               maybe_fallback_to_no_ssl(
+                 error,
+                 get_in(opts, [:replication_opts, :connection_opts])
+               ) do
+          Keyword.update!(
+            opts,
+            :replication_opts,
+            &Keyword.put(&1, :connection_opts, connection_opts)
+          )
+          |> start_replication_client()
         end
     end
   end
@@ -516,11 +529,34 @@ defmodule Electric.Connection.Manager do
     )
   end
 
+  defp maybe_fallback_to_ipv4(
+         %DBConnection.ConnectionError{message: message, severity: :error} = error,
+         connection_opts
+       ) do
+    # If network is unreachable, IPv6 is not enabled on the machine
+    # If domain cannot be resolved, assume there is no AAAA record for it
+    # Fall back to IPv4 for these cases
+    if connection_opts[:ipv6] and
+         String.starts_with?(message, "tcp connect (") and
+         (String.ends_with?(message, "): non-existing domain - :nxdomain") or
+            String.ends_with?(message, "): network is unreachable - :enetunreach")) do
+      Logger.warning(
+        "Database connection failed to find valid IPv6 address for #{connection_opts[:hostname]} - falling back to IPv4"
+      )
+
+      {:ok, connection_opts |> Keyword.put(:ipv6, false) |> update_tcp_opts()}
+    else
+      {:error, error}
+    end
+  end
+
+  defp maybe_fallback_to_ipv4(error, _connection_opts), do: {:error, error}
+
   defp maybe_fallback_to_no_ssl(
          {:error, %Postgrex.Error{message: "ssl not available"}} = error,
-         opts
+         connection_opts
        ) do
-    sslmode = get_in(opts, [:connection_opts, :sslmode])
+    sslmode = connection_opts[:sslmode]
 
     if sslmode == :require do
       error
@@ -533,12 +569,11 @@ defmodule Electric.Connection.Manager do
         )
       end
 
-      opts = Keyword.update!(opts, :connection_opts, &Keyword.put(&1, :ssl, false))
-      {:ok, opts}
+      {:ok, Keyword.put(connection_opts, :ssl, false)}
     end
   end
 
-  defp maybe_fallback_to_no_ssl(error, _opts), do: error
+  defp maybe_fallback_to_no_ssl(error, _connection_opts), do: error
 
   defp handle_connection_error(
          {:shutdown, {:failed_to_start_child, Electric.Postgres.ReplicationClient, error}},
@@ -549,36 +584,45 @@ defmodule Electric.Connection.Manager do
   end
 
   defp handle_connection_error(
-         %DBConnection.ConnectionError{message: message, severity: :error} = error,
-         %State{connection_opts: connection_opts, ipv6_enabled: true} = state,
-         mode
+         error,
+         %State{replication_opts: replication_opts} = state,
+         "replication" = mode
        ) do
-    # If network is unreachable, IPv6 is not enabled on the machine
-    # If domain cannot be resolved, assume there is no AAAA record for it
-    # Fall back to IPv4 for these cases
-    if String.starts_with?(message, "tcp connect (") and
-         (String.ends_with?(message, "): non-existing domain - :nxdomain") or
-            String.ends_with?(message, "): network is unreachable - :enetunreach")) do
-      Logger.warning(
-        "Database connection in #{mode} mode failed to find valid IPv6 address for #{connection_opts[:hostname]} - falling back to IPv4"
-      )
+    case maybe_fallback_to_ipv4(error, replication_opts[:connection_opts]) do
+      {:ok, connection_opts} ->
+        # disable IPv6 and retry immediately
+        state = %State{
+          state
+          | replication_opts: Keyword.put(replication_opts, :connection_opts, connection_opts)
+        }
 
-      # disable IPv6 and retry immediately
-      state = %State{
-        state
-        | ipv6_enabled: false,
-          connection_opts: connection_opts |> Keyword.put(:ipv6, false) |> update_tcp_opts()
-      }
+        step = current_connection_step(state)
+        handle_continue(step, state)
 
-      step = current_connection_step(state)
-      handle_continue(step, state)
-    else
-      fail_on_error_or_reconnect(error, state, mode)
+      {:error, error} ->
+        fail_on_error_or_reconnect(error, state, mode)
     end
   end
 
-  defp handle_connection_error(error, state, mode) do
-    fail_on_error_or_reconnect(error, state, mode)
+  defp handle_connection_error(
+         error,
+         %State{connection_opts: connection_opts} = state,
+         mode
+       ) do
+    case maybe_fallback_to_ipv4(error, connection_opts) do
+      {:ok, connection_opts} ->
+        # disable IPv6 and retry immediately
+        state = %State{
+          state
+          | connection_opts: connection_opts
+        }
+
+        step = current_connection_step(state)
+        handle_continue(step, state)
+
+      {:error, error} ->
+        fail_on_error_or_reconnect(error, state, mode)
+    end
   end
 
   # This separate function is needed for `handle_connection_error()` not to get stuck in a
@@ -759,6 +803,9 @@ defmodule Electric.Connection.Manager do
 
     Keyword.put(connection_opts, :socket_options, tcp_opts)
   end
+
+  defp update_connection_opts(connection_opts),
+    do: connection_opts |> update_ssl_opts() |> update_tcp_opts()
 
   defp lookup_log_collector_pid(shapes_supervisor) do
     {Electric.Replication.ShapeLogCollector, log_collector_pid, :worker, _modules} =

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -108,11 +108,11 @@ defmodule Electric.Postgres.ReplicationClient do
         # TODO: the name is not necessary
         name: name(config.stack_id),
         auto_reconnect: false
-      ] ++ Electric.Utils.deobfuscate_password(config.connection_opts)
+      ] ++ Electric.Utils.deobfuscate_password(config.replication_opts[:connection_opts])
 
     Postgrex.ReplicationConnection.start_link(
       __MODULE__,
-      config.replication_opts,
+      Keyword.delete(config.replication_opts, :connection_opts),
       start_opts
     )
   end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -50,6 +50,11 @@ defmodule Electric.StackSupervisor do
                    type: :keyword_list,
                    required: true,
                    keys: [
+                     connection_opts: [
+                       type: :keyword_list,
+                       required: true,
+                       keys: Electric.connection_opts_schema()
+                     ],
                      publication_name: [type: :string, required: true],
                      slot_name: [type: :string, required: true],
                      slot_temporary?: [type: :boolean, default: false],
@@ -129,7 +134,11 @@ defmodule Electric.StackSupervisor do
   end
 
   defp obfuscate_password(opts) when is_list(opts) do
-    Keyword.update(opts, :connection_opts, [], &Electric.Utils.obfuscate_password/1)
+    opts
+    |> Keyword.update(:connection_opts, [], &Electric.Utils.obfuscate_password/1)
+    |> Keyword.update(:replication_opts, [], fn repl_opts ->
+      Keyword.update(repl_opts, :connection_opts, [], &Electric.Utils.obfuscate_password/1)
+    end)
   end
 
   def subscribe_to_stack_events(

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -807,7 +807,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         end)
 
       # Wait for the task process to subscribe to stack events
-      wait_until_subscribed(ctx.stack_id, 50, 4)
+      wait_until_subscribed(ctx.stack_id, 50, 8)
 
       Electric.StackSupervisor.dispatch_stack_event(ctx.stack_id, :ready)
 

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -155,7 +155,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
       num_txn = 2
       num_ops = 8
       max_sleep = 20
-      receive_timeout = (num_txn + num_ops) * max_sleep * 2
+      receive_timeout = max((num_txn + num_ops) * max_sleep * 2, 1000)
 
       # Insert `num_txn` transactions, each in a separate process. Every transaction has
       # `num_ops` INSERTs with a random delay between each operation.

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -40,6 +40,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
     test "creates an empty publication on startup if requested",
          %{db_conn: conn, dummy_pid: dummy_pid} = ctx do
       replication_opts = [
+        connection_opts: ctx.db_config,
         stack_id: ctx.stack_id,
         publication_name: @publication_name,
         try_creating_publication?: true,
@@ -347,6 +348,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
   defp with_replication_opts(ctx) do
     %{
       replication_opts: [
+        connection_opts: ctx.db_config,
         stack_id: ctx.stack_id,
         publication_name: @publication_name,
         try_creating_publication?: false,
@@ -435,7 +437,6 @@ defmodule Electric.Postgres.ReplicationClientTest do
     {:ok, _pid} =
       ReplicationClient.start_link(
         stack_id: ctx.stack_id,
-        connection_opts: ctx.db_config,
         replication_opts: ctx.replication_opts
       )
   end

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -19,6 +19,11 @@ defmodule Electric.Postgres.ReplicationClientTest do
   @publication_name "test_electric_publication"
   @slot_name "test_electric_slot"
 
+  # Larger than average timeout for assertions that require
+  # seeing changes back from the database, as it can be especially
+  # slow on CI/Docker etc
+  @assert_receive_db_timeout 1000
+
   setup do
     # Spawn a dummy process to serve as the black hole for the messages that
     # ReplicationClient normally sends to Connection.Manager.
@@ -124,16 +129,20 @@ defmodule Electric.Postgres.ReplicationClientTest do
       monitor = Process.monitor(pid)
       Process.unlink(pid)
 
+      on_exit(fn -> Process.alive?(pid) && Process.exit(pid, :kill) end)
+
       interrupt_val = "interrupt #{inspect(pid)}"
       insert_item(conn, interrupt_val)
 
       assert_receive {
-        :DOWN,
-        ^monitor,
-        :process,
-        ^pid,
-        {%RuntimeError{message: "Interrupting transaction processing abnormally"}, _stacktrace}
-      }
+                       :DOWN,
+                       ^monitor,
+                       :process,
+                       ^pid,
+                       {%RuntimeError{message: "Interrupting transaction processing abnormally"},
+                        _stacktrace}
+                     },
+                     @assert_receive_db_timeout
 
       refute_received _
 
@@ -155,7 +164,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
       num_txn = 2
       num_ops = 8
       max_sleep = 20
-      receive_timeout = max((num_txn + num_ops) * max_sleep * 2, 1000)
+      receive_timeout = max((num_txn + num_ops) * max_sleep * 2, @assert_receive_db_timeout)
 
       # Insert `num_txn` transactions, each in a separate process. Every transaction has
       # `num_ops` INSERTs with a random delay between each operation.
@@ -427,7 +436,9 @@ defmodule Electric.Postgres.ReplicationClientTest do
   end
 
   defp receive_tx_change do
-    assert_receive {:from_replication, %Transaction{changes: [change]}}
+    assert_receive {:from_replication, %Transaction{changes: [change]}},
+                   @assert_receive_db_timeout
+
     change
   end
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -923,8 +923,6 @@ defmodule Electric.ShapeCacheTest do
 
     defp restart_shape_cache(context) do
       stop_shape_cache(context)
-      # Wait 1 millisecond to ensure shape handles are not generated the same
-      Process.sleep(1)
 
       with_shape_cache(Map.put(context, :inspector, @stub_inspector),
         create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -197,7 +197,7 @@ defmodule Support.ComponentSetup do
          stack_events_registry: stack_events_registry,
          persistent_kv: kv,
          storage: storage,
-         connection_opts: ctx.db_config,
+         connection_opts: ctx.pooled_db_config,
          replication_opts: [
            connection_opts: ctx.db_config,
            slot_name: "electric_test_slot_#{:erlang.phash2(stack_id)}",

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -199,6 +199,7 @@ defmodule Support.ComponentSetup do
          storage: storage,
          connection_opts: ctx.db_config,
          replication_opts: [
+           connection_opts: ctx.db_config,
            slot_name: "electric_test_slot_#{:erlang.phash2(stack_id)}",
            publication_name: publication_name,
            try_creating_publication?: true,

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -22,7 +22,7 @@ defmodule Support.DbSetup do
     db_name = "#{db_name_hash} ~ #{String.slice(full_db_name, 0..50)}"
 
     escaped_db_name = :binary.replace(db_name, ~s'"', ~s'""', [:global])
-    drop_database(utility_pool, escaped_db_name)
+    Postgrex.query!(utility_pool, "DROP DATABASE IF EXISTS \"#{escaped_db_name}\"", [])
     Postgrex.query!(utility_pool, "CREATE DATABASE \"#{escaped_db_name}\"", [])
 
     Enum.each(database_settings(ctx), fn setting ->

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -9,7 +9,7 @@ defmodule Support.DbSetup do
   ]
 
   def with_unique_db(ctx) do
-    base_config = Application.fetch_env!(:electric, :connection_opts)
+    base_config = Application.fetch_env!(:electric, :replication_connection_opts)
     {:ok, utility_pool} = start_db_pool(base_config)
     Process.unlink(utility_pool)
 
@@ -67,7 +67,7 @@ defmodule Support.DbSetup do
   end
 
   def with_shared_db(_ctx) do
-    config = Application.fetch_env!(:electric, :connection_opts)
+    config = Application.fetch_env!(:electric, :replication_connection_opts)
     {:ok, pool} = start_db_pool(config)
     {:ok, %{pool: pool, db_config: config, db_conn: pool}}
   end

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -45,7 +45,7 @@ defmodule Support.DbSetup do
       |> Keyword.put(:database, db_name)
       |> Keyword.merge(List.wrap(ctx[:connection_opt_overrides]))
 
-    {:ok, pool} = start_db_pool(updated_query_config)
+    {:ok, pool} = start_db_pool(updated_replication_config)
 
     {:ok,
      %{

--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -53,6 +53,23 @@ For a secure connection, set the `sslmode` query parameter to `require`.
 
 </EnvVarConfig>
 
+### ELECTRIC_QUERY_DATABASE_URL
+
+<EnvVarConfig
+    name="ELECTRIC_QUERY_DATABASE_URL"
+    required={false}
+    example="postgresql://user:password@example-pooled.com:54321/electric">
+
+Postgres connection string. Used to connect to the Postgres database for anything but the replication.
+
+The connection string must be in the [libpg Connection URI format](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS) of `postgresql://[userspec@][hostspec][/dbname][?sslmode=<sslmode>]`.
+
+The `userspec` section of the connection string specifies the database user that Electric connects to Postgres as. This can point to a connection pooler and does not need a `REPLICATION` role as it does not handle the replication.
+
+For a secure connection, set the `sslmode` query parameter to `require`.
+
+</EnvVarConfig>
+
 ### ELECTRIC_DATABASE_USE_IPV6
 
 <EnvVarConfig

--- a/website/docs/guides/deployment.md
+++ b/website/docs/guides/deployment.md
@@ -91,6 +91,8 @@ You connect to Postgres using a [`DATABASE_URL`](/docs/api/config#database-url) 
 
 You usually want to connect directly to Postgres and not via a connection pool. This is because Electric uses logical replication and most connection poolers don't support it. (pgBouncer does support logical replication, [as of version 1.23](https://www.pgbouncer.org/changelog.html#pgbouncer-123x) so this may change in future).
 
+You can optionally provide a separate [`ELECTRIC_QUERY_DATABASE_URL`](/docs/api/config#electric-query-database-url) env var, which can use a pooler and will be used for all queries other than replication.
+
 > [!Tip] Troubleshooting common errors
 > If you get a TCP connection error saying `non-existing domain - :nxdomain` or `network is unreachable - :enetunreach` then you may need to connect using IPv6. You can enable this by setting [`ELECTRIC_DATABASE_USE_IPV6=true`](/docs/api/config#database-use-ipv6).
 >


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/1885

- Introduce separate env var `ELECTRIC_QUERY_DATABASE_URL`
- Add another `connection_opts` field to `replication_opts`, so there are two of them
- Fallback to using the same ones, but still keep them separate and maintain them separately
  - Main disadvantage of this approach is that the fallbacks for SSL and IPv6 might need to happen twice if a separate connection string is not being used - this can be improved by only populating the `replication_opts`'s `connection_opts` right before starting the replication client with the single `connection_opts` available if a separate one was not provided.
- Make all tests (e.g. router tests) use a `pgBouncer` connection string
  - Had to ensure connections are terminated explicitly at the end of the test to avoid hanging connections from the pooler making the tests really slow.

## TODO
- [x] Write integration test with `pgBouncer` as well that simply syncs a shape with a pooled connection URL, although the unit tests already cover that
- [ ] Avoid duplicate SSL and IPv6 fallbacks when separate query connection string is not provided 