### PR TITLE
fix(sync-service): Fix shape cleanup race condition

### DIFF
--- a/.changeset/nervous-brooms-relax.md
+++ b/.changeset/nervous-brooms-relax.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Fix storage race condition when deleting shape during a live poll request


### PR DESCRIPTION
Fixes #3760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync service reliability by properly addressing offset regression scenarios that can occur during live polling. The system now detects these edge cases and returns appropriate HTTP error responses to trigger necessary data refetch operations, preventing silent failures.

* **Tests**
  * Added comprehensive test coverage for offset regression edge cases during live polling operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->