### PR TITLE
feat(sync-service): Pass shape directly to consumer process

### DIFF
--- a/.changeset/witty-adults-approve.md
+++ b/.changeset/witty-adults-approve.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Pass Shape directly to Consumer process to eliminate a redundant ShapeDb fetch for every consumer

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -242,7 +242,8 @@ defmodule Electric.ShapeCache do
     state = %{
       name: opts.name,
       stack_id: stack_id,
-      subscription: nil
+      subscription: nil,
+      feature_flags: Electric.StackConfig.lookup(stack_id, :feature_flags, [])
     }
 
     {:ok, state, {:continue, :wait_for_restore}}
@@ -278,7 +279,11 @@ defmodule Electric.ShapeCache do
   @impl GenServer
   def handle_call({:create_or_wait_shape_handle, shape, otel_ctx}, _from, state) do
     {shape_handle, latest_offset} =
-      maybe_create_shape(shape, %{stack_id: state.stack_id, otel_ctx: otel_ctx})
+      maybe_create_shape(shape, %{
+        stack_id: state.stack_id,
+        otel_ctx: otel_ctx,
+        feature_flags: state.feature_flags
+      })
 
     Logger.debug("Returning shape id #{shape_handle} for shape #{inspect(shape)}")
     {:reply, {shape_handle, latest_offset}, state}
@@ -302,7 +307,8 @@ defmodule Electric.ShapeCache do
           restore_shape_and_dependencies(shape_handle, shape, %{
             stack_id: state.stack_id,
             action: :restore,
-            otel_ctx: nil
+            otel_ctx: nil,
+            feature_flags: state.feature_flags
           }),
           state
         }
@@ -353,18 +359,17 @@ defmodule Electric.ShapeCache do
       })
     end)
 
-    feature_flags = Electric.StackConfig.lookup(stack_id, :feature_flags, [])
-
-    start_opts =
-      opts
-      |> Map.put(:shape_handle, shape_handle)
-      |> Map.put(:subqueries_enabled_for_stack?, "allow_subqueries" in feature_flags)
-
-    case Shapes.DynamicConsumerSupervisor.start_shape_consumer(stack_id, start_opts) do
+    case Shapes.DynamicConsumerSupervisor.start_shape_consumer(stack_id, %{
+           stack_id: stack_id,
+           shape_handle: shape_handle
+         }) do
       {:ok, consumer_pid} ->
+        Shapes.Consumer.initialize_shape(consumer_pid, shape, opts)
+
         # Now that the consumer process for this shape is running, we can finish initializing
         # the ShapeStatus record by recording a "last_read" timestamp on it.
         ShapeStatus.update_last_read_time_to_now(stack_id, shape_handle)
+
         {:ok, consumer_pid}
 
       {:error, _reason} = error ->

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -37,6 +37,13 @@ defmodule Electric.Shapes.Consumer do
   @stop_and_clean_timeout 30_000
   @stop_and_clean_reason ShapeCleaner.consumer_cleanup_reason()
 
+  @type initialize_shape_opts() :: %{
+          :action => :create | :restore,
+          optional(:otel_ctx) => map() | nil,
+          optional(:feature_flags) => [binary()],
+          optional(:is_subquery_shape?) => boolean()
+        }
+
   def name(stack_id, shape_handle) when is_binary(shape_handle) do
     ConsumerRegistry.name(stack_id, shape_handle)
   end
@@ -45,6 +52,13 @@ defmodule Electric.Shapes.Consumer do
     ref = make_ref()
     Registry.register(Electric.StackSupervisor.registry_name(stack_id), shape_handle, ref)
     ref
+  end
+
+  @spec initialize_shape(pid(), Shape.t(), initialize_shape_opts()) :: :ok
+  def initialize_shape(consumer_pid, shape, %{action: action} = opts)
+      when action in [:create, :restore] do
+    send(consumer_pid, {:initialize_shape, shape, opts})
+    :ok
   end
 
   @spec await_snapshot_start(Electric.stack_id(), Electric.shape_handle(), timeout()) ::
@@ -94,15 +108,15 @@ defmodule Electric.Shapes.Consumer do
     ConsumerRegistry.whereis(stack_id, shape_handle)
   end
 
-  def start_link(%{stack_id: stack_id, shape_handle: shape_handle} = config) do
-    GenServer.start_link(__MODULE__, config, name: name(stack_id, shape_handle))
+  def start_link(%{stack_id: stack_id, shape_handle: shape_handle} = _config) do
+    GenServer.start_link(__MODULE__, %{stack_id: stack_id, shape_handle: shape_handle},
+      name: name(stack_id, shape_handle)
+    )
   end
 
   @impl GenServer
-  def init(config) do
+  def init(%{stack_id: stack_id, shape_handle: shape_handle}) do
     activate_mocked_functions_from_test_process()
-
-    %{stack_id: stack_id, shape_handle: shape_handle} = config
 
     Process.set_label({:consumer, shape_handle})
     Process.flag(:trap_exit, true)
@@ -111,60 +125,13 @@ defmodule Electric.Shapes.Consumer do
     Logger.metadata(metadata)
     Electric.Telemetry.Sentry.set_tags_context(metadata)
 
-    {:ok, State.new(stack_id, shape_handle), {:continue, {:init_consumer, config}}}
+    # Shape initialization will be complete when we receive a message {:initialize_shape,
+    # <shape>, <shape_opts>} which the ShapeCache is expected to send as soon as this process
+    # is alive.
+    {:ok, State.new(stack_id, shape_handle)}
   end
 
   @impl GenServer
