### PR TITLE
fix(elixir-client): Cache busting params for expired shapes

### DIFF
--- a/.changeset/selfish-grapes-arrive.md
+++ b/.changeset/selfish-grapes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@core/elixir-client': patch
+---
+
+Fix elixir client's cache busting behaviour for expired shapes

--- a/packages/elixir-client/lib/electric/client/application.ex
+++ b/packages/elixir-client/lib/electric/client/application.ex
@@ -8,7 +8,8 @@ defmodule Electric.Client.Application do
     children = [
       {Registry, name: Electric.Client.Registry, keys: :unique},
       {Finch, name: Electric.Client.Finch},
-      {DynamicSupervisor, name: Electric.Client.RequestSupervisor, strategy: :one_for_one}
+      {DynamicSupervisor, name: Electric.Client.RequestSupervisor, strategy: :one_for_one},
+      Electric.Client.ExpiredShapesCache
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)

--- a/packages/elixir-client/lib/electric/client/expired_shapes_cache.ex
+++ b/packages/elixir-client/lib/electric/client/expired_shapes_cache.ex
@@ -1,0 +1,147 @@
+defmodule Electric.Client.ExpiredShapesCache do
+  @moduledoc """
+  LRU cache for tracking expired shape handles.
+
+  This cache stores shape handles that have been marked as expired (typically after
+  receiving a 409 response). When making subsequent requests for the same shape,
+  the client includes the expired handle as a query parameter to help bypass
+  stale CDN/proxy caches.
+
+  The cache uses ETS for fast concurrent reads and a GenServer to manage
+  LRU eviction when the cache exceeds the maximum number of entries.
+  """
+
+  use GenServer
+
+  @table_name :electric_expired_shapes
+  @max_entries 250
+
+  # Public API
+
+  @doc """
+  Get the expired handle for a shape key, if one exists.
+
+  Updates the last_used timestamp to maintain LRU ordering.
+  """
+  @spec get_expired_handle(String.t()) :: String.t() | nil
+  def get_expired_handle(shape_key) do
+    case :ets.lookup(@table_name, shape_key) do
+      [{^shape_key, %{expired_handle: handle}}] ->
+        # Update last_used timestamp asynchronously
+        GenServer.cast(__MODULE__, {:touch, shape_key})
+        handle
+
+      [] ->
+        nil
+    end
+  end
+
+  @doc """
+  Mark a shape handle as expired for the given shape key.
+
+  If the cache exceeds the maximum number of entries, the least recently
+  used entry will be evicted.
+  """
+  @spec mark_expired(String.t(), String.t()) :: :ok
+  def mark_expired(shape_key, handle) do
+    GenServer.call(__MODULE__, {:mark_expired, shape_key, handle})
+  end
+
+  @doc """
+  Clear all entries from the cache.
+  """
+  @spec clear() :: :ok
+  def clear do
+    GenServer.call(__MODULE__, :clear)
+  end
+
+  @doc """
+  Get the current number of entries in the cache.
+
+  Primarily for testing purposes.
+  """
+  @spec size() :: non_neg_integer()
+  def size do
+    :ets.info(@table_name, :size)
+  end
+
+  # GenServer implementation
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    table =
+      :ets.new(@table_name, [
+        :set,
+        :public,
+        :named_table,
+        read_concurrency: true
+      ])
+
+    {:ok, %{table: table}}
+  end
+
+  @impl true
+  def handle_call({:mark_expired, shape_key, handle}, _from, state) do
+    timestamp = System.monotonic_time()
+
+    :ets.insert(@table_name, {shape_key, %{expired_handle: handle, last_used: timestamp}})
+
+    # Evict oldest entries if we exceed the limit
+    evict_if_needed()
+
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(:clear, _from, state) do
+    :ets.delete_all_objects(@table_name)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_cast({:touch, shape_key}, state) do
+    timestamp = System.monotonic_time()
+
+    case :ets.lookup(@table_name, shape_key) do
+      [{^shape_key, entry}] ->
+        :ets.insert(@table_name, {shape_key, %{entry | last_used: timestamp}})
+
+      [] ->
+        :ok
+    end
+
+    {:noreply, state}
+  end
+
+  defp evict_if_needed do
+    size = :ets.info(@table_name, :size)
+
+    if size > @max_entries do
+      # Find and evict the oldest entry
+      oldest =
+        :ets.foldl(
+          fn {key, %{last_used: ts}}, acc ->
+            case acc do
+              nil -> {key, ts}
+              {_oldest_key, oldest_ts} when ts < oldest_ts -> {key, ts}
+              _ -> acc
+            end
+          end,
+          nil,
+          @table_name
+        )
+
+      case oldest do
+        {oldest_key, _ts} ->
+          :ets.delete(@table_name, oldest_key)
+
+        nil ->
+          :ok
+      end
+    end
+  end
+end

