### PR TITLE
feat: support non-PK selects in subqueries

### DIFF
--- a/.changeset/moody-pandas-decide.md
+++ b/.changeset/moody-pandas-decide.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+feat: support non-PK selects in subqueries

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -511,7 +511,7 @@ defmodule Electric.ShapeCache do
             stack_id: state.stack_id,
             shape_handle: shape_handle,
             storage: state.storage,
-            columns: inner_shape.selected_columns,
+            columns: inner_shape.explicitly_selected_columns,
             materialized_type: materialized_type
           })
 

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -180,6 +180,7 @@ defmodule Electric.Shapes.Consumer.Materializer do
       Enum.reduce(changes, {state.index, {state.value_counts, []}}, fn
         %Changes.NewRecord{key: key, record: record}, {index, counts_and_events} ->
           value = cast!(record, state)
+          if is_map_key(index, key), do: raise("Key #{key} already exists")
           index = Map.put(index, key, value)
 
           {index, increment_value(counts_and_events, value)}

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -56,9 +56,10 @@ defmodule Electric.Shapes.Consumer.Materializer do
     end)
   end
 
-  def subscribe(stack_id, shape_handle) do
-    GenServer.call(name(stack_id, shape_handle), :subscribe)
-  end
+  def subscribe(opts), do: GenServer.call(name(opts), :subscribe)
+
+  def subscribe(stack_id, shape_handle),
+    do: subscribe(%{stack_id: stack_id, shape_handle: shape_handle})
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: name(opts))
@@ -73,7 +74,8 @@ defmodule Electric.Shapes.Consumer.Materializer do
 
     state =
       Map.merge(opts, %{
-        view: %{},
+        index: %{},
+        value_counts: %{},
         offset: LogOffset.before_all(),
         ref: nil,
         subscribers: MapSet.new()
@@ -93,28 +95,19 @@ defmodule Electric.Shapes.Consumer.Materializer do
   def handle_continue(:read_stream, state) do
     {:ok, offset, stream} = get_stream_up_to_date(state.offset, state)
 
-    view =
+    {state, _} =
       stream
       |> Stream.map(&Jason.decode!/1)
-      |> Enum.reduce(state.view, fn %{
-                                      "key" => key,
-                                      "value" => value,
-                                      "headers" => %{"operation" => operation}
-                                    },
-                                    view ->
+      |> Enum.map(fn %{"key" => key, "value" => value, "headers" => %{"operation" => operation}} ->
         case operation do
-          "insert" ->
-            Map.put(view, key, cast!(value, state))
-
-          "update" ->
-            Map.put(view, key, cast!(value, state))
-
-          "delete" ->
-            Map.delete(view, key)
+          "insert" -> %Changes.NewRecord{key: key, record: value}
+          "update" -> %Changes.UpdatedRecord{key: key, record: value}
+          "delete" -> %Changes.DeletedRecord{key: key, old_record: value}
         end
       end)
+      |> apply_changes(state)
 
-    {:noreply, %{state | offset: offset, view: view}}
+    {:noreply, %{state | offset: offset}}
   end
 
   def get_stream_up_to_date(min_offset, state) do
@@ -145,8 +138,8 @@ defmodule Electric.Shapes.Consumer.Materializer do
   #   {:noreply, state, {:continue, :read_stream}}
   # end
 
-  def handle_call(:get_link_values, _from, %{view: view} = state) do
-    values = MapSet.new(Map.values(view))
+  def handle_call(:get_link_values, _from, %{value_counts: value_counts} = state) do
+    values = MapSet.new(Map.keys(value_counts))
 
     {:reply, values, state}
   end
@@ -156,27 +149,15 @@ defmodule Electric.Shapes.Consumer.Materializer do
   end
 
   def handle_call({:new_changes, changes}, _from, state) do
-    {view, events} =
-      Enum.reduce(changes, {state.view, []}, fn
-        %Changes.NewRecord{key: key, record: record}, {view, events} ->
-          value = cast!(record, state)
-          {Map.put(view, key, value), [{:move_in, value} | events]}
+    {state, events} = apply_changes(changes, state)
 
-        %Changes.UpdatedRecord{key: key, record: record}, {view, events} ->
-          # For now materializer for inner shape expects only PKs, so updates are not expected
-          # We might need to figure out move in/out for updates if something other than PK is selected
-          {Map.put(view, key, cast!(record, state)), events}
-
-        %Changes.DeletedRecord{key: key, old_record: old_record}, {view, events} ->
-          value = cast!(old_record, state)
-          {Map.delete(view, key), [{:move_out, value} | events]}
-      end)
-
-    for pid <- state.subscribers do
-      send(pid, {:materializer_changes, state.shape_handle, events})
+    if events != [] do
+      for pid <- state.subscribers do
+        send(pid, {:materializer_changes, state.shape_handle, events})
+      end
     end
 
-    {:reply, :ok, %{state | view: view}}
+    {:reply, :ok, state}
   end
 
   def handle_call(:subscribe, {pid, _ref} = _from, state) do
@@ -192,5 +173,57 @@ defmodule Electric.Shapes.Consumer.Materializer do
   defp cast!(record, %{columns: [column], materialized_type: {:array, type}}) do
     {:ok, value} = Eval.Env.parse_const(Eval.Env.new(), Map.fetch!(record, column), type)
     value
+  end
+
+  defp apply_changes(changes, state) when is_list(changes) do
+    {index, {value_counts, events}} =
+      Enum.reduce(changes, {state.index, {state.value_counts, []}}, fn
+        %Changes.NewRecord{key: key, record: record}, {index, counts_and_events} ->
+          value = cast!(record, state)
+          index = Map.put(index, key, value)
+
+          {index, increment_value(counts_and_events, value)}
+
+        %Changes.UpdatedRecord{key: key, record: record}, {index, counts_and_events} ->
+          # TODO: this is written as if it supports multiple selected columns, but it doesn't for now
+          if Enum.any?(state.columns, &is_map_key(record, &1)) do
+            value = cast!(record, state)
+            old_value = Map.fetch!(index, key)
+            index = Map.put(index, key, value)
+
+            {index, counts_and_events |> decrement_value(old_value) |> increment_value(value)}
+          else
+            # Nothing relevant to this materializer has been updated
+            {index, counts_and_events}
+          end
+
+        %Changes.DeletedRecord{key: key}, {index, counts_and_events} ->
+          {value, index} = Map.pop!(index, key)
+
+          {index, decrement_value(counts_and_events, value)}
+      end)
+
+    {%{state | index: index, value_counts: value_counts}, Enum.reverse(events)}
+  end
+
+  defp increment_value({value_counts, events}, value) do
+    case Map.fetch(value_counts, value) do
+      {:ok, count} ->
+        {Map.put(value_counts, value, count + 1), events}
+
+      :error ->
+        {Map.put(value_counts, value, 1), [{:move_in, value} | events]}
+    end
+  end
+
+  defp decrement_value({value_counts, events}, value) do
+    # If we're decrementing, it must have been added before
+    case Map.fetch!(value_counts, value) do
+      1 ->
+        {Map.delete(value_counts, value), [{:move_out, value} | events]}
+
+      count ->
+        {Map.put(value_counts, value, count - 1), events}
+    end
   end
 end

--- a/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/delete_shape_plug_test.exs
@@ -21,6 +21,7 @@ defmodule Electric.Plug.DeleteShapePlugTest do
     root_pk: ["id"],
     root_column_count: 1,
     selected_columns: ["id"],
+    explicitly_selected_columns: ["id"],
     flags: %{selects_all_columns: true}
   }
   @test_shape_handle "test-shape-handle"

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -33,6 +33,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     root_column_count: 2,
     root_pk: ["id"],
     selected_columns: ["id", "value"],
+    explicitly_selected_columns: ["id", "value"],
     flags: %{selects_all_columns: true}
   }
   @test_shape_handle "test-shape-handle"

--- a/packages/sync-service/test/electric/shape_cache/pure_file_storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/pure_file_storage_test.exs
@@ -19,6 +19,7 @@ defmodule Electric.ShapeCache.PureFileStorageTest do
     root_table_id: 1,
     root_pk: ["id"],
     selected_columns: ["id"],
+    explicitly_selected_columns: ["id"],
     where:
       Electric.Replication.Eval.Parser.parse_and_validate_expression!("id != '1'",
         refs: %{["id"] => :text}

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -23,6 +23,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
     root_table_id: 1,
     root_pk: ["id"],
     selected_columns: ["id"],
+    explicitly_selected_columns: ["id"],
     where:
       Electric.Replication.Eval.Parser.parse_and_validate_expression!("id != '1'",
         refs: %{["id"] => :text}

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -477,7 +477,8 @@ defmodule Electric.ShapeCacheTest do
         root_table: {"public", "partitioned_items"},
         root_table_id: 1,
         root_pk: ["a", "b"],
-        selected_columns: ["a", "b"]
+        selected_columns: ["a", "b"],
+        explicitly_selected_columns: ["a", "b"]
       }
 
       {shape_handle, _} = ShapeCache.get_or_create_shape_handle(shape, ctx.shape_cache_opts)

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -24,6 +24,7 @@ defmodule Electric.Shapes.ApiTest do
     root_column_count: 2,
     root_pk: ["id"],
     selected_columns: ["id", "value"],
+    explicitly_selected_columns: ["id", "value"],
     flags: %{selects_all_columns: true}
   }
   @registry __MODULE__.Registry

--- a/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
@@ -3,6 +3,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
   import Support.ComponentSetup
   use Repatch.ExUnit
 
+  alias Electric.LogItems
   alias Electric.Replication.Changes
   alias Electric.ShapeCache.Storage
   alias Electric.Shapes.Consumer
@@ -10,14 +11,25 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
   setup [:with_stack_id_from_test, :with_in_memory_storage]
 
-  setup %{storage: storage, stack_id: stack_id} do
+  setup %{storage: storage, stack_id: stack_id} = ctx do
     {:via, Registry, {registry_name, key}} = Consumer.name(stack_id, "test")
 
     Registry.register(registry_name, key, :consumer)
 
     Storage.for_shape("test", storage) |> Storage.start_link()
     Storage.for_shape("test", storage) |> Storage.mark_snapshot_as_started()
-    Storage.for_shape("test", storage) |> then(&Storage.make_new_snapshot!([], &1))
+
+    snapshot_data =
+      Map.get(ctx, :snapshot_data, [])
+      |> case do
+        [] -> []
+        [x | _] = items when is_map(x) -> make_snapshot_data(items)
+        [x | _] = items when is_binary(x) -> items
+        {items, opts} -> make_snapshot_data(items, opts)
+      end
+
+    Storage.for_shape("test", storage)
+    |> then(&Storage.make_new_snapshot!(snapshot_data, &1))
 
     {:ok, shape_handle: "test"}
   end
@@ -64,14 +76,296 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
     assert Materializer.get_link_values(ctx) == MapSet.new([1, 2, 3])
   end
 
-  test "materializer correctly maps non-pk changes", %{shape_handle: shape_handle} = ctx do
+  describe "materializing non-pk selected columns" do
+    test "runtime insert of a new value is seen & causes a move-in", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(ctx, [
+        %Changes.NewRecord{key: "1", record: %{"value" => "1"}}
+      ])
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([1])
+
+      assert_receive {:materializer_changes, _, move_in: 1}
+    end
+
+    @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
+    test "on-load insert of a new value is seen & does not cause a move-in", ctx do
+      ctx = with_materializer(ctx)
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10])
+
+      refute_received {:materializer_changes, _, _}
+    end
+
+    @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
+    test "runtime update of a value is seen & causes a move-out & move-in", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(
+        ctx,
+        [
+          %Changes.UpdatedRecord{
+            record: %{"id" => "1", "value" => "11"},
+            old_record: %{"id" => "1", "value" => "10"}
+          }
+        ]
+        |> prep_changes()
+      )
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([11])
+
+      assert_receive {:materializer_changes, _, move_out: 10, move_in: 11}
+    end
+
+    @tag snapshot_data: [
+           %Changes.NewRecord{record: %{"id" => "1", "value" => "10"}},
+           Changes.UpdatedRecord.new(
+             record: %{"id" => "1", "value" => "11"},
+             old_record: %{"id" => "1", "value" => "10"}
+           )
+         ]
+    test "on-load update of a value is seen & does not cause events", ctx do
+      ctx = with_materializer(ctx)
+      assert Materializer.get_link_values(ctx) == MapSet.new([11])
+      refute_received {:materializer_changes, _, _}
+    end
+
+    @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
+    test "runtime delete of a value is seen & causes a move-out", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(
+        ctx,
+        [%Changes.DeletedRecord{old_record: %{"id" => "1", "value" => "10"}}] |> prep_changes()
+      )
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([])
+
+      assert_receive {:materializer_changes, _, move_out: 10}
+    end
+
+    @tag snapshot_data: [
+           %Changes.NewRecord{record: %{"id" => "1", "value" => "10"}},
+           %Changes.DeletedRecord{old_record: %{"id" => "1", "value" => "10"}}
+         ]
+    test "on-load delete of a value is seen & does not cause events", ctx do
+      ctx = with_materializer(ctx)
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([])
+
+      refute_received {:materializer_changes, _, _}
+    end
+
+    @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
+    test "insert of a value that's already present in the shape does not cause events", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(
+        ctx,
+        [%Changes.NewRecord{record: %{"id" => "2", "value" => "10"}}] |> prep_changes()
+      )
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10])
+
+      refute_received {:materializer_changes, _, _}
+    end
+
+    @tag snapshot_data: [
+           %Changes.NewRecord{record: %{"id" => "1", "value" => "10"}},
+           %Changes.NewRecord{record: %{"id" => "2", "value" => "20"}}
+         ]
+    test "update of a value to a present value causes just a move-out", ctx do
+      ctx = with_materializer(ctx)
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10, 20])
+
+      Materializer.new_changes(
+        ctx,
+        [
+          %Changes.UpdatedRecord{
+            record: %{"id" => "1", "value" => "20"},
+            old_record: %{"id" => "1", "value" => "10"}
+          }
+        ]
+        |> prep_changes()
+      )
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([20])
+
+      assert_received {:materializer_changes, _, move_out: 10}
+    end
+
+    @tag snapshot_data: [
+           %Changes.NewRecord{record: %{"id" => "1", "value" => "10"}},
+           %Changes.NewRecord{record: %{"id" => "2", "value" => "10"}}
+         ]
+    test "update of a value to a non-present value causes a move-in", ctx do
+      ctx = with_materializer(ctx)
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10])
+
+      Materializer.new_changes(
+        ctx,
+        [
+          %Changes.UpdatedRecord{
+            record: %{"id" => "1", "value" => "20"},
+            old_record: %{"id" => "1", "value" => "10"}
+          }
+        ]
+        |> prep_changes()
+      )
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10, 20])
+
+      assert_received {:materializer_changes, _, move_in: 20}
+    end
+
+    @tag snapshot_data: [
+           %Changes.NewRecord{record: %{"id" => "1", "value" => "10"}},
+           %Changes.NewRecord{record: %{"id" => "2", "value" => "20"}},
+           %Changes.NewRecord{record: %{"id" => "3", "value" => "10"}}
+         ]
+    test "update between otherwise present values causes no events", ctx do
+      ctx = with_materializer(ctx)
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10, 20])
+
+      Materializer.new_changes(
+        ctx,
+        [
+          %Changes.UpdatedRecord{
+            record: %{"id" => "1", "value" => "20"},
+            old_record: %{"id" => "1", "value" => "10"}
+          }
+        ]
+        |> prep_changes()
+      )
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10, 20])
+
+      refute_received {:materializer_changes, _, _}
+    end
+
+    @tag snapshot_data: [
+           %Changes.NewRecord{record: %{"id" => "1", "value" => "10"}},
+           %Changes.NewRecord{record: %{"id" => "2", "value" => "10"}}
+         ]
+    test "delete of an otherwise present value causes no events", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(
+        ctx,
+        [%Changes.DeletedRecord{old_record: %{"id" => "1", "value" => "10"}}] |> prep_changes()
+      )
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10])
+
+      refute_received {:materializer_changes, _, _}
+    end
+
+    @tag snapshot_data: [
+           %Changes.NewRecord{record: %{"id" => "1", "value" => "10"}},
+           %Changes.NewRecord{record: %{"id" => "2", "value" => "10"}}
+         ]
+    test "insert of an otherwise present value causes no events", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(
+        ctx,
+        [%Changes.NewRecord{record: %{"id" => "3", "value" => "10"}}] |> prep_changes()
+      )
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10])
+
+      refute_received {:materializer_changes, _, _}
+    end
+
+    @tag snapshot_data: [
+           %Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}
+         ]
+    test "insert of a PK we've already seen raises", ctx do
+      ctx = with_materializer(ctx)
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([10])
+
+      pid = GenServer.whereis(Materializer.name(ctx))
+      Process.unlink(pid)
+
+      try do
+        Materializer.new_changes(
+          ctx,
+          [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}] |> prep_changes()
+        )
+      catch
+        :exit, {{reason, _}, _} ->
+          assert reason.message =~ ~r/Key .* already exists/
+      end
+    end
+
+    test "delete of a PK we've not seen throws an error", ctx do
+      ctx = with_materializer(ctx)
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([])
+
+      pid = GenServer.whereis(Materializer.name(ctx))
+      Process.unlink(pid)
+
+      try do
+        Materializer.new_changes(
+          ctx,
+          [%Changes.DeletedRecord{old_record: %{"id" => "1", "value" => "10"}}] |> prep_changes()
+        )
+      catch
+        :exit, {{reason, _}, _} ->
+          assert %KeyError{key: _} = reason
+      end
+    end
+
+    test "moves are correctly tracked across multiple calls", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(ctx, [
+        %Changes.NewRecord{key: "1", record: %{"value" => "1"}},
+        %Changes.NewRecord{key: "2", record: %{"value" => "2"}},
+        %Changes.NewRecord{key: "3", record: %{"value" => "1"}}
+      ])
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([1, 2])
+
+      assert_receive {:materializer_changes, _, move_in: 1, move_in: 2}
+
+      Materializer.new_changes(ctx, [
+        %Changes.UpdatedRecord{
+          key: "2",
+          record: %{"value" => "3"},
+          old_record: %{"value" => "2"}
+        },
+        %Changes.DeletedRecord{key: "3", old_record: %{"value" => "1"}},
+        %Changes.UpdatedRecord{key: "1", record: %{"other" => "1"}, old_record: %{"other" => "0"}}
+      ])
+
+      assert Materializer.get_link_values(ctx) == MapSet.new([1, 3])
+
+      assert_receive {:materializer_changes, _, move_out: 2, move_in: 3}
+    end
+  end
+
+  defp respond_to_call(request, response) do
+    receive do
+      {:"$gen_call", {from, ref}, ^request} ->
+        send(from, {ref, response})
+    end
+  end
+
+  defp with_materializer(ctx, opts \\ []) do
     {:ok, _pid} =
       Materializer.start_link(%{
         stack_id: ctx.stack_id,
-        shape_handle: shape_handle,
+        shape_handle: ctx.shape_handle,
         storage: ctx.storage,
-        columns: ["value"],
-        materialized_type: {:array, :int8}
+        columns: Keyword.get(opts, :columns, ["value"]),
+        materialized_type: Keyword.get(opts, :materialized_type, {:array, :int8})
       })
 
     respond_to_call(:await_snapshot_start, :ok)
