### PR TITLE
Make phoenix-liveview example private

### DIFF
--- a/examples/phoenix-liveview/package.json
+++ b/examples/phoenix-liveview/package.json
@@ -1,6 +1,7 @@
 {
   "name": "phoenix-liveview",
-  "version": "0.0.0",
+  "private": true,
+  "version": "0.0.1",
   "dependencies": {
     "camelcase": "^8.0.0"
   },
@@ -16,3 +17,4 @@
     "test:browser": "playwright install && playwright test ./e2e/"
   }
 }
+


### PR DESCRIPTION
So it's not included in the default npm:publish task