### PR TITLE
fix: Benchmarking image with right telemetry context

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,9 +1,8 @@
-name: Benchmark a PR alt
+name: Benchmark a PR
 
 on:
   issue_comment:
     types: [created]
-  workflow_dispatch:
 
 env:
   PROJECT_ID: vaxine


### PR DESCRIPTION
I think the main thing that it was missing the `--build-context electric-telemetry=../electric-telemetry` but I took the opportunity to move to the GH action instead which hopefully takes care of any extra cache optimisations