### PR TITLE
fix: Ensure recovered shape after crash can handle new data

### DIFF
--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -247,14 +247,21 @@
     ?$prompt
 [endmacro]
 
-[macro shape_get_snapshot table]
+[macro shape_get_url params]
   # strip ANSI codes from response for easier matching
-  !curl --silent -i "http://localhost:3000/v1/shape?table=$table&offset=-1" | sed -r "s/\x1B\[[0-9;]*[mK]//g"
+  !curl --silent -i "http://localhost:3000/v1/shape?$params" | sed -r "s/\x1B\[[0-9;]*[mK]//g"
+[endmacro]
+
+[macro shape_get_snapshot table]
+  [invoke shape_get_url "table=$table&offset=-1"]
 [endmacro]
 
 [macro shape_get table handle offset]
-  # strip ANSI codes from response for easier matching
-  !curl --silent -i "http://localhost:3000/v1/shape?table=$table&handle=$handle&offset=$offset" | sed -r "s/\x1B\[[0-9;]*[mK]//g"
+  [invoke shape_get_url "table=$table&handle=$handle&offset=$offset"]
+[endmacro]
+
+[macro shape_get_live table handle offset]
+  [invoke shape_get_url "table=$table&handle=$handle&offset=$offset&live=true"]
 [endmacro]
 
 # Prevent curl from outputing download progress, output response headers nd sort the keys in the response JSON body.

--- a/integration-tests/tests/crash-recovery.lux
+++ b/integration-tests/tests/crash-recovery.lux
@@ -60,5 +60,19 @@
   [invoke shape_get items $handle $offset]
   ??HTTP/1.1 200 OK
 
+
+# Recovered shape should handle new data
+[shell psql]
+  """!
+  INSERT INTO items (id, val)
+  VALUES (gen_random_uuid(), '# new test val');
+  """
+  ??INSERT 0 1
+
+[shell client]
+  [invoke shape_get_live items $handle $offset]
+  ??HTTP/1.1 200 OK
+  ??"val":"# new test val"
+
 [cleanup]
   [invoke teardown]


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/3420

We already had a test for Electric recovering a shape, but we were not asserting that the recovered shape can _actually_ process new data coming in for it.