### PR TITLE
fix: Handle connection not available error from inspector correctly

### DIFF
--- a/.changeset/small-insects-relate.md
+++ b/.changeset/small-insects-relate.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Handle connection unavailable in inspector when validating requests

--- a/packages/sync-service/lib/electric/postgres/inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector.ex
@@ -29,13 +29,19 @@ defmodule Electric.Postgres.Inspector do
         }
 
   @callback load_relation_oid(relation(), opts :: term()) ::
-              {:ok, Electric.oid_relation()} | :table_not_found | {:error, String.t()}
+              {:ok, Electric.oid_relation()}
+              | :table_not_found
+              | {:error, String.t() | :connection_not_available}
 
   @callback load_relation_info(relation_id(), opts :: term()) ::
-              {:ok, relation_info()} | :table_not_found | {:error, String.t()}
+              {:ok, relation_info()}
+              | :table_not_found
+              | {:error, String.t() | :connection_not_available}
 
   @callback load_column_info(relation_id(), opts :: term()) ::
-              {:ok, [column_info()]} | :table_not_found | {:error, String.t()}
+              {:ok, [column_info()]}
+              | :table_not_found
+              | {:error, String.t() | :connection_not_available}
 
   @callback clean(relation_id(), opts :: term()) :: :ok
 
@@ -51,7 +57,9 @@ defmodule Electric.Postgres.Inspector do
   Table name is expected to have been normalized beforehand
   """
   @spec load_relation_oid(relation(), inspector()) ::
-          {:ok, Electric.oid_relation()} | :table_not_found | {:error, String.t()}
+          {:ok, Electric.oid_relation()}
+          | :table_not_found
+          | {:error, String.t() | :connection_not_available}
 
   def load_relation_oid(relation, {module, opts}) when is_relation(relation) do
     module.load_relation_oid(relation, opts)
@@ -64,7 +72,9 @@ defmodule Electric.Postgres.Inspector do
   and other metadata.
   """
   @spec load_relation_info(relation_id(), inspector()) ::
-          {:ok, relation_info()} | :table_not_found | {:error, String.t()}
+          {:ok, relation_info()}
+          | :table_not_found
+          | {:error, String.t() | :connection_not_available}
 
   def load_relation_info(relation_id, {module, opts}) when is_relation_id(relation_id) do
     module.load_relation_info(relation_id, opts)
@@ -74,7 +84,9 @@ defmodule Electric.Postgres.Inspector do
   Load column information about a given table using a provided inspector.
   """
   @spec load_column_info(relation_id(), inspector()) ::
-          {:ok, [column_info()]} | :table_not_found | {:error, String.t()}
+          {:ok, [column_info()]}
+          | :table_not_found
+          | {:error, String.t() | :connection_not_available}
   def load_column_info(relation_id, {module, opts}) when is_relation_id(relation_id) do
     module.load_column_info(relation_id, opts)
   end

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -35,7 +35,9 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
   This is an internal function meant to be used by the wrapping caching inspector.
   """
   @spec normalize_and_load_relation_info(Electric.relation(), conn :: Postgrex.conn()) ::
-          {:ok, Inspector.relation_info()} | :table_not_found | {:error, String.t()}
+          {:ok, Inspector.relation_info()}
+          | :table_not_found
+          | {:error, String.t() | :connection_not_available}
   def normalize_and_load_relation_info({schema, table}, conn) do
     query = load_relation_query(@oid_from_schema_table_name_subquery)
 
@@ -53,7 +55,9 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
 
   @impl Electric.Postgres.Inspector
   @spec load_relation_info(Electric.relation_id(), conn :: Postgrex.conn()) ::
-          {:ok, Inspector.relation_info()} | :table_not_found | {:error, String.t()}
+          {:ok, Inspector.relation_info()}
+          | :table_not_found
+          | {:error, String.t() | :connection_not_available}
   def load_relation_info(oid, conn) when is_relation_id(oid) do
     query = load_relation_query("$1::oid")
 
@@ -162,7 +166,9 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
   """
   @impl Electric.Postgres.Inspector
   @spec load_column_info(Electric.relation_id(), conn :: Postgrex.conn()) ::
-          {:ok, [Inspector.column_info()]} | :table_not_found | {:error, String.t()}
+          {:ok, [Inspector.column_info()]}
+          | :table_not_found
+          | {:error, String.t() | :connection_not_available}
   def load_column_info(relation_id, conn) when is_relation_id(relation_id) do
     query = """
     #{@column_info_query_base}

