### PR TITLE
fix(client): bound the onError retry loop to prevent unbounded retries

### DIFF
--- a/.changeset/bound-onerror-retry-loop.md
+++ b/.changeset/bound-onerror-retry-loop.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/client': patch
+---
+
+Bound the `onError` retry loop to prevent unbounded retries and memory growth. When `onError` always returns a retry directive for a persistent error (e.g. a 400 from a misconfigured proxy), the client now limits consecutive retries to 50 before tearing down the stream and notifying subscribers. The counter resets on successful data (non-empty message batch or 204 No Content), so intermittent errors that recover do not accumulate toward the limit.

--- a/packages/typescript-client/SPEC.md
+++ b/packages/typescript-client/SPEC.md
@@ -352,22 +352,22 @@ Six sites in `client.ts` recurse or loop to issue a new fetch:
 | L2  | `#requestShape` catch → `#requestShape` | 874  | Abort with `FORCE_DISCONNECT_AND_REFRESH` or `SYSTEM_WAKE` | `isRefreshing` flag changes `canLongPoll`, affecting `live` param                   | Abort signals are discrete events                       |
 | L3  | `#requestShape` catch → `#requestShape` | 886  | `StaleCacheError` thrown by `#onInitialResponse`           | `StaleRetryState` adds `cache_buster` param                                         | `maxStaleCacheRetries` counter in state machine         |
 | L4  | `#requestShape` catch → `#requestShape` | 924  | HTTP 409 (shape rotation)                                  | `#reset()` sets offset=-1 + new handle; or request-scoped cache buster if no handle | New handle from 409 response or unique retry URL        |
-| L5  | `#start` catch → `#start`               | 782  | Exception + `onError` returns retry opts                   | Params/headers merged from `retryOpts`                                              | User-controlled; `#checkFastLoop` on next iteration     |
+| L5  | `#start` catch → `#start`               | 782  | Exception + `onError` returns retry opts                   | Params/headers merged from `retryOpts`                                              | `#maxConsecutiveErrorRetries` (50)                      |
 | L6  | `fetchSnapshot` catch → `fetchSnapshot` | 1975 | HTTP 409 on snapshot fetch                                 | New handle via `withHandle()`; or local retry cache buster if same/no handle        | `#maxSnapshotRetries` (5) + cache buster on same handle |
 
 ### Guard mechanisms
 
-| Guard                  | Scope                         | How it works                                                                                                                                     |
-| ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `#checkFastLoop`       | Non-live `#requestShape` only | Detects N requests at same offset within a time window. First: clears caches + resets. Persistent: exponential backoff → throws FetchError(502). |
-| `maxStaleCacheRetries` | Stale response path (L3)      | State machine counts stale retries. Throws FetchError(502) after 3 consecutive stale responses.                                                  |
-| `#maxSnapshotRetries`  | Snapshot 409 path (L6)        | Counts consecutive snapshot 409s. Adds cache buster when handle unchanged. Throws FetchError(502) after 5.                                       |
-| Pause lock             | `#requestShape` entry         | Returns immediately if paused. Prevents fetches during snapshots.                                                                                |
-| Up-to-date exit        | `#requestShape` entry         | Returns if `!subscribe` and `isUpToDate`. Breaks loop for one-shot syncs.                                                                        |
+| Guard                         | Scope                         | How it works                                                                                                                                     |
+| ----------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `#checkFastLoop`              | Non-live `#requestShape` only | Detects N requests at same offset within a time window. First: clears caches + resets. Persistent: exponential backoff → throws FetchError(502). |
+| `maxStaleCacheRetries`        | Stale response path (L3)      | State machine counts stale retries. Throws FetchError(502) after 3 consecutive stale responses.                                                  |
+| `#maxSnapshotRetries`         | Snapshot 409 path (L6)        | Counts consecutive snapshot 409s. Adds cache buster when handle unchanged. Throws FetchError(502) after 5.                                       |
+| `#maxConsecutiveErrorRetries` | `#start` onError retry (L5)   | Counts consecutive error retries. Sends error to subscribers and tears down after 50. Reset on successful message batch.                         |
+| Pause lock                    | `#requestShape` entry         | Returns immediately if paused. Prevents fetches during snapshots.                                                                                |
+| Up-to-date exit               | `#requestShape` entry         | Returns if `!subscribe` and `isUpToDate`. Breaks loop for one-shot syncs.                                                                        |
 
 ### Coverage gaps
 
-| Gap                              | Risk | Notes                                                                              |
-| -------------------------------- | ---- | ---------------------------------------------------------------------------------- |
-| L5 user `onError` infinite retry | Low  | User callback controls retry; `#checkFastLoop` provides secondary guard            |
-| Live polling same URL            | None | Intentionally allowed — server long-polls, cursor may not change between responses |
+| Gap                   | Risk | Notes                                                                              |
+| --------------------- | ---- | ---------------------------------------------------------------------------------- |
+| Live polling same URL | None | Intentionally allowed — server long-polls, cursor may not change between responses |

