### PR TITLE
fix(telemetry): align metric exports with emitted events

### DIFF
--- a/.changeset/fix-telemetry-metric-exports.md
+++ b/.changeset/fix-telemetry-metric-exports.md
@@ -1,0 +1,9 @@
+---
+'@core/electric-telemetry': patch
+---
+
+Fix telemetry metric exports to match emitted events
+
+- Fix wrong event name: `shape_cache.create_snapshot_task` → `shape_snapshot.create_snapshot_task`
+- Remove exports for metrics that are not emitted: `shape_monitor.active_reader_count`, `consumers_ready.failed_to_recover`
+- Add missing exports: `plug.serve_shape.count`, `plug.serve_shape.bytes`, `storage.transaction_stored.operations`, `storage.snapshot_stored.operations`, `subqueries.move_in_triggered.count`, `postgres.info_looked_up.pg_version`, `shape_db.pool.checkout.queue_time_μs`

--- a/integration-tests/tests/otel-export.lux
+++ b/integration-tests/tests/otel-export.lux
@@ -220,10 +220,36 @@
   ??"value":{"val":"3"}
 
 [shell otel_collector]
+  # Verify that new measurement exports from this branch are present
+  # Order matches actual OTEL export order (not alphabetical)
+  """?
+  Metric #[0-9]+
+  Descriptor:
+       -> Name: electric\.plug\.serve_shape\.count
+  """
+
+  """?
+  Metric #[0-9]+
+  Descriptor:
+       -> Name: electric\.plug\.serve_shape\.bytes
+  """
+
+  """?
+  Metric #[0-9]+
+  Descriptor:
+       -> Name: electric\.storage\.snapshot_stored\.operations
+  """
+
   """?
   Metric #[0-9]+
   Descriptor:
        -> Name: electric\.storage\.transaction_stored\.bytes
+  """
+
+  """?
+  Metric #[0-9]+
+  Descriptor:
+       -> Name: electric\.storage\.transaction_stored\.operations
   """
 
 ###

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -86,7 +86,14 @@ defmodule ElectricTelemetry.StackTelemetry do
         unit: {:native, :millisecond},
         keep: fn metadata -> metadata[:live] != true end
       ),
-      distribution("electric.shape_cache.create_snapshot_task.stop.duration",
+      counter("electric.plug.serve_shape.count",
+        keep: fn metadata -> metadata[:live] != true end
+      ),
+      sum("electric.plug.serve_shape.bytes",
+        unit: :byte,
+        keep: fn metadata -> metadata[:live] != true end
+      ),
+      distribution("electric.shape_snapshot.create_snapshot_task.stop.duration",
         unit: {:native, :millisecond}
       ),
       distribution("electric.storage.make_new_snapshot.stop.duration",
@@ -103,16 +110,19 @@ defmodule ElectricTelemetry.StackTelemetry do
       sum("electric.postgres.replication.transaction_received.bytes", unit: :byte),
       sum("electric.storage.transaction_stored.bytes", unit: :byte),
       sum("electric.storage.transaction_stored.count"),
+      sum("electric.storage.transaction_stored.operations"),
       sum("electric.storage.snapshot_stored.bytes", unit: :byte),
       sum("electric.storage.snapshot_stored.count"),
+      sum("electric.storage.snapshot_stored.operations"),
       sum("electric.subqueries.subset_result.bytes", unit: :byte),
       sum("electric.subqueries.subset_result.count"),
-      last_value("electric.shape_monitor.active_reader_count"),
+      sum("electric.subqueries.move_in_triggered.count"),
+      last_value("electric.postgres.info_looked_up.pg_version"),
+      distribution("electric.shape_db.pool.checkout.queue_time_μs", unit: :microsecond),
       last_value("electric.connection.consumers_ready.duration",
         unit: {:native, :millisecond}
       ),
       last_value("electric.connection.consumers_ready.total"),
-      last_value("electric.connection.consumers_ready.failed_to_recover"),
       last_value("electric.admission_control.acquire.current", tags: [:kind]),
       last_value("electric.admission_control.acquire.limit", tags: [:kind]),
       sum("electric.admission_control.reject.count", tags: [:kind]),


### PR DESCRIPTION
<img alt="vetted by human" src="https://github.com/user-attachments/assets/11a81387-9e4a-4d7c-873e-265062ea2b74"/>
<img alt="ready for review" src="https://github.com/user-attachments/assets/267c675d-da51-47c9-9581-6d156a63b7e2"/>


## Summary

- Fix wrong span event name in metric export: `shape_cache.create_snapshot_task` → `shape_snapshot.create_snapshot_task`
- Remove exports for metrics that are never emitted: `shape_monitor.active_reader_count`, `consumers_ready.failed_to_recover`
- Add missing exports for measurements that are emitted but not captured:
  - `plug.serve_shape.count` and `plug.serve_shape.bytes`
  - `storage.transaction_stored.operations` and `storage.snapshot_stored.operations`
  - `subqueries.move_in_triggered.count`
  - `postgres.info_looked_up.pg_version`
  - `shape_db.pool.checkout.queue_time_μs`

## Test plan

- [x] Compiles successfully
- [x] electric-telemetry tests pass
- [x] sync-service tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)