### PR TITLE
fix: Avoid crashing ETS inspector on DB conn issue to preserve cache

### DIFF
--- a/.changeset/chilled-dancers-sing.md
+++ b/.changeset/chilled-dancers-sing.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Avoid crashing ETS inspector if unable to grab DB connection to not lose cache.

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -233,6 +233,8 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
         :table_not_found -> :table_not_found
       end
     end)
+  catch
+    :exit, {_, {DBConnection.Holder, :checkout, _}} -> {:error, :connection_not_available}
   end
 
   @spec persist_data(map()) :: :ok

--- a/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
+++ b/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
@@ -446,4 +446,17 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
       assert :table_not_found = EtsInspector.load_relation_oid({"public", "items"}, opts)
     end
   end
+
+  test "handles complete lack of db pool", ctx do
+    stop_supervised!(EtsInspector)
+    %{inspector: {EtsInspector, opts}} = with_inspector(ctx |> Map.put(:db_conn, :no_pool))
+
+    assert {:error, :connection_not_available} =
+             EtsInspector.load_relation_oid({"public", "items"}, opts)
+
+    assert {:error, :connection_not_available} =
+             EtsInspector.load_column_info(1234, opts)
+
+    assert :error = EtsInspector.list_relations_with_stale_cache(opts)
+  end
 end


### PR DESCRIPTION
Overlaps a bit with @robacourt 's work, potentially relevant issue https://github.com/electric-sql/electric/issues/3053

Minimal work to avoid having the ETS inspector crash whenever we cannot grab a connection from the pool.

The pool dying is something to be expected throughout the lifetime of the app, but if the pool is dead then `Postgrex.transaction` violently exits.

In this PR I am not addressing the processes that use the inspector that can still crash as a consequence of the failure to load stuff. The goal of this PR is to prevent the ETS inspector itself from crashing and taking the cache down with it, leading to more DB pool contention upon restarting.