### PR TITLE
fix: Add retries on shape file cleanup operation to prevent `EEXIST` race

### DIFF
--- a/.changeset/metal-trains-yell.md
+++ b/.changeset/metal-trains-yell.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Mitigate `EEXIST` error on `rm_rf` due to suspected filesystem race with retries.

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -709,7 +709,6 @@ defmodule Electric.ShapeCache.FileStorage do
       # due to some FS race the deletion fails with EEXIST. Very hard to test
       # and prevent so we mitigate it with arbitrary retries.
       {:error, :eexist, _} when attempts_left > 0 ->
-        Process.sleep(1)
         unsafe_cleanup_with_retries!(opts, attempts_left - 1)
 
       {:error, reason, path} ->

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -712,8 +712,11 @@ defmodule Electric.ShapeCache.FileStorage do
         Process.sleep(1)
         unsafe_cleanup_with_retries!(opts, attempts_left - 1)
 
-      err ->
-        raise "Failed to clean up shape data: #{inspect(err)}"
+      {:error, reason, path} ->
+        raise File.Error,
+          reason: reason,
+          path: path,
+          action: "remove files and directories recursively from"
     end
   end
 


### PR DESCRIPTION
We observed the `unsafe_cleanup!` call on shape files failing with an `:eexist` reason on the `File.rm_rf!` calls, which didn't make much sense.

Looking at the Elixir source we suspect that the issue is `rm_dir` failing due to some race occurring:
https://github.com/elixir-lang/elixir/blob/e35ffc5a903bff3b595e323eb1ac12c4ecd515ad/lib/elixir/lib/file.ex#L1308-L1312

Here's a discussion with Gemini about this as well https://gemini.google.com/share/d36919a2b507

Potentially the directory is assumed to be empty after files have been deleted but something causes it to not actually be fully empty, especially on weirder filesystems like AWS' EFS which is networkd and distributed.

This PR suggests adding some arbitrary retries with small waits in an attempt to mitigate this issue - I'm open to suggestions about different wait times (if any, potentially we just retry and since they are syscalls they already will take some time) and retry attempts.