### PR TITLE
Type columns argument to typescript client

### DIFF
--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -53,15 +53,17 @@ type Replica = `full` | `default`
 /**
  * PostgreSQL-specific shape parameters that can be provided externally
  */
-export interface PostgresParams {
+export interface PostgresParams<T extends Row<unknown> = Row> {
   /** The root table for the shape. Not required if you set the table in your proxy. */
   table?: string
 
   /**
    * The columns to include in the shape.
    * Must include primary keys, and can only include valid columns.
+   * Defaults to all columns of the type `T`. If provided, must include primary keys, and can only include valid columns.
+
    */
-  columns?: string[]
+  columns?: (keyof T)[]
 
   /** The where clauses for the shape */
   where?: string
@@ -99,11 +101,11 @@ type ParamValue =
  * External params type - what users provide.
  * Excludes reserved parameters to prevent dynamic variations that could cause stream shape changes.
  */
-export type ExternalParamsRecord = {
+export type ExternalParamsRecord<T extends Row<unknown> = Row> = {
   [K in string as K extends ReservedParamKeys ? never : K]:
     | ParamValue
     | undefined
-} & Partial<PostgresParams>
+} & Partial<PostgresParams<T>>
 
 type ReservedParamKeys =
   | typeof LIVE_CACHE_BUSTER_QUERY_PARAM
@@ -145,7 +147,7 @@ export async function resolveValue<T>(
  * Helper function to convert external params to internal format
  */
 async function toInternalParams(
-  params: ExternalParamsRecord
+  params: ExternalParamsRecord<Row>
 ): Promise<InternalParamsRecord> {
   const entries = Object.entries(params)
   const resolvedEntries = await Promise.all(
@@ -261,7 +263,9 @@ export interface ShapeStreamOptions<T = never> {
 
 export interface ShapeStreamInterface<T extends Row<unknown> = Row> {
   subscribe(
-    callback: (messages: Message<T>[]) => MaybePromise<void>,
+    callback: (
+      messages: Message<T>[]
+    ) => MaybePromise<void> | { columns?: (keyof T)[] },
     onError?: (error: FetchError | Error) => void
   ): () => void
   unsubscribeAll(): void
@@ -772,8 +776,8 @@ function setQueryParam(
 }
 
 function convertWhereParamsToObj(
-  allPgParams: ExternalParamsRecord
-): ExternalParamsRecord {
+  allPgParams: ExternalParamsRecord<Row>
+): ExternalParamsRecord<Row> {
   if (Array.isArray(allPgParams.params)) {
     return {
       ...allPgParams,

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -102,10 +102,8 @@ type ParamValue =
  * Excludes reserved parameters to prevent dynamic variations that could cause stream shape changes.
  */
 export type ExternalParamsRecord<T extends Row<unknown> = Row> = {
-  [K in string as K extends ReservedParamKeys ? never : K]:
-    | ParamValue
-    | undefined
-} & Partial<PostgresParams<T>>
+  [K in string]: ParamValue | undefined
+} & Partial<PostgresParams<T>> & { [K in ReservedParamKeys]?: never }
 
 type ReservedParamKeys =
   | typeof LIVE_CACHE_BUSTER_QUERY_PARAM

--- a/packages/typescript-client/test/client.test-d.ts
+++ b/packages/typescript-client/test/client.test-d.ts
@@ -80,18 +80,18 @@ describe(`client`, () => {
 
       it(`should not allow reserved params`, () => {
         // Test that reserved parameters are not allowed in ExternalParamsRecord
-        type WithReservedParam1 = { [COLUMNS_QUERY_PARAM]: string[] }
+        type WithReservedParam1 = { [COLUMNS_QUERY_PARAM]: string }
         type WithReservedParam2 = { [LIVE_CACHE_BUSTER_QUERY_PARAM]: string }
         type WithReservedParam3 = { [SHAPE_HANDLE_QUERY_PARAM]: string }
         type WithReservedParam4 = { [LIVE_QUERY_PARAM]: string }
         type WithReservedParam5 = { [OFFSET_QUERY_PARAM]: string }
 
         // These should all not be equal to ExternalParamsRecord (not assignable)
-        expectTypeOf<WithReservedParam1>().not.toEqualTypeOf<ExternalParamsRecord>()
-        expectTypeOf<WithReservedParam2>().not.toEqualTypeOf<ExternalParamsRecord>()
-        expectTypeOf<WithReservedParam3>().not.toEqualTypeOf<ExternalParamsRecord>()
-        expectTypeOf<WithReservedParam4>().not.toEqualTypeOf<ExternalParamsRecord>()
-        expectTypeOf<WithReservedParam5>().not.toEqualTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam1>().not.toMatchTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam2>().not.toMatchTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam3>().not.toMatchTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam4>().not.toMatchTypeOf<ExternalParamsRecord>()
+        expectTypeOf<WithReservedParam5>().not.toMatchTypeOf<ExternalParamsRecord>()
       })
     })
   })

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -31,9 +31,9 @@ describe(`Shape`, () => {
     expect(() => {
       const shapeStream = new ShapeStream({
         url: `${BASE_URL}/v1/shape`,
+        subscribe: false,
         params: {
           table: `foo`,
-          live: `false`,
         },
       })
       new Shape(shapeStream)

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -31,9 +31,10 @@ describe(`Shape`, () => {
     expect(() => {
       const shapeStream = new ShapeStream({
         url: `${BASE_URL}/v1/shape`,
-        subscribe: false,
         params: {
           table: `foo`,
+          // @ts-expect-error should not allow reserved parameters
+          live: `false`,
         },
       })
       new Shape(shapeStream)


### PR DESCRIPTION
If a generic type is passed, we should constrain the columns argument to the keys in the type.

I don't think this actually works — if someone better at typescript could look at it and figure out why, that'd be appreciated :-D