### PR TITLE
Support Ecto Parameterized Types in Electric Client Queries

### DIFF
--- a/.changeset/fancy-eels-occur.md
+++ b/.changeset/fancy-eels-occur.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": minor
+---
+
+Enabling correct handling and dumping of custom types in fields

--- a/packages/elixir-client/lib/electric/client/ecto_adapter/postgres.ex
+++ b/packages/elixir-client/lib/electric/client/ecto_adapter/postgres.ex
@@ -42,20 +42,21 @@ if Code.ensure_loaded?(Ecto) do
     defp handle_call(fun, _arity), do: {:fun, Atom.to_string(fun)}
 
     def where(%{wheres: wheres} = query, sources, bindings) do
+      processed_bindings = process_bindings(query, bindings)
+      boolean("", wheres, sources, query, processed_bindings)
+    end
+
+    defp process_bindings(%{wheres: wheres} = query, bindings) do
       type_map =
         wheres
-        |> Enum.flat_map(fn %Ecto.Query.BooleanExpr{expr: expr} ->
-            collect_param_types(expr, query)
-          end)
+        |> Enum.flat_map(&collect_param_types(&1.expr, query))
         |> Map.new()
 
-      bindings =
-        Enum.with_index(bindings, 1)
-        |> Enum.map(fn
-            {val, idx} -> dump_binding(Map.get(type_map, idx), val)
-          end)
-
-      boolean("", wheres, sources, query, bindings)
+      bindings
+      |> Enum.with_index(1)
+      |> Enum.map(fn {val, idx} ->
+        dump_binding(Map.get(type_map, idx), val)
+      end)
     end
 
     defp boolean(_name, [], _sources, _query, _bindings), do: []
@@ -467,13 +468,16 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp collect_param_types(
-         {op, _, [{{:., _, [{:&, _, [_]}, field]}, _, []}, {:^, _, [ix]}]},
-         %Ecto.Query{from: %Ecto.Query.FromExpr{source: {_, schema_mod}}} = _query
-       )
-       when op in @binary_ops and is_atom(field) do
-
+           {op, _, [{{:., _, [{:&, _, [_]}, field]}, _, []}, {:^, _, [ix]}]},
+           %{from: %Ecto.Query.FromExpr{source: {_, schema_mod}}}
+         )
+         when op in @binary_ops and is_atom(field) do
       ecto_type = schema_mod.__schema__(:type, field)
       [{ix, ecto_type}]
+    end
+
+    defp collect_param_types({:fragment, _, parts}, query) do
+      Enum.flat_map(parts, &collect_fragment_part_types(&1, parts, query))
     end
 
     defp collect_param_types({_, _, args}, query) when is_list(args) do
@@ -482,13 +486,61 @@ if Code.ensure_loaded?(Ecto) do
 
     defp collect_param_types(_, _), do: []
 
+    defp collect_fragment_part_types(
+           {:expr, {:splice, _, [{:^, _, [idx, length]}]}},
+           parts,
+           query
+         ) do
+      case find_field_type_in_fragment(parts, query) do
+        nil -> []
+        field_type -> Enum.map(idx..(idx + length - 1), &{&1, field_type})
+      end
+    end
+
+    defp collect_fragment_part_types(
+           {:expr, {:^, _, [idx]}},
+           parts,
+           query
+         ) do
+      case find_field_type_in_fragment(parts, query) do
+        nil -> []
+        field_type -> [{idx, field_type}]
+      end
+    end
+
+    defp collect_fragment_part_types({:raw, _}, _, _), do: []
+
+    defp collect_fragment_part_types({:expr, expr}, _, query),
+      do: collect_param_types(expr, query)
+
+    defp find_field_type_in_fragment(fragment_parts, query) do
+      Enum.find_value(fragment_parts, fn
+        {:expr, {{:., _, [{:&, _, [0]}, field]}, _, []}} when is_atom(field) ->
+          case query do
+            %{from: %Ecto.Query.FromExpr{source: {_, schema_mod}}} ->
+              schema_mod.__schema__(:type, field)
+
+            _ ->
+              nil
+          end
+
+        _ ->
+          nil
+      end)
+    end
+
     defp dump_binding(type, {value, _}) when is_list(value) do
       Enum.map(value, &dump_binding(type, &1))
     end
 
     defp dump_binding({:parameterized, _} = type, {value, _}) do
       case Ecto.Type.dump(type, value) do
-        {:ok, dumped} -> {literal(dumped), dumped}
+        {:ok, dumped} when is_binary(dumped) and byte_size(dumped) == 16 ->
+          {Ecto.UUID.load!(dumped), dumped}
+
+        {:ok, dumped} ->
+          {dumped, dumped}
+
         :error ->
           raise ArgumentError,
                 "cannot dump value #{inspect(value)} for type #{inspect(type)}"
@@ -496,14 +548,5 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp dump_binding(_, value), do: value
-
-    defp literal(db_val) when is_binary(db_val) and byte_size(db_val) == 16 do
-      case Ecto.UUID.load(db_val) do
-        {:ok, uuid} -> uuid
-        :error -> literal(db_val)
-      end
-    end
-
-    defp literal(other), do: inspect(other)
   end
 end

--- a/packages/elixir-client/mix.exs
+++ b/packages/elixir-client/mix.exs
@@ -60,7 +60,8 @@ defmodule Electric.Client.MixProject do
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.18", only: [:test], runtime: false},
-      {:junit_formatter, "~> 3.4", only: [:test], runtime: false}
+      {:junit_formatter, "~> 3.4", only: [:test], runtime: false},
+      {:decimal, "~> 2.0"}
     ]
   end
 

