### PR TITLE
Return 409 immediately to live requests when shape invalidated

### DIFF
--- a/.changeset/giant-fishes-tease.md
+++ b/.changeset/giant-fishes-tease.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Respond immediately to live requests with a 409 if shape invalidated/rotated

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -527,10 +527,11 @@ defmodule Electric.Shapes.Api do
         # We may want to notify the client better that the shape handle had
         # changed, but just closing the response and letting the client handle
         # it on reconnection is good enough.
-        request
-        |> update_attrs(%{ot_is_shape_rotated: true})
-        |> determine_global_last_seen_lsn()
-        |> no_change_response()
+
+        Response.error(request, @must_refetch,
+          handle: shape_handle,
+          status: 409
+        )
     after
       # If we timeout, return an up-to-date message
       long_poll_timeout ->

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -524,10 +524,6 @@ defmodule Electric.Shapes.Api do
         |> do_serve_shape_log()
 
       {^ref, :shape_rotation} ->
-        # We may want to notify the client better that the shape handle had
-        # changed, but just closing the response and letting the client handle
-        # it on reconnection is good enough.
-
         Response.error(request, @must_refetch,
           handle: shape_handle,
           status: 409

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -1375,12 +1375,7 @@ defmodule Electric.Plug.RouterTest do
         end)
 
       Postgrex.query!(db_conn, "TRUNCATE TABLE items", [])
-      assert %{status: 200} = Task.await(task)
-
-      conn =
-        Router.call(conn("GET", "/v1/shape?table=items&offset=#{offset}&handle=#{handle}"), opts)
-
-      assert %{status: 409} = conn
+      assert %{status: 409} = conn = Task.await(task)
       assert [%{"headers" => %{"control" => "must-refetch"}}] = Jason.decode!(conn.resp_body)
 
       conn =

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -595,9 +595,8 @@ defmodule Electric.Plug.ServeShapePlugTest do
       # The conn process should exit after sending the response
       refute Process.alive?(conn.owner)
 
-      assert conn.status == 200
-      assert [%{"headers" => %{"control" => "up-to-date"}}] = Jason.decode!(conn.resp_body)
-      assert get_resp_header(conn, "electric-up-to-date") == [""]
+      assert conn.status == 409
+      assert [%{"headers" => %{"control" => "must-refetch"}}] = Jason.decode!(conn.resp_body)
     end
 
     test "sends an up-to-date response after a timeout if no changes are observed",

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -916,10 +916,9 @@ defmodule Electric.Shapes.ApiTest do
 
       assert response = Task.await(task)
 
-      assert response.status == 200
+      assert response.status == 409
       refute response.chunked
-      assert [%{headers: %{control: "up-to-date"}}] = response_body(response)
-      assert response.up_to_date
+      assert [%{headers: %{control: "must-refetch"}}] = response_body(response)
     end
 
     @tag long_poll_timeout: 100


### PR DESCRIPTION
There's no need to reply with a 200 and then require a second request to get the 409 status. we can just send the 409 immediately and save a round-trip. the two are functionally identical - a live request returns a 409, only the duration of that request changes.

Fixes #2585 