### PR TITLE
Msfstef/publication update independent failures

### DIFF
--- a/.changeset/rotten-cows-agree.md
+++ b/.changeset/rotten-cows-agree.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ensure publication update failures only affect relevant shapes

--- a/integration-tests/tests/manual-table-publishing.lux
+++ b/integration-tests/tests/manual-table-publishing.lux
@@ -36,10 +36,10 @@
   # Electric fails to add the table to the publication
   [invoke shape_get_snapshot items]
   ??HTTP/1.1 503
-  ??{"message":"Database table \"public.items\" is missing from the publication and the ELECTRIC_MANUAL_TABLE_PUBLISHING setting prevents Electric from adding it"}
+  ??{"message":"Database table \"public.items\" is missing from the publication \"electric_publication_integration\" and the ELECTRIC_MANUAL_TABLE_PUBLISHING setting prevents Electric from adding it"}
 
 [shell electric]
-  ?\[warning\] Failed to create snapshot for \d+-\d+: Database table \"public.items\" is missing from the publication and the ELECTRIC_MANUAL_TABLE_PUBLISHING setting prevents Electric from adding it
+  ?\[warning\] Failed to create snapshot for \d+-\d+: Database table \"public.items\" is missing from the publication \"electric_publication_integration\" and the ELECTRIC_MANUAL_TABLE_PUBLISHING setting prevents Electric from adding it
 
 ## Add the table to the publication and try again
 [shell psql]

--- a/integration-tests/tests/not-owner-of-the-publication.lux
+++ b/integration-tests/tests/not-owner-of-the-publication.lux
@@ -83,7 +83,7 @@
 
   [invoke shape_get_snapshot items]
   ??HTTP/1.1 503
-  ??{"message":"Database table \"public.items\" is missing from the publication and Electric lacks privileges to add it"}
+  ??{"message":"Database table \"public.items\" is missing from the publication \"electric_publication_integration\" and Electric lacks privileges to add it"}
 
 ## Add the table to the publication and try again
 [shell psql]

--- a/integration-tests/tests/not-owner-of-the-table.lux
+++ b/integration-tests/tests/not-owner-of-the-table.lux
@@ -42,7 +42,7 @@
   -
 
   ??[info] Configuring publication electric_publication_integration to drop [] tables, and add ["public.items"] tables
