### PR TITLE
feat(sync-service): Improve performance of LRU shape expiry

### DIFF
--- a/.changeset/gold-clocks-pull.md
+++ b/.changeset/gold-clocks-pull.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Improve performance of LRU shape expiry

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -120,6 +120,7 @@ defmodule Electric.Connection.Manager do
       # Registry used for stack events
       :stack_events_registry,
       :tweaks,
+      :max_shapes,
       :persistent_kv,
       :purge_all_shapes?,
       validated_connection_opts: %{replication: nil, pool: nil},
@@ -311,7 +312,8 @@ defmodule Electric.Connection.Manager do
         tweaks: Keyword.fetch!(opts, :tweaks),
         persistent_kv: Keyword.fetch!(opts, :persistent_kv),
         can_alter_publication?: true,
-        manual_table_publishing?: Keyword.get(opts, :manual_table_publishing?, false)
+        manual_table_publishing?: Keyword.get(opts, :manual_table_publishing?, false),
+        max_shapes: Keyword.fetch!(opts, :max_shapes)
       }
       |> initialize_connection_opts(opts)
 
@@ -535,7 +537,8 @@ defmodule Electric.Connection.Manager do
              tweaks: state.tweaks,
              can_alter_publication?: state.can_alter_publication?,
              manual_table_publishing?: state.manual_table_publishing?,
-             persistent_kv: state.persistent_kv
+             persistent_kv: state.persistent_kv,
+             max_shapes: state.max_shapes
            ) do
       Logger.error("Failed to start shape supervisor: #{inspect(reason)}")
       exit(reason)

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -79,7 +79,9 @@ defmodule Electric.Connection.Manager.Supervisor do
 
     expiry_manager_spec =
       {Electric.ShapeCache.ExpiryManager,
-       stack_id: stack_id, max_shapes: Keyword.fetch!(opts, :max_shapes)}
+       stack_id: stack_id,
+       max_shapes: Keyword.fetch!(opts, :max_shapes),
+       shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)}
 
     child_spec =
       Supervisor.child_spec(

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -79,9 +79,10 @@ defmodule Electric.Connection.Manager.Supervisor do
 
     expiry_manager_spec =
       {Electric.ShapeCache.ExpiryManager,
-       stack_id: stack_id,
        max_shapes: Keyword.fetch!(opts, :max_shapes),
-       shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)}
+       stack_id: stack_id,
+       shape_status: Keyword.fetch!(shape_cache_opts, :shape_status),
+       consumer_supervisor: Keyword.fetch!(shape_cache_opts, :consumer_supervisor)}
 
     child_spec =
       Supervisor.child_spec(

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -77,6 +77,10 @@ defmodule Electric.Connection.Manager.Supervisor do
        shape_cache: {Electric.ShapeCache, stack_id: stack_id},
        period: Keyword.get(tweaks, :schema_reconciler_period, 60_000)}
 
