### PR TITLE
fix: Configuration timeout tests get killed if transaction holding lock fails to complete within timeout

### DIFF
--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -125,7 +125,8 @@ defmodule Electric.Postgres.ConfigurationTest do
                  receive do
                    _ -> :ok
                  end
-               end
+               end,
+               timeout: :infinity
              )
            end},
           restart: :temporary


### PR DESCRIPTION
I've found a way to reproduce this flake that's occurring on CI and it seems this task getting killed is at least one reason. Given CI runs into a lot more contention and slowness than we do locally this is plausible.

Example from [this run](https://github.com/electric-sql/electric/actions/runs/19534111740/job/55923915668):
<img width="927" height="130" alt="image" src="https://github.com/user-attachments/assets/a210c6b9-b11c-4352-b236-95b187f5da38" />
