### PR TITLE
fix: Ignore noproc pool connections dying

### DIFF
--- a/.changeset/silly-ghosts-attack.md
+++ b/.changeset/silly-ghosts-attack.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ignore pool connection `:DOWN` messages with reason `:noproc`

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -720,7 +720,8 @@ defmodule Electric.Connection.Manager do
 
   # When a pooled connection terminates, we log its exit reason, but more connections will
   # be started by the connection pool supervisor, so we don't need to do anything else.
-  def handle_info({:pool_conn_down, _ref, :process, _pid, :shutdown}, state) do
+  def handle_info({:pool_conn_down, _ref, :process, _pid, reason}, state)
+      when reason in [:shutdown, :noproc] do
     {:noreply, state}
   end
 


### PR DESCRIPTION
Fixes [this sentry issue](https://electricsql-04.sentry.io/issues/48398126/events/e0ac0dc9f6fd4cce95644e05ee16f5cb/)

