### PR TITLE
Revert "Add `electric-has-data` response header (#3851)"

### DIFF
--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -607,7 +607,6 @@ defmodule Electric.Shapes.Api do
     %{
       response
       | status: 200,
-        no_changes: true,
         body: encode_log(request, [up_to_date_ctl(global_last_seen_lsn)]),
         finalized?: true
     }

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -11,7 +11,6 @@ defmodule Electric.Shapes.Api.Response do
   @electric_offset_header "electric-offset"
   @electric_schema_header "electric-schema"
   @electric_up_to_date_header "electric-up-to-date"
-  @electric_has_data_header "electric-has-data"
   @electric_known_error_header "electric-internal-known-error"
   @retry_after_header "retry-after"
 
@@ -19,7 +18,6 @@ defmodule Electric.Shapes.Api.Response do
   @electric_headers [
     @electric_cursor_header,
     @electric_handle_header,
-    @electric_has_data_header,
     @electric_offset_header,
     @electric_schema_header,
     @electric_up_to_date_header,
@@ -222,7 +220,6 @@ defmodule Electric.Shapes.Api.Response do
     |> put_shape_handle_header(response)
     |> put_schema_header(response)
     |> put_up_to_date_header(response)
-    |> put_has_data_header(response)
     |> put_offset_header(response)
     |> put_known_error_header(response)
     |> put_retry_after_header(response)
@@ -352,18 +349,6 @@ defmodule Electric.Shapes.Api.Response do
   defp put_etag_headers(conn, %__MODULE__{} = response) do
     # etag values should be in double quotes: https://www.rfc-editor.org/rfc/rfc7232#section-2.3
     Plug.Conn.put_resp_header(conn, "etag", etag(response))
-  end
-
-  defp put_has_data_header(conn, %__MODULE__{status: status}) when status >= 400 do
-    conn
-  end
-
-  defp put_has_data_header(conn, %__MODULE__{no_changes: true}) do
-    Plug.Conn.put_resp_header(conn, @electric_has_data_header, "false")
-  end
-
-  defp put_has_data_header(conn, %__MODULE__{no_changes: false}) do
-    Plug.Conn.put_resp_header(conn, @electric_has_data_header, "true")
   end
 
   defp put_up_to_date_header(conn, %__MODULE__{up_to_date: true}) do

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -111,8 +111,6 @@ defmodule Electric.Plug.ServeShapePlugTest do
                  ]
                }
              }
-
-      assert get_resp_header(conn, "electric-has-data") == []
     end
 
     test "returns 400 for invalid offset", ctx do
@@ -453,7 +451,6 @@ defmodule Electric.Plug.ServeShapePlugTest do
              ]
 
       assert get_resp_header(conn, "electric-up-to-date") == []
-      assert get_resp_header(conn, "electric-has-data") == ["true"]
     end
 
     test "returns 304 Not Modified when If-None-Match matches ETag",
@@ -579,7 +576,6 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       assert get_resp_header(conn, "electric-offset") == [next_offset_str]
       assert get_resp_header(conn, "electric-up-to-date") == [""]
-      assert get_resp_header(conn, "electric-has-data") == ["true"]
       assert get_resp_header(conn, "electric-schema") == []
 
       expected_cursor =
@@ -671,28 +667,6 @@ defmodule Electric.Plug.ServeShapePlugTest do
       expected_etag_part = "\"#{@test_shape_handle}:#{@test_offset}:#{@test_offset}:"
       assert [^expected_etag_part <> _rest] = get_resp_header(conn, "etag")
 
-      assert get_resp_header(conn, "electric-up-to-date") == [""]
-      assert get_resp_header(conn, "electric-has-data") == ["false"]
-    end
-
-    test "returns electric-has-data: false for offset=now requests", ctx do
-      patch_shape_cache(
-        get_or_create_shape_handle: fn @test_shape, _stack_id, _opts ->
-          {@test_shape_handle, @test_offset}
-        end
-      )
-
-      conn =
-        ctx
-        |> conn(
-          :get,
-          %{"table" => "public.users"},
-          "?offset=now&handle=#{@test_shape_handle}"
-        )
-        |> call_serve_shape_plug(ctx)
-
-      assert conn.status == 200
-      assert get_resp_header(conn, "electric-has-data") == ["false"]
       assert get_resp_header(conn, "electric-up-to-date") == [""]
     end
 

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -707,7 +707,6 @@ defmodule Electric.Shapes.ApiTest do
       assert response.shape_definition == @test_shape
       assert response.offset == next_next_offset
       refute response.up_to_date
-      refute response.no_changes
     end
 
     test "returns immediate up-to-date message when offset is 'now'", ctx do
@@ -745,7 +744,6 @@ defmodule Electric.Shapes.ApiTest do
       # Should have the latest offset from the shape
       assert response.offset == @test_offset
       assert response.handle == @test_shape_handle
-      assert response.no_changes
     end
 
     test "handles live updates", ctx do
@@ -1386,7 +1384,6 @@ defmodule Electric.Shapes.ApiTest do
 
       assert [%{headers: %{control: "up-to-date"}}] = response_body(response)
       assert response.up_to_date
-      assert response.no_changes
     end
 
     @tag long_poll_timeout: 100


### PR DESCRIPTION
## Summary
- Reverts #3851 which added the `electric-has-data` response header

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)