### PR TITLE
Remove orphaned shape data at boot

### DIFF
--- a/.changeset/clean-hats-invent.md
+++ b/.changeset/clean-hats-invent.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Clean up orphaned shape data when encountering an empty shape db

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -229,8 +229,9 @@ defmodule Electric.ShapeCache.PureFileStorage do
     end
   end
 
-  def cleanup_all!(%{stack_id: stack_id, base_path: base_path}) do
-    with :ok <- Electric.AsyncDeleter.delete(stack_id, base_path) do
+  def cleanup_all!(%{stack_id: stack_id, base_path: base_path, tmp_dir: tmp_dir}) do
+    with :ok <- Electric.AsyncDeleter.delete(stack_id, base_path),
+         :ok <- Electric.AsyncDeleter.delete(stack_id, tmp_dir) do
       drop_all_ets_entries(stack_id)
     end
   end


### PR DESCRIPTION
If the number of valid shapes is 0, then just efficiently remove the shape data directory entirely, forcing a re-creation. In the case of an ephemeral shape db this will reset the shape data alongside the reset of the shape db.
