### PR TITLE
Move expiring-shapes log counts into Logger metadata

### DIFF
--- a/.changeset/fix-expiry-manager-log-attributes.md
+++ b/.changeset/fix-expiry-manager-log-attributes.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Emit `number_to_expire` and `max_shapes` as Logger metadata (instead of interpolating them into the message body) for the "Expiring shapes as the number of shapes has exceeded the limit" notice. This keeps the message text static so log aggregators can group these events and so Honeycomb can filter by `shape.expiry.*` attributes.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -381,7 +381,9 @@ if Electric.telemetry_enabled?() do
              received_transaction_lsn: "received.transaction.lsn",
              publication_alter_drop_tables: "publication.alter.drop_tables",
              publication_alter_add_tables: "publication.alter.add_tables",
-             publication_alter_set_tables: "publication.alter.set_tables"
+             publication_alter_set_tables: "publication.alter.set_tables",
+             number_to_expire: "shape.expiry.number_to_expire",
+             max_shapes: "shape.expiry.max_shapes"
            }
          }
        }}

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -75,8 +75,9 @@ defmodule Electric.ShapeCache.ExpiryManager do
     {handles_to_expire, min_age} = least_recently_used(state, number_to_expire)
 
     Logger.notice(
-      "Expiring #{number_to_expire} shapes as the number of shapes " <>
-        "has exceeded the limit (#{state.max_shapes})"
+      "Expiring shapes as the number of shapes has exceeded the limit",
+      number_to_expire: number_to_expire,
+      max_shapes: state.max_shapes
     )
 
     OpenTelemetry.with_span(


### PR DESCRIPTION
<img alt="vetted by human" src="https://github.com/user-attachments/assets/11a81387-9e4a-4d7c-873e-265062ea2b74"/>
<img alt="ready for review" src="https://github.com/user-attachments/assets/267c675d-da51-47c9-9581-6d156a63b7e2"/>

## Summary

Replace the interpolated `number_to_expire`/`max_shapes` values in the `Logger.notice(\"Expiring #{n} shapes as the number of shapes has exceeded the limit (#{max})\")` call with a static message plus those values as structured Logger metadata. Extends the OTEL log handler's `metadata_map` so the counts surface as `shape.expiry.number_to_expire` and `shape.expiry.max_shapes` attributes.

## Why

The expiring-shapes notice fires frequently and every entry currently contains different counts, which prevents log aggregators from grouping them together and makes filtering/aggregation in Honeycomb awkward. Following the pattern in #4145, keeping the message text static (with the dynamic values exported as attributes) makes these events easier to search, group, and alert on.

Refs electric-sql/alco-agent-tasks#33.

## Test plan

- [x] `mix compile --warnings-as-errors` passes in `packages/sync-service`