### PR TITLE
fix(sync-service): Fix move-out race condition for rows entering shape in same txn

### DIFF
--- a/.changeset/fix-subquery-move-out-same-txn.md
+++ b/.changeset/fix-subquery-move-out-same-txn.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix race condition where rows entering a shape via FK update in the same transaction as the parent being deactivated were not correctly removed. The move-out notification could arrive before the materializer subscribed or before the transaction was fully processed, causing the new row to be missed.

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -30,7 +30,14 @@ defmodule Electric.Shapes.Consumer.State do
     terminating?: false,
     buffering?: false,
     or_with_subquery?: false,
-    not_with_subquery?: false
+    not_with_subquery?: false,
+    # Buffer for notifications that arrive before the materializer subscribes.
+    # These are flushed when the materializer subscribes.
+    pending_materializer_notifications: [],
+    # Move-out events that have been processed but may need to be re-applied
+    # to rows that enter the shape in the same transaction.
+    # Format: [{dep_handle, removed_values}, ...]
+    recent_move_outs: []
   ]
 
   @type pg_snapshot() :: SnapshotQuery.pg_snapshot()


### PR DESCRIPTION
## Summary

- Fix race condition where rows entering a shape via FK update in the same transaction as the parent being deactivated were not correctly removed
- The move-out notification could arrive before the materializer subscribed or before the transaction was fully processed, causing the new row to be missed
- Added buffering for notifications when materializer isn't subscribed yet
- Added xid tracking to scope recently_removed values to the same transaction
- Added re-application of move-outs after transaction processing

## Test plan

- [x] Existing test at `test/integration/subquery_move_out_test.exs:343` now passes
- [x] All 11 tests in `subquery_move_out_test.exs` pass
- [ ] Manual testing of shapes with subqueries involving FK updates in same transaction as parent deactivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)