### PR TITLE
fix: Electric restart shouldn't cause requests with `0_inf` to fail

### DIFF
--- a/.changeset/sour-poems-beg.md
+++ b/.changeset/sour-poems-beg.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: make sure Electric restart doesn't cause requests with `0_inf` to fail

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -874,11 +874,9 @@ defmodule Electric.Shapes.ConsumerTest do
       assert {_, offset1} = ShapeCache.get_shape(shape_handle, shape_cache_opts)
       assert offset1 == LogOffset.last_before_real_offsets()
 
-      # Kill the consumer and the shape cache server to simulate a restart
-      Process.flag(:trap_exit, true)
-      Process.exit(ctx.consumer_supervisor |> Process.whereis(), :kill)
-      Process.exit(shape_cache_opts[:server] |> Process.whereis(), :kill)
-      Process.sleep(100)
+      # Stop the consumer and the shape cache server to simulate a restart
+      Supervisor.stop(ctx.consumer_supervisor)
+      GenServer.stop(shape_cache_opts[:server])
 
       # Restart the shape cache and the consumers
       Support.ComponentSetup.with_shape_cache(


### PR DESCRIPTION
Issue was only with shapes that didn't observe any writes after being created. When creating a snapshot, we don't know ahead of reading how many total rows we would read from DB, so we created a shape with an in-memory value for last known offset of `0_inf` - after all real snapshot chunks (denoted as `0_1`, `0_2`, ..., `0_n`), but before real LSNs with `x_y` where x > 0. On a restart however we'd read actually created chunk lists and fill in "last known" offset to be say `0_2` instead. Which meant suddenly clients who previously read through the snapshot and were just hanging waiting for new changes got the 400 because requested `0_inf` was indeed larger than presumed maximum of `0_2`. The PR just makes it so that the state of the world after a restart is consistent with the one we achieve while creating a fresh shape.

Closes #2596 