### PR TITLE
chore (examples): Move nextjs to examples subdomain

### DIFF
--- a/examples/nextjs/sst.config.ts
+++ b/examples/nextjs/sst.config.ts
@@ -38,7 +38,7 @@ export default $config({
         DATABASE_URL: pooledDatabaseUri,
       },
       domain: {
-        name: `nextjs${$app.stage === `production` ? `` : `-stage-${$app.stage}`}.electric-sql.com`,
+        name: `nextjs${$app.stage === `production` ? `` : `-stage-${$app.stage}`}.examples.electric-sql.com`,
         dns: sst.cloudflare.dns(),
       },
     })


### PR DESCRIPTION
The website links to https://nextjs.examples.electric-sql.com/ but the demo is actually at https://nextjs.electric-sql.com/
This PR modifies the SST code to host the example under the examples subdomain.