### PR TITLE
Fix Mix warning about missing :opentelemetry app when MIX_TARGET != application

### DIFF
--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -274,15 +274,6 @@ config :electric,
       nil
     )
 
-# Disable opentelemetry_exporter by default.
-#
-# Without any explicit config, opentelemetry starts some resource detectors and initializes
-# otel_batch_processor which then tries to communicate with a remote OTLP server
-# (localhost:4318 by default) periodically.
-#
-# We don't want any of that unless OpenTelemetry export is explicitly enabled further down.
-config :opentelemetry, processors: []
-
 if Electric.telemetry_enabled?() do
   # Disable the default telemetry_poller process since we start our own in
   # `ElectricTelemetry.{ApplicationTelemetry, StackTelemetry}`.
@@ -357,5 +348,14 @@ if Electric.telemetry_enabled?() do
          }
        }}
     ]
+  else
+    # Disable opentelemetry_exporter.
+    #
+    # Without any explicit config, opentelemetry starts some resource detectors and initializes
+    # otel_batch_processor which then tries to communicate with a remote OTLP server
+    # (localhost:4318 by default) periodically.
+    #
+    # We don't want any of that unless OpenTelemetry export is explicitly enabled.
+    config :opentelemetry, processors: []
   end
 end


### PR DESCRIPTION
The problem got introduced in https://github.com/electric-sql/electric/commit/03c10a298ca694558fc6e1d76b71582512906ff8#diff-e39d5a2dccf3960074b1107d725583e91ddc8599a7643f63144df19981bc3c6e.