### PR TITLE
fix: Ensure PG expression execution in Electric matches PG

### DIFF
--- a/.changeset/few-eggs-relax.md
+++ b/.changeset/few-eggs-relax.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix parsing and execution for some edge casses of where clause operators.

--- a/.changeset/few-eggs-relax.md
+++ b/.changeset/few-eggs-relax.md
@@ -2,4 +2,4 @@
 "@core/sync-service": patch
 ---
 
-Fix parsing and execution for some edge casses of where clause operators.
+Fix parsing and execution for some edge cases of where clause operators.

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -1,4 +1,6 @@
 defmodule Electric.Replication.Eval.Parser do
+  require Logger
+
   alias Electric.Replication.Eval.Walker
   alias Electric.Utils
   alias Electric.Replication.PostgresInterop.Casting
@@ -1152,7 +1154,7 @@ defmodule Electric.Replication.Eval.Parser do
      }}
   rescue
     e ->
-      IO.puts(Exception.format(:error, e, __STACKTRACE__))
+      Logger.warning(Exception.format(:error, e, __STACKTRACE__))
       {:error, {func.location, "Failed to apply function to constant arguments"}}
   end
 

--- a/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
+++ b/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
@@ -154,4 +154,33 @@ defmodule Electric.Replication.PostgresInterop.Casting do
   def pg_or(true, nil), do: true
   def pg_or(_, nil), do: nil
   def pg_or(a, b), do: Kernel.or(a, b)
+
+  @doc """
+  The Postgres AND operator, which has some specific behaviour when
+  comparing NULLs with booleans.
+
+  ## Examples
+
+      iex> pg_and(true, false)
+      true
+
+      iex> pg_and(false, false)
+      false
+
+      iex> pg_and(nil, true)
+      true
+
+      iex> pg_and(nil, false)
+      nil
+
+      iex> pg_and(nil, nil)
+      nil
+  """
+  @spec pg_and(boolean() | nil, boolean() | nil) :: boolean() | nil
+  def pg_and(a, b)
+  def pg_and(nil, false), do: false
+  def pg_and(nil, _), do: nil
+  def pg_and(false, nil), do: false
+  def pg_and(_, nil), do: nil
+  def pg_and(a, b), do: Kernel.and(a, b)
 end

--- a/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
+++ b/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
@@ -161,17 +161,20 @@ defmodule Electric.Replication.PostgresInterop.Casting do
 
   ## Examples
 
-      iex> pg_and(true, false)
+      iex> pg_and(true, true)
       true
+
+      iex> pg_and(true, false)
+      false
 
       iex> pg_and(false, false)
       false
 
       iex> pg_and(nil, true)
-      true
+      nil
 
       iex> pg_and(nil, false)
-      nil
+      false
 
       iex> pg_and(nil, nil)
       nil

--- a/packages/sync-service/lib/pg_interop/array.ex
+++ b/packages/sync-service/lib/pg_interop/array.ex
@@ -328,6 +328,9 @@ defmodule PgInterop.Array do
   def concat_arrays(arr1, []), do: arr1
   def concat_arrays([], arr2), do: arr2
 
+  def concat_arrays(arr1, nil), do: arr1
+  def concat_arrays(nil, arr2), do: arr2
+
   def concat_arrays(arr1, arr2) do
     case {get_array_dim(arr1), get_array_dim(arr2)} do
       {d1, d1} -> arr1 ++ arr2
@@ -360,6 +363,18 @@ defmodule PgInterop.Array do
   def array_prepend(elem, []), do: [elem]
   def array_prepend(elem, [hd | tl]) when not is_list(hd), do: [elem, hd | tl]
 
+  def array_prepend_concat(elem, _) when is_binary(elem),
+    do: raise("Cannot prepend a binary to an array with ||")
+
+  def array_prepend_concat(nil, arr), do: arr
+  def array_prepend_concat(elem, arr) when not is_binary(elem), do: array_prepend(elem, arr)
+
   def array_append([], elem), do: [elem]
   def array_append([hd | _] = list, elem) when not is_list(hd), do: list ++ [elem]
+
+  def array_append_concat(_, elem) when is_binary(elem),
+    do: raise("Cannot append a binary to an array with ||")
+
+  def array_append_concat(arr, nil), do: arr
+  def array_append_concat(arr, elem), do: array_append(arr, elem)
 end

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -185,14 +185,47 @@ defmodule Electric.Replication.Eval.RunnerTest do
     end
   end
 
-  describe "execute/2 property test" do
-    setup [:with_unique_db]
+  describe "execute/2 against PG results" do
+    setup [:with_shared_db]
 
-    property "PostgreSQL clause behaves the same in both implementations", %{pool: pool} do
+    @max_runs 10_000
+    @max_run_time 1_000
+
+    property "numeric expressions", %{pool: pool} do
       check all(
-              clause <- PgExpressionGenerator.postgres_expression(),
-              max_runs: 1_000_000,
-              max_run_time: 600
+              clause <- PgExpressionGenerator.numeric_expression(),
+              max_runs: @max_runs,
+              max_run_time: @max_run_time
+            ) do
+        assert_runner_and_oracle_match(clause, pool)
+      end
+    end
+
+    property "string expressions", %{pool: pool} do
+      check all(
+              clause <- PgExpressionGenerator.string_expression(),
+              max_runs: @max_runs,
+              max_run_time: @max_run_time
+            ) do
+        assert_runner_and_oracle_match(clause, pool)
+      end
+    end
+
+    property "bool expressions", %{pool: pool} do
+      check all(
+              clause <- PgExpressionGenerator.bool_expression(),
+              max_runs: @max_runs,
+              max_run_time: @max_run_time
+            ) do
+        assert_runner_and_oracle_match(clause, pool)
+      end
+    end
+
+    property "array expressions", %{pool: pool} do
+      check all(
+              clause <- PgExpressionGenerator.array_expression(),
+              max_runs: @max_runs,
+              max_run_time: @max_run_time
             ) do
         assert_runner_and_oracle_match(clause, pool)
       end

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -221,6 +221,16 @@ defmodule Electric.Replication.Eval.RunnerTest do
       end
     end
 
