### PR TITLE
feat: improve startup times for existing shapes

### DIFF
--- a/.changeset/big-elephants-kneel.md
+++ b/.changeset/big-elephants-kneel.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: improve startup time of Electric when a lot of shapes are present

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -34,6 +34,8 @@ defmodule Electric.Replication.Supervisor do
       )
 
     children = [
+      {Task.Supervisor,
+       name: Electric.ProcessRegistry.name(stack_id, Electric.StackTaskSupervisor)},
       consumer_supervisor,
       publication_manager,
       log_collector,

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -715,7 +715,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
     path = Path.join(metadata_dir, "shape_definition.json")
 
     with {:ok, contents} <- File.open(path, [:read, :raw, :read_ahead], &IO.binread(&1, :eof)),
-         {:ok, decoded} <- Jason.decode(contents),
+         {:ok, decoded} <- Jason.decode(if(is_binary(contents), do: contents, else: "")),
          {:ok, rebuilt} <- Shape.from_json_safe(decoded) do
       {:ok, rebuilt}
     end

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -20,6 +20,11 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
     Electric.ProcessRegistry.name(stack_id, __MODULE__, shape_handle)
   end
 
+  def start_snapshot(stack_id, shape_handle) do
+    # Low timeout because we expect the process to be present & the block to be short
+    GenServer.call(name(stack_id, shape_handle), :start_snapshot, 1_000)
+  end
+
   def start_link(config) do
     GenServer.start_link(__MODULE__, config, name: name(config))
   end
@@ -30,7 +35,11 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
     Logger.metadata(metadata)
     Electric.Telemetry.Sentry.set_tags_context(metadata)
 
-    {:ok, config, {:continue, :start_snapshot}}
+    {:ok, config}
+  end
+
+  def handle_call(:start_snapshot, _from, state) do
+    {:reply, :ok, state, {:continue, :start_snapshot}}
   end
 
   def handle_continue(:start_snapshot, state) do

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -88,8 +88,8 @@ defmodule Electric.Shapes.ConsumerSupervisor do
 
     children = [
       {Electric.ShapeCache.Storage, shape_storage},
-      {Electric.Shapes.Consumer, shape_config},
-      {Electric.Shapes.Consumer.Snapshotter, shape_config}
+      {Electric.Shapes.Consumer.Snapshotter, shape_config},
+      {Electric.Shapes.Consumer, shape_config}
     ]
 
     Supervisor.init(children, strategy: :one_for_one, auto_shutdown: :any_significant)

--- a/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
@@ -206,7 +206,13 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
         summary("electric.querying.stream_initial_data.stop.duration",
           unit: {:native, :millisecond},
           keep: for_stack(opts)
-        )
+        ),
+        last_value("electric.connection.consumers_ready.duration",
+          unit: {:native, :millisecond},
+          keep: for_stack(opts)
+        ),
+        last_value("electric.connection.consumers_ready.total", keep: for_stack(opts)),
+        last_value("electric.connection.consumers_ready.before_recovery", keep: for_stack(opts))
       ]
       |> Enum.map(&%{&1 | tags: [:instance_id | &1.tags]})
     end
@@ -225,7 +231,13 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
           keep: for_stack(opts)
         ),
         sum("electric.storage.transaction_stored.bytes", unit: :byte, keep: for_stack(opts)),
-        last_value("electric.shape_monitor.active_reader_count", keep: for_stack(opts))
+        last_value("electric.shape_monitor.active_reader_count", keep: for_stack(opts)),
+        last_value("electric.connection.consumers_ready.duration",
+          unit: {:native, :millisecond},
+          keep: for_stack(opts)
+        ),
+        last_value("electric.connection.consumers_ready.total", keep: for_stack(opts)),
+        last_value("electric.connection.consumers_ready.failed_to_recover", keep: for_stack(opts))
       ]
     end
 
@@ -234,6 +246,7 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
 
       [
         distribution("electric.plug.serve_shape.duration",
+          unit: {:native, :millisecond},
           keep: &(&1[:live] != true && for_stack.(&1))
         ),
         distribution("electric.shape_cache.create_snapshot_task.stop.duration",

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1235,7 +1235,8 @@ defmodule Electric.ShapeCacheTest do
       for name <- [
             ctx.shape_cache_opts[:server],
             ctx.consumer_supervisor,
-            ctx.shape_log_collector
+            ctx.shape_log_collector,
+            "shape_task_supervisor"
           ] do
         stop_supervised(name)
       end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -818,6 +818,8 @@ defmodule Electric.Shapes.ConsumerTest do
       stop_supervised!(shape_cache_opts[:server])
       assert_receive {:DOWN, ^ref, :process, _pid, _reason}, 1000
 
+      stop_supervised!("shape_task_supervisor")
+
       # Restart the shape cache and the consumers
       Support.ComponentSetup.with_shape_cache(
         Map.merge(ctx, %{

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -146,6 +146,12 @@ defmodule Support.ComponentSetup do
     server = :"shape_cache_#{full_test_name(ctx)}"
     consumer_supervisor = :"consumer_supervisor_#{full_test_name(ctx)}"
 
+    start_link_supervised!(
+      {Task.Supervisor,
+       name: Electric.ProcessRegistry.name(ctx.stack_id, Electric.StackTaskSupervisor)}
+      |> Supervisor.child_spec(id: "shape_task_supervisor")
+    )
+
     start_opts =
       [
         name: server,


### PR DESCRIPTION
Closes #2928

Init goes from ~17s to ~7s on MacBook M4 for 10000 shapes. I'll open a follow-up PR with further improvements, but this is big on it's own