### PR TITLE
feat(sync-service): GenStage telemetry

### DIFF
--- a/.changeset/dull-mice-accept.md
+++ b/.changeset/dull-mice-accept.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add additional replication processing telemetry

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -59,14 +59,14 @@ defmodule Electric.Replication.ShapeLogCollector do
     timer = IntervalTimer.start_interval("message_to_collector")
     trace_context = OpenTelemetry.get_current_context()
     timer = GenStage.call(server, {:new_txn, txn, trace_context, timer}, :infinity)
-    intervals = IntervalTimer.intervals(timer)
+    durations = IntervalTimer.durations(timer)
 
-    for {name, duration} <- intervals do
-      OpenTelemetry.add_span_attributes("#{name}.duration_µs": duration)
+    for {interval_name, duration} <- durations do
+      OpenTelemetry.add_span_attributes("#{interval_name}.duration_µs": duration)
     end
 
     OpenTelemetry.add_span_attributes(
-      "new_txn_intervals.total_duration_µs": IntervalTimer.total_time(intervals)
+      "new_txn_intervals.total_duration_µs": IntervalTimer.total_time(durations)
     )
 
     :ok

--- a/packages/sync-service/lib/electric/telemetry/interval_timer.ex
+++ b/packages/sync-service/lib/electric/telemetry/interval_timer.ex
@@ -1,0 +1,31 @@
+defmodule Electric.Telemetry.IntervalTimer do
+  @state_key :timed_intervals
+
+  def state do
+    Process.get(@state_key, [])
+  end
+
+  def set_state(state) do
+    Process.put(@state_key, state)
+  end
+
+  def start(interval) do
+    [{interval, time()} | state()]
+    |> set_state()
+  end
+
+  def intervals do
+    intervals([time() | state()])
+    |> Enum.reverse()
+  end
+
+  defp intervals([end_time, {interval, start_time} | rest]) do
+    [{interval, end_time - start_time} | intervals([start_time | rest])]
+  end
+
+  defp intervals([_end_time]), do: []
+
+  defp time do
+    System.monotonic_time(:microsecond)
+  end
+end

--- a/packages/sync-service/lib/electric/telemetry/interval_timer.ex
+++ b/packages/sync-service/lib/electric/telemetry/interval_timer.ex
@@ -6,12 +6,12 @@ defmodule Electric.Telemetry.IntervalTimer do
 
   @default_state []
 
-  def start_interval(state \\ nil, interval) do
-    [{interval, time()} | state || @default_state]
+  def start_interval(state \\ nil, interval_name) do
+    [{interval_name, time()} | state || @default_state]
   end
 
   def durations(state) do
-    calculate_durations([time() | state])
+    calculate_durations(state, time())
     |> Enum.reverse()
   end
 
@@ -23,11 +23,14 @@ defmodule Electric.Telemetry.IntervalTimer do
     |> Enum.sum()
   end
 
-  defp calculate_durations([end_time, {interval, start_time} | rest]) do
-    [{interval, end_time - start_time} | calculate_durations([start_time | rest])]
+  defp calculate_durations([{interval_name, start_time} | rest], end_time) do
+    duration = {interval_name, end_time - start_time}
+    # since we're moving backwards through the intervals, the next interval's end time
+    # is this interval's start time:
+    [duration | calculate_durations(rest, _next_interval_end_time = start_time)]
   end
 
-  defp calculate_durations([_end_time]), do: []
+  defp calculate_durations([], _), do: []
 
   defp time do
     System.monotonic_time(:microsecond)

--- a/packages/sync-service/lib/electric/telemetry/interval_timer.ex
+++ b/packages/sync-service/lib/electric/telemetry/interval_timer.ex
@@ -1,4 +1,9 @@
 defmodule Electric.Telemetry.IntervalTimer do
+  @moduledoc """
+  Times intervals between calls to `start_interval/2`. This is useful when it is difficult to wrap an interval in a span, the state
+  can just be passed around instead, or kept in the process memory using `ProcessIntervalTimer`.
+  """
+
   @default_state []
 
   def start_interval(state \\ nil, interval) do
@@ -30,6 +35,10 @@ defmodule Electric.Telemetry.IntervalTimer do
 end
 
 defmodule Electric.Telemetry.ProcessIntervalTimer do
+  @moduledoc """
+  Times intervals between calls to `start_interval/2`. This is useful when it is difficult to wrap an interval in a span, the state
+  is stored in the process memory, allowing it to be accessed from any function on the process.
+  """
   alias Electric.Telemetry.IntervalTimer
 
   @state_key :timed_intervals

