### PR TITLE
ci: Account for the workflow_dispatch event when deriving the ELECTRIC_TAGS env var

### DIFF
--- a/.github/workflows/sync_service_dockerhub_image.yml
+++ b/.github/workflows/sync_service_dockerhub_image.yml
@@ -1,5 +1,7 @@
 name: Publish Electric images to Docker Hub
 
+# If you decide to modify the list of triggers for this action, don't forget to also update the
+# conditional logic in the derive_build_vars and publish_tagged_image jobs.
 on:
   push:
     branches: ['main']
@@ -42,7 +44,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Determine SHORT_COMMIT_SHA and ELECTRIC_VERSION to use in the build step
+      - name: Determine short_commit_sha and electric_version to use in the build step
         id: vars
         run: |
           echo "short_commit_sha=$(
@@ -130,7 +132,7 @@ jobs:
               echo "ELECTRIC_TAGS=-t electricsql/electric:canary" >> $GITHUB_ENV
               echo "ELECTRIC_CANARY_TAGS=-t electricsql/electric-canary:latest -t electricsql/electric-canary:${{ needs.derive_build_vars.outputs.short_commit_sha }}" >> $GITHUB_ENV
               ;;
-            release)
+            release | workflow_dispatch)
               # A release triggers official release image publishing
               echo "ELECTRIC_TAGS=-t electricsql/electric:latest -t electricsql/electric:${{ needs.derive_build_vars.outputs.electric_version }}" >> $GITHUB_ENV
           esac


### PR DESCRIPTION
Following the merging of https://github.com/electric-sql/electric/pull/3650, I triggered a [manual build](https://github.com/electric-sql/electric/actions/runs/20792273543/job/59717174555) for `@core/sync-servoce@1.2.10`. Missed value in a case statement got in the way of successful publishing of the built platform-specific images into a single tagged multi-platform image.

This PR fixes that omission.