### PR TITLE
feat(sync-service): Add LRU shape expiry

### DIFF
--- a/.changeset/hungry-pugs-kiss.md
+++ b/.changeset/hungry-pugs-kiss.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add experimental LRU shape expiry

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -253,6 +253,8 @@ config :electric,
   cache_max_age: cache_max_age,
   cache_stale_age: cache_stale_age,
   chunk_bytes_threshold: chunk_bytes_threshold,
+  # The ELECTRIC_EXPERIMENTAL_MAX_SHAPES is undocumented and will be removed in future versions.
+  max_shapes: env!("ELECTRIC_EXPERIMENTAL_MAX_SHAPES", :integer, nil),
   # Used in telemetry
   instance_id: instance_id,
   call_home_telemetry?: env!("ELECTRIC_USAGE_REPORTING", :boolean, config_env() == :prod),

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -102,7 +102,8 @@ defmodule Electric.Application do
       pool_opts: get_env_with_default(opts, :pool_opts, pool_size: get_env(opts, :db_pool_size)),
       chunk_bytes_threshold: get_env(opts, :chunk_bytes_threshold),
       telemetry_opts:
-        telemetry_opts([instance_id: instance_id, installation_id: installation_id] ++ opts)
+        telemetry_opts([instance_id: instance_id, installation_id: installation_id] ++ opts),
+      max_shapes: get_env(opts, :max_shapes)
     )
   end
 

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -50,6 +50,7 @@ defmodule Electric.Config do
     listen_on_ipv6?: false,
     stack_ready_timeout: 5_000,
     send_cache_headers?: true,
+    max_shapes: nil,
     ## Storage
     storage_dir: "./persistent",
     storage: &Electric.Config.Defaults.storage/0,

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -50,7 +50,7 @@ defmodule Electric.Config do
     listen_on_ipv6?: false,
     stack_ready_timeout: 5_000,
     send_cache_headers?: true,
-    max_shapes: nil,
+    max_shapes: 10,
     ## Storage
     storage_dir: "./persistent",
     storage: &Electric.Config.Defaults.storage/0,

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -50,7 +50,7 @@ defmodule Electric.Config do
     listen_on_ipv6?: false,
     stack_ready_timeout: 5_000,
     send_cache_headers?: true,
-    max_shapes: 10,
+    max_shapes: nil,
     ## Storage
     storage_dir: "./persistent",
     storage: &Electric.Config.Defaults.storage/0,

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -312,7 +312,7 @@ defmodule Electric.ShapeCache do
             shape_handle: shape.shape_handle,
             max_shapes: max_shapes,
             shape_count: shape_count,
-            elapsed_ms_since_use: shape.elapsed_ms_since_use
+            elapsed_minutes_since_use: shape.elapsed_minutes_since_use
           ],
           fn ->
             Logger.info(

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -61,7 +61,8 @@ defmodule Electric.ShapeCache do
               type: {:fun, 7},
               default: &Shapes.Consumer.Snapshotter.query_in_readonly_txn/7
             ],
-            purge_all_shapes?: [type: :boolean, required: false]
+            purge_all_shapes?: [type: :boolean, required: false],
+            max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil]
           )
 
   def name(stack_id) when not is_map(stack_id) and not is_list(stack_id) do
@@ -204,7 +205,7 @@ defmodule Electric.ShapeCache do
       registry: opts.registry,
       consumer_supervisor: opts.consumer_supervisor,
       subscription: nil,
-      max_shapes: nil
+      max_shapes: opts.max_shapes
     }
 
     last_processed_lsn =

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -305,17 +305,22 @@ defmodule Electric.ShapeCache do
 
       state.shape_status_state
       |> state.shape_status.least_recently_used(number_to_expire)
