### PR TITLE
fix: Remove `:pool_connection_error` stack event altogether

### DIFF
--- a/.changeset/brown-bugs-shout.md
+++ b/.changeset/brown-bugs-shout.md
@@ -2,4 +2,4 @@
 "@core/sync-service": patch
 ---
 
-Use `:pool_connection_error` stack event for pool errors that we do not retry anything on.
+Do not fire stack events for pool connection errors as they are not actionable.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -719,20 +719,10 @@ defmodule Electric.Connection.Manager do
     {:noreply, state}
   end
 
-  # When a pooled connection terminates, we can report its exit reason the same way we do for
-  # replication and lock connections.
+  # When a pooled connection terminates, we log its exit reason, but more connections will
+  # be started by the connection pool supervisor, so we don't need to do anything else.
   def handle_info({:pool_conn_down, _ref, :process, _pid, {:shutdown, exit_reason}}, state) do
     error = DbConnectionError.from_error(exit_reason)
-
-    dispatch_stack_event(
-      {:pool_connection_error,
-       %{
-         error: DbConnectionError.format_original_error(error),
-         type: error.type,
-         message: error.message
-       }},
-      state
-    )
 
     # If the error is of an unknown type, it would have already been logged by DbConnectionError itself.
     if error.type != :unknown do


### PR DESCRIPTION
Followup to https://github.com/electric-sql/electric/pull/2864

As @balegas suggested and @alco pointed out, these errors are not actionable and self-recovering, so we should not fire any stack events for them.