### PR TITLE
feat(sync-service) Sample telemetry at source for faster replication stream processing

### DIFF
--- a/.changeset/tricky-ravens-roll.md
+++ b/.changeset/tricky-ravens-roll.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Extend replication processing telemetry to cover the entire processing loop

--- a/.changeset/young-numbers-count.md
+++ b/.changeset/young-numbers-count.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Sample telemetry at source for faster replication stream processing

--- a/integration-tests/tests/replication-lifetime.lux
+++ b/integration-tests/tests/replication-lifetime.lux
@@ -67,7 +67,7 @@
     ??$PS1
 
   [shell electric]
-    ??[info] Received transaction
+    ??[debug] Received transaction
     [sleep 1]
 
   # Client should be able to continue same shape

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -163,6 +163,8 @@ otel_export_period =
     nil
   )
 
+otel_sampling_ratio = env!("ELECTRIC_OTEL_SAMPLING_RATIO", :float, 0.01)
+
 # The provided database id is relevant if you had used v0.8 and want to keep the storage
 # instead of having hanging files. We use a provided value as stack id, but nothing else.
 provided_database_id = env!("ELECTRIC_DATABASE_ID", :string, nil)
@@ -190,6 +192,7 @@ config :electric,
   system_metrics_poll_interval: system_metrics_poll_interval,
   otel_export_period: otel_export_period,
   otel_per_process_metrics?: env!("ELECTRIC_OTEL_PER_PROCESS_METRICS", :boolean, nil),
+  otel_sampling_ratio: otel_sampling_ratio,
   telemetry_top_process_count: env!("ELECTRIC_TELEMETRY_TOP_PROCESS_COUNT", :integer, nil),
   telemetry_long_gc_threshold: env!("ELECTRIC_TELEMETRY_LONG_GC_THRESHOLD", :integer, nil),
   telemetry_long_schedule_threshold:
@@ -240,7 +243,6 @@ if Electric.telemetry_enabled?() do
 
   otlp_endpoint = env!("ELECTRIC_OTLP_ENDPOINT", :string, nil)
   otel_debug = env!("ELECTRIC_OTEL_DEBUG", :boolean, false)
-  otel_sampling_ratio = env!("ELECTRIC_OTEL_SAMPLING_RATIO", :float, 0.01)
 
   otel_batch_processor =
     if otlp_endpoint do
@@ -263,19 +265,7 @@ if Electric.telemetry_enabled?() do
       service: %{name: service_name, version: Electric.version()},
       instance: %{id: instance_id}
     },
-    processors: [otel_batch_processor, otel_simple_processor] |> Enum.reject(&is_nil/1),
-    # sampler: {Electric.Telemetry.Sampler, %{ratio: otel_sampling_ratio}}
-    # Sample root spans based on our custom sampler
-    # and inherit sampling decision from remote parents
-    sampler:
-      {:parent_based,
-       %{
-         root: {Electric.Telemetry.Sampler, %{ratio: otel_sampling_ratio}},
-         remote_parent_sampled: :always_on,
-         remote_parent_not_sampled: :always_off,
-         local_parent_sampled: :always_on,
-         local_parent_not_sampled: :always_off
-       }}
+    processors: [otel_batch_processor, otel_simple_processor] |> Enum.reject(&is_nil/1)
 
   if otlp_endpoint do
     # Shortcut config for Honeycomb.io:

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -257,18 +257,6 @@ defmodule Electric.Postgres.ReplicationClient do
     handle_data(data, state)
   end
 
