### PR TITLE
fix: correct refs usage inside shape indices

### DIFF
--- a/.changeset/fuzzy-hotels-hunt.md
+++ b/.changeset/fuzzy-hotels-hunt.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+fix: correct refs usage inside shape indices

--- a/packages/sync-service/lib/electric/shapes/filter.ex
+++ b/packages/sync-service/lib/electric/shapes/filter.ex
@@ -177,7 +177,7 @@ defmodule Electric.Shapes.Filter do
         MapSet.new()
 
       [{_, where_cond_id}] ->
-        WhereCondition.affected_shapes(filter, where_cond_id, record, filter.refs_fun)
+        WhereCondition.affected_shapes(filter, where_cond_id, record)
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/equality_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/equality_index.ex
@@ -92,7 +92,7 @@ defmodule Electric.Shapes.Filter.Indexes.EqualityIndex do
         MapSet.new()
 
       [{_, {_type, next_condition_id}}] ->
-        WhereCondition.affected_shapes(filter, next_condition_id, record, fn _shape -> %{} end)
+        WhereCondition.affected_shapes(filter, next_condition_id, record)
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/inclusion_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/inclusion_index.ex
@@ -264,7 +264,7 @@ defmodule Electric.Shapes.Filter.Indexes.InclusionIndex do
   defp shapes_affected_by_node(_ctx, %{condition_id: nil}), do: nil
 
   defp shapes_affected_by_node(ctx, %{condition_id: condition_id}) do
-    WhereCondition.affected_shapes(ctx.filter, condition_id, ctx.record, fn _shape -> %{} end)
+    WhereCondition.affected_shapes(ctx.filter, condition_id, ctx.record)
   end
 
   # key matches value, so check the child then continue with the rest

--- a/packages/sync-service/lib/electric/shapes/filter/where_condition.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/where_condition.ex
@@ -164,10 +164,10 @@ defmodule Electric.Shapes.Filter.WhereCondition do
     :ok
   end
 
-  def affected_shapes(%Filter{where_cond_table: table} = filter, condition_id, record, refs_fun) do
+  def affected_shapes(%Filter{where_cond_table: table} = filter, condition_id, record) do
     MapSet.union(
       indexed_shapes_affected(filter, condition_id, record),
-      other_shapes_affected(filter, table, condition_id, record, refs_fun)
+      other_shapes_affected(filter, table, condition_id, record)
     )
   rescue
     error ->
@@ -197,7 +197,8 @@ defmodule Electric.Shapes.Filter.WhereCondition do
     )
   end
 
-  defp other_shapes_affected(filter, table, condition_id, record, refs_fun) do
+  defp other_shapes_affected(%Filter{refs_fun: refs_fun} = filter, table, condition_id, record)
+       when is_function(refs_fun, 1) do
     [{_, {_index_keys, other_shapes}}] = :ets.lookup(table, condition_id)
 
     OpenTelemetry.with_child_span(


### PR DESCRIPTION
Closes #3584

We were using a stub function in the nested recursion for some reason. This PR instead uses the function from the struct body that's never altered in that call chain