@@ -80,31 +374,25 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
     assert Materializer.wait_until_ready(ctx) == :ok
     Materializer.subscribe(ctx)
 
-    Materializer.new_changes(ctx, [
-      %Changes.NewRecord{key: "1", record: %{"value" => "1"}},
-      %Changes.NewRecord{key: "2", record: %{"value" => "2"}},
-      %Changes.NewRecord{key: "3", record: %{"value" => "1"}}
-    ])
-
-    assert Materializer.get_link_values(ctx) == MapSet.new([1, 2])
-
-    assert_receive {:materializer_changes, ^shape_handle, move_in: 1, move_in: 2}
-
-    Materializer.new_changes(ctx, [
-      %Changes.UpdatedRecord{key: "2", record: %{"value" => "3"}, old_record: %{"value" => "2"}},
-      %Changes.DeletedRecord{key: "3", old_record: %{"value" => "1"}},
-      %Changes.UpdatedRecord{key: "1", record: %{"other" => "1"}, old_record: %{"other" => "0"}}
-    ])
-
-    assert Materializer.get_link_values(ctx) == MapSet.new([1, 3])
-
-    assert_receive {:materializer_changes, ^shape_handle, move_out: 2, move_in: 3}
+    ctx
   end
 
-  defp respond_to_call(request, response) do
-    receive do
-      {:"$gen_call", {from, ref}, ^request} ->
-        send(from, {ref, response})
-    end
+  defp make_snapshot_data(changes, opts \\ []) do
+    pk_cols = Keyword.get(opts, :pk_cols, ["id"])
+
+    changes
+    |> prep_changes(opts)
+    |> Enum.flat_map(&LogItems.from_change(&1, 1, pk_cols, :default))
+    |> Enum.map(fn {_offset, item} -> Jason.encode!(item) end)
+  end
+
+  defp prep_changes(changes, opts \\ []) do
+    pk_cols = Keyword.get(opts, :pk_cols, ["id"])
+    relation = Keyword.get(opts, :relation, {"public", "test_table"})
+
+    changes
+    |> Enum.map(&Map.put(&1, :relation, relation))
+    |> Enum.map(&Map.put(&1, :log_offset, Electric.Replication.LogOffset.first()))
+    |> Enum.map(&Changes.fill_key(&1, pk_cols))
   end
 end

