### PR TITLE
fix: Return 503s rather than 400 for no generated column replication

### DIFF
--- a/.changeset/fresh-lies-begin.md
+++ b/.changeset/fresh-lies-begin.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Return 503 instead of 400 in case generated column replication is not enabled for PG >=18.

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -667,9 +667,6 @@ defmodule Electric.Shapes.Api do
         Logger.warning("Schema changed while creating snapshot for #{shape_handle}")
         Response.error(request, error.message, status: error.status)
 
-      {:error, %SnapshotError{type: :publication_missing_generated_columns} = error} ->
-        Response.error(request, error.message, status: 400, known_error: true)
-
       {:error, %SnapshotError{} = error} ->
         Logger.warning("Failed to create snapshot for #{shape_handle}: #{error.message}")
 

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -763,7 +763,7 @@ defmodule Electric.Plug.RouterTest do
         conn =
           conn("GET", "/v1/shape?table=#{@generated_pk_table}&offset=-1") |> Router.call(opts)
 
-        assert %{status: 400} = conn
+        assert %{status: 503} = conn
 
         assert Jason.decode!(conn.resp_body) ==
                  %{


### PR DESCRIPTION
When it is possible to replicate generated columns (PG >=18) but it is not configured, we should return 503 rather than 400, similar to how we return 503 for missing privileges on tables.

Simplifies API handling of snapshot errors further.