### PR TITLE
fix: move admission control before shape creation

### DIFF
--- a/.changeset/fix-admission-control-ordering.md
+++ b/.changeset/fix-admission-control-ordering.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix admission control bypass where shapes were created before admission control checks. Shape creation now happens after admission control, preventing resource exhaustion under load.

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -20,12 +20,13 @@ defmodule Electric.Plug.ServeShapePlug do
   plug :parse_body
 
   plug :validate_request
-  # Admission control is applied here, but note:
-  # - /v1/health bypasses this plug (routed to HealthCheckPlug)
-  # - /metrics bypasses this plug (on separate utility router/port)
-  # - / (root) bypasses this plug (handled directly in router)
-  # This ensures observability remains available under load
+  # Admission control is applied here, after parameter validation but before
+  # shape creation. This ensures invalid requests are rejected cheaply without
+  # consuming a permit, while shape creation (the expensive part) only happens
+  # for admitted requests.
+  # Note: /v1/health, /metrics, and / bypass this plug entirely.
   plug :check_admission
+  plug :load_shape
   plug :serve_shape_response
 
   # end_telemetry_span needs to always be the last plug here.
@@ -102,7 +103,7 @@ defmodule Electric.Plug.ServeShapePlug do
         &(&1 != "false")
       )
 
-    case Api.validate(api, all_params) do
+    case Api.validate_params(api, all_params) do
       {:ok, request} ->
         assign(conn, :request, request)
 
@@ -202,6 +203,18 @@ defmodule Electric.Plug.ServeShapePlug do
     base = 5
     jitter = :rand.uniform(5)
     base + jitter
+  end
+
+  defp load_shape(%Conn{assigns: %{request: request}} = conn, _) do
+    case Api.load_shape_info(request) do
+      {:ok, request} ->
+        assign(conn, :request, request)
+
+      {:error, response} ->
+        conn
+        |> Api.Response.send(response)
+        |> halt()
+    end
   end
 
   defp serve_shape_response(%Conn{assigns: %{request: request}} = conn, _) do

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -347,8 +347,9 @@ defmodule Electric.Plug.ServeShapePlug do
     error_str = Exception.format(:error, exception)
 
     conn = fetch_query_params(conn)
-    ensure_admission_control_release(conn)
 
+    # Admission control permit is released by the register_before_send callback
+    # set in check_admission/2, which fires when send_resp is called below.
     conn
     |> assign(:error_str, error_str)
     |> put_resp_header("retry-after", "10")
@@ -366,8 +367,9 @@ defmodule Electric.Plug.ServeShapePlug do
     error_str = Exception.format(error.kind, error.reason)
 
     conn = fetch_query_params(conn)
-    ensure_admission_control_release(conn)
 
+    # Admission control permit is released by the register_before_send callback
+    # set in check_admission/2, which fires when send_resp is called below.
     conn
     |> assign(:error_str, error_str)
     |> send_resp(conn.status, Jason.encode!(%{error: error_str}))
@@ -375,16 +377,5 @@ defmodule Electric.Plug.ServeShapePlug do
     # No end_telemetry_span() call here because by this point that stack of plugs has been
     # unwound to the point where the `conn` struct did not yet have any span-related properties
     # assigned to it.
-  end
-
-  defp ensure_admission_control_release(conn) do
-    stack_id = get_in(conn.assigns, [:config, :stack_id])
-
-    kind =
-      if conn.query_params["offset"] == "-1",
-        do: :initial,
-        else: :existing
-
-    Electric.AdmissionControl.release(stack_id, kind)
   end
 end

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -172,15 +172,45 @@ defmodule Electric.Shapes.Api do
   end
 
   @doc """
-  Validate the parameters for the request.
+  Validate the parameters for the request and load/create the shape.
+
+  This is a convenience wrapper that calls `validate_params/2` followed by
+  `load_shape_info/1`. Use the individual functions when you need to perform
+  actions (like admission control) between validation and shape creation.
   """
   @spec validate(t(), %{(atom() | binary()) => term()}) ::
           {:ok, Request.t()} | {:error, Response.t()}
   def validate(%Api{} = api, params) when is_configured(api) do
