### PR TITLE
Revert "fix(sync-service): Pass shape directly to consumer process (#3964)

### DIFF
--- a/.changeset/lovely-icons-sit.md
+++ b/.changeset/lovely-icons-sit.md
@@ -1,5 +1,0 @@
----
-'@core/sync-service': patch
----
-
-Remove redundant ShapeDb fetch from Consumer initialization

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -358,7 +358,6 @@ defmodule Electric.ShapeCache do
     start_opts =
       opts
       |> Map.put(:shape_handle, shape_handle)
-      |> Map.put(:shape, shape)
       |> Map.put(:subqueries_enabled_for_stack?, "allow_subqueries" in feature_flags)
 
     case Shapes.DynamicConsumerSupervisor.start_shape_consumer(stack_id, start_opts) do

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -186,15 +186,6 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end)
   end
 
-  @spec fetch_shape_by_handle!(stack_id(), shape_handle()) :: Shape.t() | no_return()
-  def fetch_shape_by_handle!(stack_id, shape_handle)
-      when is_stack_id(stack_id) and is_shape_handle(shape_handle) do
-    case fetch_shape_by_handle(stack_id, shape_handle) do
-      {:ok, shape} -> shape
-      :error -> raise ArgumentError, message: "No shape found for handle #{inspect(shape_handle)}"
-    end
-  end
-
   def has_shape_handle?(stack_id, shape_handle) do
     :ets.member(shape_meta_table(stack_id), shape_handle)
   end

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -121,10 +121,7 @@ defmodule Electric.Shapes.Consumer do
       shape_handle: shape_handle
     } = state
 
-    shape =
-      Map.get_lazy(config, :shape, fn ->
-        ShapeCache.ShapeStatus.fetch_shape_by_handle!(stack_id, shape_handle)
-      end)
+    {:ok, shape} = ShapeCache.ShapeStatus.fetch_shape_by_handle(stack_id, shape_handle)
 
     state = State.initialize_shape(state, shape, config)
 


### PR DESCRIPTION
This reverts commit cea4c13bbba4be9ccbcc6189aa9aa7c940c01312.

Possibly temporarily. Since this change is likely to have adverse effects on the memory footprint, we've decided to test things out in Cloud without it first.