### PR TITLE
feat: Idempotent `PublicationManager` calls

### DIFF
--- a/.changeset/dirty-cherries-poke.md
+++ b/.changeset/dirty-cherries-poke.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Make `PublicationManager` calls idempotent based on shape handles to ensure proper cleanups.

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -8,9 +8,11 @@ defmodule Electric.Replication.PublicationManager do
   alias Electric.Shapes.Shape
 
   @callback name(binary() | Keyword.t()) :: term()
-  @callback recover_shape(Shape.t(), Keyword.t()) :: :ok
-  @callback add_shape(Shape.t(), Keyword.t()) :: :ok
-  @callback remove_shape(Shape.t(), Keyword.t()) :: :ok
+  @callback recover_shape(Electric.ShapeCacheBehaviour.shape_handle(), Shape.t(), Keyword.t()) ::
+              :ok
+  @callback add_shape(Electric.ShapeCacheBehaviour.shape_handle(), Shape.t(), Keyword.t()) :: :ok
+  @callback remove_shape(Electric.ShapeCacheBehaviour.shape_handle(), Shape.t(), Keyword.t()) ::
+              :ok
   @callback refresh_publication(Keyword.t()) :: :ok
 
   defstruct [
@@ -22,6 +24,7 @@ defmodule Electric.Replication.PublicationManager do
     :scheduled_updated_ref,
     :retries,
     :waiters,
+    :shape_handles_tracked,
     :publication_name,
     :db_pool,
     :pg_version,
@@ -40,6 +43,7 @@ defmodule Electric.Replication.PublicationManager do
            update_debounce_timeout: timeout(),
            scheduled_updated_ref: nil | reference(),
            waiters: list(GenServer.from()),
+           shape_handles_tracked: MapSet.t(),
            publication_name: String.t(),
            db_pool: term(),
            pg_version: non_neg_integer(),
@@ -106,26 +110,26 @@ defmodule Electric.Replication.PublicationManager do
   end
 
   @impl __MODULE__
-  def add_shape(shape, opts \\ []) do
+  def add_shape(shape_id, shape, opts \\ []) do
     server = Access.get(opts, :server, name(opts))
 
-    case GenServer.call(server, {:add_shape, shape}) do
+    case GenServer.call(server, {:add_shape, shape_id, shape}) do
       :ok -> :ok
       {:error, err} -> raise err
     end
   end
 
   @impl __MODULE__
-  def recover_shape(shape, opts \\ []) do
+  def recover_shape(shape_id, shape, opts \\ []) do
     server = Access.get(opts, :server, name(opts))
-    GenServer.call(server, {:recover_shape, shape})
+    GenServer.call(server, {:recover_shape, shape_id, shape})
   end
 
   @impl __MODULE__
-  def remove_shape(shape, opts \\ []) do
+  def remove_shape(shape_id, shape, opts \\ []) do
     server = Access.get(opts, :server, name(opts))
 
-    case GenServer.call(server, {:remove_shape, shape}) do
+    case GenServer.call(server, {:remove_shape, shape_id, shape}) do
       :ok -> :ok
       {:error, err} -> raise err
     end
@@ -174,6 +178,7 @@ defmodule Electric.Replication.PublicationManager do
       scheduled_updated_ref: nil,
       retries: 0,
       waiters: [],
+      shape_handles_tracked: MapSet.new(),
       update_debounce_timeout: Map.get(opts, :update_debounce_timeout, @default_debounce_timeout),
       publication_name: opts.publication_name,
       db_pool: opts.db_pool,
@@ -192,18 +197,30 @@ defmodule Electric.Replication.PublicationManager do
   end
 
   @impl true
-  def handle_call({:add_shape, shape}, from, state) do
-    state = update_relation_filters_for_shape(shape, :add, state)
-    state = add_waiter(from, state)
-    state = schedule_update_publication(state.update_debounce_timeout, state)
-    {:noreply, state}
+  def handle_call({:add_shape, shape_handle, shape}, from, state) do
+    if is_tracking_shape_handle?(shape_handle, state) do
+      Logger.debug("Shape already tracked: #{inspect(shape_handle)}")
+      {:reply, :ok, state}
+    else
+      state = track_shape_handle(shape_handle, state)
+      state = update_relation_filters_for_shape(shape, :add, state)
+      state = add_waiter(from, state)
+      state = schedule_update_publication(state.update_debounce_timeout, state)
+      {:noreply, state}
+    end
   end
 
-  def handle_call({:remove_shape, shape}, from, state) do
-    state = update_relation_filters_for_shape(shape, :remove, state)
-    state = add_waiter(from, state)
-    state = schedule_update_publication(state.update_debounce_timeout, state)
-    {:noreply, state}
+  def handle_call({:remove_shape, shape_handle, shape}, from, state) do
+    if not is_tracking_shape_handle?(shape_handle, state) do
+      Logger.debug("Shape already not tracked: #{inspect(shape_handle)}")
+      {:reply, :ok, state}
+    else
+      state = untrack_shape_handle(shape_handle, state)
+      state = update_relation_filters_for_shape(shape, :remove, state)
+      state = add_waiter(from, state)
+      state = schedule_update_publication(state.update_debounce_timeout, state)
+      {:noreply, state}
+    end
   end
 
   def handle_call({:refresh_publication, forced?}, from, state) do
@@ -212,9 +229,15 @@ defmodule Electric.Replication.PublicationManager do
     {:noreply, state}
   end
 
-  def handle_call({:recover_shape, shape}, _from, state) do
-    state = update_relation_filters_for_shape(shape, :add, state)
-    {:reply, :ok, state}
+  def handle_call({:recover_shape, shape_handle, shape}, _from, state) do
+    if is_tracking_shape_handle?(shape_handle, state) do
+      Logger.debug("Shape already tracked: #{inspect(shape_handle)}")
+      {:reply, :ok, state}
+    else
+      state = track_shape_handle(shape_handle, state)
+      state = update_relation_filters_for_shape(shape, :add, state)
+      {:reply, :ok, state}
+    end
   end
 
   defguardp is_fatal(err)
@@ -530,5 +553,26 @@ defmodule Electric.Replication.PublicationManager do
   defp reply_to_waiters(reply, %__MODULE__{waiters: waiters} = state) do
     for from <- waiters, do: GenServer.reply(from, reply)
     %{state | waiters: []}
+  end
+
+  defp track_shape_handle(
+         shape_handle,
+         %__MODULE__{shape_handles_tracked: shape_handles_tracked} = state
+       ) do
+    %__MODULE__{state | shape_handles_tracked: MapSet.put(shape_handles_tracked, shape_handle)}
+  end
+
+  defp untrack_shape_handle(
+         shape_handle,
+         %__MODULE__{shape_handles_tracked: shape_handles_tracked} = state
+       ) do
+    %__MODULE__{state | shape_handles_tracked: MapSet.delete(shape_handles_tracked, shape_handle)}
+  end
+
+  defp is_tracking_shape_handle?(
+         shape_handle,
+         %__MODULE__{shape_handles_tracked: shape_handles_tracked}
+       ) do
+    MapSet.member?(shape_handles_tracked, shape_handle)
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -462,7 +462,7 @@ defmodule Electric.ShapeCache do
 
     case start_shape(shape_handle, shape, state) do
       {:ok, latest_offset} ->
-        publication_manager.recover_shape(shape, publication_manager_opts)
+        publication_manager.recover_shape(shape_handle, shape, publication_manager_opts)
         [LogOffset.extract_lsn(latest_offset)]
 
       :error ->

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -66,7 +66,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
                     shape_attrs(shape_handle, shape),
                     stack_id,
                     fn ->
-                      publication_manager.add_shape(shape, publication_manager_opts)
+                      publication_manager.add_shape(shape_handle, shape, publication_manager_opts)
                     end
                   )
 

