### PR TITLE
feat(sync-service): Include span metrics even if the OTEL span has been not included because of sampling

### DIFF
--- a/.changeset/wild-cameras-move.md
+++ b/.changeset/wild-cameras-move.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Include span metrics even if the OTEL span has been not included because of sampling

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -66,7 +66,13 @@ defmodule Electric.Telemetry.OpenTelemetry do
   will not be created either.
   """
   def with_child_span(name, attributes, stack_id \\ nil, fun) do
-    do_with_span(name, attributes, stack_id, fun, in_span_context?())
+    do_with_span(
+      name,
+      attributes,
+      stack_id,
+      fun,
+      in_span_context?() && Sampler.include_span?(name)
+    )
   end
 
   defp do_with_span(name, attributes, stack_id, fun, include_otel_span?) do

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -55,17 +55,7 @@ defmodule Electric.Telemetry.OpenTelemetry do
   @spec with_span(span_name(), span_attrs(), String.t() | nil, (-> t)) :: t when t: term
   def with_span(name, attributes, stack_id \\ nil, fun)
       when is_binary(name) and (is_list(attributes) or is_map(attributes)) do
-    erlang_telemetry_event = [
-      :electric | name |> String.split(".", trim: true) |> Enum.map(&String.to_atom/1)
-    ]
-
-    stack_id = stack_id || get_from_baggage("stack_id")
-    stack_attributes = get_stack_span_attrs(stack_id)
-    all_attributes = stack_attributes |> Map.merge(Map.new(attributes))
-
-    :telemetry.span(erlang_telemetry_event, all_attributes, fn ->
-      {maybe_with_otel_span(name, all_attributes, stack_id, fun), %{}}
-    end)
+    do_with_span(name, attributes, stack_id, fun, Sampler.include_span?(name))
   end
 
   @doc """
@@ -76,19 +66,28 @@ defmodule Electric.Telemetry.OpenTelemetry do
   will not be created either.
   """
   def with_child_span(name, attributes, stack_id \\ nil, fun) do
-    if in_span_context?() do
-      with_span(name, attributes, stack_id, fun)
-    else
-      fun.()
-    end
+    do_with_span(name, attributes, stack_id, fun, in_span_context?())
   end
 
-  defp maybe_with_otel_span(name, attributes, stack_id, fun) do
-    if Sampler.include_span?(name) do
-      with_otel_span(name, attributes, stack_id, fun)
-    else
-      fun.()
-    end
+  defp do_with_span(name, attributes, stack_id, fun, include_otel_span?) do
+    erlang_telemetry_event = [
+      :electric | name |> String.split(".", trim: true) |> Enum.map(&String.to_atom/1)
+    ]
+
+    stack_id = stack_id || get_from_baggage("stack_id")
+    stack_attributes = get_stack_span_attrs(stack_id)
+    all_attributes = stack_attributes |> Map.merge(Map.new(attributes))
+
+    :telemetry.span(erlang_telemetry_event, all_attributes, fn ->
+      fun_result =
+        if include_otel_span? do
+          with_otel_span(name, all_attributes, stack_id, fun)
+        else
+          fun.()
+        end
+
+      {fun_result, %{}}
+    end)
   end
 
   defp with_otel_span(name, attributes, stack_id, fun) do

--- a/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
+++ b/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
@@ -86,5 +86,22 @@ defmodule Electric.Telemetry.OpenTelemetryTest do
 
       refute Repatch.called?(:otel_tracer, :with_span, 4)
     end
+
+    test "calls :telemetry.span/3 even if there is not a parent span" do
+      pid = self()
+
+      :telemetry.attach(
+        pid,
+        [:electric, :child_span, :start],
+        fn _, _, _, _ -> send(pid, :span_started) end,
+        nil
+      )
+
+      OpenTelemetry.with_child_span("child_span", %{}, @stack_id, fn ->
+        :some_code
+      end)
+
+      assert_receive :span_started
+    end
   end
 end

--- a/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
+++ b/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
@@ -103,5 +103,19 @@ defmodule Electric.Telemetry.OpenTelemetryTest do
 
       assert_receive :span_started
     end
+
+    test "does not create a span if the sampler does not include the child span" do
+      OpenTelemetry.with_span("parent_span", %{}, @stack_id, fn ->
+        Repatch.spy(:otel_tracer)
+
+        Repatch.patch(Sampler, :include_span?, fn _ -> false end)
+
+        OpenTelemetry.with_child_span("child_span", %{}, @stack_id, fn ->
+          :some_code
+        end)
+
+        refute Repatch.called?(:otel_tracer, :with_span, 4)
+      end)
+    end
   end
 end

--- a/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
+++ b/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
@@ -1,7 +1,8 @@
 defmodule Electric.Telemetry.OpenTelemetryTest do
   alias Electric.Telemetry.OpenTelemetry
+  alias Electric.Telemetry.Sampler
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use Repatch.ExUnit
 
   @stack_id "the_stack_id"
@@ -21,27 +22,69 @@ defmodule Electric.Telemetry.OpenTelemetryTest do
     end)
   end
 
+  describe "with_span/4" do
+    test "creates a OTEL span" do
+      Repatch.spy(:otel_tracer)
+
+      OpenTelemetry.with_span("test_span", %{}, @stack_id, fn ->
+        :some_code
+      end)
+
+      assert Repatch.called?(:otel_tracer, :with_span, 4)
+    end
+
+    test "does not create an OTEL span if the samler does not include it" do
+      Repatch.spy(:otel_tracer)
+      Repatch.patch(Sampler, :include_span?, fn _ -> false end)
+
+      OpenTelemetry.with_span("test_span", %{}, @stack_id, fn ->
+        :some_code
+      end)
+
+      refute Repatch.called?(:otel_tracer, :with_span, 4)
+    end
+
+    test "calls :telemetry.span/3 even if the samler does not include it" do
+      pid = self()
+
+      :telemetry.attach(
+        pid,
+        [:electric, :test_span, :start],
+        fn _, _, _, _ -> send(pid, :span_started) end,
+        nil
+      )
+
+      Repatch.patch(Sampler, :include_span?, fn _ -> false end)
+
+      OpenTelemetry.with_span("test_span", %{}, @stack_id, fn ->
+        :some_code
+      end)
+
+      assert_receive :span_started
+    end
+  end
+
   describe "with_child_span/4" do
     test "creates a span if there is a parent span" do
       OpenTelemetry.with_span("parent_span", %{}, @stack_id, fn ->
-        Repatch.spy(OpenTelemetry)
+        Repatch.spy(:otel_tracer)
 
         OpenTelemetry.with_child_span("child_span", %{}, @stack_id, fn ->
           :some_code
         end)
 
-        assert Repatch.called?(OpenTelemetry, :with_span, 4)
+        assert Repatch.called?(:otel_tracer, :with_span, 4)
       end)
     end
 
     test "does not create a span if there is not a parent span" do
-      Repatch.spy(OpenTelemetry)
+      Repatch.spy(:otel_tracer)
 
       OpenTelemetry.with_child_span("child_span", %{}, @stack_id, fn ->
         :some_code
       end)
 
-      refute Repatch.called?(OpenTelemetry, :with_span, 4)
+      refute Repatch.called?(:otel_tracer, :with_span, 4)
     end
   end
 end


### PR DESCRIPTION
#2916 introduced upfront sampling, however this also sampled the span metrics. This PR keeps span metrics even if the OTEL span has not been included because of sampling.

Keeping the metrics does slow down replication processing, replication throughput benchmarks show a 10% slow down from 27µs/txn to 30µs/txn because of this PR, however we may consider this acceptable for now given how useful the metrics are.