### PR TITLE
Refactor and fix connection initialization/reconnection backoff

### DIFF
--- a/.changeset/dull-seals-flow.md
+++ b/.changeset/dull-seals-flow.md
@@ -2,4 +2,4 @@
 "@core/sync-service": patch
 ---
 
-Fix: properly more connection-related edge cases, enabling Electric to recover from exotic failure states.
+Fix: properly handle more connection-related edge cases. Streamline error reporting in stack events.

--- a/.changeset/dull-seals-flow.md
+++ b/.changeset/dull-seals-flow.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix: properly more connection-related edge cases, enabling Electric to recover from exotic failure states.

--- a/integration-tests/tests/invalid-wal-level.lux
+++ b/integration-tests/tests/invalid-wal-level.lux
@@ -20,7 +20,7 @@
   # Reset the failure pattern because we'll be matching on an error.
   -
 
-  ?? [emergency] Electric requires requires wal_level >= logical
+  ?? [emergency] Electric requires wal_level >= logical
   ?? [notice] Application electric exited: shutdown
 
 [cleanup]

--- a/integration-tests/tests/replication-slot-self-conflict.lux
+++ b/integration-tests/tests/replication-slot-self-conflict.lux
@@ -1,0 +1,79 @@
+[doc Verify that Electric can gracefully handle the replication slot conflict that appears after the attempt to start streaming]
+
+[include _macros.luxinc]
+
+[global pg_container_name=replication-slot-self-conflict__pg]
+
+[my invalidated_slot_error=
+  """
+  ** (Postgrex.Error) ERROR 55000 (object_not_in_prerequisite_state) cannot read from logical replication slot "electric_slot_integration"
+
+  This slot has been invalidated because it exceeded the maximum reserved size.
+  """]
+
+[my stack_id="single_stack"]
+
+## Start a new Postgres cluster
+[invoke setup_pg]
+
+## Start a pending transaction that will block Electric's initialization
+[invoke start_psql]
+[shell psql]
+  !BEGIN;
+  ??BEGIN
+
+  !SELECT pg_current_xact_id();
+  ??pg_current_xact_id
+  ??(1 row)
+
+## Start the sync service.
+[invoke setup_electric]
+
+[shell electric]
+  ??[info] Acquiring lock from postgres with name electric_slot_integration
+  ??[info] Lock acquired from postgres with name electric_slot_integration
+
+  # Set the failure match pattern such that we can prove that replication does not start since
+  # it's blocked by the pending transaction.
+  -Starting replication from postgres|$fail_pattern
+
+  ??[debug] Starting replication client for stack single_stack
+  ??[debug] ReplicationClient step: create_slot
+
+# Terminate Electric. Even though it closes all database connections, there still remains a
+# live backend in Postgres blocked on the `CREATE_REPLICATION_SLOT` statement. However, the
+# slot has already been created and can be seen in the result of `SELECT * FROM
+# pg_replication_slots`. So restarting Electric puts it into an odd failure state.
+[shell electric]
+  !:ok = Application.stop(:electric)
+  !:ok = Application.start(:electric)
+
+  -
+
+  ??[info] Starting replication from postgres
+  ??[debug] ReplicationClient step: start_streaming
+  ??[debug] ReplicationClient step: start_replication_slot
+  ??[error] :gen_statem {:"Elixir.Electric.ProcessRegistry:single_stack", {Electric.Postgres.ReplicationClient, nil}} terminating
+  ??** (Postgrex.Error) ERROR 55006 (object_in_use) replication slot "electric_slot_integration" is active for PID
+  ??[warning] Database connection in regular mode failed: replication slot "electric_slot_integration" is active for PID
+  ??[warning] Reconnecting in 2000ms
+
+  ??[warning] Reconnecting in 4000ms
+
+# Rollback the pending transaction to unblock Electric and verify that it completes its initialization.
+[shell psql]
+  !ROLLBACK;
+
+[shell electric]
+  -$fail_pattern
+
+  ??[debug] Restarting replication client for stack single_stack
+  ??[debug] ReplicationClient step: create_slot
+  ??[debug] Created new slot at lsn=
+  ??[info] Starting replication from postgres
+  ??[debug] ReplicationClient step: start_streaming
+  ??[debug] ReplicationClient step: start_replication_slot
+  ??[info] Reconnection succeeded after
+
+[cleanup]
+  [invoke teardown]

--- a/integration-tests/tests/replication-slot-self-conflict.lux
+++ b/integration-tests/tests/replication-slot-self-conflict.lux
@@ -55,7 +55,7 @@
   ??[debug] ReplicationClient step: start_replication_slot
   ??[error] :gen_statem {:"Elixir.Electric.ProcessRegistry:single_stack", {Electric.Postgres.ReplicationClient, nil}} terminating
   ??** (Postgrex.Error) ERROR 55006 (object_in_use) replication slot "electric_slot_integration" is active for PID