+    expiry_manager_spec =
+      {Electric.ShapeCache.ExpiryManager,
+       stack_id: stack_id, max_shapes: Keyword.fetch!(opts, :max_shapes)}
+
     child_spec =
       Supervisor.child_spec(
         {
@@ -87,7 +91,8 @@ defmodule Electric.Connection.Manager.Supervisor do
           shape_cache: shape_cache_spec,
           publication_manager: publication_manager_spec,
           log_collector: shape_log_collector_spec,
-          schema_reconciler: schema_reconciler_spec
+          schema_reconciler: schema_reconciler_spec,
+          expiry_manager: expiry_manager_spec
         },
         restart: :temporary,
         significant: true

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -47,7 +47,8 @@ defmodule Electric.Replication.Supervisor do
       publication_manager,
       consumer_supervisor,
       shape_cache,
-      schema_reconciler
+      schema_reconciler,
+      {Electric.ShapeCache.ExpiryManager, stack_id: opts[:stack_id]}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -37,6 +37,7 @@ defmodule Electric.Replication.Supervisor do
     consumer_supervisor = Keyword.fetch!(opts, :consumer_supervisor)
     shape_cache = Keyword.fetch!(opts, :shape_cache)
     schema_reconciler = Keyword.fetch!(opts, :schema_reconciler)
+    expiry_manager = Keyword.fetch!(opts, :expiry_manager)
     stack_id = Keyword.fetch!(opts, :stack_id)
 
     children = [
@@ -48,7 +49,7 @@ defmodule Electric.Replication.Supervisor do
       consumer_supervisor,
       shape_cache,
       schema_reconciler,
-      {Electric.ShapeCache.ExpiryManager, stack_id: opts[:stack_id]}
+      expiry_manager
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -66,7 +66,6 @@ defmodule Electric.ShapeCache do
               default: &Shapes.Consumer.Snapshotter.query_in_readonly_txn/7
             ],
             purge_all_shapes?: [type: :boolean, required: false],
-            max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil],
             recover_shape_timeout: [
               type: {:or, [:non_neg_integer, {:in, [:infinity]}]},
               default: 5_000
@@ -239,8 +238,7 @@ defmodule Electric.ShapeCache do
       log_producer: opts.log_producer,
       registry: opts.registry,
       consumer_supervisor: opts.consumer_supervisor,
-      subscription: nil,
-      max_shapes: opts.max_shapes
+      subscription: nil
     }
 
     {last_processed_lsn, total_recovered, total_failed_to_recover} =

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -28,11 +28,11 @@ defmodule Electric.ShapeCache do
   alias Electric.Postgres.Lsn
   alias Electric.Replication.LogOffset
   alias Electric.Replication.ShapeLogCollector
+  alias Electric.ShapeCache.ExpiryManager
   alias Electric.ShapeCache.ShapeStatus
   alias Electric.Shapes
   alias Electric.Shapes.ConsumerSupervisor
   alias Electric.Shapes.Shape
-  alias Electric.Telemetry.OpenTelemetry
 
   require Logger
 
@@ -288,12 +288,6 @@ defmodule Electric.ShapeCache do
   end
 
   @impl GenServer
-  def handle_info(:maybe_expire_shapes, state) do
-    maybe_expire_shapes(state)
-    {:noreply, state}
-  end
-
-  @impl GenServer
   def handle_call({:create_or_wait_shape_handle, shape, otel_ctx}, _from, state) do
     {shape_handle, latest_offset} = maybe_create_shape(shape, otel_ctx, state)
     Logger.debug("Returning shape id #{shape_handle} for shape #{inspect(shape)}")
@@ -346,44 +340,6 @@ defmodule Electric.ShapeCache do
     end)
 
     {:noreply, state}
-  end
-
-  defp maybe_expire_shapes(%{max_shapes: max_shapes} = state) when max_shapes != nil do
-    shape_count = shape_count(state)
-    {shape_status, shape_status_state} = state.shape_status
-
-    if shape_count > max_shapes do
-      number_to_expire = shape_count - max_shapes
-
-      shape_status.least_recently_used(shape_status_state, number_to_expire)
-      |> Enum.each(fn shape ->
-        OpenTelemetry.with_span(
-          "expiring_shape",
-          [
-            shape_handle: shape.shape_handle,
-            max_shapes: max_shapes,
-            shape_count: shape_count,
-            elapsed_minutes_since_use: shape.elapsed_minutes_since_use
-          ],
-          fn ->
-            Logger.info(
-              "Expiring shape #{shape.shape_handle} as as the number of shapes " <>
-                "has exceeded the limit (#{state.max_shapes})"
-            )
-
-            clean_up_shape(state, shape.shape_handle)
-          end
-        )
-      end)
-    end
-  end
-
-  defp maybe_expire_shapes(_), do: :ok
-
-  defp shape_count(%{shape_status: {shape_status, shape_status_state}}) do
-    shape_status_state
-    |> shape_status.list_shapes()
-    |> length()
   end
 
   defp clean_up_shape(state, shape_handle) do
