### PR TITLE
fix(sync-service): Start up with empty state when shape db file corrupted

### DIFF
--- a/.changeset/proud-mugs-cough.md
+++ b/.changeset/proud-mugs-cough.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Recover shape db startup when opening a corrupt database file

--- a/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/migrator.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/migrator.ex
@@ -33,7 +33,7 @@ defmodule Electric.ShapeCache.ShapeStatus.ShapeDb.Migrator do
   end
 
   defp apply_migration(_stack_id, opts, false = _exclusive?) do
-    with {:ok, conn} <- ShapeDb.Connection.open(opts),
+    with {:ok, conn} <- ShapeDb.Connection.open(opts, integrity_check: true),
          {:ok, _version} <- ShapeDb.Connection.migrate(conn, opts),
          :ok = ShapeDb.Connection.optimize(conn) do
       {:ok, conn}

--- a/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/query.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/query.ex
@@ -69,17 +69,14 @@ defmodule Electric.ShapeCache.ShapeStatus.ShapeDb.Query do
     ]
 
   def prepare!(conn, opts) do
-    case {Keyword.get(opts, :mode, :readwrite), Keyword.get(opts, :exclusive_mode, false)} do
-      {_, true} ->
+    case Keyword.get(opts, :mode, :readwrite) do
+      :readwrite ->
         struct(__MODULE__, prepare_stmts!(conn, @read_queries ++ @write_queries))
 
-      {:readwrite, false} ->
-        struct(__MODULE__, prepare_stmts!(conn, @read_queries ++ @write_queries))
-
-      {:read, false} ->
+      :read ->
         struct(__MODULE__, prepare_stmts!(conn, @read_queries))
 
-      {:write, false} ->
+      :write ->
         struct(__MODULE__, prepare_stmts!(conn, @write_queries))
     end
   end

--- a/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/supervisor.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/supervisor.ex
@@ -29,7 +29,7 @@ defmodule Electric.ShapeCache.ShapeStatus.ShapeDb.Supervisor do
             {
               NimblePool,
               worker: {ShapeDb.Connection, Keyword.put(opts, :mode, :read)},
-              pool_size: 2 * System.schedulers_online(),
+              pool_size: Keyword.get(opts, :read_pool_size, 2 * System.schedulers_online()),
               name: ShapeDb.PoolRegistry.pool_name(stack_id, :read, exclusive_mode)
             },
             id: {:pool, :read}

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -267,7 +267,8 @@ defmodule Support.ComponentSetup do
            Keyword.merge(
              [
                storage_dir: ctx.tmp_dir,
-               manual_flush_only: true
+               manual_flush_only: true,
+               read_pool_size: 1
              ],
              shape_db_opts
            )


### PR DESCRIPTION
If the shape database file has been corrupted, the system current fails to start. This PR catches that situation and recovers by deleting the corrupt database file and starting anew. 

Fixes #3832 