### PR TITLE
feat: Support arbitrary boolean expressions with subqueries (OR, NOT)

### DIFF
--- a/.changeset/arbitrary-boolean-expressions-with-subqueries.md
+++ b/.changeset/arbitrary-boolean-expressions-with-subqueries.md
@@ -1,0 +1,19 @@
+---
+"@core/sync-service": minor
+"@core/elixir-client": minor
+---
+
+Add support for arbitrary boolean expressions with subqueries.
+
+Previously, WHERE clauses with OR or NOT combined with subqueries would cause shape invalidation. This update implements RFC "Arbitrary Boolean Expressions with Subqueries" which enables:
+
+- OR with multiple subqueries: `WHERE project_id IN (SELECT ...) OR assigned_to IN (SELECT ...)`
+- NOT with subqueries: `WHERE project_id NOT IN (SELECT ...)`
+- Complex expressions: `WHERE (a IN sq1 AND b='x') OR c NOT IN sq2`
+
+Key features:
+- DNF (Disjunctive Normal Form) decomposition for WHERE clause analysis
+- `active_conditions` array in row messages indicating which atomic conditions are satisfied
+- Position-based move-in/move-out handling that correctly inverts behavior for negated positions
+- Deduplication logic to prevent duplicate inserts when rows match multiple disjuncts
+- Updated elixir-client to parse `active_conditions` field in message headers

--- a/docs/rfcs/arbitrary-boolean-expressions-with-subqueries.md
+++ b/docs/rfcs/arbitrary-boolean-expressions-with-subqueries.md
@@ -1,0 +1,627 @@
+---
+title: "RFC: Arbitrary Boolean Expressions with Subqueries"
+version: "1.0"
+status: draft
+owner: rob
+contributors:
+  - ilia
+  - kev
+created: 2026-01-27
+last_updated: 2026-02-16
+prd: N/A
+prd_version: N/A
+---
+
+# RFC: Arbitrary Boolean Expressions with Subqueries
+
+## Summary
+
+This RFC extends Electric's subquery support from single `IN (SELECT ...)` conditions to arbitrary boolean expressions containing multiple subqueries combined with AND, OR, and NOT. It introduces a DNF-based tag structure with per-row `active_conditions` that enables efficient move-in/move-out handling without requiring Postgres queries when rows are already present for another reason.
+
+## Background
+
+Electric currently supports subqueries in WHERE clauses (e.g., `SELECT * FROM tasks WHERE project_id IN (SELECT id FROM projects WHERE ...)`). This works well for single subqueries but has limitations:
+
+1. **OR with subqueries returns 409** — `WHERE x IN subquery1 OR y IN subquery2` causes shape invalidation on move-ins because we can't determine which condition changed
+2. **NOT with subqueries unsupported** — `WHERE x NOT IN (SELECT ...)` doesn't handle move-in/move-out correctly
+3. **Multiple subqueries at same level** — Complex boolean combinations require client refresh
+
+The existing RFC ["Move-in/Move-out Handling for Shapes with Subqueries"](./algorithm-for-move-ins-out-with-subqueries.md) established the foundation with tagging and noted that "all where clauses can be converted to a DNF form."
+
+Ilia's DNF decomposer (`ilia/dnf-form` branch) provides the algorithm to convert arbitrary WHERE clauses to Disjunctive Normal Form, enabling this extension.
+
+## Problem
+
+Users need shapes with complex WHERE clauses combining multiple subqueries:
+
+```sql
+-- Current: returns 409 on move-in
+WHERE (project_id IN (SELECT id FROM projects WHERE active) AND status = 'open')
+   OR (assigned_to IN (SELECT id FROM users WHERE role = 'admin'))
+
+-- Current: not supported
+WHERE project_id NOT IN (SELECT id FROM archived_projects)
+```
+
+The current implementation can't track which conditions caused a row's inclusion, making move-in/move-out handling impossible without full shape invalidation.
+
+**Link to PRD hypothesis:** Enables Electric to support real-world filtering patterns where data access depends on multiple dynamic criteria.
+
+## Goals & Non-Goals
+
+### Goals
+
+- Support arbitrary AND/OR/NOT combinations of subquery conditions
+- Support mixed conditions: subqueries combined with field-based filters
+- Efficient move-in: avoid Postgres queries when row is already present for another reason
+- Move-in/move-out as broadcasts to clients, not per-row targeted updates
+- Backward compatible: existing single-subquery shapes continue working
+- Client logic remains simple: evaluate tags against `active_conditions` bitmask
+
+### Non-Goals
+
+- Client-side condition evaluation (clients don't parse WHERE clauses)
+- Optimizing for shapes with dozens of subqueries (reasonable limit ~10)
+- Real-time subquery result caching across shapes
+- Supporting subqueries in SELECT clause (only WHERE)
+
+## Proposal
+
+### Overview
+
+Convert WHERE clauses to Disjunctive Normal Form (DNF), where each disjunct is a conjunction of atomic conditions. Each position in the DNF corresponds to a condition that can be independently activated/deactivated.
+
+For a row:
+- **Tags**: One slash-delimited string per disjunct, with hashed values at positions that participate and empty segments for non-participating positions
+- **`active_conditions`**: Flat boolean array indicating which positions are currently satisfied
+
+Client evaluates: for each tag, AND the `active_conditions` at non-empty positions, then OR all tag results.
+
+### DNF Decomposition
+
+Use the `Electric.Replication.Eval.Decomposer` module to convert WHERE clauses:
+
+```elixir
+# Input: WHERE (x IN subquery1 AND status = 'active') OR y IN subquery2
+# Output:
+{disjuncts, subexpressions} = Decomposer.decompose(where_ast)
+
+# disjuncts = [
+#   [ref1, ref2, nil],     # (x IN subquery1 AND status = 'active')
+#   [nil, nil, ref3]       # y IN subquery2
+# ]
+#
+# subexpressions = %{
+#   ref1 => "x IN (SELECT ...)",
+#   ref2 => "status = 'active'",
+#   ref3 => "y IN (SELECT ...)"
+# }
+```
+
+Position mapping:
+- Position 0: `x IN subquery1`
+- Position 1: `status = 'active'`
+- Position 2: `y IN subquery2`
+
+### Tag Structure
+
+Each row can have multiple tags (one per disjunct it could satisfy):
+
+```
+Row with x='a', status='active', y='b':
+
+tags: [
+  "hash(a)/hash(active)/",   # could match disjunct 1
+  "//hash(b)"                # could match disjunct 2
+]
+
+active_conditions: [true, true, false]
+# Position 0 (x IN subquery1): 'a' is in subquery1 → true
+# Position 1 (status = 'active'): field matches → true
+# Position 2 (y IN subquery2): 'b' is NOT in subquery2 → false
+```
+
+Client evaluation (split each tag on `/`, non-empty segments indicate participating positions):
+- Tag 1 `"hash(a)/hash(active)/"`: positions 0,1 → `active_conditions[0] AND active_conditions[1]` = true AND true = **true**
+- Tag 2 `"//hash(b)"`: position 2 → `active_conditions[2]` = **false**
+- Result: true OR false = **included**
+
+### Negation Handling
+
+NOT conditions are handled via De Morgan's laws in the decomposer:
+- `NOT (a OR b)` → `(NOT a) AND (NOT b)`
+- `NOT (a AND b)` → `(NOT a) OR (NOT b)`
+
+Negation is encoded by **position**, not value. For `WHERE x IN subquery OR x NOT IN subquery`:
+
+```
+Positions:
+- Position 0: x IN subquery (positive)
+- Position 1: x NOT IN subquery (negated)
+
+Row with x='a' where 'a' is in the subquery:
+tags: ["hash(a)/", "/hash(a)"]
+active_conditions: [true, false]
+# Position 0: 'a' is in subquery → true
+# Position 1: 'a' is in subquery, so NOT IN is false → false
+```
+
+The server tracks which positions are negated. When 'a' moves into the subquery:
+- Position 0 activates (positive condition now true)
+- Position 1 deactivates (negated condition now false)
+
+Clients see the same hash value at different positions with opposite activation.
+
+### Tag Value Hashing
+
+Tags use the existing hashing scheme for opacity:
+
+```elixir
+hash = md5(stack_id <> shape_handle <> namespaced_value)
+```
+
+Where `namespaced_value` is:
+- `"v:" <> value` for non-null values
+- `"NULL"` for null values
+
+### Message Format
+
+#### Row Messages
+
+Extend existing insert/update/delete messages with `active_conditions`:
+
+```json
+{
+  "key": "public.tasks/123",
+  "value": {"id": 123, "title": "..."},
+  "headers": {
+    "operation": "insert",
+    "tags": ["abc123/def456/", "//ghi789"],
+    "active_conditions": [true, true, false]
+  }
+}
+```
+
+For updates, include both `tags` and `removed_tags` as today, plus `active_conditions`.
+
+#### Move-in/Move-out Messages
+
+New control message types for broadcasting condition changes:
+
+```json
+["move-in", {"position": 0, "values": ["hash1", "hash2", "hash3"]}]
+["move-out", {"position": 2, "values": ["hash4", "hash5"]}]
+```
+
+- `position`: Which condition position changed
+- `values`: Hashed values that moved in/out (batched for efficiency)
+
+Clients update `active_conditions[position]` for all rows with matching values at that position.
+
+### Initial Snapshot Query
+
+Compute both tags and `active_conditions` in SQL:
+
+```sql
+SELECT
+  -- Condition results for active_conditions (effective values)
+  (x IN (SELECT id FROM subquery1)) as cond_0,
+  (status = 'active') as cond_1,
+  (y IN (SELECT id FROM subquery2)) as cond_2,
+  -- Tags (hashed values per disjunct)
+  ARRAY[
+    md5('...' || x_value) || '/' || md5('...' || status),
+    md5('...' || y_value)
+  ] as tags,
+  -- Row data
+  id, title, ...
+FROM tasks
+WHERE (x IN (SELECT ...) AND status = 'active')
+   OR (y IN (SELECT ...))
+```
+
+For negated positions, the SQL wraps the condition in `NOT` to produce the effective value. For example, `WHERE x NOT IN (SELECT ...)` decomposes into a single position with `negated: true` and an un-negated AST of `x IN (SELECT ...)`. The snapshot query generates `(NOT (x IN (SELECT ...))) as cond_0` so the result matches what the client expects.
+
+PostgreSQL's optimizer deduplicates identical subexpressions between SELECT and WHERE.
+
+### Move-in Query
+
+When value 'a' moves into subquery at position 0:
+
+1. **Broadcast activation** — Send `["move-in", {"position": 0, "values": ["hash(a)"]}]`
+
+2. **Query for new rows** — The WHERE clause is **reconstructed from the triggering disjunct's conditions only**, not derived from the original WHERE by string replacement. For `WHERE (x IN sq1 AND status = 'active') OR y IN sq2` with sq1 triggering at position 0:
+   ```sql
+   SELECT
+     (true) as cond_0,  -- we know x='a' matches
+     (status = 'active') as cond_1,
+     (y IN (SELECT ...)) as cond_2,
+     ...
+   FROM tasks
+   WHERE x = 'a' AND status = 'active'
+     AND NOT (y IN (SELECT ...))  -- exclude rows already sent via disjunct 2
+   ```
+
+   The base WHERE (`x = 'a' AND status = 'active'`) comes from the triggering disjunct (positions 0 and 1), with the triggering subquery replaced by `= 'a'`. The `AND NOT (other_disjuncts)` exclusion clause prevents fetching rows already in the shape via another disjunct. This approach avoids over-fetching rows that match via non-triggering disjuncts and makes the exclusion clauses meaningful — using the full original WHERE would redundantly include all disjuncts via OR.
+
+### Snapshot Positioning
+
+Move-in queries run ahead of the replication stream. We reuse the existing snapshot-based positioning mechanism:
+
+1. **REPEATABLE READ transaction** — Query runs in `REPEATABLE READ READ ONLY` isolation
+2. **Capture pg_snapshot** — `SELECT pg_current_snapshot()` returns `(xmin, xmax, xip_list)`
+3. **Stream filtering** — Skip replication stream changes already visible in query snapshot
+4. **Touch tracking** — Track keys modified in stream to skip stale query results
+5. **Correct ordering** — Query results spliced into shape log at correct position
+
+This ensures query results appear at the right point in the stream without shadowing concurrent changes. See `Electric.Shapes.Consumer.MoveIns` for implementation details.
+
+### Move-out Handling
+
+When value 'a' moves out of subquery at position 0:
+
+1. **Broadcast deactivation** — Send `["move-out", {"position": 0, "values": ["hash(a)"]}]`
+
+2. **Client evaluates** — For each row with `hash(a)` at position 0:
+   - Set `active_conditions[0] = false`
+   - Re-evaluate all tags
+   - If no tag evaluates to true, delete the row
+
+No server query needed — clients have all information to determine if row should be removed.
+
+### Race Condition Handling
+
+#### Replication stream ordering and dependency layers
+
+The replication stream delivers one transaction at a time as a sequence of operations
+(`begin op op op end begin op op end ...`). The `ShapeLogCollector` publishes each
+transaction to consumers via `ConsumerRegistry.publish`, which is a synchronous
+broadcast — it sends the event to every consumer in the layer and waits for all of them
+to return before moving on.
+
+Crucially, `DependencyLayers` organises shapes into layers based on their dependency
+relationships. Inner (subquery) shapes are in earlier layers; outer shapes are in later
+layers. The `ShapeLogCollector` publishes to layers in order (line 550 of
+`shape_log_collector.ex`):
+
+```elixir
+for layer <- DependencyLayers.get_for_handles(state.dependency_layers, affected_shapes) do
+  # Each publish is synchronous, so layers will be processed in order
+  ConsumerRegistry.publish(layer_events, state.registry_state)
+end
+```
+
+This means that for any transaction T:
+1. The inner shape's `handle_event` runs first and returns
+2. If T caused move-ins/outs, the inner shape sends `materializer_changes` to the outer
+   consumer (a regular `send`, so it lands in the outer consumer's mailbox)
+3. Only then does the outer shape's `handle_event` run (as a `handle_call`)
+
+Since GenServer processes messages in mailbox order, and the `materializer_changes`
+message was sent *before* the `handle_event` call message, the outer consumer always
+processes `materializer_changes` before `handle_event` for the same transaction.
+
+#### Why the touch_tracker race is benign
+
+The `touch_tracker` prevents move-in query results from overwriting fresher data in the
+stream. It records `{key → xid}` during `handle_event` and skips query result rows where
+the touch xid is *not* visible in the query's snapshot (meaning the stream has newer data).
+
+At first glance, there appears to be a race: `materializer_changes` starts an async
+move-in query, and `query_complete` could fire before the touch_tracker is populated by a
+later `handle_event`. But this race is benign because of how transaction ordering works:
+
+1. **Previous transactions are already processed.** The replication stream delivers
+   transactions in commit order, one at a time. By the time a move-in query starts, every
+   previously delivered transaction has been fully processed via `handle_event`, so their
+   touch_tracker entries are present. Since those transactions committed before the query
+   started, they are always visible in the query's snapshot — the touch_tracker says
+   "visible → don't skip", which is correct.
+
+2. **The triggering transaction is always in the query's snapshot.** The move-in query
+   starts *after* the triggering transaction committed (the subquery consumer had to
+   process it first). So the query snapshot includes the triggering transaction's changes.
+   Any touch_tracker entries from the triggering transaction would say "visible → don't
+   skip" — the same result as having no entry at all.
+
+3. **Future transactions may or may not be in the query's snapshot.** If a future
+   transaction T_next commits and is processed via `handle_event` while the query is in
+   flight, two cases arise:
+   - **`handle_event` runs before `query_complete`:** Touch_tracker has T_next's entries.
+     If T_next's xid is not visible in the query snapshot, stale rows are correctly
+     skipped.
+   - **`query_complete` runs before `handle_event`:** Touch_tracker is missing T_next's
+     entries. But if T_next committed after the query's snapshot, the query doesn't have
+     T_next's changes either — the query results reflect the pre-T_next state, which is
+     correct for the consumer's current stream position. If T_next committed before the
+     snapshot, the query has T_next's version (same as what the stream will deliver), so
+     including it produces at worst a same-version duplicate.
+
+4. **Subquery-only transactions don't need touch_tracker entries.** When a transaction
+   only modifies the subquery table, the outer consumer receives `materializer_changes`
+   but no `handle_event` (no changes to the outer table). This is correct — there are no
+   stream changes to deduplicate against, so the touch_tracker is correctly empty.
+
+In all cases, the worst outcome of the race is a harmless same-version duplicate in the
+log, never stale data overwriting fresher data. No buffering or message reordering is
+needed.
+
+#### moved_out_tags: filtering stale move-in results
+
+Async move-in queries can return stale data because the world changes while the query
+runs. Main handles this with `moved_out_tags`: when a move-out arrives while a move-in
+query is in flight, the hash is recorded. When the query results are written, rows
+matching the hash are skipped, preventing stale rows from entering the log.
+
+For multi-disjunct shapes, `moved_out_tags` must be **position-aware**. Main tracks
+bare hashes, but for `x IN sq1 OR x IN sq2`, both positions produce the same `hash(a)`
+for value `a`. If `a` exits sq1, position-unaware filtering would incorrectly skip rows
+for sq2 (same hash, different position). Instead, track `{position, hash}` tuples and
+filter only at the **triggering position** — the position that caused the move-in query.
+
+This handles all race conditions:
+
+| Scenario | How it's handled |
+|----------|-----------------|
+| Value enters and exits subquery in same `materializer_changes` batch | `cancel_net_zero_events` in materializer — events cancel out |
+| Value enters in one batch, exits in a later batch (same txn) | `moved_out_tags` records hash during `process_move_outs`; stale rows filtered at `query_complete` |
+| Value enters in txn T, exits in txn T+1 while query running | Same — `moved_out_tags` records hash from T+1's move-out; T's query results filtered |
+| Same hash at different positions (`x IN sq1 OR x IN sq2`) | Position-aware filtering only checks the triggering position |
+| Partial exit from multi-value query ([A, B] queried, A exits) | Per-row filtering: row with A skipped, row with B kept |
+| `find_position_for_sublink` re-derivation picks wrong position (same subquery in both IN and NOT IN) | Pre-existing TODO, low practical risk — requires identical subquery text in both positive and negated form. Fix: thread already-known position through instead of re-deriving. |
+
+##### Dual tag format: snapshot files vs wire/API
+
+Snapshot file tags (used for `moved_out_tags` filtering) use a **different format** from the
+wire/API tags sent to clients:
+
+- **Wire format** (in JSON headers, sent to clients): slash-delimited strings per disjunct —
+  e.g. `"hash1/hash2/"`, `"//hash3"`. One string per disjunct, positions within a disjunct
+  separated by `/`. Unchanged from the design above. Clients use these for their own
+  tag-based inclusion tracking.
+- **Snapshot file format** (internal, used for filtering): flat list of per-position hashes —
+  one hash per DNF position, no delimiters. `Enum.at(tags, position)` directly yields the
+  hash for that position. These tags never leave the server.
+
+**Why the flat format is sufficient**: since `moved_out_tags` is now position-aware (tracking
+`{position, tags_to_skip}` instead of just `tags_to_skip`), filtering only needs to check
+the hash at a single position index. No string splitting or multi-position comparison is
+needed. The flat list is effectively a position-indexed array.
+
+**Worked example** — shape `WHERE x IN sq1 OR x IN sq2`, tag_structure `[[x], [x]]`:
+
+| Format | Positions | Row with x=a |
+|--------|-----------|--------------|
+| Wire (per-disjunct, slash-delimited) | disjunct 0: `[x]`, disjunct 1: `[x]` | `["hash(a)/", "/hash(a)"]` |
+| Snapshot (per-position, flat) | position 0: sq1, position 1: sq2 | `["hash(a)", "hash(a)"]` |
+
+When value `a` exits sq1, `moved_out_tags` records `{position: 0, tags: {"hash(a)"}}`.
+At filter time, `Enum.at(tags, 0)` = `"hash(a)"` → match → row skipped for sq1.
+But a different move-in query for sq2 would check `Enum.at(tags, 1)` — position 0's
+move-out doesn't affect position 1's filtering.
+
+Storage version is bumped (1 → 2 in `pure_file_storage.ex`) to invalidate old-format
+snapshots on upgrade. This is a server-internal change only — clients are unaffected.
+
+### Consistency Model for Shapes with Subqueries
+
+Shapes without subqueries provide transactional atomicity: changes from a single Postgres
+transaction are delivered together, bounded by up-to-date markers. The client sees a
+consistent snapshot after each up-to-date.
+
+**Shapes with subqueries relax this to eventual consistency.** Move-in queries are async
+Postgres round-trips that complete after the triggering transaction has been processed.
+Because the up-to-date decision (`determine_up_to_date` in `api.ex`) is based purely on
+log offsets and has no visibility into pending move-in queries, the client can receive an
+up-to-date marker before move-in results have been written to the log.
+
+Concretely, if a single Postgres transaction both modifies the subquery table (causing
+move-ins) and modifies the outer table, the client may see:
+
+1. Direct changes to the outer table (from `handle_event`)
+2. Up-to-date marker
+3. Move-in rows arriving later (from `query_complete`)
+4. Another up-to-date marker
+
+This is a pre-existing property of Electric's subquery support (not introduced by this
+RFC) and applies equally to single-subquery and multi-subquery shapes.
+
+**Shapes with subqueries also break causal consistency.** Consider:
+
+```sql
+INSERT INTO projects (id, is_visible) VALUES ('p1', true), ('p2', false);
+INSERT INTO issues (id, project_id, text) VALUES ('i1', 'p1', ''), ('i2', 'p2', '');
+```
+
+With shape `SELECT * FROM issues WHERE project_id IN (SELECT id FROM projects WHERE is_visible = true)`, and changes:
+
+```sql
+UPDATE projects SET is_visible = true WHERE id = 'p2';
+UPDATE issues SET text = 'new text' WHERE id = 'i2';
+UPDATE issues SET text = 'new text' WHERE id = 'i1';
+```
+
+The client may briefly see issue `i1` with `text = 'new text'` but not see issue `i2` at
+all, despite `i2` having been made eligible for the shape (via `p2.is_visible = true`)
+*before* its text was updated. The move-in query for `i2` is async, so the direct update
+to `i1` can arrive first.
+
+**Future work:** We plan to restore both causal and transactional consistency by delaying
+the up-to-date marker until all pending move-in queries have completed and any
+transactions spanning the replication stream have been fully merged. This is out of scope
+for this RFC.
+
+The key guarantee we **do** maintain: the client will never see rows it shouldn't. The
+`moved_out_tags` mechanism ensures that rows which moved out of the shape while a move-in
+query was in flight are filtered from the results. The touch_tracker ensures that stale
+versions of rows don't overwrite fresher data already in the stream. The system converges
+to the correct state — it just may take more than one up-to-date cycle to get there.
+
+### Replication Stream Updates
+
+When the outer shape receives an insert/update/delete from the replication stream:
+
+1. **Compute `active_conditions`** — For each position in the DNF, compute the **effective** condition value:
+   - **Subquery positions**: Check `MapSet.member?(materialized_values, row_value)` using the dependency shape's materializer
+   - **Field positions**: Evaluate the simple comparison against the row's data
+   - **Negated positions**: The decomposer stores the un-negated AST with `negated: true`. Apply `NOT` to the raw evaluation result so `active_conditions` stores the effective value. This way clients can use the values directly without needing polarity information.
+
+   This replaces the current `includes_record?` call — we compute per-position effective results rather than a single boolean.
+
+2. **Derive inclusion** — Evaluate the DNF using `active_conditions` (which already stores effective values with negation applied):
+   ```
+   included = OR over disjuncts, where each disjunct = AND over its positions
+   ```
+   Since `active_conditions` contains effective values, always check for `true` regardless of the position's polarity in the DNF. If not included, skip the row (don't emit to shape log).
+
+3. **Compute tags** — For each disjunct, extract column values at participating positions and hash them (same as current `fill_move_tags`, extended for multiple disjuncts).
+
+4. **Emit message** — Include `tags` and `active_conditions` in the row message:
+   ```json
+   {
+     "key": "...",
+     "value": {...},
+     "headers": {
+       "operation": "update",
+       "tags": ["hash1/hash2/", "//hash3"],
+       "active_conditions": [true, true, false],
+       "removed_tags": ["hash1/hash4/"]
+     }
+   }
+   ```
+
+This is a single pass — no separate `includes_record?` call followed by re-evaluation for `active_conditions`.
+
+For updates, if the row's tag-relevant columns changed, include `removed_tags` for the old values (as today).
+
+### Client Requirements
+
+Clients must:
+1. Store tags and `active_conditions` for each row
+2. Index rows by `(position, hash_value)` for efficient move-in/move-out handling
+3. Evaluate inclusion: OR over tags, where each tag (split on `/`) is AND over `active_conditions` at non-empty positions
+4. Delete rows when no tag evaluates to true after an `active_conditions` update
+
+Tag structure is self-describing — clients learn the DNF shape from the first row's tags.
+
+### Protocol Versioning
+
+Complex WHERE clauses (OR/NOT with subqueries) require protocol version 2. Clients on v1 receive an error for unsupported shapes.
+
+Simple single-subquery shapes continue working on v1.
+
+### `changes_only` Mode
+
+Works the same as today:
+- Tags and `active_conditions` included on all operations (insert, update, delete)
+- Clients build state incrementally
+- Move-in/move-out broadcasts for unknown rows are ignored
+
+### Complexity Check
+
+**Is this the simplest approach?**
+
+The tag-based approach is more complex than shape invalidation, but invalidation provides poor UX for volatile subqueries. This is the minimum complexity needed for correct move-in/move-out without full resync.
+
+**What could we cut?**
+
+- Batched move-in/out messages could be single-value (simpler but more messages)
+- Could skip NOT support initially (but De Morgan handling is already in the decomposer)
+
+**What's the 90/10 solution?**
+
+This RFC. The decomposer exists, the tag infrastructure exists, we're extending it to handle the full DNF case rather than single conditions.
+
+## Design Decisions
+
+Questions resolved during RFC development:
+
+| Question | Resolution |
+|----------|------------|
+| **Maximum disjuncts/positions** | Hard limit of 100 disjuncts. DNF expansion is exponential, so an unconstrained WHERE clause can easily produce thousands of disjuncts that would overwhelm per-row tag arrays and client-side evaluation. The limit is enforced at shape creation time (400 error with a descriptive message). |
+| **Tag storage format** | Slash-delimited strings (one per disjunct), with empty segments for non-participating positions. Matches current `Enum.join("/")` implementation. |
+| **Subquery result caching** | Use current approach: subqueries are their own shapes with materializers, multiple outer shapes can reference the same inner shape. |
+
+## Definition of Success
+
+### Primary Hypothesis
+
+> We believe that implementing DNF-based tagging with `active_conditions` will enable shapes with arbitrary boolean WHERE clauses without requiring 409s or shape invalidation.
+>
+> We'll know we're right if shapes with OR/NOT subqueries handle move-ins without triggering client resync.
+>
+> We'll know we're wrong if the complexity causes correctness bugs or unacceptable performance overhead.
+
+### Functional Requirements
+
+| Requirement | Acceptance Criteria |
+|-------------|---------------------|
+| OR with subqueries | `WHERE x IN sq1 OR y IN sq2` handles move-in/out correctly |
+| NOT with subqueries | `WHERE x NOT IN sq1` handles move-in/out correctly |
+| Mixed conditions | `WHERE (x IN sq1 AND status='active') OR y IN sq2` works |
+| Nested NOT | `WHERE NOT (x IN sq1 AND y IN sq2)` decomposes correctly |
+| Move-in efficiency | No Postgres query when row already present for another disjunct |
+| Move-out correctness | Row removed only when no disjunct evaluates to true |
+| Protocol compatibility | V1 clients get error for unsupported shapes |
+
+### Learning Goals
+
+1. What's the performance impact of computing `active_conditions` in snapshot queries?
+2. How well does PostgreSQL deduplicate subquery execution between SELECT and WHERE?
+3. What's the typical tag/`active_conditions` storage overhead per row?
+
+## Alternatives Considered
+
+### Alternative 1: Shape Invalidation on OR/NOT
+
+**Description:** Continue returning 409 and forcing full resync when subquery conditions change in OR/NOT shapes.
+
+**Why not:** Poor UX for volatile subqueries. Users report frustration with constant resyncs.
+
+### Alternative 2: Server-side Row Tracking
+
+**Description:** Server maintains `{condition_values → row_keys}` index to send targeted updates instead of broadcasts.
+
+**Why not:**
+- Significant server memory/disk overhead
+- Doesn't scale with large shapes
+- Requires persistence and recovery mechanisms
+
+### Alternative 3: Client-side WHERE Evaluation
+
+**Description:** Send WHERE clause AST to client, client evaluates conditions locally.
+
+**Why not:**
+- Clients need to implement PostgreSQL function subset
+- Exposes potentially sensitive constants in WHERE clause
+- Complex client implementation across all platforms
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01-27 | rob | Initial version |
+| 1.1 | 2026-02-10 | rob | Add dual tag format (snapshot vs wire), `find_position_for_sublink` limitation |
+| 1.2 | 2026-02-16 | rob | Document causal consistency breakage and future work |
+
+---
+
+## RFC Quality Checklist
+
+Before submitting for review, verify:
+
+**Alignment**
+- [x] RFC extends existing subquery infrastructure consistently
+- [x] Message format extends existing tags field
+- [x] Success criteria are testable
+
+**Calibration for Level 1-2 PMF**
+- [x] This is the simplest approach that enables the feature
+- [x] Non-goals explicitly defer optimizations
+- [x] Complexity Check section filled out
+- [x] An engineer could start implementing tomorrow
+
+**Completeness**
+- [x] Happy path is clear (DNF decomposition → tags → active_conditions → broadcast)
+- [x] Critical failure modes addressed (protocol versioning, client evaluation)
+- [x] Design decisions documented

--- a/packages/elixir-client/lib/electric/client/message.ex
+++ b/packages/elixir-client/lib/electric/client/message.ex
@@ -13,7 +13,8 @@ defmodule Electric.Client.Message do
       txids: [],
       op_position: 0,
       tags: [],
-      removed_tags: []
+      removed_tags: [],
+      active_conditions: []
     ]
 
     @type operation :: :insert | :update | :delete
@@ -29,7 +30,8 @@ defmodule Electric.Client.Message do
             txids: txids(),
             op_position: non_neg_integer(),
             tags: [tag()],
-            removed_tags: [tag()]
+            removed_tags: [tag()],
+            active_conditions: [boolean()]
           }
 
     @doc false
@@ -44,7 +46,8 @@ defmodule Electric.Client.Message do
         lsn: Map.get(msg, "lsn", nil),
         op_position: Map.get(msg, "op_position", 0),
         tags: Map.get(msg, "tags", []),
-        removed_tags: Map.get(msg, "removed_tags", [])
+        removed_tags: Map.get(msg, "removed_tags", []),
+        active_conditions: Map.get(msg, "active_conditions", [])
       }
     end
 
@@ -193,8 +196,8 @@ defmodule Electric.Client.Message do
             shape_handle: Client.shape_handle(),
             offset: Offset.t(),
             schema: Client.schema(),
-            tag_to_keys: %{String.t() => MapSet.t(String.t())},
-            key_data: %{String.t() => %{tags: MapSet.t(String.t()), msg: ChangeMessage.t()}}
+            tag_to_keys: %{optional(term()) => MapSet.t(String.t())},
+            key_data: %{optional(String.t()) => map()}
           }
   end
 

--- a/packages/elixir-client/lib/electric/client/message.ex
+++ b/packages/elixir-client/lib/electric/client/message.ex
@@ -190,14 +190,15 @@ defmodule Electric.Client.Message do
 
     @enforce_keys [:shape_handle, :offset, :schema]
 
-    defstruct [:shape_handle, :offset, :schema, tag_to_keys: %{}, key_data: %{}]
+    defstruct [:shape_handle, :offset, :schema, tag_to_keys: %{}, key_data: %{}, disjunct_positions: nil]
 
     @type t :: %__MODULE__{
             shape_handle: Client.shape_handle(),
             offset: Offset.t(),
             schema: Client.schema(),
             tag_to_keys: %{optional(term()) => MapSet.t(String.t())},
-            key_data: %{optional(String.t()) => map()}
+            key_data: %{optional(String.t()) => map()},
+            disjunct_positions: [[non_neg_integer()]] | nil
           }
   end
 

--- a/packages/elixir-client/lib/electric/client/poll.ex
+++ b/packages/elixir-client/lib/electric/client/poll.ex
@@ -235,10 +235,11 @@ defmodule Electric.Client.Poll do
   end
 
   defp handle_message(%Message.ChangeMessage{} = msg, state) do
-    {tag_to_keys, key_data} =
-      TagTracker.update_tag_index(state.tag_to_keys, state.key_data, msg)
+    {tag_to_keys, key_data, disjunct_positions} =
+      TagTracker.update_tag_index(state.tag_to_keys, state.key_data, state.disjunct_positions, msg)
 
-    {:message, msg, %{state | tag_to_keys: tag_to_keys, key_data: key_data}}
+    {:message, msg,
+     %{state | tag_to_keys: tag_to_keys, key_data: key_data, disjunct_positions: disjunct_positions}}
   end
 
   defp handle_message(
@@ -249,6 +250,7 @@ defmodule Electric.Client.Poll do
       TagTracker.generate_synthetic_deletes(
         state.tag_to_keys,
         state.key_data,
+        state.disjunct_positions,
         patterns,
         request_timestamp
       )

--- a/packages/elixir-client/lib/electric/client/shape_state.ex
+++ b/packages/elixir-client/lib/electric/client/shape_state.ex
@@ -34,6 +34,7 @@ defmodule Electric.Client.ShapeState do
     up_to_date?: false,
     tag_to_keys: %{},
     key_data: %{},
+    disjunct_positions: nil,
     stale_cache_retry_count: 0
   ]
 
@@ -46,6 +47,7 @@ defmodule Electric.Client.ShapeState do
           up_to_date?: boolean(),
           tag_to_keys: %{optional(term()) => MapSet.t()},
           key_data: %{optional(term()) => %{tags: MapSet.t(), msg: term()}},
+          disjunct_positions: [[non_neg_integer()]] | nil,
           stale_cache_buster: String.t() | nil,
           stale_cache_retry_count: non_neg_integer()
         }
@@ -80,7 +82,8 @@ defmodule Electric.Client.ShapeState do
       schema: resume.schema,
       up_to_date?: true,
       tag_to_keys: Map.get(resume, :tag_to_keys, %{}),
-      key_data: Map.get(resume, :key_data, %{})
+      key_data: Map.get(resume, :key_data, %{}),
+      disjunct_positions: Map.get(resume, :disjunct_positions)
     }
   end
 
@@ -99,7 +102,8 @@ defmodule Electric.Client.ShapeState do
         up_to_date?: false,
         next_cursor: nil,
         tag_to_keys: %{},
-        key_data: %{}
+        key_data: %{},
+        disjunct_positions: nil
     }
   end
 
@@ -113,7 +117,8 @@ defmodule Electric.Client.ShapeState do
       offset: state.offset,
       schema: state.schema,
       tag_to_keys: state.tag_to_keys,
-      key_data: state.key_data
+      key_data: state.key_data,
+      disjunct_positions: state.disjunct_positions
     }
   end
 

--- a/packages/elixir-client/lib/electric/client/tag_tracker.ex
+++ b/packages/elixir-client/lib/electric/client/tag_tracker.ex
@@ -156,12 +156,12 @@ defmodule Electric.Client.TagTracker do
       end)
 
     # Second pass: for each matched key, update state and check visibility
-    {keys_to_delete, updated_key_data} =
-      Enum.reduce(matched_keys_with_entries, {[], key_data}, fn {key, removed_entries},
-                                                                {deletes, kd_acc} ->
+    {keys_to_delete, updated_key_data, orphaned_entries} =
+      Enum.reduce(matched_keys_with_entries, {[], key_data, []}, fn {key, removed_entries},
+                                                                    {deletes, kd_acc, orphans} ->
         case Map.get(kd_acc, key) do
           nil ->
-            {deletes, kd_acc}
+            {deletes, kd_acc, orphans}
 
           %{tags: current_entries, msg: msg} = data ->
             remaining_entries = MapSet.difference(current_entries, removed_entries)
@@ -189,11 +189,21 @@ defmodule Electric.Client.TagTracker do
               end
 
             if should_delete do
-              {[{key, msg} | deletes], Map.delete(kd_acc, key)}
+              {[{key, msg} | deletes], Map.delete(kd_acc, key),
+               [{key, remaining_entries} | orphans]}
             else
-              {deletes, Map.put(kd_acc, key, updated_data)}
+              {deletes, Map.put(kd_acc, key, updated_data), orphans}
             end
         end
+      end)
+
+    # Third pass: clean up remaining entries from tag_to_keys for deleted keys.
+    # The first pass only removed matched entries via Map.pop; remaining entries
+    # for deleted keys would otherwise persist as stale references, causing
+    # phantom synthetic deletes when matching future deactivation patterns.
+    updated_tag_to_keys =
+      Enum.reduce(orphaned_entries, updated_tag_to_keys, fn {key, remaining}, ttk ->
+        remove_key_from_tags(ttk, remaining, key)
       end)
 
     # Generate synthetic delete messages

--- a/packages/elixir-client/lib/electric/client/tag_tracker.ex
+++ b/packages/elixir-client/lib/electric/client/tag_tracker.ex
@@ -8,10 +8,10 @@ defmodule Electric.Client.TagTracker do
 
   ## Data Structures
 
-  Two maps are maintained:
+  Three structures are maintained:
   - `tag_to_keys`: `%{{position, hash} => MapSet<key>}` - which keys have each position-hash pair
-  - `key_data`: `%{key => %{tags: MapSet<{pos, hash}>, active_conditions: [boolean()] | nil,
-    disjunct_positions: [[integer()]] | nil, msg: msg}}` - each key's current state
+  - `key_data`: `%{key => %{tags: MapSet<{pos, hash}>, active_conditions: [boolean()] | nil, msg: msg}}` - each key's current state
+  - `disjunct_positions`: `[[integer()]] | nil` - shared across all keys, derived once from the first tagged message
 
   Tags arrive as slash-delimited strings per disjunct (e.g., `"hash1/hash2/"`, `"//hash3"`).
   They are normalized into 2D arrays and indexed by `{position, hash_value}` tuples.
@@ -30,20 +30,23 @@ defmodule Electric.Client.TagTracker do
           optional(key()) => %{
             tags: MapSet.t(position_hash()),
             active_conditions: [boolean()] | nil,
-            disjunct_positions: [[non_neg_integer()]] | nil,
             msg: ChangeMessage.t()
           }
         }
+  @type disjunct_positions :: [[non_neg_integer()]] | nil
 
   @doc """
   Update the tag index when a change message is received.
 
   Tags are normalized from slash-delimited wire format to position-indexed entries.
-  Returns `{updated_tag_to_keys, updated_key_data}`.
+  `disjunct_positions` is derived once from the first tagged message and reused for all
+  subsequent messages, since it is determined by the shape's WHERE clause structure.
+
+  Returns `{updated_tag_to_keys, updated_key_data, disjunct_positions}`.
   """
-  @spec update_tag_index(tag_to_keys(), key_data(), ChangeMessage.t()) ::
-          {tag_to_keys(), key_data()}
-  def update_tag_index(tag_to_keys, key_data, %ChangeMessage{headers: headers, key: key} = msg) do
+  @spec update_tag_index(tag_to_keys(), key_data(), disjunct_positions(), ChangeMessage.t()) ::
+          {tag_to_keys(), key_data(), disjunct_positions()}
+  def update_tag_index(tag_to_keys, key_data, disjunct_positions, %ChangeMessage{headers: headers, key: key} = msg) do
     raw_new_tags = headers.tags || []
     raw_removed_tags = headers.removed_tags || []
 
@@ -72,11 +75,17 @@ defmodule Electric.Client.TagTracker do
       |> MapSet.difference(removed_entries)
       |> MapSet.union(new_entries)
 
-    # Derive disjunct positions from tags
+    # Derive disjunct positions once from the first tagged message
     disjunct_positions =
-      case derive_disjunct_positions(normalized_new) do
-        [] -> current_data && current_data.disjunct_positions
-        positions -> positions
+      case disjunct_positions do
+        nil ->
+          case derive_disjunct_positions(normalized_new) do
+            [] -> nil
+            positions -> positions
+          end
+
+        already_set ->
+          already_set
       end
 
     case headers.operation do
@@ -87,7 +96,7 @@ defmodule Electric.Client.TagTracker do
             remove_key_from_tag(acc, entry, key)
           end)
 
-        {updated_tag_to_keys, Map.delete(key_data, key)}
+        {updated_tag_to_keys, Map.delete(key_data, key), disjunct_positions}
 
       _ ->
         if MapSet.size(updated_entries) == 0 do
@@ -97,7 +106,7 @@ defmodule Electric.Client.TagTracker do
               remove_key_from_tag(acc, entry, key)
             end)
 
-          {updated_tag_to_keys, Map.delete(key_data, key)}
+          {updated_tag_to_keys, Map.delete(key_data, key), disjunct_positions}
         else
           # Update tag_to_keys: remove old entries, add new entries
           entries_to_remove = MapSet.difference(current_entries, updated_entries)
@@ -112,11 +121,10 @@ defmodule Electric.Client.TagTracker do
             Map.put(key_data, key, %{
               tags: updated_entries,
               active_conditions: active_conditions,
-              disjunct_positions: disjunct_positions,
               msg: msg
             })
 
-          {updated_tag_to_keys, updated_key_data}
+          {updated_tag_to_keys, updated_key_data, disjunct_positions}
         end
     end
   end
@@ -126,14 +134,14 @@ defmodule Electric.Client.TagTracker do
 
   Patterns contain `%{pos: position, value: hash}` maps. For keys with
   `active_conditions`, positions are deactivated and visibility is re-evaluated
-  using DNF. For keys without `active_conditions`, the old behavior applies:
-  delete when no entries remain.
+  using DNF with the shared `disjunct_positions`. For keys without
+  `active_conditions`, the old behavior applies: delete when no entries remain.
 
   Returns `{synthetic_deletes, updated_tag_to_keys, updated_key_data}`.
   """
-  @spec generate_synthetic_deletes(tag_to_keys(), key_data(), [map()], DateTime.t()) ::
+  @spec generate_synthetic_deletes(tag_to_keys(), key_data(), disjunct_positions(), [map()], DateTime.t()) ::
           {[ChangeMessage.t()], tag_to_keys(), key_data()}
-  def generate_synthetic_deletes(tag_to_keys, key_data, patterns, request_timestamp) do
+  def generate_synthetic_deletes(tag_to_keys, key_data, disjunct_positions, patterns, request_timestamp) do
     # First pass: collect all keys that match any pattern and remove those entries
     {matched_keys_with_entries, updated_tag_to_keys} =
       Enum.reduce(patterns, {%{}, tag_to_keys}, fn %{pos: pos, value: value},
@@ -168,7 +176,7 @@ defmodule Electric.Client.TagTracker do
 
             # Determine if key should be deleted
             {should_delete, updated_data} =
-              if data.active_conditions != nil and data.disjunct_positions != nil do
+              if data.active_conditions != nil and disjunct_positions != nil do
                 # DNF mode: deactivate positions and check visibility
                 deactivated_positions =
                   MapSet.new(removed_entries, fn {pos, _} -> pos end)
@@ -180,7 +188,7 @@ defmodule Electric.Client.TagTracker do
                     if MapSet.member?(deactivated_positions, idx), do: false, else: val
                   end)
 
-                visible = row_visible?(updated_ac, data.disjunct_positions)
+                visible = row_visible?(updated_ac, disjunct_positions)
 
                 {not visible, %{data | tags: remaining_entries, active_conditions: updated_ac}}
               else

--- a/packages/elixir-client/test/electric/client/tag_tracker_test.exs
+++ b/packages/elixir-client/test/electric/client/tag_tracker_test.exs
@@ -8,6 +8,7 @@ defmodule Electric.Client.TagTrackerTest do
   defp make_change_msg(key, operation, opts) do
     tags = Keyword.get(opts, :tags, [])
     removed_tags = Keyword.get(opts, :removed_tags, [])
+    active_conditions = Keyword.get(opts, :active_conditions, [])
     value = Keyword.get(opts, :value, %{"id" => key})
 
     %ChangeMessage{
@@ -19,7 +20,8 @@ defmodule Electric.Client.TagTrackerTest do
         relation: ["public", "test"],
         handle: "test-handle",
         tags: tags,
-        removed_tags: removed_tags
+        removed_tags: removed_tags,
+        active_conditions: active_conditions
       },
       request_timestamp: DateTime.utc_now()
     }
@@ -32,12 +34,12 @@ defmodule Electric.Client.TagTrackerTest do
       {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg)
 
       assert tag_to_keys == %{
-               "tag_a" => MapSet.new(["key1"]),
-               "tag_b" => MapSet.new(["key1"])
+               {0, "tag_a"} => MapSet.new(["key1"]),
+               {0, "tag_b"} => MapSet.new(["key1"])
              }
 
       assert Map.has_key?(key_data, "key1")
-      assert key_data["key1"].tags == MapSet.new(["tag_a", "tag_b"])
+      assert key_data["key1"].tags == MapSet.new([{0, "tag_a"}, {0, "tag_b"}])
     end
 
     test "updates tags for updates" do
@@ -50,11 +52,11 @@ defmodule Electric.Client.TagTrackerTest do
       {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
 
       assert tag_to_keys == %{
-               "tag_a" => MapSet.new(["key1"]),
-               "tag_b" => MapSet.new(["key1"])
+               {0, "tag_a"} => MapSet.new(["key1"]),
+               {0, "tag_b"} => MapSet.new(["key1"])
              }
 
-      assert key_data["key1"].tags == MapSet.new(["tag_a", "tag_b"])
+      assert key_data["key1"].tags == MapSet.new([{0, "tag_a"}, {0, "tag_b"}])
     end
 
     test "removes tags when removed_tags specified" do
@@ -67,10 +69,10 @@ defmodule Electric.Client.TagTrackerTest do
       {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
 
       assert tag_to_keys == %{
-               "tag_b" => MapSet.new(["key1"])
+               {0, "tag_b"} => MapSet.new(["key1"])
              }
 
-      assert key_data["key1"].tags == MapSet.new(["tag_b"])
+      assert key_data["key1"].tags == MapSet.new([{0, "tag_b"}])
     end
 
     test "removes key from tracking on delete" do
@@ -100,7 +102,7 @@ defmodule Electric.Client.TagTrackerTest do
       {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
 
       assert tag_to_keys == %{
-               "shared_tag" => MapSet.new(["key1", "key2"])
+               {0, "shared_tag"} => MapSet.new(["key1", "key2"])
              }
 
       assert Map.has_key?(key_data, "key1")
@@ -155,10 +157,10 @@ defmodule Electric.Client.TagTrackerTest do
 
       # tag_a removed, tag_b remains
       assert new_tag_to_keys == %{
-               "tag_b" => MapSet.new(["key1"])
+               {0, "tag_b"} => MapSet.new(["key1"])
              }
 
-      assert new_key_data["key1"].tags == MapSet.new(["tag_b"])
+      assert new_key_data["key1"].tags == MapSet.new([{0, "tag_b"}])
     end
 
     test "handles non-existent tag pattern" do
@@ -192,6 +194,167 @@ defmodule Electric.Client.TagTrackerTest do
       assert length(deletes) == 2
       assert new_tag_to_keys == %{}
       assert new_key_data == %{}
+    end
+  end
+
+  describe "normalize_tags/1" do
+    test "normalizes slash-delimited tags to 2D structure" do
+      assert TagTracker.normalize_tags(["hash1/hash2/", "//hash3"]) ==
+               [["hash1", "hash2", nil], [nil, nil, "hash3"]]
+
+      assert TagTracker.normalize_tags(["tag_a"]) == [["tag_a"]]
+      assert TagTracker.normalize_tags([]) == []
+    end
+
+    test "single-position tags normalize to single-element lists" do
+      assert TagTracker.normalize_tags(["hash_a", "hash_b"]) ==
+               [["hash_a"], ["hash_b"]]
+    end
+
+    test "multi-position tags with mixed nils" do
+      assert TagTracker.normalize_tags(["hash_a/", "/hash_b"]) ==
+               [["hash_a", nil], [nil, "hash_b"]]
+    end
+  end
+
+  describe "tag_tracker with DNF wire format" do
+    test "removed_tags in slash-delimited format are correctly filtered" do
+      msg1 =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/hash_b"],
+          active_conditions: [true, true]
+        )
+
+      {ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg1)
+
+      assert ttk == %{
+               {0, "hash_a"} => MapSet.new(["key1"]),
+               {1, "hash_b"} => MapSet.new(["key1"])
+             }
+
+      # Remove hash_a via slash-delimited removed_tags, add new hash at pos 0
+      msg2 =
+        make_change_msg("key1", :update,
+          tags: ["hash_c/hash_b"],
+          removed_tags: ["hash_a/"],
+          active_conditions: [true, true]
+        )
+
+      {ttk, _kd} = TagTracker.update_tag_index(ttk, kd, msg2)
+
+      assert ttk == %{
+               {0, "hash_c"} => MapSet.new(["key1"]),
+               {1, "hash_b"} => MapSet.new(["key1"])
+             }
+    end
+
+    test "row_visible? evaluates DNF correctly" do
+      # Disjunct 0 needs positions [0, 1], disjunct 1 needs positions [2]
+      disjunct_positions = [[0, 1], [2]]
+
+      # All active
+      assert TagTracker.row_visible?([true, true, true], disjunct_positions)
+
+      # Only disjunct 0 satisfied
+      assert TagTracker.row_visible?([true, true, false], disjunct_positions)
+
+      # Only disjunct 1 satisfied
+      assert TagTracker.row_visible?([false, false, true], disjunct_positions)
+
+      # No disjunct satisfied (pos 0 false means disjunct 0 fails, pos 2 false means disjunct 1 fails)
+      refute TagTracker.row_visible?([false, true, false], disjunct_positions)
+      refute TagTracker.row_visible?([false, false, false], disjunct_positions)
+    end
+
+    test "generate_synthetic_deletes only deletes when all disjuncts unsatisfied" do
+      # Key1 has two disjuncts: disjunct 0 uses pos 0, disjunct 1 uses pos 1
+      msg =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/", "/hash_b"],
+          active_conditions: [true, true]
+        )
+
+      {ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+
+      # Move-out at position 0 - disjunct 1 still satisfied
+      patterns = [%{pos: 0, value: "hash_a"}]
+      timestamp = DateTime.utc_now()
+
+      {deletes, ttk, kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, timestamp)
+
+      # Still visible via disjunct 1
+      assert deletes == []
+      assert kd["key1"].active_conditions == [false, true]
+
+      # Move-out at position 1 - no disjunct satisfied
+      patterns = [%{pos: 1, value: "hash_b"}]
+
+      {deletes, _ttk, _kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, timestamp)
+
+      assert length(deletes) == 1
+      assert hd(deletes).key == "key1"
+    end
+
+    test "handle_move_in activates correct positions" do
+      msg =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/", "/hash_b"],
+          active_conditions: [true, false]
+        )
+
+      {ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+
+      # Position 1 is inactive
+      refute Enum.at(kd["key1"].active_conditions, 1)
+
+      # Move-in activates position 1
+      patterns = [%{pos: 1, value: "hash_b"}]
+      {_ttk, kd} = TagTracker.handle_move_in(ttk, kd, patterns)
+
+      assert kd["key1"].active_conditions == [true, true]
+    end
+
+    test "position-based tag_to_keys index for multi-disjunct shapes" do
+      msg =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/hash_b", "hash_c/hash_d"],
+          active_conditions: [true, true]
+        )
+
+      {ttk, _kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+
+      assert Map.has_key?(ttk, {0, "hash_a"})
+      assert Map.has_key?(ttk, {1, "hash_b"})
+      assert Map.has_key?(ttk, {0, "hash_c"})
+      assert Map.has_key?(ttk, {1, "hash_d"})
+    end
+
+    test "active_conditions stored from headers" do
+      msg =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/hash_b"],
+          active_conditions: [true, false]
+        )
+
+      {_ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+
+      assert kd["key1"].active_conditions == [true, false]
+      assert kd["key1"].disjunct_positions == [[0, 1]]
+    end
+
+    test "disjunct structure derived correctly from slash-delimited tags" do
+      msg =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/", "/hash_b"],
+          active_conditions: [true, true]
+        )
+
+      {_ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+
+      # Disjunct 0 uses position 0, disjunct 1 uses position 1
+      assert kd["key1"].disjunct_positions == [[0], [1]]
     end
   end
 end

--- a/packages/elixir-client/test/electric/client/tag_tracker_test.exs
+++ b/packages/elixir-client/test/electric/client/tag_tracker_test.exs
@@ -413,6 +413,139 @@ defmodule Electric.Client.TagTrackerTest do
       assert dp == [[0], [1]]
     end
 
+    test "multi-disjunct: row stays when one disjunct lost, deleted when all lost" do
+      # Tags: ["hash_a/hash_b/", "//hash_c"]
+      # Disjunct 0 covers positions [0, 1], disjunct 1 covers position [2]
+      msg =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/hash_b/", "//hash_c"],
+          active_conditions: [true, true, true],
+          value: %{"id" => "1", "name" => "User 1"}
+        )
+
+      {ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
+      assert dp == [[0, 1], [2]]
+
+      # Move-out at position 0 → disjunct 0 fails (needs [0,1]), disjunct 1 (pos 2) still satisfied
+      patterns = [%{pos: 0, value: "hash_a"}]
+      timestamp = DateTime.utc_now()
+
+      {deletes, ttk, kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, timestamp)
+
+      assert deletes == []
+      assert kd["key1"].active_conditions == [false, true, true]
+
+      # Move-out at position 2 → disjunct 1 also fails, no disjunct satisfied
+      patterns = [%{pos: 2, value: "hash_c"}]
+
+      {deletes, _ttk, _kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, timestamp)
+
+      assert length(deletes) == 1
+      assert hd(deletes).key == "key1"
+    end
+
+    test "overwrite active_conditions when row is re-sent (move-in overwrite)" do
+      # Insert row with active_conditions [true, false]
+      msg1 =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/hash_b"],
+          active_conditions: [true, false],
+          value: %{"id" => "1", "name" => "User 1"}
+        )
+
+      {ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
+      assert kd["key1"].active_conditions == [true, false]
+
+      # Server re-sends the same row with updated active_conditions
+      msg2 =
+        make_change_msg("key1", :update,
+          tags: ["hash_a/hash_b"],
+          active_conditions: [true, true],
+          value: %{"id" => "1", "name" => "User 1 updated"}
+        )
+
+      {ttk, kd, dp} = TagTracker.update_tag_index(ttk, kd, dp, msg2)
+      assert kd["key1"].active_conditions == [true, true]
+
+      # Verify the overwritten active_conditions work correctly:
+      # With single disjunct [0,1], move-out at pos 0 should make row invisible
+      patterns = [%{pos: 0, value: "hash_a"}]
+      timestamp = DateTime.utc_now()
+
+      {deletes, _ttk, _kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, timestamp)
+
+      assert length(deletes) == 1
+      assert hd(deletes).key == "key1"
+    end
+
+    test "delete on empty tag set for simple shapes (no active_conditions)" do
+      # Insert row with a single-position tag but NO active_conditions
+      msg =
+        make_change_msg("key1", :insert,
+          tags: ["hash1"],
+          value: %{"id" => "1", "name" => "User 1"}
+        )
+
+      {ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
+      assert kd["key1"].active_conditions == nil
+
+      # Move-out at position 0 — no active_conditions: tag removed, tag set empty → delete
+      patterns = [%{pos: 0, value: "hash1"}]
+      timestamp = DateTime.utc_now()
+
+      {deletes, new_ttk, new_kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, timestamp)
+
+      assert length(deletes) == 1
+      assert hd(deletes).key == "key1"
+      assert new_kd == %{}
+      assert new_ttk == %{}
+    end
+
+    test "mixed rows: some with active_conditions, some without" do
+      # Row 1: DNF shape (with active_conditions)
+      msg1 =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/", "/hash_b"],
+          active_conditions: [true, true],
+          value: %{"id" => "1", "name" => "DNF User"}
+        )
+
+      # Row 2: simple shape (single-position tag, no active_conditions)
+      msg2 =
+        make_change_msg("key2", :insert,
+          tags: ["hash_a"],
+          value: %{"id" => "2", "name" => "Simple User"}
+        )
+
+      {ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
+      {ttk, kd, dp} = TagTracker.update_tag_index(ttk, kd, dp, msg2)
+
+      assert Map.has_key?(kd, "key1")
+      assert Map.has_key?(kd, "key2")
+
+      # Move-out at position 0 with value hash_a
+      # DNF row: disjunct 0 ([0]) fails, but disjunct 1 ([1]) still satisfied → stays
+      # Simple row: tag "hash_a" at pos 0 removed, tag set empty → deleted
+      patterns = [%{pos: 0, value: "hash_a"}]
+      timestamp = DateTime.utc_now()
+
+      {deletes, _ttk, new_kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, timestamp)
+
+      # DNF row stays, simple row deleted
+      deleted_keys = Enum.map(deletes, & &1.key) |> MapSet.new()
+      assert MapSet.member?(deleted_keys, "key2")
+      refute MapSet.member?(deleted_keys, "key1")
+
+      assert Map.has_key?(new_kd, "key1")
+      assert new_kd["key1"].active_conditions == [false, true]
+      refute Map.has_key?(new_kd, "key2")
+    end
+
     test "disjunct_positions derived once and reused across keys" do
       msg1 =
         make_change_msg("key1", :insert,

--- a/packages/elixir-client/test/electric/client/tag_tracker_test.exs
+++ b/packages/elixir-client/test/electric/client/tag_tracker_test.exs
@@ -27,11 +27,11 @@ defmodule Electric.Client.TagTrackerTest do
     }
   end
 
-  describe "update_tag_index/3" do
+  describe "update_tag_index/4" do
     test "tracks new tags for inserts" do
       msg = make_change_msg("key1", :insert, tags: ["tag_a", "tag_b"])
 
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {tag_to_keys, key_data, _dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       assert tag_to_keys == %{
                {0, "tag_a"} => MapSet.new(["key1"]),
@@ -45,11 +45,11 @@ defmodule Electric.Client.TagTrackerTest do
     test "updates tags for updates" do
       # Initial insert with tag_a
       msg1 = make_change_msg("key1", :insert, tags: ["tag_a"])
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg1)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
 
       # Update adds tag_b
       msg2 = make_change_msg("key1", :update, tags: ["tag_b"])
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
+      {tag_to_keys, key_data, _dp} = TagTracker.update_tag_index(tag_to_keys, key_data, dp, msg2)
 
       assert tag_to_keys == %{
                {0, "tag_a"} => MapSet.new(["key1"]),
@@ -62,11 +62,11 @@ defmodule Electric.Client.TagTrackerTest do
     test "removes tags when removed_tags specified" do
       # Initial insert with tag_a and tag_b
       msg1 = make_change_msg("key1", :insert, tags: ["tag_a", "tag_b"])
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg1)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
 
       # Update removes tag_a
       msg2 = make_change_msg("key1", :update, removed_tags: ["tag_a"])
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
+      {tag_to_keys, key_data, _dp} = TagTracker.update_tag_index(tag_to_keys, key_data, dp, msg2)
 
       assert tag_to_keys == %{
                {0, "tag_b"} => MapSet.new(["key1"])
@@ -77,10 +77,10 @@ defmodule Electric.Client.TagTrackerTest do
 
     test "removes key from tracking on delete" do
       msg1 = make_change_msg("key1", :insert, tags: ["tag_a"])
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg1)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
 
       msg2 = make_change_msg("key1", :delete, tags: [])
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
+      {tag_to_keys, key_data, _dp} = TagTracker.update_tag_index(tag_to_keys, key_data, dp, msg2)
 
       assert tag_to_keys == %{}
       assert key_data == %{}
@@ -88,7 +88,7 @@ defmodule Electric.Client.TagTrackerTest do
 
     test "handles messages without tags" do
       msg = make_change_msg("key1", :insert, tags: [])
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {tag_to_keys, key_data, _dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       assert tag_to_keys == %{}
       assert key_data == %{}
@@ -98,8 +98,8 @@ defmodule Electric.Client.TagTrackerTest do
       msg1 = make_change_msg("key1", :insert, tags: ["shared_tag"])
       msg2 = make_change_msg("key2", :insert, tags: ["shared_tag"])
 
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg1)
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
+      {tag_to_keys, key_data, _dp} = TagTracker.update_tag_index(tag_to_keys, key_data, dp, msg2)
 
       assert tag_to_keys == %{
                {0, "shared_tag"} => MapSet.new(["key1", "key2"])
@@ -110,21 +110,21 @@ defmodule Electric.Client.TagTrackerTest do
     end
   end
 
-  describe "generate_synthetic_deletes/4" do
+  describe "generate_synthetic_deletes/5" do
     test "generates deletes for keys matching pattern" do
       # Set up: two keys with tag_a
       msg1 = make_change_msg("key1", :insert, tags: ["tag_a"], value: %{"id" => "1"})
       msg2 = make_change_msg("key2", :insert, tags: ["tag_a"], value: %{"id" => "2"})
 
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg1)
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(tag_to_keys, key_data, dp, msg2)
 
       # Move-out for tag_a
       patterns = [%{pos: 0, value: "tag_a"}]
       timestamp = DateTime.utc_now()
 
       {deletes, new_tag_to_keys, new_key_data} =
-        TagTracker.generate_synthetic_deletes(tag_to_keys, key_data, patterns, timestamp)
+        TagTracker.generate_synthetic_deletes(tag_to_keys, key_data, dp, patterns, timestamp)
 
       assert length(deletes) == 2
 
@@ -143,14 +143,14 @@ defmodule Electric.Client.TagTrackerTest do
     test "does not delete keys with remaining tags" do
       # Set up: key1 has tag_a and tag_b
       msg = make_change_msg("key1", :insert, tags: ["tag_a", "tag_b"], value: %{"id" => "1"})
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       # Move-out only for tag_a
       patterns = [%{pos: 0, value: "tag_a"}]
       timestamp = DateTime.utc_now()
 
       {deletes, new_tag_to_keys, new_key_data} =
-        TagTracker.generate_synthetic_deletes(tag_to_keys, key_data, patterns, timestamp)
+        TagTracker.generate_synthetic_deletes(tag_to_keys, key_data, dp, patterns, timestamp)
 
       # No synthetic deletes - key1 still has tag_b
       assert deletes == []
@@ -165,13 +165,13 @@ defmodule Electric.Client.TagTrackerTest do
 
     test "handles non-existent tag pattern" do
       msg = make_change_msg("key1", :insert, tags: ["tag_a"])
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       patterns = [%{pos: 0, value: "nonexistent_tag"}]
       timestamp = DateTime.utc_now()
 
       {deletes, new_tag_to_keys, new_key_data} =
-        TagTracker.generate_synthetic_deletes(tag_to_keys, key_data, patterns, timestamp)
+        TagTracker.generate_synthetic_deletes(tag_to_keys, key_data, dp, patterns, timestamp)
 
       assert deletes == []
       assert new_tag_to_keys == tag_to_keys
@@ -182,14 +182,14 @@ defmodule Electric.Client.TagTrackerTest do
       msg1 = make_change_msg("key1", :insert, tags: ["tag_a"])
       msg2 = make_change_msg("key2", :insert, tags: ["tag_b"])
 
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(%{}, %{}, msg1)
-      {tag_to_keys, key_data} = TagTracker.update_tag_index(tag_to_keys, key_data, msg2)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
+      {tag_to_keys, key_data, dp} = TagTracker.update_tag_index(tag_to_keys, key_data, dp, msg2)
 
       patterns = [%{pos: 0, value: "tag_a"}, %{pos: 0, value: "tag_b"}]
       timestamp = DateTime.utc_now()
 
       {deletes, new_tag_to_keys, new_key_data} =
-        TagTracker.generate_synthetic_deletes(tag_to_keys, key_data, patterns, timestamp)
+        TagTracker.generate_synthetic_deletes(tag_to_keys, key_data, dp, patterns, timestamp)
 
       assert length(deletes) == 2
       assert new_tag_to_keys == %{}
@@ -225,7 +225,7 @@ defmodule Electric.Client.TagTrackerTest do
           active_conditions: [true, true]
         )
 
-      {ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg1)
+      {ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
 
       assert ttk == %{
                {0, "hash_a"} => MapSet.new(["key1"]),
@@ -240,7 +240,7 @@ defmodule Electric.Client.TagTrackerTest do
           active_conditions: [true, true]
         )
 
-      {ttk, _kd} = TagTracker.update_tag_index(ttk, kd, msg2)
+      {ttk, _kd, _dp} = TagTracker.update_tag_index(ttk, kd, dp, msg2)
 
       assert ttk == %{
                {0, "hash_c"} => MapSet.new(["key1"]),
@@ -274,14 +274,14 @@ defmodule Electric.Client.TagTrackerTest do
           active_conditions: [true, true]
         )
 
-      {ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       # Move-out at position 0 - disjunct 1 still satisfied
       patterns = [%{pos: 0, value: "hash_a"}]
       timestamp = DateTime.utc_now()
 
       {deletes, ttk, kd} =
-        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, timestamp)
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, timestamp)
 
       # Still visible via disjunct 1
       assert deletes == []
@@ -291,7 +291,7 @@ defmodule Electric.Client.TagTrackerTest do
       patterns = [%{pos: 1, value: "hash_b"}]
 
       {deletes, _ttk, _kd} =
-        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, timestamp)
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, timestamp)
 
       assert length(deletes) == 1
       assert hd(deletes).key == "key1"
@@ -304,7 +304,7 @@ defmodule Electric.Client.TagTrackerTest do
           active_conditions: [true, false]
         )
 
-      {ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {ttk, kd, _dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       # Position 1 is inactive
       refute Enum.at(kd["key1"].active_conditions, 1)
@@ -323,7 +323,7 @@ defmodule Electric.Client.TagTrackerTest do
           active_conditions: [true, true]
         )
 
-      {ttk, _kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {ttk, _kd, _dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       assert Map.has_key?(ttk, {0, "hash_a"})
       assert Map.has_key?(ttk, {1, "hash_b"})
@@ -331,17 +331,17 @@ defmodule Electric.Client.TagTrackerTest do
       assert Map.has_key?(ttk, {1, "hash_d"})
     end
 
-    test "active_conditions stored from headers" do
+    test "active_conditions stored from headers and disjunct_positions derived once" do
       msg =
         make_change_msg("key1", :insert,
           tags: ["hash_a/hash_b"],
           active_conditions: [true, false]
         )
 
-      {_ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {_ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       assert kd["key1"].active_conditions == [true, false]
-      assert kd["key1"].disjunct_positions == [[0, 1]]
+      assert dp == [[0, 1]]
     end
 
     test "orphaned tag_to_keys entries after delete do not cause phantom deletes" do
@@ -353,14 +353,14 @@ defmodule Electric.Client.TagTrackerTest do
           active_conditions: [true, true, true, true]
         )
 
-      {ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       # Deactivate positions 1 and 3 (dep C moves out with hash "X")
       # Both disjuncts lose their C position → row invisible → deleted from key_data
       patterns = [%{pos: 1, value: "X"}, %{pos: 3, value: "X"}]
 
       {deletes, ttk, kd} =
-        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, DateTime.utc_now())
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, DateTime.utc_now())
 
       assert length(deletes) == 1
       assert hd(deletes).key == "r"
@@ -376,14 +376,14 @@ defmodule Electric.Client.TagTrackerTest do
           active_conditions: [true, true, true, true]
         )
 
-      {ttk, kd} = TagTracker.update_tag_index(ttk, kd, msg)
+      {ttk, kd, dp} = TagTracker.update_tag_index(ttk, kd, dp, msg)
 
       # Deactivate position 0 with STALE hash "X" — should have NO effect
       # since the row's current hash at pos 0 is "Y", not "X"
       patterns = [%{pos: 0, value: "X"}]
 
       {deletes, ttk, kd} =
-        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, DateTime.utc_now())
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, DateTime.utc_now())
 
       assert deletes == []
       # Without fix: active_conditions would be corrupted to [false, true, true, true]
@@ -393,7 +393,7 @@ defmodule Electric.Client.TagTrackerTest do
       patterns = [%{pos: 2, value: "Y"}]
 
       {deletes, _ttk, _kd} =
-        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, DateTime.utc_now())
+        TagTracker.generate_synthetic_deletes(ttk, kd, dp, patterns, DateTime.utc_now())
 
       # Disjunct 0 ([0,1]) is still fully active → row should remain visible
       # Without fix: the corrupted pos 0 causes both disjuncts to fail → phantom delete
@@ -407,10 +407,33 @@ defmodule Electric.Client.TagTrackerTest do
           active_conditions: [true, true]
         )
 
-      {_ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+      {_ttk, _kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg)
 
       # Disjunct 0 uses position 0, disjunct 1 uses position 1
-      assert kd["key1"].disjunct_positions == [[0], [1]]
+      assert dp == [[0], [1]]
+    end
+
+    test "disjunct_positions derived once and reused across keys" do
+      msg1 =
+        make_change_msg("key1", :insert,
+          tags: ["hash_a/", "/hash_b"],
+          active_conditions: [true, true]
+        )
+
+      {ttk, kd, dp} = TagTracker.update_tag_index(%{}, %{}, nil, msg1)
+      assert dp == [[0], [1]]
+
+      # Second key with different hashes but same structure
+      msg2 =
+        make_change_msg("key2", :insert,
+          tags: ["hash_c/", "/hash_d"],
+          active_conditions: [true, false]
+        )
+
+      {_ttk, _kd, dp2} = TagTracker.update_tag_index(ttk, kd, dp, msg2)
+
+      # disjunct_positions unchanged — derived once, reused
+      assert dp2 == dp
     end
   end
 end

--- a/packages/elixir-client/test/electric/client/tag_tracker_test.exs
+++ b/packages/elixir-client/test/electric/client/tag_tracker_test.exs
@@ -344,6 +344,62 @@ defmodule Electric.Client.TagTrackerTest do
       assert kd["key1"].disjunct_positions == [[0, 1]]
     end
 
+    test "orphaned tag_to_keys entries after delete do not cause phantom deletes" do
+      # Shape: (A AND C) OR (B AND C) → disjuncts [[0,1], [2,3]]
+      # Row "r" has all 4 positions active with hash "X"
+      msg =
+        make_change_msg("r", :insert,
+          tags: ["X/X//", "//X/X"],
+          active_conditions: [true, true, true, true]
+        )
+
+      {ttk, kd} = TagTracker.update_tag_index(%{}, %{}, msg)
+
+      # Deactivate positions 1 and 3 (dep C moves out with hash "X")
+      # Both disjuncts lose their C position → row invisible → deleted from key_data
+      patterns = [%{pos: 1, value: "X"}, %{pos: 3, value: "X"}]
+
+      {deletes, ttk, kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, DateTime.utc_now())
+
+      assert length(deletes) == 1
+      assert hd(deletes).key == "r"
+      refute Map.has_key?(kd, "r")
+
+      # Bug: {0, "X"} and {2, "X"} are still in tag_to_keys as orphans
+      # pointing to the deleted key "r"
+
+      # Re-insert row "r" with NEW hash "Y" at all positions (move-in)
+      msg =
+        make_change_msg("r", :insert,
+          tags: ["Y/Y//", "//Y/Y"],
+          active_conditions: [true, true, true, true]
+        )
+
+      {ttk, kd} = TagTracker.update_tag_index(ttk, kd, msg)
+
+      # Deactivate position 0 with STALE hash "X" — should have NO effect
+      # since the row's current hash at pos 0 is "Y", not "X"
+      patterns = [%{pos: 0, value: "X"}]
+
+      {deletes, ttk, kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, DateTime.utc_now())
+
+      assert deletes == []
+      # Without fix: active_conditions would be corrupted to [false, true, true, true]
+      assert kd["r"].active_conditions == [true, true, true, true]
+
+      # Now a legitimate deactivation at position 2 with current hash "Y"
+      patterns = [%{pos: 2, value: "Y"}]
+
+      {deletes, _ttk, _kd} =
+        TagTracker.generate_synthetic_deletes(ttk, kd, patterns, DateTime.utc_now())
+
+      # Disjunct 0 ([0,1]) is still fully active → row should remain visible
+      # Without fix: the corrupted pos 0 causes both disjuncts to fail → phantom delete
+      assert deletes == []
+    end
+
     test "disjunct structure derived correctly from slash-delimited tags" do
       msg =
         make_change_msg("key1", :insert,

--- a/packages/sync-service/IMPLEMENTATION_PLAN.md
+++ b/packages/sync-service/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,1989 @@
+# Implementation Plan: Arbitrary Boolean Expressions with Subqueries
+
+## Executive Summary
+
+This plan implements RFC "Arbitrary Boolean Expressions with Subqueries" which extends Electric's subquery support from single `IN (SELECT ...)` conditions to arbitrary boolean expressions with OR, NOT, and multiple subqueries. The implementation introduces DNF-based decomposition, per-row `active_conditions` arrays, and position-based move-in/move-out broadcasts.
+
+RFC: ../../docs/rfcs/arbitrary-boolean-expressions-with-subqueries.md
+
+## Key Architectural Constraint: Do Not Modify the Shape Struct
+
+The `Shape` struct (`lib/electric/shapes/shape.ex`) is a primitive in Electric — it is used everywhere, serialized across boundaries, and embedded in many subsystems. **No new fields should be added to `Shape`.**
+
+Instead, all DNF-related state (decomposition, position-to-dependency mappings, negated positions) is held in a separate `DnfContext` struct that lives in `Consumer.State`. The `DnfContext` is computed from the `Shape` and its dependencies at consumer startup time and is passed explicitly to functions that need it.
+
+### DnfContext (`lib/electric/shapes/consumer/dnf_context.ex`)
+
+A new module that encapsulates all DNF decomposition state:
+
+```elixir
+defmodule Electric.Shapes.Consumer.DnfContext do
+  defstruct [
+    decomposition: nil,                # %Decomposer.decomposition{} - the DNF result
+    position_to_dependency_map: %{},   # %{position => dep_handle}
+    dependency_to_positions_map: %{},  # %{dep_handle => [position]} - reverse lookup
+    negated_positions: MapSet.new()    # positions where condition is negated (NOT IN)
+  ]
+
+  @doc """
+  Build from a Shape and its dependency mappings. Returns nil if not needed.
+
+  Uses `shape.shape_dependencies_handles` to build the position-to-dependency
+  mapping. Calls `Decomposer.decompose/1` once; the result is cached on the struct
+  and should be used by all downstream consumers (querying, move_handling,
+  subquery_moves, etc.) rather than re-decomposing.
+  """
+  def from_shape(shape)
+
+  @doc "Which DNF positions does this dependency handle affect?"
+  def get_positions_for_dependency(ctx, dep_handle)
+
+  @doc "Is this position negated (NOT IN)?"
+  def position_negated?(ctx, position)
+
+  @doc "Does this context have a valid DNF with subqueries?"
+  def has_valid_dnf?(ctx)
+
+  @doc "Compute active_conditions for a record against the DNF."
+  def compute_active_conditions(ctx, record, used_refs, extra_refs)
+end
+```
+
+This keeps the `Shape` struct lean while giving the consumer everything it needs to process DNF-aware move-in/move-out operations. The `DnfContext` is computed once and stored in `Consumer.State`, passed to `move_handling`, `change_handling`, `subquery_moves`, and `querying` as needed. Functions that currently reach into `shape.dnf_decomposition` or `shape.position_to_dependency_map` should instead accept the `DnfContext`. Note: shapes without dependencies already take a separate fast path in `change_handling` (the `when not Shape.has_dependencies(shape)` guard), so the DNF code path is only reached for shapes that have a `DnfContext`.
+
+### Single Decomposition, Two Lifecycle Points
+
+`Decomposer.decompose/1` is called at two distinct lifecycle points:
+
+1. **Shape creation** (`Shape.new/5` and `Shape.from_json_safe/1`): `fill_tag_structure` calls the decomposer to build the multi-disjunct `tag_structure` that is persisted on the Shape.
+2. **Consumer startup** (`DnfContext.from_shape/1`): decomposes again to build position-to-dependency maps, negated position tracking, and the cached decomposition used throughout the consumer's lifetime.
+
+Since decomposition is deterministic (same AST always produces the same result), both calls produce identical output. This two-call pattern is acceptable because the calls happen at different lifecycle stages — shape creation may happen in a different process or even a different server restart from consumer startup.
+
+**Within the consumer's lifetime**, always use `DnfContext`'s cached decomposition. Never re-decompose in `querying.ex`, `subquery_moves.ex`, `move_handling.ex`, etc. — accept the decomposition from DnfContext instead.
+
+### Data Formats: condition_hashes, tags, and wire format
+
+There are three distinct representations of per-row hashed values, each optimised for its consumer. All three are computed independently from the underlying column values — none is derived from another in code.
+
+#### 1. condition_hashes
+
+One hash per DNF position, stored as a map with integer keys for O(1) positional access:
+
+```elixir
+%{0 => "hash_x", 1 => "hash_status", 2 => "hash_y"}
+```
+
+- **Where**: binary move-in snapshot files (on disk stored sequentially, decoded into a map in memory), `moved_out_tags` filtering
+- **Purpose**: position-aware filtering — "is the hash at position P in the moved-out set?"
+- **No nils**: every DNF position has exactly one condition with column(s) that produce a hash for every row (NULL column values get the existing `"NULL"` sentinel, non-null get `"v:" <> value`)
+
+#### 2. tags (internal 2D array)
+
+One inner list per disjunct, with `nil` at non-participating positions:
+
+```elixir
+[["hash_x", "hash_status", nil], [nil, nil, "hash_y"]]
+```
+
+- **Where**: `move_tags` on change structs, `fill_move_tags` output, consumer processing
+- **Purpose**: per-disjunct tag tracking for client-side inclusion evaluation
+
+#### 3. wire/API tags (slash-delimited per disjunct)
+
+One string per disjunct, positions separated by `/`:
+
+```json
+{"tags": ["hash_x/hash_status/", "//hash_y"]}
+```
+
+- **Where**: JSON headers sent to clients over HTTP, embedded in snapshot/move-in JSON by Postgres
+- **Purpose**: compact JSON representation for the wire
+
+#### How each format is computed
+
+- **Postgres SQL queries** (snapshot + move-in) generate both condition_hashes (as a separate `text[]` column) and wire-format tags (baked into the JSON headers string) directly from the underlying column values. The MD5 expressions are shared — Postgres deduplicates identical subexpressions.
+- **Binary snapshot write** stores condition_hashes from the separate column. The JSON column (with wire tags already embedded) is stored alongside.
+- **Binary snapshot read** decodes sequential condition_hashes into `%{position => hash}` map for filtering.
+- **`fill_move_tags`** in `shape.ex` computes the **internal 2D array** directly from the record for replication-stream changes.
+- **`log_items.ex`** converts the internal 2D array to slash-delimited wire format when building log entry headers (via `Enum.map(tags, &Enum.join(&1, "/"))`).
+
+#### Binary move-in snapshot file format
+
+```
+<<key_size::32, json_size::64, op_type::8, hash_count::16,
+  [hash_size::16, hash::binary(hash_size)]...,
+  key::binary(key_size), json::binary(json_size)>>
+```
+
+On disk, condition_hashes are sequential (position 0 first, then 1, etc.). On read, decode into `%{0 => hash0, 1 => hash1, ...}` for O(1) position lookup. The JSON already contains wire-format tags in its headers — no Elixir-side tag derivation needed at splice time.
+
+### Sublink Index Resolution
+
+When multiple subqueries reference the same column (e.g., `parent_id IN (SELECT ... WHERE category='a') OR parent_id IN (SELECT ... WHERE category='b')`), the sublink index (which dependency shape each subquery corresponds to) MUST be extracted directly from the AST node, NOT resolved by column-name matching.
+
+Column-name matching is ambiguous: both subexpressions have `column == "parent_id"`, so column matching always resolves to the first dependency, producing identical `active_conditions` for what should be distinct subqueries.
+
+Use `extract_sublink_index/1` to pattern-match on the AST's `sublink_membership_check` function node and extract the canonical `$sublink` index from its argument:
+
+```elixir
+# Resolve sublink index from AST — NOT from column name matching.
+# Each sublink_membership_check AST node carries a $sublink reference
+# that uniquely identifies its dependency, even when multiple subqueries
+# use the same column.
+defp extract_sublink_index(%Func{name: "sublink_membership_check", args: [_, sublink_ref]}) do
+  case sublink_ref.path do
+    ["$sublink", idx_str] -> String.to_integer(idx_str)
+    _ -> nil
+  end
+end
+
+defp extract_sublink_index(_), do: nil
+```
+
+This function is used in both `querying.ex` (for `active_conditions` SELECT columns) and `subquery_moves.ex` (for exclusion clauses). It should be defined once in a shared location (e.g., a helper in `SubqueryMoves` or a utility module) and referenced by both.
+
+## Current State Analysis
+
+### Key Files and Their Roles
+
+| File | Current Role | Changes Needed |
+|------|--------------|----------------|
+| `lib/electric/shapes/consumer/dnf_context.ex` | **(new)** | Holds DNF decomposition state, built from Shape |
+| `lib/electric/replication/eval/sql_generator.ex` | **(new)** | Converts AST back to SQL — used by querying.ex and subquery_moves.ex |
+| `lib/electric/shapes/shape/subquery_moves.ex` | Tag structure generation, move-out messages, move-in WHERE clause + exclusion clauses | Extend for DNF positions, DNF-aware exclusion clauses, accept DnfContext |
+| `lib/electric/shapes/consumer/state.ex` | Detects `or_with_subquery?`/`not_with_subquery?` to invalidate | Remove invalidation flags, hold DnfContext |
+| `lib/electric/shapes/consumer.ex` | Triggers invalidation on OR/NOT with subqueries | Handle multiple positions |
+| `lib/electric/shapes/consumer/move_handling.ex` | Single-subquery move-in/out processing | Per-position broadcasts, use DnfContext |
+| `lib/electric/shapes/consumer/change_handling.ex` | Filters changes, computes tags | Compute `active_conditions` via DnfContext |
+| `lib/electric/shapes/shape.ex` | `fill_move_tags`, `convert_change` | Multi-disjunct tags — **no new struct fields** |
+| `lib/electric/shapes/where_clause.ex` | `includes_record?` boolean check | Per-position evaluation |
+| `lib/electric/shapes/querying.ex` | SQL for initial data, tags | Add `active_conditions` columns, add `condition_hashes` SELECT for move-in queries, accept DnfContext |
+| `lib/electric/log_items.ex` | Formats messages with tags | Add `active_conditions` to headers, convert 2D tags to wire format |
+| `lib/electric/replication/eval/parser.ex` | Parses WHERE, handles SubLinks | No changes needed |
+| `lib/electric/replication/eval/walker.ex` | AST traversal | No changes needed |
+| `packages/elixir-client/.../tag_tracker.ex` | Client-side tag tracking, DNF eval, synthetic deletes | Slash-delimited normalization, `removed_tags` parsing, position-based indexing |
+| `packages/elixir-client/.../message/headers.ex` | Client message headers | Add `active_conditions` field |
+
+### Current Limitations Being Addressed
+
+1. **Lines 291-297 in `consumer.ex`**: Shape invalidation on OR/NOT with subqueries or multiple dependencies
+2. **Lines 32-33 in `consumer/state.ex`**: `or_with_subquery?` and `not_with_subquery?` flags
+3. **Single tag structure**: `tag_structure` is `[[column_name]]` - single disjunct
+4. **No `active_conditions`**: Client cannot determine which conditions are satisfied
+
+---
+
+## Code Block Convention
+
+Code blocks in this plan are marked as either **final** or **directional**:
+
+- **Final** — intended as the real implementation (or very close to it). Type specs, function signatures, and logic should be followed as written.
+- **Directional** — shows the shape of the solution but leaves details to the implementer. Function bodies may be sketched, error handling omitted, or variables left unresolved.
+
+When unmarked, assume directional.
+
+---
+
+## Implementation Steps
+
+### Phase 1: DNF Decomposer (New Module)
+
+**Create** `lib/electric/replication/eval/decomposer.ex`
+
+**Final** — types and module structure:
+```elixir
+defmodule Electric.Replication.Eval.Decomposer do
+  @moduledoc """
+  Converts WHERE clause AST to Disjunctive Normal Form (DNF).
+
+  DNF is a disjunction (OR) of conjunctions (AND) of literals.
+  Each literal is either a positive or negated atomic condition.
+  """
+
+  alias Electric.Replication.Eval.Parser
+  alias Electric.Replication.Eval.Walker
+
+  @type position :: non_neg_integer()
+  @type literal :: {position(), :positive | :negated}
+  @type conjunction :: [literal()]
+  @type dnf :: [conjunction()]
+
+  @type subexpression :: %{
+    ast: Parser.tree_part(),
+    is_subquery: boolean(),
+    negated: boolean()
+  }
+
+  @type decomposition :: %{
+    disjuncts: dnf(),
+    disjuncts_positions: [[position()]],  # polarity-stripped version for evaluate_dnf
+    subexpressions: %{position() => subexpression()},
+    position_count: non_neg_integer()
+  }
+
+  @max_disjuncts 100
+
+  @spec decompose(Parser.tree_part()) :: {:ok, decomposition()} | {:error, term()}
+  def decompose(ast) do
+    # Implementation:
+    # 1. Collect all atomic conditions (subqueries + field comparisons)
+    # 2. Apply De Morgan's laws to push NOT inward
+    # 3. Distribute AND over OR to get DNF
+    # 4. Assign positions to each unique atomic condition
+    # 5. Check complexity guard
+    # 6. Return disjuncts as position references
+  end
+end
+```
+
+**Key Functions**:
+- `decompose/1` - Main entry point
+- `push_negation_inward/1` - De Morgan's laws
+- `distribute_and_over_or/1` - DNF conversion
+- `collect_atomics/1` - Extract atomic conditions
+- `assign_positions/1` - Map conditions to positions
+
+**Error handling**: If decomposition fails (e.g., unsupported AST structure) or the complexity guard triggers (`length(disjuncts) > @max_disjuncts`), return `{:error, reason}`. Callers during shape creation (`Shape.new/5`) propagate the error as a 400 response to the client with a descriptive message like `"WHERE clause too complex for DNF decomposition (N disjuncts exceeds limit of 100)"`. The shape is never created — there is no silent fallback to invalidation.
+
+#### Position Stability Algorithm
+
+Position assignment must be deterministic to ensure the same WHERE clause always produces the same position assignments across shape restarts:
+
+**Directional** — sorting strategy, not exact implementation:
+```elixir
+def assign_positions(atomics) do
+  # Sort atomics by their AST string representation for determinism
+  atomics
+  |> Enum.sort_by(fn atomic ->
+    # Use a canonical string representation
+    :erlang.term_to_binary(atomic.ast)
+  end)
+  |> Enum.with_index()
+  |> Enum.map(fn {atomic, idx} -> {idx, atomic} end)
+  |> Map.new()
+end
+```
+
+### Phase 2: SQL Generator (New Module)
+
+**Create** `lib/electric/replication/eval/sql_generator.ex`
+
+A general-purpose module that converts the parsed AST (from `Parser`) back into SQL strings.
+Lives alongside `parser.ex`, `walker.ex`, `runner.ex`, and `decomposer.ex` in the `eval`
+directory. Used by `querying.ex` (for `active_conditions` SELECT columns) and
+`subquery_moves.ex` (for exclusion clauses) — both call `SqlGenerator.to_sql/1` instead of
+inlining their own AST-to-SQL conversion.
+
+**Final** — complete implementation covering all operator types:
+```elixir
+defmodule Electric.Replication.Eval.SqlGenerator do
+  @moduledoc """
+  Converts a parsed WHERE clause AST back into a SQL string.
+
+  This is the inverse of `Parser` — where `Parser` turns SQL text into an AST,
+  `SqlGenerator` turns that AST back into SQL text. Used whenever the server
+  needs to embed a condition in a generated query (snapshot active_conditions,
+  move-in exclusion clauses, etc.).
+
+  Must handle every AST node type that `Parser` can produce. Raises
+  `ArgumentError` for unrecognised nodes so gaps are caught at shape
+  creation time, but the property-based round-trip test (see Tests below)
+  enforces that no parseable expression triggers this error.
+  """
+
+  alias Electric.Replication.Eval.Parser.{Const, Ref, Func, Array}
+
+  @doc """
+  Convert an AST node to a SQL string.
+
+  Handles: comparison operators (=, <>, <, >, <=, >=), pattern matching
+  (LIKE, ILIKE), nullability (IS NULL, IS NOT NULL), membership (IN),
+  logical operators (AND, OR, NOT), column references, and constants
+  (strings, integers, floats, booleans, NULL).
+
+  Raises `ArgumentError` for unrecognised AST nodes.
+  """
+  @spec to_sql(Parser.tree_part()) :: String.t()
+
+  # Comparison operators — names are stored with surrounding quotes
+  def to_sql(%Func{name: "\"=\"", args: [left, right]}),
+    do: "(#{to_sql(left)} = #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"<>\"", args: [left, right]}),
+    do: "(#{to_sql(left)} <> #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"<\"", args: [left, right]}),
+    do: "(#{to_sql(left)} < #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\">\"", args: [left, right]}),
+    do: "(#{to_sql(left)} > #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"<=\"", args: [left, right]}),
+    do: "(#{to_sql(left)} <= #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\">=\"", args: [left, right]}),
+    do: "(#{to_sql(left)} >= #{to_sql(right)})"
+
+  # Pattern matching
+  def to_sql(%Func{name: "\"~~\"", args: [left, right]}),
+    do: "(#{to_sql(left)} LIKE #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"~~*\"", args: [left, right]}),
+    do: "(#{to_sql(left)} ILIKE #{to_sql(right)})"
+
+  # Nullability
+  def to_sql(%Func{name: "is null", args: [arg]}),
+    do: "(#{to_sql(arg)} IS NULL)"
+
+  def to_sql(%Func{name: "is not null", args: [arg]}),
+    do: "(#{to_sql(arg)} IS NOT NULL)"
+
+  # Membership (IN with literal array)
+  def to_sql(%Func{name: "in", args: [left, %Array{elements: elements}]}) do
+    values = Enum.map_join(elements, ", ", &to_sql/1)
+    "(#{to_sql(left)} IN (#{values}))"
+  end
+
+  # Logical operators
+  def to_sql(%Func{name: "not", args: [inner]}),
+    do: "(NOT #{to_sql(inner)})"
+
+  def to_sql(%Func{name: "and", args: args}) do
+    conditions = Enum.map_join(args, " AND ", &to_sql/1)
+    "(#{conditions})"
+  end
+
+  def to_sql(%Func{name: "or", args: args}) do
+    conditions = Enum.map_join(args, " OR ", &to_sql/1)
+    "(#{conditions})"
+  end
+
+  # Column references
+  def to_sql(%Ref{path: path}) do
+    ~s|"#{Enum.join(path, "\".\"")}"|
+  end
+
+  # Constants
+  def to_sql(%Const{value: nil}), do: "NULL"
+  def to_sql(%Const{value: true}), do: "true"
+  def to_sql(%Const{value: false}), do: "false"
+
+  def to_sql(%Const{value: value}) when is_binary(value) do
+    escaped = String.replace(value, "'", "''")
+    "'#{escaped}'"
+  end
+
+  def to_sql(%Const{value: value}) when is_integer(value) or is_float(value),
+    do: "#{value}"
+
+  # Catch-all — fail loudly so unsupported operators are caught at shape
+  # creation time, not at query time.
+  def to_sql(other) do
+    raise ArgumentError,
+      "SqlGenerator.to_sql/1: unsupported AST node: #{inspect(other)}. " <>
+      "This WHERE clause contains an operator or expression type that " <>
+      "cannot be converted back to SQL for active_conditions generation."
+  end
+end
+```
+
+**Tests**: `test/electric/replication/eval/sql_generator_test.exs`
+
+Comprehensive unit tests covering all operator types (=, <>, <, >, <=, >=, LIKE, ILIKE,
+IS NULL, IS NOT NULL, IN), logical connectives (AND, OR, NOT), column references
+(simple and schema-qualified), constant types (nil, bool, string, integer, float with
+single-quote escaping), error handling for unsupported AST nodes, and complex nested
+expressions. All tests construct AST structs directly and assert `SqlGenerator.to_sql/1`
+output. Representative examples:
+
+```elixir
+# Comparison: construct AST, assert SQL
+test "equals" do
+  ast = %Func{name: "\"=\"", args: [%Ref{path: ["status"]}, %Const{value: "active"}]}
+  assert SqlGenerator.to_sql(ast) == ~s|("status" = 'active')|
+end
+
+# Nested logical: AND within OR
+test "nested AND within OR" do
+  a = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+  b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
+  c = %Func{name: "\"=\"", args: [%Ref{path: ["z"]}, %Const{value: 3}]}
+  ast = %Func{name: "or", args: [%Func{name: "and", args: [a, b]}, c]}
+  assert SqlGenerator.to_sql(ast) == ~s|((("x" = 1) AND ("y" = 2)) OR ("z" = 3))|
+end
+
+# Error handling: unsupported nodes raise ArgumentError
+test "raises ArgumentError for unsupported AST node" do
+  assert_raise ArgumentError, ~r/unsupported AST node/, fn ->
+    SqlGenerator.to_sql(%{unexpected: :node})
+  end
+end
+```
+
+**Coverage invariant**: `SqlGenerator` must handle every AST node that `Parser` can produce.
+The hardcoded operator list above must stay in sync with `known_functions.ex` and the
+parser's built-in node types (boolean tests, casts, etc.). To enforce this, add a
+property-based round-trip test using `stream_data`:
+
+```elixir
+describe "round-trip: SQL -> Parser -> SqlGenerator -> SQL" do
+  # Normalize by stripping outer parens and collapsing whitespace,
+  # so `((x = 1))` and `(x = 1)` compare equal.
+  defp normalize_sql(sql) do
+    sql
+    |> String.trim()
+    |> String.replace(~r/\s+/, " ")
+    |> strip_outer_parens()
+  end
+
+  defp strip_outer_parens("(" <> _ = s) do
+    if String.ends_with?(s, ")") do
+      inner = s |> String.slice(1..-2//1) |> String.trim()
+      # Only strip if the parens are balanced (not part of nested expr)
+      if balanced?(inner), do: strip_outer_parens(inner), else: s
+    else
+      s
+    end
+  end
+  defp strip_outer_parens(s), do: s
+
+  property "any parseable WHERE clause round-trips through SqlGenerator" do
+    check all sql <- where_clause_generator() do
+      {:ok, ast} = Parser.parse_and_validate_expression(sql)
+      regenerated = SqlGenerator.to_sql(ast)
+      assert normalize_sql(sql) == normalize_sql(regenerated)
+    end
+  end
+end
+```
+
+The `where_clause_generator/0` should produce arbitrary combinations of supported
+operators, column refs, constants, and logical connectives — ensuring that any expression
+the parser accepts can be regenerated. If `SqlGenerator.to_sql/1` raises `ArgumentError`
+for a parseable expression, the test fails, catching coverage gaps immediately.
+
+### Phase 3: DnfContext (New Module)
+
+**Create** `lib/electric/shapes/consumer/dnf_context.ex` (see "Key Architectural Constraint" above)
+
+`DnfContext.from_shape/1` calls `Decomposer.decompose/1` once and caches the result. All downstream consumers use this cached decomposition.
+
+#### Dependency Handle to Position Mapping
+
+Built inside `DnfContext.from_shape/1` using `shape.shape_dependencies_handles`:
+
+**Directional** — mapping logic, exact field access may differ:
+```elixir
+# Inside DnfContext.from_shape/1
+defp build_position_to_dependency_map(decomposition, dep_handles) do
+  decomposition.subexpressions
+  |> Enum.filter(fn {_pos, subexpr} -> subexpr.is_subquery end)
+  |> Enum.map(fn {pos, subexpr} ->
+    # Use extract_sublink_index/1 (see "Sublink Index Resolution" above)
+    # to get the dependency index from the AST, NOT by column-name matching.
+    dep_index = extract_sublink_index(subexpr.ast)
+    dep_handle = Enum.at(dep_handles, dep_index)
+    {pos, dep_handle}
+  end)
+  |> Map.new()
+end
+
+# DnfContext also builds the reverse map
+defp build_dependency_to_positions_map(pos_to_dep) do
+  Enum.group_by(pos_to_dep, fn {_pos, handle} -> handle end, fn {pos, _} -> pos end)
+end
+
+# Used by move_handling.ex via DnfContext.get_positions_for_dependency/2
+```
+
+**Note:** Same subquery can appear at multiple positions (e.g., `x IN sq AND y IN sq`).
+
+#### Protocol Validation
+
+**Directional** — validation logic, location TBD:
+```elixir
+# In lib/electric/shapes/api.ex or shape validation
+defp validate_protocol_compatibility(dnf_context, protocol_version) do
+  has_complex_subqueries? = dnf_context != nil and
+    DnfContext.has_valid_dnf?(dnf_context) and
+    (length(dnf_context.decomposition.disjuncts) > 1 or
+     MapSet.size(dnf_context.negated_positions) > 0)
+
+  cond do
+    protocol_version == 1 and has_complex_subqueries? ->
+      {:error, :protocol_version_too_low,
+        "WHERE clauses with OR or NOT combined with subqueries require protocol version 2. " <>
+        "Please upgrade your client."}
+
+    true ->
+      :ok
+  end
+end
+```
+
+**Protocol version detection:**
+- Client sends `Electric-Protocol-Version: 2` header
+- Server checks before shape creation
+- Returns 400 with descriptive error for v1 clients with complex shapes
+
+### Phase 4: Shape Tag Structure and fill_move_tags
+
+**Modify** `lib/electric/shapes/shape.ex` — **no new struct fields**
+
+1. Update `fill_tag_structure/1` to produce multi-disjunct tag structures using the decomposer. The `tag_structure` field already exists on Shape and is the right place for this — it's the pattern used to hash column values into tags. For DNF shapes it becomes a list of lists (one per disjunct) where each inner list has an entry per DNF position (`nil` for positions not in that disjunct, column name(s) for participating positions):
+
+**Directional** — shows structure, error propagation details may vary:
+```elixir
+defp fill_tag_structure(shape) do
+  case shape.where do
+    nil -> shape
+    where ->
+      case Decomposer.decompose(where.eval) do
+        {:ok, decomposition} ->
+          # Build tag_structure as list of lists (one per disjunct)
+          tag_structure = build_tag_structure_from_dnf(decomposition)
+          %{shape | tag_structure: tag_structure}
+
+        {:error, reason} ->
+          # Propagate error — shape creation fails with 400
+          raise "DNF decomposition failed: #{inspect(reason)}"
+      end
+  end
+end
+```
+
+This is one of two lifecycle points where `Decomposer.decompose/1` is called (see "Single Decomposition, Two Lifecycle Points" above). The result is used only to build the tag_structure; the full decomposition is re-derived at consumer startup in `DnfContext.from_shape/1`.
+
+`build_tag_structure_from_dnf` extracts column name(s) from **every** subexpression's AST — both subquery and non-subquery positions — using the same `Walker.reduce!` approach as `extract_columns_from_ast` (Phase 12). For a subquery position like `x IN (SELECT ...)`, the entry is `"x"` (or `{:hash_together, ["x", "y"]}` for row comparisons). For a non-subquery position like `status = 'active'`, the entry is `"status"` — the column(s) referenced by the comparison. In both cases, `fill_move_tags` hashes the actual column value from the row at that position.
+
+Worked example for `WHERE (x IN sq1 AND status = 'active') OR y IN sq2`:
+- Position 0: `x IN sq1` (subquery) → column `"x"`
+- Position 1: `status = 'active'` (non-subquery) → column `"status"`
+- Position 2: `y IN sq2` (subquery) → column `"y"`
+- Disjunct 0 uses positions {0, 1}, disjunct 1 uses position {2}
+- `tag_structure`: `[["x", "status", nil], [nil, nil, "y"]]`
+
+For a row with `x='a', status='active', y='b'`, `fill_move_tags` produces:
+`[["hash(a)", "hash(active)", nil], [nil, nil, "hash(b)"]]`
+
+This means the non-subquery hash is deterministic for rows matching the condition (all rows with `status = 'active'` produce the same hash at position 1). This is correct — the hash identifies the row's contribution at that position, and the value must match between Postgres-generated hashes (`make_condition_hashes_select`) and Elixir-generated hashes (`fill_move_tags`), which it does because both hash the raw column value using the same `namespace_value` + MD5 formula.
+
+2. Update `fill_move_tags/4` to produce the **internal 2D array** format (not slash-delimited strings). The existing `make_tags_from_pattern` currently calls `Enum.join("/")` to produce slash-delimited strings; this changes to return lists directly:
+
+**Directional** — shows data shape, hashing details use existing helpers:
+```elixir
+def fill_move_tags(%Changes.NewRecord{record: record} = change, shape, stack_id, shape_handle) do
+  tags = Enum.map(shape.tag_structure, fn disjunct_pattern ->
+    Enum.map(disjunct_pattern, fn
+      nil -> nil  # Position not in this disjunct
+      column_spec -> hash_column_value(column_spec, record, stack_id, shape_handle)
+    end)
+  end)
+
+  %{change | move_tags: tags}
+end
+```
+
+The conversion from internal 2D arrays to slash-delimited wire format happens in `log_items.ex` (Phase 8), not here.
+
+### Phase 5: Consumer State Updates
+
+**Modify** `lib/electric/shapes/consumer/state.ex`
+
+Remove invalidation flags and add `dnf_context`:
+
+**Directional** — shows field changes:
+```elixir
+defstruct [
+  # ... existing fields ...
+  # REMOVE: or_with_subquery?: false,
+  # REMOVE: not_with_subquery?: false,
+  # ADD:
+  dnf_context: nil,  # %DnfContext{} - built from shape at init time
+]
+```
+
+Also remove `has_or_with_subquery?/1`, `has_not_with_subquery?/1`, and `subtree_has_sublink?/1` helper functions.
+
+Build DnfContext during initialization:
+
+```elixir
+@spec initialize_shape(uninitialized_t(), Shape.t()) :: uninitialized_t()
+def initialize_shape(%__MODULE__{} = state, shape) do
+  %{state | shape: shape, dnf_context: DnfContext.from_shape(shape)}
+end
+```
+
+The `DnfContext` holds all position-to-dependency mappings, negated position tracking, and the decomposition itself. No per-position state is added to `Shape` or `Consumer.State` directly — it all lives on the `DnfContext`.
+
+### Phase 6: Active Conditions Computation
+
+**Modify** `lib/electric/shapes/where_clause.ex`
+
+`compute_active_conditions` is called via `DnfContext.compute_active_conditions/4` which delegates here. The decomposition is passed in from the DnfContext, not read from the Shape.
+
+**Final** — `compute_active_conditions` and `evaluate_dnf`:
+```elixir
+defmodule Electric.Shapes.WhereClause do
+  @doc """
+  Compute active_conditions array for a record.
+  Returns list of **effective** booleans, one per position in the DNF.
+  For negated positions, the stored AST is the un-negated form, so we
+  apply NOT here to produce the value clients can use directly without
+  needing polarity information.
+  The decomposition is passed from DnfContext, not from the Shape struct.
+  """
+  @spec compute_active_conditions(Decomposer.decomposition(), map(), map(), map()) :: [boolean()]
+  def compute_active_conditions(decomposition, record, used_refs, extra_refs) do
+    %{subexpressions: subexpressions, position_count: position_count} = decomposition
+
+    Enum.map(0..(position_count - 1), fn position ->
+      subexpr = Map.fetch!(subexpressions, position)
+      value = evaluate_subexpression(subexpr, record, used_refs, extra_refs)
+      # Apply negation so active_conditions stores the effective value.
+      if subexpr.negated, do: not value, else: value
+    end)
+  end
+
+  @doc """
+  Evaluate DNF to determine if record is included.
+
+  `active_conditions` stores effective values (negation already applied),
+  so we only need position indices — polarity is irrelevant here.
+  Callers strip polarity before calling this function (see
+  `decomposition.disjuncts_positions`).
+  """
+  @spec evaluate_dnf([boolean()], [[Decomposer.position()]]) :: boolean()
+  def evaluate_dnf(active_conditions, disjuncts_positions) do
+    Enum.any?(disjuncts_positions, fn conjunction_positions ->
+      Enum.all?(conjunction_positions, fn pos ->
+        Enum.at(active_conditions, pos, false) == true
+      end)
+    end)
+  end
+end
+```
+
+### Phase 7: Move-in/Move-out Message Format + DNF-Aware Exclusion Clauses
+
+**Modify** `lib/electric/shapes/shape/subquery_moves.ex`
+
+> **IMPORTANT — exclusion clause logic lives here.** `move_in_where_clause/4` already
+> generates the WHERE clause for move-in queries, including exclusion clauses that prevent
+> duplicate inserts when a row is already in the shape via another disjunct. The existing
+> index-based exclusion (`build_exclusion_clauses`) is **wrong for AND+OR combinations** —
+> it excludes ALL other subquery dependencies by index, but should only exclude dependencies
+> in disjuncts that do NOT contain the triggering dependency. For example, in
+> `(x IN sq1 AND y IN sq2) OR z IN sq3`, when sq1 triggers, the old code excludes both sq2
+> and sq3, but sq2 should NOT be excluded since it's in the same disjunct as sq1.
+>
+> Replace `build_exclusion_clauses` with `build_dnf_exclusion_clauses` that uses the
+> decomposition to partition disjuncts into containing/not-containing the trigger position,
+> and only generates `AND NOT (...)` for disjuncts not containing it.
+
+#### 7a: DNF-aware WHERE clause in `move_in_where_clause`
+
+The function accepts `dnf_context` (from `Consumer.State`) to avoid re-decomposition.
+
+**Key design decision: triggering disjunct only.** For multi-disjunct shapes, the move-in
+WHERE clause is **reconstructed from the triggering disjunct's conditions**, not derived from
+the original `shape.where.query` by string replacement. The existing string-replacement
+approach works for single-disjunct shapes but is wrong for multi-disjunct: using the full
+original WHERE (which contains all disjuncts joined by OR) would over-fetch rows already
+present via other disjuncts and make the exclusion clauses redundant.
+
+For `WHERE (x IN sq1 AND status = 'active') OR y IN sq2`, when sq1 triggers with value `'a'`:
+- **Base WHERE** = triggering disjunct's conditions: `x = 'a' AND status = 'active'`
+  - The triggering subquery position uses `= ANY($1)` (or `= 'a'` for single values)
+  - Non-subquery positions use `SqlGenerator.to_sql(subexpr.ast)` to produce the SQL
+  - Other subquery positions in the same disjunct keep their original subquery SQL
+- **Exclusion clauses** = `AND NOT (...)` for each disjunct NOT containing the trigger position
+
+For single-disjunct shapes (including all existing single-subquery shapes), the existing
+string-replacement approach remains correct — the triggering disjunct IS the full WHERE.
+
+**Directional** — `move_in_where_clause` shows the dispatch structure:
+```elixir
+def move_in_where_clause(shape, shape_handle, move_ins, dnf_context, opts) do
+  dep_index = find_dep_index(shape, shape_handle)
+  decomposition = dnf_context.decomposition
+
+  # For single-disjunct shapes, use existing string-replacement approach.
+  # For multi-disjunct, reconstruct WHERE from the triggering disjunct.
+  base_where =
+    if decomposition.position_count <= 1 or length(decomposition.disjuncts) == 1 do
+      # Single disjunct: existing approach — replace subquery in shape.where.query
+      build_single_disjunct_where(shape, dep_index, move_ins, opts)
+    else
+      # Multi-disjunct: reconstruct from triggering disjunct's conditions
+      trigger_positions = find_dnf_positions_for_dep_index(decomposition, dep_index)
+      triggering_disjunct = find_disjunct_containing(decomposition.disjuncts, trigger_positions)
+      build_disjunct_where(triggering_disjunct, decomposition, shape, dep_index, move_ins, opts)
+    end
+
+  # Build exclusion clauses for disjuncts NOT containing the trigger
+  exclusion_clauses =
+    case decomposition do
+      %{disjuncts: disjuncts} when length(disjuncts) > 1 ->
+        build_dnf_exclusion_clauses(decomposition, shape.shape_dependencies,
+          shape.subquery_comparison_expressions, dep_index)
+      _ ->
+        ""
+    end
+
+  {base_where <> exclusion_clauses, params}
+end
+
+# **Final** — find_dnf_positions_for_dep_index, build_dnf_exclusion_clauses,
+# and generate_disjunct_exclusion:
+
+# Find all DNF positions that correspond to a given dependency index.
+# A single dependency can appear at multiple positions (e.g., the same subquery
+# referenced in different parts of the WHERE clause).
+defp find_dnf_positions_for_dep_index(decomposition, dep_index) do
+  Enum.flat_map(decomposition.subexpressions, fn {pos, subexpr} ->
+    if subexpr.is_subquery and extract_sublink_index(subexpr.ast) == dep_index do
+      [pos]
+    else
+      []
+    end
+  end)
+end
+
+# Build exclusion clauses using DNF decomposition.
+# Only excludes subqueries in disjuncts that do NOT contain the triggering dependency.
+# For example, in `(x IN sq1 AND y IN sq2) OR z IN sq3`:
+#   - When sq1 triggers, sq2 is in the same disjunct so NOT excluded; sq3 IS excluded
+defp build_dnf_exclusion_clauses(decomposition, shape_dependencies, comparison_expressions, trigger_dep_index) do
+  trigger_positions = find_dnf_positions_for_dep_index(decomposition, trigger_dep_index)
+
+  if trigger_positions == [] do
+    ""
+  else
+    # Partition disjuncts into those containing vs not containing any trigger position
+    {_containing, not_containing} =
+      Enum.split_with(decomposition.disjuncts, fn conjunction ->
+        Enum.any?(conjunction, fn {pos, _polarity} -> pos in trigger_positions end)
+      end)
+
+    # Generate exclusion for each disjunct NOT containing the trigger
+    clauses =
+      Enum.flat_map(not_containing, fn conjunction ->
+        case generate_disjunct_exclusion(conjunction, decomposition, shape_dependencies, comparison_expressions) do
+          nil -> []
+          clause -> [clause]
+        end
+      end)
+
+    Enum.join(clauses)
+  end
+end
+
+# Generate an exclusion clause for a single disjunct (conjunction of literals).
+# Returns nil if the disjunct contains any non-subquery positions (weaker exclusion
+# is safe since the client deduplicates via tags).
+# Otherwise returns " AND NOT (cond1 AND cond2 AND ...)"
+defp generate_disjunct_exclusion(conjunction, decomposition, shape_dependencies, comparison_expressions) do
+  all_subquery? = Enum.all?(conjunction, fn {pos, _polarity} ->
+    case Map.get(decomposition.subexpressions, pos) do
+      %{is_subquery: true} -> true
+      _ -> false
+    end
+  end)
+
+  if not all_subquery? do
+    nil
+  else
+    conditions = Enum.flat_map(conjunction, fn {pos, polarity} ->
+      info = Map.get(decomposition.subexpressions, pos)
+      # Use extract_sublink_index/1 — see "Sublink Index Resolution" above
+      case extract_sublink_index(info.ast) do
+        nil -> []
+        dep_index ->
+          subquery_shape = Enum.at(shape_dependencies, dep_index)
+          subquery_section = rebuild_subquery_section(subquery_shape)
+          column_sql = get_column_sql(comparison_expressions, dep_index)
+          if column_sql do
+            condition = "#{column_sql} #{subquery_section}"
+            case polarity do
+              :positive -> [condition]
+              :negated -> ["NOT #{condition}"]
+            end
+          else
+            []
+          end
+      end
+    end)
+
+    if conditions == [], do: nil, else: " AND NOT (#{Enum.join(conditions, " AND ")})"
+  end
+end
+```
+
+#### 7b: Move-in/move-out control messages with position information
+
+**Directional** — message shape, exact header structure may evolve:
+```elixir
+@doc """
+Generate move-in control message with position information.
+"""
+def make_move_in_control_message(shape, stack_id, shape_handle, position, values) do
+  hashed_values = Enum.map(values, fn value ->
+    make_value_hash(stack_id, shape_handle, value)
+  end)
+
+  %{
+    headers: %{
+      control: "move-in",
+      position: position,
+      values: hashed_values
+    }
+  }
+end
+
+@doc """
+Generate move-out control message with position information.
+"""
+def make_move_out_control_message(shape, stack_id, shape_handle, position, values) do
+  hashed_values = Enum.map(values, fn {_key, value} ->
+    make_value_hash(stack_id, shape_handle, value)
+  end)
+
+  %{
+    headers: %{
+      control: "move-out",
+      position: position,
+      values: hashed_values
+    }
+  }
+end
+```
+
+### Phase 8: Log Items Format
+
+**Modify** `lib/electric/log_items.ex`
+
+Two changes: add `active_conditions` to headers, and convert internal 2D tag arrays to slash-delimited wire format.
+
+**Directional** — `from_change` shows new fields; **Final** — `tags_to_wire`:
+```elixir
+def from_change(%Changes.NewRecord{} = change, txids, _, _replica) do
+  headers = %{
+    operation: :insert,
+    txids: List.wrap(txids),
+    relation: Tuple.to_list(change.relation),
+    lsn: to_string(change.log_offset.tx_offset),
+    op_position: change.log_offset.op_offset
+  }
+  |> put_if_true(:last, change.last?)
+  |> put_if_true(:tags, change.move_tags != [], tags_to_wire(change.move_tags))
+  |> put_if_true(:active_conditions, change.active_conditions != nil, change.active_conditions)
+
+  [{change.log_offset, %{key: change.key, value: change.record, headers: headers}}]
+end
+
+# Convert internal 2D tag array to slash-delimited wire format.
+# [["hash_x", "hash_status", nil], [nil, nil, "hash_y"]]
+# → ["hash_x/hash_status/", "//hash_y"]
+defp tags_to_wire(tags) do
+  Enum.map(tags, fn disjunct ->
+    Enum.map_join(disjunct, "/", fn
+      nil -> ""
+      hash -> hash
+    end)
+  end)
+end
+```
+
+#### Message Format Migration
+
+**Current format** (single-subquery, flat):
+```json
+{"tags": ["hash1/hash2"]}
+```
+
+**New format** (multi-disjunct):
+```json
+{"tags": ["hash1/hash2/", "//hash3"], "active_conditions": [true, true, false]}
+{"control": "move-out", "position": 0, "values": ["hash1", "hash2"]}
+```
+
+**Migration strategy:**
+The existing `tagged_subqueries` feature flag already gates all subquery move-in/move-out support. The new multi-disjunct format is an extension of the same mechanism — single-subquery shapes produce tags with one entry (unchanged semantics), while multi-disjunct shapes produce multiple entries. No second feature flag is needed. The `tagged_subqueries` flag continues to be the single gate for all subquery tag support.
+
+Clients must be updated to handle the new format before shapes with OR/NOT subqueries are used (enforced by protocol version validation in Phase 3).
+
+### Phase 9: Change Handling Updates
+
+**Modify** `lib/electric/shapes/consumer/change_handling.ex`
+
+Uses `state.dnf_context` (from `Consumer.State`) to compute active conditions and evaluate DNF inclusion. Per the RFC ("Replication Stream Updates"), `compute_active_conditions` replaces the separate `includes_record?` call — a single pass, not double evaluation.
+
+**Directional** — shows the new clause replacing the existing dependency path:
+```elixir
+def do_process_changes([change | rest], %State{shape: shape, dnf_context: dnf_context} = state, ctx, acc, count) do
+  # Compute active_conditions for this change via DnfContext
+  active_conditions = DnfContext.compute_active_conditions(dnf_context, change.record, used_refs, ctx.extra_refs)
+
+  # Evaluate DNF to check inclusion
+  included = WhereClause.evaluate_dnf(
+    active_conditions,
+    dnf_context.decomposition.disjuncts_positions
+  )
+
+  if included do
+    change_with_conditions = %{change | active_conditions: active_conditions}
+
+    case Shape.convert_change(shape, change_with_conditions, opts) do
+      [] -> do_process_changes(rest, state, ctx, acc, count)
+      [converted] ->
+        state = State.track_change(state, ctx.xid, converted)
+        do_process_changes(rest, state, ctx, [converted | acc], count + 1)
+    end
+  else
+    do_process_changes(rest, state, ctx, acc, count)
+  end
+end
+```
+
+#### `changes_only` Mode
+
+The `changes_only` mode uses the same tag/active_conditions computation as full sync — no separate path needed. The existing `do_process_changes/5` pipeline in `change_handling.ex` is already agnostic to `log_mode`, and the new DNF fields (`move_tags`, `active_conditions`) are computed by `Shape.convert_change` uniformly for all shapes.
+
+**Client behavior in `changes_only` mode:**
+- Clients build state incrementally from WAL changes only (no initial snapshot)
+- Move-in/move-out broadcasts for unknown rows are **ignored** (row not in local state)
+- Tags and `active_conditions` on insert/update/delete are processed normally
+- Since there is no snapshot, the client never needs to apply `moved_out` logic to snapshot rows — its DNF evaluator only handles tags/active_conditions on inserts, updates, and deletes
+
+**How clients distinguish "unknown row" from "known row with all conditions false":**
+Clients maintain a map of tracked row keys. A move-in/move-out broadcast for a key not in this map is simply ignored. A broadcast for a key that IS in the map triggers active_conditions re-evaluation and possible synthetic delete. This is the same pattern as existing single-subquery `changes_only` handling.
+
+#### Struct Changes Required
+
+**Modify `lib/electric/replication/changes.ex`:**
+
+**Directional** — shows new fields to add to each struct:
+```elixir
+defmodule Electric.Replication.Changes.NewRecord do
+  defstruct [
+    # ... existing fields ...
+    :move_tags,           # [[hash | nil]] - 2D array, one inner list per disjunct
+    :active_conditions,   # [boolean] - one per position
+    :removed_tags         # [[hash | nil]] - for updates only
+  ]
+end
+
+defmodule Electric.Replication.Changes.UpdatedRecord do
+  defstruct [
+    # ... existing fields ...
+    :move_tags,
+    :active_conditions,
+    :removed_tags  # Tags from old record that no longer apply
+  ]
+end
+
+defmodule Electric.Replication.Changes.DeletedRecord do
+  defstruct [
+    # ... existing fields ...
+    :move_tags,  # Tags at time of deletion (for client cleanup)
+    :active_conditions
+  ]
+end
+```
+
+### Phase 10: Querying Updates for Initial Snapshot
+
+**Modify** `lib/electric/shapes/querying.ex`
+
+> **IMPORTANT — condition_hashes vs wire tags:** `querying.ex` generates two different
+> hash-based outputs (see "Data Formats" above): (1) wire/API tags sent to clients
+> (slash-delimited per-disjunct via `make_tags`, embedded in JSON headers), and
+> (2) condition_hashes used internally for `moved_out_tags` filtering (one hash per DNF
+> position via `make_condition_hashes_select` — see Phase 12). `query_move_in` SELECTs
+> both: condition_hashes as a separate `text[]` column, and wire tags baked into the JSON.
+> Postgres deduplicates the MD5 calls across both columns.
+
+**Final** — `build_active_conditions_select` and `generate_subquery_condition_sql`:
+```elixir
+defp build_active_conditions_select(dnf_context) do
+  case dnf_context do
+    nil -> ""
+    %DnfContext{decomposition: %{subexpressions: subexpressions, position_count: position_count}} ->
+      conditions = Enum.map(0..(position_count - 1), fn pos ->
+        subexpr = Map.fetch!(subexpressions, pos)
+        sql = case subexpr do
+          %{is_subquery: true} ->
+            generate_subquery_condition_sql(subexpr, comparison_expressions, shape_dependencies)
+          %{is_subquery: false} ->
+            # Non-subquery conditions (field comparisons like status = 'active')
+            # MUST be converted to real SQL — returning "true" is WRONG for OR
+            # shapes where a row can be in the result via a different disjunct.
+            SqlGenerator.to_sql(subexpr.ast)
+        end
+        # For negated positions, wrap in NOT to produce the effective condition
+        # value. The decomposer stores the un-negated AST with negated=true,
+        # so we must apply the negation here to match the Elixir-side semantics
+        # in compute_active_conditions/4.
+        if subexpr.negated, do: "(NOT #{sql})", else: sql
+      end)
+
+      ", ARRAY[#{Enum.join(conditions, ", ")}]::boolean[] as active_conditions"
+  end
+end
+```
+
+For subquery subexpressions, use `extract_sublink_index/1` (see "Sublink Index Resolution" above) to resolve the dependency index from the AST:
+
+```elixir
+# For subquery subexpressions, generate SQL like:
+#   ("parent_id" IN (SELECT id FROM parent WHERE category = 'a'))
+defp generate_subquery_condition_sql(subexpr, comparison_expressions, shape_dependencies) do
+  # Use extract_sublink_index/1 — see "Sublink Index Resolution" above
+  sublink_index = extract_sublink_index(subexpr.ast)
+
+  dep_shape = if sublink_index, do: Enum.at(shape_dependencies, sublink_index)
+
+  if dep_shape do
+    subquery_section = rebuild_subquery_section(dep_shape)
+    column_sql = get_column_sql_for_subexpr(subexpr, comparison_expressions, sublink_index)
+
+    # Return the un-negated condition — negation is applied by
+    # build_active_conditions_select's outer wrapper so that all
+    # positions (subquery and non-subquery) are negated uniformly.
+    ~s[(#{column_sql} #{subquery_section})]
+  else
+    raise "Could not resolve dependency shape for sublink index #{inspect(sublink_index)}"
+  end
+end
+```
+
+```elixir
+defp build_headers_part({schema, table}, additional_headers, tags, active_conditions_sql) do
+  # Include active_conditions in headers JSON
+  # ...
+end
+```
+
+### Phase 11: Move Handling for Multiple Positions
+
+**Modify** `lib/electric/shapes/consumer/move_handling.ex`
+
+> **IMPORTANT:** This phase changes how move-in/move-out events are processed, but does NOT
+> update the `moved_out_tags` filtering that prevents stale query results. That is Phase 12,
+> which MUST be implemented immediately after — without it, `moved_out_tags` compares bare
+> hashes against slash-delimited tag strings and never matches, silently allowing stale
+> rows through.
+
+Uses `state.dnf_context` for position lookups and negation checks. Delegates WHERE clause
+generation (including DNF-aware exclusion clauses) to `SubqueryMoves.move_in_where_clause/5`
+(Phase 7a). This module handles the **orchestration** (which positions to activate/deactivate,
+when to query vs broadcast), not the SQL generation.
+
+**Directional** — orchestration flow, helper functions elided:
+```elixir
+def process_move_ins(%State{dnf_context: dnf_context} = state, dep_handle, new_values) do
+  # Find which positions this dependency affects via DnfContext
+  positions = DnfContext.get_positions_for_dependency(dnf_context, dep_handle)
+
+  # Separate negated from positive positions
+  negated_positions = Enum.filter(positions, &DnfContext.position_negated?(dnf_context, &1))
+  positive_positions = positions -- negated_positions
+
+  state =
+    if negated_positions != [] do
+      # Move-in to subquery = deactivation of NOT IN condition -> move-out
+      broadcast_deactivation(state, negated_positions, new_values)
+    else
+      state
+    end
+
+  if positive_positions != [] do
+    # Move-in to subquery = activation of IN condition -> query for new rows
+    # SubqueryMoves.move_in_where_clause handles DNF-aware exclusion (Phase 7a)
+    formed_where_clause = SubqueryMoves.move_in_where_clause(shape, dep_handle, values, dnf_context)
+    do_move_in_with_where(state, dep_handle, new_values, formed_where_clause)
+  else
+    state
+  end
+end
+
+def process_move_outs(%State{dnf_context: dnf_context} = state, dep_handle, removed_values) do
+  positions = DnfContext.get_positions_for_dependency(dnf_context, dep_handle)
+
+  negated_positions = Enum.filter(positions, &DnfContext.position_negated?(dnf_context, &1))
+  positive_positions = positions -- negated_positions
+
+  state =
+    if positive_positions != [] do
+      # Move-out from subquery = deactivation of IN condition -> broadcast move-out
+      broadcast_deactivation(state, positive_positions, removed_values)
+    else
+      state
+    end
+
+  if negated_positions != [] do
+    # Move-out from subquery = activation of NOT IN condition -> query for new rows
+    # Pass remove_not: true to strip NOT from the WHERE clause
+    formed_where_clause = SubqueryMoves.move_in_where_clause(shape, dep_handle, values, dnf_context, remove_not: true)
+    do_move_in_with_where(state, dep_handle, removed_values, formed_where_clause)
+  else
+    state
+  end
+end
+```
+
+#### Negation Handling in Move Processing
+
+Move handling inverts behavior for negated positions:
+- Move-in to subquery + negated position = **deactivation** (NOT IN now false)
+- Move-out from subquery + negated position = **activation** (NOT IN now true)
+
+**Same value at multiple positions** (e.g., `x IN sq OR x NOT IN sq`):
+```elixir
+# Positions: 0 (positive), 1 (negated)
+# Row with x='a' where 'a' is in subquery:
+tags: [[hash(a), nil], [nil, hash(a)]]  # Same hash, different positions
+active_conditions: [true, false]  # Opposite values
+```
+
+### Phase 12: Position-aware `moved_out_tags` (condition_hashes + Filtering)
+
+> **TL;DR:** Move-in snapshot files currently store wire-format tags (slash-delimited strings).
+> Phase 4 changes wire tags to a multi-disjunct format that breaks the existing filtering
+> comparison. Fix: store one hash per DNF position (`condition_hashes`) separately from the
+> JSON, make filtering position-aware, and bump the storage version. Two parts: (1) add
+> `make_condition_hashes_select` to `querying.ex` and SELECT it alongside JSON in
+> `query_move_in`, (2) change `moved_out_tags` in `move_ins.ex` from `%{name => MapSet}` to
+> `%{name => %{position => MapSet}}` and update storage filtering to match.
+
+**CRITICAL — correctness requirement, not optional.** Without this phase, move-out filtering
+is silently broken for all multi-disjunct shapes.
+
+The existing `moved_out_tags` mechanism (which prevents stale move-in query results from
+entering the log) compares bare hashes against values stored in snapshot files. When Phase 4
+changes wire tags to slash-delimited per-disjunct strings (embedded in JSON), the old
+approach of storing wire tags in the binary file and filtering against them no longer works.
+
+The solution uses the **condition_hashes** format (see "Data Formats" above): store one hash
+per DNF position separately from the JSON. Additionally, filtering must be position-aware:
+a move-out at position 0 should not affect position 1 even if both positions contain the
+same hash (e.g., `x IN sq1 OR x IN sq2` where both reference the same column).
+
+This phase has two parts:
+
+#### Part 1: Move-in snapshot files store condition_hashes (not tags)
+
+**Modify** `lib/electric/shapes/querying.ex`
+
+Add `make_condition_hashes_select/3` alongside the existing `make_tags/3`.
+Uses `extract_columns_from_ast/1` to get the column name(s) from each subexpression's
+AST — the subexpression type itself only stores `{ast, is_subquery, negated}`, so column
+extraction is done here at SQL generation time rather than at decomposition time.
+
+**Final** — `extract_columns_from_ast` and `make_condition_hashes_select`:
+```elixir
+# Extract column name(s) referenced by a subexpression's AST.
+# Uses Walker.reduce! to collect all Ref nodes with single-element paths
+# (column references). Refs with multi-element paths like ["$sublink", "0"]
+# are automatically excluded. Works for both simple `x IN (SELECT ...)` and
+# row-based `(x, y) IN (SELECT ...)` forms.
+defp extract_columns_from_ast(ast) do
+  Walker.reduce!(
+    ast,
+    fn
+      %Eval.Parser.Ref{path: [column_name]}, acc, _ctx ->
+        {:ok, [column_name | acc]}
+
+      _, acc, _ ->
+        {:ok, acc}
+    end,
+    []
+  )
+  |> Enum.reverse()
+end
+
+# make_tags:                    [[x, y], [nil, z]] -> ["md5(x)/md5(y)", "/md5(z)"]
+# make_condition_hashes_select: positions [x, y, z] -> ["md5(x)", "md5(y)", "md5(z)"]
+#
+# One hash per DNF position. No nils — every position has a condition with column(s)
+# that produce a hash for every row (NULL column values use the existing sentinel).
+defp make_condition_hashes_select(dnf_context, stack_id, shape_handle) do
+  escaped_prefix = escape_sql_string(to_string(stack_id) <> to_string(shape_handle))
+
+  dnf_context.decomposition.subexpressions
+  |> Enum.sort_by(fn {pos, _} -> pos end)
+  |> Enum.map(fn {_pos, subexpr} ->
+    columns = extract_columns_from_ast(subexpr.ast)
+
+    column_parts =
+      Enum.map(columns, fn col_name ->
+        col = pg_cast_column_to_text(col_name)
+        ~s['#{col_name}:' || #{pg_namespace_value_sql(col)}]
+      end)
+
+    ~s[md5('#{escaped_prefix}' || #{Enum.join(column_parts, " || ")})]
+  end)
+end
+```
+
+`query_move_in/6` SELECTs both condition_hashes (separate column for binary file)
+and wire-format tags (embedded in JSON headers). Postgres deduplicates the MD5 calls:
+
+**Directional** — shows SELECT structure, exact column order may differ:
+```elixir
+def query_move_in(conn, stack_id, shape_handle, shape, dnf_context, {where, params}) do
+  table = Utils.relation_to_sql(shape.root_table)
+
+  {json_like_select, _} =
+    json_like_select(shape, %{"is_move_in" => true}, stack_id, shape_handle)
+
+  key_select = key_select(shape)
+  condition_hashes_select =
+    make_condition_hashes_select(dnf_context, stack_id, shape_handle) |> Enum.join(", ")
+
+  query =
+    Postgrex.prepare!(
+      conn,
+      table,
+      ~s|SELECT #{key_select}, ARRAY[#{condition_hashes_select}]::text[], #{json_like_select} FROM #{table} WHERE #{where}|
+    )
+
+  Postgrex.stream(conn, query, params)
+  |> Stream.flat_map(& &1.rows)
+end
+```
+
+#### Part 2: `moved_out_tags` becomes position-aware
+
+**Modify** `lib/electric/shapes/consumer/move_ins.ex`
+
+Change the type from `%{name => MapSet}` to `%{name => %{position => MapSet}}`:
+
+**Directional** — type change and update logic:
+```elixir
+@type t() :: %__MODULE__{
+  moved_out_tags: %{move_in_name() => %{non_neg_integer() => MapSet.t(String.t())}}
+}
+
+def add_waiting(state, name, moved_values) do
+  # ... existing logic ...
+  # Initialize with empty map — positions are added by move_out_happened
+  moved_out_tags: Map.put(state.moved_out_tags, name, %{})
+end
+
+def move_out_happened(state, position, new_hashes) do
+  moved_out_tags =
+    Map.new(state.moved_out_tags, fn {name, per_pos_tags} ->
+      updated = Map.update(per_pos_tags, position, new_hashes, &MapSet.union(&1, new_hashes))
+      {name, updated}
+    end)
+  %{state | moved_out_tags: moved_out_tags}
+end
+```
+
+**Modify** `lib/electric/shapes/consumer/move_handling.ex`
+
+Pass position through to `move_out_happened`. Extract position from control message patterns:
+
+**Directional** — extraction approach, exact message format depends on Phase 7b:
+```elixir
+# Move-out: extract {position, hashes} from control message patterns
+patterns_by_pos =
+  message.headers.patterns
+  |> Enum.group_by(& &1[:pos], & &1[:value])
+
+Enum.each(patterns_by_pos, fn {position, hashes} ->
+  MoveIns.move_out_happened(state.move_handling_state, position, MapSet.new(hashes))
+end)
+
+# At query_complete, pass the per-position map to storage filtering:
+state.move_handling_state.moved_out_tags[name] || %{}
+```
+
+**Modify** `lib/electric/shape_cache/storage.ex` — update type spec:
+
+```elixir
+condition_hashes_to_skip :: %{non_neg_integer() => MapSet.t(String.t())}
+```
+
+**Modify** `lib/electric/shape_cache/pure_file_storage.ex` and `in_memory_storage.ex`
+
+Replace `all_parents_moved_out?/2` with position-aware filtering.
+
+On read, decode the sequential binary condition_hashes into a map for O(1) lookup:
+
+**Directional** — binary format handling:
+```elixir
+defp read_condition_hashes(file, hash_count) do
+  for i <- 0..(hash_count - 1)//1, into: %{} do
+    <<hash_size::16>> = IO.binread(file, 2)
+    <<hash::binary-size(hash_size)>> = IO.binread(file, hash_size)
+    {i, hash}
+  end
+end
+```
+
+Position-aware filtering — ANY match means skip (the move-in query's exclusion
+clause already filtered out rows present via other disjuncts, so any match at a
+tracked position means this row was returned for a now-invalid reason):
+
+**Final** — `should_skip_for_moved_out?`:
+```elixir
+defp should_skip_for_moved_out?(_condition_hashes, condition_hashes_to_skip)
+     when map_size(condition_hashes_to_skip) == 0,
+     do: false
+
+defp should_skip_for_moved_out?(condition_hashes, condition_hashes_to_skip) do
+  Enum.any?(condition_hashes_to_skip, fn {position, skip_set} ->
+    case condition_hashes do
+      %{^position => hash} -> MapSet.member?(skip_set, hash)
+      _ -> false
+    end
+  end)
+end
+```
+
+Bump `@version` from 1 -> 2 in `pure_file_storage.ex` to invalidate old-format snapshots. This means in-flight shapes will restart with fresh snapshots on deployment — a brief interruption, not data loss.
+
+Rename `tags` variables in binary read/write functions to `condition_hashes` for clarity.
+
+#### Why this is easy to miss
+
+This phase fixes the **interaction** between new multi-disjunct tag formats (Phase 4) and
+pre-existing race-condition filtering in the storage layer. Each piece works correctly in
+isolation — the bug only manifests when wire-format tags (slash-delimited strings in JSON)
+are compared against bare hashes at filtering time. The solution is to store
+condition_hashes (per-position hashes) separately from the JSON, so filtering never touches
+the wire format. No test will catch this unless it specifically exercises the
+move-out-while-move-in-in-flight race condition with a multi-disjunct shape.
+
+#### Files changed
+
+- `querying.ex` — add `extract_columns_from_ast/1` and `make_condition_hashes_select/3`, SELECT condition_hashes as separate column alongside JSON with embedded wire tags in `query_move_in/6`
+- `move_ins.ex` — change `moved_out_tags` type to `%{name => %{position => MapSet}}`, update `add_waiting/2` and `move_out_happened/3`
+- `move_handling.ex` — extract position from control message patterns, pass to `move_out_happened`
+- `storage.ex` — update `condition_hashes_to_skip` type in behaviour spec
+- `pure_file_storage.ex` — rename binary tag read/write to `condition_hashes`, decode into map on read, replace `all_parents_moved_out?` with `should_skip_for_moved_out?`, bump `@version`
+- `in_memory_storage.ex` — same filtering change
+- `storage_implementations_test.exs` — test position-aware filtering
+
+### Phase 13: Remove Shape Invalidation
+
+**Modify** `lib/electric/shapes/consumer.ex`
+
+This phase removes the entire `should_invalidate?` block, which currently guards on four conditions:
+
+1. `not tagged_subqueries_enabled?` — retained as the feature flag check
+2. `state.or_with_subquery?` — removed; DNF decomposition handles OR correctly
+3. `state.not_with_subquery?` — removed; negation is handled via polarity in the DNF
+4. `length(state.shape.shape_dependencies) > 1` — **also removed**; this was the guard
+   preventing *any* multi-subquery shape from working, even pure AND. With position-based
+   tagging and `DnfContext`, we can correctly attribute move-ins/move-outs to the specific
+   dependency that caused them via `dep_handle`, so this blanket restriction is no longer needed.
+
+**Directional** — shows the simplified handler after invalidation removal:
+```elixir
+def handle_info({:materializer_changes, dep_handle, %{move_in: move_in, move_out: move_out}}, state) do
+  feature_flags = Electric.StackConfig.lookup(state.stack_id, :feature_flags, [])
+  tagged_subqueries_enabled? = "tagged_subqueries" in feature_flags
+
+  if not tagged_subqueries_enabled? do
+    stop_and_clean(state)
+  else
+    {state, notification} =
+      state
+      |> MoveHandling.process_move_ins(dep_handle, move_in)
+      |> MoveHandling.process_move_outs(dep_handle, move_out)
+
+    notify_new_changes(state, notification)
+
+    {:noreply, state}
+  end
+end
+```
+
+### Phase 14: Elixir Client Updates
+
+The Elixir client (`packages/elixir-client`) is our example client implementation and is used
+in the integration tests. It must handle the new wire format (slash-delimited tags,
+`active_conditions`, position-based move-in/move-out) correctly.
+
+**Modify** `packages/elixir-client/lib/electric/client/tag_tracker.ex`
+
+1. **Slash-delimited tag normalization**: Tags arrive as slash-delimited strings
+   (e.g., `"hash1/hash2/"`, `"//hash3"`). Normalize to 2D arrays internally:
+   `["hash1/hash2/", "//hash3"]` -> `[["hash1", "hash2", ""], ["", "", "hash3"]]` -> replace `""` with `nil`
+
+2. **`removed_tags` normalization**: `removed_tags` arrive in the **same slash-delimited
+   format** as `tags`. They must be normalized through the same split pipeline before
+   comparison against internal position hashes. Without this, `filter_removed_tags` compares
+   bare hashes against raw slash-delimited strings — never matches.
+
+3. **DNF-based visibility evaluation**: `row_visible?/2` evaluates OR over disjuncts, where
+   each disjunct is AND over non-null `active_conditions` positions.
+
+4. **Position-based `tag_to_keys` index**: Index by `{position, hash_value}` tuples for
+   efficient move-in/move-out lookups.
+
+5. **Move-out synthetic deletes**: `generate_synthetic_deletes/4` deactivates positions
+   matching `{pos, value}` patterns and generates deletes only when no disjunct evaluates
+   to true.
+
+6. **Move-in activation**: `handle_move_in/4` activates positions for matching keys.
+
+```elixir
+# Key normalization — removed_tags must use the same pipeline as tags
+removed_tags_set =
+  removed_tags
+  |> normalize_tags()
+  |> Enum.flat_map(fn disjunct -> Enum.reject(disjunct, &is_nil/1) end)
+  |> MapSet.new()
+```
+
+**Modify** `packages/elixir-client/lib/electric/client/message/headers.ex`
+
+- Add `active_conditions` field to `Headers` struct
+- Parse `active_conditions` from incoming messages in `from_message/2`
+
+**Tests**: `packages/elixir-client/test/electric/client/tag_tracker_test.exs`
+
+```elixir
+describe "tag_tracker with DNF wire format" do
+  test "normalizes slash-delimited tags to 2D structure"
+  test "removed_tags in slash-delimited format are correctly filtered"
+  test "row_visible? evaluates DNF correctly"
+  test "generate_synthetic_deletes only deletes when all disjuncts unsatisfied"
+  test "handle_move_in activates correct positions"
+  test "position-based tag_to_keys index for multi-disjunct shapes"
+end
+```
+
+---
+
+## Test Strategy
+
+### Unit Tests
+
+#### 1. DNF Decomposer Tests (`test/electric/replication/eval/decomposer_test.exs`)
+
+```elixir
+describe "decompose/1" do
+  test "simple AND - single conjunction" do
+    # WHERE x IN subquery AND y = 1
+    # Expected: [[{0, :positive}, {1, :positive}]]
+  end
+
+  test "simple OR - multiple disjuncts" do
+    # WHERE x IN subquery1 OR y IN subquery2
+    # Expected: [[{0, :positive}], [{1, :positive}]]
+  end
+
+  test "NOT with subquery" do
+    # WHERE x NOT IN subquery
+    # Expected: [[{0, :negated}]]
+  end
+
+  test "De Morgan's law - NOT (A AND B)" do
+    # WHERE NOT (x IN sq1 AND y IN sq2)
+    # Expected: [[{0, :negated}], [{1, :negated}]]
+  end
+
+  test "De Morgan's law - NOT (A OR B)" do
+    # WHERE NOT (x IN sq1 OR y IN sq2)
+    # Expected: [[{0, :negated}, {1, :negated}]]
+  end
+
+  test "complex mixed expression" do
+    # WHERE (x IN sq1 AND status='active') OR y IN sq2
+    # Expected: [[{0, :positive}, {1, :positive}], [{2, :positive}]]
+  end
+
+  test "nested NOT - double negation" do
+    # WHERE NOT NOT (x IN subquery)
+    # Expected: [[{0, :positive}]]
+  end
+
+  test "complexity guard rejects excessive disjuncts" do
+    # Build expression that would exceed @max_disjuncts
+    # Expected: {:error, :too_complex}
+  end
+end
+```
+
+#### 2. Active Conditions Tests (`test/electric/shapes/where_clause_test.exs`)
+
+```elixir
+describe "compute_active_conditions/3" do
+  test "all conditions true" do
+    # Given: x='a', sq1 contains 'a', status='active'
+    # Expected: [true, true]
+  end
+
+  test "mixed true/false conditions" do
+    # Given: x='a', sq1 contains 'a', sq2 does NOT contain 'b'
+    # Expected: [true, false]
+  end
+
+  test "negated position inverts result" do
+    # Given: x='a', sq1 contains 'a' (negated position)
+    # Expected: active_conditions[0] = false (because NOT IN fails)
+  end
+end
+
+describe "evaluate_dnf/2" do
+  test "OR - any disjunct true means included" do
+    # active_conditions: [true, false]
+    # disjuncts_positions: [[0], [1]]
+    # Expected: true (first disjunct satisfied)
+  end
+
+  test "AND - all positions in conjunction must be true" do
+    # active_conditions: [true, false]
+    # disjuncts_positions: [[0, 1]]
+    # Expected: false (second position fails)
+  end
+end
+```
+
+### Integration Tests (`test/electric/plug/subquery_router_test.exs`)
+
+#### 3. Basic OR with Subqueries
+
+```elixir
+describe "OR with subqueries" do
+  setup [:with_unique_db, :with_subquery_tables, :with_sql_execute]
+  setup :with_complete_stack
+
+  @tag with_sql: [
+    "INSERT INTO projects (id, active) VALUES ('p1', true)",
+    "INSERT INTO users (id, admin) VALUES ('u1', true)",
+    "INSERT INTO tasks (id, project_id, assigned_to) VALUES ('t1', 'p1', null)",
+    "INSERT INTO tasks (id, project_id, assigned_to) VALUES ('t2', null, 'u1')",
+    "INSERT INTO tasks (id, project_id, assigned_to) VALUES ('t3', 'p2', 'u2')"
+  ]
+  test "initial snapshot includes rows matching either condition", ctx do
+    # WHERE project_id IN (active projects) OR assigned_to IN (admin users)
+    # t1 matches first condition, t2 matches second, t3 matches neither
+  end
+
+  test "tags have correct structure for multiple disjuncts", ctx do
+    # Verify tags: ["hash(project_id)/", "/hash(assigned_to)"]
+  end
+
+  test "active_conditions array included in response", ctx do
+    # Verify headers include active_conditions: [true, false] etc.
+  end
+end
+```
+
+#### 4. NOT with Subqueries
+
+```elixir
+describe "NOT with subqueries" do
+  @tag with_sql: [
+    "INSERT INTO archived_projects (id) VALUES ('p1')",
+    "INSERT INTO tasks (id, project_id) VALUES ('t1', 'p1')",
+    "INSERT INTO tasks (id, project_id) VALUES ('t2', 'p2')"
+  ]
+  test "NOT IN excludes rows when value in subquery", ctx do
+    # WHERE project_id NOT IN (SELECT id FROM archived_projects)
+    # t1 excluded (p1 is archived), t2 included
+  end
+
+  test "move-in to NOT IN subquery triggers move-out", ctx do
+    # Insert 'p2' into archived_projects
+    # t2 should receive synthetic delete
+  end
+
+  test "move-out from NOT IN subquery triggers move-in", ctx do
+    # Delete 'p1' from archived_projects
+    # t1 should be queried and sent to client
+  end
+end
+```
+
+#### 5. Move-in Without Query (Row Already Present)
+
+```elixir
+describe "move-in without Postgres query" do
+  @tag with_sql: [
+    "INSERT INTO projects (id, active) VALUES ('p1', false)",
+    "INSERT INTO users (id, admin) VALUES ('u1', true)",
+    "INSERT INTO tasks (id, project_id, assigned_to) VALUES ('t1', 'p1', 'u1')"
+  ]
+  test "no query when row already in shape for another disjunct", ctx do
+    # t1 is in shape because assigned_to IN (admin users)
+    # Activate p1's project -> move-in for first disjunct
+    # Should broadcast only, not query Postgres for t1
+  end
+
+  test "active_conditions updates without new insert message", ctx do
+    # Verify client receives move-in broadcast
+    # t1's active_conditions changes from [false, true] to [true, true]
+    # No duplicate insert for t1
+  end
+end
+```
+
+#### 6. Move-out with Row Still In Shape
+
+```elixir
+describe "move-out with row still in shape" do
+  @tag with_sql: [
+    "INSERT INTO projects (id, active) VALUES ('p1', true)",
+    "INSERT INTO users (id, admin) VALUES ('u1', true)",
+    "INSERT INTO tasks (id, project_id, assigned_to) VALUES ('t1', 'p1', 'u1')"
+  ]
+  test "row stays when one disjunct deactivates but another satisfied", ctx do
+    # t1 matches both disjuncts
+    # Deactivate p1's project -> first disjunct false
+    # Row stays because second disjunct (admin user) still true
+  end
+
+  test "row removed only when all disjuncts false", ctx do
+    # Deactivate p1's project AND remove u1 from admins
+    # Now t1 matches neither disjunct -> synthetic delete
+  end
+end
+```
+
+#### 7. Complex Expressions
+
+```elixir
+describe "complex boolean expressions" do
+  test "nested AND within OR" do
+    # WHERE (project_id IN sq1 AND status = 'active') OR assigned_to IN sq2
+  end
+
+  test "OR of two subqueries on same column" do
+    # WHERE parent_id IN (SELECT id FROM parent WHERE category = 'a')
+    #    OR parent_id IN (SELECT id FROM parent WHERE category = 'b')
+    # Both subqueries reference parent_id — sublink index resolution must
+    # use AST extraction (not column-name matching) to distinguish them.
+    # Row with parent_id=1 (category='a'): active_conditions = [true, false]
+    # Row with parent_id=2 (category='b'): active_conditions = [false, true]
+    # Tags must also be distinct per disjunct (different slash positions).
+  end
+
+  test "De Morgan: NOT (A AND B)" do
+    # WHERE NOT (project_id IN sq1 AND status = 'active')
+    # Equivalent to: project_id NOT IN sq1 OR status != 'active'
+  end
+
+  test "De Morgan: NOT (A OR B)" do
+    # WHERE NOT (project_id IN sq1 OR assigned_to IN sq2)
+    # Equivalent to: project_id NOT IN sq1 AND assigned_to NOT IN sq2
+  end
+
+  test "mixed positive and negated at same position" do
+    # WHERE x IN sq1 OR x NOT IN sq1
+    # Always true, but tests position handling
+  end
+end
+```
+
+#### 8. Protocol Versioning
+
+```elixir
+describe "protocol versioning" do
+  test "v1 clients rejected for complex WHERE with OR subqueries", ctx do
+    # Request with protocol v1 header
+    # WHERE with OR and subqueries
+    # Should return 400 error
+  end
+
+  test "v2 clients accepted for complex WHERE", ctx do
+    # Same request with protocol v2
+    # Should succeed
+  end
+
+  test "simple single-subquery works with v1", ctx do
+    # Backward compatibility for existing shapes
+  end
+end
+```
+
+#### 9. Edge Cases
+
+```elixir
+describe "edge cases" do
+  test "NULL values in subquery columns" do
+    # Row with NULL project_id
+    # NULL IN (...) is always NULL/false
+  end
+
+  test "empty subquery results" do
+    # Subquery returns no rows
+    # IN empty = false, NOT IN empty = true
+  end
+
+  test "concurrent move-ins at different positions" do
+    # Two dependency shapes change simultaneously
+  end
+
+  test "shape restart preserves position mapping" do
+    # Verify deterministic position assignment
+  end
+end
+```
+
+---
+
+## Order of Operations
+
+```
+Phase 1: DNF Decomposer
+    |
+    +---> Phase 2: SQL Generator (no dependencies beyond Parser AST types)
+    |
+    v
+Phase 3: DnfContext (depends on Phase 1)
+    |
+    v
+Phase 4: Shape tag_structure + fill_move_tags (depends on Phase 1, NO new Shape fields)
+    |
+    +---> Phase 5: Consumer State — holds DnfContext (depends on Phase 3)
+    |         |
+    |         +---> Phase 6: Active Conditions (depends on Phases 3, 5)
+    |         |         |
+    |         |         +---> Phase 9: Change Handling (depends on Phase 6, uses DnfContext)
+    |         |
+    |         +---> Phase 11: Move Handling (depends on Phases 5, 7, uses DnfContext)
+    |                   |
+    |                   +---> Phase 12: Position-aware moved_out_tags
+    |                   |     ^^^ REQUIRED for correctness — without this, moved_out_tags
+    |                   |         filtering is silently broken for multi-disjunct shapes
+    |                   |
+    |                   +---> Phase 13: Remove Invalidation (depends on Phase 11)
+    |
+    +---> Phase 7: Move Messages + Exclusion Clauses (depends on Phase 3)
+    |
+    +---> Phase 8: Log Items (depends on Phase 4 for tag format)
+    |
+    +---> Phase 10: Querying (depends on Phases 2, 3, 7)
+
+Phase 14: Elixir Client (depends on Phases 7, 8 for wire format definition)
+```
+
+**Implementation order** (phases are numbered to match):
+
+| Step | Phase | Name | Key dependency |
+|------|-------|------|----------------|
+| 1 | Phase 1 | DNF Decomposer | foundational, no dependencies |
+| 2 | Phase 2 | SQL Generator | standalone, depends only on Parser AST types |
+| 3 | Phase 3 | DnfContext | wraps decomposer output |
+| 4 | Phase 4 | Shape tag_structure + fill_move_tags | uses decomposer, **no new Shape struct fields** |
+| 5 | Phase 5 | Consumer State | holds DnfContext, built at init |
+| 6 | Phase 6 | Active Conditions | uses DnfContext |
+| 7 | Phase 7 | Move Messages + Exclusion Clauses | uses DnfContext for exclusion |
+| 8 | Phase 8 | Log Items | 2D-to-wire tag conversion |
+| 9 | Phase 9 | Change Handling | uses DnfContext, replaces `includes_record?` |
+| 10 | Phase 10 | Querying | uses DnfContext + SqlGenerator |
+| 11 | Phase 11 | Move Handling | uses DnfContext for position routing |
+| 12 | Phase 12 | Position-aware moved_out_tags | **MUST follow Phase 11 immediately** |
+| 13 | Phase 13 | Remove Invalidation | final cleanup |
+| 14 | Phase 14 | Elixir Client | must handle new wire format; used by integration tests |
+
+---
+
+## Gaps and Risks
+
+### Technical Risks
+
+1. **DNF Explosion**: Complex WHERE clauses can produce exponentially many disjuncts
+   - Mitigation: Complexity guard in `Decomposer.decompose/1` — reject shapes where `length(disjuncts) > 100` with a descriptive error at shape creation time (400 response)
+   - Document reasonable limits (~10 subqueries)
+
+2. **Position Stability**: If positions change between shape restarts, clients will have stale `active_conditions`
+   - Mitigation: Position assignment must be deterministic (sort by AST traversal order)
+
+3. **Concurrent Move-ins**: Multiple positions activating simultaneously
+   - Mitigation: Use existing snapshot-based ordering mechanism
+   - Test: Add integration tests for concurrent scenarios
+
+4. **NOT IN Edge Cases**: `NULL` handling in NOT IN is tricky in SQL
+   - Mitigation: Follow PostgreSQL semantics exactly
+   - Test: Include NULL value tests
+
+5. **Avoid re-decomposition within consumer lifetime**: `Decomposer.decompose/1` is called at two lifecycle points (shape creation + consumer startup — see "Single Decomposition, Two Lifecycle Points" above). Within the consumer's lifetime, always use `DnfContext`'s cached decomposition. Do not re-decompose in `querying.ex`, `subquery_moves.ex`, `move_handling.ex`, etc. — accept the decomposition from DnfContext instead.
+
+6. **Single-pass active_conditions**: Per the RFC, `compute_active_conditions` should *replace* the `includes_record?` call — not run alongside it. Avoid double evaluation in the replication stream path.
+
+7. **Non-subquery conditions require real SQL generation (Phase 2)**: For OR shapes, a row can be in the snapshot result via one disjunct while another disjunct's non-subquery condition is false. The `active_conditions` SELECT column for that position must evaluate to `false`, not `true`. Returning a hardcoded `"true"` for non-subquery conditions is **wrong** — it makes the client think both disjuncts are satisfied when only one is. `SqlGenerator.to_sql/1` (Phase 2) converts the AST back to SQL for these positions. It raises `ArgumentError` for unsupported AST nodes so missing operators are caught at shape creation time, not at query time.
+
+8. **condition_hashes vs wire tags (Phase 12)**: The binary move-in snapshot files must store condition_hashes (per-position hashes) separately from the JSON that contains wire-format tags. If filtering uses the wire-format tags instead, bare hashes are compared against slash-delimited strings and never match — a silent correctness bug. See Phase 12 for the full solution.
+
+9. **Sublink index resolution by column name is ambiguous**: When generating SQL for subquery conditions, the sublink index MUST be extracted from the AST node's `sublink_membership_check` function, NOT resolved by matching column names. See "Sublink Index Resolution" above for the authoritative explanation and `extract_sublink_index/1` implementation. This applies to both `querying.ex` (Phase 10) and `subquery_moves.ex` (Phase 7).
+   - Test: "OR of two subqueries on same column" (see Test Strategy, Complex Expressions)
+
+10. **Decomposition failure at shape creation**: If `Decomposer.decompose/1` returns `{:error, reason}`, shape creation must fail with a 400 response and descriptive error message. There is no silent fallback to invalidation — users should know their WHERE clause is unsupported.
+
+### Protocol Compatibility
+
+1. **V1 Clients**: Must reject complex WHERE clauses for v1 protocol
+   - Implementation: Protocol version check in shape validation (Phase 3)
+   - Return 400 error with descriptive message
+
+2. **Message Format**: New `active_conditions` field is additive
+   - V1 clients will ignore unknown fields (safe)
+   - V2 clients must handle missing `active_conditions` (for simple shapes)
+
+### Performance Considerations
+
+1. **Active Conditions Computation**: Done per-row in replication stream
+   - Profile: Measure overhead vs current `includes_record?`
+   - Optimize: Cache subquery results per transaction
+
+2. **Tag Storage**: Multiple disjuncts = larger tags array
+   - Profile: Measure storage overhead
+   - Consider: Sparse representation if many positions
+
+3. **Move-in Queries**: "Not in other disjuncts" clause may be expensive
+   - Profile: EXPLAIN ANALYZE on typical queries
+   - Optimize: Index recommendations for common patterns
+
+---
+
+## Critical Files for Implementation
+
+- `lib/electric/replication/eval/decomposer.ex` - **(new)** DNF decomposition of WHERE clause ASTs
+- `lib/electric/replication/eval/sql_generator.ex` - **(new)** Converts AST back to SQL — used by `querying.ex` for non-subquery `active_conditions` and by `subquery_moves.ex` for exclusion clauses
+- `lib/electric/shapes/consumer/dnf_context.ex` - **(new)** DNF state container, built from Shape at consumer startup
+- `lib/electric/shapes/shape/subquery_moves.ex` - Core tag and move message generation, **move-in WHERE clause + DNF-aware exclusion clauses**
+- `lib/electric/shapes/shape.ex` - `fill_move_tags` (2D array output), `tag_structure` — **no new struct fields**
+- `lib/electric/shapes/consumer/move_handling.ex` - Move-in/out orchestration (position routing, negation inversion), delegates SQL generation to `subquery_moves.ex`
+- `lib/electric/shapes/where_clause.ex` - Record filtering and `active_conditions`
+- `lib/electric/log_items.ex` - Message format with `active_conditions`, 2D-to-wire tag conversion
+- `lib/electric/shapes/querying.ex` - SQL generation for snapshots and move-in queries. Move-in queries SELECT condition_hashes (separate column) + wire tags (in JSON). Accepts DnfContext, delegates non-subquery AST-to-SQL to `SqlGenerator`
+- `packages/elixir-client/lib/electric/client/tag_tracker.ex` - Client-side tag tracking, DNF evaluation, synthetic deletes
+- `packages/elixir-client/lib/electric/client/message/headers.ex` - Client message header parsing
+
+## Additional Test Coverage
+
+### Snapshot Positioning Tests
+
+```elixir
+describe "snapshot positioning for move-in queries" do
+  test "move-in query runs in REPEATABLE READ isolation" do
+    # Verify transaction isolation level
+  end
+
+  test "pg_current_snapshot captured and used for filtering" do
+    # Insert row, start move-in query, insert another row during query
+    # Second row should not appear in move-in results (filtered by snapshot)
+  end
+
+  test "touch tracking prevents duplicate rows" do
+    # Row modified in stream after move-in query started
+    # Move-in query returns that row
+    # Stream change should be used, query result skipped
+  end
+
+  test "move-in results positioned correctly relative to stream" do
+    # Move-in query completes while stream has concurrent changes
+    # Results should appear at correct log offset
+  end
+end
+```
+
+### Resume and `changes_only` Mode Tests
+
+```elixir
+describe "resume with active_conditions" do
+  test "resumed stream includes active_conditions on changes" do
+    # Get initial data, disconnect, reconnect with resume
+    # Verify subsequent changes include active_conditions
+  end
+
+  test "move-out during disconnect generates synthetic delete on resume" do
+    # Disconnect, deactivate a disjunct, reconnect
+    # Should receive synthetic delete
+  end
+end
+
+describe "changes_only mode with DNF" do
+  test "inserts include tags and active_conditions" do
+    # Start with changes_only, insert row
+    # Verify headers include both
+  end
+
+  test "updates include tags, removed_tags, and active_conditions" do
+    # changes_only mode, update that changes tag-relevant column
+    # Verify all three headers present
+  end
+
+  test "move-in broadcasts for unknown rows are handled gracefully" do
+    # changes_only client receives move-in for row not in local state
+    # Client checks tracked keys map — key not present, broadcast ignored
+    # Should ignore without error
+  end
+end
+```
+
+### `removed_tags` Tests
+
+```elixir
+describe "removed_tags on updates" do
+  test "update changing tag-relevant column includes removed_tags" do
+    # Row with project_id='p1', update to project_id='p2'
+    # Should include removed_tags with hash(p1)
+  end
+
+  test "update not changing tag-relevant column has empty removed_tags" do
+    # Row with project_id='p1', update value column
+    # removed_tags should be empty or absent
+  end
+
+  test "update changing multiple tag-relevant columns" do
+    # Row with project_id='p1', assigned_to='u1'
+    # Update both columns
+    # removed_tags should include both old hashes
+  end
+end
+```
+
+### Additional Edge Cases
+
+```elixir
+describe "additional edge cases" do
+  test "same subquery referenced at multiple positions" do
+    # WHERE x IN sq1 OR y IN sq1
+    # Single dependency affects two positions
+    # Move-in should handle both positions
+  end
+
+  test "DNF complexity guard" do
+    # Extremely complex WHERE clause
+    # Should return error before explosion
+  end
+
+  test "double negation simplification" do
+    # WHERE NOT NOT (x IN sq)
+    # Should simplify to positive position
+  end
+
+  test "tautology detection" do
+    # WHERE x IN sq OR x NOT IN sq
+    # Should recognize as always-true (optional optimization)
+  end
+end
+```
+
+---
+
+## Migration Checklist
+
+Before enabling complex subquery shapes in production:
+
+1. [ ] All clients updated to handle nested tag format
+2. [ ] All clients updated to handle `active_conditions` field
+3. [ ] All clients updated to handle position-based move-in/move-out messages
+4. [ ] Protocol version negotiation implemented and tested
+5. [ ] Existing shapes will continue working (backward compatibility verified)
+6. [ ] Performance profiling completed for:
+   - [ ] `compute_active_conditions` overhead
+   - [ ] Multi-disjunct tag storage size
+   - [ ] Move-in exclusion query performance
+7. [ ] Shape handle invalidation strategy decided (if needed)

--- a/packages/sync-service/IMPLEMENTATION_PLAN.md
+++ b/packages/sync-service/IMPLEMENTATION_PLAN.md
@@ -62,9 +62,9 @@ Since decomposition is deterministic (same AST always produces the same result),
 
 **Within the consumer's lifetime**, always use `DnfContext`'s cached decomposition. Never re-decompose in `querying.ex`, `subquery_moves.ex`, `move_handling.ex`, etc. — accept the decomposition from DnfContext instead.
 
-### Data Formats: condition_hashes, tags, and wire format
+### Data Formats: condition_hashes and tags
 
-There are three distinct representations of per-row hashed values, each optimised for its consumer. All three are computed independently from the underlying column values — none is derived from another in code.
+There are two distinct representations of per-row hashed values, each optimised for its consumer. Both are computed independently from the underlying column values — neither is derived from the other in code.
 
 #### 1. condition_hashes
 
@@ -78,18 +78,7 @@ One hash per DNF position, stored as a map with integer keys for O(1) positional
 - **Purpose**: position-aware filtering — "is the hash at position P in the moved-out set?"
 - **No nils**: every DNF position has exactly one condition with column(s) that produce a hash for every row (NULL column values get the existing `"NULL"` sentinel, non-null get `"v:" <> value`)
 
-#### 2. tags (internal 2D array)
-
-One inner list per disjunct, with `nil` at non-participating positions:
-
-```elixir
-[["hash_x", "hash_status", nil], [nil, nil, "hash_y"]]
-```
-
-- **Where**: `move_tags` on change structs, `fill_move_tags` output, consumer processing
-- **Purpose**: per-disjunct tag tracking for client-side inclusion evaluation
-
-#### 3. wire/API tags (slash-delimited per disjunct)
+#### 2. tags (slash-delimited per disjunct)
 
 One string per disjunct, positions separated by `/`:
 
@@ -97,16 +86,18 @@ One string per disjunct, positions separated by `/`:
 {"tags": ["hash_x/hash_status/", "//hash_y"]}
 ```
 
-- **Where**: JSON headers sent to clients over HTTP, embedded in snapshot/move-in JSON by Postgres
-- **Purpose**: compact JSON representation for the wire
+- **Where**: `move_tags` on change structs, `fill_move_tags` output, JSON headers sent to clients over HTTP, embedded in snapshot/move-in JSON by Postgres
+- **Purpose**: per-disjunct tag tracking — used everywhere from change structs through consumer processing to the wire. A single canonical format avoids unnecessary conversions.
+
+Empty segments represent non-participating positions (e.g. `//hash_y` means positions 0 and 1 are absent, position 2 has `hash_y`). This is unambiguous because hash values are always non-empty (MD5 hex or `"v:"`/`"NULL"` prefixed).
 
 #### How each format is computed
 
-- **Postgres SQL queries** (snapshot + move-in) generate both condition_hashes (as a separate `text[]` column) and wire-format tags (baked into the JSON headers string) directly from the underlying column values. The MD5 expressions are shared — Postgres deduplicates identical subexpressions.
-- **Binary snapshot write** stores condition_hashes from the separate column. The JSON column (with wire tags already embedded) is stored alongside.
+- **Postgres SQL queries** (snapshot + move-in) generate both condition_hashes (as a separate `text[]` column) and tags (baked into the JSON headers string) directly from the underlying column values. The MD5 expressions are shared — Postgres deduplicates identical subexpressions.
+- **Binary snapshot write** stores condition_hashes from the separate column. The JSON column (with tags already embedded) is stored alongside.
 - **Binary snapshot read** decodes sequential condition_hashes into `%{position => hash}` map for filtering.
-- **`fill_move_tags`** in `shape.ex` computes the **internal 2D array** directly from the record for replication-stream changes.
-- **`log_items.ex`** converts the internal 2D array to slash-delimited wire format when building log entry headers (via `Enum.map(tags, &Enum.join(&1, "/"))`).
+- **`fill_move_tags`** in `shape.ex` computes slash-delimited tag strings directly from the record for replication-stream changes. No intermediate list format — `make_tags_from_pattern` produces the wire format immediately.
+- **`log_items.ex`** passes tags through to headers as-is (no conversion needed).
 
 #### Binary move-in snapshot file format
 
@@ -159,7 +150,7 @@ This function is used in both `querying.ex` (for `active_conditions` SELECT colu
 | `lib/electric/shapes/shape.ex` | `fill_move_tags`, `convert_change` | Multi-disjunct tags — **no new struct fields** |
 | `lib/electric/shapes/where_clause.ex` | `includes_record?` boolean check | Per-position evaluation |
 | `lib/electric/shapes/querying.ex` | SQL for initial data, tags | Add `active_conditions` columns, add `condition_hashes` SELECT for move-in queries, accept DnfContext |
-| `lib/electric/log_items.ex` | Formats messages with tags | Add `active_conditions` to headers, convert 2D tags to wire format |
+| `lib/electric/log_items.ex` | Formats messages with tags | Add `active_conditions` to headers, remove `tags_to_wire` (tags already in wire format) |
 | `lib/electric/replication/eval/parser.ex` | Parses WHERE, handles SubLinks | No changes needed |
 | `lib/electric/replication/eval/walker.ex` | AST traversal | No changes needed |
 | `packages/elixir-client/.../tag_tracker.ex` | Client-side tag tracking, DNF eval, synthetic deletes | Slash-delimited normalization, `removed_tags` parsing, position-based indexing |
@@ -565,18 +556,18 @@ Worked example for `WHERE (x IN sq1 AND status = 'active') OR y IN sq2`:
 - `tag_structure`: `[["x", "status", nil], [nil, nil, "y"]]`
 
 For a row with `x='a', status='active', y='b'`, `fill_move_tags` produces:
-`[["hash(a)", "hash(active)", nil], [nil, nil, "hash(b)"]]`
+`["hash(a)/hash(active)/", "//hash(b)"]`
 
 This means the non-subquery hash is deterministic for rows matching the condition (all rows with `status = 'active'` produce the same hash at position 1). This is correct — the hash identifies the row's contribution at that position, and the value must match between Postgres-generated hashes (`make_condition_hashes_select`) and Elixir-generated hashes (`fill_move_tags`), which it does because both hash the raw column value using the same `namespace_value` + MD5 formula.
 
-2. Update `fill_move_tags/4` to produce the **internal 2D array** format (not slash-delimited strings). The existing `make_tags_from_pattern` currently calls `Enum.join("/")` to produce slash-delimited strings; this changes to return lists directly:
+2. Update `fill_move_tags/4` to produce slash-delimited tag strings directly. `make_tags_from_pattern` maps each disjunct pattern to a single slash-delimited string:
 
 **Directional** — shows data shape, hashing details use existing helpers:
 ```elixir
 def fill_move_tags(%Changes.NewRecord{record: record} = change, shape, stack_id, shape_handle) do
   tags = Enum.map(shape.tag_structure, fn disjunct_pattern ->
-    Enum.map(disjunct_pattern, fn
-      nil -> nil  # Position not in this disjunct
+    Enum.map_join(disjunct_pattern, "/", fn
+      nil -> ""  # Non-participating position → empty segment
       column_spec -> hash_column_value(column_spec, record, stack_id, shape_handle)
     end)
   end)
@@ -585,7 +576,7 @@ def fill_move_tags(%Changes.NewRecord{record: record} = change, shape, stack_id,
 end
 ```
 
-The conversion from internal 2D arrays to slash-delimited wire format happens in `log_items.ex` (Phase 8), not here.
+Tags are slash-delimited strings from the start — no intermediate list format, no conversion needed in `log_items.ex`.
 
 ### Phase 5: Consumer State Updates
 
@@ -864,9 +855,9 @@ end
 
 **Modify** `lib/electric/log_items.ex`
 
-Two changes: add `active_conditions` to headers, and convert internal 2D tag arrays to slash-delimited wire format.
+Add `active_conditions` to headers. Tags are already slash-delimited strings from `fill_move_tags` (Phase 4), so no conversion is needed — pass them through directly.
 
-**Directional** — `from_change` shows new fields; **Final** — `tags_to_wire`:
+**Directional** — `from_change` shows new fields:
 ```elixir
 def from_change(%Changes.NewRecord{} = change, txids, _, _replica) do
   headers = %{
@@ -877,24 +868,14 @@ def from_change(%Changes.NewRecord{} = change, txids, _, _replica) do
     op_position: change.log_offset.op_offset
   }
   |> put_if_true(:last, change.last?)
-  |> put_if_true(:tags, change.move_tags != [], tags_to_wire(change.move_tags))
+  |> put_if_true(:tags, change.move_tags != [], change.move_tags)
   |> put_if_true(:active_conditions, change.active_conditions != nil, change.active_conditions)
 
   [{change.log_offset, %{key: change.key, value: change.record, headers: headers}}]
 end
-
-# Convert internal 2D tag array to slash-delimited wire format.
-# [["hash_x", "hash_status", nil], [nil, nil, "hash_y"]]
-# → ["hash_x/hash_status/", "//hash_y"]
-defp tags_to_wire(tags) do
-  Enum.map(tags, fn disjunct ->
-    Enum.map_join(disjunct, "/", fn
-      nil -> ""
-      hash -> hash
-    end)
-  end)
-end
 ```
+
+The existing `tags_to_wire` helper can be removed — `move_tags` are already in wire format.
 
 #### Message Format Migration
 
@@ -969,9 +950,9 @@ Clients maintain a map of tracked row keys. A move-in/move-out broadcast for a k
 defmodule Electric.Replication.Changes.NewRecord do
   defstruct [
     # ... existing fields ...
-    :move_tags,           # [[hash | nil]] - 2D array, one inner list per disjunct
+    :move_tags,           # [String.t()] - slash-delimited strings, one per disjunct
     :active_conditions,   # [boolean] - one per position
-    :removed_tags         # [[hash | nil]] - for updates only
+    :removed_tags         # [String.t()] - slash-delimited strings, for updates only
   ]
 end
 
@@ -1144,7 +1125,7 @@ Move handling inverts behavior for negated positions:
 ```elixir
 # Positions: 0 (positive), 1 (negated)
 # Row with x='a' where 'a' is in subquery:
-tags: [[hash(a), nil], [nil, hash(a)]]  # Same hash, different positions
+tags: ["hash(a)/", "/hash(a)"]  # Same hash, different positions
 active_conditions: [true, false]  # Opposite values
 ```
 
@@ -1412,13 +1393,13 @@ in the integration tests. It must handle the new wire format (slash-delimited ta
 
 **Modify** `packages/elixir-client/lib/electric/client/tag_tracker.ex`
 
-1. **Slash-delimited tag normalization**: Tags arrive as slash-delimited strings
-   (e.g., `"hash1/hash2/"`, `"//hash3"`). Normalize to 2D arrays internally:
-   `["hash1/hash2/", "//hash3"]` -> `[["hash1", "hash2", ""], ["", "", "hash3"]]` -> replace `""` with `nil`
+1. **Slash-delimited tag parsing**: Tags arrive as slash-delimited strings
+   (e.g., `"hash1/hash2/"`, `"//hash3"`). Split on `/` to extract per-position hashes.
+   Empty segments represent non-participating positions.
 
-2. **`removed_tags` normalization**: `removed_tags` arrive in the **same slash-delimited
-   format** as `tags`. They must be normalized through the same split pipeline before
-   comparison against internal position hashes. Without this, `filter_removed_tags` compares
+2. **`removed_tags` parsing**: `removed_tags` arrive in the **same slash-delimited
+   format** as `tags`. They must be parsed through the same split pipeline before
+   comparison against position hashes. Without this, `filter_removed_tags` compares
    bare hashes against raw slash-delimited strings — never matches.
 
 3. **DNF-based visibility evaluation**: `row_visible?/2` evaluates OR over disjuncts, where
@@ -1434,11 +1415,12 @@ in the integration tests. It must handle the new wire format (slash-delimited ta
 6. **Move-in activation**: `handle_move_in/4` activates positions for matching keys.
 
 ```elixir
-# Key normalization — removed_tags must use the same pipeline as tags
+# Key parsing — removed_tags must use the same split pipeline as tags
 removed_tags_set =
   removed_tags
-  |> normalize_tags()
-  |> Enum.flat_map(fn disjunct -> Enum.reject(disjunct, &is_nil/1) end)
+  |> Enum.flat_map(fn tag ->
+    tag |> String.split("/") |> Enum.reject(&(&1 == ""))
+  end)
   |> MapSet.new()
 ```
 
@@ -1451,7 +1433,7 @@ removed_tags_set =
 
 ```elixir
 describe "tag_tracker with DNF wire format" do
-  test "normalizes slash-delimited tags to 2D structure"
+  test "parses slash-delimited tags to position/hash pairs"
   test "removed_tags in slash-delimited format are correctly filtered"
   test "row_visible? evaluates DNF correctly"
   test "generate_synthetic_deletes only deletes when all disjuncts unsatisfied"
@@ -1760,7 +1742,7 @@ Phase 4: Shape tag_structure + fill_move_tags (depends on Phase 1, NO new Shape 
     |
     +---> Phase 7: Move Messages + Exclusion Clauses (depends on Phase 3)
     |
-    +---> Phase 8: Log Items (depends on Phase 4 for tag format)
+    +---> Phase 8: Log Items (depends on Phase 4 for active_conditions)
     |
     +---> Phase 10: Querying (depends on Phases 2, 3, 7)
 
@@ -1778,7 +1760,7 @@ Phase 14: Elixir Client (depends on Phases 7, 8 for wire format definition)
 | 5 | Phase 5 | Consumer State | holds DnfContext, built at init |
 | 6 | Phase 6 | Active Conditions | uses DnfContext |
 | 7 | Phase 7 | Move Messages + Exclusion Clauses | uses DnfContext for exclusion |
-| 8 | Phase 8 | Log Items | 2D-to-wire tag conversion |
+| 8 | Phase 8 | Log Items | `active_conditions` headers, remove `tags_to_wire` |
 | 9 | Phase 9 | Change Handling | uses DnfContext, replaces `includes_record?` |
 | 10 | Phase 10 | Querying | uses DnfContext + SqlGenerator |
 | 11 | Phase 11 | Move Handling | uses DnfContext for position routing |
@@ -1852,10 +1834,10 @@ Phase 14: Elixir Client (depends on Phases 7, 8 for wire format definition)
 - `lib/electric/replication/eval/sql_generator.ex` - **(new)** Converts AST back to SQL — used by `querying.ex` for non-subquery `active_conditions` and by `subquery_moves.ex` for exclusion clauses
 - `lib/electric/shapes/consumer/dnf_context.ex` - **(new)** DNF state container, built from Shape at consumer startup
 - `lib/electric/shapes/shape/subquery_moves.ex` - Core tag and move message generation, **move-in WHERE clause + DNF-aware exclusion clauses**
-- `lib/electric/shapes/shape.ex` - `fill_move_tags` (2D array output), `tag_structure` — **no new struct fields**
+- `lib/electric/shapes/shape.ex` - `fill_move_tags` (slash-delimited string output), `tag_structure` — **no new struct fields**
 - `lib/electric/shapes/consumer/move_handling.ex` - Move-in/out orchestration (position routing, negation inversion), delegates SQL generation to `subquery_moves.ex`
 - `lib/electric/shapes/where_clause.ex` - Record filtering and `active_conditions`
-- `lib/electric/log_items.ex` - Message format with `active_conditions`, 2D-to-wire tag conversion
+- `lib/electric/log_items.ex` - Message format with `active_conditions` (tags passed through as-is, `tags_to_wire` removed)
 - `lib/electric/shapes/querying.ex` - SQL generation for snapshots and move-in queries. Move-in queries SELECT condition_hashes (separate column) + wire tags (in JSON). Accepts DnfContext, delegates non-subquery AST-to-SQL to `SqlGenerator`
 - `packages/elixir-client/lib/electric/client/tag_tracker.ex` - Client-side tag tracking, DNF evaluation, synthetic deletes
 - `packages/elixir-client/lib/electric/client/message/headers.ex` - Client message header parsing

--- a/packages/sync-service/IMP_PLAN_UPDATE.md
+++ b/packages/sync-service/IMP_PLAN_UPDATE.md
@@ -1,0 +1,250 @@
+# Plan: Materialized-State Exclusion Clauses
+
+## Context
+
+The current implementation of move-in exclusion clauses uses **live Postgres subqueries** (`AND NOT (col IN (SELECT ...))`). When two dependencies change in the same transaction, each exclusion query sees the other's committed changes and both exclude the row — it's never delivered. The PLAN_UPDATE.md describes the fix: replace live subqueries with **parameter-based exclusion** (`= ANY($values)`) using materialized state, with a seen/unseen protocol to choose the correct snapshot of each dependency's values.
+
+## Architecture Summary
+
+- **Materializer** (`materializer.ex`): GenServer per dependency shape, tracks `value_counts` (value -> count). Sends `{:materializer_changes, handle, events}` to consumer.
+- **Consumer** (`consumer.ex`): Receives `materializer_changes` via `handle_info`. Each dependency sends a separate message. Materializers in layer 0 process before the outer consumer in layer 1.
+- **SubqueryMoves** (`subquery_moves.ex`): `build_dnf_exclusion_clauses/4` generates `AND NOT (col IN (SELECT ...))` using `rebuild_subquery_section/1`. **This is the broken code.**
+- **MoveHandling** (`move_handling.ex`): `do_start_move_in_query/3` calls `SubqueryMoves.move_in_where_clause/4`.
+
+## Key Ordering Guarantee
+
+For transaction T, ShapeLogCollector dispatches to shapes in layer order. Layer 0 (dependency) consumers process T first, materializers update and `send(pid, {:materializer_changes, ...})` to the outer consumer. The outer consumer's `handle_event` for T arrives after. Since `send` is FIFO and `handle_call`/`handle_info` share the same mailbox, the consumer processes materializer_changes for T **before** its own `do_handle_txn` for T. This lets us reset `seen_deps` inside `do_handle_txn`.
+
+---
+
+## Changes
+
+### 1. Materializer — add `prev_value_counts`
+
+**File:** `lib/electric/shapes/consumer/materializer.ex`
+
+**1a.** Add `prev_value_counts: %{}` to state in `init/1` (after line 103).
+
+**1b.** In `apply_changes_and_notify/2` (line 295), save current `value_counts` as `prev_value_counts` before calling `apply_changes`:
+
+```elixir
+defp apply_changes_and_notify(changes, state) do
+  state = %{state | prev_value_counts: state.value_counts}
+  {state, events} = apply_changes(changes, state)
+  # ... rest unchanged
+end
+```
+
+Do NOT save `prev_value_counts` in `handle_continue({:read_stream, ...})` — those are startup reads with no consumer listening.
+
+**1c.** Add `get_prev_link_values/1` public API + handler (alongside existing `get_link_values`). Same return type (`MapSet` of parsed values). No catch/raise — let GenServer.call exit naturally:
+
+```elixir
+def get_prev_link_values(opts) do
+  GenServer.call(name(opts), :get_prev_link_values)
+end
+
+def handle_call(:get_prev_link_values, _from, %{prev_value_counts: pvc} = state) do
+  {:reply, MapSet.new(Map.keys(pvc)), state}
+end
+```
+
+No `_as_strings` variants needed. String conversion happens downstream in `build_exclusion_context` (step 4) using `Eval.Env.const_to_pg_string` and the type info from `shape.where.used_refs`.
+
+### 2. Consumer State — add `seen_deps` tracking
+
+**File:** `lib/electric/shapes/consumer/state.ex`
+
+Add to `defstruct` (line 31):
+```elixir
+seen_deps: MapSet.new()
+```
+
+Add helpers:
+```elixir
+def mark_dep_seen(state, dep_handle),
+  do: %{state | seen_deps: MapSet.put(state.seen_deps, dep_handle)}
+
+def dep_seen?(state, dep_handle),
+  do: MapSet.member?(state.seen_deps, dep_handle)
+
+def reset_seen_deps(state),
+  do: %{state | seen_deps: MapSet.new()}
+```
+
+### 3. Consumer — wire seen_deps into the flow
+
+**File:** `lib/electric/shapes/consumer.ex`
+
+**3a.** In `handle_info({:materializer_changes, dep_handle, ...})` (line 276), mark dep as seen **before** processing:
+
+```elixir
+state = State.mark_dep_seen(state, dep_handle)
+```
+
+**3b.** In `do_handle_txn/2` (line 497), reset seen_deps at the start:
+
+```elixir
+defp do_handle_txn(%Transaction{xid: xid, changes: changes} = txn, state) do
+  state = State.reset_seen_deps(state)
+  # ... rest unchanged
+```
+
+### 4. MoveHandling — fetch exclusion values and pass to SubqueryMoves
+
+**File:** `lib/electric/shapes/consumer/move_handling.ex`
+
+**4a.** In `do_start_move_in_query/3` (line 190), build exclusion context and pass as 5th arg:
+
+```elixir
+exclusion_context = build_exclusion_context(state, dep_handle)
+
+formed_where_clause =
+  SubqueryMoves.move_in_where_clause(
+    state.shape, dep_handle, Enum.map(values, &elem(&1, 1)),
+    state.dnf_context, exclusion_context
+  )
+```
+
+**4b.** Add `build_exclusion_context/2`. Fetches materialized values (as parsed Elixir values via `get_link_values`/`get_prev_link_values`), then converts to PG strings using `Eval.Env.const_to_pg_string` with type info from `shape.where.used_refs`:
+
+```elixir
+defp build_exclusion_context(%State{dnf_context: nil}, _), do: nil
+
+defp build_exclusion_context(%State{} = state, trigger_dep_handle) do
+  used_refs = state.shape.where.used_refs
+
+  dep_values =
+    state.shape.shape_dependencies_handles
+    |> Enum.with_index()
+    |> Enum.reject(fn {handle, _} -> handle == trigger_dep_handle end)
+    |> Map.new(fn {handle, index} ->
+      opts = %{shape_handle: handle, stack_id: state.stack_id}
+      parsed_values =
+        if State.dep_seen?(state, handle),
+          do: Materializer.get_link_values(opts),
+          else: Materializer.get_prev_link_values(opts)
+
+      # Convert parsed values to PG strings for SQL parameters
+      ref_type = used_refs[["$sublink", Integer.to_string(index)]]
+      strings = values_to_strings(parsed_values, ref_type)
+      {index, strings}
+    end)
+
+  %{dep_values: dep_values}
+end
+
+# Convert a MapSet of parsed values to a list of PG string representations.
+# Matches the format expected by `= ANY($N::text[]::type[])` params.
+defp values_to_strings(parsed_values, {:array, {:row, types}}) do
+  Enum.map(parsed_values, fn tuple ->
+    tuple
+    |> Tuple.to_list()
+    |> Enum.zip_with(types, &Eval.Env.const_to_pg_string(Eval.Env.new(), &1, &2))
+    |> List.to_tuple()
+  end)
+end
+
+defp values_to_strings(parsed_values, {:array, type}) do
+  Enum.map(parsed_values, &Eval.Env.const_to_pg_string(Eval.Env.new(), &1, type))
+end
+```
+
+This keeps SubqueryMoves free of GenServer calls — all values are pre-fetched and pre-converted.
+
+### 5. SubqueryMoves — replace live subquery exclusion with parameterized exclusion
+
+**File:** `lib/electric/shapes/shape/subquery_moves.ex`
+
+**5a.** Update `move_in_where_clause/4` signature to accept optional 5th arg:
+
+```elixir
+def move_in_where_clause(shape, shape_handle, move_ins, dnf_context, exclusion_context \\ nil)
+```
+
+**5b.** Pass `exclusion_context` through to `build_dnf_move_in_where`.
+
+**5c.** In `build_dnf_move_in_where` (line 128-141), replace the exclusion clause generation:
+
+```elixir
+# BEFORE: always uses live subqueries
+exclusion = build_dnf_exclusion_clauses(decomposition, shape.shape_dependencies, ...)
+
+# AFTER: use materialized values when context provided
+{exclusion_sql, exclusion_params} =
+  if length(decomposition.disjuncts) > 1 and exclusion_context != nil do
+    build_materialized_exclusion_clauses(
+      decomposition, shape, trigger_dep_index,
+      exclusion_context, length(params) + 1
+    )
+  else
+    {"", []}
+  end
+
+{base_where <> exclusion_sql, params ++ exclusion_params}
+```
+
+**5d.** New function `build_materialized_exclusion_clauses/5`:
+
+Same structure as `build_dnf_exclusion_clauses` — partitions disjuncts into containing/not-containing the trigger, generates exclusion for non-containing. But instead of `rebuild_subquery_section/1` (live subquery), generates `column = ANY($N::text[]::type[])` using the pre-fetched values from `exclusion_context.dep_values`.
+
+Key changes from `generate_disjunct_exclusion`:
+- Look up `dep_index` via `extract_sublink_index(info.ast)` (same as current)
+- Look up pre-fetched values: `exclusion_context.dep_values[dep_index]`
+- Get type from `shape.where.used_refs[["$sublink", "#{dep_index}"]]`
+- Generate: `column = ANY($N::text[]::type[])` with the values as a SQL parameter
+- Track parameter index, incrementing for each exclusion dependency
+- Return `{sql_fragment, params_list, next_param_index}`
+
+**5e.** Keep `build_dnf_exclusion_clauses/4` as fallback (not used for move-in queries, but may be useful for other contexts or tests). Can mark as `@doc false` or remove if confirmed unused.
+
+### 6. Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Single-dependency shape | `length(disjuncts) > 1` is false → no exclusion generated. No change. |
+| Empty materialized values | `= ANY(ARRAY[]::type[])` matches nothing → no exclusion fires → row passes through. Correct. |
+| Dep has no changes in this txn | prev == current (no mutation) → either works. |
+| Mixed subquery/non-subquery disjunct | `all_subquery?` check returns false → `nil` → client deduplicates via tags. Same as before. |
+| Async query timing | WHERE clause + params are bound at construction time. Materializer changes later don't affect in-flight queries. |
+| Composite keys (row type) | Use `IN (SELECT * FROM unnest($N::text[]::type[], ...))`. Same pattern as `build_trigger_replacement`. |
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `lib/electric/shapes/consumer/materializer.ex` | Add `prev_value_counts`, `get_prev_link_values` |
+| `lib/electric/shapes/consumer/state.ex` | Add `seen_deps` field + helpers |
+| `lib/electric/shapes/consumer.ex` | Mark seen, reset seen_deps |
+| `lib/electric/shapes/consumer/move_handling.ex` | Build exclusion context, pass to SubqueryMoves |
+| `lib/electric/shapes/shape/subquery_moves.ex` | New `build_materialized_exclusion_clauses`, update `move_in_where_clause` |
+
+## Verification
+
+1. **Unit tests** for materializer `prev_value_counts`:
+   - `get_prev_link_values` returns empty before runtime changes
+   - Returns pre-change state after a batch of changes
+   - Not updated during initial stream read (startup)
+
+2. **Unit tests** for `build_materialized_exclusion_clauses`:
+   - Generates `= ANY($N::text[]::type[])` syntax (not live subqueries)
+   - Parameter indices are correctly incremented
+   - Empty values produce valid SQL
+
+3. **Integration test** for the two-dependency same-transaction scenario:
+   - Shape: `WHERE x IN (SELECT ...) OR y IN (SELECT ...)`
+   - Single transaction inserts x1 into dep_X and y1 into dep_Y
+   - Row `{x: x1, y: y1}` appears exactly once (not zero, not twice)
+
+4. **Run existing test suite**: `mix test` in sync-service — existing tests should pass since single-dependency shapes still skip exclusion.
+
+## Implementation Order
+
+1. Materializer changes (self-contained, testable independently)
+2. Consumer State changes (trivial struct addition)
+3. Consumer handle_info/do_handle_txn changes (wire seen_deps)
+4. MoveHandling changes (build + pass exclusion context)
+5. SubqueryMoves changes (core exclusion clause rewrite)
+6. Tests

--- a/packages/sync-service/PLAN_UPDATE.md
+++ b/packages/sync-service/PLAN_UPDATE.md
@@ -37,11 +37,11 @@ change in the same transaction, neither has — they each defer to the other.
 
 ---
 
-## Solution: Materialized-State Exclusion with Seen/Unseen Tracking
+## Solution: Materialized-State Exclusion with LSN-Keyed Snapshots
 
 Replace live subquery exclusion with **parameter-based exclusion** (`= ANY($values)`)
 using the materialized state known to the consumer. The correct materialized state to use
-depends on whether the consumer has already processed that dependency's changes.
+is determined by querying the materializer for a specific LSN.
 
 ### Why the Consumer Can't Just Use Current Materialized State
 
@@ -51,49 +51,74 @@ handles `materializer_changes` from dependency A, dependency B's materializer ha
 return post-transaction values — but the consumer hasn't started B's move-in yet. Using
 post-transaction state for exclusion reproduces the original bug.
 
-### Seen vs Unseen Dependencies
+### LSN-Keyed Value Counts in the Materializer
 
-The consumer tracks which dependencies' `materializer_changes` it has processed
-(a `seen_deps` set). When building an exclusion clause for dependency D in another
-disjunct:
+Each materializer maintains a map of `lsn → value_counts` with **at most 2 entries**,
+evicting the oldest when a third arrives. Each entry stores the value_counts as they were
+after processing changes at that LSN.
 
-- **D is seen** (consumer already processed D's `materializer_changes`): use D's
-  **current** materialized state. D's move-in has been started — any matching rows will
-  be claimed.
+```
+# After initial snapshot (lsn_0):
+%{lsn_0 => %{gb_1: 1}}
 
-- **D is unseen** (consumer hasn't processed D's `materializer_changes` yet): use D's
-  **pre-transaction** materialized state. This excludes rows already in the shape from
-  previous transactions, without falsely excluding rows matching D's newly-added values
-  (which no move-in has claimed yet).
+# After a later transaction (lsn_5) that adds gb_2:
+%{lsn_0 => %{gb_1: 1}, lsn_5 => %{gb_1: 1, gb_2: 1}}
+```
 
-To support pre-transaction queries, the materializer retains its previous state
-(`prev_value_counts`), saved before applying each transaction's changes.
+The materializer exposes a single API: `get_link_values(lsn)`:
+
+- **Exact match:** if `lsn` matches one of the stored entries, return that entry's
+  value_counts.
+- **LSN 0 (sentinel):** return the value_counts for the **minimum** stored LSN.
+
+Move event messages (`{:materializer_changes, dep_handle, events}`) are extended to
+include the LSN of the transaction that produced the changes:
+`{:materializer_changes, dep_handle, events, lsn}`.
+
+### LSN-per-Dep Tracking in the Consumer
+
+The consumer maintains a map of `dep_handle → lsn` (replacing the boolean `seen_deps`
+set). This is updated when the consumer receives a `materializer_changes` message from
+that dep.
+
+When building the exclusion context for dependency D:
+
+- **D has a recorded LSN** (consumer has processed D's `materializer_changes` at some
+  point): call `D.get_link_values(recorded_lsn)`. This returns the value_counts as of
+  the last transaction where D changed and the consumer processed it.
+
+- **D has no recorded LSN** (consumer has never received `materializer_changes` from D):
+  call `D.get_link_values(0)`. The materializer returns the minimum LSN entry — the
+  post-snapshot value_counts.
 
 ### Why This Handles All Cases
 
-| Dependency state | Seen? | Which materialized state? | Correct? |
-|------------------|-------|---------------------------|----------|
-| Changed in this txn | Yes | Current (post-txn) | Move-in started, rows will be claimed |
-| Changed in this txn | No | Pre-txn | New values not yet claimed, old values already in shape |
-| Stable (no change) | N/A | Pre-txn = current (identical) | Either works |
+| Dependency state | Consumer has LSN? | `get_link_values` arg | Returns | Correct? |
+|---|---|---|---|---|
+| Changed in this txn, already processed | Yes (current txn LSN) | current txn LSN | Post-change values | Move-in started, rows claimed |
+| Changed in this txn, not yet processed | Yes (older LSN) | older LSN | Pre-change values | New values not yet claimed |
+| Changed in prior txn | Yes (prior txn LSN) | prior txn LSN | Values after that txn | Stable state, correct |
+| Never changed after snapshot | No | 0 (sentinel) | Post-snapshot values | Stable state, correct |
 
 ### Worked Example
 
 Same scenario. Processing order: subqueryX first, then subqueryY.
 
-**Step 1: Process subqueryX's `materializer_changes` (x1 added)**
+**Step 1: Process subqueryX's `materializer_changes` (x1 added, lsn=100)**
 
-- Mark subqueryX as **seen**
-- SubqueryY is **unseen** → exclusion uses pre-txn Y (does not contain `y1`)
-- Move-in query: `WHERE x = 'x1' AND NOT (y = ANY($prev_Y))`
-- `t1`: `y1` not in pre-txn Y → **t1 returned**
+- Record `subqueryX → lsn 100`
+- SubqueryY has recorded LSN from a prior txn (or 0 if never seen)
+- `subqueryY.get_link_values(prior_lsn)` → pre-txn Y (does not contain `y1`)
+- Move-in query: `WHERE x = 'x1' AND NOT (y = ANY($Y_values))`
+- `t1`: `y1` not in Y values → **t1 returned**
 
-**Step 2: Process subqueryY's `materializer_changes` (y1 added)**
+**Step 2: Process subqueryY's `materializer_changes` (y1 added, lsn=100)**
 
-- Mark subqueryY as **seen**
-- SubqueryX is **seen** → exclusion uses current X (contains `x1`)
-- Move-in query: `WHERE y = 'y1' AND NOT (x = ANY($current_X))`
-- `t1`: `x1` in current X → **t1 excluded** (no duplicate)
+- Record `subqueryY → lsn 100`
+- SubqueryX has recorded `lsn 100`
+- `subqueryX.get_link_values(100)` → post-change X (contains `x1`)
+- Move-in query: `WHERE y = 'y1' AND NOT (x = ANY($X_values))`
+- `t1`: `x1` in X values → **t1 excluded** (no duplicate)
 
 **Result:** `t1` returned exactly once. Order doesn't matter — whichever dependency is
 processed first claims the row.
@@ -113,11 +138,12 @@ activation in the **control path** (position state updates).
 
 ### Cross-Transaction Scenario
 
-SubqueryX adds `x1` in T1, subqueryY adds `y1` in T2:
+SubqueryX adds `x1` in T1 (lsn=100), subqueryY adds `y1` in T2 (lsn=200):
 
-- T1: subqueryY unseen, pre-txn Y has no `y1` → `t1` returned by subqueryX move-in
-- T2: subqueryX unseen, pre-txn X has `x1` (stable from T1) → `t1` excluded by
-  subqueryY move-in
+- T1: subqueryY's recorded LSN is 0 or from a prior txn → returns stable Y values
+  (no `y1`) → `t1` returned by subqueryX move-in
+- T2: subqueryX's recorded LSN is 100 → `subqueryX.get_link_values(100)` returns values
+  containing `x1` → `t1` excluded by subqueryY move-in
 
-Pre-txn state for stable deps equals current state, so cross-transaction works
-identically.
+Stable deps return current values regardless of which LSN is requested (they only have
+one entry in their map), so cross-transaction works identically.

--- a/packages/sync-service/PLAN_UPDATE.md
+++ b/packages/sync-service/PLAN_UPDATE.md
@@ -1,0 +1,123 @@
+# Plan Update: Materialized-State Exclusion Clauses
+
+## Problem: Live Subquery Exclusion Causes Missed Move-ins
+
+The current implementation plan (Phase 7a in `IMPLEMENTATION_PLAN.md`) and the RFC
+(`docs/rfcs/arbitrary-boolean-expressions-with-subqueries.md`, lines 232–245) specify that
+move-in exclusion clauses use **live subqueries** against Postgres. This is broken when
+multiple subqueries change concurrently, because each move-in's exclusion sees the other
+subquery's changes as already committed — both queries exclude the row, and it is never
+delivered to the client.
+
+### Concrete Example
+
+**Shape:** `WHERE x IN (subqueryX) OR y IN (subqueryY)` on table `t`
+
+| id | x  | y  |
+|----|----|----|
+| t1 | x1 | y1 |
+| t2 | x2 | y2 |
+
+**Transaction:** subqueryX adds `x1`, subqueryY adds `y1`.
+
+After this transaction, `t1` matches the shape (via `x1 IN subqueryX`). It should move in.
+
+**What happens with live exclusion:**
+
+Move-in for subqueryX: `WHERE x = 'x1' AND NOT (y IN (SELECT ... subqueryY))`
+- By query execution time, subqueryY already contains `y1` → exclusion fires → **t1 excluded**
+
+Move-in for subqueryY: `WHERE y = 'y1' AND NOT (x IN (SELECT ... subqueryX))`
+- subqueryX already contains `x1` → exclusion fires → **t1 excluded**
+
+**Result:** `t1` missed by both queries. Correctness bug.
+
+The exclusion assumes the other disjunct's move-in already claimed the row. When both
+change in the same transaction, neither has — they each defer to the other.
+
+---
+
+## Solution: Materialized-State Exclusion with Seen/Unseen Tracking
+
+Replace live subquery exclusion with **parameter-based exclusion** (`= ANY($values)`)
+using the materialized state known to the consumer. The correct materialized state to use
+depends on whether the consumer has already processed that dependency's changes.
+
+### Why the Consumer Can't Just Use Current Materialized State
+
+The materializers process in an earlier dependency layer. By the time the outer consumer
+handles `materializer_changes` from dependency A, dependency B's materializer has
+**already updated** to reflect the current transaction. Querying B's current state would
+return post-transaction values — but the consumer hasn't started B's move-in yet. Using
+post-transaction state for exclusion reproduces the original bug.
+
+### Seen vs Unseen Dependencies
+
+The consumer tracks which dependencies' `materializer_changes` it has processed
+(a `seen_deps` set). When building an exclusion clause for dependency D in another
+disjunct:
+
+- **D is seen** (consumer already processed D's `materializer_changes`): use D's
+  **current** materialized state. D's move-in has been started — any matching rows will
+  be claimed.
+
+- **D is unseen** (consumer hasn't processed D's `materializer_changes` yet): use D's
+  **pre-transaction** materialized state. This excludes rows already in the shape from
+  previous transactions, without falsely excluding rows matching D's newly-added values
+  (which no move-in has claimed yet).
+
+To support pre-transaction queries, the materializer retains its previous state
+(`prev_value_counts`), saved before applying each transaction's changes.
+
+### Why This Handles All Cases
+
+| Dependency state | Seen? | Which materialized state? | Correct? |
+|------------------|-------|---------------------------|----------|
+| Changed in this txn | Yes | Current (post-txn) | Move-in started, rows will be claimed |
+| Changed in this txn | No | Pre-txn | New values not yet claimed, old values already in shape |
+| Stable (no change) | N/A | Pre-txn = current (identical) | Either works |
+
+### Worked Example
+
+Same scenario. Processing order: subqueryX first, then subqueryY.
+
+**Step 1: Process subqueryX's `materializer_changes` (x1 added)**
+
+- Mark subqueryX as **seen**
+- SubqueryY is **unseen** → exclusion uses pre-txn Y (does not contain `y1`)
+- Move-in query: `WHERE x = 'x1' AND NOT (y = ANY($prev_Y))`
+- `t1`: `y1` not in pre-txn Y → **t1 returned**
+
+**Step 2: Process subqueryY's `materializer_changes` (y1 added)**
+
+- Mark subqueryY as **seen**
+- SubqueryX is **seen** → exclusion uses current X (contains `x1`)
+- Move-in query: `WHERE y = 'y1' AND NOT (x = ANY($current_X))`
+- `t1`: `x1` in current X → **t1 excluded** (no duplicate)
+
+**Result:** `t1` returned exactly once. Order doesn't matter — whichever dependency is
+processed first claims the row.
+
+### How Position 1 Becomes Active for t1
+
+The first move-in query returns `t1` with **tags at all positions** (tags are derived
+from column values, always computed). So `t1` has `hash(y1)` at position 1.
+
+The second move-in doesn't return `t1` in its query results — but it doesn't need to.
+The **move-in broadcast** for position 1 is a control message written to the log
+independently of the query. The client already has `t1`, matches `hash(y1)` against
+position 1's tag, and activates position 1.
+
+Exclusion prevents duplicates in the **data path** (query results). Broadcasts handle
+activation in the **control path** (position state updates).
+
+### Cross-Transaction Scenario
+
+SubqueryX adds `x1` in T1, subqueryY adds `y1` in T2:
+
+- T1: subqueryY unseen, pre-txn Y has no `y1` → `t1` returned by subqueryX move-in
+- T2: subqueryX unseen, pre-txn X has `x1` (stable from T1) → `t1` excluded by
+  subqueryY move-in
+
+Pre-txn state for stable deps equals current state, so cross-transaction works
+identically.

--- a/packages/sync-service/lib/electric/log_items.ex
+++ b/packages/sync-service/lib/electric/log_items.ex
@@ -48,7 +48,7 @@ defmodule Electric.LogItems do
              op_position: change.log_offset.op_offset
            }
            |> put_if_true(:last, change.last?)
-           |> put_if_true(:tags, change.move_tags != [], tags_to_wire(change.move_tags))
+           |> put_if_true(:tags, change.move_tags != [], change.move_tags)
            |> put_if_true(
              :active_conditions,
              change.active_conditions != nil,
@@ -73,7 +73,7 @@ defmodule Electric.LogItems do
              op_position: change.log_offset.op_offset
            }
            |> put_if_true(:last, change.last?)
-           |> put_if_true(:tags, change.move_tags != [], tags_to_wire(change.move_tags))
+           |> put_if_true(:tags, change.move_tags != [], change.move_tags)
            |> put_if_true(
              :active_conditions,
              change.active_conditions != nil,
@@ -98,11 +98,11 @@ defmodule Electric.LogItems do
              op_position: change.log_offset.op_offset
            }
            |> put_if_true(:last, change.last?)
-           |> put_if_true(:tags, change.move_tags != [], tags_to_wire(change.move_tags))
+           |> put_if_true(:tags, change.move_tags != [], change.move_tags)
            |> put_if_true(
              :removed_tags,
              change.move_tags != [],
-             tags_to_wire(change.removed_move_tags)
+             change.removed_move_tags
            )
            |> put_if_true(
              :active_conditions,
@@ -134,7 +134,7 @@ defmodule Electric.LogItems do
            |> put_if_true(
              :tags,
              change.move_tags != [],
-             tags_to_wire(change.move_tags ++ change.removed_move_tags)
+             change.move_tags ++ change.removed_move_tags
            )
        }},
       {new_offset,
@@ -151,7 +151,7 @@ defmodule Electric.LogItems do
              op_position: new_offset.op_offset
            }
            |> put_if_true(:last, change.last?)
-           |> put_if_true(:tags, change.move_tags != [], tags_to_wire(change.move_tags))
+           |> put_if_true(:tags, change.move_tags != [], change.move_tags)
            |> put_if_true(
              :active_conditions,
              change.active_conditions != nil,
@@ -166,23 +166,6 @@ defmodule Electric.LogItems do
       do: LogOffset.increment(offset)
 
   def expected_offset_after_split(%{log_offset: offset}), do: offset
-
-  # Convert internal 2D tag array to slash-delimited wire format.
-  # [["hash_x", "hash_status", nil], [nil, nil, "hash_y"]]
-  # → ["hash_x/hash_status/", "//hash_y"]
-  defp tags_to_wire(tags) do
-    Enum.map(tags, fn
-      disjunct when is_list(disjunct) ->
-        Enum.map_join(disjunct, "/", fn
-          nil -> ""
-          hash -> hash
-        end)
-
-      # Backward compat: if move_tags still contains bare strings, pass through
-      tag when is_binary(tag) ->
-        tag
-    end)
-  end
 
   defp take_pks_or_all(record, _pks, :full), do: record
   defp take_pks_or_all(record, [], :default), do: record

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -101,6 +101,12 @@ defmodule Electric.Plug.ServeShapePlug do
         Map.get(merged_params, "experimental_live_sse", "false"),
         &(&1 != "false")
       )
+      |> Map.put_new_lazy("electric_protocol_version", fn ->
+        case Conn.get_req_header(conn, "electric-protocol-version") do
+          [version | _] -> version
+          [] -> "1"
+        end
+      end)
 
     case Api.validate(api, all_params) do
       {:ok, request} ->

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -181,7 +181,15 @@ defmodule Electric.Replication.Changes do
   end
 
   defmodule NewRecord do
-    defstruct [:relation, :record, :log_offset, :key, last?: false, move_tags: []]
+    defstruct [
+      :relation,
+      :record,
+      :log_offset,
+      :key,
+      last?: false,
+      move_tags: [],
+      active_conditions: nil
+    ]
 
     @type t() :: %__MODULE__{
             relation: Changes.relation_name(),
@@ -204,7 +212,8 @@ defmodule Electric.Replication.Changes do
       move_tags: [],
       removed_move_tags: [],
       changed_columns: MapSet.new(),
-      last?: false
+      last?: false,
+      active_conditions: nil
     ]
 
     @type t() :: %__MODULE__{
@@ -253,7 +262,15 @@ defmodule Electric.Replication.Changes do
   end
 
   defmodule DeletedRecord do
-    defstruct [:relation, :old_record, :log_offset, :key, move_tags: [], last?: false]
+    defstruct [
+      :relation,
+      :old_record,
+      :log_offset,
+      :key,
+      move_tags: [],
+      active_conditions: nil,
+      last?: false
+    ]
 
     @type t() :: %__MODULE__{
             relation: Changes.relation_name(),

--- a/packages/sync-service/lib/electric/replication/eval/decomposer.ex
+++ b/packages/sync-service/lib/electric/replication/eval/decomposer.ex
@@ -1,0 +1,229 @@
+defmodule Electric.Replication.Eval.Decomposer do
+  @moduledoc """
+  Decomposes a query to an expanded DNF form.
+
+  Takes a where clause part of a query and decomposes it into a list of expressions
+  in a Disjunctive Normal Form (DNF). Each expression is a conjunction of comparisons.
+
+  To avoid duplication, it returns a list of lists, where the outer list is a list of disjuncts (conjunctions),
+  and the inner list is a list of comparisons. Each comparison (i.e. the sub-expression of the original where clause)
+  is represented by an Erlang reference, which is then mentioned in the map of references to the protobuf of the
+  referenced subexpression.
+
+  ## NOT handling
+
+  To properly convert to DNF, NOT expressions are pushed down to leaf expressions using De Morgan's laws:
+  - `NOT (a OR b)` becomes `(NOT a) AND (NOT b)`
+  - `NOT (a AND b)` becomes `(NOT a) OR (NOT b)`
+
+  Because of this, leaf expressions in the result can be either:
+  - `ref` - a positive reference to a subexpression
+  - `{:not, ref}` - a negated reference to a subexpression
+  - `nil` - this position is not part of this disjunct
+
+  The subexpressions map always contains the base (non-negated) form of each expression.
+
+  ## Expanded format
+
+  The "expanded" part means that each inner list MUST be the same length, equal to the total count of expressions
+  across all disjuncts. Each position in the inner list corresponds to a specific expression slot from the original
+  query structure, and contains either a reference (possibly negated) to that subexpression or `nil` if that
+  expression is not part of the given disjunct.
+
+  References allow deduplication: if the same subexpression appears in multiple disjuncts, they will share the
+  same reference (but occupy different positions, since positions correspond to the original query structure).
+
+  ## Examples
+
+  For the query (already in a normalized form):
+
+  ```sql
+  WHERE (a = 1 AND b = 2) OR (c = 3 AND d = 4) OR (a = 1 AND c = 3)
+  ```
+
+  Has 3 disjuncts with 2 + 2 + 2 = 6 total expression slots. It will be decomposed into:
+
+  ```
+  [[r1, r2, nil, nil, nil, nil],
+   [nil, nil, r3, r4, nil, nil],
+   [nil, nil, nil, nil, r1, r3]]
+  ```
+
+  Where:
+  - Positions 0-1 correspond to disjunct 1's expressions (`a = 1`, `b = 2`)
+  - Positions 2-3 correspond to disjunct 2's expressions (`c = 3`, `d = 4`)
+  - Positions 4-5 correspond to disjunct 3's expressions (`a = 1`, `c = 3`)
+  - `r1` appears at positions 0 and 4 (same subexpression `a = 1`)
+  - `r3` appears at positions 2 and 5 (same subexpression `c = 3`)
+
+  The reference map will contain: `r1 => "a = 1"`, `r2 => "b = 2"`, `r3 => "c = 3"`, `r4 => "d = 4"`.
+
+  For a query with NOT that needs De Morgan transformation:
+
+  ```sql
+  WHERE NOT (a = 1 OR b = 2)
+  ```
+
+  Becomes `(NOT a = 1) AND (NOT b = 2)` - a single disjunct with two negated terms:
+
+  ```
+  [[{:not, r1}, {:not, r2}]]
+  ```
+
+  And for:
+
+  ```sql
+  WHERE NOT (a = 1 AND b = 2)
+  ```
+
+  Becomes `(NOT a = 1) OR (NOT b = 2)` - two disjuncts:
+
+  ```
+  [[{:not, r1}, nil],
+   [nil, {:not, r2}]]
+  ```
+  """
+
+  @type pgquery_protobuf() :: PgQuery.Node.t()
+  @type dnf_term() :: reference() | {:not, reference()} | nil
+
+  @spec decompose(query :: pgquery_protobuf()) ::
+          {[[dnf_term()]], %{reference() => pgquery_protobuf()}}
+  def decompose(query) do
+    # Phase 1: Convert to intermediate DNF (list of disjuncts, each is a list of {ast, negated?})
+    internal_dnf = to_dnf(query, false)
+
+    # Phase 2: Expand to fixed-width format with references
+    expand(internal_dnf)
+  end
+
+  # Convert AST to internal DNF representation
+  # negated? tracks whether we're inside a NOT context (for De Morgan transformations)
+  defp to_dnf(
+         %PgQuery.Node{node: {:bool_expr, %PgQuery.BoolExpr{boolop: boolop, args: args}}},
+         negated
+       ) do
+    case {boolop, negated} do
+      {:OR_EXPR, false} ->
+        # OR: concatenate disjuncts from all branches
+        Enum.flat_map(args, &to_dnf(&1, false))
+
+      {:OR_EXPR, true} ->
+        # NOT OR => AND (De Morgan's law)
+        # NOT (a OR b) = NOT a AND NOT b
+        args_dnfs = Enum.map(args, &to_dnf(&1, true))
+        cross_product(args_dnfs)
+
+      {:AND_EXPR, false} ->
+        # AND: cross-product of disjuncts from all branches
+        args_dnfs = Enum.map(args, &to_dnf(&1, false))
+        cross_product(args_dnfs)
+
+      {:AND_EXPR, true} ->
+        # NOT AND => OR (De Morgan's law)
+        # NOT (a AND b) = NOT a OR NOT b
+        Enum.flat_map(args, &to_dnf(&1, true))
+
+      {:NOT_EXPR, _} ->
+        # NOT: flip the negation state (handles double negation automatically)
+        [arg] = args
+        to_dnf(arg, not negated)
+    end
+  end
+
+  defp to_dnf(%PgQuery.Node{} = leaf, negated) do
+    # Leaf expression: single disjunct with single term
+    [[{leaf, negated}]]
+  end
+
+  # Cross-product of multiple DNF forms
+  # Used for AND distribution: (A1 OR A2) AND (B1 OR B2) => (A1 AND B1) OR (A1 AND B2) OR (A2 AND B1) OR (A2 AND B2)
+  defp cross_product([]), do: [[]]
+
+  defp cross_product([dnf | rest]) do
+    rest_product = cross_product(rest)
+
+    for disjunct <- dnf, rest_disjunct <- rest_product do
+      disjunct ++ rest_disjunct
+    end
+  end
+
+  # Expand internal DNF to fixed-width format with references
+  defp expand(internal_dnf) do
+    # Calculate width of each disjunct and total width
+    widths = Enum.map(internal_dnf, &length/1)
+    total_width = Enum.sum(widths)
+
+    # Calculate start positions for each disjunct: [0, w1, w1+w2, ...]
+    start_positions = calc_start_positions(widths)
+
+    # Build subexpressions map with deduplication based on SQL string
+    {ast_to_ref, subexpressions} = build_subexpressions(internal_dnf)
+
+    # Expand each disjunct to full width
+    disjuncts =
+      internal_dnf
+      |> Enum.zip(start_positions)
+      |> Enum.map(fn {disjunct, start_pos} ->
+        # Create a list of nils of the total width
+        row = List.duplicate(nil, total_width)
+
+        # Fill in the terms at the appropriate positions
+        disjunct
+        |> Enum.with_index()
+        |> Enum.reduce(row, fn {{ast, negated}, term_idx}, row ->
+          pos = start_pos + term_idx
+          ref = Map.fetch!(ast_to_ref, deparse(ast))
+          term = if negated, do: {:not, ref}, else: ref
+          List.replace_at(row, pos, term)
+        end)
+      end)
+
+    {disjuncts, subexpressions}
+  end
+
+  defp calc_start_positions(widths) do
+    widths
+    |> Enum.reduce({[], 0}, fn width, {positions, acc} ->
+      {positions ++ [acc], acc + width}
+    end)
+    |> elem(0)
+  end
+
+  defp build_subexpressions(internal_dnf) do
+    internal_dnf
+    |> List.flatten()
+    |> Enum.map(fn {ast, _negated} -> ast end)
+    |> Enum.reduce({%{}, %{}}, fn ast, {ast_to_ref, subexpressions} ->
+      key = deparse(ast)
+
+      case Map.fetch(ast_to_ref, key) do
+        {:ok, _ref} -> {ast_to_ref, subexpressions}
+
+        :error ->
+          ref = make_ref()
+          {Map.put(ast_to_ref, key, ref), Map.put(subexpressions, ref, ast)}
+      end
+    end)
+  end
+
+  # Convert AST node back to SQL string for deduplication
+  defp deparse(ast) do
+    %PgQuery.ParseResult{
+      stmts: [
+        %PgQuery.RawStmt{
+          stmt: %PgQuery.Node{
+            node:
+              {:select_stmt,
+               %PgQuery.SelectStmt{
+                 target_list: [%PgQuery.Node{node: {:res_target, %PgQuery.ResTarget{val: ast}}}]
+               }}
+          }
+        }
+      ]
+    }
+    |> PgQuery.protobuf_to_query!()
+    |> String.replace_prefix("SELECT ", "")
+    |> String.trim()
+  end
+end

--- a/packages/sync-service/lib/electric/replication/eval/decomposer.ex
+++ b/packages/sync-service/lib/electric/replication/eval/decomposer.ex
@@ -220,7 +220,8 @@ defmodule Electric.Replication.Eval.Decomposer do
       key = deparse(ast)
 
       case Map.fetch(ast_to_ref, key) do
-        {:ok, _ref} -> {ast_to_ref, subexpressions}
+        {:ok, _ref} ->
+          {ast_to_ref, subexpressions}
 
         :error ->
           ref = make_ref()

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -996,7 +996,7 @@ defmodule Electric.Replication.Eval.Parser do
          comparisons = [left_comparison, right_comparison],
          {:ok, reduced} <-
            build_bool_chain(
-             %{name: "or", impl: &pg_and/2, strict?: false},
+             %{name: "and", impl: &pg_and/2, strict?: false},
              comparisons,
              expr.location
            ) do

--- a/packages/sync-service/lib/electric/replication/eval/sql_generator.ex
+++ b/packages/sync-service/lib/electric/replication/eval/sql_generator.ex
@@ -7,6 +7,9 @@ defmodule Electric.Replication.Eval.SqlGenerator do
   needs to embed a condition in a generated query (snapshot active_conditions,
   move-in exclusion clauses, etc.).
 
+  Uses precedence-aware parenthesization to produce minimal, readable SQL.
+  Parentheses are only added when needed to preserve the AST's evaluation order.
+
   Must handle every AST node type that `Parser` can produce. Raises
   `ArgumentError` for unrecognised nodes so gaps are caught at shape
   creation time, but the property-based round-trip test (see Tests below)
@@ -14,6 +17,22 @@ defmodule Electric.Replication.Eval.SqlGenerator do
   """
 
   alias Electric.Replication.Eval.Parser.{Const, Ref, Func, Array, RowExpr}
+
+  # PostgreSQL operator precedence (higher number = tighter binding)
+  # See: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE
+  @prec_or 10
+  @prec_and 20
+  @prec_not 30
+  @prec_is 40
+  @prec_comparison 50
+  @prec_like_in 60
+  @prec_other_op 70
+  @prec_addition 80
+  @prec_multiplication 90
+  @prec_exponent 100
+  @prec_unary 110
+  @prec_cast 130
+  @prec_atom 1000
 
   @doc """
   Convert an AST node to a SQL string.
@@ -30,182 +49,189 @@ defmodule Electric.Replication.Eval.SqlGenerator do
   Raises `ArgumentError` for unrecognised AST nodes.
   """
   @spec to_sql(term()) :: String.t()
+  def to_sql(ast) do
+    {sql, _prec} = to_sql_prec(ast)
+    sql
+  end
 
-  # Comparison operators — names are stored with surrounding quotes
-  def to_sql(%Func{name: "\"=\"", args: [left, right]}),
-    do: "(#{to_sql(left)} = #{to_sql(right)})"
+  # --- Private: precedence-aware SQL generation ---
+  # Each clause returns {sql_string, precedence_level}
 
-  def to_sql(%Func{name: "\"<>\"", args: [left, right]}),
-    do: "(#{to_sql(left)} <> #{to_sql(right)})"
+  # Comparison operators
+  defp to_sql_prec(%Func{name: "\"=\"", args: [left, right]}),
+    do: binary_op(left, "=", right, @prec_comparison)
 
-  def to_sql(%Func{name: "\"<\"", args: [left, right]}),
-    do: "(#{to_sql(left)} < #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"<>\"", args: [left, right]}),
+    do: binary_op(left, "<>", right, @prec_comparison)
 
-  def to_sql(%Func{name: "\">\"", args: [left, right]}),
-    do: "(#{to_sql(left)} > #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"<\"", args: [left, right]}),
+    do: binary_op(left, "<", right, @prec_comparison)
 
-  def to_sql(%Func{name: "\"<=\"", args: [left, right]}),
-    do: "(#{to_sql(left)} <= #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\">\"", args: [left, right]}),
+    do: binary_op(left, ">", right, @prec_comparison)
 
-  def to_sql(%Func{name: "\">=\"", args: [left, right]}),
-    do: "(#{to_sql(left)} >= #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"<=\"", args: [left, right]}),
+    do: binary_op(left, "<=", right, @prec_comparison)
+
+  defp to_sql_prec(%Func{name: "\">=\"", args: [left, right]}),
+    do: binary_op(left, ">=", right, @prec_comparison)
 
   # Pattern matching
-  def to_sql(%Func{name: "\"~~\"", args: [left, right]}),
-    do: "(#{to_sql(left)} LIKE #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"~~\"", args: [left, right]}),
+    do: binary_op(left, "LIKE", right, @prec_like_in)
 
-  def to_sql(%Func{name: "\"~~*\"", args: [left, right]}),
-    do: "(#{to_sql(left)} ILIKE #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"~~*\"", args: [left, right]}),
+    do: binary_op(left, "ILIKE", right, @prec_like_in)
 
-  def to_sql(%Func{name: "\"!~~\"", args: [left, right]}),
-    do: "(#{to_sql(left)} NOT LIKE #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"!~~\"", args: [left, right]}),
+    do: binary_op(left, "NOT LIKE", right, @prec_like_in)
 
-  def to_sql(%Func{name: "\"!~~*\"", args: [left, right]}),
-    do: "(#{to_sql(left)} NOT ILIKE #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"!~~*\"", args: [left, right]}),
+    do: binary_op(left, "NOT ILIKE", right, @prec_like_in)
 
   # Nullability — parser produces "is null"/"is not null" from constant folding
   # and "IS_NULL"/"IS_NOT_NULL" from NullTest on column refs
-  def to_sql(%Func{name: name, args: [arg]}) when name in ["is null", "IS_NULL"],
-    do: "(#{to_sql(arg)} IS NULL)"
+  defp to_sql_prec(%Func{name: name, args: [arg]}) when name in ["is null", "IS_NULL"],
+    do: postfix_op(arg, "IS NULL", @prec_is)
 
-  def to_sql(%Func{name: name, args: [arg]}) when name in ["is not null", "IS_NOT_NULL"],
-    do: "(#{to_sql(arg)} IS NOT NULL)"
+  defp to_sql_prec(%Func{name: name, args: [arg]}) when name in ["is not null", "IS_NOT_NULL"],
+    do: postfix_op(arg, "IS NOT NULL", @prec_is)
 
   # Boolean tests
-  def to_sql(%Func{name: "IS_TRUE", args: [arg]}),
-    do: "(#{to_sql(arg)} IS TRUE)"
+  defp to_sql_prec(%Func{name: "IS_TRUE", args: [arg]}),
+    do: postfix_op(arg, "IS TRUE", @prec_is)
 
-  def to_sql(%Func{name: "IS_NOT_TRUE", args: [arg]}),
-    do: "(#{to_sql(arg)} IS NOT TRUE)"
+  defp to_sql_prec(%Func{name: "IS_NOT_TRUE", args: [arg]}),
+    do: postfix_op(arg, "IS NOT TRUE", @prec_is)
 
-  def to_sql(%Func{name: "IS_FALSE", args: [arg]}),
-    do: "(#{to_sql(arg)} IS FALSE)"
+  defp to_sql_prec(%Func{name: "IS_FALSE", args: [arg]}),
+    do: postfix_op(arg, "IS FALSE", @prec_is)
 
-  def to_sql(%Func{name: "IS_NOT_FALSE", args: [arg]}),
-    do: "(#{to_sql(arg)} IS NOT FALSE)"
+  defp to_sql_prec(%Func{name: "IS_NOT_FALSE", args: [arg]}),
+    do: postfix_op(arg, "IS NOT FALSE", @prec_is)
 
-  def to_sql(%Func{name: "IS_UNKNOWN", args: [arg]}),
-    do: "(#{to_sql(arg)} IS UNKNOWN)"
+  defp to_sql_prec(%Func{name: "IS_UNKNOWN", args: [arg]}),
+    do: postfix_op(arg, "IS UNKNOWN", @prec_is)
 
-  def to_sql(%Func{name: "IS_NOT_UNKNOWN", args: [arg]}),
-    do: "(#{to_sql(arg)} IS NOT UNKNOWN)"
+  defp to_sql_prec(%Func{name: "IS_NOT_UNKNOWN", args: [arg]}),
+    do: postfix_op(arg, "IS NOT UNKNOWN", @prec_is)
 
   # Membership (IN with literal array)
-  def to_sql(%Func{name: "in", args: [left, %Array{elements: elements}]}) do
+  defp to_sql_prec(%Func{name: "in", args: [left, %Array{elements: elements}]}) do
     values = Enum.map_join(elements, ", ", &to_sql/1)
-    "(#{to_sql(left)} IN (#{values}))"
+    {"#{wrap(left, @prec_like_in)} IN (#{values})", @prec_like_in}
   end
 
   # Sublink membership check (IN with subquery) — rendered as a placeholder
   # since the actual subquery SQL is not in the AST
-  def to_sql(%Func{name: "sublink_membership_check", args: [left, %Ref{path: path}]}) do
+  defp to_sql_prec(%Func{name: "sublink_membership_check", args: [left, %Ref{path: path}]}) do
     sublink_ref = Enum.join(path, ".")
-    "(#{to_sql(left)} IN (SELECT #{sublink_ref}))"
+    {"#{wrap(left, @prec_like_in)} IN (SELECT #{sublink_ref})", @prec_like_in}
   end
 
   # Logical operators
-  def to_sql(%Func{name: "not", args: [inner]}),
-    do: "(NOT #{to_sql(inner)})"
+  defp to_sql_prec(%Func{name: "not", args: [inner]}),
+    do: prefix_op("NOT", inner, @prec_not)
 
-  def to_sql(%Func{name: "and", args: args}) do
-    conditions = Enum.map_join(args, " AND ", &to_sql/1)
-    "(#{conditions})"
+  defp to_sql_prec(%Func{name: "and", args: args}) do
+    conditions = Enum.map_join(args, " AND ", &wrap(&1, @prec_and))
+    {conditions, @prec_and}
   end
 
-  def to_sql(%Func{name: "or", args: args}) do
-    conditions = Enum.map_join(args, " OR ", &to_sql/1)
-    "(#{conditions})"
+  defp to_sql_prec(%Func{name: "or", args: args}) do
+    conditions = Enum.map_join(args, " OR ", &wrap(&1, @prec_or))
+    {conditions, @prec_or}
   end
 
   # DISTINCT / NOT DISTINCT — args are [left, right, comparison_func]
-  def to_sql(%Func{name: "values_distinct?", args: [left, right | _]}),
-    do: "(#{to_sql(left)} IS DISTINCT FROM #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "values_distinct?", args: [left, right | _]}),
+    do: binary_op(left, "IS DISTINCT FROM", right, @prec_is)
 
-  def to_sql(%Func{name: "values_not_distinct?", args: [left, right | _]}),
-    do: "(#{to_sql(left)} IS NOT DISTINCT FROM #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "values_not_distinct?", args: [left, right | _]}),
+    do: binary_op(left, "IS NOT DISTINCT FROM", right, @prec_is)
 
   # ANY / ALL — arg is a single Func with map_over_array_in_pos
-  def to_sql(%Func{name: "any", args: [%Func{} = inner]}) do
+  defp to_sql_prec(%Func{name: "any", args: [%Func{} = inner]}) do
     {op_sql, left, right} = extract_mapped_operator(inner)
-    "(#{to_sql(left)} #{op_sql} ANY(#{to_sql(right)}))"
+    {"#{wrap(left, @prec_comparison)} #{op_sql} ANY(#{to_sql(right)})", @prec_comparison}
   end
 
-  def to_sql(%Func{name: "all", args: [%Func{} = inner]}) do
+  defp to_sql_prec(%Func{name: "all", args: [%Func{} = inner]}) do
     {op_sql, left, right} = extract_mapped_operator(inner)
-    "(#{to_sql(left)} #{op_sql} ALL(#{to_sql(right)}))"
+    {"#{wrap(left, @prec_comparison)} #{op_sql} ALL(#{to_sql(right)})", @prec_comparison}
   end
 
   # Arithmetic binary operators
-  def to_sql(%Func{name: "\"+\"", args: [left, right]}),
-    do: "(#{to_sql(left)} + #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"+\"", args: [left, right]}),
+    do: binary_op(left, "+", right, @prec_addition)
 
-  def to_sql(%Func{name: "\"-\"", args: [left, right]}),
-    do: "(#{to_sql(left)} - #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"-\"", args: [left, right]}),
+    do: binary_op(left, "-", right, @prec_addition)
 
-  def to_sql(%Func{name: "\"*\"", args: [left, right]}),
-    do: "(#{to_sql(left)} * #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"*\"", args: [left, right]}),
+    do: binary_op(left, "*", right, @prec_multiplication)
 
-  def to_sql(%Func{name: "\"/\"", args: [left, right]}),
-    do: "(#{to_sql(left)} / #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"/\"", args: [left, right]}),
+    do: binary_op(left, "/", right, @prec_multiplication)
 
-  def to_sql(%Func{name: "\"^\"", args: [left, right]}),
-    do: "(#{to_sql(left)} ^ #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"^\"", args: [left, right]}),
+    do: binary_op_right(left, "^", right, @prec_exponent)
 
   # Bitwise binary operators
-  def to_sql(%Func{name: "\"&\"", args: [left, right]}),
-    do: "(#{to_sql(left)} & #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"&\"", args: [left, right]}),
+    do: binary_op(left, "&", right, @prec_other_op)
 
-  def to_sql(%Func{name: "\"|\"", args: [left, right]}),
-    do: "(#{to_sql(left)} | #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"|\"", args: [left, right]}),
+    do: binary_op(left, "|", right, @prec_other_op)
 
-  def to_sql(%Func{name: "\"#\"", args: [left, right]}),
-    do: "(#{to_sql(left)} # #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"#\"", args: [left, right]}),
+    do: binary_op(left, "#", right, @prec_other_op)
 
   # Unary operators
-  def to_sql(%Func{name: "\"+\"", args: [arg]}),
-    do: "(+ #{to_sql(arg)})"
+  defp to_sql_prec(%Func{name: "\"+\"", args: [arg]}),
+    do: prefix_op("+", arg, @prec_unary)
 
-  def to_sql(%Func{name: "\"-\"", args: [arg]}),
-    do: "(- #{to_sql(arg)})"
+  defp to_sql_prec(%Func{name: "\"-\"", args: [arg]}),
+    do: prefix_op("-", arg, @prec_unary)
 
-  def to_sql(%Func{name: "\"~\"", args: [arg]}),
-    do: "(~ #{to_sql(arg)})"
+  defp to_sql_prec(%Func{name: "\"~\"", args: [arg]}),
+    do: prefix_op("~", arg, @prec_unary)
 
-  def to_sql(%Func{name: "\"|/\"", args: [arg]}),
-    do: "(|/ #{to_sql(arg)})"
+  defp to_sql_prec(%Func{name: "\"|/\"", args: [arg]}),
+    do: prefix_op("|/", arg, @prec_unary)
 
-  def to_sql(%Func{name: "\"@\"", args: [arg]}),
-    do: "(@ #{to_sql(arg)})"
+  defp to_sql_prec(%Func{name: "\"@\"", args: [arg]}),
+    do: prefix_op("@", arg, @prec_unary)
 
   # String concatenation
-  def to_sql(%Func{name: "\"||\"", args: [left, right]}),
-    do: "(#{to_sql(left)} || #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"||\"", args: [left, right]}),
+    do: binary_op(left, "||", right, @prec_other_op)
 
   # Array operators
-  def to_sql(%Func{name: "\"@>\"", args: [left, right]}),
-    do: "(#{to_sql(left)} @> #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"@>\"", args: [left, right]}),
+    do: binary_op(left, "@>", right, @prec_other_op)
 
-  def to_sql(%Func{name: "\"<@\"", args: [left, right]}),
-    do: "(#{to_sql(left)} <@ #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"<@\"", args: [left, right]}),
+    do: binary_op(left, "<@", right, @prec_other_op)
 
-  def to_sql(%Func{name: "\"&&\"", args: [left, right]}),
-    do: "(#{to_sql(left)} && #{to_sql(right)})"
+  defp to_sql_prec(%Func{name: "\"&&\"", args: [left, right]}),
+    do: binary_op(left, "&&", right, @prec_other_op)
 
   # Named functions (lower, upper, like, ilike, array_*, justify_*, timezone, casts, etc.)
   # These are Func nodes where the name is a plain identifier (no quotes around operators)
-  def to_sql(%Func{name: name, args: args})
-      when name in ~w(lower upper like ilike array_cat array_prepend array_append array_ndims
-                      justify_days justify_hours justify_interval timezone
-                      index_access slice_access) do
+  defp to_sql_prec(%Func{name: name, args: args})
+       when name in ~w(lower upper like ilike array_cat array_prepend array_append array_ndims
+                       justify_days justify_hours justify_interval timezone
+                       index_access slice_access) do
     arg_list = Enum.map_join(args, ", ", &to_sql/1)
-    "#{name}(#{arg_list})"
+    {"#{name}(#{arg_list})", @prec_atom}
   end
 
   # Type cast functions (e.g., "int4_to_bool", "text_to_int4")
-  def to_sql(%Func{name: name, args: [arg]}) when is_binary(name) do
+  defp to_sql_prec(%Func{name: name, args: [arg]}) when is_binary(name) do
     if String.contains?(name, "_to_") do
       target_type = name |> String.split("_to_") |> List.last()
-      "(#{to_sql(arg)})::#{target_type}"
+      {"#{wrap(arg, @prec_cast)}::#{target_type}", @prec_cast}
     else
       raise ArgumentError,
             "SqlGenerator.to_sql/1: unsupported AST node: %Func{name: #{inspect(name)}}. " <>
@@ -215,63 +241,94 @@ defmodule Electric.Replication.Eval.SqlGenerator do
   end
 
   # Column references
-  def to_sql(%Ref{path: path}) do
-    Enum.map_join(path, ".", &~s|"#{&1}"|)
+  defp to_sql_prec(%Ref{path: path}) do
+    {Enum.map_join(path, ".", &~s|"#{&1}"|), @prec_atom}
   end
 
   # Constants
-  def to_sql(%Const{value: nil}), do: "NULL"
-  def to_sql(%Const{value: true}), do: "true"
-  def to_sql(%Const{value: false}), do: "false"
+  defp to_sql_prec(%Const{value: nil}), do: {"NULL", @prec_atom}
+  defp to_sql_prec(%Const{value: true}), do: {"true", @prec_atom}
+  defp to_sql_prec(%Const{value: false}), do: {"false", @prec_atom}
 
-  def to_sql(%Const{value: value}) when is_binary(value) do
+  defp to_sql_prec(%Const{value: value}) when is_binary(value) do
     escaped = String.replace(value, "'", "''")
-    "'#{escaped}'"
+    {"'#{escaped}'", @prec_atom}
   end
 
-  def to_sql(%Const{value: value}) when is_integer(value) or is_float(value),
-    do: "#{value}"
+  defp to_sql_prec(%Const{value: value}) when is_integer(value) or is_float(value),
+    do: {"#{value}", @prec_atom}
 
   # Constant-folded arrays (parser evaluates e.g. ARRAY[1, 2] to %Const{value: [1, 2]})
-  def to_sql(%Const{value: value}) when is_list(value) do
+  defp to_sql_prec(%Const{value: value}) when is_list(value) do
     elements = Enum.map_join(value, ", ", &const_list_element_to_sql/1)
-    "ARRAY[#{elements}]"
+    {"ARRAY[#{elements}]", @prec_atom}
   end
 
   # Date/time/interval constants — the parser constant-folds typed literals
   # (e.g. '2024-01-01'::date) into Const nodes with Elixir struct values.
-  def to_sql(%Const{value: %Date{} = d}), do: "'#{Date.to_iso8601(d)}'::date"
-  def to_sql(%Const{value: %Time{} = t}), do: "'#{Time.to_iso8601(t)}'::time"
+  defp to_sql_prec(%Const{value: %Date{} = d}), do: {"'#{Date.to_iso8601(d)}'::date", @prec_atom}
+  defp to_sql_prec(%Const{value: %Time{} = t}), do: {"'#{Time.to_iso8601(t)}'::time", @prec_atom}
 
-  def to_sql(%Const{value: %NaiveDateTime{} = ndt}),
-    do: "'#{NaiveDateTime.to_iso8601(ndt)}'::timestamp"
+  defp to_sql_prec(%Const{value: %NaiveDateTime{} = ndt}),
+    do: {"'#{NaiveDateTime.to_iso8601(ndt)}'::timestamp", @prec_atom}
 
-  def to_sql(%Const{value: %DateTime{} = dt}),
-    do: "'#{DateTime.to_iso8601(dt)}'::timestamptz"
+  defp to_sql_prec(%Const{value: %DateTime{} = dt}),
+    do: {"'#{DateTime.to_iso8601(dt)}'::timestamptz", @prec_atom}
 
-  def to_sql(%Const{value: %PgInterop.Interval{} = i}),
-    do: "'#{PgInterop.Interval.format(i)}'::interval"
+  defp to_sql_prec(%Const{value: %PgInterop.Interval{} = i}),
+    do: {"'#{PgInterop.Interval.format(i)}'::interval", @prec_atom}
 
   # Row expressions — e.g. ROW(a, b) or (a, b) in row comparisons
-  def to_sql(%RowExpr{elements: elements}) do
+  defp to_sql_prec(%RowExpr{elements: elements}) do
     values = Enum.map_join(elements, ", ", &to_sql/1)
-    "ROW(#{values})"
+    {"ROW(#{values})", @prec_atom}
   end
 
   # Array literals
-  def to_sql(%Array{elements: elements}) do
+  defp to_sql_prec(%Array{elements: elements}) do
     values = Enum.map_join(elements, ", ", &to_sql/1)
-    "ARRAY[#{values}]"
+    {"ARRAY[#{values}]", @prec_atom}
   end
 
   # Catch-all — fail loudly so unsupported operators are caught at shape
   # creation time, not at query time.
-  def to_sql(other) do
+  defp to_sql_prec(other) do
     raise ArgumentError,
           "SqlGenerator.to_sql/1: unsupported AST node: #{inspect(other)}. " <>
             "This WHERE clause contains an operator or expression type that " <>
             "cannot be converted back to SQL for active_conditions generation."
   end
+
+  # --- Precedence helpers ---
+
+  # Binary operator, left-associative: left child at prec, right child at prec+1
+  defp binary_op(left, op, right, prec) do
+    {"#{wrap(left, prec)} #{op} #{wrap(right, prec + 1)}", prec}
+  end
+
+  # Binary operator, right-associative: left child at prec+1, right child at prec
+  defp binary_op_right(left, op, right, prec) do
+    {"#{wrap(left, prec + 1)} #{op} #{wrap(right, prec)}", prec}
+  end
+
+  # Prefix unary operator: operand at same prec (same-level nesting is fine)
+  defp prefix_op(op, operand, prec) do
+    {"#{op} #{wrap(operand, prec)}", prec}
+  end
+
+  # Postfix unary operator: operand must be strictly higher precedence to avoid
+  # ambiguity (e.g. `x IS DISTINCT FROM y IS NULL` is ambiguous)
+  defp postfix_op(operand, op, prec) do
+    {"#{wrap(operand, prec + 1)} #{op}", prec}
+  end
+
+  # Wrap an AST node in parens if its precedence is lower than the context
+  defp wrap(ast, context_prec) do
+    {sql, prec} = to_sql_prec(ast)
+    if prec < context_prec, do: "(#{sql})", else: sql
+  end
+
+  # --- Unchanged helpers ---
 
   # Helper for rendering constant-folded array elements (plain Elixir values, not AST nodes)
   defp const_list_element_to_sql(nil), do: "NULL"

--- a/packages/sync-service/lib/electric/replication/eval/sql_generator.ex
+++ b/packages/sync-service/lib/electric/replication/eval/sql_generator.ex
@@ -1,0 +1,312 @@
+defmodule Electric.Replication.Eval.SqlGenerator do
+  @moduledoc """
+  Converts a parsed WHERE clause AST back into a SQL string.
+
+  This is the inverse of `Parser` — where `Parser` turns SQL text into an AST,
+  `SqlGenerator` turns that AST back into SQL text. Used whenever the server
+  needs to embed a condition in a generated query (snapshot active_conditions,
+  move-in exclusion clauses, etc.).
+
+  Must handle every AST node type that `Parser` can produce. Raises
+  `ArgumentError` for unrecognised nodes so gaps are caught at shape
+  creation time, but the property-based round-trip test (see Tests below)
+  enforces that no parseable expression triggers this error.
+  """
+
+  alias Electric.Replication.Eval.Parser.{Const, Ref, Func, Array, RowExpr}
+
+  @doc """
+  Convert an AST node to a SQL string.
+
+  Handles: comparison operators (=, <>, <, >, <=, >=), pattern matching
+  (LIKE, ILIKE, NOT LIKE, NOT ILIKE), nullability (IS NULL, IS NOT NULL),
+  membership (IN), logical operators (AND, OR, NOT), boolean tests
+  (IS TRUE, IS FALSE, IS UNKNOWN, etc.), column references, constants
+  (strings, integers, floats, booleans, NULL), type casts, arithmetic
+  operators (+, -, *, /, ^, |/, @, &, |, #, ~), string concatenation (||),
+  array operators (@>, <@, &&), array/slice access, DISTINCT/NOT DISTINCT,
+  ANY/ALL, and sublink membership checks.
+
+  Raises `ArgumentError` for unrecognised AST nodes.
+  """
+  @spec to_sql(term()) :: String.t()
+
+  # Comparison operators — names are stored with surrounding quotes
+  def to_sql(%Func{name: "\"=\"", args: [left, right]}),
+    do: "(#{to_sql(left)} = #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"<>\"", args: [left, right]}),
+    do: "(#{to_sql(left)} <> #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"<\"", args: [left, right]}),
+    do: "(#{to_sql(left)} < #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\">\"", args: [left, right]}),
+    do: "(#{to_sql(left)} > #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"<=\"", args: [left, right]}),
+    do: "(#{to_sql(left)} <= #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\">=\"", args: [left, right]}),
+    do: "(#{to_sql(left)} >= #{to_sql(right)})"
+
+  # Pattern matching
+  def to_sql(%Func{name: "\"~~\"", args: [left, right]}),
+    do: "(#{to_sql(left)} LIKE #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"~~*\"", args: [left, right]}),
+    do: "(#{to_sql(left)} ILIKE #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"!~~\"", args: [left, right]}),
+    do: "(#{to_sql(left)} NOT LIKE #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"!~~*\"", args: [left, right]}),
+    do: "(#{to_sql(left)} NOT ILIKE #{to_sql(right)})"
+
+  # Nullability — parser produces "is null"/"is not null" from constant folding
+  # and "IS_NULL"/"IS_NOT_NULL" from NullTest on column refs
+  def to_sql(%Func{name: name, args: [arg]}) when name in ["is null", "IS_NULL"],
+    do: "(#{to_sql(arg)} IS NULL)"
+
+  def to_sql(%Func{name: name, args: [arg]}) when name in ["is not null", "IS_NOT_NULL"],
+    do: "(#{to_sql(arg)} IS NOT NULL)"
+
+  # Boolean tests
+  def to_sql(%Func{name: "IS_TRUE", args: [arg]}),
+    do: "(#{to_sql(arg)} IS TRUE)"
+
+  def to_sql(%Func{name: "IS_NOT_TRUE", args: [arg]}),
+    do: "(#{to_sql(arg)} IS NOT TRUE)"
+
+  def to_sql(%Func{name: "IS_FALSE", args: [arg]}),
+    do: "(#{to_sql(arg)} IS FALSE)"
+
+  def to_sql(%Func{name: "IS_NOT_FALSE", args: [arg]}),
+    do: "(#{to_sql(arg)} IS NOT FALSE)"
+
+  def to_sql(%Func{name: "IS_UNKNOWN", args: [arg]}),
+    do: "(#{to_sql(arg)} IS UNKNOWN)"
+
+  def to_sql(%Func{name: "IS_NOT_UNKNOWN", args: [arg]}),
+    do: "(#{to_sql(arg)} IS NOT UNKNOWN)"
+
+  # Membership (IN with literal array)
+  def to_sql(%Func{name: "in", args: [left, %Array{elements: elements}]}) do
+    values = Enum.map_join(elements, ", ", &to_sql/1)
+    "(#{to_sql(left)} IN (#{values}))"
+  end
+
+  # Sublink membership check (IN with subquery) — rendered as a placeholder
+  # since the actual subquery SQL is not in the AST
+  def to_sql(%Func{name: "sublink_membership_check", args: [left, %Ref{path: path}]}) do
+    sublink_ref = Enum.join(path, ".")
+    "(#{to_sql(left)} IN (SELECT #{sublink_ref}))"
+  end
+
+  # Logical operators
+  def to_sql(%Func{name: "not", args: [inner]}),
+    do: "(NOT #{to_sql(inner)})"
+
+  def to_sql(%Func{name: "and", args: args}) do
+    conditions = Enum.map_join(args, " AND ", &to_sql/1)
+    "(#{conditions})"
+  end
+
+  def to_sql(%Func{name: "or", args: args}) do
+    conditions = Enum.map_join(args, " OR ", &to_sql/1)
+    "(#{conditions})"
+  end
+
+  # DISTINCT / NOT DISTINCT — args are [left, right, comparison_func]
+  def to_sql(%Func{name: "values_distinct?", args: [left, right | _]}),
+    do: "(#{to_sql(left)} IS DISTINCT FROM #{to_sql(right)})"
+
+  def to_sql(%Func{name: "values_not_distinct?", args: [left, right | _]}),
+    do: "(#{to_sql(left)} IS NOT DISTINCT FROM #{to_sql(right)})"
+
+  # ANY / ALL — arg is a single Func with map_over_array_in_pos
+  def to_sql(%Func{name: "any", args: [%Func{} = inner]}) do
+    {op_sql, left, right} = extract_mapped_operator(inner)
+    "(#{to_sql(left)} #{op_sql} ANY(#{to_sql(right)}))"
+  end
+
+  def to_sql(%Func{name: "all", args: [%Func{} = inner]}) do
+    {op_sql, left, right} = extract_mapped_operator(inner)
+    "(#{to_sql(left)} #{op_sql} ALL(#{to_sql(right)}))"
+  end
+
+  # Arithmetic binary operators
+  def to_sql(%Func{name: "\"+\"", args: [left, right]}),
+    do: "(#{to_sql(left)} + #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"-\"", args: [left, right]}),
+    do: "(#{to_sql(left)} - #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"*\"", args: [left, right]}),
+    do: "(#{to_sql(left)} * #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"/\"", args: [left, right]}),
+    do: "(#{to_sql(left)} / #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"^\"", args: [left, right]}),
+    do: "(#{to_sql(left)} ^ #{to_sql(right)})"
+
+  # Bitwise binary operators
+  def to_sql(%Func{name: "\"&\"", args: [left, right]}),
+    do: "(#{to_sql(left)} & #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"|\"", args: [left, right]}),
+    do: "(#{to_sql(left)} | #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"#\"", args: [left, right]}),
+    do: "(#{to_sql(left)} # #{to_sql(right)})"
+
+  # Unary operators
+  def to_sql(%Func{name: "\"+\"", args: [arg]}),
+    do: "(+ #{to_sql(arg)})"
+
+  def to_sql(%Func{name: "\"-\"", args: [arg]}),
+    do: "(- #{to_sql(arg)})"
+
+  def to_sql(%Func{name: "\"~\"", args: [arg]}),
+    do: "(~ #{to_sql(arg)})"
+
+  def to_sql(%Func{name: "\"|/\"", args: [arg]}),
+    do: "(|/ #{to_sql(arg)})"
+
+  def to_sql(%Func{name: "\"@\"", args: [arg]}),
+    do: "(@ #{to_sql(arg)})"
+
+  # String concatenation
+  def to_sql(%Func{name: "\"||\"", args: [left, right]}),
+    do: "(#{to_sql(left)} || #{to_sql(right)})"
+
+  # Array operators
+  def to_sql(%Func{name: "\"@>\"", args: [left, right]}),
+    do: "(#{to_sql(left)} @> #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"<@\"", args: [left, right]}),
+    do: "(#{to_sql(left)} <@ #{to_sql(right)})"
+
+  def to_sql(%Func{name: "\"&&\"", args: [left, right]}),
+    do: "(#{to_sql(left)} && #{to_sql(right)})"
+
+  # Named functions (lower, upper, like, ilike, array_*, justify_*, timezone, casts, etc.)
+  # These are Func nodes where the name is a plain identifier (no quotes around operators)
+  def to_sql(%Func{name: name, args: args})
+      when name in ~w(lower upper like ilike array_cat array_prepend array_append array_ndims
+                      justify_days justify_hours justify_interval timezone
+                      index_access slice_access) do
+    arg_list = Enum.map_join(args, ", ", &to_sql/1)
+    "#{name}(#{arg_list})"
+  end
+
+  # Type cast functions (e.g., "int4_to_bool", "text_to_int4")
+  def to_sql(%Func{name: name, args: [arg]}) when is_binary(name) do
+    if String.contains?(name, "_to_") do
+      target_type = name |> String.split("_to_") |> List.last()
+      "(#{to_sql(arg)})::#{target_type}"
+    else
+      raise ArgumentError,
+            "SqlGenerator.to_sql/1: unsupported AST node: %Func{name: #{inspect(name)}}. " <>
+              "This WHERE clause contains an operator or expression type that " <>
+              "cannot be converted back to SQL for active_conditions generation."
+    end
+  end
+
+  # Column references
+  def to_sql(%Ref{path: path}) do
+    Enum.map_join(path, ".", &~s|"#{&1}"|)
+  end
+
+  # Constants
+  def to_sql(%Const{value: nil}), do: "NULL"
+  def to_sql(%Const{value: true}), do: "true"
+  def to_sql(%Const{value: false}), do: "false"
+
+  def to_sql(%Const{value: value}) when is_binary(value) do
+    escaped = String.replace(value, "'", "''")
+    "'#{escaped}'"
+  end
+
+  def to_sql(%Const{value: value}) when is_integer(value) or is_float(value),
+    do: "#{value}"
+
+  # Constant-folded arrays (parser evaluates e.g. ARRAY[1, 2] to %Const{value: [1, 2]})
+  def to_sql(%Const{value: value}) when is_list(value) do
+    elements = Enum.map_join(value, ", ", &const_list_element_to_sql/1)
+    "ARRAY[#{elements}]"
+  end
+
+  # Date/time/interval constants — the parser constant-folds typed literals
+  # (e.g. '2024-01-01'::date) into Const nodes with Elixir struct values.
+  def to_sql(%Const{value: %Date{} = d}), do: "'#{Date.to_iso8601(d)}'::date"
+  def to_sql(%Const{value: %Time{} = t}), do: "'#{Time.to_iso8601(t)}'::time"
+
+  def to_sql(%Const{value: %NaiveDateTime{} = ndt}),
+    do: "'#{NaiveDateTime.to_iso8601(ndt)}'::timestamp"
+
+  def to_sql(%Const{value: %DateTime{} = dt}),
+    do: "'#{DateTime.to_iso8601(dt)}'::timestamptz"
+
+  def to_sql(%Const{value: %PgInterop.Interval{} = i}),
+    do: "'#{PgInterop.Interval.format(i)}'::interval"
+
+  # Row expressions — e.g. ROW(a, b) or (a, b) in row comparisons
+  def to_sql(%RowExpr{elements: elements}) do
+    values = Enum.map_join(elements, ", ", &to_sql/1)
+    "ROW(#{values})"
+  end
+
+  # Array literals
+  def to_sql(%Array{elements: elements}) do
+    values = Enum.map_join(elements, ", ", &to_sql/1)
+    "ARRAY[#{values}]"
+  end
+
+  # Catch-all — fail loudly so unsupported operators are caught at shape
+  # creation time, not at query time.
+  def to_sql(other) do
+    raise ArgumentError,
+          "SqlGenerator.to_sql/1: unsupported AST node: #{inspect(other)}. " <>
+            "This WHERE clause contains an operator or expression type that " <>
+            "cannot be converted back to SQL for active_conditions generation."
+  end
+
+  # Helper for rendering constant-folded array elements (plain Elixir values, not AST nodes)
+  defp const_list_element_to_sql(nil), do: "NULL"
+  defp const_list_element_to_sql(true), do: "true"
+  defp const_list_element_to_sql(false), do: "false"
+
+  defp const_list_element_to_sql(value) when is_binary(value) do
+    escaped = String.replace(value, "'", "''")
+    "'#{escaped}'"
+  end
+
+  defp const_list_element_to_sql(value) when is_integer(value) or is_float(value),
+    do: "#{value}"
+
+  defp const_list_element_to_sql(value) when is_list(value) do
+    elements = Enum.map_join(value, ", ", &const_list_element_to_sql/1)
+    "ARRAY[#{elements}]"
+  end
+
+  # Helper for ANY/ALL: extract the operator, left operand, and array right operand
+  # from a Func with map_over_array_in_pos set
+  defp extract_mapped_operator(%Func{name: name, args: [left, right]}) do
+    op_sql =
+      case name do
+        ~s|"="| -> "="
+        ~s|"<>"| -> "<>"
+        ~s|"<"| -> "<"
+        ~s|">"| -> ">"
+        ~s|"<="| -> "<="
+        ~s|">="| -> ">="
+        ~s|"~~"| -> "LIKE"
+        ~s|"~~*"| -> "ILIKE"
+        other -> String.trim(other, "\"")
+      end
+
+    {op_sql, left, right}
+  end
+end

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -49,7 +49,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
   @behaviour Electric.ShapeCache.Storage
 
   # Struct that can be used to create a writer_state record or a reader
-  @version 1
+  @version 2
   defstruct [
     :buffer_ets,
     :chunk_bytes_threshold,
@@ -878,15 +878,15 @@ defmodule Electric.ShapeCache.PureFileStorage do
     FileInfo.mkdir_p(shape_snapshot_dir(opts))
 
     stream
-    |> Stream.map(fn [key, tags, json] ->
-      tags_binary = Enum.map(tags, &[<<byte_size(&1)::16>>, &1])
+    |> Stream.map(fn [key, condition_hashes, json] ->
+      hashes_binary = Enum.map(condition_hashes, &[<<byte_size(&1)::16>>, &1])
 
       [
         <<byte_size(key)::32>>,
         <<byte_size(json)::64>>,
         <<?i::8>>,
-        <<length(tags)::16>>,
-        tags_binary,
+        <<length(condition_hashes)::16>>,
+        hashes_binary,
         key,
         json
       ]
@@ -908,9 +908,9 @@ defmodule Electric.ShapeCache.PureFileStorage do
            LogOffset.increment(starting_offset)}
         end,
         fn {file, offset} ->
-          with {:meta, <<key_size::32, json_size::64, op_type::8, tag_count::16>>} <-
+          with {:meta, <<key_size::32, json_size::64, op_type::8, hash_count::16>>} <-
                  {:meta, IO.binread(file, 15)},
-               _tags = read_tags(file, tag_count),
+               _condition_hashes = read_condition_hashes(file, hash_count),
                <<key::binary-size(key_size)>> <- IO.binread(file, key_size),
                <<json::binary-size(json_size)>> <- IO.binread(file, json_size) do
             {[{offset, key_size, key, op_type, 0, json_size, json}],
@@ -936,11 +936,12 @@ defmodule Electric.ShapeCache.PureFileStorage do
     {inserted_range, state}
   end
 
-  defp read_tags(file, tag_count) do
-    for _ <- 1..tag_count//1 do
-      <<tag_size::16>> = IO.binread(file, 2)
-      <<tag::binary-size(tag_size)>> = IO.binread(file, tag_size)
-      tag
+  # Read condition_hashes from binary file, returning a position-indexed map.
+  defp read_condition_hashes(file, hash_count) do
+    for i <- 0..(hash_count - 1)//1, into: %{} do
+      <<hash_size::16>> = IO.binread(file, 2)
+      <<hash::binary-size(hash_size)>> = IO.binread(file, hash_size)
+      {i, hash}
     end
   end
 
@@ -949,7 +950,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
         writer_state(opts: opts, writer_acc: acc) = state,
         touch_tracker,
         snapshot,
-        tags_to_skip
+        condition_hashes_to_skip
       ) do
     starting_offset = WriteLoop.last_seen_offset(acc)
 
@@ -961,13 +962,13 @@ defmodule Electric.ShapeCache.PureFileStorage do
            LogOffset.increment(starting_offset)}
         end,
         fn {file, offset} ->
-          with {:meta, <<key_size::32, json_size::64, op_type::8, tag_count::16>>} <-
+          with {:meta, <<key_size::32, json_size::64, op_type::8, hash_count::16>>} <-
                  {:meta, IO.binread(file, 15)},
-               tags = read_tags(file, tag_count),
+               condition_hashes = read_condition_hashes(file, hash_count),
                <<key::binary-size(key_size)>> <- IO.binread(file, key_size),
                <<json::binary-size(json_size)>> <- IO.binread(file, json_size) do
             # Check if this row should be skipped
-            if all_parents_moved_out?(tags, tags_to_skip) or
+            if should_skip_for_moved_out?(condition_hashes, condition_hashes_to_skip) or
                  Electric.Shapes.Consumer.MoveIns.should_skip_query_row?(
                    touch_tracker,
                    snapshot,
@@ -1001,8 +1002,18 @@ defmodule Electric.ShapeCache.PureFileStorage do
     {inserted_range, state}
   end
 
-  defp all_parents_moved_out?(tags, tags_to_skip) do
-    tags != [] and Enum.all?(tags, &MapSet.member?(tags_to_skip, &1))
+  # Position-aware filtering: ANY match at a tracked position means skip.
+  defp should_skip_for_moved_out?(_condition_hashes, condition_hashes_to_skip)
+       when map_size(condition_hashes_to_skip) == 0,
+       do: false
+
+  defp should_skip_for_moved_out?(condition_hashes, condition_hashes_to_skip) do
+    Enum.any?(condition_hashes_to_skip, fn {position, skip_set} ->
+      case condition_hashes do
+        %{^position => hash} -> MapSet.member?(skip_set, hash)
+        _ -> false
+      end
+    end)
   end
 
   def append_control_message!(control_message, writer_state(writer_acc: acc) = state)

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -118,7 +118,7 @@ defmodule Electric.ShapeCache.Storage do
               writer_state(),
               touch_tracker :: %{String.t() => pos_integer()},
               snapshot :: {pos_integer(), pos_integer(), [pos_integer()]},
-              tags_to_skip :: MapSet.t(String.t())
+              condition_hashes_to_skip :: %{non_neg_integer() => MapSet.t(String.t())}
             ) ::
               {inserted_range :: {LogOffset.t(), LogOffset.t()}, writer_state()} | no_return()
 
@@ -305,7 +305,7 @@ defmodule Electric.ShapeCache.Storage do
         {mod, writer_state},
         touch_tracker,
         snapshot,
-        tags_to_skip
+        condition_hashes_to_skip
       ) do
     {inserted_range, new_writer_state} =
       mod.append_move_in_snapshot_to_log_filtered!(
@@ -313,7 +313,7 @@ defmodule Electric.ShapeCache.Storage do
         writer_state,
         touch_tracker,
         snapshot,
-        tags_to_skip
+        condition_hashes_to_skip
       )
 
     {inserted_range, {mod, new_writer_state}}

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -284,17 +284,10 @@ defmodule Electric.Shapes.Consumer do
     feature_flags = Electric.StackConfig.lookup(state.stack_id, :feature_flags, [])
     tagged_subqueries_enabled? = "tagged_subqueries" in feature_flags
 
-    # We need to invalidate the consumer in the following cases:
-    # - tagged subqueries are disabled since we cannot support causally correct event processing of 3+ level dependency trees
-    #   so we just invalidating this middle shape instead
-    # - the where clause has an OR combined with the subquery so we can't tell if the move ins/outs actually affect the shape or not
-    # - the where clause has a NOT combined with the subquery (e.g. NOT IN) since move-in to the subquery
-    #   should cause move-out from the outer shape, which isn't implemented
-    # - the shape has multiple subqueries at the same level since we can't correctly determine
-    #   which dependency caused the move-in/out
-    should_invalidate? =
-      not tagged_subqueries_enabled? or state.or_with_subquery? or state.not_with_subquery? or
-        length(state.shape.shape_dependencies) > 1
+    # Invalidate if tagged subqueries feature flag is disabled.
+    # OR/NOT with subqueries and multiple dependencies are now handled by
+    # DNF decomposition and position-based tagging (via DnfContext).
+    should_invalidate? = not tagged_subqueries_enabled?
 
     if should_invalidate? do
       stop_and_clean(state)

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -284,12 +284,7 @@ defmodule Electric.Shapes.Consumer do
     feature_flags = Electric.StackConfig.lookup(state.stack_id, :feature_flags, [])
     tagged_subqueries_enabled? = "tagged_subqueries" in feature_flags
 
-    # Invalidate if tagged subqueries feature flag is disabled.
-    # OR/NOT with subqueries and multiple dependencies are now handled by
-    # DNF decomposition and position-based tagging (via DnfContext).
-    should_invalidate? = not tagged_subqueries_enabled?
-
-    if should_invalidate? do
+    if not tagged_subqueries_enabled? do
       stop_and_clean(state)
     else
       {state, move_in_notification} =

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -292,12 +292,15 @@ defmodule Electric.Shapes.Consumer do
     if should_invalidate? do
       stop_and_clean(state)
     else
-      {state, notification} =
-        state
-        |> MoveHandling.process_move_ins(dep_handle, move_in)
-        |> MoveHandling.process_move_outs(dep_handle, move_out)
+      {state, move_in_notification} =
+        MoveHandling.process_move_ins(state, dep_handle, move_in)
 
-      notify_new_changes(state, notification)
+      state = notify_new_changes(state, move_in_notification)
+
+      {state, move_out_notification} =
+        MoveHandling.process_move_outs(state, dep_handle, move_out)
+
+      state = notify_new_changes(state, move_out_notification)
 
       {:noreply, state}
     end

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -287,6 +287,8 @@ defmodule Electric.Shapes.Consumer do
     if not tagged_subqueries_enabled? do
       stop_and_clean(state)
     else
+      state = State.mark_dep_seen(state, dep_handle)
+
       {state, move_in_notification} =
         MoveHandling.process_move_ins(state, dep_handle, move_in)
 
@@ -501,6 +503,7 @@ defmodule Electric.Shapes.Consumer do
       writer: writer
     } = state
 
+    state = State.reset_seen_deps(state)
     state = State.remove_completed_move_ins(state, txn)
 
     Logger.debug(fn -> "Txn received in Shapes.Consumer: #{inspect(txn)}" end)

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -504,6 +504,7 @@ defmodule Electric.Shapes.Consumer do
       writer: writer
     } = state
 
+    state = %{state | last_processed_xid: xid}
     state = State.reset_dep_lsns(state)
     state = State.remove_completed_move_ins(state, txn)
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -274,7 +274,7 @@ defmodule Electric.Shapes.Consumer do
   end
 
   def handle_info(
-        {:materializer_changes, dep_handle, %{move_in: move_in, move_out: move_out}},
+        {:materializer_changes, dep_handle, %{move_in: move_in, move_out: move_out}, tx_offset},
         state
       ) do
     Logger.debug(fn ->
@@ -287,7 +287,8 @@ defmodule Electric.Shapes.Consumer do
     if not tagged_subqueries_enabled? do
       stop_and_clean(state)
     else
-      state = State.mark_dep_seen(state, dep_handle)
+      state = State.reset_dep_lsns(state)
+      state = State.record_dep_lsn(state, dep_handle, tx_offset)
 
       {state, move_in_notification} =
         MoveHandling.process_move_ins(state, dep_handle, move_in)
@@ -503,7 +504,7 @@ defmodule Electric.Shapes.Consumer do
       writer: writer
     } = state
 
-    state = State.reset_seen_deps(state)
+    state = State.reset_dep_lsns(state)
     state = State.remove_completed_move_ins(state, txn)
 
     Logger.debug(fn -> "Txn received in Shapes.Consumer: #{inspect(txn)}" end)
@@ -597,7 +598,7 @@ defmodule Electric.Shapes.Consumer do
         ) :: map()
   defp notify_new_changes(state, changes_or_bounds, latest_log_offset) do
     if state.materializer_subscribed? do
-      Materializer.new_changes(Map.take(state, [:stack_id, :shape_handle]), changes_or_bounds)
+      Materializer.new_changes(Map.take(state, [:stack_id, :shape_handle]), changes_or_bounds, latest_log_offset.tx_offset)
     end
 
     Registry.dispatch(

--- a/packages/sync-service/lib/electric/shapes/consumer/change_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/change_handling.ex
@@ -61,7 +61,8 @@ defmodule Electric.Shapes.Consumer.ChangeHandling do
       case Shape.convert_change(shape, change,
              stack_id: stack_id,
              shape_handle: shape_handle,
-             extra_refs: ctx.extra_refs
+             extra_refs: ctx.extra_refs,
+             dnf_context: state.dnf_context
            ) do
         [] ->
           do_process_changes(rest, state, ctx, acc, count)

--- a/packages/sync-service/lib/electric/shapes/consumer/change_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/change_handling.ex
@@ -1,4 +1,5 @@
 defmodule Electric.Shapes.Consumer.ChangeHandling do
+  alias Electric.Shapes.Consumer.DnfContext
   alias Electric.Shapes.Consumer.MoveIns
   alias Electric.Replication.Eval.Runner
   alias Electric.Shapes.Shape
@@ -103,7 +104,14 @@ defmodule Electric.Shapes.Consumer.ChangeHandling do
         # won't return this row and we need to process this change normally.
         case ctx.extra_refs do
           {_extra_refs_old, extra_refs_new} ->
-            WhereClause.includes_record?(state.shape.where, change.record, extra_refs_new)
+            WhereClause.includes_record?(state.shape.where, change.record, extra_refs_new) and
+              not record_excluded_by_move_in?(
+                change,
+                state,
+                ctx,
+                referenced_values,
+                extra_refs_new
+              )
 
           _ ->
             # If extra_refs is not a tuple (e.g., empty map in tests), fall back to
@@ -113,6 +121,32 @@ defmodule Electric.Shapes.Consumer.ChangeHandling do
       end
     else
       false
+    end
+  end
+
+  # Check if the record would be excluded by the move-in query's exclusion clauses.
+  # If the record matches a non-containing disjunct, the move-in's AND NOT (...)
+  # will filter it out, so we should NOT skip this change.
+  defp record_excluded_by_move_in?(change, state, ctx, referenced_values, extra_refs) do
+    case state.dnf_context do
+      %DnfContext{decomposition: decomposition} when decomposition != nil ->
+        active_conditions =
+          DnfContext.compute_active_conditions(
+            state.dnf_context,
+            change.record,
+            state.shape.where.used_refs,
+            extra_refs
+          )
+
+        MoveIns.record_excluded_by_matching_move_in?(
+          state.move_handling_state,
+          referenced_values,
+          active_conditions,
+          ctx.xid
+        )
+
+      _ ->
+        false
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer/dnf_context.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/dnf_context.ex
@@ -121,6 +121,25 @@ defmodule Electric.Shapes.Consumer.DnfContext do
   end
 
   @doc """
+  Compute active_conditions and evaluate DNF inclusion in one call.
+
+  Returns `{included?, active_conditions}` where `included?` is true if
+  the record satisfies at least one disjunct, and `active_conditions` is
+  the per-position boolean list for the wire format.
+  """
+  @spec evaluate_record(t(), map(), map(), map()) :: {boolean(), [boolean()]}
+  def evaluate_record(
+        %__MODULE__{decomposition: decomposition} = ctx,
+        record,
+        used_refs,
+        extra_refs
+      ) do
+    active_conditions = compute_active_conditions(ctx, record, used_refs, extra_refs)
+    included = evaluate_dnf(active_conditions, decomposition.disjuncts_positions)
+    {included, active_conditions}
+  end
+
+  @doc """
   Extract the sublink index from a sublink_membership_check AST node.
 
   Used to resolve which dependency shape a subquery corresponds to, even when

--- a/packages/sync-service/lib/electric/shapes/consumer/dnf_context.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/dnf_context.ex
@@ -160,7 +160,7 @@ defmodule Electric.Shapes.Consumer.DnfContext do
 
   defp build_negated_positions(decomposition) do
     decomposition.subexpressions
-    |> Enum.filter(fn {_pos, subexpr} -> subexpr.negated end)
+    |> Enum.filter(fn {_pos, subexpr} -> subexpr.negated and subexpr.is_subquery end)
     |> Enum.map(fn {pos, _} -> pos end)
     |> MapSet.new()
   end

--- a/packages/sync-service/lib/electric/shapes/consumer/dnf_context.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/dnf_context.ex
@@ -1,0 +1,180 @@
+defmodule Electric.Shapes.Consumer.DnfContext do
+  @moduledoc """
+  Holds DNF decomposition state for a shape's WHERE clause.
+
+  Built from a Shape at consumer startup time, this struct encapsulates all
+  DNF-related state: the decomposition result, position-to-dependency mappings,
+  and negated position tracking.
+
+  The `DnfContext` is computed once and stored in `Consumer.State`, then passed
+  explicitly to functions that need it (move_handling, change_handling,
+  subquery_moves, querying).
+  """
+
+  alias Electric.Replication.Eval.Decomposer
+  alias Electric.Replication.Eval.Parser.Func
+  alias Electric.Replication.Eval.Parser.Ref
+  alias Electric.Replication.Eval.Runner
+  alias Electric.Shapes.Shape
+
+  defstruct [
+    :decomposition,
+    position_to_dependency_map: %{},
+    dependency_to_positions_map: %{},
+    negated_positions: MapSet.new()
+  ]
+
+  @type t :: %__MODULE__{
+          decomposition: Decomposer.decomposition(),
+          position_to_dependency_map: %{non_neg_integer() => term()},
+          dependency_to_positions_map: %{term() => [non_neg_integer()]},
+          negated_positions: MapSet.t(non_neg_integer())
+        }
+
+  @doc """
+  Build a DnfContext from a Shape and its dependency mappings.
+
+  Returns nil if the shape has no WHERE clause or no dependencies (no DNF needed).
+  Calls `Decomposer.decompose/1` once; the result is cached on the struct.
+  """
+  @spec from_shape(Shape.t()) :: t() | nil
+  def from_shape(%Shape{where: nil}), do: nil
+  def from_shape(%Shape{shape_dependencies: []}), do: nil
+
+  def from_shape(%Shape{} = shape) do
+    case Decomposer.decompose(shape.where.eval) do
+      {:ok, decomposition} ->
+        pos_to_dep =
+          build_position_to_dependency_map(decomposition, shape.shape_dependencies_handles)
+
+        dep_to_pos = build_dependency_to_positions_map(pos_to_dep)
+        negated = build_negated_positions(decomposition)
+
+        %__MODULE__{
+          decomposition: decomposition,
+          position_to_dependency_map: pos_to_dep,
+          dependency_to_positions_map: dep_to_pos,
+          negated_positions: negated
+        }
+
+      {:error, _reason} ->
+        nil
+    end
+  end
+
+  @doc "Which DNF positions does this dependency handle affect?"
+  @spec get_positions_for_dependency(t(), term()) :: [non_neg_integer()]
+  def get_positions_for_dependency(%__MODULE__{dependency_to_positions_map: map}, dep_handle) do
+    Map.get(map, dep_handle, [])
+  end
+
+  @doc "Is this position negated (NOT IN)?"
+  @spec position_negated?(t(), non_neg_integer()) :: boolean()
+  def position_negated?(%__MODULE__{negated_positions: negated}, position) do
+    MapSet.member?(negated, position)
+  end
+
+  @doc "Does this context have a valid DNF with subqueries?"
+  @spec has_valid_dnf?(t() | nil) :: boolean()
+  def has_valid_dnf?(nil), do: false
+
+  def has_valid_dnf?(%__MODULE__{decomposition: decomposition}) do
+    decomposition != nil and decomposition.position_count > 0
+  end
+
+  @doc """
+  Compute active_conditions for a record against the DNF.
+
+  Returns a list of booleans, one per position. For negated positions,
+  the stored AST is the un-negated form, so NOT is applied here to produce
+  the effective value clients can use directly.
+  """
+  @spec compute_active_conditions(t(), map(), map(), map()) :: [boolean()]
+  def compute_active_conditions(
+        %__MODULE__{decomposition: decomposition},
+        record,
+        used_refs,
+        extra_refs
+      ) do
+    %{subexpressions: subexpressions, position_count: position_count} = decomposition
+
+    Enum.map(0..(position_count - 1), fn position ->
+      subexpr = Map.fetch!(subexpressions, position)
+      value = evaluate_subexpression(subexpr, record, used_refs, extra_refs)
+      if subexpr.negated, do: not value, else: value
+    end)
+  end
+
+  @doc """
+  Evaluate DNF to determine if record is included.
+
+  `active_conditions` stores effective values (negation already applied),
+  so we only need position indices.
+  """
+  @spec evaluate_dnf([boolean()], [[Decomposer.position()]]) :: boolean()
+  def evaluate_dnf(active_conditions, disjuncts_positions) do
+    Enum.any?(disjuncts_positions, fn conjunction_positions ->
+      Enum.all?(conjunction_positions, fn pos ->
+        Enum.at(active_conditions, pos, false) == true
+      end)
+    end)
+  end
+
+  @doc """
+  Extract the sublink index from a sublink_membership_check AST node.
+
+  Used to resolve which dependency shape a subquery corresponds to, even when
+  multiple subqueries reference the same column.
+  """
+  @spec extract_sublink_index(term()) :: non_neg_integer() | nil
+  def extract_sublink_index(%Func{name: "sublink_membership_check", args: [_, sublink_ref]}) do
+    case sublink_ref do
+      %Ref{path: ["$sublink", idx_str]} -> String.to_integer(idx_str)
+      _ -> nil
+    end
+  end
+
+  def extract_sublink_index(_), do: nil
+
+  # --- Private helpers ---
+
+  defp build_position_to_dependency_map(decomposition, dep_handles) do
+    decomposition.subexpressions
+    |> Enum.filter(fn {_pos, subexpr} -> subexpr.is_subquery end)
+    |> Enum.flat_map(fn {pos, subexpr} ->
+      case extract_sublink_index(subexpr.ast) do
+        nil ->
+          []
+
+        dep_index ->
+          dep_handle = Enum.at(dep_handles, dep_index)
+          if dep_handle, do: [{pos, dep_handle}], else: []
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp build_dependency_to_positions_map(pos_to_dep) do
+    Enum.group_by(pos_to_dep, fn {_pos, handle} -> handle end, fn {pos, _} -> pos end)
+  end
+
+  defp build_negated_positions(decomposition) do
+    decomposition.subexpressions
+    |> Enum.filter(fn {_pos, subexpr} -> subexpr.negated end)
+    |> Enum.map(fn {pos, _} -> pos end)
+    |> MapSet.new()
+  end
+
+  defp evaluate_subexpression(subexpr, record, used_refs, extra_refs) do
+    ast = subexpr.ast
+    # Build a minimal expression wrapper for evaluation
+    expr = %Electric.Replication.Eval.Expr{eval: ast, used_refs: used_refs, returns: :bool}
+
+    with {:ok, refs} <- Runner.record_to_ref_values(used_refs, record),
+         {:ok, evaluated} <- Runner.execute(expr, Map.merge(refs, extra_refs)) do
+      if is_nil(evaluated), do: false, else: evaluated
+    else
+      _ -> false
+    end
+  end
+end

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -438,36 +438,57 @@ defmodule Electric.Shapes.Consumer.Materializer do
     end
   end
 
+  # Parse a slash-delimited wire-format tag string into {position, hash} pairs.
+  # e.g., "hash1/hash2/" → [{0, "hash1"}, {1, "hash2"}]
+  # Empty segments (from nil positions) are skipped.
+  defp tag_to_position_entries(tag) when is_binary(tag) do
+    tag
+    |> String.split("/")
+    |> Enum.with_index()
+    |> Enum.flat_map(fn
+      {"", _pos} -> []
+      {hash, pos} -> [{pos, hash}]
+    end)
+  end
+
   defp add_row_to_tag_indices(tag_indices, key, move_tags) do
-    # For now we only support one move tag per row (i.e. no `OR`s in the where clause if there's a subquery)
     Enum.reduce(move_tags, tag_indices, fn tag, acc when is_binary(tag) ->
-      Map.update(acc, tag, MapSet.new([key]), &MapSet.put(&1, key))
+      entries = tag_to_position_entries(tag)
+
+      Enum.reduce(entries, acc, fn {pos, hash}, inner_acc ->
+        Map.update(inner_acc, {pos, hash}, MapSet.new([key]), &MapSet.put(&1, key))
+      end)
     end)
   end
 
   defp remove_row_from_tag_indices(tag_indices, key, move_tags) do
     Enum.reduce(move_tags, tag_indices, fn tag, acc when is_binary(tag) ->
-      case Map.fetch(acc, tag) do
-        {:ok, v} ->
-          new_mapset = MapSet.delete(v, key)
+      entries = tag_to_position_entries(tag)
 
-          if MapSet.size(new_mapset) == 0 do
-            Map.delete(acc, tag)
-          else
-            Map.put(acc, tag, new_mapset)
-          end
+      Enum.reduce(entries, acc, fn {pos, hash}, inner_acc ->
+        tag_key = {pos, hash}
 
-        :error ->
-          acc
-      end
+        case Map.fetch(inner_acc, tag_key) do
+          {:ok, v} ->
+            new_mapset = MapSet.delete(v, key)
+
+            if MapSet.size(new_mapset) == 0 do
+              Map.delete(inner_acc, tag_key)
+            else
+              Map.put(inner_acc, tag_key, new_mapset)
+            end
+
+          :error ->
+            inner_acc
+        end
+      end)
     end)
   end
 
   defp pop_keys_from_tag_indices(tag_indices, patterns) do
-    # This implementation is naive while we support only one tag per row and no composite tags.
-    Enum.reduce(patterns, {MapSet.new(), tag_indices}, fn %{pos: _pos, value: value},
+    Enum.reduce(patterns, {MapSet.new(), tag_indices}, fn %{pos: pos, value: value},
                                                           {keys, acc} ->
-      case Map.pop(acc, value) do
+      case Map.pop(acc, {pos, value}) do
         {nil, acc} -> {keys, acc}
         {v, acc} -> {MapSet.union(keys, v), acc}
       end

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -46,9 +46,9 @@ defmodule Electric.Shapes.Consumer.Materializer do
 
   def whereis(stack_id, shape_handle), do: GenServer.whereis(name(stack_id, shape_handle))
 
-  @spec new_changes(map(), list(Changes.change()) | {LogOffset.t(), LogOffset.t()}) :: :ok
-  def new_changes(state, changes) do
-    GenServer.call(name(state), {:new_changes, changes}, :infinity)
+  @spec new_changes(map(), list(Changes.change()) | {LogOffset.t(), LogOffset.t()}, non_neg_integer()) :: :ok
+  def new_changes(state, changes, tx_offset \\ 0) do
+    GenServer.call(name(state), {:new_changes, changes, tx_offset}, :infinity)
   end
 
   def wait_until_ready(state) do
@@ -62,8 +62,11 @@ defmodule Electric.Shapes.Consumer.Materializer do
       raise ~s|Materializer for stack "#{opts.stack_id}" and handle "#{opts.shape_handle}" is not available|
   end
 
-  def get_prev_link_values(opts) do
-    GenServer.call(name(opts), :get_prev_link_values)
+  def get_link_values(opts, tx_offset) do
+    GenServer.call(name(opts), {:get_link_values, tx_offset})
+  catch
+    :exit, _reason ->
+      raise ~s|Materializer for stack "#{opts.stack_id}" and handle "#{opts.shape_handle}" is not available|
   end
 
   def get_all_as_refs(shape, stack_id) when are_deps_filled(shape) do
@@ -102,7 +105,7 @@ defmodule Electric.Shapes.Consumer.Materializer do
         index: %{},
         tag_indices: %{},
         value_counts: %{},
-        prev_value_counts: %{},
+        snapshots: [],
         offset: LogOffset.before_all(),
         subscribed_offset: nil,
         ref: nil,
@@ -151,6 +154,8 @@ defmodule Electric.Shapes.Consumer.Materializer do
       |> decode_json_stream()
       |> apply_changes(state)
 
+    state = store_snapshot(state, state.subscribed_offset.tx_offset)
+
     {:noreply, %{state | offset: offset}}
   end
 
@@ -177,26 +182,27 @@ defmodule Electric.Shapes.Consumer.Materializer do
     {:reply, values, state}
   end
 
-  def handle_call(:get_prev_link_values, _from, %{prev_value_counts: pvc} = state) do
-    {:reply, MapSet.new(Map.keys(pvc)), state}
+  def handle_call({:get_link_values, tx_offset}, _from, state) do
+    values = snapshot_values_for(state.snapshots, tx_offset)
+    {:reply, values, state}
   end
 
   def handle_call(:wait_until_ready, _from, state) do
     {:reply, :ok, state}
   end
 
-  def handle_call({:new_changes, {range_start, range_end}}, _from, state) do
+  def handle_call({:new_changes, {range_start, range_end}, tx_offset}, _from, state) do
     stack_storage = Storage.for_stack(state.stack_id)
     storage = Storage.for_shape(state.shape_handle, stack_storage)
 
     Storage.get_log_stream(range_start, range_end, storage)
     |> decode_json_stream()
-    |> apply_changes_and_notify(state)
+    |> apply_changes_and_notify(state, tx_offset)
     |> then(fn state -> {:reply, :ok, state} end)
   end
 
-  def handle_call({:new_changes, changes}, _from, state) when is_list(changes) do
-    {:reply, :ok, apply_changes_and_notify(changes, state)}
+  def handle_call({:new_changes, changes, tx_offset}, _from, state) when is_list(changes) do
+    {:reply, :ok, apply_changes_and_notify(changes, state, tx_offset)}
   end
 
   def handle_call(:subscribe, {pid, _ref} = _from, state) do
@@ -301,17 +307,39 @@ defmodule Electric.Shapes.Consumer.Materializer do
     Eval.Env.const_to_pg_string(Eval.Env.new(), value, type)
   end
 
-  defp apply_changes_and_notify(changes, state) do
-    state = %{state | prev_value_counts: state.value_counts}
+  defp apply_changes_and_notify(changes, state, tx_offset) do
     {state, events} = apply_changes(changes, state)
+    state = store_snapshot(state, tx_offset)
 
     if events != %{} do
       for pid <- state.subscribers do
-        send(pid, {:materializer_changes, state.shape_handle, events})
+        send(pid, {:materializer_changes, state.shape_handle, events, tx_offset})
       end
     end
 
     state
+  end
+
+  defp store_snapshot(state, tx_offset) do
+    entry = {tx_offset, state.value_counts}
+    snapshots = state.snapshots ++ [entry]
+    snapshots = if length(snapshots) > 2, do: tl(snapshots), else: snapshots
+    %{state | snapshots: snapshots}
+  end
+
+  defp snapshot_values_for([], _tx_offset), do: MapSet.new()
+
+  defp snapshot_values_for(_snapshots, 0), do: MapSet.new()
+
+  defp snapshot_values_for(snapshots, tx_offset) do
+    case Enum.find(snapshots, fn {offset, _} -> offset == tx_offset end) do
+      {_, value_counts} ->
+        MapSet.new(Map.keys(value_counts))
+
+      nil ->
+        {_, value_counts} = List.first(snapshots)
+        MapSet.new(Map.keys(value_counts))
+    end
   end
 
   # A value's count can cross the 0↔1 boundary multiple times in a single batch

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -439,8 +439,11 @@ defmodule Electric.Shapes.Consumer.Materializer do
   end
 
   # Parse a slash-delimited wire-format tag string into {position, hash} pairs.
-  # e.g., "hash1/hash2/" → [{0, "hash1"}, {1, "hash2"}]
-  # Empty segments (from nil positions) are skipped.
+  # Convert a tag to position/hash pairs.
+  # Supports both formats:
+  #   - Wire format (string): "hash1/hash2/" → [{0, "hash1"}, {1, "hash2"}]
+  #   - Internal format (list): ["hash1", "hash2", nil] → [{0, "hash1"}, {1, "hash2"}]
+  # Empty segments / nil positions are skipped.
   defp tag_to_position_entries(tag) when is_binary(tag) do
     tag
     |> String.split("/")
@@ -451,8 +454,17 @@ defmodule Electric.Shapes.Consumer.Materializer do
     end)
   end
 
+  defp tag_to_position_entries(tag) when is_list(tag) do
+    tag
+    |> Enum.with_index()
+    |> Enum.flat_map(fn
+      {nil, _pos} -> []
+      {hash, pos} -> [{pos, hash}]
+    end)
+  end
+
   defp add_row_to_tag_indices(tag_indices, key, move_tags) do
-    Enum.reduce(move_tags, tag_indices, fn tag, acc when is_binary(tag) ->
+    Enum.reduce(move_tags, tag_indices, fn tag, acc ->
       entries = tag_to_position_entries(tag)
 
       Enum.reduce(entries, acc, fn {pos, hash}, inner_acc ->
@@ -462,7 +474,7 @@ defmodule Electric.Shapes.Consumer.Materializer do
   end
 
   defp remove_row_from_tag_indices(tag_indices, key, move_tags) do
-    Enum.reduce(move_tags, tag_indices, fn tag, acc when is_binary(tag) ->
+    Enum.reduce(move_tags, tag_indices, fn tag, acc ->
       entries = tag_to_position_entries(tag)
 
       Enum.reduce(entries, acc, fn {pos, hash}, inner_acc ->

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -341,7 +341,16 @@ defmodule Electric.Shapes.Consumer.Materializer do
           %Changes.NewRecord{key: key, record: record, move_tags: move_tags},
           {{index, tag_indices}, counts_and_events} ->
             {value, original_string} = cast!(record, state)
-            if is_map_key(index, key), do: raise("Key #{key} already exists")
+
+            if is_map_key(index, key) do
+              raise """
+              Key #{key} already exists in materializer index.
+              This is an invariant violation: we've received a NewRecord for
+              for a row that is already present.
+              Do NOT remove this assertion. Do NOT treat NewRecord as an update.
+              """
+            end
+
             index = Map.put(index, key, value)
             tag_indices = add_row_to_tag_indices(tag_indices, key, move_tags)
             {{index, tag_indices}, increment_value(counts_and_events, value, original_string)}

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -62,6 +62,10 @@ defmodule Electric.Shapes.Consumer.Materializer do
       raise ~s|Materializer for stack "#{opts.stack_id}" and handle "#{opts.shape_handle}" is not available|
   end
 
+  def get_prev_link_values(opts) do
+    GenServer.call(name(opts), :get_prev_link_values)
+  end
+
   def get_all_as_refs(shape, stack_id) when are_deps_filled(shape) do
     shape.shape_dependencies_handles
     |> Enum.with_index()
@@ -98,6 +102,7 @@ defmodule Electric.Shapes.Consumer.Materializer do
         index: %{},
         tag_indices: %{},
         value_counts: %{},
+        prev_value_counts: %{},
         offset: LogOffset.before_all(),
         subscribed_offset: nil,
         ref: nil,
@@ -170,6 +175,10 @@ defmodule Electric.Shapes.Consumer.Materializer do
     values = MapSet.new(Map.keys(value_counts))
 
     {:reply, values, state}
+  end
+
+  def handle_call(:get_prev_link_values, _from, %{prev_value_counts: pvc} = state) do
+    {:reply, MapSet.new(Map.keys(pvc)), state}
   end
 
   def handle_call(:wait_until_ready, _from, state) do
@@ -293,6 +302,7 @@ defmodule Electric.Shapes.Consumer.Materializer do
   end
 
   defp apply_changes_and_notify(changes, state) do
+    state = %{state | prev_value_counts: state.value_counts}
     {state, events} = apply_changes(changes, state)
 
     if events != %{} do

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -438,27 +438,15 @@ defmodule Electric.Shapes.Consumer.Materializer do
     end
   end
 
-  # Parse a slash-delimited wire-format tag string into {position, hash} pairs.
-  # Convert a tag to position/hash pairs.
-  # Supports both formats:
-  #   - Wire format (string): "hash1/hash2/" → [{0, "hash1"}, {1, "hash2"}]
-  #   - Internal format (list): ["hash1", "hash2", nil] → [{0, "hash1"}, {1, "hash2"}]
-  # Empty segments / nil positions are skipped.
+  # Parse a slash-delimited tag string into {position, hash} pairs.
+  # e.g., "hash1/hash2/" → [{0, "hash1"}, {1, "hash2"}]
+  # Empty segments (non-participating positions) are skipped.
   defp tag_to_position_entries(tag) when is_binary(tag) do
     tag
     |> String.split("/")
     |> Enum.with_index()
     |> Enum.flat_map(fn
       {"", _pos} -> []
-      {hash, pos} -> [{pos, hash}]
-    end)
-  end
-
-  defp tag_to_position_entries(tag) when is_list(tag) do
-    tag
-    |> Enum.with_index()
-    |> Enum.flat_map(fn
-      {nil, _pos} -> []
       {hash, pos} -> [{pos, hash}]
     end)
   end

--- a/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
@@ -258,10 +258,8 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
       |> Map.new(fn {handle, index} ->
         opts = %{shape_handle: handle, stack_id: state.stack_id}
 
-        parsed_values =
-          if State.dep_seen?(state, handle),
-            do: Materializer.get_link_values(opts),
-            else: Materializer.get_prev_link_values(opts)
+        dep_lsn = State.get_dep_lsn(state, handle) || 0
+        parsed_values = Materializer.get_link_values(opts, dep_lsn)
 
         ref_type = used_refs[["$sublink", Integer.to_string(index)]]
         strings = values_to_strings(parsed_values, ref_type)

--- a/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
@@ -76,7 +76,7 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
         # Negated positions: move-out from subquery = activation (NOT IN now true) → query
         state =
           if negated_positions != [] do
-            do_start_move_in_query(state, dep_handle, removed_values, remove_not: true)
+            do_start_move_in_query(state, dep_handle, removed_values)
           else
             state
           end
@@ -187,14 +187,13 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
   end
 
   # Start an async move-in query for new values.
-  defp do_start_move_in_query(state, dep_handle, values, opts \\ []) do
+  defp do_start_move_in_query(state, dep_handle, values) do
     formed_where_clause =
       SubqueryMoves.move_in_where_clause(
         state.shape,
         dep_handle,
         Enum.map(values, &elem(&1, 1)),
-        state.dnf_context,
-        opts
+        state.dnf_context
       )
 
     storage = state.storage

--- a/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
@@ -201,6 +201,11 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
         exclusion_context
       )
 
+    # Compute which disjuncts the move-in query excludes (non-containing disjuncts).
+    # These are stored with the pending move-in so that change_will_be_covered_by_move_in?
+    # can detect when a record would be filtered out by the move-in's exclusion clauses.
+    excluded_disjuncts = compute_excluded_disjuncts(state, dep_handle)
+
     storage = state.storage
     name = Electric.Utils.uuid4()
     consumer_pid = self()
@@ -238,12 +243,44 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
       MoveIns.add_waiting(
         state.move_handling_state,
         name,
-        {["$sublink", Integer.to_string(index)], MapSet.new(Enum.map(values, &elem(&1, 0)))}
+        {["$sublink", Integer.to_string(index)], MapSet.new(Enum.map(values, &elem(&1, 0)))},
+        excluded_disjuncts
       )
 
     Logger.debug("Move-in #{name} has been triggered from #{dep_handle}")
 
     %{state | move_handling_state: move_handling_state}
+  end
+
+  # Compute the non-containing disjunct positions for a move-in query.
+  # These are the disjuncts that DON'T contain the trigger dependency and thus
+  # have exclusion clauses (AND NOT ...) in the move-in query.
+  defp compute_excluded_disjuncts(%State{dnf_context: nil}, _dep_handle), do: []
+
+  defp compute_excluded_disjuncts(%State{dnf_context: dnf_context, shape: shape}, dep_handle) do
+    if DnfContext.has_valid_dnf?(dnf_context) do
+      decomposition = dnf_context.decomposition
+
+      all_trigger_indices =
+        shape.shape_dependencies_handles
+        |> Enum.with_index()
+        |> Enum.filter(fn {h, _} -> h == dep_handle end)
+        |> Enum.map(fn {_, i} -> i end)
+
+      trigger_positions =
+        Enum.flat_map(all_trigger_indices, fn idx ->
+          SubqueryMoves.find_dnf_positions_for_dep_index(decomposition, idx)
+        end)
+
+      {_containing, not_containing} =
+        Enum.split_with(decomposition.disjuncts_positions, fn positions ->
+          Enum.any?(positions, &(&1 in trigger_positions))
+        end)
+
+      not_containing
+    else
+      []
+    end
   end
 
   defp build_exclusion_context(%State{dnf_context: nil}, _) do

--- a/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
@@ -10,6 +10,7 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
   alias Electric.Shapes.Consumer.Materializer
   alias Electric.Shapes.Consumer.MoveIns
   alias Electric.Replication.Eval
+  alias Electric.Replication.Changes.Transaction
 
   require Logger
 
@@ -88,6 +89,16 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
   end
 
   def query_complete(%State{} = state, name, key_set, snapshot) do
+    if state.last_processed_xid &&
+         not Transaction.visible_in_snapshot?(state.last_processed_xid, snapshot) do
+      raise """
+      Move-in query snapshot response is BEHIND replication stream!
+        last_processed_xid=#{state.last_processed_xid}
+        snapshot=#{inspect(snapshot)}
+        This must not happen because the move-in could overwrite changes that should be applied after it.
+      """
+    end
+
     # Filter moved_out_tags to only include positions relevant to this move-in's
     # dependency. Without this, move-out patterns from unrelated dependencies can
     # incorrectly filter rows (especially when different positions use the same column).

--- a/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
@@ -7,7 +7,9 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
   alias Electric.Shapes.PartialModes
   alias Electric.Shapes.Shape
   alias Electric.Shapes.Shape.SubqueryMoves
+  alias Electric.Shapes.Consumer.Materializer
   alias Electric.Shapes.Consumer.MoveIns
+  alias Electric.Replication.Eval
 
   require Logger
 
@@ -188,12 +190,15 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
 
   # Start an async move-in query for new values.
   defp do_start_move_in_query(state, dep_handle, values) do
+    exclusion_context = build_exclusion_context(state, dep_handle)
+
     formed_where_clause =
       SubqueryMoves.move_in_where_clause(
         state.shape,
         dep_handle,
         Enum.map(values, &elem(&1, 1)),
-        state.dnf_context
+        state.dnf_context,
+        exclusion_context
       )
 
     storage = state.storage
@@ -239,6 +244,44 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
     Logger.debug("Move-in #{name} has been triggered from #{dep_handle}")
 
     %{state | move_handling_state: move_handling_state}
+  end
+
+  defp build_exclusion_context(%State{dnf_context: nil}, _), do: nil
+
+  defp build_exclusion_context(%State{} = state, trigger_dep_handle) do
+    used_refs = state.shape.where.used_refs
+
+    dep_values =
+      state.shape.shape_dependencies_handles
+      |> Enum.with_index()
+      |> Enum.reject(fn {handle, _} -> handle == trigger_dep_handle end)
+      |> Map.new(fn {handle, index} ->
+        opts = %{shape_handle: handle, stack_id: state.stack_id}
+
+        parsed_values =
+          if State.dep_seen?(state, handle),
+            do: Materializer.get_link_values(opts),
+            else: Materializer.get_prev_link_values(opts)
+
+        ref_type = used_refs[["$sublink", Integer.to_string(index)]]
+        strings = values_to_strings(parsed_values, ref_type)
+        {index, strings}
+      end)
+
+    %{dep_values: dep_values}
+  end
+
+  defp values_to_strings(parsed_values, {:array, {:row, types}}) do
+    Enum.map(parsed_values, fn tuple ->
+      tuple
+      |> Tuple.to_list()
+      |> Enum.zip_with(types, &Eval.Env.const_to_pg_string(Eval.Env.new(), &1, &2))
+      |> List.to_tuple()
+    end)
+  end
+
+  defp values_to_strings(parsed_values, {:array, type}) do
+    Enum.map(parsed_values, &Eval.Env.const_to_pg_string(Eval.Env.new(), &1, type))
   end
 
   # Broadcast a deactivation (move-out) control message.

--- a/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/move_handling.ex
@@ -246,7 +246,10 @@ defmodule Electric.Shapes.Consumer.MoveHandling do
     %{state | move_handling_state: move_handling_state}
   end
 
-  defp build_exclusion_context(%State{dnf_context: nil}, _), do: nil
+  defp build_exclusion_context(%State{dnf_context: nil}, _) do
+    raise "build_exclusion_context called with nil dnf_context — " <>
+            "DNF context must be present for shapes with dependencies"
+  end
 
   defp build_exclusion_context(%State{} = state, trigger_dep_handle) do
     used_refs = state.shape.where.used_refs

--- a/packages/sync-service/lib/electric/shapes/consumer/move_ins.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/move_ins.ex
@@ -13,7 +13,8 @@ defmodule Electric.Shapes.Consumer.MoveIns do
             in_flight_values: %{},
             moved_out_tags: %{},
             maximum_resolved_snapshot: nil,
-            minimum_unresolved_snapshot: nil
+            minimum_unresolved_snapshot: nil,
+            excluded_disjuncts: %{}
 
   @type pg_snapshot() :: SnapshotQuery.pg_snapshot()
   @type move_in_name() :: String.t()
@@ -48,7 +49,8 @@ defmodule Electric.Shapes.Consumer.MoveIns do
           in_flight_values: in_flight_values(),
           moved_out_tags: %{move_in_name() => %{non_neg_integer() => MapSet.t(String.t())}},
           maximum_resolved_snapshot: nil | pg_snapshot(),
-          minimum_unresolved_snapshot: nil | pg_snapshot()
+          minimum_unresolved_snapshot: nil | pg_snapshot(),
+          excluded_disjuncts: %{move_in_name() => [[non_neg_integer()]]}
         }
   def new() do
     %__MODULE__{}
@@ -58,11 +60,12 @@ defmodule Electric.Shapes.Consumer.MoveIns do
   Add information about a new move-in to the state for which we're waiting.
   Snapshot is initially nil and will be set later when the query begins.
   """
-  @spec add_waiting(t(), move_in_name(), {term(), MapSet.t()}) :: t()
+  @spec add_waiting(t(), move_in_name(), {term(), MapSet.t()}, [[non_neg_integer()]]) :: t()
   def add_waiting(
         %__MODULE__{waiting_move_ins: waiting_move_ins} = state,
         name,
-        moved_values
+        moved_values,
+        excluded_disjuncts \\ []
       ) do
     new_waiting_move_ins = Map.put(waiting_move_ins, name, {nil, moved_values})
     new_buffering_snapshot = make_move_in_buffering_snapshot(new_waiting_move_ins)
@@ -72,7 +75,8 @@ defmodule Electric.Shapes.Consumer.MoveIns do
       | waiting_move_ins: new_waiting_move_ins,
         move_in_buffering_snapshot: new_buffering_snapshot,
         in_flight_values: make_in_flight_values(new_waiting_move_ins),
-        moved_out_tags: Map.put(state.moved_out_tags, name, %{})
+        moved_out_tags: Map.put(state.moved_out_tags, name, %{}),
+        excluded_disjuncts: Map.put(state.excluded_disjuncts, name, excluded_disjuncts)
     }
   end
 
@@ -176,6 +180,7 @@ defmodule Electric.Shapes.Consumer.MoveIns do
         move_in_buffering_snapshot: buffering_snapshot,
         in_flight_values: make_in_flight_values(waiting_move_ins),
         moved_out_tags: Map.delete(state.moved_out_tags, name),
+        excluded_disjuncts: Map.delete(state.excluded_disjuncts, name),
         minimum_unresolved_snapshot: find_minimum_unresolved_snapshot(waiting_move_ins),
         maximum_resolved_snapshot: maximum_resolved_snapshot
     }
@@ -224,6 +229,53 @@ defmodule Electric.Shapes.Consumer.MoveIns do
   def change_already_visible?(%__MODULE__{filtering_move_ins: filters}, xid, %{key: key}) do
     Enum.any?(filters, fn {snapshot, key_set} ->
       Transaction.visible_in_snapshot?(xid, snapshot) and MapSet.member?(key_set, key)
+    end)
+  end
+
+  @doc """
+  Check if a record would be excluded by a matching pending move-in's exclusion clauses.
+
+  Returns true if the record matches a non-containing disjunct of any matching
+  move-in, meaning the move-in query's `AND NOT (...)` exclusion clause would
+  filter it out and the change should NOT be skipped.
+  """
+  @spec record_excluded_by_matching_move_in?(t(), map(), [boolean()], Xid.anyxid()) :: boolean()
+  def record_excluded_by_matching_move_in?(
+        %__MODULE__{
+          waiting_move_ins: waiting_move_ins,
+          excluded_disjuncts: excluded_disjuncts
+        },
+        referenced_values,
+        active_conditions,
+        xid
+      ) do
+    Enum.any?(waiting_move_ins, fn {name, {snapshot, {path, moved_values}}} ->
+      case Map.fetch(referenced_values, path) do
+        {:ok, value} ->
+          matches =
+            (is_nil(snapshot) or Transaction.visible_in_snapshot?(xid, snapshot)) and
+              MapSet.member?(moved_values, value)
+
+          if matches do
+            excluded = Map.get(excluded_disjuncts, name, [])
+            record_matches_any_disjunct?(active_conditions, excluded)
+          else
+            false
+          end
+
+        :error ->
+          false
+      end
+    end)
+  end
+
+  defp record_matches_any_disjunct?(_active_conditions, []), do: false
+
+  defp record_matches_any_disjunct?(active_conditions, disjuncts) do
+    Enum.any?(disjuncts, fn conjunction_positions ->
+      Enum.all?(conjunction_positions, fn pos ->
+        Enum.at(active_conditions, pos, false) == true
+      end)
     end)
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -29,7 +29,8 @@ defmodule Electric.Shapes.Consumer.State do
     terminating?: false,
     buffering?: false,
     dnf_context: nil,
-    dep_lsns: %{}
+    dep_lsns: %{},
+    last_processed_xid: nil
   ]
 
   @type pg_snapshot() :: SnapshotQuery.pg_snapshot()

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -29,7 +29,7 @@ defmodule Electric.Shapes.Consumer.State do
     terminating?: false,
     buffering?: false,
     dnf_context: nil,
-    seen_deps: MapSet.new()
+    dep_lsns: %{}
   ]
 
   @type pg_snapshot() :: SnapshotQuery.pg_snapshot()
@@ -279,12 +279,12 @@ defmodule Electric.Shapes.Consumer.State do
     ]
   end
 
-  def mark_dep_seen(state, dep_handle),
-    do: %{state | seen_deps: MapSet.put(state.seen_deps, dep_handle)}
+  def record_dep_lsn(state, dep_handle, tx_offset),
+    do: %{state | dep_lsns: Map.put(state.dep_lsns, dep_handle, tx_offset)}
 
-  def dep_seen?(state, dep_handle),
-    do: MapSet.member?(state.seen_deps, dep_handle)
+  def get_dep_lsn(state, dep_handle),
+    do: Map.get(state.dep_lsns, dep_handle)
 
-  def reset_seen_deps(state),
-    do: %{state | seen_deps: MapSet.new()}
+  def reset_dep_lsns(state),
+    do: %{state | dep_lsns: %{}}
 end

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -28,7 +28,8 @@ defmodule Electric.Shapes.Consumer.State do
     materializer_subscribed?: false,
     terminating?: false,
     buffering?: false,
-    dnf_context: nil
+    dnf_context: nil,
+    seen_deps: MapSet.new()
   ]
 
   @type pg_snapshot() :: SnapshotQuery.pg_snapshot()
@@ -277,4 +278,13 @@ defmodule Electric.Shapes.Consumer.State do
       stack_id: stack_id
     ]
   end
+
+  def mark_dep_seen(state, dep_handle),
+    do: %{state | seen_deps: MapSet.put(state.seen_deps, dep_handle)}
+
+  def dep_seen?(state, dep_handle),
+    do: MapSet.member?(state.seen_deps, dep_handle)
+
+  def reset_seen_deps(state),
+    do: %{state | seen_deps: MapSet.new()}
 end

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -149,10 +149,15 @@ defmodule Electric.Shapes.Querying do
   end
 
   # Converts a tag structure to something PG select can fill, but returns a list of separate strings for each tag
-  # - it's up to the caller to interpolate them into the query correctly
+  # - it's up to the caller to interpolate them into the query correctly.
+  # For DNF shapes, each disjunct pattern may contain nil entries for positions not in that disjunct.
+  # These become empty strings in the slash-delimited wire format.
   defp make_tags(%Shape{tag_structure: tag_structure}, stack_id, shape_handle) do
     Enum.map(tag_structure, fn pattern ->
       Enum.map(pattern, fn
+        nil ->
+          "''"
+
         column_name when is_binary(column_name) ->
           col = pg_cast_column_to_text(column_name)
           namespaced = pg_namespace_value_sql(col)

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -723,9 +723,9 @@ defmodule Electric.Shapes.Shape do
 
   defp make_tags_from_pattern(patterns, record, stack_id, shape_handle) do
     Enum.map(patterns, fn pattern ->
-      Enum.map(pattern, fn
+      Enum.map_join(pattern, "/", fn
         nil ->
-          nil
+          ""
 
         column_name when is_binary(column_name) ->
           SubqueryMoves.make_value_hash(stack_id, shape_handle, Map.get(record, column_name))

--- a/packages/sync-service/lib/electric/shapes/shape/subquery_moves.ex
+++ b/packages/sync-service/lib/electric/shapes/shape/subquery_moves.ex
@@ -35,12 +35,21 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
       [["1", "2", "3"]]
   """
   def move_in_where_clause(
+        shape,
+        shape_handle,
+        move_ins,
+        dnf_context,
+        exclusion_context \\ nil
+      )
+
+  def move_in_where_clause(
         %Shape{
           shape_dependencies_handles: shape_dependencies_handles
         } = shape,
         shape_handle,
         move_ins,
-        dnf_context
+        dnf_context,
+        exclusion_context
       ) do
     index = Enum.find_index(shape_dependencies_handles, &(&1 == shape_handle))
 
@@ -53,7 +62,14 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
       |> Enum.filter(fn {h, _} -> h == shape_handle end)
       |> Enum.map(fn {_, i} -> i end)
 
-    build_dnf_move_in_where(shape, index, all_trigger_indices, move_ins, dnf_context)
+    build_dnf_move_in_where(
+      shape,
+      index,
+      all_trigger_indices,
+      move_ins,
+      dnf_context,
+      exclusion_context
+    )
   end
 
   # Reconstruct the move-in WHERE clause from all disjuncts containing the trigger.
@@ -70,7 +86,14 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
   # since we're finding rows that now satisfy the condition. Negation is only
   # applied to non-triggering positions in the disjunct.
   #
-  defp build_dnf_move_in_where(shape, trigger_dep_index, all_trigger_indices, move_ins, dnf_context) do
+  defp build_dnf_move_in_where(
+         shape,
+         trigger_dep_index,
+         all_trigger_indices,
+         move_ins,
+         dnf_context,
+         exclusion_context
+       ) do
     decomposition = dnf_context.decomposition
 
     # Collect trigger positions from ALL dep indices sharing the same handle.
@@ -125,20 +148,35 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
           "#{trigger_sql} AND (#{or_clause})"
       end
 
-    # Append exclusion clauses for disjuncts that don't contain the trigger
-    exclusion =
-      if length(decomposition.disjuncts) > 1 do
-        build_dnf_exclusion_clauses(
+    # Append exclusion clauses for disjuncts that don't contain the trigger.
+    # When exclusion_context is provided, use materialized values (parameter-based)
+    # instead of live subqueries to avoid the concurrent-change exclusion bug.
+    {exclusion_sql, exclusion_params} =
+      if length(decomposition.disjuncts) > 1 and exclusion_context != nil do
+        build_materialized_exclusion_clauses(
           decomposition,
-          shape.shape_dependencies,
-          shape.subquery_comparison_expressions,
-          trigger_dep_index
+          shape,
+          trigger_dep_index,
+          exclusion_context,
+          length(params) + 1
         )
       else
-        ""
+        exclusion =
+          if length(decomposition.disjuncts) > 1 do
+            build_dnf_exclusion_clauses(
+              decomposition,
+              shape.shape_dependencies,
+              shape.subquery_comparison_expressions,
+              trigger_dep_index
+            )
+          else
+            ""
+          end
+
+        {exclusion, []}
       end
 
-    {base_where <> exclusion, params}
+    {base_where <> exclusion_sql, params ++ exclusion_params}
   end
 
   # Build the SQL fragment and params for the triggering subquery position.
@@ -324,6 +362,164 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
   end
 
   def extract_sublink_index(_), do: nil
+
+  @doc """
+  Build exclusion clauses using materialized values instead of live subqueries.
+
+  Same structure as `build_dnf_exclusion_clauses` — partitions disjuncts into
+  containing/not-containing the trigger. But instead of live subqueries, generates
+  `column = ANY($N::text[]::type[])` using pre-fetched values from the exclusion context.
+  """
+  def build_materialized_exclusion_clauses(
+        decomposition,
+        shape,
+        trigger_dep_index,
+        exclusion_context,
+        start_param_index
+      ) do
+    trigger_positions = find_dnf_positions_for_dep_index(decomposition, trigger_dep_index)
+
+    if trigger_positions == [] do
+      {"", []}
+    else
+      {_containing, not_containing} =
+        Enum.split_with(decomposition.disjuncts, fn conjunction ->
+          Enum.any?(conjunction, fn {pos, _polarity} -> pos in trigger_positions end)
+        end)
+
+      {clauses, params, _next_idx} =
+        Enum.reduce(not_containing, {[], [], start_param_index}, fn conjunction,
+                                                                     {clauses_acc, params_acc,
+                                                                      param_idx} ->
+          case generate_materialized_disjunct_exclusion(
+                 conjunction,
+                 decomposition,
+                 shape,
+                 exclusion_context,
+                 param_idx
+               ) do
+            nil ->
+              {clauses_acc, params_acc, param_idx}
+
+            {clause, new_params, next_idx} ->
+              {[clause | clauses_acc], params_acc ++ new_params, next_idx}
+          end
+        end)
+
+      {Enum.join(Enum.reverse(clauses)), params}
+    end
+  end
+
+  defp generate_materialized_disjunct_exclusion(
+         conjunction,
+         decomposition,
+         shape,
+         exclusion_context,
+         param_idx
+       ) do
+    all_subquery? =
+      Enum.all?(conjunction, fn {pos, _polarity} ->
+        case Map.get(decomposition.subexpressions, pos) do
+          %{is_subquery: true} -> true
+          _ -> false
+        end
+      end)
+
+    if not all_subquery? do
+      nil
+    else
+      used_refs = shape.where.used_refs
+
+      {conditions, params, next_idx} =
+        Enum.reduce(conjunction, {[], [], param_idx}, fn {pos, polarity},
+                                                         {conds_acc, params_acc, idx} ->
+          info = Map.get(decomposition.subexpressions, pos)
+
+          case extract_sublink_index(info.ast) do
+            nil ->
+              {conds_acc, params_acc, idx}
+
+            dep_index ->
+              column_sql = get_column_sql(shape.subquery_comparison_expressions, dep_index)
+
+              if column_sql do
+                values = Map.get(exclusion_context.dep_values, dep_index, [])
+
+                case used_refs[["$sublink", "#{dep_index}"]] do
+                  {:array, {:row, cols}} ->
+                    {sql, new_params, new_idx} =
+                      build_materialized_row_condition(
+                        column_sql,
+                        values,
+                        cols,
+                        polarity,
+                        idx
+                      )
+
+                    {[sql | conds_acc], params_acc ++ new_params, new_idx}
+
+                  ref_type ->
+                    type =
+                      case ref_type do
+                        {:array, t} -> t
+                        t -> t
+                      end
+
+                    pg_type = Eval.type_to_pg_cast(type)
+                    param_ref = "$#{idx}::text[]::#{pg_type}[]"
+
+                    condition = "#{column_sql} = ANY (#{param_ref})"
+
+                    condition =
+                      case polarity do
+                        :positive -> condition
+                        :negated -> "NOT #{condition}"
+                      end
+
+                    {[condition | conds_acc], params_acc ++ [values], idx + 1}
+                end
+              else
+                {conds_acc, params_acc, idx}
+              end
+          end
+        end)
+
+      if conditions == [] do
+        nil
+      else
+        clause = " AND NOT (#{Enum.join(Enum.reverse(conditions), " AND ")})"
+        {clause, params, next_idx}
+      end
+    end
+  end
+
+  defp build_materialized_row_condition(column_sql, values, col_types, polarity, param_idx) do
+    unnest_sections =
+      col_types
+      |> Enum.with_index(fn col_type, i ->
+        pg_type = Eval.type_to_pg_cast(col_type)
+        "$#{param_idx + i}::text[]::#{pg_type}[]"
+      end)
+      |> Enum.join(", ")
+
+    condition = "#{column_sql} IN (SELECT * FROM unnest(#{unnest_sections}))"
+
+    condition =
+      case polarity do
+        :positive -> condition
+        :negated -> "NOT (#{condition})"
+      end
+
+    params =
+      if values == [] do
+        Enum.map(col_types, fn _ -> [] end)
+      else
+        Electric.Utils.unzip_any(values) |> Tuple.to_list()
+      end
+
+    next_idx = param_idx + length(col_types)
+    {condition, params, next_idx}
+  end
 
   @doc """
   Build exclusion clauses using DNF decomposition.

--- a/packages/sync-service/lib/electric/shapes/shape/subquery_moves.ex
+++ b/packages/sync-service/lib/electric/shapes/shape/subquery_moves.ex
@@ -417,24 +417,14 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
          exclusion_context,
          param_idx
        ) do
-    all_subquery? =
-      Enum.all?(conjunction, fn {pos, _polarity} ->
-        case Map.get(decomposition.subexpressions, pos) do
-          %{is_subquery: true} -> true
-          _ -> false
-        end
-      end)
+    used_refs = shape.where.used_refs
 
-    if not all_subquery? do
-      nil
-    else
-      used_refs = shape.where.used_refs
+    {conditions, params, next_idx} =
+      Enum.reduce(conjunction, {[], [], param_idx}, fn {pos, polarity},
+                                                       {conds_acc, params_acc, idx} ->
+        info = Map.get(decomposition.subexpressions, pos)
 
-      {conditions, params, next_idx} =
-        Enum.reduce(conjunction, {[], [], param_idx}, fn {pos, polarity},
-                                                         {conds_acc, params_acc, idx} ->
-          info = Map.get(decomposition.subexpressions, pos)
-
+        if info.is_subquery do
           case extract_sublink_index(info.ast) do
             nil ->
               {conds_acc, params_acc, idx}
@@ -482,14 +472,24 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
                 {conds_acc, params_acc, idx}
               end
           end
-        end)
+        else
+          sql = SqlGenerator.to_sql(info.ast)
 
-      if conditions == [] do
-        nil
-      else
-        clause = " AND NOT (#{Enum.join(Enum.reverse(conditions), " AND ")})"
-        {clause, params, next_idx}
-      end
+          condition =
+            case polarity do
+              :positive -> sql
+              :negated -> "(NOT #{sql})"
+            end
+
+          {[condition | conds_acc], params_acc, idx}
+        end
+      end)
+
+    if conditions == [] do
+      nil
+    else
+      clause = " AND NOT (#{Enum.join(Enum.reverse(conditions), " AND ")})"
+      {clause, params, next_idx}
     end
   end
 
@@ -564,30 +564,18 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
   end
 
   # Generate an exclusion clause for a single disjunct (conjunction of literals).
-  # Returns nil if the disjunct contains any non-subquery positions (weaker exclusion
-  # is safe since the client deduplicates via tags).
-  # Otherwise returns " AND NOT (cond1 AND cond2 AND ...)"
+  # Returns " AND NOT (cond1 AND cond2 AND ...)" or nil if no conditions could be built.
   defp generate_disjunct_exclusion(
          conjunction,
          decomposition,
          shape_dependencies,
          comparison_expressions
        ) do
-    all_subquery? =
-      Enum.all?(conjunction, fn {pos, _polarity} ->
-        case Map.get(decomposition.subexpressions, pos) do
-          %{is_subquery: true} -> true
-          _ -> false
-        end
-      end)
+    conditions =
+      Enum.flat_map(conjunction, fn {pos, polarity} ->
+        info = Map.get(decomposition.subexpressions, pos)
 
-    if not all_subquery? do
-      nil
-    else
-      conditions =
-        Enum.flat_map(conjunction, fn {pos, polarity} ->
-          info = Map.get(decomposition.subexpressions, pos)
-
+        if info.is_subquery do
           case extract_sublink_index(info.ast) do
             nil ->
               []
@@ -608,10 +596,17 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
                 []
               end
           end
-        end)
+        else
+          sql = SqlGenerator.to_sql(info.ast)
 
-      if conditions == [], do: nil, else: " AND NOT (#{Enum.join(conditions, " AND ")})"
-    end
+          case polarity do
+            :positive -> [sql]
+            :negated -> ["(NOT #{sql})"]
+          end
+        end
+      end)
+
+    if conditions == [], do: nil, else: " AND NOT (#{Enum.join(conditions, " AND ")})"
   end
 
   @doc """

--- a/packages/sync-service/lib/electric/shapes/shape/subquery_moves.ex
+++ b/packages/sync-service/lib/electric/shapes/shape/subquery_moves.ex
@@ -34,59 +34,26 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
 
       [["1", "2", "3"]]
   """
-  def move_in_where_clause(shape, shape_handle, move_ins, dnf_context \\ nil, _opts \\ [])
-
   def move_in_where_clause(
         %Shape{
-          where: %{query: query, used_refs: used_refs},
-          shape_dependencies: shape_dependencies,
           shape_dependencies_handles: shape_dependencies_handles
         } = shape,
         shape_handle,
         move_ins,
-        dnf_context,
-        _opts
+        dnf_context
       ) do
     index = Enum.find_index(shape_dependencies_handles, &(&1 == shape_handle))
 
-    if dnf_context && dnf_context.decomposition do
-      # DNF-aware path: reconstruct WHERE from the triggering disjunct's conditions.
-      # Find ALL dep indices sharing the same handle (handles degenerate A OR A cases
-      # where the same subquery appears multiple times with different dep indices).
-      all_trigger_indices =
-        shape_dependencies_handles
-        |> Enum.with_index()
-        |> Enum.filter(fn {h, _} -> h == shape_handle end)
-        |> Enum.map(fn {_, i} -> i end)
+    # DNF-aware path: reconstruct WHERE from the triggering disjunct's conditions.
+    # Find ALL dep indices sharing the same handle (handles degenerate A OR A cases
+    # where the same subquery appears multiple times with different dep indices).
+    all_trigger_indices =
+      shape_dependencies_handles
+      |> Enum.with_index()
+      |> Enum.filter(fn {h, _} -> h == shape_handle end)
+      |> Enum.map(fn {_, i} -> i end)
 
-      build_dnf_move_in_where(shape, index, all_trigger_indices, move_ins, dnf_context)
-    else
-      # Legacy path (no DnfContext): string replacement on shape.where.query.
-      # Works for simple single-subquery positive IN shapes.
-      target_section = Enum.at(shape_dependencies, index) |> rebuild_subquery_section()
-
-      {where, params} =
-        case used_refs[["$sublink", "#{index}"]] do
-          {:array, {:row, cols}} ->
-            unnest_sections =
-              cols
-              |> Enum.map(&Electric.Replication.Eval.type_to_pg_cast/1)
-              |> Enum.with_index(fn col, index -> "$#{index + 1}::text[]::#{col}[]" end)
-              |> Enum.join(", ")
-
-            {String.replace(
-               query,
-               target_section,
-               "IN (SELECT * FROM unnest(#{unnest_sections}))"
-             ), Electric.Utils.unzip_any(move_ins) |> Tuple.to_list()}
-
-          col ->
-            type = Electric.Replication.Eval.type_to_pg_cast(col)
-            {String.replace(query, target_section, "= ANY ($1::text[]::#{type})"), [move_ins]}
-        end
-
-      {where, params}
-    end
+    build_dnf_move_in_where(shape, index, all_trigger_indices, move_ins, dnf_context)
   end
 
   # Reconstruct the move-in WHERE clause from all disjuncts containing the trigger.

--- a/packages/sync-service/lib/electric/shapes/shape/subquery_moves.ex
+++ b/packages/sync-service/lib/electric/shapes/shape/subquery_moves.ex
@@ -34,7 +34,7 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
 
       [["1", "2", "3"]]
   """
-  def move_in_where_clause(shape, shape_handle, move_ins, dnf_context \\ nil, opts \\ [])
+  def move_in_where_clause(shape, shape_handle, move_ins, dnf_context \\ nil, _opts \\ [])
 
   def move_in_where_clause(
         %Shape{
@@ -45,50 +45,173 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
         shape_handle,
         move_ins,
         dnf_context,
-        opts
+        _opts
       ) do
     index = Enum.find_index(shape_dependencies_handles, &(&1 == shape_handle))
-    target_section = Enum.at(shape_dependencies, index) |> rebuild_subquery_section()
 
-    # For negated positions (NOT IN), the original WHERE has "NOT IN (...)"
-    # and we need to replace the whole "NOT IN (...)" to get correct SQL
-    target_section = if opts[:remove_not], do: "NOT " <> target_section, else: target_section
+    if dnf_context && dnf_context.decomposition do
+      # DNF-aware path: reconstruct WHERE from the triggering disjunct's conditions.
+      # Find ALL dep indices sharing the same handle (handles degenerate A OR A cases
+      # where the same subquery appears multiple times with different dep indices).
+      all_trigger_indices =
+        shape_dependencies_handles
+        |> Enum.with_index()
+        |> Enum.filter(fn {h, _} -> h == shape_handle end)
+        |> Enum.map(fn {_, i} -> i end)
 
-    {where, params} =
-      case used_refs[["$sublink", "#{index}"]] do
-        {:array, {:row, cols}} ->
-          unnest_sections =
-            cols
-            |> Enum.map(&Electric.Replication.Eval.type_to_pg_cast/1)
-            |> Enum.with_index(fn col, index -> "$#{index + 1}::text[]::#{col}[]" end)
-            |> Enum.join(", ")
+      build_dnf_move_in_where(shape, index, all_trigger_indices, move_ins, dnf_context)
+    else
+      # Legacy path (no DnfContext): string replacement on shape.where.query.
+      # Works for simple single-subquery positive IN shapes.
+      target_section = Enum.at(shape_dependencies, index) |> rebuild_subquery_section()
 
-          {String.replace(
-             query,
-             target_section,
-             "IN (SELECT * FROM unnest(#{unnest_sections}))"
-           ), Electric.Utils.unzip_any(move_ins) |> Tuple.to_list()}
+      {where, params} =
+        case used_refs[["$sublink", "#{index}"]] do
+          {:array, {:row, cols}} ->
+            unnest_sections =
+              cols
+              |> Enum.map(&Electric.Replication.Eval.type_to_pg_cast/1)
+              |> Enum.with_index(fn col, index -> "$#{index + 1}::text[]::#{col}[]" end)
+              |> Enum.join(", ")
 
-        col ->
-          type = Electric.Replication.Eval.type_to_pg_cast(col)
-          {String.replace(query, target_section, "= ANY ($1::text[]::#{type})"), [move_ins]}
+            {String.replace(
+               query,
+               target_section,
+               "IN (SELECT * FROM unnest(#{unnest_sections}))"
+             ), Electric.Utils.unzip_any(move_ins) |> Tuple.to_list()}
+
+          col ->
+            type = Electric.Replication.Eval.type_to_pg_cast(col)
+            {String.replace(query, target_section, "= ANY ($1::text[]::#{type})"), [move_ins]}
+        end
+
+      {where, params}
+    end
+  end
+
+  # Reconstruct the move-in WHERE clause from all disjuncts containing the trigger.
+  #
+  # When the same subquery appears in multiple disjuncts (e.g., because
+  # `IN ('a', 'b', 'c')` was expanded to OR'd equalities), we must include
+  # rows matching ANY of those disjuncts, not just the first.
+  #
+  # For `WHERE (x IN sq1 AND id = 'a') OR (x IN sq1 AND id = 'b') OR y IN sq2`,
+  # when sq1 triggers:
+  #   base_where = "col = ANY($1) AND (("id" = 'a') OR ("id" = 'b'))"
+  #
+  # For NOT IN: the triggering subquery is always a positive match (= ANY),
+  # since we're finding rows that now satisfy the condition. Negation is only
+  # applied to non-triggering positions in the disjunct.
+  #
+  defp build_dnf_move_in_where(shape, trigger_dep_index, all_trigger_indices, move_ins, dnf_context) do
+    decomposition = dnf_context.decomposition
+
+    # Collect trigger positions from ALL dep indices sharing the same handle.
+    # This handles the case where identical subqueries (same handle) appear at
+    # different dep indices (e.g., `A OR A` producing dep_0 and dep_1).
+    trigger_positions =
+      Enum.flat_map(all_trigger_indices, fn idx ->
+        find_dnf_positions_for_dep_index(decomposition, idx)
+      end)
+
+    # Find all disjuncts containing a trigger position
+    containing =
+      Enum.filter(decomposition.disjuncts, fn conjunction ->
+        Enum.any?(conjunction, fn {pos, _} -> pos in trigger_positions end)
+      end)
+
+    # Build the trigger SQL + params (shared across all containing disjuncts)
+    used_refs = shape.where.used_refs
+
+    {trigger_sql, params} =
+      build_trigger_replacement(shape, trigger_dep_index, move_ins, used_refs)
+
+    # For each containing disjunct, build the non-trigger conditions
+    disjunct_non_trigger_clauses =
+      Enum.map(containing, fn conjunction ->
+        non_trigger_conditions =
+          conjunction
+          |> Enum.reject(fn {pos, _} -> pos in trigger_positions end)
+          |> Enum.map(fn {pos, polarity} ->
+            subexpr = Map.fetch!(decomposition.subexpressions, pos)
+            build_non_trigger_condition(subexpr, polarity, shape)
+          end)
+
+        case non_trigger_conditions do
+          [] -> nil
+          conditions -> Enum.join(conditions, " AND ")
+        end
+      end)
+
+    # Combine: trigger AND (disjunct1_conditions OR disjunct2_conditions OR ...)
+    base_where =
+      case Enum.reject(disjunct_non_trigger_clauses, &is_nil/1) do
+        [] ->
+          # No non-trigger conditions in any disjunct — just the trigger
+          trigger_sql
+
+        [single] ->
+          "#{trigger_sql} AND (#{single})"
+
+        multiple ->
+          or_clause = Enum.map_join(multiple, " OR ", &"(#{&1})")
+          "#{trigger_sql} AND (#{or_clause})"
       end
 
-    # Append exclusion clauses for multi-disjunct shapes
+    # Append exclusion clauses for disjuncts that don't contain the trigger
     exclusion =
-      if dnf_context && dnf_context.decomposition &&
-           length(dnf_context.decomposition.disjuncts) > 1 do
+      if length(decomposition.disjuncts) > 1 do
         build_dnf_exclusion_clauses(
-          dnf_context.decomposition,
+          decomposition,
           shape.shape_dependencies,
           shape.subquery_comparison_expressions,
-          index
+          trigger_dep_index
         )
       else
         ""
       end
 
-    {where <> exclusion, params}
+    {base_where <> exclusion, params}
+  end
+
+  # Build the SQL fragment and params for the triggering subquery position.
+  # Always a positive match — no NOT applied.
+  defp build_trigger_replacement(shape, dep_index, move_ins, used_refs) do
+    column_sql = get_column_sql(shape.subquery_comparison_expressions, dep_index)
+
+    case used_refs[["$sublink", "#{dep_index}"]] do
+      {:array, {:row, cols}} ->
+        unnest_sections =
+          cols
+          |> Enum.map(&Electric.Replication.Eval.type_to_pg_cast/1)
+          |> Enum.with_index(fn col, index -> "$#{index + 1}::text[]::#{col}[]" end)
+          |> Enum.join(", ")
+
+        sql = "#{column_sql} IN (SELECT * FROM unnest(#{unnest_sections}))"
+        params = Electric.Utils.unzip_any(move_ins) |> Tuple.to_list()
+        {sql, params}
+
+      col ->
+        type = Electric.Replication.Eval.type_to_pg_cast(col)
+        {"#{column_sql} = ANY ($1::text[]::#{type})", [move_ins]}
+    end
+  end
+
+  # Build a SQL condition for a non-triggering position in the disjunct.
+  defp build_non_trigger_condition(subexpr, polarity, shape) do
+    if subexpr.is_subquery do
+      # Another subquery in the same disjunct: keep original subquery SQL
+      dep_index = extract_sublink_index(subexpr.ast)
+      column_sql = get_column_sql(shape.subquery_comparison_expressions, dep_index)
+      subquery_shape = Enum.at(shape.shape_dependencies, dep_index)
+      subquery_section = rebuild_subquery_section(subquery_shape)
+      condition = "#{column_sql} #{subquery_section}"
+      if polarity == :negated, do: "(NOT (#{condition}))", else: condition
+    else
+      # Non-subquery condition: convert AST back to SQL
+      sql = SqlGenerator.to_sql(subexpr.ast)
+      if polarity == :negated, do: "(NOT #{sql})", else: sql
+    end
   end
 
   defp rebuild_subquery_section(shape) do
@@ -236,22 +359,6 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
   def extract_sublink_index(_), do: nil
 
   @doc """
-  Find all DNF positions that correspond to a given dependency index.
-
-  A single dependency can appear at multiple positions (e.g., the same subquery
-  referenced in different parts of the WHERE clause).
-  """
-  def find_dnf_positions_for_dep_index(decomposition, dep_index) do
-    Enum.flat_map(decomposition.subexpressions, fn {pos, subexpr} ->
-      if subexpr.is_subquery and extract_sublink_index(subexpr.ast) == dep_index do
-        [pos]
-      else
-        []
-      end
-    end)
-  end
-
-  @doc """
   Build exclusion clauses using DNF decomposition.
 
   Only excludes subqueries in disjuncts that do NOT contain the triggering dependency.
@@ -342,6 +449,22 @@ defmodule Electric.Shapes.Shape.SubqueryMoves do
 
       if conditions == [], do: nil, else: " AND NOT (#{Enum.join(conditions, " AND ")})"
     end
+  end
+
+  @doc """
+  Find all DNF positions that correspond to a given dependency index.
+
+  A single dependency can appear at multiple positions (e.g., the same subquery
+  referenced in different parts of the WHERE clause).
+  """
+  def find_dnf_positions_for_dep_index(decomposition, dep_index) do
+    Enum.flat_map(decomposition.subexpressions, fn {pos, subexpr} ->
+      if subexpr.is_subquery and extract_sublink_index(subexpr.ast) == dep_index do
+        [pos]
+      else
+        []
+      end
+    end)
   end
 
   # Get the SQL for the column expression used in a subquery comparison.

--- a/packages/sync-service/plan.md
+++ b/packages/sync-service/plan.md
@@ -1,0 +1,58 @@
+# Postgres as an Oracle
+
+## Overview
+
+look at the tests in ./test/integration . They're written at a level where electric (a combination of the sync-service and the elixir-client) starts to behave a lot like Postgres. It's not quite the same,
+  the client doesn't materialize the view but Postgres does, but that's just a few logical steps. 
+
+The pattern is:
+- given some tables
+- create a view by specifing one of those tables to select and a where clause (the where clause can mention the other tables in subqueries if it wants to)
+- make a change to those tables
+- check the view is updates accordingly
+
+The view here is either:
+- a materialized view based on the output of the electric client (in combination with the sync-service and postgres)
+- a direct query to postgres
+
+The key point here is that if Electric does not have bugs, these two views should match.
+
+This pattern can be used over all known where clauses and we'll have a great way of ensuring electric is correct.
+
+## Deep investigation
+
+How could we impliment these tests? Property tests? What properties do we already have in the elixir code or should we consider alternatives? We're going to be using LLMs to generate code and humans may not read all of the code, but a human should be able to see what is happening at a high level and what is being tested.
+
+Do some deep research. Consider at least 3 alternatives and weigh up the pros and cons of each.
+
+## Defining correctness and whether a where clause is optimised
+
+For any given change that affects the view, the live request to the elixir client may:
+
+1) give the correct change
+2) give an incorrect change
+3) won't return for 20s
+4) returns only up-to-date
+5) give an 409
+6) give an error other than a 409
+7) does something else
+
+2,3,4,6 and 7 are all bugs. 1 is ideal. 5 is acceptable but not optimised and we should be able to define a subset of where clauses that are optimised and be able to test that they are indeed optimsed (don't return 409s)
+
+For any given change that affects the view, the live request to the elixir client may:
+
+1) give an update that doesn't change any values in the view
+2) gives an change that does change the values in the view
+3) won't return for 20s
+4) returns only up-to-date
+5) gives an 409
+6) give an error other than a 409
+7) does something else
+
+2,6 and 7 are all bugs. 1,3,4 are all fine. 5 is acceptable but not optimised and we should be able to define a subset of where clauses that are optimised and be able to test that they are indeed optimsed (don't return 409s)
+
+## Other considerations
+
+- It would be nice to run many tests in parralel on the same database, e.g. same set of tables, many differert where clauses (shapes) on them, make a change to the tables then check each shape's view matches the equivalent postgres view
+- The test setup may be slow so having a single setup with many changes and checks would be good
+- We may want to introduce other views, e.g. the typescript client, in the future

--- a/packages/sync-service/review.md
+++ b/packages/sync-service/review.md
@@ -1,0 +1,128 @@
+# Branch Review: `rob/arbitrary-boolean-expressions-with-subqueries`
+
+## Overall Assessment
+
+The implementation is **architecturally sound and comprehensive**. All 14 phases from the implementation plan are complete, and the code aligns well with both the plan and RFC. The key design decision — keeping DNF state in a separate `DnfContext` rather than modifying the `Shape` struct — is clean and well-executed.
+
+Below are findings organized by category.
+
+---
+
+## Alignment with Plan & RFC
+
+All 14 phases are implemented and match the plan's intent:
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| 1. Decomposer | Complete | De Morgan's laws, complexity guard, position stability |
+| 2. SqlGenerator | Complete | Comprehensive operator coverage with precedence |
+| 3. DnfContext | Complete | Correct sublink index extraction from AST |
+| 4. Shape tag_structure | Complete | Multi-disjunct, no new Shape fields |
+| 5. Consumer State | Complete | Removed invalidation flags, holds DnfContext |
+| 6. Active Conditions | Complete | Single-pass via `evaluate_record/4` |
+| 7. Move Messages + Exclusion | Complete | DNF-aware exclusion clauses |
+| 8. Log Items | Complete | 2D-to-wire conversion via `tags_to_wire/1` |
+| 9. Change Handling | Complete | Uses DnfContext, replaces `includes_record?` |
+| 10. Querying | Complete | `active_conditions` + `condition_hashes` SELECT |
+| 11. Move Handling | Complete | Position-aware, negation inversion |
+| 12. Position-aware moved_out_tags | Complete | Per-position filtering, storage version bump |
+| 13. Remove Invalidation | Complete | `or_with_subquery?` / `not_with_subquery?` removed |
+| 14. Elixir Client | Complete | Tag normalization, DNF visibility eval |
+
+**Minor deviation**: The plan calls for `extract_sublink_index/1` to be "defined once in a shared location." In practice it's defined in both `dnf_context.ex` and `subquery_moves.ex`. Both use the same pattern-match on `$sublink` AST nodes, so correctness is fine, but there's a maintenance risk if the logic needs updating.
+
+---
+
+## Correctness Concerns
+
+**1. `DnfContext.from_shape/1` silently returns `nil` on decomposer failure**
+
+If `Decomposer.decompose/1` returns `{:error, _}`, the context is nil and the consumer silently falls back to legacy behavior. This shouldn't happen in practice (failures are caught at shape creation time with a 400), but there's no logging to understand if a shape that *should* have a DnfContext ends up without one at runtime.
+
+**2. Exclusion clause generation (`build_dnf_exclusion_clauses/4`) lacks dedicated unit tests**
+
+This is complex logic (partitioning disjuncts, generating `AND NOT (...)` clauses for non-containing disjuncts) tested only indirectly through oracle property tests. A bug here would cause incorrect move-in queries — either over-fetching (wasted work) or under-fetching (missed rows). The oracle tests likely catch this, but targeted unit tests would improve debuggability.
+
+**3. Two-point decomposition is correct but undocumented in code**
+
+The plan explicitly calls out that `Decomposer.decompose/1` is called at both shape creation and consumer startup, and that this is safe because decomposition is deterministic. The code does this correctly but doesn't include a comment explaining why the redundant call is intentional.
+
+**4. Move event cancellation (`cancel_matching_move_events/1`) is correct**
+
+The sorted-pair algorithm handles multiple occurrences of the same value correctly. The O(n log n) sort is acceptable for typical batch sizes.
+
+---
+
+## Potential Scaling Issues
+
+**1. Exclusion clause SQL size — O(disjuncts x subqueries x subquery_SQL_size)**
+
+Each non-containing disjunct generates an `AND NOT (cond1 AND cond2 ...)` clause where each condition can contain a full subquery. With the 100-disjunct limit:
+- Worst case: ~50 exclusion disjuncts x 3 conditions x 200 chars = ~30KB of SQL per move-in query
+- PostgreSQL can handle this (1GB query limit), but query planning time grows with SQL complexity
+- **Practical risk**: Low. Real WHERE clauses typically produce 2-5 disjuncts.
+- **Recommendation**: Monitor query plan times for shapes approaching the disjunct limit.
+
+**2. Per-row `active_conditions` computation in replication stream**
+
+Every row from the replication stream now evaluates `position_count` subexpressions (via `DnfContext.evaluate_record/4`) instead of a single `includes_record?` call. Each subexpression evaluation involves:
+- Subquery positions: `MapSet.member?` lookup (O(1) amortized)
+- Non-subquery positions: AST evaluation via `Runner.execute/3`
+
+With `position_count` up to ~10 in realistic cases, this is a constant-factor overhead over the existing single-evaluation path. The plan acknowledges this replaces (not adds to) `includes_record?`, so it's a single pass, not double evaluation.
+
+**Risk**: For shapes with many non-subquery positions, the AST evaluation overhead could add up on high-throughput replication streams. The existing `when not Shape.has_dependencies(shape)` guard ensures shapes without subqueries skip DNF entirely.
+
+**3. Tag storage per row — O(disjuncts x positions)**
+
+Each row carries:
+- 2D tag array: `num_disjuncts x num_positions` entries (many nil)
+- `active_conditions`: `num_positions` booleans
+
+With 100 disjuncts x 10 positions = ~1000 entries per row. For batches of 1000 rows = ~1M entries. These are small values (hashes or booleans), so memory impact is negligible for realistic cases but could add up at the 100-disjunct limit.
+
+**4. `condition_hashes_to_skip` accumulation during in-flight move-in queries**
+
+`moved_out_tags` grows as move-outs arrive while move-in queries are in flight. The type changed from `%{name => MapSet}` to `%{name => %{position => MapSet}}`, adding one level of nesting. Filtering is O(positions x skip_set_size) per row, which is fine for typical cases.
+
+**5. Snapshot query active_conditions SQL — O(positions x subquery_size)**
+
+The snapshot SELECT includes `ARRAY[cond_0, cond_1, ..., cond_N]::boolean[]` where each `cond_i` can be a full subquery. PostgreSQL deduplicates identical subexpressions between SELECT and WHERE, but the query planner still needs to process them. For 10 positions with subqueries, this adds moderate overhead to snapshot queries.
+
+**6. Binary snapshot file format overhead**
+
+The new format stores `hash_count` condition hashes per row (one per position). With 10 positions x ~32 bytes per hash = ~320 extra bytes per row. For a 1M-row snapshot, this adds ~320MB. This is proportional and unavoidable, but worth monitoring for large shapes.
+
+---
+
+## RFC Compliance
+
+The implementation matches the RFC on all key points:
+
+- **DNF decomposition**: Correct De Morgan's laws, position assignment, complexity guard
+- **Tag structure**: Three-format distinction (condition_hashes, internal 2D, wire) correctly implemented
+- **Message format**: `active_conditions` added to headers, `tags_to_wire` conversion correct
+- **Move-in queries**: Triggering-disjunct-only WHERE clause with exclusion clauses
+- **Negation handling**: Positions store un-negated AST with `negated: true`, NOT applied at evaluation time
+- **Protocol versioning**: V1 clients rejected for complex shapes, V2 required
+- **Consistency model**: Eventual consistency for subquery shapes (pre-existing, correctly documented)
+- **Client requirements**: Elixir client implements position-based indexing, DNF visibility evaluation, synthetic deletes
+
+One area the RFC calls out as "future work" — restoring transactional/causal consistency by delaying up-to-date markers — is correctly deferred (not attempted on this branch).
+
+---
+
+## Summary of Recommendations
+
+**High priority:**
+1. Add dedicated unit tests for `build_dnf_exclusion_clauses/4` covering various disjunct combinations, negated positions, and mixed condition types
+2. Add a code comment in `fill_tag_structure` explaining the intentional two-point decomposition
+
+**Medium priority:**
+3. Consolidate `extract_sublink_index/1` into a single shared location (or at minimum add a comment cross-referencing the copies)
+4. Add logging in `DnfContext.from_shape/1` when decomposition fails (to catch unexpected nil contexts at runtime)
+5. Monitor move-in query SQL size and plan time in production for shapes with many disjuncts
+
+**Low priority:**
+6. Consider a round-trip property test: WHERE -> parse -> SqlGenerator -> parse again -> assert equivalent ASTs
+7. Document the exclusion clause algorithm inline (currently the most complex and least documented part of the codebase)

--- a/packages/sync-service/summary.md
+++ b/packages/sync-service/summary.md
@@ -1,0 +1,135 @@
+# Bug-Fixing Context: Arbitrary Boolean Expressions with Subqueries
+
+This document provides the key context needed to debug issues in the "arbitrary boolean expressions with subqueries" implementation. For full details, see:
+
+- **RFC**: `../../docs/rfcs/arbitrary-boolean-expressions-with-subqueries.md`
+- **Original implementation plan**: `./IMPLEMENTATION_PLAN.md` (14 phases)
+- **Exclusion clause bug & fix**: `./PLAN_UPDATE.md`
+- **Exclusion clause implementation details**: `./IMP_PLAN_UPDATE.md`
+
+---
+
+## What This Feature Does
+
+Previously, Electric only supported single `column IN (SELECT ...)` subqueries in shape WHERE clauses. This feature extends support to arbitrary boolean expressions: OR, AND, NOT, and multiple subqueries. For example:
+
+```sql
+WHERE project_id IN (SELECT id FROM projects WHERE active)
+   OR assigned_to IN (SELECT id FROM users WHERE admin)
+```
+
+The WHERE clause is decomposed into **Disjunctive Normal Form (DNF)** — a disjunction (OR) of conjunctions (AND) of literals. Each unique atomic condition gets a **position** index. The system tracks per-row, per-position state to determine visibility.
+
+---
+
+## Core Concepts
+
+### DNF Positions
+Every atomic condition in the WHERE clause gets a unique integer position (0-indexed). For `WHERE (x IN sq1 AND status = 'active') OR y IN sq2`:
+- Position 0: `x IN sq1` (subquery)
+- Position 1: `status = 'active'` (non-subquery)
+- Position 2: `y IN sq2` (subquery)
+- Disjunct 0 = positions {0, 1}, Disjunct 1 = position {2}
+
+### active_conditions
+A `[boolean]` array, one entry per DNF position, sent to clients with every row. Tells the client which conditions are satisfied for that row. Negated positions store the **effective** value (negation already applied).
+
+### Tags (slash-delimited per-disjunct)
+Wire format: `["hash_x/hash_status/", "//hash_y"]`. One string per disjunct, positions separated by `/`. Empty segments = non-participating positions. Used in change structs, JSON headers, and on the wire to clients.
+
+### condition_hashes (per-position map)
+Internal format: `%{0 => "hash_x", 1 => "hash_status", 2 => "hash_y"}`. One hash per DNF position. Stored in binary move-in snapshot files for `moved_out_tags` filtering. **Not** the same as wire tags — these are stored separately from the JSON.
+
+### DnfContext
+Struct in `lib/electric/shapes/consumer/dnf_context.ex` — holds the cached DNF decomposition, position-to-dependency maps, and negated position tracking. Built once at consumer startup from the Shape. All downstream code should use this cached decomposition, never re-decompose.
+
+---
+
+## Key Architecture & Data Flow
+
+### Layer ordering
+Dependency shapes (layer 0) process transactions before the outer shape (layer 1). Materializers in layer 0 `send` `{:materializer_changes, handle, events}` to the outer consumer. Due to FIFO mailbox ordering, the consumer processes all `materializer_changes` **before** its own `do_handle_txn` for the same transaction.
+
+### Move-in flow
+1. Materializer detects value added to dependency → sends `materializer_changes` with `move_in` values
+2. Consumer's `handle_info({:materializer_changes, ...})` receives it
+3. `MoveHandling.process_move_ins` looks up affected DNF positions via `DnfContext`
+4. For positive positions: builds WHERE clause via `SubqueryMoves.move_in_where_clause` and queries Postgres
+5. For negated positions: broadcasts deactivation (move-out)
+
+### Move-out flow
+Inverse of move-in. Positive positions broadcast deactivation; negated positions query Postgres for newly matching rows.
+
+### Exclusion clauses (the PLAN_UPDATE fix)
+When multiple disjuncts exist, move-in queries include `AND NOT (...)` clauses to avoid returning rows that will be claimed by another disjunct's move-in. **The original plan used live subqueries for exclusion, which is broken** — see `PLAN_UPDATE.md` for the full explanation.
+
+**Fix**: Use **parameter-based exclusion** (`= ANY($values)`) with materialized state. The materializer retains `prev_value_counts` (pre-transaction state). The consumer tracks `seen_deps` — which dependencies' `materializer_changes` it has already processed for the current transaction:
+
+- **Seen dependency** → use **current** materialized values (its move-in already started)
+- **Unseen dependency** → use **pre-transaction** materialized values (avoids false exclusion)
+
+`seen_deps` is reset at the start of each `do_handle_txn`.
+
+---
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `lib/electric/replication/eval/decomposer.ex` | DNF decomposition of WHERE clause ASTs |
+| `lib/electric/replication/eval/sql_generator.ex` | AST → SQL conversion (for active_conditions SELECT and exclusion clauses) |
+| `lib/electric/shapes/consumer/dnf_context.ex` | Cached DNF state (decomposition, position maps, negated positions) |
+| `lib/electric/shapes/shape/subquery_moves.ex` | Move-in WHERE clause generation including DNF-aware exclusion clauses |
+| `lib/electric/shapes/shape.ex` | `fill_tag_structure` (multi-disjunct tag patterns), `fill_move_tags` (slash-delimited output) |
+| `lib/electric/shapes/consumer/move_handling.ex` | Move-in/out orchestration, position routing, negation inversion, builds exclusion context |
+| `lib/electric/shapes/consumer/materializer.ex` | Tracks `value_counts` and `prev_value_counts`, serves `get_link_values`/`get_prev_link_values` |
+| `lib/electric/shapes/consumer/state.ex` | Holds `dnf_context`, `seen_deps` tracking |
+| `lib/electric/shapes/consumer.ex` | Wires `materializer_changes` → marks seen deps, resets seen_deps in `do_handle_txn` |
+| `lib/electric/shapes/where_clause.ex` | `compute_active_conditions`, `evaluate_dnf` |
+| `lib/electric/shapes/consumer/change_handling.ex` | Computes active_conditions per change, evaluates DNF for inclusion |
+| `lib/electric/shapes/querying.ex` | SQL for snapshots/move-ins, `build_active_conditions_select`, `make_condition_hashes_select` |
+| `lib/electric/log_items.ex` | Formats messages with `active_conditions` in headers, tags passed through as-is |
+| `lib/electric/shapes/consumer/move_ins.ex` | `moved_out_tags` — position-aware `%{name => %{position => MapSet}}` |
+| `lib/electric/shape_cache/pure_file_storage.ex` | Binary snapshot read/write with condition_hashes, position-aware `should_skip_for_moved_out?` |
+| `packages/elixir-client/lib/electric/client/tag_tracker.ex` | Client-side DNF evaluation, synthetic deletes, slash-delimited tag parsing |
+
+---
+
+## Common Bug Categories & What to Check
+
+### 1. Rows missing (not delivered to client)
+- **Exclusion clause bug**: Are both disjuncts excluding a row? Check `seen_deps` logic in `move_handling.ex` → `build_exclusion_context`. Verify that unseen deps use `get_prev_link_values` (pre-txn state) and seen deps use `get_link_values` (current state).
+- **moved_out_tags false positive**: Is `should_skip_for_moved_out?` in storage incorrectly filtering a row? Check that condition_hashes (per-position) are being compared, not wire-format tags.
+- **Wrong disjunct in WHERE**: Is `build_dnf_move_in_where` using the full original WHERE instead of the triggering disjunct's conditions?
+
+### 2. Duplicate rows delivered
+- **Exclusion clause not firing**: Check `build_dnf_exclusion_clauses` — it should only exclude disjuncts that do NOT contain the trigger position. If exclusion is missing entirely, both move-ins return the same row.
+- **Tag mismatch**: Verify that Postgres-generated hashes (from `make_condition_hashes_select` and `make_tags`) match Elixir-generated hashes (from `fill_move_tags`). They both must use the same `namespace_value` + MD5 formula with identical column value formatting.
+
+### 3. Wrong active_conditions values
+- **Sublink index resolution**: If two subqueries reference the same column (e.g., `parent_id IN sq1 OR parent_id IN sq2`), `extract_sublink_index` must be used to distinguish them via AST node, NOT column-name matching. Column-name matching always resolves to the first dependency.
+- **Negation not applied**: `compute_active_conditions` in `where_clause.ex` must apply `not` for negated positions. The decomposer stores un-negated ASTs with `negated: true`.
+- **Non-subquery conditions returning true**: In `build_active_conditions_select` (querying.ex), non-subquery positions must use `SqlGenerator.to_sql(subexpr.ast)` — a hardcoded `"true"` is wrong for OR shapes.
+
+### 4. Synthetic deletes not generated / generated incorrectly
+- **Client tag parsing**: `removed_tags` arrive in the same slash-delimited format as `tags`. The client must split them on `/` before comparison. If compared as raw strings against individual hashes, they'll never match.
+- **DNF evaluation**: Client's `row_visible?` must evaluate OR-of-ANDs over disjunct positions. A row is visible if ANY disjunct has ALL its positions active.
+- **Orphaned tag_to_keys entries**: When a row is deleted or all its positions become inactive, ensure the `tag_to_keys` index is cleaned up. Stale entries cause phantom synthetic deletes when a move-out broadcast matches a key that is no longer tracked.
+
+### 5. Position instability across restarts
+- Position assignment in the decomposer must be deterministic (sorted by canonical AST representation). If positions shift, clients holding cached `active_conditions` will misinterpret them.
+
+### 6. Single-dependency shapes regressing
+- Single-disjunct shapes should take the fast path in most places (`length(disjuncts) == 1`). The `when not Shape.has_dependencies(shape)` guard in `change_handling.ex` already skips DNF code for shapes without dependencies.
+
+---
+
+## Invariants That Must Hold
+
+1. **No re-decomposition within consumer lifetime** — always use `DnfContext`'s cached decomposition
+2. **`seen_deps` reset at start of every `do_handle_txn`** — stale seen_deps from a previous transaction will use wrong materialized state
+3. **`prev_value_counts` NOT saved during startup stream reads** — only saved before applying runtime transaction changes
+4. **condition_hashes stored separately from JSON in binary snapshot files** — filtering must use per-position hashes, not wire-format tags
+5. **Tags and condition_hashes both computed from the same column values** using the same hashing formula — Postgres-side and Elixir-side must produce identical results
+6. **`extract_sublink_index` used everywhere** a sublink's dependency index is needed — never resolve by column name
+7. **Negated positions invert move semantics**: move-in to subquery + negated position = deactivation; move-out from subquery + negated position = activation

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -3017,7 +3017,7 @@ defmodule Electric.Plug.RouterTest do
            "INSERT INTO project_members (project_id, user_id) VALUES (1, 100), (3, 100)",
            "INSERT INTO projects (id, workspace_id, name) VALUES (1, 1, 'project 1'), (2, 1, 'project 2')"
          ]
-    test "supports two subqueries at the same level but returns 409 on move-in", %{
+    test "supports two subqueries at the same level with move-in", %{
       opts: opts,
       db_conn: db_conn
     } do
@@ -3085,8 +3085,16 @@ defmodule Electric.Plug.RouterTest do
         []
       )
 
-      # Should get a 409 because multiple same-level subqueries cannot currently correctly handle move-ins
-      assert %{status: 409} = Task.await(task)
+      # Move-in now works correctly with multiple same-level subqueries
+      assert %{status: 200} = conn = Task.await(task)
+
+      assert [
+               %{
+                 "headers" => %{"is_move_in" => true, "operation" => "insert"},
+                 "value" => %{"id" => "2", "workspace_id" => "1", "name" => "project 2"}
+               },
+               %{"headers" => %{"control" => "snapshot-end"}} | _
+             ] = Jason.decode!(conn.resp_body)
     end
   end
 

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2331,7 +2331,7 @@ defmodule Electric.Plug.RouterTest do
            "INSERT INTO parent (id, excluded) VALUES (1, false), (2, true)",
            "INSERT INTO child (id, parent_id, value) VALUES (1, 1, 10), (2, 2, 20)"
          ]
-    test "NOT IN subquery should return 409 on move-in to subquery", %{
+    test "NOT IN subquery should handle move-out correctly", %{
       opts: opts,
       db_conn: db_conn
     } do
@@ -2340,7 +2340,8 @@ defmodule Electric.Plug.RouterTest do
       # parent 2 is excluded, so child 2 is NOT in the shape
       req =
         make_shape_req("child",
-          where: "parent_id NOT IN (SELECT id FROM parent WHERE excluded = true)"
+          where: "parent_id NOT IN (SELECT id FROM parent WHERE excluded = true)",
+          electric_protocol_version: "2"
         )
 
       assert {req, 200, [data, snapshot_end]} = shape_req(req, opts)
@@ -2357,11 +2358,14 @@ defmodule Electric.Plug.RouterTest do
 
       # Now set parent 1 to excluded = true
       # This causes parent 1 to move INTO the subquery result
-      # Which should cause child 1 to move OUT of the outer shape
-      # Since NOT IN subquery move-out isn't implemented, we expect a 409
+      # Which should cause child 1 to move OUT of the outer shape (NOT IN is negated)
       Postgrex.query!(db_conn, "UPDATE parent SET excluded = true WHERE id = 1", [])
 
-      assert {_req, 409, _response} = Task.await(task)
+      assert {_req, 200,
+              [
+                %{"headers" => %{"event" => "move-out", "patterns" => [%{"pos" => 0}]}},
+                %{"headers" => %{"control" => "up-to-date"}}
+              ]} = Task.await(task)
     end
 
     @tag with_sql: [
@@ -2492,14 +2496,15 @@ defmodule Electric.Plug.RouterTest do
            "INSERT INTO parent (id, include_parent) VALUES (1, true)",
            "INSERT INTO child (id, parent_id, include_child) VALUES (1, 1, true)"
          ]
-    test "subquery combined with OR should return a 409 on move-out", %{
+    test "subquery combined with OR emits move-out for affected position", %{
       opts: opts,
       db_conn: db_conn
     } do
       orig_req =
         make_shape_req("child",
           where:
-            "parent_id in (SELECT id FROM parent WHERE include_parent = true) OR include_child = true"
+            "parent_id in (SELECT id FROM parent WHERE include_parent = true) OR include_child = true",
+          electric_protocol_version: "2"
         )
 
       assert {req, 200, response} = shape_req(orig_req, opts)
@@ -2511,11 +2516,16 @@ defmodule Electric.Plug.RouterTest do
 
       task = live_shape_req(req, opts)
 
-      # Setting include_parent to false may cause a move out, but it doesn't in this case because include_child is still true
+      # Setting include_parent to false causes position 0 (subquery) to no longer match,
+      # but include_child is still true so the row stays visible via the other disjunct.
+      # The server emits a move-out for the affected position.
       Postgrex.query!(db_conn, "UPDATE parent SET include_parent = false WHERE id = 1", [])
 
-      # Rather than working out whether this is a move out or not we return a 409
-      assert {_req, 409, _response} = Task.await(task)
+      assert {_req, 200,
+              [
+                %{"headers" => %{"event" => "move-out", "patterns" => [%{"pos" => 0}]}},
+                %{"headers" => %{"control" => "up-to-date"}}
+              ]} = Task.await(task)
     end
 
     @tag with_sql: [
@@ -2524,14 +2534,15 @@ defmodule Electric.Plug.RouterTest do
            "INSERT INTO parent (id, include_parent) VALUES (1, false)",
            "INSERT INTO child (id, parent_id, include_child) VALUES (1, 1, true)"
          ]
-    test "subquery combined with OR should return a 409 on move-in", %{
+    test "subquery combined with OR emits move-in for newly matching position", %{
       opts: opts,
       db_conn: db_conn
     } do
       orig_req =
         make_shape_req("child",
           where:
-            "parent_id in (SELECT id FROM parent WHERE include_parent = true) OR include_child = true"
+            "parent_id in (SELECT id FROM parent WHERE include_parent = true) OR include_child = true",
+          electric_protocol_version: "2"
         )
 
       assert {req, 200, response} = shape_req(orig_req, opts)
@@ -2543,11 +2554,23 @@ defmodule Electric.Plug.RouterTest do
 
       task = live_shape_req(req, opts)
 
-      # Setting include_parent to true may cause a move in, but it doesn't in this case because include_child is already true
+      # Setting include_parent to true causes the subquery position to also match.
+      # The row already matches via include_child, so the server emits a move-in
+      # with both conditions now active.
       Postgrex.query!(db_conn, "UPDATE parent SET include_parent = true WHERE id = 1", [])
 
-      # Rather than working out whether this is a move in or not we return a 409
-      assert {_req, 409, _response} = Task.await(task)
+      assert {_req, 200,
+              [
+                %{
+                  "headers" => %{
+                    "is_move_in" => true,
+                    "operation" => "insert",
+                    "active_conditions" => [true, true]
+                  },
+                  "value" => %{"id" => "1", "include_child" => "true", "parent_id" => "1"}
+                },
+                %{"headers" => %{"control" => "snapshot-end"}} | _
+              ]} = Task.await(task)
     end
 
     @tag with_sql: [

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2798,9 +2798,14 @@ defmodule Electric.Plug.RouterTest do
         :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:20")
         |> Base.encode16(case: :lower)
 
+      # Tags are now slash-delimited with one hash per DNF position.
+      # Both positions (subquery on value and non-subquery on other_value)
+      # hash "v:20" for child 3, so the tag is "hash/hash".
+      full_tag = tag <> "/" <> tag
+
       assert {_, 200,
               [
-                %{"headers" => %{"tags" => [^tag]}, "value" => %{"id" => "3"}},
+                %{"headers" => %{"tags" => [^full_tag]}, "value" => %{"id" => "3"}},
                 %{"headers" => %{"control" => "snapshot-end"}},
                 up_to_date_ctl()
               ]} =
@@ -2825,11 +2830,18 @@ defmodule Electric.Plug.RouterTest do
       # Should contain the data record and the snapshot-end control message
       assert length(response) == 2
 
-      tag = :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:1") |> Base.encode16(case: :lower)
+      # Tags are now slash-delimited: position 0 hashes parentId, position 1 hashes Value
+      tag0 =
+        :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:1") |> Base.encode16(case: :lower)
+
+      tag1 =
+        :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:10") |> Base.encode16(case: :lower)
+
+      full_tag = tag0 <> "/" <> tag1
 
       assert %{
                "value" => %{"id" => "1", "parentId" => "1", "Value" => "10"},
-               "headers" => %{"tags" => [^tag]}
+               "headers" => %{"tags" => [^full_tag]}
              } =
                Enum.find(response, &Map.has_key?(&1, "key"))
 

--- a/packages/sync-service/test/electric/replication/eval/decomposer_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/decomposer_test.exs
@@ -1,0 +1,300 @@
+defmodule Electric.Replication.Eval.DecomposerTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Replication.Eval.Parser
+  alias Electric.Replication.Eval.Decomposer
+
+  describe "decompose/1" do
+    test "should decompose a DNF query with shared subexpressions" do
+      # (a = 1 AND b = 2) OR (c = 3 AND d = 4) OR (a = 1 AND c = 3)
+      # Disjunct 1: positions 0-1
+      # Disjunct 2: positions 2-3
+      # Disjunct 3: positions 4-5 (reuses r1 for a=1, r3 for c=3)
+      ~S"(a = 1 AND b = 2) OR (c = 3 AND d = 4) OR (a = 1 AND c = 3)"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [
+          ["a = 1", "b = 2", nil, nil, nil, nil],
+          [nil, nil, "c = 3", "d = 4", nil, nil],
+          [nil, nil, nil, nil, "a = 1", "c = 3"]
+        ],
+        expected_subexpressions: ["a = 1", "b = 2", "c = 3", "d = 4"]
+      )
+    end
+
+    test "should handle a single comparison without AND/OR" do
+      ~S"a = 1"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [["a = 1"]],
+        expected_subexpressions: ["a = 1"]
+      )
+    end
+
+    test "should handle all ANDs as a single disjunct" do
+      ~S"a = 1 AND b = 2 AND c = 3"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [["a = 1", "b = 2", "c = 3"]],
+        expected_subexpressions: ["a = 1", "b = 2", "c = 3"]
+      )
+    end
+
+    test "should handle all ORs as N disjuncts with 1 expression each" do
+      # a = 1 OR b = 2 OR c = 3
+      # Each OR branch is its own disjunct with 1 expression
+      # Total positions: 3 (one per disjunct)
+      ~S"a = 1 OR b = 2 OR c = 3"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [
+          ["a = 1", nil, nil],
+          [nil, "b = 2", nil],
+          [nil, nil, "c = 3"]
+        ],
+        expected_subexpressions: ["a = 1", "b = 2", "c = 3"]
+      )
+    end
+
+    test "should distribute AND over OR with subexpression reuse" do
+      # a = 1 AND (b = 2 OR c = 3) => (a = 1 AND b = 2) OR (a = 1 AND c = 3)
+      # After distribution, we get 2 disjuncts with 2 expressions each
+      # The "a = 1" subexpression should be deduplicated (same reference)
+      ~S"a = 1 AND (b = 2 OR c = 3)"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [
+          ["a = 1", "b = 2", nil, nil],
+          [nil, nil, "a = 1", "c = 3"]
+        ],
+        expected_subexpressions: ["a = 1", "b = 2", "c = 3"]
+      )
+    end
+
+    test "should handle subquery expressions as atomic subexpressions" do
+      ~S"a = 1 AND (b IN (SELECT id FROM test_table) OR c = 3)"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [
+          ["a = 1", "b IN (SELECT id FROM test_table)", nil, nil],
+          [nil, nil, "a = 1", "c = 3"]
+        ],
+        expected_subexpressions: ["a = 1", "b IN (SELECT id FROM test_table)", "c = 3"]
+      )
+    end
+
+    test "should handle deeply nested distribution ((a OR b) AND (c OR d))" do
+      # (a OR b) AND (c OR d) => (a AND c) OR (a AND d) OR (b AND c) OR (b AND d)
+      # 4 disjuncts, each with 2 expressions
+      ~S"(a = 1 OR b = 2) AND (c = 3 OR d = 4)"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [
+          ["a = 1", "c = 3", nil, nil, nil, nil, nil, nil],
+          [nil, nil, "a = 1", "d = 4", nil, nil, nil, nil],
+          [nil, nil, nil, nil, "b = 2", "c = 3", nil, nil],
+          [nil, nil, nil, nil, nil, nil, "b = 2", "d = 4"]
+        ],
+        expected_subexpressions: ["a = 1", "b = 2", "c = 3", "d = 4"]
+      )
+    end
+
+    test "should push NOT down to leaf expressions" do
+      # NOT a = 1 AND b = 2 parses as (NOT a = 1) AND b = 2
+      # The NOT is already at the leaf, so it becomes {:not, ref}
+      ~S"NOT a = 1 AND b = 2"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [[{:not, "a = 1"}, "b = 2"]],
+        expected_subexpressions: ["a = 1", "b = 2"]
+      )
+    end
+
+    test "should apply De Morgan's law for NOT over OR" do
+      # NOT (a = 1 OR b = 2) => (NOT a = 1) AND (NOT b = 2)
+      # Single disjunct with two negated terms
+      ~S"NOT (a = 1 OR b = 2)"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [[{:not, "a = 1"}, {:not, "b = 2"}]],
+        expected_subexpressions: ["a = 1", "b = 2"]
+      )
+    end
+
+    test "should apply De Morgan's law for NOT over AND" do
+      # NOT (a = 1 AND b = 2) => (NOT a = 1) OR (NOT b = 2)
+      # Two disjuncts, each with one negated term
+      ~S"NOT (a = 1 AND b = 2)"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [
+          [{:not, "a = 1"}, nil],
+          [nil, {:not, "b = 2"}]
+        ],
+        expected_subexpressions: ["a = 1", "b = 2"]
+      )
+    end
+
+    test "should handle double negation" do
+      # NOT NOT a = 1 => a = 1 (double negation elimination)
+      ~S"NOT NOT a = 1"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [["a = 1"]],
+        expected_subexpressions: ["a = 1"]
+      )
+    end
+
+    test "should handle function calls as atomic subexpressions" do
+      ~S"lower(name) = 'test' OR upper(name) = 'TEST'"
+      |> prepare()
+      |> Decomposer.decompose()
+      |> assert_expanded_dnf(
+        expected_disjuncts: [
+          ["lower(name) = 'test'", nil],
+          [nil, "upper(name) = 'TEST'"]
+        ],
+        expected_subexpressions: ["lower(name) = 'test'", "upper(name) = 'TEST'"]
+      )
+    end
+
+    test "should deduplicate references for identical subexpressions" do
+      # All three disjuncts contain `a = 1` - should use same reference
+      {disjuncts, subexpressions} =
+        ~S"(a = 1 AND b = 2) OR (a = 1 AND c = 3) OR a = 1"
+        |> prepare()
+        |> Decomposer.decompose()
+
+      assert_expanded_dnf({disjuncts, subexpressions},
+        expected_disjuncts: [
+          ["a = 1", "b = 2", nil, nil, nil],
+          [nil, nil, "a = 1", "c = 3", nil],
+          [nil, nil, nil, nil, "a = 1"]
+        ],
+        expected_subexpressions: ["a = 1", "b = 2", "c = 3"]
+      )
+
+      # Additionally verify that a = 1 uses the same reference across disjuncts
+      subexpressions_deparsed = Map.new(subexpressions, fn {ref, ast} -> {deparse(ast), ref} end)
+      a_eq_1_ref = Map.fetch!(subexpressions_deparsed, "a = 1")
+
+      # Find all occurrences of the a = 1 reference across disjuncts
+      # Handle both plain refs and {:not, ref} tuples
+      a_eq_1_positions =
+        disjuncts
+        |> Enum.with_index()
+        |> Enum.flat_map(fn {conjuncts, disjunct_idx} ->
+          conjuncts
+          |> Enum.with_index()
+          |> Enum.filter(fn {term, _pos} -> extract_ref(term) == a_eq_1_ref end)
+          |> Enum.map(fn {_term, pos} -> {disjunct_idx, pos} end)
+        end)
+
+      # a = 1 should appear in all 3 disjuncts
+      assert length(a_eq_1_positions) == 3
+    end
+  end
+
+  # Helper to prepare a WHERE clause string into an AST
+  defp prepare(where_clause) do
+    {:ok, ast} = Parser.parse_query(where_clause)
+    ast
+  end
+
+  # Helper to deparse an AST node back to SQL string
+  defp deparse(ast) do
+    %PgQuery.ParseResult{
+      stmts: [
+        %PgQuery.RawStmt{
+          stmt: %PgQuery.Node{
+            node:
+              {:select_stmt,
+               %PgQuery.SelectStmt{
+                 target_list: [%PgQuery.Node{node: {:res_target, %PgQuery.ResTarget{val: ast}}}]
+               }}
+          }
+        }
+      ]
+    }
+    |> PgQuery.protobuf_to_query!()
+    |> String.replace_prefix("SELECT ", "")
+    |> String.trim()
+  end
+
+  # Assertion helper that verifies:
+  # 1. All inner lists have the same length (expanded property)
+  # 2. Each disjunct matches the expected structure (including nil positions)
+  # 3. Subexpressions map contains exactly the expected unique expressions
+  # 4. References are properly reused for identical subexpressions
+  # 5. {:not, ref} terms are handled correctly
+  defp assert_expanded_dnf({disjuncts, subexpressions}, opts) do
+    expected_disjuncts = Keyword.fetch!(opts, :expected_disjuncts)
+    expected_subexpressions = Keyword.fetch!(opts, :expected_subexpressions)
+
+    # Convert subexpressions to deparsed form for comparison
+    subexpressions_deparsed = Map.new(subexpressions, fn {ref, ast} -> {ref, deparse(ast)} end)
+
+    # 1. Verify all disjuncts have the same length
+    lengths = Enum.map(disjuncts, &length/1)
+    assert lengths != [], "Disjuncts list cannot be empty"
+    assert Enum.uniq(lengths) == [hd(lengths)], "All disjuncts must have same length"
+    width = hd(lengths)
+
+    # 2. Verify width matches expected disjuncts width
+    expected_width = expected_disjuncts |> hd() |> length()
+
+    assert width == expected_width,
+           "Width (#{width}) must equal expected width (#{expected_width})"
+
+    # 3. Verify correct number of disjuncts
+    assert length(disjuncts) == length(expected_disjuncts),
+           "Expected #{length(expected_disjuncts)} disjuncts, got #{length(disjuncts)}"
+
+    # 4. Verify subexpressions map contains exactly the expected unique expressions
+    assert length(expected_subexpressions) == map_size(subexpressions_deparsed),
+           "Expected #{length(expected_subexpressions)} subexpressions, got #{map_size(subexpressions_deparsed)}"
+
+    actual_subexprs = subexpressions_deparsed |> Map.values() |> MapSet.new()
+    expected_subexprs = MapSet.new(expected_subexpressions)
+
+    assert actual_subexprs == expected_subexprs,
+           "Subexpressions mismatch. Expected: #{inspect(expected_subexprs)}, got: #{inspect(actual_subexprs)}"
+
+    # 5. Verify each disjunct matches the expected structure
+    expected = MapSet.new(expected_disjuncts)
+
+    actual =
+      MapSet.new(disjuncts, fn disjunct ->
+        Enum.map(disjunct, &deparse_term(&1, subexpressions_deparsed))
+      end)
+
+    assert actual == expected
+  end
+
+  # Convert a DNF term (ref, {:not, ref}, or nil) to its expected format
+  defp deparse_term(nil, _subexpressions_deparsed), do: nil
+
+  defp deparse_term({:not, ref}, subexpressions_deparsed) do
+    {:not, Map.fetch!(subexpressions_deparsed, ref)}
+  end
+
+  defp deparse_term(ref, subexpressions_deparsed) when is_reference(ref) do
+    Map.fetch!(subexpressions_deparsed, ref)
+  end
+
+  # Extract the base reference from a DNF term
+  defp extract_ref(nil), do: nil
+  defp extract_ref({:not, ref}), do: ref
+  defp extract_ref(ref) when is_reference(ref), do: ref
+end

--- a/packages/sync-service/test/electric/replication/eval/decomposer_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/decomposer_test.exs
@@ -328,6 +328,21 @@ defmodule Electric.Replication.Eval.DecomposerTest do
 
       assert a_eq_1_count == 3
     end
+
+    test "should return error when disjunct count exceeds limit" do
+      # Build a WHERE clause with >100 disjuncts: a = 1 OR a = 2 OR ... OR a = 101
+      clause = Enum.map_join(1..101, " OR ", &"a = #{&1}")
+
+      result =
+        clause
+        |> prepare()
+        |> Decomposer.decompose()
+
+      assert {:error, message} = result
+      assert message =~ "too complex"
+      assert message =~ "101 disjuncts"
+      assert message =~ "limit of 100"
+    end
   end
 
   # Helper to prepare a WHERE clause string into a Parser AST

--- a/packages/sync-service/test/electric/replication/eval/decomposer_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/decomposer_test.exs
@@ -252,21 +252,90 @@ defmodule Electric.Replication.Eval.DecomposerTest do
       assert_expanded_dnf({:ok, decomposition},
         expected_disjuncts: [
           # ab × de
-          [~s|"a" = 1|, ~s|"b" = 2|, ~s|"d" = 4|, ~s|"e" = 5|,
-           nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil],
+          [
+            ~s|"a" = 1|,
+            ~s|"b" = 2|,
+            ~s|"d" = 4|,
+            ~s|"e" = 5|,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil
+          ],
           # ab × fg
-          [nil, nil, nil, nil, ~s|"a" = 1|, ~s|"b" = 2|, ~s|"f" = 6|, ~s|"g" = 7|,
-           nil, nil, nil, nil, nil, nil, nil, nil],
+          [
+            nil,
+            nil,
+            nil,
+            nil,
+            ~s|"a" = 1|,
+            ~s|"b" = 2|,
+            ~s|"f" = 6|,
+            ~s|"g" = 7|,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil
+          ],
           # cd × de
-          [nil, nil, nil, nil, nil, nil, nil, nil,
-           ~s|"c" = 3|, ~s|"d" = 4|, ~s|"d" = 4|, ~s|"e" = 5|, nil, nil, nil, nil],
+          [
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            ~s|"c" = 3|,
+            ~s|"d" = 4|,
+            ~s|"d" = 4|,
+            ~s|"e" = 5|,
+            nil,
+            nil,
+            nil,
+            nil
+          ],
           # cd × fg
-          [nil, nil, nil, nil, nil, nil, nil, nil,
-           nil, nil, nil, nil, ~s|"c" = 3|, ~s|"d" = 4|, ~s|"f" = 6|, ~s|"g" = 7|]
+          [
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            ~s|"c" = 3|,
+            ~s|"d" = 4|,
+            ~s|"f" = 6|,
+            ~s|"g" = 7|
+          ]
         ],
         expected_subexpressions: [
-          ~s|"a" = 1|, ~s|"b" = 2|, ~s|"c" = 3|, ~s|"d" = 4|,
-          ~s|"e" = 5|, ~s|"f" = 6|, ~s|"g" = 7|
+          ~s|"a" = 1|,
+          ~s|"b" = 2|,
+          ~s|"c" = 3|,
+          ~s|"d" = 4|,
+          ~s|"e" = 5|,
+          ~s|"f" = 6|,
+          ~s|"g" = 7|
         ]
       )
 

--- a/packages/sync-service/test/electric/replication/eval/sql_generator_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/sql_generator_test.exs
@@ -1,0 +1,579 @@
+defmodule Electric.Replication.Eval.SqlGeneratorTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Replication.Eval.SqlGenerator
+  alias Electric.Replication.Eval.Parser.{Const, Ref, Func, Array, RowExpr}
+
+  describe "comparison operators" do
+    test "equals" do
+      ast = %Func{name: "\"=\"", args: [%Ref{path: ["status"]}, %Const{value: "active"}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("status" = 'active')|
+    end
+
+    test "not equals" do
+      ast = %Func{name: "\"<>\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" <> 1)|
+    end
+
+    test "less than" do
+      ast = %Func{name: "\"<\"", args: [%Ref{path: ["age"]}, %Const{value: 30}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("age" < 30)|
+    end
+
+    test "greater than" do
+      ast = %Func{name: "\">\"", args: [%Ref{path: ["score"]}, %Const{value: 100}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("score" > 100)|
+    end
+
+    test "less than or equal" do
+      ast = %Func{name: "\"<=\"", args: [%Ref{path: ["x"]}, %Const{value: 5}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" <= 5)|
+    end
+
+    test "greater than or equal" do
+      ast = %Func{name: "\">=\"", args: [%Ref{path: ["y"]}, %Const{value: 10}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("y" >= 10)|
+    end
+  end
+
+  describe "pattern matching" do
+    test "LIKE" do
+      ast = %Func{name: "\"~~\"", args: [%Ref{path: ["name"]}, %Const{value: "%foo%"}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("name" LIKE '%foo%')|
+    end
+
+    test "ILIKE" do
+      ast = %Func{name: "\"~~*\"", args: [%Ref{path: ["name"]}, %Const{value: "%bar%"}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("name" ILIKE '%bar%')|
+    end
+
+    test "NOT LIKE" do
+      ast = %Func{name: "\"!~~\"", args: [%Ref{path: ["name"]}, %Const{value: "%baz%"}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("name" NOT LIKE '%baz%')|
+    end
+
+    test "NOT ILIKE" do
+      ast = %Func{name: "\"!~~*\"", args: [%Ref{path: ["name"]}, %Const{value: "%qux%"}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("name" NOT ILIKE '%qux%')|
+    end
+  end
+
+  describe "nullability" do
+    test "IS NULL" do
+      ast = %Func{name: "is null", args: [%Ref{path: ["deleted_at"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("deleted_at" IS NULL)|
+    end
+
+    test "IS NOT NULL" do
+      ast = %Func{name: "is not null", args: [%Ref{path: ["email"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("email" IS NOT NULL)|
+    end
+  end
+
+  describe "boolean tests" do
+    test "IS TRUE" do
+      ast = %Func{name: "IS_TRUE", args: [%Ref{path: ["active"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("active" IS TRUE)|
+    end
+
+    test "IS NOT TRUE" do
+      ast = %Func{name: "IS_NOT_TRUE", args: [%Ref{path: ["active"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("active" IS NOT TRUE)|
+    end
+
+    test "IS FALSE" do
+      ast = %Func{name: "IS_FALSE", args: [%Ref{path: ["deleted"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("deleted" IS FALSE)|
+    end
+
+    test "IS NOT FALSE" do
+      ast = %Func{name: "IS_NOT_FALSE", args: [%Ref{path: ["enabled"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("enabled" IS NOT FALSE)|
+    end
+
+    test "IS UNKNOWN" do
+      ast = %Func{name: "IS_UNKNOWN", args: [%Ref{path: ["flag"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("flag" IS UNKNOWN)|
+    end
+
+    test "IS NOT UNKNOWN" do
+      ast = %Func{name: "IS_NOT_UNKNOWN", args: [%Ref{path: ["flag"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("flag" IS NOT UNKNOWN)|
+    end
+  end
+
+  describe "membership" do
+    test "IN with literal array" do
+      ast = %Func{
+        name: "in",
+        args: [
+          %Ref{path: ["status"]},
+          %Array{elements: [%Const{value: "a"}, %Const{value: "b"}, %Const{value: "c"}]}
+        ]
+      }
+
+      assert SqlGenerator.to_sql(ast) == ~s|("status" IN ('a', 'b', 'c'))|
+    end
+
+    test "IN with integer array" do
+      ast = %Func{
+        name: "in",
+        args: [
+          %Ref{path: ["id"]},
+          %Array{elements: [%Const{value: 1}, %Const{value: 2}, %Const{value: 3}]}
+        ]
+      }
+
+      assert SqlGenerator.to_sql(ast) == ~s|("id" IN (1, 2, 3))|
+    end
+  end
+
+  describe "sublink membership check" do
+    test "renders sublink reference" do
+      ast = %Func{
+        name: "sublink_membership_check",
+        args: [
+          %Ref{path: ["parent_id"]},
+          %Ref{path: ["$sublink", "0"]}
+        ]
+      }
+
+      assert SqlGenerator.to_sql(ast) == ~s|("parent_id" IN (SELECT $sublink.0))|
+    end
+  end
+
+  describe "logical operators" do
+    test "NOT" do
+      inner = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      ast = %Func{name: "not", args: [inner]}
+      assert SqlGenerator.to_sql(ast) == ~s|(NOT ("x" = 1))|
+    end
+
+    test "AND" do
+      a = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
+      ast = %Func{name: "and", args: [a, b]}
+      assert SqlGenerator.to_sql(ast) == ~s|(("x" = 1) AND ("y" = 2))|
+    end
+
+    test "OR" do
+      a = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
+      ast = %Func{name: "or", args: [a, b]}
+      assert SqlGenerator.to_sql(ast) == ~s|(("x" = 1) OR ("y" = 2))|
+    end
+
+    test "nested AND within OR" do
+      a = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
+      c = %Func{name: "\"=\"", args: [%Ref{path: ["z"]}, %Const{value: 3}]}
+      ast = %Func{name: "or", args: [%Func{name: "and", args: [a, b]}, c]}
+      assert SqlGenerator.to_sql(ast) == ~s|((("x" = 1) AND ("y" = 2)) OR ("z" = 3))|
+    end
+
+    test "nested OR within AND" do
+      a = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
+      c = %Func{name: "\"=\"", args: [%Ref{path: ["z"]}, %Const{value: 3}]}
+      ast = %Func{name: "and", args: [%Func{name: "or", args: [a, b]}, c]}
+      assert SqlGenerator.to_sql(ast) == ~s|((("x" = 1) OR ("y" = 2)) AND ("z" = 3))|
+    end
+
+    test "deeply nested logical expression" do
+      a = %Func{name: "\"=\"", args: [%Ref{path: ["a"]}, %Const{value: 1}]}
+      b = %Func{name: "\">\"", args: [%Ref{path: ["b"]}, %Const{value: 2}]}
+      c = %Func{name: "\"<\"", args: [%Ref{path: ["c"]}, %Const{value: 3}]}
+      d = %Func{name: "is null", args: [%Ref{path: ["d"]}]}
+
+      ast =
+        %Func{
+          name: "or",
+          args: [
+            %Func{name: "and", args: [a, b]},
+            %Func{name: "and", args: [c, %Func{name: "not", args: [d]}]}
+          ]
+        }
+
+      assert SqlGenerator.to_sql(ast) ==
+               ~s|((("a" = 1) AND ("b" > 2)) OR (("c" < 3) AND (NOT ("d" IS NULL))))|
+    end
+  end
+
+  describe "DISTINCT / NOT DISTINCT" do
+    test "IS DISTINCT FROM" do
+      left = %Ref{path: ["x"]}
+      right = %Const{value: 1}
+      comparison = %Func{name: "\"<>\"", args: [left, right]}
+      ast = %Func{name: "values_distinct?", args: [left, right, comparison]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" IS DISTINCT FROM 1)|
+    end
+
+    test "IS NOT DISTINCT FROM" do
+      left = %Ref{path: ["x"]}
+      right = %Const{value: nil}
+      comparison = %Func{name: "\"<>\"", args: [left, right]}
+      ast = %Func{name: "values_not_distinct?", args: [left, right, comparison]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" IS NOT DISTINCT FROM NULL)|
+    end
+  end
+
+  describe "ANY / ALL" do
+    test "ANY with equals" do
+      inner = %Func{
+        name: "\"=\"",
+        args: [%Ref{path: ["x"]}, %Ref{path: ["arr"]}],
+        map_over_array_in_pos: 1
+      }
+
+      ast = %Func{name: "any", args: [inner]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" = ANY("arr"))|
+    end
+
+    test "ALL with less than" do
+      inner = %Func{
+        name: "\"<\"",
+        args: [%Ref{path: ["x"]}, %Ref{path: ["arr"]}],
+        map_over_array_in_pos: 1
+      }
+
+      ast = %Func{name: "all", args: [inner]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" < ALL("arr"))|
+    end
+  end
+
+  describe "arithmetic operators" do
+    test "addition" do
+      ast = %Func{name: "\"+\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" + 1)|
+    end
+
+    test "subtraction" do
+      ast = %Func{name: "\"-\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" - 1)|
+    end
+
+    test "multiplication" do
+      ast = %Func{name: "\"*\"", args: [%Ref{path: ["x"]}, %Const{value: 2}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" * 2)|
+    end
+
+    test "division" do
+      ast = %Func{name: "\"/\"", args: [%Ref{path: ["x"]}, %Const{value: 2}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" / 2)|
+    end
+
+    test "exponentiation" do
+      ast = %Func{name: "\"^\"", args: [%Ref{path: ["x"]}, %Const{value: 2}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" ^ 2)|
+    end
+
+    test "unary plus" do
+      ast = %Func{name: "\"+\"", args: [%Ref{path: ["x"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|(+ "x")|
+    end
+
+    test "unary minus" do
+      ast = %Func{name: "\"-\"", args: [%Ref{path: ["x"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|(- "x")|
+    end
+
+    test "square root" do
+      ast = %Func{name: "\"|/\"", args: [%Ref{path: ["x"]}]}
+      assert SqlGenerator.to_sql(ast) == "(|/ \"x\")"
+    end
+
+    test "absolute value" do
+      ast = %Func{name: "\"@\"", args: [%Ref{path: ["x"]}]}
+      assert SqlGenerator.to_sql(ast) == "(@ \"x\")"
+    end
+  end
+
+  describe "bitwise operators" do
+    test "bitwise AND" do
+      ast = %Func{name: "\"&\"", args: [%Ref{path: ["x"]}, %Const{value: 3}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" & 3)|
+    end
+
+    test "bitwise OR" do
+      ast = %Func{name: "\"|\"", args: [%Ref{path: ["x"]}, %Const{value: 3}]}
+      assert SqlGenerator.to_sql(ast) == "(\"x\" | 3)"
+    end
+
+    test "bitwise XOR" do
+      ast = %Func{name: "\"#\"", args: [%Ref{path: ["x"]}, %Const{value: 3}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x" # 3)|
+    end
+
+    test "bitwise NOT" do
+      ast = %Func{name: "\"~\"", args: [%Ref{path: ["x"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|(~ "x")|
+    end
+  end
+
+  describe "string concatenation" do
+    test "||" do
+      ast = %Func{name: "\"||\"", args: [%Ref{path: ["first"]}, %Ref{path: ["last"]}]}
+      assert SqlGenerator.to_sql(ast) == "(\"first\" || \"last\")"
+    end
+  end
+
+  describe "array operators" do
+    test "contains (@>)" do
+      ast = %Func{name: "\"@>\"", args: [%Ref{path: ["tags"]}, %Ref{path: ["required"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("tags" @> "required")|
+    end
+
+    test "contained by (<@)" do
+      ast = %Func{name: "\"<@\"", args: [%Ref{path: ["tags"]}, %Ref{path: ["allowed"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("tags" <@ "allowed")|
+    end
+
+    test "overlap (&&)" do
+      ast = %Func{name: "\"&&\"", args: [%Ref{path: ["a"]}, %Ref{path: ["b"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("a" && "b")|
+    end
+  end
+
+  describe "named functions" do
+    test "lower" do
+      ast = %Func{name: "lower", args: [%Ref{path: ["name"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|lower("name")|
+    end
+
+    test "upper" do
+      ast = %Func{name: "upper", args: [%Ref{path: ["name"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|upper("name")|
+    end
+
+    test "array_ndims" do
+      ast = %Func{name: "array_ndims", args: [%Ref{path: ["arr"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|array_ndims("arr")|
+    end
+  end
+
+  describe "type casts" do
+    test "cast with _to_ naming convention" do
+      ast = %Func{name: "int4_to_bool", args: [%Ref{path: ["x"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("x")::bool|
+    end
+
+    test "another cast" do
+      ast = %Func{name: "text_to_int4", args: [%Ref{path: ["val"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("val")::int4|
+    end
+  end
+
+  describe "column references" do
+    test "simple column" do
+      assert SqlGenerator.to_sql(%Ref{path: ["status"]}) == ~s|"status"|
+    end
+
+    test "schema-qualified column" do
+      assert SqlGenerator.to_sql(%Ref{path: ["public", "users", "id"]}) ==
+               ~s|"public"."users"."id"|
+    end
+  end
+
+  describe "constants" do
+    test "NULL" do
+      assert SqlGenerator.to_sql(%Const{value: nil}) == "NULL"
+    end
+
+    test "true" do
+      assert SqlGenerator.to_sql(%Const{value: true}) == "true"
+    end
+
+    test "false" do
+      assert SqlGenerator.to_sql(%Const{value: false}) == "false"
+    end
+
+    test "string" do
+      assert SqlGenerator.to_sql(%Const{value: "hello"}) == "'hello'"
+    end
+
+    test "string with single quote escaping" do
+      assert SqlGenerator.to_sql(%Const{value: "it's"}) == "'it''s'"
+    end
+
+    test "integer" do
+      assert SqlGenerator.to_sql(%Const{value: 42}) == "42"
+    end
+
+    test "float" do
+      assert SqlGenerator.to_sql(%Const{value: 3.14}) == "3.14"
+    end
+
+    test "negative integer" do
+      assert SqlGenerator.to_sql(%Const{value: -1}) == "-1"
+    end
+  end
+
+  describe "array literals" do
+    test "simple array" do
+      ast = %Array{elements: [%Const{value: 1}, %Const{value: 2}, %Const{value: 3}]}
+      assert SqlGenerator.to_sql(ast) == "ARRAY[1, 2, 3]"
+    end
+
+    test "string array" do
+      ast = %Array{elements: [%Const{value: "a"}, %Const{value: "b"}]}
+      assert SqlGenerator.to_sql(ast) == "ARRAY['a', 'b']"
+    end
+
+    test "empty array" do
+      ast = %Array{elements: []}
+      assert SqlGenerator.to_sql(ast) == "ARRAY[]"
+    end
+  end
+
+  describe "row expressions" do
+    test "simple row" do
+      ast = %RowExpr{elements: [%Ref{path: ["a"]}, %Ref{path: ["b"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|ROW("a", "b")|
+    end
+
+    test "row in sublink membership check" do
+      row = %RowExpr{elements: [%Ref{path: ["a"]}, %Ref{path: ["b"]}]}
+
+      ast = %Func{
+        name: "sublink_membership_check",
+        args: [row, %Ref{path: ["$sublink", "0"]}]
+      }
+
+      assert SqlGenerator.to_sql(ast) == ~s|(ROW("a", "b") IN (SELECT $sublink.0))|
+    end
+  end
+
+  describe "date/time/interval constants" do
+    test "date" do
+      ast = %Const{value: ~D[2024-01-15]}
+      assert SqlGenerator.to_sql(ast) == "'2024-01-15'::date"
+    end
+
+    test "time" do
+      ast = %Const{value: ~T[13:45:00]}
+      assert SqlGenerator.to_sql(ast) == "'13:45:00'::time"
+    end
+
+    test "timestamp (NaiveDateTime)" do
+      ast = %Const{value: ~N[2024-01-15 13:45:00]}
+      assert SqlGenerator.to_sql(ast) == "'2024-01-15T13:45:00'::timestamp"
+    end
+
+    test "timestamptz (DateTime)" do
+      ast = %Const{value: DateTime.from_naive!(~N[2024-01-15 13:45:00], "Etc/UTC")}
+      assert SqlGenerator.to_sql(ast) == "'2024-01-15T13:45:00Z'::timestamptz"
+    end
+
+    test "interval" do
+      ast = %Const{value: PgInterop.Interval.parse!("1 year 2 months 3 days")}
+      result = SqlGenerator.to_sql(ast)
+      assert result =~ ~r/^'.*'::interval$/
+    end
+  end
+
+  describe "error handling" do
+    test "raises ArgumentError for unsupported AST node" do
+      assert_raise ArgumentError, ~r/unsupported AST node/, fn ->
+        SqlGenerator.to_sql(%{unexpected: :node})
+      end
+    end
+
+    test "raises ArgumentError for unknown function name" do
+      assert_raise ArgumentError, ~r/unsupported AST node/, fn ->
+        SqlGenerator.to_sql(%Func{name: "totally_unknown_func", args: [%Const{value: 1}]})
+      end
+    end
+  end
+
+  describe "complex nested expressions" do
+    test "WHERE clause with AND, OR, comparisons and NULL check" do
+      status_check = %Func{
+        name: "\"=\"",
+        args: [%Ref{path: ["status"]}, %Const{value: "active"}]
+      }
+
+      age_check = %Func{name: "\">=\"", args: [%Ref{path: ["age"]}, %Const{value: 18}]}
+      email_check = %Func{name: "is not null", args: [%Ref{path: ["email"]}]}
+
+      ast =
+        %Func{
+          name: "and",
+          args: [
+            %Func{name: "or", args: [status_check, age_check]},
+            email_check
+          ]
+        }
+
+      assert SqlGenerator.to_sql(ast) ==
+               ~s|((("status" = 'active') OR ("age" >= 18)) AND ("email" IS NOT NULL))|
+    end
+
+    test "NOT with nested OR" do
+      a = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
+      b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
+
+      ast = %Func{name: "not", args: [%Func{name: "or", args: [a, b]}]}
+
+      assert SqlGenerator.to_sql(ast) == ~s|(NOT (("x" = 1) OR ("y" = 2)))|
+    end
+
+    test "comparison with string concatenation" do
+      concat = %Func{name: "\"||\"", args: [%Ref{path: ["first"]}, %Ref{path: ["last"]}]}
+      ast = %Func{name: "\"=\"", args: [concat, %Const{value: "JohnDoe"}]}
+      assert SqlGenerator.to_sql(ast) == "((\"first\" || \"last\") = 'JohnDoe')"
+    end
+  end
+
+  describe "to_sql is the inverse of parse" do
+    use ExUnitProperties
+
+    alias Electric.Replication.Eval.Parser
+    alias Support.PgExpressionGenerator
+
+    property "to_sql output is parseable for any parseable WHERE clause" do
+      check all(
+              {sql, refs} <- PgExpressionGenerator.where_clause_generator(),
+              max_runs: 1_000,
+              max_run_time: 10_000
+            ) do
+        assert_to_sql_inverts_parse(sql, refs)
+      end
+    end
+
+    defp assert_to_sql_inverts_parse(sql, refs) do
+      # The parser may raise on some generated expressions (pre-existing parser
+      # limitations). We rescue those and skip — we only care that successfully
+      # parsed expressions produce valid SQL via to_sql.
+      parsed =
+        try do
+          Parser.parse_and_validate_expression(sql, refs: refs)
+        rescue
+          _ -> :skip
+        end
+
+      case parsed do
+        {:ok, %{eval: ast}} ->
+          regenerated = SqlGenerator.to_sql(ast)
+
+          reparsed =
+            try do
+              Parser.parse_and_validate_expression(regenerated, refs: refs)
+            rescue
+              e ->
+                flunk(
+                  "to_sql output raised #{inspect(e)} when re-parsing: #{regenerated} (from: #{sql})"
+                )
+            end
+
+          assert {:ok, _} = reparsed,
+                 "to_sql output is not valid SQL: #{regenerated} (from: #{sql})"
+
+        {:error, _reason} ->
+          :ok
+
+        :skip ->
+          :ok
+      end
+    end
+  end
+end

--- a/packages/sync-service/test/electric/replication/eval/sql_generator_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/sql_generator_test.exs
@@ -7,98 +7,98 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
   describe "comparison operators" do
     test "equals" do
       ast = %Func{name: "\"=\"", args: [%Ref{path: ["status"]}, %Const{value: "active"}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("status" = 'active')|
+      assert SqlGenerator.to_sql(ast) == ~s|"status" = 'active'|
     end
 
     test "not equals" do
       ast = %Func{name: "\"<>\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" <> 1)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" <> 1|
     end
 
     test "less than" do
       ast = %Func{name: "\"<\"", args: [%Ref{path: ["age"]}, %Const{value: 30}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("age" < 30)|
+      assert SqlGenerator.to_sql(ast) == ~s|"age" < 30|
     end
 
     test "greater than" do
       ast = %Func{name: "\">\"", args: [%Ref{path: ["score"]}, %Const{value: 100}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("score" > 100)|
+      assert SqlGenerator.to_sql(ast) == ~s|"score" > 100|
     end
 
     test "less than or equal" do
       ast = %Func{name: "\"<=\"", args: [%Ref{path: ["x"]}, %Const{value: 5}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" <= 5)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" <= 5|
     end
 
     test "greater than or equal" do
       ast = %Func{name: "\">=\"", args: [%Ref{path: ["y"]}, %Const{value: 10}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("y" >= 10)|
+      assert SqlGenerator.to_sql(ast) == ~s|"y" >= 10|
     end
   end
 
   describe "pattern matching" do
     test "LIKE" do
       ast = %Func{name: "\"~~\"", args: [%Ref{path: ["name"]}, %Const{value: "%foo%"}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("name" LIKE '%foo%')|
+      assert SqlGenerator.to_sql(ast) == ~s|"name" LIKE '%foo%'|
     end
 
     test "ILIKE" do
       ast = %Func{name: "\"~~*\"", args: [%Ref{path: ["name"]}, %Const{value: "%bar%"}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("name" ILIKE '%bar%')|
+      assert SqlGenerator.to_sql(ast) == ~s|"name" ILIKE '%bar%'|
     end
 
     test "NOT LIKE" do
       ast = %Func{name: "\"!~~\"", args: [%Ref{path: ["name"]}, %Const{value: "%baz%"}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("name" NOT LIKE '%baz%')|
+      assert SqlGenerator.to_sql(ast) == ~s|"name" NOT LIKE '%baz%'|
     end
 
     test "NOT ILIKE" do
       ast = %Func{name: "\"!~~*\"", args: [%Ref{path: ["name"]}, %Const{value: "%qux%"}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("name" NOT ILIKE '%qux%')|
+      assert SqlGenerator.to_sql(ast) == ~s|"name" NOT ILIKE '%qux%'|
     end
   end
 
   describe "nullability" do
     test "IS NULL" do
       ast = %Func{name: "is null", args: [%Ref{path: ["deleted_at"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("deleted_at" IS NULL)|
+      assert SqlGenerator.to_sql(ast) == ~s|"deleted_at" IS NULL|
     end
 
     test "IS NOT NULL" do
       ast = %Func{name: "is not null", args: [%Ref{path: ["email"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("email" IS NOT NULL)|
+      assert SqlGenerator.to_sql(ast) == ~s|"email" IS NOT NULL|
     end
   end
 
   describe "boolean tests" do
     test "IS TRUE" do
       ast = %Func{name: "IS_TRUE", args: [%Ref{path: ["active"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("active" IS TRUE)|
+      assert SqlGenerator.to_sql(ast) == ~s|"active" IS TRUE|
     end
 
     test "IS NOT TRUE" do
       ast = %Func{name: "IS_NOT_TRUE", args: [%Ref{path: ["active"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("active" IS NOT TRUE)|
+      assert SqlGenerator.to_sql(ast) == ~s|"active" IS NOT TRUE|
     end
 
     test "IS FALSE" do
       ast = %Func{name: "IS_FALSE", args: [%Ref{path: ["deleted"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("deleted" IS FALSE)|
+      assert SqlGenerator.to_sql(ast) == ~s|"deleted" IS FALSE|
     end
 
     test "IS NOT FALSE" do
       ast = %Func{name: "IS_NOT_FALSE", args: [%Ref{path: ["enabled"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("enabled" IS NOT FALSE)|
+      assert SqlGenerator.to_sql(ast) == ~s|"enabled" IS NOT FALSE|
     end
 
     test "IS UNKNOWN" do
       ast = %Func{name: "IS_UNKNOWN", args: [%Ref{path: ["flag"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("flag" IS UNKNOWN)|
+      assert SqlGenerator.to_sql(ast) == ~s|"flag" IS UNKNOWN|
     end
 
     test "IS NOT UNKNOWN" do
       ast = %Func{name: "IS_NOT_UNKNOWN", args: [%Ref{path: ["flag"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("flag" IS NOT UNKNOWN)|
+      assert SqlGenerator.to_sql(ast) == ~s|"flag" IS NOT UNKNOWN|
     end
   end
 
@@ -112,7 +112,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
         ]
       }
 
-      assert SqlGenerator.to_sql(ast) == ~s|("status" IN ('a', 'b', 'c'))|
+      assert SqlGenerator.to_sql(ast) == ~s|"status" IN ('a', 'b', 'c')|
     end
 
     test "IN with integer array" do
@@ -124,7 +124,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
         ]
       }
 
-      assert SqlGenerator.to_sql(ast) == ~s|("id" IN (1, 2, 3))|
+      assert SqlGenerator.to_sql(ast) == ~s|"id" IN (1, 2, 3)|
     end
   end
 
@@ -138,7 +138,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
         ]
       }
 
-      assert SqlGenerator.to_sql(ast) == ~s|("parent_id" IN (SELECT $sublink.0))|
+      assert SqlGenerator.to_sql(ast) == ~s|"parent_id" IN (SELECT $sublink.0)|
     end
   end
 
@@ -146,21 +146,21 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
     test "NOT" do
       inner = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
       ast = %Func{name: "not", args: [inner]}
-      assert SqlGenerator.to_sql(ast) == ~s|(NOT ("x" = 1))|
+      assert SqlGenerator.to_sql(ast) == ~s|NOT "x" = 1|
     end
 
     test "AND" do
       a = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
       b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
       ast = %Func{name: "and", args: [a, b]}
-      assert SqlGenerator.to_sql(ast) == ~s|(("x" = 1) AND ("y" = 2))|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" = 1 AND "y" = 2|
     end
 
     test "OR" do
       a = %Func{name: "\"=\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
       b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
       ast = %Func{name: "or", args: [a, b]}
-      assert SqlGenerator.to_sql(ast) == ~s|(("x" = 1) OR ("y" = 2))|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" = 1 OR "y" = 2|
     end
 
     test "nested AND within OR" do
@@ -168,7 +168,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
       b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
       c = %Func{name: "\"=\"", args: [%Ref{path: ["z"]}, %Const{value: 3}]}
       ast = %Func{name: "or", args: [%Func{name: "and", args: [a, b]}, c]}
-      assert SqlGenerator.to_sql(ast) == ~s|((("x" = 1) AND ("y" = 2)) OR ("z" = 3))|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" = 1 AND "y" = 2 OR "z" = 3|
     end
 
     test "nested OR within AND" do
@@ -176,7 +176,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
       b = %Func{name: "\"=\"", args: [%Ref{path: ["y"]}, %Const{value: 2}]}
       c = %Func{name: "\"=\"", args: [%Ref{path: ["z"]}, %Const{value: 3}]}
       ast = %Func{name: "and", args: [%Func{name: "or", args: [a, b]}, c]}
-      assert SqlGenerator.to_sql(ast) == ~s|((("x" = 1) OR ("y" = 2)) AND ("z" = 3))|
+      assert SqlGenerator.to_sql(ast) == ~s|("x" = 1 OR "y" = 2) AND "z" = 3|
     end
 
     test "deeply nested logical expression" do
@@ -195,7 +195,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
         }
 
       assert SqlGenerator.to_sql(ast) ==
-               ~s|((("a" = 1) AND ("b" > 2)) OR (("c" < 3) AND (NOT ("d" IS NULL))))|
+               ~s|"a" = 1 AND "b" > 2 OR "c" < 3 AND NOT "d" IS NULL|
     end
   end
 
@@ -205,7 +205,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
       right = %Const{value: 1}
       comparison = %Func{name: "\"<>\"", args: [left, right]}
       ast = %Func{name: "values_distinct?", args: [left, right, comparison]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" IS DISTINCT FROM 1)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" IS DISTINCT FROM 1|
     end
 
     test "IS NOT DISTINCT FROM" do
@@ -213,7 +213,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
       right = %Const{value: nil}
       comparison = %Func{name: "\"<>\"", args: [left, right]}
       ast = %Func{name: "values_not_distinct?", args: [left, right, comparison]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" IS NOT DISTINCT FROM NULL)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" IS NOT DISTINCT FROM NULL|
     end
   end
 
@@ -226,7 +226,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
       }
 
       ast = %Func{name: "any", args: [inner]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" = ANY("arr"))|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" = ANY("arr")|
     end
 
     test "ALL with less than" do
@@ -237,100 +237,100 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
       }
 
       ast = %Func{name: "all", args: [inner]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" < ALL("arr"))|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" < ALL("arr")|
     end
   end
 
   describe "arithmetic operators" do
     test "addition" do
       ast = %Func{name: "\"+\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" + 1)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" + 1|
     end
 
     test "subtraction" do
       ast = %Func{name: "\"-\"", args: [%Ref{path: ["x"]}, %Const{value: 1}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" - 1)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" - 1|
     end
 
     test "multiplication" do
       ast = %Func{name: "\"*\"", args: [%Ref{path: ["x"]}, %Const{value: 2}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" * 2)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" * 2|
     end
 
     test "division" do
       ast = %Func{name: "\"/\"", args: [%Ref{path: ["x"]}, %Const{value: 2}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" / 2)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" / 2|
     end
 
     test "exponentiation" do
       ast = %Func{name: "\"^\"", args: [%Ref{path: ["x"]}, %Const{value: 2}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" ^ 2)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" ^ 2|
     end
 
     test "unary plus" do
       ast = %Func{name: "\"+\"", args: [%Ref{path: ["x"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|(+ "x")|
+      assert SqlGenerator.to_sql(ast) == ~s|+ "x"|
     end
 
     test "unary minus" do
       ast = %Func{name: "\"-\"", args: [%Ref{path: ["x"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|(- "x")|
+      assert SqlGenerator.to_sql(ast) == ~s|- "x"|
     end
 
     test "square root" do
       ast = %Func{name: "\"|/\"", args: [%Ref{path: ["x"]}]}
-      assert SqlGenerator.to_sql(ast) == "(|/ \"x\")"
+      assert SqlGenerator.to_sql(ast) == ~s(\|/ "x")
     end
 
     test "absolute value" do
       ast = %Func{name: "\"@\"", args: [%Ref{path: ["x"]}]}
-      assert SqlGenerator.to_sql(ast) == "(@ \"x\")"
+      assert SqlGenerator.to_sql(ast) == ~s|@ "x"|
     end
   end
 
   describe "bitwise operators" do
     test "bitwise AND" do
       ast = %Func{name: "\"&\"", args: [%Ref{path: ["x"]}, %Const{value: 3}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" & 3)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" & 3|
     end
 
     test "bitwise OR" do
       ast = %Func{name: "\"|\"", args: [%Ref{path: ["x"]}, %Const{value: 3}]}
-      assert SqlGenerator.to_sql(ast) == "(\"x\" | 3)"
+      assert SqlGenerator.to_sql(ast) == ~s("x" | 3)
     end
 
     test "bitwise XOR" do
       ast = %Func{name: "\"#\"", args: [%Ref{path: ["x"]}, %Const{value: 3}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x" # 3)|
+      assert SqlGenerator.to_sql(ast) == ~s|"x" # 3|
     end
 
     test "bitwise NOT" do
       ast = %Func{name: "\"~\"", args: [%Ref{path: ["x"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|(~ "x")|
+      assert SqlGenerator.to_sql(ast) == ~s|~ "x"|
     end
   end
 
   describe "string concatenation" do
     test "||" do
       ast = %Func{name: "\"||\"", args: [%Ref{path: ["first"]}, %Ref{path: ["last"]}]}
-      assert SqlGenerator.to_sql(ast) == "(\"first\" || \"last\")"
+      assert SqlGenerator.to_sql(ast) == ~s("first" || "last")
     end
   end
 
   describe "array operators" do
     test "contains (@>)" do
       ast = %Func{name: "\"@>\"", args: [%Ref{path: ["tags"]}, %Ref{path: ["required"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("tags" @> "required")|
+      assert SqlGenerator.to_sql(ast) == ~s|"tags" @> "required"|
     end
 
     test "contained by (<@)" do
       ast = %Func{name: "\"<@\"", args: [%Ref{path: ["tags"]}, %Ref{path: ["allowed"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("tags" <@ "allowed")|
+      assert SqlGenerator.to_sql(ast) == ~s|"tags" <@ "allowed"|
     end
 
     test "overlap (&&)" do
       ast = %Func{name: "\"&&\"", args: [%Ref{path: ["a"]}, %Ref{path: ["b"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("a" && "b")|
+      assert SqlGenerator.to_sql(ast) == ~s|"a" && "b"|
     end
   end
 
@@ -354,12 +354,12 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
   describe "type casts" do
     test "cast with _to_ naming convention" do
       ast = %Func{name: "int4_to_bool", args: [%Ref{path: ["x"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("x")::bool|
+      assert SqlGenerator.to_sql(ast) == ~s|"x"::bool|
     end
 
     test "another cast" do
       ast = %Func{name: "text_to_int4", args: [%Ref{path: ["val"]}]}
-      assert SqlGenerator.to_sql(ast) == ~s|("val")::int4|
+      assert SqlGenerator.to_sql(ast) == ~s|"val"::int4|
     end
   end
 
@@ -439,7 +439,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
         args: [row, %Ref{path: ["$sublink", "0"]}]
       }
 
-      assert SqlGenerator.to_sql(ast) == ~s|(ROW("a", "b") IN (SELECT $sublink.0))|
+      assert SqlGenerator.to_sql(ast) == ~s|ROW("a", "b") IN (SELECT $sublink.0)|
     end
   end
 
@@ -505,7 +505,7 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
         }
 
       assert SqlGenerator.to_sql(ast) ==
-               ~s|((("status" = 'active') OR ("age" >= 18)) AND ("email" IS NOT NULL))|
+               ~s|("status" = 'active' OR "age" >= 18) AND "email" IS NOT NULL|
     end
 
     test "NOT with nested OR" do
@@ -514,13 +514,55 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
 
       ast = %Func{name: "not", args: [%Func{name: "or", args: [a, b]}]}
 
-      assert SqlGenerator.to_sql(ast) == ~s|(NOT (("x" = 1) OR ("y" = 2)))|
+      assert SqlGenerator.to_sql(ast) == ~s|NOT ("x" = 1 OR "y" = 2)|
     end
 
     test "comparison with string concatenation" do
       concat = %Func{name: "\"||\"", args: [%Ref{path: ["first"]}, %Ref{path: ["last"]}]}
       ast = %Func{name: "\"=\"", args: [concat, %Const{value: "JohnDoe"}]}
-      assert SqlGenerator.to_sql(ast) == "((\"first\" || \"last\") = 'JohnDoe')"
+      assert SqlGenerator.to_sql(ast) == ~s("first" || "last" = 'JohnDoe')
+    end
+
+    test "precedence: multiplication inside addition" do
+      # (a * b) + c — no parens needed since * binds tighter
+      mul = %Func{name: "\"*\"", args: [%Ref{path: ["a"]}, %Ref{path: ["b"]}]}
+      ast = %Func{name: "\"+\"", args: [mul, %Ref{path: ["c"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|"a" * "b" + "c"|
+    end
+
+    test "precedence: addition inside multiplication" do
+      # a * (b + c) — parens needed since + binds looser
+      add = %Func{name: "\"+\"", args: [%Ref{path: ["b"]}, %Ref{path: ["c"]}]}
+      ast = %Func{name: "\"*\"", args: [%Ref{path: ["a"]}, add]}
+      assert SqlGenerator.to_sql(ast) == ~s|"a" * ("b" + "c")|
+    end
+
+    test "precedence: left-associative subtraction" do
+      # a - (b - c) — parens needed on right child
+      inner = %Func{name: "\"-\"", args: [%Ref{path: ["b"]}, %Ref{path: ["c"]}]}
+      ast = %Func{name: "\"-\"", args: [%Ref{path: ["a"]}, inner]}
+      assert SqlGenerator.to_sql(ast) == ~s|"a" - ("b" - "c")|
+    end
+
+    test "precedence: left-associative subtraction, left child" do
+      # (a - b) - c — no parens needed (left-associative)
+      inner = %Func{name: "\"-\"", args: [%Ref{path: ["a"]}, %Ref{path: ["b"]}]}
+      ast = %Func{name: "\"-\"", args: [inner, %Ref{path: ["c"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|"a" - "b" - "c"|
+    end
+
+    test "precedence: right-associative exponentiation" do
+      # a ^ (b ^ c) — no parens needed (right-associative)
+      inner = %Func{name: "\"^\"", args: [%Ref{path: ["b"]}, %Ref{path: ["c"]}]}
+      ast = %Func{name: "\"^\"", args: [%Ref{path: ["a"]}, inner]}
+      assert SqlGenerator.to_sql(ast) == ~s|"a" ^ "b" ^ "c"|
+    end
+
+    test "precedence: right-associative exponentiation, left child" do
+      # (a ^ b) ^ c — parens needed on left child
+      inner = %Func{name: "\"^\"", args: [%Ref{path: ["a"]}, %Ref{path: ["b"]}]}
+      ast = %Func{name: "\"^\"", args: [inner, %Ref{path: ["c"]}]}
+      assert SqlGenerator.to_sql(ast) == ~s|("a" ^ "b") ^ "c"|
     end
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
@@ -111,7 +111,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([1])
 
-      assert_receive {:materializer_changes, _, %{move_in: [{1, "1"}]}}
+      assert_receive {:materializer_changes, _, %{move_in: [{1, "1"}]}, _}
     end
 
     @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
@@ -120,7 +120,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
@@ -140,7 +140,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([11])
 
-      assert_receive {:materializer_changes, _, %{move_out: [{10, "10"}], move_in: [{11, "11"}]}}
+      assert_receive {:materializer_changes, _, %{move_out: [{10, "10"}], move_in: [{11, "11"}]}, _}
     end
 
     @tag snapshot_data: [
@@ -153,7 +153,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
     test "on-load update of a value is seen & does not cause events", ctx do
       ctx = with_materializer(ctx)
       assert Materializer.get_link_values(ctx) == MapSet.new([11])
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
@@ -167,7 +167,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([])
 
-      assert_receive {:materializer_changes, _, %{move_out: [{10, "10"}]}}
+      assert_receive {:materializer_changes, _, %{move_out: [{10, "10"}]}, _}
     end
 
     @tag snapshot_data: [
@@ -179,7 +179,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([])
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
@@ -193,7 +193,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [
@@ -218,7 +218,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([20])
 
-      assert_received {:materializer_changes, _, %{move_out: [{10, "10"}]}}
+      assert_received {:materializer_changes, _, %{move_out: [{10, "10"}]}, _}
     end
 
     @tag snapshot_data: [
@@ -243,7 +243,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10, 20])
 
-      assert_received {:materializer_changes, _, %{move_in: [{20, "20"}]}}
+      assert_received {:materializer_changes, _, %{move_in: [{20, "20"}]}, _}
     end
 
     @tag snapshot_data: [
@@ -269,7 +269,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10, 20])
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [
@@ -286,7 +286,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [
@@ -303,7 +303,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [
@@ -361,7 +361,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([1, 2])
 
-      assert_receive {:materializer_changes, _, %{move_in: move_in}}
+      assert_receive {:materializer_changes, _, %{move_in: move_in}, _}
       assert Enum.sort(move_in) == [{1, "1"}, {2, "2"}]
 
       Materializer.new_changes(ctx, [
@@ -376,7 +376,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       assert Materializer.get_link_values(ctx) == MapSet.new([1, 3])
 
-      assert_receive {:materializer_changes, _, %{move_out: [{2, "2"}], move_in: [{3, "3"}]}}
+      assert_receive {:materializer_changes, _, %{move_out: [{2, "2"}], move_in: [{3, "3"}]}, _}
     end
   end
 
@@ -389,7 +389,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
         delete("1", "10")
       ])
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
@@ -401,7 +401,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
         update("1", "20", "10")
       ])
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     test "two move_ins and one move_out emits net one move_in", ctx do
@@ -469,12 +469,12 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       do: Materializer.new_changes(ctx, prep_changes(changes))
 
     defp assert_moved_in(values) do
-      assert_receive {:materializer_changes, _, events}
+      assert_receive {:materializer_changes, _, events, _tx_offset}
       assert Enum.sort(events.move_in) == Enum.map(values, &{String.to_integer(&1), &1})
     end
 
     defp assert_moved_out(values) do
-      assert_receive {:materializer_changes, _, events}
+      assert_receive {:materializer_changes, _, events, _tx_offset}
       assert Enum.sort(events.move_out) == Enum.map(values, &{String.to_integer(&1), &1})
     end
   end
@@ -504,7 +504,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
 
       # No move events should be emitted since the value didn't change
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: {
@@ -531,7 +531,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       )
 
       # No events from the tag-only update
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
 
       # Now send a move_out for the OLD tag - should find nothing since the row moved to new_tag
       Materializer.new_changes(ctx, [
@@ -542,7 +542,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
 
       # No move events since the row was already moved to new_tag
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: {
@@ -568,7 +568,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
         ]
       )
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
 
       # Now send a move_out for the NEW tag - should find and remove the row
       Materializer.new_changes(ctx, [
@@ -579,7 +579,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       assert Materializer.get_link_values(ctx) == MapSet.new([])
 
       # Should emit move_out event
-      assert_receive {:materializer_changes, _, %{move_out: [{10, "10"}]}}
+      assert_receive {:materializer_changes, _, %{move_out: [{10, "10"}]}, _}
     end
 
     @tag snapshot_data: {
@@ -608,7 +608,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
         ]
       )
 
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
 
       # move_out for tag_a should only affect row 2 (row 1 moved to tag_b)
       Materializer.new_changes(ctx, [
@@ -619,7 +619,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
 
       # Should emit move_out only for row 2's value
-      assert_receive {:materializer_changes, _, %{move_out: [{20, "20"}]}}
+      assert_receive {:materializer_changes, _, %{move_out: [{20, "20"}]}, _}
     end
   end
 
@@ -635,7 +635,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       ])
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10, 20, 30])
-      assert_receive {:materializer_changes, _, %{move_in: _}}
+      assert_receive {:materializer_changes, _, %{move_in: _}, _}
 
       # Send move_out event to remove rows with tag1
       Materializer.new_changes(ctx, [
@@ -643,7 +643,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       ])
 
       assert Materializer.get_link_values(ctx) == MapSet.new([20])
-      assert_receive {:materializer_changes, _, %{move_out: move_out}}
+      assert_receive {:materializer_changes, _, %{move_out: move_out}, _}
       assert Enum.sort(move_out) == [{10, "10"}, {30, "30"}]
     end
 
@@ -657,7 +657,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       ])
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10, 20, 30])
-      assert_receive {:materializer_changes, _, %{move_in: _}}
+      assert_receive {:materializer_changes, _, %{move_in: _}, _}
 
       # Remove rows with tag1 or tag3
       Materializer.new_changes(ctx, [
@@ -670,7 +670,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       ])
 
       assert Materializer.get_link_values(ctx) == MapSet.new([20])
-      assert_receive {:materializer_changes, _, %{move_out: move_out}}
+      assert_receive {:materializer_changes, _, %{move_out: move_out}, _}
       assert Enum.sort(move_out) == [{10, "10"}, {30, "30"}]
     end
 
@@ -682,7 +682,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       ])
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
-      assert_receive {:materializer_changes, _, %{move_in: [{10, "10"}]}}
+      assert_receive {:materializer_changes, _, %{move_in: [{10, "10"}]}, _}
 
       # Try to remove rows with non-existent tag
       Materializer.new_changes(ctx, [
@@ -690,7 +690,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       ])
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     test "runtime move_out event removes row but value remains if another row has same value",
@@ -703,7 +703,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       ])
 
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
-      assert_receive {:materializer_changes, _, %{move_in: [{10, "10"}]}}
+      assert_receive {:materializer_changes, _, %{move_in: [{10, "10"}]}, _}
 
       # Remove only tag1 row
       Materializer.new_changes(ctx, [
@@ -712,7 +712,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       # Value 10 should still be present because key "2" still has it
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: {
@@ -735,7 +735,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       # Only value 20 should remain after move_out
       assert Materializer.get_link_values(ctx) == MapSet.new([20])
-      assert_receive {:materializer_changes, _, %{move_out: [{10, "10"}]}}
+      assert_receive {:materializer_changes, _, %{move_out: [{10, "10"}]}, _}
     end
 
     @tag snapshot_data: {
@@ -758,7 +758,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       # Value 10 should still be present because key "2" still has it
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: {
@@ -780,7 +780,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       ])
 
       assert Materializer.get_link_values(ctx) == MapSet.new([30])
-      assert_receive {:materializer_changes, _, %{move_out: move_out}}
+      assert_receive {:materializer_changes, _, %{move_out: move_out}, _}
       assert Enum.sort(move_out) == [{10, "10"}, {20, "20"}]
     end
 
@@ -794,7 +794,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       # Only value 20 should remain after on-load processing of move_out
       assert Materializer.get_link_values(ctx) == MapSet.new([20])
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     @tag snapshot_data: [
@@ -807,7 +807,7 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
 
       # Value 10 should still be present because key "2" still has it
       assert Materializer.get_link_values(ctx) == MapSet.new([10])
-      refute_received {:materializer_changes, _, _}
+      refute_received {:materializer_changes, _, _, _}
     end
 
     test "runtime move-in tags are tracked correctly if read from a storage range",

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -1,6 +1,7 @@
 defmodule Electric.Shapes.QueryingTest do
   use Support.TransactionCase, async: true
 
+  alias Electric.Shapes.Consumer.DnfContext
   alias Electric.Shapes.Shape.SubqueryMoves
   alias Electric.Postgres.Inspector.DirectInspector
   alias Electric.Shapes.Shape
@@ -445,13 +446,15 @@ defmodule Electric.Shapes.QueryingTest do
         )
         |> fill_handles()
 
+      dnf_context = DnfContext.from_shape(shape)
       move_in_values = ["1", "2"]
 
       assert {where, params} =
                SubqueryMoves.move_in_where_clause(
                  shape,
                  hd(shape.shape_dependencies_handles),
-                 move_in_values
+                 move_in_values,
+                 dnf_context
                )
 
       tag1 =
@@ -493,13 +496,15 @@ defmodule Electric.Shapes.QueryingTest do
         )
         |> fill_handles()
 
+      dnf_context = DnfContext.from_shape(shape)
       move_in_values = [{"1", "1"}, {"2", "2"}]
 
       assert {where, params} =
                SubqueryMoves.move_in_where_clause(
                  shape,
                  hd(shape.shape_dependencies_handles),
-                 move_in_values
+                 move_in_values,
+                 dnf_context
                )
 
       tag1 =

--- a/packages/sync-service/test/electric/shapes/shape/subquery_moves_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape/subquery_moves_test.exs
@@ -2,6 +2,7 @@ defmodule Electric.Shapes.Shape.SubqueryMovesTest do
   use ExUnit.Case, async: true
 
   alias Electric.Replication.Eval
+  alias Electric.Shapes.Consumer.DnfContext
   alias Electric.Shapes.Shape
   alias Electric.Shapes.Shape.SubqueryMoves
 
@@ -35,16 +36,18 @@ defmodule Electric.Shapes.Shape.SubqueryMovesTest do
         )
         |> fill_handles()
 
+      dnf_context = DnfContext.from_shape(shape)
       move_ins = ["1", "2", "3"]
 
       {query, params} =
         SubqueryMoves.move_in_where_clause(
           shape,
           Enum.at(shape.shape_dependencies_handles, 0),
-          move_ins
+          move_ins,
+          dnf_context
         )
 
-      assert query == "parent_id = ANY ($1::text[]::int8[])"
+      assert query == ~s|"parent_id" = ANY ($1::text[]::int8[])|
       assert params == [["1", "2", "3"]]
     end
 
@@ -56,6 +59,7 @@ defmodule Electric.Shapes.Shape.SubqueryMovesTest do
         )
         |> fill_handles()
 
+      dnf_context = DnfContext.from_shape(shape)
       # Move-ins for composite keys come as tuples
       move_ins = [{"1", "a"}, {"2", "b"}]
 
@@ -63,11 +67,12 @@ defmodule Electric.Shapes.Shape.SubqueryMovesTest do
         SubqueryMoves.move_in_where_clause(
           shape,
           Enum.at(shape.shape_dependencies_handles, 0),
-          move_ins
+          move_ins,
+          dnf_context
         )
 
       assert query ==
-               "(col1, col2) IN (SELECT * FROM unnest($1::text[]::int4[], $2::text[]::text[]))"
+               ~s|ROW("col1", "col2") IN (SELECT * FROM unnest($1::text[]::int4[], $2::text[]::text[]))|
 
       assert params == [["1", "2"], ["a", "b"]]
     end
@@ -80,16 +85,18 @@ defmodule Electric.Shapes.Shape.SubqueryMovesTest do
         )
         |> fill_handles()
 
+      dnf_context = DnfContext.from_shape(shape)
       move_ins = ["1"]
 
       {query, params} =
         SubqueryMoves.move_in_where_clause(
           shape,
           Enum.at(shape.shape_dependencies_handles, 0),
-          move_ins
+          move_ins,
+          dnf_context
         )
 
-      assert query == "parent_id = ANY ($1::text[]::int8[])"
+      assert query == ~s|"parent_id" = ANY ($1::text[]::int8[])|
       assert params == [["1"]]
     end
   end

--- a/packages/sync-service/test/integration/oracle_property_test.exs
+++ b/packages/sync-service/test/integration/oracle_property_test.exs
@@ -1,0 +1,73 @@
+defmodule Electric.Integration.OraclePropertyTest do
+  @moduledoc """
+  Property-based oracle tests that run many parallel shapes with generated
+  where clauses and mutations.
+
+  Reproduce failures with: mix test --include oracle --seed <seed>
+
+  Configuration via environment variables:
+    - SHAPE_COUNT: Number of shapes to run in parallel (default: 100)
+    - TXN_COUNT: Number of transactions per test (default: 100)
+    - MUTATIONS_PER_TXN: Number of mutations per transaction (default: 5)
+    - PROP_RUNS: Number of property test iterations (default: 1)
+    - LONG_POLL_TIMEOUT: Server long-poll timeout in ms (default: 100)
+    - RETRY_WINDOW_MS: Max time to wait for changes after up_to_date (default: 5000)
+  """
+
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  import Support.ComponentSetup
+  import Support.DbSetup
+  import Support.IntegrationSetup
+  import Support.OracleHarness
+  import Support.OracleHarness.StandardSchema
+
+  @moduletag :oracle
+  @moduletag timeout: :infinity
+  @moduletag :tmp_dir
+
+  @default_long_poll_timeout 100
+  @default_shape_count 100
+  @default_txn_count 100
+  @default_mutations_per_txn 5
+
+  setup [:with_unique_db]
+  setup :with_complete_stack
+
+  # Use a short long_poll_timeout to speed up tests - shapes with no changes
+  # will get up_to_date faster instead of waiting 4 seconds for the default timeout.
+  # Scale server and client connection pools to the shape count so we don't
+  # hit Finch pool exhaustion with many concurrent long-polling shapes.
+  setup ctx do
+    long_poll_timeout = env_int("LONG_POLL_TIMEOUT") || @default_long_poll_timeout
+    shape_count = env_int("SHAPE_COUNT") || @default_shape_count
+
+    ctx =
+      with_electric_client(ctx,
+        router_opts: [long_poll_timeout: long_poll_timeout],
+        num_clients: shape_count
+      )
+
+    setup_standard_schema(ctx)
+    ctx
+  end
+
+  test "shapes with generated where clauses and mutations", ctx do
+    max_runs = env_int("PROP_RUNS") || 1
+    shape_count = env_int("SHAPE_COUNT") || @default_shape_count
+    txn_count = env_int("TXN_COUNT") || @default_txn_count
+    mutations_per_txn = env_int("MUTATIONS_PER_TXN") || @default_mutations_per_txn
+
+    check all iteration_seed <- StreamData.integer(0..10_000),
+              max_runs: max_runs do
+      IO.puts("[oracle] iteration_seed=#{iteration_seed}")
+
+      shapes = generate_diverse_shapes(shape_count, iteration_seed)
+      mutations = generate_mutations(txn_count * mutations_per_txn, iteration_seed + 1)
+      transactions = Enum.chunk_every(mutations, mutations_per_txn)
+
+      test_against_oracle(ctx, shapes, transactions)
+    end
+  end
+end

--- a/packages/sync-service/test/integration/oracle_property_test.exs
+++ b/packages/sync-service/test/integration/oracle_property_test.exs
@@ -46,7 +46,8 @@ defmodule Electric.Integration.OraclePropertyTest do
     ctx =
       with_electric_client(ctx,
         router_opts: [long_poll_timeout: long_poll_timeout],
-        num_clients: shape_count
+        num_clients: shape_count,
+        headers: [{"electric-protocol-version", "2"}]
       )
 
     setup_standard_schema(ctx)

--- a/packages/sync-service/test/integration/oracle_property_test.exs
+++ b/packages/sync-service/test/integration/oracle_property_test.exs
@@ -21,7 +21,8 @@ defmodule Electric.Integration.OraclePropertyTest do
   import Support.DbSetup
   import Support.IntegrationSetup
   import Support.OracleHarness
-  import Support.OracleHarness.StandardSchema
+  alias Support.OracleHarness.StandardSchema
+  alias Support.OracleHarness.WhereClauseGenerator
 
   @moduletag :oracle
   @moduletag timeout: :infinity
@@ -50,7 +51,7 @@ defmodule Electric.Integration.OraclePropertyTest do
         headers: [{"electric-protocol-version", "2"}]
       )
 
-    setup_standard_schema(ctx)
+    StandardSchema.setup_standard_schema(ctx)
     ctx
   end
 
@@ -60,14 +61,10 @@ defmodule Electric.Integration.OraclePropertyTest do
     txn_count = env_int("TXN_COUNT") || @default_txn_count
     mutations_per_txn = env_int("MUTATIONS_PER_TXN") || @default_mutations_per_txn
 
-    check all iteration_seed <- StreamData.integer(0..10_000),
+    check all shapes <- WhereClauseGenerator.shapes_gen(shape_count),
+              mutations <- StandardSchema.mutations_gen(txn_count * mutations_per_txn),
               max_runs: max_runs do
-      IO.puts("[oracle] iteration_seed=#{iteration_seed}")
-
-      shapes = generate_diverse_shapes(shape_count, iteration_seed)
-      mutations = generate_mutations(txn_count * mutations_per_txn, iteration_seed + 1)
       transactions = Enum.chunk_every(mutations, mutations_per_txn)
-
       test_against_oracle(ctx, shapes, transactions)
     end
   end

--- a/packages/sync-service/test/integration/oracle_property_test.exs
+++ b/packages/sync-service/test/integration/oracle_property_test.exs
@@ -7,7 +7,8 @@ defmodule Electric.Integration.OraclePropertyTest do
 
   Configuration via environment variables:
     - SHAPE_COUNT: Number of shapes to run in parallel (default: 100)
-    - TXN_COUNT: Number of transactions per test (default: 100)
+    - BATCH_COUNT: Number of batches per test (default: 10)
+    - TXNS_PER_BATCH: Number of transactions per batch (default: 10)
     - MUTATIONS_PER_TXN: Number of mutations per transaction (default: 5)
     - PROP_RUNS: Number of property test iterations (default: 1)
     - LONG_POLL_TIMEOUT: Server long-poll timeout in ms (default: 100)
@@ -30,7 +31,8 @@ defmodule Electric.Integration.OraclePropertyTest do
 
   @default_long_poll_timeout 100
   @default_shape_count 100
-  @default_txn_count 100
+  @default_batch_count 10
+  @default_txns_per_batch 10
   @default_mutations_per_txn 5
 
   setup [:with_unique_db]
@@ -58,14 +60,18 @@ defmodule Electric.Integration.OraclePropertyTest do
   test "shapes with generated where clauses and mutations", ctx do
     max_runs = env_int("PROP_RUNS") || 1
     shape_count = env_int("SHAPE_COUNT") || @default_shape_count
-    txn_count = env_int("TXN_COUNT") || @default_txn_count
+    batch_count = env_int("BATCH_COUNT") || @default_batch_count
+    txns_per_batch = env_int("TXNS_PER_BATCH") || @default_txns_per_batch
     mutations_per_txn = env_int("MUTATIONS_PER_TXN") || @default_mutations_per_txn
 
+    total_mutations = batch_count * txns_per_batch * mutations_per_txn
+
     check all shapes <- WhereClauseGenerator.shapes_gen(shape_count),
-              mutations <- StandardSchema.mutations_gen(txn_count * mutations_per_txn),
+              mutations <- StandardSchema.mutations_gen(total_mutations),
               max_runs: max_runs do
       transactions = Enum.chunk_every(mutations, mutations_per_txn)
-      test_against_oracle(ctx, shapes, transactions)
+      batches = Enum.chunk_every(transactions, txns_per_batch)
+      test_against_oracle(ctx, shapes, batches)
     end
   end
 end

--- a/packages/sync-service/test/integration/oracle_view_test.exs
+++ b/packages/sync-service/test/integration/oracle_view_test.exs
@@ -1,0 +1,304 @@
+defmodule Electric.Integration.OracleViewTest do
+  @moduledoc """
+  Hand-written oracle tests using the standard schema.
+
+  These tests verify specific scenarios with explicit shapes and mutations
+  to ensure coverage of important edge cases.
+
+  Run with: mix test --include oracle
+  """
+
+  use ExUnit.Case, async: false
+
+  import Support.ComponentSetup
+  import Support.DbSetup
+  import Support.IntegrationSetup
+  import Support.OracleHarness
+  import Support.OracleHarness.StandardSchema
+
+  @moduletag :oracle
+  @moduletag timeout: :infinity
+  @moduletag :tmp_dir
+
+  setup [:with_unique_db]
+  setup :with_complete_stack
+  setup :with_electric_client
+
+  setup ctx do
+    setup_standard_schema(ctx)
+    :ok
+  end
+
+  describe "simple where clauses" do
+    test "equality on parent_id", ctx do
+      shapes = [
+        %{
+          name: "l4_by_l3",
+          table: "level_4",
+          where: "level_3_id = 'l3-1'",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: true
+        }
+      ]
+
+      mutations = [
+        %{name: "update_value", sql: "UPDATE level_4 SET value = 'updated' WHERE id = 'l4-1'"},
+        %{name: "move_out", sql: "UPDATE level_4 SET level_3_id = 'l3-2' WHERE id = 'l4-1'"},
+        %{name: "move_in", sql: "UPDATE level_4 SET level_3_id = 'l3-1' WHERE id = 'l4-6'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+  end
+
+  describe "1-level subqueries" do
+    test "IN subquery on active parent", ctx do
+      shapes = [
+        %{
+          name: "active_l3_children",
+          table: "level_4",
+          where: "level_3_id IN (SELECT id FROM level_3 WHERE active = true)",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        %{name: "noop_toggle", sql: "UPDATE level_3 SET active = false WHERE id = 'l3-2'"},
+        %{name: "deactivate_l3", sql: "UPDATE level_3 SET active = false WHERE id = 'l3-1'"},
+        %{name: "activate_l3", sql: "UPDATE level_3 SET active = true WHERE id = 'l3-2'"},
+        %{name: "update_child", sql: "UPDATE level_4 SET value = 'changed' WHERE id = 'l4-2'"},
+        %{name: "move_child", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+
+    test "IN subquery on specific grandparent", ctx do
+      shapes = [
+        %{
+          name: "l2_1_descendants",
+          table: "level_4",
+          where: "level_3_id IN (SELECT id FROM level_3 WHERE level_2_id = 'l2-1')",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        %{name: "move_l3_out", sql: "UPDATE level_3 SET level_2_id = 'l2-2' WHERE id = 'l3-1'"},
+        %{name: "move_l3_in", sql: "UPDATE level_3 SET level_2_id = 'l2-1' WHERE id = 'l3-2'"},
+        %{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+  end
+
+  describe "2-level subqueries" do
+    test "nested active flags", ctx do
+      shapes = [
+        %{
+          name: "active_l2_l3_children",
+          table: "level_4",
+          where:
+            "level_3_id IN (SELECT id FROM level_3 WHERE active = true AND level_2_id IN (SELECT id FROM level_2 WHERE active = true))",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        %{name: "toggle_l2", sql: "UPDATE level_2 SET active = NOT active WHERE id = 'l2-1'"},
+        %{name: "toggle_l3", sql: "UPDATE level_3 SET active = NOT active WHERE id = 'l3-1'"},
+        %{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-3' WHERE id = 'l3-1'"},
+        %{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-4' WHERE id = 'l4-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+
+    test "through specific level_1", ctx do
+      shapes = [
+        %{
+          name: "l1_1_descendants",
+          table: "level_4",
+          where:
+            "level_3_id IN (SELECT id FROM level_3 WHERE level_2_id IN (SELECT id FROM level_2 WHERE level_1_id = 'l1-1'))",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        %{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-2' WHERE id = 'l2-1'"},
+        %{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-3' WHERE id = 'l3-1'"},
+        %{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+  end
+
+  describe "3-level subqueries" do
+    test "through active level_1", ctx do
+      shapes = [
+        %{
+          name: "active_l1_descendants",
+          table: "level_4",
+          where:
+            "level_3_id IN (SELECT id FROM level_3 WHERE level_2_id IN (SELECT id FROM level_2 WHERE level_1_id IN (SELECT id FROM level_1 WHERE active = true)))",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        %{name: "toggle_l1_1", sql: "UPDATE level_1 SET active = NOT active WHERE id = 'l1-1'"},
+        %{name: "toggle_l1_2", sql: "UPDATE level_1 SET active = NOT active WHERE id = 'l1-2'"},
+        %{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-3' WHERE id = 'l2-1'"},
+        %{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-4' WHERE id = 'l3-1'"},
+        %{name: "update_l4", sql: "UPDATE level_4 SET value = 'new' WHERE id = 'l4-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+  end
+
+  describe "tag-based subqueries" do
+    test "1-level tag filter", ctx do
+      shapes = [
+        %{
+          name: "alpha_l3_children",
+          table: "level_4",
+          where:
+            "level_3_id IN (SELECT id FROM level_3 WHERE id IN (SELECT level_3_id FROM level_3_tags WHERE tag = 'alpha'))",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        %{
+          name: "add_alpha_tag",
+          sql:
+            "INSERT INTO level_3_tags (level_3_id, tag) VALUES ('l3-2', 'alpha') ON CONFLICT DO NOTHING"
+        },
+        %{
+          name: "remove_alpha_tag",
+          sql: "DELETE FROM level_3_tags WHERE level_3_id = 'l3-1' AND tag = 'alpha'"
+        },
+        %{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+
+    test "2-level tag filter through level_2", ctx do
+      shapes = [
+        %{
+          name: "beta_l2_descendants",
+          table: "level_4",
+          where:
+            "level_3_id IN (SELECT id FROM level_3 WHERE level_2_id IN (SELECT id FROM level_2 WHERE id IN (SELECT level_2_id FROM level_2_tags WHERE tag = 'beta')))",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        %{
+          name: "add_beta_tag",
+          sql:
+            "INSERT INTO level_2_tags (level_2_id, tag) VALUES ('l2-3', 'beta') ON CONFLICT DO NOTHING"
+        },
+        %{
+          name: "remove_beta_tag",
+          sql: "DELETE FROM level_2_tags WHERE level_2_id = 'l2-2' AND tag = 'beta'"
+        },
+        %{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-4' WHERE id = 'l3-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+
+    test "3-level tag filter through level_1", ctx do
+      shapes = [
+        %{
+          name: "gamma_l1_descendants",
+          table: "level_4",
+          where:
+            "level_3_id IN (SELECT id FROM level_3 WHERE level_2_id IN (SELECT id FROM level_2 WHERE level_1_id IN (SELECT id FROM level_1 WHERE id IN (SELECT level_1_id FROM level_1_tags WHERE tag = 'gamma'))))",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        %{
+          name: "add_gamma_tag",
+          sql:
+            "INSERT INTO level_1_tags (level_1_id, tag) VALUES ('l1-2', 'gamma') ON CONFLICT DO NOTHING"
+        },
+        %{
+          name: "remove_gamma_tag",
+          sql: "DELETE FROM level_1_tags WHERE level_1_id = 'l1-3' AND tag = 'gamma'"
+        },
+        %{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-4' WHERE id = 'l2-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+  end
+
+  describe "multiple parallel shapes" do
+    test "same mutation affects different shapes differently", ctx do
+      shapes = [
+        %{
+          name: "l3_1_children",
+          table: "level_4",
+          where: "level_3_id = 'l3-1'",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: true
+        },
+        %{
+          name: "l3_2_children",
+          table: "level_4",
+          where: "level_3_id = 'l3-2'",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: true
+        },
+        %{
+          name: "active_l3_children",
+          table: "level_4",
+          where: "level_3_id IN (SELECT id FROM level_3 WHERE active = true)",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        # This moves l4-1 from l3-1 to l3-2, affecting first two shapes
+        %{name: "move_l4_1", sql: "UPDATE level_4 SET level_3_id = 'l3-2' WHERE id = 'l4-1'"},
+        # This affects the subquery shape by changing which l3s are active
+        %{name: "toggle_l3_1", sql: "UPDATE level_3 SET active = NOT active WHERE id = 'l3-1'"},
+        # Move it back
+        %{name: "move_l4_1_back", sql: "UPDATE level_4 SET level_3_id = 'l3-1' WHERE id = 'l4-1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+  end
+end

--- a/packages/sync-service/test/integration/oracle_view_test.exs
+++ b/packages/sync-service/test/integration/oracle_view_test.exs
@@ -276,10 +276,11 @@ defmodule Electric.Integration.OracleViewTest do
       #   1. l3-1.active → false  (triggers move-in for disjunct 0)
       #   2. l4-1.value → 'v100'  (now matches disjunct 1: contains '1')
       #
-      # Bug: move-in query has AND NOT (value LIKE '%1%') exclusion for disjunct 1,
-      #      which filters out l4-1. Meanwhile WAL change for l4-1 is skipped by
-      #      change_will_be_covered_by_move_in? (pending move-in for l3-1 values).
-      #      Both sides defer to the other — l4-1 is lost.
+      # Bug (fixed): move-in query has AND NOT (value LIKE '%1%') exclusion for
+      #      disjunct 1, which filters out l4-1. Previously the WAL change for l4-1
+      #      was skipped by change_will_be_covered_by_move_in? — both sides deferred
+      #      to the other and l4-1 was lost. Fix: store excluded disjuncts per
+      #      move-in and check them in change_will_be_covered_by_move_in?.
       shapes = [
         %{
           name: "subquery_or_value",

--- a/packages/sync-service/test/integration/oracle_view_test.exs
+++ b/packages/sync-service/test/integration/oracle_view_test.exs
@@ -263,6 +263,46 @@ defmodule Electric.Integration.OracleViewTest do
     end
   end
 
+  describe "exclusion clause vs change_will_be_covered_by_move_in" do
+    test "row value change + subquery dep change in same txn with OR clause", ctx do
+      # WHERE has two disjuncts:
+      #   disjunct 0: level_3_id IN (SELECT id FROM level_3 WHERE active = false)  [subquery]
+      #   disjunct 1: value LIKE '%1%'  [direct column condition]
+      #
+      # Initial state: l3-1 has active=true, l4-1 has level_3_id=l3-1, value='v0'
+      #   → l4-1 matches neither disjunct, not in shape
+      #
+      # Single transaction changes both:
+      #   1. l3-1.active → false  (triggers move-in for disjunct 0)
+      #   2. l4-1.value → 'v100'  (now matches disjunct 1: contains '1')
+      #
+      # Bug: move-in query has AND NOT (value LIKE '%1%') exclusion for disjunct 1,
+      #      which filters out l4-1. Meanwhile WAL change for l4-1 is skipped by
+      #      change_will_be_covered_by_move_in? (pending move-in for l3-1 values).
+      #      Both sides defer to the other — l4-1 is lost.
+      shapes = [
+        %{
+          name: "subquery_or_value",
+          table: "level_4",
+          where:
+            "(level_3_id IN (SELECT id FROM level_3 WHERE active = false)) OR (value LIKE '%1%')",
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      ]
+
+      mutations = [
+        [
+          %{name: "deactivate_l3_1", sql: "UPDATE level_3 SET active = false WHERE id = 'l3-1'"},
+          %{name: "update_l4_1_value", sql: "UPDATE level_4 SET value = 'v100' WHERE id = 'l4-1'"}
+        ]
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+    end
+  end
+
   describe "multiple parallel shapes" do
     test "same mutation affects different shapes differently", ctx do
       shapes = [

--- a/packages/sync-service/test/integration/oracle_view_test.exs
+++ b/packages/sync-service/test/integration/oracle_view_test.exs
@@ -45,13 +45,15 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{name: "update_value", sql: "UPDATE level_4 SET value = 'updated' WHERE id = 'l4-1'"},
-        %{name: "move_out", sql: "UPDATE level_4 SET level_3_id = 'l3-2' WHERE id = 'l4-1'"},
-        %{name: "move_in", sql: "UPDATE level_4 SET level_3_id = 'l3-1' WHERE id = 'l4-6'"}
+      batches = [
+        [
+          [%{name: "update_value", sql: "UPDATE level_4 SET value = 'updated' WHERE id = 'l4-1'"}],
+          [%{name: "move_out", sql: "UPDATE level_4 SET level_3_id = 'l3-2' WHERE id = 'l4-1'"}],
+          [%{name: "move_in", sql: "UPDATE level_4 SET level_3_id = 'l3-1' WHERE id = 'l4-6'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
   end
 
@@ -68,15 +70,17 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{name: "noop_toggle", sql: "UPDATE level_3 SET active = false WHERE id = 'l3-2'"},
-        %{name: "deactivate_l3", sql: "UPDATE level_3 SET active = false WHERE id = 'l3-1'"},
-        %{name: "activate_l3", sql: "UPDATE level_3 SET active = true WHERE id = 'l3-2'"},
-        %{name: "update_child", sql: "UPDATE level_4 SET value = 'changed' WHERE id = 'l4-2'"},
-        %{name: "move_child", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}
+      batches = [
+        [
+          [%{name: "noop_toggle", sql: "UPDATE level_3 SET active = false WHERE id = 'l3-2'"}],
+          [%{name: "deactivate_l3", sql: "UPDATE level_3 SET active = false WHERE id = 'l3-1'"}],
+          [%{name: "activate_l3", sql: "UPDATE level_3 SET active = true WHERE id = 'l3-2'"}],
+          [%{name: "update_child", sql: "UPDATE level_4 SET value = 'changed' WHERE id = 'l4-2'"}],
+          [%{name: "move_child", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
 
     test "IN subquery on specific grandparent", ctx do
@@ -91,13 +95,15 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{name: "move_l3_out", sql: "UPDATE level_3 SET level_2_id = 'l2-2' WHERE id = 'l3-1'"},
-        %{name: "move_l3_in", sql: "UPDATE level_3 SET level_2_id = 'l2-1' WHERE id = 'l3-2'"},
-        %{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}
+      batches = [
+        [
+          [%{name: "move_l3_out", sql: "UPDATE level_3 SET level_2_id = 'l2-2' WHERE id = 'l3-1'"}],
+          [%{name: "move_l3_in", sql: "UPDATE level_3 SET level_2_id = 'l2-1' WHERE id = 'l3-2'"}],
+          [%{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
   end
 
@@ -115,14 +121,16 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{name: "toggle_l2", sql: "UPDATE level_2 SET active = NOT active WHERE id = 'l2-1'"},
-        %{name: "toggle_l3", sql: "UPDATE level_3 SET active = NOT active WHERE id = 'l3-1'"},
-        %{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-3' WHERE id = 'l3-1'"},
-        %{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-4' WHERE id = 'l4-1'"}
+      batches = [
+        [
+          [%{name: "toggle_l2", sql: "UPDATE level_2 SET active = NOT active WHERE id = 'l2-1'"}],
+          [%{name: "toggle_l3", sql: "UPDATE level_3 SET active = NOT active WHERE id = 'l3-1'"}],
+          [%{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-3' WHERE id = 'l3-1'"}],
+          [%{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-4' WHERE id = 'l4-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
 
     test "through specific level_1", ctx do
@@ -138,13 +146,15 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-2' WHERE id = 'l2-1'"},
-        %{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-3' WHERE id = 'l3-1'"},
-        %{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}
+      batches = [
+        [
+          [%{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-2' WHERE id = 'l2-1'"}],
+          [%{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-3' WHERE id = 'l3-1'"}],
+          [%{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
   end
 
@@ -162,15 +172,17 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{name: "toggle_l1_1", sql: "UPDATE level_1 SET active = NOT active WHERE id = 'l1-1'"},
-        %{name: "toggle_l1_2", sql: "UPDATE level_1 SET active = NOT active WHERE id = 'l1-2'"},
-        %{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-3' WHERE id = 'l2-1'"},
-        %{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-4' WHERE id = 'l3-1'"},
-        %{name: "update_l4", sql: "UPDATE level_4 SET value = 'new' WHERE id = 'l4-1'"}
+      batches = [
+        [
+          [%{name: "toggle_l1_1", sql: "UPDATE level_1 SET active = NOT active WHERE id = 'l1-1'"}],
+          [%{name: "toggle_l1_2", sql: "UPDATE level_1 SET active = NOT active WHERE id = 'l1-2'"}],
+          [%{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-3' WHERE id = 'l2-1'"}],
+          [%{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-4' WHERE id = 'l3-1'"}],
+          [%{name: "update_l4", sql: "UPDATE level_4 SET value = 'new' WHERE id = 'l4-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
   end
 
@@ -188,20 +200,26 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{
-          name: "add_alpha_tag",
-          sql:
-            "INSERT INTO level_3_tags (level_3_id, tag) VALUES ('l3-2', 'alpha') ON CONFLICT DO NOTHING"
-        },
-        %{
-          name: "remove_alpha_tag",
-          sql: "DELETE FROM level_3_tags WHERE level_3_id = 'l3-1' AND tag = 'alpha'"
-        },
-        %{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}
+      batches = [
+        [
+          [
+            %{
+              name: "add_alpha_tag",
+              sql:
+                "INSERT INTO level_3_tags (level_3_id, tag) VALUES ('l3-2', 'alpha') ON CONFLICT DO NOTHING"
+            }
+          ],
+          [
+            %{
+              name: "remove_alpha_tag",
+              sql: "DELETE FROM level_3_tags WHERE level_3_id = 'l3-1' AND tag = 'alpha'"
+            }
+          ],
+          [%{name: "move_l4", sql: "UPDATE level_4 SET level_3_id = 'l3-3' WHERE id = 'l4-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
 
     test "2-level tag filter through level_2", ctx do
@@ -217,20 +235,26 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{
-          name: "add_beta_tag",
-          sql:
-            "INSERT INTO level_2_tags (level_2_id, tag) VALUES ('l2-3', 'beta') ON CONFLICT DO NOTHING"
-        },
-        %{
-          name: "remove_beta_tag",
-          sql: "DELETE FROM level_2_tags WHERE level_2_id = 'l2-2' AND tag = 'beta'"
-        },
-        %{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-4' WHERE id = 'l3-1'"}
+      batches = [
+        [
+          [
+            %{
+              name: "add_beta_tag",
+              sql:
+                "INSERT INTO level_2_tags (level_2_id, tag) VALUES ('l2-3', 'beta') ON CONFLICT DO NOTHING"
+            }
+          ],
+          [
+            %{
+              name: "remove_beta_tag",
+              sql: "DELETE FROM level_2_tags WHERE level_2_id = 'l2-2' AND tag = 'beta'"
+            }
+          ],
+          [%{name: "move_l3", sql: "UPDATE level_3 SET level_2_id = 'l2-4' WHERE id = 'l3-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
 
     test "3-level tag filter through level_1", ctx do
@@ -246,20 +270,26 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        %{
-          name: "add_gamma_tag",
-          sql:
-            "INSERT INTO level_1_tags (level_1_id, tag) VALUES ('l1-2', 'gamma') ON CONFLICT DO NOTHING"
-        },
-        %{
-          name: "remove_gamma_tag",
-          sql: "DELETE FROM level_1_tags WHERE level_1_id = 'l1-3' AND tag = 'gamma'"
-        },
-        %{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-4' WHERE id = 'l2-1'"}
+      batches = [
+        [
+          [
+            %{
+              name: "add_gamma_tag",
+              sql:
+                "INSERT INTO level_1_tags (level_1_id, tag) VALUES ('l1-2', 'gamma') ON CONFLICT DO NOTHING"
+            }
+          ],
+          [
+            %{
+              name: "remove_gamma_tag",
+              sql: "DELETE FROM level_1_tags WHERE level_1_id = 'l1-3' AND tag = 'gamma'"
+            }
+          ],
+          [%{name: "move_l2", sql: "UPDATE level_2 SET level_1_id = 'l1-4' WHERE id = 'l2-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
   end
 
@@ -333,16 +363,18 @@ defmodule Electric.Integration.OracleViewTest do
         }
       ]
 
-      mutations = [
-        # This moves l4-1 from l3-1 to l3-2, affecting first two shapes
-        %{name: "move_l4_1", sql: "UPDATE level_4 SET level_3_id = 'l3-2' WHERE id = 'l4-1'"},
-        # This affects the subquery shape by changing which l3s are active
-        %{name: "toggle_l3_1", sql: "UPDATE level_3 SET active = NOT active WHERE id = 'l3-1'"},
-        # Move it back
-        %{name: "move_l4_1_back", sql: "UPDATE level_4 SET level_3_id = 'l3-1' WHERE id = 'l4-1'"}
+      batches = [
+        [
+          # This moves l4-1 from l3-1 to l3-2, affecting first two shapes
+          [%{name: "move_l4_1", sql: "UPDATE level_4 SET level_3_id = 'l3-2' WHERE id = 'l4-1'"}],
+          # This affects the subquery shape by changing which l3s are active
+          [%{name: "toggle_l3_1", sql: "UPDATE level_3 SET active = NOT active WHERE id = 'l3-1'"}],
+          # Move it back
+          [%{name: "move_l4_1_back", sql: "UPDATE level_4 SET level_3_id = 'l3-1' WHERE id = 'l4-1'"}]
+        ]
       ]
 
-      test_against_oracle(ctx, shapes, mutations)
+      test_against_oracle(ctx, shapes, batches)
     end
   end
 end

--- a/packages/sync-service/test/integration/oracle_view_test.exs
+++ b/packages/sync-service/test/integration/oracle_view_test.exs
@@ -22,7 +22,10 @@ defmodule Electric.Integration.OracleViewTest do
 
   setup [:with_unique_db]
   setup :with_complete_stack
-  setup :with_electric_client
+
+  setup ctx do
+    with_electric_client(ctx, headers: [{"electric-protocol-version", "2"}])
+  end
 
   setup ctx do
     setup_standard_schema(ctx)

--- a/packages/sync-service/test/support/integration_setup.ex
+++ b/packages/sync-service/test/support/integration_setup.ex
@@ -32,13 +32,19 @@ defmodule Support.IntegrationSetup do
     {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
     base_url = "http://localhost:#{port}"
 
+    headers = Keyword.get(opts, :headers, [])
+
     client_opts =
       if num_clients > 1 do
         finch_name = :"Electric.Client.Finch.Test.#{System.unique_integer([:positive])}"
         {:ok, _} = Finch.start_link(name: finch_name, pools: %{default: [size: num_clients]})
-        [fetch: {Electric.Client.Fetch.HTTP, [request: [finch: finch_name]]}]
+        [fetch: {Electric.Client.Fetch.HTTP, [request: [finch: finch_name], headers: headers]}]
       else
-        []
+        if headers != [] do
+          [fetch: {Electric.Client.Fetch.HTTP, [headers: headers]}]
+        else
+          []
+        end
       end
 
     {:ok, client} = Electric.Client.new([base_url: base_url] ++ client_opts)

--- a/packages/sync-service/test/support/oracle_harness.ex
+++ b/packages/sync-service/test/support/oracle_harness.ex
@@ -1,0 +1,222 @@
+defmodule Support.OracleHarness do
+  @moduledoc """
+  Generic harness for comparing Electric shape streams against Postgres query results.
+
+  This module provides the framework for running parallel shape verification tests.
+  It is schema-agnostic - use it with any schema by providing explicit shapes and mutations.
+
+  For the standard 4-level hierarchy test schema, see `Support.OracleHarness.StandardSchema`.
+
+  ## Usage
+
+      shapes = [
+        %{
+          name: "my_shape",
+          table: "my_table",
+          where: "some_column = 'value'",
+          columns: ["id", "some_column"],
+          pk: ["id"],
+          optimized: true
+        }
+      ]
+
+      mutations = [
+        %{name: "update_value", sql: "UPDATE my_table SET some_column = 'new' WHERE id = '1'"}
+      ]
+
+      test_against_oracle(ctx, shapes, mutations)
+  """
+
+  alias Support.OracleHarness.ShapeChecker
+
+  @default_timeout_ms 20_000
+  @default_oracle_pool_size 50
+
+  # ----------------------------------------------------------------------------
+  # Main Test Runner
+  # ----------------------------------------------------------------------------
+
+  def default_opts_from_env do
+    %{
+      oracle_pool_size: env_int("ORACLE_POOL_SIZE") || @default_oracle_pool_size
+    }
+  end
+
+  @doc """
+  Runs with explicit shapes and transactions, comparing Electric's output against Postgres.
+
+  Transactions can be:
+  - A list of transactions, where each transaction is a list of mutations (executed atomically)
+  - A flat list of mutations (each mutation becomes its own transaction for backwards compatibility)
+
+  ## Options
+
+    - :oracle_pool_size - number of parallel oracle connections (default: 50, env: ORACLE_POOL_SIZE)
+    - :timeout_ms - timeout for waiting on shapes (default: 20_000)
+  """
+  def test_against_oracle(ctx, shapes, transactions, opts \\ %{}) do
+    opts = Map.merge(default_opts_from_env(), opts)
+    timeout_ms = opts[:timeout_ms] || @default_timeout_ms
+
+    # Normalize transactions: wrap flat mutation lists into single-mutation transactions
+    transactions = normalize_transactions(transactions)
+
+    log_test_config(shapes, transactions)
+
+    # Start oracle pool for parallel Postgres queries
+    {:ok, oracle_pool} = start_oracle_pool(ctx, opts)
+
+    # Start checker GenServers
+    pids = start_checkers(ctx, shapes, oracle_pool, timeout_ms)
+
+    # Check initial state (all in parallel)
+    log("Checking initial snapshot for #{length(pids)} shapes")
+
+    pids
+    |> Task.async_stream(&ShapeChecker.check_initial_state/1, timeout: :infinity)
+    |> Stream.run()
+
+    # Run each transaction
+    log("Running #{length(transactions)} transactions")
+
+    transactions
+    |> Enum.with_index(1)
+    |> Enum.each(fn {mutations, txn_idx} ->
+      run_transaction(ctx, pids, mutations, txn_idx)
+    end)
+
+    # Cleanup
+    Enum.each(pids, &GenServer.stop/1)
+    GenServer.stop(oracle_pool)
+    :ok
+  end
+
+  # ----------------------------------------------------------------------------
+  # Internal Implementation
+  # ----------------------------------------------------------------------------
+
+  defp start_oracle_pool(ctx, opts) do
+    pool_size = opts[:oracle_pool_size] || @default_oracle_pool_size
+
+    conn_opts =
+      ctx.db_config
+      |> Electric.Utils.deobfuscate_password()
+      |> Keyword.put(:pool_size, pool_size)
+      |> Keyword.put(:types, PgInterop.Postgrex.Types)
+      |> Keyword.put(:backoff_type, :stop)
+      |> Keyword.put(:max_restarts, 0)
+
+    Postgrex.start_link(conn_opts)
+  end
+
+  defp start_checkers(ctx, shapes, oracle_pool, timeout_ms) do
+    Enum.map(shapes, fn shape ->
+      {:ok, pid} = ShapeChecker.start_link(ctx, shape, oracle_pool, timeout_ms: timeout_ms)
+      pid
+    end)
+  end
+
+  defp run_transaction(ctx, pids, mutations, txn_idx) do
+    txn_name = "txn_#{txn_idx}"
+    cycle_start = System.monotonic_time(:millisecond)
+
+    # Apply all mutations in a single transaction
+    sql_statements = Enum.map(mutations, & &1.sql)
+    apply_sql_transaction(ctx, sql_statements)
+
+    apply_end = System.monotonic_time(:millisecond)
+
+    # Check all shapes (polls until up_to_date, then verifies against oracle)
+    pids
+    |> Task.async_stream(&ShapeChecker.check_transaction(&1, txn_name), timeout: :infinity)
+    |> Stream.run()
+
+    check_end = System.monotonic_time(:millisecond)
+
+    log(
+      "#{txn_name} (#{length(mutations)} mutations): " <>
+        "total=#{check_end - cycle_start}ms " <>
+        "(apply=#{apply_end - cycle_start}ms, check=#{check_end - apply_end}ms)"
+    )
+  end
+
+  defp log_test_config(shapes, transactions) do
+    log("Starting #{length(shapes)} shapes")
+
+    IO.puts("\n=== SHAPES ===")
+
+    Enum.each(shapes, fn shape ->
+      IO.puts("  #{shape.name}: #{shape.where}")
+    end)
+
+    total_mutations = transactions |> Enum.map(&length/1) |> Enum.sum()
+
+    IO.puts("\n=== TRANSACTIONS (#{length(transactions)} txns, #{total_mutations} mutations) ===")
+
+    transactions
+    |> Enum.with_index(1)
+    |> Enum.each(fn {mutations, txn_idx} ->
+      IO.puts("  txn_#{txn_idx} (#{length(mutations)} mutations):")
+
+      Enum.each(mutations, fn mutation ->
+        IO.puts("    #{mutation.name}: #{mutation.sql}")
+      end)
+    end)
+
+    IO.puts("")
+  end
+
+  # ----------------------------------------------------------------------------
+  # Helpers
+  # ----------------------------------------------------------------------------
+
+  @doc false
+  def apply_sql(_ctx, nil), do: :ok
+  def apply_sql(ctx, sql) when is_list(sql), do: Enum.each(sql, &apply_sql(ctx, &1))
+
+  def apply_sql(ctx, sql) when is_binary(sql) do
+    Postgrex.query!(ctx.db_conn, sql, [])
+  end
+
+  @doc """
+  Executes multiple SQL statements atomically within a single Postgres transaction.
+  Uses Postgrex.transaction/3 which handles rollback on error automatically.
+  """
+  def apply_sql_transaction(_ctx, []), do: :ok
+
+  def apply_sql_transaction(ctx, sql_statements) when is_list(sql_statements) do
+    Postgrex.transaction(ctx.db_conn, fn conn ->
+      Enum.each(sql_statements, fn sql ->
+        Postgrex.query!(conn, sql, [])
+      end)
+    end)
+  end
+
+  @doc """
+  Parses an environment variable as an integer.
+  Returns nil if not set.
+  """
+  def env_int(name) do
+    case System.get_env(name) do
+      nil -> nil
+      value -> String.to_integer(value)
+    end
+  end
+
+  defp log(message) do
+    IO.puts("[oracle] #{message}")
+  end
+
+  # Normalize transactions: if it's a flat list of mutations, wrap each in its own transaction
+  defp normalize_transactions([]), do: []
+
+  defp normalize_transactions([first | _] = transactions) when is_list(first) do
+    # Already a list of transactions
+    transactions
+  end
+
+  defp normalize_transactions([first | _] = mutations) when is_map(first) do
+    # Flat list of mutations - wrap each in its own transaction
+    Enum.map(mutations, &[&1])
+  end
+end

--- a/packages/sync-service/test/support/oracle_harness.ex
+++ b/packages/sync-service/test/support/oracle_harness.ex
@@ -43,25 +43,23 @@ defmodule Support.OracleHarness do
   end
 
   @doc """
-  Runs with explicit shapes and transactions, comparing Electric's output against Postgres.
+  Runs with explicit shapes and batches of transactions, comparing Electric's output against Postgres.
 
-  Transactions can be:
-  - A list of transactions, where each transaction is a list of mutations (executed atomically)
-  - A flat list of mutations (each mutation becomes its own transaction for backwards compatibility)
+  Batches is a list of batches, where each batch is a list of transactions,
+  and each transaction is a list of mutations. All transactions in a batch are
+  applied sequentially (each in its own Postgres transaction), then all shape
+  checkers verify once at the end of the batch.
 
   ## Options
 
     - :oracle_pool_size - number of parallel oracle connections (default: 50, env: ORACLE_POOL_SIZE)
     - :timeout_ms - timeout for waiting on shapes (default: 20_000)
   """
-  def test_against_oracle(ctx, shapes, transactions, opts \\ %{}) do
+  def test_against_oracle(ctx, shapes, batches, opts \\ %{}) do
     opts = Map.merge(default_opts_from_env(), opts)
     timeout_ms = opts[:timeout_ms] || @default_timeout_ms
 
-    # Normalize transactions: wrap flat mutation lists into single-mutation transactions
-    transactions = normalize_transactions(transactions)
-
-    log_test_config(shapes, transactions)
+    log_test_config(shapes, batches)
 
     # Start oracle pool for parallel Postgres queries
     {:ok, oracle_pool} = start_oracle_pool(ctx, opts)
@@ -76,13 +74,13 @@ defmodule Support.OracleHarness do
     |> Task.async_stream(&ShapeChecker.check_initial_state/1, timeout: :infinity)
     |> Stream.run()
 
-    # Run each transaction
-    log("Running #{length(transactions)} transactions")
+    # Run each batch
+    log("Running #{length(batches)} batches")
 
-    transactions
+    batches
     |> Enum.with_index(1)
-    |> Enum.each(fn {mutations, txn_idx} ->
-      run_transaction(ctx, pids, mutations, txn_idx)
+    |> Enum.each(fn {transactions, batch_idx} ->
+      run_batch(ctx, pids, transactions, batch_idx)
     end)
 
     # Cleanup
@@ -116,31 +114,34 @@ defmodule Support.OracleHarness do
     end)
   end
 
-  defp run_transaction(ctx, pids, mutations, txn_idx) do
-    txn_name = "txn_#{txn_idx}"
+  defp run_batch(ctx, pids, transactions, batch_idx) do
+    batch_name = "batch_#{batch_idx}"
+    total_mutations = transactions |> Enum.map(&length/1) |> Enum.sum()
     cycle_start = System.monotonic_time(:millisecond)
 
-    # Apply all mutations in a single transaction
-    sql_statements = Enum.map(mutations, & &1.sql)
-    apply_sql_transaction(ctx, sql_statements)
+    # Apply all transactions in the batch sequentially
+    Enum.each(transactions, fn mutations ->
+      sql_statements = Enum.map(mutations, & &1.sql)
+      apply_sql_transaction(ctx, sql_statements)
+    end)
 
     apply_end = System.monotonic_time(:millisecond)
 
-    # Check all shapes (polls until up_to_date, then verifies against oracle)
+    # Check all shapes once for the entire batch
     pids
-    |> Task.async_stream(&ShapeChecker.check_transaction(&1, txn_name), timeout: :infinity)
+    |> Task.async_stream(&ShapeChecker.check_transaction(&1, batch_name), timeout: :infinity)
     |> Stream.run()
 
     check_end = System.monotonic_time(:millisecond)
 
     log(
-      "#{txn_name} (#{length(mutations)} mutations): " <>
+      "#{batch_name} (#{length(transactions)} txns, #{total_mutations} mutations): " <>
         "total=#{check_end - cycle_start}ms " <>
         "(apply=#{apply_end - cycle_start}ms, check=#{check_end - apply_end}ms)"
     )
   end
 
-  defp log_test_config(shapes, transactions) do
+  defp log_test_config(shapes, batches) do
     log("Starting #{length(shapes)} shapes")
 
     IO.puts("\n=== SHAPES ===")
@@ -149,17 +150,26 @@ defmodule Support.OracleHarness do
       IO.puts("  #{shape.name}: #{shape.where}")
     end)
 
-    total_mutations = transactions |> Enum.map(&length/1) |> Enum.sum()
+    total_txns = batches |> Enum.map(&length/1) |> Enum.sum()
+    total_mutations = batches |> Enum.flat_map(& &1) |> Enum.map(&length/1) |> Enum.sum()
 
-    IO.puts("\n=== TRANSACTIONS (#{length(transactions)} txns, #{total_mutations} mutations) ===")
+    IO.puts(
+      "\n=== BATCHES (#{length(batches)} batches, #{total_txns} txns, #{total_mutations} mutations) ==="
+    )
 
-    transactions
+    batches
     |> Enum.with_index(1)
-    |> Enum.each(fn {mutations, txn_idx} ->
-      IO.puts("  txn_#{txn_idx} (#{length(mutations)} mutations):")
+    |> Enum.each(fn {transactions, batch_idx} ->
+      IO.puts("  batch_#{batch_idx} (#{length(transactions)} txns):")
 
-      Enum.each(mutations, fn mutation ->
-        IO.puts("    #{mutation.name}: #{mutation.sql}")
+      transactions
+      |> Enum.with_index(1)
+      |> Enum.each(fn {mutations, txn_idx} ->
+        IO.puts("    txn_#{txn_idx} (#{length(mutations)} mutations):")
+
+        Enum.each(mutations, fn mutation ->
+          IO.puts("      #{mutation.name}: #{mutation.sql}")
+        end)
       end)
     end)
 
@@ -207,16 +217,4 @@ defmodule Support.OracleHarness do
     IO.puts("[oracle] #{message}")
   end
 
-  # Normalize transactions: if it's a flat list of mutations, wrap each in its own transaction
-  defp normalize_transactions([]), do: []
-
-  defp normalize_transactions([first | _] = transactions) when is_list(first) do
-    # Already a list of transactions
-    transactions
-  end
-
-  defp normalize_transactions([first | _] = mutations) when is_map(first) do
-    # Flat list of mutations - wrap each in its own transaction
-    Enum.map(mutations, &[&1])
-  end
 end

--- a/packages/sync-service/test/support/oracle_harness/shape_checker.ex
+++ b/packages/sync-service/test/support/oracle_harness/shape_checker.ex
@@ -1,0 +1,315 @@
+defmodule Support.OracleHarness.ShapeChecker do
+  @moduledoc """
+  GenServer that verifies a single shape's consistency with the Postgres oracle.
+
+  Each checker:
+  - Maintains its own materialized view from Electric shape changes
+  - Queries the oracle (Postgres) via a shared pool
+  - Verifies consistency between materialized client state and oracle
+
+  ## Usage
+
+      {:ok, pid} = ShapeChecker.start_link(ctx, shape, oracle_pool, timeout_ms: 20_000)
+
+      # Check initial snapshot matches oracle
+      ShapeChecker.check_initial_state(pid)
+
+      # After mutations, check transaction result matches oracle
+      ShapeChecker.check_transaction(pid, "txn_1")
+
+  """
+
+  use GenServer
+
+  import ExUnit.Assertions
+
+  alias Electric.Client
+  alias Electric.Client.Message.ChangeMessage
+  alias Electric.Client.Message.ControlMessage
+  alias Electric.Client.ShapeDefinition
+  alias Electric.Client.ShapeState
+
+  # Max time to wait for changes after receiving up_to_date without changes
+  @default_retry_window_ms 5_000
+  @default_timeout_ms 20_000
+
+  defstruct [
+    :name,
+    :table,
+    :where,
+    :columns,
+    :pk,
+    :optimized,
+    :client,
+    :shape_def,
+    :oracle_pool,
+    :timeout_ms,
+    poll_state: nil,
+    rows: %{},
+    # Cached oracle state from previous check (used as "before" for next check)
+    oracle_before: nil
+  ]
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Starts a ShapeChecker GenServer.
+  """
+  def start_link(ctx, shape, oracle_pool, opts \\ []) do
+    GenServer.start_link(__MODULE__, {ctx, shape, oracle_pool, opts})
+  end
+
+  @doc """
+  Checks the initial state: queries oracle, polls shape until up_to_date,
+  and verifies they match. Caches oracle state for subsequent transaction checks.
+
+  Raises on mismatch or timeout.
+  """
+  def check_initial_state(pid) do
+    GenServer.call(pid, :check_initial_state, :infinity)
+  end
+
+  @doc """
+  Checks after a transaction: polls shape until up_to_date, queries oracle,
+  and verifies they match. Uses cached "before" state for logging.
+
+  Raises on mismatch or timeout.
+  """
+  def check_transaction(pid, txn_name) do
+    GenServer.call(pid, {:check_transaction, txn_name}, :infinity)
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer Callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def init({ctx, shape, oracle_pool, opts}) do
+    validate_identifier!(shape.table, "table")
+    Enum.each(shape.columns, &validate_identifier!(&1, "column"))
+    Enum.each(shape.pk, &validate_identifier!(&1, "pk column"))
+
+    shape_def = ShapeDefinition.new!(shape.table, where: shape.where)
+    timeout_ms = opts[:timeout_ms] || @default_timeout_ms
+
+    state = %__MODULE__{
+      name: shape.name,
+      table: shape.table,
+      where: shape.where,
+      columns: shape.columns,
+      pk: shape.pk,
+      optimized: Map.get(shape, :optimized, false),
+      client: ctx.client,
+      shape_def: shape_def,
+      oracle_pool: oracle_pool,
+      timeout_ms: timeout_ms,
+      poll_state: ShapeState.new()
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:check_initial_state, _from, state) do
+    log("Checking initial state for shape=#{state.name}")
+
+    # Get oracle state (this becomes our "before" for the first transaction)
+    oracle = query_oracle(state)
+
+    # Poll until up_to_date
+    state = await_up_to_date(state)
+
+    # Verify consistency
+    assert_consistent!(state, "initial_snapshot", oracle, oracle)
+
+    # Cache oracle state for next check
+    state = %{state | oracle_before: oracle}
+
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:check_transaction, txn_name}, _from, state) do
+    # Poll until up_to_date
+    state = await_up_to_date(state)
+
+    # Get new oracle state
+    oracle_after = query_oracle(state)
+
+    # Verify consistency (uses cached oracle_before)
+    assert_consistent!(state, txn_name, state.oracle_before, oracle_after)
+
+    # Cache new oracle state for next check
+    state = %{state | oracle_before: oracle_after}
+
+    {:reply, :ok, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Polling Logic
+  # ---------------------------------------------------------------------------
+
+  defp await_up_to_date(state) do
+    do_await(state, System.monotonic_time(:millisecond), _retry_start = nil)
+  end
+
+  defp do_await(state, start_ms, retry_start) do
+    elapsed = System.monotonic_time(:millisecond) - start_ms
+
+    if elapsed >= state.timeout_ms do
+      flunk("Timeout waiting for shape=#{state.name} where=#{state.where}")
+    end
+
+    case Client.poll(state.client, state.shape_def, state.poll_state, replica: :full) do
+      {:ok, messages, new_state} ->
+        state = %{state | poll_state: new_state}
+        state = apply_messages(state, messages)
+
+        if new_state.up_to_date? do
+          handle_up_to_date(state, start_ms, retry_start)
+        else
+          do_await(state, start_ms, retry_start)
+        end
+
+      {:must_refetch, messages, new_state} ->
+        if state.optimized do
+          flunk(
+            "Unexpected 409 (must-refetch) in optimized shape=#{state.name} where=#{state.where}"
+          )
+        end
+
+        state = %{state | poll_state: new_state, rows: %{}}
+        state = apply_messages(state, messages)
+        do_await(state, start_ms, _retry_start = nil)
+
+      {:error, error} ->
+        flunk("Poll error for shape=#{state.name} where=#{state.where}: #{inspect(error)}")
+    end
+  end
+
+  defp handle_up_to_date(state, start_ms, retry_start) do
+    now = System.monotonic_time(:millisecond)
+    oracle_rows = query_oracle(state)
+    materialized = materialized_rows(state)
+
+    if materialized == oracle_rows do
+      # Oracle matches - done
+      state
+    else
+      # Oracle differs - Electric may not have sent all changes yet
+      retry_start = retry_start || now
+
+      if now - retry_start >= @default_retry_window_ms do
+        # Exceeded retry window - return state (will fail in assert_consistent!)
+        state
+      else
+        # Continue polling
+        do_await(state, start_ms, retry_start)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Message Application
+  # ---------------------------------------------------------------------------
+
+  defp apply_messages(state, messages) do
+    Enum.reduce(messages, state, &apply_message/2)
+  end
+
+  defp apply_message(%ChangeMessage{headers: %{operation: :delete}, value: value}, state) do
+    key = key_from_value(state.pk, value)
+    %{state | rows: Map.delete(state.rows, key)}
+  end
+
+  defp apply_message(%ChangeMessage{value: value}, state) do
+    key = key_from_value(state.pk, value)
+    row = Map.take(value, state.columns)
+    %{state | rows: Map.put(state.rows, key, row)}
+  end
+
+  defp apply_message(%ControlMessage{}, state), do: state
+  defp apply_message(_other, state), do: state
+
+  defp key_from_value(pk, value) do
+    pk
+    |> Enum.map(&Map.get(value, &1))
+    |> List.to_tuple()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Oracle Queries
+  # ---------------------------------------------------------------------------
+
+  defp query_oracle(state) do
+    where_sql = state.where || "TRUE"
+    columns_sql = Enum.map(state.columns, &quote_ident/1) |> Enum.join(", ")
+    order_sql = Enum.map(state.pk, &quote_ident/1) |> Enum.join(", ")
+
+    sql =
+      "SELECT #{columns_sql} FROM #{quote_ident(state.table)} WHERE #{where_sql} ORDER BY #{order_sql}"
+
+    %Postgrex.Result{columns: columns, rows: rows} =
+      Postgrex.query!(state.oracle_pool, sql, [])
+
+    Enum.map(rows, fn row ->
+      columns
+      |> Enum.zip(row)
+      |> Map.new(fn {col, val} -> {col, to_string_value(val)} end)
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Assertions
+  # ---------------------------------------------------------------------------
+
+  defp assert_consistent!(state, step_name, oracle_before, oracle_after) do
+    view_changed? = oracle_before != oracle_after
+    materialized = materialized_rows(state)
+
+    if materialized != oracle_after do
+      IO.puts(
+        "[oracle] View mismatch in step=#{step_name} shape=#{state.name} where=#{state.where} view_changed?=#{view_changed?}"
+      )
+
+      assert materialized == oracle_after
+    end
+
+    view_status = if view_changed?, do: "changed", else: "unchanged"
+    log("  #{step_name} shape=#{state.name} (#{view_status}) PASS")
+
+    :ok
+  end
+
+  defp materialized_rows(state) do
+    state.rows
+    |> Map.values()
+    |> Enum.sort_by(&key_from_value(state.pk, &1))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp validate_identifier!(value, label) do
+    if String.match?(value, ~r/^[A-Za-z_][A-Za-z0-9_]*$/) do
+      :ok
+    else
+      raise ArgumentError, "invalid #{label} identifier: #{inspect(value)}"
+    end
+  end
+
+  defp quote_ident(value), do: ~s|"#{value}"|
+
+  defp to_string_value(nil), do: nil
+  defp to_string_value(true), do: "true"
+  defp to_string_value(false), do: "false"
+  defp to_string_value(val) when is_binary(val), do: val
+  defp to_string_value(val), do: to_string(val)
+
+  defp log(message) do
+    IO.puts("[oracle] #{message}")
+  end
+end

--- a/packages/sync-service/test/support/oracle_harness/standard_schema.ex
+++ b/packages/sync-service/test/support/oracle_harness/standard_schema.ex
@@ -1,0 +1,364 @@
+defmodule Support.OracleHarness.StandardSchema do
+  @moduledoc """
+  Standard 4-level hierarchy schema for OracleHarness testing.
+
+  Supports testing subqueries up to 4 levels deep.
+
+  ## Schema Structure
+
+      level_1 (id, active)
+          ├── level_1_tags (level_1_id, tag)
+          └── level_2 (id, level_1_id, active)
+                  ├── level_2_tags (level_2_id, tag)
+                  └── level_3 (id, level_2_id, active)
+                          ├── level_3_tags (level_3_id, tag)
+                          └── level_4 (id, level_3_id, value)
+  """
+
+  alias Support.OracleHarness
+  alias Support.OracleHarness.WhereClauseGenerator
+
+  # Standard IDs for seeded data
+  @level_1_ids Enum.map(1..5, &"l1-#{&1}")
+  @level_2_ids Enum.map(1..5, &"l2-#{&1}")
+  @level_3_ids Enum.map(1..5, &"l3-#{&1}")
+  @level_4_ids Enum.map(1..20, &"l4-#{&1}")
+  @tags ["alpha", "beta", "gamma", "delta"]
+
+  # ----------------------------------------------------------------------------
+  # Standard Schema
+  # ----------------------------------------------------------------------------
+
+  def schema_sql do
+    [
+      "DROP TABLE IF EXISTS level_4 CASCADE",
+      "DROP TABLE IF EXISTS level_3_tags CASCADE",
+      "DROP TABLE IF EXISTS level_3 CASCADE",
+      "DROP TABLE IF EXISTS level_2_tags CASCADE",
+      "DROP TABLE IF EXISTS level_2 CASCADE",
+      "DROP TABLE IF EXISTS level_1_tags CASCADE",
+      "DROP TABLE IF EXISTS level_1 CASCADE",
+      """
+      CREATE TABLE level_1 (
+        id TEXT PRIMARY KEY,
+        active BOOLEAN NOT NULL DEFAULT true
+      )
+      """,
+      """
+      CREATE TABLE level_1_tags (
+        level_1_id TEXT NOT NULL REFERENCES level_1(id) ON DELETE CASCADE,
+        tag TEXT NOT NULL,
+        PRIMARY KEY (level_1_id, tag)
+      )
+      """,
+      """
+      CREATE TABLE level_2 (
+        id TEXT PRIMARY KEY,
+        level_1_id TEXT NOT NULL REFERENCES level_1(id) ON DELETE CASCADE,
+        active BOOLEAN NOT NULL DEFAULT true
+      )
+      """,
+      """
+      CREATE TABLE level_2_tags (
+        level_2_id TEXT NOT NULL REFERENCES level_2(id) ON DELETE CASCADE,
+        tag TEXT NOT NULL,
+        PRIMARY KEY (level_2_id, tag)
+      )
+      """,
+      """
+      CREATE TABLE level_3 (
+        id TEXT PRIMARY KEY,
+        level_2_id TEXT NOT NULL REFERENCES level_2(id) ON DELETE CASCADE,
+        active BOOLEAN NOT NULL DEFAULT true
+      )
+      """,
+      """
+      CREATE TABLE level_3_tags (
+        level_3_id TEXT NOT NULL REFERENCES level_3(id) ON DELETE CASCADE,
+        tag TEXT NOT NULL,
+        PRIMARY KEY (level_3_id, tag)
+      )
+      """,
+      """
+      CREATE TABLE level_4 (
+        id TEXT PRIMARY KEY,
+        level_3_id TEXT NOT NULL REFERENCES level_3(id) ON DELETE CASCADE,
+        value TEXT NOT NULL
+      )
+      """
+    ]
+  end
+
+  def seed_sql do
+    level_1_values =
+      @level_1_ids
+      |> Enum.with_index()
+      |> Enum.map(fn {id, idx} -> "('#{id}', #{rem(idx, 2) == 0})" end)
+      |> Enum.join(", ")
+
+    level_2_values =
+      for {l2_id, idx} <- Enum.with_index(@level_2_ids) do
+        l1_id = Enum.at(@level_1_ids, rem(idx, length(@level_1_ids)))
+        "('#{l2_id}', '#{l1_id}', #{rem(idx, 2) == 0})"
+      end
+      |> Enum.join(", ")
+
+    level_3_values =
+      for {l3_id, idx} <- Enum.with_index(@level_3_ids) do
+        l2_id = Enum.at(@level_2_ids, rem(idx, length(@level_2_ids)))
+        "('#{l3_id}', '#{l2_id}', #{rem(idx, 2) == 0})"
+      end
+      |> Enum.join(", ")
+
+    level_4_values =
+      for {l4_id, idx} <- Enum.with_index(@level_4_ids) do
+        l3_id = Enum.at(@level_3_ids, rem(idx, length(@level_3_ids)))
+        "('#{l4_id}', '#{l3_id}', 'v#{idx}')"
+      end
+      |> Enum.join(", ")
+
+    # Tags: assign tags in a pattern so we get variety
+    level_1_tag_values =
+      for {l1_id, idx} <- Enum.with_index(@level_1_ids),
+          tag <- Enum.take(@tags, rem(idx, length(@tags)) + 1) do
+        "('#{l1_id}', '#{tag}')"
+      end
+      |> Enum.join(", ")
+
+    level_2_tag_values =
+      for {l2_id, idx} <- Enum.with_index(@level_2_ids),
+          tag <- Enum.take(@tags, rem(idx, length(@tags)) + 1) do
+        "('#{l2_id}', '#{tag}')"
+      end
+      |> Enum.join(", ")
+
+    level_3_tag_values =
+      for {l3_id, idx} <- Enum.with_index(@level_3_ids),
+          tag <- Enum.take(@tags, rem(idx, length(@tags)) + 1) do
+        "('#{l3_id}', '#{tag}')"
+      end
+      |> Enum.join(", ")
+
+    [
+      "INSERT INTO level_1 (id, active) VALUES #{level_1_values}",
+      "INSERT INTO level_2 (id, level_1_id, active) VALUES #{level_2_values}",
+      "INSERT INTO level_3 (id, level_2_id, active) VALUES #{level_3_values}",
+      "INSERT INTO level_4 (id, level_3_id, value) VALUES #{level_4_values}",
+      "INSERT INTO level_1_tags (level_1_id, tag) VALUES #{level_1_tag_values}",
+      "INSERT INTO level_2_tags (level_2_id, tag) VALUES #{level_2_tag_values}",
+      "INSERT INTO level_3_tags (level_3_id, tag) VALUES #{level_3_tag_values}"
+    ]
+  end
+
+  def level_1_ids, do: @level_1_ids
+  def level_2_ids, do: @level_2_ids
+  def level_3_ids, do: @level_3_ids
+  def level_4_ids, do: @level_4_ids
+  def tags, do: @tags
+
+  # ----------------------------------------------------------------------------
+  # Setup and Reset
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Sets up the standard schema and seeds it with data.
+  Call this once before running tests.
+  """
+  def setup_standard_schema(ctx) do
+    OracleHarness.apply_sql(ctx, schema_sql())
+    OracleHarness.apply_sql(ctx, seed_sql())
+    :ok
+  end
+
+  @doc """
+  Resets the standard schema data to its initial seeded state.
+  Faster than full schema recreation.
+  """
+  def reset_standard_data(ctx) do
+    # Delete in reverse order of dependencies (avoid TRUNCATE which invalidates shapes via replication)
+    OracleHarness.apply_sql(ctx, [
+      "DELETE FROM level_4",
+      "DELETE FROM level_3_tags",
+      "DELETE FROM level_3",
+      "DELETE FROM level_2_tags",
+      "DELETE FROM level_2",
+      "DELETE FROM level_1_tags",
+      "DELETE FROM level_1"
+    ])
+
+    OracleHarness.apply_sql(ctx, seed_sql())
+    :ok
+  end
+
+  # ----------------------------------------------------------------------------
+  # Shape Generation
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Generates a list of diverse shape specs using StreamData-based generator.
+
+  This exercises the full range of SQL patterns supported by the parser including:
+  - OR/AND combinations with subqueries
+  - NOT patterns (NOT IN, NOT LIKE, NOT BETWEEN)
+  - Comparison operators (<, >, <=, >=, <>)
+  - BETWEEN/NOT BETWEEN
+  - LIKE/NOT LIKE with various patterns
+  - Nested subqueries (1-3 levels)
+  - Tag-based subqueries
+  - Mixed compositions
+
+  Uses the provided seed for deterministic generation.
+  """
+  def generate_diverse_shapes(count, seed) do
+    WhereClauseGenerator.generate_where_clauses(count, seed)
+    |> Enum.with_index(1)
+    |> Enum.map(fn {where_spec, idx} ->
+      %{
+        name: "shape_#{idx}",
+        table: "level_4",
+        where: where_spec.where,
+        columns: ["id", "level_3_id", "value"],
+        pk: ["id"],
+        optimized: where_spec.optimized
+      }
+    end)
+  end
+
+  # ----------------------------------------------------------------------------
+  # Mutation Generation
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Generates a list of mutations to apply.
+  """
+  def generate_mutations(count, seed \\ nil) do
+    :rand.seed(:exsss, seed || :erlang.monotonic_time())
+
+    Enum.map(1..count, fn idx ->
+      generate_one_mutation(idx)
+    end)
+  end
+
+  defp generate_one_mutation(idx) do
+    case rem(idx, 8) do
+      0 -> toggle_level_1_active()
+      1 -> toggle_level_2_active()
+      2 -> toggle_level_3_active()
+      3 -> move_level_2_parent()
+      4 -> move_level_3_parent()
+      5 -> move_level_4_parent()
+      6 -> add_or_remove_tag()
+      7 -> update_level_4_value()
+    end
+  end
+
+  defp toggle_level_1_active do
+    id = Enum.random(@level_1_ids)
+    %{name: "toggle_l1_#{id}", sql: "UPDATE level_1 SET active = NOT active WHERE id = '#{id}'"}
+  end
+
+  defp toggle_level_2_active do
+    id = Enum.random(@level_2_ids)
+    %{name: "toggle_l2_#{id}", sql: "UPDATE level_2 SET active = NOT active WHERE id = '#{id}'"}
+  end
+
+  defp toggle_level_3_active do
+    id = Enum.random(@level_3_ids)
+    %{name: "toggle_l3_#{id}", sql: "UPDATE level_3 SET active = NOT active WHERE id = '#{id}'"}
+  end
+
+  defp move_level_2_parent do
+    id = Enum.random(@level_2_ids)
+    new_parent = Enum.random(@level_1_ids)
+
+    %{
+      name: "move_l2_#{id}_to_#{new_parent}",
+      sql: "UPDATE level_2 SET level_1_id = '#{new_parent}' WHERE id = '#{id}'"
+    }
+  end
+
+  defp move_level_3_parent do
+    id = Enum.random(@level_3_ids)
+    new_parent = Enum.random(@level_2_ids)
+
+    %{
+      name: "move_l3_#{id}_to_#{new_parent}",
+      sql: "UPDATE level_3 SET level_2_id = '#{new_parent}' WHERE id = '#{id}'"
+    }
+  end
+
+  defp move_level_4_parent do
+    id = Enum.random(@level_4_ids)
+    new_parent = Enum.random(@level_3_ids)
+
+    %{
+      name: "move_l4_#{id}_to_#{new_parent}",
+      sql: "UPDATE level_4 SET level_3_id = '#{new_parent}' WHERE id = '#{id}'"
+    }
+  end
+
+  defp add_or_remove_tag do
+    level = :rand.uniform(3)
+    tag = Enum.random(@tags)
+
+    case level do
+      1 ->
+        id = Enum.random(@level_1_ids)
+
+        if :rand.uniform(2) == 1 do
+          %{
+            name: "add_tag_l1_#{id}_#{tag}",
+            sql:
+              "INSERT INTO level_1_tags (level_1_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
+          }
+        else
+          %{
+            name: "remove_tag_l1_#{id}_#{tag}",
+            sql: "DELETE FROM level_1_tags WHERE level_1_id = '#{id}' AND tag = '#{tag}'"
+          }
+        end
+
+      2 ->
+        id = Enum.random(@level_2_ids)
+
+        if :rand.uniform(2) == 1 do
+          %{
+            name: "add_tag_l2_#{id}_#{tag}",
+            sql:
+              "INSERT INTO level_2_tags (level_2_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
+          }
+        else
+          %{
+            name: "remove_tag_l2_#{id}_#{tag}",
+            sql: "DELETE FROM level_2_tags WHERE level_2_id = '#{id}' AND tag = '#{tag}'"
+          }
+        end
+
+      3 ->
+        id = Enum.random(@level_3_ids)
+
+        if :rand.uniform(2) == 1 do
+          %{
+            name: "add_tag_l3_#{id}_#{tag}",
+            sql:
+              "INSERT INTO level_3_tags (level_3_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
+          }
+        else
+          %{
+            name: "remove_tag_l3_#{id}_#{tag}",
+            sql: "DELETE FROM level_3_tags WHERE level_3_id = '#{id}' AND tag = '#{tag}'"
+          }
+        end
+    end
+  end
+
+  defp update_level_4_value do
+    id = Enum.random(@level_4_ids)
+    new_value = "v#{:rand.uniform(1000)}"
+
+    %{
+      name: "update_l4_#{id}",
+      sql: "UPDATE level_4 SET value = '#{new_value}' WHERE id = '#{id}'"
+    }
+  end
+end

--- a/packages/sync-service/test/support/oracle_harness/standard_schema.ex
+++ b/packages/sync-service/test/support/oracle_harness/standard_schema.ex
@@ -15,8 +15,9 @@ defmodule Support.OracleHarness.StandardSchema do
                           └── level_4 (id, level_3_id, value)
   """
 
+  import StreamData
+
   alias Support.OracleHarness
-  alias Support.OracleHarness.WhereClauseGenerator
 
   # Standard IDs for seeded data
   @level_1_ids Enum.map(1..5, &"l1-#{&1}")
@@ -191,174 +192,142 @@ defmodule Support.OracleHarness.StandardSchema do
   end
 
   # ----------------------------------------------------------------------------
-  # Shape Generation
-  # ----------------------------------------------------------------------------
-
-  @doc """
-  Generates a list of diverse shape specs using StreamData-based generator.
-
-  This exercises the full range of SQL patterns supported by the parser including:
-  - OR/AND combinations with subqueries
-  - NOT patterns (NOT IN, NOT LIKE, NOT BETWEEN)
-  - Comparison operators (<, >, <=, >=, <>)
-  - BETWEEN/NOT BETWEEN
-  - LIKE/NOT LIKE with various patterns
-  - Nested subqueries (1-3 levels)
-  - Tag-based subqueries
-  - Mixed compositions
-
-  Uses the provided seed for deterministic generation.
-  """
-  def generate_diverse_shapes(count, seed) do
-    WhereClauseGenerator.generate_where_clauses(count, seed)
-    |> Enum.with_index(1)
-    |> Enum.map(fn {where_spec, idx} ->
-      %{
-        name: "shape_#{idx}",
-        table: "level_4",
-        where: where_spec.where,
-        columns: ["id", "level_3_id", "value"],
-        pk: ["id"],
-        optimized: where_spec.optimized
-      }
-    end)
-  end
-
-  # ----------------------------------------------------------------------------
   # Mutation Generation
   # ----------------------------------------------------------------------------
 
   @doc """
-  Generates a list of mutations to apply.
-  """
-  def generate_mutations(count, seed \\ nil) do
-    :rand.seed(:exsss, seed || :erlang.monotonic_time())
+  Returns a StreamData generator that produces a list of mutation maps.
 
-    Enum.map(1..count, fn idx ->
-      generate_one_mutation(idx)
+  Designed to be consumed directly by `check all` for deterministic seeding.
+  """
+  def mutations_gen(count) do
+    list_of(mutation_gen(), length: count)
+  end
+
+  defp mutation_gen do
+    one_of([
+      toggle_level_1_active_gen(),
+      toggle_level_2_active_gen(),
+      toggle_level_3_active_gen(),
+      move_level_2_parent_gen(),
+      move_level_3_parent_gen(),
+      move_level_4_parent_gen(),
+      add_or_remove_tag_gen(),
+      update_level_4_value_gen()
+    ])
+  end
+
+  defp toggle_level_1_active_gen do
+    member_of(@level_1_ids)
+    |> map(fn id ->
+      %{name: "toggle_l1_#{id}", sql: "UPDATE level_1 SET active = NOT active WHERE id = '#{id}'"}
     end)
   end
 
-  defp generate_one_mutation(idx) do
-    case rem(idx, 8) do
-      0 -> toggle_level_1_active()
-      1 -> toggle_level_2_active()
-      2 -> toggle_level_3_active()
-      3 -> move_level_2_parent()
-      4 -> move_level_3_parent()
-      5 -> move_level_4_parent()
-      6 -> add_or_remove_tag()
-      7 -> update_level_4_value()
-    end
+  defp toggle_level_2_active_gen do
+    member_of(@level_2_ids)
+    |> map(fn id ->
+      %{name: "toggle_l2_#{id}", sql: "UPDATE level_2 SET active = NOT active WHERE id = '#{id}'"}
+    end)
   end
 
-  defp toggle_level_1_active do
-    id = Enum.random(@level_1_ids)
-    %{name: "toggle_l1_#{id}", sql: "UPDATE level_1 SET active = NOT active WHERE id = '#{id}'"}
+  defp toggle_level_3_active_gen do
+    member_of(@level_3_ids)
+    |> map(fn id ->
+      %{name: "toggle_l3_#{id}", sql: "UPDATE level_3 SET active = NOT active WHERE id = '#{id}'"}
+    end)
   end
 
-  defp toggle_level_2_active do
-    id = Enum.random(@level_2_ids)
-    %{name: "toggle_l2_#{id}", sql: "UPDATE level_2 SET active = NOT active WHERE id = '#{id}'"}
+  defp move_level_2_parent_gen do
+    bind({member_of(@level_2_ids), member_of(@level_1_ids)}, fn {id, new_parent} ->
+      constant(%{
+        name: "move_l2_#{id}_to_#{new_parent}",
+        sql: "UPDATE level_2 SET level_1_id = '#{new_parent}' WHERE id = '#{id}'"
+      })
+    end)
   end
 
-  defp toggle_level_3_active do
-    id = Enum.random(@level_3_ids)
-    %{name: "toggle_l3_#{id}", sql: "UPDATE level_3 SET active = NOT active WHERE id = '#{id}'"}
+  defp move_level_3_parent_gen do
+    bind({member_of(@level_3_ids), member_of(@level_2_ids)}, fn {id, new_parent} ->
+      constant(%{
+        name: "move_l3_#{id}_to_#{new_parent}",
+        sql: "UPDATE level_3 SET level_2_id = '#{new_parent}' WHERE id = '#{id}'"
+      })
+    end)
   end
 
-  defp move_level_2_parent do
-    id = Enum.random(@level_2_ids)
-    new_parent = Enum.random(@level_1_ids)
-
-    %{
-      name: "move_l2_#{id}_to_#{new_parent}",
-      sql: "UPDATE level_2 SET level_1_id = '#{new_parent}' WHERE id = '#{id}'"
-    }
+  defp move_level_4_parent_gen do
+    bind({member_of(@level_4_ids), member_of(@level_3_ids)}, fn {id, new_parent} ->
+      constant(%{
+        name: "move_l4_#{id}_to_#{new_parent}",
+        sql: "UPDATE level_4 SET level_3_id = '#{new_parent}' WHERE id = '#{id}'"
+      })
+    end)
   end
 
-  defp move_level_3_parent do
-    id = Enum.random(@level_3_ids)
-    new_parent = Enum.random(@level_2_ids)
+  defp add_or_remove_tag_gen do
+    bind(
+      {member_of(1..3), member_of(@tags), member_of([true, false])},
+      fn {level, tag, add?} ->
+        case level do
+          1 ->
+            bind(member_of(@level_1_ids), fn id ->
+              if add? do
+                constant(%{
+                  name: "add_tag_l1_#{id}_#{tag}",
+                  sql:
+                    "INSERT INTO level_1_tags (level_1_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
+                })
+              else
+                constant(%{
+                  name: "remove_tag_l1_#{id}_#{tag}",
+                  sql: "DELETE FROM level_1_tags WHERE level_1_id = '#{id}' AND tag = '#{tag}'"
+                })
+              end
+            end)
 
-    %{
-      name: "move_l3_#{id}_to_#{new_parent}",
-      sql: "UPDATE level_3 SET level_2_id = '#{new_parent}' WHERE id = '#{id}'"
-    }
-  end
+          2 ->
+            bind(member_of(@level_2_ids), fn id ->
+              if add? do
+                constant(%{
+                  name: "add_tag_l2_#{id}_#{tag}",
+                  sql:
+                    "INSERT INTO level_2_tags (level_2_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
+                })
+              else
+                constant(%{
+                  name: "remove_tag_l2_#{id}_#{tag}",
+                  sql: "DELETE FROM level_2_tags WHERE level_2_id = '#{id}' AND tag = '#{tag}'"
+                })
+              end
+            end)
 
-  defp move_level_4_parent do
-    id = Enum.random(@level_4_ids)
-    new_parent = Enum.random(@level_3_ids)
-
-    %{
-      name: "move_l4_#{id}_to_#{new_parent}",
-      sql: "UPDATE level_4 SET level_3_id = '#{new_parent}' WHERE id = '#{id}'"
-    }
-  end
-
-  defp add_or_remove_tag do
-    level = :rand.uniform(3)
-    tag = Enum.random(@tags)
-
-    case level do
-      1 ->
-        id = Enum.random(@level_1_ids)
-
-        if :rand.uniform(2) == 1 do
-          %{
-            name: "add_tag_l1_#{id}_#{tag}",
-            sql:
-              "INSERT INTO level_1_tags (level_1_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
-          }
-        else
-          %{
-            name: "remove_tag_l1_#{id}_#{tag}",
-            sql: "DELETE FROM level_1_tags WHERE level_1_id = '#{id}' AND tag = '#{tag}'"
-          }
+          3 ->
+            bind(member_of(@level_3_ids), fn id ->
+              if add? do
+                constant(%{
+                  name: "add_tag_l3_#{id}_#{tag}",
+                  sql:
+                    "INSERT INTO level_3_tags (level_3_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
+                })
+              else
+                constant(%{
+                  name: "remove_tag_l3_#{id}_#{tag}",
+                  sql: "DELETE FROM level_3_tags WHERE level_3_id = '#{id}' AND tag = '#{tag}'"
+                })
+              end
+            end)
         end
-
-      2 ->
-        id = Enum.random(@level_2_ids)
-
-        if :rand.uniform(2) == 1 do
-          %{
-            name: "add_tag_l2_#{id}_#{tag}",
-            sql:
-              "INSERT INTO level_2_tags (level_2_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
-          }
-        else
-          %{
-            name: "remove_tag_l2_#{id}_#{tag}",
-            sql: "DELETE FROM level_2_tags WHERE level_2_id = '#{id}' AND tag = '#{tag}'"
-          }
-        end
-
-      3 ->
-        id = Enum.random(@level_3_ids)
-
-        if :rand.uniform(2) == 1 do
-          %{
-            name: "add_tag_l3_#{id}_#{tag}",
-            sql:
-              "INSERT INTO level_3_tags (level_3_id, tag) VALUES ('#{id}', '#{tag}') ON CONFLICT DO NOTHING"
-          }
-        else
-          %{
-            name: "remove_tag_l3_#{id}_#{tag}",
-            sql: "DELETE FROM level_3_tags WHERE level_3_id = '#{id}' AND tag = '#{tag}'"
-          }
-        end
-    end
+      end
+    )
   end
 
-  defp update_level_4_value do
-    id = Enum.random(@level_4_ids)
-    new_value = "v#{:rand.uniform(1000)}"
-
-    %{
-      name: "update_l4_#{id}",
-      sql: "UPDATE level_4 SET value = '#{new_value}' WHERE id = '#{id}'"
-    }
+  defp update_level_4_value_gen do
+    bind({member_of(@level_4_ids), integer(1..1000)}, fn {id, val} ->
+      constant(%{
+        name: "update_l4_#{id}",
+        sql: "UPDATE level_4 SET value = 'v#{val}' WHERE id = '#{id}'"
+      })
+    end)
   end
 end

--- a/packages/sync-service/test/support/oracle_harness/where_clause_generator.ex
+++ b/packages/sync-service/test/support/oracle_harness/where_clause_generator.ex
@@ -1,0 +1,359 @@
+defmodule Support.OracleHarness.WhereClauseGenerator do
+  @moduledoc """
+  StreamData-based generator for WHERE clauses.
+  Generates diverse SQL patterns for oracle testing including:
+  - AND/OR combinations with subqueries
+  - NOT patterns (NOT IN, NOT LIKE, NOT BETWEEN)
+  - Comparison operators (<, >, <=, >=, <>)
+  - BETWEEN/NOT BETWEEN
+  - LIKE/NOT LIKE with various patterns
+  - Nested subqueries (1-3 levels)
+  - Tag-based subqueries
+  - Mixed compositions
+  """
+
+  import StreamData
+
+  # Schema constants (match standard_schema.ex)
+  @level_1_ids Enum.map(1..5, &"l1-#{&1}")
+  @level_2_ids Enum.map(1..5, &"l2-#{&1}")
+  @level_3_ids Enum.map(1..5, &"l3-#{&1}")
+  @level_4_ids Enum.map(1..20, &"l4-#{&1}")
+  @tags ["alpha", "beta", "gamma", "delta"]
+
+  # ============================================================================
+  # Main Entry Points
+  # ============================================================================
+
+  @doc """
+  Returns a StreamData generator that produces {where_clause, optimized?} tuples.
+
+  Options:
+    - :max_depth - Maximum nesting depth for compositions (default: 2)
+  """
+  def where_clause_gen(opts \\ []) do
+    max_depth = Keyword.get(opts, :max_depth, 2)
+
+    frequency([
+      {4, atomic_with_meta()},
+      {3, subquery_with_meta()},
+      {2, and_composition(max_depth)},
+      {2, or_composition(max_depth)},
+      {1, complex_composition(max_depth)}
+    ])
+  end
+
+  @doc """
+  Generates a list of shape specs using StreamData.
+
+  Uses the provided seed for deterministic generation.
+  Returns list of maps with :where and :optimized keys.
+  """
+  def generate_where_clauses(count, seed) do
+    # Seed the process dictionary so StreamData's Enum.take uses deterministic randomness
+    :rand.seed(:exsss, seed)
+
+    where_clause_gen()
+    |> Enum.take(count * 3)
+    |> Enum.uniq_by(fn {where, _optimized} -> where end)
+    |> Enum.take(count)
+    |> Enum.shuffle()
+    |> Enum.map(fn {where, optimized} ->
+      %{where: where, optimized: optimized}
+    end)
+  end
+
+  # ============================================================================
+  # Value Generators
+  # ============================================================================
+
+  defp level_1_id_gen, do: member_of(@level_1_ids)
+  defp level_2_id_gen, do: member_of(@level_2_ids)
+  defp level_3_id_gen, do: member_of(@level_3_ids)
+  defp level_4_id_gen, do: member_of(@level_4_ids)
+  defp bool_gen, do: member_of(["true", "false"])
+  defp tag_gen, do: member_of(@tags)
+
+  # Value patterns for level_4.value column
+  defp value_literal_gen do
+    member_of(["v0", "v1", "v5", "v10", "v15", "v19"])
+  end
+
+  defp like_pattern_gen do
+    member_of(["v%", "v1%", "v_", "%5", "%1%"])
+  end
+
+  # ============================================================================
+  # Atomic Condition Generators (Base Predicates)
+  # ============================================================================
+
+  defp atomic_with_meta do
+    frequency([
+      {3, equality_gen()},
+      {2, comparison_gen()},
+      {2, like_gen()},
+      {1, between_gen()},
+      {2, in_values_gen()}
+    ])
+  end
+
+  # col = 'val'
+  defp equality_gen do
+    one_of([
+      # level_3_id = 'l3-X'
+      level_3_id_gen() |> map(&{"level_3_id = '#{&1}'", false}),
+      # id = 'l4-X'
+      level_4_id_gen() |> map(&{"id = '#{&1}'", false}),
+      # value = 'vX'
+      value_literal_gen() |> map(&{"value = '#{&1}'", false})
+    ])
+  end
+
+  # col > 'val', col <> 'val', etc.
+  defp comparison_gen do
+    bind({member_of(["<", ">", "<=", ">=", "<>"]), value_literal_gen()}, fn {op, val} ->
+      constant({"value #{op} '#{val}'", false})
+    end)
+  end
+
+  # col LIKE 'pattern' / col NOT LIKE 'pattern'
+  defp like_gen do
+    bind({member_of([{"LIKE", false}, {"NOT LIKE", false}]), like_pattern_gen()}, fn
+      {{op, optimized}, pattern} ->
+        constant({"value #{op} '#{pattern}'", optimized})
+    end)
+  end
+
+  # col BETWEEN 'a' AND 'b' / col NOT BETWEEN 'a' AND 'b'
+  defp between_gen do
+    bind(
+      {member_of([{"BETWEEN", false}, {"NOT BETWEEN", false}]), value_literal_gen(),
+       value_literal_gen()},
+      fn {{op, optimized}, v1, v2} ->
+        # Ensure v1 <= v2 for valid BETWEEN
+        {low, high} = if v1 <= v2, do: {v1, v2}, else: {v2, v1}
+        constant({"value #{op} '#{low}' AND '#{high}'", optimized})
+      end
+    )
+  end
+
+  # col IN ('a', 'b', 'c')
+  defp in_values_gen do
+    one_of([
+      # level_3_id IN ('l3-1', 'l3-2', ...)
+      bind(list_of(level_3_id_gen(), min_length: 2, max_length: 4), fn ids ->
+        values = ids |> Enum.uniq() |> Enum.map(&"'#{&1}'") |> Enum.join(", ")
+        constant({"level_3_id IN (#{values})", false})
+      end),
+      # id IN ('l4-1', 'l4-2', ...)
+      bind(list_of(level_4_id_gen(), min_length: 2, max_length: 4), fn ids ->
+        values = ids |> Enum.uniq() |> Enum.map(&"'#{&1}'") |> Enum.join(", ")
+        constant({"id IN (#{values})", false})
+      end)
+    ])
+  end
+
+  # ============================================================================
+  # Subquery Generators
+  # ============================================================================
+
+  defp subquery_with_meta do
+    frequency([
+      {3, subquery_1_level_gen()},
+      {2, subquery_2_level_gen()},
+      {1, subquery_3_level_gen()},
+      {2, tag_subquery_gen()}
+    ])
+  end
+
+  # 1-level subquery: level_3_id IN (SELECT id FROM level_3 WHERE ...)
+  defp subquery_1_level_gen do
+    one_of([
+      # Filter by active flag
+      bool_gen()
+      |> map(fn active ->
+        {"level_3_id IN (SELECT id FROM level_3 WHERE active = #{active})", false}
+      end),
+      # Filter by level_2_id
+      level_2_id_gen()
+      |> map(fn l2_id ->
+        {"level_3_id IN (SELECT id FROM level_3 WHERE level_2_id = '#{l2_id}')", false}
+      end)
+    ])
+  end
+
+  # 2-level subquery
+  defp subquery_2_level_gen do
+    one_of([
+      # Through active flags at both levels
+      bind({bool_gen(), bool_gen()}, fn {active_l3, active_l2} ->
+        constant(
+          {"level_3_id IN (SELECT id FROM level_3 WHERE active = #{active_l3} AND level_2_id IN (SELECT id FROM level_2 WHERE active = #{active_l2}))",
+           false}
+        )
+      end),
+      # Through specific level_1_id
+      level_1_id_gen()
+      |> map(fn l1_id ->
+        {"level_3_id IN (SELECT id FROM level_3 WHERE level_2_id IN (SELECT id FROM level_2 WHERE level_1_id = '#{l1_id}'))",
+         false}
+      end)
+    ])
+  end
+
+  # 3-level subquery
+  defp subquery_3_level_gen do
+    bool_gen()
+    |> map(fn active_l1 ->
+      {"level_3_id IN (SELECT id FROM level_3 WHERE level_2_id IN (SELECT id FROM level_2 WHERE level_1_id IN (SELECT id FROM level_1 WHERE active = #{active_l1})))",
+       false}
+    end)
+  end
+
+  # Tag-based subqueries
+  defp tag_subquery_gen do
+    bind({tag_gen(), member_of([1, 2, 3])}, fn {tag, level} ->
+      case level do
+        1 ->
+          constant(
+            {"level_3_id IN (SELECT level_3_id FROM level_3_tags WHERE tag = '#{tag}')", false}
+          )
+
+        2 ->
+          constant(
+            {"level_3_id IN (SELECT id FROM level_3 WHERE level_2_id IN (SELECT level_2_id FROM level_2_tags WHERE tag = '#{tag}'))",
+             false}
+          )
+
+        3 ->
+          constant(
+            {"level_3_id IN (SELECT id FROM level_3 WHERE level_2_id IN (SELECT id FROM level_2 WHERE level_1_id IN (SELECT level_1_id FROM level_1_tags WHERE tag = '#{tag}')))",
+             false}
+          )
+      end
+    end)
+  end
+
+  # ============================================================================
+  # NOT Subquery Generators
+  # ============================================================================
+
+  defp not_in_subquery_gen do
+    one_of([
+      # NOT IN with active flag
+      bool_gen()
+      |> map(fn active ->
+        {"level_3_id NOT IN (SELECT id FROM level_3 WHERE active = #{active})", false}
+      end),
+      # NOT IN with level_2_id
+      level_2_id_gen()
+      |> map(fn l2_id ->
+        {"level_3_id NOT IN (SELECT id FROM level_3 WHERE level_2_id = '#{l2_id}')", false}
+      end)
+    ])
+  end
+
+  # ============================================================================
+  # Composition Generators
+  # ============================================================================
+
+  # AND composition: expr AND expr
+  defp and_composition(depth) when depth <= 0, do: atomic_with_meta()
+
+  defp and_composition(depth) do
+    bind({base_expr_gen(depth - 1), base_expr_gen(depth - 1)}, fn
+      {{left, left_opt}, {right, right_opt}} ->
+        has_left_subquery = contains_subquery?(left)
+        has_right_subquery = contains_subquery?(right)
+
+        # AND with multiple subqueries at same level is NOT optimized
+        optimized = left_opt and right_opt and not (has_left_subquery and has_right_subquery)
+        constant({"(#{left}) AND (#{right})", optimized})
+    end)
+  end
+
+  # OR composition: expr OR expr
+  defp or_composition(depth) when depth <= 0, do: atomic_with_meta()
+
+  defp or_composition(depth) do
+    bind({base_expr_gen(depth - 1), base_expr_gen(depth - 1)}, fn
+      {{left, left_opt}, {right, right_opt}} ->
+        # OR with subqueries is typically not optimized
+        optimized =
+          left_opt and right_opt and not contains_subquery?(left) and
+            not contains_subquery?(right)
+
+        constant({"(#{left}) OR (#{right})", optimized})
+    end)
+  end
+
+  # Complex mixed compositions
+  defp complex_composition(depth) when depth <= 0, do: atomic_with_meta()
+
+  defp complex_composition(depth) do
+    frequency([
+      # (a OR b) AND c
+      {2, and_or_composition(depth)},
+      # NOT (condition)
+      {1, not_composition(depth)},
+      # a OR b OR c (multiple ORs)
+      {1, multi_or_composition(depth)},
+      # Subquery OR simple condition
+      {2, subquery_or_simple(depth)}
+    ])
+  end
+
+  defp and_or_composition(depth) do
+    bind({or_composition(depth - 1), base_expr_gen(depth - 1)}, fn
+      {{or_expr, or_opt}, {simple, simple_opt}} ->
+        optimized = or_opt and simple_opt
+        constant({"(#{or_expr}) AND (#{simple})", optimized})
+    end)
+  end
+
+  defp not_composition(_depth) do
+    one_of([
+      # NOT (simple condition)
+      atomic_with_meta() |> map(fn {expr, _} -> {"NOT (#{expr})", false} end),
+      # NOT IN subquery
+      not_in_subquery_gen()
+    ])
+  end
+
+  defp multi_or_composition(depth) do
+    bind(list_of(base_expr_gen(depth - 1), min_length: 2, max_length: 3), fn exprs ->
+      clauses = Enum.map(exprs, fn {expr, _} -> "(#{expr})" end)
+      combined = Enum.join(clauses, " OR ")
+      # Multi-OR is generally not optimized
+      constant({combined, false})
+    end)
+  end
+
+  defp subquery_or_simple(_depth) do
+    bind({subquery_1_level_gen(), atomic_with_meta()}, fn
+      {{subq, _}, {simple, _}} ->
+        # OR with subquery is not optimized
+        constant({"(#{subq}) OR (#{simple})", false})
+    end)
+  end
+
+  # Base expression generator for compositions
+  defp base_expr_gen(depth) when depth <= 0 do
+    frequency([
+      {3, atomic_with_meta()},
+      {1, subquery_1_level_gen()}
+    ])
+  end
+
+  defp base_expr_gen(depth) do
+    frequency([
+      {4, atomic_with_meta()},
+      {2, subquery_with_meta()},
+      {1, and_composition(depth - 1)},
+      {1, or_composition(depth - 1)}
+    ])
+  end
+
+  # Helper to detect if expression contains a subquery
+  defp contains_subquery?(expr), do: String.contains?(expr, "SELECT")
+end

--- a/packages/sync-service/test/support/oracle_harness/where_clause_generator.ex
+++ b/packages/sync-service/test/support/oracle_harness/where_clause_generator.ex
@@ -44,22 +44,26 @@ defmodule Support.OracleHarness.WhereClauseGenerator do
   end
 
   @doc """
-  Generates a list of shape specs using StreamData.
+  Returns a StreamData generator that produces a list of shape spec maps.
 
-  Uses the provided seed for deterministic generation.
-  Returns list of maps with :where and :optimized keys.
+  Each shape has :name, :table, :where, :columns, :pk, and :optimized keys.
+  Designed to be consumed directly by `check all` for deterministic seeding.
   """
-  def generate_where_clauses(count, seed) do
-    # Seed the process dictionary so StreamData's Enum.take uses deterministic randomness
-    :rand.seed(:exsss, seed)
-
-    where_clause_gen()
-    |> Enum.take(count * 3)
-    |> Enum.uniq_by(fn {where, _optimized} -> where end)
-    |> Enum.take(count)
-    |> Enum.shuffle()
-    |> Enum.map(fn {where, optimized} ->
-      %{where: where, optimized: optimized}
+  def shapes_gen(count) do
+    list_of(where_clause_gen(), length: count)
+    |> map(fn clauses ->
+      clauses
+      |> Enum.with_index(1)
+      |> Enum.map(fn {{where, _optimized}, idx} ->
+        %{
+          name: "shape_#{idx}",
+          table: "level_4",
+          where: where,
+          columns: ["id", "level_3_id", "value"],
+          pk: ["id"],
+          optimized: false
+        }
+      end)
     end)
   end
 

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -5,7 +5,7 @@
 # Registry.start_link(name: Electric.Application.process_registry(), keys: :unique)
 
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
-ExUnit.start(assert_receive_timeout: 400, exclude: [:slow], capture_log: true)
+ExUnit.start(assert_receive_timeout: 400, exclude: [:slow, :oracle], capture_log: true)
 
 # Start electric_client application directly, bypassing OTP's dependency resolution.
 # This avoids a circular dependency: electric_client has :electric as an optional dep,


### PR DESCRIPTION
## Summary

This PR implements [RFC "Arbitrary Boolean Expressions with Subqueries"](https://github.com/electric-sql/electric/pull/3776) which extends Electric's subquery support from single `IN (SELECT ...)` conditions to arbitrary boolean expressions with OR, NOT, and multiple subqueries.

### What's Changed
- **OR with multiple subqueries**: `WHERE project_id IN (SELECT ...) OR assigned_to IN (SELECT ...)`
- **NOT with subqueries**: `WHERE project_id NOT IN (SELECT ...)`
- **Complex expressions**: `WHERE (a IN sq1 AND b='x') OR c NOT IN sq2`

### Key Implementation Details

1. **DNF Decomposer** (`lib/electric/replication/eval/decomposer.ex`)
   - Converts WHERE clause AST to Disjunctive Normal Form
   - Applies De Morgan's laws for NOT handling
   - Assigns positions to atomic conditions for tracking

2. **Active Conditions** (`lib/electric/shapes/where_clause.ex`)
   - Computes `active_conditions` array indicating which atomic conditions are satisfied
   - Evaluates DNF against active conditions to determine inclusion
   - Used for both replication stream changes and initial snapshots

3. **Move-in/Move-out Handling** (`lib/electric/shapes/consumer/move_handling.ex`)
   - Position-based move-in/move-out with correct NOT inversion
   - Move-in to negated position triggers move-out
   - Move-out from negated position triggers move-in query
   - Deduplication logic prevents duplicate inserts for rows matching multiple disjuncts

4. **Message Format** (`lib/electric/log_items.ex`, `lib/electric/shapes/querying.ex`)
   - `active_conditions` array included in row message headers
   - SQL generation for initial snapshots includes `active_conditions`
   - Updated elixir-client to parse `active_conditions` field

## Test plan

- [x] All 1389 existing tests pass
- [x] 21 new integration tests for OR/NOT with subqueries (`test/electric/plug/subquery_router_test.exs`)
- [x] DNF decomposer tests (`test/electric/replication/eval/decomposer_test.exs`)
- [x] WhereClause tests for active conditions (`test/electric/shapes/where_clause_test.exs`)
- [x] Updated router tests no longer expect 409 for OR/NOT shapes

### Test Coverage
- Initial snapshot with OR subqueries
- Move-in/move-out with OR subqueries
- NOT IN shapes with correct inversion
- Row matching both disjuncts (deduplication)
- Row removed when all disjuncts become false
- Complex De Morgan expressions

## Related

- RFC: `docs/rfcs/arbitrary-boolean-expressions-with-subqueries.md`
- Implementation Plan: `packages/sync-service/IMPLEMENTATION_PLAN.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)