### PR TITLE
fix: ensure graceful crash when `ALTER TABLE` can't take a lock

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -82,7 +82,7 @@ jobs:
         run: mix compile --force --all-warnings --warnings-as-errors
 
       - name: Run tests
-        run: mix test
+        run: mix test --include slow
 
   formatting:
     name: Check formatting

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -148,7 +148,7 @@ defmodule Electric.ShapeCache do
 
       true ->
         server = Electric.Shapes.Consumer.name(stack_id, shape_handle)
-        GenServer.call(server, :await_snapshot_start)
+        GenServer.call(server, :await_snapshot_start, 15_000)
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -507,7 +507,7 @@ defmodule Electric.Shapes.Api do
 
         Response.error(
           request,
-          "Unable retrieve shape log: #{Exception.format(:error, error, [])}",
+          "Unable to retrieve shape log: #{Exception.format(:error, error, [])}",
           status: 500
         )
     end

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -85,6 +85,14 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
                       consumer,
                       {:snapshot_failed, shape_handle, error, __STACKTRACE__}
                     )
+                catch
+                  :exit, {:timeout, {GenServer, :call, _}} ->
+                    GenServer.cast(
+                      consumer,
+                      {:snapshot_failed, shape_handle,
+                       %RuntimeError{message: "Timed out while waiting for a table lock"},
+                       __STACKTRACE__}
+                    )
                 end
               end
             )

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -4,4 +4,4 @@
 # supervision tree in the test environment.
 # Registry.start_link(name: Electric.Application.process_registry(), keys: :unique)
 
-ExUnit.start(assert_receive_timeout: 400)
+ExUnit.start(assert_receive_timeout: 400, exclude: [slow: true])


### PR DESCRIPTION
"Graceful" here means we return a 500 with a clear error, and next request will succeed if that one can take out a lock. That's instead of crash that leaves the system in unrecoverable state. Closes #2403 