### PR TITLE
feat(sync-service): Scale down database connections after a lull in streamed transactions

### DIFF
--- a/.changeset/nasty-birds-build.md
+++ b/.changeset/nasty-birds-build.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Support shutting down database connections automatically when the replication stream is idle. This allows for scaling down the database compute on supported providers.

--- a/integration-tests/scripts/init_db.sh
+++ b/integration-tests/scripts/init_db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -x
+
+psql --dbname electric -c "$INIT_DB_SQL"

--- a/integration-tests/scripts/low_privilege_db.sh
+++ b/integration-tests/scripts/low_privilege_db.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -x
-
-psql --dbname electric -c "CREATE ROLE low_privilege LOGIN PASSWORD 'password' REPLICATION; $LOW_PRIVILEGE_TEST_INIT_SQL"

--- a/integration-tests/scripts/test_user_db.sh
+++ b/integration-tests/scripts/test_user_db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -x
+
+psql --dbname electric -c "CREATE ROLE electric_test LOGIN PASSWORD 'password' REPLICATION; GRANT CREATE ON DATABASE electric TO electric_test;"

--- a/integration-tests/scripts/test_user_db.sh
+++ b/integration-tests/scripts/test_user_db.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -x
-
-psql --dbname electric -c "CREATE ROLE electric_test LOGIN PASSWORD 'password' REPLICATION; GRANT CREATE ON DATABASE electric TO electric_test;"

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -179,7 +179,9 @@
 
     ??[info] Starting ElectricSQL
 
-    !{:ok, _pid} = Electric.TestUtils.ConnectionManagerPing.start_link(manager_name: Electric.Connection.Manager.name("single_stack"))
+    !if is_nil(System.get_env("DO_NOT_START_CONN_MAN_PING")) do \
+      {:ok, _pid} = Electric.TestUtils.ConnectionManagerPing.start_link(manager_name: Electric.Connection.Manager.name("single_stack")) \
+     end
 [endmacro]
 
 [macro start_electric_script shell_name port env]

