### PR TITLE
Bring back tls_certificate_check dependency

### DIFF
--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -96,6 +96,8 @@ defmodule Electric.MixProject do
         {:remote_ip, "~> 1.2"},
         {:req, "~> 0.5"},
         {:telemetry_poller, "~> 1.2"},
+        # tls_certificate_check is required by otel_exporter_otlp
+        {:tls_certificate_check, "~> 1.27"},
         {:tz, "~> 0.28"}
       ],
       dev_and_test_deps(),


### PR DESCRIPTION
Without this, we'd see the following log output at Electric startup:

    [debug] OTLP exporter failed to initialize: exception throw:
      {application_either_not_started_or_not_ready, tls_certificate_check}

      in function tls_certificate_check_shared_state:latest_shared_state_key/0
      (packages/sync-service/deps/tls_certificate_check/src/tls_certificate_check_shared_state.erl, line 479)
      in call from tls_certificate_check_shared_state:get_latest_shared_state/0
      (packages/sync-service/deps/tls_certificate_check/src/tls_certificate_check_shared_state.erl, line 455)
      in call from tls_certificate_check_shared_state:authoritative_certificate_values/0
      (packages/sync-service/deps/tls_certificate_check/src/tls_certificate_check_shared_state.erl, line 139)
      in call from tls_certificate_check:options/1
      (packages/sync-service/deps/tls_certificate_check/src/tls_certificate_check.erl, line 84)
      in call from otel_exporter_otlp:parse_endpoint/2
      (packages/sync-service/deps/opentelemetry_exporter/src/otel_exporter_otlp.erl, line 278)
      in call from otel_exporter_otlp:endpoint/2
      (packages/sync-service/deps/opentelemetry_exporter/src/otel_exporter_otlp.erl, line 240)
      in call from lists:filtermap_1/2 (lists.erl, line 2279)
      in call from otel_exporter_otlp:init/1
      (packages/sync-service/deps/opentelemetry_exporter/src/otel_exporter_otlp.erl, line 127)

    [warning] OTLP exporter failed to initialize with exception
      :throw:{:application_either_not_started_or_not_ready, :tls_certificate_check}