### PR TITLE
Parse feature flags into relevant config options

### DIFF
--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -152,10 +152,15 @@ defmodule Electric.Application do
   # Gets the API-side configuration based on the same opts + application config
   # used for `configuration/1`
   defp api_configuration(opts) do
-    opts
-    |> core_configuration()
-    |> Electric.StackSupervisor.build_shared_opts()
+    {feature_flags, core_config} =
+      opts
+      |> core_configuration()
+      |> Electric.StackSupervisor.build_shared_opts()
+      |> Keyword.pop(:feature_flags)
+
+    core_config
     |> Keyword.merge(
+      allow_subqueries?: Electric.Config.feature_flag_allow_subqueries() in feature_flags,
       long_poll_timeout: get_env(opts, :long_poll_timeout),
       max_age: get_env(opts, :cache_max_age),
       stale_age: get_env(opts, :cache_stale_age),

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -19,7 +19,7 @@ defmodule Electric.Shapes.Api do
     stack_id: [type: :string, required: true],
     inspector: [type: :mod_arg, required: true],
     allow_shape_deletion: [type: :boolean],
-    feature_flags: [type: {:list, :string}, default: []],
+    allow_subqueries?: [type: :boolean],
     keepalive_interval: [type: :integer],
     long_poll_timeout: [type: :integer],
     sse_timeout: [type: :integer],
@@ -45,9 +45,9 @@ defmodule Electric.Shapes.Api do
     :inspector,
     :shape,
     :stack_id,
-    :feature_flags,
     :max_concurrent_requests,
     allow_shape_deletion: false,
+    allow_subqueries?: false,
     keepalive_interval: 21_000,
     long_poll_timeout: 20_000,
     sse_timeout: 60_000,
@@ -139,7 +139,11 @@ defmodule Electric.Shapes.Api do
   def predefined_shape(%Api{} = api, shape_params) do
     with :ok <- hold_until_stack_ready(api),
          {:ok, params} <- normalise_shape_params(shape_params),
-         opts = Keyword.merge(params, inspector: api.inspector, feature_flags: api.feature_flags),
+         opts =
+           Keyword.merge(params,
+             inspector: api.inspector,
+             allow_subqueries?: api.allow_subqueries?
+           ),
          {:ok, shape} <- Shapes.Shape.new(opts) do
       {:ok, %{api | shape: shape}}
     end

--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -322,7 +322,7 @@ defmodule Electric.Shapes.Api.Params do
            columns: columns,
            replica: replica,
            inspector: api.inspector,
-           feature_flags: api.feature_flags,
+           allow_subqueries?: api.allow_subqueries?,
            storage: %{compaction: if(compaction_enabled?, do: :enabled, else: :disabled)},
            log_mode: fetch_field!(changeset, :log)
          ) do

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -292,8 +292,8 @@ defmodule Electric.Shapes.Consumer do
       "Consumer reacting to #{length(move_in)} move ins and #{length(move_out)} move outs in it's #{dep_handle} dependency"
     end)
 
-    feature_flags = Electric.StackConfig.lookup(state.stack_id, :feature_flags, [])
-    tagged_subqueries_enabled? = "tagged_subqueries" in feature_flags
+    tagged_subqueries_enabled? =
+      Electric.StackConfig.lookup!(state.stack_id, :tagged_subqueries_enabled?)
 
     should_invalidate? = own_materializer_exists?(state) or not tagged_subqueries_enabled?
 
@@ -384,7 +384,8 @@ defmodule Electric.Shapes.Consumer do
   end
 
   defp consumer_suspend_enabled?(%{stack_id: stack_id}) do
-    Electric.StackConfig.lookup(stack_id, :shape_enable_suspend?, true)
+    # Electric.StackConfig.lookup(stack_id, :shape_enable_suspend?, true)
+    Electric.StackConfig.lookup!(stack_id, :shape_enable_suspend?)
   end
 
   defp consumer_can_suspend?(state) do

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -166,7 +166,9 @@ defmodule Electric.Shapes.Shape do
       type: :mod_arg,
       default: {Electric.Postgres.Inspector, Electric.DbPool}
     ],
