### PR TITLE
Debugging the shutdown sequence of Electric.Connection.Supervisor

### DIFF
--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -14,7 +14,7 @@ defmodule Electric.Application do
 
       Supervisor.start_link(
         children_application(),
-        [auto_shutdown: :any_significant] ++ supervisor_opts
+        supervisor_opts
       )
     end
   end

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -23,7 +23,7 @@ defmodule Electric.Connection.Supervisor do
   # The `restart: :transient, significant: true` combo allows for shutting the supervisor down
   # and signalling the parent supervisor to shut itself down as well if that one has
   # `:auto_shutdown` set to `:any_significant` or `:all_significant`.
-  use Supervisor, restart: :transient, significant: true
+  use Supervisor, restart: :transient
 
   require Logger
 

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -37,10 +37,9 @@ defmodule Electric.StackSupervisor do
       ]
     else
       [
-        restart: :transient,
+        restart: :transient
         # Make StackSupervisor `significant` so that in the case that electric is in single-stack mode, the stack stopping
         # will stop the entire Electric application (since `auto_shutdown` is set to `:any_significant` in `Application`).
-        significant: true
       ]
     end
 
@@ -372,6 +371,6 @@ defmodule Electric.StackSupervisor do
           telemetry_span_attrs
         )
 
-    Supervisor.init(children, strategy: :one_for_one, auto_shutdown: :any_significant)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end


### PR DESCRIPTION
First example shows explicit stopping of the connection supervisor. None of the Logger calls that are triggered by an `EXIT` message in Connection.Manager has executed. We only see an explicit stopping of ReplicationClient when Connection.Manager receives a DOWN message from the shape log collector pid.

```elixir
iex(1)> sup_name = Electric.Connection.Supervisor.name(stack_id: "single_stack")
{:via, Registry,
 {:"Electric.ProcessRegistry:single_stack",
  {Electric.Connection.Supervisor, nil}}}

iex(2)> GenServer.whereis sup_name
#PID<0.332.0>

iex(3)> Supervisor.which_children sup_name
[
  {Electric.Replication.Supervisor, #PID<0.361.0>, :supervisor,
   [Electric.Replication.Supervisor]},
  {Electric.Connection.Manager, #PID<0.334.0>, :supervisor,
   [Electric.Connection.Manager]},
  {Electric.StatusMonitor, #PID<0.333.0>, :worker, [Electric.StatusMonitor]}
]

iex(4)> rep_sup = :erlang.list_to_pid '<0.361.0>'
#PID<0.361.0>

iex(5)> Supervisor.which_children rep_sup
[
  {Electric.Replication.SchemaReconciler, #PID<0.375.0>, :worker,
   [Electric.Replication.SchemaReconciler]},
  {Electric.ShapeCache, #PID<0.373.0>, :worker, [Electric.ShapeCache]},
  {Electric.Replication.ShapeLogCollector, #PID<0.364.0>, :worker,
   [Electric.Replication.ShapeLogCollector]},
  {Electric.Replication.PublicationManager, #PID<0.363.0>, :worker,
   [Electric.Replication.PublicationManager]},
  {Electric.Shapes.DynamicConsumerSupervisor, #PID<0.362.0>, :supervisor,
   [Electric.Shapes.DynamicConsumerSupervisor]}
]

iex(6)> Supervisor.stop sup_name

14:16:18.413 pid=<0.351.0> [notice] Replication client #PID<0.351.0> is stopping after receiving stop request from #PID<0.334.0> with reason :shutdown
:ok

14:16:18.417 pid=<0.45.0> [notice] Application electric exited: shutdown
iex(7)> 
```