-  ?\[error\] Failed to configure publication: %Postgrex.Error\{message: nil, postgres: %\{code: :insufficient_privilege,.*message: "must be owner of table items"
+  ?\[warning\] Failed to configure publication for relation \{\d+, \{"public", "items"\}\}: %Postgrex.Error\{message: nil, postgres: %\{code: :insufficient_privilege,.*message: "must be owner of table items"
 
 ## Add the table to the publication and try again
 [shell psql]
@@ -62,15 +62,13 @@
   ??{"message":"Unable to create initial snapshot: must be owner of table items"}
 
 [shell electric]
-	??[info] Altering identity of public.items to FULL
-  ?\[error\] Failed to configure publication: %Postgrex.Error\{message: nil, postgres: %\{code: :insufficient_privilege,.*message: "must be owner of table items"
+	??[info] Configuring publication electric_publication_integration to drop [] tables, and add ["public.items"] tables
+  ?\[warning\] Failed to configure publication for relation \{\d+, \{"public", "items"\}\}: %Postgrex.Error\{message: nil, postgres: %\{code: :insufficient_privilege,.*message: "must be owner of table items"
 
 ## Wait for the publication to be refreshed and verify that the table is removed from it
 [shell electric]
   ??[info] Configuring publication electric_publication_integration to drop ["public.items"] tables, and add [] tables
-
-  # sleep a bit to ensure the publication update completed
-  [sleep 3]
+  ??[debug] Publication configuration committed
 
 [shell psql]
   !SELECT * FROM pg_publication_tables;

--- a/packages/sync-service/lib/electric/db_configuration_error.ex
+++ b/packages/sync-service/lib/electric/db_configuration_error.ex
@@ -1,3 +1,27 @@
 defmodule Electric.DbConfigurationError do
+  alias Electric.Utils
+
   defexception [:type, :message]
+
+  def publication_missing(pub_name) do
+    %Electric.DbConfigurationError{
+      type: :publication_missing,
+      message: "Publication #{Utils.quote_name(pub_name)} not found in the database"
+    }
+  end
+
+  def publication_missing_operations(pub_name) do
+    %Electric.DbConfigurationError{
+      type: :publication_missing_operations,
+      message:
+        "Publication #{Utils.quote_name(pub_name)} does not publish all required operations: INSERT, UPDATE, DELETE, TRUNCATE"
+    }
+  end
+
+  def publication_not_owned(pub_name) do
+    %Electric.DbConfigurationError{
+      type: :publication_not_owned,
+      message: "Publication #{Utils.quote_name(pub_name)} is not owned by the provided user"
+    }
+  end
 end

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -9,13 +9,13 @@ defmodule Electric.Postgres.Configuration do
 
   @type relation_filters :: PublicationManager.relation_filters()
   @type relations_configured :: %{
-          Electric.oid_relation() => :ok | {:error, :relation_invalidated | term()}
+          Electric.oid_relation() => :ok | {:error, :schema_changed | term()}
         }
   @type relations_checked :: %{
           Electric.oid_relation() =>
             :ok
             | {:error,
-               :relation_invalidated
+               :schema_changed
                | :relation_missing_from_publication
                | :misconfigured_replica_identity}
         }
@@ -101,7 +101,7 @@ defmodule Electric.Postgres.Configuration do
         Enum.map(valid, &{&1, :ok}),
         Enum.map(to_add, &{&1, {:error, :relation_missing_from_publication}}),
         Enum.map(to_fix, &{&1, {:error, :misconfigured_replica_identity}}),
-        Enum.map(to_invalidate, &{&1, {:error, :relation_invalidated}})
+        Enum.map(to_invalidate, &{&1, {:error, :schema_changed}})
       ]
       |> List.flatten()
       |> Map.new()
@@ -174,7 +174,7 @@ defmodule Electric.Postgres.Configuration do
         Enum.map(to_add, &{&1, add_table_to_publication(conn, publication_name, &1)})
       )
       |> Enum.concat(Enum.map(valid, &{&1, :ok}))
-      |> Enum.concat(Enum.map(to_invalidate, &{&1, {:error, :relation_invalidated}}))
+      |> Enum.concat(Enum.map(to_invalidate, &{&1, {:error, :schema_changed}}))
       |> Map.new()
 
     configuration_result

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -85,9 +85,9 @@ defmodule Electric.Postgres.Configuration do
   has changed), those will be returned as a list of invalidated relations from this function to
   allow for the cleanup of their corresponding shapes.
   """
-  @spec validate_publication_configuration!(Postgrex.conn(), relation_filters(), String.t()) ::
+  @spec validate_publication_configuration!(Postgrex.conn(), String.t(), relation_filters()) ::
           relations_configured()
-  def validate_publication_configuration!(conn, expected_rels, publication_name) do
+  def validate_publication_configuration!(conn, publication_name, expected_rels) do
     %{
       valid: valid,
       to_add: to_add,

--- a/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
@@ -115,8 +115,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
           Enum.zip(cols, row) |> Map.new()
 
         _ ->
-          raise Electric.DbConfigurationError,
-                "Publication #{Utils.quote_name(state.publication_name)} not found in the database"
+          raise Electric.DbConfigurationError.publication_missing(state.publication_name)
       end
 
     case publication do
@@ -124,8 +123,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
         state
 
       _ ->
-        raise Electric.DbConfigurationError,
-              "Publication #{Utils.quote_name(state.publication_name)} does not publish all required operations: INSERT, UPDATE, DELETE, TRUNCATE"
+        raise Electric.DbConfigurationError.publication_missing_operations(state.publication_name)
     end
   end
 

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -501,13 +501,13 @@ defmodule Electric.Replication.PublicationManager do
     }
   end
 
-  defp publication_error(:relation_invalidated, oid_rel, _state) do
+  defp publication_error(:schema_changed, oid_rel, _state) do
     {_oid, rel} = oid_rel
 
     table = rel |> Utils.relation_to_sql() |> Utils.quote_name()
 
     %Electric.DbConfigurationError{
-      type: :relation_invalidated,
+      type: :schema_changed,
       message: "Database table #{table} has been dropped or renamed"
     }
   end

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -480,7 +480,7 @@ defmodule Electric.Replication.PublicationManager do
       end
 
     {_oid, rel} = oid_rel
-    table = Utils.relation_to_sql(rel)
+    table = rel |> Utils.relation_to_sql() |> Utils.quote_name()
 
     %Electric.DbConfigurationError{
       type: :relation_missing_from_publication,
@@ -493,7 +493,7 @@ defmodule Electric.Replication.PublicationManager do
 
   defp publication_error(:misconfigured_replica_identity, oid_rel, _state) do
     {_oid, rel} = oid_rel
-    table = Utils.relation_to_sql(rel)
+    table = rel |> Utils.relation_to_sql() |> Utils.quote_name()
 
     %Electric.DbConfigurationError{
       type: :misconfigured_replica_identity,
@@ -503,7 +503,8 @@ defmodule Electric.Replication.PublicationManager do
 
   defp publication_error(:relation_invalidated, oid_rel, _state) do
     {_oid, rel} = oid_rel
-    table = Utils.relation_to_sql(rel)
+
+    table = rel |> Utils.relation_to_sql() |> Utils.quote_name()
 
     %Electric.DbConfigurationError{
       type: :relation_invalidated,

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -236,8 +236,8 @@ defmodule Electric.Replication.PublicationManager do
           else
             Configuration.validate_publication_configuration!(
               state.db_pool,
-              state.prepared_relation_filters,
-              state.publication_name
+              state.publication_name,
+              state.prepared_relation_filters
             )
           end
 

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -272,10 +272,6 @@ defmodule Electric.Replication.PublicationManager do
           %{state | committed_relation_filters: new_committed_filters}
 
         {oid_rel, {:error, reason}}, state ->
-          prepared_filters = MapSet.delete(state.prepared_relation_filters, oid_rel)
-          committed_filters = MapSet.delete(state.committed_relation_filters, oid_rel)
-          ShapeCleaner.remove_shapes_for_relations([oid_rel], stack_id: state.stack_id)
-
           error = publication_error(reason, oid_rel, state) || reason
 
           log_level = if is_known_publication_error(error), do: :warning, else: :error
@@ -287,6 +283,10 @@ defmodule Electric.Replication.PublicationManager do
           )
 
           state = reply_to_relation_waiters(oid_rel, {:error, error}, state)
+
+          prepared_filters = MapSet.delete(state.prepared_relation_filters, oid_rel)
+          committed_filters = MapSet.delete(state.committed_relation_filters, oid_rel)
+          ShapeCleaner.remove_shapes_for_relations([oid_rel], stack_id: state.stack_id)
 
           %{
             state

--- a/packages/sync-service/test/electric/plug/low_privilege_router_test.exs
+++ b/packages/sync-service/test/electric/plug/low_privilege_router_test.exs
@@ -48,7 +48,7 @@ defmodule Electric.Plug.LowPrivilegeRouterTest do
       assert {503,
               %{
                 "message" =>
-                  "Database table \"public.items\" is missing from the publication and the ELECTRIC_MANUAL_TABLE_PUBLISHING setting prevents Electric from adding it"
+                  "Database table \"public.items\" is missing from the publication \"#{ctx.publication_name}\" and the ELECTRIC_MANUAL_TABLE_PUBLISHING setting prevents Electric from adding it"
               }} == get_shape(ctx)
 
       Postgrex.query!(ctx.pool, "ALTER PUBLICATION \"#{ctx.publication_name}\" ADD TABLE items")

--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -237,7 +237,7 @@ defmodule Electric.Postgres.ConfigurationTest do
       )
 
       # Adding a new where clause shoudn't re-add the table to the publication but should return that info
-      assert %{oid_rel1 => {:error, :relation_invalidated}} ==
+      assert %{oid_rel1 => {:error, :schema_changed}} ==
                Configuration.configure_publication!(
                  conn,
                  publication,
@@ -355,8 +355,8 @@ defmodule Electric.Postgres.ConfigurationTest do
 
       # Should return invalidated relations
       assert %{
-               oid_rel1 => {:error, :relation_invalidated},
-               oid_rel2 => {:error, :relation_invalidated},
+               oid_rel1 => {:error, :schema_changed},
+               oid_rel2 => {:error, :schema_changed},
                {oid1, {"public", "items_old"}} => :ok
              } ==
                Configuration.validate_publication_configuration!(

--- a/packages/sync-service/test/electric/replication/publication_manager_db_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_db_test.exs
@@ -145,7 +145,7 @@ defmodule Electric.Replication.PublicationManagerDbTest do
       shape_1 = generate_shape(relation_with_oid, @where_clause_1)
 
       assert_raise Electric.DbConfigurationError,
-                   "Database table #{Utils.relation_to_sql(ctx.relation)} is missing from " <>
+                   "Database table #{Utils.relation_to_sql(ctx.relation) |> Utils.quote_name()} is missing from " <>
                      "the publication #{Utils.quote_name(ctx.publication_name)} and " <>
                      "Electric lacks privileges to add it",
                    fn ->

--- a/packages/sync-service/test/electric/replication/publication_manager_manual_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_manual_test.exs
@@ -61,8 +61,8 @@ defmodule Electric.Replication.PublicationManagerManualTest do
       shape = generate_shape(ctx.relation_with_oid)
 
       assert_raise Electric.DbConfigurationError,
-                   "Database table \"public.items\" is missing from the publication and the ELECTRIC_MANUAL_TABLE_PUBLISHING setting " <>
-                     "prevents Electric from adding it",
+                   "Database table \"public.items\" is missing from the publication \"#{ctx.publication_name}\" and " <>
+                     "the ELECTRIC_MANUAL_TABLE_PUBLISHING setting prevents Electric from adding it",
                    fn ->
                      PublicationManager.add_shape(@shape_handle, shape, ctx.pub_mgr_opts)
                    end

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -103,7 +103,7 @@ defmodule Electric.Replication.PublicationManagerTest do
     end
 
     @tag configuration_result_overrides: %{
-           {10, {"public", "another_table"}} => {:error, :relation_invalidated}
+           {10, {"public", "another_table"}} => {:error, :schema_changed}
          }
     test "broadcasts dropped relations to shape cache", %{opts: opts} do
       shape = generate_shape({"public", "items"})

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -317,8 +317,18 @@ defmodule Electric.ShapeCacheTest do
       :ok
     end
 
-    test "creates initial snapshot from DB data", %{storage: storage, shape_cache_opts: opts} do
-      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, opts)
+    setup %{inspector: inspector} do
+      %{shape: Shape.new!("items", inspector: inspector)}
+    end
+
+    test "creates initial snapshot from DB data", %{
+      storage: storage,
+      shape_cache_opts: opts,
+      shape: shape
+    } do
+      {shape_handle, _} =
+        ShapeCache.get_or_create_shape_handle(shape, opts)
+
       assert :started = ShapeCache.await_snapshot_start(shape_handle, opts)
       storage = Storage.for_shape(shape_handle, storage)
 
@@ -346,9 +356,10 @@ defmodule Electric.ShapeCacheTest do
     test "uses correct display settings when querying initial data", %{
       pool: pool,
       storage: storage,
-      shape_cache_opts: opts
+      shape_cache_opts: opts,
+      shape: shape
     } do
-      shape = %{@shape | selected_columns: ~w|id value date timestamptz float bytea interval|}
+      shape = %{shape | selected_columns: ~w|id value date timestamptz float bytea interval|}
 
       Postgrex.query!(
         pool,
@@ -403,9 +414,9 @@ defmodule Electric.ShapeCacheTest do
              } = map
     end
 
-    test "correctly propagates the error", %{shape_cache_opts: opts} do
+    test "correctly propagates the error", %{shape_cache_opts: opts, shape: shape} do
       shape = %{
-        @shape
+        shape
         | root_table: {"public", "nonexistent"},
           root_table_id: 2
       }
@@ -438,13 +449,12 @@ defmodule Electric.ShapeCacheTest do
         [1, 50, 2, 150, 3, 10]
       )
 
-      shape = %Shape{
-        root_table: {"public", "partitioned_items"},
-        root_table_id: 1,
-        root_pk: ["a", "b"],
-        selected_columns: ["a", "b"],
-        explicitly_selected_columns: ["a", "b"]
-      }
+      shape =
+        Shape.new!(
+          "partitioned_items",
+          columns: ["a", "b"],
+          inspector: ctx.inspector
+        )
 
       {shape_handle, _} = ShapeCache.get_or_create_shape_handle(shape, ctx.shape_cache_opts)
       assert :started = ShapeCache.await_snapshot_start(shape_handle, ctx.shape_cache_opts)
@@ -466,13 +476,14 @@ defmodule Electric.ShapeCacheTest do
 
     @tag shape_cache_opts_overrides: [snapshot_timeout_to_first_data: 500]
     test "crashes when initial snapshot query fails to return data quickly enough", %{
-      shape_cache_opts: opts
+      shape_cache_opts: opts,
+      shape: shape
     } do
       alias Electric.Replication.Eval.Parser
       where_clause = Parser.parse_and_validate_expression!("TRUE", refs: %{})
       # Insert a fake slow query
       where_clause = %{where_clause | query: "PG_SLEEP(10)::text ILIKE ''"}
-      shape = %{@shape | where: where_clause}
+      shape = %{shape | where: where_clause}
 
       {shape_handle, _} = ShapeCache.get_or_create_shape_handle(shape, opts)
 

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -11,5 +11,11 @@ ExUnit.start(assert_receive_timeout: 400, exclude: [:slow, :telemetry_target], c
 # we force recompilation in the setup. The issue is tracked here:
 # https://github.com/hissssst/repatch/issues/2
 Repatch.setup(
-  recompile: [Postgrex, Electric.StatusMonitor, Electric.Telemetry.Sampler, :otel_tracer]
+  recompile: [
+    Postgrex,
+    Electric.StatusMonitor,
+    Electric.Telemetry.Sampler,
+    Electric.ShapeCache.ShapeCleaner,
+    :otel_tracer
+  ]
 )


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/3186

This PR includes significant changes to `Electric.Postgres.Configuration` and `Electric.Replication.PublicationManager`.


### Changes
- Ensure PubMan handles per-relation errors such that only relevant shapes fail
- If any individual relation fails to be configured, relevant shapes are terminated
- If global error (e.g. connection error) occurs, propagate error to all requesters but do not invalidate shapes explicitly
- Got rid of retries - we don't do them everywhere, e.g. snapshots, and should be handled at network layer (see @robacourt 's work)
- Configuration now returns map with configuration result for each relation it either touched or detected to be invalid
- Validating the configuration returns the same result for simplicity of API, with different error codes since it cannot actually modify the relations
- PubMan now also checks that the publication 1) exists, 2) is configured to publish all operations, and 3) is owned by the Electric PG user.
  - These are all checks done once at the start of setting up the replication connection and publication, but are replicated in PubMan which will be doing these before every publication update/check, which also occur periodically, so we can detect something going wrong
  - These checks will also set the `can_alter_publication?` flag if the ownership changes so appropriate results are returned for shape requests
- Only log errors for unknown errors when failing to configure a relation, everything else is a warning
- _Slightly_ more generous with calling `ALTER TABLE` and `ALTER PUBLICATION` when fixing misconfigured relations just for the sake of API simplicity - no reason to be so cheap for something that doesn't happen often at the expense of clarity IMO.


## TODOs
- If the publication does not exist, we should notify the connection manager so that the whole stack is restarted. We are not doing this right now, we are just shutting down the publication manager which just restarts the replication supervisor but doesn't actually fix the problem. I'll add this as a separate PR.
- Cover case where we don't have ownership over the publication, but we do over the table, so we would need to set the replica identity without trying to add it to the publication.