### PR TITLE
fix: use 1 query to check repl identities of all tables

### DIFF
--- a/.changeset/itchy-lobsters-share.md
+++ b/.changeset/itchy-lobsters-share.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: check for table identities in one query instead of N when altering the publication


### PR DESCRIPTION
One of the cloud customers set up a DB in Sydney against an Electric instance in US-east, then added shapes for 40 tables. It had shown that when we were altering the publication, after the alter with issued N queries to check that identity of all affected tables was set to `FULL`. Each query took a ~400ms roundtrip, putting us at about 16s for entire alteration which we considered over the time budget and cancelled the transaction. I'll take a better look at timeouts and budgets in a later PR, but this one replaces N queries with 1 query to get all tables that don't have the correct identity, and another query to alter all those found. 