--- a/packages/typescript-client/bin/lib/shape-stream-static-analysis.mjs
+++ b/packages/typescript-client/bin/lib/shape-stream-static-analysis.mjs
@@ -187,11 +187,12 @@ export function analyzeShapeStreamClient(filePath = CLIENT_FILE) {
       .map((report) => ({
         kind: `unbounded-retry-loop`,
         severity: `error`,
-        title: `Recursive call in catch block without bound check: ${report.method} -> ${report.callee}`,
+        title: `Recursive call in catch block without detected bound: ${report.method} -> ${report.callee}`,
         message:
           `${report.method} calls ${report.callee} inside a catch block at line ${report.callLine} ` +
-          `without a preceding counter/limit check that returns or throws. ` +
-          `This can cause an unbounded retry loop when errors persist.`,
+          `without a recognized bounding pattern (counter/limit check, error type guard, or abort signal). ` +
+          `This may indicate an unbounded retry loop when errors persist. ` +
+          `Note: this is a heuristic — verify manually if the call is actually bounded by other means.`,
         file: filePath,
         line: report.callLine,
         locations: [

--- a/packages/typescript-client/bin/lib/shape-stream-static-analysis.mjs
+++ b/packages/typescript-client/bin/lib/shape-stream-static-analysis.mjs
@@ -116,6 +116,7 @@ export function analyzeTypeScriptClient(options = {}) {
     reports: {
       recursiveMethods: clientAnalysis.recursiveMethods,
       sharedFieldReport: clientAnalysis.sharedFieldReport,
+      unboundedRetryReport: clientAnalysis.unboundedRetryReport,
       ignoredActionReport: stateMachineAnalysis.ignoredActionReport,
       protocolLiteralReport: protocolLiteralAnalysis.report,
     },
@@ -136,6 +137,13 @@ export function analyzeShapeStreamClient(filePath = CLIENT_FILE) {
   const classInfo = buildClassInfo(sourceFile, classDecl)
   const recursiveMethods = buildRecursiveMethodReport(classInfo)
   const sharedFieldReport = buildSharedFieldReport(classInfo)
+  const unboundedRetryReport = buildUnboundedRetryReport(
+    sourceFile,
+    classDecl,
+    classInfo,
+    recursiveMethods
+  )
+
   const findings = sharedFieldReport
     .filter((report) => report.risky)
     .map((report) => ({
@@ -173,11 +181,45 @@ export function analyzeShapeStreamClient(filePath = CLIENT_FILE) {
       },
     }))
 
+  findings.push(
+    ...unboundedRetryReport
+      .filter((report) => !report.hasBoundCheck)
+      .map((report) => ({
+        kind: `unbounded-retry-loop`,
+        severity: `error`,
+        title: `Recursive call in catch block without bound check: ${report.method} -> ${report.callee}`,
+        message:
+          `${report.method} calls ${report.callee} inside a catch block at line ${report.callLine} ` +
+          `without a preceding counter/limit check that returns or throws. ` +
+          `This can cause an unbounded retry loop when errors persist.`,
+        file: filePath,
+        line: report.callLine,
+        locations: [
+          {
+            file: filePath,
+            line: report.callLine,
+            label: `unbounded recursive call`,
+          },
+          {
+            file: filePath,
+            line: report.catchLine,
+            label: `catch block`,
+          },
+        ],
+        details: {
+          method: report.method,
+          callee: report.callee,
+          catchLine: report.catchLine,
+        },
+      }))
+  )
+
   return {
     sourceFile,
     classInfo,
     recursiveMethods,
     sharedFieldReport,
+    unboundedRetryReport,
     findings,
   }
 }
@@ -663,6 +705,222 @@ function buildSharedFieldReport(classInfo) {
   }
 
   return reports.sort(compareReports)
+}
+
+function buildUnboundedRetryReport(sourceFile, classDecl, _classInfo, recursiveMethods) {
+  const recursiveNames = new Set(recursiveMethods.map((m) => m.name))
+  const reports = []
+
+  for (const member of classDecl.members) {
+    if (!ts.isMethodDeclaration(member) || !member.body || !member.name) {
+      continue
+    }
+
+    const methodName = formatMemberName(member.name)
+    if (!recursiveNames.has(methodName)) continue
+
+    walk(member.body, (node) => {
+      if (!ts.isCatchClause(node)) return
+
+      const catchLine = getLine(sourceFile, node)
+      const catchBlock = node.block
+
+      const recursiveCalls = []
+      walk(catchBlock, (inner) => {
+        if (!ts.isCallExpression(inner)) return
+        const callee = getThisMemberName(inner.expression)
+        if (!callee) {
+          if (
+            ts.isAwaitExpression(inner.parent) &&
+            ts.isCallExpression(inner)
+          ) {
+            const awaitedCallee = getThisMemberName(inner.expression)
+            if (awaitedCallee && recursiveNames.has(awaitedCallee)) {
+              recursiveCalls.push({
+                callee: awaitedCallee,
+                node: inner,
+                line: getLine(sourceFile, inner),
+              })
+            }
+          }
+          return
+        }
+        if (recursiveNames.has(callee)) {
+          recursiveCalls.push({
+            callee,
+            node: inner,
+            line: getLine(sourceFile, inner),
+          })
+        }
+      })
+
+      for (const call of recursiveCalls) {
+        const hasBoundCheck = catchBlockHasBoundCheckBefore(
+          sourceFile,
+          catchBlock,
+          call.node
+        )
+        const hasTypeGuard = isInsideErrorTypeGuard(call.node, catchBlock)
+
+        reports.push({
+          method: methodName,
+          callee: call.callee,
+          callLine: call.line,
+          catchLine,
+          hasBoundCheck: hasBoundCheck || hasTypeGuard,
+          boundKind: hasBoundCheck
+            ? `counter-check`
+            : hasTypeGuard
+              ? `error-type-guard`
+              : null,
+        })
+      }
+    })
+  }
+
+  return reports
+}
+
+function catchBlockHasBoundCheckBefore(sourceFile, catchBlock, targetCall) {
+  const targetLine = getLine(sourceFile, targetCall)
+
+  let found = false
+  walk(catchBlock, (node) => {
+    if (found) return
+    if (!ts.isIfStatement(node)) return
+    if (getLine(sourceFile, node) >= targetLine) return
+    if (ifStatementIsBoundCheck(node)) {
+      found = true
+    }
+  })
+
+  return found
+}
+
+function ifStatementIsBoundCheck(ifStatement) {
+  const condition = ifStatement.expression
+
+  // Pattern 1: counter comparison (e.g., if (this.#counter > this.#limit))
+  if (hasComparisonOperator(condition) && hasThisFieldReference(condition)) {
+    if (blockContainsReturnOrThrow(ifStatement.thenStatement)) {
+      return true
+    }
+  }
+
+  // Pattern 2: abort signal check (e.g., if (... && isRestartAbort))
+  // These guard recursive calls that only fire on deliberate abort events
+  if (hasAbortSignalCheck(condition)) {
+    return true
+  }
+
+  return false
+}
+
+function hasAbortSignalCheck(node) {
+  let found = false
+  walk(node, (child) => {
+    if (found) return
+    if (ts.isPropertyAccessExpression(child) && child.name.text === `aborted`) {
+      found = true
+    }
+  })
+  return found
+}
+
+function isInsideErrorTypeGuard(callNode, catchBlock) {
+  let current = callNode.parent
+  while (current && current !== catchBlock) {
+    if (ts.isIfStatement(current)) {
+      if (conditionHasTypeNarrowing(current.expression)) {
+        return true
+      }
+    }
+    if (ts.isBlock(current) && ts.isIfStatement(current.parent)) {
+      if (conditionHasTypeNarrowing(current.parent.expression)) {
+        return true
+      }
+    }
+    current = current.parent
+  }
+  return false
+}
+
+function conditionHasTypeNarrowing(node) {
+  let found = false
+  walk(node, (child) => {
+    if (found) return
+    if (ts.isBinaryExpression(child)) {
+      const op = child.operatorToken.kind
+      // instanceof check (e instanceof FetchError)
+      if (op === ts.SyntaxKind.InstanceOfKeyword) {
+        found = true
+        return
+      }
+      // Property equality check (e.status == 409) — specific error code guard
+      if (
+        op === ts.SyntaxKind.EqualsEqualsToken ||
+        op === ts.SyntaxKind.EqualsEqualsEqualsToken
+      ) {
+        const hasPropertyAccess =
+          ts.isPropertyAccessExpression(child.left) ||
+          ts.isPropertyAccessExpression(child.right)
+        const hasLiteral =
+          ts.isNumericLiteral(child.left) ||
+          ts.isNumericLiteral(child.right) ||
+          ts.isStringLiteral(child.left) ||
+          ts.isStringLiteral(child.right)
+        if (hasPropertyAccess && hasLiteral) {
+          found = true
+        }
+      }
+    }
+  })
+  return found
+}
+
+function hasComparisonOperator(node) {
+  if (ts.isBinaryExpression(node)) {
+    const op = node.operatorToken.kind
+    if (
+      op === ts.SyntaxKind.GreaterThanToken ||
+      op === ts.SyntaxKind.GreaterThanEqualsToken ||
+      op === ts.SyntaxKind.LessThanToken ||
+      op === ts.SyntaxKind.LessThanEqualsToken ||
+      op === ts.SyntaxKind.EqualsEqualsToken ||
+      op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+      op === ts.SyntaxKind.ExclamationEqualsToken ||
+      op === ts.SyntaxKind.ExclamationEqualsEqualsToken
+    ) {
+      return true
+    }
+    return hasComparisonOperator(node.left) || hasComparisonOperator(node.right)
+  }
+  if (ts.isParenthesizedExpression(node)) {
+    return hasComparisonOperator(node.expression)
+  }
+  return false
+}
+
+function hasThisFieldReference(node) {
+  let found = false
+  walk(node, (child) => {
+    if (found) return
+    if (getThisMemberName(child)) {
+      found = true
+    }
+  })
+  return found
+}
+
+function blockContainsReturnOrThrow(node) {
+  let found = false
+  walk(node, (child) => {
+    if (found) return
+    if (ts.isReturnStatement(child) || ts.isThrowStatement(child)) {
+      found = true
+    }
+  })
+  return found
 }
 
 function stronglyConnectedComponents(graph) {

--- a/packages/typescript-client/bin/lib/shape-stream-static-analysis.mjs
+++ b/packages/typescript-client/bin/lib/shape-stream-static-analysis.mjs
@@ -707,7 +707,12 @@ function buildSharedFieldReport(classInfo) {
   return reports.sort(compareReports)
 }
 
-function buildUnboundedRetryReport(sourceFile, classDecl, _classInfo, recursiveMethods) {
+function buildUnboundedRetryReport(
+  sourceFile,
+  classDecl,
+  _classInfo,
+  recursiveMethods
+) {
   const recursiveNames = new Set(recursiveMethods.map((m) => m.name))
   const reports = []
 

--- a/packages/typescript-client/package.json
+++ b/packages/typescript-client/package.json
@@ -21,6 +21,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "fast-check": "^4.6.0",
     "glob": "^10.3.10",
     "jsdom": "^26.1.0",
     "pg": "^8.12.0",

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -623,6 +623,8 @@ export class ShapeStream<T extends Row<unknown> = Row>
   #fastLoopMaxCount = 5
   #pendingRequestShapeCacheBuster?: string
   #maxSnapshotRetries = 5
+  #consecutiveErrorRetries = 0
+  #maxConsecutiveErrorRetries = 50
 
   constructor(options: ShapeStreamOptions<GetExtensions<T>>) {
     this.options = { subscribe: true, ...options }
@@ -762,6 +764,24 @@ export class ShapeStream<T extends Row<unknown> = Row>
             }
           }
 
+          // Bound the onError retry loop to prevent unbounded retries
+          this.#consecutiveErrorRetries++
+          if (
+            this.#consecutiveErrorRetries > this.#maxConsecutiveErrorRetries
+          ) {
+            console.warn(
+              `[Electric] onError retry loop exhausted after ${this.#maxConsecutiveErrorRetries} consecutive retries. ` +
+                `The error was never resolved by the onError handler. ` +
+                `Error: ${err instanceof Error ? err.message : String(err)}`,
+              new Error(`stack trace`)
+            )
+            if (err instanceof Error) {
+              this.#sendErrorToSubscribers(err)
+            }
+            this.#teardown()
+            return
+          }
+
           // Clear the error since we're retrying
           this.#error = null
           if (this.#syncState instanceof ErrorState) {
@@ -803,6 +823,12 @@ export class ShapeStream<T extends Row<unknown> = Row>
   }
 
   async #requestShape(requestShapeCacheBuster?: string): Promise<void> {
+    // ErrorState should never reach the request loop — re-throw so
+    // #start's catch block can route it through onError properly.
+    if (this.#syncState instanceof ErrorState) {
+      throw this.#syncState.error
+    }
+
     const activeCacheBuster =
       requestShapeCacheBuster ?? this.#pendingRequestShapeCacheBuster
 
@@ -1237,6 +1263,10 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
     this.#syncState = transition.state
 
+    if (transition.action === `accepted` && status === 204) {
+      this.#consecutiveErrorRetries = 0
+    }
+
     if (transition.action === `stale-retry`) {
       // Cancel the response body to release the connection before retrying.
       await response.body?.cancel()
@@ -1292,6 +1322,8 @@ export class ShapeStream<T extends Row<unknown> = Row>
       return
     }
     if (batch.length === 0) return
+
+    this.#consecutiveErrorRetries = 0
 
     const lastMessage = batch[batch.length - 1]
     const hasUpToDateMessage = isUpToDateMessage(lastMessage)

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -792,8 +792,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
           // Restart from current offset
           this.#started = false
-          await this.#start()
-          return
+          return this.#start()
         }
         // onError returned void, meaning it doesn't want to retry
         // This is an unrecoverable error, notify subscribers

--- a/packages/typescript-client/test/expired-shapes-cache.test.ts
+++ b/packages/typescript-client/test/expired-shapes-cache.test.ts
@@ -634,6 +634,7 @@ describe(`ExpiredShapesCache`, () => {
       signal: aborter.signal,
       fetchClient: fetchMock,
       subscribe: false,
+      onError: () => {},
     })
 
     stream.subscribe(() => {})
@@ -760,6 +761,7 @@ describe(`ExpiredShapesCache`, () => {
       signal: aborter.signal,
       fetchClient: fetchMock,
       subscribe: false,
+      onError: () => {},
     })
 
     stream.subscribe(() => {})
@@ -835,6 +837,7 @@ describe(`ExpiredShapesCache`, () => {
       signal: aborter.signal,
       fetchClient: fetchMock,
       subscribe: false,
+      onError: () => {},
     })
 
     stream.subscribe(() => {})

--- a/packages/typescript-client/test/model-based.test.ts
+++ b/packages/typescript-client/test/model-based.test.ts
@@ -134,6 +134,13 @@ class FetchGate {
   private _fetchResolve: ((r: Response) => void) | null = null
   private _onRequest: (() => void) | null = null
 
+  /** Last two request URLs — used to verify no identity loops. */
+  lastUrl: string | null = null
+  prevUrl: string | null = null
+
+  /** Maximum URL length seen across all requests. */
+  maxUrlLength = 0
+
   get requestCount(): number {
     return this._requestCount
   }
@@ -143,11 +150,17 @@ class FetchGate {
   }
 
   readonly fetchClient = async (
-    _input: RequestInfo | URL,
+    input: RequestInfo | URL,
     init?: RequestInit
   ): Promise<Response> => {
     if (init?.signal?.aborted) return Response.error()
     this._requestCount++
+
+    // Track URLs for invariant checking
+    const urlStr = input.toString()
+    this.prevUrl = this.lastUrl
+    this.lastUrl = urlStr
+    if (urlStr.length > this.maxUrlLength) this.maxUrlLength = urlStr.length
 
     if (this._onRequest) {
       const cb = this._onRequest
@@ -189,6 +202,7 @@ class FetchGate {
 
 interface StreamReal {
   gate: FetchGate
+  stream: ShapeStream
   subscriberError: Error | null
   currentHandle: string
   respond(response: Response): Promise<void>
@@ -250,6 +264,7 @@ async function createStreamReal(): Promise<StreamReal> {
 
   return {
     gate,
+    stream,
     get subscriberError() {
       return errorRef.error
     },
@@ -278,6 +293,24 @@ interface StreamModel {
 }
 
 const MAX_CONSECUTIVE_ERROR_RETRIES = 50
+const MAX_URL_LENGTH = 2000
+
+/**
+ * Invariants checked after every command. These catch historical bugs
+ * like URL identity loops (bug #1), `-next` suffix growth (bug #3),
+ * and handle/offset mismatches (bug #10).
+ */
+function assertGlobalInvariants(r: StreamReal): void {
+  // URL length is bounded (catches unbounded suffix growth like -next-next-next)
+  expect(r.gate.maxUrlLength).toBeLessThan(MAX_URL_LENGTH)
+
+  // After any successful (non-error) response, isUpToDate state should be
+  // consistent with what we observe (no silent stuck states)
+  if (!r.subscriberError && r.stream.isUpToDate) {
+    // If the stream thinks it's up-to-date, it should have synced at some point
+    expect(r.stream.lastSyncedAt()).toBeDefined()
+  }
+}
 
 // ─── Commands ───────────────────────────────────────────────────────
 //
@@ -295,6 +328,7 @@ class Respond200DataCmd implements fc.AsyncCommand<StreamModel, StreamReal> {
     m.consecutiveErrors = 0
     await r.respond(make200WithData(r.currentHandle))
     expect(r.subscriberError).toBeNull()
+    assertGlobalInvariants(r)
   }
   toString(): string {
     return `Respond200Data`
@@ -312,6 +346,7 @@ class Respond200UpToDateCmd
     m.consecutiveErrors = 0
     await r.respond(make200UpToDate(r.currentHandle))
     expect(r.subscriberError).toBeNull()
+    assertGlobalInvariants(r)
   }
   toString(): string {
     return `Respond200UpToDate`
@@ -327,9 +362,9 @@ class Respond200EmptyCmd implements fc.AsyncCommand<StreamModel, StreamReal> {
     return !m.terminated
   }
   async run(_m: StreamModel, r: StreamReal): Promise<void> {
-    // Empty batch → early return → counter unchanged
     await r.respond(make200Empty(r.currentHandle))
     expect(r.subscriberError).toBeNull()
+    assertGlobalInvariants(r)
   }
   toString(): string {
     return `Respond200Empty`
@@ -345,6 +380,7 @@ class Respond204Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
     m.consecutiveErrors = 0
     await r.respond(make204(r.currentHandle))
     expect(r.subscriberError).toBeNull()
+    assertGlobalInvariants(r)
   }
   toString(): string {
     return `Respond204`
@@ -367,6 +403,7 @@ class Respond400Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
       expect(r.subscriberError).not.toBeNull()
     } else {
       expect(r.subscriberError).toBeNull()
+      assertGlobalInvariants(r)
     }
   }
   toString(): string {
@@ -384,10 +421,17 @@ class Respond409Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
     return !m.terminated
   }
   async run(_m: StreamModel, r: StreamReal): Promise<void> {
+    const prevUrl = r.gate.lastUrl
     const newHandle = `handle-${nextSeq()}`
     await r.respond(make409(newHandle))
     r.currentHandle = newHandle
     expect(r.subscriberError).toBeNull()
+    assertGlobalInvariants(r)
+    // After 409, the retry URL must differ from the pre-409 URL
+    // (catches identity-loop bugs like bug #1 and #6)
+    if (prevUrl) {
+      expect(r.gate.lastUrl).not.toBe(prevUrl)
+    }
   }
   toString(): string {
     return `Respond409`
@@ -412,6 +456,7 @@ class RespondMalformed200Cmd
       expect(r.subscriberError).not.toBeNull()
     } else {
       expect(r.subscriberError).toBeNull()
+      assertGlobalInvariants(r)
     }
   }
   toString(): string {

--- a/packages/typescript-client/test/model-based.test.ts
+++ b/packages/typescript-client/test/model-based.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import * as fc from 'fast-check'
 import { ShapeStream } from '../src'
 import { expiredShapesCache } from '../src/expired-shapes-cache'
@@ -8,7 +8,9 @@ import { upToDateTracker } from '../src/up-to-date-tracker'
 //
 // Each factory generates a valid Electric protocol response. A
 // monotonically increasing sequence number keeps offsets and cursors
-// unique across the entire test run.
+// unique across the test run, preventing stale-response detection
+// from firing unexpectedly. All factories accept a `handle` parameter
+// so that responses stay consistent after 409 rotations.
 
 let responseSeq = 0
 
@@ -16,7 +18,19 @@ function nextSeq(): number {
   return ++responseSeq
 }
 
-function make200WithData(): Response {
+/** All Electric headers — valid for both live and non-live requests. */
+function allHeaders(handle: string): Record<string, string> {
+  const seq = responseSeq // use current seq without incrementing
+  return {
+    'electric-handle': handle,
+    'electric-offset': `${seq}_0`,
+    'electric-schema': `{"id":"int4"}`,
+    'electric-cursor': `cursor-${seq}`,
+  }
+}
+
+/** Valid 200 with one data message. Resets the error retry counter. */
+function make200WithData(handle: string): Response {
   const seq = nextSeq()
   return new Response(
     JSON.stringify([
@@ -27,47 +41,41 @@ function make200WithData(): Response {
         key: `key-${seq}`,
       },
     ]),
-    {
-      status: 200,
-      headers: {
-        'electric-handle': `test-handle`,
-        'electric-offset': `${seq}_0`,
-        'electric-schema': `{"id":"int4"}`,
-        'electric-cursor': `cursor-${seq}`,
-      },
-    }
+    { status: 200, headers: allHeaders(handle) }
   )
 }
 
-function make200UpToDate(): Response {
-  const seq = nextSeq()
+/** Valid 200 with up-to-date control message. Resets the error retry counter. */
+function make200UpToDate(handle: string): Response {
+  nextSeq()
   return new Response(
     JSON.stringify([{ headers: { control: `up-to-date` } }]),
     {
       status: 200,
-      headers: {
-        'electric-handle': `test-handle`,
-        'electric-offset': `${seq}_0`,
-        'electric-schema': `{"id":"int4"}`,
-        'electric-cursor': `cursor-${seq}`,
-        'electric-up-to-date': ``,
-      },
+      headers: { ...allHeaders(handle), 'electric-up-to-date': `` },
     }
   )
 }
 
-function make204(): Response {
-  const seq = nextSeq()
-  return new Response(null, {
-    status: 204,
-    headers: {
-      'electric-handle': `test-handle`,
-      'electric-offset': `${seq}_0`,
-      'electric-cursor': `cursor-${seq}`,
-    },
+/** Valid 200 with empty body []. Does NOT reset the error retry counter. */
+function make200Empty(handle: string): Response {
+  nextSeq()
+  return new Response(JSON.stringify([]), {
+    status: 200,
+    headers: allHeaders(handle),
   })
 }
 
+/** 204 No Content. Resets the error retry counter. */
+function make204(handle: string): Response {
+  nextSeq()
+  return new Response(null, {
+    status: 204,
+    headers: allHeaders(handle),
+  })
+}
+
+/** 400 Bad Request. Bypasses backoff, goes straight to onError. */
 function make400(): Response {
   return new Response(`Bad Request`, {
     status: 400,
@@ -75,16 +83,42 @@ function make400(): Response {
   })
 }
 
-function makeMalformed200(): Response {
-  const seq = nextSeq()
+/**
+ * 409 Conflict (shape rotation). Caught by #requestShape internally —
+ * does NOT go through onError, does NOT affect the retry counter.
+ * Returns a unique new handle so that subsequent responses avoid
+ * stale-cache detection.
+ */
+function make409(newHandle: string): Response {
+  return new Response(
+    JSON.stringify([{ headers: { control: `must-refetch` } }]),
+    {
+      status: 409,
+      headers: {
+        'electric-handle': newHandle,
+        'content-type': `application/json`,
+      },
+    }
+  )
+}
+
+/** Valid headers but non-array body. Throws FetchError → onError. */
+function makeMalformed200(handle: string): Response {
+  nextSeq()
   return new Response(JSON.stringify({ error: `not an array` }), {
     status: 200,
-    headers: {
-      'electric-handle': `test-handle`,
-      'electric-offset': `${seq}_0`,
-      'electric-schema': `{"id":"int4"}`,
-      'electric-cursor': `cursor-${seq}`,
-    },
+    headers: allHeaders(handle),
+  })
+}
+
+/**
+ * 200 OK but missing required Electric headers.
+ * Throws MissingHeadersError which is NOT retryable — terminates immediately.
+ */
+function make200MissingHeaders(): Response {
+  return new Response(JSON.stringify([]), {
+    status: 200,
+    headers: {},
   })
 }
 
@@ -115,7 +149,6 @@ class FetchGate {
     if (init?.signal?.aborted) return Response.error()
     this._requestCount++
 
-    // Notify that a new request arrived
     if (this._onRequest) {
       const cb = this._onRequest
       this._onRequest = null
@@ -157,23 +190,24 @@ class FetchGate {
 interface StreamReal {
   gate: FetchGate
   subscriberError: Error | null
+  currentHandle: string
   respond(response: Response): Promise<void>
   cleanup(): void
 }
 
 /**
- * Yield to the event loop until the gate has a pending request,
- * meaning the stream has fully processed the previous response and
- * is blocked waiting for the next one.
+ * Yield to the event loop until the gate has a pending request
+ * (stream processed the response and is blocked on next fetch)
+ * or the stream terminated (subscriber error set).
  */
-async function waitUntilBlocked(
+async function waitUntilSettled(
   gate: FetchGate,
-  subscriberErrorRef: { error: Error | null },
+  errorRef: { error: Error | null },
   maxYields = 50
 ): Promise<void> {
   for (let i = 0; i < maxYields; i++) {
     await new Promise((r) => setTimeout(r, 0))
-    if (gate.hasPendingRequest || subscriberErrorRef.error !== null) return
+    if (gate.hasPendingRequest || errorRef.error !== null) return
   }
   throw new Error(
     `Stream did not settle: no pending request and no subscriber error after ${maxYields} yields`
@@ -181,10 +215,17 @@ async function waitUntilBlocked(
 }
 
 async function createStreamReal(): Promise<StreamReal> {
+  // Reset all shared state to prevent cross-iteration pollution
   responseSeq = 0
+  localStorage.clear()
+  expiredShapesCache.clear()
+  upToDateTracker.clear()
+
+  const initialHandle = `test-handle`
   const gate = new FetchGate()
   const aborter = new AbortController()
   const errorRef = { error: null as Error | null }
+  const handleRef = { current: initialHandle }
 
   const stream = new ShapeStream({
     url: `https://example.com/v1/shape`,
@@ -204,18 +245,24 @@ async function createStreamReal(): Promise<StreamReal> {
 
   // Wait for the first fetch, then bootstrap into live mode
   await gate.waitForRequest()
-  gate.provideResponse(make200UpToDate())
-  await waitUntilBlocked(gate, errorRef)
+  gate.provideResponse(make200UpToDate(initialHandle))
+  await waitUntilSettled(gate, errorRef)
 
   return {
     gate,
     get subscriberError() {
       return errorRef.error
     },
+    get currentHandle() {
+      return handleRef.current
+    },
+    set currentHandle(h: string) {
+      handleRef.current = h
+    },
     async respond(response: Response) {
       await gate.waitForRequest()
       gate.provideResponse(response)
-      await waitUntilBlocked(gate, errorRef)
+      await waitUntilSettled(gate, errorRef)
     },
     cleanup() {
       aborter.abort()
@@ -234,18 +281,19 @@ const MAX_CONSECUTIVE_ERROR_RETRIES = 50
 
 // ─── Commands ───────────────────────────────────────────────────────
 //
-// Each command represents one server response. The `check` method
-// gates on the model (skip if stream already terminated), and the
-// `run` method updates the model, feeds the response to the real
-// system, and asserts consistency.
+// Each command represents one server response. The model predicts
+// the expected state change, and assertions verify the real system
+// matches. fast-check generates adversarial sequences and shrinks
+// failures to minimal reproductions.
 
+/** 200 with data — counter resets to 0 */
 class Respond200DataCmd implements fc.AsyncCommand<StreamModel, StreamReal> {
   check(m: Readonly<StreamModel>): boolean {
     return !m.terminated
   }
   async run(m: StreamModel, r: StreamReal): Promise<void> {
     m.consecutiveErrors = 0
-    await r.respond(make200WithData())
+    await r.respond(make200WithData(r.currentHandle))
     expect(r.subscriberError).toBeNull()
   }
   toString(): string {
@@ -253,6 +301,7 @@ class Respond200DataCmd implements fc.AsyncCommand<StreamModel, StreamReal> {
   }
 }
 
+/** 200 with up-to-date control — counter resets to 0 */
 class Respond200UpToDateCmd
   implements fc.AsyncCommand<StreamModel, StreamReal>
 {
@@ -261,7 +310,7 @@ class Respond200UpToDateCmd
   }
   async run(m: StreamModel, r: StreamReal): Promise<void> {
     m.consecutiveErrors = 0
-    await r.respond(make200UpToDate())
+    await r.respond(make200UpToDate(r.currentHandle))
     expect(r.subscriberError).toBeNull()
   }
   toString(): string {
@@ -269,13 +318,32 @@ class Respond200UpToDateCmd
   }
 }
 
+/**
+ * 200 with empty body [] — does NOT reset counter.
+ * The counter reset in #onMessages is gated by `if (batch.length === 0) return`.
+ */
+class Respond200EmptyCmd implements fc.AsyncCommand<StreamModel, StreamReal> {
+  check(m: Readonly<StreamModel>): boolean {
+    return !m.terminated
+  }
+  async run(_m: StreamModel, r: StreamReal): Promise<void> {
+    // Empty batch → early return → counter unchanged
+    await r.respond(make200Empty(r.currentHandle))
+    expect(r.subscriberError).toBeNull()
+  }
+  toString(): string {
+    return `Respond200Empty`
+  }
+}
+
+/** 204 No Content — counter resets to 0 */
 class Respond204Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
   check(m: Readonly<StreamModel>): boolean {
     return !m.terminated
   }
   async run(m: StreamModel, r: StreamReal): Promise<void> {
     m.consecutiveErrors = 0
-    await r.respond(make204())
+    await r.respond(make204(r.currentHandle))
     expect(r.subscriberError).toBeNull()
   }
   toString(): string {
@@ -283,6 +351,7 @@ class Respond204Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
   }
 }
 
+/** 400 Bad Request — counter increments, may terminate at >50 */
 class Respond400Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
   check(m: Readonly<StreamModel>): boolean {
     return !m.terminated
@@ -305,6 +374,27 @@ class Respond400Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
   }
 }
 
+/**
+ * 409 Conflict — caught internally by #requestShape, does NOT go
+ * through onError, does NOT affect the retry counter. Rotates to
+ * a unique handle so subsequent responses avoid stale-cache detection.
+ */
+class Respond409Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
+  check(m: Readonly<StreamModel>): boolean {
+    return !m.terminated
+  }
+  async run(_m: StreamModel, r: StreamReal): Promise<void> {
+    const newHandle = `handle-${nextSeq()}`
+    await r.respond(make409(newHandle))
+    r.currentHandle = newHandle
+    expect(r.subscriberError).toBeNull()
+  }
+  toString(): string {
+    return `Respond409`
+  }
+}
+
+/** Malformed 200 (non-array body) — counter increments, may terminate */
 class RespondMalformed200Cmd
   implements fc.AsyncCommand<StreamModel, StreamReal>
 {
@@ -316,7 +406,7 @@ class RespondMalformed200Cmd
     const shouldTerminate = m.consecutiveErrors > MAX_CONSECUTIVE_ERROR_RETRIES
     if (shouldTerminate) m.terminated = true
 
-    await r.respond(makeMalformed200())
+    await r.respond(makeMalformed200(r.currentHandle))
 
     if (shouldTerminate) {
       expect(r.subscriberError).not.toBeNull()
@@ -329,18 +419,29 @@ class RespondMalformed200Cmd
   }
 }
 
+/**
+ * 200 with missing Electric headers — throws MissingHeadersError which
+ * is NOT retryable. Stream terminates immediately regardless of counter.
+ */
+class RespondMissingHeadersCmd
+  implements fc.AsyncCommand<StreamModel, StreamReal>
+{
+  check(m: Readonly<StreamModel>): boolean {
+    return !m.terminated
+  }
+  async run(m: StreamModel, r: StreamReal): Promise<void> {
+    m.terminated = true
+    await r.respond(make200MissingHeaders())
+    expect(r.subscriberError).not.toBeNull()
+  }
+  toString(): string {
+    return `RespondMissingHeaders`
+  }
+}
+
 // ─── Property Tests ─────────────────────────────────────────────────
 
 describe(`ShapeStream model-based property tests`, () => {
-  beforeEach(() => {
-    localStorage.clear()
-    expiredShapesCache.clear()
-    upToDateTracker.clear()
-  })
-
-  // Cleanup is handled per-run inside the property via real.cleanup()
-  afterEach(() => {})
-
   it(`bounded retry: any mix of server responses respects the retry limit and counter resets`, async () => {
     await fc.assert(
       fc.asyncProperty(
@@ -348,9 +449,12 @@ describe(`ShapeStream model-based property tests`, () => {
           [
             fc.constant(new Respond200DataCmd()),
             fc.constant(new Respond200UpToDateCmd()),
+            fc.constant(new Respond200EmptyCmd()),
             fc.constant(new Respond204Cmd()),
             fc.constant(new Respond400Cmd()),
+            fc.constant(new Respond409Cmd()),
             fc.constant(new RespondMalformed200Cmd()),
+            fc.constant(new RespondMissingHeadersCmd()),
           ],
           { maxCommands: 80 }
         ),
@@ -367,7 +471,7 @@ describe(`ShapeStream model-based property tests`, () => {
           }
         }
       ),
-      { numRuns: 100 }
+      { numRuns: 200 }
     )
-  }, 60_000)
+  }, 120_000)
 })

--- a/packages/typescript-client/test/model-based.test.ts
+++ b/packages/typescript-client/test/model-based.test.ts
@@ -1,0 +1,373 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fc from 'fast-check'
+import { ShapeStream } from '../src'
+import { expiredShapesCache } from '../src/expired-shapes-cache'
+import { upToDateTracker } from '../src/up-to-date-tracker'
+
+// ─── Response Factories ─────────────────────────────────────────────
+//
+// Each factory generates a valid Electric protocol response. A
+// monotonically increasing sequence number keeps offsets and cursors
+// unique across the entire test run.
+
+let responseSeq = 0
+
+function nextSeq(): number {
+  return ++responseSeq
+}
+
+function make200WithData(): Response {
+  const seq = nextSeq()
+  return new Response(
+    JSON.stringify([
+      {
+        offset: `${seq}_0`,
+        value: { id: seq },
+        headers: { operation: `insert` },
+        key: `key-${seq}`,
+      },
+    ]),
+    {
+      status: 200,
+      headers: {
+        'electric-handle': `test-handle`,
+        'electric-offset': `${seq}_0`,
+        'electric-schema': `{"id":"int4"}`,
+        'electric-cursor': `cursor-${seq}`,
+      },
+    }
+  )
+}
+
+function make200UpToDate(): Response {
+  const seq = nextSeq()
+  return new Response(
+    JSON.stringify([{ headers: { control: `up-to-date` } }]),
+    {
+      status: 200,
+      headers: {
+        'electric-handle': `test-handle`,
+        'electric-offset': `${seq}_0`,
+        'electric-schema': `{"id":"int4"}`,
+        'electric-cursor': `cursor-${seq}`,
+        'electric-up-to-date': ``,
+      },
+    }
+  )
+}
+
+function make204(): Response {
+  const seq = nextSeq()
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'electric-handle': `test-handle`,
+      'electric-offset': `${seq}_0`,
+      'electric-cursor': `cursor-${seq}`,
+    },
+  })
+}
+
+function make400(): Response {
+  return new Response(`Bad Request`, {
+    status: 400,
+    statusText: `Bad Request`,
+  })
+}
+
+function makeMalformed200(): Response {
+  const seq = nextSeq()
+  return new Response(JSON.stringify({ error: `not an array` }), {
+    status: 200,
+    headers: {
+      'electric-handle': `test-handle`,
+      'electric-offset': `${seq}_0`,
+      'electric-schema': `{"id":"int4"}`,
+      'electric-cursor': `cursor-${seq}`,
+    },
+  })
+}
+
+// ─── Fetch Gate ─────────────────────────────────────────────────────
+//
+// A controllable mock fetch that blocks each request until the test
+// provides a response. This gives the test full control over the
+// server response sequence while letting ShapeStream drive the
+// request timing naturally.
+
+class FetchGate {
+  private _requestCount = 0
+  private _fetchResolve: ((r: Response) => void) | null = null
+  private _onRequest: (() => void) | null = null
+
+  get requestCount(): number {
+    return this._requestCount
+  }
+
+  get hasPendingRequest(): boolean {
+    return this._fetchResolve !== null
+  }
+
+  readonly fetchClient = async (
+    _input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> => {
+    if (init?.signal?.aborted) return Response.error()
+    this._requestCount++
+
+    // Notify that a new request arrived
+    if (this._onRequest) {
+      const cb = this._onRequest
+      this._onRequest = null
+      cb()
+    }
+
+    return new Promise<Response>((resolve) => {
+      this._fetchResolve = resolve
+      init?.signal?.addEventListener(
+        `abort`,
+        () => {
+          if (this._fetchResolve === resolve) {
+            this._fetchResolve = null
+            resolve(Response.error())
+          }
+        },
+        { once: true }
+      )
+    })
+  }
+
+  waitForRequest(): Promise<void> {
+    if (this._fetchResolve) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      this._onRequest = resolve
+    })
+  }
+
+  provideResponse(response: Response): void {
+    if (!this._fetchResolve) throw new Error(`No pending fetch request`)
+    const resolve = this._fetchResolve
+    this._fetchResolve = null
+    resolve(response)
+  }
+}
+
+// ─── Test System (Real) ─────────────────────────────────────────────
+
+interface StreamReal {
+  gate: FetchGate
+  subscriberError: Error | null
+  respond(response: Response): Promise<void>
+  cleanup(): void
+}
+
+/**
+ * Yield to the event loop until the gate has a pending request,
+ * meaning the stream has fully processed the previous response and
+ * is blocked waiting for the next one.
+ */
+async function waitUntilBlocked(
+  gate: FetchGate,
+  subscriberErrorRef: { error: Error | null },
+  maxYields = 50
+): Promise<void> {
+  for (let i = 0; i < maxYields; i++) {
+    await new Promise((r) => setTimeout(r, 0))
+    if (gate.hasPendingRequest || subscriberErrorRef.error !== null) return
+  }
+  throw new Error(
+    `Stream did not settle: no pending request and no subscriber error after ${maxYields} yields`
+  )
+}
+
+async function createStreamReal(): Promise<StreamReal> {
+  responseSeq = 0
+  const gate = new FetchGate()
+  const aborter = new AbortController()
+  const errorRef = { error: null as Error | null }
+
+  const stream = new ShapeStream({
+    url: `https://example.com/v1/shape`,
+    params: { table: `test` },
+    fetchClient: gate.fetchClient,
+    signal: aborter.signal,
+    subscribe: true,
+    onError: () => ({}), // always retry — the scenario under test
+  })
+
+  stream.subscribe(
+    () => {},
+    (err: Error) => {
+      errorRef.error = err
+    }
+  )
+
+  // Wait for the first fetch, then bootstrap into live mode
+  await gate.waitForRequest()
+  gate.provideResponse(make200UpToDate())
+  await waitUntilBlocked(gate, errorRef)
+
+  return {
+    gate,
+    get subscriberError() {
+      return errorRef.error
+    },
+    async respond(response: Response) {
+      await gate.waitForRequest()
+      gate.provideResponse(response)
+      await waitUntilBlocked(gate, errorRef)
+    },
+    cleanup() {
+      aborter.abort()
+    },
+  }
+}
+
+// ─── Model ──────────────────────────────────────────────────────────
+
+interface StreamModel {
+  consecutiveErrors: number
+  terminated: boolean
+}
+
+const MAX_CONSECUTIVE_ERROR_RETRIES = 50
+
+// ─── Commands ───────────────────────────────────────────────────────
+//
+// Each command represents one server response. The `check` method
+// gates on the model (skip if stream already terminated), and the
+// `run` method updates the model, feeds the response to the real
+// system, and asserts consistency.
+
+class Respond200DataCmd implements fc.AsyncCommand<StreamModel, StreamReal> {
+  check(m: Readonly<StreamModel>): boolean {
+    return !m.terminated
+  }
+  async run(m: StreamModel, r: StreamReal): Promise<void> {
+    m.consecutiveErrors = 0
+    await r.respond(make200WithData())
+    expect(r.subscriberError).toBeNull()
+  }
+  toString(): string {
+    return `Respond200Data`
+  }
+}
+
+class Respond200UpToDateCmd
+  implements fc.AsyncCommand<StreamModel, StreamReal>
+{
+  check(m: Readonly<StreamModel>): boolean {
+    return !m.terminated
+  }
+  async run(m: StreamModel, r: StreamReal): Promise<void> {
+    m.consecutiveErrors = 0
+    await r.respond(make200UpToDate())
+    expect(r.subscriberError).toBeNull()
+  }
+  toString(): string {
+    return `Respond200UpToDate`
+  }
+}
+
+class Respond204Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
+  check(m: Readonly<StreamModel>): boolean {
+    return !m.terminated
+  }
+  async run(m: StreamModel, r: StreamReal): Promise<void> {
+    m.consecutiveErrors = 0
+    await r.respond(make204())
+    expect(r.subscriberError).toBeNull()
+  }
+  toString(): string {
+    return `Respond204`
+  }
+}
+
+class Respond400Cmd implements fc.AsyncCommand<StreamModel, StreamReal> {
+  check(m: Readonly<StreamModel>): boolean {
+    return !m.terminated
+  }
+  async run(m: StreamModel, r: StreamReal): Promise<void> {
+    m.consecutiveErrors++
+    const shouldTerminate = m.consecutiveErrors > MAX_CONSECUTIVE_ERROR_RETRIES
+    if (shouldTerminate) m.terminated = true
+
+    await r.respond(make400())
+
+    if (shouldTerminate) {
+      expect(r.subscriberError).not.toBeNull()
+    } else {
+      expect(r.subscriberError).toBeNull()
+    }
+  }
+  toString(): string {
+    return `Respond400`
+  }
+}
+
+class RespondMalformed200Cmd
+  implements fc.AsyncCommand<StreamModel, StreamReal>
+{
+  check(m: Readonly<StreamModel>): boolean {
+    return !m.terminated
+  }
+  async run(m: StreamModel, r: StreamReal): Promise<void> {
+    m.consecutiveErrors++
+    const shouldTerminate = m.consecutiveErrors > MAX_CONSECUTIVE_ERROR_RETRIES
+    if (shouldTerminate) m.terminated = true
+
+    await r.respond(makeMalformed200())
+
+    if (shouldTerminate) {
+      expect(r.subscriberError).not.toBeNull()
+    } else {
+      expect(r.subscriberError).toBeNull()
+    }
+  }
+  toString(): string {
+    return `RespondMalformed200`
+  }
+}
+
+// ─── Property Tests ─────────────────────────────────────────────────
+
+describe(`ShapeStream model-based property tests`, () => {
+  beforeEach(() => {
+    localStorage.clear()
+    expiredShapesCache.clear()
+    upToDateTracker.clear()
+  })
+
+  // Cleanup is handled per-run inside the property via real.cleanup()
+  afterEach(() => {})
+
+  it(`bounded retry: any mix of server responses respects the retry limit and counter resets`, async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.commands(
+          [
+            fc.constant(new Respond200DataCmd()),
+            fc.constant(new Respond200UpToDateCmd()),
+            fc.constant(new Respond204Cmd()),
+            fc.constant(new Respond400Cmd()),
+            fc.constant(new RespondMalformed200Cmd()),
+          ],
+          { maxCommands: 80 }
+        ),
+        async (cmds) => {
+          const real = await createStreamReal()
+          const model: StreamModel = {
+            consecutiveErrors: 0,
+            terminated: false,
+          }
+          try {
+            await fc.asyncModelRun(() => ({ model, real }), cmds)
+          } finally {
+            real.cleanup()
+          }
+        }
+      ),
+      { numRuns: 100 }
+    )
+  }, 60_000)
+})

--- a/packages/typescript-client/test/static-analysis.test.ts
+++ b/packages/typescript-client/test/static-analysis.test.ts
@@ -14,10 +14,20 @@ interface RecursiveMethodReport {
   name: string
 }
 
+interface UnboundedRetryReport {
+  method: string
+  callee: string
+  callLine: number
+  catchLine: number
+  hasBoundCheck: boolean
+  boundKind: string | null
+}
+
 interface TypeScriptClientAnalysisResult {
   findings: AnalysisFinding[]
   reports: {
     recursiveMethods: RecursiveMethodReport[]
+    unboundedRetryReport: UnboundedRetryReport[]
   }
 }
 
@@ -71,6 +81,21 @@ describe(`shape-stream static analysis`, () => {
     )
 
     expect(ignoredActionFindings).toEqual([])
+  })
+
+  it(`does not report unbounded retry loops in recursive catch blocks`, async () => {
+    const { analyzeTypeScriptClient } = await loadAnalyzerModule()
+    const result = analyzeTypeScriptClient()
+    const unboundedFindings = result.findings.filter(
+      (entry) => entry.kind === `unbounded-retry-loop`
+    )
+
+    expect(unboundedFindings).toEqual([])
+
+    // Every recursive call in a catch block must have a bound check
+    for (const entry of result.reports.unboundedRetryReport) {
+      expect(entry.hasBoundCheck).toBe(true)
+    }
   })
 
   it(`reports near-miss Electric protocol literals`, async () => {

--- a/packages/typescript-client/test/static-analysis.test.ts
+++ b/packages/typescript-client/test/static-analysis.test.ts
@@ -92,7 +92,8 @@ describe(`shape-stream static analysis`, () => {
 
     expect(unboundedFindings).toEqual([])
 
-    // Every recursive call in a catch block must have a bound check
+    // Heuristic check: every recursive call in a catch block should have
+    // a recognizable bound pattern (counter check, type guard, or abort signal)
     for (const entry of result.reports.unboundedRetryReport) {
       expect(entry.hasBoundCheck).toBe(true)
     }

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ShapeStream, isChangeMessage, Message, Row } from '../src'
 import { snakeCamelMapper } from '../src/column-mapper'
+import { expiredShapesCache } from '../src/expired-shapes-cache'
+import { upToDateTracker } from '../src/up-to-date-tracker'
 import { resolveInMacrotask } from './support/test-helpers'
 
 describe(`ShapeStream`, () => {
@@ -8,6 +10,9 @@ describe(`ShapeStream`, () => {
   let aborter: AbortController
 
   beforeEach(() => {
+    localStorage.clear()
+    expiredShapesCache.clear()
+    upToDateTracker.clear()
     aborter = new AbortController()
   })
 
@@ -705,5 +710,332 @@ describe(`ShapeStream`, () => {
     )
 
     warnSpy.mockRestore()
+  })
+
+  it(`onError retry loop should be bounded for persistent errors`, async () => {
+    // Regression: onError always returning retry for a persistent error
+    // caused an unbounded retry loop. The consecutive error retry limit
+    // ensures the loop terminates.
+    let requestCount = 0
+
+    // First request succeeds → LiveState. All subsequent → persistent 400.
+    const fetchMock = vi.fn(async () => {
+      requestCount++
+
+      if (requestCount === 1) {
+        return new Response(
+          JSON.stringify([
+            { value: { id: 1 } },
+            { headers: { control: `up-to-date` } },
+          ]),
+          {
+            status: 200,
+            headers: {
+              'electric-handle': `test-handle`,
+              'electric-offset': `0_0`,
+              'electric-schema': `{"id":"int4"}`,
+              'electric-up-to-date': ``,
+            },
+          }
+        )
+      }
+
+      // 400 bypasses backoff, creating a tight retry loop
+      return new Response(`Bad Request`, {
+        status: 400,
+        statusText: `Bad Request`,
+      })
+    })
+
+    let lastError: Error | null = null
+    const stream = new ShapeStream({
+      url: shapeUrl,
+      params: { table: `test` },
+      signal: aborter.signal,
+      fetchClient: fetchMock,
+      subscribe: true,
+      onError: (error) => {
+        lastError = error
+        return {} // always retry — simulates TanStack DB's shouldRetryOnFailure
+      },
+    })
+
+    let subscriberError: Error | null = null
+    stream.subscribe(
+      () => {},
+      (err) => {
+        subscriberError = err
+      }
+    )
+
+    // The retry loop is asynchronous recursion via microtasks, so it
+    // completes well within this window.
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    expect(lastError).not.toBeNull()
+    expect(subscriberError).not.toBeNull()
+    // 1 initial success + ~51 retries (limit fires at >50)
+    expect(requestCount).toBeLessThan(100)
+  })
+
+  it(`onError retry counter resets after successful data`, async () => {
+    // The consecutive error retry counter must reset when the stream
+    // processes real data. Without the reset, intermittent error bursts
+    // would accumulate across the stream's lifetime and eventually kill
+    // a stream that is making progress between failures.
+
+    let requestCount = 0
+    const phase = { current: `errors1` } // errors1 → success1 → errors2 → done
+
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        // Yield to the event loop to prevent OOM from deeply nested
+        // recursive await this.#start() with instant mock resolution
+        await new Promise((r) => setTimeout(r, 0))
+        if (init?.signal?.aborted) return Response.error()
+
+        requestCount++
+
+        if (phase.current === `errors1` && requestCount <= 30) {
+          return new Response(`Bad Request`, {
+            status: 400,
+            statusText: `Bad Request`,
+          })
+        }
+        if (phase.current === `errors1`) {
+          phase.current = `success1`
+        }
+        if (phase.current === `success1`) {
+          phase.current = `errors2`
+          requestCount = 0
+          return new Response(
+            JSON.stringify([
+              { value: { id: 1 } },
+              { headers: { control: `up-to-date` } },
+            ]),
+            {
+              status: 200,
+              headers: {
+                'electric-handle': `test-handle`,
+                'electric-offset': `0_0`,
+                'electric-schema': `{"id":"int4"}`,
+                'electric-cursor': `cursor-1`,
+                'electric-up-to-date': ``,
+              },
+            }
+          )
+        }
+        if (phase.current === `errors2` && requestCount <= 30) {
+          return new Response(`Bad Request`, {
+            status: 400,
+            statusText: `Bad Request`,
+          })
+        }
+        // Both bursts survived — abort
+        phase.current = `done`
+        aborter.abort()
+        return new Response(
+          JSON.stringify([
+            { value: { id: 2 } },
+            { headers: { control: `up-to-date` } },
+          ]),
+          {
+            status: 200,
+            headers: {
+              'electric-handle': `test-handle`,
+              'electric-offset': `0_1`,
+              'electric-schema': `{"id":"int4"}`,
+              'electric-cursor': `cursor-2`,
+              'electric-up-to-date': ``,
+            },
+          }
+        )
+      }
+    )
+
+    let subscriberError: Error | null = null
+    const stream = new ShapeStream({
+      url: shapeUrl,
+      params: { table: `test` },
+      signal: aborter.signal,
+      fetchClient: fetchMock,
+      subscribe: true,
+      onError: () => ({}), // always retry
+    })
+
+    stream.subscribe(
+      () => {},
+      (err) => {
+        subscriberError = err
+      }
+    )
+
+    await vi.waitFor(
+      () => {
+        expect(phase.current).toBe(`done`)
+      },
+      { timeout: 10_000 }
+    )
+
+    // Stream survived 60 total errors (2 bursts of 30) because the
+    // counter reset between bursts. Without the reset, the cumulative
+    // count would hit 50 and kill the stream during the first burst.
+    expect(subscriberError).toBeNull()
+  })
+
+  it(`204 No Content responses reset the consecutive error retry counter`, async () => {
+    // 204 is a deprecated but supported "you're caught up" response that
+    // returns an empty body. The retry counter must reset on 204 success,
+    // not just on non-empty message batches.
+    let requestCount = 0
+
+    // Pattern: initial 200 → LiveState, then alternating bursts of
+    // 10 errors and 204 successes, repeated 6 times.
+    // Total errors: 60 (exceeds the 50 cap if counter doesn't reset).
+    const fetchMock = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+      requestCount++
+
+      // First request: initial 200 to establish shape
+      if (requestCount === 1) {
+        return new Response(
+          JSON.stringify([
+            { value: { id: 1 } },
+            { headers: { control: `up-to-date` } },
+          ]),
+          {
+            status: 200,
+            headers: {
+              'electric-handle': `handle-204-test`,
+              'electric-offset': `0_0`,
+              'electric-schema': `{"id":"int4"}`,
+              'electric-up-to-date': ``,
+            },
+          }
+        )
+      }
+
+      // After initial success: cycle through 10 errors then 1 x 204, repeat
+      const cyclePos = (requestCount - 2) % 11 // 0-9 = errors, 10 = 204
+      if (cyclePos < 10) {
+        return new Response(`Bad Request`, {
+          status: 400,
+          statusText: `Bad Request`,
+        })
+      }
+
+      // 204 No Content — should reset counter
+      return new Response(null, {
+        status: 204,
+        headers: {
+          'electric-handle': `handle-204-test`,
+          'electric-offset': `0_0`,
+          'electric-schema': `{"id":"int4"}`,
+          'electric-cursor': `cursor-${requestCount}`,
+        },
+      })
+    })
+
+    let subscriberError: Error | null = null
+    const stream = new ShapeStream({
+      url: shapeUrl,
+      params: { table: `test` },
+      signal: aborter.signal,
+      fetchClient: fetchMock,
+      subscribe: true,
+      onError: () => ({}),
+    })
+
+    stream.subscribe(
+      () => {},
+      (err) => {
+        subscriberError = err
+      }
+    )
+
+    // Wait long enough for 60+ errors across 6 cycles
+    await vi.waitFor(
+      () => {
+        expect(requestCount).toBeGreaterThan(60)
+      },
+      { timeout: 10_000 }
+    )
+
+    aborter.abort()
+
+    // If counter resets on 204, the stream survives 60+ total errors.
+    // If it doesn't, the counter hits 50 and tears down the stream.
+    expect(subscriberError).toBeNull()
+  })
+
+  it(`malformed 200 responses are bounded by the retry counter`, async () => {
+    // A proxy/CDN returning 200 OK with invalid JSON (non-array body)
+    // must still be bounded. The counter must NOT reset before the body
+    // is successfully parsed, otherwise accepted headers + parse failure
+    // creates an unbounded loop (counter resets to 0 every iteration).
+    let requestCount = 0
+
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        await new Promise((r) => setTimeout(r, 0))
+        if (init?.signal?.aborted) return Response.error()
+        requestCount++
+
+        // First request: valid 200 to establish shape
+        if (requestCount === 1) {
+          return new Response(
+            JSON.stringify([
+              { value: { id: 1 } },
+              { headers: { control: `up-to-date` } },
+            ]),
+            {
+              status: 200,
+              headers: {
+                'electric-handle': `handle-malformed-test`,
+                'electric-offset': `0_0`,
+                'electric-schema': `{"id":"int4"}`,
+                'electric-up-to-date': ``,
+              },
+            }
+          )
+        }
+
+        // All subsequent: 200 OK with valid headers but non-array body
+        return new Response(`{"error": "not an array"}`, {
+          status: 200,
+          headers: {
+            'electric-handle': `handle-malformed-test`,
+            'electric-offset': `0_0`,
+            'electric-schema': `{"id":"int4"}`,
+            'electric-cursor': `cursor-${requestCount}`,
+          },
+        })
+      }
+    )
+
+    let subscriberError: Error | null = null
+    const stream = new ShapeStream({
+      url: shapeUrl,
+      params: { table: `test` },
+      signal: aborter.signal,
+      fetchClient: fetchMock,
+      subscribe: true,
+      onError: () => ({}),
+    })
+
+    stream.subscribe(
+      () => {},
+      (err) => {
+        subscriberError = err
+      }
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    // The retry counter must eventually exhaust and tear down the stream.
+    // If the counter resets on accepted headers (before parse), this
+    // assertion fails because the stream loops forever.
+    expect(subscriberError).not.toBeNull()
+    expect(requestCount).toBeLessThan(200)
   })
 })

--- a/packages/typescript-client/vitest.unit.config.ts
+++ b/packages/typescript-client/vitest.unit.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       `test/static-analysis.test.ts`,
       `test/stream.test.ts`,
       `test/204-no-content.test.ts`,
+      `test/model-based.test.ts`,
     ],
     testTimeout: 30000,
     environment: `jsdom`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1747,6 +1747,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.1.3
         version: 5.2.1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.3.3)
+      fast-check:
+        specifier: ^4.6.0
+        version: 4.6.0
       glob:
         specifier: ^10.3.10
         version: 10.4.5
@@ -9869,6 +9872,10 @@ packages:
   fast-base64-decode@1.0.0:
     resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
 
+  fast-check@4.6.0:
+    resolution: {integrity: sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -12949,6 +12956,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
@@ -25490,6 +25500,10 @@ snapshots:
 
   fast-base64-decode@1.0.0: {}
 
+  fast-check@4.6.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -29103,6 +29117,8 @@ snapshots:
   punycode@1.3.2: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   qrcode-terminal@0.11.0: {}
 


### PR DESCRIPTION
## Summary

Bounds the `onError` retry loop so that persistent errors (e.g. a misconfigured proxy returning 400) no longer create unbounded recursive retries with unbounded memory growth. Adds static analysis to prevent regressions.

## Root Cause

When `onError` always returns a retry directive (as TanStack DB's `shouldRetryOnFailure` does), the `#start` catch block calls `this.#start()` recursively for every error. Two gaps made this unbounded:

1. **No retry limit** — the catch block had no counter, so retries continued forever.
2. **Fast-loop detector bypass** — `ErrorState` wrapping `LiveState` delegates `isUpToDate` → `true`, causing the fast-loop check to be skipped entirely and its counters to reset in the else branch.

The combination means a persistent 400 (which bypasses backoff in `createFetchWithBackoff`) creates a tight recursive loop that grows the heap until the process crashes.

## Approach

**Consecutive error retry counter** (`#consecutiveErrorRetries`) on `ShapeStream`:

- Incremented on each `onError` retry in `#start`'s catch block
- When it exceeds 50, the stream logs a warning, notifies subscribers of the error, and tears down
- Resets on successful data: non-empty message batch in `#onMessages`, or accepted 204 in `#onInitialResponse`

The 204-specific reset is deliberate: 204 has no body to parse, so resetting on accepted headers is safe. For normal 200s the counter only resets *after* successful batch processing — otherwise a malformed 200 (invalid JSON from a proxy) would reset the counter on every iteration and defeat the limit.

**Tail-call optimization for error recovery**: the retry path uses `return this.#start()` instead of `await this.#start()` to release the outer async frame immediately, preventing frame accumulation across multiple recovery cycles.

**ErrorState guard** at the top of `#requestShape`: if the state machine is somehow in `ErrorState` when entering the request loop, re-throw so `#start`'s catch can route through `onError` properly.

**Static analysis** (`buildUnboundedRetryReport`): walks the AST to find every recursive call inside a catch block and heuristically checks each has a recognized bounding pattern — either a counter-check (field comparison + return/throw), an error-type-guard (instanceof/status-code narrowing), or an abort signal check. This is smoke detection for regressions, not a formal proof of boundedness — novel patterns may need manual verification.

## Key Invariants

1. The retry counter is monotonically increasing during consecutive errors and strictly resets only on proven successful data flow
2. Every recursive call in a catch block across `ShapeStream` has a recognized bounding pattern (heuristically enforced by static analysis test)
3. The fast-loop detector bypass is mitigated by the retry counter firing before it matters

## Non-goals

- Making the 50-retry limit configurable (can be added later if needed)
- Fixing the `isUpToDate` delegation in `ErrorState` (the retry counter makes this safe)

## Verification

```bash
cd packages/typescript-client
pnpm vitest run --config vitest.unit.config.ts
# 316 tests pass
```

Key test cases:
- `onError retry loop should be bounded for persistent errors` — verifies the limit fires
- `onError retry counter resets after successful data` — 60 errors across 2 bursts of 30, separated by success
- `204 No Content responses reset the consecutive error retry counter` — 60 errors separated by 204s
- `malformed 200 responses are bounded by the retry counter` — 200 OK with invalid JSON body
- `does not report unbounded retry loops in recursive catch blocks` — static analysis guard

## Files Changed

| File | Change |
|------|--------|
| `src/client.ts` | Add retry counter fields, bound check in `#start` catch, ErrorState guard in `#requestShape`, counter resets in `#onMessages` and `#onInitialResponse` (204 only), `return this.#start()` for frame release |
| `bin/lib/shape-stream-static-analysis.mjs` | Add `buildUnboundedRetryReport` — heuristic detection of recursive calls in catch blocks without recognized bounding patterns |
| `test/stream.test.ts` | 4 new tests: bounded retry, counter reset, 204 reset, malformed 200 bound |
| `test/static-analysis.test.ts` | 1 new test: no unbounded retry findings |
| `test/expired-shapes-cache.test.ts` | Add `onError` handlers to 3 streams to prevent unhandled rejections from fast-loop 502 errors |
| `SPEC.md` | Document `#maxConsecutiveErrorRetries` guard |

🤖 Generated with [Claude Code](https://claude.com/claude-code)