### PR TITLE
Fix missing drizzle-orm module in production

### DIFF
--- a/examples/tanstack-db-web-starter/vite.config.ts
+++ b/examples/tanstack-db-web-starter/vite.config.ts
@@ -31,7 +31,7 @@ const config = defineConfig({
     exclude: [`@tanstack/start-server-core`],
   },
   ssr: {
-    noExternal: [`zod`],
+    noExternal: [`zod`, `drizzle-orm`],
   },
 })
 


### PR DESCRIPTION
The drizzle-orm package was being externalized by Vite's SSR bundling, causing the /pg-core subpath to not resolve correctly in Lambda. Adding it to noExternal ensures proper bundling for AWS Lambda deployment.