### PR TITLE
chore: Ensure test processes are supervised by the test supervisor

### DIFF
--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -58,7 +58,12 @@ defmodule Electric.Postgres.LockConnection do
     Postgrex.SimpleConnection.start_link(
       __MODULE__,
       init_opts,
-      [timeout: :infinity, auto_reconnect: false, sync_connect: false, name: name(stack_id)] ++
+      [
+        timeout: :infinity,
+        auto_reconnect: false,
+        sync_connect: false,
+        name: opts[:name] || name(stack_id)
+      ] ++
         connection_opts
     )
   end

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -58,12 +58,7 @@ defmodule Electric.Postgres.LockConnection do
     Postgrex.SimpleConnection.start_link(
       __MODULE__,
       init_opts,
-      [
-        timeout: :infinity,
-        auto_reconnect: false,
-        sync_connect: false,
-        name: opts[:name] || name(stack_id)
-      ] ++
+      [timeout: :infinity, auto_reconnect: false, sync_connect: false, name: name(stack_id)] ++
         connection_opts
     )
   end

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -215,6 +215,12 @@ defmodule Electric.Postgres.ReplicationClient do
     {:noreply, state}
   end
 
+  # This callback is invoked when the connection process receives a shutdown signal.
+  def handle_info({:EXIT, _pid, :shutdown}, _state) do
+    Logger.debug("Replication client #{inspect(self())} received shutdown signal, stopping")
+    {:disconnect, :shutdown}
+  end
+
   # The implementation of Postgrex.ReplicationConnection doesn't give us a convenient way to
   # check whether the START_REPLICATION_SLOT statement succeeded before switching the
   # connection into streaming mode. Returning {:query, "START_REPLICATION_SLOT ...", state}

--- a/packages/sync-service/test/electric/concurrent_stream_test.exs
+++ b/packages/sync-service/test/electric/concurrent_stream_test.exs
@@ -7,7 +7,7 @@ defmodule Electric.ConcurrentStreamTest do
   describe "stream_to_end/2" do
     setup %{tmp_dir: tmp_dir, test: test} do
       db = :"cubdb_#{test}"
-      CubDB.start_link(data_dir: tmp_dir, name: db)
+      start_link_supervised!({CubDB, data_dir: tmp_dir, name: db})
       {:ok, %{db: db}}
     end
 

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -102,12 +102,14 @@ defmodule Electric.Connection.ConnectionManagerTest do
       wait_until_active(stack_id)
 
       # Start another lock process so that when ConnectionManager exits it is not able to restore its readiness immediately.
+      new_stack_id = stack_id <> "_new"
+      _registry = start_link_supervised!({Electric.ProcessRegistry, stack_id: new_stack_id})
+
       lock_opts = [
         connection_opts: ctx.connection_opts,
         connection_manager: self(),
         lock_name: Keyword.fetch!(ctx.replication_opts, :slot_name),
-        stack_id: stack_id,
-        name: :"#{inspect(Electric.Postgres.LockConnection)}_#{stack_id}_alt_lock"
+        stack_id: new_stack_id
       ]
 
       start_supervised!(%{

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -106,10 +106,14 @@ defmodule Electric.Connection.ConnectionManagerTest do
         connection_opts: ctx.connection_opts,
         connection_manager: self(),
         lock_name: Keyword.fetch!(ctx.replication_opts, :slot_name),
-        stack_id: stack_id
+        stack_id: stack_id,
+        name: :"#{inspect(Electric.Postgres.LockConnection)}_#{stack_id}_alt_lock"
       ]
 
-      Electric.Postgres.LockConnection.start_link(lock_opts)
+      start_supervised!(%{
+        id: :alt_lock,
+        start: {Electric.Postgres.LockConnection, :start_link, [lock_opts]}
+      })
 
       monitor = monitor_replication_client(stack_id)
 

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -475,7 +475,8 @@ defmodule Electric.Postgres.ReplicationClientTest do
         id: ReplicationClient,
         start:
           {ReplicationClient, :start_link,
-           [[stack_id: ctx.stack_id, replication_opts: ctx.replication_opts]]}
+           [[stack_id: ctx.stack_id, replication_opts: ctx.replication_opts]]},
+        restart: :temporary
       })
 
     conn_mgr = ctx.connection_manager

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -470,11 +470,13 @@ defmodule Electric.Postgres.ReplicationClientTest do
   defp start_client(ctx, overrides \\ []) do
     ctx = Enum.into(overrides, ctx)
 
-    {:ok, client_pid} =
-      ReplicationClient.start_link(
-        stack_id: ctx.stack_id,
-        replication_opts: ctx.replication_opts
-      )
+    client_pid =
+      start_link_supervised!(%{
+        id: ReplicationClient,
+        start:
+          {ReplicationClient, :start_link,
+           [[stack_id: ctx.stack_id, replication_opts: ctx.replication_opts]]}
+      })
 
     conn_mgr = ctx.connection_manager
     assert_receive {^conn_mgr, :streaming_started}, @assert_receive_db_timeout

