### PR TITLE
blog: Fix typo

### DIFF
--- a/website/blog/posts/2024-11-21-local-first-with-your-existing-api.md
+++ b/website/blog/posts/2024-11-21-local-first-with-your-existing-api.md
@@ -431,7 +431,7 @@ Implemented in the [shared API server](https://github.com/electric-sql/electric/
 
 Just as [with reads](#auth), because you're sending writes to an API endpoint, you can use your API, middleware, or a proxy to authorize them. Just as you would any other API request.
 
-Agaim, to emphasise, this allows you to develop local-first apps, without having to codify write-path authorization logic into database rules. In fact, in many cases, you can just keep your existing API endpoints and you may not need to change any code at all.
+Again, to emphasise, this allows you to develop local-first apps, without having to codify write-path authorization logic into database rules. In fact, in many cases, you can just keep your existing API endpoints and you may not need to change any code at all.
 
 ### Encryption
 


### PR DESCRIPTION
I was reading this article and noticed this typo in this blog [post](https://electric-sql.com/blog/2024/11/21/local-first-with-your-existing-api#authorizing-writes)

**Image**
<img width="763" height="224" alt="Screenshot 2025-07-11 at 12 40 39 PM" src="https://github.com/user-attachments/assets/f9fdcea4-377b-47b2-b982-f03a3a2142f1" />
