### PR TITLE
chore: Rename server header to electric-server

### DIFF
--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -45,7 +45,7 @@ defmodule Electric.Plug.Router do
   match _, do: send_resp(conn, 404, "Not found")
 
   def server_header(conn, version),
-    do: conn |> Plug.Conn.put_resp_header("server", "ElectricSQL/#{version}")
+    do: conn |> Plug.Conn.put_resp_header("electric-server", "ElectricSQL/#{version}")
 
   def put_cors_headers(%Plug.Conn{path_info: ["v1", "shape" | _]} = conn, _opts),
     do: CORSHeaderPlug.call(conn, %{methods: ["GET", "HEAD", "DELETE", "OPTIONS"]})


### PR DESCRIPTION
In certain environments, e.g. when running in a cloudflare tunnel, the `server` header that we set to `"ElectricSQL/#{version}"` gets overwritten by cloudflare with the value `"cloudflare"`. This PR renames the response header to `electric-version` to avoid this and improve visibility.

**Should we mark this as a breaking change or not?**
If someone relies on this header it is in theory a breaking change.
Or we could keep the `server` header and also introduce the `electric-server` header.