### PR TITLE
fix(ci): improve ref derivation in docker publish workflow

### DIFF
--- a/.github/workflows/sync_service_dockerhub_image.yml
+++ b/.github/workflows/sync_service_dockerhub_image.yml
@@ -39,15 +39,19 @@ jobs:
     steps:
       - name: Determine the ref to check out
         id: git_ref
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          if [ -n "${{ inputs.release_tag }}" ]; then
-            ref="refs/tags/${{ inputs.release_tag }}"
+          if [ -n "$INPUT_RELEASE_TAG" ]; then
+            ref="refs/tags/$INPUT_RELEASE_TAG"
             is_release=true
-          elif [ -n "${{ github.event.release.tag_name }}" ]; then
-            ref="refs/tags/${{ github.event.release.tag_name }}"
+          elif [ -n "$EVENT_RELEASE_TAG" ]; then
+            ref="refs/tags/$EVENT_RELEASE_TAG"
             is_release=true
           else
-            ref="${{ github.sha }}"
+            ref="$COMMIT_SHA"
             is_release=false
           fi
 


### PR DESCRIPTION
### 🔗 Context
When this workflow is called by the Changesets workflow, the `github.event_name` context variable evaluates to `push` (the parent's trigger) rather than `workflow_call`. This caused our previous logic to skip the release flow and default to canary builds.

So the most recent [package publishing](https://github.com/electric-sql/electric/actions/runs/21003147814/job/60379128532) only pushed canary images:

```
 #1 [internal] pushing docker.io/electricsql/electric:canary
#1 0.000 pushing sha256:e372c6ad86713cdbf726bbef83920eb32ecf9034d3794abde8d9fa73805413b1 to docker.io/electricsql/electric:canary
#1 DONE 1.9s
#1 [internal] pushing docker.io/electricsql/electric-canary:3516b9780
#1 0.000 pushing sha256:e372c6ad86713cdbf726bbef83920eb32ecf9034d3794abde8d9fa73805413b1 to docker.io/electricsql/electric-canary:3516b9780
#1 ...

#2 [internal] pushing docker.io/electricsql/electric-canary:latest
#2 0.000 pushing sha256:e372c6ad86713cdbf726bbef83920eb32ecf9034d3794abde8d9fa73805413b1 to docker.io/electricsql/electric-canary:latest
#2 DONE 1.8s

#1 [internal] pushing docker.io/electricsql/electric-canary:3516b9780
#1 DONE 1.8s
```


### 🛠️ Changes
- Updated `derive_build_vars` job to prioritize `inputs.release_tag` and `github.event.release.tag_name` over the event name string.
- Refactored shell logic to use more idiomatic `-n` (non-zero string) checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the Docker Hub image sync workflow's release detection logic to prioritize explicit release tags and fallback to commit-based runs, preserving existing behavior for release and manual triggers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->