### PR TITLE
fix(typescript-client): use positive check in isControlMessage type guard

### DIFF
--- a/packages/typescript-client/src/helpers.ts
+++ b/packages/typescript-client/src/helpers.ts
@@ -51,7 +51,7 @@ export function isChangeMessage<T extends Row<unknown> = Row>(
 export function isControlMessage<T extends Row<unknown> = Row>(
   message: Message<T>
 ): message is ControlMessage {
-  return message != null && !isChangeMessage(message)
+  return message != null && `headers` in message && `control` in message.headers
 }
 
 export function isUpToDateMessage<T extends Row<unknown> = Row>(

--- a/packages/typescript-client/test/helpers.test.ts
+++ b/packages/typescript-client/test/helpers.test.ts
@@ -24,6 +24,13 @@ describe(`helpers`, () => {
     },
   } as Message
 
+  const eventMsg = {
+    headers: {
+      event: `move-out`,
+      patterns: [{ pos: 0, value: `test` }],
+    },
+  } as Message
+
   it(`should correctly detect ChangeMessages`, () => {
     expect(isChangeMessage(changeMsg)).toBe(true)
     expect(isControlMessage(changeMsg)).toBe(false)
@@ -40,6 +47,21 @@ describe(`helpers`, () => {
     expect(isUpToDateMessage(upToDateMsg)).toBe(true)
     expect(isUpToDateMessage(mustRefetchMsg)).toBe(false)
     expect(isUpToDateMessage(changeMsg)).toBe(false)
+  })
+
+  it(`should not classify EventMessages as ControlMessages`, () => {
+    expect(isControlMessage(eventMsg)).toBe(false)
+    expect(isChangeMessage(eventMsg)).toBe(false)
+    expect(isUpToDateMessage(eventMsg)).toBe(false)
+  })
+
+  it(`should not classify messages without headers as ControlMessages`, () => {
+    // Messages without headers can arrive from proxy/CDN interference
+    // or unexpected server responses (e.g. 409 during initialization).
+    const noHeadersMsg = {} as unknown as Message
+    expect(isControlMessage(noHeadersMsg)).toBe(false)
+    expect(isChangeMessage(noHeadersMsg)).toBe(false)
+    expect(isUpToDateMessage(noHeadersMsg)).toBe(false)
   })
 
   describe(`bigintSafeStringify`, () => {


### PR DESCRIPTION
## Summary

Closes #3875

`isControlMessage()` used a negation check (`!isChangeMessage(message)`) which returned `true` for **any** non-null message without a `key` property — including `EventMessage`s and malformed messages without `headers`. Downstream code in `Shape.process_fn`, `isUpToDateMessage`, and `getOffset` then crashed with `TypeError: Cannot read property 'control' of undefined` when accessing `message.headers.control` on these misclassified messages.

The fix replaces the negation with a positive check:

```typescript
// Before
return message != null && !isChangeMessage(message)

// After
return message != null && `headers` in message && `control` in message.headers
```

This is consistent with how `isChangeMessage` already works (positively checking for `'key' in message`), and protects all consumers: `Shape.#process()`, `isUpToDateMessage()`, `getOffset()`, `y-electric`, and `multi-shape-stream`.

## Test plan

- [x] Added test: EventMessages are not classified as ControlMessages
- [x] Added test: messages without `headers` are not classified as ControlMessages
- [x] Existing tests for ChangeMessage, ControlMessage, up-to-date, null/undefined all still pass
- [x] Verify no regressions in integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)