### PR TITLE
fix: Use regular connection for advisory lock instead of pooled one

### DIFF
--- a/.changeset/mighty-otters-fry.md
+++ b/.changeset/mighty-otters-fry.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Use non-pooled connection for grabbing advisory lock to avoid unexpected behaviour.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -277,12 +277,13 @@ defmodule Electric.Connection.Manager do
         :start_lock_connection,
         %State{
           current_phase: :connection_setup,
-          current_step: {:start_lock_connection = step, _},
+          current_step: {:start_lock_connection, _},
           lock_connection_pid: nil
         } = state
       ) do
     opts = [
-      connection_opts: connection_opts(step, state),
+      # Lock connection must be direct-to-database, hence no pooled connection opts here.
+      connection_opts: replication_connection_opts(state),
       connection_manager: self(),
       lock_name: Keyword.fetch!(state.replication_opts, :slot_name),
       stack_id: state.stack_id
@@ -356,7 +357,7 @@ defmodule Electric.Connection.Manager do
     # process are both terminated when the shape is removed.
     #
     # See https://github.com/electric-sql/electric/issues/1554
-    conn_opts = connection_opts(nil, state) |> Electric.Utils.deobfuscate_password()
+    conn_opts = pooled_connection_opts(state) |> Electric.Utils.deobfuscate_password()
 
     {:ok, pool_pid} =
       Postgrex.start_link(
@@ -537,7 +538,7 @@ defmodule Electric.Connection.Manager do
     error = strip_exit_signal_stacktrace(reason)
     state = nillify_pid(state, pid)
     {step, _} = state.current_step
-    conn_opts = connection_opts(step, state)
+    conn_opts = connection_opts_for_step(step, state)
 
     repaired_conn_opts =
       case error do
@@ -1044,17 +1045,23 @@ defmodule Electric.Connection.Manager do
   defp populate_connection_opts(conn_opts),
     do: conn_opts |> populate_ssl_opts() |> populate_tcp_opts()
 
-  defp connection_opts(step, %State{shared_connection_opts: nil} = state)
+  defp connection_opts_for_step(step, state)
        when step in [:start_lock_connection, :start_replication_client] do
-    Keyword.fetch!(state.replication_opts, :connection_opts)
+    replication_connection_opts(state)
   end
 
-  defp connection_opts(_step, %State{shared_connection_opts: nil} = state) do
-    state.connection_opts
+  defp connection_opts_for_step(_step, state) do
+    pooled_connection_opts(state)
   end
 
-  defp connection_opts(_step, state) do
-    state.shared_connection_opts
+  defp replication_connection_opts(state) do
+    state
+    |> replication_opts()
+    |> Keyword.fetch!(:connection_opts)
+  end
+
+  defp pooled_connection_opts(state) do
+    state.shared_connection_opts || state.connection_opts
   end
 
   defp replication_opts(%State{shared_connection_opts: nil} = state), do: state.replication_opts

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -277,12 +277,12 @@ defmodule Electric.Connection.Manager do
         :start_lock_connection,
         %State{
           current_phase: :connection_setup,
-          current_step: {:start_lock_connection, _},
+          current_step: {:start_lock_connection = step, _},
           lock_connection_pid: nil
         } = state
       ) do
     opts = [
-      connection_opts: connection_opts(nil, state),
+      connection_opts: connection_opts(step, state),
       connection_manager: self(),
       lock_name: Keyword.fetch!(state.replication_opts, :slot_name),
       stack_id: state.stack_id
@@ -1044,7 +1044,8 @@ defmodule Electric.Connection.Manager do
   defp populate_connection_opts(conn_opts),
     do: conn_opts |> populate_ssl_opts() |> populate_tcp_opts()
 
-  defp connection_opts(:start_replication_client, %State{shared_connection_opts: nil} = state) do
+  defp connection_opts(step, %State{shared_connection_opts: nil} = state)
+       when step in [:start_lock_connection, :start_replication_client] do
     Keyword.fetch!(state.replication_opts, :connection_opts)
   end
 

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -1063,10 +1063,11 @@ defmodule Electric.Connection.Manager do
     do: Keyword.put(state.replication_opts, :connection_opts, conn_opts)
 
   defp update_connection_opts(
-         :start_replication_client,
+         step,
          conn_opts,
          %State{shared_connection_opts: nil, replication_opts: replication_opts} = state
-       ) do
+       )
+       when step in [:start_lock_connection, :start_replication_client] do
     %State{state | replication_opts: put_in(replication_opts, [:connection_opts], conn_opts)}
   end
 


### PR DESCRIPTION
I'm investigating some issues around the release of the advisory lock - sometimes I've noticed that we've terminated the Electric process but when trying to grab the relevant advisory lock elsewhere we fail as the lock is still in use.

I'm not sure how quickly Postgres should be responding to the session ending and releasing the lock, I assume very quickly, but I started thinking about what happens with connection pooling.

For example, pgBouncer [does not support session locks](https://www.pgbouncer.org/features.html) when in transaction pooling mode, and generally unless advisory locks are explicitly supported poolers would mess with the expected behaviour of the advisory lock.

For that reason I suggest using the unpooled connection for the advisory lock. I also thought that we might want to explicitly unlock it but according to PG docs:
> pg_advisory_unlock_all () → void : Releases all session-level advisory locks held by the current session. (This function is implicitly invoked at session end, even if the client disconnects ungracefully.)

