### PR TITLE
chore: Trigger Cloud workflow for updating Electric on release

### DIFF
--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -43,3 +43,23 @@ jobs:
         run: node scripts/tag-latest.mjs
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Get the Electric version of the Docker image
+      - name: Get sync-service version
+        if: steps.changesets.outputs.published == 'true'
+        id: sync_version
+        run: |
+          VERSION=$(jq -r '.version' packages/sync-service/package.json)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      # Trigger cloud update workflow
+      - name: Trigger cloud update
+        if: steps.changesets.outputs.published == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CLOUD_REPO_TRIGGER_TOKEN }}
+          repository: electric-sql/stratovolt
+          event-type: update-electric
+          client-payload: |
+            {
+              "electric_commit_sha": "${{ github.sha }}",
+              "electric_docker_version": "${{ steps.sync_version.outputs.version }}"
+            }

--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -43,8 +43,13 @@ jobs:
         run: node scripts/tag-latest.mjs
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  update-cloud:
+    name: Update Electric version used by Cloud
+    runs-on: ubuntu-latest
+    needs: changesets
+    steps:
       # Get the Electric version of the Docker image
-      - name: Get sync-service version
+      - name: Get Electric version
         if: steps.changesets.outputs.published == 'true'
         id: sync_version
         run: |

--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -55,10 +55,9 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' packages/sync-service/package.json)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      # Trigger cloud update workflow
-      - name: Trigger cloud update
-        if: steps.changesets.outputs.published == 'true'
+      - name: Trigger cloud update (on release)
         uses: peter-evans/repository-dispatch@v2
+        if: steps.changesets.outputs.published == 'true'
         with:
           token: ${{ secrets.CLOUD_REPO_TRIGGER_TOKEN }}
           repository: electric-sql/stratovolt
@@ -66,5 +65,17 @@ jobs:
           client-payload: |
             {
               "electric_commit_sha": "${{ github.sha }}",
-              "electric_docker_version": "${{ steps.sync_version.outputs.version }}"
+              "electric_docker_version": "{{ steps.sync_version.outputs.version }}"
+            }
+      # On commit, only update the commit SHA, not the Docker image version
+      - name: Trigger cloud update (on commit)
+        uses: peter-evans/repository-dispatch@v2
+        if: steps.changesets.outputs.published == 'false'
+        with:
+          token: ${{ secrets.CLOUD_REPO_TRIGGER_TOKEN }}
+          repository: electric-sql/stratovolt
+          event-type: update-electric
+          client-payload: |
+            {
+              "electric_commit_sha": "${{ github.sha }}",
             }


### PR DESCRIPTION
This PR extends the changesets workflow such that we trigger the Cloud workflow for updating the version of Electric that is used by the cloud.