-      |> Enum.each(fn shape_handle ->
+      |> Enum.each(fn shape ->
         OpenTelemetry.with_span(
           "expiring_shape",
-          [shape_handle: shape_handle, max_shapes: max_shapes, shape_count: shape_count],
+          [
+            shape_handle: shape.shape_handle,
+            max_shapes: max_shapes,
+            shape_count: shape_count,
+            elapsed_ms_since_use: shape.elapsed_ms_since_use
+          ],
           fn ->
             Logger.info(
-              "Expiring shape #{shape_handle} as as the number of shapes " <>
+              "Expiring shape #{shape.shape_handle} as as the number of shapes " <>
                 "has exceeded the limit (#{state.max_shapes})"
             )
 
-            clean_up_shape(state, shape_handle)
+            clean_up_shape(state, shape.shape_handle)
           end
         )
       end)

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -292,7 +292,12 @@ defmodule Electric.ShapeCache do
 
   defp maybe_expire_shapes(%{shape_status: shape_status} = state) do
     if state.max_shapes && shape_count(state) > state.max_shapes do
-      {:ok, shape_handle} = shape_status.least_recently_used(shape_status)
+      {:ok, shape_handle} = shape_status.least_recently_used(state.shape_status_state)
+
+      Logger.info(
+        "Expiring shape #{shape_handle} as as the number of shapes has exceeded the limit (#{state.max_shapes})"
+      )
+
       clean_up_shape(state, shape_handle)
     end
   end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -144,6 +144,8 @@ defmodule Electric.ShapeCache do
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
     stack_id = Access.fetch!(opts, :stack_id)
 
+    shape_status.set_last_read_time(table, shape_handle)
+
     cond do
       shape_status.snapshot_started?(table, shape_handle) ->
         :started

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -146,6 +146,8 @@ defmodule Electric.ShapeCache do
     stack_id = Access.fetch!(opts, :stack_id)
 
     shape_status.update_last_read_time_to_now(table, shape_handle)
+    server = Access.get(opts, :server, name(opts))
+    GenServer.cast(server, :maybe_expire_shapes)
 
     cond do
       shape_status.snapshot_started?(table, shape_handle) ->
@@ -156,7 +158,6 @@ defmodule Electric.ShapeCache do
 
       true ->
         server = Electric.Shapes.Consumer.name(stack_id, shape_handle)
-        send(self(), :maybe_expire_shapes)
         GenServer.call(server, :await_snapshot_start, 15_000)
     end
   end
@@ -246,7 +247,8 @@ defmodule Electric.ShapeCache do
     {:noreply, state}
   end
 
-  def handle_info(:maybe_expire_shapes, state) do
+  @impl GenServer
+  def handle_cast(:maybe_expire_shapes, state) do
     maybe_expire_shapes(state)
     {:noreply, state}
   end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -144,7 +144,7 @@ defmodule Electric.ShapeCache do
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
     stack_id = Access.fetch!(opts, :stack_id)
 
-    shape_status.set_last_read_time(table, shape_handle)
+    shape_status.update_last_read_time_to_now(table, shape_handle)
 
     cond do
       shape_status.snapshot_started?(table, shape_handle) ->

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -231,7 +231,12 @@ defmodule Electric.ShapeCache.ShapeStatus do
       }
     ])
     |> Enum.sort_by(fn {_, last_read} -> last_read end)
-    |> Stream.map(fn {handle, _} -> handle end)
+    |> Stream.map(fn {handle, last_read} ->
+      %{
+        shape_handle: handle,
+        elapsed_ms_since_use: (:erlang.monotonic_time(:microsecond) - last_read) / 1000
+      }
+    end)
     |> Enum.take(shape_count)
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -208,11 +208,11 @@ defmodule Electric.ShapeCache.ShapeStatus do
     ])
   end
 
-  def set_last_read_time(%__MODULE__{shape_meta_table: meta_table}, shape_handle) do
-    set_last_read_time(meta_table, shape_handle)
+  def update_last_read_time_to_now(%__MODULE__{shape_meta_table: meta_table}, shape_handle) do
+    update_last_read_time_to_now(meta_table, shape_handle)
   end
 
-  def set_last_read_time(meta_table, shape_handle) do
+  def update_last_read_time_to_now(meta_table, shape_handle) do
     :ets.update_element(meta_table, {@shape_meta_data, shape_handle}, [
       {@shape_meta_last_read_pos, :erlang.monotonic_time(:microsecond)}
     ])

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -222,6 +222,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     least_recently_used(meta_table, shape_count)
   end
 
