### PR TITLE
fix: Ensure shape cleanup after consumer unexpected shutdown

### DIFF
--- a/.changeset/lemon-numbers-travel.md
+++ b/.changeset/lemon-numbers-travel.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix infinite loop situation caused by unexpected termination of shape consumer not resulting in full shape cleanup.

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -74,6 +74,7 @@ defmodule Electric.Connection.Supervisor do
     db_pool_opts = Keyword.fetch!(opts, :pool_opts)
     replication_opts = Keyword.fetch!(opts, :replication_opts)
     inspector = Keyword.fetch!(shape_cache_opts, :inspector)
+    storage = Keyword.fetch!(shape_cache_opts, :storage)
     persistent_kv = Keyword.fetch!(opts, :persistent_kv)
 
     shape_cache_spec = {Electric.ShapeCache, shape_cache_opts}
@@ -94,6 +95,11 @@ defmodule Electric.Connection.Supervisor do
        inspector: inspector,
        shape_cache: {Electric.ShapeCache, stack_id: stack_id}}
 
+    shape_cleaner_spec = {
+      Electric.Shapes.ShapeCleaner,
+      stack_id: stack_id, publication_manager: publication_manager_spec, storage: storage
+    }
+
     child_spec =
       Supervisor.child_spec(
         {
@@ -102,7 +108,8 @@ defmodule Electric.Connection.Supervisor do
           shape_cache: shape_cache_spec,
           publication_manager: publication_manager_spec,
           log_collector: shape_log_collector_spec,
-          schema_reconciler: schema_reconciler_spec
+          schema_reconciler: schema_reconciler_spec,
+          shape_cleaner: shape_cleaner_spec
         },
         restart: :temporary
       )

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -24,6 +24,7 @@ defmodule Electric.Replication.Supervisor do
     # TODO: weird to have these without defaults but `consumer_supervisor` with a default
     shape_cache = Keyword.fetch!(opts, :shape_cache)
     publication_manager = Keyword.fetch!(opts, :publication_manager)
+    shape_cleaner = Keyword.fetch!(opts, :shape_cleaner)
     log_collector = Keyword.fetch!(opts, :log_collector)
     schema_reconciler = Keyword.fetch!(opts, :schema_reconciler)
     stack_id = Keyword.fetch!(opts, :stack_id)
@@ -38,6 +39,7 @@ defmodule Electric.Replication.Supervisor do
     children = [
       consumer_supervisor,
       publication_manager,
+      shape_cleaner,
       log_collector,
       schema_reconciler,
       shape_cache

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -176,7 +176,8 @@ defmodule Electric.ShapeCache do
           :exit, {:noproc, _} ->
             # The fact that we got the shape handle means we know the shape exists, and the process should
             # exist too. We can get here if registry didn't propagate registration across partitions yet, so
-            # we'll just retry.
+            # we'll just retry after waiting for a short time to avoid busy waiting.
+            Process.sleep(50)
             await_snapshot_start(shape_handle, opts)
         end
     end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -381,7 +381,7 @@ defmodule Electric.ShapeCache do
       # clean itself - this is not guaranteed to run in case of an actual exit
       # but provides an additional safeguard
 
-      unsafe_cleanup_shape!(shape_handle, state)
+      Electric.Shapes.ShapeCleaner.ensure_shape_cleanup(shape_handle, state)
     end
 
     :ok
@@ -428,7 +428,7 @@ defmodule Electric.ShapeCache do
           shape_handle
         )
 
-        unsafe_cleanup_shape!(shape_handle, state)
+        Electric.Shapes.ShapeCleaner.ensure_shape_cleanup(shape_handle, state)
 
         Logger.error(
           "shape #{inspect(shape)} (#{inspect(shape_handle)}) failed to start within #{timeout}ms"
@@ -453,7 +453,7 @@ defmodule Electric.ShapeCache do
       )
 
       # clean up corrupted data to avoid persisting bad state
-      unsafe_cleanup_shape!(shape_handle, state)
+      Electric.Shapes.ShapeCleaner.ensure_shape_cleanup(shape_handle, state)
       []
   end
 
@@ -484,16 +484,6 @@ defmodule Electric.ShapeCache do
       {:ok, latest_offset} = Shapes.Consumer.initial_state(consumer)
       {:ok, latest_offset}
     end
-  end
-
-  defp unsafe_cleanup_shape!(shape_handle, state) do
-    # Remove the handle from the shape status
-    state.shape_status.remove_shape(state.shape_status_state, shape_handle)
-
-    # Cleanup the storage for the shape
-    shape_handle
-    |> Electric.ShapeCache.Storage.for_shape(state.storage)
-    |> Electric.ShapeCache.Storage.unsafe_cleanup!()
   end
 
   def get_shape_meta_table(opts),

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -276,7 +276,10 @@ defmodule Electric.ShapeCache do
 
   def handle_info({:DOWN, ref, :process, _pid, reason}, state)
       when not is_expected_consumer_shutdown?(reason) do