--- a/integration-tests/tests/db-connection-scaledown.lux
+++ b/integration-tests/tests/db-connection-scaledown.lux
@@ -1,0 +1,55 @@
+[doc Verify Electric can scale down database connections after a lull in stream transactions]
+
+[include _macros.luxinc]
+
+[global pg_container_name=db-connection-scaledown__pg]
+[global database_url=postgresql://electric_test:password@localhost:$pg_host_port/electric?sslmode=disable]
+
+###
+
+# Start Postgres and create an additional role that will be used by Electric in this test
+[invoke setup_pg_with_shell_name \
+  "pg" \
+  "" \
+  "" \
+  "-v $(realpath ../scripts/test_user_db.sh):/docker-entrypoint-initdb.d/initdb-test_user_db.sh"]
+
+# Start Electric and wait for it to finish initialization
+[invoke setup_electric_with_env "ELECTRIC_DATABASE_SCALE_DOWN_ON_IDLE_TIMEOUT=1s"]
+[shell electric]
+  [timeout 10]
+  ??[debug] Replication client started streaming
+
+# Verify that Electric has multiple database connections open
+[invoke start_psql]
+
+[shell psql]
+  !\a
+  !\pset pager_min_lines 1000
+
+  !select datname, usename, backend_type, query from pg_stat_activity where usename = 'electric_test' order by query;
+  ??datname|usename|backend_type|query
+  ??electric|electric_test|walsender|SELECT pg_advisory_lock(hashtext('electric_slot_integration'))
+  ??electric|electric_test|walsender|START_REPLICATION SLOT "electric_slot_integration"
+  ??(4 rows)
+
+# Force Electric to scale down by sending the :idle_check message to the replication client.
+# Normally the client performs the check once a minute, so we're speeding it up here for
+# testing purposes.
+[shell electric]
+  [sleep 2]
+
+  !Electric.Postgres.ReplicationClient.name("single_stack") |> GenServer.whereis() |> send(:check_if_idle)
+  ??[warning] Closing all database connections after the replication stream has been idle for
+
+  ??[debug] Terminating connection manager with reason :shutdown.
+
+# Confirm that Postgres no longer sees any open connections for the electric user
+[shell psql]
+  [sleep 2]
+
+  !select datname, usename, backend_type, query from pg_stat_activity where usename = 'electric_test';
+  ??(0 rows)
+
+[cleanup]
+  [invoke teardown]

--- a/integration-tests/tests/db-connection-scaledown.lux
+++ b/integration-tests/tests/db-connection-scaledown.lux
@@ -33,7 +33,7 @@
   ??datname|usename|backend_type|query
   ??electric|electric_test|walsender|SELECT pg_advisory_lock(hashtext('electric_slot_integration'))
   ??electric|electric_test|walsender|START_REPLICATION SLOT "electric_slot_integration"
-  ??(4 rows)
+  ?\(([1-9]|[1-9][0-9]) rows\)
 
 # Force Electric to scale down by sending the :idle_check message to the replication client.
 # Normally the client performs the check once a minute, so we're speeding it up here for

--- a/integration-tests/tests/db-connection-scaledown.lux
+++ b/integration-tests/tests/db-connection-scaledown.lux
@@ -10,7 +10,9 @@
 # Start Postgres and create an additional role that will be used by Electric in this test
 [invoke setup_pg_with_shell_name \
   "pg" \
-  "-e INIT_DB_SQL=\"CREATE ROLE electric_test LOGIN PASSWORD 'password' REPLICATION; GRANT CREATE ON DATABASE electric TO electric_test;\"" \
+  "-e INIT_DB_SQL=\"\
+    CREATE ROLE electric_test LOGIN PASSWORD 'password' REPLICATION;\
+    GRANT CREATE ON DATABASE electric TO electric_test\"" \
   "" \
   "-v $(realpath ../scripts/init_db.sh):/docker-entrypoint-initdb.d/initdb-init_db.sh"]
 
@@ -52,6 +54,29 @@
 
   !select datname, usename, backend_type, query from pg_stat_activity where usename = 'electric_test';
   ??(0 rows)
+
+# Create a table for a subsequent shape request
+[shell psql]
+  !create table items(val text);
+  ??CREATE
+
+  !insert into items values ('1'), ('2');
+  ??INSERT
+
+  !alter table items owner to electric_test;
+  ??ALTER TABLE
+
+# Scaling back up is just one shape request away
+[shell client]
+  [invoke shape_get_snapshot items]
+
+  ??HTTP/1.1 200
+  ??transfer-encoding: chunked
+  ??electric-schema: {"val":{"type":"text"}}
+  ??electric-offset: 0_0
+
+  ??[{"key":"\"public\".\"items\"/\"1\"","value":{"val":"1"},"headers":{"operation":"insert","relation":["public","items"]}},\
+     {"key":"\"public\".\"items\"/\"2\"","value":{"val":"2"},"headers":{"operation":"insert","relation":["public","items"]}}]
 
 [cleanup]
   [invoke teardown]

--- a/integration-tests/tests/db-connection-scaledown.lux
+++ b/integration-tests/tests/db-connection-scaledown.lux
@@ -10,9 +10,9 @@
 # Start Postgres and create an additional role that will be used by Electric in this test
 [invoke setup_pg_with_shell_name \
   "pg" \
+  "-e INIT_DB_SQL=\"CREATE ROLE electric_test LOGIN PASSWORD 'password' REPLICATION; GRANT CREATE ON DATABASE electric TO electric_test;\"" \
   "" \
-  "" \
-  "-v $(realpath ../scripts/test_user_db.sh):/docker-entrypoint-initdb.d/initdb-test_user_db.sh"]
+  "-v $(realpath ../scripts/init_db.sh):/docker-entrypoint-initdb.d/initdb-init_db.sh"]
 
 # Start Electric and wait for it to finish initialization
 [invoke setup_electric_with_env "ELECTRIC_DATABASE_SCALE_DOWN_ON_IDLE_TIMEOUT=1s"]

--- a/integration-tests/tests/db-connection-scaledown.lux
+++ b/integration-tests/tests/db-connection-scaledown.lux
@@ -14,8 +14,10 @@
   "" \
   "-v $(realpath ../scripts/init_db.sh):/docker-entrypoint-initdb.d/initdb-init_db.sh"]
 
-# Start Electric and wait for it to finish initialization
-[invoke setup_electric_with_env "ELECTRIC_DATABASE_SCALE_DOWN_ON_IDLE_TIMEOUT=1s"]
+# Start Electric and wait for it to finish initialization.
+# Have to disable the ConnectionManagerPing process, otherwise it will error when
+# Connection.Manager itself goes down as part of the test scenario.
+[invoke setup_electric_with_env "ELECTRIC_DATABASE_SCALE_DOWN_ON_IDLE_TIMEOUT=1s DO_NOT_START_CONN_MAN_PING=true"]
 [shell electric]
   [timeout 10]
   ??[debug] Replication client started streaming

