### PR TITLE
chore: Remove outdated CubDB references from comments

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -1104,7 +1104,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
 
       {nil, _offset} ->
         # Try streaming the next chunk if the file already exists, otherwise wait for the file or end of snapshot to be announced
-        # where either event should happen shortly, we just either hit a file switch or just before CubDB was updatred
+        # where either event should happen shortly, we just either hit a file switch or just before the storage was updated
         wait_for_chunk_file_or_snapshot_end(opts, op_offset + 1)
 
       {%LogOffset{}, offset} ->

--- a/packages/sync-service/test/electric/concurrent_stream_test.exs
+++ b/packages/sync-service/test/electric/concurrent_stream_test.exs
@@ -12,7 +12,7 @@ defmodule Electric.ConcurrentStreamTest do
       {:ok, %{table: table}}
     end
 
-    test "returns complete stream from CubDB when it's being written to concurrently", %{
+    test "returns complete stream when it's being written to concurrently", %{
       table: table
     } do
       stream =

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1025,10 +1025,8 @@ defmodule Electric.ShapeCacheTest do
 
       {^shape_handle, ^offset} = ShapeCache.get_or_create_shape_handle(@shape, ctx.stack_id)
 
-      # without this sleep, this test becomes unreliable. I think maybe due to
-      # delays in actually writing the data to cubdb/fsyncing the tx. I've
-      # tried explicit `CubDb.file_sync/1` calls but it doesn't work, the only
-      # reliable method is to wait just a little bit...
+      # without this sleep, this test becomes unreliable due to
+      # delays in persisting data to storage.
       Process.sleep(10)
 
       restart_shape_cache(ctx)


### PR DESCRIPTION
## Summary

- Removes outdated CubDB references from code comments after CubDB was removed from the codebase (commits 17132f5, 19e267b)
- Updates comments in `pure_file_storage.ex`, `shape_cache_test.exs`, and `concurrent_stream_test.exs` to be storage-agnostic
- Also fixes a typo ("updatred" → "updated")