-    case state.shape_status.get_shape_for_consumer_ref(state.shape_status_state, ref) do
+    shape_for_ref = state.shape_status.get_shape_for_consumer_ref(state.shape_status_state, ref)
+    state.shape_status.remove_consumer_ref(state.shape_status_state, ref)
+
+    case shape_for_ref do
       nil ->
         # shape already cleaned up by consumer itself
         {:noreply, state}
@@ -294,7 +297,8 @@ defmodule Electric.ShapeCache do
     end
   end
 
-  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    state.shape_status.remove_consumer_ref(state.shape_status_state, ref)
     {:noreply, state}
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -13,14 +13,10 @@ defmodule Electric.ShapeCache.ShapeStatusBehaviour do
   @callback list_shapes(ShapeStatus.t()) :: [{shape_handle(), Shape.t()}]
   @callback get_existing_shape(ShapeStatus.t(), Shape.t() | shape_handle()) ::
               {shape_handle(), LogOffset.t()} | nil
-  @callback get_shape_for_consumer_ref(ShapeStatus.t(), reference()) ::
-              {shape_handle(), Shape.t()} | nil
   @callback add_shape(ShapeStatus.t(), Shape.t()) ::
               {:ok, shape_handle()} | {:error, term()}
   @callback initialise_shape(ShapeStatus.t(), shape_handle(), xmin(), LogOffset.t()) ::
               :ok
-  @callback set_consumer_ref(ShapeStatus.t(), shape_handle(), reference()) :: :ok
-  @callback remove_consumer_ref(ShapeStatus.t(), reference()) :: :ok
   @callback set_snapshot_xmin(ShapeStatus.t(), shape_handle(), xmin()) :: :ok
   @callback set_latest_offset(ShapeStatus.t(), shape_handle(), LogOffset.t()) :: :ok
   @callback mark_snapshot_started(ShapeStatus.t(), shape_handle()) :: :ok
@@ -72,7 +68,6 @@ defmodule Electric.ShapeCache.ShapeStatus do
 
   @shape_meta_data :shape_meta_data
   @shape_hash_lookup :shape_hash_lookup
-  @shape_consumer_ref_lookup :shape_consumer_ref_lookup
   @shape_relation_lookup :shape_relation_lookup
   @shape_meta_shape_pos 2
   @shape_meta_xmin_pos 3
@@ -202,52 +197,12 @@ defmodule Electric.ShapeCache.ShapeStatus do
   end
 
   @impl true
-  def get_shape_for_consumer_ref(%__MODULE__{shape_meta_table: meta_table} = _state, ref) do
-    get_shape_for_consumer_ref(meta_table, ref)
-  end
-
-  def get_shape_for_consumer_ref(meta_table, ref) do
-    case :ets.select(meta_table, [{{{@shape_consumer_ref_lookup, ref}, :"$1"}, [true], [:"$1"]}]) do
-      [] ->
-        nil
-
-      [shape_handle] ->
-        case shape_definition(meta_table, shape_handle) do
-          {:ok, shape} -> {shape_handle, shape}
-          _ -> nil
-        end
-    end
-  end
-
-  @impl true
   def initialise_shape(state, shape_handle, snapshot_xmin, latest_offset) do
     true =
       :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_handle}, [
         {@shape_meta_xmin_pos, snapshot_xmin},
         {@shape_meta_latest_offset_pos, latest_offset}
       ])
-
-    :ok
-  end
-
-  @impl true
-  def set_consumer_ref(state, shape_handle, ref) do
-    true =
-      :ets.insert_new(
-        state.shape_meta_table,
-        {{@shape_consumer_ref_lookup, ref}, shape_handle}
-      )
-
-    :ok
-  end
-
-  @impl true
-  def remove_consumer_ref(state, ref) do
-    true =
-      :ets.delete(
-        state.shape_meta_table,
-        {@shape_consumer_ref_lookup, ref}
-      )
 
     :ok
   end
@@ -340,7 +295,11 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end)
   end
 
