### PR TITLE
chore(agents): bump @electric-ax/durable-streams-*-beta to latest

### DIFF
--- a/.changeset/update-durable-streams.md
+++ b/.changeset/update-durable-streams.md
@@ -1,0 +1,9 @@
+---
+"@electric-ax/agents": patch
+"@electric-ax/agents-runtime": patch
+"@electric-ax/agents-server": patch
+"@electric-ax/agents-server-conformance-tests": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Bump `@electric-ax/durable-streams-*-beta` dependencies to the latest published versions (`client@^0.3.1`, `state@^0.3.1`, `server@^0.3.2`).

--- a/packages/agents-runtime/package.json
+++ b/packages/agents-runtime/package.json
@@ -67,8 +67,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.0",
-    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.1",
+    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.1",
     "@mariozechner/pi-agent-core": "^0.70.2",
     "@mariozechner/pi-ai": "^0.70.2",
     "@mozilla/readability": "^0.6.0",
@@ -85,7 +85,7 @@
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
-    "@durable-streams/server": "npm:@electric-ax/durable-streams-server-beta@^0.3.0",
+    "@durable-streams/server": "npm:@electric-ax/durable-streams-server-beta@^0.3.2",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^22.19.15",
     "@types/turndown": "^5.0.6",

--- a/packages/agents-server-conformance-tests/package.json
+++ b/packages/agents-server-conformance-tests/package.json
@@ -36,7 +36,7 @@
     "stylecheck": "eslint . --quiet"
   },
   "dependencies": {
-    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.0",
+    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.1",
     "@electric-sql/client": "^1.5.14",
     "fast-check": "^4.6.0",
     "vitest": "^4.1.0"

--- a/packages/agents-server-ui/package.json
+++ b/packages/agents-server-ui/package.json
@@ -12,8 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.0",
-    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.1",
+    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.1",
     "@electric-ax/agents-runtime": "workspace:*",
     "@radix-ui/themes": "^3.3.0",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/agents-server/package.json
+++ b/packages/agents-server/package.json
@@ -42,9 +42,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.0",
-    "@durable-streams/server": "npm:@electric-ax/durable-streams-server-beta@^0.3.0",
-    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.1",
+    "@durable-streams/server": "npm:@electric-ax/durable-streams-server-beta@^0.3.2",
+    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.1",
     "@electric-ax/agents-runtime": "workspace:*",
     "@electric-sql/client": "^1.5.14",
     "@mariozechner/pi-agent-core": "^0.70.2",

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -93,7 +93,7 @@ export class StreamClient {
 
       await handle.append(data)
       const head = await handle.head()
-      return { offset: head.offset ?? `` }
+      return { offset: (head.exists && head.offset) || `` }
     })
   }
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.1",
     "@electric-ax/agents-runtime": "workspace:*",
     "@mariozechner/pi-agent-core": "^0.70.2",
     "@mariozechner/pi-ai": "^0.70.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1435,8 +1435,8 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
       '@durable-streams/state':
-        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.1
+        version: '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)'
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../agents-runtime
@@ -1496,11 +1496,11 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
       '@durable-streams/client':
-        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.0
-        version: '@electric-ax/durable-streams-client-beta@0.3.0'
+        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.1
+        version: '@electric-ax/durable-streams-client-beta@0.3.1'
       '@durable-streams/state':
-        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.1
+        version: '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)'
       '@mariozechner/pi-agent-core':
         specifier: ^0.70.2
         version: 0.70.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
@@ -1551,8 +1551,8 @@ importers:
         version: 3.25.2(zod@4.3.6)
     devDependencies:
       '@durable-streams/server':
-        specifier: npm:@electric-ax/durable-streams-server-beta@^0.3.0
-        version: '@electric-ax/durable-streams-server-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-server-beta@^0.3.2
+        version: '@electric-ax/durable-streams-server-beta@0.3.2(typescript@5.8.3)'
       '@types/jsdom':
         specifier: ^27.0.0
         version: 27.0.0
@@ -1581,14 +1581,14 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
       '@durable-streams/client':
-        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.0
-        version: '@electric-ax/durable-streams-client-beta@0.3.0'
+        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.1
+        version: '@electric-ax/durable-streams-client-beta@0.3.1'
       '@durable-streams/server':
-        specifier: npm:@electric-ax/durable-streams-server-beta@^0.3.0
-        version: '@electric-ax/durable-streams-server-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-server-beta@^0.3.2
+        version: '@electric-ax/durable-streams-server-beta@0.3.2(typescript@5.8.3)'
       '@durable-streams/state':
