### PR TITLE
Add subset telemetry attrs and rows metric

### DIFF
--- a/.changeset/khaki-penguins-smile.md
+++ b/.changeset/khaki-penguins-smile.md
@@ -1,0 +1,6 @@
+---
+"@core/sync-service": patch
+"@core/electric-telemetry": patch
+---
+
+Add subset telemetry for query result rows and bytes, capture POST body params as request telemetry attributes, and expose subset result rows in stack telemetry.

--- a/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/stack_telemetry.ex
@@ -115,6 +115,7 @@ defmodule ElectricTelemetry.StackTelemetry do
       sum("electric.storage.snapshot_stored.count"),
       sum("electric.storage.snapshot_stored.operations"),
       sum("electric.subqueries.subset_result.bytes", unit: :byte),
+      sum("electric.subqueries.subset_result.rows"),
       sum("electric.subqueries.subset_result.count"),
       sum("electric.subqueries.move_in_triggered.count"),
       last_value("electric.postgres.info_looked_up.pg_version"),

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -83,7 +83,22 @@ defmodule Electric.Plug.Utils do
   end
 
   alias OpenTelemetry.SemConv, as: SC
-  @max_telemetry_string_bytes 64 * 1024
+  @max_telemetry_string_bytes 256
+  @telemetry_body_root_keys ~w(
+    table
+    offset
+    handle
+    live
+    where
+    columns
+    replica
+    params
+    experimental_compaction
+    live_sse
+    experimental_live_sse
+    log
+  )
+  @telemetry_body_subset_keys ~w(where order_by limit offset params)
 
   @doc false
   def redact_query_string(nil), do: nil
@@ -145,46 +160,86 @@ defmodule Electric.Plug.Utils do
     |> Map.merge(Map.new(conn.resp_headers, fn {k, v} -> {"http.response.header.#{k}", v} end))
   end
 
+  # GET requests already expose raw query params in telemetry. For POST requests,
+  # mirror the supported JSON body params under http.body_param.* so subset filters
+  # and pagination remain visible without logging arbitrary JSON payloads.
   defp telemetry_body_params(body_params) when body_params == %{}, do: %{}
 
-  defp telemetry_body_params(body_params) when is_map(body_params),
-    do: flatten_telemetry_params(body_params)
+  defp telemetry_body_params(body_params) when is_map(body_params) do
+    {root_params, subset_params} = split_telemetry_body_params(body_params)
+
+    body_param_attrs(root_params, @telemetry_body_root_keys, "http.body_param")
+    |> Map.merge(body_param_attrs(subset_params, @telemetry_body_subset_keys, "http.body_param.subset"))
+  end
 
   defp telemetry_body_params(_), do: %{}
 
-  defp flatten_telemetry_params(params, prefix \\ "http.body_param") do
+  defp split_telemetry_body_params(%{"subset" => subset_params} = body_params)
+       when is_map(subset_params) do
+    {Map.delete(body_params, "subset"), subset_params}
+  end
+
+  defp split_telemetry_body_params(body_params) do
+    {subset_params, root_params} = Map.split(body_params, @telemetry_body_subset_keys)
+    {root_params, subset_params}
+  end
+
+  defp body_param_attrs(params, keys, prefix) do
+    Enum.reduce(keys, %{}, fn key, attrs ->
+      case Map.fetch(params, key) do
+        {:ok, value} ->
+          Map.merge(attrs, body_param_attr(key, value, "#{prefix}.#{key}"))
+
+        :error ->
+          attrs
+      end
+    end)
+  end
+
+  defp body_param_attr(_key, nil, _prefix), do: %{}
+
+  defp body_param_attr("params", %{} = params, prefix), do: scalar_map_attrs(params, prefix)
+
+  defp body_param_attr("columns", columns, prefix) when is_list(columns) do
+    if Enum.all?(columns, &is_binary/1) do
+      %{prefix => truncate_telemetry_string(Enum.join(columns, ","))}
+    else
+      %{}
+    end
+  end
+
+  defp body_param_attr(_key, value, prefix) when is_binary(value) do
+    %{prefix => truncate_telemetry_string(value)}
+  end
+
+  defp body_param_attr(_key, value, prefix) when is_boolean(value) or is_number(value) do
+    %{prefix => value}
+  end
+
+  defp body_param_attr(_key, _value, _prefix), do: %{}
+
+  defp scalar_map_attrs(params, prefix) do
     Enum.reduce(params, %{}, fn {key, value}, attrs ->
-      Map.merge(attrs, flatten_telemetry_param(value, "#{prefix}.#{key}"))
+      case scalar_attr_value(value) do
+        {:ok, telemetry_value} -> Map.put(attrs, "#{prefix}.#{key}", telemetry_value)
+        :skip -> attrs
+      end
     end)
   end
 
-  defp flatten_telemetry_param(%{} = params, prefix), do: flatten_telemetry_params(params, prefix)
+  defp scalar_attr_value(nil), do: :skip
 
-  defp flatten_telemetry_param(params, prefix) when is_list(params) do
-    params
-    |> Enum.with_index()
-    |> Enum.reduce(%{}, fn {value, index}, attrs ->
-      Map.merge(attrs, flatten_telemetry_param(value, "#{prefix}.#{index}"))
-    end)
+  defp scalar_attr_value(value) when is_binary(value) do
+    {:ok, truncate_telemetry_string(value)}
   end
 
-  defp flatten_telemetry_param(nil, _prefix), do: %{}
+  defp scalar_attr_value(value) when is_boolean(value) or is_number(value), do: {:ok, value}
+  defp scalar_attr_value(_value), do: :skip
 
