### PR TITLE
chore: Make Sentry logger handler ID configurable

### DIFF
--- a/.changeset/gorgeous-badgers-press.md
+++ b/.changeset/gorgeous-badgers-press.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Make Sentry logger handler ID configurable.

--- a/packages/sync-service/lib/electric/telemetry/sentry.ex
+++ b/packages/sync-service/lib/electric/telemetry/sentry.ex
@@ -1,14 +1,19 @@
 defmodule Electric.Telemetry.Sentry do
   use Electric.Telemetry
 
+  @default_handler_id :electric_sentry_handler
+
+  @spec add_logger_handler(atom()) :: :ok | {:error, term()}
+  def add_logger_handler(id \\ @default_handler_id)
+
   with_telemetry Sentry.LoggerHandler do
-    def add_logger_handler do
-      :logger.add_handler(:electric_sentry_handler, Sentry.LoggerHandler, %{
+    def add_logger_handler(id \\ @default_handler_id) do
+      :logger.add_handler(id, Sentry.LoggerHandler, %{
         config: %{metadata: :all, capture_log_messages: true, level: :error}
       })
     end
   else
-    def add_logger_handler, do: :ok
+    def add_logger_handler(_id), do: :ok
   end
 
   @spec set_tags_context(keyword()) :: :ok


### PR DESCRIPTION
Makes Sentry logger handler ID configurable - came up as a need for Cloud so filters can be attached safely to the handler