### PR TITLE
docs: fix broken github links

### DIFF
--- a/website/demos/encryption.md
+++ b/website/demos/encryption.md
@@ -21,7 +21,7 @@ Electric syncs ciphertext as well as it syncs plaintext. You can encrypt data on
 - encrypting data before it leaves the client
 - decrypting data after it syncs in to the client through Electric
 
-It's a React app with a very simple Express API server. The Electric-specific code is in [`./src/Example.tsx`](https://github.com/electric-sql/electric/blog/main/examples/encryption/src/Example.tsx):
+It's a React app with a very simple Express API server. The Electric-specific code is in [`./src/Example.tsx`](https://github.com/electric-sql/electric/blob/main/examples/encryption/src/Example.tsx):
 
 <<< @../../examples/encryption/src/Example.tsx{tsx}
 

--- a/website/demos/nextjs.md
+++ b/website/demos/nextjs.md
@@ -18,7 +18,7 @@ example: true
 
 This is an example using Electric with [Next.js](/docs/integrations/next).
 
-The entrypoint for the Electric-specific code is in [`./app/page.tsx`](https://github.com/electric-sql/electric/blog/main/examples/nextjs/app/page.tsx):
+The entrypoint for the Electric-specific code is in [`./app/page.tsx`](https://github.com/electric-sql/electric/blob/main/examples/nextjs/app/page.tsx):
 
 <<< @../../examples/nextjs/app/page.tsx{tsx}
 

--- a/website/demos/phoenix-liveview.md
+++ b/website/demos/phoenix-liveview.md
@@ -19,7 +19,7 @@ This is an example app using our [`Electric.Phoenix`](/docs/integrations/phoenix
 
 It uses Electric for read-path sync into a LiveView using [`electric_stream/4`](https://hexdocs.pm/electric_phoenix/Electric.Phoenix.LiveView.html#electric_stream/4) and standard Phoenix APIs for writes. This keeps the LiveView automatically in-sync with Postgres, without having to re-run queries or trigger any change handling yourself.
 
-See e.g.: [`lib/electric_phoenix_example_web/live/todo_live/index.ex`](https://github.com/electric-sql/electric/blog/main/examples/phoenix-liveview/lib/electric_phoenix_example_web/live/todo_live/index.ex):
+See e.g.: [`lib/electric_phoenix_example_web/live/todo_live/index.ex`](https://github.com/electric-sql/electric/blob/main/examples/phoenix-liveview/lib/electric_phoenix_example_web/live/todo_live/index.ex):
 
 <<< @../../examples/phoenix-liveview/lib/electric_phoenix_example_web/live/todo_live/index.ex{elixir}
 

--- a/website/demos/react.md
+++ b/website/demos/react.md
@@ -18,7 +18,7 @@ example: true
 
 This is our simplest example of a web app using Electric with [React](https://react.dev) and [Vite](https://vite.dev).
 
-The Electric-specific code is in [`./src/Example.tsx`](https://github.com/electric-sql/electric/blog/main/examples/react/src/Example.tsx):
+The Electric-specific code is in [`./src/Example.tsx`](https://github.com/electric-sql/electric/blob/main/examples/react/src/Example.tsx):
 
 <<< @../../examples/react/src/Example.tsx{tsx}
 

--- a/website/demos/remix.md
+++ b/website/demos/remix.md
@@ -20,6 +20,6 @@ This is an example using Electric with [Remix](https://remix.run/).
 
 The entrypoint for the Electric-specific code is in [`./app/routes/_index.tsx`](https://github.com/electric-sql/electric/blob/main/examples/remix/app/routes/_index.tsx):
 
-<<< @../../examples/remix/app/routes/\_index.tsx{tsx}
+<<< @../../examples/remix/app/routes/_index.tsx{tsx}
 
 <DemoCTAs :demo="$frontmatter" />

--- a/website/demos/remix.md
+++ b/website/demos/remix.md
@@ -18,8 +18,8 @@ example: true
 
 This is an example using Electric with [Remix](https://remix.run/).
 
-The entrypoint for the Electric-specific code is in [`./app/routes/_index.tsx`](https://github.com/electric-sql/electric/blog/main/examples/remix/app/routes/_index.tsx):
+The entrypoint for the Electric-specific code is in [`./app/routes/_index.tsx`](https://github.com/electric-sql/electric/blob/main/examples/remix/app/routes/_index.tsx):
 
-<<< @../../examples/remix/app/routes/_index.tsx{tsx}
+<<< @../../examples/remix/app/routes/\_index.tsx{tsx}
 
 <DemoCTAs :demo="$frontmatter" />

--- a/website/demos/tanstack.md
+++ b/website/demos/tanstack.md
@@ -20,7 +20,7 @@ This is an example TanStack application developed using Electric for read-path s
 
 See the [Electric <> Tanstack integration docs](https://electric-sql.com/docs/integrations/tanstack) for more context and a [video of the example running here](https://x.com/msfstef/status/1828763769498952173).
 
-The main Electric code is in [`./src/Example.tsx`](https://github.com/electric-sql/electric/blog/main/examples/tanstack/src/Example.tsx):
+The main Electric code is in [`./src/Example.tsx`](https://github.com/electric-sql/electric/blob/main/examples/tanstack/src/Example.tsx):
 
 <<< @../../examples/tanstack/src/Example.tsx{tsx}
 

--- a/website/demos/todo-app.md
+++ b/website/demos/todo-app.md
@@ -14,7 +14,7 @@ example: true
 
 ## Todo MVC using Electric
 
-The main Electric code is in [`./src/routes/index.tsx`](https://github.com/electric-sql/electric/blog/main/examples/todo-app/src/routes/index.tsx):
+The main Electric code is in [`./src/routes/index.tsx`](https://github.com/electric-sql/electric/blob/main/examples/todo-app/src/routes/index.tsx):
 
 <<< @../../examples/todo-app/src/routes/index.tsx{tsx}
 

--- a/website/docs/guides/auth.md
+++ b/website/docs/guides/auth.md
@@ -22,7 +22,7 @@ import GatekeeperFlowJPG from '/static/img/docs/guides/auth/gatekeeper-flow.jpg?
 
 <div class="hidden-xs">
 
-  How to do auth<span class="hidden-sm inline-md">entication and authorization</span> with Electric. Including examples for <span class="no-wrap-md">[proxy](#proxy-auth) and</span> [gatekeeper](#gatekeeper-auth)&nbsp;auth.
+How to do auth<span class="hidden-sm inline-md">entication and authorization</span> with Electric. Including examples for <span class="no-wrap-md">[proxy](#proxy-auth) and</span> [gatekeeper](#gatekeeper-auth)&nbsp;auth.
 
 </div>
 <div class="block-xs">
@@ -38,7 +38,6 @@ Including examples for <span class="no-wrap-md">[proxy](#proxy-auth) and</span> 
 The golden rule with Electric is that it's [all just HTTP](/docs/api/http).
 
 So when it comes to auth, you can use existing primitives, such as your API, middleware and external authorization services<!-- (like [Auth0](/docs/integrations/auth0) and [Authzed](/docs/integrations/auth0)) -->.
-
 
 ### Shapes are resources
 
@@ -63,7 +62,7 @@ You can proxy the request in your cloud, or at the edge, [in-front of a CDN](#cd
 
 ### Rules are optional
 
-You *don't* have to codify your auth logic into a database rule system.
+You _don't_ have to codify your auth logic into a database rule system.
 
 There's no need to use database rules to [secure data access](/docs/guides/security) when your sync engine runs over standard HTTP.
 
@@ -101,12 +100,12 @@ const usersShape = (): ShapeStreamOptions => {
   return {
     url: new URL(`/api/shapes/users`, window.location.origin).href,
     headers: {
-      authorization: `Bearer ${user.token}`
-    }
+      authorization: `Bearer ${user.token}`,
+    },
   }
 }
 
-export default function ExampleComponent () {
+export default function ExampleComponent() {
   const { data: users } = useShape(usersShape())
 }
 ```
@@ -114,9 +113,7 @@ export default function ExampleComponent () {
 Then for the `/api/shapes/users` route:
 
 ```tsx
-export async function GET(
-  request: Request,
-) {
+export async function GET(request: Request) {
   const url = new URL(request.url)
 
   // Construct the upstream URL
@@ -180,7 +177,7 @@ The auth token should include a claim containing the shape definition. This allo
 This keeps your main auth logic:
 
 - in your API (in the gatekeeper endpoint) where it's natural to do things like query the database and call external services
-- running *once* when generating a token, rather than on the "hot path" of every shape request in your authorising proxy
+- running _once_ when generating a token, rather than on the "hot path" of every shape request in your authorising proxy
 
 #### Implementation
 
@@ -190,7 +187,7 @@ The [GitHub example](https://github.com/electric-sql/electric/tree/main/examples
 2. [`./caddy`](https://github.com/electric-sql/electric/tree/main/examples/gatekeeper-auth/caddy) a Caddy web server as a reverse proxy
 3. [`./edge`](https://github.com/electric-sql/electric/tree/main/examples/gatekeeper-auth/edge) an edge function that you can run in front of a CDN
 
-The API is an [Elixir/Phoenix](/docs/integrations/phoenix) web application that [exposes](https://github.com/electric-sql/electric/blog/main/examples/gatekeeper-auth/api/lib/api_web/router.ex) two endpoints:
+The API is an [Elixir/Phoenix](/docs/integrations/phoenix) web application that [exposes](https://github.com/electric-sql/electric/blob/main/examples/gatekeeper-auth/api/lib/api_web/router.ex) two endpoints:
 
 1. a gatekeeper endpoint at `POST /gatekeeper/:table`
 2. a proxy endpoint at `GET /proxy/v1/shape`
@@ -213,7 +210,7 @@ The API is an [Elixir/Phoenix](/docs/integrations/phoenix) web application that 
 
 4. the proxy validates the JWT and verifies that the shape claim in the token matches the shape being requested; if so it sends the request on to Electric
 5. Electric then handles the request as normal
-6. sending a response back *through the proxy* to the client
+6. sending a response back _through the proxy_ to the client
 
 The client can then process the data and make additional requests using the same token (step 3). If the token expires or is rejected, the client starts again (step 1).
 
@@ -232,15 +229,16 @@ The TypeScript client supports function-based options for headers and params, ma
 
 ```typescript
 const stream = new ShapeStream({
-  url: 'http://localhost:3000/v1/shape',
+  url: "http://localhost:3000/v1/shape",
   headers: {
     // Token will be refreshed on each request
-    'Authorization': async () => `Bearer ${await getAccessToken()}`
-  }
+    Authorization: async () => `Bearer ${await getAccessToken()}`,
+  },
 })
 ```
 
 This pattern is particularly useful when:
+
 - Your auth tokens need periodic refreshing
 - You're using session-based authentication
 - You need to fetch tokens from a secure storage
@@ -258,7 +256,7 @@ If you're using an external authentication service, such as [Auth0](https://auth
 
 If you're using an external authorization service to authorize a user's access to a shape, then you can call this whereever you run your authorization logic. For proxy auth this is the proxy. For gatekeeper auth this is the gatekeeper endpoint.
 
-Note that if you're using a distributed auth service to ensure consistent distributed auth, such as [Authzed](https://authzed.com/), then this works best with the proxy auth pattern. This is because you explicitly *want* to authorize the user each shape request, as opposed to the gatekeeper generating a token that can potentially become stale.
+Note that if you're using a distributed auth service to ensure consistent distributed auth, such as [Authzed](https://authzed.com/), then this works best with the proxy auth pattern. This is because you explicitly _want_ to authorize the user each shape request, as opposed to the gatekeeper generating a token that can potentially become stale.
 
 ### CDN <-> Proxy
 

--- a/website/docs/guides/auth.md
+++ b/website/docs/guides/auth.md
@@ -22,7 +22,7 @@ import GatekeeperFlowJPG from '/static/img/docs/guides/auth/gatekeeper-flow.jpg?
 
 <div class="hidden-xs">
 
-How to do auth<span class="hidden-sm inline-md">entication and authorization</span> with Electric. Including examples for <span class="no-wrap-md">[proxy](#proxy-auth) and</span> [gatekeeper](#gatekeeper-auth)&nbsp;auth.
+  How to do auth<span class="hidden-sm inline-md">entication and authorization</span> with Electric. Including examples for <span class="no-wrap-md">[proxy](#proxy-auth) and</span> [gatekeeper](#gatekeeper-auth)&nbsp;auth.
 
 </div>
 <div class="block-xs">
@@ -38,6 +38,7 @@ Including examples for <span class="no-wrap-md">[proxy](#proxy-auth) and</span> 
 The golden rule with Electric is that it's [all just HTTP](/docs/api/http).
 
 So when it comes to auth, you can use existing primitives, such as your API, middleware and external authorization services<!-- (like [Auth0](/docs/integrations/auth0) and [Authzed](/docs/integrations/auth0)) -->.
+
 
 ### Shapes are resources
 
@@ -62,7 +63,7 @@ You can proxy the request in your cloud, or at the edge, [in-front of a CDN](#cd
 
 ### Rules are optional
 
-You _don't_ have to codify your auth logic into a database rule system.
+You *don't* have to codify your auth logic into a database rule system.
 
 There's no need to use database rules to [secure data access](/docs/guides/security) when your sync engine runs over standard HTTP.
 
@@ -100,12 +101,12 @@ const usersShape = (): ShapeStreamOptions => {
   return {
     url: new URL(`/api/shapes/users`, window.location.origin).href,
     headers: {
-      authorization: `Bearer ${user.token}`,
-    },
+      authorization: `Bearer ${user.token}`
+    }
   }
 }
 
-export default function ExampleComponent() {
+export default function ExampleComponent () {
   const { data: users } = useShape(usersShape())
 }
 ```
@@ -113,7 +114,9 @@ export default function ExampleComponent() {
 Then for the `/api/shapes/users` route:
 
 ```tsx
-export async function GET(request: Request) {
+export async function GET(
+  request: Request,
+) {
   const url = new URL(request.url)
 
   // Construct the upstream URL
@@ -177,7 +180,7 @@ The auth token should include a claim containing the shape definition. This allo
 This keeps your main auth logic:
 
 - in your API (in the gatekeeper endpoint) where it's natural to do things like query the database and call external services
-- running _once_ when generating a token, rather than on the "hot path" of every shape request in your authorising proxy
+- running *once* when generating a token, rather than on the "hot path" of every shape request in your authorising proxy
 
 #### Implementation
 
@@ -210,7 +213,7 @@ The API is an [Elixir/Phoenix](/docs/integrations/phoenix) web application that 
 
 4. the proxy validates the JWT and verifies that the shape claim in the token matches the shape being requested; if so it sends the request on to Electric
 5. Electric then handles the request as normal
-6. sending a response back _through the proxy_ to the client
+6. sending a response back *through the proxy* to the client
 
 The client can then process the data and make additional requests using the same token (step 3). If the token expires or is rejected, the client starts again (step 1).
 
@@ -229,16 +232,15 @@ The TypeScript client supports function-based options for headers and params, ma
 
 ```typescript
 const stream = new ShapeStream({
-  url: "http://localhost:3000/v1/shape",
+  url: 'http://localhost:3000/v1/shape',
   headers: {
     // Token will be refreshed on each request
-    Authorization: async () => `Bearer ${await getAccessToken()}`,
-  },
+    'Authorization': async () => `Bearer ${await getAccessToken()}`
+  }
 })
 ```
 
 This pattern is particularly useful when:
-
 - Your auth tokens need periodic refreshing
 - You're using session-based authentication
 - You need to fetch tokens from a secure storage
@@ -256,7 +258,7 @@ If you're using an external authentication service, such as [Auth0](https://auth
 
 If you're using an external authorization service to authorize a user's access to a shape, then you can call this whereever you run your authorization logic. For proxy auth this is the proxy. For gatekeeper auth this is the gatekeeper endpoint.
 
-Note that if you're using a distributed auth service to ensure consistent distributed auth, such as [Authzed](https://authzed.com/), then this works best with the proxy auth pattern. This is because you explicitly _want_ to authorize the user each shape request, as opposed to the gatekeeper generating a token that can potentially become stale.
+Note that if you're using a distributed auth service to ensure consistent distributed auth, such as [Authzed](https://authzed.com/), then this works best with the proxy auth pattern. This is because you explicitly *want* to authorize the user each shape request, as opposed to the gatekeeper generating a token that can potentially become stale.
 
 ### CDN <-> Proxy
 

--- a/website/docs/guides/writes.md
+++ b/website/docs/guides/writes.md
@@ -84,7 +84,6 @@ Good use-cases include:
 
 You have the network on the write path. This can be slow and laggy with the user left watching loading spinners. The UI doesn't update until the server responds. Applications won't work offline.
 
-
 <h3 id="optimistic-state" tabindex="-1" style="display: inline-block">
   2. Optimistic state
   <a class="header-anchor" href="#online-writes" aria-label="Permalink to &quot;Optimistic state&quot;">&ZeroWidthSpace;</a>
@@ -123,7 +122,6 @@ This example illustrates a "simple" approach where the optimistic state:
 2. is not persisted
 
 This means that other components may display inconsistent information and users may be confused by the optimistic state dissapearing if they unmount the component or reload the page. These limitations are addressed by the more comprehensive approach in the next pattern.
-
 
 <h3 id="shared-persistent" tabindex="-1" style="display: inline-block">
   3. Shared persistent <span class="hidden-xs">optimistic state</span>
@@ -167,7 +165,6 @@ The entrypoint for handling rollbacks has the local write context available. So 
 
 Because it has the shared store available, it would also be possible to extend this to implement more sophisticated strategies. Such as also removing other local writes that causally depended-on or were related-to the rejected write.
 
-
 <h3 id="through-the-db" tabindex="-1" style="display: inline-block">
   4. Through the database sync
   <a class="header-anchor" href="#online-writes" aria-label="Permalink to &quot;Through the database sync&quot;">&ZeroWidthSpace;</a>
@@ -202,7 +199,7 @@ Through this, the implementation:
 - presents a single table interface for reads and writes
 - auto-syncs the local writes to the server
 
-The application code in [`index.tsx`](https://github.com/electric-sql/electric/blog/main/examples/write-patterns/patterns/4-through-the-db/index.tsx) stays very simple. Most of the complexity is abstracted into the local database schema, defined in [`local-schema.sql`](https://github.com/electric-sql/electric/blog/main/examples/write-patterns/patterns/4-through-the-db/local-schema.sql). The write-path sync utility in [`sync.ts`](https://github.com/electric-sql/electric/blog/main/examples/write-patterns/patterns/4-through-the-db/local-schema.sql) handles sending data to the server.
+The application code in [`index.tsx`](https://github.com/electric-sql/electric/blob/main/examples/write-patterns/patterns/4-through-the-db/index.tsx) stays very simple. Most of the complexity is abstracted into the local database schema, defined in [`local-schema.sql`](https://github.com/electric-sql/electric/blob/main/examples/write-patterns/patterns/4-through-the-db/local-schema.sql). The write-path sync utility in [`sync.ts`](https://github.com/electric-sql/electric/blob/main/examples/write-patterns/patterns/4-through-the-db/local-schema.sql) handles sending data to the server.
 
 These are shown in the three tabs below:
 
@@ -233,12 +230,11 @@ Syncing changes in the background complicates any potential [rollback handling](
 
 #### Implementation notes
 
-The [merge logic](#merge-logic) in the `delete_local_on_synced_insert_and_update_trigger` in [`./local-schema.sql`](https://github.com/electric-sql/electric/blog/main/examples/write-patterns/patterns/4-through-the-db/local-schema.sql) supports rebasing local optimistic state on concurrent updates from other users.
+The [merge logic](#merge-logic) in the `delete_local_on_synced_insert_and_update_trigger` in [`./local-schema.sql`](https://github.com/electric-sql/electric/blob/main/examples/write-patterns/patterns/4-through-the-db/local-schema.sql) supports rebasing local optimistic state on concurrent updates from other users.
 
-The rollback strategy in the `rollback` method of the `ChangeLogSynchronizer` in [`./sync.ts`](https://github.com/electric-sql/electric/blog/main/examples/write-patterns/patterns/4-through-the-db/sync.ts) is very naive: clearing all local state and writes in the event of any write being rejected by the server. You may want to implement a more nuanced strategy. For example, to provide information to the user about what is happening and / or minimise data loss by only clearing local-state that's causally dependent on a rejected write.
+The rollback strategy in the `rollback` method of the `ChangeLogSynchronizer` in [`./sync.ts`](https://github.com/electric-sql/electric/blob/main/examples/write-patterns/patterns/4-through-the-db/sync.ts) is very naive: clearing all local state and writes in the event of any write being rejected by the server. You may want to implement a more nuanced strategy. For example, to provide information to the user about what is happening and / or minimise data loss by only clearing local-state that's causally dependent on a rejected write.
 
 This opens the door to a lot of complexity that may best be addressed by [using an existing framework](#framework) or one of the [simpler patterns](#patterns).
-
 
 ## Advanced
 
@@ -254,7 +250,7 @@ There are two key complexities introduced by handling offline writes or local wr
 
 When a change syncs in over the Electric replication stream, the application has to decide how to handle any overlapping optimistic state. This can be complicated by concurrency, when changes syncing in may be made by other users (or devices, or even tabs). The third and fourth examples both demonstrate approaches to rebasing the local state on the synced state, rather than just naively clearing the local state, in order to preserve local changes.
 
-[Linearlite](https://github.com/electric-sql/electric/blog/main/examples/linearlite) is another example of through-the-DB sync with more sophisticated merge logic.
+[Linearlite](https://github.com/electric-sql/electric/blob/main/examples/linearlite) is another example of through-the-DB sync with more sophisticated merge logic.
 
 ### Rollbacks
 
@@ -276,7 +272,6 @@ One consideration is the indirection between making a write and handling a rollb
 </div>
 
 If you're crafting a highly concurrent, collaborative experience, you may want to engage with the complexities of merge logic and rebasing local state. However, blunt strategies like those illustrated by the [patterns in this guide](#patterns) can be much easier to implement and reason about &mdash; and are perfectly serviceable for many applications.
-
 
 ## Tools
 


### PR DESCRIPTION
## Description

While reading through the documentation, I noticed a couple of broken GitHub links. This PR fixes those links to ensure they correctly point to the intended locations, improving the developer experience and helping others navigate the docs more easily.