### PR TITLE
Add changeset for columnMapper feature

### DIFF
--- a/.changeset/fix-column-mapper-subsets.md
+++ b/.changeset/fix-column-mapper-subsets.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Fix columnMapper to support loading subsets. When using `columnMapper` with ShapeStream, the `columns` parameter is now properly encoded from application column names (e.g., camelCase) to database column names (e.g., snake_case) before transmission to the server.


### PR DESCRIPTION
Add patch changeset for @electric-sql/client to document the fix for columnMapper to support loading subsets.