### PR TITLE
fix(ci): use OIDC provenance for canary npm auth

### DIFF
--- a/.github/workflows/canary_npm_publish.yml
+++ b/.github/workflows/canary_npm_publish.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           node-version-file: '.tool-versions'
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
 
@@ -57,11 +56,9 @@ jobs:
           pnpm run --filter '@electric-ax/agents' build
           pnpm run --filter 'electric-ax' build
 
-      # Publish with canary tag
+      # Publish with canary tag (uses OIDC provenance for auth, matching the release workflow)
       - name: Publish canary packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          pnpm publish --filter '@electric-ax/agents-runtime' --tag canary --no-git-checks --access public
-          pnpm publish --filter '@electric-ax/agents' --tag canary --no-git-checks --access public
-          pnpm publish --filter 'electric-ax' --tag canary --no-git-checks --access public
+          pnpm publish --filter '@electric-ax/agents-runtime' --tag canary --no-git-checks --access public --provenance
+          pnpm publish --filter '@electric-ax/agents' --tag canary --no-git-checks --access public --provenance
+          pnpm publish --filter 'electric-ax' --tag canary --no-git-checks --access public --provenance


### PR DESCRIPTION
## Summary

- Fix canary npm publish auth failure (`ENEEDAUTH`) by switching from token-based auth to OIDC provenance, matching the release workflow
- Remove `registry-url` from `setup-node` and `NODE_AUTH_TOKEN` / `NPM_TOKEN` references
- Add `--provenance` flag to all `pnpm publish` commands

## Context

The canary workflow failed on first run because `NPM_TOKEN` secret doesn't exist — the repo uses npm OIDC trusted publishing via `id-token: write`, not token-based auth.

## Test plan

- [ ] Merge and verify the canary workflow succeeds on the next push to `main` that touches agent packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)