### PR TITLE
fix: load instance_id from opts for configuring application_telemetry

### DIFF
--- a/.changeset/purple-snakes-poke.md
+++ b/.changeset/purple-snakes-poke.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: load instance_id from opts for configuring application_telemetry

--- a/integration-tests/tests/installation-id-persistence.lux
+++ b/integration-tests/tests/installation-id-persistence.lux
@@ -15,7 +15,7 @@
 [shell electric]
   ??[info] Starting replication from postgres
 
-  !instance_id = Electric.instance_id()
+  !instance_id = Electric.Config.fetch_env!(:instance_id)
   ?"([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})"
   [my instance_id=$1]
 
@@ -47,10 +47,11 @@
   !">> installation_id = #{installation_id}"
   ??>> installation_id = $installation_id
 
-  !Electric.instance_id() == installation_id
+  !instance_id = Electric.Config.fetch_env!(:instance_id)
+  !instance_id == installation_id
   ??false
 
-  !Electric.instance_id() == "$instance_id"
+  !instance_id == "$instance_id"
   ??false
 
 [cleanup]

--- a/packages/sync-service/lib/electric.ex
+++ b/packages/sync-service/lib/electric.ex
@@ -113,14 +113,6 @@ defmodule Electric do
     @connection_opts
   end
 
-  @doc """
-  `instance_id` is used to track a particular server's telemetry metrics.
-  """
-  @spec instance_id() :: binary | no_return
-  def instance_id do
-    Electric.Config.fetch_env!(:instance_id)
-  end
-
   @type relation :: {schema :: String.t(), table :: String.t()}
   @type relation_id :: non_neg_integer()
   @type oid_relation :: {oid :: relation_id(), relation :: relation()}

--- a/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
@@ -84,7 +84,7 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
           arch: to_string(arch),
           cores: processors,
           ram: total_mem,
-          electric_instance_id: Electric.instance_id(),
+          electric_instance_id: Map.fetch!(opts, :instance_id),
           electric_installation_id: Map.get(opts, :installation_id, "electric_default")
         }
       }

--- a/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
@@ -101,7 +101,7 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
           arch: to_string(arch),
           cores: processors,
           ram: total_mem,
-          electric_instance_id: Electric.instance_id(),
+          electric_instance_id: Map.fetch!(opts, :instance_id),
           electric_installation_id: Map.fetch!(opts, :installation_id),
           stack_id: opts.stack_id
         }


### PR DESCRIPTION
`instance_id` is required in telemetry_opts but in application_telemetry supervision tree we load it from Electric (supervision tree?) configuration, which is not started with the top-level application in Cloud.

```elixir
defp telemetry_opts(opts) do
    [
      instance_id: Keyword.fetch!(opts, :instance_id),
     ...
    ]
  end
```
This was causing issues when we enable the call_home_telemetry in Cloud since it emits some metrics for the instance even without any tenants. Hope this is right, but I'm happy to learn if there is a better way of doing it.