### PR TITLE
Conditionally compile Electric.TelemetryTest when telemetry is enabled

### DIFF
--- a/packages/sync-service/test/electric/telemetry/application_telemetry_test.exs
+++ b/packages/sync-service/test/electric/telemetry/application_telemetry_test.exs
@@ -1,35 +1,39 @@
-defmodule Electric.TelemetryTest do
-  use ExUnit.Case, async: true
+use Electric.Telemetry
 
-  alias Electric.Telemetry.ApplicationTelemetry
+with_telemetry [Electric.Telemetry.ApplicationTelemetry] do
+  defmodule Electric.TelemetryTest do
+    use ExUnit.Case, async: true
 
-  @moduletag :telemetry_target
+    alias Electric.Telemetry.ApplicationTelemetry
 
-  describe "get_system_memory_usage" do
-    test "returns calculated memory stats" do
-      case :os.type() do
-        {:unix, :darwin} ->
-          assert %{
-                   total_memory: _,
-                   available_memory: _,
-                   free_memory: _,
-                   used_memory: _,
-                   resident_memory: _
-                 } = ApplicationTelemetry.get_system_memory_usage()
+    @moduletag :telemetry_target
 
-        _ ->
-          assert %{
-                   total_memory: _,
-                   available_memory: _,
-                   buffered_memory: _,
-                   cached_memory: _,
-                   free_memory: _,
-                   used_memory: _,
-                   resident_memory: _,
-                   total_swap: _,
-                   free_swap: _,
-                   used_swap: _
-                 } = ApplicationTelemetry.get_system_memory_usage()
+    describe "get_system_memory_usage" do
+      test "returns calculated memory stats" do
+        case :os.type() do
+          {:unix, :darwin} ->
+            assert %{
+                     total_memory: _,
+                     available_memory: _,
+                     free_memory: _,
+                     used_memory: _,
+                     resident_memory: _
+                   } = ApplicationTelemetry.get_system_memory_usage()
+
+          _ ->
+            assert %{
+                     total_memory: _,
+                     available_memory: _,
+                     buffered_memory: _,
+                     cached_memory: _,
+                     free_memory: _,
+                     used_memory: _,
+                     resident_memory: _,
+                     total_swap: _,
+                     free_swap: _,
+                     used_swap: _
+                   } = ApplicationTelemetry.get_system_memory_usage()
+        end
       end
     end
   end


### PR DESCRIPTION
This removes the warning about missing functions when running `mix test`.