### PR TITLE
fix(sync-service): Log warning rather than error if the shape cleanup tasks time out

### DIFF
--- a/.changeset/big-tigers-perform.md
+++ b/.changeset/big-tigers-perform.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Log warning rarther than error if the shape cleanup tasks time out

--- a/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
@@ -61,6 +61,13 @@ defmodule Electric.Shapes.Monitor.CleanupTaskSupervisor do
           try do
             [task1, task2, task3]
             |> Task.await_many(@cleanup_timeout)
+          catch
+            :exit, {:timeout, _} ->
+              Logger.warning(
+                "Shape cleanup tasks for shape #{shape_handle} timed out after #{@cleanup_timeout}ms"
+              )
+
+              :ok
           after
             on_cleanup.(shape_handle)
           end


### PR DESCRIPTION
Closes #2986