### PR TITLE
docs: Update source_secret to secret in proxy example

### DIFF
--- a/examples/proxy-auth/app/shape-proxy/route.ts
+++ b/examples/proxy-auth/app/shape-proxy/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
 
   if (process.env.ELECTRIC_SOURCE_SECRET) {
     originUrl.searchParams.set(
-      `source_secret`,
+      `secret`,
       process.env.ELECTRIC_SOURCE_SECRET
     )
   }


### PR DESCRIPTION
It seems `source_secret` was renamed to `secret` #2475
But this proxy example was not updated accordingly.

Updating this example should help users avoid confusion and potential 401 errors.

