### PR TITLE
Fix transformer option typing

### DIFF
--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -259,7 +259,7 @@ export interface ShapeStreamOptions<T = never> {
   fetchClient?: typeof fetch
   backoffOptions?: BackoffOptions
   parser?: Parser<T>
-  transformer?: TransformFunction<T>
+  transformer?: TransformFunction
 
   /**
    * A function for handling shapestream errors.

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -19,9 +19,9 @@ export type Parser<Extensions = never> = {
   [key: string]: ParseFunction<Extensions>
 }
 
-export type TransformFunction<Extensions = never> = (
+export type TransformFunction = (
   record: Record<string, unknown>
-) => Row<Extensions>
+) => Record<string, unknown>
 
 const parseNumber = (value: string) => Number(value)
 const parseBool = (value: string) => value === `true` || value === `t`
@@ -98,10 +98,10 @@ export function pgArrayParser<Extensions>(
 
 export class MessageParser<T extends Row<unknown>> {
   private parser: Parser<GetExtensions<T>>
-  private transformer?: TransformFunction<GetExtensions<T>>
+  private transformer?: TransformFunction
   constructor(
     parser?: Parser<GetExtensions<T>>,
-    transformer?: TransformFunction<GetExtensions<T>>
+    transformer?: TransformFunction
   ) {
     // Merge the provided parser with the default parser
     // to use the provided parser whenever defined

--- a/packages/typescript-client/src/parser.ts
+++ b/packages/typescript-client/src/parser.ts
@@ -20,7 +20,7 @@ export type Parser<Extensions = never> = {
 }
 
 export type TransformFunction<Extensions = never> = (
-  message: Row<Extensions>
+  record: Record<string, unknown>
 ) => Row<Extensions>
 
 const parseNumber = (value: string) => Number(value)

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -127,13 +127,19 @@ describe.for(fetchAndSse)(
     }) => {
       const [id] = await insertIssues({ title: `test title` })
 
+      type CustomRow = {
+        ID: number
+        TITLE: string
+        PRIORITY: number
+      }
+
       // transformer example: uppercase keys
       const uppercaseKeys: TransformFunction = (row) =>
         Object.fromEntries(
           Object.entries(row).map(([k, v]) => [k.toUpperCase(), v])
-        ) as Row
+        )
 
-      const shapeStream = new ShapeStream({
+      const shapeStream = new ShapeStream<CustomRow>({
         url: `${BASE_URL}/v1/shape`,
         params: {
           table: issuesTableUrl,

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -131,7 +131,7 @@ describe.for(fetchAndSse)(
       const uppercaseKeys: TransformFunction = (row) =>
         Object.fromEntries(
           Object.entries(row).map(([k, v]) => [k.toUpperCase(), v])
-        )
+        ) as Row
 
       const shapeStream = new ShapeStream({
         url: `${BASE_URL}/v1/shape`,


### PR DESCRIPTION
I tried some TypeScript tricks to make `TransformFunction` generic, but found it hard to write a version that would satisfy type constraints after narrowing in the `ShapeStream` class.

But I think this is okay, since the call site for `transformer` is in the land of `JSON.parse` and the final value is returned `as Result` that `Record<string, unknown>` is the most accurate typing available in that context.

This also saves end users from having to return with `as Row` in their `transformer` implementation.  It seems like the lowest friction signature for users.

I tested with:

```
cd packages/typescript-client && pnpm typecheck && pnpm build && cd -
cd packages/react-hooks && pnpm build && cd -
cd examples/nextjs && pnpm typecheck && cd -
cd examples/proxy-auth && pnpm typecheck && cd -
```