### PR TITLE
chore(sync-service): Hibernate ShapeStatusOwner process

### DIFF
--- a/.changeset/eleven-radios-sit.md
+++ b/.changeset/eleven-radios-sit.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Hibernate the shape status owner process to release any memory accumulated during startup

--- a/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
@@ -43,7 +43,7 @@ defmodule Electric.ShapeCache.ShapeStatusOwner do
     :ok = ShapeStatus.initialize_from_storage(stack_id, config.storage)
     :ok = Electric.LsnTracker.initialize(stack_id)
 
-    {:ok, %{stack_id: stack_id, storage: config.storage}}
+    {:ok, %{stack_id: stack_id, storage: config.storage}, :hibernate}
   end
 
   @impl true


### PR DESCRIPTION
If the recovery process is unable to restore the status ets tables from backup files and has to iterate the filesystem then ShapeStatusOwner is left with a lot of accumulated memory (~300MB for a system with 200K shapes).

Release this by hibernating immediately (this process does nothing but own ets tables anyway).