### PR TITLE
fix: Parse "remaining connection slots reserved" DB error as insufficient resources

### DIFF
--- a/.changeset/sour-suns-tell.md
+++ b/.changeset/sour-suns-tell.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Parse DB error about remaining slots being reserved as insufficient resources.

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -202,6 +202,25 @@ defmodule Electric.DbConnectionError do
     }
   end
 
+  def from_error(
+        %Postgrex.Error{
+          postgres: %{
+            code: :internal_error,
+            message:
+              "remaining connection slots are reserved for roles with the SUPERUSER attribute",
+            severity: "ERROR",
+            pg_code: "XX000"
+          }
+        } = error
+      ) do
+    %DbConnectionError{
+      message: error.postgres.message,
+      type: :insufficient_resources,
+      original_error: error,
+      retry_may_fix?: true
+    }
+  end
+
   def from_error(%Postgrex.Error{message: "ssl not available"} = error) do
     %DbConnectionError{
       message: "Database server not configured to accept SSL connections",

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -121,6 +121,29 @@ defmodule Electric.DbConnectionErrorTest do
              } == DbConnectionError.from_error(error)
     end
 
+    test "with remaining connection slots reserved error" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :internal_error,
+          message:
+            "remaining connection slots are reserved for roles with the SUPERUSER attribute",
+          severity: "ERROR",
+          pg_code: "XX000"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message:
+                 "remaining connection slots are reserved for roles with the SUPERUSER attribute",
+               type: :insufficient_resources,
+               original_error: error,
+               retry_may_fix?: true
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with server connection crashed error" do
       error = %Postgrex.Error{
         message: nil,


### PR DESCRIPTION
Fixes [Sentry issue](https://electricsql-04.sentry.io/issues/58939671/) - this is just another instance of insufficient resources, definitely retryable (until resources are freed).