-  defp flatten_telemetry_param(value, prefix)
-       when is_binary(value) or is_boolean(value) or is_number(value) do
-    %{prefix => maybe_truncate_telemetry_string(value)}
-  end
-
-  defp flatten_telemetry_param(value, prefix) do
-    %{prefix => value |> inspect() |> maybe_truncate_telemetry_string()}
-  end
-
-  defp maybe_truncate_telemetry_string(value) when not is_binary(value), do: value
-
-  defp maybe_truncate_telemetry_string(value)
+  defp truncate_telemetry_string(value)
        when byte_size(value) <= @max_telemetry_string_bytes, do: value
 
-  defp maybe_truncate_telemetry_string(value) do
+  defp truncate_telemetry_string(value) do
     value
     |> binary_part(0, @max_telemetry_string_bytes)
     |> trim_invalid_utf8()

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -170,7 +170,7 @@ defmodule Electric.Plug.Utils do
         %{
           "http.body_param.subset.params" =>
             value
-            |> inspect(limit: :infinity, printable_limit: :infinity)
+            |> inspect()
             |> truncate_telemetry_string()
         }
 

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -83,6 +83,7 @@ defmodule Electric.Plug.Utils do
   end
 
   alias OpenTelemetry.SemConv, as: SC
+  @max_telemetry_string_bytes 64 * 1024
 
   @doc false
   def redact_query_string(nil), do: nil
@@ -105,6 +106,11 @@ defmodule Electric.Plug.Utils do
           {"http.query_param.#{k}", redact_query_param_value(k, v)}
         end)
       end
+
+    body_params_map =
+      assigns
+      |> Map.get(:body_params, %{})
+      |> telemetry_body_params()
 
     %{
       "error.type" => assigns[:error_str],
@@ -134,8 +140,64 @@ defmodule Electric.Plug.Utils do
     |> Map.filter(fn {_k, v} -> not is_nil(v) end)
     |> Map.merge(Map.get(conn.private, :telemetry_span_attrs, %{}))
     |> Map.merge(query_params_map)
+    |> Map.merge(body_params_map)
     |> Map.merge(Map.new(conn.req_headers, fn {k, v} -> {"http.request.header.#{k}", v} end))
     |> Map.merge(Map.new(conn.resp_headers, fn {k, v} -> {"http.response.header.#{k}", v} end))
+  end
+
+  defp telemetry_body_params(body_params) when body_params == %{}, do: %{}
+
+  defp telemetry_body_params(body_params) when is_map(body_params),
+    do: flatten_telemetry_params(body_params)
+
+  defp telemetry_body_params(_), do: %{}
+
+  defp flatten_telemetry_params(params, prefix \\ "http.body_param") do
+    Enum.reduce(params, %{}, fn {key, value}, attrs ->
+      Map.merge(attrs, flatten_telemetry_param(value, "#{prefix}.#{key}"))
+    end)
+  end
+
+  defp flatten_telemetry_param(%{} = params, prefix), do: flatten_telemetry_params(params, prefix)
+
+  defp flatten_telemetry_param(params, prefix) when is_list(params) do
+    params
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {value, index}, attrs ->
+      Map.merge(attrs, flatten_telemetry_param(value, "#{prefix}.#{index}"))
+    end)
+  end
+
+  defp flatten_telemetry_param(nil, _prefix), do: %{}
+
+  defp flatten_telemetry_param(value, prefix)
+       when is_binary(value) or is_boolean(value) or is_number(value) do
+    %{prefix => maybe_truncate_telemetry_string(value)}
+  end
+
+  defp flatten_telemetry_param(value, prefix) do
+    %{prefix => value |> inspect() |> maybe_truncate_telemetry_string()}
+  end
+
+  defp maybe_truncate_telemetry_string(value) when not is_binary(value), do: value
+
+  defp maybe_truncate_telemetry_string(value)
+       when byte_size(value) <= @max_telemetry_string_bytes, do: value
+
+  defp maybe_truncate_telemetry_string(value) do
+    value
+    |> binary_part(0, @max_telemetry_string_bytes)
+    |> trim_invalid_utf8()
+  end
+
+  defp trim_invalid_utf8(value) when value == "", do: value
+
+  defp trim_invalid_utf8(value) do
+    if String.valid?(value) do
+      value
+    else
+      trim_invalid_utf8(binary_part(value, 0, byte_size(value) - 1))
+    end
   end
 
   defp user_agent(%Plug.Conn{} = conn) do

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -147,26 +147,7 @@ defmodule Electric.Plug.Utils do
     |> Map.merge(Map.new(conn.resp_headers, fn {k, v} -> {"http.response.header.#{k}", v} end))
   end
 
-  # GET requests already expose raw query params in telemetry. For POST requests,
-  # only mirror the documented top-level subset fields. Legacy nested
-  # %{"subset" => %{...}} bodies are still accepted by request parsing, but we
-  # intentionally do not surface them in telemetry.
-  defp telemetry_body_params(body_params) when body_params == %{}, do: %{}
-
-  defp telemetry_body_params(body_params) when is_map(body_params) do
-    if Enum.any?(
-         @telemetry_body_subset_keys ++ [@telemetry_body_subset_params_key],
-         &Map.has_key?(body_params, &1)
-       ) do
-      subset_telemetry_attrs(body_params)
-    else
-      %{}
-    end
-  end
-
-  defp telemetry_body_params(_), do: %{}
-
-  defp subset_telemetry_attrs(params) do
+  defp telemetry_body_params(params) when is_map(params) do
     Enum.reduce(@telemetry_body_subset_keys, %{}, fn key, attrs ->
       prefix = "http.body_param.subset.#{key}"
 
@@ -180,6 +161,8 @@ defmodule Electric.Plug.Utils do
     end)
     |> Map.merge(subset_params_telemetry_attr(params))
   end
+
+  defp telemetry_body_params(_), do: %{}
 
   defp subset_params_telemetry_attr(params) do
     case Map.fetch(params, @telemetry_body_subset_params_key) do

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -203,13 +203,14 @@ defmodule Electric.Plug.Utils do
     |> trim_invalid_utf8()
   end
 
