### PR TITLE
chore (examples): Rename source_secret to secret

### DIFF
--- a/.github/workflows/teardown_examples_pr_stack.yml
+++ b/.github/workflows/teardown_examples_pr_stack.yml
@@ -67,21 +67,17 @@ jobs:
           export PR_NUMBER=${{ github.event.number }}
           echo "Removing stage pr-$PR_NUMBER"
 
-          # If we fail to remove the stage, the app might not have been deployed
-          # so check the output to see if that's the case
-          # and if that's the case, exit with a 0 exit code (success)
-          output=$(pnpm sst remove --stage "pr-$PR_NUMBER" 2>&1)
-          exit_code=$?
-          
-          if [ $exit_code -ne 0 ]; then
+          # Run the command and capture both stdout and stderr
+          if ! output=$(pnpm sst remove --stage "pr-$PR_NUMBER" 2>&1); then
+            # Check if the error is because the stage doesn't exist
             if echo "$output" | grep -q "Stage not found"; then
               echo "Example was not deployed."
               exit 0
-            else
-              echo "$output" >&2
-              exit $exit_code
             fi
+            # If it's a different error, print it and fail
+            echo "Error removing stage: $output" >&2
+            exit 1
           fi
           
-          # If we get here, the command succeeded normally
+          echo "Successfully removed stage"
           exit 0

