### PR TITLE
Fix compilation warning when running with MIX_ENV=test

### DIFF
--- a/packages/elixir-client/test/support/money.ex
+++ b/packages/elixir-client/test/support/money.ex
@@ -21,7 +21,7 @@ defmodule Support.Money do
   end
 
   def load(nil, _, _), do: {:ok, nil}
-  def load(val, _, _), do: :error
+  def load(_, _, _), do: :error
 
   @impl Ecto.ParameterizedType
   def dump(%Decimal{} = decimal_val, _, _) do


### PR DESCRIPTION
Fix the compilation issue introduced in https://github.com/electric-sql/electric/pull/2754.