-  defp trim_invalid_utf8(value) when value == "", do: value
-
   defp trim_invalid_utf8(value) do
     if String.valid?(value) do
       value
     else
-      trim_invalid_utf8(binary_part(value, 0, byte_size(value) - 1))
+      value
+      |> String.chunk(:valid)
+      |> Enum.filter(&String.valid?/1)
+      |> Enum.join()
     end
   end
 

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -84,21 +84,7 @@ defmodule Electric.Plug.Utils do
 
   alias OpenTelemetry.SemConv, as: SC
   @max_telemetry_string_bytes 2000
-  @telemetry_body_root_keys ~w(
-    table
-    offset
-    handle
-    live
-    where
-    columns
-    replica
-    params
-    experimental_compaction
-    live_sse
-    experimental_live_sse
-    log
-  )
-  @telemetry_body_subset_keys ~w(where order_by limit offset params)
+  @telemetry_body_subset_keys ~w(where order_by limit offset)
 
   @doc false
   def redact_query_string(nil), do: nil
@@ -161,70 +147,64 @@ defmodule Electric.Plug.Utils do
   end
 
   # GET requests already expose raw query params in telemetry. For POST requests,
-  # mirror the supported JSON body params under http.body_param.* so subset filters
-  # and pagination remain visible without logging arbitrary JSON payloads.
+  # only mirror subset-defining body params so subset filters and pagination remain
+  # visible without trying to serialize the full request body.
   defp telemetry_body_params(body_params) when body_params == %{}, do: %{}
 
+  defp telemetry_body_params(%{"subset" => subset_params}) when is_map(subset_params) do
+    subset_telemetry_attrs(subset_params)
+  end
+
   defp telemetry_body_params(body_params) when is_map(body_params) do
-    {root_params, subset_params} = split_telemetry_body_params(body_params)
-
-    body_param_attrs(root_params, @telemetry_body_root_keys, "http.body_param")
-    |> Map.merge(body_param_attrs(subset_params, @telemetry_body_subset_keys, "http.body_param.subset"))
-  end
-
-  defp telemetry_body_params(_), do: %{}
-
-  defp split_telemetry_body_params(%{"subset" => subset_params} = body_params)
-       when is_map(subset_params) do
-    {Map.delete(body_params, "subset"), subset_params}
-  end
-
-  defp split_telemetry_body_params(body_params) do
-    {subset_params, root_params} = Map.split(body_params, @telemetry_body_subset_keys)
-    {root_params, subset_params}
-  end
-
-  defp body_param_attrs(params, keys, prefix) do
-    Enum.reduce(keys, %{}, fn key, attrs ->
-      case Map.fetch(params, key) do
-        {:ok, value} ->
-          Map.merge(attrs, body_param_attr(key, value, "#{prefix}.#{key}"))
-
-        :error ->
-          attrs
-      end
-    end)
-  end
-
-  defp body_param_attr(_key, nil, _prefix), do: %{}
-
-  defp body_param_attr("params", %{} = params, prefix), do: scalar_map_attrs(params, prefix)
-
-  defp body_param_attr("columns", columns, prefix) when is_list(columns) do
-    if Enum.all?(columns, &is_binary/1) do
-      %{prefix => truncate_telemetry_string(Enum.join(columns, ","))}
+    if Enum.any?(@telemetry_body_subset_keys, &Map.has_key?(body_params, &1)) do
+      subset_telemetry_attrs(body_params)
     else
       %{}
     end
   end
 
-  defp body_param_attr(_key, value, prefix) when is_binary(value) do
-    %{prefix => truncate_telemetry_string(value)}
-  end
+  defp telemetry_body_params(_), do: %{}
 
