### PR TITLE
Add prefix support to the Elixir client

### DIFF
--- a/.changeset/nasty-deers-count.md
+++ b/.changeset/nasty-deers-count.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Add prefix support to the Elixir client

--- a/packages/elixir-client/lib/electric/client/ecto_adapter.ex
+++ b/packages/elixir-client/lib/electric/client/ecto_adapter.ex
@@ -28,8 +28,11 @@ if Code.ensure_loaded?(Ecto) do
       )
     end
 
-    defp table_name(%{from: %{prefix: prefix, source: {table_name, struct}}}) do
-      {table_name, prefix, struct}
+    defp table_name(%{
+           prefix: query_prefix,
+           from: %{prefix: source_prefix, source: {table_name, struct}}
+         }) do
+      {table_name, query_prefix || source_prefix, struct}
     end
 
     defp query_columns(%{from: %{source: {_table_name, struct}}}) do

--- a/packages/elixir-client/test/electric/client/ecto_adapter_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter_test.exs
@@ -129,6 +129,16 @@ defmodule Electric.Client.EctoAdapterTest do
                parser: {EctoAdapter, NamespacedTable}
              } = EctoAdapter.shape_from_query!(NamespacedTable)
     end
+
+    test "prefixed queries", %{column_names: column_names} = _ctx do
+      assert %Electric.Client.ShapeDefinition{
+               namespace: "hamster",
+               table: @table_name,
+               where: nil,
+               columns: ^column_names,
+               parser: {EctoAdapter, TestTable}
+             } = EctoAdapter.shape_from_query!(Ecto.Query.put_query_prefix(TestTable, "hamster"))
+    end
   end
 
   describe "ValueMapper.for_schema/2" do


### PR DESCRIPTION
Honour both the schema namespace and the per-query namespace as set by `Ecto.Query.put_query_prefix/2`

Fixes #2275