### PR TITLE
Use descriptive names for CI jobs

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-    name: Build and test on PR comment
+    name: Build image and run benchmarks on PR comment
     if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'CONTRIBUTOR') && (startsWith(github.event.comment.body, 'benchmark this') || startsWith(github.event.comment.body, 'Benchmark this'))}}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/benchmarking_dockerhub_tags.yml
+++ b/.github/workflows/benchmarking_dockerhub_tags.yml
@@ -1,4 +1,4 @@
-name: Benchmark a PR
+name: Benchmark Electric image from DockerHub
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    name: Build and test on PR comment
+    name: Run predefined benchmarks for DockerHub image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/deploy_all_examples.yml
+++ b/.github/workflows/deploy_all_examples.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy ${{ matrix.example.name }}
+    name: Deploy ${{ matrix.example.name }} example
     environment: "Production"
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/elixir_client_tests.yml
+++ b/.github/workflows/elixir_client_tests.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    name: Build and test
+    name: Build and test elixir-client
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -93,7 +93,7 @@ jobs:
           files: ./junit/test-junit-report.xml
 
   formatting:
-    name: Check formatting
+    name: Check formatting for elixir-client
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -1,4 +1,4 @@
-name: Elixir CI
+name: Electric CI
 
 on:
   push:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build_and_test:
-    name: "Build and test, Postgres ${{ matrix.postgres_version }}"
+    name: "Build and test sync-service, Postgres ${{ matrix.postgres_version }}"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -122,7 +122,7 @@ jobs:
           files: ./junit/regular-test-junit-report.xml,./junit/telemetry-test-junit-report.xml
 
   formatting:
-    name: Check formatting
+    name: Check formatting for sync-service
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Lux Integration Tests
 
 on:
   push:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    name: Build and test
+    name: Run Lux integration tests
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   list_ts_packages:
-    name: List packages
+    name: List TS packages
     runs-on: ubuntu-latest
     outputs:
       directories: ${{ steps.list_ts_packages.outputs.directories }}
@@ -35,7 +35,7 @@ jobs:
         id: list_examples
 
   check_packages:
-    name: Check ${{ matrix.package_dir }}
+    name: Check TS package at ${{ matrix.package_dir }}
     needs: [list_ts_packages]
     runs-on: ubuntu-latest
     strategy:
@@ -58,7 +58,7 @@ jobs:
       - run: pnpm run typecheck
 
   build_and_test_packages:
-    name: Build and test
+    name: Test TS packages against sync-service
     needs: [list_ts_packages]
     runs-on: ubuntu-latest
     strategy:
@@ -151,7 +151,7 @@ jobs:
           files: ./junit/test-report.junit.xml
 
   check_and_build_examples:
-    name: Check and build ${{ matrix.example_folder }}
+    name: Check and build ${{ matrix.example_folder }} example
     needs: [list_examples, build_and_test_packages]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
We have been erroneously treating job naming as if namespaced under the workflow name. It doesn't always work, like when viewing the CI runs for an already merged PR. And in general it's not too helpful to have different jobs all called "Build and test".

<img width="1171" height="540" alt="image" src="https://github.com/user-attachments/assets/f9150426-2f17-4c19-8ae1-a4b7ade07053" />
