### PR TITLE
fix: Restart stack on irrecoverable replication issues

### DIFF
--- a/.changeset/little-impalas-lay.md
+++ b/.changeset/little-impalas-lay.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ensure service can recover from unhandleable replication slots, in cases such as too large transactions or incorrectly configured replica identity.

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -114,27 +114,19 @@
 [endmacro]
 
 [macro setup_electric]
-  [invoke setup_electric_with_env "DATABASE_URL=$database_url ELECTRIC_INSECURE=true"]
+  [invoke setup_electric_with_env ""]
 [endmacro]
 
 [macro setup_secure_electric secret]
-  [invoke setup_electric_with_env "DATABASE_URL=$database_url ELECTRIC_INSECURE=false ELECTRIC_SECRET=$secret"]
+  [invoke setup_electric_with_env "ELECTRIC_INSECURE=false ELECTRIC_SECRET=$secret"]
 [endmacro]
 
 [macro setup_electric_with_pooler]
-  [invoke setup_electric_with_env "ELECTRIC_INSECURE=true DATABASE_URL=$database_url ELECTRIC_QUERY_DATABASE_URL=$pooled_database_url"]
-[endmacro]
-
-[macro setup_multi_tenant_electric]
-  [invoke setup_electric_with_env "ELECTRIC_INSECURE=true"]
+  [invoke setup_electric_with_env "ELECTRIC_QUERY_DATABASE_URL=$pooled_database_url"]
 [endmacro]
 
 [macro setup_electric_with_env env]
-  [invoke setup_electric_shell "electric" "3000" $env]
-[endmacro]
-
-[macro setup_electric_with_env_and_tenant env]
-  [invoke setup_electric_with_env "DATABASE_URL=$database_url $env"]
+  [invoke setup_electric_shell "electric" "3000" "DATABASE_URL=$database_url ELECTRIC_INSECURE=true $env"]
 [endmacro]
 
 [macro setup_electric_shell shell_name port env]
@@ -160,25 +152,9 @@
     ??"$tenant_id"
 [endmacro]
 
-[macro check_tenant_status tenant_id expected_status electric_port]
-  [shell $tenant_id]
-    [invoke wait-for "curl -X GET http://localhost:$electric_port/v1/health?database_id=$tenant_id" "\{\"status\":\"$expected_status\"\}" 10 $PS1]
-[endmacro]
-
-[macro capture_stack_supervisor_pid]
-  ?pid=(<\d+\.\d+\.\d+>) \[debug\] StackSupervisor for stack "single_stack" is initializing
-  # All interactive commands and matches are performed within a single IEx session,
-  # so we can assign local variables here which is less of a hassle than using lux variables.
-  !stack_supervisor_pid = :erlang.list_to_pid(~c"$1")
-  !stack_supervisor_mon = Process.monitor(stack_supervisor_pid)
-[endmacro]
-
-[macro wait_on_stack_supervisor_registration]
-  # Verify that the stack supervisor is registered using regular process registration. If we
-  # change this at any point, the line below will catch it and we'll be able to correct the
-  # check further down that verifies that the stack supervisor is no longer running.
-  !IO.puts("Stack supervisor pid: #{inspect Process.whereis(Electric.StackSupervisor)}")
-  ??Stack supervisor pid: #PID<
+[macro check_health_status expected_status]
+  [shell electric-health]
+    [invoke wait-for "curl -X GET http://localhost:3000/v1/health" "\{\"status\":\"$expected_status\"\}" 10 $PS1]
 [endmacro]
 
 [macro teardown_container container_name]

