### PR TITLE
feat: Feature flag as stack configuration

### DIFF
--- a/.changeset/tame-items-wait.md
+++ b/.changeset/tame-items-wait.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Turn `feature_flags` into an explicit API+StackSupervisor configuration.

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -188,7 +188,8 @@ defmodule Electric.Application do
       stack_id: stack_id,
       stack_events_registry: Electric.stack_events_registry(),
       persistent_kv: persistent_kv,
-      storage: storage
+      storage: storage,
+      feature_flags: get_env(opts, :feature_flags)
     ]
   end
 

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -34,6 +34,8 @@ end
 defmodule Electric.Config do
   require Logger
 
+  @type instance_id :: String.t()
+
   @build_env Mix.env()
 
   @known_feature_flags ~w[allow_subqueries]
@@ -102,7 +104,7 @@ defmodule Electric.Config do
   end
 
   @doc false
-  @spec ensure_instance_id() :: :ok
+  @spec ensure_instance_id() :: instance_id()
   # the instance id needs to be consistent across calls, so we do need to have
   # a value in the config, even if it's not configured by the user.
   def ensure_instance_id do
@@ -125,7 +127,7 @@ defmodule Electric.Config do
   end
 
   # the installation id is persisted to disk to remain the same between restarts of the sync service
-  @spec persist_installation_id(term, binary) :: :ok
+  @spec persist_installation_id(term, binary) :: instance_id()
   def persist_installation_id(persistent_kv, instance_id) when is_binary(instance_id) do
     case Electric.PersistentKV.get(persistent_kv, @installation_id_key) do
       {:ok, id} when is_binary(id) ->

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -28,6 +28,7 @@ defmodule Electric.Shapes.Api do
       required: true
     ],
     allow_shape_deletion: [type: :boolean],
+    feature_flags: [type: {:list, :string}, default: []],
     keepalive_interval: [type: :integer],
     long_poll_timeout: [type: :integer],
     sse_timeout: [type: :integer],
@@ -52,6 +53,7 @@ defmodule Electric.Shapes.Api do
     :stack_events_registry,
     :stack_id,
     :storage,
+    :feature_flags,
     allow_shape_deletion: false,
     keepalive_interval: 21_000,
     long_poll_timeout: 20_000,
@@ -144,7 +146,7 @@ defmodule Electric.Shapes.Api do
   def predefined_shape(%Api{} = api, shape_params) do
     with :ok <- hold_until_stack_ready(api),
          {:ok, params} <- normalise_shape_params(shape_params),
-         opts = Keyword.merge(params, inspector: api.inspector),
+         opts = Keyword.merge(params, inspector: api.inspector, feature_flags: api.feature_flags),
          {:ok, shape} <- Shapes.Shape.new(opts) do
       {:ok, %{api | shape: shape}}
     end

--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -198,6 +198,7 @@ defmodule Electric.Shapes.Api.Params do
            columns: columns,
            replica: replica,
            inspector: api.inspector,
+           feature_flags: api.feature_flags,
            storage: %{compaction: if(compaction_enabled?, do: :enabled, else: :disabled)}
          ) do
       {:ok, shape} ->

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -90,6 +90,7 @@ defmodule Electric.StackSupervisor do
                    type: :pos_integer,
                    default: LogChunker.default_chunk_size_threshold()
                  ],
+                 feature_flags: [type: {:list, :string}, default: []],
                  tweaks: [
                    type: :keyword_list,
                    required: false,
@@ -242,7 +243,8 @@ defmodule Electric.StackSupervisor do
       storage: storage_mod_arg(opts),
       inspector: inspector,
       stack_id: stack_id,
-      persistent_kv: persistent_kv
+      persistent_kv: persistent_kv,
+      feature_flags: Map.get(opts, :feature_flags, [])
     ]
   end
 

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -418,6 +418,7 @@ defmodule Support.ComponentSetup do
       storage: storage,
       inspector:
         {EtsInspector, stack_id: stack_id, server: EtsInspector.name(stack_id: stack_id)},
+      feature_flags: Electric.Config.get_env(:feature_flags),
       publication_name: publication_name
     }
   end
@@ -439,7 +440,8 @@ defmodule Support.ComponentSetup do
         stack_id: ctx.stack_id,
         stack_events_registry: ctx.stack_events_registry,
         storage: ctx.storage,
-        persistent_kv: ctx.persistent_kv
+        persistent_kv: ctx.persistent_kv,
+        feature_flags: ctx.feature_flags
       )
     )
     |> Keyword.merge(overrides)


### PR DESCRIPTION
In order to be able to configure feature flags per stack we need them to not be a global config.

Trying to thread things through turned out to be a bit messy - perhaps we should revisit the number of configuration calls we're making as I feel we should be able to get them down to 2 (stack config and API config I suppose?). This is ultimately what we're doing but there's many layers of reutilization (`core_configuration` `build_shared_opts` etc) which make it slightly confusing IMO.

One thing worth noting is that I added a default to the `Shape` schema to be `Electric.Config.get_env(:feature_flags)` - otherwise in all tests we'd have to explicitly specify the feature flags. I could make this default a test only thing, let me know your thoughts.

Ultimately outside of tests, `Shape.new` is only called in one place in the API, but in tests we call it _everywhere_.
