### PR TITLE
fix: Use `codecov/pr-test-aggregation` virtual branch for CodeCov

### DIFF
--- a/.github/workflows/elixir_client_tests.yml
+++ b/.github/workflows/elixir_client_tests.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Upload test results to CodeCov
         uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
         if: ${{ !cancelled() }}
+        env:
+          DUMMY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}-dummy
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -93,7 +95,7 @@ jobs:
           files: ./junit/test-junit-report.xml
           # Upload all PR test results to single branch - requires overriding branch and commit
           override_branch: ${{ github.event_name == 'pull_request' && 'codecov/pr-test-aggregation' || '' }}
-          override_commit: ${{ github.event_name == 'pull_request' && 'dummy' || '' }}
+          override_commit: ${{ github.event_name == 'pull_request' && env.DUMMY_COMMIT_SHA || '' }}
 
   formatting:
     name: Check formatting for elixir-client

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -115,6 +115,8 @@ jobs:
       - name: Upload test results to CodeCov
         uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
         if: ${{ !cancelled() }}
+        env:
+          DUMMY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}-dummy
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -122,7 +124,7 @@ jobs:
           files: ./junit/regular-test-junit-report.xml,./junit/telemetry-test-junit-report.xml
           # Upload all PR test results to single branch - requires overriding branch and commit
           override_branch: ${{ github.event_name == 'pull_request' && 'codecov/pr-test-aggregation' || '' }}
-          override_commit: ${{ github.event_name == 'pull_request' && 'dummy' || '' }}
+          override_commit: ${{ github.event_name == 'pull_request' && env.DUMMY_COMMIT_SHA || '' }}
 
   formatting:
     name: Check formatting for sync-service

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -144,6 +144,8 @@ jobs:
       - name: Upload test results to CodeCov
         uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
         if: ${{ !cancelled() }}
+        env:
+          DUMMY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}-dummy
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -151,7 +153,7 @@ jobs:
           files: ./junit/test-report.junit.xml
           # Upload all PR test results to single branch - requires overriding branch and commit
           override_branch: ${{ github.event_name == 'pull_request' && 'codecov/pr-test-aggregation' || '' }}
-          override_commit: ${{ github.event_name == 'pull_request' && 'dummy' || '' }}
+          override_commit: ${{ github.event_name == 'pull_request' && env.DUMMY_COMMIT_SHA || '' }}
 
   check_and_build_examples:
     name: Check and build ${{ matrix.example_folder }} example


### PR DESCRIPTION
It makes sense to keep data for `main` separate and not pollute it with test failures from incomplete and experimental PRs, but it would be beneficial to aggregate all PR test results together so that failures due to changes made in individual PRs average out to be insignificant compared to actual flakes (if they are present).

Subsequently, if we see some flakes on main, we can look at the same tests on the PR aggregation virtual branch to get a better idea how flakey they actually are.

I've opted to fallback to an empty string for `override_branch` in the hope that it basically just uses the default behaviour (rather than explicitly specifying `main`) as I think it's cleaner. Here is the relevant source for the action:
https://github.com/codecov/test-results-action/blob/47f89e9acb64b76debcd5ea40642d25a4adced9f/src/buildExec.ts#L141-L143

If it doesn't work and it doesn't upload stuff on main I'll just fix forward.


Update: I've made PRs upload to a branch `codecov/pr-test-aggregation`, which required setting both `override_branch` and `override_commit` to work (the latter I've set to a dummy value). In the process of trying to make it work I also created the remote branch in case it was ensuring it existed - not sure if it's necessary as I think the commit override was the key to making it work, but should be fine either way.

<img width="1048" height="610" alt="image" src="https://github.com/user-attachments/assets/a97caeb8-e783-4a07-80c2-5f54b16798ae" />

You can view the aggregated results under the `codecov/pr-test-aggregation` branch context.