### PR TITLE
Stop utilizing publication row filtering

### DIFF
--- a/.changeset/late-berries-do.md
+++ b/.changeset/late-berries-do.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Disable the use of row filters in the Postgres publication.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -34,7 +34,6 @@ config :logger,
   handle_sasl_reports: sasl?
 
 if config_env() == :test do
-  config :electric, pg_version_for_tests: env!("POSTGRES_VERSION", :integer, 150_001)
   config :logger, :default_handler, level: test_log_level
 end
 

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -458,7 +458,6 @@ defmodule Electric.Connection.Manager do
              pool_opts: state.pool_opts,
              replication_opts: state.replication_opts,
              tweaks: state.tweaks,
-             pg_version: state.pg_version,
              can_alter_publication?: state.can_alter_publication?,
              manual_table_publishing?: state.manual_table_publishing?,
              persistent_kv: state.persistent_kv

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -89,7 +89,6 @@ defmodule Electric.Connection.Supervisor do
       {Electric.Replication.PublicationManager,
        stack_id: stack_id,
        publication_name: Keyword.fetch!(replication_opts, :publication_name),
-       pg_version: Keyword.fetch!(opts, :pg_version),
        can_alter_publication?: Keyword.fetch!(opts, :can_alter_publication?),
        manual_table_publishing?: Keyword.fetch!(opts, :manual_table_publishing?),
        db_pool: Keyword.fetch!(db_pool_opts, :name),

--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -7,11 +7,8 @@ defmodule Electric.Postgres.ConfigurationTest do
   alias Electric.Replication.Eval
   alias Electric.Postgres.Configuration
 
-  @pg_15 150_000
-
   setup :with_unique_db
   setup :with_publication
-  setup :with_pg_version
 
   setup %{db_conn: conn} do
     Postgrex.query!(
@@ -51,11 +48,11 @@ defmodule Electric.Postgres.ConfigurationTest do
     :ok
   end
 
-  describe "configure_publication!/3" do
+  describe "configure_publication!/4" do
     test "sets REPLICA IDENTITY on the table and adds it to the publication",
-         %{pool: conn, publication_name: publication, pg_version: pg_version} do
+         %{pool: conn, publication_name: publication} do
       assert get_table_identity(conn, {"public", "items"}) == "d"
-      assert list_tables_in_publication(conn, publication, pg_version) == []
+      assert list_tables_in_publication(conn, publication) == []
       oid = get_table_oid(conn, {"public", "items"})
 
       assert [] ==
@@ -68,25 +65,19 @@ defmodule Electric.Postgres.ConfigurationTest do
                      where_clauses: [%Eval.Expr{query: "(value ILIKE 'yes%')"}]
                    }
                  },
-                 pg_version,
                  publication
                )
 
       assert get_table_identity(conn, {"public", "items"}) == "f"
 
-      assert list_tables_in_publication(conn, publication, pg_version) ==
-               expected_filters(
-                 [
-                   {"public", "items", "(value ~~* 'yes%'::text)"}
-                 ],
-                 pg_version
-               )
+      assert list_tables_in_publication(conn, publication) ==
+               expected_filters([{"public", "items"}])
     end
 
     test "doesn't execute `ALTER TABLE` if table identity is already full",
-         %{pool: conn, publication_name: publication, pg_version: pg_version} do
+         %{pool: conn, publication_name: publication} do
       assert get_table_identity(conn, {"public", "items"}) == "d"
-      assert list_tables_in_publication(conn, publication, pg_version) == []
+      assert list_tables_in_publication(conn, publication) == []
       oid = get_table_oid(conn, {"public", "items"})
 
       assert capture_log(fn ->
@@ -99,7 +90,6 @@ defmodule Electric.Postgres.ConfigurationTest do
                      where_clauses: [%Eval.Expr{query: "(value ILIKE 'yes%')"}]
                    }
                  },
-                 pg_version,
                  publication
                )
              end) =~ ~r"#{:erlang.pid_to_list(self())}.*Altering identity"
