### PR TITLE
New quickstart package and docs.

### DIFF
--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -1013,3 +1013,30 @@ ul.demo-actions li .VPButton {
     margin-bottom: 1rem;
   }
 }
+
+:root {
+  --vp-plugin-tabs-tab-text-color: var(--vp-c-text-1);
+  --vp-plugin-tabs-tab-active-text-color: var(--vp-c-brand-1);
+  --vp-plugin-tabs-tab-hover-text-color: var(--vp-c-brand-1);
+}
+.plugin-tabs {
+  background: none;
+}
+.plugin-tabs--tab-list {
+  padding: 0;
+  margin-bottom: 4px;
+}
+.plugin-tabs--tab {
+  padding: 0 16px;
+  font-weight: 550;
+  line-height: 56px;
+  border-bottom: 3px solid transparent;
+}
+.plugin-tabs--tab::after {
+  left: 0;
+  right: 0;
+  height: 3px;
+}
+.plugin-tabs--content {
+  padding: 16px 0 !important;
+}

--- a/website/blog/posts/2025-07-29-local-first-sync-with-tanstack-db.md
+++ b/website/blog/posts/2025-07-29-local-first-sync-with-tanstack-db.md
@@ -1,5 +1,5 @@
 ---
-title: Local-first sync with TanStack DB and Electric
+title: Local-first sync with Electric and TanStack DB
 description: >-
   Tanstack DB is a reactive client store for building super fast apps on sync.
   Paired with Electric, it provides an optimal end-to-end sync stack for
@@ -43,7 +43,7 @@ import ScalabilityChart from '../../src/components/ScalabilityChart.vue'
 
 <div class="hidden-xs">
 
