### PR TITLE
fix: disallow generated columns in shapes

### DIFF
--- a/.changeset/forty-buttons-accept.md
+++ b/.changeset/forty-buttons-accept.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: disallow generated columns in shapes

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -88,6 +88,7 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
       attndims as array_dimensions,
       atttypmod as type_mod,
       attnotnull as not_null,
+      attgenerated != '' as is_generated,
       pg_type.typname as type,
       pg_type.typtype as type_kind, -- e.g. an enum is kind 'e'
       elem_pg_type.typname as array_type, -- type of the element inside the array or nil if it's not an array

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -26,7 +26,8 @@ defmodule Electric.Plug.DeleteShapePlugTest do
   @test_pg_id "12345"
 
   def load_column_info({"public", "users"}, _),
-    do: {:ok, [%{name: "id", type: "int8", pk_position: 0, type_id: {20, -1}}]}
+    do:
+      {:ok, [%{name: "id", type: "int8", pk_position: 0, type_id: {20, -1}, is_generated: false}]}
 
   def load_relation(tbl, _),
     do: Support.StubInspector.load_relation(tbl, nil)

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -43,8 +43,22 @@ defmodule Electric.Plug.ServeShapePlugTest do
     do:
       {:ok,
        [
-         %{name: "id", type: "int8", type_id: {20, 1}, pk_position: 0, array_dimensions: 0},
-         %{name: "value", type: "text", type_id: {28, 1}, pk_position: nil, array_dimensions: 0}
+         %{
+           name: "id",
+           type: "int8",
+           type_id: {20, 1},
+           pk_position: 0,
+           array_dimensions: 0,
+           is_generated: false
+         },
+         %{
+           name: "value",
+           type: "text",
+           type_id: {28, 1},
+           pk_position: nil,
+           array_dimensions: 0,
+           is_generated: false
+         }
        ]}
 
   def load_column_info(_, _),

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -117,7 +117,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
           {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
       end)
       |> stub(:load_column_info, fn {"public", "test_table"}, _ ->
-        {:ok, [%{pk_position: 0, name: "id"}]}
+        {:ok, [%{pk_position: 0, name: "id", is_generated: false}]}
       end)
       |> allow(self(), ctx.server)
 
@@ -158,7 +158,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
           {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
       end)
       |> stub(:load_column_info, fn {"public", "test_table"}, _ ->
-        {:ok, [%{pk_position: 0, name: "id"}]}
+        {:ok, [%{pk_position: 0, name: "id", is_generated: false}]}
       end)
       |> allow(self(), ctx.server)
 
@@ -295,7 +295,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
     end)
     |> stub(:load_column_info, fn {"public", "test_table"}, _ ->
-      {:ok, [%{pk_position: 0, name: "id"}]}
+      {:ok, [%{pk_position: 0, name: "id", is_generated: false}]}
     end)
     |> allow(self(), pid)
 

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -205,12 +205,12 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     do:
       {:ok,
        [
-         %{name: "id", type: :int8, type_id: {1, 1}, pk_position: 0},
-         %{name: "value", type: :text, type_id: {2, 2}, pk_position: nil}
+         %{name: "id", type: :int8, type_id: {1, 1}, pk_position: 0, is_generated: false},
+         %{name: "value", type: :text, type_id: {2, 2}, pk_position: nil, is_generated: false}
        ]}
 
   def load_column_info({"public", "table"}, _),
-    do: {:ok, [%{name: "id", type: :int8, pk_position: 0}]}
+    do: {:ok, [%{name: "id", type: :int8, type_id: {1, 1}, pk_position: 0, is_generated: false}]}
 
   def load_relation(tbl, _),
     do: StubInspector.load_relation(tbl, nil)

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -44,8 +44,14 @@ defmodule Electric.ShapeCacheTest do
   @zero_offset LogOffset.last_before_real_offsets()
 
   @stub_inspector StubInspector.new([
-                    %{name: "id", type: "int8", type_id: {20, 1}, pk_position: 0},
-                    %{name: "value", type: "text", type_id: {25, 1}}
+                    %{
+                      name: "id",
+                      type: "int8",
+                      type_id: {20, 1},
+                      pk_position: 0,
+                      is_generated: false
+                    },
+                    %{name: "value", type: "text", type_id: {25, 1}, is_generated: false}
                   ])
 
   # {xmin, xmax, xip_list}

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -35,8 +35,22 @@ defmodule Electric.Shapes.ApiTest do
   def load_column_info({"public", "users"}, _) do
     {:ok,
      [
-       %{name: "id", type: "int8", type_id: {20, 1}, pk_position: 0, array_dimensions: 0},
-       %{name: "value", type: "text", type_id: {28, 1}, pk_position: nil, array_dimensions: 0}
+       %{
+         name: "id",
+         type: "int8",
+         type_id: {20, 1},
+         pk_position: 0,
+         array_dimensions: 0,
+         is_generated: false
+       },
+       %{
+         name: "value",
+         type: "text",
+         type_id: {28, 1},
+         pk_position: nil,
+         array_dimensions: 0,
+         is_generated: false
+       }
      ]}
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -45,7 +45,8 @@ defmodule Electric.Shapes.ConsumerTest do
   @moduletag :capture_log
 
   stub(Mock.Inspector, :load_column_info, fn
-    {"public", "test_table"}, _ -> {:ok, [%{name: "id", type: "int8", pk_position: 0}]}
+    {"public", "test_table"}, _ ->
+      {:ok, [%{name: "id", type: "int8", pk_position: 0, is_generated: false}]}
   end)
 
   stub(Mock.Inspector, :load_relation, fn

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -367,6 +367,16 @@ defmodule Electric.Shapes.ShapeTest do
 
       assert {:error, _} = Shape.new("other_table", inspector: inspector, replica: :teapot)
     end
+
+    @tag with_sql: [
+           "CREATE TABLE IF NOT EXISTS gen_col_table (val JSONB NOT NULL, id uuid PRIMARY KEY GENERATED ALWAYS AS ((val->>'id')::uuid) STORED)"
+         ]
+    test "validates selected columns for generated columns", %{inspector: inspector} do
+      assert {:error,
+              {:columns,
+               ["The following columns are generated and cannot be included in replication: id"]}} =
+               Shape.new("gen_col_table", inspector: inspector)
+    end
   end
 
   describe "new!/2" do

--- a/packages/sync-service/test/support/stub_inspector.ex
+++ b/packages/sync-service/test/support/stub_inspector.ex
@@ -13,6 +13,7 @@ defmodule Support.StubInspector do
       |> Map.put_new(:pk_position, nil)
       |> Map.put_new(:type, "text")
       |> Map.put_new(:type_id, {25, -1})
+      |> Map.put_new(:is_generated, false)
     end)
     |> then(&{:ok, &1})
   end


### PR DESCRIPTION
Closes #2448 

Generated columns cannot be included in a publication by PostgreSQL, so we disallow them in shapes. When doing `CREATE PUBLICATION p FOR TABLE t` without a column list, generated columns are omitted. When doing an explicit `FOR TABLE t (id)` (if `id` is generated), then it says `ERROR:  cannot use generated column "id" in publication column list`. 

We could, later, allow generated columns based on the subset of where clause functions we support by filling the stored values on our side too, but that's a way off.