### PR TITLE
Unlink the lock breaker connection

### DIFF
--- a/.changeset/thirty-lions-laugh.md
+++ b/.changeset/thirty-lions-laugh.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Ensure the lock breaker connection is not linked to the connection manager to avoid unnecessary crashes.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -582,6 +582,10 @@ defmodule Electric.Connection.Manager do
           stack_id: state.stack_id
         )
 
+      # unlink the lock breaker so that if it crashes it does not affect the manager,
+      # since it is a one shot fix attempt anyway
+      Process.unlink(breaker_pid)
+
       lock_name = Keyword.fetch!(state.replication_opts, :slot_name)
 
       LockBreakerConnection.stop_backends_and_close(breaker_pid, lock_name, pid)


### PR DESCRIPTION
Fixes https://github.com/electric-sql/electric/issues/3232

I've tested this manually by raising in the lock breaker connection and reproduced the error.