### PR TITLE
Fix bug where changes were incorrectly skipped due to move-in coverage

### DIFF
--- a/.changeset/fix-move-in-coverage-check.md
+++ b/.changeset/fix-move-in-coverage-check.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/sync-service": patch
+---
+
+Fixed a bug where changes were incorrectly skipped when a record's subquery reference value was in a pending move-in, but the record didn't match other non-subquery conditions in the WHERE clause. For example, with a shape `parent_id IN (SELECT ...) AND status = 'published'`, if the parent became active (triggering a move-in) but the child had `status = 'draft'`, the change would incorrectly be skipped instead of being processed as a delete.

--- a/packages/sync-service/test/electric/shapes/consumer/change_handling_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/change_handling_test.exs
@@ -153,4 +153,180 @@ defmodule Electric.Shapes.Consumer.ChangeHandlingTest do
       assert state.move_handling_state.touch_tracker == %{key => 970}
     end
   end
+
+  describe "process_changes/3 with subquery combined with other conditions" do
+    # Tests for shapes that have a subquery ANDed with other non-subquery conditions.
+    # The bug occurred when a change's sublink value was in a pending move-in, but
+    # the record didn't match other parts of the WHERE clause. The old code would
+    # incorrectly skip the change, assuming the move-in would cover it.
+    #
+    # Example: "parent_id IN (SELECT id FROM parents WHERE active) AND status = 'published'"
+    # If parent becomes active (triggers move-in), but record has status='draft',
+    # the change should NOT be skipped because the move-in won't return this row.
+
+    @parents_inspector Support.StubInspector.new(
+                         tables: ["parents", "children"],
+                         columns: [
+                           %{name: "id", type: "int8", pk_position: 0, type_id: {20, 1}},
+                           %{name: "parent_id", type: "int8", pk_position: nil, type_id: {20, 1}},
+                           %{name: "status", type: "text", pk_position: nil, type_id: {28, 1}},
+                           %{name: "active", type: "bool", pk_position: nil, type_id: {16, 1}}
+                         ]
+                       )
+
+    setup [:with_stack_id_from_test]
+
+    setup %{stack_id: stack_id} do
+      # Create a shape with a subquery AND a simple equality condition:
+      # parent must be active AND child must be published
+      shape =
+        Shape.new!(
+          "children",
+          where:
+            "parent_id IN (SELECT id FROM parents WHERE active = true) AND status = 'published'",
+          inspector: @parents_inspector
+        )
+
+      state = State.new(stack_id, "test-handle", shape)
+      %{state: state, shape: shape}
+    end
+
+    test "processes change when sublink is in move-in but record fails other WHERE conditions", %{
+      state: state
+    } do
+      # This tests the fix: parent_id=3 enters a move-in (parent became active),
+      # but the child has status='draft', so the change should NOT be skipped.
+      # The move-in query uses the full WHERE clause, so it won't return this row.
+
+      # Set up move-in state: parent_id=3 just became active (triggers move-in)
+      move_handling_state =
+        MoveIns.new()
+        |> MoveIns.add_waiting(
+          "move-in-for-parent-3",
+          {["$sublink", "0"], MapSet.new([3])}
+        )
+
+      state = %{state | move_handling_state: move_handling_state}
+
+      # A record moving FROM parent_id=1 (in shape) TO parent_id=3 (active but status=draft)
+      # Old record: parent_id=1 active, status=published -> in shape
+      # New record: parent_id=3 active, status=draft -> NOT in shape (fails status check)
+      # This should result in a DELETE, not be skipped
+      change = %UpdatedRecord{
+        relation: {"public", "children"},
+        old_record: %{"id" => "100", "parent_id" => "1", "status" => "published"},
+        record: %{"id" => "100", "parent_id" => "3", "status" => "draft"},
+        log_offset: LogOffset.new(12345, 0),
+        key: "\"public\".\"children\"/\"100\"",
+        changed_columns: MapSet.new(["parent_id", "status"])
+      }
+
+      # extra_refs: old has parent 1 active, new has parent 3 active
+      ctx = %{
+        xid: 962,
+        extra_refs:
+          {%{["$sublink", "0"] => MapSet.new([1])}, %{["$sublink", "0"] => MapSet.new([1, 3])}}
+      }
+
+      result = ChangeHandling.process_changes([change], state, ctx)
+      {filtered_changes, _state, count, _offset} = result
+
+      # The change should NOT be skipped - it should be processed as a delete
+      # because the new record doesn't match status = 'published'
+      assert count == 1
+      assert length(filtered_changes) == 1
+
+      [processed_change] = filtered_changes
+      # Should be converted to a delete since old was in shape, new is not
+      assert %Electric.Replication.Changes.DeletedRecord{} = processed_change
+      assert processed_change.old_record["id"] == "100"
+    end
+
+    test "skips change when value is in move-in AND matches full WHERE clause", %{state: state} do
+      # When parent_id=2 enters a move-in AND the record has status='published',
+      # the change should be skipped (covered by move-in query)
+
+      # Set up move-in state: parent_id=2 just became active (triggers move-in)
+      move_handling_state =
+        MoveIns.new()
+        |> MoveIns.add_waiting(
+          "move-in-for-parent-2",
+          {["$sublink", "0"], MapSet.new([2])}
+        )
+
+      state = %{state | move_handling_state: move_handling_state}
+
+      # A record with parent_id=2 and status=published being updated
+      # Both subquery (parent active) and status condition are satisfied
+      # This change should be skipped because the move-in will handle it
+      change = %UpdatedRecord{
+        relation: {"public", "children"},
+        old_record: %{"id" => "100", "parent_id" => "2", "status" => "published"},
+        record: %{"id" => "100", "parent_id" => "2", "status" => "published"},
+        log_offset: LogOffset.new(12345, 0),
+        key: "\"public\".\"children\"/\"100\"",
+        changed_columns: MapSet.new([])
+      }
+
+      # extra_refs: parent 2 is now active (in new refs)
+      ctx = %{
+        xid: 962,
+        extra_refs:
+          {%{["$sublink", "0"] => MapSet.new([1])}, %{["$sublink", "0"] => MapSet.new([1, 2])}}
+      }
+
+      result = ChangeHandling.process_changes([change], state, ctx)
+      {filtered_changes, _state, count, _offset} = result
+
+      # The change should be skipped because:
+      # 1. parent_id=2 is in the pending move-in
+      # 2. status='published' satisfies the other WHERE condition
+      # 3. The move-in query will return this row
+      assert filtered_changes == []
+      assert count == 0
+    end
+
+    test "processes delete when record fails non-subquery condition even with active move-in", %{
+      state: state
+    } do
+      # When a record changes from status='published' to status='draft',
+      # even if the parent is in a pending move-in, we should delete
+      # because the status condition fails.
+
+      move_handling_state =
+        MoveIns.new()
+        |> MoveIns.add_waiting(
+          "move-in-for-parent-1",
+          {["$sublink", "0"], MapSet.new([1])}
+        )
+        |> MoveIns.set_snapshot("move-in-for-parent-1", {963, 963, []})
+
+      state = %{state | move_handling_state: move_handling_state}
+
+      # Record changes status from published (in shape) to draft (not in shape)
+      change = %UpdatedRecord{
+        relation: {"public", "children"},
+        old_record: %{"id" => "200", "parent_id" => "1", "status" => "published"},
+        record: %{"id" => "200", "parent_id" => "1", "status" => "draft"},
+        log_offset: LogOffset.new(12346, 0),
+        key: "\"public\".\"children\"/\"200\"",
+        changed_columns: MapSet.new(["status"])
+      }
+
+      # xid 962 is visible in snapshot {963, 963, []}
+      ctx = %{
+        xid: 962,
+        extra_refs:
+          {%{["$sublink", "0"] => MapSet.new([1])}, %{["$sublink", "0"] => MapSet.new([1])}}
+      }
+
+      result = ChangeHandling.process_changes([change], state, ctx)
+      {filtered_changes, _state, count, _offset} = result
+
+      # Should produce a delete, not be skipped
+      assert count == 1
+      assert [%Electric.Replication.Changes.DeletedRecord{} = delete] = filtered_changes
+      assert delete.old_record["id"] == "200"
+    end
+  end
 end

