### PR TITLE
docs: improve PostgreSQL permissions guide clarity and security

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22239,7 +22239,7 @@ snapshots:
       css-what: 6.1.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      domutils: 3.1.0
+      domutils: 3.2.2
 
   cheerio@1.0.0:
     dependencies:
@@ -22582,7 +22582,7 @@ snapshots:
       boolbase: 1.0.0
       css-what: 6.1.0
       domhandler: 5.0.3
-      domutils: 3.1.0
+      domutils: 3.2.2
       nth-check: 2.1.1
 
   css-to-react-native@3.2.0:
@@ -26922,11 +26922,11 @@ snapshots:
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
-      parse5: 7.2.1
+      parse5: 7.3.0
 
   parse5-parser-stream@7.1.2:
     dependencies:
-      parse5: 7.2.1
+      parse5: 7.3.0
 
   parse5@7.2.1:
     dependencies:


### PR DESCRIPTION
## Summary

The PostgreSQL permissions guide now provides clearer guidance for setting up Electric with minimal necessary privileges and fixes a critical error about permission requirements.

### Critical Fix

The guide previously claimed Electric could work with Automatic Mode when a DBA pre-configured tables without transferring ownership. This is impossible - PostgreSQL requires table ownership to add tables to publications. The guide now correctly documents that:
- Electric-managed publications requires table ownership transfer
- Manual mode is the only option when the app must retain table ownership

### Documentation Structure

The guide flows as:

1. **Which Permission Setup Should You Use?** - Color-coded decision guide (🟢 Superuser, 🔵 Electric-managed publications, 🔴 Manual Mode) with use cases, pros/cons for each approach

2. **Automatic vs Manual Publication Management** - Technical explanation of how the two modes work and their requirements

3. **Core Permission Requirements** - Table showing exactly which PostgreSQL privileges each mode requires:
   - Both modes: `REPLICATION`, `SELECT`
   - Electric-managed only: `CREATE` on database, table ownership, publication ownership
   - Manual mode: DBA configures REPLICA IDENTITY and publications

4. **Setup Examples** - Step-by-step SQL and configuration for:
   - Development (superuser)
   - Electric-managed publications (production)
   - Manual mode (least-privilege production)

5. **Manual Configuration Steps** - Complete DBA workflow with verification queries

6. **Troubleshooting & Next Steps**

### Security Posture

- Electric-managed publications requires only `CREATE ON DATABASE` (not `CREATE ON SCHEMA`)
- Ownership transfer examples show both targeted (specific tables) and bulk approaches
- Manual mode requires only `REPLICATION` + `SELECT` - DBA handles all configuration
- Verification queries help users confirm correct setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)