### PR TITLE
chore(sync-service): Fix warning for mix alias

### DIFF
--- a/packages/sync-service/mix.exs
+++ b/packages/sync-service/mix.exs
@@ -170,7 +170,7 @@ defmodule Electric.MixProject do
       start_dev: "cmd --cd dev docker compose up -d",
       stop_dev: "cmd --cd dev docker compose down -v",
       clean_persistent: "cmd rm -rf persistent",
-      reset: "do clean_persistent, stop_dev, start_dev"
+      reset: "do clean_persistent + stop_dev + start_dev"
     ]
   end
 


### PR DESCRIPTION
To fix the warning:
```
warning: using commas as separators in "mix do" is deprecated, use + between commands instead
  (mix 1.19.1) lib/mix/tasks/do.ex:129: Mix.Tasks.Do.gather_commands/3
  (mix 1.19.1) lib/mix/tasks/do.ex:75: Mix.Tasks.Do.run/1
  (mix 1.19.1) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
  (mix 1.19.1) lib/mix/task.ex:573: Mix.Task.run_alias/6
  (mix 1.19.1) lib/mix/cli.ex:131: Mix.CLI.run_task/2
  /Users/rob/.asdf/installs/elixir/1.19.1-otp-28/bin/mix:7: (file)
```