### PR TITLE
feat: Add more standard `fetch` options to `ShapeStreamOptions`

### DIFF
--- a/.changeset/shaggy-nails-juggle.md
+++ b/.changeset/shaggy-nails-juggle.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Add more `fetch` options to `ShapeStreamOptions` that get carried forward to requests.

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -14,15 +14,7 @@ import {
 
 export type AllowedRequestOptions = Pick<
   RequestInit,
-  | `signal`
-  | `credentials`
-  | `redirect`
-  | `referrer`
-  | `referrerPolicy`
-  | `mode`
-  | `priority`
-  | `cache`
-  | `window`
+  `signal` | `credentials` | `redirect` | `referrer` | `referrerPolicy` | `mode`
 >
 
 // Some specific 4xx and 5xx HTTP status codes that we definitely
@@ -252,9 +244,6 @@ export function createFetchWithRequestOptions(
     referrer: requestOpts.referrer,
     referrerPolicy: requestOpts.referrerPolicy,
     mode: requestOpts.mode,
-    priority: requestOpts.priority,
-    cache: requestOpts.cache,
-    window: requestOpts.window,
   }
   return async (...args: Parameters<typeof fetchClient>) => {
     return fetchClient(args[0], {

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -12,6 +12,19 @@ import {
   MissingHeadersError,
 } from './error'
 
+export type AllowedRequestOptions = Pick<
+  RequestInit,
+  | `signal`
+  | `credentials`
+  | `redirect`
+  | `referrer`
+  | `referrerPolicy`
+  | `mode`
+  | `priority`
+  | `cache`
+  | `window`
+>
+
 // Some specific 4xx and 5xx HTTP status codes that we definitely
 // want to retry
 const HTTP_RETRY_STATUS_CODES = [429]
@@ -225,6 +238,18 @@ export function createFetchWithResponseHeadersCheck(
     }
 
     return response
+  }
+}
+
+export function createFetchWithRequestOptions(
+  fetchClient: typeof fetch,
+  requestOpts: AllowedRequestOptions
+) {
+  return async (...args: Parameters<typeof fetchClient>) => {
+    return fetchClient(args[0], {
+      ...requestOpts,
+      ...args[1],
+    })
   }
 }
 

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -245,10 +245,21 @@ export function createFetchWithRequestOptions(
   fetchClient: typeof fetch,
   requestOpts: AllowedRequestOptions
 ) {
+  const baseOpts = {
+    signal: requestOpts.signal,
+    credentials: requestOpts.credentials,
+    redirect: requestOpts.redirect,
+    referrer: requestOpts.referrer,
+    referrerPolicy: requestOpts.referrerPolicy,
+    mode: requestOpts.mode,
+    priority: requestOpts.priority,
+    cache: requestOpts.cache,
+    window: requestOpts.window,
+  }
   return async (...args: Parameters<typeof fetchClient>) => {
     return fetchClient(args[0], {
-      ...requestOpts,
-      ...args[1],
+      ...baseOpts,
+      ...(args[1] ?? {}),
     })
   }
 }

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -245,7 +245,7 @@ export function createFetchWithRequestOptions(
   fetchClient: typeof fetch,
   requestOpts: AllowedRequestOptions
 ) {
-  const baseOpts = {
+  const baseOpts: AllowedRequestOptions = {
     signal: requestOpts.signal,
     credentials: requestOpts.credentials,
     redirect: requestOpts.redirect,

--- a/packages/typescript-client/test/fetch.test.ts
+++ b/packages/typescript-client/test/fetch.test.ts
@@ -577,7 +577,6 @@ describe(`createFetchWithRequestOptions`, () => {
   const mockRequestOptions: AllowedRequestOptions = {
     credentials: `include`,
     mode: `cors`,
-    cache: `no-store`,
   }
 
   it(`should merge provided request options with fetch call options`, async () => {
@@ -592,7 +591,6 @@ describe(`createFetchWithRequestOptions`, () => {
       expect.objectContaining({
         credentials: `include`,
         mode: `cors`,
-        cache: `no-store`,
         headers: { 'X-Test': `value` },
       })
     )
@@ -600,14 +598,14 @@ describe(`createFetchWithRequestOptions`, () => {
 
   it(`should prioritize fetch call options over default options when conflicts exist`, async () => {
     const customFetch = createFetchWithRequestOptions(mockFetch, {
-      cache: `no-store`,
+      mode: `cors`,
     })
-    await customFetch(`https://example.com`, { cache: `force-cache` })
+    await customFetch(`https://example.com`, { mode: `navigate` })
 
     expect(mockFetch).toHaveBeenCalledWith(
       `https://example.com`,
       expect.objectContaining({
-        cache: `force-cache`,
+        mode: `navigate`,
       })
     )
   })


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2571

Adds more standard `fetch` options to `ShapeStreamOptions` since we already had `headers` and `signal`.

Technically already possible via a custom `fetchClient` but this PR addresses the mentioned issue to ensure we make a decision on whether we want this or not.

I don't love that we're "polluting" the `ShapeStreamOptions` at the root level with more fetch options, as we could potentially want some of these keys for our own purposes (and we could've instead had a `requestOpts` key with all of these).

Happy to hear feedback on this.