### PR TITLE
fix: clarify wording, correct grammar, and improve formatting in Electric docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Real-time sync for Postgres.
 
 Sync is the magic ingredient behind fast, modern software. From apps like Figma and Linear to AI agents running on live local data.
 
-Electric is a Postgres sync engine. It solves the hard problems of sync for you, including partial replication, fan-out, and data delivery. So you can build awesome software, without rolling your own sync.
+Electric is a Postgres sync engine. It solves the hard problems of sync for you, including partial replication, fan-out, and data delivery. So you can build awesome software without rolling your own sync.
 
 Specifically, Electric is a read-path sync engine for Postgres. It syncs data out of Postgres into ... anything you like. The core sync protocol is based on a low-level [HTTP API](https://electric-sql.com/docs/api/http). This integrates with CDNs for highly-scalable data delivery.
 
@@ -59,7 +59,7 @@ Partial replication is managed using [Shapes](https://electric-sql.com/docs/guid
 
 See the [Quickstart guide](https://electric-sql.com/docs/quickstart) to get up and running. In short, you need to:
 
-1. have a Postgres database with logical replication enabled; and then to
+1. have a Postgres database with logical replication enabled; and then
 2. run Electric in front of it, connected via `DATABASE_URL`
 
 For example, using [Docker Compose](https://docs.docker.com/compose/) from the root of this repo:
@@ -125,6 +125,6 @@ See the:
 
 ## Support
 
-We have an [open community Discord](https://discord.electric-sql.com). Come and say hello and let us know if you have any questions or need any help getting things running.
+We have an [open community Discord](https://discord.electric-sql.com). Come and say hello, and let us know if you have any questions or need any help getting things running.
 
 It's also super helpful if you leave the project a star here at the [top of the page☝️](#start-of-content)


### PR DESCRIPTION
fix: clarify wording, correct grammar, and improve formatting in Electric docs