### PR TITLE
Make the initialization procedure of ReplicationClient async

### DIFF
--- a/integration-tests/tests/startup-delayed-by-pending-transaction.lux
+++ b/integration-tests/tests/startup-delayed-by-pending-transaction.lux
@@ -1,0 +1,115 @@
+[doc Verify that health checks remain responsive and Electric can eventually proceed with its normal operation after getting delayed by a pending database transaction]
+
+[include _macros.luxinc]
+
+[global pg_container_name=pending-transaction__pg]
+
+###
+
+## Start a new Postgres cluster
+[invoke setup_pg "" ""]
+
+## Start a pending transaction that will block Electric's initialization
+[invoke start_psql]
+[shell psql]
+  !BEGIN;
+  ??BEGIN
+
+  !SELECT pg_current_xact_id();
+  ??pg_current_xact_id
+  ??(1 row)
+
+## Start the first sync service.
+[invoke setup_electric_shell_with_tenant "electric_1" "3000"]
+
+[shell electric_1]
+  ??[info] Acquiring lock from postgres with name electric_slot_integration
+  ??[info] Lock acquired from postgres with name electric_slot_integration
+
+  # Set the failure match pattern such that we can prove that replication does not start since
+  # it's blocked by the pending transaction.
+  -Starting replication from postgres|$fail_pattern
+
+  ??[debug] Starting replication client for stack single_stack
+  ??[debug] ReplicationClient step: create_slot
+
+## Verify that Electric's health check can report that the service is starting
+[shell client]
+  # Give the sync service some time before querying its health. Just to make sure it hasn't
+  # started replicating within that time period.
+  [sleep 5]
+
+  !curl -X GET http://localhost:3000/v1/health?database_id=integration_test_tenant
+  ??{"status":"starting"}
+
+[shell electric_1]
+  ??[warning] Waiting for the replication connection setup to complete... \
+    Check that you don't have pending transactions in the database. \
+    Electric has to wait for all pending transactions to commit or rollback \
+    before it can create the replication slot.
+
+## Start the second sync service.
+[invoke setup_electric_shell_with_tenant "electric_2" "3001"]
+
+## Assert that the lock is not acquired and replication does not start
+## in the second Electric
+[shell electric_2]
+  -Lock acquired from postgres|Starting replication from postgres|$fail_pattern
+  ??[info] Acquiring lock from postgres with name electric_slot_integration
+
+# The 2nd service should be in waiting state, ready to take over
+[shell client]
+  [sleep 5]
+
+  !curl -X GET http://localhost:3000/v1/health?database_id=integration_test_tenant
+  ??{"status":"starting"}
+  !curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant
+  ??{"status":"waiting"}
+
+## Commit the pending transaction to unblock the 1st Electric, then immediately start a new one.
+[shell psql]
+  !COMMIT;
+  ??COMMIT
+
+  !BEGIN;
+  ??BEGIN
+
+  !SELECT pg_current_xact_id();
+  ??pg_current_xact_id
+  ??(1 row)
+
+## Verify that the 1st Electric has successfully initialized
+[shell electric_1]
+  # Reset the failure pattern before the next match
+  -$fail_pattern
+
+  ??[info] Starting replication from postgres
+
+## The 2nd Electric is still waiting
+[shell client]
+  !curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant
+  ??{"status":"waiting"}
+
+## Terminate the 1st Electric
+[shell electric_1]
+  !System.halt()
+
+  # Confirm Electric process exit.
+  ??$PS1
+
+## The lock should now be acquired by the 2nd Electric. Since the replication slot has already
+## been created, the pending transaction does not hinder the 2nd Electric from starting streaming
+## replication.
+[shell electric_2]
+  -$fail_pattern
+
+  ??[info] Lock acquired from postgres with name electric_slot_integration
+  ??[info] Starting replication from postgres
+
+# The 2nd Electric is now healthy and active
+[shell client]
+  !curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant
+  ??{"status":"active"}
+
+[cleanup]
+  [invoke teardown]

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -446,7 +446,12 @@ defmodule Electric.Connection.Manager do
         "Handling the exit of the replication client #{inspect(pid)} with reason #{inspect(reason)}"
       )
 
