### PR TITLE
fix: Ensure `:ready` message fires after a replication client restart

### DIFF
--- a/.changeset/fluffy-pants-wink.md
+++ b/.changeset/fluffy-pants-wink.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Consistently send `:ready` stack event after replication client restarts as well.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -455,8 +455,6 @@ defmodule Electric.Connection.Manager do
           exit(reason)
       end
 
-    dispatch_stack_event(:ready, state)
-
     # Remember the shape log collector pid for later because we want to tie the replication
     # client's lifetime to it.
     log_collector_pid = lookup_log_collector_pid(shapes_sup_pid)
@@ -483,6 +481,7 @@ defmodule Electric.Connection.Manager do
     # Everything is ready to start accepting and processing logical messages from Postgres.
     Logger.info("Starting replication from postgres")
     Electric.Postgres.ReplicationClient.start_streaming(state.replication_client_pid)
+    dispatch_stack_event(:ready, state)
 
     state = %State{
       state


### PR DESCRIPTION
Ensures `:ready` stack event is fired even after a replication client restart

Addresses https://github.com/electric-sql/stratovolt/issues/660