+  @microseconds_in_a_minute 60 * 1000 * 1000
   def least_recently_used(meta_table, shape_count) do
     :ets.select(meta_table, [
       {
@@ -234,7 +235,8 @@ defmodule Electric.ShapeCache.ShapeStatus do
     |> Stream.map(fn {handle, last_read} ->
       %{
         shape_handle: handle,
-        elapsed_ms_since_use: (:erlang.monotonic_time(:microsecond) - last_read) / 1000
+        elapsed_minutes_since_use:
+          (:erlang.monotonic_time(:microsecond) - last_read) / @microseconds_in_a_minute
       }
     end)
     |> Enum.take(shape_count)

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -209,12 +209,20 @@ defmodule Electric.ShapeCache.ShapeStatus do
   end
 
   def set_last_read_time(%__MODULE__{shape_meta_table: meta_table}, shape_handle) do
+    set_last_read_time(meta_table, shape_handle)
+  end
+
+  def set_last_read_time(meta_table, shape_handle) do
     :ets.update_element(meta_table, {@shape_meta_data, shape_handle}, [
       {@shape_meta_last_read_pos, :erlang.monotonic_time(:microsecond)}
     ])
   end
 
   def least_recently_used(%__MODULE__{shape_meta_table: meta_table}) do
+    least_recently_used(meta_table)
+  end
+
+  def least_recently_used(meta_table) do
     case :ets.select(meta_table, [
            {
              {{@shape_meta_data, :"$1"}, :_, :_, :_, :"$2"},

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -46,6 +46,7 @@ defmodule Electric.StackSupervisor do
                    required: true,
                    keys: Electric.connection_opts_schema()
                  ],
+                 max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil],
                  replication_opts: [
                    type: :keyword_list,
                    required: true,
@@ -267,7 +268,8 @@ defmodule Electric.StackSupervisor do
       chunk_bytes_threshold: config.chunk_bytes_threshold,
       log_producer: shape_log_collector,
       consumer_supervisor: Electric.Shapes.DynamicConsumerSupervisor.name(stack_id),
-      registry: shape_changes_registry_name
+      registry: shape_changes_registry_name,
+      max_shapes: config.max_shapes
     ]
 
     new_connection_manager_opts = [

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -201,7 +201,7 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     assert ShapeStatus.snapshot_started?(state.shape_meta_table, shape_handle)
   end
 
-  describe "least_recently_used/1" do
+  describe "least_recently_used/2" do
     test "returns last shape update_last_read_time_to_now was called on", ctx do
       {:ok, state, []} = new_state(ctx)
       {:ok, shape1} = ShapeStatus.add_shape(state, shape!())
@@ -209,7 +209,7 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
       ShapeStatus.update_last_read_time_to_now(state, shape2)
       ShapeStatus.update_last_read_time_to_now(state, shape1)
 
-      assert ShapeStatus.least_recently_used(state) == {:ok, shape2}
+      assert ShapeStatus.least_recently_used(state, _count = 1) == [shape2]
     end
 
     test "returns shape first created if update_last_read_time_to_now has not been called", ctx do
@@ -217,23 +217,23 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
       {:ok, shape1} = ShapeStatus.add_shape(state, shape!())
       {:ok, _shape2} = ShapeStatus.add_shape(state, shape2!())
 
-      assert ShapeStatus.least_recently_used(state) == {:ok, shape1}
+      assert ShapeStatus.least_recently_used(state, _count = 1) == [shape1]
     end
 
-    test "returns no_shapes if no shapes have been added", ctx do
+    test "returns empty list if no shapes have been added", ctx do
       {:ok, state, []} = new_state(ctx)
 
-      assert ShapeStatus.least_recently_used(state) == {:error, :no_shapes}
+      assert ShapeStatus.least_recently_used(state, _count = 1) == []
     end
 
-    test "returns no_shapes if all shapes have been deleted", ctx do
+    test "returns empty list if all shapes have been deleted", ctx do
       {:ok, state, []} = new_state(ctx)
       {:ok, shape1} = ShapeStatus.add_shape(state, shape!())
       {:ok, shape2} = ShapeStatus.add_shape(state, shape2!())
       ShapeStatus.remove_shape(state, shape1)
       ShapeStatus.remove_shape(state, shape2)
 
-      assert ShapeStatus.least_recently_used(state) == {:error, :no_shapes}
+      assert ShapeStatus.least_recently_used(state, _count = 1) == []
     end
   end
 

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -202,17 +202,17 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
   end
 
   describe "least_recently_used/1" do
-    test "returns last shape set_last_read_time was called on", ctx do
+    test "returns last shape update_last_read_time_to_now was called on", ctx do
       {:ok, state, []} = new_state(ctx)
       {:ok, shape1} = ShapeStatus.add_shape(state, shape!())
       {:ok, shape2} = ShapeStatus.add_shape(state, shape2!())
-      ShapeStatus.set_last_read_time(state, shape2)
-      ShapeStatus.set_last_read_time(state, shape1)
+      ShapeStatus.update_last_read_time_to_now(state, shape2)
+      ShapeStatus.update_last_read_time_to_now(state, shape1)
 
       assert ShapeStatus.least_recently_used(state) == {:ok, shape2}
     end
 
-    test "returns shape first created if set_last_read_time has not been called", ctx do
+    test "returns shape first created if update_last_read_time_to_now has not been called", ctx do
       {:ok, state, []} = new_state(ctx)
       {:ok, shape1} = ShapeStatus.add_shape(state, shape!())
       {:ok, _shape2} = ShapeStatus.add_shape(state, shape2!())

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -209,7 +209,7 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
       ShapeStatus.update_last_read_time_to_now(state, shape2)
       ShapeStatus.update_last_read_time_to_now(state, shape1)
 
-      assert ShapeStatus.least_recently_used(state, _count = 1) == [shape2]
+      assert [%{shape_handle: ^shape2}] = ShapeStatus.least_recently_used(state, _count = 1)
     end
 
     test "returns shape first created if update_last_read_time_to_now has not been called", ctx do
@@ -217,13 +217,13 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
       {:ok, shape1} = ShapeStatus.add_shape(state, shape!())
       {:ok, _shape2} = ShapeStatus.add_shape(state, shape2!())
 
-      assert ShapeStatus.least_recently_used(state, _count = 1) == [shape1]
+      assert [%{shape_handle: ^shape1}] = ShapeStatus.least_recently_used(state, _count = 1)
     end
 
     test "returns empty list if no shapes have been added", ctx do
       {:ok, state, []} = new_state(ctx)
 
-      assert ShapeStatus.least_recently_used(state, _count = 1) == []
+      assert [] == ShapeStatus.least_recently_used(state, _count = 1)
     end
 
     test "returns empty list if all shapes have been deleted", ctx do
@@ -233,7 +233,7 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
       ShapeStatus.remove_shape(state, shape1)
       ShapeStatus.remove_shape(state, shape2)
 
-      assert ShapeStatus.least_recently_used(state, _count = 1) == []
+      assert [] == ShapeStatus.least_recently_used(state, _count = 1)
     end
   end
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -658,6 +658,64 @@ defmodule Electric.ShapeCacheTest do
 
       assert log =~ "Snapshot creation failed for #{shape_handle}"
     end
+
+    test "expires shapes if shape count has gone over max_shapes", ctx do
+      %{shape_cache_opts: opts} =
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+          run_with_conn_fn: &run_with_conn_noop/2,
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
+            Storage.make_new_snapshot!([["test"]], storage)
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
+          end,
+          max_shapes: 1
+        )
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      Process.sleep(50)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+
+      storage = Storage.for_shape(shape_handle, ctx.storage)
+
+      Storage.append_to_log!(
+        changes_to_log_items([
+          %Electric.Replication.Changes.NewRecord{
+            relation: {"public", "items"},
+            record: %{"id" => "1", "value" => "Alice"},
+            log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
+          }
+        ]),
+        storage
+      )
+
+      assert Storage.snapshot_started?(storage)
+
+      assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
+               1
+
+      {module, _} = storage
+
+      ref =
+        Process.monitor(
+          module.name(ctx.stack_id, shape_handle)
+          |> GenServer.whereis()
+        )
+
+      {new_shape_handle, _} =
+        ShapeCache.get_or_create_shape_handle(%{@shape | where: "1 == 1"}, opts)
+
+      Process.sleep(50)
+      assert :started = ShapeCache.await_snapshot_start(new_shape_handle, opts)
+
+      assert_receive {:DOWN, ^ref, :process, _pid, _reason}
+
+      assert_raise ArgumentError,
+                   ~r"the table identifier does not refer to an existing ETS table",
+                   fn -> Stream.run(Storage.get_log_stream(@zero_offset, storage)) end
+
+      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert shape_handle != shape_handle2
+    end
   end
 
   describe "clean_shape/2" do

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -201,6 +201,64 @@ defmodule Electric.ShapeCacheTest do
 
       assert_received {:called, :create_snapshot_fn}
     end
+
+    test "expires shapes if shape count has gone over max_shapes", ctx do
+      %{shape_cache_opts: opts} =
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+          run_with_conn_fn: &run_with_conn_noop/2,
+          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
+            Storage.make_new_snapshot!([["test"]], storage)
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
+          end,
+          max_shapes: 1
+        )
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      Process.sleep(50)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+
+      storage = Storage.for_shape(shape_handle, ctx.storage)
+
+      Storage.append_to_log!(
+        changes_to_log_items([
+          %Electric.Replication.Changes.NewRecord{
+            relation: {"public", "items"},
+            record: %{"id" => "1", "value" => "Alice"},
+            log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
+          }
+        ]),
+        storage
+      )
+
+      assert Storage.snapshot_started?(storage)
+
+      assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
+               1
+
+      {module, _} = storage
+
+      ref =
+        Process.monitor(
+          module.name(ctx.stack_id, shape_handle)
+          |> GenServer.whereis()
+        )
+
+      {new_shape_handle, _} =
+        ShapeCache.get_or_create_shape_handle(%{@shape | where: "1 == 1"}, opts)
+
+      Process.sleep(50)
+      assert :started = ShapeCache.await_snapshot_start(new_shape_handle, opts)
+
+      assert_receive {:DOWN, ^ref, :process, _pid, _reason}
+
+      assert_raise ArgumentError,
+                   ~r"the table identifier does not refer to an existing ETS table",
+                   fn -> Stream.run(Storage.get_log_stream(@zero_offset, storage)) end
+
+      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert shape_handle != shape_handle2
+    end
   end
 
   describe "get_or_create_shape_handle/2 against real db" do
@@ -657,64 +715,6 @@ defmodule Electric.ShapeCacheTest do
         end)
 
       assert log =~ "Snapshot creation failed for #{shape_handle}"
-    end
-
-    test "expires shapes if shape count has gone over max_shapes", ctx do
-      %{shape_cache_opts: opts} =
-        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
-          run_with_conn_fn: &run_with_conn_noop/2,
-          create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
-            Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_handle})
-          end,
-          max_shapes: 1
-        )
-
-      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-      Process.sleep(50)
-      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
-
-      storage = Storage.for_shape(shape_handle, ctx.storage)
-
-      Storage.append_to_log!(
-        changes_to_log_items([
-          %Electric.Replication.Changes.NewRecord{
-            relation: {"public", "items"},
-            record: %{"id" => "1", "value" => "Alice"},
-            log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
-          }
-        ]),
-        storage
-      )
-
-      assert Storage.snapshot_started?(storage)
-
-      assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
-               1
-
-      {module, _} = storage
-
-      ref =
-        Process.monitor(
-          module.name(ctx.stack_id, shape_handle)
-          |> GenServer.whereis()
-        )
-
-      {new_shape_handle, _} =
-        ShapeCache.get_or_create_shape_handle(%{@shape | where: "1 == 1"}, opts)
-
-      Process.sleep(50)
-      assert :started = ShapeCache.await_snapshot_start(new_shape_handle, opts)
-
-      assert_receive {:DOWN, ^ref, :process, _pid, _reason}
-
-      assert_raise ArgumentError,
-                   ~r"the table identifier does not refer to an existing ETS table",
-                   fn -> Stream.run(Storage.get_log_stream(@zero_offset, storage)) end
-
-      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-      assert shape_handle != shape_handle2
     end
   end
 


### PR DESCRIPTION
With this PR, once the number of shapes exceeds `max_shapes` shapes are expired, least recently used first.

`max_shapes` is currently fixed and specified with the new `ELECTRIC_EXPERIMENTAL_MAX_SHAPES` environment variable. The env var has `EXPERIMENTAL` in it's name to convey that we will not be supporting this variable in the future since we would prefer that `max_shapes` was dynamically calculated. However for trigger.dev we can see setting max_shapes to 8000 should prevent WAL lag and shapes that have not been used for about two hours are expired which suits their needs.

A shapes `last_read` time is not currently persisted to disk. That has been left to a later PR. For trigger.dev this is fine since they do not currently recover shapes on restart. In the event that shape recovery was used with this implementation of cache expiry, shapes not used since restoration would have a `last_read` time of the time of recovery and so maybe be expired in an unexpected order.