--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -101,6 +101,8 @@ defmodule Electric.Shapes.Api.Params do
     |> cast(params, __schema__(:fields) -- [:shape_definition])
   end
 
+  defp convert_error({:ok, params}, _api), do: {:ok, params}
+
   defp convert_error({:error, changeset}, api) do
     reason =
       traverse_errors(changeset, fn {msg, opts} ->

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -185,7 +185,7 @@ defmodule Electric.Replication.PublicationManagerTest do
       refute_receive :task2_done, 0
 
       assert_receive :task1_done
-      assert_receive :task2_done, 0
+      assert_receive :task2_done, 10
       assert_receive {:filters, []}
       refute_receive {:filters, _}, 200
     end

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -92,12 +92,12 @@ defmodule Electric.Replication.PublicationManagerTest do
       end)
 
       refute_receive :task1_done, 50
-      refute_received {:filters, _}
-      refute_received :task2_done
+      refute_receive {:filters, _}, 0
+      refute_receive :task2_done, 0
 
       assert_receive :task1_done
-      assert_received :task2_done
-      assert_received {:filters, [{_, {"public", "items"}}]}
+      assert_receive :task2_done, 10
+      assert_receive {:filters, [{_, {"public", "items"}}]}, 10
       refute_receive {:filters, _}, 200
     end
 

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -137,6 +137,18 @@ defmodule Electric.Shapes.ApiTest do
              }
     end
 
+    test "returns error when connection not available to parse schema", ctx do
+      api = Map.put(ctx.api, :inspector, Support.StubInspector.no_conn())
+
+      assert {:error, %{status: 503} = response} =
+               Api.validate(api, %{table: "public.users", offset: "-1"})
+
+      assert response_body(response) == %{
+               message:
+                 "Cannot connect to the database to verify the shape. Please try again later."
+             }
+    end
+
     test "returns error for missing shape_handle when offset != -1", ctx do
       assert {:error, %{status: 400} = response} =
                Api.validate(

--- a/packages/sync-service/test/support/stub_inspector.ex
+++ b/packages/sync-service/test/support/stub_inspector.ex
@@ -50,6 +50,8 @@ defmodule Support.StubInspector do
     {__MODULE__, {Map.new(relation_to_oid), Map.new(info)}}
   end
 
+  def no_conn(), do: {__MODULE__, :no_conn}
+
   defp normalize_oid_relation(oid_relation) when is_oid_relation(oid_relation) do
     oid_relation
   end
@@ -69,6 +71,10 @@ defmodule Support.StubInspector do
   defp get_column_info(column_list) when is_list(column_list), do: column_list
 
   @impl true
+  def load_relation_oid(_, :no_conn) do
+    {:error, :connection_not_available}
+  end
+
   def load_relation_oid(relation, {relation_to_oid, _}) when is_relation(relation) do
     case Map.fetch(relation_to_oid, relation) do
       {:ok, oid} -> {:ok, {oid, relation}}
@@ -77,6 +83,10 @@ defmodule Support.StubInspector do
   end
 
   @impl true
+  def load_column_info(_, :no_conn) do
+    {:error, :connection_not_available}
+  end
+
   def load_column_info(oid, {_, info}) when is_relation_id(oid) when is_map_key(info, oid) do
     info[oid].columns
     |> Enum.map(fn column ->
@@ -91,6 +101,10 @@ defmodule Support.StubInspector do
   end
 
   @impl true
+  def load_relation_info(_, :no_conn) do
+    {:error, :connection_not_available}
+  end
+
   def load_relation_info(oid, {_, info}) when is_relation_id(oid) and is_map_key(info, oid) do
     {:ok, info[oid].relation}
   end


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/3175

I'm not super familiar with Ecto so I tried to stay as close to the end of the pipeline as possible for this.

I don't love that the inspector returns an `:ok` tuple _or_ a `:table_not_found` _or_ and `:error` tuple - either the table not found error should be in the error tuple or `connection_not_available` should not be in one - but we can fix with a subsequent PR.

Happy to accept feedback or direct fixes on this PR, just want to fix this error asap.