### PR TITLE
Improves SPA Link Behavior for Cloud Sign-up Redirect

### DIFF
--- a/website/product/cloud.md
+++ b/website/product/cloud.md
@@ -171,7 +171,7 @@ Let us know if you have any questions. We'll be very happy to help. You can ask 
 <div class="actions cta-actions page-footer-actions left">
   <div class="action cloud-cta">
     <VPButton
-        href="/product/cloud/sign-up"
+        href="https://dashboard.electric-sql.cloud/"
         text="Sign-up for Cloud"
         theme="brand"
     />


### PR DESCRIPTION
This update addresses inconsistent redirect behavior when navigating to the Cloud sign-up page. Previously, clicking the link within the same tab triggered the SPA router, keeping the user inside the VitePress app. Opening the same link in a new tab bypassed the router and correctly followed the server-side redirect to the ElectricSQL Cloud dashboard.

This change ensures consistent navigation by updating the sign-up link logic, preventing router interception and allowing the expected redirect to occur in both same-tab and new-tab scenarios.