### PR TITLE
feat(sync-service): Read-only mode for seamless rolling deploys

### DIFF
--- a/.changeset/read-only-rolling-deploys.md
+++ b/.changeset/read-only-rolling-deploys.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add read-only mode for seamless rolling deploys. Electric instances now serve existing shape data while waiting for the advisory lock, eliminating the HTTP outage window during rolling deploys.

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -217,7 +217,11 @@
 
 [macro check_health_status expected_status]
   [shell electric-health]
-    [invoke wait-for "curl --silent -X GET http://localhost:3000/v1/health" "\{\"status\":\"$expected_status\"\}" 10 $PS1]
+    [invoke wait_health "3000" $expected_status]
+[endmacro]
+
+[macro wait_health port expected_status]
+  [invoke wait-for "curl --silent http://localhost:$port/v1/health" "\{\"status\":\"$expected_status\"\}" 10 $PS1]
 [endmacro]
 
 [macro setup_otel_collector]
@@ -266,21 +270,35 @@
     ?$prompt
 [endmacro]
 
-[macro shape_get_url params]
+[macro shape_get_url port params]
   # strip ANSI codes from response for easier matching
-  !curl --silent -i "http://localhost:$shape_url_port/v1/shape?$params" | sed -r "s/\x1B\[[0-9;]*[mK]//g"
+  !curl --silent -i "http://localhost:$port/v1/shape?$params" | sed -r "s/\x1B\[[0-9;]*[mK]//g"
 [endmacro]
 
+# Convenience macros using $shape_url_port as default port
 [macro shape_get_snapshot table]
-  [invoke shape_get_url "table=$table&offset=-1"]
+  [invoke shape_get_url $shape_url_port "table=$table&offset=-1"]
 [endmacro]
 
 [macro shape_get table handle offset]
-  [invoke shape_get_url "table=$table&handle=$handle&offset=$offset"]
+  [invoke shape_get_url $shape_url_port "table=$table&handle=$handle&offset=$offset"]
 [endmacro]
 
 [macro shape_get_live table handle offset]
-  [invoke shape_get_url "table=$table&handle=$handle&offset=$offset&live=true"]
+  [invoke shape_get_url $shape_url_port "table=$table&handle=$handle&offset=$offset&live=true"]
+[endmacro]
+
+# Port-explicit variants for multi-instance tests
+[macro shape_get_snapshot_on port table]
+  [invoke shape_get_url $port "table=$table&offset=-1"]
+[endmacro]
+
+[macro shape_get_on port table handle offset]
+  [invoke shape_get_url $port "table=$table&handle=$handle&offset=$offset"]
+[endmacro]
+
+[macro shape_get_live_on port table handle offset]
+  [invoke shape_get_url $port "table=$table&handle=$handle&offset=$offset&live=true"]
 [endmacro]
 
 # Prevent curl from outputing download progress, output response headers nd sort the keys in the response JSON body.

--- a/integration-tests/tests/rolling-deploy.lux
+++ b/integration-tests/tests/rolling-deploy.lux
@@ -1,4 +1,4 @@
-[doc Verify handling of an Electric rolling deploy]
+[doc Verify handling of an Electric rolling deploy with read-only serving]
 
 [include _macros.luxinc]
 
@@ -40,19 +40,19 @@
   ??[notice] Lock acquired from postgres with name electric_slot_integration
   ??[notice] Starting replication from postgres
 
-# First service should be health and active
-[shell orchestator]
-  !curl -X GET http://localhost:3000/v1/health?database_id=integration_test_tenant
-  ??{"status":"active"}
+# First service should be healthy and active
+[shell orchestrator]
+  [invoke wait_health "3000" "active"]
 
 
-# Initialize a shape and collect the offset
+# Initialize a shape and collect the handle/offset
+[global shape_url_port=3000]
 [shell client]
   [invoke shape_get_snapshot items]
   ?electric-handle: ([\d-]+)
-  [local handle=$1]
+  [global handle=$1]
   ?electric-offset: ([\w\d_]+)
-  [local offset=$1]
+  [global offset=$1]
 
 ## Start the second sync service.
 [invoke setup_electric_shell_with_tenant "electric_2" "3001"]
@@ -62,15 +62,28 @@
 [shell electric_2]
   -Lock acquired from postgres|Starting replication from postgres|$fail_pattern
   ??[notice] Acquiring lock from postgres with name electric_slot_integration
-  [sleep 2]
+
+# Second service should be waiting, ready to take over
+[shell orchestrator]
+  [invoke wait_health "3000" "active"]
+  [invoke wait_health "3001" "waiting"]
 
 
-# Second service should be in waiting state, ready to take over
-[shell orchestator]
-  !curl -X GET http://localhost:3000/v1/health?database_id=integration_test_tenant
-  ??{"status":"active"}
-  !curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant
-  ??{"status":"waiting"}
+## Read-only: instance 2 serves existing shape data while waiting
+[shell client_ro]
+  [invoke shape_get_on "3001" items $handle "-1"]
+  ??HTTP/1.1 200 OK
+  ??electric-handle: $handle
+  ??"#1 test val"
+  ?$PS1
+
+## Read-only: instance 2 returns 503 for non-existent table
+[shell client_ro]
+  [invoke shape_get_snapshot_on "3001" nonexistent_table]
+  ??HTTP/1.1 503
+  ??retry-after:
+  ?$PS1
+
 
 # Add more data before handover
 [shell psql]
@@ -80,21 +93,25 @@
   """
   ??INSERT 0 1
 
-# Should see handover update
+# Should see handover update on instance 1
 [shell client]
   [invoke shape_get_live items $handle $offset]
   ??HTTP/1.1 200 OK
   ?electric-offset: ([\w\d_]+)
-  [local offset=$1]
+  [global offset=$1]
   ??"val":"#handover test val"
 
+# Read-only: instance 2 sees fresh data written by instance 1 via shared storage
+# Poll since the active instance's disk flush may lag by ~1s
+[shell client_ro]
+  [loop i 1..5]
+    @handover test val
+    [invoke shape_get_on "3001" items $handle "0_inf"]
+    ?$PS1
+    [sleep 1]
+  [endloop]
+  ?$PS1
 
-# Switch request port to second electric
-[global shape_url_port=3001]
-
-# Should continue same shape in new instance
-[shell client]
-  [invoke shape_get_live items $handle $offset]
 
 # Terminate first electric
 [shell electric_1]
@@ -105,6 +122,11 @@
 [shell electric_2]
   -$fail_pattern
   ??[notice] Lock acquired from postgres with name electric_slot_integration
+  ??[notice] Refreshing shape metadata
+  ??[notice] Starting replication from postgres
+
+[shell orchestrator]
+  [invoke wait_health "3001" "active"]
 
 # Add more data after handover
 [shell psql]
@@ -114,20 +136,27 @@
   """
   ??INSERT 0 1
 
-# Second service should reach healthy and active with loaded backup
-[shell electric_2]
-  ??[notice] Found 1 existing valid shapes
-  ??[notice] Starting replication from postgres
-
-[shell orchestator]
-  # Use wait-for to poll for active status since shape initialization may still be in progress
-  [invoke wait-for "curl -X GET http://localhost:3001/v1/health?database_id=integration_test_tenant" "\{\"status\":\"active\"\}" 10 $PS1]
-
-# Should see post handover update
+# Should continue same shape in new instance and see post handover update
 [shell client]
+  [invoke shape_get_live_on "3001" items $handle $offset]
   ??HTTP/1.1 200 OK
   ??electric-handle: $handle
   ??"val":"#post-handover test val"
+
+# Completeness check: snapshot has initial data, log has all accumulated changes
+[shell client]
+  [invoke shape_get_snapshot_on "3001" items]
+  ??HTTP/1.1 200 OK
+  ??electric-handle: $handle
+  ??"#1 test val"
+  ?$PS1
+
+[shell client]
+  [invoke shape_get_on "3001" items $handle "0_inf"]
+  ??HTTP/1.1 200 OK
+  ??"#handover test val"
+  ??"#post-handover test val"
+  ?$PS1
 
 
 [cleanup]

--- a/integration-tests/tests/rolling-deploy.lux
+++ b/integration-tests/tests/rolling-deploy.lux
@@ -77,11 +77,13 @@
   ??"#1 test val"
   ?$PS1
 
-## Read-only: instance 2 returns 503 for non-existent table
+## Read-only: instance 2 returns 400 for non-existent table
+## (admin pool is available before lock acquisition, so EtsInspector
+## can query the DB and validate the table doesn't exist)
 [shell client_ro]
   [invoke shape_get_snapshot_on "3001" nonexistent_table]
-  ??HTTP/1.1 503
-  ??retry-after:
+  ??HTTP/1.1 400
+  ??does not exist
   ?$PS1
 
 

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -730,9 +730,9 @@ defmodule Electric.Connection.Manager do
     dispatch_stack_event(:connection_lock_acquired, state)
     tref = schedule_periodic_connection_status_check(:replication_configuration)
 
