### PR TITLE
Centralize telemetry collector error handling via Poller.safe_invoke/3

### DIFF
--- a/.changeset/telemetry-poller-safe-invoke.md
+++ b/.changeset/telemetry-poller-safe-invoke.md
@@ -1,0 +1,8 @@
+---
+'@core/electric-telemetry': patch
+'@core/sync-service': patch
+---
+
+Wrap telemetry-poller MFAs in `ElectricTelemetry.Poller.safe_invoke/3` so that transient collector failures (`:noproc`, `:timeout`, `:shutdown`/`:normal` exits, `ArgumentError` from not-yet-created ETS tables) no longer cause `:telemetry_poller` to permanently remove the measurement from its polling list. Unexpected errors are now logged as warnings with the offending MFA and the collector keeps being polled on subsequent ticks. Strips now-redundant defensive `try/catch` / `with`-fallthrough code from `count_shapes/2` and `report_retained_wal_size/3`.
+
+Note: user-supplied periodic measurement functions no longer have exceptions propagated up to `:telemetry_poller`'s own error logger — they are caught and logged via `ElectricTelemetry.Poller` instead.

--- a/.changeset/telemetry-poller-safe-invoke.md
+++ b/.changeset/telemetry-poller-safe-invoke.md
@@ -3,6 +3,6 @@
 '@core/sync-service': patch
 ---
 
-Wrap telemetry-poller MFAs in `ElectricTelemetry.Poller.safe_invoke/3` so that transient collector failures (`:noproc`, `:timeout`, `:shutdown`/`:normal` exits, `ArgumentError` from not-yet-created ETS tables) no longer cause `:telemetry_poller` to permanently remove the measurement from its polling list. Unexpected errors are now logged as warnings with the offending MFA and the collector keeps being polled on subsequent ticks. Strips now-redundant defensive `try/catch` / `with`-fallthrough code from `count_shapes/2` and `report_retained_wal_size/3`.
+Wrap telemetry-poller MFAs in `ElectricTelemetry.Poller.safe_invoke/3` so that transient collector failures (`:noproc`, `:timeout`, `:shutdown`/`:normal` exits, `ArgumentError` from not-yet-created ETS tables) no longer cause `:telemetry_poller` to permanently remove the measurement from its polling list. Unexpected errors are now logged as warnings with the offending MFA and the collector keeps being polled on subsequent ticks. Strips now-redundant defensive `try/catch` / `with`-fallthrough code from individual collectors.
 
 Note: user-supplied periodic measurement functions no longer have exceptions propagated up to `:telemetry_poller`'s own error logger — they are caught and logged via `ElectricTelemetry.Poller` instead.

--- a/packages/electric-telemetry/lib/electric/telemetry/poller.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/poller.ex
@@ -1,4 +1,6 @@
 defmodule ElectricTelemetry.Poller do
+  require Logger
+
   @callback builtin_periodic_measurements(map) :: list()
 
   def child_spec(telemetry_opts, poller_opts) do
@@ -29,15 +31,59 @@ defmodule ElectricTelemetry.Poller do
       # These are implemented by telemetry_poller
       f when f in [:memory, :persistent_term, :system_counts, :total_run_queue_lengths] -> [f]
       # Bare function names are assumed to be referring to functions defined in the caller module
-      f when is_atom(f) -> {module, f, [telemetry_opts]}
-      f when is_function(f, 1) -> {__MODULE__, :user_measurement, [f, telemetry_opts]}
-      {m, f, a} when is_atom(m) and is_atom(f) and is_list(a) -> [{m, f, a ++ [telemetry_opts]}]
+      f when is_atom(f) -> [wrap(module, f, [telemetry_opts])]
+      f when is_function(f, 1) -> [wrap(__MODULE__, :user_measurement, [f, telemetry_opts])]
+      {m, f, a} when is_atom(m) and is_atom(f) and is_list(a) -> [wrap(m, f, a ++ [telemetry_opts])]
     end)
   end
 
   def periodic_measurements(telemetry_opts, module),
-    do: module.builtin_periodic_measurements(telemetry_opts)
+    do: Enum.map(module.builtin_periodic_measurements(telemetry_opts), &wrap_mfa/1)
+
+  defp wrap_mfa({m, f, a}), do: wrap(m, f, a)
+  defp wrap_mfa(other), do: other
+
+  defp wrap(m, f, a), do: {__MODULE__, :safe_invoke, [m, f, a]}
 
   # Helper function to enable telemetry_poller to call a user-provided anonymous function
   def user_measurement(f, telemetry_opts), do: f.(telemetry_opts)
