### PR TITLE
fix: Match exit by pid type to error regardless of phase

### DIFF
--- a/.changeset/nasty-pans-hear.md
+++ b/.changeset/nasty-pans-hear.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Simplify connection status error handling for runtime failures

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -1043,35 +1043,18 @@ defmodule Electric.Connection.Manager do
     schedule_reconnection(step, state)
   end
 
-  defp set_connection_status_error(
-         error_message,
-         _pid_type,
-         %State{
-           current_phase: :connection_setup,
-           current_step: {:start_lock_connection, _}
-         } = state
-       ) do
+  defp set_connection_status_error(error_message, :lock_connection, state) do
     StatusMonitor.mark_pg_lock_as_errored(state.stack_id, error_message)
     "lock_connection"
   end
 
-  defp set_connection_status_error(
-         error_message,
-         _pid_type,
-         %State{
-           current_phase: :connection_setup,
-           current_step: {:start_replication_client, _}
-         } = state
-       ) do
+  defp set_connection_status_error(error_message, :replication_client, state) do
     StatusMonitor.mark_replication_client_as_errored(state.stack_id, error_message)
     "replication"
   end
 
-  defp set_connection_status_error(
-         error_message,
-         pid_type,
-         %State{current_phase: :connection_setup} = state
-       ) do
+  defp set_connection_status_error(error_message, pid_type, state)
+       when pid_type in [:pools, :admin_pool, :snapshot_pool] do
     roles =
       case pid_type do
         :admin_pool -> [:admin]


### PR DESCRIPTION
Fixes [this error](https://electricsql-04.sentry.io/issues/65568224/?environment=production&project=4508410462404688&query=is%3Aunresolved&referrer=issue-stream)

We might get crashes at any point of the connection manager lifetime, so matching only to the connection setup doesn't make sense.

Since we now have a pid type for all tracked processes, we can simply match them to the right error.