### PR TITLE
feat: Add client-side cache buster for expired shapes to prevent 409s

### DIFF
--- a/packages/typescript-client/src/constants.ts
+++ b/packages/typescript-client/src/constants.ts
@@ -5,6 +5,7 @@ export const SHAPE_SCHEMA_HEADER = `electric-schema`
 export const CHUNK_UP_TO_DATE_HEADER = `electric-up-to-date`
 export const COLUMNS_QUERY_PARAM = `columns`
 export const LIVE_CACHE_BUSTER_QUERY_PARAM = `cursor`
+export const SHAPE_CACHE_BUSTER_QUERY_PARAM = `cache_buster`
 export const SHAPE_HANDLE_QUERY_PARAM = `handle`
 export const LIVE_QUERY_PARAM = `live`
 export const OFFSET_QUERY_PARAM = `offset`


### PR DESCRIPTION
## Summary
- Implements client-side caching of 409'd shapes using localStorage
- Adds cache_buster parameter to prevent redundant 409 responses  
- Reduces app loading latency when shapes expire

## Changes
- Add `SHAPE_CACHE_BUSTER_QUERY_PARAM` constant for expired shape requests
- Store expired shape handles in localStorage when 409 responses occur
- Check for expired shapes during URL construction and add cache buster
- Gracefully handle localStorage availability and errors

## Test plan
- [ ] Test 409 response handling stores shape in localStorage
- [ ] Verify subsequent requests include cache_buster parameter
- [ ] Confirm behavior works correctly when localStorage unavailable
- [ ] Test multiple expired shapes don't interfere with each other

Fixes #3100

🤖 Generated with [Claude Code](https://claude.ai/code)