### PR TITLE
feat: Log slow snapshot queries for ease of debugging

### DIFF
--- a/.changeset/cyan-seals-shout.md
+++ b/.changeset/cyan-seals-shout.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Log slow snapshot queries along with the actual query used for ease of debugging.

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -212,8 +212,9 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
               Logger.warning(
                 "Slow query for handle #{shape_handle} took #{total_query_time}ms, shape: #{inspect(shape)}, query: #{query_str}",
-                query_str: query_str,
-                stack_id: stack_id
+                stack_id: stack_id,
+                shape_handle: shape_handle,
+                query_str: query_str
               )
             end
 

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -5,211 +5,248 @@ defmodule Electric.Shapes.QueryingTest do
   alias Electric.Shapes.Shape
   alias Electric.Shapes.Querying
 
-  test "should give information about the table and the result stream", %{db_conn: conn} do
-    Postgrex.query!(
-      conn,
-      """
-      CREATE TABLE items (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        value INTEGER
+  describe "strema_initial_data/3" do
+    test "should give information about the table and the result stream", %{db_conn: conn} do
+      Postgrex.query!(
+        conn,
+        """
+        CREATE TABLE items (
+          id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+          value INTEGER
+        )
+        """,
+        []
       )
-      """,
-      []
-    )
 
-    Postgrex.query!(conn, "INSERT INTO items (value) VALUES (1), (2), (3), (4), (5)", [])
-    shape = Shape.new!("items", inspector: {DirectInspector, conn})
+      Postgrex.query!(conn, "INSERT INTO items (value) VALUES (1), (2), (3), (4), (5)", [])
+      shape = Shape.new!("items", inspector: {DirectInspector, conn})
 
