### PR TITLE
fix(sync-service): handle deleted ETS buffer table in storage read path

### DIFF
--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage.ex
@@ -519,8 +519,8 @@ defmodule Electric.ShapeCache.PureFileStorage do
 
   def terminate(writer_state(ets: ets_table, opts: opts) = state) do
     close_all_files(state)
-    try(do: :ets.delete(ets_table), rescue: (_ -> true))
     clean_shape_ets_entry(opts)
+    try(do: :ets.delete(ets_table), rescue: (_ -> true))
   end
 
   # remove cached values not needed for the read path
@@ -1145,7 +1145,10 @@ defmodule Electric.ShapeCache.PureFileStorage do
           LogOffset.t_tuple() | nil
         ) :: {list(), LogOffset.t_tuple() | nil}
   defp read_range_from_ets_cache(ets, min, {max_tx, max_op} = max, acc, last_offset) do
-    case :ets.next_lookup(ets, min) do
+    case safe_next_lookup(ets, min) do
+      :ets_dead ->
+        {Enum.reverse(acc), last_offset}
+
       :"$end_of_table" ->
         {Enum.reverse(acc), last_offset}
 
@@ -1155,6 +1158,14 @@ defmodule Electric.ShapeCache.PureFileStorage do
       {new_min, [{_, item}]} ->
         read_range_from_ets_cache(ets, new_min, max, [item | acc], new_min)
     end
+  end
+
+  # The owning Consumer's buffer ETS table may be destroyed during terminate.
+  # Falling back is safe because terminate flushes to disk before deleting.
+  defp safe_next_lookup(ets, min) do
+    :ets.next_lookup(ets, min)
+  rescue
+    ArgumentError -> :ets_dead
   end
 
   defp stream_from_disk(%__MODULE__{}, min_offset, max_offset, _)

--- a/packages/sync-service/test/electric/shape_cache/pure_file_storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/pure_file_storage_test.exs
@@ -1173,6 +1173,101 @@ defmodule Electric.ShapeCache.PureFileStorageTest do
 
       PureFileStorage.terminate(writer)
     end
+
+    test "reader falls back to disk when ETS table is deleted (pure ETS path)", %{
+      writer: writer,
+      opts: opts,
+      stack_id: stack_id
+    } do
+      import Electric.ShapeCache.PureFileStorage.SharedRecords
+
+      writer =
+        PureFileStorage.append_to_log!(
+          [{LogOffset.new(10, 0), "test_key", :insert, ~S|{"test": 1}|}],
+          writer
+        )
+
+      assert_receive {Storage, {PureFileStorage, :perform_scheduled_flush, [0]}}
+      _writer = PureFileStorage.perform_scheduled_flush(writer, 0)
+
+      stack_ets = PureFileStorage.stack_ets(stack_id)
+      [fresh_meta] = :ets.lookup(stack_ets, @shape_handle)
+      assert storage_meta(ets_table: ets_ref) = fresh_meta
+
+      # Stale last_persisted <= min_offset forces the pure ETS branch in stream_main_log
+      stale_meta =
+        storage_meta(fresh_meta,
+          last_persisted_offset: LogOffset.last_before_real_offsets(),
+          last_seen_txn_offset: LogOffset.new(10, 0)
+        )
+
+      :ets.insert(stack_ets, stale_meta)
+      :ets.delete(ets_ref)
+
+      result =
+        PureFileStorage.get_log_stream(
+          LogOffset.new(5, 0),
+          LogOffset.last(),
+          opts
+        )
+        |> Enum.to_list()
+
+      assert result == [~S|{"test": 1}|]
+
+      PureFileStorage.cleanup!(opts)
+    end
+
+    test "reader falls back to disk when ETS table is deleted (mixed disk + ETS path)", %{
+      writer: writer,
+      opts: opts,
+      stack_id: stack_id
+    } do
+      import Electric.ShapeCache.PureFileStorage.SharedRecords
+
+      writer =
+        PureFileStorage.append_to_log!(
+          [{LogOffset.new(10, 0), "test_key", :insert, ~S|{"test": 1}|}],
+          writer
+        )
+
+      assert_receive {Storage, {PureFileStorage, :perform_scheduled_flush, [0]}}
+      writer = PureFileStorage.perform_scheduled_flush(writer, 0)
+
+      writer =
+        PureFileStorage.append_to_log!(
+          [{LogOffset.new(11, 0), "test_key2", :insert, ~S|{"test": 2}|}],
+          writer
+        )
+
+      assert_receive {Storage, {PureFileStorage, :perform_scheduled_flush, [1]}}
+      _writer = PureFileStorage.perform_scheduled_flush(writer, 1)
+
+      stack_ets = PureFileStorage.stack_ets(stack_id)
+      [fresh_meta] = :ets.lookup(stack_ets, @shape_handle)
+      assert storage_meta(ets_table: ets_ref) = fresh_meta
+
+      # Stale last_persisted between the two offsets forces the mixed disk+ETS branch
+      stale_meta =
+        storage_meta(fresh_meta,
+          last_persisted_offset: LogOffset.new(10, 0),
+          last_seen_txn_offset: LogOffset.new(11, 0)
+        )
+
+      :ets.insert(stack_ets, stale_meta)
+      :ets.delete(ets_ref)
+
+      result =
+        PureFileStorage.get_log_stream(
+          LogOffset.new(0, 0),
+          LogOffset.last(),
+          opts
+        )
+        |> Enum.to_list()
+
+      assert result == [~S|{"test": 1}|, ~S|{"test": 2}|]
+
+      PureFileStorage.cleanup!(opts)
+    end
   end
 
   describe "remove_unnested_storage/1" do