@@ -116,7 +106,6 @@ defmodule Electric.Postgres.ConfigurationTest do
                      where_clauses: [%Eval.Expr{query: "(value ILIKE 'no%')"}]
                    }
                  },
-                 pg_version,
                  publication
                )
              end) =~ ~r"#{:erlang.pid_to_list(self())}.*Altering identity"
@@ -125,14 +114,10 @@ defmodule Electric.Postgres.ConfigurationTest do
       # otherwise this test can sporadically fail when run concurrently with other tests that log that message
     end
 
-    test "works with multiple tables", %{
-      pool: conn,
-      publication_name: publication,
-      pg_version: pg_version
-    } do
+    test "works with multiple tables", %{pool: conn, publication_name: publication} do
       assert get_table_identity(conn, {"public", "items"}) == "d"
       assert get_table_identity(conn, {"public", "other_table"}) == "d"
-      assert list_tables_in_publication(conn, publication, pg_version) == []
+      assert list_tables_in_publication(conn, publication) == []
       oid1 = get_table_oid(conn, {"public", "items"})
       oid2 = get_table_oid(conn, {"public", "other_table"})
 
@@ -149,31 +134,23 @@ defmodule Electric.Postgres.ConfigurationTest do
             where_clauses: [%Eval.Expr{query: "(value ILIKE 'no%')"}]
           }
         },
-        pg_version,
         publication
       )
 
       assert get_table_identity(conn, {"public", "items"}) == "f"
       assert get_table_identity(conn, {"public", "other_table"}) == "f"
 
-      assert list_tables_in_publication(conn, publication, pg_version) ==
-               expected_filters(
-                 [
-                   {"public", "items", "(value ~~* 'yes%'::text)"},
-                   {"public", "other_table", "(value ~~* 'no%'::text)"}
-                 ],
-                 pg_version
-               )
+      assert list_tables_in_publication(conn, publication) ==
+               expected_filters([{"public", "items"}, {"public", "other_table"}])
     end
 
     test "can update existing where clauses by updating all tables", %{
       pool: conn,
-      publication_name: publication,
-      pg_version: pg_version
+      publication_name: publication
     } do
       assert get_table_identity(conn, {"public", "items"}) == "d"
       assert get_table_identity(conn, {"public", "other_table"}) == "d"
-      assert list_tables_in_publication(conn, publication, pg_version) == []
+      assert list_tables_in_publication(conn, publication) == []
       oid1 = get_table_oid(conn, {"public", "items"})
       oid2 = get_table_oid(conn, {"public", "other_table"})
 
@@ -190,21 +167,14 @@ defmodule Electric.Postgres.ConfigurationTest do
                    where_clauses: [%Eval.Expr{query: "(value ILIKE 'no%')"}]
                  }
                },
-               pg_version,
                publication
              ) == []
 
       assert get_table_identity(conn, {"public", "items"}) == "f"
       assert get_table_identity(conn, {"public", "other_table"}) == "f"
 
-      assert list_tables_in_publication(conn, publication, pg_version) ==
-               expected_filters(
-                 [
-                   {"public", "items", "(value ~~* 'yes%'::text)"},
-                   {"public", "other_table", "(value ~~* 'no%'::text)"}
-                 ],
-                 pg_version
-               )
+      assert list_tables_in_publication(conn, publication) ==
+               expected_filters([{"public", "items"}, {"public", "other_table"}])
 
       assert Configuration.configure_publication!(
                conn,
@@ -219,22 +189,15 @@ defmodule Electric.Postgres.ConfigurationTest do
                    where_clauses: [%Eval.Expr{query: "(value ILIKE 'yes%')"}]
                  }
                },
-               pg_version,
                publication
              ) == []
 
-      assert list_tables_in_publication(conn, publication, pg_version) ==
-               expected_filters(
-                 [
-                   {"public", "items", "(value ~~* 'yes%'::text)"},
-                   {"public", "other_table", "(value ~~* 'yes%'::text)"}
-                 ],
-                 pg_version
-               )
+      assert list_tables_in_publication(conn, publication) ==
+               expected_filters([{"public", "items"}, {"public", "other_table"}])
     end
 
     test "doesn't fail when one of the tables is already configured",
