### PR TITLE
Fix Materializer startup race condition via offset coordination

### DIFF
--- a/.changeset/fix-materializer-startup-race.md
+++ b/.changeset/fix-materializer-startup-race.md
@@ -1,0 +1,7 @@
+---
+'@core/sync-service': patch
+---
+
+Fix Materializer startup race condition that caused "Key already exists" crashes
+
+The Materializer subscribed to the Consumer before reading from storage, creating a window where the same record could be delivered twice (via storage AND via new_changes). Now the Consumer returns its current offset on subscription, and the Materializer reads storage only up to that offset.

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -54,7 +54,8 @@ defmodule Electric.Shapes.Consumer do
     |> GenServer.call(:await_snapshot_start, timeout)
   end
 
-  @spec subscribe_materializer(Electric.stack_id(), Electric.shape_handle(), pid()) :: :ok
+  @spec subscribe_materializer(Electric.stack_id(), Electric.shape_handle(), pid()) ::
+          {:ok, LogOffset.t()}
   def subscribe_materializer(stack_id, shape_handle, pid) do
     stack_id
     |> consumer_pid(shape_handle)
@@ -210,7 +211,9 @@ defmodule Electric.Shapes.Consumer do
   def handle_call({:subscribe_materializer, pid}, _from, state) do
     Logger.debug("Subscribing materializer for #{state.shape_handle}")
     Process.monitor(pid, tag: :materializer_down)
-    {:reply, :ok, %{state | materializer_subscribed?: true}, state.hibernate_after}
+
+    {:reply, {:ok, state.latest_offset}, %{state | materializer_subscribed?: true},
+     state.hibernate_after}
   end
 
   def handle_call({:stop, reason}, _from, state) do


### PR DESCRIPTION
## Summary

Fixes #3787 - addresses the snapshot/replication race condition in the Materializer that caused "Key already exists" crashes.

### The race condition

The Materializer subscribed to the Consumer **before** reading from storage:

```elixir
# BEFORE: In handle_continue(:start_materializer, ...)
Consumer.subscribe_materializer(stack_id, shape_handle, self())  # <- Subscribes first
{:noreply, state, {:continue, {:read_stream, shape_storage}}}    # <- Then reads ALL storage
```

During the window between subscribing and reading, any changes that arrive via `Consumer.new_changes()` would be delivered to the Materializer. If those changes included records that were also in the snapshot being read, the Materializer received duplicates and crashed.

### Production example (maxwell instance, 27 Jan 2026)

```
18:10:10.437 [error] GenServer Materializer "97489818-..." terminating
** (RuntimeError) Key "public"."offers"/"d3c8d8a5-5060-4a36-a67d-240de0c95a88" already exists
```

The transaction that triggered it:
```elixir
%Electric.Replication.Changes.NewRecord{
  relation: {"public", "offers"},
  record: %{"id" => "d3c8d8a5-5060-4a36-a67d-240de0c95a88"},
  key: "\"public\".\"offers\"/\"d3c8d8a5-5060-4a36-a67d-240de0c95a88\"",
  move_tags: ["e12422d3af57a36d01a50b4645a517e4"]  # <- Move-in event
}
```

The record was already in the snapshot (matched via `is_template = true` OR the subquery), AND was delivered via replication with `move_tags` as a move-in event.

### The fix

Consumer now returns its current offset when a Materializer subscribes. The Materializer reads storage **only up to that offset**, not beyond. Changes after that offset will be delivered via `new_changes` messages, ensuring each change is delivered exactly once.

```elixir
# AFTER: Consumer returns offset on subscription
def handle_call({:subscribe_materializer, pid}, _from, state) do
  {:reply, {:ok, state.latest_offset}, %{state | materializer_subscribed?: true}, ...}
end

# AFTER: Materializer uses offset to bound storage reads
{:ok, subscribed_offset} = Consumer.subscribe_materializer(stack_id, shape_handle, self())
{:noreply, %{state | subscribed_offset: subscribed_offset}, {:continue, {:read_stream, ...}}}

# In handle_continue({:read_stream, ...})
{:ok, offset, stream} = get_stream_up_to_offset(state.offset, state.subscribed_offset, storage)
```

## Test plan

- [x] Added test verifying offset coordination prevents duplicates
- [x] All existing Materializer tests pass (35 tests)
- [x] Full test suite passes (1334 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)