### PR TITLE
fix: postgres 18 volume mount path in docker-compose

### DIFF
--- a/.changeset/fix-postgres-18-volume-mount.md
+++ b/.changeset/fix-postgres-18-volume-mount.md
@@ -1,0 +1,5 @@
+---
+'electric-ax': patch
+---
+
+Fix postgres 18 docker volume mount path to use `/var/lib/postgresql` instead of `/var/lib/postgresql/data`

--- a/packages/agents-server/docker-compose.full.yml
+++ b/packages/agents-server/docker-compose.full.yml
@@ -24,7 +24,7 @@ services:
       timeout: 5s
       retries: 30
     volumes:
-      - electric-agents-postgres-data:/var/lib/postgresql/data
+      - electric-agents-postgres-data:/var/lib/postgresql
 
   electric:
     image: electricsql/electric:latest

--- a/packages/electric-ax/docker-compose.full.yml
+++ b/packages/electric-ax/docker-compose.full.yml
@@ -24,7 +24,7 @@ services:
       timeout: 5s
       retries: 30
     volumes:
-      - electric-agents-postgres-data:/var/lib/postgresql/data
+      - electric-agents-postgres-data:/var/lib/postgresql
 
   electric:
     image: electricsql/electric:latest


### PR DESCRIPTION
## Summary

PostgreSQL 18+ containers fail to start (crash loop) when the data volume is mounted at `/var/lib/postgresql/data`. This fixes the `agent quickstart` command and the agents-server docker-compose to mount at `/var/lib/postgresql` instead.

## Root Cause

PostgreSQL 18 changed its data directory layout to use `pg_ctlcluster`-compatible, major-version-specific subdirectories (e.g. `/var/lib/postgresql/18/main`). When a volume is mounted directly at `/var/lib/postgresql/data`, Postgres 18 detects the old-style layout and refuses to start, printing an error about incompatible data format.

See: https://github.com/docker-library/postgres/pull/1259

## Approach

Changed the volume mount from `/var/lib/postgresql/data` → `/var/lib/postgresql` in both `docker-compose.full.yml` files. This matches what the `docker-compose.dev.yml` already does correctly, and lets Postgres 18 create its own versioned subdirectory structure.

### Key Invariants
- Volume mount must be at `/var/lib/postgresql` (not `/data` subdirectory) for any postgres 18+ image
- The dev compose file (`agents-server/docker-compose.dev.yml`) was already correct — this aligns the production-style compose files

### Non-goals
- No image version pinning changes — postgres:18-alpine is correct
- No `pg_upgrade` migration path for existing volumes — users with stale volumes need `docker compose -p electric-agents down -v` to clear them

### Trade-offs
An alternative would be to pin to `postgres:17-alpine` to avoid the breaking change. However, 18 is the current version and the dev compose already uses it successfully with the correct mount path, so aligning is the right fix.

## Verification

```bash
# Remove any stale volumes from previous failed attempts
docker compose -p electric-agents down -v

# Run quickstart — postgres container should start healthy
npx electric-ax agent quickstart
```

Verified locally: all three containers (postgres, electric, electric-agents) start successfully.

## Files changed

- **`packages/electric-ax/docker-compose.full.yml`** — volume mount `/var/lib/postgresql/data` → `/var/lib/postgresql`
- **`packages/agents-server/docker-compose.full.yml`** — same fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)