### PR TITLE
fix: Always include latest versions

### DIFF
--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -56,14 +56,13 @@ jobs:
           fetch-depth: 0
       # Get the Electric version of the Docker image
       - name: Get Electric version
-        if: needs.changesets.outputs.published == 'true'
         id: sync_version
         run: |
           VERSION=$(jq -r '.version' packages/sync-service/package.json)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Trigger cloud update (on release)
+
+      - name: Trigger cloud update
         uses: peter-evans/repository-dispatch@v2
-        if: needs.changesets.outputs.published == 'true'
         with:
           token: ${{ secrets.CROSSREPO_PAT }}
           repository: electric-sql/stratovolt
@@ -72,16 +71,4 @@ jobs:
             {
               "electric_commit_sha": "${{ github.sha }}",
               "electric_docker_version": "${{ steps.sync_version.outputs.version }}"
-            }
-      # On commit, only update the commit SHA, not the Docker image version
-      - name: Trigger cloud update (on commit)
-        uses: peter-evans/repository-dispatch@v2
-        if: needs.changesets.outputs.published != 'true'
-        with:
-          token: ${{ secrets.CROSSREPO_PAT }}
-          repository: electric-sql/stratovolt
-          event-type: update-electric
-          client-payload: |
-            {
-              "electric_commit_sha": "${{ github.sha }}"
             }


### PR DESCRIPTION
With our current approach we end up skipping Docker image updates because the commits get overwritten - I propose always sending the latest versions of both the commit sha and the docker version and we just ensure we don't do unnecessary updates at the target.