### PR TITLE
docs: fix ShapeStreamOptions handle parameter name

### DIFF
--- a/website/docs/api/clients/typescript.md
+++ b/website/docs/api/clients/typescript.md
@@ -235,7 +235,7 @@ export interface ShapeStreamOptions<T = never> {
    * will handle this automatically. A common scenario where you might pass an offset
    * is if you're maintaining a local cache of the log. If you've gone offline
    * and are re-starting a ShapeStream to catch-up to the latest state of the Shape,
-   * you'd pass in the last offset and shapeHandle you'd seen from the Electric server
+   * you'd pass in the last offset and handle you'd seen from the Electric server
    * so it knows at what point in the shape to catch you up from.
    */
   offset?: Offset
@@ -244,7 +244,7 @@ export interface ShapeStreamOptions<T = never> {
    * Similar to `offset`, this isn't typically used unless you're maintaining
    * a cache of the shape log.
    */
-  shapeHandle?: string
+  handle?: string
 
   /**
    * HTTP headers to attach to requests made by the client.


### PR DESCRIPTION
The ShapeStreamOptions documentation incorrectly referred to the handle parameter as `shapeHandle`. This fixes both the property definition and the comment reference to use the correct name `handle`, matching the actual TypeScript client implementation.