### PR TITLE
fix: Only log long message queue if process alive

### DIFF
--- a/.changeset/loud-hotels-collect.md
+++ b/.changeset/loud-hotels-collect.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Handle missing process when examining message queue lengths


### PR DESCRIPTION
Fixes [this Sentry error](https://electricsql-04.sentry.io/issues/74386802/?environment=production&project=4508410462404688&query=is%3Aunresolved&referrer=issue-stream)

We are not ensuring the process is alive when trying to log its message queue - we should guard against it being dead by the time we try to inspect it.