### PR TITLE
fix: Only include schema in 200 responses

### DIFF
--- a/.changeset/unlucky-pants-cheat.md
+++ b/.changeset/unlucky-pants-cheat.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Only include schema in 200 responses

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -238,7 +238,7 @@ defmodule Electric.Shapes.Api.Response do
     Plug.Conn.put_resp_header(conn, @electric_handle_header, response.handle)
   end
 
-  defp put_schema_header(conn, %__MODULE__{params: %{live: false}} = response) do
+  defp put_schema_header(conn, %__MODULE__{params: %{live: false}, status: 200} = response) do
     Plug.Conn.put_resp_header(
       conn,
       @electric_schema_header,


### PR DESCRIPTION
We've seen a large amount of errors on Sentry from the `Api.schema` being called when there is no connection for tons of responses.

Looking at the code it seems we _always_ call `put_schema_header` as part of `put_resp_header` even for errors - and when the error is that the stack is not up and no connection is available, an error from the schema trying to be read is guaranteed to happen.

We need to examine `put_resp_header` being called on _all_ responses as I suspect we are including too many headers on error responses, but for the schema one in particular that requires a live stack and potentially a connection, we should either only include it in 200 responses (what this PR does), or we should just omit it if it is not available.

I decided not to omit it as I am not sure what it is used for and if it is an integral part of the protocol, so for now I am just guarding it to be added on 200 responses only.