### PR TITLE
ci: Use the preconfigured Postgres image in CI workflows

### DIFF
--- a/.github/workflows/docker_image_smoketest.yml
+++ b/.github/workflows/docker_image_smoketest.yml
@@ -19,18 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: 'postgres:17-alpine'
+        image: 'ghcr.io/${{ github.repository }}/postgres:17-alpine-logical'
         env:
           POSTGRES_PASSWORD: password
         ports:
           - 5432:5432
 
     steps:
-      - name: 'Set PG settings'
-        run: |
-          docker exec ${{ job.services.postgres.id }} sh -c 'echo "wal_level=logical" >> /var/lib/postgresql/data/postgresql.conf'
-          docker restart ${{ job.services.postgres.id }}
-
       - uses: docker/setup-buildx-action@v3
 
       - uses: actions/checkout@v4

--- a/.github/workflows/elixir_client_tests.yml
+++ b/.github/workflows/elixir_client_tests.yml
@@ -33,7 +33,7 @@ jobs:
       DATABASE_URL: 'postgresql://postgres:password@127.0.0.1:54323/postgres?sslmode=disable'
     services:
       postgres:
-        image: postgres:14-alpine
+        image: 'ghcr.io/${{ github.repository }}/postgres:17-alpine-logical'
         env:
           POSTGRES_PASSWORD: password
         options: >-
@@ -45,10 +45,6 @@ jobs:
           - 54323:5432
     steps:
       - uses: actions/checkout@v4
-      - name: 'Set PG settings'
-        run: |
-          docker exec ${{ job.services.postgres.id }} sh -c 'echo "wal_level=logical" >> /var/lib/postgresql/data/postgresql.conf'
-          docker restart ${{ job.services.postgres.id }}
 
       - uses: erlef/setup-beam@v1
         with:

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -39,7 +39,7 @@ jobs:
       POSTGRES_VERSION: '${{ matrix.postgres_version }}0000'
     services:
       postgres:
-        image: 'postgres:${{ matrix.postgres_version }}-alpine'
+        image: 'ghcr.io/${{ github.repository }}/postgres:${{ matrix.postgres_version }}-alpine-logical'
         env:
           POSTGRES_PASSWORD: password
         options: >-
@@ -64,13 +64,6 @@ jobs:
           - 65432:6432
     steps:
       - uses: actions/checkout@v4
-
-      # https://github.com/orgs/community/discussions/126453#discussioncomment-11414956
-      - name: Set PG settings
-        run: |
-          docker exec ${{ job.services.postgres.id }} sh -c 'psql -U postgres -c "ALTER SYSTEM SET wal_level = '"'"'logical'"'"';"'
-          docker exec ${{ job.services.postgres.id }} sh -c 'psql -U postgres -c "ALTER SYSTEM SET max_replication_slots = 100;"'
-          docker restart ${{ job.services.postgres.id }}
 
       - name: Seed the database
         run: psql -d postgresql://postgres:password@localhost:54321/postgres?sslmode=disable -f dev/init.sql


### PR DESCRIPTION
Simplify starting a Postgres database on CI. Having a [preconfigured image available](https://github.com/electric-sql/electric/pull/3588) eliminates the need for manual configuration steps inside the CI job. This will also work great together with https://github.com/electric-sql/electric/pull/3594.