### PR TITLE
chore: Add AGENTS.md file for sync-service

### DIFF
--- a/packages/sync-service/AGENTS.md
+++ b/packages/sync-service/AGENTS.md
@@ -92,6 +92,19 @@ assert [
   `junit/`, `node_modules/`, `erl_crash.dump`.
 - Do not commit real secrets; `.env.*` is for local dev only.
 
+## Cross-package APIs
+
+`Electric.Application` exposes APIs for embedding sync-service in other apps:
+
+- `api/1` – returns a configured `Electric.Shapes.Api` for programmatic access;
+  used by **elixir-client** (`packages/elixir-client`) for embedded mode.
+- `api_plug_opts/1` – returns plug options for mounting the shapes router;
+  used by **Phoenix.Sync** (external Hex package).
+- `configuration/1` – returns full config for `StackSupervisor`.
+
+These are marked `@doc false` but are required public APIs. Changes here can
+break downstream consumers.
+
 ## Security/ops notes
 
 - `ELECTRIC_INSECURE=true` is dev-only; prod requires `ELECTRIC_SECRET`.


### PR DESCRIPTION
This PR adds a AGENTS.md file for the sync-service. At the moment it's very small, but it serves as a starting point to add to as we discover issues to do with the agents not having the right context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Electric Sync Service, describing service scope and goals, architecture and subsystems, development workflows and commands, testing guidance, project structure, environment configuration, cross-package APIs, and security and operational guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->