-         %{pool: conn, publication_name: publication, pg_version: pg_version} do
+         %{pool: conn, publication_name: publication} do
       oid = get_table_oid(conn, {"public", "items"})
       oid2 = get_table_oid(conn, {"public", "other_table"})
 
@@ -247,19 +210,13 @@ defmodule Electric.Postgres.ConfigurationTest do
                    where_clauses: [%Eval.Expr{query: "(value ILIKE 'yes%')"}]
                  }
                },
-               pg_version,
                publication
              ) == []
 
       assert get_table_identity(conn, {"public", "other_table"}) == "d"
 
-      assert list_tables_in_publication(conn, publication, pg_version) ==
-               expected_filters(
-                 [
-                   {"public", "items", "(value ~~* 'yes%'::text)"}
-                 ],
-                 pg_version
-               )
+      assert list_tables_in_publication(conn, publication) ==
+               expected_filters([{"public", "items"}])
 
       # Configure `items` table again but with a different where clause
       assert Configuration.configure_publication!(
@@ -274,21 +231,14 @@ defmodule Electric.Postgres.ConfigurationTest do
                    relation: {"public", "other_table"}
                  }
                },
-               pg_version,
                publication
              ) == []
 
       assert get_table_identity(conn, {"public", "items"}) == "f"
       assert get_table_identity(conn, {"public", "other_table"}) == "f"
 
-      assert list_tables_in_publication(conn, publication, pg_version) ==
-               expected_filters(
-                 [
-                   {"public", "items", "(value ~~* 'no%'::text)"},
-                   {"public", "other_table", nil}
-                 ],
-                 pg_version
-               )
+      assert list_tables_in_publication(conn, publication) ==
+               expected_filters([{"public", "items"}, {"public", "other_table"}])
 
       # Now configure it again but for a shape that has no where clause
       # the resulting publication should no longer have a filter for that table
@@ -301,67 +251,14 @@ defmodule Electric.Postgres.ConfigurationTest do
                    relation: {"public", "other_table"}
                  }
                },
-               pg_version,
                publication
              ) == []
 
-      assert list_tables_in_publication(conn, publication, pg_version) ==
-               expected_filters(
-                 [
-                   {"public", "items", nil},
-                   {"public", "other_table", nil}
-                 ],
-                 pg_version
-               )
+      assert list_tables_in_publication(conn, publication) ==
+               expected_filters([{"public", "items"}, {"public", "other_table"}])
     end
 
-    test "fails with invalid where clause error when unsupported clause provided",
-         %{pool: conn, publication_name: publication, pg_version: pg_version} do
-      oid = get_table_oid(conn, {"public", "items"})
-
-      if pg_version >= @pg_15 do
-        error =
-          assert_raise Postgrex.Error, fn ->
-            Configuration.configure_publication!(
-              conn,
-              [],
-              %{
-                {oid, {"public", "items"}} => %RelationFilter{
-                  relation: {"public", "items"},
-                  where_clauses: [%Eval.Expr{query: "(value_c in ('a','b'))"}]
-                }
-              },
-              pg_version,
-              publication
-            )
-          end
-
-        assert %Postgrex.Error{
-                 postgres: %{
-                   code: :feature_not_supported,
-                   detail:
-                     "Only columns, constants, built-in operators, built-in data types, built-in collations, and immutable built-in functions are allowed."
-                 }
-               } = error
-      else
-        # pg versions without row filtering should just accept this
-        assert _ =
-                 Configuration.configure_publication!(
-                   conn,
-                   [{oid, {"public", "items"}}],
-                   %{
-                     {oid, {"public", "items"}} => %RelationFilter{
-                       relation: {"public", "items"},
-                       where_clauses: [%Eval.Expr{query: "(value_c in ('a','b'))"}]
-                     }
-                   },
-                   pg_version,
-                   publication
-                 )
-      end
-    end
-
-    test "fails when a publication doesn't exist", %{pool: conn, pg_version: pg_version} do
+    test "fails when a publication doesn't exist", %{pool: conn} do
       oid = get_table_oid(conn, {"public", "items"})
 
       assert_raise Postgrex.Error, ~r/undefined_object/, fn ->