+
+  @doc """
+  Invoke a periodic measurement MFA, absorbing common failure modes.
+
+  `:telemetry_poller` removes a measurement permanently from its polling list
+  after the first failure. Wrapping every MFA in `safe_invoke/3` prevents that:
+  transient errors (GenServer restart races, ETS tables not yet created, DB
+  unavailability) are logged as warnings and swallowed so the measurement keeps
+  being polled on subsequent ticks.
+  """
+  def safe_invoke(m, f, a) do
+    apply(m, f, a)
+    :ok
+  rescue
+    ArgumentError ->
+      :ok
+
+    e ->
+      Logger.warning(
+        "Telemetry collector #{inspect(m)}.#{f}/#{length(a)} crashed: " <>
+          Exception.message(e)
+      )
+
+      :ok
+  catch
+    :exit, {reason, _} when reason in [:noproc, :timeout, :shutdown, :normal] ->
+      :ok
+
+    :exit, reason when reason in [:noproc, :shutdown, :normal] ->
+      :ok
+
+    kind, reason ->
+      Logger.warning(
+        "Telemetry collector #{inspect(m)}.#{f}/#{length(a)} #{kind}: " <>
+          inspect(reason)
+      )
+
+      :ok
+  end
 end

--- a/packages/electric-telemetry/lib/electric/telemetry/poller.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/poller.ex
@@ -27,13 +27,22 @@ defmodule ElectricTelemetry.Poller do
 
   def periodic_measurements(%{periodic_measurements: measurements} = telemetry_opts, module) do
     Enum.flat_map(measurements, fn
-      :builtin -> module.builtin_periodic_measurements(telemetry_opts)
+      :builtin ->
+        module.builtin_periodic_measurements(telemetry_opts)
+
       # These are implemented by telemetry_poller
-      f when f in [:memory, :persistent_term, :system_counts, :total_run_queue_lengths] -> [f]
+      f when f in [:memory, :persistent_term, :system_counts, :total_run_queue_lengths] ->
+        [f]
+
       # Bare function names are assumed to be referring to functions defined in the caller module
-      f when is_atom(f) -> [wrap(module, f, [telemetry_opts])]
-      f when is_function(f, 1) -> [wrap(__MODULE__, :user_measurement, [f, telemetry_opts])]
-      {m, f, a} when is_atom(m) and is_atom(f) and is_list(a) -> [wrap(m, f, a ++ [telemetry_opts])]
+      f when is_atom(f) ->
+        [wrap(module, f, [telemetry_opts])]
+
+      f when is_function(f, 1) ->
+        [wrap(__MODULE__, :user_measurement, [f, telemetry_opts])]
+
+      {m, f, a} when is_atom(m) and is_atom(f) and is_list(a) ->
+        [wrap(m, f, a ++ [telemetry_opts])]
     end)
   end
 

--- a/packages/electric-telemetry/lib/electric/telemetry/poller.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/poller.ex
@@ -75,7 +75,7 @@ defmodule ElectricTelemetry.Poller do
 
     e ->
       Logger.warning(
-        "Telemetry collector #{inspect(m)}.#{f}/#{length(a)} crashed: " <>
+        "Periodic user metric function crash #{inspect(m)}.#{f}/#{length(a)}: " <>
           Exception.message(e)
       )
 
@@ -89,7 +89,7 @@ defmodule ElectricTelemetry.Poller do
 
     kind, reason ->
       Logger.warning(
-        "Telemetry collector #{inspect(m)}.#{f}/#{length(a)} #{kind}: " <>
+        "Periodic user metric function #{kind} #{inspect(m)}.#{f}/#{length(a)}: " <>
           inspect(reason)
       )
 

--- a/packages/electric-telemetry/lib/electric/telemetry/poller.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/poller.ex
@@ -71,6 +71,7 @@ defmodule ElectricTelemetry.Poller do
     :ok
   rescue
     ArgumentError ->
+      # Raised by an :ets function referencing a non-existent ETS table during startup/restart.
       :ok
 
     e ->

