### PR TITLE
docs: remove line break from website title.

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -29,10 +29,7 @@ const blogSidebarItems = await posts.map(post => ({
 export default defineConfig({
   lang: 'en',
   title: "ElectricSQL",
-  description: `
-    Electric is a Postgres sync engine. It solves the
-    hard problems of sync so that you don't have to.
-  `,
+  description: "Electric is a Postgres sync engine. It solves the hard problems of sync so that you don't have to.",
   appearance: 'force-dark',
   base: '/',
   cleanUrls: true,


### PR DESCRIPTION
This fixes formatting in some chat summaries etc.