### PR TITLE
fix(ci): Fix invalid 'command' key in workflow service container

### DIFF
--- a/.github/workflows/build_postgres_image.yml
+++ b/.github/workflows/build_postgres_image.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           echo '
             FROM postgres:${{ matrix.postgres_version }}-alpine
-            CMD ["postgres", "-c", "wal_level=logical", "-c", "max_replication_slots=40"]
+            CMD ["postgres", "-c", "wal_level=logical", "-c", "max_replication_slots=40", "-c", "max_connections=200"]
           ' > Dockerfile
 
       - name: Build and push

--- a/.github/workflows/sync_service_tests.yml
+++ b/.github/workflows/sync_service_tests.yml
@@ -42,7 +42,6 @@ jobs:
           --health-retries 5
         ports:
           - 54321:5432
-        command: postgres -c max_connections=200
 
       pgbouncer:
         image: bitnamilegacy/pgbouncer:latest


### PR DESCRIPTION
## Summary

Fixes the CI workflow syntax error:
```
Invalid workflow file: .github/workflows/sync_service_tests.yml#L1
(Line: 45, Col: 9): Unexpected value 'command'
```

GitHub Actions service containers don't support the `command` key. This PR:
1. Removes the invalid `command` key from `sync_service_tests.yml`
2. Adds `max_connections=200` to the postgres image build in `build_postgres_image.yml`

## Note

The postgres images will need to be rebuilt to include `max_connections=200`. Either:
- Manually trigger the "Postgres image for CI" workflow, or
- Wait for the next scheduled rebuild (Sunday 00:00 UTC)

Until then, tests will use the default `max_connections` (100).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL configuration to establish a connection limit of 200 across build and test environments, consolidating database startup parameters into the image configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->