-  defp body_param_attr(_key, value, prefix) when is_boolean(value) or is_number(value) do
-    %{prefix => value}
-  end
+  defp subset_telemetry_attrs(params) do
+    subset_scalar_attrs =
+      Enum.reduce(@telemetry_body_subset_keys, %{}, fn key, attrs ->
+        prefix = "http.body_param.subset.#{key}"
 
-  defp body_param_attr(_key, _value, _prefix), do: %{}
+      case Map.fetch(params, key) do
+        {:ok, value} ->
+          Map.merge(attrs, body_param_scalar_attr(value, prefix))
 
-  defp scalar_map_attrs(params, prefix) do
-    Enum.reduce(params, %{}, fn {key, value}, attrs ->
-      case scalar_attr_value(value) do
-        {:ok, telemetry_value} -> Map.put(attrs, "#{prefix}.#{key}", telemetry_value)
-        :skip -> attrs
+        :error ->
+          attrs
       end
     end)
+
+    Map.merge(
+      subset_scalar_attrs,
+      scalar_map_attrs(Map.get(params, "params", %{}), "http.body_param.subset.params")
+    )
+  end
+
+  defp scalar_map_attrs(params, prefix) do
+    if is_map(params) do
+      Enum.reduce(params, %{}, fn {key, value}, attrs ->
+        case scalar_attr_value(value) do
+          {:ok, telemetry_value} -> Map.put(attrs, "#{prefix}.#{key}", telemetry_value)
+          :skip -> attrs
+        end
+      end)
+    else
+      %{}
+    end
+  end
+
+  defp body_param_scalar_attr(nil, _prefix), do: %{}
+
+  defp body_param_scalar_attr(value, prefix) do
+    case scalar_attr_value(value) do
+      {:ok, telemetry_value} -> %{prefix => telemetry_value}
+      :skip -> %{}
+    end
   end
 
   defp scalar_attr_value(nil), do: :skip

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -83,7 +83,7 @@ defmodule Electric.Plug.Utils do
   end
 
   alias OpenTelemetry.SemConv, as: SC
-  @max_telemetry_string_bytes 2000
+  @max_telemetry_string_graphemes 2000
   @telemetry_body_subset_keys ~w(where order_by limit offset)
   @telemetry_body_subset_params_key "params"
 
@@ -197,13 +197,10 @@ defmodule Electric.Plug.Utils do
   defp scalar_attr_value(value) when is_boolean(value) or is_number(value), do: {:ok, value}
   defp scalar_attr_value(_value), do: :skip
 
-  defp truncate_telemetry_string(value)
-       when byte_size(value) <= @max_telemetry_string_bytes, do: value
-
   defp truncate_telemetry_string(value) do
     value
-    |> binary_part(0, @max_telemetry_string_bytes)
     |> trim_invalid_utf8()
+    |> String.slice(0, @max_telemetry_string_graphemes)
   end
 
   defp trim_invalid_utf8(value) do

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -166,9 +166,8 @@ defmodule Electric.Plug.Utils do
   defp telemetry_body_params(_), do: %{}
 
   defp subset_telemetry_attrs(params) do
-    subset_scalar_attrs =
-      Enum.reduce(@telemetry_body_subset_keys, %{}, fn key, attrs ->
-        prefix = "http.body_param.subset.#{key}"
+    Enum.reduce(@telemetry_body_subset_keys, %{}, fn key, attrs ->
+      prefix = "http.body_param.subset.#{key}"
 
       case Map.fetch(params, key) do
         {:ok, value} ->
@@ -178,24 +177,6 @@ defmodule Electric.Plug.Utils do
           attrs
       end
     end)
-
-    Map.merge(
-      subset_scalar_attrs,
-      scalar_map_attrs(Map.get(params, "params", %{}), "http.body_param.subset.params")
-    )
-  end
-
-  defp scalar_map_attrs(params, prefix) do
-    if is_map(params) do
-      Enum.reduce(params, %{}, fn {key, value}, attrs ->
-        case scalar_attr_value(value) do
-          {:ok, telemetry_value} -> Map.put(attrs, "#{prefix}.#{key}", telemetry_value)
-          :skip -> attrs
-        end
-      end)
-    else
-      %{}
-    end
   end
 
   defp body_param_scalar_attr(nil, _prefix), do: %{}

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -83,7 +83,7 @@ defmodule Electric.Plug.Utils do
   end
 
   alias OpenTelemetry.SemConv, as: SC
-  @max_telemetry_string_bytes 256
+  @max_telemetry_string_bytes 2000
   @telemetry_body_root_keys ~w(
     table
     offset

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -85,6 +85,7 @@ defmodule Electric.Plug.Utils do
   alias OpenTelemetry.SemConv, as: SC
   @max_telemetry_string_bytes 2000
   @telemetry_body_subset_keys ~w(where order_by limit offset)
+  @telemetry_body_subset_params_key "params"
 
   @doc false
   def redact_query_string(nil), do: nil
@@ -153,7 +154,10 @@ defmodule Electric.Plug.Utils do
   defp telemetry_body_params(body_params) when body_params == %{}, do: %{}
 
   defp telemetry_body_params(body_params) when is_map(body_params) do
-    if Enum.any?(@telemetry_body_subset_keys, &Map.has_key?(body_params, &1)) do
+    if Enum.any?(
+         @telemetry_body_subset_keys ++ [@telemetry_body_subset_params_key],
+         &Map.has_key?(body_params, &1)
+       ) do
       subset_telemetry_attrs(body_params)
     else
       %{}
@@ -174,6 +178,22 @@ defmodule Electric.Plug.Utils do
           attrs
       end
     end)
+    |> Map.merge(subset_params_telemetry_attr(params))
+  end
+
+  defp subset_params_telemetry_attr(params) do
+    case Map.fetch(params, @telemetry_body_subset_params_key) do
+      {:ok, value} ->
+        %{
+          "http.body_param.subset.params" =>
+            value
+            |> inspect(limit: :infinity, printable_limit: :infinity)
+            |> truncate_telemetry_string()
+        }
+
+      :error ->
+        %{}
+    end
   end
 
   defp body_param_scalar_attr(nil, _prefix), do: %{}

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -147,13 +147,10 @@ defmodule Electric.Plug.Utils do
   end
 
   # GET requests already expose raw query params in telemetry. For POST requests,
-  # only mirror subset-defining body params so subset filters and pagination remain
-  # visible without trying to serialize the full request body.
+  # only mirror the documented top-level subset fields. Legacy nested
+  # %{"subset" => %{...}} bodies are still accepted by request parsing, but we
+  # intentionally do not surface them in telemetry.
   defp telemetry_body_params(body_params) when body_params == %{}, do: %{}
-
-  defp telemetry_body_params(%{"subset" => subset_params}) when is_map(subset_params) do
-    subset_telemetry_attrs(subset_params)
-  end
 
   defp telemetry_body_params(body_params) when is_map(body_params) do
     if Enum.any?(@telemetry_body_subset_keys, &Map.has_key?(body_params, &1)) do

--- a/packages/sync-service/lib/electric/shapes/partial_modes.ex
+++ b/packages/sync-service/lib/electric/shapes/partial_modes.ex
@@ -77,6 +77,11 @@ defmodule Electric.Shapes.PartialModes do
             "shape.root_table": shape.root_table
           }
         )
+
+        OpenTelemetry.add_span_attributes(%{
+          "subset.rows" => rows,
+          "subset.result_bytes" => bytes
+        })
       end
     )
   end

--- a/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
+++ b/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
@@ -85,10 +85,10 @@ defmodule Electric.Plug.SubsetTelemetryTest do
 
   test "truncates large POST body strings to 2000 bytes in telemetry attrs", ctx do
     test_pid = self()
