### PR TITLE
fix(sync-service): recover from dead consumers blocking WAL flush advancement

### DIFF
--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -554,25 +554,34 @@ defmodule Electric.Replication.ShapeLogCollector do
     OpenTelemetry.start_interval(:"shape_log_collector.publish.duration_µs")
     context = OpenTelemetry.get_current_context()
 
-    for layer <- DependencyLayers.get_for_handles(state.dependency_layers, affected_shapes) do
-      # Each publish is synchronous, so layers will be processed in order
-      layer_events =
-        Map.new(layer, fn handle ->
-          {handle, {:handle_event, Map.fetch!(events_by_handle, handle), context}}
-        end)
+    undeliverable =
+      for layer <- DependencyLayers.get_for_handles(state.dependency_layers, affected_shapes),
+          reduce: MapSet.new() do
+        acc ->
+          # Each publish is synchronous, so layers will be processed in order
+          layer_events =
+            Map.new(layer, fn handle ->
+              {handle, {:handle_event, Map.fetch!(events_by_handle, handle), context}}
+            end)
 
-      ConsumerRegistry.publish(layer_events, state.registry_state)
-    end
+          failed = ConsumerRegistry.publish(layer_events, state.registry_state)
+          MapSet.union(acc, failed)
+      end
 
     OpenTelemetry.start_interval(:"shape_log_collector.set_last_processed_lsn.duration_µs")
 
     lsn = Lsn.from_integer(state.last_processed_offset.tx_offset)
     LsnTracker.set_last_processed_lsn(state.lsn_tracker_ref, lsn)
 
+    # Exclude shapes where delivery permanently failed — tracking them in the
+    # FlushTracker would block flush advancement since no consumer will ever
+    # report a flush for these handles.
+    delivered_shapes = MapSet.difference(affected_shapes, undeliverable)
+
     flush_tracker =
       case event do
         %TransactionFragment{commit: commit} when not is_nil(commit) ->
-          FlushTracker.handle_txn_fragment(state.flush_tracker, event, affected_shapes)
+          FlushTracker.handle_txn_fragment(state.flush_tracker, event, delivered_shapes)
 
         _ ->
           state.flush_tracker

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -543,6 +543,24 @@ defmodule Electric.Shapes.Consumer do
 
   defp handle_txn_fragment(txn_fragment, state), do: process_txn_fragment(txn_fragment, state)
 
+  # A replacement consumer (started after a crash) may receive a mid-transaction
+  # fragment before seeing the begin fragment. Since we have no transaction context,
+  # skip the fragment. If it's the commit fragment, mark it as flushed so the
+  # FlushTracker doesn't get permanently stuck waiting for this shape.
+  defp process_txn_fragment(
+         %TransactionFragment{has_begin?: false} = txn_fragment,
+         %State{pending_txn: nil} = state
+       ) do
+    Logger.warning(fn ->
+      "Received non-begin fragment with no pending transaction, skipping"
+    end)
+
+    case txn_fragment do
+      %TransactionFragment{commit: nil} -> state
+      _ -> consider_flushed(state, txn_fragment.last_log_offset)
+    end
+  end
+
   defp process_txn_fragment(
          %TransactionFragment{} = txn_fragment,
          %State{pending_txn: txn} = state

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -73,20 +73,59 @@ defmodule Electric.Shapes.ConsumerRegistry do
     :ets.insert_new(table, [{shape_handle, pid}])
   end
 
-  @spec publish(%{shape_handle() => term()}, t()) :: :ok
+  @doc """
+  Publishes events to consumers, starting new ones if needed.
+
+  Returns a `MapSet` of shape handles where delivery permanently failed
+  (e.g. the shape was removed between event routing and delivery).
+  An empty `MapSet` means all events were delivered successfully.
+  """
+  @spec publish(%{shape_handle() => term()}, t()) :: MapSet.t(shape_handle())
   def publish(events_by_handle, _registry_state) when events_by_handle == %{} do
-    :ok
+    MapSet.new()
   end
 
   def publish(events_by_handle, registry_state) do
     %{table: table} = registry_state
 
-    events_by_handle
-    |> Enum.map(fn {handle, event} ->
-      {handle, event, consumer_pid(handle, table) || start_consumer!(handle, registry_state)}
+    handle_event_pids =
+      Enum.map(events_by_handle, fn {handle, event} ->
+        {handle, event, consumer_pid(handle, table) || start_consumer!(handle, registry_state)}
+      end)
+
+    # Handles with nil PIDs are permanently undeliverable (shape was removed).
+    undeliverable =
+      for {handle, _event, nil} <- handle_event_pids, into: MapSet.new(), do: handle
+
+    if MapSet.size(undeliverable) > 0 do
+      Logger.warning(fn ->
+        ["Undeliverable events for removed shapes: ", inspect(MapSet.to_list(undeliverable))]
+      end)
+    end
+
+    retry_handles = broadcast(handle_event_pids)
+
+    # Clean up dead consumer PIDs from ETS before retrying.
+    # When a consumer crashes (non-suspend DOWN), broadcast returns the handle
+    # for retry, but the dead PID is still in ETS. We must remove it so that
+    # the recursive publish call triggers start_consumer! for a fresh consumer.
+    Enum.each(retry_handles, fn {handle, _event} ->
+      case consumer_pid(handle, table) do
+        nil ->
+          :ok
+
+        pid ->
+          unless Process.alive?(pid) do
+            :ets.delete(table, handle)
+
+            Logger.warning(fn ->
+              "Removed dead consumer for shape #{handle}, starting replacement"
+            end)
+          end
+      end
     end)
-    |> broadcast()
-    |> publish(registry_state)
+
+    MapSet.union(undeliverable, publish(retry_handles, registry_state))
   end
 
   @spec remove_consumer(shape_handle(), t()) :: :ok
@@ -146,7 +185,9 @@ defmodule Electric.Shapes.ConsumerRegistry do
           [{handle, event}]
 
         {:DOWN, ^ref, _, _, _reason} ->
-          []
+          # Consumer crashed — return for retry so publish/2 can clean up
+          # the dead PID from ETS and start a replacement consumer.
+          [{handle, event}]
       end
     end)
     |> Map.new()
@@ -154,9 +195,9 @@ defmodule Electric.Shapes.ConsumerRegistry do
       map when map == %{} ->
         :ok
 
-      suspended_handles ->
+      retry_handles ->
         Logger.debug(fn ->
-          ["Re-trying suspended shape handles ", inspect(Map.keys(suspended_handles))]
+          ["Re-trying shape handles ", inspect(Map.keys(retry_handles))]
         end)
     end)
   end