--- a/packages/sync-service/lib/electric/telemetry/interval_timer.ex
+++ b/packages/sync-service/lib/electric/telemetry/interval_timer.ex
@@ -1,11 +1,21 @@
 defmodule Electric.Telemetry.IntervalTimer do
-  def start(state, interval) do
-    [{interval, time()} | state]
+  @default_state []
+
+  def start_interval(state \\ nil, interval) do
+    [{interval, time()} | state || @default_state]
   end
 
   def intervals(state) do
     calculate_intervals([time() | state])
     |> Enum.reverse()
+  end
+
+  def total_time([]), do: 0
+
+  def total_time(intervals) do
+    intervals
+    |> Enum.map(fn {_, duration} -> duration end)
+    |> Enum.sum()
   end
 
   defp calculate_intervals([end_time, {interval, start_time} | rest]) do
@@ -32,8 +42,12 @@ defmodule Electric.Telemetry.ProcessIntervalTimer do
     Process.put(@state_key, state)
   end
 
-  def start(interval) do
-    IntervalTimer.start(state(), interval)
+  def wipe_state do
+    Process.delete(@state_key)
+  end
+
+  def start_interval(interval) do
+    IntervalTimer.start_interval(state(), interval)
     |> set_state()
   end
 

--- a/packages/sync-service/lib/electric/telemetry/interval_timer.ex
+++ b/packages/sync-service/lib/electric/telemetry/interval_timer.ex
@@ -1,4 +1,27 @@
 defmodule Electric.Telemetry.IntervalTimer do
+  def start(state, interval) do
+    [{interval, time()} | state]
+  end
+
+  def intervals(state) do
+    calculate_intervals([time() | state])
+    |> Enum.reverse()
+  end
+
+  defp calculate_intervals([end_time, {interval, start_time} | rest]) do
+    [{interval, end_time - start_time} | calculate_intervals([start_time | rest])]
+  end
+
+  defp calculate_intervals([_end_time]), do: []
+
+  defp time do
+    System.monotonic_time(:microsecond)
+  end
+end
+
+defmodule Electric.Telemetry.ProcessIntervalTimer do
+  alias Electric.Telemetry.IntervalTimer
+
   @state_key :timed_intervals
 
   def state do
@@ -10,22 +33,11 @@ defmodule Electric.Telemetry.IntervalTimer do
   end
 
   def start(interval) do
-    [{interval, time()} | state()]
+    IntervalTimer.start(state(), interval)
     |> set_state()
   end
 
   def intervals do
-    intervals([time() | state()])
-    |> Enum.reverse()
-  end
-
-  defp intervals([end_time, {interval, start_time} | rest]) do
-    [{interval, end_time - start_time} | intervals([start_time | rest])]
-  end
-
-  defp intervals([_end_time]), do: []
-
-  defp time do
-    System.monotonic_time(:microsecond)
+    IntervalTimer.intervals(state())
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/interval_timer.ex
+++ b/packages/sync-service/lib/electric/telemetry/interval_timer.ex
@@ -10,24 +10,24 @@ defmodule Electric.Telemetry.IntervalTimer do
     [{interval, time()} | state || @default_state]
   end
 
-  def intervals(state) do
-    calculate_intervals([time() | state])
+  def durations(state) do
+    calculate_durations([time() | state])
     |> Enum.reverse()
   end
 
   def total_time([]), do: 0
 
-  def total_time(intervals) do
-    intervals
+  def total_time(durations) do
+    durations
     |> Enum.map(fn {_, duration} -> duration end)
     |> Enum.sum()
   end
 
-  defp calculate_intervals([end_time, {interval, start_time} | rest]) do
-    [{interval, end_time - start_time} | calculate_intervals([start_time | rest])]
+  defp calculate_durations([end_time, {interval, start_time} | rest]) do
+    [{interval, end_time - start_time} | calculate_durations([start_time | rest])]
   end
 
-  defp calculate_intervals([_end_time]), do: []
+  defp calculate_durations([_end_time]), do: []
 
   defp time do
     System.monotonic_time(:microsecond)
@@ -60,7 +60,7 @@ defmodule Electric.Telemetry.ProcessIntervalTimer do
     |> set_state()
   end
 
-  def intervals do
-    IntervalTimer.intervals(state())
+  def durations do
+    IntervalTimer.durations(state())
   end
 end

