### PR TITLE
Msfstef/fix erlang errors from connections

### DIFF
--- a/.changeset/rotten-birds-argue.md
+++ b/.changeset/rotten-birds-argue.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Prevent pool connections from starting if supervisor is found to already be dead.

--- a/.changeset/tame-donkeys-approve.md
+++ b/.changeset/tame-donkeys-approve.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Change order of replication supervisor processes to ensure consumers can perform all operations.

--- a/packages/sync-service/lib/electric/connection/manager/pool.ex
+++ b/packages/sync-service/lib/electric/connection/manager/pool.ex
@@ -243,7 +243,12 @@ defmodule Electric.Connection.Manager.Pool do
   # and log any issues before and after the connection is established.
   def configure_pool_conn(opts, supervisor_pid) do
     send(supervisor_pid, {:pool_conn_started, self()})
-    Process.link(supervisor_pid)
+
+    # If supervisor process not alive when initializing connection, abort it
+    if Process.alive?(supervisor_pid),
+      do: Process.link(supervisor_pid),
+      else: exit({:shutdown, {:supervisor_not_alive, supervisor_pid}})
+
     opts
   end
 

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -20,10 +20,10 @@ defmodule Electric.Replication.Supervisor do
     Logger.info("Starting shape replication pipeline")
 
     shape_status_agent = Keyword.fetch!(opts, :shape_status_agent)
+    log_collector = Keyword.fetch!(opts, :log_collector)
+    publication_manager = Keyword.fetch!(opts, :publication_manager)
     consumer_supervisor = Keyword.fetch!(opts, :consumer_supervisor)
     shape_cache = Keyword.fetch!(opts, :shape_cache)
-    publication_manager = Keyword.fetch!(opts, :publication_manager)
-    log_collector = Keyword.fetch!(opts, :log_collector)
     schema_reconciler = Keyword.fetch!(opts, :schema_reconciler)
     stack_id = Keyword.fetch!(opts, :stack_id)
 
@@ -31,9 +31,9 @@ defmodule Electric.Replication.Supervisor do
       {Task.Supervisor,
        name: Electric.ProcessRegistry.name(stack_id, Electric.StackTaskSupervisor)},
       shape_status_agent,
-      consumer_supervisor,
-      publication_manager,
       log_collector,
+      publication_manager,
+      consumer_supervisor,
       shape_cache,
       schema_reconciler
     ]


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/3049

The error that is hidden is a `:noproc` `ErlangError` when trying to do `Process.link` from the connection being set up to a supervisor that is no longer alive.

The underlying DBConnection application has various processes living in its own extra application handling connection lifecycles with some levels of indirection so we cannot rely on the pool being terminated to ensure there's no new connections popping up when the supervisor is dead.

Instead, we check if the supervisor is alive at the time of the connection being configured, and if it is not we exit.

I've reproduced the error manually by randomly killing off the supervisor with timeouts while the pool connections are setting up and was consistently reproducing this - the suggested fix does the trick. I was also thinking of rescuing the `ErlangError` but the `alive?` check feels more explicit (even if it technically has a gap between the check and the link op?). I don't _love_ it but it does take care of the issue and I can't find a better approach currently.


While running tests I also noticed some errors that I figured were because of an incorrect order of processes in our replication supervisor. The consumer supervisor should be started after the shape status table, the shape log collector, and the publication manager, as consumers make use of all three during their lifetime, so during controlled shutdowns we want this order to be maintained.