### PR TITLE
elixir-client: Build shape definition from changeset

### DIFF
--- a/.changeset/lazy-rivers-camp.md
+++ b/.changeset/lazy-rivers-camp.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Support generating shape definitions from Ecto.Changeset structs, add replica mode to client ShapeDefinitions, ensure client parameters are always of type %{binary() => binary()} and expose some options schema information for use in Phoenix.Sync

--- a/packages/elixir-client/lib/electric/client.ex
+++ b/packages/elixir-client/lib/electric/client.ex
@@ -451,7 +451,7 @@ defmodule Electric.Client do
   - Using a full shape definition:
 
         {:ok, client} = Electric.Client.new(base_url: "http://localhost:3000")
-        {:ok, shape} = Electric.Client.shape("todos", where: "completed = false")
+        {:ok, shape} = Electric.Client.shape("todos", where: "completed = false", replica: :full)
         stream = Electric.Client.stream(client, shape)
 
   - Or with an `Ecto` query or `Ecto.Schema` struct:

--- a/packages/elixir-client/lib/electric/client.ex
+++ b/packages/elixir-client/lib/electric/client.ex
@@ -373,12 +373,6 @@ defmodule Electric.Client do
       |> validate_queryable!()
     end
 
-    defp validate_queryable!(other) do
-      raise ArgumentError,
-        message:
-          "Expected an Ecto.Schema module, %Ecto.Query{} struct, a 1-arity function returning an %Ecto.Changeset{} or an %Ecto.Changeset{} but got #{inspect(other)}"
-    end
-
     @doc """
     Create a [`ShapeDefinition`](`Electric.Client.ShapeDefinition`) from an `Ecto` query.
 

--- a/packages/elixir-client/lib/electric/client.ex
+++ b/packages/elixir-client/lib/electric/client.ex
@@ -369,8 +369,7 @@ defmodule Electric.Client do
     defp validate_queryable!(%Ecto.Changeset{} = changeset), do: changeset
 
     defp validate_queryable!(changeset_fun) when is_function(changeset_fun, 1) do
-      changeset_fun.(%{})
-      |> validate_queryable!()
+      changeset_fun
     end
 
     @doc """

--- a/packages/elixir-client/lib/electric/client/authenticator/mock_authenticator.ex
+++ b/packages/elixir-client/lib/electric/client/authenticator/mock_authenticator.ex
@@ -22,7 +22,7 @@ defmodule Electric.Client.Authenticator.MockAuthenticator do
   end
 
   defp shape_hash(params, config) do
-    auth_hash([:table, :columns, :where], params, config)
+    auth_hash(["table", "columns", "where"], params, config)
   end
 
   defp put_request_params(request, hash) do

--- a/packages/elixir-client/lib/electric/client/ecto_adapter.ex
+++ b/packages/elixir-client/lib/electric/client/ecto_adapter.ex
@@ -6,16 +6,18 @@ if Code.ensure_loaded?(Ecto) do
 
     @behaviour Electric.Client.ValueMapper
 
-    def shape!(schema) when is_atom(schema), do: shape_from_query!(schema)
-    def shape!(%Ecto.Query{} = query), do: shape_from_query!(query)
-    def shape!(%Ecto.Changeset{} = changeset), do: shape_from_changeset!(changeset)
+    def shape!(schema, opts \\ [])
 
-    def shape!(changeset_fun) when is_function(changeset_fun, 1),
-      do: shape_from_changeset!(changeset_fun)
+    def shape!(schema, opts) when is_atom(schema), do: shape_from_query!(schema, opts)
+    def shape!(%Ecto.Query{} = query, opts), do: shape_from_query!(query, opts)
+    def shape!(%Ecto.Changeset{} = changeset, opts), do: shape_from_changeset!(changeset, opts)
+
+    def shape!(changeset_fun, opts) when is_function(changeset_fun, 1),
+      do: shape_from_changeset!(changeset_fun, opts)
 
     @doc false
     @spec shape_from_query!(Ecto.Queryable.t()) :: ShapeDefinition.t()
-    def shape_from_query!(queryable) do
+    def shape_from_query!(queryable, opts \\ []) do
       query = Ecto.Queryable.to_query(queryable)
 
       validate_query!(query)
@@ -27,11 +29,12 @@ if Code.ensure_loaded?(Ecto) do
       columns = query_columns(query)
       where = where(query)
 
