### PR TITLE
fix: ensure split PK update is always visible

### DIFF
--- a/.changeset/popular-mice-change.md
+++ b/.changeset/popular-mice-change.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: make sure a split PK update is visible in the read log when it's in the last position in the transaction


### PR DESCRIPTION
Closes #2600 