### PR TITLE
fix: Amend raise in existing shape race

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -227,11 +227,8 @@ defmodule Electric.ShapeCache.ShapeStatus do
 
   def get_existing_shape(meta_table, %Shape{} = shape) do
     case :ets.lookup_element(meta_table, {@shape_hash_lookup, Shape.comparable(shape)}, 2, nil) do
-      nil ->
-        nil
-
-      shape_handle when is_binary(shape_handle) ->
-        {shape_handle, latest_offset!(meta_table, shape_handle)}
+      nil -> nil
+      shape_handle when is_binary(shape_handle) -> get_existing_shape(meta_table, shape_handle)
     end
   end
 


### PR DESCRIPTION
Small amendment to https://github.com/electric-sql/electric/pull/3174 (no changeset added)

I had argued that we should raise if we find the (a) `shape -> handle` lookup but not the (b) `handle -> metadata` lookup in `get_existing_shape` - but with the fix I did to the raise the only guarantee is that if we find (a) but not (b), we know that (a) has been cleaned up (which wasn't the case before).

Scenario calling `get_existing_shape`:
1. `shape -> handle` exists, so we go to the offset lookup (`handle -> metadata`)
2. Before offset lookup is made, `remove_shape` is called
3a. Only `shape -> handle` is cleaned up before the offset lookup, so offset is found and shape is returned (all good)
3b. Both `shape -> handle` and `handle -> metadata` are cleaned up before offset lookup, so offset lookup _raises_ (not good)

For case (3b), since we now guarantee that if `handle -> metadata` is missing, then `shape -> handle` has already been deleted, we can safely restore the semantics in `get_existing_shape` we had that basically asserted that, without having the risk of a raise because of a race.

## Analysis of `get_existing_shape`
(a) `shape -> handle`
(b) `handle -> metadata` (always after (a))
(c) `del shape -> handle`
(d) `del handle -> metadata` (always after (c))

- (a) -> (b) [-> (c) -> (d), irrelevant]: returns shape ✅ 
- (a) -> (c) -> (b) [-> (d), irrelevant]: returns shape ✅ 
- (a) -> (c) -> (d) -> (b): raises ❌, this PR fixes it to return no shape ✅ 
- (c) -> (d) -> (a): returns no shape ✅ 
- (c) -> (a): returns no shape ✅


## Notes
This race is extremely unlikely to happen so even the high concurrency test is not running into it, but I'd rather rely on things making sense than wait for even higher concurrency scenarios to reveal it.