### PR TITLE
feat(sync-service): Allow configuration of TCP send timeout

### DIFF
--- a/.changeset/chilled-oranges-type.md
+++ b/.changeset/chilled-oranges-type.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add ELECTRIC_TCP_SEND_TIMEOUT to allow configuration of TCP/SSL send timeout

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -217,7 +217,9 @@ config :electric,
       nil
     ),
   process_registry_partitions: env!("ELECTRIC_TWEAKS_PROCESS_REGISTRY_PARTITIONS", :integer, nil),
-  http_api_num_acceptors: env!("ELECTRIC_TWEAKS_HTTP_API_NUM_ACCEPTORS", :integer, 100)
+  http_api_num_acceptors: env!("ELECTRIC_TWEAKS_HTTP_API_NUM_ACCEPTORS", :integer, 100),
+  tcp_send_timeout:
+    env!("ELECTRIC_TCP_SEND_TIMEOUT", &Electric.Config.parse_human_readable_time!/1, nil)
 
 if Electric.telemetry_enabled?() do
   config :sentry,

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -282,12 +282,22 @@ defmodule Electric.Application do
   defp thousand_island_options(opts) do
     acceptor_opts = Keyword.take(opts, [:num_acceptors])
 
-    transport_opts =
-      if get_env(opts, :listen_on_ipv6?) do
-        [transport_options: [:inet6]]
+    send_opts =
+      case get_env(opts, :tcp_send_timeout) do
+        nil -> []
+        send_timeout -> [send_timeout: send_timeout]
       end
 
-    concat_opts([acceptor_opts, transport_opts])
+    ipv6_opts =
+      if get_env(opts, :listen_on_ipv6?) do
+        [:inet6]
+      else
+        []
+      end
+
+    transport_opts = [transport_options: ipv6_opts ++ send_opts]
+
+    acceptor_opts ++ transport_opts
   end
 
   defp cowboy_options(opts) do
@@ -316,11 +326,5 @@ defmodule Electric.Application do
       long_message_queue_disable_threshold:
         get_env(opts, :telemetry_long_message_queue_disable_threshold)
     ]
-  end
-
-  defp concat_opts(list_of_kw_lists) do
-    list_of_kw_lists
-    |> Enum.map(&List.wrap/1)
-    |> Enum.concat()
   end
 end

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -48,6 +48,7 @@ defmodule Electric.Config do
     enable_http_api: true,
     long_poll_timeout: 20_000,
     http_api_num_acceptors: nil,
+    tcp_send_timeout: :timer.seconds(30),
     cache_max_age: 60,
     cache_stale_age: 60 * 5,
     chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),

--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -178,6 +178,23 @@ By default, Electric binds to IPv4. Enable this to listen on IPv6 addresses as w
 
 </EnvVarConfig>
 
+### ELECTRIC_TCP_SEND_TIMEOUT
+
+<EnvVarConfig
+    name="ELECTRIC_TCP_SEND_TIMEOUT"
+    defaultValue="30s"
+    example="60s">
+Timeout for sending a response chunk back to the client. Defaults to 30 seconds.
+
+Slow response processing on the client or bandwidth restristrictions can cause TCP backpressure leading to the error message:
+```
+Error while streaming response: :timeout
+```
+This environment variable increases this timeout.
+
+
+</EnvVarConfig>
+
 ### ELECTRIC_SHAPE_CHUNK_BYTES_THRESHOLD
 
 <EnvVarConfig


### PR DESCRIPTION
AntonOfTheWoods experiences the following error message:
```
Error while streaming response: :timeout
```

This is most probably due to slow response processing on the client side causing TCP backpressure. AntonOfTheWoods has asked for configuration to increase the timeout, so this PR introduces `ELECTRIC_TCP_SEND_TIMEOUT` to allow configuration of the TCP/SSL send timeout.

The default is `30s` as it is right now, but for example the timeout can be set to 60 seconds with:
```
ELECTRIC_TCP_SEND_TIMEOUT=60s
```