-    # Initialize the ShapeStatusOwner process once the lock is acquired and
-    # storage is entirely within this service's control
-    :ok = Electric.ShapeCache.ShapeStatusOwner.initialize(state.stack_id)
+    # Refresh shape metadata now that the lock is acquired and storage is
+    # entirely within this service's control
+    :ok = Electric.ShapeCache.ShapeStatusOwner.refresh(state.stack_id)
 
     state = %{
       state

--- a/packages/sync-service/lib/electric/plug/health_check_plug.ex
+++ b/packages/sync-service/lib/electric/plug/health_check_plug.ex
@@ -15,15 +15,14 @@ defmodule Electric.Plug.HealthCheckPlug do
   # of the status to ensure the API is stable
   defp check_service_status(%Conn{assigns: %{config: config}} = conn, _) do
     {status_code, status_text} =
-      case StatusMonitor.status(config[:stack_id]) do
-        %{conn: :waiting_on_lock, shape: _} -> {202, "waiting"}
-        %{conn: :starting, shape: _} -> {202, "starting"}
-        %{conn: _, shape: :starting} -> {202, "starting"}
-        %{conn: :up, shape: :up} -> {200, "active"}
+      case StatusMonitor.service_status(config[:stack_id]) do
+        :active -> {200, "active"}
+        :waiting -> {202, "waiting"}
+        :starting -> {202, "starting"}
         # when Electric is in the scaled-down mode (all database connections are closed),
         # report its status as active because for any incoming shape request it will
         # transparently restore the connection subsystem before processing the request
-        %{conn: :sleeping, shape: _} -> {200, "active"}
+        :sleeping -> {200, "active"}
       end
 
     conn |> assign(:status_text, status_text) |> assign(:status_code, status_code)

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -69,7 +69,9 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   @spec load_supported_features(opts :: term()) ::
           {:ok, Map.t()} | {:error, String.t() | :connection_not_available}
   def load_supported_features(opts) do
-    GenServer.call(opts[:server], :load_supported_features, :infinity)
+    with :not_in_cache <- fetch_supported_features_from_ets(opts) do
+      GenServer.call(opts[:server], :load_supported_features, :infinity)
+    end
   end
 
   @impl Inspector
@@ -153,6 +155,7 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
            {:ok, features} <-
              wrap_in_db_errors(fn -> DirectInspector.load_supported_features(state.pg_pool) end) do
         store_supported_features(state, features)
+        persist_data(state)
         {:ok, features}
       end
 

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -457,13 +457,11 @@ defmodule Electric.ShapeCache do
     {descendents ++ [{handle, shape, start_shape_opts} | siblings], known}
   end
 
-  @spec fetch_latest_offset(stack_id(), shape_handle()) ::
-          {:ok, LogOffset.t()} | :error
   @spec fetch_latest_offset(stack_id(), shape_handle(), keyword()) ::
           {:ok, LogOffset.t()} | :error
   defp fetch_latest_offset(stack_id, shape_handle, opts \\ []) do
-    storage = Storage.for_shape(shape_handle, Storage.for_stack(stack_id))
-    storage = if opts[:read_only], do: Storage.as_read_only(storage), else: storage
+    storage =
+      Storage.for_shape(shape_handle, Storage.for_stack(stack_id, read_only?: opts[:read_only?]))
 
     case Storage.fetch_latest_offset(storage) do
       {:ok, offset} -> {:ok, normalize_latest_offset(offset)}

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -77,8 +77,9 @@ defmodule Electric.ShapeCache do
     end
   end
 
-  @spec resolve_shape_handle(shape_handle(), shape_def(), stack_id()) :: handle_position() | nil
-  def resolve_shape_handle(shape_handle, shape, stack_id) do
+  @spec resolve_shape_handle(shape_handle(), shape_def(), stack_id(), keyword()) ::
+          handle_position() | nil
+  def resolve_shape_handle(shape_handle, shape, stack_id, opts \\ []) do
     # Ensure that the given shape handle matches the shape using a cheap shape
     # hash check.
     # If not (or the handle has gone/changed) then try a more expensive
@@ -90,7 +91,7 @@ defmodule Electric.ShapeCache do
         else: fetch_handle_by_shape(shape, stack_id)
 
     with {:ok, resolved_handle} <- result,
-         {:ok, offset} <- fetch_latest_offset(stack_id, resolved_handle) do
+         {:ok, offset} <- fetch_latest_offset(stack_id, resolved_handle, opts) do
       {resolved_handle, offset}
     else
       _ -> nil
@@ -216,8 +217,17 @@ defmodule Electric.ShapeCache do
   @spec has_shape?(shape_handle(), Access.t()) :: boolean()
   def has_shape?(shape_handle, stack_id)
       when is_shape_handle(shape_handle) and is_stack_id(stack_id) do
-    ShapeStatus.has_shape_handle?(stack_id, shape_handle) ||
-      GenServer.call(name(stack_id), {:has_shape_handle?, shape_handle}, @call_timeout)
+    if ShapeStatus.has_shape_handle?(stack_id, shape_handle) do
+      true
+    else
+      try do
+        GenServer.call(name(stack_id), {:has_shape_handle?, shape_handle}, @call_timeout)
+      catch
+        :exit, {:noproc, _} ->
+          Logger.debug("ShapeCache GenServer not running, shape #{shape_handle} not found in ETS")
+          false
+      end
+    end
   end
 
   @spec start_consumer_for_handle(shape_handle(), stack_id()) ::
@@ -447,12 +457,15 @@ defmodule Electric.ShapeCache do
     {descendents ++ [{handle, shape, start_shape_opts} | siblings], known}
   end
 
-  @spec fetch_latest_offset(stack_id(), shape_handle()) :: {:ok, LogOffset.t()} | :error
-  defp fetch_latest_offset(stack_id, shape_handle) do
-    shape_handle
-    |> Storage.for_shape(Storage.for_stack(stack_id))
-    |> Storage.fetch_latest_offset()
-    |> case do
+  @spec fetch_latest_offset(stack_id(), shape_handle()) ::
+          {:ok, LogOffset.t()} | :error
+  @spec fetch_latest_offset(stack_id(), shape_handle(), keyword()) ::
+          {:ok, LogOffset.t()} | :error
+  defp fetch_latest_offset(stack_id, shape_handle, opts \\ []) do
+    storage = Storage.for_shape(shape_handle, Storage.for_stack(stack_id))
+    storage = if opts[:read_only], do: Storage.as_read_only(storage), else: storage
+
+    case Storage.fetch_latest_offset(storage) do
       {:ok, offset} -> {:ok, normalize_latest_offset(offset)}
       {:error, _reason} -> :error
     end

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -56,7 +56,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
     :shape_handle,
     :stack_id,
     :stack_ets,
-    read_only: false,
+    read_only?: false,
     snapshot_file_timeout: :timer.seconds(5),
     version: @version
   ]
@@ -125,6 +125,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
     %__MODULE__{
       buffer_ets: buffer_ets,
       chunk_bytes_threshold: stack_opts.chunk_bytes_threshold,
+      read_only?: Map.get(stack_opts, :read_only?, false),
       shape_handle: shape_handle,
       stack_id: stack_id,
       stack_ets: :ets.whereis(stack_ets)
@@ -634,7 +635,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
     |> expand_storage_meta(keys)
   end
 
-  defp read_or_initialize_metadata(%__MODULE__{read_only: true} = opts, keys) do
+  defp read_or_initialize_metadata(%__MODULE__{read_only?: true} = opts, keys) do
     # In read-only mode, always read from disk to see the latest data
     # written by the active instance. Do not cache in ETS.
     # This trades throughput (~1-2ms per request for file reads) for freshness,

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -56,6 +56,7 @@ defmodule Electric.ShapeCache.PureFileStorage do
     :shape_handle,
     :stack_id,
     :stack_ets,
+    read_only: false,
     snapshot_file_timeout: :timer.seconds(5),
     version: @version
   ]
@@ -633,11 +634,30 @@ defmodule Electric.ShapeCache.PureFileStorage do
     |> expand_storage_meta(keys)
   end
 
+  defp read_or_initialize_metadata(%__MODULE__{read_only: true} = opts, keys) do
+    # In read-only mode, always read from disk to see the latest data
+    # written by the active instance. Do not cache in ETS.
+    # This trades throughput (~1-2ms per request for file reads) for freshness,
+    # which is acceptable since read-only mode is transient during rolling deploys.
+    read_from_disk_without_caching(opts, keys)
+  end
+
   defp read_or_initialize_metadata(%__MODULE__{shape_handle: handle} = opts, keys) do
     case :ets.lookup(opts.stack_ets, handle) do
       [] -> populate_read_through_cache!(opts, keys)
       [storage_meta() = meta] -> meta
     end
+  end
+
+  defp read_from_disk_without_caching(%__MODULE__{shape_handle: handle} = opts, extra_keys) do
+    read_keys = Enum.into(extra_keys, MapSet.new(@read_path_keys))
+
+    keys =
+      for key <- read_keys do
+        {key, read_metadata!(opts, key)}
+      end
+
+    create_storage_meta([{:shape_handle, handle} | keys])
   end
 
   defp populate_read_through_cache!(%__MODULE__{} = opts, extra_keys) do

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -114,6 +114,9 @@ defmodule Electric.ShapeCache.ShapeStatus do
       with {:ok, shape_hash} <- ShapeDb.add_shape(stack_id, shape, shape_handle) do
         if :ets.insert_new(
              shape_meta_table(stack_id),
+             # Generation 0 is safe here: add_shape only runs in active mode,
+             # and refresh/1 (which sweeps by generation) only runs before active.
+             # They are sequentially ordered by the Connection.Manager state machine.
              {shape_handle, shape_hash, false, nil, 0}
            ) do
           {:ok, shape_handle}

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -46,7 +46,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
   """
   @spec initialize(stack_id()) :: :ok | {:error, term()}
   def initialize(stack_id) when is_stack_id(stack_id) do
-    create_or_clear_shape_meta_table(stack_id)
+    create_shape_meta_table(stack_id)
 
     {:ok, invalid_handles, valid_shape_count} = ShapeDb.validate_existing_shapes(stack_id)
 
@@ -67,7 +67,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
                stack_id,
                invalid_handles
              ) do
-        populate_shape_meta_table(stack_id)
+        populate_shape_meta_table(stack_id, 0)
       end
     end
   end
@@ -366,28 +366,17 @@ defmodule Electric.ShapeCache.ShapeStatus do
   defp shape_meta_table(stack_id),
     do: :"shape_meta_table:#{stack_id}"
 
-  defp create_or_clear_shape_meta_table(stack_id) do
-    table = shape_meta_table(stack_id)
-
-    case :ets.whereis(table) do
-      :undefined ->
-        :ets.new(table, [
-          :named_table,
-          :public,
-          :set,
-          read_concurrency: true,
-          write_concurrency: :auto
-        ])
-
-      _ref ->
-        :ets.delete_all_objects(table)
-        table
-    end
-
-    table
+  defp create_shape_meta_table(stack_id) do
+    :ets.new(shape_meta_table(stack_id), [
+      :named_table,
+      :public,
+      :set,
+      read_concurrency: true,
+      write_concurrency: :auto
+    ])
   end
 
-  defp populate_shape_meta_table(stack_id, generation \\ 0) do
+  defp populate_shape_meta_table(stack_id, generation) do
     start_time = System.monotonic_time()
 
     ShapeDb.reduce_shape_meta(

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -29,8 +29,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
   # MUST be updated when Shape.comparable/1 changes.
   @version 8
 
-  # Position of last_read_time in the shape_meta_table tuple:
-  # {handle, hash, snapshot_started, last_read_time}
+  # Tuple format: {handle, hash, snapshot_started, last_read_time, generation}
   @shape_last_used_time_pos 4
 
   @spec version() :: pos_integer()
@@ -47,7 +46,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
   """
   @spec initialize(stack_id()) :: :ok | {:error, term()}
   def initialize(stack_id) when is_stack_id(stack_id) do
-    create_shape_meta_table(stack_id)
+    create_or_clear_shape_meta_table(stack_id)
 
     {:ok, invalid_handles, valid_shape_count} = ShapeDb.validate_existing_shapes(stack_id)
 
@@ -73,6 +72,39 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end
   end
 
