### PR TITLE
docs: add deep survey README and fix env/dep issues

### DIFF
--- a/examples/deep-survey/README.md
+++ b/examples/deep-survey/README.md
@@ -79,39 +79,25 @@ The orchestrator creates the shared DB, and each explorer receives a handle to i
 From the repository root:
 
 ```bash
-pnpm install
-```
-
-Then build the agents-runtime package (the example links to it via the monorepo workspace):
-
-```bash
-pnpm --filter @electric-ax/agents-runtime build
+pnpm install && pnpm --filter @electric-ax/agents-runtime build
 ```
 
 ### 2. Configure environment
 
-Create a `.env` file in the `examples/deep-survey/` directory:
+Create a `.env` file in this directory:
 
 ```bash
-ANTHROPIC_API_KEY=sk-ant-...
-BRAVE_SEARCH_API_KEY=...  # optional
+ANTHROPIC_API_KEY=sk-ant-...       # https://console.anthropic.com/
+BRAVE_SEARCH_API_KEY=...           # https://brave.com/search/api/ (optional)
 ```
 
 ### 3. Start the Electric Agents server
-
-This starts the Electric Agents server and its backing infrastructure (Postgres, Electric) via Docker:
 
 ```bash
 npx electric-ax agent quickstart
 ```
 
-Or from the monorepo root using the dev CLI:
-
-```bash
-node packages/electric-ax/bin/electric-dev.mjs agent quickstart
-```
-
-The agents server will be available at `http://localhost:4437`.
+This starts the agents server and its backing infrastructure (Postgres, Electric) via Docker. The agents server will be available at `http://localhost:4437`.
 
 ### 4. Run the example
 
@@ -129,13 +115,21 @@ The UI will be available at `http://localhost:5175`.
 
 ### Stopping
 
-To stop the Electric Agents infrastructure:
-
 ```bash
 npx electric-ax agent stop
 ```
 
 Add `--remove-volumes` to also delete persisted data.
+
+### Local CLI
+
+You can also use the dev CLI directly from the monorepo instead of `npx`:
+
+```bash
+node packages/electric-ax/bin/electric-dev.mjs agent quickstart
+node packages/electric-ax/bin/electric-dev.mjs agent run
+node packages/electric-ax/bin/electric-dev.mjs agent stop
+```
 
 ## Tech Stack
 

