### PR TITLE
fix: Document `op_position` as integer in OpenAPI spec

### DIFF
--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -334,7 +334,7 @@ paths:
                             Operations with the same LSN were committed in the same transaction and
                             can be ordered by `op_position` within the same LSN.
                         op_position:
-                          type: string
+                          type: integer
                           description: |-
                             The position of the operation in the transaction.
 


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/3067

We do currently return it as an integer (should we be returning it as a string?) so this fixes the spec to match our implementations on both the server and clients.