--- a/packages/sync-service/test/integration/subquery_dependency_update_test.exs
+++ b/packages/sync-service/test/integration/subquery_dependency_update_test.exs
@@ -165,6 +165,139 @@ defmodule Electric.Integration.SubqueryDependencyUpdateTest do
     end
   end
 
+  describe "subquery combined with other conditions" do
+    # Tests for shapes that have a subquery ANDed with other non-subquery conditions.
+    # The bug occurred when a change's sublink value was in a pending move-in, but
+    # the record didn't match other parts of the WHERE clause. The old code would
+    # incorrectly skip the change, assuming the move-in would cover it.
+
+    setup [:with_unique_db, :with_simple_parent_child_tables, :with_sql_execute]
+    setup :with_complete_stack
+    setup :with_electric_client
+
+    # Shape: children of active parents, but only if child is published
+    # This combines a subquery with a simple column condition using AND
+    @active_parents_published_children_where """
+    parent_id IN (SELECT id FROM parents WHERE active = true) AND status = 'published'
+    """
+
+    @tag with_sql: [
+           # Two parents: parent-a (active), parent-b (initially inactive)
+           "INSERT INTO parents (id, name, active) VALUES ('parent-a', 'Parent A', true), ('parent-b', 'Parent B', false)",
+           # A published child in parent-a (active) - in shape
+           "INSERT INTO children (id, name, parent_id, status) VALUES ('child-1', 'Child One', 'parent-a', 'published')"
+         ]
+    test "child is deleted when moved to parent that satisfies subquery but child status fails",
+         ctx do
+      # SETUP:
+      #   child-1 -> parent-a (ACTIVE), status=published -> in shape
+      #   parent-b is NOT active
+      #   Shape requires: parent is active AND status = 'published'
+      #
+      # In a SINGLE TRANSACTION we:
+      #   1. Make parent-b active (triggers move-in for parent-b)
+      #   2. Move child-1 to parent-b AND change status to 'draft'
+      #
+      # After the transaction:
+      #   - parent-b IS now active (satisfies subquery)
+      #   - But child-1 has status='draft' (fails the other condition)
+      #   - child-1 should be DELETED from the shape (not covered by the move-in)
+
+      shape = ShapeDefinition.new!("children", where: @active_parents_published_children_where)
+      stream = Client.stream(ctx.client, shape, live: true)
+
+      with_consumer stream do
+        # Verify child-1 is in the shape initially
+        assert_insert(consumer, %{"id" => "child-1", "name" => "Child One"})
+        assert_up_to_date(consumer)
+
+        # In a single transaction:
+        # 1. Make parent-b active (triggers a move-in)
+        # 2. Move child-1 to parent-b and change status to draft
+        Postgrex.transaction(ctx.db_conn, fn conn ->
+          Postgrex.query!(conn, "UPDATE parents SET active = true WHERE id = 'parent-b'", [])
+
+          Postgrex.query!(
+            conn,
+            "UPDATE children SET parent_id = 'parent-b', status = 'draft' WHERE id = 'child-1'",
+            []
+          )
+        end)
+
+        # child-1 should be deleted because status='draft' fails the WHERE clause,
+        # even though parent-b became active in the same transaction
+        assert_delete(consumer, %{"id" => "child-1"})
+      end
+    end
+
+    @tag with_sql: [
+           # Two parents: parent-a (active), parent-b (initially inactive)
+           "INSERT INTO parents (id, name, active) VALUES ('parent-a', 'Parent A', true), ('parent-b', 'Parent B', false)",
+           # A published child in parent-b (inactive) - NOT in shape
+           "INSERT INTO children (id, name, parent_id, status) VALUES ('child-1', 'Child One', 'parent-b', 'published')"
+         ]
+    test "child moves into shape when parent becomes active and child satisfies other conditions",
+         ctx do
+      # SETUP:
+      #   child-1 -> parent-b (NOT active), status=published -> NOT in shape
+      #   Shape requires: parent is active AND status = 'published'
+      #
+      # When parent-b becomes active:
+      #   - parent-b IS now active (satisfies subquery)
+      #   - child-1 has status='published' (satisfies other condition)
+      #   - Both conditions satisfied, child-1 should be INSERTED into shape
+
+      shape = ShapeDefinition.new!("children", where: @active_parents_published_children_where)
+      stream = Client.stream(ctx.client, shape, live: true)
+
+      with_consumer stream do
+        # Initially no children in the shape (parent-b is not active)
+        assert_up_to_date(consumer)
+
+        # Make parent-b active
+        Postgrex.query!(
+          ctx.db_conn,
+          "UPDATE parents SET active = true WHERE id = 'parent-b'",
+          []
+        )
+
+        # child-1 should now appear in the shape (both conditions now satisfied)
+        assert_insert(consumer, %{"id" => "child-1", "name" => "Child One"})
+      end
+    end
+  end
+
+  # ---- Simple Parent/Child Schema for 1-level subquery tests ----
+
+  def with_simple_parent_child_tables(%{db_conn: conn} = _context) do
+    Postgrex.query!(
+      conn,
+      """
+        CREATE TABLE parents (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          active BOOLEAN NOT NULL DEFAULT false
+        )
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      """
+        CREATE TABLE children (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          parent_id TEXT NOT NULL REFERENCES parents(id) ON DELETE CASCADE,
+          status TEXT NOT NULL DEFAULT 'draft'
+        )
+      """,
+      []
+    )
+
+    %{tables: [{"public", "parents"}, {"public", "children"}]}
+  end
+
   # ---- Helpers ----
 
   defp filter_deletes(messages) do


### PR DESCRIPTION
## Summary

Fixed a bug where changes were incorrectly skipped when a record's subquery reference value was in a pending move-in, but the record didn't match other non-subquery conditions in the WHERE clause.

## Problem

When a shape has a subquery combined with other conditions in its WHERE clause (e.g., `parent_id IN (SELECT ...) AND status = 'published'`), changes could be incorrectly skipped if the sublink value was in a pending move-in, even when the new record didn't match other parts of the WHERE clause.

For example:
- Shape: `parent_id IN (SELECT id FROM parents WHERE active) AND status = 'published'`
- Parent becomes active (triggers move-in)
- In the same transaction, a child moves to that parent AND changes `status` to `'draft'`
- **Bug**: The change was skipped because the parent_id was in the pending move-in
- **Expected**: The change should produce a DELETE because `status = 'draft'` fails the WHERE clause

## Solution

Added a check in `change_will_be_covered_by_move_in?/3` to verify the new record actually matches the full WHERE clause before deciding to skip a change based on move-in coverage. The move-in query uses the full WHERE clause, so if the record doesn't match non-subquery conditions, the move-in won't return that row and we need to process the change normally.

## Test Plan

- [x] Added unit tests in `change_handling_test.exs` covering the fix
- [x] Added integration tests in `subquery_dependency_update_test.exs` with end-to-end scenarios
- [x] All existing tests pass

---
Generated with [Claude Code](https://claude.com/claude-code)