### PR TITLE
feat(sync-service): Re-enable pluggable snapshot function

### DIFF
--- a/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
+++ b/packages/sync-service/lib/electric/shapes/dynamic_consumer_supervisor.ex
@@ -14,7 +14,7 @@ defmodule Electric.Shapes.DynamicConsumerSupervisor do
   """
   def child_spec(opts) do
     stack_id = Keyword.fetch!(opts, :stack_id)
-    name = Keyword.get(opts, :name, name(stack_id))
+    {name, opts} = Keyword.pop(opts, :name, name(stack_id))
 
     # We're overriding Electric.Shapes.DynamicConsumerSupervisor's child_spec() function here
     # to make the usage of PartitionSupervisor transparent to the callers. As a consequence, we

--- a/packages/sync-service/lib/electric/stack_config.ex
+++ b/packages/sync-service/lib/electric/stack_config.ex
@@ -17,6 +17,16 @@ defmodule Electric.StackConfig do
         message: "stack config value #{inspect(key)} is missing for stack #{stack_id}"
   end
 
+  @doc false
+  # Should provide all required values not defined dynamically at stack init
+  def default_seed_config do
+    [
+      snapshot_timeout_to_first_data: :timer.seconds(30),
+      shape_hibernate_after: Electric.Config.default(:shape_hibernate_after),
+      chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold()
+    ]
+  end
+
   ###
 
   def name(stack_ref) do
@@ -37,9 +47,11 @@ defmodule Electric.StackConfig do
   def init(opts) do
     stack_id = Keyword.fetch!(opts, :stack_id)
 
+    seed_config = Keyword.merge(default_seed_config(), Keyword.get(opts, :seed_config, []))
+
     tab = table(stack_id)
     :ets.new(tab, [:public, :named_table, :set, read_concurrency: true])
-    :ets.insert(tab, Keyword.fetch!(opts, :seed_config))
+    :ets.insert(tab, seed_config)
 
     {:ok, nil}
   end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -363,7 +363,6 @@ defmodule Electric.StackSupervisor do
              chunk_bytes_threshold: config.chunk_bytes_threshold,
              snapshot_timeout_to_first_data: config.tweaks[:snapshot_timeout_to_first_data],
              inspector: inspector,
-             shape_changes_registry: shape_changes_registry_name,
              shape_hibernate_after: shape_hibernate_after
            ]},
           {Electric.AsyncDeleter,


### PR DESCRIPTION
Phoenix.Sync relies on patching the snapshot function in its sandbox repo feature (where it uses an Ecto.Repo instance to get a pool connection and returns fake xids). When we removed dependency injection we broke this, so this PR just adds back in the ability to inject a custom stream_snapshot_from_db/5 function.

I also removed the requirement to pass seed_config to the stack config instance by adding in defaults for most of the required values and removed the unused `shape_changes_registry` value from the stack config. We have defaults for these values so we should use them. Generally if we add config we should have a default -- it makes Phoenix.Sync less likely to break with every addition.

In DynamicConsumerSupervisor I noticed a potential problem where the DynamicSupervisor spec passed to PartitionSupervisor could have a `name` which would cause problems.