@@ -371,7 +268,6 @@ defmodule Electric.Postgres.ConfigurationTest do
           %{
             {oid, {"public", "items"}} => %RelationFilter{relation: {"public", "items"}}
           },
-          pg_version,
           "nonexistent"
         )
       end
@@ -379,8 +275,7 @@ defmodule Electric.Postgres.ConfigurationTest do
 
     test "concurrent alters to the publication don't deadlock and run correctly", %{
       pool: conn,
-      publication_name: publication,
-      pg_version: pg_version
+      publication_name: publication
     } do
       oid1 = get_table_oid(conn, {"public", "items"})
       oid2 = get_table_oid(conn, {"public", "other_table"})
@@ -404,7 +299,6 @@ defmodule Electric.Postgres.ConfigurationTest do
             where_clauses: [%Eval.Expr{query: "(value ILIKE '1%')"}]
           }
         },
-        pg_version,
         publication
       )
 
@@ -429,7 +323,6 @@ defmodule Electric.Postgres.ConfigurationTest do
             conn,
             Map.keys(new_filters),
             new_filters,
-            pg_version,
             publication
           )
         end)
@@ -440,7 +333,6 @@ defmodule Electric.Postgres.ConfigurationTest do
             conn,
             Map.keys(new_filters),
             new_filters,
-            pg_version,
             publication
           )
         end)
@@ -449,21 +341,17 @@ defmodule Electric.Postgres.ConfigurationTest do
       assert [[], []] == Task.await_many([task1, task2])
 
       # Second check: the publication has the correct filters, that means one didn't override the other
-      assert list_tables_in_publication(conn, publication, pg_version) |> Enum.sort() ==
-               expected_filters(
-                 [
-                   {"public", "items", "(value ~~* 'yes%'::text)"},
-                   {"public", "other_other_table", "(value ~~* '2%'::text)"},
-                   {"public", "other_table", "(value ~~* '2%'::text)"}
-                 ],
-                 pg_version
-               )
+      assert list_tables_in_publication(conn, publication) |> Enum.sort() ==
+               expected_filters([
+                 {"public", "items"},
+                 {"public", "other_other_table"},
+                 {"public", "other_table"}
+               ])
     end
 
     test "dropped table isn't re-added to the publication, even if recreated", %{
       pool: conn,
-      publication_name: publication,
-      pg_version: pg_version
+      publication_name: publication
     } do
       oid1 = get_table_oid(conn, {"public", "items"})
 
@@ -476,12 +364,11 @@ defmodule Electric.Postgres.ConfigurationTest do
                    where_clauses: [%Eval.Expr{query: "(value ILIKE 'yes%')"}]
                  }
                },
-               pg_version,
                publication
              ) == []
 
-      assert list_tables_in_publication(conn, publication, pg_version) ==
-               expected_filters([{"public", "items", "(value ~~* 'yes%'::text)"}], pg_version)
+      assert list_tables_in_publication(conn, publication) ==
+               expected_filters([{"public", "items"}])
 
       # Recreate the table
       Postgrex.query!(conn, "DROP TABLE public.items", [])
@@ -505,11 +392,10 @@ defmodule Electric.Postgres.ConfigurationTest do
                    ]
                  }
                },
-               pg_version,
                publication
              ) == [{oid1, {"public", "items"}}]
 
-      assert list_tables_in_publication(conn, publication, pg_version) == []
+      assert list_tables_in_publication(conn, publication) == []
     end
   end
 
@@ -545,7 +431,7 @@ defmodule Electric.Postgres.ConfigurationTest do
     oid
   end
 
