### PR TITLE
fix: Minor publication and connection error changes

### DIFF
--- a/.changeset/empty-spiders-peel.md
+++ b/.changeset/empty-spiders-peel.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Parse pooler login errors as retryable errors and `econnrefused` as retryable.

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -460,7 +460,7 @@ defmodule Electric.DbConnectionError do
           message: "connection refused while trying to connect to #{destination}",
           type: :connection_refused,
           original_error: error,
-          retry_may_fix?: false
+          retry_may_fix?: true
         }
 
       _ ->

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -33,7 +33,6 @@ defmodule Electric.Replication.PublicationManager do
     :db_pool,
     :can_alter_publication?,
     :manual_table_publishing?,
-    :configure_tables_for_replication_fn,
     :publication_refresh_period,
     next_update_forced?: false
   ]
@@ -50,7 +49,6 @@ defmodule Electric.Replication.PublicationManager do
            tracked_shape_handles: %{shape_handle() => Electric.oid_relation()},
            publication_name: String.t(),
            db_pool: term(),
-           configure_tables_for_replication_fn: fun(),
            publication_refresh_period: non_neg_integer(),
            next_update_forced?: boolean()
          }
@@ -74,11 +72,6 @@ defmodule Electric.Replication.PublicationManager do
             can_alter_publication?: [type: :boolean, required: false, default: true],
             manual_table_publishing?: [type: :boolean, required: false, default: false],
             update_debounce_timeout: [type: :timeout, default: @default_debounce_timeout],
-            configure_tables_for_replication_fn: [
-              type: {:fun, 4},
-              required: false,
-              default: &Configuration.configure_publication!/4
-            ],
             server: [type: :any, required: false],
             refresh_period: [type: :pos_integer, required: false, default: 60_000]
           )
@@ -153,7 +146,6 @@ defmodule Electric.Replication.PublicationManager do
       db_pool: opts.db_pool,
       can_alter_publication?: opts.can_alter_publication?,
       manual_table_publishing?: opts.manual_table_publishing?,
-      configure_tables_for_replication_fn: opts.configure_tables_for_replication_fn,
       publication_refresh_period: opts.refresh_period
     }
 
@@ -388,7 +380,6 @@ defmodule Electric.Replication.PublicationManager do
            prepared_relation_filters: current_filters,
            publication_name: publication_name,
            db_pool: db_pool,
-           configure_tables_for_replication_fn: configure_tables_for_replication_fn,
            next_update_forced?: forced?
          } = state
        ) do
@@ -400,7 +391,7 @@ defmodule Electric.Replication.PublicationManager do
     else
       try do
         missing_relations =
-          configure_tables_for_replication_fn.(
+          Configuration.configure_publication!(
             db_pool,
             committed_filters,
             current_filters,

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -40,7 +40,7 @@ defmodule Electric.Replication.PublicationManager do
 
   @type relation_filters() :: MapSet.t(Electric.oid_relation())
   @typep state() :: %__MODULE__{
-           stack_id: Electric.ShapeCacheBehaviour.stack_id(),
+           stack_id: Electric.stack_id(),
            relation_ref_counts: %{Electric.oid_relation() => non_neg_integer()},
            prepared_relation_filters: relation_filters(),
            committed_relation_filters: relation_filters(),

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -360,7 +360,7 @@ defmodule Electric.DbConnectionErrorTest do
                message: "connection refused while trying to connect to localhost:54321",
                type: :connection_refused,
                original_error: error,
-               retry_may_fix?: false
+               retry_may_fix?: true
              } == DbConnectionError.from_error(error)
     end
 

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -411,6 +411,29 @@ defmodule Electric.DbConnectionErrorTest do
              } == DbConnectionError.from_error(error)
     end
 
+    test "with pooler login failed error" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :internal_error,
+          message:
+            "server login has been failing, cached error: connect failed (server_login_retry)",
+          severity: "ERROR",
+          pg_code: "XX000"
+        },
+        connection_id: nil,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message:
+                 "server login has been failing, cached error: connect failed (server_login_retry)",
+               type: :pooler_login_failed,
+               original_error: error,
+               retry_may_fix?: true
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with an unknown error" do
       error = %DBConnection.ConnectionError{
         message: "made-up error",

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -121,13 +121,7 @@ defmodule Support.ComponentSetup do
             publication_name: ctx.publication_name,
             update_debounce_timeout: Access.get(ctx, :update_debounce_timeout, 0),
             db_pool: ctx.pool,
-            manual_table_publishing?: Access.get(ctx, :manual_table_publishing?, false),
-            configure_tables_for_replication_fn:
-              Access.get(
-                ctx,
-                :configure_tables_for_replication_fn,
-                &Electric.Postgres.Configuration.configure_publication!/4
-              )
+            manual_table_publishing?: Access.get(ctx, :manual_table_publishing?, false)
           ]
         ]
       },


### PR DESCRIPTION
- make `econnrefused` a retryable error, server might be overloaded, temporarily not running, we should not be shutting down so eagerly
- parse server login failures by poolers and make them retryable (currently only [this pgbouncer error](https://electricsql-04.sentry.io/issues/66120509/?environment=production&project=4508410462404688&query=is%3Aunresolved&referrer=issue-stream) captures but we can add more if we see them
- Remove dependency injection from pubman since we were already referencing `Configuration` module for manual publication updates - we use Repatch in tests instead.
- Fix type