### PR TITLE
Create a single enum type for use in tests

### DIFF
--- a/packages/sync-service/dev/init.sql
+++ b/packages/sync-service/dev/init.sql
@@ -2,3 +2,7 @@
 
 -- Unprivileged role for use in tests.
 CREATE ROLE unprivileged LOGIN PASSWORD 'password' REPLICATION;
+
+-- An enum type for tests. Since enum types are global per Postgres cluster, it's easier to set
+-- one up here than to manage their lifetimes in test setup code.
+CREATE TYPE my_enum AS ENUM ('value1', 'value2', 'value3');

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2745,7 +2745,6 @@ defmodule Electric.Plug.RouterTest do
     end
 
     @tag with_sql: [
-           "CREATE TYPE my_enum AS ENUM ('value1', 'value2', 'value3')",
            "CREATE TABLE enum_table (id UUID PRIMARY KEY, status my_enum NOT NULL)",
            "INSERT INTO enum_table VALUES (gen_random_uuid(), 'value1')",
            "INSERT INTO enum_table VALUES (gen_random_uuid(), 'value2')"
@@ -2766,7 +2765,6 @@ defmodule Electric.Plug.RouterTest do
     end
 
     @tag with_sql: [
-           "CREATE TYPE my_enum AS ENUM ('value1', 'value2', 'value3')",
            "CREATE TABLE enum_table (id UUID PRIMARY KEY, status my_enum NOT NULL)",
            "INSERT INTO enum_table VALUES (gen_random_uuid(), 'value1')"
          ]


### PR DESCRIPTION
Creating enums on-demand doesn't work with our current test setup because the type is not scoped under a single database. It's been working fine on CI but when running tests locally, after the first time the enum type is created, subsequent attempts all fail with the "type already exists" error.