### PR TITLE
Do not run Electric Client CI on doc or readme changes

### DIFF
--- a/.github/workflows/elixir_client_tests.yml
+++ b/.github/workflows/elixir_client_tests.yml
@@ -3,7 +3,13 @@ name: Elixir Client CI
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "website/**"
+      - "**/README.md"
   pull_request:
+    paths-ignore:
+      - "website/**"
+      - "**/README.md"
 
 permissions:
   contents: read


### PR DESCRIPTION
Noticed this randomly while updating a doc page. Electric Client workflows were the only one running besides the netlify build.