### PR TITLE
Fix error with dead processes

### DIFF
--- a/.changeset/orange-insects-wait.md
+++ b/.changeset/orange-insects-wait.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix error generated when getting memory stats with dead processes

--- a/packages/sync-service/lib/debug/process.ex
+++ b/packages/sync-service/lib/debug/process.ex
@@ -10,8 +10,14 @@ defmodule Debug.Process do
   end
 
   defp type_and_memory(pid) do
-    [memory: memory] = Process.info(pid, [:memory])
-    %{type: type(pid), memory: memory}
+    case type(pid) do
+      :dead ->
+        %{type: :dead, memory: 0}
+
+      type ->
+        [memory: memory] = Process.info(pid, [:memory])
+        %{type: type, memory: memory}
+    end
   end
 
   def type(pid) do

--- a/packages/sync-service/lib/electric/debug/process.ex
+++ b/packages/sync-service/lib/electric/debug/process.ex
@@ -1,6 +1,21 @@
-defmodule Debug.Process do
-  def top_memory_by_type(count \\ 5) do
-    Process.list()
+defmodule Electric.Debug.Process do
+  @default_count 5
+
+  def top_memory_by_type do
+    top_memory_by_type(Process.list(), @default_count)
+  end
+
+  def top_memory_by_type(count) when is_integer(count) do
+    top_memory_by_type(Process.list(), count)
+  end
+
+  def top_memory_by_type(process_list) when is_list(process_list) do
+    top_memory_by_type(process_list, @default_count)
+  end
+
+  def top_memory_by_type(process_list, count)
+      when is_list(process_list) and is_integer(count) and count > 0 do
+    process_list
     |> Enum.map(&type_and_memory/1)
     |> Enum.reject(&is_dead_or_nil/1)
     |> Enum.group_by(& &1.type, & &1.memory)
@@ -15,8 +30,13 @@ defmodule Debug.Process do
         %{type: :dead, memory: 0}
 
       type ->
-        [memory: memory] = Process.info(pid, [:memory])
-        %{type: type, memory: memory}
+        case Process.info(pid, [:memory]) do
+          [memory: nil] ->
+            %{type: :dead, memory: 0}
+
+          [memory: memory] ->
+            %{type: type, memory: memory}
+        end
     end
   end
 

--- a/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
@@ -231,7 +231,8 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
     end
 
     def memory_by_process_type(%{top_process_count: process_count}) do
-      for %{type: type, memory: memory} <- Debug.Process.top_memory_by_type(process_count) do
+      for %{type: type, memory: memory} <-
+            Electric.Debug.Process.top_memory_by_type(process_count) do
         :telemetry.execute([:vm, :memory], %{processes_by_type: memory}, %{
           process_type: to_string(type)
         })

--- a/packages/sync-service/test/electric/debug/process_test.exs
+++ b/packages/sync-service/test/electric/debug/process_test.exs
@@ -1,0 +1,51 @@
+defmodule Electric.Debug.ProcessTest do
+  use ExUnit.Case, async: true
+
+  describe "top_memory_by_type/[1, 2]" do
+    test "handles dead processes" do
+      parent = self()
+
+      pid1 =
+        spawn(fn ->
+          receive do
+            _ -> send(parent, {:dead, 1})
+          end
+        end)
+
+      pid2 =
+        spawn(fn ->
+          receive do
+            _ -> send(parent, {:dead, 2})
+          end
+        end)
+
+      send(pid1, :die)
+
+      assert_receive {:dead, 1}
+
+      refute Process.alive?(pid1)
+
+      assert [%{memory: memory, type: :erlang}] =
+               Electric.Debug.Process.top_memory_by_type([pid1, pid2])
+
+      assert is_integer(memory)
+    end
+
+    test "defaults to top 5 of all processes" do
+      assert [
+               %{memory: _, type: _},
+               %{memory: _, type: _},
+               %{memory: _, type: _},
+               %{memory: _, type: _},
+               %{memory: _, type: _}
+             ] = Electric.Debug.Process.top_memory_by_type()
+    end
+
+    test "allows for setting limit" do
+      assert [
+               %{memory: _, type: _},
+               %{memory: _, type: _}
+             ] = Electric.Debug.Process.top_memory_by_type(2)
+    end
+  end
+end


### PR DESCRIPTION
the with clause meant that instead of returning a %{type, memory} map dead processes were returning just `:dead`.

Fixes https://github.com/electric-sql/electric/issues/2534