### PR TITLE
Add `shardSubdomain` shape option.

### DIFF
--- a/.changeset/lazy-walls-look.md
+++ b/.changeset/lazy-walls-look.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": patch
+"@electric-sql/docs": patch
+---
+
+Add optional `shardSubdomain` shape option to auto-shard the url subdomain in development. This solves the slow shapes in development problem without needing HTTP/2 or system level deps like Caddy or mkcert.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -290,28 +290,38 @@ export interface ShapeStreamOptions<T = never> {
 
   /**
    * Enable subdomain sharding to bypass browser HTTP/1.1 connection limits.
+   * This is useful in local development and is enabled by default for localhost URLs.
    *
-   * Each shape gets a unique subdomain (e.g., `a7f2c.localhost:3000`),
-   * providing independent connection pools. Eliminates need for HTTP/2,
-   * Caddy, or trusted certificates in development.
+   * See https://electric-sql.com/docs/guides/troubleshooting#slow-shapes-mdash-why-are-my-shapes-slow-in-the-browser-in-local-development
+   *
+   * When sharded, each shape stream gets a unique subdomain (e.g., `a7f2c.localhost`),
+   * which bypasses the browser HTTP/1.1 connection limits. This avoids the need to serve
+   * the development server over HTTP/2 (and thus HTTPS) in development.
    *
    * Options:
-   * - `'localhost'` - Only shard localhost and *.localhost URLs (recommended for development)
-   * - `'always'` - Shard all URLs (use with custom infrastructure that supports wildcard subdomains)
-   * - `'never'` - Disable sharding (default)
+   * - `'localhost'` - Automatically shard `localhost` and `*.localhost` URLs (the default)
+   * - `'always'` - Shard URLs regardless of the hostname
+   * - `'never'` - Disable sharding
    * - `true` - Alias for `'always'`
    * - `false` - Alias for `'never'`
    *
-   * @default 'never'
-   * @example
-   * // Recommended: Opt-in for localhost development
-   * { url: 'http://localhost:3000/v1/shape', shardSubdomain: 'localhost' }
-   * // → http://a7f2c.localhost:3000/v1/shape
+   * @default 'localhost'
    *
    * @example
-   * // Advanced: Custom subdomain sharding with supporting infrastructure
-   * { url: 'http://api.example.com/v1/shape', shardSubdomain: 'always' }
-   * // → http://a7f2c.api.example.com/v1/shape
+   * { url: 'http://localhost:3000/v1/shape', shardSubdomain: 'localhost' }
+   * // → http://a1c2f.localhost:3000/v1/shape
+   *
+   * @example
+   * { url: 'https://api.example.com', shardSubdomain: 'localhost' }
+   * // → https://api.example.com
+   *
+   * @example
+   * { url: 'https://localhost:3000', shardSubdomain: 'never' }
+   * // → https://localhost:3000
+   *
+   * @example
+   * { url: 'https://api.example.com', shardSubdomain: 'always' }
+   * // → https://b2d3g.api.example.com
    */
   shardSubdomain?: ShardSubdomainOption
 

--- a/packages/typescript-client/src/helpers.ts
+++ b/packages/typescript-client/src/helpers.ts
@@ -97,3 +97,45 @@ export function isVisibleInSnapshot(
 
   return xid < xmin || (xid < xmax && !xip.includes(xid))
 }
+
+export function generateShardId(): string {
+  return Math.floor(Math.random() * 0xfffff)
+    .toString(16)
+    .padStart(5, `0`)
+}
+
+export function isLocalhostUrl(url: URL): boolean {
+  const hostname = url.hostname.toLowerCase()
+  return hostname === `localhost` || hostname.endsWith(`.localhost`)
+}
+
+export type ShardSubdomainOption = `always` | `localhost` | `never` | boolean
+
+export function applySubdomainSharding(
+  originalUrl: string,
+  option: ShardSubdomainOption | undefined
+): string {
+  if (!option || option === `never`) {
+    return originalUrl
+  }
+
+  if (typeof option === `boolean` && !option) {
+    return originalUrl
+  }
+
+  const url = new URL(originalUrl)
+
+  const shouldShard =
+    option === `always` ||
+    option === true ||
+    (option === `localhost` && isLocalhostUrl(url))
+
+  if (!shouldShard) {
+    return originalUrl
+  }
+
+  const shardId = generateShardId()
+  url.hostname = `${shardId}.${url.hostname}`
+
+  return url.toString()
+}

--- a/packages/typescript-client/src/helpers.ts
+++ b/packages/typescript-client/src/helpers.ts
@@ -113,13 +113,9 @@ export type ShardSubdomainOption = `always` | `localhost` | `never` | boolean
 
 export function applySubdomainSharding(
   originalUrl: string,
-  option: ShardSubdomainOption | undefined
+  option: ShardSubdomainOption = `localhost`
 ): string {
-  if (!option || option === `never`) {
-    return originalUrl
-  }
-
-  if (typeof option === `boolean` && !option) {
+  if (option === `never` || option === false) {
     return originalUrl
   }
 

--- a/packages/typescript-client/src/index.ts
+++ b/packages/typescript-client/src/index.ts
@@ -5,6 +5,7 @@ export {
   isChangeMessage,
   isControlMessage,
   isVisibleInSnapshot,
+  type ShardSubdomainOption,
 } from './helpers'
 export { FetchError } from './error'
 export { type BackoffOptions, BackoffDefaults } from './fetch'

--- a/packages/typescript-client/test/helpers.test.ts
+++ b/packages/typescript-client/test/helpers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { isChangeMessage, isControlMessage, Message } from '../src'
-import { isUpToDateMessage } from '../src/helpers'
+import {
+  isUpToDateMessage,
+  generateShardId,
+  isLocalhostUrl,
+  applySubdomainSharding,
+} from '../src/helpers'
 
 describe(`helpers`, () => {
   const changeMsg = {
@@ -40,5 +45,163 @@ describe(`helpers`, () => {
     expect(isUpToDateMessage(upToDateMsg)).toBe(true)
     expect(isUpToDateMessage(mustRefetchMsg)).toBe(false)
     expect(isUpToDateMessage(changeMsg)).toBe(false)
+  })
+})
+
+describe(`generateShardId`, () => {
+  it(`should generate 5-character hex strings`, () => {
+    const id = generateShardId()
+    expect(id).toMatch(/^[0-9a-f]{5}$/)
+  })
+
+  it(`should generate unique values`, () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateShardId()))
+    expect(ids.size).toBeGreaterThan(90)
+  })
+})
+
+describe(`isLocalhostUrl`, () => {
+  it(`should return true for localhost`, () => {
+    expect(isLocalhostUrl(new URL(`http://localhost:3000`))).toBe(true)
+    expect(isLocalhostUrl(new URL(`https://localhost`))).toBe(true)
+  })
+
+  it(`should return true for *.localhost subdomains`, () => {
+    expect(isLocalhostUrl(new URL(`http://dev.localhost:3000`))).toBe(true)
+    expect(isLocalhostUrl(new URL(`http://api.localhost`))).toBe(true)
+    expect(isLocalhostUrl(new URL(`http://a.b.c.localhost:8080`))).toBe(true)
+  })
+
+  it(`should return false for non-localhost domains`, () => {
+    expect(isLocalhostUrl(new URL(`http://example.com`))).toBe(false)
+    expect(isLocalhostUrl(new URL(`http://api.example.com`))).toBe(false)
+    expect(isLocalhostUrl(new URL(`http://localhost.com`))).toBe(false)
+  })
+
+  it(`should return false for IP addresses`, () => {
+    expect(isLocalhostUrl(new URL(`http://127.0.0.1:3000`))).toBe(false)
+    expect(isLocalhostUrl(new URL(`http://0.0.0.0:3000`))).toBe(false)
+  })
+
+  it(`should be case insensitive`, () => {
+    expect(isLocalhostUrl(new URL(`http://LOCALHOST:3000`))).toBe(true)
+    expect(isLocalhostUrl(new URL(`http://dev.LOCALHOST:3000`))).toBe(true)
+  })
+})
+
+describe(`applySubdomainSharding`, () => {
+  describe(`with 'never' or false`, () => {
+    it(`should not modify URL when option is 'never'`, () => {
+      const url = `http://localhost:3000/v1/shape`
+      expect(applySubdomainSharding(url, `never`)).toBe(url)
+    })
+
+    it(`should not modify URL when option is false`, () => {
+      const url = `http://localhost:3000/v1/shape`
+      expect(applySubdomainSharding(url, false)).toBe(url)
+    })
+
+    it(`should not modify URL when option is undefined`, () => {
+      const url = `http://localhost:3000/v1/shape`
+      expect(applySubdomainSharding(url, undefined)).toBe(url)
+    })
+  })
+
+  describe(`with 'always' or true`, () => {
+    it(`should add subdomain when option is 'always'`, () => {
+      const url = `http://localhost:3000/v1/shape`
+      const result = applySubdomainSharding(url, `always`)
+      expect(result).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.localhost:3000\/v1\/shape$/
+      )
+    })
+
+    it(`should add subdomain when option is true`, () => {
+      const url = `http://localhost:3000/v1/shape`
+      const result = applySubdomainSharding(url, true)
+      expect(result).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.localhost:3000\/v1\/shape$/
+      )
+    })
+
+    it(`should shard any domain with 'always'`, () => {
+      const url = `http://api.example.com/v1/shape`
+      const result = applySubdomainSharding(url, `always`)
+      expect(result).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.api\.example\.com\/v1\/shape$/
+      )
+    })
+
+    it(`should preserve existing subdomains`, () => {
+      const url = `http://api.example.com/v1/shape`
+      const result = applySubdomainSharding(url, `always`)
+      expect(result).toMatch(/^http:\/\/[0-9a-f]{5}\.api\.example\.com/)
+    })
+  })
+
+  describe(`with 'localhost'`, () => {
+    it(`should shard localhost URLs`, () => {
+      const url = `http://localhost:3000/v1/shape`
+      const result = applySubdomainSharding(url, `localhost`)
+      expect(result).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.localhost:3000\/v1\/shape$/
+      )
+    })
+
+    it(`should shard *.localhost URLs`, () => {
+      const url = `http://dev.localhost:3000/v1/shape`
+      const result = applySubdomainSharding(url, `localhost`)
+      expect(result).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.dev\.localhost:3000\/v1\/shape$/
+      )
+    })
+
+    it(`should not shard non-localhost URLs`, () => {
+      const url = `http://api.example.com/v1/shape`
+      const result = applySubdomainSharding(url, `localhost`)
+      expect(result).toBe(url)
+    })
+
+    it(`should not shard IP addresses`, () => {
+      const url = `http://127.0.0.1:3000/v1/shape`
+      const result = applySubdomainSharding(url, `localhost`)
+      expect(result).toBe(url)
+    })
+  })
+
+  describe(`URL preservation`, () => {
+    it(`should preserve ports`, () => {
+      const url = `http://localhost:8080/v1/shape`
+      const result = applySubdomainSharding(url, `always`)
+      expect(result).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.localhost:8080\/v1\/shape$/
+      )
+    })
+
+    it(`should preserve paths`, () => {
+      const url = `http://localhost:3000/api/v1/shape/table`
+      const result = applySubdomainSharding(url, `always`)
+      expect(result).toMatch(/\/api\/v1\/shape\/table$/)
+    })
+
+    it(`should preserve query parameters`, () => {
+      const url = `http://localhost:3000/v1/shape?table=foo&where=bar`
+      const result = applySubdomainSharding(url, `always`)
+      expect(result).toMatch(/\?table=foo&where=bar$/)
+    })
+
+    it(`should preserve hash fragments`, () => {
+      const url = `http://localhost:3000/v1/shape#section`
+      const result = applySubdomainSharding(url, `always`)
+      expect(result).toMatch(/#section$/)
+    })
+
+    it(`should preserve HTTPS protocol`, () => {
+      const url = `https://localhost:3000/v1/shape`
+      const result = applySubdomainSharding(url, `always`)
+      expect(result).toMatch(
+        /^https:\/\/[0-9a-f]{5}\.localhost:3000\/v1\/shape$/
+      )
+    })
   })
 })

