### PR TITLE
ci: Avoid running vitest in interactive/watch mode on CI

### DIFF
--- a/.github/workflows/ts_tests.yml
+++ b/.github/workflows/ts_tests.yml
@@ -37,7 +37,7 @@ jobs:
         id: list_examples
 
   check_packages:
-    name: Check TS package at ${{ matrix.package_dir }}
+    name: Build and typecheck ${{ matrix.package_dir }}
     needs: [list_ts_packages]
     runs-on: ubuntu-latest
     strategy:
@@ -59,7 +59,7 @@ jobs:
       - run: pnpm run typecheck
 
   build_and_test_packages:
-    name: Test TS packages against sync-service
+    name: 'Test ${{ matrix.package_dir }} w/ sync-service'
     needs: [list_ts_packages]
     runs-on: ubuntu-latest
     # There is currently a buggy TS test that causes the job for typescript-client to get stuck
@@ -80,46 +80,51 @@ jobs:
       MIX_OS_DEPS_COMPILE_PARTITION_COUNT: 4
     steps:
       - uses: actions/checkout@v4
+
       - uses: erlef/setup-beam@v1
         with:
           version-type: strict
           version-file: '.tool-versions'
+
       - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.tool-versions'
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
 
-      - name: Cache dependencies
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache sync-service dependencies
         uses: actions/cache@v4
         with:
           path: packages/sync-service/deps
-          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_TARGET }}-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-deps-${{ env.MIX_TARGET }}-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
-            ${{ runner.os }}-sync-service-deps-${{ env.MIX_TARGET }}-${{ env.MIX_ENV }}-
-            ${{ runner.os }}-sync-service-deps-
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}
+            ${{ runner.os }}-sync-service-deps
 
-      - name: Cache compiled code
+      - name: Cache sync-service compiled code
         uses: actions/cache@v4
         with:
           path: |
             packages/sync-service/_build/*/lib
             !packages/sync-service/_build/*/lib/electric
-          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_TARGET }}-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
           restore-keys: |
-            ${{ runner.os }}-sync-service-build-${{ env.MIX_TARGET }}-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
-            ${{ runner.os }}-sync-service-build-${{ env.MIX_TARGET }}-${{ env.MIX_ENV }}-
-            ${{ runner.os }}-sync-service-build-
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}
+            ${{ runner.os }}-sync-service-build
 
-      - name: Install dependencies
-        run: mix do deps.get + deps.compile
+      - name: Install sync-service dependencies
         working-directory: packages/sync-service
+        run: mix do deps.get + deps.compile
 
       - name: Compile sync-service
-        run: mix compile
         working-directory: packages/sync-service
+        run: mix compile
 
       - uses: JarvusInnovations/background-action@v1
         name: Bootstrap System Under Test (SUT)
@@ -137,9 +142,12 @@ jobs:
           log-output: true
           log-output-if: failure
           working-directory: packages/sync-service
-      - name: build dependencies, if any
+
+      - name: Build Node dependencies, if any
         run: pnpm -r --filter "$(jq '.name' -r package.json)^..." build
-      - run: pnpm run coverage --run
+
+      - name: Run tests with coverage
+        run: pnpm run coverage --run
 
       - name: Upload coverage reports to CodeCov
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
@@ -159,7 +167,7 @@ jobs:
           files: ./junit/test-report.junit.xml
 
   check_and_build_examples:
