### PR TITLE
feat(agents-server): add subtree fork support for agents

### DIFF
--- a/.changeset/update-durable-streams.md
+++ b/.changeset/update-durable-streams.md
@@ -1,0 +1,9 @@
+---
+"@electric-ax/agents": patch
+"@electric-ax/agents-runtime": patch
+"@electric-ax/agents-server": patch
+"@electric-ax/agents-server-conformance-tests": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Bump `@electric-ax/durable-streams-*-beta` dependencies to the latest published versions (`client@^0.3.1`, `state@^0.3.1`, `server@^0.3.2`).

--- a/packages/agents-runtime/package.json
+++ b/packages/agents-runtime/package.json
@@ -67,8 +67,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.0",
-    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.1",
+    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.1",
     "@mariozechner/pi-agent-core": "^0.70.2",
     "@mariozechner/pi-ai": "^0.70.2",
     "@mozilla/readability": "^0.6.0",
@@ -85,7 +85,7 @@
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
-    "@durable-streams/server": "npm:@electric-ax/durable-streams-server-beta@^0.3.0",
+    "@durable-streams/server": "npm:@electric-ax/durable-streams-server-beta@^0.3.2",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^22.19.15",
     "@types/turndown": "^5.0.6",

--- a/packages/agents-server-conformance-tests/package.json
+++ b/packages/agents-server-conformance-tests/package.json
@@ -36,7 +36,7 @@
     "stylecheck": "eslint . --quiet"
   },
   "dependencies": {
-    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.0",
+    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.1",
     "@electric-sql/client": "^1.5.14",
     "fast-check": "^4.6.0",
     "vitest": "^4.1.0"

--- a/packages/agents-server-ui/package.json
+++ b/packages/agents-server-ui/package.json
@@ -12,8 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.0",
-    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.1",
+    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.1",
     "@electric-ax/agents-runtime": "workspace:*",
     "@radix-ui/themes": "^3.3.0",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/agents-server-ui/src/components/EntityHeader.tsx
+++ b/packages/agents-server-ui/src/components/EntityHeader.tsx
@@ -11,6 +11,7 @@ import {
   Copy,
   Database,
   Eye,
+  GitFork,
   MoreHorizontal,
   Pin,
   PinOff,
@@ -31,16 +32,22 @@ export function EntityHeader({
   entity,
   pinned,
   onTogglePin,
+  onFork,
   onKill,
   killError,
+  forkError,
+  forking,
   stateExplorerOpen,
   onToggleStateExplorer,
 }: {
   entity: ElectricEntity
   pinned: boolean
   onTogglePin: () => void
+  onFork?: () => void
   onKill: () => void
   killError?: string | null
+  forkError?: string | null
+  forking?: boolean
   stateExplorerOpen?: boolean
   onToggleStateExplorer?: () => void
 }): React.ReactElement {
@@ -71,12 +78,34 @@ export function EntityHeader({
             {killError}
           </Text>
         )}
+        {forkError && (
+          <Text size="1" color="red">
+            {forkError}
+          </Text>
+        )}
       </Flex>
 
       <Flex ml="auto" align="center" gap="2">
         <Badge color={STATUS_COLOR[entity.status] ?? `gray`} variant="soft">
           {entity.status}
         </Badge>
+
+        {onFork && (
+          <Button
+            variant="soft"
+            size="1"
+            onClick={onFork}
+            disabled={forking || entity.status === `stopped`}
+            title={
+              entity.status === `idle`
+                ? `Fork subtree`
+                : `Fork subtree once idle`
+            }
+          >
+            <GitFork size={14} />
+            <Text size="1">{forking ? `Forking` : `Fork`}</Text>
+          </Button>
+        )}
 
         {onToggleStateExplorer && (
           <Button

--- a/packages/agents-server-ui/src/lib/ElectricAgentsProvider.tsx
+++ b/packages/agents-server-ui/src/lib/ElectricAgentsProvider.tsx
@@ -176,6 +176,35 @@ function createKillAction(
   })
 }
 
+function createForkEntity(baseUrl: string) {
+  return async (entityUrl: string): Promise<{ url: string }> => {
+    const res = await fetch(`${baseUrl}${entityUrl}/fork`, {
+      method: `POST`,
+      headers: { 'content-type': `application/json` },
+      body: JSON.stringify({}),
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => ``)
+      let message = text || `Fork failed (${res.status})`
+      try {
+        const data = JSON.parse(text) as {
+          error?: { message?: string }
+          message?: string
+        }
+        message = data.error?.message ?? data.message ?? message
+      } catch {
+        // Keep the raw response text.
+      }
+      throw new Error(message)
+    }
+    const data = (await res.json()) as { root?: { url?: string } }
+    if (!data.root?.url) {
+      throw new Error(`Fork returned an invalid response`)
+    }
+    return { url: data.root.url }
+  }
+}
+
 // --- Context ---
 
 interface ElectricAgentsState {
@@ -183,6 +212,7 @@ interface ElectricAgentsState {
   entityTypesCollection: EntityTypesCollection | null
   spawnEntity: ReturnType<typeof createSpawnAction> | null
   killEntity: ReturnType<typeof createKillAction> | null
+  forkEntity: ReturnType<typeof createForkEntity> | null
 }
 
 const ElectricAgentsContext = createContext<ElectricAgentsState>({
@@ -190,6 +220,7 @@ const ElectricAgentsContext = createContext<ElectricAgentsState>({
   entityTypesCollection: null,
   spawnEntity: null,
   killEntity: null,
+  forkEntity: null,
 })
 
 export function ElectricAgentsProvider({
@@ -204,6 +235,7 @@ export function ElectricAgentsProvider({
     entityTypesCollection: null,
     spawnEntity: null,
     killEntity: null,
+    forkEntity: null,
   })
   const prevUrlRef = useRef<string | null>(null)
   const collectionsRef = useRef<{
@@ -226,6 +258,7 @@ export function ElectricAgentsProvider({
         entityTypesCollection: null,
         spawnEntity: null,
         killEntity: null,
+        forkEntity: null,
       })
       return
     }
@@ -240,6 +273,7 @@ export function ElectricAgentsProvider({
       entityTypesCollection: entityTypes,
       spawnEntity: createSpawnAction(baseUrl, entities),
       killEntity: createKillAction(baseUrl, entities),
+      forkEntity: createForkEntity(baseUrl),
     })
 
     return () => {

--- a/packages/agents-server-ui/src/router.tsx
+++ b/packages/agents-server-ui/src/router.tsx
@@ -68,7 +68,8 @@ function EntityPage(): React.ReactElement {
   const entityUrl = `/${_splat}`
   const { activeServer } = useServerConnection()
   const { pinnedUrls, togglePin } = usePinnedEntities()
-  const { entitiesCollection, killEntity } = useElectricAgents()
+  const { entitiesCollection, forkEntity, killEntity } = useElectricAgents()
+  const navigate = useNavigate()
 
   const { data: matchingEntities = [] } = useLiveQuery(
     (query) => {
@@ -87,6 +88,8 @@ function EntityPage(): React.ReactElement {
   const [statePanelWidth, setStatePanelWidth] = useState(0.5)
   const containerRef = useRef<HTMLDivElement>(null)
   const [killError, setKillError] = useState<string | null>(null)
+  const [forkError, setForkError] = useState<string | null>(null)
+  const [forking, setForking] = useState(false)
 
   const handleKill = useCallback(() => {
     if (!killEntity) return
@@ -96,6 +99,25 @@ function EntityPage(): React.ReactElement {
       setKillError(err.message)
     })
   }, [killEntity, entityUrl])
+
+  const handleFork = useCallback(() => {
+    if (!forkEntity || forking) return
+    setForkError(null)
+    setForking(true)
+    forkEntity(entityUrl)
+      .then((root) => {
+        navigate({
+          to: `/entity/$`,
+          params: { _splat: root.url.replace(/^\//, ``) },
+        })
+      })
+      .catch((err: Error) => {
+        setForkError(err.message)
+      })
+      .finally(() => {
+        setForking(false)
+      })
+  }, [entityUrl, forkEntity, forking, navigate])
 
   if (!selectedEntity) {
     return (
@@ -119,6 +141,9 @@ function EntityPage(): React.ReactElement {
         onTogglePin={() => togglePin(entityUrl)}
         onKill={handleKill}
         killError={killError}
+        onFork={forkEntity && !selectedEntity.parent ? handleFork : undefined}
+        forkError={forkError}
+        forking={forking}
         stateExplorerOpen={stateExplorerOpen}
         onToggleStateExplorer={() => setStateExplorerOpen((prev) => !prev)}
       />

--- a/packages/agents-server/package.json
+++ b/packages/agents-server/package.json
@@ -42,9 +42,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.0",
-    "@durable-streams/server": "npm:@electric-ax/durable-streams-server-beta@^0.3.0",
-    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@durable-streams/client": "npm:@electric-ax/durable-streams-client-beta@^0.3.1",
+    "@durable-streams/server": "npm:@electric-ax/durable-streams-server-beta@^0.3.2",
+    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.1",
     "@electric-ax/agents-runtime": "workspace:*",
     "@electric-sql/client": "^1.5.14",
     "@mariozechner/pi-agent-core": "^0.70.2",

--- a/packages/agents-server/src/electric-agents-manager.ts
+++ b/packages/agents-server/src/electric-agents-manager.ts
@@ -12,11 +12,17 @@ import {
   assertTags,
   entityStateSchema,
   getCronStreamPath,
+  getSharedStateStreamPath,
   getNextCronFireAt,
+  manifestChildKey,
+  manifestSharedStateKey,
+  manifestSourceKey,
   resolveCronScheduleSpec,
 } from '@electric-ax/agents-runtime'
 import {
   ErrCodeDuplicateURL,
+  ErrCodeForkInProgress,
+  ErrCodeForkWaitTimeout,
   ErrCodeInvalidRequest,
   ErrCodeNotFound,
   ErrCodeNotRunning,
@@ -31,7 +37,11 @@ import { serverLog } from './log.js'
 import { ATTR, withSpan } from './tracing.js'
 import type { queueAsPromised } from 'fastq'
 import type { Scheduler } from './scheduler.js'
-import type { WakeEvalResult, WakeRegistry } from './wake-registry.js'
+import type {
+  WakeEvalResult,
+  WakeRegistration,
+  WakeRegistry,
+} from './wake-registry.js'
 import type { WakeMessage } from '@electric-ax/agents-runtime'
 import type { PostgresRegistry } from './electric-agents-registry.js'
 import type { SchemaValidator } from './electric-agents-schema-validator.js'
@@ -53,6 +63,50 @@ type SpawnPersistResult = [
 ]
 type SpawnPersistJob = () => Promise<SpawnPersistResult>
 
+type ForkSubtreeOptions = {
+  rootInstanceId?: string
+  waitTimeoutMs?: number
+  waitPollMs?: number
+}
+
+type ForkEntityPlan = {
+  source: ElectricAgentsEntity
+  fork: ElectricAgentsEntity
+}
+
+type ForkStateSnapshot = {
+  manifestsByEntity: Map<string, Map<string, Record<string, unknown>>>
+  childStatusesByEntity: Map<string, Map<string, Record<string, unknown>>>
+  replayWatermarksByEntity: Map<string, Map<string, Record<string, unknown>>>
+  sharedStateIds: Set<string>
+}
+
+type ForkResult = {
+  root: ElectricAgentsEntity
+  entities: Array<ElectricAgentsEntity>
+}
+
+const DEFAULT_FORK_WAIT_TIMEOUT_MS = 120_000
+const DEFAULT_FORK_WAIT_POLL_MS = 250
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  ) as T
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === `object` && value !== null && !Array.isArray(value)
+}
+
+function cloneRecord<T extends Record<string, unknown>>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
 export class ElectricAgentsManager {
   readonly registry: PostgresRegistry
   private streamClient: StreamClient
@@ -60,6 +114,9 @@ export class ElectricAgentsManager {
   private scheduler: Scheduler | null = null
   private entityBridgeManager: EntityBridgeManager | null = null
   readonly wakeRegistry: WakeRegistry
+  private forkWorkLockedEntities = new Map<string, number>()
+  private forkWriteLockedEntities = new Map<string, number>()
+  private forkWriteLockedStreams = new Map<string, number>()
   private spawnPersistQueue: queueAsPromised<
     SpawnPersistJob,
     SpawnPersistResult
@@ -479,6 +536,1104 @@ export class ElectricAgentsManager {
   }
 
   // ==========================================================================
+  // Fork
+  // ==========================================================================
+
+  async forkSubtree(
+    rootUrl: string,
+    opts: ForkSubtreeOptions = {}
+  ): Promise<ForkResult> {
+    return await withSpan(`electric_agents.forkSubtree`, async (span) => {
+      span.setAttribute(ATTR.ENTITY_URL, rootUrl)
+      const result = await this.forkSubtreeInner(rootUrl, opts)
+      span.setAttribute(`electric_agents.fork.root_url`, result.root.url)
+      span.setAttribute(
+        `electric_agents.fork.entity_count`,
+        result.entities.length
+      )
+      return result
+    })
+  }
+
+  private async forkSubtreeInner(
+    rootUrl: string,
+    opts: ForkSubtreeOptions
+  ): Promise<ForkResult> {
+    const forkT0 = performance.now()
+    const workLocks = new Set<string>()
+    const writeEntityLocks = new Set<string>()
+    const writeStreamLocks = new Set<string>()
+
+    try {
+      const sourceTree = await this.waitForIdleSubtree(rootUrl, opts, workLocks)
+      const sourceRoot = sourceTree[0]!
+      if (sourceRoot.parent) {
+        throw new ElectricAgentsError(
+          ErrCodeInvalidRequest,
+          `Only top-level entities can be forked`,
+          400
+        )
+      }
+
+      const snapshot = await this.readForkStateSnapshot(sourceTree)
+      const suffix = randomUUID().slice(0, 8)
+      const entityUrlMap = await this.buildForkEntityUrlMap(sourceTree, {
+        suffix,
+        rootUrl,
+        rootInstanceId: opts.rootInstanceId,
+      })
+      const sharedStateIdMap = await this.buildForkSharedStateIdMap(
+        snapshot.sharedStateIds,
+        suffix
+      )
+      const stringMap = this.buildForkStringMap(entityUrlMap, sharedStateIdMap)
+      const entityPlans = this.buildForkEntityPlans(
+        sourceTree,
+        entityUrlMap,
+        stringMap
+      )
+
+      this.addForkLocks(
+        this.forkWriteLockedEntities,
+        sourceTree.map((entity) => entity.url),
+        writeEntityLocks
+      )
+      this.addForkLocks(
+        this.forkWriteLockedStreams,
+        [...snapshot.sharedStateIds].map((id) => getSharedStateStreamPath(id)),
+        writeStreamLocks
+      )
+
+      const createdStreams: Array<string> = []
+      const createdEntities: Array<string> = []
+      const activeManifestsByEntity = new Map<
+        string,
+        Map<string, Record<string, unknown>>
+      >()
+
+      try {
+        for (const plan of entityPlans) {
+          await this.streamClient.fork(
+            plan.fork.streams.main,
+            plan.source.streams.main
+          )
+          createdStreams.push(plan.fork.streams.main)
+          await this.streamClient.fork(
+            plan.fork.streams.error,
+            plan.source.streams.error
+          )
+          createdStreams.push(plan.fork.streams.error)
+        }
+
+        for (const [sourceId, forkId] of sharedStateIdMap) {
+          const sourcePath = getSharedStateStreamPath(sourceId)
+          const forkPath = getSharedStateStreamPath(forkId)
+          await this.streamClient.fork(forkPath, sourcePath)
+          createdStreams.push(forkPath)
+        }
+
+        for (const plan of entityPlans) {
+          const reconciliation = this.buildForkReconciliation(
+            plan,
+            snapshot,
+            entityUrlMap,
+            sharedStateIdMap,
+            stringMap
+          )
+          activeManifestsByEntity.set(plan.fork.url, reconciliation.manifests)
+          for (const event of reconciliation.events) {
+            await this.streamClient.append(
+              plan.fork.streams.main,
+              this.encodeChangeEvent(event)
+            )
+          }
+        }
+
+        for (const plan of entityPlans) {
+          await this.registry.createEntity(plan.fork)
+          createdEntities.push(plan.fork.url)
+        }
+
+        for (const plan of entityPlans) {
+          const manifests =
+            activeManifestsByEntity.get(plan.fork.url) ?? new Map()
+          await this.materializeForkManifestSideEffects(
+            plan.fork.url,
+            manifests
+          )
+        }
+
+        const root = entityPlans.find(
+          (plan) => plan.source.url === rootUrl
+        )!.fork
+        serverLog.event(
+          {
+            event: `fork`,
+            url: rootUrl,
+            forkUrl: root.url,
+            entities: entityPlans.length,
+            sharedStateStreams: sharedStateIdMap.size,
+            totalMs: +(performance.now() - forkT0).toFixed(2),
+          },
+          `fork done`
+        )
+        return { root, entities: entityPlans.map((plan) => plan.fork) }
+      } catch (err) {
+        await Promise.allSettled([
+          ...createdEntities.flatMap((entityUrl) => [
+            this.wakeRegistry.unregisterBySubscriber(entityUrl),
+            this.wakeRegistry.unregisterBySource(entityUrl),
+            this.registry.deleteEntity(entityUrl),
+          ]),
+          ...Array.from(sharedStateIdMap.values()).map((id) =>
+            this.wakeRegistry.unregisterBySource(getSharedStateStreamPath(id))
+          ),
+          ...createdStreams.map((streamPath) =>
+            this.streamClient.delete(streamPath)
+          ),
+        ])
+        throw err
+      } finally {
+        this.releaseForkLocks(this.forkWriteLockedStreams, writeStreamLocks)
+        this.releaseForkLocks(this.forkWriteLockedEntities, writeEntityLocks)
+      }
+    } finally {
+      this.releaseForkLocks(this.forkWorkLockedEntities, workLocks)
+    }
+  }
+
+  isForkWorkLockedEntity(entityUrl: string): boolean {
+    return (this.forkWorkLockedEntities.get(entityUrl) ?? 0) > 0
+  }
+
+  isForkWriteLockedEntity(entityUrl: string): boolean {
+    return (this.forkWriteLockedEntities.get(entityUrl) ?? 0) > 0
+  }
+
+  isForkWriteLockedStream(streamPath: string): boolean {
+    return (this.forkWriteLockedStreams.get(streamPath) ?? 0) > 0
+  }
+
+  private assertEntityNotForkWorkLocked(entityUrl: string): void {
+    if (!this.isForkWorkLockedEntity(entityUrl)) return
+    throw new ElectricAgentsError(
+      ErrCodeForkInProgress,
+      `Entity subtree is being forked`,
+      409
+    )
+  }
+
+  private addForkLocks(
+    locks: Map<string, number>,
+    keys: Array<string>,
+    held: Set<string>
+  ): void {
+    for (const key of keys) {
+      if (held.has(key)) continue
+      locks.set(key, (locks.get(key) ?? 0) + 1)
+      held.add(key)
+    }
+  }
+
+  private releaseForkLocks(
+    locks: Map<string, number>,
+    held: Set<string>
+  ): void {
+    for (const key of held) {
+      const count = locks.get(key) ?? 0
+      if (count <= 1) {
+        locks.delete(key)
+      } else {
+        locks.set(key, count - 1)
+      }
+    }
+    held.clear()
+  }
+
+  private async waitForIdleSubtree(
+    rootUrl: string,
+    opts: ForkSubtreeOptions,
+    workLocks: Set<string>
+  ): Promise<Array<ElectricAgentsEntity>> {
+    const timeoutMs = opts.waitTimeoutMs ?? DEFAULT_FORK_WAIT_TIMEOUT_MS
+    const pollMs = opts.waitPollMs ?? DEFAULT_FORK_WAIT_POLL_MS
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+      throw new ElectricAgentsError(
+        ErrCodeInvalidRequest,
+        `waitTimeoutMs must be a non-negative number`,
+        400
+      )
+    }
+    if (!Number.isFinite(pollMs) || pollMs <= 0) {
+      throw new ElectricAgentsError(
+        ErrCodeInvalidRequest,
+        `waitPollMs must be a positive number`,
+        400
+      )
+    }
+
+    const deadline = Date.now() + timeoutMs
+    while (true) {
+      const root = await this.registry.getEntity(rootUrl)
+      if (!root) {
+        throw new ElectricAgentsError(ErrCodeNotFound, `Entity not found`, 404)
+      }
+      if (root.parent) {
+        throw new ElectricAgentsError(
+          ErrCodeInvalidRequest,
+          `Only top-level entities can be forked`,
+          400
+        )
+      }
+
+      const subtree = await this.listEntitySubtree(root)
+      const stopped = subtree.find((entity) => entity.status === `stopped`)
+      if (stopped) {
+        throw new ElectricAgentsError(
+          ErrCodeNotRunning,
+          `Cannot fork stopped entity "${stopped.url}"`,
+          409
+        )
+      }
+
+      let active = subtree.filter((entity) => entity.status !== `idle`)
+      if (active.length === 0) {
+        this.addForkLocks(
+          this.forkWorkLockedEntities,
+          subtree.map((entity) => entity.url),
+          workLocks
+        )
+        const lockedRoot = await this.registry.getEntity(rootUrl)
+        if (!lockedRoot) {
+          throw new ElectricAgentsError(
+            ErrCodeNotFound,
+            `Entity not found`,
+            404
+          )
+        }
+        const lockedSubtree = await this.listEntitySubtree(lockedRoot)
+        this.addForkLocks(
+          this.forkWorkLockedEntities,
+          lockedSubtree.map((entity) => entity.url),
+          workLocks
+        )
+        const lockedActive = lockedSubtree.filter(
+          (entity) => entity.status !== `idle`
+        )
+        if (lockedActive.length === 0) {
+          return lockedSubtree
+        }
+        this.releaseForkLocks(this.forkWorkLockedEntities, workLocks)
+        active = lockedActive
+      }
+
+      if (Date.now() >= deadline) {
+        throw new ElectricAgentsError(
+          ErrCodeForkWaitTimeout,
+          `Timed out waiting for subtree to become idle`,
+          409,
+          { active: active.map((entity) => entity.url) }
+        )
+      }
+
+      await sleep(Math.min(pollMs, Math.max(0, deadline - Date.now())))
+    }
+  }
+
+  private async listEntitySubtree(
+    root: ElectricAgentsEntity
+  ): Promise<Array<ElectricAgentsEntity>> {
+    const result: Array<ElectricAgentsEntity> = []
+    const queue: Array<ElectricAgentsEntity> = [root]
+    const seen = new Set<string>()
+
+    while (queue.length > 0) {
+      const entity = queue.shift()!
+      if (seen.has(entity.url)) continue
+      seen.add(entity.url)
+      result.push(entity)
+
+      const { entities: children } = await this.registry.listEntities({
+        parent: entity.url,
+        limit: 10_000,
+      })
+      for (const child of children) {
+        queue.push(child)
+      }
+    }
+
+    return result
+  }
+
+  private async readForkStateSnapshot(
+    entitiesToFork: Array<ElectricAgentsEntity>
+  ): Promise<ForkStateSnapshot> {
+    const manifestsByEntity = new Map<
+      string,
+      Map<string, Record<string, unknown>>
+    >()
+    const childStatusesByEntity = new Map<
+      string,
+      Map<string, Record<string, unknown>>
+    >()
+    const replayWatermarksByEntity = new Map<
+      string,
+      Map<string, Record<string, unknown>>
+    >()
+    const sharedStateIds = new Set<string>()
+
+    for (const entity of entitiesToFork) {
+      const events = await this.streamClient.readJson<Record<string, unknown>>(
+        entity.streams.main
+      )
+      const manifests = this.reduceStateRows(events, `manifest`)
+      const childStatuses = this.reduceStateRows(events, `child_status`)
+      const replayWatermarks = this.reduceStateRows(events, `replay_watermark`)
+
+      manifestsByEntity.set(entity.url, manifests)
+      childStatusesByEntity.set(entity.url, childStatuses)
+      replayWatermarksByEntity.set(entity.url, replayWatermarks)
+
+      for (const manifest of manifests.values()) {
+        this.collectSharedStateIds(manifest, sharedStateIds)
+      }
+    }
+
+    return {
+      manifestsByEntity,
+      childStatusesByEntity,
+      replayWatermarksByEntity,
+      sharedStateIds,
+    }
+  }
+
+  private reduceStateRows(
+    rawEvents: Array<unknown>,
+    eventType: string
+  ): Map<string, Record<string, unknown>> {
+    const rows = new Map<string, Record<string, unknown>>()
+    const events = rawEvents.flatMap((item) =>
+      Array.isArray(item) ? item : [item]
+    )
+
+    for (const event of events) {
+      if (!isRecord(event) || event.type !== eventType) continue
+      if (typeof event.key !== `string`) continue
+      const headers = isRecord(event.headers) ? event.headers : undefined
+      const operation = headers?.operation
+      if (operation === `delete`) {
+        rows.delete(event.key)
+        continue
+      }
+      if (isRecord(event.value)) {
+        rows.set(event.key, cloneRecord(event.value))
+      }
+    }
+
+    return rows
+  }
+
+  private collectSharedStateIds(
+    manifest: Record<string, unknown>,
+    sharedStateIds: Set<string>
+  ): void {
+    if (manifest.kind === `shared-state` && typeof manifest.id === `string`) {
+      sharedStateIds.add(manifest.id)
+      return
+    }
+
+    if (manifest.kind !== `source` || manifest.sourceType !== `db`) {
+      return
+    }
+
+    if (typeof manifest.sourceRef === `string`) {
+      sharedStateIds.add(manifest.sourceRef)
+    }
+    const config = isRecord(manifest.config) ? manifest.config : undefined
+    if (typeof config?.id === `string`) {
+      sharedStateIds.add(config.id)
+    }
+  }
+
+  private async buildForkEntityUrlMap(
+    entitiesToFork: Array<ElectricAgentsEntity>,
+    opts: { suffix: string; rootUrl: string; rootInstanceId?: string }
+  ): Promise<Map<string, string>> {
+    const map = new Map<string, string>()
+    const reserved = new Set<string>()
+
+    for (const entity of entitiesToFork) {
+      const { type, instanceId } = this.parseEntityUrl(entity.url)
+      const rootRequestedId =
+        entity.url === opts.rootUrl ? opts.rootInstanceId : undefined
+      const baseId = rootRequestedId ?? `${instanceId}-fork-${opts.suffix}`
+      const forkUrl = await this.reserveForkEntityUrl(type, baseId, reserved, {
+        exact: rootRequestedId !== undefined,
+      })
+      map.set(entity.url, forkUrl)
+    }
+
+    return map
+  }
+
+  private async reserveForkEntityUrl(
+    type: string,
+    baseId: string,
+    reserved: Set<string>,
+    opts?: { exact?: boolean }
+  ): Promise<string> {
+    if (!baseId || baseId.includes(`/`)) {
+      throw new ElectricAgentsError(
+        ErrCodeInvalidRequest,
+        `Fork instance_id must not be empty or contain forward slashes`,
+        400
+      )
+    }
+
+    let attempt = 0
+    while (true) {
+      const instanceId = attempt === 0 ? baseId : `${baseId}-${attempt}`
+      const url = `/${type}/${instanceId}`
+      const exists = reserved.has(url) || (await this.registry.getEntity(url))
+      if (!exists) {
+        reserved.add(url)
+        return url
+      }
+      if (opts?.exact) {
+        throw new ElectricAgentsError(
+          ErrCodeDuplicateURL,
+          `Entity already exists at URL "${url}"`,
+          409
+        )
+      }
+      attempt += 1
+    }
+  }
+
+  private async buildForkSharedStateIdMap(
+    sourceIds: Set<string>,
+    suffix: string
+  ): Promise<Map<string, string>> {
+    const map = new Map<string, string>()
+    const reserved = new Set<string>()
+
+    for (const sourceId of [...sourceIds].sort()) {
+      const baseId = `${sourceId}-fork-${suffix}`
+      let attempt = 0
+      while (true) {
+        const candidate = attempt === 0 ? baseId : `${baseId}-${attempt}`
+        const path = getSharedStateStreamPath(candidate)
+        if (
+          !reserved.has(candidate) &&
+          !(await this.streamClient.exists(path))
+        ) {
+          reserved.add(candidate)
+          map.set(sourceId, candidate)
+          break
+        }
+        attempt += 1
+      }
+    }
+
+    return map
+  }
+
+  private buildForkStringMap(
+    entityUrlMap: Map<string, string>,
+    sharedStateIdMap: Map<string, string>
+  ): Map<string, string> {
+    const stringMap = new Map<string, string>()
+    for (const [sourceUrl, forkUrl] of entityUrlMap) {
+      stringMap.set(sourceUrl, forkUrl)
+      stringMap.set(`${sourceUrl}/main`, `${forkUrl}/main`)
+      stringMap.set(`${sourceUrl}/error`, `${forkUrl}/error`)
+    }
+    for (const [sourceId, forkId] of sharedStateIdMap) {
+      stringMap.set(sourceId, forkId)
+      stringMap.set(
+        getSharedStateStreamPath(sourceId),
+        getSharedStateStreamPath(forkId)
+      )
+    }
+    return stringMap
+  }
+
+  private buildForkEntityPlans(
+    entitiesToFork: Array<ElectricAgentsEntity>,
+    entityUrlMap: Map<string, string>,
+    stringMap: Map<string, string>
+  ): Array<ForkEntityPlan> {
+    const now = Date.now()
+    return entitiesToFork.map((source) => {
+      const forkUrl = entityUrlMap.get(source.url)
+      if (!forkUrl) {
+        throw new Error(`Missing fork URL for ${source.url}`)
+      }
+      const { type } = this.parseEntityUrl(forkUrl)
+      const parent = source.parent ? entityUrlMap.get(source.parent) : undefined
+      const spawnArgs = isRecord(source.spawn_args)
+        ? (this.remapJsonValue(source.spawn_args, stringMap) as Record<
+            string,
+            unknown
+          >)
+        : source.spawn_args
+
+      const fork: ElectricAgentsEntity = {
+        ...source,
+        url: forkUrl,
+        type,
+        status: `idle`,
+        streams: {
+          main: `${forkUrl}/main`,
+          error: `${forkUrl}/error`,
+        },
+        subscription_id: `${type}-handler`,
+        write_token: randomUUID(),
+        spawn_args: spawnArgs,
+        parent,
+        created_at: now,
+        updated_at: now,
+      }
+      if (!parent) {
+        delete fork.parent
+      }
+
+      return { source, fork }
+    })
+  }
+
+  private buildForkReconciliation(
+    plan: ForkEntityPlan,
+    snapshot: ForkStateSnapshot,
+    entityUrlMap: Map<string, string>,
+    sharedStateIdMap: Map<string, string>,
+    stringMap: Map<string, string>
+  ): {
+    events: Array<Record<string, unknown>>
+    manifests: Map<string, Record<string, unknown>>
+  } {
+    const txid = `fork-${randomUUID()}`
+    const headers = {
+      txid,
+      forkedFrom: plan.source.url,
+    }
+    const events: Array<Record<string, unknown>> = [
+      entityStateSchema.entityCreated.update({
+        key: `entity-created`,
+        value: omitUndefined({
+          entity_type: plan.fork.type,
+          timestamp: new Date().toISOString(),
+          args: plan.fork.spawn_args ?? {},
+          parent_url: plan.fork.parent,
+        }),
+        headers,
+      } as any) as Record<string, unknown>,
+    ]
+
+    const activeManifests = new Map<string, Record<string, unknown>>()
+    const sourceManifests =
+      snapshot.manifestsByEntity.get(plan.source.url) ?? new Map()
+    for (const [key, value] of sourceManifests) {
+      const remapped = this.remapManifestEntry(
+        key,
+        value,
+        entityUrlMap,
+        sharedStateIdMap
+      )
+      activeManifests.set(remapped.key, remapped.value)
+      if (!remapped.changed) {
+        continue
+      }
+
+      if (remapped.key !== key) {
+        events.push(
+          entityStateSchema.manifests.delete({
+            key,
+            headers,
+          } as any) as Record<string, unknown>
+        )
+        events.push(
+          entityStateSchema.manifests.insert({
+            key: remapped.key,
+            value: remapped.value as any,
+            headers,
+          } as any) as Record<string, unknown>
+        )
+      } else {
+        events.push(
+          entityStateSchema.manifests.update({
+            key,
+            value: remapped.value as any,
+            headers,
+          } as any) as Record<string, unknown>
+        )
+      }
+    }
+
+    const childStatuses =
+      snapshot.childStatusesByEntity.get(plan.source.url) ?? new Map()
+    for (const [key, value] of childStatuses) {
+      const remapped = this.remapChildStatus(value, entityUrlMap)
+      if (!remapped) continue
+      events.push(
+        entityStateSchema.childStatus.update({
+          key,
+          value: remapped as any,
+          headers,
+        } as any) as Record<string, unknown>
+      )
+    }
+
+    const replayWatermarks =
+      snapshot.replayWatermarksByEntity.get(plan.source.url) ?? new Map()
+    for (const [key, value] of replayWatermarks) {
+      const remapped = this.remapReplayWatermark(key, value, stringMap)
+      if (!remapped) continue
+      if (remapped.key !== key) {
+        events.push(
+          entityStateSchema.replayWatermarks.delete({
+            key,
+            headers,
+          } as any) as Record<string, unknown>
+        )
+        events.push(
+          entityStateSchema.replayWatermarks.insert({
+            key: remapped.key,
+            value: remapped.value as any,
+            headers,
+          } as any) as Record<string, unknown>
+        )
+      } else {
+        events.push(
+          entityStateSchema.replayWatermarks.update({
+            key,
+            value: remapped.value as any,
+            headers,
+          } as any) as Record<string, unknown>
+        )
+      }
+    }
+
+    return { events, manifests: activeManifests }
+  }
+
+  private remapManifestEntry(
+    key: string,
+    value: Record<string, unknown>,
+    entityUrlMap: Map<string, string>,
+    sharedStateIdMap: Map<string, string>
+  ): {
+    key: string
+    value: Record<string, unknown>
+    changed: boolean
+  } {
+    const next = cloneRecord(value)
+
+    if (next.kind === `child` && typeof next.entity_url === `string`) {
+      const forkUrl = entityUrlMap.get(next.entity_url)
+      if (!forkUrl) return { key, value: next, changed: false }
+      const { instanceId } = this.parseEntityUrl(forkUrl)
+      next.id = instanceId
+      next.entity_url = forkUrl
+      next.key = manifestChildKey(String(next.entity_type), instanceId)
+      return { key: String(next.key), value: next, changed: true }
+    }
+
+    if (next.kind === `shared-state` && typeof next.id === `string`) {
+      const forkId = sharedStateIdMap.get(next.id)
+      if (!forkId) return { key, value: next, changed: false }
+      next.id = forkId
+      next.key = manifestSharedStateKey(forkId)
+      return { key: String(next.key), value: next, changed: true }
+    }
+
+    if (next.kind === `source` && next.sourceType === `entity`) {
+      const config = isRecord(next.config) ? next.config : {}
+      const sourceUrl =
+        typeof config.entityUrl === `string`
+          ? config.entityUrl
+          : typeof next.sourceRef === `string`
+            ? next.sourceRef
+            : undefined
+      const forkUrl = sourceUrl ? entityUrlMap.get(sourceUrl) : undefined
+      if (!forkUrl) return { key, value: next, changed: false }
+      const { type } = this.parseEntityUrl(forkUrl)
+      next.sourceRef = forkUrl
+      next.key = manifestSourceKey(`entity`, forkUrl)
+      next.config = {
+        ...config,
+        entityUrl: forkUrl,
+        streamPath: `${forkUrl}/main`,
+        entityType: type,
+      }
+      return { key: String(next.key), value: next, changed: true }
+    }
+
+    if (next.kind === `source` && next.sourceType === `db`) {
+      const config = isRecord(next.config) ? next.config : {}
+      const sourceId =
+        typeof next.sourceRef === `string`
+          ? next.sourceRef
+          : typeof config.id === `string`
+            ? config.id
+            : undefined
+      const forkId = sourceId ? sharedStateIdMap.get(sourceId) : undefined
+      if (!forkId) return { key, value: next, changed: false }
+      next.sourceRef = forkId
+      next.key = manifestSourceKey(`db`, forkId)
+      next.config = {
+        ...config,
+        id: forkId,
+      }
+      return { key: String(next.key), value: next, changed: true }
+    }
+
+    if (next.kind === `schedule` && next.scheduleType === `future_send`) {
+      let changed = false
+      if (typeof next.targetUrl === `string`) {
+        const forkTarget = entityUrlMap.get(next.targetUrl)
+        if (forkTarget) {
+          next.targetUrl = forkTarget
+          changed = true
+        }
+      }
+      if (typeof next.from === `string`) {
+        const forkFrom = entityUrlMap.get(next.from)
+        if (forkFrom) {
+          next.from = forkFrom
+          changed = true
+        }
+      }
+      return { key, value: next, changed }
+    }
+
+    return { key, value: next, changed: false }
+  }
+
+  private remapChildStatus(
+    value: Record<string, unknown>,
+    entityUrlMap: Map<string, string>
+  ): Record<string, unknown> | null {
+    if (typeof value.entity_url !== `string`) return null
+    const forkUrl = entityUrlMap.get(value.entity_url)
+    if (!forkUrl) return null
+    const { type } = this.parseEntityUrl(forkUrl)
+    return {
+      ...value,
+      entity_url: forkUrl,
+      entity_type: type,
+    }
+  }
+
+  private remapReplayWatermark(
+    key: string,
+    value: Record<string, unknown>,
+    stringMap: Map<string, string>
+  ): { key: string; value: Record<string, unknown> } | null {
+    if (typeof value.source_id !== `string`) return null
+    const sourceId = value.source_id
+    const forkSourceId = stringMap.get(sourceId)
+    if (!forkSourceId) return null
+    const next = { ...value, source_id: forkSourceId }
+    return {
+      key: key === sourceId ? forkSourceId : key,
+      value: next,
+    }
+  }
+
+  private remapJsonValue(
+    value: unknown,
+    stringMap: Map<string, string>
+  ): unknown {
+    if (typeof value === `string`) {
+      return stringMap.get(value) ?? value
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.remapJsonValue(item, stringMap))
+    }
+    if (isRecord(value)) {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [
+          key,
+          this.remapJsonValue(item, stringMap),
+        ])
+      )
+    }
+    return value
+  }
+
+  private async materializeForkManifestSideEffects(
+    entityUrl: string,
+    manifests: Map<string, Record<string, unknown>>
+  ): Promise<void> {
+    for (const [manifestKey, manifest] of manifests) {
+      await this.syncEntitiesManifestSource(
+        entityUrl,
+        manifestKey,
+        `upsert`,
+        manifest
+      )
+
+      const wake = this.buildManifestWakeRegistration(
+        entityUrl,
+        manifestKey,
+        manifest
+      )
+      if (wake) {
+        await this.wakeRegistry.register(wake)
+      }
+
+      const cronSpec = this.extractManifestCronSpec(manifest)
+      if (cronSpec && this.scheduler) {
+        await this.getOrCreateCronStream(cronSpec.expression, cronSpec.timezone)
+      }
+
+      await this.syncManifestFutureSendSchedule(
+        entityUrl,
+        manifestKey,
+        manifest
+      )
+    }
+  }
+
+  private buildManifestWakeRegistration(
+    subscriberUrl: string,
+    manifestKey: string,
+    manifest: Record<string, unknown>
+  ): WakeRegistration | null {
+    const sourceUrl = this.extractManifestSourceUrl(manifest)
+    if (!sourceUrl) return null
+
+    const wake =
+      manifest.kind === `schedule` && manifest.scheduleType === `cron`
+        ? (manifest.wake ?? { on: `change` })
+        : manifest.wake
+
+    if (wake === `runFinished`) {
+      return {
+        subscriberUrl,
+        sourceUrl,
+        condition: `runFinished`,
+        oneShot: false,
+        manifestKey,
+      }
+    }
+
+    if (!isRecord(wake)) return null
+
+    if (wake.on === `runFinished`) {
+      return {
+        subscriberUrl,
+        sourceUrl,
+        condition: `runFinished`,
+        oneShot: false,
+        includeResponse:
+          typeof wake.includeResponse === `boolean`
+            ? wake.includeResponse
+            : undefined,
+        manifestKey,
+      }
+    }
+
+    if (wake.on !== `change`) return null
+
+    const collections = Array.isArray(wake.collections)
+      ? wake.collections.filter((c): c is string => typeof c === `string`)
+      : undefined
+    const ops = Array.isArray(wake.ops)
+      ? wake.ops.filter(
+          (op): op is `insert` | `update` | `delete` =>
+            op === `insert` || op === `update` || op === `delete`
+        )
+      : undefined
+
+    return {
+      subscriberUrl,
+      sourceUrl,
+      condition: {
+        on: `change`,
+        ...(collections ? { collections } : {}),
+        ...(ops ? { ops } : {}),
+      },
+      debounceMs:
+        typeof wake.debounceMs === `number` ? wake.debounceMs : undefined,
+      timeoutMs:
+        typeof wake.timeoutMs === `number` ? wake.timeoutMs : undefined,
+      oneShot: false,
+      manifestKey,
+    }
+  }
+
+  private extractManifestSourceUrl(
+    manifest: Record<string, unknown>
+  ): string | undefined {
+    if (manifest.kind === `child`) {
+      return typeof manifest.entity_url === `string`
+        ? manifest.entity_url
+        : undefined
+    }
+    if (manifest.kind === `source`) {
+      const config = isRecord(manifest.config) ? manifest.config : undefined
+      if (manifest.sourceType === `entity`) {
+        return typeof config?.entityUrl === `string`
+          ? config.entityUrl
+          : typeof manifest.sourceRef === `string`
+            ? manifest.sourceRef
+            : undefined
+      }
+      if (manifest.sourceType === `cron` && config) {
+        const expression = config.expression
+        if (typeof expression === `string`) {
+          const spec = resolveCronScheduleSpec(
+            expression,
+            typeof config.timezone === `string` ? config.timezone : undefined,
+            { fallback: `utc` }
+          )
+          return getCronStreamPath(spec.expression, spec.timezone)
+        }
+      }
+      if (manifest.sourceType === `entities`) {
+        return typeof manifest.sourceRef === `string`
+          ? `/_entities/${manifest.sourceRef}`
+          : undefined
+      }
+      if (manifest.sourceType === `db`) {
+        return typeof manifest.sourceRef === `string`
+          ? getSharedStateStreamPath(manifest.sourceRef)
+          : undefined
+      }
+    }
+    if (manifest.kind === `shared-state`) {
+      return typeof manifest.id === `string`
+        ? getSharedStateStreamPath(manifest.id)
+        : undefined
+    }
+    if (
+      manifest.kind === `schedule` &&
+      manifest.scheduleType === `cron` &&
+      typeof manifest.expression === `string`
+    ) {
+      const spec = resolveCronScheduleSpec(
+        manifest.expression,
+        typeof manifest.timezone === `string` ? manifest.timezone : undefined,
+        { fallback: `utc` }
+      )
+      return getCronStreamPath(spec.expression, spec.timezone)
+    }
+    return undefined
+  }
+
+  private extractManifestCronSpec(
+    manifest: Record<string, unknown>
+  ): { expression: string; timezone: string } | undefined {
+    if (manifest.kind === `source` && manifest.sourceType === `cron`) {
+      const config = isRecord(manifest.config) ? manifest.config : undefined
+      if (typeof config?.expression === `string`) {
+        return resolveCronScheduleSpec(
+          config.expression,
+          typeof config.timezone === `string` ? config.timezone : undefined,
+          { fallback: `utc` }
+        )
+      }
+    }
+
+    if (
+      manifest.kind === `schedule` &&
+      manifest.scheduleType === `cron` &&
+      typeof manifest.expression === `string`
+    ) {
+      return resolveCronScheduleSpec(
+        manifest.expression,
+        typeof manifest.timezone === `string` ? manifest.timezone : undefined,
+        { fallback: `utc` }
+      )
+    }
+
+    return undefined
+  }
+
+  private async syncManifestFutureSendSchedule(
+    ownerEntityUrl: string,
+    manifestKey: string,
+    manifest: Record<string, unknown>
+  ): Promise<void> {
+    if (!this.scheduler) return
+    if (
+      manifest.kind !== `schedule` ||
+      manifest.scheduleType !== `future_send` ||
+      (manifest.status !== undefined && manifest.status !== `pending`)
+    ) {
+      return
+    }
+
+    const fireAtRaw = manifest.fireAt
+    const producerId = manifest.producerId
+    const targetUrl = manifest.targetUrl
+    if (
+      typeof fireAtRaw !== `string` ||
+      typeof producerId !== `string` ||
+      typeof targetUrl !== `string`
+    ) {
+      serverLog.warn(
+        `[agent-server] invalid forked future_send manifest entry for ${ownerEntityUrl}/${manifestKey}`
+      )
+      return
+    }
+
+    const fireAt = new Date(fireAtRaw)
+    if (Number.isNaN(fireAt.getTime())) {
+      serverLog.warn(
+        `[agent-server] invalid forked future_send fireAt for ${ownerEntityUrl}/${manifestKey}: ${fireAtRaw}`
+      )
+      return
+    }
+
+    await this.scheduler.syncManifestDelayedSend(
+      ownerEntityUrl,
+      manifestKey,
+      {
+        entityUrl: targetUrl,
+        from:
+          typeof manifest.from === `string` ? manifest.from : ownerEntityUrl,
+        payload: manifest.payload,
+        key: `scheduled-${producerId}`,
+        type:
+          typeof manifest.messageType === `string`
+            ? manifest.messageType
+            : undefined,
+        producerId,
+        manifest: {
+          ownerEntityUrl,
+          key: manifestKey,
+          entry: omitUndefined({
+            ...manifest,
+            key: manifestKey,
+            kind: `schedule`,
+            scheduleType: `future_send`,
+            targetUrl,
+            fireAt: fireAt.toISOString(),
+            producerId,
+            status: `pending`,
+          }),
+        },
+      },
+      fireAt
+    )
+  }
+
+  private parseEntityUrl(url: string): { type: string; instanceId: string } {
+    const segments = url.split(`/`).filter(Boolean)
+    if (segments.length !== 2 || !segments[0] || !segments[1]) {
+      throw new ElectricAgentsError(
+        ErrCodeInvalidRequest,
+        `Invalid entity URL "${url}"`,
+        400
+      )
+    }
+    return { type: segments[0], instanceId: segments[1] }
+  }
+
+  // ==========================================================================
   // Send
   // ==========================================================================
 
@@ -492,6 +1647,12 @@ export class ElectricAgentsManager {
     opts?: { producerId?: string }
   ): Promise<void> {
     const entity = await this.validateSendRequest(entityUrl, req)
+    if (
+      this.isForkWorkLockedEntity(entityUrl) &&
+      !(req.from && this.isForkWorkLockedEntity(req.from))
+    ) {
+      this.assertEntityNotForkWorkLocked(entityUrl)
+    }
 
     const now = new Date().toISOString()
     const key =

--- a/packages/agents-server/src/electric-agents-routes.ts
+++ b/packages/agents-server/src/electric-agents-routes.ts
@@ -113,6 +113,33 @@ export class ElectricAgentsRoutes {
 
     // Entity action routes: /{type}/{name}/send
     // Excludes _-prefixed paths and glob patterns (*)
+    const forkMatch = path.match(/^(\/(?!_)[^/*]+\/[^/*]+)\/fork$/)
+    if (forkMatch) {
+      const entityUrl = forkMatch[1]!
+
+      const entity = await this.manager.registry.getEntity(entityUrl)
+      if (!entity) {
+        const typeName = entityUrl.split(`/`)[1]!
+        const entityType = await this.manager.registry.getEntityType(typeName)
+        if (entityType) {
+          sendJsonError(
+            res,
+            404,
+            `NOT_FOUND`,
+            `Entity not found at ${entityUrl}`
+          )
+          return true
+        }
+        return false
+      }
+
+      if (method === `POST`) {
+        await this.handleFork(entityUrl, req, res)
+        return true
+      }
+      return false
+    }
+
     const actionMatch = path.match(/^(\/(?!_)[^/*]+\/[^/*]+)\/send$/)
     if (actionMatch) {
       const entityUrl = actionMatch[1]!
@@ -304,6 +331,40 @@ export class ElectricAgentsRoutes {
       }
       res.writeHead(204)
       res.end()
+    } catch (err) {
+      handleElectricAgentsError(err, res)
+    }
+  }
+
+  private async handleFork(
+    entityUrl: string,
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> {
+    let parsed: {
+      instance_id?: string
+      waitTimeoutMs?: number
+    } = {}
+    const bodyBytes = await readBody(req)
+    const bodyStr = new TextDecoder().decode(bodyBytes)
+    if (bodyStr.trim()) {
+      try {
+        parsed = JSON.parse(bodyStr)
+      } catch {
+        sendJsonError(res, 400, `INVALID_REQUEST`, `Invalid JSON body`)
+        return
+      }
+    }
+
+    try {
+      const result = await this.manager.forkSubtree(entityUrl, {
+        rootInstanceId: parsed.instance_id,
+        waitTimeoutMs: parsed.waitTimeoutMs,
+      })
+      sendJson(res, 201, {
+        root: toPublicEntity(result.root),
+        entities: result.entities.map((entity) => toPublicEntity(entity)),
+      })
     } catch (err) {
       handleElectricAgentsError(err, res)
     }

--- a/packages/agents-server/src/electric-agents-types.ts
+++ b/packages/agents-server/src/electric-agents-types.ts
@@ -144,3 +144,5 @@ export const ErrCodeUnknownEventType = `UNKNOWN_EVENT_TYPE`
 export const ErrCodeSchemaKeyExists = `SCHEMA_KEY_EXISTS`
 export const ErrCodeServeEndpointUnreachable = `SERVE_ENDPOINT_UNREACHABLE`
 export const ErrCodeServeEndpointNameMismatch = `SERVE_ENDPOINT_NAME_MISMATCH`
+export const ErrCodeForkInProgress = `FORK_IN_PROGRESS`
+export const ErrCodeForkWaitTimeout = `FORK_WAIT_TIMEOUT`

--- a/packages/agents-server/src/server.ts
+++ b/packages/agents-server/src/server.ts
@@ -815,6 +815,15 @@ export class ElectricAgentsServer {
         sendJsonError(res, 401, `UNAUTHORIZED`, `Invalid write token`)
         return true
       }
+      if (this.electricAgentsManager.isForkWriteLockedEntity(entity.url)) {
+        sendJsonError(
+          res,
+          409,
+          `FORK_IN_PROGRESS`,
+          `Entity subtree is being forked`
+        )
+        return true
+      }
       if (entity.status === `stopped`) {
         sendJsonError(res, 409, `NOT_RUNNING`, `Entity is stopped`)
         return true
@@ -839,6 +848,17 @@ export class ElectricAgentsServer {
           }
         }
       }
+    } else if (
+      isSharedState &&
+      this.electricAgentsManager.isForkWriteLockedStream(path)
+    ) {
+      sendJsonError(
+        res,
+        409,
+        `FORK_IN_PROGRESS`,
+        `Entity subtree is being forked`
+      )
+      return true
     }
 
     const upstream = await this.forwardRequest(req, body)
@@ -1613,6 +1633,19 @@ export class ElectricAgentsServer {
         ])
 
         if (upsertPromise) await upsertPromise
+
+        if (
+          entity &&
+          this.electricAgentsManager!.isForkWorkLockedEntity(entity.url)
+        ) {
+          sendJsonError(
+            res,
+            409,
+            `FORK_IN_PROGRESS`,
+            `Entity subtree is being forked`
+          )
+          return
+        }
 
         if (entity && entity.status !== `stopped`) {
           rootSpan?.setAttribute(ATTR.ENTITY_URL, entity.url)

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -93,7 +93,7 @@ export class StreamClient {
 
       await handle.append(data)
       const head = await handle.head()
-      return { offset: head.offset ?? `` }
+      return { offset: (head.exists && head.offset) || `` }
     })
   }
 

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -71,6 +71,31 @@ export class StreamClient {
     })
   }
 
+  async fork(path: string, sourcePath: string): Promise<void> {
+    return await withSpan(`stream.fork`, async (span) => {
+      span.setAttributes({
+        [ATTR.STREAM_PATH]: path,
+        [ATTR.STREAM_OP]: `fork`,
+      })
+      const headers: Record<string, string> = {
+        'content-type': `application/json`,
+        'Stream-Forked-From': sourcePath,
+      }
+      injectTraceHeaders(headers)
+
+      const response = await fetch(this.streamUrl(path), {
+        method: `PUT`,
+        headers,
+      })
+
+      if (response.ok) return
+
+      throw new Error(
+        `Stream fork failed: ${response.status} ${await response.text()}`
+      )
+    })
+  }
+
   async append(
     path: string,
     data: Uint8Array | string,

--- a/packages/agents-server/test/electric-agents-routes.test.ts
+++ b/packages/agents-server/test/electric-agents-routes.test.ts
@@ -229,3 +229,63 @@ describe(`ElectricAgentsRoutes send endpoint`, () => {
     )
   })
 })
+
+describe(`ElectricAgentsRoutes fork endpoint`, () => {
+  it(`routes fork requests to the manager and returns public entities`, async () => {
+    const forkedRoot = {
+      url: `/chat/root-copy`,
+      type: `chat`,
+      status: `idle`,
+      streams: {
+        main: `/chat/root-copy/main`,
+        error: `/chat/root-copy/error`,
+      },
+      subscription_id: `chat-handler`,
+      write_token: `secret-token`,
+      tags: {},
+      spawn_args: {},
+      created_at: 1,
+      updated_at: 1,
+    }
+    const manager = {
+      registry: {
+        getEntity: vi.fn().mockResolvedValue({ url: `/chat/root` }),
+        getEntityType: vi.fn(),
+      },
+      forkSubtree: vi.fn().mockResolvedValue({
+        root: forkedRoot,
+        entities: [forkedRoot],
+      }),
+    } as any
+
+    const routes = new ElectricAgentsRoutes(manager)
+    const req = createRequest({ waitTimeoutMs: 5000 })
+    const res = createResponse()
+
+    const handled = await routes.handleRequest(
+      `POST`,
+      `/chat/root/fork`,
+      req,
+      res
+    )
+
+    expect(handled).toBe(true)
+    expect(manager.forkSubtree).toHaveBeenCalledWith(`/chat/root`, {
+      rootInstanceId: undefined,
+      waitTimeoutMs: 5000,
+    })
+    expect(res.writeHead).toHaveBeenCalledWith(201, {
+      'content-type': `application/json`,
+    })
+    const payload = JSON.parse(res.end.mock.calls[0]![0]) as {
+      root: Record<string, unknown>
+    }
+    expect(payload.root).toMatchObject({
+      url: `/chat/root-copy`,
+      type: `chat`,
+      status: `idle`,
+    })
+    expect(payload.root).not.toHaveProperty(`write_token`)
+    expect(payload.root).not.toHaveProperty(`subscription_id`)
+  })
+})

--- a/packages/agents-server/test/electric-agents-status.test.ts
+++ b/packages/agents-server/test/electric-agents-status.test.ts
@@ -167,3 +167,320 @@ describe(`ElectricAgentsManager.spawn wake cleanup on failure`, () => {
     expect(createStream).not.toHaveBeenCalled()
   })
 })
+
+describe(`ElectricAgentsManager.forkSubtree`, () => {
+  function makeEntity(url: string, parent?: string) {
+    const type = url.split(`/`)[1]!
+    return {
+      url,
+      type,
+      status: `idle`,
+      streams: {
+        main: `${url}/main`,
+        error: `${url}/error`,
+      },
+      subscription_id: `${type}-handler`,
+      write_token: `${type}-token`,
+      tags: {},
+      spawn_args: {},
+      ...(parent ? { parent } : {}),
+      created_at: Date.now(),
+      updated_at: Date.now(),
+    } as const
+  }
+
+  it(`forks durable streams before registering remapped entity rows`, async () => {
+    const root = makeEntity(`/manager/root`)
+    const child = makeEntity(`/worker/child`, root.url)
+    const entitiesByUrl = new Map<string, any>([
+      [root.url, root],
+      [child.url, child],
+    ])
+    const calls: Array<string> = []
+    const appendedEvents: Array<Record<string, unknown>> = []
+
+    const registry = {
+      getEntity: vi.fn(async (url: string) => entitiesByUrl.get(url) ?? null),
+      listEntities: vi.fn(async ({ parent }: { parent?: string }) => ({
+        entities: parent === root.url ? [child] : [],
+        total: parent === root.url ? 1 : 0,
+      })),
+      createEntity: vi.fn(async (entity: any) => {
+        calls.push(`entity:${entity.url}`)
+        entitiesByUrl.set(entity.url, entity)
+        return 123
+      }),
+      deleteEntity: vi.fn(),
+      replaceEntityManifestSource: vi.fn(),
+    }
+
+    const streamClient = {
+      readJson: vi.fn(async (path: string) => {
+        if (path !== root.streams.main) return []
+        return [
+          {
+            type: `manifest`,
+            key: `child:worker:child`,
+            headers: { operation: `insert` },
+            value: {
+              key: `child:worker:child`,
+              kind: `child`,
+              id: `child`,
+              entity_type: `worker`,
+              entity_url: child.url,
+              observed: true,
+            },
+          },
+          {
+            type: `manifest`,
+            key: `shared-state:board`,
+            headers: { operation: `insert` },
+            value: {
+              key: `shared-state:board`,
+              kind: `shared-state`,
+              id: `board`,
+              mode: `create`,
+              collections: {
+                notes: { type: `shared:note`, primaryKey: `id` },
+              },
+            },
+          },
+        ]
+      }),
+      exists: vi.fn().mockResolvedValue(false),
+      fork: vi.fn(async (path: string, sourcePath: string) => {
+        calls.push(`fork:${path}<-${sourcePath}`)
+      }),
+      append: vi.fn(async (_path: string, data: Uint8Array | string) => {
+        const text =
+          typeof data === `string` ? data : new TextDecoder().decode(data)
+        appendedEvents.push(JSON.parse(text))
+        return { offset: `1` }
+      }),
+      delete: vi.fn(),
+    }
+
+    const manager = new ElectricAgentsManager({
+      registry: registry as any,
+      streamClient: streamClient as any,
+      validator: {} as any,
+      wakeRegistry: {
+        register: vi.fn(),
+        unregisterBySubscriber: vi.fn(),
+        unregisterBySource: vi.fn(),
+        setTimeoutCallback: vi.fn(),
+        setDebounceCallback: vi.fn(),
+      } as any,
+    })
+
+    const result = await manager.forkSubtree(root.url, {
+      rootInstanceId: `root-copy`,
+      waitTimeoutMs: 0,
+    })
+
+    expect(result.root.url).toBe(`/manager/root-copy`)
+    expect(result.entities).toHaveLength(2)
+    const forkedChild = result.entities.find(
+      (entity) => entity.type === `worker`
+    )
+    expect(forkedChild?.parent).toBe(`/manager/root-copy`)
+
+    const firstEntityWrite = calls.findIndex((call) =>
+      call.startsWith(`entity:`)
+    )
+    const lastFork = calls.reduce(
+      (index, call, current) => (call.startsWith(`fork:`) ? current : index),
+      -1
+    )
+    expect(firstEntityWrite).toBeGreaterThan(lastFork)
+    expect(streamClient.fork).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/_electric\/shared-state\/board-fork-/),
+      `/_electric/shared-state/board`
+    )
+
+    const manifestInserts = appendedEvents.filter(
+      (event) =>
+        event.type === `manifest` &&
+        (event.headers as Record<string, unknown>).operation === `insert`
+    )
+    expect(manifestInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          value: expect.objectContaining({
+            kind: `child`,
+            entity_url: forkedChild?.url,
+          }),
+        }),
+        expect.objectContaining({
+          value: expect.objectContaining({
+            kind: `shared-state`,
+            id: expect.stringMatching(/^board-fork-/),
+          }),
+        }),
+      ])
+    )
+  })
+
+  it(`times out instead of forking while the subtree is active`, async () => {
+    const root = {
+      ...makeEntity(`/manager/busy`),
+      status: `running`,
+    }
+    const manager = new ElectricAgentsManager({
+      registry: {
+        getEntity: vi.fn().mockResolvedValue(root),
+        listEntities: vi.fn().mockResolvedValue({ entities: [], total: 0 }),
+      } as any,
+      streamClient: {
+        fork: vi.fn(),
+      } as any,
+      validator: {} as any,
+      wakeRegistry: {
+        register: vi.fn(),
+        unregisterBySubscriber: vi.fn(),
+        unregisterBySource: vi.fn(),
+        setTimeoutCallback: vi.fn(),
+        setDebounceCallback: vi.fn(),
+      } as any,
+    })
+
+    await expect(
+      manager.forkSubtree(root.url, {
+        waitTimeoutMs: 1,
+        waitPollMs: 1,
+      })
+    ).rejects.toMatchObject({
+      code: `FORK_WAIT_TIMEOUT`,
+      status: 409,
+    })
+  })
+
+  it(`rejects sends to any subtree entity while fork snapshotting is in progress`, async () => {
+    const root = makeEntity(`/manager/root`)
+    const child = makeEntity(`/worker/child`, root.url)
+    const entitiesByUrl = new Map<string, any>([
+      [root.url, root],
+      [child.url, child],
+    ])
+    let releaseRootRead!: () => void
+    const rootReadStarted = new Promise<void>((resolve) => {
+      releaseRootRead = resolve
+    })
+
+    const streamClient = {
+      readJson: vi.fn(async (path: string) => {
+        if (path === root.streams.main) {
+          await new Promise<void>((resolve) => {
+            rootReadStarted.then(resolve)
+          })
+        }
+        return []
+      }),
+      exists: vi.fn().mockResolvedValue(false),
+      fork: vi.fn().mockResolvedValue(undefined),
+      append: vi.fn().mockResolvedValue({ offset: `1` }),
+      delete: vi.fn(),
+    }
+
+    const manager = new ElectricAgentsManager({
+      registry: {
+        getEntity: vi.fn(async (url: string) => entitiesByUrl.get(url) ?? null),
+        listEntities: vi.fn(async ({ parent }: { parent?: string }) => ({
+          entities: parent === root.url ? [child] : [],
+          total: parent === root.url ? 1 : 0,
+        })),
+        createEntity: vi.fn(async (entity: any) => {
+          entitiesByUrl.set(entity.url, entity)
+          return 123
+        }),
+        deleteEntity: vi.fn(),
+        replaceEntityManifestSource: vi.fn(),
+      } as any,
+      streamClient: streamClient as any,
+      validator: {} as any,
+      wakeRegistry: {
+        register: vi.fn(),
+        unregisterBySubscriber: vi.fn(),
+        unregisterBySource: vi.fn(),
+        setTimeoutCallback: vi.fn(),
+        setDebounceCallback: vi.fn(),
+      } as any,
+    })
+
+    const forkPromise = manager.forkSubtree(root.url, {
+      rootInstanceId: `root-copy`,
+      waitTimeoutMs: 100,
+    })
+
+    await vi.waitFor(() => {
+      expect(streamClient.readJson).toHaveBeenCalledWith(root.streams.main)
+    })
+
+    await expect(
+      manager.send(child.url, {
+        from: `user`,
+        payload: `new work`,
+      })
+    ).rejects.toMatchObject({
+      code: `FORK_IN_PROGRESS`,
+      status: 409,
+    })
+    expect(streamClient.append).not.toHaveBeenCalledWith(
+      child.streams.main,
+      expect.anything()
+    )
+
+    releaseRootRead()
+    await forkPromise
+  })
+
+  it(`releases fork locks when stream forking fails`, async () => {
+    const root = makeEntity(`/manager/root`)
+    const entitiesByUrl = new Map<string, any>([[root.url, root]])
+
+    const streamClient = {
+      readJson: vi.fn().mockResolvedValue([]),
+      exists: vi.fn().mockResolvedValue(false),
+      fork: vi.fn().mockRejectedValue(new Error(`fork failed`)),
+      append: vi.fn().mockResolvedValue({ offset: `1` }),
+      delete: vi.fn(),
+    }
+
+    const manager = new ElectricAgentsManager({
+      registry: {
+        getEntity: vi.fn(async (url: string) => entitiesByUrl.get(url) ?? null),
+        listEntities: vi.fn().mockResolvedValue({ entities: [], total: 0 }),
+        createEntity: vi.fn(),
+        deleteEntity: vi.fn(),
+        replaceEntityManifestSource: vi.fn(),
+      } as any,
+      streamClient: streamClient as any,
+      validator: {} as any,
+      wakeRegistry: {
+        register: vi.fn(),
+        unregisterBySubscriber: vi.fn(),
+        unregisterBySource: vi.fn(),
+        setTimeoutCallback: vi.fn(),
+        setDebounceCallback: vi.fn(),
+      } as any,
+    })
+
+    await expect(
+      manager.forkSubtree(root.url, {
+        rootInstanceId: `root-copy`,
+        waitTimeoutMs: 0,
+      })
+    ).rejects.toThrow(`fork failed`)
+
+    await expect(
+      manager.send(root.url, {
+        from: `user`,
+        payload: `after failure`,
+      })
+    ).resolves.toBeUndefined()
+    expect(streamClient.append).toHaveBeenCalledWith(
+      root.streams.main,
+      expect.any(Uint8Array)
+    )
+  })
+})

--- a/packages/agents-server/test/stream-client-fork.test.ts
+++ b/packages/agents-server/test/stream-client-fork.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { DurableStreamTestServer } from '@durable-streams/server'
+
+import { StreamClient } from '../src/stream-client'
+
+describe(`StreamClient.fork`, () => {
+  let dsServer: DurableStreamTestServer | null = null
+  let client: StreamClient
+
+  beforeAll(async () => {
+    dsServer = new DurableStreamTestServer({
+      port: 0,
+      longPollTimeout: 500,
+      webhooks: true,
+    })
+    const baseUrl = await dsServer.start()
+    client = new StreamClient(baseUrl)
+  })
+
+  afterAll(async () => {
+    await dsServer?.stop()
+  })
+
+  it(`forks JSON streams so JSON appends to the fork are accepted`, async () => {
+    await client.create(`/source-json`, {
+      contentType: `application/json`,
+      body: `[]`,
+    })
+
+    await client.fork(`/fork-json`, `/source-json`)
+
+    await expect(
+      client.append(`/fork-json`, JSON.stringify({ type: `reconcile` }))
+    ).resolves.toEqual({ offset: expect.any(String) })
+  })
+
+  it(`preserves source history when reading the fork`, async () => {
+    const sourceEvent = {
+      type: `message_received`,
+      key: `msg-in-original`,
+      headers: { operation: `insert` },
+      value: { payload: { text: `original message` } },
+    }
+    await client.create(`/source-history`, {
+      contentType: `application/json`,
+      body: JSON.stringify([sourceEvent]),
+    })
+
+    await client.fork(`/fork-history`, `/source-history`)
+
+    await expect(client.readJson(`/fork-history`)).resolves.toMatchObject([
+      sourceEvent,
+    ])
+  })
+})

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.0",
+    "@durable-streams/state": "npm:@electric-ax/durable-streams-state-beta@^0.3.1",
     "@electric-ax/agents-runtime": "workspace:*",
     "@mariozechner/pi-agent-core": "^0.70.2",
     "@mariozechner/pi-ai": "^0.70.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1435,8 +1435,8 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
       '@durable-streams/state':
-        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.1
+        version: '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)'
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../agents-runtime
@@ -1496,11 +1496,11 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
       '@durable-streams/client':
-        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.0
-        version: '@electric-ax/durable-streams-client-beta@0.3.0'
+        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.1
+        version: '@electric-ax/durable-streams-client-beta@0.3.1'
       '@durable-streams/state':
-        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.1
+        version: '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)'
       '@mariozechner/pi-agent-core':
         specifier: ^0.70.2
         version: 0.70.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
@@ -1551,8 +1551,8 @@ importers:
         version: 3.25.2(zod@4.3.6)
     devDependencies:
       '@durable-streams/server':
-        specifier: npm:@electric-ax/durable-streams-server-beta@^0.3.0
-        version: '@electric-ax/durable-streams-server-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-server-beta@^0.3.2
+        version: '@electric-ax/durable-streams-server-beta@0.3.2(typescript@5.8.3)'
       '@types/jsdom':
         specifier: ^27.0.0
         version: 27.0.0
@@ -1581,14 +1581,14 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
       '@durable-streams/client':
-        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.0
-        version: '@electric-ax/durable-streams-client-beta@0.3.0'
+        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.1
+        version: '@electric-ax/durable-streams-client-beta@0.3.1'
       '@durable-streams/server':
-        specifier: npm:@electric-ax/durable-streams-server-beta@^0.3.0
-        version: '@electric-ax/durable-streams-server-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-server-beta@^0.3.2
+        version: '@electric-ax/durable-streams-server-beta@0.3.2(typescript@5.8.3)'
       '@durable-streams/state':
-        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.1
+        version: '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)'
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../agents-runtime
@@ -1663,8 +1663,8 @@ importers:
   packages/agents-server-conformance-tests:
     dependencies:
       '@durable-streams/client':
-        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.0
-        version: '@electric-ax/durable-streams-client-beta@0.3.0'
+        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.1
+        version: '@electric-ax/durable-streams-client-beta@0.3.1'
       '@electric-sql/client':
         specifier: ^1.5.14
         version: link:../typescript-client
@@ -1691,11 +1691,11 @@ importers:
   packages/agents-server-ui:
     dependencies:
       '@durable-streams/client':
-        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.0
-        version: '@electric-ax/durable-streams-client-beta@0.3.0'
+        specifier: npm:@electric-ax/durable-streams-client-beta@^0.3.1
+        version: '@electric-ax/durable-streams-client-beta@0.3.1'
       '@durable-streams/state':
-        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.0
-        version: '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+        specifier: npm:@electric-ax/durable-streams-state-beta@^0.3.1
+        version: '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)'
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../agents-runtime
@@ -3937,12 +3937,22 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@electric-ax/durable-streams-server-beta@0.3.0':
-    resolution: {integrity: sha512-EnM/zUIJ0Bv1wLQOQmeBcrHNyaz8jCdfC0GotvtFEyvz/Tivu996XNsmAecrXKj7AammLe7oX576n15OIbhQsw==}
+  '@electric-ax/durable-streams-client-beta@0.3.1':
+    resolution: {integrity: sha512-smWzyfwrkA5TyRTnyO/HEbElJm54lyifRe6hgQpcfYaW0M3l3jedI5voOEvu2GTHfBKuOsFrFWsbMB0ltGm6qg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  '@electric-ax/durable-streams-server-beta@0.3.2':
+    resolution: {integrity: sha512-jo0siJmG6awFjMxaHbIkcUW+SGzmoT2JezxSLZ/wzKVt24Ao4HyWmBMjKXVaEm9Qtq8RjdYiSd6o8X8i0K/wHw==}
     engines: {node: '>=18.0.0'}
 
   '@electric-ax/durable-streams-state-beta@0.3.0':
     resolution: {integrity: sha512-/jJyT757kz765v6vhmElYTz4E1IMa547UXuOjEYEdHW6TjubLWVve+6bc7w4rXma1AXoE6e8j3sYi+JT0aJeZw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  '@electric-ax/durable-streams-state-beta@0.3.1':
+    resolution: {integrity: sha512-84Y3/ERaJgXEtXRqkyK+lML59ABqg/zjsQD3YYR+EWysMsoy6f664GZ5QzTqbuxO/03nP83FuAYFDPw6jgIsCA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -21282,10 +21292,15 @@ snapshots:
       '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
       fastq: 1.20.1
 
-  '@electric-ax/durable-streams-server-beta@0.3.0(typescript@5.8.3)':
+  '@electric-ax/durable-streams-client-beta@0.3.1':
     dependencies:
-      '@durable-streams/client': '@electric-ax/durable-streams-client-beta@0.3.0'
-      '@durable-streams/state': '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)'
+      '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
+      fastq: 1.20.1
+
+  '@electric-ax/durable-streams-server-beta@0.3.2(typescript@5.8.3)':
+    dependencies:
+      '@electric-ax/durable-streams-client-beta': 0.3.1
+      '@electric-ax/durable-streams-state-beta': 0.3.1(typescript@5.8.3)
       '@neophi/sieve-cache': 1.5.0
       '@opentelemetry/api': 1.9.1
       lmdb: 3.5.4
@@ -21297,6 +21312,14 @@ snapshots:
   '@electric-ax/durable-streams-state-beta@0.3.0(typescript@5.8.3)':
     dependencies:
       '@durable-streams/client': '@electric-ax/durable-streams-client-beta@0.3.0'
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db': 0.6.5(typescript@5.8.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@electric-ax/durable-streams-state-beta@0.3.1(typescript@5.8.3)':
+    dependencies:
+      '@electric-ax/durable-streams-client-beta': 0.3.1
       '@standard-schema/spec': 1.1.0
       '@tanstack/db': 0.6.5(typescript@5.8.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Add a fork flow for top-level agents that forks the underlying durable streams first, then registers the forked entities in the server
- Lock the source subtree during fork so work cannot race with offset collection or stream duplication
- Expose the action in the agent UI with a top-right `fork` button on the entity view
- Update the durable-streams packages and related workspace dependencies to the newer fork-capable versions
- Add server-side coverage for the fork route, subtree locking, and stream history preservation during fork
- `fork` waits for the entire subtree to be idle to avoid mid-process forking until we have better coordination primitives

--- 

<img width="1197" height="514" alt="image" src="https://github.com/user-attachments/assets/b9439471-24cb-4fa1-a390-8b141791673c" />
