### PR TITLE
ci: Create per-platform Dockerfile for proper Docker image layer caching

### DIFF
--- a/.github/workflows/sync_service_dockerhub_image.yml
+++ b/.github/workflows/sync_service_dockerhub_image.yml
@@ -23,8 +23,8 @@ on:
         type: string
 
 env:
-  DOCKERHUB_REPO: electricsql/electric
-  DOCKERHUB_CANARY_REPO: electricsql/electric-canary
+  DOCKERHUB_REPO: alco/electric
+  DOCKERHUB_CANARY_REPO: alco/electric-canary
 
 jobs:
   derive_build_vars:
@@ -111,8 +111,8 @@ jobs:
       - uses: docker/login-action@v3
         with:
           registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_ALCO }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_ALCO }}
 
       - name: Create a temporary per-platform Dockerfile (CI only)
         run: |
@@ -165,8 +165,8 @@ jobs:
     steps:
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_ALCO }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_ALCO }}
 
       - uses: useblacksmith/setup-docker-builder@v1
 


### PR DESCRIPTION
## Summary

- Creates a unique, per-platform Dockerfile path so Blacksmith uses separate sticky disks for image layer caching
- Without this, caches produced by builds for different platforms trample each other and only the last written cache persists

## Problem

When building multi-platform Docker images (amd64 and arm64), both platform builds use the same Dockerfile path. Blacksmith's sticky disk caching keys on the Dockerfile path, causing the caches to overwrite each other. Only one platform benefits from caching in subsequent builds.

### Evidence from [run #21174363588](https://github.com/electric-sql/electric/actions/runs/21174363588)

This run happened immediately after [run #21173980401](https://github.com/electric-sql/electric/actions/runs/21173980401) where both platforms had successfully built. Despite both caches being freshly populated, only one platform could use its cache:

**amd64 build (cache HIT)** — most build steps are CACHED:
```
#10 CACHED
#11 [builder  6/17] COPY mix.* /builder/electric/
#11 CACHED
#12 [builder 10/17] COPY lib /builder/electric/lib/
#12 CACHED
#13 [builder  3/17] RUN mix local.hex --force && mix local.rebar --force
#13 CACHED
#14 [builder  8/17] RUN MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4 mix deps.compile
#14 CACHED
#15 [builder  9/17] COPY rel /builder/electric/rel
#15 CACHED
...
```

**arm64 build (cache MISS)** — expensive steps like `mix deps.compile` run from scratch:
```
#10 [builder  2/17] RUN apt-get update -y && ...
#10 CACHED
#11 [builder  3/17] RUN mix local.hex --force && mix local.rebar --force
#11 CACHED
#12 CACHED
#13 [builder  5/17] COPY --from=electric-telemetry / /builder/electric-telemetry
#14 [builder  6/17] COPY mix.* /builder/electric/
#15 [builder  7/17] RUN mix deps.get
#16 [builder  8/17] RUN MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4 mix deps.compile
#17 [builder  9/17] COPY rel /builder/electric/rel
...
```

The arm64 build had to run `mix deps.compile` (~60s) while amd64 got it from cache.

## Solution

Create a unique Dockerfile path per platform by prepending a cache scope comment:
```
/tmp/sync-service.Dockerfile.amd64
/tmp/sync-service.Dockerfile.arm64
```

This ensures Blacksmith treats each platform's build cache independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved multi-platform Docker build caching by isolating per-platform build files to prevent cross-platform cache interference and speed up builds.
  * Updated Docker image publishing to target a different image repository namespace and adjusted CI publishing configuration accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->