-  def handle_data(
-        <<@repl_msg_x_log_data, _wal_start::64, wal_end::64, _clock::64, rest::binary>>,
-        %State{stack_id: stack_id} = state
-      ) do
-    OpenTelemetry.with_span(
-      "pg_txn.replication_client.process_x_log_data",
-      [msg_size: byte_size(rest)],
-      stack_id,
-      fn -> process_x_log_data(rest, wal_end, state) end
-    )
-  end
-
   def handle_data(<<@repl_msg_primary_keepalive, wal_end::64, _clock::64, reply>>, state) do
     Logger.debug(fn ->
       "Primary Keepalive: wal_end=#{wal_end} (#{Lsn.from_integer(wal_end)}) reply=#{reply}"
@@ -290,8 +278,11 @@ defmodule Electric.Postgres.ReplicationClient do
     end
   end
 
-  defp process_x_log_data(data, _wal_end, %State{stack_id: stack_id} = state) do
-    OpenTelemetry.timed_fun("decode_message_duration", fn -> decode_message(data) end)
+  def handle_data(
+        <<@repl_msg_x_log_data, _wal_start::64, _wal_end::64, _clock::64, data::binary>>,
+        %State{stack_id: stack_id} = state
+      ) do
+    decode_message(data)
     # # Useful for debugging:
     # |> tap(fn %struct{} = msg ->
     #   message_type = struct |> to_string() |> String.split(".") |> List.last()

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -149,8 +149,10 @@ defmodule Electric.Replication.ShapeLogCollector do
 
     OpenTelemetry.start_interval("shape_log_collector.logging")
 
-    Logger.info(
-      "Received transaction #{xid} (#{txn.num_changes} changes) from Postgres at #{lsn}",
+    Logger.debug(
+      fn ->
+        "Received transaction #{xid} (#{txn.num_changes} changes) from Postgres at #{lsn}"
+      end,
       received_transaction_xid: xid,
       received_transaction_num_changes: txn.num_changes,
       received_transaction_lsn: lsn

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -261,7 +261,7 @@ defmodule Electric.Shapes.Consumer do
   end
 
   defp handle_event(%Transaction{} = txn, %{pg_snapshot: %{xmin: xmin, xmax: xmax}} = state) do
-    OpenTelemetry.with_span(
+    OpenTelemetry.with_child_span(
       "shape_write.consumer.handle_txns",
       [snapshot_xmin: xmin, snapshot_xmax: xmax],
       state.stack_id,
@@ -323,9 +323,14 @@ defmodule Electric.Shapes.Consumer do
       [xid: txn.xid, total_num_changes: txn.num_changes] ++
         shape_attrs(state.shape_handle, state.shape)
 
-    OpenTelemetry.with_span("shape_write.consumer.handle_txn", ot_attrs, state.stack_id, fn ->
-      do_handle_txn(txn, state)
-    end)
+    OpenTelemetry.with_child_span(
+      "shape_write.consumer.handle_txn",
+      ot_attrs,
+      state.stack_id,
+      fn ->
+        do_handle_txn(txn, state)
+      end
+    )
   end
 
   defp do_handle_txn(%Transaction{xid: xid, changes: changes} = txn, state) do

--- a/packages/sync-service/lib/electric/shapes/filter/where_condition.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/where_condition.ex
@@ -149,7 +149,7 @@ defmodule Electric.Shapes.Filter.WhereCondition do
   end
 
   defp indexed_shapes_affected(condition, record) do
-    OpenTelemetry.with_span(
+    OpenTelemetry.with_child_span(
       "filter.filter_using_indexes",
       [index_count: map_size(condition.indexes)],
       fn ->
@@ -163,7 +163,7 @@ defmodule Electric.Shapes.Filter.WhereCondition do
   end
 
   defp other_shapes_affected(condition, record) do
-    OpenTelemetry.with_span(
+    OpenTelemetry.with_child_span(
       "filter.filter_other_shapes",
       [shape_count: map_size(condition.other_shapes)],
       fn ->

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -170,9 +170,11 @@ defmodule Electric.Telemetry.OpenTelemetry do
     total_sleep_µs: 3000
   """
   @spec start_interval(binary()) :: :ok
-  def start_interval(interval_name) do
+  def start_interval(context \\ nil, interval_name) do
     IntervalTimer.start_interval(get_interval_timer(), interval_name)
     |> set_interval_timer()
+
+    context
   end
 
   @doc """

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -70,9 +70,10 @@ defmodule Electric.Telemetry.OpenTelemetry do
   will not be created either.
   """
   def with_child_span(name, attributes, stack_id \\ nil, fun) do
-    case get_current_context() do
-      {:undefined, _} -> fun.()
-      _ -> with_span(name, attributes, stack_id, fun)
+    if in_span_context?() do
+      with_span(name, attributes, stack_id, fun)
+    else
+      fun.()
     end
   end
 
@@ -299,5 +300,9 @@ defmodule Electric.Telemetry.OpenTelemetry do
 
   defp current_span_context do
     :otel_tracer.current_span_ctx()
+  end
+
+  defp in_span_context? do
+    current_span_context() != :undefined
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/optional_spans.ex
+++ b/packages/sync-service/lib/electric/telemetry/optional_spans.ex
@@ -1,4 +1,0 @@
-defmodule Electric.Telemetry.OptionalSpans do
-  def include?("filter." <> _), do: Application.get_env(:electric, :profile_where_clauses?)
-  def include?(_), do: true
-end

--- a/packages/sync-service/lib/electric/telemetry/sampler.ex
+++ b/packages/sync-service/lib/electric/telemetry/sampler.ex
@@ -10,10 +10,10 @@ defmodule Electric.Telemetry.Sampler do
   """
 
   def include_span?("filter." <> _), do: Application.get_env(:electric, :profile_where_clauses?)
-  def include_span?("pg_txn.replication_client.transaction_received"), do: sample()
+  def include_span?("pg_txn.replication_client.transaction_received"), do: sample?()
   def include_span?(_), do: true
 
-  defp sample do
+  def sample? do
     :rand.uniform() <= Application.get_env(:electric, :otel_sampling_ratio, 0)
   end
 end

--- a/packages/sync-service/lib/electric/telemetry/sampler.ex
+++ b/packages/sync-service/lib/electric/telemetry/sampler.ex
@@ -10,8 +10,6 @@ defmodule Electric.Telemetry.Sampler do
   """
 
   def include_span?("filter." <> _), do: Application.get_env(:electric, :profile_where_clauses?)
-  def include_span?("pg_txn.replication_client.process_x_log_data"), do: false
-  def include_span?("pg_txn.replication_client.relation_received"), do: false
   def include_span?("pg_txn.replication_client.transaction_received"), do: sample()
   def include_span?(_), do: true
 

--- a/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
+++ b/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
@@ -2,9 +2,12 @@ defmodule Electric.Telemetry.OpenTelemetryTest do
   alias Electric.Telemetry.OpenTelemetry
 
   use ExUnit.Case
+  use Repatch.ExUnit
+
+  @stack_id "the_stack_id"
 
   test "baggage is propagated to new processes when the context is carried over" do
-    OpenTelemetry.with_span("test", %{}, "stack_id", fn ->
+    OpenTelemetry.with_span("test", %{}, @stack_id, fn ->
       OpenTelemetry.set_in_baggage("some_key", "some_value")
 
       context = OpenTelemetry.get_current_context()
@@ -16,5 +19,29 @@ defmodule Electric.Telemetry.OpenTelemetryTest do
       end)
       |> Task.await()
     end)
+  end
+
+  describe "with_child_span/4" do
+    test "creates a span if there is a parent span" do
+      OpenTelemetry.with_span("parent_span", %{}, @stack_id, fn ->
+        Repatch.spy(OpenTelemetry)
+
+        OpenTelemetry.with_child_span("child_span", %{}, @stack_id, fn ->
+          :some_code
+        end)
+
+        assert Repatch.called?(OpenTelemetry, :with_span, 4)
+      end)
+    end
+
+    test "does not create a span if there is not a parent span" do
+      Repatch.spy(OpenTelemetry)
+
+      OpenTelemetry.with_child_span("child_span", %{}, @stack_id, fn ->
+        :some_code
+      end)
+
+      refute Repatch.called?(OpenTelemetry, :with_span, 4)
+    end
   end
 end


### PR DESCRIPTION
<img width="875" height="334" alt="Screenshot 2025-07-29 at 15 01 56" src="https://github.com/user-attachments/assets/e8351cac-7163-43cf-ad92-3888ce4215ee" />

This PR speeds up replication processing by 65%. The above benchmarks were run via docker which slows them down a bit, without docker processing time came down to 23µs (43.5K TPS) which is about [as fast as Postgres can go](https://www.enterprisedb.com/blog/performance-comparison-major-PostgreSQL-versions) (on a 72 CPU  144 GB RAM machine)

The performance improvements come from:
- Bespoke upfront span sampling. Standard OpenTelemetry sampling acts once the spans have been created. This bespoke mechanism samples at source to reduce the overhead of `with_span` from 13µs to practically nothing.
- Transaction logging is now at debug level
- Transaction metrics are sampled at source
- The `pg_txn.replication_client.process_x_log_data` span which measured decoding duration and other durations before the transaction was formed has been replaced by attributes on the `pg_txn.replication_client.transaction_received` which not only includes decoding time, it has full granular interval timing for message collection time, time spent waiting for postgres, updateing the applied WAL, etc. 

These different changes can be seen separately in the rebased commits of this PR.