### PR TITLE
fix: ignore unknown query params in parse_postgresql_uri

### DIFF
--- a/.changeset/fix-parse-url-query-unknown-params.md
+++ b/.changeset/fix-parse-url-query-unknown-params.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Fix `parse_postgresql_uri` to ignore unknown query parameters instead of rejecting them. Previously, unknown params like `uselibpqcompat=true` were silently ignored when `sslmode` was present (due to Elixir map pattern matching) but rejected when alone. Now unknown params are always ignored, and only `sslmode` and `replication` are validated.

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -303,7 +303,31 @@ defmodule Electric.Config do
       {:error, "missing host"}
 
       iex> parse_postgresql_uri("postgresql://user@localhost:5433/mydb?opts=-c%20synchronous_commit%3Doff&foo=bar")
-      {:error, "unsupported query options: \"foo\", \"opts\""}
+      {:ok, [
+        hostname: "localhost",
+        port: 5433,
+        database: "mydb",
+        username: "user"
+      ]}
+
+      iex> parse_postgresql_uri("postgres://user:pass@localhost:5432/db?uselibpqcompat=true") |> deobfuscate()
+      {:ok, [
+        hostname: "localhost",
+        port: 5432,
+        database: "db",
+        username: "user",
+        password: "pass"
+      ]}
+
+      iex> parse_postgresql_uri("postgres://user:pass@localhost:5432/db?uselibpqcompat=true&sslmode=require") |> deobfuscate()
+      {:ok, [
+        hostname: "localhost",
+        port: 5432,
+        database: "db",
+        username: "user",
+        password: "pass",
+        sslmode: :require
+      ]}
 
       iex> parse_postgresql_uri("postgresql://electric@localhost/db?replication=database")
       {:error, "unsupported \"replication\" query option. Electric opens both a replication connection and regular connections to Postgres as needed"}
@@ -375,30 +399,36 @@ defmodule Electric.Config do
   defp parse_url_query(nil), do: {:ok, []}
 
   defp parse_url_query(query_str) do
-    case URI.decode_query(query_str) do
-      empty when map_size(empty) == 0 ->
-        {:ok, []}
+    params = URI.decode_query(query_str)
 
-      %{"sslmode" => sslmode} when sslmode in ~w[disable allow prefer require] ->
-        {:ok, sslmode: String.to_existing_atom(sslmode)}
-
-      %{"sslmode" => sslmode} when sslmode in ~w[verify-ca verify-full] ->
-        {:error,
-         "unsupported \"sslmode\" value #{inspect(sslmode)}. Use sslmode=require and set the ELECTRIC_DATABASE_CA_CERTIFICATE_FILE config to ensure Electric verifies database server identity"}
-
-      %{"sslmode" => sslmode} ->
-        {:error, "invalid \"sslmode\" value: #{inspect(sslmode)}"}
-
-      %{"replication" => _} ->
-        {:error,
-         "unsupported \"replication\" query option. Electric opens both a replication connection and regular connections to Postgres as needed"}
-
-      map ->
-        {:error,
-         "unsupported query options: " <>
-           (map |> Map.keys() |> Enum.sort() |> Enum.map_join(", ", &inspect/1))}
+    with :ok <- validate_no_replication_param(params) do
+      parse_sslmode(params)
     end
   end
+
+  defp validate_no_replication_param(%{"replication" => _}) do
+    {:error,
+     "unsupported \"replication\" query option. Electric opens both a replication connection and regular connections to Postgres as needed"}
+  end
+
+  defp validate_no_replication_param(_), do: :ok
+
+  defp parse_sslmode(%{"sslmode" => sslmode})
+       when sslmode in ~w[disable allow prefer require] do
+    {:ok, sslmode: String.to_existing_atom(sslmode)}
+  end
+
+  defp parse_sslmode(%{"sslmode" => sslmode})
+       when sslmode in ~w[verify-ca verify-full] do
+    {:error,
+     "unsupported \"sslmode\" value #{inspect(sslmode)}. Use sslmode=require and set the ELECTRIC_DATABASE_CA_CERTIFICATE_FILE config to ensure Electric verifies database server identity"}
+  end
+
+  defp parse_sslmode(%{"sslmode" => sslmode}) do
+    {:error, "invalid \"sslmode\" value: #{inspect(sslmode)}"}
+  end
+
+  defp parse_sslmode(_), do: {:ok, []}
 
   defp parse_database(nil, username), do: username
   defp parse_database("/", username), do: username


### PR DESCRIPTION
## Summary

`parse_postgresql_uri` now ignores unknown query parameters (like `uselibpqcompat=true`) instead of rejecting them. Previously, behavior was inconsistent: unknown params were silently ignored when `sslmode` was present but rejected when absent. This caused production failures in Electric Cloud for connection URLs containing driver-specific parameters.

## Root Cause

`parse_url_query/1` used a single `case` statement with Elixir map pattern matching:

```elixir
case URI.decode_query(query_str) do
  %{"sslmode" => sslmode} when sslmode in ~w[...] ->   # matches any map WITH sslmode
    {:ok, sslmode: ...}
  # ...
  map ->                                                # catch-all for everything else
    {:error, "unsupported query options: ..."}
end
```

`%{"sslmode" => sslmode}` is a **partial match** — it matches any map containing `sslmode`, regardless of other keys. So `?uselibpqcompat=true&sslmode=prefer` succeeded (extra key ignored), but `?uselibpqcompat=true` alone hit the catch-all and was rejected.

This inconsistency meant the same parameter was accepted or rejected depending on whether an unrelated parameter (`sslmode`) happened to be present.

## Approach

Replaced the monolithic `case` with two focused functions:

1. **`validate_no_replication_param/1`** — explicitly rejects the `replication` param (Electric manages replication connections itself, so this must remain an error)
2. **`parse_sslmode/1`** — extracts and validates `sslmode` if present, ignores everything else

This makes the intent explicit: Electric validates params it cares about and ignores the rest.

## Key Invariants

- `sslmode` validation is unchanged — same accepted values, same error messages
- `replication` param is still rejected — this is intentional, not an unknown param
- Unknown params (e.g., `uselibpqcompat`, `options`, `connect_timeout`) are silently ignored
- No change to the parsed output structure (`{:ok, keyword()}`)

## Non-goals

- **Strict validation**: We explicitly chose NOT to reject unknown params. Connection URLs come from various sources (dashboards, CLIs, provider APIs) that may add driver-specific params. Being lenient here is more robust.

## Verification

```sh
cd packages/sync-service
mix test test/electric/config_test.exs    # 37 doctests + 9 tests
mix test                                  # full suite (1835 tests)
```

## Files changed

| File | Change |
|------|--------|
| `packages/sync-service/lib/electric/config.ex` | Replace `parse_url_query` case statement with `validate_no_replication_param` + `parse_sslmode` functions; update doctests |
| `.changeset/fix-parse-url-query-unknown-params.md` | Patch changeset |

Fixes #3993

🤖 Generated with [Claude Code](https://claude.com/claude-code)