### PR TITLE
feat(sync-service): Support LIKE and ILIKE functions

### DIFF
--- a/.changeset/empty-actors-leave.md
+++ b/.changeset/empty-actors-leave.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Support LIKE and ILIKE functions in where clauses (LIKE and ILIKE binary operators were already supported)

--- a/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
@@ -96,6 +96,9 @@ defmodule Electric.Replication.Eval.Env.KnownFunctions do
     def not_ilike?(text1, text2), do: not Casting.ilike?(text1, text2)
   end
 
+  defpostgres("like(text, text) -> bool", delegate: &Casting.like?/2)
+  defpostgres("ilike(text, text) -> bool", delegate: &Casting.ilike?/2)
+
   ## Date functions
   defpostgres("date + int8 -> date", commutative?: true, delegate: &Date.add/2)
   defpostgres("date - date -> int8", delegate: &Date.diff/2)

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -350,6 +350,18 @@ defmodule Electric.Replication.Eval.ParserTest do
       assert %Const{value: true, type: :bool} = result
     end
 
+    test "should work with LIKE and ILIKE functions" do
+      env = Env.new()
+
+      assert {:ok, %Expr{eval: result}} =
+               Parser.parse_and_validate_expression(
+                 ~S|NOT LIKE('hello', 'hell\%') AND ILIKE('hello', 'h%o') |,
+                 env: env
+               )
+
+      assert %Const{value: true, type: :bool} = result
+    end
+
     test "should work with BETWEEN clauses" do
       env = Env.new()
 


### PR DESCRIPTION
Fix for #3487 . This PR adds support for `LIKE/2` and `ILIKE/2` functions in where clauses. `LIKE` and `ILIKE` operators were already supported.