### PR TITLE
Add runtime validation for columnMapper to catch common mistakes

### DIFF
--- a/.changeset/add-columnmapper-validation.md
+++ b/.changeset/add-columnmapper-validation.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/client': patch
+---
+
+Add runtime validation for `columnMapper` option to catch common mistake of passing the factory function instead of calling it. Provides helpful error messages like "Did you forget to call snakeCamelMapper()?" when users pass `snakeCamelMapper` instead of `snakeCamelMapper()`.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1737,14 +1737,10 @@ function validateOptions<T>(options: Partial<ShapeStreamOptions<T>>): void {
 
   validateParams(options.params)
 
-  // Validate columnMapper if provided
-  // Note: Runtime validation catches common mistakes like passing the factory function
-  // instead of calling it, even though TypeScript types should prevent this.
   if (options.columnMapper !== undefined) {
-    // Cast to unknown to handle runtime cases where user passes wrong type
     const mapper = options.columnMapper as unknown
+
     if (typeof mapper === `function`) {
-      // Common mistake: passing the factory function instead of calling it
       const fnName =
         (mapper as { name?: string }).name || `columnMapper function`
       throw new InvalidColumnMapperError(
@@ -1761,8 +1757,6 @@ function validateOptions<T>(options: Partial<ShapeStreamOptions<T>>): void {
       )
     }
   }
-
-  return
 }
 
 // `unknown` being in the value is a bit of defensive programming if user doesn't use TS

--- a/packages/typescript-client/src/column-mapper.ts
+++ b/packages/typescript-client/src/column-mapper.ts
@@ -4,14 +4,6 @@ type DbColumnName = string
 type AppColumnName = string
 
 /**
- * Symbol used to brand ColumnMapper objects.
- * This helps TypeScript distinguish between a ColumnMapper object
- * and a function that returns a ColumnMapper.
- * @internal
- */
-export const COLUMN_MAPPER_BRAND = Symbol.for(`electric.columnMapper`)
-
-/**
  * Quote a PostgreSQL identifier for safe use in query parameters.
  *
  * Wraps the identifier in double quotes and escapes any internal
@@ -62,14 +54,6 @@ export function quoteIdentifier(identifier: string): string {
  */
 export interface ColumnMapper {
   /**
-   * Brand marker to distinguish ColumnMapper objects from functions.
-   * This helps catch the common mistake of passing `snakeCamelMapper`
-   * instead of `snakeCamelMapper()`.
-   * @internal
-   */
-  readonly [COLUMN_MAPPER_BRAND]: true
-
-  /**
    * Transform a column name from database format to application format.
    * Applied to column names in query results.
    */
@@ -86,11 +70,6 @@ export interface ColumnMapper {
  * Validates that a value is a valid ColumnMapper object.
  * Returns false if the value is a function (common mistake of passing
  * the factory without calling it) or if it lacks encode/decode methods.
- *
- * Note: This intentionally does NOT check for COLUMN_MAPPER_BRAND to maintain
- * backwards compatibility with custom ColumnMapper implementations that use
- * plain objects with encode/decode methods. The brand is used for TypeScript
- * type narrowing and documentation, not runtime enforcement.
  *
  * @param value - The value to validate
  * @returns true if the value is a valid ColumnMapper, false otherwise
@@ -204,8 +183,6 @@ export function createColumnMapper(
   }
 
   return {
-    [COLUMN_MAPPER_BRAND]: true as const,
-
     decode: (dbColumnName: string) => {
       return mapping[dbColumnName] ?? dbColumnName
     },
@@ -421,8 +398,6 @@ export function snakeCamelMapper(schema?: Schema): ColumnMapper {
 
   // Otherwise, map dynamically
   return {
-    [COLUMN_MAPPER_BRAND]: true as const,
-
     decode: (dbColumnName: string) => {
       return snakeToCamel(dbColumnName)
     },

--- a/packages/typescript-client/src/column-mapper.ts
+++ b/packages/typescript-client/src/column-mapper.ts
@@ -84,19 +84,19 @@ export interface ColumnMapper {
 
 /**
  * Validates that a value is a valid ColumnMapper object.
- * Throws an InvalidColumnMapperError with a helpful message if the value
- * appears to be a factory function passed without being called.
+ * Returns false if the value is a function (common mistake of passing
+ * the factory without calling it) or if it lacks encode/decode methods.
+ *
+ * Note: This intentionally does NOT check for COLUMN_MAPPER_BRAND to maintain
+ * backwards compatibility with custom ColumnMapper implementations that use
+ * plain objects with encode/decode methods. The brand is used for TypeScript
+ * type narrowing and documentation, not runtime enforcement.
  *
  * @param value - The value to validate
- * @returns true if valid
- * @throws {InvalidColumnMapperError} if the value is not a valid ColumnMapper
+ * @returns true if the value is a valid ColumnMapper, false otherwise
  * @internal
  */
 export function isValidColumnMapper(value: unknown): value is ColumnMapper {
-  if (typeof value === `function`) {
-    return false
-  }
-
   if (typeof value !== `object` || value === null) {
     return false
   }

--- a/packages/typescript-client/src/error.ts
+++ b/packages/typescript-client/src/error.ts
@@ -123,3 +123,10 @@ export class StaleCacheError extends Error {
     this.name = `StaleCacheError`
   }
 }
+
+export class InvalidColumnMapperError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = `InvalidColumnMapperError`
+  }
+}

--- a/packages/typescript-client/src/index.ts
+++ b/packages/typescript-client/src/index.ts
@@ -6,7 +6,7 @@ export {
   isControlMessage,
   isVisibleInSnapshot,
 } from './helpers'
-export { FetchError } from './error'
+export { FetchError, InvalidColumnMapperError } from './error'
 export { type BackoffOptions, BackoffDefaults } from './fetch'
 export { ELECTRIC_PROTOCOL_QUERY_PARAMS } from './constants'
 export {
@@ -15,5 +15,6 @@ export {
   snakeCamelMapper,
   snakeToCamel,
   camelToSnake,
+  isValidColumnMapper,
 } from './column-mapper'
 export { compileExpression, compileOrderBy } from './expression-compiler'

--- a/packages/typescript-client/test/column-mapper.test.ts
+++ b/packages/typescript-client/test/column-mapper.test.ts
@@ -7,7 +7,6 @@ import {
   encodeWhereClause,
   quoteIdentifier,
   isValidColumnMapper,
-  COLUMN_MAPPER_BRAND,
 } from '../src/column-mapper'
 import type { Schema } from '../src/types'
 
@@ -478,23 +477,5 @@ describe(`isValidColumnMapper`, () => {
   it(`should return false for objects with non-function encode/decode`, () => {
     const invalid = { encode: `not a function`, decode: `not a function` }
     expect(isValidColumnMapper(invalid)).toBe(false)
-  })
-})
-
-describe(`ColumnMapper brand`, () => {
-  it(`should include the brand symbol in snakeCamelMapper result`, () => {
-    const mapper = snakeCamelMapper()
-    expect(mapper[COLUMN_MAPPER_BRAND]).toBe(true)
-  })
-
-  it(`should include the brand symbol in createColumnMapper result`, () => {
-    const mapper = createColumnMapper({ user_id: `userId` })
-    expect(mapper[COLUMN_MAPPER_BRAND]).toBe(true)
-  })
-
-  it(`should include the brand symbol when using schema with snakeCamelMapper`, () => {
-    const schema: Schema = { user_id: { type: `int4` } }
-    const mapper = snakeCamelMapper(schema)
-    expect(mapper[COLUMN_MAPPER_BRAND]).toBe(true)
   })
 })

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -449,7 +449,7 @@ describe(`ShapeStream`, () => {
       }).toThrow(InvalidColumnMapperError)
     })
 
-    it(`should throw InvalidColumnMapperError for invalid columnMapper object`, () => {
+    it(`should throw InvalidColumnMapperError for invalid columnMapper object with helpful guidance`, () => {
       expect(() => {
         new ShapeStream({
           url: shapeUrl,
@@ -457,7 +457,18 @@ describe(`ShapeStream`, () => {
           // @ts-expect-error - intentionally testing invalid input
           columnMapper: { notEncode: () => ``, notDecode: () => `` },
         })
-      }).toThrow(InvalidColumnMapperError)
+      }).toThrow(/snakeCamelMapper\(\) or createColumnMapper\(\)/)
+    })
+
+    it(`should throw InvalidColumnMapperError with fallback message for anonymous functions`, () => {
+      expect(() => {
+        new ShapeStream({
+          url: shapeUrl,
+          params: { table: `foo` },
+          // @ts-expect-error - intentionally testing invalid input
+          columnMapper: () => ({ encode: () => ``, decode: () => `` }),
+        })
+      }).toThrow(/columnMapper function\(\)/)
     })
 
     it(`should throw InvalidColumnMapperError for null columnMapper`, () => {

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -461,12 +461,14 @@ describe(`ShapeStream`, () => {
     })
 
     it(`should throw InvalidColumnMapperError with fallback message for anonymous functions`, () => {
+      // Extract function via array to prevent JavaScript from inferring a name
+      const anonFn = [() => ({ encode: () => ``, decode: () => `` })][0]
       expect(() => {
         new ShapeStream({
           url: shapeUrl,
           params: { table: `foo` },
           // @ts-expect-error - intentionally testing invalid input
-          columnMapper: () => ({ encode: () => ``, decode: () => `` }),
+          columnMapper: anonFn,
         })
       }).toThrow(/columnMapper function\(\)/)
     })

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -513,11 +513,11 @@ describe(`ShapeStream`, () => {
         const stream = new ShapeStream({
           url: shapeUrl,
           params: { table: `foo` },
-          // Custom mapper that works but lacks the brand (for backwards compatibility)
+          // Custom mapper with encode/decode methods
           columnMapper: {
             encode: (name: string) => name.toLowerCase(),
             decode: (name: string) => name.toUpperCase(),
-          } as ReturnType<typeof snakeCamelMapper>,
+          },
           signal: aborter.signal,
         })
         stream.unsubscribeAll()


### PR DESCRIPTION
## Summary

Adds runtime validation for the `columnMapper` option in `ShapeStream` to catch a common developer mistake: passing the factory function (`snakeCamelMapper`) instead of calling it (`snakeCamelMapper()`).

## Root Cause

TypeScript's structural typing means that both `snakeCamelMapper` (the function) and `snakeCamelMapper()` (the result) type-check as valid `columnMapper` values at compile time. When users make this mistake, they get confusing runtime errors deep in the column mapping logic rather than a clear error at construction time.

## Approach

1. **Brand symbol** (`COLUMN_MAPPER_BRAND`) added to `ColumnMapper` interface to distinguish objects from functions at the type level
2. **Runtime validation** in `validateOptions()` checks:
   - If a function was passed → error with "Did you forget to call snakeCamelMapper()?"
   - If object lacks encode/decode → error with guidance to use factory functions
3. **Backwards compatible**: Custom mappers without the brand are still accepted if they have valid `encode`/`decode` methods

## Key Invariants

- Factory functions (`snakeCamelMapper()`, `createColumnMapper()`) always return branded objects
- Validation is duck-typed for backwards compatibility (brand not required at runtime)
- Error messages include the function name when available for actionable guidance

## Non-goals

- **Breaking custom mappers**: Users with plain `{ encode, decode }` objects should continue working
- **Type-level enforcement**: While the brand helps TypeScript, runtime validation is the primary defense

## Verification

```bash
# Type-check
cd packages/typescript-client && pnpm exec tsc --noEmit

# Run tests (requires Electric server)
pnpm test
```

## Files Changed

| File | Change |
|------|--------|
| `src/error.ts` | Add `InvalidColumnMapperError` class |
| `src/column-mapper.ts` | Add `COLUMN_MAPPER_BRAND`, `isValidColumnMapper()`, update factories |
| `src/client.ts` | Add validation in `validateOptions()` |
| `src/index.ts` | Export new error and validator |
| `test/column-mapper.test.ts` | Unit tests for validator and brand |
| `test/stream.test.ts` | Integration tests for validation errors |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)