### PR TITLE
fix: Ensure all stack telemetry respects `telemetry_span_attrs`

### DIFF
--- a/.changeset/early-rules-smile.md
+++ b/.changeset/early-rules-smile.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ensure all stack telemetry adds `telemetry_span_attrs` to its metadata.

--- a/.changeset/giant-students-juggle.md
+++ b/.changeset/giant-students-juggle.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix `electric.postgres.replication.transaction_received.bytes` metric to use actual transaction size.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -840,7 +840,7 @@ defmodule Electric.Connection.Manager do
       "Consumers ready in #{System.convert_time_unit(duration, :native, :millisecond)}ms (#{total_recovered} shapes, #{total_failed_to_recover} failed to recover)"
     )
 
-    :telemetry.execute(
+    Electric.Telemetry.OpenTelemetry.execute(
       [:electric, :connection, :consumers_ready],
       %{duration: duration, total: total_recovered, failed_to_recover: total_failed_to_recover},
       %{stack_id: state.stack_id}
@@ -892,7 +892,7 @@ defmodule Electric.Connection.Manager do
         "timeline_id = #{state.pg_timeline_id}"
     )
 
-    :telemetry.execute(
+    Electric.Telemetry.OpenTelemetry.execute(
       [:electric, :postgres, :info_looked_up],
       %{
         pg_version: server_version,

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -11,17 +11,17 @@ defmodule Electric.Plug.ServeShapePlug do
 
   require Logger
 
-  plug(:fetch_query_params)
+  plug :fetch_query_params
 
   # start_telemetry_span needs to always be the first plug after fetching query params.
-  plug(:start_telemetry_span)
-  plug(:put_resp_content_type, "application/json")
+  plug :start_telemetry_span
+  plug :put_resp_content_type, "application/json"
 
-  plug(:validate_request)
-  plug(:serve_shape_log)
+  plug :validate_request
+  plug :serve_shape_log
 
   # end_telemetry_span needs to always be the last plug here.
-  plug(:end_telemetry_span)
+  plug :end_telemetry_span
 
   defp validate_request(%Conn{assigns: %{config: config}} = conn, _) do
     Logger.debug("Query String: #{conn.query_string}")

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -11,17 +11,17 @@ defmodule Electric.Plug.ServeShapePlug do
 
   require Logger
 
-  plug :fetch_query_params
+  plug(:fetch_query_params)
 
   # start_telemetry_span needs to always be the first plug after fetching query params.
-  plug :start_telemetry_span
-  plug :put_resp_content_type, "application/json"
+  plug(:start_telemetry_span)
+  plug(:put_resp_content_type, "application/json")
 
-  plug :validate_request
-  plug :serve_shape_log
+  plug(:validate_request)
+  plug(:serve_shape_log)
 
   # end_telemetry_span needs to always be the last plug here.
-  plug :end_telemetry_span
+  plug(:end_telemetry_span)
 
   defp validate_request(%Conn{assigns: %{config: config}} = conn, _) do
     Logger.debug("Query String: #{conn.query_string}")
@@ -70,9 +70,7 @@ defmodule Electric.Plug.ServeShapePlug do
         do: conn.query_params["columns"],
         else: Enum.join(params[:columns], ",")
 
-    Electric.Telemetry.OpenTelemetry.get_stack_span_attrs(
-      get_in(conn.assigns, [:config, :stack_id])
-    )
+    OpenTelemetry.get_stack_span_attrs(get_in(conn.assigns, [:config, :stack_id]))
     |> Map.merge(Electric.Plug.Utils.common_open_telemetry_attrs(conn))
     |> Map.merge(%{
       "shape.handle" => conn.query_params["handle"] || params[:handle] || request[:handle],
@@ -123,7 +121,7 @@ defmodule Electric.Plug.ServeShapePlug do
   # is the place to assign them because we keep this plug last in the "plug pipeline" defined
   # in this module.
   defp end_telemetry_span(%Conn{assigns: assigns} = conn, _ \\ nil) do
-    :telemetry.execute(
+    OpenTelemetry.execute(
       [:electric, :plug, :serve_shape],
       %{
         count: 1,

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -366,7 +366,7 @@ defmodule Electric.Postgres.ReplicationClient do
         OpenTelemetry.start_interval("replication_client.telemetry_execute")
 
         if Sampler.sample_metrics?() do
-          :telemetry.execute(
+          OpenTelemetry.execute(
             [:electric, :postgres, :replication, :transaction_received],
             %{
               monotonic_time: System.monotonic_time(),

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -358,7 +358,7 @@ defmodule Electric.Postgres.ReplicationClient do
         OpenTelemetry.start_interval("replication_client.await_more_data")
         {:noreply, %{state | txn_collector: txn_collector}}
 
-      {%Transaction{} = txn, %Collector{} = txn_collector} ->
+      {%Transaction{} = txn, txn_meta, %Collector{} = txn_collector} ->
         state = %{state | txn_collector: txn_collector, last_seen_txn_lsn: txn.lsn}
 
         {m, f, args} = state.transaction_received
@@ -371,7 +371,7 @@ defmodule Electric.Postgres.ReplicationClient do
             %{
               monotonic_time: System.monotonic_time(),
               receive_lag: DateTime.diff(DateTime.utc_now(), txn.commit_timestamp, :millisecond),
-              bytes: byte_size(data),
+              bytes: txn_meta.byte_size,
               count: 1,
               operations: txn.num_changes
             },

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -485,7 +485,7 @@ defmodule Electric.Shapes.Consumer do
         lag = calculate_replication_lag(txn)
         OpenTelemetry.add_span_attributes(replication_lag: lag)
 
-        :telemetry.execute(
+        Electric.Telemetry.OpenTelemetry.execute(
           [:electric, :storage, :transaction_stored],
           %{
             duration: System.monotonic_time() - timestamp,

--- a/packages/sync-service/lib/electric/shapes/monitor/ref_counter.ex
+++ b/packages/sync-service/lib/electric/shapes/monitor/ref_counter.ex
@@ -385,7 +385,7 @@ defmodule Electric.Shapes.Monitor.RefCounter do
   end
 
   defp record_telemetry(state) do
-    :telemetry.execute(
+    Electric.Telemetry.OpenTelemetry.execute(
       [:electric, :shape_monitor],
       %{active_reader_count: reader_count!(state.stack_id)},
       %{stack_id: state.stack_id}

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -114,6 +114,21 @@ defmodule Electric.Telemetry.OpenTelemetry do
   end
 
   @doc """
+  A thin wrapper around `:telemetry.execute/3` that adds the span attributes for the current
+  stack to the metadata.
+  """
+  @spec execute(
+          :telemetry.event_name(),
+          :telemetry.event_measurements() | :telemetry.event_value(),
+          :telemetry.event_metadata()
+        ) :: :ok
+  def execute(event_name, measurements, metadata) do
+    stack_id = metadata[:stack_id] || get_from_baggage("stack_id")
+    metadata = Map.merge(metadata, get_stack_span_attrs(stack_id))
+    :telemetry.execute(event_name, measurements, metadata)
+  end
+
+  @doc """
   Executes the provided function and records its duration in microseconds.
   The duration is added to the current span as a span attribute named with the given `name`.
   """

--- a/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
@@ -287,9 +287,13 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
           :ok
 
         shapes ->
-          :telemetry.execute([:electric, :shapes, :total_shapes], %{count: length(shapes)}, %{
-            stack_id: stack_id
-          })
+          Electric.Telemetry.OpenTelemetry.execute(
+            [:electric, :shapes, :total_shapes],
+            %{count: length(shapes)},
+            %{
+              stack_id: stack_id
+            }
+          )
       end
     end
 
@@ -298,7 +302,7 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
 
       Electric.ShapeCache.Storage.get_total_disk_usage(storage)
       |> then(
-        &:telemetry.execute([:electric, :storage], %{used: &1}, %{
+        &Electric.Telemetry.OpenTelemetry.execute([:electric, :storage], %{used: &1}, %{
           stack_id: opts[:stack_id]
         })
       )
@@ -341,7 +345,7 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
         # This is a confusing stat if we're measuring in bytes, so normalise to
         # [0, :infinity)
 
-        :telemetry.execute(
+        Electric.Telemetry.OpenTelemetry.execute(
           [:electric, :postgres, :replication],
           %{wal_size: max(0, wal_size)},
           %{stack_id: stack_id}


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/3047

- Fixes `electric.postgres.replication.transaction_received.bytes` to use actual byte size of transaction
  - I made the collector return an extra element in the tuple that is transaction meta to avoid adding more properties on the transaction itself unless they are actually needed in the shapes - no reason to copy over more things to all consumers
- Implemented thin wrapper over `:telemetry.execute` in OpenTelemetry module which we use for spans so that any stack related telemetry uses that and respects `telemetry_span_attrs`
  - This ensures all stack metrics actually end up having a `source_id` on them in Cloud