### PR TITLE
ci(sync-service): trigger workflow when workflow file is modified

### DIFF
--- a/.github/workflows/sync_service_tests.yml
+++ b/.github/workflows/sync_service_tests.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'packages/electric-telemetry/**'
       - 'packages/sync-service/**'
+      - '.github/workflows/sync_service_tests.yml'
   pull_request:
     paths:
       - 'packages/electric-telemetry/**'
       - 'packages/sync-service/**'
+      - '.github/workflows/sync_service_tests.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `.github/workflows/sync_service_tests.yml` to the workflow's path triggers
- Ensures the sync-service tests run when the workflow file itself is modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration for testing processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->