### PR TITLE
chore(sync-service): Fix enum test

### DIFF
--- a/packages/sync-service/test/electric/shapes/shape/subset_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape/subset_test.exs
@@ -11,7 +11,7 @@ defmodule Electric.Shapes.Shape.SubsetTest do
 
     setup [
       :with_stack_id_from_test,
-      :with_shared_db,
+      :with_unique_db,
       :with_persistent_kv,
       :with_inspector,
       :with_sql_execute


### PR DESCRIPTION
Fix for:
```
  1) test new/2 where clause with enum comparison (Electric.Shapes.Shape.SubsetTest)
     test/electric/shapes/shape/subset_test.exs:45
     ** (Postgrex.Error) ERROR 42710 (duplicate_object) type "my_enum" already exists
     stacktrace:
       (postgrex 0.21.1) lib/postgrex.ex:347: Postgrex."REPATCH-query!"/4
       (elixir 1.19.1) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.19.1) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
       (db_connection 2.8.1) lib/db_connection.ex:1753: DBConnection.run_transaction/4
       (electric 1.2.7) test/support/db_structure_setup.ex:26: Support.DbStructureSetup.with_sql_execute/1
       Electric.Shapes.Shape.SubsetTest.__ex_unit_describe_0/1
 ```
 
The test was using `with_shared_db` which does not delete the database if it already exists. If a test run is cancelled, `ExUnit.after_suite` may not run and the database with the enum will remain.

This PR fixes the issue by using `with_unique_db` that does use a new DB each time.