### PR TITLE
Use object as `subscriptionId` in clients

### DIFF
--- a/packages/experimental/src/multi-shape-stream.ts
+++ b/packages/experimental/src/multi-shape-stream.ts
@@ -130,7 +130,7 @@ export class MultiShapeStream<
   #lastUpToDateLsns: { [K in keyof TShapeRows]: bigint }
 
   readonly #subscribers = new Map<
-    number,
+    object,
     [
       (messages: MultiShapeMessages<TShapeRows>[]) => MaybePromise<void>,
       ((error: Error) => void) | undefined,
@@ -293,7 +293,7 @@ export class MultiShapeStream<
     ) => MaybePromise<void>,
     onError?: (error: FetchError | Error) => void
   ) {
-    const subscriptionId = Math.random()
+    const subscriptionId = {}
 
     this.#subscribers.set(subscriptionId, [callback, onError])
     if (!this.#started) this.#start()

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -534,7 +534,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
   readonly #messageParser: MessageParser<T>
 
   readonly #subscribers = new Map<
-    number,
+    object,
     [
       (messages: Message<T>[]) => MaybePromise<void>,
       ((error: Error) => void) | undefined,
@@ -1328,7 +1328,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
     callback: (messages: Message<T>[]) => MaybePromise<void>,
     onError: (error: Error) => void = () => {}
   ) {
-    const subscriptionId = Math.random()
+    const subscriptionId = {}
 
     this.#subscribers.set(subscriptionId, [callback, onError])
     if (!this.#started) this.#start()

--- a/packages/typescript-client/src/shape.ts
+++ b/packages/typescript-client/src/shape.ts
@@ -51,7 +51,7 @@ export class Shape<T extends Row<unknown> = Row> {
   readonly stream: ShapeStreamInterface<T>
 
   readonly #data: ShapeData<T> = new Map()
-  readonly #subscribers = new Map<number, ShapeChangedCallback<T>>()
+  readonly #subscribers = new Map<object, ShapeChangedCallback<T>>()
   readonly #insertedKeys = new Set<string>()
   readonly #requestedSubSnapshots = new Set<string>()
   #reexecuteSnapshotsPending = false
@@ -149,7 +149,7 @@ export class Shape<T extends Row<unknown> = Row> {
   }
 
   subscribe(callback: ShapeChangedCallback<T>): () => void {
-    const subscriptionId = Math.random()
+    const subscriptionId = {}
 
     this.#subscribers.set(subscriptionId, callback)
 


### PR DESCRIPTION
This is such a small thing I spotted when looking into how things work I wondered if it was even worth opening. There's a _tiny_ chance of a collision with `Math.random()`, when that could be removed by using an object here, or maybe symbol/counter even 🤷

A while back we did discover some smart tv's which unbelievably returned a static number from `Math.random()` 😅