### PR TITLE
Fix GetExtensions to infer minimal Extensions

### DIFF
--- a/.changeset/spotty-oranges-pretend.md
+++ b/.changeset/spotty-oranges-pretend.md
@@ -1,5 +1,0 @@
----
-"@electric-sql/client": patch
----
-
-Fix problem with types of transformer due to a problem with the GetExtensions type.

--- a/.changeset/spotty-oranges-pretend.md
+++ b/.changeset/spotty-oranges-pretend.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Fix problem with types of transformer due to a problem with the GetExtensions type.

--- a/packages/typescript-client/src/types.ts
+++ b/packages/typescript-client/src/types.ts
@@ -14,8 +14,14 @@ export type Value<Extensions = never> =
 
 export type Row<Extensions = never> = Record<string, Value<Extensions>>
 
-export type GetExtensions<T extends Row<unknown>> =
-  T extends Row<infer Extensions> ? Extensions : never
+// Check if `T` extends the base Row type without extensions
+// if yes, it has no extensions so we return `never`
+// otherwise, we infer the extensions from the Row type
+export type GetExtensions<T> = [T] extends [Row<never>]
+  ? never
+  : [T] extends [Row<infer E>]
+    ? E
+    : never
 
 export type Offset = `-1` | `${number}_${number}` | `${bigint}_${number}`
 


### PR DESCRIPTION
Fixes the issue with the transformer which is blocking CI due to failing typecheck.

The problem was that the `GetExtensions` type was inferring types that aren't extensions:
```ts
GetExtensions<{
  id: number
  name: string
  org_id: number
}>
```
The snippet above was being resolved to `string | number` instead of `never`. That was wrong because `string` and `number` are built-in types so they don't count as extensions. Since this object type has no extensions it should return `never`.

Fixed that by changing the `GetExtensions` type to explicitly check whether the type extends the base `Row` type. If that's the case, then there are no extensions and we just return `never`. Otherwise, we infer the extensions.