### PR TITLE
fix: don't send a 500 on a shape delete race condition

### DIFF
--- a/.changeset/wet-items-whisper.md
+++ b/.changeset/wet-items-whisper.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: don't send a 500 on a shape delete race condition

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -21,7 +21,9 @@ defmodule Electric.Shapes do
         {:ok, Storage.get_log_stream(offset, max_offset, storage)}
       end
     else
-      raise "Unknown shape: #{shape_handle}"
+      # If we have a shape handle, but no shape, it means the shape was deleted. Send a 409
+      # and expect the client to retry - if the state of the world allows, it'll get a new handle.
+      {:error, Electric.Shapes.Api.Error.must_refetch()}
     end
   end
 


### PR DESCRIPTION
We're currently sending a 500 by raising an error when a shape has been deleted in-between us getting a shape handle and asking for the log of that shape. It's more reasonable to send a 409 and let the client deal with an actual error of table being deleted or some such.