### PR TITLE
Add a stale shape handle cache to ensure we don't get in infinite loops on must-refetch

### DIFF
--- a/.changeset/fix-409-stale-cache-loop.md
+++ b/.changeset/fix-409-stale-cache-loop.md
@@ -1,0 +1,14 @@
+---
+'@electric-sql/client': patch
+---
+
+Fix infinite 409 loop when proxy returns stale cached response with expired shape handle.
+
+**Root cause:** When a 409 response arrives, the client marks the old handle as expired and fetches with a new handle. If a proxy ignores the `expired_handle` cache buster parameter and returns a stale cached response containing the old handle, the client would accept it and enter an infinite 409 loop.
+
+**The fix:**
+- In `#onInitialResponse`: Don't accept a shape handle from the response if it matches the expired handle in the expired shapes cache
+- In `getNextChunkUrl` (prefetch): Don't prefetch the next chunk if the response handle equals the `expired_handle` from the request URL
+- Added console warnings when this situation is detected to help developers debug proxy misconfigurations
+
+This provides defense-in-depth against misconfigured proxies that don't include all query parameters in their cache keys.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -993,6 +993,14 @@ export class ShapeStream<T extends Row<unknown> = Row>
         : null
       if (shapeHandle !== expiredHandle) {
         this.#shapeHandle = shapeHandle
+      } else {
+        console.warn(
+          `[Electric] Received stale cached response with expired shape handle. ` +
+            `This should not happen and indicates a proxy/CDN caching misconfiguration. ` +
+            `The response contained handle "${shapeHandle}" which was previously marked as expired. ` +
+            `Check that your proxy includes all query parameters (especially 'handle' and 'offset') in its cache key. ` +
+            `Ignoring the stale handle and continuing with handle "${this.#shapeHandle}".`
+        )
       }
     }
 

--- a/packages/typescript-client/src/fetch.ts
+++ b/packages/typescript-client/src/fetch.ts
@@ -441,7 +441,16 @@ function getNextChunkUrl(url: string, res: Response): string | void {
   // this can happen when a proxy serves a stale cached response despite the
   // expired_handle cache buster parameter
   const expiredHandle = nextUrl.searchParams.get(EXPIRED_HANDLE_QUERY_PARAM)
-  if (expiredHandle && shapeHandle === expiredHandle) return
+  if (expiredHandle && shapeHandle === expiredHandle) {
+    console.warn(
+      `[Electric] Received stale cached response with expired shape handle. ` +
+        `This should not happen and indicates a proxy/CDN caching misconfiguration. ` +
+        `The response contained handle "${shapeHandle}" which was previously marked as expired. ` +
+        `Check that your proxy includes all query parameters (especially 'handle' and 'offset') in its cache key. ` +
+        `Skipping prefetch to prevent infinite 409 loop.`
+    )
+    return
+  }
 
   nextUrl.searchParams.set(SHAPE_HANDLE_QUERY_PARAM, shapeHandle)
   nextUrl.searchParams.set(OFFSET_QUERY_PARAM, lastOffset)

--- a/packages/typescript-client/test/expired-shapes-cache.test.ts
+++ b/packages/typescript-client/test/expired-shapes-cache.test.ts
@@ -283,15 +283,18 @@ describe(`ExpiredShapesCache`, () => {
         // This is the bug scenario - proxy ignores cache buster and returns stale response
         resolveSecondRequest()
         return Promise.resolve(
-          new Response(JSON.stringify([{ headers: { control: `up-to-date` } }]), {
-            status: 200,
-            headers: {
-              'electric-handle': `original-handle-H1`, // OLD handle from cached response!
-              'electric-offset': `0_0`,
-              'electric-schema': `{}`,
-              'electric-cursor': `cursor-1`,
-            },
-          })
+          new Response(
+            JSON.stringify([{ headers: { control: `up-to-date` } }]),
+            {
+              status: 200,
+              headers: {
+                'electric-handle': `original-handle-H1`, // OLD handle from cached response!
+                'electric-offset': `0_0`,
+                'electric-schema': `{}`,
+                'electric-cursor': `cursor-1`,
+              },
+            }
+          )
         )
       } else {
         // Third+ request: if client incorrectly accepted H1, it would 409 again
@@ -310,15 +313,18 @@ describe(`ExpiredShapesCache`, () => {
         // Normal response for H2
         aborter.abort()
         return Promise.resolve(
-          new Response(JSON.stringify([{ headers: { control: `up-to-date` } }]), {
-            status: 200,
-            headers: {
-              'electric-handle': `new-handle-H2`,
-              'electric-offset': `0_0`,
-              'electric-schema': `{}`,
-              'electric-cursor': `cursor-1`,
-            },
-          })
+          new Response(
+            JSON.stringify([{ headers: { control: `up-to-date` } }]),
+            {
+              status: 200,
+              headers: {
+                'electric-handle': `new-handle-H2`,
+                'electric-offset': `0_0`,
+                'electric-schema': `{}`,
+                'electric-cursor': `cursor-1`,
+              },
+            }
+          )
         )
       }
     })


### PR DESCRIPTION
Reported here https://discord.com/channels/933657521581858818/1445242388539773151/1450986696303972564

When a 409 response arrives, the client marks the old handle as expired and fetches with a new handle. If a proxy ignores the expired_handle cache buster parameter and returns a stale cached response containing the old handle, the client would accept the stale handle and enter an infinite 409 loop.

This fix prevents the loop in two places:
1. In #onInitialResponse: Don't accept a shape handle from the response if it matches the expired handle from the expired shapes cache.
2. In getNextChunkUrl (prefetch): Don't prefetch the next chunk if the response handle equals the expired_handle from the request URL.

Added a test case that simulates this exact scenario.