### PR TITLE
feat: Use separate `ShapeCleaner` process for shape removals to avoid blocking `ShapeCache`

### DIFF
--- a/.changeset/odd-kangaroos-hunt.md
+++ b/.changeset/odd-kangaroos-hunt.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Move shape deletion operations into separate process to avoid blocking `ShapeCache` on critical path.

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -55,6 +55,10 @@ defmodule Electric.Connection.Manager.Supervisor do
 
     consumer_supervisor_spec = {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
 
+    shape_cleaner_spec =
+      {Electric.Shapes.Cleaner,
+       stack_id: stack_id, shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)}
+
     shape_cache_spec = {Electric.ShapeCache, shape_cache_opts}
 
     publication_manager_spec =
@@ -75,7 +79,6 @@ defmodule Electric.Connection.Manager.Supervisor do
       {Electric.Replication.SchemaReconciler,
        stack_id: stack_id,
        inspector: inspector,
-       shape_cache: {Electric.ShapeCache, stack_id: stack_id},
        period: Keyword.get(tweaks, :schema_reconciler_period, 60_000)}
 
     expiry_manager_spec =
@@ -93,6 +96,7 @@ defmodule Electric.Connection.Manager.Supervisor do
           stack_id: stack_id,
           shape_status_owner: shape_status_owner_spec,
           consumer_supervisor: consumer_supervisor_spec,
+          shape_cleaner: shape_cleaner_spec,
           shape_cache: shape_cache_spec,
           publication_manager: publication_manager_spec,
           log_collector: shape_log_collector_spec,

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -56,7 +56,7 @@ defmodule Electric.Connection.Manager.Supervisor do
     consumer_supervisor_spec = {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
 
     shape_cleaner_spec =
-      {Electric.Shapes.Cleaner,
+      {Electric.ShapeCache.ShapeCleaner,
        stack_id: stack_id, shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)}
 
     shape_cache_spec = {Electric.ShapeCache, shape_cache_opts}
@@ -86,8 +86,7 @@ defmodule Electric.Connection.Manager.Supervisor do
        max_shapes: Keyword.fetch!(opts, :max_shapes),
        expiry_batch_size: Keyword.fetch!(opts, :expiry_batch_size),
        stack_id: stack_id,
-       shape_status: Keyword.fetch!(shape_cache_opts, :shape_status),
-       consumer_supervisor: Keyword.fetch!(shape_cache_opts, :consumer_supervisor)}
+       shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)}
 
     child_spec =
       Supervisor.child_spec(

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -145,7 +145,7 @@ defmodule Electric.Postgres.Configuration do
       if MapSet.size(changed_relations) > 0,
         do:
           Logger.info(
-            "Configuring publication #{publication_name} to include #{map_size(used_relations)} tables - " <>
+            "Configuring publication #{publication_name} to include #{MapSet.size(used_relations)} tables - " <>
               "skipping altered tables #{inspect(MapSet.to_list(changed_relations))}"
           )
 

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -3,6 +3,7 @@ defmodule Electric.Replication.PublicationManager do
   use GenServer
 
   alias Electric.Postgres.Configuration
+  alias Electric.Shapes.ShapeCleaner
   alias Electric.Shapes.Shape
   alias Electric.Utils
 
@@ -16,6 +17,7 @@ defmodule Electric.Replication.PublicationManager do
   @callback refresh_publication(Keyword.t()) :: :ok
 
   defstruct [
+    :stack_id,
     # %{ {oid, relation} => count }
     :relation_ref_counts,
     # %MapSet{{oid, relation}}
@@ -34,12 +36,12 @@ defmodule Electric.Replication.PublicationManager do
     :manual_table_publishing?,
     :configure_tables_for_replication_fn,
     :publication_refresh_period,
-    :shape_cache,
     next_update_forced?: false
   ]
 
   @type relation_filters() :: MapSet.t(Electric.oid_relation())
   @typep state() :: %__MODULE__{
+           stack_id: Electric.ShapeCacheBehaviour.stack_id(),
            relation_ref_counts: %{Electric.oid_relation() => non_neg_integer()},
            prepared_relation_filters: relation_filters(),
            committed_relation_filters: relation_filters(),
@@ -51,7 +53,6 @@ defmodule Electric.Replication.PublicationManager do
            db_pool: term(),
            configure_tables_for_replication_fn: fun(),
            publication_refresh_period: non_neg_integer(),
-           shape_cache: {module(), term()},
            next_update_forced?: boolean()
          }
 
@@ -71,7 +72,6 @@ defmodule Electric.Replication.PublicationManager do
             stack_id: [type: :string, required: true],
             publication_name: [type: :string, required: true],
             db_pool: [type: {:or, [:atom, :pid, @name_schema_tuple]}],
-            shape_cache: [type: :mod_arg, required: false],
             can_alter_publication?: [type: :boolean, required: false, default: true],
             manual_table_publishing?: [type: :boolean, required: false, default: false],
             update_debounce_timeout: [type: :timeout, default: @default_debounce_timeout],
@@ -155,6 +155,7 @@ defmodule Electric.Replication.PublicationManager do
     Process.set_label({:publication_manager, opts.stack_id})
 
     state = %__MODULE__{
+      stack_id: opts.stack_id,
       relation_ref_counts: %{},
       prepared_relation_filters: MapSet.new(),
       committed_relation_filters: MapSet.new(),
@@ -167,7 +168,6 @@ defmodule Electric.Replication.PublicationManager do
       db_pool: opts.db_pool,
       can_alter_publication?: opts.can_alter_publication?,
       manual_table_publishing?: opts.manual_table_publishing?,
-      shape_cache: Map.get(opts, :shape_cache, {Electric.ShapeCache, [stack_id: opts.stack_id]}),
       configure_tables_for_replication_fn: opts.configure_tables_for_replication_fn,
       publication_refresh_period: opts.refresh_period
     }
@@ -270,11 +270,9 @@ defmodule Electric.Replication.PublicationManager do
             "Cleaning up shapes for misconfigured or unpublished relations #{inspect(relations)}"
           )
 
