### PR TITLE
chore(sync-service): Add test that validates consumer remains hibernated

### DIFF
--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -135,7 +135,8 @@ defmodule Electric.Application do
         registry_partitions: get_env(opts, :process_registry_partitions),
         publication_refresh_period: get_env(opts, :publication_refresh_period),
         schema_reconciler_period: get_env(opts, :schema_reconciler_period),
-        cleanup_interval_ms: get_env(opts, :cleanup_interval_ms)
+        cleanup_interval_ms: get_env(opts, :cleanup_interval_ms),
+        shape_hibernate_after: get_env(opts, :shape_hibernate_after)
       ],
       manual_table_publishing?: get_env(opts, :manual_table_publishing?)
     )

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -55,6 +55,10 @@ defmodule Electric.ShapeCache do
             shape_status: [type: :mod_arg, required: true],
             registry: [type: {:or, [:atom, :pid]}, required: true],
             db_pool: [type: {:or, [:atom, :pid, @name_schema_tuple]}],
+            shape_hibernate_after: [
+              type: :integer,
+              default: Electric.Config.default(:shape_hibernate_after)
+            ],
             run_with_conn_fn: [
               type: {:fun, 2},
               default: &Shapes.Consumer.Snapshotter.run_with_conn/2
@@ -234,6 +238,7 @@ defmodule Electric.ShapeCache do
       registry: opts.registry,
       consumer_supervisor: opts.consumer_supervisor,
       subscription: nil,
+      shape_hibernate_after: opts.shape_hibernate_after,
       snapshot_timeout_to_first_data: opts.snapshot_timeout_to_first_data
     }
 
@@ -396,6 +401,7 @@ defmodule Electric.ShapeCache do
            db_pool: state.db_pool,
            run_with_conn_fn: state.run_with_conn_fn,
            create_snapshot_fn: state.create_snapshot_fn,
+           hibernate_after: state.shape_hibernate_after,
            otel_ctx: otel_ctx,
            snapshot_timeout_to_first_data: state.snapshot_timeout_to_first_data
          ) do

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -62,11 +62,7 @@ defmodule Electric.Shapes.Consumer do
   end
 
   def start_link(config) when is_map(config) do
-    GenServer.start_link(
-      __MODULE__,
-      Map.put(config, :hibernate_after, Electric.Config.get_env(:shape_hibernate_after)),
-      name: name(config)
-    )
+    GenServer.start_link(__MODULE__, config, name: name(config))
   end
 
   @impl GenServer

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -27,6 +27,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
               type: {:or, [:non_neg_integer, {:in, [:infinity]}]},
               default: :timer.seconds(30)
             ],
+            hibernate_after: [type: :integer, required: true],
             otel_ctx: [type: :any, required: false]
           )
 

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -112,7 +112,11 @@ defmodule Electric.StackSupervisor do
                        ]
                      ],
                      publication_refresh_period: [type: :non_neg_integer, default: 60_000],
-                     schema_reconciler_period: [type: :non_neg_integer, default: 60_000]
+                     schema_reconciler_period: [type: :non_neg_integer, default: 60_000],
+                     shape_hibernate_after: [
+                       type: :integer,
+                       default: Electric.Config.default(:shape_hibernate_after)
+                     ]
                    ]
                  ],
                  manual_table_publishing?: [
@@ -304,6 +308,8 @@ defmodule Electric.StackSupervisor do
          storage: storage
        )}
 
+    shape_hibernate_after = Keyword.fetch!(config.tweaks, :shape_hibernate_after)
+
     shape_cache_opts = [
       stack_id: stack_id,
       storage: storage,
@@ -313,7 +319,8 @@ defmodule Electric.StackSupervisor do
       chunk_bytes_threshold: config.chunk_bytes_threshold,
       log_producer: shape_log_collector,
       consumer_supervisor: Electric.Shapes.DynamicConsumerSupervisor.name(stack_id),
-      registry: shape_changes_registry_name
+      registry: shape_changes_registry_name,
+      shape_hibernate_after: shape_hibernate_after
     ]
 
     {monitor_opts, tweaks} = Keyword.pop(config.tweaks, :monitor_opts, [])

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -167,6 +167,7 @@ defmodule Electric.Shapes.ConsumerTest do
                registry: registry_name,
                shape_status: {Mock.ShapeStatus, []},
                publication_manager: {Mock.PublicationManager, []},
+               hibernate_after: 1_000,
                storage: storage,
                chunk_bytes_threshold:
                  Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
@@ -696,6 +697,7 @@ defmodule Electric.Shapes.ConsumerTest do
             pool: nil,
             inspector: @base_inspector
           }),
+          shape_hibernate_after: Map.get(ctx, :hibernate_after, 10_000),
           log_producer: ctx.shape_log_collector,
           run_with_conn_fn: &run_with_conn_noop/2,
           create_snapshot_fn: fn parent, shape_handle, _shape, %{storage: storage} ->

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -972,5 +972,47 @@ defmodule Electric.Shapes.ConsumerTest do
       assert_receive {:flush_boundary_updated, 300}, 1_000
       assert_receive {:flush_boundary_updated, 301}, 1_000
     end
+
+    @tag hibernate_after: 1, with_pure_file_storage_opts: [flush_period: 1]
+    test "should hibernate after :hibernate_after ms", ctx do
+      {:via, Registry, {name, key}} = Electric.Postgres.ReplicationClient.name(ctx.stack_id)
+      Registry.register(name, key, nil)
+
+      %{shape_cache_opts: shape_cache_opts} = ctx
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, shape_cache_opts)
+      lsn1 = Lsn.from_integer(300)
+
+      :started = ShapeCache.await_snapshot_start(shape_handle, shape_cache_opts)
+
+      txn =
+        %Transaction{
+          xid: 2,
+          lsn: lsn1,
+          commit_timestamp: DateTime.utc_now()
+        }
+        |> Transaction.prepend_change(%Changes.NewRecord{
+          relation: {"public", "test_table"},
+          record: %{"id" => "21"},
+          log_offset: LogOffset.new(lsn1, 0)
+        })
+        |> Transaction.finalize()
+
+      assert :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
+
+      assert_receive {:flush_boundary_updated, 300}, 1_000
+
+      Process.sleep(20)
+
+      consumer_pid = Consumer.name(ctx.stack_id, shape_handle) |> GenServer.whereis()
+
+      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
+               Process.info(consumer_pid, :current_function)
+
+      Process.sleep(20)
+
+      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
+               Process.info(consumer_pid, :current_function)
+    end
   end
 end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -206,6 +206,7 @@ defmodule Support.ComponentSetup do
         shape_status: ctx.shape_status,
         storage: ctx.storage,
         publication_manager: ctx.publication_manager,
+        shape_hibernate_after: 1_000,
         chunk_bytes_threshold: ctx.chunk_bytes_threshold,
         db_pool: ctx.pool,
         registry: ctx.registry,


### PR DESCRIPTION
As @msfstef pointed out, we didn't have a test for the consumer's hibernation.

This required properly wiring the hibernation timeout through the stack config.

I also took the opportunity to use GenServer's built-in timeout functionality.