--- a/examples/deep-survey/README.md
+++ b/examples/deep-survey/README.md
@@ -1,0 +1,186 @@
+# Deep Survey
+
+A multi-agent deep research app powered by [Electric Agents](../../packages/agents-runtime/). An orchestrator coordinates a swarm of ~50 AI explorer agents that research a topic in parallel, each performing real web searches and writing wiki entries with cross-references — all synchronized in real time through shared state.
+
+## How It Works
+
+1. **You provide a target** — a topic, codebase, or any subject to explore
+2. **The orchestrator agent** does initial web research to understand the landscape, then decomposes it into individual topics
+3. **Explorer agents spawn in parallel** — one per topic — each with web search and URL fetching capabilities
+4. **Each explorer researches its topic**, writes a wiki entry (100–200 words of synthesized findings), and creates cross-references to related entries in the shared knowledge base
+5. **The live dashboard** shows everything happening in real time: agent status, the growing knowledge graph, wiki entries, and activity
+
+Once the swarm completes, you can ask follow-up questions in the chat sidebar. The orchestrator queries the accumulated wiki to synthesize answers across all explored topics.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     React Frontend                      │
+│  SwarmGraph · WikiColumn · ChatSidebar · ActivityHeatmap│
+│                          │                              │
+│              useSwarm hook (TanStack DB)                 │
+│                    real-time sync                        │
+└──────────────────────────┬──────────────────────────────┘
+                           │
+                Electric Agents Server
+                   (entity runtime)
+                           │
+              ┌────────────┴────────────┐
+              │                         │
+        Orchestrator              Shared State DB
+        (Claude LLM)             ┌──────┴──────┐
+              │                  │ wiki entries │
+     ┌────────┼────────┐        │ cross-refs   │
+     │        │        │        └──────────────┘
+  Explorer Explorer Explorer         ▲
+  Agent 1  Agent 2  Agent N ─────────┘
+     │        │        │        read/write
+     └────────┴────────┘
+       brave_search
+       fetch_url
+```
+
+**Backend** — Two entity types registered with the Electric Agents runtime:
+
+- **Orchestrator**: Receives the user's target, performs initial web research via the Brave Search API, then calls `explore_corpus` to decompose the target into topics and spawn N explorer agents. Uses shared state to query the accumulated wiki and answer follow-up questions.
+- **Explorer workers**: Each explorer gets `brave_search` and `fetch_url` tools, plus auto-generated CRUD tools (`write_wiki`, `read_wiki`, `write_xrefs`, etc.) for the shared knowledge base. After researching their topic and writing an entry, they scan other entries and record cross-references.
+
+**Frontend** — Real-time reactive UI built with React 19 and TanStack DB:
+
+- **SwarmGraph** — Interactive D3 force-directed graph showing the spawn tree and knowledge cross-references
+- **WikiColumn** — Browsable knowledge base with table of contents and cross-reference links
+- **ChatSidebar** — Orchestrator message timeline and follow-up input
+- **ActivityHeatmap** — Color-coded grid showing agent status (spawning, running, idle, stopped)
+- **StreamLog** — Live tail of the most recent agent events
+
+## Shared State
+
+Agents coordinate through a shared state database with two collections defined as [Zod](https://zod.dev/) schemas:
+
+| Collection | Fields                                       | Purpose                                    |
+| ---------- | -------------------------------------------- | ------------------------------------------ |
+| `wiki`     | `key`, `title`, `body`, `author`, `improved` | Research findings per topic                |
+| `xrefs`    | `key`, `a`, `b`                              | Cross-reference edges between wiki entries |
+
+The orchestrator creates the shared DB, and each explorer receives a handle to it when spawned. The frontend subscribes to these collections for live updates as agents write their findings.
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) v22+
+- [Docker](https://www.docker.com/) (for the Electric Agents infrastructure)
+- An [Anthropic API key](https://console.anthropic.com/)
+- (Optional) A [Brave Search API key](https://brave.com/search/api/) for web research
+
+### 1. Install dependencies
+
+From the repository root:
+
+```bash
+pnpm install
+```
+
+Then build the agents-runtime package (the example links to it via the monorepo workspace):
+
+```bash
+pnpm --filter @electric-ax/agents-runtime build
+```
+
+### 2. Configure environment
+
+Create a `.env` file in the `examples/deep-survey/` directory:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+BRAVE_SEARCH_API_KEY=...  # optional
+```
+
+### 3. Start the Electric Agents server
+
+This starts the Electric Agents server and its backing infrastructure (Postgres, Electric) via Docker:
+
+```bash
+npx electric-ax agent quickstart
+```
+
+Or from the monorepo root using the dev CLI:
+
+```bash
+node packages/electric-ax/bin/electric-dev.mjs agent quickstart
+```
+
+The agents server will be available at `http://localhost:4437`.
+
+### 4. Run the example
+
+Start the entity server and the UI dev server in separate terminals:
+
+```bash
+# Terminal 1 — entity server (registers the orchestrator with the agents server)
+pnpm run dev:server
+
+# Terminal 2 — Vite UI dev server
+pnpm run dev:ui
+```
+
+The UI will be available at `http://localhost:5175`.
+
+### Stopping
+
+To stop the Electric Agents infrastructure:
+
+```bash
+npx electric-ax agent stop
+```
+
+Add `--remove-volumes` to also delete persisted data.
+
+## Tech Stack
+
+| Layer             | Technology                                                    |
+| ----------------- | ------------------------------------------------------------- |
+| Agent runtime     | [@electric-ax/agents-runtime](../../packages/agents-runtime/) |
+| LLM               | Claude (Anthropic API)                                        |
+| Web search        | Brave Search API                                              |
+| Frontend          | React 19, Vite 7, TypeScript                                  |
+| Real-time state   | TanStack DB, Durable Streams                                  |
+| Visualization     | D3.js force simulation                                        |
+| Schema validation | Zod 4                                                         |
+| UI components     | Radix UI                                                      |
+
+## Environment Variables
+
+| Variable               | Default                  | Description                                |
+| ---------------------- | ------------------------ | ------------------------------------------ |
+| `ANTHROPIC_API_KEY`    | —                        | Anthropic API key (required)               |
+| `BRAVE_SEARCH_API_KEY` | —                        | Brave Search API key for web research      |
+| `DARIX_URL`            | `http://localhost:4437`  | Electric Agents server URL                 |
+| `PORT`                 | `4700`                   | Backend server port                        |
+| `SERVE_URL`            | `http://localhost:$PORT` | Webhook callback URL for the agents server |
+
+## Project Structure
+
+```
+src/
+├── server/
+│   ├── index.ts          # HTTP server, API endpoints, entity registration
+│   ├── orchestrator.ts   # Orchestrator entity: prompts, tools, spawn logic
+│   ├── explorer.ts       # Explorer agent blueprint and spawn args
+│   └── schema.ts         # Shared state Zod schemas (wiki + xrefs)
+└── ui/
+    ├── main.tsx           # App entry point, swarm lifecycle
+    ├── swarm-theme.css    # Dark monospace theme
+    ├── hooks/
+    │   └── useSwarm.ts    # Real-time entity and shared state subscriptions
+    └── components/
+        ├── SwarmView.tsx       # Main 3-column layout
+        ├── TopBar.tsx          # Status bar with counts
+        ├── ChatSidebar.tsx     # Message history and input
+        ├── SwarmGraph.tsx      # D3 force-directed graph
+        ├── WikiColumn.tsx      # Knowledge base browser
+        ├── StreamLog.tsx       # Live activity log
+        ├── ActivityHeatmap.tsx  # Agent status grid
+        └── AgentList.tsx       # Scrollable agent list
+```

