### PR TITLE
Use the standard OTEL_RESOURCE_ATTRIBUTES env variables since Docker now supports it

### DIFF
--- a/packages/sync-service/dev/docker-compose-otel.yml
+++ b/packages/sync-service/dev/docker-compose-otel.yml
@@ -14,7 +14,7 @@ services:
       - ./postgres.conf:/etc/postgresql.conf:ro
       - ./init.sql:/docker-entrypoint-initdb.d/00_shared_init.sql:ro
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql
       - /tmp
     entrypoint:
       - docker-entrypoint.sh


### PR DESCRIPTION
There used to be a [bug](https://github.com/docker/cli/issues/4958) in Docker CLI where it was overwriting custom OTEL_RESOURCE_ATTRIBUTES variable with its own attributes. It was fixed in https://github.com/docker/cli/pull/5842 and shipped in Docker version 28.0.2.