--- a/packages/elixir-client/lib/electric/client/shape_key.ex
+++ b/packages/elixir-client/lib/electric/client/shape_key.ex
@@ -1,0 +1,81 @@
+defmodule Electric.Client.ShapeKey do
+  @moduledoc """
+  Generate canonical shape keys for cache lookup.
+
+  The canonical shape key is a stable identifier for a shape definition that
+  excludes Electric protocol parameters (like cursor, handle, offset, etc.).
+  This allows the client to identify when different requests are for the same
+  underlying shape, which is useful for cache busting when CDN/proxy caches
+  serve stale responses.
+  """
+
+  # Parameters that are part of the Electric protocol and should be excluded
+  # from the canonical shape key
+  @protocol_params ~w(
+    cursor
+    handle
+    live
+    offset
+    cache-buster
+    expired_handle
+    log
+    subset__where
+    subset__limit
+    subset__offset
+    subset__order_by
+    subset__params
+    subset__where_expr
+    subset__order_by_expr
+  )
+
+  @doc """
+  Generate a canonical shape key from a URI.
+
+  Extracts query parameters, filters out Electric protocol parameters,
+  sorts the remaining parameters alphabetically, and returns a canonical
+  URL string.
+
+  ## Examples
+
+      iex> uri = URI.parse("http://localhost:3000/v1/shape?table=items&cursor=123&offset=0_0")
+      iex> ShapeKey.canonical(uri)
+      "http://localhost:3000/v1/shape?table=items"
+
+  """
+  @spec canonical(URI.t()) :: String.t()
+  def canonical(%URI{} = uri) do
+    params = URI.decode_query(uri.query || "")
+    canonical(uri, params)
+  end
+
+  @doc """
+  Generate a canonical shape key from an endpoint URI and params map.
+
+  ## Examples
+
+      iex> endpoint = URI.parse("http://localhost:3000/v1/shape")
+      iex> params = %{"table" => "items", "where" => "id > 0", "offset" => "0_0"}
+      iex> ShapeKey.canonical(endpoint, params)
+      "http://localhost:3000/v1/shape?table=items&where=id%20%3E%200"
+
+  """
+  @spec canonical(URI.t(), map()) :: String.t()
+  def canonical(%URI{} = endpoint, params) when is_map(params) do
+    # Filter out protocol parameters
+    shape_params =
+      params
+      |> Enum.reject(fn {key, _value} -> key in @protocol_params end)
+      |> Enum.sort_by(fn {key, _value} -> key end)
+
+    # Build the canonical URL
+    query =
+      if shape_params == [] do
+        nil
+      else
+        URI.encode_query(shape_params, :rfc3986)
+      end
+
+    %{endpoint | query: query}
+    |> URI.to_string()
+  end
+end

--- a/packages/elixir-client/lib/electric/client/stream.ex
+++ b/packages/elixir-client/lib/electric/client/stream.ex
@@ -166,6 +166,16 @@ defmodule Electric.Client.Stream do
         |> handle_messages(messages)
         |> dispatch()
 
+      {:stale_retry, new_poll_state} ->
+        # Retry immediately with cache buster
+        %{stream | poll_state: new_poll_state}
+        |> fetch()
+
+      {:stale_ignored, new_poll_state} ->
+        # Stale response ignored, continue polling
+        %{stream | poll_state: new_poll_state}
+        |> fetch()
+
       {:error, error} ->
         handle_error(error, stream)
     end

