### PR TITLE
fix(sync-service): Fix bug with case-sensitive column names in subqueries

### DIFF
--- a/.changeset/witty-beans-yawn.md
+++ b/.changeset/witty-beans-yawn.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Fix bug with case-sensitive column names in subqueries

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -361,10 +361,9 @@ defmodule Electric.Shapes.Shape do
 
   defp extract_sublink_queries(shapes) do
     Enum.with_index(shapes, fn %__MODULE__{} = shape, i ->
-      base =
-        "SELECT " <>
-          Enum.join(shape.explicitly_selected_columns, ", ") <>
-          " FROM " <> Utils.relation_to_sql(shape.root_table)
+      columns = Enum.map_join(shape.explicitly_selected_columns, ", ", &Utils.quote_name/1)
+
+      base = "SELECT " <> columns <> " FROM " <> Utils.relation_to_sql(shape.root_table)
 
       where = if shape.where, do: " WHERE " <> shape.where.query, else: ""
 


### PR DESCRIPTION
Fixes #3677 