### PR TITLE
fix: Handle missing publication errors

### DIFF
--- a/.changeset/happy-parents-decide.md
+++ b/.changeset/happy-parents-decide.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Handle missing publication at runtime by dropping slot and restarting - expected to happen with manual editing of Electric slots and publications.

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -265,8 +265,7 @@ defmodule Electric.DbConnectionError do
       """,
       type: :missing_publication,
       original_error: error,
-      retry_may_fix?: false,
-      drop_slot_and_restart?: true
+      retry_may_fix?: true
     }
   end
 

--- a/packages/sync-service/lib/electric/snapshot_error.ex
+++ b/packages/sync-service/lib/electric/snapshot_error.ex
@@ -37,6 +37,23 @@ defmodule Electric.SnapshotError do
     }
   end
 
+  def from_error(
+        %Postgrex.Error{
+          postgres: %{
+            code: :undefined_object,
+            message: "publication " <> _ = message,
+            severity: "ERROR",
+            pg_code: "42704"
+          }
+        } = error
+      ) do
+    %SnapshotError{
+      type: :missing_publication,
+      message: message,
+      original_error: error
+    }
+  end
+
   def from_error(%Postgrex.Error{} = error) do
     %SnapshotError{
       type: :unknown,

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -163,6 +163,32 @@ defmodule Electric.DbConnectionErrorTest do
              } == DbConnectionError.from_error(error)
     end
 
+    test "with publication not found error" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :undefined_object,
+          message: "publication \"cloud_electric_pub_random_tenant_id\" does not exist",
+          severity: "ERROR",
+          pg_code: "42704"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message: """
+               The publication was expected to be present but was not found.
+               Publications and replication slots created by Electric should not
+               be manually modified or deleted, as it breaks replication integrity.
+               """,
+               type: :missing_publication,
+               original_error: error,
+               retry_may_fix?: false,
+               drop_slot_and_restart?: true
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with insufficient privileges error" do
       error = %Postgrex.Error{
         message: nil,

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -184,8 +184,7 @@ defmodule Electric.DbConnectionErrorTest do
                """,
                type: :missing_publication,
                original_error: error,
-               retry_may_fix?: false,
-               drop_slot_and_restart?: true
+               retry_may_fix?: true
              } == DbConnectionError.from_error(error)
     end
 

--- a/packages/sync-service/test/electric/snapshot_error_test.exs
+++ b/packages/sync-service/test/electric/snapshot_error_test.exs
@@ -1,0 +1,104 @@
+defmodule Electric.SnapshotErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.SnapshotError
+
+  describe "table_lock_timeout/0" do
+    test "returns table lock timeout error" do
+      assert %SnapshotError{
+               type: :table_lock_timeout,
+               message: "Snapshot timed out while waiting for a table lock"
+             } = SnapshotError.table_lock_timeout()
+    end
+  end
+
+  describe "from_error/1" do
+    test "with a queue timeout DBConnection error" do
+      error = %DBConnection.ConnectionError{
+        reason: :queue_timeout,
+        message: "client queue timeout",
+        severity: :error
+      }
+
+      assert %SnapshotError{
+               type: :queue_timeout,
+               message: "Snapshot creation failed because of a connection pool queue timeout",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
+
+    test "with schema changed (undefined_table) error" do
+      error = %Postgrex.Error{
+        postgres: %{code: :undefined_table, message: "relation \"items\" does not exist"}
+      }
+
+      assert %SnapshotError{
+               type: :schema_changed,
+               message: "Schema changed while creating snapshot",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
+
+    test "with insufficient privilege error" do
+      error = %Postgrex.Error{
+        postgres: %{code: :insufficient_privilege, message: "permission denied for table items"}
+      }
+
+      assert %SnapshotError{
+               type: :missing_privilege,
+               message: "permission denied for table items",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
+
+    test "with missing publication error" do
+      error = %Postgrex.Error{
+        postgres: %{
+          code: :undefined_object,
+          message: "publication \"pub_foo\" does not exist",
+          severity: "ERROR",
+          pg_code: "42704"
+        }
+      }
+
+      assert %SnapshotError{
+               type: :missing_publication,
+               message: "publication \"pub_foo\" does not exist",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
+
+    test "with generic Postgrex error" do
+      error = %Postgrex.Error{postgres: %{code: :some_other, message: "some other message"}}
+
+      assert %SnapshotError{
+               type: :unknown,
+               message: "some other message",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
+
+    test "with DbConfigurationError" do
+      error = %Electric.DbConfigurationError{
+        type: :tables_missing_from_publication,
+        message: "tables missing"
+      }
+
+      assert %SnapshotError{
+               type: :tables_missing_from_publication,
+               message: "tables missing",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
+
+    test "with arbitrary error" do
+      error = %RuntimeError{message: "runtime oops"}
+
+      assert %SnapshotError{
+               type: :unknown,
+               message: "runtime oops",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/electric-sql/stratovolt/issues/761

The errors we observed were because the publication created by Electric was being manually deleted by the developer. We should be safe to parse it into an error that restarts, ensuring consistency.

## EDIT
I've converted it to `retry_may_fix?: true` as 1) that was the current behaviour and 2) since this error basically restarts the replication client and the process of creating the slot/publication, this might be more appropriate?

@alco what do you think? should we force a harder restart on this error or rely on `retry_may_fix?`?


## EDIT 2

We are now capturing the missing publication error in `PublicationManager` as well and immediately terminating it, which causes a subsequent termination of `ShapeLogCollector` and thus a restart of the replication client which fixes the missing publication.