--- a/integration-tests/tests/manual-table-publishing.lux
+++ b/integration-tests/tests/manual-table-publishing.lux
@@ -10,9 +10,11 @@
 ## Start a Postgres cluster with a role that does not own the user table
 [invoke setup_pg_with_shell_name \
   "pg" \
-  "-e LOW_PRIVILEGE_TEST_INIT_SQL='GRANT CREATE ON DATABASE electric TO low_privilege'" \
+  "-e INIT_DB_SQL=\"\
+    CREATE ROLE low_privilege LOGIN PASSWORD 'password' REPLICATION;\
+    GRANT CREATE ON DATABASE electric TO low_privilege\"" \
   "" \
-  "-v $(realpath ../scripts/low_privilege_db.sh):/docker-entrypoint-initdb.d/initdb-low_privilege_db.sh"]
+  "-v $(realpath ../scripts/init_db.sh):/docker-entrypoint-initdb.d/initdb-init_db.sh"]
 
 ## Start the sync service
 [invoke setup_electric_with_env "ELECTRIC_MANUAL_TABLE_PUBLISHING=true"]

--- a/integration-tests/tests/not-owner-of-the-publication.lux
+++ b/integration-tests/tests/not-owner-of-the-publication.lux
@@ -10,9 +10,9 @@
 ## Start a Postgres cluster with no publication and an unprivileged role
 [invoke setup_pg_with_shell_name \
   "pg" \
+  "-e INIT_DB_SQL=\"CREATE ROLE low_privilege LOGIN PASSWORD 'password' REPLICATION\"" \
   "" \
-  "" \
-  "-v $(realpath ../scripts/low_privilege_db.sh):/docker-entrypoint-initdb.d/initdb-low_privilege_db.sh"]
+  "-v $(realpath ../scripts/init_db.sh):/docker-entrypoint-initdb.d/initdb-init_db.sh"]
 
 ## Start the sync service
 [invoke setup_electric]
@@ -34,9 +34,11 @@
 ## Start a Postgres cluster with incorrectly configured publication and an unprivileged role
 [invoke setup_pg_with_shell_name \
   "pg" \
-  "-e LOW_PRIVILEGE_TEST_INIT_SQL='CREATE PUBLICATION electric_publication_integration WITH (publish = 'insert')'" \
+  "-e INIT_DB_SQL=\"\
+    CREATE ROLE low_privilege LOGIN PASSWORD 'password' REPLICATION;\
+    CREATE PUBLICATION electric_publication_integration WITH (publish = 'insert')\"" \
   "" \
-  "-v $(realpath ../scripts/low_privilege_db.sh):/docker-entrypoint-initdb.d/initdb-low_privilege_db.sh"]
+  "-v $(realpath ../scripts/init_db.sh):/docker-entrypoint-initdb.d/initdb-init_db.sh"]
 
 ## Start the sync service
 [invoke setup_electric]
@@ -58,9 +60,11 @@
 ## Start a Postgres cluster with precreated publication and an unprivileged role
 [invoke setup_pg_with_shell_name \
   "pg" \
-  "-e LOW_PRIVILEGE_TEST_INIT_SQL='CREATE PUBLICATION electric_publication_integration'" \
+  "-e INIT_DB_SQL=\"\
+    CREATE ROLE low_privilege LOGIN PASSWORD 'password' REPLICATION;\
+    CREATE PUBLICATION electric_publication_integration\"" \
   "" \
-  "-v $(realpath ../scripts/low_privilege_db.sh):/docker-entrypoint-initdb.d/initdb-low_privilege_db.sh"]
+  "-v $(realpath ../scripts/init_db.sh):/docker-entrypoint-initdb.d/initdb-init_db.sh"]
 
 ## Start the sync service
 [invoke setup_electric]

--- a/integration-tests/tests/not-owner-of-the-table.lux
+++ b/integration-tests/tests/not-owner-of-the-table.lux
@@ -10,9 +10,11 @@
 ## Start a Postgres cluster with a role that does not own the user table
 [invoke setup_pg_with_shell_name \
   "pg" \
-  "-e LOW_PRIVILEGE_TEST_INIT_SQL='GRANT CREATE ON DATABASE electric TO low_privilege'" \
+  "-e INIT_DB_SQL=\"\
+    CREATE ROLE low_privilege LOGIN PASSWORD 'password' REPLICATION;\
+    GRANT CREATE ON DATABASE electric TO low_privilege\"" \
   "" \
-  "-v $(realpath ../scripts/low_privilege_db.sh):/docker-entrypoint-initdb.d/initdb-low_privilege_db.sh"]
+  "-v $(realpath ../scripts/init_db.sh):/docker-entrypoint-initdb.d/initdb-init_db.sh"]
 
 ## Start the sync service
 [invoke setup_electric_with_env "ELECTRIC_TWEAKS_SCHEMA_RECONCILER_PERIOD=2s"]

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -247,6 +247,12 @@ config :electric,
       "ELECTRIC_TWEAKS_SCHEMA_RECONCILER_PERIOD",
       &Electric.Config.parse_human_readable_time!/1,
       nil
