### PR TITLE
docs: add Electric Agents dev environment setup guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,41 @@ const bootstrapTodoListAction = createOptimisticAction<string>({
 })
 ```
 
+## Developing Electric Agents
+
+The agents subsystem spans five packages: `agents-runtime`, `agents-server`, `agents` (built-in Horton & Worker), `agents-server-ui`, and `agents-server-conformance-tests`.
+
+**Quick start** (all commands from project root, ensure `.env` has `ANTHROPIC_API_KEY`):
+
+```sh
+# 1. Install deps + build prerequisites (fresh checkout/worktree only)
+pnpm install && pnpm -C packages/typescript-client build
+
+# 2. Backing services (Postgres, Electric, Jaeger)
+docker compose -f packages/agents-server/docker-compose.dev.yml up -d
+
+# 3. Build agents-runtime first (other packages depend on it)
+pnpm -C packages/agents-runtime dev             # wait for "Build complete"
+
+# 4. Build agents-server + agents in parallel
+pnpm -C packages/agents-server dev              # terminal 2
+pnpm -C packages/agents dev                     # terminal 3
+
+# 5. Start server processes (run from root to pick up .env)
+DATABASE_URL=postgresql://electric_agents:electric_agents@localhost:5432/electric_agents \
+  ELECTRIC_AGENTS_ELECTRIC_URL=http://localhost:3060 \
+  ELECTRIC_INSECURE=true \
+  node packages/agents-server/dist/entrypoint.js  # terminal 4
+
+ELECTRIC_AGENTS_SERVER_URL=http://localhost:4437 \
+  node packages/agents/dist/entrypoint.js         # terminal 5
+
+# 6. UI dashboard
+pnpm -C packages/agents-server-ui dev             # terminal 6
+```
+
+See **[docs/agents-development.md](docs/agents-development.md)** for the full guide: env vars, testing, iteration workflows, and teardown.
+
 ## Working on the TypeScript client
 
 Before making changes to `packages/typescript-client`, **always read `packages/typescript-client/SPEC.md` first**. It is the single source of truth for the ShapeStream state machine — invariants, constraints, state transitions, and how they're enforced. Design fixes and features around the spec's invariants rather than patching symptoms ad-hoc.

--- a/docs/agents-development.md
+++ b/docs/agents-development.md
@@ -159,10 +159,16 @@ pnpm dev  # starts both server (tsx watch) and UI (vite) in parallel
 
 It requires the agents-server backing services (Postgres + Electric) to be running.
 
+## Local state
+
+- **Postgres** (docker volume) — entity types, entities, wake registrations, scheduling state.
+- **Durable streams** — in-memory by default in dev. Data resets on server restart. Set `ELECTRIC_AGENTS_STREAMS_DATA_DIR` to persist streams to disk (uses lmdb + log files).
+
+To clear all state: stop the servers and run `docker compose down -v` to remove the Postgres volume.
+
 ## Teardown
 
 ```sh
