### PR TITLE
Improve proxy docs around removing content-length/content-encoding

### DIFF
--- a/examples/proxy-auth/app/shape-proxy/route.ts
+++ b/examples/proxy-auth/app/shape-proxy/route.ts
@@ -39,21 +39,20 @@ export async function GET(request: Request) {
     originUrl.searchParams.set(`where`, `"org_id" = ${user.org_id}`)
   }
 
-  // When proxying long-polling requests, content-encoding & content-length are added
-  // erroneously (saying the body is gzipped when it's not) so we'll just remove
-  // them to avoid content decoding errors in the browser.
+  const response = await fetch(originUrl)
+
+  // Fetch decompresses the body but doesn't remove the
+  // content-encoding & content-length headers which would
+  // break decoding in the browser.
   //
-  // Similar-ish problem to https://github.com/wintercg/fetch/issues/23
-  const resp = await fetch(originUrl)
-  if (resp.headers.get(`content-encoding`)) {
-    const headers = new Headers(resp.headers)
-    headers.delete(`content-encoding`)
-    headers.delete(`content-length`)
-    return new Response(resp.body, {
-      status: resp.status,
-      statusText: resp.statusText,
-      headers,
-    })
-  }
-  return resp
+  // See https://github.com/whatwg/fetch/issues/1729
+  const headers = new Headers(response.headers)
+  headers.delete(`content-encoding`)
+  headers.delete(`content-length`)
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
 }

--- a/examples/remix/app/routes/shape-proxy.ts
+++ b/examples/remix/app/routes/shape-proxy.ts
@@ -7,21 +7,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
     originUrl.searchParams.set(key, value)
   })
 
-  // When proxying long-polling requests, content-encoding & content-length are added
-  // erroneously (saying the body is gzipped when it's not) so we'll just remove
-  // them to avoid content decoding errors in the browser.
+  const response = await fetch(originUrl)
+
+  // Fetch decompresses the body but doesn't remove the
+  // content-encoding & content-length headers which would
+  // break decoding in the browser.
   //
-  // Similar-ish problem to https://github.com/wintercg/fetch/issues/23
-  let resp = await fetch(originUrl.toString())
-  if (resp.headers.get(`content-encoding`)) {
-    const headers = new Headers(resp.headers)
-    headers.delete(`content-encoding`)
-    headers.delete(`content-length`)
-    resp = new Response(resp.body, {
-      status: resp.status,
-      statusText: resp.statusText,
-      headers,
-    })
-  }
-  return resp
+  // See https://github.com/whatwg/fetch/issues/1729
+  const headers = new Headers(response.headers)
+  headers.delete(`content-encoding`)
+  headers.delete(`content-length`)
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
 }

--- a/website/product/cloud.md
+++ b/website/product/cloud.md
@@ -139,7 +139,22 @@ export async function GET(req: Request) {
   originUrl.searchParams.set(`source_secret`, process.env.SOURCE_SECRET)
 
   // Proxy the authorised request on to the Electric Cloud.
-  return fetch(originUrl, {headers: req.headers})
+  const response = await fetch(originUrl)
+
+  // Fetch decompresses the body but doesn't remove the
+  // content-encoding & content-length headers which would
+  // break decoding in the browser.
+  //
+  // See https://github.com/whatwg/fetch/issues/1729
+  const headers = new Headers(response.headers)
+  headers.delete(`content-encoding`)
+  headers.delete(`content-length`)
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
 }
 ```
 


### PR DESCRIPTION
Tighten the code pattern & also add it to the cloud docs as well where it was missing.