### PR TITLE
fix: Ensure stack is active after long poll timeout

### DIFF
--- a/.changeset/hot-carpets-destroy.md
+++ b/.changeset/hot-carpets-destroy.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ensure stack is active after long poll timeout

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -86,4 +86,8 @@ defmodule Support.TestUtils do
     Electric.StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
     Electric.StatusMonitor.wait_for_messages_to_be_processed(stack_id)
   end
+
+  def set_status_to_errored(%{stack_id: stack_id}, error_message) do
+    Electric.StatusMonitor.mark_pg_lock_as_errored(stack_id, error_message)
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/2559

The steps to reproduce this issue, along with a host of other ones, was to essentially delete the database while a request was in-flight and waiting for updates (either new changes or a shape rotation).

If the database is deleted or the connection fails for any other reason, the stack is retrying and trying to set itself up, which means that the `LsnTracker` ETS table is not live, and thus the `global_last_seen_lsn` cannot be read.

Initially I tried to address that problem in isolation, but more kept coming, and I thought that the cleanest thing would be to ensure that the stack is actually up and running after a long poll timeout and return the same class of stack not ready errors if it is not.

This means potentially adding, at worst, an additional `stack_ready_timeout` ms on top of the `long_poll_timeout` to the response, the defaults are 5s and 20s respectively. I could modify the code to use a short `stack_ready_timeout` just for that case but I think keeping things simple for handling things falling over is cleaner. I think it's fine to provide a little bit of time if the stack is actually recovering rather than eagerly return 500s.

An alternative would be to subscribe to stack status notifications (I'd need to write the code for `StatusMonitor` to handle that) and _immediately_ return a 500, but I think that's not appropriate, as the stack might fall over due to a connection issue and recover within a few seconds - I think long poll requests should be able to wait quietly for the stack to potentially get back up and send over changes processed within the long poll timeout. That being said, it might be a cleaner approach (and more in line with our 'is stack ready' checks before starting to handle requests).

I've added a check that the registry exists as from my tests potentially the whole of the application might fall over (e.g. due to fatal connection errors) and therefore there is no registry from which to "clean up" the change listener, and we can ensure this way that decent/consistent error responses are sent back.