### PR TITLE
feat(telemetry): export admission_control.limit metric

### DIFF
--- a/.changeset/export-admission-control-limit.md
+++ b/.changeset/export-admission-control-limit.md
@@ -1,0 +1,5 @@
+---
+'@core/electric-telemetry': patch
+---
+
+Export `electric.admission_control.limit` metric so dashboards can plot fill percentage (`acquire.current / limit`) by `kind`.

--- a/.changeset/export-admission-control-limit.md
+++ b/.changeset/export-admission-control-limit.md
@@ -2,4 +2,4 @@
 '@core/electric-telemetry': patch
 ---
 
-Export `electric.admission_control.limit` metric so dashboards can plot fill percentage (`acquire.current / limit`) by `kind`.
+Export `electric.admission_control.acquire.limit` metric so dashboards can plot fill percentage (`acquire.current / acquire.limit`) by `kind`.

--- a/.changeset/export-admission-control-limit.md
+++ b/.changeset/export-admission-control-limit.md
@@ -1,5 +1,6 @@
 ---
 '@core/electric-telemetry': patch
+'@core/sync-service': patch
 ---
 
-Export `electric.admission_control.acquire.limit` metric so dashboards can plot fill percentage (`acquire.current / acquire.limit`) by `kind`.
+Export `electric.admission_control.acquire.limit` and `electric.admission_control.reject.limit` metrics so dashboards can plot fill percentage (`acquire.current / acquire.limit`) and over-limit pressure by `kind`.

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -114,8 +114,7 @@ defmodule ElectricTelemetry.StackTelemetry do
       last_value("electric.connection.consumers_ready.total"),
       last_value("electric.connection.consumers_ready.failed_to_recover"),
       last_value("electric.admission_control.acquire.current", tags: [:kind]),
-      last_value("electric.admission_control.limit",
-        event_name: [:electric, :admission_control, :acquire],
+      last_value("electric.admission_control.acquire.limit",
         measurement: fn _measurements, metadata -> metadata.limit end,
         tags: [:kind]
       ),

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -114,11 +114,9 @@ defmodule ElectricTelemetry.StackTelemetry do
       last_value("electric.connection.consumers_ready.total"),
       last_value("electric.connection.consumers_ready.failed_to_recover"),
       last_value("electric.admission_control.acquire.current", tags: [:kind]),
-      last_value("electric.admission_control.acquire.limit",
-        measurement: fn _measurements, metadata -> metadata.limit end,
-        tags: [:kind]
-      ),
+      last_value("electric.admission_control.acquire.limit", tags: [:kind]),
       sum("electric.admission_control.reject.count", tags: [:kind]),
+      last_value("electric.admission_control.reject.limit", tags: [:kind]),
       distribution("electric.shape_log_collector.transaction.affected_shape_count")
       | additional_metrics(telemetry_opts)
     ]

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -114,6 +114,11 @@ defmodule ElectricTelemetry.StackTelemetry do
       last_value("electric.connection.consumers_ready.total"),
       last_value("electric.connection.consumers_ready.failed_to_recover"),
       last_value("electric.admission_control.acquire.current", tags: [:kind]),
+      last_value("electric.admission_control.limit",
+        event_name: [:electric, :admission_control, :acquire],
+        measurement: fn _measurements, metadata -> metadata.limit end,
+        tags: [:kind]
+      ),
       sum("electric.admission_control.reject.count", tags: [:kind]),
       distribution("electric.shape_log_collector.transaction.affected_shape_count")
       | additional_metrics(telemetry_opts)

--- a/packages/sync-service/lib/electric/admission_control.ex
+++ b/packages/sync-service/lib/electric/admission_control.ex
@@ -91,13 +91,12 @@ defmodule Electric.AdmissionControl do
       # Emit telemetry event
       :telemetry.execute(
         [:electric, :admission_control, :reject],
-        %{count: 1},
+        %{count: 1, limit: max_concurrent},
         %{
           stack_id: stack_id,
           reason: :overloaded,
           kind: kind,
-          current: current,
-          limit: max_concurrent
+          current: current
         }
       )
 
@@ -107,8 +106,8 @@ defmodule Electric.AdmissionControl do
       # Emit telemetry for current concurrency level
       :telemetry.execute(
         [:electric, :admission_control, :acquire],
-        %{count: 1, current: current},
-        %{stack_id: stack_id, kind: kind, limit: max_concurrent}
+        %{count: 1, current: current, limit: max_concurrent},
+        %{stack_id: stack_id, kind: kind}
       )
 
       :ok

--- a/packages/sync-service/test/electric/admission_control_test.exs
+++ b/packages/sync-service/test/electric/admission_control_test.exs
@@ -232,8 +232,8 @@ defmodule Electric.AdmissionControlTest do
 
       assert measurements.count == 1
       assert measurements.current == 1
+      assert measurements.limit == 10
       assert metadata.kind == :initial
-      assert metadata.limit == 10
 
       :telemetry.detach(handler_id)
     end
@@ -278,10 +278,10 @@ defmodule Electric.AdmissionControlTest do
                       %{stack_id: ^stack_id} = metadata}
 
       assert measurements.count == 1
+      assert measurements.limit == 2
       assert metadata.kind == :initial
       assert metadata.reason == :overloaded
       assert metadata.current == 3
-      assert metadata.limit == 2
 
       :telemetry.detach(handler_id)
     end


### PR DESCRIPTION
<img alt="vetted by human" src="https://github.com/user-attachments/assets/11a81387-9e4a-4d7c-873e-265062ea2b74"/>
<img alt="ready for review" src="https://github.com/user-attachments/assets/267c675d-da51-47c9-9581-6d156a63b7e2"/>

## Summary

- Moves `limit` from event metadata into measurements in `Electric.AdmissionControl` for both `[:electric, :admission_control, :acquire]` and `[:electric, :admission_control, :reject]` events.
- Exports two new `last_value` metrics tagged by `:kind` in `StackTelemetry`:
  - `electric.admission_control.acquire.limit`
  - `electric.admission_control.reject.limit`
- With the limit now exported alongside `acquire.current`, the "Electric — Admission Control" dashboard (stratovolt#1467) can plot fill percentage = `acquire.current / acquire.limit` per kind.

Closes electric-sql/stratovolt#1471

## Test plan

- [x] `mix test` in `packages/electric-telemetry` (99 tests pass)
- [x] `mix test test/electric/admission_control_test.exs` in `packages/sync-service` (11 tests pass)
- [ ] Verify `electric.admission_control.acquire.limit` and `electric.admission_control.reject.limit` columns appear in the `admin-electric` / `electric-region` datasets on Honeycomb after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)