### PR TITLE
feat(sync-service): Support multiple subqueries at the same level

### DIFF
--- a/.changeset/grumpy-deers-behave.md
+++ b/.changeset/grumpy-deers-behave.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Support multiple subqueries on the same level, returning 409s on move-ins/outs

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -284,7 +284,11 @@ defmodule Electric.Shapes.Consumer do
     # - tagged subqueries are disabled since we cannot support causally correct event processing of 3+ level dependency trees
     #   so we just invalidating this middle shape instead
     # - the where clause has an OR combined with the subquery so we can't tell if the move ins/outs actually affect the shape or not
-    should_invalidate? = not tagged_subqueries_enabled? or state.or_with_subquery?
+    # - the shape has multiple subqueries at the same level since we can't correctly determine
+    #   which dependency caused the move-in/out
+    should_invalidate? =
+      not tagged_subqueries_enabled? or state.or_with_subquery? or
+        length(state.shape.shape_dependencies) > 1
 
     if should_invalidate? do
       stop_and_clean(state)

--- a/packages/sync-service/lib/electric/shapes/dependency_layers.ex
+++ b/packages/sync-service/lib/electric/shapes/dependency_layers.ex
@@ -8,15 +8,23 @@ defmodule Electric.Shapes.DependencyLayers do
       [] ->
         add_to_first_layer(layers, shape_handle)
 
-      [dependency_handle] ->
-        [first_layer | rest] = layers
-
-        if MapSet.member?(first_layer, dependency_handle) do
-          [first_layer | add_to_first_layer(rest, shape_handle)]
-        else
-          [first_layer | add_dependency(rest, shape, shape_handle)]
-        end
+      dependency_handles ->
+        add_after_dependencies(layers, shape_handle, MapSet.new(dependency_handles))
     end
+  end
+
+  defp add_after_dependencies([layer | rest], shape_handle, deps_to_find) do
+    remaining_deps = MapSet.difference(deps_to_find, layer)
+
+    if MapSet.size(remaining_deps) == 0 do
+      [layer | add_to_first_layer(rest, shape_handle)]
+    else
+      [layer | add_after_dependencies(rest, shape_handle, remaining_deps)]
+    end
+  end
+
+  defp add_after_dependencies([], shape_handle, deps_to_find) when map_size(deps_to_find) == 0 do
+    [MapSet.new([shape_handle])]
   end
 
   def remove_dependency(layers, shape_handle) do

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -280,7 +280,6 @@ defmodule Electric.Shapes.Shape do
     with {:ok, where} <- Parser.parse_query(where),
          {:ok, subqueries} <- Parser.extract_subqueries(where),
          :ok <- check_feature_flag(subqueries, opts),
-         :ok <- check_single_subquery(subqueries),
          {:ok, shape_dependencies} <- build_shape_dependencies(subqueries, opts),
          {:ok, dependency_refs} <- build_dependency_refs(shape_dependencies, inspector),
          all_refs = Map.merge(refs, dependency_refs),
@@ -306,13 +305,6 @@ defmodule Electric.Shapes.Shape do
     else
       :ok
     end
-  end
-
-  defp check_single_subquery(subqueries) when length(subqueries) <= 1, do: :ok
-
-  defp check_single_subquery(_subqueries) do
-    {:error,
-     {:where, "Multiple subqueries at the same level in a where clause are not supported"}}
   end
 
   defp make_opts_from_select(select, opts) do

--- a/packages/sync-service/test/electric/shapes/dependency_layers_test.exs
+++ b/packages/sync-service/test/electric/shapes/dependency_layers_test.exs
@@ -93,5 +93,98 @@ defmodule Electric.Shapes.DependencyLayersTest do
                MapSet.new([@outer_shape_handle])
              ]
     end
