### PR TITLE
feat: Simplify `PublicationManager` to not require full shape for removal

### DIFF
--- a/.changeset/calm-planes-whisper.md
+++ b/.changeset/calm-planes-whisper.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Simplify `PublicationManager` to not require a full shape to remove existing tracked shape.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -358,11 +358,11 @@ defmodule Electric.ShapeCache do
     :ok
   end
 
-  defp purge_shape(state, shape_handle, shape) do
+  defp purge_shape(state, shape_handle) do
     case ConsumerSupervisor.stop_and_clean(state.stack_id, shape_handle) do
       :noproc ->
         # if the consumer isn't running then we can just delete things gratuitously
-        :ok = Electric.Shapes.Monitor.purge_shape(state.stack_id, shape_handle, shape)
+        :ok = Electric.Shapes.Monitor.purge_shape(state.stack_id, shape_handle)
 
       :ok ->
         # if it is running then the stop_and_clean process will cleanup properly
@@ -406,7 +406,7 @@ defmodule Electric.ShapeCache do
             "shape #{inspect(shape)} (#{inspect(shape_handle)}) failed to start within #{timeout}ms"
           )
 
-          purge_shape(state, shape_handle, shape)
+          purge_shape(state, shape_handle)
 
           []
       end)
@@ -442,7 +442,7 @@ defmodule Electric.ShapeCache do
       )
 
       # clean up corrupted data to avoid persisting bad state
-      purge_shape(state, shape_handle, shape)
+      purge_shape(state, shape_handle)
       []
   end
 
@@ -510,7 +510,7 @@ defmodule Electric.ShapeCache do
       {:error, _reason} = error ->
         Logger.error("Failed to start shape #{shape_handle}: #{inspect(error)}")
         # purge because we know the consumer isn't running
-        purge_shape(state, shape_handle, shape)
+        purge_shape(state, shape_handle)
         :error
     end
   end

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -92,8 +92,7 @@ defmodule Electric.Shapes.Consumer do
         hibernate_timer: nil
       })
 
-    :ok =
-      Electric.Shapes.Monitor.register_writer(config.stack_id, config.shape_handle, config.shape)
+    :ok = Electric.Shapes.Monitor.register_writer(config.stack_id, config.shape_handle)
 
     {:ok, state, {:continue, :init_storage}}
   end

--- a/packages/sync-service/lib/electric/shapes/monitor.ex
+++ b/packages/sync-service/lib/electric/shapes/monitor.ex
@@ -41,7 +41,7 @@ defmodule Electric.Shapes.Monitor do
   Register the current process as a writer (consumer) of the given shape.
   """
   @spec register_writer(stack_id(), shape_handle(), pid()) :: :ok | {:error, term()}
-  defdelegate register_writer(stack_id, shape_handle, shape, pid \\ self()), to: RefCounter
+  defdelegate register_writer(stack_id, shape_handle, pid \\ self()), to: RefCounter
 
   @doc """
   The number of active readers of the given shape.
@@ -74,8 +74,8 @@ defmodule Electric.Shapes.Monitor do
   @doc """
   clean up the state of a non-running consumer.
   """
-  @spec purge_shape(stack_id(), shape_handle(), Electric.Shapes.Shape.t()) :: :ok
-  defdelegate purge_shape(stack_id, shape_handle, shape), to: RefCounter
+  @spec purge_shape(stack_id(), shape_handle()) :: :ok
+  defdelegate purge_shape(stack_id, shape_handle), to: RefCounter
 
   # used in tests to validate internal state
   @doc false

--- a/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
@@ -108,13 +108,13 @@ defmodule Electric.Shapes.Monitor.CleanupTaskSupervisor do
   defp cleanup_publication_manager(
          publication_manager_impl,
          shape_handle,
-         shape
+         _shape
        ) do
     {publication_manager, publication_manager_opts} = publication_manager_impl
 
     perform_reporting_errors(
       fn ->
-        publication_manager.remove_shape(shape_handle, shape, publication_manager_opts)
+        publication_manager.remove_shape(shape_handle, publication_manager_opts)
       end,
       "Failed to remove shape #{shape_handle} from publication"
     )

