### PR TITLE
chore (examples): Deploy example apps in parallel

### DIFF
--- a/.github/workflows/deploy_all_examples.yml
+++ b/.github/workflows/deploy_all_examples.yml
@@ -8,10 +8,27 @@ concurrency:
   group: ${{ github.event_name == 'push' && 'prod-deploy-group' || format('examples-pr-{0}', github.event.number) }}
 
 jobs:
-  deploy-examples:
-    name: Deploy All Examples to Production
+  deploy:
+    name: Deploy ${{ matrix.example.name }}
     environment: "Production"
     runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: changed-files
+    strategy:
+      matrix:
+        example:
+          - name: yjs
+            path: examples/yjs
+          - name: linearlite-read-only
+            path: examples/linearlite-read-only
+          - name: write-patterns
+            path: examples/write-patterns
+          - name: nextjs
+            path: examples/nextjs
+          - name: todo-app
+            path: examples/todo-app
+          - name: proxy-auth
+            path: examples/proxy-auth
 
     env:
       DEPLOY_ENV: "production"
@@ -43,34 +60,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .sst
-          key: sst-cache-main-${{ runner.os }}
+          key: sst-cache-${{ matrix.example.name }}-${{ runner.os }}
           restore-keys: |
-            sst-cache-main-${{ runner.os }}
+            sst-cache-${{ matrix.example.name }}-${{ runner.os }}
 
-      - name: Deploy proxy-auth example
-        working-directory: ./examples/proxy-auth
-        run: pnpm sst deploy --stage production
-
-      - name: Deploy todo-app example
-        working-directory: ./examples/todo-app
-        run: pnpm sst deploy --stage production
-
-      - name: Deploy Write Patterns example
-        working-directory: ./examples/write-patterns
-        run: pnpm sst deploy --stage production
-
-      - name: Deploy Linearlite Read Only
-        working-directory: ./examples/linearlite-read-only
-        run: pnpm sst deploy --stage production
-
-      # - name: Deploy Linearlite
-      #   working-directory: ./examples/linearlite
-      #   run: pnpm sst deploy --stage production
-
-      - name: Deploy NextJs example
-        working-directory: ./examples/nextjs
-        run: pnpm sst deploy --stage production
-
-      - name: Deploy Yjs example
-        working-directory: ./examples/yjs
-        run: pnpm sst deploy --stage production
+      - name: Deploy
+        id: deploy
+        working-directory: ./${{ matrix.example.path }}
+        run: |
+          pnpm --filter @electric-sql/client --filter @electric-sql/experimental --filter @electric-sql/react run build
+          pnpm sst deploy --stage production

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -70,14 +70,11 @@ jobs:
           restore-keys: |
             sst-cache-${{ matrix.example.name }}-${{ runner.os }}
 
-      - name: Optional Build (Write Patterns only)
-        if: matrix.example.name == 'write-patterns'
-        run: pnpm --filter @electric-sql/client --filter @electric-sql/experimental --filter @electric-sql/react run build
-
       - name: Deploy
         id: deploy
         working-directory: ./${{ matrix.example.path }}
         run: |
+          pnpm --filter @electric-sql/client --filter @electric-sql/experimental --filter @electric-sql/react run build
           pnpm sst deploy --stage ${{ env.DEPLOY_ENV }}
 
           if [ -f ".sst/outputs.json" ]; then

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -14,6 +14,7 @@ jobs:
     name: Deploy ${{ matrix.example.name }}
     environment: ${{ github.event_name == 'push' && 'Production' || 'Pull request' }}
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     strategy:
       matrix:

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -10,27 +10,49 @@ concurrency:
   group: ${{ github.event_name == 'push' && 'prod-deploy-group' || format('examples-pr-{0}', github.event.number) }}
 
 jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-example-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v41
+        with:
+          path: "examples"
+          diff_relative: true
+          dir_names: true
+          dir_names_max_depth: 1
+
+      - name: Create example matrix
+        id: create-example-matrix
+        run: |
+          # Get changed example directories
+          CHANGED_DIRS="${{ steps.changed-files.outputs.all_changed_files }}"
+          
+          # Initialize empty JSON array
+          MATRIX='{"example":[]}'
+          
+          # Add each changed directory to the matrix
+          if [ -n "$CHANGED_DIRS" ]; then
+            for dir in $CHANGED_DIRS; do
+              name=$(basename $dir)
+              MATRIX=$(echo $MATRIX | jq --arg name "$name" --arg path "examples/$name" '.example += [{"name": $name, "path": $path}]')
+            done
+          fi
+          
+          # Use jq to properly format and escape the JSON
+          echo "matrix=$(echo $MATRIX | jq -c '.')" >> $GITHUB_OUTPUT
+
   deploy:
     name: Deploy ${{ matrix.example.name }}
     environment: ${{ github.event_name == 'push' && 'Production' || 'Pull request' }}
     runs-on: ubuntu-latest
     continue-on-error: true
