### PR TITLE
Fix missing headers causing infinite loop

### DIFF
--- a/.changeset/fix-missing-headers-loop.md
+++ b/.changeset/fix-missing-headers-loop.md
@@ -1,0 +1,7 @@
+---
+'@electric-sql/client': patch
+---
+
+Fix infinite loop when response is missing required headers
+
+When the server returns 200 OK but with missing required headers (like `electric-cursor`), the client would enter an infinite retry loop if `onError` returned `{}`. Now `MissingHeadersError` is treated as non-retryable since it's a configuration issue that won't self-heal.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -669,7 +669,8 @@ export class ShapeStream<T extends Row<unknown> = Row>
       if (this.#onError) {
         const retryOpts = await this.#onError(err as Error)
         // Guard against null (typeof null === "object" in JavaScript)
-        if (retryOpts && typeof retryOpts === `object`) {
+        const isRetryable = !(err instanceof MissingHeadersError)
+        if (retryOpts && typeof retryOpts === `object` && isRetryable) {
           // Update params/headers but don't reset offset
           // We want to continue from where we left off, not refetch everything
           if (retryOpts.params) {


### PR DESCRIPTION
When a electric server/proxy returns a 200 OK response but with missing required headers (like `electric-cursor`), the client would enter an infinite retry loop if the `onError` handler returned {} to request a retry.

The issue occurred because `MissingHeadersError` is thrown AFTER the backoff wrapper returns successfully (since the HTTP request itself succeeded), so no backoff delay was applied between retries.

Since `MissingHeadersError` indicates a configuration issue  that won't fix itself without manual intervention, we now explicitly refuse to retry on this error type and log a warning instead.

Also added a test case to verify this behavior.