### PR TITLE
 fix(sync-service): Fix where clause inclusion index to support array is null

### DIFF
--- a/.changeset/two-spies-care.md
+++ b/.changeset/two-spies-care.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix where clause inclusion index to support array is null

--- a/packages/sync-service/lib/electric/shapes/filter.ex
+++ b/packages/sync-service/lib/electric/shapes/filter.ex
@@ -86,6 +86,8 @@ defmodule Electric.Shapes.Filter do
       #{Exception.format(:error, error, __STACKTRACE__)}
       """)
 
+      OpenTelemetry.record_exception(:error, error, __STACKTRACE__)
+
       # We can't tell which shapes are affected, the safest thing to do is return all shapes
       filter
       |> all_shapes()

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/inclusion_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/inclusion_index.ex
@@ -124,9 +124,16 @@ defmodule Electric.Shapes.Filter.Indexes.InclusionIndex do
     defp node_empty?(_), do: false
 
     def affected_shapes(%InclusionIndex{} = index, field, record) do
+      record
+      |> value_from_record(field, index.type)
+      |> shapes_affected_by_array(index, record)
+    end
+
+    defp shapes_affected_by_array(nil, _, _), do: MapSet.new()
+
+    defp shapes_affected_by_array(values, index, record) when is_list(values) do
       values =
-        record
-        |> value_from_record(field, index.type)
+        values
         |> Enum.sort()
         |> Enum.dedup()
 

--- a/packages/sync-service/test/electric/shapes/filter_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter_test.exs
@@ -290,7 +290,8 @@ defmodule Electric.Shapes.FilterTest do
           %{where: "an_array @> '{1,3}'", record: %{"an_array" => "{1,2}"}, affected: false},
           %{where: "an_array @> '{1,3}'", record: %{"an_array" => "{1,3}"}, affected: true},
           %{where: "an_array @> '{}'", record: %{"an_array" => "{1,3}"}, affected: true},
-          %{where: "an_array @> '{}'", record: %{"an_array" => "{}"}, affected: true}
+          %{where: "an_array @> '{}'", record: %{"an_array" => "{}"}, affected: true},
+          %{where: "an_array @> '{1}'", record: %{"an_array" => nil}, affected: false}
         ] do
       test "where: #{test.where}, record: #{inspect(test.record)}" do
         %{where: where, record: record, affected: affected} = unquote(Macro.escape(test))


### PR DESCRIPTION
Currently if a shape has a where clause that includes `array_field @> array_constant` and the array_field is null, the index will log an exception and fallback to non indexed where clause evaluation which is slow. This PR adds supprt for null arrays in the inclusion index.