-
+    needs: changed-files
     strategy:
-      matrix:
-        example:
-          - name: yjs
-            path: examples/yjs
-          - name: linearlite-read-only
-            path: examples/linearlite-read-only
-          - name: write-patterns
-            path: examples/write-patterns
-          - name: nextjs
-            path: examples/nextjs
-          - name: todo-app
-            path: examples/todo-app
-          - name: proxy-auth
-            path: examples/proxy-auth
+      matrix: ${{ fromJson(needs.changed-files.outputs.matrix) }}
 
     outputs:
       yjs: ${{ steps.deploy.outputs.yjs }}
@@ -91,7 +113,7 @@ jobs:
 
   comment:
     if: github.event_name == 'pull_request'
-    needs: deploy
+    needs: [changed-files, deploy]
     runs-on: ubuntu-latest
     steps:
       - name: Create PR comment with deployment URLs
@@ -99,28 +121,37 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const deployments = [
-              { name: 'yjs', url: '${{ needs.deploy.outputs.yjs }}' },
-              { name: 'linearlite-read-only', url: '${{ needs.deploy.outputs.linearlite-read-only }}' },
-              { name: 'write-patterns', url: '${{ needs.deploy.outputs.write-patterns }}' },
-              { name: 'nextjs', url: '${{ needs.deploy.outputs.nextjs }}' },
-              { name: 'todo-app', url: '${{ needs.deploy.outputs.todo-app }}' },
-              { name: 'proxy-auth', url: '${{ needs.deploy.outputs.proxy-auth }}' },
-            ];
+            // Get the matrix of examples that were deployed
+            const matrix = JSON.parse(${{ toJSON(needs.changed-files.outputs.matrix) }})
+            
+            const urls = {
+              yjs: "${{ needs.deploy.outputs.yjs }}",
+              "linearlite-read-only": "${{ needs.deploy.outputs.linearlite-read-only }}",
+              "write-patterns": "${{ needs.deploy.outputs.write-patterns }}",
+              nextjs: "${{ needs.deploy.outputs.nextjs }}",
+              "todo-app": "${{ needs.deploy.outputs.todo-app }}",
+              "proxy-auth": "${{ needs.deploy.outputs.proxy-auth }}"
+            }
+
+            // Create deployments array only for examples that were deployed
+            const deployments = matrix.example.map(example => ({
+              name: example.name,
+              url: urls[example.name]
+            }))
 
             const commentBody = [
               "## Examples",
               ...deployments.map(d => `- ${d.name}: ${d.url || '*deploy failed*'}`),
-            ].join('\n');
+            ].join('\n')
 
-            const prNumber = context.issue.number;
+            const prNumber = context.issue.number
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-            });
+            })
 
-            const existingComment = comments.find(comment => comment.user.login ==='github-actions[bot]' && comment.body.startsWith("## Examples"));
+            const existingComment = comments.find(comment => comment.user.login ==='github-actions[bot]' && comment.body.startsWith("## Examples"))
 
             if (existingComment) {
               // Update the existing comment
@@ -129,7 +160,7 @@ jobs:
                 repo: context.repo.repo,
                 comment_id: existingComment.id,
                 body: commentBody,
-              });
+              })
             } else {
               // Create a new comment if none exists
               await github.rest.issues.createComment({
@@ -137,5 +168,5 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: prNumber,
                 body: commentBody,
-              });
+              })
             }

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -10,10 +10,30 @@ concurrency:
   group: ${{ github.event_name == 'push' && 'prod-deploy-group' || format('examples-pr-{0}', github.event.number) }}
 
 jobs:
-  deploy-examples:
-    name: Deploy Examples
+  deploy:
+    name: Deploy ${{ matrix.example.name }}
     environment: ${{ github.event_name == 'push' && 'Production' || 'Pull request' }}
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        example:
+          - name: yjs
+            path: examples/yjs
+          - name: linearlite-read-only
+            path: examples/linearlite-read-only
+          - name: write-patterns
+            path: examples/write-patterns
+          - name: nextjs
+            path: examples/nextjs
+          - name: todo-app
+            path: examples/todo-app
+          - name: proxy-auth
+            path: examples/proxy-auth
+
+    outputs:
+      website_url: ${{ steps.deploy.outputs.website_url }}
+      example_name: ${{ matrix.example.name }}
 
     env:
       DEPLOY_ENV: ${{ github.event_name == 'push' && 'production' || format('pr-{0}', github.event.number) }}
