### PR TITLE
fix: Use legacy bitnami image

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -42,7 +42,7 @@ jobs:
           - 54321:5432
 
       pgbouncer:
-        image: bitnami/pgbouncer:latest
+        image: bitnamilegacy/pgbouncer:latest
         env:
           PGBOUNCER_AUTH_TYPE: trust
           PGBOUNCER_DATABASE: "*"

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -85,7 +85,7 @@
       -e POSTGRESQL_USERNAME=postgres \
       -e POSTGRESQL_PASSWORD=password \
       -p $pg_pooler_host_port:6432 \
-      bitnami/pgbouncer:latest
+      bitnamilegacy/pgbouncer:latest
 
     ??LOG process up: PgBouncer
 [endmacro]

--- a/packages/sync-service/dev/docker-compose.yml
+++ b/packages/sync-service/dev/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - -c
       - config_file=/etc/postgresql.conf
   pgbouncer:
-    image: bitnami/pgbouncer:latest
+    image: bitnamilegacy/pgbouncer:latest
     environment:
       PGBOUNCER_AUTH_TYPE: trust
       PGBOUNCER_DATABASE: "*"


### PR DESCRIPTION
Bitnami deprecated their public image - we should switch to https://hub.docker.com/r/edoburu/pgbouncer/ eventually