### PR TITLE
Fix shape param encoding in the location header returned as part of a 409 response

### DIFF
--- a/.changeset/shaggy-masks-cheer.md
+++ b/.changeset/shaggy-masks-cheer.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix a fatal bug in the encoding of WHERE query params when returning a 409 response from the server.

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -122,7 +122,7 @@ defmodule Electric.Shapes.Api.Response do
       |> Map.delete("live")
       |> Map.delete("cursor")
 
-    query = URI.encode_query(params)
+    query = Plug.Conn.Query.encode(params)
 
     Plug.Conn.put_resp_header(
       conn,


### PR DESCRIPTION
This should fix #2536.

My brain is too fried by now to write a proper test for this. I'll finish it tomorrow or feel free to pick it up.