### PR TITLE
fix: Clean up slot after the replication client

### DIFF
--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -919,17 +919,20 @@ defmodule Electric.Connection.Manager do
     Logger.debug("Terminating connection manager with reason #{inspect(reason)}.")
 
     %{
-      pool_pid: pool_pid,
       replication_client_pid: replication_client_pid,
+      pool_pid: pool_pid,
       lock_connection_pid: lock_connection_pid
     } = state
 
-    if state.drop_slot_requested do
-      drop_slot(state)
-    end
-
-    if is_pid(pool_pid), do: shutdown_child(pool_pid, :shutdown)
     if is_pid(replication_client_pid), do: shutdown_child(replication_client_pid, :shutdown)
+
+    if is_pid(pool_pid) do
+      if state.drop_slot_requested do
+        drop_slot(state)
+      end
+
+      shutdown_child(pool_pid, :shutdown)
+    end
 
     # We brutally kill the lock connection process as it might hang on waiting
     # to establish a connection and can't be gracefully killed


### PR DESCRIPTION
Followup to https://github.com/electric-sql/electric/pull/3079 ...

I've noticed more errors on cloud - before we were ensuring the slot was dropped after the replication client was stopped, othrwise we run into `:object_in_use` errors - so in the termination procedure we should be doing the same:

1. terminate replication client
2. if pool is available, drop the slot
3. terminate the pool
4. terminate the lock connection

I cannot seem to reproduce this in the connection manager tests...