-    with {:ok, mode} <- hold_until_stack_ready(api),
-         {:ok, request} <- validate_params(api, params),
-         request = %{request | read_only?: mode == :read_only},
+    with {:ok, request} <- validate_params(api, params),
          {:ok, request} <- load_shape_info(request) do
+      {:ok, request}
+    end
+  end
+
+  @doc """
+  Validate request parameters without creating or loading a shape.
+
+  Returns a validated `Request` with parsed parameters and shape definition,
+  but no shape handle. Call `load_shape_info/1` afterwards to create or look
+  up the shape.
+  """
+  @spec validate_params(t(), %{(atom() | binary()) => term()}) ::
+          {:ok, Request.t()} | {:error, Response.t()}
+  def validate_params(%Api{} = api, params) when is_configured(api) do
+    with {:ok, mode} <- hold_until_stack_ready(api),
+         {:ok, request} <- cast_and_validate_params(api, params) do
+      {:ok, %{request | read_only?: mode == :read_only}}
+    end
+  end
+
+  @doc """
+  Load or create the shape for a validated request, and seek to the correct offset.
+
+  Must be called with a request returned by `validate_params/2`.
+  """
+  @spec load_shape_info(Request.t()) :: {:ok, Request.t()} | {:error, Response.t()}
+  def load_shape_info(%Request{} = request) do
+    with {:ok, request} <- do_load_shape_info(request) do
       {:ok, seek(request)}
     end
   end
@@ -193,7 +223,7 @@ defmodule Electric.Shapes.Api do
     end
   end
 
