### PR TITLE
fix: Consistent cache busting on 409s

### DIFF
--- a/.changeset/purple-ligers-play.md
+++ b/.changeset/purple-ligers-play.md
@@ -1,0 +1,7 @@
+---
+"@electric-sql/client": patch
+"@core/elixir-client": patch
+"@core/sync-service": patch
+---
+
+Ensure 409s do not lead to infinite request cycles because of caching.

--- a/packages/elixir-client/lib/electric/client/stream.ex
+++ b/packages/elixir-client/lib/electric/client/stream.ex
@@ -189,11 +189,12 @@ defmodule Electric.Client.Stream do
   end
 
   # 409: Upon receiving a 409, we should start from scratch with the newly
-  #      provided shape handle
+  #      provided shape handle or with a fallback pseudo-handle to ensure
+  #      a consistent cache buster is used
   defp handle_response({:error, %Fetch.Response{status: status} = resp}, stream)
        when status in [409] do
     %{value_mapper_fun: value_mapper_fun} = stream
-    handle = shape_handle(resp)
+    handle = shape_handle(resp) || "#{stream.shape_handle}-next"
 
     stream
     |> reset(handle)

--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -135,7 +135,7 @@ defmodule Electric.Shapes.Api.Params do
     offset = fetch_change!(changeset, :offset)
 
     if offset == LogOffset.before_all() do
-      changeset
+      delete_change(changeset, :handle)
     else
       validate_required(changeset, [:handle], message: "can't be blank when offset != -1")
     end

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -453,6 +453,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "the 304 response includes caching headers that are appropriate for the offset", ctx do
       Mock.ShapeCache
       |> stub(:has_shape?, fn @test_shape_handle, _opts -> true end)
+      |> stub(:get_or_create_shape_handle, fn @test_shape, _opts ->
+        {@test_shape_handle, @test_offset}
+      end)
       |> stub(:get_shape, fn @test_shape, _opts -> {@test_shape_handle, @test_offset} end)
 
       Mock.Storage

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -211,7 +211,7 @@ defmodule Electric.Shapes.ApiTest do
                  %{
                    table: "public.users",
                    handle: "#{request_handle}",
-                   offset: "-1"
+                   offset: "0_0"
                  }
                )
 
@@ -231,7 +231,7 @@ defmodule Electric.Shapes.ApiTest do
                  %{
                    table: "public.users",
                    handle: request_handle,
-                   offset: "-1"
+                   offset: "0_0"
                  }
                )
 
@@ -251,7 +251,7 @@ defmodule Electric.Shapes.ApiTest do
                  %{
                    table: "public.users",
                    handle: request_handle,
-                   offset: "-1"
+                   offset: "0_0"
                  }
                )
 

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -514,8 +514,11 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
       if (e.status == 409) {
         // Upon receiving a 409, we should start from scratch
-        // with the newly provided shape handle
-        const newShapeHandle = e.headers[SHAPE_HANDLE_HEADER]
+        // with the newly provided shape handle, or a fallback
+        // pseudo-handle based on the current one to act as a
+        // consistent cache buster
+        const newShapeHandle =
+          e.headers[SHAPE_HANDLE_HEADER] || `${this.#shapeHandle!}-next`
         this.#reset(newShapeHandle)
         await this.#publish(e.json as Message<T>[])
         return this.#requestShape()

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -414,12 +414,25 @@ paths:
         "409":
           description:
             The requested offset for the given shape no longer exists.
-            Client should sync the shape using the relative path from the location header.
+            Client should resync the shape using the new shape handle if provided, or
+            using a consistent cache buster for their next `offset=-1` request.
           headers:
             electric-handle:
               schema:
                 type: string
-              description: Handle of the new shape that must be used in client requests from now on.
+              description: |-
+                Handle of the new shape that must be used in client requests from now on.
+
+                This will not always be returned, as a new shape handle might not be immediately
+                available at the point of invalidation of the current operation.
+
+                If the replacement handle is not present, clients should attempt to use a
+                consistent cache buster for their next `offset=-1` request to avoid running into
+                the cached response for the invalidated shape.
+
+                A suggested approach is to set the handle in the next `offset=-1` approach as the
+                current shape's handle with a suffix like `-next` - the handle will be ignored
+                by the server, and it can act as a consistent cache buster between clients.
           content:
             application/json:
               schema:


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/3020

Before adapting the cursor for the purpose of 409s, I decided to use the handle itself which we were already using.

Here is my reasoninig:

1. Our main issue is that we are caching 409s (with or without a next handle) for 60 seconds - we are caching them as they are part of our regular request flow and it would create unnecessary load to break request coalescing and go to origin for them
  1a. One immediate fix is to change the caching for 409s _without_ a handle to 1 second, the minimum to enable request coalescing. This means that on the next request cycle they would most likely run into a 409 _with_ a shape handle anyway.
  1b. We could disable caching on 409s without a handle altogether - I _think_ that would would happen is that the 409 is return to one of the "held" requests, and the next one is picked as the "champion", and that one goes to the origin and it would _now_ receive a 409 _with_ a shape handle - so perhaps this is the better option.
2. I'm explicitly removing the shape handle as part of the `offset=-1` requests, so it really now only acts as a cache buster and it is not respected.
  2a. This allows us to "abuse" the `handle` parameter for `offset=-1` requests as a cache buster (which we were already sort of doing) - and rather than rely on a cursor we can make clients just request the same handle with a `-next` suffix, which is already consistent as per @samwillis ' suggestion and does not require coordination.


The reason I'm avoiding reusing the cursor is that it is used very explicitly in clients for _live_ requests, and ultimately it wouldn't give us a big benefit since all we really want is for clients to go on to the "next" chain of requests from the one they are on - whether that's via an explicit new handle that is given or via a consistent cache buster without coordination is irrelevant. I'd rather not add more complexity to the protocol.


## IMPORTANT

This change basically makes the `offset=-1` calls _ignore_ the `handle` parameter, so if you provide an invalid handle we will still match to an existing shape and return the valid one. If this is not how we would like the API to behave then I will scrap this change and use a different approach (with the cursor).