--- a/packages/elixir-client/test/electric/client/expired_shapes_cache_test.exs
+++ b/packages/elixir-client/test/electric/client/expired_shapes_cache_test.exs
@@ -1,0 +1,134 @@
+defmodule Electric.Client.ExpiredShapesCacheTest do
+  use ExUnit.Case, async: false
+
+  alias Electric.Client.ExpiredShapesCache
+
+  setup do
+    ExpiredShapesCache.clear()
+    :ok
+  end
+
+  describe "get_expired_handle/1" do
+    test "returns nil for unknown shape key" do
+      assert ExpiredShapesCache.get_expired_handle("unknown-key") == nil
+    end
+
+    test "returns expired handle after marking" do
+      ExpiredShapesCache.mark_expired("http://localhost:3000/v1/shape?table=items", "handle-123")
+
+      assert ExpiredShapesCache.get_expired_handle("http://localhost:3000/v1/shape?table=items") ==
+               "handle-123"
+    end
+
+    test "returns nil after clearing" do
+      ExpiredShapesCache.mark_expired("http://localhost:3000/v1/shape?table=items", "handle-123")
+      ExpiredShapesCache.clear()
+
+      assert ExpiredShapesCache.get_expired_handle("http://localhost:3000/v1/shape?table=items") ==
+               nil
+    end
+  end
+
+  describe "mark_expired/2" do
+    test "stores expired handle for shape key" do
+      assert :ok = ExpiredShapesCache.mark_expired("shape-key-1", "expired-handle-1")
+      assert ExpiredShapesCache.get_expired_handle("shape-key-1") == "expired-handle-1"
+    end
+
+    test "overwrites previous expired handle" do
+      ExpiredShapesCache.mark_expired("shape-key-1", "old-handle")
+      ExpiredShapesCache.mark_expired("shape-key-1", "new-handle")
+
+      assert ExpiredShapesCache.get_expired_handle("shape-key-1") == "new-handle"
+    end
+
+    test "can store multiple shape keys" do
+      ExpiredShapesCache.mark_expired("shape-key-1", "handle-1")
+      ExpiredShapesCache.mark_expired("shape-key-2", "handle-2")
+      ExpiredShapesCache.mark_expired("shape-key-3", "handle-3")
+
+      assert ExpiredShapesCache.get_expired_handle("shape-key-1") == "handle-1"
+      assert ExpiredShapesCache.get_expired_handle("shape-key-2") == "handle-2"
+      assert ExpiredShapesCache.get_expired_handle("shape-key-3") == "handle-3"
+    end
+  end
+
+  describe "LRU eviction" do
+    test "evicts oldest entry when exceeding 250 entries" do
+      # Insert 251 entries - the first one should be evicted
+      for i <- 1..251 do
+        ExpiredShapesCache.mark_expired("key-#{i}", "handle-#{i}")
+      end
+
+      # Wait briefly for the eviction to complete
+      Process.sleep(10)
+
+      # The first entry should have been evicted
+      assert ExpiredShapesCache.get_expired_handle("key-1") == nil
+
+      # Recent entries should still exist
+      assert ExpiredShapesCache.get_expired_handle("key-251") == "handle-251"
+      assert ExpiredShapesCache.get_expired_handle("key-250") == "handle-250"
+    end
+
+    test "accessing entry updates its LRU position" do
+      # Insert entries up to the limit
+      for i <- 1..250 do
+        ExpiredShapesCache.mark_expired("key-#{i}", "handle-#{i}")
+      end
+
+      # Access key-1 to make it recently used
+      assert ExpiredShapesCache.get_expired_handle("key-1") == "handle-1"
+
+      # Wait briefly for the LRU update
+      Process.sleep(10)
+
+      # Insert one more entry to trigger eviction
+      ExpiredShapesCache.mark_expired("key-251", "handle-251")
+
+      # Wait for eviction
+      Process.sleep(10)
+
+      # key-1 should still exist because we accessed it
+      assert ExpiredShapesCache.get_expired_handle("key-1") == "handle-1"
+
+      # key-2 (which wasn't accessed) should have been evicted
+      assert ExpiredShapesCache.get_expired_handle("key-2") == nil
+    end
+  end
+
+  describe "size/0" do
+    test "returns 0 for empty cache" do
+      assert ExpiredShapesCache.size() == 0
+    end
+
+    test "returns correct count after marking" do
+      ExpiredShapesCache.mark_expired("key-1", "handle-1")
+      assert ExpiredShapesCache.size() == 1
+
+      ExpiredShapesCache.mark_expired("key-2", "handle-2")
+      assert ExpiredShapesCache.size() == 2
+    end
+
+    test "doesn't increase for duplicate keys" do
+      ExpiredShapesCache.mark_expired("key-1", "handle-1")
+      ExpiredShapesCache.mark_expired("key-1", "handle-2")
+
+      assert ExpiredShapesCache.size() == 1
+    end
+  end
+
+  describe "clear/0" do
+    test "removes all entries" do
+      for i <- 1..10 do
+        ExpiredShapesCache.mark_expired("key-#{i}", "handle-#{i}")
+      end
+
+      assert ExpiredShapesCache.size() == 10
+
+      ExpiredShapesCache.clear()
+
+      assert ExpiredShapesCache.size() == 0
+    end
+  end
+end

