### PR TITLE
fix: Handle db does not exist error as a fatal error

### DIFF
--- a/.changeset/breezy-trainers-brake.md
+++ b/.changeset/breezy-trainers-brake.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Handle non existant DB as a fatal error.

--- a/integration-tests/tests/invalidated-replication-slot.lux
+++ b/integration-tests/tests/invalidated-replication-slot.lux
@@ -25,7 +25,7 @@
 
 [macro verify_connection_and_stack_supervisors_shutdown stack_id invalidated_slot_error]
   ??$invalidated_slot_error
-  ??[error] Stopping connection supervisor with stack_id=$stack_id due to an unrecoverable error
+  ??[warning] Stopping connection supervisor with stack_id=$stack_id due to an unrecoverable error
 
   !receive do \
      {:DOWN, ^stack_supervisor_mon, :process, ^stack_supervisor_pid, _} -> IO.puts "stack supervisor is down" \

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -734,6 +734,31 @@ defmodule Electric.Connection.Manager do
     {:noreply, state}
   end
 
+  defp stop_if_fatal_error(
+         %Postgrex.Error{
+           postgres: %{
+             code: :internal_error,
+             pg_code: "XX000"
+           }
+         } = error,
+         state
+       ) do
+    if Regex.match?(~r/database ".*" does not exist$/, error.postgres.message) do
+      Electric.StackSupervisor.dispatch_stack_event(
+        state.stack_events_registry,
+        state.stack_id,
+        {:database_does_not_exist, %{error: error}}
+      )
+    end
+
+    # Perform supervisor shutdown in a task to avoid a circular dependency where the manager
+    # process is waiting for the supervisor to shut down its children, one of which is the
+    # manager process itself.
+    Task.start(Electric.Connection.Supervisor, :shutdown, [state.stack_id, error])
+
+    {:noreply, state}
+  end
+
   defp stop_if_fatal_error(_, _), do: false
 
   defp schedule_reconnection(

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -36,7 +36,7 @@ defmodule Electric.Connection.Supervisor do
   end
 
   def shutdown(stack_id, reason) do
-    Logger.error(
+    Logger.warning(
       "Stopping connection supervisor with stack_id=#{inspect(stack_id)} " <>
         "due to an unrecoverable error: #{inspect(reason)}"
     )


### PR DESCRIPTION
This PR handles the Postgres "database does not exist" error which can occur when a user deletes their database. This is a fatal error we can't recover from so we now also handle it like that. I modified the shutdown method to log a warning rather than an error since the shutdown is not unexpected since we are shutting it down on purpose as a response to the DB no longer existing. This will also avoid that this error pops up in Sentry for our cloud.

Fixes https://github.com/electric-sql/electric/issues/2552