### PR TITLE
fix: Require pg version for publication manager

### DIFF
--- a/.changeset/tough-cows-kick.md
+++ b/.changeset/tough-cows-kick.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ensure publication manager is given pg_version to remove redundant queries

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -463,6 +463,7 @@ defmodule Electric.Connection.Manager do
              pool_opts: state.pool_opts,
              replication_opts: state.replication_opts,
              tweaks: state.tweaks,
+             pg_version: state.pg_version,
              persistent_kv: state.persistent_kv
            ) do
         {:ok, shapes_sup_pid} ->

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -83,6 +83,7 @@ defmodule Electric.Connection.Supervisor do
       {Electric.Replication.PublicationManager,
        stack_id: stack_id,
        publication_name: Keyword.fetch!(replication_opts, :publication_name),
+       pg_version: Keyword.fetch!(opts, :pg_version),
        db_pool: Keyword.fetch!(db_pool_opts, :name),
        update_debounce_timeout: Keyword.get(tweaks, :publication_alter_debounce_ms, 0)}
 

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -111,25 +111,6 @@ defmodule Electric.Postgres.Configuration do
     end
   end
 
-  @doc """
-  Get Postgres server version
-  """
-  @spec get_pg_version(Postgrex.conn()) :: {:ok, non_neg_integer()} | {:error, term()}
-  def get_pg_version(conn) do
-    case Postgrex.query(
-           conn,
-           "SELECT current_setting('server_version_num') server_version_num",
-           []
-         ) do
-      {:ok, result} when result.num_rows == 1 ->
-        [[version_str]] = result.rows
-        {:ok, String.to_integer(version_str)}
-
-      {:error, err} ->
-        {:error, err}
-    end
-  end
-
   defp alter_pub_set_whole_tables!(conn, publication_name, relation_filters) do
     publication = Utils.quote_name(publication_name)
 

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -113,7 +113,7 @@ defmodule Support.ComponentSetup do
             publication_name: ctx.publication_name,
             update_debounce_timeout: Access.get(ctx, :update_debounce_timeout, 0),
             db_pool: ctx.pool,
-            pg_version: Access.get(ctx, :pg_version, nil),
+            pg_version: Access.get(ctx, :pg_version, 150_001),
             configure_tables_for_replication_fn:
               Access.get(
                 ctx,

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -94,6 +94,8 @@ defmodule Support.DbSetup do
     %{rows: [[pg_version]]} =
       Postgrex.query!(ctx.db_conn, "SELECT current_setting('server_version_num')::integer", [])
 
+    true = is_integer(pg_version)
+
     {:ok, %{pg_version: pg_version}}
   end
 


### PR DESCRIPTION
No reason we should be seeing [errors like these](https://electricsql-04.sentry.io/issues/14716077/?environment=production&project=4508410462404688&query=is%3Aunresolved&referrer=issue-stream&stream_index=1) when we already have a `pg_version` available from the replication client.

Removing code that's unnecessary, simplifying the publication manager.