### PR TITLE
fix: ensure materializer starting after consumer died doesn't log an error

### DIFF
--- a/.changeset/soft-pandas-guess.md
+++ b/.changeset/soft-pandas-guess.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+fix: ensure materializer starting after consumer died doesn't log an error


### PR DESCRIPTION
Closes #3657