@@ -530,7 +486,7 @@ defmodule Electric.ShapeCache do
 
       :ok = start_shape(shape_handle, shape, state, otel_ctx)
 
-      send(self(), :maybe_expire_shapes)
+      ExpiryManager.notify_new_shape_added(state.stack_id)
 
       # In this branch of `if`, we're guaranteed to have a newly started shape, so we can be sure about it's
       # "latest offset" because it'll be in the snapshotting stage

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -3,6 +3,7 @@ defmodule Electric.ShapeCache.ExpiryManager do
 
   @schema NimbleOptions.new!(
             stack_id: [type: :string, required: true],
+            shape_status: [type: :mod_arg, required: true],
             max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil]
           )
 
@@ -27,6 +28,10 @@ defmodule Electric.ShapeCache.ExpiryManager do
     Logger.metadata(stack_id: stack_id)
     Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
 
-    {:ok, %{max_shapes: Keyword.fetch!(opts, :max_shapes)}}
+    {:ok,
+     %{
+       max_shapes: Keyword.fetch!(opts, :max_shapes),
+       shape_status: Keyword.fetch!(opts, :shape_status)
+     }}
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -1,11 +1,18 @@
 defmodule Electric.ShapeCache.ExpiryManager do
   use GenServer
 
+  alias Electric.Telemetry.OpenTelemetry
+
+  require Logger
+
   @schema NimbleOptions.new!(
             stack_id: [type: :string, required: true],
             shape_status: [type: :mod_arg, required: true],
             max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil]
           )
+
+  @debounce_time_ms 50
+  @debounce_finished :timeout
 
   def name(stack_id) when not is_map(stack_id) and not is_list(stack_id) do
     Electric.ProcessRegistry.name(stack_id, __MODULE__)
@@ -14,6 +21,10 @@ defmodule Electric.ShapeCache.ExpiryManager do
   def name(opts) do
     stack_id = Access.fetch!(opts, :stack_id)
     name(stack_id)
+  end
+
+  def notify_new_shape_added(stack_id) do
+    GenServer.cast(name(stack_id), :notify_new_shape_added)
   end
 
   def start_link(opts) do
@@ -33,5 +44,94 @@ defmodule Electric.ShapeCache.ExpiryManager do
        max_shapes: Keyword.fetch!(opts, :max_shapes),
        shape_status: Keyword.fetch!(opts, :shape_status)
      }}