+    ),
+  scale_down_on_idle_timeout:
+    env!(
+      "ELECTRIC_DATABASE_SCALE_DOWN_ON_IDLE_TIMEOUT",
+      &Electric.Config.parse_human_readable_time!/1,
+      nil
     )
 
 if Electric.telemetry_enabled?() do

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -122,7 +122,8 @@ defmodule Electric.Application do
         publication_name: publication_name,
         slot_name: slot_name,
         slot_temporary?: get_env(opts, :replication_slot_temporary?),
-        max_txn_size: get_env(opts, :max_txn_size)
+        max_txn_size: get_env(opts, :max_txn_size),
+        max_idle_time: get_env(opts, :scale_down_on_idle_timeout)
       ],
       pool_opts:
         get_env_lazy(opts, :pool_opts, fn -> [pool_size: get_env(opts, :db_pool_size)] end),

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -48,6 +48,7 @@ defmodule Electric.Config do
     replication_slot_temporary?: false,
     replication_slot_temporary_random_name?: false,
     max_txn_size: 250 * 1024 * 1024,
+    scale_down_on_idle_timeout: 0,
     manual_table_publishing?: false,
     ## HTTP API
     # set enable_http_api: false to turn off the HTTP server totally

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -524,21 +524,31 @@ defmodule Electric.Connection.Manager do
       )
     end
 
+    repl_sup_opts = [
+      stack_id: state.stack_id,
+      shape_cache_opts: shape_cache_opts,
+      pool_opts: state.pool_opts,
+      replication_opts: state.replication_opts,
+      tweaks: state.tweaks,
+      can_alter_publication?: state.can_alter_publication?,
+      manual_table_publishing?: state.manual_table_publishing?,
+      persistent_kv: state.persistent_kv
+    ]
+
     start_time = System.monotonic_time()
 
-    with {:error, reason} <-
-           Electric.Connection.Manager.Supervisor.start_replication_supervisor(
-             stack_id: state.stack_id,
-             shape_cache_opts: shape_cache_opts,
-             pool_opts: state.pool_opts,
-             replication_opts: state.replication_opts,
-             tweaks: state.tweaks,
-             can_alter_publication?: state.can_alter_publication?,
-             manual_table_publishing?: state.manual_table_publishing?,
-             persistent_kv: state.persistent_kv
-           ) do
-      Logger.error("Failed to start shape supervisor: #{inspect(reason)}")
-      exit(reason)
+    case Electric.Connection.Manager.Supervisor.start_replication_supervisor(repl_sup_opts) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        # Ask the existing shape cache to clean itself up and stuff.
+        # Update last processed lsn based on the the latest replication client state ???
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to start shape supervisor: #{inspect(reason)}")
+        exit(reason)
     end
 
     state = %{

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -968,6 +968,8 @@ defmodule Electric.Connection.Manager do
       {:replication_liveness_check, state.replication_client_pid}
     )
 
+    Logger.debug("Replication client started streaming")
+
     state = %{state | current_step: :streaming}
     {:noreply, state}
   end

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -95,4 +95,8 @@ defmodule Electric.Connection.Manager.Supervisor do
 
     Supervisor.start_child(name(opts), child_spec)
   end
+
+  def stop_connection_manager(opts) do
+    Supervisor.terminate_child(name(opts), Electric.Connection.Manager)
+  end
 end

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -44,7 +44,6 @@ defmodule Electric.Postgres.ReplicationClient do
       :display_settings,
       :txn_collector,
       :publication_owner?,
-      origin: "postgres",
       step: :disconnected,
       # Cache the end_lsn of the last processed Commit message to report it back to Postgres
       # on demand via standby status update messages -
@@ -71,7 +70,6 @@ defmodule Electric.Postgres.ReplicationClient do
             start_streaming?: boolean(),
             slot_name: String.t(),
             slot_temporary?: boolean(),
-            origin: String.t(),
             txn_collector: Collector.t(),
             step: Electric.Postgres.ReplicationClient.step(),
             display_settings: [String.t()],

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -44,6 +44,7 @@ defmodule Electric.Postgres.ReplicationClient do
       :display_settings,
       :txn_collector,
       :publication_owner?,
+      :max_idle_time,
       step: :disconnected,
       # Cache the end_lsn of the last processed Commit message to report it back to Postgres
       # on demand via standby status update messages -
@@ -56,6 +57,7 @@ defmodule Electric.Postgres.ReplicationClient do
       received_wal: 0,
       flushed_wal: 0,
       last_seen_txn_lsn: Lsn.from_integer(0),
