### PR TITLE
fix: Do not fail fast on matrix jobs

### DIFF
--- a/.github/workflows/deploy_all_examples.yml
+++ b/.github/workflows/deploy_all_examples.yml
@@ -13,8 +13,8 @@ jobs:
     environment: "Production"
     runs-on: ubuntu-latest
     continue-on-error: true
-    needs: changed-files
     strategy:
+      fail-fast: false
       matrix:
         example:
           - name: yjs

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -39,11 +39,11 @@ jobs:
         run: |
           # Get changed example directories
           CHANGED_DIRS="${{ steps.changed-files.outputs.all_changed_files }}"
-          
+
           # Initialize empty JSON array
           MATRIX='{"example":[]}'
           HAS_CHANGES="false"
-          
+
           # Add each changed directory to the matrix
           if [ -n "$CHANGED_DIRS" ]; then
             for dir in $CHANGED_DIRS; do
@@ -52,7 +52,7 @@ jobs:
               HAS_CHANGES="true"
             done
           fi
-          
+
           # Use jq to properly format and escape the JSON
           echo "matrix=$(echo $MATRIX | jq -c '.')" >> $GITHUB_OUTPUT
           echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
@@ -65,6 +65,7 @@ jobs:
     needs: changed-files
     if: ${{ needs.changed-files.outputs.has_changes == 'true' }}
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.changed-files.outputs.matrix) }}
 
     outputs:
@@ -136,7 +137,7 @@ jobs:
           script: |
             // Get the matrix of examples that were deployed
             const matrix = JSON.parse(${{ toJSON(needs.changed-files.outputs.matrix) }})
-            
+
             const urls = {
               yjs: "${{ needs.deploy.outputs.yjs }}",
               "linearlite-read-only": "${{ needs.deploy.outputs.linearlite-read-only }}",

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -22,6 +22,7 @@ jobs:
       run:
         working-directory: packages/sync-service
     strategy:
+      fail-fast: false
       matrix:
         postgres_version: [14, 15, 17]
     env:


### PR DESCRIPTION
Avoid fail fast strategy for the following:

- elxir tests on various PG versions: we might suceed in one and fail in another, or might flake in one and not in another in our case, we should not be cancelling the rest
- deploy examples (dispatch and regular): if one example fails to deploy it should not cancel the other deployments - in fact this could lead to a bad SST state @kevin-dp 