### PR TITLE
chore: Use cross repo PAT instead of cloud repo PAT

### DIFF
--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         if: steps.changesets.outputs.published == 'true'
         with:
-          token: ${{ secrets.CLOUD_REPO_TRIGGER_TOKEN }}
+          token: ${{ secrets.CROSSREPO_PAT }}
           repository: electric-sql/stratovolt
           event-type: update-electric
           client-payload: |
@@ -72,7 +72,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         if: steps.changesets.outputs.published != 'true'
         with:
-          token: ${{ secrets.CLOUD_REPO_TRIGGER_TOKEN }}
+          token: ${{ secrets.CROSSREPO_PAT }}
           repository: electric-sql/stratovolt
           event-type: update-electric
           client-payload: |

--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -50,14 +50,14 @@ jobs:
     steps:
       # Get the Electric version of the Docker image
       - name: Get Electric version
-        if: steps.changesets.outputs.published == 'true'
+        if: needs.changesets.outputs.published == 'true'
         id: sync_version
         run: |
           VERSION=$(jq -r '.version' packages/sync-service/package.json)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Trigger cloud update (on release)
         uses: peter-evans/repository-dispatch@v2
-        if: steps.changesets.outputs.published == 'true'
+        if: needs.changesets.outputs.published == 'true'
         with:
           token: ${{ secrets.CROSSREPO_PAT }}
           repository: electric-sql/stratovolt
@@ -70,7 +70,7 @@ jobs:
       # On commit, only update the commit SHA, not the Docker image version
       - name: Trigger cloud update (on commit)
         uses: peter-evans/repository-dispatch@v2
-        if: steps.changesets.outputs.published != 'true'
+        if: needs.changesets.outputs.published != 'true'
         with:
           token: ${{ secrets.CROSSREPO_PAT }}
           repository: electric-sql/stratovolt


### PR DESCRIPTION
I regenerated the cross repo PAT as it was expired and i updated the CROSSREPO_PAT accordingly.
This PR replaces the use of the CLOUD_REPO_TRIGGER_TOKEN by the CROSSREPO_PAT we already had in place.