--- a/packages/sync-service/test/electric/replication/shape_log_collector/flush_tracker_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector/flush_tracker_test.exs
@@ -163,6 +163,58 @@ defmodule Electric.Replication.ShapeLogCollector.FlushTrackerTest do
     end
   end
 
+  describe "dead consumer blocks flush advancement" do
+    test "a shape that never flushes permanently blocks last_global_flushed_offset", %{
+      tracker: tracker
+    } do
+      # Simulate: two shapes affected by txn at lsn 5
+      tracker =
+        FlushTracker.handle_txn_fragment(tracker, batch(lsn: 5, last_offset: 10), [
+          "alive_shape",
+          "dead_shape"
+        ])
+
+      # alive_shape flushes normally
+      tracker =
+        FlushTracker.handle_flush_notification(tracker, "alive_shape", LogOffset.new(5, 10))
+
+      # dead_shape never flushes (simulates dead consumer)
+      # Global offset should NOT advance to lsn 5
+      refute_receive {:flush_confirmed, 5}, 50
+
+      # Even subsequent transactions with no affected shapes can't unstick it
+      tracker = FlushTracker.handle_txn_fragment(tracker, batch(lsn: 6, last_offset: 10), [])
+      refute_receive {:flush_confirmed, 6}, 50
+
+      # The tracker is NOT empty - it's stuck on dead_shape
+      refute FlushTracker.empty?(tracker)
+
+      # Only handle_shape_removed can unstick it
+      _tracker = FlushTracker.handle_shape_removed(tracker, "dead_shape")
+      assert_receive {:flush_confirmed, 6}
+    end
+
+    test "a single dead shape blocks advancement even when many shapes flush", %{
+      tracker: tracker
+    } do
+      shapes = for i <- 1..100, do: "shape_#{i}"
+      all_shapes = ["dead_shape" | shapes]
+
+      tracker =
+        FlushTracker.handle_txn_fragment(tracker, batch(lsn: 10, last_offset: 10), all_shapes)
+
+      # All 100 live shapes flush
+      tracker =
+        Enum.reduce(shapes, tracker, fn shape, acc ->
+          FlushTracker.handle_flush_notification(acc, shape, LogOffset.new(10, 10))
+        end)
+
+      # Global offset still blocked by the single dead shape
+      refute_receive {:flush_confirmed, 10}, 50
+      refute FlushTracker.empty?(tracker)
+    end
+  end
+
   describe "handle_shape_removed/2" do
     test "should notify immediately when last shape catches up", %{tracker: tracker} do
       tracker =

