### PR TITLE
fix: Add timeout before considering replication connection successful

### DIFF
--- a/.changeset/gorgeous-kiwis-crash.md
+++ b/.changeset/gorgeous-kiwis-crash.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Allow replication connection some time before considering it succeeded so errors can come through.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -142,8 +142,10 @@ defmodule Electric.Connection.Manager do
 
   @connection_status_check_interval 10_000
 
-  # Time after establishing replication connection before we consider it successful,
-  # to allow for setup errors sent over the stream to be received.
+  # Time after establishing replication connection before we consider it successful
+  # from a retrying perspective, to allow for setup errors sent over the stream
+  # to be received. Any failure within this period will trigger a retry within
+  # the same reconnection period rather than a new one.
   @replication_liveness_confirmation_duration 5_000
 
   def child_spec(init_arg) do

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -144,7 +144,7 @@ defmodule Electric.Connection.Manager do
 
   # Time after establishing replication connection before we consider it successful,
   # to allow for setup errors sent over the stream to be received.
-  @replication_liveness_timeout 5_000
+  @replication_liveness_confirmation_duration 5_000
 
   def child_spec(init_arg) do
     %{
@@ -775,7 +775,7 @@ defmodule Electric.Connection.Manager do
     Process.send_after(
       self(),
       {:replication_liveness_timeout, state.replication_client_pid},
-      @replication_liveness_timeout
+      @replication_liveness_confirmation_duration
     )
 
     state = %State{state | current_step: :streaming}

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -142,6 +142,10 @@ defmodule Electric.Connection.Manager do
 
   @connection_status_check_interval 10_000
 
+  # Time after establishing replication connection before we consider it successful,
+  # to allow for setup errors sent over the stream to be received.
+  @replication_liveness_timeout 5_000
+
   def child_spec(init_arg) do
     %{
       id: __MODULE__,
@@ -526,6 +530,19 @@ defmodule Electric.Connection.Manager do
     handle_continue(step, state)
   end
 
+  # After a replication liveness timeout passes, if the same replication client is still
+  # alive, a call to `mark_connection_succeeded()` resets the backoff timer, so the next
+  # reconnection attempt will start from the minimum timeout and grow exponentially from
+  # there.
+  def handle_info(
+        {:replication_liveness_timeout, replication_client_pid},
+        %State{replication_client_pid: replication_client_pid} = state
+      ),
+      do: {:noreply, mark_connection_succeeded(state)}
+
+  def handle_info({:replication_liveness_timeout, _replication_client_pid}, state),
+    do: {:noreply, state}
+
   # Special-case the explicit shutdown of the supervision tree
   def handle_info({:EXIT, _, :shutdown}, state), do: {:noreply, state}
   def handle_info({:EXIT, _, {:shutdown, _}}, state), do: {:noreply, state}
@@ -748,15 +765,19 @@ defmodule Electric.Connection.Manager do
         :replication_client_streamed_first_message,
         %State{current_phase: :running, current_step: :waiting_for_streaming_confirmation} = state
       ) do
-    # The call to `mark_connection_succeeded()` resets the backoff timer, so the next
-    # reconnection attempt will start from the minimum timeout and grow exponentially from
-    # there.
     # When the replication connection is stuck in a reconnection loop, we only mark it as
-    # having succeeded after receiving confirmation that streaming replication has started.
+    # having succeeded after receiving confirmation that streaming replication has started
+    # and waiting for some time to ensure no errors are sent over the stream due to a failure
+    # to start replication.
     # This is the only way to be sure because it can still fail after we issue the
     # start_streaming() call, so marking it as having succeeded earlier would result in a
     # reconnection loop with no exponential backoff.
-    state = mark_connection_succeeded(state)
+    Process.send_after(
+      self(),
+      {:replication_liveness_timeout, state.replication_client_pid},
+      @replication_liveness_timeout
+    )
+
     state = %State{state | current_step: :streaming}
     {:noreply, state}
   end


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2691

Added a 5 second timeout - what we've observed is setup errors would come through within a few milliseconds, but I think allowing a few seconds is reasonable. A connection that falls over within 5 seconds of being established should be considered unsuccessful IMO.

I've avoided using timers and storing timer references, as I think we can get the job done by relying on the fact that if the replication client pid is the same between receiving the first message and the timeout passing, we can consider the connection successful.

Will test this ad hoc with @alco 's reproduction steps - we don't really have proper testing around the ConnMan so not sure what to do with this.