### PR TITLE
chore(sync-service): Reduce log level of start consumer message

### DIFF
--- a/.changeset/neat-melons-report.md
+++ b/.changeset/neat-melons-report.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Reduce logging when starting a consumer process

--- a/integration-tests/tests/shape-suspension-resumption.lux
+++ b/integration-tests/tests/shape-suspension-resumption.lux
@@ -57,7 +57,7 @@
 
 
 [shell electric]
-  ??[info] Started consumer for existing handle $handle
+  ??[debug] Started consumer for existing handle $handle
   !{:active_consumer_count, Electric.Shapes.ConsumerRegistry.active_consumer_count("single_stack")}
   ?{:active_consumer_count, 1}
 

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -161,7 +161,7 @@ defmodule Electric.Shapes.ConsumerRegistry do
       fn ->
         case ShapeCache.start_consumer_for_handle(handle, stack_id) do
           {:ok, pid} ->
-            Logger.info("Started consumer for existing handle #{handle}")
+            Logger.debug(fn -> ["Started consumer for existing handle ", handle] end)
 
             pid
 


### PR DESCRIPTION
This happens a lot with consumers now suspending and is really not that useful