### PR TITLE
fix(sync-service): Pass stack_id correctly to start_consumer_for_handle/2

### DIFF
--- a/.changeset/three-adults-drum.md
+++ b/.changeset/three-adults-drum.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Fix function arguments for ShapeCache.start_consumer_for_handle/2

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -128,7 +128,7 @@ defmodule Electric.Shapes.ConsumerRegistry do
       ["shape.handle": handle],
       state.stack_id,
       fn ->
-        case ShapeCache.start_consumer_for_handle(handle, stack_id: stack_id) do
+        case ShapeCache.start_consumer_for_handle(handle, stack_id) do
           {:ok, pid} ->
             Logger.info("Started consumer for existing handle #{handle}")
 

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -147,7 +147,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         Electric.ShapeCache,
         :start_consumer_for_handle,
         [mode: :shared],
-        fn shape_handle, stack_id: ^stack_id ->
+        fn shape_handle, ^stack_id ->
           id = System.unique_integer([:positive, :monotonic])
 
           with {:ok, pid} <-

--- a/packages/sync-service/test/electric/shapes/consumer_registry_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_registry_test.exs
@@ -39,7 +39,7 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
     Repatch.patch(
       Electric.ShapeCache,
       :start_consumer_for_handle,
-      fn handle, stack_id: ^stack_id ->
+      fn handle, ^stack_id ->
         send(parent, {:start_consumer, handle})
 
         {:ok, pid} =


### PR DESCRIPTION
Fixes #3417