### PR TITLE
fix: better error handling for timing issues when accessing PG

### DIFF
--- a/.changeset/lazy-eyes-add.md
+++ b/.changeset/lazy-eyes-add.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: improve error handling in bad PG connectivity

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -161,6 +161,18 @@ defmodule Electric.Plug.ServeShapePlug do
   end
 
   @impl Plug.ErrorHandler
+  def handle_errors(conn, %{kind: :error, reason: exception, stack: stack})
+      when is_exception(exception, DBConnection.ConnectionError) do
+    OpenTelemetry.record_exception(:error, exception, stack)
+
+    error_str = Exception.format(:error, exception)
+
+    conn
+    |> fetch_query_params()
+    |> assign(:error_str, error_str)
+    |> send_resp(503, Jason.encode!(%{error: "Database is unreachable"}))
+  end
+
   def handle_errors(conn, error) do
     OpenTelemetry.record_exception(error.kind, error.reason, error.stack)
 
@@ -169,11 +181,10 @@ defmodule Electric.Plug.ServeShapePlug do
     conn
     |> fetch_query_params()
     |> assign(:error_str, error_str)
+    |> send_resp(conn.status, Jason.encode!(%{error: error_str}))
 
     # No end_telemetry_span() call here because by this point that stack of plugs has been
     # unwound to the point where the `conn` struct did not yet have any span-related properties
     # assigned to it.
-
-    conn
   end
 end

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -153,6 +153,7 @@ defmodule Electric.Postgres.Configuration do
       if not correct_identity? do
         Logger.info("Altering identity of #{table} to FULL")
         Postgrex.query!(conn, "ALTER TABLE #{table} REPLICA IDENTITY FULL", [])
+        Logger.debug("Altered identity of #{table} to FULL")
       end
     end
   end

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -33,7 +33,8 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   def load_relation(table, opts) do
     case relation_from_ets(table, opts) do
       :not_found ->
-        GenServer.call(opts[:server], {:load_relation, table})
+        # We don't set a timeout here because it's managed by the underlying query.
+        GenServer.call(opts[:server], {:load_relation, table}, :infinity)
 
       rel ->
         {:ok, rel}
@@ -56,7 +57,7 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   def load_column_info({_namespace, _table_name} = table, opts) do
     case column_info_from_ets(table, opts) do
       :not_found ->
-        case GenServer.call(opts[:server], {:load_column_info, table}) do
+        case GenServer.call(opts[:server], {:load_column_info, table}, :infinity) do
           {:error, err, stacktrace} -> reraise err, stacktrace
           result -> result
         end

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -518,10 +518,10 @@ defmodule Electric.ShapeCache.FileStorage do
                 # First time we see eof after any valid lines, we store a timestamp
                 {[], {file, System.monotonic_time(:millisecond), incomplete_line}}
 
-              # If it's been 60s without any new lines, and also we've not seen <<4>>,
+              # If it's been 90s without any new lines, and also we've not seen <<4>>,
               # then likely something is wrong
-              System.monotonic_time(:millisecond) - eof_seen > 60_000 ->
-                raise "Snapshot hasn't updated in 60s"
+              System.monotonic_time(:millisecond) - eof_seen > 90_000 ->
+                raise "Snapshot hasn't updated in 90s"
 
               true ->
                 # Sleep a little and check for new lines
@@ -545,7 +545,8 @@ defmodule Electric.ShapeCache.FileStorage do
     )
   end
 
-  defp open_snapshot_chunk(opts, chunk_num, attempts_left \\ 100)
+  # Attempts enough for a 5s wait
+  defp open_snapshot_chunk(opts, chunk_num, attempts_left \\ 250)
   defp open_snapshot_chunk(_, _, 0), do: raise(IO.StreamError, reason: :enoent)
 
   defp open_snapshot_chunk(opts, chunk_num, attempts_left) do

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -183,9 +183,19 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
               end
             )
 
-            stream = Querying.stream_initial_data(conn, stack_id, shape, chunk_bytes_threshold)
-
-            GenServer.cast(parent, {:snapshot_started, shape_handle})
+            stream =
+              Querying.stream_initial_data(conn, stack_id, shape, chunk_bytes_threshold)
+              |> Stream.transform(
+                fn -> false end,
+                fn item, acc ->
+                  if not acc, do: GenServer.cast(parent, {:snapshot_started, shape_handle})
+                  {[item], true}
+                end,
+                fn acc ->
+                  if not acc, do: GenServer.cast(parent, {:snapshot_started, shape_handle})
+                  acc
+                end
+              )
 
             # could pass the shape and then make_new_snapshot! can pass it to row_to_snapshot_item
             # that way it has the relation, but it is still missing the pk_cols


### PR DESCRIPTION
- Catch the exits when altering tables to account for GenServer timeouts as well as DBConnection raises:
  - Closes #2502 
  - Closes #2503 
- Make sure to mark snapshot as started only after getting first row from PG to avoid race condition where the file wasn't created yet
  - Closes #2505 