### PR TITLE
fix(telemetry): remove unused stack-level Prometheus reporter

### DIFF
--- a/.changeset/fix-stack-prometheus-ets-leak.md
+++ b/.changeset/fix-stack-prometheus-ets-leak.md
@@ -1,0 +1,5 @@
+---
+'@core/electric-telemetry': patch
+---
+
+Remove unused stack-level Prometheus reporter to fix unbounded ETS table growth

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -63,10 +63,6 @@ defmodule ElectricTelemetry.StackTelemetry do
         name: :"stack_otel_telemetry_#{stack_id}",
         metrics: metrics
       ),
-      Reporters.Prometheus.child_spec(opts,
-        name: :"stack_prometheus_telemetry_#{stack_id}",
-        metrics: metrics
-      ),
       Reporters.Statsd.child_spec(opts,
         metrics: metrics ++ Reporters.Statsd.router_dispatch_metrics()
       )


### PR DESCRIPTION
## Summary

- Remove the stack-level Prometheus reporter from `StackTelemetry` that was never scraped, causing unbounded ETS table growth (~300 rows/sec under moderate load)
- The `/metrics` endpoint only scrapes the application-level reporter; stack metrics continue to be exported via OTEL, StatsD, and call-home reporters

Closes #4123

## Test plan

- [x] Verify the sync service starts without errors
- [x] Verify `/metrics` endpoint still returns application-level metrics
- [x] Confirm no `stack_prometheus_telemetry_*` ETS tables are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)