### PR TITLE
chore: fix docker image publishing for 2 images

### DIFF
--- a/.github/workflows/agent_server_dockerhub_image.yml
+++ b/.github/workflows/agent_server_dockerhub_image.yml
@@ -106,6 +106,7 @@ jobs:
     with:
       git_ref: ${{ needs.derive_build_vars.outputs.git_ref }}
       image_repo: electricax/agents-server
+      artifact_prefix: agents-server
       context: .
       file: packages/agents-server/Dockerfile
       tags: ${{ needs.derive_build_vars.outputs.image_tags }}

--- a/.github/workflows/docker_multiarch_image.yml
+++ b/.github/workflows/docker_multiarch_image.yml
@@ -43,6 +43,11 @@ on:
         required: false
         default: '{"include":[{"platform":"linux/amd64","platform_id":"amd64","runner":"blacksmith-4vcpu-ubuntu-2404"},{"platform":"linux/arm64/v8","platform_id":"arm64","runner":"blacksmith-4vcpu-ubuntu-2404-arm"}]}'
         type: string
+      artifact_prefix:
+        description: 'Prefix used to isolate digest artifacts when multiple image publish workflows run together'
+        required: false
+        default: 'image'
+        type: string
 
 jobs:
   build_and_push_image:
@@ -82,7 +87,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.platform_id }}
+          name: ${{ inputs.artifact_prefix }}-digests-${{ matrix.platform_id }}
           path: /tmp/digests/*
 
   publish_tagged_image:
@@ -99,7 +104,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: digests-*
+          pattern: ${{ inputs.artifact_prefix }}-digests-*
           merge-multiple: true
           path: /tmp/digests
 

--- a/.github/workflows/sync_service_dockerhub_image.yml
+++ b/.github/workflows/sync_service_dockerhub_image.yml
@@ -165,7 +165,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.platform_id }}
+          name: electric-digests-${{ matrix.platform_id }}
           path: /tmp/digests/*
 
   publish_tagged_image:
@@ -181,7 +181,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: digests-*
+          pattern: electric-digests-*
           merge-multiple: true
           path: /tmp/digests
 


### PR DESCRIPTION
## Summary

Fixes Docker image publishing from the Changesets workflow when both Electric and agents-server images are published in the same workflow run.

Both workflows were uploading per-platform digest artifacts with the same names:

- `digests-amd64`
- `digests-arm64`

Both manifest jobs then downloaded `digests-*` from the shared workflow run artifact namespace. When both image publish jobs ran together, a manifest job could pick up digests from the other image repo and then fail with errors like:

```text
ERROR: docker.io/electricsql/electric@sha256:...: not found
```

or:

```text
ERROR: docker.io/electricax/agents-server@sha256:...: not found
```

## Changes

- Add an `artifact_prefix` input to the generic multi-arch Docker workflow.
- Use prefixed artifact names and download patterns in the generic workflow.
- Pass `artifact_prefix: agents-server` from the agents-server Docker workflow.
- Rename Electric image digest artifacts to `electric-digests-*`.

## Why

Artifacts are scoped to the workflow run, not isolated per reusable workflow call. The Changesets run can invoke both publishers, so broad `digests-*` artifact names allow cross-talk between the two manifest jobs.

## Validation

- Parsed modified workflow YAML successfully.
- Ran `git diff --check`.