--- a/packages/elixir-client/test/electric/client/ecto_adapter/postgres_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter/postgres_test.exs
@@ -4,6 +4,51 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
   alias Electric.Client.EctoAdapter
   import Ecto.Query
 
+  defmodule Money do
+    use Ecto.ParameterizedType
+
+    @impl Ecto.ParameterizedType
+    def init(opts) do
+      {:ok, opts}
+    end
+
+    @impl Ecto.ParameterizedType
+    def type(_), do: :integer
+
+    @impl Ecto.ParameterizedType
+    def cast(value, _) do
+      {:ok, value}
+    end
+
+    @impl Ecto.ParameterizedType
+    def load(db_integer, _, _) when is_integer(db_integer) do
+      dollars = Decimal.div(Decimal.new(db_integer), Decimal.new(1_000_000))
+      {:ok, dollars}
+    end
+
+    def load(nil, _, _), do: {:ok, nil}
+    def load(_, _, _), do: :error
+
+    @impl Ecto.ParameterizedType
+    def dump(%Decimal{} = decimal_val, _, _) do
+      micro =
+        decimal_val
+        |> Decimal.mult(1_000_000)
+        |> Decimal.to_integer()
+
+      {:ok, micro}
+    end
+
+    def dump(nil, _, _), do: {:ok, nil}
+    def dump(_, _, _), do: :error
+
+    @impl Ecto.ParameterizedType
+    def equal?(%Decimal{} = val1, %Decimal{} = val2, _), do: Decimal.eq?(val1, val2)
+
+    def equal?(nil, nil, _), do: true
+    def equal?(_, _, _), do: false
+  end
+
   defmodule TestTable do
     use Ecto.Schema
 
@@ -16,6 +61,7 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
       field(:ud, :utc_datetime)
       field(:dd, :date)
       field(:aa, {:array, :integer})
+      field(:mm, Money)
     end
   end
 
@@ -34,6 +80,7 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
     nd = ~N[2024-10-23 14:36:39]
     ud = ~U[2024-10-23 14:36:39Z]
     dd = ~D[2024-10-23]
+    mm = Decimal.new("199.99")
 
     assert_where(where(TestTable, ii: ^ii), ~s[("ii" = 1234)])
     assert_where(where(TestTable, ff: ^ff), ~s[("ff" = 3.14::float)])
@@ -43,6 +90,34 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
     assert_where(where(TestTable, nd: ^nd), ~s[("nd" = '2024-10-23T14:36:39'::timestamp)])
     assert_where(where(TestTable, ud: ^ud), ~s[("ud" = '2024-10-23T14:36:39Z'::timestamptz)])
     assert_where(where(TestTable, dd: ^dd), ~s[("dd" = '2024-10-23'::date)])
+    assert_where(where(TestTable, mm: ^mm), ~s[("mm" = 199990000)])
+  end
+
+  test "fragment" do
+    ii = 5678
+    mm_min = Decimal.new("123.45")
+    mm_max = Decimal.new("678.90")
+
+    assert_where(
+      from(t in TestTable,
+        where: fragment("? = ?", t.ii, ^ii)
+      ),
+      ~s[("ii" = 5678)]
+    )
+
+    assert_where(
+      from(t in TestTable,
+        where: fragment("? BETWEEN ? AND ?", t.ii, ^10, ^100) and fragment("? IS NOT NULL", t.ss)
+      ),
+      ~s[("ii" BETWEEN 10 AND 100 AND "ss" IS NOT NULL)]
+    )
+
+    assert_where(
+      from(t in TestTable,
+        where: fragment("? > ? AND ? < ?", t.mm, ^mm_min, t.mm, ^mm_max)
+      ),
+      ~s[("mm" > 123450000 AND "mm" < 678900000)]
+    )
   end
 
   test "spliced values" do
@@ -50,6 +125,7 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
     aa = [1, 2, 3, 4]
     ss = "my string"
     uu = ["247a6f62-9f05-4ac6-8314-89e77177d1e3", "61a8129e-6970-48e8-9dae-b26777c7d225"]
+    mm = [Decimal.new("199.99"), Decimal.new("150.00")]
 
     assert_where(
       from(t in TestTable,
@@ -63,6 +139,13 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
         where: t.id == ^ii and fragment("? in (?)", t.uu, splice(^uu)) and t.ss == ^ss
       ),
       ~s[((("id" = 1234) AND "uu" in ('247a6f62-9f05-4ac6-8314-89e77177d1e3','61a8129e-6970-48e8-9dae-b26777c7d225')) AND ("ss" = 'my string'))]
+    )
+
+    assert_where(
+      from(t in TestTable,
+        where: t.id == ^ii and fragment("? in (?)", t.mm, splice(^mm)) and t.ss == ^ss
+      ),
+      ~s[((("id" = 1234) AND "mm" in (199990000,150000000)) AND ("ss" = 'my string'))]
     )
   end
 end


### PR DESCRIPTION
**Description:**
This PR adds support for Ecto parameterized types in the elixir-client. It can now correctly handle and dump parameterized types.

**Note**:
The `decimal `dependency is required for the test suite and has been added to `mix.exs`. However, since the `protox `dependency also requires `decimal`, it cannot be marked as `only: [:test]`.