### PR TITLE
fix(sync-service): Fix RelationTracker not syncing with Configurator after restart

### DIFF
--- a/.changeset/fix-relation-tracker-restart.md
+++ b/.changeset/fix-relation-tracker-restart.md
@@ -1,0 +1,7 @@
+---
+"@core/sync-service": patch
+---
+
+Fix RelationTracker not syncing with Configurator after restart
+
+When the RelationTracker restarts while the Configurator is still running, it now properly notifies the Configurator of the restored filters. Previously, after a RelationTracker restart, subsequent shape removals would not update the publication because the internal filter state was inconsistent.

--- a/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
@@ -180,8 +180,11 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
           "Restored publication filters in #{System.convert_time_unit(System.monotonic_time() - start, :native, :millisecond)}ms"
         )
 
-        # filters will be pulled by the configurator on startup, so no
-        # need to explicitly call for an update here
+        # Notify the Configurator of the restored filters. This is necessary
+        # when the RelationTracker restarts while the Configurator is still
+        # running, as the Configurator only fetches filters on its own startup.
+        state = update_publication_if_necessary(state)
+
         {:noreply, state, state.publication_refresh_period}
       end
     )


### PR DESCRIPTION
## Summary

- Fix a bug where the RelationTracker didn't notify the Configurator after restart, causing subsequent shape removals to not update the publication
- Fix the fundamentally broken "handles relation tracker restart" test. You can see it flaking [here](https://github.com/electric-sql/electric/actions/runs/21210008866/job/61015850512)

## Problem

**Production bug:** When the `RelationTracker` restarts while the `Configurator` is still running (`:one_for_one` supervision), the restored filters were not being synced to the Configurator. This caused the internal state to become inconsistent:
- `prepared_relation_filters` was restored from ShapeStatus
- `submitted_relation_filters` remained empty (from init)

After a shape removal, both would be empty, so `update_needed?` returned false and no publication update was triggered. The system would eventually self-heal via the 60-second periodic refresh, but this is too slow for correct behavior.

**Test bug:** The original test expected `assert_raise RuntimeError` but the actual behavior when a GenServer dies during a call is an **EXIT**, not a RuntimeError. The async task wasn't being awaited, so the assertion failure was being silently ignored - the test was "passing" based on other assertions.

## Solution

1. Added `update_publication_if_necessary(state)` after restoring filters in `handle_continue(:restore_relations, ...)` to immediately sync with the Configurator.

2. Rewrote the test to correctly verify the restart-and-recovery scenario without the flawed async/RuntimeError expectations.

## Test plan

- [x] Verified the production fix is needed: without it, the test fails (publication not updated within 2s timeout)
- [x] Ran the test 5+ times with different seeds - all pass
- [x] Ran full publication_manager_test.exs - all 22 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where filter state became inconsistent when internal services restarted while running. This prevented data shape removals from properly updating the database publication. The system now correctly restores and communicates filter information during restart, ensuring consistent data synchronization behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->