### PR TITLE
chore(sync-service): Fix flakey Publisher tests

### DIFF
--- a/packages/sync-service/test/electric/publisher_test.exs
+++ b/packages/sync-service/test/electric/publisher_test.exs
@@ -32,14 +32,14 @@ defmodule Electric.PublisherTest do
     end
 
     test "does not return until all subscibers have processed the message" do
-      on_event = fn :test_message ->
+      on_message = fn :test_message ->
         receive do
-          :finish_processing_event -> :ok
+          :finish_processing_message -> :ok
         end
       end
 
-      {:ok, sub1} = TestSubscriber.start_link(on_event)
-      {:ok, sub2} = TestSubscriber.start_link(on_event)
+      {:ok, sub1} = TestSubscriber.start_link(on_message)
+      {:ok, sub2} = TestSubscriber.start_link(on_message)
 
       pid = self()
 
@@ -49,21 +49,21 @@ defmodule Electric.PublisherTest do
       end)
 
       refute_receive :publish_finished, 10
-      send(sub2, :finish_processing_event)
+      send(sub2, :finish_processing_message)
       refute_receive :publish_finished, 10
-      send(sub1, :finish_processing_event)
+      send(sub1, :finish_processing_message)
       assert_receive :publish_finished, 5000
     end
 
     test "does not return until all subscibers have processed the message or died" do
-      on_event = fn :test_message ->
+      on_message = fn :test_message ->
         receive do
-          :finish_processing_event -> :ok
+          :finish_processing_message -> :ok
         end
       end
 
-      {:ok, sub1} = TestSubscriber.start_link(on_event)
-      {:ok, sub2} = TestSubscriber.start_link(on_event)
+      {:ok, sub1} = TestSubscriber.start_link(on_message)
+      {:ok, sub2} = TestSubscriber.start_link(on_message)
 
       pid = self()
 
@@ -76,7 +76,7 @@ defmodule Electric.PublisherTest do
       Process.unlink(sub2)
       Process.exit(sub2, :kill)
       refute_receive :publish_finished, 10
-      send(sub1, :finish_processing_event)
+      send(sub1, :finish_processing_message)
       assert_receive :publish_finished, 5000
     end
   end


### PR DESCRIPTION
These tests can occasionally fail with:

```
 Assertion failed, no matching message after 5000ms
     The process mailbox is empty.
     code: assert_receive :publish_finished
```

The race condition occurs if the TestSubscriber receives the `:finish_processing_message` message before it receives the publisher call, in which case it swallows the message since `handle_info` is not implemented on TestSubscriber. A GenServer would log that a message had been received and not handled, but as `use GenServer` was omitted from the TestSubscriber the message was swallowed silently.

This PR:
- Adds `use GenServer` to the TestSubscriber as this is best practice (the race condition would have been obvious had it been included in the first place)
- Waits for `:message_received` from each of the subscribers before sending `:finish_processing_message`. This eliminates the race condition.
- Renames `event` to `message` for consistency  

Credit to ChatGPT which worked out what the race condition was. It's solution was terrible, but the hard part was knowing what the race condition was, so that was super helpful.