-[Tanstack DB](https://tanstack.com/db) is a [reactive client store for building super fast apps on sync](https://tanstack.com/blog/tanstack-db-0.1-the-embedded-client-database-for-tanstack-query). Paired with [Electric](/), it provides an optimal end-to-end sync stack for [local-first app development](/use-cases/local-first-software).
+[Tanstack DB](https://tanstack.com/db) is a [reactive client store for building super fast apps on sync](https://tanstack.com/blog/tanstack-db-0.1-the-embedded-client-database-for-tanstack-query). Paired with [Electric](/), it provides an optimal end-to-end sync stack for building <span class="no-wrap-sm">[local-first apps](/use-cases/local-first-software)</span>.
 
 </div>
 <div class="block-xs">

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
 description: >-
-  Get up-and-running with Electric and real-time sync of your Postgres data.
+  Get up-and-running with Electric and TanStack DB. Install, develop and deploy a super-fast, reactive web app, based on real-time sync of your Postgres data.
 outline: 2
 ---
 
@@ -14,225 +14,161 @@ outline: 2
 
 # Quickstart
 
-Let's get you up-and-running with Electric and start syncing data out of Postgres in real-time.
+Let's make a super-fast, reactive web app using <span class="no-wrap-xs">[Electric with TanStack&nbsp;DB](/blog/2025/07/29/local-first-sync-with-tanstack-db)</span>.
 
-First we'll setup Electric and show you how to use the low-level [HTTP API](/docs/api/http) directly. Then we'll create a simple React app using our higher-level [React hooks](/docs/integrations/react#useshape).
+<div style="max-width: 632px">
+
+> [!Warning] ✨ Just want to see it in action?
+> See the [app running here](https://quickstart.examples.electric-sql.com) or [fork it on StackBlitz](https://stackblitz.com/fork/github/electric-sql/electric/tree/main/examples/tanstack-db-web-starter).
+
+</div>
 
 ## Setup
 
-We're going to run a fresh Postgres and Electric using [Docker Compose](https://docs.docker.com/compose). First create a new folder to work in:
+You'll need [Node](https://nodejs.org/en), [pnpm](https://pnpm.io) and [Caddy](https://caddyserver.com) installed. If you haven't used Caddy before, you'll need to install it's [root certificate](https://caddyserver.com/docs/command-line#caddy-trust) using:
 
 ```sh
-mkdir my-first-electric
-cd my-first-electric
+caddy trust # may require sudo
 ```
 
-Then download and run this [docker-compose.yaml](https://github.com/electric-sql/electric/blob/main/website/public/docker-compose.yaml) file:
+<small><em>Why Caddy? Electric [uses HTTP/2](https://electric-sql.com/docs/guides/troubleshooting#slow-shapes-mdash-why-are-my-shapes-slow-in-the-browser-in-local-development). Caddy enables HTTP/2 in local development.</em></small>
 
-```sh
-curl -O https://electric-sql.com/docker-compose.yaml
-docker compose up
+## Get started
+
+:::tabs
+== Cloud (default)
+
+Run the starter script:
+
+```shell
+npx @electric-sql/start my-electric-app
 ```
 
-You can now start using Electric!
+Start the dev server:
 
-## HTTP API
-
-First let's try the low-level [HTTP API](/docs/api/http).
-
-In a new terminal, use `curl` to request a [Shape](/docs/guides/shapes) containing all rows in the `scores` table:
-
-```sh
-curl -i 'http://localhost:3000/v1/shape?table=scores&offset=-1'
+```shell
+pnpm dev
 ```
 
-::: info A bit of explanation about the URL structure.
+Open [https://localhost:5173](https://localhost:5173).
 
-- `/v1/shape` is a standard prefix with the API version and the shape sync endpoint path
-- `scores` is the name of the [`table`](/docs/guides/shapes#table) of the shape (and is required); if you wanted to sync data from the `items` table, you would change the path to `/v1/shape?table=items`
-- `offset=-1` means we're asking for the _entire_ Shape as we don't have any of the data cached locally yet. If we had previously fetched the shape and wanted to see if there were any updates, we'd set the offset to the last offset we'd already seen.
-  :::
+### See the real-time sync
 
-You should get a response like this:
+In another terminal, connect to Postgres using `psql`:
 
-```http
-HTTP/1.1 400 Bad Request
-date: Wed, 09 Apr 2025 20:03:40 GMT
-content-length: 170
-vary: accept-encoding
-cache-control: no-cache
-x-request-id: GDS_DYUuk2dR6FEAAAAh
-electric-server: ElectricSQL/1.0.4
-access-control-allow-origin: *
-access-control-expose-headers: *
-access-control-allow-methods: GET, HEAD, DELETE, OPTIONS
-content-type: application/json; charset=utf-8
-electric-schema: null
-
-{"message":"Invalid request","errors":{"table":["Table \"public\".\"scores\" does not exist. If the table name contains capitals or special characters you must quote it."]}}
+```shell
+pnpm psql
 ```
 
-So it didn't work! Which makes sense... as it's an empty database without any tables or data. Let's fix that.
-
-### Create a table and insert some data
-
-Use a Postgres client to connect to Postgres. For example, with [psql](https://www.postgresql.org/docs/current/app-psql.html) you can run:
-
-```sh
-psql "postgresql://postgres:password@localhost:54321/electric"
-```
-
-Then create a `scores` table
+Update the project name:
 
 ```sql
-CREATE TABLE scores (
-  id SERIAL PRIMARY KEY,
-  name VARCHAR(255),
-  value FLOAT
-);
+UPDATE projects SET name = 'Baz bam!';
 ```
 
-And insert some rows:
+The app updates instantly in real-time &mdash; across all users and devices.
 
-```sql
-INSERT INTO scores (name, value) VALUES
-  ('Alice', 3.14),
-  ('Bob', 2.71),
-  ('Charlie', -1.618),
-  ('David', 1.414),
-  ('Eve', 0);
-```
+### Develop your app
 
-#### Now try the curl command again
+The starter is a fully-fledged [TanStack Start](https://tanstack.com/start/latest/docs/framework/react/overview) app with routing and auth.
 
-Exit your Postgres client (e.g.: with `psql` enter `\q`) and try the `curl` request again:
+You can edit the code manually. Or it has an `AGENTS.md` file you can load directly into your AI code editor:
 
 ```sh
-curl -i 'http://localhost:3000/v1/shape?table=scores&offset=-1'
+claude "Read Agents.md. Sort the project page todo list alphabetically."
 ```
 
-Success! You should see the data you just put into Postgres in the shape response:
+See the [starter template README](https://github.com/electric-sql/electric/blob/main/examples/tanstack-db-web-starter/README.md#developing-your-app) for more details.
 
-```bash
-HTTP/1.1 200 OK
-transfer-encoding: chunked
-date: Wed, 09 Apr 2025 20:07:01 GMT
-cache-control: public, max-age=604800, s-maxage=3600, stale-while-revalidate=2629746
-x-request-id: GDS_PHZhjLuApVQAAAEB
-electric-server: ElectricSQL/1.0.4
-access-control-allow-origin: *
-access-control-expose-headers: *
-access-control-allow-methods: GET, HEAD, DELETE, OPTIONS
-content-type: application/json; charset=utf-8
-etag: "64351139-1744229222132:-1:0_0"
-electric-handle: 64351139-1744229222132
-electric-schema: {"id":{"type":"int4","not_null":true,"pk_index":0},"name":{"type":"varchar","max_length":255},"value":{"type":"float8"}}
-electric-offset: 0_0
+### Deploy your app
 
-[{"key":"\"public\".\"scores\"/\"1\"","value":{"id":"1","name":"Alice","value":"3.14"},"headers":{"operation":"insert","relation":["public","scores"]}}
-,{"key":"\"public\".\"scores\"/\"2\"","value":{"id":"2","name":"Bob","value":"2.71"},"headers":{"operation":"insert","relation":["public","scores"]}}
-,{"key":"\"public\".\"scores\"/\"3\"","value":{"id":"3","name":"Charlie","value":"-1.618"},"headers":{"operation":"insert","relation":["public","scores"]}}
-,{"key":"\"public\".\"scores\"/\"4\"","value":{"id":"4","name":"David","value":"1.414"},"headers":{"operation":"insert","relation":["public","scores"]}}
-,{"key":"\"public\".\"scores\"/\"5\"","value":{"id":"5","name":"Eve","value":"0"},"headers":{"operation":"insert","relation":["public","scores"]}}
-]
+Claim the [Electric Cloud](/product/cloud) resources:
+
+```shell
+pnpm claim
 ```
 
-::: info What are those messages in the response data?
-When you request shape data using the HTTP API you're actually requesting entries from a log of database operations affecting the data in the shape. This is called the [Shape Log](/docs/api/http#shape-log).
+Deploy the app, for example to [Netlify](https://tanstack.com/start/latest/docs/framework/react/hosting#what-is-netlify):
 
-The `offset` that you see in the messages and provide as the `?offset=...` query parameter in your request identifies a position in the log. The messages you see in the response are shape log entries (the ones with `value`s and `operation` headers) and control messages (the ones with `control` headers).
+```sh
+pnpm deploy
+```
+
+Congratulations! You've shipped a super-fast, reactive web app based on real-time sync!
+
+== Docker
+
+You can also run the [starter template](https://github.com/electric-sql/electric/tree/main/examples/tanstack-db-web-starter) with local backend services in Docker:
+
+```sh
+npx gitpick electric-sql/electric/tree/main/examples/tanstack-db-web-starter my-electric-app
+cd my-electric-app
+```
+
+Copy the `.env.example` file to `.env`:
+
+```sh
+cp .env.example .env
+```
+
+Install the dependencies:
+
+```sh
+pnpm install
+```
+
+Start Postgres and Electric running as background services using Docker Compose:
+
+```sh
+pnpm backend:up
+```
+
+Apply the database migrations:
+
+```sh
+pnpm migrate
+```
+
+Start the dev server:
+
+```sh
+pnpm dev
+```
+
+Open the application on [https://localhost:5173](https://localhost:5173).
+
+## See the real-time sync
+
+In another terminal, connect to Postgres using `psql`:
+
+```shell
+pnpm psql
+```
+
+Update the project name:
+
+```sql
+UPDATE projects SET name = 'Baz bam!';
+```
+
+The app updates instantly in real-time &mdash; across all users and devices.
+
+## Develop your app
+
+The starter is a fully-fledged [TanStack Start](https://tanstack.com/start/latest/docs/framework/react/overview) app with routing and auth.
+
+You can edit the code manually. Or it has an `AGENTS.md` file you can load directly into your AI code editor:
+
+```sh
+claude "Read Agents.md. Sort the project page todo list alphabetically."
+```
+
+See the [starter template README](https://github.com/electric-sql/electric/blob/main/examples/tanstack-db-web-starter/README.md#developing-your-app) for more details.
+
 :::
 
-At this point, you could continue to fetch data using HTTP requests. However, let's switch up to fetch the same shape to use in a React app instead.
+## Next steps
 
-## React app
-
-Run the following to create a standard React app:
-
-```sh
-npm create --yes vite@latest react-app -- --template react-ts
-```
-
-Change into the `react-app` subfolder and install the `@electric-sql/react` package:
-
-```sh
-cd react-app
-npm install @electric-sql/react
-```
-
-Replace the contents of `src/App.tsx` with the following. Note that we're requesting the same shape as before:
-
-```tsx
-import { useShape } from '@electric-sql/react'
-
-function Component() {
-  const { data } = useShape({
-    url: `http://localhost:3000/v1/shape`,
-    params: {
-      table: `scores`,
-    },
-  })
-
-  return <pre>{JSON.stringify(data, null, 2)}</pre>
-}
-
-export default Component
-```
-
-Finally run the dev server to see it all in action!
-
-```sh
-npm run dev
-```
-
-Navigate to http://localhost:5173 in your web browser. You should see output like this:
-
-```json
-[
-  {
-    "id": 1,
-    "name": "Alice",
-    "value": 3.14
-  },
-  {
-    "id": 2,
-    "name": "Bob",
-    "value": 2.71
-  },
-  {
-    "id": 3,
-    "name": "Charlie",
-    "value": -1.618
-  },
-  {
-    "id": 4,
-    "name": "David",
-    "value": 1.414
-  },
-  {
-    "id": 5,
-    "name": "Eve",
-    "value": 0
-  }
-]
-```
-
-#### Postgres as a real-time database
-
-Note that the row with id `2` has the name `"Bob"`. Go back to your Postgres client and update the name of that row. It'll instantly be synced to your component!
-
-```sql
-UPDATE scores SET name = 'James' WHERE id = 2;
-```
-
-Congratulations! You've built your first real-time, reactive Electric app!
-
-## Production Best Practices
-
-The examples above connect directly to Electric for simplicity. However, **for production applications, you should always proxy Electric requests through your backend API**.
-
-### Why Use an API Proxy?
-
-Direct connections expose your database structure and require client-side authorization logic. Instead, treat Electric shapes like normal API calls.
-
-**→ See the [authentication guide](/docs/guides/auth) for a complete walkthrough of why and how to implement the API proxy pattern.**
+<!-- - follow the [Tutorial](/docs/tutorial) to evolve your starter into a production-quality app. -->
+- learn more about [Local-first sync with Electric and TanStack DB](/blog/2025/07/29/local-first-sync-with-tanstack-db)
+- see the [Interactive guide to TanStack DB](https://frontendatscale.com/blog/tanstack-db).

--- a/website/docs/stacks.md
+++ b/website/docs/stacks.md
@@ -267,7 +267,7 @@ For example, sync into [LiveStore](https://docs.livestore.dev/reference/syncing/
 
 [Tanstack DB](https://tanstack.com/db) is a reactive client store for [building super fast apps on&nbsp;sync](https://tanstack.com/blog/tanstack-db-0.1-the-embedded-client-database-for-tanstack-query).
 
-Paired with [Electric](/) and [TanStack Start](https://tanstack.com/start), it gives you an end-to-end sync stack that's type-safe, declarative, incrementally adoptable and insanely fast.
+[Paired with Electric](/blog/2025/07/29/local-first-sync-with-tanstack-db) and [TanStack Start](https://tanstack.com/start), it gives you an end-to-end sync stack that's type-safe, declarative, incrementally adoptable and insanely fast.
 
 ### End-to-end Typescript
 


### PR DESCRIPTION
A simpler Quickstart based on the tanstack-db.web-starter and @electric-sql/start package:
https://deploy-preview-3114--electric-next.netlify.app/docs/quickstart

Relies on #3595 being finished and published and #3634 being merged and used to deploy the Quickstart demo.