### PR TITLE
fix: `OR` operator in where clauses should not be strict

### DIFF
--- a/.changeset/gentle-wolves-unite.md
+++ b/.changeset/gentle-wolves-unite.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix evaluation of OR operator in where clauses with null values - NULL OR TRUE should be TRUE.

--- a/.changeset/gentle-wolves-unite.md
+++ b/.changeset/gentle-wolves-unite.md
@@ -2,4 +2,4 @@
 "@core/sync-service": patch
 ---
 
-Fix evaluation of OR operator in where clauses with null values - NULL OR TRUE should be TRUE.
+Fix evaluation of OR operator in where clauses with null values - `null OR true` should be `true` and `1 IN (1, NULL)` should be `true`.

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -1320,12 +1320,4 @@ defmodule Electric.Replication.Eval.Parser do
   defp replace_refs(anything_with_children, children, _) do
     {:ok, Map.merge(anything_with_children, children)}
   end
-
-  # postgres OR behaviour is peculiar, we have:
-  # true or null -> true
-  # false or null -> null
-  defp pg_or(nil, true), do: true
-  defp pg_or(nil, _b), do: nil
-  defp pg_or(a, nil), do: pg_or(nil, a)
-  defp pg_or(a, b), do: Kernel.or(a, b)
 end

--- a/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
+++ b/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
@@ -125,4 +125,32 @@ defmodule Electric.Replication.PostgresInterop.Casting do
   end
 
   def ilike?(text, pattern), do: like?(text, pattern, true)
+
+  @doc """
+  The Postgres OR operator, which has some specific behaviour when
+  comparing NULLs with booleans.
+
+  ## Examples
+
+      iex> pg_or(true, false)
+      true
+
+      iex> pg_or(false, false)
+      false
+
+      iex> pg_or(nil, true)
+      true
+
+      iex> pg_or(nil, false)
+      nil
+
+      iex> pg_or(nil, nil)
+      nil
+  """
+  @spec pg_or(boolean() | nil, boolean() | nil) :: boolean() | nil
+  def pg_or(a, b)
+  def pg_or(nil, true), do: true
+  def pg_or(nil, _b), do: nil
+  def pg_or(a, nil), do: pg_or(nil, a)
+  def pg_or(a, b), do: Kernel.or(a, b)
 end

--- a/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
+++ b/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
@@ -150,7 +150,8 @@ defmodule Electric.Replication.PostgresInterop.Casting do
   @spec pg_or(boolean() | nil, boolean() | nil) :: boolean() | nil
   def pg_or(a, b)
   def pg_or(nil, true), do: true
-  def pg_or(nil, _b), do: nil
-  def pg_or(a, nil), do: pg_or(nil, a)
+  def pg_or(nil, _), do: nil
+  def pg_or(true, nil), do: true
+  def pg_or(_, nil), do: nil
   def pg_or(a, b), do: Kernel.or(a, b)
 end

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -76,6 +76,13 @@ defmodule Electric.Replication.Eval.RunnerTest do
                  refs: %{["foo"] => :int4, ["bar"] => :int4}
                )
                |> Runner.execute(%{["foo"] => 1, ["bar"] => nil})
+
+      assert {:ok, nil} =
+               ~S|foo = 1 OR bar = 1|
+               |> Parser.parse_and_validate_expression!(
+                 refs: %{["foo"] => :int4, ["bar"] => :int4}
+               )
+               |> Runner.execute(%{["foo"] => 2, ["bar"] => nil})
     end
 
     test "should work with array types" do

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -69,6 +69,15 @@ defmodule Electric.Replication.Eval.RunnerTest do
                |> Runner.execute(%{["test"] => 2})
     end
 
+    test "can evaluate OR expression with nil values" do
+      assert {:ok, true} =
+               ~S|foo = 1 OR bar = 1|
+               |> Parser.parse_and_validate_expression!(
+                 refs: %{["foo"] => :int4, ["bar"] => :int4}
+               )
+               |> Runner.execute(%{["foo"] => 1, ["bar"] => nil})
+    end
+
     test "should work with array types" do
       assert {:ok, [[1, 2], [3, 4]]} =
                ~S|ARRAY[ARRAY[1, x], ARRAY['3', 2 + 2]]|


### PR DESCRIPTION
Was trying to get a where clause in a shape to work, where either one field would match a value OR another field would, and in practice I would set one field to null and move the value over to the other (meaning that it should trigger an update) and I was seeing a delete coming through.

Digging through the code I found the issue to be that we were treating `AND`, `OR`, and `NOT` all as `strict?` operators, meaning that if any of their arguments are `NULL` we collapse the result to `NULL` also. However this is not the correct behaviour on postgres for the `OR` operator, as shown below:

```sql
select null and true; # -> null
select not null; # -> null
select null or true; # -> t
select null or false; # -> null
```

I've changed the `OR` operator to not be strict along with a simple test for it. I wonder if we should populate our where clause execution tests a bit more, we can probably generate a good suite of tests for it.


edit: I've added a custom `or` operator after @icehaunter 's note about the odd behaviour, and also had to fix up some "bool chains" we were parsing.

The affected operators are:
- `OR`  - before `true OR null` would be `null` rather than `true`
- `IN` - before `1 IN (1, null)` would be `null` rather than `true`, since `IN` is just a chain of `OR`s
- `BETWEEN SYMMETRIC` - no behaviour change as the underlying operations are comparisons that will always either both yield `null` or a boolean, but it now uses the correct `or` operator either way


