### PR TITLE
fix(sync-service): Ignore failure to rollback

### DIFF
--- a/.changeset/light-pandas-pull.md
+++ b/.changeset/light-pandas-pull.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Ignore failures to rollback a transaction when handling a shape db write exception.

--- a/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/connection.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/connection.ex
@@ -426,7 +426,7 @@ defmodule Electric.ShapeCache.ShapeStatus.ShapeDb.Connection do
       result
     rescue
       e ->
-        :ok = execute(conn, "ROLLBACK")
+        _ = execute(conn, "ROLLBACK")
         reraise e, __STACKTRACE__
     end
   end

--- a/packages/sync-service/test/electric/shape_cache/shape_status/shape_db_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status/shape_db_test.exs
@@ -609,4 +609,17 @@ defmodule Electric.ShapeCache.ShapeStatus.ShapeDbTest do
                )
     end
   end
+
+  describe "error handling" do
+    test "errors raised within transaction do not cause errors attempting to rollback", ctx do
+      assert_raise RuntimeError, "source error", fn ->
+        ShapeDb.Connection.checkout_write!(ctx.stack_id, :raising, fn %{conn: conn} ->
+          # commit the txn so that attempting to rollback after the exception
+          # will return an error
+          :ok = ShapeDb.Connection.execute(conn, "COMMIT")
+          raise RuntimeError, "source error"
+        end)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ignore result of attempting to rollback a write transaction. 

Errors may happen after the txn has already been committed (or aborted) so we can ignore any errors resulting from any secondary ROLLBACK.

Helps with #3943
