### PR TITLE
feat: Faster recovery times with single point controlled shutdown recovery

### DIFF
--- a/.changeset/twenty-foxes-kiss.md
+++ b/.changeset/twenty-foxes-kiss.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add controlled shutdown backing up of storage and shape metadata for significantly faster recovery on restart.

--- a/packages/sync-service/dev/gen_shapes.sh
+++ b/packages/sync-service/dev/gen_shapes.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# gen_shapes.sh — create a table and generate N shapes via the Electric API
+#
+# Requirements:
+# - DATABASE_URL must point to a reachable Postgres instance that psql can use
+# - Electric API is available at http://localhost:${ELECTRIC_PORT:-3000}
+# - Optional: ELECTRIC_SECRET will be appended as a query param if set
+#
+# Usage:
+#   ./dev/gen_shapes.sh NUM_SHAPES
+#   NUM_SHAPES can also be provided via env var NUM_SHAPES
+#   Configure parallelism with CONCURRENCY (default: min(32, 2*CPU cores))
+
+NUM_SHAPES_INPUT=${1:-${NUM_SHAPES:-}}
+if [[ -z "${NUM_SHAPES_INPUT}" ]]; then
+	echo "Usage: $0 NUM_SHAPES" >&2
+	exit 1
+fi
+
+if ! [[ "${NUM_SHAPES_INPUT}" =~ ^[0-9]+$ ]]; then
+	echo "NUM_SHAPES must be a positive integer" >&2
+	exit 1
+fi
+
+NUM_SHAPES=${NUM_SHAPES_INPUT}
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+	echo "DATABASE_URL is not set. Please export DATABASE_URL with a Postgres URI." >&2
+	exit 1
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+	echo "psql is required but not found in PATH" >&2
+	exit 1
+fi
+
+ELECTRIC_PORT=${ELECTRIC_PORT:-3000}
+BASE_URL="http://localhost:${ELECTRIC_PORT}/v1/shape"
+
+# Create table 'foo' suitable for where clauses like id={i} and seed rows 1..NUM_SHAPES
+echo "Creating table 'foo' (if not exists) and seeding ${NUM_SHAPES} rows in Postgres..."
+psql -v ON_ERROR_STOP=1 -d "${DATABASE_URL}" <<SQL
+CREATE TABLE IF NOT EXISTS public.foo (
+	id   integer PRIMARY KEY,
+	data text
+);
+
+INSERT INTO public.foo (id, data)
+SELECT i, 'row-' || i::text
+FROM generate_series(1, ${NUM_SHAPES}) AS s(i)
+ON CONFLICT (id) DO NOTHING;
+SQL
+
+echo "Generating ${NUM_SHAPES} shapes against Electric at ${BASE_URL}..."
+
+# Build optional secret query param
+SECRET_QS=""
+if [[ -n "${ELECTRIC_SECRET:-}" ]]; then
+	# The API accepts either 'secret' or 'api_secret'; prefer 'secret'
+	SECRET_QS="&secret=$(printf %s "${ELECTRIC_SECRET}" | sed -e 's/\&/%26/g' -e 's/\?/%3F/g')"
+fi
+
+# Determine concurrency
+CPU_CORES=1
+if command -v sysctl >/dev/null 2>&1; then
+	CPU_CORES=$(sysctl -n hw.ncpu 2>/dev/null || echo 1)
+fi
+DEFAULT_CONCURRENCY=$(( CPU_CORES * 2 ))
+if (( DEFAULT_CONCURRENCY > 32 )); then DEFAULT_CONCURRENCY=32; fi
+CONCURRENCY=${CONCURRENCY:-$DEFAULT_CONCURRENCY}
+
+echo "Using concurrency: ${CONCURRENCY}"
+
+# Temp dir for artifacts
+TMP_DIR=$(mktemp -d -t gen_shapes.XXXXXX)
+cleanup() {
+	rm -rf "${TMP_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Sequence generator (portable across macOS/Linux)
+gen_sequence() {
+	local n=$1
+	if command -v seq >/dev/null 2>&1; then
+		seq 1 "$n"
+	elif command -v jot >/dev/null 2>&1; then
+		jot -w "%d" "$n" 1
+	else
+		awk -v n="$n" 'BEGIN{for(i=1;i<=n;i++) print i}'
+	fi
+}
+
+export BASE_URL SECRET_QS TMP_DIR
+
+gen_sequence "$NUM_SHAPES" | xargs -P "$CONCURRENCY" -n 1 -I {} bash -c '
+	i="$1"
+	url="${BASE_URL}?table=foo&where=id=${i}&offset=-1${SECRET_QS}"
+	body="${TMP_DIR}/shape_${i}.json"
+	status_file="${TMP_DIR}/shape_${i}.status"
+
+	code=$(curl -sS --max-time 15 --retry 2 --retry-delay 1 \
+			-H "Accept: application/json" \
+			--write-out "%{http_code}" \
+			--output "$body" \
+			--fail-with-body \
+			"$url" 2>/dev/null || echo "000")
+
+	printf "%s" "$code" > "$status_file"
+
+	if [[ "$code" == "200" || "$code" == "304" ]]; then
+		exit 0
+	else
+		# Keep a small snippet for debugging
+		if [[ -s "$body" ]]; then
+			head -c 200 "$body" > "${body}.snippet" 2>/dev/null || true
+		fi
+		exit 1
+	fi
+' _ {}
+
+# Summarize results
+total_status=0
+successes=0
+failures=0
+if ls "${TMP_DIR}"/*.status >/dev/null 2>&1; then
+	total_status=$(ls "${TMP_DIR}"/*.status | wc -l | tr -d ' ')
+	successes=$(grep -E -h "^(200|304)$" "${TMP_DIR}"/*.status | wc -l | tr -d ' ')
+	failures=$(( total_status - successes ))
+fi
+
+if (( failures > 0 )); then
+	echo "Completed with ${failures} failures out of ${total_status}." >&2
+	# Print up to 5 example failures
+	count=0
+	for f in "${TMP_DIR}"/*.status; do
+		[[ -e "$f" ]] || break
+		code=$(cat "$f")
+		if [[ "$code" != "200" && "$code" != "304" ]]; then
+			i=${f##*/}
+			i=${i#shape_}
+			i=${i%.status}
+			echo "- where=id=${i}: HTTP ${code}" >&2
+			if [[ -s "${TMP_DIR}/shape_${i}.json.snippet" ]]; then
+				echo "  Response: $(cat "${TMP_DIR}/shape_${i}.json.snippet")" >&2
+			fi
+			count=$((count+1))
+			if (( count >= 5 )); then break; fi
+		fi
+	done
+	if [[ -z "${ELECTRIC_SECRET:-}" ]]; then
+		echo "Note: If your Electric server requires an API secret, set ELECTRIC_SECRET and rerun." >&2
+	fi
+	exit 1
+fi
+
+echo "All ${total_status} shapes generated successfully."
+

--- a/packages/sync-service/lib/electric/connection/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/supervisor.ex
@@ -77,8 +77,8 @@ defmodule Electric.Connection.Supervisor do
     persistent_kv = Keyword.fetch!(opts, :persistent_kv)
     tweaks = Keyword.fetch!(opts, :tweaks)
 
-    shape_status_agent_spec =
-      {Electric.ShapeCache.ShapeStatusAgent,
+    shape_status_owner_spec =
+      {Electric.ShapeCache.ShapeStatusOwner,
        [stack_id: stack_id, shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)]}
 
     consumer_supervisor_spec = {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
@@ -110,7 +110,7 @@ defmodule Electric.Connection.Supervisor do
         {
           Electric.Replication.Supervisor,
           stack_id: stack_id,
-          shape_status_agent: shape_status_agent_spec,
+          shape_status_owner: shape_status_owner_spec,
           consumer_supervisor: consumer_supervisor_spec,
           shape_cache: shape_cache_spec,
           publication_manager: publication_manager_spec,

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -19,7 +19,7 @@ defmodule Electric.Replication.Supervisor do
     Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
     Logger.info("Starting shape replication pipeline")
 
-    shape_status_agent = Keyword.fetch!(opts, :shape_status_agent)
+    shape_status_owner = Keyword.fetch!(opts, :shape_status_owner)
     log_collector = Keyword.fetch!(opts, :log_collector)
     publication_manager = Keyword.fetch!(opts, :publication_manager)
     consumer_supervisor = Keyword.fetch!(opts, :consumer_supervisor)
@@ -30,7 +30,7 @@ defmodule Electric.Replication.Supervisor do
     children = [
       {Task.Supervisor,
        name: Electric.ProcessRegistry.name(stack_id, Electric.StackTaskSupervisor)},
-      shape_status_agent,
+      shape_status_owner,
       log_collector,
       publication_manager,
       consumer_supervisor,

--- a/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
@@ -31,7 +31,7 @@ defmodule Electric.ShapeCache.CrashingFileStorage do
     |> Map.put(:extra_opts, %{num_calls_until_crash: Keyword.fetch!(opts, :num_calls_until_crash)})
   end
 
-  def init_writer!(opts, shape_definition) do
+  def init_writer!(opts, shape_definition, _storage_recovery_state) do
     CubDB.put(opts.db, @num_calls_until_crash_key, opts.extra_opts.num_calls_until_crash)
     FileStorage.init_writer!(opts, shape_definition)
   end

--- a/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
@@ -12,7 +12,9 @@ defmodule Electric.ShapeCache.CrashingFileStorage do
   defdelegate for_shape(shape_handle, opts), to: FileStorage
   defdelegate stack_start_link(opts), to: FileStorage
   defdelegate start_link(opts), to: FileStorage
+  defdelegate get_all_stored_shape_handles(opts), to: FileStorage
   defdelegate get_all_stored_shapes(opts), to: FileStorage
+  defdelegate metadata_backup_dir(opts), to: FileStorage
   defdelegate get_total_disk_usage(opts), to: FileStorage
   defdelegate get_current_position(opts), to: FileStorage
   defdelegate set_pg_snapshot(pg_snapshot, opts), to: FileStorage

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -167,7 +167,7 @@ defmodule Electric.ShapeCache.FileStorage do
     case File.ls(shapes_dir) do
       {:ok, shape_handles} ->
         shape_handles
-        |> Enum.reject(&match?(@metadata_storage_dir, &1))
+        |> Enum.reject(&String.starts_with?(&1, "."))
         |> Enum.reject(&exists?(deletion_marker_path(shapes_dir, &1)))
         |> then(&{:ok, MapSet.new(&1)})
 
@@ -208,7 +208,7 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def metadata_backup_dir(%{base_path: base_path} = opts) do
+  def metadata_backup_dir(%{base_path: base_path}) do
     base_path |> Path.join(@metadata_storage_dir) |> Path.join("backups")
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -209,7 +209,7 @@ defmodule Electric.ShapeCache.FileStorage do
 
   @impl Electric.ShapeCache.Storage
   def metadata_backup_dir(%{base_path: base_path}) do
-    base_path |> Path.join(@metadata_storage_dir) |> Path.join("backups")
+    Path.join([base_path, @metadata_storage_dir, "backups"])
   end
 
   @impl Electric.ShapeCache.Storage

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -113,7 +113,7 @@ defmodule Electric.ShapeCache.FileStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def init_writer!(%FS{} = opts, shape_definition) do
+  def init_writer!(%FS{} = opts, shape_definition, _storage_recovery_state \\ nil) do
     stored_version = stored_version(opts)
     db = validate_db_process!(opts.db)
 

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -93,7 +93,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def init_writer!(%MS{} = opts, _shape_definition), do: opts
+  def init_writer!(%MS{} = opts, _shape_definition, _storage_recovery_state), do: opts
 
   @impl Electric.ShapeCache.Storage
   def get_current_position(%MS{} = opts) do

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -123,7 +123,13 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   end
 
   @impl Electric.ShapeCache.Storage
+  def get_all_stored_shape_handles(_opts), do: {:ok, MapSet.new()}
+
+  @impl Electric.ShapeCache.Storage
   def get_all_stored_shapes(_opts), do: {:ok, %{}}
+
+  @impl Electric.ShapeCache.Storage
+  def metadata_backup_dir(_opts), do: nil
 
   @impl Electric.ShapeCache.Storage
   def get_total_disk_usage(_opts), do: 0

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -176,7 +176,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
   end
 
   def get_all_stored_shape_handles(%{base_path: base_path} = opts) do
-    case File.ls(base_path) do
+    case ls(base_path) do
       {:ok, shape_handles} ->
         shape_handles
         |> Enum.reject(&String.starts_with?(&1, "."))

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -210,7 +210,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
   end
 
   def metadata_backup_dir(%{base_path: base_path}) do
-    base_path |> Path.join(@metadata_storage_dir) |> Path.join("backups")
+    Path.join([base_path, @metadata_storage_dir, "backups"])
   end
 
   def cleanup!(%__MODULE__{} = opts) do

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -436,8 +436,6 @@ defmodule Electric.ShapeCache.ShapeStatus do
                   {:ok, table}
 
                 {:error, reason} ->
-                  dbg("failed integrity")
-
                   Logger.warning(
                     "Loaded shape status backup but failed integrity check with #{inspect(reason)} - aborting restore"
                   )

--- a/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
@@ -12,8 +12,6 @@ defmodule Electric.ShapeCache.ShapeStatusOwner do
 
   require Logger
 
-  alias Electric.ShapeCache.ShapeStatus
-
   @schema NimbleOptions.new!(
             stack_id: [type: :string, required: true],
             shape_status: [type: :mod_arg, required: true]
@@ -52,7 +50,7 @@ defmodule Electric.ShapeCache.ShapeStatusOwner do
 
   @impl true
   def terminate(_reason, %{shape_status: {shape_status, shape_status_state}}) do
-    Logger.info("Terminating shape status owner, backing up state.")
+    Logger.info("Terminating shape status owner, backing up state for faster recovery.")
     shape_status.terminate(shape_status_state)
     :ok
   end

--- a/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
@@ -1,20 +1,16 @@
-defmodule Electric.ShapeCache.ShapeStatusAgent do
+defmodule Electric.ShapeCache.ShapeStatusOwner do
   @moduledoc """
   Owns the ETS table and the ShapeStatus state.
 
-  This Agent creates the ETS table for shapes and initializes
+  This process creates the ETS table for shapes and initializes
   `Electric.ShapeCache.ShapeStatus` early in the supervision tree so that
   dependent processes (e.g., shape consumers) can use a single, shared
   ShapeStatus instance regardless of their own supervisor start order.
   """
 
-  use Agent
+  use GenServer, shutdown: 60_000
 
   alias Electric.ShapeCache.ShapeStatus
-
-  @type t :: %{
-          shape_status_opts: ShapeStatus.t()
-        }
 
   @schema NimbleOptions.new!(
             stack_id: [type: :string, required: true],
@@ -28,24 +24,31 @@ defmodule Electric.ShapeCache.ShapeStatusAgent do
   def start_link(opts) do
     with {:ok, opts} <- NimbleOptions.validate(opts, @schema) do
       stack_id = Keyword.fetch!(opts, :stack_id)
-      Agent.start_link(fn -> init_state(opts) end, name: name(stack_id))
+      GenServer.start_link(__MODULE__, opts, name: name(stack_id))
     end
   end
 
-  defp init_state(opts) do
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
     stack_id = Keyword.fetch!(opts, :stack_id)
-    {shape_status, shape_status_opts} = Keyword.fetch!(opts, :shape_status)
+    {shape_status, shape_status_state} = Keyword.fetch!(opts, :shape_status)
 
-    stack_id
-    |> shape_status.shape_meta_table()
-    |> :ets.new([:named_table, :public, :ordered_set])
+    :ok = shape_status.initialise(shape_status_state)
+    dbg("Initialised shape status")
 
-    :ok = shape_status.initialise(shape_status_opts)
-
-    %{shape_status_opts: shape_status_opts}
+    {:ok, %{shape_status: {shape_status, shape_status_state}}}
   end
 
-  def shape_status_opts(stack_id) do
-    Agent.get(name(stack_id), fn state -> state.shape_status_opts end)
+  @impl true
+  def handle_info({:EXIT, _, reason}, state) do
+    {:stop, reason, state}
+  end
+
+  @impl true
+  def terminate(reason, %{shape_status: {shape_status, shape_status_state}}) do
+    dbg("storing shape status ets table")
+    shape_status.terminate(shape_status_state)
+    :ok
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -47,7 +47,7 @@ defmodule Electric.ShapeCache.Storage do
   @callback start_link(shape_opts()) :: GenServer.on_start()
 
   @doc "Prepare the in-process writer state, returning an accumulator."
-  @callback init_writer!(shape_opts(), shape_definition :: Shape.t()) :: writer_state()
+  @callback init_writer!(shape_opts(), shape_definition :: Shape.t(), term()) :: writer_state()
 
   @doc "Retrieve all stored shapes"
   @callback get_all_stored_shapes(compiled_opts()) ::
@@ -177,8 +177,8 @@ defmodule Electric.ShapeCache.Storage do
   end
 
   @impl __MODULE__
-  def init_writer!({mod, shape_opts}, shape_definition) do
-    {mod, mod.init_writer!(shape_opts, shape_definition)}
+  def init_writer!({mod, shape_opts}, shape_definition, storage_recovery_state \\ nil) do
+    {mod, mod.init_writer!(shape_opts, shape_definition, storage_recovery_state)}
   end
 
   @impl __MODULE__

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -49,9 +49,16 @@ defmodule Electric.ShapeCache.Storage do
   @doc "Prepare the in-process writer state, returning an accumulator."
   @callback init_writer!(shape_opts(), shape_definition :: Shape.t(), term()) :: writer_state()
 
+  @doc "Retrieve all stored shape handles"
+  @callback get_all_stored_shape_handles(compiled_opts()) ::
+              {:ok, MapSet.t(shape_handle())} | {:error, term()}
+
   @doc "Retrieve all stored shapes"
   @callback get_all_stored_shapes(compiled_opts()) ::
               {:ok, %{shape_handle() => Shape.t()}} | {:error, term()}
+
+  @doc "Get the directory where metadata backups are stored."
+  @callback metadata_backup_dir(compiled_opts()) :: String.t() | nil
 
   @doc "Get the total disk usage for all shapes"
   @callback get_total_disk_usage(compiled_opts()) :: non_neg_integer()
@@ -182,8 +189,18 @@ defmodule Electric.ShapeCache.Storage do
   end
 
   @impl __MODULE__
+  def get_all_stored_shape_handles({mod, opts}) do
+    mod.get_all_stored_shape_handles(opts)
+  end
+
+  @impl __MODULE__
   def get_all_stored_shapes({mod, opts}) do
     mod.get_all_stored_shapes(opts)
+  end
+
+  @impl __MODULE__
+  def metadata_backup_dir({mod, opts}) do
+    mod.metadata_backup_dir(opts)
   end
 
   @impl __MODULE__

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -512,7 +512,7 @@ defmodule Electric.Shapes.Consumer do
     state
   end
 
-  defp set_pg_snapshot(pg_snapshot, %{pg_snapshot: nil} = state) do
+  defp set_pg_snapshot(pg_snapshot, %{pg_snapshot: nil} = state) when not is_nil(pg_snapshot) do
     ShapeCache.Storage.set_pg_snapshot(pg_snapshot, state.storage)
     set_pg_snapshot(pg_snapshot, %{state | pg_snapshot: pg_snapshot})
   end

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -104,7 +104,12 @@ defmodule Electric.Shapes.Consumer do
       shape_status: {shape_status, shape_status_state}
     } = state
 
-    writer = ShapeCache.Storage.init_writer!(storage, state.shape)
+    writer =
+      ShapeCache.Storage.init_writer!(
+        storage,
+        state.shape,
+        shape_status.consume_shape_storage_state(shape_status_state, state.shape_handle)
+      )
 
     {:ok, latest_offset, pg_snapshot} = ShapeCache.Storage.get_current_position(storage)
 
@@ -289,7 +294,17 @@ defmodule Electric.Shapes.Consumer do
     end)
 
     if is_map_key(state, :writer) do
-      ShapeCache.Storage.terminate(state.writer)
+      storage_recovery_state = ShapeCache.Storage.terminate(state.writer)
+
+      {shape_status, shape_status_state} = state.shape_status
+
+      if not is_nil(shape_status.get_existing_shape(shape_status_state, state.shape_handle)) do
+        shape_status.set_shape_storage_state(
+          shape_status_state,
+          state.shape_handle,
+          storage_recovery_state
+        )
+      end
     end
 
     reply_to_snapshot_waiters(state, {:error, "Shape terminated before snapshot was ready"})

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -25,16 +25,13 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
   end
 
   defp table_name,
-    do:
-      :ets.new(:"#{__MODULE__}-#{System.unique_integer([:positive, :monotonic])}", [
-        :public,
-        :ordered_set
-      ])
+    do: :"#{__MODULE__}-#{System.unique_integer([:positive, :monotonic])}"
 
   defp new_state(_ctx, opts \\ []) do
     table = Keyword.get(opts, :table, table_name())
 
     Mock.Storage
+    |> stub(:metadata_backup_dir, fn _ -> nil end)
     |> expect(:get_all_stored_shapes, 1, fn _ -> {:ok, Access.get(opts, :stored_shapes, %{})} end)
 
     shape_status_opts =

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -263,6 +263,132 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     end
   end
 
+  describe "shape storage and backup" do
+    test "can set and consume shape storage state", ctx do
+      {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape!()])
+
+      assert :ok = ShapeStatus.set_shape_storage_state(state, shape_handle, %{foo: :bar})
+      assert %{foo: :bar} = ShapeStatus.consume_shape_storage_state(state, shape_handle)
+      # entry is deleted after consumption
+      assert nil == ShapeStatus.consume_shape_storage_state(state, shape_handle)
+
+      # unknown shape returns nil
+      assert nil == ShapeStatus.consume_shape_storage_state(state, "missing")
+    end
+
+    test "removing shape clears stored shape storage state", ctx do
+      {:ok, state, [shape_handle]} = new_state(ctx, shapes: [shape!()])
+      assert :ok = ShapeStatus.set_shape_storage_state(state, shape_handle, :some_state)
+      assert {:ok, _shape} = ShapeStatus.remove_shape(state, shape_handle)
+      # cleanup removes backup entry so nothing to consume
+      assert nil == ShapeStatus.consume_shape_storage_state(state, shape_handle)
+    end
+
+    test "terminate stores backup and initialise loads from backup instead of storage", _ctx do
+      backup_base_dir =
+        Path.join(System.tmp_dir!(), "shape_status_test_#{System.unique_integer([:positive])}")
+
+      table = table_name()
+
+      # First lifecycle: no shapes in storage, start empty, add a shape, terminate to create backup
+      Mock.Storage
+      |> stub(:metadata_backup_dir, fn _ -> backup_base_dir end)
+      |> expect(:get_all_stored_shapes, 1, fn _ -> {:ok, %{}} end)
+      |> stub(:get_all_stored_shape_handles, fn _ -> {:ok, MapSet.new()} end)
+
+      state =
+        ShapeStatus.opts(
+          storage: {Mock.Storage, []},
+          shape_meta_table: table
+        )
+
+      assert :ok = ShapeStatus.initialise(state)
+      shape = shape!()
+      assert {:ok, shape_handle} = ShapeStatus.add_shape(state, shape)
+      assert [{^shape_handle, ^shape}] = ShapeStatus.list_shapes(state)
+
+      # Persist backup
+      assert :ok = ShapeStatus.terminate(state)
+
+      backup_file =
+        Path.join([backup_base_dir, "shape_status_backups", "shape_status_v1.ets.backup"])
+
+      assert File.exists?(backup_file)
+
+      # Simulate restart: remove ETS table (would be removed with process exit in real system)
+      :ets.delete(table)
+
+      # Second lifecycle: should load from backup (so must NOT call get_all_stored_shapes)
+      Mock.Storage
+      |> stub(:metadata_backup_dir, fn _ -> backup_base_dir end)
+      |> stub(:get_all_stored_shapes, fn _ ->
+        flunk("get_all_stored_shapes should not be called when backup exists")
+      end)
+      |> expect(:get_all_stored_shape_handles, 1, fn _ -> {:ok, MapSet.new([shape_handle])} end)
+
+      state2 =
+        ShapeStatus.opts(
+          storage: {Mock.Storage, []},
+          shape_meta_table: table
+        )
+
+      assert :ok = ShapeStatus.initialise(state2)
+      assert [{^shape_handle, ^shape}] = ShapeStatus.list_shapes(state2)
+      # consuming backup directory should have removed it after load
+      refute File.exists?(backup_file)
+    end
+
+    test "backup restore aborted on storage integrity failure", _ctx do
+      backup_base_dir =
+        Path.join(System.tmp_dir!(), "shape_status_test_#{System.unique_integer([:positive])}")
+
+      table = table_name()
+
+      # First lifecycle: create backup containing one shape
+      Mock.Storage
+      |> stub(:metadata_backup_dir, fn _ -> backup_base_dir end)
+      |> expect(:get_all_stored_shapes, 1, fn _ -> {:ok, %{}} end)
+      |> stub(:get_all_stored_shape_handles, fn _ -> {:ok, MapSet.new()} end)
+
+      state =
+        ShapeStatus.opts(
+          storage: {Mock.Storage, []},
+          shape_meta_table: table
+        )
+
+      assert :ok = ShapeStatus.initialise(state)
+      shape = shape!()
+      assert {:ok, shape_handle} = ShapeStatus.add_shape(state, shape)
+      assert [{^shape_handle, ^shape}] = ShapeStatus.list_shapes(state)
+      assert :ok = ShapeStatus.terminate(state)
+
+      backup_file =
+        Path.join([backup_base_dir, "shape_status_backups", "shape_status_v1.ets.backup"])
+
+      assert File.exists?(backup_file)
+
+      :ets.delete(table)
+
+      # Second lifecycle: integrity check fails because storage reports NO handles
+      Mock.Storage
+      |> stub(:metadata_backup_dir, fn _ -> backup_base_dir end)
+      |> expect(:get_all_stored_shape_handles, 1, fn _ -> {:ok, MapSet.new()} end)
+      # After integrity failure, initialise will call load/1 -> get_all_stored_shapes
+      |> expect(:get_all_stored_shapes, 1, fn _ -> {:ok, %{}} end)
+
+      state2 =
+        ShapeStatus.opts(
+          storage: {Mock.Storage, []},
+          shape_meta_table: table
+        )
+
+      assert :ok = ShapeStatus.initialise(state2)
+      # Shape from backup should NOT be present after failed integrity
+      assert [] == ShapeStatus.list_shapes(state2)
+      refute File.exists?(backup_file)
+    end
+  end
+
   def load_column_info(1338, _),
     do:
       {:ok,

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -742,6 +742,30 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
       end
     end
 
+    describe "#{module_name}.get_all_stored_shape_handles/1" do
+      @describetag skip_initialise: true
+      setup :start_storage
+
+      test "retrieves no shape handles if no shapes persisted", %{storage: opts} do
+        assert {:ok, MapSet.new()} == Storage.get_all_stored_shape_handles(opts)
+      end
+
+      test "retrieves stored shape handles", %{storage: opts} do
+        _writer = Storage.init_writer!(opts, @shape)
+
+        assert {:ok, MapSet.new([@shape_handle])} == Storage.get_all_stored_shape_handles(opts)
+      end
+
+      test "ignores shapes marked for deletion", %{storage: opts} do
+        _writer = Storage.init_writer!(opts, @shape)
+
+        {PureFileStorage, shape_opts} = opts
+        File.touch(PureFileStorage.deletion_marker_path(shape_opts))
+
+        assert {:ok, MapSet.new()} == Storage.get_all_stored_shape_handles(opts)
+      end
+    end
+
     describe "#{module_name}.get_all_stored_shapes/1" do
       @describetag skip_initialise: true
       setup :start_storage
@@ -756,6 +780,17 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         assert {:ok, %{@shape_handle => parsed}} = Storage.get_all_stored_shapes(opts)
 
         assert @shape == parsed
+      end
+    end
+
+    describe "#{module_name}.metadata_backup_dir/1" do
+      @describetag skip_initialise: true
+      setup :start_storage
+
+      test "returns metadata backup directory", %{storage: opts} do
+        assert dir = Storage.metadata_backup_dir(opts)
+        assert is_binary(dir)
+        assert Path.type(dir) == :absolute
       end
     end
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1236,7 +1236,7 @@ defmodule Electric.ShapeCacheTest do
             ctx.shape_cache_opts[:server],
             ctx.consumer_supervisor,
             ctx.shape_log_collector,
-            ctx.shape_status_agent,
+            ctx.shape_status_owner,
             "shape_task_supervisor"
           ] do
         stop_supervised(name)

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -77,6 +77,13 @@ defmodule Electric.Shapes.ConsumerTest do
     Lsn.from_integer(offset)
   end
 
+  defp stub_shape_status_shutdown(shape_handle, ctx) do
+    Mock.ShapeStatus
+    |> stub(:get_existing_shape, fn _, _ -> {shape_handle, @shape1} end)
+    |> stub(:set_shape_storage_state, fn _, _, _ -> :ok end)
+    |> allow(self(), Consumer.whereis(ctx.stack_id, shape_handle))
+  end
+
   defp run_with_conn_noop(conn, cb), do: cb.(conn)
 
   describe "event handling" do
@@ -124,12 +131,11 @@ defmodule Electric.Shapes.ConsumerTest do
       consumers =
         for {shape_handle, shape} <- ctx.shapes do
           Mock.ShapeStatus
+          |> stub(:consume_shape_storage_state, fn _, ^shape_handle -> nil end)
           |> expect(:initialise_shape, 1, fn _, ^shape_handle, _, _ -> :ok end)
           |> expect(:set_snapshot_xmin, 1, fn _, ^shape_handle, _ -> :ok end)
           |> expect(:mark_snapshot_started, 1, fn _, ^shape_handle -> :ok end)
-          |> allow(self(), fn ->
-            Consumer.whereis(ctx.stack_id, shape_handle)
-          end)
+          |> allow(self(), fn -> Consumer.whereis(ctx.stack_id, shape_handle) end)
 
           {:ok, consumer} =
             start_supervised(
@@ -150,11 +156,13 @@ defmodule Electric.Shapes.ConsumerTest do
               id: {Shapes.ConsumerSupervisor, shape_handle}
             )
 
-          assert_receive {Support.TestStorage, :init_writer!, ^shape_handle, ^shape}
+          assert_receive {Support.TestStorage, :init_writer!, ^shape_handle, ^shape, _}
           # Wait for the virtual snapshot to have started to avoid overriding any of the
           # defined Mox expectations
           :started =
             GenServer.call(Consumer.name(ctx.stack_id, shape_handle), :await_snapshot_start)
+
+          stub_shape_status_shutdown(shape_handle, ctx)
 
           consumer
         end
@@ -385,6 +393,8 @@ defmodule Electric.Shapes.ConsumerTest do
 
       Mock.ShapeStatus
       |> expect(:remove_shape, fn _, @shape_handle1 -> :ok end)
+      |> stub(:get_existing_shape, fn _, @shape_handle1 -> {@shape_handle1, @shape1} end)
+      |> stub(:set_shape_storage_state, fn _, @shape_handle1, _ -> :ok end)
       |> allow(
         self(),
         Shapes.Consumer.whereis(ctx.stack_id, @shape_handle1)
@@ -452,8 +462,13 @@ defmodule Electric.Shapes.ConsumerTest do
 
       Mock.ShapeStatus
       |> expect(:remove_shape, 0, fn _, _ -> :ok end)
+      |> expect(:set_shape_storage_state, 0, fn _, _, _ -> :ok end)
+      |> stub(:get_existing_shape, fn _, _ -> {@shape_handle1, @shape1} end)
+      |> stub(:set_shape_storage_state, fn _, _, _ -> :ok end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
       |> expect(:remove_shape, 0, fn _, _ -> :ok end)
+      |> stub(:get_existing_shape, fn _, _ -> {@shape_handle2, @shape2} end)
+      |> stub(:set_shape_storage_state, fn _, _, _ -> :ok end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.producer)
@@ -487,9 +502,13 @@ defmodule Electric.Shapes.ConsumerTest do
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
 
       Mock.ShapeStatus
-      |> expect(:remove_shape, 1, fn _, _ -> :ok end)
+      |> expect(:remove_shape, 1, fn _, @shape_handle1 -> :ok end)
+      |> stub(:get_existing_shape, fn _, @shape_handle1 -> {@shape_handle1, @shape1} end)
+      |> expect(:set_shape_storage_state, 1, fn _, @shape_handle1, _ -> :ok end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
       |> expect(:remove_shape, 0, fn _, _ -> :ok end)
+      |> stub(:get_existing_shape, fn _, _ -> {@shape_handle2, @shape2} end)
+      |> stub(:set_shape_storage_state, fn _, _, _ -> :ok end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel, ctx.producer)
@@ -527,8 +546,12 @@ defmodule Electric.Shapes.ConsumerTest do
 
       Mock.ShapeStatus
       |> expect(:remove_shape, 1, fn _, _ -> :ok end)
+      |> stub(:get_existing_shape, fn _, @shape_handle1 -> {@shape_handle1, @shape1} end)
+      |> expect(:set_shape_storage_state, 1, fn _, @shape_handle1, _ -> :ok end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle1))
       |> expect(:remove_shape, 0, fn _, _ -> :ok end)
+      |> stub(:get_existing_shape, fn _, _ -> {@shape_handle2, @shape2} end)
+      |> stub(:set_shape_storage_state, fn _, _, _ -> :ok end)
       |> allow(self(), Consumer.whereis(ctx.stack_id, @shape_handle2))
 
       assert :ok = ShapeLogCollector.handle_relation_msg(rel_changed, ctx.producer)
@@ -728,6 +751,8 @@ defmodule Electric.Shapes.ConsumerTest do
       assert [^op1, ^op2] =
                Storage.get_log_stream(LogOffset.last_before_real_offsets(), shape_storage)
                |> Enum.map(&Jason.decode!/1)
+
+      stop_supervised!(ctx.consumer_supervisor)
     end
 
     @tag snapshot_delay: 100
@@ -792,6 +817,8 @@ defmodule Electric.Shapes.ConsumerTest do
       assert [_op1, _op2] =
                Storage.get_log_stream(LogOffset.last_before_real_offsets(), shape_storage)
                |> Enum.map(&Jason.decode!/1)
+
+      stop_supervised!(ctx.consumer_supervisor)
     end
 
     test "restarting a consumer doesn't lower the last known offset when only snapshot is present",

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -150,9 +150,9 @@ defmodule Support.ComponentSetup do
       )
 
     start_link_supervised!(%{
-      id: "shape_status_agent",
+      id: "shape_status_owner",
       start:
-        {Electric.ShapeCache.ShapeStatusAgent, :start_link,
+        {Electric.ShapeCache.ShapeStatusOwner, :start_link,
          [
            [
              stack_id: ctx.stack_id,
@@ -163,7 +163,7 @@ defmodule Support.ComponentSetup do
     })
 
     %{
-      shape_status_agent: "shape_status_agent",
+      shape_status_owner: "shape_status_owner",
       shape_status_opts: shape_status_opts,
       shape_status: {Electric.ShapeCache.ShapeStatus, shape_status_opts}
     }

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -55,12 +55,12 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
-  def init_writer!({parent, shape_handle, init, storage}, shape_definition) do
-    send(parent, {__MODULE__, :init_writer!, shape_handle, shape_definition})
+  def init_writer!({parent, shape_handle, init, storage}, shape_definition, recovery_state) do
+    send(parent, {__MODULE__, :init_writer!, shape_handle, shape_definition, recovery_state})
 
     {module, opts} = storage
 
-    with state <- Storage.init_writer!(storage, shape_definition) do
+    with state <- Storage.init_writer!(storage, shape_definition, recovery_state) do
       for {name, args} <- init do
         apply(module, name, args ++ [opts])
       end
@@ -70,9 +70,21 @@ defmodule Support.TestStorage do
   end
 
   @impl Electric.ShapeCache.Storage
+  def get_all_stored_shape_handles({parent, _init, storage}) do
+    send(parent, {__MODULE__, :get_all_stored_shape_handles})
+    Storage.get_all_stored_shape_handles(storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
   def get_all_stored_shapes({parent, _init, storage}) do
     send(parent, {__MODULE__, :get_all_stored_shapes})
     Storage.get_all_stored_shapes(storage)
+  end
+
+  @impl Electric.ShapeCache.Storage
+  def metadata_backup_dir({parent, _init, storage}) do
+    send(parent, {__MODULE__, :metadata_backup_dir})
+    Storage.metadata_backup_dir(storage)
   end
 
   @impl Electric.ShapeCache.Storage


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/2984

We had observed that loading stored shapes took a long time, especially with larger number of shapes.

Doing some research most of the time was spent waiting on the various reads being done per-shape in order to load it up. @icehaunter is working on reducing those, but either way this would always scale with the number of shapes (at least 2-3 calls per shape). On slow FS like networked storage the time spent waiting on FS calls racks up pretty quickly.

After testing per-shape caching of metadata (reducing basically things to a single read per shape load), I concluded that to see a significant enough speedup we would need a global index that would avoid scaling FS operations with shapes recovered as much as possible.

Ultimately, the `ShapeStatus` table is started before everything else and it has now been assigned its own process as well, so it's the perfect place to do a controlled shutdown backup and restore.


## Backup procedure
- On `ShapeStatusOwner` shutdown, we dump the ETS table to a "backup" directory in our storage dir (with a 60 sec shutdown timeout, should be enough for this)
- On every shape consumer's controlled shutdown, we terminate the writer, flushing the state, closing file handles, and finalising metadata, and if the shape is still being tracked in `ShapeStatus`, we store the "storage recovery state" in the same ETS table - this will get dumped in the `ShapeStatusOwner` shutdown, as consumers all die before that process.
- We dump the ETS table with a basic validation of object count


## Restore procedure
- The `ShapeStatusOwner` attempts to restore the table on init from the backup
 - On top of ETS' own object count validation, I've added an additional integrity check that compares the shape handles found on the file system (a single `ls` call) with the ones found in the restored ETS table - if they do not match the backup is discarded.
 - If the backup restore fails for any reason, we fallback to our regular recovery mechanism with FS as the source of truth
 - On every backup restore (or attempted restore), we delete the backup to avoid any loops or stale state - since the backups are versioned we basically remove a shape status backup dir in its entirety.
- On every consumer startup, "consume" the shape storage state that was stored in ETS to avoid doing any FS operations to initialise the writer
 - No integrity checks are made - we just ensure the stored version and metadata structure matches, otherwise discard
 - We do not verify any files exist, directory structure exists, or anything else - it would defeat the purpose of a controlled restore. Failures will lead to a shape cleanup, nothing catastrophic.
 - I've added `pg_snapshot` in the cached metadata list to avoid all reads, even for the `get_current_position` one.
 - Shape restore has been reduced to just grabbing the file handles.


## Performance 
On my MacBook Air M2, 10k shapes recovery went from ~13sec to ~3sec. I haven't tested this on EFS but I suspect due to the significant reduction in FS/syscalls we're going to see a large speedup (as 10k shapes are taking minutes to load up currently).


## TODO
[] add more tests for covering FS edge cases of failed recovery