--- a/examples/.shared/lib/neon.ts
+++ b/examples/.shared/lib/neon.ts
@@ -52,17 +52,40 @@ export function createNeonDb({
 
   const ownerName = `neondb_owner`
 
-  const createCommand = `curl -f "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches/$BRANCH_ID/databases" \
-    -H 'Accept: application/json' \
-    -H "Authorization: Bearer $NEON_API_KEY" \
-    -H 'Content-Type: application/json' \
-    -d '{
-      "database": {
-        "name": "'$DATABASE_NAME'",
-        "owner_name": "${ownerName}"
-      }
-    }' \
-    && echo " SUCCESS" || echo " FAILURE"`
+  const createCommand = `
+    max_retries=10
+    retry_count=0
+    
+    while [ $retry_count -lt $max_retries ]; do
+      response=$(curl -f -w "\\n%{http_code}" "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches/$BRANCH_ID/databases" \
+        -H 'Accept: application/json' \
+        -H "Authorization: Bearer $NEON_API_KEY" \
+        -H 'Content-Type: application/json' \
+        -d '{
+          "database": {
+            "name": "'$DATABASE_NAME'",
+            "owner_name": "${ownerName}"
+          }
+        }' 2>/dev/null)
+      
+      status_code=$(echo "$response" | tail -n1)
+      body=$(echo "$response" | sed '$d')
+      
+      if [ "$status_code" = "423" ]; then
+        retry_count=$((retry_count + 1))
+        if [ $retry_count -eq $max_retries ]; then
+          echo "$body"
+          echo " FAILURE"
+          exit 1
+        fi
+        # Random sleep between 1-5 seconds
+        sleep $((RANDOM % 5 + 1))
+        continue
+      fi
+      
+      echo " SUCCESS"
+      exit 0
+    done`
 
   const updateCommand = `echo "Cannot update Neon database with this provisioning method SUCCESS"`
 

--- a/examples/.shared/lib/neon.ts
+++ b/examples/.shared/lib/neon.ts
@@ -52,7 +52,7 @@ export function createNeonDb({
 
   const ownerName = `neondb_owner`
 
-  const createCommand = `curl -f -s "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches/$BRANCH_ID/databases" \
+  const createCommand = `curl -f "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches/$BRANCH_ID/databases" \
     -H 'Accept: application/json' \
     -H "Authorization: Bearer $NEON_API_KEY" \
     -H 'Content-Type: application/json' \

--- a/examples/.shared/lib/neon.ts
+++ b/examples/.shared/lib/neon.ts
@@ -75,6 +75,7 @@ export function createNeonDb({
         retry_count=$((retry_count + 1))
         if [ $retry_count -eq $max_retries ]; then
           echo "$body"
+          echo " Max retries reached"
           echo " FAILURE"
           exit 1
         fi

--- a/examples/linearlite-read-only/src/electric.tsx
+++ b/examples/linearlite-read-only/src/electric.tsx
@@ -1,5 +1,5 @@
 export const baseUrl = import.meta.env.VITE_ELECTRIC_URL
   ? new URL(import.meta.env.VITE_ELECTRIC_URL).origin
   : `http://localhost:3000`
-export const source_secret = import.meta.env.VITE_ELECTRIC_SOURCE_SECRET ?? ``
+export const secret = import.meta.env.VITE_ELECTRIC_SOURCE_SECRET ?? ``
 export const source_id = import.meta.env.VITE_ELECTRIC_SOURCE_ID ?? ``

--- a/examples/linearlite-read-only/src/pages/Issue/Comments.tsx
+++ b/examples/linearlite-read-only/src/pages/Issue/Comments.tsx
@@ -8,7 +8,7 @@ import { formatDate } from '../../utils/date'
 import { showWarning } from '../../utils/notification'
 import { Comment, Issue } from '../../types/types'
 import { useShape } from '@electric-sql/react'
-import { baseUrl, source_id, source_secret } from '../../electric'
+import { baseUrl, source_id, secret } from '../../electric'
 
 export interface CommentsProps {
   issue: Issue
@@ -19,7 +19,7 @@ function Comments(commentProps: CommentsProps) {
   const allComments = useShape({
     url: `${baseUrl}/v1/shape`,
     params: {
-      source_secret,
+      secret,
       source_id,
       table: `comment`,
     },

--- a/examples/linearlite-read-only/src/shapes.ts
+++ b/examples/linearlite-read-only/src/shapes.ts
@@ -1,11 +1,11 @@
 import { ShapeStreamOptions } from '@electric-sql/client'
-import { baseUrl, source_id, source_secret } from './electric'
+import { baseUrl, source_id, secret } from './electric'
 
 export const issueShape: ShapeStreamOptions = {
   url: `${baseUrl}/v1/shape/`,
   params: {
     table: `issue`,
-    source_secret,
+    secret,
     source_id,
   },
 }

--- a/examples/linearlite/src/sync.ts
+++ b/examples/linearlite/src/sync.ts
@@ -58,7 +58,7 @@ async function startSyncToDatabase(pg: PGliteWithExtensions) {
 
   const issueUrl = new URL(`${ELECTRIC_URL}/v1/shape`)
   if (ELECTRIC_SOURCE_SECRET) {
-    issueUrl.searchParams.set('source_secret', ELECTRIC_SOURCE_SECRET)
+    issueUrl.searchParams.set('secret', ELECTRIC_SOURCE_SECRET)
   }
 
   // Issues Sync
@@ -94,7 +94,7 @@ async function startSyncToDatabase(pg: PGliteWithExtensions) {
 
   const commentUrl = new URL(`${ELECTRIC_URL}/v1/shape`)
   if (ELECTRIC_SOURCE_SECRET) {
-    commentUrl.searchParams.set('source_secret', ELECTRIC_SOURCE_SECRET)
+    commentUrl.searchParams.set('secret', ELECTRIC_SOURCE_SECRET)
   }
 
   // Comments Sync

--- a/examples/linearlite/sst.config.ts
+++ b/examples/linearlite/sst.config.ts
@@ -63,8 +63,6 @@ export default $config({
 
       return {
         databaseUri,
-        // source_id: electricInfo.id,
-        // source_secret: electricInfo.source_secret,
         website: website.url,
       }
     } catch (e) {

--- a/examples/proxy-auth/app/shape-proxy/route.ts
+++ b/examples/proxy-auth/app/shape-proxy/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
 
   if (process.env.ELECTRIC_SOURCE_SECRET) {
     originUrl.searchParams.set(
-      `source_secret`,
+      `secret`,
       process.env.ELECTRIC_SOURCE_SECRET
     )
   }

--- a/examples/react/src/Example.tsx
+++ b/examples/react/src/Example.tsx
@@ -11,7 +11,7 @@ export const Example = () => {
     params: {
       table: `items`,
       source_id: import.meta.env.VITE_ELECTRIC_SOURCE_ID,
-      source_secret: import.meta.env.VITE_ELECTRIC_SOURCE_SECRET,
+      secret: import.meta.env.VITE_ELECTRIC_SOURCE_SECRET,
     },
   })
 

--- a/examples/remix/app/routes/shape-proxy.ts
+++ b/examples/remix/app/routes/shape-proxy.ts
@@ -14,7 +14,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   originUrl.searchParams.set(`source_id`, process.env.ELECTRIC_SOURCE_ID!)
   originUrl.searchParams.set(
-    `source_secret`,
+    `secret`,
     process.env.ELECTRIC_SOURCE_SECRET!
   )
 

--- a/examples/tanstack/src/Example.tsx
+++ b/examples/tanstack/src/Example.tsx
@@ -19,7 +19,7 @@ const itemShape = () => ({
   params: {
     table: `items`,
     source_id: import.meta.env.VITE_ELECTRIC_SOURCE_ID,
-    source_secret: import.meta.env.VITE_ELECTRIC_SOURCE_SECRET,
+    secret: import.meta.env.VITE_ELECTRIC_SOURCE_SECRET,
   },
 })
 

--- a/examples/todo-app/src/routes/index.tsx
+++ b/examples/todo-app/src/routes/index.tsx
@@ -27,7 +27,7 @@ export default function Index() {
     params: {
       table: `todos`,
       source_id: import.meta.env.VITE_ELECTRIC_SOURCE_ID,
-      source_secret: import.meta.env.VITE_ELECTRIC_SOURCE_SECRET,
+      secret: import.meta.env.VITE_ELECTRIC_SOURCE_SECRET,
     },
   })
   todos.sort((a, b) => a.created_at - b.created_at)

--- a/examples/write-patterns/shared/app/config.ts
+++ b/examples/write-patterns/shared/app/config.ts
@@ -1,11 +1,11 @@
 export const ELECTRIC_URL =
   import.meta.env.VITE_ELECTRIC_URL || 'http://localhost:3000'
 
-export const envParams: { source_id?: string; source_secret?: string } =
+export const envParams: { source_id?: string; secret?: string } =
   import.meta.env.VITE_ELECTRIC_SOURCE_SECRET &&
   import.meta.env.VITE_ELECTRIC_SOURCE_ID
     ? {
         source_id: import.meta.env.VITE_ELECTRIC_SOURCE_ID,
-        source_secret: import.meta.env.VITE_ELECTRIC_SOURCE_SECRET,
+        secret: import.meta.env.VITE_ELECTRIC_SOURCE_SECRET,
       }
     : {}

--- a/examples/yjs/src/server/server.ts
+++ b/examples/yjs/src/server/server.ts
@@ -115,7 +115,7 @@ app.get(`/shape-proxy/v1/shape`, async (c: Context) => {
 
   if (process.env.ELECTRIC_SOURCE_SECRET) {
     originUrl.searchParams.set(
-      `source_secret`,
+      `secret`,
       process.env.ELECTRIC_SOURCE_SECRET
     )
   }

--- a/website/product/cloud.md
+++ b/website/product/cloud.md
@@ -87,7 +87,7 @@ export SHAPE_DEFINITION="table=items&offset=-1"
 
 curl -i "https://api.electric-sql.cloud/v1/shape?$SHAPE_DEFINITION\
     &source_id=$SOURCE_ID\
-    &source_secret=$SECRET"
+    &secret=$SECRET"
 ```
 
 ### Security Model
@@ -107,7 +107,7 @@ The recommended pattern for secure use of the Electric Cloud is to add the sourc
 
 ##### Example
 
-In your client, request the shape as normal, without the `source_id` and `source_secret` parameters. For example here using the [Typescript client](/docs/api/clients/typescript):
+In your client, request the shape as normal, without the `source_id` and `secret` parameters. For example here using the [Typescript client](/docs/api/clients/typescript):
 
 ```ts
 import { ShapeStream } from '@electric-sql/client'
@@ -136,7 +136,7 @@ export async function GET(req: Request) {
 
   // Add the source params.
   originUrl.searchParams.set(`source_id`, process.env.SOURCE_ID)
-  originUrl.searchParams.set(`source_secret`, process.env.SOURCE_SECRET)
+  originUrl.searchParams.set(`secret`, process.env.SOURCE_SECRET)
 
   // Proxy the authorised request on to the Electric Cloud.
   const response = await fetch(originUrl)


### PR DESCRIPTION
This PR modifies the examples to use the secret parameter when interacting with Electric instead of the deprecated source_secret. Fixes https://github.com/electric-sql/electric/issues/2732

This PR is the same as https://github.com/electric-sql/electric/pull/2756 but in the other one the SST state seems to be stuck.