--- a/packages/sync-service/test/electric/process_registry_test.exs
+++ b/packages/sync-service/test/electric/process_registry_test.exs
@@ -6,12 +6,10 @@ defmodule Electric.ProcessRegistryTest do
 
   describe "alive?/2" do
     test "should return false for inexistent process" do
-      {:ok, _} =
-        ProcessRegistry.start_link(
-          name: ProcessRegistry.registry_name(@stack_id),
-          keys: :duplicate,
-          stack_id: @stack_id
-        )
+      start_link_supervised!(
+        {ProcessRegistry,
+         name: ProcessRegistry.registry_name(@stack_id), keys: :duplicate, stack_id: @stack_id}
+      )
 
       assert false == ProcessRegistry.alive?(@stack_id, "bar")
     end

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -240,7 +240,7 @@ defmodule Electric.Replication.PublicationManagerTest do
       ctx: ctx,
       opts: opts
     } do
-      GenServer.stop(opts[:server])
+      stop_supervised!(opts[:server])
 
       test_id = self()
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -81,7 +81,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         registry: registry_name
       ]
 
-    {:ok, shape_cache_pid} = Electric.ShapeCache.start_link(shape_cache_opts)
+    shape_cache_pid = start_link_supervised!({Electric.ShapeCache, shape_cache_opts})
 
     %{server: pid, registry: registry_name, shape_cache: shape_cache_pid}
   end
@@ -103,13 +103,13 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
       consumers =
         Enum.map(1..3, fn id ->
-          {:ok, consumer} =
-            Support.TransactionConsumer.start_link(
-              id: id,
-              parent: parent,
-              producer: ctx.server,
-              shape: @shape
-            )
+          consumer =
+            start_link_supervised!(%{
+              id: {:consumer, id},
+              start:
+                {Support.TransactionConsumer, :start_link,
+                 [[id: id, parent: parent, producer: ctx.server, shape: @shape]]}
+            })
 
           {id, consumer}
         end)
@@ -240,13 +240,13 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
       consumers =
         Enum.map(1..3, fn id ->
-          {:ok, consumer} =
-            Support.TransactionConsumer.start_link(
-              id: id,
-              parent: parent,
-              producer: ctx.server,
-              shape: @shape
-            )
+          consumer =
+            start_link_supervised!(%{
+              id: {:consumer, id},
+              start:
+                {Support.TransactionConsumer, :start_link,
+                 [[id: id, parent: parent, producer: ctx.server, shape: @shape]]}
+            })
 
           {id, consumer}
         end)
@@ -338,12 +338,10 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
     consumer_id = "test_consumer"
 
-    {:ok, consumer} =
-      Support.TransactionConsumer.start_link(
-        id: consumer_id,
-        parent: self(),
-        producer: pid,
-        shape: @shape
+    consumer =
+      start_link_supervised!(
+        {Support.TransactionConsumer,
+         id: consumer_id, parent: self(), producer: pid, shape: @shape}
       )
 
     consumers = [{consumer_id, consumer}]

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -108,7 +108,8 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
               id: {:consumer, id},
               start:
                 {Support.TransactionConsumer, :start_link,
-                 [[id: id, parent: parent, producer: ctx.server, shape: @shape]]}
+                 [[id: id, parent: parent, producer: ctx.server, shape: @shape]]},
+              restart: :temporary
             })
 
           {id, consumer}
@@ -245,7 +246,8 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
               id: {:consumer, id},
               start:
                 {Support.TransactionConsumer, :start_link,
-                 [[id: id, parent: parent, producer: ctx.server, shape: @shape]]}
+                 [[id: id, parent: parent, producer: ctx.server, shape: @shape]]},
+              restart: :temporary
             })
 
           {id, consumer}

--- a/packages/sync-service/test/electric/shape_cache/file_storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/file_storage_test.exs
@@ -27,7 +27,7 @@ defmodule Electric.ShapeCache.FileStorageTest do
       )
 
     shape_opts = FileStorage.for_shape(@shape_handle, opts)
-    {:ok, pid} = FileStorage.start_link(shape_opts)
+    pid = start_link_supervised!({FileStorage, shape_opts})
     {:ok, %{opts: shape_opts, shared_opts: opts, pid: pid, storage: {FileStorage, shape_opts}}}
   end
 

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -753,7 +753,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
   defp start_storage(%{module: module} = context) do
     opts = module |> opts(context) |> module.shared_opts()
     shape_opts = module.for_shape(@shape_handle, opts)
-    {:ok, pid} = module.start_link(shape_opts)
+    pid = start_link_supervised!({module, shape_opts})
     {:ok, %{opts: shape_opts, shared_opts: opts, pid: pid, storage: {module, shape_opts}}}
   end
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1223,8 +1223,12 @@ defmodule Electric.ShapeCacheTest do
       )
     end
 
