### PR TITLE
chore: make the server confromance tests package private

### DIFF
--- a/packages/agents-server-conformance-tests/package.json
+++ b/packages/agents-server-conformance-tests/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@electric-ax/agents-server-conformance-tests",
   "version": "0.1.0",
+  "private": true,
   "description": "Conformance test suite for Electric Agents server implementations",
   "author": "Durable Stream contributors",
   "license": "Apache-2.0",


### PR DESCRIPTION
Without this changesets are trying to publish this package which is intended as internal dependency