### PR TITLE
feat: allow snapshot-less shapes & subset snapshots

### DIFF
--- a/.changeset/tame-moles-explain.md
+++ b/.changeset/tame-moles-explain.md
@@ -1,0 +1,10 @@
+---
+"@electric-sql/client": patch
+"@core/sync-service": patch
+---
+
+feat: add support for `changes_only` mode, subset snapshots, and `offset=now`
+
+- `changes_only` - in this mode the server will not create initial snapshot for the shape, the clients will start receiving changes without seeing base data. Best paired with...
+- Subset snapshots - the server now accepts a `subset__*` set of parameters, which when provided result in a special-form response containing a snapshot of a subset (may be full) of a shape, and information on how to position this response in the stream. The client exposes a new method `requestSnapshot` which will make this request and then inject the response into the correct place in the subscribed messages stream, bounded with a `snapshot-end` control message.
+- `offset=now` - the server now accepts a `offset=now` special value, in which case the client will receive an immediate up-to-date response with the latest possible continuation offset, allowing it to skip all historical data and start "from scratch". This works best with `changes_only` and subset snapshots where a client doesn't keep state and upon a reload needs to start fresh without historical data.

--- a/integration-tests/tests/manual-table-publishing.lux
+++ b/integration-tests/tests/manual-table-publishing.lux
@@ -84,7 +84,7 @@
   ??electric-schema: {"val":{"type":"text"}}
   ??electric-offset: 0_0
 