--- a/packages/typescript-client/test/helpers.test.ts
+++ b/packages/typescript-client/test/helpers.test.ts
@@ -100,11 +100,6 @@ describe(`applySubdomainSharding`, () => {
       const url = `http://localhost:3000/v1/shape`
       expect(applySubdomainSharding(url, false)).toBe(url)
     })
-
-    it(`should not modify URL when option is undefined`, () => {
-      const url = `http://localhost:3000/v1/shape`
-      expect(applySubdomainSharding(url, undefined)).toBe(url)
-    })
   })
 
   describe(`with 'always' or true`, () => {
@@ -139,10 +134,18 @@ describe(`applySubdomainSharding`, () => {
     })
   })
 
-  describe(`with 'localhost'`, () => {
+  describe(`with 'localhost' or undefined`, () => {
     it(`should shard localhost URLs`, () => {
       const url = `http://localhost:3000/v1/shape`
       const result = applySubdomainSharding(url, `localhost`)
+      expect(result).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.localhost:3000\/v1\/shape$/
+      )
+    })
+
+    it(`should shard localhost URLs when option is undefined`, () => {
+      const url = `http://localhost:3000/v1/shape`
+      const result = applySubdomainSharding(url, undefined)
       expect(result).toMatch(
         /^http:\/\/[0-9a-f]{5}\.localhost:3000\/v1\/shape$/
       )
@@ -159,6 +162,12 @@ describe(`applySubdomainSharding`, () => {
     it(`should not shard non-localhost URLs`, () => {
       const url = `http://api.example.com/v1/shape`
       const result = applySubdomainSharding(url, `localhost`)
+      expect(result).toBe(url)
+    })
+
+    it(`should not shard non-localhost URLs when option is undefined`, () => {
+      const url = `http://api.example.com/v1/shape`
+      const result = applySubdomainSharding(url, undefined)
       expect(result).toBe(url)
     })
 

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -195,4 +195,216 @@ describe(`ShapeStream`, () => {
       `columns=id&handle=potato&log=full&offset=-1&params%5B1%5D=test1&params%5B2%5D=test2&table=foo&where=a%3D%241+and+b%3D%242`
     )
   })
+
+  describe(`subdomain sharding`, () => {
+    it(`should not shard by default`, async () => {
+      const eventTarget = new EventTarget()
+      const requestedUrls: Array<string> = []
+      const fetchWrapper = (
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response> => {
+        requestedUrls.push(args[0].toString())
+        eventTarget.dispatchEvent(new Event(`fetch`))
+        return Promise.resolve(Response.error())
+      }
+
+      const aborter = new AbortController()
+      const stream = new ShapeStream({
+        url: `http://localhost:3000/v1/shape`,
+        params: { table: `foo` },
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
+
+      const unsub = stream.subscribe(() => unsub())
+
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(`fetch`, resolve, { once: true })
+      )
+
+      expect(requestedUrls[0]).toMatch(/^http:\/\/localhost:3000\/v1\/shape/)
+    })
+
+    it(`should shard localhost URLs when shardSubdomain is 'localhost'`, async () => {
+      const eventTarget = new EventTarget()
+      const requestedUrls: Array<string> = []
+      const fetchWrapper = (
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response> => {
+        requestedUrls.push(args[0].toString())
+        eventTarget.dispatchEvent(new Event(`fetch`))
+        return Promise.resolve(Response.error())
+      }
+
+      const aborter = new AbortController()
+      const stream = new ShapeStream({
+        url: `http://localhost:3000/v1/shape`,
+        params: { table: `foo` },
+        shardSubdomain: `localhost`,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
+
+      const unsub = stream.subscribe(() => unsub())
+
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(`fetch`, resolve, { once: true })
+      )
+
+      expect(requestedUrls[0]).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.localhost:3000\/v1\/shape/
+      )
+    })
+
+    it(`should not shard non-localhost URLs when shardSubdomain is 'localhost'`, async () => {
+      const eventTarget = new EventTarget()
+      const requestedUrls: Array<string> = []
+      const fetchWrapper = (
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response> => {
+        requestedUrls.push(args[0].toString())
+        eventTarget.dispatchEvent(new Event(`fetch`))
+        return Promise.resolve(Response.error())
+      }
+
+      const aborter = new AbortController()
+      const stream = new ShapeStream({
+        url: `https://api.example.com/v1/shape`,
+        params: { table: `foo` },
+        shardSubdomain: `localhost`,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
+
+      const unsub = stream.subscribe(() => unsub())
+
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(`fetch`, resolve, { once: true })
+      )
+
+      expect(requestedUrls[0]).toMatch(
+        /^https:\/\/api\.example\.com\/v1\/shape/
+      )
+    })
+
+    it(`should shard any URL when shardSubdomain is 'always'`, async () => {
+      const eventTarget = new EventTarget()
+      const requestedUrls: Array<string> = []
+      const fetchWrapper = (
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response> => {
+        requestedUrls.push(args[0].toString())
+        eventTarget.dispatchEvent(new Event(`fetch`))
+        return Promise.resolve(Response.error())
+      }
+
+      const aborter = new AbortController()
+      const stream = new ShapeStream({
+        url: `https://api.example.com/v1/shape`,
+        params: { table: `foo` },
+        shardSubdomain: `always`,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
+
+      const unsub = stream.subscribe(() => unsub())
+
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(`fetch`, resolve, { once: true })
+      )
+
+      expect(requestedUrls[0]).toMatch(
+        /^https:\/\/[0-9a-f]{5}\.api\.example\.com\/v1\/shape/
+      )
+    })
+
+    it(`should not shard when shardSubdomain is 'never'`, async () => {
+      const eventTarget = new EventTarget()
+      const requestedUrls: Array<string> = []
+      const fetchWrapper = (
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response> => {
+        requestedUrls.push(args[0].toString())
+        eventTarget.dispatchEvent(new Event(`fetch`))
+        return Promise.resolve(Response.error())
+      }
+
+      const aborter = new AbortController()
+      const stream = new ShapeStream({
+        url: `http://localhost:3000/v1/shape`,
+        params: { table: `foo` },
+        shardSubdomain: `never`,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
+
+      const unsub = stream.subscribe(() => unsub())
+
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(`fetch`, resolve, { once: true })
+      )
+
+      expect(requestedUrls[0]).toMatch(/^http:\/\/localhost:3000\/v1\/shape/)
+    })
+
+    it(`should support boolean true as alias for 'always'`, async () => {
+      const eventTarget = new EventTarget()
+      const requestedUrls: Array<string> = []
+      const fetchWrapper = (
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response> => {
+        requestedUrls.push(args[0].toString())
+        eventTarget.dispatchEvent(new Event(`fetch`))
+        return Promise.resolve(Response.error())
+      }
+
+      const aborter = new AbortController()
+      const stream = new ShapeStream({
+        url: `http://localhost:3000/v1/shape`,
+        params: { table: `foo` },
+        shardSubdomain: true,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
+
+      const unsub = stream.subscribe(() => unsub())
+
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(`fetch`, resolve, { once: true })
+      )
+
+      expect(requestedUrls[0]).toMatch(
+        /^http:\/\/[0-9a-f]{5}\.localhost:3000\/v1\/shape/
+      )
+    })
+
+    it(`should support boolean false as alias for 'never'`, async () => {
+      const eventTarget = new EventTarget()
+      const requestedUrls: Array<string> = []
+      const fetchWrapper = (
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response> => {
+        requestedUrls.push(args[0].toString())
+        eventTarget.dispatchEvent(new Event(`fetch`))
+        return Promise.resolve(Response.error())
+      }
+
+      const aborter = new AbortController()
+      const stream = new ShapeStream({
+        url: `http://localhost:3000/v1/shape`,
+        params: { table: `foo` },
+        shardSubdomain: false,
+        signal: aborter.signal,
+        fetchClient: fetchWrapper,
+      })
+
+      const unsub = stream.subscribe(() => unsub())
+
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(`fetch`, resolve, { once: true })
+      )
+
+      expect(requestedUrls[0]).toMatch(/^http:\/\/localhost:3000\/v1\/shape/)
+    })
+  })
 })

--- a/website/docs/api/clients/typescript.md
+++ b/website/docs/api/clients/typescript.md
@@ -129,7 +129,7 @@ stream.subscribe((messages) => {
 
 #### Options
 
-The `ShapeStream` constructor takes [the following options](https://github.com/electric-sql/electric/blob/main/packages/typescript-client/src/client.ts#L39):
+The `ShapeStream` constructor takes [the following options](https://github.com/electric-sql/electric/blob/main/packages/typescript-client/src/client.ts):
 
 ```ts
 /**
@@ -142,6 +142,26 @@ export interface ShapeStreamOptions<T = never> {
    * set `http://localhost:3000/v1/shape`
    */
   url: string
+
+  /**
+   * Enable subdomain sharding to bypass browser HTTP/1.1 connection limits.
+   * This is useful in local development.
+   *
+   * Each shape gets a unique subdomain (e.g., `a7f2c.localhost:3000`),
+   * providing independent connection pools. Eliminates need for HTTP/2,
+   * Caddy, or trusted certificates in development.
+   *
+   * Options:
+   * - `'localhost'` - Only shard localhost and *.localhost URLs (recommended for development)
+   * - `'always'` - Shard all URLs (use with custom infrastructure that supports wildcard subdomains)
+   * - `'never'` - Disable sharding (default)
+   * - `true` - Alias for `'always'`
+   * - `false` - Alias for `'never'`
+   *
+   * See the [Troubleshooting guide](/docs/guides/troubleshooting)
+   * for more details on when and why to use this option.
+   */
+  shardSubdomain?: 'localhost' | 'always' | 'never' | boolean
 
   /**
    * PostgreSQL-specific parameters for the shape.

--- a/website/docs/api/clients/typescript.md
+++ b/website/docs/api/clients/typescript.md
@@ -144,26 +144,6 @@ export interface ShapeStreamOptions<T = never> {
   url: string
 
   /**
-   * Enable subdomain sharding to bypass browser HTTP/1.1 connection limits.
-   * This is useful in local development.
-   *
-   * Each shape gets a unique subdomain (e.g., `a7f2c.localhost:3000`),
-   * providing independent connection pools. Eliminates need for HTTP/2,
-   * Caddy, or trusted certificates in development.
-   *
-   * Options:
-   * - `'localhost'` - Only shard localhost and *.localhost URLs (recommended for development)
-   * - `'always'` - Shard all URLs (use with custom infrastructure that supports wildcard subdomains)
-   * - `'never'` - Disable sharding (default)
-   * - `true` - Alias for `'always'`
-   * - `false` - Alias for `'never'`
-   *
-   * See the [Troubleshooting guide](/docs/guides/troubleshooting)
-   * for more details on when and why to use this option.
-   */
-  shardSubdomain?: 'localhost' | 'always' | 'never' | boolean
-
-  /**
    * PostgreSQL-specific parameters for the shape.
    * This includes table, where clause, columns, and replica settings.
    */
@@ -255,6 +235,43 @@ export interface ShapeStreamOptions<T = never> {
    * fetch subsets of data on-demand.
    */
   mode?: "full" | "changes_only"
+
+  /**
+   * Enable subdomain sharding to bypass browser HTTP/1.1 connection limits.
+   * This is useful in local development and is enabled by default for localhost URLs.
+   *
+   * See https://electric-sql.com/docs/guides/troubleshooting#slow-shapes-mdash-why-are-my-shapes-slow-in-the-browser-in-local-development
+   *
+   * When sharded, each shape stream gets a unique subdomain (e.g., `a7f2c.localhost`),
+   * which bypasses the browser HTTP/1.1 connection limits. This avoids the need to serve
+   * the development server over HTTP/2 (and thus HTTPS) in development.
+   *
+   * Options:
+   * - `'localhost'` - Automatically shard `localhost` and `*.localhost` URLs (the default)
+   * - `'always'` - Shard URLs regardless of the hostname
+   * - `'never'` - Disable sharding
+   * - `true` - Alias for `'always'`
+   * - `false` - Alias for `'never'`
+   *
+   * @default 'localhost'
+   *
+   * @example
+   * { url: 'http://localhost:3000/v1/shape', shardSubdomain: 'localhost' }
+   * // → http://a1c2f.localhost:3000/v1/shape
+   *
+   * @example
+   * { url: 'https://api.example.com', shardSubdomain: 'localhost' }
+   * // → https://api.example.com
+   *
+   * @example
+   * { url: 'https://localhost:3000', shardSubdomain: 'never' }
+   * // → https://localhost:3000
+   *
+   * @example
+   * { url: 'https://api.example.com', shardSubdomain: 'always' }
+   * // → https://b2d3g.api.example.com
+   */
+  shardSubdomain?: ShardSubdomainOption
 
   /**
    * Signal to abort the stream.


### PR DESCRIPTION
Adds an optional `shardSubdomain` shape option to auto-shard the url subdomain in development:

```ts
const url = isProd
  ? 'https://example.com' 
  : 'http://localhost:3000'

const stream = new ShapeStream({
  url,
  shardSubdomain: 'localhost'
})
```

```ts
/**
 * Enable subdomain sharding to bypass browser HTTP/1.1 connection limits.
 * This is useful in local development and is enabled by default for localhost URLs.
 *
 * See https://electric-sql.com/docs/guides/troubleshooting#slow-shapes-mdash-why-are-my-shapes-slow-in-the-browser-in-local-development
 *
 * When sharded, each shape stream gets a unique subdomain (e.g., `a7f2c.localhost`),
 * which bypasses the browser HTTP/1.1 connection limits. This avoids the need to serve
 * the development server over HTTP/2 (and thus HTTPS) in development.
 *
 * Options:
 * - `'localhost'` - Automatically shard `localhost` and `*.localhost` URLs (the default)
 * - `'always'` - Shard URLs regardless of the hostname
 * - `'never'` - Disable sharding
 * - `true` - Alias for `'always'`
 * - `false` - Alias for `'never'`
 *
 * @default 'localhost'
 *
 * @example
 * { url: 'http://localhost:3000/v1/shape', shardSubdomain: 'localhost' }
 * // → http://a1c2f.localhost:3000/v1/shape
 *
 * @example
 * { url: 'https://api.example.com', shardSubdomain: 'localhost' }
 * // → https://api.example.com
 *
 * @example
 * { url: 'https://localhost:3000', shardSubdomain: 'never' }
 * // → https://localhost:3000
 *
 * @example
 * { url: 'https://api.example.com', shardSubdomain: 'always' }
 * // → https://b2d3g.api.example.com
 */
shardSubdomain?: ShardSubdomainOption
```

This solves the [slow shapes in development](https://electric-sql.com/docs/guides/troubleshooting#slow-shapes-mdash-why-are-my-shapes-slow-in-the-browser-in-local-development) problem without needing http2 or system level deps like Caddy or mkcert.