### PR TITLE
ci: add canary npm publish for agents packages

### DIFF
--- a/.github/workflows/canary_npm_publish.yml
+++ b/.github/workflows/canary_npm_publish.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
@@ -47,10 +49,13 @@ jobs:
       # Point canary CLI at canary Docker images
       - name: Set canary image tag defaults
         run: |
-          sed -i "s/\`latest\`/\`canary\`/g" packages/electric-ax/src/version.ts
+          sed -i "s/= \`latest\`/= \`canary\`/g" packages/electric-ax/src/version.ts
 
-      # Build all packages (order matters — runtime before agents before electric-ax)
-      - run: pnpm run -r --filter './packages/**' build
+      # Build only the agent packages (in dependency order: runtime -> agents -> electric-ax)
+      - run: |
+          pnpm run --filter '@electric-ax/agents-runtime' build
+          pnpm run --filter '@electric-ax/agents' build
+          pnpm run --filter 'electric-ax' build
 
       # Publish with canary tag
       - name: Publish canary packages

--- a/.github/workflows/canary_npm_publish.yml
+++ b/.github/workflows/canary_npm_publish.yml
@@ -1,0 +1,62 @@
+name: Publish canary npm packages
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'packages/agents/**'
+      - 'packages/agents-runtime/**'
+      - 'packages/electric-ax/**'
+
+concurrency:
+  group: canary-npm-publish
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish-canary:
+    name: Publish canary to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      # Set canary versions: <current>-canary.<short-sha>
+      - name: Set canary versions
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          for pkg in packages/agents packages/agents-runtime packages/electric-ax; do
+            current=$(jq -r '.version' "$pkg/package.json")
+            canary_version="${current}-canary.${SHORT_SHA}"
+            jq --arg v "$canary_version" '.version = $v' "$pkg/package.json" > tmp.json && mv tmp.json "$pkg/package.json"
+            echo "Set $pkg to $canary_version"
+          done
+
+      # Point canary CLI at canary Docker images
+      - name: Set canary image tag defaults
+        run: |
+          sed -i "s/\`latest\`/\`canary\`/g" packages/electric-ax/src/version.ts
+
+      # Build all packages (order matters — runtime before agents before electric-ax)
+      - run: pnpm run -r --filter './packages/**' build
+
+      # Publish with canary tag
+      - name: Publish canary packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          pnpm publish --filter '@electric-ax/agents-runtime' --tag canary --no-git-checks --access public
+          pnpm publish --filter '@electric-ax/agents' --tag canary --no-git-checks --access public
+          pnpm publish --filter 'electric-ax' --tag canary --no-git-checks --access public

--- a/packages/electric-ax/docker-compose.full.yml
+++ b/packages/electric-ax/docker-compose.full.yml
@@ -28,7 +28,6 @@ services:
 
   electric:
     image: electricsql/electric:${ELECTRIC_IMAGE_TAG:-latest}
-    pull_policy: always
     restart: unless-stopped
     depends_on:
       postgres:
@@ -39,7 +38,6 @@ services:
 
   electric-agents:
     image: electricax/agents-server:${ELECTRIC_AGENTS_SERVER_IMAGE_TAG:-latest}
