### PR TITLE
(chore) Remove invalid changeset

### DIFF
--- a/.changeset/reduce-hc-logging.md
+++ b/.changeset/reduce-hc-logging.md
@@ -1,5 +1,0 @@
----
-"@electric-sql/sync-service": patch
----
-
-Reclassify most Logger.info calls to Logger.notice to reduce Honeycomb OTEL log volume. High-volume shape lifecycle messages (create, remove, relation received) remain at info level for AWS CloudWatch debugging while being filtered from Honeycomb via the notice level threshold.


### PR DESCRIPTION
#3921 included a changeset created by an agent which turned out to be invalid (it should be `@core/sync-service` not `@electric-sql/sync-service`). 

#3923 added a valid changeset created with `pnpm changeset` 

This PR removes the invalid changeset