+    property "complex bool expressions", %{pool: pool} do
+      check all(
+              clause <- PgExpressionGenerator.complex_bool_expression(),
+              max_runs: @max_runs,
+              max_run_time: @max_run_time
+            ) do
+        assert_runner_and_oracle_match(clause, pool)
+      end
+    end
+
     property "array expressions", %{pool: pool} do
       check all(
               clause <- PgExpressionGenerator.array_expression(),

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -1,5 +1,6 @@
 defmodule Electric.Replication.Eval.RunnerTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Electric.Replication.Eval.Runner
   alias Electric.Replication.Eval.Parser
@@ -178,6 +179,354 @@ defmodule Electric.Replication.Eval.RunnerTest do
                  }
                )
                |> Runner.execute(%{["x"] => [[[3, 4]]]})
+    end
+  end
+
+  describe "execute/2 property test" do
+    import Support.ComponentSetup
+    import Support.DbSetup
+    import StreamData
+
+    setup [:with_unique_db]
+
+    property "PostgreSQL clause behaves the same in both implementations", %{pool: pool} do
+      check all(
+              clause <- clause_generator(),
+              max_runs: 1000
+            ) do
+        assert_runner_and_oracle_match(clause, pool)
+      end
+    end
+
+    defp execute_oracle(clause, db_conn) do
+      oracle_result =
+        case Postgrex.query(db_conn, "SELECT #{clause}", []) do
+          {:ok, %Postgrex.Result{rows: [[result]]}} -> {:ok, result}
+          {:error, %Postgrex.Error{postgres: %{message: reason}}} -> {:error, reason}
+        end
+    end
+
+    defp execute_runner(clause) do
+      runner_result =
+        try do
+          clause
+          |> Parser.parse_and_validate_expression!()
+          |> Runner.execute(%{})
+        rescue
+          err -> {:error, err}
+        end
+    end
+
+    defp assert_runner_and_oracle_match(clause, db_conn) do
+      oracle_result = execute_oracle(clause, db_conn)
+      runner_result = execute_runner(clause)
+
+      case {runner_result, oracle_result} do
+        {{:ok, runner_val}, {:ok, oracle_val}} ->
+          # Both results are ok, we can compare them
+          oracle_val = cast_decimals_to_floats(oracle_val)
+
+          case oracle_val do
+            val when is_number(oracle_val) and is_number(runner_val) ->
+              assert_in_delta(runner_val, oracle_val, abs(0.01 * oracle_val))
+
+            _ ->
+              assert runner_val == oracle_val,
+                     """
+                     MISMATCH!
+
+                     SQL: #{clause}
+
+                     runner returned: #{inspect(runner_val)}
+                     oracle returned: #{inspect(oracle_val)}
+                     """
+          end
+
+          :ok
+
+        {{:error, _}, {:error, _}} ->
+          # Both results are errors - which is fine
+          :ok
+
+        {{:ok, nil}, {:error, _}} ->
+          # Runner coalescing to nil rather than erroring is not ideal,
+          # but we can live with it
+          :ok
+
+        {{:ok, _}, {:error, "value out of range:" <> _}} ->
+          # We are fine with being able to handle values the oracle cannot
+          :ok
+
+        {{:ok, _}, {:error, "integer out of range"}} ->
+          # We are fine with being able to handle values the oracle cannot
+          :ok
+
+        {{:error, err}, {:ok, _}} ->
+          raise "Runner error: #{inspect(err)} for clause: #{clause}"
+
+        {{:ok, _}, {:error, err}} ->
+          raise "Oracle error: #{inspect(err)} for clause: #{clause}"
+      end
+    end
+
+    defp cast_decimals_to_floats(value) when is_list(value) do
+      Enum.map(value, &cast_decimals_to_floats/1)
+    end
+
+    defp cast_decimals_to_floats(%Decimal{} = decimal), do: Decimal.to_float(decimal)
+    defp cast_decimals_to_floats(value), do: value
+
+    ## TYPE GENERATORS
+
+    defp null_gen, do: constant("NULL")
+    defp bool_gen, do: member_of(["TRUE", "FALSE"])
+
+    defp int_gen, do: integer() |> map(&Integer.to_string/1)
+    defp pos_int_gen, do: positive_integer() |> map(&Integer.to_string/1)
+    defp double_gen, do: float(min: -1.0e6, max: 1.0e6) |> map(&Float.to_string/1)
+    defp numeric_gen, do: one_of([int_gen(), double_gen()])
+
+    defp str_gen,
+      do:
+        StreamData.string(:ascii, max_length: 10)
+        |> map(&"'#{String.replace(&1, "'", "''")}'")
+
+    defp array_gen(type_gen, opts \\ []) do
+      dimension = Access.get(opts, :dimension, 1)
+      min_length = Access.get(opts, :min_length, 1)
+      max_length = Access.get(opts, :max_length, 5)
+
+      Enum.reduce(1..dimension, type_gen, fn dim, gen ->
+        list_gen =
+          if dim == dimension do
+            list_of(gen, min_length: min_length, max_length: max_length)
+          else
+            list_of(gen, length: Enum.random(min_length..max_length))
+          end
+
+        list_gen
+        |> map(fn elements ->
+          "ARRAY[" <> Enum.join(elements, ", ") <> "]"
+        end)
+      end)
+    end
+
+    defp datatype_gen_func do
+      member_of([int_gen(), double_gen(), bool_gen(), str_gen()])
+      |> map(&nullable_type_gen/1)
+    end
+
+    defp nullable_type_gen(type_gen, null_ratio \\ 0.25),
+      do: frequency([{floor(1.0 / null_ratio), type_gen}, {1, null_gen()}])
+
+    ## OPERATION GENERATORS
+
+    defp comparison_op_gen,
+      do:
+        member_of([
+          "=",
+          "!=",
+          "<>",
+          ">",
+          "<",
+          ">=",
+          "<=",
+          "IS DISTINCT FROM",
+          "IS NOT DISTINCT FROM"
+        ])
+
+    defp bool_comparison_op_gen, do: member_of(["AND", "OR"])
+    defp bool_unary_op_gen, do: constant("NOT")
+
+    defp range_comparison_op_gen,
+      do: member_of(["BETWEEN", "BETWEEN SYMMETRIC"]) |> with_negation()
+
+    defp array_op_gen, do: member_of(["||"])
+    defp string_function_op_gen, do: member_of(["LOWER", "UPPER"])
+    defp array_comparison_op_gen, do: member_of(["@>", "<@", "&&"])
+
+    defp numeric_op_gen, do: member_of(["+", "-", "/", "*"])
+    defp numeric_unary_op_gen, do: member_of(["+", "-", "@"])
+    defp int_op_gen, do: one_of([numeric_op_gen(), member_of(["&", "|", "#"])])
+    defp int_unary_op_gen, do: one_of([numeric_unary_op_gen(), member_of(["~"])])
+    defp double_unary_op_gen, do: one_of([numeric_unary_op_gen(), member_of(["|/"])])
+
+    defp string_op_gen, do: member_of(["||"])
+    defp string_comparison_op_gen, do: member_of(["~~", "~~*", "!~~", "!~~*"])
+    defp string_function_op_gen, do: member_of(["LOWER", "UPPER"])
+
+    defp membership_op_gen, do: with_negation(constant("IN"))
+
+    defp is_null_op_gen, do: null_gen() |> map(&"IS #{&1}")
+
+    defp predicate_op_gen,
+      do: one_of([bool_gen(), constant("UNKNOWN"), null_gen()]) |> map(&"IS #{&1}")
+
+    ## OPERATION COMPOSITION UTILITIES
+
+    defp with_negation(op_gen), do: one_of([op_gen, map(op_gen, &"NOT #{&1}")])
+
+    defp compose_unary_op(type_gen, unary_op_gen),
+      do: bind({type_gen, unary_op_gen}, fn {a, unary_op} -> constant("#{unary_op} #{a}") end)
+
+    defp compose_predicate_op(type_gen, predicate_op_gen),
+      do:
+        bind({type_gen, predicate_op_gen}, fn {a, predicate_op} ->
+          constant("#{a} #{predicate_op}")
+        end)
+
+    defp compose_op(type_gen, op_gen),
+      do: bind({type_gen, op_gen, type_gen}, fn {a, op, b} -> constant("#{a} #{op} #{b}") end)
+
+    defp compose_range_op(type_gen, range_op_gen),
+      do:
+        bind({type_gen, range_op_gen, type_gen, type_gen}, fn {a, range_op, b, c} ->
+          constant("#{a} #{range_op} #{b} AND #{c}")
+        end)
+
+    defp compose_function_op(type_gen, op_gen) do
+      bind({type_gen, op_gen}, fn {val, op} -> constant("#{op}(#{val})") end)
+    end
+
+    defp compose_membership_op(type_gen, op_gen, opts \\ []) do
+      min_length = Access.get(opts, :min_length, 1)
+      max_length = Access.get(opts, :max_length, 5)
+
+      bind(
+        {
+          type_gen,
+          op_gen,
+          list_of(type_gen, min_length: min_length, max_length: max_length)
+        },
+        fn {val, op, values} -> constant("#{val} #{op} (#{Enum.join(values, ", ")})") end
+      )
+    end
+
+    ## EXPRESSION GENERATORS
+
+    defp expression_gen(type_gen, op_generators) do
+      type_gen = nullable_type_gen(type_gen)
+
+      op_generators
+      |> Enum.concat([
+        # {:comparison_op, comparison_op_gen()},
+        {:unary_op, is_null_op_gen()}
+        # {:range_op, range_comparison_op_gen()},
+        # {:membership_op, membership_op_gen()}
+      ])
+      |> Enum.map(fn
+        {:combine_op, op_gen} -> compose_op(type_gen, op_gen)
+        {:comparison_op, op_gen} -> compose_op(type_gen, op_gen)
+        {:unary_op, op_gen} -> compose_unary_op(type_gen, op_gen)
+        {:predicate_op, op_gen} -> compose_predicate_op(type_gen, op_gen)
+        {:range_op, op_gen} -> compose_range_op(type_gen, op_gen)
+        {:membership_op, op_gen} -> compose_membership_op(type_gen, op_gen)
+        {:function_op, op_gen} -> compose_function_op(type_gen, op_gen)
+      end)
+      |> one_of()
+    end
+
+    defp nested_expression_gen(type_gen, ops, opts \\ []) do
+      max_nesting = Access.get(opts, :max_nesting, 3)
+
+      Enum.map(1..max_nesting, fn nest_level ->
+        Enum.reduce(1..nest_level, type_gen, fn _, gen ->
+          expression_gen(gen |> map(&"(#{&1})"), ops)
+        end)
+      end)
+      |> one_of
+    end
+
+    defp numeric_expression_gen do
+      one_of([
+        expression_gen(numeric_gen() |> nullable_type_gen(), [
+          {:combine_op, numeric_op_gen()},
+          {:unary_op, numeric_unary_op_gen()},
+          {:range_op, range_comparison_op_gen()}
+        ]),
+        expression_gen(int_gen() |> nullable_type_gen(), [
+          {:combine_op, int_op_gen()},
+          {:unary_op, int_unary_op_gen()},
+          {:range_op, range_comparison_op_gen()}
+        ]),
+        expression_gen(double_gen() |> nullable_type_gen(), [
+          {:combine_op, numeric_op_gen()},
+          {:unary_op, double_unary_op_gen()},
+          {:range_op, range_comparison_op_gen()}
+        ])
+      ])
+    end
+
+    defp string_expression_gen do
+      expression_gen(str_gen() |> nullable_type_gen(), [
+        {:combine_op, string_op_gen()},
+        {:function_op, string_function_op_gen()},
+        {:comparison_op, string_comparison_op_gen()},
+        {:range_op, range_comparison_op_gen()}
+      ])
+    end
+
+    defp bool_expression_gen do
+      expression_gen(bool_gen() |> nullable_type_gen(), [
+        {:comparison_op, bool_comparison_op_gen()},
+        {:unary_op, bool_unary_op_gen()},
+        {:predicate_op, predicate_op_gen()}
+      ])
+    end
+
+    defp array_expression_gen(opts \\ []) do
+      max_dimensions = Access.get(opts, :max_dimensions, 3)
+
+      Enum.zip(
+        [int_gen(), double_gen(), bool_gen(), str_gen()]
+        |> Enum.map(&nullable_type_gen/1),
+        1..max_dimensions
+      )
+      |> Enum.map(fn {type_gen, dim} -> {type_gen, array_gen(type_gen, dimension: dim)} end)
+      |> Enum.flat_map(fn {type_gen, array_type_gen} ->
+        [
+          expression_gen(array_type_gen, [
+            {:combine_op, array_op_gen()},
+            {:comparison_op, array_comparison_op_gen()}
+          ]),
+          bind({array_type_gen, nullable_type_gen(type_gen)}, fn {array, element} ->
+            one_of([
+              constant("array_append(#{array}, #{element})"),
+              constant("array_prepend(#{element}, #{array})"),
+              constant("#{array} || #{element}"),
+              constant("#{element} || #{array}")
+            ])
+          end)
+        ]
+      end)
+      |> one_of
+    end
+
+    defp combine_to_bool_expression(type_gen, comparison_ops \\ []) do
+      expression_gen(
+        type_gen,
+        [
+          {:comparison_op, comparison_op_gen()},
+          {:unary_op, is_null_op_gen()},
+          {:range_op, range_comparison_op_gen()},
+          {:membership_op, membership_op_gen()}
+        ]
+        |> Enum.concat(comparison_ops)
+      )
+    end
+
+    defp datatype_expression_gen() do
+      [
+        numeric_expression_gen(),
+        string_expression_gen(),
+        bool_expression_gen(),
+        array_expression_gen()
+      ]
+      |> one_of()
+    end
+
+    defp clause_generator do
+      datatype_expression_gen()
     end
   end
 end

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -2,8 +2,11 @@ defmodule Electric.Replication.Eval.RunnerTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
+  import Support.DbSetup
+
   alias Electric.Replication.Eval.Runner
   alias Electric.Replication.Eval.Parser
+  alias Support.PgExpressionGenerator
 
   describe "record_to_ref_values/3" do
     test "should build ref values from record with known types and nils" do
@@ -183,38 +186,33 @@ defmodule Electric.Replication.Eval.RunnerTest do
   end
 
   describe "execute/2 property test" do
-    import Support.ComponentSetup
-    import Support.DbSetup
-    import StreamData
-
     setup [:with_unique_db]
 
     property "PostgreSQL clause behaves the same in both implementations", %{pool: pool} do
       check all(
-              clause <- clause_generator(),
-              max_runs: 1000
+              clause <- PgExpressionGenerator.postgres_expression(),
+              max_runs: 1_000_000,
+              max_run_time: 600
             ) do
         assert_runner_and_oracle_match(clause, pool)
       end
     end
 
     defp execute_oracle(clause, db_conn) do
-      oracle_result =
-        case Postgrex.query(db_conn, "SELECT #{clause}", []) do
-          {:ok, %Postgrex.Result{rows: [[result]]}} -> {:ok, result}
-          {:error, %Postgrex.Error{postgres: %{message: reason}}} -> {:error, reason}
-        end
+      case Postgrex.query(db_conn, "SELECT #{clause}", []) do
+        {:ok, %Postgrex.Result{rows: [[result]]}} -> {:ok, result}
+        {:error, %Postgrex.Error{postgres: %{message: reason}}} -> {:error, reason}
+      end
     end
 
     defp execute_runner(clause) do
-      runner_result =
-        try do
-          clause
-          |> Parser.parse_and_validate_expression!()
-          |> Runner.execute(%{})
-        rescue
-          err -> {:error, err}
-        end
+      try do
+        clause
+        |> Parser.parse_and_validate_expression!()
+        |> Runner.execute(%{})
+      rescue
+        err -> {:error, err}
+      end
     end
 
     defp assert_runner_and_oracle_match(clause, db_conn) do
@@ -226,20 +224,18 @@ defmodule Electric.Replication.Eval.RunnerTest do
           # Both results are ok, we can compare them
           oracle_val = cast_decimals_to_floats(oracle_val)
 
-          case oracle_val do
-            val when is_number(oracle_val) and is_number(runner_val) ->
-              assert_in_delta(runner_val, oracle_val, abs(0.01 * oracle_val))
+          if is_number(oracle_val) do
+            assert_in_delta(runner_val, oracle_val, abs(0.01 * oracle_val))
+          else
+            assert runner_val == oracle_val,
+                   """
+                   MISMATCH!
 
-            _ ->
-              assert runner_val == oracle_val,
-                     """
-                     MISMATCH!
+                   SQL: #{clause}
 
-                     SQL: #{clause}
-
-                     runner returned: #{inspect(runner_val)}
-                     oracle returned: #{inspect(oracle_val)}
-                     """
+                   runner returned: #{inspect(runner_val)}
+                   oracle returned: #{inspect(oracle_val)}
+                   """
           end
 
           :ok
@@ -275,258 +271,5 @@ defmodule Electric.Replication.Eval.RunnerTest do
 
     defp cast_decimals_to_floats(%Decimal{} = decimal), do: Decimal.to_float(decimal)
     defp cast_decimals_to_floats(value), do: value
-
-    ## TYPE GENERATORS
-
-    defp null_gen, do: constant("NULL")
-    defp bool_gen, do: member_of(["TRUE", "FALSE"])
-
-    defp int_gen, do: integer() |> map(&Integer.to_string/1)
-    defp pos_int_gen, do: positive_integer() |> map(&Integer.to_string/1)
-    defp double_gen, do: float(min: -1.0e6, max: 1.0e6) |> map(&Float.to_string/1)
-    defp numeric_gen, do: one_of([int_gen(), double_gen()])
-
-    defp str_gen,
-      do:
-        StreamData.string(:ascii, max_length: 10)
-        |> map(&"'#{String.replace(&1, "'", "''")}'")
-
-    defp array_gen(type_gen, opts \\ []) do
-      dimension = Access.get(opts, :dimension, 1)
-      min_length = Access.get(opts, :min_length, 1)
-      max_length = Access.get(opts, :max_length, 5)
-
-      Enum.reduce(1..dimension, type_gen, fn dim, gen ->
-        list_gen =
-          if dim == dimension do
-            list_of(gen, min_length: min_length, max_length: max_length)
-          else
-            list_of(gen, length: Enum.random(min_length..max_length))
-          end
-
-        list_gen
-        |> map(fn elements ->
-          "ARRAY[" <> Enum.join(elements, ", ") <> "]"
-        end)
-      end)
-    end
-
-    defp datatype_gen_func do
-      member_of([int_gen(), double_gen(), bool_gen(), str_gen()])
-      |> map(&nullable_type_gen/1)
-    end
-
-    defp nullable_type_gen(type_gen, null_ratio \\ 0.25),
-      do: frequency([{floor(1.0 / null_ratio), type_gen}, {1, null_gen()}])
-
-    ## OPERATION GENERATORS
-
-    defp comparison_op_gen,
-      do:
-        member_of([
-          "=",
-          "!=",
-          "<>",
-          ">",
-          "<",
-          ">=",
-          "<=",
-          "IS DISTINCT FROM",
-          "IS NOT DISTINCT FROM"
-        ])
-
-    defp bool_comparison_op_gen, do: member_of(["AND", "OR"])
-    defp bool_unary_op_gen, do: constant("NOT")
-
-    defp range_comparison_op_gen,
-      do: member_of(["BETWEEN", "BETWEEN SYMMETRIC"]) |> with_negation()
-
-    defp array_op_gen, do: member_of(["||"])
-    defp string_function_op_gen, do: member_of(["LOWER", "UPPER"])
-    defp array_comparison_op_gen, do: member_of(["@>", "<@", "&&"])
-
-    defp numeric_op_gen, do: member_of(["+", "-", "/", "*"])
-    defp numeric_unary_op_gen, do: member_of(["+", "-", "@"])
-    defp int_op_gen, do: one_of([numeric_op_gen(), member_of(["&", "|", "#"])])
-    defp int_unary_op_gen, do: one_of([numeric_unary_op_gen(), member_of(["~"])])
-    defp double_unary_op_gen, do: one_of([numeric_unary_op_gen(), member_of(["|/"])])
-
-    defp string_op_gen, do: member_of(["||"])
-    defp string_comparison_op_gen, do: member_of(["~~", "~~*", "!~~", "!~~*"])
-    defp string_function_op_gen, do: member_of(["LOWER", "UPPER"])
-
-    defp membership_op_gen, do: with_negation(constant("IN"))
-
-    defp is_null_op_gen, do: null_gen() |> map(&"IS #{&1}")
-
-    defp predicate_op_gen,
-      do: one_of([bool_gen(), constant("UNKNOWN"), null_gen()]) |> map(&"IS #{&1}")
-
-    ## OPERATION COMPOSITION UTILITIES
-
-    defp with_negation(op_gen), do: one_of([op_gen, map(op_gen, &"NOT #{&1}")])
-
-    defp compose_unary_op(type_gen, unary_op_gen),
-      do: bind({type_gen, unary_op_gen}, fn {a, unary_op} -> constant("#{unary_op} #{a}") end)
-
-    defp compose_predicate_op(type_gen, predicate_op_gen),
-      do:
-        bind({type_gen, predicate_op_gen}, fn {a, predicate_op} ->
-          constant("#{a} #{predicate_op}")
-        end)
-
-    defp compose_op(type_gen, op_gen),
-      do: bind({type_gen, op_gen, type_gen}, fn {a, op, b} -> constant("#{a} #{op} #{b}") end)
-
-    defp compose_range_op(type_gen, range_op_gen),
-      do:
-        bind({type_gen, range_op_gen, type_gen, type_gen}, fn {a, range_op, b, c} ->
-          constant("#{a} #{range_op} #{b} AND #{c}")
-        end)
-
-    defp compose_function_op(type_gen, op_gen) do
-      bind({type_gen, op_gen}, fn {val, op} -> constant("#{op}(#{val})") end)
-    end
-
-    defp compose_membership_op(type_gen, op_gen, opts \\ []) do
-      min_length = Access.get(opts, :min_length, 1)
-      max_length = Access.get(opts, :max_length, 5)
-
-      bind(
-        {
-          type_gen,
-          op_gen,
-          list_of(type_gen, min_length: min_length, max_length: max_length)
-        },
-        fn {val, op, values} -> constant("#{val} #{op} (#{Enum.join(values, ", ")})") end
-      )
-    end
-
-    ## EXPRESSION GENERATORS
-
-    defp expression_gen(type_gen, op_generators) do
-      type_gen = nullable_type_gen(type_gen)
-
-      op_generators
-      |> Enum.concat([
-        # {:comparison_op, comparison_op_gen()},
-        {:unary_op, is_null_op_gen()}
-        # {:range_op, range_comparison_op_gen()},
-        # {:membership_op, membership_op_gen()}
-      ])
-      |> Enum.map(fn
-        {:combine_op, op_gen} -> compose_op(type_gen, op_gen)
-        {:comparison_op, op_gen} -> compose_op(type_gen, op_gen)
-        {:unary_op, op_gen} -> compose_unary_op(type_gen, op_gen)
-        {:predicate_op, op_gen} -> compose_predicate_op(type_gen, op_gen)
-        {:range_op, op_gen} -> compose_range_op(type_gen, op_gen)
-        {:membership_op, op_gen} -> compose_membership_op(type_gen, op_gen)
-        {:function_op, op_gen} -> compose_function_op(type_gen, op_gen)
-      end)
-      |> one_of()
-    end
-
-    defp nested_expression_gen(type_gen, ops, opts \\ []) do
-      max_nesting = Access.get(opts, :max_nesting, 3)
-
-      Enum.map(1..max_nesting, fn nest_level ->
-        Enum.reduce(1..nest_level, type_gen, fn _, gen ->
-          expression_gen(gen |> map(&"(#{&1})"), ops)
-        end)
-      end)
-      |> one_of
-    end
-
-    defp numeric_expression_gen do
-      one_of([
-        expression_gen(numeric_gen() |> nullable_type_gen(), [
-          {:combine_op, numeric_op_gen()},
-          {:unary_op, numeric_unary_op_gen()},
-          {:range_op, range_comparison_op_gen()}
-        ]),
-        expression_gen(int_gen() |> nullable_type_gen(), [
-          {:combine_op, int_op_gen()},
-          {:unary_op, int_unary_op_gen()},
-          {:range_op, range_comparison_op_gen()}
-        ]),
-        expression_gen(double_gen() |> nullable_type_gen(), [
-          {:combine_op, numeric_op_gen()},
-          {:unary_op, double_unary_op_gen()},
-          {:range_op, range_comparison_op_gen()}
-        ])
-      ])
-    end
-
-    defp string_expression_gen do
-      expression_gen(str_gen() |> nullable_type_gen(), [
-        {:combine_op, string_op_gen()},
-        {:function_op, string_function_op_gen()},
-        {:comparison_op, string_comparison_op_gen()},
-        {:range_op, range_comparison_op_gen()}
-      ])
-    end
-
-    defp bool_expression_gen do
-      expression_gen(bool_gen() |> nullable_type_gen(), [
-        {:comparison_op, bool_comparison_op_gen()},
-        {:unary_op, bool_unary_op_gen()},
-        {:predicate_op, predicate_op_gen()}
-      ])
-    end
-
-    defp array_expression_gen(opts \\ []) do
-      max_dimensions = Access.get(opts, :max_dimensions, 3)
-
-      Enum.zip(
-        [int_gen(), double_gen(), bool_gen(), str_gen()]
-        |> Enum.map(&nullable_type_gen/1),
-        1..max_dimensions
-      )
-      |> Enum.map(fn {type_gen, dim} -> {type_gen, array_gen(type_gen, dimension: dim)} end)
-      |> Enum.flat_map(fn {type_gen, array_type_gen} ->
-        [
-          expression_gen(array_type_gen, [
-            {:combine_op, array_op_gen()},
-            {:comparison_op, array_comparison_op_gen()}
-          ]),
-          bind({array_type_gen, nullable_type_gen(type_gen)}, fn {array, element} ->
-            one_of([
-              constant("array_append(#{array}, #{element})"),
-              constant("array_prepend(#{element}, #{array})"),
-              constant("#{array} || #{element}"),
-              constant("#{element} || #{array}")
-            ])
-          end)
-        ]
-      end)
-      |> one_of
-    end
-
-    defp combine_to_bool_expression(type_gen, comparison_ops \\ []) do
-      expression_gen(
-        type_gen,
-        [
-          {:comparison_op, comparison_op_gen()},
-          {:unary_op, is_null_op_gen()},
-          {:range_op, range_comparison_op_gen()},
-          {:membership_op, membership_op_gen()}
-        ]
-        |> Enum.concat(comparison_ops)
-      )
-    end
-
-    defp datatype_expression_gen() do
-      [
-        numeric_expression_gen(),
-        string_expression_gen(),
-        bool_expression_gen(),
-        array_expression_gen()
-      ]
-      |> one_of()
-    end
-
-    defp clause_generator do
-      datatype_expression_gen()
-    end
   end
 end

--- a/packages/sync-service/test/support/pg_expression_generator.ex
+++ b/packages/sync-service/test/support/pg_expression_generator.ex
@@ -1,0 +1,253 @@
+defmodule Support.PgExpressionGenerator do
+  @moduledoc """
+  Generates Postgres expressions for testing purposes.
+  """
+
+  import StreamData
+
+  ## TYPE GENERATORS
+
+  defp null_gen, do: constant("NULL")
+  defp bool_gen, do: member_of(["TRUE", "FALSE"])
+
+  defp int_gen, do: integer() |> map(&Integer.to_string/1)
+  defp double_gen, do: float(min: -1.0e6, max: 1.0e6) |> map(&Float.to_string/1)
+  defp numeric_gen, do: one_of([int_gen(), double_gen()])
+
+  defp str_gen,
+    do:
+      StreamData.string(:ascii, max_length: 10)
+      |> map(&"'#{String.replace(&1, "'", "''")}'")
+
+  defp array_gen(type_gen, opts) do
+    dimension = Access.get(opts, :dimension, 1)
+    min_length = Access.get(opts, :min_length, 1)
+    max_length = Access.get(opts, :max_length, 5)
+
+    Enum.reduce(1..dimension, type_gen, fn dim, gen ->
+      list_gen =
+        if dim == dimension do
+          list_of(gen, min_length: min_length, max_length: max_length)
+        else
+          list_of(gen, length: Enum.random(min_length..max_length))
+        end
+
+      list_gen
+      |> map(fn elements ->
+        "ARRAY[" <> Enum.join(elements, ", ") <> "]"
+      end)
+    end)
+  end
+
+  defp nullable_type_gen(type_gen, null_ratio \\ 0.25),
+    do: frequency([{floor(1.0 / null_ratio), type_gen}, {1, null_gen()}])
+
+  ## OPERATION GENERATORS
+
+  defp comparison_op_gen,
+    do:
+      member_of([
+        "=",
+        "!=",
+        "<>",
+        ">",
+        "<",
+        ">=",
+        "<=",
+        "IS DISTINCT FROM",
+        "IS NOT DISTINCT FROM"
+      ])
+
+  defp bool_comparison_op_gen, do: member_of(["AND", "OR"])
+  defp bool_unary_op_gen, do: constant("NOT")
+
+  defp range_comparison_op_gen,
+    do: member_of(["BETWEEN", "BETWEEN SYMMETRIC"]) |> with_negation()
+
+  defp array_op_gen, do: member_of(["||"])
+  defp array_function_op_gen, do: member_of(["array_ndims"])
+  defp array_comparison_op_gen, do: member_of(["@>", "<@", "&&"])
+
+  defp numeric_op_gen, do: member_of(["+", "-", "/", "*"])
+  defp numeric_unary_op_gen, do: member_of(["+", "-", "@"])
+  defp int_op_gen, do: one_of([numeric_op_gen(), member_of(["&", "|", "#"])])
+  defp int_unary_op_gen, do: one_of([numeric_unary_op_gen(), member_of(["~"])])
+  defp double_unary_op_gen, do: one_of([numeric_unary_op_gen(), member_of(["|/"])])
+
+  defp string_op_gen, do: member_of(["||"])
+  defp string_comparison_op_gen, do: member_of(["~~", "~~*", "!~~", "!~~*"])
+  defp string_function_op_gen, do: member_of(["LOWER", "UPPER"])
+
+  defp membership_op_gen, do: with_negation(constant("IN"))
+
+  defp is_null_op_gen, do: null_gen() |> map(&"IS #{&1}")
+
+  defp predicate_op_gen,
+    do: one_of([bool_gen(), constant("UNKNOWN"), null_gen()]) |> map(&"IS #{&1}")
+
+  ## OPERATION COMPOSITION UTILITIES
+
+  defp with_negation(op_gen), do: one_of([op_gen, map(op_gen, &"NOT #{&1}")])
+
+  defp compose_unary_op(type_gen, unary_op_gen),
+    do: bind({type_gen, unary_op_gen}, fn {a, unary_op} -> constant("#{unary_op} #{a}") end)
+
+  defp compose_predicate_op(type_gen, predicate_op_gen),
+    do:
+      bind({type_gen, predicate_op_gen}, fn {a, predicate_op} ->
+        constant("#{a} #{predicate_op}")
+      end)
+
+  defp compose_op(type_gen, op_gen),
+    do: bind({type_gen, op_gen, type_gen}, fn {a, op, b} -> constant("#{a} #{op} #{b}") end)
+
+  defp compose_range_op(type_gen, range_op_gen),
+    do:
+      bind({type_gen, range_op_gen, type_gen, type_gen}, fn {a, range_op, b, c} ->
+        constant("#{a} #{range_op} #{b} AND #{c}")
+      end)
+
+  defp compose_function_op(type_gen, op_gen) do
+    bind({type_gen, op_gen}, fn {val, op} -> constant("#{op}(#{val})") end)
+  end
+
+  defp compose_membership_op(type_gen, op_gen, opts \\ []) do
+    min_length = Access.get(opts, :min_length, 1)
+    max_length = Access.get(opts, :max_length, 5)
+
+    bind(
+      {
+        type_gen,
+        op_gen,
+        list_of(type_gen, min_length: min_length, max_length: max_length)
+      },
+      fn {val, op, values} -> constant("#{val} #{op} (#{Enum.join(values, ", ")})") end
+    )
+  end
+
+  ## EXPRESSION GENERATORS
+
+  defp expression_gen(type_gen, op_generators) do
+    type_gen = nullable_type_gen(type_gen)
+
+    op_generators
+    |> Enum.concat([
+      {:unary_op, is_null_op_gen()}
+      # {:comparison_op, comparison_op_gen()},
+      # {:range_op, range_comparison_op_gen()},
+      # {:membership_op, membership_op_gen()}
+    ])
+    |> Enum.map(fn
+      {:combine_op, op_gen} -> compose_op(type_gen, op_gen)
+      {:comparison_op, op_gen} -> compose_op(type_gen, op_gen)
+      {:unary_op, op_gen} -> compose_unary_op(type_gen, op_gen)
+      {:predicate_op, op_gen} -> compose_predicate_op(type_gen, op_gen)
+      {:range_op, op_gen} -> compose_range_op(type_gen, op_gen)
+      {:membership_op, op_gen} -> compose_membership_op(type_gen, op_gen)
+      {:function_op, op_gen} -> compose_function_op(type_gen, op_gen)
+    end)
+    |> one_of()
+  end
+
+  defp numeric_expression_gen do
+    one_of([
+      expression_gen(numeric_gen() |> nullable_type_gen(), [
+        {:combine_op, numeric_op_gen()},
+        {:unary_op, numeric_unary_op_gen()},
+        {:range_op, range_comparison_op_gen()},
+        {:comparison_op, comparison_op_gen()},
+        {:range_op, range_comparison_op_gen()},
+        {:membership_op, membership_op_gen()}
+      ]),
+      expression_gen(int_gen() |> nullable_type_gen(), [
+        {:combine_op, int_op_gen()},
+        {:unary_op, int_unary_op_gen()},
+        {:range_op, range_comparison_op_gen()},
+        {:range_op, range_comparison_op_gen()},
+        {:comparison_op, comparison_op_gen()},
+        {:range_op, range_comparison_op_gen()},
+        {:membership_op, membership_op_gen()}
+      ]),
+      expression_gen(double_gen() |> nullable_type_gen(), [
+        {:combine_op, numeric_op_gen()},
+        {:unary_op, double_unary_op_gen()},
+        {:range_op, range_comparison_op_gen()},
+        {:range_op, range_comparison_op_gen()},
+        {:comparison_op, comparison_op_gen()},
+        {:range_op, range_comparison_op_gen()},
+        {:membership_op, membership_op_gen()}
+      ])
+    ])
+  end
+
+  defp string_expression_gen do
+    expression_gen(str_gen() |> nullable_type_gen(), [
+      {:combine_op, string_op_gen()},
+      {:function_op, string_function_op_gen()},
+      {:comparison_op, string_comparison_op_gen()},
+      {:range_op, range_comparison_op_gen()},
+      {:comparison_op, comparison_op_gen()},
+      {:range_op, range_comparison_op_gen()},
+      {:membership_op, membership_op_gen()}
+    ])
+  end
+
+  defp bool_expression_gen do
+    expression_gen(bool_gen() |> nullable_type_gen(), [
+      {:comparison_op, bool_comparison_op_gen()},
+      {:unary_op, bool_unary_op_gen()},
+      {:predicate_op, predicate_op_gen()}
+      # TODO: comparisons don't work on nullable booleans
+      # {:range_op, range_comparison_op_gen()},
+      # {:comparison_op, comparison_op_gen()}
+      # {:range_op, range_comparison_op_gen()},
+      # {:membership_op, membership_op_gen()}
+    ])
+  end
+
+  defp array_expression_gen(opts \\ []) do
+    max_dimensions = Access.get(opts, :max_dimensions, 3)
+
+    Enum.zip(
+      [int_gen(), double_gen(), bool_gen(), str_gen()]
+      |> Enum.map(&nullable_type_gen/1),
+      1..max_dimensions
+    )
+    |> Enum.map(fn {type_gen, dim} -> {type_gen, array_gen(type_gen, dimension: dim)} end)
+    |> Enum.flat_map(fn {type_gen, array_type_gen} ->
+      [
+        expression_gen(array_type_gen, [
+          {:combine_op, array_op_gen()},
+          {:comparison_op, array_comparison_op_gen()},
+          {:function_op, array_function_op_gen()},
+          {:membership_op, membership_op_gen()}
+        ]),
+        bind({array_type_gen, nullable_type_gen(type_gen)}, fn {array, element} ->
+          one_of([
+            constant("array_append(#{array}, #{element})"),
+            constant("array_prepend(#{element}, #{array})"),
+            constant("#{array} || #{element}"),
+            constant("#{element} || #{array}")
+          ])
+        end)
+      ]
+    end)
+    |> one_of
+  end
+
+  defp datatype_expression_gen() do
+    [
+      numeric_expression_gen(),
+      string_expression_gen(),
+      bool_expression_gen(),
+      array_expression_gen()
+    ]
+    |> one_of()
+  end
+
+  @doc """
+  Generates a Postgres expression stream that can be used in
+  StreamData property tests.
+  """
+  def postgres_expression, do: datatype_expression_gen()
+end

--- a/packages/sync-service/test/support/pg_expression_generator.ex
+++ b/packages/sync-service/test/support/pg_expression_generator.ex
@@ -154,7 +154,6 @@ defmodule Support.PgExpressionGenerator do
       expression_gen(numeric_gen() |> nullable_type_gen(), [
         {:combine_op, numeric_op_gen()},
         {:unary_op, numeric_unary_op_gen()},
-        {:range_op, range_comparison_op_gen()},
         {:comparison_op, comparison_op_gen()},
         {:range_op, range_comparison_op_gen()},
         {:membership_op, membership_op_gen()}
@@ -162,8 +161,6 @@ defmodule Support.PgExpressionGenerator do
       expression_gen(int_gen() |> nullable_type_gen(), [
         {:combine_op, int_op_gen()},
         {:unary_op, int_unary_op_gen()},
-        {:range_op, range_comparison_op_gen()},
-        {:range_op, range_comparison_op_gen()},
         {:comparison_op, comparison_op_gen()},
         {:range_op, range_comparison_op_gen()},
         {:membership_op, membership_op_gen()}
@@ -171,8 +168,6 @@ defmodule Support.PgExpressionGenerator do
       expression_gen(double_gen() |> nullable_type_gen(), [
         {:combine_op, numeric_op_gen()},
         {:unary_op, double_unary_op_gen()},
-        {:range_op, range_comparison_op_gen()},
-        {:range_op, range_comparison_op_gen()},
         {:comparison_op, comparison_op_gen()},
         {:range_op, range_comparison_op_gen()},
         {:membership_op, membership_op_gen()}
@@ -185,7 +180,6 @@ defmodule Support.PgExpressionGenerator do
       {:combine_op, string_op_gen()},
       {:function_op, string_function_op_gen()},
       {:comparison_op, string_comparison_op_gen()},
-      {:range_op, range_comparison_op_gen()},
       {:comparison_op, comparison_op_gen()},
       {:range_op, range_comparison_op_gen()},
       {:membership_op, membership_op_gen()}

--- a/packages/sync-service/test/support/pg_expression_generator.ex
+++ b/packages/sync-service/test/support/pg_expression_generator.ex
@@ -17,7 +17,7 @@ defmodule Support.PgExpressionGenerator do
   defp str_gen,
     do:
       StreamData.string(:ascii, max_length: 10)
-      |> map(&"'#{String.replace(&1, "'", "''")}'")
+      |> map(&"'#{String.replace(&1, "'", "''") |> String.replace("\\", "\\\\")}'")
 
   defp array_gen(type_gen, opts) do
     dimension = Access.get(opts, :dimension, 1)
@@ -149,7 +149,7 @@ defmodule Support.PgExpressionGenerator do
     |> one_of()
   end
 
-  defp numeric_expression_gen do
+  def numeric_expression do
     one_of([
       expression_gen(numeric_gen() |> nullable_type_gen(), [
         {:combine_op, numeric_op_gen()},
@@ -180,7 +180,7 @@ defmodule Support.PgExpressionGenerator do
     ])
   end
 
-  defp string_expression_gen do
+  def string_expression do
     expression_gen(str_gen() |> nullable_type_gen(), [
       {:combine_op, string_op_gen()},
       {:function_op, string_function_op_gen()},
@@ -192,7 +192,7 @@ defmodule Support.PgExpressionGenerator do
     ])
   end
 
-  defp bool_expression_gen do
+  def bool_expression do
     expression_gen(bool_gen() |> nullable_type_gen(), [
       {:comparison_op, bool_comparison_op_gen()},
       {:unary_op, bool_unary_op_gen()},
@@ -205,7 +205,7 @@ defmodule Support.PgExpressionGenerator do
     ])
   end
 
-  defp array_expression_gen(opts \\ []) do
+  def array_expression(opts \\ []) do
     max_dimensions = Access.get(opts, :max_dimensions, 3)
 
     Enum.zip(
@@ -235,19 +235,13 @@ defmodule Support.PgExpressionGenerator do
     |> one_of
   end
 
-  defp datatype_expression_gen() do
+  def datatype_expression() do
     [
-      numeric_expression_gen(),
-      string_expression_gen(),
-      bool_expression_gen(),
-      array_expression_gen()
+      numeric_expression(),
+      string_expression(),
+      bool_expression(),
+      array_expression()
     ]
     |> one_of()
   end
-
-  @doc """
-  Generates a Postgres expression stream that can be used in
-  StreamData property tests.
-  """
-  def postgres_expression, do: datatype_expression_gen()
 end

--- a/packages/sync-service/test/support/pg_expression_generator.ex
+++ b/packages/sync-service/test/support/pg_expression_generator.ex
@@ -132,10 +132,8 @@ defmodule Support.PgExpressionGenerator do
 
     op_generators
     |> Enum.concat([
+      # this applies to every type
       {:unary_op, is_null_op_gen()}
-      # {:comparison_op, comparison_op_gen()},
-      # {:range_op, range_comparison_op_gen()},
-      # {:membership_op, membership_op_gen()}
     ])
     |> Enum.map(fn
       {:combine_op, op_gen} -> compose_op(type_gen, op_gen)


### PR DESCRIPTION
Introduces some `StreamData` property tests for our PG expression parser and executor.

Not the prettiest but I did already find several issues, some of which I would need confirmation that they were not intentional:

1. `AND` should handle `false and null` case as `false`
2. Array concatenation with `null` should return the same array
3. `array_prepend` and `array_append` work with `null`s, and they actually add the null to the array
4. Array prepends and appends using `||` work with `null` but they keep the array the same, and they do not work with strings
5. Array contains and is contained have specific behaviours with `null` - if the array that should be contained has a `null` then it will never pass the check - whether the array containing the other has a `null` or not.
6. The `^` operator should handle `0^0`, which `Float.pow` did not - not sure if this affects performance significantly @icehaunter 
7. Added bitwise not operator - not necessary, can remove, was just checking most operators


I've also found that various comparison operators don't work on booleans and arrays, but decided to leave that as separate work and instead try to get this merged as it is an improvement over what we had before.

The tests generate arbitrary expressions and then use postgres as the oracle to ensure that the values we produce are the same.

If both our runner and postgres error, we ignore the result.

If our runner resolves to nil but postgres errors I also ignore that result, as we have this concept of `strict?` execution that would need examination in lots of parts to ensure we have the same behaviour as postgres exactly. Can be done iteratively.