### PR TITLE
fix: Prevent race between shape adding and removing

### DIFF
--- a/.changeset/modern-chairs-speak.md
+++ b/.changeset/modern-chairs-speak.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix race condition between removing and adding new shapes concurrently that led to crashes.

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -190,10 +190,14 @@ defmodule Electric.ShapeCache.ShapeStatus do
           @shape_meta_shape_pos
         )
 
+      # Always delete the hash lookup first, so that we guarantee that no shape spec
+      # is ever matched to a handle with incomplete information, since deleting with
+      # select_delete can lead to inconsistent state
+      :ets.delete(state.shape_meta_table, {@shape_hash_lookup, Shape.comparable(shape)})
+
       :ets.select_delete(
         state.shape_meta_table,
         [
-          {{{@shape_meta_data, shape_handle}, :_, :_, :_}, [], [true]},
           {{{@shape_hash_lookup, Shape.comparable(shape)}, shape_handle}, [], [true]},
           {{{@shape_storage_state_backup, shape_handle}, :_}, [], [true]},
           {{{@snapshot_started, shape_handle}, :_}, [], [true]}

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -198,7 +198,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
       :ets.select_delete(
         state.shape_meta_table,
         [
-          {{{@shape_hash_lookup, Shape.comparable(shape)}, shape_handle}, [], [true]},
+          {{{@shape_meta_data, shape_handle}, :_, :_, :_}, [], [true]},
           {{{@shape_storage_state_backup, shape_handle}, :_}, [], [true]},
           {{{@snapshot_started, shape_handle}, :_}, [], [true]}
           | Enum.map(Shape.list_relations(shape), fn {oid, _} ->
@@ -231,12 +231,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
         nil
 
       shape_handle when is_binary(shape_handle) ->
-        try do
-          {shape_handle, latest_offset!(meta_table, shape_handle)}
-        rescue
-          ArgumentError ->
-            nil
-        end
+        {shape_handle, latest_offset!(meta_table, shape_handle)}
     end
   end
 

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -10,9 +10,13 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
 
   setup :verify_on_exit!
 
-  defp shape! do
-    assert {:ok, %Shape{where: %{query: "value = 'test'"}} = shape} =
-             Shape.new("other_table", inspector: {__MODULE__, []}, where: "value = 'test'")
+  defp shape!, do: shape!("test")
+
+  defp shape!(val) do
+    where = "value = '#{val}'"
+
+    assert {:ok, %Shape{where: %{query: ^where}} = shape} =
+             Shape.new("other_table", inspector: {__MODULE__, []}, where: where)
 
     shape
   end
@@ -272,6 +276,48 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
       ShapeStatus.remove_shape(state, shape2)
 
       assert [] == ShapeStatus.least_recently_used(state, _count = 1)
+    end
+  end
+
+  describe "high concurrency" do
+    @num_shapes_to_seed 10_000
+    setup ctx do
+      {:ok, state, []} = new_state(ctx)
+
+      for i <- 1..@num_shapes_to_seed do
+        ShapeStatus.add_shape(state, shape!("seed_#{i}"))
+      end
+
+      {:ok, state: state}
+    end
+
+    test "add and delete of the same shape should never fail", ctx do
+      %{state: state} = ctx
+
+      shape = shape!()
+      ShapeStatus.add_shape(state, shape)
+
+      add_task =
+        Task.async(fn ->
+          for _ <- 1..100 do
+            case ShapeStatus.get_existing_shape(state, shape) do
+              nil -> ShapeStatus.add_shape(state, shape)
+              _ -> :ok
+            end
+          end
+        end)
+
+      remove_tasks =
+        for _ <- 1..100 do
+          Task.async(fn ->
+            case ShapeStatus.get_existing_shape(state, shape) do
+              nil -> :ok
+              {handle, _} -> ShapeStatus.remove_shape(state, handle)
+            end
+          end)
+        end
+
+      Task.await_many([add_task | remove_tasks], 20_000)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/3173

Our `remove_shape` call uses a `select_delete` to remove all relevant records from the table for a given shape.

Because `select_delete` does a traversal and does not guarantee that concurrent operations won't see mixed results during it (i.e. it is not atomic and isolated), we ran into the following scenario:

1. We check `get_existing_shape` to determine whether a handle exists for a given shape spec
2. That checks the `shape -> handle` lookup, which returned a handle
3. That _subsequently_ checks the `handle -> metadata` lookup for the latest offset on the shape, which returns nil
4. The overall `get_existing_shape` call returns nil (assuming that if anything is missing, all records are missing)
5. We get to `add_shape` which expects `:ets.insert_new` to succeed for the entry to the `shape -> handle` lookup
6. The operation fails as the `shape -> handle` lookup entry is still present (see step 2)

I've opted for the following solution:
- In `remove_shape`, ensure the `shape -> handle` lookup entry gets deleted _first_, as it is the pointer from a shape def to any existing shapes.
  - The shape cleanup can be delayed (similarly for the files as well), but the first thing that needs to happen is to "deprecate" it such that the shape spec is no longer pointing to its handle
- In `get_existing_shape`, rather than swallowing the error in case the `shape -> handle` entry is present, but the `handle -> metadata` entry is not, I'm asserting that it _should_ be present.
  - The swallowing of the error in that call was essentially what was causing this race silently
  - An alternative solution would have been for `get_existing_shape` to call itself recursively until it returns a consistent result, but I thought that would be disgusting. 