### PR TITLE
chore(sync-service): Remove redundant behaviours

### DIFF
--- a/.changeset/perfect-dryers-mate.md
+++ b/.changeset/perfect-dryers-mate.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Remove redundant behaviour descriptions

--- a/packages/sync-service/lib/electric.ex
+++ b/packages/sync-service/lib/electric.ex
@@ -31,6 +31,7 @@ defmodule Electric do
 
   @type pg_connection_opts :: [unquote(NimbleOptions.option_typespec(opts_schema))]
   @type stack_id :: binary()
+  @type shape_handle() :: binary()
 
   default = fn key -> inspect(Electric.Config.default(key)) end
 

--- a/packages/sync-service/lib/electric/replication/publication_manager.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager.ex
@@ -9,27 +9,11 @@ defmodule Electric.Replication.PublicationManager do
   permission issues.
   """
 
-  @type stack_id :: Electric.stack_id()
-  @type shape_handle :: Electric.ShapeCache.shape_handle()
-
-  @callback add_shape(stack_id(), shape_handle(), Electric.Shapes.Shape.t()) :: :ok
-  @callback remove_shape(stack_id(), shape_handle()) :: :ok
-  @callback wait_for_restore(stack_id(), Keyword.t()) :: :ok
-
-  @behaviour __MODULE__
-
   defdelegate start_link(opts), to: __MODULE__.Supervisor
-
   defdelegate child_spec(opts), to: __MODULE__.Supervisor
 
   defdelegate name(opts), to: __MODULE__.RelationTracker
-
-  @impl __MODULE__
   defdelegate add_shape(stack_id, shape_handle, shape), to: __MODULE__.RelationTracker
-
-  @impl __MODULE__
   defdelegate remove_shape(stack_id, shape_handle), to: __MODULE__.RelationTracker
-
-  @impl __MODULE__
   defdelegate wait_for_restore(stack_id, opts \\ []), to: __MODULE__.RelationTracker
 end

--- a/packages/sync-service/lib/electric/shape_cache/shape_cleaner.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_cleaner.ex
@@ -11,7 +11,7 @@ defmodule Electric.ShapeCache.ShapeCleaner do
 
   require Logger
 
-  @type shape_handle() :: Electric.ShapeCacheBehaviour.shape_handle()
+  @type shape_handle() :: Electric.shape_handle()
   @type stack_id() :: Electric.stack_id()
 
   @shutdown_cleanup {:shutdown, :cleanup}

--- a/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db.ex
@@ -9,7 +9,7 @@ defmodule Electric.ShapeCache.ShapeStatus.ShapeDb do
 
   import Electric, only: [is_stack_id: 1]
 
-  @type shape_handle() :: Electric.ShapeCacheBehaviour.shape_handle()
+  @type shape_handle() :: Electric.shape_handle()
   @type stack_id() :: Electric.stack_id()
 
   # this is called if the load_backup call fails

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -10,7 +10,7 @@ defmodule Electric.ShapeCache.Storage do
     defexception [:message]
   end
 
-  @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
+  @type shape_handle :: Electric.shape_handle()
   @type pg_snapshot :: %{
           xmin: pos_integer(),
           xmax: pos_integer(),

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -6,7 +6,7 @@ defmodule Electric.Shapes do
 
   import Electric, only: [is_stack_id: 1, is_shape_handle: 1]
 
-  @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
+  @type shape_handle :: Electric.shape_handle()
   @type stack_id :: Electric.stack_id()
 
   @doc """

--- a/packages/sync-service/lib/electric/shapes/api/request.ex
+++ b/packages/sync-service/lib/electric/shapes/api/request.ex
@@ -14,7 +14,7 @@ defmodule Electric.Shapes.Api.Request do
     response: %Api.Response{}
   ]
 
-  @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
+  @type shape_handle :: Electric.shape_handle()
   @type t() :: %__MODULE__{
           chunk_end_offset: nil | LogOffset.t(),
           handle: nil | shape_handle(),

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -43,7 +43,7 @@ defmodule Electric.Shapes.Api.Response do
     finalized?: false
   ]
 
-  @type shape_handle :: Electric.ShapeCacheBehaviour.shape_handle()
+  @type shape_handle :: Electric.shape_handle()
 
   @type t() :: %__MODULE__{
           api: Api.t(),

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -45,7 +45,7 @@ defmodule Electric.Shapes.Consumer do
     ref
   end
 
-  @spec await_snapshot_start(Electric.stack_id(), ShapeCache.shape_handle(), timeout()) ::
+  @spec await_snapshot_start(Electric.stack_id(), Electric.shape_handle(), timeout()) ::
           :started | {:error, any()}
   def await_snapshot_start(stack_id, shape_handle, timeout \\ @default_snapshot_timeout)
       when is_binary(stack_id) and is_binary(shape_handle) do
@@ -54,14 +54,14 @@ defmodule Electric.Shapes.Consumer do
     |> GenServer.call(:await_snapshot_start, timeout)
   end
 
-  @spec subscribe_materializer(Electric.stack_id(), ShapeCache.shape_handle(), pid()) :: :ok
+  @spec subscribe_materializer(Electric.stack_id(), Electric.shape_handle(), pid()) :: :ok
   def subscribe_materializer(stack_id, shape_handle, pid) do
     stack_id
     |> consumer_pid(shape_handle)
     |> GenServer.call({:subscribe_materializer, pid})
   end
 
-  @spec whereis(Electric.stack_id(), ShapeCache.shape_handle()) :: pid() | nil
+  @spec whereis(Electric.stack_id(), Electric.shape_handle()) :: pid() | nil
   def whereis(stack_id, shape_handle) do
     consumer_pid(stack_id, shape_handle)
   end

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -11,7 +11,7 @@ defmodule Electric.Shapes.ConsumerRegistry do
 
   @type stack_id() :: Electric.stack_id()
   @type stack_ref() :: stack_id() | [stack_id: stack_id()] | %{stack_id: stack_id()}
-  @type shape_handle() :: Electric.ShapeCacheBehaviour.shape_handle()
+  @type shape_handle() :: Electric.shape_handle()
   @type t() :: %__MODULE__{
           table: :ets.table(),
           stack_id: stack_id()

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -13,8 +13,6 @@ defmodule Support.ComponentSetup do
   defmodule NoopPublicationManager do
     use GenServer
 
-    @behaviour Electric.Replication.PublicationManager
-
     def add_shape(_stack_id, _handle, _shape), do: :ok
     def remove_shape(_stack_id, _handle), do: :ok
     def wait_for_restore(_stack_id, _opts), do: :ok
@@ -42,7 +40,6 @@ defmodule Support.ComponentSetup do
   defmodule TestPublicationManager do
     use GenServer
 
-    @behaviour Electric.Replication.PublicationManager
     def add_shape(stack_id, handle, shape) do
       GenServer.call(
         Electric.Replication.PublicationManager.name(stack_id),
@@ -234,7 +231,7 @@ defmodule Support.ComponentSetup do
 
   def with_noop_publication_manager(ctx) do
     start_supervised!({NoopPublicationManager, ctx.stack_id})
-    %{publication_manager: {NoopPublicationManager, []}}
+    :ok
   end
 
   def with_shape_status(ctx) do


### PR DESCRIPTION
Behaviours were a side effect of Mox and useful when we used dependency injection more universally. Now they're just an additional layer we have to keep up-to-date with the actual apis in use.