### PR TITLE
feat: add complete skill tree (16 skills + 8 references)

### DIFF
--- a/packages/typescript-client/package.json
+++ b/packages/typescript-client/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "skills"
   ],
   "homepage": "https://electric-sql.com",
   "license": "Apache-2.0",

--- a/packages/typescript-client/skills/deploying-electric/SKILL.md
+++ b/packages/typescript-client/skills/deploying-electric/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: deploying-electric
+description: >
+  Deployment options — Electric Cloud (npx @electric-sql/start), Docker Compose,
+  self-hosted, DATABASE_URL, ELECTRIC_SECRET, ELECTRIC_INSECURE, wal_level,
+  REPLICATION role, env var configuration, reverse proxy, SSL
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:website/docs/guides/installation.md'
+  - 'electric:website/docs/guides/postgres-permissions.md'
+  - 'electric:AGENTS.md'
+---
+
+# Deploying Electric
+
+Three deployment options: Electric Cloud, Docker Compose, or self-hosted.
+
+## Setup
+
+### Postgres Requirements (all deployments)
+
+- PostgreSQL 14+
+- `wal_level=logical` (not the default `replica`)
+- User with `REPLICATION` role
+- Tables must have `REPLICA IDENTITY FULL`
+
+```sql
+-- Enable logical replication (requires restart)
+ALTER SYSTEM SET wal_level = 'logical';
+
+-- Create Electric user
+CREATE ROLE electric_user WITH LOGIN PASSWORD 'secret' REPLICATION;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO electric_user;
+```
+
+## Core Patterns
+
+### Electric Cloud
+
+```bash
+npx @electric-sql/start my-app
+pnpm claim && pnpm deploy
+```
+
+Environment for proxy:
+
+```bash
+ELECTRIC_URL=https://api.electric-sql.cloud
+ELECTRIC_SOURCE_ID=your-source-id
+ELECTRIC_SECRET=your-secret
+```
+
+### Docker Compose
+
+```yaml
+name: 'electric-backend'
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: electric
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports: ['54321:5432']
+    volumes: ['./postgres.conf:/etc/postgresql/postgresql.conf:ro']
+    tmpfs: ['/var/lib/postgresql/data', '/tmp']
+    command: ['postgres', '-c', 'config_file=/etc/postgresql/postgresql.conf']
+
+  electric:
+    image: electricsql/electric:canary
+    environment:
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/electric?sslmode=disable
+      ELECTRIC_INSECURE: true # dev only — use ELECTRIC_SECRET in production
+    ports: ['3000:3000']
+    depends_on: ['postgres']
+```
+
+### Self-Hosted
+
+```bash
+docker run -e DATABASE_URL=postgres://user:pass@host:5432/db \
+  -e ELECTRIC_SECRET=your-production-secret \
+  -p 3000:3000 electricsql/electric
+```
+
+## Common Mistakes
+
+### [CRITICAL] Postgres without logical replication enabled
+
+Wrong:
+
+```bash
+# Default Postgres — wal_level=replica
+docker run postgres:16
+```
+
+Correct:
+
+```bash
+# postgres.conf must include:
+# wal_level = logical
+docker run -v ./postgres.conf:/etc/postgresql/postgresql.conf:ro \
+  postgres:16 -c config_file=/etc/postgresql/postgresql.conf
+```
+
+`wal_level=logical` is required. The default `wal_level=replica` causes an unclear
+connection failure when Electric tries to create a replication slot.
+
+Source: website/docs/guides/installation.md
+
+### [CRITICAL] Database user missing REPLICATION role
+
+Wrong:
+
+```sql
+CREATE ROLE electric_user WITH LOGIN PASSWORD 'secret';
+```
+
+Correct:
+
+```sql
+CREATE ROLE electric_user WITH LOGIN PASSWORD 'secret' REPLICATION;
+```
+
+Electric creates a logical replication slot. Without the `REPLICATION` role, slot
+creation fails with a permissions error.
+
+Source: website/docs/guides/postgres-permissions.md
+
+### [HIGH] Not setting ELECTRIC_SECRET in production
+
+Wrong:
+
+```yaml
+environment:
+  DATABASE_URL: postgres://...
+  ELECTRIC_INSECURE: true # "I'll add auth later"
+```
+
+Correct:
+
+```yaml
+environment:
+  DATABASE_URL: postgres://...
+  ELECTRIC_SECRET: your-strong-secret-here
+```
+
+`ELECTRIC_SECRET` is required since v1.0. Without it or `ELECTRIC_INSECURE=true`,
+the service refuses to start. `ELECTRIC_INSECURE` must never reach production.
+
+Source: sync-service CHANGELOG.md v1.0.0
+
+## Tension: CDN cacheability vs real-time freshness
+
+Electric's HTTP responses include cache headers enabling CDN distribution. But
+proxy/CDN misconfigurations can cause stale data. Preserve Electric's
+`cache-control` and `etag` headers — don't override them with aggressive caching.
+
+Cross-reference: `electric-http-api`
+
+## References
+
+- [Installation Guide](https://electric-sql.com/docs/guides/installation)
+- [Postgres Permissions](https://electric-sql.com/docs/guides/postgres-permissions)
+- [Configuration Reference](https://electric-sql.com/docs/api/config)
+- Reference: `deploying-electric/references/electric-cloud.md`
+- Reference: `deploying-electric/references/docker.md`
+- Reference: `deploying-electric/references/self-hosted.md`

--- a/packages/typescript-client/skills/deploying-electric/references/docker.md
+++ b/packages/typescript-client/skills/deploying-electric/references/docker.md
@@ -1,0 +1,82 @@
+---
+name: docker-reference
+parent: deploying-electric
+---
+
+# Docker Compose Reference
+
+## Minimal Development Setup
+
+```yaml
+name: 'electric-backend'
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: electric
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports: ['54321:5432']
+    volumes: ['./postgres.conf:/etc/postgresql/postgresql.conf:ro']
+    tmpfs: ['/var/lib/postgresql/data', '/tmp']
+    command: ['postgres', '-c', 'config_file=/etc/postgresql/postgresql.conf']
+
+  electric:
+    image: electricsql/electric:canary
+    environment:
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/electric?sslmode=disable
+      ELECTRIC_INSECURE: true
+    ports: ['3000:3000']
+    depends_on: ['postgres']
+```
+
+## postgres.conf
+
+```ini
+listen_addresses = '*'
+wal_level = logical
+max_wal_senders = 10
+max_replication_slots = 10
+```
+
+## Production Docker Compose
+
+```yaml
+services:
+  electric:
+    image: electricsql/electric:latest
+    environment:
+      DATABASE_URL: postgresql://electric:secret@postgres:5432/mydb
+      ELECTRIC_SECRET: ${ELECTRIC_SECRET}
+      ELECTRIC_STORAGE_DIR: /var/lib/electric
+    ports: ['3000:3000']
+    volumes:
+      - electric-data:/var/lib/electric
+    restart: unless-stopped
+
+volumes:
+  electric-data:
+```
+
+## Useful Commands
+
+```bash
+# Start services
+docker compose up --wait postgres electric
+
+# Clear all state and start fresh
+docker compose down --volumes
+docker compose up
+
+# Build local Electric image (for feature branches)
+docker build -t electric-local \
+  -f packages/sync-service/Dockerfile \
+  --build-context electric-telemetry=packages/electric-telemetry \
+  packages/sync-service
+```
+
+## Common Issues
+
+- **Connection refused**: Check `depends_on` ordering, Postgres may not be ready
+- **Replication slot errors**: User needs `REPLICATION` role
+- **WAL growth**: Set `max_slot_wal_keep_size` in postgres.conf

--- a/packages/typescript-client/skills/deploying-electric/references/electric-cloud.md
+++ b/packages/typescript-client/skills/deploying-electric/references/electric-cloud.md
@@ -1,0 +1,46 @@
+---
+name: electric-cloud-reference
+parent: deploying-electric
+---
+
+# Electric Cloud Reference
+
+Managed Electric hosting — no infrastructure to manage.
+
+## Quick Setup
+
+```bash
+npx @electric-sql/start my-app
+pnpm claim && pnpm deploy
+```
+
+## Environment Variables
+
+| Variable             | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `ELECTRIC_SOURCE_ID` | Source identifier (from Electric Cloud dashboard) |
+| `ELECTRIC_SECRET`    | Source secret (server-side only, never in client) |
+
+## Proxy Configuration
+
+```typescript
+// In your proxy route
+if (process.env.ELECTRIC_SOURCE_ID && process.env.ELECTRIC_SECRET) {
+  originUrl.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID)
+  originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET)
+}
+```
+
+## Cloud API Endpoint
+
+```
+https://api.electric-sql.cloud/v1/shape
+```
+
+## Postgres Requirements
+
+Same as self-hosted:
+
+- PostgreSQL 14+ with `wal_level=logical`
+- User with `REPLICATION` role
+- Network access from Electric Cloud to your Postgres instance

--- a/packages/typescript-client/skills/deploying-electric/references/self-hosted.md
+++ b/packages/typescript-client/skills/deploying-electric/references/self-hosted.md
@@ -1,0 +1,84 @@
+---
+name: self-hosted-reference
+parent: deploying-electric
+---
+
+# Self-Hosted Reference
+
+Full control over Electric infrastructure.
+
+## Quick Start
+
+```bash
+docker run -e DATABASE_URL=postgres://user:pass@host:5432/db \
+  -e ELECTRIC_SECRET=your-secret \
+  -p 3000:3000 electricsql/electric
+```
+
+## Key Environment Variables
+
+| Variable                           | Required | Default         | Description                                         |
+| ---------------------------------- | -------- | --------------- | --------------------------------------------------- |
+| `DATABASE_URL`                     | Yes      | —               | Postgres connection string                          |
+| `ELECTRIC_SECRET`                  | Yes\*    | —               | Auth secret (\*or `ELECTRIC_INSECURE=true` for dev) |
+| `ELECTRIC_PORT`                    | No       | `3000`          | HTTP listen port                                    |
+| `ELECTRIC_STORAGE_DIR`             | No       | `/tmp/electric` | Shape log storage path                              |
+| `ELECTRIC_INSECURE`                | No       | `false`         | Skip auth (dev only)                                |
+| `ELECTRIC_SHAPE_DB_EXCLUSIVE_MODE` | No       | `false`         | Required for network FS (EFS)                       |
+| `ELECTRIC_DATABASE_USE_IPV6`       | No       | `false`         | Connect to Postgres over IPv6                       |
+| `ELECTRIC_LISTEN_ON_IPV6`          | No       | `false`         | Bind to IPv6 addresses                              |
+| `ELECTRIC_PROMETHEUS_PORT`         | No       | —               | Enable Prometheus metrics                           |
+
+## Reverse Proxy Setup
+
+### Caddy (recommended)
+
+```caddyfile
+electric.example.com {
+  reverse_proxy electric:3000 {
+    flush_interval -1
+  }
+  encode gzip
+}
+```
+
+### Nginx
+
+```nginx
+upstream electric {
+  server electric:3000;
+}
+
+server {
+  listen 443 ssl http2;
+  server_name electric.example.com;
+
+  location /v1/shape {
+    proxy_pass http://electric;
+    proxy_buffering off;
+    proxy_http_version 1.1;
+    proxy_read_timeout 60s;
+  }
+}
+```
+
+## Health Check
+
+```bash
+curl http://localhost:3000/health
+```
+
+## Monitoring
+
+Enable Prometheus metrics:
+
+```bash
+docker run -e DATABASE_URL=... \
+  -e ELECTRIC_PROMETHEUS_PORT=9090 \
+  -p 3000:3000 -p 9090:9090 electricsql/electric
+```
+
+Key metrics:
+
+- `electric.postgres.replication.slot_retained_wal_size`
+- `electric.postgres.replication.slot_confirmed_flush_lsn_lag`

--- a/packages/typescript-client/skills/electric-auth/SKILL.md
+++ b/packages/typescript-client/skills/electric-auth/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: electric-auth
+description: >
+  Authentication and authorization — proxy auth pattern, gatekeeper tokens,
+  shape-scoped access, session isolation, Vary header, dynamic headers,
+  FetchError 401/403 handling, role-based access, team isolation, Clerk,
+  Auth0, Supabase Auth integration
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:website/docs/guides/auth.md'
+  - 'electric:website/docs/guides/security.md'
+---
+
+# Electric Auth
+
+Electric is just HTTP — use standard web auth patterns.
+
+## Setup
+
+```typescript
+import { ShapeStream, FetchError } from '@electric-sql/client'
+```
+
+## Core Patterns
+
+### Proxy Auth (Recommended)
+
+```
+Client → Auth Proxy → Electric → Postgres
+           ↓
+    Validates user → Scopes shape → Injects secret
+```
+
+```typescript
+// Client
+const stream = new ShapeStream({
+  url: '/api/todos',
+  headers: { Authorization: `Bearer ${authToken}` },
+})
+
+// Server proxy
+const user = await validateToken(request.headers.get('Authorization'))
+if (!user) return new Response('Unauthorized', { status: 401 })
+
+originUrl.searchParams.set('table', 'todos')
+originUrl.searchParams.set('where', 'user_id = $1')
+originUrl.searchParams.set('params', JSON.stringify([user.id]))
+originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET!)
+
+const headers = new Headers(response.headers)
+headers.set('Vary', 'Authorization') // cache isolation
+```
+
+### Dynamic Header Refresh
+
+```typescript
+const stream = new ShapeStream({
+  url: '/api/todos',
+  headers: {
+    Authorization: async () => `Bearer ${await getAccessToken()}`,
+  },
+})
+```
+
+### Error Handling for Auth
+
+```typescript
+const stream = new ShapeStream({
+  url: '/api/todos',
+  onError: async (error) => {
+    if (error instanceof FetchError && error.status === 401) {
+      const newToken = await refreshAuthToken()
+      return { headers: { Authorization: `Bearer ${newToken}` } }
+    }
+    if (error instanceof FetchError && error.status === 403) {
+      showAccessDenied()
+      return // stop stream
+    }
+  },
+})
+```
+
+### Authorization Patterns
+
+**Role-based:**
+
+```typescript
+if (user.role === 'admin') {
+  originUrl.searchParams.set('table', 'todos')
+} else {
+  originUrl.searchParams.set('table', 'todos')
+  originUrl.searchParams.set('where', 'user_id = $1')
+  originUrl.searchParams.set('params', JSON.stringify([user.id]))
+}
+```
+
+**Team/org isolation:**
+
+```typescript
+originUrl.searchParams.set('where', 'org_id = $1')
+originUrl.searchParams.set('params', JSON.stringify([user.orgId]))
+```
+
+### External Auth Providers
+
+Works with any provider (Clerk, Auth0, Supabase):
+
+```typescript
+// Clerk example
+import { auth } from '@clerk/nextjs'
+
+export async function GET(request: Request) {
+  const { userId } = auth()
+  if (!userId) return new Response('Unauthorized', { status: 401 })
+
+  originUrl.searchParams.set('where', 'user_id = $1')
+  originUrl.searchParams.set('params', JSON.stringify([userId]))
+}
+```
+
+## Common Mistakes
+
+### [CRITICAL] Exposing ELECTRIC_SECRET to browser client
+
+Wrong:
+
+```typescript
+const stream = new ShapeStream({
+  url: `https://electric.example.com/v1/shape?secret=${SECRET}`,
+})
+```
+
+Correct:
+
+```typescript
+// Client: no secret
+const stream = new ShapeStream({ url: '/api/todos' })
+
+// Server proxy: inject secret
+originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET!)
+```
+
+ELECTRIC_SECRET is for server-to-Electric auth. It must be injected server-side
+in the proxy, never included in client-side code or bundles.
+
+Source: AGENTS.md Security Rules #1
+
+### [CRITICAL] Calling Electric directly from client in production
+
+Wrong:
+
+```typescript
+const stream = new ShapeStream({
+  url: 'https://api.electric-sql.cloud/v1/shape?table=todos',
+})
+```
+
+Correct:
+
+```typescript
+const stream = new ShapeStream({ url: '/api/todos' })
+```
+
+Electric is public by default. Without a proxy, any client can request any table.
+Always route through your authenticated backend.
+
+Source: AGENTS.md Security Rules #2-3
+
+### [HIGH] Not setting Vary header on proxy response
+
+Wrong:
+
+```typescript
+return new Response(response.body, { headers })
+```
+
+Correct:
+
+```typescript
+headers.set('Vary', 'Authorization')
+return new Response(response.body, { headers })
+```
+
+Without `Vary: Authorization`, CDN or browser caches serve one user's shape
+response to another user. This leaks data between sessions.
+
+Source: website/docs/guides/auth.md
+
+### [MEDIUM] Using deprecated api_secret parameter
+
+Wrong:
+
+```typescript
+originUrl.searchParams.set('api_secret', process.env.ELECTRIC_SECRET!)
+```
+
+Correct:
+
+```typescript
+originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET!)
+```
+
+`api_secret` is deprecated in favor of `secret`. Removal planned for v2.
+
+Source: website/electric-api.yaml
+
+## Tension: Secure-by-default vs tutorial simplicity
+
+The simplest tutorial skips auth. But starting without a proxy means every reader
+builds insecure patterns they must retrofit later. All Electric skills use the
+proxy pattern from step one.
+
+Cross-reference: `electric-quickstart`, `electric-security-check`
+
+## References
+
+- [Auth Guide](https://electric-sql.com/docs/guides/auth)
+- [Security Guide](https://electric-sql.com/docs/guides/security)
+- [gatekeeper-auth example](https://github.com/electric-sql/electric/tree/main/examples/gatekeeper-auth)
+- [proxy-auth example](https://github.com/electric-sql/electric/tree/main/examples/proxy-auth)

--- a/packages/typescript-client/skills/electric-auth/SKILL.md
+++ b/packages/typescript-client/skills/electric-auth/SKILL.md
@@ -179,12 +179,20 @@ return new Response(response.body, { headers })
 Correct:
 
 ```typescript
