### PR TITLE
fix(sync-service): Add stack canary process to detect shutdown

### DIFF
--- a/.changeset/calm-rockets-glow.md
+++ b/.changeset/calm-rockets-glow.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Detect stack termination and mark as down immediately

--- a/packages/sync-service/lib/electric/replication/supervisor.ex
+++ b/packages/sync-service/lib/electric/replication/supervisor.ex
@@ -59,9 +59,19 @@ defmodule Electric.Replication.Supervisor do
       consumer_supervisor,
       shape_cache,
       expiry_manager,
-      schema_reconciler
+      schema_reconciler,
+      canary_spec(stack_id)
     ]
 
     Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  defp canary_spec(stack_id) do
+    {
+      Agent,
+      fn ->
+        Electric.StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
+      end
+    }
   end
 end

--- a/packages/sync-service/lib/electric/status_monitor.ex
+++ b/packages/sync-service/lib/electric/status_monitor.ex
@@ -9,7 +9,8 @@ defmodule Electric.StatusMonitor do
     :replication_client_ready,
     :admin_connection_pool_ready,
     :snapshot_connection_pool_ready,
-    :shape_log_collector_ready
+    :shape_log_collector_ready,
+    :supervisor_processes_ready
   ]
 
   @default_results for condition <- @conditions, into: %{}, do: {condition, {false, %{}}}
@@ -37,7 +38,8 @@ defmodule Electric.StatusMonitor do
         replication_client_ready: {true, _},
         admin_connection_pool_ready: {true, _},
         snapshot_connection_pool_ready: {true, _},
-        shape_log_collector_ready: {true, _}
+        shape_log_collector_ready: {true, _},
+        supervisor_processes_ready: {true, _}
       } ->
         :active
 
@@ -64,6 +66,10 @@ defmodule Electric.StatusMonitor do
 
   def mark_shape_log_collector_ready(stack_id, collector_pid) do
     mark_condition_met(stack_id, :shape_log_collector_ready, collector_pid)
+  end
+
+  def mark_supervisor_processes_ready(stack_id, canary_pid) do
+    mark_condition_met(stack_id, :supervisor_processes_ready, canary_pid)
   end
 
   def mark_pg_lock_as_errored(stack_id, message) when is_binary(message) do
@@ -244,6 +250,9 @@ defmodule Electric.StatusMonitor do
 
       %{shape_log_collector_ready: {false, details}} ->
         "Timeout waiting for shape data to be loaded" <> format_details(details)
+
+      %{supervisor_processes_ready: {false, details}} ->
+        "Timeout waiting for stack restart" <> format_details(details)
     end
   end
 

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -182,6 +182,26 @@ defmodule Electric.Connection.ConnectionManagerTest do
 
       assert StatusMonitor.status(stack_id) in [:waiting, :starting]
     end
+
+    test "backtracks the status when the canary goes down", %{stack_id: stack_id} do
+      wait_until_active(stack_id)
+
+      # should backtrack the status by virtue of the shape log collector being shut down
+      # by the replication supervisor
+      monitor =
+        stack_id
+        |> Electric.Replication.Supervisor.canary_name()
+        |> GenServer.whereis()
+        |> Process.monitor()
+
+      :ok = GenServer.stop(Electric.Replication.Supervisor.canary_name(stack_id), :shutdown)
+
+      assert_receive {:DOWN, ^monitor, :process, _pid, :shutdown}
+
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      assert StatusMonitor.status(stack_id) in [:waiting, :starting]
+    end
   end
 
   describe "process dependencies" do

--- a/packages/sync-service/test/electric/status_monitor_test.exs
+++ b/packages/sync-service/test/electric/status_monitor_test.exs
@@ -29,6 +29,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
+      StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
       assert StatusMonitor.status(stack_id) == :active
     end
@@ -39,6 +40,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
+      StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
       assert StatusMonitor.status(stack_id) == :starting
     end
@@ -48,6 +50,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_pg_lock_acquired(stack_id, self())
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
+      StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
       assert StatusMonitor.status(stack_id) == :starting
     end
@@ -58,6 +61,18 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
       StatusMonitor.mark_replication_client_ready(stack_id, self())
+      StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+      assert StatusMonitor.status(stack_id) == :starting
+    end
+
+    test "when canary process not ready returns :starting", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id})
+      StatusMonitor.mark_pg_lock_acquired(stack_id, self())
+      StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
+      StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_replication_client_ready(stack_id, self())
+      StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
       assert StatusMonitor.status(stack_id) == :starting
     end
@@ -87,6 +102,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
+      StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
       assert StatusMonitor.status(stack_id) == :active
 
@@ -117,6 +133,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
 
       refute_receive :active, 20
       assert StatusMonitor.mark_shape_log_collector_ready(stack_id, self()) == :ok

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -74,6 +74,7 @@ defmodule Support.TestUtils do
     Electric.StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
     Electric.StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
     Electric.StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
+    Electric.StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
     Electric.StatusMonitor.wait_for_messages_to_be_processed(stack_id)
   end
 


### PR DESCRIPTION
The last process in a supervisor's children list will be the first to be terminated in a restart. This canary process registers itself with the stack status and any shutdown of the Recplication.Supervisor, either due to a crash or a stack restart, will mark the stack as down immediately.

Seems to prevent a lot of errors on stack termination locally: only active requests raise due to the exit of the "crashed" process rather than every request after the process crash until the consumers have been terminated.

Fixes #3190