### PR TITLE
fix: Account for race between loading shape and listening for changes

### DIFF
--- a/.changeset/tender-crabs-retire.md
+++ b/.changeset/tender-crabs-retire.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix race between loading shape and listening for updates to it that caused requests to hang for longer than necessary.

--- a/packages/experimental/test/support/test-context.ts
+++ b/packages/experimental/test/support/test-context.ts
@@ -164,7 +164,7 @@ export const testWithIssuesTable = testWithDbClient.extend<{
   clearIssuesShape: async ({ clearShape, issuesTableUrl }, use) => {
     use((handle?: string) => clearShape(issuesTableUrl, { handle }))
   },
-  waitForIssues: ({ issuesTableUrl, baseUrl }, use) =>
+  waitForIssues: ({ issuesTableUrl, baseUrl, aborter }, use) =>
     use(
       ({
         numChangesExpected,
@@ -178,6 +178,7 @@ export const testWithIssuesTable = testWithDbClient.extend<{
           table: issuesTableUrl,
           shapeStreamOptions,
           numChangesExpected,
+          aborter,
         })
     ),
 })

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -566,11 +566,62 @@ defmodule Electric.Shapes.Api do
   defp hold_until_change(%Request{} = request) do
     %{
       new_changes_ref: ref,
+      last_offset: last_offset,
       handle: shape_handle,
-      api: %{long_poll_timeout: long_poll_timeout}
+      params: %{shape_definition: shape_def},
+      api: %{long_poll_timeout: long_poll_timeout} = api
     } = request
 
     Logger.debug("Client #{inspect(self())} is waiting for changes to #{shape_handle}")
+
+    # Between loading the shape info and registering as a listener for new changes,
+    # there is a short time period where information might be lost, so we check our
+    # mailbox and then do an explicit check if nothing is present
+    hold_until_change_with_timeout(
+      request,
+      0,
+      fn ->
+        case Shapes.get_shape(api, shape_def) do
+          {^shape_handle, ^last_offset} ->
+            # no-op, shape is still present and unchanged
+            nil
+
+          {^shape_handle, latest_log_offset}
+          when is_log_offset_lt(last_offset, latest_log_offset) ->
+            send(self(), {ref, :new_changes, latest_log_offset})
+
+          {other_shape_handle, _} when other_shape_handle != shape_handle ->
+            send(self(), {ref, :shape_rotation, other_shape_handle})
+
+          nil ->
+            send(self(), {ref, :shape_rotation})
+        end
+
+        hold_until_change_with_timeout(
+          request,
+          # If we timeout, return an up-to-date message
+          long_poll_timeout,
+          fn ->
+            # Ensure stack is ready after a long poll timeout, as it might
+            # have failed during this period
+            case hold_until_stack_ready(request.api) do
+              :ok ->
+                request
+                |> update_attrs(%{ot_is_long_poll_timeout: true})
+                |> determine_global_last_seen_lsn()
+                |> no_change_response()
+
+              {:error, response} ->
+                response
+            end
+          end
+        )
+      end
+    )
+  end
+
+  defp hold_until_change_with_timeout(%Request{} = request, timeout, on_timeout_fn) do
+    %{new_changes_ref: ref} = request
 
     receive do
       {^ref, :new_changes, latest_log_offset} ->
@@ -581,26 +632,16 @@ defmodule Electric.Shapes.Api do
         |> determine_up_to_date()
         |> do_serve_shape_log()
 
-      {^ref, :shape_rotation} ->
+      {^ref, :shape_rotation, new_handle} ->
         Response.error(request, @must_refetch,
-          handle: shape_handle,
+          handle: new_handle,
           status: 409
         )
-    after
-      # If we timeout, return an up-to-date message
-      long_poll_timeout ->
-        # Ensure stack is ready after a long poll timeout, as it might
-        # have failed during this period
-        case hold_until_stack_ready(request.api) do
-          :ok ->
-            request
-            |> update_attrs(%{ot_is_long_poll_timeout: true})
-            |> determine_global_last_seen_lsn()
-            |> no_change_response()
 