@@ -29,7 +49,6 @@ jobs:
       ELECTRIC_ADMIN_API: ${{ secrets.ELECTRIC_ADMIN_API }}
       ELECTRIC_TEAM_ID: ${{ secrets.ELECTRIC_TEAM_ID }}
       ELECTRIC_ADMIN_API_AUTH_TOKEN: ${{ secrets.ELECTRIC_ADMIN_API_AUTH_TOKEN }}
-      # HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }} TODO
 
     steps:
       - uses: actions/checkout@v4
@@ -46,118 +65,53 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .sst
-          key: sst-cache-main-${{ runner.os }}
+          key: sst-cache-${{ matrix.example.name }}-${{ runner.os }}
           restore-keys: |
-            sst-cache-main-${{ runner.os }}
+            sst-cache-${{ matrix.example.name }}-${{ runner.os }}
 
-      - name: Deploy Yjs example
-        working-directory: ./examples/yjs
+      - name: Optional Build (Write Patterns only)
+        if: matrix.example.name == 'write-patterns'
+        run: pnpm --filter @electric-sql/client --filter @electric-sql/experimental --filter @electric-sql/react run build
+
+      - name: Deploy
+        id: deploy
+        working-directory: ./${{ matrix.example.path }}
         run: |
           pnpm sst deploy --stage ${{ env.DEPLOY_ENV }}
-          code=$!
+
           if [ -f ".sst/outputs.json" ]; then
-            yjs=$(jq -r '.website' .sst/outputs.json)
-            echo "yjs=$yjs" >> $GITHUB_ENV
+            website=$(jq -r '.website' .sst/outputs.json)
+            echo "${{ matrix.example.name }}=$website" >> $GITHUB_OUTPUT
           else
             echo "sst outputs file not found. Exiting."
             exit 123
           fi
-          exit $code
 
-      - name: Deploy Linearlite Read Only
-        working-directory: ./examples/linearlite-read-only
-        run: |
-          pnpm sst deploy --stage ${{ env.DEPLOY_ENV }}
-          code=$!
-          if [ -f ".sst/outputs.json" ]; then
-            linearlite_read_only=$(jq -r '.website' .sst/outputs.json)
-            echo "linearlite_read_only=$linearlite_read_only" >> $GITHUB_ENV
-          else
-            echo "sst outputs file not found. Exiting."
-            exit 123
-          fi
-          exit $code
-
-      - name: Deploy Write Patterns example
-        working-directory: ./examples/write-patterns
-        run: |
-          pnpm --filter @electric-sql/client --filter @electric-sql/experimental --filter @electric-sql/react run build
-          pnpm sst deploy --stage ${{ env.DEPLOY_ENV }}
-          code=$!
-          if [ -f ".sst/outputs.json" ]; then
-            writes=$(jq -r '.website' .sst/outputs.json)
-            echo "writes=$writes" >> $GITHUB_ENV
-          else
-            echo "sst outputs file not found. Exiting."
-            exit 123
-          fi
-          exit $code
-
-      - name: Deploy NextJs example
-        working-directory: ./examples/nextjs
-        run: |
-          pnpm sst deploy --stage ${{ env.DEPLOY_ENV }}
-          code=$!
-          if [ -f ".sst/outputs.json" ]; then
-            nextjs=$(jq -r '.website' .sst/outputs.json)
-            echo "nextjs=$nextjs" >> $GITHUB_ENV
-          else
-            echo "sst outputs file not found. Exiting."
-            exit 123
-          fi
-          exit $code
-
-      - name: Deploy TODO App example
-        working-directory: ./examples/todo-app
-        run: |
-          pnpm sst deploy --stage ${{ env.DEPLOY_ENV }}
-          code=$!
-          if [ -f ".sst/outputs.json" ]; then
-            todoapp=$(jq -r '.website' .sst/outputs.json)
-            echo "todoapp=$todoapp" >> $GITHUB_ENV
-          else
-            echo "sst outputs file not found. Exiting."
-            exit 123
-          fi
-          exit $code
-
-      - name: Deploy proxy-auth example
-        working-directory: ./examples/proxy-auth
-        run: |
-          pnpm sst deploy --stage ${{ env.DEPLOY_ENV }}
-          code=$!
-          if [ -f ".sst/outputs.json" ]; then
-            auth=$(jq -r '.website' .sst/outputs.json)
-            echo "auth=$auth" >> $GITHUB_ENV
-          else
-            echo "sst outputs file not found. Exiting."
-            exit 123
-          fi
-          exit $code
-
-      - name: Add comment to PR
-        if: github.event_name == 'pull_request'
+  comment:
+    if: github.event_name == 'pull_request'
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR comment with deployment URLs
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const linearlite_read_only = process.env.linearlite_read_only;
-            const nextjs = process.env.nextjs;
-            const todoapp = process.env.todoapp;
-            const yjs = process.env.yjs;
-            const writes = process.env.writes;
-            const auth = process.env.auth;
+            const deployments = [
+              { name: 'yjs', url: '${{ needs.deploy.outputs.yjs }}' },
+              { name: 'linearlite-read-only', url: '${{ needs.deploy.outputs.linearlite-read-only }}' },
+              { name: 'write-patterns', url: '${{ needs.deploy.outputs.write-patterns }}' },
+              { name: 'nextjs', url: '${{ needs.deploy.outputs.nextjs }}' },
+              { name: 'todo-app', url: '${{ needs.deploy.outputs.todo-app }}' },
+              { name: 'proxy-auth', url: '${{ needs.deploy.outputs.proxy-auth }}' },
+            ];
+
+            const commentBody = [
+              "## Examples",
+              ...deployments.map(d => `- ${d.name}: ${d.url || '*deploy failed or missing output*'}`),
+            ].join('\n');
 
             const prNumber = context.issue.number;
