### PR TITLE
Move shape_handle into Logger metadata for No-consumer error

### DIFF
--- a/.changeset/fix-no-consumer-log-shape-handle.md
+++ b/.changeset/fix-no-consumer-log-shape-handle.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Emit `shape_handle` as Logger metadata (instead of interpolating it into the message body) for the "No consumer process when waiting on initial snapshot creation" error. This keeps the message text static so Sentry can deduplicate these events properly during incidents.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -189,7 +189,8 @@ defmodule Electric.ShapeCache do
                     ])
 
                     Logger.error(
-                      "No consumer process when waiting on initial snapshot creation for #{shape_handle}"
+                      "No consumer process when waiting on initial snapshot creation",
+                      shape_handle: shape_handle
                     )
 
                     {:error, :unknown}

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1070,11 +1070,8 @@ defmodule Electric.ShapeCacheTest do
 
       assert String.contains?(
                log,
-               "[error] No consumer process when waiting on initial snapshot creation"
+               "shape_handle=#{shape_handle} [error] No consumer process when waiting on initial snapshot creation"
              )
-
-      assert String.contains?(log, shape_handle),
-             "expected shape_handle #{shape_handle} to be present in log metadata"
 
       assert_receive {ShapeCache.ShapeCleaner, :cleanup, ^shape_handle}
       assert_receive {ShapeCache.ShapeCleaner, :cleanup, ^subshape_handle}

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1073,6 +1073,9 @@ defmodule Electric.ShapeCacheTest do
                "[error] No consumer process when waiting on initial snapshot creation"
              )
 
+      assert String.contains?(log, shape_handle),
+             "expected shape_handle #{shape_handle} to be present in log metadata"
+
       assert_receive {ShapeCache.ShapeCleaner, :cleanup, ^shape_handle}
       assert_receive {ShapeCache.ShapeCleaner, :cleanup, ^subshape_handle}
     end

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1070,7 +1070,7 @@ defmodule Electric.ShapeCacheTest do
 
       assert String.contains?(
                log,
-               "[error] No consumer process when waiting on initial snapshot creation for #{shape_handle}"
+               "[error] No consumer process when waiting on initial snapshot creation"
              )
 
       assert_receive {ShapeCache.ShapeCleaner, :cleanup, ^shape_handle}


### PR DESCRIPTION
<img alt="vetted by human" src="https://github.com/user-attachments/assets/11a81387-9e4a-4d7c-873e-265062ea2b74"/>
<img alt="ready for review" src="https://github.com/user-attachments/assets/267c675d-da51-47c9-9581-6d156a63b7e2"/>

## Summary

Replace the interpolated `shape_handle` in the `Logger.error("No consumer process when waiting on initial snapshot creation for #{shape_handle}")` call with a static message plus `shape_handle` as structured Logger metadata.

## Why

Including the shape handle directly in the error message is unnecessary — the handle is better logged as a metadata item. The `shape_handle` key is already in the stratovolt `:default_formatter` metadata list and mapped to the `shape.handle` OTEL attribute, so the handle remains visible in both plain-text logs and OTEL-exported logs.

This also improves log aggregation — static messages are easier to group and search for.

Fixes https://github.com/electric-sql/stratovolt/issues/1457.

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] Existing `shape_cache_test.exs` assertion updated to match the new static message