### PR TITLE
feat(sync-service) Optimise removing a shape from the where clause filter indexes

### DIFF
--- a/.changeset/fifty-lemons-shop.md
+++ b/.changeset/fifty-lemons-shop.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Optimise removing a shape from where clause filter indexes

--- a/packages/sync-service/lib/electric/shapes/filter/index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/index.ex
@@ -11,16 +11,16 @@ defmodule Electric.Shapes.Filter.Index do
   def new("@>", type), do: Indexes.InclusionIndex.new(type)
 
   defdelegate empty?(index), to: Protocol
-  defdelegate add_shape(index, value, shape_instance, and_where), to: Protocol
-  defdelegate remove_shape(index, value, shape_instance, and_where), to: Protocol
-  defdelegate affected_shapes(index, field, record), to: Protocol
-  defdelegate all_shapes(index), to: Protocol
+  defdelegate add_shape(index, value, shape_id, and_where), to: Protocol
+  defdelegate remove_shape(index, value, shape_id, and_where), to: Protocol
+  defdelegate affected_shapes(index, field, record, shapes), to: Protocol
+  defdelegate all_shape_ids(index), to: Protocol
 end
 
 defprotocol Electric.Shapes.Filter.Index.Protocol do
   def empty?(index)
-  def add_shape(index, value, shape_instance, and_where)
-  def remove_shape(index, value, shape_instance, and_where)
-  def affected_shapes(index, field, record)
-  def all_shapes(index)
+  def add_shape(index, value, shape_id, and_where)
+  def remove_shape(index, value, shape_id, and_where)
+  def affected_shapes(index, field, record, shapes)
+  def all_shape_ids(index)
 end

--- a/packages/sync-service/lib/electric/shapes/filter/where_condition.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/where_condition.ex
@@ -31,35 +31,34 @@ defmodule Electric.Shapes.Filter.WhereCondition do
     indexes == %{} && other_shapes == %{}
   end
 
-  def add_shape(%WhereCondition{} = condition, {shape_id, shape} = shape_instance, where_clause) do
+  def add_shape(%WhereCondition{} = condition, shape_id, where_clause) do
     case optimise_where(where_clause) do
       :not_optimised ->
         %{
           condition
-          | other_shapes:
-              Map.put(condition.other_shapes, shape_id, %{shape: shape, where: where_clause})
+          | other_shapes: Map.put(condition.other_shapes, shape_id, where_clause)
         }
 
       optimisation ->
         %{
           condition
-          | indexes: add_shape_to_indexes(condition.indexes, shape_instance, optimisation)
+          | indexes: add_shape_to_indexes(condition.indexes, shape_id, optimisation)
         }
     end
   end
 
-  defp add_shape_to_indexes(indexes, shape_instance, optimisation) do
+  defp add_shape_to_indexes(indexes, shape_id, optimisation) do
     Map.update(
       indexes,
       {optimisation.field, optimisation.operation},
       Index.add_shape(
         Index.new(optimisation.operation, optimisation.type),
         optimisation.value,
-        shape_instance,
+        shape_id,
         optimisation.and_where
       ),
       fn index ->
-        Index.add_shape(index, optimisation.value, shape_instance, optimisation.and_where)
+        Index.add_shape(index, optimisation.value, shape_id, optimisation.and_where)
       end
     )
   end
@@ -115,7 +114,7 @@ defmodule Electric.Shapes.Filter.WhereCondition do
     %Expr{eval: eval, used_refs: Parser.find_refs(eval), returns: :bool}
   end
 
-  def remove_shape(%WhereCondition{} = condition, {shape_id, _} = shape_instance, where_clause) do
+  def remove_shape(%WhereCondition{} = condition, shape_id, where_clause) do
     case optimise_where(where_clause) do
       :not_optimised ->
         %{condition | other_shapes: Map.delete(condition.other_shapes, shape_id)}
@@ -123,16 +122,16 @@ defmodule Electric.Shapes.Filter.WhereCondition do
       optimisation ->
         %{
           condition
-          | indexes: remove_shape_from_indexes(condition.indexes, shape_instance, optimisation)
+          | indexes: remove_shape_from_indexes(condition.indexes, shape_id, optimisation)
         }
     end
   end
 
-  defp remove_shape_from_indexes(indexes, shape_instance, optimisation) do
+  defp remove_shape_from_indexes(indexes, shape_id, optimisation) do
     index =
       indexes
       |> Map.fetch!({optimisation.field, optimisation.operation})
-      |> Index.remove_shape(optimisation.value, shape_instance, optimisation.and_where)
+      |> Index.remove_shape(optimisation.value, shape_id, optimisation.and_where)
 
     if Index.empty?(index) do
       Map.delete(indexes, {optimisation.field, optimisation.operation})
@@ -141,10 +140,10 @@ defmodule Electric.Shapes.Filter.WhereCondition do
     end
   end
 
-  def affected_shapes(%WhereCondition{} = condition, record, refs_fun \\ fn _ -> %{} end) do
+  def affected_shapes(%WhereCondition{} = condition, record, shapes, refs_fun \\ fn _ -> %{} end) do
     MapSet.union(
-      indexed_shapes_affected(condition, record),
-      other_shapes_affected(condition, record, refs_fun)
+      indexed_shapes_affected(condition, record, shapes),
+      other_shapes_affected(condition, record, shapes, refs_fun)
     )
   rescue
     error ->
