### PR TITLE
ci: Limit the runtime of TS test CI jobs to 10 minutes

### DIFF
--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -62,6 +62,11 @@ jobs:
     name: Test TS packages against sync-service
     needs: [list_ts_packages]
     runs-on: ubuntu-latest
+    # There is currently a buggy TS test that causes the job for typescript-client to get stuck
+    # for 6 hours on end.
+    # And it's a good practice in general to limit the test runtime and investigate at the
+    # point when it starts exceeding the limit.
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
See https://github.com/electric-sql/electric/pull/3593 for context. It gets old fast having to manually cancel [all those stuck jobs](https://github.com/electric-sql/electric/actions/workflows/ts_test.yml).