### PR TITLE
fix: Parse more connection closures as retryable errors

### DIFF
--- a/.changeset/polite-ghosts-switch.md
+++ b/.changeset/polite-ghosts-switch.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Parse more DB errors as retryable (`ssl connect: closed` and `connection_refused` with PG code 08006).

--- a/packages/sync-service/lib/electric/db_connection_error.ex
+++ b/packages/sync-service/lib/electric/db_connection_error.ex
@@ -28,6 +28,7 @@ defmodule Electric.DbConnectionError do
              "ssl recv (idle): closed",
              "tcp recv: closed",
              "ssl recv: closed",
+             "ssl connect: closed",
              "tcp async recv: closed",
              "ssl async recv: closed",
              "tcp async_recv: closed",
@@ -197,6 +198,19 @@ defmodule Electric.DbConnectionError do
     %DbConnectionError{
       message: error.postgres.message,
       type: :insufficient_resources,
+      original_error: error,
+      retry_may_fix?: true
+    }
+  end
+
+  def from_error(
+        %Postgrex.Error{
+          postgres: %{code: :connection_failure, severity: "FATAL", pg_code: "08006"}
+        } = error
+      ) do
+    %DbConnectionError{
+      message: error.postgres.message,
+      type: :connection_failure,
       original_error: error,
       retry_may_fix?: true
     }

--- a/packages/sync-service/test/electric/db_connection_error_test.exs
+++ b/packages/sync-service/test/electric/db_connection_error_test.exs
@@ -121,6 +121,29 @@ defmodule Electric.DbConnectionErrorTest do
              } == DbConnectionError.from_error(error)
     end
 
+    test "with connection failure from upstream" do
+      error = %Postgrex.Error{
+        message: nil,
+        postgres: %{
+          code: :connection_failure,
+          message: "connection closed by upstream database",
+          unknown: "FATAL",
+          severity: "FATAL",
+          detail: "The upstream Postgres database has closed the connection.",
+          pg_code: "08006"
+        },
+        connection_id: 8186,
+        query: nil
+      }
+
+      assert %DbConnectionError{
+               message: "connection closed by upstream database",
+               type: :connection_failure,
+               original_error: error,
+               retry_may_fix?: true
+             } == DbConnectionError.from_error(error)
+    end
+
     test "with remaining connection slots reserved error" do
       error = %Postgrex.Error{
         message: nil,
@@ -332,6 +355,7 @@ defmodule Electric.DbConnectionErrorTest do
             "ssl recv (idle): closed",
             "tcp recv: closed",
             "ssl recv: closed",
+            "ssl connect: closed",
             "ssl async_recv: closed"
           ] do
         error = %DBConnection.ConnectionError{


### PR DESCRIPTION
Fixes [error 1](https://electricsql-04.sentry.io/issues/67931755/?alert_rule_id=130196&alert_timestamp=1759588783369&alert_type=email&environment=production&notification_uuid=cdf63771-ae86-45eb-8d73-8e2171406e67&project=4508410462404688&referrer=alert_email) and [error 2](https://electricsql-04.sentry.io/issues/67990265/?alert_rule_id=130196&alert_timestamp=1759598732763&alert_type=email&environment=production&notification_uuid=ee54f307-5539-4335-8bce-a1190244eca2&project=4508410462404688&referrer=alert_email)