### PR TITLE
fix(sync-service): Increase restore timeout

### DIFF
--- a/.changeset/tidy-ants-protect.md
+++ b/.changeset/tidy-ants-protect.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Increase timeout for restored shape subscriptions

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -34,7 +34,9 @@ defmodule Electric.Replication.ShapeLogCollector do
   end
 
   def start_processing(server, last_processed_lsn) do
-    GenStage.call(server, {:start_processing, last_processed_lsn})
+    # Allow 60s for this call as it may need to wait for thousands of restored shapes
+    # to subscribe before it returns.
+    GenStage.call(server, {:start_processing, last_processed_lsn}, 60_000)
   end
 
   # use `GenStage.call/2` here to make the event processing synchronous.


### PR DESCRIPTION
Fixes #2741 . The [20s timeout was in version 1.0.30(https://github.com/electric-sql/electric/blob/8c0a22aaf676552ebc38efc7e03481c6c1b6db37/packages/sync-service/lib/electric/shape_cache.ex#L96) which trigger.dev are using, however we've replace the timeout for a shape specific timeout in the latest version which has mostly sorted the issue, and probably would fix trigger.dev. There is still one place it can time out which is the `start_processing` call, since this waits until all consumers have subscribed and surprisingly this can happen _after_ the consumers are all restored, so this PR increases the timeout of that to 60s. I haven't made it scale with the number of shapes or be configurable as yet as as long as subscription time is roughly the same as restoration time which it typically is, no time is used at all, if we find this timeout is actually hit we'll be in a better position to see what the best solution is.