### PR TITLE
fix: Avoid edge case with 409 causing more SSE requests

### DIFF
--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -2276,7 +2276,7 @@ it(
   async ({ issuesTableUrl, aborter }) => {
     let requestCount = 0
     let sseRequestCount = 0
-    let initialHandle: string | null = null
+    let initialHandle: string | undefined
     const requestUrls: string[] = []
 
     // Mock console.warn to capture the fallback warning
@@ -2300,7 +2300,7 @@ it(
         const reqHandle = urlObj.searchParams.get(SHAPE_HANDLE_HEADER)
 
         if (isSSE && (!initialHandle || reqHandle === initialHandle)) {
-          initialHandle ??= reqHandle
+          initialHandle ??= reqHandle!
           sseRequestCount++
           // Handle up to 4 SSE requests (we expect 3, but might see 4 due to timing)
           if (sseRequestCount <= 4) {


### PR DESCRIPTION
Fix test flake (see [this run](https://github.com/electric-sql/electric/actions/runs/19533935381/job/55923347981) for example) caused by 409s for the shape resetting the fallback from SSE to long polling.

Not sure if 409s _should_ reset this fallback but it does, and the test should account for it as we occasionally see these 409s from the tests overlapping each other.