### PR TITLE
chore: add changeset for isControlMessage fix

### DIFF
--- a/.changeset/fix-is-control-message.md
+++ b/.changeset/fix-is-control-message.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/client': patch
+---
+
+Fixed `isControlMessage` type guard crashing on messages without a `control` header (e.g. `EventMessage`s or malformed responses). The function previously used a negation check (`!isChangeMessage()`) which misclassified any non-change message as a `ControlMessage`, causing `TypeError: Cannot read property 'control' of undefined` in `Shape.process_fn`. Now uses a positive check for `'control' in message.headers`, consistent with how `isChangeMessage` checks for `'key' in message`.


### PR DESCRIPTION
## Summary

Adds a changeset for the `isControlMessage` type guard fix merged in #3879 (closes #3875).

The fix replaced the negation check in `isControlMessage()` with a positive check for `'control' in message.headers`, preventing `TypeError: Cannot read property 'control' of undefined` when processing `EventMessage`s or messages without headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)