### PR TITLE
fix: electric-ax quickstart to fail fast without Anthropic key

### DIFF
--- a/.changeset/quickstart-anthropic-key.md
+++ b/.changeset/quickstart-anthropic-key.md
@@ -1,0 +1,5 @@
+---
+"electric-ax": patch
+---
+
+Block `electric agent quickstart` before startup when no Anthropic API key is available.

--- a/packages/electric-ax/src/env.ts
+++ b/packages/electric-ax/src/env.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs'
+import { resolve as resolvePath } from 'node:path'
+
+interface AnthropicApiKeyOptions {
+  anthropicApiKey?: string
+}
+
+function parseDotEnvValue(raw: string): string {
+  const trimmed = raw.trim()
+  if (
+    (trimmed.startsWith(`"`) && trimmed.endsWith(`"`)) ||
+    (trimmed.startsWith(`'`) && trimmed.endsWith(`'`))
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  const hashIndex = trimmed.indexOf(`#`)
+  return hashIndex === -1 ? trimmed : trimmed.slice(0, hashIndex).trim()
+}
+
+export function readDotEnvFile(
+  cwd: string = process.cwd()
+): Record<string, string> {
+  const envPath = resolvePath(cwd, `.env`)
+
+  try {
+    const content = readFileSync(envPath, `utf8`)
+    const values: Record<string, string> = {}
+
+    for (const line of content.split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith(`#`)) {
+        continue
+      }
+
+      const equalsIndex = trimmed.indexOf(`=`)
+      if (equalsIndex <= 0) {
+        continue
+      }
+
+      const key = trimmed.slice(0, equalsIndex).trim()
+      const value = parseDotEnvValue(trimmed.slice(equalsIndex + 1))
+      values[key] = value
+    }
+
+    return values
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === `ENOENT`) {
+      return {}
+    }
+    throw error
+  }
+}
+
+export function resolveAnthropicApiKey(
+  options: AnthropicApiKeyOptions,
+  env: NodeJS.ProcessEnv = process.env,
+  fileEnv: Record<string, string> = readDotEnvFile()
+): string {
+  const candidate =
+    options.anthropicApiKey?.trim() ||
+    env.ANTHROPIC_API_KEY?.trim() ||
+    fileEnv.ANTHROPIC_API_KEY?.trim()
+
+  if (!candidate) {
+    throw new Error(
+      `ANTHROPIC_API_KEY is required. Pass --anthropic-api-key, export it in your shell, or set it in .env.`
+    )
+  }
+
+  return candidate
+}

--- a/packages/electric-ax/src/index.ts
+++ b/packages/electric-ax/src/index.ts
@@ -6,6 +6,7 @@ import { basename, resolve as resolvePath } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Command } from 'commander'
 import { installCompletions, setupCompletions } from './completions.js'
