### PR TITLE
Benchmark replication throughput with publication row filters enabled/disabled

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -10,6 +10,7 @@ defaults:
 env:
   PROJECT_ID: vaxine
   REGISTRY: europe-docker.pkg.dev/vaxine/electric
+  ISSUE_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
   build:
@@ -51,8 +52,8 @@ jobs:
         run: |
           docker pull ${{ env.REGISTRY }}/electric:canary-builder || true
           docker pull ${{ env.REGISTRY }}/electric:canary-runner-base || true
-          docker pull ${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-builder || true
-          docker pull ${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-runner-base || true
+          docker pull ${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-builder || true
+          docker pull ${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-runner-base || true
       - name: Build base images
         env:
           DOCKER_BUILDKIT: "1"
@@ -60,18 +61,18 @@ jobs:
           docker build \
             --push \
             --cache-from ${{ env.REGISTRY }}/electric:canary-builder \
-            --cache-from ${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-builder \
+            --cache-from ${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-builder \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --tag ${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-builder \
+            --tag ${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-builder \
             --target builder \
             .
 
           docker build \
             --push \
             --cache-from ${{ env.REGISTRY }}/electric:canary-runner-base \
-            --cache-from ${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-runner-base \
+            --cache-from ${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-runner-base \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --tag  ${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-runner-base \
+            --tag  ${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-runner-base \
             --target runner_setup \
             .
       - name: Build actual image
@@ -80,9 +81,9 @@ jobs:
         run: >
           docker build \
             --push \
-            --cache-from=${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-builder \
-            --cache-from=${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-runner-base \
-            --tag  ${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }} \
+            --cache-from=${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-builder \
+            --cache-from=${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-runner-base \
+            --tag  ${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-${{ env.SHORT_SHA }} \
             .
       - name: Replication throughput benchmark
         run: |
@@ -93,7 +94,7 @@ jobs:
             -d '{
               "benchmark_run": {
                 "spec_values": {
-                  "electric_image": ["${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}"],
+                  "electric_image": ["${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-${{ env.SHORT_SHA }}"],
                   "postgres_image": ["postgres:17-alpine"],
                   "row_count": [1],
                   "shape_count": [5,2000,4000,8000,16000],
@@ -109,7 +110,7 @@ jobs:
                 },
                 "metadata": {
                   "pr": ${{ github.event.issue.number }},
-                  "short_version": "pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}",
+                  "short_version": "pr-${{ env.ISSUE_NUMBER }}-${{ env.SHORT_SHA }}",
                   "callback": {
                     "method": "POST",
                     "headers": [
@@ -118,7 +119,7 @@ jobs:
                       ["X-GitHub-Api-Version","2022-11-28"]
                     ],
                     "url":"https://api.github.com/repos/electric-sql/electric/actions/workflows/leave_benchmark_comment.yml/dispatches",
-                    "body": "{\"ref\":\"main\",\"inputs\":{\"pr\":\"${{ github.event.issue.number }}\",\"benchmark_info\":#{benchmark_info},\"original_commit\":\"${{ env.SHORT_SHA }}\"}}"
+                    "body": "{\"ref\":\"main\",\"inputs\":{\"pr\":\"${{ env.ISSUE_NUMBER }}\",\"benchmark_info\":#{benchmark_info},\"original_commit\":\"${{ env.SHORT_SHA }}\"}}"
                   }
                 }
               }

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       contents: read
     name: Build image and run benchmarks on PR comment
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'CONTRIBUTOR') && (startsWith(github.event.comment.body, 'benchmark this') || startsWith(github.event.comment.body, 'Benchmark this'))}}
+    #if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'CONTRIBUTOR') && (startsWith(github.event.comment.body, 'benchmark this') || startsWith(github.event.comment.body, 'Benchmark this'))}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -85,7 +85,7 @@ jobs:
             --cache-from=${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-runner-base \
             --tag  ${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }} \
             .
-      - name: Write fanout benchmark
+      - name: Replication throughput benchmark
         run: |
           curl -X POST 'https://benchmarking.electric-sql.com/api/benchmarks/write_fanout/runs' \
             -u benchmarking:${{ secrets.BENCHMARKING_API_PASSWORD }} \
@@ -95,150 +95,14 @@ jobs:
               "benchmark_run": {
                 "spec_values": {
                   "electric_image": ["${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}"],
-                  "postgres_image": ["postgres:16-alpine"],
-                  "row_count": [500],
-                  "concurrent": [5, 105, 205, 305, 405, 505, 605, 705, 805, 905, 1005],
-                  "tx_row_count": [50]
-                },
-                "machine_request": {
-                  "vcpu": 4,
-                  "mem_gb": 8
-                },
-                "metadata": {
-                  "pr": ${{ github.event.issue.number }},
-                  "short_version": "pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}",
-                  "callback": {
-                    "method": "POST",
-                    "headers": [
-                      ["Accept","application/vnd.github+json"],
-                      ["Authorization","Bearer ${{ secrets.CROSSREPO_PAT }}"],
-                      ["X-GitHub-Api-Version","2022-11-28"]
-                    ],
-                    "url":"https://api.github.com/repos/electric-sql/electric/actions/workflows/leave_benchmark_comment.yml/dispatches",
-                    "body": "{\"ref\":\"main\",\"inputs\":{\"pr\":\"${{ github.event.issue.number }}\",\"benchmark_info\":#{benchmark_info},\"original_commit\":\"${{ env.SHORT_SHA }}\"}}"
-                  }
-                }
-              }
-            }'
-      - name: unrelated_shapes_one_client_latency benchmark
-        run: |
-          curl -X POST 'https://benchmarking.electric-sql.com/api/benchmarks/unrelated_shapes_one_client_latency/runs' \
-            -u benchmarking:${{ secrets.BENCHMARKING_API_PASSWORD }} \
-            -H 'Content-Type: application/json' \
-            --fail-with-body \
-            -d '{
-              "benchmark_run": {
-                "spec_values": {
-                  "electric_image": ["${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}"],
-                  "postgres_image": ["postgres:16-alpine"],
-                  "row_count": [500],
-                  "shape_count": [100,300,500,700,900,1100,1300,1500,1700,1900,2100,2300,2500,2700,2900,3100],
-                  "tx_row_count": [50],
-                  "where_clause": ["name = '"'#{name}'"'"]
-                },
-                "machine_request": {
-                  "vcpu": 4,
-                  "mem_gb": 8
-                },
-                "metadata": {
-                  "pr": ${{ github.event.issue.number }},
-                  "short_version": "pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}",
-                  "callback": {
-                    "method": "POST",
-                    "headers": [
-                      ["Accept","application/vnd.github+json"],
-                      ["Authorization","Bearer ${{ secrets.CROSSREPO_PAT }}"],
-                      ["X-GitHub-Api-Version","2022-11-28"]
-                    ],
-                    "url":"https://api.github.com/repos/electric-sql/electric/actions/workflows/leave_benchmark_comment.yml/dispatches",
-                    "body": "{\"ref\":\"main\",\"inputs\":{\"pr\":\"${{ github.event.issue.number }}\",\"benchmark_info\":#{benchmark_info},\"original_commit\":\"${{ env.SHORT_SHA }}\"}}"
-                  }
-                }
-              }
-            }'
-      - name: many_shapes_one_client_latency benchmark
-        run: |
-          curl -X POST 'https://benchmarking.electric-sql.com/api/benchmarks/many_shapes_one_client_latency/runs' \
-            -u benchmarking:${{ secrets.BENCHMARKING_API_PASSWORD }} \
-            -H 'Content-Type: application/json' \
-            --fail-with-body \
-            -d '{
-              "benchmark_run": {
-                "spec_values": {
-                  "electric_image": ["${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}"],
-                  "postgres_image": ["postgres:16-alpine"],
-                  "row_count": [500],
-                  "shape_count": [100,300,500,700,900,1100,1300,1500,1700,1900,2100,2300,2500,2700,2900,3100],
-                  "tx_row_count": [50]
-                },
-                "machine_request": {
-                  "vcpu": 4,
-                  "mem_gb": 8
-                },
-                "metadata": {
-                  "pr": ${{ github.event.issue.number }},
-                  "short_version": "pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}",
-                  "callback": {
-                    "method": "POST",
-                    "headers": [
-                      ["Accept","application/vnd.github+json"],
-                      ["Authorization","Bearer ${{ secrets.CROSSREPO_PAT }}"],
-                      ["X-GitHub-Api-Version","2022-11-28"]
-                    ],
-                    "url":"https://api.github.com/repos/electric-sql/electric/actions/workflows/leave_benchmark_comment.yml/dispatches",
-                    "body": "{\"ref\":\"main\",\"inputs\":{\"pr\":\"${{ github.event.issue.number }}\",\"benchmark_info\":#{benchmark_info},\"original_commit\":\"${{ env.SHORT_SHA }}\"}}"
-                  }
-                }
-              }
-            }'
-      - name: concurrent_shape_creation benchmark
-        run: |
-          curl -X POST 'https://benchmarking.electric-sql.com/api/benchmarks/concurrent_shape_creation/runs' \
-            -u benchmarking:${{ secrets.BENCHMARKING_API_PASSWORD }} \
-            -H 'Content-Type: application/json' \
-            --fail-with-body \
-            -d '{
-              "benchmark_run": {
-                "spec_values": {
-                  "electric_image": ["${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}"],
-                  "postgres_image": ["postgres:16-alpine"],
-                  "row_count": [500],
-                  "concurrent": [50, 450, 850, 1250, 1650, 2050, 2450, 2850, 3250, 3650]
-                },
-                "machine_request": {
-                  "vcpu": 4,
-                  "mem_gb": 8
-                },
-                "metadata": {
-                  "pr": ${{ github.event.issue.number }},
-                  "short_version": "pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}",
-                  "callback": {
-                    "method": "POST",
-                    "headers": [
-                      ["Accept","application/vnd.github+json"],
-                      ["Authorization","Bearer ${{ secrets.CROSSREPO_PAT }}"],
-                      ["X-GitHub-Api-Version","2022-11-28"]
-                    ],
-                    "url":"https://api.github.com/repos/electric-sql/electric/actions/workflows/leave_benchmark_comment.yml/dispatches",
-                    "body": "{\"ref\":\"main\",\"inputs\":{\"pr\":\"${{ github.event.issue.number }}\",\"benchmark_info\":#{benchmark_info},\"original_commit\":\"${{ env.SHORT_SHA }}\"}}"
-                  }
-                }
-              }
-            }'
-      - name: diverse_shape_fanout benchmark
-        run: |
-          curl -X POST 'https://benchmarking.electric-sql.com/api/benchmarks/diverse_shape_fanout/runs' \
-            -u benchmarking:${{ secrets.BENCHMARKING_API_PASSWORD }} \
-            -H 'Content-Type: application/json' \
-            --fail-with-body \
-            -d '{
-              "benchmark_run": {
-                "spec_values": {
-                  "electric_image": ["${{ env.REGISTRY }}/electric:pr-${{ github.event.issue.number }}-${{ env.SHORT_SHA }}"],
-                  "postgres_image": ["postgres:16-alpine"],
-                  "row_count": [500],
-                  "concurrent": [50, 450, 850, 1250, 1650, 2050, 2450, 2850, 3250, 3650],
-                  "tx_row_count": [50]
+                  "postgres_image": ["postgres:17-alpine"],
+                  "row_count": [1],
+                  "shape_count": [5,2000,4000,8000,16000],
+                  "tx_count": [100, 1000],
+                  "tx_row_count": [100],
+                  "tx_affects_shape": [false],
+                  "row_size": [100],
+                  "where_clause": ["name = '"'#{name}'"'", "name ILIKE '"'#{name}%'"'"]
                 },
                 "machine_request": {
                   "vcpu": 4,

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -97,12 +97,12 @@ jobs:
                   "electric_image": ["${{ env.REGISTRY }}/electric:pr-${{ env.ISSUE_NUMBER }}-${{ env.SHORT_SHA }}"],
                   "postgres_image": ["postgres:17-alpine"],
                   "row_count": [1],
-                  "shape_count": [5,2000,4000,8000,16000],
-                  "tx_count": [100, 1000],
-                  "tx_row_count": [100],
+                  "shape_count": [10000,20000,30000,60000],
+                  "tx_count": [100],
+                  "tx_row_count": [200],
                   "tx_affects_shape": [false],
-                  "row_size": [100],
-                  "where_clause": ["name = '"'#{name}'"'", "name > '"'az'"'"]
+                  "row_size": [50],
+                  "where_clause": ["name ILIKE '"'#{name}%'"'", "name = '"'#{name}'"'"]
                 },
                 "machine_request": {
                   "vcpu": 4,

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,8 +1,7 @@
 name: Benchmark a PR
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
 
 defaults:
   run:
@@ -102,7 +101,7 @@ jobs:
                   "tx_row_count": [100],
                   "tx_affects_shape": [false],
                   "row_size": [100],
-                  "where_clause": ["name = '"'#{name}'"'", "name ILIKE '"'#{name}%'"'"]
+                  "where_clause": ["name = '"'#{name}'"'", "name > '"'az'"'"]
                 },
                 "machine_request": {
                   "vcpu": 4,

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -98,8 +98,8 @@ jobs:
                   "postgres_image": ["postgres:17-alpine"],
                   "row_count": [1],
                   "shape_count": [10000,20000,30000,60000],
-                  "tx_count": [100],
-                  "tx_row_count": [200],
+                  "tx_count": [50],
+                  "tx_row_count": [20],
                   "tx_affects_shape": [false],
                   "row_size": [50],
                   "where_clause": ["name ILIKE '"'#{name}%'"'", "name = '"'#{name}'"'"]

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -86,7 +86,7 @@ jobs:
             .
       - name: Replication throughput benchmark
         run: |
-          curl -X POST 'https://benchmarking.electric-sql.com/api/benchmarks/write_fanout/runs' \
+          curl -X POST 'https://benchmarking.electric-sql.com/api/benchmarks/replication_throughput/runs' \
             -u benchmarking:${{ secrets.BENCHMARKING_API_PASSWORD }} \
             -H 'Content-Type: application/json' \
             --fail-with-body \

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -109,7 +109,7 @@ jobs:
                   "mem_gb": 8
                 },
                 "metadata": {
-                  "pr": ${{ github.event.issue.number }},
+                  "pr": ${{ env.ISSUE_NUMBER }},
                   "short_version": "pr-${{ env.ISSUE_NUMBER }}-${{ env.SHORT_SHA }}",
                   "callback": {
                     "method": "POST",

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -3,8 +3,8 @@ name: Deploy Examples
 on:
   push:
     branches: ["main"]
-  pull_request:
-    paths: ["examples/*/**"]
+#  pull_request:
+#    paths: ["examples/*/**"]
 
 concurrency:
   group: ${{ github.event_name == 'push' && 'prod-deploy-group' || format('examples-pr-{0}', github.event.number) }}

--- a/.github/workflows/docker_image_smoketest.yml
+++ b/.github/workflows/docker_image_smoketest.yml
@@ -6,10 +6,10 @@ on:
     paths-ignore:
       - "website/**"
       - "**/README.md"
-  pull_request:
-    paths-ignore:
-      - "website/**"
-      - "**/README.md"
+#  pull_request:
+#    paths-ignore:
+#      - "website/**"
+#      - "**/README.md"
 
 jobs:
   docker_image_smoketest:

--- a/.github/workflows/elixir_client_tests.yml
+++ b/.github/workflows/elixir_client_tests.yml
@@ -3,7 +3,7 @@ name: Elixir Client CI
 on:
   push:
     branches: ["main"]
-  pull_request:
+  #pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -6,10 +6,10 @@ on:
     paths-ignore:
       - "website/**"
       - "**/README.md"
-  pull_request:
-    paths-ignore:
-      - "website/**"
-      - "**/README.md"
+#  pull_request:
+#    paths-ignore:
+#      - "website/**"
+#      - "**/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -6,10 +6,10 @@ on:
     paths-ignore:
       - "website/**"
       - "**/README.md"
-  pull_request:
-    paths-ignore:
-      - "website/**"
-      - "**/README.md"
+#  pull_request:
+#    paths-ignore:
+#      - "website/**"
+#      - "**/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -6,10 +6,10 @@ on:
     paths-ignore:
       - "website/**"
       - "**/README.md"
-  pull_request:
-    paths-ignore:
-      - "website/**"
-      - "**/README.md"
+#  pull_request:
+#    paths-ignore:
+#      - "website/**"
+#      - "**/README.md"
 
 permissions:
   contents: read

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -175,6 +175,7 @@ defmodule Electric.Replication.PublicationManager do
       relation_filter_counters: %{},
       prepared_relation_filters: %{},
       committed_relation_filters: %{},
+      # take 2
       row_filtering_enabled: false,
       scheduled_updated_ref: nil,
       retries: 0,

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -175,7 +175,7 @@ defmodule Electric.Replication.PublicationManager do
       relation_filter_counters: %{},
       prepared_relation_filters: %{},
       committed_relation_filters: %{},
-      row_filtering_enabled: true,
+      row_filtering_enabled: false,
       scheduled_updated_ref: nil,
       retries: 0,
       waiters: [],

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -175,7 +175,7 @@ defmodule Electric.Replication.PublicationManager do
       relation_filter_counters: %{},
       prepared_relation_filters: %{},
       committed_relation_filters: %{},
-      row_filtering_enabled: opts.pg_version >= @pg_15,
+      row_filtering_enabled: true,
       scheduled_updated_ref: nil,
       retries: 0,
       waiters: [],

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -175,7 +175,7 @@ defmodule Electric.Replication.PublicationManager do
       relation_filter_counters: %{},
       prepared_relation_filters: %{},
       committed_relation_filters: %{},
-      row_filtering_enabled: opts.pg_version >= @pg_15,
+      row_filtering_enabled: false,
       scheduled_updated_ref: nil,
       retries: 0,
       waiters: [],

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -176,7 +176,7 @@ defmodule Electric.Replication.PublicationManager do
       prepared_relation_filters: %{},
       committed_relation_filters: %{},
       # take 2
-      row_filtering_enabled: false,
+      row_filtering_enabled: true,
       scheduled_updated_ref: nil,
       retries: 0,
       waiters: [],

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -175,7 +175,7 @@ defmodule Electric.Replication.PublicationManager do
       relation_filter_counters: %{},
       prepared_relation_filters: %{},
       committed_relation_filters: %{},
-      row_filtering_enabled: false,
+      row_filtering_enabled: opts.pg_version >= @pg_15,
       scheduled_updated_ref: nil,
       retries: 0,
       waiters: [],


### PR DESCRIPTION
## Benchmarking results

All benchmark runs were using the `postgres:17-alpine` Docker image for the database.

### Comparison 1: Static or indexed where clauses

| Parameter | Value |
------------|--------------
| row_size | 100 |
| tx_count | 100, 1000 |
| tx_row_count | 100 |
| shape_count | 5, 2000, 4000, 8000, 16000 |
| where_clause | `name = '#{name}'`, `name > 'az'` |

**Green** - row filters enabled, **Purple** - row filters disabled

![470-471-row-filter-comparison](https://github.com/user-attachments/assets/c2eef4ee-0f61-4ada-b985-8b47185ffffe)

### Comparison 2: Large number of shapes, unindexed where clause

| Parameter | Value |
------------|--------------
| row_size | 50 |
| tx_count | 100 |
| tx_row_count | 200 |
| shape_count | 10000, 20000, 30000, 60000 |
| where_clause | `name = '#{name}'`, `name ILIKE '#{name}%'` |

**Green** - row filters enabled, **Purple** - row filters disabled

![472-490-more-shapes](https://github.com/user-attachments/assets/d961837e-a165-428b-892c-abcd74a74d03)

---

**N.B.** The last curve seems to be affected by the maximum runtime cap of a client request. Here's an updated chart for the large number of shapes with the runtime cap fixed.

This one has fewer data points because the last two benchmark runs failed to process the shape request with the `name ILIKE '#{name}%'` where clause with row filtering disabled. This is concerning...

![511-504-more-shapes-no-cap](https://github.com/user-attachments/assets/0488d158-1b55-4ddd-9660-6231414e2f0a)

### Comparison 3: Large number of shapes, revisited

Here's the final comparison between enabled and disabled row filters. I had to lower the number of txs and the number of rows per tx for each test run to obtain data points that were missing from the last chart above.

| Parameter | Value |
------------|--------------
| row_size | 50 |
| tx_count | 50 |
| tx_row_count | 20 |
| shape_count | 10000, 20000, 30000, 60000 |
| where_clause | `name = '#{name}'`, `name ILIKE '#{name}%'` |

**Green** - row filters enabled, **Purple** - row filters disabled

![512-513-more-shapes-all-data-points](https://github.com/user-attachments/assets/c9d94be8-16c2-49df-be58-962d7c815491)
