### PR TITLE
feat(sync-service): Add ELECTRIC_EXCLUDE_SPANS env var

### DIFF
--- a/.changeset/cold-swans-tear.md
+++ b/.changeset/cold-swans-tear.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Add `ELECTRIC_EXCLUDE_SPANS` env var to exclude arbitrary OTel spans by name, helping manage telemetry quota usage.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -283,7 +283,9 @@ config :electric,
   shape_db_synchronous: env!("ELECTRIC_SHAPE_DB_SYNCHRONOUS", :string, nil),
   shape_db_cache_size:
     env!("ELECTRIC_SHAPE_DB_CACHE_SIZE", &Electric.Config.parse_human_readable_size!/1, nil),
-  shape_db_enable_memory_stats: env!("ELECTRIC_SHAPE_DB_ENABLE_MEMORY_STATS", :boolean, nil)
+  shape_db_enable_memory_stats: env!("ELECTRIC_SHAPE_DB_ENABLE_MEMORY_STATS", :boolean, nil),
+  exclude_spans:
+    env!("ELECTRIC_EXCLUDE_SPANS", &Electric.Config.parse_comma_separated_set!/1, nil)
 
 if Electric.telemetry_enabled?() do
   # Disable the default telemetry_poller process since we start our own in

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -113,7 +113,8 @@ defmodule Electric.Config do
     shape_db_synchronous:
       Electric.ShapeCache.ShapeStatus.ShapeDb.Connection.default!(:synchronous),
     shape_db_cache_size: Electric.ShapeCache.ShapeStatus.ShapeDb.Connection.default!(:cache_size),
-    shape_db_enable_memory_stats: false
+    shape_db_enable_memory_stats: false,
+    exclude_spans: MapSet.new()
   ]
 
   @installation_id_key "electric_installation_id"
@@ -612,6 +613,30 @@ defmodule Electric.Config do
     do: {:ok, Electric.Utils.deobfuscate_password(connection_opts)}
 
   def deobfuscate(other), do: other
+
+  @doc ~S"""
+  Parse a comma-separated string into a MapSet of trimmed values.
+
+  ## Examples
+
+      iex> parse_comma_separated_set!("foo,bar,baz")
+      MapSet.new(["bar", "baz", "foo"])
+
+      iex> parse_comma_separated_set!(" foo , bar , baz ")
+      MapSet.new(["bar", "baz", "foo"])
+
+      iex> parse_comma_separated_set!("single")
+      MapSet.new(["single"])
+
+      iex> parse_comma_separated_set!(",,,")
+      MapSet.new()
+
+      iex> parse_comma_separated_set!("")
+      MapSet.new()
+  """
+  def parse_comma_separated_set!(str) do
+    str |> String.split(",", trim: true) |> Enum.map(&String.trim/1) |> MapSet.new()
+  end
 
   def parse_feature_flags(str) do
     str

--- a/packages/sync-service/lib/electric/telemetry/sampler.ex
+++ b/packages/sync-service/lib/electric/telemetry/sampler.ex
@@ -9,9 +9,20 @@ defmodule Electric.Telemetry.Sampler do
   they are only sampled if the parent span is sampled.
   """
 
-  def include_span?("filter." <> _), do: Application.get_env(:electric, :profile_where_clauses?)
-  def include_span?("pg_txn.replication_client.transaction_received"), do: sample?()
-  def include_span?(_), do: true
+  def include_span?(name) do
+    !excluded?(name) && included?(name)
+  end
+
+  defp included?("filter." <> _), do: Application.get_env(:electric, :profile_where_clauses?)
+  defp included?("pg_txn.replication_client.transaction_received"), do: sample?()
+  defp included?(_), do: true
+
+  defp excluded?(name) do
+    case Electric.Config.get_env(:exclude_spans) do
+      nil -> false
+      set -> MapSet.member?(set, name)
+    end
+  end
 
   defp sample? do
     :rand.uniform() <= Electric.Config.get_env(:otel_sampling_ratio)


### PR DESCRIPTION
## Summary
Add a general-purpose `ELECTRIC_EXCLUDE_SPANS` environment variable that allows excluding arbitrary OTel spans by name via a comma-separated list, helping manage telemetry quota usage with providers like Honeycomb.

## Changes
- Parse `ELECTRIC_EXCLUDE_SPANS` in `config/runtime.exs` into a `MapSet` of span names
- Add exclusion check in `Electric.Telemetry.Sampler` that gates span creation before existing `filter.*` and `pg_txn.*` rules
- Add `exclude_spans: MapSet.new()` default in `Electric.Config`

## Usage
```bash
ELECTRIC_EXCLUDE_SPANS="shape_status.validate_shape_handle,shape_get.api.load_shape_info"
```

## Test Plan
- [x] All existing telemetry tests pass (11 tests)
- [x] Full test suite passes (1780 tests, 0 failures)
- [ ] Manual verification: set `ELECTRIC_EXCLUDE_SPANS` and confirm excluded spans are no longer created

---
Generated with [Claude Code](https://claude.com/claude-code)