### PR TITLE
fix: Handle more pool connection exit reasons

### DIFF
--- a/.changeset/healthy-needles-fetch.md
+++ b/.changeset/healthy-needles-fetch.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Handle more pool connection disconnect exit reasons

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -720,13 +720,12 @@ defmodule Electric.Connection.Manager do
 
   # When a pooled connection terminates, we log its exit reason, but more connections will
   # be started by the connection pool supervisor, so we don't need to do anything else.
-  def handle_info({:pool_conn_down, _ref, :process, _pid, reason}, state) do
-    error =
-      case reason do
-        {:shutdown, exit_reason} -> exit_reason
-        exit_reason -> exit_reason
-      end
-      |> DbConnectionError.from_error()
+  def handle_info({:pool_conn_down, _ref, :process, _pid, :shutdown}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:pool_conn_down, _ref, :process, _pid, {:shutdown, exit_reason}}, state) do
+    error = DbConnectionError.from_error(exit_reason)
 
     # If the error is of an unknown type, it would have already been logged by DbConnectionError itself.
     if error.type != :unknown do

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -720,8 +720,13 @@ defmodule Electric.Connection.Manager do
 
   # When a pooled connection terminates, we log its exit reason, but more connections will
   # be started by the connection pool supervisor, so we don't need to do anything else.
-  def handle_info({:pool_conn_down, _ref, :process, _pid, {:shutdown, exit_reason}}, state) do
-    error = DbConnectionError.from_error(exit_reason)
+  def handle_info({:pool_conn_down, _ref, :process, _pid, reason}, state) do
+    error =
+      case reason do
+        {:shutdown, exit_reason} -> exit_reason
+        exit_reason -> exit_reason
+      end
+      |> DbConnectionError.from_error()
 
     # If the error is of an unknown type, it would have already been logged by DbConnectionError itself.
     if error.type != :unknown do


### PR DESCRIPTION
We are occasionally getting crashes because there is no function clause matching for `:pool_conn_down` messages with reason `:shutdown`, as we only cover `{:shutdown, reason}` (see [this Sentry issue](https://electricsql-04.sentry.io/issues/48398126/?environment=production&project=4508410462404688&query=is%3Aunresolved&referrer=issue-stream&stream_index=20))

I've generalized the handler for `:pool_conn_down` to handle all exit reasons, since they are mostly no-ops anyway.