### PR TITLE
fix: Avoid existence check for async deletes

### DIFF
--- a/.changeset/pretty-tomatoes-eat.md
+++ b/.changeset/pretty-tomatoes-eat.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Avoid additionaly syscall when asynchronously deleting things by assuming uniqueness with strong fallback.


### PR DESCRIPTION
Follow-up to https://github.com/electric-sql/electric/pull/3403
See relevant discussion https://github.com/electric-sql/electric/pull/3403#discussion_r2509361641

Instead of doing two syscalls for deleting files asynchronously via a rename, an existence check and the rename itself, assume the target is unique enough and add a fallback in case it is not.

I've added a limited retry attempts mechanism _just in case_ - thankfully very easy to implement and very encapsulated.

I've kept the `System.unique_integer` alone as the random suffix and did not replace it or use monotonic time - firstly because monotonic time alone is not enough of a uniqueness guarantee, and secondly because I thought that adding both would be overkill (to ensure uniqueness across restarts).