-  defp list_tables_in_publication(conn, publication, pg_version) when pg_version < @pg_15 do
+  defp list_tables_in_publication(conn, publication) do
     Postgrex.query!(
       conn,
       "SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = $1 ORDER BY tablename",
@@ -555,19 +441,5 @@ defmodule Electric.Postgres.ConfigurationTest do
     |> Enum.map(&List.to_tuple/1)
   end
 
-  defp list_tables_in_publication(conn, publication, _pg_version) do
-    Postgrex.query!(
-      conn,
-      "SELECT schemaname, tablename, rowfilter FROM pg_publication_tables WHERE pubname = $1 ORDER BY tablename",
-      [publication]
-    )
-    |> Map.fetch!(:rows)
-    |> Enum.map(&List.to_tuple/1)
-  end
-
-  defp expected_filters(filters, pg_version) when pg_version < @pg_15 do
-    Enum.map(filters, fn {schema, table, _filter} -> {schema, table} end)
-  end
-
-  defp expected_filters(filters, _pg_version), do: filters
+  defp expected_filters(filters), do: filters
 end

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -28,7 +28,7 @@ defmodule Electric.Replication.PublicationManagerTest do
   setup ctx do
     test_pid = self()
 
-    configure_tables_fn = fn _, _, filters, _, _ ->
+    configure_tables_fn = fn _, _, filters, _ ->
       send(test_pid, {:filters, Map.values(filters)})
       Map.get(ctx, :returned_relations, [])
     end
@@ -42,7 +42,6 @@ defmodule Electric.Replication.PublicationManagerTest do
         shape_cache: {__MODULE__, [self()]},
         publication_name: "pub_#{ctx.stack_id}",
         pool: :no_pool,
-        pg_version: Access.get(ctx, :pg_version, 150_001),
         configure_tables_for_replication_fn: configure_tables_fn
       })
 
@@ -103,28 +102,16 @@ defmodule Electric.Replication.PublicationManagerTest do
       assert :ok == PublicationManager.add_shape(@shape_handle_2, shape2, opts)
       assert :ok == PublicationManager.add_shape(@shape_handle_3, shape3, opts)
 
+      # Since only the first addition of the shape makes changes to the publication, we only expect to see the first where clause.
       assert_receive {:filters,
                       [
                         %RelationFilter{
                           relation: {"public", "items"},
-                          where_clauses: [@where_clause_2, @where_clause_1]
+                          where_clauses: [@where_clause_1]
                         }
                       ]}
-    end
 
-    test "should remove where clauses when one covers everything", %{opts: opts} do
-      shape1 = generate_shape({"public", "items"}, @where_clause_1)
-      shape2 = generate_shape({"public", "items"}, nil)
-      assert :ok == PublicationManager.add_shape(@shape_handle_1, shape1, opts)
-      assert :ok == PublicationManager.add_shape(@shape_handle_3, shape2, opts)
-
-      assert_receive {:filters,
-                      [
-                        %RelationFilter{
-                          relation: {"public", "items"},
-                          where_clauses: nil
-                        }
-                      ]}
+      refute_receive {:filters, _}, 500
     end
 
     test "should ignore where clauses that use unsupported column types (enums)", %{opts: opts} do
@@ -220,12 +207,11 @@ defmodule Electric.Replication.PublicationManagerTest do
     end
 
     @tag update_debounce_timeout: 100
-    @tag pg_version: 14_0001
-    test "should not update publication if new shape adds nothing when where clauses aren't considered",
+    test "should not update publication if new shape adds nothing new since where clauses aren't considered",
          %{opts: opts} do
       shape1 = generate_shape({"public", "items"}, @where_clause_1)
       shape2 = generate_shape({"public", "items"}, @where_clause_2)
-      # different clause, but PG 14 doesn't support those filters
+      # different clause but we're no using those filters in publication
       shape3 = generate_shape({"public", "items"}, @where_clause_3)
 
       task1 = Task.async(fn -> PublicationManager.add_shape(@shape_handle_1, shape1, opts) end)
@@ -237,69 +223,13 @@ defmodule Electric.Replication.PublicationManagerTest do
                       [
                         %RelationFilter{
                           relation: {"public", "items"},
-                          where_clauses: nil
+                          where_clauses: [@where_clause_2, @where_clause_1]
                         }
                       ]}
 
       assert :ok == PublicationManager.add_shape(@shape_handle_3, shape3, opts)
 
       refute_receive {:filters, _}, 500
