### PR TITLE
feat: Consumers idempotently handle transactions

### DIFF
--- a/.changeset/brave-crews-help.md
+++ b/.changeset/brave-crews-help.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Ensure shape consumers idempotently handle transactions using log offset comparisons.

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -722,6 +722,9 @@ defmodule Electric.Shapes.ConsumerTest do
                Storage.get_log_stream(LogOffset.last_before_real_offsets(), shape_storage)
                |> Enum.map(&Jason.decode!/1)
 
+      # Reset LSN to re-send transaction
+      ShapeLogCollector.set_last_processed_lsn(ctx.producer, Lsn.increment(lsn, -1))
+
       # If we encounter & store the same transaction, log stream should be stable
       assert :ok = ShapeLogCollector.store_transaction(txn, ctx.producer)
 


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/3447

This is part of a larger piece of work described in https://github.com/electric-sql/electric/issues/3442

We were already filtering transactions at the SLC level, but for the sake of loosening the requirements of having a central "latest LSN processed" node for filtering we move the filter at the consumer level.

For the sake of maintaining what we already have in place, I'm simply comparing the latest log offset of the transaction compared to the latest log offset tracked by the consumer - the flush acknowledgements are separate anyway, if a flush ack is not sent for a transaction then it will be sent again anyway.

I've also fixed the `latest_offset` state variable kept in the consumer which was not being updated.