-    defp stop_shape_cache(_ctx) do
-      for name <- [ShapeCache, ShapeLogCollector, Shapes.DynamicConsumerSupervisor] do
+    defp stop_shape_cache(ctx) do
+      for name <- [
+            ctx.shape_cache_opts[:server],
+            ctx.consumer_supervisor,
+            ctx.shape_log_collector
+          ] do
         stop_supervised(name)
       end
     end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -111,12 +111,11 @@ defmodule Electric.Shapes.ConsumerTest do
           ]
         })
 
-      {:ok, producer} =
-        ShapeLogCollector.start_link(
-          stack_id: ctx.stack_id,
-          persistent_kv: ctx.persistent_kv,
-          inspector: @base_inspector
-        )
+      producer =
+        start_link_supervised!({
+          ShapeLogCollector,
+          stack_id: ctx.stack_id, persistent_kv: ctx.persistent_kv, inspector: @base_inspector
+        })
 
       ShapeLogCollector.start_processing(producer, Lsn.from_integer(0))
 
@@ -811,12 +810,12 @@ defmodule Electric.Shapes.ConsumerTest do
 
       ref = ctx.consumer_supervisor |> GenServer.whereis() |> Process.monitor()
       # Stop the consumer and the shape cache server to simulate a restart
-      Supervisor.stop(ctx.consumer_supervisor)
+      stop_supervised!(ctx.consumer_supervisor)
       assert_receive {:DOWN, ^ref, :process, _pid, _reason}, 1000
       assert_receive {Electric.Shapes.Monitor, :remove, ^shape_handle}
 
       ref = shape_cache_opts[:server] |> GenServer.whereis() |> Process.monitor()
-      GenServer.stop(shape_cache_opts[:server])
+      stop_supervised!(shape_cache_opts[:server])
       assert_receive {:DOWN, ^ref, :process, _pid, _reason}, 1000
 
       # Restart the shape cache and the consumers

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -101,22 +101,32 @@ defmodule Support.ComponentSetup do
   def with_publication_manager(ctx) do
     server = :"publication_manager_#{full_test_name(ctx)}"
 
-    start_link_supervised!(
-      {Electric.Replication.PublicationManager,
-       name: server,
-       stack_id: ctx.stack_id,
-       publication_name: ctx.publication_name,
-       update_debounce_timeout: Access.get(ctx, :update_debounce_timeout, 0),
-       db_pool: ctx.pool,
-       pg_version: Access.get(ctx, :pg_version, nil),
-       configure_tables_for_replication_fn:
-         Access.get(
-           ctx,
-           :configure_tables_for_replication_fn,
-           &Electric.Postgres.Configuration.configure_publication!/5
-         ),
-       shape_cache: Access.get(ctx, :shape_cache, {Electric.ShapeCache, [stack_id: ctx.stack_id]})}
-    )
+    start_link_supervised!(%{
+      id: server,
+      start: {
+        Electric.Replication.PublicationManager,
+        :start_link,
+        [
+          [
+            name: server,
+            stack_id: ctx.stack_id,
+            publication_name: ctx.publication_name,
+            update_debounce_timeout: Access.get(ctx, :update_debounce_timeout, 0),
+            db_pool: ctx.pool,
+            pg_version: Access.get(ctx, :pg_version, nil),
+            configure_tables_for_replication_fn:
+              Access.get(
+                ctx,
+                :configure_tables_for_replication_fn,
+                &Electric.Postgres.Configuration.configure_publication!/5
+              ),
+            shape_cache:
+              Access.get(ctx, :shape_cache, {Electric.ShapeCache, [stack_id: ctx.stack_id]})
+          ]
+        ]
+      },
+      restart: :temporary
+    })
 
     %{
       publication_manager:

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -157,12 +157,14 @@ defmodule Support.ComponentSetup do
         Electric.Shapes.DynamicConsumerSupervisor,
         :start_link,
         [[name: consumer_supervisor, stack_id: ctx.stack_id]]
-      }
+      },
+      restart: :temporary
     })
 
     start_link_supervised!(%{
       id: start_opts[:name],
-      start: {ShapeCache, :start_link, [start_opts]}
+      start: {ShapeCache, :start_link, [start_opts]},
+      restart: :temporary
     })
 
     shape_meta_table = ShapeCache.get_shape_meta_table(stack_id: ctx.stack_id)
@@ -195,7 +197,8 @@ defmodule Support.ComponentSetup do
       id: name,
       start:
         {ShapeLogCollector, :start_link,
-         [[stack_id: ctx.stack_id, inspector: ctx.inspector, persistent_kv: ctx.persistent_kv]]}
+         [[stack_id: ctx.stack_id, inspector: ctx.inspector, persistent_kv: ctx.persistent_kv]]},
+      restart: :temporary
     })
 
     %{shape_log_collector: name}


### PR DESCRIPTION
Ensures that all processes started are started under the ExUnit test supervisor, in the hope that this gives us better guarantees about cleanups occurring at the right time and we reduce flakes that seem to potentially be related to timing issues.