### PR TITLE
Removing file writes from the main WAL processing loop

### DIFF
--- a/.changeset/honest-crabs-sing.md
+++ b/.changeset/honest-crabs-sing.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Speed up replication processing by removing file writes from the main processing loop

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -332,6 +332,8 @@ defmodule Electric.Connection.Manager do
             stack_id: state.stack_id,
             persistent_kv: state.persistent_kv
           )
+
+          Electric.LsnTracker.reset(state.stack_id)
         end
 
         {:ok, shapes_sup_pid} =

--- a/packages/sync-service/lib/electric/lsn_tracker.ex
+++ b/packages/sync-service/lib/electric/lsn_tracker.ex
@@ -24,6 +24,10 @@ defmodule Electric.LsnTracker do
     lsn
   end
 
+  def reset(stack_id) do
+    set_last_processed_lsn(Lsn.from_integer(0), stack_id)
+  end
+
   defp table(stack_id) do
     :"#{stack_id}:lsn_tracker"
   end

--- a/packages/sync-service/lib/electric/lsn_tracker.ex
+++ b/packages/sync-service/lib/electric/lsn_tracker.ex
@@ -1,0 +1,30 @@
+defmodule Electric.LsnTracker do
+  alias Electric.Postgres.Lsn
+
+  def init(stack_id) do
+    stack_id
+    |> table()
+    |> :ets.new([:public, :named_table])
+  end
+
+  @spec set_last_processed_lsn(Lsn.t(), String.t()) :: :ok
+  def set_last_processed_lsn(lsn, stack_id) when is_struct(lsn, Lsn) do
+    stack_id
+    |> table()
+    |> :ets.insert({:last_processed_lsn, lsn})
+  end
+
+  @spec get_last_processed_lsn(String.t()) :: Lsn.t()
+  def get_last_processed_lsn(stack_id) do
+    [last_processed_lsn: lsn] =
+      stack_id
+      |> table()
+      |> :ets.lookup(:last_processed_lsn)
+
+    lsn
+  end
+
+  defp table(stack_id) do
+    :"#{stack_id}:lsn_tracker"
+  end
+end

--- a/packages/sync-service/lib/electric/lsn_tracker.ex
+++ b/packages/sync-service/lib/electric/lsn_tracker.ex
@@ -7,21 +7,29 @@ defmodule Electric.LsnTracker do
     |> :ets.new([:public, :named_table])
   end
 
-  @spec set_last_processed_lsn(Lsn.t(), String.t()) :: :ok
+  @spec set_last_processed_lsn(Lsn.t() | non_neg_integer(), String.t()) :: :ok
   def set_last_processed_lsn(lsn, stack_id) when is_struct(lsn, Lsn) do
     stack_id
     |> table()
     |> :ets.insert({:last_processed_lsn, lsn})
   end
 
+  def set_last_processed_lsn(lsn, stack_id) when is_integer(lsn) do
+    set_last_processed_lsn(Lsn.from_integer(lsn), stack_id)
+  end
+
   @spec get_last_processed_lsn(String.t()) :: Lsn.t()
   def get_last_processed_lsn(stack_id) do
-    [last_processed_lsn: lsn] =
-      stack_id
-      |> table()
-      |> :ets.lookup(:last_processed_lsn)
+    stack_id
+    |> table()
+    |> :ets.lookup(:last_processed_lsn)
+    |> case do
+      [last_processed_lsn: lsn] ->
+        lsn
 
-    lsn
+      [] ->
+        Lsn.from_integer(0)
+    end
   end
 
   def reset(stack_id) do

--- a/packages/sync-service/lib/electric/lsn_tracker.ex
+++ b/packages/sync-service/lib/electric/lsn_tracker.ex
@@ -1,10 +1,10 @@
 defmodule Electric.LsnTracker do
   alias Electric.Postgres.Lsn
 
-  def init(stack_id) do
-    stack_id
-    |> table()
-    |> :ets.new([:public, :named_table])
+  def init(last_processed_lsn, stack_id) do
+    create_table(stack_id)
+
+    set_last_processed_lsn(last_processed_lsn, stack_id)
   end
 
   @spec set_last_processed_lsn(Lsn.t() | non_neg_integer(), String.t()) :: :ok
@@ -20,20 +20,22 @@ defmodule Electric.LsnTracker do
 
   @spec get_last_processed_lsn(String.t()) :: Lsn.t()
   def get_last_processed_lsn(stack_id) do
-    stack_id
-    |> table()
-    |> :ets.lookup(:last_processed_lsn)
-    |> case do
-      [last_processed_lsn: lsn] ->
-        lsn
+    [last_processed_lsn: lsn] =
+      stack_id
+      |> table()
+      |> :ets.lookup(:last_processed_lsn)
 
-      [] ->
-        Lsn.from_integer(0)
-    end
+    lsn
   end
 
   def reset(stack_id) do
     set_last_processed_lsn(Lsn.from_integer(0), stack_id)
