### PR TITLE
Unpublish the reference doc for internal configuration option

### DIFF
--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -172,7 +172,7 @@ A unique identifier for the Electric instance. Defaults to a randomly generated 
     defaultValue="electric"
     example="my-electric-service">
 
-Name of the electric service. Used as a resource identifier and namespace.
+Name of the electric service. Used as a resource name in OTEL traces and metrics.
 
 </EnvVarConfig>
 

--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -176,18 +176,6 @@ Name of the electric service. Used as a resource identifier and namespace.
 
 </EnvVarConfig>
 
-### ELECTRIC_ENABLE_INTEGRATION_TESTING
-
-<EnvVarConfig
-    name="ELECTRIC_ENABLE_INTEGRATION_TESTING"
-    defaultValue="false"
-    example="true">
-
-Expose some unsafe operations that faciliate integration testing.
-Do not enable this in production.
-
-</EnvVarConfig>
-
 ### ELECTRIC_LISTEN_ON_IPV6
 
 <EnvVarConfig


### PR DESCRIPTION
This option is effectively about enabling shape removal and it's not supposed to be publicly documented, and its documentation isn't helpful anyway.