### PR TITLE
wip: respect order_by and limit on initial query.

### DIFF
--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -45,6 +45,11 @@ defmodule Electric.Shapes.Api.Params do
     field(:handle, :string)
     field(:live, :boolean, default: false)
     field(:where, :string)
+
+    # XXX
+    field(:order_by, :string)
+    field(:limit, :integer)
+
     field(:columns, ColumnList)
     field(:shape_definition, :string)
     field(:replica, Ecto.Enum, values: [:default, :full], default: :default)
@@ -169,6 +174,8 @@ defmodule Electric.Shapes.Api.Params do
   defp define_shape(%Ecto.Changeset{} = changeset, api) do
     table = fetch_change!(changeset, :table)
     where = fetch_field!(changeset, :where)
+    order_by = fetch_field!(changeset, :order_by)
+    limit = fetch_field!(changeset, :limit)
     columns = get_change(changeset, :columns, nil)
     replica = fetch_field!(changeset, :replica)
     params = fetch_field!(changeset, :params)
@@ -177,6 +184,8 @@ defmodule Electric.Shapes.Api.Params do
     case Shape.new(
            table,
            where: where,
+           order_by: order_by,
+           limit: limit,
            params: params,
            columns: columns,
            replica: replica,

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -27,10 +27,20 @@ defmodule Electric.Shapes.Querying do
       where =
         if not is_nil(shape.where), do: " WHERE " <> shape.where.query, else: ""
 
+      order_by =
+        if not is_nil(shape.order_by), do: " ORDER BY " <> shape.order_by, else: ""
+
+      limit =
+        if not is_nil(shape.limit), do: " LIMIT #{shape.limit} ", else: ""
+
       {json_like_select, params} = json_like_select(shape)
 
       query =
-        Postgrex.prepare!(conn, table, ~s|SELECT #{json_like_select} FROM #{table} #{where}|)
+        Postgrex.prepare!(
+          conn,
+          table,
+          ~s|SELECT #{json_like_select} FROM #{table} #{where} #{order_by} #{limit}|
+        )
 
       Postgrex.stream(conn, query, params)
       |> Stream.flat_map(& &1.rows)


### PR DESCRIPTION
The server-side of the on-site hackathon work on respecting order_by and limit on initial shape query. @balegas added equivalent client-side support.