### PR TITLE
feat: allow publication alter debounce to be configurable

### DIFF
--- a/.changeset/tidy-days-matter.md
+++ b/.changeset/tidy-days-matter.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+feat: allow publication alter debounce to be configurable

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -202,7 +202,13 @@ config :electric,
   profile_where_clauses?: env!("ELECTRIC_PROFILE_WHERE_CLAUSES", :boolean, false),
   persistent_kv: persistent_kv_spec,
   listen_on_ipv6?: env!("ELECTRIC_LISTEN_ON_IPV6", :boolean, nil),
-  secret: secret
+  secret: secret,
+  publication_alter_debounce_ms:
+    env!(
+      "ELECTRIC_PUBLICATION_ALTER_DEBOUNCE_TIME",
+      &Electric.Config.parse_human_readable_time!/1,
+      nil
+    )
 
 if Electric.telemetry_enabled?() do
   config :sentry,

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -128,7 +128,8 @@ defmodule Electric.Application do
       chunk_bytes_threshold: get_env(opts, :chunk_bytes_threshold),
       telemetry_opts:
         telemetry_opts([instance_id: instance_id, installation_id: installation_id] ++ opts),
-      max_shapes: get_env(opts, :max_shapes)
+      max_shapes: get_env(opts, :max_shapes),
+      tweaks: [publication_alter_debounce_ms: get_env(opts, :publication_alter_debounce_ms)]
     )
   end
 

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -67,7 +67,9 @@ defmodule Electric.Config do
     otel_per_process_metrics?: false,
     telemetry_top_process_count: 5,
     ## Memory
-    shape_hibernate_after: :timer.seconds(30)
+    shape_hibernate_after: :timer.seconds(30),
+    ## Performance tweaks
+    publication_alter_debounce_ms: 0
   ]
 
   @installation_id_key "electric_installation_id"

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -75,6 +75,7 @@ defmodule Electric.Connection.Supervisor do
     replication_opts = Keyword.fetch!(opts, :replication_opts)
     inspector = Keyword.fetch!(shape_cache_opts, :inspector)
     persistent_kv = Keyword.fetch!(opts, :persistent_kv)
+    tweaks = Keyword.fetch!(opts, :tweaks)
 
     shape_cache_spec = {Electric.ShapeCache, shape_cache_opts}
 
@@ -82,7 +83,8 @@ defmodule Electric.Connection.Supervisor do
       {Electric.Replication.PublicationManager,
        stack_id: stack_id,
        publication_name: Keyword.fetch!(replication_opts, :publication_name),
-       db_pool: Keyword.fetch!(db_pool_opts, :name)}
+       db_pool: Keyword.fetch!(db_pool_opts, :name),
+       update_debounce_timeout: Keyword.get(tweaks, :publication_alter_debounce_ms, 0)}
 
     shape_log_collector_spec =
       {Electric.Replication.ShapeLogCollector,

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -39,8 +39,8 @@ defmodule Electric.Replication.Supervisor do
       consumer_supervisor,
       publication_manager,
       log_collector,
-      schema_reconciler,
-      shape_cache
+      shape_cache,
+      schema_reconciler
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -96,6 +96,7 @@ defmodule Electric.StackSupervisor do
                      "tweaks to the behaviour of parts of the supervision tree, used mostly for tests",
                    default: [],
                    keys: [
+                     publication_alter_debounce_ms: [type: :non_neg_integer, default: 0],
                      registry_partitions: [type: :non_neg_integer, required: false],
                      monitor_opts: [
                        type: :keyword_list,


### PR DESCRIPTION
- Introduce a tweak variable to debounce `ALTER PUBLICATION` calls
  - This is currently required for some setups against AWS aurora
- Fix weird startup order issue
  - We did start schema reconcilier, then schema cache, but essentially first functional line of the reconciler was to call into the schema cache, which was blocked on startup until it could refresh the publication and such. Putting the reconcilier behind schema cache in order makes it so our startup is more linear, and any shape requests that come in during startup (that need a publication alter) will be debounced together with the schema reconciler normalizing the publication