### PR TITLE
fix: Remove location header from 409 responses

### DIFF
--- a/.changeset/olive-garlics-clap.md
+++ b/.changeset/olive-garlics-clap.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Remove `location` header from 409 resopnses

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -124,32 +124,10 @@ defmodule Electric.Shapes.Api.Response do
     |> put_cache_headers(response)
     |> put_cursor_headers(response)
     |> put_etag_headers(response)
-    |> put_location_header(response)
     |> put_shape_handle_header(response)
     |> put_schema_header(response)
     |> put_up_to_date_header(response)
     |> put_offset_header(response)
-  end
-
-  defp put_location_header(conn, %__MODULE__{status: 409} = response) do
-    params =
-      conn.query_params
-      |> Map.put("handle", response.handle)
-      |> Map.put("offset", to_string(@before_all_offset))
-      |> Map.delete("live")
-      |> Map.delete("cursor")
-
-    query = Plug.Conn.Query.encode(params)
-
-    Plug.Conn.put_resp_header(
-      conn,
-      "location",
-      "#{conn.request_path}?#{query}"
-    )
-  end
-
-  defp put_location_header(conn, _response) do
-    conn
   end
 
   defp put_shape_handle_header(conn, %__MODULE__{handle: nil}) do

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -1282,9 +1282,6 @@ defmodule Electric.Plug.RouterTest do
 
       new_shape_handle = get_resp_header(conn, "electric-handle")
       assert new_shape_handle != shape_handle
-
-      assert get_resp_header(conn, "location") ==
-               "/v1/shape?handle=#{new_shape_handle}&offset=-1&table=items"
     end
 
     test "GET receives 409 to a newly created shape when shape handle is not found and no shape matches the shape definition",
@@ -1298,10 +1295,8 @@ defmodule Electric.Plug.RouterTest do
 
       assert %{status: 409} = conn
       assert conn.resp_body == Jason.encode!([%{headers: %{control: "must-refetch"}}])
-      new_shape_handle = get_resp_header(conn, "electric-handle")
-
-      assert get_resp_header(conn, "location") ==
-               "/v1/shape?handle=#{new_shape_handle}&offset=-1&table=items&unrelated=foo"
+      assert new_shape_handle = get_resp_header(conn, "electric-handle")
+      assert is_binary(new_shape_handle)
     end
 
     test "GET receives 409 when shape handle is not found but there is another shape matching the definition",

--- a/packages/typescript-client/test/cache.test.ts
+++ b/packages/typescript-client/test/cache.test.ts
@@ -324,28 +324,28 @@ describe(`HTTP Initial Data Caching`, { timeout: 30000 }, () => {
       {}
     )
     expect(liveRes.status).toBe(409)
-    const redirectLocation = liveRes.headers.get(`location`)
-    assert(redirectLocation)
+    const newShapeHandle = liveRes.headers.get(SHAPE_HANDLE_HEADER)
+    assert(newShapeHandle !== originalShapeHandle)
 
     const newCacheIgnoredSyncRes = await fetch(
-      `${proxyCacheBaseUrl}${redirectLocation}`,
+      `${proxyCacheBaseUrl}/v1/shape?table=${issuesTableUrl}&offset=-1&handle=${newShapeHandle}`,
       {}
     )
 
     expect(newCacheIgnoredSyncRes.status).toBe(200)
     expect(getCacheStatus(newCacheIgnoredSyncRes)).toBe(CacheStatus.MISS)
     const cacheBustedShapeHandle =
-      newCacheIgnoredSyncRes.headers.get(`electric-handle`)
+      newCacheIgnoredSyncRes.headers.get(SHAPE_HANDLE_HEADER)
     assert(cacheBustedShapeHandle)
     expect(cacheBustedShapeHandle).not.toBe(originalShapeHandle)
 
     // Then try do that and check that we get new shape handle
     const newInitialSyncRes = await fetch(
-      `${proxyCacheBaseUrl}${redirectLocation}`,
+      `${proxyCacheBaseUrl}/v1/shape?table=${issuesTableUrl}&offset=-1&handle=${newShapeHandle}`,
       {}
     )
     const cachedShapeHandle =
-      newInitialSyncRes.headers.get(`electric-handle`) ?? undefined
+      newInitialSyncRes.headers.get(SHAPE_HANDLE_HEADER) ?? undefined
     expect(newInitialSyncRes.status).toBe(200)
     expect(getCacheStatus(newInitialSyncRes)).toBe(CacheStatus.HIT)
     expect(

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -416,10 +416,6 @@ paths:
             The requested offset for the given shape no longer exists.
             Client should sync the shape using the relative path from the location header.
           headers:
-            location:
-              schema:
-                type: string
-              description: Relative path for syncing the latest version of the requested shape.
             electric-handle:
               schema:
                 type: string


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2504

Technically we were documenting this in our OpenAPI spec, so even though we don't use it in our clients and we don't advertise it much in our docs this _is_ a bit of a breaking change?

I'll let @KyleAMathews decide if we want to move forward with this, I've prepared this PR to get rid of it just to accelerate a decision on this.