### PR TITLE
fix(agents-server): strip upstream CORS headers in Electric proxy

### DIFF
--- a/.changeset/pretty-socks-smash.md
+++ b/.changeset/pretty-socks-smash.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server': patch
+---
+
+fix: ensure CORS is set to \*

--- a/packages/agents-server/src/server.ts
+++ b/packages/agents-server/src/server.ts
@@ -1917,7 +1917,8 @@ export class ElectricAgentsServer {
         key === `content-encoding` ||
         key === `content-length` ||
         key === `transfer-encoding` ||
-        key === `connection`
+        key === `connection` ||
+        key.startsWith(`access-control-`)
       ) {
         return
       }


### PR DESCRIPTION
## Summary
- Strip `access-control-*` headers from upstream Electric responses in the agents-server proxy
- The agents-server already sets `access-control-allow-origin: *` on all responses, but upstream Electric headers were overwriting this with a specific origin, causing CORS failures when the UI restarts on a different port

## Test plan
- [x] All 185 agents-server tests pass
- [x] Verified the `responseHeaders` filter now excludes `access-control-*` alongside other hop-by-hop headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)