### PR TITLE
Extract shape's last_read timestamp into a separate ETS table

### DIFF
--- a/.changeset/khaki-zebras-lay.md
+++ b/.changeset/khaki-zebras-lay.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Spead up shape counting and LRU shape expiration by storing last access timestamps in a separate ETS table.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -142,7 +142,7 @@ defmodule Electric.ShapeCache do
   @impl Electric.ShapeCacheBehaviour
   @spec count_shapes(Access.t()) :: non_neg_integer() | :error
   def count_shapes(opts) do
-    table = ShapeStatus.shape_meta_table(opts)
+    table = ShapeStatus.shape_last_used_table(opts)
     shape_status = Access.get(opts, :shape_status, ShapeStatus)
 
     shape_status.count_shapes(table)

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -29,7 +29,6 @@ defmodule Electric.ShapeCache do
   alias Electric.Postgres.Lsn
   alias Electric.Replication.LogOffset
   alias Electric.Replication.ShapeLogCollector
-  alias Electric.ShapeCache.ExpiryManager
   alias Electric.ShapeCache.ShapeStatus
   alias Electric.Shapes
   alias Electric.Shapes.ConsumerSupervisor
@@ -477,8 +476,6 @@ defmodule Electric.ShapeCache do
       Logger.info("Creating new shape for #{inspect(shape)} with handle #{shape_handle}")
 
       :ok = start_shape(shape_handle, shape, state, otel_ctx)
-
-      ExpiryManager.notify_new_shape_added(state.stack_id)
 
       # In this branch of `if`, we're guaranteed to have a newly started shape, so we can be sure about it's
       # "latest offset" because it'll be in the snapshotting stage

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -10,7 +10,7 @@ defmodule Electric.ShapeCache.ExpiryManager do
   @schema NimbleOptions.new!(
             max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil],
             expiry_batch_size: [type: :pos_integer],
-            period: [type: :non_neg_integer, default: 1_000],
+            period: [type: :non_neg_integer, default: 60_000],
             stack_id: [type: :string, required: true],
             shape_status: [type: :mod_arg, required: true],
             consumer_supervisor: [type: @genserver_name_schema, required: true]

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -98,24 +98,14 @@ defmodule Electric.ShapeCache.ExpiryManager do
         shape_handle: shape.shape_handle,
         elapsed_minutes_since_use: shape.elapsed_minutes_since_use
       ],
-      fn -> clean_up_shape(state, shape.shape_handle) end
-    )
-  end
-
-  defp clean_up_shape(state, shape_handle) do
-    OpenTelemetry.with_span(
-      "expiry_manager.stop_shape_consumer",
-      [shape_handle: shape_handle],
       fn ->
         Electric.Shapes.DynamicConsumerSupervisor.stop_shape_consumer(
           state.consumer_supervisor,
           state.stack_id,
-          shape_handle
+          shape.shape_handle
         )
       end
     )
-
-    :ok
   end
 
   defp least_recently_used(%{shape_status: {shape_status, shape_status_state}}, number_to_expire) do

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -10,17 +10,11 @@ defmodule Electric.ShapeCache.ExpiryManager do
   @schema NimbleOptions.new!(
             max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil],
             expiry_batch_size: [type: :pos_integer],
-            recheck_delay_ms: [type: :non_neg_integer, default: 1_000],
+            period: [type: :non_neg_integer, default: 1_000],
             stack_id: [type: :string, required: true],
             shape_status: [type: :mod_arg, required: true],
             consumer_supervisor: [type: @genserver_name_schema, required: true]
           )
-
-  # Debounce time set to 0 meaning that it will debouce while processing but no longer.
-  # It's best to keep this to 0 because if shapes are consistently being added in less
-  # than the @bebounce_time, the @debounce_finished will never fire.
-  @debounce_time 0
-  @debounce_finished :timeout
 
   def name(stack_id) when not is_map(stack_id) and not is_list(stack_id) do
     Electric.ProcessRegistry.name(stack_id, __MODULE__)
@@ -29,10 +23,6 @@ defmodule Electric.ShapeCache.ExpiryManager do
   def name(opts) do
     stack_id = Access.fetch!(opts, :stack_id)
     name(stack_id)
-  end
-
-  def notify_new_shape_added(stack_id) do
-    GenServer.cast(name(stack_id), :notify_new_shape_added)
   end
 
   def start_link(opts) do
@@ -47,53 +37,59 @@ defmodule Electric.ShapeCache.ExpiryManager do
     Logger.metadata(stack_id: stack_id)
     Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
 
-    {:ok,
-     %{
-       stack_id: stack_id,
-       max_shapes: Keyword.fetch!(opts, :max_shapes),
-       expiry_batch_size: Keyword.fetch!(opts, :expiry_batch_size),
-       recheck_delay_ms: Keyword.fetch!(opts, :recheck_delay_ms),
-       shape_status: Keyword.fetch!(opts, :shape_status),
-       consumer_supervisor: Keyword.fetch!(opts, :consumer_supervisor)
-     }}
+    state =
+      %{
+        stack_id: stack_id,
+        max_shapes: Keyword.fetch!(opts, :max_shapes),
+        expiry_batch_size: Keyword.fetch!(opts, :expiry_batch_size),
+        period: Keyword.fetch!(opts, :period),
+        shape_status: Keyword.fetch!(opts, :shape_status),
+        consumer_supervisor: Keyword.fetch!(opts, :consumer_supervisor)
+      }
+
+    if not is_nil(state.max_shapes), do: schedule_next_check(state)
+
+    {:ok, state}
   end
 