+  @doc """
+  Refresh the shape meta table from SQLite without recreating it.
+
+  Used on lock acquisition to pick up any shapes that were created/deleted
+  by a previous instance while we were in read-only mode.
+  """
+  @spec refresh(stack_id()) :: :ok | {:error, term()}
+  def refresh(stack_id) when is_stack_id(stack_id) do
+    {:ok, invalid_handles, valid_shape_count} = ShapeDb.validate_existing_shapes(stack_id)
+
+    Logger.notice(
+      "Refreshing shape metadata: #{valid_shape_count} valid shapes, #{length(invalid_handles)} invalid"
+    )
+
+    with :ok <-
+           Electric.ShapeCache.ShapeCleaner.remove_shape_storage_async(
+             stack_id,
+             invalid_handles
+           ) do
+      # Use a generation counter to avoid clearing the table (which would race
+      # with concurrent readers). Upsert all current shapes with a new generation,
+      # then delete any entries still on the old generation.
+      generation = System.unique_integer([:positive, :monotonic])
+      populate_shape_meta_table(stack_id, generation)
+
+      :ets.select_delete(shape_meta_table(stack_id), [
+        {{:_, :_, :_, :_, :"$1"}, [{:"/=", :"$1", generation}], [true]}
+      ])
+
+      :ok
+    end
+  end
+
   @spec add_shape(stack_id(), Shape.t()) :: {:ok, shape_handle()} | {:error, term()}
   def add_shape(stack_id, shape) when is_stack_id(stack_id) do
     OpenTelemetry.with_child_span("shape_status.add_shape", [], stack_id, fn ->
@@ -80,10 +112,9 @@ defmodule Electric.ShapeCache.ShapeStatus do
 
       # Add the lookup last as it is the one that enables clients to find the shape
       with {:ok, shape_hash} <- ShapeDb.add_shape(stack_id, shape, shape_handle) do
-        # Cache shape metadata: {handle, hash, snapshot_started, last_read_time}
         if :ets.insert_new(
              shape_meta_table(stack_id),
-             {shape_handle, shape_hash, false, nil}
+             {shape_handle, shape_hash, false, nil, 0}
            ) do
           {:ok, shape_handle}
         else
@@ -219,7 +250,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
   def validate_shape_handle(stack_id, shape_handle, %Shape{} = shape)
       when is_stack_id(stack_id) do
     case :ets.lookup(shape_meta_table(stack_id), shape_handle) do
-      [{^shape_handle, hash, _snapshot_started, _last_read}] ->
+      [{^shape_handle, hash, _snapshot_started, _last_read, _gen}] ->
         if Shape.hash(shape) == hash, do: :ok, else: :error
 
       [] ->
@@ -238,7 +269,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
 
   def snapshot_started?(stack_id, shape_handle) do
     case :ets.lookup(shape_meta_table(stack_id), shape_handle) do
-      [{^shape_handle, _hash, snapshot_started, _last_read}] -> snapshot_started
+      [{^shape_handle, _hash, snapshot_started, _last_read, _gen}] -> snapshot_started
       [] -> false
     end
   end
@@ -285,10 +316,10 @@ defmodule Electric.ShapeCache.ShapeStatus do
         fn
           # This shape has only just been created, so it's too young to be considered for
           # expiration.
-          {_handle, _hash, _snapshot_started, nil}, tree ->
+          {_handle, _hash, _snapshot_started, nil, _gen}, tree ->
             tree
 
-          {handle, _hash, _snapshot_started, last_read}, tree ->
+          {handle, _hash, _snapshot_started, last_read, _gen}, tree ->
             last_read_tuple = {last_read, handle}
 
             if :gb_trees.size(tree) < shape_count do
@@ -332,21 +363,28 @@ defmodule Electric.ShapeCache.ShapeStatus do
   defp shape_meta_table(stack_id),
     do: :"shape_meta_table:#{stack_id}"
 
-  defp create_shape_meta_table(stack_id) do
+  defp create_or_clear_shape_meta_table(stack_id) do
     table = shape_meta_table(stack_id)
 
-    :ets.new(table, [
-      :named_table,
-      :public,
-      :set,
-      read_concurrency: true,
-      write_concurrency: :auto
-    ])
+    case :ets.whereis(table) do
+      :undefined ->
+        :ets.new(table, [
+          :named_table,
+          :public,
+          :set,
+          read_concurrency: true,
+          write_concurrency: :auto
+        ])
+
+      _ref ->
+        :ets.delete_all_objects(table)
+        table
+    end
 
     table
   end
 
-  defp populate_shape_meta_table(stack_id) do
+  defp populate_shape_meta_table(stack_id, generation \\ 0) do
     start_time = System.monotonic_time()
 
     ShapeDb.reduce_shape_meta(
@@ -356,7 +394,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
         # any shapes where the snapshot didn't complete have been deleted
         # so there is no intermediate started-but-not-complete state
         # and completed implies started
-        true = :ets.insert(table, {handle, hash, snapshot_complete?, start_time})
+        true = :ets.insert(table, {handle, hash, snapshot_complete?, start_time, generation})
         table
       end
     )

--- a/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status_owner.ex
@@ -6,6 +6,9 @@ defmodule Electric.ShapeCache.ShapeStatusOwner do
   `Electric.ShapeCache.ShapeStatus` early in the supervision tree so that
   dependent processes (e.g., shape consumers) can use a single, shared
   ShapeStatus instance regardless of their own supervisor start order.
+
+  Initialization is done asynchronously via `handle_continue` to avoid
+  blocking the supervision tree startup on potentially slow SQLite reads.
   """
 
   use GenServer
@@ -20,13 +23,14 @@ defmodule Electric.ShapeCache.ShapeStatusOwner do
     Electric.ProcessRegistry.name(stack_id, __MODULE__)
   end
 
-  def initialize(stack_id) do
-    # Use an infinite timeout because on laggy storage with an incorrectly
-    # shut-down database this call can take  a long time, none of which is
-    # really within our control. So rather than be sensitive to this timing at
-    # a critical point, just let SQLite do its thing, which normally is quite
-    # quick.
-    GenServer.call(name(stack_id), :initialize, :infinity)
+  @doc """
+  Refresh shape metadata from SQLite after lock acquisition.
+
+  Uses an infinite timeout because on laggy storage with an incorrectly
+  shut-down database this can take a long time.
+  """
+  def refresh(stack_id) do
+    GenServer.call(name(stack_id), :refresh, :infinity)
   end
 
   def start_link(opts) do
@@ -46,16 +50,26 @@ defmodule Electric.ShapeCache.ShapeStatusOwner do
 
     :ok = Electric.LsnTracker.initialize(stack_id)
 
-    {:ok, %{stack_id: stack_id, initialized: false}, :hibernate}
+    {:ok, %{stack_id: stack_id}, {:continue, :initialize}}
   end
 
   @impl true
-  def handle_call(:initialize, _from, %{initialized: false} = state) do
+  def handle_continue(:initialize, state) do
+    # Initialize shape metadata from SQLite so we can serve shapes in
+    # read-only mode before the advisory lock is acquired
     :ok = ShapeStatus.initialize(state.stack_id)
-    {:reply, :ok, %{state | initialized: true}, :hibernate}
+
+    # Signal that shape metadata is loaded and shapes can be served read-only
+    Electric.StatusMonitor.mark_shape_metadata_ready(state.stack_id, self())
+
+    Logger.notice("Shape metadata initialized, entering read-only mode")
+
+    {:noreply, state, :hibernate}
   end
 
-  def handle_call(:initialize, _from, %{initialized: true} = state) do
+  @impl true
+  def handle_call(:refresh, _from, state) do
+    :ok = ShapeStatus.refresh(state.stack_id)
     {:reply, :ok, state, :hibernate}
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -222,8 +222,12 @@ defmodule Electric.ShapeCache.Storage do
     {mod, apply(m, f, [writer_state | a])}
   end
 
-  def for_stack(stack_id) do
-    Electric.StackConfig.lookup!(stack_id, Electric.ShapeCache.Storage)
+  def for_stack(stack_id, opts \\ []) do
+    {mod, storage_opts} = Electric.StackConfig.lookup!(stack_id, Electric.ShapeCache.Storage)
+
+    if opts[:read_only?] && is_map(storage_opts),
+      do: {mod, Map.put(storage_opts, :read_only?, true)},
+      else: {mod, storage_opts}
   end
 
   def opts_for_stack(stack_id) do
@@ -263,10 +267,6 @@ defmodule Electric.ShapeCache.Storage do
   def for_shape(shape_handle, {mod, opts}) do
     {mod, mod.for_shape(shape_handle, opts)}
   end
-
-  @doc "Mark a storage reference for read-only disk access (no ETS caching)"
-  def as_read_only({mod, storage_opts}), do: {mod, Map.put(storage_opts, :read_only, true)}
-  def as_read_only(storage), do: storage
 
   @impl __MODULE__
   def stack_start_link({mod, opts} = storage) do

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -264,6 +264,10 @@ defmodule Electric.ShapeCache.Storage do
     {mod, mod.for_shape(shape_handle, opts)}
   end
 
+  @doc "Mark a storage reference for read-only disk access (no ETS caching)"
+  def as_read_only({mod, storage_opts}), do: {mod, Map.put(storage_opts, :read_only, true)}
+  def as_read_only(storage), do: storage
+
   @impl __MODULE__
   def stack_start_link({mod, opts} = storage) do
     Electric.StackConfig.put(opts.stack_id, __MODULE__, storage)

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -225,7 +225,8 @@ defmodule Electric.ShapeCache.Storage do
   def for_stack(stack_id, opts \\ []) do
     {mod, storage_opts} = Electric.StackConfig.lookup!(stack_id, Electric.ShapeCache.Storage)
 
-    if opts[:read_only?] && is_map(storage_opts),
+    # is_map guard: TestStorage uses tuples for opts where read_only? is a no-op
+    if opts[:read_only?] == true and is_map(storage_opts),
       do: {mod, Map.put(storage_opts, :read_only?, true)},
       else: {mod, storage_opts}
   end

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -20,7 +20,12 @@ defmodule Electric.Shapes do
 
     if ShapeCache.has_shape?(shape_handle, stack_id) do
       with :started <- ShapeCache.await_snapshot_start(shape_handle, stack_id) do
-        storage = shape_storage(stack_id, shape_handle, read_only: opts[:read_only])
+        storage =
+          Storage.for_shape(
+            shape_handle,
+            Storage.for_stack(stack_id, read_only?: opts[:read_only?])
+          )
+
         {:ok, Storage.get_log_stream(offset, max_offset, storage)}
       end
     else
@@ -71,7 +76,12 @@ defmodule Electric.Shapes do
   @spec get_chunk_end_log_offset(stack_id(), shape_handle(), LogOffset.t(), keyword()) ::
           LogOffset.t() | nil
   def get_chunk_end_log_offset(stack_id, shape_handle, offset, opts \\ []) do
-    storage = shape_storage(stack_id, shape_handle, opts)
+    storage =
+      Storage.for_shape(
+        shape_handle,
+        Storage.for_stack(stack_id, read_only?: opts[:read_only?])
+      )
+
     Storage.get_chunk_end_log_offset(offset, storage)
   end
 
@@ -125,11 +135,6 @@ defmodule Electric.Shapes do
     with :ok <- Storage.mark_snapshot_as_started(storage) do
       ShapeStatus.mark_snapshot_started(stack_id, shape_handle)
     end
-  end
-
-  defp shape_storage(stack_id, shape_handle, opts) do
-    storage = Storage.for_shape(shape_handle, Storage.for_stack(stack_id))
-    if opts[:read_only], do: Storage.as_read_only(storage), else: storage
   end
 
   def query_subset(handle, shape, subset, opts) do

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -20,7 +20,7 @@ defmodule Electric.Shapes do
 
     if ShapeCache.has_shape?(shape_handle, stack_id) do
       with :started <- ShapeCache.await_snapshot_start(shape_handle, stack_id) do
-        storage = shape_storage(stack_id, shape_handle)
+        storage = shape_storage(stack_id, shape_handle, read_only: opts[:read_only])
         {:ok, Storage.get_log_stream(offset, max_offset, storage)}
       end
     else
@@ -47,8 +47,8 @@ defmodule Electric.Shapes do
   @doc """
   Cheaply validate that a shape handle matches the shape definition.
   """
-  def resolve_shape_handle(stack_id, shape_handle, %Shape{} = shape) do
-    ShapeCache.resolve_shape_handle(shape_handle, shape, stack_id)
+  def resolve_shape_handle(stack_id, shape_handle, %Shape{} = shape, opts \\ []) do
+    ShapeCache.resolve_shape_handle(shape_handle, shape, stack_id, opts)
   end
 
   @doc """
@@ -68,9 +68,10 @@ defmodule Electric.Shapes do
 
   If `nil` is returned, chunk is not complete and the shape's latest offset should be used
   """
-  @spec get_chunk_end_log_offset(stack_id(), shape_handle(), LogOffset.t()) :: LogOffset.t() | nil
-  def get_chunk_end_log_offset(stack_id, shape_handle, offset) do
-    storage = shape_storage(stack_id, shape_handle)
+  @spec get_chunk_end_log_offset(stack_id(), shape_handle(), LogOffset.t(), keyword()) ::
+          LogOffset.t() | nil
+  def get_chunk_end_log_offset(stack_id, shape_handle, offset, opts \\ []) do
+    storage = shape_storage(stack_id, shape_handle, opts)
     Storage.get_chunk_end_log_offset(offset, storage)
   end
 
@@ -126,8 +127,9 @@ defmodule Electric.Shapes do
     end
   end
 
-  defp shape_storage(stack_id, shape_handle) do
-    Storage.for_shape(shape_handle, Storage.for_stack(stack_id))
+  defp shape_storage(stack_id, shape_handle, opts) do
+    storage = Storage.for_shape(shape_handle, Storage.for_stack(stack_id))
+    if opts[:read_only], do: Storage.as_read_only(storage), else: storage
   end
 
   def query_subset(handle, shape, subset, opts) do

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -140,7 +140,9 @@ defmodule Electric.Shapes.Api do
   """
   @spec predefined_shape(t(), shape_opts()) :: {:ok, t()} | {:error, term()}
   def predefined_shape(%Api{} = api, shape_params) do
-    with :ok <- hold_until_stack_ready(api),
+    # In read-only mode, Shape.new relies on the EtsInspector cache being warm
+    # from PersistentKV. If not available, this will return an error.
+    with {:ok, _mode} <- hold_until_stack_ready(api),
          {:ok, params} <- normalise_shape_params(shape_params),
          opts = Keyword.merge(params, inspector: api.inspector, feature_flags: api.feature_flags),
          {:ok, shape} <- Shapes.Shape.new(opts) do
@@ -175,8 +177,9 @@ defmodule Electric.Shapes.Api do
   @spec validate(t(), %{(atom() | binary()) => term()}) ::
           {:ok, Request.t()} | {:error, Response.t()}
   def validate(%Api{} = api, params) when is_configured(api) do
-    with :ok <- hold_until_stack_ready(api),
+    with {:ok, mode} <- hold_until_stack_ready(api),
          {:ok, request} <- validate_params(api, params),
+         request = %{request | read_only: mode == :read_only},
          {:ok, request} <- load_shape_info(request) do
       {:ok, seek(request)}
     end
@@ -185,7 +188,7 @@ defmodule Electric.Shapes.Api do
   @spec validate_for_delete(t(), %{(atom() | binary()) => term()}) ::
           {:ok, Request.t()} | {:error, Response.t()}
   def validate_for_delete(%Api{} = api, params) do
-    with :ok <- hold_until_stack_ready(api) do
+    with {:ok, _mode} <- hold_until_stack_ready(api, require: :active) do
       Api.Delete.validate_for_delete(api, params)
     end
   end
@@ -270,6 +273,15 @@ defmodule Electric.Shapes.Api do
     end)
   end
 
