### PR TITLE
Use parameterized query syntax in TanStack web example

### DIFF
--- a/examples/proxy-auth/app/shape-proxy/route.ts
+++ b/examples/proxy-auth/app/shape-proxy/route.ts
@@ -40,8 +40,10 @@ export async function GET(request: Request) {
   }
 
   // Only query orgs the user has access to.
+  // Use parameterized query to prevent SQL injection
   if (!user.isAdmin) {
-    originUrl.searchParams.set(`where`, `"org_id" = ${user.org_id}`)
+    originUrl.searchParams.set(`where`, `"org_id" = $1`)
+    originUrl.searchParams.set(`params[1]`, user.org_id)
   }
 
   const response = await fetch(originUrl)

--- a/examples/tanstack-db-web-starter/README.md
+++ b/examples/tanstack-db-web-starter/README.md
@@ -149,9 +149,9 @@ const serve = async ({ request }: { request: Request }) => {
   // 2. Build the Electric URL with row-level filtering
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set("table", "todos")
-  // Only sync rows where the user has access
-  const filter = `'${session.user.id}' = ANY(user_ids)`
-  originUrl.searchParams.set("where", filter)
+  // Only sync rows where the user has access (using parameterized query)
+  originUrl.searchParams.set("where", "$1 = ANY(user_ids)")
+  originUrl.searchParams.set("params[1]", session.user.id)
 
   // 3. Proxy the request to Electric
   return proxyElectricRequest(originUrl)
@@ -262,9 +262,9 @@ const serve = async ({ request }: { request: Request }) => {
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set("table", "categories")
-  // Filter to user's own categories
-  const filter = `user_id = '${session.user.id}'`
-  originUrl.searchParams.set("where", filter)
+  // Filter to user's own categories (using parameterized query)
+  originUrl.searchParams.set("where", "user_id = $1")
+  originUrl.searchParams.set("params[1]", session.user.id)
 
   return proxyElectricRequest(originUrl)
 }

--- a/examples/tanstack-db-web-starter/src/routes/api/projects.ts
+++ b/examples/tanstack-db-web-starter/src/routes/api/projects.ts
@@ -13,8 +13,12 @@ const serve = async ({ request }: { request: Request }) => {
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `projects`)
-  const filter = `owner_id = '${session.user.id}' OR '${session.user.id}' = ANY(shared_user_ids)`
-  originUrl.searchParams.set(`where`, filter)
+  // Use parameterized query to prevent SQL injection
+  originUrl.searchParams.set(
+    `where`,
+    `owner_id = $1 OR $1 = ANY(shared_user_ids)`
+  )
+  originUrl.searchParams.set(`params[1]`, session.user.id)
 
   return proxyElectricRequest(originUrl)
 }

--- a/examples/tanstack-db-web-starter/src/routes/api/todos.ts
+++ b/examples/tanstack-db-web-starter/src/routes/api/todos.ts
@@ -13,8 +13,9 @@ const serve = async ({ request }: { request: Request }) => {
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `todos`)
-  const filter = `'${session.user.id}' = ANY(user_ids)`
-  originUrl.searchParams.set(`where`, filter)
+  // Use parameterized query to prevent SQL injection
+  originUrl.searchParams.set(`where`, `$1 = ANY(user_ids)`)
+  originUrl.searchParams.set(`params[1]`, session.user.id)
 
   return proxyElectricRequest(originUrl)
 }

--- a/website/docs/sync/guides/auth.md
+++ b/website/docs/sync/guides/auth.md
@@ -143,9 +143,10 @@ export async function GET(request: Request) {
   }
 
   // Only query data the user has access to unless they're an admin.
+  // Use parameterized queries to prevent SQL injection
   if (!user.roles.includes(`admin`)) {
-    // For type-safe WHERE clause generation, see the section below
-    originUrl.searchParams.set(`where`, `org_id = '${user.org_id}'`)
+    originUrl.searchParams.set(`where`, `org_id = $1`)
+    originUrl.searchParams.set(`params[1]`, user.org_id)
   }
 
   const response = await fetch(originUrl)
@@ -169,7 +170,7 @@ export async function GET(request: Request) {
 
 #### Type-safe where clause generation
 
-The example above uses simple string-based WHERE clauses, which works well for straightforward cases. If you'd like type-safe WHERE clause generation with compile-time validation, you can use query builder libraries like Drizzle or Kysely. This is particularly useful for complex queries or when you want to catch column reference errors at compile-time rather than runtime.
+The example above uses parameterized WHERE clauses with `$1` placeholders and `params[1]` values, which prevents SQL injection. For more complex queries where you'd like type-safe WHERE clause generation with compile-time validation, you can use query builder libraries like Drizzle or Kysely. This is particularly useful when you want to catch column reference errors at compile-time rather than runtime.
 
 > [!Tip] General pattern
 > These examples show JavaScript/TypeScript APIs, but you can use this same pattern of type-safe where clause generation in any language with similar query builder libraries for your backend API.


### PR DESCRIPTION
Replace string interpolation with Electric's parameterized query syntax ($1 placeholders with params[1] values) in shape proxy routes to prevent potential SQL injection vulnerabilities.

While the current implementation has low risk since session.user.id is server-generated, using parameterized queries follows security best practices and sets a better example for developers.

Affected files:
- examples/tanstack-db-web-starter/src/routes/api/projects.ts
- examples/tanstack-db-web-starter/src/routes/api/todos.ts
- examples/proxy-auth/app/shape-proxy/route.ts
- examples/tanstack-db-web-starter/README.md
- website/docs/guides/auth.md