### PR TITLE
fix: Maintain backwards compatibility with 204s

### DIFF
--- a/.changeset/chatty-pens-notice.md
+++ b/.changeset/chatty-pens-notice.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Maintain backwards compatibility of client for 204 responses

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -554,12 +554,12 @@ export class ShapeStream<T extends Row<unknown> = Row>
         // NOTE: 204s are deprecated, the Electric server should not
         // send these in latest versions but this is here for backwards
         // compatibility
-        const messages = status === 204 ? `[]` : await response.text()
         if (status === 204) {
           // There's no content so we are live and up to date
           this.#lastSyncedAt = Date.now()
         }
 
+        const messages = (await response.text()) || `[]`
         const batch = this.#messageParser.parse(messages, this.#schema)
 
         // Update isUpToDate

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -95,13 +95,18 @@ export function createFetchWithBackoff(
   }
 }
 
+const NO_BODY_STATUS_CODES = [201, 204, 205]
+
 // Ensure body can actually be read in its entirety
 export function createFetchWithConsumedMessages(fetchClient: typeof fetch) {
   return async (...args: Parameters<typeof fetch>): Promise<Response> => {
     const url = args[0]
     const res = await fetchClient(...args)
     try {
-      if (res.body === null) return res
+      if (res.status < 200 || NO_BODY_STATUS_CODES.includes(res.status)) {
+        return res
+      }
+
       const text = await res.text()
       return new Response(text, res)
     } catch (err) {


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2538

Maintain backwards compatibility after https://github.com/electric-sql/electric/pull/2486

The change was forwards compatible (old clients work with new servers) but not backwards compatible (new clients didn't work with old servers - old enough that they wouldn't return a body with the 204).

NOTE: The change was actually both forwards and backwards compatible as of the official 1.0.0 release, as we were already (wrongly) including a body with 204 responses at that point. I think that we should not reinsert this for the sake of backwards compatibility for versions prior to the official 1.0.0.
