### PR TITLE
fix: wrong return value caused metric sending to fail sometimes

### DIFF
--- a/.changeset/brown-ducks-admire.md
+++ b/.changeset/brown-ducks-admire.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+fix: wrong return value caused metric sending to fail sometimes

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -44,7 +44,10 @@ defmodule Electric.Shapes.ConsumerRegistry do
 
   @spec active_consumer_count(stack_id()) :: non_neg_integer()
   def active_consumer_count(stack_id) when is_binary(stack_id) do
-    :ets.info(ets_name(stack_id), :size)
+    case :ets.info(ets_name(stack_id), :size) do
+      :undefined -> 0
+      size -> size
+    end
   rescue
     ArgumentError -> 0
   end


### PR DESCRIPTION
Found in the logs with:

```
Task #PID<0.x.0> started from :"stack_otel_telemetry_<stack_id>" terminating
** (Protobuf.EncodeError) Failed to encode body: Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest#resource_metrics: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.ResourceMetrics#resource: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.ResourceMetrics#scope_metrics: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.ScopeMetrics#scope: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.ScopeMetrics#metrics: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.Metric#name: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.Metric#description: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.Metric#unit: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.Metric#gauge: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.Gauge#data_points: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.NumberDataPoint#start_time_unix_nano: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.NumberDataPoint#time_unix_nano: ** (Protobuf.EncodeError) Got error when encoding OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.NumberDataPoint#as_double: ** (ArgumentError) construction of binary failed: segment 1 of type 'float': expected a float or an integer but got: :undefined

Body (cleaned manually):

%OtelMetricExporter.Opentelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest{
  resource_metrics: [
    %OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.ResourceMetrics{
      resource: %OtelMetricExporter.Opentelemetry.Proto.Resource.V1.Resource{},
      scope_metrics: [
        %OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.ScopeMetrics{
          scope: %OtelMetricExporter.Opentelemetry.Proto.Common.V1.InstrumentationScope{},
          metrics: [
            %OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.Metric{
              name: "electric.shapes.active_shapes.count",
              data: {:gauge,
               %OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.Gauge{
                 data_points: [
                   %OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.NumberDataPoint{
                     value: {:as_double, :undefined},
                   }
                 ],
                 __unknown_fields__: []
               }},
              __unknown_fields__: []
            }
            # more metrics...
          ]
        }
      ]
    }
  ]
}
```