### PR TITLE
chore(sync-service): instrument snapshot query timing

### DIFF
--- a/packages/sync-service/lib/electric/postgres/snapshot_query.ex
+++ b/packages/sync-service/lib/electric/postgres/snapshot_query.ex
@@ -44,29 +44,24 @@ defmodule Electric.Postgres.SnapshotQuery do
     query_reason = Access.get(opts, :query_reason, "initial_snapshot")
     shape_attrs = shape_attrs(shape_handle, shape, query_reason)
     stack_id = Access.fetch!(opts, :stack_id)
-    started_at = System.monotonic_time(:microsecond)
 
     OpenTelemetry.with_child_span(
       "shape_snapshot.execute_for_shape",
       shape_attrs,
       stack_id,
       fn ->
+        OpenTelemetry.start_interval(:"shape_snapshot.checkout_wait.duration_µs")
+
         Postgrex.transaction(
           pool,
           fn conn ->
-            checkout_wait_duration = System.monotonic_time(:microsecond) - started_at
+            OpenTelemetry.start_interval(:"shape_snapshot.setup.duration_µs")
 
             ctx = %{
               conn: conn,
               stack_id: stack_id,
               span_attrs: shape_attrs
             }
-
-            OpenTelemetry.add_span_attributes(
-              "shape_snapshot.checkout_wait.duration_µs": checkout_wait_duration
-            )
-
-            setup_started_at = System.monotonic_time(:microsecond)
 
             query!(ctx, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
               span_name: "shape_snapshot.start_readonly_txn"
@@ -83,41 +78,18 @@ defmodule Electric.Postgres.SnapshotQuery do
               span_name: "shape_snapshot.set_display_settings"
             )
 
-            setup_duration = System.monotonic_time(:microsecond) - setup_started_at
+            OpenTelemetry.start_interval(:"shape_snapshot.query.duration_µs")
 
-            OpenTelemetry.add_span_attributes("shape_snapshot.setup.duration_µs": setup_duration)
+            result =
+              OpenTelemetry.with_child_span(
+                "shape_snapshot.query_fn",
+                shape_attrs,
+                stack_id,
+                fn -> query_fn.(conn, pg_snapshot, lsn) end
+              )
 
-            {query_duration, result} =
-              :timer.tc(fn ->
-                OpenTelemetry.with_child_span(
-                  "shape_snapshot.query_fn",
-                  shape_attrs,
-                  stack_id,
-                  fn -> query_fn.(conn, pg_snapshot, lsn) end
-                )
-              end)
-
-            total_duration = System.monotonic_time(:microsecond) - started_at
-
-            OpenTelemetry.add_span_attributes(%{
-              "shape_snapshot.query.duration_µs" => query_duration,
-              "shape_snapshot.total.duration_µs" => total_duration
-            })
-
-            OpenTelemetry.execute(
-              [:electric, :shape_snapshot, :query],
-              %{
-                checkout_wait_duration: checkout_wait_duration,
-                setup_duration: setup_duration,
-                query_duration: query_duration,
-                total_duration: total_duration
-              },
-              %{
-                stack_id: stack_id,
-                query_reason: query_reason,
-                "shape.handle": shape_handle,
-                "shape.root_table": shape.root_table
-              }
+            OpenTelemetry.stop_and_save_intervals(
+              total_attribute: :"shape_snapshot.total.duration_µs"
             )
 
             result

--- a/packages/sync-service/lib/electric/postgres/snapshot_query.ex
+++ b/packages/sync-service/lib/electric/postgres/snapshot_query.ex
@@ -41,48 +41,102 @@ defmodule Electric.Postgres.SnapshotQuery do
   def execute_for_shape(pool, shape_handle, shape, opts) do
     query_fn = Access.fetch!(opts, :query_fn)
     snapshot_info_fn = Access.fetch!(opts, :snapshot_info_fn)
-    shape_attrs = shape_attrs(shape_handle, shape)
+    query_reason = Access.get(opts, :query_reason, "initial_snapshot")
+    shape_attrs = shape_attrs(shape_handle, shape, query_reason)
     stack_id = Access.fetch!(opts, :stack_id)
+    started_at = System.monotonic_time(:microsecond)
 
-    Postgrex.transaction(
-      pool,
-      fn conn ->
-        ctx = %{
-          conn: conn,
-          stack_id: stack_id,
-          span_attrs: shape_attrs,
-          query_reason: Access.get(opts, :query_reason, "initial_snapshot")
-        }
+    OpenTelemetry.with_child_span(
+      "shape_snapshot.execute_for_shape",
+      shape_attrs,
+      stack_id,
+      fn ->
+        Postgrex.transaction(
+          pool,
+          fn conn ->
+            checkout_wait_duration = System.monotonic_time(:microsecond) - started_at
 
-        query!(ctx, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
-          span_name: "shape_snapshot.start_readonly_txn"
+            ctx = %{
+              conn: conn,
+              stack_id: stack_id,
+              span_attrs: shape_attrs
+            }
+
+            OpenTelemetry.add_span_attributes(
+              "shape_snapshot.checkout_wait.duration_µs": checkout_wait_duration
+            )
+
+            setup_started_at = System.monotonic_time(:microsecond)
+
+            query!(ctx, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+              span_name: "shape_snapshot.start_readonly_txn"
+            )
+
+            [%{rows: [[pg_snapshot, lsn]]}] =
+              query!(ctx, "SELECT pg_current_snapshot(), pg_current_wal_lsn()",
+                span_name: "shape_snapshot.get_pg_snapshot"
+              )
+
+            snapshot_info_fn.(shape_handle, pg_snapshot, lsn)
+
+            query!(ctx, Electric.Postgres.display_settings(),
+              span_name: "shape_snapshot.set_display_settings"
+            )
+
+            setup_duration = System.monotonic_time(:microsecond) - setup_started_at
+
+            OpenTelemetry.add_span_attributes("shape_snapshot.setup.duration_µs": setup_duration)
+
+            {query_duration, result} =
+              :timer.tc(fn ->
+                OpenTelemetry.with_child_span(
+                  "shape_snapshot.query_fn",
+                  shape_attrs,
+                  stack_id,
+                  fn -> query_fn.(conn, pg_snapshot, lsn) end
+                )
+              end)
+
+            total_duration = System.monotonic_time(:microsecond) - started_at
+
+            OpenTelemetry.add_span_attributes(%{
+              "shape_snapshot.query.duration_µs" => query_duration,
+              "shape_snapshot.total.duration_µs" => total_duration
+            })
+
+            OpenTelemetry.execute(
+              [:electric, :shape_snapshot, :query],
+              %{
+                checkout_wait_duration: checkout_wait_duration,
+                setup_duration: setup_duration,
+                query_duration: query_duration,
+                total_duration: total_duration
+              },
+              %{
+                stack_id: stack_id,
+                query_reason: query_reason,
+                "shape.handle": shape_handle,
+                "shape.root_table": shape.root_table
+              }
+            )
+
+            result
+          end,
+          timeout: :infinity
         )
-
-        [%{rows: [[pg_snapshot, lsn]]}] =
-          query!(ctx, "SELECT pg_current_snapshot(), pg_current_wal_lsn()",
-            span_name: "shape_snapshot.get_pg_snapshot"
-          )
-
-        snapshot_info_fn.(shape_handle, pg_snapshot, lsn)
-
-        query!(ctx, Electric.Postgres.display_settings(),
-          span_name: "shape_snapshot.set_display_settings"
-        )
-
-        query_fn.(conn, pg_snapshot, lsn)
-      end,
-      timeout: :infinity
+      end
     )
   catch
     :exit, {_, {DBConnection.Holder, :checkout, _}} ->
       raise SnapshotError.connection_not_available()
   end
 
-  defp shape_attrs(shape_handle, shape) do
+  defp shape_attrs(shape_handle, shape, query_reason) do
     [
       "shape.handle": shape_handle,
       "shape.root_table": shape.root_table,
-      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil)
+      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil),
+      "shape.query_reason": query_reason
     ]
   end
 


### PR DESCRIPTION
Summary
- add a top-level snapshot query span around SnapshotQuery.execute_for_shape/4
- record checkout wait, setup, query, and total durations for snapshot-backed requests
- emit a telemetry event tagged with query_reason so subset, move-in, and initial snapshot paths can be separated in analysis

Verification
- mix compile in packages/sync-service
- mix test test/electric/shape_cache_test.exs in packages/sync-service (real-db cases fail here because local Postgres on localhost:54321 is unavailable in this environment)