--- a/packages/sync-service/test/electric/telemetry/interval_timer_test.exs
+++ b/packages/sync-service/test/electric/telemetry/interval_timer_test.exs
@@ -19,7 +19,7 @@ defmodule Electric.Telemetry.IntervalTimerTest do
         ProcessIntervalTimer.start_interval("C")
         Process.sleep(@c_time)
 
-        ProcessIntervalTimer.intervals()
+        ProcessIntervalTimer.durations()
       end)
 
     assert [{"A", a_time}, {"B", b_time}, {"C", c_time}] = intervals

--- a/packages/sync-service/test/electric/telemetry/interval_timer_test.exs
+++ b/packages/sync-service/test/electric/telemetry/interval_timer_test.exs
@@ -1,0 +1,32 @@
+defmodule Electric.Telemetry.IntervalTimerTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Telemetry.IntervalTimer
+
+  @a_time 2
+  @b_time 5
+  @c_time 9
+  @μs_per_ms 1000
+  @rounding_error 1
+
+  test "times how long each interval takes" do
+    {total, intervals} =
+      :timer.tc(fn ->
+        IntervalTimer.start("A")
+        Process.sleep(@a_time)
+        IntervalTimer.start("B")
+        Process.sleep(@b_time)
+        IntervalTimer.start("C")
+        Process.sleep(@c_time)
+
+        IntervalTimer.intervals()
+      end)
+
+    assert [{"A", a_time}, {"B", b_time}, {"C", c_time}] = intervals
+
+    assert a_time >= @a_time * @μs_per_ms
+    assert b_time >= @b_time * @μs_per_ms
+    assert c_time >= @c_time * @μs_per_ms
+    assert a_time + b_time + c_time <= total + @rounding_error
+  end
+end

--- a/packages/sync-service/test/electric/telemetry/interval_timer_test.exs
+++ b/packages/sync-service/test/electric/telemetry/interval_timer_test.exs
@@ -1,7 +1,7 @@
 defmodule Electric.Telemetry.IntervalTimerTest do
   use ExUnit.Case, async: true
 
-  alias Electric.Telemetry.IntervalTimer
+  alias Electric.Telemetry.ProcessIntervalTimer
 
   @a_time 2
   @b_time 5
@@ -12,14 +12,14 @@ defmodule Electric.Telemetry.IntervalTimerTest do
   test "times how long each interval takes" do
     {total, intervals} =
       :timer.tc(fn ->
-        IntervalTimer.start("A")
+        ProcessIntervalTimer.start("A")
         Process.sleep(@a_time)
-        IntervalTimer.start("B")
+        ProcessIntervalTimer.start("B")
         Process.sleep(@b_time)
-        IntervalTimer.start("C")
+        ProcessIntervalTimer.start("C")
         Process.sleep(@c_time)
 
-        IntervalTimer.intervals()
+        ProcessIntervalTimer.intervals()
       end)
 
     assert [{"A", a_time}, {"B", b_time}, {"C", c_time}] = intervals

--- a/packages/sync-service/test/electric/telemetry/interval_timer_test.exs
+++ b/packages/sync-service/test/electric/telemetry/interval_timer_test.exs
@@ -12,11 +12,11 @@ defmodule Electric.Telemetry.IntervalTimerTest do
   test "times how long each interval takes" do
     {total, intervals} =
       :timer.tc(fn ->
-        ProcessIntervalTimer.start("A")
+        ProcessIntervalTimer.start_interval("A")
         Process.sleep(@a_time)
-        ProcessIntervalTimer.start("B")
+        ProcessIntervalTimer.start_interval("B")
         Process.sleep(@b_time)
-        ProcessIntervalTimer.start("C")
+        ProcessIntervalTimer.start_interval("C")
         Process.sleep(@c_time)
 
         ProcessIntervalTimer.intervals()


### PR DESCRIPTION
Current replication processing time telemetry records overall time and breaks down by it's various parts, however there are gaps in this breakdown and data from trigger.dev shows that a significant amount of time is spent in these gaps.

This PR times all the following 7 intervals (in this order):
1. message_to_collector
2. new_txn_handle_call
3. gen_stage_receive_txn
4. partitions.handle_event
5. dispatcher.dispatch
6. gen_stage.post_dispatch
7. message_from_collector

3 of these intervals were already available: message_to_collector, partitions.handle_event and dispatcher.dispatch however are now using the new IntervalTimer for consistency.

The new IntervalTimer (and it's sibling ProcessIntervalTimer) have been introduced as many of these intervals are impossible to put spans around due to way GenStage code is structured. ProcessIntervalTimer additionally uses process memory for the times when the timer state cannot be passed around (again due to how GenStage code is structured)