-  ??[warning] Database connection in regular mode failed: replication slot "electric_slot_integration" is active for PID
+  ??[warning] Database connection in replication mode failed: Replication slot already in use by another database connection, possibly external to Electric. (PG code: 55006, PG routine: ReplicationSlotAcquire)
   ??[warning] Reconnecting in 2000ms
 
   ??[warning] Reconnecting in 4000ms

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -114,14 +114,15 @@ defmodule Electric.Application do
     Keyword.merge(
       core_config,
       connection_opts:
-        get_env_with_default(opts, :query_connection_opts, replication_connection_opts),
+        get_env_lazy(opts, :query_connection_opts, fn -> replication_connection_opts end),
       replication_opts: [
         connection_opts: replication_connection_opts,
         publication_name: publication_name,
         slot_name: slot_name,
         slot_temporary?: get_env(opts, :replication_slot_temporary?)
       ],
-      pool_opts: get_env_with_default(opts, :pool_opts, pool_size: get_env(opts, :db_pool_size)),
+      pool_opts:
+        get_env_lazy(opts, :pool_opts, fn -> [pool_size: get_env(opts, :db_pool_size)] end),
       chunk_bytes_threshold: get_env(opts, :chunk_bytes_threshold),
       telemetry_opts:
         telemetry_opts([instance_id: instance_id, installation_id: installation_id] ++ opts),
@@ -200,10 +201,6 @@ defmodule Electric.Application do
     Keyword.get_lazy(opts, key, fn ->
       Electric.Config.get_env_lazy(key, fun)
     end)
-  end
-
-  defp get_env_with_default(opts, key, default) do
-    Keyword.get(opts, key, default)
   end
 
   defp application_telemetry(config) do

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -1047,9 +1047,9 @@ defmodule Electric.Connection.Manager do
   defp update_connection_opts(
          :start_replication_client,
          conn_opts,
-         %State{shared_connection_opts: nil} = state
+         %State{shared_connection_opts: nil, replication_opts: replication_opts} = state
        ) do
-    %State{state | replication_opts: put_in(state.replication_opts[:connection_opts], conn_opts)}
+    %State{state | replication_opts: put_in(replication_opts, [:connection_opts], conn_opts)}
   end
 
   defp update_connection_opts(_step, conn_opts, %State{shared_connection_opts: nil} = state) do

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -27,8 +27,55 @@ defmodule Electric.Connection.Manager do
       Supervisor.start_link(children, strategy: :one_for_one)
   """
 
+  # We model the connection manager as a state machine with 2 levels of state. On the 1st
+  # level, it can be in one of several phases:
+  #
+  #   - :connection_setup
+  #   - :running
+  #   - :restarting_replication_client
+  #
+  # Connection manager starts in the :connection_setup phase and moves into the :running phase
+  # after all processes have been started and the replication client is given the command to
+  # start streaming.
+  #
+  # If at any point after that the replication client process exits, connection manager
+  # transitions into the :restarting_replication_client phase and tries to restart the client.
+  #
+  # If any other connection process exits, connection manager itself will shut down to start
+  # from scratch, as there could be too many failure states to address each one individually.
+  #
+  # The 2nd level of the state machine splits the current phase into a series of steps which
+  # the process goes through until it finishes the connection setup phase and transitions into
+  # the running phase.
+  #
+  # Function clauses match on the current phase and step as a way to both assert on the current
+  # state as well as make the code more self-documenting.
+
   defmodule State do
+    @type phase :: :connection_setup | :running | :restarting_replication_client
+    @type step ::
+            {:start_lock_connection, nil}
+            | {:start_lock_connection, :connecting}
+            | {:start_lock_connection, :acquiring_lock}
+            # Steps that start with {:start_replication_client, ...} are pertinent to both the
+            # :connection_setup phase and the :restarting_replication_client phase
+            | {:start_replication_client, nil}
+            | {:start_replication_client, :connecting}
+            | {:start_replication_client, :configuring_connection}
+            | :start_connection_pool
+            | :start_shapes_supervisor
+            | {:start_replication_client, :start_streaming}
+            # Steps of the :running phase:
+            | nil
+            | :waiting_for_streaming_to_start
+
     defstruct [
+      # The phase the connection manager is in. It defines which actions are taken if any of
+      # the connection processes exit.
+      :current_phase,
+      # The current step defines what the connection manager does in the current phase and
+      # which step will be taken next.
+      :current_step,
       # Database connection opts to be passed to Postgrex modules
       :connection_opts,
       # Replication options specific to `Electric.Postgres.ReplicationClient`
@@ -46,18 +93,18 @@ defmodule Electric.Connection.Manager do
       :shape_cache_opts,
       # PID of the replication client
       :replication_client_pid,
+      # Timer reference for the periodic replication client status check
+      :replication_client_timer,
       # PID of the Postgres connection lock
       :lock_connection_pid,
+      # Timer reference for the periodic lock status check
+      :lock_connection_timer,
       # PID of the database connection pool
       :pool_pid,
       # PID of the shape log collector
       :shape_log_collector_pid,
       # Backoff term used for reconnection with exponential back-off
       :connection_backoff,
-      # Flag indicating whether the lock on the replication has been acquired
-      :pg_lock_acquired,
-      # This flag is set to true when the replication connection completes its setup procedure.
-      :replication_connection_established,
       # PostgreSQL server version
       :pg_version,
       # PostgreSQL system identifier
@@ -93,10 +140,7 @@ defmodule Electric.Connection.Manager do
 
   @type options :: [option]
 
-  @connection_status_logging_interval 10_000
-  @replication_mode "replication"
-  @regular_mode "regular"
-  @lock_mode "lock_connection"
+  @connection_status_check_interval 10_000
 
   def child_spec(init_arg) do
     %{
@@ -133,16 +177,28 @@ defmodule Electric.Connection.Manager do
     GenServer.cast(server, :drop_replication_slot_on_stop)
   end
 
+  def lock_connection_started(server) do
+    GenServer.cast(server, :lock_connection_started)
+  end
+
+  def exclusive_connection_lock_acquisition_failed(server, error) do
+    GenServer.cast(server, {:exclusive_connection_lock_acquisition_failed, error})
+  end
+
   def exclusive_connection_lock_acquired(server) do
     GenServer.cast(server, :exclusive_connection_lock_acquired)
   end
 
-  def replication_connection_initializing(server) do
-    GenServer.cast(server, :replication_connection_initializing)
+  def replication_client_started(server) do
+    GenServer.cast(server, :replication_client_started)
   end
 
-  def replication_connection_established(server) do
-    GenServer.cast(server, :replication_connection_established)
+  def replication_client_ready_to_stream(server) do
+    GenServer.cast(server, :replication_client_ready_to_stream)
+  end
+
+  def replication_client_started_streaming(server) do
+    GenServer.cast(server, :replication_client_started_streaming)
   end
 
   def pg_info_looked_up(server, pg_info) do
@@ -166,11 +222,11 @@ defmodule Electric.Connection.Manager do
 
     state =
       %State{
+        current_phase: :connection_setup,
+        current_step: {:start_lock_connection, nil},
         pool_opts: pool_opts,
         timeline_opts: timeline_opts,
         shape_cache_opts: shape_cache_opts,
-        pg_lock_acquired: false,
-        replication_connection_established: false,
         connection_backoff: {ConnectionBackoff.init(1000, 10_000), nil},
         stack_id: Keyword.fetch!(opts, :stack_id),
         stack_events_registry: Keyword.fetch!(opts, :stack_events_registry),
@@ -217,133 +273,235 @@ defmodule Electric.Connection.Manager do
   end
 
   @impl true
-  def handle_continue(:start_lock_connection, %State{lock_connection_pid: nil} = state) do
+  def handle_continue(
+        :start_lock_connection,
+        %State{
+          current_phase: :connection_setup,
+          current_step: {:start_lock_connection, _},
+          lock_connection_pid: nil
+        } = state
+      ) do
     opts = [
-      connection_opts: connection_opts(state),
+      connection_opts: connection_opts(nil, state),
       connection_manager: self(),
       lock_name: Keyword.fetch!(state.replication_opts, :slot_name),
       stack_id: state.stack_id
     ]
 
-    case start_lock_connection(opts) do
-      {:ok, pid, connection_opts} ->
-        state =
-          %State{state | lock_connection_pid: pid}
-          |> mark_connection_succeeded()
-          |> update_connection_opts(connection_opts)
+    {:ok, pid} = Electric.Postgres.LockConnection.start_link(opts)
 
-        dispatch_stack_event(:waiting_for_connection_lock, state)
-        schedule_periodic_connection_status_log(:log_lock_connection_status)
+    state = %State{
+      state
+      | lock_connection_pid: pid,
+        current_step: {:start_lock_connection, :connecting}
+    }
 
-        {:noreply, state}
-
-      {:error, reason} ->
-        handle_connection_error(reason, state, @lock_mode)
-    end
+    # The lock connection has started but we need to wait for it to acquire the advisory
+    # lock before we proceed to starting the replication client.
+    {:noreply, state}
   end
 
   def handle_continue(
         :start_replication_client,
-        %State{replication_connection_established: false} = state
-      ) do
+        %State{
+          current_phase: phase,
+          current_step: {:start_replication_client, _},
+          replication_client_pid: nil
+        } = state
+      )
+      when phase in [:connection_setup, :restarting_replication_client] do
     opts = [
       replication_opts: replication_opts(state),
       connection_manager: self(),
       stack_id: state.stack_id
     ]
 
-    # This function might be called multiple times due to the possibility of the noSSL
-    # fallback. We want to do some of the steps on the first connection attempt only.
-    first_time? = is_nil(state.replication_client_pid)
+    Logger.debug("Starting replication client for stack #{state.stack_id}")
 
-    if first_time?, do: Logger.debug("Starting replication client for stack #{state.stack_id}")
+    {:ok, pid} = Electric.Postgres.ReplicationClient.start_link(opts)
 
-    case Electric.Postgres.ReplicationClient.start_link(opts) do
-      {:ok, pid} ->
-        state = %State{state | replication_client_pid: pid}
+    state = %State{
+      state
+      | replication_client_pid: pid,
+        current_step: {:start_replication_client, :connecting}
+    }
 
-        if first_time?,
-          do: schedule_periodic_connection_status_log(:log_replication_connection_status)
-
-        {:noreply, state}
-
-      {:error, reason} ->
-        handle_connection_error(reason, state, @replication_mode)
-    end
+    # The replication client has started but it still needs to open a database connection
+    # and perform setup queries before it's be ready to start streaming.
+    {:noreply, state}
   end
 
-  def handle_continue(:start_connection_pool, state) do
-    case start_connection_pool(connection_opts(state), state.pool_opts) do
-      {:ok, pool_pid} ->
-        StatusMonitor.mark_connection_pool_ready(state.stack_id, pool_pid)
+  def handle_continue(
+        :start_connection_pool,
+        %State{
+          current_phase: :connection_setup,
+          current_step: :start_connection_pool,
+          pool_pid: nil
+        } = state
+      ) do
+    # Use default backoff strategy for connections to prevent pool from shutting down
+    # in the case of a connection error. Deleting a shape while its still generating
+    # its snapshot from the db can trigger this as the snapshot process and the storage
+    # process are both terminated when the shape is removed.
+    #
+    # See https://github.com/electric-sql/electric/issues/1554
+    conn_opts = connection_opts(nil, state) |> Electric.Utils.deobfuscate_password()
 
-        state = mark_connection_succeeded(state)
-        # Checking the timeline continuity to see if we need to purge all shapes persisted so far
-        # and reset any replication related persistent state
-        timeline_changed? =
-          Electric.Timeline.check(
-            {state.pg_system_identifier, state.pg_timeline_id},
-            state.timeline_opts
-          ) == :timeline_changed
+    {:ok, pool_pid} =
+      Postgrex.start_link(
+        state.pool_opts ++
+          [
+            backoff_type: :exp,
+            max_restarts: 3,
+            max_seconds: 5,
+            # Assume the manager connection might be pooled, so use unnamed prepared
+            # statements to avoid issues with the pooler
+            #
+            # See https://hexdocs.pm/postgrex/0.19.3/readme.html#pgbouncer
+            prepare: :unnamed
+          ] ++ conn_opts
+      )
 
-        shape_cache_opts =
-          state.shape_cache_opts
-          |> Keyword.put(:purge_all_shapes?, timeline_changed?)
+    # NOTE(alco): We're jumping ahead of ourselves here a bit because at this point we don't
+    # yet have a confirmation that the connection pool has succeeded in opening a database
+    # connection. But since we already have a lock connection and a replication connection
+    # open, it's likely the connection pool will also succeed.
+    Electric.StatusMonitor.mark_connection_pool_ready(state.stack_id, pool_pid)
+    state = mark_connection_succeeded(state)
 
-        if timeline_changed? do
-          Electric.Replication.PersistentReplicationState.reset(
-            stack_id: state.stack_id,
-            persistent_kv: state.persistent_kv
-          )
-
-          dispatch_stack_event(
-            {:database_id_or_timeline_changed,
-             %{
-               message:
-                 "Purging shape logs from disk. Clients will refetch shape data automatically."
-             }},
-            state
-          )
-        end
-
-        shapes_sup_pid =
-          case Electric.Connection.Supervisor.start_shapes_supervisor(
-                 stack_id: state.stack_id,
-                 shape_cache_opts: shape_cache_opts,
-                 pool_opts: state.pool_opts,
-                 replication_opts: state.replication_opts,
-                 stack_events_registry: state.stack_events_registry,
-                 tweaks: state.tweaks,
-                 persistent_kv: state.persistent_kv
-               ) do
-            {:ok, shapes_sup_pid} ->
-              shapes_sup_pid
-
-            {:error, reason} ->
-              Logger.error("Failed to start shape supervisor: #{inspect(reason)}")
-              exit(reason)
-          end
-
-        # Everything is ready to start accepting and processing logical messages from Postgres.
-        Electric.Postgres.ReplicationClient.start_streaming(state.replication_client_pid)
-
-        # Remember the shape log collector pid for later because we want to tie the replication
-        # client's lifetime to it.
-        log_collector_pid = lookup_log_collector_pid(shapes_sup_pid)
-        Process.monitor(log_collector_pid)
-
-        state = %State{state | pool_pid: pool_pid, shape_log_collector_pid: log_collector_pid}
-
-        {:noreply, state}
-
-      {:error, reason} ->
-        handle_connection_error(reason, state, @regular_mode)
-    end
+    state = %State{state | pool_pid: pool_pid, current_step: :start_shapes_supervisor}
+    {:noreply, state, {:continue, :start_shapes_supervisor}}
   end
 
+  def handle_continue(
+        :start_shapes_supervisor,
+        %State{
+          current_phase: :connection_setup,
+          current_step: :start_shapes_supervisor,
+          shape_log_collector_pid: nil
+        } = state
+      ) do
+    # Checking the timeline continuity to see if we need to purge all shapes persisted so far
+    # and reset any replication related persistent state
+    timeline_changed? =
+      Electric.Timeline.check(
+        {state.pg_system_identifier, state.pg_timeline_id},
+        state.timeline_opts
+      ) == :timeline_changed
+
+    shape_cache_opts =
+      state.shape_cache_opts
+      |> Keyword.put(:purge_all_shapes?, timeline_changed?)
+
+    if timeline_changed? do
+      Electric.Replication.PersistentReplicationState.reset(
+        stack_id: state.stack_id,
+        persistent_kv: state.persistent_kv
+      )
+
+      dispatch_stack_event(
+        {:database_id_or_timeline_changed,
+         %{
+           message: "Purging shape logs from disk. Clients will refetch shape data automatically."
+         }},
+        state
+      )
+    end
+
+    shapes_sup_pid =
+      case Electric.Connection.Supervisor.start_shapes_supervisor(
+             stack_id: state.stack_id,
+             shape_cache_opts: shape_cache_opts,
+             pool_opts: state.pool_opts,
+             replication_opts: state.replication_opts,
+             stack_events_registry: state.stack_events_registry,
+             tweaks: state.tweaks,
+             persistent_kv: state.persistent_kv
+           ) do
+        {:ok, shapes_sup_pid} ->
+          shapes_sup_pid
+
+        {:error, reason} ->
+          Logger.error("Failed to start shape supervisor: #{inspect(reason)}")
+          exit(reason)
+      end
+
+    # Remember the shape log collector pid for later because we want to tie the replication
+    # client's lifetime to it.
+    log_collector_pid = lookup_log_collector_pid(shapes_sup_pid)
+    Process.monitor(log_collector_pid)
+
+    state = %State{
+      state
+      | shape_log_collector_pid: log_collector_pid,
+        current_step: {:start_replication_client, :start_streaming}
+    }
+
+    {:noreply, state, {:continue, :start_streaming}}
+  end
+
+  def handle_continue(
+        :start_streaming,
+        %State{
+          current_phase: phase,
+          current_step: {:start_replication_client, :start_streaming}
+        } = state
+      )
+      when phase in [:connection_setup, :restarting_replication_client] do
+    # Everything is ready to start accepting and processing logical messages from Postgres.
+    Logger.info("Starting replication from postgres")
+    Electric.Postgres.ReplicationClient.start_streaming(state.replication_client_pid)
+    state = %State{state | current_phase: :running, current_step: :waiting_for_streaming_to_start}
+    {:noreply, state}
+  end
+
+  # Periodically log the connection status for easier debugging and diagnostics.
   @impl true
   def handle_info(
-        {:timeout, tref, step},
+        {:timeout, tref, {:check_status, :lock_connection}},
+        %State{
+          lock_connection_timer: tref,
+          current_phase: :connection_setup,
+          current_step: {:start_lock_connection, :acquiring_lock}
+        } = state
+      ) do
+    Logger.warning(fn -> "Waiting for postgres lock to be acquired..." end)
+    tref = schedule_periodic_connection_status_check(:lock_connection)
+    state = %State{state | lock_connection_timer: tref}
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {:timeout, tref, {:check_status, :replication_client}},
+        %State{
+          replication_client_timer: tref,
+          current_phase: phase,
+          current_step: {:start_replication_client, :configuring_connection}
+        } = state
+      )
+      when phase in [:connection_setup, :restarting_replication_client] do
+    Logger.warning(fn ->
+      "Waiting for the replication connection setup to complete... " <>
+        "Check that you don't have pending transactions in the database. " <>
+        "Electric has to wait for all pending transactions to commit or rollback " <>
+        "before it can create the replication slot."
+    end)
+
+    tref = schedule_periodic_connection_status_check(:replication_client)
+    state = %State{state | replication_client_timer: tref}
+    {:noreply, state}
+  end
+
+  def handle_info({:timeout, tref, {:check_status, _}}, state) do
+    # The connection status must have changed after the last schedule_periodic_connection_status_check()
+    # call and before this callback has been invoked. Or a new timer has been created, so this
+    # one needs to lapse without scheduling another tick.
+    state = nillify_timer(state, tref)
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {:timeout, tref, {:retry_connection, step}},
         %State{connection_backoff: {conn_backoff, tref}} = state
       ) do
     state = %State{state | connection_backoff: {conn_backoff, nil}}
@@ -354,57 +512,67 @@ defmodule Electric.Connection.Manager do
   def handle_info({:EXIT, _, :shutdown}, state), do: {:noreply, state}
   def handle_info({:EXIT, _, {:shutdown, _}}, state), do: {:noreply, state}
 
-  # The replication client failed to establish its database connection.
-  def handle_info(
-        {:EXIT, pid, signal},
-        %State{replication_client_pid: pid, replication_connection_established: false} = state
-      ) do
-    reason = strip_exit_signal_stacktrace(signal)
-    conn_opts = Keyword.fetch!(replication_opts(state), :connection_opts)
+  # A process exited as it was trying to open a database connection.
+  def handle_info({:EXIT, pid, reason}, %State{current_phase: :connection_setup} = state) do
+    # Try repairing the connection opts and try connecting again. If we're already using noSSL
+    # and IPv4, the error will be propagated to a `shutdown_or_reconnect()` function call
+    # further down below.
+    error = strip_exit_signal_stacktrace(reason)
+    state = nillify_pid(state, pid)
+    {step, _} = state.current_step
+    conn_opts = connection_opts(step, state)
 
-    case maybe_fallback_to_no_ssl(reason, conn_opts) do
-      {:ok, conn_opts} ->
-        state = update_replication_connection_opts(state, conn_opts)
-        {:noreply, state, {:continue, :start_replication_client}}
+    repaired_conn_opts =
+      case error do
+        %Postgrex.Error{message: "ssl not available"} ->
+          maybe_fallback_to_no_ssl(conn_opts)
 
-      {:error, error} ->
-        handle_connection_error(error, state, @replication_mode)
+        # Seen this when connecting to Fly Postgres
+        %DBConnection.ConnectionError{message: "ssl connect: closed"} ->
+          maybe_fallback_to_no_ssl(conn_opts)
+
+        %DBConnection.ConnectionError{message: message, severity: :error} ->
+          maybe_fallback_to_ipv4(message, conn_opts)
+
+        _ ->
+          nil
+      end
+
+    if repaired_conn_opts do
+      state = update_connection_opts(step, repaired_conn_opts, state)
+      {:noreply, state, {:continue, step}}
+    else
+      shutdown_or_reconnect(error, state)
     end
   end
 
-  # The replication client exited after it had already started streaming from the database.
-  # It can be restarted independently of the lock connection and the DB pool. If any of the
+  # The replication client exited after the connection setup has completed, it can be restarted
+  # independently of the lock connection and the DB pool. On the other hand, if any of the
   # latter two shut down, Connection.Manager will itself terminate to be restarted by its
   # supervisor in a clean state.
-  def handle_info({:EXIT, pid, signal}, %State{replication_client_pid: pid} = state) do
-    reason = strip_exit_signal_stacktrace(signal)
+  def handle_info(
+        {:EXIT, pid, reason},
+        %State{replication_client_pid: pid, current_phase: :running} = state
+      ) do
+    state = nillify_pid(state, pid)
+    error = strip_exit_signal_stacktrace(reason)
 
-    with false <- drop_slot_and_restart(reason, state),
-         false <- stop_if_fatal_error(reason, state, @replication_mode) do
-      Logger.debug(
-        "Handling the exit of the replication client #{inspect(pid)} with reason #{inspect(reason)}"
-      )
+    state = %State{
+      state
+      | current_phase: :restarting_replication_client,
+        current_step: {:start_replication_client, nil}
+    }
 
-      state = %State{
-        state
-        | replication_client_pid: nil,
-          replication_connection_established: false
-      }
-
-      state = schedule_reconnection(:start_replication_client, state)
-      {:noreply, state}
-    end
+    shutdown_or_reconnect(error, state)
   end
 
-  # The most likely reason for the lock connection or the DB pool to exit is the database
-  # server going offline or shutting down. Stop Connection.Manager to allow its supervisor to
-  # restart it in the initial state.
-  def handle_info({:EXIT, pid, signal}, state) do
-    reason = strip_exit_signal_stacktrace(signal)
-
+  # The most likely reason for any database connection to get closed after we've already opened a
+  # bunch of them is the database server going offline or shutting down. Stop
+  # Connection.Manager to allow its supervisor to restart it in the initial state.
+  def handle_info({:EXIT, pid, reason}, state) do
     Logger.warning(
       "#{inspect(__MODULE__)} is restarting after it has encountered an error in process #{inspect(pid)}:\n" <>
-        inspect(reason, pretty: true) <> "\n\n" <> inspect(state, pretty: true)
+        format_exit_reason(reason, pretty: true) <> "\n\n" <> inspect(state, pretty: true)
     )
 
     dispatch_stack_event({:database_connection_severed, format_exit_reason(reason)}, state)
@@ -443,75 +611,118 @@ defmodule Electric.Connection.Manager do
     {:noreply, %State{state | shape_log_collector_pid: nil, replication_client_pid: nil}}
   end
 
-  # Periodically log the status of the lock connection until it is acquired for
-  # easier debugging and diagnostics.
-  def handle_info(:log_lock_connection_status, state) do
-    if not state.pg_lock_acquired do
-      Logger.warning(fn -> "Waiting for postgres lock to be acquired..." end)
-      schedule_periodic_connection_status_log(:log_lock_connection_status)
-    end
-
-    {:noreply, state}
-  end
-
-  # Periodically log the status of the replication connection while waiting for it to get ready
-  # for streaming.
-  def handle_info(:log_replication_connection_status, state) do
-    if not state.replication_connection_established do
-      Logger.warning(fn ->
-        "Waiting for the replication connection setup to complete... " <>
-          "Check that you don't have pending transactions in the database. " <>
-          "Electric has to wait for all pending transactions to commit or rollback " <>
-          "before it can create the replication slot."
-      end)
-
-      schedule_periodic_connection_status_log(:log_replication_connection_status)
-    end
-
-    {:noreply, state}
-  end
-
   @impl true
   def handle_cast(:drop_replication_slot_on_stop, state) do
     {:noreply, %State{state | drop_slot_requested: true}}
   end
 
-  def handle_cast(:exclusive_connection_lock_acquired, %State{pg_lock_acquired: false} = state) do
-    # As soon as we acquire the connection lock, we try to start the replication connection
-    # first because it requires additional privileges compared to regular "pooled" connections,
-    # so failure to open a replication connection should be reported ASAP.
-    {:noreply, %State{state | pg_lock_acquired: true}, {:continue, :start_replication_client}}
-  end
-
   def handle_cast(
-        :replication_connection_initializing,
-        %State{replication_connection_established: false} = state
+        :lock_connection_started,
+        %State{
+          current_phase: :connection_setup,
+          current_step: {:start_lock_connection, :connecting}
+        } = state
       ) do
+    dispatch_stack_event(:waiting_for_connection_lock, state)
+    tref = schedule_periodic_connection_status_check(:lock_connection)
     state = mark_connection_succeeded(state)
+
+    state = %State{
+      state
+      | lock_connection_timer: tref,
+        current_step: {:start_lock_connection, :acquiring_lock}
+    }
+
     {:noreply, state}
   end
 
   def handle_cast(
-        :replication_connection_established,
-        %State{replication_connection_established: false} = state
+        {:exclusive_connection_lock_acquisition_failed, error},
+        %State{
+          current_phase: :connection_setup,
+          current_step: {:start_lock_connection, :acquiring_lock}
+        } = state
       ) do
-    state = %State{state | replication_connection_established: true}
+    Electric.StatusMonitor.mark_pg_lock_as_errored(state.stack_id, inspect(error))
+    dispatch_stack_event({:failed_to_acquire_connection_lock, %{error: error}}, state)
 
-    if is_nil(state.pool_pid) do
-      # This is the case where Connection.Manager starts connections from the initial state.
-      # Replication connection is opened after the lock connection has acquired the
-      # exclusive lock. After it, we start the connection pool.
-      false = is_nil(state.lock_connection_pid)
-      {:noreply, state, {:continue, :start_connection_pool}}
-    else
-      # The replication client process exited while the other connection processes were
-      # already running. Now that it's been restarted, we can transition it into the
-      # logical replication mode immediately since all the other connection process and the
-      # shapes supervisor are already up.
-      false = is_nil(state.lock_connection_pid)
-      Electric.Postgres.ReplicationClient.start_streaming(state.replication_client_pid)
-      {:noreply, state}
+    # The LockConnection process will keep retrying to acquire the lock.
+    {:noreply, state}
+  end
+
+  def handle_cast(
+        :exclusive_connection_lock_acquired,
+        %State{
+          current_phase: :connection_setup,
+          current_step: {:start_lock_connection, :acquiring_lock}
+        } = state
+      ) do
+    Electric.StatusMonitor.mark_pg_lock_acquired(state.stack_id, state.lock_connection_pid)
+
+    # As soon as we acquire the connection lock, we try to start the replication connection
+    # first because it requires additional privileges compared to regular "pooled" connections,
+    # so failure to open a replication connection should be reported ASAP.
+    state = %State{state | current_step: {:start_replication_client, nil}}
+    {:noreply, state, {:continue, :start_replication_client}}
+  end
+
+  def handle_cast(
+        :replication_client_started,
+        %State{
+          current_phase: phase,
+          current_step: {:start_replication_client, :connecting}
+        } = state
+      )
+      when phase in [:connection_setup, :restarting_replication_client] do
+    tref = schedule_periodic_connection_status_check(:replication_client)
+
+    state = %{
+      state
+      | replication_client_timer: tref,
+        current_step: {:start_replication_client, :configuring_connection}
+    }
+
+    {:noreply, state}
+  end
+
+  def handle_cast(
+        :replication_client_ready_to_stream,
+        %State{
+          current_phase: phase,
+          current_step: {:start_replication_client, :configuring_connection}
+        } = state
+      )
+      when phase in [:connection_setup, :restarting_replication_client] do
+    Electric.StatusMonitor.mark_replication_client_ready(
+      state.stack_id,
+      state.replication_client_pid
+    )
+
+    case phase do
+      :connection_setup ->
+        # This is the case where Connection.Manager starts connections from the initial state.
+        # Replication connection is opened after the lock connection has acquired the
+        # exclusive lock. Now it's time to start the connection pool.
+        state = %{state | current_step: :start_connection_pool}
+        {:noreply, state, {:continue, :start_connection_pool}}
+
+      :restarting_replication_client ->
+        # The replication client process exited while the other connection processes were
+        # already running. Now that it's been restarted, we can transition it into the
+        # logical replication mode immediately since all the other connection process and the
+        # shapes supervisor are already up.
+        state = %{state | current_step: {:start_replication_client, :start_streaming}}
+        {:noreply, state, {:continue, :start_streaming}}
     end
+  end
+
+  def handle_cast(
+        :replication_client_started_streaming,
+        %State{current_phase: :running, current_step: :waiting_for_streaming_to_start} = state
+      ) do
+    state = mark_connection_succeeded(state)
+    state = %State{state | current_step: nil}
+    {:noreply, state}
   end
 
   def handle_cast({:pg_info_looked_up, {server_version, system_identifier, timeline_id}}, state) do
@@ -534,83 +745,24 @@ defmodule Electric.Connection.Manager do
      }}
   end
 
-  defp start_lock_connection(opts) do
-    case Electric.Postgres.LockConnection.start_link(opts) do
-      {:ok, pid} ->
-        {:ok, pid, opts[:connection_opts]}
-
-      {:error, reason} ->
-        with {:ok, connection_opts} <- maybe_fallback_to_no_ssl(reason, opts[:connection_opts]) do
-          opts = Keyword.put(opts, :connection_opts, connection_opts)
-          start_lock_connection(opts)
-        end
-    end
-  end
-
-  defp start_connection_pool(connection_opts, pool_opts) do
-    # Use default backoff strategy for connections to prevent pool from shutting down
-    # in the case of a connection error. Deleting a shape while its still generating
-    # its snapshot from the db can trigger this as the snapshot process and the storage
-    # process are both terminated when the shape is removed.
-    #
-    # See https://github.com/electric-sql/electric/issues/1554
-    Postgrex.start_link(
-      pool_opts ++
-        [
-          backoff_type: :exp,
-          max_restarts: 3,
-          max_seconds: 5,
-          # Assume the manager connection might be pooled, so use unnamed prepared
-          # statements to avoid issues with the pooler
-          #
-          # See https://hexdocs.pm/postgrex/0.19.3/readme.html#pgbouncer
-          prepare: :unnamed
-        ] ++
-        Electric.Utils.deobfuscate_password(connection_opts)
-    )
-  end
-
-  defp maybe_fallback_to_ipv4(
-         %DBConnection.ConnectionError{message: message, severity: :error} = error,
-         connection_opts
-       ) do
+  defp maybe_fallback_to_ipv4(error_message, conn_opts) do
     # If network is unreachable, IPv6 is not enabled on the machine
     # If domain cannot be resolved, assume there is no AAAA record for it
     # Fall back to IPv4 for these cases
-    if connection_opts[:ipv6] and
-         String.starts_with?(message, "tcp connect (") and
-         (String.ends_with?(message, "): non-existing domain - :nxdomain") or
-            String.ends_with?(message, "): network is unreachable - :enetunreach")) do
+    if conn_opts[:ipv6] and
+         String.starts_with?(error_message, "tcp connect (") and
+         (String.ends_with?(error_message, "): non-existing domain - :nxdomain") or
+            String.ends_with?(error_message, "): network is unreachable - :enetunreach")) do
       Logger.warning(
-        "Database connection failed to find valid IPv6 address for #{connection_opts[:hostname]} - falling back to IPv4"
+        "Database connection failed to find valid IPv6 address for #{conn_opts[:hostname]} - falling back to IPv4"
       )
 
-      {:ok, connection_opts |> Keyword.put(:ipv6, false) |> populate_tcp_opts()}
-    else
-      {:error, error}
+      conn_opts |> Keyword.put(:ipv6, false) |> populate_tcp_opts()
     end
   end
 
-  defp maybe_fallback_to_ipv4(error, _connection_opts), do: {:error, error}
-
-  defp maybe_fallback_to_no_ssl(reason, connection_opts) do
-    error = {:error, reason}
-
-    case reason do
-      %Postgrex.Error{message: "ssl not available"} ->
-        do_fallback_to_no_ssl(connection_opts) || error
-
-      # Seen this when connecting to Fly Postgres
-      %DBConnection.ConnectionError{message: "ssl connect: closed"} ->
-        do_fallback_to_no_ssl(connection_opts) || error
-
-      _ ->
-        error
-    end
-  end
-
-  defp do_fallback_to_no_ssl(connection_opts) do
-    sslmode = connection_opts[:sslmode]
+  defp maybe_fallback_to_no_ssl(conn_opts) do
+    sslmode = conn_opts[:sslmode]
 
     if sslmode != :require do
       if not is_nil(sslmode) do
@@ -621,54 +773,21 @@ defmodule Electric.Connection.Manager do
         )
       end
 
-      {:ok, Keyword.put(connection_opts, :ssl, false)}
+      Keyword.put(conn_opts, :ssl, false)
     end
   end
 
-  defp handle_connection_error(
-         %DBConnection.ConnectionError{severity: :error} = error,
-         state,
-         mode
-       ) do
-    conn_opts =
-      if current_connection_step(state) == :start_replication_client do
-        Keyword.fetch!(replication_opts(state), :connection_opts)
-      else
-        connection_opts(state)
-      end
+  defp shutdown_or_reconnect(error, state) do
+    error = DbConnectionError.from_error(error)
 
-    case maybe_fallback_to_ipv4(error, conn_opts) do
-      {:ok, conn_opts} ->
-        # disable IPv6 and retry immediately
-        state =
-          if current_connection_step(state) == :start_replication_client do
-            update_replication_connection_opts(state, conn_opts)
-          else
-            update_connection_opts(state, conn_opts)
-          end
-
-        step = current_connection_step(state)
-        handle_continue(step, state)
-
-      {:error, reason} ->
-        fail_on_error_or_reconnect(reason, state, mode)
-    end
-  end
-
-  defp handle_connection_error(error, state, mode) do
-    fail_on_error_or_reconnect(error, state, mode)
-  end
-
-  # This separate function is needed for `handle_connection_error()` not to get stuck in a
-  # recursive function call loop.
-  defp fail_on_error_or_reconnect(error, state, mode) do
-    with false <- stop_if_fatal_error(error, state, mode) do
-      state = schedule_reconnection_after_error(error, state, mode)
+    with false <- drop_slot_and_restart(error, state),
+         false <- stop_if_fatal_error(error, state) do
+      state = schedule_reconnection_after_error(error, state)
       {:noreply, state}
     end
   end
 
-  defp schedule_reconnection_after_error(error, state, mode) do
+  defp schedule_reconnection_after_error(error, state) do
     message =
       case error do
         %DBConnection.ConnectionError{message: message} ->
@@ -681,7 +800,18 @@ defmodule Electric.Connection.Manager do
           message <> pg_error_extra_info(pg_error)
       end
 
-    Logger.warning("Database connection in #{mode} mode failed: #{message}")
+    connection_mode = set_connection_status_error(error, state)
+
+    # TODO: error.message
+    Logger.warning(
+      "Database connection in #{connection_mode} mode failed: #{message}\nRetrying..."
+    )
+
+    dispatch_stack_event(
+      {:retryable_error,
+       %{error: error.original_error, message: error.message, type: error.type}},
+      state
+    )
 
     dispatch_stack_event(
       {:database_connection_failed,
@@ -692,18 +822,41 @@ defmodule Electric.Connection.Manager do
       state
     )
 
-    step = current_connection_step(state)
+    {step, _} = state.current_step
     schedule_reconnection(step, state)
   end
 
-  defp current_connection_step(%State{lock_connection_pid: nil}),
-    do: :start_lock_connection
+  defp set_connection_status_error(
+         error,
+         %State{
+           current_phase: :connection_setup,
+           current_step: {:start_lock_connection, _}
+         } = state
+       ) do
+    StatusMonitor.mark_pg_lock_as_errored(state.stack_id, error)
+    "lock_connection"
+  end
 
-  defp current_connection_step(%State{replication_connection_established: false}),
-    do: :start_replication_client
+  defp set_connection_status_error(
+         error,
+         %State{
+           current_phase: phase,
+           current_step: {:start_replication_client, _}
+         } = state
+       )
+       when phase in [:connection_setup, :restarting_replication_client] do
+    StatusMonitor.mark_replication_client_as_errored(state.stack_id, error)
+    "replication"
+  end
 
-  defp current_connection_step(%State{pool_pid: nil}),
-    do: :start_connection_pool
+  defp set_connection_status_error(error, %State{current_phase: :connection_setup} = state) do
+    StatusMonitor.mark_connection_pool_as_errored(state.stack_id, error)
+    "connection_pool"
+  end
+
+  defp set_connection_status_error(_error, _state) do
+    "regular"
+  end
 
   defp pg_error_extra_info(pg_error) do
     extra_info_items =
@@ -753,38 +906,12 @@ defmodule Electric.Connection.Manager do
 
   defp drop_slot_and_restart(_, _), do: false
 
-  defp stop_if_fatal_error(error, state, mode) do
-    error = DbConnectionError.from_error(error)
-
+  defp stop_if_fatal_error(error, state) do
     if error.retry_may_fix? do
-      Logger.warning(
-        "Error while trying to connect to the database (#{mode}): #{error.message}\n" <>
-          "Retrying..."
-      )
-
-      dispatch_stack_event(
-        {:retryable_error,
-         %{error: error.original_error, message: error.message, type: error.type}},
-        state
-      )
-
-      mark_error_for_mode(mode, error.message, state.stack_id)
       false
     else
       dispatch_fatal_error_and_shutdown(error, state)
     end
-  end
-
-  defp mark_error_for_mode(@replication_mode, error, stack_id) do
-    StatusMonitor.mark_replication_client_as_errored(stack_id, error)
-  end
-
-  defp mark_error_for_mode(@regular_mode, error, stack_id) do
-    StatusMonitor.mark_connection_pool_as_errored(stack_id, error)
-  end
-
-  defp mark_error_for_mode(@lock_mode, error, stack_id) do
-    StatusMonitor.mark_pg_lock_as_errored(stack_id, error)
   end
 
   defp dispatch_fatal_error_and_shutdown(%DbConnectionError{} = error, state) do
@@ -808,7 +935,7 @@ defmodule Electric.Connection.Manager do
          } = state
        ) do
     {time, conn_backoff} = ConnectionBackoff.fail(conn_backoff)
-    tref = :erlang.start_timer(time, self(), step)
+    tref = :erlang.start_timer(time, self(), {:retry_connection, step})
     Logger.warning("Reconnecting in #{inspect(time)}ms")
     %State{state | connection_backoff: {conn_backoff, tref}}
   end
@@ -894,16 +1021,37 @@ defmodule Electric.Connection.Manager do
   defp populate_connection_opts(conn_opts),
     do: conn_opts |> populate_ssl_opts() |> populate_tcp_opts()
 
-  defp update_connection_opts(%State{shared_connection_opts: nil} = state, conn_opts) do
+  defp connection_opts(:start_replication_client, %State{shared_connection_opts: nil} = state) do
+    Keyword.fetch!(state.replication_opts, :connection_opts)
+  end
+
+  defp connection_opts(_step, %State{shared_connection_opts: nil} = state) do
+    state.connection_opts
+  end
+
+  defp connection_opts(_step, state) do
+    state.shared_connection_opts
+  end
+
+  defp replication_opts(%State{shared_connection_opts: nil} = state), do: state.replication_opts
+
+  defp replication_opts(%State{shared_connection_opts: conn_opts} = state),
+    do: Keyword.put(state.replication_opts, :connection_opts, conn_opts)
+
+  defp update_connection_opts(
+         :start_replication_client,
+         conn_opts,
+         %State{shared_connection_opts: nil} = state
+       ) do
+    %State{state | replication_opts: put_in(state.replication_opts[:connection_opts], conn_opts)}
+  end
+
+  defp update_connection_opts(_step, conn_opts, %State{shared_connection_opts: nil} = state) do
     %State{state | connection_opts: conn_opts}
   end
 
-  defp update_connection_opts(state, conn_opts) do
+  defp update_connection_opts(_step, conn_opts, state) do
     %State{state | shared_connection_opts: conn_opts}
-  end
-
-  defp update_replication_connection_opts(%State{shared_connection_opts: nil} = state, conn_opts) do
-    %State{state | replication_opts: put_in(state.replication_opts[:connection_opts], conn_opts)}
   end
 
   defp lookup_log_collector_pid(shapes_supervisor) do
@@ -941,17 +1089,9 @@ defmodule Electric.Connection.Manager do
     end
   end
 
-  defp schedule_periodic_connection_status_log(type) do
-    Process.send_after(self(), type, @connection_status_logging_interval)
+  defp schedule_periodic_connection_status_check(type) do
+    :erlang.start_timer(@connection_status_check_interval, self(), {:check_status, type})
   end
-
-  defp connection_opts(%State{shared_connection_opts: nil} = state), do: state.connection_opts
-  defp connection_opts(%State{shared_connection_opts: conn_opts}), do: conn_opts
-
-  defp replication_opts(%State{shared_connection_opts: nil} = state), do: state.replication_opts
-
-  defp replication_opts(%State{shared_connection_opts: conn_opts} = state),
-    do: Keyword.put(state.replication_opts, :connection_opts, conn_opts)
 
   # It's possible that the exit signal received from the replication client process includes a
   # stacktrace. I haven't found the rule that would describe when the stacktrace is to be
@@ -963,13 +1103,13 @@ defmodule Electric.Connection.Manager do
     end
   end
 
-  defp format_exit_reason(error) do
+  defp format_exit_reason(error, inspect_opts \\ []) do
     if is_exception(error) do
       Exception.format(:error, error)
     else
       error
       |> strip_exit_signal_stacktrace()
-      |> inspect()
+      |> inspect(inspect_opts)
     end
   end
 
@@ -980,4 +1120,24 @@ defmodule Electric.Connection.Manager do
       event
     )
   end
+
+  defp nillify_pid(%State{lock_connection_pid: pid} = state, pid),
+    do: %State{state | lock_connection_pid: nil}
+
+  defp nillify_pid(%State{replication_client_pid: pid} = state, pid),
+    do: %State{state | replication_client_pid: nil}
+
+  defp nillify_pid(%State{pool_pid: pid} = state, pid),
+    do: %State{state | pool_pid: nil}
+
+  defp nillify_pid(%State{shape_log_collector_pid: pid} = state, pid),
+    do: %State{state | shape_log_collector_pid: nil}
+
+  defp nillify_timer(%State{lock_connection_timer: tref} = state, tref),
+    do: %State{state | lock_connection_timer: nil}
+
+  defp nillify_timer(%State{replication_client_timer: tref} = state, tref),
+    do: %State{state | replication_client_timer: nil}
+
+  defp nillify_timer(state, _tref), do: state
 end

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -425,7 +425,6 @@ defmodule Electric.Connection.Manager do
              shape_cache_opts: shape_cache_opts,
              pool_opts: state.pool_opts,
              replication_opts: state.replication_opts,
-             stack_events_registry: state.stack_events_registry,
              tweaks: state.tweaks,
              persistent_kv: state.persistent_kv
            ) do
@@ -436,6 +435,8 @@ defmodule Electric.Connection.Manager do
           Logger.error("Failed to start shape supervisor: #{inspect(reason)}")
           exit(reason)
       end
+
+    dispatch_stack_event(:ready, state)
 
     # Remember the shape log collector pid for later because we want to tie the replication
     # client's lifetime to it.
@@ -668,6 +669,7 @@ defmodule Electric.Connection.Manager do
         } = state
       ) do
     Electric.StatusMonitor.mark_pg_lock_acquired(state.stack_id, state.lock_connection_pid)
+    dispatch_stack_event(:connection_lock_acquired, state)
 
     # As soon as we acquire the connection lock, we try to start the replication connection
     # first because it requires additional privileges compared to regular "pooled" connections,

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -811,7 +811,7 @@ defmodule Electric.Connection.Manager do
     message = error.message
     connection_mode = set_connection_status_error(message, state)
 
-    extended_message = message <> pg_error_extra_info(Map.get(error.original_error, :postgres))
+    extended_message = message <> pg_error_extra_info(error.original_error)
 
     Logger.warning(
       "Database connection in #{connection_mode} mode failed: #{extended_message}\nRetrying..."
@@ -867,9 +867,7 @@ defmodule Electric.Connection.Manager do
     "regular"
   end
 
-  defp pg_error_extra_info(nil), do: ""
-
-  defp pg_error_extra_info(pg_error) do
+  defp pg_error_extra_info(%Postgrex.Error{postgres: pg_error}) do
     extra_info_items =
       [
         {"PG code:", Map.get(pg_error, :pg_code)},
@@ -884,6 +882,8 @@ defmodule Electric.Connection.Manager do
       ""
     end
   end
+
+  defp pg_error_extra_info(_), do: ""
 
   defp drop_slot_and_restart(
          %DbConnectionError{type: :replication_slot_invalidated} = error,

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -107,14 +107,6 @@ defmodule Electric.Connection.Supervisor do
         restart: :temporary
       )
 
-    with {:ok, pid} <- Supervisor.start_child(name(opts), child_spec) do
-      Electric.StackSupervisor.dispatch_stack_event(
-        opts[:stack_events_registry],
-        stack_id,
-        :ready
-      )
-
-      {:ok, pid}
-    end
+    Supervisor.start_child(name(opts), child_spec)
   end
 end

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -73,6 +73,27 @@ defmodule Electric.DbConnectionError do
   def from_error(
         %Postgrex.Error{
           postgres: %{
+            code: :object_in_use,
+            message: "replication slot " <> _,
+            severity: "ERROR",
+            pg_code: "55006"
+          }
+        } = error
+      ) do
+    # The full error message in this case looks like
+    # "replication slot \"electric_slot_integration\" is active for PID 83",
+    %DbConnectionError{
+      message:
+        "Replication slot already in use by another database connection, possibly external to Electric.",
+      type: :replication_slot_in_use,
+      original_error: error,
+      retry_may_fix?: true
+    }
+  end
+
+  def from_error(
+        %Postgrex.Error{
+          postgres: %{
             code: :insufficient_privilege,
             detail: "Only roles with the REPLICATION attribute may start a WAL sender process."
           }

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -62,8 +62,7 @@ defmodule Electric.Postgres.LockConnection do
       connection_manager: opts.connection_manager,
       lock_name: opts.lock_name,
       lock_acquired: false,
-      backoff: {:backoff.init(1000, 10_000), nil},
-      stack_id: opts.stack_id
+      backoff: {:backoff.init(1000, 10_000), nil}
     }
 
     {:ok, state}

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -121,6 +121,9 @@ defmodule Electric.Postgres.ReplicationClient do
     Electric.ProcessRegistry.name(stack_id, __MODULE__)
   end
 
+  # This is a send() and not a call() to prevent the caller (the Connection.Manager process) from
+  # getting blocked when the replication connection is blocked some replication slot condition
+  # that doesn't let it start streaming immediately.
   def start_streaming(client) do
     send(client, :start_streaming)
   end
@@ -169,18 +172,14 @@ defmodule Electric.Postgres.ReplicationClient do
   @impl true
   def handle_connect(state) do
     %State{state | step: :connected}
-    |> notify_connection_open()
+    |> notify_connection_opened()
     |> ConnectionSetup.start()
   end
 
   @impl true
   def handle_result(result_list_or_error, state) do
     {step, return_val} = ConnectionSetup.process_query_result(result_list_or_error, state)
-
-    if step in [:ready_to_stream, :streaming] do
-      notify_connection_ready_for_streaming(state)
-    end
-
+    if step == :ready_to_stream, do: notify_ready_to_stream(state)
     return_val
   end
 
@@ -203,9 +202,26 @@ defmodule Electric.Postgres.ReplicationClient do
     {:noreply, state}
   end
 
+  # The implementation of Postgrex.ReplicationConnection doesn't give us a convenient way to
+  # check whether the START_REPLICATION_SLOT statement succeeded before switching the
+  # connection into streaming mode. Returning {:query, "START_REPLICATION_SLOT ...", state}
+  # works fine when the query result is an error: it is then passed to the handle_result()
+  # callback. But if streaming starts without issues, a function clause error is encountered
+  # inside Postgrex.ReplicationConnection because it expects the connection to already have
+  # been switched into streaming mode by returning {:stream, "START_REPLICATION_SLOT ...", [], state}.
+  #
+  # Hence this function clause of `handle_data()` that notifies the connection manager about
+  # successful streaming start as soon as it receives the first replication message from
+  # Postgres.
   @impl true
   @spec handle_data(binary(), State.t()) ::
           {:noreply, State.t()} | {:noreply, list(binary()), State.t()}
+  def handle_data(data, %State{step: :start_streaming} = state) do
+    state = %State{state | step: :streaming}
+    notify_streaming_started(state)
+    handle_data(data, state)
+  end
+
   def handle_data(
         <<@repl_msg_x_log_data, _wal_start::64, wal_end::64, _clock::64, rest::binary>>,
         %State{stack_id: stack_id} = state
@@ -350,18 +366,18 @@ defmodule Electric.Postgres.ReplicationClient do
 
   defp update_applied_wal(state, wal) when is_number(wal), do: state
 
-  defp notify_connection_open(%State{connection_manager: connection_manager} = state) do
-    :ok =
-      Electric.Connection.Manager.replication_connection_initializing(connection_manager)
-
+  defp notify_connection_opened(%State{connection_manager: connection_manager} = state) do
+    :ok = Electric.Connection.Manager.replication_client_started(connection_manager)
     state
   end
 
-  defp notify_connection_ready_for_streaming(
-         %State{connection_manager: connection_manager} = state
-       ) do
-    Electric.StatusMonitor.mark_replication_client_ready(state.stack_id, self())
-    :ok = Electric.Connection.Manager.replication_connection_established(connection_manager)
+  defp notify_ready_to_stream(%State{connection_manager: connection_manager} = state) do
+    :ok = Electric.Connection.Manager.replication_client_ready_to_stream(connection_manager)
+    state
+  end
+
+  defp notify_streaming_started(%State{connection_manager: connection_manager} = state) do
+    :ok = Electric.Connection.Manager.replication_client_started_streaming(connection_manager)
     state
   end
 end

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -218,7 +218,7 @@ defmodule Electric.Postgres.ReplicationClient do
           {:noreply, State.t()} | {:noreply, list(binary()), State.t()}
   def handle_data(data, %State{step: :start_streaming} = state) do
     state = %State{state | step: :streaming}
-    notify_streaming_started(state)
+    notify_seen_first_message(state)
     handle_data(data, state)
   end
 
@@ -376,8 +376,10 @@ defmodule Electric.Postgres.ReplicationClient do
     state
   end
 
-  defp notify_streaming_started(%State{connection_manager: connection_manager} = state) do
-    :ok = Electric.Connection.Manager.replication_client_started_streaming(connection_manager)
+  defp notify_seen_first_message(%State{connection_manager: connection_manager} = state) do
+    :ok =
+      Electric.Connection.Manager.replication_client_streamed_first_message(connection_manager)
+
     state
   end
 end

--- a/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
@@ -42,7 +42,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   @spec start_streaming(state) :: callback_return
   def start_streaming(%{step: :ready_to_stream} = state) do
     Logger.debug("ReplicationClient step: start_streaming")
-    query_for_step(:streaming, %{state | step: :streaming})
+    query_for_step(:start_streaming, %{state | step: :start_streaming})
   end
 
   ###
@@ -192,8 +192,6 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
     query =
       "START_REPLICATION SLOT #{Utils.quote_name(state.slot_name)} LOGICAL 0/0 (proto_version '1', publication_names '#{state.publication_name}')"
 
-    Logger.info("Starting replication from postgres")
-
     {:stream, query, [], state}
   end
 
@@ -224,7 +222,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
     do: :set_display_setting
 
   defp next_step(%{step: :set_display_setting, start_streaming?: true}),
-    do: :streaming
+    do: :start_streaming
 
   defp next_step(%{step: :set_display_setting}),
     do: :ready_to_stream
@@ -241,7 +239,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
   defp query_for_step(:create_slot, state), do: create_slot_query(state)
   defp query_for_step(:set_display_setting, state), do: set_display_setting_query(state)
   defp query_for_step(:ready_to_stream, state), do: ready_to_stream(state)
-  defp query_for_step(:streaming, state), do: start_replication_slot_query(state)
+  defp query_for_step(:start_streaming, state), do: start_replication_slot_query(state)
 
   ###
 

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -1,0 +1,128 @@
+defmodule Electric.Connection.ConnectionManagerTest do
+  use ExUnit.Case
+
+  import Support.ComponentSetup
+  import Support.DbSetup
+
+  alias Electric.Connection
+  alias Electric.StatusMonitor
+
+  setup [
+    :with_unique_db,
+    :with_stack_id_from_test,
+    :with_persistent_kv,
+    :with_inspector,
+    :with_slot_name_and_stream_id,
+    :with_in_memory_storage
+  ]
+
+  describe "status monitor" do
+    setup %{stack_id: stack_id} = ctx do
+      stack_events_registry = Electric.stack_events_registry()
+      publication_name = "electric_conn_mgr_test_pub_#{:erlang.phash2(stack_id)}"
+      connection_opts = ctx.db_config
+
+      replication_opts = [
+        stack_id: stack_id,
+        connection_opts: ctx.db_config,
+        slot_name: ctx.slot_name,
+        publication_name: publication_name,
+        try_creating_publication?: true,
+        slot_temporary?: true,
+        transaction_received: nil,
+        relation_received: nil
+      ]
+
+      conn_sup =
+        start_link_supervised!(
+          {Connection.Supervisor,
+           stack_id: stack_id,
+           connection_opts: connection_opts,
+           replication_opts: replication_opts,
+           pool_opts: [name: Electric.Connection.Manager.pool_name(stack_id), pool_size: 2],
+           timeline_opts: [stack_id: stack_id, persistent_kv: ctx.persistent_kv],
+           shape_cache_opts: [
+             stack_id: stack_id,
+             inspector: ctx.inspector,
+             log_producer: Electric.Replication.ShapeLogCollector.name(stack_id),
+             consumer_supervisor: Electric.Shapes.DynamicConsumerSupervisor.name(stack_id),
+             storage: ctx.storage,
+             publication_manager: {Electric.Replication.PublicationManager, stack_id: stack_id},
+             chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
+             registry: Electric.StackSupervisor.registry_name(stack_id)
+           ],
+           tweaks: [],
+           persistent_kv: ctx.persistent_kv,
+           stack_events_registry: stack_events_registry},
+          # The test supervisor under which this one is started has `auto_shutdown` set to
+          # `:never`, so we need to make sure the connection supervisor is not a significant
+          # child, otherwise we'd get the following error:
+          #
+          #     ** (RuntimeError) failed to start child with the spec {Electric.Connection.Supervisor, [...]}.
+          #      Reason: bad child specification, got: {:bad_combination, [auto_shutdown: :never, significant: true]}
+          significant: false
+        )
+
+      Registry.register(stack_events_registry, {:stack_status, stack_id}, nil)
+
+      %{conn_sup: conn_sup, connection_opts: connection_opts, replication_opts: replication_opts}
+    end
+
+    test "reports status=waiting initially", %{stack_id: stack_id} do
+      assert StatusMonitor.status(stack_id) == :waiting
+    end
+
+    test "reports status=starting once the exclusive connection lock is acquired", %{
+      stack_id: stack_id
+    } do
+      assert_receive {:stack_status, _, :waiting_for_connection_lock}
+      assert_receive {:stack_status, _, :connection_lock_acquired}
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+      assert StatusMonitor.status(stack_id) == :starting
+    end
+
+    test "reports status=active when all connection processes are running", %{stack_id: stack_id} do
+      assert_receive {:stack_status, _, :waiting_for_connection_lock}
+      assert_receive {:stack_status, _, :connection_lock_acquired}
+      assert_receive {:stack_status, _, :ready}
+      StatusMonitor.wait_until_active(stack_id, 1000)
+      assert StatusMonitor.status(stack_id) == :active
+    end
+
+    test "resets the status when connection manager goes down", %{stack_id: stack_id} = ctx do
+      assert_receive {:stack_status, _, :waiting_for_connection_lock}
+      assert_receive {:stack_status, _, :connection_lock_acquired}
+      assert_receive {:stack_status, _, :ready}
+      StatusMonitor.wait_until_active(stack_id, 1000)
+      assert StatusMonitor.status(stack_id) == :active
+
+      # Start a lock process so that when ConnectionManager exits it is not able to restore its readiness immediately.
+      lock_opts = [
+        connection_opts: ctx.connection_opts,
+        connection_manager: self(),
+        lock_name: Keyword.fetch!(ctx.replication_opts, :slot_name),
+        stack_id: stack_id
+      ]
+
+      Electric.Postgres.LockConnection.start_link(lock_opts)
+
+      monitor =
+        stack_id
+        |> Electric.Postgres.ReplicationClient.name()
+        |> GenServer.whereis()
+        |> Process.monitor()
+
+      :ok =
+        Supervisor.terminate_child(
+          Connection.Supervisor.name(stack_id: stack_id),
+          Connection.Manager
+        )
+
+      assert_receive {:DOWN, ^monitor, :process, _pid, :shutdown}
+
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      assert StatusMonitor.status(stack_id) == :waiting
+    end
+  end
+end

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -48,7 +48,7 @@ defmodule Electric.FatalErrorTest do
       }
 
       assert %DbConnectionError{
-               message: "User does have the REPLICATION attribute. " <> _,
+               message: "User does not have the REPLICATION attribute. " <> _,
                type: :insufficient_privileges,
                original_error: ^error,
                retry_may_fix?: false

--- a/packages/sync-service/test/electric/postgres/lock_connection_test.exs
+++ b/packages/sync-service/test/electric/postgres/lock_connection_test.exs
@@ -1,12 +1,10 @@
 defmodule Electric.Postgres.LockConnectionTest do
   use ExUnit.Case, async: true
-  use Repatch.ExUnit
   import ExUnit.CaptureLog
   import Support.DbSetup, except: [with_publication: 1]
   import Support.ComponentSetup, only: [with_stack_id_from_test: 1]
 
   alias Electric.Postgres.LockConnection
-  alias Electric.StatusMonitor
 
   @lock_name "test_electric_slot"
 
@@ -18,20 +16,15 @@ defmodule Electric.Postgres.LockConnectionTest do
       db_conn: conn,
       stack_id: stack_id
     } do
-      Repatch.patch(StatusMonitor, :mark_pg_lock_acquired, [mode: :shared], fn _, _ -> :ok end)
-      owner = self()
-
       log =
         capture_log(fn ->
-          assert {:ok, lock_pid} =
+          assert {:ok, _pid} =
                    LockConnection.start_link(
                      connection_opts: config,
                      connection_manager: self(),
                      lock_name: @lock_name,
                      stack_id: stack_id
                    )
-
-          Repatch.allow(owner, lock_pid)
 
           assert_lock_acquired()
         end)
@@ -50,56 +43,42 @@ defmodule Electric.Postgres.LockConnectionTest do
     end
 
     test "should wait if lock is already acquired", %{db_config: config, stack_id: stack_id} do
-      Repatch.patch(StatusMonitor, :mark_pg_lock_acquired, [mode: :shared], fn _, _ -> :ok end)
-      owner = self()
       # grab lock with one connection
-      {pid1, _} =
-        with_log(fn ->
-          assert {:ok, lock_pid} =
-                   LockConnection.start_link(
-                     connection_opts: config,
-                     connection_manager: self(),
-                     lock_name: @lock_name,
-                     stack_id: stack_id
-                   )
+      assert {:ok, pid1} =
+               LockConnection.start_link(
+                 connection_opts: config,
+                 connection_manager: self(),
+                 lock_name: @lock_name,
+                 stack_id: stack_id
+               )
 
-          Repatch.allow(owner, lock_pid)
-
-          assert_lock_acquired()
-          lock_pid
-        end)
+      assert_lock_acquired()
 
       # try to grab the same with another
-      _ =
-        capture_log(fn ->
-          new_stack_id = :"#{stack_id}_new"
+      new_stack_id = :"#{stack_id}_new"
 
-          assert {:ok, pid} =
-                   LockConnection.start_link(
-                     connection_opts: config,
-                     connection_manager: self(),
-                     lock_name: @lock_name,
-                     stack_id: new_stack_id
-                   )
+      assert {:ok, _pid} =
+               LockConnection.start_link(
+                 connection_opts: config,
+                 connection_manager: self(),
+                 lock_name: @lock_name,
+                 stack_id: new_stack_id
+               )
 
-          Repatch.allow(owner, pid)
+      # should fail to grab it
+      refute_lock_acquired()
 
-          # should fail to grab it
-          refute_lock_acquired()
-
-          # should immediately grab it once previous lock is released
-          GenServer.stop(pid1)
-          assert_lock_acquired()
-          pid
-        end)
+      # should immediately grab it once previous lock is released
+      GenServer.stop(pid1)
+      assert_lock_acquired()
     end
   end
 
-  defp assert_lock_acquired() do
-    assert_receive {_, :exclusive_connection_lock_acquired}
+  defp assert_lock_acquired do
+    assert_receive {:"$gen_cast", :exclusive_connection_lock_acquired}
   end
 
-  defp refute_lock_acquired() do
-    refute_receive {_, :exclusive_connection_lock_acquired}, 1000
+  defp refute_lock_acquired do
+    refute_receive {:"$gen_cast", :exclusive_connection_lock_acquired}, 1000
   end
 end

--- a/packages/sync-service/test/electric/postgres/lock_connection_test.exs
+++ b/packages/sync-service/test/electric/postgres/lock_connection_test.exs
@@ -33,7 +33,7 @@ defmodule Electric.Postgres.LockConnectionTest do
 
           Repatch.allow(owner, lock_pid)
 
-          assert_lock_acquired(stack_id, lock_pid)
+          assert_lock_acquired()
         end)
 
       # should have logged lock acquisition process
@@ -65,7 +65,7 @@ defmodule Electric.Postgres.LockConnectionTest do
 
           Repatch.allow(owner, lock_pid)
 
-          assert_lock_acquired(stack_id, lock_pid)
+          assert_lock_acquired()
           lock_pid
         end)
 
@@ -85,23 +85,21 @@ defmodule Electric.Postgres.LockConnectionTest do
           Repatch.allow(owner, pid)
 
           # should fail to grab it
-          refute_lock_acquired(pid)
+          refute_lock_acquired()
 
           # should immediately grab it once previous lock is released
           GenServer.stop(pid1)
-          assert_lock_acquired(new_stack_id, pid)
+          assert_lock_acquired()
           pid
         end)
     end
   end
 
-  defp assert_lock_acquired(stack_id, lock_pid) do
+  defp assert_lock_acquired() do
     assert_receive {_, :exclusive_connection_lock_acquired}
-    assert Repatch.called?(StatusMonitor, :mark_pg_lock_acquired, [stack_id, lock_pid], by: :any)
   end
 
-  defp refute_lock_acquired(pid) do
+  defp refute_lock_acquired() do
     refute_receive {_, :exclusive_connection_lock_acquired}, 1000
-    refute Repatch.called?(StatusMonitor, :mark_pg_lock_acquired, 2, by: pid)
   end
 end

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -38,7 +38,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
     defp process_message({:"$gen_cast", :replication_client_started}), do: nil
     defp process_message({:"$gen_cast", {:pg_info_looked_up, _}}), do: nil
 
-    defp process_message({:"$gen_cast", :replication_client_started_streaming}),
+    defp process_message({:"$gen_cast", :replication_client_streamed_first_message}),
       do: {self(), :streaming_started}
   end
 


### PR DESCRIPTION
The highlight of this PR is the code refactoring inside Connection.Manager module to make the state machine that it implements more explicit and transitions between steps better documented.

Not too long ago we made the initialization of ReplicationClient asynchronous which had been necessitated by the possibility of its startup getting blocked on a pending DB transaction. This PR also makes LockConnection's initialization async for consistency. Both types of processes now return early from their respective `init()` callbacks and then cast messages to the connection manager when reaching a new milestone (connected, lock_acquired, ready_to_stream, streaming_started).

What prompted this refactoring was a new failure state we had discovered. If there's a pending transaction that blocks Electric's initialization for the first time and Electric is then shut down, Postgres will still have a running backend blocked on the `CREATE_REPLICATION_SLOT` statement. When Electric starts again, it will be able to complete the full connection setup (because the replication slot has already been created in Postgres) but will fail when switching ReplicationClient into streaming mode because it's aready actively used by a different OS process (the `walsender` backend in Postgres stuck from Electric's first launch).

Electric's failure to handle this specific scenario resulted in that it got stuck in a reconnection loop without exponential backoff, always trying to reconnect every 2 seconds. Additionally, it resulted in a snowballing of warning logs with each new logger call getting added on every reconnection attempt, due to the absence of any way to keep track of periodic connection status checks and the logs they were emitting.

The PR fixes both the runaway logging and the error handling of this new failure state. It is now simulated in the new integration test defined in `replication-client-self-conflict.lux`.

A new unit test is added that shows the minimum required configuration to start a Connection.Supervisor in isolation. Trimming it down further to only start the Connection.Manager process would require some mocking which I dislike.

As a nice bonus, I discovered a bug in reading the connection options and pool options from application env: the app env wasn't actually being consulted. Probably not a problem in Electric Cloud but it did result in the `ELECTRIC_QUERY_DATABASE_URL` config to be ignored.

For code reivew, I suggest opening the updated code for Connection.Manager and reading it top down. This should be easier than trying to make sense of the diff view.