### PR TITLE
Mention the 'columns' query param in the error message for generated columns

### DIFF
--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -660,7 +660,8 @@ defmodule Electric.Plug.RouterTest do
                %{
                  "errors" => %{
                    "columns" => [
-                     "The following columns are generated and cannot be included in replication: id"
+                     "The following columns are generated and cannot be included in the shape: id. " <>
+                       "You can exclude them from the shape by explicitly listing which columns to fetch in the 'columns' query param"
                    ]
                  },
                  "message" => "Invalid request"
@@ -675,7 +676,11 @@ defmodule Electric.Plug.RouterTest do
 
       assert Jason.decode!(conn.resp_body) ==
                %{
-                 "errors" => %{"columns" => ["Must include all primary key columns, missing: id"]},
+                 "errors" => %{
+                   "columns" => [
+                     "The list of columns must include all primary key columns, missing: id"
+                   ]
+                 },
                  "message" => "Invalid request"
                }
 
@@ -690,7 +695,7 @@ defmodule Electric.Plug.RouterTest do
                %{
                  "errors" => %{
                    "columns" => [
-                     "The following columns are generated and cannot be included in replication: id"
+                     "The following columns are generated and cannot be included in the shape: id"
                    ]
                  },
                  "message" => "Invalid request"

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -734,7 +734,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Jason.decode!(conn.resp_body) == %{
                "message" => "Invalid request",
                "errors" => %{
-                 "columns" => ["Must include all primary key columns, missing: id"]
+                 "columns" => [
+                   "The list of columns must include all primary key columns, missing: id"
+                 ]
                }
              }
     end
@@ -750,7 +752,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert Jason.decode!(conn.resp_body) == %{
                "message" => "Invalid request",
                "errors" => %{
-                 "columns" => ["The following columns could not be found: invalid"]
+                 "columns" => ["The following columns are not found on the table: invalid"]
                }
              }
     end

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -301,7 +301,9 @@ defmodule Electric.Shapes.ApiTest do
       assert response_body(response) == %{
                message: "Invalid request",
                errors: %{
-                 columns: ["Must include all primary key columns, missing: id"]
+                 columns: [
+                   "The list of columns must include all primary key columns, missing: id"
+                 ]
                }
              }
     end

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -344,7 +344,7 @@ defmodule Electric.Shapes.ShapeTest do
            "CREATE TABLE IF NOT EXISTS col_table (id INT PRIMARY KEY, value1 TEXT, value2 TEXT)"
          ]
     test "validates selected columns for invalid columns", %{inspector: inspector} do
-      assert {:error, {:columns, ["The following columns could not be found: invalid"]}} =
+      assert {:error, {:columns, ["The following columns are not found on the table: invalid"]}} =
                Shape.new("col_table", inspector: inspector, columns: ["id", "invalid"])
     end
 
@@ -352,7 +352,9 @@ defmodule Electric.Shapes.ShapeTest do
            "CREATE TABLE IF NOT EXISTS col_table (id INT PRIMARY KEY, value1 TEXT, value2 TEXT)"
          ]
     test "validates selected columns for missing PK columns", %{inspector: inspector} do
-      assert {:error, {:columns, ["Must include all primary key columns, missing: id"]}} =
+      assert {:error,
+              {:columns,
+               ["The list of columns must include all primary key columns, missing: id"]}} =
                Shape.new("col_table", inspector: inspector, columns: ["value1"])
     end
 
@@ -375,7 +377,10 @@ defmodule Electric.Shapes.ShapeTest do
     test "validates selected columns for generated columns", %{inspector: inspector} do
       assert {:error,
               {:columns,
-               ["The following columns are generated and cannot be included in replication: id"]}} =
+               [
+                 "The following columns are generated and cannot be included in the shape: id. " <>
+                   "You can exclude them from the shape by explicitly listing which columns to fetch in the 'columns' query param"
+               ]}} =
                Shape.new("gen_col_table", inspector: inspector)
     end
 


### PR DESCRIPTION
Fix #2906