### PR TITLE
fix: Remove shape hash lookup entry upon shape removal

### DIFF
--- a/.changeset/rare-pots-sleep.md
+++ b/.changeset/rare-pots-sleep.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix shape hash lookup deletion upon removing shape

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -150,13 +150,11 @@ defmodule Electric.ShapeCache.ShapeStatus do
           @shape_meta_shape_pos
         )
 
-      hash = Shape.hash(shape)
-
       :ets.select_delete(
         state.shape_meta_table,
         [
           {{{@shape_meta_data, shape_handle}, :_, :_, :_, :_}, [], [true]},
-          {{{@shape_hash_lookup, hash}, shape_handle}, [], [true]},
+          {{{@shape_hash_lookup, Shape.comparable(shape)}, shape_handle}, [], [true]},
           {{{@snapshot_started, shape_handle}, :_}, [], [true]}
           | Enum.map(Shape.list_relations(shape), fn {oid, _} ->
               {{{@shape_relation_lookup, oid, shape_handle}, :_}, [], [true]}


### PR DESCRIPTION
Things got mixed up between merging https://github.com/electric-sql/electric/pull/2779 and https://github.com/electric-sql/electric/pull/2672 and the shape hash lookup entry was not being removed.