+      last_seen_txn_timestamp: nil,
       flush_up_to_date?: true
     ]
 
@@ -70,12 +72,15 @@ defmodule Electric.Postgres.ReplicationClient do
             start_streaming?: boolean(),
             slot_name: String.t(),
             slot_temporary?: boolean(),
-            txn_collector: Collector.t(),
-            step: Electric.Postgres.ReplicationClient.step(),
             display_settings: [String.t()],
+            txn_collector: Collector.t(),
+            publication_owner?: boolean(),
+            max_idle_time: non_neg_integer(),
+            step: Electric.Postgres.ReplicationClient.step(),
             received_wal: non_neg_integer(),
             flushed_wal: non_neg_integer(),
             last_seen_txn_lsn: Lsn.t(),
+            last_seen_txn_timestamp: integer(),
             flush_up_to_date?: boolean()
           }
 
@@ -89,6 +94,7 @@ defmodule Electric.Postgres.ReplicationClient do
                    start_streaming?: [type: :boolean, default: true],
                    slot_name: [required: true, type: :string],
                    slot_temporary?: [type: :boolean, default: false],
+                   max_idle_time: [type: :non_neg_integer, default: 0],
                    # Set a reasonable limit for the maximum size of a transaction that
                    # we can handle, above which we would exit as we run the risk of running
                    # out of memmory.
@@ -116,6 +122,8 @@ defmodule Electric.Postgres.ReplicationClient do
   @repl_msg_x_log_data ?w
   @repl_msg_primary_keepalive ?k
   @repl_msg_standby_status_update ?r
+
+  @idle_check_interval 60_000
 
   @spec start_link(Keyword.t()) :: :gen_statem.start_ret()
   def start_link(opts) do
@@ -259,6 +267,16 @@ defmodule Electric.Postgres.ReplicationClient do
     {:noreply, state}
   end
 
+  def handle_info(:check_if_idle, %State{last_seen_txn_timestamp: txn_ts} = state) do
+    time_diff = System.convert_time_unit(System.monotonic_time() - txn_ts, :native, :millisecond)
+
+    if time_diff >= state.max_idle_time do
+      {:disconnect, {:shutdown, {:connection_idle, time_diff}}}
+    else
+      {:noreply, state}
+    end
+  end
+
   # This callback is invoked when the connection process receives a shutdown signal.
   def handle_info({:EXIT, _pid, :shutdown}, _state) do
     Logger.debug("Replication client #{inspect(self())} received shutdown signal, stopping")
@@ -285,7 +303,14 @@ defmodule Electric.Postgres.ReplicationClient do
   @spec handle_data(binary(), State.t()) ::
           {:noreply, State.t()} | {:noreply, list(binary()), State.t()}
   def handle_data(data, %State{step: :start_streaming} = state) do
-    state = %{state | step: :streaming}
+    # Modify the state as if we've just seen a transaction so that in the future we have a
+    # starting point to check how long the stream has been idle for.
+    state = %{state | step: :streaming, last_seen_txn_timestamp: System.monotonic_time()}
+
+    if state.max_idle_time > 0 do
+      :timer.send_interval(@idle_check_interval, :check_if_idle)
+    end
+
     notify_seen_first_message(state)
     handle_data(data, state)
   end
@@ -357,7 +382,14 @@ defmodule Electric.Postgres.ReplicationClient do
         {:noreply, %{state | txn_collector: txn_collector}}
 
       {%Transaction{} = txn, txn_meta, %Collector{} = txn_collector} ->
-        state = %{state | txn_collector: txn_collector, last_seen_txn_lsn: txn.lsn}
+        timestamp = System.monotonic_time()
+
+        state = %{
+          state
+          | txn_collector: txn_collector,
+            last_seen_txn_lsn: txn.lsn,
+            last_seen_txn_timestamp: timestamp
+        }
 
         {m, f, args} = state.transaction_received
 
@@ -408,7 +440,10 @@ defmodule Electric.Postgres.ReplicationClient do
                 # new transaction into the shape log store. So, when the applied function
                 # returns, we can safely advance the replication slot past the transaction's commit
                 # LSN.
