### PR TITLE
chore(sync-service): Delay statistics collection and optimize via pool

### DIFF
--- a/.changeset/stale-masks-reply.md
+++ b/.changeset/stale-masks-reply.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Run optimize using the write pool rather than using a separate persistent connection even in non-exclusive mode

--- a/.changeset/tall-peas-rhyme.md
+++ b/.changeset/tall-peas-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@core/electric-telemetry': patch
+---
+
+Delay first collection of statistics so that shape db system has time to start properly

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -38,7 +38,7 @@ defmodule ElectricTelemetry.StackTelemetry do
         [
           ElectricTelemetry.Poller.child_spec(opts,
             callback_module: __MODULE__,
-            init_delay: :timer.seconds(3)
+            init_delay: :timer.seconds(30)
           )
         ],
         disk_usage_child_specs(opts),

--- a/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/connection.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/connection.ex
@@ -118,8 +118,20 @@ defmodule Electric.ShapeCache.ShapeStatus.ShapeDb.Connection do
     end
   end
 
-  def optimize(conn) when is_raw_connection(conn) do
-    execute_all(conn, ["PRAGMA optimize=0x10002"])
+  # https://sqlite.org/pragma.html#pragma_optimize
+  # This pragma is usually a no-op or nearly so and is very fast. On the
+  # occasions where it does need to run ANALYZE on one or more tables, it sets
+  # a temporary analysis limit, valid for the duration of this pragma only,
+  # that prevents the ANALYZE invocations from running for too long.
+  def optimize(conn, mask \\ nil) when is_raw_connection(conn) do
+    stmts =
+      if is_nil(mask) do
+        ["PRAGMA optimize"]
+      else
+        ["PRAGMA optimize=#{mask}"]
+      end
+
+    execute_all(conn, stmts)
   end
 
   def enable_extension(conn, extension) when is_raw_connection(conn) do

--- a/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/migrator.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status/shape_db/migrator.ex
@@ -20,44 +20,40 @@ defmodule Electric.ShapeCache.ShapeStatus.ShapeDb.Migrator do
     Logger.metadata(stack_id: stack_id)
     Electric.Telemetry.Sentry.set_tags_context(stack_id: stack_id)
 
-    with {:ok, conn} <- apply_migration(stack_id, args, exclusive_mode) do
-      {:ok, schedule_optimize(stack_id, conn), :hibernate}
+    with :ok <- apply_migration(stack_id, args, exclusive_mode) do
+      {:ok, schedule_optimize(stack_id), :hibernate}
     end
   end
 
   defp apply_migration(_stack_id, _opts, true = _exclusive?) do
     # In exclusive  mode we *must* apply the migrations within the pool
     # connection initialization because we might be using a memory db.
-    # We return nil to trigger checkout-mode.
-    {:ok, nil}
+    :ok
   end
 
   defp apply_migration(_stack_id, opts, false = _exclusive?) do
     with {:ok, conn} <- ShapeDb.Connection.open(opts, integrity_check: true),
          {:ok, _version} <- ShapeDb.Connection.migrate(conn, opts),
-         :ok = ShapeDb.Connection.optimize(conn) do
-      {:ok, conn}
+         # https://sqlite.org/pragma.html#pragma_optimize
+         # Applications with long-lived database connections should run "PRAGMA
+         # optimize=0x10002" when the database connection first opens
+         :ok = ShapeDb.Connection.optimize(conn, "0x10002"),
+         :ok = ShapeDb.Connection.close(conn) do
+      :ok
     end
   end
 
   @impl GenServer
-  def handle_info(:optimize, {stack_id, nil}) do
+  def handle_info(:optimize, stack_id) do
     ShapeDb.Connection.checkout_write!(stack_id, :optimize, fn %{conn: conn} ->
       :ok = ShapeDb.Connection.optimize(conn)
     end)
 
-    {:noreply, schedule_optimize(stack_id, nil), :hibernate}
+    {:noreply, schedule_optimize(stack_id), :hibernate}
   end
 
-  def handle_info(:optimize, {stack_id, conn}) do
-    Logger.notice("Optimizing shape db tables")
-    :ok = ShapeDb.Connection.optimize(conn)
-
-    {:noreply, schedule_optimize(stack_id, conn), :hibernate}
-  end
-
-  defp schedule_optimize(stack_id, conn) do
+  defp schedule_optimize(stack_id) do
     Process.send_after(self(), :optimize, @optimization_period)
-    {stack_id, conn}
+    stack_id
   end
 end


### PR DESCRIPTION
Running locally I've seen errors collecting the statistics for the number of shapes and sqlite metrics because the telemetry poller runs before the shape db has properly started.

This pr adds an arbitrary delay to the start of metrics collection to make that situation less likely. 

It also simplifies the db optimization process by always checking out a connection from the write pool even in non-exclusive mode, rather than maintaining a separate persistent connection just for the periodic optimize call.