### PR TITLE
fix(sync-service): Make Shape.comparable robust after serialisation

### DIFF
--- a/.changeset/calm-insects-fly.md
+++ b/.changeset/calm-insects-fly.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix bug in Shape.comparable/1 preventing client shapes matching existing ones loaded from storage

--- a/packages/sync-service/lib/electric/replication/eval/expr.ex
+++ b/packages/sync-service/lib/electric/replication/eval/expr.ex
@@ -67,6 +67,12 @@ defmodule Electric.Replication.Eval.Expr do
 
   def from_json_safe(_),
     do: {:error, "Incorrect serialized format: keys must be `version`, `query`, `used_refs`"}
+
+  defimpl Electric.Shapes.Shape.Comparable do
+    def comparable(%Electric.Replication.Eval.Expr{} = expr) do
+      %{expr | eval: Electric.Shapes.Shape.Comparable.comparable(expr.eval)}
+    end
+  end
 end
 
 defimpl Jason.Encoder, for: Electric.Replication.Eval.Expr do

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -19,9 +19,7 @@ defmodule Electric.Replication.Eval.Parser do
     end
 
     defimpl Electric.Shapes.Shape.Comparable do
-      def comparable(%Const{} = const) do
-        %{const | location: 0}
-      end
+      def comparable(%Const{} = const), do: %{const | location: 0}
     end
   end
 
@@ -29,9 +27,7 @@ defmodule Electric.Replication.Eval.Parser do
     defstruct [:value, :meta, location: 0]
 
     defimpl Electric.Shapes.Shape.Comparable do
-      def comparable(%UnknownConst{} = unknown_const) do
-        %{unknown_const | location: 0}
-      end
+      def comparable(%UnknownConst{} = unknown_const), do: %{unknown_const | location: 0}
     end
   end
 
@@ -47,9 +43,7 @@ defmodule Electric.Replication.Eval.Parser do
     end
 
     defimpl Electric.Shapes.Shape.Comparable do
-      def comparable(%Ref{} = ref) do
-        %{ref | location: 0}
-      end
+      def comparable(%Ref{} = ref), do: %{ref | location: 0}
     end
   end
 
@@ -65,9 +59,7 @@ defmodule Electric.Replication.Eval.Parser do
     end
 
     defimpl Electric.Shapes.Shape.Comparable do
-      def comparable(%Array{} = array) do
-        %{array | location: 0}
-      end
+      def comparable(%Array{} = array), do: %{array | location: 0}
     end
   end
 
@@ -96,13 +88,10 @@ defmodule Electric.Replication.Eval.Parser do
     end
 
     defimpl Electric.Shapes.Shape.Comparable do
-      def comparable(%Func{} = func) do
-        %{
-          func
-          | location: 0,
-            args: Enum.map(func.args, &Electric.Shapes.Shape.Comparable.comparable/1)
-        }
-      end
+      alias Electric.Shapes.Shape.Comparable
+
+      def comparable(%Func{} = func),
+        do: %{func | location: 0, args: Enum.map(func.args, &Comparable.comparable/1)}
     end
   end
 

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -17,10 +17,22 @@ defmodule Electric.Replication.Eval.Parser do
         concat(["#Const(", to_doc(value, opts), ")"])
       end
     end
+
+    defimpl Electric.Shapes.Shape.Comparable do
+      def comparable(%Const{} = const) do
+        %{const | location: 0}
+      end
+    end
   end
 
   defmodule UnknownConst do
     defstruct [:value, :meta, location: 0]
+
+    defimpl Electric.Shapes.Shape.Comparable do
+      def comparable(%UnknownConst{} = unknown_const) do
+        %{unknown_const | location: 0}
+      end
+    end
   end
 
   defmodule Ref do
@@ -33,6 +45,12 @@ defmodule Electric.Replication.Eval.Parser do
         concat(["#Ref(", Enum.join(path, "."), ")"])
       end
     end
+
+    defimpl Electric.Shapes.Shape.Comparable do
+      def comparable(%Ref{} = ref) do
+        %{ref | location: 0}
+      end
+    end
   end
 
   defmodule Array do
@@ -43,6 +61,12 @@ defmodule Electric.Replication.Eval.Parser do
 
       def inspect(%Array{elements: elements}, opts) do
         concat(["#Array(", to_doc(elements, opts), ")"])
+      end
+    end
+
+    defimpl Electric.Shapes.Shape.Comparable do
+      def comparable(%Array{} = array) do
+        %{array | location: 0}
       end
     end
   end
@@ -68,6 +92,16 @@ defmodule Electric.Replication.Eval.Parser do
 
       def inspect(%Func{args: args, name: name}, opts) do
         concat(["Func(", name, ")", to_doc(args, opts)])