--- a/examples/deep-survey/package.json
+++ b/examples/deep-survey/package.json
@@ -11,13 +11,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@electric-ax/agents-runtime": "workspace:*",
     "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@electric-ax/agents-runtime": "workspace:*",
+    "@mariozechner/pi-agent-core": "^0.57.1",
     "@radix-ui/themes": "^3.3.0",
+    "@sinclair/typebox": "^0.34.0",
     "@tanstack/db": "^0.6.0",
     "@tanstack/react-db": "^0.1.78",
-    "@mariozechner/pi-agent-core": "^0.57.1",
-    "@sinclair/typebox": "^0.34.0",
     "d3-force": "^3.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -29,7 +29,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
     "tsx": "^4.0.0",
-    "typescript": "~5.9.3",
+    "typescript": "^5.7.0",
     "vite": "^7.2.4"
   }
 }

--- a/examples/deep-survey/src/server/index.ts
+++ b/examples/deep-survey/src/server/index.ts
@@ -1,10 +1,17 @@
 import path from 'node:path'
 
-try {
-  process.loadEnvFile(path.resolve(import.meta.dirname, `../../../../.env`))
-} catch (err) {
-  if ((err as NodeJS.ErrnoException).code !== `ENOENT`) {
-    console.error(`Failed to load .env file:`, err)
+// Load repo root .env first, then local .env (local values take precedence)
+const envPaths = [
+  path.resolve(import.meta.dirname, `../../../../.env`),
+  path.resolve(import.meta.dirname, `../../.env`),
+]
+for (const envPath of envPaths) {
+  try {
+    process.loadEnvFile(envPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== `ENOENT`) {
+      console.error(`Failed to load .env file:`, err)
+    }
   }
 }
 

--- a/examples/deep-survey/src/ui/components/TopBar.tsx
+++ b/examples/deep-survey/src/ui/components/TopBar.tsx
@@ -83,7 +83,17 @@ export function TopBar({
         background: `var(--swarm-bg-topbar)`,
       }}
     >
-      <div style={{ display: `flex`, alignItems: `center`, gap: 9 }}>
+      <div
+        style={{
+          display: `flex`,
+          alignItems: `center`,
+          gap: 9,
+          cursor: `pointer`,
+        }}
+        onClick={() => {
+          window.location.hash = ``
+        }}
+      >
         <div
           style={{
             width: 16,

--- a/examples/deep-survey/src/ui/main.tsx
+++ b/examples/deep-survey/src/ui/main.tsx
@@ -4,15 +4,30 @@ import { useSwarm } from './hooks/useSwarm'
 import { SwarmView } from './components/SwarmView'
 import './swarm-theme.css'
 
+function getSwarmFromHash(): {
+  name: string
+  orchestratorUrl: string
+} | null {
+  const hash = window.location.hash.slice(1)
+  if (!hash) return null
+  return { name: hash, orchestratorUrl: `/orchestrator/${hash}` }
+}
+
 function App() {
   const [config, setConfig] = useState<{ darixUrl: string } | null>(null)
   const [swarm, setSwarm] = useState<{
     name: string
     orchestratorUrl: string
-  } | null>(null)
+  } | null>(getSwarmFromHash)
   const [inputValue, setInputValue] = useState(``)
   const [starting, setStarting] = useState(false)
   const [launchError, setLaunchError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const onHashChange = () => setSwarm(getSwarmFromHash())
+    window.addEventListener(`hashchange`, onHashChange)
+    return () => window.removeEventListener(`hashchange`, onHashChange)
+  }, [])
 
   useEffect(() => {
     fetch(`/api/config`)
@@ -53,6 +68,7 @@ function App() {
         name: string
         orchestratorUrl: string
       }
+      window.location.hash = data.name
       setSwarm(data)
     } catch (err) {
       setLaunchError(err instanceof Error ? err.message : String(err))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
     dependencies:
       '@durable-streams/state':
         specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.9.3)'
+        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../../packages/agents-runtime
@@ -109,10 +109,10 @@ importers:
         version: 0.34.49
       '@tanstack/db':
         specifier: ^0.6.0
-        version: 0.6.5(typescript@5.9.3)
+        version: 0.6.5(typescript@5.8.3)
       '@tanstack/react-db':
         specifier: ^0.1.78
-        version: 0.1.83(react@19.2.5)(typescript@5.9.3)
+        version: 0.1.83(react@19.2.5)(typescript@5.8.3)
       d3-force:
         specifier: ^3.0.0
         version: 3.0.0
@@ -142,8 +142,8 @@ importers:
         specifier: ^4.0.0
         version: 4.20.3
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ^5.7.0
+        version: 5.8.3
       vite:
         specifier: ^7.2.4
         version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1)
@@ -10050,8 +10050,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.6:
-    resolution: {integrity: sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==}
+  baseline-browser-mapping@2.10.21:
+    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   basic-ftp@5.3.0:
@@ -21025,14 +21026,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.9.3)':
-    dependencies:
-      '@durable-streams/client': '@electric-ax/durable-streams-client-beta@0.3.0'
-      '@standard-schema/spec': 1.1.0
-      '@tanstack/db': 0.6.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - typescript
-
   '@electric-sql/client@1.0.0-beta.3':
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.24.4
@@ -26265,12 +26258,6 @@ snapshots:
       sorted-btree: 1.8.1
       typescript: 5.8.3
 
-  '@tanstack/db-ivm@0.1.18(typescript@5.9.3)':
-    dependencies:
-      fractional-indexing: 3.2.0
-      sorted-btree: 1.8.1
-      typescript: 5.9.3
-
   '@tanstack/db@0.0.27(typescript@5.8.3)':
     dependencies:
       '@electric-sql/d2mini': 0.1.8
@@ -26296,13 +26283,6 @@ snapshots:
       '@tanstack/db-ivm': 0.1.18(typescript@5.8.3)
       '@tanstack/pacer-lite': 0.2.1
       typescript: 5.8.3
-
-  '@tanstack/db@0.6.5(typescript@5.9.3)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@tanstack/db-ivm': 0.1.18(typescript@5.9.3)
-      '@tanstack/pacer-lite': 0.2.1
-      typescript: 5.9.3
 
   '@tanstack/devtools-client@0.0.4':
     dependencies:
@@ -26429,9 +26409,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@tanstack/react-db@0.1.83(react@19.2.5)(typescript@5.9.3)':
+  '@tanstack/react-db@0.1.83(react@19.2.5)(typescript@5.8.3)':
     dependencies:
-      '@tanstack/db': 0.6.5(typescript@5.9.3)
+      '@tanstack/db': 0.6.5(typescript@5.8.3)
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
     transitivePeerDependencies:
@@ -28940,7 +28920,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.6: {}
+  baseline-browser-mapping@2.10.21: {}
 
   basic-ftp@5.3.0: {}
 
@@ -29096,7 +29076,7 @@ snapshots:
 
   browserslist@4.26.2:
     dependencies:
-      baseline-browser-mapping: 2.8.6
+      baseline-browser-mapping: 2.10.21
       caniuse-lite: 1.0.30001743
       electron-to-chromium: 1.5.223
       node-releases: 2.0.21


### PR DESCRIPTION
## Summary

- Add README for the deep-survey example with architecture overview, setup instructions (using `npx electric-ax agent quickstart`), tech stack, env vars, and project structure
- Fix `.env` loading in `src/server/index.ts` to load both repo root and local `.env` files (local values take precedence), so API keys can be split across files
- Change example's typescript version from `~5.9.3` to `^5.7.0` to match `agents-runtime`, preventing pnpm from creating duplicate `@tanstack/db` instances that caused "not a Collection" runtime errors in `queryOnce`

## Test plan

- [ ] `pnpm install` from repo root
- [ ] `npx electric-ax agent quickstart` starts infrastructure + built-in agents
- [ ] `pnpm run dev:server` and `pnpm run dev:ui` from `examples/deep-survey/`
- [ ] Verify `.env` in example directory is picked up (e.g. `BRAVE_SEARCH_API_KEY`)
- [ ] Verify `.env` at repo root is also loaded (e.g. `ANTHROPIC_API_KEY`)
- [ ] Submit a survey topic in the UI and confirm orchestrator + explorers run

🤖 Generated with [Claude Code](https://claude.com/claude-code)