### PR TITLE
fix: Only log unexpected lock acquisition errors

### DIFF
--- a/.changeset/gentle-buttons-cover.md
+++ b/.changeset/gentle-buttons-cover.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Lower severity of expected lock acquisition errors

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -101,12 +101,11 @@ defmodule Electric.Postgres.LockConnection do
     {time, backoff} = :backoff.fail(backoff)
     tref = :erlang.start_timer(time, self(), :acquire_lock)
 
-    log_message =
-      "Failed to acquire lock #{state.lock_name} with reason #{inspect(error)} - retrying in #{inspect(time)}ms."
-
-    if is_expected_error?(error),
-      do: Logger.info(log_message),
-      else: Logger.error(log_message)
+    if not is_expected_error?(error),
+      do:
+        Logger.error(
+          "Failed to acquire lock #{state.lock_name} with reason #{inspect(error)} - retrying in #{inspect(time)}ms."
+        )
 
     notify_lock_acquisition_error(error, state)
 


### PR DESCRIPTION
The lock acquisition might take a while, and many PG providers might time out the statement execution - we're fine to just keep trying but we should only log unexpected errors.

We could argue that we don't even want to backoff and retry, and just immediately retry, but I'm worried that since the providers are timing statements out we might be better off not retrying immediately.