+// Bearer token auth:
 headers.set('Vary', 'Authorization')
+// Cookie/session auth:
+headers.set('Vary', 'Cookie')
+
+// For CDN-fronted deployments, also consider:
+headers.set('Cache-Control', 'private, no-store')
 return new Response(response.body, { headers })
 ```
 
-Without `Vary: Authorization`, CDN or browser caches serve one user's shape
-response to another user. This leaks data between sessions.
+Without `Vary`, CDN or browser caches serve one user's shape response to another
+user. Use `Vary: Authorization` for bearer tokens, `Vary: Cookie` for session
+cookies. For authenticated shapes behind a CDN, add `Cache-Control: private,
+no-store` to prevent the CDN from caching user-scoped data.
 
 Source: website/docs/guides/auth.md
 

--- a/packages/typescript-client/skills/electric-drizzle/SKILL.md
+++ b/packages/typescript-client/skills/electric-drizzle/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: electric-drizzle
+description: >
+  Drizzle ORM with Electric — pgTable schema, drizzle-kit migrations,
+  drizzle-zod createSchemaFactory, createSelectSchema, createInsertSchema,
+  generateTxId, pg_current_xact_id, transaction txid pattern, snake_case casing
+type: composition
+library: '@electric-sql/client'
+library_version: '1.5.8'
+requires:
+  - 'drizzle-orm'
+  - 'drizzle-kit'
+  - 'drizzle-zod'
+sources:
+  - 'electric:examples/tanstack-db-web-starter/src/db'
+  - 'electric:examples/tanstack-db-web-starter/drizzle.config.ts'
+---
+
+# Drizzle ORM with Electric
+
+Drizzle handles schema definition, migrations, Zod validation, and txid
+generation for the Electric write path.
+
+## Setup
+
+```bash
+pnpm add drizzle-orm pg drizzle-zod zod
+pnpm add -D drizzle-kit @types/pg
+```
+
+## Core Patterns
+
+### Schema Definition
+
+```typescript
+// src/db/schema.ts
+import {
+  pgTable,
+  text,
+  varchar,
+  boolean,
+  integer,
+  timestamp,
+} from 'drizzle-orm/pg-core'
+
+export const todosTable = pgTable('todos', {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  text: varchar({ length: 500 }).notNull(),
+  completed: boolean().notNull().default(false),
+  created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  user_id: text('user_id').notNull(),
+})
+```
+
+### Zod Schema Generation
+
+```typescript
+import { createSchemaFactory } from 'drizzle-zod'
+import { z } from 'zod'
+
+const { createSelectSchema, createInsertSchema } = createSchemaFactory({
+  zodInstance: z,
+})
+
+export const selectTodoSchema = createSelectSchema(todosTable)
+export const insertTodoSchema = createInsertSchema(todosTable)
+export const createTodoSchema = insertTodoSchema.omit({
+  id: true,
+  created_at: true,
+})
+```
+
+### Transaction ID Generation
+
+```typescript
+import { sql } from 'drizzle-orm'
+
+async function generateTxId(tx: any): Promise<number> {
+  const result = await tx.execute(
+    sql`SELECT pg_current_xact_id()::xid::text as txid`
+  )
+  return parseInt(result.rows[0].txid, 10)
+}
+```
+
+The `::xid` cast strips the epoch to match Electric's replication stream format.
+
+### Mutations with txid
+
+```typescript
+export async function createTodo(input: NewTodo) {
+  return await db.transaction(async (tx) => {
+    const txid = await generateTxId(tx)
+    const [newTodo] = await tx.insert(todosTable).values(input).returning()
+    return { item: newTodo, txid }
+  })
+}
+```
+
+### Drizzle Config
+
+```typescript
+// drizzle.config.ts
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  out: './src/db/migrations',
+  schema: './src/db/schema.ts',
+  dialect: 'postgresql',
+  casing: 'snake_case',
+  dbCredentials: { url: process.env.DATABASE_URL! },
+})
+```
+
+### Migrations
+
+```bash
+pnpm drizzle-kit generate   # generate migration from schema changes
+pnpm drizzle-kit migrate    # apply migrations
+pnpm drizzle-kit push       # push directly (dev only)
+```
+
+## Common Mistakes
+
+### [CRITICAL] Not generating txid in Drizzle mutation
+
+Wrong:
+
+```typescript
+export async function createTodo(input: NewTodo) {
+  const [todo] = await db.insert(todosTable).values(input).returning()
+  return { todo }
+}
+```
+
+Correct:
+
+```typescript
+export async function createTodo(input: NewTodo) {
+  return await db.transaction(async (tx) => {
+    const txid = await generateTxId(tx)
+    const [todo] = await tx.insert(todosTable).values(input).returning()
+    return { todo, txid }
+  })
+}
+```
+
+Must call `pg_current_xact_id()::xid::text` in the same transaction as the write.
+Without txid, the TanStack DB collection can't drop optimistic state.
+
+Source: AGENTS.md Write-path contract
+
+### [HIGH] Schema mismatch between Drizzle and Electric shape
+
+Wrong:
+
+```typescript
+// Drizzle schema has "createdAt" (camelCase)
+// But Electric shape uses column name "created_at" (snake_case)
+origin.searchParams.set('columns', 'id,createdAt')
+```
+
+Correct:
+
+```typescript
+// Use the actual Postgres column names in shape params
+origin.searchParams.set('columns', 'id,created_at')
+```
+
+Shape `columns` param must match the actual Postgres column names, not Drizzle's
+JavaScript property names.
+
+Source: examples/tanstack-db-web-starter
+
+### [HIGH] Using timestamp without timezone
+
+Wrong:
+
+```typescript
+created_at: timestamp().notNull().defaultNow(),
+```
+
+Correct:
+
+```typescript
+created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
+```
+
+Always use `withTimezone: true` for timestamps. Electric preserves timezone info,
+and timestamps without timezone can cause inconsistencies across time zones.
+
+Source: examples/tanstack-db-web-starter/src/db/schema.ts
+
+## References
+
+- [Drizzle ORM Docs](https://orm.drizzle.team)
+- [drizzle-zod](https://orm.drizzle.team/docs/zod)
+- [tanstack-db-web-starter](https://github.com/electric-sql/electric/tree/main/examples/tanstack-db-web-starter)

--- a/packages/typescript-client/skills/electric-expo/SKILL.md
+++ b/packages/typescript-client/skills/electric-expo/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: electric-expo
+description: >
+  React Native + Expo setup — react-native-random-uuid polyfill,
+  electricCollectionOptions, useLiveQuery, mobile proxy patterns, Express
+  backend, hostname detection via expo-constants, txid generation,
+  timestamp parsing, collection CRUD handlers
+type: composition
+library: '@electric-sql/client'
+library_version: '1.5.8'
+requires:
+  - 'expo'
+  - '@tanstack/react-db'
+  - '@tanstack/electric-db-collection'
+  - 'react-native-random-uuid'
+sources:
+  - 'electric:examples/tanstack-db-expo-starter'
+  - 'electric:AGENTS.md'
+---
+
+# Expo/React Native + Electric
+
+React Native integration with Electric sync via TanStack DB collections.
+
+## Setup
+
+```bash
+npx create-expo-app my-app
+cd my-app
+pnpm add @electric-sql/client @tanstack/react-db @tanstack/electric-db-collection
+pnpm add react-native-random-uuid expo-constants
+```
+
+**Critical**: Import the UUID polyfill at the top of your entry point:
+
+```typescript
+// index.ts or app/_layout.tsx — MUST be first import
+import 'react-native-random-uuid'
+```
+
+## Core Patterns
+
+### Collection Setup
+
+```typescript
+import 'react-native-random-uuid'
+import { createCollection, useLiveQuery } from '@tanstack/react-db'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+import { selectTodoSchema } from './db/schema'
+import { hostname } from './utils/api-client'
+
+const todoCollection = createCollection(
+  electricCollectionOptions({
+    id: 'todos',
+    schema: selectTodoSchema,
+    getKey: (item) => item.id,
+    shapeOptions: {
+      url: `http://${hostname}:3001/api/todos`,
+      parser: {
+        timestamptz: (date: string) => new Date(date),
+      },
+    },
+    onInsert: async ({ transaction }) => {
+      const { txid } = await apiClient.createTodo(
+        transaction.mutations[0].modified
+      )
+      return { txid: String(txid) }
+    },
+    onUpdate: async ({ transaction }) => {
+      const { original, changes } = transaction.mutations[0]
+      const { txid } = await apiClient.updateTodo(original.id, changes)
+      return { txid: String(txid) }
+    },
+    onDelete: async ({ transaction }) => {
+      const { id } = transaction.mutations[0].original
+      const { txid } = await apiClient.deleteTodo(id)
+      return { txid: String(txid) }
+    },
+  })
+)
+```
+
+### Hostname Detection
+
+```typescript
+// src/utils/api-client.ts
+import Constants from 'expo-constants'
+
+export const hostname =
+  Constants.expoConfig?.hostUri?.split(':')[0] ?? 'localhost'
+```
+
+In development, Expo dev server and your backend run on the same host but
+different ports. `expo-constants` extracts the correct hostname.
+
+### Express Backend with Proxy
+
+```typescript
+import express from 'express'
+import { ELECTRIC_PROTOCOL_QUERY_PARAMS } from '@electric-sql/client'
+
+const app = express()
+
+// Shape proxy
+app.get('/api/todos', async (req, res) => {
+  const electricUrl = new URL(
+    `${process.env.ELECTRIC_URL || 'http://localhost:3000'}/v1/shape`
+  )
+
+  Object.keys(req.query).forEach((key) => {
+    if (ELECTRIC_PROTOCOL_QUERY_PARAMS.includes(key as any)) {
+      electricUrl.searchParams.set(key, req.query[key] as string)
+    }
+  })
+  electricUrl.searchParams.set('table', 'todos')
+
+  const response = await fetch(electricUrl)
+  const headers: Record<string, string> = {}
+  response.headers.forEach((value, key) => {
+    if (key !== 'content-encoding' && key !== 'content-length') {
+      headers[key] = value
+    }
+  })
+
+  res.writeHead(response.status, headers)
+  const { Readable } = require('stream')
+  const nodeStream = Readable.fromWeb(response.body)
+  nodeStream.pipe(res)
+})
+
+// CRUD endpoints (return txid)
+app.post('/api/todos', async (req, res) => {
+  const result = await db.transaction(async (tx) => {
+    const txid = await generateTxId(tx)
+    const [todo] = await tx.insert(todos).values(req.body).returning()
+    return { todo, txid }
+  })
+  res.json(result)
+})
+```
+
+### React Native UI
+
+```tsx
+export default function HomeScreen() {
+  const [text, setText] = useState('')
+  const { data: todos } = useLiveQuery((q) => q.from({ todoCollection }))
+
+  return (
+    <View>
+      <TextInput value={text} onChangeText={setText} />
+      <Button
+        title="Add"
+        onPress={() => {
+          if (text.length > 0) {
+            todoCollection.insert({
+              id: Math.floor(Math.random() * 1000000),
+              text,
+              completed: false,
+              created_at: new Date(),
+              updated_at: new Date(),
+            })
+            setText('')
+          }
+        }}
+      />
+      <FlatList
+        data={todos}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            onPress={() =>
+              todoCollection.update(item.id, (d) => {
+                d.completed = !d.completed
+              })
+            }
+          >
+            <Text>{item.text}</Text>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  )
+}
+```
+
+## Common Mistakes
+
+### [HIGH] Missing react-native-random-uuid polyfill
+
+Wrong:
+
+```typescript
+// Entry point — no UUID polyfill
+import { createCollection } from '@tanstack/react-db'
+// crypto.randomUUID() throws: "crypto.randomUUID is not a function"
+```
+
+Correct:
+
+```typescript
+// Entry point — polyfill MUST be first import
+import 'react-native-random-uuid'
+import { createCollection } from '@tanstack/react-db'
+```
+
+React Native lacks `crypto.randomUUID()`. The polyfill must be imported before
+any code that uses it (including TanStack DB internals).
+
+Source: AGENTS.md React Native note
+
+### [HIGH] Using localhost URL in Expo app
+
+Wrong:
+
+```typescript
+shapeOptions: {
+  url: "http://localhost:3001/api/todos",
+}
+```
+
+Correct:
+
+```typescript
+import Constants from "expo-constants"
+const hostname = Constants.expoConfig?.hostUri?.split(":")[0] ?? "localhost"
+
+shapeOptions: {
+  url: `http://${hostname}:3001/api/todos`,
+}
+```
+
+On physical devices, `localhost` refers to the device itself, not your dev machine.
+Use `expo-constants` to get the correct host.
+
+Source: examples/tanstack-db-expo-starter
+
+### [CRITICAL] Not returning txid from mobile API
+
+Wrong:
+
+```typescript
+app.post('/api/todos', async (req, res) => {
+  const [todo] = await db.insert(todos).values(req.body).returning()
+  res.json({ todo })
+})
+```
+
+Correct:
+
+```typescript
+app.post('/api/todos', async (req, res) => {
+  const result = await db.transaction(async (tx) => {
+    const txid = await generateTxId(tx)
+    const [todo] = await tx.insert(todos).values(req.body).returning()
+    return { todo, txid }
+  })
+  res.json(result)
+})
+```
+
+Without txid, optimistic state never drops and UI shows duplicates.
+
+Source: AGENTS.md Write-path contract
+
+## References
+
+- [Expo Documentation](https://docs.expo.dev)
+- [tanstack-db-expo-starter](https://github.com/electric-sql/electric/tree/main/examples/tanstack-db-expo-starter)
+- [TanStack DB](https://tanstack.com/db/latest/docs/overview)

--- a/packages/typescript-client/skills/electric-go-live/SKILL.md
+++ b/packages/typescript-client/skills/electric-go-live/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: electric-go-live
+description: >
+  Production readiness checklist — security audit, deployment verification,
+  WAL monitoring, replication slot health, ELECTRIC_SECRET, proxy verification,
+  performance, SQLite storage, network FS exclusive mode
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:website/docs/guides/troubleshooting.md'
+  - 'electric:AGENTS.md'
+---
+
+# Electric Go-Live Checklist
+
+Production readiness verification before launch.
+
+## Setup
+
+Run through each section before deploying to production.
+
+## Core Patterns
+
+### Security Checklist
+
+- [ ] Electric behind authenticated proxy (never direct client access)
+- [ ] `ELECTRIC_SECRET` set (not `ELECTRIC_INSECURE=true`)
+- [ ] Server defines shapes (client cannot control `table` or `where`)
+- [ ] `Vary` header set on proxy responses (`Authorization` or `Cookie`)
+- [ ] No secrets in client bundle (`ELECTRIC_SECRET`, `SOURCE_SECRET`)
+- [ ] User scoping on every proxy route (`where user_id = $1`)
+
+### Database Checklist
+
+- [ ] `wal_level=logical` confirmed
+- [ ] Electric user has `REPLICATION` role
+- [ ] Tables have `REPLICA IDENTITY FULL`
+- [ ] `max_slot_wal_keep_size` set (e.g., `10GB`) to prevent unbounded WAL growth
+
+### Monitoring
+
+```sql
+-- Check replication slot health
+SELECT slot_name, active, wal_status,
+  pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal
+FROM pg_replication_slots
+WHERE slot_name LIKE 'electric%';
+```
+
+Key metrics to watch:
+
+- `electric.postgres.replication.slot_retained_wal_size`
+- `electric.postgres.replication.slot_confirmed_flush_lsn_lag`
+- `wal_status` should be `reserved` (not `extended` or `unreserved`)
+
+### Performance Checklist
+
+- [ ] HTTP/2 proxy configured (Caddy or nginx) — fixes 6-connection limit
+- [ ] SSE proxy buffering disabled (`flush_interval -1` / `proxy_buffering off`)
+- [ ] Shape columns limited to what's needed (skip large text/blob columns)
+- [ ] Custom type parsers configured for timestamps, JSON, arrays
+
+### Infrastructure
+
+- [ ] Electric service health check endpoint monitored (`/health`)
+- [ ] WAL retention alerts configured
+- [ ] Backup strategy includes replication slot awareness
+
+## Common Mistakes
+
+### [HIGH] WAL growth without monitoring
+
+Wrong:
+
+```sql
+-- No monitoring, default unlimited WAL retention
+-- Disk fills silently over days/weeks
+```
+
+Correct:
+
+```sql
+ALTER SYSTEM SET max_slot_wal_keep_size = '10GB';
+SELECT pg_reload_conf();
+```
+
+Active replication slots prevent WAL cleanup. Without `max_slot_wal_keep_size`,
+disk fills silently. If Electric disconnects, its slot holds WAL indefinitely.
+
+Source: website/docs/guides/troubleshooting.md
+
+### [MEDIUM] Using SQLite storage on network FS without exclusive mode
+
+Wrong:
+
+```yaml
+environment:
+  DATABASE_URL: postgres://...
+  ELECTRIC_STORAGE_DIR: /efs/electric # AWS EFS without exclusive mode
+```
+
+Correct:
+
+```yaml
+environment:
+  DATABASE_URL: postgres://...
+  ELECTRIC_STORAGE_DIR: /efs/electric
+  ELECTRIC_SHAPE_DB_EXCLUSIVE_MODE: true # Required for network FS
+```
+
+Network file systems (AWS EFS) need `ELECTRIC_SHAPE_DB_EXCLUSIVE_MODE=true`
+for SQLite-based shape storage to work correctly.
+
+Source: sync-service CHANGELOG.md
+
+### [HIGH] Deploying without HTTP/2 proxy
+
+Wrong:
+
+```yaml
+# Direct Electric exposure on port 3000, HTTP/1.1
+ports: ['3000:3000']
+```
+
+Correct:
+
+```yaml
+# Caddy reverse proxy with HTTP/2
+services:
+  caddy:
+    image: caddy:alpine
+    ports: ['443:443']
+    volumes: ['./Caddyfile:/etc/caddy/Caddyfile']
+```
+
+HTTP/1.1's 6-connection browser limit causes visible delays with multiple shapes.
+Production deployments should always use HTTP/2 via a reverse proxy.
+
+Source: website/docs/guides/troubleshooting.md
+
+## References
+
+- [Troubleshooting Guide](https://electric-sql.com/docs/guides/troubleshooting)
+- [Configuration Reference](https://electric-sql.com/docs/api/config)
+- [Postgres Permissions](https://electric-sql.com/docs/guides/postgres-permissions)

--- a/packages/typescript-client/skills/electric-http-api/SKILL.md
+++ b/packages/typescript-client/skills/electric-http-api/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: electric-http-api
+description: >
+  Electric HTTP protocol — GET /v1/shape, offsets, handles, live mode, SSE,
+  control messages, up-to-date, must-refetch, shape log, caching, CDN,
+  request collapsing, POST subset snapshots, changes-only mode
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:website/docs/api/http.md'
+  - 'electric:website/electric-api.yaml'
+---
+
+# Electric HTTP API
+
+The HTTP API is the low-level interface for syncing shapes. In production, always
+proxy through your backend. See `electric-proxy` for implementation patterns.
+
+## Setup
+
+The TypeScript client handles the protocol automatically:
+
+```typescript
+import { ShapeStream, Shape } from '@electric-sql/client'
+
+const stream = new ShapeStream({ url: `/api/todos` })
+const shape = new Shape(stream)
+```
+
+## Core Patterns
+
+### Sync Flow
+
+1. **Initial sync** — `GET /v1/shape?table=todos&offset=-1`
+2. **Catch up** — continue with `offset` from response until `up-to-date`
+3. **Live mode** — add `live=true&handle=<handle>` for real-time updates
+4. **SSE mode** — add `live_sse=true` for persistent streaming connection
+
+### Response Format
+
+```json
+[
+  {
+    "key": "1",
+    "value": { "id": "1", "title": "Buy milk" },
+    "headers": { "operation": "insert" }
+  },
+  { "headers": { "control": "up-to-date" } }
+]
+```
+
+Operations: `insert`, `update`, `delete`
+Control messages: `up-to-date`, `must-refetch`
+
+### Response Headers
+
+| Header            | Description                              |
+| ----------------- | ---------------------------------------- |
+| `electric-handle` | Shape identifier for subsequent requests |
+| `electric-offset` | Next offset to request                   |
+| `electric-schema` | JSON schema (first request only)         |
+
+### SSE Mode
+
+```bash
+curl 'http://localhost:3000/v1/shape?table=todos&offset=0_0&handle=abc&live=true&live_sse=true'
+```
+
+SSE provides persistent streaming with lower latency. Keep-alive comments sent
+every 21 seconds. Client auto-detects buffered SSE and falls back to long-polling.
+
+### Caching and CDN
+
+Electric responses include `cache-control` and `etag` headers enabling:
+
+- CDN caching of shape log segments
+- Browser cache for unchanged data
+- Request collapsing (many clients share one upstream request)
+
+### Subset Snapshots (POST)
+
+For large WHERE clauses that exceed URL limits, use POST:
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/items`,
+  params: { table: 'items' },
+  log: 'changes_only',
+  subsetMethod: 'POST',
+})
+
+const { data } = await stream.requestSnapshot({
+  where: 'id = ANY($1)',
+  params: { '1': '{id1,id2,id3}' },
+})
+```
+
+## Common Mistakes
+
+### [HIGH] Not handling must-refetch control message
+
+Wrong:
+
+```typescript
+stream.subscribe((messages) => {
+  for (const msg of messages) {
+    if ('value' in msg) {
+      rows.set(msg.key, msg.value)
+    }
+  }
+})
+```
+
+Correct:
+
+```typescript
+stream.subscribe((messages) => {
+  for (const msg of messages) {
+    if ('value' in msg) {
+      rows.set(msg.key, msg.value)
+    } else if (msg.headers?.control === 'must-refetch') {
+      rows.clear()
+      // stream will automatically restart
+    }
+  }
+})
+```
+
+Shape rotation sends `must-refetch`. Ignoring it means the client has stale data
+with no error signal.
+
+Source: website/electric-api.yaml
+
+### [HIGH] Using offset > -1 without providing handle
+
+Wrong:
+
+```typescript
+const url = `/v1/shape?table=todos&offset=0_5`
+```
+
+Correct:
+
+```typescript
+const url = `/v1/shape?table=todos&offset=0_5&handle=abc123`
+```
+
+Requesting with a non-initial offset without a handle throws
+`MissingShapeHandleError`. The handle identifies which shape log to continue from.
+
+Source: packages/typescript-client/src/client.ts
+
+### [MEDIUM] Using GET for large subset snapshots
+
+Wrong:
+
+```typescript
+// URL exceeds 8KB with hundreds of IDs
+const url = `/v1/shape?table=items&subset__where=id=ANY($1)&subset__params=...`
+```
+
+Correct:
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/items`,
+  log: 'changes_only',
+  subsetMethod: 'POST',
+})
+```
+
+Complex WHERE clauses with many values hit HTTP 414 (URI Too Long). Use POST
+with JSON body. In Electric 2.0, GET for subsets will be deprecated.
+
+Source: typescript-client CHANGELOG.md v1.5.0
+
+## Tension: CDN cacheability vs real-time freshness
+
+Electric's HTTP caching enables CDN-scale distribution but can cause stale data
+if caching is too aggressive. Electric manages this with short `max-age` and
+`stale-while-revalidate`, but proxy/CDN config must preserve these headers.
+
+Cross-reference: `deploying-electric`
+
+## Tension: SSE efficiency vs proxy compatibility
+
+SSE provides lower-latency streaming but requires proxies to disable buffering.
+Most proxies buffer by default, causing SSE to silently degrade to long-polling.
+
+Cross-reference: `electric-proxy-config`
+
+## References
+
+- [OpenAPI Specification](https://electric-sql.com/openapi.html)
+- [HTTP API Docs](https://electric-sql.com/docs/api/http)
+- Reference: `electric-http-api/references/subset-params.md`

--- a/packages/typescript-client/skills/electric-http-api/SKILL.md
+++ b/packages/typescript-client/skills/electric-http-api/SKILL.md
@@ -171,7 +171,8 @@ const stream = new ShapeStream({
 ```
 
 Complex WHERE clauses with many values hit HTTP 414 (URI Too Long). Use POST
