### PR TITLE
fix(ci): use OIDC trusted publishing for canary npm auth

### DIFF
--- a/.github/workflows/canary_npm_publish.yml
+++ b/.github/workflows/canary_npm_publish.yml
@@ -1,6 +1,7 @@
 name: Publish canary npm packages
 
 on:
+  workflow_dispatch: {}
   push:
     branches: ['main']
     paths:
@@ -56,9 +57,9 @@ jobs:
           pnpm run --filter '@electric-ax/agents' build
           pnpm run --filter 'electric-ax' build
 
-      # Publish with canary tag (uses OIDC provenance for auth, matching the release workflow)
+      # Publish with canary tag (uses OIDC trusted publishing for auth, matching the release workflow)
       - name: Publish canary packages
         run: |
-          pnpm publish --filter '@electric-ax/agents-runtime' --tag canary --no-git-checks --access public --provenance
-          pnpm publish --filter '@electric-ax/agents' --tag canary --no-git-checks --access public --provenance
-          pnpm publish --filter 'electric-ax' --tag canary --no-git-checks --access public --provenance
+          pnpm publish --filter '@electric-ax/agents-runtime' --tag canary --no-git-checks --access public
+          pnpm publish --filter '@electric-ax/agents' --tag canary --no-git-checks --access public
+          pnpm publish --filter 'electric-ax' --tag canary --no-git-checks --access public


### PR DESCRIPTION
## Summary

- Remove explicit `--provenance` flag from `pnpm publish` commands in the canary workflow
- Add `workflow_dispatch` trigger for manual testing

## Context

The canary npm publish workflow has failed on every run with `ENEEDAUTH`. The previous fix (#4210) removed token-based auth and added `--provenance`, but that didn't resolve it.

The working changesets release workflow uses `pnpm publish` **without** `--provenance` — npm auto-detects the OIDC environment (`ACTIONS_ID_TOKEN_REQUEST_TOKEN` set by `id-token: write`) and uses it for both authentication and provenance generation automatically. The explicit `--provenance` flag appears to interfere with this flow.

## Test plan

- [ ] Manually trigger workflow from this branch via Actions → "Run workflow"
- [ ] Verify canary packages publish successfully with OIDC auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)