### PR TITLE
fix: Parse more password auth DB connection errors

### DIFF
--- a/.changeset/wicked-needles-worry.md
+++ b/.changeset/wicked-needles-worry.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Parse more password authentication DB connection errors

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -222,6 +222,7 @@ defmodule Electric.DbConnectionError do
       maybe_endpoint_does_not_exist(error) ||
       maybe_compute_quota_exceeded(error) ||
       maybe_data_transfer_quota_exceeded(error) ||
+      maybe_password_authentication_failed(error) ||
       unknown_error(error)
   end
 
@@ -334,6 +335,17 @@ defmodule Electric.DbConnectionError do
 
       _ ->
         nil
+    end
+  end
+
+  defp maybe_password_authentication_failed(error) do
+    if Regex.match?(~r/^password authentication failed for user '.*'$/, error.postgres.message) do
+      %DbConnectionError{
+        message: error.postgres.message,
+        type: :invalid_username_or_password,
+        original_error: error,
+        retry_may_fix?: false
+      }
     end
   end
 

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -29,6 +29,27 @@ defmodule Electric.DbConnectionErrorTest do
              } == DbConnectionError.from_error(error)
     end
 
+    test "with an invalid username or password error (internal)" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :internal_error,
+          message: "password authentication failed for user 'foo'",
+          severity: "ERROR",
+          pg_code: "XX000"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message: ~s|password authentication failed for user 'foo'|,
+               type: :invalid_username_or_password,
+               original_error: error,
+               retry_may_fix?: false
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with database does not exist error" do
       error = %Postgrex.Error{
         message: nil,


### PR DESCRIPTION
Fixes [Sentry issue](https://electricsql-04.sentry.io/issues/56533704/)