### PR TITLE
fix(electric-client): Properly translate error responses  returned by the validation step

### DIFF
--- a/.changeset/rare-taxis-end.md
+++ b/.changeset/rare-taxis-end.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Translate error responses from Api.validate/2 to the expected form in the embedded client

--- a/packages/elixir-client/lib/electric/client/embedded.ex
+++ b/packages/elixir-client/lib/electric/client/embedded.ex
@@ -33,9 +33,13 @@ if Code.ensure_loaded?(Electric.Shapes.Api) do
 
       timestamp = DateTime.utc_now()
 
-      with {:ok, request} <- Api.validate(api, request_to_params(request)),
-           %Api.Response{} = response = Api.serve_shape_log(request) do
-        {:ok, translate_response(response, timestamp)}
+      case Api.validate(api, request_to_params(request)) do
+        {:ok, request} ->
+          %Api.Response{} = response = Api.serve_shape_log(request)
+          {:ok, translate_response(response, timestamp)}
+
+        {:error, response} ->
+          {:error, translate_response(response, timestamp)}
       end
     end
 


### PR DESCRIPTION

e.g. a 409 response returned by `Api.validate/2` needs to be mapped to a client response with the same status