### PR DESCRIPTION
## Summary

During deployments, we observed an onslaught of `ArgumentError` crashes when the stack is trying to get ready:

```
** (ArgumentError) errors were found at the given arguments:
  * 1st argument: the table identifier does not refer to an existing ETS table
    (stdlib) :ets.next_lookup(#Reference<...>, {51460894745528, 0})
    pure_file_storage.ex:1148: Electric.ShapeCache.PureFileStorage.read_range_from_ets_cache/5
    pure_file_storage.ex:1076: Electric.ShapeCache.PureFileStorage.stream_main_log/3
```

### Root cause

Each shape's Consumer process owns an unnamed ETS buffer table for in-memory log data. The table's TID (reference) is stored in the stack-wide named ETS table so that HTTP reader processes can look it up via `for_shape/2` and `read_or_initialize_metadata/2`.

During stack restarts, Consumer processes terminate (or crash and restart), which destroys their buffer ETS tables. HTTP requests that are in-flight — or arrive during this window — can capture a stale TID and crash when they attempt `:ets.next_lookup` on it.

### Race windows identified

1. **Terminate ordering gap** — Between `:ets.delete(buffer_ets)` and `clean_shape_ets_entry` (which nils the reference in stack ETS), new readers could look up the dead TID from stack ETS.
2. **Already-captured TID** — Even after the reference is nil'd, readers that captured the TID *before* terminate started still hold the stale reference in a local variable.
3. **Startup churn** — During stack initialization many Consumers start simultaneously and some may fail/restart, creating repeated windows where stale TIDs exist in the stack ETS.

### Fix

- **`safe_next_lookup/2`**: Wraps `:ets.next_lookup` in a rescue for `ArgumentError`, returning `:ets_dead`. The recursive `read_range_from_ets_cache/5` handles this the same as `:"$end_of_table"` — returning whatever was accumulated so far. The callers at both call sites (pure ETS path and mixed disk+ETS path) already detect empty/partial reads and fall back to reading from disk. The rescue is isolated to this leaf function specifically to **preserve tail call optimization** in the recursive reader.
- **Reversed terminate ordering**: `clean_shape_ets_entry` (which nils the `ets_table` field) now runs *before* `:ets.delete(buffer_ets)`, closing race window #1 for new readers — they see `ets_table: nil` and hit the existing nil guard at `read_range_from_ets_cache(nil, _, _)`. Git history confirms the original intent was nil-before-delete (commit 5677df71), and the current ordering was an artifact of successive refactors.

### Data correctness analysis

The key invariant that makes this safe: **`terminate` calls `close_all_files` (which flushes buffered data to disk via `IO.binwrite` + `:file.datasync`) *before* touching the ETS table.** After terminate, all data that was in the buffer ETS is on disk.

The existing code already handles the semantically identical case of "ETS cleared by a concurrent flush" — comments at lines 1060 and 1079 describe this exact pattern. A deleted table is the same situation: data was in ETS, now it's on disk.

Failure scenario analysis:

| Scenario | Wrong data? | Wrong order? | Duplicates? | Missing data? |
|---|---|---|---|---|
| Clean terminate (flush succeeds) | No | No | No | No — chunk index finds flushed data |
| Partial ETS read before crash | No | No | No | No — partial data discarded, full range re-read from disk |
| Consumer killed without terminate | No | No | No | Yes — tail data lost (inherent to unclean kill, not introduced by this fix) |
| No chunk index entry yet | No | No | No | Yes — empty response, client retries |

In all cases: data returned is correct and ordered. The only failure mode is returning less data than the absolute latest, which triggers client retry.

## Test plan

- [x] New test: reader falls back to disk when ETS table is deleted (pure ETS path)
- [x] New test: reader falls back to disk when ETS table is deleted (mixed disk + ETS path)
- [x] Both tests fail with `ArgumentError` before the fix, pass after
- [x] Existing "ETS read/write race condition" tests still pass
- [x] Full `test/electric/shape_cache/` suite passes (181 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)