-          {mod, args} = state.shape_cache
-
           relations
           |> MapSet.to_list()
-          |> mod.clean_all_shapes_for_relations(args)
+          |> ShapeCleaner.remove_shapes_for_relations(stack_id: state.stack_id)
 
           tables = Enum.map(relations, fn {_oid, relation} -> Utils.relation_to_sql(relation) end)
           message = publication_error_message(error_type, tables, state)
@@ -329,11 +327,9 @@ defmodule Electric.Replication.PublicationManager do
         "Relations dropped/renamed since last publication update: #{inspect(MapSet.to_list(invalidated_relations))}"
       )
 
-      {mod, args} = state.shape_cache
-
       invalidated_relations
       |> MapSet.to_list()
-      |> mod.clean_all_shapes_for_relations(args)
+      |> ShapeCleaner.remove_shapes_for_relations(stack_id: state.stack_id)
     end
 
     state = reply_to_waiters(:ok, state)

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -3,7 +3,7 @@ defmodule Electric.Replication.PublicationManager do
   use GenServer
 
   alias Electric.Postgres.Configuration
-  alias Electric.Shapes.ShapeCleaner
+  alias Electric.ShapeCache.ShapeCleaner
   alias Electric.Shapes.Shape
   alias Electric.Utils
 

--- a/packages/sync-service/lib/electric/replication/schema_reconciler.ex
+++ b/packages/sync-service/lib/electric/replication/schema_reconciler.ex
@@ -14,7 +14,7 @@ defmodule Electric.Replication.SchemaReconciler do
 
   alias Electric.Postgres.Inspector
   alias Electric.Replication.PublicationManager
-  alias Electric.Shapes.ShapeCleaner
+  alias Electric.ShapeCache.ShapeCleaner
 
   @name_schema_tuple {:tuple, [:atom, :atom, :any]}
   @genserver_name_schema {:or, [:atom, @name_schema_tuple]}

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -33,9 +33,10 @@ defmodule Electric.Replication.Supervisor do
 
   @impl Supervisor
   def init(opts) do
