### PR TITLE
Surface more connection-related events as stack events

### DIFF
--- a/.changeset/thirty-jeans-hope.md
+++ b/.changeset/thirty-jeans-hope.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add stack events for when timeline change is detected and when the database connection shuts down.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -787,19 +787,6 @@ defmodule Electric.Connection.Manager do
   defp stop_if_fatal_error(
          %Postgrex.Error{
            postgres: %{
-             code: :object_not_in_prerequisite_state,
-             detail: "This slot has been invalidated" <> _,
-             pg_code: "55000"
-           }
-         } = error,
-         state
-       ) do
-    dispatch_fatal_error_and_shutdown({:database_slot_invalidated, %{error: error}}, state)
-  end
-
-  defp stop_if_fatal_error(
-         %Postgrex.Error{
-           postgres: %{
              code: :internal_error,
              pg_code: "XX000"
            }


### PR DESCRIPTION
Addresses #2612 and https://github.com/electric-sql/stratovolt/issues/421.

Here's an example of what it looks like and PG is stopped and later restarted:
![Screenshot from 2025-04-24 02-39-45](https://github.com/user-attachments/assets/3fe70853-08cd-494e-8949-bae41d881ba3)
