### PR TITLE
Fix the gating of telemetry deps behind a Mix target

### DIFF
--- a/.changeset/loud-walls-do.md
+++ b/.changeset/loud-walls-do.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix a typo in the 'targets' option for telemetry deps, ensuring they are left out from compilation unless MIX_TARGET=application.

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Run tests
         run: mix test --include slow
 
+      - name: Run telemetry tests
+        run: MIX_TARGET=application mix test --only telemetry_target
+
   formatting:
     name: Check formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -98,7 +98,10 @@ jobs:
         run: mix test --include slow
 
       - name: Run telemetry tests
-        run: MIX_TARGET=application mix test --only telemetry_target
+        run: |
+          cp -R _build/test _build/application_test
+          rm -rf _build/application_test/lib/electric
+          MIX_TARGET=application mix test --only telemetry_target
 
   formatting:
     name: Check formatting

--- a/packages/sync-service/config/config.exs
+++ b/packages/sync-service/config/config.exs
@@ -1,10 +1,12 @@
 import Config
 
-# Sentry's source-context-related options need to be set in compile-time config files
-# cf. https://hexdocs.pm/sentry/Mix.Tasks.Sentry.PackageSourceCode.html
-config :sentry,
-  enable_source_code_context: true,
-  root_source_code_paths: [File.cwd!()]
+if Mix.target() == Electric.MixProject.telemetry_target() do
+  # Sentry's source-context-related options need to be set in compile-time config files
+  # cf. https://hexdocs.pm/sentry/Mix.Tasks.Sentry.PackageSourceCode.html
+  config :sentry,
+    enable_source_code_context: true,
+    root_source_code_paths: [File.cwd!()]
+end
 
 config :electric,
   start_in_library_mode: Mix.env() == :test

--- a/packages/sync-service/lib/electric/telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry.ex
@@ -1,7 +1,7 @@
 defmodule Electric.Telemetry do
   require Logger
 
-  @enabled Mix.env() == :test || Mix.target() == Electric.MixProject.telemetry_target()
+  @enabled Mix.target() == Electric.MixProject.telemetry_target()
   @log_level Application.compile_env(:electric, [Electric.Telemetry, :log_level], false)
 
   defmacro __using__(_opts) do

--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -3,11 +3,8 @@ defmodule Electric.MixProject do
 
   @github_repo "https://github.com/electric-sql/electric"
 
-  # Telemetry deps are marked as `target: :application` to prevent their
-  # inclusion in applications including `:electric` as a dependency.
-  #
-  # To build Electric as a standalone app with telemetry enabled, add
-  # `MIX_TARGET=application` to the compilation (& runtime?) environment.
+  # Application and Stack telemetry are enabled when Mix target is set to this value,
+  # e.g. via `MIX_TARGET=application` environment variable.
   @telemetry_target :application
 
   # make the metrics-enabled target available to the rest of the app
@@ -33,12 +30,7 @@ defmodule Electric.MixProject do
       ],
       releases: [
         electric: [
-          applications:
-            [
-              electric: :permanent
-              # This order of application is important to ensure proper startup sequence of
-              # application dependencies, namely, inets.
-            ] ++ telemetry_applications(),
+          applications: [electric: :permanent] ++ telemetry_applications_in_release(),
           include_executables_for: [:unix]
         ]
       ],
@@ -123,8 +115,10 @@ defmodule Electric.MixProject do
     ]
   end
 
-  defp telemetry_applications do
+  defp telemetry_applications_in_release do
     if Mix.target() == @telemetry_target do
+      # This order of application is important to ensure proper startup sequence of
+      # application dependencies, namely, inets.
       [
         opentelemetry_exporter: :permanent,
         opentelemetry: :temporary
@@ -158,7 +152,7 @@ defmodule Electric.MixProject do
   end
 
   defp telemetry_dep_opts(source_opts) do
-    Keyword.merge(source_opts, target: @telemetry_target, optional: true)
+    Keyword.merge(source_opts, targets: @telemetry_target, optional: true)
   end
 
   defp aliases() do

--- a/packages/sync-service/test/electric/telemetry/application_telemetry_test.exs
+++ b/packages/sync-service/test/electric/telemetry/application_telemetry_test.exs
@@ -3,6 +3,8 @@ defmodule Electric.TelemetryTest do
 
   alias Electric.Telemetry.ApplicationTelemetry
 
+  @moduletag :telemetry_target
+
   describe "get_system_memory_usage" do
     test "returns calculated memory stats" do
       case :os.type() do

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -4,5 +4,5 @@
 # supervision tree in the test environment.
 # Registry.start_link(name: Electric.Application.process_registry(), keys: :unique)
 
-ExUnit.start(assert_receive_timeout: 400, exclude: [slow: true], capture_log: true)
+ExUnit.start(assert_receive_timeout: 400, exclude: [:slow, :telemetry_target], capture_log: true)
 Repatch.setup()


### PR DESCRIPTION
This PR fixes the typo in the `targets` option for telemetry deps. All it does is make sure those deps aren't compiled when Mix target is set to anything other than `application`.

We also disable compilation of telemetry modules in the test env to make sure the stub code is exercised. A new CI step has been added specifically for the tests that exercise ApplicationTelemetry.