### PR TITLE
Dont drop publication if manual_table_publishing is enabled

### DIFF
--- a/.changeset/gorgeous-lamps-protect.md
+++ b/.changeset/gorgeous-lamps-protect.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Don't drop publication with manual_table_publishing

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -1129,6 +1129,10 @@ defmodule Electric.Connection.Manager do
     Logger.warning("Skipping publication drop, pool connection not available")
   end
 
+  defp drop_publication(state) when state.manual_table_publishing? do
+    Logger.info("Skipping publication drop, manual_table_publishing is enabled")
+  end
+
   defp drop_publication(state) do
     pool = pool_name(state.stack_id, :admin)
     publication_name = Keyword.fetch!(state.replication_opts, :publication_name)


### PR DESCRIPTION
We're dropping the publication when we drop the replication slot on restart and shutdown. We should never drop the publication when `manual_table_publishing` is set to avoid resetting any filters the user has set.