+  # In read-only mode, resolve existing shapes only — no creation.
+  # When handle is nil (new client), resolve_shape_handle falls through to
+  # fetch_handle_by_shape via the validate_shape_handle(nil) -> :error path.
+  # Pass read_only to get fresh offsets from disk rather than stale ETS cache.
+  defp get_or_create_shape_handle(%Request{read_only: true} = request) do
+    %{params: %{handle: handle, shape_definition: shape}, api: %{stack_id: stack_id}} = request
+    Shapes.resolve_shape_handle(stack_id, handle, shape, read_only: true)
+  end
+
   # No handle is provided so we can get the existing one for this shape
   # or create a new shape if it does not yet exist
   defp get_or_create_shape_handle(%Request{params: %{handle: nil}} = request) do
@@ -283,6 +295,14 @@ defmodule Electric.Shapes.Api do
     %{params: %{handle: handle, shape_definition: shape}, api: %{stack_id: stack_id}} = request
 
     Shapes.resolve_shape_handle(stack_id, handle, shape)
+  end
+
+  defp handle_shape_info(nil, %Request{read_only: true, api: api} = request) do
+    # Shape doesn't exist — creation requires active mode.
+    # Wait for active; resolves quickly during startup, times out during rolling deploy.
+    with {:ok, _} <- hold_until_stack_ready(api, require: :active) do
+      handle_shape_info(nil, %{request | read_only: false})
+    end
   end
 
   defp handle_shape_info(nil, %Request{} = request) do
@@ -351,25 +371,19 @@ defmodule Electric.Shapes.Api do
 
   defp hold_until_stack_ready(%Api{} = api, opts \\ []) do
     stack_id = stack_id(api)
-    opts = Keyword.put_new(opts, :timeout, api.stack_ready_timeout)
+    level = Keyword.get(opts, :require, :read_only)
+    wait_opts = Keyword.put_new(opts, :timeout, api.stack_ready_timeout)
 
-    case Electric.StatusMonitor.wait_until_active(stack_id, opts) do
-      :ok ->
-        :ok
+    case Electric.StatusMonitor.wait_until(stack_id, level, wait_opts) do
+      {:ok, _mode} = ok ->
+        ok
 
       :conn_sleeping ->
-        # If the database connections are sleeping, initiate the scaleup process immediately
-        # and hold the request until the stack becomes active again.
-        #
-        # Because the state change happens asynchronoously, we pass the
-        # `block_on_conn_sleeping` flag to the next call of
-        # `Electric.StatusMonitor.wait_until_active()` to prevent this request from getting
-        # into a recursive spin loop until the status value changes in StatusMonitor's ETS table.
         Electric.Connection.Restarter.restore_connection_subsystem(stack_id)
-        hold_until_stack_ready(api, block_on_conn_sleeping: true)
+        hold_until_stack_ready(api, Keyword.put(opts, :block_on_conn_sleeping, true))
 
       {:error, message} ->
-        Logger.warning("Stack not ready after #{opts[:timeout]}ms. Reason: #{message}")
+        Logger.warning("Stack not ready after #{wait_opts[:timeout]}ms. Reason: #{message}")
         {:error, Response.error(api, message, status: 503, retry_after: 5)}
     end
   end
@@ -415,6 +429,16 @@ defmodule Electric.Shapes.Api do
     %{request | new_changes_pid: self(), new_changes_ref: ref}
   end
 
+  # In read-only mode, LsnTracker isn't populated (no replication connection).
+  # Use the shape's own latest offset as the LSN — it's the Postgres LSN of
+  # the last transaction persisted for this shape, which is the best available
+  # value without the replication stream or persisting the LsnTracker or loading
+  # all shapes' latest offsets up front. If we need stronger guarantees on this
+  # we should be persisting the LsnTracker updates to a file.
+  defp determine_global_last_seen_lsn(%Request{read_only: true} = request) do
+    %{request | global_last_seen_lsn: request.last_offset.tx_offset}
+  end
+
   defp determine_global_last_seen_lsn(%Request{} = request) do
     offset =
       request.api.stack_id
@@ -439,7 +463,8 @@ defmodule Electric.Shapes.Api do
       request
 
     chunk_end_offset =
-      Shapes.get_chunk_end_log_offset(api.stack_id, handle, offset) || last_offset
+      Shapes.get_chunk_end_log_offset(api.stack_id, handle, offset, read_only: request.read_only) ||
+        last_offset
 
     Request.update_response(
       %{request | chunk_end_offset: chunk_end_offset},
@@ -645,7 +670,8 @@ defmodule Electric.Shapes.Api do
     case Shapes.get_merged_log_stream(stack_id, shape_handle,
            since: offset,
            up_to: chunk_end_offset,
-           live_sse: in_sse?
+           live_sse: in_sse?,
+           read_only: request.read_only
          ) do
       {:ok, log} ->
         if live? && Enum.take(log, 1) == [] do

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -773,7 +773,9 @@ defmodule Electric.Shapes.Api do
       "Client #{inspect(self())} is checking for any changes to #{shape_handle} since start of request"
     )
 
-    case Shapes.resolve_shape_handle(stack_id, shape_handle, shape_def) do
+    case Shapes.resolve_shape_handle(stack_id, shape_handle, shape_def,
+           read_only?: request.read_only?
+         ) do
       {^shape_handle, ^last_offset} ->
         # no-op, shape is still present and unchanged
         nil
@@ -850,23 +852,72 @@ defmodule Electric.Shapes.Api do
             "changes to #{shape_handle} (out-of-bounds check)"
         end)
 
-        Response.invalid_request(api, errors: @offset_out_of_bounds)
+        case check_for_disk_updates(request) do
+          {:updated, new_offset} ->
+            %{request | last_offset: new_offset}
+            |> determine_global_last_seen_lsn()
+            |> determine_log_chunk_offset()
+            |> determine_up_to_date()
+            |> do_serve_shape_log()
+
+          _ ->
+            Response.invalid_request(api, errors: @offset_out_of_bounds)
+        end
     after
-      # If we timeout, check that the stack is still up and
-      # return an up-to-date message
       long_poll_timeout ->
         request = update_attrs(request, %{ot_is_long_poll_timeout: true})
+        status = Electric.StatusMonitor.status(api.stack_id)
 
-        case Electric.StatusMonitor.status(api.stack_id) do
-          %{shape: :up} ->
+        cond do
+          request.read_only? or status.shape == :read_only ->
+            # No consumer is running (or it stopped), so check if the
+            # active instance has flushed new data to disk.
+            case check_for_disk_updates(request) do
+              {:updated, new_offset} ->
+                %{request | last_offset: new_offset}
+                |> determine_global_last_seen_lsn()
+                |> determine_log_chunk_offset()
+                |> determine_up_to_date()
+                |> do_serve_shape_log()
+
+              _ ->
+                request
+                |> determine_global_last_seen_lsn()
+                |> no_change_response()
+            end
+
+          status.shape == :up ->
             request
             |> determine_global_last_seen_lsn()
             |> no_change_response()
 
-          _ ->
+          true ->
             message = Electric.StatusMonitor.timeout_message(api.stack_id)
             Response.error(request, message, status: 503, retry_after: 10)
         end
+    end
+  end
+
+  # Check if the latest offset on disk has advanced beyond what the request
+  # last saw. This is useful in read-only mode where no consumer process is
+  # running to send :new_changes messages — the active instance may have
+  # flushed new data to the shared filesystem.
+  defp check_for_disk_updates(%Request{} = request) do
+    %{
+      handle: shape_handle,
+      last_offset: last_offset,
+      params: %{shape_definition: shape_def, offset: requested_offset},
+      api: %{stack_id: stack_id}
+    } = request
+
+    case Shapes.resolve_shape_handle(stack_id, shape_handle, shape_def, read_only?: true) do
+      {^shape_handle, latest_offset}
+      when is_log_offset_lt(last_offset, latest_offset) and
+             not is_log_offset_lt(latest_offset, requested_offset) ->
+        {:updated, latest_offset}
+
+      _ ->
+        :no_change
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -179,7 +179,7 @@ defmodule Electric.Shapes.Api do
   def validate(%Api{} = api, params) when is_configured(api) do
     with {:ok, mode} <- hold_until_stack_ready(api),
          {:ok, request} <- validate_params(api, params),
-         request = %{request | read_only: mode == :read_only},
+         request = %{request | read_only?: mode == :read_only},
          {:ok, request} <- load_shape_info(request) do
       {:ok, seek(request)}
     end
@@ -277,9 +277,9 @@ defmodule Electric.Shapes.Api do
   # When handle is nil (new client), resolve_shape_handle falls through to
   # fetch_handle_by_shape via the validate_shape_handle(nil) -> :error path.
   # Pass read_only to get fresh offsets from disk rather than stale ETS cache.
-  defp get_or_create_shape_handle(%Request{read_only: true} = request) do
+  defp get_or_create_shape_handle(%Request{read_only?: true} = request) do
     %{params: %{handle: handle, shape_definition: shape}, api: %{stack_id: stack_id}} = request
-    Shapes.resolve_shape_handle(stack_id, handle, shape, read_only: true)
+    Shapes.resolve_shape_handle(stack_id, handle, shape, read_only?: true)
   end
 
   # No handle is provided so we can get the existing one for this shape
@@ -297,11 +297,11 @@ defmodule Electric.Shapes.Api do
     Shapes.resolve_shape_handle(stack_id, handle, shape)
   end
 
-  defp handle_shape_info(nil, %Request{read_only: true, api: api} = request) do
+  defp handle_shape_info(nil, %Request{read_only?: true, api: api} = request) do
     # Shape doesn't exist — creation requires active mode.
     # Wait for active; resolves quickly during startup, times out during rolling deploy.
     with {:ok, _} <- hold_until_stack_ready(api, require: :active) do
-      handle_shape_info(nil, %{request | read_only: false})
+      handle_shape_info(nil, %{request | read_only?: false})
     end
   end
 
@@ -435,7 +435,7 @@ defmodule Electric.Shapes.Api do
   # value without the replication stream or persisting the LsnTracker or loading
   # all shapes' latest offsets up front. If we need stronger guarantees on this
   # we should be persisting the LsnTracker updates to a file.
-  defp determine_global_last_seen_lsn(%Request{read_only: true} = request) do
+  defp determine_global_last_seen_lsn(%Request{read_only?: true} = request) do
     %{request | global_last_seen_lsn: request.last_offset.tx_offset}
   end
 
@@ -463,7 +463,9 @@ defmodule Electric.Shapes.Api do
       request
 
     chunk_end_offset =
-      Shapes.get_chunk_end_log_offset(api.stack_id, handle, offset, read_only: request.read_only) ||
+      Shapes.get_chunk_end_log_offset(api.stack_id, handle, offset,
+        read_only?: request.read_only?
+      ) ||
         last_offset
 
     Request.update_response(
@@ -671,7 +673,7 @@ defmodule Electric.Shapes.Api do
            since: offset,
            up_to: chunk_end_offset,
            live_sse: in_sse?,
-           read_only: request.read_only
+           read_only?: request.read_only?
          ) do
       {:ok, log} ->
         if live? && Enum.take(log, 1) == [] do

--- a/packages/sync-service/lib/electric/shapes/api/params.ex
+++ b/packages/sync-service/lib/electric/shapes/api/params.ex
@@ -222,8 +222,11 @@ defmodule Electric.Shapes.Api.Params do
 
     response =
       case reason do
-        %{connection_not_available: [msg]} -> Api.Response.error(api, msg, status: 503)
-        _ -> Api.Response.invalid_request(api, errors: reason)
+        %{connection_not_available: [msg]} ->
+          Api.Response.error(api, msg, status: 503, retry_after: 1)
+
+        _ ->
+          Api.Response.invalid_request(api, errors: reason)
       end
 
     {:error, response}

--- a/packages/sync-service/lib/electric/shapes/api/request.ex
+++ b/packages/sync-service/lib/electric/shapes/api/request.ex
@@ -9,7 +9,7 @@ defmodule Electric.Shapes.Api.Request do
     :global_last_seen_lsn,
     :new_changes_ref,
     :new_changes_pid,
