### PR TITLE
fix(sync-service): Lock breaker respects tenant ownership during rolling deployments

### DIFF
--- a/.changeset/chatty-birds-kick.md
+++ b/.changeset/chatty-birds-kick.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Add lock_breaker_guard to optionally disable the lock breaker behaviour

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -143,6 +143,12 @@ defmodule Electric.StackSupervisor do
                      process_spawn_opts: [type: :map, default: %{}]
                    ]
                  ],
+                 lock_breaker_guard: [
+                   type: {:or, [{:fun, 0}, nil]},
+                   default: nil,
+                   doc:
+                     "Optional guard callback for the lock breaker. When set, the lock breaker will only run if this callback returns true."
+                 ],
                  manual_table_publishing?: [
                    type: :boolean,
                    required: false,
@@ -359,7 +365,8 @@ defmodule Electric.StackSupervisor do
       inspector: inspector,
       max_shapes: config.max_shapes,
       tweaks: config.tweaks,
-      manual_table_publishing?: config.manual_table_publishing?
+      manual_table_publishing?: config.manual_table_publishing?,
+      lock_breaker_guard: config.lock_breaker_guard
     ]
 
     registry_partitions =


### PR DESCRIPTION
Problem

  During rolling deployments, the old tenant instance kills the new tenant's legitimate database backend via the "terminate stuck backend" lock breaker logic. The lock breaker operates independently of the ownership protocol — it doesn't check whether the instance has ownership rights before forcefully terminating other backends.

  This causes a "lock battle" between old and new instances, stale webhook state, and the source getting stuck in "waiting" state for hours until manual restart.

  Solution

  An optional lock_breaker_guard callback was added to Electric's Connection Manager ([electric-sql/electric PR link]). When set, the callback is invoked before the lock breaker runs — if it returns false, the lock breaker is skipped.

  On the Stratovolt side, TenantManager.create_tenant_spec/3 now passes a guard that calls ClusterManager.is_tenant_owner?/2. During a rolling deployment, the old (non-owner) instance will no longer terminate backends belonging to the new owner.

  Changes

  - packages/cloud-sync-service/lib/cloud_electric/tenant_manager.ex — Pass a lock_breaker_guard callback in start_tenant_opts that checks tenant ownership via ClusterManager.is_tenant_owner?/2
  - packages/cloud-sync-service/mix.exs — Update Electric dependencies to dee6437 which includes the lock_breaker_guard support

  Upstream dependency

  This requires the Electric change that adds the lock_breaker_guard option to Connection.Manager and StackSupervisor:
  - Electric.Connection.Manager — new lock_breaker_guard field on State, checked before running the lock breaker in handle_continue(:check_lock_not_abandoned, ...)
  - Electric.StackSupervisor — passes lock_breaker_guard through opts schema to the connection manager
  - Tests in manager_test.exs verify the guard skips/allows the lock breaker

Part of https://github.com/electric-sql/stratovolt/issues/1130