-      state = %State{state | replication_client_pid: nil, replication_connection_established: false}
+      state = %State{
+        state
+        | replication_client_pid: nil,
+          replication_connection_established: false
+      }
+
       state = schedule_reconnection(:start_replication_client, state)
       {:noreply, state}
     end

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -322,7 +322,6 @@ defmodule Electric.Connection.Manager do
 
     if first_time?, do: Logger.debug("Starting replication client for stack #{state.stack_id}")
 
-
     case Electric.Postgres.ReplicationClient.start_link(opts) do
       {:ok, pid} ->
         state = %State{state | replication_client_pid: pid}

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -446,7 +446,7 @@ defmodule Electric.Connection.Manager do
         "Handling the exit of the replication client #{inspect(pid)} with reason #{inspect(reason)}"
       )
 
-      state = %State{state | replication_client_pid: nil}
+      state = %State{state | replication_client_pid: nil, replication_connection_established: false}
       state = schedule_reconnection(:start_replication_client, state)
       {:noreply, state}
     end

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -360,8 +360,6 @@ defmodule Electric.Connection.Manager do
             stack_id: state.stack_id,
             persistent_kv: state.persistent_kv
           )
-
-          Electric.LsnTracker.reset(state.stack_id)
         end
 
         shapes_sup_pid =

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -206,6 +206,9 @@ defmodule Electric.Connection.Manager do
     in_connection_opts = Keyword.fetch!(opts, :connection_opts)
     in_replication_opts = Keyword.fetch!(opts, :replication_opts)
 
+    # If we see that both top-level connection opts and replication connection opts have been
+    # initialized from the same kwlist, we'll skip the extra work and only perform the no-ssl
+    # and ipv4 fallbacks once.
     shared_connection_opts =
       if in_connection_opts == Keyword.fetch!(in_replication_opts, :connection_opts) do
         populate_connection_opts(in_connection_opts)

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -150,8 +150,8 @@ defmodule Electric.Connection.Manager do
     GenServer.cast(server, :exclusive_connection_lock_acquired)
   end
 
-  def replication_connection_started_initializing(server) do
-    GenServer.cast(server, :replication_connection_started_initializing)
+  def replication_connection_initializing(server) do
+    GenServer.cast(server, :replication_connection_initializing)
   end
 
   def replication_connection_established(server) do
@@ -540,7 +540,7 @@ defmodule Electric.Connection.Manager do
   end
 
   def handle_cast(
-        :replication_connection_started_initializing,
+        :replication_connection_initializing,
         %State{replication_connection_established: false} = state
       ) do
     state = mark_connection_succeeded(state)

--- a/packages/sync-service/lib/electric/lsn_tracker.ex
+++ b/packages/sync-service/lib/electric/lsn_tracker.ex
@@ -28,10 +28,6 @@ defmodule Electric.LsnTracker do
     lsn
   end
 
-  def reset(stack_id) do
-    set_last_processed_lsn(Lsn.from_integer(0), stack_id)
-  end
-
   defp create_table(stack_id) do
     stack_id
     |> table()

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -351,7 +351,7 @@ defmodule Electric.Postgres.ReplicationClient do
 
   defp notify_connection_open(%State{connection_manager: connection_manager} = state) do
     :ok =
