### PR TITLE
perf: Optimize lint-staged pre-commit hook with file filter

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,9 @@
-pnpm exec lint-staged
+#!/bin/sh
+
+# Quick check if any staged files match lint-staged patterns
+# Patterns from package.json: *.{js,jsx,ts,tsx,json,css,md,yml,yaml}
+if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.(js|jsx|ts|tsx|json|css|md|yml|yaml)$'; then
+  pnpm exec lint-staged
+else
+  echo "No files matching lint-staged patterns, skipping..."
+fi


### PR DESCRIPTION
## Summary

- Adds early exit check to pre-commit hook to skip lint-staged when no relevant files are staged
- Uses fast git diff + grep to check for matching file extensions before invoking lint-staged
- Significantly speeds up commits that only touch Elixir files or other non-linted files in the monorepo

## Test plan

- [x] Created this PR (tested the hook during commit - it correctly skipped lint-staged)
- [ ] Test with JS/TS file changes to ensure lint-staged still runs
- [ ] Test with only Elixir file changes to confirm it skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)