-    read_only: false,
+    read_only?: false,
     api: %Api{},
     params: %Api.Params{},
     response: %Api.Response{}

--- a/packages/sync-service/lib/electric/shapes/api/request.ex
+++ b/packages/sync-service/lib/electric/shapes/api/request.ex
@@ -9,6 +9,7 @@ defmodule Electric.Shapes.Api.Request do
     :global_last_seen_lsn,
     :new_changes_ref,
     :new_changes_pid,
+    read_only: false,
     api: %Api{},
     params: %Api.Params{},
     response: %Api.Response{}

--- a/packages/sync-service/lib/electric/status_monitor.ex
+++ b/packages/sync-service/lib/electric/status_monitor.ex
@@ -258,11 +258,6 @@ defmodule Electric.StatusMonitor do
     end
   end
 
-  @doc "Convenience wrapper: wait until shapes are servable."
-  def wait_until_shape_servable(stack_id, opts \\ []) do
-    wait_until(stack_id, :read_only, opts)
-  end
-
   @doc """
   Just like `wait_until_active/2` but non-blocking.
 
@@ -439,6 +434,9 @@ defmodule Electric.StatusMonitor do
       %{snapshot_connection_pool_ready: {false, details}} ->
         "Timeout waiting for database connection pool (snapshot) to be ready" <>
           format_details(details)
+
+      %{shape_metadata_ready: {false, details}} ->
+        "Timeout waiting for shape metadata to be loaded" <> format_details(details)
 
       %{shape_log_collector_ready: {false, details}} ->
         "Timeout waiting for shape data to be loaded" <> format_details(details)

--- a/packages/sync-service/lib/electric/status_monitor.ex
+++ b/packages/sync-service/lib/electric/status_monitor.ex
@@ -6,7 +6,7 @@ defmodule Electric.StatusMonitor do
 
   @type status() :: %{
           conn: :waiting_on_lock | :starting | :up | :sleeping,
-          shape: :starting | :up
+          shape: :starting | :read_only | :up
         }
 
   @conditions [
@@ -16,12 +16,14 @@ defmodule Electric.StatusMonitor do
     :snapshot_connection_pool_ready,
     :shape_log_collector_ready,
     :supervisor_processes_ready,
-    :integrety_checks_passed
+    :integrety_checks_passed,
+    :shape_metadata_ready
   ]
 
   @default_results for condition <- @conditions, into: %{}, do: {condition, {false, %{}}}
 
   @db_state_key :db_state
+  @spin_prevention_delay 10
 
   def start_link(opts) do
     stack_id = Keyword.fetch!(opts, :stack_id)
@@ -35,6 +37,24 @@ defmodule Electric.StatusMonitor do
     :ets.new(ets_table(stack_id), [:named_table, :protected])
 
     {:ok, %{stack_id: stack_id, waiters: MapSet.new(), conn_waiters: []}}
+  end
+
+  @doc """
+  Returns the high-level service status as a single atom.
+
+  - `:active` — fully operational
+  - `:waiting` — waiting on advisory lock, shape metadata loaded (can serve existing shapes read-only)
+  - `:starting` — system is initializing (metadata not yet loaded or connection progressing)
+  - `:sleeping` — connections scaled down
+  """
+  @spec service_status(String.t()) :: :active | :waiting | :starting | :sleeping
+  def service_status(stack_id) do
+    case status(stack_id) do
+      %{conn: :up, shape: :up} -> :active
+      %{conn: :waiting_on_lock, shape: :read_only} -> :waiting
+      %{conn: :sleeping} -> :sleeping
+      _ -> :starting
+    end
   end
 
   @spec status(String.t()) :: status()
@@ -67,10 +87,13 @@ defmodule Electric.StatusMonitor do
   defp conn_status_from_results(_), do: :starting
 
   defp shape_status_from_results(%{
+         shape_metadata_ready: {true, _},
          shape_log_collector_ready: {true, _},
          supervisor_processes_ready: {true, _}
        }),
        do: :up
+
+  defp shape_status_from_results(%{shape_metadata_ready: {true, _}}), do: :read_only
 
   defp shape_status_from_results(_), do: :starting
 
@@ -80,6 +103,10 @@ defmodule Electric.StatusMonitor do
 
   def database_connections_waking_up(stack_id) do
     GenServer.cast(name(stack_id), :database_connections_waking_up)
+  end
+
+  def mark_shape_metadata_ready(stack_id, pid) do
+    mark_condition_met(stack_id, :shape_metadata_ready, pid)
   end
 
   def mark_pg_lock_acquired(stack_id, lock_pid) do
@@ -134,56 +161,71 @@ defmodule Electric.StatusMonitor do
     GenServer.cast(name(stack_id), {:condition_met, condition, process})
   end
 
-  def wait_until_active(stack_id, opts \\ []) do
-    case status(stack_id) do
-      %{conn: :up, shape: :up} ->
-        :ok
+  @doc """
+  Wait until the system reaches at least the required level.
 
-      %{conn: :sleeping} ->
+  Levels (ordered):
+  - `:read_only` — can serve existing shapes (waiting on lock, metadata loaded)
+  - `:active` — fully operational, can create shapes and stream changes
+
+  Returns:
+  - `{:ok, :active}` when fully operational
+  - `{:ok, :read_only}` when existing shapes can be served (only for `:read_only` level)
+  - `:conn_sleeping` when connections are sleeping
+  - `{:error, message}` on timeout
+  """
+  def wait_until(stack_id, level, opts \\ [])
+      when level in [:read_only, :active] do
+    case service_status(stack_id) do
+      :active ->
+        {:ok, :active}
+
+      :waiting when level == :read_only ->
+        {:ok, :read_only}
+
+      :sleeping ->
         if Keyword.get(opts, :block_on_conn_sleeping, false) do
-          do_wait_until_active(stack_id, opts)
+          do_wait_until(stack_id, level, opts)
         else
           :conn_sleeping
         end
 
       _ ->
-        do_wait_until_active(stack_id, opts)
+        do_wait_until(stack_id, level, opts)
     end
   end
 
-  defp do_wait_until_active(stack_id, opts) do
+  defp do_wait_until(stack_id, level, opts) do
     timeout = Keyword.fetch!(opts, :timeout)
 
     try do
-      status_monitor_pid = stack_id |> name() |> GenServer.whereis()
-
-      case status_monitor_pid do
+      case stack_id |> name() |> GenServer.whereis() do
         nil ->
-          # Either the status monitor has not started yet, or the stack has
-          # been terminated in some permanent way
-          maybe_retry_wait_until_active(
+          maybe_retry_wait_until(
             stack_id,
+            level,
             opts,
             timeout,
             "Status monitor not found for stack ID: #{stack_id}"
           )
 
         pid when is_pid(pid) ->
-          GenServer.call(pid, {:wait_until_active, timeout}, :infinity)
+          GenServer.call(pid, {:wait_until, level, timeout}, :infinity)
       end
     rescue
       ArgumentError ->
-        # This happens when the Process Registry has not been created yet
-        maybe_retry_wait_until_active(
+        maybe_retry_wait_until(
           stack_id,
+          level,
           opts,
           timeout,
           "Stack ID not recognised: #{stack_id}"
         )
     catch
       :exit, _reason ->
-        maybe_retry_wait_until_active(
+        maybe_retry_wait_until(
           stack_id,
+          level,
           opts,
           timeout,
           "Stack #{inspect(stack_id)} has terminated"
@@ -191,13 +233,12 @@ defmodule Electric.StatusMonitor do
     end
   end
 
-  @spin_prevention_delay 10
-  defp maybe_retry_wait_until_active(_stack_id, _opts, timeout, last_error)
+  defp maybe_retry_wait_until(_stack_id, _level, _opts, timeout, last_error)
        when timeout <= @spin_prevention_delay do
     {:error, last_error}
   end
 
-  defp maybe_retry_wait_until_active(stack_id, opts, timeout, _) do
+  defp maybe_retry_wait_until(stack_id, level, opts, timeout, _) do
     Process.sleep(@spin_prevention_delay)
 
     remaining_timeout =
@@ -206,7 +247,20 @@ defmodule Electric.StatusMonitor do
         _ -> timeout - @spin_prevention_delay
       end
 
-    wait_until_active(stack_id, Keyword.put(opts, :timeout, remaining_timeout))
+    wait_until(stack_id, level, Keyword.put(opts, :timeout, remaining_timeout))
+  end
+
+  @doc "Convenience wrapper: wait until fully active. Returns `:ok` on success."
+  def wait_until_active(stack_id, opts \\ []) do
+    case wait_until(stack_id, :active, opts) do
+      {:ok, :active} -> :ok
+      other -> other
+    end
+  end
+
+  @doc "Convenience wrapper: wait until shapes are servable."
+  def wait_until_shape_servable(stack_id, opts \\ []) do
+    wait_until(stack_id, :read_only, opts)
   end
 
   @doc """
@@ -259,17 +313,17 @@ defmodule Electric.StatusMonitor do
     {:noreply, state}
   end
 
-  def handle_call({:wait_until_active, timeout}, from, %{waiters: waiters} = state) do
-    case status(state.stack_id) do
-      %{conn: :up, shape: :up} ->
-        {:reply, :ok, state}
+  def handle_call({:wait_until, level, timeout}, from, %{waiters: waiters} = state) do
+    case check_level(level, state.stack_id) do
+      {:ok, _} = reply ->
+        {:reply, reply, state}
 
-      _ ->
+      :not_ready ->
         if timeout != :infinity do
-          Process.send_after(self(), {:timeout_waiter, from}, timeout)
+          Process.send_after(self(), {:timeout_waiter, {from, level}}, timeout)
         end
 
-        {:noreply, %{state | waiters: MapSet.put(waiters, from)}}
+        {:noreply, %{state | waiters: MapSet.put(waiters, {from, level})}}
     end
   end
 
@@ -284,6 +338,14 @@ defmodule Electric.StatusMonitor do
     {:reply, :ok, state}
   end
 
+  defp check_level(level, stack_id) do
+    case service_status(stack_id) do
+      :active -> {:ok, :active}
+      :waiting when level == :read_only -> {:ok, :read_only}
+      _ -> :not_ready
+    end
+  end
+
   def handle_info({{:down, condition}, _ref, :process, pid, _reason}, state) do
     :ets.match_delete(ets_table(state.stack_id), {:_, {true, %{process: pid}}})
 
@@ -294,9 +356,9 @@ defmodule Electric.StatusMonitor do
     {:noreply, state}
   end
 
-  def handle_info({:timeout_waiter, waiter}, state) do
+  def handle_info({:timeout_waiter, {from, _level} = waiter}, state) do
     if MapSet.member?(state.waiters, waiter) do
-      GenServer.reply(waiter, {:error, timeout_message(state.stack_id)})
+      GenServer.reply(from, {:error, timeout_message(state.stack_id)})
       {:noreply, %{state | waiters: MapSet.delete(state.waiters, waiter)}}
     else
       {:noreply, state}
@@ -310,11 +372,18 @@ defmodule Electric.StatusMonitor do
   defp maybe_reply_to_waiters(state) do
     status = status(state.stack_id)
 
+    # Reply to level-based waiters whose requirements are now met
     waiters =
-      if status.conn == :up and status.shape == :up do
-        Enum.each(state.waiters, &GenServer.reply(&1, :ok))
-        MapSet.new()
-      end
+      Enum.reduce(state.waiters, state.waiters, fn {from, level} = waiter, acc ->
+        case check_level(level, state.stack_id) do
+          {:ok, _} = reply ->
+            GenServer.reply(from, reply)
+            MapSet.delete(acc, waiter)
+
+          :not_ready ->
+            acc
+        end
+      end)
 
     conn_waiters =
       if status.conn == :up do
@@ -323,7 +392,7 @@ defmodule Electric.StatusMonitor do
       end
 
     state
-    |> Map.update!(:waiters, &(waiters || &1))
+    |> Map.update!(:waiters, fn _ -> waiters end)
     |> Map.update!(:conn_waiters, &(conn_waiters || &1))
   end
 

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -85,7 +85,7 @@ defmodule Electric.Connection.ConnectionManagerTest do
     setup [:start_connection_manager]
 
     test "reports status=waiting initially", %{stack_id: stack_id} do
