### PR TITLE
Test the sync-service with Postgres 18

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -56,10 +56,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # https://github.com/orgs/community/discussions/126453#discussioncomment-11414956
       - name: Set PG settings
         run: |
-          docker exec ${{ job.services.postgres.id }} sh -c 'echo "wal_level=logical" >> /var/lib/postgresql/data/postgresql.conf'
-          docker exec ${{ job.services.postgres.id }} sh -c 'echo "max_replication_slots=100" >> /var/lib/postgresql/data/postgresql.conf'
+          docker exec ${{ job.services.postgres.id }} sh -c 'psql -U postgres -c "ALTER SYSTEM SET wal_level = '"'"'logical'"'"';"'
+          docker exec ${{ job.services.postgres.id }} sh -c 'psql -U postgres -c "ALTER SYSTEM SET max_replication_slots = 100;"'
           docker restart ${{ job.services.postgres.id }}
 
       - name: Seed the database

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_version: [14, 15, 17]
+        postgres_version: [14, 15, 17, 18]
     env:
       MIX_ENV: test
       POSTGRES_VERSION: "${{ matrix.postgres_version }}0000"

--- a/packages/sync-service/dev/docker-compose.yml
+++ b/packages/sync-service/dev/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/00_shared_init.sql:ro
       - ./reset_wal.sh:/docker-entrypoint-initdb.d/initdb-reset_wal.sh:x
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql
       - /tmp
     entrypoint:
       - docker-entrypoint.sh
@@ -34,7 +34,7 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/00_shared_init.sql:ro
       - ./reset_wal.sh:/docker-entrypoint-initdb.d/initdb-reset_wal.sh:x
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql
       - /tmp
     entrypoint:
       - docker-entrypoint.sh

--- a/scripts/reset_wal.sh
+++ b/scripts/reset_wal.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This script generates a random WAL position and uses pg_resetwal to reset the WAL to that position.
 # This also requires restarting Postgres if ran as an initdb script, which is recommended
 # as it requires appropriate user privileges.
@@ -15,11 +17,11 @@ log_offset=$(printf "%08X" $(( (RANDOM << 17) | (RANDOM << 2) | (RANDOM % 4) )))
 wal_pos=${ELECTRIC_PG_START_WAL:-$(printf "%08X%s%s" $timeline_id $log_segment $log_offset)}
 
 # Stop PostgreSQL to run pg_resetwal
-pg_ctl stop -D /var/lib/postgresql/data
+pg_ctl stop -D $PGDATA
 
 # Run pg_resetwal with the generated LSN
 echo "Resetting WAL to $wal_pos"
-pg_resetwal -l $wal_pos /var/lib/postgresql/data
+pg_resetwal -l $wal_pos $PGDATA
 
 # Restart PostgreSQL
-pg_ctl start -D /var/lib/postgresql/data
+pg_ctl start -D $PGDATA


### PR DESCRIPTION
Starting with Postgres 18, Docker images for it have a new default value for the `PGDATA` environment variable. ([details](https://github.com/docker-library/postgres/pull/1259)).

In this PR I'm removing assumptions about the data directory path so that both CI workflows and local development works with both pre- and post-18 versions of Postgres images.