-    long_value = String.duplicate("a", 3_000)
+    long_where = "value ILIKE $1" <> String.duplicate(" ", 3_000)
 
     Repatch.patch(OpenTelemetry, :add_span_attributes, [mode: :shared], fn attrs ->
-      if is_map(attrs) and Map.has_key?(attrs, "http.body_param.subset.params.1") do
+      if is_map(attrs) and Map.has_key?(attrs, "http.body_param.subset.where") do
         send(test_pid, {:body_attrs, attrs})
       end
 
@@ -101,8 +101,8 @@ defmodule Electric.Plug.SubsetTelemetryTest do
         "/v1/shape?table=items&offset=-1&log=changes_only",
         Jason.encode!(%{
           "subset" => %{
-            "where" => "value ILIKE $1",
-            "params" => %{"1" => long_value}
+            "where" => long_where,
+            "params" => %{"1" => "%2"}
           }
         })
       )
@@ -111,7 +111,7 @@ defmodule Electric.Plug.SubsetTelemetryTest do
 
     assert conn.status == 200
     assert_receive {:body_attrs, attrs}
-    assert byte_size(attrs["http.body_param.subset.params.1"]) == 2_000
-    assert attrs["http.body_param.subset.params.1"] == binary_part(long_value, 0, 2_000)
+    assert byte_size(attrs["http.body_param.subset.where"]) == 2_000
+    assert attrs["http.body_param.subset.where"] == binary_part(long_where, 0, 2_000)
   end
 end

--- a/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
+++ b/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
@@ -24,7 +24,7 @@ defmodule Electric.Plug.SubsetTelemetryTest do
          "INSERT INTO items VALUES (gen_random_uuid(), 'test value 1')",
          "INSERT INTO items VALUES (gen_random_uuid(), 'test value 2')"
        ]
-  test "adds POST body attrs and subset query attrs for POST subset requests", ctx do
+  test "adds POST body attrs and subset query attrs for documented POST subset requests", ctx do
     test_pid = self()
 
     Repatch.patch(OpenTelemetry, :add_span_attributes, [mode: :shared], fn attrs ->
@@ -42,13 +42,11 @@ defmodule Electric.Plug.SubsetTelemetryTest do
         "POST",
         "/v1/shape?table=items&offset=-1&log=changes_only",
         Jason.encode!(%{
-          "subset" => %{
-            "where" => "value ILIKE $1",
-            "params" => %{"1" => "%2"},
-            "limit" => 1,
-            "offset" => 0,
-            "order_by" => "value ASC"
-          }
+          "where" => "value ILIKE $1",
+          "params" => %{"1" => "%2"},
+          "limit" => 1,
+          "offset" => 0,
+          "order_by" => "value ASC"
         })
       )
       |> Plug.Conn.put_req_header("content-type", "application/json")
@@ -100,10 +98,8 @@ defmodule Electric.Plug.SubsetTelemetryTest do
         "POST",
         "/v1/shape?table=items&offset=-1&log=changes_only",
         Jason.encode!(%{
-          "subset" => %{
-            "where" => long_where,
-            "params" => %{"1" => "%2"}
-          }
+          "where" => long_where,
+          "params" => %{"1" => "%2"}
         })
       )
       |> Plug.Conn.put_req_header("content-type", "application/json")

--- a/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
+++ b/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
@@ -83,9 +83,9 @@ defmodule Electric.Plug.SubsetTelemetryTest do
     assert query_attrs["subset.result_bytes"] > 0
   end
 
-  test "truncates large POST body strings to 256 bytes in telemetry attrs", ctx do
+  test "truncates large POST body strings to 2000 bytes in telemetry attrs", ctx do
     test_pid = self()