-                state = update_received_wal(state, Electric.Postgres.Lsn.to_integer(txn.lsn))
+                state =
+                  state
+                  |> update_received_wal(Electric.Postgres.Lsn.to_integer(txn.lsn))
+
                 response = [encode_standby_status_update(state)]
 
                 OpenTelemetry.stop_and_save_intervals(

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -31,7 +31,6 @@ defmodule Electric.Replication.Supervisor do
 
     Logger.info("Starting shape replication pipeline")
 
-    shape_status_owner = Keyword.fetch!(opts, :shape_status_owner)
     log_collector = Keyword.fetch!(opts, :log_collector)
     publication_manager = Keyword.fetch!(opts, :publication_manager)
     consumer_supervisor = Keyword.fetch!(opts, :consumer_supervisor)
@@ -42,7 +41,6 @@ defmodule Electric.Replication.Supervisor do
     children = [
       {Task.Supervisor,
        name: Electric.ProcessRegistry.name(stack_id, Electric.StackTaskSupervisor)},
-      shape_status_owner,
       log_collector,
       publication_manager,
       consumer_supervisor,

--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -211,6 +211,13 @@ defmodule Electric.Shapes.Api.Params do
 
           message, changeset when is_binary(message) ->
             add_error(changeset, field, message)
+
+          :connection_not_available, changeset ->
+            add_error(
+              changeset,
+              field,
+              "Cannot look up #{field} info while the database connection is down"
+            )
         end)
 
       {:error, %NimbleOptions.ValidationError{message: message, key: key}} ->

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -76,6 +76,7 @@ defmodule Electric.StackSupervisor do
                      slot_temporary?: [type: :boolean, default: false],
                      try_creating_publication?: [type: :boolean, default: true],
                      max_txn_size: [type: {:or, [:non_neg_integer, nil]}, default: nil],
+                     max_idle_time: [type: :non_neg_integer, default: 0],
                      stream_id: [type: :string, required: false]
                    ]
                  ],

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -386,4 +386,8 @@ defmodule Electric.StackSupervisor do
 
     Supervisor.init(children, strategy: :one_for_one, auto_shutdown: :any_significant)
   end
+
+  def shutdown_database_connections(stack_id) do
+    Electric.Connection.Manager.Supervisor.stop_connection_manager(stack_id: stack_id)
+  end
 end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -388,6 +388,7 @@ defmodule Electric.StackSupervisor do
   end
 
   def shutdown_database_connections(stack_id) do
+    Electric.StatusMonitor.database_connections_scaled_down(stack_id)
     Electric.Connection.Manager.Supervisor.stop_connection_manager(stack_id: stack_id)
   end
 end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -391,4 +391,13 @@ defmodule Electric.StackSupervisor do
     Electric.StatusMonitor.database_connections_scaled_down(stack_id)
     Electric.Connection.Manager.Supervisor.stop_connection_manager(stack_id: stack_id)
   end
+
+  def restore_database_connections(stack_id) do
+    # Stopping the Connection.Manager.Supervisor causes the Connection.Supervisor to restart it
+    # from a clean state. The end result is the Connection.Manager is back up and the
+    # Replication.Supervisor has the opportunity to purge shapes if the need for this is
+    # communicated by Connection.Manager.
+    Supervisor.stop(Electric.Connection.Manager.Supervisor.name(stack_id: stack_id))
+    Electric.StatusMonitor.database_connections_scaled_up(stack_id)
+  end
 end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -391,16 +391,16 @@ defmodule Electric.StackSupervisor do
   end
 
   def shutdown_database_connections(stack_id) do
-    Electric.StatusMonitor.database_connections_scaled_down(stack_id)
+    Electric.StatusMonitor.database_connections_scaling_down(stack_id)
     Electric.Connection.Manager.Supervisor.stop_connection_manager(stack_id: stack_id)
   end
 
   def restore_database_connections(stack_id) do
+    Electric.StatusMonitor.database_connections_scaling_up(stack_id)
     # Stopping the Connection.Manager.Supervisor causes the Connection.Supervisor to restart it
     # from a clean state. The end result is the Connection.Manager is back up and the
     # Replication.Supervisor has the opportunity to purge shapes if the need for this is
     # communicated by Connection.Manager.
     Supervisor.stop(Electric.Connection.Manager.Supervisor.name(stack_id: stack_id))
-    Electric.StatusMonitor.database_connections_scaled_up(stack_id)
   end
 end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -371,6 +371,8 @@ defmodule Electric.StackSupervisor do
              Keyword.take(monitor_opts, [:on_remove, :on_cleanup]),
              Keyword.take(shape_cache_opts, [:publication_manager])
            ])},
+          {Electric.ShapeCache.ShapeStatusOwner,
+           [stack_id: stack_id, shape_status: shape_status]},
           {Electric.Connection.Supervisor, new_connection_manager_opts}
         ]
 

--- a/packages/sync-service/lib/electric/status_monitor.ex
+++ b/packages/sync-service/lib/electric/status_monitor.ex
@@ -16,6 +16,8 @@ defmodule Electric.StatusMonitor do
 
   @db_scaled_down_key :db_scaled_down?
 
