### PR TITLE
fix: Add health endpoints to yjs and write patterns examples

### DIFF
--- a/examples/write-patterns/shared/backend/api.js
+++ b/examples/write-patterns/shared/backend/api.js
@@ -178,6 +178,10 @@ app.post('/changes', async (req, res) => {
   return res.status(200).json({ status: 'OK' })
 })
 
+app.get('/health', (_req, res) => {
+  return res.sendStatus(200)
+})
+
 // Start the server
 app.listen(PORT, () => {
   console.log(`Server listening at port ${PORT}`)

--- a/examples/write-patterns/sst.config.ts
+++ b/examples/write-patterns/sst.config.ts
@@ -39,6 +39,11 @@ export default $config({
     const service = cluster.addService(`write-patterns-${$app.stage}-service`, {
       loadBalancer: {
         ports: [{ listen: '443/https', forward: '3001/http' }],
+        health: {
+          '3001/http': {
+            path: '/health',
+          },
+        },
         domain: {
           name: `write-patterns-backend${
             isProduction() ? '' : `-stage-${$app.stage}`

--- a/examples/yjs/src/server/server.ts
+++ b/examples/yjs/src/server/server.ts
@@ -171,6 +171,10 @@ app.get(`/shape-proxy/v1/shape`, async (c: Context) => {
   }
 })
 
+app.get(`/health`, (c: Context) => {
+  return c.body(null, 200)
+})
+
 // Start the server
 const port = process.env.PORT ? parseInt(process.env.PORT) : 3002
 console.log(`Server is running on port ${port}`)

--- a/examples/yjs/sst.config.ts
+++ b/examples/yjs/sst.config.ts
@@ -36,6 +36,11 @@ export default $config({
     const service = cluster.addService(`yjs-${$app.stage}-service`, {
       loadBalancer: {
         ports: [{ listen: `443/https`, forward: `3002/http` }],
+        health: {
+          "3002/http": {
+            path: "/health",
+          },
+        },
         domain: {
           name: `yjs-server${isProduction() ? `` : `-${$app.stage}`}.examples.electric-sql.com`,
           dns: sst.cloudflare.dns(),


### PR DESCRIPTION
The yjs and write patterns examples were not deploying properly because the `/health` endpoint was missing from the backend API and thus the ECS health checks would fail and force a roll back after failing for a certain amount of time.