### PR TITLE
sync-service: Use separate mock modules per-test

### DIFF
--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -1,12 +1,12 @@
 defmodule Electric.Plug.DeleteShapePlugTest do
   use ExUnit.Case, async: true
+  use Support.Mock
 
   alias Electric.Plug.DeleteShapePlug
   alias Electric.Shapes.Shape
 
   import Support.ComponentSetup
   import Support.TestUtils, only: [set_status_to_active: 1]
-  alias Support.Mock
 
   import Mox
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -1,5 +1,7 @@
 defmodule Electric.Plug.ServeShapePlugTest do
   use ExUnit.Case, async: true
+  use Support.Mock
+
   import Plug.Conn
 
   alias Electric.Postgres.Lsn
@@ -10,8 +12,6 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
   import Support.ComponentSetup
   import Support.TestUtils, only: [set_status_to_active: 1]
-
-  alias Support.Mock
 
   import Mox
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -1,6 +1,7 @@
 defmodule Electric.Replication.ShapeLogCollectorTest do
   use ExUnit.Case, async: false
   use Repatch.ExUnit
+  use Support.Mock
 
   alias Electric.LsnTracker
   alias Electric.Postgres.Lsn
@@ -11,7 +12,6 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   alias Electric.Shapes.Shape
   alias Electric.StatusMonitor
 
-  alias Support.Mock
   alias Support.StubInspector
   alias Support.RepatchExt
 

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -1,12 +1,12 @@
 defmodule Electric.ShapeCache.ShapeStatusTest do
   use ExUnit.Case, async: true
+  use Support.Mock
 
   alias Electric.Replication.LogOffset
   alias Electric.ShapeCache.ShapeStatus
   alias Electric.Shapes.Shape
   alias Support.StubInspector
 
-  alias Support.Mock
   import Mox
 
   setup :verify_on_exit!

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -1,9 +1,9 @@
 defmodule Electric.ShapeCache.StorageTest do
   use ExUnit.Case, async: true
+  use Support.Mock
+
   alias Electric.ShapeCache.Storage
   alias Electric.Replication.LogOffset
-
-  alias Support.Mock
 
   import Mox
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1,5 +1,6 @@
 defmodule Electric.ShapeCacheTest do
   use ExUnit.Case, async: true
+  use Support.Mock
 
   alias Electric.Replication.Changes
   alias Electric.Replication.LogOffset
@@ -17,7 +18,6 @@ defmodule Electric.ShapeCacheTest do
   import Support.DbSetup
   import Support.DbStructureSetup
   import Support.TestUtils
-  alias Support.Mock
 
   @shape %Shape{
     root_table: {"public", "items"},

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -1,13 +1,12 @@
 defmodule Electric.Shapes.ApiTest do
   use ExUnit.Case, async: true
   use Plug.Test
+  use Support.Mock
 
   alias Electric.Postgres.Lsn
   alias Electric.Replication.LogOffset
   alias Electric.Shapes.Api
   alias Electric.Shapes.Shape
-
-  alias Support.Mock
 
   import Support.ComponentSetup
   import Support.TestUtils, only: [set_status_to_active: 1, set_status_to_errored: 2]

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -1,5 +1,6 @@
 defmodule Electric.Shapes.ConsumerTest do
   use ExUnit.Case, async: true
+  use Support.Mock
 
   alias Electric.Postgres.Lsn
   alias Electric.Replication.Changes.{Transaction, Relation}
@@ -12,7 +13,6 @@ defmodule Electric.Shapes.ConsumerTest do
   alias Electric.Shapes.Shape
   alias Electric.Shapes.Consumer
 
-  alias Support.Mock
   alias Support.StubInspector
 
   import Support.ComponentSetup

--- a/packages/sync-service/test/support/mocks.ex
+++ b/packages/sync-service/test/support/mocks.ex
@@ -1,11 +1,17 @@
 defmodule Support.Mock do
-  Mox.defmock(Support.Mock.Storage, for: Electric.ShapeCache.Storage)
-  Mox.defmock(Support.Mock.ShapeCache, for: Electric.ShapeCacheBehaviour)
-  Mox.defmock(Support.Mock.Inspector, for: Electric.Postgres.Inspector)
-  Mox.defmock(Support.Mock.ShapeStatus, for: Electric.ShapeCache.ShapeStatusBehaviour)
-  Mox.defmock(Support.Mock.PersistentKV, for: Electric.PersistentKV)
+  defmacro __using__(_args) do
+    quote do
+      Mox.defmock(__MODULE__.Mock.Storage, for: Electric.ShapeCache.Storage)
+      Mox.defmock(__MODULE__.Mock.ShapeCache, for: Electric.ShapeCacheBehaviour)
+      Mox.defmock(__MODULE__.Mock.Inspector, for: Electric.Postgres.Inspector)
+      Mox.defmock(__MODULE__.Mock.ShapeStatus, for: Electric.ShapeCache.ShapeStatusBehaviour)
+      Mox.defmock(__MODULE__.Mock.PersistentKV, for: Electric.PersistentKV)
 
-  Mox.defmock(Support.Mock.PublicationManager,
-    for: Electric.Replication.PublicationManager
-  )
+      Mox.defmock(__MODULE__.Mock.PublicationManager,
+        for: Electric.Replication.PublicationManager
+      )
+
+      alias __MODULE__.Mock
+    end
+  end
 end


### PR DESCRIPTION
keeping the same Mock.* naming

This prevents expectations defined in simultaneously executing tests from clashing. I think this is the cause of various flakes in the CI - we define expectations on `Support.Mock.Behaviour` and occasionally a parallel test hits that expectation but fails because it's coming from an unregistered pid.

This pr gives every test module its own set of `__MODULE__.Mock.Behaviour` mocks to define expectations on but keeps the same usage in the tests.