### PR TITLE
fix: Increase queue timeouts for snapshot connections

### DIFF
--- a/.changeset/silent-dots-bathe.md
+++ b/.changeset/silent-dots-bathe.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Allow snapshot query connection pool to queue up requests for connections for longer to smoothen out bursts.


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/3365

During startup, if there is a large burst of requests for new shapes, we see a huge number of shapes started and then immediately failed and cleaned up, with the failure reason being that they could not check out a connection from the snapshot pool. (e.g. we've seen ~100k shapes being invalidated in less than 15 minutes because of bursts)

The default timeout used is 50ms, doubled to 100ms if the pool is very busy. That is still a very low threshold to consider a shape failed, I think we can afford to wait for a bit longer for a connection to become available for a snapshot before failing the shape wholesale.

Instead of implementing messy retries in the snapshotter and deciding on arbitrary timeouts there, I think it makes sense to leverage the queueing mechanism of Postgrex pools and set the queue targets to something much larger than the default. 

I've picked 5 seconds target and 10 seconds queue interval, meaning that if the pool is fully busy during a 10 second interval, checkouts might take as long as 2 x 5 = 10 seconds to checkout a connection before being marked as failed.

This ensures that new shapes are not immediately invalidated if the pool is busy, but instead queue up on the connection pool queuing mechanism.