-    feature_flags: [type: {:list, :string}, default: Electric.Config.get_env(:feature_flags)],
+    # The default value is only used in tests. In normal usage we expect this option to be
+    # passed in by the caller.
+    allow_subqueries?: [type: :boolean, default: Electric.Config.get_env(:allow_subqueries?)],
     storage: [
       type: {
         :or,
@@ -269,7 +271,7 @@ defmodule Electric.Shapes.Shape do
   defp validate_where_clause(where, %{inspector: inspector} = opts, refs) do
     with {:ok, where} <- Parser.parse_query(where),
          {:ok, subqueries} <- Parser.extract_subqueries(where),
-         :ok <- check_feature_flag(subqueries, opts),
+         :ok <- check_if_subqueries_are_allowed(subqueries, opts),
          {:ok, shape_dependencies} <- build_shape_dependencies(subqueries, opts),
          {:ok, dependency_refs} <- build_dependency_refs(shape_dependencies, inspector),
          all_refs = Map.merge(refs, dependency_refs),
@@ -288,12 +290,11 @@ defmodule Electric.Shapes.Shape do
     end
   end
 
-  defp check_feature_flag(subqueries, opts) do
-    if subqueries != [] and
-         not Enum.member?(opts.feature_flags, "allow_subqueries") do
-      {:error, {:where, "Subqueries are not supported"}}
-    else
+  defp check_if_subqueries_are_allowed(subqueries, opts) do
+    if subqueries == [] or opts.allow_subqueries? do
       :ok
+    else
+      {:error, {:where, "Subqueries are not supported"}}
     end
   end
 

--- a/packages/sync-service/lib/electric/stack_config.ex
+++ b/packages/sync-service/lib/electric/stack_config.ex
@@ -31,7 +31,6 @@ defmodule Electric.StackConfig do
       shape_hibernate_after: Electric.Config.default(:shape_hibernate_after),
       shape_enable_suspend?: Electric.Config.default(:shape_enable_suspend?),
       chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
-      feature_flags: [],
       process_spawn_opts: %{}
     ]
   end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -100,7 +100,7 @@ defmodule Electric.StackSupervisor do
                    type: :pos_integer,
                    default: LogChunker.default_chunk_size_threshold()
                  ],
-                 feature_flags: [type: {:list, :string}, default: []],
+                 feature_flags: [type: {:list, :atom}, default: []],
                  tweaks: [
                    type: :keyword_list,
                    required: false,
@@ -318,6 +318,10 @@ defmodule Electric.StackSupervisor do
 
     shape_hibernate_after = Keyword.fetch!(config.tweaks, :shape_hibernate_after)
     shape_enable_suspend? = Keyword.fetch!(config.tweaks, :shape_enable_suspend?)
+
+    tagged_subqueries_enabled? =
+      Electric.Config.feature_flag_tagged_subqueries() in config.feature_flags
+
     process_spawn_opts = Keyword.fetch!(config.tweaks, :process_spawn_opts)
 
     shape_cache_opts = [
@@ -368,8 +372,8 @@ defmodule Electric.StackSupervisor do
            inspector: inspector,
            shape_hibernate_after: shape_hibernate_after,
            shape_enable_suspend?: shape_enable_suspend?,
-           process_spawn_opts: process_spawn_opts,
-           feature_flags: Map.get(config, :feature_flags, [])
+           tagged_subqueries_enabled?: tagged_subqueries_enabled?,
+           process_spawn_opts: process_spawn_opts
          ]},
         {Electric.AsyncDeleter,
          stack_id: stack_id,

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -111,7 +111,6 @@ defmodule Support.ComponentSetup do
                Map.get(ctx, :registry, Electric.StackSupervisor.registry_name(stack_id)),
              shape_hibernate_after: Map.get(ctx, :shape_hibernate_after, 1_000),
              shape_enable_suspend?: Map.get(ctx, :suspend, false),
-             feature_flags: Electric.Config.get_env(:feature_flags),
              process_spawn_opts: Map.get(ctx, :process_spawn_opts, %{})
            ],
            seed_config
@@ -416,6 +415,8 @@ defmodule Support.ComponentSetup do
     replication_connection_opts =
       Keyword.merge(ctx.db_config, List.wrap(ctx[:connection_opt_overrides]))
 
+    feature_flags = Electric.Config.get_env(:feature_flags)
+
     stack_supervisor =
       start_supervised!(
         {Electric.StackSupervisor,
@@ -448,7 +449,7 @@ defmodule Support.ComponentSetup do
            shape_cleaner_opts: shape_cleaner_opts(ctx)
          ],
          manual_table_publishing?: Map.get(ctx, :manual_table_publishing?, false),
-         feature_flags: Electric.Config.get_env(:feature_flags)},
+         feature_flags: feature_flags},
         restart: :temporary,
         significant: false
       )
@@ -467,7 +468,7 @@ defmodule Support.ComponentSetup do
       storage: storage,
       inspector:
         {EtsInspector, stack_id: stack_id, server: EtsInspector.name(stack_id: stack_id)},
-      feature_flags: Electric.Config.get_env(:feature_flags),
+      feature_flags: feature_flags,
       publication_name: publication_name
     }
   end
@@ -482,6 +483,7 @@ defmodule Support.ComponentSetup do
       max_age: 60,
       stale_age: 300,
       allow_shape_deletion: true,
+      allow_subqueries?: true,
       secret: ctx[:secret]
     ]
     |> Keyword.merge(


### PR DESCRIPTION
Can anyone name one good reason for threading feature flags as a list of strings through internal module function calls?

They are used as a convenient way to provide tweaks from the outside. Internally, they should be parsed into relevant options at the edge.

Unfortunately, Electric has multiple input edges, so the resulting code is not as simple as I'd have liked it to be.