--- a/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
@@ -73,7 +73,7 @@ defmodule Electric.Shapes.Monitor.CleanupTaskSupervisor do
       Logger.debug("cleaning shape data #{inspect(shape_handle)}")
 
       shape_status.remove_shape(shape_status_state, shape_handle)
-      publication_manager.remove_shape(shape, publication_manager_opts)
+      publication_manager.remove_shape(shape_handle, shape, publication_manager_opts)
 
       shape_handle
       |> Storage.for_shape(storage_impl)

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -8,6 +8,9 @@ defmodule Electric.Replication.PublicationManagerTest do
 
   import Support.ComponentSetup
 
+  @shape_handle_1 "shape_handle_1"
+  @shape_handle_2 "shape_handle_2"
+  @shape_handle_3 "shape_handle_3"
   @where_clause_1 %Expr{query: "id = '1'", used_refs: %{["id"] => :text}}
   @where_clause_2 %Expr{query: "id = '2'", used_refs: %{["id"] => :text}}
   @where_clause_enum %Expr{
@@ -66,7 +69,7 @@ defmodule Electric.Replication.PublicationManagerTest do
   describe "add_shape/2" do
     test "should add filters for single shape", %{opts: opts} do
       shape = generate_shape({"public", "items"}, @where_clause_1)
-      assert :ok == PublicationManager.add_shape(shape, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape, opts)
 
       assert_receive {:filters,
                       [
@@ -80,8 +83,8 @@ defmodule Electric.Replication.PublicationManagerTest do
     test "should accept multiple shapes for different relations", %{opts: opts} do
       shape1 = generate_shape({"public", "items"}, @where_clause_1)
       shape2 = generate_shape({"public", "other"})
-      assert :ok == PublicationManager.add_shape(shape1, opts)
-      assert :ok == PublicationManager.add_shape(shape2, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape1, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_2, shape2, opts)
 
       assert_receive {:filters,
                       [
@@ -97,9 +100,9 @@ defmodule Electric.Replication.PublicationManagerTest do
       shape1 = generate_shape({"public", "items"}, @where_clause_1)
       shape2 = generate_shape({"public", "items"}, @where_clause_2)
       shape3 = generate_shape({"public", "items"}, @where_clause_1)
-      assert :ok == PublicationManager.add_shape(shape1, opts)
-      assert :ok == PublicationManager.add_shape(shape2, opts)
-      assert :ok == PublicationManager.add_shape(shape3, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape1, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_2, shape2, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_3, shape3, opts)
 
       assert_receive {:filters,
                       [
@@ -113,8 +116,8 @@ defmodule Electric.Replication.PublicationManagerTest do
     test "should remove where clauses when one covers everything", %{opts: opts} do
       shape1 = generate_shape({"public", "items"}, @where_clause_1)
       shape2 = generate_shape({"public", "items"}, nil)
-      assert :ok == PublicationManager.add_shape(shape1, opts)
-      assert :ok == PublicationManager.add_shape(shape2, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape1, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_3, shape2, opts)
 
       assert_receive {:filters,
                       [
@@ -127,7 +130,7 @@ defmodule Electric.Replication.PublicationManagerTest do
 
     test "should ignore where clauses that use unsupported column types (enums)", %{opts: opts} do
       shape = generate_shape({"public", "items"}, @where_clause_enum)
-      assert :ok == PublicationManager.add_shape(shape, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape, opts)
 
       assert_receive {:filters,
                       [
@@ -141,8 +144,8 @@ defmodule Electric.Replication.PublicationManagerTest do
     test "should merge selected columns for same relation", %{opts: opts} do
       shape1 = generate_shape({"public", "items"}, nil, ["id", "value"])
       shape2 = generate_shape({"public", "items"}, nil, ["id", "potato"])
-      assert :ok == PublicationManager.add_shape(shape1, opts)
-      assert :ok == PublicationManager.add_shape(shape2, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape1, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_2, shape2, opts)
 
       assert_receive {:filters,
                       [
@@ -156,8 +159,8 @@ defmodule Electric.Replication.PublicationManagerTest do
     test "should remove selected columns when all selected by shape", %{opts: opts} do
       shape1 = generate_shape({"public", "items"}, nil, ["id", "value"])
       shape2 = generate_shape({"public", "items"}, nil, nil)
-      assert :ok == PublicationManager.add_shape(shape1, opts)
-      assert :ok == PublicationManager.add_shape(shape2, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape1, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_2, shape2, opts)
 
       assert_receive {:filters,
                       [
@@ -181,7 +184,7 @@ defmodule Electric.Replication.PublicationManagerTest do
           ["id", "value"]
         )
 
-      assert :ok == PublicationManager.add_shape(shape, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape, opts)
 
       assert_receive {:filters,
                       [
@@ -199,8 +202,8 @@ defmodule Electric.Replication.PublicationManagerTest do
       shape2 = generate_shape({"public", "items"}, @where_clause_2)
       shape3 = generate_shape({"public", "items"}, @where_clause_1)
 
-      task1 = Task.async(fn -> PublicationManager.add_shape(shape1, opts) end)
-      task2 = Task.async(fn -> PublicationManager.add_shape(shape2, opts) end)
+      task1 = Task.async(fn -> PublicationManager.add_shape(@shape_handle_1, shape1, opts) end)
+      task2 = Task.async(fn -> PublicationManager.add_shape(@shape_handle_2, shape2, opts) end)
 
       Task.await_many([task1, task2])
 
@@ -212,7 +215,7 @@ defmodule Electric.Replication.PublicationManagerTest do
                         }
                       ]}
 
-      assert :ok == PublicationManager.add_shape(shape3, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_3, shape3, opts)
 
       refute_receive {:filters, _}, 500
     end
@@ -252,17 +255,23 @@ defmodule Electric.Replication.PublicationManagerTest do
       shape3 = generate_shape({"public", "items_other"}, @where_clause_2)
 
       # should fall back to relation-only filtering
-      assert :ok == PublicationManager.add_shape(shape1, publication_manager_opts)
+      assert :ok ==
+               PublicationManager.add_shape(@shape_handle_1, shape1, publication_manager_opts)
+
       assert_receive {:got_filters, :with_where_clauses}
       assert_receive {:got_filters, :without_where_clauses}
       refute_receive {:got_filters, _}, 50
 
       # should remain in relation-only filtering mode after that, which
       # only updates the publication if the tracked relations change
-      assert :ok == PublicationManager.add_shape(shape2, publication_manager_opts)
+      assert :ok ==
+               PublicationManager.add_shape(@shape_handle_2, shape2, publication_manager_opts)
+
       refute_receive {:got_filters, _}, 50
 
-      assert :ok == PublicationManager.add_shape(shape3, publication_manager_opts)
+      assert :ok ==
+               PublicationManager.add_shape(@shape_handle_3, shape3, publication_manager_opts)
+
       assert_receive {:got_filters, :without_where_clauses}
       refute_receive {:got_filters, _}, 50
     end
@@ -270,7 +279,7 @@ defmodule Electric.Replication.PublicationManagerTest do
     @tag returned_relations: [{10, {"public", "another_table"}}]
     test "should broadcast clean_all_shapes_for_relations/2 to shape cache", %{opts: opts} do
       shape = generate_shape({"public", "items"}, @where_clause_1)
-      assert :ok == PublicationManager.add_shape(shape, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape, opts)
 
       assert_receive {:filters,
                       [
@@ -287,8 +296,8 @@ defmodule Electric.Replication.PublicationManagerTest do
   describe "remove_shape/2" do
     test "should remove single shape", %{opts: opts} do
       shape = generate_shape({"public", "items"}, @where_clause_1)
-      assert :ok == PublicationManager.add_shape(shape, opts)
-      assert :ok == PublicationManager.remove_shape(shape, opts)
+      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape, opts)
+      assert :ok == PublicationManager.remove_shape(@shape_handle_1, shape, opts)
 
       assert_receive {:filters, []}
     end
@@ -298,9 +307,9 @@ defmodule Electric.Replication.PublicationManagerTest do
       shape1 = generate_shape({"public", "items"}, @where_clause_1)
       shape2 = generate_shape({"public", "items"}, @where_clause_2)
       shape3 = generate_shape({"public", "items"}, @where_clause_1)
-      task1 = Task.async(fn -> PublicationManager.add_shape(shape1, opts) end)
-      task2 = Task.async(fn -> PublicationManager.add_shape(shape2, opts) end)
-      task3 = Task.async(fn -> PublicationManager.add_shape(shape3, opts) end)
+      task1 = Task.async(fn -> PublicationManager.add_shape(@shape_handle_1, shape1, opts) end)
+      task2 = Task.async(fn -> PublicationManager.add_shape(@shape_handle_2, shape2, opts) end)
+      task3 = Task.async(fn -> PublicationManager.add_shape(@shape_handle_3, shape3, opts) end)
 
       Task.await_many([task1, task2, task3])
 
@@ -312,7 +321,7 @@ defmodule Electric.Replication.PublicationManagerTest do
                         }
                       ]}
 
-      assert :ok == PublicationManager.remove_shape(shape1, opts)
+      assert :ok == PublicationManager.remove_shape(@shape_handle_1, shape1, opts)
 
       refute_receive {:filters, _}, 500
     end
@@ -321,7 +330,7 @@ defmodule Electric.Replication.PublicationManagerTest do
   describe "recover_shape/2" do
     test "should add filters for single shape without updating anything", %{opts: opts} do
       shape = generate_shape({"public", "items"}, @where_clause_1)
-      assert :ok == PublicationManager.recover_shape(shape, opts)
+      assert :ok == PublicationManager.recover_shape(@shape_handle_1, shape, opts)
 
       refute_receive {:filters, _}, 500
     end
@@ -330,7 +339,7 @@ defmodule Electric.Replication.PublicationManagerTest do
   describe "refresh_publication/2" do
     test "should update publication if there are changes to add", %{opts: opts} do
       shape = generate_shape({"public", "items"}, @where_clause_1)
-      assert :ok == PublicationManager.recover_shape(shape, opts)
+      assert :ok == PublicationManager.recover_shape(@shape_handle_1, shape, opts)
 
       refute_receive {:filters, _}, 500
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -59,7 +59,7 @@ defmodule Electric.ShapeCacheTest do
   @moduletag :tmp_dir
 
   defmodule TempPubManager do
-    def add_shape(_, opts) do
+    def add_shape(_handle, _, opts) do
       send(opts[:test_pid], {:called, :prepare_tables_fn})
     end
 
@@ -1010,7 +1010,7 @@ defmodule Electric.ShapeCacheTest do
       :started = ShapeCache.await_snapshot_start(shape_handle1, opts)
 
       Mock.PublicationManager
-      |> expect(:recover_shape, 1, fn _, _ -> :ok end)
+      |> expect(:recover_shape, 1, fn ^shape_handle1, _, _ -> :ok end)
       |> expect(:refresh_publication, 1, fn _ -> :ok end)
       |> allow(self(), fn -> Process.whereis(opts[:server]) end)
 
@@ -1063,8 +1063,8 @@ defmodule Electric.ShapeCacheTest do
       :started = ShapeCache.await_snapshot_start(shape_handle1, opts)
 
       Mock.PublicationManager
-      |> stub(:remove_shape, fn _, _ -> :ok end)
-      |> expect(:recover_shape, 1, fn _, _ -> :ok end)
+      |> stub(:remove_shape, fn ^shape_handle1, _, _ -> :ok end)
+      |> expect(:recover_shape, 1, fn ^shape_handle1, _, _ -> :ok end)
       |> expect(:refresh_publication, 1, fn _ -> raise "failed recovery" end)
       |> allow(self(), fn -> Shapes.Consumer.whereis(context[:stack_id], shape_handle1) end)
       |> allow(self(), fn -> Process.whereis(opts[:server]) end)

--- a/packages/sync-service/test/electric/shapes/monitor_test.exs
+++ b/packages/sync-service/test/electric/shapes/monitor_test.exs
@@ -296,7 +296,10 @@ defmodule Electric.Shapes.MonitorTest do
       exit_consumer(ctx, handle, {:raise, "boom"})
 
       assert_receive {:on_cleanup, ^handle}
-      assert_receive {Support.ComponentSetup.TestPublicationManager, :remove_shape, @shape}
+
+      assert_receive {Support.ComponentSetup.TestPublicationManager, :remove_shape, ^handle,
+                      @shape}
+
       assert_receive {TestStatus, :remove_shape, ^handle}
     end
 
@@ -306,7 +309,10 @@ defmodule Electric.Shapes.MonitorTest do
       exit_consumer(ctx, handle, {:shutdown, :cleanup})
 
       assert_receive {:on_cleanup, ^handle}
-      assert_receive {Support.ComponentSetup.TestPublicationManager, :remove_shape, @shape}
+
+      assert_receive {Support.ComponentSetup.TestPublicationManager, :remove_shape, ^handle,
+                      @shape}
+
       assert_receive {TestStatus, :remove_shape, ^handle}
     end
 

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -12,9 +12,9 @@ defmodule Support.ComponentSetup do
   defmodule NoopPublicationManager do
     @behaviour Electric.Replication.PublicationManager
     def name(_), do: :pub_man
-    def add_shape(_shape, _opts), do: :ok
-    def recover_shape(_shape, _opts), do: :ok
-    def remove_shape(_shape, _opts), do: :ok
+    def add_shape(_handle, _shape, _opts), do: :ok
+    def recover_shape(_handle, _shape, _opts), do: :ok
+    def remove_shape(_handle, _shape, _opts), do: :ok
     def refresh_publication(_opts), do: :ok
   end
 
@@ -27,18 +27,18 @@ defmodule Support.ComponentSetup do
 
     def name(_), do: TestPublicationManager
 
-    def add_shape(shape, %{parent: parent}) do
-      send(parent, {TestPublicationManager, :add_shape, shape})
+    def add_shape(handle, shape, %{parent: parent}) do
+      send(parent, {TestPublicationManager, :add_shape, handle, shape})
       :ok
     end
 
-    def recover_shape(shape, %{parent: parent}) do
-      send(parent, {TestPublicationManager, :recover_shape, shape})
+    def recover_shape(handle, shape, %{parent: parent}) do
+      send(parent, {TestPublicationManager, :recover_shape, handle, shape})
       :ok
     end
 
-    def remove_shape(shape, %{parent: parent}) do
-      send(parent, {TestPublicationManager, :remove_shape, shape})
+    def remove_shape(handle, shape, %{parent: parent}) do
+      send(parent, {TestPublicationManager, :remove_shape, handle, shape})
       :ok
     end
 


### PR DESCRIPTION
Ensures calls to `PublicationManager` are made with an associated shape handle to ensure idempotency and proper cleanups.

This prevents cases where the following happens:
1. Shape with handle X and shape definition A is added
2. Shape with handle Y != X and shape definition A is added
3. Shape X is removed/deleted - cleanup ends up trying to clean the associated publication more than once
4. Shape Y gets accidentally removed from the publication because of Shape X's cleanup

To avoid such cases, we also keep track of the shape handles we track - this is not a large memory overhead and ensures we no longer have to worry about this. We can improve the approach but tracking shape handles in the publication is something we definitely want to do.