### PR TITLE
Log accessible tables on Electric connection startup

### DIFF
--- a/.changeset/log-accessible-tables.md
+++ b/.changeset/log-accessible-tables.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Log all tables accessible to Electric at startup. This helps operators understand which tables the connected database user has SELECT permission on and aids in debugging permission issues.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -1251,7 +1251,9 @@ defmodule Electric.Connection.Manager do
            Configuration.list_accessible_tables!(pool)
          end) do
       {:error, reason} ->
-        Logger.warning("Failed to list accessible tables for stack #{state.stack_id}: #{inspect(reason)}")
+        Logger.warning(
+          "Failed to list accessible tables for stack #{state.stack_id}: #{inspect(reason)}"
+        )
 
       tables when is_list(tables) ->
         table_names = Enum.map(tables, &Electric.Utils.relation_to_sql/1)


### PR DESCRIPTION
## Summary
Add logging of all tables accessible to Electric when the connection manager initializes. This helps operators understand which tables the connected database user has SELECT permission on.

## Changes
- **Configuration module**: Added `list_accessible_tables!/1` function that queries PostgreSQL for all ordinary and partitioned tables (excluding system schemas) that the connected user has SELECT permission on
- **Connection manager**: Added `log_accessible_tables/1` function that retrieves and logs the list of accessible tables during connection setup, with error handling for database connection issues
- Logs are emitted at INFO level on success and WARNING level if the query fails

## Implementation Details
- The SQL query uses `has_table_privilege()` to check SELECT permissions, ensuring only truly accessible tables are reported
- System schemas (`pg_catalog`, `information_schema`) are excluded from results
- Results are sorted by schema and table name for consistent output
- Database connection errors are handled gracefully without blocking connection initialization
- The logging occurs after connection setup but before replication supervisor initialization

https://claude.ai/code/session_012BtysQooC3gKQrgpj4KbGk