### PR TITLE
fix: Isolate call home reporter post request

### DIFF
--- a/.changeset/fast-pens-yell.md
+++ b/.changeset/fast-pens-yell.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Isolate call home reporter HTTP request to avoid interference from HTTP pool messages.

--- a/packages/sync-service/lib/electric/telemetry/call_home_reporter.ex
+++ b/packages/sync-service/lib/electric/telemetry/call_home_reporter.ex
@@ -42,7 +42,10 @@ with_telemetry Telemetry.Metrics do
     end
 
     def report_home(results) do
-      Req.post!(telemetry_url(), json: results, retry: :transient)
+      url = telemetry_url()
+      # Isolate the request in a separate task to avoid blocking and
+      # to not receive any messages from the HTTP pool internals
+      Task.start(fn -> Req.post!(url, json: results, retry: :transient) end)
       :ok
     end
 


### PR DESCRIPTION
We have observed :reuse messages received because of the usage of Req/HTTP requests in the process, see [Sentry issue](https://electricsql-04.sentry.io/issues/76823353/?environment=production&project=4508410462404688&query=is%3Aunresolved&referrer=issue-stream), and relevant PR for the OTEL metric exporter https://github.com/electric-sql/elixir-otel-metric-exporter/pull/25

Rather than handle those messages in the process arbitrarily it feels like it makes more sense to simply isolate the request itself - and since we don't do anything with the response, we can just fire and forget.