### PR TITLE
fix: Set full sentry metadata everywhere

### DIFF
--- a/.changeset/nice-panthers-cheer.md
+++ b/.changeset/nice-panthers-cheer.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Set full sentry metadata everywhere

--- a/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
+++ b/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
@@ -10,6 +10,7 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
 
     def init(stack_id) do
       Logger.metadata(stack_id: stack_id, is_connection_process?: true)
+      Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
       {:ok, []}
     end
 

--- a/packages/sync-service/lib/electric/connection/manager/pool.ex
+++ b/packages/sync-service/lib/electric/connection/manager/pool.ex
@@ -267,11 +267,8 @@ defmodule Electric.Connection.Manager.Pool do
   def configure_pool_conn(opts, supervisor_pid, stack_id) do
     send(supervisor_pid, {:pool_conn_started, self()})
 
-    Logger.metadata(
-      # flag used for error filtering
-      is_connection_process?: true,
-      stack_id: stack_id
-    )
+    Logger.metadata(stack_id: stack_id, is_connection_process?: true)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
 
     # If supervisor process not alive when initializing connection, abort it
     try do

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -173,12 +173,7 @@ defmodule Electric.Postgres.ReplicationClient do
 
     Process.set_label({:replication_client, state.stack_id})
 
-    Logger.metadata(
-      # flag used for error filtering
-      is_connection_process?: true,
-      stack_id: state.stack_id
-    )
-
+    Logger.metadata(stack_id: state.stack_id, is_connection_process?: true)
     Electric.Telemetry.Sentry.set_tags_context(stack_id: state.stack_id)
 
     {:ok, state}

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -151,8 +151,9 @@ defmodule Electric.Replication.PublicationManager do
   def init(opts) do
     opts = Map.new(opts)
 
-    Logger.metadata(stack_id: opts.stack_id)
     Process.set_label({:publication_manager, opts.stack_id})
+    Logger.metadata(stack_id: opts.stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts.stack_id)
 
     state = %__MODULE__{
       stack_id: opts.stack_id,

--- a/packages/sync-service/lib/electric/replication/schema_reconciler.ex
+++ b/packages/sync-service/lib/electric/replication/schema_reconciler.ex
@@ -48,6 +48,8 @@ defmodule Electric.Replication.SchemaReconciler do
   def init(opts) do
     Process.set_label({:schema_reconciler, opts.stack_id})
     Logger.metadata(stack_id: opts.stack_id)
+    Electric.Telemetry.Sentry.set_tags_context(stack_id: opts.stack_id)
+
     Logger.debug("SchemaReconciler started with state #{inspect(opts)}")
     {:ok, opts, {:continue, :reconcile}}
   end

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -72,6 +72,7 @@ defmodule Electric.Shapes.Consumer.Materializer do
     Process.set_label({:materializer, shape_handle})
     metadata = [stack_id: stack_id, shape_handle: shape_handle]
     Logger.metadata(metadata)
+    Electric.Telemetry.Sentry.set_tags_context(metadata)
 
     state =
       Map.merge(opts, %{

--- a/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/monitor/cleanup_task_supervisor.ex
@@ -41,19 +41,19 @@ defmodule Electric.Shapes.Monitor.CleanupTaskSupervisor do
 
           task1 =
             Task.Supervisor.async(name(stack_id), fn ->
-              Logger.metadata(stack_id: stack_id, shape_handle: shape_handle)
+              set_task_metadata(stack_id, shape_handle)
               cleanup_shape_status(shape_status_impl, shape_handle)
             end)
 
           task2 =
             Task.Supervisor.async(name(stack_id), fn ->
-              Logger.metadata(stack_id: stack_id, shape_handle: shape_handle)
+              set_task_metadata(stack_id, shape_handle)
               cleanup_storage(storage_impl, shape_handle)
             end)
 
           task3 =
             Task.Supervisor.async(name(stack_id), fn ->
-              Logger.metadata(stack_id: stack_id, shape_handle: shape_handle)
+              set_task_metadata(stack_id, shape_handle)
               cleanup_publication_manager(publication_manager_impl, shape_handle)
             end)
 
@@ -113,6 +113,12 @@ defmodule Electric.Shapes.Monitor.CleanupTaskSupervisor do
       end,
       "Failed to remove shape #{shape_handle} from publication"
     )
+  end
+
+  defp set_task_metadata(stack_id, shape_handle) do
+    metadata = [stack_id: stack_id, shape_handle: shape_handle]
+    Logger.metadata(metadata)
+    Electric.Telemetry.Sentry.set_tags_context(metadata)
   end
 
   defp perform_reporting_errors(fun, message) do


### PR DESCRIPTION
We are missing some tags on sentry in some places making it harder to debug.