### PR TITLE
Try partitioning shape monitor

### DIFF
--- a/packages/sync-service/lib/electric/shapes/monitor.ex
+++ b/packages/sync-service/lib/electric/shapes/monitor.ex
@@ -2,12 +2,16 @@ defmodule Electric.Shapes.Monitor do
   use Supervisor
 
   alias __MODULE__.RefCounter
+  alias __MODULE__.Partitions
+
+  require Logger
 
   @type stack_id :: Electric.stack_id()
   @type shape_handle :: Electric.ShapeCache.shape_handle()
 
   @schema NimbleOptions.new!(
             stack_id: [type: :string, required: true],
+            partitions: [type: :pos_integer],
             storage: [type: :mod_arg, required: true],
             shape_status: [type: :mod_arg, required: true],
             publication_manager: [type: :mod_arg, required: true],
@@ -25,41 +29,106 @@ defmodule Electric.Shapes.Monitor do
     end
   end
 
+  @doc false
+  def partitions(stack_id) when is_binary(stack_id) do
+    Partitions.count(stack_id)
+  end
+
+  def partitions(n) when is_integer(n) do
+    n
+  end
+
+  defp partition_list(stack_id) do
+    0..(partitions(stack_id) - 1)
+  end
+
+  @doc false
+  def shape_partition(stack_id, shape_handle) do
+    :erlang.phash2(shape_handle, partitions(stack_id))
+  end
+
   @doc """
   Register the current process as a reader of the given shape.
   """
   @spec register_reader(stack_id(), shape_handle(), pid()) :: :ok
-  defdelegate register_reader(stack_id, shape_handle, pid \\ self()), to: RefCounter
+  def register_reader(stack_id, shape_handle, pid \\ self()) do
+    # test (quickly) if any other partition has this pid registered for another handle
+    # if so, trigger the removal of that reader then register as usual
+    partitions = partitions(stack_id)
+    partition = :erlang.phash2(shape_handle, partitions)
+
+    moved? =
+      0..(partitions - 1)
+      |> Enum.reduce_while(false, fn
+        ^partition, acc ->
+          {:cont, acc}
+
+        p, _acc ->
+          if RefCounter.deregister_if_owned(stack_id, p, pid),
+            do: {:halt, true},
+            else: {:cont, false}
+      end)
+
+    if moved?,
+      do:
+        Logger.debug(fn ->
+          "process #{inspect(pid)} re-registered to new partition: #{inspect(shape_handle)}"
+        end)
+
+    RefCounter.register_reader(stack_id, partition, shape_handle, pid)
+  end
 
   @doc """
   Unregister the current process as a reader of the given shape.
   """
   @spec unregister_reader(stack_id(), shape_handle(), pid()) :: :ok
-  defdelegate unregister_reader(stack_id, shape_handle, pid \\ self()), to: RefCounter
+  def unregister_reader(stack_id, shape_handle, pid \\ self()) do
+    partition = shape_partition(stack_id, shape_handle)
+    RefCounter.unregister_reader(stack_id, partition, shape_handle, pid)
+  end
 
   @doc """
   Register the current process as a writer (consumer) of the given shape.
   """
   @spec register_writer(stack_id(), shape_handle(), pid()) :: :ok | {:error, term()}
-  defdelegate register_writer(stack_id, shape_handle, shape, pid \\ self()), to: RefCounter
+  def register_writer(stack_id, shape_handle, pid \\ self()) do
+    partition = shape_partition(stack_id, shape_handle)
+    RefCounter.register_writer(stack_id, partition, shape_handle, pid)
+  end
 
   @doc """
   The number of active readers of the given shape.
   """
   @spec reader_count(stack_id(), shape_handle()) :: {:ok, non_neg_integer()}
-  defdelegate reader_count(stack_id, shape_handle), to: RefCounter
+  def reader_count(stack_id, shape_handle) do
+    partition = shape_partition(stack_id, shape_handle)
+    RefCounter.reader_count(stack_id, partition, shape_handle)
+  end
 
   @doc """
   The number of active readers of all shapes.
   """
   @spec reader_count(stack_id()) :: {:ok, non_neg_integer()}
-  defdelegate reader_count(stack_id), to: RefCounter
+  def reader_count(stack_id) do
+    {
+      :ok,
+      stack_id
+      |> partition_list()
+      |> Enum.reduce(0, fn partition, sum ->
+        {:ok, count} = RefCounter.reader_count(stack_id, partition)
+        sum + count
+      end)
+    }
+  end
 
   @doc """
   The number of active readers of all shapes.
   """
   @spec reader_count!(stack_id()) :: non_neg_integer()
-  defdelegate reader_count!(stack_id), to: RefCounter
+  def reader_count!(stack_id) do
+    {:ok, count} = reader_count(stack_id)
+    count
+  end
 
   @doc """
   Request a message when all readers of the given handle have finished or terminated.
@@ -68,18 +137,26 @@ defmodule Electric.Shapes.Monitor do
   to the registered `pid` when the reader count on a shape is `0`.
   """
   @spec notify_reader_termination(stack_id(), shape_handle(), term(), pid()) :: :ok
-  defdelegate notify_reader_termination(stack_id, shape_handle, reason, pid \\ self()),
-    to: RefCounter
+  def notify_reader_termination(stack_id, shape_handle, reason, pid \\ self()) do
+    partition = shape_partition(stack_id, shape_handle)
+    RefCounter.notify_reader_termination(stack_id, partition, shape_handle, reason, pid)
+  end
 
   @doc """
   clean up the state of a non-running consumer.
   """
   @spec purge_shape(stack_id(), shape_handle(), Electric.Shapes.Shape.t()) :: :ok
-  defdelegate purge_shape(stack_id, shape_handle, shape), to: RefCounter
+  def purge_shape(stack_id, shape_handle, shape) do
+    partition = shape_partition(stack_id, shape_handle)
+    RefCounter.purge_shape(stack_id, partition, shape_handle, shape)
+  end
 
   # used in tests to validate internal state
   @doc false
-  defdelegate termination_watchers(stack_id, shape_handle), to: RefCounter
+  def termination_watchers(stack_id, shape_handle) do
+    partition = shape_partition(stack_id, shape_handle)
+    RefCounter.termination_watchers(stack_id, partition, shape_handle)
+  end
 
   def init(opts) do
     %{
@@ -89,17 +166,65 @@ defmodule Electric.Shapes.Monitor do
       shape_status: shape_status
     } = opts
 
-    children = [
-      {__MODULE__.CleanupTaskSupervisor, stack_id: stack_id},
-      {__MODULE__.RefCounter,
-       stack_id: stack_id,
-       storage: storage,
-       publication_manager: publication_manager,
-       shape_status: shape_status,
-       on_remove: Map.get(opts, :on_remove),
-       on_cleanup: Map.get(opts, :on_cleanup)}
-    ]
+    partitions = Map.get(opts, :partitions, System.schedulers_online())
+
+    Logger.info("starting #{inspect(__MODULE__)} with #{partitions} partitions")
+
+    partition_children =
+      Enum.map(0..(partitions - 1), fn partition ->
+        {__MODULE__.RefCounter,
+         stack_id: stack_id,
+         partition: partition,
+         storage: storage,
+         publication_manager: publication_manager,
+         shape_status: shape_status,
+         on_remove: Map.get(opts, :on_remove),
+         on_cleanup: Map.get(opts, :on_cleanup)}
+      end)
+
+    children =
+      [
+        {__MODULE__.Partitions, stack_id: stack_id, partitions: partitions},
+        {__MODULE__.CleanupTaskSupervisor, stack_id: stack_id}
+      ] ++ partition_children
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+end
+
+defmodule Electric.Shapes.Monitor.Partitions do
+  @moduledoc false
+
+  # Just owns the ets table with the number of partitions for the given stack
+
+  use GenServer
+
+  @key :partition_count
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
+  end
+
+  def table(stack_id) do
+    :"Elixir.Electric.Shapes.Monitor.Partitions.#{stack_id}"
+  end
+
+  def count(stack_id) do
+    case :ets.lookup(table(stack_id), @key) do
+      [{@key, partitions}] -> partitions
+    end
+  end
+
+  def init(stack_id: stack_id, partitions: partitions) do
+    table =
+      :ets.new(table(stack_id), [
+        :protected,
+        :named_table,
+        read_concurrency: true
+      ])
+
+    :ets.insert(table, {@key, partitions})
+
+    {:ok, table}
   end
 end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -285,7 +285,7 @@ defmodule Support.ComponentSetup do
         send(parent, {Electric.Shapes.Monitor, :cleanup, handle})
       end)
 
-    [on_remove: on_remove, on_cleanup: on_cleanup]
+    [on_remove: on_remove, on_cleanup: on_cleanup, partitions: 2]
   end
 
   def with_complete_stack(ctx) do
@@ -324,9 +324,9 @@ defmodule Support.ComponentSetup do
            pool_size: 2
          ],
          tweaks: [
-           registry_partitions: 1,
-           monitor_opts: monitor_config(ctx)
-         ]},
+           registry_partitions: 1
+         ],
+         monitor_opts: monitor_config(ctx)},
         restart: :temporary,
         significant: false
       )


### PR DESCRIPTION
Builds on shape cleanup race-condition fixes with a partitioned shape monitor to distribute process registrations across multiple processes