### PR TITLE
Fix CI flake

### DIFF
--- a/integration-tests/tests/rolling-deploy.lux
+++ b/integration-tests/tests/rolling-deploy.lux
@@ -120,8 +120,8 @@
   ??[info] Starting replication from postgres
 
 [shell orchestator]
-  !curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant
-  ??{"status":"active"}
+  # Use wait-for to poll for active status since shape initialization may still be in progress
+  [invoke wait-for "curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant" "\{\"status\":\"active\"\}" 10 $PS1]
 
 # Should see post handover update
 [shell client]

--- a/integration-tests/tests/startup-delayed-by-pending-transaction.lux
+++ b/integration-tests/tests/startup-delayed-by-pending-transaction.lux
@@ -107,8 +107,8 @@
 
 # The 2nd Electric is now healthy and active
 [shell client]
-  !curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant
-  ??{"status":"active"}
+  # Use wait-for to poll for active status since shape initialization may still be in progress
+  [invoke wait-for "curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant" "\{\"status\":\"active\"\}" 10 $PS1]
 
 [cleanup]
   [invoke teardown]


### PR DESCRIPTION
The SQLite-backed metadata storage (cb9f571) introduces initialization overhead that can cause a race condition in tests that check health status immediately after seeing "Starting replication" log.

The shape_log_collector_ready condition is set asynchronously in ShapeCache's handle_continue(:wait_for_restore), which now takes longer due to SQLite operations. This causes the health check to return "starting" instead of "active" if checked too quickly.

Fix by using the wait-for macro to poll for active status, allowing up to 10 seconds for shape initialization to complete.