--- a/integration-tests/tests/exceedingly-large-transaction.lux
+++ b/integration-tests/tests/exceedingly-large-transaction.lux
@@ -1,0 +1,80 @@
+[doc Verify handling of exceedingly large transactions]
+
+[include _macros.luxinc]
+
+[global pg_container_name=exceedingly-large-transaction__pg]
+
+[my max_txn_bytes=5000]
+[my exceeded_transaction_limit_error=
+  """
+  Collected transaction exceeds limit of $max_txn_bytes bytes.
+  """]
+
+## Start a new Postgres cluster configured for easy replication slot invalidation.
+[invoke setup_pg_with_shell_name "pg" "" ""]
+
+## Start the sync service.
+[invoke setup_electric_with_env "ELECTRIC_EXPERIMENTAL_MAX_TXN_SIZE=$max_txn_bytes"]
+
+[invoke check_health_status "active"]
+
+## Create a table and shape, and send through a large transaction that should
+## surpass the limit specified
+[invoke start_psql]
+[shell psql]
+[shell psql]
+  """!
+  CREATE TABLE items (
+    id UUID PRIMARY KEY,
+    val TEXT
+  );
+  """
+  ??CREATE TABLE
+
+  """!
+  INSERT INTO items (id, val) VALUES (gen_random_uuid(), 'initial');
+  """
+  ??INSERT 0 1
+
+[shell client]
+  [invoke shape_get_snapshot items]
+  ??HTTP/1.1 200 OK
+  ?electric-handle: ([\d-]+)
+  [local handle=$1]
+  ?electric-offset: ([\w\d_]+)
+  [local offset=$1]
+  ??"val":"initial"
+
+[shell psql]
+  """!
+  INSERT INTO items (id, val) VALUES (
+    gen_random_uuid(),
+    'large val ' || repeat('012345679abcdef', 4096)
+  );
+  """
+  ??INSERT 0 1
+
+## Observe the error and clean restart of the stack
+[shell electric]
+  # Reset the failure pattern because we'll be matching on an error.
+  -
+
+  ??$exceeded_transaction_limit_error
+  ??Purging all shapes.
+  ??Starting replication from postgres
+
+[invoke check_health_status "active"]
+
+## Should now be able to observe data from large transaction
+[shell client]
+  [invoke shape_get_snapshot items]
+  ??HTTP/1.1 200 OK
+  ?electric-handle: ([\d-]+)
+  [local handle=$1]
+  ?electric-offset: ([\w\d_]+)
+  [local offset=$1]
+  ??"val":"initial"
+  ?"val":"large val [\w\d]+"
+
+[cleanup]
+  [invoke teardown]

--- a/integration-tests/tests/invalidated-replication-slot.lux
+++ b/integration-tests/tests/invalidated-replication-slot.lux
@@ -20,9 +20,8 @@
 ## Start the sync service.
 [invoke setup_electric]
 
-[shell electric]
-  [invoke capture_stack_supervisor_pid]
-  [invoke wait_on_stack_supervisor_registration]
+[invoke check_health_status "active"]
+  
 
 ## Seed the database with enough data to exceed max_wal_size and force a checkpoint that
 ## will invalidate the replication slot.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -205,6 +205,7 @@ config :electric,
   replication_slot_temporary?: env!("CLEANUP_REPLICATION_SLOTS_ON_SHUTDOWN", :boolean, nil),
   replication_slot_temporary_random_name?:
     env!("ELECTRIC_TEMPORARY_REPLICATION_SLOT_USE_RANDOM_NAME", :boolean, nil),
+  max_txn_size: env!("ELECTRIC_MAX_TXN_SIZE", :integer, nil),
   service_port: env!("ELECTRIC_PORT", :integer, nil),
   shape_hibernate_after: shape_hibernate_after,
   storage_dir: storage_dir,

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -205,7 +205,8 @@ config :electric,
   replication_slot_temporary?: env!("CLEANUP_REPLICATION_SLOTS_ON_SHUTDOWN", :boolean, nil),
   replication_slot_temporary_random_name?:
     env!("ELECTRIC_TEMPORARY_REPLICATION_SLOT_USE_RANDOM_NAME", :boolean, nil),
