### PR TITLE
Update invocations of "mix do" to match the current convention

### DIFF
--- a/packages/elixir-client/package.json
+++ b/packages/elixir-client/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "version": "0.7.3",
   "scripts": {
-    "publish:hex": "mix do deps.get, hex.publish --yes || true"
+    "publish:hex": "mix do deps.get + hex.publish --yes || true"
   }
 }

--- a/packages/sync-service/package.json
+++ b/packages/sync-service/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.2.0",
   "scripts": {
-    "publish:hex": "mix do deps.get, hex.publish --yes || true",
+    "publish:hex": "mix do deps.get + hex.publish --yes || true",
     "changeset": "pushd ../..; pnpm changeset; popd"
   }
 }


### PR DESCRIPTION
We're seeing the following warnings from the Changesets CI workflow:
```
. ci:publish:hex-electric: > mix do deps.get, hex.publish --yes || true
. ci:publish:hex-electric: warning: using commas as separators in "mix do" is deprecated, use + between commands instead
. ci:publish:hex-electric:   (mix 1.19.1) lib/mix/tasks/do.ex:129: Mix.Tasks.Do.gather_commands/3
. ci:publish:hex-electric:   (mix 1.19.1) lib/mix/tasks/do.ex:75: Mix.Tasks.Do.run/1
. ci:publish:hex-electric:   (mix 1.19.1) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
. ci:publish:hex-electric:   (mix 1.19.1) lib/mix/cli.ex:131: Mix.CLI.run_task/2
. ci:publish:hex-electric:   /home/runner/work/_temp/.setup-beam/elixir/bin/mix:7: (file)
. ci:publish:hex-electric:   (elixir 1.19.1) src/elixir_compiler.erl:81: :elixir_compiler.dispatch/4
```
```
. ci:publish:hex-electric-client: > mix do deps.get, hex.publish --yes || true
. ci:publish:hex-electric-client: warning: using commas as separators in "mix do" is deprecated, use + between commands instead
. ci:publish:hex-electric-client:   (mix 1.19.1) lib/mix/tasks/do.ex:129: Mix.Tasks.Do.gather_commands/3
. ci:publish:hex-electric-client:   (mix 1.19.1) lib/mix/tasks/do.ex:75: Mix.Tasks.Do.run/1
. ci:publish:hex-electric-client:   (mix 1.19.1) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
. ci:publish:hex-electric-client:   (mix 1.19.1) lib/mix/cli.ex:131: Mix.CLI.run_task/2
. ci:publish:hex-electric-client:   /home/runner/work/_temp/.setup-beam/elixir/bin/mix:7: (file)
. ci:publish:hex-electric-client:   (elixir 1.19.1) src/elixir_compiler.erl:81: :elixir_compiler.dispatch/4
```