### PR TITLE
fix: Parse query cancellation errors as retryable

### DIFF
--- a/.changeset/silver-frogs-report.md
+++ b/.changeset/silver-frogs-report.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Parse DB query cancellation errors as retryable.

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -229,6 +229,24 @@ defmodule Electric.DbConnectionError do
     }
   end
 
+  def from_error(
+        %Postgrex.Error{
+          postgres: %{
+            code: :query_canceled,
+            message: "canceling statement due to user request",
+            severity: "ERROR",
+            pg_code: "57014"
+          }
+        } = error
+      ) do
+    %DbConnectionError{
+      message: error.postgres.message,
+      type: :query_canceled,
+      original_error: error,
+      retry_may_fix?: true
+    }
+  end
+
   def from_error(%Postgrex.Error{postgres: %{code: :internal_error, pg_code: "XX000"}} = error) do
     maybe_database_does_not_exist(error) ||
       maybe_endpoint_does_not_exist(error) ||

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -142,6 +142,27 @@ defmodule Electric.DbConnectionErrorTest do
              } == DbConnectionError.from_error(error)
     end
 
+    test "with query cancelled error" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :query_canceled,
+          message: "canceling statement due to user request",
+          severity: "ERROR",
+          pg_code: "57014"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message: "canceling statement due to user request",
+               type: :query_canceled,
+               original_error: error,
+               retry_may_fix?: true
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with insufficient privileges error" do
       error = %Postgrex.Error{
         message: nil,


### PR DESCRIPTION
Parsing [one more error](https://electricsql-04.sentry.io/issues/59667277/?environment=production&project=4508410462404688&query=is%3Aunresolved&referrer=issue-stream) that should be marked as retryable.