### PR TITLE
chore: Add transaction stored count in exported metrics

### DIFF
--- a/.changeset/curly-forks-yawn.md
+++ b/.changeset/curly-forks-yawn.md
@@ -2,4 +2,4 @@
 '@core/electric-telemetry': patch
 ---
 
-Add transaction stored count and operations in core metrics we export.
+Add transaction stored count in core metrics we export.

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -104,7 +104,6 @@ defmodule ElectricTelemetry.StackTelemetry do
       sum("electric.postgres.replication.transaction_received.bytes", unit: :byte),
       sum("electric.storage.transaction_stored.bytes", unit: :byte),
       sum("electric.storage.transaction_stored.count"),
-      sum("electric.storage.transaction_stored.operations"),
       last_value("electric.shape_monitor.active_reader_count"),
       last_value("electric.connection.consumers_ready.duration",
         unit: {:native, :millisecond}


### PR DESCRIPTION
This is a relevant metric we want to be exporting as part of the stack - the count of transactions being stored.