-      assert StatusMonitor.status(stack_id) == %{conn: :waiting_on_lock, shape: :starting}
+      assert StatusMonitor.status(stack_id).conn == :waiting_on_lock
     end
 
     test "reports status=starting once the exclusive connection lock is acquired", %{
@@ -94,7 +94,7 @@ defmodule Electric.Connection.ConnectionManagerTest do
       assert_receive {:stack_status, _, :waiting_for_connection_lock}
       assert_receive {:stack_status, _, :connection_lock_acquired}
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
-      assert StatusMonitor.status(stack_id) == %{conn: :starting, shape: :starting}
+      assert StatusMonitor.status(stack_id).conn == :starting
     end
 
     test "reports status=active when all connection processes are running", %{stack_id: stack_id} do
@@ -153,7 +153,7 @@ defmodule Electric.Connection.ConnectionManagerTest do
       assert_receive :test_lock_acquired
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
 
-      assert StatusMonitor.status(stack_id) == %{conn: :waiting_on_lock, shape: :up}
+      assert StatusMonitor.status(stack_id).conn == :waiting_on_lock
     end
 
     test "backtracks the status when the shape log collector goes down", %{stack_id: stack_id} do
@@ -164,7 +164,9 @@ defmodule Electric.Connection.ConnectionManagerTest do
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
 
       status = StatusMonitor.status(stack_id)
-      assert status.shape == :starting
+
+      # shape_metadata_ready survives (ShapeStatusOwner is alive), so shape is :read_only not :starting
+      assert status.shape == :read_only
     end
 
     test "backtracks the status when the shape cache goes down", %{stack_id: stack_id} do
@@ -181,7 +183,7 @@ defmodule Electric.Connection.ConnectionManagerTest do
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
 
       status = StatusMonitor.status(stack_id)
-      assert status.shape == :starting
+      assert status.shape == :read_only
     end
 
     test "backtracks the status when the canary goes down", %{stack_id: stack_id} do
@@ -202,7 +204,7 @@ defmodule Electric.Connection.ConnectionManagerTest do
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
 
       status = StatusMonitor.status(stack_id)
-      assert status.shape == :starting
+      assert status.shape == :read_only
     end
   end
 

--- a/packages/sync-service/test/electric/plug/health_check_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/health_check_plug_test.exs
@@ -38,7 +38,17 @@ defmodule Electric.Plug.HealthCheckPlugTest do
     end
 
     @tag connection_status: %{conn: :waiting_on_lock, shape: :starting}
-    test "returns 202 when waiting on the lock", ctx do
+    test "returns 202 starting when waiting on lock but shapes not loaded", ctx do
+      conn =
+        conn(ctx)
+        |> HealthCheckPlug.call([])
+
+      assert conn.status == 202
+      assert Jason.decode!(conn.resp_body) == %{"status" => "starting"}
+    end
+
+    @tag connection_status: %{conn: :waiting_on_lock, shape: :read_only}
+    test "returns 202 waiting when waiting on lock with shapes loaded", ctx do
       conn =
         conn(ctx)
         |> HealthCheckPlug.call([])

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -188,7 +188,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       out_of_bounds_offset = LogOffset.increment(@test_offset)
 
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end
       )
@@ -394,7 +394,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "returns log when offset is >= 0", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -459,7 +459,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "returns 304 Not Modified when If-None-Match matches ETag",
          ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end
@@ -482,7 +482,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
         get_or_create_shape_handle: fn @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end
       )
@@ -517,7 +517,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "handles live updates", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -591,7 +591,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "handles shape rotation", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -637,7 +637,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "sends an up-to-date response after a timeout if no changes are observed",
          ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -699,7 +699,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
     test "sends 409 with a redirect to existing shape when requested shape handle does not exist",
          ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn "foo", @test_shape, _stack_id -> nil end,
+        resolve_shape_handle: fn "foo", @test_shape, _stack_id, _opts -> nil end,
         fetch_handle_by_shape: fn @test_shape, _opts -> {:ok, @test_shape_handle} end,
         has_shape?: fn "foo", _opts -> false end
       )
@@ -729,7 +729,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       patch_shape_cache(has_shape?: fn @test_shape_handle, _opts -> false end)
 
       expect_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           nil
         end,
         get_or_create_shape_handle: fn @test_shape, _stack_id, _opts ->
@@ -757,7 +757,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       new_shape_handle = "new-shape-handle"
 
       expect_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           nil
         end,
         get_or_create_shape_handle: fn @test_shape, _stack_id, _opts ->
@@ -884,7 +884,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "returns proper SSE format response when live_sse=true and live=true", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -956,7 +956,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
       )
 
       expect_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end
       )
@@ -982,7 +982,7 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
     test "works with deprecated experimental_live_sse=true", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,

--- a/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
+++ b/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
@@ -475,6 +475,17 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
       assert {:ok, ^features} = EtsInspector.load_supported_features(opts)
     end
 
+    test "returns supported features from persistence when DB is unavailable",
+         %{opts: opts} = ctx do
+      assert {:ok, features} = EtsInspector.load_supported_features(opts)
+      stop_supervised!(EtsInspector)
+
+      # Restart inspector without a DB pool — features should come from PersistentKV
+      %{inspector: {EtsInspector, opts}} = with_inspector(ctx |> Map.put(:db_conn, :no_pool))
+
+      assert {:ok, ^features} = EtsInspector.load_supported_features(opts)
+    end
+
     test "doesn't load back last seen state on a restart if the storage format is old",
          %{
            opts: opts,

--- a/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/shape_status_test.exs
@@ -321,6 +321,74 @@ defmodule Electric.ShapeCache.ShapeStatusTest do
     end
   end
 
+  describe "refresh/1" do
+    test "picks up new shapes added to SQLite", ctx do
+      {:ok, state, [handle]} = new_state(ctx, shapes: [shape!()])
+      ShapeStatus.ShapeDb.mark_snapshot_complete(state, handle)
+
+      # Add a new shape directly to SQLite (simulating another instance)
+      new_shape = shape!("new_from_other_instance")
+      {:ok, _hash} = ShapeStatus.ShapeDb.add_shape(state, new_shape, "other-handle-123")
+      ShapeStatus.ShapeDb.mark_snapshot_complete(state, "other-handle-123")
+
+      refute ShapeStatus.has_shape_handle?(state, "other-handle-123")
+
+      :ok = ShapeStatus.refresh(state)
+
+      assert ShapeStatus.has_shape_handle?(state, "other-handle-123")
+      # Original shape still present
+      assert ShapeStatus.has_shape_handle?(state, handle)
+    end
+
+    test "removes shapes deleted from SQLite", ctx do
+      {:ok, state, [handle]} = new_state(ctx, shapes: [shape!()])
+      ShapeStatus.ShapeDb.mark_snapshot_complete(state, handle)
+
+      assert ShapeStatus.has_shape_handle?(state, handle)
+
+      # Remove from SQLite directly (simulating another instance's cleanup)
+      :ok = ShapeStatus.ShapeDb.remove_shape(state, handle)
+
+      # Still in ETS
+      assert ShapeStatus.has_shape_handle?(state, handle)
+
+      :ok = ShapeStatus.refresh(state)
+
+      # Now gone from ETS
+      refute ShapeStatus.has_shape_handle?(state, handle)
+    end
+
+    test "updates snapshot_complete flag", ctx do
+      # Create two shapes, one with complete snapshot, one without
+      {:ok, state, [handle_a, handle_b]} =
+        new_state(ctx, shapes: [shape!("a"), shape!("b")])
+
+      # Mark both complete so validate_existing_shapes doesn't reject them
+      ShapeStatus.ShapeDb.mark_snapshot_complete(state, handle_a)
+      ShapeStatus.ShapeDb.mark_snapshot_complete(state, handle_b)
+
+      # ETS still has old value (snapshot_started? = false from add_shape)
+      refute ShapeStatus.snapshot_started?(state, handle_b)
+
+      :ok = ShapeStatus.refresh(state)
+
+      # Now updated from SQLite
+      assert ShapeStatus.snapshot_started?(state, handle_b)
+    end
+
+    test "existing entries remain visible during refresh", ctx do
+      {:ok, state, [handle]} = new_state(ctx, shapes: [shape!()])
+      ShapeStatus.ShapeDb.mark_snapshot_complete(state, handle)
+
+      # Refresh uses upsert (not clear-then-populate), so the entry
+      # should be visible at all times. We verify it's present after refresh.
+      :ok = ShapeStatus.refresh(state)
+
+      assert ShapeStatus.has_shape_handle?(state, handle)
+      assert ShapeStatus.snapshot_started?(state, handle)
+    end
+  end
+
   defp shape!, do: shape!("test")
 
   defp shape!(val) do

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -1548,7 +1548,7 @@ defmodule Electric.Shapes.ApiTest do
                  offset: "#{@start_offset_50}"
                })
 
-      assert request.read_only == true
+      assert request.read_only? == true
     end
 
     test "serves existing shape in read-only mode", ctx do

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -889,6 +889,10 @@ defmodule Electric.Shapes.ApiTest do
         end,
         resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
+        end,
+        # check_for_disk_updates at out-of-bounds timeout — still behind
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
         end
       )
 
@@ -1619,6 +1623,186 @@ defmodule Electric.Shapes.ApiTest do
                })
 
       assert response.status == 503
+    end
+
+    @tag long_poll_timeout: 100
+    test "returns up-to-date on long poll timeout when no new data on disk", ctx do
+      set_read_only(ctx)
+
+      patch_shape_cache(
+        has_shape?: fn @test_shape_handle, _opts -> true end,
+        await_snapshot_start: fn @test_shape_handle, _ -> :started end,
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end
+      )
+
+      patch_storage(
+        for_shape: fn @test_shape_handle, _opts -> @test_opts end,
+        get_chunk_end_log_offset: fn _, @test_opts -> nil end,
+        get_log_stream: fn @test_offset, _, @test_opts -> [] end
+      )
+
+      assert {:ok, request} =
+               Api.validate(ctx.api, %{
+                 table: "public.users",
+                 offset: "#{@test_offset}",
+                 handle: @test_shape_handle,
+                 live: true
+               })
+
+      assert response = Api.serve_shape_response(request)
+      assert response.status == 200
+      assert response.no_changes
+      assert [%{headers: %{control: "up-to-date"}}] = response_body(response)
+    end
+
+    @tag long_poll_timeout: 100
+    test "serves new data on long poll timeout when active instance has flushed", ctx do
+      set_read_only(ctx)
+      next_offset = LogOffset.increment(@test_offset)
+
+      # First resolve during validate returns @test_offset,
+      # second resolve at timeout returns next_offset (active instance flushed)
+      expect_shape_cache(
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end,
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end,
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, next_offset}
+        end
+      )
+
+      patch_shape_cache(
+        has_shape?: fn @test_shape_handle, _opts -> true end,
+        await_snapshot_start: fn @test_shape_handle, _ -> :started end
+      )
+
+      patch_storage(
+        for_shape: fn @test_shape_handle, _opts -> @test_opts end,
+        get_chunk_end_log_offset: fn _, @test_opts -> nil end
+      )
+
+      expect_storage(
+        get_log_stream: fn @test_offset, @test_offset, @test_opts -> [] end,
+        get_log_stream: fn @test_offset, ^next_offset, @test_opts ->
+          [Jason.encode!(%{key: "log1", value: "foo", headers: %{}, offset: next_offset})]
+        end
+      )
+
+      assert {:ok, request} =
+               Api.validate(ctx.api, %{
+                 table: "public.users",
+                 offset: "#{@test_offset}",
+                 handle: @test_shape_handle,
+                 live: true
+               })
+
+      assert response = Api.serve_shape_response(request)
+      assert response.status == 200
+
+      assert [
+               %{"key" => "log1"},
+               %{headers: %{control: "up-to-date"}}
+             ] = response_body(response)
+    end
+
+    @tag long_poll_timeout: 100
+    test "out-of-bounds recovers when active instance flushes data to disk", ctx do
+      set_read_only(ctx)
+      next_offset = LogOffset.increment(@test_offset)
+      next_next_offset = LogOffset.increment(next_offset)
+
+      # First resolve during validate returns @test_offset (behind next_offset),
+      # second resolve at out-of-bounds timeout returns next_next_offset (caught up)
+      expect_shape_cache(
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end,
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end,
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, next_next_offset}
+        end
+      )
+
+      patch_shape_cache(
+        has_shape?: fn @test_shape_handle, _opts -> true end,
+        await_snapshot_start: fn @test_shape_handle, _ -> :started end
+      )
+
+      patch_storage(
+        for_shape: fn @test_shape_handle, _opts -> @test_opts end,
+        get_chunk_end_log_offset: fn _, @test_opts -> nil end
+      )
+
+      expect_storage(
+        get_log_stream: fn ^next_offset, ^next_next_offset, @test_opts ->
+          [Jason.encode!(%{key: "log1", value: "foo", headers: %{}, offset: next_next_offset})]
+        end
+      )
+
+      assert {:ok, request} =
+               Api.validate(ctx.api, %{
+                 table: "public.users",
+                 offset: "#{next_offset}",
+                 handle: @test_shape_handle,
+                 live: true
+               })
+
+      assert response = Api.serve_shape_response(request)
+      assert response.status == 200
+
+      assert [
+               %{"key" => "log1"},
+               %{headers: %{control: "up-to-date"}}
+             ] = response_body(response)
+    end
+
+    @tag long_poll_timeout: 100
+    test "out-of-bounds still returns 400 when disk has not caught up", ctx do
+      set_read_only(ctx)
+      next_offset = LogOffset.increment(@test_offset)
+
+      # Both resolves return @test_offset — still behind the requested offset
+      expect_shape_cache(
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end,
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end,
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end
+      )
+
+      patch_shape_cache(
+        has_shape?: fn @test_shape_handle, _opts -> true end,
+        await_snapshot_start: fn @test_shape_handle, _ -> :started end
+      )
+
+      patch_storage(for_shape: fn @test_shape_handle, _opts -> @test_opts end)
+
+      assert {:ok, request} =
+               Api.validate(ctx.api, %{
+                 table: "public.users",
+                 offset: "#{next_offset}",
+                 handle: @test_shape_handle,
+                 live: true
+               })
+
+      assert response = Api.serve_shape_response(request)
+      assert response.status == 400
+
+      assert response_body(response) == %{
+               message: "Invalid request",
+               errors: %{offset: ["out of bounds for this shape"]}
+             }
     end
   end
 