-  ??[{"key":"\"public\".\"items\"/\"hello\"","value":{"val":"hello"},"headers":{"operation":"insert","relation":["public","items"]}},{"headers":{"control":"snapshot-end"
+  ??[{"key":"\"public\".\"items\"/\"hello\"","value":{"val":"hello"},"headers":{"relation":["public","items"],"operation":"insert"}},{"headers":{"control":"snapshot-end"
 
 ## Wait for the schema reconciler to run and verify that the table is NOT removed from the publication
 [shell psql]

--- a/integration-tests/tests/not-owner-of-the-publication.lux
+++ b/integration-tests/tests/not-owner-of-the-publication.lux
@@ -120,7 +120,7 @@
   ??electric-schema: {"val":{"type":"text"}}
   ??electric-offset: 0_0
 
-  ??[{"key":"\"public\".\"items\"/\"hello\"","value":{"val":"hello"},"headers":{"operation":"insert","relation":["public","items"]}},{"headers":{"control":"snapshot-end"
+  ??[{"key":"\"public\".\"items\"/\"hello\"","value":{"val":"hello"},"headers":{"relation":["public","items"],"operation":"insert"}},{"headers":{"control":"snapshot-end"
 
 [cleanup]
   [invoke teardown]

--- a/packages/sync-service/lib/electric/replication/eval/walker.ex
+++ b/packages/sync-service/lib/electric/replication/eval/walker.ex
@@ -231,6 +231,10 @@ defimpl Electric.Walkable, for: PgQuery.RowExpr do
   def children(%PgQuery.RowExpr{args: args}), do: [args: args]
 end
 
+defimpl Electric.Walkable, for: PgQuery.SortBy do
+  def children(%PgQuery.SortBy{node: node, use_op: use_op}), do: [use_op: use_op, node: node]
+end
+
 defimpl Electric.Walkable, for: Electric.Replication.Eval.Parser.Func do
   def children(%Electric.Replication.Eval.Parser.Func{args: args}), do: [args: args]
 end

--- a/packages/sync-service/lib/electric/replication/log_offset.ex
+++ b/packages/sync-service/lib/electric/replication/log_offset.ex
@@ -272,6 +272,9 @@ defmodule Electric.Replication.LogOffset do
       iex> from_string("-1")
       {:ok, before_all()}
 
+      iex> from_string("now")
+      {:ok, :now}
+
       iex> from_string("0_0")
       {:ok, %LogOffset{tx_offset: 0, op_offset: 0}}
 
@@ -296,19 +299,24 @@ defmodule Electric.Replication.LogOffset do
       iex> from_string("10_32.1")
       {:error, "has invalid format"}
   """
-  @spec from_string(String.t()) :: {:ok, t} | {:error, String.t()}
+  @spec from_string(String.t()) :: {:ok, t | :now} | {:error, String.t()}
   def from_string(str) when is_binary(str) do
-    if str == "-1" do
-      {:ok, before_all()}
-    else
-      with [tx_offset_str, op_offset_str] <- String.split(str, "_"),
-           {tx_offset, ""} <- Integer.parse(tx_offset_str),
-           {op_offset, ""} <- parse_int_or_inf(op_offset_str),
-           offset <- new(tx_offset, op_offset) do
-        {:ok, offset}
-      else
-        _ -> {:error, "has invalid format"}
-      end
+    cond do
+      str == "-1" ->
+        {:ok, before_all()}
+
+      str == "now" ->
+        {:ok, :now}
+
+      true ->
+        with [tx_offset_str, op_offset_str] <- String.split(str, "_"),
+             {tx_offset, ""} <- Integer.parse(tx_offset_str),
+             {op_offset, ""} <- parse_int_or_inf(op_offset_str),
+             offset <- new(tx_offset, op_offset) do
+          {:ok, offset}
+        else
+          _ -> {:error, "has invalid format"}
+        end
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -37,6 +37,12 @@ defmodule Electric.Shapes do
     shape_cache.get_shape(shape_def, opts)
   end
 
+  @spec get_shape_by_handle(Access.t(), shape_handle()) :: Shape.t() | nil
+  def get_shape_by_handle(config, shape_handle) do
+    {shape_cache, opts} = Access.get(config, :shape_cache, {ShapeCache, []})
+    shape_cache.get_shape_by_handle(shape_handle, opts)
+  end
+
   @doc """
   Get or create a shape handle and return it along with the latest offset of the shape
   """
@@ -96,5 +102,9 @@ defmodule Electric.Shapes do
 
   defp shape_storage(config, shape_handle) do
     Storage.for_shape(shape_handle, Access.fetch!(config, :storage))
+  end
+
+  def query_subset(shape, subset, opts) do
+    Electric.Shapes.PartialModes.query_subset(shape, subset, opts)
   end
 end

--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -40,6 +40,63 @@ defmodule Electric.Shapes.Api.Params do
     end
   end
 
+  defmodule SubsetParams do
+    use Ecto.Schema
+    alias Electric.Shapes.Shape
+
+    embedded_schema do
+      field(:order_by, :string)
+      field(:limit, :integer)
+      field(:offset, :integer)
+      field(:where, :string)
+      field(:params, {:map, :string}, default: %{})
+
+      field(:result, :any, virtual: true)
+    end
+
+    def changeset(struct, params, shape_definition, api) do
+      struct
+      |> cast(params, __schema__(:fields) -- [:result])
+      |> validate_number(:limit, greater_than: 0)
+      |> validate_number(:offset, greater_than_or_equal_to: 0)
+      |> validate_ordered_when_limited()
+      |> cast_subset(shape_definition, api)
+    end
+
+    defp cast_subset(%Ecto.Changeset{valid?: false} = changeset, _shape_definition, _api),
+      do: changeset
+
+    defp cast_subset(changeset, shape_definition, api) do
+      case Shape.Subset.new(shape_definition, changeset.changes, api) do
+        {:ok, subset} ->
+          put_change(changeset, :result, subset)
+
+        {:error, {field, reason}} ->
+          add_error(changeset, field, reason)
+      end
+    end
+
+    defp validate_ordered_when_limited(changeset) do
+      if changed?(changeset, :limit) or changed?(changeset, :offset) do
+        validate_required(changeset, [:order_by],
+          message: "order_by is required when limit or offset is present"
+        )
+      else
+        changeset
+      end
+    end
+
+    def extract_result({:ok, data}, from: key) do
+      {:ok,
+       Map.update!(data, key, fn
+         nil -> nil
+         %{result: result} -> result
+       end)}
+    end
+
+    def extract_result(data, _), do: data
+  end
+
   embedded_schema do
     field(:table, :string)
     field(:offset, :string)
@@ -52,6 +109,9 @@ defmodule Electric.Shapes.Api.Params do
     field(:params, {:map, :string}, default: %{})
     field(@tmp_compaction_flag, :boolean, default: false)
     field(@tmp_sse_flag, :boolean, default: false)
+    field(:log, Ecto.Enum, values: [:changes_only, :full], default: :full)
+
+    embeds_one(:subset, SubsetParams)
   end
 
   @type t() :: %__MODULE__{}
@@ -65,7 +125,9 @@ defmodule Electric.Shapes.Api.Params do
     |> validate_live_with_offset()
     |> validate_live_sse()
     |> cast_root_table(api)
+    |> cast_subset(api)
     |> apply_action(:validate)
+    |> SubsetParams.extract_result(from: :subset)
     |> convert_error(api)
   end
 
@@ -98,7 +160,7 @@ defmodule Electric.Shapes.Api.Params do
 
   defp cast_params(params) do
     %__MODULE__{}
-    |> cast(params, __schema__(:fields) -- [:shape_definition])
+    |> cast(params, __schema__(:fields) -- [:shape_definition, :subset])
   end
 
   defp convert_error({:ok, params}, _api), do: {:ok, params}
@@ -205,7 +267,8 @@ defmodule Electric.Shapes.Api.Params do
            replica: replica,
            inspector: api.inspector,
            feature_flags: api.feature_flags,
-           storage: %{compaction: if(compaction_enabled?, do: :enabled, else: :disabled)}
+           storage: %{compaction: if(compaction_enabled?, do: :enabled, else: :disabled)},
+           log_mode: fetch_field!(changeset, :log)
          ) do
       {:ok, shape} ->
         put_change(changeset, :shape_definition, shape)
@@ -229,5 +292,20 @@ defmodule Electric.Shapes.Api.Params do
       {:error, %NimbleOptions.ValidationError{message: message, key: key}} ->
         add_error(changeset, key, message)
     end
+  end
+
+  defp cast_subset(%Ecto.Changeset{valid?: false} = changeset, _api), do: changeset
+
+  defp cast_subset(%Ecto.Changeset{} = changeset, api) do
+    cast_embed(changeset, :subset,
+      with:
+        &SubsetParams.changeset(
+          &1,
+          &2,
+          Ecto.Changeset.fetch_change!(changeset, :shape_definition),
+          api
+        ),
+      required: false
+    )
   end
 end

--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -202,10 +202,12 @@ defmodule Electric.Shapes.Api.Params do
   def validate_handle_with_offset(%Ecto.Changeset{} = changeset) do
     offset = fetch_change!(changeset, :offset)
 
-    if offset == LogOffset.before_all() do
-      delete_change(changeset, :handle)
-    else
-      validate_required(changeset, [:handle], message: "can't be blank when offset != -1")
+    cond do
+      offset in [LogOffset.before_all(), :now] ->
+        delete_change(changeset, :handle)
+
+      true ->
+        validate_required(changeset, [:handle], message: "can't be blank when offset != -1")
     end
   end
 
@@ -214,10 +216,17 @@ defmodule Electric.Shapes.Api.Params do
   def validate_live_with_offset(%Ecto.Changeset{} = changeset) do
     offset = fetch_change!(changeset, :offset)
 
-    if offset != LogOffset.before_all() do
-      changeset
-    else
-      validate_exclusion(changeset, :live, [true], message: "can't be true when offset == -1")
+    cond do
+      offset == LogOffset.before_all() ->
+        validate_exclusion(changeset, :live, [true], message: "can't be true when offset == -1")
+
+      offset == :now ->
+        validate_exclusion(changeset, :live, [true],
+          message: "can't be true when offset is 'now'"
+        )
+
+      true ->
+        changeset
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/partial_modes.ex
+++ b/packages/sync-service/lib/electric/shapes/partial_modes.ex
@@ -1,0 +1,30 @@
+defmodule Electric.Shapes.PartialModes do
+  alias Electric.Postgres.Lsn
+  alias Electric.Shapes.Querying
+  alias Electric.Connection.Manager
+
+  def query_subset(shape, subset, opts) do
+    pool = Manager.pool_name(opts[:stack_id], :snapshot)
+
+    Postgrex.transaction(pool, fn conn ->
+      Postgrex.query!(conn, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+
+      %{rows: [[{xmin, xmax, xip_list}, lsn]]} =
+        Postgrex.query!(conn, "SELECT pg_current_snapshot(), pg_current_wal_lsn()")
+
+      mark = Enum.random(1..(2 ** 31))
+
+      metadata = %{
+        xmin: xmin,
+        xmax: xmax,
+        xip_list: xip_list,
+        snapshot_mark: mark,
+        database_lsn: to_string(Lsn.to_integer(lsn))
+      }
+
+      # TODO: This is required for now to avoid abstraction leaks - we can't send this as a chunk response
+      #       after closing the transaction, so we can't return a stream here, we'd need to pass in the reducer.
+      {metadata, Querying.query_subset(conn, shape, subset, mark) |> Enum.to_list()}
+    end)
+  end
+end

--- a/packages/sync-service/lib/electric/shapes/shape/subset.ex
+++ b/packages/sync-service/lib/electric/shapes/shape/subset.ex
@@ -1,0 +1,85 @@
+defmodule Electric.Shapes.Shape.Subset do
+  alias Electric.Postgres.Inspector
+  alias Electric.Replication.Eval.Parser
+  alias Electric.Shapes.Shape.Validators
+
+  defstruct [
+    :order_by,
+    :limit,
+    :offset,
+    :where
+  ]
+
+  @schema_options [
+                    order_by: [type: :string],
+                    limit: [type: :pos_integer],
+                    offset: [type: :non_neg_integer],
+                    where: [type: :string],
+                    params: [type: {:map, :string, :string}, default: %{}]
+                  ]
+                  |> NimbleOptions.new!()
+
+  def new(shape, fields, opts) do
+    inspector = Access.fetch!(opts, :inspector)
+
+    with {:ok, fields} <- NimbleOptions.validate(Map.new(fields), @schema_options),
+         {:ok, columns} <- load_column_info(shape, inspector),
+         :ok <- validate_order_by(fields[:order_by], columns),
+         refs = Inspector.columns_to_expr(columns),
+         {:ok, where} <- validate_where_clause(fields[:where], fields[:params], refs) do
+      {:ok,
+       %__MODULE__{
+         order_by: fields[:order_by],
+         limit: fields[:limit],
+         offset: fields[:offset],
+         where: where
+       }}
+    else
+      {:error, %NimbleOptions.ValidationError{message: reason, key: key}} ->
+        {:error, {key, reason}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp load_column_info(%{root_table_id: table_oid, root_table: table}, inspector) do
+    case Inspector.load_column_info(table_oid, inspector) do
+      :table_not_found ->
+        {:error,
+         {:order_by,
+          "Table #{Electric.Utils.inspect_relation(table)} does not exist. " <>
+            "If the table name contains capitals or special characters you must quote it."}}
+
+      {:ok, columns} ->
+        {:ok, columns}
+    end
+  end
+
+  defp validate_order_by(nil, _columns), do: :ok
+
+  defp validate_order_by(order_by, columns) do
+    case Parser.validate_order_by(order_by, columns) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:order_by, reason}}
+    end
+  end
+
+  defp validate_where_clause(nil, _params, _refs), do: {:ok, nil}
+
+  defp validate_where_clause(where, params, refs) do
+    with {:ok, where} <- Parser.parse_query(where),
+         {:ok, subqueries} <- Parser.extract_subqueries(where),
+         :ok <- assert_no_subqueries(subqueries),
+         :ok <- Validators.validate_parameters(params),
+         {:ok, where} <- Parser.validate_where_ast(where, params: params, refs: refs),
+         {:ok, where} <- Validators.validate_where_return_type(where) do
+      {:ok, where}
+    else
+      {:error, reason} -> {:error, {:where, reason}}
+    end
+  end
+
+  defp assert_no_subqueries([]), do: :ok
+  defp assert_no_subqueries(_), do: {:error, "Subqueries are not allowed in subsets"}
+end

--- a/packages/sync-service/lib/electric/shapes/shape/validators.ex
+++ b/packages/sync-service/lib/electric/shapes/shape/validators.ex
@@ -1,0 +1,35 @@
+defmodule Electric.Shapes.Shape.Validators do
+  def validate_parameters(params) when is_map(params) do
+    with {:ok, keys} <- all_keys_are_numbers(params),
+         :ok <- all_keys_are_sequential(keys) do
+      :ok
+    end
+  end
+
+  def validate_parameters(_), do: :ok
+
+  defp all_keys_are_numbers(params) do
+    Electric.Utils.map_while_ok(params, fn {key, _} ->
+      case Integer.parse(key) do
+        {int, ""} -> {:ok, int}
+        _ -> {:error, {:params, "Parameters can only use numbers as keys"}}
+      end
+    end)
+  end
+
+  defp all_keys_are_sequential(keys) do
+    Enum.with_index(keys, fn key, index -> key == index + 1 end)
+    |> Enum.all?()
+    |> if(
+      do: :ok,
+      else: {:error, {:params, "Parameters must be numbered sequentially, starting from 1"}}
+    )
+  end
+
+  def validate_where_return_type(where) do
+    case where.returns do
+      :bool -> {:ok, where}
+      _ -> {:error, {:where, "WHERE clause must return a boolean"}}
+    end
+  end
+end

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -748,4 +748,30 @@ defmodule Electric.Utils do
       Keyword.merge(merged, k)
     end)
   end
+
+  @doc """
+  Extract keys from a map that start with a given prefix into a nested map.
+
+  ## Examples
+
+      iex> extract_prefixed_keys_into_map(%{"foo_bar" => "baz", "foo_moo" => "qux", "other" => "value"}, "foo")
+      %{"foo" => %{"bar" => "baz", "moo" => "qux"}, "other" => "value"}
+
+      iex> extract_prefixed_keys_into_map(%{"other" => "value"}, "foo")
+      %{"other" => "value"}
+  """
+  @spec extract_prefixed_keys_into_map(map(), String.t(), String.t()) :: map()
+  def extract_prefixed_keys_into_map(map, prefix, joiner \\ "_") do
+    {prefixed, rest} =
+      Enum.split_with(map, fn {k, _} -> String.starts_with?(k, prefix <> joiner) end)
+
+    if prefixed == [] do
+      map
+    else
+      nested =
+        Map.new(prefixed, fn {k, v} -> {String.replace_prefix(k, prefix <> joiner, ""), v} end)
+
+      Map.new([{prefix, nested} | rest])
+    end
+  end
 end

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2361,6 +2361,123 @@ defmodule Electric.Plug.RouterTest do
     end
   end
 
+  describe "/v1/shapes - subset snapshots" do
+    setup [:with_unique_db, :with_basic_tables, :with_sql_execute]
+
+    setup :with_complete_stack
+
+    setup(ctx) do
+      :ok = Electric.StatusMonitor.wait_until_active(ctx.stack_id, 1000)
+      %{opts: Router.init(build_router_opts(ctx))}
+    end
+
+    @tag with_sql: [
+           "INSERT INTO items VALUES (gen_random_uuid(), 'test value 1')"
+         ]
+    test "GET with log=changes_only doesn't return any data initial but lets all updates through",
+         ctx do
+      req = make_shape_req("items", log: "changes_only")
+      assert {req, 200, []} = shape_req(req, ctx.opts)
+
+      task = live_shape_req(req, ctx.opts)
+
+      Postgrex.query!(ctx.db_conn, "UPDATE items SET value = 'test value 2'")
+
+      assert {_, 200, [%{"value" => %{"id" => _, "value" => "test value 2"}}, _]} =
+               Task.await(task)
+    end
+
+    @tag with_sql: [
+           "INSERT INTO items VALUES (gen_random_uuid(), 'test value 1')"
+         ]
+    test "GET with any parameter mentioning a subset returns a subset snapshot", ctx do
+      req = make_shape_req("items", log: "changes_only")
+
+      assert {_, 200,
+              %{
+                "metadata" => %{
+                  "xmin" => _,
+                  "xmax" => _,
+                  "xip_list" => _,
+                  "snapshot_mark" => mark,
+                  "database_lsn" => _
+                },
+                "data" => [
+                  %{
+                    "value" => %{"id" => _, "value" => "test value 1"},
+                    "headers" => %{"operation" => "insert", "snapshot_mark" => mark}
+                  }
+                ]
+              }} = shape_req(req, ctx.opts, subset: %{})
+    end
+
+    @tag with_sql: [
+           "INSERT INTO items VALUES (gen_random_uuid(), 'test value 1')",
+           "INSERT INTO items VALUES (gen_random_uuid(), 'test value 2')"
+         ]
+    test "subsets can be filtered", ctx do
+      req = make_shape_req("items", log: "changes_only")
+
+      assert {_, 200,
+              %{
+                "metadata" => _,
+                "data" => [
+                  %{
+                    "value" => %{"id" => _, "value" => "test value 2"}
+                  }
+                ]
+              }} =
+               shape_req(req, ctx.opts,
+                 subset: %{where: "value ILIKE $1", params: %{"1" => "%2"}}
+               )
+    end
+
+    @tag with_sql: [
+           "INSERT INTO items VALUES (gen_random_uuid(), 'test value 1')",
+           "INSERT INTO items VALUES (gen_random_uuid(), 'test value 2')"
+         ]
+    test "subsets can be sorted and limited", ctx do
+      req = make_shape_req("items", log: "changes_only")
+
+      assert {_, 400, %{"errors" => %{"subset" => %{"order_by" => _}}}} =
+               shape_req(req, ctx.opts, subset: %{limit: 1})
+
+      assert {_, 200,
+              %{
+                "metadata" => _,
+                "data" => [
+                  %{
+                    "value" => %{"id" => _, "value" => "test value 1"}
+                  }
+                ]
+              }} =
+               shape_req(req, ctx.opts, subset: %{limit: 1, order_by: "value ASC"})
+
+      assert {_, 200,
+              %{
+                "metadata" => _,
+                "data" => [
+                  %{
+                    "value" => %{"id" => _, "value" => "test value 2"}
+                  }
+                ]
+              }} =
+               shape_req(req, ctx.opts, subset: %{limit: 1, order_by: "value DESC"})
+    end
+
+    test "GET requests aren't cached", ctx do
+      req = make_shape_req("items", log: "changes_only", subset: %{}, offset: "-1")
+
+      result =
+        conn("GET", "/v1/shape", req)
+        |> Router.call(ctx.opts)
+
+      assert %{status: 200} = result
+
+      assert Plug.Conn.get_resp_header(result, "cache-control") == ["no-cache"]
+    end
+  end
+
   describe "404" do
     test "GET on invalid path returns 404", _ do
       conn =
@@ -2492,20 +2609,24 @@ defmodule Electric.Plug.RouterTest do
     |> Map.put(:table, table)
   end
 
-  defp shape_req(base, router_opts, opts \\ []) do
-    if Keyword.has_key?(opts, :offset), do: Map.put(base, :offset, opts[:offset]), else: base
-
+  defp shape_req(orig_base, router_opts, opts \\ []) do
     base =
-      base
+      orig_base
       |> Map.put_new(:offset, "-1")
       |> Map.put_new(:live, false)
+      |> Map.merge(Map.new(opts))
 
     result =
       conn("GET", "/v1/shape", base)
       |> Router.call(router_opts)
 
-    case result.status do
-      200 ->
+    case {result.status, Plug.Conn.get_resp_header(result, "electric-snapshot")} do
+      {200, ["true"]} ->
+        base
+        |> Map.put(:handle, get_resp_shape_handle(result))
+        |> then(&{&1, result.status, Jason.decode!(result.resp_body)})
+
+      {200, _} ->
         base
         |> Map.put(:handle, get_resp_shape_handle(result))
         |> Map.put(:offset, get_resp_last_offset(result))

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -391,7 +391,7 @@ defmodule Electric.Shapes.ApiTest do
                  }
                )
 
-      assert response = Api.serve_shape_log(request)
+      assert response = Api.serve_shape_response(request)
       assert response.status == 200
       assert response.handle == test_shape_handle
 
@@ -438,7 +438,7 @@ defmodule Electric.Shapes.ApiTest do
                  }
                )
 
-      assert response = Api.serve_shape_log(Plug.Test.conn(:get, "/"), request)
+      assert response = Api.serve_shape_response(Plug.Test.conn(:get, "/"), request)
       assert response.status == 200
 
       assert ["max-age=0, private, must-revalidate"] =
@@ -575,7 +575,7 @@ defmodule Electric.Shapes.ApiTest do
                  %{table: "public.users", offset: "-1"}
                )
 
-      assert response = Api.serve_shape_log(request)
+      assert response = Api.serve_shape_response(request)
 
       assert response.status == 200
       assert response.chunked
@@ -625,7 +625,7 @@ defmodule Electric.Shapes.ApiTest do
                  }
                )
 
-      assert response = Api.serve_shape_log(request)
+      assert response = Api.serve_shape_response(request)
       assert response.status == 200
       assert response.chunked
 
@@ -688,7 +688,7 @@ defmodule Electric.Shapes.ApiTest do
                      }
                    )
 
-          response = Api.serve_shape_log(request)
+          response = Api.serve_shape_response(request)
 
           {response, response_body(response)}
         end)
@@ -765,7 +765,7 @@ defmodule Electric.Shapes.ApiTest do
                      }
                    )
 
-          Api.serve_shape_log(request)
+          Api.serve_shape_response(request)
         end)
 
       assert_receive :got_log_stream, @receive_timeout
@@ -848,7 +848,7 @@ defmodule Electric.Shapes.ApiTest do
                  }
                )
 
-      assert response = Api.serve_shape_log(request)
+      assert response = Api.serve_shape_response(request)
       assert response.status == 200
 
       # Should see the last seen log entry at the start of the request
@@ -881,7 +881,7 @@ defmodule Electric.Shapes.ApiTest do
           }
         )
 
-      response = Api.serve_shape_log(request)
+      response = Api.serve_shape_response(request)
 
       assert response_body(response) == [
                %{
@@ -939,7 +939,7 @@ defmodule Electric.Shapes.ApiTest do
                      }
                    )
 
-          response = Api.serve_shape_log(request)
+          response = Api.serve_shape_response(request)
           {response, response_body(response)}
         end)
 
@@ -999,7 +999,7 @@ defmodule Electric.Shapes.ApiTest do
                  }
                )
 
-      assert response = Api.serve_shape_log(request)
+      assert response = Api.serve_shape_response(request)
 
       assert response.status == 200
 
@@ -1041,7 +1041,7 @@ defmodule Electric.Shapes.ApiTest do
                  }
                )
 
-      assert response = Api.serve_shape_log(request)
+      assert response = Api.serve_shape_response(request)
       assert response.status == 409
       assert [%{headers: %{control: "must-refetch"}}] = response_body(response)
     end
@@ -1073,7 +1073,7 @@ defmodule Electric.Shapes.ApiTest do
                  }
                )
 
-      assert response = Api.serve_shape_log(request)
+      assert response = Api.serve_shape_response(request)
 
       assert response.status == 200
       refute response.chunked
@@ -1114,7 +1114,7 @@ defmodule Electric.Shapes.ApiTest do
                    )
 
           set_status_to_errored(ctx, error_message)
-          Api.serve_shape_log(request)
+          Api.serve_shape_response(request)
         end)
 
       assert response = Task.await(task)

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -5,9 +5,11 @@ import {
   Row,
   MaybePromise,
   GetExtensions,
+  ChangeMessage,
+  SnapshotMetadata,
 } from './types'
 import { MessageParser, Parser, TransformFunction } from './parser'
-import { getOffset, isUpToDateMessage } from './helpers'
+import { getOffset, isUpToDateMessage, isChangeMessage } from './helpers'
 import {
   FetchError,
   FetchBackoffAbortError,
@@ -43,12 +45,19 @@ import {
   PAUSE_STREAM,
   EXPERIMENTAL_LIVE_SSE_QUERY_PARAM,
   ELECTRIC_PROTOCOL_QUERY_PARAMS,
+  LOG_MODE_QUERY_PARAM,
+  SUBSET_PARAM_WHERE,
+  SUBSET_PARAM_WHERE_PARAMS,
+  SUBSET_PARAM_LIMIT,
+  SUBSET_PARAM_OFFSET,
+  SUBSET_PARAM_ORDER_BY,
 } from './constants'
 import {
   EventSourceMessage,
   fetchEventSource,
 } from '@microsoft/fetch-event-source'
 import { expiredShapesCache } from './expired-shapes-cache'
+import { SnapshotTracker } from './snapshot-tracker'
 
 const RESERVED_PARAMS: Set<ReservedParamKeys> = new Set([
   LIVE_CACHE_BUSTER_QUERY_PARAM,
@@ -58,6 +67,7 @@ const RESERVED_PARAMS: Set<ReservedParamKeys> = new Set([
 ])
 
 type Replica = `full` | `default`
+export type LogMode = `changes_only` | `full`
 
 /**
  * PostgreSQL-specific shape parameters that can be provided externally
@@ -114,11 +124,20 @@ export type ExternalParamsRecord<T extends Row<unknown> = Row> = {
   [K in string]: ParamValue | undefined
 } & Partial<PostgresParams<T>> & { [K in ReservedParamKeys]?: never }
 
+export type SubsetParams = {
+  where?: string
+  params?: Record<string, string>
+  limit?: number
+  offset?: number
+  orderBy?: string
+}
+
 type ReservedParamKeys =
   | typeof LIVE_CACHE_BUSTER_QUERY_PARAM
   | typeof SHAPE_HANDLE_QUERY_PARAM
   | typeof LIVE_QUERY_PARAM
   | typeof OFFSET_QUERY_PARAM
+  | `subset__${string}`
 
 /**
  * External headers type - what users provide.
@@ -258,6 +277,11 @@ export interface ShapeStreamOptions<T = never> {
    */
   experimentalLiveSse?: boolean
 
+  /**
+   * Initial data loading mode
+   */
+  mode?: LogMode
+
   signal?: AbortSignal
   fetchClient?: typeof fetch
   backoffOptions?: BackoffOptions
@@ -293,8 +317,20 @@ export interface ShapeStreamInterface<T extends Row<unknown> = Row> {
   lastOffset: Offset
   shapeHandle?: string
   error?: unknown
+  mode: LogMode
 
   forceDisconnectAndRefresh(): Promise<void>
+
+  requestSnapshot(params: {
+    where?: string
+    params?: Record<string, string>
+    limit: number
+    offset?: number
+    orderBy: string
+  }): Promise<{
+    metadata: SnapshotMetadata
+    data: Array<Message<T>>
+  }>
 }
 
 /**
@@ -385,6 +421,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
   #isUpToDate: boolean = false
   #connected: boolean = false
   #shapeHandle?: string
+  #mode: LogMode
   #schema?: Schema
   #onError?: ShapeStreamErrorHandler
   #requestAbortController?: AbortController
@@ -393,6 +430,8 @@ export class ShapeStream<T extends Row<unknown> = Row>
   #tickPromiseResolver?: () => void
   #tickPromiseRejecter?: (reason?: unknown) => void
   #messageChain = Promise.resolve<void[]>([]) // promise chain for incoming messages
+  #snapshotTracker = new SnapshotTracker()
+  #activeSnapshotRequests = 0 // counter for concurrent snapshot requests
 
   constructor(options: ShapeStreamOptions<GetExtensions<T>>) {
     this.options = { subscribe: true, ...options }
@@ -405,6 +444,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
       options.transformer
     )
     this.#onError = this.options.onError
+    this.#mode = this.options.mode ?? `full`
 
     const baseFetchClient =
       options.fetchClient ??
@@ -445,6 +485,10 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
   get lastOffset() {
     return this.#lastOffset
+  }
+
+  get mode() {
+    return this.#mode
   }
 
   async #start(): Promise<void> {
@@ -573,7 +617,11 @@ export class ShapeStream<T extends Row<unknown> = Row>
     return this.#requestShape()
   }
 
-  async #constructUrl(url: string, resumingFromPause: boolean) {
+  async #constructUrl(
+    url: string,
+    resumingFromPause: boolean,
+    subsetParams?: SubsetParams
+  ) {
     // Resolve headers and params in parallel
     const [requestHeaders, params] = await Promise.all([
       resolveHeaders(this.options.headers),
@@ -583,9 +631,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
     ])
 
     // Validate params after resolution
-    if (params) {
-      validateParams(params)
-    }
+    if (params) validateParams(params)
 
     const fetchUrl = new URL(url)
 
@@ -612,8 +658,22 @@ export class ShapeStream<T extends Row<unknown> = Row>
       }
     }
 
+    if (subsetParams) {
+      if (subsetParams.where)
+        setQueryParam(fetchUrl, SUBSET_PARAM_WHERE, subsetParams.where)
+      if (subsetParams.params)
+        setQueryParam(fetchUrl, SUBSET_PARAM_WHERE_PARAMS, subsetParams.params)
+      if (subsetParams.limit)
+        setQueryParam(fetchUrl, SUBSET_PARAM_LIMIT, subsetParams.limit)
+      if (subsetParams.offset)
+        setQueryParam(fetchUrl, SUBSET_PARAM_OFFSET, subsetParams.offset)
+      if (subsetParams.orderBy)
+        setQueryParam(fetchUrl, SUBSET_PARAM_ORDER_BY, subsetParams.orderBy)
+    }
+
     // Add Electric's internal parameters
     fetchUrl.searchParams.set(OFFSET_QUERY_PARAM, this.#lastOffset)
+    fetchUrl.searchParams.set(LOG_MODE_QUERY_PARAM, this.#mode)
 
     if (this.#isUpToDate) {
       // If we are resuming from a paused state, we don't want to perform a live request
@@ -720,7 +780,15 @@ export class ShapeStream<T extends Row<unknown> = Row>
         this.#isUpToDate = true
       }
 
-      await this.#publish(batch)
+      // Filter messages using snapshot tracker
+      const messagesToProcess = batch.filter((message) => {
+        if (isChangeMessage(message)) {
+          return !this.#snapshotTracker.shouldRejectMessage(message)
+        }
+        return true // Always process control messages
+      })
+
+      await this.#publish(messagesToProcess)
     }
   }
 
@@ -978,6 +1046,101 @@ export class ShapeStream<T extends Row<unknown> = Row>
     this.#isUpToDate = false
     this.#connected = false
     this.#schema = undefined
+    this.#activeSnapshotRequests = 0
+  }
+
+  /**
+   * Request a snapshot for subset of data.
+   *
+   * Only available when mode is `changes_only`.
+   * Returns the insertion point & the data, but more importantly injects the data
+   * into the subscribed data stream. Returned value is unlikely to be useful for the caller,
+   * unless the caller has complicated additional logic.
+   *
+   * Data will be injected in a way that's also tracking further incoming changes, and it'll
+   * skip the ones that are already in the snapshot.
+   *
+   * @param opts - The options for the snapshot request.
+   * @returns The metadata and the data for the snapshot.
+   */
+  async requestSnapshot(opts: SubsetParams): Promise<{
+    metadata: SnapshotMetadata
+    data: Array<ChangeMessage<T>>
+  }> {
+    if (this.#mode === `full`) {
+      throw new Error(
+        `Snapshot requests are not supported in ${this.#mode} mode, as the consumer is guaranteed to observe all data`
+      )
+    }
+    // We shouldn't be getting a snapshot on a shape that's not started
+    if (!this.#started) await this.#start()
+
+    // Pause the stream if this is the first snapshot request
+    this.#activeSnapshotRequests++
+
+    try {
+      if (this.#activeSnapshotRequests === 1) {
+        // Currently this cannot throw, but in case it can later it's in this try block to not have a stuck counter
+        this.#pause()
+      }
+
+      const { fetchUrl, requestHeaders } = await this.#constructUrl(
+        this.options.url,
+        true,
+        opts
+      )
+
+      const { metadata, data } = await this.#fetchSnapshot(
+        fetchUrl,
+        requestHeaders
+      )
+
+      const dataWithEndBoundary = (data as Array<Message<T>>).concat([
+        { headers: { control: `snapshot-end`, ...metadata } },
+      ])
+
+      this.#snapshotTracker.addSnapshot(
+        metadata,
+        new Set(data.map((message) => message.key))
+      )
+      this.#onMessages(dataWithEndBoundary, false)
+
+      return {
+        metadata,
+        data,
+      }
+    } finally {
+      // Resume the stream if this was the last snapshot request
+      this.#activeSnapshotRequests--
+      if (this.#activeSnapshotRequests === 0) {
+        this.#resume()
+      }
+    }
+  }
+
+  async #fetchSnapshot(url: URL, headers: Record<string, string>) {
+    const response = await this.#fetchClient(url.toString(), { headers })
+
+    if (!response.ok) {
+      throw new FetchError(
+        response.status,
+        undefined,
+        undefined,
+        Object.fromEntries([...response.headers.entries()]),
+        url.toString()
+      )
+    }
+
+    const { metadata, data } = await response.json()
+    const batch = this.#messageParser.parse<Array<ChangeMessage<T>>>(
+      JSON.stringify(data),
+      this.#schema!
+    )
+
+    return {
+      metadata,
+      data: batch,
+    }
   }
 }
 

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1203,6 +1203,7 @@ function validateOptions<T>(options: Partial<ShapeStreamOptions<T>>): void {
   if (
     options.offset !== undefined &&
     options.offset !== `-1` &&
+    options.offset !== `now` &&
     !options.handle
   ) {
     throw new MissingShapeHandleError()

--- a/packages/typescript-client/src/constants.ts
+++ b/packages/typescript-client/src/constants.ts
@@ -16,6 +16,12 @@ export const WHERE_PARAMS_PARAM = `params`
 export const EXPERIMENTAL_LIVE_SSE_QUERY_PARAM = `experimental_live_sse`
 export const FORCE_DISCONNECT_AND_REFRESH = `force-disconnect-and-refresh`
 export const PAUSE_STREAM = `pause-stream`
+export const LOG_MODE_QUERY_PARAM = `log`
+export const SUBSET_PARAM_WHERE = `subset__where`
+export const SUBSET_PARAM_LIMIT = `subset__limit`
+export const SUBSET_PARAM_OFFSET = `subset__offset`
+export const SUBSET_PARAM_ORDER_BY = `subset__order_by`
+export const SUBSET_PARAM_WHERE_PARAMS = `subset__params`
 
 // Query parameters that should be passed through when proxying Electric requests
 export const ELECTRIC_PROTOCOL_QUERY_PARAMS: Array<string> = [
@@ -24,4 +30,10 @@ export const ELECTRIC_PROTOCOL_QUERY_PARAMS: Array<string> = [
   OFFSET_QUERY_PARAM,
   LIVE_CACHE_BUSTER_QUERY_PARAM,
   EXPIRED_HANDLE_QUERY_PARAM,
+  LOG_MODE_QUERY_PARAM,
+  SUBSET_PARAM_WHERE,
+  SUBSET_PARAM_LIMIT,
+  SUBSET_PARAM_OFFSET,
+  SUBSET_PARAM_ORDER_BY,
+  SUBSET_PARAM_WHERE_PARAMS,
 ]

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -5,6 +5,11 @@ import {
   OFFSET_QUERY_PARAM,
   SHAPE_HANDLE_HEADER,
   SHAPE_HANDLE_QUERY_PARAM,
+  SUBSET_PARAM_LIMIT,
+  SUBSET_PARAM_OFFSET,
+  SUBSET_PARAM_ORDER_BY,
+  SUBSET_PARAM_WHERE,
+  SUBSET_PARAM_WHERE_PARAMS,
 } from './constants'
 import {
   FetchError,
@@ -206,11 +211,24 @@ export function createFetchWithResponseHeadersCheck(
 
       const addMissingHeaders = (requiredHeaders: Array<string>) =>
         missingHeaders.push(...requiredHeaders.filter((h) => !headers.has(h)))
-      addMissingHeaders(requiredElectricResponseHeaders)
 
       const input = args[0]
       const urlString = input.toString()
       const url = new URL(urlString)
+
+      // Snapshot responses (subset params) return a JSON object and do not include Electric chunk headers
+      const isSnapshotRequest = [
+        SUBSET_PARAM_WHERE,
+        SUBSET_PARAM_WHERE_PARAMS,
+        SUBSET_PARAM_LIMIT,
+        SUBSET_PARAM_OFFSET,
+        SUBSET_PARAM_ORDER_BY,
+      ].some((p) => url.searchParams.has(p))
+      if (isSnapshotRequest) {
+        return response
+      }
+
+      addMissingHeaders(requiredElectricResponseHeaders)
       if (url.searchParams.get(LIVE_QUERY_PARAM) === `true`) {
         addMissingHeaders(requiredLiveResponseHeaders)
       }

--- a/packages/typescript-client/src/helpers.ts
+++ b/packages/typescript-client/src/helpers.ts
@@ -87,11 +87,13 @@ export function isVisibleInSnapshot(
   const xid = BigInt(txid)
   const xmin = BigInt(snapshot.xmin)
   const xmax = BigInt(snapshot.xmax)
-  const xip = snapshot.xip.map(BigInt)
+  const xip = snapshot.xip_list.map(BigInt)
 
-  if (xid < xmin) return true
-  if (xid < xmax && !xip.includes(xid)) return true
-  if (xid < xmax) return false
+  // If the transaction id is less than the minimum transaction id, it is visible in the snapshot.
+  // If the transaction id is less than the maximum transaction id and not in the list of active
+  //   transactions at the time of the snapshot, it has been committed before the snapshot was taken
+  //   and is therefore visible in the snapshot.
+  // Otherwise, it is not visible in the snapshot.
 
-  return false
+  return xid < xmin || (xid < xmax && !xip.includes(xid))
 }

--- a/packages/typescript-client/src/index.ts
+++ b/packages/typescript-client/src/index.ts
@@ -1,7 +1,11 @@
 export * from './client'
 export * from './shape'
 export * from './types'
-export { isChangeMessage, isControlMessage } from './helpers'
+export {
+  isChangeMessage,
+  isControlMessage,
+  isVisibleInSnapshot,
+} from './helpers'
 export { FetchError } from './error'
 export { type BackoffOptions, BackoffDefaults } from './fetch'
 export { ELECTRIC_PROTOCOL_QUERY_PARAMS } from './constants'

--- a/packages/typescript-client/src/snapshot-tracker.ts
+++ b/packages/typescript-client/src/snapshot-tracker.ts
@@ -1,0 +1,88 @@
+import { isVisibleInSnapshot } from './helpers'
+import { Row, SnapshotMetadata } from './types'
+import { ChangeMessage } from './types'
+
+/**
+ * Tracks active snapshots and filters out duplicate change messages that are already included in snapshots.
+ *
+ * When requesting a snapshot in changes_only mode, we need to track which transactions were included in the
+ * snapshot to avoid processing duplicate changes that arrive via the live stream. This class maintains that
+ * tracking state and provides methods to:
+ *
+ * - Add new snapshots for tracking via addSnapshot()
+ * - Remove completed snapshots via removeSnapshot()
+ * - Check if incoming changes should be filtered via shouldRejectMessage()
+ */
+export class SnapshotTracker {
+  private activeSnapshots: Map<
+    number,
+    { xmin: bigint; xmax: bigint; xip_list: bigint[]; keys: Set<string> }
+  > = new Map()
+  private xmaxSnapshots: Map<bigint, Set<number>> = new Map()
+  private snapshotsByDatabaseLsn: Map<bigint, Set<number>> = new Map()
+
+  /**
+   * Add a new snapshot for tracking
+   */
+  addSnapshot(metadata: SnapshotMetadata, keys: Set<string>): void {
+    this.activeSnapshots.set(metadata.snapshot_mark, {
+      xmin: BigInt(metadata.xmin),
+      xmax: BigInt(metadata.xmax),
+      xip_list: metadata.xip_list.map(BigInt),
+      keys,
+    })
+    const xmaxSet =
+      this.xmaxSnapshots
+        .get(BigInt(metadata.xmax))
+        ?.add(metadata.snapshot_mark) ?? new Set([metadata.snapshot_mark])
+    this.xmaxSnapshots.set(BigInt(metadata.xmax), xmaxSet)
+    const databaseLsnSet =
+      this.snapshotsByDatabaseLsn
+        .get(BigInt(metadata.database_lsn))
+        ?.add(metadata.snapshot_mark) ?? new Set([metadata.snapshot_mark])
+    this.snapshotsByDatabaseLsn.set(
+      BigInt(metadata.database_lsn),
+      databaseLsnSet
+    )
+  }
+
+  /**
+   * Remove a snapshot from tracking
+   */
+  removeSnapshot(snapshotMark: number): void {
+    this.activeSnapshots.delete(snapshotMark)
+  }
+
+  /**
+   * Check if a change message should be filtered because its already in an active snapshot
+   * Returns true if the message should be filtered out (not processed)
+   */
+  shouldRejectMessage(message: ChangeMessage<Row<unknown>>): boolean {
+    const txids = message.headers.txids || []
+    if (txids.length === 0) return false
+
+    const xid = Math.max(...txids) // Use the maximum transaction ID
+
+    for (const [xmax, snapshots] of this.xmaxSnapshots.entries()) {
+      if (xid >= xmax) {
+        for (const snapshot of snapshots) {
+          this.removeSnapshot(snapshot)
+        }
+      }
+    }
+
+    return [...this.activeSnapshots.values()].some(
+      (x) => x.keys.has(message.key) && isVisibleInSnapshot(xid, x)
+    )
+  }
+
+  lastSeenUpdate(newDatabaseLsn: bigint): void {
+    for (const [dbLsn, snapshots] of this.snapshotsByDatabaseLsn.entries()) {
+      if (dbLsn <= newDatabaseLsn) {
+        for (const snapshot of snapshots) {
+          this.removeSnapshot(snapshot)
+        }
+      }
+    }
+  }
+}

--- a/packages/typescript-client/src/types.ts
+++ b/packages/typescript-client/src/types.ts
@@ -23,7 +23,11 @@ export type GetExtensions<T> = [T] extends [Row<never>]
     ? E
     : never
 
-export type Offset = `-1` | `${number}_${number}` | `${bigint}_${number}`
+export type Offset =
+  | `-1`
+  | `now`
+  | `${number}_${number}`
+  | `${bigint}_${number}`
 
 /** Information about transaction visibility for a snapshot. All fields are encoded as strings, but should be treated as uint64. */
 export type PostgresSnapshot = {

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -1341,3 +1341,493 @@ function createSSEFilterStream(filterFn: (event: string) => boolean) {
     },
   })
 }
+
+describe.for(fetchAndSse)(
+  `Shape - changes_only mode (liveSSE=$experimentalLiveSse)`,
+  ({ experimentalLiveSse }) => {
+    it(`should expose mode on Shape`, async ({ issuesTableUrl, aborter }) => {
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const shape = new Shape(shapeStream)
+      await waitForFetch(shapeStream)
+      expect(shape.mode).toBe(`changes_only`)
+    })
+
+    it(`should start empty even when data exists`, async ({
+      issuesTableUrl,
+      insertIssues,
+      aborter,
+    }) => {
+      await insertIssues({ title: `pre-existing` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+
+      const shape = new Shape(shapeStream)
+
+      expect(await shape.rows).toEqual([])
+    })
+
+    it(`should propagate updates immediately as update messages`, async ({
+      issuesTableUrl,
+      insertIssues,
+      updateIssue,
+      aborter,
+    }) => {
+      const [id] = await insertIssues({ title: `before` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+
+      const messages: Message<Row>[] = []
+      const unsubscribe = shapeStream.subscribe((msgs) => {
+        messages.push(...msgs)
+      })
+
+      await waitForFetch(shapeStream)
+
+      await updateIssue({ id, title: `after` })
+
+      await vi.waitFor(() => {
+        const updateMsg = messages.find(
+          (m) => isChangeMessage(m) && m.headers.operation === `update`
+        ) as ChangeMessage<Row> | undefined
+        expect(updateMsg?.value?.title).toBe(`after`)
+      })
+
+      unsubscribe()
+    })
+
+    it(`requestSnapshot should populate stream and match returned data`, async ({
+      issuesTableUrl,
+      insertIssues,
+      aborter,
+    }) => {
+      await insertIssues({ title: `A` }, { title: `B` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+
+      const shape = new Shape(shapeStream)
+
+      // Initial state should be empty
+      expect(await shape.rows).toEqual([])
+
+      // Capture messages published to the stream during snapshot
+      const seenKeys = new Set<string>()
+      const unsub = shapeStream.subscribe((msgs) => {
+        for (const m of msgs) {
+          if (isChangeMessage(m)) seenKeys.add(m.key)
+        }
+      })
+
+      const { data } = await shapeStream.requestSnapshot({
+        orderBy: `title ASC`,
+        limit: 100,
+      })
+
+      // Wait until shape reflects the snapshot
+      await vi.waitFor(() => {
+        expect(shape.currentRows.length).toBe(data.length)
+      })
+
+      // Compare keys in stream vs returned snapshot data
+      const returnedKeys = new Set(data.map((m) => m.key))
+      expect(seenKeys).toEqual(returnedKeys)
+
+      // Compare values (ignoring order)
+      const rowsById = new Map(shape.currentRows.map((r) => [r.id, r]))
+      for (const msg of data) {
+        const row = rowsById.get(msg.value.id)
+        expect(row).toBeTruthy()
+        Object.entries(msg.value).forEach(([k, v]) => {
+          expect(row![k]).toEqual(v)
+        })
+      }
+
+      unsub()
+    })
+
+    it(`requestSnapshot supports orderBy`, async ({
+      issuesTableUrl,
+      insertIssues,
+      aborter,
+    }) => {
+      await insertIssues({ title: `B` }, { title: `C` }, { title: `A` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const _shape = new Shape(shapeStream)
+      await waitForFetch(shapeStream)
+
+      const { data } = await shapeStream.requestSnapshot({
+        orderBy: `title ASC`,
+        limit: 100,
+      })
+      const titles = data.map((m) => m.value.title)
+      expect(titles).toEqual([`A`, `B`, `C`])
+    })
+
+    it(`requestSnapshot supports where clause`, async ({
+      issuesTableUrl,
+      insertIssues,
+      aborter,
+    }) => {
+      await insertIssues({ title: `foo` }, { title: `bar` }, { title: `baz` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const _shape = new Shape(shapeStream)
+      await waitForFetch(shapeStream)
+
+      const { data } = await shapeStream.requestSnapshot({
+        where: `title = 'bar'`,
+        orderBy: `title ASC`,
+        limit: 100,
+      })
+      const titles = data.map((m) => m.value.title)
+      expect(titles).toEqual([`bar`])
+    })
+
+    it(`requestSnapshot supports parametrised where clause`, async ({
+      issuesTableUrl,
+      insertIssues,
+      aborter,
+    }) => {
+      await insertIssues({ title: `one` }, { title: `two` }, { title: `three` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const _shape = new Shape(shapeStream)
+      await waitForFetch(shapeStream)
+
+      const { data } = await shapeStream.requestSnapshot({
+        where: `title = $1 OR title = $2`,
+        params: { '1': `two`, '2': `three` },
+        orderBy: `title ASC`,
+        limit: 100,
+      })
+      const titles = data.map((m) => m.value.title).sort()
+      expect(titles).toEqual([`three`, `two`])
+    })
+
+    it(`requestSnapshot supports orderBy + limit`, async ({
+      issuesTableUrl,
+      insertIssues,
+      aborter,
+    }) => {
+      await insertIssues({ title: `a` }, { title: `b` }, { title: `c` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const _shape = new Shape(shapeStream)
+      await waitForFetch(shapeStream)
+
+      const { data } = await shapeStream.requestSnapshot({
+        orderBy: `title DESC`,
+        limit: 2,
+      })
+      const titles = data.map((m) => m.value.title)
+      expect(titles).toEqual([`c`, `b`])
+    })
+
+    it(`should stream updates after snapshot completes`, async ({
+      issuesTableUrl,
+      insertIssues,
+      updateIssue,
+      aborter,
+    }) => {
+      const [id] = await insertIssues({ title: `before` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const _shape = new Shape(shapeStream)
+      await waitForFetch(shapeStream)
+
+      // Perform a snapshot to populate data and ensure pause/resume flow
+      await shapeStream.requestSnapshot({ orderBy: `title ASC`, limit: 100 })
+
+      // Now perform an update and ensure it is streamed after snapshot finishes
+      const messages: Message<Row>[] = []
+      const unsub = shapeStream.subscribe((msgs) => {
+        messages.push(...msgs)
+      })
+      await updateIssue({ id, title: `after` })
+
+      await vi.waitFor(() => {
+        const updateMsg = messages.find(
+          (m) => isChangeMessage(m) && m.headers.operation === `update`
+        ) as ChangeMessage<Row> | undefined
+        expect(updateMsg?.value?.title).toBe(`after`)
+      })
+      unsub()
+    })
+
+    it(`should observe update committed after snapshot taken in parallel transaction`, async ({
+      issuesTableUrl,
+      issuesTableSql,
+      insertIssues,
+      dbClient,
+      aborter,
+    }) => {
+      const [id] = await insertIssues({ title: `base` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const _shape = new Shape(shapeStream)
+      await waitForFetch(shapeStream)
+
+      // Begin a transaction and update the row, but do not commit yet
+      await dbClient.query(`BEGIN`)
+      await dbClient.query(
+        `UPDATE ${issuesTableSql} SET title = $2 WHERE id = $1`,
+        [id, `updated-in-tx`]
+      )
+
+      // Take a snapshot that includes this row by id
+      await shapeStream.requestSnapshot({
+        where: `id = $1`,
+        params: { '1': id },
+        orderBy: `id ASC`,
+        limit: 100,
+      })
+
+      // Now commit the transaction so the update becomes visible and is replicated
+      await dbClient.query(`COMMIT`)
+
+      // Expect to observe the update via the replication stream
+      const seen: Array<ChangeMessage<Row>> = []
+      const unsub = shapeStream.subscribe((msgs) => {
+        for (const m of msgs)
+          if (isChangeMessage(m)) seen.push(m as ChangeMessage<Row>)
+      })
+
+      await vi.waitFor(() => {
+        const upd = seen.find(
+          (m) => m.key && m.value.id === id && m.headers.operation === `update`
+        )
+        expect(upd?.value?.title).toBe(`updated-in-tx`)
+      })
+      unsub()
+    })
+
+    it(`should ignore updates/deletes for unseen keys until insert observed`, async ({
+      issuesTableUrl,
+      insertIssues,
+      updateIssue,
+      deleteIssue,
+      waitForIssues,
+      aborter,
+    }) => {
+      // Create a row before starting the stream
+      const [preId] = await insertIssues({ title: `pre` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const shape = new Shape(shapeStream)
+
+      // Subscribe to capture raw messages to know when updates arrive
+      const seen: Message<Row>[] = []
+      const unsub = shape.stream.subscribe((msgs) => {
+        seen.push(...msgs)
+      })
+
+      // Initial state should be empty
+      expect(await shape.rows).toEqual([])
+
+      // Update pre-existing row; Shape should ignore
+      await updateIssue({ id: preId, title: `pre-updated` })
+      await waitForIssues({ numChangesExpected: 1 })
+      await vi.waitFor(() => {
+        expect(
+          seen.some(
+            (m) =>
+              isChangeMessage(m) &&
+              m.headers.operation === `update` &&
+              (m as ChangeMessage<Row>).value.id === preId
+          )
+        ).toBe(true)
+      })
+      expect(shape.currentRows).toEqual([])
+
+      // Delete pre-existing row; still ignored
+      await deleteIssue({ id: preId, title: `pre-updated` })
+      await waitForIssues({ numChangesExpected: 1 })
+      await vi.waitFor(() => {
+        expect(
+          seen.some(
+            (m) => isChangeMessage(m) && m.headers.operation === `delete`
+          )
+        ).toBe(true)
+      })
+      expect(shape.currentRows).toEqual([])
+
+      // Insert a new row after the stream starts; Shape should include it
+      const [id2] = await insertIssues({ title: `live` })
+      await vi.waitFor(() => {
+        const rows = shape.currentRows
+        expect(rows.length).toBe(1)
+        expect(rows[0].id).toBe(id2)
+        expect(rows[0].title).toBe(`live`)
+      })
+
+      // Update the inserted row; Shape should apply update
+      await updateIssue({ id: id2, title: `live-updated` })
+      await waitForIssues({ numChangesExpected: 1 })
+      await vi.waitFor(() => {
+        const rows = shape.currentRows
+        expect(rows.length).toBe(1)
+        expect(rows[0].title).toBe(`live-updated`)
+      })
+
+      // Delete the inserted row; Shape should remove it
+      await deleteIssue({ id: id2, title: `live-updated` })
+      await waitForIssues({ numChangesExpected: 1 })
+      await vi.waitFor(() => {
+        expect(shape.currentRows).toEqual([])
+      })
+
+      unsub()
+    })
+
+    it(`Shape.requestSnapshot should populate data and return void`, async ({
+      issuesTableUrl,
+      insertIssues,
+      aborter,
+    }) => {
+      await insertIssues({ title: `A` }, { title: `B` })
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+      })
+      const shape = new Shape(shapeStream)
+
+      // Initially empty
+      expect(await shape.rows).toEqual([])
+
+      const result = await shape.requestSnapshot({
+        orderBy: `title ASC`,
+        limit: 100,
+      })
+      expect(result).toBeUndefined()
+
+      await vi.waitFor(() => {
+        expect(shape.currentRows.length).toBe(2)
+      })
+      const titles = shape.currentRows.map((r) => r.title).sort()
+      expect(titles).toEqual([`A`, `B`])
+    })
+
+    it(`should re-execute requested sub-snapshots on must-refetch`, async ({
+      issuesTableUrl,
+      insertIssues,
+      deleteIssue,
+      waitForIssues,
+      clearIssuesShape,
+      aborter,
+    }) => {
+      const [_, id2] = await insertIssues(
+        { title: `snap1` },
+        { title: `snap2` }
+      )
+
+      let fetchPausePromise: Promise<void> = Promise.resolve()
+      const fetchWrapper = async (...args: Parameters<typeof fetch>) => {
+        await fetchPausePromise
+        return await fetch(...args)
+      }
+
+      const shapeStream = new ShapeStream({
+        url: `${BASE_URL}/v1/shape`,
+        params: { table: issuesTableUrl },
+        mode: `changes_only`,
+        experimentalLiveSse,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
+      const shape = new Shape(shapeStream)
+
+      // Request a snapshot to populate data (and to be re-executed later)
+      await shape.requestSnapshot({ orderBy: `title ASC`, limit: 100 })
+      await vi.waitFor(() => {
+        expect(shape.currentRows.length).toBe(2)
+      })
+
+      // Prepare rotation: before next fetch, delete id2 and insert a new row, then clear shape
+      fetchPausePromise = Promise.resolve().then(async () => {
+        await deleteIssue({ id: id2, title: `snap2` })
+        await insertIssues({ title: `snap3` })
+        await waitForIssues({ numChangesExpected: 2 })
+        await clearIssuesShape(shapeStream.shapeHandle)
+      })
+
+      // Wait until shape reflects re-executed snapshot on the new shape
+      await vi.waitFor(
+        () => {
+          const titles = shape.currentRows.map((r) => r.title).sort()
+          expect(titles).toEqual([`snap1`, `snap3`])
+        },
+        { timeout: 4000 }
+      )
+    })
+  }
+)

--- a/packages/typescript-client/test/snapshot-tracker.test.ts
+++ b/packages/typescript-client/test/snapshot-tracker.test.ts
@@ -1,0 +1,469 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { SnapshotTracker } from '../src/snapshot-tracker'
+import { ChangeMessage, SnapshotMetadata, Row } from '../src/types'
+
+describe(`SnapshotTracker`, () => {
+  let tracker: SnapshotTracker
+
+  beforeEach(() => {
+    tracker = new SnapshotTracker()
+  })
+
+  describe(`Single snapshot filtering logic`, () => {
+    it(`should reject message when xid < xmin (already included in snapshot)`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `100`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [50], // xid < xmin (50 < 100)
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(true)
+    })
+
+    it(`should reject message when xid < xmax AND xid not in xip (already included in snapshot)`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `50`,
+        xmax: `200`,
+        xip_list: [`150`, `175`], // xid 100 is not in xip
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `update`,
+          txids: [100], // xid < xmax (100 < 200) AND not in xip
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(true)
+    })
+
+    it(`should NOT reject message when xid < xmax AND xid is in xip (parallel transaction)`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `50`,
+        xmax: `200`,
+        xip_list: [`100`, `150`], // xid 100 is in xip
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `update`,
+          txids: [100], // xid < xmax (100 < 200) AND in xip (parallel)
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(false)
+    })
+
+    it(`should NOT reject message when xid >= xmax (not included in snapshot)`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `50`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [250], // xid >= xmax (250 >= 200)
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(false)
+    })
+  })
+
+  describe(`Keys not in snapshots are always let through`, () => {
+    it(`should NOT reject message when key is not in any snapshot`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `100`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`, `user:2`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:3`, // Key not in snapshot
+        value: { id: 3, name: `Charlie` },
+        headers: {
+          operation: `insert`,
+          txids: [50], // Would be rejected if key was in snapshot
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(false)
+    })
+
+    it(`should reject message when key is in snapshot but txid condition met`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `100`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`, // Key is in snapshot
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [50], // xid < xmin, should be rejected
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(true)
+    })
+  })
+
+  describe(`Multiple snapshots logic`, () => {
+    it(`should reject message if included in ANY snapshot`, () => {
+      const snapshot1: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `100`,
+        xmax: `200`,
+        xip_list: [`170`],
+        database_lsn: `123`,
+      }
+      const snapshot2: SnapshotMetadata = {
+        snapshot_mark: 2,
+        xmin: `300`,
+        xmax: `400`,
+        xip_list: [],
+        database_lsn: `456`,
+      }
+      const keys1 = new Set([`user:1`, `user:2`])
+
+      tracker.addSnapshot(snapshot1, keys1)
+      tracker.addSnapshot(snapshot2, keys1)
+
+      // Message that would be included in snapshot2 (xid < xmin)
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`, // In snapshot1
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [170], // xid < xmin of snapshot2 and in xip of snapshot1
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(true)
+    })
+
+    it(`should NOT reject message if not included in ANY snapshot`, () => {
+      const snapshot1: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `100`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const snapshot2: SnapshotMetadata = {
+        snapshot_mark: 2,
+        xmin: `300`,
+        xmax: `400`,
+        xip_list: [],
+        database_lsn: `456`,
+      }
+      const keys1 = new Set([`user:1`])
+      const keys2 = new Set([`user:3`])
+
+      tracker.addSnapshot(snapshot1, keys1)
+      tracker.addSnapshot(snapshot2, keys2)
+
+      // Message that is not included in either snapshot
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:2`, // Not in any snapshot
+        value: { id: 2, name: `Bob` },
+        headers: {
+          operation: `insert`,
+          txids: [50], // xid < xmin of snapshot1
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(false)
+    })
+  })
+
+  describe(`Snapshot cleanup when xid >= xmax`, () => {
+    it(`should remove snapshot when xid >= xmax`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `50`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [250], // xid >= xmax (250 >= 200)
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(false)
+
+      // After processing a message with xid >= xmax, the snapshot should be removed
+      // So a subsequent message with xid < xmin should NOT be rejected
+      const subsequentMessage: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [25], // xid < xmin, but snapshot was removed
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(subsequentMessage)).toBe(false)
+    })
+
+    it(`should keep other snapshots active when one is cleaned up`, () => {
+      const snapshot1: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `50`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const snapshot2: SnapshotMetadata = {
+        snapshot_mark: 2,
+        xmin: `300`,
+        xmax: `400`,
+        xip_list: [],
+        database_lsn: `456`,
+      }
+      const keys1 = new Set([`user:1`])
+      const keys2 = new Set([`user:2`])
+
+      tracker.addSnapshot(snapshot1, keys1)
+      tracker.addSnapshot(snapshot2, keys2)
+
+      // Message that triggers cleanup of snapshot1 (xid >= xmax of snapshot1)
+      const cleanupMessage: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [250], // xid >= xmax of snapshot1
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(cleanupMessage)).toBe(false)
+
+      // snapshot1 should be removed, but snapshot2 should still be active
+      const messageForSnapshot2: ChangeMessage<Row<unknown>> = {
+        key: `user:2`,
+        value: { id: 2, name: `Bob` },
+        headers: {
+          operation: `insert`,
+          txids: [250], // xid < xmin of snapshot2
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(messageForSnapshot2)).toBe(true)
+    })
+  })
+
+  describe(`Multiple snapshots with same xmax cleanup`, () => {
+    it(`should clean up all snapshots with same xmax from one message`, () => {
+      const snapshot1: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `50`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const snapshot2: SnapshotMetadata = {
+        snapshot_mark: 2,
+        xmin: `60`,
+        xmax: `200`, // Same xmax as snapshot1
+        xip_list: [],
+        database_lsn: `456`,
+      }
+      const keys1 = new Set([`user:1`])
+      const keys2 = new Set([`user:2`])
+
+      tracker.addSnapshot(snapshot1, keys1)
+      tracker.addSnapshot(snapshot2, keys2)
+
+      // Message that triggers cleanup of both snapshots (xid >= xmax)
+      const cleanupMessage: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [250], // xid >= xmax (250 >= 200)
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(cleanupMessage)).toBe(false)
+
+      // Both snapshots should be removed
+      const message1: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [25], // xid < xmin of snapshot1
+        },
+      }
+
+      const message2: ChangeMessage<Row<unknown>> = {
+        key: `user:2`,
+        value: { id: 2, name: `Bob` },
+        headers: {
+          operation: `insert`,
+          txids: [30], // xid < xmin of snapshot2
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message1)).toBe(false)
+      expect(tracker.shouldRejectMessage(message2)).toBe(false)
+    })
+  })
+
+  describe(`Edge cases and additional functionality`, () => {
+    it(`should handle messages with no txids`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `100`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          // No txids
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(false)
+    })
+
+    it(`should handle messages with multiple txids (uses maximum)`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `100`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      const keys = new Set([`user:1`])
+
+      tracker.addSnapshot(metadata, keys)
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [50, 150, 250], // Max is 250
+        },
+      }
+
+      // 250 >= xmax, so should not be rejected
+      expect(tracker.shouldRejectMessage(message)).toBe(false)
+    })
+
+    it(`should handle lastSeenUpdate method`, () => {
+      const snapshot1: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `50`,
+        xmax: `200`,
+        xip_list: [],
+        database_lsn: `100`,
+      }
+      const snapshot2: SnapshotMetadata = {
+        snapshot_mark: 2,
+        xmin: `60`,
+        xmax: `300`,
+        xip_list: [],
+        database_lsn: `200`,
+      }
+      const keys1 = new Set([`user:1`])
+      const keys2 = new Set([`user:2`])
+
+      tracker.addSnapshot(snapshot1, keys1)
+      tracker.addSnapshot(snapshot2, keys2)
+
+      // Update with LSN that removes snapshot1
+      tracker.lastSeenUpdate(BigInt(150))
+
+      // snapshot1 should be removed, snapshot2 should remain
+      const message1: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `insert`,
+          txids: [25], // Would be rejected by snapshot1 if it existed
+        },
+      }
+
+      const message2: ChangeMessage<Row<unknown>> = {
+        key: `user:2`,
+        value: { id: 2, name: `Bob` },
+        headers: {
+          operation: `insert`,
+          txids: [30], // Should still be rejected by snapshot2
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message1)).toBe(false)
+      expect(tracker.shouldRejectMessage(message2)).toBe(true)
+    })
+  })
+})

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -80,7 +80,7 @@ describe(`ShapeStream`, () => {
     )
 
     expect(requestedUrls[0].split(`?`)[1]).toEqual(
-      `columns=id&handle=potato&offset=-1&table=foo&where=a%3D1`
+      `columns=id&handle=potato&log=full&offset=-1&table=foo&where=a%3D1`
     )
   })
 
@@ -156,7 +156,7 @@ describe(`ShapeStream`, () => {
     )
 
     expect(requestedUrls[0].split(`?`)[1]).toEqual(
-      `columns=id&handle=potato&offset=-1&params%5B1%5D=test1&params%5B2%5D=test2&table=foo&where=a%3D%241+and+b%3D%242`
+      `columns=id&handle=potato&log=full&offset=-1&params%5B1%5D=test1&params%5B2%5D=test2&table=foo&where=a%3D%241+and+b%3D%242`
     )
   })
 
@@ -192,7 +192,7 @@ describe(`ShapeStream`, () => {
     )
 
     expect(requestedUrls[0].split(`?`)[1]).toEqual(
-      `columns=id&handle=potato&offset=-1&params%5B1%5D=test1&params%5B2%5D=test2&table=foo&where=a%3D%241+and+b%3D%242`
+      `columns=id&handle=potato&log=full&offset=-1&params%5B1%5D=test1&params%5B2%5D=test2&table=foo&where=a%3D%241+and+b%3D%242`
     )
   })
 })


### PR DESCRIPTION
Adds:
- `log` query parameter, values `full | changes_only`. Latter adds the new behaviour where we're not asking for an initial snapshot at all from Postgres
- `subset__` parameter group (`where/order_by/limit/offset`) that, if present, alters the response form to be
```typescript
{
  metadata: SnapshotMetadata,
  data: ChangeMessage
}
 
 export type SnapshotMetadata = {
  xmin: number
  xmax: number
  xip: number[]
  /** Random number that's reflected in the `snapshot_mark` header on the snapshot items. */
  snapshot_mark: number
  database_lsn: string
}
```
- `subset__where` is validated much the same as normal where clause, with an additional assertion on lack of subqueries
- Support for `offset=now` on the server to skip historical data

Where data contains the `snapshot_mark` in the headers if the client needs to match back the results after passing them through some pipeline

Updates the client:
- Adds a `log` parameter, values `lazy | eager`
- Addes a `requestSnapshot` function that returns data/metadata described above AND injects the data into the shape stream
- Shape stream then drops any changes deemed to be already seen via the snapshot according to xmin/xmax/xip logic

