### PR TITLE
fix: Parse `NULL`s correctly in TS client

### DIFF
--- a/.changeset/hot-poems-fry.md
+++ b/.changeset/hot-poems-fry.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Fix parsing of text `"NULL"` values as text rather than `NULL`

--- a/packages/typescript-client/test/parser.test.ts
+++ b/packages/typescript-client/test/parser.test.ts
@@ -216,6 +216,23 @@ describe(`Message parser`, () => {
     }
   })
 
+  it(`should parse text values like "NULL" correctly`, () => {
+    expect(
+      parser.parse(`[ { "value": { "a": "NULL" } } ]`, {
+        a: { type: `text`, not_null: true },
+      })
+    ).toEqual([{ value: { a: `NULL` } }])
+
+    expect(
+      parser.parse(
+        `[ { "value": { "a": "{\\"a\\",\\"NULL\\",NULL,\\"b\\"}" } } ]`,
+        {
+          a: { type: `text`, dims: 1 },
+        }
+      )
+    ).toEqual([{ value: { a: [`a`, `NULL`, null, `b`] } }])
+  })
+
   it(`should parse arrays including null values`, () => {
     const schema = {
       a: { type: `int2`, dims: 1 },


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/2877

We used to parse tokens of the form `NULL` to `null` in TS as we needed to pars the nulls within arrays (that are received as string tokens). However this ended up causing any text value `NULL` to be parsed as a `null` too.

In order to fix this we directly convert the `NULL` string tokens to `null` inside `pgArrayParser`, which can handle quoted `"NULL"` within arrays correctly so that it can pass it on to subsequent parsing stages as a string.