-          {:error, response} ->
-            response
-        end
+      {^ref, :shape_rotation} ->
+        Response.error(request, @must_refetch, status: 409)
+    after
+      timeout -> on_timeout_fn.()
     end
   end
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -177,9 +177,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "returns 400 when offset is out of bounds", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> expect(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
 
       invalid_offset = LogOffset.increment(@test_offset)
 
@@ -376,9 +374,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "returns log when offset is >= 0", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -439,9 +435,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "returns 304 Not Modified when If-None-Match matches ETag",
          ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
 
       Mock.Storage
@@ -458,7 +452,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "the 304 response includes caching headers that are appropriate for the offset", ctx do
       Mock.ShapeCache
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
-      |> expect(:get_shape, 3, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
 
       Mock.Storage
       |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
@@ -490,9 +484,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "handles live updates", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -566,9 +558,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "handles shape rotation", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -614,9 +604,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "sends an up-to-date response after a timeout if no changes are observed",
          ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -657,9 +645,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "sends 409 with a redirect to existing shape when requested shape handle does not exist",
          ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn "foo", _opts -> false end)
 
       Mock.Storage

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -172,9 +172,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "returns error when offset is out of bounds", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> expect(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
 
       invalid_offset = LogOffset.increment(@test_offset)
 
@@ -202,9 +200,7 @@ defmodule Electric.Shapes.ApiTest do
       request_handle = @test_shape_handle <> "-wrong"
 
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        nil
-      end)
+      |> expect(:get_shape, fn @test_shape, _opts -> nil end)
       |> expect(:get_or_create_shape_handle, fn @test_shape, _opts ->
         {@test_shape_handle, @test_offset}
       end)
@@ -227,9 +223,7 @@ defmodule Electric.Shapes.ApiTest do
       request_handle = @test_shape_handle <> "-wrong"
 
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @before_all_offset}
-      end)
+      |> expect(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @before_all_offset} end)
 
       assert {:error, %{status: 409} = response} =
                Api.validate(
@@ -249,9 +243,7 @@ defmodule Electric.Shapes.ApiTest do
       request_handle = @test_shape_handle <> "-wrong"
 
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @before_all_offset}
-      end)
+      |> expect(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @before_all_offset} end)
 
       assert {:error, %{status: 409} = response} =
                Api.validate(
@@ -468,9 +460,7 @@ defmodule Electric.Shapes.ApiTest do
       %{admin_shape: admin_shape} = ctx
 
       Mock.ShapeCache
-      |> expect(:get_shape, fn ^admin_shape, _opts ->
-        nil
-      end)
+      |> expect(:get_shape, fn ^admin_shape, _opts -> nil end)
 
       assert {:error, %{status: 404} = _response} =
                Api.validate_for_delete(
@@ -488,9 +478,7 @@ defmodule Electric.Shapes.ApiTest do
       handle = "admin-shape-handle"
 
       Mock.ShapeCache
-      |> expect(:get_shape, fn ^admin_shape, _opts ->
-        {handle, @before_all_offset}
-      end)
+      |> expect(:get_shape, fn ^admin_shape, _opts -> {handle, @before_all_offset} end)
 
       assert {:ok, %{handle: ^handle} = _response} =
                Api.validate_for_delete(
@@ -509,9 +497,7 @@ defmodule Electric.Shapes.ApiTest do
       handle = "admin-shape-handle"
 
       Mock.ShapeCache
-      |> expect(:get_shape, fn ^admin_shape, _opts ->
-        {handle, @before_all_offset}
-      end)
+      |> expect(:get_shape, fn ^admin_shape, _opts -> {handle, @before_all_offset} end)
 
       assert {:error, %{status: 400} = _response} =
                Api.validate_for_delete(
@@ -595,9 +581,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "returns log when offset is >= 0", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -653,9 +637,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "handles live updates", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -732,9 +714,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "raises if body is read from a different process", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -915,9 +895,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "handles shape rotation", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -978,7 +956,7 @@ defmodule Electric.Shapes.ApiTest do
         {@test_shape_handle, @test_offset}
       end)
       # any subsequent get shape calls should return the new offset
-      |> stub(:get_shape, fn @test_shape_handle, _opts -> {@test_shape_handle, next_offset} end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, next_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -986,10 +964,10 @@ defmodule Electric.Shapes.ApiTest do
       |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
       |> stub(:get_chunk_end_log_offset, fn _, @test_opts -> nil end)
       |> stub(:get_log_stream, fn
-        @test_offset, _, @test_opts ->
+        @test_offset, @test_offset, @test_opts ->
           []
 
-        ^next_offset, _, @test_opts ->
+        @test_offset, ^next_offset, @test_opts ->
           [
             Jason.encode!(%{key: "log1", value: "foo", headers: %{}, offset: next_offset})
           ]
@@ -1056,9 +1034,7 @@ defmodule Electric.Shapes.ApiTest do
     @tag long_poll_timeout: 100
     test "sends an up-to-date response after a timeout if no changes are observed", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 
@@ -1094,9 +1070,7 @@ defmodule Electric.Shapes.ApiTest do
     @tag long_poll_timeout: 100
     test "sends an error response after a timeout if stack has failed", ctx do
       Mock.ShapeCache
-      |> expect(:get_shape, fn @test_shape, _opts ->
-        {@test_shape_handle, @test_offset}
-      end)
+      |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
       |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
 

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -965,6 +965,95 @@ defmodule Electric.Shapes.ApiTest do
     end
 
     @tag long_poll_timeout: 100
+    test "picks up changes missed between loading shape and listening for changes", ctx do
+      next_offset = LogOffset.increment(@test_offset)
+
+      Mock.ShapeCache
+      |> expect(:get_shape, fn @test_shape, _opts ->
+        # Simulate new changes arriving the moment we load the shape
+        Registry.dispatch(@registry, @test_shape_handle, fn [{pid, ref}] ->
+          send(pid, {ref, :new_changes, next_offset})
+        end)
+
+        {@test_shape_handle, @test_offset}
+      end)
+      # any subsequent get shape calls should return the new offset
+      |> stub(:get_shape, fn @test_shape_handle, _opts -> {@test_shape_handle, next_offset} end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
+
+      Mock.Storage
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
+      |> stub(:get_chunk_end_log_offset, fn _, @test_opts -> nil end)
+      |> stub(:get_log_stream, fn
+        @test_offset, _, @test_opts ->
+          []
+
+        ^next_offset, _, @test_opts ->
+          [
+            Jason.encode!(%{key: "log1", value: "foo", headers: %{}, offset: next_offset})
+          ]
+      end)
+
+      assert {:ok, request} =
+               Api.validate(
+                 ctx.api,
+                 %{
+                   table: "public.users",
+                   offset: "#{@test_offset}",
+                   handle: @test_shape_handle,
+                   live: true
+                 }
+               )
+
+      assert response = Api.serve_shape_log(request)
+
+      assert response.status == 200
+
+      assert [
+               %{"key" => "log1"},
+               %{headers: %{control: "up-to-date"}}
+             ] = response_body(response)
+    end
+
+    @tag long_poll_timeout: 100
+    test "picks up shape rotation missed between loading shape and listening for changes", ctx do
+      Mock.ShapeCache
+      |> expect(:get_shape, fn @test_shape, _opts ->
+        # Simulate shape rotating a moment after we load the shape
+        Registry.dispatch(@registry, @test_shape_handle, fn [{pid, ref}] ->
+          send(pid, {ref, :shape_rotation})
+        end)
+
+        {@test_shape_handle, @test_offset}
+      end)
+      # subsequent calls to get shape should not return the shape as it is gone
+      |> stub(:get_shape, fn @test_shape, _opts -> nil end)
+      |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> stub(:await_snapshot_start, fn @test_shape_handle, _ -> :started end)
+
+      Mock.Storage
+      |> stub(:for_shape, fn @test_shape_handle, _opts -> @test_opts end)
+      |> stub(:get_chunk_end_log_offset, fn _, @test_opts -> nil end)
+      |> stub(:get_log_stream, fn @test_offset, _, @test_opts -> [] end)
+
+      assert {:ok, request} =
+               Api.validate(
+                 ctx.api,
+                 %{
+                   table: "public.users",
+                   offset: "#{@test_offset}",
+                   handle: @test_shape_handle,
+                   live: true
+                 }
+               )
+
+      assert response = Api.serve_shape_log(request)
+      assert response.status == 409
+      assert [%{headers: %{control: "must-refetch"}}] = response_body(response)
+    end
+
+    @tag long_poll_timeout: 100
     test "sends an up-to-date response after a timeout if no changes are observed", ctx do
       Mock.ShapeCache
       |> expect(:get_shape, fn @test_shape, _opts ->

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -360,10 +360,12 @@ describe(`HTTP Sync`, () => {
     issuesTableKey,
     updateIssue,
     insertIssues,
+    waitForIssues,
   }) => {
     // With initial data
     const rowId = uuidv4()
     await insertIssues({ id: rowId, title: `original insert` })
+    await waitForIssues({ numChangesExpected: 1 })
 
     const shapeData = new Map()
     const issueStream = new ShapeStream({
@@ -375,6 +377,7 @@ describe(`HTTP Sync`, () => {
     })
     let secondRowId = ``
     await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
+      console.log(`got message ${nth}:`, msg)
       if (!isChangeMessage(msg)) return
       shapeData.set(msg.key, msg.value)
 

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -377,7 +377,6 @@ describe(`HTTP Sync`, () => {
     })
     let secondRowId = ``
     await h.forEachMessage(issueStream, aborter, async (res, msg, nth) => {
-      console.log(`got message ${nth}:`, msg)
       if (!isChangeMessage(msg)) return
       shapeData.set(msg.key, msg.value)
 

--- a/packages/typescript-client/test/support/test-context.ts
+++ b/packages/typescript-client/test/support/test-context.ts
@@ -142,7 +142,7 @@ export const testWithIssuesTable = testWithDbClient.extend<{
     use((handle?: string) => clearShape(issuesTableUrl, { handle }))
   },
 
-  waitForIssues: ({ issuesTableUrl, baseUrl }, use) =>
+  waitForIssues: ({ issuesTableUrl, baseUrl, aborter }, use) =>
     use(
       ({
         numChangesExpected,
@@ -156,6 +156,7 @@ export const testWithIssuesTable = testWithDbClient.extend<{
           table: issuesTableUrl,
           shapeStreamOptions,
           numChangesExpected,
+          aborter,
         })
     ),
 })

--- a/packages/typescript-client/test/support/test-helpers.ts
+++ b/packages/typescript-client/test/support/test-helpers.ts
@@ -44,7 +44,7 @@ export function forEachMessage<T extends Row<unknown>>(
             message as Message<T>,
             messageIdx
           )
-          if (`operation` in message.headers) messageIdx++
+          if (isChangeMessage(message)) messageIdx++
         } catch (e) {
           controller.abort()
           return reject(e)
@@ -59,13 +59,17 @@ export async function waitForTransaction({
   table,
   numChangesExpected,
   shapeStreamOptions,
+  aborter,
 }: {
   baseUrl: string
   table: string
   numChangesExpected?: number
   shapeStreamOptions?: Partial<ShapeStreamOptions>
+  aborter?: AbortController
 }): Promise<Pick<ShapeStreamOptions, `offset` | `handle`>> {
-  const aborter = new AbortController()
+  const waitAborter = new AbortController()
+  if (aborter?.signal.aborted) waitAborter.abort()
+  else aborter?.signal.addEventListener(`abort`, () => waitAborter.abort())
   const issueStream = new ShapeStream({
     ...(shapeStreamOptions ?? {}),
     url: `${baseUrl}/v1/shape`,
@@ -73,13 +77,13 @@ export async function waitForTransaction({
       ...(shapeStreamOptions?.params ?? {}),
       table,
     },
-    signal: aborter.signal,
+    signal: waitAborter.signal,
     subscribe: true,
   })
 
   numChangesExpected ??= 1
   let numChangesSeen = 0
-  await forEachMessage(issueStream, aborter, (res, msg) => {
+  await forEachMessage(issueStream, waitAborter, (res, msg) => {
     if (isChangeMessage(msg)) {
       numChangesSeen++
     }


### PR DESCRIPTION
This PR started as an attempt to fix a flaky TS test, that basically just tested that it received updates to a shape.

After some investigation, I found that the reason it was flaking was that sometimes the updates arrived at the shape consumer the moment between the request:
1. Loaded the shape (its handle and latest offset)
2. Started listening for changes to the shape (which we only do if the request's offset is larger than or equal to the read latest offset)

In this case, the `:new changes` message would not have been received by the request process as the changes were processed before it started listening, and the latest offset is loaded is now out of date.

This leads to the request hanging for 20 seconds waiting for new updates (despite the update already having been processed). The next request would pick it up, so this is not a correctness issue, but it does lead to cases where live updates might take an upper bound of the long poll timeout to arrive to clients, which is not ideal.

Possible solutions:
1. Start listening for changes before we load the shape's latest offset
 1a. Not sure how expensive registering basically _all_ requests would be for changes, and potentially deregistering them early if it is not necessary
 2b. We would have to separately load the handle and the offset, as the changes are keyed on the handle, which would mean two separate ETS reads anyway up front, on top of "flooding" the registry
2. Do an additional check for the latest offset after we start listening for changes
 2a. This ensures that we capture any missed changes, and can occur at any point after we have registered the request for new changes, and the cost is just an additional ETS read.
 2b. We can do the manual check early or as late as when we block on the receive for new changes
 2c. We can even delay the second check such that it happens at e.g. 200ms of waiting, basically setting an upper bound on the amount of time a request can be delayed because of a missed change, just for the sake of reducing the number of additional ETS reads, but I would avoid overoptimising to avoid the read.
3. Somehow always read up to the latest part of the log when we don't find a chunk boundary, rather than up to the latest offset that was loaded at the start of the request.
 3a. I don't think this approach is actually viable because we'd have to introspect the log, which we generally stream out after already having sent the headers


I opted for option 2, as I think it is the most explicit and requires the least amount of changes, and it comes at the cost of a simple additional ETS read.

## Implementation
1. Check for any messages in the mailbox (receive do with 0 timeout)
2. If new change messages arrived, terminate there
3. If no messages arrived, do a lookup to check manually if we are up to date.
4. If we are not up to date (shape updated or rotated), send ourselves a message
5. Wait for changes again with a long poll timeout

This currently just checks the mailbox immediately, but we could do this additional read with an "upper bound" of time we're willing to wait for changes, in order to reduce the number of additional lookups we do. I doubt it's worth it though.

Note, I've added 2 failing tests, one for missing changes and one for missing a shape rotation, although I'm not sure if we could ever miss the shape rotation as we do interact with the shape process after listening for changes (and if it had rotated between loading and listening for changes, the subsequent interaction would crash) - perhaps the rotation edge case is causing a different kind of crash elsewhere that might be worth investigating. The rotation race is an argument for doing the ETS lookup _immediately_ after registering for changes, to appropriately handle the request.