### PR TITLE
feat: Fail requests waiting for snapshot after a short time without crashing shape

### DIFF
--- a/.changeset/nine-walls-carry.md
+++ b/.changeset/nine-walls-carry.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Fail requests waiting for snapshot to start after shorter time without failing entire snapshot.

--- a/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_supervisor.ex
@@ -18,6 +18,10 @@ defmodule Electric.Shapes.ConsumerSupervisor do
               type: {:or, [:non_neg_integer, {:in, [:infinity]}]},
               default: :timer.seconds(30)
             ],
+            snapshot_waiting_for_data_interval: [
+              type: :non_neg_integer,
+              default: :timer.seconds(5)
+            ],
             hibernate_after: [type: :integer, required: true],
             action: [type: {:in, [:restore, :create]}, default: :create],
             otel_ctx: [type: :any, required: false]
@@ -96,6 +100,7 @@ defmodule Electric.Shapes.ConsumerSupervisor do
          shape: config.shape,
          shape_handle: shape_handle,
          snapshot_timeout_to_first_data: config.snapshot_timeout_to_first_data,
+         snapshot_waiting_for_data_interval: config.snapshot_waiting_for_data_interval,
          stack_id: config.stack_id,
          storage: shape_storage
        }},

--- a/packages/sync-service/lib/electric/snapshot_error.ex
+++ b/packages/sync-service/lib/electric/snapshot_error.ex
@@ -17,11 +17,17 @@ defmodule Electric.SnapshotError do
     }
   end
 
-  def slow_snapshot_query(ttf_ms) do
+  def slow_snapshot_query(ttf_ms, cancelled?: cancelled?) do
+    message =
+      if cancelled?,
+        do: "Snapshot query took too long to return data (cancelled after #{ttf_ms}ms).",
+        else: "Snapshot query is taking a long time to return data (waiting for #{ttf_ms}ms)."
+
     %SnapshotError{
       type: :slow_snapshot_query,
       message:
-        "Snapshot query took too long to return data (cancelled after #{ttf_ms}ms). Please ensure snapshot queries are using an index to avoid taking up all database connections."
+        message <>
+          " Please ensure snapshot queries are using an index to avoid taking up all database connections."
     }
   end
 


### PR DESCRIPTION
Relevant to https://github.com/electric-sql/electric/issues/3365

We have observed lots of timeouts on requests calling `await_snapshot_start`, which fail with a `RuntimeError` because the call times out after 15 seconds. We log those as errors on Sentry and return 500s, but we should break down what happens more cleanly.

Looking at honeycomb I've noticed at high peak load we sometimes see queries taking >20-25 seconds, and I believe that it takes that long to see the first data appear (e.g. because the query is unindexed/on a large table).

Our default snapshot "timeout" to first data is 30 seconds, as we want to allow snapshot to take long, but requests for it time out before we error the snapshot, ending up as 500s, although they really should be 503s.

I've added a `snapshot_waiting_for_data_interval` option and set that to 5 seconds. As soon as the query is executed, we send a `waiting_for_snapshot_data` message to the consumer every 5 seconds, and fail any snapshot waiters with an appropriate error.

This solves being able to quickly and correctly reply to requests without holding them for too long, without sacrificing the ability to let a shape take longer than how long we want requests to be held for.

With this, we can observe if we still get snapshot timeouts 500s, at which point I can only think that it might happen because the consumers take _too long_ to subscribe to a busy ShapeLogCollector, but I have no evidence for that so I'd like to filter out the cases where the database being the actual bottleneck.



## NOTE

Currently if a request comes in the _moment_ a `waiting_for_snapshot_data` message is sent, it will immediately be failed, so the interval timeout is not per request. However that is already the behaviour for our overall snapshot timeout - if a request comes in right before the overall timeout runs out it is immediately failed.

I could make the request holding per-request by adding "request_arrived_at" timestamps on the waiters and doing appropriate calculations, but I'd prefer to keep things simple, especially for cases like these where it's already _very_ slow snapshots.

There is also an alternative of just setting the timeout for the snapshot to get data to a much smaller time, but it _will_ start failing actual queries that can be fulfilled that just take long.