### PR TITLE
feat: Monitor pooled connections fully and handle failures gracefully

### DIFF
--- a/.changeset/tidy-elephants-boil.md
+++ b/.changeset/tidy-elephants-boil.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fully monitor pool connections and gracefully handle failures.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -62,7 +62,8 @@ defmodule Electric.Connection.Manager do
             | {:start_replication_client, nil}
             | {:start_replication_client, :connecting}
             | {:start_replication_client, :configuring_connection}
-            | :start_connection_pool
+            | {:start_connection_pool, nil}
+            | {:start_connection_pool, :connecting}
             | :start_shapes_supervisor
             | {:waiting_for_consumers, integer()}
             | {:start_replication_client, :start_streaming}
@@ -88,8 +89,6 @@ defmodule Electric.Connection.Manager do
       :shared_connection_opts,
       # Database connection pool options
       :pool_opts,
-      # Unique ref for matching on :connected and :disconnected events the connection pool
-      :pool_ref,
       # Options specific to `Electric.Timeline`
       :timeline_opts,
       # Options passed to the Replication.Supervisor's start_link() function
@@ -127,6 +126,9 @@ defmodule Electric.Connection.Manager do
       drop_slot_requested: false
     ]
   end
+
+  defguardp is_connection_process_pid(pid, state)
+            when pid in [state.lock_connection_pid, state.replication_client_pid, state.pool_pid]
 
   use GenServer, shutdown: :infinity
   alias Electric.Connection.Manager.ConnectionBackoff
@@ -230,6 +232,10 @@ defmodule Electric.Connection.Manager do
     GenServer.cast(manager, {:pg_info_obtained, pg_info})
   end
 
+  def connection_pool_ready(manager) do
+    GenServer.cast(manager, :connection_pool_ready)
+  end
+
   # Used for testing the responsiveness of the manager process
   def ping(manager, timeout \\ 1000) do
     GenServer.call(manager, :ping, timeout)
@@ -255,7 +261,6 @@ defmodule Electric.Connection.Manager do
         current_phase: :connection_setup,
         current_step: {:start_lock_connection, nil},
         pool_opts: pool_opts,
-        pool_ref: make_ref(),
         timeline_opts: timeline_opts,
         shape_cache_opts: shape_cache_opts,
         connection_backoff: {ConnectionBackoff.init(1000, 10_000), nil},
@@ -379,44 +384,22 @@ defmodule Electric.Connection.Manager do
         :start_connection_pool,
         %State{
           current_phase: :connection_setup,
-          current_step: :start_connection_pool,
+          current_step: {:start_connection_pool, _},
           pool_pid: nil
         } = state
       ) do
-    pool_size = Keyword.get(state.pool_opts, :pool_size, 2)
     conn_opts = pooled_connection_opts(state) |> Electric.Utils.deobfuscate_password()
 
-    pool_config =
-      [
-        # Disable automatic reconnection for pooled connections making them terminate on
-        # error. This lets us observe connection errors by configuring the current process
-        # as a connection listener in the pool.
-        # The value for `max_restarts` is based on the pool size so the pool supervisor
-        # doesn't shutdown unless all pooled connections fall into a restart loop within
-        # the 5 second grace interval.
-        backoff_type: :stop,
-        max_restarts: pool_size * 3,
-        max_seconds: 5,
-        connection_listeners: {[self()], state.pool_ref},
-        # Assume the manager connection might be pooled, so use unnamed prepared
-        # statements to avoid issues with the pooler
-        #
-        # See https://hexdocs.pm/postgrex/0.19.3/readme.html#pgbouncer
-        prepare: :unnamed
-      ]
-
     {:ok, pool_pid} =
-      Postgrex.start_link(pool_config ++ state.pool_opts ++ conn_opts)
+      Electric.Connection.Manager.Pool.start_link(
+        stack_id: state.stack_id,
+        connection_manager: self(),
+        pool_opts: state.pool_opts,
+        conn_opts: conn_opts
+      )
 
