### PR TITLE
Partition DynamicConsumerSupervisor to improve startup and shutdown times

### DIFF
--- a/.changeset/many-pears-smell.md
+++ b/.changeset/many-pears-smell.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Improve startup and shutdown times for shape processes by partitioning DynamicConsumerSupervisor.

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -53,8 +53,7 @@ defmodule Electric.Connection.Manager.Supervisor do
       {Electric.ShapeCache.ShapeStatusOwner,
        [stack_id: stack_id, shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)]}
 
-    consumer_supervisor_spec =
-      Electric.Shapes.DynamicConsumerSupervisor.partition_supervisor_spec(stack_id)
+    consumer_supervisor_spec = {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
 
     shape_cleaner_spec =
       {Electric.ShapeCache.ShapeCleaner,

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -53,7 +53,8 @@ defmodule Electric.Connection.Manager.Supervisor do
       {Electric.ShapeCache.ShapeStatusOwner,
        [stack_id: stack_id, shape_status: Keyword.fetch!(shape_cache_opts, :shape_status)]}
 
-    consumer_supervisor_spec = {Electric.Shapes.DynamicConsumerSupervisor, [stack_id: stack_id]}
+    consumer_supervisor_spec =
+      Electric.Shapes.DynamicConsumerSupervisor.partition_supervisor_spec(stack_id)
 
     shape_cleaner_spec =
       {Electric.ShapeCache.ShapeCleaner,

--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -14,8 +14,15 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
 
   The number of dynamic supervisors is equal to the number of CPU cores.
   """
-  def partition_supervisor_spec(stack_id) do
-    {PartitionSupervisor, child_spec: {__MODULE__, [stack_id: stack_id]}, name: name(stack_id)}
+  def child_spec(opts) do
+    stack_id = Keyword.fetch!(opts, :stack_id)
+    name = Keyword.get(opts, :name, name(stack_id))
+
+    # We're overriding Electric.Shapes.DynamicConsumerSupervisor's child_spec() function here
+    # to make the usage of PartitionSupervisor transparent to the callers. As a consequence, we
+    # need to call `super()` to obtain the original DynamicSupervisor child_spec() to pass as an option to
+    # PartitionSupervisor.
+    PartitionSupervisor.child_spec(child_spec: super(opts), name: name)
   end
 
   def name(stack_id) do

--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -8,6 +8,12 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
 
   require Logger
 
+  @doc """
+  Returns a child spec for the PartitionSupervisor that starts a pool of
+  DynamicConsumerSupervisor procecesses to shard child processes across.
+
+  The number of dynamic supervisors is equal to the number of CPU cores.
+  """
   def partition_supervisor_spec(stack_id) do
     {PartitionSupervisor, child_spec: {__MODULE__, [stack_id: stack_id]}, name: name(stack_id)}
   end
@@ -16,6 +22,8 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
     Electric.ProcessRegistry.name(stack_id, __MODULE__)
   end
 
+  # This function will be invoked for each dynamic supervisor process in PartitionSupervisor's
+  # pool, so we keep these processes unnamed.
   def start_link(opts) do
     stack_id = Keyword.fetch!(opts, :stack_id)
     DynamicSupervisor.start_link(__MODULE__, stack_id: stack_id)
@@ -24,6 +32,10 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
   def start_shape_consumer(name, config) do
     Logger.debug(fn -> "Starting consumer for #{Keyword.fetch!(config, :shape_handle)}" end)
 
+    # Use a random integer as the routing key to achieve balanced sharding of child processes
+    # across all dynamic supervisors. The top limit for the key is picked to future-proof it
+    # for cases where Electric runs on a CPU with many cores. 256 should be sufficient for the
+    # foreseeable future.
     key = :rand.uniform(256)
 
     DynamicSupervisor.start_child(

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -204,15 +204,10 @@ defmodule Support.ComponentSetup do
       |> Keyword.merge(additional_opts)
       |> Keyword.merge(Map.get(ctx, :shape_cache_opts_overrides, []))
 
-    start_link_supervised!(%{
-      id: consumer_supervisor,
-      start: {
-        Electric.Shapes.DynamicConsumerSupervisor,
-        :start_link,
-        [[name: consumer_supervisor, stack_id: ctx.stack_id]]
-      },
-      restart: :temporary
-    })
+    {Electric.Shapes.DynamicConsumerSupervisor,
+     [name: consumer_supervisor, stack_id: ctx.stack_id]}
+    |> Supervisor.child_spec(id: consumer_supervisor, restart: :temporary)
+    |> start_link_supervised!()
 
     start_link_supervised!(%{
       id: start_opts[:name],


### PR DESCRIPTION
This adds a supervisor layer where a `PartitionSupervisor` now carries the `DynamicConsumerSupervisor.name(stack_id)` name and it starts a number of `DynamicConsumerSupervisor` processes to shard load between them. This change is transparent for the rest of the code that uses `DynamicConsumerSupervisor`'s public API.

I've done some measurements by repeatedly starting Electric, waiting for it to start all consumer processes for 50K shapes, then terminating it with the `SIGTERM` signal. I have done 5 attempts for the current implementation in `main` and for this PR, measuring both the startup and shutdown time.

|  | Attempt 1 | Attempt 2 | Attempt 3 | Attempt 4 | Attempt 5 |
| --- | --- | --- | --- | --- | --- |
| PartitionSupervisor startup | 28.8s | 12.5s | 11.8s | 11.0s | 11.8s |
| DynamicSupervisor startup | 20.6s | 20.0s | 20.0s | 19.7s | 20.5s |

|  | Attempt 1 | Attempt 2 | Attempt 3 | Attempt 4 |
| --- | --- | --- | --- | --- |
| PartitionSupervisor shutdown | 4.8s | 10.1s | 11.0s | 11.0s |
| DynamicSupervisor shutdown | 27.0s | 27.4s | 28.2s | 28.6s |

The 1st attempt can be considered an outlier since timings have become consistent afterwards.

When a PartitionSupervisor is used, all processes shut down within 2-3 seconds and the rest of the shutdown time is dominated by the shape status table backup.