-  max_txn_size: env!("ELECTRIC_MAX_TXN_SIZE", :integer, nil),
+  # The ELECTRIC_EXPERIMENTAL_MAX_TXN_SIZE is undocumented and will be removed in future versions.
+  max_txn_size: env!("ELECTRIC_EXPERIMENTAL_MAX_TXN_SIZE", :non_neg_integer, nil),
   service_port: env!("ELECTRIC_PORT", :integer, nil),
   shape_hibernate_after: shape_hibernate_after,
   storage_dir: storage_dir,

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -206,7 +206,7 @@ config :electric,
   replication_slot_temporary_random_name?:
     env!("ELECTRIC_TEMPORARY_REPLICATION_SLOT_USE_RANDOM_NAME", :boolean, nil),
   # The ELECTRIC_EXPERIMENTAL_MAX_TXN_SIZE is undocumented and will be removed in future versions.
-  max_txn_size: env!("ELECTRIC_EXPERIMENTAL_MAX_TXN_SIZE", :non_neg_integer, nil),
+  max_txn_size: env!("ELECTRIC_EXPERIMENTAL_MAX_TXN_SIZE", :integer, nil),
   service_port: env!("ELECTRIC_PORT", :integer, nil),
   shape_hibernate_after: shape_hibernate_after,
   storage_dir: storage_dir,

--- a/packages/sync-service/lib/electric.ex
+++ b/packages/sync-service/lib/electric.ex
@@ -40,6 +40,7 @@ defmodule Electric do
         db_pool_size: #{default.(:db_pool_size)},
         replication_stream_id: #{default.(:replication_stream_id)},
         replication_slot_temporary?: #{default.(:replication_slot_temporary?)},
+        max_txn_size: #{default.(:max_txn_size)},
         # HTTP API
         service_port: #{default.(:service_port)},
         allow_shape_deletion?: #{default.(:allow_shape_deletion?)},

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -121,7 +121,8 @@ defmodule Electric.Application do
         connection_opts: replication_connection_opts,
         publication_name: publication_name,
         slot_name: slot_name,
-        slot_temporary?: get_env(opts, :replication_slot_temporary?)
+        slot_temporary?: get_env(opts, :replication_slot_temporary?),
+        max_txn_size: get_env(opts, :max_txn_size)
       ],
       pool_opts:
         get_env_lazy(opts, :pool_opts, fn -> [pool_size: get_env(opts, :db_pool_size)] end),

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -43,6 +43,7 @@ defmodule Electric.Config do
     replication_stream_id: "default",
     replication_slot_temporary?: false,
     replication_slot_temporary_random_name?: false,
+    max_txn_size: 250 * 1024 * 1024,
     ## HTTP API
     # set enable_http_api: false to turn off the HTTP server totally
     enable_http_api: true,

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -1112,7 +1112,7 @@ defmodule Electric.Connection.Manager do
 
   defp pg_error_extra_info(_), do: ""
 
-  defp drop_slot_and_restart(%DbConnectionError{drop_replication_slot?: true} = error, state) do
+  defp drop_slot_and_restart(%DbConnectionError{drop_slot_and_restart?: true} = error, state) do
     Logger.warning(error.message)
 
     dispatch_stack_event(

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -1112,16 +1112,13 @@ defmodule Electric.Connection.Manager do
 
   defp pg_error_extra_info(_), do: ""
 
-  defp drop_slot_and_restart(
-         %DbConnectionError{type: :replication_slot_invalidated} = error,
-         state
-       ) do
+  defp drop_slot_and_restart(%DbConnectionError{drop_replication_slot?: true} = error, state) do
     Logger.warning(error.message)
 
     dispatch_stack_event(
       {:warning,
        %{
-         type: :database_slot_exceeded_max_size,
+         type: error.type,
          message: error.message,
          error: DbConnectionError.format_original_error(error)
        }},
@@ -1135,7 +1132,7 @@ defmodule Electric.Connection.Manager do
       state.timeline_opts
     )
 
-    {:stop, {:shutdown, :database_slot_exceeded_max_size}, state}
+    {:stop, {:shutdown, error.type}, state}
   end
 
   defp drop_slot_and_restart(_, _), do: false

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -6,7 +6,7 @@ defmodule Electric.DbConnectionError do
     :type,
     :original_error,
     :retry_may_fix?,
-    drop_replication_slot?: false
+    drop_slot_and_restart?: false
   ]
 
   alias Electric.DbConnectionError