-    # NOTE(alco): We're jumping ahead of ourselves here a bit because at this point we don't
-    # yet have a confirmation that the connection pool has succeeded in opening a database
-    # connection. But since we already have a lock connection and a replication connection
-    # open, it's likely the connection pool will also succeed.
-    Electric.StatusMonitor.mark_connection_pool_ready(state.stack_id, pool_pid)
-    state = mark_connection_succeeded(state)
-
-    state = %{state | pool_pid: pool_pid, current_step: :start_shapes_supervisor}
-    {:noreply, state, {:continue, :start_shapes_supervisor}}
+    state = %{state | pool_pid: pool_pid, current_step: {:start_connection_pool, :connecting}}
+    {:noreply, state}
   end
 
   def handle_continue(
@@ -599,7 +582,8 @@ defmodule Electric.Connection.Manager do
   def handle_info({:EXIT, _, :shutdown}, state), do: {:noreply, state}
 
   # A process exited as it was trying to open a database connection.
-  def handle_info({:EXIT, pid, reason}, %State{current_phase: :connection_setup} = state) do
+  def handle_info({:EXIT, pid, reason}, %State{current_phase: :connection_setup} = state)
+      when is_connection_process_pid(pid, state) do
     # Try repairing the connection opts and try connecting again. If we're already using noSSL
     # and IPv4, the error will be propagated to a `shutdown_or_reconnect()` function call
     # further down below.
@@ -659,7 +643,7 @@ defmodule Electric.Connection.Manager do
   # The most likely reason for any database connection to get closed after we've already opened a
   # bunch of them is the database server going offline or shutting down. Stop
   # Connection.Manager to allow its supervisor to restart it in the initial state.
-  def handle_info({:EXIT, pid, reason}, state) do
+  def handle_info({:EXIT, pid, reason}, state) when is_connection_process_pid(pid, state) do
     error =
       reason
       |> strip_exit_signal_stacktrace()
@@ -682,6 +666,35 @@ defmodule Electric.Connection.Manager do
     )
 
     {:stop, {:shutdown, reason}, state}
