### PR TITLE
fix: Fix backwards compatibility parsing of shape definitions' flags

### DIFF
--- a/.changeset/three-pans-bake.md
+++ b/.changeset/three-pans-bake.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix backwards compatibility parsing of old shape definitions' flags

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -447,6 +447,7 @@ defmodule Electric.Shapes.Shape do
         ],
         &is_nil/1
       )
+      |> Map.new(&{&1, true})
 
     {:ok,
      %__MODULE__{

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -456,7 +456,7 @@ defmodule Electric.Shapes.ShapeTest do
         %{
           root_table: ["public", "foo"],
           root_table_id: 1,
-          selected_columns: ["first", "second", "third", "fourth"],
+          selected_columns: nil,
           where: nil,
           table_info: [
             [
@@ -483,6 +483,7 @@ defmodule Electric.Shapes.ShapeTest do
           root_pk: ["first", "second", "third"],
           root_column_count: 4,
           selected_columns: ["first", "second", "third", "fourth"],
+          flags: %{selects_all_columns: true},
           where: nil
         }
 


### PR DESCRIPTION
There was an error in the parsing of old shape definitions introduced when the table info was removed from the shape in https://github.com/electric-sql/electric/pull/2454

I've added a test for parsing the flags so that they are properly parsed as a map rather than a list, which was causing the publication manager to fail:

![image](https://github.com/user-attachments/assets/208f44e7-ccb8-40f2-9c08-bf5d5bd8b7a5)