@@ -104,8 +104,8 @@ defmodule Electric.DbConnectionError do
       """,
       type: :database_slot_exceeded_max_size,
       original_error: error,
-      retry_may_fix?: true,
-      drop_replication_slot?: true
+      retry_may_fix?: false,
+      drop_slot_and_restart?: true
     }
   end
 
@@ -226,8 +226,8 @@ defmodule Electric.DbConnectionError do
       message: message,
       type: type,
       original_error: error,
-      retry_may_fix?: true,
-      drop_replication_slot?: true
+      retry_may_fix?: false,
+      drop_slot_and_restart?: true
     }
   end
 

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -11,6 +11,8 @@ defmodule Electric.DbConnectionError do
 
   alias Electric.DbConnectionError
 
+  def from_error(%DbConnectionError{} = err), do: err
+
   def from_error(%DBConnection.ConnectionError{message: message} = error)
       when message in [
              "tcp recv (idle): closed",

--- a/packages/sync-service/lib/electric/postgres/logical_replication/messages.ex
+++ b/packages/sync-service/lib/electric/postgres/logical_replication/messages.ex
@@ -58,32 +58,35 @@ defmodule Electric.Postgres.LogicalReplication.Messages do
   end
 
   defmodule Insert do
-    defstruct([:relation_id, :tuple_data])
+    defstruct([:relation_id, :tuple_data, :bytes])
 
     @type t() :: %__MODULE__{
             relation_id: Messages.relation_id(),
-            tuple_data: tuple()
+            tuple_data: tuple(),
+            bytes: non_neg_integer()
           }
   end
 
   defmodule Update do
-    defstruct([:relation_id, :changed_key_tuple_data, :old_tuple_data, :tuple_data])
+    defstruct([:relation_id, :changed_key_tuple_data, :old_tuple_data, :tuple_data, :bytes])
 
     @type t() :: %__MODULE__{
             relation_id: Messages.relation_id(),
             changed_key_tuple_data: nil | {String.t(), nil | String.t()},
             old_tuple_data: tuple(),
-            tuple_data: tuple()
+            tuple_data: tuple(),
+            bytes: non_neg_integer()
           }
   end
 
   defmodule Delete do
-    defstruct([:relation_id, :changed_key_tuple_data, :old_tuple_data])
+    defstruct([:relation_id, :changed_key_tuple_data, :old_tuple_data, :bytes])
 
     @type t() :: %__MODULE__{
             relation_id: Messages.relation_id(),
             changed_key_tuple_data: nil | {String.t(), nil | String.t()},
-            old_tuple_data: nil | tuple()
+            old_tuple_data: nil | tuple(),
+            bytes: non_neg_integer()
           }
   end
 

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -86,11 +86,7 @@ defmodule Electric.Postgres.ReplicationClient do
                    # we can handle, above which we would exit as we run the risk of running
                    # out of memmory.
                    # TODO: stream out transactions and collect on disk to avoid this
-                   max_txn_size: [
-                     required: false,
-                     type: :non_neg_integer,
-                     default: 250 * 1024 * 1024
-                   ]
+                   max_txn_size: [type: {:or, [:non_neg_integer, nil]}, default: nil]
                  )
 
     @spec new(Access.t()) :: t()

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -305,7 +305,7 @@ defmodule Electric.Postgres.ReplicationClient do
     |> Collector.handle_message(state.txn_collector)
     |> case do
       {:error, reason, _} ->
-        raise Electric.DbConnectionError.from_error({:irrecoverable_slot, reason})
+        {:disconnect, {:irrecoverable_slot, reason}}
 
       %Collector{} = txn_collector ->
         {:noreply, %{state | txn_collector: txn_collector}}

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -305,7 +305,7 @@ defmodule Electric.Postgres.ReplicationClient do
     |> Collector.handle_message(state.txn_collector)
     |> case do
       {:error, reason, _} ->
-        exit({:irrecoverable_slot, reason})
+        raise Electric.DbConnectionError.from_error({:irrecoverable_slot, reason})
 
       %Collector{} = txn_collector ->
         {:noreply, %{state | txn_collector: txn_collector}}

--- a/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
@@ -175,12 +175,14 @@ defmodule Electric.Postgres.ReplicationClient.Collector do
 
   defp column_value(_column_name, value), do: value
 
-  @spec prepend_change(Changes.change(), non_neg_integer(), t()) :: t()
-  defp prepend_change(_, bytes, %__MODULE__{max_tx_size: max_tx_size, tx_size: tx_size})
+  @spec prepend_change(Changes.change(), non_neg_integer(), t()) ::
+          t() | {:error, {:exceeded_max_tx_size, String.t()}, t()}
+  defp prepend_change(_, bytes, %__MODULE__{max_tx_size: max_tx_size, tx_size: tx_size} = state)
        when is_number(max_tx_size) and tx_size + bytes > max_tx_size do
     {
       :error,
-      {:exceeded_max_tx_size, "Collected transaction exceeds limit of #{max_tx_size} bytes."}
+      {:exceeded_max_tx_size, "Collected transaction exceeds limit of #{max_tx_size} bytes."},
+      state
     }
   end
 

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -75,6 +75,7 @@ defmodule Electric.StackSupervisor do
                      slot_name: [type: :string, required: true],
                      slot_temporary?: [type: :boolean, default: false],
                      try_creating_publication?: [type: :boolean, default: true],
+                     max_txn_size: [type: {:or, [:non_neg_integer, nil]}, default: nil],
                      stream_id: [type: :string, required: false]
                    ]
                  ],

--- a/packages/sync-service/test/electric/postgres/decoder_test.exs
+++ b/packages/sync-service/test/electric/postgres/decoder_test.exs
@@ -216,21 +216,24 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                  48>>
              ) == %Insert{
                relation_id: 24576,
-               tuple_data: ["baz", "560"]
+               tuple_data: ["baz", "560"],
+               bytes: 6
              }
     end
 
     test "decodes insert messages with null values" do
       assert decode(<<73, 0, 0, 96, 0, 78, 0, 2, 110, 116, 0, 0, 0, 3, 53, 54, 48>>) == %Insert{
                relation_id: 24576,
-               tuple_data: [nil, "560"]
+               tuple_data: [nil, "560"],
+               bytes: 3
              }
     end
 
     test "decodes insert messages with unchanged toasted values" do
       assert decode(<<73, 0, 0, 96, 0, 78, 0, 2, 117, 116, 0, 0, 0, 3, 53, 54, 48>>) == %Insert{
                relation_id: 24576,
-               tuple_data: [:unchanged_toast, "560"]
+               tuple_data: [:unchanged_toast, "560"],
+               bytes: 3
              }
     end
 
@@ -242,7 +245,8 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                relation_id: 24576,
                changed_key_tuple_data: nil,
                old_tuple_data: nil,
-               tuple_data: ["example", "560"]
+               tuple_data: ["example", "560"],
+               bytes: 10
              }
     end
 
@@ -255,7 +259,8 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                relation_id: 24576,
                changed_key_tuple_data: nil,
                old_tuple_data: ["baz", "560"],
-               tuple_data: ["example", "560"]
+               tuple_data: ["example", "560"],
+               bytes: 16
              }
     end
 
@@ -267,7 +272,8 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                relation_id: 24576,
                changed_key_tuple_data: ["baz", nil],
                old_tuple_data: nil,
-               tuple_data: ["example", "560"]
+               tuple_data: ["example", "560"],
+               bytes: 13
              }
     end
 
@@ -277,7 +283,8 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                  110>>
              ) == %Delete{
                relation_id: 24576,
-               changed_key_tuple_data: ["example", nil]
+               changed_key_tuple_data: ["example", nil],
+               bytes: 7
              }
     end
 
@@ -287,7 +294,8 @@ defmodule Electric.Postgres.LogicalReplication.DecoderTest do
                  48>>
              ) == %Delete{
                relation_id: 24576,
-               old_tuple_data: ["baz", "560"]
+               old_tuple_data: ["baz", "560"],
+               bytes: 6
              }
     end
   end

--- a/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
@@ -245,7 +245,7 @@ defmodule Electric.Postgres.ReplicationClient.CollectorTest do
 
     err_msg = "Collected transaction exceeds limit of #{max_tx_size} bytes."
 
-    assert {:error, {:exceeded_max_tx_size, ^err_msg}} =
+    assert {:error, {:exceeded_max_tx_size, ^err_msg}, %Collector{} = _} =
              Collector.handle_message(insert_msg, collector)
   end
 

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -290,10 +290,9 @@ defmodule Electric.Postgres.ReplicationClientTest do
                        ^monitor,
                        :process,
                        ^pid,
-                       {%Electric.DbConnectionError{
-                          type: :exceeded_max_tx_size,
-                          message: "Collected transaction exceeds limit of 5000 bytes."
-                        }, _stacktrace}
+                       {:irrecoverable_slot,
+                        {:exceeded_max_tx_size,
+                         "Collected transaction exceeds limit of 5000 bytes."}}
                      },
                      @assert_receive_db_timeout
     end
@@ -318,8 +317,7 @@ defmodule Electric.Postgres.ReplicationClientTest do
                        ^monitor,
                        :process,
                        ^pid,
-                       {%Electric.DbConnectionError{type: :replica_not_full, message: msg},
-                        _stacktrace}
+                       {:irrecoverable_slot, {:replica_not_full, msg}}
                      },
                      @assert_receive_db_timeout
 

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -290,9 +290,10 @@ defmodule Electric.Postgres.ReplicationClientTest do
                        ^monitor,
                        :process,
                        ^pid,
-                       {:irrecoverable_slot,
-                        {:exceeded_max_tx_size,
-                         "Collected transaction exceeds limit of 5000 bytes."}}
+                       {%Electric.DbConnectionError{
+                          type: :exceeded_max_tx_size,
+                          message: "Collected transaction exceeds limit of 5000 bytes."
+                        }, _stacktrace}
                      },
                      @assert_receive_db_timeout
     end
@@ -317,7 +318,8 @@ defmodule Electric.Postgres.ReplicationClientTest do
                        ^monitor,
                        :process,
                        ^pid,
-                       {:irrecoverable_slot, {:replica_not_full, msg}}
+                       {%Electric.DbConnectionError{type: :replica_not_full, message: msg},
+                        _stacktrace}
                      },
                      @assert_receive_db_timeout
 


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/2900
Fixes https://github.com/electric-sql/electric/issues/2101

We will now be handling the following two cases:
1. Transaction comes in with a replica identity not set to `FULL` - something got misconfigured, and the stream is no longer valid since changes don't contain all information we need
2. Transaction gets collected and its data content surpasses `max_txn_size`, which defaults to 250 MB (I can make it env var configurable)

When these things happen, we exit the replication client with an `:irrecoverable_slot` error, which gets parsed as a `DbConnectionError`.

I've added a `drop_replication_slot?` field on these errors to make it clearer whether an error should trigger slot drop, and subsequently a full stack reset. Combined with a `retry_may_fix?` flag, this causes the slot and shapes to be cleaned up and thus we replicate from scratch, so the above 2 issues should resolve as the large transaction will be now part of the snapshot, and the replica will be reconfigured by the publication manager.

I've also renamed `:replication_slot_invalidated` to `:database_slot_exceeded_max_size` to make it consistent across the code, and made that error retryable with a replication slot drop - a warning stack event is still fired but no reason we shouldn't just restart things.