### PR TITLE
chore (examples): Do not deploy if there are no changes to the examples

### DIFF
--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.create-example-matrix.outputs.matrix }}
+      has_changes: ${{ steps.create-example-matrix.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v4
       - name: Check for changed files
@@ -41,17 +42,20 @@ jobs:
           
           # Initialize empty JSON array
           MATRIX='{"example":[]}'
+          HAS_CHANGES="false"
           
           # Add each changed directory to the matrix
           if [ -n "$CHANGED_DIRS" ]; then
             for dir in $CHANGED_DIRS; do
               name=$(basename $dir)
               MATRIX=$(echo $MATRIX | jq --arg name "$name" --arg path "examples/$name" '.example += [{"name": $name, "path": $path}]')
+              HAS_CHANGES="true"
             done
           fi
           
           # Use jq to properly format and escape the JSON
           echo "matrix=$(echo $MATRIX | jq -c '.')" >> $GITHUB_OUTPUT
+          echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
 
   deploy:
     name: Deploy ${{ matrix.example.name }}
@@ -59,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: changed-files
+    if: ${{ needs.changed-files.outputs.has_changes == 'true' }}
     strategy:
       matrix: ${{ fromJson(needs.changed-files.outputs.matrix) }}
 
@@ -120,7 +125,7 @@ jobs:
           fi
 
   comment:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.changed-files.outputs.has_changes == 'true'
     needs: [changed-files, deploy]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR fixes a problem with the deployment action in CI which would try to deploy with an empty matrix when none of the deployable examples changed.