-    long_value = String.duplicate("a", 300)
+    long_value = String.duplicate("a", 3_000)
 
     Repatch.patch(OpenTelemetry, :add_span_attributes, [mode: :shared], fn attrs ->
       if is_map(attrs) and Map.has_key?(attrs, "http.body_param.subset.params.1") do
@@ -111,7 +111,7 @@ defmodule Electric.Plug.SubsetTelemetryTest do
 
     assert conn.status == 200
     assert_receive {:body_attrs, attrs}
-    assert byte_size(attrs["http.body_param.subset.params.1"]) == 256
-    assert attrs["http.body_param.subset.params.1"] == binary_part(long_value, 0, 256)
+    assert byte_size(attrs["http.body_param.subset.params.1"]) == 2_000
+    assert attrs["http.body_param.subset.params.1"] == binary_part(long_value, 0, 2_000)
   end
 end

--- a/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
+++ b/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
@@ -82,7 +82,7 @@ defmodule Electric.Plug.SubsetTelemetryTest do
     assert query_attrs["subset.result_bytes"] > 0
   end
 
-  test "truncates large POST body strings to 2000 bytes in telemetry attrs", ctx do
+  test "truncates large POST body strings to 2000 graphemes in telemetry attrs", ctx do
     test_pid = self()
     long_where = "value ILIKE $1" <> String.duplicate(" ", 3_000)
 
@@ -108,7 +108,7 @@ defmodule Electric.Plug.SubsetTelemetryTest do
 
     assert conn.status == 200
     assert_receive {:body_attrs, attrs}
-    assert byte_size(attrs["http.body_param.subset.where"]) == 2_000
-    assert attrs["http.body_param.subset.where"] == binary_part(long_where, 0, 2_000)
+    assert String.length(attrs["http.body_param.subset.where"]) == 2_000
+    assert attrs["http.body_param.subset.where"] == String.slice(long_where, 0, 2_000)
   end
 end

--- a/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
+++ b/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
@@ -1,0 +1,115 @@
+defmodule Electric.Plug.SubsetTelemetryTest do
+  use ExUnit.Case, async: false
+  use Repatch.ExUnit
+
+  import Plug.Test
+  import Support.ComponentSetup
+  import Support.DbSetup
+  import Support.DbStructureSetup
+
+  alias Electric.Plug.Router
+  alias Electric.Telemetry.OpenTelemetry
+
+  @moduletag :tmp_dir
+
+  setup [:with_unique_db, :with_basic_tables, :with_sql_execute]
+  setup :with_complete_stack
+
+  setup(ctx) do
+    :ok = Electric.StatusMonitor.wait_until_active(ctx.stack_id, timeout: 1000)
+    %{opts: Router.init(build_router_opts(ctx))}
+  end
+
+  @tag with_sql: [
+         "INSERT INTO items VALUES (gen_random_uuid(), 'test value 1')",
+         "INSERT INTO items VALUES (gen_random_uuid(), 'test value 2')"
+       ]
+  test "adds POST body attrs and subset query attrs for POST subset requests", ctx do
+    test_pid = self()
+
+    Repatch.patch(OpenTelemetry, :add_span_attributes, [mode: :shared], fn attrs ->
+      if is_map(attrs) and
+           (Map.has_key?(attrs, "subset.rows") or
+              Map.has_key?(attrs, "http.body_param.subset.where")) do
+        send(test_pid, {:subset_span_attrs, attrs})
+      end
+
+      true
+    end)
+
+    conn =
+      conn(
+        "POST",
+        "/v1/shape?table=items&offset=-1&log=changes_only",
+        Jason.encode!(%{
+          "subset" => %{
+            "where" => "value ILIKE $1",
+            "params" => %{"1" => "%2"},
+            "limit" => 1,
+            "offset" => 0,
+            "order_by" => "value ASC"
+          }
+        })
+      )
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Router.call(ctx.opts)
+
+    assert conn.status == 200
+
+    assert %{
+             "data" => [
+               %{
+                 "value" => %{"value" => "test value 2"}
+               }
+             ]
+           } = Jason.decode!(conn.resp_body)
+
+    assert_receive {:subset_span_attrs, attrs1}
+    assert_receive {:subset_span_attrs, attrs2}
+    refute_receive {:subset_span_attrs, _other}
+
+    {request_attrs, query_attrs} =
+      case {Map.has_key?(attrs1, "http.body_param.subset.where"),
+            Map.has_key?(attrs2, "http.body_param.subset.where")} do
+        {true, false} -> {attrs1, attrs2}
+        {false, true} -> {attrs2, attrs1}
+      end
+
+    assert request_attrs["http.body_param.subset.limit"] == 1
+    assert request_attrs["http.body_param.subset.offset"] == 0
+    assert request_attrs["http.body_param.subset.where"] == "value ILIKE $1"
+
+    assert query_attrs["subset.rows"] == 1
+    assert query_attrs["subset.result_bytes"] > 0
+  end
+
+  test "truncates large POST body strings to 64KB in telemetry attrs", ctx do
+    test_pid = self()
+    long_value = String.duplicate("a", 70_000)
+
+    Repatch.patch(OpenTelemetry, :add_span_attributes, [mode: :shared], fn attrs ->
+      if is_map(attrs) and Map.has_key?(attrs, "http.body_param.extra") do
+        send(test_pid, {:body_attrs, attrs})
+      end
+
+      true
+    end)
+
+    conn =
+      conn(
+        "POST",
+        "/v1/shape?table=items&offset=-1&log=changes_only",
+        Jason.encode!(%{
+          "subset" => %{},
+          "extra" => long_value
+        })
+      )
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Router.call(ctx.opts)
+
+    assert conn.status == 200
+    assert_receive {:body_attrs, attrs}
+    assert byte_size(attrs["http.body_param.extra"]) == 64 * 1024
+    assert attrs["http.body_param.extra"] == binary_part(long_value, 0, 64 * 1024)
+  end
+end

--- a/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
+++ b/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
@@ -83,12 +83,12 @@ defmodule Electric.Plug.SubsetTelemetryTest do
     assert query_attrs["subset.result_bytes"] > 0
   end
 
-  test "truncates large POST body strings to 64KB in telemetry attrs", ctx do
+  test "truncates large POST body strings to 256 bytes in telemetry attrs", ctx do
     test_pid = self()
-    long_value = String.duplicate("a", 70_000)
+    long_value = String.duplicate("a", 300)
 
     Repatch.patch(OpenTelemetry, :add_span_attributes, [mode: :shared], fn attrs ->
-      if is_map(attrs) and Map.has_key?(attrs, "http.body_param.extra") do
+      if is_map(attrs) and Map.has_key?(attrs, "http.body_param.subset.params.1") do
         send(test_pid, {:body_attrs, attrs})
       end
 
@@ -100,8 +100,10 @@ defmodule Electric.Plug.SubsetTelemetryTest do
         "POST",
         "/v1/shape?table=items&offset=-1&log=changes_only",
         Jason.encode!(%{
-          "subset" => %{},
-          "extra" => long_value
+          "subset" => %{
+            "where" => "value ILIKE $1",
+            "params" => %{"1" => long_value}
+          }
         })
       )
       |> Plug.Conn.put_req_header("content-type", "application/json")
@@ -109,7 +111,7 @@ defmodule Electric.Plug.SubsetTelemetryTest do
 
     assert conn.status == 200
     assert_receive {:body_attrs, attrs}
-    assert byte_size(attrs["http.body_param.extra"]) == 64 * 1024
-    assert attrs["http.body_param.extra"] == binary_part(long_value, 0, 64 * 1024)
+    assert byte_size(attrs["http.body_param.subset.params.1"]) == 256
+    assert attrs["http.body_param.subset.params.1"] == binary_part(long_value, 0, 256)
   end
 end

--- a/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
+++ b/packages/sync-service/test/electric/plug/subset_telemetry_test.exs
@@ -76,6 +76,7 @@ defmodule Electric.Plug.SubsetTelemetryTest do
     assert request_attrs["http.body_param.subset.limit"] == 1
     assert request_attrs["http.body_param.subset.offset"] == 0
     assert request_attrs["http.body_param.subset.where"] == "value ILIKE $1"
+    assert request_attrs["http.body_param.subset.params"] == ~s(%{"1" => "%2"})
 
     assert query_attrs["subset.rows"] == 1
     assert query_attrs["subset.result_bytes"] > 0

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -110,6 +110,23 @@ defmodule Electric.Plug.UtilsTest do
       assert String.starts_with?(long_value, truncated)
     end
 
+    test "drops invalid leading bytes when truncating body param strings" do
+      long_value = <<255>> <> String.duplicate("a", 3_000)
+
+      conn =
+        Plug.Test.conn(:post, "/v1/shape")
+        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.assign(:body_params, %{
+          "where" => long_value
+        })
+
+      attrs = Utils.common_open_telemetry_attrs(conn)
+      truncated = attrs["http.body_param.subset.where"]
+
+      assert String.valid?(truncated)
+      assert truncated == String.duplicate("a", 1_999)
+    end
+
     test "ignores non-subset top-level POST body params" do
       conn =
         Plug.Test.conn(:post, "/v1/shape")

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -123,6 +123,7 @@ defmodule Electric.Plug.UtilsTest do
 
       refute Map.has_key?(attrs, "http.body_param.table")
       refute Map.has_key?(attrs, "http.body_param.subset.params")
+
       refute Enum.any?(Map.keys(attrs), fn key ->
                is_binary(key) and String.starts_with?(key, "http.body_param.")
              end)

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -47,7 +47,6 @@ defmodule Electric.Plug.UtilsTest do
       assert attrs["http.query_param.offset"] == "-1"
       assert attrs["http.query_param.flag"] == ""
     end
-
     test "includes documented top-level subset body params alongside query params" do
       conn =
         Plug.Test.conn(:post, "/v1/shape?foo=bar")

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -123,7 +123,6 @@ defmodule Electric.Plug.UtilsTest do
 
       refute Map.has_key?(attrs, "http.body_param.table")
       refute Map.has_key?(attrs, "http.body_param.subset.params")
-      refute Map.has_key?(attrs, "http.body_param.subset.params")
       refute Enum.any?(Map.keys(attrs), fn key ->
                is_binary(key) and String.starts_with?(key, "http.body_param.")
              end)

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -47,6 +47,87 @@ defmodule Electric.Plug.UtilsTest do
       assert attrs["http.query_param.offset"] == "-1"
       assert attrs["http.query_param.flag"] == ""
     end
+
+    test "includes documented top-level subset body params alongside query params" do
+      conn =
+        Plug.Test.conn(:post, "/v1/shape?foo=bar")
+        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.assign(:body_params, %{
+          "where" => "value ILIKE $1",
+          "limit" => 1,
+          "offset" => 0,
+          "tags" => ["a", 2, nil],
+          "table" => "items",
+          "skip_me" => nil
+        })
+
+      attrs = Utils.common_open_telemetry_attrs(conn)
+
+      assert attrs["http.query_param.foo"] == "bar"
+      assert attrs["http.body_param.subset.where"] == "value ILIKE $1"
+      assert attrs["http.body_param.subset.limit"] == 1
+      assert attrs["http.body_param.subset.offset"] == 0
+      refute Map.has_key?(attrs, "http.body_param.table")
+      refute Map.has_key?(attrs, "http.body_param.subset.params")
+      refute Map.has_key?(attrs, "http.body_param.subset.tags")
+      refute Map.has_key?(attrs, "http.body_param.skip_me")
+    end
+
+    test "treats top-level subset body params as subset telemetry attrs" do
+      conn =
+        Plug.Test.conn(:post, "/v1/shape")
+        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.assign(:body_params, %{
+          "where" => "value ILIKE $1",
+          "limit" => 1,
+          "offset" => 0
+        })
+
+      attrs = Utils.common_open_telemetry_attrs(conn)
+
+      assert attrs["http.body_param.subset.where"] == "value ILIKE $1"
+      assert attrs["http.body_param.subset.limit"] == 1
+      assert attrs["http.body_param.subset.offset"] == 0
+      refute Map.has_key?(attrs, "http.body_param.where")
+    end
+
+    test "truncates large body param strings to 2000 bytes and keeps valid UTF-8" do
+      long_value = String.duplicate("😀", 20_000)
+
+      conn =
+        Plug.Test.conn(:post, "/v1/shape")
+        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.assign(:body_params, %{
+          "where" => long_value
+        })
+
+      attrs = Utils.common_open_telemetry_attrs(conn)
+      truncated = attrs["http.body_param.subset.where"]
+
+      assert String.valid?(truncated)
+      assert byte_size(truncated) <= 2000
+      assert byte_size(truncated) < byte_size(long_value)
+      assert String.starts_with?(long_value, truncated)
+    end
+
+    test "ignores non-subset top-level POST body params" do
+      conn =
+        Plug.Test.conn(:post, "/v1/shape")
+        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.assign(:body_params, %{
+          "table" => "items",
+          "params" => %{"tenant" => "acme"}
+        })
+
+      attrs = Utils.common_open_telemetry_attrs(conn)
+
+      refute Map.has_key?(attrs, "http.body_param.table")
+      refute Map.has_key?(attrs, "http.body_param.subset.params")
+
+      refute Enum.any?(Map.keys(attrs), fn key ->
+               is_binary(key) and String.starts_with?(key, "http.body_param.")
+             end)
+    end
   end
 
   describe "get_next_interval_timestamp/2" do

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -123,7 +123,7 @@ defmodule Electric.Plug.UtilsTest do
 
       refute Map.has_key?(attrs, "http.body_param.table")
       refute Map.has_key?(attrs, "http.body_param.subset.params")
-
+      refute Map.has_key?(attrs, "http.body_param.subset.params")
       refute Enum.any?(Map.keys(attrs), fn key ->
                is_binary(key) and String.starts_with?(key, "http.body_param.")
              end)

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -94,7 +94,7 @@ defmodule Electric.Plug.UtilsTest do
       refute Map.has_key?(attrs, "http.body_param.where")
     end
 
-    test "truncates large body param strings to 2000 bytes and keeps valid UTF-8" do
+    test "truncates large body param strings to 2000 graphemes and keeps valid UTF-8" do
       long_value = String.duplicate("😀", 20_000)
 
       conn =
@@ -108,7 +108,7 @@ defmodule Electric.Plug.UtilsTest do
       truncated = attrs["http.body_param.subset.where"]
 
       assert String.valid?(truncated)
-      assert byte_size(truncated) <= 2000
+      assert String.length(truncated) == 2_000
       assert byte_size(truncated) < byte_size(long_value)
       assert String.starts_with?(long_value, truncated)
     end
@@ -127,7 +127,24 @@ defmodule Electric.Plug.UtilsTest do
       truncated = attrs["http.body_param.subset.where"]
 
       assert String.valid?(truncated)
-      assert truncated == String.duplicate("a", 1_999)
+      assert truncated == String.duplicate("a", 2_000)
+    end
+
+    test "drops invalid bytes from body param strings that do not need truncation" do
+      value = "prefix" <> <<255>> <> "suffix"
+
+      conn =
+        Plug.Test.conn(:post, "/v1/shape")
+        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.assign(:body_params, %{
+          "where" => value
+        })
+
+      attrs = Utils.common_open_telemetry_attrs(conn)
+      sanitized = attrs["http.body_param.subset.where"]
+
+      assert String.valid?(sanitized)
+      assert sanitized == "prefixsuffix"
     end
 
     test "records subset params as a single truncated string attr" do
@@ -144,7 +161,7 @@ defmodule Electric.Plug.UtilsTest do
       params_attr = attrs["http.body_param.subset.params"]
 
       assert String.valid?(params_attr)
-      assert byte_size(params_attr) <= 2000
+      assert String.length(params_attr) <= 2_000
       assert String.starts_with?(params_attr, ~s(%{"1" => "aaaa))
     end
 

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -54,6 +54,7 @@ defmodule Electric.Plug.UtilsTest do
         |> Plug.Conn.fetch_query_params()
         |> Plug.Conn.assign(:body_params, %{
           "where" => "value ILIKE $1",
+          "params" => %{"1" => "%2"},
           "limit" => 1,
           "offset" => 0,
           "tags" => ["a", 2, nil],
@@ -65,10 +66,10 @@ defmodule Electric.Plug.UtilsTest do
 
       assert attrs["http.query_param.foo"] == "bar"
       assert attrs["http.body_param.subset.where"] == "value ILIKE $1"
+      assert attrs["http.body_param.subset.params"] == ~s(%{"1" => "%2"})
       assert attrs["http.body_param.subset.limit"] == 1
       assert attrs["http.body_param.subset.offset"] == 0
       refute Map.has_key?(attrs, "http.body_param.table")
-      refute Map.has_key?(attrs, "http.body_param.subset.params")
       refute Map.has_key?(attrs, "http.body_param.subset.tags")
       refute Map.has_key?(attrs, "http.body_param.skip_me")
     end
@@ -79,6 +80,7 @@ defmodule Electric.Plug.UtilsTest do
         |> Plug.Conn.fetch_query_params()
         |> Plug.Conn.assign(:body_params, %{
           "where" => "value ILIKE $1",
+          "params" => %{"1" => "%2"},
           "limit" => 1,
           "offset" => 0
         })
@@ -86,6 +88,7 @@ defmodule Electric.Plug.UtilsTest do
       attrs = Utils.common_open_telemetry_attrs(conn)
 
       assert attrs["http.body_param.subset.where"] == "value ILIKE $1"
+      assert attrs["http.body_param.subset.params"] == ~s(%{"1" => "%2"})
       assert attrs["http.body_param.subset.limit"] == 1
       assert attrs["http.body_param.subset.offset"] == 0
       refute Map.has_key?(attrs, "http.body_param.where")
@@ -127,13 +130,31 @@ defmodule Electric.Plug.UtilsTest do
       assert truncated == String.duplicate("a", 1_999)
     end
 
+    test "records subset params as a single truncated string attr" do
+      long_param = String.duplicate("a", 3_000)
+
+      conn =
+        Plug.Test.conn(:post, "/v1/shape")
+        |> Plug.Conn.fetch_query_params()
+        |> Plug.Conn.assign(:body_params, %{
+          "params" => %{"1" => long_param}
+        })
+
+      attrs = Utils.common_open_telemetry_attrs(conn)
+      params_attr = attrs["http.body_param.subset.params"]
+
+      assert String.valid?(params_attr)
+      assert byte_size(params_attr) <= 2000
+      assert String.starts_with?(params_attr, ~s(%{"1" => "aaaa))
+    end
+
     test "ignores non-subset top-level POST body params" do
       conn =
         Plug.Test.conn(:post, "/v1/shape")
         |> Plug.Conn.fetch_query_params()
         |> Plug.Conn.assign(:body_params, %{
           "table" => "items",
-          "params" => %{"tenant" => "acme"}
+          "columns" => ["id"]
         })
 
       attrs = Utils.common_open_telemetry_attrs(conn)

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -47,6 +47,7 @@ defmodule Electric.Plug.UtilsTest do
       assert attrs["http.query_param.offset"] == "-1"
       assert attrs["http.query_param.flag"] == ""
     end
+
     test "includes documented top-level subset body params alongside query params" do
       conn =
         Plug.Test.conn(:post, "/v1/shape?foo=bar")


### PR DESCRIPTION
## Summary
- add subset query span attrs for returned row count and result bytes
- record POST body params as telemetry attrs, truncating long strings to 64KB
- surface `electric.subqueries.subset_result.rows` from `ElectricTelemetry.StackTelemetry`
- add focused tests for POST body telemetry flattening/truncation and the new stack metric

## Testing
- `mix test test/electric/plug/utils_test.exs test/electric/plug/subset_telemetry_test.exs`
- `mix test test/electric/telemetry/stack_telemetry_test.exs`
