### PR TITLE
Add a "bailout" clause to maybe_client_exit_error()

### DIFF
--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -403,11 +403,7 @@ defmodule Electric.DbConnectionError do
   end
 
   defp maybe_client_exit_error(
-         %DBConnection.ConnectionError{
-           message: message,
-           severity: :info,
-           reason: :error
-         } = error
+         %DBConnection.ConnectionError{message: message, severity: :info, reason: :error} = error
        ) do
     if Regex.match?(
          ~r/^client #PID<\d+.\d+.\d+> exited$/,
@@ -421,4 +417,6 @@ defmodule Electric.DbConnectionError do
       }
     end
   end
+
+  defp maybe_client_exit_error(_), do: nil
 end

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -318,5 +318,21 @@ defmodule Electric.DbConnectionErrorTest do
                retry_may_fix?: false
              } == DbConnectionError.from_error(error)
     end
+
+    test "with an unknown error" do
+      error = %DBConnection.ConnectionError{
+        message: "made-up error",
+        severity: :error,
+        reason: :error
+      }
+
+      assert %DbConnectionError{
+               type: :unknown,
+               message:
+                 "%DBConnection.ConnectionError{message: \"made-up error\", severity: :error, reason: :error}",
+               original_error: error,
+               retry_may_fix?: true
+             } == DbConnectionError.from_error(error)
+    end
   end
 end


### PR DESCRIPTION
The new helper function `maybe_client_exit_error()` introduced in https://github.com/electric-sql/electric/pull/2941/commits/e9143da06953e0a803e61c314944f20ab9c19153 crashes with a FunctionClauseError when called with an unknown error. It should instead return `nil` to let the caller properly handle the unknown error.