+
+    test "for multiple dependencies at the same level" do
+      # Two inner shapes at layer 0
+      inner_shape_1 =
+        Shape.new!("parent", select: "SELECT id FROM parent", inspector: @inspector)
+
+      inner_shape_2 =
+        Shape.new!("projects", select: "SELECT id FROM projects", inspector: @inspector)
+
+      inner_handle_1 = "inner-shape-1"
+      inner_handle_2 = "inner-shape-2"
+
+      # Outer shape depends on both inner shapes
+      outer_shape =
+        Shape.new!("child",
+          where:
+            "parent_id IN (SELECT id FROM parent) AND project_id IN (SELECT id FROM projects)",
+          inspector: @inspector
+        )
+        |> Map.put(:shape_dependencies, [inner_shape_1, inner_shape_2])
+        |> Map.put(:shape_dependencies_handles, [inner_handle_1, inner_handle_2])
+
+      layers =
+        DependencyLayers.new()
+        |> DependencyLayers.add_dependency(inner_shape_1, inner_handle_1)
+        |> DependencyLayers.add_dependency(inner_shape_2, inner_handle_2)
+        |> DependencyLayers.add_dependency(outer_shape, @outer_shape_handle)
+
+      # Both inner shapes should be in layer 0, outer shape should be in layer 1
+      assert DependencyLayers.get_for_handles(
+               layers,
+               MapSet.new([@outer_shape_handle, inner_handle_1, inner_handle_2])
+             ) == [
+               MapSet.new([inner_handle_1, inner_handle_2]),
+               MapSet.new([@outer_shape_handle])
+             ]
+    end
+
+    test "for multiple dependencies at different levels" do
+      # inner_inner at layer 0
+      inner_inner_shape =
+        Shape.new!("projects", select: "SELECT id FROM projects", inspector: @inspector)
+
+      # inner depends on inner_inner, goes to layer 1
+      inner_shape =
+        Shape.new!("issues",
+          select: "SELECT id FROM issues WHERE project_id IN (SELECT id FROM projects)",
+          inspector: @inspector
+        )
+        |> Map.put(:shape_dependencies, [inner_inner_shape])
+        |> Map.put(:shape_dependencies_handles, [@inner_inner_shape_handle])
+
+      # another inner shape with no dependencies, goes to layer 0
+      another_inner_shape =
+        Shape.new!("parent", select: "SELECT id FROM parent", inspector: @inspector)
+
+      another_inner_handle = "another-inner-shape"
+
+      # Outer shape depends on both inner and another_inner (layers 1 and 0)
+      # Should go to layer 2 (1 + max(1, 0))
+      outer_shape =
+        Shape.new!("comments",
+          where:
+            "issue_id IN (SELECT id FROM issues WHERE project_id IN (SELECT id FROM projects)) AND parent_id IN (SELECT id FROM parent)",
+          inspector: @inspector
+        )
+        |> Map.put(:shape_dependencies, [inner_shape, another_inner_shape])
+        |> Map.put(:shape_dependencies_handles, [@inner_shape_handle, another_inner_handle])
+
+      layers =
+        DependencyLayers.new()
+        |> DependencyLayers.add_dependency(inner_inner_shape, @inner_inner_shape_handle)
+        |> DependencyLayers.add_dependency(inner_shape, @inner_shape_handle)
+        |> DependencyLayers.add_dependency(another_inner_shape, another_inner_handle)
+        |> DependencyLayers.add_dependency(outer_shape, @outer_shape_handle)
+
+      assert DependencyLayers.get_for_handles(
+               layers,
+               MapSet.new([
+                 @outer_shape_handle,
+                 @inner_inner_shape_handle,
+                 @inner_shape_handle,
+                 another_inner_handle
+               ])
+             ) == [
+               # Layer 0: inner_inner and another_inner
+               MapSet.new([@inner_inner_shape_handle, another_inner_handle]),
+               # Layer 1: inner
+               MapSet.new([@inner_shape_handle]),
+               # Layer 2: outer
+               MapSet.new([@outer_shape_handle])
+             ]
+    end
   end
 end


### PR DESCRIPTION
Support multiple subqueries at the same level in shape where clauses (e.g., `x IN (subquery) AND y IN (subquery)`), addressing #3675.

Previously, shapes with multiple same-level subqueries were rejected with a 400 error. This PR removes that restriction and:

  - Updates `DependencyLayers` to correctly layer shapes with multiple dependencies by placing them after *all* dependencies are found (1 + max layer of all dependencies)
  - Fixes `extract_subqueries` to preserve AST traversal order
  - Returns 409 (shape invalidation) on move-in/out operations for shapes with multiple same-level subqueries, since we cannot correctly determine which dependency caused the change