### PR TITLE
fix(ci): add push trigger to rebuild agents-server Docker image on main

### DIFF
--- a/.github/workflows/agent_server_dockerhub_image.yml
+++ b/.github/workflows/agent_server_dockerhub_image.yml
@@ -1,6 +1,15 @@
 name: Publish agents-server image to Docker Hub
 
+# If you decide to modify the list of triggers for this action, don't forget to also update the
+# conditional logic in the derive_build_vars job below.
 on:
+  push:
+    branches: ['main']
+    paths:
+      - 'packages/agents-server/**'
+      - 'packages/agents-server-ui/**'
+      - 'packages/agents-runtime/**'
+  # Allows the workflow to be called by the Changesets workflow
   workflow_call:
     inputs:
       git_ref:
@@ -11,6 +20,7 @@ on:
         description: 'Optional Docker Hub tag override (derived from git_ref if omitted)'
         required: false
         type: string
+  # Allows the workflow to be triggered manually from the UI
   workflow_dispatch:
     inputs:
       git_ref:
@@ -39,13 +49,17 @@ jobs:
         env:
           INPUT_GIT_REF: ${{ inputs.git_ref }}
           INPUT_DOCKER_TAG: ${{ inputs.docker_tag }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           if [ -n "$INPUT_DOCKER_TAG" ]; then
             ref="$INPUT_GIT_REF"
             build_mode=custom
-          else
+          elif [ -n "$INPUT_GIT_REF" ]; then
             ref="refs/tags/$INPUT_GIT_REF"
             build_mode=release
+          else
+            ref="$COMMIT_SHA"
+            build_mode=canary
           fi
 
           echo "git_ref=$ref" >> $GITHUB_OUTPUT
@@ -69,12 +83,14 @@ jobs:
 
           if [ -n "$INPUT_DOCKER_TAG" ]; then
             IMAGE_TAGS="${DOCKERHUB_REPO}:${INPUT_DOCKER_TAG}"
-          else
+          elif [ "$BUILD_MODE" = "release" ]; then
             IMAGE_TAGS=$(
               printf '%s\n%s\n' \
                 "${DOCKERHUB_REPO}:latest" \
                 "${DOCKERHUB_REPO}:${AGENT_SERVER_VERSION}"
             )
+          else
+            IMAGE_TAGS="${DOCKERHUB_REPO}:canary"
           fi
 
           {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.12.1",
   "private": true,
   "scripts": {
-    "ci:publish": "pnpm '/^ci:publish:.+/' && pnpm exec changeset tag",
+    "ci:publish": "pnpm exec changeset tag && pnpm '/^ci:publish:.+/'",
     "ci:publish:hex-electric": "pnpm run --dir packages/sync-service publish:hex",
     "ci:publish:hex-electric-client": "pnpm run --dir packages/elixir-client publish:hex",
     "ci:publish:npm": "pnpm publish -r --filter './packages/**' --no-git-checks --access public",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.12.1",
   "private": true,
   "scripts": {
-    "ci:publish": "pnpm exec changeset tag && pnpm '/^ci:publish:.+/'",
+    "ci:publish": "pnpm '/^ci:publish:.+/' && pnpm exec changeset tag",
     "ci:publish:hex-electric": "pnpm run --dir packages/sync-service publish:hex",
     "ci:publish:hex-electric-client": "pnpm run --dir packages/elixir-client publish:hex",
     "ci:publish:npm": "pnpm publish -r --filter './packages/**' --no-git-checks --access public",


### PR DESCRIPTION
## Summary

The `electricax/agents-server` Docker image was never rebuilt automatically. Unlike the sync-service workflow which rebuilds on every push to main, the agents-server workflow only had `workflow_call` and `workflow_dispatch` triggers.

The `workflow_call` path (from changesets release) also never triggered because `changeset tag` is chained after hex publishing via `&&` in `ci:publish` — when hex failed ([run #4174](https://github.com/electric-sql/electric/actions/runs/24899369017), [run #4168](https://github.com/electric-sql/electric/actions/runs/24898153739)), tags were never created, so `publishedPackages` was empty.

This meant features like the state explorer (#4156) were merged and published to npm but never included in the Docker image.

## Fix

Add a `push` trigger with path filtering to `agent_server_dockerhub_image.yml`, matching the pattern used by the sync-service workflow:

- Pushes to main touching `packages/agents-server/**`, `packages/agents-server-ui/**`, or `packages/agents-runtime/**` → **canary** image
- Changesets `workflow_call` → tagged **release** image (`:latest` + version)
- `workflow_dispatch` → **custom** image

## Test plan

- [ ] Merge this PR, then push a change touching any of the three agent packages
- [ ] Confirm `electricax/agents-server:canary` is published to Docker Hub
- [ ] Verify the canary image contains the state explorer from #4156

🤖 Generated with [Claude Code](https://claude.com/claude-code)