--- a/packages/elixir-client/test/electric/client/shape_key_test.exs
+++ b/packages/elixir-client/test/electric/client/shape_key_test.exs
@@ -1,0 +1,181 @@
+defmodule Electric.Client.ShapeKeyTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Client.ShapeKey
+
+  describe "canonical/1 with URI" do
+    test "excludes protocol parameters (cursor, handle, live, offset)" do
+      uri =
+        URI.parse(
+          "http://localhost:3000/v1/shape?table=items&cursor=123&handle=abc&live=true&offset=0_0"
+        )
+
+      result = ShapeKey.canonical(uri)
+
+      assert result == "http://localhost:3000/v1/shape?table=items"
+    end
+
+    test "excludes cache-buster and expired_handle params" do
+      uri =
+        URI.parse(
+          "http://localhost:3000/v1/shape?table=items&cache-buster=xyz&expired_handle=old-handle"
+        )
+
+      result = ShapeKey.canonical(uri)
+
+      assert result == "http://localhost:3000/v1/shape?table=items"
+    end
+
+    test "excludes log parameter" do
+      uri = URI.parse("http://localhost:3000/v1/shape?table=items&log=true")
+      result = ShapeKey.canonical(uri)
+
+      assert result == "http://localhost:3000/v1/shape?table=items"
+    end
+
+    test "excludes subset parameters" do
+      uri =
+        URI.parse(
+          "http://localhost:3000/v1/shape?table=items&subset__where=id>0&subset__limit=100"
+        )
+
+      result = ShapeKey.canonical(uri)
+
+      assert result == "http://localhost:3000/v1/shape?table=items"
+    end
+
+    test "sorts remaining parameters alphabetically" do
+      uri = URI.parse("http://localhost:3000/v1/shape?where=id>0&table=items&columns=id,name")
+      result = ShapeKey.canonical(uri)
+
+      assert result == "http://localhost:3000/v1/shape?columns=id%2Cname&table=items&where=id%3E0"
+    end
+
+    test "produces consistent keys for same shape definition" do
+      # Different parameter order, same content
+      uri1 = URI.parse("http://localhost:3000/v1/shape?table=items&where=id>0")
+      uri2 = URI.parse("http://localhost:3000/v1/shape?where=id>0&table=items")
+
+      assert ShapeKey.canonical(uri1) == ShapeKey.canonical(uri2)
+    end
+
+    test "produces different keys for different tables" do
+      uri1 = URI.parse("http://localhost:3000/v1/shape?table=items")
+      uri2 = URI.parse("http://localhost:3000/v1/shape?table=orders")
+
+      refute ShapeKey.canonical(uri1) == ShapeKey.canonical(uri2)
+    end
+
+    test "produces different keys for different where clauses" do
+      uri1 = URI.parse("http://localhost:3000/v1/shape?table=items&where=id>0")
+      uri2 = URI.parse("http://localhost:3000/v1/shape?table=items&where=id>100")
+
+      refute ShapeKey.canonical(uri1) == ShapeKey.canonical(uri2)
+    end
+
+    test "handles URI without query params" do
+      uri = URI.parse("http://localhost:3000/v1/shape")
+      result = ShapeKey.canonical(uri)
+
+      assert result == "http://localhost:3000/v1/shape"
+    end
+
+    test "handles URI with only protocol params" do
+      uri = URI.parse("http://localhost:3000/v1/shape?offset=0_0&handle=abc&live=true")
+      result = ShapeKey.canonical(uri)
+
+      assert result == "http://localhost:3000/v1/shape"
+    end
+  end
+
+  describe "canonical/2 with endpoint and params" do
+    test "filters out protocol parameters" do
+      endpoint = URI.parse("http://localhost:3000/v1/shape")
+
+      params = %{
+        "table" => "items",
+        "offset" => "0_0",
+        "handle" => "my-handle",
+        "live" => "true",
+        "cursor" => "123"
+      }
+
+      result = ShapeKey.canonical(endpoint, params)
+
+      assert result == "http://localhost:3000/v1/shape?table=items"
+    end
+
+    test "filters out cache busting parameters" do
+      endpoint = URI.parse("http://localhost:3000/v1/shape")
+
+      params = %{
+        "table" => "items",
+        "expired_handle" => "old-handle",
+        "cache-buster" => "xyz123"
+      }
+
+      result = ShapeKey.canonical(endpoint, params)
+
+      assert result == "http://localhost:3000/v1/shape?table=items"
+    end
+
+    test "sorts parameters alphabetically" do
+      endpoint = URI.parse("http://localhost:3000/v1/shape")
+
+      params = %{
+        "where" => "status = 'active'",
+        "table" => "orders",
+        "columns" => "id,total,status"
+      }
+
+      result = ShapeKey.canonical(endpoint, params)
+
+      # Parameters should be sorted: columns, table, where
+      assert result =~ "columns="
+      assert result =~ "table="
+      assert result =~ "where="
+
+      # Verify order by checking the full result
+      decoded = URI.parse(result).query |> URI.decode_query()
+      keys = Map.keys(decoded) |> Enum.sort()
+      assert keys == ["columns", "table", "where"]
+    end
+
+    test "handles empty params" do
+      endpoint = URI.parse("http://localhost:3000/v1/shape")
+      result = ShapeKey.canonical(endpoint, %{})
+
+      assert result == "http://localhost:3000/v1/shape"
+    end
+
+    test "handles params that are all protocol params" do
+      endpoint = URI.parse("http://localhost:3000/v1/shape")
+
+      params = %{
+        "offset" => "-1",
+        "handle" => "abc",
+        "live" => "false",
+        "cursor" => "999"
+      }
+
+      result = ShapeKey.canonical(endpoint, params)
+
+      assert result == "http://localhost:3000/v1/shape"
+    end
+
+    test "preserves special characters in parameter values" do
+      endpoint = URI.parse("http://localhost:3000/v1/shape")
+
+      params = %{
+        "table" => "items",
+        "where" => "name ILIKE '%test%' AND id > 0"
+      }
+
+      result = ShapeKey.canonical(endpoint, params)
+
+      # Should be properly URL encoded
+      assert result =~ "table=items"
+      assert result =~ "where="
+    end
+  end
+end


### PR DESCRIPTION
Adds cache busting features to the Elixir client to match the TypeScript client's functionality, preventing infinite 409 loops caused by CDN/proxy caching issues.

 ## Problem

  When a shape is reset (409 response), the server returns a new shape handle. However, CDN/proxy caches may continue serving stale responses with the old handle. Without cache busting, the client can get stuck in an infinite loop:

  1. Client receives 409, gets new handle
  2. Client makes request with new handle
  3. CDN serves cached response with old handle
  4. Client receives 409 again (handle mismatch)
  5. Repeat forever

 ## Solution

  This PR implements the same cache busting strategy as the TypeScript client:

  1. ExpiredShapesCache - LRU cache (max 250 entries) tracking expired shape handles by canonical shape key
  2. Canonical Shape Key - Stable cache key generation that excludes protocol parameters (offset, cursor, handle, etc.)
  3. expired_handle parameter - Included in requests when a shape key has an expired handle cached
  4. cache-buster parameter - Random string added to requests when retrying after detecting stale responses
  5. Stale detection - When server returns an expired handle and client has no valid local handle, retry with cache-buster
  6. Max retries - Fails after 3 stale retry attempts with a clear error message