+  end
+
+  def handle_cast(:notify_new_shape_added, state) do
+    {:noreply, state, @debounce_time_ms}
+  end
+
+  def handle_info(@debounce_finished, state) do
+    maybe_expire_shapes(state)
+    {:noreply, state}
+  end
+
+  defp maybe_expire_shapes(%{max_shapes: max_shapes} = state) when max_shapes != nil do
+    shape_count = shape_count(state)
+
+    if shape_count > max_shapes do
+      number_to_expire = shape_count - max_shapes
+
+      shapes_to_expire = least_recently_used(state, number_to_expire)
+
+      OpenTelemetry.with_span(
+        "expiry_manager.expire_shapes",
+        [
+          max_shapes: max_shapes,
+          shape_count: shape_count,
+          number_to_expire: number_to_expire
+        ],
+        fn ->
+          shapes_to_expire
+          |> Enum.each(fn shape -> expire_shape(shape, state) end)
+        end
+      )
+    end
+  end
+
+  defp maybe_expire_shapes(_), do: :ok
+
+  defp expire_shape(shape, state) do
+    OpenTelemetry.with_span(
+      "expiry_manager.expire_shape",
+      [
+        shape_handle: shape.shape_handle,
+        elapsed_minutes_since_use: shape.elapsed_minutes_since_use
+      ],
+      fn ->
+        Logger.info(
+          "Expiring shape #{shape.shape_handle} as as the number of shapes " <>
+            "has exceeded the limit (#{state.max_shapes})"
+        )
+
+        clean_up_shape(state, shape.shape_handle)
+      end
+    )
+  end
+
+  defp clean_up_shape(state, shape_handle) do
+    # remove the shape immediately so new clients are redirected elsewhere
+    deregister_shape(shape_handle, state)
+
+    OpenTelemetry.with_span(
+      "expiry_manager.stop_shape_consumer",
+      [shape_handle: shape_handle],
+      fn ->
+        Electric.Shapes.DynamicConsumerSupervisor.stop_shape_consumer(
+          state.consumer_supervisor,
+          state.stack_id,
+          shape_handle
+        )
+      end
+    )
+
+    :ok
+  end
+
+  defp deregister_shape(shape_handle, %{shape_status: {shape_status, shape_status_state}}) do
+    shape_status.remove_shape(shape_status_state, shape_handle)
+  end
+
+  defp least_recently_used(%{shape_status: {shape_status, shape_status_state}}, number_to_expire) do
+    OpenTelemetry.with_span("expiry_manager.get_least_recently_used", [], fn ->
+      shape_status.least_recently_used(shape_status_state, number_to_expire)
+    end)
+  end
+
+  defp shape_count(%{shape_status: {shape_status, shape_status_state}}) do
+    OpenTelemetry.with_span("expiry_manager.get_shape_count", [], fn ->
+      shape_status_state
+      |> shape_status.list_shapes()
+      |> length()
+    end)
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -5,10 +5,13 @@ defmodule Electric.ShapeCache.ExpiryManager do
 
   require Logger
 
+  @name_schema_tuple {:tuple, [:atom, :atom, :any]}
+  @genserver_name_schema {:or, [:atom, @name_schema_tuple]}
   @schema NimbleOptions.new!(
+            max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil],
             stack_id: [type: :string, required: true],
             shape_status: [type: :mod_arg, required: true],
-            max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil]
+            consumer_supervisor: [type: @genserver_name_schema, required: true]
           )
 
   @debounce_time_ms 50
@@ -41,8 +44,10 @@ defmodule Electric.ShapeCache.ExpiryManager do
 
     {:ok,
      %{
+       stack_id: stack_id,
        max_shapes: Keyword.fetch!(opts, :max_shapes),
-       shape_status: Keyword.fetch!(opts, :shape_status)
+       shape_status: Keyword.fetch!(opts, :shape_status),
+       consumer_supervisor: Keyword.fetch!(opts, :consumer_supervisor)
      }}
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -1,0 +1,25 @@
+defmodule Electric.ShapeCache.ExpiryManager do
+  use GenServer
+
+  def name(stack_id) when not is_map(stack_id) and not is_list(stack_id) do
+    Electric.ProcessRegistry.name(stack_id, __MODULE__)
+  end
+
+  def name(opts) do
+    stack_id = Access.fetch!(opts, :stack_id)
+    name(stack_id)
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: name(opts))
+  end
+
+  def init(opts) do
+    stack_id = Keyword.fetch!(opts, :stack_id)
+    Process.set_label({:shape_expiry_manager, stack_id})
+    Logger.metadata(stack_id: stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
+
+    {:ok, opts}
+  end
+end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -308,8 +308,7 @@ defmodule Electric.StackSupervisor do
       chunk_bytes_threshold: config.chunk_bytes_threshold,
       log_producer: shape_log_collector,
       consumer_supervisor: Electric.Shapes.DynamicConsumerSupervisor.name(stack_id),
-      registry: shape_changes_registry_name,
-      max_shapes: config.max_shapes
+      registry: shape_changes_registry_name
     ]
 
     {monitor_opts, tweaks} = Keyword.pop(config.tweaks, :monitor_opts, [])
@@ -334,6 +333,7 @@ defmodule Electric.StackSupervisor do
       ],
       persistent_kv: config.persistent_kv,
       shape_cache_opts: shape_cache_opts,
