### PR TITLE
fix: Only cleanup shapes via `ShapeCleaner`

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -381,7 +381,7 @@ defmodule Electric.ShapeCache do
       # clean itself - this is not guaranteed to run in case of an actual exit
       # but provides an additional safeguard
 
-      unsafe_cleanup_shape!(shape_handle, state)
+      Electric.Shapes.ShapeCleaner.ensure_shape_cleanup(shape_handle, state)
     end
 
     :ok
@@ -428,7 +428,7 @@ defmodule Electric.ShapeCache do
           shape_handle
         )
 
-        unsafe_cleanup_shape!(shape_handle, state)
+        Electric.Shapes.ShapeCleaner.ensure_shape_cleanup(shape_handle, state)
 
         Logger.error(
           "shape #{inspect(shape)} (#{inspect(shape_handle)}) failed to start within #{timeout}ms"
@@ -453,7 +453,7 @@ defmodule Electric.ShapeCache do
       )
 
       # clean up corrupted data to avoid persisting bad state
-      unsafe_cleanup_shape!(shape_handle, state)
+      Electric.Shapes.ShapeCleaner.ensure_shape_cleanup(shape_handle, state)
       []
   end
 
@@ -484,16 +484,6 @@ defmodule Electric.ShapeCache do
       {:ok, latest_offset} = Shapes.Consumer.initial_state(consumer)
       {:ok, latest_offset}
     end
-  end
-
-  defp unsafe_cleanup_shape!(shape_handle, state) do
-    # Remove the handle from the shape status
-    state.shape_status.remove_shape(state.shape_status_state, shape_handle)
-
-    # Cleanup the storage for the shape
-    shape_handle
-    |> Electric.ShapeCache.Storage.for_shape(state.storage)
-    |> Electric.ShapeCache.Storage.unsafe_cleanup!()
   end
 
   def get_shape_meta_table(opts),

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -120,16 +120,13 @@ defmodule Electric.Shapes.Consumer do
     {:reply, ref, [], %{state | monitors: [{pid, ref} | monitors]}}
   end
 
-  def handle_call(:clean_and_stop, _from, state) do
+  def handle_call(:stop, _from, state) do
     # Waiter will receive this response if the snapshot wasn't done yet, but
-    # given that this is definitely a cleanup call, a 409 is appropriate
+    # given that this is definitely a termination call, a 409 is appropriate
     # as old shape handle is no longer valid
     state =
       reply_to_snapshot_waiters(state, {:error, Api.Error.must_refetch()})
 
-    # TODO: ensure cleanup occurs after snapshot is done/failed/interrupted to avoid
-    # any race conditions and leftover data
-    cleanup(state)
     {:stop, :normal, :ok, state}
   end
 
@@ -199,7 +196,6 @@ defmodule Electric.Shapes.Consumer do
       end
 
     state = reply_to_snapshot_waiters(state, {:error, error})
-    cleanup(state)
     {:stop, :normal, state}
   end
 
@@ -211,22 +207,8 @@ defmodule Electric.Shapes.Consumer do
 
   def terminate(reason, state) do
     Logger.debug("Shapes.Consumer terminating with reason: #{inspect(reason)}")
-
-    state =
-      reply_to_snapshot_waiters(state, {:error, "Shape terminated before snapshot was ready"})
-
-    if is_error?(reason) do
-      cleanup(state)
-    end
-
-    state
+    reply_to_snapshot_waiters(state, {:error, "Shape terminated before snapshot was ready"})
   end
-
-  defp is_error?(:normal), do: false
-  defp is_error?(:killed), do: false
-  defp is_error?(:shutdown), do: false
-  defp is_error?({:shutdown, _}), do: false
-  defp is_error?(_), do: true
 
   # `Shapes.Dispatcher` only works with single-events, so we can safely assert
   # that here
@@ -252,7 +234,6 @@ defmodule Electric.Shapes.Consumer do
       state
       |> reply_to_snapshot_waiters({:error, "Shape relation changed before snapshot was ready"})
       |> notify_shape_rotation()
-      |> cleanup()
 
     {:stop, :normal, state}
   end
