### PR TITLE
Add CLAUDE.md symlink to sync-service

### DIFF
--- a/packages/sync-service/CLAUDE.md
+++ b/packages/sync-service/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Adds a `CLAUDE.md` symlink pointing to `AGENTS.md` in `packages/sync-service` so that Claude Code automatically loads the sync-service guidelines into context.

## Test plan
- [x] Verify symlink resolves correctly: `readlink packages/sync-service/CLAUDE.md` → `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)