### PR TITLE
fix(elixir-client): Improve handling of uuid-based ecto types

### DIFF
--- a/.changeset/rich-cats-shop.md
+++ b/.changeset/rich-cats-shop.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Ensure that UUID fields are passed to parameterized types' load function in the expected binary form

--- a/packages/elixir-client/test/electric/client/ecto_adapter/postgres_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter/postgres_test.exs
@@ -40,7 +40,7 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
     ud = ~U[2024-10-23 14:36:39Z]
     dd = ~D[2024-10-23]
     mm = Decimal.new("199.99")
-    ul = "ul_5aa36ce4-18ee-4334-a8e2-c04613652809"
+    ul = "ul_coa2saf4czblth3g5jhleb4574"
 
     assert_where(where(TestTable, ii: ^ii), ~s[("ii" = 1234)])
     assert_where(where(TestTable, ff: ^ff), ~s[("ff" = 3.14::float)])
@@ -55,7 +55,7 @@ defmodule Electric.Client.EctoAdapter.PostgresTest do
 
     assert_where(
       from(t in TestTable, where: t.ul == ^ul),
-      ~s[("ul" = '5aa36ce4-18ee-4334-a8e2-c04613652809')]
+      ~s[("ul" = '1381a900-bc16-42b9-9f66-ea4eb2079dff')]
     )
   end
 

--- a/packages/elixir-client/test/electric/client/ecto_adapter_test.exs
+++ b/packages/elixir-client/test/electric/client/ecto_adapter_test.exs
@@ -8,6 +8,7 @@ defmodule Electric.Client.EctoAdapterTest do
   alias Electric.Client.EctoAdapter
   alias Electric.Client.Message
   alias Support.Money
+  alias Support.ULID
 
   defp stream(ctx, query) do
     Client.stream(ctx.client, query)
@@ -31,6 +32,7 @@ defmodule Electric.Client.EctoAdapterTest do
       field(:bits, :bitstring)
       field(:blob, :binary)
       field(:rejected_at, :utc_datetime)
+      field(:external_id, ULID, prefix: "external")
 
       embeds_one :mushroom, Mushroom do
         field(:name, :string)
@@ -163,6 +165,7 @@ defmodule Electric.Client.EctoAdapterTest do
       {"bits", "varbit"},
       {"blob", "bytea"},
       {"rejected_at", "timestamp with time zone"},
+      {"external_id", "uuid"},
       {"inserted_at", "timestamp without time zone"},
       {"updated_at", "timestamp without time zone"}
     ]
@@ -535,6 +538,7 @@ defmodule Electric.Client.EctoAdapterTest do
                "int_list" => "{1}",
                "map_list" => ~s[{"{\\"a\\":1}"}],
                "rejected_at" => "2016-03-24 17:53:17+00",
+               "external_id" => "1381a900-bc16-42b9-9f66-ea4eb2079dff",
                "inserted_at" => "2016-03-24 17:53:17+00",
                "updated_at" => "2017-04-28 18:54:18+00"
              }) == %TestTable{
@@ -561,6 +565,7 @@ defmodule Electric.Client.EctoAdapterTest do
                string_list: ["a", "b", ["c", "d"]],
                int_list: [1],
                map_list: [%{"a" => 1}],
+               external_id: "external_coa2saf4czblth3g5jhleb4574",
                rejected_at: ~U[2016-03-24 17:53:17Z],
                updated_at: ~N[2017-04-28 18:54:18]
              }

--- a/packages/elixir-client/test/support/ulid.ex
+++ b/packages/elixir-client/test/support/ulid.ex
@@ -24,9 +24,9 @@ defmodule Support.ULID do
   @impl Ecto.ParameterizedType
   def load(nil, _, _), do: {:ok, nil}
 
-  def load(data, _loader, %{prefix: prefix}) when is_binary(data) do
-    with {:ok, uuid} = Ecto.UUID.load(data) do
-      {:ok, prefix <> "_" <> uuid}
+  def load(data, _loader, %{prefix: prefix}) when is_binary(data) and byte_size(data) == 16 do
+    with {:ok, _uuid} = Ecto.UUID.load(data) do
+      {:ok, prefix <> "_" <> Base.encode32(data, case: :lower, padding: false)}
     end
   end
 
@@ -37,7 +37,7 @@ defmodule Support.ULID do
 
   def dump(ulid, _, %{prefix: prefix}) do
     with [^prefix, uuid] <- String.split(ulid, "_", parts: 2) do
-      Ecto.UUID.dump(uuid)
+      Base.decode32(uuid, case: :lower, padding: false)
     else
       _ -> :error
     end


### PR DESCRIPTION
By converting them from the string encoding to raw bytes before passing to the type's load function we mimic the behaviour of loading direct from the db via postgrex.