### PR TITLE
An attempt to optimize the collection of memory usage by process type

### DIFF
--- a/packages/sync-service/lib/electric/telemetry/processes.ex
+++ b/packages/sync-service/lib/electric/telemetry/processes.ex
@@ -34,6 +34,7 @@ defmodule Electric.Telemetry.Processes do
     |> Stream.reject(&(proc_mem(&1, :type) == :dead))
     |> Enum.group_by(&proc_mem(&1, :type), &proc_mem(&1, :memory))
     |> keep_top_n(&memory_sum/1, count)
+    |> Enum.map(fn {rec, _} -> %{type: proc_mem(rec, :type), memory: proc_mem(rec, :memory)} end)
   end
 
   defp memory_sum({type, memory_list}) do
@@ -54,7 +55,6 @@ defmodule Electric.Telemetry.Processes do
     |> Stream.map(trans_fun)
     |> Enum.reduce(first_n, fn item, acc -> insert_into_sorted(item, acc, n) end)
     |> Enum.take(n)
-    |> Enum.map(fn {rec, _} -> %{type: proc_mem(rec, :type), memory: proc_mem(rec, :memory)} end)
   end
 
   defp insert_into_sorted(item, acc, limit), do: insert_into_sorted(item, acc, 0, limit)


### PR DESCRIPTION
- replace Process.list() with more efficient iteration over processes
- minimize the number of list traversals by implementing insert_into_sorted() with a limit
- use a private record for more efficient key lookup and to reduce the number of garbage maps created

Benchmarking code:

```elixir
# benchmarks/top_memory_by_type.exs
defmodule S do
  use GenServer

  def start_link(_) do
    GenServer.start_link(__MODULE__, nil, [])
  end

  def init(_) do
    {:ok, nil}
  end
end

{:ok, sup} = DynamicSupervisor.start_link([])

Enum.each(1..200_000, fn _ ->
  DynamicSupervisor.start_child(sup, {S, nil})
end)

IO.puts "Total procs: #{length(Process.list())}"

Benchee.run(
  %{
    "Debug.Process" => &Electric.Debug.Process.top_memory_by_type/1,
    "Telemetry.Processes" => &Electric.Telemetry.Processes.top_memory_by_type/1,
  },
  inputs: Map.new([5, 10, 100], fn n -> {"top #{n}", n} end)
)
```

The first run shows that the new one is actually slower :facepalm: 

```shell
$ mix run benchmarks/top_memory_by_type.exs
Total procs: 200110
Operating System: Linux
CPU Information: 13th Gen Intel(R) Core(TM) i7-1360P
Number of Available Cores: 16
Available memory: 31.02 GB
Elixir 1.19.1
Erlang 28.1.1
JIT enabled: true

##### With input top 5 #####
Name                          ips        average  deviation         median         99th %
Debug.Process                2.38      420.21 ms    ±10.24%      420.70 ms      486.91 ms
Telemetry.Processes          2.21      451.74 ms    ±10.53%      442.46 ms      529.69 ms

Comparison: 
Debug.Process                2.38
Telemetry.Processes          2.21 - 1.08x slower +31.53 ms

##### With input top 10 #####
Name                          ips        average  deviation         median         99th %
Debug.Process                2.28      439.13 ms     ±3.69%      437.32 ms      470.63 ms
Telemetry.Processes          1.77      565.20 ms    ±16.39%      526.56 ms      708.77 ms

Comparison: 
Debug.Process                2.28
Telemetry.Processes          1.77 - 1.29x slower +126.07 ms

##### With input top 100 #####
Name                          ips        average  deviation         median         99th %
Debug.Process                2.44      410.14 ms     ±4.02%      411.77 ms      437.21 ms
Telemetry.Processes          2.19      457.47 ms    ±10.70%      451.42 ms      554.54 ms

Comparison: 
Debug.Process                2.44
Telemetry.Processes          2.19 - 1.12x slower +47.33 ms
```

However, the second run shows the runtimes reversed:

```shell
##### With input top 5 #####
Name                          ips        average  deviation         median         99th %
Telemetry.Processes          2.93      341.08 ms     ±1.82%      340.19 ms      352.41 ms
Debug.Process                2.69      372.11 ms     ±2.20%      369.17 ms      389.23 ms

Comparison: 
Telemetry.Processes          2.93
Debug.Process                2.69 - 1.09x slower +31.03 ms

##### With input top 10 #####
Name                          ips        average  deviation         median         99th %
Telemetry.Processes          2.88      347.57 ms     ±3.06%      349.69 ms      362.23 ms
Debug.Process                2.24      446.43 ms     ±9.97%      460.58 ms      506.38 ms

Comparison: 
Telemetry.Processes          2.88
Debug.Process                2.24 - 1.28x slower +98.87 ms

##### With input top 100 #####
Name                          ips        average  deviation         median         99th %
Telemetry.Processes          3.03      330.36 ms     ±2.98%      332.20 ms      353.66 ms
Debug.Process                2.65      377.30 ms     ±3.42%      375.21 ms      409.22 ms

Comparison: 
Telemetry.Processes          3.03
Debug.Process                2.65 - 1.14x slower +46.94 ms
```