### PR TITLE
Guard report_shape_db_stats against :noproc during deployments

### DIFF
--- a/.changeset/fix-report-shape-db-stats-noproc.md
+++ b/.changeset/fix-report-shape-db-stats-noproc.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Guard `report_shape_db_stats` telemetry poller against `:noproc` exits when the shape status GenServer terminates during stack restarts, mirroring the existing handling in `report_retained_wal_size`.

--- a/packages/sync-service/lib/electric/stack_supervisor/telemetry.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor/telemetry.ex
@@ -138,15 +138,20 @@ defmodule Electric.StackSupervisor.Telemetry do
   end
 
   def report_shape_db_stats(stack_id, _telemetry_opts) do
-    case Electric.ShapeCache.ShapeStatus.ShapeDb.statistics(stack_id) do
-      {:ok, stats} ->
-        Electric.Telemetry.OpenTelemetry.execute(
-          [:electric, :shape_db, :sqlite],
-          stats,
-          %{stack_id: stack_id}
-        )
+    try do
+      case Electric.ShapeCache.ShapeStatus.ShapeDb.statistics(stack_id) do
+        {:ok, stats} ->
+          Electric.Telemetry.OpenTelemetry.execute(
+            [:electric, :shape_db, :sqlite],
+            stats,
+            %{stack_id: stack_id}
+          )
 
-      _ ->
+        _ ->
+          :ok
+      end
+    catch
+      :exit, {:noproc, _} ->
         :ok
     end
   end


### PR DESCRIPTION
## Summary

`Electric.StackSupervisor.Telemetry.report_shape_db_stats/2` calls `ShapeDb.statistics/1`, which resolves the GenServer pid and then issues a `GenServer.call`. During stack restarts the underlying server can exit between those two steps, producing an uncaught `:exit, :noproc` from the telemetry poller and flooding Sentry with errors on every deployment.

The sibling function `report_retained_wal_size` already handles this race. This change mirrors its `try/catch :exit, {:noproc, _}` pattern. Surgical, no behavioural change on the happy path.

Refs electric-sql/stratovolt#1452.

## Test plan

- [x] `mix compile --warnings-as-errors` is clean
- [x] `mix test test/electric/stack_supervisor_test.exs` passes