### PR TITLE
fix: Ensure slot is dropped upon termination if requested

### DIFF
--- a/.changeset/curly-wolves-wait.md
+++ b/.changeset/curly-wolves-wait.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ensure replication slot is dropped if requested upon termination

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -924,6 +924,10 @@ defmodule Electric.Connection.Manager do
       lock_connection_pid: lock_connection_pid
     } = state
 
+    if state.drop_slot_requested do
+      drop_slot(state)
+    end
+
     if is_pid(pool_pid), do: shutdown_child(pool_pid, :shutdown)
     if is_pid(replication_client_pid), do: shutdown_child(replication_client_pid, :shutdown)
 


### PR DESCRIPTION
Followup to https://github.com/electric-sql/electric/pull/3065

By removing the shape log collector monitoring code, we also [removed](https://github.com/electric-sql/electric/pull/3065/files#diff-58fff6f19695125bcf9644f088b82fa5874ead4a15cb8c0ed5d5fec73ef2999eL709-L711) the dropping of the replication slot if a drop was requested.

This adds it back in as part of the conn man's termination handler along with a test.