--- a/packages/sync-service/test/electric/shapes/api_test.exs
+++ b/packages/sync-service/test/electric/shapes/api_test.exs
@@ -189,7 +189,7 @@ defmodule Electric.Shapes.ApiTest do
       request_handle = @test_shape_handle <> "-wrong"
 
       expect_shape_cache(
-        resolve_shape_handle: fn ^request_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn ^request_handle, @test_shape, _stack_id, _opts ->
           nil
         end,
         get_or_create_shape_handle: fn @test_shape, _stack_id, _opts ->
@@ -215,7 +215,7 @@ defmodule Electric.Shapes.ApiTest do
       request_handle = @test_shape_handle <> "-wrong"
 
       expect_shape_cache(
-        resolve_shape_handle: fn ^request_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn ^request_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @before_all_offset}
         end
       )
@@ -238,7 +238,7 @@ defmodule Electric.Shapes.ApiTest do
       request_handle = @test_shape_handle <> "-wrong"
 
       expect_shape_cache(
-        resolve_shape_handle: fn ^request_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn ^request_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @before_all_offset}
         end
       )
@@ -264,7 +264,7 @@ defmodule Electric.Shapes.ApiTest do
       patch_shape_cache(has_shape?: fn @test_shape_handle, _opts -> false end)
 
       expect_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id -> nil end,
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts -> nil end,
         get_or_create_shape_handle: fn @test_shape, _stack_id, _opts ->
           {new_shape_handle, @test_offset}
         end
@@ -650,7 +650,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "returns log when offset is >= 0", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -750,7 +750,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "handles live updates", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -826,7 +826,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "raises if body is read from a different process", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -884,10 +884,10 @@ defmodule Electric.Shapes.ApiTest do
     @tag long_poll_timeout: 100
     test "returns error after timeout when offset is out of bounds", ctx do
       expect_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end
       )
@@ -934,7 +934,7 @@ defmodule Electric.Shapes.ApiTest do
         patch_shape_cache(
           has_shape?: fn @test_shape_handle, _opts -> true end,
           await_snapshot_start: fn @test_shape_handle, _ -> :started end,
-          resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+          resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
             {@test_shape_handle, @test_offset}
           end
         )
@@ -1015,10 +1015,10 @@ defmodule Electric.Shapes.ApiTest do
       )
 
       expect_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, next_offset}
         end,
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, last_minute_next_offset}
         end
       )
@@ -1134,7 +1134,7 @@ defmodule Electric.Shapes.ApiTest do
 
     test "handles shape rotation", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -1195,7 +1195,7 @@ defmodule Electric.Shapes.ApiTest do
 
       # # any subsequent get shape calls should return the new offset
       expect_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           # Simulate new changes arriving the moment we load the shape
           Registry.dispatch(ctx.registry, @test_shape_handle, fn [{pid, ref}] ->
             send(pid, {ref, :new_changes, next_offset})
@@ -1203,7 +1203,7 @@ defmodule Electric.Shapes.ApiTest do
 
           {@test_shape_handle, @test_offset}
         end,
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, next_offset}
         end
       )
@@ -1246,7 +1246,7 @@ defmodule Electric.Shapes.ApiTest do
     @tag long_poll_timeout: 100
     test "picks up shape rotation missed between loading shape and listening for changes", ctx do
       expect_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           # Simulate shape rotating a moment after we load the shape
           Registry.dispatch(ctx.registry, @test_shape_handle, fn [{pid, ref}] ->
             send(pid, {ref, :shape_rotation})
@@ -1254,7 +1254,7 @@ defmodule Electric.Shapes.ApiTest do
 
           {@test_shape_handle, @test_offset}
         end,
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           nil
         end
       )
@@ -1303,13 +1303,13 @@ defmodule Electric.Shapes.ApiTest do
 
       expect_shape_cache(
         # First call during validation - returns valid offset
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         # Second call during notify_changes_since_request_start - simulates
         # the race condition where shape metadata was partially cleaned up,
         # causing offset to regress to last_before_real_offsets()
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, regressed_offset}
         end
       )
@@ -1354,7 +1354,7 @@ defmodule Electric.Shapes.ApiTest do
     @tag long_poll_timeout: 100
     test "sends an up-to-date response after a timeout if no changes are observed", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -1392,7 +1392,7 @@ defmodule Electric.Shapes.ApiTest do
     @tag long_poll_timeout: 100
     test "returns the latest lsn after the long poll timeout even if stack has failed", ctx do
       patch_shape_cache(
-        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id ->
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
           {@test_shape_handle, @test_offset}
         end,
         has_shape?: fn @test_shape_handle, _opts -> true end,
@@ -1516,6 +1516,109 @@ defmodule Electric.Shapes.ApiTest do
                )
 
       assert api.shape == shape
+    end
+  end
+
+  describe "read-only mode" do
+    setup [:configure_request]
+
+    defp set_read_only(ctx) do
+      {:via, _, {registry_name, registry_key}} = Electric.Shapes.Supervisor.name(ctx.stack_id)
+      {:ok, _} = Registry.register(registry_name, registry_key, nil)
+      Electric.LsnTracker.initialize(ctx.stack_id)
+      # Only mark shape metadata ready — not full active
+      Electric.StatusMonitor.mark_shape_metadata_ready(ctx.stack_id, self())
+      Electric.StatusMonitor.wait_for_messages_to_be_processed(ctx.stack_id)
+    end
+
+    test "sets read_only flag on request when in read-only mode", ctx do
+      set_read_only(ctx)
+
+      Repatch.patch(Electric.ShapeCache, :resolve_shape_handle, fn @test_shape_handle,
+                                                                   @test_shape,
+                                                                   _stack_id,
+                                                                   _opts ->
+        {@test_shape_handle, @first_offset}
+      end)
+
+      assert {:ok, request} =
+               Api.validate(ctx.api, %{
+                 table: "public.users",
+                 handle: @test_shape_handle,
+                 offset: "#{@start_offset_50}"
+               })
+
+      assert request.read_only == true
+    end
+
+    test "serves existing shape in read-only mode", ctx do
+      set_read_only(ctx)
+
+      Repatch.patch(Electric.ShapeCache, :resolve_shape_handle, fn @test_shape_handle,
+                                                                   @test_shape,
+                                                                   _stack_id,
+                                                                   _opts ->
+        {@test_shape_handle, @first_offset}
+      end)
+
+      assert {:ok, request} =
+               Api.validate(ctx.api, %{
+                 table: "public.users",
+                 handle: @test_shape_handle,
+                 offset: "#{@start_offset_50}"
+               })
+
+      assert request.handle == @test_shape_handle
+    end
+
+    test "uses shape's last offset as global_last_seen_lsn in read-only mode", ctx do
+      set_read_only(ctx)
+
+      Repatch.patch(Electric.ShapeCache, :resolve_shape_handle, fn @test_shape_handle,
+                                                                   @test_shape,
+                                                                   _stack_id,
+                                                                   _opts ->
+        {@test_shape_handle, @start_offset_50}
+      end)
+
+      assert {:ok, request} =
+               Api.validate(ctx.api, %{
+                 table: "public.users",
+                 handle: @test_shape_handle,
+                 offset: "#{@start_offset_50}"
+               })
+
+      assert request.global_last_seen_lsn == @start_offset_50.tx_offset
+    end
+
+    @tag stack_ready_timeout: 100
+    test "waits for active when shape not found in read-only mode", ctx do
+      set_read_only(ctx)
+
+      Repatch.patch(Electric.ShapeCache, :resolve_shape_handle, fn nil,
+                                                                   @test_shape,
+                                                                   _stack_id,
+                                                                   _opts ->
+        nil
+      end)
+
+      assert {:error, response} =
+               Api.validate(ctx.api, %{table: "public.users", offset: "-1"})
+
+      assert response.status == 503
+    end
+
+    @tag stack_ready_timeout: 100
+    test "delete returns 503 in read-only mode", ctx do
+      set_read_only(ctx)
+
+      assert {:error, response} =
+               Api.validate_for_delete(ctx.api, %{
+                 table: "public.users",
+                 handle: @test_shape_handle
+               })
+
+      assert response.status == 503
     end
   end
 

--- a/packages/sync-service/test/electric/status_monitor_test.exs
+++ b/packages/sync-service/test/electric/status_monitor_test.exs
@@ -39,6 +39,23 @@ defmodule Electric.StatusMonitorTest do
       assert StatusMonitor.service_status(stack_id) == :starting
     end
 
+    test "returns :starting when conn is up but shape pipeline not ready", %{
+      stack_id: stack_id
+    } do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      StatusMonitor.mark_pg_lock_acquired(stack_id, self())
+      StatusMonitor.mark_replication_client_ready(stack_id, self())
+      StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
+      StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_integrety_checks_passed(stack_id, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      # conn is :up, shape is :read_only (log collector + supervisor not ready)
+      # This is a transient post-lock state — should return :starting, not :waiting
+      assert StatusMonitor.service_status(stack_id) == :starting
+    end
+
     test "returns :active when fully operational", %{stack_id: stack_id} do
       start_link_supervised!({StatusMonitor, stack_id: stack_id})
       set_status_to_active(%{stack_id: stack_id})
@@ -302,6 +319,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
 
       assert StatusMonitor.wait_until_active(stack_id, timeout: 1) ==
                {:error, "Timeout waiting for shape data to be loaded"}
@@ -313,6 +331,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)

--- a/packages/sync-service/test/electric/status_monitor_test.exs
+++ b/packages/sync-service/test/electric/status_monitor_test.exs
@@ -2,8 +2,58 @@ defmodule Electric.StatusMonitorTest do
   use ExUnit.Case, async: true
 
   alias Electric.StatusMonitor
+  import Support.TestUtils, only: [set_status_to_active: 1]
 
   setup {Support.ComponentSetup, :with_stack_id_from_test}
