### PR TITLE
Propagate OTel context into spawned snapshot and move-in tasks

### DIFF
--- a/.changeset/propagate-otel-context-to-snapshot-tasks.md
+++ b/.changeset/propagate-otel-context-to-snapshot-tasks.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Propagate OpenTelemetry context into spawned snapshot and move-in tasks so that spans created via `with_child_span` (e.g. `shape_snapshot.execute_for_shape`, `shape_snapshot.query_fn`, `shape_snapshot.checkout_wait`) are linked to the originating trace instead of being silently dropped.

--- a/integration-tests/tests/otel-export.lux
+++ b/integration-tests/tests/otel-export.lux
@@ -209,15 +209,37 @@
   ?electric-offset: ([\w\d_]+)
   [global offset=$1]
 
+[shell otel_collector]
+  # Verify that the initial snapshot query span is exported from the Snapshotter path.
+  ?Span #[0-9]+
+  ?Name[ ]+: shape_snapshot\.execute_for_shape
+  ?->[ ]shape\.query_reason: Str\(initial_snapshot\)
+
 [shell psql]
   !insert into items values ('3');
   ??INSERT
+
+[shell client]
+  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&subset__where=val%20%3D%20%273%27"]
+
+  ??HTTP/1.1 200 OK
+  ??"metadata"
+
+[shell otel_collector]
+  # Verify that a direct subset snapshot query span is exported from the PartialModes path.
+  ?Span #[0-9]+
+  ?Name[ ]+: shape_snapshot\.execute_for_shape
+  ?->[ ]shape\.query_reason: Str\(subset_query\)
 
 [shell client]
   [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&live"]
 
   ??HTTP/1.1 200 OK
   ??"value":{"val":"3"}
+
+[shell psql]
+  !insert into items values ('4');
+  ??INSERT
 
 [shell otel_collector]
   """?

--- a/packages/sync-service/lib/electric/shapes.ex
+++ b/packages/sync-service/lib/electric/shapes.ex
@@ -4,6 +4,7 @@ defmodule Electric.Shapes do
   alias Electric.ShapeCache
   alias Electric.ShapeCache.ShapeStatus
   alias Electric.Shapes.Shape
+  alias Electric.Telemetry.OpenTelemetry
 
   import Electric, only: [is_stack_id: 1, is_shape_handle: 1]
 
@@ -65,7 +66,7 @@ defmodule Electric.Shapes do
     ShapeCache.get_or_create_shape_handle(
       shape_def,
       stack_id,
-      otel_ctx: :otel_ctx.get_current()
+      otel_ctx: OpenTelemetry.get_current_context()
     )
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -39,7 +39,7 @@ defmodule Electric.Shapes.Consumer do
 
   @type initialize_shape_opts() :: %{
           :action => :create | :restore,
-          optional(:otel_ctx) => map() | nil,
+          optional(:otel_ctx) => OpenTelemetry.otel_ctx() | nil,
           optional(:feature_flags) => [binary()],
           optional(:is_subquery_shape?) => boolean()
         }

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -42,7 +42,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
       storage: storage
     } = state
 
-    ctx_token = if not is_nil(state.otel_ctx), do: :otel_ctx.attach(state.otel_ctx)
+    if not is_nil(state.otel_ctx), do: OpenTelemetry.set_current_context(state.otel_ctx)
 
     result =
       case Shapes.Consumer.whereis(stack_id, shape_handle) do
@@ -104,8 +104,6 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
           {:stop, {:error, "consumer not found"}, state}
       end
 
-    if not is_nil(ctx_token), do: :otel_ctx.detach(ctx_token)
-
     result
   end
 
@@ -129,7 +127,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
     # Capture OTel context so spans created inside the spawned task are linked to
     # the originating trace. OTel context is per-process, so without this any
     # `with_child_span` calls in the task would be silently dropped.
-    otel_ctx = :otel_ctx.get_current()
+    trace_context = OpenTelemetry.get_current_context()
 
     # We're looking to avoid saturating the DB connection pool with queries that are "bad" - those that don't start
     # returning any data (likely because they're not using an index). To acheive that, we're running the query in a task,
@@ -142,7 +140,7 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
     task =
       Task.Supervisor.async_nolink(supervisor, fn ->
-        ctx_token = :otel_ctx.attach(otel_ctx)
+        OpenTelemetry.set_current_context(trace_context)
 
         snapshot_fun =
           Electric.StackConfig.lookup(stack_id, :create_snapshot_fn, &stream_snapshot_from_db/5)
@@ -162,8 +160,6 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
         rescue
           error ->
             {:error, error, __STACKTRACE__}
-        after
-          :otel_ctx.detach(ctx_token)
         end
       end)
 

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -126,6 +126,11 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
     # not an ephemeral unnamed task process
     db_pool = Electric.Connection.Manager.snapshot_pool(ctx.stack_id)
 
+    # Capture OTel context so spans created inside the spawned task are linked to
+    # the originating trace. OTel context is per-process, so without this any
+    # `with_child_span` calls in the task would be silently dropped.
+    otel_ctx = :otel_ctx.get_current()
+
     # We're looking to avoid saturating the DB connection pool with queries that are "bad" - those that don't start
     # returning any data (likely because they're not using an index). To acheive that, we're running the query in a task,
     # and waiting for the task to (a) send us a message that it's ready to stream and (b) send us a message when it sees any data
@@ -137,6 +142,8 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
     task =
       Task.Supervisor.async_nolink(supervisor, fn ->
+        ctx_token = :otel_ctx.attach(otel_ctx)
+
         snapshot_fun =
           Electric.StackConfig.lookup(stack_id, :create_snapshot_fn, &stream_snapshot_from_db/5)
 
@@ -155,6 +162,8 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
         rescue
           error ->
             {:error, error, __STACKTRACE__}
+        after
+          :otel_ctx.detach(ctx_token)
         end
       end)
 

--- a/packages/sync-service/lib/electric/shapes/partial_modes.ex
+++ b/packages/sync-service/lib/electric/shapes/partial_modes.ex
@@ -95,7 +95,14 @@ defmodule Electric.Shapes.PartialModes do
       stack_id: opts[:stack_id]
     })
 
+    # Propagate OTel context so spans created inside the task are linked to the
+    # caller's trace. OTel context is per-process, so without this any
+    # `with_child_span` calls in the task would be silently dropped.
+    otel_ctx = :otel_ctx.get_current()
+
     Task.Supervisor.start_child(supervisor, fn ->
+      ctx_token = :otel_ctx.attach(otel_ctx)
+
       try do
         SnapshotQuery.execute_for_shape(pool, shape_handle, shape,
           stack_id: opts[:stack_id],
@@ -116,6 +123,8 @@ defmodule Electric.Shapes.PartialModes do
       rescue
         error ->
           send(consumer_pid, {:query_move_in_error, opts[:move_in_name], error, __STACKTRACE__})
+      after
+        :otel_ctx.detach(ctx_token)
       end
     end)
 
@@ -127,7 +136,14 @@ defmodule Electric.Shapes.PartialModes do
     pool = Manager.pool_name(opts[:stack_id], :snapshot)
     results_fn = Access.fetch!(opts, :results_fn)
 
+    # Propagate OTel context so spans created inside the task are linked to the
+    # caller's trace. OTel context is per-process, so without this any
+    # `with_child_span` calls in the task would be silently dropped.
+    otel_ctx = :otel_ctx.get_current()
+
     Task.Supervisor.start_child(supervisor, fn ->
+      ctx_token = :otel_ctx.attach(otel_ctx)
+
       try do
         SnapshotQuery.execute_for_shape(pool, shape_handle, shape,
           stack_id: opts[:stack_id],
@@ -146,6 +162,8 @@ defmodule Electric.Shapes.PartialModes do
       rescue
         error ->
           send(parent, {:query_move_in_error, opts[:move_in_name], error, __STACKTRACE__})
+      after
+        :otel_ctx.detach(ctx_token)
       end
     end)
 

--- a/packages/sync-service/lib/electric/shapes/partial_modes.ex
+++ b/packages/sync-service/lib/electric/shapes/partial_modes.ex
@@ -98,10 +98,10 @@ defmodule Electric.Shapes.PartialModes do
     # Propagate OTel context so spans created inside the task are linked to the
     # caller's trace. OTel context is per-process, so without this any
     # `with_child_span` calls in the task would be silently dropped.
-    otel_ctx = :otel_ctx.get_current()
+    trace_context = OpenTelemetry.get_current_context()
 
     Task.Supervisor.start_child(supervisor, fn ->
-      ctx_token = :otel_ctx.attach(otel_ctx)
+      OpenTelemetry.set_current_context(trace_context)
 
       try do
         SnapshotQuery.execute_for_shape(pool, shape_handle, shape,
@@ -123,8 +123,6 @@ defmodule Electric.Shapes.PartialModes do
       rescue
         error ->
           send(consumer_pid, {:query_move_in_error, opts[:move_in_name], error, __STACKTRACE__})
-      after
-        :otel_ctx.detach(ctx_token)
       end
     end)
 
@@ -139,10 +137,10 @@ defmodule Electric.Shapes.PartialModes do
     # Propagate OTel context so spans created inside the task are linked to the
     # caller's trace. OTel context is per-process, so without this any
     # `with_child_span` calls in the task would be silently dropped.
-    otel_ctx = :otel_ctx.get_current()
+    trace_context = OpenTelemetry.get_current_context()
 
     Task.Supervisor.start_child(supervisor, fn ->
-      ctx_token = :otel_ctx.attach(otel_ctx)
+      OpenTelemetry.set_current_context(trace_context)
 
       try do
         SnapshotQuery.execute_for_shape(pool, shape_handle, shape,
@@ -162,8 +160,6 @@ defmodule Electric.Shapes.PartialModes do
       rescue
         error ->
           send(parent, {:query_move_in_error, opts[:move_in_name], error, __STACKTRACE__})
-      after
-        :otel_ctx.detach(ctx_token)
       end
     end)
 

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -35,7 +35,12 @@ defmodule Electric.Telemetry.OpenTelemetry do
   @typep span_name :: String.t()
   @typep attr_name :: String.t()
   @typep span_attrs :: :opentelemetry.attributes_map()
-  @typep span_ctx :: :opentelemetry.span_ctx()
+  @type span_ctx :: :opentelemetry.span_ctx()
+
+  @typedoc """
+  Span + baggage pair returned by `get_current_context/0` and consumed by `set_current_context/1`.
+  """
+  @type otel_ctx :: {span_ctx() | :undefined, :otel_baggage.t()}
 
   @doc """
   Create a span that starts at the current point in time and ends when `fun` returns.


### PR DESCRIPTION
<img alt="vetted by human" src="https://github.com/user-attachments/assets/11a81387-9e4a-4d7c-873e-265062ea2b74"/>
<img alt="ready for review" src="https://github.com/user-attachments/assets/267c675d-da51-47c9-9581-6d156a63b7e2"/>

## Summary

Fixes a bug where telemetry spans defined with `OpenTelemetry.with_child_span` inside spawned tasks (initial-snapshot and move-in code paths) were silently dropped, hiding expected fine-grained spans such as `shape_snapshot.execute_for_shape`, `shape_snapshot.query_fn`, `shape_snapshot.checkout_wait`, `shape_snapshot.setup`, and `shape_snapshot.query` from Honeycomb on hosts whose traffic is dominated by initial snapshots.

### Root cause

`with_child_span/4` only creates a span when there is already a parent span in the **current Erlang process's** OTel context. `Task.Supervisor.async_nolink` / `Task.Supervisor.start_child` start new processes that do not inherit the caller's OTel context, so `in_span_context?()` returns `false` and the whole span subtree is dropped. Three spawn sites were affected:

- `Electric.Shapes.Consumer.Snapshotter.start_streaming_snapshot_from_db/4`
- `Electric.Shapes.PartialModes.query_move_in_async/5`
- `Electric.Shapes.PartialModes.query_move_in/5`

(`PartialModes.query_subset/4` is called synchronously from an HTTP-request process that already has a parent span — it was not affected.)

### Fix

Capture the context via `:otel_ctx.get_current()` before each spawn and attach it inside the task closure with `:otel_ctx.attach/1` (detached in `after`). This mirrors the pattern already used for `state.otel_ctx` in `Snapshotter.handle_continue/2`.

## Test plan

- [x] `mix compile` clean
- [x] `mix test test/electric/shapes/consumer_test.exs` — 29 passing
- [x] `mix test test/electric/shapes/consumer/move_ins_test.exs test/electric/shapes/consumer/initial_snapshot_test.exs` — 60 passing
- [ ] After deploy: verify `name = shape_snapshot.execute_for_shape AND shape.query_reason = "initial_snapshot"` returns rows in Honeycomb (previously 0 across all hosts over 24h)

Refs: https://github.com/electric-sql/alco-agent-tasks/issues/27

🤖 Generated with [Claude Code](https://claude.com/claude-code)