### PR TITLE
Avoid masking the underlying file error when opening chunk index

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage/chunk_index.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage/chunk_index.ex
@@ -254,7 +254,7 @@ defmodule Electric.ShapeCache.PureFileStorage.ChunkIndex do
     end
   end
 
-  def fetch_chunk_with_positions(chunk_file_path, %LogOffset{} = exclusive_min_offset) do
+  defp fetch_chunk_with_positions(chunk_file_path, %LogOffset{} = exclusive_min_offset) do
     file = File.open!(chunk_file_path, [:read, :raw])
 
     try do
@@ -276,10 +276,9 @@ defmodule Electric.ShapeCache.PureFileStorage.ChunkIndex do
       File.close(file)
     end
   rescue
-    File.Error ->
-      reraise Storage.Error,
-              [message: "Could not open chunk index file #{chunk_file_path}"],
-              __STACKTRACE__
+    err in [File.Error] ->
+      message = "Could not open chunk index file #{chunk_file_path}: #{inspect(err.reason)}"
+      reraise Storage.Error, [message: message], __STACKTRACE__
   end
 
   defp read_last_partial_chunk(file, size) do

--- a/packages/sync-service/test/electric/shape_cache/pure_file_storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/pure_file_storage_test.exs
@@ -377,6 +377,14 @@ defmodule Electric.ShapeCache.PureFileStorageTest do
            |> Enum.to_list() == [~S|{"test":1}|, ~S|{"test":2}|, ~S|{"test":3}|, ~S|{"test":4}|]
   end
 
+  test "includes the underlying file open error when unable to open a chunk", %{opts: opts} do
+    chunk_index_path = Path.join([opts.base_path, @shape_handle, "log", "log.latest.0.chunk.bin"])
+
+    assert_raise Electric.ShapeCache.Storage.Error,
+                 "Could not open chunk index file #{chunk_index_path}: :enoent",
+                 fn -> PureFileStorage.get_chunk_end_log_offset(LogOffset.new(1, 0), opts) end
+  end
+
   describe "flush timer" do
     setup :with_started_writer
     @describetag flush_period: 100

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -56,7 +56,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
     @moduletag storage: module_name
     @moduletag mod: module
 
-    # doctest module, import: true
+    doctest module, import: true
 
     describe "#{module_name}.snapshot_started?/2" do
       setup :start_storage


### PR DESCRIPTION
By wrapping the `File.open!()` error in our own exception we were losing information about the actual reason why the open call failed.