-  def handle_continue({:init_consumer, config}, state) do
-    %{
-      stack_id: stack_id,
-      shape_handle: shape_handle
-    } = state
-
-    {:ok, shape} = ShapeCache.ShapeStatus.fetch_shape_by_handle(stack_id, shape_handle)
-
-    state = State.initialize_shape(state, shape, config)
-
-    stack_storage = ShapeCache.Storage.for_stack(stack_id)
-    storage = ShapeCache.Storage.for_shape(shape_handle, stack_storage)
-
-    # TODO: Remove. Only needed for InMemoryStorage
-    case ShapeCache.Storage.start_link(storage) do
-      {:ok, _pid} -> :ok
-      :ignore -> :ok
-    end
-
-    writer = ShapeCache.Storage.init_writer!(storage, shape)
-
-    state = State.initialize(state, storage, writer)
-
-    if all_materializers_alive?(state) && subscribe(state, config.action) do
-      Logger.debug("Writer for #{shape_handle} initialized")
-
-      # We start the snapshotter even if there's a snapshot because it also performs the call
-      # to PublicationManager.add_shape/3. We *could* do that call here and avoid spawning a
-      # process if the shape already has a snapshot but the current semantics rely on being able
-      # to wait for the snapshot asynchronously and if we called publication manager here it would
-      # block and prevent await_snapshot_start calls from adding snapshot subscribers.
-
-      {:ok, _pid} =
-        Shapes.DynamicConsumerSupervisor.start_snapshotter(
-          stack_id,
-          %{
-            stack_id: stack_id,
-            shape: shape,
-            shape_handle: shape_handle,
-            storage: storage,
-            otel_ctx: config.otel_ctx
-          }
-        )
-
-      {:noreply, state}
-    else
-      stop_and_clean(state)
-    end
-  end
-
   def handle_continue(:stop_and_clean, state) do
     stop_and_clean(state)
   end
@@ -258,6 +225,51 @@ defmodule Electric.Shapes.Consumer do
   end
 
   @impl GenServer
+  def handle_info({:initialize_shape, shape, opts}, state) do
+    %{stack_id: stack_id, shape_handle: shape_handle} = state
+
+    state = State.initialize_shape(state, shape, opts)
+
+    stack_storage = ShapeCache.Storage.for_stack(stack_id)
+    storage = ShapeCache.Storage.for_shape(shape_handle, stack_storage)
+
+    # TODO: Remove. Only needed for InMemoryStorage
+    case ShapeCache.Storage.start_link(storage) do
+      {:ok, _pid} -> :ok
+      :ignore -> :ok
+    end
+
+    writer = ShapeCache.Storage.init_writer!(storage, shape)
+
+    state = State.initialize(state, storage, writer)
+
+    if all_materializers_alive?(state) && subscribe(state, opts.action) do
+      Logger.debug("Writer for #{shape_handle} initialized")
+
+      # We start the snapshotter even if there's a snapshot because it also performs the call
+      # to PublicationManager.add_shape/3. We *could* do that call here and avoid spawning a
+      # process if the shape already has a snapshot but the current semantics rely on being able
+      # to wait for the snapshot asynchronously and if we called publication manager here it would
+      # block and prevent await_snapshot_start calls from adding snapshot subscribers.
+
+      {:ok, _pid} =
+        Shapes.DynamicConsumerSupervisor.start_snapshotter(
+          stack_id,
+          %{
+            stack_id: stack_id,
+            shape: shape,
+            shape_handle: shape_handle,
+            storage: storage,
+            otel_ctx: Map.get(opts, :otel_ctx, nil)
+          }
+        )
+
+      {:noreply, state}
+    else
+      stop_and_clean(state)
+    end
+  end
+
   def handle_info({ShapeCache.Storage, :flushed, offset_in}, state) do
     {state, offset_txn} = State.align_offset_to_txn_boundary(state, offset_in)
 

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -165,6 +165,9 @@ defmodule Electric.Shapes.Consumer.State do
 
   @spec initialize_shape(uninitialized_t(), Shape.t(), map()) :: uninitialized_t()
   def initialize_shape(%__MODULE__{} = state, shape, opts) do
+    feature_flags = Map.get(opts, :feature_flags, [])
+    is_subquery_shape? = Map.get(opts, :is_subquery_shape?, false)
+
     %{
       state
       | shape: shape,
@@ -173,8 +176,8 @@ defmodule Electric.Shapes.Consumer.State do
         # Enable direct fragment-to-storage streaming for shapes without subquery dependencies
         # and if the current shape itself isn't an inner shape of a shape with subqueries.
         write_unit:
-          if Map.get(opts, :subqueries_enabled_for_stack?, false) or
-               shape.shape_dependencies != [] or Map.get(opts, :is_subquery_shape?, false) do
+          if "allow_subqueries" in feature_flags or shape.shape_dependencies != [] or
+               is_subquery_shape? do
             @write_unit_txn
           else
             @write_unit_txn_fragment

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -168,13 +168,12 @@ defmodule Electric.Shapes.ConsumerTest do
               {Shapes.Consumer,
                %{
                  shape_handle: shape_handle,
-                 stack_id: ctx.stack_id,
-                 # inspector: {Mock.Inspector, []},
-                 otel_ctx: nil,
-                 action: :create
+                 stack_id: ctx.stack_id
                }},
               id: {Shapes.Consumer, shape_handle}
             )
+
+          Shapes.Consumer.initialize_shape(consumer, shape, %{action: :create})
 
           assert_receive {Support.TestStorage, :init_writer!, ^shape_handle, ^shape}
 


### PR DESCRIPTION
Remove the requirement for a duplicate ShapeDb fetch to get the shape when we always have it in memory at the point of starting a consumer process.

This takes  pressure off the ShapeDb which can have a high (and unpredictable) latency on a busy system.