+  end
+
+  defp create_table(stack_id) do
+    stack_id
+    |> table()
+    |> :ets.new([:protected, :named_table])
   end
 
   defp table(stack_id) do

--- a/packages/sync-service/lib/electric/postgres/lsn.ex
+++ b/packages/sync-service/lib/electric/postgres/lsn.ex
@@ -245,6 +245,7 @@ defmodule Electric.Postgres.Lsn do
       %#{Lsn}{segment: 0, offset: 0}
 
   """
+  @spec max(Enumerable.t(t())) :: t()
   def max([]), do: from_integer(0)
   def max(lsns) when is_list(lsns), do: Enum.max_by(lsns, &to_integer/1)
 

--- a/packages/sync-service/lib/electric/postgres/lsn.ex
+++ b/packages/sync-service/lib/electric/postgres/lsn.ex
@@ -229,26 +229,6 @@ defmodule Electric.Postgres.Lsn do
     |> from_integer()
   end
 
-  @doc """
-  Returns the highest Lsn from the given list of Lsns.
-
-  When the list is empty, it returns #Lsn<0/0>.
-
-  ## Examples
-      iex> max([%#{Lsn}{segment: 0, offset: 1}, %#{Lsn}{segment: 0, offset: 2}])
-      %#{Lsn}{segment: 0, offset: 2}
-
-      iex> max([%#{Lsn}{segment: 1, offset: 1}, %#{Lsn}{segment: 0, offset: 2}])
-      %#{Lsn}{segment: 1, offset: 1}
-
-      iex> max([])
-      %#{Lsn}{segment: 0, offset: 0}
-
-  """
-  @spec max(Enumerable.t(t())) :: t()
-  def max([]), do: from_integer(0)
-  def max(lsns) when is_list(lsns), do: Enum.max_by(lsns, &to_integer/1)
-
   defimpl Inspect do
     def inspect(lsn, _opts) do
       "#Lsn<#{Electric.Postgres.Lsn.to_iolist(lsn)}>"

--- a/packages/sync-service/lib/electric/postgres/lsn.ex
+++ b/packages/sync-service/lib/electric/postgres/lsn.ex
@@ -229,6 +229,25 @@ defmodule Electric.Postgres.Lsn do
     |> from_integer()
   end
 
+  @doc """
+  Returns the highest Lsn from the given list of Lsns.
+
+  When the list is empty, it returns #Lsn<0/0>.
+
+  ## Examples
+      iex> max([%#{Lsn}{segment: 0, offset: 1}, %#{Lsn}{segment: 0, offset: 2}])
+      %#{Lsn}{segment: 0, offset: 2}
+
+      iex> max([%#{Lsn}{segment: 1, offset: 1}, %#{Lsn}{segment: 0, offset: 2}])
+      %#{Lsn}{segment: 1, offset: 1}
+
+      iex> max([])
+      %#{Lsn}{segment: 0, offset: 0}
+
+  """
+  def max([]), do: from_integer(0)
+  def max(lsns) when is_list(lsns), do: Enum.max_by(lsns, &to_integer/1)
+
   defimpl Inspect do
     def inspect(lsn, _opts) do
       "#Lsn<#{Electric.Postgres.Lsn.to_iolist(lsn)}>"

--- a/packages/sync-service/lib/electric/postgres/lsn.ex
+++ b/packages/sync-service/lib/electric/postgres/lsn.ex
@@ -229,6 +229,26 @@ defmodule Electric.Postgres.Lsn do
     |> from_integer()
   end
 
+  @doc """
+  Returns the highest Lsn from the given list of Lsns.
+
+  When the list is empty, it returns #Lsn<0/0>.
+
+  ## Examples
+      iex> max([%#{Lsn}{segment: 0, offset: 1}, %#{Lsn}{segment: 0, offset: 2}])
+      %#{Lsn}{segment: 0, offset: 2}
+
+      iex> max([%#{Lsn}{segment: 1, offset: 1}, %#{Lsn}{segment: 0, offset: 2}])
+      %#{Lsn}{segment: 1, offset: 1}
+
+      iex> max([])
+      %#{Lsn}{segment: 0, offset: 0}
+
+  """
+  @spec max(Enumerable.t(t())) :: t()
+  def max([]), do: from_integer(0)
+  def max(lsns) when is_list(lsns), do: Enum.max_by(lsns, &to_integer/1)
+
   defimpl Inspect do
     def inspect(lsn, _opts) do
       "#Lsn<#{Electric.Postgres.Lsn.to_iolist(lsn)}>"

--- a/packages/sync-service/lib/electric/replication/log_offset.ex
+++ b/packages/sync-service/lib/electric/replication/log_offset.ex
@@ -76,6 +76,7 @@ defmodule Electric.Replication.LogOffset do
       iex> extract_lsn(%LogOffset{tx_offset: 11, op_offset: 5})
       #Lsn<0/B>
   """
+  @spec extract_lsn(t()) :: Lsn.t()
   def extract_lsn(%LogOffset{tx_offset: tx_offset, op_offset: _}), do: Lsn.from_integer(tx_offset)
 
   @doc """

--- a/packages/sync-service/lib/electric/replication/log_offset.ex
+++ b/packages/sync-service/lib/electric/replication/log_offset.ex
@@ -63,6 +63,22 @@ defmodule Electric.Replication.LogOffset do
   def new(%__MODULE__{} = offset), do: offset
 
   @doc """
+  Returns the LSN part of the LogOffset.
+
+  ## Examples
+
+      iex> extract_lsn(%LogOffset{tx_offset: 10, op_offset: 0})
+      #Lsn<0/A>
+
+      iex> extract_lsn(%LogOffset{tx_offset: 10, op_offset: 5})
+      #Lsn<0/A>
+
+      iex> extract_lsn(%LogOffset{tx_offset: 11, op_offset: 5})
+      #Lsn<0/B>
+  """
+  def extract_lsn(%LogOffset{tx_offset: tx_offset, op_offset: _}), do: Lsn.from_integer(tx_offset)
+
+  @doc """
   Compare two log offsets
 
   ## Examples

--- a/packages/sync-service/lib/electric/replication/log_offset.ex
+++ b/packages/sync-service/lib/electric/replication/log_offset.ex
@@ -12,6 +12,9 @@ defmodule Electric.Replication.LogOffset do
 
   defstruct tx_offset: 0, op_offset: 0
 
+  @before_all_tx_offset -1
+  @before_all_op_offset 0
+
   @type int64 :: 0..0xFFFFFFFFFFFFFFFF
   @type t :: %LogOffset{
           tx_offset: int64() | -1,
@@ -67,6 +70,12 @@ defmodule Electric.Replication.LogOffset do
 
   ## Examples
 
+      iex> extract_lsn(LogOffset.before_all())
+      #Lsn<0/0>
+
+      iex> extract_lsn(LogOffset.first())
+      #Lsn<0/0>
+
       iex> extract_lsn(%LogOffset{tx_offset: 10, op_offset: 0})
       #Lsn<0/A>
 
@@ -77,6 +86,9 @@ defmodule Electric.Replication.LogOffset do
       #Lsn<0/B>
   """
   @spec extract_lsn(t()) :: Lsn.t()
+  def extract_lsn(%LogOffset{tx_offset: @before_all_tx_offset, op_offset: @before_all_op_offset}),
+    do: Lsn.from_integer(0)
+
   def extract_lsn(%LogOffset{tx_offset: tx_offset, op_offset: _}), do: Lsn.from_integer(tx_offset)
 
   @doc """
@@ -119,6 +131,26 @@ defmodule Electric.Replication.LogOffset do
                   (offset1.tx_offset == offset2.tx_offset and
                      offset1.op_offset < offset2.op_offset)
 
+  @doc """
+  Returns the maximum offset in the given enumerable.
+
+  ## Examples
+
+      iex> max([])
+      %LogOffset{tx_offset: -1, op_offset: 0}
+
+      iex> max([before_all(), first()])
+      %LogOffset{tx_offset: 0, op_offset: 0}
+
+      iex> max([%LogOffset{tx_offset: 1, op_offset: 1}, before_all(), first()])
+      %LogOffset{tx_offset: 1, op_offset: 1}
+  """
+  @spec max(Enumerable.t(t())) :: t()
+  def max([]), do: before_all()
+
+  def max(offsets) when is_list(offsets),
+    do: Enum.max(offsets, fn a, b -> not is_log_offset_lt(a, b) end)
+
   defguard is_min_offset(offset) when offset.tx_offset == -1
 
   defguard is_virtual_offset(offset) when offset.tx_offset == 0
@@ -132,7 +164,8 @@ defmodule Electric.Replication.LogOffset do
       :lt
   """
   @spec before_all() :: t
-  def before_all(), do: %LogOffset{tx_offset: -1, op_offset: 0}
+  def before_all(),
+    do: %LogOffset{tx_offset: @before_all_tx_offset, op_offset: @before_all_op_offset}
 
   @doc """
   The first possible offset in the log.

--- a/packages/sync-service/lib/electric/replication/persistent_replication_state.ex
+++ b/packages/sync-service/lib/electric/replication/persistent_replication_state.ex
@@ -1,6 +1,5 @@
 defmodule Electric.Replication.PersistentReplicationState do
   alias Electric.PersistentKV
-  alias Electric.Postgres.Lsn
   alias Electric.Replication.Changes
   require Logger
 
@@ -8,27 +7,6 @@ defmodule Electric.Replication.PersistentReplicationState do
           stack_id: String.t(),
           persistent_kv: Electric.PersistentKV.t()
         ]
-
-  @last_processed_lsn_key "last_processed_lsn"
-
-  @spec set_last_processed_lsn(Lsn.t() | non_neg_integer(), opts()) :: :ok
-  def set_last_processed_lsn(lsn, opts) when is_struct(lsn, Lsn) do
-    lsn |> Lsn.to_integer() |> set_last_processed_lsn(opts)
-  end
-
-  def set_last_processed_lsn(lsn, opts) when is_integer(lsn) do
-    Logger.debug("Updating last processed lsn to #{lsn}")
-    set(@last_processed_lsn_key, lsn, opts)
-  end
-
-  @spec get_last_processed_lsn(opts()) :: Lsn.t()
-  def get_last_processed_lsn(opts) do
-    case get(@last_processed_lsn_key, opts) do
-      {:ok, last_processed_lsn} -> last_processed_lsn
-      {:error, :not_found} -> 0
-    end
-    |> Lsn.from_integer()
-  end
 
   @base_tracked_relations %{
     table_to_id: %{},
@@ -55,7 +33,6 @@ defmodule Electric.Replication.PersistentReplicationState do
 
   @spec reset(opts()) :: :ok
   def reset(opts) do
-    set(@last_processed_lsn_key, 0, opts)
     set_tracked_relations(@base_tracked_relations, opts)
   end
 

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -6,6 +6,7 @@ defmodule Electric.Replication.ShapeLogCollector do
   use GenStage
 
   require Electric.Postgres.Lsn
+  alias Electric.Replication.LogOffset
   alias Electric.LsnTracker
   alias Electric.Replication.ShapeLogCollector.AffectedColumns
   alias Electric.Postgres.Lsn
@@ -33,8 +34,8 @@ defmodule Electric.Replication.ShapeLogCollector do
     Electric.ProcessRegistry.name(stack_id, __MODULE__)
   end
 
-  def start_publishing(server, last_processed_lsn) do
-    GenStage.call(server, {:set_last_processed_lsn, last_processed_lsn})
+  def start_processing(server, global_latest_offset) do
+    GenStage.call(server, {:set_last_processed_lsn, LogOffset.extract_lsn(global_latest_offset)})
     :ok = GenStage.demand(server, :forward)
   end
 

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -111,12 +111,12 @@ defmodule Electric.Replication.ShapeLogCollector do
   # last transaction and we can reply to the call and unblock the replication
   # client.
   def handle_demand(_demand, %{producer: producer} = state) do
-    GenServer.reply(producer, :ok)
-
     LsnTracker.set_last_processed_lsn(
       state.last_seen_lsn,
       state.stack_id
     )
+
+    GenServer.reply(producer, :ok)
 
     {:noreply, [], %{state | producer: nil}}
   end

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -117,12 +117,6 @@ defmodule Electric.Replication.ShapeLogCollector do
         state.persistent_replication_data_opts
       )
 
-    :ok =
-      PersistentReplicationState.set_tracked_relations(
-        state.tracked_relations,
-        state.persistent_replication_data_opts
-      )
-
     {:noreply, [], %{state | producer: nil}}
   end
 
@@ -200,17 +194,17 @@ defmodule Electric.Replication.ShapeLogCollector do
     {updated_rel, tracker_state} =
       AffectedColumns.transform_relation(rel, state.tracked_relations)
 
+    :ok =
+      PersistentReplicationState.set_tracked_relations(
+        tracker_state,
+        state.persistent_replication_data_opts
+      )
+
     case state do
       %{subscriptions: {0, _}} ->
         Logger.debug(fn ->
           "Dropping relation message for #{inspect(rel.schema)}.#{inspect(rel.table)}: no active consumers"
         end)
-
-        :ok =
-          PersistentReplicationState.set_tracked_relations(
-            state.tracked_relations,
-            state.persistent_replication_data_opts
-          )
 
         {:reply, :ok, [], %{state | tracked_relations: tracker_state}}
 

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -6,7 +6,6 @@ defmodule Electric.Replication.ShapeLogCollector do
   use GenStage
 
   require Electric.Postgres.Lsn
-  alias Electric.Replication.LogOffset
   alias Electric.LsnTracker
   alias Electric.Replication.ShapeLogCollector.AffectedColumns
   alias Electric.Postgres.Lsn
@@ -34,8 +33,8 @@ defmodule Electric.Replication.ShapeLogCollector do
     Electric.ProcessRegistry.name(stack_id, __MODULE__)
   end
 
-  def start_processing(server, global_latest_offset) do
-    GenStage.call(server, {:set_last_processed_lsn, LogOffset.extract_lsn(global_latest_offset)})
+  def start_processing(server, last_processed_lsn) do
+    GenStage.call(server, {:set_last_processed_lsn, last_processed_lsn})
     :ok = GenStage.demand(server, :forward)
   end
 

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -20,9 +20,7 @@ defmodule Electric.Replication.ShapeLogCollector do
   @schema NimbleOptions.new!(
             stack_id: [type: :string, required: true],
             inspector: [type: :mod_arg, required: true],
-            persistent_kv: [type: :any, required: true],
-            # see https://hexdocs.pm/gen_stage/GenStage.html#c:init/1-options
-            demand: [type: {:in, [:forward, :accumulate]}, default: :accumulate]
+            persistent_kv: [type: :any, required: true]
           )
 
   def start_link(opts) do
@@ -90,7 +88,7 @@ defmodule Electric.Replication.ShapeLogCollector do
     # start in demand: :accumulate mode so that the ShapeCache is able to start
     # all active consumers before we start sending transactions
     {:producer, state,
-     dispatcher: {Electric.Shapes.Dispatcher, inspector: state.inspector}, demand: opts.demand}
+     dispatcher: {Electric.Shapes.Dispatcher, inspector: state.inspector}, demand: :accumulate}
   end
 
   def handle_subscribe(:consumer, _opts, from, state) do

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -34,7 +34,7 @@ defmodule Electric.Replication.Supervisor do
         {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
       )
 
-    children = [consumer_supervisor, publication_manager, shape_cache, log_collector]
+    children = [consumer_supervisor, publication_manager, log_collector, shape_cache]
     Supervisor.init(children, strategy: :one_for_all)
   end
 end

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -34,7 +34,7 @@ defmodule Electric.Replication.Supervisor do
         {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
       )
 
-    children = [consumer_supervisor, publication_manager, log_collector, shape_cache]
+    children = [consumer_supervisor, publication_manager, shape_cache, log_collector]
     Supervisor.init(children, strategy: :one_for_all)
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -23,6 +23,7 @@ end
 defmodule Electric.ShapeCache do
   use GenServer
 
+  alias Electric.Postgres.Lsn
   alias Electric.Replication.LogOffset
   alias Electric.ShapeCache.ShapeStatus
   alias Electric.Shapes
@@ -291,23 +292,28 @@ defmodule Electric.ShapeCache do
   defp recover_shapes(state) do
     %{publication_manager: {publication_manager, publication_manager_opts}} = state
 
-    state.shape_status_state
-    |> state.shape_status.list_shapes()
-    |> Enum.each(fn {shape_handle, shape} ->
-      try do
-        {:ok, _latest_offset} = start_shape(shape_handle, shape, state)
+    last_processed_lsn =
+      state.shape_status_state
+      |> state.shape_status.list_shapes()
+      |> Enum.flat_map(fn {shape_handle, shape} ->
+        try do
+          {:ok, latest_offset} = start_shape(shape_handle, shape, state)
 
-        # recover publication filter state
-        publication_manager.recover_shape(shape, publication_manager_opts)
-      rescue
-        e ->
-          Logger.error("Failed to recover shape #{shape_handle}: #{inspect(e)}")
+          # recover publication filter state
+          publication_manager.recover_shape(shape, publication_manager_opts)
+          [LogOffset.extract_lsn(latest_offset)]
+        rescue
+          e ->
+            Logger.error("Failed to recover shape #{shape_handle}: #{inspect(e)}")
 
-          # clean up corrupted data to avoid persisting bad state
-          Electric.ShapeCache.Storage.for_shape(shape_handle, state.storage)
-          |> Electric.ShapeCache.Storage.unsafe_cleanup!()
-      end
-    end)
+            # clean up corrupted data to avoid persisting bad state
+            Electric.ShapeCache.Storage.for_shape(shape_handle, state.storage)
+            |> Electric.ShapeCache.Storage.unsafe_cleanup!()
+
+            []
+        end
+      end)
+      |> Lsn.max()
   end
 
   defp start_shape(shape_handle, shape, state, otel_ctx \\ nil) do

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -221,7 +221,11 @@ defmodule Electric.ShapeCache do
 
   @impl GenServer
   def handle_info({:consumers_ready, global_latest_offset}, state) do
-    ShapeLogCollector.start_processing(state.log_producer, global_latest_offset)
+    ShapeLogCollector.start_processing(
+      state.log_producer,
+      LogOffset.extract_lsn(global_latest_offset)
+    )
+
     {:noreply, state}
   end
 

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -575,10 +575,7 @@ defmodule Electric.Shapes.Api do
   end
 
   defp get_global_last_seen_lsn(%Request{} = request) do
-    Electric.Replication.PersistentReplicationState.get_last_processed_lsn(
-      persistent_kv: request.api.persistent_kv,
-      stack_id: request.api.stack_id
-    )
+    Electric.LsnTracker.get_last_processed_lsn(request.api.stack_id)
     |> Electric.Postgres.Lsn.to_integer()
   end
 

--- a/packages/sync-service/test/electric/lsn_tracker_test.exs
+++ b/packages/sync-service/test/electric/lsn_tracker_test.exs
@@ -1,10 +1,13 @@
 defmodule Electric.LsnTrackerTest do
   use ExUnit.Case
+
+  import Support.ComponentSetup, only: [with_stack_id_from_test: 1]
   alias Electric.LsnTracker
   alias Electric.Postgres.Lsn
 
-  test "set_last_processed_lsn/2" do
-    stack_id = "stack_id"
+  setup [:with_stack_id_from_test]
+
+  test "get_last_processed_lsn/1", %{stack_id: stack_id} do
     lsn = Lsn.from_integer(7)
 
     LsnTracker.init(stack_id)
@@ -13,8 +16,7 @@ defmodule Electric.LsnTrackerTest do
     assert LsnTracker.get_last_processed_lsn(stack_id) == lsn
   end
 
-  test "reset/1" do
-    stack_id = "stack_id"
+  test "reset/1", %{stack_id: stack_id} do
     lsn = Lsn.from_integer(7)
 
     LsnTracker.init(stack_id)

--- a/packages/sync-service/test/electric/lsn_tracker_test.exs
+++ b/packages/sync-service/test/electric/lsn_tracker_test.exs
@@ -1,0 +1,15 @@
+defmodule Electric.LsnTrackerTest do
+  use ExUnit.Case
+  alias Electric.LsnTracker
+  alias Electric.Postgres.Lsn
+
+  test "set_last_processed_lsn/2" do
+    stack_id = "stack_id"
+    lsn = Lsn.from_integer(7)
+
+    LsnTracker.init(stack_id)
+    LsnTracker.set_last_processed_lsn(lsn, stack_id)
+
+    assert LsnTracker.get_last_processed_lsn(stack_id) == lsn
+  end
+end

--- a/packages/sync-service/test/electric/lsn_tracker_test.exs
+++ b/packages/sync-service/test/electric/lsn_tracker_test.exs
@@ -8,27 +8,26 @@ defmodule Electric.LsnTrackerTest do
   setup [:with_stack_id_from_test]
 
   describe "get_last_processed_lsn/1" do
-    test "returns last set lsn", %{stack_id: stack_id} do
+    test "returns inital lsn if not set", %{stack_id: stack_id} do
       lsn = Lsn.from_integer(7)
-
-      LsnTracker.init(stack_id)
-      LsnTracker.set_last_processed_lsn(lsn, stack_id)
+      LsnTracker.init(lsn, stack_id)
 
       assert LsnTracker.get_last_processed_lsn(stack_id) == lsn
     end
 
-    test "returns lsn of 0 if lsn has not been set", %{stack_id: stack_id} do
-      LsnTracker.init(stack_id)
+    test "returns last set lsn", %{stack_id: stack_id} do
+      lsn = Lsn.from_integer(7)
+      LsnTracker.init(Lsn.from_integer(0), stack_id)
+      LsnTracker.set_last_processed_lsn(lsn, stack_id)
 
-      assert LsnTracker.get_last_processed_lsn(stack_id) == Lsn.from_integer(0)
+      assert LsnTracker.get_last_processed_lsn(stack_id) == lsn
     end
   end
 
   test "reset/1", %{stack_id: stack_id} do
     lsn = Lsn.from_integer(7)
 
-    LsnTracker.init(stack_id)
-    LsnTracker.set_last_processed_lsn(lsn, stack_id)
+    LsnTracker.init(lsn, stack_id)
     LsnTracker.reset(stack_id)
 
     assert LsnTracker.get_last_processed_lsn(stack_id) == Lsn.from_integer(0)

--- a/packages/sync-service/test/electric/lsn_tracker_test.exs
+++ b/packages/sync-service/test/electric/lsn_tracker_test.exs
@@ -12,4 +12,15 @@ defmodule Electric.LsnTrackerTest do
 
     assert LsnTracker.get_last_processed_lsn(stack_id) == lsn
   end
+
+  test "reset/1" do
+    stack_id = "stack_id"
+    lsn = Lsn.from_integer(7)
+
+    LsnTracker.init(stack_id)
+    LsnTracker.set_last_processed_lsn(lsn, stack_id)
+    LsnTracker.reset(stack_id)
+
+    assert LsnTracker.get_last_processed_lsn(stack_id) == Lsn.from_integer(0)
+  end
 end

--- a/packages/sync-service/test/electric/lsn_tracker_test.exs
+++ b/packages/sync-service/test/electric/lsn_tracker_test.exs
@@ -7,13 +7,21 @@ defmodule Electric.LsnTrackerTest do
 
   setup [:with_stack_id_from_test]
 
-  test "get_last_processed_lsn/1", %{stack_id: stack_id} do
-    lsn = Lsn.from_integer(7)
+  describe "get_last_processed_lsn/1" do
+    test "returns last set lsn", %{stack_id: stack_id} do
+      lsn = Lsn.from_integer(7)
 
-    LsnTracker.init(stack_id)
-    LsnTracker.set_last_processed_lsn(lsn, stack_id)
+      LsnTracker.init(stack_id)
+      LsnTracker.set_last_processed_lsn(lsn, stack_id)
 
-    assert LsnTracker.get_last_processed_lsn(stack_id) == lsn
+      assert LsnTracker.get_last_processed_lsn(stack_id) == lsn
+    end
+
+    test "returns lsn of 0 if lsn has not been set", %{stack_id: stack_id} do
+      LsnTracker.init(stack_id)
+
+      assert LsnTracker.get_last_processed_lsn(stack_id) == Lsn.from_integer(0)
+    end
   end
 
   test "reset/1", %{stack_id: stack_id} do

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -85,7 +85,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
   end
 
   describe "serving shape" do
-    setup :with_stack_id_from_test
+    setup [:with_stack_id_from_test, :with_lsn_tracker]
 
     setup ctx do
       {:via, _, {registry_name, registry_key}} =

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -41,8 +41,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     opts = [
       stack_id: ctx.stack_id,
       inspector: {Mock.Inspector, []},
-      persistent_kv: ctx.persistent_kv,
-      demand: :forward
+      persistent_kv: ctx.persistent_kv
     ]
 
     {:ok, pid} = start_supervised({ShapeLogCollector, opts})

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -1,6 +1,7 @@
 defmodule Electric.Replication.ShapeLogCollectorTest do
   use ExUnit.Case, async: false
 
+  alias Electric.LsnTracker
   alias Electric.Postgres.Lsn
   alias Electric.Replication.ShapeLogCollector
   alias Electric.Replication.Changes.{Transaction, Relation}
@@ -32,7 +33,10 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     :with_persistent_kv
   ]
 
-  setup(ctx) do
+  @inspector StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
+  @shape Shape.new!("test_table", inspector: @inspector)
+
+  def setup_log_collector(ctx) do
     # Start a test Registry
     registry_name = Module.concat(__MODULE__, Registry)
     start_link_supervised!({Registry, keys: :duplicate, name: registry_name})
@@ -73,8 +77,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   end
 
   describe "store_transaction/2" do
-    @inspector StubInspector.new([%{name: "id", type: "int8", pk_position: 0}])
-    @shape Shape.new!("test_table", where: "id = 2", inspector: @inspector)
+    setup :setup_log_collector
 
     setup ctx do
       parent = self()
@@ -204,6 +207,8 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   end
 
   describe "handle_relation_msg/2" do
+    setup :setup_log_collector
+
     setup ctx do
       parent = self()
 
@@ -255,6 +260,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   end
 
   test "closes the loop even with no active shapes", ctx do
+    ctx = setup_log_collector(ctx)
     xmin = 100
     lsn = Lsn.from_string("0/10")
     last_log_offset = LogOffset.new(lsn, 0)
@@ -268,5 +274,75 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
     # this call should return immediately
     assert :ok = ShapeLogCollector.store_transaction(txn, ctx.server)
+  end
+
+  test "initializes with provided LSN", ctx do
+    # Start a test Registry
+    registry_name = Module.concat(__MODULE__, Registry)
+    start_link_supervised!({Registry, keys: :duplicate, name: registry_name})
+
+    # Start the ShapeLogCollector process
+    opts = [
+      stack_id: ctx.stack_id,
+      inspector: {Mock.Inspector, []},
+      persistent_kv: ctx.persistent_kv
+    ]
+
+    {:ok, pid} = start_supervised({ShapeLogCollector, opts})
+
+    Mock.Inspector
+    |> stub(:load_relation, fn {"public", "test_table"}, _ ->
+      {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
+    end)
+    |> stub(:load_column_info, fn {"public", "test_table"}, _ ->
+      {:ok, [%{pk_position: 0, name: "id"}]}
+    end)
+    |> allow(self(), pid)
+
+    consumer_id = "test_consumer"
+
+    {:ok, consumer} =
+      Support.TransactionConsumer.start_link(
+        id: consumer_id,
+        parent: self(),
+        producer: pid,
+        shape: @shape
+      )
+
+    consumers = [{consumer_id, consumer}]
+
+    start_lsn = Lsn.from_integer(100)
+    prev_lsn = Lsn.increment(start_lsn, -1)
+    next_lsn = Lsn.increment(start_lsn, +1)
+
+    ShapeLogCollector.start_processing(pid, start_lsn)
+
+    assert start_lsn == LsnTracker.get_last_processed_lsn(ctx.stack_id)
+
+    txn_to_drop =
+      %Transaction{xid: 99, lsn: prev_lsn, last_log_offset: LogOffset.new(prev_lsn, 0)}
+      |> Transaction.prepend_change(%Changes.NewRecord{
+        relation: {"public", "test_table"},
+        record: %{"id" => "1"}
+      })
+
+    # this call should return immediately
+    assert :ok = ShapeLogCollector.store_transaction(txn_to_drop, pid)
+
+    # should drop the transaction and not update the lsn
+    Support.TransactionConsumer.refute_consume(consumers)
+    assert start_lsn == LsnTracker.get_last_processed_lsn(ctx.stack_id)
+
+    # should accept a transaction with a higher LSN and update it
+    txn_to_process =
+      %Transaction{xid: 101, lsn: next_lsn, last_log_offset: LogOffset.new(next_lsn, 0)}
+      |> Transaction.prepend_change(%Changes.NewRecord{
+        relation: {"public", "test_table"},
+        record: %{"id" => "3"}
+      })
+
+    assert :ok = ShapeLogCollector.store_transaction(txn_to_process, pid)
+    Support.TransactionConsumer.assert_consume(consumers, [txn_to_process])
+    assert next_lsn == LsnTracker.get_last_processed_lsn(ctx.stack_id)
   end
 end

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -70,6 +70,7 @@ defmodule Electric.Shapes.ApiTest do
     {:via, _, {registry_name, registry_key}} = Electric.Replication.Supervisor.name(ctx)
 
     {:ok, _} = Registry.register(registry_name, registry_key, nil)
+    Electric.LsnTracker.init(ctx.stack_id)
     :ok
   end
 
@@ -746,10 +747,9 @@ defmodule Electric.Shapes.ApiTest do
 
       # Initially set the last_processed_lsn to next_offset_lsn, with this being
       # the last seen log entry at the start of the request
-      Electric.Replication.PersistentReplicationState.set_last_processed_lsn(
+      Electric.LsnTracker.set_last_processed_lsn(
         next_offset_lsn,
-        persistent_kv: ctx.persistent_kv,
-        stack_id: ctx.stack_id
+        ctx.stack_id
       )
 
       Mock.ShapeCache
@@ -769,10 +769,9 @@ defmodule Electric.Shapes.ApiTest do
         # the chunk end log offset, simulating the race where the next log entry
         # arrives in between determining the the end point of the log to read
         # and serving the log.
-        Electric.Replication.PersistentReplicationState.set_last_processed_lsn(
+        Electric.LsnTracker.set_last_processed_lsn(
           last_minute_next_offset_lsn,
-          persistent_kv: ctx.persistent_kv,
-          stack_id: ctx.stack_id
+          ctx.stack_id
         )
 
         next_offset

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -70,7 +70,7 @@ defmodule Electric.Shapes.ApiTest do
     {:via, _, {registry_name, registry_key}} = Electric.Replication.Supervisor.name(ctx)
 
     {:ok, _} = Registry.register(registry_name, registry_key, nil)
-    Electric.LsnTracker.init(ctx.stack_id)
+    Electric.LsnTracker.init(Lsn.from_integer(0), ctx.stack_id)
     :ok
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -115,7 +115,7 @@ defmodule Electric.Shapes.ConsumerTest do
             ])
         )
 
-      ShapeLogCollector.start_publishing(producer, Lsn.from_integer(0))
+      ShapeLogCollector.start_processing(producer, LogOffset.before_all())
 
       consumers =
         for {shape_handle, shape} <- ctx.shapes do

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -108,13 +108,14 @@ defmodule Electric.Shapes.ConsumerTest do
       {:ok, producer} =
         ShapeLogCollector.start_link(
           stack_id: ctx.stack_id,
-          demand: :forward,
           persistent_kv: ctx.persistent_kv,
           inspector:
             Support.StubInspector.new([
               %{name: "id", type: "int8", pk_position: 0}
             ])
         )
+
+      ShapeLogCollector.start_publishing(producer, Lsn.from_integer(0))
 
       consumers =
         for {shape_handle, shape} <- ctx.shapes do

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -115,7 +115,7 @@ defmodule Electric.Shapes.ConsumerTest do
             ])
         )
 
-      ShapeLogCollector.start_processing(producer, LogOffset.before_all())
+      ShapeLogCollector.start_processing(producer, Lsn.from_integer(0))
 
       consumers =
         for {shape_handle, shape} <- ctx.shapes do

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -142,6 +142,11 @@ defmodule Support.ComponentSetup do
     }
   end
 
+  def with_lsn_tracker(ctx) do
+    Electric.LsnTracker.init(Electric.Postgres.Lsn.from_integer(0), ctx.stack_id)
+    %{}
+  end
+
   def with_shape_log_collector(ctx) do
     {:ok, _} =
       ShapeLogCollector.start_link(


### PR DESCRIPTION
Speed up replication processing by removing file writes from the main processing loop:
- persisting the tracked relations now only happens on a relation change, not every transaction
- `last_processed_lsn` is no longer persisted, but it is worked out from the last lsn seen in the shape logs. This also avoids a race condition where the lsn is written in the shape logs but not the PersistedReplicationState.

As part of this PR, this also fixes a bug we found where `last_processed_lsn` was always being set to `Lsn.from_integer(0)` on start-up rather than reading from disk.

Please note that as part of this PR, `last_processed_lsn` and `global_last_seen_lsn` no longer include LSNs from transactions that do not affect any shapes.

Here we can see a 20% increase in WAL processing speed:
<img width="811" alt="Screenshot 2025-03-24 at 15 11 29" src="https://github.com/user-attachments/assets/ee299705-504d-41a7-a244-57d44bad5e39" />