### PR TITLE
chore: add changeset for worker shared state support

### DIFF
--- a/.changeset/worker-shared-state.md
+++ b/.changeset/worker-shared-state.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': patch
+---
+
+feat: add shared state (sharedDb) support to built-in worker agent


### PR DESCRIPTION
## Summary
- Adds a patch changeset for `@electric-ax/agents` to release the shared state (`sharedDb`) support added to the built-in worker agent, which was missed in the last publish.

## Test plan
- [ ] Verify changeset is picked up by `changeset version`
- [ ] Confirm `@electric-ax/agents` gets a patch bump on next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)