-  def handle_cast(:notify_new_shape_added, state) do
-    {:noreply, state, @debounce_time}
+  defp schedule_next_check(state) do
+    Process.send_after(self(), :maybe_expire_shapes, state.period)
   end
 
-  def handle_info(@debounce_finished, state) do
+  def handle_info(:maybe_expire_shapes, state) do
     maybe_expire_shapes(state)
+    schedule_next_check(state)
     {:noreply, state}
   end
 
-  defp maybe_expire_shapes(%{max_shapes: max_shapes} = state) when max_shapes != nil do
+  defp maybe_expire_shapes(%{max_shapes: nil}), do: :ok
+
+  defp maybe_expire_shapes(%{max_shapes: max_shapes} = state) do
     shape_count = shape_count(state)
 
     if shape_count > max_shapes do
-      shapes_to_expire = least_recently_used(state, state.expiry_batch_size)
-
-      Logger.info(
-        "Expiring #{length(shapes_to_expire)} shapes as the number of shapes " <>
-          "has exceeded the limit (#{state.max_shapes})"
-      )
-
-      OpenTelemetry.with_span(
-        "expiry_manager.expire_shapes",
-        [
-          max_shapes: max_shapes,
-          shape_count: shape_count,
-          number_to_expire: state.expiry_batch_size
-        ],
-        fn -> Enum.each(shapes_to_expire, &expire_shape(&1, state)) end
-      )
-    else
-      # We're under the max number of shapes, don't recheck again for at least recheck_delay_ms
-      Process.sleep(state.recheck_delay_ms)
+      expire_shapes(shape_count, state)
     end
   end
 
-  defp maybe_expire_shapes(_), do: :ok
+  defp expire_shapes(shape_count, state) do
+    shapes_to_expire = least_recently_used(state, state.expiry_batch_size)
+
+    Logger.info(
+      "Expiring #{length(shapes_to_expire)} shapes as the number of shapes " <>
+        "has exceeded the limit (#{state.max_shapes})"
+    )
+
+    OpenTelemetry.with_span(
+      "expiry_manager.expire_shapes",
+      [
+        max_shapes: state.max_shapes,
+        shape_count: shape_count,
+        number_to_expire: state.expiry_batch_size
+      ],
+      fn -> Enum.each(shapes_to_expire, &expire_shape(&1, state)) end
+    )
+  end
 
   defp expire_shape(shape, state) do
     OpenTelemetry.with_span(

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -297,6 +297,7 @@ defmodule Electric.StackSupervisor do
       {ShapeStatus,
        ShapeStatus.opts(
          shape_meta_table: ShapeStatus.shape_meta_table(stack_id),
+         shape_last_used_table: ShapeStatus.shape_last_used_table(stack_id),
          storage: storage
        )}
 

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -51,7 +51,9 @@ defmodule Electric.Connection.ConnectionManagerTest do
              {Electric.ShapeCache.ShapeStatus,
               Electric.ShapeCache.ShapeStatus.opts(
                 storage: ctx.storage,
-                shape_meta_table: Electric.ShapeCache.ShapeStatus.shape_meta_table(stack_id)
+                shape_meta_table: Electric.ShapeCache.ShapeStatus.shape_meta_table(stack_id),
+                shape_last_used_table:
+                  Electric.ShapeCache.ShapeStatus.shape_last_used_table(stack_id)
               )},
            log_producer: Electric.Replication.ShapeLogCollector.name(stack_id),
            consumer_supervisor: Electric.Shapes.DynamicConsumerSupervisor.name(stack_id),

--- a/packages/sync-service/test/electric/shape_cache/expiry_manager_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/expiry_manager_test.exs
@@ -76,7 +76,7 @@ defmodule Electric.ExpiryManagerTest do
       {ExpiryManager,
        max_shapes: 1,
        expiry_batch_size: 1,
-       recheck_delay_ms: 1,
+       period: 10,
        stack_id: ctx.stack_id,
        shape_status: ctx.shape_status,
        consumer_supervisor: consumer_supervisor}

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -150,6 +150,8 @@ defmodule Support.ComponentSetup do
     shape_status_opts =
       Electric.ShapeCache.ShapeStatus.opts(
         shape_meta_table: Electric.ShapeCache.ShapeStatus.shape_meta_table(ctx.stack_id),
+        shape_last_used_table:
+          Electric.ShapeCache.ShapeStatus.shape_last_used_table(ctx.stack_id),
         storage: Map.get(ctx, :storage, {Mock.Storage, []})
       )
 


### PR DESCRIPTION
Listing least recently used shape handles becomes more efficient.

Counting shapes becomes an O(1) operation.

The the shape counting operation being cheap now, we can remove the complexity of spamming ExpiryManager's inbox and debouncing expiry checks.

If the tenant is in a steady state where it doesn't see any new shape creations, the cost of the periodic check is a call to `:ets.info(..., :size)`. On the other end of the spectrum, if the tenant is constantly churning through new shapes, sending a message for each shape to ExpiryManager is pure overhead.

The current debouncing implementation violates OTP's conventions by using Process.sleep() inside a GenServer callback. This results in the ExpiryManager process accumulating messages in its inbox which immediately stands out among other processes in the Observer or observer_cli. A periodic check is simpler and is less taxing on the VM.