-    pull_policy: always
     restart: unless-stopped
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/packages/electric-ax/docker-compose.full.yml
+++ b/packages/electric-ax/docker-compose.full.yml
@@ -38,6 +38,7 @@ services:
 
   electric-agents:
     image: electricax/agents-server:${ELECTRIC_AGENTS_SERVER_IMAGE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/packages/electric-ax/docker-compose.full.yml
+++ b/packages/electric-ax/docker-compose.full.yml
@@ -27,7 +27,7 @@ services:
       - electric-agents-postgres-data:/var/lib/postgresql
 
   electric:
-    image: electricsql/electric:latest
+    image: electricsql/electric:${ELECTRIC_IMAGE_TAG:-latest}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -37,7 +37,7 @@ services:
       ELECTRIC_INSECURE: 'true'
 
   electric-agents:
-    image: electricax/agents-server:latest
+    image: electricax/agents-server:${ELECTRIC_AGENTS_SERVER_IMAGE_TAG:-latest}
     restart: unless-stopped
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/packages/electric-ax/docker-compose.full.yml
+++ b/packages/electric-ax/docker-compose.full.yml
@@ -28,6 +28,7 @@ services:
 
   electric:
     image: electricsql/electric:${ELECTRIC_IMAGE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     depends_on:
       postgres:
@@ -38,6 +39,7 @@ services:
 
   electric-agents:
     image: electricax/agents-server:${ELECTRIC_AGENTS_SERVER_IMAGE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/packages/electric-ax/src/start.ts
+++ b/packages/electric-ax/src/start.ts
@@ -192,14 +192,23 @@ export async function startElectricAgentsDevEnvironment(
   const port = resolveElectricAgentsPort(env, fileEnv)
   const composeProjectName = resolveComposeProjectName(cwd, env)
 
-  await runDockerCompose([`compose`, `-f`, DOCKER_COMPOSE_FILE, `up`, `-d`], {
+  const composeEnv = {
     ...env,
     COMPOSE_PROJECT_NAME: composeProjectName,
     ELECTRIC_AGENTS_PORT: String(port),
     ELECTRIC_IMAGE_TAG: env.ELECTRIC_IMAGE_TAG ?? ELECTRIC_IMAGE_TAG,
     ELECTRIC_AGENTS_SERVER_IMAGE_TAG:
       env.ELECTRIC_AGENTS_SERVER_IMAGE_TAG ?? ELECTRIC_AGENTS_SERVER_IMAGE_TAG,
-  })
+  }
+
+  await runDockerCompose(
+    [`compose`, `-f`, DOCKER_COMPOSE_FILE, `pull`],
+    composeEnv
+  )
+  await runDockerCompose(
+    [`compose`, `-f`, DOCKER_COMPOSE_FILE, `up`, `-d`],
+    composeEnv
+  )
 
   const uiUrl = `http://localhost:${port}`
   await waitForElectricAgentsServer(uiUrl)

--- a/packages/electric-ax/src/start.ts
+++ b/packages/electric-ax/src/start.ts
@@ -2,6 +2,10 @@ import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { BuiltinAgentsServer } from '@electric-ax/agents'
 import { readDotEnvFile, resolveAnthropicApiKey } from './env.js'
+import {
+  ELECTRIC_IMAGE_TAG,
+  ELECTRIC_AGENTS_SERVER_IMAGE_TAG,
+} from './version.js'
 import type {
   StartCommandOptions,
   StartBuiltinCommandOptions,
@@ -192,6 +196,9 @@ export async function startElectricAgentsDevEnvironment(
     ...env,
     COMPOSE_PROJECT_NAME: composeProjectName,
     ELECTRIC_AGENTS_PORT: String(port),
+    ELECTRIC_IMAGE_TAG: env.ELECTRIC_IMAGE_TAG ?? ELECTRIC_IMAGE_TAG,
+    ELECTRIC_AGENTS_SERVER_IMAGE_TAG:
+      env.ELECTRIC_AGENTS_SERVER_IMAGE_TAG ?? ELECTRIC_AGENTS_SERVER_IMAGE_TAG,
   })
 
   const uiUrl = `http://localhost:${port}`

--- a/packages/electric-ax/src/start.ts
+++ b/packages/electric-ax/src/start.ts
@@ -192,23 +192,14 @@ export async function startElectricAgentsDevEnvironment(
   const port = resolveElectricAgentsPort(env, fileEnv)
   const composeProjectName = resolveComposeProjectName(cwd, env)
 
-  const composeEnv = {
+  await runDockerCompose([`compose`, `-f`, DOCKER_COMPOSE_FILE, `up`, `-d`], {
     ...env,
     COMPOSE_PROJECT_NAME: composeProjectName,
     ELECTRIC_AGENTS_PORT: String(port),
     ELECTRIC_IMAGE_TAG: env.ELECTRIC_IMAGE_TAG ?? ELECTRIC_IMAGE_TAG,
     ELECTRIC_AGENTS_SERVER_IMAGE_TAG:
       env.ELECTRIC_AGENTS_SERVER_IMAGE_TAG ?? ELECTRIC_AGENTS_SERVER_IMAGE_TAG,
-  }
-
-  await runDockerCompose(
-    [`compose`, `-f`, DOCKER_COMPOSE_FILE, `pull`],
-    composeEnv
-  )
-  await runDockerCompose(
-    [`compose`, `-f`, DOCKER_COMPOSE_FILE, `up`, `-d`],
-    composeEnv
-  )
+  })
 
   const uiUrl = `http://localhost:${port}`
   await waitForElectricAgentsServer(uiUrl)

--- a/packages/electric-ax/src/version.ts
+++ b/packages/electric-ax/src/version.ts
@@ -1,0 +1,9 @@
+/**
+ * Default Docker image tags used by the CLI when launching
+ * the dev environment via docker compose.
+ *
+ * For release builds these remain "latest".
+ * The canary CI overwrites them to "canary" before building.
+ */
+export const ELECTRIC_IMAGE_TAG = `latest`
+export const ELECTRIC_AGENTS_SERVER_IMAGE_TAG = `latest`


### PR DESCRIPTION
## Summary

- Parameterize Docker image tags in `electric-ax`'s `docker-compose.full.yml` via `ELECTRIC_IMAGE_TAG` and `ELECTRIC_AGENTS_SERVER_IMAGE_TAG` env vars (default `:latest`)
- Add `version.ts` with image tag constants, forwarded by the CLI to `docker compose` — canary builds override these to `:canary`
- New GitHub Actions workflow (`.github/workflows/canary_npm_publish.yml`) that publishes `@electric-ax/agents-runtime`, `@electric-ax/agents`, and `electric-ax` to npm with `--tag canary` on every push to `main` that touches agent packages
- Add `pull_policy: always` to the `electric-agents` service so users always get the freshest image for their tag (`:latest` or `:canary`)

Canary versions use the format `<version>-canary.<short-sha>`. Users install via `npx electric-ax@canary`.

## Pre-requisite

This workflow requires an `NPM_TOKEN` repository secret with publish access to the `@electric-ax` scope and `electric-ax` package.

## Test plan

- [ ] Verify `NPM_TOKEN` secret exists in repo settings (or create one)
- [ ] Merge and confirm the workflow runs successfully on the next push to `main` that touches agent packages
- [ ] Verify canary packages appear on npm: `npm view electric-ax dist-tags`
- [ ] Test install: `npx electric-ax@canary start` should pull `:canary` Docker images

🤖 Generated with [Claude Code](https://claude.com/claude-code)