### PR TITLE
fix: Avoid function arg destructuring to not hit stack limits

### DIFF
--- a/.changeset/brown-impalas-listen.md
+++ b/.changeset/brown-impalas-listen.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/experimental": patch
+---
+
+Fix stack limit issue when using functions with array arg destructuring.

--- a/packages/experimental/src/bigint-utils.ts
+++ b/packages/experimental/src/bigint-utils.ts
@@ -1,9 +1,9 @@
-export function bigIntMax(...args: Array<bigint | number>): bigint {
-  return BigInt(args.reduce((m, e) => (e > m ? e : m)))
+export function bigIntMax(nums: Array<bigint | number>): bigint {
+  return BigInt(nums.reduce((m, e) => (e > m ? e : m)))
 }
 
-export function bigIntMin(...args: Array<bigint | number>): bigint {
-  return BigInt(args.reduce((m, e) => (e < m ? e : m)))
+export function bigIntMin(nums: Array<bigint | number>): bigint {
+  return BigInt(nums.reduce((m, e) => (e < m ? e : m)))
 }
 
 export function bigIntCompare(a: bigint, b: bigint): 1 | -1 | 0 {

--- a/packages/experimental/src/multi-shape-stream.ts
+++ b/packages/experimental/src/multi-shape-stream.ts
@@ -312,9 +312,9 @@ export class MultiShapeStream<
     // Min of all the lastSyncedAt values
     const shapeEntries = this.#shapeEntries()
     if (shapeEntries.length === 0) return
-    return shapeEntries
-      .map(([_, shape]) => shape.lastSyncedAt() ?? Infinity)
-      .reduce((a, b) => (a < b ? a : b))
+    return shapeEntries.reduce((minLastSyncedAt, [_, shape]) => {
+      return Math.min(minLastSyncedAt, shape.lastSyncedAt() ?? Infinity)
+    }, Infinity)
   }
 
   /** Time elapsed since last sync (in ms). Infinity if we did not yet sync. */

--- a/packages/experimental/src/multi-shape-stream.ts
+++ b/packages/experimental/src/multi-shape-stream.ts
@@ -183,7 +183,7 @@ export class MultiShapeStream<
                 : BigInt(0)
             )
           if (upToDateLsns.length > 0) {
-            const maxUpToDateLsn = bigIntMax(...upToDateLsns)
+            const maxUpToDateLsn = bigIntMax(upToDateLsns)
             const lastMaxUpToDateLsn = this.#lastUpToDateLsns[key]
             if (maxUpToDateLsn > lastMaxUpToDateLsn) {
               this.#lastUpToDateLsns[key] = maxUpToDateLsn
@@ -197,7 +197,7 @@ export class MultiShapeStream<
               typeof headers.lsn === `string` ? BigInt(headers.lsn) : BigInt(0)
             )
           if (dataLsns.length > 0) {
-            const maxDataLsn = bigIntMax(...dataLsns)
+            const maxDataLsn = bigIntMax(dataLsns)
             const lastMaxDataLsn = this.#lastDataLsns[key]
             if (maxDataLsn > lastMaxDataLsn) {
               this.#lastDataLsns[key] = maxDataLsn
@@ -231,7 +231,7 @@ export class MultiShapeStream<
   }
 
   async #checkForUpdates() {
-    const maxDataLsn = bigIntMax(...Object.values(this.#lastDataLsns))
+    const maxDataLsn = bigIntMax(Object.values(this.#lastDataLsns))
     const refreshPromises = this.#shapeEntries()
       .filter(([key]) => {
         // We only need to refresh shapes that have not seen an up-to-date message
@@ -310,11 +310,11 @@ export class MultiShapeStream<
   /** Unix time at which we last synced. Undefined when `isLoading` is true. */
   lastSyncedAt(): number | undefined {
     // Min of all the lastSyncedAt values
-    return Math.min(
-      ...this.#shapeEntries().map(
-        ([_, shape]) => shape.lastSyncedAt() ?? Infinity
-      )
-    )
+    const shapeEntries = this.#shapeEntries()
+    if (shapeEntries.length === 0) return
+    return shapeEntries
+      .map(([_, shape]) => shape.lastSyncedAt() ?? Infinity)
+      .reduce((a, b) => (a < b ? a : b))
   }
 
   /** Time elapsed since last sync (in ms). Infinity if we did not yet sync. */
@@ -394,7 +394,7 @@ export class TransactionalMultiShapeStream<
   }
 
   #getLowestCompleteLsn() {
-    return bigIntMin(...Object.values(this.#completeLsns))
+    return bigIntMin(Object.values(this.#completeLsns))
   }
 
   protected async _publish(
@@ -447,17 +447,20 @@ export class TransactionalMultiShapeStream<
           typeof headers.last === `boolean` &&
           headers.last === true
         ) {
-          this.#completeLsns[shape] = bigIntMax(this.#completeLsns[shape], lsn)
+          this.#completeLsns[shape] = bigIntMax([
+            this.#completeLsns[shape],
+            lsn,
+          ])
         }
       } else if (isControlMessage(message)) {
         if (headers.control === `up-to-date`) {
           if (typeof headers.global_last_seen_lsn !== `string`) {
             throw new Error(`global_last_seen_lsn is not a number`)
           }
-          this.#completeLsns[shape] = bigIntMax(
+          this.#completeLsns[shape] = bigIntMax([
             this.#completeLsns[shape],
-            BigInt(headers.global_last_seen_lsn)
-          )
+            BigInt(headers.global_last_seen_lsn),
+          ])
         }
       }
     })

--- a/packages/experimental/test/bigint-utils.test.ts
+++ b/packages/experimental/test/bigint-utils.test.ts
@@ -1,38 +1,61 @@
 import { describe, expect, it } from 'vitest'
 import { bigIntCompare, bigIntMax, bigIntMin } from '../src/bigint-utils'
+
+// Number of args where destructuring them would cause a stack overflow
+const STACK_LIMIT_ARG_DESTRUCTURE_NUM = 150000
+
 describe(`bigIntMax`, () => {
   it(`should return the maximum of bigint and number arguments as a bigint`, () => {
-    expect(bigIntMax(BigInt(1), BigInt(2), BigInt(3))).toBe(BigInt(3))
-    expect(bigIntMax(5, 10, 2)).toBe(BigInt(10))
-    expect(bigIntMax(BigInt(1), 2, BigInt(3), 4)).toBe(BigInt(4))
+    expect(bigIntMax([BigInt(1), BigInt(2), BigInt(3)])).toBe(BigInt(3))
+    expect(bigIntMax([5, 10, 2])).toBe(BigInt(10))
+    expect(bigIntMax([BigInt(1), 2, BigInt(3), 4])).toBe(BigInt(4))
   })
 
   it(`should return the only element as a bigint when there is one argument`, () => {
-    expect(bigIntMax(BigInt(42))).toBe(BigInt(42))
-    expect(bigIntMax(99)).toBe(BigInt(99))
+    expect(bigIntMax([BigInt(42)])).toBe(BigInt(42))
+    expect(bigIntMax([99])).toBe(BigInt(99))
   })
 
   it(`should handle negative numbers and bigints`, () => {
-    expect(bigIntMax(BigInt(-10), BigInt(-5), BigInt(-1))).toBe(BigInt(-1))
-    expect(bigIntMax(-100, -50, -10)).toBe(BigInt(-10))
+    expect(bigIntMax([BigInt(-10), BigInt(-5), BigInt(-1)])).toBe(BigInt(-1))
+    expect(bigIntMax([-100, -50, -10])).toBe(BigInt(-10))
+  })
+
+  it(`should handle very large number of comparisons`, () => {
+    const largeArray = Array.from(
+      { length: STACK_LIMIT_ARG_DESTRUCTURE_NUM },
+      (_, idx) => BigInt(idx)
+    )
+
+    expect(bigIntMax(largeArray)).toBe(
+      BigInt(STACK_LIMIT_ARG_DESTRUCTURE_NUM - 1)
+    )
   })
 })
 
 describe(`bigIntMin`, () => {
   it(`should return the minimum of bigint and number arguments as a bigint`, () => {
-    expect(bigIntMin(BigInt(1), BigInt(2), BigInt(3))).toBe(BigInt(1))
-    expect(bigIntMin(5, 10, 2)).toBe(BigInt(2))
-    expect(bigIntMin(BigInt(1), 2, BigInt(3), 4)).toBe(BigInt(1))
+    expect(bigIntMin([BigInt(1), BigInt(2), BigInt(3)])).toBe(BigInt(1))
+    expect(bigIntMin([5, 10, 2])).toBe(BigInt(2))
+    expect(bigIntMin([BigInt(1), 2, BigInt(3), 4])).toBe(BigInt(1))
   })
 
   it(`should return the only element as a bigint when there is one argument`, () => {
-    expect(bigIntMin(BigInt(42))).toBe(BigInt(42))
-    expect(bigIntMin(99)).toBe(BigInt(99))
+    expect(bigIntMin([BigInt(42)])).toBe(BigInt(42))
+    expect(bigIntMin([99])).toBe(BigInt(99))
   })
 
   it(`should handle negative numbers and bigints`, () => {
-    expect(bigIntMin(BigInt(-10), BigInt(-5), BigInt(-1))).toBe(BigInt(-10))
-    expect(bigIntMin(-100, -50, -10)).toBe(BigInt(-100))
+    expect(bigIntMin([BigInt(-10), BigInt(-5), BigInt(-1)])).toBe(BigInt(-10))
+    expect(bigIntMin([-100, -50, -10])).toBe(BigInt(-100))
+  })
+
+  it(`should handle very large number of comparisons`, () => {
+    const largeArray = Array.from(
+      { length: STACK_LIMIT_ARG_DESTRUCTURE_NUM },
+      (_, idx) => BigInt(idx)
+    )
+    expect(bigIntMin(largeArray)).toBe(BigInt(0))
   })
 })
 


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2493

We should avoid this pattern for functions that are to be used with unbounded argument sizes (if not avoid it all together given this issue)