-            const commentBody = `## Examples
-            - linearlite-read-only: ${linearlite_read_only}
-            - nextjs: ${nextjs}
-            - todoapp: ${todoapp}
-            - yjs: ${yjs}
-            - writes: ${writes}
-            - auth: ${auth}
-            `;
-
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy ${{ matrix.example.name }}
+    name: Deploy Examples
     environment: ${{ github.event_name == 'push' && 'Production' || 'Pull request' }}
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -33,8 +33,12 @@ jobs:
             path: examples/proxy-auth
 
     outputs:
-      website_url: ${{ steps.deploy.outputs.website_url }}
-      example_name: ${{ matrix.example.name }}
+      yjs: ${{ steps.deploy.outputs.yjs }}
+      linearlite-read-only: ${{ steps.deploy.outputs.linearlite-read-only }}
+      write-patterns: ${{ steps.deploy.outputs.write-patterns }}
+      nextjs: ${{ steps.deploy.outputs.nextjs }}
+      todo-app: ${{ steps.deploy.outputs.todo-app }}
+      proxy-auth: ${{ steps.deploy.outputs.proxy-auth }}
 
     env:
       DEPLOY_ENV: ${{ github.event_name == 'push' && 'production' || format('pr-{0}', github.event.number) }}

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy Examples
+    name: Deploy ${{ matrix.example.name }}
     environment: ${{ github.event_name == 'push' && 'Production' || 'Pull request' }}
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -110,7 +110,7 @@ jobs:
 
             const commentBody = [
               "## Examples",
-              ...deployments.map(d => `- ${d.name}: ${d.url || '*deploy failed or missing output*'}`),
+              ...deployments.map(d => `- ${d.name}: ${d.url || '*deploy failed*'}`),
             ].join('\n');
 
             const prNumber = context.issue.number;

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -24,6 +24,14 @@ jobs:
           diff_relative: true
           dir_names: true
           dir_names_max_depth: 1
+          # Whitelist examples that need to be deployed
+          files: |
+            yjs/**
+            linearlite-read-only/**
+            write-patterns/**
+            nextjs/**
+            todo-app/**
+            proxy-auth/**
 
       - name: Create example matrix
         id: create-example-matrix

--- a/.github/workflows/teardown_examples_pr_stack.yml
+++ b/.github/workflows/teardown_examples_pr_stack.yml
@@ -62,4 +62,22 @@ jobs:
         run: |
           export PR_NUMBER=${{ github.event.number }}
           echo "Removing stage pr-$PR_NUMBER"
-          pnpm sst remove --stage "pr-$PR_NUMBER"
+
+          # If we fail to remove the stage, the app might not have been deployed
+          # so check the output to see if that's the case
+          # and if that's the case, exit with a 0 exit code (success)
+          output=$(pnpm sst remove --stage "pr-$PR_NUMBER" 2>&1)
+          exit_code=$?
+          
+          if [ $exit_code -ne 0 ]; then
+            if echo "$output" | grep -q "Stage not found"; then
+              echo "Example was not deployed."
+              exit 0
+            else
+              echo "$output" >&2
+              exit $exit_code
+            fi
+          fi
+          
+          # If we get here, the command succeeded normally
+          exit 0


### PR DESCRIPTION
Currently, example apps are deployed sequentially. This takes a very long time (> 40 minutes). This is not very practical when we want to quickly test changes to one of these example apps. This PR modifies the workflow to **deploy** the **changed examples in parallel**. 