-      Electric.Connection.Manager.replication_connection_started_initializing(connection_manager)
+      Electric.Connection.Manager.replication_connection_initializing(connection_manager)
 
     state
   end

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -105,9 +105,9 @@ defmodule Electric.Postgres.ReplicationClient do
     # one test process exiting and the next one starting.
     start_opts =
       [
-        # TODO: the name is not necessary
         name: name(config.stack_id),
-        auto_reconnect: false
+        auto_reconnect: false,
+        sync_connect: false
       ] ++ Electric.Utils.deobfuscate_password(config.replication_opts[:connection_opts])
 
     Postgrex.ReplicationConnection.start_link(
@@ -168,12 +168,19 @@ defmodule Electric.Postgres.ReplicationClient do
   @impl true
   def handle_connect(state) do
     %State{state | step: :connected}
+    |> notify_connection_open()
     |> ConnectionSetup.start()
   end
 
   @impl true
   def handle_result(result_list_or_error, state) do
-    ConnectionSetup.process_query_result(result_list_or_error, state)
+    {step, return_val} = ConnectionSetup.process_query_result(result_list_or_error, state)
+
+    if step in [:ready_to_stream, :streaming] do
+      notify_connection_ready_for_streaming(state)
+    end
+
+    return_val
   end
 
   @impl true
@@ -341,4 +348,18 @@ defmodule Electric.Postgres.ReplicationClient do
     do: %State{state | applied_wal: wal}
 
   defp update_applied_wal(state, wal) when is_number(wal), do: state
+
+  defp notify_connection_open(%State{connection_manager: connection_manager} = state) do
+    :ok =
+      Electric.Connection.Manager.replication_connection_started_initializing(connection_manager)
+
+    state
+  end
+
+  defp notify_connection_ready_for_streaming(
+         %State{connection_manager: connection_manager} = state
+       ) do
+    :ok = Electric.Connection.Manager.replication_connection_established(connection_manager)
+    state
+  end
 end

--- a/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
@@ -34,7 +34,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   def process_query_result(result, %{step: step} = state) do
     state = dispatch_query_result(step, result, state)
     next_step = next_step(state)
-    query_for_step(next_step, %{state | step: next_step})
+    {next_step, query_for_step(next_step, %{state | step: next_step})}
   end
 
   # Instruct `Postgrex.ReplicationConnection` to switch the connection into the logical

--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -100,7 +100,7 @@ defmodule Electric.MixProject do
         {:pg_query_ex, "0.6.0"},
         {:plug, "~> 1.16"},
         {:postgrex, "~> 0.19"},
-        {:retry, "~> 0.18"},
+        {:retry, "~> 0.19"},
         {:remote_ip, "~> 1.2"},
         {:req, "~> 0.5"},
         {:telemetry_poller, "~> 1.1"},

--- a/packages/sync-service/test/electric/lsn_tracker_test.exs
+++ b/packages/sync-service/test/electric/lsn_tracker_test.exs
@@ -23,13 +23,4 @@ defmodule Electric.LsnTrackerTest do
       assert LsnTracker.get_last_processed_lsn(stack_id) == lsn
     end
   end
-
-  test "reset/1", %{stack_id: stack_id} do
-    lsn = Lsn.from_integer(7)
-
-    LsnTracker.init(lsn, stack_id)
-    LsnTracker.reset(stack_id)
-
-    assert LsnTracker.get_last_processed_lsn(stack_id) == Lsn.from_integer(0)
-  end
 end

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -36,7 +36,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
       end
     end
 
-    defp process_message({:"$gen_cast", :replication_connection_started_initializing}), do: nil
+    defp process_message({:"$gen_cast", :replication_connection_initializing}), do: nil
     defp process_message({:"$gen_cast", {:pg_info_looked_up, _}}), do: nil
 
     defp process_message({:"$gen_cast", :replication_connection_established}),

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -465,7 +465,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
       )
 
     conn_mgr = ctx.connection_manager
-    assert_receive {^conn_mgr, :ready_to_stream}
+    assert_receive {^conn_mgr, :ready_to_stream}, @assert_receive_db_timeout
     ReplicationClient.start_streaming(client_pid)
 
     client_pid


### PR DESCRIPTION
This unblocks the connection manager process even if the replication client gets stuck waiting for all pending transactions to commit or rollback.

Fixes #2391.

The PR also adjusts the handling of connection options, in particular the fallback logic for noSSL and IPv4.