### PR TITLE
Change form event type: React.FormEvent to React.SubmitEvent

### DIFF
--- a/examples/tanstack-db-web-starter/src/routes/login.tsx
+++ b/examples/tanstack-db-web-starter/src/routes/login.tsx
@@ -14,7 +14,7 @@ function Layout() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(``)
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault()
     setIsLoading(true)
     setError(``)


### PR DESCRIPTION
```
FormEvent is deprecated.
interface React.FormEvent<T = Element>
@deprecated
FormEvent doesn't actually exist. You probably meant to use ChangeEvent, InputEvent, SubmitEvent, or just SyntheticEvent instead depending on the event type.
```