+  @wake_up_if_scaled_down_opt :wake_up_if_scaled_down
+
   def start_link(stack_id) do
     GenServer.start_link(__MODULE__, stack_id, name: name(stack_id))
   end
@@ -29,10 +31,17 @@ defmodule Electric.StatusMonitor do
     {:ok, %{stack_id: stack_id, waiters: MapSet.new()}}
   end
 
-  @spec status(String.t()) :: status()
-  def status(stack_id) do
+  @spec status(String.t(), [Atom.t()]) :: status()
+  def status(stack_id, opts \\ []) do
     if db_scaled_down?(stack_id) do
-      :active
+      if @wake_up_if_scaled_down_opt in opts do
+        Electric.StackSupervisor.restore_database_connections(stack_id)
+        :starting
+      else
+        # If there's no explicit request to wake the DB connections up, we assume this call is
+        # coming from the health check endpoint and report the servicec as active.
+        :active
+      end
     else
       stack_id
       |> results()
@@ -52,12 +61,12 @@ defmodule Electric.StatusMonitor do
 
   defp status_from_results(_), do: :starting
 
-  def database_connections_scaled_down(stack_id) do
-    GenServer.cast(name(stack_id), :db_scale_down)
+  def database_connections_scaling_down(stack_id) do
+    GenServer.cast(name(stack_id), :db_scaling_down)
   end
 
-  def database_connections_scaled_up(stack_id) do
-    GenServer.cast(name(stack_id), :db_scale_up)
+  def database_connections_scaling_up(stack_id) do
+    GenServer.cast(name(stack_id), :db_scaling_up)
   end
 
   def mark_pg_lock_acquired(stack_id, lock_pid) do
@@ -105,7 +114,7 @@ defmodule Electric.StatusMonitor do
   end
 
   def wait_until_active(stack_id, timeout) do
-    if status(stack_id) == :active do
+    if status(stack_id, [@wake_up_if_scaled_down_opt]) == :active do
       :ok
     else
       try do
@@ -172,12 +181,12 @@ defmodule Electric.StatusMonitor do
     {:noreply, state}
   end
 
-  def handle_cast(:db_scale_down, state) do
+  def handle_cast(:db_scaling_down, state) do
     :ets.insert(ets_table(state.stack_id), {@db_scaled_down_key, true})
     {:noreply, maybe_reply_to_waiters(state)}
   end
 
-  def handle_cast(:db_scale_up, state) do
+  def handle_cast(:db_scaling_up, state) do
     :ets.insert(ets_table(state.stack_id), {@db_scaled_down_key, false})
     {:noreply, maybe_reply_to_waiters(state)}
   end

--- a/packages/sync-service/lib/electric/status_monitor.ex
+++ b/packages/sync-service/lib/electric/status_monitor.ex
@@ -56,6 +56,10 @@ defmodule Electric.StatusMonitor do
     GenServer.cast(name(stack_id), :db_scale_down)
   end
 
+  def database_connections_scaled_up(stack_id) do
+    GenServer.cast(name(stack_id), :db_scale_up)
+  end
+
   def mark_pg_lock_acquired(stack_id, lock_pid) do
     mark_condition_met(stack_id, :pg_lock_acquired, lock_pid)
   end
@@ -170,6 +174,11 @@ defmodule Electric.StatusMonitor do
 
   def handle_cast(:db_scale_down, state) do
     :ets.insert(ets_table(state.stack_id), {@db_scaled_down_key, true})
+    {:noreply, maybe_reply_to_waiters(state)}
+  end
+
+  def handle_cast(:db_scale_up, state) do
+    :ets.insert(ets_table(state.stack_id), {@db_scaled_down_key, false})
     {:noreply, maybe_reply_to_waiters(state)}
   end
 

--- a/packages/sync-service/lib/electric/status_monitor.ex
+++ b/packages/sync-service/lib/electric/status_monitor.ex
@@ -14,6 +14,8 @@ defmodule Electric.StatusMonitor do
 
   @default_results for condition <- @conditions, into: %{}, do: {condition, {false, %{}}}
 
+  @db_scaled_down_key :db_scaled_down?
+
   def start_link(stack_id) do
     GenServer.start_link(__MODULE__, stack_id, name: name(stack_id))
   end
@@ -29,21 +31,29 @@ defmodule Electric.StatusMonitor do
 
   @spec status(String.t()) :: status()
   def status(stack_id) do
