### PR TITLE
Fix issues in Prometheus metric collection

### DIFF
--- a/.changeset/happy-cats-do.md
+++ b/.changeset/happy-cats-do.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix the issue with failing to report vm memory metrics. Change the name of the "vm.memory.processes_by_type" metric to "process.memory.total".

--- a/packages/sync-service/lib/electric/plug/utility_router.ex
+++ b/packages/sync-service/lib/electric/plug/utility_router.ex
@@ -10,4 +10,6 @@ defmodule Electric.Plug.UtilityRouter do
   else
     get "/metrics", do: resp(conn, 200, "[]")
   end
+
+  get _, do: resp(conn, 404, "Not found")
 end

--- a/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/application_telemetry.ex
@@ -159,10 +159,10 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
 
     defp prometheus_metrics do
       [
+        last_value("process.memory.total", tags: [:process_type], unit: :byte),
         last_value("system.cpu.core_count"),
         last_value("system.cpu.utilization.total"),
         last_value("vm.memory.processes_used", unit: :byte),
-        last_value("vm.memory.processes_by_type", tags: [:process_type], unit: :byte),
         last_value("vm.memory.binary", unit: :byte),
         last_value("vm.memory.ets", unit: :byte),
         last_value("vm.system_counts.process_count"),
@@ -197,7 +197,7 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
 
     defp memory_by_process_type_metrics(%{otel_per_process_metrics?: true}) do
       [
-        last_value("vm.memory.processes_by_type", tags: [:process_type], unit: :byte)
+        last_value("process.memory.total", tags: [:process_type], unit: :byte)
       ]
     end
 
@@ -218,7 +218,7 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
         # Our custom measurements:
         {__MODULE__, :uptime_event, []},
         {__MODULE__, :cpu_utilization, []},
-        {__MODULE__, :memory_by_process_type, [opts]},
+        {__MODULE__, :process_memory, [opts]},
         {__MODULE__, :get_system_load_average, []},
         {__MODULE__, :get_system_memory_usage, []}
       ]
@@ -230,12 +230,10 @@ with_telemetry [Telemetry.Metrics, OtelMetricExporter] do
       })
     end
 
-    def memory_by_process_type(%{top_process_count: process_count}) do
+    def process_memory(%{top_process_count: process_count}) do
       for %{type: type, memory: memory} <-
             Electric.Debug.Process.top_memory_by_type(process_count) do
-        :telemetry.execute([:vm, :memory], %{processes_by_type: memory}, %{
-          process_type: to_string(type)
-        })
+        :telemetry.execute([:process, :memory], %{total: memory}, %{process_type: to_string(type)})
       end
     end
 


### PR DESCRIPTION
Fixes #2674.

Trying to report out custom per-process-type memory metrics as part of telemetry poller's builtin `memory` probe was a mistake, as explained in the linked issue. This PR defines a separate event for our custom memory probes.

Now, instead of exporting `vm.memory.processes_by_type` we have the  `process.memory.total` measurement which is tagged with the process type/name. Such measurements are still reported only for the top N processes.

From what I've been able to find, the `vm.memory.processes_by_type` metric has only been referenced in Honeycomb by @robacourt's query that showcased the mem usage grouped by process type/name. 