### PR TITLE
fix(elixir-client): Correctly encode uuid-backed columns in where clauses

### DIFF
--- a/.changeset/ninety-buses-pretend.md
+++ b/.changeset/ninety-buses-pretend.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Fix representation in query of parameterized types backed by uuid column

--- a/packages/elixir-client/test/electric/client/ecto_adapter/postgres_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter/postgres_test.exs
@@ -3,6 +3,7 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
 
   alias Electric.Client.EctoAdapter
   alias Support.Money
+  alias Support.ULID
 
   import Ecto.Query
 
@@ -19,6 +20,7 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
       field(:dd, :date)
       field(:aa, {:array, :integer})
       field(:mm, Money)
+      field(:ul, ULID, prefix: "ul")
     end
   end
 
@@ -38,6 +40,7 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
     ud = ~U[2024-10-23 14:36:39Z]
     dd = ~D[2024-10-23]
     mm = Decimal.new("199.99")
+    ul = "ul_5aa36ce4-18ee-4334-a8e2-c04613652809"
 
     assert_where(where(TestTable, ii: ^ii), ~s[("ii" = 1234)])
     assert_where(where(TestTable, ff: ^ff), ~s[("ff" = 3.14::float)])
@@ -49,6 +52,11 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
     assert_where(where(TestTable, dd: ^dd), ~s[("dd" = '2024-10-23'::date)])
 
     assert_where(where(TestTable, mm: ^mm), ~s[("mm" = 199990000)])
+
+    assert_where(
+      from(t in TestTable, where: t.ul == ^ul),
+      ~s[("ul" = '5aa36ce4-18ee-4334-a8e2-c04613652809')]
+    )
   end
 
   test "where IN (...)" do

--- a/packages/elixir-client/test/support/ulid.ex
+++ b/packages/elixir-client/test/support/ulid.ex
@@ -1,0 +1,52 @@
+defmodule Support.ULID do
+  # A dumb parameterized type that stores a UUID with a prefix in the application
+  # useful for testing the handling of uuid-format columns in e.g. the query
+  # generator
+  use Ecto.ParameterizedType
+
+  @impl Ecto.ParameterizedType
+  def init(opts) do
+    Map.new(opts)
+  end
+
+  @impl Ecto.ParameterizedType
+  def type(_), do: :uuid
+
+  @impl Ecto.ParameterizedType
+  def cast(value, %{prefix: prefix}) do
+    if String.starts_with?(value, prefix <> "_") do
+      {:ok, value}
+    else
+      :error
+    end
+  end
+
+  @impl Ecto.ParameterizedType
+  def load(nil, _, _), do: {:ok, nil}
+
+  def load(data, _loader, %{prefix: prefix}) when is_binary(data) do
+    with {:ok, uuid} = Ecto.UUID.load(data) do
+      {:ok, prefix <> "_" <> uuid}
+    end
+  end
+
+  def load(_, _, _), do: :error
+
+  @impl Ecto.ParameterizedType
+  def dump(nil, _, _), do: {:ok, nil}
+
+  def dump(ulid, _, %{prefix: prefix}) do
+    with [^prefix, uuid] <- String.split(ulid, "_", parts: 2) do
+      Ecto.UUID.dump(uuid)
+    else
+      _ -> :error
+    end
+  end
+
+  def dump(_, _, _), do: :error
+
+  @impl Ecto.ParameterizedType
+  def equal?(nil, nil, _), do: true
+  def equal?(val, val, _), do: true
+  def equal?(_, _, _), do: false
+end


### PR DESCRIPTION
Dumping a parameterized column with a :uuid type results in a binary
representation of the underlying bytes of the uuid. This doesn't work
with electric, which expects UUIDs to be string encoded.

Fixes #3083