### PR TITLE
add an `enabled` option to `useShape` hook that allows conditionally disabling shape synchronization

### DIFF
--- a/.changeset/add-enabled-option-to-useshape.md
+++ b/.changeset/add-enabled-option-to-useshape.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/react": minor
+---
+
+Add `enabled` option to `useShape` hook that allows conditionally disabling shape synchronization. When `enabled` is `false`, the hook returns an empty array as data and skips creating the underlying shape. The return type is now a discriminating union with an `isEnabled` flag, providing full type safety while maintaining backwards compatibility.

--- a/packages/react-hooks/test/react-hooks.test-d.ts
+++ b/packages/react-hooks/test/react-hooks.test-d.ts
@@ -1,5 +1,10 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { useShape, UseShapeResult } from '../src/react-hooks'
+import {
+  useShape,
+  UseShapeResult,
+  UseShapeResultEnabled,
+  UseShapeResultDisabled,
+} from '../src/react-hooks'
 import { Row } from 'packages/typescript-client/dist'
 
 describe(`useShape`, () => {
@@ -11,7 +16,7 @@ describe(`useShape`, () => {
       url: ``,
     })
 
-    expectTypeOf(shape).toEqualTypeOf<UseShapeResult>()
+    expectTypeOf(shape).toEqualTypeOf<UseShapeResultEnabled>()
   })
 
   type SelectorRetType = {
@@ -58,6 +63,77 @@ describe(`useShape`, () => {
     })
 
     // Return type is based on the type argument
+    expectTypeOf(shape).toEqualTypeOf<number>()
+  })
+
+  it(`should return UseShapeResultEnabled when enabled is true or undefined`, () => {
+    const shape1 = useShape({
+      params: {
+        table: ``,
+      },
+      url: ``,
+      enabled: true,
+    })
+
+    const shape2 = useShape({
+      params: {
+        table: ``,
+      },
+      url: ``,
+      // enabled is undefined (default)
+    })
+
+    expectTypeOf(shape1).toEqualTypeOf<UseShapeResultEnabled>()
+    expectTypeOf(shape2).toEqualTypeOf<UseShapeResultEnabled>()
+  })
+
+  it(`should return UseShapeResultDisabled when enabled is false`, () => {
+    const shape = useShape({
+      params: {
+        table: ``,
+      },
+      url: ``,
+      enabled: false,
+    })
+
+    expectTypeOf(shape).toEqualTypeOf<UseShapeResultDisabled>()
+  })
+
+  it(`should maintain backwards compatibility when no enabled option is provided`, () => {
+    const shape = useShape({
+      params: {
+        table: ``,
+      },
+      url: ``,
+    })
+
+    // Should return UseShapeResult for backwards compatibility
+    expectTypeOf(shape).toEqualTypeOf<UseShapeResultEnabled>()
+  })
+
+  it(`should work with selector when enabled is false`, () => {
+    const shape = useShape({
+      params: {
+        table: ``,
+      },
+      url: ``,
+      enabled: false,
+      selector: (result) => result.data.length,
+    })
+
+    expectTypeOf(shape).toEqualTypeOf<number>()
+  })
+
+  it(`should work with selector when enabled is true`, () => {
+    const shape = useShape({
+      params: {
+        table: ``,
+      },
+      url: ``,
+      enabled: true,
+      selector: (result) => result.data.length,
+    })
+
     expectTypeOf(shape).toEqualTypeOf<number>()
   })
 })


### PR DESCRIPTION
This addresses the reports we have had from users where they want a way to disable a useShape hook until they are ready to define the params for it.

This should maintain full backwards compatibly on the types as the return type of `useShape` is now a discriminating union with an `isEnabled` flag with overloads that ensure that you get the old type when enabled isn't set or is false.