### PR TITLE
elixir-client: put server errors in the stream rather than raise

### DIFF
--- a/.changeset/lovely-files-worry.md
+++ b/.changeset/lovely-files-worry.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": minor
+---
+
+Allow server errors to be streamed to the consumer rather than raising


### PR DESCRIPTION
client streams now have an `errors: :raise | :stream` that allows for configuration of the error handling. the default is `:raise` which preserves the current behaviour of raising on server errors but if you set `errors: :stream` then the error will be returned as a message in the stream. 

this is useful for Phoenix.Sync.LiveStream where the stream is run in a separate process so exceptions don't propagate back to the stream consumer