### PR TITLE
fix: Use separate stack event for pool connection errors

### DIFF
--- a/.changeset/brown-bugs-shout.md
+++ b/.changeset/brown-bugs-shout.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Use `:pool_connection_error` stack event for pool errors that we do not retry anything on.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -725,7 +725,7 @@ defmodule Electric.Connection.Manager do
     error = DbConnectionError.from_error(exit_reason)
 
     dispatch_stack_event(
-      {:connection_error,
+      {:pool_connection_error,
        %{
          error: DbConnectionError.format_original_error(error),
          type: error.type,


### PR DESCRIPTION
Fixes https://github.com/electric-sql/stratovolt/issues/697

We need to classify these pool connection errors differently than the errors that cause either a reconnection or a failure to electric.

We can do that either with a separate stack event as suggested by @alco and done here with `:pool_connection_error`, or adding a property to indicate that we can ignore this. I am of the opinion that this should be a clearly different event since it is not fatal or causes a full reconnection, but am happy to hear other thoughts - my understanding is the pool connections will be reinstated?

