### PR TITLE
Add outdated blog post disclaimer component

### DIFF
--- a/website/blog/posts/2022-12-16-evolution-state-transfer.md
+++ b/website/blog/posts/2022-12-16-evolution-state-transfer.md
@@ -16,6 +16,9 @@ post: true
 import Tweet from 'vue-tweet'
 </script>
 
+> [!WARNING]
+> This post was written for a previous version of Electric that is no longer active. It is preserved for historical interest only. See the [Electric Next](/blog/2024/07/17/electric-next) post for context on the new system.
+
 Web development has been progressing through an evolution of state transfer. Local-first is the natural endgame and the vision we're working towards with Electric.
 
 State transfer is fundamental to online applications. Web apps are architected around the network, with the separation of front-end from back-end and protocols like AJAX and REST. However, newer protocols like GraphQL and frameworks like Remix are increasingly abstracting state transfer away from application code.

--- a/website/blog/posts/2023-02-09-developing-local-first-software.md
+++ b/website/blog/posts/2023-02-09-developing-local-first-software.md
@@ -12,6 +12,9 @@ outline: deep
 post: true
 ---
 
+> [!WARNING]
+> This post was written for a previous version of Electric that is no longer active. It is preserved for historical interest only. See the [Electric Next](/blog/2024/07/17/electric-next) post for context on the new system.
+
 [Local-first software](https://www.inkandswitch.com/local-first) is the future. It's the [natural evolution of state-transfer](/blog/2022/12/16/evolution-state-transfer). It enables a modern, realtime multi-user experience, with built in offline support, resilience, privacy and data ownership. You get instant reactivity and a network-free interaction path. Plus it's much cheaper to operate and scale.
 
 <!--truncate-->

--- a/website/blog/posts/2023-10-26-local-first-software-London-meet-up.md
+++ b/website/blog/posts/2023-10-26-local-first-software-London-meet-up.md
@@ -12,6 +12,9 @@ outline: deep
 post: true
 ---
 
+> [!WARNING]
+> This post was written for a previous version of Electric that is no longer active. It is preserved for historical interest only. See the [Electric Next](/blog/2024/07/17/electric-next) post for context on the new system.
+
 Last Thursday, the Electric team was excited to host the first [Local-first Software London](https://guild.host/local-first-software-london/events) meet-up. It was a really successful evening, and it was brilliant to meet so many people from the Local-first movement in person, many of whom had travelled to London for the [React Advanced](https://reactadvanced.com) conference on Friday.
 
 We had a great turn out for the meet-up, both in person, and from those joining in via the livestream. We were delighted that the speakers we'd asked to join us accepted our invitation, and we were treated to an evening of interesting and enthusiastic presentations from each. Our guest speakers are all leaders from across the broad spectrum of Local-first projects and products. We are grateful to all of them for contributing to this first meet-up, and for further taking the time to answer follow-up questions from the attendees after each talk.

--- a/website/blog/posts/2023-12-15-secure-transactions-with-local-first.md
+++ b/website/blog/posts/2023-12-15-secure-transactions-with-local-first.md
@@ -9,6 +9,9 @@ outline: deep
 post: true
 ---
 
+> [!WARNING]
+> This post was written for a previous version of Electric that is no longer active. It is preserved for historical interest only. See the [Electric Next](/blog/2024/07/17/electric-next) post for context on the new system.
+
 One of the most common questions we get asked about developing on ElectricSQL and local-first in general is how to do secure, confirmed transactions like bookings and payments. <!--truncate-->It's a great question, because you typically need to use a server for these type of transactions. You don't want to bundle secrets into a client app and the server can make sure that a transaction is only executed once.
 
 The good news is that there's a simple pattern you can easily implement to do secure transactions with ElectricSQL and local-first applications in general. Read ahead for more context, or [jump straight to the solution](#solution--use-a-state-machine).

--- a/website/blog/posts/2024-02-05-local-first-ai-with-tauri-postgres-pgvector-llama.md
+++ b/website/blog/posts/2024-02-05-local-first-ai-with-tauri-postgres-pgvector-llama.md
@@ -11,6 +11,9 @@ outline: deep
 post: true
 ---
 
+> [!WARNING]
+> This post was written for a previous version of Electric that is no longer active. It is preserved for historical interest only. See the [Electric Next](/blog/2024/07/17/electric-next) post for context on the new system.
+
 The first wave of LLM-enabled apps used large models running in the cloud. It's a running joke that most AI startups are just a wrapper around the OpenAI API. This naturally involves sending your prompt and context data to a third party API.
 
 This typically doesn't matter too much when you're just generating [funny elephant pictures](/img/blog/local-first-ai-with-tauri-postgres-pgvector-llama/electric-elephant.jpg). But if you're building consumer or professional apps, you don't want to leak sensitive and private data. Retrieval-augmented generation (RAG) compounds the problem, by feeding even more data into the model &mdash; silently, in the background.

--- a/website/blog/posts/2024-02-27-intel-ignite.md
+++ b/website/blog/posts/2024-02-27-intel-ignite.md
@@ -12,6 +12,9 @@ outline: deep
 post: true
 ---
 
+> [!WARNING]
+> This post was written for a previous version of Electric that is no longer active. It is preserved for historical interest only. See the [Electric Next](/blog/2024/07/17/electric-next) post for context on the new system.
+
 ElectricSQL was selected by Intel as one of 10 startups to participate in [batch #6](https://intelignite.com/intel-ignite-selects-10-startups-for-fall-2023-european-cohort/) of it's [Intel Ignite](https://intelignite.com) accelerator programme in Munich.
 
 It's a unique opportunity and our thanks go to [Alois](https://www.linkedin.com/in/alois-eder-013b0460/), [Kate](https://www.linkedin.com/in/katehach/), [Markus](https://www.linkedin.com/in/markusbohl/) and [Martha](https://www.linkedin.com/in/martha-ivanovas-78a897b/) on the programme team. We'd also like to thank our mentors [Ralph](https://www.linkedin.com/in/ralphdw/), [Karl](https://www.linkedin.com/in/0xpit/), [Benny](https://www.linkedin.com/in/fuhry/) and of course, the amazing [Diego](https://www.linkedin.com/in/diego-bailón-humpert-92390a28b/).


### PR DESCRIPTION
Add warning banners to blog posts written before the Electric Next rewrite to prevent confusion. These posts are preserved for historical interest but their content is no longer applicable to the current version of Electric.

Affected posts:
- 2022-12-16 The evolution of state transfer
- 2023-02-09 Developing local-first software
- 2023-10-26 Local-first Software London meet-up
- 2023-12-15 Secure transactions with local-first
- 2024-02-05 Local AI with Tauri, Postgres, pgvector and llama2
- 2024-02-27 Intel Ignite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added version history notices to archived blog posts, directing readers to Electric Next for current information.
  * Enhanced a meetup recap post with embedded presentation recordings, event details, and an invitation to join the community.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->