-      ShapeDefinition.new!(table_name,
-        namespace: namespace,
-        where: where,
-        columns: columns,
-        parser: {__MODULE__, struct}
+      ShapeDefinition.new!(
+        table_name,
+        merge_shape_opts(
+          [namespace: namespace, where: where, columns: columns, parser: {__MODULE__, struct}],
+          opts
+        )
       )
     end
 
@@ -84,14 +87,19 @@ if Code.ensure_loaded?(Ecto) do
         |> Enum.map(&schema.__schema__(:field_source, &1))
         |> Enum.map(&to_string/1)
 
-      shape_opts = Keyword.take(opts, Keyword.keys(ShapeDefinition.schema_definition()))
-
       ShapeDefinition.new!(
         table_name,
-        shape_opts
-        |> Keyword.put_new(:namespace, namespace)
-        |> Keyword.merge(columns: columns)
+        merge_shape_opts(
+          [columns: columns, parser: {__MODULE__, schema}, namespace: namespace],
+          opts
+        )
       )
+    end
+
+    defp merge_shape_opts(base, overrides) do
+      Keyword.merge(base, overrides, fn _key, base, over ->
+        if is_nil(over), do: base, else: over
+      end)
     end
 
     defp table_name(%{

--- a/packages/elixir-client/lib/electric/client/embedded.ex
+++ b/packages/elixir-client/lib/electric/client/embedded.ex
@@ -57,10 +57,10 @@ if Code.ensure_loaded?(Electric.Shapes.Api) do
       Map.merge(
         request.params,
         %{
-          offset: to_string(request.offset),
-          handle: request.shape_handle,
-          live: request.live,
-          replica: request.replica
+          "offset" => to_string(request.offset),
+          "handle" => request.shape_handle,
+          "live" => request.live,
+          "replica" => request.replica
         }
       )
     end

--- a/packages/elixir-client/lib/electric/client/fetch/request.ex
+++ b/packages/elixir-client/lib/electric/client/fetch/request.ex
@@ -13,6 +13,10 @@ defmodule Electric.Client.Fetch.Request do
     :shape_handle,
     :live,
     :next_cursor,
+    # `replica` does not belong here, it's part of the shape definition that we
+    # receive via the client params. the other keys in this struct are part
+    # of consuming a stream rather than defining the shape.
+    # kept for backwards compatibility
     replica: :default,
     method: :get,
     offset: Client.Offset.before_all(),

--- a/packages/elixir-client/lib/electric/client/shape_definition.ex
+++ b/packages/elixir-client/lib/electric/client/shape_definition.ex
@@ -3,12 +3,12 @@ defmodule Electric.Client.ShapeDefinition do
   Struct for defining a shape.
 
       iex> ShapeDefinition.new("items", where: "something = true")
-      {:ok, %ShapeDefinition{table: "items", where: "something = true"}}
+      {:ok, %ShapeDefinition{table: "items", where: "something = true", replica: :default}}
   """
 
   alias Electric.Client.Util
 
-  @public_keys [:namespace, :table, :columns, :where, :params]
+  @public_keys [:namespace, :table, :columns, :where, :params, :replica]
   @derive {Jason.Encoder, only: @public_keys}
   @enforce_keys [:table]
 
@@ -42,6 +42,16 @@ defmodule Electric.Client.ShapeDefinition do
       default: nil,
       doc:
         "Values of positional parameters in the where clause. These will substitute `$i` placeholder in the where clause."
+    ],
+    replica: [
+      type: {:in, [:default, :full]},
+      default: :default,
+      doc: """
+      Modifies the data sent in update and delete change messages.
+
+      When set to `:full` the entire row will be sent for updates and deletes,
+      not just the changed columns.
+      """
     ],
     parser: [
       type: :mod_arg,
@@ -95,9 +105,17 @@ defmodule Electric.Client.ShapeDefinition do
          where: Access.get(opts, :where),
          columns: Access.get(opts, :columns),
          namespace: Access.get(opts, :namespace),
+         replica: Access.get(opts, :replica),
          parser: Access.get(opts, :parser),
          params: Access.get(opts, :params)
        }}
+    end
+  end
+
+  def new!(opts) when is_list(opts) do
+    case new(opts) do
+      {:ok, shape} -> shape
+      {:error, %NimbleOptions.ValidationError{} = error} -> raise error
     end
   end
 
@@ -175,29 +193,53 @@ defmodule Electric.Client.ShapeDefinition do
   def matches?(_term1, _term2), do: false
 
   @doc false
-  @spec params(t(), [{:format, :query | :json}]) :: Electric.Client.Fetch.Request.params()
+  @spec params(t(), [{:format, :query | :json | :keyword}]) ::
+          Electric.Client.Fetch.Request.params()
   def params(%__MODULE__{} = shape, opts \\ []) do
-    %{where: where, columns: columns, params: params} = shape
-    table_name = url_table_name(shape)
+    %{where: where, columns: columns, params: params, replica: replica} = shape
     format = Keyword.get(opts, :format, :query)
 
-    %{table: table_name}
+    shape
+    |> table_params(format)
     |> Util.map_put_if(:where, where, is_binary(where))
     |> Util.map_put_if(
       :columns,
       fn -> params_columns_list(columns, format) end,
       is_list(columns)
     )
+    |> maybe_add_replica(replica, format)
     |> maybe_add_where_params(:params, params, format)
     |> normalize_keys(format)
+  end
+
+  defp table_params(shape, :keyword) do
+    Map.take(shape, [:table, :namespace])
+    |> Map.reject(&is_nil(elem(&1, 1)))
+  end
+
+  defp table_params(shape, _format) do
+    %{table: url_table_name(shape)}
   end
 
   defp params_columns_list(columns, :query) when is_list(columns) do
     Enum.join(columns, ",")
   end
 
-  defp params_columns_list(columns, :json) when is_list(columns) do
+  defp params_columns_list(columns, format)
+       when is_list(columns) and format in [:json, :keyword] do
     columns
+  end
+
+  defp maybe_add_replica(input, :default, _format) do
+    input
+  end
+
+  defp maybe_add_replica(input, replica, :keyword) when is_atom(replica) do
+    Map.put(input, :replica, replica)
+  end
+
+  defp maybe_add_replica(input, replica, _) when is_atom(replica) do
+    Map.put(input, :replica, to_string(replica))
   end
 
   defp maybe_add_where_params(input, _, nil, _), do: input
@@ -224,7 +266,7 @@ defmodule Electric.Client.ShapeDefinition do
     |> Map.merge(input)
   end
 
-  defp put_param_map(input, key, params, :json) do
+  defp put_param_map(input, key, params, format) when format in [:json, :keyword] do
     Map.put(input, key, params)
   end
 
@@ -234,5 +276,9 @@ defmodule Electric.Client.ShapeDefinition do
 
   defp normalize_keys(params, :json) do
     params
+  end
+
+  defp normalize_keys(params, :keyword) do
+    Map.to_list(params)
   end
 end

--- a/packages/elixir-client/lib/electric/client/shape_definition.ex
+++ b/packages/elixir-client/lib/electric/client/shape_definition.ex
@@ -14,42 +14,43 @@ defmodule Electric.Client.ShapeDefinition do
 
   defstruct @public_keys ++ [parser: {Electric.Client.ValueMapper, []}]
 
-  @schema NimbleOptions.new!(
-            where: [
-              type: {:or, [nil, :string]},
-              required: false,
-              default: nil,
-              doc: "Filter the table according to the where clause."
-            ],
-            columns: [
-              type: {:or, [nil, {:list, :string}]},
-              default: nil,
-              doc:
-                "List of columns to include in the shape. Must include all primary keys. If `nil` this is equivalent to all columns (`SELECT *`)"
-            ],
-            namespace: [
-              type: {:or, [nil, :string]},
-              required: false,
-              default: nil,
-              doc:
-                "The namespace the table belongs to. If `nil` then Postgres will use whatever schema is the default (usually `public`)."
-            ],
-            params: [
-              type: {:or, [nil, {:map, :pos_integer, :string}, {:list, :string}]},
-              default: nil,
-              doc:
-                "Values of positional parameters in the where clause. These will substitute `$i` placeholder in the where clause."
-            ],
-            parser: [
-              type: :mod_arg,
-              default: {Electric.Client.ValueMapper, []},
-              doc: """
-              A `{module, args}` tuple specifying the `Electric.Client.ValueMapper`
-              implementation to use for mapping values from the sync stream into Elixir
-              terms.
-              """
-            ]
-          )
+  @schema_opts [
+    where: [
+      type: {:or, [nil, :string]},
+      required: false,
+      default: nil,
+      doc: "Filter the table according to the where clause."
+    ],
+    columns: [
+      type: {:or, [nil, {:list, :string}]},
+      default: nil,
+      doc:
+        "List of columns to include in the shape. Must include all primary keys. If `nil` this is equivalent to all columns (`SELECT *`)"
+    ],
+    namespace: [
+      type: {:or, [nil, :string]},
+      required: false,
+      default: nil,
+      doc:
+        "The namespace the table belongs to. If `nil` then Postgres will use whatever schema is the default (usually `public`)."
+    ],
+    params: [
+      type: {:or, [nil, {:map, :pos_integer, :string}, {:list, :string}]},
+      default: nil,
+      doc:
+        "Values of positional parameters in the where clause. These will substitute `$i` placeholder in the where clause."
+    ],
+    parser: [
+      type: :mod_arg,
+      default: {Electric.Client.ValueMapper, []},
+      doc: """
+      A `{module, args}` tuple specifying the `Electric.Client.ValueMapper`
+      implementation to use for mapping values from the sync stream into Elixir
+      terms.
+      """
+    ]
+  ]
+  @schema NimbleOptions.new!(@schema_opts)
 
   @type t :: %__MODULE__{
           namespace: String.t() | nil,
@@ -61,6 +62,9 @@ defmodule Electric.Client.ShapeDefinition do
 
   @type option :: unquote(NimbleOptions.option_typespec(@schema))
   @type options :: [option()]
+
+  @doc false
+  def schema_definition, do: @schema_opts
 
   @spec new(String.t() | keyword()) :: {:ok, t()} | {:error, term()}
   def new(table_name) when is_binary(table_name) do

--- a/packages/elixir-client/lib/electric/client/shape_definition.ex
+++ b/packages/elixir-client/lib/electric/client/shape_definition.ex
@@ -112,18 +112,28 @@ defmodule Electric.Client.ShapeDefinition do
     end
   end
 
+  def new(table, _opts) do
+    {:error, "Missing or invalid table: #{inspect(table)}"}
+  end
+
   def new!(opts) when is_list(opts) do
-    case new(opts) do
-      {:ok, shape} -> shape
-      {:error, %NimbleOptions.ValidationError{} = error} -> raise error
-    end
+    opts
+    |> new()
+    |> raise_for_invalid!()
   end
 
   @spec new!(String.t(), options()) :: t() | no_return()
   def new!(table_name, opts \\ []) do
-    case new(table_name, opts) do
+    table_name
+    |> new(opts)
+    |> raise_for_invalid!()
+  end
+
+  defp raise_for_invalid!(result) do
+    case result do
       {:ok, shape} -> shape
       {:error, %NimbleOptions.ValidationError{} = error} -> raise error
+      {:error, message} when is_binary(message) -> raise ArgumentError, message: message
     end
   end
 

--- a/packages/elixir-client/test/electric/client/ecto_adapter_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter_test.exs
@@ -283,6 +283,14 @@ defmodule Electric.Client.EctoAdapterTest do
                Enum.sort(["id", "city", "temp_lo", "temp_hi", "prcp", "meta"])
     end
 
+    test "raises if changeset function returns something other than a Changeset" do
+      changeset_fun = fn _params -> %TestTable{} end
+
+      assert_raise ArgumentError, fn ->
+        EctoAdapter.shape_from_changeset!(changeset_fun)
+      end
+    end
+
     defmodule User do
       defstruct [:name, :email, :age]
     end
@@ -440,6 +448,12 @@ defmodule Electric.Client.EctoAdapterTest do
                inserted_at: %NaiveDateTime{},
                updated_at: %NaiveDateTime{}
              } = message.value
+    end
+
+    test "raises if passed a module that isn't an ecto schema", ctx do
+      assert_raise ArgumentError, fn ->
+        stream(ctx, __MODULE__)
+      end
     end
   end
 

--- a/packages/elixir-client/test/electric/client/ecto_adapter_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter_test.exs
@@ -6,6 +6,7 @@ end
 defmodule Electric.Client.EctoAdapterTest do
   use ExUnit.Case, async: true
 
+  alias Electric.Client.ShapeDefinition
   alias Electric.Client
   alias Electric.Client.EctoAdapter
   alias Electric.Client.Message
@@ -30,6 +31,12 @@ defmodule Electric.Client.EctoAdapterTest do
       field(:visible, :boolean, default: true)
       timestamps()
     end
+
+    def changeset(data \\ %__MODULE__{}, params) do
+      Ecto.Changeset.cast(data, params, [:name, :amount, :price])
+      |> Ecto.Changeset.validate_required([:name, :amount, :price])
+      |> Ecto.Changeset.validate_number(:price, greater_than_or_equal_to: 10)
+    end
   end
 
   defmodule NamespacedTable do
@@ -43,7 +50,57 @@ defmodule Electric.Client.EctoAdapterTest do
       field(:price, :decimal, source: :cost)
       field(:net_price, Money)
       field(:visible, :boolean, default: true)
+      field(:virtual, :string, virtual: true)
       timestamps()
+    end
+  end
+
+  defmodule Weather do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    schema "weather" do
+      field(:city, :string)
+      field(:temp_lo, :integer)
+      field(:temp_hi, :integer)
+      field(:prcp, :float, default: 0.0)
+
+      has_many(:history, History)
+
+      embeds_one :meta, Meta do
+        field(:type, Ecto.Enum, values: [:foo, :bar, :baz])
+      end
+    end
+
+    def changeset(weather \\ %__MODULE__{}, data) do
+      weather
+      |> cast(data, [:city, :temp_lo, :temp_hi, :prcp])
+      |> validate_required([:city, :temp_lo, :temp_hi])
+      |> validate_number(:prcp, greater_than_or_equal_to: 0)
+      # meta only appears in the shape if required: true
+      |> cast_embed(:meta, required: true)
+      |> cast_assoc(:history)
+    end
+  end
+
+  defmodule History do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    schema "history" do
+      field(:date, :date)
+      field(:temp_lo, :integer)
+      field(:temp_hi, :integer)
+      field(:prcp, :float, default: 0.0)
+
+      belongs_to(:weather, Weather)
+    end
+
+    def changeset(history \\ %__MODULE__{}, data) do
+      history
+      |> cast(data, [:date, :temp_lo, :temp_hi, :prcp])
+      |> validate_required([:date, :temp_lo, :temp_hi])
+      |> validate_number(:prcp, greater_than_or_equal_to: 0)
     end
   end
 
@@ -149,6 +206,141 @@ defmodule Electric.Client.EctoAdapterTest do
                columns: ^column_names,
                parser: {EctoAdapter, TestTable}
              } = EctoAdapter.shape_from_query!(Ecto.Query.put_query_prefix(TestTable, "hamster"))
+    end
+
+    test "uses changeset information to define table + columns", _ctx do
+      assert %Electric.Client.ShapeDefinition{} =
+               shape = EctoAdapter.shape_from_changeset!(&TestTable.changeset/1)
+
+      assert Enum.sort(shape.columns) == ~w[amount cost id name]
+      assert shape.table == @table_name
+    end
+
+    test "allows custom namespace", _ctx do
+      assert %Electric.Client.ShapeDefinition{} =
+               shape =
+               EctoAdapter.shape_from_changeset!(&TestTable.changeset/1, namespace: "unsettling")
+
+      assert shape.namespace == "unsettling"
+    end
+
+    test "allows for custom where clause with params and parser", _ctx do
+      assert %Electric.Client.ShapeDefinition{} =
+               shape =
+               EctoAdapter.shape_from_changeset!(&TestTable.changeset/1,
+                 where: "name = $1",
+                 params: ["a name"],
+                 parser: {__MODULE__, []}
+               )
+
+      assert Enum.sort(shape.columns) == ~w[amount cost id name]
+
+      assert %ShapeDefinition{
+               where: "name = $1",
+               params: ["a name"],
+               parser: {__MODULE__, []}
+             } = shape
+    end
+
+    test "allows passing a custom changeset/1 function", _ctx do
+      changeset_fun =
+        fn params ->
+          Ecto.Changeset.cast(
+            %TestTable{},
+            params,
+            [:name, :price]
+          )
+          |> Ecto.Changeset.validate_required([:name])
+          |> Ecto.Changeset.validate_number(:price, greater_than_or_equal_to: 10)
+        end
+
+      assert %Electric.Client.ShapeDefinition{} =
+               shape = EctoAdapter.shape_from_changeset!(changeset_fun)
+
+      assert Enum.sort(shape.columns) == ~w[cost id name]
+      assert shape.table == @table_name
+    end
+
+    test "allows passing a changeset", _ctx do
+      changeset =
+        %TestTable{}
+        |> Ecto.Changeset.cast(%{}, [:name, :price])
+        |> Ecto.Changeset.validate_required([:name])
+        |> Ecto.Changeset.validate_number(:price, greater_than_or_equal_to: 10)
+
+      assert %Electric.Client.ShapeDefinition{} =
+               shape = EctoAdapter.shape_from_changeset!(changeset)
+
+      assert Enum.sort(shape.columns) == ~w[cost id name]
+      assert shape.table == @table_name
+    end
+
+    test "supports complex changesets", _ctx do
+      assert %Electric.Client.ShapeDefinition{} =
+               shape = EctoAdapter.shape_from_changeset!(&Weather.changeset/1)
+
+      assert Enum.sort(shape.columns) ==
+               Enum.sort(["id", "city", "temp_lo", "temp_hi", "prcp", "meta"])
+    end
+
+    defmodule User do
+      defstruct [:name, :email, :age]
+    end
+
+    # no point supporting schemaless changesets - you might as well just
+    # call ShapeDefinition.new/2
+    test "raises if given a schemaless changeset", _ctx do
+      changeset =
+        {%User{}, %{name: :string, email: :string, age: :integer}}
+        |> Ecto.Changeset.cast(%{}, [:name, :email, :age])
+        |> Ecto.Changeset.validate_required([:name, :email, :age])
+        |> Ecto.Changeset.validate_number(:age, greater_than: 0)
+
+      assert_raise ArgumentError, fn ->
+        EctoAdapter.shape_from_changeset!(changeset)
+      end
+    end
+
+    test "derives correct namespace from changeset + schema", _ctx do
+      changeset_fun =
+        fn params ->
+          Ecto.Changeset.cast(
+            %NamespacedTable{},
+            params,
+            [:name, :amount, :price, :visible]
+          )
+          |> Ecto.Changeset.validate_required([:name, :amount, :price, :visible])
+          |> Ecto.Changeset.validate_number(:price, greater_than_or_equal_to: 10)
+        end
+
+      assert %Electric.Client.ShapeDefinition{} =
+               shape =
+               EctoAdapter.shape_from_changeset!(changeset_fun)
+
+      assert Enum.sort(shape.columns) == ~w[amount cost id name visible]
+      assert shape.table == "my_table"
+      assert shape.namespace == "myapp"
+    end
+
+    test "ignores virtual fields", _ctx do
+      changeset_fun =
+        fn params ->
+          Ecto.Changeset.cast(
+            %NamespacedTable{},
+            params,
+            [:name, :amount, :price, :virtual]
+          )
+          |> Ecto.Changeset.validate_required([:name, :amount, :price])
+          |> Ecto.Changeset.validate_number(:price, greater_than_or_equal_to: 10)
+        end
+
+      assert %Electric.Client.ShapeDefinition{} =
+               shape =
+               EctoAdapter.shape_from_changeset!(changeset_fun)
+
+      assert Enum.sort(shape.columns) == ~w[amount cost id name]
+      assert shape.table == "my_table"
+      assert shape.namespace == "myapp"
     end
   end
 

--- a/packages/elixir-client/test/electric/client/fetch/request_test.exs
+++ b/packages/elixir-client/test/electric/client/fetch/request_test.exs
@@ -33,7 +33,7 @@ defmodule Electric.Client.Fetch.RequestTest do
       params = URI.decode_query(query)
 
       # should have sorted parameters
-      assert query == "table=my_table&cursor=123948&handle=my-shape&live=true&offset=1234_1"
+      assert query == "cursor=123948&handle=my-shape&live=true&offset=1234_1&table=my_table"
 
       assert %{
                "table" => "my_table",

--- a/packages/elixir-client/test/electric/client/shape_definition_test.exs
+++ b/packages/elixir-client/test/electric/client/shape_definition_test.exs
@@ -48,40 +48,49 @@ defmodule Electric.Client.ShapeDefinitionTest do
       assert {:ok, shape} = ShapeDefinition.new("my_table", columns: ["id", "size", "cost"])
 
       assert ShapeDefinition.params(shape, format: :query) == %{
-               columns: "id,size,cost",
-               table: "my_table"
+               "columns" => "id,size,cost",
+               "table" => "my_table"
              }
 
       assert ShapeDefinition.params(shape) == %{
-               columns: "id,size,cost",
-               table: "my_table"
+               "columns" => "id,size,cost",
+               "table" => "my_table"
              }
     end
 
     test "returns params as separate key-value pairs when params is a list" do
-      assert {:ok, shape} = ShapeDefinition.new("my_table", where: "id = $1", params: ["id1"])
+      assert {:ok, shape} =
+               ShapeDefinition.new("my_table",
+                 where: "id = $1 and value > $2",
+                 params: ["id1", 2]
+               )
 
       assert ShapeDefinition.params(shape, format: :query) == %{
                "params[1]" => "id1",
-               where: "id = $1",
-               table: "my_table"
+               "params[2]" => "2",
+               "where" => "id = $1 and value > $2",
+               "table" => "my_table"
              }
     end
 
     test "returns params as separate key-value pairs when params is an object" do
       assert {:ok, shape} =
-               ShapeDefinition.new("my_table", where: "id = $1", params: %{1 => "id1"})
+               ShapeDefinition.new("my_table",
+                 where: "id = $1 and value > $2",
+                 params: %{1 => "id1", 2 => 2}
+               )
 
       assert ShapeDefinition.params(shape, format: :query) == %{
                "params[1]" => "id1",
-               where: "id = $1",
-               table: "my_table"
+               "params[2]" => "2",
+               "where" => "id = $1 and value > $2",
+               "table" => "my_table"
              }
     end
   end
 
   describe "params/2 with `:json` formatting" do
-    test "returns column names joined by comma" do
+    test "returns column names as a list" do
       assert {:ok, shape} = ShapeDefinition.new("my_table", columns: ["id", "size", "cost"])
 
       assert ShapeDefinition.params(shape, format: :json) == %{
@@ -91,26 +100,35 @@ defmodule Electric.Client.ShapeDefinitionTest do
     end
 
     test "returns params as separate key-value pairs when params is a list" do
-      assert {:ok, shape} = ShapeDefinition.new("my_table", where: "id = $1", params: ["id1"])
+      assert {:ok, shape} =
+               ShapeDefinition.new("my_table",
+                 where: "id = $1 and amount > $2",
+                 params: ["id1", 2]
+               )
 
       assert ShapeDefinition.params(shape, format: :json) == %{
                params: %{
-                 "1" => "id1"
+                 "1" => "id1",
+                 "2" => "2"
                },
-               where: "id = $1",
+               where: "id = $1 and amount > $2",
                table: "my_table"
              }
     end
 
     test "returns params as separate key-value pairs when params is an object" do
       assert {:ok, shape} =
-               ShapeDefinition.new("my_table", where: "id = $1", params: %{1 => "id1"})
+               ShapeDefinition.new("my_table",
+                 where: "id = $1 and value > $2",
+                 params: %{1 => "id1", 2 => 2}
+               )
 
       assert ShapeDefinition.params(shape, format: :json) == %{
                params: %{
-                 "1" => "id1"
+                 "1" => "id1",
+                 "2" => "2"
                },
-               where: "id = $1",
+               where: "id = $1 and value > $2",
                table: "my_table"
              }
     end

--- a/packages/elixir-client/test/electric/client/shape_definition_test.exs
+++ b/packages/elixir-client/test/electric/client/shape_definition_test.exs
@@ -87,6 +87,29 @@ defmodule Electric.Client.ShapeDefinitionTest do
                "table" => "my_table"
              }
     end
+
+    test "excludes replica setting if default" do
+      assert {:ok, shape} = ShapeDefinition.new("my_table", replica: :default)
+
+      assert ShapeDefinition.params(shape, format: :query) == %{
+               "table" => "my_table"
+             }
+
+      assert {:ok, shape} = ShapeDefinition.new("my_table")
+
+      assert ShapeDefinition.params(shape, format: :query) == %{
+               "table" => "my_table"
+             }
+    end
+
+    test "includes replica setting if not default" do
+      assert {:ok, shape} = ShapeDefinition.new("my_table", replica: :full)
+
+      assert ShapeDefinition.params(shape, format: :query) == %{
+               "replica" => "full",
+               "table" => "my_table"
+             }
+    end
   end
 
   describe "params/2 with `:json` formatting" do
@@ -131,6 +154,69 @@ defmodule Electric.Client.ShapeDefinitionTest do
                where: "id = $1 and value > $2",
                table: "my_table"
              }
+    end
+  end
+
+  describe "params/2 with `:keyword` formatting" do
+    defp assert_keyword_params_equal(shape, expected) do
+      assert shape |> ShapeDefinition.params(format: :keyword) |> Enum.sort() ==
+               Enum.sort(expected)
+    end
+
+    test "keeps table and namespace separate" do
+      assert {:ok, shape} =
+               ShapeDefinition.new("my_table",
+                 namespace: "other",
+                 columns: ["id", "size", "cost"]
+               )
+
+      assert_keyword_params_equal(shape,
+        namespace: "other",
+        columns: ["id", "size", "cost"],
+        table: "my_table"
+      )
+    end
+
+    test "does not stringify replica" do
+      assert {:ok, shape} =
+               ShapeDefinition.new("my_table",
+                 namespace: "other",
+                 replica: :full,
+                 columns: ["id", "size", "cost"]
+               )
+
+      assert_keyword_params_equal(shape,
+        namespace: "other",
+        replica: :full,
+        columns: ["id", "size", "cost"],
+        table: "my_table"
+      )
+    end
+
+    test "returns column names as a list" do
+      assert {:ok, shape} = ShapeDefinition.new("my_table", columns: ["id", "size", "cost"])
+
+      assert_keyword_params_equal(shape,
+        columns: ["id", "size", "cost"],
+        table: "my_table"
+      )
+    end
+
+    test "returns params as separate key-value pairs when params is a list" do
+      assert {:ok, shape} =
+               ShapeDefinition.new("my_table",
+                 where: "id = $1 and amount > $2",
+                 params: ["id1", 2]
+               )
+
+      assert_keyword_params_equal(shape,
+        params: %{
+          "1" => "id1",
+          "2" => "2"
+        },
+        where: "id = $1 and amount > $2",
+        table: "my_table"
+      )
     end
   end
 end

--- a/packages/elixir-client/test/electric/client/shape_definition_test.exs
+++ b/packages/elixir-client/test/electric/client/shape_definition_test.exs
@@ -5,7 +5,7 @@ defmodule Electric.Client.ShapeDefinitionTest do
 
   doctest ShapeDefinition, import: true
 
-  describe "new" do
+  describe "new/2" do
     test "includes columns" do
       assert {:ok, shape} = ShapeDefinition.new("my_table", columns: ["id", "size", "cost"])
       assert shape.columns == ["id", "size", "cost"]
@@ -13,6 +13,14 @@ defmodule Electric.Client.ShapeDefinitionTest do
 
     test "errors if column list is invalid" do
       assert {:error, _} = ShapeDefinition.new("my_table", columns: "id")
+    end
+  end
+
+  describe "new!/1" do
+    test "raises for invalid config" do
+      assert_raise ArgumentError, fn ->
+        ShapeDefinition.new!(columns: ["id"])
+      end
     end
   end
 

--- a/packages/elixir-client/test/electric/client_test.exs
+++ b/packages/elixir-client/test/electric/client_test.exs
@@ -459,7 +459,7 @@ defmodule Electric.ClientTest do
 
     test "schema module", ctx do
       %{client: %{params: params}} = Client.stream(ctx.client, TestTable)
-      assert %{table: "test_table", columns: "id,name,amount,cost"} = params
+      assert %{"table" => "test_table", "columns" => "id,name,amount,cost"} = params
     end
 
     test "ecto query", ctx do
@@ -469,7 +469,11 @@ defmodule Electric.ClientTest do
 
       %{client: %{params: params}} = Client.stream(ctx.client, query)
 
-      assert %{table: "test_table", where: "(\"cost\" > 10)", columns: "id,name,amount,cost"} =
+      assert %{
+               "table" => "test_table",
+               "where" => "(\"cost\" > 10)",
+               "columns" => "id,name,amount,cost"
+             } =
                params
     end
 
@@ -477,7 +481,7 @@ defmodule Electric.ClientTest do
       %{client: %{params: params}} =
         Client.stream(ctx.client, &TestTable.changeset/1)
 
-      assert %{table: "test_table", columns: "id,name,amount,cost"} =
+      assert %{"table" => "test_table", "columns" => "id,name,amount,cost"} =
                params
     end
 
@@ -486,7 +490,7 @@ defmodule Electric.ClientTest do
 
       %{client: %{params: params}} = Client.stream(ctx.client, changeset)
 
-      assert %{table: "test_table", columns: "id,name,amount,cost"} =
+      assert %{"table" => "test_table", "columns" => "id,name,amount,cost"} =
                params
     end
   end

--- a/packages/elixir-client/test/support/money.ex
+++ b/packages/elixir-client/test/support/money.ex
@@ -3,7 +3,7 @@ defmodule Support.Money do
 
   @impl Ecto.ParameterizedType
   def init(opts) do
-    {:ok, opts}
+    opts
   end
 
   @impl Ecto.ParameterizedType


### PR DESCRIPTION
Allows for generating a ShapeDefinition from an Ecto.Changeset

Also bundles a few quality-of-life changes:

- ShapeDefinition.params/1 returns a `%{binary => binary}` map in query string mode, rather than a mix of atom and binary keys
- Widen accepted types for where parameters from `:string` to [:string, :integer, :float, :boolean]` to make life simpler for user. these types are trivial to convert to strings so why not do that for people
- Give ShapeDefinitions a `replica` setting. This is how it should have been to begin with -- the replica mode is a property of the shape, not of the stream
- Expose the ShapeDefinition validation schema so we can split options and validate partial shape parameters (Phoenix.Sync.PredefinedShape accepts a big bag of options that we need to assign appropriately)