-    Process.set_label({:replication_supervisor, opts[:stack_id]})
-    Logger.metadata(stack_id: opts[:stack_id])
-    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
+    stack_id = Keyword.fetch!(opts, :stack_id)
+    Process.set_label({:replication_supervisor, stack_id})
+    Logger.metadata(stack_id: stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
 
     Logger.info("Starting shape replication pipeline")
 
@@ -43,10 +44,10 @@ defmodule Electric.Replication.Supervisor do
     log_collector = Keyword.fetch!(opts, :log_collector)
     publication_manager = Keyword.fetch!(opts, :publication_manager)
     consumer_supervisor = Keyword.fetch!(opts, :consumer_supervisor)
+    shape_cleaner = Keyword.fetch!(opts, :shape_cleaner)
     shape_cache = Keyword.fetch!(opts, :shape_cache)
-    schema_reconciler = Keyword.fetch!(opts, :schema_reconciler)
     expiry_manager = Keyword.fetch!(opts, :expiry_manager)
-    stack_id = Keyword.fetch!(opts, :stack_id)
+    schema_reconciler = Keyword.fetch!(opts, :schema_reconciler)
 
     children = [
       {Task.Supervisor,
@@ -55,8 +56,9 @@ defmodule Electric.Replication.Supervisor do
       log_collector,
       publication_manager,
       consumer_supervisor,
-      expiry_manager,
+      shape_cleaner,
       shape_cache,
+      expiry_manager,
       schema_reconciler
     ]
 

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -41,10 +41,10 @@ defmodule Electric.Replication.Supervisor do
     Logger.info("Starting shape replication pipeline")
 
     shape_status_owner = Keyword.fetch!(opts, :shape_status_owner)
+    shape_cleaner = Keyword.fetch!(opts, :shape_cleaner)
     log_collector = Keyword.fetch!(opts, :log_collector)
     publication_manager = Keyword.fetch!(opts, :publication_manager)
     consumer_supervisor = Keyword.fetch!(opts, :consumer_supervisor)
-    shape_cleaner = Keyword.fetch!(opts, :shape_cleaner)
     shape_cache = Keyword.fetch!(opts, :shape_cache)
     expiry_manager = Keyword.fetch!(opts, :expiry_manager)
     schema_reconciler = Keyword.fetch!(opts, :schema_reconciler)
@@ -53,10 +53,10 @@ defmodule Electric.Replication.Supervisor do
       {Task.Supervisor,
        name: Electric.ProcessRegistry.name(stack_id, Electric.StackTaskSupervisor)},
       shape_status_owner,
+      shape_cleaner,
       log_collector,
       publication_manager,
       consumer_supervisor,
-      shape_cleaner,
       shape_cache,
       expiry_manager,
       schema_reconciler

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -152,6 +152,12 @@ defmodule Electric.ShapeCache do
   end
 
   @impl Electric.ShapeCacheBehaviour
+  @spec clean_shape(shape_handle(), Access.t()) :: :ok
+  def clean_shape(shape_handle, opts) do
+    ShapeCleaner.remove_shape(shape_handle, opts)
+  end
+
+  @impl Electric.ShapeCacheBehaviour
   @spec await_snapshot_start(shape_handle(), Access.t()) :: :started | {:error, term()}
   def await_snapshot_start(shape_handle, opts \\ []) when is_binary(shape_handle) do
     table = ShapeStatus.shape_meta_table(opts)
@@ -201,11 +207,6 @@ defmodule Electric.ShapeCache do
       server = Access.get(opts, :server, name(opts))
       GenServer.call(server, {:wait_shape_handle, shape_handle}, @call_timeout)
     end
-  end
-
-  @impl Electric.ShapeCacheBehaviour
-  def clean_shape(shape_handle, opts \\ []) do
-    ShapeCleaner.remove_shape(shape_handle, opts)
   end
 
   @impl GenServer

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -28,7 +28,7 @@ defmodule Electric.ShapeCache do
   alias Electric.ShapeCache.ShapeStatus
   alias Electric.Shapes
   alias Electric.Shapes.ConsumerSupervisor
-  alias Electric.Shapes.ShapeCleaner
+  alias Electric.ShapeCache.ShapeCleaner
   alias Electric.Shapes.Shape
 
   require Logger

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -17,6 +17,7 @@ defmodule Electric.ShapeCacheBehaviour do
   @callback await_snapshot_start(shape_handle(), opts :: Access.t()) ::
               :started | {:error, term()}
   @callback has_shape?(shape_handle(), Access.t()) :: boolean()
+  @callback clean_shape(shape_handle(), Access.t()) :: :ok
 end
 
 defmodule Electric.ShapeCache do
@@ -200,6 +201,11 @@ defmodule Electric.ShapeCache do
       server = Access.get(opts, :server, name(opts))
       GenServer.call(server, {:wait_shape_handle, shape_handle}, @call_timeout)
     end
+  end
+
+  @impl Electric.ShapeCacheBehaviour
+  def clean_shape(shape_handle, opts \\ []) do
+    ShapeCleaner.remove_shape(shape_handle, opts)
   end
 
   @impl GenServer

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -5,15 +5,12 @@ defmodule Electric.ShapeCache.ExpiryManager do
 
   require Logger
 
-  @name_schema_tuple {:tuple, [:atom, :atom, :any]}
-  @genserver_name_schema {:or, [:atom, @name_schema_tuple]}
   @schema NimbleOptions.new!(
             max_shapes: [type: {:or, [:non_neg_integer, nil]}, default: nil],
             expiry_batch_size: [type: :pos_integer],
             period: [type: :non_neg_integer, default: 60_000],
             stack_id: [type: :string, required: true],
-            shape_status: [type: :mod_arg, required: true],
-            consumer_supervisor: [type: @genserver_name_schema, required: true]
+            shape_status: [type: :mod_arg, required: true]
           )
 
   def name(stack_id) when not is_map(stack_id) and not is_list(stack_id) do
@@ -43,8 +40,7 @@ defmodule Electric.ShapeCache.ExpiryManager do
         max_shapes: Keyword.fetch!(opts, :max_shapes),
         expiry_batch_size: Keyword.fetch!(opts, :expiry_batch_size),
         period: Keyword.fetch!(opts, :period),
-        shape_status: Keyword.fetch!(opts, :shape_status),
-        consumer_supervisor: Keyword.fetch!(opts, :consumer_supervisor)
+        shape_status: Keyword.fetch!(opts, :shape_status)
       }
 
     if not is_nil(state.max_shapes), do: schedule_next_check(state)

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -95,7 +95,9 @@ defmodule Electric.ShapeCache.ExpiryManager do
         elapsed_minutes_since_use: shape.elapsed_minutes_since_use
       ],
       fn ->
-        Electric.Shapes.ShapeCleaner.remove_shape(shape.shape_handle, stack_id: state.stack_id)
+        Electric.ShapeCache.ShapeCleaner.remove_shape(shape.shape_handle,
+          stack_id: state.stack_id
+        )
       end
     )
   end

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -99,11 +99,7 @@ defmodule Electric.ShapeCache.ExpiryManager do
         elapsed_minutes_since_use: shape.elapsed_minutes_since_use
       ],
       fn ->
-        Electric.Shapes.DynamicConsumerSupervisor.stop_shape_consumer(
-          state.consumer_supervisor,
-          state.stack_id,
-          shape.shape_handle
-        )
+        Electric.Shapes.ShapeCleaner.remove_shape(shape.shape_handle, stack_id: state.stack_id)
       end
     )
   end

--- a/packages/sync-service/lib/electric/shape_cache/shape_cleaner.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_cleaner.ex
@@ -1,4 +1,4 @@
-defmodule Electric.Shapes.ShapeCleaner do
+defmodule Electric.ShapeCache.ShapeCleaner do
   @moduledoc """
   Removes a shape (consumer, status entry, on-disk data and publication entry) on demand.
 

--- a/packages/sync-service/lib/electric/shape_cache/shape_cleaner.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_cleaner.ex
@@ -19,18 +19,16 @@ defmodule Electric.ShapeCache.ShapeCleaner do
   @spec remove_shape(shape_handle(), Keyword.t()) :: :ok | {:error, term()}
   def remove_shape(shape_handle, opts) do
     stack_id = Keyword.fetch!(opts, :stack_id)
-    server = Keyword.get(opts, :server, name(stack_id))
     timeout = Keyword.get(opts, :timeout, 15_000)
-    GenServer.call(server, {:remove_shape, shape_handle}, timeout)
+    GenServer.call(name(stack_id), {:remove_shape, shape_handle}, timeout)
   end
 
   @spec remove_shapes_for_relations(list(Electric.oid_relation()), Keyword.t()) :: :ok
   def remove_shapes_for_relations(relations, opts) do
     stack_id = Keyword.fetch!(opts, :stack_id)
-    server = Keyword.get(opts, :server, name(stack_id))
     # We don't want for this call to be blocking because it will be called in `PublicationManager`
     # if it notices a discrepancy in the schema
-    GenServer.cast(server, {:clean_all_shapes_for_relations, relations})
+    GenServer.cast(name(stack_id), {:clean_all_shapes_for_relations, relations})
   end
 
   def name(stack_id), do: Electric.ProcessRegistry.name(stack_id, __MODULE__)

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -73,7 +73,8 @@ defmodule Electric.Shapes do
   end
 
   @doc """