+  end
+
+  # When a pooled connection terminates, we log its exit reason, but more connections will
+  # be started by the connection pool supervisor, so we don't need to do anything else.
+  def handle_info({:EXIT, pid, reason}, state) do
+    if not Map.has_key?(state.pool_connection_pids, pid) do
+      raise RuntimeError,
+            "Unexpected exit of a process #{inspect(pid)} with reason #{inspect(reason)}."
+    end
+
+    Logger.debug("Pooled connection #{inspect(pid)} exited with reason: #{inspect(reason)}")
+
+    reason =
+      case reason do
+        {:shutdown, reason} -> reason
+        reason -> reason
+      end
+
+    error = DbConnectionError.from_error(reason)
+
+    # If the error is of an unknown type, it would have already been logged by DbConnectionError itself.
+    if error.type != :unknown do
+      Logger.warning(
+        "Pooled database connection encountered an error: " <>
+          DbConnectionError.format_original_error(error)
+      )
+    end
+
+    {:noreply, %{state | pool_connection_pids: Map.delete(state.pool_connection_pids, pid)}}
   end
 
   def handle_info(
@@ -713,38 +726,6 @@ defmodule Electric.Connection.Manager do
     end
 
     {:noreply, %{state | shape_log_collector_pid: nil, replication_client_pid: nil}}
-  end
-
-  # The following two messages are sent by the DBConnection library because we've configured
-  # the connection manager process as connection listener for the DB connection pool.
-  def handle_info({:connected, conn_pid, ref}, %State{pool_ref: ref} = state) do
-    Process.monitor(conn_pid, tag: :pool_conn_down)
-    {:noreply, state}
-  end
-
-  def handle_info({:disconnected, _pid, ref}, %State{pool_ref: ref} = state) do
-    {:noreply, state}
-  end
-
-  # When a pooled connection terminates, we log its exit reason, but more connections will
-  # be started by the connection pool supervisor, so we don't need to do anything else.
-  def handle_info({:pool_conn_down, _ref, :process, _pid, reason}, state)
-      when reason in [:shutdown, :noproc] do
-    {:noreply, state}
-  end
-
-  def handle_info({:pool_conn_down, _ref, :process, _pid, {:shutdown, exit_reason}}, state) do
-    error = DbConnectionError.from_error(exit_reason)
-
-    # If the error is of an unknown type, it would have already been logged by DbConnectionError itself.
-    if error.type != :unknown do
-      Logger.warning(
-        "Pooled database connection encountered an error: " <>
-          DbConnectionError.format_original_error(error)
-      )
-    end
-
-    {:noreply, state}
   end
 
   @impl true
@@ -871,7 +852,7 @@ defmodule Electric.Connection.Manager do
         # This is the case where Connection.Manager starts connections from the initial state.
         # Replication connection is opened after the lock connection has acquired the
         # exclusive lock. Now it's time to start the connection pool.
-        state = %{state | current_step: :start_connection_pool}
+        state = %{state | current_step: {:start_connection_pool, nil}}
         {:noreply, state, {:continue, :start_connection_pool}}
 
       :restarting_replication_client ->
@@ -882,6 +863,21 @@ defmodule Electric.Connection.Manager do
         state = %{state | current_step: {:start_replication_client, :start_streaming}}
         {:noreply, state, {:continue, :start_streaming}}
     end
+  end
+
+  def handle_cast(
+        :connection_pool_ready,
+        %State{
+          pool_pid: pool_pid,
+          current_phase: :connection_setup,
+          current_step: {:start_connection_pool, :connecting}
+        } = state
+      ) do
+    Electric.StatusMonitor.mark_connection_pool_ready(state.stack_id, pool_pid)
+    state = mark_connection_succeeded(state)
+
+    {:noreply, %{state | current_step: :start_shapes_supervisor},
+     {:continue, :start_shapes_supervisor}}
   end
 
   def handle_cast(
@@ -903,7 +899,7 @@ defmodule Electric.Connection.Manager do
       %{stack_id: state.stack_id}
     )
 
-    state = %State{state | current_step: {:start_replication_client, :start_streaming}}
+    state = %{state | current_step: {:start_replication_client, :start_streaming}}
     {:noreply, state, {:continue, :start_streaming}}
   end
 

--- a/packages/sync-service/lib/electric/connection/manager/pool.ex
+++ b/packages/sync-service/lib/electric/connection/manager/pool.ex
@@ -1,0 +1,226 @@
+defmodule Electric.Connection.Manager.Pool do
+  @moduledoc """
+  A connection pool for managing multiple connections to a PostgreSQL database.
+  """
+
+  use GenServer
+  require Logger
+  alias Electric.DbConnectionError
+
+  @type pool_status :: :starting | :ready | :repopulating
+
+  @type connection_status :: :starting | :connected | :disconnected
+
+  @type t :: %__MODULE__{
+          stack_id: Electric.stack_id(),
+          pool_ref: reference(),
+          pool_pid: pid(),
+          pool_size: non_neg_integer(),
+          connection_manager: GenServer.server(),
+          status: pool_status(),
+          connection_pids: %{pid() => connection_status()}
+        }
+
+  defstruct [
+    :stack_id,
+    :pool_ref,
+    :pool_pid,
+    :pool_size,
+    :connection_manager,
+    status: :starting,
+    connection_pids: %{}
+  ]
+
+  def name(stack_id) when not is_map(stack_id) and not is_list(stack_id) do
+    Electric.ProcessRegistry.name(stack_id, __MODULE__)
+  end
+
+  def name(opts) do
+    name(Access.fetch!(opts, :stack_id))
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: name(opts))
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    Process.set_label({:connection_pool, opts[:stack_id]})
+    Logger.metadata(stack_id: opts[:stack_id])
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
+
+    pool_opts = Access.fetch!(opts, :pool_opts)
+    conn_opts = Access.fetch!(opts, :conn_opts)
+
+    pool_ref = make_ref()
+
+    pool_size = Keyword.get(pool_opts, :pool_size, 2)
+
+    pool_config =
+      [
+        # Disable automatic reconnection for pooled connections making them terminate on
+        # error. This lets us observe connection errors by configuring the current process
+        # as a connection listener in the pool.
+        # The value for `max_restarts` is based on the pool size so the pool supervisor
+        # doesn't shutdown unless all pooled connections fall into a restart loop within
+        # the 5 second grace interval.
+        backoff_type: :stop,
+        max_restarts: pool_size * 3,
+        max_seconds: 5,
+        configure: {__MODULE__, :configure_pool_conn, [self()]},
+        connection_listeners: {[self()], pool_ref},
+        # Assume the manager connection might be pooled, so use unnamed prepared
+        # statements to avoid issues with the pooler
+        #
+        # See https://hexdocs.pm/postgrex/0.19.3/readme.html#pgbouncer
+        prepare: :unnamed
+      ]
+
+    {:ok, pool_pid} =
+      Postgrex.start_link(pool_config ++ pool_opts ++ conn_opts)
+
+    state = %__MODULE__{
+      stack_id: Access.fetch!(opts, :stack_id),
+      pool_ref: pool_ref,
+      pool_pid: pool_pid,
+      pool_size: pool_size,
+      connection_manager: Access.fetch!(opts, :connection_manager)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_continue(:update_pool_status, state) do
+    pool_is_ready = num_connected(state) >= state.pool_size
+
+    case {state.status, pool_is_ready} do
+      {:starting, true} ->
+        Logger.info("Connection pool is ready with #{state.pool_size} connections")
+        notify_connection_pool_ready(state)
+        {:noreply, %{state | status: :ready}}
+
+      {:repopulating, true} ->
+        Logger.debug("Connection pool fully repopulated with #{state.pool_size} connections")
+        {:noreply, %{state | status: :ready}}
+
+      {:ready, false} ->
+        Logger.debug("Connection pool no longer fully populated, waiting for more connections")
+        {:noreply, %{state | status: :repopulating}}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info({:pool_conn_started, pid}, state) do
+    # The connection pool has started a new connection, so we need to remember it.
+    Logger.debug("Pooled connection #{inspect(pid)} started")
+
+    {
+      :noreply,
+      %{state | connection_pids: Map.put(state.connection_pids, pid, :starting)}
+    }
+  end
+
+  # The following two messages are sent by the DBConnection library because we've configured
+  # the connection manager process as connection listener for the DB connection pool.
+  def handle_info({:connected, pid, ref}, %{pool_ref: ref} = state) do
+    Logger.debug("Pooled connection #{inspect(pid)} connected")
+
+    {
+      :noreply,
+      %{state | connection_pids: Map.put(state.connection_pids, pid, :connected)},
+      {:continue, :update_pool_status}
+    }
+  end
+
+  def handle_info({:disconnected, pid, ref}, %{pool_ref: ref} = state) do
+    Logger.debug("Pooled connection #{inspect(pid)} disconnected")
+
+    {
+      :noreply,
+      %{state | connection_pids: Map.put(state.connection_pids, pid, :disconnected)},
+      {:continue, :update_pool_status}
+    }
+  end
+
+  # Special-case the explicit shutdown of the supervision tree.
+  def handle_info({:EXIT, _, :shutdown}, state), do: {:noreply, state}
+
+  # Special-case the :killed exit of the pool process, which would occur if the pool connection
+  # supervisor reaches its max restarts within the grace period, indicating that the pool could
+  # not set up the specified number of connections.
+  def handle_info({:EXIT, pid, :killed}, %{pool_pid: pid, status: status} = state)
+      when status in [:starting, :repopulating] do
+    # TODO(msfstef): we should potentially keep track of the reasons pool connections are
+    # failing and propagate one of those instead, as it will be more informative on how they
+    # can be actioned (e.g. if max_connections is too low)
+    {
+      :stop,
+      %DbConnectionError{
+        message: "Connection pool was unable to fill up with healthy connections.",
+        type: :connection_pool_failed_to_populate,
+        original_error: :killed,
+        retry_may_fix?: true
+      },
+      state
+    }
+  end
+
+  def handle_info({:EXIT, pid, reason}, %{pool_pid: pid} = state) do
+    {:stop, reason, state}
+  end
+
+  def handle_info({:EXIT, pid, reason}, state) do
+    if not Map.has_key?(state.connection_pids, pid) do
+      raise RuntimeError, "Received EXIT for unknown process #{inspect(pid)}: #{inspect(reason)}"
+    end
+
+    Logger.debug("Pooled connection #{inspect(pid)} exited with reason: #{inspect(reason)}")
+
+    if reason not in [:killed, :shutdown] do
+      error =
+        case reason do
+          {:shutdown, error} -> error
+          error -> error
+        end
+        |> DbConnectionError.from_error()
+
+      # If the error is of an unknown type, it would have already been logged by DbConnectionError itself.
+      if error.type != :unknown do
+        Logger.warning(
+          "Pooled database connection encountered an error: " <>
+            DbConnectionError.format_original_error(error)
+        )
+      end
+    end
+
+    {
+      :noreply,
+      %{state | connection_pids: Map.delete(state.connection_pids, pid)},
+      {:continue, :update_pool_status}
+    }
+  end
+
+  # We call this before configuring pool connections in order to fully monitor them
+  # and log any issues before and after the connection is established.
+  def configure_pool_conn(opts, supervisor_pid) do
+    send(supervisor_pid, {:pool_conn_started, self()})
+    Process.link(supervisor_pid)
+    opts
+  end
+
+  @spec num_connected(t()) :: non_neg_integer()
+  defp num_connected(%__MODULE__{connection_pids: connection_pids}) do
+    connection_pids
+    |> Enum.count(fn {_pid, status} -> status == :connected end)
+  end
+
+  defp notify_connection_pool_ready(%__MODULE__{connection_manager: manager}) do
+    Electric.Connection.Manager.connection_pool_ready(manager)
+  end
+end

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -11,7 +11,7 @@ defmodule Electric.DbConnectionError do
 
   alias Electric.DbConnectionError
 
-  def from_error(%DbConnectionError{} = err), do: err
+  def from_error(%DbConnectionError{} = error), do: error
 
   def from_error(%DBConnection.ConnectionError{message: message} = error)
       when message in [


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/2967

After some extensive research with @alco on why we were seeing `:killed` messages from the connection pool, we found that it was due to the pool connections failing to connect (see linked issue description).

I started working entirely within ConnMan but was disgusted at how monolithic it was becoming so I decided to split the pool logic out to its own process.

The `Pool` process now handles the actual DbConnection pool, monitors the pool connections fully by linking them with the "supervisor" process and doing some bookkeeping.

I keep track of the most recent pool connection error and return that in case the entire pool dies - this piece of logic can and should become more fleshed out (perhaps track errors with a timeout?) but I find it to be _much_ better than what we currently do and it does the trick.

You can reproduce the problem described in the issue by setting PG's `max_connections` to something lower than 20, which makes the pool unable to become healthy and thus fail with a `:killed` message.

Through this change, ConnMan now also waits for all the pool connections to become healthy, and it also handles restarts of the pool with a backoff, and along with the reporting of the individual pool connection errors this should sort out Cloud reporting as well.

I intend to add an integration test as well for the case where we run out of connections and encounter this, but ran out of time. Happy for someone else to do that or for me to pick this back up when I'm back.