### PR TITLE
fix: Recognize and parse more connection errors

### DIFF
--- a/.changeset/unlucky-taxis-breathe.md
+++ b/.changeset/unlucky-taxis-breathe.md
@@ -2,4 +2,4 @@
 "@core/sync-service": patch
 ---
 
-Add more connection errors to recognized list (timeouts, pool timeouts, data tranfser quota issues)
+Add more connection errors to recognized list (timeouts, pool timeouts, data tranfser quota issues, insufficient resources, unknown endpoint)

--- a/.changeset/unlucky-taxis-breathe.md
+++ b/.changeset/unlucky-taxis-breathe.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add more connection errors to recognized list (timeouts, pool timeouts, data tranfser quota issues)

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -167,6 +167,19 @@ defmodule Electric.DbConnectionError do
     }
   end
 
+  def from_error(
+        %Postgrex.Error{
+          postgres: %{code: :too_many_connections, severity: "FATAL", pg_code: "53300"}
+        } = error
+      ) do
+    %DbConnectionError{
+      message: error.postgres.message,
+      type: :insufficient_resources,
+      original_error: error,
+      retry_may_fix?: true
+    }
+  end
+
   def from_error(%Postgrex.Error{message: "ssl not available"} = error) do
     %DbConnectionError{
       message: "Database server not configured to accept SSL connections",

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -54,7 +54,11 @@ defmodule Electric.DbConnectionError do
   end
 
   def from_error(%DBConnection.ConnectionError{} = error) do
-    maybe_nxdomain_error(error) || maybe_connection_refused_error(error) || unknown_error(error)
+    maybe_nxdomain_error(error) ||
+      maybe_connection_refused_error(error) ||
+      maybe_connection_timeout_error(error) ||
+      maybe_pool_queue_timeout_error(error) ||
+      unknown_error(error)
   end
 
   def from_error(
@@ -173,7 +177,9 @@ defmodule Electric.DbConnectionError do
   end
 
   def from_error(%Postgrex.Error{postgres: %{code: :internal_error, pg_code: "XX000"}} = error) do
-    maybe_database_does_not_exist(error) || maybe_compute_quota_exceeded(error) ||
+    maybe_database_does_not_exist(error) ||
+      maybe_compute_quota_exceeded(error) ||
+      maybe_data_transfer_quota_exceeded(error) ||
       unknown_error(error)
   end
 
@@ -249,6 +255,21 @@ defmodule Electric.DbConnectionError do
     end
   end
 
+  defp maybe_data_transfer_quota_exceeded(error) do
+    case error.postgres.message do
+      "Your project has exceeded the data transfer quota." <> _ ->
+        %DbConnectionError{
+          message: error.postgres.message,
+          type: :data_transfer_quota_exceeded,
+          original_error: error,
+          retry_may_fix?: false
+        }
+
+      _ ->
+        nil
+    end
+  end
+
   defp maybe_nxdomain_error(error) do
     ~r/\((?<domain>[^:]+).*\): non-existing domain - :nxdomain/
     |> Regex.named_captures(error.message)
@@ -280,6 +301,38 @@ defmodule Electric.DbConnectionError do
 
       _ ->
         nil
+    end
+  end
+
+  defp maybe_connection_timeout_error(error) do
+    ~r/tcp connect \((?<destination>.*)\): (?:timeout|connection timed out - :etimedout)/
+    |> Regex.named_captures(error.message)
+    |> case do
+      %{"destination" => destination} ->
+        %DbConnectionError{
+          message: "connection timed out while trying to connect to #{destination}",
+          type: :connection_timeout,
+          original_error: error,
+          retry_may_fix?: true
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  defp maybe_pool_queue_timeout_error(error) do
+    ~r/^client #PID<\d+.\d+.\d+> timed out because it queued and checked out the connection for longer than \d+ms/
+    |> Regex.match?(error.message)
+    |> if do
+      %DbConnectionError{
+        message: "timed out trying to acquire connection from pool",
+        type: :connection_timeout,
+        original_error: error,
+        retry_may_fix?: true
+      }
+    else
+      nil
     end
   end
 end

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -29,6 +29,50 @@ defmodule Electric.DbConnectionErrorTest do
              } == DbConnectionError.from_error(error)
     end
 
+    test "with database does not exist error" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :internal_error,
+          message: ~s|database "foo" does not exist|,
+          severity: "ERROR",
+          pg_code: "XX000"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message: ~s|database "foo" does not exist|,
+               type: :database_does_not_exist,
+               original_error: error,
+               retry_may_fix?: false
+             } == DbConnectionError.from_error(error)
+    end
+
+    test "with endpoint could not be found error" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :internal_error,
+          message:
+            ~s|The requested endpoint could not be found, or you don't have access to it. Please check the provided ID and try again.|,
+          severity: "ERROR",
+          pg_code: "XX000"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message:
+                 ~s|The requested endpoint could not be found, or you don't have access to it. Please check the provided ID and try again.|,
+               type: :endpoint_not_found,
+               original_error: error,
+               retry_may_fix?: false
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with insufficient privileges error" do
       error = %Postgrex.Error{
         message: nil,

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -91,6 +91,42 @@ defmodule Electric.DbConnectionErrorTest do
       end
     end
 
+    test "with a tcp timeout with destination error" do
+      for message <- [
+            "tcp connect (localhost:54321): connection timed out - :etimedout",
+            "tcp connect (localhost:54321): timeout"
+          ] do
+        error = %DBConnection.ConnectionError{
+          message: message,
+          severity: :error,
+          reason: :error
+        }
+
+        assert %DbConnectionError{
+                 message: "connection timed out while trying to connect to localhost:54321",
+                 type: :connection_timeout,
+                 original_error: error,
+                 retry_may_fix?: true
+               } == DbConnectionError.from_error(error)
+      end
+    end
+
+    test "with a pool queue timeout error" do
+      error = %DBConnection.ConnectionError{
+        message:
+          "client #PID<0.4201.0> timed out because it queued and checked out the connection for longer than 3000ms\n\n whatever stack trace",
+        severity: :error,
+        reason: :error
+      }
+
+      assert %DbConnectionError{
+               message: "timed out trying to acquire connection from pool",
+               type: :connection_timeout,
+               original_error: error,
+               retry_may_fix?: true
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with tcp closed error" do
       for message <- [
             "tcp recv (idle): closed",
@@ -148,6 +184,29 @@ defmodule Electric.DbConnectionErrorTest do
                message:
                  "Your account or project has exceeded the compute time quota. Upgrade your plan to increase limits.",
                type: :compute_quota_exceeded,
+               original_error: error,
+               retry_may_fix?: false
+             } == DbConnectionError.from_error(error)
+    end
+
+    test "with data transfer quota exceeded error" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :internal_error,
+          message:
+            "Your project has exceeded the data transfer quota. Upgrade your plan to increase limits.",
+          severity: "ERROR",
+          pg_code: "XX000"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message:
+                 "Your project has exceeded the data transfer quota. Upgrade your plan to increase limits.",
+               type: :data_transfer_quota_exceeded,
                original_error: error,
                retry_may_fix?: false
              } == DbConnectionError.from_error(error)

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -73,6 +73,33 @@ defmodule Electric.DbConnectionErrorTest do
              } == DbConnectionError.from_error(error)
     end
 
+    test "with too many connections error" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :too_many_connections,
+          line: "353",
+          message:
+            "number of requested standby connections exceeds max_wal_senders (currently 5)",
+          file: "proc.c",
+          unknown: "FATAL",
+          severity: "FATAL",
+          pg_code: "53300",
+          routine: "InitProcess"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message:
+                 ~s|number of requested standby connections exceeds max_wal_senders (currently 5)|,
+               type: :insufficient_resources,
+               original_error: error,
+               retry_may_fix?: true
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with insufficient privileges error" do
       error = %Postgrex.Error{
         message: nil,


### PR DESCRIPTION
Went through sentry and covered some more common errors that we should be able to recognize:


- Connection timeouts (tcp connect) [sentry1](https://electricsql-04.sentry.io/issues/46552901/?environment=production&project=4508410462404688&query=is%3Aunresolved%20Electric.DBConnection%20unknown%20error&referrer=issue-stream&stream_index=6) [sentry2](https://electricsql-04.sentry.io/issues/51034946/?alert_rule_id=105022&alert_timestamp=1751930919832&alert_type=email&notification_uuid=244b98d5-9159-490a-90dc-7020448febfa&project=4508410462404688&referrer=digest_email) - we already recognize some, but when they happen during `Postgrex.Protocol.connect` they come in a different format
- Pool timeouts [sentry](https://electricsql-04.sentry.io/issues/47793877/?environment=production&project=4508410462404688&query=is%3Aunresolved&referrer=issue-stream&stream_index=8) - these are the most common, its when we are waiting to grab a connection from the pool and time out. No reason we should be logging these errors and not retry on them.
- Data transfer quota exceeded [sentry](https://electricsql-04.sentry.io/issues/44358021/?environment=production&project=4508410462404688&query=is%3Aunresolved%20Electric.DBConnection%20unknown%20error&referrer=issue-stream&stream_index=3) - we already had the compute quota error, might as well add the data transfer one that seems to happen often
- Too many connections (walsenders) [sentry](https://electricsql-04.sentry.io/issues/45900698/events/c5a369bf21c3441d9891b7f468753351/) - under the category of insufficient resources, retryable, although technically I think this occurs because it runs out of walsenders so it's either temporary as another electric is shutting down and releasing them or needs manual fixing - but I think in principle it should be retryable (?)
- Unknown endpoint/could not be found [sentry](https://electricsql-04.sentry.io/issues/40620803/?environment=production&project=4508410462404688&query=is%3Aunresolved%20Electric.DBConnection%20unknown%20error&referrer=issue-stream&stream_index=9) - neon issue, basically like database does not exist