--- a/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
@@ -30,7 +30,6 @@ defmodule Electric.Shapes.Monitor.CleanupTaskSupervisor do
         publication_manager_impl,
         shape_status_impl,
         shape_handle,
-        shape,
         on_cleanup \\ fn _ -> :ok end
       ) do
     if consumer_alive?(stack_id, shape_handle) do
@@ -55,7 +54,7 @@ defmodule Electric.Shapes.Monitor.CleanupTaskSupervisor do
           task3 =
             Task.Supervisor.async(name(stack_id), fn ->
               Logger.metadata(stack_id: stack_id, shape_handle: shape_handle)
-              cleanup_publication_manager(publication_manager_impl, shape_handle, shape)
+              cleanup_publication_manager(publication_manager_impl, shape_handle)
             end)
 
           try do
@@ -105,11 +104,7 @@ defmodule Electric.Shapes.Monitor.CleanupTaskSupervisor do
     )
   end
 
-  defp cleanup_publication_manager(
-         publication_manager_impl,
-         shape_handle,
-         _shape
-       ) do
+  defp cleanup_publication_manager(publication_manager_impl, shape_handle) do
     {publication_manager, publication_manager_opts} = publication_manager_impl
 
     perform_reporting_errors(

--- a/packages/sync-service/test/electric/replication/publication_manager_db_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_db_test.exs
@@ -66,10 +66,10 @@ defmodule Electric.Replication.PublicationManagerDbTest do
       assert :ok == PublicationManager.add_shape(@shape_handle_2, shape_2, ctx.pub_mgr_opts)
       assert [ctx.relation] == fetch_pub_tables(ctx)
 
-      assert :ok == PublicationManager.remove_shape(@shape_handle_2, shape_2, ctx.pub_mgr_opts)
+      assert :ok == PublicationManager.remove_shape(@shape_handle_2, ctx.pub_mgr_opts)
       assert [ctx.relation] == fetch_pub_tables(ctx)
 
-      assert :ok == PublicationManager.remove_shape(@shape_handle_1, shape_1, ctx.pub_mgr_opts)
+      assert :ok == PublicationManager.remove_shape(@shape_handle_1, ctx.pub_mgr_opts)
       assert [] == fetch_pub_tables(ctx)
     end
   end

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -113,7 +113,7 @@ defmodule Electric.Replication.PublicationManagerTest do
       shape = generate_shape({"public", "items"})
       assert :ok == PublicationManager.add_shape(@shape_handle_1, shape, opts)
       assert_receive {:filters, [{_, {"public", "items"}}]}
-      assert :ok == PublicationManager.remove_shape(@shape_handle_1, shape, opts)
+      assert :ok == PublicationManager.remove_shape(@shape_handle_1, opts)
       assert_receive {:filters, []}
     end
 
@@ -122,8 +122,8 @@ defmodule Electric.Replication.PublicationManagerTest do
       shape = generate_shape({"public", "items"})
       task1 = Task.async(fn -> PublicationManager.add_shape(@shape_handle_1, shape, opts) end)
       task2 = Task.async(fn -> PublicationManager.add_shape(@shape_handle_2, shape, opts) end)
-      task3 = Task.async(fn -> PublicationManager.remove_shape(@shape_handle_1, shape, opts) end)
-      task4 = Task.async(fn -> PublicationManager.remove_shape(@shape_handle_1, shape, opts) end)
+      task3 = Task.async(fn -> PublicationManager.remove_shape(@shape_handle_1, opts) end)
+      task4 = Task.async(fn -> PublicationManager.remove_shape(@shape_handle_1, opts) end)
 
       Task.await_many([task1, task2, task3, task4])
 
@@ -143,7 +143,7 @@ defmodule Electric.Replication.PublicationManagerTest do
       assert_receive {:filters, [{_, {"public", "items"}}]}
 
       # Remove one handle; relation should stay
-      assert :ok == PublicationManager.remove_shape(@shape_handle_1, shape1, opts)
+      assert :ok == PublicationManager.remove_shape(@shape_handle_1, opts)
       refute_receive {:filters, _}, 500
     end
   end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1097,7 +1097,7 @@ defmodule Electric.ShapeCacheTest do
       :started = ShapeCache.await_snapshot_start(shape_handle1, opts)
 
       Mock.PublicationManager
-      |> stub(:remove_shape, fn ^shape_handle1, _, _ -> :ok end)
+      |> stub(:remove_shape, fn ^shape_handle1, _ -> :ok end)
       |> expect(:recover_shape, 1, fn ^shape_handle1, _, _ -> :ok end)
       |> expect(:refresh_publication, 1, fn _ -> raise "failed recovery" end)
       |> allow(self(), fn -> Shapes.Consumer.whereis(context[:stack_id], shape_handle1) end)

--- a/packages/sync-service/test/electric/shapes/monitor_test.exs
+++ b/packages/sync-service/test/electric/shapes/monitor_test.exs
@@ -197,7 +197,7 @@ defmodule Electric.Shapes.MonitorTest do
 
       @impl GenServer
       def init({stack_id, handle, parent}) do
-        :ok = Monitor.register_writer(stack_id, handle, Electric.Shapes.MonitorTest.shape())
+        :ok = Monitor.register_writer(stack_id, handle)
         send(parent, {:ready, :consumer, 1})
         {:ok, {stack_id, handle, parent}}
       end

--- a/packages/sync-service/test/electric/shapes/monitor_test.exs
+++ b/packages/sync-service/test/electric/shapes/monitor_test.exs
@@ -316,8 +316,7 @@ defmodule Electric.Shapes.MonitorTest do
 
       assert_receive {:on_cleanup, ^handle}
 
-      assert_receive {Support.ComponentSetup.TestPublicationManager, :remove_shape, ^handle,
-                      @shape}
+      assert_receive {Support.ComponentSetup.TestPublicationManager, :remove_shape, ^handle}
 
       assert_receive {TestStatus, :remove_shape, ^handle}
     end
@@ -329,8 +328,7 @@ defmodule Electric.Shapes.MonitorTest do
 
       assert_receive {:on_cleanup, ^handle}
 
-      assert_receive {Support.ComponentSetup.TestPublicationManager, :remove_shape, ^handle,
-                      @shape}
+      assert_receive {Support.ComponentSetup.TestPublicationManager, :remove_shape, ^handle}
 
       assert_receive {TestStatus, :remove_shape, ^handle}
     end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -15,7 +15,7 @@ defmodule Support.ComponentSetup do
     def name(_), do: :pub_man
     def add_shape(_handle, _shape, _opts), do: :ok
     def recover_shape(_handle, _shape, _opts), do: :ok
-    def remove_shape(_handle, _shape, _opts), do: :ok
+    def remove_shape(_handle, _opts), do: :ok
     def refresh_publication(_opts), do: :ok
   end
 
@@ -38,8 +38,8 @@ defmodule Support.ComponentSetup do
       :ok
     end
 
-    def remove_shape(handle, shape, %{parent: parent}) do
-      send(parent, {TestPublicationManager, :remove_shape, handle, shape})
+    def remove_shape(handle, %{parent: parent}) do
+      send(parent, {TestPublicationManager, :remove_shape, handle})
       :ok
     end
 


### PR DESCRIPTION
Now that we have simplified the publication manager, it lends itself to easier cleanups without needing the full shape.

This is part of the work of simplifying, unifying, and speeding up cleanups.

By making `remove_shape` only require the shape handle it simplifies the required information for cleaning up shapes - we only need the handle.