### PR TITLE
Improved replication processing telemetry

### DIFF
--- a/.changeset/pink-panthers-draw.md
+++ b/.changeset/pink-panthers-draw.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Improved replication processing telemetry

--- a/packages/sync-service/lib/electric/shapes/filter.ex
+++ b/packages/sync-service/lib/electric/shapes/filter.ex
@@ -77,21 +77,23 @@ defmodule Electric.Shapes.Filter do
   @spec affected_shapes(Filter.t(), Transaction.t() | Relation.t()) :: MapSet.t(shape_id())
   def affected_shapes(%Filter{} = filter, change) do
     OpenTelemetry.timed_fun("filter.affected_shapes.duration_µs", fn ->
-      shapes_affected_by_change(filter, change)
+      try do
+        shapes_affected_by_change(filter, change)
+      rescue
+        error ->
+          Logger.error("""
+          Unexpected error in Filter.affected_shapes:
+          #{Exception.format(:error, error, __STACKTRACE__)}
+          """)
+
+          OpenTelemetry.record_exception(:error, error, __STACKTRACE__)
+
+          # We can't tell which shapes are affected, the safest thing to do is return all shapes
+          filter
+          |> all_shapes()
+          |> MapSet.new(fn {shape_id, _shape} -> shape_id end)
+      end
     end)
-  rescue
-    error ->
-      Logger.error("""
-      Unexpected error in Filter.affected_shapes:
-      #{Exception.format(:error, error, __STACKTRACE__)}
-      """)
-
-      OpenTelemetry.record_exception(:error, error, __STACKTRACE__)
-
-      # We can't tell which shapes are affected, the safest thing to do is return all shapes
-      filter
-      |> all_shapes()
-      |> MapSet.new(fn {shape_id, _shape} -> shape_id end)
   end
 
   defp shapes_affected_by_change(%Filter{} = filter, %Relation{} = relation) do


### PR DESCRIPTION
Includes two changes:
[Include error time in filter span](https://github.com/electric-sql/electric/commit/dae5c7f59d0908be861f4e06c747b9f922135ad1)
[Time how log it takes for txn message to be received](https://github.com/electric-sql/electric/commit/32a467351b30715de2f0104255aaebdd529dfe3e)