### PR TITLE
fix: Add metadata marking logs from postgrex connection processes

### DIFF
--- a/.changeset/stupid-dodos-suffer.md
+++ b/.changeset/stupid-dodos-suffer.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add logger metadata flag for postgrex processes

--- a/packages/sync-service/lib/electric/postgres/lock_connection.ex
+++ b/packages/sync-service/lib/electric/postgres/lock_connection.ex
@@ -78,6 +78,8 @@ defmodule Electric.Postgres.LockConnection do
 
     metadata = [
       lock_name: opts.lock_name,
+      # flag used for error filtering
+      is_connection_process?: true,
       stack_id: opts.stack_id
     ]
 

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -172,7 +172,13 @@ defmodule Electric.Postgres.ReplicationClient do
     state = State.new(replication_opts)
 
     Process.set_label({:replication_client, state.stack_id})
-    Logger.metadata(stack_id: state.stack_id)
+
+    Logger.metadata(
+      # flag used for error filtering
+      is_connection_process?: true,
+      stack_id: state.stack_id
+    )
+
     Electric.Telemetry.Sentry.set_tags_context(stack_id: state.stack_id)
 
     {:ok, state}


### PR DESCRIPTION
Until we implement https://github.com/electric-sql/electric/issues/3019 which remains to be designed and implemented, it will make life much easier if we can tell what error logs are coming from processes that are also Postgrex connection processes.

We already make use of such indirect info for the lock connection that adds `lock_name` as metadata - I'd rather have this explicit flag.