### PR TITLE
chore(sync-service): Rename shape supervisor functions

### DIFF
--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -56,7 +56,7 @@ defmodule Electric.Connection.Manager do
             | {:start_replication_client, :configuring_connection}
             | {:start_connection_pool, nil}
             | {:start_connection_pool, :connecting}
-            | :start_replication_supervisor
+            | :start_shapes_supervisor
             | {:start_replication_client, :start_streaming}
             # Steps of the :running phase:
             | :waiting_for_streaming_confirmation
@@ -424,10 +424,10 @@ defmodule Electric.Connection.Manager do
   end
 
   def handle_continue(
-        :start_replication_supervisor,
+        :start_shapes_supervisor,
         %State{
           current_phase: :connection_setup,
-          current_step: :start_replication_supervisor
+          current_step: :start_shapes_supervisor
         } = state
       ) do
     # Checking the timeline continuity to see if we need to purge all shapes persisted so far
@@ -444,8 +444,8 @@ defmodule Electric.Connection.Manager do
     if timeline_changed? or (state.purge_all_shapes? and not initializing?) do
       # Reset the Shape Subsystem:
 
-      # Stop the replication supervisor if it's running before resetting storage
-      Electric.CoreSupervisor.stop_replication_supervisor(stack_id: state.stack_id)
+      # Stop the shapes supervisor if it's running before resetting storage
+      Electric.CoreSupervisor.stop_shapes_supervisor(stack_id: state.stack_id)
 
       # Clean up the on-disk storage from all shapes.
       Electric.Shapes.Supervisor.reset_storage(shape_cache_opts: state.shape_cache_opts)
@@ -484,12 +484,12 @@ defmodule Electric.Connection.Manager do
       max_shapes: state.max_shapes
     ]
 
-    case Electric.CoreSupervisor.start_replication_supervisor(repl_sup_opts) do
+    case Electric.CoreSupervisor.start_shapes_supervisor(repl_sup_opts) do
       {:ok, _pid} ->
         :ok
 
       {:error, {:already_started, _pid}} ->
-        # Replication supervisor is already running, which can happen if the
+        # Shapes supervisor is already running, which can happen if the
         # Connection.Manager is restarting
         :ok
 
@@ -780,8 +780,8 @@ defmodule Electric.Connection.Manager do
       %{admin: {pid1, true}, snapshot: {pid2, true}} when is_pid(pid1) and is_pid(pid2) ->
         state = mark_connection_succeeded(state)
 
-        {:noreply, %{state | current_step: :start_replication_supervisor},
-         {:continue, :start_replication_supervisor}}
+        {:noreply, %{state | current_step: :start_shapes_supervisor},
+         {:continue, :start_shapes_supervisor}}
 
       _ ->
         {:noreply, state}

--- a/packages/sync-service/lib/electric/core_supervisor.ex
+++ b/packages/sync-service/lib/electric/core_supervisor.ex
@@ -37,7 +37,7 @@ defmodule Electric.CoreSupervisor do
   This function is supposed to be called from Connection.Manager at the right point in its
   initialization sequence.
   """
-  def start_replication_supervisor(opts) do
+  def start_shapes_supervisor(opts) do
     stack_id = Keyword.fetch!(opts, :stack_id)
     shape_cache_opts = Keyword.fetch!(opts, :shape_cache_opts)
     replication_opts = Keyword.fetch!(opts, :replication_opts)
@@ -99,7 +99,7 @@ defmodule Electric.CoreSupervisor do
   This is useful when you need to reset storage before starting a new supervisor.
   Returns :ok if the supervisor was stopped or wasn't running.
   """
-  def stop_replication_supervisor(opts) do
+  def stop_shapes_supervisor(opts) do
     case Supervisor.terminate_child(name(opts), Electric.Shapes.Supervisor) do
       :ok ->
         Supervisor.delete_child(name(opts), Electric.Shapes.Supervisor)


### PR DESCRIPTION
Follow up to #3369 , this renames some functions associated with the Shapes.Supervisor to be consistent.