### PR TITLE
Fix missing data in release comments

### DIFF
--- a/scripts/comment-on-release.mjs
+++ b/scripts/comment-on-release.mjs
@@ -198,10 +198,12 @@ Thanks for contributing to Electric!`
       return
     }
 
-    execSync(
-      `gh pr comment ${prNumber} --repo ${REPO} --body "${body.replace(/"/g, '\\"')}"`,
-      { stdio: 'inherit' }
-    )
+    // Use --body-file with stdin to avoid shell interpretation of backticks
+    execSync(`gh pr comment ${prNumber} --repo ${REPO} --body-file -`, {
+      input: body,
+      encoding: 'utf8',
+      stdio: ['pipe', 'inherit', 'inherit'],
+    })
     console.log(`  Commented on PR #${prNumber}`)
   } catch (e) {
     console.error(`  Failed to comment on PR #${prNumber}:`, e.message)
@@ -270,10 +272,12 @@ Thanks for reporting!`
       return
     }
 
-    execSync(
-      `gh issue comment ${issueNumber} --repo ${REPO} --body "${body.replace(/"/g, '\\"')}"`,
-      { stdio: 'inherit' }
-    )
+    // Use --body-file with stdin to avoid shell interpretation of backticks
+    execSync(`gh issue comment ${issueNumber} --repo ${REPO} --body-file -`, {
+      input: body,
+      encoding: 'utf8',
+      stdio: ['pipe', 'inherit', 'inherit'],
+    })
     console.log(`  Commented on issue #${issueNumber}`)
   } catch (e) {
     console.error(`  Failed to comment on issue #${issueNumber}:`, e.message)


### PR DESCRIPTION
The release notification comments were missing package data because backticks in the body text (e.g., `@electric-sql/client@1.2.8`) were being interpreted by the shell as command substitution. This caused the package names to be replaced with empty strings.

Fix by using gh's --body-file - flag to pass the body via stdin, avoiding shell interpretation entirely.

Fixes comments like https://github.com/electric-sql/electric/pull/3547#issuecomment-3640975021