### PR TITLE
Configuring log level in the test environment

### DIFF
--- a/packages/elixir-client/test/electric/client/embedded_test.exs
+++ b/packages/elixir-client/test/electric/client/embedded_test.exs
@@ -1,8 +1,6 @@
 defmodule Electric.Client.EmbeddedTest do
   use ExUnit.Case, async: false
 
-  @moduletag :capture_log
-
   alias Electric.Client
   alias Electric.Client.Message.{ChangeMessage, ControlMessage}
   alias Electric.Client.ShapeDefinition

--- a/packages/elixir-client/test/electric/client_test.exs
+++ b/packages/elixir-client/test/electric/client_test.exs
@@ -1,8 +1,6 @@
 defmodule Electric.ClientTest do
   use ExUnit.Case, async: false
 
-  @moduletag :capture_log
-
   import Support.DbSetup
   import Support.ClientHelpers
 

--- a/packages/sync-service/.env.test
+++ b/packages/sync-service/.env.test
@@ -1,6 +1,12 @@
-## The ELECTRIC_LOG_LEVEL setting has no effect in the test env. Adjust the log level in runtime.exs instead by editing the line
-##    config :logger, :default_handler, level: :error
-#ELECTRIC_LOG_LEVEL=info
+# When running ExUnit, log capturing is enabled by default. The logger level of the captured
+# log may be configured via the ELECTRIC_LOG_LEVEL setting.
+ELECTRIC_LOG_LEVEL=info
+
+# There are also log entries that are emitted outside of any test process (e.g. during Electric
+# application startup). The level for those logs can be adjusted via the
+# ELECTRIC_TEST_LOG_LEVEL setting. This value will also be used for the captured log entries if
+# `ELECTRIC_LOG_LEVEL` is not explicitly set.
+ELECTRIC_TEST_LOG_LEVEL=error
 
 DATABASE_URL=postgresql://postgres:password@localhost:54321/postgres?sslmode=disable
 ELECTRIC_QUERY_DATABASE_URL=postgresql://postgres:password@localhost:64321/postgres?sslmode=disable

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -7,14 +7,14 @@ if config_env() in [:dev, :test] do
   source!([".env.#{config_env()}", ".env.#{config_env()}.local", System.get_env()])
 end
 
-user_test_log_level =
+test_log_level =
   if config_env() == :test,
     do: env!("ELECTRIC_TEST_LOG_LEVEL", &Electric.Config.parse_log_level!/1, nil)
 
-user_log_level =
-  user_test_log_level || env!("ELECTRIC_LOG_LEVEL", &Electric.Config.parse_log_level!/1, :info)
+log_level =
+  env!("ELECTRIC_LOG_LEVEL", &Electric.Config.parse_log_level!/1, test_log_level) || :info
 
-config :logger, level: user_log_level
+config :logger, level: log_level
 
 config :logger, :default_formatter,
   # Doubled line breaks serve as long message boundaries
@@ -33,7 +33,7 @@ config :logger,
 
 if config_env() == :test do
   config :electric, pg_version_for_tests: env!("POSTGRES_VERSION", :integer, 150_001)
-  config :logger, :default_handler, level: user_test_log_level
+  config :logger, :default_handler, level: test_log_level
 end
 
 config :sentry,

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -9,7 +9,7 @@ end
 
 test_log_level =
   if config_env() == :test,
-    do: env!("ELECTRIC_TEST_LOG_LEVEL", &Electric.Config.parse_log_level!/1, nil)
+    do: env!("ELECTRIC_TEST_LOG_LEVEL", &Electric.Config.parse_log_level!/1, :error)
 
 log_level =
   env!("ELECTRIC_LOG_LEVEL", &Electric.Config.parse_log_level!/1, test_log_level) || :info

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -11,7 +11,6 @@ defmodule Electric.Plug.DeleteShapePlugTest do
   import Mox
 
   setup :verify_on_exit!
-  @moduletag :capture_log
 
   @registry Registry.DeleteShapePlugTest
 

--- a/packages/sync-service/test/electric/plug/health_check_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/health_check_plug_test.exs
@@ -9,8 +9,6 @@ defmodule Electric.Plug.HealthCheckPlugTest do
   alias Electric.Plug.HealthCheckPlug
   alias Electric.StatusMonitor
 
-  @moduletag :capture_log
-
   setup :with_stack_id_from_test
 
   def conn(ctx) do

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -16,7 +16,6 @@ defmodule Electric.Plug.RouterTest do
   alias Electric.Replication.LogOffset
 
   @moduletag :tmp_dir
-  @moduletag :capture_log
 
   @first_offset to_string(LogOffset.first())
   @up_to_date %{"headers" => %{"control" => "up-to-date"}}

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -17,8 +17,6 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
   setup :verify_on_exit!
 
-  @moduletag :capture_log
-
   @registry Registry.ServeShapePlugTest
 
   @test_shape %Shape{

--- a/packages/sync-service/test/electric/postgres/lock_connection_test.exs
+++ b/packages/sync-service/test/electric/postgres/lock_connection_test.exs
@@ -8,7 +8,6 @@ defmodule Electric.Postgres.LockConnectionTest do
   alias Electric.Postgres.LockConnection
   alias Electric.StatusMonitor
 
-  @moduletag :capture_log
   @lock_name "test_electric_slot"
 
   describe "LockConnection init" do

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -17,7 +17,6 @@ defmodule Electric.Postgres.ReplicationClientTest do
     UpdatedRecord
   }
 
-  @moduletag :capture_log
   @publication_name "test_electric_publication"
   @slot_name "test_electric_slot"
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -25,8 +25,6 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
   import Mox
 
-  @moduletag :capture_log
-
   setup :verify_on_exit!
 
   setup [

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -19,8 +19,6 @@ defmodule Electric.ShapeCacheTest do
   import Support.TestUtils
   alias Support.Mock
 
-  @moduletag :capture_log
-
   @shape %Shape{
     root_table: {"public", "items"},
     root_table_id: 1,
@@ -838,9 +836,6 @@ defmodule Electric.ShapeCacheTest do
   end
 
   describe "after restart" do
-    # Capture the log to hide the GenServer exit messages
-    @describetag capture_log: true
-
     @describetag :tmp_dir
 
     setup do

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -42,8 +42,6 @@ defmodule Electric.Shapes.ConsumerTest do
     }
   }
 
-  @moduletag :capture_log
-
   stub(Mock.Inspector, :load_column_info, fn
     {"public", "test_table"}, _ ->
       {:ok, [%{name: "id", type: "int8", pk_position: 0, is_generated: false}]}

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -4,5 +4,5 @@
 # supervision tree in the test environment.
 # Registry.start_link(name: Electric.Application.process_registry(), keys: :unique)
 
-ExUnit.start(assert_receive_timeout: 400, exclude: [slow: true])
+ExUnit.start(assert_receive_timeout: 400, exclude: [slow: true], capture_log: true)
 Repatch.setup()


### PR DESCRIPTION
#2541 turned out to be partly misleading.

This change addresses the confusion and makes log level in the test env fully configurable with env variables.