--- a/packages/electric-telemetry/test/electric/telemetry/poller_test.exs
+++ b/packages/electric-telemetry/test/electric/telemetry/poller_test.exs
@@ -1,0 +1,106 @@
+defmodule ElectricTelemetry.PollerTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias ElectricTelemetry.Poller
+
+  defmodule Fixture do
+    def ok(), do: :done
+    def raise_argument(), do: raise(ArgumentError, "boom")
+    def raise_runtime(), do: raise(RuntimeError, "kaboom")
+    def exit_noproc(), do: exit({:noproc, {GenServer, :call, [:nowhere, :hi]}})
+    def exit_timeout(), do: exit({:timeout, {GenServer, :call, [:slow, :hi]}})
+    def exit_shutdown(), do: exit({:shutdown, :foo})
+    def exit_normal_atom(), do: exit(:normal)
+    def exit_shutdown_atom(), do: exit(:shutdown)
+    def exit_weird(), do: exit(:weird)
+    def throw_it(), do: throw(:nope)
+  end
+
+  describe "safe_invoke/3" do
+    test "returns :ok and runs the function on success" do
+      assert Poller.safe_invoke(Fixture, :ok, []) == :ok
+    end
+
+    test "swallows ArgumentError (ETS missing, etc.) silently" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :raise_argument, []) == :ok end)
+      refute log =~ "crashed"
+    end
+
+    test "swallows generic exceptions with a warning" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :raise_runtime, []) == :ok end)
+      assert log =~ "crashed"
+      assert log =~ "kaboom"
+    end
+
+    test "swallows :noproc exit silently" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_noproc, []) == :ok end)
+      refute log =~ "exit"
+    end
+
+    test "swallows :timeout exit silently" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_timeout, []) == :ok end)
+      refute log =~ "exit"
+    end
+
+    test "swallows :shutdown exit silently" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_shutdown, []) == :ok end)
+      refute log =~ "exit"
+    end
+
+    test "swallows bare :normal exit silently" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_normal_atom, []) == :ok end)
+      refute log =~ "exit"
+    end
+
+    test "swallows bare :shutdown exit silently" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_shutdown_atom, []) == :ok end)
+      refute log =~ "exit"
+    end
+
+    test "logs a warning for unexpected exits" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_weird, []) == :ok end)
+      assert log =~ "exit"
+      assert log =~ "weird"
+    end
+
+    test "logs a warning for throws" do
+      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :throw_it, []) == :ok end)
+      assert log =~ "throw"
+    end
+  end
+
+  describe "periodic_measurements/2 wrapping" do
+    defmodule CallbackMod do
+      @behaviour ElectricTelemetry.Poller
+      def builtin_periodic_measurements(_opts), do: []
+      def some_measurement(_opts), do: :ok
+    end
+
+    test "wraps {m, f, a} tuples in safe_invoke" do
+      opts = %{periodic_measurements: [{CallbackMod, :some_measurement, []}]}
+      assert [{ElectricTelemetry.Poller, :safe_invoke, [CallbackMod, :some_measurement, [_]]}] =
+               Poller.periodic_measurements(opts, CallbackMod)
+    end
+
+    test "wraps bare function atoms in safe_invoke" do
+      opts = %{periodic_measurements: [:some_measurement]}
+      assert [{ElectricTelemetry.Poller, :safe_invoke, [CallbackMod, :some_measurement, [_]]}] =
+               Poller.periodic_measurements(opts, CallbackMod)
+    end
+
+    test "wraps anonymous functions in safe_invoke around user_measurement" do
+      f = fn _ -> :ok end
+      opts = %{periodic_measurements: [f]}
+
+      assert [{ElectricTelemetry.Poller, :safe_invoke, [ElectricTelemetry.Poller, :user_measurement, [^f, _]]}] =
+               Poller.periodic_measurements(opts, CallbackMod)
+    end
+
+    test "leaves telemetry_poller builtins unwrapped" do
+      opts = %{periodic_measurements: [:memory, :persistent_term]}
+      assert Poller.periodic_measurements(opts, CallbackMod) == [:memory, :persistent_term]
+    end
+  end
+end

--- a/packages/electric-telemetry/test/electric/telemetry/poller_test.exs
+++ b/packages/electric-telemetry/test/electric/telemetry/poller_test.exs
@@ -50,12 +50,16 @@ defmodule ElectricTelemetry.PollerTest do
     end
 
     test "swallows bare :normal exit silently" do
