### PR TITLE
ci: Add 'issues: write' permission to the changesets_release workflow

### DIFF
--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -11,6 +11,7 @@ permissions:
   id-token: write # Required for OIDC
   contents: write # Required to push tags and create releases
   pull-requests: write # Required for changesets to create PRs
+  issues: write # Required for changesets to comment on issues about the release in which they were fixed
 
 jobs:
   changesets:


### PR DESCRIPTION
The release workflow was failing to comment on Issues linked in the changelogs (while PR comments worked fine). This was due to the GITHUB_TOKEN lacking the explicit `issues: write` permission required for the gh issue comment command.

[Problematic Output:](https://github.com/electric-sql/electric/actions/runs/20758307644/job/59606255072)
```
Found 3 linked issues to comment on
GraphQL: Resource not accessible by integration (addComment)
  Failed to comment on issue #3669: Command failed: gh issue comment 3669 --repo electric-sql/electric --body-file -
GraphQL: Resource not accessible by integration (addComment)
  Failed to comment on issue #3639: Command failed: gh issue comment 3639 --repo electric-sql/electric --body-file -
GraphQL: Resource not accessible by integration (addComment)
  Failed to comment on issue #3677: Command failed: gh issue comment 3677 --repo electric-sql/electric --body-file -
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable release automation to comment on GitHub issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->