-  defp validate_params(api, params) do
+  defp cast_and_validate_params(api, params) do
     with {:ok, request_params} <- Api.Params.validate(api, params) do
       request_for_params(
         api,
@@ -265,7 +295,7 @@ defmodule Electric.Shapes.Api do
     Request.update_response(request, &%{&1 | up_to_date: true, offset: request.last_offset})
   end
 
-  defp load_shape_info(%Request{} = request) do
+  defp do_load_shape_info(%Request{} = request) do
     with_span(request, "shape_get.api.load_shape_info", fn ->
       request
       |> get_or_create_shape_handle()

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2196,9 +2196,9 @@ defmodule Electric.Plug.RouterTest do
       conn = conn("GET", "/v1/shape?table=items&offset=-1") |> Router.call(opts)
       assert %{status: 503} = conn
 
-      # BUG: shapes are created during validation, BEFORE admission control checks.
-      # This means a shape gets created even though the request is rejected.
-      # After the fix, no shape should be created when admission control rejects.
+      # Previously, shapes were created during validation, before admission control
+      # ran, so a rejected request would still leave a shape in the cache.
+      # This test asserts the fix: no shape is created when admission control rejects.
       assert Electric.ShapeCache.count_shapes(stack_id) == 0
 
       # Clean up manually acquired permits

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2176,6 +2176,35 @@ defmodule Electric.Plug.RouterTest do
       # After completion, all permits should be released
       assert %{initial: 0, existing: 0} = Electric.AdmissionControl.get_current(stack_id)
     end
+
+    @tag with_sql: [
+           "INSERT INTO items VALUES (gen_random_uuid(), 'test value 1')"
+         ]
+    test "does not create shapes when admission control rejects initial requests", %{
+      opts: opts,
+      stack_id: stack_id
+    } do
+      # Verify no shapes exist initially
+      assert Electric.ShapeCache.count_shapes(stack_id) == 0
+
+      # Pre-fill both initial admission slots (limit is 2) so the next request is rejected
+      :ok = Electric.AdmissionControl.try_acquire(stack_id, :initial, max_concurrent: 2)
+      :ok = Electric.AdmissionControl.try_acquire(stack_id, :initial, max_concurrent: 2)
+      assert %{initial: 2, existing: 0} = Electric.AdmissionControl.get_current(stack_id)
+
+      # Send an initial request for a new shape - should be rejected by admission control
+      conn = conn("GET", "/v1/shape?table=items&offset=-1") |> Router.call(opts)
+      assert %{status: 503} = conn
+
+      # BUG: shapes are created during validation, BEFORE admission control checks.
+      # This means a shape gets created even though the request is rejected.
+      # After the fix, no shape should be created when admission control rejects.
+      assert Electric.ShapeCache.count_shapes(stack_id) == 0
+
+      # Clean up manually acquired permits
+      Electric.AdmissionControl.release(stack_id, :initial)
+      Electric.AdmissionControl.release(stack_id, :initial)
+    end
   end
 
   describe "/v1/shapes - subqueries" do


### PR DESCRIPTION
## Summary

- **Fixed admission control bypass** where shapes were created before admission control could reject requests, defeating its purpose under load
- **Fixed pre-existing double-decrement bug** in `handle_errors` where admission control permits could be released twice (or spuriously released when no permit was acquired)

## Problem

In `ServeShapePlug`, the plug pipeline was:

```
plug :validate_request      # ← calls Api.validate() which creates shapes
plug :check_admission       # ← admission control runs AFTER shapes already exist
plug :serve_shape_response
```

`Api.validate/2` calls `load_shape_info()` → `get_or_create_shape_handle()`, which creates shapes in ETS/SQLite and starts consumer processes — all **before** admission control runs. A flood of requests for new shapes would create all shapes and start all consumers, then admission control would reject the requests. The expensive work had already happened.

Additionally, `handle_errors` called `ensure_admission_control_release` unconditionally before calling `send_resp`. Since `check_admission` registers a `before_send` callback that also releases the permit, this caused a double-decrement when exceptions occurred after permit acquisition. If the exception occurred *before* `check_admission`, the unconditional release would spuriously decrement the counter despite no permit being acquired. The ETS counter floor of 0 masked the issue (it never went negative), but it still undercounted active requests.

## Validation

Added a deterministic integration test (`router_test.exs`) that proves the bug:

1. Pre-fills admission control slots so the next request will be rejected
2. Sends an initial request (`offset=-1`) for a new shape
3. Asserts the request is rejected with 503
4. **Asserts no shape was created** (`ShapeCache.count_shapes == 0`)

On the original code this test **fails** — the shape count is **1** (shape created despite rejection). After the fix it passes.

## Solution

Split `Api.validate/2` into two public functions:
- **`validate_params/2`** — parameter validation + `Shape.new()` only (no shape creation in cache)
- **`load_shape_info/1`** — shape creation/lookup + seek (the expensive part)

`validate/2` remains as a convenience wrapper calling both (backward-compatible for elixir-client, Phoenix.Sync, existing tests).

Reordered the plug pipeline:

```
plug :validate_request      # param validation only (no shape creation)
plug :check_admission       # admission control BEFORE shape creation
plug :load_shape            # shape creation/lookup (after admission)
plug :serve_shape_response
```

This means:
- Invalid requests still fail fast before admission control (no wasted permits)
- Shape creation only happens for admitted requests
- Permit release via `register_before_send` handles errors in `load_shape` correctly
- Existing shapes (with handle) go through cheap `resolve_shape_handle` in `load_shape`

Removed `ensure_admission_control_release` from `handle_errors` — the `before_send` callback registered in `check_admission` is the single correct mechanism for releasing permits, and it fires when `send_resp` is called in the error handler path.

## Test plan

- [x] New test fails on original code, passes after fix
- [x] All 84 router tests pass
- [x] Full test suite passes (1532 tests + 391 doctests + 8 properties, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)