### PR TITLE
feat(sync-service): Sample metrics with separate env var

### DIFF
--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -191,6 +191,7 @@ config :electric,
   otel_export_period: otel_export_period,
   otel_per_process_metrics?: env!("ELECTRIC_OTEL_PER_PROCESS_METRICS", :boolean, nil),
   otel_sampling_ratio: env!("ELECTRIC_OTEL_SAMPLING_RATIO", :float, nil),
+  metrics_sampling_ratio: env!("ELECTRIC_METRICS_SAMPLING_RATIO", :float, nil),
   telemetry_top_process_count: env!("ELECTRIC_TELEMETRY_TOP_PROCESS_COUNT", :integer, nil),
   telemetry_long_gc_threshold: env!("ELECTRIC_TELEMETRY_LONG_GC_THRESHOLD", :integer, nil),
   telemetry_long_schedule_threshold:

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -73,6 +73,7 @@ defmodule Electric.Config do
     otel_export_period: :timer.seconds(30),
     otel_per_process_metrics?: false,
     otel_sampling_ratio: 0.01,
+    metrics_sampling_ratio: 1,
     telemetry_top_process_count: 5,
     telemetry_long_gc_threshold: 500,
     telemetry_long_schedule_threshold: 500,

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -336,7 +336,7 @@ defmodule Electric.Postgres.ReplicationClient do
 
         OpenTelemetry.start_interval("replication_client.telemetry_execute")
 
-        if Sampler.sample?() do
+        if Sampler.sample_metrics?() do
           :telemetry.execute(
             [:electric, :postgres, :replication, :transaction_received],
             %{

--- a/packages/sync-service/lib/electric/telemetry/sampler.ex
+++ b/packages/sync-service/lib/electric/telemetry/sampler.ex
@@ -13,7 +13,11 @@ defmodule Electric.Telemetry.Sampler do
   def include_span?("pg_txn.replication_client.transaction_received"), do: sample?()
   def include_span?(_), do: true
 
-  def sample? do
+  defp sample? do
     :rand.uniform() <= Electric.Config.get_env(:otel_sampling_ratio)
+  end
+
+  def sample_metrics? do
+    :rand.uniform() <= Electric.Config.get_env(:metrics_sampling_ratio)
   end
 end


### PR DESCRIPTION
Although sampling transaction metrics improves replication processing speed by 10%, @icehaunter [has questioned](https://github.com/electric-sql/stratovolt/issues/742#issuecomment-3173968555) whether the 5µs it saves per transaction is really worth the extra complexity of reading sampled metrics. This PR keeps the ability to sample metrics (set the ENV VAR `ELECTRIC_METRICS_SAMPLING_RATIO=0.01`) for power users but defaults to `ELECTRIC_METRICS_SAMPLING_RATIO=1` (i.e. 100% of metrics are kept, no sampling) for the average user and for our cloud service at this time.  