### PR TITLE
fix: Crash recovery fails because of invalid restored offset

### DIFF
--- a/integration-tests/tests/crash-recovery.lux
+++ b/integration-tests/tests/crash-recovery.lux
@@ -80,7 +80,7 @@
   [invoke shape_get items $handle $offset]
   ??HTTP/1.1 200 OK
   ??electric-handle: $handle
-  ??"val":"#pre-crash test val"
+  ??[{"headers":{"control":"up-to-date","global_last_seen_lsn":
 
 
 # Recovered shape should handle new data


### PR DESCRIPTION
Companion to https://github.com/electric-sql/electric/pull/3482

Updated the integration test to show that it currently fails to read recovered shapes, and it only worked because it happened to only test the snapshot.

The recovered shapes are not woken up and thus their latest offset is not updated, causing the readers to fail with out of bounds error.