### PR TITLE
fix(sync-service): Prevent negative replication lag statistics

### DIFF
--- a/.changeset/wicked-cheetahs-talk.md
+++ b/.changeset/wicked-cheetahs-talk.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Handle server clockskew that presents as a -ve replication lag in statistics

--- a/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
@@ -215,10 +215,15 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
   end
 
   def convert(%LR.Commit{} = msg, %__MODULE__{txn_fragment: fragment} = state) do
+    now_mono = System.monotonic_time()
+    initial_lag = Commit.calculate_initial_receive_lag(msg.commit_timestamp, DateTime.utc_now())
+
     commit = %Commit{
       commit_timestamp: msg.commit_timestamp,
       transaction_size: state.tx_size,
-      txn_change_count: state.tx_change_count
+      txn_change_count: state.tx_change_count,
+      received_at_mono: now_mono,
+      initial_receive_lag: initial_lag
     }
 
     returned_txn_fragment =


### PR DESCRIPTION
Detect clock skew that presents as transaction commit timestamps being after the current system time and use the diff in the final replication lag calculation.

As noted this removes information but in the presence of detectable clock skew this information is unhelpful.

Clock skew make a mockery of our idea that the replication lag calculation in any way represents the actual time between a commit in pg and a write in electric. With this at least we get an end to end time for the processing of a transaction and can monitor trends.