### PR TITLE
ci: Build Postgres images preconfigured with logical replication for use in CI workflows

### DIFF
--- a/.github/workflows/build_postgres_image.yml
+++ b/.github/workflows/build_postgres_image.yml
@@ -1,0 +1,54 @@
+name: Postgres image for CI
+
+on:
+  # Run daily at 00:00 UTC. This allows the image to pick up updates from upstream and avoid
+  # going stale.
+  schedule:
+    - cron: '0 0 * * 0'
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  build_image:
+    name: 'Build postgres:${{ matrix.postgres_version }}-alpine-logical'
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    strategy:
+      matrix:
+        # The same versions are used by elixir_tests.yml
+        postgres_version: [14, 15, 17, 18]
+
+    steps:
+      - name: Set image ref
+        id: vars
+        run: |
+          echo "IMAGE=ghcr.io/${{ github.repository }}/postgres" >> $GITHUB_ENV
+
+      - name: Login to GHCR (private)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up buildx for advanced Docker caching
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare the Dockerfile
+        run: |
+          echo '
+            FROM postgres:${{ matrix.postgres_version }}-alpine
+            CMD ["postgres", "-c", "wal_level=logical", "-c", "max_replication_slots=40"]
+          ' > Dockerfile
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: '${{ env.IMAGE }}:${{ matrix.postgres_version }}-alpine-logical'
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This serves multiple goals:
- avoid repeating configuration code between CI workflows
- get rid of the need to run `psql` or `docker exec` commands in addition to defining Postgres as a service in those CI workflows that need it. See https://github.com/electric-sql/electric/pull/3600.
- https://github.com/electric-sql/electric/pull/3594 packages up sync-service as a Docker image for use in CI. However, it cannot be easily started as a service if the postgres service needs to be configured afterwards

In other words, this together with building a Docker image for sync service to use in CI workflows from the other PR helps avoid redoing some of the build steps between different CI workflows.