+
+  describe "service_status/1" do
+    test "returns :starting before any conditions are met", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      assert StatusMonitor.service_status(stack_id) == :starting
+    end
+
+    test "returns :starting when conn is waiting but shapes not loaded", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      # pg_lock_acquired is not set, so conn is :waiting_on_lock, but shape is :starting
+      assert StatusMonitor.service_status(stack_id) == :starting
+    end
+
+    test "returns :waiting when conn waiting on lock and shapes loaded", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      assert StatusMonitor.service_status(stack_id) == :waiting
+    end
+
+    test "returns :starting when conn is progressing even with shapes loaded", %{
+      stack_id: stack_id
+    } do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      StatusMonitor.mark_pg_lock_acquired(stack_id, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      # conn is :starting (not all conn conditions met), shape is :read_only
+      # This is a transient startup state — should NOT return :waiting
+      assert StatusMonitor.service_status(stack_id) == :starting
+    end
+
+    test "returns :active when fully operational", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      set_status_to_active(%{stack_id: stack_id})
+
+      assert StatusMonitor.service_status(stack_id) == :active
+    end
+
+    test "returns :sleeping when connections scaled down", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      StatusMonitor.database_connections_going_to_sleep(stack_id)
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      assert StatusMonitor.service_status(stack_id) == :sleeping
+    end
+  end
 
   describe "status/1" do
     test "when not started, returns :waiting_on_lock", %{stack_id: stack_id} do
@@ -30,6 +80,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.mark_integrety_checks_passed(stack_id, self())
@@ -43,6 +94,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
@@ -54,6 +106,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_pg_lock_acquired(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
@@ -64,34 +117,37 @@ defmodule Electric.StatusMonitorTest do
       start_link_supervised!({StatusMonitor, stack_id: stack_id})
       StatusMonitor.mark_pg_lock_acquired(stack_id, self())
       StatusMonitor.mark_replication_client_ready(stack_id, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
       assert StatusMonitor.status(stack_id) == %{conn: :starting, shape: :up}
     end
 
-    test "when shape log collector not ready, returns :starting", %{stack_id: stack_id} do
+    test "when shape log collector not ready, shape returns :read_only", %{stack_id: stack_id} do
       start_link_supervised!({StatusMonitor, stack_id: stack_id})
       StatusMonitor.mark_pg_lock_acquired(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
       StatusMonitor.mark_replication_client_ready(stack_id, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.mark_integrety_checks_passed(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
-      assert StatusMonitor.status(stack_id) == %{conn: :up, shape: :starting}
+      assert StatusMonitor.status(stack_id) == %{conn: :up, shape: :read_only}
     end
 
-    test "when canary process not ready returns :starting", %{stack_id: stack_id} do
+    test "when canary process not ready, shape returns :read_only", %{stack_id: stack_id} do
       start_link_supervised!({StatusMonitor, stack_id: stack_id})
       StatusMonitor.mark_pg_lock_acquired(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
       StatusMonitor.mark_replication_client_ready(stack_id, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
       StatusMonitor.mark_integrety_checks_passed(stack_id, self())
       StatusMonitor.wait_for_messages_to_be_processed(stack_id)
-      assert StatusMonitor.status(stack_id) == %{conn: :up, shape: :starting}
+      assert StatusMonitor.status(stack_id) == %{conn: :up, shape: :read_only}
     end
 
     test "when a process dies, it's condition is reset", %{stack_id: stack_id} do
@@ -118,6 +174,7 @@ defmodule Electric.StatusMonitorTest do
 
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.mark_integrety_checks_passed(stack_id, self())
@@ -151,6 +208,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.mark_integrety_checks_passed(stack_id, self())
 
@@ -174,6 +232,7 @@ defmodule Electric.StatusMonitorTest do
       StatusMonitor.mark_replication_client_ready(stack_id, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
       StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
       StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
       StatusMonitor.mark_integrety_checks_passed(stack_id, self())
 
@@ -279,6 +338,14 @@ defmodule Electric.StatusMonitorTest do
                 "Timeout waiting for database connection pool (snapshot) to be ready: #{error_message}"}
     end
 
+    test "returns :conn_sleeping when connections are sleeping", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      StatusMonitor.database_connections_going_to_sleep(stack_id)
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      assert StatusMonitor.wait_until_active(stack_id, timeout: 1) == :conn_sleeping
+    end
+
     test "returns error if stack is terminated before fully initialized", %{stack_id: stack_id} do
       parent = self()
 
@@ -318,6 +385,105 @@ defmodule Electric.StatusMonitorTest do
       # the actual returned error is caused by the status monitor pid not
       # existing, not by the exit message
       assert {:error, _message} = Task.await(task, 1_000)
+    end
+  end
+
+  describe "wait_until/3" do
+    test "with :read_only returns {:ok, :active} when fully active", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      set_status_to_active(%{stack_id: stack_id})
+
+      assert StatusMonitor.wait_until(stack_id, :read_only, timeout: 100) == {:ok, :active}
+    end
+
+    test "with :read_only returns {:ok, :read_only} when shape metadata is ready", %{
+      stack_id: stack_id
+    } do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      assert StatusMonitor.wait_until(stack_id, :read_only, timeout: 100) == {:ok, :read_only}
+    end
+
+    test "with :read_only waits until shape metadata becomes ready", %{stack_id: stack_id} do
+      test_process = self()
+
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+
+      Task.async(fn ->
+        result = StatusMonitor.wait_until(stack_id, :read_only, timeout: 500)
+        send(test_process, {:result, result})
+      end)
+
+      refute_receive {:result, _}, 50
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
+      assert_receive {:result, {:ok, :read_only}}, 200
+    end
+
+    test "with :active returns {:ok, :active} when fully active", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      set_status_to_active(%{stack_id: stack_id})
+
+      assert StatusMonitor.wait_until(stack_id, :active, timeout: 100) == {:ok, :active}
+    end
+
+    test "with :active waits and does not return for :read_only", %{stack_id: stack_id} do
+      test_process = self()
+
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+
+      Task.async(fn ->
+        result = StatusMonitor.wait_until(stack_id, :active, timeout: 100)
+        send(test_process, {:result, result})
+      end)
+
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      # Should not return for read_only — must wait for active
+      refute_receive {:result, {:ok, :read_only}}, 50
+      assert_receive {:result, {:error, _}}, 200
+    end
+
+    test "with :active waits until all conditions are met", %{stack_id: stack_id} do
+      test_process = self()
+      stop_supervised!(Electric.ProcessRegistry.registry_name(stack_id))
+
+      Task.async(fn ->
+        result = StatusMonitor.wait_until(stack_id, :active, timeout: 500)
+        send(test_process, {:result, result})
+      end)
+
+      start_link_supervised!({Electric.ProcessRegistry, stack_id: stack_id})
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      StatusMonitor.mark_pg_lock_acquired(stack_id, self())
+      StatusMonitor.mark_replication_client_ready(stack_id, self())
+      StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
+      StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+      StatusMonitor.mark_shape_metadata_ready(stack_id, self())
+      StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
+      StatusMonitor.mark_integrety_checks_passed(stack_id, self())
+
+      refute_receive {:result, _}, 20
+      StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
+      assert_receive {:result, {:ok, :active}}, 200
+    end
+
+    test "returns :conn_sleeping when connections are sleeping", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+      StatusMonitor.database_connections_going_to_sleep(stack_id)
+      StatusMonitor.wait_for_messages_to_be_processed(stack_id)
+
+      assert StatusMonitor.wait_until(stack_id, :read_only, timeout: 100) == :conn_sleeping
+      assert StatusMonitor.wait_until(stack_id, :active, timeout: 100) == :conn_sleeping
+    end
+
+    test "returns error on timeout", %{stack_id: stack_id} do
+      start_link_supervised!({StatusMonitor, stack_id: stack_id})
+
+      assert {:error, _} = StatusMonitor.wait_until(stack_id, :read_only, timeout: 1)
+      assert {:error, _} = StatusMonitor.wait_until(stack_id, :active, timeout: 1)
     end
   end
 end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -251,7 +251,7 @@ defmodule Support.ComponentSetup do
       restart: :temporary
     })
 
-    :ok = Electric.ShapeCache.ShapeStatusOwner.initialize(ctx.stack_id)
+    :ok = Electric.ShapeCache.ShapeStatusOwner.refresh(ctx.stack_id)
 
     %{shape_status_owner: "shape_status_owner", shape_db: shape_db, async_deleter: async_deleter}
   end

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -120,6 +120,7 @@ defmodule Support.TestUtils do
     Electric.StatusMonitor.mark_replication_client_ready(stack_id, self())
     Electric.StatusMonitor.mark_connection_pool_ready(stack_id, :admin, self())
     Electric.StatusMonitor.mark_connection_pool_ready(stack_id, :snapshot, self())
+    Electric.StatusMonitor.mark_shape_metadata_ready(stack_id, self())
     Electric.StatusMonitor.mark_shape_log_collector_ready(stack_id, self())
     Electric.StatusMonitor.mark_supervisor_processes_ready(stack_id, self())
     Electric.StatusMonitor.mark_integrety_checks_passed(stack_id, self())


### PR DESCRIPTION
## Summary

Enables Electric instances to serve existing shape data in **read-only mode** when they don't hold the Postgres advisory lock. This unblocks smoother rolling deploys by eliminating the HTTP outage window where the new instance previously blocked all requests while waiting for the lock.

### The problem

During a rolling deploy, only one instance can hold the advisory lock and stream from the replication slot. The new instance would block on `pg_advisory_lock` — during which it served zero requests, creating a 5-20 second HTTP outage window.

### The solution

The new instance now eagerly initializes shape metadata from SQLite on startup and enters read-only mode, serving existing shapes from the shared filesystem while waiting for the lock. When the lock is acquired, it refreshes metadata and transitions to full active mode.

**State machine:** `:starting` → read-only (waiting) → `:active` ↔ read-only (waiting)

- **Read-only**: Serves existing shapes from disk. New shape creation and deletion wait for active mode (preserving previous behavior for those operations).
- **Active**: Full functionality as before.
- **Transitions are cheap**: No per-shape work, just a SQLite metadata refresh on lock acquisition.

## Key changes

- **ShapeStatusOwner** eagerly initializes shape metadata from SQLite via `handle_continue` (non-blocking to supervision tree), signaling `shape_metadata_ready` to the StatusMonitor
- **StatusMonitor** gains `service_status/1` (canonical `:active | :waiting | :starting | :sleeping` mapping) and a unified `wait_until/3` API with levels `:read_only` and `:active`
- **API** uses `hold_until_stack_ready(api, require: :read_only | :active)` — shape reads default to `:read_only`, new shape creation and deletion require `:active`
- **PureFileStorage** skips ETS caching in read-only mode (`read_only` flag on storage opts via `Storage.as_read_only/1`), reading directly from disk to see latest data from the active instance
- **ShapeStatus.refresh/1** uses a generation counter for race-free ETS updates — concurrent readers never see a missing entry during the refresh
- **EtsInspector** `load_supported_features` checks ETS before calling GenServer, and persists after storing features — so read-only instances can resolve shapes without a DB connection
- **HealthCheckPlug** uses `service_status/1` — reports "waiting" (202) during read-only mode

## What's NOT changed

- `wait_until_active` keeps its existing `:ok` contract — existing callers (replication client, tests) are unaffected
- Shape handle derivation, storage format, replication protocol unchanged
- The advisory lock mechanism is unchanged
- Client-facing API contract is preserved — clients may see brief 503s for new shape creation during rolling deploy, with `retry-after` headers

## Companion PR

- #4077 moves the admin connection pool to start before lock acquisition, making the admin pool available during the lock-waiting phase. Combined with this PR, the EtsInspector can now populate its cache for unknown schemas even in read-only mode (reducing 503s on cold starts).

## Future work

- Periodic SQLite metadata refresh during read-only mode for longer-running deploys (currently a single load on startup + refresh on lock acquisition)
- The read-only state is designed to be transitory — these improvements would make longer read-only windows more robust

## Test plan

- [x] Unit tests: 1883 tests passing (new tests for `service_status/1`, `wait_until/3`, `ShapeStatus.refresh/1`, API read-only path)
- [x] Integration test: `rolling-deploy.lux` covers full story — read-only serving, fresh data visibility via shared filesystem, handover, post-handover data, completeness check
- [x] All 9 existing integration tests pass (no regressions)
- [x] `mix format --check-formatted` clean
- [x] `mix compile --warnings-as-errors` clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)