### PR TITLE
fix(website): remove stale nextjs and remix embeds

### DIFF
--- a/website/demos/nextjs.md
+++ b/website/demos/nextjs.md
@@ -3,7 +3,6 @@ title: Next.js
 description: >-
   Example of an Electric app using Next.js.
 deployed_url: https://nextjs.examples.electric-sql.com/
-source_url: https://github.com/electric-sql/electric/tree/main/examples/nextjs
 image: /img/demos/items-screenshot.png
 example: true
 ---
@@ -16,10 +15,14 @@ example: true
 
 ## Next.js example app
 
-This is an example using Electric with [Next.js](/docs/integrations/next).
+This page refers to the historical Electric demo built with
+[Next.js](/docs/integrations/next).
 
-The entrypoint for the Electric-specific code is in [`./app/page.tsx`](https://github.com/electric-sql/electric/blob/main/examples/nextjs/app/page.tsx):
+The `examples/nextjs` source tree was removed from the repository on April 23,
+2026 after it fell behind the supported Next.js and React stack, so there is
+no maintained in-repo source snapshot to embed here on `main`.
 
-<<< @../../examples/nextjs/app/page.tsx{tsx}
+For current guidance, see the [Next.js integration guide](/docs/integrations/next),
+[auth guide](/docs/guides/auth), and [write patterns guide](/docs/guides/writes).
 
 <DemoCTAs :demo="$frontmatter" />

--- a/website/demos/remix.md
+++ b/website/demos/remix.md
@@ -3,7 +3,6 @@ title: Remix
 description: >-
   Example of an Electric app using Remix.
 deployed_url: https://remix.examples.electric-sql.com/
-source_url: https://github.com/electric-sql/electric/tree/main/examples/nextjs
 image: /img/demos/items-screenshot.png
 example: true
 ---
@@ -18,8 +17,11 @@ example: true
 
 This is an example using Electric with [Remix](https://remix.run/).
 
-The entrypoint for the Electric-specific code is in [`./app/routes/_index.tsx`](https://github.com/electric-sql/electric/blob/main/examples/remix/app/routes/_index.tsx):
+The `examples/remix` source tree was removed from the repository on April 23,
+2026 after it fell behind the maintained example set, so there is no
+in-repo source snapshot to embed here on `main`.
 
-<<< @../../examples/remix/app/routes/_index.tsx{tsx}
+For current guidance, see the [React integration guide](/docs/integrations/react),
+[auth guide](/docs/guides/auth), and [write patterns guide](/docs/guides/writes).
 
 <DemoCTAs :demo="$frontmatter" />

--- a/website/docs/integrations/next.md
+++ b/website/docs/integrations/next.md
@@ -20,13 +20,21 @@ Next.js is based on React. Electric [works with React](./react). You can integra
 
 #### Next.js example
 
-See the [Nextjs example](/demos/nextjs) on GitHub. This demonstrates using Electric for read-path sync and a Next.js API for handling writes:
+We do not currently ship a maintained `examples/nextjs` app in this repository.
+The previous example was removed from `main` on April 23, 2026 after it fell
+behind the supported Next.js and React stack.
 
-<<< @../../examples/nextjs/app/page.tsx
+When integrating Electric with Next.js, the key pieces are:
 
-It also demonstrates using a [shape-proxy endpoint](https://github.com/electric-sql/electric/blob/main/examples/nextjs/app/shape-proxy/route.ts) for proxying access to the Electric sync service. This allows you to implement [auth](/docs/guides/auth) and routing in-front-of Electric (and other concerns like transforming or decrypting the stream) using your Next.js backend:
+- Use the normal Electric React client patterns inside client components.
+- Proxy Electric through a Next.js route handler or other server-side endpoint
+  so secrets stay on the server.
+- Handle writes through your own API and keep Electric on the read path.
 
-<<< @../../examples/nextjs/app/shape-proxy/route.ts
+The [Next.js demo page](/demos/nextjs) remains as a historical deployment
+reference. For current implementation guidance, see the
+[auth guide](/docs/guides/auth), [shapes guide](/docs/guides/shapes), and
+[write patterns guide](/docs/guides/writes).
 
 #### ElectroDrizzle
 


### PR DESCRIPTION
## Summary
- remove the stale `examples/nextjs` and `examples/remix` code embeds from the website
- remove the dead GitHub source links from the Next.js and Remix demo pages
- replace those embeds with stable guidance that points readers at the maintained docs

## Root cause
On April 23, 2026, commit `3cef0caf9` (`fix: repair broken example builds (nextjs, linearlite)`, PR #4160) removed `examples/nextjs` and `examples/remix` from `main`.

That commit fixed the example builds, but it left the website referencing deleted files in:
- `website/demos/nextjs.md`
- `website/demos/remix.md`
- `website/docs/integrations/next.md`

As of April 27, 2026, `origin/main` still failed locally in `website/` with:

```text
[vitepress] ENOENT: no such file or directory, stat '.../examples/nextjs/app/page.tsx'
file: .../website/demos/nextjs.md
```

The first hard failure was the Next.js demo page, and the Remix demo page would have been the next missing-file failure once that was fixed.

## Notes
- The breaking commit was authored by Valter Balegas in PR #4160.
- `website/demos/remix.md` also had a stale `source_url` pointing at `examples/nextjs`.
- This PR is the minimal unblock for rebasing other branches onto `main`; it does not try to decide the long-term product/docs story for maintained Next.js or Remix examples.

## Test plan
- `cd website && npm run build`
  - build now completes successfully
  - existing `vue-tweet` SSR `TypeError` output is still present but unchanged, and the build exits `0`