-  Clean up all data (meta data and shape log + snapshot) associated with the given shape handle
+  Remove and clean up all data (meta data and shape log + snapshot) associated with
+  the given shape handle
   """
   @spec clean_shape(shape_handle(), Access.t()) :: :ok
   def clean_shape(shape_handle, opts \\ []) do

--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -26,30 +26,6 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
     DynamicSupervisor.start_child(name, {ConsumerSupervisor, config})
   end
 
-  def stop_shape_consumer(_name, stack_id, shape_handle) do
-    case GenServer.whereis(ConsumerSupervisor.name(stack_id, shape_handle)) do
-      nil ->
-        {:error, "no consumer for shape handle #{inspect(shape_handle)}"}
-
-      pid when is_pid(pid) ->
-        ConsumerSupervisor.stop_and_clean(%{
-          stack_id: stack_id,
-          shape_handle: shape_handle
-        })
-
-        :ok
-    end
-  end
-
-  @doc false
-  def stop_all_consumers(name) do
-    for {:undefined, pid, _type, _} when is_pid(pid) <- DynamicSupervisor.which_children(name) do
-      DynamicSupervisor.terminate_child(name, pid)
-    end
-
-    :ok
-  end
-
   @impl true
   def init(stack_id: stack_id) do
     Process.set_label({:dynamic_consumer_supervisor, stack_id})

--- a/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
+++ b/packages/sync-service/lib/electric/shapes/shape_cleaner.ex
@@ -1,0 +1,126 @@
+defmodule Electric.Shapes.ShapeCleaner do
+  @moduledoc """
+  Removes a shape (consumer, status entry, on-disk data and publication entry) on demand.
+
+  This process ensures removing of shapes does not block critical path of shape creation.
+  """
+  use GenServer
+  require Logger
+
+  alias Electric.Shapes.ConsumerSupervisor
+  @type shape_handle() :: Electric.ShapeCacheBehaviour.shape_handle()
+
+  @schema NimbleOptions.new!(
+            stack_id: [type: :string, required: true],
+            shape_status: [type: :mod_arg, required: true]
+          )
+
+  # Public API
+  @spec remove_shape(shape_handle(), Keyword.t()) :: :ok | {:error, term()}
+  def remove_shape(shape_handle, opts) do
+    stack_id = Keyword.fetch!(opts, :stack_id)
+    server = Keyword.get(opts, :server, name(stack_id))
+    timeout = Keyword.get(opts, :timeout, 15_000)
+    GenServer.call(server, {:remove_shape, shape_handle}, timeout)
+  end
+
+  @spec remove_shapes_for_relations(list(Electric.oid_relation()), Keyword.t()) :: :ok
+  def remove_shapes_for_relations(relations, opts) do
+    stack_id = Keyword.fetch!(opts, :stack_id)
+    server = Keyword.get(opts, :server, name(stack_id))
+    # We don't want for this call to be blocking because it will be called in `PublicationManager`
+    # if it notices a discrepancy in the schema
+    GenServer.cast(server, {:clean_all_shapes_for_relations, relations})
+  end
+
+  def name(stack_id), do: Electric.ProcessRegistry.name(stack_id, __MODULE__)
+
+  def start_link(opts) do
+    with {:ok, opts} <- NimbleOptions.validate(opts, @schema) do
+      opts = Keyword.put_new(opts, :on_cleanup, fn _ -> :ok end)
+      stack_id = Keyword.fetch!(opts, :stack_id)
+      GenServer.start_link(__MODULE__, opts, name: name(stack_id))
+    end
+  end
+
+  # GenServer callbacks
+  @impl true
+  def init(opts) do
+    Process.set_label({:shape_remover, opts[:stack_id]})
+    Logger.metadata(stack_id: opts[:stack_id])
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts[:stack_id])
+
+    {:ok,
+     %{
+       stack_id: opts[:stack_id],
+       shape_status: Keyword.fetch!(opts, :shape_status),
+       queued_removals: []
+     }}
+  end
+
+  @impl true
+  def handle_call({:remove_shape, shape_handle}, _from, state) do
+    :ok = stop_and_clean_shape(shape_handle, state)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_cast({:clean_all_shapes_for_relations, relations}, state) do
+    {shape_status, shape_status_state} = state.shape_status
+
+    affected_shapes =
+      shape_status.list_shape_handles_for_relations(
+        shape_status_state,
+        relations
+      )
+
+    if relations != [] do
+      Logger.info(fn ->
+        "Cleaning up all shapes for relations #{inspect(relations)}: #{length(affected_shapes)} shapes total"
+      end)
+    end
+
+    # schedule these shape removals one by one to avoid blocking the GenServer
+    # for too long to allow interleaved sync removals
+
+    {:noreply, %{state | queued_removals: state.queued_removals ++ affected_shapes}}
+  end
+
+  def handle_cast(:remove_queued_shapes, %{queued_removals: []} = state) do
+    {:noreply, state}
+  end
+
+  def handle_cast(:remove_queued_shapes, %{queued_removals: [next_shape | rest]} = state) do
+    :ok = stop_and_clean_shape(next_shape, state)
+    # schedule the next removal immediately
+    send(self(), :remove_queued_shapes)
+    {:noreply, %{state | queued_removals: rest}}
+  end
+
+  @impl true
+  def handle_info({:remove_shape, shape_handle}, state) do
+    Logger.debug("Removing shape #{inspect(shape_handle)}")
+    :ok = stop_and_clean_shape(shape_handle, state)
+    {:noreply, state}
+  end
+
+  defp stop_and_clean_shape(shape_handle, state) do
+    Logger.debug("Removing shape #{inspect(shape_handle)}")
+
+    case ConsumerSupervisor.stop_and_clean(state.stack_id, shape_handle) do
+      :noproc ->
+        # if the consumer isn't running then we can just delete things gratuitously,
+        # starting with an immediate shape status removal
+        {shape_status, shape_status_state} = state.shape_status
+        shape_status.remove_shape(shape_status_state, shape_handle)
+
+        :ok = purge_shape(state.stack_id, shape_handle)
+
+      :ok ->
+        # if it is running then the stop_and_clean process will cleanup properly
+        :ok
+    end
+  end
+
+  defdelegate purge_shape(stack_id, shape_handle), to: Electric.Shapes.Monitor
+end

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -198,12 +198,12 @@ defmodule Electric.Replication.PublicationManagerTest do
       end)
 
       refute_receive :task1_done, 50
-      refute_received {:filters, _}
-      refute_received :task2_done
+      refute_receive {:filters, _}, 0
+      refute_receive :task2_done, 0
 
       assert_receive :task1_done
-      assert_received :task2_done
-      assert_received {:filters, []}
+      assert_receive :task2_done, 0
+      assert_receive {:filters, []}
       refute_receive {:filters, _}, 200
     end
   end

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -1,5 +1,6 @@
 defmodule Electric.Replication.PublicationManagerTest do
   use ExUnit.Case, async: true
+  use Repatch.ExUnit
 
   import Support.ComponentSetup
   import Support.TestUtils
@@ -9,10 +10,6 @@ defmodule Electric.Replication.PublicationManagerTest do
   @shape_handle_1 "shape_handle_1"
   @shape_handle_2 "shape_handle_2"
   @shape_handle_3 "shape_handle_3"
-
-  def clean_all_shapes_for_relations(relations, [parent_pid]) do
-    send(parent_pid, {:clean_all_shapes_for_relations, relations})
-  end
 
   setup :with_stack_id_from_test
 
@@ -31,11 +28,21 @@ defmodule Electric.Replication.PublicationManagerTest do
         test: ctx.test,
         stack_id: ctx.stack_id,
         update_debounce_timeout: Access.get(ctx, :update_debounce_timeout, 0),
-        shape_cache: {__MODULE__, [self()]},
         publication_name: "pub_#{ctx.stack_id}",
         pool: :no_pool,
         configure_tables_for_replication_fn: configure_tables_fn
       })
+
+    Repatch.patch(
+      Electric.Shapes.ShapeCleaner,
+      :remove_shapes_for_relations,
+      [mode: :shared],
+      fn relations, _ ->
+        send(test_pid, {:remove_shapes_for_relations, relations})
+      end
+    )
+
+    Repatch.allow(test_pid, publication_manager_opts[:server])
 
     %{opts: publication_manager_opts, ctx: ctx}
   end
@@ -129,7 +136,7 @@ defmodule Electric.Replication.PublicationManagerTest do
       shape = generate_shape({"public", "items"})
       assert :ok == PublicationManager.add_shape(@shape_handle_1, shape, opts)
       assert_receive {:filters, [{_, {"public", "items"}}]}
-      assert_receive {:clean_all_shapes_for_relations, [{10, {"public", "another_table"}}]}
+      assert_receive {:remove_shapes_for_relations, [{10, {"public", "another_table"}}]}
     end
   end
 
@@ -224,11 +231,12 @@ defmodule Electric.Replication.PublicationManagerTest do
           test: ctx.test,
           stack_id: ctx.stack_id,
           update_debounce_timeout: 0,
-          shape_cache: {__MODULE__, [self()]},
           publication_name: "pub_#{ctx.stack_id}",
           pool: :no_pool,
           configure_tables_for_replication_fn: configure_tables_fn
         })
+
+      Repatch.allow(self(), publication_manager_opts[:server])
 
       pid = GenServer.whereis(publication_manager_opts[:server])
       mref = Process.monitor(pid)

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -34,7 +34,7 @@ defmodule Electric.Replication.PublicationManagerTest do
       })
 
     Repatch.patch(
-      Electric.Shapes.ShapeCleaner,
+      Electric.ShapeCache.ShapeCleaner,
       :remove_shapes_for_relations,
       [mode: :shared],
       fn relations, _ ->

--- a/packages/sync-service/test/electric/shape_cache/expiry_manager_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/expiry_manager_test.exs
@@ -54,6 +54,7 @@ defmodule Electric.ExpiryManagerTest do
     :with_async_deleter,
     :with_pure_file_storage,
     :with_shape_status,
+    :with_shape_cleaner,
     :with_status_monitor,
     :with_shape_monitor,
     :with_log_chunking,
@@ -63,7 +64,7 @@ defmodule Electric.ExpiryManagerTest do
   ]
 
   test "expires shapes if shape count has gone over max_shapes", ctx do
-    %{shape_cache_opts: opts, consumer_supervisor: consumer_supervisor} =
+    %{shape_cache_opts: opts} =
       with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
         run_with_conn_fn: &run_with_conn_noop/2,
         create_snapshot_fn: fn parent, shape_handle, _shape, %{storage: storage} ->
@@ -79,8 +80,7 @@ defmodule Electric.ExpiryManagerTest do
        expiry_batch_size: 1,
        period: 10,
        stack_id: ctx.stack_id,
-       shape_status: ctx.shape_status,
-       consumer_supervisor: consumer_supervisor}
+       shape_status: ctx.shape_status}
     )
 
     {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -16,7 +16,6 @@ defmodule Electric.ShapeCacheTest do
   import Support.ComponentSetup
   import Support.DbSetup
   import Support.DbStructureSetup
-  import Support.TestUtils
 
   @stub_inspector Support.StubInspector.new(
                     tables: [{1, {"public", "items"}}],
@@ -823,156 +822,6 @@ defmodule Electric.ShapeCacheTest do
     end
   end
 
-  describe "clean_shape/2" do
-    setup [
-      :with_log_chunking,
-      :with_registry,
-      :with_shape_log_collector,
-      :with_noop_publication_manager
-    ]
-
-    test "cleans up shape data and rotates the shape handle", ctx do
-      %{shape_cache_opts: opts} =
-        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
-          run_with_conn_fn: &run_with_conn_noop/2,
-          create_snapshot_fn: fn parent, shape_handle, _shape, %{storage: storage} ->
-            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
-            Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_handle})
-          end
-        )
-
-      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
-
-      consumer_ref =
-        Electric.Shapes.Consumer.whereis(ctx.stack_id, shape_handle)
-        |> Process.monitor()
-
-      storage = Storage.for_shape(shape_handle, ctx.storage)
-      writer = Storage.init_writer!(storage, @shape)
-
-      Storage.append_to_log!(
-        changes_to_log_items([
-          %Electric.Replication.Changes.NewRecord{
-            relation: {"public", "items"},
-            record: %{"id" => "1", "value" => "Alice"},
-            log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
-          }
-        ]),
-        writer
-      )
-
-      assert Storage.snapshot_started?(storage)
-
-      assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
-               1
-
-      log = capture_log(fn -> :ok = ShapeCache.clean_shape(shape_handle, opts) end)
-      assert log =~ "Cleaning up shape"
-
-      assert_receive {:DOWN, ^consumer_ref, :process, _pid, {:shutdown, :cleanup}}
-      assert :ok = await_for_storage_to_raise(storage)
-
-      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-      assert :started = ShapeCache.await_snapshot_start(shape_handle2, opts)
-      assert shape_handle != shape_handle2
-    end
-
-    test "cleans up shape swallows error if no shape to clean up", ctx do
-      shape_handle = "foo"
-
-      %{shape_cache_opts: opts} =
-        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
-          run_with_conn_fn: &run_with_conn_noop/2,
-          create_snapshot_fn: fn parent, shape_handle, _shape, %{storage: storage} ->
-            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
-            Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_handle})
-          end
-        )
-
-      {:ok, _} = with_log(fn -> ShapeCache.clean_shape(shape_handle, opts) end)
-    end
-  end
-
-  describe "clean_all_shapes_for_relations/2" do
-    setup [
-      :with_log_chunking,
-      :with_registry,
-      :with_shape_log_collector,
-      :with_noop_publication_manager
-    ]
-
-    setup ctx do
-      %{shape_cache_opts: opts} =
-        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
-          run_with_conn_fn: &run_with_conn_noop/2,
-          create_snapshot_fn: fn parent, shape_handle, _shape, %{storage: storage} ->
-            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_10})
-            Storage.make_new_snapshot!([["test"]], storage)
-            GenServer.cast(parent, {:snapshot_started, shape_handle})
-          end
-        )
-
-      {:ok, %{shape_cache_opts: opts}}
-    end
-
-    test "cleans up shape data for relevant shapes", %{shape_cache_opts: opts} = ctx do
-      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
-
-      consumer_ref =
-        Electric.Shapes.Consumer.whereis(ctx.stack_id, shape_handle)
-        |> Process.monitor()
-
-      storage = Storage.for_shape(shape_handle, ctx.storage)
-      writer = Storage.init_writer!(storage, @shape)
-
-      Storage.append_to_log!(
-        changes_to_log_items([
-          %Electric.Replication.Changes.NewRecord{
-            relation: {"public", "items"},
-            record: %{"id" => "1", "value" => "Alice"},
-            log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
-          }
-        ]),
-        writer
-      )
-
-      assert Storage.snapshot_started?(storage)
-
-      assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
-               1
-
-      # Cleaning unrelated relations should not affect the shape
-      :ok =
-        ShapeCache.clean_all_shapes_for_relations(
-          [{@shape.root_table_id + 1, {"public", "different"}}],
-          opts
-        )
-
-      refute_receive {:DOWN, ^consumer_ref, :process, _pid, {:shutdown, :cleanup}}, 100
-
-      # Shouldn't raise
-      assert :ok = Stream.run(Storage.get_log_stream(@zero_offset, storage))
-
-      :ok =
-        ShapeCache.clean_all_shapes_for_relations(
-          [{@shape.root_table_id, {"public", "items"}}],
-          opts
-        )
-
-      assert_receive {:DOWN, ^consumer_ref, :process, _pid, {:shutdown, :cleanup}}
-
-      assert :ok = await_for_storage_to_raise(storage)
-
-      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-      assert :started = ShapeCache.await_snapshot_start(shape_handle2, opts)
-      assert shape_handle != shape_handle2
-    end
-  end
-
   describe "after restart" do
     setup [
       :with_log_chunking,
@@ -1023,6 +872,13 @@ defmodule Electric.ShapeCacheTest do
     test "restores publication filters", %{shape_cache_opts: opts} = context do
       {shape_handle1, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
       :started = ShapeCache.await_snapshot_start(shape_handle1, opts)
+
+      ref =
+        Shapes.Consumer.Snapshotter.name(context.stack_id, shape_handle1)
+        |> GenServer.whereis()
+        |> Process.monitor()
+
+      assert_receive {:DOWN, ^ref, :process, _pid, _reason}, 1000
 
       Mock.PublicationManager
       |> expect(:add_shape, 1, fn ^shape_handle1, _, _ -> :ok end)
@@ -1177,22 +1033,6 @@ defmodule Electric.ShapeCacheTest do
 
       other ->
         other
-    end
-  end
-
-  defp await_for_storage_to_raise(storage, num_attempts \\ 10)
-
-  defp await_for_storage_to_raise(_storage, 0) do
-    raise "Storage did not raise Storage.Error in time"
-  end
-
-  defp await_for_storage_to_raise(storage, num_attempts) do
-    try do
-      Stream.run(Storage.get_log_stream(LogOffset.before_all(), storage))
-      Process.sleep(50)
-      await_for_storage_to_raise(storage, num_attempts - 1)
-    rescue
-      Storage.Error -> :ok
     end
   end
 end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -892,8 +892,15 @@ defmodule Electric.ShapeCacheTest do
       })
 
       {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
-      :started = ShapeCache.await_snapshot_start(shape_handle2, opts)
       assert shape_handle1 == shape_handle2
+      :started = ShapeCache.await_snapshot_start(shape_handle2, opts)
+
+      ref =
+        Shapes.Consumer.Snapshotter.name(context.stack_id, shape_handle2)
+        |> GenServer.whereis()
+        |> Process.monitor()
+
+      assert_receive {:DOWN, ^ref, :process, _pid, _reason}, 1000
     end
 
     test "restores latest offset", %{shape_cache_opts: opts} = context do

--- a/packages/sync-service/test/electric/shape_cleaner_test.exs
+++ b/packages/sync-service/test/electric/shape_cleaner_test.exs
@@ -1,0 +1,194 @@
+defmodule Electric.ShapeCleanerTest do
+  use ExUnit.Case, async: true
+  use Support.Mock
+
+  import ExUnit.CaptureLog
+  import Support.ComponentSetup
+  import Support.TestUtils
+  import Mox
+
+  alias Electric.ShapeCache
+  alias Electric.ShapeCache.Storage
+  alias Electric.ShapeCache.ShapeCleaner
+  alias Electric.Replication.LogOffset
+
+  @stub_inspector Support.StubInspector.new(
+                    tables: [{1, {"public", "items"}}],
+                    columns: [
+                      %{name: "id", type: "text", type_id: {25, 1}, is_generated: false},
+                      %{name: "value", type: "text", type_id: {25, 1}, is_generated: false}
+                    ]
+                  )
+
+  @shape Electric.Shapes.Shape.new!("items", inspector: @stub_inspector)
+  @zero_offset LogOffset.last_before_real_offsets()
+  @moduletag :tmp_dir
+
+  setup :verify_on_exit!
+
+  # Provide an inspector for downstream setup helpers (shape log collector, etc.)
+  setup do
+    %{inspector: @stub_inspector}
+  end
+
+  setup [
+    :with_persistent_kv,
+    :with_stack_id_from_test,
+    :with_async_deleter,
+    :with_pure_file_storage,
+    :with_shape_status,
+    :with_status_monitor,
+    :with_shape_monitor,
+    :with_shape_cleaner
+  ]
+
+  describe "remove_shape/2" do
+    setup [
+      :with_log_chunking,
+      :with_registry,
+      :with_shape_log_collector,
+      :with_noop_publication_manager
+    ]
+
+    test "cleans up shape data and rotates the shape handle", ctx do
+      %{shape_cache_opts: opts} =
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+          run_with_conn_fn: &run_with_conn_noop/2,
+          create_snapshot_fn: fn parent, shape_handle, _shape, %{storage: storage} ->
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, {10, 11, [10]}})
+            Storage.make_new_snapshot!([["test"]], storage)
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
+          end
+        )
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+
+      consumer_ref =
+        Electric.Shapes.Consumer.whereis(ctx.stack_id, shape_handle)
+        |> Process.monitor()
+
+      storage = Storage.for_shape(shape_handle, ctx.storage)
+      writer = Storage.init_writer!(storage, @shape)
+
+      Storage.append_to_log!(
+        changes_to_log_items([
+          %Electric.Replication.Changes.NewRecord{
+            relation: {"public", "items"},
+            record: %{"id" => "1", "value" => "Alice"},
+            log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
+          }
+        ]),
+        writer
+      )
+
+      assert Storage.snapshot_started?(storage)
+
+      assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
+               1
+
+      :ok = ShapeCleaner.remove_shape(shape_handle, stack_id: ctx.stack_id)
+
+      assert_receive {:DOWN, ^consumer_ref, :process, _pid, {:shutdown, :cleanup}}
+
+      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle2, opts)
+      assert shape_handle != shape_handle2
+    end
+
+    test "remove_shape swallows error if no shape to clean up", ctx do
+      shape_handle = "foo"
+
+      %{shape_cache_opts: _opts} =
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+          run_with_conn_fn: &run_with_conn_noop/2,
+          create_snapshot_fn: fn parent, shape_handle, _shape, %{storage: storage} ->
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, {10, 11, [10]}})
+            Storage.make_new_snapshot!([["test"]], storage)
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
+          end
+        )
+
+      {:ok, _} =
+        with_log(fn -> ShapeCleaner.remove_shape(shape_handle, stack_id: ctx.stack_id) end)
+    end
+  end
+
+  describe "remove_shapes_for_relations/2" do
+    setup [
+      :with_log_chunking,
+      :with_registry,
+      :with_shape_log_collector,
+      :with_noop_publication_manager
+    ]
+
+    setup ctx do
+      %{shape_cache_opts: opts} =
+        with_shape_cache(Map.merge(ctx, %{pool: nil, inspector: @stub_inspector}),
+          run_with_conn_fn: &run_with_conn_noop/2,
+          create_snapshot_fn: fn parent, shape_handle, _shape, %{storage: storage} ->
+            GenServer.cast(parent, {:pg_snapshot_known, shape_handle, {10, 11, [10]}})
+            Storage.make_new_snapshot!([["test"]], storage)
+            GenServer.cast(parent, {:snapshot_started, shape_handle})
+          end
+        )
+
+      {:ok, %{shape_cache_opts: opts}}
+    end
+
+    test "cleans up shape data for relevant shapes", %{shape_cache_opts: opts} = ctx do
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
+
+      consumer_ref =
+        Electric.Shapes.Consumer.whereis(ctx.stack_id, shape_handle)
+        |> Process.monitor()
+
+      storage = Storage.for_shape(shape_handle, ctx.storage)
+      writer = Storage.init_writer!(storage, @shape)
+
+      Storage.append_to_log!(
+        changes_to_log_items([
+          %Electric.Replication.Changes.NewRecord{
+            relation: {"public", "items"},
+            record: %{"id" => "1", "value" => "Alice"},
+            log_offset: LogOffset.new(Electric.Postgres.Lsn.from_integer(1000), 0)
+          }
+        ]),
+        writer
+      )
+
+      assert Storage.snapshot_started?(storage)
+
+      assert Enum.count(Storage.get_log_stream(LogOffset.last_before_real_offsets(), storage)) ==
+               1
+
+      # Cleaning unrelated relations should not affect the shape
+      :ok =
+        ShapeCleaner.remove_shapes_for_relations(
+          [{@shape.root_table_id + 1, {"public", "different"}}],
+          stack_id: ctx.stack_id
+        )
+
+      refute_receive {:DOWN, ^consumer_ref, :process, _pid, {:shutdown, :cleanup}}, 100
+
+      # Shouldn't raise
+      assert :ok = Stream.run(Storage.get_log_stream(@zero_offset, storage))
+
+      :ok =
+        ShapeCleaner.remove_shapes_for_relations(
+          [{@shape.root_table_id, {"public", "items"}}],
+          stack_id: ctx.stack_id
+        )
+
+      # Allow asynchronous queued removal to complete
+      assert_receive {:DOWN, ^consumer_ref, :process, _pid, {:shutdown, :cleanup}}, 1_000
+
+      {shape_handle2, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+      assert :started = ShapeCache.await_snapshot_start(shape_handle2, opts)
+      assert shape_handle != shape_handle2
+    end
+  end
+
+  def run_with_conn_noop(conn, cb), do: cb.(conn)
+end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -104,6 +104,14 @@ defmodule Support.ComponentSetup do
     %{chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold()}
   end
 
+  def with_shape_cleaner(ctx) do
+    start_link_supervised!(
+      {Electric.Shapes.ShapeCleaner, stack_id: ctx.stack_id, shape_status: ctx.shape_status}
+    )
+
+    %{}
+  end
+
   def with_publication_manager(ctx) do
     server = :"publication_manager_#{full_test_name(ctx)}"
 
@@ -125,9 +133,7 @@ defmodule Support.ComponentSetup do
                 ctx,
                 :configure_tables_for_replication_fn,
                 &Electric.Postgres.Configuration.configure_publication!/4
-              ),
-            shape_cache:
-              Access.get(ctx, :shape_cache, {Electric.ShapeCache, [stack_id: ctx.stack_id]})
+              )
           ]
         ]
       },

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -106,7 +106,7 @@ defmodule Support.ComponentSetup do
 
   def with_shape_cleaner(ctx) do
     start_link_supervised!(
-      {Electric.Shapes.ShapeCleaner, stack_id: ctx.stack_id, shape_status: ctx.shape_status}
+      {Electric.ShapeCache.ShapeCleaner, stack_id: ctx.stack_id, shape_status: ctx.shape_status}
     )
 
     %{}


### PR DESCRIPTION
We had spread out deletions a bit too much over the code base, so this is a first attempt at unifying that again.

The main purpose is to move shape cleaning operations away from `ShapeCache`, and especially `clean_all_shapes_for_relations` which was running in a blocking manner, and on a relation change could affect potentially thousands of shapes and block the critical path unnecessarily.

I've kept the actual cleanup in `Electric.Shapes.Monitor` to avoid making this PR too large, and also because it lives outside of the shape supervision and is thus able to clean up storage even during stack restarts due to connection issues, although I'm not entirely sure that's good as it makes it hard to reason about race conditions (especially with restoring backed up state).

- Now `SchemaReconciler`, `ExpiryManager`, `PublicationManager` and `ShapeCache` all point to the `ShapeCleaner` for both stopping and cleaning shapes.
- The `ShapeCleaner` in turn ensures the shape consumer is dead, and if it is already dead schedules a shape "purging" via the monitor as we are already doing.
- On a sync `remove_shape` call, we immediately remove the shape from shape status if the consumer is already dead - this shouldn't really happen as we should not have a shape withotu a consumer in our index, but it's there for safety.
- On a `remove_shapes_for_relations`, rather than do things synchronously and block the process, removals are queued up and done one by one to allow `remove_shape` calls to be interleaved by the `ExpiryManager` and `ShapeCache`'s failed recoveries and starts.
