### PR TITLE
Remove explicit calls to :erlang.garbage_collect()

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -232,11 +232,6 @@ defmodule Electric.ShapeCache do
     {last_processed_lsn, total_recovered, total_failed_to_recover} =
       recover_shapes(state, recover_shape_timeout)
 
-    # Empirical evidence shows that after recovering 50K shapes ShapeStatusOwner and ShapeCache
-    # each take up 200+MB of memory. Explicitly running garbage collection for both immediately
-    # takes that down to 4-5MB.
-    :erlang.garbage_collect()
-
     {pub_man, pub_man_opts} = state.publication_manager
     pub_man.wait_for_restore(pub_man_opts)
 

--- a/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
@@ -44,11 +44,6 @@ defmodule Electric.ShapeCache.ShapeStatusOwner do
 
     Electric.LsnTracker.create_table(stack_id)
 
-    # Empirical evidence shows that after recovering 50K shapes ShapeStatusOwner and ShapeCache
-    # each take up 200+MB of memory. Explicitly running garbage collection for both immediately
-    # takes that down to 4-5MB.
-    :erlang.garbage_collect()
-
     {:ok, %{stack_id: stack_id, backup_dir: ShapeStatus.backup_dir(config.storage)}}
   end
 


### PR DESCRIPTION
The code is not sitting still and at least one of these calls is becoming obsolete with Gary's work on starting consumer processes lazily. Moreover, the current startup of consumer processes in ShapeCache already spawns a separate `Task` process for each consumer, so it's not that clear where all the garbage is coming from.

In any case, we should refrain from adding explicit GC unless we can reliably reproduce the situtations the show its unquestionable benefit.