### PR TITLE
fix: Ensure `consumer_pid` returns nil if table missing

### DIFF
--- a/.changeset/rude-olives-pay.md
+++ b/.changeset/rude-olives-pay.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Ensure consumer registry does not crash on a lookup when registry table is missing.

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -120,6 +120,8 @@ defmodule Electric.Shapes.ConsumerRegistry do
 
   defp consumer_pid(handle, table) do
     :ets.lookup_element(table, handle, 2, nil)
+  rescue
+    ArgumentError -> nil
   end
 
   defp start_consumer!(handle, %__MODULE__{stack_id: stack_id} = state) do


### PR DESCRIPTION
If the shape log collector is down, then the consumer supervisor is down and no consumers are alive, and thus we can safely return `nil` when looking up a consumer process.