--- a/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
@@ -64,6 +64,43 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
     assert Materializer.get_link_values(ctx) == MapSet.new([1, 2, 3])
   end
 
+  test "materializer correctly maps non-pk changes", %{shape_handle: shape_handle} = ctx do
+    {:ok, _pid} =
+      Materializer.start_link(%{
+        stack_id: ctx.stack_id,
+        shape_handle: shape_handle,
+        storage: ctx.storage,
+        columns: ["value"],
+        materialized_type: {:array, :int8}
+      })
+
+    respond_to_call(:await_snapshot_start, :ok)
+    respond_to_call(:subscribe_materializer, :ok)
+
+    assert Materializer.wait_until_ready(ctx) == :ok
+    Materializer.subscribe(ctx)
+
+    Materializer.new_changes(ctx, [
+      %Changes.NewRecord{key: "1", record: %{"value" => "1"}},
+      %Changes.NewRecord{key: "2", record: %{"value" => "2"}},
+      %Changes.NewRecord{key: "3", record: %{"value" => "1"}}
+    ])
+
+    assert Materializer.get_link_values(ctx) == MapSet.new([1, 2])
+
+    assert_receive {:materializer_changes, ^shape_handle, move_in: 1, move_in: 2}
+
+    Materializer.new_changes(ctx, [
+      %Changes.UpdatedRecord{key: "2", record: %{"value" => "3"}, old_record: %{"value" => "2"}},
+      %Changes.DeletedRecord{key: "3", old_record: %{"value" => "1"}},
+      %Changes.UpdatedRecord{key: "1", record: %{"other" => "1"}, old_record: %{"other" => "0"}}
+    ])
+
+    assert Materializer.get_link_values(ctx) == MapSet.new([1, 3])
+
+    assert_receive {:materializer_changes, ^shape_handle, move_out: 2, move_in: 3}
+  end
+
   defp respond_to_call(request, response) do
     receive do
       {:"$gen_call", {from, ref}, ^request} ->


### PR DESCRIPTION
Closes #3037

Keeps around 2 structures - a reference counter for the values, and the key => value mapping, because on our replica modes we might not see old values that need to be counted down, especially on deletes.

Allows following one-to-many relations:
```sql
CREATE TABLE comments (..., task_id INT NOT NULL, ...);
CREATE TABLE tasks (id INT PRIMARY KEY, ...);
```

You can define a shape with `where: "id IN (SELECT task_id FROM comments WHERE ...)"` - or other applications of course.