### PR TITLE
chore (deployments): Pin changed-files action

### DIFF
--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
         with:
           path: "examples"
           diff_relative: true


### PR DESCRIPTION
We're pinning this action because some versions were compromised and we want to be sure we don't accidentally use one of those versions. This hash corresponds to the latest release: v46.0.5