### PR TITLE
docs: Mark api_secret as deprecated in OpenAPI spec

### DIFF
--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -28,6 +28,16 @@ components:
         configuration variable. This is required unless
         `ELECTRIC_INSECURE` is set to `true`. More details are
         available in the [security guide](https://electric-sql.com/docs/guides/security).
+    api_secret:
+      name: api_secret
+      in: query
+      schema:
+        type: string
+      example: 1U6ItbhoQb4kGUU5wXBLbxvNf
+      deprecated: true
+      description: |-
+        Deprecated in favor of the `secret` query parameter.
+        Will be removed in v2.
 
 paths:
   /v1/shape:
@@ -200,6 +210,7 @@ paths:
             Note that insert operations always include the full row,
             in either mode.
         - $ref: '#/components/parameters/secret'
+        - $ref: '#/components/parameters/api_secret'
         # Headers
         - name: If-None-Match
           in: header
@@ -497,6 +508,7 @@ paths:
             Optional, deletes the current shape if it matches the `handle` provided.
             If not provided, deletes the current shape.
         - $ref: '#/components/parameters/secret'
+        - $ref: '#/components/parameters/api_secret'
       responses:
         "202":
           description: |-


### PR DESCRIPTION
Introduces the `secret` query param in favor of `api_secret` which is deprecated and will be removed in v2.