### PR TITLE
Add changeset for merged pull request #3701

### DIFF
--- a/.changeset/stale-cache-buster.md
+++ b/.changeset/stale-cache-buster.md
@@ -1,0 +1,7 @@
+---
+'@electric-sql/client': patch
+---
+
+Fix stale cached responses with expired shape handles
+
+When a CDN/proxy is misconfigured and serves a stale cached response with an expired shape handle, the client would get into a broken state where the handle was rejected but the offset was still advanced. This fix detects stale responses and triggers a retry with a cache buster parameter to bypass the misconfigured CDN cache.


### PR DESCRIPTION
Adds a patch changeset for the stale cache buster fix that was merged without a changeset.

https://github.com/electric-sql/electric/pull/3701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved stale cache responses that could occur with misconfigured CDN/proxy setups. The client now automatically detects stale data and retries with cache-busting to ensure users receive the most up-to-date information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->