-cd packages/agents-server
-docker compose -f docker-compose.dev.yml down    # stop services
-docker compose -f docker-compose.dev.yml down -v  # stop + remove volumes
+docker compose -f packages/agents-server/docker-compose.dev.yml down    # stop services
+docker compose -f packages/agents-server/docker-compose.dev.yml down -v  # stop + remove volumes
 ```

--- a/docs/agents-development.md
+++ b/docs/agents-development.md
@@ -1,0 +1,168 @@
+# Electric Agents — Development Guide
+
+## Package overview
+
+The agents subsystem lives in five packages under `packages/`:
+
+| Package                           | Description                                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------- |
+| `agents-runtime`                  | Core runtime — entity definitions, context, handler lifecycle                         |
+| `agents-server`                   | Orchestration server — wake registry, scheduling, Electric + Postgres integration     |
+| `agents`                          | Built-in agents (Horton & Worker) with tools (bash, read, write, edit, fetch, search) |
+| `agents-server-ui`                | React dashboard for agent monitoring and interaction                                  |
+| `agents-server-conformance-tests` | Conformance test suite for agents-server                                              |
+
+## Prerequisites
+
+- **Docker Desktop** running (for Postgres + Electric)
+- **Node.js** and **pnpm** (see `.tool-versions` for exact versions)
+- **`.env` file** at the project root with at least `ANTHROPIC_API_KEY` (needed by built-in agents). Both entrypoints call `process.loadEnvFile()` on startup, loading from the current working directory — so always run entrypoints from the project root.
+
+## Starting the dev environment
+
+All commands below assume you are in the project root. All `pnpm dev` commands use `tsdown --watch` (or Vite for the UI) — they do an initial build then watch for changes. The build order matters because packages import from each other's `dist/`.
+
+### Step 1 — Install dependencies and build workspace prerequisites
+
+In a fresh checkout or worktree, workspace packages have no `dist/` directories. Agent packages depend on `@electric-sql/client` (the typescript-client) at runtime, so it must be built before starting any agent server.
+
+```sh
+pnpm install
+pnpm -C packages/typescript-client build
+```
+
+### Step 2 — Start backing services (Postgres + Electric + Jaeger)
+
+```sh
+docker compose -f packages/agents-server/docker-compose.dev.yml up -d
+```
+
+Services will be available at:
+
+- PostgreSQL: `localhost:5432` (electric_agents/electric_agents)
+- Electric API: `http://localhost:3060`
+- Jaeger UI: `http://localhost:16686` (tracing)
+
+### Step 3 — Build agents-runtime
+
+`agents-server` and `agents` both depend on `agents-runtime`, so it must be built first.
+
+```sh
+pnpm -C packages/agents-runtime dev
+# wait for "Build complete" before step 4
+```
+
+### Step 4 — Build agents-server and agents
+
+These can be started in parallel once the runtime is built.
+
+```sh
+# Terminal 2:
+pnpm -C packages/agents-server dev
+
+# Terminal 3:
+pnpm -C packages/agents dev
+```
+
+Wait for both "Build complete" messages before step 5.
+
+### Step 5 — Start the server processes
+
+Run entrypoints from the project root so they pick up the root `.env` file.
+
+```sh
+# Terminal 4: agents-server
+DATABASE_URL=postgresql://electric_agents:electric_agents@localhost:5432/electric_agents \
+  ELECTRIC_AGENTS_ELECTRIC_URL=http://localhost:3060 \
+  ELECTRIC_INSECURE=true \
+  node packages/agents-server/dist/entrypoint.js
+```
+
+The agents-server will start on `http://localhost:4437` with an embedded durable streams server.
+
+```sh
+# Terminal 5: built-in agents (Horton + Worker)
+ELECTRIC_AGENTS_SERVER_URL=http://localhost:4437 \
+  node packages/agents/dist/entrypoint.js
+```
+
+The built-in agents server starts on `http://localhost:4448` and auto-registers Horton and Worker entity types.
+
+### Step 6 — Start the agents UI dashboard
+
+```sh
+pnpm -C packages/agents-server-ui dev
+```
+
+Vite dev server with HMR — changes appear instantly.
+
+## Environment variables reference
+
+### agents-server
+
+| Variable                              | Default   | Description                                         |
+| ------------------------------------- | --------- | --------------------------------------------------- |
+| `DATABASE_URL`                        | —         | Postgres connection URL (required)                  |
+| `ELECTRIC_AGENTS_ELECTRIC_URL`        | —         | Electric sync service URL                           |
+| `ELECTRIC_AGENTS_HOST`                | `0.0.0.0` | Bind address                                        |
+| `ELECTRIC_AGENTS_PORT`                | `4437`    | Server port                                         |
+| `ELECTRIC_AGENTS_BASE_URL`            | —         | Public webhook base URL                             |
+| `ELECTRIC_AGENTS_STREAMS_DATA_DIR`    | —         | Local streams data directory                        |
+| `ELECTRIC_AGENTS_DURABLE_STREAMS_URL` | —         | External durable streams URL (omit to use embedded) |
+
+### agents (built-in)
+
+| Variable                       | Default     | Description                  |
+| ------------------------------ | ----------- | ---------------------------- |
+| `ELECTRIC_AGENTS_SERVER_URL`   | —           | agents-server URL (required) |
+| `ANTHROPIC_API_KEY`            | —           | Claude API key (required)    |
+| `ELECTRIC_AGENTS_BUILTIN_HOST` | `127.0.0.1` | Bind address                 |
+| `ELECTRIC_AGENTS_BUILTIN_PORT` | `4448`      | Server port                  |
+
+## Running tests
+
+```sh
+# Runtime unit tests (no services needed)
+cd packages/agents-runtime
+pnpm test
+
+# Server tests (requires Postgres + Electric via docker-compose.dev.yml)
+cd packages/agents-server
+pnpm test
+
+# Built-in agents tests
+cd packages/agents
+pnpm test
+
+# All with coverage
+pnpm coverage  # in any agent package
+```
+
+## Iterating on agent packages
+
+All agent packages use `tsdown` for building. The `pnpm dev` command in each starts a watch-mode rebuild, so changes are picked up automatically.
+
+- **Runtime changes** (`agents-runtime`): Rebuild propagates to `agents-server` and `agents` since they depend on it via workspace links.
+- **Server changes** (`agents-server`): Restart `node dist/entrypoint.js` after rebuild (watch mode rebuilds but does not restart the process).
+- **Agent logic changes** (`agents`): Same — restart the entrypoint after rebuild.
+- **UI changes** (`agents-server-ui`): Vite HMR — changes appear instantly.
+
+## Working with examples
+
+The `examples/deep-survey` example demonstrates a custom agent with its own entity types:
+
+```sh
+cd examples/deep-survey
+pnpm install
+pnpm dev  # starts both server (tsx watch) and UI (vite) in parallel
+```
+
+It requires the agents-server backing services (Postgres + Electric) to be running.
+
+## Teardown
+
+```sh
+cd packages/agents-server
+docker compose -f docker-compose.dev.yml down    # stop services
+docker compose -f docker-compose.dev.yml down -v  # stop + remove volumes
+```


### PR DESCRIPTION
## Summary
- Add `docs/agents-development.md` with full guide for setting up the Electric Agents dev environment: backing services, build ordering, env vars, testing, iteration workflows, and teardown
- Add quick-start section to `AGENTS.md` linking to the full guide
- Instructions tested end-to-end in a fresh worktree — covers `pnpm install`, prerequisite builds (`typescript-client`, `agents-runtime`), docker compose services, and server entrypoints

## Test plan
- [x] Followed instructions from scratch in a fresh git worktree
- [x] Verified docker compose brings up Postgres, Electric, and Jaeger
- [x] Verified agents-server starts and runs migrations
- [x] Verified built-in agents (Horton + Worker) register successfully
- [x] Verified UI dashboard starts on Vite dev server
- [x] Confirmed `.env` at project root is picked up by `process.loadEnvFile()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)