+      end
+    end
+
+    defimpl Electric.Shapes.Shape.Comparable do
+      def comparable(%Func{} = func) do
+        %{
+          func
+          | location: 0,
+            args: Enum.map(func.args, &Electric.Shapes.Shape.Comparable.comparable/1)
+        }
       end
     end
   end

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -571,7 +571,12 @@ defmodule Electric.Shapes.ShapeTest do
          %{inspector: inspector} do
       tests = [
         {"(FALSE)", ["false", "(false)", " false "]},
-        {"(VALUE IN (1,2,3))", ["value in (1, 2, 3)", ~s[("value" in (1, 2, 3))]]}
+        {"(VALUE IN (1,2,3))", ["value in (1, 2, 3)", ~s[("value" in (1, 2, 3))]]},
+        {~S|time '20:00:00' + date '2024-01-01'|,
+         [
+           ~S|((TIME '20:00:00') + (DATE '2024-01-01'))|,
+           ~S| (((time  '20:00:00')  +  (date  '2024-01-01')))|
+         ]}
       ]
 
       shape_fun = fn where ->

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -504,4 +504,93 @@ defmodule Electric.Shapes.ShapeTest do
       assert shape_old_decoded == shape_v1
     end
   end
+
+  describe "comparable/1" do
+    setup do
+      [
+        inspector:
+          Support.StubInspector.new(
+            tables: ["the_table", "another_table"],
+            columns: [
+              %{name: "id", type: "int8", pk_position: 0},
+              %{name: "value", type: "int8", pk_position: nil},
+              %{name: "size", type: "int8", pk_position: nil}
+            ]
+          )
+      ]
+    end
+
+    defp assert_shapes_equal(shape1, shape2) do
+      assert Shape.comparable(shape1) == Shape.comparable(shape2)
+      assert Shape.comparable(shape1) === Shape.comparable(shape2)
+    end
+
+    defp do_assert_shape_comparable(serialized_shape, reference_shape) do
+      assert {:ok, json} = Jason.encode(serialized_shape)
+      assert {:ok, serialized_shape} = Jason.decode!(json) |> Shape.from_json_safe()
+
+      assert_shapes_equal(serialized_shape, reference_shape)
+    end
+
+    defp assert_shape_comparable(serialized_shape, reference_shape) do
+      assert_shapes_equal(serialized_shape, reference_shape)
+
+      do_assert_shape_comparable(serialized_shape, reference_shape)
+      do_assert_shape_comparable(reference_shape, serialized_shape)
+    end
+
+    test "equal shapes compare as equal", %{inspector: inspector} do
+      assert {:ok, %Shape{} = shape1} =
+               Shape.new(~S|the_table|, where: "false", inspector: inspector)
+
+      assert {:ok, %Shape{} = shape2} =
+               Shape.new(~S|the_table|, where: "false", inspector: inspector)
+
+      assert_shape_comparable(shape1, shape2)
+    end
+
+    test "equal shapes compare as equal after json serialization", %{inspector: inspector} do
+      assert {:ok, %Shape{} = shape1} =
+               Shape.new(~S|the_table|,
+                 where: "(FALSE)",
+                 columns: ["id", "value", "size"],
+                 inspector: inspector
+               )
+
+      assert {:ok, %Shape{} = shape2} =
+               Shape.new(~S|the_table|,
+                 where: "(FALSE)",
+                 columns: ["id", "value", "size"],
+                 inspector: inspector
+               )
+
+      assert_shape_comparable(shape1, shape2)
+    end
+
+    test "equal shapes with equivalent but not identical where clauses compare as equal after json serialization",
+         %{inspector: inspector} do
+      tests = [
+        {"(FALSE)", ["false", "(false)", " false "]},
+        {"(VALUE IN (1,2,3))", ["value in (1, 2, 3)", ~s[("value" in (1, 2, 3))]]}
+      ]
+
+      shape_fun = fn where ->
+        Shape.new(~S|the_table|,
+          where: where,
+          columns: ["id", "value", "size"],
+          inspector: inspector
+        )
+      end
+
+      for {base, wheres} <- tests do
+        assert {:ok, %Shape{} = shape1} = shape_fun.(base)
+
+        for where <- wheres do
+          assert {:ok, %Shape{} = shape2} = shape_fun.(where)
+
+          assert_shape_comparable(shape1, shape2)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because the original sql where clause is normalised before serialisation, shapes generated with a consistent where clause would not match against existing, identical, shapes due to differences in the parser output.

So a shape generated with the where clause `(USER_ID = 'something')` would be deserialised with the where clause `user_id = 'something'` which wouldn't match against shapes coming from clients with the original form because the `location` fields in the deserialised version would be off-by-one due to the missing parentheses.

Fixes https://github.com/electric-sql/phoenix_sync/issues/56