### PR TITLE
feat: add variadic function support to eval

### DIFF
--- a/packages/sync-service/lib/electric/replication/eval/env.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env.ex
@@ -62,6 +62,7 @@ defmodule Electric.Replication.Eval.Env do
   @type func :: %{
           optional(:strict?) => boolean(),
           optional(:immutable?) => boolean(),
+          optional(:variadic_arg) => non_neg_integer(),
           args: [pg_type()],
           returns: pg_type(),
           implementation: {module(), atom()} | fun(),

--- a/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
@@ -5,6 +5,60 @@ defmodule Electric.Replication.Eval.Env.KnownFunctions do
   alias Electric.Replication.PostgresInterop.Casting
   alias Electric.Replication.Eval.Env.BasicTypes
 
+  def coalesce(values), do: Enum.find(values, &(not is_nil(&1)))
+
+  def greatest(values), do: pick_extreme(values, :greatest)
+  def least(values), do: pick_extreme(values, :least)
+
+  defp pick_extreme(values, direction) do
+    case Enum.reject(values, &is_nil/1) do
+      [] ->
+        nil
+
+      [head | tail] ->
+        Enum.reduce(tail, head, fn value, acc ->
+          case compare(value, acc) do
+            :gt when direction == :greatest -> value
+            :lt when direction == :least -> value
+            _ -> acc
+          end
+        end)
+    end
+  end
+
+  defp compare(%Date{} = left, %Date{} = right), do: Date.compare(left, right)
+  defp compare(%Time{} = left, %Time{} = right), do: Time.compare(left, right)
+
+  defp compare(%NaiveDateTime{} = left, %NaiveDateTime{} = right),
+    do: NaiveDateTime.compare(left, right)
+
+  defp compare(%DateTime{} = left, %DateTime{} = right), do: DateTime.compare(left, right)
+
+  defp compare(left, right) do
+    cond do
+      left > right -> :gt
+      left < right -> :lt
+      true -> :eq
+    end
+  end
+
+  ## Conditional expressions
+
+  defpostgres("coalesce(VARIADIC anycompatible) -> anycompatible",
+    strict?: false,
+    delegate: &__MODULE__.coalesce/1
+  )
+
+  defpostgres("greatest(VARIADIC anycompatible) -> anycompatible",
+    strict?: false,
+    delegate: &__MODULE__.greatest/1
+  )
+
+  defpostgres("least(VARIADIC anycompatible) -> anycompatible",
+    strict?: false,
+    delegate: &__MODULE__.least/1
+  )
+
   ## "input" functions
 
   defpostgres("int2(text) -> int2", delegate: &Casting.parse_int2/1)

--- a/packages/sync-service/lib/electric/replication/eval/known_definition.ex
+++ b/packages/sync-service/lib/electric/replication/eval/known_definition.ex
@@ -16,6 +16,7 @@ defmodule Electric.Replication.Eval.KnownDefinition do
   @known_definition_keys [
     :args,
     :returns,
+    :variadic_arg,
     :strict?,
     :immutable?,
     :commutative_overload?,
@@ -207,7 +208,7 @@ defmodule Electric.Replication.Eval.KnownDefinition do
         parse_binary_operator(operator_or_func)
 
       Regex.match?(func_regex(), operator_or_func) ->
-        parse_function(operator_or_func)
+        parse_function(operator_or_func, caller)
 
       true ->
         raise CompileError,
@@ -243,16 +244,44 @@ defmodule Electric.Replication.Eval.KnownDefinition do
     }
   end
 
-  defp parse_function(function) do
+  defp parse_function(function, caller) do
     %{"name" => name, "args" => args, "return_type" => return} =
       Regex.named_captures(func_regex(), function)
 
     # TODO: doesn't support default or optional arguments
-    arg_types =
+    arg_defs =
       args
       |> String.split(",", trim: true)
-      |> Enum.map(fn arg ->
-        String.to_atom(String.trim(arg))
+      |> Enum.map(&String.trim/1)
+
+    variadic_positions =
+      Enum.with_index(arg_defs)
+      |> Enum.filter(fn {arg, _idx} -> String.match?(arg, ~r/^VARIADIC\s+/i) end)
+
+    variadic_arg =
+      case variadic_positions do
+        [] ->
+          nil
+
+        [{_, idx}] when idx == length(arg_defs) - 1 ->
+          idx
+
+        [{_arg, idx}] ->
+          raise CompileError,
+            line: caller.line,
+            description:
+              "VARIADIC argument must be the last function argument in defpostgres, got position #{idx + 1}"
+
+        _ ->
+          raise CompileError,
+            line: caller.line,
+            description: "defpostgres does not support more than one VARIADIC argument"
+      end
+
+    arg_types =
+      Enum.map(arg_defs, fn arg ->
+        Regex.replace(~r/^VARIADIC\s+/i, arg, "")
+        |> String.to_atom()
       end)
 
     %{
@@ -260,7 +289,8 @@ defmodule Electric.Replication.Eval.KnownDefinition do
       name: name,
       arity: length(arg_types),
       args: arg_types,
-      returns: String.to_atom(return)
+      returns: String.to_atom(return),
+      variadic_arg: variadic_arg
     }
   end
 

--- a/packages/sync-service/lib/electric/replication/eval/lookups.ex
+++ b/packages/sync-service/lib/electric/replication/eval/lookups.ex
@@ -132,6 +132,17 @@ defmodule Electric.Replication.Eval.Lookups do
     end
   end
 
+  @doc """
+  Expand a variadic function definition to a concrete call arity.
+  """
+  @spec expand_variadic_function_overload(map(), non_neg_integer()) :: map()
+  def expand_variadic_function_overload(%{variadic_arg: variadic_arg, args: args} = choice, arity)
+      when is_integer(variadic_arg) and variadic_arg >= 0 do
+    {fixed_args, [variadic_type]} = Enum.split(args, variadic_arg)
+
+    %{choice | args: fixed_args ++ List.duplicate(variadic_type, arity - variadic_arg)}
+  end
+
   defp filter_overloads_on_heuristics(choices, arg_types, any_unknowns?, env) do
     steps = [
       &filter_overloads_on_implicit_conversion/4,

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -77,9 +77,9 @@ defmodule Electric.Replication.Eval.Parser do
       :name,
       strict?: true,
       immutable?: true,
-      # So this parameter is (1) internal for now, i.e. `defpostgres` in known functions cannot set it,
-      # and (2) is a bit of a hack. This allows us to specify that this function should be applied to each element of an array,
-      # without supporting essentially anonymous functions in our AST for an equivalent of `Enum.map/2`.
+      # Variadic arguments are represented as a single packed array-like AST node at this position.
+      # This is also reused internally for helpers such as array indexing, where one argument is
+      # already list-like and should be passed through as a single value.
       map_over_array_in_pos: nil,
       variadic_arg: nil,
       location: 0
@@ -705,26 +705,37 @@ defmodule Electric.Replication.Eval.Parser do
          _,
          %{env: env}
        ) do
-    with {:ok, choices} <- find_available_functions(call, env),
-         {:ok, concrete} <- Lookups.pick_concrete_function_overload(choices, args, env),
-         {:ok, args} <- cast_unknowns(args, concrete.args, env),
-         {:ok, args} <- cast_implicit(args, concrete.args, env) do
-      {:ok, from_concrete(concrete, args)}
-    else
-      {:error, {_loc, _msg}} = error ->
-        error
+    handle_function_call(
+      identifier(call.funcname),
+      args,
+      call.location,
+      env,
+      explicit_variadic?: call.func_variadic
+    )
+  end
 
-      :error ->
-        arg_list =
-          Enum.map_join(args, ", ", fn
-            %UnknownConst{} -> "unknown"
-            %{type: type} -> to_string(type)
-          end)
+  defp node_to_ast(
+         %PgQuery.CoalesceExpr{location: location},
+         %{args: args},
+         _,
+         %{env: env}
+       ) do
+    handle_function_call("coalesce", args, location, env)
+  end
 
-        {:error,
-         {call.location,
-          "Could not select a function overload for #{identifier(call.funcname)}(#{arg_list})"}}
-    end
+  defp node_to_ast(
+         %PgQuery.MinMaxExpr{location: location, op: op},
+         %{args: args},
+         _,
+         %{env: env}
+       ) do
+    func_name =
+      case op do
+        :IS_GREATEST -> "greatest"
+        :IS_LEAST -> "least"
+      end
+
+    handle_function_call(func_name, args, location, env)
   end
 
   # Next block of overloads matches on `A_Expr`, which is any operator call, as well as special syntax calls (e.g. `BETWEEN` or `ANY`).
@@ -1117,13 +1128,57 @@ defmodule Electric.Replication.Eval.Parser do
     end
   end
 
-  defp find_available_functions(%PgQuery.FuncCall{} = call, %{funcs: funcs}) do
-    name = identifier(call.funcname)
-    arity = length(call.args)
+  defp handle_function_call(name, args, location, env, opts \\ []) do
+    with {:ok, choices} <-
+           find_available_functions(name, length(args), location, env,
+             explicit_variadic?: Keyword.get(opts, :explicit_variadic?, false)
+           ),
+         {:ok, concrete} <- Lookups.pick_concrete_function_overload(choices, args, env),
+         {:ok, args} <- cast_unknowns(args, concrete.args, env),
+         {:ok, args} <- cast_implicit(args, concrete.args, env) do
+      {:ok, from_concrete(concrete, args)}
+    else
+      {:error, {_loc, _msg}} = error ->
+        error
 
-    case Map.fetch(funcs, {name, arity}) do
-      {:ok, options} -> {:ok, options}
-      :error -> {:error, {call.location, "unknown or unsupported function #{name}/#{arity}"}}
+      :error ->
+        arg_list =
+          Enum.map_join(args, ", ", fn
+            %UnknownConst{} -> "unknown"
+            %{type: type} -> to_string(type)
+          end)
+
+        {:error, {location, "Could not select a function overload for #{name}(#{arg_list})"}}
+    end
+  end
+
+  defp find_available_functions(name, arity, location, %{funcs: funcs}, opts) do
+    exact_choices = Map.get(funcs, {name, arity}, [])
+    explicit_variadic? = Keyword.get(opts, :explicit_variadic?, false)
+
+    variadic_choices =
+      if explicit_variadic? do
+        []
+      else
+        funcs
+        |> Enum.flat_map(fn
+          {{^name, candidate_arity}, overloads} when candidate_arity < arity ->
+            overloads
+            |> Enum.filter(&(&1[:variadic_arg] == candidate_arity - 1))
+            |> Enum.map(&Lookups.expand_variadic_function_overload(&1, arity))
+
+          _ ->
+            []
+        end)
+      end
+
+    choices =
+      (exact_choices ++ variadic_choices)
+      |> Enum.sort_by(&if is_nil(&1[:variadic_arg]), do: 0, else: 1)
+
+    case choices do
+      [] -> {:error, {location, "unknown or unsupported function #{name}/#{arity}"}}
+      options -> {:ok, options}
     end
   end
 
@@ -1310,11 +1365,39 @@ defmodule Electric.Replication.Eval.Parser do
     # arguments are of different types (e.g. `date + int8`)
     commutative_overload? = Map.get(concrete, :commutative_overload?, false)
 
+    args =
+      if commutative_overload? do
+        Enum.reverse(args)
+      else
+        args
+      end
+
+    args =
+      case Map.get(concrete, :variadic_arg) do
+        nil ->
+          args
+
+        variadic_arg ->
+          {fixed_args, variadic_args} = Enum.split(args, variadic_arg)
+          variadic_type = Enum.at(concrete.args, variadic_arg)
+          variadic_location = variadic_args |> List.first() |> Map.get(:location, 0)
+
+          fixed_args ++
+            [
+              %Array{
+                elements: variadic_args,
+                type: {:array, variadic_type},
+                location: variadic_location
+              }
+            ]
+      end
+
     %Func{
       implementation: concrete.implementation,
       name: concrete.name,
-      args: if(commutative_overload?, do: Enum.reverse(args), else: args),
+      args: args,
       type: concrete.returns,
+      variadic_arg: Map.get(concrete, :variadic_arg),
       # These two fields are always set by macro generation, but not always in tests
       strict?: Map.get(concrete, :strict?, true),
       immutable?: Map.get(concrete, :immutable?, true)

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -483,9 +483,64 @@ defmodule Electric.Replication.Eval.Parser do
   end
 
   defp reduce_ast(ast) do
-    Walker.fold(ast, fn node, children, _ctx ->
-      do_maybe_reduce(Map.merge(node, children))
-    end)
+    reduce_node(ast)
+  end
+
+  defp reduce_node(%Const{} = const), do: {:ok, const}
+  defp reduce_node(%Ref{} = ref), do: {:ok, ref}
+  defp reduce_node(%UnknownConst{} = unknown), do: {:ok, unknown}
+
+  defp reduce_node(%Array{elements: elements} = array) do
+    with {:ok, elements} <- Utils.map_while_ok(elements, &reduce_node/1) do
+      do_maybe_reduce(%{array | elements: elements})
+    end
+  end
+
+  defp reduce_node(%RowExpr{elements: elements} = row_expr) do
+    with {:ok, elements} <- Utils.map_while_ok(elements, &reduce_node/1) do
+      do_maybe_reduce(%{row_expr | elements: elements})
+    end
+  end
+
+  defp reduce_node(
+         %Func{name: "coalesce", variadic_arg: 0, args: [%Array{} = variadic_args]} = func
+       ) do
+    case reduce_coalesce_elements(variadic_args.elements, []) do
+      {:ok, {:const, const}} ->
+        {:ok, const}
+
+      {:ok, {:elements, elements}} ->
+        {:ok, %{func | args: [%{variadic_args | elements: elements}]}}
+
+      {:ok, :all_nil} ->
+        {:ok, %Const{type: func.type, location: func.location, value: nil}}
+
+      {:error, {_loc, _message}} = error ->
+        error
+    end
+  end
+
+  defp reduce_node(%Func{args: args} = func) do
+    with {:ok, args} <- Utils.map_while_ok(args, &reduce_node/1) do
+      do_maybe_reduce(%{func | args: args})
+    end
+  end
+
+  defp reduce_coalesce_elements([], _reduced_prefix), do: {:ok, :all_nil}
+
+  defp reduce_coalesce_elements([arg | rest], reduced_prefix) do
+    with {:ok, reduced_arg} <- reduce_node(arg) do
+      case reduced_arg do
+        %Const{value: nil} ->
+          reduce_coalesce_elements(rest, [reduced_arg | reduced_prefix])
+
+        %Const{} = const ->
+          {:ok, {:const, const}}
+
+        other ->
+          {:ok, {:elements, Enum.reverse([other | reduced_prefix]) ++ rest}}
+      end
+    end
   end
 
   @spec node_to_ast(struct(), map(), map(), map()) ::

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -77,10 +77,10 @@ defmodule Electric.Replication.Eval.Parser do
       :name,
       strict?: true,
       immutable?: true,
-      # Variadic arguments are represented as a single packed array-like AST node at this position.
-      # This is also reused internally for helpers such as array indexing, where one argument is
-      # already list-like and should be passed through as a single value.
+      # Allows treating one argument position as an array-mapped input without introducing
+      # anonymous function nodes into the eval AST.
       map_over_array_in_pos: nil,
+      # Variadic arguments are packed into a single array-like AST node at this position.
       variadic_arg: nil,
       location: 0
     ]
@@ -1129,10 +1129,23 @@ defmodule Electric.Replication.Eval.Parser do
   end
 
   defp handle_function_call(name, args, location, env, opts \\ []) do
+    if Keyword.get(opts, :explicit_variadic?, false) do
+      {:error, {location, "explicit VARIADIC function calls are not currently supported"}}
+    else
+      do_handle_function_call(name, args, location, env)
+    end
+  end
+
+  @spec do_handle_function_call(
+          String.t(),
+          list(tree_part() | UnknownConst.t()),
+          non_neg_integer(),
+          Env.t()
+        ) ::
+          {:ok, tree_part()} | {:error, {non_neg_integer(), String.t()}}
+  defp do_handle_function_call(name, args, location, env) do
     with {:ok, choices} <-
-           find_available_functions(name, length(args), location, env,
-             explicit_variadic?: Keyword.get(opts, :explicit_variadic?, false)
-           ),
+           find_available_functions(name, length(args), location, env),
          {:ok, concrete} <- Lookups.pick_concrete_function_overload(choices, args, env),
          {:ok, args} <- cast_unknowns(args, concrete.args, env),
          {:ok, args} <- cast_implicit(args, concrete.args, env) do
@@ -1152,29 +1165,26 @@ defmodule Electric.Replication.Eval.Parser do
     end
   end
 
-  defp find_available_functions(name, arity, location, %{funcs: funcs}, opts) do
+  @spec find_available_functions(String.t(), non_neg_integer(), non_neg_integer(), Env.t()) ::
+          {:ok, list(map())} | {:error, {non_neg_integer(), String.t()}}
+  defp find_available_functions(name, arity, location, %{funcs: funcs}) do
     exact_choices = Map.get(funcs, {name, arity}, [])
-    explicit_variadic? = Keyword.get(opts, :explicit_variadic?, false)
 
     variadic_choices =
-      if explicit_variadic? do
-        []
-      else
-        funcs
-        |> Enum.flat_map(fn
-          {{^name, candidate_arity}, overloads} when candidate_arity < arity ->
-            overloads
-            |> Enum.filter(&(&1[:variadic_arg] == candidate_arity - 1))
-            |> Enum.map(&Lookups.expand_variadic_function_overload(&1, arity))
+      funcs
+      |> Enum.flat_map(fn
+        {{^name, candidate_arity}, overloads} when candidate_arity < arity ->
+          overloads
+          |> Enum.filter(&(&1[:variadic_arg] == candidate_arity - 1))
+          |> Enum.map(&Lookups.expand_variadic_function_overload(&1, arity))
 
-          _ ->
-            []
-        end)
-      end
+        _ ->
+          []
+      end)
 
     choices =
       (exact_choices ++ variadic_choices)
-      |> Enum.sort_by(&if is_nil(&1[:variadic_arg]), do: 0, else: 1)
+      |> Enum.sort_by(&(not is_nil(&1[:variadic_arg])))
 
     case choices do
       [] -> {:error, {location, "unknown or unsupported function #{name}/#{arity}"}}
@@ -1380,7 +1390,12 @@ defmodule Electric.Replication.Eval.Parser do
         variadic_arg ->
           {fixed_args, variadic_args} = Enum.split(args, variadic_arg)
           variadic_type = Enum.at(concrete.args, variadic_arg)
-          variadic_location = variadic_args |> List.first() |> Map.get(:location, 0)
+
+          variadic_location =
+            case variadic_args do
+              [%{location: location} | _] -> location
+              [] -> 0
+            end
 
           fixed_args ++
             [

--- a/packages/sync-service/lib/electric/replication/eval/runner.ex
+++ b/packages/sync-service/lib/electric/replication/eval/runner.ex
@@ -1,6 +1,5 @@
 defmodule Electric.Replication.Eval.Runner do
   require Logger
-  alias Electric.Replication.Eval.Walker
   alias Electric.Utils
   alias Electric.Replication.Eval.Expr
   alias Electric.Replication.Eval.Env
@@ -52,22 +51,52 @@ defmodule Electric.Replication.Eval.Runner do
   """
   @spec execute(Expr.t(), map()) :: {:ok, term()} | {:error, {%Func{}, [term()]}}
   def execute(%Expr{} = tree, ref_values) do
-    Walker.fold(tree.eval, &do_execute/3, ref_values)
+    execute_node(tree.eval, ref_values)
   catch
     {:could_not_compute, func} -> {:error, func}
   end
 
-  defp do_execute(%Const{value: value}, _, _), do: {:ok, value}
-  defp do_execute(%Ref{path: path}, _, refs), do: {:ok, Map.fetch!(refs, path)}
-  defp do_execute(%Array{}, %{elements: elements}, _), do: {:ok, elements}
-  defp do_execute(%RowExpr{}, %{elements: elements}, _), do: {:ok, List.to_tuple(elements)}
+  defp execute_node(%Const{value: value}, _), do: {:ok, value}
+  defp execute_node(%Ref{path: path}, refs), do: {:ok, Map.fetch!(refs, path)}
 
-  defp do_execute(%Func{strict?: false} = func, %{args: args}, _) do
+  defp execute_node(%Array{elements: elements}, refs) do
+    Utils.map_while_ok(elements, &execute_node(&1, refs))
+  end
+
+  defp execute_node(%RowExpr{elements: elements}, refs) do
+    with {:ok, elements} <- Utils.map_while_ok(elements, &execute_node(&1, refs)) do
+      {:ok, List.to_tuple(elements)}
+    end
+  end
+
+  defp execute_node(
+         %Func{name: "coalesce", variadic_arg: 0, args: [%Array{elements: elements}]},
+         refs
+       ) do
+    execute_coalesce(elements, refs)
+  end
+
+  defp execute_node(%Func{args: args} = func, refs) do
+    with {:ok, args} <- Utils.map_while_ok(args, &execute_node(&1, refs)) do
+      apply_func(func, args)
+    end
+  end
+
+  defp execute_coalesce([], _refs), do: {:ok, nil}
+
+  defp execute_coalesce([arg | rest], refs) do
+    case execute_node(arg, refs) do
+      {:ok, nil} -> execute_coalesce(rest, refs)
+      {:ok, value} -> {:ok, value}
+    end
+  end
+
+  defp apply_func(%Func{strict?: false} = func, args) do
     # For a non-strict function, we don't care about nil values in the arguments
     {:ok, try_apply(func, args)}
   end
 
-  defp do_execute(%Func{strict?: true, variadic_arg: vararg_position} = func, %{args: args}, _) do
+  defp apply_func(%Func{strict?: true, variadic_arg: vararg_position} = func, args) do
     has_nils? =
       case vararg_position do
         nil -> Enum.any?(args, &is_nil/1)

--- a/packages/sync-service/lib/electric/replication/eval/walker.ex
+++ b/packages/sync-service/lib/electric/replication/eval/walker.ex
@@ -211,6 +211,14 @@ defimpl Electric.Walkable, for: PgQuery.FuncCall do
   def children(%PgQuery.FuncCall{args: args}), do: [args: args]
 end
 
+defimpl Electric.Walkable, for: PgQuery.CoalesceExpr do
+  def children(%PgQuery.CoalesceExpr{args: args}), do: [args: args]
+end
+
+defimpl Electric.Walkable, for: PgQuery.MinMaxExpr do
+  def children(%PgQuery.MinMaxExpr{args: args}), do: [args: args]
+end
+
 defimpl Electric.Walkable, for: PgQuery.A_Expr do
   def children(%PgQuery.A_Expr{lexpr: lexpr, rexpr: rexpr, name: name}),
     do: [lexpr: lexpr, rexpr: rexpr, name: name]

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -290,6 +290,11 @@ defmodule Electric.Replication.Eval.ParserTest do
              } = result
     end
 
+    test "should stop reducing coalesce after the first non-null constant" do
+      assert {:ok, %Expr{eval: %Const{type: :int4, value: 1}}} =
+               Parser.parse_and_validate_expression(~S|coalesce(NULL::int4, 1, 1 / 0)|)
+    end
+
     test "should correctly resolve a variadic greatest special form" do
       assert {:ok, %Expr{eval: result}} =
                Parser.parse_and_validate_expression(

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -3,7 +3,7 @@ defmodule Electric.Replication.Eval.ParserTest do
 
   alias Electric.Replication.Eval.Env.ExplicitCasts
   alias Electric.Replication.Eval.Parser
-  alias Electric.Replication.Eval.Parser.{Const, Func, Ref}
+  alias Electric.Replication.Eval.Parser.{Array, Const, Func, Ref}
   alias Electric.Replication.Eval.Env
   alias Electric.Replication.Eval.Expr
 
@@ -256,6 +256,80 @@ defmodule Electric.Replication.Eval.ParserTest do
                )
 
       assert %Func{name: "-", args: [%Ref{path: ["test"], type: :int4}]} = result
+    end
+
+    test "should correctly parse coalesce special form as a variadic function" do
+      assert {:ok, %Expr{eval: result}} =
+               Parser.parse_and_validate_expression(
+                 ~S|coalesce("test", 'fallback')|,
+                 refs: %{["test"] => :text}
+               )
+
+      assert %Func{
+               name: "coalesce",
+               variadic_arg: 0,
+               strict?: false,
+               type: :text,
+               args: [
+                 %Array{
+                   type: {:array, :text},
+                   elements: [
+                     %Ref{path: ["test"], type: :text},
+                     %Const{type: :text, value: "fallback"}
+                   ]
+                 }
+               ]
+             } = result
+    end
+
+    test "should correctly resolve a variadic greatest special form" do
+      assert {:ok, %Expr{eval: result}} =
+               Parser.parse_and_validate_expression(
+                 ~S|greatest("test", 2, '3')|,
+                 refs: %{["test"] => :int4}
+               )
+
+      assert %Func{
+               name: "greatest",
+               variadic_arg: 0,
+               strict?: false,
+               type: :int4,
+               args: [
+                 %Array{
+                   type: {:array, :int4},
+                   elements: [
+                     %Ref{path: ["test"], type: :int4},
+                     %Const{type: :int4, value: 2},
+                     %Const{type: :int4, value: 3}
+                   ]
+                 }
+               ]
+             } = result
+    end
+
+    test "should correctly resolve a variadic least special form" do
+      assert {:ok, %Expr{eval: result}} =
+               Parser.parse_and_validate_expression(
+                 ~S|least("test", 2.0, '3')|,
+                 refs: %{["test"] => :int4}
+               )
+
+      assert %Func{
+               name: "least",
+               variadic_arg: 0,
+               strict?: false,
+               type: :numeric,
+               args: [
+                 %Array{
+                   type: {:array, :numeric},
+                   elements: [
+                     %Ref{path: ["test"], type: :int4},
+                     %Const{type: :numeric, value: 2.0},
+                     %Const{type: :numeric, value: 3.0}
+                   ]
+                 }
+               ]
+             } = result
     end
 
     test "should reduce down immutable function calls that have only constants" do

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -258,6 +258,14 @@ defmodule Electric.Replication.Eval.ParserTest do
       assert %Func{name: "-", args: [%Ref{path: ["test"], type: :int4}]} = result
     end
 
+    test "should reject explicit variadic function calls for now" do
+      assert {:error,
+              "At location 0: explicit VARIADIC function calls are not currently supported"} =
+               Parser.parse_and_validate_expression(
+                 ~S|array_cat(VARIADIC ARRAY[ARRAY[1], ARRAY[2]])|
+               )
+    end
+
     test "should correctly parse coalesce special form as a variadic function" do
       assert {:ok, %Expr{eval: result}} =
                Parser.parse_and_validate_expression(
@@ -330,6 +338,38 @@ defmodule Electric.Replication.Eval.ParserTest do
                  }
                ]
              } = result
+    end
+
+    test "should prefer an exact non-variadic overload over a variadic expansion" do
+      env =
+        Env.empty(
+          funcs: %{
+            {"prefer_exact", 1} => [
+              %{
+                args: [:int4],
+                variadic_arg: 0,
+                returns: :int4,
+                implementation: &List.first/1,
+                name: "variadic"
+              }
+            ],
+            {"prefer_exact", 2} => [
+              %{
+                args: [:int4, :int4],
+                returns: :int4,
+                implementation: &Kernel.+/2,
+                name: "exact"
+              }
+            ]
+          }
+        )
+
+      assert {:ok, %Expr{eval: %Func{name: "exact"}}} =
+               Parser.parse_and_validate_expression(
+                 ~S|prefer_exact("test", 2)|,
+                 refs: %{["test"] => :int4},
+                 env: env
+               )
     end
 
     test "should reduce down immutable function calls that have only constants" do

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -184,6 +184,43 @@ defmodule Electric.Replication.Eval.RunnerTest do
                |> Runner.execute(%{["x"] => [[[3, 4]]]})
     end
 
+    test "supports coalesce as a variadic function" do
+      expr =
+        ~S|coalesce("value", 'fallback', 'unused')|
+        |> Parser.parse_and_validate_expression!(refs: %{["value"] => :text})
+
+      assert {:ok, "fallback"} = Runner.execute(expr, %{["value"] => nil})
+      assert {:ok, "present"} = Runner.execute(expr, %{["value"] => "present"})
+    end
+
+    test "supports greatest as a variadic function and ignores nil arguments" do
+      expr =
+        ~S|greatest("value", 2, 3, NULL::int4)|
+        |> Parser.parse_and_validate_expression!(refs: %{["value"] => :int4})
+
+      assert {:ok, 3} = Runner.execute(expr, %{["value"] => nil})
+      assert {:ok, 4} = Runner.execute(expr, %{["value"] => 4})
+
+      assert {:ok, nil} =
+               ~S|greatest(NULL::int4, NULL::int4)|
+               |> Parser.parse_and_validate_expression!()
+               |> Runner.execute(%{})
+    end
+
+    test "supports least as a variadic function for datetime values" do
+      expr =
+        ~S|least("value", date '2024-01-02', NULL::date)|
+        |> Parser.parse_and_validate_expression!(refs: %{["value"] => :date})
+
+      assert {:ok, ~D[2024-01-02]} = Runner.execute(expr, %{["value"] => nil})
+      assert {:ok, ~D[2024-01-01]} = Runner.execute(expr, %{["value"] => ~D[2024-01-01]})
+
+      assert {:ok, nil} =
+               ~S|least(NULL::date, NULL::date)|
+               |> Parser.parse_and_validate_expression!()
+               |> Runner.execute(%{})
+    end
+
     test "subquery" do
       assert {:ok, true} =
                ~S|test IN (SELECT val FROM tester)|

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -193,6 +193,29 @@ defmodule Electric.Replication.Eval.RunnerTest do
       assert {:ok, "present"} = Runner.execute(expr, %{["value"] => "present"})
     end
 
+    test "coalesce short-circuits later arguments" do
+      expr =
+        ~S|coalesce("value", 1 / "divisor")|
+        |> Parser.parse_and_validate_expression!(
+          refs: %{["value"] => :int4, ["divisor"] => :int4}
+        )
+
+      assert {:ok, 10} = Runner.execute(expr, %{["value"] => 10, ["divisor"] => 0})
+
+      assert {:error, _} =
+               Runner.execute(expr, %{["value"] => nil, ["divisor"] => 0})
+    end
+
+    test "coalesce skips unreachable constant branches after a non-null fallback" do
+      expr =
+        ~S|coalesce("value", 1, 1 / "divisor")|
+        |> Parser.parse_and_validate_expression!(
+          refs: %{["value"] => :int4, ["divisor"] => :int4}
+        )
+
+      assert {:ok, 1} = Runner.execute(expr, %{["value"] => nil, ["divisor"] => 0})
+    end
+
     test "supports greatest as a variadic function and ignores nil arguments" do
       expr =
         ~S|greatest("value", 2, 3, NULL::int4)|


### PR DESCRIPTION
## Summary
- add variadic function support to the eval stack, including `defpostgres` definitions and overload lookup support
- lower `coalesce`, `greatest`, and `least` through the shared function parsing and execution path
- tighten variadic parsing behavior around explicit `VARIADIC` calls and precedence between exact and variadic overloads
- implement true `coalesce` short-circuiting in parser reduction and runtime execution

## Testing
- mix test test/electric/replication/eval_test.exs test/electric/replication/eval/*.exs