### PR TITLE
Avoid invoking PublicationManager from SchemaReconciler when there are no diverged relations

### DIFF
--- a/integration-tests/tests/not-owner-of-the-table.lux
+++ b/integration-tests/tests/not-owner-of-the-table.lux
@@ -15,7 +15,7 @@
   "-v $(realpath ../scripts/low_privilege_db.sh):/docker-entrypoint-initdb.d/initdb-low_privilege_db.sh"]
 
 ## Start the sync service
-[invoke setup_electric_with_env "ELECTRIC_TWEAKS_SCHEMA_RECONCILER_PERIOD=2s"]
+[invoke setup_electric_with_env "ELECTRIC_TWEAKS_PUBLICATION_REFRESH_PERIOD=2s"]
 
 ## Verify that the replication pipeline has initialized successfully
 [shell electric]
@@ -65,11 +65,14 @@
 	??[info] Altering identity of public.items to FULL
   ?\[error\] Failed to configure publication: %Postgrex.Error\{message: nil, postgres: %\{code: :insufficient_privilege,.*message: "must be owner of table items"
 
-## Wait for the schema reconciler to run and verify that the table is removed from the publication
+## Wait for the publication to be refreshed and verify that the table is removed from it
 [shell electric]
   ??[info] Configuring publication electric_publication_integration to drop ["public.items"] tables, and add [] tables
-  ## Wait a bit for configuration to run
-  [sleep 3]
+
+  # Call refresh_publication() once more to ensure the previous update has completed. This is
+  # going to be a noop call since there are no changes pending for the publication.
+  !Electric.Replication.PublicationManager.refresh_publication(stack_id: "single_stack", forced?: true)
+  ??:ok
 
 [shell psql]
   !SELECT * FROM pg_publication_tables;

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -243,6 +243,12 @@ config :electric,
     env!("ELECTRIC_TCP_SEND_TIMEOUT", &Electric.Config.parse_human_readable_time!/1, nil),
   feature_flags: env!("ELECTRIC_FEATURE_FLAGS", &Electric.Config.parse_feature_flags/1, nil),
   manual_table_publishing?: env!("ELECTRIC_MANUAL_TABLE_PUBLISHING", :boolean, nil),
+  publication_refresh_period:
+    env!(
+      "ELECTRIC_TWEAKS_PUBLICATION_REFRESH_PERIOD",
+      &Electric.Config.parse_human_readable_time!/1,
+      nil
+    ),
   schema_reconciler_period:
     env!(
       "ELECTRIC_TWEAKS_SCHEMA_RECONCILER_PERIOD",

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -133,6 +133,7 @@ defmodule Electric.Application do
       tweaks: [
         publication_alter_debounce_ms: get_env(opts, :publication_alter_debounce_ms),
         registry_partitions: get_env(opts, :process_registry_partitions),
+        publication_refresh_period: get_env(opts, :publication_refresh_period),
         schema_reconciler_period: get_env(opts, :schema_reconciler_period)
       ],
       manual_table_publishing?: get_env(opts, :manual_table_publishing?)

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -92,6 +92,7 @@ defmodule Electric.Config do
     ## Misc
     process_registry_partitions: &Electric.Config.Defaults.process_registry_partitions/0,
     feature_flags: if(Mix.env() == :test, do: @known_feature_flags, else: []),
+    publication_refresh_period: 60_000,
     schema_reconciler_period: 60_000
   ]
 

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -64,7 +64,8 @@ defmodule Electric.Connection.Manager.Supervisor do
        can_alter_publication?: Keyword.fetch!(opts, :can_alter_publication?),
        manual_table_publishing?: Keyword.fetch!(opts, :manual_table_publishing?),
        db_pool: Electric.Connection.Manager.admin_pool(stack_id),
-       update_debounce_timeout: Keyword.get(tweaks, :publication_alter_debounce_ms, 0)}
+       update_debounce_timeout: Keyword.get(tweaks, :publication_alter_debounce_ms, 0),
+       refresh_period: Keyword.get(tweaks, :publication_refresh_period, 60_000)}
 
     shape_log_collector_spec =
       {Electric.Replication.ShapeLogCollector,

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -109,6 +109,7 @@ defmodule Electric.StackSupervisor do
                          on_cleanup: [type: {:fun, 1}]
                        ]
                      ],
+                     publication_refresh_period: [type: :non_neg_integer, default: 60_000],
                      schema_reconciler_period: [type: :non_neg_integer, default: 60_000]
                    ]
                  ],


### PR DESCRIPTION
Just getting rid of a no-op function invocation that pollutes the log with periodic log entries.