### PR TITLE
fix(electric-telmetry): Handle non-existent storage-dir

### DIFF
--- a/.changeset/real-planes-brake.md
+++ b/.changeset/real-planes-brake.md
@@ -1,0 +1,5 @@
+---
+'@core/electric-telemetry': patch
+---
+
+Ensure storage dir exists before writing cached disk usage information

--- a/packages/electric-telemetry/lib/electric/telemetry/disk_usage.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/disk_usage.ex
@@ -139,6 +139,7 @@ defmodule ElectricTelemetry.DiskUsage do
         DateTime.to_iso8601(state.updated_at)
       ])
 
+    File.mkdir_p!(Path.dirname(cache_file))
     File.write!(cache_file, data, [:binary, :raw])
 
     state

--- a/packages/electric-telemetry/test/electric/telemetry/disk_usage_test.exs
+++ b/packages/electric-telemetry/test/electric/telemetry/disk_usage_test.exs
@@ -61,6 +61,15 @@ defmodule ElectricTelemetry.DiskUsageTest do
     assert eventually_read_usage(ctx, bytes)
   end
 
+  @tag start_usage: false
+  test "ensures storage_dir exists before writing to it", ctx do
+    ctx =
+      start_usage(%{ctx | tmp_dir: Path.join(ctx.tmp_dir, "dir#{System.monotonic_time()}-#{}")})
+
+    Process.link(ctx.usage)
+    :ok = DiskUsage.update(ctx.usage)
+  end
+
   defp stop_usage(ctx) do
     ref = Process.monitor(ctx.usage)
     Process.unlink(ctx.usage)


### PR DESCRIPTION
Make sure the given `storage_dir` exists before writing the cached usage