### PR TITLE
fix: Actually pass the pooled database url for examples

### DIFF
--- a/examples/.shared/lib/database.ts
+++ b/examples/.shared/lib/database.ts
@@ -44,7 +44,7 @@ function addDatabaseToElectric({
           database_url: dbUri,
           source_options: {
             db_pool_size: 5,
-            ...(pooledDbUri ? { pooled_db_uri: pooledDbUri } : {}),
+            ...(pooledDbUri ? { pooled_database_url: pooledDbUri } : {}),
           },
           region: `us-east-1`,
           team_id: teamId,


### PR DESCRIPTION
Was passing the wrong parameter for source options - apparently doesn't get validated to a 400 if extra keys present