### PR TITLE
fix(sync-service): Properly handle File.Errors

### DIFF
--- a/.changeset/forty-meals-greet.md
+++ b/.changeset/forty-meals-greet.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Correctly wrap filesystem errors from the snapshot process

--- a/packages/sync-service/lib/electric/snapshot_error.ex
+++ b/packages/sync-service/lib/electric/snapshot_error.ex
@@ -78,12 +78,20 @@ defmodule Electric.SnapshotError do
     }
   end
 
+  def from_error(%File.Error{} = error) do
+    %SnapshotError{
+      type: :storage,
+      message: Exception.message(error),
+      original_error: error
+    }
+  end
+
   def from_error(%SnapshotError{} = error), do: error
 
   def from_error(error) do
     %SnapshotError{
       type: :unknown,
-      message: error.message,
+      message: Exception.message(error),
       original_error: error
     }
   end

--- a/packages/sync-service/test/electric/snapshot_error_test.exs
+++ b/packages/sync-service/test/electric/snapshot_error_test.exs
@@ -100,5 +100,35 @@ defmodule Electric.SnapshotErrorTest do
                original_error: ^error
              } = SnapshotError.from_error(error)
     end
+
+    test "with a File.Error" do
+      error = %File.Error{
+        reason: :eexist,
+        path: "./persistent/shapes/single_stack/49493699-17",
+        action: "open"
+      }
+
+      assert %SnapshotError{
+               type: :storage,
+               message:
+                 "could not open \"./persistent/shapes/single_stack/49493699-17\": file already exists",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
+
+    defmodule MyError do
+      defexception [:reason]
+      def message(%{reason: reason}), do: "exception due to: #{reason}"
+    end
+
+    test "with any exception" do
+      error = %MyError{reason: "belief"}
+
+      assert %SnapshotError{
+               type: :unknown,
+               message: "exception due to: belief",
+               original_error: ^error
+             } = SnapshotError.from_error(error)
+    end
   end
 end


### PR DESCRIPTION
And make sure that other generic exceptions don't cause problems either.

Seen in production during stack restarts:
https://ui.honeycomb.io/electric-sql-06/environments/production/result/boxnGdBAn2m?expd_col=_hny.ts&expd_fwd=false&expd_id=HM9kS5fdfv9&expd_page=25&tab=explore