-    end
-
-    test "should fallback to relation-only filtering if we cannot do row filtering", %{
-      ctx: ctx,
-      opts: opts
-    } do
-      stop_supervised!(opts[:server])
-
-      test_id = self()
-
-      configure_tables_fn = fn _, _old_relations, filters, _, _ ->
-        if filters |> Map.values() |> Enum.any?(&(&1.where_clauses != nil)) do
-          send(test_id, {:got_filters, :with_where_clauses})
-          raise %Postgrex.Error{postgres: %{code: :feature_not_supported}}
-        end
-
-        send(test_id, {:got_filters, :without_where_clauses})
-        []
-      end
-
-      %{publication_manager: {_, publication_manager_opts}} =
-        with_publication_manager(%{
-          module: ctx.module,
-          test: ctx.test,
-          stack_id: ctx.stack_id,
-          update_debounce_timeout: Access.get(ctx, :update_debounce_timeout, 0),
-          publication_name: "pub_#{ctx.stack_id}",
-          pool: :no_pool,
-          pg_version: 150_001,
-          configure_tables_for_replication_fn: configure_tables_fn
-        })
-
-      shape1 = generate_shape({"public", "items"}, @where_clause_1)
-      shape2 = generate_shape({"public", "items"}, @where_clause_2)
-      shape3 = generate_shape({"public", "items_other"}, @where_clause_2)
-
-      # should fall back to relation-only filtering
-      assert :ok ==
-               PublicationManager.add_shape(@shape_handle_1, shape1, publication_manager_opts)
-
-      assert_receive {:got_filters, :with_where_clauses}
-      assert_receive {:got_filters, :without_where_clauses}
-      refute_receive {:got_filters, _}, 50
-
-      # should remain in relation-only filtering mode after that, which
-      # only updates the publication if the tracked relations change
-      assert :ok ==
-               PublicationManager.add_shape(@shape_handle_2, shape2, publication_manager_opts)
-
-      refute_receive {:got_filters, _}, 50
-
-      assert :ok ==
-               PublicationManager.add_shape(@shape_handle_3, shape3, publication_manager_opts)
-
-      assert_receive {:got_filters, :without_where_clauses}
-      refute_receive {:got_filters, _}, 50
     end
 
     @tag returned_relations: [{10, {"public", "another_table"}}]

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -113,13 +113,12 @@ defmodule Support.ComponentSetup do
             publication_name: ctx.publication_name,
             update_debounce_timeout: Access.get(ctx, :update_debounce_timeout, 0),
             db_pool: ctx.pool,
-            pg_version: Access.get(ctx, :pg_version, 150_001),
             manual_table_publishing?: Access.get(ctx, :manual_table_publishing?, false),
             configure_tables_for_replication_fn:
               Access.get(
                 ctx,
                 :configure_tables_for_replication_fn,
-                &Electric.Postgres.Configuration.configure_publication!/5
+                &Electric.Postgres.Configuration.configure_publication!/4
               ),
             shape_cache:
               Access.get(ctx, :shape_cache, {Electric.ShapeCache, [stack_id: ctx.stack_id]})

--- a/packages/sync-service/test/support/db_setup.ex
+++ b/packages/sync-service/test/support/db_setup.ex
@@ -104,15 +104,6 @@ defmodule Support.DbSetup do
     %{publication_name: publication_name}
   end
 
-  def with_pg_version(ctx) do
-    %{rows: [[pg_version]]} =
-      Postgrex.query!(ctx.db_conn, "SELECT current_setting('server_version_num')::integer", [])
-
-    true = is_integer(pg_version)
-
-    {:ok, %{pg_version: pg_version}}
-  end
-
   @doc """
   Creates a database that is shared between all tests in the module
   """


### PR DESCRIPTION
This removes the code that was responsible for adding and maintaining the row filter on the publication (aka the WHERE clause).

We're still waiting on the final benchmark results from https://github.com/electric-sql/electric/pull/2895#issuecomment-3139023498 to have a better understanding of transaction processing times with row filtering enabled and disabled.