### PR TITLE
fix(sync-service): Split pg connections across two pools

### DIFF
--- a/.changeset/curly-rice-train.md
+++ b/.changeset/curly-rice-train.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Split pg connections across two pools so that high demand for snapshots doesn't interfere with the ability to introspect tables, configure the publication or monitor the WAL size

--- a/.changeset/little-schools-destroy.md
+++ b/.changeset/little-schools-destroy.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Move connection opts resolution out of connection manager into a separate synchronous function call

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -163,6 +163,10 @@
   [invoke setup_electric_with_env "ELECTRIC_QUERY_DATABASE_URL=$pooled_database_url"]
 [endmacro]
 
+[macro setup_electric_with_pooler_with_env env]
+  [invoke setup_electric_with_env "ELECTRIC_QUERY_DATABASE_URL=$pooled_database_url $env"]
+[endmacro]
+
 [macro setup_electric_with_env env]
   [invoke setup_electric_shell "electric" "3000" "DATABASE_URL=$database_url ELECTRIC_INSECURE=true $env"]
 [endmacro]

--- a/integration-tests/tests/ipv6-to-ipv4-fallback.lux
+++ b/integration-tests/tests/ipv6-to-ipv4-fallback.lux
@@ -1,0 +1,32 @@
+[doc Verify fallback from IPv6 to IPv4 when connecting to a PostgreSQL server]
+
+[include _macros.luxinc]
+
+[global pg_container_name=ipv6-to-ipv4-fallback__pg]
+[global pg_host_name=local-ipv4-only.electric-sql.dev]
+[global database_url=postgresql://postgres:password@$pg_host_name:$pg_host_port/electric?sslmode=disable]
+[global pooled_database_url=postgresql://postgres:password@$pg_host_name:$pg_pooler_host_port/electric?sslmode=disable]
+
+###
+
+[invoke setup_pg_with_pooler]
+
+## Start the sync service and observe the fallback
+[invoke setup_electric_with_pooler_with_env "ELECTRIC_DATABASE_USE_IPV6=true"]
+
+[shell electric]
+  # Reset the failure pattern to make it possible to pattern-match on errors below
+  -
+
+  ??tcp connect (local-ipv4-only.electric-sql.dev:$pg_host_port): non-existing domain - :nxdomain
+  ??[warning] Database connection failed to find valid IPv6 address for local-ipv4-only.electric-sql.dev - falling back to IPv4
+  ??[info] Lock acquired
+  ??tcp connect (local-ipv4-only.electric-sql.dev:$pg_pooler_host_port): non-existing domain - :nxdomain
+  ??[warning] Database connection failed to find valid IPv6 address for local-ipv4-only.electric-sql.dev - falling back to IPv4
+  ?+\[info\] Connection pool \[admin: $pg_host_name:$pg_pooler_host_port\] is ready
+  ?\[info\] Connection pool \[snapshot: $pg_host_name:$pg_pooler_host_port\] is ready
+  ??[info] Starting replication from postgres
+
+
+[cleanup]
+  [invoke teardown]

--- a/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
+++ b/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
@@ -1,0 +1,237 @@
+defmodule Electric.Connection.Manager.ConnectionResolver do
+  use GenServer
+
+  require Logger
+
+  defmodule Connection do
+    @moduledoc false
+    @behaviour Postgrex.SimpleConnection
+
+    def init(stack_id) do
+      Logger.metadata(stack_id: stack_id, is_connection_process?: true)
+      {:ok, []}
+    end
+
+    def notify(_channel, _payload, _state) do
+      :ok
+    end
+  end
+
+  def name(stack_id) when is_binary(stack_id) do
+    Electric.ProcessRegistry.name(stack_id, __MODULE__)
+  end
+
+  def start_link(opts) do
+    with {:ok, stack_id} <- Keyword.fetch(opts, :stack_id) do
+      GenServer.start_link(__MODULE__, opts, name: name(stack_id))
+    end
+  end
+
+  def validate(stack_id, db_connection) do
+    GenServer.call(name(stack_id), {:validate, db_connection}, :infinity)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    stack_id = Keyword.fetch!(opts, :stack_id)
+
+    # ignore exits from connection processes that fail to start due to
+    # connection errors or from us killing the connection after we're
+    # done
+    Process.flag(:trap_exit, true)
+
+    Process.set_label({:connection_resolver, stack_id})
+    Logger.metadata(stack_id: stack_id, is_connection_process?: true)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
+
+    {_m, _f, _a} =
+      connection_mod =
+      Keyword.get(opts, :connection_mod, {Postgrex.SimpleConnection, :start_link, []})
+
+    {:ok, %{connection_mod: connection_mod, stack_id: stack_id}}
+  end
+
+  @impl GenServer
+  def handle_call({:validate, connection}, _from, state) do
+    # convert to postgrex style for return to conn.manager
+    connection = populate_connection_opts(connection)
+
+    result = attempt_connection({:cont, connection}, state)
+
+    {:reply, result, state, :hibernate}
+  end
+
+  @impl GenServer
+  def handle_info(:shutdown, state) do
+    {:stop, {:shutdown, :normal}, state}
+  end
+
+  # ignore connections exiting because of invalid config
+  def handle_info({:EXIT, _pid, _reason}, state), do: {:noreply, state}
+
+  defp attempt_connection({:cont, conn_opts}, state) do
+    %{
+      connection_mod: {connection_mod, connection_fun, connection_args}
+    } = state
+
+    connection_opts =
+      Keyword.merge(Electric.Utils.deobfuscate_password(conn_opts),
+        auto_reconnect: false,
+        sync_connect: true
+      )
+
+    args = [Connection, state.stack_id, connection_opts | connection_args]
+
+    case apply(connection_mod, connection_fun, args) do
+      {:ok, conn} ->
+        Process.exit(conn, :kill)
+
+        {:ok, conn_opts}
+
+      {:error, error} ->
+        error
+        |> mutate_based_on_error(conn_opts)
+        |> attempt_connection(state)
+    end
+  end
+
+  defp attempt_connection({:halt, error}, _state) do
+    {:error, error}
+  end
+
+  defp populate_connection_opts(conn_opts) do
+    conn_opts |> populate_ssl_opts() |> populate_tcp_opts()
+  end
+
+  defp populate_ssl_opts(connection_opts) do
+    ssl_opts =
+      case connection_opts[:sslmode] do
+        :disable ->
+          false
+
+        _ ->
+          ssl_verify_opts(connection_opts[:hostname], connection_opts[:cacertfile])
+      end
+
+    Keyword.put(connection_opts, :ssl, ssl_opts)
+  end
+
+  # Unless explicitly requested by the user, Electric doesn't perform server certificate
+  # verification even when the database connection is encrypted. This mimics the behaviour of
+  # psql with sslmode=prefer or sslmode=require.
+  #
+  # Here's an example of connecting to DigitalOcean's Managed PostgreSQL to illustrate the point.
+  # Specifying sslmode=require does not result in certificate verification, it only instructs
+  # psql to use SSL for encryption of the database connection:
+  #
+  #     $ psql 'postgresql://...?sslmode=require'
+  #     psql (16.1, server 16.3)
+  #     SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
+  #     Type "help" for help.
+  #
+  #     [db-postgresql-do-user-13160360-0] doadmin:defaultdb=> \q
+  #
+  # Now if we request certificate verification, we get a different result:
+  #
+  #     $ psql 'postgresql://...?sslmode=verify-full'
+  #     psql: error: connection to server at "***.db.ondigitalocean.com" (167.99.250.38), o
+  #     port 25060 failed: root certificate file "/home/alco/.postgresql/root.crt" does not exist
+  #     Either provide the file, use the system's trusted roots with sslrootcert=system, or change
+  #     sslmode to disable server certificate verification.
+  #
+  #     $ psql 'sslrootcert=system sslmode=verify-full host=***.db.ondigitalocean.com ...'
+  #     psql: error: connection to server at "***.db.ondigitalocean.com" (167.99.250.38), port 25060
+  #     failed: SSL error: certificate verify failed
+  #
+  # In Electric, specifying the path to a file containing trusted certificate(s) forces the
+  # full verification to take place, equivalent to psql's sslmode=verify-full.
+  defp ssl_verify_opts(hostname, nil) do
+    # Even with `verify: :verify_none` we still need to include `server_name_indication`
+    # since, for example, Neon relies on it being present in the client's TLS handshake.
+    [
+      verify: :verify_none,
+      server_name_indication: String.to_charlist(hostname)
+    ]
+  end
+
+  defp ssl_verify_opts(hostname, cacertfile_path) when is_binary(cacertfile_path) do
+    [
+      verify: :verify_peer,
+      cacertfile: cacertfile_path,
+      server_name_indication: String.to_charlist(hostname)
+    ]
+  end
+
+  defp populate_tcp_opts(connection_opts) do
+    tcp_opts =
+      if connection_opts[:ipv6] do
+        [:inet6]
+      else
+        []
+      end
+
+    Keyword.put(connection_opts, :socket_options, tcp_opts)
+  end
+
+  defp mutate_based_on_error(%Postgrex.Error{message: "ssl not available"} = error, conn_opts) do
+    maybe_fallback_to_no_ssl(conn_opts, error)
+  end
+
+  defp mutate_based_on_error(
+         %DBConnection.ConnectionError{message: "ssl connect: closed"} = error,
+         conn_opts
+       ) do
+    maybe_fallback_to_no_ssl(conn_opts, error)
+  end
+
+  defp mutate_based_on_error(
+         %DBConnection.ConnectionError{severity: :error} = error,
+         conn_opts
+       ) do
+    maybe_fallback_to_ipv4(error, conn_opts)
+  end
+
+  defp mutate_based_on_error(error, _conn_opts) do
+    {:halt, error}
+  end
+
+  defp maybe_fallback_to_no_ssl(conn_opts, error) do
+    sslmode = conn_opts[:sslmode]
+
+    if sslmode != :require and is_nil(conn_opts[:cacertfile]) do
+      if not is_nil(sslmode) do
+        # Only log a warning when there's an explicit sslmode parameter in the database
+        # config, meaning the user has requested a certain sslmode.
+        Logger.warning(
+          "Failed to connect to the database using SSL. Trying again, using an unencrypted connection."
+        )
+      end
+
+      {:cont, Keyword.put(conn_opts, :ssl, false)}
+    else
+      {:halt, error}
+    end
+  end
+
+  defp maybe_fallback_to_ipv4(
+         %DBConnection.ConnectionError{message: message, severity: :error} = error,
+         conn_opts
+       ) do
+    # If network is unreachable, IPv6 is not enabled on the machine
+    # If domain cannot be resolved, assume there is no AAAA record for it
+    # Fall back to IPv4 for these cases
+    if conn_opts[:ipv6] and
+         String.starts_with?(message, "tcp connect (") and
+         (String.ends_with?(message, "): non-existing domain - :nxdomain") or
+            String.ends_with?(message, "): host is unreachable - :ehostunreach") or
+            String.ends_with?(message, "): network is unreachable - :enetunreach")) do
+      Logger.warning(
+        "Database connection failed to find valid IPv6 address for #{conn_opts[:hostname]} - falling back to IPv4"
+      )
+
+      {:cont, conn_opts |> Keyword.put(:ipv6, false) |> populate_tcp_opts()}
+    else
+      {:halt, error}
+    end
+  end
+end

--- a/packages/sync-service/lib/electric/connection/manager/pool.ex
+++ b/packages/sync-service/lib/electric/connection/manager/pool.ex
@@ -26,6 +26,7 @@ defmodule Electric.Connection.Manager.Pool do
   defstruct [
     :stack_id,
     :role,
+    :host,
     :pool_ref,
     :pool_pid,
     :pool_size,
@@ -79,6 +80,7 @@ defmodule Electric.Connection.Manager.Pool do
     pool_mod = Access.fetch!(opts, :pool_mod)
     pool_opts = Access.fetch!(opts, :pool_opts)
     conn_opts = Access.fetch!(opts, :conn_opts)
+    host = "#{conn_opts[:hostname]}:#{conn_opts[:port] || 5432}"
 
     pool_ref = make_ref()
 
@@ -111,6 +113,7 @@ defmodule Electric.Connection.Manager.Pool do
     state = %__MODULE__{
       stack_id: Access.fetch!(opts, :stack_id),
       role: role,
+      host: host,
       pool_ref: pool_ref,
       pool_pid: pool_pid,
       pool_size: pool_size,
@@ -127,18 +130,24 @@ defmodule Electric.Connection.Manager.Pool do
     case {state.status, pool_is_ready} do
       {:starting, true} ->
         Logger.info(
-          "Connection pool [#{state.role}] is ready with #{state.pool_size} connections"
+          "Connection pool [#{state.role}: #{state.host}] is ready with #{state.pool_size} connections"
         )
 
         notify_connection_pool_ready(state)
         {:noreply, %{state | status: :ready, last_connection_error: nil}}
 
       {:repopulating, true} ->
-        Logger.debug("Connection pool fully repopulated with #{state.pool_size} connections")
+        Logger.debug(
+          "Connection pool [#{state.role}] fully repopulated with #{state.pool_size} connections"
+        )
+
         {:noreply, %{state | status: :ready, last_connection_error: nil}}
 
       {:ready, false} ->
-        Logger.debug("Connection pool no longer fully populated, waiting for more connections")
+        Logger.debug(
+          "Connection pool [#{state.role}] no longer fully populated, waiting for more connections"
+        )
+
         {:noreply, %{state | status: :repopulating}}
 
       _ ->
@@ -149,7 +158,7 @@ defmodule Electric.Connection.Manager.Pool do
   @impl true
   def handle_info({:pool_conn_started, pid}, state) do
     # The connection pool has started a new connection, so we need to remember it.
-    Logger.debug("Pooled connection #{inspect(pid)} started")
+    Logger.debug("Pooled connection [#{state.role}] #{inspect(pid)} started")
 
     {
       :noreply,
@@ -160,7 +169,7 @@ defmodule Electric.Connection.Manager.Pool do
   # The following two messages are sent by the DBConnection library because we've configured
   # the connection manager process as connection listener for the DB connection pool.
   def handle_info({:connected, pid, ref}, %{pool_ref: ref} = state) do
-    Logger.debug("Pooled connection #{inspect(pid)} connected")
+    Logger.debug("Pooled connection [#{state.role}] #{inspect(pid)} connected")
 
     {
       :noreply,
@@ -170,7 +179,7 @@ defmodule Electric.Connection.Manager.Pool do
   end
 
   def handle_info({:disconnected, pid, ref}, %{pool_ref: ref} = state) do
-    Logger.debug("Pooled connection #{inspect(pid)} disconnected")
+    Logger.debug("Pooled connection [#{state.role}] #{inspect(pid)} disconnected")
 
     {
       :noreply,
@@ -190,7 +199,8 @@ defmodule Electric.Connection.Manager.Pool do
     error =
       if is_nil(state.last_connection_error) do
         %DbConnectionError{
-          message: "Connection pool was unable to fill up with healthy connections.",
+          message:
+            "Connection pool [#{state.role}] was unable to fill up with healthy connections.",
           type: :connection_pool_failed_to_populate,
           original_error: :killed,
           retry_may_fix?: true
@@ -207,7 +217,9 @@ defmodule Electric.Connection.Manager.Pool do
   end
 
   def handle_info({:EXIT, pid, reason}, state) when is_map_key(state.connection_pids, pid) do
-    Logger.debug("Pooled connection #{inspect(pid)} exited with reason: #{inspect(reason)}")
+    Logger.debug(
+      "Pooled connection [#{state.role}] #{inspect(pid)} exited with reason: #{inspect(reason)}"
+    )
 
     # Keep track of the most recent pooled connection error seen so we can use it as the
     # reason for the pool failing as a whole if it does not manage to recover.
@@ -221,7 +233,7 @@ defmodule Electric.Connection.Manager.Pool do
 
     if not is_nil(state.last_connection_error) do
       Logger.warning(
-        "Pooled database connection encountered an error: #{inspect(state.last_connection_error, pretty: true)}"
+        "Pooled database connection [#{state.role}] encountered an error: #{inspect(state.last_connection_error, pretty: true)}"
       )
     end
 
@@ -268,7 +280,7 @@ defmodule Electric.Connection.Manager.Pool do
       :error, :noproc -> exit({:shutdown, {:supervisor_not_alive, supervisor_pid}})
     end
 
-    opts
+    Electric.Utils.deobfuscate_password(opts)
   end
 
   @spec num_connected(t()) :: non_neg_integer()

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -41,7 +41,6 @@ defmodule Electric.Connection.Manager.Supervisor do
   def start_replication_supervisor(opts) do
     stack_id = Keyword.fetch!(opts, :stack_id)
     shape_cache_opts = Keyword.fetch!(opts, :shape_cache_opts)
-    db_pool_opts = Keyword.fetch!(opts, :pool_opts)
     replication_opts = Keyword.fetch!(opts, :replication_opts)
     inspector = Keyword.fetch!(shape_cache_opts, :inspector)
     persistent_kv = Keyword.fetch!(opts, :persistent_kv)
@@ -61,7 +60,7 @@ defmodule Electric.Connection.Manager.Supervisor do
        publication_name: Keyword.fetch!(replication_opts, :publication_name),
        can_alter_publication?: Keyword.fetch!(opts, :can_alter_publication?),
        manual_table_publishing?: Keyword.fetch!(opts, :manual_table_publishing?),
-       db_pool: Keyword.fetch!(db_pool_opts, :name),
+       db_pool: Electric.Connection.Manager.admin_pool(stack_id),
        update_debounce_timeout: Keyword.get(tweaks, :publication_alter_debounce_ms, 0)}
 
     shape_log_collector_spec =

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -18,7 +18,10 @@ defmodule Electric.Connection.Manager.Supervisor do
     Logger.metadata(stack_id: opts[:stack_id])
     Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
 
-    children = [{Electric.Connection.Manager, opts}]
+    children = [
+      {Electric.Connection.Manager.ConnectionResolver, stack_id: opts[:stack_id]},
+      {Electric.Connection.Manager, opts}
+    ]
 
     # Electric.Connection.Manager is a permanent child of the supervisor, so when it dies, the
     # :one_for_all strategy will kick in and restart the other children.

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -154,7 +154,9 @@ defmodule Electric.Replication.PublicationManager do
       stack_id = Keyword.fetch!(opts, :stack_id)
 
       name = Keyword.get(opts, :name, name(stack_id))
-      db_pool = Keyword.get(opts, :db_pool, Electric.Connection.Manager.pool_name(stack_id))
+
+      db_pool =
+        Keyword.get(opts, :db_pool, Electric.Connection.Manager.admin_pool(stack_id))
 
       GenServer.start_link(__MODULE__, [name: name, db_pool: db_pool] ++ opts, name: name)
     end

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -94,7 +94,13 @@ defmodule Electric.ShapeCache do
       stack_id = Keyword.fetch!(opts, :stack_id)
 
       name = Keyword.get(opts, :name, name(stack_id))
-      db_pool = Keyword.get(opts, :db_pool, Electric.Connection.Manager.pool_name(stack_id))
+
+      db_pool =
+        Keyword.get(
+          opts,
+          :db_pool,
+          Electric.Connection.Manager.snapshot_pool(stack_id)
+        )
 
       GenServer.start_link(__MODULE__, [name: name, db_pool: db_pool] ++ opts, name: name)
     end

--- a/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/stack_telemetry.ex
@@ -334,7 +334,7 @@ with_telemetry [OtelMetricExporter, Telemetry.Metrics] do
       try do
         %Postgrex.Result{rows: [[wal_size]]} =
           Postgrex.query!(
-            Electric.Connection.Manager.pool_name(stack_id),
+            Electric.Connection.Manager.admin_pool(stack_id),
             @retained_wal_size_query,
             [slot_name],
             timeout: 3_000,

--- a/packages/sync-service/test/electric/connection/manager/connection_resolver_test.exs
+++ b/packages/sync-service/test/electric/connection/manager/connection_resolver_test.exs
@@ -1,0 +1,174 @@
+defmodule Electric.Connection.Manager.ConnectionResolverTest do
+  use ExUnit.Case, async: true
+  use Repatch.ExUnit
+
+  alias Electric.Connection.Manager.ConnectionResolver
+
+  import Support.ComponentSetup, only: [with_stack_id_from_test: 1]
+  import Support.DbSetup
+
+  defp start_connection_resolver!(ctx, connection_mod \\ nil) do
+    opts = [stack_id: ctx.stack_id]
+
+    opts =
+      if connection_mod do
+        Keyword.put(opts, :connection_mod, connection_mod)
+      else
+        opts
+      end
+
+    start_supervised!({ConnectionResolver, opts})
+  end
+
+  setup [
+    :with_unique_db,
+    :with_stack_id_from_test
+  ]
+
+  defmodule ErrorConnection do
+    def start_link(_handler, _args, conn_opts, match_fun) do
+      match_fun.(conn_opts)
+    end
+  end
+
+  defp assert_obfuscated_password(conn_opts) do
+    assert is_function(Keyword.get(conn_opts, :password), 0)
+  end
+
+  # actually connect to make sure we can do that
+  # overwrite :connection_mod with custom modules that implement start_link but exit with some pre-defined postgres error
+  # need to assert that the connection options are mutated between attempts
+  test "valid connection opts", ctx do
+    start_connection_resolver!(ctx)
+
+    db_config = Keyword.put(ctx.db_config, :sslmode, :disable)
+
+    assert {:ok, resolved_db_config} = ConnectionResolver.validate(ctx.stack_id, db_config)
+
+    expected = Keyword.merge(db_config, ssl: false)
+
+    for {k, v} <- expected do
+      assert Keyword.get(resolved_db_config, k) == v
+    end
+
+    assert_obfuscated_password(resolved_db_config)
+  end
+
+  test "fallback to no-ssl works with ssmodle: :prefer", ctx do
+    start_connection_resolver!(ctx)
+
+    db_config = Keyword.put(ctx.db_config, :sslmode, :prefer)
+
+    assert {:ok, resolved_db_config} = ConnectionResolver.validate(ctx.stack_id, db_config)
+
+    expected = Keyword.merge(db_config, ssl: false)
+
+    for {k, v} <- expected do
+      assert Keyword.get(resolved_db_config, k) == v
+    end
+
+    assert_obfuscated_password(resolved_db_config)
+  end
+
+  test "sslmode: :require with no ssl returns error", ctx do
+    start_connection_resolver!(ctx)
+    db_config = Keyword.put(ctx.db_config, :sslmode, :require)
+
+    assert {:error, %Postgrex.Error{message: "ssl not available"}} =
+             ConnectionResolver.validate(ctx.stack_id, db_config)
+  end
+
+  test "fly connection can fallback to no ssl", ctx do
+    conn = spawn(fn -> Process.sleep(:infinity) end)
+
+    start_connection_resolver!(
+      ctx,
+      {ErrorConnection, :start_link,
+       [
+         fn conn_opts ->
+           if Keyword.get(conn_opts, :ssl) do
+             {:error,
+              %DBConnection.ConnectionError{
+                message: "ssl connect: closed",
+                severity: :error
+              }}
+           else
+             {:ok, conn}
+           end
+         end
+       ]}
+    )
+
+    db_config = Keyword.put(ctx.db_config, :sslmode, :prefer)
+
+    assert {:ok, resolved_db_config} = ConnectionResolver.validate(ctx.stack_id, db_config)
+
+    expected = Keyword.merge(db_config, ssl: false)
+
+    for {k, v} <- expected do
+      assert Keyword.get(resolved_db_config, k) == v
+    end
+
+    assert_obfuscated_password(resolved_db_config)
+  end
+
+  test "fallback to ipv4 works", ctx do
+    start_connection_resolver!(ctx)
+
+    db_config =
+      Keyword.merge(ctx.db_config, ipv6: true, hostname: "local-ipv4-only.electric-sql.dev")
+
+    assert {:ok, resolved_db_config} = ConnectionResolver.validate(ctx.stack_id, db_config)
+
+    expected = Keyword.merge(db_config, ipv6: false, hostname: "local-ipv4-only.electric-sql.dev")
+
+    for {k, v} <- expected do
+      assert Keyword.get(resolved_db_config, k) == v
+    end
+
+    assert_obfuscated_password(resolved_db_config)
+  end
+
+  test "fallback to ipv4 handles various error results", ctx do
+    conn = spawn(fn -> Process.sleep(:infinity) end)
+
+    start_connection_resolver!(
+      ctx,
+      {ErrorConnection, :start_link,
+       [
+         fn conn_opts ->
+           if Keyword.get(conn_opts, :ipv6, true) do
+             {:error,
+              %DBConnection.ConnectionError{
+                message: ipv6_error_message("localhost"),
+                severity: :error
+              }}
+           else
+             {:ok, conn}
+           end
+         end
+       ]}
+    )
+
+    db_config = Keyword.put(ctx.db_config, :ipv6, true)
+
+    assert {:ok, resolved_db_config} = ConnectionResolver.validate(ctx.stack_id, db_config)
+
+    expected = Keyword.merge(db_config, ipv6: false)
+
+    for {k, v} <- expected do
+      assert Keyword.get(resolved_db_config, k) == v
+    end
+
+    assert_obfuscated_password(resolved_db_config)
+  end
+
+  defp ipv6_error_message(hostname) do
+    "tcp connect (#{hostname}): " <>
+      Enum.random([
+        "non-existing domain - :nxdomain",
+        "host is unreachable - :ehostunreach",
+        "network is unreachable - :enetunreach"
+      ])
+  end
+end

--- a/packages/sync-service/test/electric/connection/manager/pool_test.exs
+++ b/packages/sync-service/test/electric/connection/manager/pool_test.exs
@@ -167,10 +167,10 @@ defmodule Electric.Connection.Manager.PoolTest do
 
   test "configure_pool_conn sends :pool_conn_started and returns opts", ctx do
     parent = self()
-    opts = [foo: :bar]
+    opts = Electric.Utils.obfuscate_password(foo: :bar, password: "password")
 
     returned = Pool.configure_pool_conn(opts, parent, ctx.stack_id)
-    assert returned == opts
+    assert returned == Electric.Utils.deobfuscate_password(opts)
 
     assert_receive {:pool_conn_started, pid} when is_pid(pid)
   end

--- a/packages/sync-service/test/electric/connection/manager/pool_test.exs
+++ b/packages/sync-service/test/electric/connection/manager/pool_test.exs
@@ -7,6 +7,7 @@ defmodule Electric.Connection.Manager.PoolTest do
   alias Electric.Connection.Manager.Pool
   alias Electric.DbConnectionError
 
+  @pool_role :snapshot
   setup [:with_stack_id_from_test]
 
   defmodule TestPostgrex do
@@ -28,6 +29,7 @@ defmodule Electric.Connection.Manager.PoolTest do
          [
            [
              stack_id: stack_id,
+             role: @pool_role,
              pool_mod: TestPostgrex,
              pool_opts: [pool_size: pool_size],
              conn_opts: [],
@@ -43,7 +45,7 @@ defmodule Electric.Connection.Manager.PoolTest do
 
   defp pool_state(stack_id) do
     stack_id
-    |> Pool.name()
+    |> Pool.name(@pool_role)
     |> :sys.get_state()
   end
 
@@ -56,13 +58,13 @@ defmodule Electric.Connection.Manager.PoolTest do
       Electric.Connection.Manager,
       :connection_pool_ready,
       [mode: :shared],
-      fn mng_pid ->
-        send(mng_pid, {:pool_ready_notified, pool_pid})
+      fn mng_pid, role, _pid ->
+        send(mng_pid, {:pool_ready_notified, pool_pid, role})
         :ok
       end
     )
 
-    Repatch.allow(test_pid, Pool.name(stack_id))
+    Repatch.allow(test_pid, Pool.name(stack_id, @pool_role))
 
     state = pool_state(stack_id)
     assert state.status == :starting
@@ -84,7 +86,7 @@ defmodule Electric.Connection.Manager.PoolTest do
     send(pool_pid, {:connected, c2, ref})
 
     # Should transition to ready and notify
-    assert_receive {:pool_ready_notified, ^pool_pid}, 500
+    assert_receive {:pool_ready_notified, ^pool_pid, @pool_role}, 500
     assert pool_state(stack_id).status == :ready
   end
 

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -295,8 +295,10 @@ defmodule Electric.Connection.ConnectionManagerTest do
 
       start_connection_manager(ctx)
 
-      assert_receive {:validate, ^pooled_conn_opts}, 1000
-      assert_receive {:validate, ^repl_opts}, 1000
+      StatusMonitor.wait_until_active(stack_id, 1000)
+
+      assert_receive {:validate, ^pooled_conn_opts}
+      assert_receive {:validate, ^repl_opts}
     end
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -157,7 +157,7 @@ defmodule Electric.Shapes.ConsumerTest do
                stack_id: ctx.stack_id,
                inspector: {Mock.Inspector, []},
                log_producer: ShapeLogCollector.name(ctx.stack_id),
-               db_pool: Electric.Connection.Manager.pool_name(ctx.stack_id),
+               db_pool: Electric.Connection.Manager.snapshot_pool(ctx.stack_id),
                registry: registry_name,
                shape_status: {Mock.ShapeStatus, []},
                publication_manager: {Mock.PublicationManager, []},

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -71,7 +71,8 @@ defmodule Support.TestUtils do
   def set_status_to_active(%{stack_id: stack_id}) do
     Electric.StatusMonitor.mark_pg_lock_acquired(stack_id, self())
     Electric.StatusMonitor.mark_replication_client_ready(stack_id, self())
-    Electric.StatusMonitor.mark_connection_pool_ready(stack_id, self())
+    Electric.StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
+    Electric.StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
     Electric.StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
     Electric.StatusMonitor.wait_for_messages_to_be_processed(stack_id)
   end


### PR DESCRIPTION
Separating long-running snapshot connections from the various admin/metadata queries

Also move connection opts discovery into external process