### PR TITLE
fix: skip updates that don't change any columns

### DIFF
--- a/.changeset/short-crabs-glow.md
+++ b/.changeset/short-crabs-glow.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: skip updates that don't change any columns

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -149,7 +149,7 @@ defmodule Electric.Plug.RouterTest do
         conn("GET", "/v1/shape?table=items&handle=#{shape_handle}&offset=0_0&live")
         |> Router.call(opts)
 
-      assert length(Jason.decode!(conn.resp_body)) == 11
+      assert length(Jason.decode!(conn.resp_body)) == 10
       {:ok, offset} = LogOffset.from_string(get_resp_header(conn, "electric-offset"))
 
       # Force compaction


### PR DESCRIPTION
Closes #2452 