### PR TITLE
fix(sync-service): Add a temporary shape mailbox

### DIFF
--- a/.changeset/angry-pears-beam.md
+++ b/.changeset/angry-pears-beam.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Pass shape to consumer using a single-use ets entry

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -355,10 +355,12 @@ defmodule Electric.ShapeCache do
 
     feature_flags = Electric.StackConfig.lookup(stack_id, :feature_flags, [])
 
+    # put the shape into a temporary mailbox to speed retrieval from consumer
+    :ok = ShapeStatus.post_shape(stack_id, shape_handle, shape)
+
     start_opts =
       opts
       |> Map.put(:shape_handle, shape_handle)
-      |> Map.put(:shape, shape)
       |> Map.put(:subqueries_enabled_for_stack?, "allow_subqueries" in feature_flags)
 
     case Shapes.DynamicConsumerSupervisor.start_shape_consumer(stack_id, start_opts) do

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -48,6 +48,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
   @spec initialize(stack_id()) :: :ok | {:error, term()}
   def initialize(stack_id) when is_stack_id(stack_id) do
     create_shape_meta_table(stack_id)
+    create_shape_mailbox(stack_id)
 
     {:ok, invalid_handles, valid_shape_count} = ShapeDb.validate_existing_shapes(stack_id)
 
@@ -141,6 +142,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
     OpenTelemetry.with_span("shape_status.remove_shape", [], stack_id, fn ->
       with :ok <- ShapeDb.remove_shape(stack_id, shape_handle) do
         :ets.delete(shape_meta_table(stack_id), shape_handle)
+        :ets.delete(shape_mailbox(stack_id), shape_handle)
         :ok
       end
     end)
@@ -150,6 +152,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
   def reset(stack_id) when is_stack_id(stack_id) do
     :ok = ShapeDb.reset(stack_id)
     :ets.delete_all_objects(shape_meta_table(stack_id))
+    :ets.delete_all_objects(shape_mailbox(stack_id))
     :ok
   end
 
@@ -331,6 +334,58 @@ defmodule Electric.ShapeCache.ShapeStatus do
       :none ->
         {handles, largest_last_read}
     end
+  end
+
+  @spec post_shape(stack_id(), shape_handle(), Shape.t()) :: :ok | {:error, term()}
+  def post_shape(stack_id, shape_handle, shape) do
+    if :ets.insert_new(shape_mailbox(stack_id), {shape_handle, shape}) do
+      :ok
+    else
+      {:error, "Duplicate shape in mailbox: #{inspect(shape_handle)}"}
+    end
+  end
+
+  @spec deliver_shape!(stack_id(), shape_handle()) :: Shape.t() | no_return()
+  def deliver_shape!(stack_id, shape_handle) do
+    table = shape_mailbox(stack_id)
+
+    case :ets.lookup_element(table, shape_handle, 2, nil) do
+      nil ->
+        Logger.warning("Shape not available in mailbox: #{inspect(shape_handle)}")
+        # Fall back to the shapedb - mostly to support test scenarios since
+        # consumers are not restarted on error, so won't be re-retrieving the
+        # shape from the mailbox
+        case fetch_shape_by_handle(stack_id, shape_handle) do
+          {:ok, shape} ->
+            shape
+
+          :error ->
+            raise ArgumentError,
+              message: "Unable to retrieve shape for handle #{inspect(shape_handle)}"
+        end
+
+      %Shape{} = shape ->
+        :ets.delete(table, shape_handle)
+        shape
+    end
+  end
+
+  @spec shape_mailbox(stack_id()) :: atom()
+  defp shape_mailbox(stack_id),
+    do: :"shape_mailbox:#{stack_id}"
+
+  defp create_shape_mailbox(stack_id) do
+    table = shape_mailbox(stack_id)
+
+    :ets.new(table, [
+      :named_table,
+      :public,
+      :set,
+      read_concurrency: true,
+      write_concurrency: :auto
+    ])
+
+    table
   end
 
   @spec shape_meta_table(stack_id()) :: atom()

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -111,22 +111,18 @@ defmodule Electric.Shapes.Consumer do
     Logger.metadata(metadata)
     Electric.Telemetry.Sentry.set_tags_context(metadata)
 
-    {:ok, State.new(stack_id, shape_handle), {:continue, {:init_consumer, config}}}
+    shape = ShapeCache.ShapeStatus.deliver_shape!(stack_id, shape_handle)
+
+    {:ok, State.new(stack_id, shape_handle, shape), {:continue, {:init_consumer, config}}}
   end
 
   @impl GenServer
   def handle_continue({:init_consumer, config}, state) do
     %{
       stack_id: stack_id,
-      shape_handle: shape_handle
+      shape_handle: shape_handle,
+      shape: shape
     } = state
-
-    shape =
-      Map.get_lazy(config, :shape, fn ->
-        ShapeCache.ShapeStatus.fetch_shape_by_handle!(stack_id, shape_handle)
-      end)
-
-    state = State.initialize_shape(state, shape, config)
 
     stack_storage = ShapeCache.Storage.for_stack(stack_id)
     storage = ShapeCache.Storage.for_shape(shape_handle, stack_storage)


### PR DESCRIPTION
Add a single use mailbox for passing a shape to a consumer process without going through the disk

This ensures that shapes are passed cleanly to new consumer processes without increasing RAM by duplicating the shape in the supervisor's state.
