### PR TITLE
feat: remove full table info from shape definitions to lower mem

### DIFF
--- a/.changeset/big-candles-approve.md
+++ b/.changeset/big-candles-approve.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+feat: lower the per-shape memory usage, especially for very large tables

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -177,13 +177,14 @@ defmodule Electric.Replication.Changes do
 
   defmodule Relation do
     @derive Jason.Encoder
-    defstruct [:id, :schema, :table, :columns]
+    defstruct [:id, :schema, :table, :columns, affected_columns: []]
 
     @type t() :: %__MODULE__{
             id: Changes.relation_id(),
             schema: Changes.db_identifier(),
             table: Changes.db_identifier(),
-            columns: [Column.t()]
+            columns: [Column.t()],
+            affected_columns: [Changes.db_identifier()]
           }
   end
 

--- a/packages/sync-service/lib/electric/replication/eval/expr.ex
+++ b/packages/sync-service/lib/electric/replication/eval/expr.ex
@@ -3,6 +3,7 @@ defmodule Electric.Replication.Eval.Expr do
   Parsed expression, available for evaluation using the runner
   """
 
+  alias Electric.Replication.Eval.Parser
   alias Electric.Replication.Eval.Env
 
   defstruct [:query, :eval, :used_refs, :returns]
@@ -36,5 +37,42 @@ defmodule Electric.Replication.Eval.Expr do
     # Keep only used refs that are pointing to current table
     |> Enum.filter(&match?({[_], _}, &1))
     |> Enum.map(fn {[key], _} -> key end)
+  end
+
+  @doc false
+  @spec to_json_safe(t()) :: map()
+  def to_json_safe(%__MODULE__{query: query, used_refs: used_refs}) do
+    %{
+      version: 1,
+      query: query,
+      used_refs:
+        Enum.map(used_refs, fn
+          {k, v} when is_tuple(v) -> [k, Tuple.to_list(v)]
+          {k, v} -> [k, v]
+        end)
+    }
+  end
+
+  @doc false
+  @spec from_json_safe(map()) :: {:ok, t()} | {:error, String.t()}
+  def from_json_safe(%{"version" => 1, "query" => query, "used_refs" => refs}) do
+    refs =
+      Map.new(refs, fn
+        [k, v] when is_list(v) -> {k, List.to_tuple(v)}
+        [k, v] when is_binary(v) -> {k, String.to_existing_atom(v)}
+      end)
+
+    Parser.parse_and_validate_expression(query, refs: refs)
+  end
+
+  def from_json_safe(_),
+    do: {:error, "Incorrect serialized format: keys must be `version`, `query`, `used_refs`"}
+end
+
+defimpl Jason.Encoder, for: Electric.Replication.Eval.Expr do
+  def encode(expr, opts) do
+    expr
+    |> Electric.Replication.Eval.Expr.to_json_safe()
+    |> Jason.Encode.map(opts)
   end
 end

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -73,7 +73,9 @@ defmodule Electric.Replication.ShapeLogCollector do
         subscriptions: {0, MapSet.new()},
         persistent_replication_data_opts: persistent_replication_data_opts,
         last_seen_lsn:
-          PersistentReplicationState.get_last_processed_lsn(persistent_replication_data_opts)
+          PersistentReplicationState.get_last_processed_lsn(persistent_replication_data_opts),
+        tracked_relations:
+          PersistentReplicationState.get_tracked_relations(persistent_replication_data_opts)
       })
 
     # start in demand: :accumulate mode so that the ShapeCache is able to start
@@ -107,6 +109,12 @@ defmodule Electric.Replication.ShapeLogCollector do
     :ok =
       PersistentReplicationState.set_last_processed_lsn(
         state.last_seen_lsn,
+        state.persistent_replication_data_opts
+      )
+
+    :ok =
+      PersistentReplicationState.set_tracked_relations(
+        state.tracked_relations,
         state.persistent_replication_data_opts
       )
 
@@ -181,19 +189,109 @@ defmodule Electric.Replication.ShapeLogCollector do
     {:noreply, [txn], %{state | producer: from} |> put_last_seen_lsn(txn.lsn)}
   end
 
-  defp handle_relation(rel, _from, %{subscriptions: {0, _}} = state) do
-    Logger.debug(fn ->
-      "Dropping relation message for #{inspect(rel.schema)}.#{inspect(rel.table)}: no active consumers"
-    end)
-
-    OpenTelemetry.add_span_attributes("rel.is_dropped": true)
-
-    {:reply, :ok, [], state}
-  end
-
   defp handle_relation(rel, from, state) do
     OpenTelemetry.add_span_attributes("rel.is_dropped": false)
-    {:noreply, [rel], %{state | producer: from}}
+
+    {updated_rel, updated_state} = track_relation(rel, state)
+
+    case updated_state do
+      %{subscriptions: {0, _}} ->
+        Logger.debug(fn ->
+          "Dropping relation message for #{inspect(rel.schema)}.#{inspect(rel.table)}: no active consumers"
+        end)
+
+        :ok =
+          PersistentReplicationState.set_tracked_relations(
+            state.tracked_relations,
+            state.persistent_replication_data_opts
+          )
+
+        {:reply, :ok, [], updated_state}
+
+      updated_state ->
+        {:noreply, [updated_rel], %{updated_state | producer: from}}
+    end
+  end
+
+  # Helper functions to access relation properties
+  defp schema_table_key(%Relation{schema: schema, table: table}), do: {schema, table}
+  defp schema_table_key(nil), do: nil
+
+  # Tracks a relation and detects changes
+  defp track_relation(
+         %Relation{schema: schema, table: table} = rel,
+         %{tracked_relations: %{id_to_table_info: id_to_table_info, table_to_id: table_to_id}} =
+           state
+       ) do
+    id = rel.id
+    schema_table = schema_table_key(rel)
+
+    # Look up existing relations
+    existing_id = Map.get(table_to_id, schema_table)
+    existing_rel = Map.get(id_to_table_info, id)
+
+    case {existing_id, existing_rel} do
+      # New relation, register it
+      {nil, nil} ->
+        {rel, add_relation(state, id, rel)}
+
+      # Relation identity matches known, let's compare columns
+      {^id, %Relation{schema: ^schema, table: ^table}} ->
+        case find_differing_columns(existing_rel, rel) do
+          # No (noticable) changes to the relation, continue as-is
+          [] ->
+            {rel, state}
+
+          affected_cols ->
+            updated_rel = %{rel | affected_columns: affected_cols}
+            {updated_rel, add_relation(state, id, rel)}
+        end
+
+      # Some part of identity changed, update the state and pass it through
+      {_, _} ->
+        Logger.debug(fn ->
+          "Relation identity changed: #{existing_id}/#{inspect(existing_rel)} -> #{inspect(rel)}"
+        end)
+
+        {rel,
+         state
+         |> delete_tracked_relation(schema_table_key(existing_rel), existing_id)
+         |> add_relation(id, rel)}
+    end
+  end
+
+  defp add_relation(state, id, rel) do
+    # new_table_to_id = Map.put(state.tracked_relations.table_to_id, schema_table_key(rel), id)
+    # new_id_to_table_info = Map.put(state.tracked_relations.id_to_table_info, id, rel)
+    # %{state | tracked_relations: %{state.tracked_relations | table_to_id: new_table_to_id, id_to_table_info: new_id_to_table_info}}
+    state
+    |> put_in([:tracked_relations, :table_to_id, schema_table_key(rel)], id)
+    |> put_in([:tracked_relations, :id_to_table_info, id], rel)
+  end
+
+  defp delete_tracked_relation(state, schema_table, id) do
+    state
+    |> update_in([:tracked_relations, :table_to_id], &Map.delete(&1, schema_table))
+    |> update_in([:tracked_relations, :id_to_table_info], &Map.delete(&1, id))
+  end
+
+  defp find_differing_columns(%Relation{columns: old_cols}, %Relation{columns: new_cols})
+       when old_cols == new_cols,
+       do: []
+
+  defp find_differing_columns(%Relation{columns: old_cols}, %Relation{columns: new_cols}) do
+    (old_cols ++ new_cols)
+    |> Enum.reduce(%{}, fn
+      %{name: name, type_oid: type_oid}, acc when is_map_key(acc, name) ->
+        # We're seeing column with this name for a second time, so we can remove it from the diff if type oid is the same
+        if acc[name] == type_oid, do: Map.delete(acc, name), else: acc
+
+      %{name: name, type_oid: type_oid}, acc ->
+        # If we're seeing column with this name for a first time, it'll either stay if it's present only in one set,
+        # or be deleted if seen again
+        Map.put(acc, name, type_oid)
+    end)
+    |> Map.keys()
   end
 
   defp drop_transaction(txn, state) do

--- a/packages/sync-service/lib/electric/replication/shape_log_collector/affected_columns.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector/affected_columns.ex
@@ -1,0 +1,87 @@
+defmodule Electric.Replication.ShapeLogCollector.AffectedColumns do
+  @moduledoc false
+
+  require Logger
+  alias Electric.Replication.Changes.Relation
+
+  def init(%{id_to_table_info: id_to_table_info, table_to_id: table_to_id})
+      when is_map(id_to_table_info) and is_map(table_to_id) do
+    {:ok, %{id_to_table_info: id_to_table_info, table_to_id: table_to_id}}
+  end
+
+  def transform_relation(
+        %Relation{schema: schema, table: table, id: id} = rel,
+        %{
+          id_to_table_info: id_to_table_info,
+          table_to_id: table_to_id
+        } = state
+      ) do
+    schema_table = {schema, table}
+
+    existing_id = Map.get(table_to_id, schema_table)
+    existing_rel = Map.get(id_to_table_info, id)
+
+    case {existing_id, existing_rel} do
+      # New relation, register it
+      {nil, nil} ->
+        {rel, add_relation(state, id, rel)}
+
+      # Relation identity matches known, let's compare columns
+      {^id, %Relation{schema: ^schema, table: ^table}} ->
+        case find_differing_columns(existing_rel, rel) do
+          # No (noticable) changes to the relation, continue as-is
+          [] ->
+            {rel, state}
+
+          affected_cols ->
+            updated_rel = %{rel | affected_columns: affected_cols}
+            {updated_rel, add_relation(state, id, rel)}
+        end
+
+      # Some part of identity changed, update the state and pass it through
+      {_, _} ->
+        Logger.debug(fn ->
+          "Relation identity changed: #{existing_id}/#{inspect(existing_rel)} -> #{inspect(rel)}"
+        end)
+
+        {rel,
+         state
+         |> delete_tracked_relation(schema_table_key(existing_rel), existing_id)
+         |> add_relation(id, rel)}
+    end
+  end
+
+  defp schema_table_key(%Relation{schema: schema, table: table}), do: {schema, table}
+  defp schema_table_key(nil), do: nil
+
+  defp add_relation(state, id, rel) do
+    state
+    |> put_in([:table_to_id, schema_table_key(rel)], id)
+    |> put_in([:id_to_table_info, id], rel)
+  end
+
+  defp delete_tracked_relation(state, schema_table, id) do
+    state
+    |> update_in([:table_to_id], &Map.delete(&1, schema_table))
+    |> update_in([:id_to_table_info], &Map.delete(&1, id))
+  end
+
+  defp find_differing_columns(%Relation{columns: old_cols}, %Relation{columns: new_cols})
+       when old_cols == new_cols,
+       do: []
+
+  defp find_differing_columns(%Relation{columns: old_cols}, %Relation{columns: new_cols}) do
+    (old_cols ++ new_cols)
+    |> Enum.reduce(%{}, fn
+      %{name: name, type_oid: type_oid}, acc when is_map_key(acc, name) ->
+        # We're seeing column with this name for a second time, so we can remove it from the diff if type oid is the same
+        if acc[name] == type_oid, do: Map.delete(acc, name), else: acc
+
+      %{name: name, type_oid: type_oid}, acc ->
+        # If we're seeing column with this name for a first time, it'll either stay if it's present only in one set,
+        # or be deleted if seen again
+        Map.put(acc, name, type_oid)
+    end)
+    |> Map.keys()
+  end
+end

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -167,7 +167,7 @@ defmodule Electric.ShapeCache.FileStorage do
 
           with {:ok, shape_def_encoded} <- File.read(shape_def_path),
                {:ok, shape_def_json} <- Jason.decode(shape_def_encoded),
-               shape = Electric.Shapes.Shape.from_json_safe!(shape_def_json) do
+               {:ok, shape} <- Electric.Shapes.Shape.from_json_safe(shape_def_json) do
             Map.put(acc, shape_handle, shape)
           else
             # if the shape definition file cannot be read/decoded, just ignore it

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -54,6 +54,7 @@ defmodule Electric.Shapes.Api.Response do
       args
       |> Keyword.put_new(:status, 400)
       |> Keyword.put(:body, error_body(api, message, args))
+      |> Keyword.put(:api, api)
 
     struct(__MODULE__, opts)
   end
@@ -64,6 +65,7 @@ defmodule Electric.Shapes.Api.Response do
       |> Keyword.put_new(:status, 400)
       |> Keyword.put(:body, error_body(request, message, args))
       |> Keyword.put(:shape_definition, request.params.shape_definition)
+      |> Keyword.put(:api, request.api)
 
     struct(__MODULE__, opts)
   end

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -51,16 +51,11 @@ defmodule Electric.Shapes.Querying do
     end)
   end
 
-  defp json_like_select(
-         %Shape{
-           table_info: table_info,
-           root_table: root_table,
-           selected_columns: selected_columns
-         } = shape
-       ) do
-    pk_cols = Shape.pk(shape)
-    columns = get_column_names(table_info, root_table, selected_columns)
-
+  defp json_like_select(%Shape{
+         root_table: root_table,
+         selected_columns: columns,
+         root_pk: pk_cols
+       }) do
     key_part = build_key_part(root_table, pk_cols)
     value_part = build_value_part(columns)
     headers_part = build_headers_part(root_table)
@@ -81,17 +76,6 @@ defmodule Electric.Shapes.Querying do
       ~s['{' || #{key_part} || ',' || #{value_part} || ',' || #{headers_part} || '}']
 
     {query, []}
-  end
-
-  defp get_column_names(table_info, root_table, nil) do
-    table_info
-    |> Map.fetch!(root_table)
-    |> Map.fetch!(:columns)
-    |> Enum.map(& &1.name)
-  end
-
-  defp get_column_names(_table_info, _root_table, selected_columns) do
-    selected_columns
   end
 
   defp build_headers_part(root_table) do

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -17,18 +17,16 @@ defmodule Electric.Plug.DeleteShapePlugTest do
   @test_shape %Shape{
     root_table: {"public", "users"},
     root_table_id: :erlang.phash2({"public", "users"}),
-    table_info: %{
-      {"public", "users"} => %{
-        columns: [%{name: "id", type: "int8", pk_position: 0, type_id: {20, -1}}],
-        pk: ["id"]
-      }
-    }
+    root_pk: ["id"],
+    root_column_count: 1,
+    selected_columns: ["id"],
+    flags: %{selects_all_columns: true}
   }
   @test_shape_handle "test-shape-handle"
   @test_pg_id "12345"
 
   def load_column_info({"public", "users"}, _),
-    do: {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
+    do: {:ok, [%{name: "id", type: "int8", pk_position: 0, type_id: {20, -1}}]}
 
   def load_relation(tbl, _),
     do: Support.StubInspector.load_relation(tbl, nil)

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -23,15 +23,10 @@ defmodule Electric.Plug.ServeShapePlugTest do
   @test_shape %Shape{
     root_table: {"public", "users"},
     root_table_id: :erlang.phash2({"public", "users"}),
-    table_info: %{
-      {"public", "users"} => %{
-        columns: [
-          %{name: "id", type: "int8", type_id: {20, 1}, pk_position: 0, array_dimensions: 0},
-          %{name: "value", type: "text", type_id: {28, 1}, pk_position: nil, array_dimensions: 0}
-        ],
-        pk: ["id"]
-      }
-    }
+    root_column_count: 2,
+    root_pk: ["id"],
+    selected_columns: ["id", "value"],
+    flags: %{selects_all_columns: true}
   }
   @test_shape_handle "test-shape-handle"
   @test_opts %{foo: "bar"}
@@ -45,7 +40,12 @@ defmodule Electric.Plug.ServeShapePlugTest do
   @receive_timeout 2000
 
   def load_column_info({"public", "users"}, _),
-    do: {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
+    do:
+      {:ok,
+       [
+         %{name: "id", type: "int8", type_id: {20, 1}, pk_position: 0, array_dimensions: 0},
+         %{name: "value", type: "text", type_id: {28, 1}, pk_position: nil, array_dimensions: 0}
+       ]}
 
   def load_column_info(_, _),
     do: :table_not_found

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -16,30 +16,20 @@ defmodule Electric.Replication.PublicationManagerTest do
   }
 
   defp generate_shape(relation, where_clause \\ nil, selected_columns \\ nil) do
+    all_columns = Enum.uniq(["id", "value", "foo_enum"] ++ (selected_columns || []))
+    selected_columns = selected_columns || all_columns
+
     %Shape{
       root_table: relation,
       root_table_id: 1,
-      table_info: %{
-        relation => %{
-          columns:
-            [
-              %{name: "id", type: :text, type_kind: :base, type_id: {25, 1}},
-              %{name: "value", type: :text, type_kind: :base, type_id: {25, 1}},
-              %{
-                name: "foo_enum",
-                type: {:enum, "foo_enum"},
-                type_kind: :enum,
-                type_id: {2999, 1}
-              }
-            ] ++
-              Enum.map(selected_columns || [], fn col ->
-                %{name: col, type: :text, type_id: {25, 1}}
-              end),
-          pk: ["id"]
-        }
+      root_pk: ["id"],
+      selected_columns: selected_columns,
+      flags: %{
+        selects_all_columns: selected_columns == all_columns,
+        non_primitive_columns_in_where:
+          where_clause && is_map_key(where_clause.used_refs, ["foo_enum"])
       },
-      where: where_clause,
-      selected_columns: selected_columns
+      where: where_clause
     }
   end
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector/affected_columns_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector/affected_columns_test.exs
@@ -1,0 +1,264 @@
+defmodule Electric.Replication.ShapeLogCollector.AffectedColumnsTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Replication.ShapeLogCollector.AffectedColumns
+  alias Electric.Replication.Changes.{Relation, Column}
+
+  setup do
+    init_state = %{id_to_table_info: %{}, table_to_id: %{}}
+    {:ok, state} = AffectedColumns.init(init_state)
+    # The state returned by init/1 is our starting state
+    %{state: state}
+  end
+
+  describe "transform_relation/2" do
+    test "adding new relation", %{state: state} do
+      relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25}
+        ]
+      }
+
+      {returned_relation, new_state} = AffectedColumns.transform_relation(relation, state)
+
+      # Verify relation is returned unchanged
+      assert returned_relation == relation
+      # Verify relation is added to state
+      assert new_state.table_to_id[{"public", "users"}] == 1
+      assert new_state.id_to_table_info[1] == relation
+    end
+
+    test "adding a second unrelated relation", %{state: state} do
+      # First relation
+      relation1 = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25}
+        ]
+      }
+
+      {_, state_with_first} = AffectedColumns.transform_relation(relation1, state)
+
+      # Second relation
+      relation2 = %Relation{
+        id: 2,
+        schema: "public",
+        table: "posts",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "title", type_oid: 25},
+          %Column{name: "content", type_oid: 25}
+        ]
+      }
+
+      {returned_relation, new_state} =
+        AffectedColumns.transform_relation(relation2, state_with_first)
+
+      # Verify relation is returned unchanged
+      assert returned_relation == relation2
+      # Verify both relations are in state
+      assert new_state.table_to_id[{"public", "users"}] == 1
+      assert new_state.table_to_id[{"public", "posts"}] == 2
+      assert new_state.id_to_table_info[1] == relation1
+      assert new_state.id_to_table_info[2] == relation2
+    end
+
+    test "relation with same id/schema/table but column was added", %{state: state} do
+      # Original relation
+      original_relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25}
+        ]
+      }
+
+      {_, state_with_original} = AffectedColumns.transform_relation(original_relation, state)
+
+      # Updated relation with new column
+      updated_relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25},
+          %Column{name: "email", type_oid: 25}
+        ]
+      }
+
+      {returned_relation, new_state} =
+        AffectedColumns.transform_relation(updated_relation, state_with_original)
+
+      # Verify "email" is detected as an affected column
+      assert returned_relation.affected_columns == ["email"]
+      # Verify state is updated with the new relation
+      assert new_state.id_to_table_info[1] == updated_relation
+      assert new_state.table_to_id[{"public", "users"}] == 1
+    end
+
+    test "relation with same id/schema/table but column type changed", %{state: state} do
+      # Original relation
+      original_relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25}
+        ]
+      }
+
+      {_, state_with_original} = AffectedColumns.transform_relation(original_relation, state)
+
+      # Updated relation with changed column type
+      updated_relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          # Changed type OID
+          %Column{name: "name", type_oid: 26}
+        ]
+      }
+
+      {returned_relation, new_state} =
+        AffectedColumns.transform_relation(updated_relation, state_with_original)
+
+      # Verify "name" is detected as an affected column
+      assert returned_relation.affected_columns == ["name"]
+      # Verify state is updated with the new relation
+      assert new_state.id_to_table_info[1] == updated_relation
+      assert new_state.table_to_id[{"public", "users"}] == 1
+    end
+
+    test "relation with same id/schema/table but column name and type changed", %{state: state} do
+      # Original relation
+      original_relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25},
+          %Column{name: "description", type_oid: 25}
+        ]
+      }
+
+      {_, state_with_original} = AffectedColumns.transform_relation(original_relation, state)
+
+      # Updated relation with both name and type changes
+      updated_relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          # Changed name
+          %Column{name: "username", type_oid: 25},
+          # Changed type
+          %Column{name: "description", type_oid: 26}
+        ]
+      }
+
+      {returned_relation, new_state} =
+        AffectedColumns.transform_relation(updated_relation, state_with_original)
+
+      # Verify both "name"/"username" and "description" are affected columns
+      assert Enum.sort(returned_relation.affected_columns) ==
+               Enum.sort(["name", "username", "description"])
+
+      # Verify state is updated with the new relation
+      assert new_state.id_to_table_info[1] == updated_relation
+      assert new_state.table_to_id[{"public", "users"}] == 1
+    end
+
+    test "relation with changed id but same schema/table & column list", %{state: state} do
+      # Original relation
+      original_relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25}
+        ]
+      }
+
+      {_, state_with_original} = AffectedColumns.transform_relation(original_relation, state)
+
+      # Relation with changed ID
+      updated_relation = %Relation{
+        id: 2,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25}
+        ]
+      }
+
+      {returned_relation, new_state} =
+        AffectedColumns.transform_relation(updated_relation, state_with_original)
+
+      # Verify relation is returned unchanged
+      assert returned_relation == updated_relation
+      # Verify old ID is removed
+      refute Map.has_key?(new_state.id_to_table_info, 1)
+      # Verify new ID is added
+      assert new_state.id_to_table_info == %{2 => updated_relation}
+      # Verify schema/table points to new ID
+      assert new_state.table_to_id == %{{"public", "users"} => 2}
+    end
+
+    test "relation with changed schema/table but same id & column list", %{state: state} do
+      # Original relation
+      original_relation = %Relation{
+        id: 1,
+        schema: "public",
+        table: "users",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25}
+        ]
+      }
+
+      {_, state_with_original} = AffectedColumns.transform_relation(original_relation, state)
+
+      # Relation with changed schema/table
+      updated_relation = %Relation{
+        id: 1,
+        # Changed schema
+        schema: "app",
+        # Changed table
+        table: "accounts",
+        columns: [
+          %Column{name: "id", type_oid: 23},
+          %Column{name: "name", type_oid: 25}
+        ]
+      }
+
+      {returned_relation, new_state} =
+        AffectedColumns.transform_relation(updated_relation, state_with_original)
+
+      # Verify relation is returned unchanged
+      assert returned_relation == updated_relation
+      # Verify old schema/table mapping is removed
+      refute Map.has_key?(new_state.table_to_id, {"public", "users"})
+      # Verify new schema/table is added
+      assert new_state.table_to_id == %{{"app", "accounts"} => 1}
+      # Verify ID still points to the updated relation
+      assert new_state.id_to_table_info == %{1 => updated_relation}
+    end
+  end
+end

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -19,12 +19,12 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   @shape %Shape{
     root_table: {"public", "items"},
     root_table_id: 1,
-    table_info: %{
-      {"public", "items"} => %{
-        columns: [%{name: "id", type: :text}, %{name: "value", type: :text}],
-        pk: ["id"]
-      }
-    }
+    root_pk: ["id"],
+    selected_columns: ["id"],
+    where:
+      Electric.Replication.Eval.Parser.parse_and_validate_expression!("id != '1'",
+        refs: %{["id"] => :text}
+      )
   }
 
   @snapshot_offset LogOffset.first()
@@ -671,8 +671,10 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         storage.initialise(opts)
         storage.set_shape_definition(@shape, opts)
 
-        assert {:ok, %{@shape_handle => @shape}} =
+        assert {:ok, %{@shape_handle => parsed}} =
                  Electric.ShapeCache.Storage.get_all_stored_shapes({storage, opts})
+
+        assert @shape == parsed
       end
     end
 
@@ -729,7 +731,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         storage.initialise(shape_opts)
         storage.set_shape_definition(@shape, shape_opts)
 
-        assert 2330 = Electric.ShapeCache.Storage.get_total_disk_usage({storage, opts})
+        assert Electric.ShapeCache.Storage.get_total_disk_usage({storage, opts}) > 2300
       end
     end
   end

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -15,15 +15,10 @@ defmodule Electric.Shapes.ApiTest do
   @test_shape %Shape{
     root_table: {"public", "users"},
     root_table_id: :erlang.phash2({"public", "users"}),
-    table_info: %{
-      {"public", "users"} => %{
-        columns: [
-          %{name: "id", type: "int8", type_id: {20, 1}, pk_position: 0, array_dimensions: 0},
-          %{name: "value", type: "text", type_id: {28, 1}, pk_position: nil, array_dimensions: 0}
-        ],
-        pk: ["id"]
-      }
-    }
+    root_column_count: 2,
+    root_pk: ["id"],
+    selected_columns: ["id", "value"],
+    flags: %{selects_all_columns: true}
   }
   @registry __MODULE__.Registry
   @test_shape_handle "test-shape-handle"
@@ -38,7 +33,11 @@ defmodule Electric.Shapes.ApiTest do
   @receive_timeout 1000
 
   def load_column_info({"public", "users"}, _) do
-    {:ok, @test_shape.table_info[{"public", "users"}][:columns]}
+    {:ok,
+     [
+       %{name: "id", type: "int8", type_id: {20, 1}, pk_position: 0, array_dimensions: 0},
+       %{name: "value", type: "text", type_id: {28, 1}, pk_position: nil, array_dimensions: 0}
+     ]}
   end
 
   def load_column_info(_, _),

--- a/packages/sync-service/test/electric/shapes/filter_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter_test.exs
@@ -124,6 +124,47 @@ defmodule Electric.Shapes.FilterTest do
       assert Filter.affected_shapes(filter, rename) == MapSet.new(["s2"])
     end
 
+    test "returns shapes affected by column addition" do
+      s1 = Shape.new!("t1", inspector: @inspector)
+      s2 = Shape.new!("t1", inspector: @inspector, columns: ["id", "number"])
+
+      filter =
+        Filter.new()
+        |> Filter.add_shape("s1", s1)
+        |> Filter.add_shape("s2", s2)
+
+      rename = %Relation{
+        schema: "public",
+        table: "t1",
+        id: s1.root_table_id,
+        columns: ["id", "number", "an_array", "new one"]
+      }
+
+      assert Filter.affected_shapes(filter, rename) == MapSet.new(["s1"])
+    end
+
+    test "returns shapes affected by column change" do
+      s1 = Shape.new!("t1", inspector: @inspector)
+      s2 = Shape.new!("t1", inspector: @inspector, columns: ["id", "number"])
+      s3 = Shape.new!("t1", inspector: @inspector, columns: ["id", "an_array"])
+
+      filter =
+        Filter.new()
+        |> Filter.add_shape("s1", s1)
+        |> Filter.add_shape("s2", s2)
+        |> Filter.add_shape("s3", s3)
+
+      rename = %Relation{
+        schema: "public",
+        table: "t1",
+        id: s1.root_table_id,
+        columns: ["id", "number", "an_array"],
+        affected_columns: ["number"]
+      }
+
+      assert Filter.affected_shapes(filter, rename) == MapSet.new(["s1", "s2"])
+    end
+
     test "returns shapes affected by truncation" do
       filter =
         Filter.new()

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -438,69 +438,17 @@ defmodule Electric.Shapes.ShapeTest do
 
   describe "JSON" do
     test "should serialize shape with complex columns" do
-      shape = %Electric.Shapes.Shape{
+      shape = %Shape{
         root_table: {"public", "foo"},
         root_table_id: 1,
-        table_info: %{
-          {"public", "foo"} => %{
-            columns: [
-              %{
-                name: "second",
-                type: :text,
-                formatted_type: "text",
-                type_mod: -1,
-                type_kind: :base,
-                pk_position: 1,
-                type_id: {25, -1},
-                array_dimensions: 0,
-                not_null: true,
-                array_type: nil
-              },
-              %{
-                name: "first",
-                type: :text,
-                formatted_type: "text",
-                type_mod: -1,
-                type_kind: :base,
-                pk_position: 0,
-                type_id: {25, -1},
-                array_dimensions: 0,
-                not_null: true,
-                array_type: nil
-              },
-              %{
-                name: "fourth",
-                type: :text,
-                formatted_type: "text",
-                type_mod: -1,
-                type_kind: :base,
-                pk_position: nil,
-                type_id: {25, -1},
-                array_dimensions: 0,
-                not_null: false,
-                array_type: nil
-              },
-              %{
-                name: "third",
-                type: :text,
-                formatted_type: "text",
-                type_mod: -1,
-                type_kind: :enum,
-                pk_position: 2,
-                type_id: {25, -1},
-                array_dimensions: 0,
-                not_null: true,
-                array_type: nil
-              }
-            ],
-            pk: ["first", "second", "third"]
-          }
-        },
+        root_pk: ["first", "second", "third"],
+        selected_columns: ["first", "second", "third", "fourth"],
+        flags: %{selects_all_columns: true, non_primitive_columns_in_where: true},
         where: nil
       }
 
       assert {:ok, json} = Jason.encode(shape)
-      assert ^shape = Jason.decode!(json) |> Shape.from_json_safe!()
+      assert {:ok, ^shape} = Jason.decode!(json) |> Shape.from_json_safe()
     end
   end
 


### PR DESCRIPTION
## Reasons

We have a process setup where we have 2 layers of supervisors which store entire child spec of their children as state, plus the `ShapeLogCollector` that the shape consumers register with, plus the consumers themselves -- all these processes happen to have shapes in their state. _Arguably, we can inject shapes into consumers bypassing supervisors, but that's a different PR._ These shapes, however, happened to know entire schema of the table they were defined against, which was duplicated a lot. This caused a lot of unnecessary memory usage when the table schema was sufficiently large.

So, in numbers, for a 75 column table, without any transactions going through (just shape creation)
Baseline, no shapes: 71kB
- Current, 300 shapes
	- Total (for shape-related processes): 64.1MB
	- Total overhead in shared processes: 28MB 
	- Total overhead in shared per shape: 93kB
	- Per-shape process total: 35.9MB
	- Per-shape 119kB
- With this PR, 300 shapes
	- Total (for shape-related processes): 21MB
	- Total overhead in shared processes: 7.3MB
	- Total overhead in shared per shape: 24kB
	- Per-shape process total: 13MB
	- Per-shape 45kB

So for a sufficiently large table, this PR drops used memory a lot, 60% in this particular case. Further optimizations of state are possible and we'll do them, but this is the lowest hanging fruit.

## Changes

Shapes now don't store their table's entire schema. That's OK when processing transactions or querying the DB, but that's not enough to invalidate the shape when the schema changes, and it can change while Electric is down as well.

To address this, now the burden of figuring out whether a schema-breaking change has happened from the incoming relations now lies upon `ShapeLogCollector`. It tracks all seen relation messages (which should be relatively rare unless PG is constantly disconnecting), and marks the columns that have changed within this relation as compared to a previously seen version. It also saves these last-seen relations when all shapes have reacted to it and invalidated themselves.