-with JSON body. In Electric 2.0, GET for subsets will be deprecated.
+with JSON body. GET for subset snapshots is planned for deprecation
+(see [troubleshooting docs](https://electric-sql.com/docs/guides/troubleshooting#414-request-uri-too-long)).
 
 Source: typescript-client CHANGELOG.md v1.5.0
 

--- a/packages/typescript-client/skills/electric-http-api/references/subset-params.md
+++ b/packages/typescript-client/skills/electric-http-api/references/subset-params.md
@@ -1,0 +1,75 @@
+---
+name: subset-params-reference
+parent: electric-http-api
+---
+
+# Subset Snapshot Parameters Reference
+
+Subset snapshots let you fetch specific data portions in changes-only mode.
+
+## Query Parameters (GET)
+
+| Parameter          | Type          | Description                                        |
+| ------------------ | ------------- | -------------------------------------------------- |
+| `subset__where`    | `string`      | SQL WHERE filter for subset                        |
+| `subset__params`   | `JSON object` | Positional parameters for WHERE (`{"1": "value"}`) |
+| `subset__limit`    | `number`      | Maximum rows to return                             |
+| `subset__order_by` | `string`      | Column to order results by                         |
+
+## POST Body (recommended for large queries)
+
+```json
+{
+  "where": "id = ANY($1)",
+  "params": { "1": "{id1,id2,id3}" },
+  "order_by": "created_at",
+  "limit": 100
+}
+```
+
+## TypeScript Client
+
+```typescript
+// Set POST as default for all subset requests
+const stream = new ShapeStream({
+  url: `/api/items`,
+  log: 'changes_only',
+  subsetMethod: 'POST',
+})
+
+// Request a snapshot
+const { metadata, data } = await stream.requestSnapshot({
+  where: 'priority = $1',
+  params: { '1': 'high' },
+  limit: 50,
+})
+
+// Override method per-request
+const { data } = await stream.requestSnapshot({
+  where: 'id = ANY($1)',
+  params: { '1': '{id1,id2,...}' },
+  method: 'POST',
+})
+```
+
+## Response
+
+Subset snapshot responses include metadata for change deduplication:
+
+```json
+{
+  "metadata": {
+    "snapshotOffset": "123_4",
+    "snapshotHandle": "abc"
+  },
+  "data": [{ "key": "1", "value": { "id": "1", "priority": "high" } }]
+}
+```
+
+## Interaction with Changes-Only Mode
+
+Subset snapshots only work with `log: "changes_only"`. The workflow is:
+
+1. Subscribe to changes-only stream for real-time updates
+2. Request subset snapshots as needed for specific data
+3. Use snapshot metadata to deduplicate with incoming changes

--- a/packages/typescript-client/skills/electric-nextjs/SKILL.md
+++ b/packages/typescript-client/skills/electric-nextjs/SKILL.md
@@ -173,7 +173,8 @@ export async function GET(request: Request) {
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set('table', 'todos')
-  originUrl.searchParams.set('where', `user_id = '${session.user.id}'`)
+  originUrl.searchParams.set('where', 'user_id = $1')
+  originUrl.searchParams.set('params', JSON.stringify([session.user.id]))
 
   return proxyElectricRequest(originUrl)
 }

--- a/packages/typescript-client/skills/electric-nextjs/SKILL.md
+++ b/packages/typescript-client/skills/electric-nextjs/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: electric-nextjs
+description: >
+  Next.js App Router integration — route.ts proxy handlers, NextRequest,
+  ELECTRIC_PROTOCOL_QUERY_PARAMS, useShape, getShapeStream, matchStream,
+  useOptimistic, content-encoding deletion, Vercel deployment, edge runtime
+  SSE considerations, server components
+type: composition
+library: '@electric-sql/client'
+library_version: '1.5.8'
+requires:
+  - 'next'
+  - '@electric-sql/client'
+  - '@electric-sql/react'
+sources:
+  - 'electric:examples/nextjs/app/shape-proxy/route.ts'
+  - 'electric:examples/nextjs/app/page.tsx'
+---
+
+# Next.js + Electric
+
+Next.js App Router integration with Electric shape proxy routes.
+
+## Setup
+
+```bash
+pnpm add @electric-sql/client @electric-sql/react
+```
+
+## Core Patterns
+
+### Proxy Route (App Router)
+
+```typescript
+// app/api/todos/route.ts (or app/shape-proxy/route.ts)
+import { ELECTRIC_PROTOCOL_QUERY_PARAMS } from '@electric-sql/client'
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const originUrl = new URL(
+    `${process.env.ELECTRIC_URL || 'http://localhost:3000'}/v1/shape`
+  )
+
+  // Only forward Electric protocol params
+  url.searchParams.forEach((value, key) => {
+    if (ELECTRIC_PROTOCOL_QUERY_PARAMS.includes(key)) {
+      originUrl.searchParams.set(key, value)
+    }
+  })
+
+  // Server defines the shape
+  originUrl.searchParams.set('table', 'items')
+
+  // Electric Cloud auth (if configured)
+  if (process.env.ELECTRIC_SOURCE_ID) {
+    originUrl.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID)
+  }
+  if (process.env.ELECTRIC_SOURCE_SECRET) {
+    originUrl.searchParams.set('secret', process.env.ELECTRIC_SOURCE_SECRET)
+  }
+
+  let resp = await fetch(originUrl.toString())
+
+  // Remove encoding headers that break browser decoding
+  if (resp.headers.get('content-encoding')) {
+    const headers = new Headers(resp.headers)
+    headers.delete('content-encoding')
+    headers.delete('content-length')
+    resp = new Response(resp.body, {
+      status: resp.status,
+      statusText: resp.statusText,
+      headers,
+    })
+  }
+
+  return resp
+}
+```
+
+### Client Component with useShape
+
+```tsx
+'use client'
+
+import { useShape } from '@electric-sql/react'
+
+type Item = { id: string; title: string }
+
+export default function ItemList() {
+  const { data: items, isLoading } = useShape<Item>({
+    url: `/api/todos`,
+  })
+
+  if (isLoading) return <p>Loading...</p>
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### Optimistic Updates with React 19
+
+```tsx
+'use client'
+
+import { useOptimistic } from 'react'
+import { useShape, getShapeStream } from '@electric-sql/react'
+import { matchStream } from './match-stream'
+
+type Item = { id: string }
+
+export default function Items() {
+  const { data: items } = useShape<Item>({
+    url: `/shape-proxy`,
+  })
+
+  const [optimisticItems, updateOptimistic] = useOptimistic(
+    items,
+    (state, { newId }: { newId: string }) => {
+      const map = new Map(state.map((i) => [i.id, i]))
+      map.set(newId, { id: newId })
+      return Array.from(map.values())
+    }
+  )
+
+  async function addItem(newId: string) {
+    const stream = getShapeStream<Item>({ url: `/shape-proxy` })
+
+    const findPromise = matchStream({
+      stream,
+      operations: ['insert'],
+      matchFn: ({ message }) => message.value.id === newId,
+    })
+
+    const fetchPromise = fetch('/api/items', {
+      method: 'POST',
+      body: JSON.stringify({ uuid: newId }),
+    })
+
+    await Promise.all([findPromise, fetchPromise])
+  }
+
+  return (
+    <form
+      action={async (formData) => {
+        const newId = formData.get('new-id') as string
+        updateOptimistic({ newId })
+        await addItem(newId)
+      }}
+    >
+      <input type="hidden" name="new-id" value={crypto.randomUUID()} />
+      <button type="submit">Add Item</button>
+    </form>
+  )
+}
+```
+
+### Auth-Protected Proxy
+
+```typescript
+// app/api/todos/route.ts
+import { auth } from '@/lib/auth'
+
+export async function GET(request: Request) {
+  const session = await auth()
+  if (!session?.user) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const originUrl = prepareElectricUrl(request.url)
+  originUrl.searchParams.set('table', 'todos')
+  originUrl.searchParams.set('where', `user_id = '${session.user.id}'`)
+
+  return proxyElectricRequest(originUrl)
+}
+```
+
+## Common Mistakes
+
+### [HIGH] Using Pages Router API route patterns in App Router
+
+Wrong:
+
+```typescript
+// pages/api/todos.ts (Pages Router — wrong for App Router)
+export default function handler(req, res) {
+  res.json({ data: [] })
+}
+```
+
+Correct:
+
+```typescript
+// app/api/todos/route.ts (App Router)
+export async function GET(request: Request) {
+  return new Response(JSON.stringify({ data: [] }))
+}
+```
+
+App Router uses `route.ts` with Web API `Request`/`Response`. Pages Router uses
+`handler(req, res)`. These are incompatible API surfaces.
+
+Source: Next.js documentation
+
+### [MEDIUM] SSE on Vercel serverless (timeout)
+
+Wrong:
+
+```typescript
+// Default serverless runtime — 10s timeout
+export async function GET(request: Request) {
+  // SSE connection will be killed by timeout
+}
+```
+
+Correct:
+
+```typescript
+// Use edge runtime for long-lived connections
+export const runtime = 'edge'
+
+export async function GET(request: Request) {
+  // Edge runtime has longer timeout for streaming
+}
+```
+
+Vercel serverless functions have execution time limits. SSE streaming may not
+work without edge runtime. The Electric client falls back to long-polling.
+
+Source: Vercel documentation
+
+### [HIGH] Not disabling Vercel CDN caching for Electric routes
+
+Wrong:
+
+```typescript
+// No cache config — Vercel CDN may cache shape responses
+```
+
+Correct:
+
+```json
+{
+  "headers": [
+    {
+      "source": "/api/electric/(.*)",
+      "headers": [
+        { "key": "CDN-Cache-Control", "value": "no-store" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "no-store" }
+      ]
+    }
+  ]
+}
+```
+
+Vercel's CDN caches responses and its cache keys may not differentiate between
+offset/handle parameters. Stale responses break shape sync.
+
+Source: website/docs/guides/troubleshooting.md
+
+## References
+
+- [Next.js App Router](https://nextjs.org/docs/app)
+- [nextjs example](https://github.com/electric-sql/electric/tree/main/examples/nextjs)
+- [Vercel Deployment](https://vercel.com/docs)

--- a/packages/typescript-client/skills/electric-proxy-config/SKILL.md
+++ b/packages/typescript-client/skills/electric-proxy-config/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: electric-proxy-config
+description: >
+  Configuring Caddy and nginx for HTTP/2 and SSE streaming — flush_interval,
+  proxy_buffering off, reverse_proxy, 6-connection limit fix, slow shapes
+  in dev and production, gzip encoding, keep-alive, fallback detection
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:website/docs/guides/troubleshooting.md'
+---
+
+# Electric HTTP/2 & SSE Proxy Setup
+
+Fixes slow shapes caused by HTTP/1.1's 6-connection browser limit and SSE
+proxy buffering issues.
+
+## Setup
+
+No code dependencies — this is infrastructure configuration.
+
+## Core Patterns
+
+### Why HTTP/2 Matters
+
+HTTP/1.1 allows only 6 simultaneous connections per origin. Each Electric shape
+holds a connection, so 6+ shapes cause visible delays. This also blocks HMR and
+dev server assets sharing the same origin.
+
+HTTP/2 multiplexes requests over a single TCP connection — unlimited shapes.
+
+### Caddy (Recommended for Local Dev)
+
+```bash
+# 1. Install Caddy
+brew install caddy  # macOS
+
+# 2. Trust Caddy's certificate (required for HTTP/2)
+caddy trust
+```
+
+```bash
+# 3. Run Caddy proxy
+caddy run --config - --adapter caddyfile <<EOF
+localhost:3001 {
+  reverse_proxy localhost:3000 {
+    flush_interval -1
+  }
+  encode gzip
+}
+EOF
+```
+
+Then change shape URLs to use port 3001 instead of 3000.
+
+**Important**: Run Caddy directly on your machine, not in Docker. Docker cannot
+use HTTP/2 without additional TLS setup, defeating the purpose.
+
+### Caddy with SSE Streaming
+
+```caddyfile
+localhost:3001 {
+  reverse_proxy localhost:3000 {
+    flush_interval -1
+  }
+  encode gzip
+  header {
+    Cache-Control "no-cache, no-transform"
+    X-Accel-Buffering "no"
+  }
+}
+```
+
+`flush_interval -1` disables internal buffering so SSE events arrive immediately.
+
+### Nginx
+
+```nginx
+location /v1/shape {
+  proxy_pass http://localhost:3000;
+  proxy_buffering off;
+  proxy_http_version 1.1;
+  proxy_cache_valid 200 1s;
+}
+```
+
+`proxy_buffering off` is required for SSE. Preserve Electric's cache headers for
+request collapsing efficiency.
+
+### Vercel CDN Configuration
+
+Vercel may cache Electric responses via its CDN. Disable caching for Electric routes:
+
+```json
+{
+  "headers": [
+    {
+      "source": "/api/electric/(.*)",
+      "headers": [
+        { "key": "CDN-Cache-Control", "value": "no-store" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "no-store" }
+      ]
+    }
+  ]
+}
+```
+
+## Common Mistakes
+
+### [HIGH] Not configuring HTTP/2 proxy in local dev
+
+Wrong:
+
+```typescript
+// Direct to Electric on HTTP/1.1
+const stream = new ShapeStream({ url: 'http://localhost:3000/v1/shape' })
+```
+
+Correct:
+
+```bash
+# Run Caddy, then use port 3001
+caddy run --config - --adapter caddyfile <<EOF
+localhost:3001 {
+  reverse_proxy localhost:3000
+  encode gzip
+}
+EOF
+```
+
+```typescript
+const stream = new ShapeStream({ url: 'http://localhost:3001/v1/shape' })
+```
+
+HTTP/1.1's 6-connection limit causes delays with multiple shapes. Also blocks
+dev server HMR. Caddy adds HTTP/2 with zero configuration.
+
+Source: website/docs/guides/troubleshooting.md
+
+### [MEDIUM] SSE without disabling proxy buffering
+
+Wrong:
+
+```nginx
+# nginx default: proxy_buffering on
+location /v1/shape {
+  proxy_pass http://localhost:3000;
+}
+```
+
+Correct:
+
+```nginx
+location /v1/shape {
+  proxy_pass http://localhost:3000;
+  proxy_buffering off;
+}
+```
+
+Without disabling buffering, nginx holds SSE events until the buffer fills. The
+Electric client detects this (3 consecutive short connections) and falls back to
+long-polling — functional but less efficient.
+
+Source: website/docs/guides/troubleshooting.md
+
+### [HIGH] Running Caddy in Docker (loses HTTP/2)
+
+Wrong:
+
+```yaml
+# docker-compose.yml
+services:
+  caddy:
+    image: caddy:alpine
+    ports: ['3001:3001']
+```
+
+Correct:
+
+```bash
+# Install and run directly on host machine
+brew install caddy
+caddy trust
+caddy run --config - --adapter caddyfile <<EOF
+localhost:3001 { reverse_proxy localhost:3000 }
+EOF
+```
+
+Caddy in Docker can't install certificates into the host OS. Without trusted certs,
+browsers won't use HTTP/2, defeating the purpose.
+
+Source: website/docs/guides/troubleshooting.md
+
+## Tension: SSE efficiency vs proxy compatibility
+
+SSE provides lower-latency streaming, but most proxies buffer responses by default.
+Without proper proxy configuration, SSE silently degrades to long-polling.
+
+Cross-reference: `electric-http-api`
+
+## References
+
+- [Troubleshooting Guide](https://electric-sql.com/docs/guides/troubleshooting)
+- [Caddy Server](https://caddyserver.com/docs)

--- a/packages/typescript-client/skills/electric-proxy/SKILL.md
+++ b/packages/typescript-client/skills/electric-proxy/SKILL.md
@@ -114,7 +114,8 @@ export async function GET(request: NextRequest) {
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set('table', 'todos')
-  originUrl.searchParams.set('where', `user_id = '${session.user.id}'`)
+  originUrl.searchParams.set('where', 'user_id = $1')
+  originUrl.searchParams.set('params', JSON.stringify([session.user.id]))
   return proxyElectricRequest(originUrl)
 }
 ```
@@ -194,8 +195,15 @@ headers.delete('content-length')
 return new Response(response.body, { headers })
 ```
 
-`electric-offset`, `electric-handle`, and `electric-schema` must be forwarded.
-Stripping them throws `MissingHeadersError` in the client.
+These headers must be forwarded to the client:
+
+- `electric-offset` — next position in the shape log
+- `electric-handle` — shape identifier for subsequent requests
+- `electric-schema` — JSON schema (first request only)
+- `cache-control`, `etag` — caching directives for CDN/browser
+
+Stripping the `electric-*` headers throws `MissingHeadersError` in the client.
+Stripping cache headers breaks request collapsing and CDN efficiency.
 
 Source: packages/typescript-client/src/fetch.ts
 

--- a/packages/typescript-client/skills/electric-proxy/SKILL.md
+++ b/packages/typescript-client/skills/electric-proxy/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: electric-proxy
+description: >
+  Implementing proxy routes — ELECTRIC_PROTOCOL_QUERY_PARAMS, prepareElectricUrl,
+  proxyElectricRequest, content-encoding deletion, Vary header, one route per
+  table, server-defined shapes, parameterized WHERE, TanStack Start, Next.js,
+  Express, Hono framework examples
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:examples/tanstack-db-web-starter/src/lib/electric-proxy.ts'
+  - 'electric:website/docs/guides/auth.md'
+  - 'electric:AGENTS.md'
+---
+
+# Electric Proxy Implementation
+
+Electric is public by default — **always use a proxy in production**.
+
+## Setup
+
+```typescript
+import { ELECTRIC_PROTOCOL_QUERY_PARAMS } from '@electric-sql/client'
+```
+
+## Core Patterns
+
+### Reusable Helper Functions
+
+```typescript
+// lib/electric-proxy.ts
+import { ELECTRIC_PROTOCOL_QUERY_PARAMS } from '@electric-sql/client'
+
+export function prepareElectricUrl(requestUrl: string): URL {
+  const url = new URL(requestUrl)
+  const originUrl = new URL(
+    `${process.env.ELECTRIC_URL || 'http://localhost:3000'}/v1/shape`
+  )
+
+  url.searchParams.forEach((value, key) => {
+    if (ELECTRIC_PROTOCOL_QUERY_PARAMS.includes(key)) {
+      originUrl.searchParams.set(key, value)
+    }
+  })
+
+  if (process.env.ELECTRIC_SOURCE_ID && process.env.ELECTRIC_SECRET) {
+    originUrl.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID)
+    originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET)
+  }
+
+  return originUrl
+}
+
+export async function proxyElectricRequest(originUrl: URL): Promise<Response> {
+  const response = await fetch(originUrl)
+  const headers = new Headers(response.headers)
+  headers.delete('content-encoding')
+  headers.delete('content-length')
+  headers.set('vary', 'authorization')
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+```
+
+### One Route Per Table
+
+```typescript
+// /api/todos — server hardcodes table
+const originUrl = prepareElectricUrl(request.url)
+originUrl.searchParams.set('table', 'todos')
+return proxyElectricRequest(originUrl)
+
+// /api/projects — separate route, separate table
+const originUrl = prepareElectricUrl(request.url)
+originUrl.searchParams.set('table', 'projects')
+return proxyElectricRequest(originUrl)
+```
+
+### Parameterized WHERE (user scoping)
+
+```typescript
+originUrl.searchParams.set('where', 'user_id = $1')
+originUrl.searchParams.set('params', JSON.stringify([userId]))
+```
+
+### Passing Client Arguments to Proxy
+
+```typescript
+// Client
+shapeOptions: {
+  url: `/api/todos?projectId=${projectId}`
+}
+
+// Server
+const projectId = new URL(request.url).searchParams.get('projectId')
+originUrl.searchParams.set('where', 'project_id = $1')
+originUrl.searchParams.set('params', JSON.stringify([projectId]))
+```
+
+### Framework Examples
+
+**Next.js App Router:**
+
+```typescript
+// app/api/todos/route.ts
+export async function GET(request: NextRequest) {
+  const session = await auth()
+  if (!session?.user) return new Response('Unauthorized', { status: 401 })
+
+  const originUrl = prepareElectricUrl(request.url)
+  originUrl.searchParams.set('table', 'todos')
+  originUrl.searchParams.set('where', `user_id = '${session.user.id}'`)
+  return proxyElectricRequest(originUrl)
+}
+```
+
+**TanStack Start:**
+
+```typescript
+const serve = async ({ request }: { request: Request }) => {
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session) return new Response('Unauthorized', { status: 401 })
+
+  const originUrl = prepareElectricUrl(request.url)
+  originUrl.searchParams.set('table', 'todos')
+  return proxyElectricRequest(originUrl)
+}
+```
+
+**Express:**
+
+```typescript
+router.get('/todos', async (req, res) => {
+  const fullUrl = `${req.protocol}://${req.get('host')}${req.originalUrl}`
+  const originUrl = prepareElectricUrl(fullUrl)
+  originUrl.searchParams.set('table', 'todos')
+
+  const response = await proxyElectricRequest(originUrl)
+  res.status(response.status)
+  response.headers.forEach((v, k) => res.setHeader(k, v))
+  res.send(Buffer.from(await response.arrayBuffer()))
+})
+```
+
+## Common Mistakes
+
+### [CRITICAL] Letting client define table and WHERE params
+
+Wrong:
+
+```typescript
+app.get('/api/shape', (req) => {
+  const { table, where } = req.query
+  originUrl.searchParams.set('table', table)
+  originUrl.searchParams.set('where', where)
+})
+```
+
+Correct:
+
+```typescript
+// /api/todos.ts — server hardcodes the table
+originUrl.searchParams.set('table', 'todos')
+originUrl.searchParams.set('where', 'user_id = $1')
+originUrl.searchParams.set('params', JSON.stringify([session.user.id]))
+```
+
+Client-controlled shape params allow data exfiltration. A generic `/api/shape?table=X`
+endpoint lets clients query ANY table. Server must define table and WHERE.
+
+Source: AGENTS.md Security Rules #4
+
+### [HIGH] Proxy strips required Electric response headers
+
+Wrong:
+
+```typescript
+const headers = new Headers()
+headers.set('content-type', response.headers.get('content-type')!)
+return new Response(response.body, { headers })
+```
+
+Correct:
+
+```typescript
+const headers = new Headers(response.headers)
+headers.delete('content-encoding')
+headers.delete('content-length')
+return new Response(response.body, { headers })
+```
+
+`electric-offset`, `electric-handle`, and `electric-schema` must be forwarded.
+Stripping them throws `MissingHeadersError` in the client.
+
+Source: packages/typescript-client/src/fetch.ts
+
+### [HIGH] Not forwarding Electric protocol query params
+
+Wrong:
+
+```typescript
+const originUrl = new URL(`${ELECTRIC_URL}/v1/shape`)
+originUrl.searchParams.set('table', 'todos')
+return fetch(originUrl)
+```
+
+Correct:
+
+```typescript
+const originUrl = prepareElectricUrl(request.url)
+originUrl.searchParams.set('table', 'todos')
+return proxyElectricRequest(originUrl)
+```
+
+Must pass `offset`, `handle`, `live`, `cursor` through the proxy. Use the
+`ELECTRIC_PROTOCOL_QUERY_PARAMS` constant to know which params to forward.
+
+Source: AGENTS.md proxy example
+
+## References
+
+- [Auth Guide](https://electric-sql.com/docs/guides/auth)
+- [Security Guide](https://electric-sql.com/docs/guides/security)
+- [proxy-auth example](https://github.com/electric-sql/electric/tree/main/examples/proxy-auth)

--- a/packages/typescript-client/skills/electric-quickstart/SKILL.md
+++ b/packages/typescript-client/skills/electric-quickstart/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: electric-quickstart
+description: >
+  Scaffolding a new Electric project — prerequisites, pnpm install, first shape,
+  ShapeStream, Shape, proxy route, ELECTRIC_PROTOCOL_QUERY_PARAMS, secure-by-default
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:AGENTS.md'
+  - 'electric:website/docs/quickstart.md'
+---
+
+# Electric Quickstart
+
+Start a new Electric project with the **secure proxy pattern from the start**.
+Security is not a production upgrade step.
+
+## Prerequisites
+
+- Node.js 18+
+- Postgres 14+ with `wal_level=logical` and a user with `REPLICATION` role
+- Electric sync service running (Cloud or Docker)
+
+## Scaffold from Starter
+
+```bash
+npx gitpick electric-sql/electric/tree/main/examples/tanstack-db-web-starter my-app
+cd my-app
+cp .env.example .env
+pnpm install
+pnpm dev
+# in new terminal
+pnpm migrate
+```
+
+## Minimal Manual Setup
+
+### 1. Install
+
+```bash
+pnpm add @electric-sql/client
+```
+
+### 2. Create Proxy Route (Server)
+
+```typescript
+// api/todos.ts
+import { ELECTRIC_PROTOCOL_QUERY_PARAMS } from '@electric-sql/client'
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const origin = new URL(`${process.env.ELECTRIC_URL}/v1/shape`)
+
+  url.searchParams.forEach((value, key) => {
+    if (ELECTRIC_PROTOCOL_QUERY_PARAMS.includes(key)) {
+      origin.searchParams.set(key, value)
+    }
+  })
+
+  origin.searchParams.set('table', 'todos')
+
+  if (process.env.ELECTRIC_SOURCE_ID) {
+    origin.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID)
+    origin.searchParams.set('secret', process.env.ELECTRIC_SECRET!)
+  }
+
+  const res = await fetch(origin)
+  const headers = new Headers(res.headers)
+  headers.delete('content-encoding')
+  headers.delete('content-length')
+
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  })
+}
+```
+
+### 3. Consume Shape (Client)
+
+```typescript
+import { ShapeStream, Shape } from '@electric-sql/client'
+
+const stream = new ShapeStream({ url: `/api/todos` })
+const shape = new Shape(stream)
+
+const rows = await shape.rows
+shape.subscribe(({ rows }) => {
+  console.log('Synced todos:', rows)
+})
+```
+
+### 4. Environment
+
+```bash
+# .env
+ELECTRIC_URL=http://localhost:3000        # or https://api.electric-sql.cloud
+ELECTRIC_SOURCE_ID=your-source-id         # Cloud only
+ELECTRIC_SECRET=your-secret-keep-server   # Cloud only
+```
+
+## Core Patterns
+
+- **One proxy route per table** — server hardcodes `table`, never the client
+- **Forward only protocol params** — use `ELECTRIC_PROTOCOL_QUERY_PARAMS`
+- **Delete encoding headers** — `content-encoding` and `content-length` must go
+- **Add Vary header** — `Vary: Authorization` or `Vary: Cookie`
+
+## Common Mistakes
+
+### [CRITICAL] Using electrify() or db.table.create() from old Electric
+
+Wrong:
+
+```typescript
+import { electrify } from 'electric-sql/wa-sqlite'
+const { db } = await electrify(conn, schema)
+await db.todos.create({ text: 'Buy milk' })
+```
+
+Correct:
+
+```typescript
+import { ShapeStream, Shape } from '@electric-sql/client'
+const stream = new ShapeStream({ url: `/api/todos` })
+const shape = new Shape(stream)
+```
+
+Old Electric had bidirectional SQLite sync. New Electric is read-only HTTP —
+`electrify()` does not exist. Writes go through your API to Postgres.
+
+Source: AGENTS.md lines 379-393
+
+### [HIGH] Skipping HTTP/2 proxy in local dev
+
+Wrong:
+
+```typescript
+// Direct connection, HTTP/1.1
+const stream = new ShapeStream({ url: 'http://localhost:3000/v1/shape' })
+```
+
+Correct:
+
+```typescript
+// Through proxy (Caddy/nginx with HTTP/2)
+const stream = new ShapeStream({ url: `/api/todos` })
+```
+
+HTTP/1.1 has a 6-connection limit per origin. Multiple shapes cause visible
+delays. Use an HTTP/2 proxy (Caddy or nginx) even in development.
+
+Source: AGENTS.md line 296
+
+### [HIGH] Setting up without a proxy (treating security as a later step)
+
+Wrong:
+
+```typescript
+// "I'll add auth later"
+const stream = new ShapeStream({
+  url: 'http://localhost:3000/v1/shape?table=todos',
+})
+```
+
+Correct:
+
+```typescript
+// Proxy from day one
+const stream = new ShapeStream({ url: `/api/todos` })
+```
+
+The quickstart must include a proxy from the start. Direct Electric connection is
+never the right starting point — it creates insecure patterns that are hard to
+retrofit.
+
+Source: Maintainer interview, domain discovery feedback
+
+## Tension: Secure-by-default vs tutorial simplicity
+
+Tutorials naturally want the fewest possible steps. But skipping the proxy means
+every quickstart reader starts insecure and must retrofit auth later. This skill
+uses the proxy pattern from step 1.
+
+Cross-reference: `electric-auth`, `electric-security-check`
+
+## References
+
+- [Quickstart Guide](https://electric-sql.com/docs/quickstart)
+- [Shapes Guide](https://electric-sql.com/docs/guides/shapes)
+- [TypeScript Client](https://electric-sql.com/docs/api/clients/typescript)

--- a/packages/typescript-client/skills/electric-quickstart/SKILL.md
+++ b/packages/typescript-client/skills/electric-quickstart/SKILL.md
@@ -60,9 +60,13 @@ export async function GET(request: Request) {
 
   origin.searchParams.set('table', 'todos')
 
+  // Electric Cloud: include source_id + secret
   if (process.env.ELECTRIC_SOURCE_ID) {
     origin.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID)
-    origin.searchParams.set('secret', process.env.ELECTRIC_SECRET!)
+  }
+  // Auth: secret is required for both Cloud and self-hosted production
+  if (process.env.ELECTRIC_SECRET) {
+    origin.searchParams.set('secret', process.env.ELECTRIC_SECRET)
   }
 
   const res = await fetch(origin)
@@ -95,10 +99,18 @@ shape.subscribe(({ rows }) => {
 ### 4. Environment
 
 ```bash
