### PR TITLE
Make password obfuscation more implicit

### DIFF
--- a/packages/sync-service/README.md
+++ b/packages/sync-service/README.md
@@ -61,20 +61,21 @@ reuse that configuration if you want:
       password: "postgres",
       hostname: "localhost"
     ]
+
     config :my_app, Repo, database_config
 
-    config :electric,
-      replication_connection_opts: Electric.Utils.obfuscate_password(database_config)
+    config :electric, replication_connection_opts: database_config
 
 Or if you're getting your db connection from an environment variable, then you
 can use
 [`Electric.Config.parse_postgresql_uri!/1`](https://hexdocs.pm/electric/Electric.Config.html#parse_postgresql_uri!/1):
 
     # config/*.exs
-    {:ok, database_config} = Electric.Config.parse_postgresql_uri(System.fetch_env!("DATABASE_URL"))
+    {:ok, database_config} =
+      System.fetch_env!("DATABASE_URL")
+      |> Electric.Config.parse_postgresql_uri()
 
-    config :electric,
-      replication_connection_opts: Electric.Utils.obfuscate_password(database_config)
+    config :electric, replication_connection_opts: database_config
 
 The Electric app will startup along with the rest of your Elixir app.
 

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -134,12 +134,9 @@ query_database_url_config =
 
 database_ipv6_config = env!("ELECTRIC_DATABASE_USE_IPV6", :boolean, false)
 
-replication_connection_opts = replication_database_url_config ++ [ipv6: database_ipv6_config]
-query_connection_opts = query_database_url_config ++ [ipv6: database_ipv6_config]
-
 config :electric,
-  replication_connection_opts: Electric.Utils.obfuscate_password(replication_connection_opts),
-  query_connection_opts: Electric.Utils.obfuscate_password(query_connection_opts)
+  replication_connection_opts: replication_database_url_config ++ [ipv6: database_ipv6_config],
+  query_connection_opts: query_database_url_config ++ [ipv6: database_ipv6_config]
 
 enable_integration_testing? = env!("ELECTRIC_ENABLE_INTEGRATION_TESTING", :boolean, nil)
 cache_max_age = env!("ELECTRIC_CACHE_MAX_AGE", :integer, nil)

--- a/packages/sync-service/lib/electric.ex
+++ b/packages/sync-service/lib/electric.ex
@@ -4,14 +4,7 @@ defmodule Electric do
     port: [type: :integer, required: true, doc: "Server port"],
     database: [type: :string, required: true, doc: "Database"],
     username: [type: :string, required: true, doc: "Username"],
-    password: [
-      type: {:fun, 0},
-      required: true,
-      doc:
-        "User password. To prevent leaking of the Pg password in logs and stack traces, you **must** wrap the password with a function." <>
-          " We provide `Electric.Utils.obfuscate_password/1` which will return the `connection_opts` with a wrapped password value.\n\n" <>
-          "    config :electric, connection_opts: Electric.Utils.obfuscate_password(connection_opts)"
-    ],
+    password: [type: {:or, [:string, {:fun, 0}]}, required: true, doc: "User password"],
     sslmode: [
       type: {:in, [:disable, :allow, :prefer, :require]},
       required: false,

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -161,7 +161,7 @@ defmodule Electric.Config do
 
   ## Examples
 
-      iex> parse_postgresql_uri("postgresql://postgres:password@example.com/app-db")
+      iex> parse_postgresql_uri("postgresql://postgres:password@example.com/app-db") |> deobfuscate()
       {:ok, [
         hostname: "example.com",
         port: 5432,
@@ -194,7 +194,7 @@ defmodule Electric.Config do
         username: "user"
       ]}
 
-      iex> parse_postgresql_uri("postgresql://user%2Btesting%40gmail.com:weird%2Fpassword@localhost:5433/my%2Bdb%2Bname")
+      iex> parse_postgresql_uri("postgresql://user%2Btesting%40gmail.com:weird%2Fpassword@localhost:5433/my%2Bdb%2Bname") |> deobfuscate()
       {:ok, [
         hostname: "localhost",
         port: 5433,
@@ -267,7 +267,7 @@ defmodule Electric.Config do
             port: port || 5432,
             database: parse_database(path, username) |> URI.decode(),
             username: URI.decode(username),
-            password: if(password, do: URI.decode(password))
+            password: if(password, do: password |> URI.decode() |> Electric.Utils.wrap_in_fun())
           ] ++ options,
           fn {_key, val} -> is_nil(val) end
         )
@@ -422,4 +422,11 @@ defmodule Electric.Config do
         :ok
     end
   end
+
+  @doc false
+  # helper function for use in doc tests
+  def deobfuscate({:ok, connection_opts}),
+    do: {:ok, Electric.Utils.deobfuscate_password(connection_opts)}
+
+  def deobfuscate(other), do: other
 end

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -442,8 +442,9 @@ defmodule Electric.Utils do
   @spec map_values(map(), (term() -> term())) :: map()
   def map_values(map, fun), do: Map.new(map, fn {k, v} -> {k, fun.(v)} end)
 
-  defp wrap_in_fun(val) when is_function(val, 0), do: val
-  defp wrap_in_fun(val), do: fn -> val end
+  @doc false
+  def wrap_in_fun(val) when is_function(val, 0), do: val
+  def wrap_in_fun(val), do: fn -> val end
 
   @doc """
   Merge a list of streams by taking the minimum element from each stream and emitting it and its


### PR DESCRIPTION
In the spirit of the changes made in
https://github.com/electric-sql/electric/pull/2375, this change goes further in lifting the requirement of explicitly calling the obfuscate_password() function.

The calls we still had in config/runtime.exs were redundant because StackSupervisor performs the obfuscation anyway.