-    case results(stack_id) do
-      %{pg_lock_acquired: {false, _}} ->
-        :waiting
-
-      %{
-        replication_client_ready: {true, _},
-        admin_connection_pool_ready: {true, _},
-        snapshot_connection_pool_ready: {true, _},
-        shape_log_collector_ready: {true, _}
-      } ->
-        :active
-
-      _ ->
-        :starting
+    if db_scaled_down?(stack_id) do
+      :active
+    else
+      stack_id
+      |> results()
+      |> status_from_results()
     end
+  end
+
+  defp status_from_results(%{pg_lock_acquired: {false, _}}), do: :waiting
+
+  defp status_from_results(%{
+         replication_client_ready: {true, _},
+         admin_connection_pool_ready: {true, _},
+         snapshot_connection_pool_ready: {true, _},
+         shape_log_collector_ready: {true, _}
+       }),
+       do: :active
+
+  defp status_from_results(_), do: :starting
+
+  def database_connections_scaled_down(stack_id) do
+    GenServer.cast(name(stack_id), :db_scale_down)
   end
 
   def mark_pg_lock_acquired(stack_id, lock_pid) do
@@ -158,6 +168,11 @@ defmodule Electric.StatusMonitor do
     {:noreply, state}
   end
 
+  def handle_cast(:db_scale_down, state) do
+    :ets.insert(ets_table(state.stack_id), {@db_scaled_down_key, true})
+    {:noreply, maybe_reply_to_waiters(state)}
+  end
+
   def handle_call({:wait_until_active, timeout}, from, %{waiters: waiters} = state) do
     if status(state.stack_id) == :active do
       {:reply, :ok, state}
@@ -200,6 +215,15 @@ defmodule Electric.StatusMonitor do
       _ ->
         state
     end
+  end
+
+  defp db_scaled_down?(stack_id) do
+    :ets.lookup_element(ets_table(stack_id), @db_scaled_down_key, 2, false)
+  rescue
+    ArgumentError ->
+      # This happens when the table is not found, which means the
+      # process has not been started yet
+      false
   end
 
   defp results(stack_id) do

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -14,7 +14,8 @@ defmodule Electric.Connection.ConnectionManagerTest do
     :with_persistent_kv,
     :with_inspector,
     :with_slot_name_and_stream_id,
-    :with_in_memory_storage
+    :with_in_memory_storage,
+    :with_shape_status
   ]
 
   defp start_connection_manager(%{stack_id: stack_id} = ctx) do


### PR DESCRIPTION
Part of #2792.

This PR adds an internal API for shutting connection manager down (which closes all database connections) and bringing it back up (which is done by restarting both the connection manager and the replication supervisor). A new configuration option called `ELECTRIC_DATABASE_SCALE_DOWN_ON_IDLE_TIMEOUT` is introduced to allow users to configure the idle timeout, after which Electric will shut down its database connections if it hasn't seen a transaction in that time interval.

When a shape request comes in, the database connections are scaled back up to allow logical streaming to resume and populate the shape log with new transactions.

The first optimization we can implement that would help delay the scaling up is to serve shapes from the shape logs without proactively scaling up and only do so if the request is asking for the bleeding edge, i.e. beyond the last offset available in the log.

~~I had to make `StatusMonitor` aware of the scaled-down state and say that the stack is `active` for Electric to be able to continue serving shape requests for shapes it already has cached. New shape requests will currently fail with snapshot timeout but we can make it so they cause the connection manager to "wake up" as the next iteration.~~

From our [brief discussion on Discord](https://discord.com/channels/933657521581858818/972052396605837342/1400968235968495648) from some time ago:

> So basically the first step could be adding a setting like ELECTRIC_LOGICAL_REPLICATION_IDLE_TIMEOUT. When Electric doesn't receive a transaction from PG for that amount of time, it closes its DB connections (the replication connection, the lock connection and its internal DB pool connections).
> 
> Currently closing DB connections also implies shutting down the HTTP API but we've been planning to decouple the "write to shape logs" and "read from shape logs" parts of Electric, so doing that could be a bonus subtask under this scale-to-zero task.

~~In this PR we keep the ability to serve shape requests for known shapes. We can do more later when we get more coupling between read and write facets of Electric.~~

~~I have deliberately *not* made any shape request "wake up" the connection manager because that would defeat the purpose of the feature. Imagine a dev leaving their demo app running overnight or publishing it online. With Electric's long-polling going, the replication connection would never go to sleep if it's woken up every time by an incoming shape request. The same reasoning applies if we start scaling down connections for sources in cloud.~~

Remaining things:
- [x] integration test that verifies shutting down Connection.Manager causes all Electric's database connection to close
- [x] configuration option for setting the idle timeout: after that amount of time has passed with no new transactions, Electric will scale down
- ~~[ ] configuration option for the WAL size check period: while scaled down, Electric will check for new transactions with this period to see if it needs to restore the replication connection~~