-        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.1
+        version: '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)'
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../agents-runtime
@@ -1663,8 +1663,8 @@ importers:
   packages/agents-server-conformance-tests:
     dependencies:
       '@durable-streams/client':
-        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.0
-        version: '@electric-ax/durable-streams-client-beta@0.3.0'
+        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.1
+        version: '@electric-ax/durable-streams-client-beta@0.3.1'
       '@electric-sql/client':
         specifier: ^1.5.14
         version: link:../typescript-client
@@ -1691,11 +1691,11 @@ importers:
   packages/agents-server-ui:
     dependencies:
       '@durable-streams/client':
-        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.0
-        version: '@electric-ax/durable-streams-client-beta@0.3.0'
+        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.1
+        version: '@electric-ax/durable-streams-client-beta@0.3.1'
       '@durable-streams/state':
-        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.1
+        version: '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)'
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../agents-runtime
@@ -3937,12 +3937,22 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@electric-ax/durable-streams-server-beta@0.3.0':
-    resolution: {integrity: sha512-EnM/zUIJ0Bv1wLQOQmeBcrHNyaz8jCdfC0GotvtFEyvz/Tivu996XNsmAecrXKj7AammLe7oX576n15OIbhQsw==}
+  '@electric-ax/durable-streams-client-beta@0.3.1':
+    resolution: {integrity: sha512-smWzyfwrkA5TyRTnyO/HEbElJm54lyifRe6hgQpcfYaW0M3l3jedI5voOEvu2GTHfBKuOsFrFWsbMB0ltGm6qg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  '@electric-ax/durable-streams-server-beta@0.3.2':
+    resolution: {integrity: sha512-jo0siJmG6awFjMxaHbIkcUW+SGzmoT2JezxSLZ/wzKVt24Ao4HyWmBMjKXVaEm9Qtq8RjdYiSd6o8X8i0K/wHw==}
     engines: {node: '>=18.0.0'}
 
   '@electric-ax/durable-streams-state-beta@0.3.0':
     resolution: {integrity: sha512-/jJyT757kz765v6vhmElYTz4E1IMa547UXuOjEYEdHW6TjubLWVve+6bc7w4rXma1AXoE6e8j3sYi+JT0aJeZw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  '@electric-ax/durable-streams-state-beta@0.3.1':
+    resolution: {integrity: sha512-84Y3/ERaJgXEtXRqkyK+lML59ABqg/zjsQD3YYR+EWysMsoy6f664GZ5QzTqbuxO/03nP83FuAYFDPw6jgIsCA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -21282,10 +21292,15 @@ snapshots:
       '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
       fastq: 1.20.1
 
-  '@electric-ax/durable-streams-server-beta@0.3.0(typescript@5.8.3)':
+  '@electric-ax/durable-streams-client-beta@0.3.1':
     dependencies:
-      '@durable-streams/client': '@electric-ax/durable-streams-client-beta@0.3.0'
-      '@durable-streams/state': '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+      '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
+      fastq: 1.20.1
+
+  '@electric-ax/durable-streams-server-beta@0.3.2(typescript@5.8.3)':
+    dependencies:
+      '@electric-ax/durable-streams-client-beta': 0.3.1
+      '@electric-ax/durable-streams-state-beta': 0.3.1(typescript@5.8.3)
       '@neophi/sieve-cache': 1.5.0
       '@opentelemetry/api': 1.9.1
       lmdb: 3.5.4
@@ -21297,6 +21312,14 @@ snapshots:
   '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)':
     dependencies:
       '@durable-streams/client': '@electric-ax/durable-streams-client-beta@0.3.0'
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db': 0.6.5(typescript@5.8.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)':
+    dependencies:
+      '@electric-ax/durable-streams-client-beta': 0.3.1
       '@standard-schema/spec': 1.1.0
       '@tanstack/db': 0.6.5(typescript@5.8.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Bumps the `@electric-ax/durable-streams-*-beta` aliased dependencies in all `agents-*` packages (`agents`, `agents-runtime`, `agents-server`, `agents-server-conformance-tests`, `agents-server-ui`) to the latest published versions: `client@^0.3.1`, `state@^0.3.1`, `server@^0.3.2`.
- Refreshes `pnpm-lock.yaml` and adds a changeset.

## Test plan
- [ ] CI passes (typecheck, lint, tests for affected packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)