-      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_normal_atom, []) == :ok end)
+      log =
+        capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_normal_atom, []) == :ok end)
+
       refute log =~ "exit"
     end
 
     test "swallows bare :shutdown exit silently" do
-      log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_shutdown_atom, []) == :ok end)
+      log =
+        capture_log(fn -> assert Poller.safe_invoke(Fixture, :exit_shutdown_atom, []) == :ok end)
+
       refute log =~ "exit"
     end
 
@@ -80,12 +84,14 @@ defmodule ElectricTelemetry.PollerTest do
 
     test "wraps {m, f, a} tuples in safe_invoke" do
       opts = %{periodic_measurements: [{CallbackMod, :some_measurement, []}]}
+
       assert [{ElectricTelemetry.Poller, :safe_invoke, [CallbackMod, :some_measurement, [_]]}] =
                Poller.periodic_measurements(opts, CallbackMod)
     end
 
     test "wraps bare function atoms in safe_invoke" do
       opts = %{periodic_measurements: [:some_measurement]}
+
       assert [{ElectricTelemetry.Poller, :safe_invoke, [CallbackMod, :some_measurement, [_]]}] =
                Poller.periodic_measurements(opts, CallbackMod)
     end
@@ -94,7 +100,10 @@ defmodule ElectricTelemetry.PollerTest do
       f = fn _ -> :ok end
       opts = %{periodic_measurements: [f]}
 
-      assert [{ElectricTelemetry.Poller, :safe_invoke, [ElectricTelemetry.Poller, :user_measurement, [^f, _]]}] =
+      assert [
+               {ElectricTelemetry.Poller, :safe_invoke,
+                [ElectricTelemetry.Poller, :user_measurement, [^f, _]]}
+             ] =
                Poller.periodic_measurements(opts, CallbackMod)
     end
 

--- a/packages/electric-telemetry/test/electric/telemetry/poller_test.exs
+++ b/packages/electric-telemetry/test/electric/telemetry/poller_test.exs
@@ -25,12 +25,12 @@ defmodule ElectricTelemetry.PollerTest do
 
     test "swallows ArgumentError (ETS missing, etc.) silently" do
       log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :raise_argument, []) == :ok end)
-      refute log =~ "crashed"
+      refute log =~ "crash"
     end
 
     test "swallows generic exceptions with a warning" do
       log = capture_log(fn -> assert Poller.safe_invoke(Fixture, :raise_runtime, []) == :ok end)
-      assert log =~ "crashed"
+      assert log =~ "crash"
       assert log =~ "kaboom"
     end
 

--- a/packages/sync-service/lib/electric/stack_supervisor/telemetry.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor/telemetry.ex
@@ -1,6 +1,4 @@
 defmodule Electric.StackSupervisor.Telemetry do
-  require Logger
-
   def configure(config) do
     # Set shared OpenTelemetry span attributes for the given stack. They are stored in
     # persistent_term so it doesn't matter which process this function is called from.
@@ -29,20 +27,20 @@ defmodule Electric.StackSupervisor.Telemetry do
   end
 
   def count_shapes(stack_id, _telemetry_opts) do
-    # Telemetry is started before everything else in the stack, so handle the case where the
-    # shape cache is not started yet: emit what we can and skip what we can't independently.
-    with %{total: num_shapes, indexed: indexed_shapes, unindexed: unindexed_shapes} <-
-           Electric.ShapeCache.shape_counts(stack_id) do
-      Electric.Telemetry.OpenTelemetry.execute(
-        [:electric, :shapes, :total_shapes],
-        %{count: num_shapes, count_indexed: indexed_shapes, count_unindexed: unindexed_shapes},
-        %{stack_id: stack_id}
-      )
-    end
-
+    # Emit active_shapes first so that a failure in shape_counts (e.g. shape cache not yet
+    # started during stack startup) doesn't drop this metric for the tick.
     Electric.Telemetry.OpenTelemetry.execute(
       [:electric, :shapes, :active_shapes],
       %{count: Electric.Shapes.ConsumerRegistry.active_consumer_count(stack_id)},
+      %{stack_id: stack_id}
+    )
+
+    %{total: num_shapes, indexed: indexed_shapes, unindexed: unindexed_shapes} =
+      Electric.ShapeCache.shape_counts(stack_id)
+
+    Electric.Telemetry.OpenTelemetry.execute(
+      [:electric, :shapes, :total_shapes],
+      %{count: num_shapes, count_indexed: indexed_shapes, count_unindexed: unindexed_shapes},
       %{stack_id: stack_id}
     )
   end
