### PR TITLE
fix: improve error handling around a periodic wal size check

### DIFF
--- a/.changeset/twenty-rings-lay.md
+++ b/.changeset/twenty-rings-lay.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: add a more explicit error handling in case periodic metric collection fails and make wal queries async


### PR DESCRIPTION
This fixes an error we're seeing sometimes in Sentry around monitoring. Not sure about the root cause of process being unresponsive, but it might be that it's a slow query against Postgres that's blocking the entire thing. This PR moves the wal query into a task so that the manager can continue to handle `DOWN` messages and such