### PR TITLE
fix: Parse more TCP DB connection timeouts

### DIFF
--- a/.changeset/sour-birds-refuse.md
+++ b/.changeset/sour-birds-refuse.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Parse more TCP DB connection timeout errors

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -37,6 +37,8 @@ defmodule Electric.DbConnectionError do
              "tcp recv: connection timed out - :etimedout",
              "tcp recv (idle): timeout",
              "ssl recv (idle): timeout",
+             "ssl async_recv: timeout",
+             "tcp async_recv: timeout",
              "tcp recv: timeout",
              "ssl recv: timeout"
            ] do

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -187,6 +187,8 @@ defmodule Electric.DbConnectionErrorTest do
       for message <- [
             "tcp recv: connection timed out - :etimedout",
             "ssl recv (idle): timeout",
+            "ssl async_recv: timeout",
+            "tcp async_recv: timeout",
             "tcp recv: timeout"
           ] do
         error = %DBConnection.ConnectionError{


### PR DESCRIPTION
Fix [Sentry issue](https://electricsql-04.sentry.io/issues/57252512/?alert_rule_id=130196&alert_timestamp=1755099876302&alert_type=email&environment=production&notification_uuid=44978dc1-d68b-4388-a457-09477027c97d&project=4508410462404688&referrer=alert_email)