### PR TITLE
Fix sublink tag not updated when dedup skips UpdatedRecord during move-in

### DIFF
--- a/.changeset/fix-sublink-tag-update.md
+++ b/.changeset/fix-sublink-tag-update.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fixed a bug where rows with subquery-based WHERE clauses could retain stale move tags when the sublink column value changed during a pending move-in, causing the row to not be properly removed on subsequent move-outs.

--- a/packages/sync-service/lib/electric/shapes/consumer/change_handling.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/change_handling.ex
@@ -86,23 +86,44 @@ defmodule Electric.Shapes.Consumer.ChangeHandling do
     referenced_values = get_referenced_values(change, state)
 
     if change_visible_in_unresolved_move_ins_for_values?(referenced_values, state, ctx) do
-      # Even if the sublink value is in a pending move-in, we should only skip
-      # this change if the new record actually matches the full WHERE clause.
-      # The move-in query uses the full WHERE clause, so if the record doesn't
-      # match other non-subquery conditions in the WHERE clause, the move-in
-      # won't return this row and we need to process this change normally.
-      case ctx.extra_refs do
-        {_extra_refs_old, extra_refs_new} ->
-          WhereClause.includes_record?(state.shape.where, change.record, extra_refs_new)
+      # For UpdatedRecords where the sublink value changed, we must NOT skip the change.
+      # The move-in query will return this row as an INSERT, which doesn't carry
+      # removed_move_tags. Without the tag transition from the WAL change, the client
+      # will retain the old tag, causing the row to not be properly cleaned up on
+      # subsequent move-outs.
+      if is_struct(change, Changes.UpdatedRecord) and
+           sublink_value_changed?(change, state) do
+        false
+      else
+        # Even if the sublink value is in a pending move-in, we should only skip
+        # this change if the new record actually matches the full WHERE clause.
+        # The move-in query uses the full WHERE clause, so if the record doesn't
+        # match other non-subquery conditions in the WHERE clause, the move-in
+        # won't return this row and we need to process this change normally.
+        case ctx.extra_refs do
+          {_extra_refs_old, extra_refs_new} ->
+            WhereClause.includes_record?(state.shape.where, change.record, extra_refs_new)
 
-        _ ->
-          # If extra_refs is not a tuple (e.g., empty map in tests), fall back to
-          # the old behavior of skipping the change
-          true
+          _ ->
+            # If extra_refs is not a tuple (e.g., empty map in tests), fall back to
+            # the old behavior of skipping the change
+            true
+        end
       end
     else
       false
     end
+  end
+
+  defp sublink_value_changed?(
+         %Changes.UpdatedRecord{record: new_record, old_record: old_record},
+         state
+       ) do
+    Enum.any?(state.shape.subquery_comparison_expressions, fn {_path, expr} ->
+      {:ok, new_value} = Runner.execute_for_record(expr, new_record)
+      {:ok, old_value} = Runner.execute_for_record(expr, old_record)
+      new_value != old_value
+    end)
   end
 
   defp get_referenced_values(change, state) do


### PR DESCRIPTION
## Summary

When a row's sublink column value changes while a move-in query is pending for the new value, the dedup check in `change_will_be_covered_by_move_in?` was incorrectly skipping the `UpdatedRecord`. The move-in query returns the row as an INSERT — which doesn't carry `removed_move_tags` — so the client never removed the old tag. On a subsequent move-out for the new value, the row wasn't deleted because it still had the stale old tag.

## Problem

1. Row exists in shape with `sublink_value=A`, tagged `hash(A)`
2. Value `B` enters dependency shape → pending move-in for `B`
3. WAL transaction updates the row's sublink from `A` to `B`
4. Dedup check sees `B` in pending move-in → **skips the change entirely**
5. Move-in query returns the row as INSERT with `tags=[hash(B)]`, no `removed_move_tags`
6. Client adds `hash(B)` but never removes `hash(A)` — row now has **both** tags
7. Later move-out for `B` removes `hash(B)` → row still has `hash(A)` → **not deleted**

## Solution

In `change_will_be_covered_by_move_in?`, check whether the sublink value actually changed in an `UpdatedRecord`. If it did, the change must not be skipped because the move-in cannot provide the tag transition (`removed_move_tags`) that the WAL change carries.

## Test Plan

- [x] Unit tests for both cases: sublink value changed (must not skip) and unchanged (still skips)
- [x] Oracle property tests pass with seeds that previously reproduced the failure

---
Generated with [Claude Code](https://claude.com/claude-code)