### PR TITLE
Add Sentry error tracking documentation

### DIFF
--- a/website/docs/api/config.md
+++ b/website/docs/api/config.md
@@ -478,6 +478,19 @@ Enable sending telemetry data to a StatsD reporting endpoint.
 
 </EnvVarConfig>
 
+### SENTRY_DSN
+
+<EnvVarConfig
+    name="SENTRY_DSN"
+    optional="true"
+    example="https://key@o0.ingest.sentry.io/0">
+
+Set a [Sentry](https://sentry.io) DSN to enable error tracking via the Sentry Elixir SDK. When configured, Electric will automatically capture errors and report them to your Sentry project.
+
+This requires Electric to be built with telemetry enabled (which is the case for the official Docker images).
+
+</EnvVarConfig>
+
 ## Logging
 
 ### ELECTRIC_LOG_LEVEL

--- a/website/docs/reference/telemetry.md
+++ b/website/docs/reference/telemetry.md
@@ -47,6 +47,26 @@ Attributes `service_name` and `instance_id` can be overridden with `ELECTRIC_SER
 
 Electric will also load additional resource attributes from `OTEL_RESOURCE_ATTRIBUTES`. Learn more about resource attributes in the [OpenTelemetry documentation](https://opentelemetry.io/docs/languages/js/resources/).
 
+## Sentry
+
+Electric includes built-in support for [Sentry](https://sentry.io) error tracking. When enabled, errors are automatically captured and reported to your Sentry project, including source code context in stack traces.
+
+To enable Sentry, set the `SENTRY_DSN` environment variable to your Sentry project's DSN:
+
+| VARIABLE   | Type     | Description                            |
+| ---------- | -------- | -------------------------------------- |
+| SENTRY_DSN | `string` | DSN for your Sentry project (optional) |
+
+When configured, Electric will:
+
+- Capture all error-level log messages and report them to Sentry
+- Include source code context in stack traces for easier debugging
+- Tag errors with stack context for multi-tenant debugging
+
+:::info
+Sentry support requires Electric to be built with telemetry enabled. The official Docker images (`electricsql/electric`) include telemetry by default.
+:::
+
 ## Example
 
 You can find an example of a docker compose that runs Electric with an OpenTelemetry Collector agent that sends telemetry data to Honeycomb under `packages/sync-service/dev`.


### PR DESCRIPTION
## Summary
This PR adds documentation for Electric's built-in Sentry integration, enabling users to configure error tracking and reporting to their Sentry projects.

## Changes
- **telemetry.md**: Added new "Sentry" section documenting:
  - Overview of Sentry error tracking capabilities
  - Configuration via `SENTRY_DSN` environment variable
  - Features including automatic error capture, source code context in stack traces, and error tagging
  - Note about telemetry requirement for Sentry support

- **config.md**: Added `SENTRY_DSN` configuration reference documenting:
  - Environment variable name and type
  - Example DSN format
  - Description of functionality and telemetry dependency

## Notable Details
- Documentation clarifies that Sentry support requires Electric to be built with telemetry enabled
- Notes that official Docker images include telemetry by default
- Provides example DSN format to guide users in configuration

https://claude.ai/code/session_013ua43YdvuciG1eJDgQowgT