@@ -154,31 +153,30 @@ defmodule Electric.Shapes.Filter.WhereCondition do
       """)
 
       # We can't tell which shapes are affected, the safest thing to do is return all shapes
-      condition
-      |> all_shapes()
-      |> MapSet.new(fn {shape_id, _shape} -> shape_id end)
+      all_shape_ids(condition)
   end
 
-  defp indexed_shapes_affected(condition, record) do
+  defp indexed_shapes_affected(condition, record, shapes) do
     OpenTelemetry.with_child_span(
       "filter.filter_using_indexes",
       [index_count: map_size(condition.indexes)],
       fn ->
         condition.indexes
         |> Enum.map(fn {{field, _operation}, index} ->
-          Index.affected_shapes(index, field, record)
+          Index.affected_shapes(index, field, record, shapes)
         end)
         |> Enum.reduce(MapSet.new(), &MapSet.union(&1, &2))
       end
     )
   end
 
-  defp other_shapes_affected(condition, record, refs_fun) do
+  defp other_shapes_affected(condition, record, shapes, refs_fun) do
     OpenTelemetry.with_child_span(
       "filter.filter_other_shapes",
       [shape_count: map_size(condition.other_shapes)],
       fn ->
-        for {shape_id, %{where: where, shape: shape}} <- condition.other_shapes,
+        for {shape_id, where} <- condition.other_shapes,
+            shape = Map.fetch!(shapes, shape_id),
             WhereClause.includes_record?(where, record, refs_fun.(shape)),
             into: MapSet.new() do
           shape_id
@@ -187,17 +185,14 @@ defmodule Electric.Shapes.Filter.WhereCondition do
     )
   end
 
-  def all_shapes(%WhereCondition{indexes: indexes, other_shapes: other_shapes}) do
-    Map.merge(
-      for {_key, index} <- indexes,
-          {shape_id, shape} <- Index.all_shapes(index),
-          into: %{} do
-        {shape_id, shape}
-      end,
-      for {shape_id, %{shape: shape}} <- other_shapes,
-          into: %{} do
-        {shape_id, shape}
-      end
+  def all_shape_ids(%WhereCondition{indexes: indexes, other_shapes: other_shapes}) do
+    MapSet.union(
+      Enum.reduce(indexes, MapSet.new(), fn {_key, index}, ids ->
+        MapSet.union(ids, Index.all_shape_ids(index))
+      end),
+      Enum.reduce(other_shapes, MapSet.new(), fn {shape_id, _}, ids ->
+        MapSet.put(ids, shape_id)
+      end)
     )
   end
 end

--- a/packages/sync-service/test/electric/shapes/filter_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter_test.exs
@@ -334,7 +334,7 @@ defmodule Electric.Shapes.FilterTest do
       filter_with_shape_added = Filter.add_shape(filter, i, shape)
 
       # Check that whenever you remove a shape the filter is the same as if the shape was never added
-      assert Filter.remove_shape(filter_with_shape_added, i, shape) == filter
+      assert Filter.remove_shape(filter_with_shape_added, i) == filter
 
       filter_with_shape_added
     end)
@@ -348,7 +348,7 @@ defmodule Electric.Shapes.FilterTest do
     # have been chosen instead of time since the time taken is not deterministic and
     # leads to flakey tests.
     #
-    # Modern machines process approx 300-400 reductions per μs so @max_reductions of 1200
+    # Modern machines process approx 300-400 reductions per μs so @max_reductions of 1300
     # is roughly equivalent to 3μs.
     #
     # 3μs per change is a desirable and achievable target for replication stream processing.
@@ -361,7 +361,7 @@ defmodule Electric.Shapes.FilterTest do
     # to keep to a microsecond per change. 10_000 shapes makes for a slow test though as the setup
     # time (n Filter.add_shape calls) is slow.
     @shape_count 1000
-    @max_reductions 1200
+    @max_reductions 1300
 
     test "where clause in the form `field = const` is optimised" do
       filter =


### PR DESCRIPTION
Turbo.ai are seeing ShapeLogCollector.unsubscribe take 100ms on average with a P99 of 300ms. This blocks the replication stream and given that 50 shapes can be expired at a time can cause many seconds of lag.

We've seen from telemetry that it's removing from the where clause filter indexes that is the bottleneck.

This PR speeds up removing a shape from the where clause filter indexes. For 60K shapes, it speeds it up 12800x. It achieves this by using the shape data to selectively remove from the index tree rather than traversing the whole tree looking for the shape handles.

This PR also lowers the memory footprint of the filter. A naive implementation would have increased the memory footprint since the shape data is needed for removal now, but since we're trying to lower memory use I've taken this opportunity to remove the duplication of shape data in the filter so now the memory use is less than before.


```
# before
Removing 100 shapes from 60000: each took 12.805ms mean, P99 48.303ms

:erts_debug.flat_size(filter) #=> 12581546

# this PR
Removing 100 shapes from 60000: each took 0.001ms mean, P99 0.008ms

:erts_debug.flat_size(filter) #=> 12324026
```