### PR TITLE
fix: Flush tracker acknowledgements under heavy load

### DIFF
--- a/.changeset/proud-pears-jog.md
+++ b/.changeset/proud-pears-jog.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ensure flush tracker handles progressive flush acknowledgements under continuous use. Fixes issue where under heavy load acknowledgements would be delayed.

--- a/packages/sync-service/lib/electric/replication/shape_log_collector/flush_tracker.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector/flush_tracker.ex
@@ -105,8 +105,8 @@ defmodule Electric.Replication.ShapeLogCollector.FlushTracker do
     {last_flushed, mapset} =
       Enum.reduce(affected_shapes, {last_flushed, mapset}, fn shape, {acc, mapset} ->
         case Map.fetch(acc, shape) do
-          {:ok, {_, last_flushed}} ->
-            {Map.put(acc, shape, {last_log_offset, last_flushed}), mapset}
+          {:ok, {_, last_flushed_offset}} ->
+            {Map.put(acc, shape, {last_log_offset, last_flushed_offset}), mapset}
 
           :error ->
             {Map.put(acc, shape, {last_log_offset, last_global_flushed_offset}),

--- a/packages/sync-service/test/electric/connection/manager/connection_backoff_test.exs
+++ b/packages/sync-service/test/electric/connection/manager/connection_backoff_test.exs
@@ -1,5 +1,5 @@
 defmodule Electric.Connection.Manager.ConnectionBackoffTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Electric.Connection.Manager.ConnectionBackoff
 
   describe "total_retry_time/1" do

--- a/packages/sync-service/test/electric/lsn_tracker_test.exs
+++ b/packages/sync-service/test/electric/lsn_tracker_test.exs
@@ -1,5 +1,5 @@
 defmodule Electric.LsnTrackerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import Support.ComponentSetup, only: [with_stack_id_from_test: 1]
   alias Electric.LsnTracker

--- a/packages/sync-service/test/electric/replication/shape_log_collector/flush_tracker_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector/flush_tracker_test.exs
@@ -84,6 +84,7 @@ defmodule Electric.Replication.ShapeLogCollector.FlushTrackerTest do
         |> FlushTracker.handle_flush_notification("shape1", LogOffset.new(5, 10))
         |> FlushTracker.handle_flush_notification("shape2", LogOffset.new(5, 10))
 
+      assert_receive {:flush_confirmed, 3}
       assert_receive {:flush_confirmed, 4}
       refute_receive {:flush_confirmed, _}, 50
 
@@ -106,6 +107,21 @@ defmodule Electric.Replication.ShapeLogCollector.FlushTrackerTest do
       assert_receive {:flush_confirmed, 12}
 
       assert FlushTracker.empty?(tracker)
+    end
+
+    test "should notify flushes under continuous updates", %{tracker: tracker} do
+      tracker
+      |> FlushTracker.handle_transaction(txn(lsn: 10, last_offset: 10), ["shape1"])
+      |> FlushTracker.handle_transaction(txn(lsn: 11, last_offset: 10), ["shape2"])
+      |> FlushTracker.handle_flush_notification("shape1", LogOffset.new(10, 10))
+      |> FlushTracker.handle_transaction(txn(lsn: 12, last_offset: 10), ["shape1"])
+      |> FlushTracker.handle_flush_notification("shape2", LogOffset.new(11, 10))
+      |> FlushTracker.handle_transaction(txn(lsn: 13, last_offset: 10), ["shape2"])
+      |> FlushTracker.handle_flush_notification("shape1", LogOffset.new(12, 10))
+
+      assert_receive {:flush_confirmed, 9}
+      assert_receive {:flush_confirmed, 10}
+      assert_receive {:flush_confirmed, 11}
     end
   end
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector/flush_tracker_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector/flush_tracker_test.exs
@@ -1,5 +1,5 @@
 defmodule Electric.Replication.ShapeLogCollector.FlushTrackerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Electric.Replication.LogOffset
   alias Electric.Replication.ShapeLogCollector.FlushTracker

--- a/packages/sync-service/test/electric/shape_cache/pure_file_storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/pure_file_storage_test.exs
@@ -1,5 +1,5 @@
 defmodule Electric.ShapeCache.PureFileStorageTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import Support.ComponentSetup
   import Support.TestUtils

--- a/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
@@ -1,5 +1,5 @@
 defmodule Electric.Shapes.Consumer.MaterializerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import Support.ComponentSetup
   use Repatch.ExUnit
 


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/3102

The main issue was that whenever we starter tracking flushes for a shape that we were not already tracking, we assumed its `last_flushed_offset` was the `last_global_flushed_offset`. This sounds like a reasonable assumption, and it is a valid lower bound for the new shape's last flushed offset, but it leads to the following scenario covered by the new test:


## Problematic Case

0. Initial state is `last_global_flushed_offset` is at transaction 9.
1. Transaction 10 for Shape A is ingested
2. Transaction 11 for Shape B is ingested
3. Flush ack for transaction 10 by Shape A is received
  3a. `last_global_flushed_offset` is not updated as Shape B's most recent flush  was set to txn 9
4. Transaction 12 for Shape A is ingested
  4a. We set Shape A's most recent flush as `last_global_flushed_offset` which is txn 9, despite the fact that we had just acknowledged its flush of transaction 10 moments ago.
5. Flush ack for transaction 11 by Shape B is received
  5a. Again no updates to `last_global_flushed_offset` as Shape A's most recent one is still at txn 9

This can go on with multiple shapes, and with enough transactions the `last_flushed` mapping is never empty and thus `last_global_flushed_offset` is never updated.

## Proposed Solution

The solution I have implemented is changing our assumption of what the last flushed transaction for a newly tracked shape is. Instead of using the `last_global_flushed_offset`, we assume the shape has flushed all transactions up to the previous one from the one that is being ingested now.

I claim that this is a safe assumption and a safe upper bound, because if the shape was not being tracked when a transaction is ingested, it means that:
1. Either the shape was previously tracked, and was flushed up to the most recently seen transaction and removed from the mapping
2. Or the shape is new and this is the first relevant transaction ingested for the shape

In either case, we can assume that all relevant transactions to the shape before the current one have been flushed. If the transaction right before this one was not relevant to the shape, and thus was not sent to the shape, it is safe to say that it is effectively flushed, as flushing a transaction for a shape that has nothing to write from it involves doing nothing (it is "flushed" by virtue of it being irrelevant).


## Attempts to cover more issues

I spent some time thinking about what we could do to avoid more issues. I tried writing a property test but it ended up not being as simple as I was initially envisioning it.

One thing we could do is block the ingestion of new transactions if we have not acknowledged anything for a while (or if acknowledged seen LSN is getting significantly larger than the ackowledged flushed LSN), so as to give time for shapes to flush and acknowledge things fully. Basically create backpressure based on how far the seen and flushed acknowledged LSNs are getting.

P.S. I also made a bunch of tests async as it was missing and I didn't see any particular reason they weren't before.

