### PR TITLE
fix: Make rate limit error a known error

### DIFF
--- a/.changeset/spicy-rice-taste.md
+++ b/.changeset/spicy-rice-taste.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Make rate limit error a known error

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -95,6 +95,7 @@ defmodule Electric.Plug.ServeShapePlug do
             get_in(config, [:api]),
             %{code: "overloaded", message: "Server is currently overloaded, please retry"},
             status: 503,
+            known_error: true,
             retry_after: retry_after
           )
 


### PR DESCRIPTION
## Summary
- Marks the 503 rate limit/overloaded error as a known error by adding `known_error: true` to the error response
- This ensures rate limiting responses are treated as expected behavior rather than unexpected errors

## Test plan
- [ ] Verify rate limit responses include the known_error flag
- [ ] Confirm error handling/logging treats this as a known error

🤖 Generated with [Claude Code](https://claude.com/claude-code)