### PR TITLE
fix: Ensure system load measurement uses valid number of cores

### DIFF
--- a/.changeset/rich-apes-agree.md
+++ b/.changeset/rich-apes-agree.md
@@ -1,5 +1,0 @@
----
-"@core/sync-service": patch
----
-
-Fix system load measurement arithmetic issues


### PR DESCRIPTION
The return type of `:erlang.system_info(:logical_processors)` is `:unknown | pos_integer()`, but our guard was only checking `cores > 0`, but because of Elixir's term ordering, `:unknown > 0` is `true` 👀

Added an explicit number check

edit: removed changeset, keeping existing one from previous PR we haven't released yet