### PR TITLE
docs: fix typo in OpenAPI spec

### DIFF
--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -154,7 +154,7 @@ paths:
           explode: true
           schema:
             type: object
-            pattenProperties:
+            patternProperties:
               '^\d+$':
                 type: string
           description: |-


### PR DESCRIPTION
Fixes a minor typo in the OpenAPI spec.