### PR TITLE
chore: Refactor `ShapeStatus` table to begin separately before `ShapeCache` and consumers

### DIFF
--- a/.changeset/smooth-ducks-eat.md
+++ b/.changeset/smooth-ducks-eat.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Move `ShapeStatus` ETS table to initialise before all consumers and `ShapeCache`.

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -77,6 +77,12 @@ defmodule Electric.Connection.Supervisor do
     persistent_kv = Keyword.fetch!(opts, :persistent_kv)
     tweaks = Keyword.fetch!(opts, :tweaks)
 
+    shape_status_agent_spec =
+      {Electric.ShapeCache.ShapeStatusAgent,
+       [stack_id: stack_id, shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)]}
+
+    consumer_supervisor_spec = {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
+
     shape_cache_spec = {Electric.ShapeCache, shape_cache_opts}
 
     publication_manager_spec =
@@ -102,6 +108,8 @@ defmodule Electric.Connection.Supervisor do
         {
           Electric.Replication.Supervisor,
           stack_id: stack_id,
+          shape_status_agent: shape_status_agent_spec,
+          consumer_supervisor: consumer_supervisor_spec,
           shape_cache: shape_cache_spec,
           publication_manager: publication_manager_spec,
           log_collector: shape_log_collector_spec,

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -19,23 +19,18 @@ defmodule Electric.Replication.Supervisor do
     Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
     Logger.info("Starting shape replication pipeline")
 
-    # TODO: weird to have these without defaults but `consumer_supervisor` with a default
+    shape_status_agent = Keyword.fetch!(opts, :shape_status_agent)
+    consumer_supervisor = Keyword.fetch!(opts, :consumer_supervisor)
     shape_cache = Keyword.fetch!(opts, :shape_cache)
     publication_manager = Keyword.fetch!(opts, :publication_manager)
     log_collector = Keyword.fetch!(opts, :log_collector)
     schema_reconciler = Keyword.fetch!(opts, :schema_reconciler)
     stack_id = Keyword.fetch!(opts, :stack_id)
 
-    consumer_supervisor =
-      Keyword.get(
-        opts,
-        :consumer_supervisor,
-        {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
-      )
-
     children = [
       {Task.Supervisor,
        name: Electric.ProcessRegistry.name(stack_id, Electric.StackTaskSupervisor)},
+      shape_status_agent,
       consumer_supervisor,
       publication_manager,
       log_collector,

--- a/packages/sync-service/lib/electric/shape_cache/shape_status_agent.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status_agent.ex
@@ -1,0 +1,51 @@
+defmodule Electric.ShapeCache.ShapeStatusAgent do
+  @moduledoc """
+  Owns the ETS table and the ShapeStatus state.
+
+  This Agent creates the ETS table for shapes and initializes
+  `Electric.ShapeCache.ShapeStatus` early in the supervision tree so that
+  dependent processes (e.g., shape consumers) can use a single, shared
+  ShapeStatus instance regardless of their own supervisor start order.
+  """
+
+  use Agent
+
+  alias Electric.ShapeCache.ShapeStatus
+
+  @type t :: %{
+          shape_status_opts: ShapeStatus.t()
+        }
+
+  @schema NimbleOptions.new!(
+            stack_id: [type: :string, required: true],
+            shape_status: [type: :mod_arg, required: true]
+          )
+
+  def name(stack_id) do
+    Electric.ProcessRegistry.name(stack_id, __MODULE__)
+  end
+
+  def start_link(opts) do
+    with {:ok, opts} <- NimbleOptions.validate(opts, @schema) do
+      stack_id = Keyword.fetch!(opts, :stack_id)
+      Agent.start_link(fn -> init_state(opts) end, name: name(stack_id))
+    end
+  end
+
+  defp init_state(opts) do
+    stack_id = Keyword.fetch!(opts, :stack_id)
+    {shape_status, shape_status_opts} = Keyword.fetch!(opts, :shape_status)
+
+    stack_id
+    |> shape_status.shape_meta_table()
+    |> :ets.new([:named_table, :public, :ordered_set])
+
+    :ok = shape_status.initialise(shape_status_opts)
+
+    %{shape_status_opts: shape_status_opts}
+  end
+
+  def shape_status_opts(stack_id) do
+    Agent.get(name(stack_id), fn state -> state.shape_status_opts end)
+  end
+end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -282,10 +282,18 @@ defmodule Electric.StackSupervisor do
 
     shape_changes_registry_name = registry_name(stack_id)
 
+    shape_status =
+      {ShapeStatus,
+       ShapeStatus.opts(
+         shape_meta_table: ShapeStatus.shape_meta_table(stack_id),
+         storage: storage
+       )}
+
     shape_cache_opts = [
       stack_id: stack_id,
       storage: storage,
       inspector: inspector,
+      shape_status: shape_status,
       publication_manager: {Electric.Replication.PublicationManager, stack_id: stack_id},
       chunk_bytes_threshold: config.chunk_bytes_threshold,
       log_producer: shape_log_collector,
@@ -340,12 +348,6 @@ defmodule Electric.StackSupervisor do
       else
         []
       end
-
-    shape_status =
-      {ShapeStatus,
-       %ShapeStatus{
-         shape_meta_table: Electric.ShapeCache.get_shape_meta_table(stack_id: stack_id)
-       }}
 
     children =
       telemetry_children ++

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -44,6 +44,12 @@ defmodule Electric.Connection.ConnectionManagerTest do
            shape_cache_opts: [
              stack_id: stack_id,
              inspector: ctx.inspector,
+             shape_status:
+               {Electric.ShapeCache.ShapeStatus,
+                Electric.ShapeCache.ShapeStatus.opts(
+                  storage: ctx.storage,
+                  shape_meta_table: Electric.ShapeCache.ShapeStatus.shape_meta_table(stack_id)
+                )},
              log_producer: Electric.Replication.ShapeLogCollector.name(stack_id),
              consumer_supervisor: Electric.Shapes.DynamicConsumerSupervisor.name(stack_id),
              storage: ctx.storage,

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -37,21 +37,23 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     Mock.Storage
     |> expect(:get_all_stored_shapes, 1, fn _ -> {:ok, Access.get(opts, :stored_shapes, %{})} end)
 
-    {:ok, state} =
-      ShapeStatus.initialise(
+    shape_status_opts =
+      ShapeStatus.opts(
         storage: {Mock.Storage, []},
         shape_meta_table: table
       )
+
+    :ok = ShapeStatus.initialise(shape_status_opts)
 
     shapes = Keyword.get(opts, :shapes, [])
 
     shape_handles =
       for shape <- shapes do
-        {:ok, shape_handle} = ShapeStatus.add_shape(state, shape)
+        {:ok, shape_handle} = ShapeStatus.add_shape(shape_status_opts, shape)
         shape_handle
       end
 
-    {:ok, state, shape_handles}
+    {:ok, shape_status_opts, shape_handles}
   end
 
   test "starts empty", ctx do

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -82,6 +82,7 @@ defmodule Electric.Shapes.ConsumerTest do
   describe "event handling" do
     setup [
       :with_in_memory_storage,
+      :with_shape_status,
       :with_persistent_kv,
       :with_status_monitor,
       :with_shape_monitor
@@ -636,6 +637,7 @@ defmodule Electric.Shapes.ConsumerTest do
     setup [
       :with_registry,
       :with_pure_file_storage,
+      :with_shape_status,
       :with_log_chunking,
       :with_persistent_kv,
       :with_shape_log_collector,

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -10,4 +10,6 @@ ExUnit.start(assert_receive_timeout: 400, exclude: [:slow, :telemetry_target], c
 # Repatch in async tests has lazy recompilation issues, so as a temporary fix
 # we force recompilation in the setup. The issue is tracked here:
 # https://github.com/hissssst/repatch/issues/2
-Repatch.setup(recompile: [Postgrex, Electric.StatusMonitor, Electric.Telemetry.Sampler])
+Repatch.setup(
+  recompile: [Postgrex, Electric.StatusMonitor, Electric.Telemetry.Sampler, :otel_tracer]
+)

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -10,4 +10,4 @@ ExUnit.start(assert_receive_timeout: 400, exclude: [:slow, :telemetry_target], c
 # Repatch in async tests has lazy recompilation issues, so as a temporary fix
 # we force recompilation in the setup. The issue is tracked here:
 # https://github.com/hissssst/repatch/issues/2
-Repatch.setup(recompile: [Postgrex, Electric.StatusMonitor])
+Repatch.setup(recompile: [Postgrex, Electric.StatusMonitor, Electric.Telemetry.Sampler])


### PR DESCRIPTION
This work precedes the work I'm doing on https://github.com/electric-sql/electric/issues/2984

The `ShapeStatus` ETS table was being initialised by `ShapeCache`, but consumers also use it, and the consumer supervisor lives before the shape cache, causing issues in tests during shutdowns etc.

This changes _no_ behaviour in Electric (or at least it shouldn't!). I've refactored the tests and everything relevant to use shape cache in its new form.

I still don't love how it looks and I think it can be simplified further but this addresses the initial concern of moving it up front, and simplifies it as a mod arg passed at the stack supervisor level and then passed as is to appropriate modules, with a dedicated `ShapeStatusAgent` initializing and owning the table.