@@ -74,41 +72,34 @@ defmodule Electric.StackSupervisor.Telemetry do
   @doc false
   @spec report_retained_wal_size(Electric.stack_id(), binary(), map()) :: :ok
   def report_retained_wal_size(stack_id, slot_name, _telemetry_opts) do
-    try do
-      %Postgrex.Result{rows: [[pg_wal_offset, retained_wal_size, confirmed_flush_lsn_lag]]} =
-        Postgrex.query!(
-          Electric.Connection.Manager.admin_pool(stack_id),
-          @retained_wal_size_query,
-          [slot_name],
-          timeout: 3_000,
-          deadline: 3_000
-        )
-
-      # The query above can return `-1` for `confirmed_flush_lsn_lag` which means that Electric
-      # is caught up with Postgres' replication stream.
-      # This is a confusing stat if we're measuring in bytes, so use 0 as the bottom limit.
-
-      Electric.Telemetry.OpenTelemetry.execute(
-        [:electric, :postgres, :replication],
-        %{
-          # The absolute value of pg_current_wal_lsn() doesn't convey any useful info but by
-          # plotting its rate of change we can see how fast the WAL is growing.
-          #
-          # We shift the absolute value of pg_current_wal_lsn() by -2**63 in the query above
-          # to make sure it fits inside the signed 64-bit integer type expected by the
-          # OpenTelemetry Protocol,
-          pg_wal_offset: pg_wal_offset,
-          slot_retained_wal_size: retained_wal_size,
-          slot_confirmed_flush_lsn_lag: max(0, confirmed_flush_lsn_lag)
-        },
-        %{stack_id: stack_id}
+    %Postgrex.Result{rows: [[pg_wal_offset, retained_wal_size, confirmed_flush_lsn_lag]]} =
+      Postgrex.query!(
+        Electric.Connection.Manager.admin_pool(stack_id),
+        @retained_wal_size_query,
+        [slot_name],
+        timeout: 3_000,
+        deadline: 3_000
       )
-    catch
-      kind, reason when kind in [:error, :exit] ->
-        Logger.debug("report_retained_wal_size/3 skipped: #{kind} #{inspect(reason)}")
 
-        :ok
-    end
+    # The query above can return `-1` for `confirmed_flush_lsn_lag` which means that Electric
+    # is caught up with Postgres' replication stream.
+    # This is a confusing stat if we're measuring in bytes, so use 0 as the bottom limit.
+
+    Electric.Telemetry.OpenTelemetry.execute(
+      [:electric, :postgres, :replication],
+      %{
+        # The absolute value of pg_current_wal_lsn() doesn't convey any useful info but by
+        # plotting its rate of change we can see how fast the WAL is growing.
+        #
+        # We shift the absolute value of pg_current_wal_lsn() by -2**63 in the query above
+        # to make sure it fits inside the signed 64-bit integer type expected by the
+        # OpenTelemetry Protocol,
+        pg_wal_offset: pg_wal_offset,
+        slot_retained_wal_size: retained_wal_size,
+        slot_confirmed_flush_lsn_lag: max(0, confirmed_flush_lsn_lag)
+      },
+      %{stack_id: stack_id}
+    )
   end
 
   if Code.ensure_loaded?(ElectricTelemetry.DiskUsage) do

--- a/packages/sync-service/lib/electric/stack_supervisor/telemetry.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor/telemetry.ex
@@ -1,4 +1,6 @@
 defmodule Electric.StackSupervisor.Telemetry do
+  require Logger
+
   def configure(config) do
     # Set shared OpenTelemetry span attributes for the given stack. They are stored in
     # persistent_term so it doesn't matter which process this function is called from.
@@ -27,14 +29,16 @@ defmodule Electric.StackSupervisor.Telemetry do
   end
 
   def count_shapes(stack_id, _telemetry_opts) do
-    %{total: num_shapes, indexed: indexed_shapes, unindexed: unindexed_shapes} =
-      Electric.ShapeCache.shape_counts(stack_id)
-
-    Electric.Telemetry.OpenTelemetry.execute(
-      [:electric, :shapes, :total_shapes],
-      %{count: num_shapes, count_indexed: indexed_shapes, count_unindexed: unindexed_shapes},
-      %{stack_id: stack_id}
-    )
+    # Telemetry is started before everything else in the stack, so handle the case where the
+    # shape cache is not started yet: emit what we can and skip what we can't independently.
+    with %{total: num_shapes, indexed: indexed_shapes, unindexed: unindexed_shapes} <-
+           Electric.ShapeCache.shape_counts(stack_id) do
+      Electric.Telemetry.OpenTelemetry.execute(
+        [:electric, :shapes, :total_shapes],
+        %{count: num_shapes, count_indexed: indexed_shapes, count_unindexed: unindexed_shapes},
+        %{stack_id: stack_id}
+      )
+    end
 
     Electric.Telemetry.OpenTelemetry.execute(
       [:electric, :shapes, :active_shapes],
@@ -70,34 +74,41 @@ defmodule Electric.StackSupervisor.Telemetry do
   @doc false
   @spec report_retained_wal_size(Electric.stack_id(), binary(), map()) :: :ok
   def report_retained_wal_size(stack_id, slot_name, _telemetry_opts) do
-    %Postgrex.Result{rows: [[pg_wal_offset, retained_wal_size, confirmed_flush_lsn_lag]]} =
-      Postgrex.query!(
-        Electric.Connection.Manager.admin_pool(stack_id),
-        @retained_wal_size_query,
-        [slot_name],
-        timeout: 3_000,
-        deadline: 3_000
+    try do
+      %Postgrex.Result{rows: [[pg_wal_offset, retained_wal_size, confirmed_flush_lsn_lag]]} =
+        Postgrex.query!(
+          Electric.Connection.Manager.admin_pool(stack_id),
+          @retained_wal_size_query,
+          [slot_name],
+          timeout: 3_000,
+          deadline: 3_000
+        )
+
+      # The query above can return `-1` for `confirmed_flush_lsn_lag` which means that Electric
+      # is caught up with Postgres' replication stream.
+      # This is a confusing stat if we're measuring in bytes, so use 0 as the bottom limit.
+
+      Electric.Telemetry.OpenTelemetry.execute(
+        [:electric, :postgres, :replication],
+        %{
+          # The absolute value of pg_current_wal_lsn() doesn't convey any useful info but by
+          # plotting its rate of change we can see how fast the WAL is growing.
+          #
+          # We shift the absolute value of pg_current_wal_lsn() by -2**63 in the query above
+          # to make sure it fits inside the signed 64-bit integer type expected by the
+          # OpenTelemetry Protocol,
+          pg_wal_offset: pg_wal_offset,
+          slot_retained_wal_size: retained_wal_size,
+          slot_confirmed_flush_lsn_lag: max(0, confirmed_flush_lsn_lag)
+        },
+        %{stack_id: stack_id}
       )
+    catch
+      kind, reason when kind in [:error, :exit] ->
+        Logger.debug("report_retained_wal_size/3 skipped: #{kind} #{inspect(reason)}")
 
-    # The query above can return `-1` for `confirmed_flush_lsn_lag` which means that Electric
-    # is caught up with Postgres' replication stream.
-    # This is a confusing stat if we're measuring in bytes, so use 0 as the bottom limit.
-
-    Electric.Telemetry.OpenTelemetry.execute(
-      [:electric, :postgres, :replication],
-      %{
-        # The absolute value of pg_current_wal_lsn() doesn't convey any useful info but by
-        # plotting its rate of change we can see how fast the WAL is growing.
-        #
-        # We shift the absolute value of pg_current_wal_lsn() by -2**63 in the query above
-        # to make sure it fits inside the signed 64-bit integer type expected by the
-        # OpenTelemetry Protocol,
-        pg_wal_offset: pg_wal_offset,
-        slot_retained_wal_size: retained_wal_size,
-        slot_confirmed_flush_lsn_lag: max(0, confirmed_flush_lsn_lag)
-      },
-      %{stack_id: stack_id}
-    )
+        :ok
+    end
   end
 
   if Code.ensure_loaded?(ElectricTelemetry.DiskUsage) do

--- a/packages/sync-service/lib/electric/stack_supervisor/telemetry.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor/telemetry.ex
@@ -1,6 +1,4 @@
 defmodule Electric.StackSupervisor.Telemetry do
-  require Logger
-
   def configure(config) do
     # Set shared OpenTelemetry span attributes for the given stack. They are stored in
     # persistent_term so it doesn't matter which process this function is called from.
@@ -29,16 +27,14 @@ defmodule Electric.StackSupervisor.Telemetry do
   end
 
   def count_shapes(stack_id, _telemetry_opts) do
-    # Telemetry is started before everything else in the stack, so we need to handle
-    # the case where the shape cache is not started yet.
-    with %{total: num_shapes, indexed: indexed_shapes, unindexed: unindexed_shapes} <-
-           Electric.ShapeCache.shape_counts(stack_id) do
-      Electric.Telemetry.OpenTelemetry.execute(
-        [:electric, :shapes, :total_shapes],
-        %{count: num_shapes, count_indexed: indexed_shapes, count_unindexed: unindexed_shapes},
-        %{stack_id: stack_id}
-      )
-    end
+    %{total: num_shapes, indexed: indexed_shapes, unindexed: unindexed_shapes} =
+      Electric.ShapeCache.shape_counts(stack_id)
+
+    Electric.Telemetry.OpenTelemetry.execute(
+      [:electric, :shapes, :total_shapes],
+      %{count: num_shapes, count_indexed: indexed_shapes, count_unindexed: unindexed_shapes},
+      %{stack_id: stack_id}
+    )
 
     Electric.Telemetry.OpenTelemetry.execute(
       [:electric, :shapes, :active_shapes],
@@ -74,47 +70,34 @@ defmodule Electric.StackSupervisor.Telemetry do
   @doc false
   @spec report_retained_wal_size(Electric.stack_id(), binary(), map()) :: :ok
   def report_retained_wal_size(stack_id, slot_name, _telemetry_opts) do
-    try do
-      %Postgrex.Result{rows: [[pg_wal_offset, retained_wal_size, confirmed_flush_lsn_lag]]} =
-        Postgrex.query!(
-          Electric.Connection.Manager.admin_pool(stack_id),
-          @retained_wal_size_query,
-          [slot_name],
-          timeout: 3_000,
-          deadline: 3_000
-        )
-
-      # The query above can return `-1` for `confirmed_flush_lsn_lag` which means that Electric
-      # is caught up with Postgres' replication stream.
-      # This is a confusing stat if we're measuring in bytes, so use 0 as the bottom limit.
-
-      Electric.Telemetry.OpenTelemetry.execute(
-        [:electric, :postgres, :replication],
-        %{
-          # The absolute value of pg_current_wal_lsn() doesn't convey any useful info but by
-          # plotting its rate of change we can see how fast the WAL is growing.
-          #
-          # We shift the absolute value of pg_current_wal_lsn() by -2**63 in the query above
-          # to make sure it fits inside the signed 64-bit integer type expected by the
-          # OpenTelemetry Protocol,
-          pg_wal_offset: pg_wal_offset,
-          slot_retained_wal_size: retained_wal_size,
-          slot_confirmed_flush_lsn_lag: max(0, confirmed_flush_lsn_lag)
-        },
-        %{stack_id: stack_id}
+    %Postgrex.Result{rows: [[pg_wal_offset, retained_wal_size, confirmed_flush_lsn_lag]]} =
+      Postgrex.query!(
+        Electric.Connection.Manager.admin_pool(stack_id),
+        @retained_wal_size_query,
+        [slot_name],
+        timeout: 3_000,
+        deadline: 3_000
       )
-    catch
-      :exit, {:noproc, _} ->
-        :ok
 
-      # catch all errors to not log them as errors, those are reporing issues at best
-      type, reason ->
-        Logger.warning(
-          "Failed to query retained WAL size\nError: #{Exception.format(type, reason)}",
-          stack_id: stack_id,
-          slot_name: slot_name
-        )
-    end
+    # The query above can return `-1` for `confirmed_flush_lsn_lag` which means that Electric
+    # is caught up with Postgres' replication stream.
+    # This is a confusing stat if we're measuring in bytes, so use 0 as the bottom limit.
+
+    Electric.Telemetry.OpenTelemetry.execute(
+      [:electric, :postgres, :replication],
+      %{
+        # The absolute value of pg_current_wal_lsn() doesn't convey any useful info but by
+        # plotting its rate of change we can see how fast the WAL is growing.
+        #
+        # We shift the absolute value of pg_current_wal_lsn() by -2**63 in the query above
+        # to make sure it fits inside the signed 64-bit integer type expected by the
+        # OpenTelemetry Protocol,
+        pg_wal_offset: pg_wal_offset,
+        slot_retained_wal_size: retained_wal_size,
+        slot_confirmed_flush_lsn_lag: max(0, confirmed_flush_lsn_lag)
+      },
+      %{stack_id: stack_id}
+    )
   end
 
   if Code.ensure_loaded?(ElectricTelemetry.DiskUsage) do

--- a/packages/sync-service/test/electric/stack_supervisor_test.exs
+++ b/packages/sync-service/test/electric/stack_supervisor_test.exs
@@ -9,16 +9,6 @@ defmodule Electric.StackSupervisorTest do
   describe "Telemetry" do
     setup [:with_stack_id_from_test]
 
-    test "default_periodic_measurements/1 do not raise if stack down", ctx do
-      for {m, f, a} <-
-            StackSupervisor.Telemetry.default_periodic_measurements(%{
-              stack_id: ctx.stack_id,
-              replication_opts: [slot_name: "no_such_slot"]
-            }) do
-        apply(m, f, a ++ [%{}])
-      end
-    end
-
     test "count_shapes/2 emits split shape metrics", ctx do
       stack_id = ctx.stack_id
 


### PR DESCRIPTION
<img alt="vetted by human" src="https://github.com/user-attachments/assets/11a81387-9e4a-4d7c-873e-265062ea2b74"/>
<img alt="ready for review" src="https://github.com/user-attachments/assets/267c675d-da51-47c9-9581-6d156a63b7e2"/>

## Summary

- Adds `ElectricTelemetry.Poller.safe_invoke/3` and wraps every MFA built by `periodic_measurements/2` in it, so transient collector failures no longer cause `:telemetry_poller` to permanently drop a measurement from its polling list.
- Silently absorbs `:noproc`/`:timeout`/`:shutdown`/`:normal` exits and `ArgumentError` (typical startup/restart races); logs a warning tagged with the MFA for anything else.
- Strips now-redundant defensive `try/catch` and `with`-fallthrough code from individual collectors in `Electric.StackSupervisor.Telemetry`, since `safe_invoke/3` is the single contract for containing transient errors. The one ordering tweak worth noting: `count_shapes/2` emits `active_shapes` before calling `shape_counts/1`, so a startup-race failure in the latter only drops `total_shapes` for the tick.

## Refactorings enabled by centralized error handling

Thanks to `safe_invoke/3`, the following defensive patterns were removed from `StackSupervisor.Telemetry`:

- **`report_retained_wal_size/2`**: Removed `try/catch` block that was catching `:noproc` exits and logging warnings for query failures. Now a clean straight-line function.
- **`count_shapes/2`**: Removed `with` pattern that silently handled shape cache not being ready during startup. Replaced with simple pattern match.

## Discarded one-off fixes (now unnecessary)

The following Sentry-driven issues proposed individual fixes that are superseded by the central handler:

- **stratovolt#1452** (`report_shape_db_stats` `:noproc` during deployments): Proposed adding `try/catch` to the function. Now handled centrally.
- **stratovolt#1453** (`count_shapes` `ArgumentError` on missing ETS table): Proposed wrapping `:ets.select` with `try/rescue`. Now handled centrally.

## Background

`:telemetry_poller` catches MFA exceptions but returns `error` to its internal loop, which removes the measurement permanently. A single GenServer restart race or ETS-table startup race is enough to silently disable a metric for the lifetime of the poller. See issue electric-sql/alco-agent-tasks#32 for the full audit and design.

## Note on semantics

User-supplied periodic measurement functions passed to `ElectricTelemetry` no longer have their exceptions propagated up to `:telemetry_poller`'s own error logger — they are now caught and logged via `ElectricTelemetry.Poller` instead. This is called out in the changeset.

## Test plan

- [x] New `ElectricTelemetry.PollerTest` covers all catch clauses + the wrapping logic in `periodic_measurements/2`
- [x] `mix format` clean
- [x] `mix compile` clean for `@core/sync-service` and `@core/electric-telemetry`
- [x] `Electric.StackSupervisorTest` passes
- [ ] Existing telemetry / stack-supervisor tests pass in CI

Refs electric-sql/alco-agent-tasks#32