### PR TITLE
fix(sync-service, electric-telemetry): Export affected_shape_count

### DIFF
--- a/.changeset/strange-cups-flow.md
+++ b/.changeset/strange-cups-flow.md
@@ -1,0 +1,6 @@
+---
+'@core/electric-telemetry': patch
+'@core/sync-service': patch
+---
+
+Export number of affected shapes per transaction into the global metrics

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -112,7 +112,8 @@ defmodule ElectricTelemetry.StackTelemetry do
       last_value("electric.connection.consumers_ready.total"),
       last_value("electric.connection.consumers_ready.failed_to_recover"),
       last_value("electric.admission_control.acquire.current", tags: [:kind]),
-      sum("electric.admission_control.reject.count", tags: [:kind])
+      sum("electric.admission_control.reject.count", tags: [:kind]),
+      distribution("electric.shape_log_collector.transaction.affected_shape_count")
       | additional_metrics(telemetry_opts)
     ]
     |> ElectricTelemetry.keep_for_stack(telemetry_opts.stack_id)

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -545,6 +545,12 @@ defmodule Electric.Replication.ShapeLogCollector do
       "shape_log_collector.affected_shape_count": affected_shape_count
     )
 
+    OpenTelemetry.execute(
+      [:electric, :shape_log_collector, :transaction],
+      %{affected_shape_count: affected_shape_count},
+      %{stack_id: state.stack_id}
+    )
+
     OpenTelemetry.start_interval(:"shape_log_collector.publish.duration_µs")
     context = OpenTelemetry.get_current_context()
 


### PR DESCRIPTION
We calculate the affected shape count for every transaction and attach that data to the current span. However span data cannot be queried alongside the other stack metrics, which means we lose important information when looking at events in the system dashboards.

This PR also adds the affected shape count as an exported metric so that we can correlate the number of affected shapes with other events in the metrics dashboards.

