### PR TITLE
Fix lock semantics for the exclusive connection lock when running against a pooler

### DIFF
--- a/.changeset/eight-pigs-swim.md
+++ b/.changeset/eight-pigs-swim.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Open a replication connection to acquire the exclusive connection lock, fixing the lock semantics for cases where Electric runs with a pooled connection string.

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -132,6 +132,15 @@ defmodule Electric.DbConnectionError do
     maybe_database_does_not_exist(error) || unknown_error(error)
   end
 
+  def from_error(%Postgrex.Error{postgres: %{code: :syntax_error, pg_code: "42601"}} = error) do
+    %DbConnectionError{
+      message: error.postgres.message,
+      type: :syntax_error,
+      original_error: error,
+      retry_may_fix?: false
+    }
+  end
+
   def from_error(error), do: unknown_error(error)
 
   def format_original_error(%DbConnectionError{original_error: error}) do

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -94,7 +94,7 @@ defmodule Electric.Postgres.LockConnection do
     # semantics.
     #
     # Issuing a statement that would cause a syntax error on a regular connection is a surefire
-    # to ensure the connection is running in the correct mode.
+    # way to ensure the connection is running in the correct mode.
     send(self(), :identify_system)
 
     {:noreply, state}

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -184,6 +184,9 @@ defmodule Electric.Postgres.ReplicationClient do
     {current_step, next_step, extra_info, return_val} =
       ConnectionSetup.process_query_result(result_list_or_error, state)
 
+    if current_step == :query_pg_info,
+      do: notify_pg_info_obtained(state, extra_info)
+
     if current_step == :create_slot and extra_info == :created_new_slot,
       do: notify_created_new_slot(state)
 
@@ -377,6 +380,11 @@ defmodule Electric.Postgres.ReplicationClient do
 
   defp notify_connection_opened(%State{connection_manager: connection_manager} = state) do
     :ok = Electric.Connection.Manager.replication_client_started(connection_manager)
+    state
+  end
+
+  defp notify_pg_info_obtained(%State{connection_manager: manager} = state, pg_info) do
+    :ok = Electric.Connection.Manager.pg_info_obtained(manager, pg_info)
     state
   end
 

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -190,7 +190,8 @@ defmodule Electric.Postgres.ReplicationClient do
     if current_step == :create_slot and extra_info == :created_new_slot,
       do: notify_created_new_slot(state)
 
-    if next_step == :ready_to_stream, do: notify_ready_to_stream(state)
+    if next_step == :ready_to_stream,
+      do: notify_ready_to_stream(state)
 
     return_val
   end
@@ -378,8 +379,8 @@ defmodule Electric.Postgres.ReplicationClient do
 
   defp update_applied_wal(state, wal) when is_number(wal), do: state
 
-  defp notify_connection_opened(%State{connection_manager: connection_manager} = state) do
-    :ok = Electric.Connection.Manager.replication_client_started(connection_manager)
+  defp notify_connection_opened(%State{connection_manager: manager} = state) do
+    :ok = Electric.Connection.Manager.replication_client_started(manager)
     state
   end
 
@@ -388,20 +389,18 @@ defmodule Electric.Postgres.ReplicationClient do
     state
   end
 
-  defp notify_created_new_slot(%State{connection_manager: connection_manager} = state) do
-    :ok = Electric.Connection.Manager.replication_client_created_new_slot(connection_manager)
+  defp notify_created_new_slot(%State{connection_manager: manager} = state) do
+    :ok = Electric.Connection.Manager.replication_client_created_new_slot(manager)
     state
   end
 
-  defp notify_ready_to_stream(%State{connection_manager: connection_manager} = state) do
-    :ok = Electric.Connection.Manager.replication_client_ready_to_stream(connection_manager)
+  defp notify_ready_to_stream(%State{connection_manager: manager} = state) do
+    :ok = Electric.Connection.Manager.replication_client_ready_to_stream(manager)
     state
   end
 
-  defp notify_seen_first_message(%State{connection_manager: connection_manager} = state) do
-    :ok =
-      Electric.Connection.Manager.replication_client_streamed_first_message(connection_manager)
-
+  defp notify_seen_first_message(%State{connection_manager: manager} = state) do
+    :ok = Electric.Connection.Manager.replication_client_streamed_first_message(manager)
     state
   end
 end

--- a/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
@@ -55,32 +55,13 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
 
   defp pg_info_query(state) do
     Logger.debug("ReplicationClient step: pg_info_query")
-
-    query = """
-    SELECT
-      current_setting('server_version_num') server_version_num,
-      (pg_control_system()).system_identifier,
-      (pg_control_checkpoint()).timeline_id
-    """
-
+    query = "SELECT current_setting('server_version_num') server_version_num"
     {:query, query, state}
   end
 
   defp pg_info_result([%Postgrex.Result{} = result], state) do
-    %{rows: [[version_str, system_identifier, timeline_id]]} = result
-
-    Logger.info(
-      "Postgres server version = #{version_str}, " <>
-        "system identifier = #{system_identifier}, " <>
-        "timeline_id = #{timeline_id}"
-    )
-
-    Electric.Connection.Manager.pg_info_looked_up(
-      state.connection_manager,
-      {String.to_integer(version_str), system_identifier, timeline_id}
-    )
-
-    state
+    %{rows: [[version_str]]} = result
+    {%{server_version_num: String.to_integer(version_str)}, state}
   end
 
   defp create_publication_query(state) do

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -37,7 +37,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
 
     defp process_message({:"$gen_cast", :replication_client_started}), do: nil
     defp process_message({:"$gen_cast", :replication_client_created_new_slot}), do: nil
-    defp process_message({:"$gen_cast", {:pg_info_looked_up, _}}), do: nil
+    defp process_message({:"$gen_cast", {:pg_info_obtained, _}}), do: nil
 
     defp process_message({:"$gen_cast", :replication_client_streamed_first_message}),
       do: {self(), :streaming_started}


### PR DESCRIPTION
We have recently observed some source in Electric Cloud struggle due to lock and replication slot contention issues which in theory shouldn't have happened at all. The cause of the issues was an imperfect validation logic applied to the creation of new sources. As a consequence, some sources get created with a pooled connection URL.

More concretely, our validation can successfully weed out pooled connection strings from Supabase, but Neon's pool allows establishing replication connections by proxying them directly to the DB. As a result, Electric ends up acquiring an advisory lock on a pooled connection where the pooler runs in transaction mode, leading to a bunch of undesirable effects that prevent Electric's normal operation.

---

This PR addresses the cause of the issues by making the `LockConnection` process open a replication connection to the DB or fail if that cannot be achieved. In this way, either the advisory lock will be taken on a long-living connection as expected, or the connection won't be able to open and the source will immediately transition into an error state, instead of assigning an advisory lock to a random pooled connection as it currently does.