### PR TITLE
Report view mismatch instead of generic timeout in oracle shape checker

### DIFF
--- a/packages/sync-service/test/support/oracle_harness/shape_checker.ex
+++ b/packages/sync-service/test/support/oracle_harness/shape_checker.ex
@@ -157,33 +157,34 @@ defmodule Support.OracleHarness.ShapeChecker do
     elapsed = System.monotonic_time(:millisecond) - start_ms
 
     if elapsed >= state.timeout_ms do
-      flunk("Timeout waiting for shape=#{state.name} where=#{state.where}")
-    end
+      # Timed out — return state and let assert_consistent! report the mismatch
+      state
+    else
+      case Client.poll(state.client, state.shape_def, state.poll_state, replica: :full) do
+        {:ok, messages, new_state} ->
+          state = %{state | poll_state: new_state}
+          state = apply_messages(state, messages)
 
-    case Client.poll(state.client, state.shape_def, state.poll_state, replica: :full) do
-      {:ok, messages, new_state} ->
-        state = %{state | poll_state: new_state}
-        state = apply_messages(state, messages)
+          if new_state.up_to_date? do
+            handle_up_to_date(state, start_ms)
+          else
+            do_await(state, start_ms)
+          end
 
-        if new_state.up_to_date? do
-          handle_up_to_date(state, start_ms)
-        else
+        {:must_refetch, messages, new_state} ->
+          if state.optimized do
+            flunk(
+              "Unexpected 409 (must-refetch) in optimized shape=#{state.name} where=#{state.where}"
+            )
+          end
+
+          state = %{state | poll_state: new_state, rows: %{}}
+          state = apply_messages(state, messages)
           do_await(state, start_ms)
-        end
 
-      {:must_refetch, messages, new_state} ->
-        if state.optimized do
-          flunk(
-            "Unexpected 409 (must-refetch) in optimized shape=#{state.name} where=#{state.where}"
-          )
-        end
-
-        state = %{state | poll_state: new_state, rows: %{}}
-        state = apply_messages(state, messages)
-        do_await(state, start_ms)
-
-      {:error, error} ->
-        flunk("Poll error for shape=#{state.name} where=#{state.where}: #{inspect(error)}")
+        {:error, error} ->
+          flunk("Poll error for shape=#{state.name} where=#{state.where}: #{inspect(error)}")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Improve oracle test error reporting by showing the actual view mismatch instead of a generic timeout message.

## Problem

When the oracle shape checker timed out waiting for consistency, it called `flunk("Timeout waiting for shape=...")` which gave no information about what the actual mismatch was. This made debugging oracle test failures harder than necessary — you'd see a timeout error when the real problem was a data discrepancy.

## Solution

On timeout, instead of calling `flunk()`, the checker now returns the current state and lets `assert_consistent!` compare the views and report the actual difference. This way, test failures show which rows or values diverged rather than just "timed out".

## Test Plan

- [x] Code compiles cleanly with `--warnings-as-errors`
- [x] Formatting passes
- [x] Oracle tests exercise this path (tagged `:oracle`, require special infrastructure)

---
Generated with [Claude Code](https://claude.com/claude-code)