### PR TITLE
fix: buffer SSE messages until up-to-date message

### DIFF
--- a/.changeset/silent-ears-agree.md
+++ b/.changeset/silent-ears-agree.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Buffer SSE messages until up-to-date message to avoid duplicate operations from being published on the shape stream.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -398,21 +398,11 @@ export class ShapeStream<T extends Row<unknown> = Row>
       backOffOpts
     )
 
-    this.#fetchClient = createFetchWithConsumedMessages(
-      createFetchWithResponseHeadersCheck(
-        createFetchWithChunkBuffer(fetchWithBackoffClient)
-      )
-    )
-
-    const sseFetchWithBackoffClient = createFetchWithBackoff(
-      baseFetchClient,
-      backOffOpts,
-      true
-    )
-
     this.#sseFetchClient = createFetchWithResponseHeadersCheck(
-      createFetchWithChunkBuffer(sseFetchWithBackoffClient)
+      createFetchWithChunkBuffer(fetchWithBackoffClient)
     )
+
+    this.#fetchClient = createFetchWithConsumedMessages(this.#sseFetchClient)
 
     this.#subscribeToVisibilityChanges()
   }
@@ -498,7 +488,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
         fetchUrl,
         requestAbortController,
         headers: requestHeaders,
-        resumingFromPause: true,
+        resumingFromPause,
       })
     } catch (e) {
       // Handle abort error triggered by refresh

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -38,8 +38,7 @@ export const BackoffDefaults = {
 
 export function createFetchWithBackoff(
   fetchClient: typeof fetch,
-  backoffOptions: BackoffOptions = BackoffDefaults,
-  sseMode: boolean = false
+  backoffOptions: BackoffOptions = BackoffDefaults
 ): typeof fetch {
   const {
     initialDelay,
@@ -67,12 +66,6 @@ export function createFetchWithBackoff(
         if (result.ok) return result
 
         const err = await FetchError.fromResponse(result, url.toString())
-        if (err.status === 409 && sseMode) {
-          // The json body is [ { headers: { control: 'must-refetch' } } ] in normal mode
-          // and is { headers: { control: 'must-refetch' } } in SSE mode
-          // So in SSE mode we need to wrap it in an array
-          err.json = [err.json]
-        }
 
         throw err
       } catch (e) {

--- a/packages/typescript-client/src/helpers.ts
+++ b/packages/typescript-client/src/helpers.ts
@@ -58,8 +58,10 @@ export function isUpToDateMessage<T extends Row<unknown> = Row>(
  * If we are not in SSE mode this function will return undefined.
  */
 export function getOffset(message: ControlMessage): Offset | undefined {
-  const lsn = Number(message.headers.global_last_seen_lsn)
-  if (lsn && !isNaN(lsn)) {
-    return `${lsn}_0`
+  if (!message.headers.global_last_seen_lsn) {
+    return
   }
+
+  const lsn = BigInt(message.headers.global_last_seen_lsn)
+  return `${lsn}_0`
 }

--- a/packages/typescript-client/src/helpers.ts
+++ b/packages/typescript-client/src/helpers.ts
@@ -58,10 +58,9 @@ export function isUpToDateMessage<T extends Row<unknown> = Row>(
  * If we are not in SSE mode this function will return undefined.
  */
 export function getOffset(message: ControlMessage): Offset | undefined {
-  if (!message.headers.global_last_seen_lsn) {
+  const lsn = message.headers.global_last_seen_lsn
+  if (!lsn) {
     return
   }
-
-  const lsn = BigInt(message.headers.global_last_seen_lsn)
-  return `${lsn}_0`
+  return `${lsn}_0` as Offset
 }

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -1,4 +1,4 @@
-import { ColumnInfo, GetExtensions, Message, Row, Schema, Value } from './types'
+import { ColumnInfo, GetExtensions, Row, Schema, Value } from './types'
 import { ParserNullValueError } from './error'
 
 type NullToken = null | `NULL`
@@ -98,7 +98,7 @@ export class MessageParser<T extends Row<unknown>> {
     this.parser = { ...defaultParser, ...parser }
   }
 
-  parse(messages: string, schema: Schema): Message<T>[] {
+  parse<Result>(messages: string, schema: Schema): Result {
     return JSON.parse(messages, (key, value) => {
       // typeof value === `object` && value !== null
       // is needed because there could be a column named `value`
@@ -117,7 +117,7 @@ export class MessageParser<T extends Row<unknown>> {
         })
       }
       return value
-    }) as Message<T>[]
+    }) as Result
   }
 
   // Parses the message values using the provided parser based on the schema information

--- a/packages/typescript-client/src/types.ts
+++ b/packages/typescript-client/src/types.ts
@@ -17,7 +17,7 @@ export type Row<Extensions = never> = Record<string, Value<Extensions>>
 export type GetExtensions<T extends Row<unknown>> =
   T extends Row<infer Extensions> ? Extensions : never
 
-export type Offset = `-1` | `${number}_${number}`
+export type Offset = `-1` | `${number}_${number}` | `${bigint}_${number}`
 
 interface Header {
   [key: Exclude<string, `operation` | `control`>]: Value


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/electric-sql/electric/pull/2546#issuecomment-3007137018. The crux of the issue is that messages might be processed several times if the SSE connection breaks after processing a message but before receiving the up-to-date message. This is because we only advance the offset when processing the up-to-date message, hence, we would fetch again at the old offset and receive some messages that we already processed.

The fix is easy: we batch SSE messages until we receive up-to-date and only process the messages at that point. The hard part was to write a unit test that reproduces this scenario. After a bit of trial and error i managed to do that by creating a custom fetch wrapper that proxies the SSE response but filters out the first up-to-date message and then forces a refresh of the shapestream at that point.