### PR TITLE
fix(elixir-client): Add support for new snapshot-end control to elixir client

### DIFF
--- a/.changeset/seven-tomatoes-jam.md
+++ b/.changeset/seven-tomatoes-jam.md
@@ -1,0 +1,5 @@
+---
+"@core/elixir-client": patch
+---
+
+Add support for new snapshot-end control to elixir client

--- a/packages/elixir-client/lib/electric/client/message.ex
+++ b/packages/elixir-client/lib/electric/client/message.ex
@@ -78,6 +78,7 @@ defmodule Electric.Client.Message do
 
     defp control_atom("must-refetch"), do: :must_refetch
     defp control_atom("up-to-date"), do: :up_to_date
+    defp control_atom("snapshot-end"), do: :snapshot_end
     defp control_atom(a) when is_atom(a), do: a
 
     defp global_last_seen_lsn(headers) do

--- a/packages/elixir-client/lib/electric/client/stream.ex
+++ b/packages/elixir-client/lib/electric/client/stream.ex
@@ -216,6 +216,10 @@ defmodule Electric.Client.Stream do
     handle_up_to_date(%{stream | buffer: :queue.in(msg, stream.buffer), up_to_date?: true})
   end
 
+  defp handle_msg(%Message.ControlMessage{control: :snapshot_end} = msg, stream) do
+    {:cont, stream}
+  end
+
   defp handle_msg(%Message.ChangeMessage{} = msg, stream) do
     {:cont, %{stream | buffer: :queue.in(msg, stream.buffer)}}
   end

--- a/packages/elixir-client/lib/electric/client/stream.ex
+++ b/packages/elixir-client/lib/electric/client/stream.ex
@@ -216,7 +216,7 @@ defmodule Electric.Client.Stream do
     handle_up_to_date(%{stream | buffer: :queue.in(msg, stream.buffer), up_to_date?: true})
   end
 
-  defp handle_msg(%Message.ControlMessage{control: :snapshot_end} = msg, stream) do
+  defp handle_msg(%Message.ControlMessage{control: :snapshot_end} = _msg, stream) do
     {:cont, stream}
   end
 

--- a/packages/elixir-client/test/electric/client/message_test.exs
+++ b/packages/elixir-client/test/electric/client/message_test.exs
@@ -1,0 +1,32 @@
+defmodule Electric.Client.MessageTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Client.Message
+  alias Electric.Client.Message.ControlMessage
+
+  describe "ControlMessage" do
+    test "up-to-date" do
+      assert [%ControlMessage{control: :up_to_date}] =
+               Message.parse(%{"headers" => %{"control" => "up-to-date"}}, "handle", & &1)
+
+      assert [%ControlMessage{control: :up_to_date}] =
+               Message.parse(%{headers: %{control: "up-to-date"}}, "handle", & &1)
+    end
+
+    test "must-refetch" do
+      assert [%ControlMessage{control: :must_refetch}] =
+               Message.parse(%{"headers" => %{"control" => "must-refetch"}}, "handle", & &1)
+
+      assert [%ControlMessage{control: :must_refetch}] =
+               Message.parse(%{headers: %{control: "must-refetch"}}, "handle", & &1)
+    end
+
+    test "snapshot-end" do
+      assert [%ControlMessage{control: :snapshot_end}] =
+               Message.parse(%{"headers" => %{"control" => "snapshot-end"}}, "handle", & &1)
+
+      assert [%ControlMessage{control: :snapshot_end}] =
+               Message.parse(%{headers: %{control: "snapshot-end"}}, "handle", & &1)
+    end
+  end
+end

--- a/packages/elixir-client/test/electric/client_test.exs
+++ b/packages/elixir-client/test/electric/client_test.exs
@@ -628,6 +628,8 @@ defmodule Electric.ClientTest do
             "offset" => "1_0",
             "value" => %{"id" => "1111"}
           },
+          # just put this message in to test handling
+          %{"headers" => %{"control" => "snapshot-end"}},
           %{"headers" => %{"control" => "up-to-date", "global_last_seen_lsn" => 9998}}
         ])
 

--- a/packages/elixir-client/test/support/client_helpers.ex
+++ b/packages/elixir-client/test/support/client_helpers.ex
@@ -15,4 +15,12 @@ defmodule Support.ClientHelpers do
       }
     )
   end
+
+  defmacro snapshot_end(_opts \\ []) do
+    quote do
+      %ControlMessage{
+        control: :snapshot_end
+      }
+    end
+  end
 end


### PR DESCRIPTION
Don't want to bump the electric version requirement here yet