### PR TITLE
fix: shape cleanup should delete the shape handle too

### DIFF
--- a/.changeset/tasty-readers-boil.md
+++ b/.changeset/tasty-readers-boil.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: shape cleanup should delete the shape handle too

--- a/packages/sync-service/config/config.exs
+++ b/packages/sync-service/config/config.exs
@@ -7,4 +7,4 @@ config :sentry,
   root_source_code_paths: [File.cwd!()]
 
 config :electric,
-  start_in_library_mode: false
+  start_in_library_mode: Mix.env() == :test

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -400,6 +400,12 @@ defmodule Electric.ShapeCache do
         lsn
 
       nil ->
+        Electric.Shapes.DynamicConsumerSupervisor.stop_shape_consumer(
+          state.consumer_supervisor,
+          state.stack_id,
+          shape_handle
+        )
+
         unsafe_cleanup_shape!(shape_handle, state)
 
         Logger.error(
@@ -455,6 +461,10 @@ defmodule Electric.ShapeCache do
   end
 
   defp unsafe_cleanup_shape!(shape_handle, state) do
+    # Remove the handle from the shape status
+    state.shape_status.remove_shape(state.shape_status_state, shape_handle)
+
+    # Cleanup the storage for the shape
     shape_handle
     |> Electric.ShapeCache.Storage.for_shape(state.storage)
     |> Electric.ShapeCache.Storage.unsafe_cleanup!()


### PR DESCRIPTION
We had an issue, where when we cleaned up shapes (e.g. on `purge_all_shapes` which happened to be triggered for everyone because of `timeline null` issue), if the processes were never started (again, in particular for `purge_all_shapes`, then the shape handle failed to be cleaned up, and it got our system into an incosistent state where the ETS said shape exists, but no associated processes were ever started