### PR TITLE
fix: metrics from consumer

### DIFF
--- a/.changeset/fast-ducks-sip.md
+++ b/.changeset/fast-ducks-sip.md
@@ -1,0 +1,6 @@
+---
+'@core/electric-telemetry': patch
+'@core/sync-service': patch
+---
+
+fix: metrics from consumer seem to not be emitted because of a struct

--- a/integration-tests/tests/stack-telemetry.lux
+++ b/integration-tests/tests/stack-telemetry.lux
@@ -61,7 +61,37 @@
   Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
   Value: [-+.0-9]+
   """
+[invoke start_psql]
 
+[shell psql]
+  !create table items (val text);
+  ??CREATE
+
+[shell client]
+  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&offset=-1"]
+
+  ??HTTP/1.1 200 OK
+  ?electric-handle: ([\d-]+)
+  [global handle=$1]
+  ?electric-offset: ([\w\d_]+)
+  [global offset=$1]
+
+[shell psql]
+  !insert into items values ('3');
+  ??INSERT
+
+[shell client]
+  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&live"]
+
+  ??HTTP/1.1 200 OK
+  ??"value":{"val":"3"}
+
+[shell otel_collector]
+  """?
+  Metric #[0-9]+
+  Descriptor:
+       -> Name: electric\.storage\.transaction_stored\.bytes
+  """
 ###
 
 [cleanup]

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -98,8 +98,8 @@ defmodule ElectricTelemetry.StackTelemetry do
       ),
       last_value("electric.connection.consumers_ready.total"),
       last_value("electric.connection.consumers_ready.failed_to_recover"),
-      last_value("electric.admission_control.acquire.current"),
-      sum("electric.admission_control.reject.count")
+      last_value("electric.admission_control.acquire.current", tags: [:kind]),
+      sum("electric.admission_control.reject.count", tags: [:kind])
       | additional_metrics(telemetry_opts)
     ]
     |> ElectricTelemetry.keep_for_stack(telemetry_opts.stack_id)

--- a/packages/sync-service/lib/electric/postgres/snapshot_query.ex
+++ b/packages/sync-service/lib/electric/postgres/snapshot_query.ex
@@ -82,7 +82,7 @@ defmodule Electric.Postgres.SnapshotQuery do
     [
       "shape.handle": shape_handle,
       "shape.root_table": shape.root_table,
-      "shape.where": shape.where
+      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil)
     ]
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -484,8 +484,7 @@ defmodule Electric.Shapes.Consumer do
 
   defp handle_txn_in_span(txn, %State{} = state) do
     ot_attrs =
-      [xid: txn.xid, total_num_changes: txn.num_changes] ++
-        shape_attrs(state.shape_handle, state.shape)
+      [xid: txn.xid, total_num_changes: txn.num_changes] ++ State.telemetry_attrs(state)
 
     OpenTelemetry.with_child_span(
       "shape_write.consumer.handle_txn",
@@ -577,7 +576,7 @@ defmodule Electric.Shapes.Consumer do
             operations: num_changes,
             replication_lag: lag
           },
-          Map.new(shape_attrs(state.shape_handle, state.shape))
+          Map.new(State.telemetry_attrs(state))
         )
 
         {:cont,
@@ -666,14 +665,6 @@ defmodule Electric.Shapes.Consumer do
       line_tuple = {offset, key, operation, json_line}
       {line_tuple, total_size + byte_size(json_line)}
     end)
-  end
-
-  defp shape_attrs(shape_handle, shape) do
-    [
-      "shape.handle": shape_handle,
-      "shape.root_table": shape.root_table,
-      "shape.where": shape.where
-    ]
   end
 
   defp calculate_replication_lag(%Transaction{commit_timestamp: nil}) do

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -273,7 +273,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
     [
       "shape.handle": shape_handle,
       "shape.root_table": shape.root_table,
-      "shape.where": shape.where
+      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil)
     ]
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -331,4 +331,13 @@ defmodule Electric.Shapes.Consumer.State do
       ) do
     %{state | move_handling_state: MoveIns.remove_completed(move_handling_state, xid)}
   end
+
+  def telemetry_attrs(%__MODULE__{stack_id: stack_id, shape_handle: shape_handle, shape: shape}) do
+    [
+      "shape.handle": shape_handle,
+      "shape.root_table": shape.root_table,
+      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil),
+      stack_id: stack_id
+    ]
+  end
 end


### PR DESCRIPTION
the `electric.storage.transaction_stored` metric is not being reported because it was missing a stack id. I've added a test to check that it's indeed exported