-  defp shape_definition(meta_table, shape_handle) do
+  def shape_definition(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
+    shape_definition(table, shape_handle)
+  end
+
+  def shape_definition(meta_table, shape_handle) do
     turn_raise_into_error(fn ->
       :ets.lookup_element(
         meta_table,

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -13,10 +13,13 @@ defmodule Electric.ShapeCache.ShapeStatusBehaviour do
   @callback list_shapes(ShapeStatus.t()) :: [{shape_handle(), Shape.t()}]
   @callback get_existing_shape(ShapeStatus.t(), Shape.t() | shape_handle()) ::
               {shape_handle(), LogOffset.t()} | nil
+  @callback get_shape_for_consumer_ref(ShapeStatus.t(), reference()) ::
+              {shape_handle(), Shape.t()} | nil
   @callback add_shape(ShapeStatus.t(), Shape.t()) ::
               {:ok, shape_handle()} | {:error, term()}
   @callback initialise_shape(ShapeStatus.t(), shape_handle(), xmin(), LogOffset.t()) ::
               :ok
+  @callback set_consumer_ref(ShapeStatus.t(), shape_handle(), reference()) :: :ok
   @callback set_snapshot_xmin(ShapeStatus.t(), shape_handle(), xmin()) :: :ok
   @callback set_latest_offset(ShapeStatus.t(), shape_handle(), LogOffset.t()) :: :ok
   @callback mark_snapshot_started(ShapeStatus.t(), shape_handle()) :: :ok
@@ -41,6 +44,8 @@ defmodule Electric.ShapeCache.ShapeStatus do
   to access the data in the ETS from anywhere, so there's an internal api,
   using the full state and an external api using just the table name.
   """
+  @behaviour Electric.ShapeCache.ShapeStatusBehaviour
+
   alias Electric.Shapes.Shape
   alias Electric.ShapeCache.Storage
   alias Electric.Replication.LogOffset
@@ -66,6 +71,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
 
   @shape_meta_data :shape_meta_data
   @shape_hash_lookup :shape_hash_lookup
+  @shape_consumer_ref_lookup :shape_consumer_ref_lookup
   @shape_relation_lookup :shape_relation_lookup
   @shape_meta_shape_pos 2
   @shape_meta_xmin_pos 3
@@ -73,7 +79,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
   @shape_meta_last_read_pos 5
   @snapshot_started :snapshot_started
 
-  @spec initialise(options()) :: {:ok, t()} | {:error, term()}
+  @impl true
   def initialise(opts) do
     with {:ok, config} <- NimbleOptions.validate(opts, @schema),
          {:ok, meta_table} = Access.fetch(config, :shape_meta_table),
@@ -91,7 +97,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
-  @spec add_shape(t(), Shape.t()) :: {:ok, shape_handle()} | {:error, term()}
+  @impl true
   def add_shape(state, shape) do
     {hash, shape_handle} = Shape.generate_id(shape)
     # For fresh snapshots we're setting "latest" offset to be a highest possible virtual offset,
@@ -115,7 +121,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     {:ok, shape_handle}
   end
 
-  @spec list_shapes(t()) :: [{shape_handle(), Shape.t()}]
+  @impl true
   def list_shapes(state) do
     :ets.select(state.shape_meta_table, [
       {
@@ -136,7 +142,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     |> then(&:ets.select(state.shape_meta_table, &1))
   end
 
-  @spec remove_shape(t(), Shape.t()) :: {:ok, t()} | {:error, term()}
+  @impl true
   def remove_shape(state, shape_handle) do
     try do
       shape =
@@ -150,7 +156,8 @@ defmodule Electric.ShapeCache.ShapeStatus do
         state.shape_meta_table,
         [
           {{{@shape_meta_data, shape_handle}, :_, :_, :_, :_}, [], [true]},
-          {{{@shape_hash_lookup, :_}, shape_handle}, [], [true]}
+          {{{@shape_hash_lookup, :_}, shape_handle}, [], [true]},
+          {{{@shape_consumer_ref_lookup, :_}, shape_handle}, [], [true]}
           | Enum.map(Shape.list_relations(shape), fn {oid, _} ->
               {{{@shape_relation_lookup, oid, shape_handle}, :_}, [], [true]}
             end)
@@ -168,13 +175,11 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
-  @spec get_existing_shape(t(), shape_handle() | Shape.t()) ::
-          nil | {shape_handle(), LogOffset.t()}
+  @impl true
   def get_existing_shape(%__MODULE__{shape_meta_table: table}, shape_or_id) do
     get_existing_shape(table, shape_or_id)
   end
 
-  @spec get_existing_shape(table(), Shape.t()) :: nil | {shape_handle(), LogOffset.t()}
   def get_existing_shape(meta_table, %Shape{} = shape) do
     hash = Shape.hash(shape)
 
@@ -187,7 +192,6 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
-  @spec get_existing_shape(table(), shape_handle()) :: nil | {shape_handle(), LogOffset.t()}
   def get_existing_shape(meta_table, shape_handle) when is_binary(shape_handle) do
     case :ets.lookup(meta_table, {@shape_meta_data, shape_handle}) do
       [] -> nil
@@ -195,22 +199,51 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
-  @spec initialise_shape(t(), shape_handle(), xmin(), LogOffset.t()) :: :ok
+  @impl true
+  def get_shape_for_consumer_ref(%__MODULE__{shape_meta_table: meta_table} = _state, ref) do
+    get_shape_for_consumer_ref(meta_table, ref)
+  end
+
+  def get_shape_for_consumer_ref(meta_table, ref) do
+    case :ets.select(meta_table, [{{{@shape_consumer_ref_lookup, ref}, :"$1"}, [true], [:"$1"]}]) do
+      [] -> nil
+      [shape_handle] -> {shape_handle, shape_definition!(meta_table, shape_handle)}
+    end
+  end
+
+  @impl true
   def initialise_shape(state, shape_handle, snapshot_xmin, latest_offset) do
-    :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_handle}, [
-      {@shape_meta_xmin_pos, snapshot_xmin},
-      {@shape_meta_latest_offset_pos, latest_offset}
-    ])
+    true =
+      :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_handle}, [
+        {@shape_meta_xmin_pos, snapshot_xmin},
+        {@shape_meta_latest_offset_pos, latest_offset}
+      ])
 
     :ok
   end
 
-  def set_snapshot_xmin(state, shape_handle, snapshot_xmin) do
-    :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_handle}, [
-      {@shape_meta_xmin_pos, snapshot_xmin}
-    ])
+  @impl true
+  def set_consumer_ref(state, shape_handle, ref) do
+    true =
+      :ets.insert_new(
+        state.shape_meta_table,
+        {{@shape_consumer_ref_lookup, ref}, shape_handle}
+      )
+
+    :ok
   end
 
+  @impl true
+  def set_snapshot_xmin(state, shape_handle, snapshot_xmin) do
+    true =
+      :ets.update_element(state.shape_meta_table, {@shape_meta_data, shape_handle}, [
+        {@shape_meta_xmin_pos, snapshot_xmin}
+      ])
+
+    :ok
+  end
+
+  @impl true
   def set_latest_offset(
         %__MODULE__{shape_meta_table: table} = _state,
         shape_handle,
@@ -220,9 +253,12 @@ defmodule Electric.ShapeCache.ShapeStatus do
   end
 
   def set_latest_offset(meta_table, shape_handle, latest_offset) do
-    :ets.update_element(meta_table, {@shape_meta_data, shape_handle}, [
-      {@shape_meta_latest_offset_pos, latest_offset}
-    ])
+    true =
+      :ets.update_element(meta_table, {@shape_meta_data, shape_handle}, [
+        {@shape_meta_latest_offset_pos, latest_offset}
+      ])
+
+    :ok
   end
 
   def update_last_read_time_to_now(%__MODULE__{shape_meta_table: meta_table}, shape_handle) do
@@ -285,6 +321,14 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end)
   end
 
+  defp shape_definition!(meta_table, shape_handle) do
+    :ets.lookup_element(
+      meta_table,
+      {@shape_meta_data, shape_handle},
+      @shape_meta_shape_pos
+    )
+  end
+
   def snapshot_xmin(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
     snapshot_xmin(table, shape_handle)
   end
@@ -300,6 +344,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end)
   end
 
+  @impl true
   def snapshot_started?(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
     snapshot_started?(table, shape_handle)
   end
@@ -311,6 +356,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
+  @impl true
   def mark_snapshot_started(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
     :ets.insert(table, {{@snapshot_started, shape_handle}, true})
     :ok

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -17,6 +17,7 @@ defmodule Electric.ShapeCache.ShapeStatusBehaviour do
               {:ok, shape_handle()} | {:error, term()}
   @callback initialise_shape(ShapeStatus.t(), shape_handle(), xmin(), LogOffset.t()) ::
               :ok
+  @callback shape_definition(ShapeStatus.t(), shape_handle()) :: {:ok, Shape.t()} | :error
   @callback set_snapshot_xmin(ShapeStatus.t(), shape_handle(), xmin()) :: :ok
   @callback set_latest_offset(ShapeStatus.t(), shape_handle(), LogOffset.t()) :: :ok
   @callback mark_snapshot_started(ShapeStatus.t(), shape_handle()) :: :ok
@@ -295,6 +296,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end)
   end
 
+  @impl true
   def shape_definition(%__MODULE__{shape_meta_table: table} = _state, shape_handle) do
     shape_definition(table, shape_handle)
   end

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -44,7 +44,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
     end
   end
 
-  def clean_and_stop(%{
+  def stop_and_clean(%{
         stack_id: stack_id,
         shape_handle: shape_handle
       }) do
@@ -53,7 +53,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
 
     case GenServer.whereis(consumer) do
       nil -> Supervisor.stop(name(stack_id, shape_handle))
-      consumer_pid when is_pid(consumer_pid) -> GenServer.call(consumer_pid, :clean_and_stop)
+      consumer_pid when is_pid(consumer_pid) -> GenServer.call(consumer_pid, :stop_and_clean)
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -32,7 +32,7 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
         {:error, "no consumer for shape handle #{inspect(shape_handle)}"}
 
       pid when is_pid(pid) ->
-        ConsumerSupervisor.clean_and_stop(%{
+        ConsumerSupervisor.stop_and_clean(%{
           stack_id: stack_id,
           shape_handle: shape_handle
         })

--- a/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
+++ b/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
@@ -18,6 +18,11 @@ defmodule Electric.Shapes.ShapeCleaner do
             shape_status: [type: :atom, default: Electric.ShapeCache.ShapeStatus]
           )
 
+  defguardp is_consumer_shutdown_with_data_retention?(reason)
+            when reason in [:normal, :killed, :shutdown] or
+                   (is_tuple(reason) and elem(reason, 0) == :shutdown and
+                      elem(reason, 1) != :cleanup)
+
   def name(stack_id) when not is_map(stack_id) and not is_list(stack_id) do
     Electric.ProcessRegistry.name(stack_id, __MODULE__)
   end
@@ -36,9 +41,21 @@ defmodule Electric.Shapes.ShapeCleaner do
     end
   end
 
+  @doc """
+  Monitor a shape to ensure it is cleaned up when it is terminated
+  """
   def monitor_shape(shape_handle, opts \\ []) do
     server = Access.get(opts, :server, name(opts))
     GenServer.call(server, {:monitor_shape, shape_handle})
+  end
+
+  @doc """
+  Ensure that the shape is cleaned up.
+  Does not clean up publication, only runs idempotent cleanups
+  """
+  def ensure_shape_cleanup(shape_handle, opts \\ []) do
+    server = Access.get(opts, :server, name(opts))
+    GenServer.call(server, {:ensure_shape_cleanup, shape_handle})
   end
 
   @impl true
@@ -71,16 +88,24 @@ defmodule Electric.Shapes.ShapeCleaner do
     {:reply, :ok, state}
   end
 
-  defguardp is_expected_consumer_shutdown?(reason)
-            when reason in [:normal, :killed, :shutdown] or
-                   (is_tuple(reason) and elem(reason, 0) == :shutdown and tuple_size(reason) == 2)
+  def handle_call({:ensure_shape_cleanup, shape_handle}, _from, state) do
+    case Electric.Shapes.Consumer.whereis(state.stack_id, shape_handle) do
+      nil ->
+        unsafe_cleanup_shape!(shape_handle, state)
+        {:reply, :ok, state}
+
+      _ ->
+        {:reply,
+         {:error,
+          "Expected shape #{shape_handle} consumer to not be alive before cleaning shape"}, state}
+    end
+  end
 
   @impl true
+
   def handle_info({{:consumer_down, shape_handle}, _ref, :process, _pid, reason}, state)
-      when not is_expected_consumer_shutdown?(reason) do
-    Logger.warning(
-      "Cleaning up shape #{shape_handle} after unexpected consumer exit: #{inspect(reason)}"
-    )
+      when not is_consumer_shutdown_with_data_retention?(reason) do
+    Logger.debug("Cleaning up shape #{shape_handle} after consumer exit: #{inspect(reason)}")
 
     {shape_status, shape_status_state} = state.shape_status
     {publication_manager, publication_manager_opts} = state.publication_manager
@@ -96,7 +121,7 @@ defmodule Electric.Shapes.ShapeCleaner do
   end
 
   def handle_info({{:consumer_down, _shape_handle}, _ref, :process, _pid, _reason}, state) do
-    # ignore regular consumer shutdowns
+    # ignore non-cleanup consumer shutdowns
     {:noreply, state}
   end
 
@@ -113,6 +138,7 @@ defmodule Electric.Shapes.ShapeCleaner do
   defp unsafe_cleanup_shape!(shape_handle, state) do
     # Remove the handle from the shape status
     {shape_status, shape_status_state} = state.shape_status
+
     shape_status.remove_shape(shape_status_state, shape_handle)
 
     # Cleanup the storage for the shape, asynchronously to avoid

--- a/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
+++ b/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
@@ -85,7 +85,7 @@ defmodule Electric.Shapes.ShapeCleaner do
     {shape_status, shape_status_state} = state.shape_status
     {publication_manager, publication_manager_opts} = state.publication_manager
 
-    with %Electric.Shapes.Shape{} = shape <-
+    with {:ok, shape} <-
            shape_status.shape_definition(shape_status_state, shape_handle) do
       # clean up publication and data related to shape
       publication_manager.remove_shape_async(shape, publication_manager_opts)
@@ -96,6 +96,12 @@ defmodule Electric.Shapes.ShapeCleaner do
   end
 
   def handle_info({{:consumer_down, _shape_handle}, _ref, :process, _pid, _reason}, state) do
+    # ignore regular consumer shutdowns
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+    # ignore down messages from task failures
     {:noreply, state}
   end
 

--- a/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
+++ b/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
@@ -1,0 +1,129 @@
+defmodule Electric.Shapes.ShapeCleaner do
+  use GenServer
+
+  alias Electric.ShapeCache.ShapeStatus
+
+  require Logger
+
+  @name_schema_tuple {:tuple, [:atom, :atom, :any]}
+  @genserver_name_schema {:or, [:atom, @name_schema_tuple]}
+  @schema NimbleOptions.new!(
+            name: [
+              type: @genserver_name_schema,
+              required: false
+            ],
+            stack_id: [type: :string, required: true],
+            publication_manager: [type: :mod_arg, required: true],
+            storage: [type: :mod_arg, required: true],
+            shape_status: [type: :atom, default: Electric.ShapeCache.ShapeStatus]
+          )
+
+  def name(stack_id) when not is_map(stack_id) and not is_list(stack_id) do
+    Electric.ProcessRegistry.name(stack_id, __MODULE__)
+  end
+
+  def name(opts) do
+    stack_id = Access.fetch!(opts, :stack_id)
+    name(stack_id)
+  end
+
+  def start_link(opts) do
+    with {:ok, opts} <- NimbleOptions.validate(opts, @schema) do
+      stack_id = Keyword.fetch!(opts, :stack_id)
+      name = Keyword.get(opts, :name, name(stack_id))
+
+      GenServer.start_link(__MODULE__, [name: name] ++ opts, name: name)
+    end
+  end
+
+  def monitor_shape(shape_handle, opts \\ []) do
+    server = Access.get(opts, :server, name(opts))
+    GenServer.call(server, {:monitor_shape, shape_handle})
+  end
+
+  @impl true
+  def init(opts) do
+    opts = Map.new(opts)
+    stack_id = opts.stack_id
+
+    Process.set_label({:shape_cleaner, stack_id})
+    Logger.metadata(stack_id: stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
+
+    {:ok,
+     %{
+       name: opts.name,
+       stack_id: stack_id,
+       publication_manager: opts.publication_manager,
+       storage: opts.storage,
+       shape_status:
+         {opts.shape_status,
+          %ShapeStatus{shape_meta_table: Electric.ShapeCache.get_shape_meta_table(opts)}},
+       ref_to_shape_handle: %{}
+     }}
+  end
+
+  @impl true
+  def handle_call({:monitor_shape, shape_handle}, _from, state) do
+    # monitor the consumer to ensure we clean up killed shapes
+    shape_consumer_pid = Electric.Shapes.Consumer.whereis(state.stack_id, shape_handle)
+    ref = Process.monitor(shape_consumer_pid)
+
+    {:reply, :ok,
+     %{state | ref_to_shape_handle: Map.put(state.ref_to_shape_handle, ref, shape_handle)}}
+  end
+
+  defguardp is_expected_consumer_shutdown?(reason)
+            when reason in [:normal, :killed, :shutdown] or
+                   (is_tuple(reason) and elem(reason, 0) == :shutdown and tuple_size(reason) == 2)
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state)
+      when not is_expected_consumer_shutdown?(reason) do
+    case Map.get(state.ref_to_shape_handle, ref) do
+      nil ->
+        # shape already cleaned up by consumer itself
+        {:noreply, state}
+
+      shape_handle ->
+        Logger.warning(
+          "Cleaning up shape #{shape_handle} after unexpected consumer exit: #{inspect(reason)}"
+        )
+
+        {shape_status, shape_status_state} = state.shape_status
+        {publication_manager, publication_manager_opts} = state.publication_manager
+
+        with %Electric.Shapes.Shape{} = shape <-
+               shape_status.shape_definition(shape_status_state, shape_handle) do
+          # clean up publication and data related to shape
+          publication_manager.remove_shape_async(shape, publication_manager_opts)
+        end
+
+        unsafe_cleanup_shape!(state.ref_to_shape_handle[ref], state)
+        {:noreply, %{state | ref_to_shape_handle: Map.delete(state.ref_to_shape_handle, ref)}}
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    {:noreply, %{state | ref_to_shape_handle: Map.delete(state.ref_to_shape_handle, ref)}}
+  end
+
+  def handle_info({_ref, :ok}, state) do
+    # ignore async task completions
+    {:noreply, state}
+  end
+
+  defp unsafe_cleanup_shape!(shape_handle, state) do
+    # Remove the handle from the shape status
+    {shape_status, shape_status_state} = state.shape_status
+    shape_status.remove_shape(shape_status_state, shape_handle)
+
+    # Cleanup the storage for the shape, asynchronously to avoid
+    # blocking in memory cleanups due to slow IO
+    Task.async(fn ->
+      shape_handle
+      |> Electric.ShapeCache.Storage.for_shape(state.storage)
+      |> Electric.ShapeCache.Storage.unsafe_cleanup!()
+    end)
+  end
+end

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -170,6 +170,13 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
 
     assert {^shape_handle, ^shape} = ShapeStatus.get_shape_for_consumer_ref(table, ref)
 
+    # remove the consumer ref, should no longer match to the shape
+    ShapeStatus.remove_consumer_ref(state, ref)
+    refute ShapeStatus.get_shape_for_consumer_ref(table, ref)
+
+    # set the consumer ref again, but if shape is gone nothing is returned
+    ShapeStatus.set_consumer_ref(state, shape_handle, ref)
+
     assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_handle)
     refute ShapeStatus.get_shape_for_consumer_ref(table, ref)
   end

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -157,30 +157,6 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     refute ShapeStatus.get_existing_shape(table, shape_handle)
   end
 
-  test "get_shape_for_consumer_ref/2 public api", ctx do
-    shape = shape!()
-    table = table_name()
-
-    {:ok, state, [shape_handle]} = new_state(ctx, table: table, shapes: [shape])
-
-    ref = make_ref()
-    ShapeStatus.set_consumer_ref(state, shape_handle, ref)
-
-    refute ShapeStatus.get_shape_for_consumer_ref(table, make_ref())
-
-    assert {^shape_handle, ^shape} = ShapeStatus.get_shape_for_consumer_ref(table, ref)
-
-    # remove the consumer ref, should no longer match to the shape
-    ShapeStatus.remove_consumer_ref(state, ref)
-    refute ShapeStatus.get_shape_for_consumer_ref(table, ref)
-
-    # set the consumer ref again, but if shape is gone nothing is returned
-    ShapeStatus.set_consumer_ref(state, shape_handle, ref)
-
-    assert {:ok, ^shape} = ShapeStatus.remove_shape(state, shape_handle)
-    refute ShapeStatus.get_shape_for_consumer_ref(table, ref)
-  end
-
   test "latest_offset", ctx do
     {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape!()])
     assert :error = ShapeStatus.latest_offset(state, "sdfsodf")

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -277,6 +277,9 @@ defmodule Electric.ShapeCacheTest do
 
       assert_receive {:DOWN, ^consumer_ref, :process, _pid, :some_reason}
 
+      # give it little time to clean up
+      Process.sleep(10)
+
       # should have cleaned up the shape
       meta_table = Keyword.fetch!(opts, :shape_meta_table)
       assert nil == ShapeStatus.get_existing_shape(meta_table, shape_handle)
@@ -1093,6 +1096,7 @@ defmodule Electric.ShapeCacheTest do
     defmodule SlowPublicationManager do
       def refresh_publication(_), do: :ok
       def remove_shape(_, _), do: :ok
+      def remove_shape_async(_, _), do: :ok
       def recover_shape(_, _), do: Process.sleep(100)
       def add_shape(_, _), do: :ok
     end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1176,6 +1176,8 @@ defmodule Electric.ShapeCacheTest do
         Shapes.DynamicConsumerSupervisor.stop_all_consumers(ctx.consumer_supervisor)
       end
 
+      GenServer.stop(Shapes.ShapeCleaner.name(ctx.stack_id))
+
       for {pid, ref} <- consumers do
         assert_receive {:DOWN, ^ref, :process, ^pid, _}
       end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -885,6 +885,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       # Stop the consumer and the shape cache server to simulate a restart
       Supervisor.stop(ctx.consumer_supervisor)
+      GenServer.stop(Electric.Shapes.ShapeCleaner.name(ctx.stack_id))
       GenServer.stop(shape_cache_opts[:server])
 
       # Restart the shape cache and the consumers

--- a/packages/sync-service/test/electric/shapes/partitioned_tables_test.exs
+++ b/packages/sync-service/test/electric/shapes/partitioned_tables_test.exs
@@ -195,6 +195,9 @@ defmodule Electric.Shapes.PartitionedTablesTest do
 
     assert_receive {^ref, :shape_rotation}, 5000
 
+    # wait for a bit for cleanup to occur
+    Process.sleep(50)
+
     assert [_] = active_shapes = ShapeCache.list_shapes(stack_id: ctx.stack_id)
 
     assert MapSet.equal?(
@@ -248,6 +251,9 @@ defmodule Electric.Shapes.PartitionedTablesTest do
 
     assert_receive {^ref, :shape_rotation}, 5000
     assert_receive {^partition_ref, :shape_rotation}, 5000
+
+    # wait for a bit for cleanup to occur
+    Process.sleep(50)
 
     assert [] = ShapeCache.list_shapes(stack_id: ctx.stack_id)
 

--- a/packages/sync-service/test/electric/shapes/shape_cleaner_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_cleaner_test.exs
@@ -1,0 +1,90 @@
+defmodule Electric.Shapes.ShapeCleanerTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Shapes.ShapeCleaner
+
+  import Support.ComponentSetup
+  alias Support.Mock
+
+  import Mox
+
+  setup :verify_on_exit!
+  setup :with_stack_id_from_test
+
+  describe "monitors and cleans shapes" do
+    setup ctx do
+      {:ok, cleaner} =
+        start_supervised(
+          {ShapeCleaner,
+           stack_id: ctx.stack_id,
+           publication_manager: {Mock.PublicationManager, []},
+           storage: {Mock.Storage, []},
+           shape_status: Mock.ShapeStatus}
+        )
+
+      {:ok, cleaner: cleaner, shape_handle: "test_shape_#{ctx.stack_id}"}
+    end
+
+    test "handles cleanup of unexpected consumer shutdown",
+         %{cleaner: cleaner, shape_handle: shape_handle} = ctx do
+      Mock.ShapeStatus
+      |> stub(:shape_definition, fn _, _ -> {:ok, %{}} end)
+      |> expect(:remove_shape, 1, fn _, _ -> :ok end)
+      |> allow(self(), cleaner)
+
+      Mock.PublicationManager
+      |> expect(:remove_shape_async, 1, fn _, _ -> :ok end)
+      |> allow(self(), cleaner)
+
+      {:ok, pid} = start_mock_consumer(ctx)
+
+      ShapeCleaner.monitor_shape(shape_handle, server: cleaner, stack_id: ctx.stack_id)
+
+      # ensure consumer is killed
+      on_exit(fn -> Process.alive?(pid) && Process.exit(pid, :kill) end)
+      Process.unlink(pid)
+      Process.exit(pid, :bad_reason)
+
+      # give some time to process messages
+      Process.sleep(10)
+    end
+
+    test "ignore expected consumer shutdowns",
+         %{cleaner: cleaner, shape_handle: shape_handle} = ctx do
+      Mock.ShapeStatus
+      |> stub(:shape_definition, fn _, _ -> {:ok, %{}} end)
+      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
+      |> allow(self(), cleaner)
+
+      Mock.PublicationManager
+      |> expect(:remove_shape_async, 0, fn _, _ -> :ok end)
+      |> allow(self(), cleaner)
+
+      {:ok, pid} = start_mock_consumer(ctx)
+
+      ShapeCleaner.monitor_shape(shape_handle, server: cleaner, stack_id: ctx.stack_id)
+
+      # ensure consumer is killed
+      on_exit(fn -> Process.alive?(pid) && Process.exit(pid, :kill) end)
+      Process.unlink(pid)
+      Process.exit(pid, :normal)
+
+      # give some time to process messages
+      Process.sleep(10)
+    end
+  end
+
+  defp start_mock_consumer(ctx) do
+    GenServer.start_link(__MODULE__.MockConsumer, [],
+      name: Electric.Shapes.Consumer.name(ctx.stack_id, ctx.shape_handle)
+    )
+  end
+
+  defmodule __MODULE__.MockConsumer do
+    use GenServer
+
+    def init(_opts) do
+      {:ok, %{}}
+    end
+  end
+end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -128,8 +128,8 @@ defmodule Support.ComponentSetup do
     {:ok, _pid} =
       Electric.Shapes.ShapeCleaner.start_link(
         stack_id: ctx.stack_id,
-        publication_manager: ctx.publication_manager,
-        storage: ctx.storage
+        publication_manager: start_opts[:publication_manager],
+        storage: start_opts[:storage]
       )
 
     {:ok, _pid} = ShapeCache.start_link(start_opts)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -125,6 +125,13 @@ defmodule Support.ComponentSetup do
         stack_id: ctx.stack_id
       )
 
+    {:ok, _pid} =
+      Electric.Shapes.ShapeCleaner.start_link(
+        stack_id: ctx.stack_id,
+        publication_manager: ctx.publication_manager,
+        storage: ctx.storage
+      )
+
     {:ok, _pid} = ShapeCache.start_link(start_opts)
 
     shape_meta_table = ShapeCache.get_shape_meta_table(stack_id: ctx.stack_id)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -15,6 +15,7 @@ defmodule Support.ComponentSetup do
     def add_shape(_shape, _opts), do: :ok
     def recover_shape(_shape, _opts), do: :ok
     def remove_shape(_shape, _opts), do: :ok
+    def remove_shape_async(_shape, _opts), do: :ok
     def refresh_publication(_opts), do: :ok
   end
 


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2597

The infinite loop would occur in the case where a consumer would not longer exist but the `ShapeStatus` table still had an entry for the corresponding shape.

After going through the code and consulting with @icehaunter as well, the issue was that there are cases where the internal cleanup run by the consumer itself in the `terminate` callback would not always occur - the only surefire way to go about this is to monitor the consumers and trigger cleanups when unexpected shutdowns occur.

I initially added two failing tests covering this situation, which do indeed get fixed by introducing this monitoring + cleanup of shape consumers in the `ShapeCache`.

Technically we should be able to get rid of the cleanups in the `terminate` callback in the consumer now, but I figured that whenever the consumer can cleanup after itself it's less load on the shape cache process, and since the shape cache will only attempt a cleanup if the ETS entry is still present (i.e. the consumer failed to clean itself up), I decided to keep both in. Also for the sake of fewer changes and simpler review, I can create a new PR to clean up the unnecessary code and fix tests appropriately.

I introduced an asynchronous publication cleanup call as well, as there is no reason to block the shape cache process  which is a central one waiting for the publication update.

I also cleaned up a few things to make use of the behaviours we've defined and fixed some dialyzer/type issues in the process.

Finally, I added a 50ms wait when retrying `await_snapshot_start` - we should no longer get into this infinite loop situation since this fix is trying to address the root cause, but in case there's more edge cases we at least avoid busy waiting and taking up too much CPU time. Not adding finite retries yet however as we should never need them - let the request time out.