-    assert [
-             %{
-               key: ~S["public"."items"/"1"],
-               value: %{id: "1", value: "1"},
-               headers: %{operation: "insert", relation: ["public", "items"]}
-             },
-             %{
-               key: ~S["public"."items"/"2"],
-               value: %{id: "2", value: "2"},
-               headers: %{operation: "insert", relation: ["public", "items"]}
-             },
-             %{
-               key: ~S["public"."items"/"3"],
-               value: %{id: "3", value: "3"},
-               headers: %{operation: "insert", relation: ["public", "items"]}
-             },
-             %{
-               key: ~S["public"."items"/"4"],
-               value: %{id: "4", value: "4"},
-               headers: %{operation: "insert", relation: ["public", "items"]}
-             },
-             %{
-               key: ~S["public"."items"/"5"],
-               value: %{id: "5", value: "5"},
-               headers: %{operation: "insert", relation: ["public", "items"]}
-             }
-           ] == decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
+      assert [
+               %{
+                 key: ~S["public"."items"/"1"],
+                 value: %{id: "1", value: "1"},
+                 headers: %{operation: "insert", relation: ["public", "items"]}
+               },
+               %{
+                 key: ~S["public"."items"/"2"],
+                 value: %{id: "2", value: "2"},
+                 headers: %{operation: "insert", relation: ["public", "items"]}
+               },
+               %{
+                 key: ~S["public"."items"/"3"],
+                 value: %{id: "3", value: "3"},
+                 headers: %{operation: "insert", relation: ["public", "items"]}
+               },
+               %{
+                 key: ~S["public"."items"/"4"],
+                 value: %{id: "4", value: "4"},
+                 headers: %{operation: "insert", relation: ["public", "items"]}
+               },
+               %{
+                 key: ~S["public"."items"/"5"],
+                 value: %{id: "5", value: "5"},
+                 headers: %{operation: "insert", relation: ["public", "items"]}
+               }
+             ] == decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
+    end
+
+    test "respects the where clauses", %{db_conn: conn} do
+      Postgrex.query!(
+        conn,
+        """
+        CREATE TABLE items (
+          id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+          value INTEGER
+        )
+        """,
+        []
+      )
+
+      Postgrex.query!(conn, "INSERT INTO items (value) VALUES (1), (2), (3), (4), (5)", [])
+      shape = Shape.new!("items", where: "value > 3", inspector: {DirectInspector, conn})
+
+      assert [
+               %{key: ~S["public"."items"/"4"], value: %{value: "4"}},
+               %{key: ~S["public"."items"/"5"], value: %{value: "5"}}
+             ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
+    end
+
+    test "respects the where clauses with params", %{db_conn: conn} do
+      Postgrex.query!(
+        conn,
+        """
+        CREATE TABLE items (
+          id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+          value INTEGER,
+          test INTEGER[]
+        )
+        """,
+        []
+      )
+
+      Postgrex.query!(
+        conn,
+        "INSERT INTO items (value, test) VALUES (1, '{1,2,3}'), (2, '{4,5,6}'), (3, '{7,8,9}'), (4, '{10,11,12}'), (5, '{12,14,15}')",
+        []
+      )
+
+      shape =
+        Shape.new!("items",
+          where: "test @> $1",
+          inspector: {DirectInspector, conn},
+          params: %{"1" => "{12}"}
+        )
+
+      assert [
+               %{key: ~S["public"."items"/"4"], value: %{value: "4"}},
+               %{key: ~S["public"."items"/"5"], value: %{value: "5"}}
+             ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
+    end
+
+    test "allows column names to have special characters", %{db_conn: conn} do
+      Postgrex.query!(
+        conn,
+        """
+        CREATE TABLE items (
+          id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+          "col with ""' in it" INTEGER
+        )
+        """,
+        []
+      )
+
+      Postgrex.query!(
+        conn,
+        ~s|INSERT INTO items ("col with ""' in it") VALUES (1)|,
+        []
+      )
+
+      shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+      assert [
+               %{key: ~S["public"."items"/"1"], value: %{"col with \"' in it": "1"}}
+             ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
+    end
+
+    test "works with composite PKs", %{db_conn: conn} do
+      Postgrex.query!(
+        conn,
+        """
+        CREATE TABLE items (
+          id1 INTEGER,
+          id2 INTEGER,
+          "test" INTEGER,
+          PRIMARY KEY (id1, id2)
+        )
+        """,
+        []
+      )
+
+      Postgrex.query!(
+        conn,
+        ~s|INSERT INTO items (id1, id2, "test") VALUES (1, 2, 1), (3,4, 2)|,
+        []
+      )
+
+      shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+      assert [
+               %{key: ~S["public"."items"/"1"/"2"], value: %{test: "1"}},
+               %{key: ~S["public"."items"/"3"/"4"], value: %{test: "2"}}
+             ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
+    end
+
+    test "works with null values & values with special characters", %{db_conn: conn} do
+      Postgrex.query!(
+        conn,
+        """
+        CREATE TABLE items (
+          id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+          value TEXT
+        )
+        """,
+        []
+      )
+
+      Postgrex.query!(
+        conn,
+        ~s|INSERT INTO items (value) VALUES ('1'), (NULL), ('"test\\x0001\n"')|,
+        []
+      )
+
+      shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+      assert [
+               %{key: ~S["public"."items"/"1"], value: %{value: "1"}},
+               %{key: ~S["public"."items"/"2"], value: %{value: nil}},
+               %{key: ~S["public"."items"/"3"], value: %{value: ~s["test\\x0001\n"]}}
+             ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
+    end
   end
 
-  test "respects the where clauses", %{db_conn: conn} do
-    Postgrex.query!(
-      conn,
-      """
-      CREATE TABLE items (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        value INTEGER
+  describe "strema_initial_data/4" do
+    test "splits the result into chunks according to the chunk size threshold", %{db_conn: conn} do
+      Postgrex.query!(
+        conn,
+        """
+        CREATE TABLE items (
+          id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+          value TEXT
+        )
+        """,
+        []
       )
-      """,
-      []
-    )
 
-    Postgrex.query!(conn, "INSERT INTO items (value) VALUES (1), (2), (3), (4), (5)", [])
-    shape = Shape.new!("items", where: "value > 3", inspector: {DirectInspector, conn})
+      Postgrex.query!(
+        conn,
+        ~s|INSERT INTO items (value) VALUES ('1'), (NULL), ('"test\\x0001\n"')|,
+        []
+      )
 
-    assert [
-             %{key: ~S["public"."items"/"4"], value: %{value: "4"}},
-             %{key: ~S["public"."items"/"5"], value: %{value: "5"}}
-           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
+      shape = Shape.new!("items", inspector: {DirectInspector, conn})
+
+      assert [
+               %{key: ~S["public"."items"/"1"], value: %{value: "1"}},
+               :chunk_boundary,
+               %{key: ~S["public"."items"/"2"], value: %{value: nil}},
+               :chunk_boundary,
+               %{key: ~S["public"."items"/"3"], value: %{value: ~s["test\\x0001\n"]}},
+               :chunk_boundary
+             ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape, 10))
+    end
   end
 
-  test "respects the where clauses with params", %{db_conn: conn} do
-    Postgrex.query!(
-      conn,
-      """
-      CREATE TABLE items (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        value INTEGER,
-        test INTEGER[]
-      )
-      """,
-      []
-    )
-
-    Postgrex.query!(
-      conn,
-      "INSERT INTO items (value, test) VALUES (1, '{1,2,3}'), (2, '{4,5,6}'), (3, '{7,8,9}'), (4, '{10,11,12}'), (5, '{12,14,15}')",
-      []
-    )
-
-    shape =
-      Shape.new!("items",
-        where: "test @> $1",
-        inspector: {DirectInspector, conn},
-        params: %{"1" => "{12}"}
+  describe "build_initial_data_query/1" do
+    test "builds the initial data query", %{db_conn: conn} do
+      Postgrex.query!(
+        conn,
+        """
+        CREATE TABLE items (
+          id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+          value INTEGER,
+          test INTEGER[]
+        )
+        """,
+        []
       )
 
-    assert [
-             %{key: ~S["public"."items"/"4"], value: %{value: "4"}},
-             %{key: ~S["public"."items"/"5"], value: %{value: "5"}}
-           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
-  end
+      shape =
+        Shape.new!("items",
+          where: "test @> $1",
+          inspector: {DirectInspector, conn},
+          params: %{"1" => "{12}"}
+        )
 
-  test "allows column names to have special characters", %{db_conn: conn} do
-    Postgrex.query!(
-      conn,
-      """
-      CREATE TABLE items (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        "col with ""' in it" INTEGER
-      )
-      """,
-      []
-    )
-
-    Postgrex.query!(
-      conn,
-      ~s|INSERT INTO items ("col with ""' in it") VALUES (1)|,
-      []
-    )
-
-    shape = Shape.new!("items", inspector: {DirectInspector, conn})
-
-    assert [
-             %{key: ~S["public"."items"/"1"], value: %{"col with \"' in it": "1"}}
-           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
-  end
-
-  test "works with composite PKs", %{db_conn: conn} do
-    Postgrex.query!(
-      conn,
-      """
-      CREATE TABLE items (
-        id1 INTEGER,
-        id2 INTEGER,
-        "test" INTEGER,
-        PRIMARY KEY (id1, id2)
-      )
-      """,
-      []
-    )
-
-    Postgrex.query!(
-      conn,
-      ~s|INSERT INTO items (id1, id2, "test") VALUES (1, 2, 1), (3,4, 2)|,
-      []
-    )
-
-    shape = Shape.new!("items", inspector: {DirectInspector, conn})
-
-    assert [
-             %{key: ~S["public"."items"/"1"/"2"], value: %{test: "1"}},
-             %{key: ~S["public"."items"/"3"/"4"], value: %{test: "2"}}
-           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
-  end
-
-  test "works with null values & values with special characters", %{db_conn: conn} do
-    Postgrex.query!(
-      conn,
-      """
-      CREATE TABLE items (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        value TEXT
-      )
-      """,
-      []
-    )
-
-    Postgrex.query!(
-      conn,
-      ~s|INSERT INTO items (value) VALUES ('1'), (NULL), ('"test\\x0001\n"')|,
-      []
-    )
-
-    shape = Shape.new!("items", inspector: {DirectInspector, conn})
-
-    assert [
-             %{key: ~S["public"."items"/"1"], value: %{value: "1"}},
-             %{key: ~S["public"."items"/"2"], value: %{value: nil}},
-             %{key: ~S["public"."items"/"3"], value: %{value: ~s["test\\x0001\n"]}}
-           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape))
-  end
-
-  test "splits the result into chunks according to the chunk size threshold", %{db_conn: conn} do
-    Postgrex.query!(
-      conn,
-      """
-      CREATE TABLE items (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        value TEXT
-      )
-      """,
-      []
-    )
-
-    Postgrex.query!(
-      conn,
-      ~s|INSERT INTO items (value) VALUES ('1'), (NULL), ('"test\\x0001\n"')|,
-      []
-    )
-
-    shape = Shape.new!("items", inspector: {DirectInspector, conn})
-
-    assert [
-             %{key: ~S["public"."items"/"1"], value: %{value: "1"}},
-             :chunk_boundary,
-             %{key: ~S["public"."items"/"2"], value: %{value: nil}},
-             :chunk_boundary,
-             %{key: ~S["public"."items"/"3"], value: %{value: ~s["test\\x0001\n"]}},
-             :chunk_boundary
-           ] = decode_stream(Querying.stream_initial_data(conn, "dummy-stack-id", shape, 10))
+      assert {"SELECT '{' || '\"key\":' || to_json('\"public\".\"items\"' " <>
+                "|| '/\"' || coalesce(replace(\"id\"::text, '/', '//'), '') " <>
+                "|| '\"')::text || ',' || '\"value\":{' " <>
+                "|| '\"id\":' || coalesce(coalesce(to_json(\"id\"::text)::text , 'null') , 'null') " <>
+                "|| ',' || '\"test\":' || coalesce(coalesce(to_json(\"test\"::text)::text , 'null') , 'null') " <>
+                "|| ',' || '\"value\":' || coalesce(coalesce(to_json(\"value\"::text)::text , 'null') , 'null') " <>
+                "|| '}' || ',' || '\"headers\":{\"operation\":\"insert\",\"relation\":[\"public\",\"items\"]}' " <>
+                "|| '}' FROM public.items  WHERE test @> '{12}'::int4[]",
+              []} = Querying.build_initial_data_query(shape)
+    end
   end
 
   defp decode_stream(stream),


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2437

Implementing a feature request by @KyleAMathews - logs slow queries (that take longer than 1 second) as a warning, along wit the actual query executed so it can be more easily debugged.

I don't have a good way to test this however, any advice appreciated.