-# .env
-ELECTRIC_URL=http://localhost:3000        # or https://api.electric-sql.cloud
-ELECTRIC_SOURCE_ID=your-source-id         # Cloud only
-ELECTRIC_SECRET=your-secret-keep-server   # Cloud only
+# .env — Electric Cloud
+ELECTRIC_URL=https://api.electric-sql.cloud
+ELECTRIC_SOURCE_ID=your-source-id         # identifies your Cloud source
+ELECTRIC_SECRET=your-secret-keep-server   # authenticates upstream requests
+
+# .env — Self-hosted (production)
+ELECTRIC_URL=http://localhost:3000
+ELECTRIC_SECRET=your-secret-keep-server   # required since v1.0
+
+# .env — Self-hosted (dev only)
+ELECTRIC_URL=http://localhost:3000
+# No secret needed when ELECTRIC_INSECURE=true on the server
 ```
 
 ## Core Patterns

--- a/packages/typescript-client/skills/electric-security-check/SKILL.md
+++ b/packages/typescript-client/skills/electric-security-check/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: electric-security-check
+description: >
+  Security audit checklist before production — verify proxy, ELECTRIC_SECRET,
+  shape scoping, Vary headers, session isolation, no client-controlled shapes,
+  ELECTRIC_INSECURE removal
+type: security
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:AGENTS.md'
+  - 'electric:website/docs/guides/security.md'
+---
+
+# Electric Security Audit
+
+Run through this checklist before production deployment.
+
+## Security Checklist
+
+### Proxy & Access Control
+
+- [ ] **Electric behind proxy** — client never talks to Electric directly
+- [ ] **Every route authenticates** — no proxy routes without auth checks
+- [ ] **Server defines shapes** — `table` and `where` set server-side, not from client params
+- [ ] **User scoping on all routes** — `where user_id = $1` or equivalent
+- [ ] **One route per table** — no generic `/api/shape?table=X` endpoint
+
+### Secrets
+
+- [ ] **`ELECTRIC_SECRET` set** — not `ELECTRIC_INSECURE=true`
+- [ ] **No secrets in client bundle** — `ELECTRIC_SECRET`, `SOURCE_SECRET` server-only
+- [ ] **Env vars not in client code** — check for `process.env.ELECTRIC_SECRET` in browser code
+
+### Headers & Caching
+
+- [ ] **`Vary` header set** — `Authorization` or `Cookie` on every proxy response
+- [ ] **Electric headers forwarded** — `electric-handle`, `electric-offset`, `electric-schema`
+- [ ] **Encoding headers removed** — `content-encoding` and `content-length` deleted
+
+### Session Isolation
+
+- [ ] **Cache per user** — `Vary` header prevents serving cached shape to wrong user
+- [ ] **Auth token refresh** — dynamic headers handle token expiry
+- [ ] **403 handling** — graceful UI when user lacks access
+
+## Quick Audit Script
+
+```bash
+# Check for secrets in client code
+grep -r "ELECTRIC_SECRET\|SOURCE_SECRET" src/ --include="*.ts" --include="*.tsx" | \
+  grep -v "process.env\|server\|api\|route"
+
+# Check for direct Electric URLs in client
+grep -r "localhost:3000/v1/shape\|electric-sql.cloud/v1/shape" src/ \
+  --include="*.ts" --include="*.tsx"
+
+# Check proxy routes have auth
+grep -rn "prepareElectricUrl\|proxyElectricRequest" src/ --include="*.ts" -A5 | \
+  grep -c "session\|auth\|user"
+```
+
+## Common Mistakes
+
+### [CRITICAL] Dev patterns in production
+
+Wrong:
+
+```yaml
+# docker-compose.prod.yml
+environment:
+  ELECTRIC_INSECURE: true # "same as dev, it works!"
+```
+
+Correct:
+
+```yaml
+environment:
+  ELECTRIC_SECRET: ${ELECTRIC_SECRET} # from secure env
+```
+
+`ELECTRIC_INSECURE=true` disables all auth. `ELECTRIC_SECRET` is required since
+v1.0. Direct client connections bypass all access control.
+
+Source: AGENTS.md Security Rules
+
+### [CRITICAL] Generic shape endpoint
+
+Wrong:
+
+```typescript
+app.get('/api/shape', (req) => {
+  const { table } = req.query
+  originUrl.searchParams.set('table', table as string)
+})
+```
+
+Correct:
+
+```typescript
+// /api/todos.ts
+originUrl.searchParams.set('table', 'todos')
+originUrl.searchParams.set('where', 'user_id = $1')
+originUrl.searchParams.set('params', JSON.stringify([session.user.id]))
+```
+
+Client-controlled `table` param lets any user query any table in the database.
+
+Source: AGENTS.md Security Rules #4
+
+### [HIGH] Missing Vary header allows cache data leakage
+
+Wrong:
+
+```typescript
+return new Response(response.body, { headers })
+```
+
+Correct:
+
+```typescript
+headers.set('Vary', 'Authorization')
+return new Response(response.body, { headers })
+```
+
+Without Vary, CDN or browser caches may serve one user's shape data to another.
+
+Source: website/docs/guides/auth.md
+
+## Tension: Secure-by-default vs tutorial simplicity
+
+Every Electric skill uses proxy-first patterns. This checklist validates that no
+shortcuts from development leaked into production.
+
+Cross-reference: `electric-quickstart`, `electric-auth`
+
+## References
+
+- [Security Guide](https://electric-sql.com/docs/guides/security)
+- [Auth Guide](https://electric-sql.com/docs/guides/auth)

--- a/packages/typescript-client/skills/electric-shapes/SKILL.md
+++ b/packages/typescript-client/skills/electric-shapes/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: electric-shapes
+description: >
+  Defining and consuming shapes — ShapeStream, Shape, useShape, params sub-key,
+  WHERE clauses, columns selection, type parsing, column mapping, parser config,
+  onError handler, FetchError, subscribe, camelCase mapping, single-table only
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:website/docs/guides/shapes.md'
+  - 'electric:packages/typescript-client/src/shape.ts'
+  - 'electric:packages/typescript-client/src/parser.ts'
+---
+
+# Electric Shapes
+
+Shapes define subsets of Postgres data to sync. A shape is a **table** + optional
+**where** + optional **columns**. Electric syncs all matching rows, then streams
+changes in real-time.
+
+## Setup
+
+```typescript
+import { ShapeStream, Shape } from '@electric-sql/client'
+```
+
+## Core Patterns
+
+### Basic Shape
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/todos`, // proxy URL (server defines actual shape)
+})
+
+const shape = new Shape(stream)
+const rows = await shape.rows // wait for initial sync
+
+shape.subscribe(({ rows }) => {
+  console.log('Current data:', rows)
+})
+```
+
+### Shape Definition (Server-Side Proxy)
+
+Shapes are defined in your proxy, not client code:
+
+```typescript
+const origin = new URL(`${process.env.ELECTRIC_URL}/v1/shape`)
+origin.searchParams.set('table', 'todos')
+origin.searchParams.set('where', 'user_id = $1')
+origin.searchParams.set('columns', 'id,title,status')
+origin.searchParams.set('params', JSON.stringify([userId]))
+```
+
+### Type Parsing
+
+Electric sends all values as strings. Parse custom types:
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/todos`,
+  parser: {
+    timestamptz: (v: string) => new Date(v),
+    jsonb: (v: string) => JSON.parse(v),
+    int8: (v: string) => BigInt(v),
+    _int4: (v: string) => v.replace(/[{}]/g, '').split(',').map(Number),
+  },
+})
+```
+
+### Dynamic Headers
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/todos`,
+  headers: {
+    Authorization: async () => `Bearer ${await getAccessToken()}`,
+  },
+})
+```
+
+### Error Handling
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/todos`,
+  onError: async (error) => {
+    if (error instanceof FetchError && error.status === 401) {
+      return { headers: { Authorization: `Bearer ${await refreshToken()}` } }
+    }
+    if (error instanceof FetchError && error.status === 403) {
+      return // stop stream
+    }
+    return {} // retry
+  },
+})
+```
+
+Return `{ headers, params }` to retry, `{}` to retry same config, or `void` to stop.
+
+### With React
+
+```tsx
+import { useShape } from '@electric-sql/react'
+
+function TodoList() {
+  const { data, isLoading } = useShape({ url: `/api/todos` })
+  if (isLoading) return <p>Loading...</p>
+  return (
+    <ul>
+      {data.map((t) => (
+        <li key={t.id}>{t.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### Stream Events
+
+```typescript
+stream.subscribe((messages) => {
+  for (const msg of messages) {
+    if ('value' in msg) {
+      // msg.headers.operation: "insert" | "update" | "delete"
+    } else if (msg.headers?.control === 'must-refetch') {
+      // shape rotated — resync from scratch
+    }
+  }
+})
+```
+
+## Common Mistakes
+
+### [CRITICAL] table/where/columns at top level instead of params
+
+Wrong:
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/todos`,
+  table: 'todos',
+  where: "status = 'active'",
+})
+```
+
+Correct:
+
+```typescript
+// Client: just pass the proxy URL
+const stream = new ShapeStream({ url: `/api/todos` })
+
+// Server proxy: set shape params on Electric URL
+origin.searchParams.set('table', 'todos')
+origin.searchParams.set('where', "status = 'active'")
+```
+
+Pre-0.9 API had `table`/`where`/`columns` as top-level ShapeStream options. Current
+API requires them as URL search params set server-side in the proxy.
+
+Source: typescript-client CHANGELOG.md v0.9.0
+
+### [CRITICAL] Using old Electric patterns (electrify, db.table.create)
+
+Wrong:
+
+```typescript
+const { db } = await electrify(conn, schema)
+await db.todos.create({ text: 'New' })
+```
+
+Correct:
+
+```typescript
+const stream = new ShapeStream({ url: `/api/todos` })
+```
+
+`electrify()` is from old Electric (bidirectional SQLite sync). New Electric is
+read-only HTTP. Writes go through API → Postgres → Electric streams back.
+
+Source: AGENTS.md lines 379-393
+
+### [HIGH] Missing primary key in columns selection
+
+Wrong:
+
+```typescript
+origin.searchParams.set('columns', 'title,status')
+```
+
+Correct:
+
+```typescript
+origin.searchParams.set('columns', 'id,title,status')
+```
+
+The `columns` param must include primary key columns or the shape request will fail.
+
+Source: website/electric-api.yaml
+
+### [HIGH] Expecting shapes to span multiple tables
+
+Wrong:
+
+```typescript
+origin.searchParams.set('table', 'todos JOIN users ON ...')
+```
+
+Correct:
+
+```typescript
+// Sync separate shapes, join client-side with TanStack DB
+const todoStream = new ShapeStream({ url: `/api/todos` })
+const userStream = new ShapeStream({ url: `/api/users` })
+```
+
+Shapes are single-table only. Cross-table joins require multiple shapes plus
+client-side joining (e.g., TanStack DB `useLiveQuery` with `.join()`).
+
+Source: website/docs/guides/shapes.md
+
+### [HIGH] Not parsing custom Postgres types
+
+Wrong:
+
+```typescript
+const stream = new ShapeStream({ url: `/api/events` })
+// event.created_at is "2024-01-15T10:30:00Z" (string, not Date)
+```
+
+Correct:
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/events`,
+  parser: {
+    timestamptz: (v: string) => new Date(v),
+    jsonb: (v: string) => JSON.parse(v),
+  },
+})
+```
+
+Values arrive as strings from HTTP. Without a parser, `timestamptz`, `jsonb`, and
+array types remain as unparsed strings — no error, just wrong types at runtime.
+
+Source: packages/typescript-client/src/parser.ts
+
+### [MEDIUM] Using reserved param names in custom params
+
+Wrong:
+
+```typescript
+origin.searchParams.set('cursor', 'my-cursor')
+origin.searchParams.set('offset', 'custom-offset')
+```
+
+Correct:
+
+```typescript
+// These names are reserved for the Electric protocol:
+// cursor, handle, live, offset, cache-buster, subset__*
+// Use different names for your own params
+origin.searchParams.set('filter_cursor', 'my-cursor')
+```
+
+Reserved param names (`cursor`, `handle`, `live`, `offset`, `cache-buster`,
+`subset__*`) throw `ReservedParamError`.
+
+Source: packages/typescript-client/src/client.ts
+
+## Tension: Read-only sync vs write-path expectations
+
+Electric is read-only. Developers (and agents trained on old Electric) expect
+bidirectional sync. Shapes only stream data _from_ Postgres — there is no
+write API on shapes. Writes go through your backend API to Postgres, and Electric
+syncs the changes back to clients.
+
+Cross-reference: `electric-tanstack-integration`
+
+## References
+
+- [Shapes Guide](https://electric-sql.com/docs/guides/shapes)
+- [HTTP API](https://electric-sql.com/docs/api/http)
+- [TypeScript Client API](https://electric-sql.com/docs/api/clients/typescript)
+- Reference: `electric-shapes/references/shape-options.md`
+- Reference: `electric-shapes/references/parser-types.md`

--- a/packages/typescript-client/skills/electric-shapes/references/parser-types.md
+++ b/packages/typescript-client/skills/electric-shapes/references/parser-types.md
@@ -1,0 +1,80 @@
+---
+name: parser-types-reference
+parent: electric-shapes
+---
+
+# Parser Type Mapping Reference
+
+Electric sends all Postgres values as strings over HTTP. Use the `parser` option
+on `ShapeStream` to convert them to JavaScript types.
+
+## Common Type Parsers
+
+| Postgres Type | Parser                        | JavaScript Type |
+| ------------- | ----------------------------- | --------------- |
+| `timestamptz` | `(v) => new Date(v)`          | `Date`          |
+| `timestamp`   | `(v) => new Date(v)`          | `Date`          |
+| `jsonb`       | `(v) => JSON.parse(v)`        | `object`        |
+| `json`        | `(v) => JSON.parse(v)`        | `object`        |
+| `numeric`     | `(v) => parseFloat(v)`        | `number`        |
+| `float4`      | `(v) => parseFloat(v)`        | `number`        |
+| `float8`      | `(v) => parseFloat(v)`        | `number`        |
+| `int8`        | `(v) => BigInt(v)`            | `bigint`        |
+| `bool`        | `(v) => v === "true"`         | `boolean`       |
+| `bytea`       | `(v) => Uint8Array.from(...)` | `Uint8Array`    |
+
+## Array Types
+
+Postgres array types are prefixed with `_`:
+
+| Postgres Type | Parser                                                         | JavaScript Type |
+| ------------- | -------------------------------------------------------------- | --------------- |
+| `_int4`       | `(v) => v.replace(/[{}]/g, "").split(",").map(Number)`         | `number[]`      |
+| `_text`       | `(v) => v.replace(/[{}]/g, "").split(",")`                     | `string[]`      |
+| `_bool`       | `(v) => v.replace(/[{}]/g, "").split(",").map(b => b === "t")` | `boolean[]`     |
+| `_float8`     | `(v) => v.replace(/[{}]/g, "").split(",").map(parseFloat)`     | `number[]`      |
+
+## NULL Handling
+
+- NULL values are not passed through the parser
+- The parser only receives non-null string values
+- Your TypeScript types should account for nullability separately
+
+## Custom Type Example
+
+```typescript
+const stream = new ShapeStream({
+  url: `/api/locations`,
+  parser: {
+    point: (value: string) => {
+      const [x, y] = value.replace(/[()]/g, '').split(',')
+      return { x: parseFloat(x), y: parseFloat(y) }
+    },
+    daterange: (value: string) => {
+      const [start, end] = value.replace(/[\[\]()]/g, '').split(',')
+      return { start: new Date(start), end: new Date(end) }
+    },
+  },
+})
+```
+
+## With TanStack DB Collections
+
+When using `electricCollectionOptions`, pass the parser in `shapeOptions`:
+
+```typescript
+const collection = createCollection(
+  electricCollectionOptions({
+    id: 'events',
+    schema: eventSchema,
+    getKey: (row) => row.id,
+    shapeOptions: {
+      url: `/api/events`,
+      parser: {
+        timestamptz: (v: string) => new Date(v),
+        jsonb: (v: string) => JSON.parse(v),
+      },
+    },
+  })
+)
+```

--- a/packages/typescript-client/skills/electric-shapes/references/shape-options.md
+++ b/packages/typescript-client/skills/electric-shapes/references/shape-options.md
@@ -1,0 +1,69 @@
+---
+name: shape-options-reference
+parent: electric-shapes
+---
+
+# ShapeStream Options Reference
+
+## Constructor Options
+
+| Option           | Type                                                          | Required | Description                                                |
+| ---------------- | ------------------------------------------------------------- | -------- | ---------------------------------------------------------- |
+| `url`            | `string`                                                      | Yes      | Proxy endpoint URL                                         |
+| `headers`        | `Record<string, string \| (() => string \| Promise<string>)>` | No       | Request headers (can be async functions for token refresh) |
+| `params`         | `Record<string, string>`                                      | No       | Additional URL search params                               |
+| `parser`         | `Record<string, (value: string) => any>`                      | No       | Type parsers for Postgres types                            |
+| `fetchClient`    | `typeof fetch`                                                | No       | Custom fetch implementation                                |
+| `onError`        | `(error: Error) => Promise<void \| { headers?, params? }>`    | No       | Error handler (return to retry, void to stop)              |
+| `backoffOptions` | `BackoffOptions`                                              | No       | Exponential backoff config                                 |
+| `signal`         | `AbortSignal`                                                 | No       | Abort signal for cancellation                              |
+| `subscribe`      | `boolean`                                                     | No       | Auto-subscribe to changes (default: true)                  |
+
+## Server-Side URL Parameters (set in proxy)
+
+| Parameter   | Required   | Description                                    |
+| ----------- | ---------- | ---------------------------------------------- |
+| `table`     | Yes        | Table name (e.g., `todos` or `public.todos`)   |
+| `where`     | No         | SQL WHERE clause filter                        |
+| `columns`   | No         | Comma-separated column list (must include PK)  |
+| `params`    | No         | JSON array for WHERE placeholders (`$1`, `$2`) |
+| `source_id` | Cloud only | Electric Cloud source identifier               |
+| `secret`    | Cloud only | Electric Cloud secret (server-side only)       |
+
+## Protocol Parameters (forwarded by proxy)
+
+These are in the `ELECTRIC_PROTOCOL_QUERY_PARAMS` constant:
+
+| Parameter | Description                               |
+| --------- | ----------------------------------------- |
+| `offset`  | Position in shape log (`-1` for start)    |
+| `handle`  | Shape identifier from initial response    |
+| `live`    | Enable long-polling for real-time updates |
+| `cursor`  | Cursor for pagination                     |
+
+## BackoffOptions
+
+| Option         | Type     | Default | Description         |
+| -------------- | -------- | ------- | ------------------- |
+| `initialDelay` | `number` | 100     | Initial delay in ms |
+| `maxDelay`     | `number` | 10000   | Maximum delay in ms |
+| `multiplier`   | `number` | 1.3     | Backoff multiplier  |
+
+## Shape Methods
+
+| Method                   | Returns          | Description                               |
+| ------------------------ | ---------------- | ----------------------------------------- |
+| `shape.rows`             | `Promise<Row[]>` | All rows (resolves when caught up)        |
+| `shape.currentRows`      | `Row[]`          | Current rows synchronously                |
+| `shape.isUpToDate()`     | `boolean`        | Whether shape is caught up                |
+| `shape.subscribe(cb)`    | `() => void`     | Subscribe to changes, returns unsubscribe |
+| `shape.unsubscribeAll()` | `void`           | Remove all subscribers                    |
+
+## ShapeStream Methods
+
+| Method                 | Returns               | Description               |
+| ---------------------- | --------------------- | ------------------------- |
+| `stream.subscribe(cb)` | `() => void`          | Subscribe to raw messages |
+| `stream.isConnected()` | `boolean`             | Connection status         |
+| `stream.lastOffset`    | `Offset`              | Last seen offset          |
+| `stream.shapeHandle`   | `string \| undefined` | Current shape handle      |

--- a/packages/typescript-client/skills/electric-tanstack-integration/SKILL.md
+++ b/packages/typescript-client/skills/electric-tanstack-integration/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: electric-tanstack-integration
+description: >
+  TanStack DB collections with Electric — createCollection,
+  electricCollectionOptions, useLiveQuery, optimistic mutations, onInsert,
+  onUpdate, onDelete, txid write-path contract, awaitTxId,
+  createOptimisticAction, cross-collection joins, sub-ms differential dataflow
+type: composition
+library: '@electric-sql/client'
+library_version: '1.5.8'
+requires:
+  - '@tanstack/react-db'
+  - '@tanstack/electric-db-collection'
+sources:
+  - 'electric:AGENTS.md'
+  - 'tanstack:tanstack.com/db/latest/docs/collections/electric-collection.md'
+---
+
+# Electric + TanStack DB Integration
+
+TanStack DB collections are the default for apps that need writes, joins, or
+multiple shapes. Prefer collections over lower-level ShapeStream/useShape.
+
+## Setup
+
+```bash
+pnpm add @tanstack/react-db @tanstack/electric-db-collection @electric-sql/client
+```
+
+## Core Patterns
+
+### Create Collection
+
+```typescript
+import { createCollection } from '@tanstack/react-db'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+import { todoSchema } from './schema'
+
+export const todoCollection = createCollection(
+  electricCollectionOptions({
+    id: 'todos',
+    schema: todoSchema,
+    getKey: (row) => row.id,
+    shapeOptions: { url: '/api/todos' },
+    onInsert: async ({ transaction }) => {
+      const newTodo = transaction.mutations[0].modified
+      const { txid } = await api.todos.create(newTodo)
+      return { txid }
+    },
+    onUpdate: async ({ transaction }) => {
+      const { original, changes } = transaction.mutations[0]
+      const { txid } = await api.todos.update(original.id, changes)
+      return { txid }
+    },
+    onDelete: async ({ transaction }) => {
+      const { id } = transaction.mutations[0].original
+      const { txid } = await api.todos.delete(id)
+      return { txid }
+    },
+  })
+)
+```
+
+### Live Queries
+
+```typescript
+import { useLiveQuery, eq } from "@tanstack/react-db"
+
+function TodoList() {
+  const { data: todos } = useLiveQuery((q) =>
+    q.from({ todo: todoCollection })
+      .where(({ todo }) => eq(todo.completed, false))
+      .orderBy(({ todo }) => todo.created_at, "desc")
+      .limit(50)
+  )
+  return <ul>{todos.map((t) => <li key={t.id}>{t.text}</li>)}</ul>
+}
+```
+
+### Cross-Collection Joins
+
+```typescript
+const { data } = useLiveQuery((q) =>
+  q
+    .from({ todo: todoCollection })
+    .join({ user: userCollection }, ({ todo, user }) =>
+      eq(todo.user_id, user.id)
+    )
+    .select(({ todo, user }) => ({
+      id: todo.id,
+      text: todo.text,
+      userName: user.name,
+    }))
+)
+```
+
+### Direct Mutations
+
+```typescript
+todoCollection.insert({
+  id: crypto.randomUUID(),
+  text: 'New todo',
+  completed: false,
+  createdAt: Date.now(),
+})
+
+todoCollection.update(todoId, (draft) => {
+  draft.completed = !draft.completed
+})
+
+todoCollection.delete(todoId)
+```
+
+### Write-Path Contract
+
+```
+UI mutation → optimistic → onInsert/onUpdate/onDelete → API → Postgres
+  → returns txid → Electric streams change → collection drops optimistic state
+```
+
+Backend must return txid from the same transaction:
+
+```sql
+SELECT pg_current_xact_id()::xid::text as txid
+```
+
+### Multi-Collection Optimistic Actions
+
+```typescript
+import { createOptimisticAction } from '@tanstack/react-db'
+
+const bootstrapAction = createOptimisticAction<string>({
+  onMutate: (listId, text) => {
+    listCollection.insert({ id: listId })
+    todoCollection.insert({ id: crypto.randomUUID(), text, listId })
+  },
+  mutationFn: async (listId, text) => {
+    const { txid } = await api.bootstrap({ listId, text })
+    await Promise.all([
+      listCollection.utils.awaitTxId(txid),
+      todoCollection.utils.awaitTxId(txid),
+    ])
+  },
+})
+```
+
+## Common Mistakes
+
+### [CRITICAL] Not returning txid from write API
+
+Wrong:
+
+```typescript
+// Server
+app.post('/api/todos', async (req, res) => {
+  const todo = await db.insert(todosTable).values(req.body).returning()
+  res.json({ todo })
+})
+```
+
+Correct:
+
+```typescript
+app.post('/api/todos', async (req, res) => {
+  const result = await db.transaction(async (tx) => {
+    const txid = await generateTxId(tx)
+    const [todo] = await tx.insert(todosTable).values(req.body).returning()
+    return { todo, txid }
+  })
+  res.json(result)
+})
+```
+
+Without txid, optimistic state never drops — UI shows duplicates or stale rows.
+
+Source: AGENTS.md Write-path contract
+
+### [CRITICAL] Writing directly to Electric (bidirectional assumption)
+
+Wrong:
+
+```typescript
+const { db } = await electrify(conn, schema)
+await db.todos.create({ text: 'New' })
+```
+
+Correct:
+
+```typescript
+todoCollection.insert({ id: crypto.randomUUID(), text: 'New' })
+// → onInsert → API → Postgres → Electric streams back
+```
+
+Electric is read-only. Writes go through API → Postgres → Electric streams back.
+There is no `electrify()` or bidirectional sync.
+
+Source: AGENTS.md Evolution from Old Electric
+
+### [HIGH] Using ShapeStream/useShape instead of TanStack DB collection
+
+Wrong:
+
+```typescript
+import { useShape } from '@electric-sql/react'
+const { data } = useShape({ url: '/api/todos' })
+```
+
+Correct:
+
+```typescript
+import { useLiveQuery } from '@tanstack/react-db'
+const { data } = useLiveQuery((q) => q.from({ todo: todoCollection }))
+```
+
+`useShape` is fine for simple read-only views. But most apps need writes, joins,
+or multiple shapes — use collections for these.
+
+Source: AGENTS.md line 393
+
+### [HIGH] Not awaiting txid on ALL affected collections
+
+Wrong:
+
+```typescript
+mutationFn: async (listId, text) => {
+  const { txid } = await api.bootstrap({ listId, text })
+  await listCollection.utils.awaitTxId(txid)
+  // Forgot todoCollection!
+}
+```
+
+Correct:
+
+```typescript
+mutationFn: async (listId, text) => {
+  const { txid } = await api.bootstrap({ listId, text })
+  await Promise.all([
+    listCollection.utils.awaitTxId(txid),
+    todoCollection.utils.awaitTxId(txid),
+  ])
+}
+```
+
+Multi-collection mutations must await txid on every affected collection.
+Missing one leaves optimistic state indefinitely.
+
+Source: AGENTS.md Custom optimistic actions
+
+## Tension: Read-only sync vs write-path expectations
+
+Electric only syncs data _from_ Postgres. Developers expect bidirectional sync
+(especially agents trained on old Electric). Writes always go through your API
+to Postgres. The collection's `onInsert`/`onUpdate`/`onDelete` handlers bridge
+the gap with optimistic mutations.
+
+Cross-reference: `electric-shapes`
+
+## References
+
+- [TanStack DB Overview](https://tanstack.com/db/latest/docs/overview)
+- [Electric Collection](https://tanstack.com/db/latest/docs/collections/electric-collection)
+- [Live Queries](https://tanstack.com/db/latest/docs/guides/live-queries)

--- a/packages/typescript-client/skills/electric-testing/SKILL.md
+++ b/packages/typescript-client/skills/electric-testing/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: electric-testing
+description: >
+  Testing Electric apps — unit testing with mocked fetchClient, vi.fn(),
+  ShapeStream mock, integration testing with real Electric + Postgres + nginx,
+  Docker services, pnpm test, vitest patterns
+type: sub-skill
+library: '@electric-sql/client'
+library_version: '1.5.8'
+sources:
+  - 'electric:AGENTS.md'
+---
+
+# Electric Testing Patterns
+
+Unit tests mock the fetch layer. Integration tests run against real Electric +
+Postgres.
+
+## Setup
+
+```bash
+pnpm add -D vitest
+```
+
+## Core Patterns
+
+### Unit Testing (Mocked Fetch)
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { ShapeStream, Shape } from '@electric-sql/client'
+
+describe('todo sync', () => {
+  it('creates shape stream with correct URL', () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            key: '1',
+            value: { id: '1', text: 'Test' },
+            headers: { operation: 'insert' },
+          },
+          { headers: { control: 'up-to-date' } },
+        ]),
+        {
+          headers: {
+            'electric-handle': 'test-handle',
+            'electric-offset': '0_0',
+          },
+        }
+      )
+    )
+
+    const stream = new ShapeStream({
+      url: '/api/todos',
+      fetchClient: mockFetch,
+    })
+
+    expect(mockFetch).toHaveBeenCalled()
+    const calledUrl = mockFetch.mock.calls[0][0]
+    expect(calledUrl).toContain('/api/todos')
+  })
+})
+```
+
+### Mocking Collection Shape Options
+
+```typescript
+const testCollection = createCollection(
+  electricCollectionOptions({
+    id: 'test-todos',
+    schema: todoSchema,
+    getKey: (row) => row.id,
+    shapeOptions: {
+      url: '/api/todos',
+      fetchClient: vi.fn(), // prevents real HTTP calls
+    },
+    onInsert: async ({ transaction }) => {
+      return { txid: '1' } // mock txid
+    },
+  })
+)
+```
+
+### Integration Testing (Real Services)
+
+**Step 1 — Start Docker services:**
+
+```bash
+# Start Postgres, Electric, and nginx
+cd packages/sync-service/dev
+ELECTRIC_IMAGE=electricsql/electric:canary \
+  docker compose -f docker-compose.yml -f docker-compose-electric.yml \
+  up --wait postgres electric nginx
+```
+
+Services:
+
+- PostgreSQL: `localhost:54321`
+- Electric API: `http://localhost:3000`
+- Nginx proxy: `http://localhost:3002`
+
+**Step 2 — Run tests:**
+
+```bash
+cd packages/typescript-client
+pnpm test              # watch mode
+pnpm test --run        # single run
+pnpm test -t "pattern" # filter by name
+```
+
+**Step 3 — Teardown:**
+
+```bash
+cd packages/sync-service/dev
+docker compose -f docker-compose.yml -f docker-compose-electric.yml down
+```
+
+### Testing Proxy Routes
+
+```typescript
+import { describe, it, expect } from 'vitest'
+
+describe('proxy route', () => {
+  it('returns 401 without auth', async () => {
+    const response = await fetch('/api/todos')
+    expect(response.status).toBe(401)
+  })
+
+  it('sets table server-side', async () => {
+    const mockElectric = vi.fn().mockResolvedValue(new Response('[]'))
+    // Verify the proxy sets table=todos, not from client
+  })
+
+  it('forwards Electric protocol params', async () => {
+    const response = await fetch('/api/todos?offset=0_0&handle=abc&live=true')
+    // Verify offset, handle, live are forwarded
+  })
+
+  it('strips client table/where params', async () => {
+    const response = await fetch('/api/todos?table=users&where=1=1')
+    // Verify table and where from client are ignored
+  })
+})
+```
+
+## Common Mistakes
+
+### [MEDIUM] Not mocking fetchClient for unit tests
+
+Wrong:
+
+```typescript
+const stream = new ShapeStream({ url: '/api/todos' })
+// Hits real Electric server — flaky, slow, requires infra
+```
+
+Correct:
+
+```typescript
+const stream = new ShapeStream({
+  url: '/api/todos',
+  fetchClient: vi.fn().mockResolvedValue(
+    new Response('[]', {
+      headers: { 'electric-handle': 'h', 'electric-offset': '0_0' },
+    })
+  ),
+})
+```
+
+Without a mock, unit tests require a running Electric server. Use
+`shapeOptions.fetchClient = vi.fn()` for isolated tests.
+
+Source: AGENTS.md Testing section
+
+### [MEDIUM] Building local Electric image when not needed
+
+Wrong:
+
+```bash
+# Always building from source (slow, 5+ minutes)
+docker build -t electric-local -f packages/sync-service/Dockerfile ...
+```
+
+Correct:
+
+```bash
+# Use canary image when your changes are client-only
+export ELECTRIC_IMAGE=electricsql/electric:canary
+docker compose up --wait postgres electric nginx
+```
+
+Only build locally when working on branches that change the sync service.
+Client-only changes can use the canary image.
+
+Source: AGENTS.md Integration testing section
+
+### [HIGH] Not testing proxy auth enforcement
+
+Wrong:
+
+```typescript
+// Only testing happy path
+it('returns data when authenticated', async () => {
+  const res = await fetch('/api/todos', { headers: { Authorization: '...' } })
+  expect(res.ok).toBe(true)
+})
+```
+
+Correct:
+
+```typescript
+it('returns 401 without auth', async () => {
+  const res = await fetch('/api/todos')
+  expect(res.status).toBe(401)
+})
+
+it('returns 403 for wrong user', async () => {
+  const res = await fetch('/api/todos', {
+    headers: { Authorization: `Bearer ${otherUserToken}` },
+  })
+  expect(res.status).toBe(403)
+})
+```
+
+Security proxy routes must be tested for rejection, not just acceptance.
+
+Source: AGENTS.md Security Rules
+
+## References
+
+- [Vitest Documentation](https://vitest.dev)
+- [TypeScript Client API](https://electric-sql.com/docs/api/clients/typescript)

--- a/packages/typescript-client/skills/tanstack-start-quickstart/SKILL.md
+++ b/packages/typescript-client/skills/tanstack-start-quickstart/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: tanstack-start-quickstart
+description: >
+  Full-stack TanStack Start setup — createFileRoute server handlers, proxy
+  routes, Electric collections, Drizzle schema, migrations, server functions,
+  ELECTRIC_PROTOCOL_QUERY_PARAMS, electricCollectionOptions
+type: composition
+library: '@electric-sql/client'
+library_version: '1.5.8'
+requires:
+  - '@tanstack/react-start'
+  - '@tanstack/react-db'
+  - '@tanstack/electric-db-collection'
+  - 'drizzle-orm'
+sources:
+  - 'electric:AGENTS.md'
+  - 'electric:examples/tanstack-db-web-starter'
+---
+
+# TanStack Start Quickstart
+
+Full-stack setup with TanStack Start, Electric sync, and Drizzle ORM.
+
+## Setup
+
+```bash
+npx gitpick electric-sql/electric/tree/main/examples/tanstack-db-web-starter my-app
+cd my-app
+cp .env.example .env
+pnpm install
+pnpm dev
+# in new terminal
+pnpm migrate
+```
+
+## Core Patterns
+
+### Proxy Route (Server)
+
+```typescript
+// src/routes/api/todos.ts
+import { createFileRoute } from '@tanstack/react-router'
+import { ELECTRIC_PROTOCOL_QUERY_PARAMS } from '@electric-sql/client'
+
+const serve = async ({ request }: { request: Request }) => {
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const url = new URL(request.url)
+  const origin = new URL(`${process.env.ELECTRIC_URL}/v1/shape`)
+
+  url.searchParams.forEach((v, k) => {
+    if (ELECTRIC_PROTOCOL_QUERY_PARAMS.includes(k))
+      origin.searchParams.set(k, v)
+  })
+
+  origin.searchParams.set('table', 'todos')
+  origin.searchParams.set('where', 'user_id = $1')
+  origin.searchParams.set('params', JSON.stringify([session.user.id]))
+
+  if (process.env.ELECTRIC_SOURCE_ID) {
+    origin.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID)
+    origin.searchParams.set('secret', process.env.ELECTRIC_SECRET!)
+  }
+
+  const res = await fetch(origin)
+  const headers = new Headers(res.headers)
+  headers.delete('content-encoding')
+  headers.delete('content-length')
+  headers.set('vary', 'authorization')
+
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  })
+}
+
+export const Route = createFileRoute('/api/todos')({
+  server: { handlers: { GET: serve } },
+})
+```
+
+### Collection (Client)
+
+```typescript
+// src/lib/collections.ts
+import { createCollection } from '@tanstack/react-db'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+import { selectTodoSchema } from '@/db/schema'
+
+export const todoCollection = createCollection(
+  electricCollectionOptions({
+    id: 'todos',
+    schema: selectTodoSchema,
+    getKey: (item) => item.id,
+    shapeOptions: { url: '/api/todos' },
+    onInsert: async ({ transaction }) => {
+      const { txid } = await api.todos.create(transaction.mutations[0].modified)
+      return { txid }
+    },
+  })
+)
+```
+
+### Drizzle Schema + Migrations
+
+```typescript
+// src/db/schema.ts
+import {
+  pgTable,
+  integer,
+  varchar,
+  boolean,
+  timestamp,
+} from 'drizzle-orm/pg-core'
+
+export const todosTable = pgTable('todos', {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  text: varchar({ length: 500 }).notNull(),
+  completed: boolean().notNull().default(false),
+  created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
+})
+```
+
+```bash
+pnpm drizzle-kit generate && pnpm drizzle-kit migrate
+```
+
+### Live Query UI
+
+```tsx
+import { useLiveQuery } from '@tanstack/react-db'
+
+function Todos() {
+  const { data } = useLiveQuery((q) =>
+    q
+      .from({ todo: todoCollection })
+      .orderBy(({ todo }) => todo.created_at, 'desc')
+  )
+  return (
+    <ul>
+      {data.map((t) => (
+        <li key={t.id}>{t.text}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## Common Mistakes
+
+### [CRITICAL] Exposing ELECTRIC_SECRET in client code
+
+Wrong:
+
+```typescript
+// This runs in the browser!
+const stream = new ShapeStream({
+  url: `${ELECTRIC_URL}/v1/shape?secret=${process.env.ELECTRIC_SECRET}`,
+})
+```
+
+Correct:
+
+```typescript
+// Client: no secrets
+const stream = new ShapeStream({ url: '/api/todos' })
+
+// Server route: secret stays server-side
+origin.searchParams.set('secret', process.env.ELECTRIC_SECRET!)
+```
+
+TanStack Start server functions run server-side. The secret must stay there,
+never in the client bundle.
+
+Source: AGENTS.md Security Rules #1
+
+### [CRITICAL] Not returning txid from API mutations
+
+Wrong:
+
+```typescript
+const [todo] = await db.insert(todosTable).values(input).returning()
+return { todo }
+```
+
+Correct:
+
+```typescript
+return await db.transaction(async (tx) => {
+  const txid = await generateTxId(tx)
+  const [todo] = await tx.insert(todosTable).values(input).returning()
+  return { todo, txid }
+})
+```
+
+Without txid, optimistic state in the collection never resolves.
+
+Source: AGENTS.md Write-path contract
+
+### [HIGH] Using useShape instead of collection for apps with writes
+
+Wrong:
+
+```typescript
+import { useShape } from '@electric-sql/react'
+const { data } = useShape({ url: '/api/todos' })
+```
+
+Correct:
+
+```typescript
+import { useLiveQuery } from '@tanstack/react-db'
+const { data } = useLiveQuery((q) => q.from({ todo: todoCollection }))
+```
+
+Collections provide optimistic mutations, joins, and sub-ms live queries.
+`useShape` is only for simple read-only views.
+
+Source: AGENTS.md line 393
+
+## References
+
+- [TanStack Start Docs](https://tanstack.com/start/latest)
+- [tanstack-db-web-starter](https://github.com/electric-sql/electric/tree/main/examples/tanstack-db-web-starter)
+- [Electric Collection](https://tanstack.com/db/latest/docs/collections/electric-collection)

--- a/packages/typescript-client/skills/y-electric/SKILL.md
+++ b/packages/typescript-client/skills/y-electric/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: y-electric
+description: >
+  Yjs CRDT collaboration via Electric — ElectricProvider, Y.Doc, Awareness,
+  ResumeState, LocalStorageResumeState, documentUpdates shape, awarenessUpdates
+  shape, sendUrl, debounceMs, bytea parsing, CodeMirror integration
+type: composition
+library: '@electric-sql/client'
+library_version: '1.5.8'
+requires:
+  - 'yjs'
+  - '@electric-sql/y-electric'
+  - 'y-protocols'
+sources:
+  - 'electric:packages/y-electric/src/y-electric.ts'
+  - 'electric:examples/yjs'
+---
+
+# Y-Electric (Yjs Collaboration)
+
+Real-time CRDT collaboration using Yjs synced through Electric.
+
+## Setup
+
+```bash
+pnpm add yjs @electric-sql/y-electric y-protocols
+```
+
+## Core Patterns
+
+### Basic ElectricProvider
+
+```typescript
+import * as Y from 'yjs'
+import { ElectricProvider } from '@electric-sql/y-electric'
+import { parseToDecoder } from '@electric-sql/y-electric/utils'
+
+const doc = new Y.Doc()
+
+const provider = new ElectricProvider({
+  doc,
+  documentUpdates: {
+    shape: {
+      url: '/shape-proxy/v1/shape',
+      params: {
+        table: 'ydoc_updates',
+        where: `room = 'my-room'`,
+      },
+      parser: {
+        bytea: parseToDecoder.bytea(),
+      },
+    },
+    sendUrl: '/api/update',
+    getUpdateFromRow: (row) => row.data,
+  },
+  debounceMs: 100,
+})
+```
+
+### With Awareness (Cursor Positions, User Presence)
+
+```typescript
+import * as awarenessProtocol from 'y-protocols/awareness'
+
+const awareness = new awarenessProtocol.Awareness(doc)
+
+const provider = new ElectricProvider({
+  doc,
+  documentUpdates: {
+    shape: {
+      url: '/shape-proxy/v1/shape',
+      params: { table: 'ydoc_updates', where: `room = 'my-room'` },
+      parser: { bytea: parseToDecoder.bytea() },
+      liveSse: true,
+    },
+    sendUrl: '/api/update',
+    getUpdateFromRow: (row) => row.data,
+  },
+  awarenessUpdates: {
+    shape: {
+      url: '/shape-proxy/v1/shape',
+      params: { table: 'ydoc_awareness', where: `room = 'my-room'` },
+      parser: { bytea: parseToDecoder.bytea() },
+      liveSse: true,
+    },
+    sendUrl: '/api/update',
+    protocol: awareness,
+    getUpdateFromRow: (row) => row.data,
+  },
+  debounceMs: 100,
+})
+```
+
+### Resume State (Offline Persistence)
+
+```typescript
+import { LocalStorageResumeStateProvider } from '@electric-sql/y-electric'
+
+const resumeStateProvider = new LocalStorageResumeStateProvider('my-room')
+
+const provider = new ElectricProvider({
+  doc,
+  documentUpdates: {
+    /* ... */
+  },
+  resumeState: resumeStateProvider.getResumeState(),
+})
+
+// Save resume state when it updates
+provider.on('resumeState', (state) => {
+  resumeStateProvider.save(state)
+})
+```
+
+### Server-Side (Hono Example)
+
+```typescript
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+// Save document updates
+app.put('/api/update', async (c) => {
+  const body = await c.req.arrayBuffer()
+  const room = c.req.query('room')
+  const clientId = c.req.query('client_id')
+
+  await db.query('INSERT INTO ydoc_updates (room, data) VALUES ($1, $2)', [
+    room,
+    Buffer.from(body),
+  ])
+  return c.json({ ok: true })
+})
+
+// Shape proxy
+app.get('/shape-proxy/v1/shape', async (c) => {
+  const electricUrl = new URL(`${ELECTRIC_URL}/v1/shape`)
+  // Forward params, set auth...
+  const resp = await fetch(electricUrl)
+  // Forward response with header cleanup
+  return resp
+})
+```
+
+### Database Schema
+
+```sql
+CREATE TABLE ydoc_updates (
+  id SERIAL PRIMARY KEY,
+  room TEXT NOT NULL,
+  data BYTEA NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE ydoc_awareness (
+  room TEXT NOT NULL,
+  client_id INTEGER NOT NULL,
+  data BYTEA NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (room, client_id)
+);
+```
+
+### Provider Events
+
+```typescript
+provider.on('synced', (synced: boolean) => {
+  console.log('Sync status:', synced)
+})
+
+provider.on('status', ({ status }) => {
+  console.log('Connection:', status) // "connected" | "disconnected" | "connecting"
+})
+
+provider.on('resumeState', (state) => {
+  // Persist for offline resume
+})
+```
+
+### Connect/Disconnect
+
+```typescript
+provider.disconnect() // pause sync
+provider.connect() // resume sync
+provider.destroy() // clean up completely
+```
+
+## Common Mistakes
+
+### [HIGH] Not handling offline resume state
+
+Wrong:
+
+```typescript
+const provider = new ElectricProvider({
+  doc,
+  documentUpdates: {
+    shape: {
+      /* ... */
+    },
+    sendUrl: '/api/update',
+  },
+})
+// No resume state — full re-sync on every page load
+```
+
+Correct:
+
+```typescript
+const resumeState = new LocalStorageResumeStateProvider('room-id')
+
+const provider = new ElectricProvider({
+  doc,
+  documentUpdates: {
+    /* ... */
+  },
+  resumeState: resumeState.getResumeState(),
+})
+
+provider.on('resumeState', (state) => resumeState.save(state))
+```
+
+Without resume state persistence, the provider downloads the entire document
+history on every connection. `LocalStorageResumeStateProvider` tracks the last
+synced offset and state vector.
+
+Source: packages/y-electric/src/local-storage-resume-state.ts
+
+### [HIGH] Missing bytea parser for shape streams
+
+Wrong:
+
+```typescript
+documentUpdates: {
+  shape: {
+    url: "/shape-proxy/v1/shape",
+    params: { table: "ydoc_updates" },
+    // No parser — bytea arrives as hex string, not decoder
+  },
+}
+```
+
+Correct:
+
+```typescript
+documentUpdates: {
+  shape: {
+    url: "/shape-proxy/v1/shape",
+    params: { table: "ydoc_updates" },
+    parser: { bytea: parseToDecoder.bytea() },
+  },
+}
+```
+
+Postgres `bytea` columns arrive as hex-encoded strings. The `parseToDecoder.bytea()`
+parser converts them to the decoder format that `getUpdateFromRow` expects.
+
+Source: packages/y-electric/src/utils.ts
+
+### [MEDIUM] Not using debounce for high-frequency edits
+
+Wrong:
+
+```typescript
+const provider = new ElectricProvider({
+  doc,
+  documentUpdates: {
+    /* ... */
+  },
+  // debounceMs: 0 (default) — every keystroke sends an HTTP request
+})
+```
+
+Correct:
+
+```typescript
+const provider = new ElectricProvider({
+  doc,
+  documentUpdates: {
+    /* ... */
+  },
+  debounceMs: 100, // batch updates within 100ms window
+})
+```
+
+Without debouncing, every Yjs document change triggers an immediate HTTP PUT.
+With fast typing, this creates excessive requests. `debounceMs: 100` batches
+updates using `Y.mergeUpdates`.
+
+Source: packages/y-electric/src/y-electric.ts
+
+## References
+
+- [Yjs Documentation](https://docs.yjs.dev)
+- [y-electric package](https://github.com/electric-sql/electric/tree/main/packages/y-electric)
+- [yjs example](https://github.com/electric-sql/electric/tree/main/examples/yjs)


### PR DESCRIPTION
## Summary

- Adds 16 task-focused SKILL.md files + 8 reference files under `packages/typescript-client/skills/`
- Follows flat task-focused architecture (domain discovery found this outperforms nested domain grouping)
- Every skill uses spec frontmatter: `name`, `description`, `type`, `library`, `library_version`, `sources`, and `requires` for composition skills
- Body structure: Setup → Core Patterns → Common Mistakes (Wrong/Correct + mechanism + source) → Tensions → References
- All skills under 500 lines, minimum 3 sourced failure modes each
- 4 cross-domain tensions wired across relevant skill pairs
- Adds `"skills"` to `package.json` files array

### Skills created

**Sub-skills (7):** electric-quickstart, electric-shapes, electric-http-api, electric-proxy, electric-auth, deploying-electric, electric-go-live, electric-proxy-config, electric-testing

**Composition (6):** electric-tanstack-integration, electric-drizzle, tanstack-start-quickstart, electric-nextjs, electric-expo, y-electric

**Security (1):** electric-security-check

**References (8):** shape-options, parser-types, subset-params, electric-cloud, docker, self-hosted

### Source material

Existing skills from `skillz` branch (5 files reformatted), AGENTS.md, domain_map.yaml, troubleshooting.md, and example apps (nextjs, tanstack-db-expo-starter, yjs).

## Test plan

- [ ] Verify `wc -l` on all SKILL.md files — all under 500
- [ ] Grep for `library_version` — present in every frontmatter
- [ ] Count Common Mistakes per skill — minimum 3 each
- [ ] Verify composition skills have `requires`
- [ ] Spot-check code blocks for real `@electric-sql` and `@tanstack` imports
- [ ] Verify 4 tensions appear in correct skill pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)