+import { resolveAnthropicApiKey } from './env.js'
 import type {
   ElectricAgentsEntityRow,
   ElectricAgentsEntityType,
@@ -514,6 +515,7 @@ export function createElectricCliHandlers(
       return stopped
     },
     quickstart: async (options) => {
+      resolveAnthropicApiKey(options)
       const { startBuiltinAgentsServer, startElectricAgentsDevEnvironment } =
         await loadStartModule()
       const started = await startElectricAgentsDevEnvironment()

--- a/packages/electric-ax/src/start.ts
+++ b/packages/electric-ax/src/start.ts
@@ -1,13 +1,14 @@
-import { readFileSync } from 'node:fs'
-import { resolve as resolvePath } from 'node:path'
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { BuiltinAgentsServer } from '@electric-ax/agents'
+import { readDotEnvFile, resolveAnthropicApiKey } from './env.js'
 import type {
   StartCommandOptions,
   StartBuiltinCommandOptions,
   StopCommandOptions,
 } from './index.js'
+
+export { readDotEnvFile, resolveAnthropicApiKey } from './env.js'
 
 const DEFAULT_ELECTRIC_AGENTS_PORT = 4437
 const DEFAULT_BUILTIN_AGENTS_PORT = 4448
@@ -38,71 +39,6 @@ interface WaitForServerOptions {
   fetchImpl?: typeof globalThis.fetch
   timeoutMs?: number
   intervalMs?: number
-}
-
-function parseDotEnvValue(raw: string): string {
-  const trimmed = raw.trim()
-  if (
-    (trimmed.startsWith(`"`) && trimmed.endsWith(`"`)) ||
-    (trimmed.startsWith(`'`) && trimmed.endsWith(`'`))
-  ) {
-    return trimmed.slice(1, -1)
-  }
-  const hashIndex = trimmed.indexOf(`#`)
-  return hashIndex === -1 ? trimmed : trimmed.slice(0, hashIndex).trim()
-}
-
-export function readDotEnvFile(
-  cwd: string = process.cwd()
-): Record<string, string> {
-  const envPath = resolvePath(cwd, `.env`)
-
-  try {
-    const content = readFileSync(envPath, `utf8`)
-    const values: Record<string, string> = {}
-
-    for (const line of content.split(/\r?\n/)) {
-      const trimmed = line.trim()
-      if (!trimmed || trimmed.startsWith(`#`)) {
-        continue
-      }
-
-      const equalsIndex = trimmed.indexOf(`=`)
-      if (equalsIndex <= 0) {
-        continue
-      }
-
-      const key = trimmed.slice(0, equalsIndex).trim()
-      const value = parseDotEnvValue(trimmed.slice(equalsIndex + 1))
-      values[key] = value
-    }
-
-    return values
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === `ENOENT`) {
-      return {}
-    }
-    throw error
-  }
-}
-
-export function resolveAnthropicApiKey(
-  options: StartBuiltinCommandOptions,
-  env: NodeJS.ProcessEnv = process.env,
-  fileEnv: Record<string, string> = readDotEnvFile()
-): string {
-  const candidate =
-    options.anthropicApiKey?.trim() ||
-    env.ANTHROPIC_API_KEY?.trim() ||
-    fileEnv.ANTHROPIC_API_KEY?.trim()
-
-  if (!candidate) {
-    throw new Error(
-      `ANTHROPIC_API_KEY is required. Pass --anthropic-api-key, export it in your shell, or set it in .env.`
-    )
-  }
-
-  return candidate
 }
 
 export function resolveBuiltinAgentsPort(

--- a/packages/electric-ax/test/cli.test.ts
+++ b/packages/electric-ax/test/cli.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createElectricProgram, resolveCommandPrefix, run } from '../src/index'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createElectricCliHandlers,
+  createElectricProgram,
+  resolveCommandPrefix,
+  run,
+} from '../src/index'
 import type {
   ElectricCliEnv,
   ElectricCliHandlers,
@@ -239,6 +247,28 @@ describe(`createElectricProgram`, () => {
         anthropicApiKey: `sk-ant-test`,
       })
     )
+  })
+
+  it(`blocks quickstart when no Anthropic API key is available`, async () => {
+    const originalCwd = process.cwd()
+    const originalKey = process.env.ANTHROPIC_API_KEY
+    const tmpDir = mkdtempSync(join(tmpdir(), `electric-ax-quickstart-`))
+
+    try {
+      process.chdir(tmpDir)
+      delete process.env.ANTHROPIC_API_KEY
+
+      await expect(
+        createElectricCliHandlers(TEST_ENV).quickstart({})
+      ).rejects.toThrow(/ANTHROPIC_API_KEY/)
+    } finally {
+      process.chdir(originalCwd)
+      if (originalKey === undefined) {
+        delete process.env.ANTHROPIC_API_KEY
+      } else {
+        process.env.ANTHROPIC_API_KEY = originalKey
+      }
+    }
   })
 
   it(`registers the nested completion command`, async () => {


### PR DESCRIPTION
## Summary
- Added a lightweight env resolver so `quickstart` can validate `ANTHROPIC_API_KEY` before loading the startup module.
- Kept the existing startup path intact by re-exporting the env helpers from `start.ts`.
- Added a regression test that verifies quickstart fails immediately when no key is available.

## Testing
- `pnpm format`
- `pnpm -C packages/electric-ax exec vitest run test/cli.test.ts test/start.test.ts`
- `pnpm -C packages/electric-ax test`
- `pnpm -C packages/electric-ax typecheck`
- `pnpm -C packages/electric-ax build`