### PR TITLE
elixir-client: Add support for more Ecto field types

### DIFF
--- a/.changeset/two-singers-care.md
+++ b/.changeset/two-singers-care.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Add support for casting array and map fields to the Ecto.Adapter

--- a/packages/elixir-client/config/config.exs
+++ b/packages/elixir-client/config/config.exs
@@ -5,6 +5,11 @@ if Mix.env() == :test do
     report_file: "test-junit-report.xml",
     automatic_create_dir?: true,
     report_dir: "./junit"
+
+  config :plug, :statuses, %{
+    530 => "CF unable to resolve origin hostname",
+    599 => "Some random error"
+  }
 end
 
 config :electric,

--- a/packages/elixir-client/lib/electric/client/ecto_adapter/array_decoder.ex
+++ b/packages/elixir-client/lib/electric/client/ecto_adapter/array_decoder.ex
@@ -1,0 +1,94 @@
+defmodule Electric.Client.EctoAdapter.ArrayDecoder do
+  alias Electric.Client.EctoAdapter
+
+  def decode!("{}", _type), do: []
+
+  def decode!(encoded_array, type) when is_binary(encoded_array) do
+    {"", [result]} = decode_array(encoded_array, [], {EctoAdapter.cast_to(type), encoded_array})
+
+    result
+  end
+
+  ##############################
+
+  defp decode_array("", acc, _state) do
+    {"", :lists.reverse(acc)}
+  end
+
+  defp decode_array(<<"{}", rest::bitstring>>, acc, state) do
+    decode_array(rest, [[] | acc], state)
+  end
+
+  defp decode_array(<<"{", rest::bitstring>>, acc, state) do
+    {rest, array} = decode_array(rest, [], state)
+    decode_array(rest, [array | acc], state)
+  end
+
+  defp decode_array(<<"}", rest::bitstring>>, acc, _state) do
+    {rest, :lists.reverse(acc)}
+  end
+
+  defp decode_array(<<?,, rest::bitstring>>, acc, state) do
+    decode_array(rest, acc, state)
+  end
+
+  defp decode_array(<<?", rest::bitstring>>, acc, state) do
+    {rest, elem} = decode_quoted_elem(rest, [], state)
+    decode_array(rest, [elem | acc], state)
+  end
+
+  defp decode_array(rest, acc, state) do
+    {rest, elem} = decode_elem(rest, [], state)
+    decode_array(rest, [elem | acc], state)
+  end
+
+  ##############################
+
+  defp decode_elem(<<",", _::bitstring>> = rest, acc, state),
+    do: {rest, cast(acc, state)}
+
+  defp decode_elem(<<"{", rest::bitstring>>, [], state),
+    do: decode_array(rest, [], state)
+
+  defp decode_elem(<<"}", _::bitstring>> = rest, acc, state),
+    do: {rest, cast(acc, state)}
+
+  defp decode_elem(<<c::utf8, rest::bitstring>>, acc, state),
+    do: decode_elem(rest, [acc | <<c::utf8>>], state)
+
+  defp decode_elem("", _acc, {_cast_fun, source}) do
+    raise "malformed array #{inspect(source)}"
+  end
+
+  ##############################
+
+  defp decode_quoted_elem(<<?", rest::bitstring>>, acc, state),
+    do: {rest, cast_quoted(acc, state)}
+
+  defp decode_quoted_elem(<<"\\\"", rest::bitstring>>, acc, state),
+    do: decode_quoted_elem(rest, [acc | [?"]], state)
+
+  defp decode_quoted_elem(<<c::utf8, rest::bitstring>>, acc, state),
+    do: decode_quoted_elem(rest, [acc | <<c::utf8>>], state)
+
+  defp decode_quoted_elem("", _acc, {_cast_fun, source}) do
+    raise "malformed array #{inspect(source)}"
+  end
+
+  ##############################
+
+  defp cast(iodata, {cast_fun, _source}) do
+    iodata
+    |> IO.iodata_to_binary()
+    |> case do
+      "NULL" -> nil
+      value -> cast_fun.(value)
+    end
+  end
+
+  defp cast_quoted(iodata, {cast_fun, _source}) do
+    iodata
+    |> IO.iodata_to_binary()
+    |> cast_fun.()
+  end
+end

--- a/packages/elixir-client/lib/electric/client/ecto_adapter/array_decoder.ex
+++ b/packages/elixir-client/lib/electric/client/ecto_adapter/array_decoder.ex
@@ -47,9 +47,6 @@ defmodule Electric.Client.EctoAdapter.ArrayDecoder do
   defp decode_elem(<<",", _::bitstring>> = rest, acc, state),
     do: {rest, cast(acc, state)}
 
-  defp decode_elem(<<"{", rest::bitstring>>, [], state),
-    do: decode_array(rest, [], state)
-
   defp decode_elem(<<"}", _::bitstring>> = rest, acc, state),
     do: {rest, cast(acc, state)}
 
@@ -57,7 +54,7 @@ defmodule Electric.Client.EctoAdapter.ArrayDecoder do
     do: decode_elem(rest, [acc | <<c::utf8>>], state)
 
   defp decode_elem("", _acc, {_cast_fun, source}) do
-    raise "malformed array #{inspect(source)}"
+    raise ArgumentError, message: "malformed array: #{source}"
   end
 
   ##############################
@@ -72,7 +69,7 @@ defmodule Electric.Client.EctoAdapter.ArrayDecoder do
     do: decode_quoted_elem(rest, [acc | <<c::utf8>>], state)
 
   defp decode_quoted_elem("", _acc, {_cast_fun, source}) do
-    raise "malformed array #{inspect(source)}"
+    raise ArgumentError, message: "malformed array: #{source}"
   end
 
   ##############################

--- a/packages/elixir-client/test/electric/client/ecto_adapter/array_decoder_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter/array_decoder_test.exs
@@ -59,4 +59,14 @@ defmodule Electric.Client.EctoAdapter.ArrayDecoderTest do
              [%{}, %{}]
            ]
   end
+
+  test "raises if the array is invalid" do
+    assert_raise ArgumentError, "malformed array: {a,b,c\"", fn ->
+      ArrayDecoder.decode!(~s[{a,b,c"], :string)
+    end
+
+    assert_raise ArgumentError, "malformed array: {a,b,\"", fn ->
+      ArrayDecoder.decode!(~s[{a,b,"], :string)
+    end
+  end
 end

--- a/packages/elixir-client/test/electric/client/ecto_adapter/array_decoder_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter/array_decoder_test.exs
@@ -61,11 +61,11 @@ defmodule Electric.Client.EctoAdapter.ArrayDecoderTest do
   end
 
   test "raises if the array is invalid" do
-    assert_raise ArgumentError, "malformed array: {a,b,c\"", fn ->
+    assert_raise Ecto.CastError, fn ->
       ArrayDecoder.decode!(~s[{a,b,c"], :string)
     end
 
-    assert_raise ArgumentError, "malformed array: {a,b,\"", fn ->
+    assert_raise Ecto.CastError, fn ->
       ArrayDecoder.decode!(~s[{a,b,"], :string)
     end
   end

--- a/packages/elixir-client/test/electric/client/ecto_adapter/array_decoder_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter/array_decoder_test.exs
@@ -1,0 +1,62 @@
+defmodule Electric.Client.EctoAdapter.ArrayDecoderTest do
+  use ExUnit.Case, async: true
+  alias Electric.Client.EctoAdapter.ArrayDecoder
+
+  test "simple string arrays" do
+    assert ArrayDecoder.decode!(~s[{}], :string) == []
+    assert ArrayDecoder.decode!(~s[{a,b,c}], :string) == ["a", "b", "c"]
+    assert ArrayDecoder.decode!(~s[{"a","b","c"}], :string) == ["a", "b", "c"]
+    assert ArrayDecoder.decode!(~s[{"a{}","b","c"}], :string) == ["a{}", "b", "c"]
+    assert ArrayDecoder.decode!(~S[{"a\"","b","c"}], :string) == ["a\"", "b", "c"]
+
+    assert ArrayDecoder.decode!(~S[{"this isn't here","b","c"}], :string) == [
+             "this isn't here",
+             "b",
+             "c"
+           ]
+
+    assert ArrayDecoder.decode!(~S[{NULL,NULL,"NULL"}], :string) == [nil, nil, "NULL"]
+  end
+
+  test "nested string arrays" do
+    assert ArrayDecoder.decode!(~s[{{},{}}], :string) == [[], []]
+
+    assert ArrayDecoder.decode!(~s[{{"a","b","c"},{},{c,d,e}], :string) == [
+             ["a", "b", "c"],
+             [],
+             ["c", "d", "e"]
+           ]
+  end
+
+  test "simple integer arrays" do
+    assert ArrayDecoder.decode!(~s[{}], :integer) == []
+    assert ArrayDecoder.decode!(~s[{1,2,3}], :integer) == [1, 2, 3]
+    assert ArrayDecoder.decode!(~S[{NULL,NULL,23}], :integer) == [nil, nil, 23]
+  end
+
+  test "nested integer arrays" do
+    assert ArrayDecoder.decode!(~s[{{},{}}], :integer) == [[], []]
+
+    assert ArrayDecoder.decode!(~s[{{1,2,3},{},{4,5,6}], :integer) == [
+             [1, 2, 3],
+             [],
+             [4, 5, 6]
+           ]
+
+    assert ArrayDecoder.decode!(~s[{{{1,{2,{7,8}},3},{},{4,5,6}}], :integer) == [
+             [
+               [1, [2, [7, 8]], 3],
+               [],
+               [4, 5, 6]
+             ]
+           ]
+  end
+
+  test "nested jsonb arrays" do
+    assert ArrayDecoder.decode!(~s[{{{"{\\\"this\\\":4}"},"{}"},{},{"{}","{}"}], :map) == [
+             [[%{"this" => 4}], %{}],
+             [],
+             [%{}, %{}]
+           ]
+  end
+end

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -520,7 +520,7 @@ defmodule Electric.Shapes.Api do
 
       {:error, :unknown} ->
         # the shape has been deleted between the request validation and the attempt
-        # to resturn the log stream
+        # to return the log stream
         Response.error(request, @must_refetch, status: 409)
 
       {:error, error} ->


### PR DESCRIPTION
including:

- `{:array, type}`
- `:map`
- `:bitstring`
- `:binary`

And validate decoding of other types and embedded schemas