### PR TITLE
fix: Catch reason `:closed` for a lost connection

### DIFF
--- a/.changeset/four-tomatoes-glow.md
+++ b/.changeset/four-tomatoes-glow.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Properly handle response stream interruptions with reason `:closed`.

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -268,7 +268,7 @@ defmodule Electric.Shapes.Api.Response do
               {:ok, conn} ->
                 {:cont, {conn, bytes_sent + chunk_size}}
 
-              {:error, "closed"} ->
+              {:error, reason} when reason in ["closed", :closed] ->
                 error_str = "Connection closed unexpectedly while streaming response"
                 conn = Plug.Conn.assign(conn, :error_str, error_str)
                 {:halt, {conn, bytes_sent}}


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2770

I included reason `:closed` on top of `"closed"` to the existing handling clause for interrupted streams. Not sure if both actually occur or if the existing clause was a mistake @magnetised .