### PR TITLE
fix: RequestBatcher should not reply to `nil` waiters

### DIFF
--- a/.changeset/cold-peaches-dream.md
+++ b/.changeset/cold-peaches-dream.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Guard against `nil` waiters in SLC RequestBatcher correctly.

--- a/packages/sync-service/lib/electric/replication/shape_log_collector/request_batcher.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector/request_batcher.ex
@@ -146,7 +146,7 @@ defmodule Electric.Replication.ShapeLogCollector.RequestBatcher do
         {:handle_processor_update_response, ref, results},
         %{ack_ref: ref} = state
       ) do
-    for {shape_handle, from} <- state.ack_waiters do
+    for {shape_handle, from} when not is_nil(from) <- state.ack_waiters do
       GenServer.reply(from, Map.fetch!(results, shape_handle))
     end
 
@@ -181,7 +181,7 @@ defmodule Electric.Replication.ShapeLogCollector.RequestBatcher do
         state.to_remove
       )
 
-    ack_waiters = state.to_schedule_waiters |> Enum.to_list() |> List.keydelete(nil, 1)
+    ack_waiters = state.to_schedule_waiters |> Enum.reject(&is_nil(elem(&1, 1)))
 
     {:noreply,
      %{


### PR DESCRIPTION
Unfortunately `List.keydelete` doesn't do what I thought it was doing - should've read the docs more carefully.