+      max_shapes: config.max_shapes,
       tweaks: tweaks,
       manual_table_publishing?: config.manual_table_publishing?
     ]

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -61,6 +61,7 @@ defmodule Electric.Connection.ConnectionManagerTest do
            registry: Electric.StackSupervisor.registry_name(stack_id)
          ],
          tweaks: [],
+         max_shapes: nil,
          persistent_kv: ctx.persistent_kv,
          stack_events_registry: stack_events_registry},
         # The test supervisor under which this one is started has `auto_shutdown` set to

--- a/packages/sync-service/test/electric/shape_cache/expiry_manager_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/expiry_manager_test.exs
@@ -1,0 +1,140 @@
+defmodule Electric.ExpiryManagerTest do
+  use ExUnit.Case, async: true
+  use Support.Mock
+  use Repatch.ExUnit
+
+  alias Electric.Replication.Changes
+  alias Electric.Replication.LogOffset
+  alias Electric.ShapeCache
+  alias Electric.ShapeCache.ExpiryManager
+  alias Electric.ShapeCache.Storage
+  alias Electric.Shapes.Shape
+
+  import Mox
+  import Support.ComponentSetup
+  import Support.TestUtils
+
+  @stub_inspector Support.StubInspector.new(
+                    tables: [{1, {"public", "items"}}],
+                    columns: [
+                      %{
+                        name: "id",
+                        type: "int8",
+                        type_id: {20, 1},
+                        pk_position: 0,
+                        is_generated: false
+                      },
+                      %{name: "value", type: "text", type_id: {25, 1}, is_generated: false}
+                    ]
+                  )
+  @shape Shape.new!("items", inspector: @stub_inspector)
+
+  # {xmin, xmax, xip_list}
+  @pg_snapshot_xmin_10 {10, 11, [10]}
+
+  @moduletag :tmp_dir
+
+  defmodule TempPubManager do
+    def add_shape(_handle, _, opts) do
+      send(opts[:test_pid], {:called, :prepare_tables_fn})
+    end
+
+    def refresh_publication(_), do: :ok
+  end
+
+  setup :verify_on_exit!
+
+  setup do
+    %{inspector: @stub_inspector, run_with_conn_fn: fn _, cb -> cb.(:connection) end}
+  end
+
+  setup [
+    :with_persistent_kv,
+    :with_stack_id_from_test,
+    :with_pure_file_storage,
+    :with_shape_status,
+    :with_status_monitor,
+    :with_shape_monitor,
+    :with_log_chunking,
+    :with_registry,
+    :with_shape_log_collector,
+    :with_noop_publication_manager
+  ]
+
+  test "expires shapes if shape count has gone over max_shapes", ctx do
+    %{shape_cache_opts: opts, consumer_supervisor: consumer_supervisor} =
+      with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+        run_with_conn_fn: &run_with_conn_noop/2,
+        create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
+          GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
+          Storage.make_new_snapshot!([["test"]], storage)
+          GenServer.cast(parent, {:snapshot_started, shape_handle})
+        end
+      )
+
+    start_supervised!(
+      {ExpiryManager,
+       max_shapes: 1,
+       stack_id: ctx.stack_id,
+       shape_status: ctx.shape_status,
+       consumer_supervisor: consumer_supervisor}
+    )
+
+    {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+    assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+
+    consumer_ref =
+      Electric.Shapes.Consumer.whereis(ctx.stack_id, shape_handle)
+      |> Process.monitor()
+
+    storage = Storage.for_shape(shape_handle, ctx.storage)
+    writer = Storage.init_writer!(storage, @shape)
+
+    Storage.append_to_log!(
+      changes_to_log_items([
+        %Changes.NewRecord{
+          relation: {"public", "items"},
+          record: %{"id" => "1", "value" => "Alice"},
+          log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
+        }
+      ]),
+      writer
+    )
+
+    assert Storage.snapshot_started?(storage)
+
+    assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
+             1
+
+    {new_shape_handle, _} =
+      ShapeCache.get_or_create_shape_handle(%{@shape | where: "1 == 1"}, opts)
+
+    assert :started = ShapeCache.await_snapshot_start(new_shape_handle, opts)
+
+    assert_receive {:DOWN, ^consumer_ref, :process, _pid, {:shutdown, :cleanup}}
+
+    assert :ok = await_for_storage_to_raise(storage)
+
+    {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+    assert shape_handle != shape_handle2
+    assert :started = ShapeCache.await_snapshot_start(shape_handle2, opts)
+  end
+
+  def run_with_conn_noop(conn, cb), do: cb.(conn)
+
+  defp await_for_storage_to_raise(storage, num_attempts \\ 10)
+
+  defp await_for_storage_to_raise(_storage, 0) do
+    raise "Storage did not raise Storage.Error in time"
+  end
+
+  defp await_for_storage_to_raise(storage, num_attempts) do
+    try do
+      Stream.run(Storage.get_log_stream(LogOffset.before_all(), storage))
+      Process.sleep(50)
+      await_for_storage_to_raise(storage, num_attempts - 1)
+    rescue
+      Storage.Error -> :ok
+    end
+  end
+end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -251,58 +251,6 @@ defmodule Electric.ShapeCacheTest do
       assert_received {:called, :create_snapshot_fn}
     end
 
-    # test "expires shapes if shape count has gone over max_shapes", ctx do
-    #   %{shape_cache_opts: opts} =
-    #     with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
-    #       run_with_conn_fn: &run_with_conn_noop/2,
-    #       create_snapshot_fn: fn parent, shape_handle, _shape, _, storage, _, _ ->
-    #         GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
-    #         Storage.make_new_snapshot!([["test"]], storage)
-    #         GenServer.cast(parent, {:snapshot_started, shape_handle})
-    #       end,
-    #       max_shapes: 1
-    #     )
-
-    #   {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-    #   assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
-
-    #   consumer_ref =
-    #     Electric.Shapes.Consumer.whereis(ctx.stack_id, shape_handle)
-    #     |> Process.monitor()
-
-    #   storage = Storage.for_shape(shape_handle, ctx.storage)
-    #   writer = Storage.init_writer!(storage, @shape)
-
-    #   Storage.append_to_log!(
-    #     changes_to_log_items([
-    #       %Electric.Replication.Changes.NewRecord{
-    #         relation: {"public", "items"},
-    #         record: %{"id" => "1", "value" => "Alice"},
-    #         log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
-    #       }
-    #     ]),
-    #     writer
-    #   )
-
-    #   assert Storage.snapshot_started?(storage)
-
-    #   assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
-    #            1
-
-    #   {new_shape_handle, _} =
-    #     ShapeCache.get_or_create_shape_handle(%{@shape | where: "1 == 1"}, opts)
-
-    #   assert :started = ShapeCache.await_snapshot_start(new_shape_handle, opts)
-
-    #   assert_receive {:DOWN, ^consumer_ref, :process, _pid, {:shutdown, :cleanup}}
-
-    #   assert :ok = await_for_storage_to_raise(storage)
-
-    #   {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-    #   assert shape_handle != shape_handle2
-    #   assert :started = ShapeCache.await_snapshot_start(shape_handle2, opts)
-    # end
-
     test "shape gets cleaned up if terminated unexpectedly", %{storage: storage} = ctx do
       %{shape_cache_opts: opts} =
         with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),


### PR DESCRIPTION
Turbo.ai have been seeing 2-8s latency on requests when the number of shapes exceeds the maximum number of shapes and LRU expiry kicks in. This is due to the shape cache process being blocked while the expiry happens, which can take a few seconds.

This PR moves expiry out of the ShapeCache process and into a new ExpiryManager process. When a new shape is added, the ShapeCache calls `ExpiryManager.notify_new_shape_added/1` which is non-blocking and debounced, and if max_shapes has been set, triggers finding the LRU shapes and expiring them. 