@@ -376,7 +357,6 @@ defmodule Electric.Shapes.Consumer do
         )
 
         state
-        |> cleanup()
         |> notify_shape_rotation()
 
         {:halt, {:truncate, notify(txn, %{state | log_state: @initial_log_state})}}
@@ -486,19 +466,6 @@ defmodule Electric.Shapes.Consumer do
     pg_snapshot = Map.put(state.pg_snapshot, :filter_txns?, false)
     ShapeCache.Storage.set_pg_snapshot(pg_snapshot, state.storage)
     %{state | pg_snapshot: pg_snapshot}
-  end
-
-  defp cleanup(state) do
-    %{
-      shape_status: {shape_status, shape_status_state},
-      publication_manager: {publication_manager, publication_manager_opts}
-    } = state
-
-    shape_status.remove_shape(shape_status_state, state.shape_handle)
-    publication_manager.remove_shape(state.shape, publication_manager_opts)
-    ShapeCache.Storage.cleanup!(state.storage)
-
-    state
   end
 
   defp reply_to_snapshot_waiters(%{awaiting_snapshot_start: []} = state, _reply) do

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -44,7 +44,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
     end
   end
 
-  def stop(%{
+  def stop_and_clean(%{
         stack_id: stack_id,
         shape_handle: shape_handle
       }) do
@@ -53,7 +53,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
 
     case GenServer.whereis(consumer) do
       nil -> Supervisor.stop(name(stack_id, shape_handle))
-      consumer_pid when is_pid(consumer_pid) -> GenServer.call(consumer_pid, :stop)
+      consumer_pid when is_pid(consumer_pid) -> GenServer.call(consumer_pid, :stop_and_clean)
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -44,7 +44,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
     end
   end
 
-  def clean_and_stop(%{
+  def stop(%{
         stack_id: stack_id,
         shape_handle: shape_handle
       }) do
@@ -53,7 +53,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
 
     case GenServer.whereis(consumer) do
       nil -> Supervisor.stop(name(stack_id, shape_handle))
-      consumer_pid when is_pid(consumer_pid) -> GenServer.call(consumer_pid, :clean_and_stop)
+      consumer_pid when is_pid(consumer_pid) -> GenServer.call(consumer_pid, :stop)
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -32,7 +32,7 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
         {:error, "no consumer for shape handle #{inspect(shape_handle)}"}
 
       pid when is_pid(pid) ->
-        ConsumerSupervisor.stop(%{
+        ConsumerSupervisor.stop_and_clean(%{
           stack_id: stack_id,
           shape_handle: shape_handle
         })

--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -32,7 +32,7 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
         {:error, "no consumer for shape handle #{inspect(shape_handle)}"}
 
       pid when is_pid(pid) ->
-        ConsumerSupervisor.clean_and_stop(%{
+        ConsumerSupervisor.stop(%{
           stack_id: stack_id,
           shape_handle: shape_handle
         })

--- a/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
+++ b/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
@@ -71,10 +71,6 @@ defmodule Electric.Shapes.ShapeCleaner do
     {:reply, :ok, state}
   end
 
-  defguardp is_expected_consumer_shutdown?(reason)
-            when reason in [:normal, :killed, :shutdown] or
-                   (is_tuple(reason) and elem(reason, 0) == :shutdown and tuple_size(reason) == 2)
-
   @impl true
   def handle_info({{:consumer_down, shape_handle}, _ref, :process, _pid, reason}, state)
       when not is_expected_consumer_shutdown?(reason) do
@@ -113,6 +109,7 @@ defmodule Electric.Shapes.ShapeCleaner do
   defp unsafe_cleanup_shape!(shape_handle, state) do
     # Remove the handle from the shape status
     {shape_status, shape_status_state} = state.shape_status
+
     shape_status.remove_shape(shape_status_state, shape_handle)
 
     # Cleanup the storage for the shape, asynchronously to avoid

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1085,6 +1085,9 @@ defmodule Electric.ShapeCacheTest do
 
       Process.flag(:trap_exit, false)
 
+      # Give some time for cleanups to take place
+      Process.sleep(50)
+
       # Next restart should not recover shape
       restart_shape_cache(context)
       {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -950,7 +950,6 @@ defmodule Electric.ShapeCacheTest do
 
       assert_receive {:DOWN, ^ref, :process, _pid, _reason}
 
-      assert_receive {Support.TestStorage, :cleanup!, ^shape_handle}
       assert_receive {Support.TestStorage, :unsafe_cleanup!, ^shape_handle}
     end
   end
@@ -1068,10 +1067,10 @@ defmodule Electric.ShapeCacheTest do
       :started = ShapeCache.await_snapshot_start(shape_handle1, opts)
 
       Mock.PublicationManager
-      |> stub(:remove_shape, fn _, _ -> :ok end)
+      |> stub(:remove_shape_async, fn _, _ -> :ok end)
       |> expect(:recover_shape, 1, fn _, _ -> :ok end)
       |> expect(:refresh_publication, 1, fn _ -> raise "failed recovery" end)
-      |> allow(self(), fn -> Shapes.Consumer.whereis(context[:stack_id], shape_handle1) end)
+      |> allow(self(), fn -> GenServer.whereis(Shapes.ShapeCleaner.name(context[:stack_id])) end)
       |> allow(self(), fn -> Process.whereis(opts[:server]) end)
 
       # Should fail to start shape cache and clean up shapes
@@ -1134,7 +1133,15 @@ defmodule Electric.ShapeCacheTest do
       assert {:ok, found} = Electric.ShapeCache.Storage.get_all_stored_shapes(ctx.storage)
       assert map_size(found) == 2
 
-      restart_shape_cache(ctx, purge_all_shapes?: true)
+      restart_shape_cache(ctx,
+        purge_all_shapes?: true,
+        storage: Support.TestStorage.wrap(ctx.storage, %{})
+      )
+
+      # give some time to clean up shape
+      assert_receive {Support.TestStorage, :unsafe_cleanup!, ^shape_handle1}
+      assert_receive {Support.TestStorage, :unsafe_cleanup!, ^shape_handle2}
+      Process.sleep(50)
 
       assert {:ok, found} = Electric.ShapeCache.Storage.get_all_stored_shapes(ctx.storage)
       assert map_size(found) == 0

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -350,7 +350,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       for {ref, pid} <- monitors do
         assert_receive {:DOWN, ^ref, :process, ^pid, reason}
-                       when reason in [:shutdown, {:shutdown, :truncate}]
+                       when reason in [:shutdown, {:shutdown, :cleanup}]
       end
     end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -323,16 +323,6 @@ defmodule Electric.Shapes.ConsumerTest do
       lsn = Lsn.from_string("0/10")
       last_log_offset = LogOffset.new(lsn, 0)
 
-      Mock.ShapeStatus
-      |> expect(:remove_shape, 1, fn _, @shape_handle1 -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-
-      shape1 = ctx.shapes[@shape_handle1]
-
-      Mock.PublicationManager
-      |> expect(:remove_shape, 1, fn ^shape1, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-
       txn =
         %Transaction{xid: xid, lsn: lsn, last_log_offset: last_log_offset}
         |> Transaction.prepend_change(%Changes.TruncatedRelation{
@@ -342,9 +332,6 @@ defmodule Electric.Shapes.ConsumerTest do
       assert_consumer_shutdown(ctx.stack_id, @shape_handle1, fn ->
         assert :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
       end)
-
-      assert_receive {Support.TestStorage, :cleanup!, @shape_handle1}
-      refute_receive {Support.TestStorage, :cleanup!, @shape_handle2}
     end
 
     defp assert_consumer_shutdown(stack_id, shape_handle, fun) do
@@ -379,22 +366,6 @@ defmodule Electric.Shapes.ConsumerTest do
       lsn = Lsn.from_string("0/10")
       last_log_offset = LogOffset.new(lsn, 0)
 
-      Mock.ShapeStatus
-      |> expect(:remove_shape, fn _, @shape_handle1 -> :ok end)
-      |> allow(
-        self(),
-        Shapes.Consumer.whereis(ctx.stack_id, @shape_handle1)
-      )
-
-      shape = ctx.shapes[@shape_handle1]
-
-      Mock.PublicationManager
-      |> expect(:remove_shape, 1, fn ^shape, _ -> :ok end)
-      |> allow(
-        self(),
-        Shapes.Consumer.whereis(ctx.stack_id, @shape_handle1)
-      )
-
       txn =
         %Transaction{
           xid: xid,
@@ -411,8 +382,6 @@ defmodule Electric.Shapes.ConsumerTest do
       end)
 
       refute_receive {Support.TestStorage, :append_to_log!, @shape_handle1, _}
-      assert_receive {Support.TestStorage, :cleanup!, @shape_handle1}
-      refute_receive {Support.TestStorage, :cleanup!, @shape_handle2}
     end
 
     test "notifies listeners of new changes", ctx do
@@ -455,12 +424,6 @@ defmodule Electric.Shapes.ConsumerTest do
       ref2 =
         Process.monitor(Consumer.whereis(ctx.stack_id, @shape_handle2))
 
-      Mock.ShapeStatus
-      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.producer)
 
       refute_receive {:DOWN, ^ref1, :process, _, _}
@@ -488,18 +451,6 @@ defmodule Electric.Shapes.ConsumerTest do
       |> expect(:clean, 1, fn _, _ -> true end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
       |> expect(:clean, 0, fn _, _ -> true end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
-      Mock.ShapeStatus
-      |> expect(:remove_shape, 1, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
-      Mock.PublicationManager
-      |> expect(:remove_shape, 1, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.producer)
@@ -534,21 +485,6 @@ defmodule Electric.Shapes.ConsumerTest do
       |> expect(:clean, 0, fn _, _ -> true end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
 
-      Mock.ShapeStatus
-      |> expect(:remove_shape, 1, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
-      shape1 = ctx.shapes[@shape_handle1]
-      shape2 = ctx.shapes[@shape_handle2]
-
-      Mock.PublicationManager
-      |> expect(:remove_shape, 1, fn ^shape1, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn ^shape2, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
       assert :ok = ShapeLogCollector.handle_relation_msg(rel_changed, ctx.producer)
 
       assert_receive {:DOWN, ^ref1, :process, _, :normal}
@@ -580,23 +516,13 @@ defmodule Electric.Shapes.ConsumerTest do
       |> expect(:clean, 1, fn _, _ -> true end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
 
-      Mock.ShapeStatus
-      |> expect(:remove_shape, 1, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-
-      shape1 = ctx.shapes[@shape_handle1]
-
-      Mock.PublicationManager
-      |> expect(:remove_shape, 1, fn ^shape1, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-
       assert :ok = ShapeLogCollector.handle_relation_msg(rel_changed, ctx.producer)
 
       assert_receive {:DOWN, ^ref1, :process, _, :normal}
       assert_receive {^live_ref, :shape_rotation}
     end
 
-    test "unexpected error while handling events stops affected consumer and cleans affected shape",
+    test "unexpected error while handling events stops affected consumer",
          ctx do
       Mock.ShapeStatus
       |> expect(:set_latest_offset, fn _, @shape_handle1, _ ->
@@ -625,80 +551,23 @@ defmodule Electric.Shapes.ConsumerTest do
       ref2 =
         Process.monitor(Consumer.whereis(ctx.stack_id, @shape_handle2))
 
-      Mock.ShapeStatus
-      |> expect(:remove_shape, 1, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
-      shape1 = ctx.shapes[@shape_handle1]
-      shape2 = ctx.shapes[@shape_handle2]
-
-      Mock.PublicationManager
-      |> expect(:remove_shape, 1, fn ^shape1, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn ^shape2, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
       :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
-
-      assert_receive {Support.TestStorage, :cleanup!, @shape_handle1}
-      refute_receive {Support.TestStorage, :cleanup!, @shape_handle2}
 
       assert_receive {:DOWN, ^ref1, :process, _, _}
       refute_receive {:DOWN, ^ref2, :process, _, _}
     end
 
-    test "consumer crashing stops affected consumer and cleans affected shape", ctx do
+    test "consumer crashing stops affected consumer", ctx do
       ref1 =
         Process.monitor(Consumer.whereis(ctx.stack_id, @shape_handle1))
 
       ref2 =
         Process.monitor(Consumer.whereis(ctx.stack_id, @shape_handle2))
 
-      Mock.ShapeStatus
-      |> expect(:remove_shape, 1, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
-      shape1 = ctx.shapes[@shape_handle1]
-      shape2 = ctx.shapes[@shape_handle2]
-
-      Mock.PublicationManager
-      |> expect(:remove_shape, 1, fn ^shape1, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-      |> expect(:remove_shape, 0, fn ^shape2, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
-
       GenServer.cast(Consumer.whereis(ctx.stack_id, @shape_handle1), :unexpected_cast)
-
-      assert_receive {Support.TestStorage, :cleanup!, @shape_handle1}
-      refute_receive {Support.TestStorage, :cleanup!, @shape_handle2}
 
       assert_receive {:DOWN, ^ref1, :process, _, _}
       refute_receive {:DOWN, ^ref2, :process, _, _}
-    end
-
-    test "consumer exiting normally does not clean up the shape", ctx do
-      ref =
-        Process.monitor(Consumer.whereis(ctx.stack_id, @shape_handle1))
-
-      Mock.ShapeStatus
-      |> expect(:remove_shape, 0, fn _, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-
-      shape1 = ctx.shapes[@shape_handle1]
-
-      Mock.PublicationManager
-      |> expect(:remove_shape, 0, fn ^shape1, _ -> :ok end)
-      |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
-
-      GenServer.stop(Consumer.whereis(ctx.stack_id, @shape_handle1))
-
-      refute_receive {Support.TestStorage, :cleanup!, @shape_handle1}
-
-      assert_receive {:DOWN, ^ref, :process, _, _}
     end
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -455,7 +455,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.producer)
 
-      assert_receive {:DOWN, ^ref1, :process, _, :normal}
+      assert_receive {:DOWN, ^ref1, :process, _, {:shutdown, :cleanup}}
       refute_receive {:DOWN, ^ref2, :process, _, _}
     end
 
@@ -487,7 +487,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel_changed, ctx.producer)
 
-      assert_receive {:DOWN, ^ref1, :process, _, :normal}
+      assert_receive {:DOWN, ^ref1, :process, _, {:shutdown, :cleanup}}
       refute_receive {:DOWN, ^ref2, :process, _, _}
     end
 
@@ -518,7 +518,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel_changed, ctx.producer)
 
-      assert_receive {:DOWN, ^ref1, :process, _, :normal}
+      assert_receive {:DOWN, ^ref1, :process, _, {:shutdown, :cleanup}}
       assert_receive {^live_ref, :shape_rotation}
     end
 

--- a/packages/sync-service/test/electric/shapes/partitioned_tables_test.exs
+++ b/packages/sync-service/test/electric/shapes/partitioned_tables_test.exs
@@ -195,6 +195,9 @@ defmodule Electric.Shapes.PartitionedTablesTest do
 
     assert_receive {^ref, :shape_rotation}, 5000
 
+    # wait for a bit for cleanup to occur
+    Process.sleep(50)
+
     assert [_] = active_shapes = ShapeCache.list_shapes(stack_id: ctx.stack_id)
 
     assert MapSet.equal?(
@@ -248,6 +251,9 @@ defmodule Electric.Shapes.PartitionedTablesTest do
 
     assert_receive {^ref, :shape_rotation}, 5000
     assert_receive {^partition_ref, :shape_rotation}, 5000
+
+    # wait for a bit for cleanup to occur
+    Process.sleep(50)
 
     assert [] = ShapeCache.list_shapes(stack_id: ctx.stack_id)
 

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -128,8 +128,8 @@ defmodule Support.ComponentSetup do
     {:ok, _pid} =
       Electric.Shapes.ShapeCleaner.start_link(
         stack_id: ctx.stack_id,
-        publication_manager: ctx.publication_manager,
-        storage: ctx.storage
+        publication_manager: start_opts[:publication_manager],
+        storage: start_opts[:storage]
       )
 
     {:ok, _pid} = ShapeCache.start_link(start_opts)


### PR DESCRIPTION
Followup to https://github.com/electric-sql/electric/pull/2656

Need to fix a shape cache test still but opening for visibility