--- a/packages/sync-service/test/electric/shapes/consumer_registry_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_registry_test.exs
@@ -61,7 +61,7 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
   describe "publish/2" do
     test "starts consumer when receiving a message", ctx do
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 0
-      :ok = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 1}}}, ctx.registry_state)
+      %MapSet{} = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 1}}}, ctx.registry_state)
 
       assert_receive {:start_consumer, "handle-1"}
       assert_receive {:broadcast, "handle-1", {:txn, %{lsn: 1}}}
@@ -70,13 +70,13 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
 
     test "uses existing consumer when already active", ctx do
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 0
-      :ok = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 1}}}, ctx.registry_state)
+      %MapSet{} = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 1}}}, ctx.registry_state)
 
       assert_receive {:start_consumer, "handle-1"}
       assert_receive {:broadcast, "handle-1", {:txn, %{lsn: 1}}}
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 1
 
-      :ok = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 2}}}, ctx.registry_state)
+      %MapSet{} = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 2}}}, ctx.registry_state)
 
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 1
       assert_receive {:broadcast, "handle-1", {:txn, %{lsn: 2}}}
@@ -85,13 +85,13 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
 
     test "starts any missing consumers", ctx do
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 0
-      :ok = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 1}}}, ctx.registry_state)
+      %MapSet{} = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 1}}}, ctx.registry_state)
 
       assert_receive {:start_consumer, "handle-1"}
       assert_receive {:broadcast, "handle-1", {:txn, %{lsn: 1}}}
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 1
 
-      :ok =
+      %MapSet{} =
         ConsumerRegistry.publish(
           %{"handle-1" => {:txn, %{lsn: 2}}, "handle-2" => {:txn, %{lsn: 2}}},
           ctx.registry_state
@@ -150,7 +150,7 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
 
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 3
 
-      :ok =
+      %MapSet{} =
         ConsumerRegistry.publish(
           %{
             "handle-1" => {:txn, %{lsn: 1}},
@@ -166,6 +166,68 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
       assert_receive {:broadcast, "handle-1", {:txn, %{lsn: 1}}}
       assert_receive {:broadcast, "handle-2", {:txn, %{lsn: 1}}}
       assert_receive {:broadcast, "handle-3", {:txn, %{lsn: 1}}}
+    end
+  end
+
+  describe "dead consumer recovery" do
+    test "crashed consumer is replaced and event is retried", ctx do
+      Process.flag(:trap_exit, true)
+
+      # Start a consumer that will crash on message
+      {:ok, doomed} =
+        TestSubscriber.start_link(ctx.stack_id, "handle-crash", fn _msg, _state ->
+          raise "consumer crash"
+        end)
+
+      assert Process.alive?(doomed)
+      assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 1
+
+      # Publish to the crashing consumer — should recover by starting a replacement
+      %MapSet{} =
+        ConsumerRegistry.publish(
+          %{"handle-crash" => {:txn, %{lsn: 1}}},
+          ctx.registry_state
+        )
+
+      # Drain the EXIT message from the crashed consumer
+      assert_receive {:EXIT, ^doomed, _}
+
+      # A replacement consumer was started via start_consumer!
+      assert_receive {:start_consumer, "handle-crash"}
+
+      # The event was retried and delivered to the replacement consumer
+      assert_receive {:broadcast, "handle-crash", {:txn, %{lsn: 1}}}
+    end
+
+    test "dead PID is cleaned from ETS before retry", ctx do
+      Process.flag(:trap_exit, true)
+
+      {:ok, doomed} =
+        TestSubscriber.start_link(ctx.stack_id, "handle-dead", fn _msg, _state ->
+          raise "consumer crash"
+        end)
+
+      # First message causes crash — ETS is cleaned and consumer is restarted
+      %MapSet{} =
+        ConsumerRegistry.publish(
+          %{"handle-dead" => {:txn, %{lsn: 1}}},
+          ctx.registry_state
+        )
+
+      assert_receive {:EXIT, ^doomed, _}
+      assert_receive {:start_consumer, "handle-dead"}
+      assert_receive {:broadcast, "handle-dead", {:txn, %{lsn: 1}}}
+
+      # Second message goes to the replacement consumer directly (no crash recovery needed)
+      %MapSet{} =
+        ConsumerRegistry.publish(
+          %{"handle-dead" => {:txn, %{lsn: 2}}},
+          ctx.registry_state
+        )
+
+      assert_receive {:broadcast, "handle-dead", {:txn, %{lsn: 2}}}
+      # No new start_consumer! call — the replacement from the first publish is reused
+      refute_receive {:start_consumer, "handle-dead"}, 50
     end
   end
 
@@ -186,7 +248,7 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
 
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 1
 
-      :ok = ConsumerRegistry.publish(%{handle => {:txn, %{lsn: 1}}}, ctx.registry_state)
+      %MapSet{} = ConsumerRegistry.publish(%{handle => {:txn, %{lsn: 1}}}, ctx.registry_state)
       assert_receive {:broadcast, ^handle, {:txn, %{lsn: 1}}}
       refute_receive {:start_consumer, ^handle}, 10
     end
@@ -222,7 +284,7 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
 
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 1
 
-      :ok = ConsumerRegistry.publish(%{handle => {:txn, %{lsn: 1}}}, ctx.registry_state)
+      %MapSet{} = ConsumerRegistry.publish(%{handle => {:txn, %{lsn: 1}}}, ctx.registry_state)
       assert_receive {:broadcast, ^handle, {:txn, %{lsn: 1}}}
       refute_receive {:start_consumer, ^handle}, 10
 
@@ -230,7 +292,7 @@ defmodule Electric.Shapes.ConsumerRegistryTest do
 
       assert ConsumerRegistry.active_consumer_count(ctx.stack_id) == 0
 
-      :ok = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 1}}}, ctx.registry_state)
+      %MapSet{} = ConsumerRegistry.publish(%{"handle-1" => {:txn, %{lsn: 1}}}, ctx.registry_state)
 
       assert_receive {:start_consumer, "handle-1"}
       assert_receive {:broadcast, "handle-1", {:txn, %{lsn: 1}}}