-    name: Check and build ${{ matrix.example_folder }} example
+    name: Check and build ${{ matrix.example_folder }}
     needs: [list_examples, build_and_test_packages]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Starting on December 10, the [Test TS packages against sync-service (packages/typescript-client)](https://github.com/electric-sql/electric/actions/runs/20137012761/job/57793064524#logs) CI job started hanging until cancelled by GH Actions after 6 hours of runtime.

<img width="2530" height="1403" alt="image" src="https://github.com/user-attachments/assets/dd8759a1-01b7-453c-9cc9-34bc647f353d" />

This seems to be related to the fact that `pnpm coverage` and `pnpm test` run in interactive mode by default. Passing the `--run` command-line flag to those prevents this behaviour and makes sure the process exits after it has finished running the tests.

EDIT: found the actual culprit, it's not the way we run `pnpm coverage` but a certain test that got added in a [recent PR](https://github.com/electric-sql/electric/pull/3564) causes the test runner to hang. The [CI job](https://github.com/electric-sql/electric/actions/runs/20106623917/job/57693276499) on that PR is the first known occurrence of the "CI job stuck for 6 hours" problem.

I have reproduced it locally by running `pnpm exec vitest --coverage "--run"`. The test runner was stuck running `test/stream.test.ts` for some minutes, then produced the following output and exited with exit code 1:
```
<--- Last few GCs --->

[166905:0x28ad6000]   201497 ms: Mark-Compact 4077.8 (4104.3) -> 4066.1 (4104.3) MB, pooled: 0 MB, 1656.56 / 0.00 ms  (average mu = 0.238, current mu = 0.184) allocation failure; scavenge might not succeed
[166905:0x28ad6000]   203588 ms: Mark-Compact 4074.2 (4104.8) -> 4066.1 (4100.8) MB, pooled: 4 MB, 2076.70 / 0.00 ms  (average mu = 0.120, current mu = 0.007) allocation failure; scavenge might not succeed

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0x72be1c node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
 2: 0xb9dc10  [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
 3: 0xb9dcff  [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
 4: 0xe367e5  [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
 5: 0xe36812  [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
 6: 0xe36b0a  [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
 7: 0xe4702a  [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
 8: 0xe4b3d0  [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
 9: 0x18de281  [/home/alco/.asdf/installs/nodejs/24.11.1/bin/node]
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: [vitest-pool]: Worker forks emitted error.
 ❯ EventEmitter.<anonymous> ../../node_modules/.pnpm/vitest@4.0.15_@types+node@22.19.1_jiti@2.6.1_jsdom@26.1.0_lightningcss@1.30.1_terser@5.44.0_tsx@4.20.3_yaml@2.8.1/node_modules/vitest/dist/chunks/cli-api.C7sYjHmQ.js:8010:22
 ❯ EventEmitter.emit node:events:508:28
 ❯ ChildProcess.emitUnexpectedExit ../../node_modules/.pnpm/vitest@4.0.15_@types+node@22.19.1_jiti@2.6.1_jsdom@26.1.0_lightningcss@1.30.1_terser@5.44.0_tsx@4.20.3_yaml@2.8.1/node_modules/vitest/dist/chunks/cli-api.C7sYjHmQ.js:7583:22
 ❯ ChildProcess.emit node:events:508:28
 ❯ Process.ChildProcess._handle.onexit node:internal/child_process:294:12

Caused by: Error: Worker exited unexpectedly
 ❯ ChildProcess.emitUnexpectedExit ../../node_modules/.pnpm/vitest@4.0.15_@types+node@22.19.1_jiti@2.6.1_jsdom@26.1.0_lightningcss@1.30.1_terser@5.44.0_tsx@4.20.3_yaml@2.8.1/node_modules/vitest/dist/chunks/cli-api.C7sYjHmQ.js:7582:33
 ❯ ChildProcess.emit node:events:508:28
 ❯ Process.ChildProcess._handle.onexit node:internal/child_process:294:12

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  13 passed (14)
      Tests  275 passed (283)
Type Errors  no errors
     Errors  1 error
   Start at  14:25:51
   Duration  261.75s (transform 696ms, setup 56ms, import 1.05s, tests 34.06s, environment 2.99s, typecheck 599ms)

JUNIT report written to /home/alco/code/electric-sql/electric/packages/typescript-client/junit/test-report.junit.xml
 % Coverage report from istanbul
-------------------------|---------|----------|---------|---------|------------------------------------------------------------------------------------------------------------------------------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                                                                        
-------------------------|---------|----------|---------|---------|------------------------------------------------------------------------------------------------------------------------------------------
All files                |   92.76 |     86.2 |   89.61 |   92.99 |                                                                                                                                          
 client.ts               |   90.23 |    80.37 |   87.03 |   90.93 | 598-611,718-723,869,880,885,917,1052,1265,1286-1287,1316,1322,1342,1382-1383,1417,1459,1526,1572,1596,1599,1608,1623,1627-1628,1639-1641 
 column-mapper.ts        |   98.27 |    97.05 |     100 |   98.21 | 304                                                                                                                                      
 constants.ts            |     100 |      100 |     100 |     100 |                                                                                                                                          
 error.ts                |   74.35 |    83.33 |   58.33 |   74.35 | 57-81,103-104                                                                                                                            
 expired-shapes-cache.ts |   96.77 |    91.66 |     100 |   96.55 | 57                                                                                                                                       
 fetch.ts                |   96.79 |    91.39 |   96.29 |   96.55 | 123,149-150,182,334                                                                                                                      
 helpers.ts              |   91.66 |    85.71 |     100 |   91.66 | 71                                                                                                                                       
 parser.ts               |    98.8 |     87.3 |     100 |   98.73 | 153                                                                                                                                      
 shape.ts                |   91.34 |    91.17 |   82.75 |      92 | 78,108,123-128,269,282-284                                                                                                               
 snapshot-tracker.ts     |     100 |      100 |     100 |     100 |                                                                                                                                          
 up-to-date-tracker.ts   |   93.33 |    95.83 |      90 |    93.1 | 70-72,138                                                                                                                                
-------------------------|---------|----------|---------|---------|------------------------------------------------------------------------------------------------------------------------------------------
```