### PR TITLE
feat: close files on inactive shapes and don't open all on startup

### DIFF
--- a/.changeset/four-llamas-deny.md
+++ b/.changeset/four-llamas-deny.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+feat: close file handles on inactive shapes and don't open on startup

--- a/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/crashing_file_storage.ex
@@ -25,6 +25,7 @@ defmodule Electric.ShapeCache.CrashingFileStorage do
   defdelegate get_chunk_end_log_offset(offset, opts), to: FileStorage
   defdelegate cleanup!(opts), to: FileStorage
   defdelegate terminate(opts), to: FileStorage
+  defdelegate hibernate(opts), to: FileStorage
   defdelegate compact(opts, keep_complete_chunks), to: FileStorage
 
   def shared_opts(opts) do

--- a/packages/sync-service/lib/electric/shape_cache/file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/file_storage.ex
@@ -813,6 +813,9 @@ defmodule Electric.ShapeCache.FileStorage do
   def terminate(%FS{} = _opts), do: :ok
 
   @impl Electric.ShapeCache.Storage
+  def hibernate(%FS{} = _opts), do: :ok
+
+  @impl Electric.ShapeCache.Storage
   def cleanup!(%FS{} = opts) do
     # do a quick touch operation to exclude this directory from `get_all_stored_shapes`
     marker_file = deletion_marker_path(opts.base_path, opts.shape_handle)

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -349,4 +349,7 @@ defmodule Electric.ShapeCache.InMemoryStorage do
 
   @impl Electric.ShapeCache.Storage
   def terminate(_opts), do: :ok
+
+  @impl Electric.ShapeCache.Storage
+  def hibernate(_opts), do: :ok
 end

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -119,6 +119,11 @@ defmodule Electric.ShapeCache.Storage do
   @callback terminate(writer_state()) :: term()
 
   @doc """
+  Commit any pending writes to disk and close open resources that can be safely reopened later.
+  """
+  @callback hibernate(writer_state()) :: writer_state()
+
+  @doc """
   Clean up snapshots/logs for a shape handle by deleting whole directory.
 
   Is expected to be only called once the storage has been stopped.
@@ -252,6 +257,11 @@ defmodule Electric.ShapeCache.Storage do
   @impl __MODULE__
   def terminate({mod, writer_state}) do
     mod.terminate(writer_state)
+  end
+
+  @impl __MODULE__
+  def hibernate({mod, writer_state}) do
+    {mod, mod.hibernate(writer_state)}
   end
 
   @impl __MODULE__

--- a/packages/sync-service/test/support/test_storage.ex
+++ b/packages/sync-service/test/support/test_storage.ex
@@ -159,4 +159,10 @@ defmodule Support.TestStorage do
     send(parent, {__MODULE__, :terminate, shape_handle})
     Storage.terminate(storage)
   end
+
+  @impl Electric.ShapeCache.Storage
+  def hibernate({parent, shape_handle, _, storage}) do
+    send(parent, {__MODULE__, :hibernate, shape_handle})
+    Storage.hibernate(storage)
+  end
 end


### PR DESCRIPTION
Closes #3039. I'm planning to make a follow-up PR that's going to also lower the amount of open file handles per active shape. Also our hibernate timer is 30 seconds - we may want to actually raise that to like 1-2 minutes? 