### PR DESCRIPTION
## Summary

Fixes a bug where crashed consumer processes permanently block WAL flush advancement (`confirmed_flush_lsn`), causing unbounded WAL growth on Postgres.

When a consumer crashes during `ConsumerRegistry.broadcast`:
1. Its dead PID stays in the ETS lookup table (consumers use `restart: :temporary`)
2. All subsequent events are silently dropped (non-suspend `{:DOWN, ...}` returns `[]`)
3. `FlushTracker` still records the shape as needing to flush (updated *after* publish)
4. Dead consumer never calls `notify_flushed` → `last_global_flushed_offset` permanently stuck
5. A **single** dead consumer blocks flush advancement for **all** shapes

Observed in production with recurring WAL spikes up to ~24 GB at 300K concurrent shapes.

## Changes

### Fix 1 — Dead consumer recovery (`consumer_registry.ex`)
- `broadcast/1`: Non-suspend `{:DOWN}` now returns the handle for retry instead of silently dropping
- `publish/2`: Before retrying, checks `Process.alive?` on the PID in ETS, deletes dead entries, logs a warning, and lets the recursive call start a fresh consumer via `start_consumer!`

### Fix 2 — Nil pending_txn guard (`consumer.ex`)
- New `process_txn_fragment/2` clause for `has_begin?: false` + `pending_txn: nil`
- A replacement consumer started after a crash may receive a mid-transaction fragment without prior context — skip it instead of crashing on `nil.consider_flushed?`
- On commit fragments, calls `consider_flushed` so the FlushTracker isn't blocked

### Fix 3 — Delivery failure reporting (`consumer_registry.ex`, `shape_log_collector.ex`)
- `publish/2` now returns a `MapSet` of handles where delivery permanently failed (shape removed between event routing and delivery)
- SLC subtracts undeliverable handles from `affected_shapes` before updating the FlushTracker, preventing it from tracking shapes that will never flush

## Deferred: Periodic liveness sweep

A periodic sweep checking `Process.alive?` on all ETS entries would serve as a safety net for any edge cases not caught by Fix 1. This was deferred for human evaluation — a timeout-based staleness check is **unsafe** because legitimate consumers can be very slow:
- Synchronous `broadcast` blocks `{:writer_flushed, ...}` cast processing for the duration of the fan-out (seconds to minutes at 300K shapes)
- Storage flush is periodic, not immediate
- New shapes buffer fragments (`buffering?: true`) until snapshot info arrives (minutes under pool contention)
- SLC mailbox backlog (1M+ messages observed) can delay flush casts indefinitely

A `Process.alive?` check has zero false positives — a dead process will never flush.

## Test plan

- [x] New FlushTracker tests: "dead consumer blocks flush advancement" — verifies a single unflushed shape permanently blocks `last_global_flushed_offset`, and that `handle_shape_removed` unblocks it
- [x] New ConsumerRegistry tests: "dead consumer recovery" — verifies crashed consumers are detected, cleaned from ETS, and replaced with fresh consumers that receive the retried event
- [x] All existing FlushTracker tests pass (14)
- [x] All existing ConsumerRegistry tests pass (15)
- [x] All SLC tests pass (24)
- [x] All consumer tests pass (26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)