### PR TITLE
feat(agents): bundle Electric Agents docs for Horton knowledge base

### DIFF
--- a/.changeset/bundle-agents-docs.md
+++ b/.changeset/bundle-agents-docs.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents": patch
+---
+
+Bundle Electric Agents documentation with the package so Horton can search docs without an external docs directory. Copies 39 markdown files from the docs site into `packages/agents/docs/` and updates `resolveDocsRoot` to find them relative to the module directory in both development and production builds.

--- a/examples/agents-chat-starter/README.md
+++ b/examples/agents-chat-starter/README.md
@@ -1,8 +1,6 @@
 # Electric Agents Chat Starter
 
-[Electric Agents](https://electric-sql.com/docs/agents/) is a framework for building durable, collaborative AI agents. Agents run as long-lived entities with persistent state on durable streams — they scale to zero, survive restarts, and coordinate through shared state and wake events. This starter builds a multi-agent chatroom on top of it.
-
-Two agents — an **Optimist** and a **Critic** — join every room. Ask a question and watch them debate from opposing viewpoints.
+A multi-agent chatroom built on [Electric Agents](https://electric-sql.com/docs/agents/) — the durable runtime for long-lived agents. Two agents (an Optimist and a Critic) join every room and debate from opposing viewpoints.
 
 ## Quick Start
 
@@ -37,35 +35,10 @@ See the [full documentation](https://electric-sql.com/docs/agents/) to learn mor
 
 ## How It Works
 
-Each agent is an **entity** — an addressable unit of state at `/{type}/{id}` backed by a durable event stream. The runtime wakes entities in response to events (new messages, state changes, timers) and provides a handler context (`ctx`) for configuring the agent's LLM, tools, and coordination.
-
-In this starter:
-
 1. **User sends message** — backend writes to a shared state stream
-2. **Agents wake** — `ctx.observe(db(...), { wake: { on: 'change' } })` triggers the handler when new messages arrive
-3. **Agents respond** — the LLM runs with conversation context and uses the `send_message` tool to post back to shared state
-4. **Frontend updates** — `useLiveQuery` on the shared state collection updates the UI reactively
-
-## Project Structure
-
-```
-src/
-  server/
-    index.ts          # HTTP server, room management, entity registration
-    schema.ts         # Zod schema for chat messages + shared state
-    shared-tools.ts   # registerChatAgent factory, send_message & web_search tools
-  ui/
-    main.tsx          # App entry, room lifecycle, 3-column layout
-    main.css          # Minimal styles using Radix theme tokens
-    hooks/
-      useChatroom.ts  # Subscribe to shared state (messages + agents)
-      useEntityTypes.ts  # Fetch entity types from registry
-    components/
-      RoomsSidebar.tsx   # Room list + create
-      ChatArea.tsx       # Messages + input + typing indicator
-      MembersSidebar.tsx # Agent list + spawn controls
-      MessageBubble.tsx  # Single message
-```
+2. **Agents wake** — `ctx.observe(db(...), { wake: { on: 'change' } })` triggers when new messages arrive
+3. **Agents respond** — the LLM runs and uses the `send_message` tool to post back to shared state
+4. **Frontend updates** — `useLiveQuery` reactively renders new messages
 
 ## Adding New Agents
 
@@ -87,10 +60,3 @@ The agent automatically observes shared state, wakes on new messages, gets conve
 - [Electric Agents documentation](https://electric-sql.com/docs/agents/)
 - [Entity concepts and lifecycle](https://electric-sql.com/docs/agents/concepts)
 - [Coordination patterns](https://electric-sql.com/docs/agents/patterns)
-
-## Stack
-
-- **Runtime**: `@electric-ax/agents-runtime` — entity lifecycle, shared state, context assembly
-- **Frontend**: React 19 + Vite + Radix UI Themes + TanStack DB
-- **Backend**: Node.js HTTP server
-- **Infrastructure**: Postgres + Electric + Durable Streams (via `electric-ax agents quickstart`)

--- a/examples/agents-chat-starter/README.md
+++ b/examples/agents-chat-starter/README.md
@@ -1,6 +1,8 @@
 # Electric Agents Chat Starter
 
-A multi-agent chatroom built on [Electric Agents](https://electric-sql.com/docs/agents/) — the durable runtime for long-lived agents. Two agents (an Optimist and a Critic) join every room and debate from opposing viewpoints.
+[Electric Agents](https://electric-sql.com/docs/agents/) is a framework for building durable, collaborative AI agents. Agents run as long-lived entities with persistent state on durable streams — they scale to zero, survive restarts, and coordinate through shared state and wake events. This starter builds a multi-agent chatroom on top of it.
+
+Two agents — an **Optimist** and a **Critic** — join every room. Ask a question and watch them debate from opposing viewpoints.
 
 ## Quick Start
 
@@ -35,10 +37,35 @@ See the [full documentation](https://electric-sql.com/docs/agents/) to learn mor
 
 ## How It Works
 
+Each agent is an **entity** — an addressable unit of state at `/{type}/{id}` backed by a durable event stream. The runtime wakes entities in response to events (new messages, state changes, timers) and provides a handler context (`ctx`) for configuring the agent's LLM, tools, and coordination.
+
+In this starter:
+
 1. **User sends message** — backend writes to a shared state stream
-2. **Agents wake** — `ctx.observe(db(...), { wake: { on: 'change' } })` triggers when new messages arrive
-3. **Agents respond** — the LLM runs and uses the `send_message` tool to post back to shared state
-4. **Frontend updates** — `useLiveQuery` reactively renders new messages
+2. **Agents wake** — `ctx.observe(db(...), { wake: { on: 'change' } })` triggers the handler when new messages arrive
+3. **Agents respond** — the LLM runs with conversation context and uses the `send_message` tool to post back to shared state
+4. **Frontend updates** — `useLiveQuery` on the shared state collection updates the UI reactively
+
+## Project Structure
+
+```
+src/
+  server/
+    index.ts          # HTTP server, room management, entity registration
+    schema.ts         # Zod schema for chat messages + shared state
+    shared-tools.ts   # registerChatAgent factory, send_message & web_search tools
+  ui/
+    main.tsx          # App entry, room lifecycle, 3-column layout
+    main.css          # Minimal styles using Radix theme tokens
+    hooks/
+      useChatroom.ts  # Subscribe to shared state (messages + agents)
+      useEntityTypes.ts  # Fetch entity types from registry
+    components/
+      RoomsSidebar.tsx   # Room list + create
+      ChatArea.tsx       # Messages + input + typing indicator
+      MembersSidebar.tsx # Agent list + spawn controls
+      MessageBubble.tsx  # Single message
+```
 
 ## Adding New Agents
 
@@ -60,3 +87,10 @@ The agent automatically observes shared state, wakes on new messages, gets conve
 - [Electric Agents documentation](https://electric-sql.com/docs/agents/)
 - [Entity concepts and lifecycle](https://electric-sql.com/docs/agents/concepts)
 - [Coordination patterns](https://electric-sql.com/docs/agents/patterns)
+
+## Stack
+
+- **Runtime**: `@electric-ax/agents-runtime` — entity lifecycle, shared state, context assembly
+- **Frontend**: React 19 + Vite + Radix UI Themes + TanStack DB
+- **Backend**: Node.js HTTP server
+- **Infrastructure**: Postgres + Electric + Durable Streams (via `electric-ax agents quickstart`)

--- a/packages/agents/docs/entities/agents/horton.md
+++ b/packages/agents/docs/entities/agents/horton.md
@@ -1,0 +1,89 @@
+---
+title: Horton agent
+titleTemplate: '... - Electric Agents'
+description: >-
+  The built-in Horton assistant - chat, research, code, and dispatch subagents in one entity type.
+outline: [2, 3]
+---
+
+# Horton agent
+
+The built-in assistant registered by the Electric Agents dev server. Horton can chat conversationally, search the web, read and edit files, run shell commands, and dispatch subagents (workers) for isolated subtasks.
+
+**Source:** [`packages/agents/src/agents/horton.ts`](https://github.com/electric-sql/electric/blob/main/packages/agents/src/agents/horton.ts)
+
+## Try it
+
+With the dev server running (`npx electric-ax agents quickstart`):
+
+```sh
+npx electric-ax agents spawn /horton/my-horton
+npx electric-ax agents send /horton/my-horton 'What's in this directory?'
+npx electric-ax agents observe /horton/my-horton
+```
+
+## Tools
+
+Horton is configured with `ctx.electricTools` plus the base Horton tool set:
+
+| Tool           | Purpose                                                  |
+| -------------- | -------------------------------------------------------- |
+| `bash`         | Run shell commands in the working directory.             |
+| `read`         | Read a file. Tracked in a per-wake `readSet`.            |
+| `write`        | Create or overwrite a file.                              |
+| `edit`         | Targeted string replacement (file must be `read` first). |
+| `brave_search` | Web search via the Brave Search API.                     |
+| `fetch_url`    | Fetch a URL and return it as markdown.                   |
+| `spawn_worker` | Dispatch a subagent for an isolated subtask.             |
+
+`brave_search` requires `BRAVE_SEARCH_API_KEY` in the environment; without it the tool errors at call time.
+
+When docs support or skills are available, Horton also adds the docs search tool and skill tools during bootstrap.
+
+## Title generation
+
+After the first agent run completes, Horton calls `generateTitle()` (Haiku) to summarise the user's first message into a 3-5 word session title and stores it via `ctx.setTag('title', title)`. Failures are logged and ignored — the entity continues without a title.
+
+## Details
+
+| Property          | Value                                                                             |
+| ----------------- | --------------------------------------------------------------------------------- |
+| Type name         | `horton`                                                                          |
+| Model             | `HORTON_MODEL` (`claude-sonnet-4-5-20250929`)                                     |
+| Title model       | `claude-haiku-4-5-20251001`                                                       |
+| Tools             | `ctx.electricTools` + base Horton tool set, plus docs/skill tools when configured |
+| Working directory | Passed at bootstrap (defaults to `process.cwd()`)                                 |
+| Title generation  | Yes, after the first run if no title tag exists                                   |
+
+## Extending Horton
+
+The system prompt and tool factory are exported so you can build your own variants:
+
+```ts
+import {
+  HORTON_MODEL,
+  buildHortonSystemPrompt,
+  createHortonTools,
+} from '@electric-ax/agents'
+
+registry.define('my-assistant', {
+  description: 'Horton with an extra custom tool',
+  async handler(ctx) {
+    const readSet = new Set<string>()
+    ctx.useAgent({
+      systemPrompt: buildHortonSystemPrompt(process.cwd()),
+      model: HORTON_MODEL,
+      tools: [
+        ...ctx.electricTools,
+        ...createHortonTools(process.cwd(), ctx, readSet),
+        myCustomTool,
+      ],
+    })
+    await ctx.agent.run()
+  },
+})
+```
+
+## Related
+
+- [Worker](./worker) — the subagent type Horton dispatches via `spawn_worker`.

--- a/packages/agents/docs/entities/agents/worker.md
+++ b/packages/agents/docs/entities/agents/worker.md
@@ -1,0 +1,102 @@
+---
+title: Worker
+titleTemplate: '... - Electric Agents'
+description: >-
+  Generic sandboxed subagent type. Spawned by Horton (or any agent) via the spawn_worker tool with a system prompt and a chosen tool subset.
+outline: [2, 3]
+---
+
+# Worker
+
+A generic, sandboxed subagent type. Workers are spawned by other agents (typically [Horton](./horton)) via the `spawn_worker` tool — the spawner provides a system prompt and picks the subset of tools the worker should have access to.
+
+**Source:** [`packages/agents/src/agents/worker.ts`](https://github.com/electric-sql/electric/blob/main/packages/agents/src/agents/worker.ts)
+
+## Spawn args
+
+```ts
+interface WorkerArgs {
+  systemPrompt: string
+  tools?: Array<WorkerToolName>
+  sharedDb?: { id: string; schema: SharedStateSchemaMap }
+  sharedDbToolMode?: 'full' | 'write-only'
+}
+```
+
+| Field              | Required | Description                                                                                   |
+| ------------------ | -------- | --------------------------------------------------------------------------------------------- |
+| `systemPrompt`     | Yes      | The worker's system prompt. Brief it like a colleague: file paths, line numbers, deliverable. |
+| `tools`            | No       | Subset of valid tool names (see below). Unknown names throw at parse time.                    |
+| `sharedDb`         | No       | Shared state stream id and schema to connect to.                                              |
+| `sharedDbToolMode` | No       | Shared state tool mode: `"full"` (default) or `"write-only"`.                                 |
+
+`registerWorker(registry, { workingDirectory, streamFn? })` is called by the dev server during bootstrap; you don't usually call it yourself.
+
+## Valid tool names
+
+```ts
+type WorkerToolName =
+  | 'bash'
+  | 'read'
+  | 'write'
+  | 'edit'
+  | 'brave_search'
+  | 'fetch_url'
+  | 'spawn_worker'
+```
+
+These are the same primitives Horton uses. Pick the smallest subset the worker needs — tools are the worker's permission set.
+
+The worker must receive at least one tool or a `sharedDb` config. If `sharedDb` is provided, the worker gets generated shared-state tools in addition to any selected primitives.
+
+## Spawning a worker
+
+The canonical way to spawn a worker is the `spawn_worker` tool, which Horton calls from inside its agent loop:
+
+```ts
+spawn_worker({
+  systemPrompt:
+    'You are a focused researcher. Find the three most-cited papers on X and return their titles, authors, and DOIs as a markdown table.',
+  tools: ['brave_search', 'fetch_url'],
+  initialMessage: 'Begin research now.',
+})
+```
+
+| Field            | Required | Notes                                                                         |
+| ---------------- | -------- | ----------------------------------------------------------------------------- |
+| `systemPrompt`   | Yes      | Sets persona and constraints.                                                 |
+| `tools`          | Yes      | Subset of `WorkerToolName`. Must contain at least one entry.                  |
+| `initialMessage` | Yes      | First user message. **Without this the worker idles** — nothing kicks it off. |
+
+The spawn uses `wake: { on: 'runFinished', includeResponse: true }`, so the spawner wakes when the worker finishes its run and receives the worker's response in the wake message.
+
+## What the handler does
+
+1. Parses `ctx.args` into `WorkerArgs`. Throws if `systemPrompt` is empty, if `tools` contains an unknown name, or if neither `tools` nor `sharedDb` is provided.
+2. Builds the requested tool instances against the worker's `workingDirectory` (and a fresh per-wake `readSet` for the read-first-then-edit guard).
+3. If `sharedDb` is present, connects with `ctx.observe(db(id, schema))` and exposes generated `read_*`, `write_*`, `update_*`, and `delete_*` tools (`write_*` only in `"write-only"` mode).
+4. Configures the agent with `HORTON_MODEL` (`claude-sonnet-4-5-20250929`), the provided system prompt (with a brief reporting-back footer appended), and the assembled tool list.
+5. Runs the agent until the LLM stops.
+
+::: warning Least-privilege sandbox
+Workers deliberately do **not** receive `ctx.electricTools`. The spawner already picked the worker's tool subset; granting entity-runtime primitives (cron, schedule, send-to-arbitrary-entity) would let a worker escape that scope. If a worker needs those primitives, it must spawn its own subagent or report back to the spawner.
+:::
+
+## Reporting footer
+
+The runtime appends this to every worker's system prompt:
+
+```text
+# Reporting back
+When you finish, respond with a concise report covering what was done and any key findings. The caller will relay this to the user, so it only needs the essentials.
+```
+
+## Details
+
+| Property          | Value                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Type name         | `worker`                                                                                                                  |
+| Model             | `HORTON_MODEL` (`claude-sonnet-4-5-20250929`)                                                                             |
+| Tools             | Subset of 7 primitives plus optional shared-state tools. **No `ctx.electricTools`.**                                      |
+| Working directory | Provided to `registerWorker` at bootstrap                                                                                 |
+| Description       | `Internal — generic worker spawned by other agents. Configure via spawn args (systemPrompt + tools + optional sharedDb).` |

--- a/packages/agents/docs/entities/patterns/blackboard.md
+++ b/packages/agents/docs/entities/patterns/blackboard.md
@@ -1,0 +1,111 @@
+---
+title: Blackboard (shared state)
+titleTemplate: '... - Electric Agents'
+description: >-
+  Multi-agent coordination using shared state as a common data structure for reads and writes.
+outline: [2, 3]
+---
+
+# Blackboard (shared state)
+
+Pattern: multiple agents coordinate through a shared data structure. A parent creates shared state, spawns workers that connect to it, and workers read/write shared collections via auto-generated CRUD tools.
+
+**Source:** [`packages/agents-runtime/skills/designing-entities/references/patterns/blackboard.md`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/blackboard.md)
+
+## Debate example
+
+The canonical blackboard example: a moderator runs a structured debate between pro and con workers via shared state.
+
+### Schema
+
+```ts
+const debateSchema = {
+  arguments: {
+    schema: z.object({
+      key: z.string(),
+      side: z.enum(['pro', 'con']),
+      text: z.string(),
+      round: z.number(),
+    }),
+    type: 'shared:argument',
+    primaryKey: 'key',
+  },
+}
+```
+
+### Registration
+
+```ts
+import { db } from '@electric-ax/agents-runtime'
+
+export function registerDebate(registry: EntityRegistry) {
+  registry.define(`debate`, {
+    description: `Debate moderator that creates shared state, spawns pro and con workers, and writes a final ruling based on arguments written to shared state`,
+    state: {
+      status: { primaryKey: `key` },
+    },
+
+    async handler(ctx) {
+      if (ctx.firstWake) {
+        ctx.db.actions.status_insert({ row: { key: `current`, value: `idle` } })
+        ctx.mkdb(`debate-${ctx.entityUrl}`, debateSchema)
+      }
+      const shared = await ctx.observe(
+        db(`debate-${ctx.entityUrl}`, debateSchema)
+      )
+
+      // ... create tools that reference `shared` ...
+
+      ctx.useAgent({
+        systemPrompt: DEBATE_SYSTEM_PROMPT,
+        model: `claude-sonnet-4-5-20250929`,
+        tools: [...ctx.electricTools, startTool, checkTool, endTool],
+      })
+      await ctx.agent.run()
+    },
+  })
+}
+```
+
+### How it works
+
+1. On first wake, the moderator creates shared state with `ctx.mkdb()`.
+2. The moderator connects to the shared state with `ctx.observe(db(...))`.
+3. The `start_debate` tool spawns pro and con workers, each connected to the same shared state:
+
+```ts
+const proWorker = await ctx.spawn(
+  `worker`,
+  `debate-pro-${Date.now()}-${spawnCounter}`,
+  {
+    systemPrompt: PRO_WORKER_PROMPT,
+    sharedDb: { id: `debate-${ctx.entityUrl}`, schema: debateSchema },
+  },
+  { initialMessage: proInitialMessage, wake: `runFinished` }
+)
+```
+
+4. Workers write arguments to the shared `arguments` collection using auto-generated `write_arguments` tools (see [Worker](../agents/worker.md)).
+5. The `check_debate` tool reads the shared state to see current arguments:
+
+```ts
+const args = shared.arguments.toArray
+```
+
+6. The `end_debate` tool reads all arguments and transitions to `done`.
+
+### State transitions
+
+```ts
+type DebateStatus = 'idle' | 'debating' | 'ruling' | 'done'
+```
+
+## Other blackboard variants
+
+The same structure applies to other blackboard workflows:
+
+- **Wiki** -- specialist workers collaboratively build a knowledge base. Each writes articles to a shared `articles` collection.
+- **Peer review** -- workers submit reviews with scores and feedback to a shared `reviews` collection. A coordinator summarizes the reviews.
+- **Trading floor** -- trader agents submit buy/sell orders to a shared `orders` collection and transition through market sessions.
+
+All follow the same structure: parent creates shared state, spawns workers with `sharedDb` in their args, workers use generated CRUD tools to coordinate.

--- a/packages/agents/docs/entities/patterns/dispatcher.md
+++ b/packages/agents/docs/entities/patterns/dispatcher.md
@@ -1,0 +1,77 @@
+---
+title: Dispatcher
+titleTemplate: '... - Electric Agents'
+description: >-
+  Message routing pattern that classifies incoming messages and dispatches to specialist agents.
+outline: [2, 3]
+---
+
+# Dispatcher
+
+Pattern: classify incoming messages and route to the appropriate agent type.
+
+**Source:** [`packages/agents-runtime/skills/designing-entities/references/patterns/dispatcher.md`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/dispatcher.md)
+
+## Registration
+
+```ts
+export function registerDispatcher(registry: EntityRegistry) {
+  registry.define(`dispatcher`, {
+    description: `Router agent that classifies incoming messages and dispatches to the appropriate specialist agent type`,
+
+    async handler(ctx) {
+      const dispatchTool = createDispatchTool(ctx)
+
+      ctx.useAgent({
+        systemPrompt: DISPATCHER_SYSTEM_PROMPT,
+        model: `claude-sonnet-4-5-20250929`,
+        tools: [...ctx.electricTools, dispatchTool],
+      })
+      await ctx.agent.run()
+    },
+  })
+}
+```
+
+::: info No local state
+The dispatcher entity defines no `state` collections. It is stateless -- it relies entirely on the wake mechanism to receive child completion events and forwards specialist output to the user.
+:::
+
+## How it works
+
+The dispatcher exposes a `dispatch` tool. When the LLM classifies an incoming message, it calls the tool with:
+
+- `type` -- the entity type to spawn (e.g. `"horton"`, `"worker"`, or an app-defined type)
+- `systemPrompt` -- a focused prompt crafted for the task
+- `task` -- the original message to forward
+
+The tool then:
+
+1. Spawns the requested entity type with `wake: 'runFinished'`.
+2. Returns immediately with a status message. The dispatcher is re-invoked when the specialist finishes.
+
+## Dispatch tool
+
+```ts
+await ctx.spawn(
+  type,
+  id,
+  type === `worker` ? { systemPrompt, tools: [`read`] } : { systemPrompt },
+  {
+    initialMessage: task,
+    wake: `runFinished`,
+  }
+)
+
+return {
+  content: [
+    {
+      type: `text` as const,
+      text: `Dispatched to "${type}" specialist (${id}). You will be woken when it finishes.`,
+    },
+  ],
+  details: { id, type },
+}
+```
+
+When dispatching to the built-in `worker`, include its required tool subset in the spawn args.

--- a/packages/agents/docs/entities/patterns/manager-worker.md
+++ b/packages/agents/docs/entities/patterns/manager-worker.md
@@ -1,0 +1,127 @@
+---
+title: Manager-Worker
+titleTemplate: '... - Electric Agents'
+description: >-
+  Coordination pattern where a parent spawns specialist children, waits for completion, and synthesizes results.
+outline: [2, 3]
+---
+
+# Manager-Worker
+
+Pattern: a parent agent spawns multiple specialist children, waits for all to complete, and synthesizes results.
+
+**Source:** [`packages/agents-runtime/skills/designing-entities/references/patterns/manager-worker.md`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/manager-worker.md)
+
+## Registration
+
+```ts
+export function registerManagerWorker(registry: EntityRegistry) {
+  registry.define(`manager-worker`, {
+    description: `Manager agent that spawns optimist, pessimist, and pragmatist workers to analyze any question from multiple perspectives`,
+    state: {
+      children: { schema: managerChildSchema, primaryKey: `key` },
+    },
+
+    async handler(ctx) {
+      const analyzeTool = createAnalyzeWithPerspectivesTool(ctx)
+
+      ctx.useAgent({
+        systemPrompt: MANAGER_SYSTEM_PROMPT,
+        model: `claude-sonnet-4-5-20250929`,
+        tools: [...ctx.electricTools, analyzeTool],
+      })
+      await ctx.agent.run()
+    },
+  })
+}
+```
+
+## How it works
+
+The manager defines a handler-scoped tool called `analyze_with_perspectives`. When the LLM calls this tool, it:
+
+1. Spawns 3 worker children -- optimist, pessimist, pragmatist -- each with a different system prompt.
+2. Sends the same question to all three as `initialMessage`.
+3. Uses `wake: 'runFinished'` to wait for each child to complete.
+4. Collects results with `Promise.all` and `handle.text()`.
+5. Returns the combined perspectives to the LLM for synthesis.
+
+On subsequent calls, the tool reuses existing children via `ctx.observe()` and `child.send()` instead of spawning new ones.
+
+## Spawn-or-reuse pattern
+
+The core of the tool -- first-call spawns, subsequent calls reuse:
+
+```ts
+for (const perspective of PERSPECTIVES) {
+  const existing = children.get(perspective.id)
+  const childId = `${parentId}-${perspective.id}`
+
+  if (!existing?.url) {
+    // First time: spawn a new worker
+    const child = await ctx.spawn(
+      `worker`,
+      childId,
+      { systemPrompt: perspective.systemPrompt, tools: [`read`] },
+      { initialMessage: question, wake: `runFinished` }
+    )
+    children.insert({
+      key: perspective.id,
+      url: child.entityUrl,
+      kind: perspective.id,
+      question,
+    })
+    handles.push({ id: perspective.id, handle: child })
+    continue
+  }
+
+  // Subsequent calls: observe existing child and send new question
+  const child = await ctx.observe(entity(existing.url))
+  child.send(question)
+  children.update(perspective.id, (draft) => {
+    draft.question = question
+  })
+  handles.push({ id: perspective.id, handle: child })
+}
+```
+
+## Collecting results
+
+The `readLatestCompletedText` helper awaits the child's current run, reads all text outputs, and returns the last one:
+
+```ts
+async function readLatestCompletedText(
+  handle: EntityHandle,
+  fallback: string
+): Promise<string> {
+  await handle.run
+  const runs = await handle.text()
+  const latest = runs[runs.length - 1]?.trim()
+  return latest || fallback
+}
+
+const results = await Promise.all(
+  handles.map(async ({ id, handle }) => ({
+    id,
+    text: await readLatestCompletedText(
+      handle,
+      `(no completed output from ${id})`
+    ),
+  }))
+)
+```
+
+## State
+
+The `children` collection tracks spawned workers:
+
+```ts
+const managerChildSchema = z.object({
+  key: z.string(),
+  url: z.string(),
+  kind: z.string(),
+  question: z.string(),
+})
+```
+
+This allows the manager to find and reuse children across handler invocations.

--- a/packages/agents/docs/entities/patterns/map-reduce.md
+++ b/packages/agents/docs/entities/patterns/map-reduce.md
@@ -1,0 +1,81 @@
+---
+title: Map-Reduce
+titleTemplate: '... - Electric Agents'
+description: >-
+  Parallel processing pattern that splits work into chunks, processes simultaneously, and reduces results.
+outline: [2, 3]
+---
+
+# Map-Reduce
+
+Pattern: split input into chunks, process all in parallel, collect results.
+
+**Source:** [`packages/agents-runtime/skills/designing-entities/references/patterns/map-reduce.md`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/map-reduce.md)
+
+## Registration
+
+```ts
+export function registerMapReduce(registry: EntityRegistry) {
+  registry.define(`map-reduce`, {
+    description: `Map-reduce orchestrator that splits input into chunks, processes them in parallel with worker agents, then synthesizes results`,
+    state: {
+      children: { primaryKey: `key` },
+    },
+
+    async handler(ctx) {
+      ctx.useAgent({
+        systemPrompt: MAP_REDUCE_SYSTEM_PROMPT,
+        model: `claude-sonnet-4-5-20250929`,
+        tools: [...ctx.electricTools, createMapChunksTool(ctx)],
+      })
+      await ctx.agent.run()
+    },
+  })
+}
+```
+
+## How it works
+
+The agent exposes a `map_chunks` tool. When called:
+
+1. **Map phase** -- spawns one worker per chunk simultaneously. All workers run in parallel.
+2. Returns immediately. The entity is re-invoked as each worker finishes.
+3. The LLM synthesizes results once all workers have reported in via wake events.
+
+## Core
+
+```ts
+// Map phase - spawn all workers in parallel
+for (let i = 0; i < chunks.length; i++) {
+  spawnCounter++
+  const id = `chunk-${i}-${Date.now()}-${spawnCounter}`
+  const child = await ctx.spawn(
+    `worker`,
+    id,
+    { systemPrompt: task, tools: [`read`] },
+    {
+      initialMessage: chunks[i],
+      wake: `runFinished`,
+    }
+  )
+  ctx.db.actions.children_insert({
+    row: { key: id, url: child.entityUrl, chunk: i },
+  })
+}
+
+return {
+  content: [
+    {
+      type: `text` as const,
+      text: `Spawned ${chunks.length} parallel workers. You will be woken as each finishes with its output in finished_child.response.`,
+    },
+  ],
+  details: { chunkCount: chunks.length },
+}
+```
+
+## State collections
+
+| Collection | Purpose                                        |
+| ---------- | ---------------------------------------------- |
+| `children` | Spawned chunk workers (key, URL, chunk index). |

--- a/packages/agents/docs/entities/patterns/pipeline.md
+++ b/packages/agents/docs/entities/patterns/pipeline.md
@@ -1,0 +1,101 @@
+---
+title: Pipeline
+titleTemplate: '... - Electric Agents'
+description: >-
+  Sequential processing pattern where each stage's output feeds into the next via state transitions.
+outline: [2, 3]
+---
+
+# Pipeline
+
+Pattern: sequential stages where each stage's output feeds into the next.
+
+**Source:** [`packages/agents-runtime/skills/designing-entities/references/patterns/pipeline.md`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/pipeline.md)
+
+## Registration
+
+```ts
+export function registerPipeline(registry: EntityRegistry) {
+  registry.define(`pipeline`, {
+    description: `Pipeline orchestrator that chains sequential worker stages, feeding each stage output into the next`,
+    state: {
+      children: { primaryKey: `key` },
+    },
+
+    async handler(ctx) {
+      ctx.useAgent({
+        systemPrompt: PIPELINE_SYSTEM_PROMPT,
+        model: `claude-sonnet-4-5-20250929`,
+        tools: [...ctx.electricTools, createRunStageTool(ctx)],
+      })
+      await ctx.agent.run()
+    },
+  })
+}
+```
+
+## How it works
+
+The pipeline agent exposes a `run_stage` tool. The LLM drives the pipeline one stage at a time:
+
+1. The LLM calls `run_stage` with an instruction and input for the current stage.
+2. The tool spawns a worker with the instruction as its system prompt and the input as `initialMessage`, using `wake: 'runFinished'`.
+3. The tool returns immediately. The pipeline entity is re-invoked when the worker finishes.
+4. On each re-invocation, the wake event contains `finished_child.response` with the stage's output. The LLM then calls `run_stage` again with the next stage's instruction and the previous output as input.
+5. This repeats until all stages are complete.
+
+## Stage tool
+
+```ts
+function createRunStageTool(ctx: HandlerContext): AgentTool {
+  let stageCount = 0
+
+  return {
+    name: `run_stage`,
+    label: `Run Stage`,
+    description: `Spawns a worker for one pipeline stage.`,
+    parameters: Type.Object({
+      instruction: Type.String({
+        description: `The instruction for this stage.`,
+      }),
+      input: Type.String({ description: `The input for this stage.` }),
+    }),
+    execute: async (_toolCallId, params) => {
+      const { instruction, input } = params as {
+        instruction: string
+        input: string
+      }
+
+      stageCount++
+      const parentId = entityIdFromUrl(ctx.entityUrl)
+      const id = `${parentId}-stage-${stageCount}`
+
+      const child = await ctx.spawn(
+        `worker`,
+        id,
+        { systemPrompt: instruction, tools: [`read`] },
+        { initialMessage: input, wake: `runFinished` }
+      )
+      ctx.db.actions.children_insert({
+        row: { key: id, url: child.entityUrl, stage: stageCount },
+      })
+
+      return {
+        content: [
+          {
+            type: `text` as const,
+            text: `Stage ${stageCount} spawned. You will be woken when it finishes.`,
+          },
+        ],
+        details: { stage: stageCount },
+      }
+    },
+  }
+}
+```
+
+## State collections
+
+| Collection | Purpose                                             |
+| ---------- | --------------------------------------------------- |
+| `children` | Spawned worker references (key, URL, stage number). |

--- a/packages/agents/docs/entities/patterns/reactive-observers.md
+++ b/packages/agents/docs/entities/patterns/reactive-observers.md
@@ -1,0 +1,125 @@
+---
+title: Reactive observers
+titleTemplate: '... - Electric Agents'
+description: >-
+  Pattern for entities that watch others and react to changes using ctx.observe() with wake conditions.
+outline: [2, 3]
+---
+
+# Reactive observers
+
+Pattern: entities that watch other entities and react to changes.
+
+**Source:** [`packages/agents-runtime/skills/designing-entities/references/patterns/reactive-observers.md`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/reactive-observers.md)
+
+## Core mechanism
+
+An entity calls `ctx.observe(entity(entityUrl), { wake: { on: 'change', collections: [...] } })` to start watching another entity. The `entity()` helper (imported from `@electric-ax/agents-runtime`) wraps a raw URL into the correct observe target. When the observed entity has new activity in the specified collections, the observer is woken.
+
+## Monitor example
+
+The monitor watches multiple entities and reports status changes.
+
+**Source:** [`packages/agents-runtime/skills/designing-entities/references/patterns/reactive-observers.md`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/reactive-observers.md)
+
+```ts
+export function registerMonitor(registry: EntityRegistry) {
+  registry.define(`monitor`, {
+    description: `Health dashboard agent that watches multiple entities and reports status changes and anomalies`,
+    state: {
+      status: { primaryKey: `key` },
+    },
+
+    async handler(ctx) {
+      if (ctx.firstWake) {
+        ctx.db.actions.status_insert({ row: { key: `current`, value: `idle` } })
+      }
+      const baseObserveTool = createObserveTool(ctx)
+      const observeTool = {
+        ...baseObserveTool,
+        execute: async (toolCallId: string, params: unknown) => {
+          ctx.db.actions.status_update({
+            key: `current`,
+            updater: (draft) => {
+              draft.value = `observing`
+            },
+          })
+          return baseObserveTool.execute(toolCallId, params)
+        },
+      }
+
+      ctx.useAgent({
+        systemPrompt: MONITOR_SYSTEM_PROMPT,
+        model: `claude-sonnet-4-5-20250929`,
+        tools: [...ctx.electricTools, observeTool],
+      })
+      await ctx.agent.run()
+    },
+  })
+}
+```
+
+The monitor wraps the base observe tool to also transition its own state to `observing`.
+
+## The observe tool
+
+The `observe_entity` tool lets the LLM decide what to watch:
+
+```ts
+import { entity } from '@electric-ax/agents-runtime'
+
+export function createObserveTool(ctx: HandlerContext): AgentTool {
+  return {
+    name: `observe_entity`,
+    label: `Observe Entity`,
+    description: `Start observing another entity by its URL. The current entity will wake with a change payload when the observed entity has new activity.`,
+    parameters: Type.Object({
+      entity_url: Type.String({
+        description: `The URL of the entity to observe`,
+      }),
+      collections: Type.Optional(
+        Type.Array(Type.String(), {
+          description: `Which collections to watch (default: all). Options: texts, textDeltas, runs, toolCalls, childStatus`,
+        })
+      ),
+    }),
+    execute: async (_toolCallId, params) => {
+      const { entity_url, collections } = params as {
+        entity_url: string
+        collections?: string[]
+      }
+      try {
+        await ctx.observe(entity(entity_url), {
+          wake: { on: `change`, collections },
+        })
+        return {
+          content: [
+            {
+              type: `text`,
+              text: `Now observing entity: ${entity_url}. You will be woken when new activity is detected.`,
+            },
+          ],
+          details: {},
+        }
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: `text`,
+              text: `Error observing entity: ${err instanceof Error ? err.message : `Unknown error`}`,
+            },
+          ],
+          details: {},
+        }
+      }
+    },
+  }
+}
+```
+
+## Other reactive variants
+
+- **Summarizer** -- observes an entity's `texts` and `textDeltas` collections and produces progressive summaries of its output.
+- **Guardian** -- observes an entity's `texts` and `toolCalls` collections and evaluates output quality, checking for hallucination signals, safety issues, and formatting problems.
+
+All three follow the same structure: register an entity, wrap `createObserveTool` with a state transition, configure the agent with the observe tool, and run.

--- a/packages/agents/docs/examples/mega-draw.md
+++ b/packages/agents/docs/examples/mega-draw.md
@@ -1,0 +1,106 @@
+---
+title: Mega Draw
+titleTemplate: '... - Electric Agents'
+description: >-
+  Multi-agent collaborative drawing example with coordinator-worker patterns and 100 tile agents.
+outline: [2, 3]
+---
+
+# Mega Draw
+
+A collaborative multi-agent drawing app where 100 AI agents each own a tile of a shared 1000x1000 pixel canvas and work together to produce a drawing from a single text prompt. Located at `examples/mega-draw/` in the repository.
+
+## What it demonstrates
+
+- **Coordinator + worker pattern** at scale (1 coordinator spawning 100 tile agents)
+- **Custom drawing tools** --- `fill_rect`, `draw_line`, `draw_circle`, `fill_gradient`, `set_pixels`
+- **Shared canvas** --- in-memory pixel buffer flushed to PNG, served via a live viewer
+- **Follow-up instructions** --- send a new prompt and only affected tiles get re-instructed
+- **Two-pass workflow** --- coordinator does a quick first pass for backgrounds, then a detail pass
+
+## Architecture
+
+```
+User
+  │
+  │  spawn /coordinator/my-drawing
+  │  send "Draw a sunset over mountains"
+  ▼
+┌────────────────────────────────┐
+│       Coordinator Agent        │
+│  - Receives prompt             │
+│  - Plans composition + palette │
+│  - Spawns 100 tile agents      │
+│  - Can re-instruct tiles       │
+└──────────┬─────────────────────┘
+           │ spawn tile-agent (10×10 grid)
+           ▼
+┌────────┐ ┌────────┐
+│Tile 0,0│ │Tile 1,0│  ...  (10 columns)
+└────────┘ └────────┘
+┌────────┐ ┌────────┐
+│Tile 0,1│ │Tile 1,1│  ...
+└────────┘ └────────┘
+   ...        ...       (10 rows = 100 tiles)
+```
+
+Each tile agent:
+
+- Owns a 100x100 pixel region
+- Can **see** 50px beyond its borders (200x200 viewport) for edge coordination
+- Can only **draw** within its own tile
+- Receives drawing instructions from the coordinator
+
+## Key files
+
+### `src/server.ts`
+
+Entry point. Creates the registry, runtime handler, and two HTTP servers (one for the Electric Agents webhook, one for the canvas viewer).
+
+```ts
+const registry = createEntityRegistry()
+registerCoordinator(registry, WEB_PORT)
+registerTileAgent(registry)
+
+const runtime = createRuntimeHandler({
+  baseUrl: ELECTRIC_AGENTS_URL,
+  serveEndpoint: `${SERVE_URL}/webhook`,
+  registry,
+})
+```
+
+### `src/coordinator.ts`
+
+The coordinator entity. Defines two custom tools:
+
+- `set_drawing_plan` --- sets the composition description and color palette
+- `instruct_tile` --- spawns or re-instructs a tile agent with drawing directions
+
+### `src/tile-agent.ts`
+
+The tile agent entity. Each instance gets drawing tools scoped to its tile:
+
+- `read_viewport` --- see current pixel state (own tile + neighbors)
+- `fill_rect`, `draw_line`, `draw_circle`, `fill_gradient`, `set_pixels`
+
+All coordinates are tile-relative (0--99) and automatically clipped to tile bounds.
+
+## Running it
+
+```bash
+cd examples/mega-draw
+pnpm install
+cp ../../.env.template .env  # Set ANTHROPIC_API_KEY
+pnpm dev
+```
+
+Requires a running Electric Agents runtime server at `http://localhost:4437`.
+
+Then in another terminal:
+
+```bash
+npx electric-ax agents spawn /coordinator/my-drawing
+npx electric-ax agents send /coordinator/my-drawing 'Draw a sunset over mountains'
+```
+
+View the canvas live at `http://localhost:3000/my-drawing` --- it auto-refreshes as tiles draw.

--- a/packages/agents/docs/examples/playground.md
+++ b/packages/agents/docs/examples/playground.md
@@ -1,0 +1,46 @@
+---
+title: Pattern references
+titleTemplate: '... - Electric Agents'
+description: >-
+  Electric Agents pattern references for standalone, coordination, blackboard, and reactive designs.
+outline: [2, 3]
+---
+
+# Pattern references
+
+Electric Agents pattern references live in the monorepo under `packages/agents-runtime/skills/designing-entities/references/patterns/`.
+
+## What it includes
+
+The patterns are organized into four categories.
+
+### Standalone
+
+- `single-agent` --- one entity handles the full task itself
+
+### Coordination
+
+- `manager-worker` --- multi-perspective analysis (optimist/pessimist/pragmatist)
+- `dispatcher` --- routes tasks to the appropriate agent type
+- `pipeline` --- sequential worker stages
+- `map-reduce` --- parallel chunk processing
+
+### Blackboard (shared state)
+
+- `blackboard` --- multiple workers coordinate through shared state
+
+### Reactive
+
+- `reactive-observers` --- observes entity streams and reacts to changes
+
+## Source references
+
+- [`single-agent`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/single-agent.md)
+- [`manager-worker`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/manager-worker.md)
+- [`dispatcher`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/dispatcher.md)
+- [`pipeline`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/pipeline.md)
+- [`map-reduce`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/map-reduce.md)
+- [`blackboard`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/blackboard.md)
+- [`reactive-observers`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/skills/designing-entities/references/patterns/reactive-observers.md)
+
+See [Agents & Patterns](../usage/spawning-and-coordinating.md) for detailed documentation of each pattern.

--- a/packages/agents/docs/index.md
+++ b/packages/agents/docs/index.md
@@ -1,0 +1,208 @@
+---
+title: Electric Agents
+titleTemplate: '... - Electric Agents'
+description: >-
+  The durable runtime for long-lived agents — entities, handlers, wakes, agent loops, and coordination, built on Electric Streams, TanStack DB, and pi.
+outline: [2, 3]
+---
+
+<script setup>
+import EntityOverviewDiagram from '../../src/components/agents-home/EntityOverviewDiagram.vue'
+</script>
+
+# Electric Agents
+
+Electric Agents is **the durable runtime for long-lived agents**. It's a runtime and communication fabric for spawning and scaling collaborative agents on serverless compute, using your existing web and AI&nbsp;frameworks.
+
+Each agent is an **entity** — an addressable, schema-typed unit of state at `/{type}/{id}`. An entity's session and state live on a durable [Electric&nbsp;Stream](/streams/) of events.
+
+Entities **wake** when something happens — a message arrives, a child finishes, state changes, or a scheduled time elapses. When woken, the entity's handler runs. It can configure an LLM agent loop, update state, spawn children, and coordinate with other entities.
+
+Every step — runs, tool calls, text deltas, state changes — is appended to the entity's stream as it happens. Agents scale to zero and survive restarts. Any session can be replayed or [forked](/blog/2026/04/15/fork-branching-for-durable-streams) from any point, and observed in real time by any number of users and entities, both inside the system and from external apps.
+
+<EntityOverviewDiagram />
+
+Start with the [Quickstart](/docs/agents/quickstart) to run the built-in `horton` agent and connect your own app in a few minutes. The [Usage overview](/docs/agents/usage/overview) summarises the full developer surface in a single page.
+
+## How it works
+
+The runtime SDK is a layer over three foundations:
+
+- **[Electric&nbsp;Streams](/streams/)** — durable, ordered event log per entity.
+- **[TanStack&nbsp;DB](https://tanstack.com/db)** — typed local reads and writes via collections.
+- **Mario Zechner's [pi](https://github.com/badlogic/pi-mono) toolkit** — `pi-ai` (unified multi-provider LLM API) and `pi-agent-core` (agent runtime) for the LLM agent loop.
+
+**One stream per entity.** The runtime projects that stream into a typed local DB of collections — an `EntityStreamDB`. Inside a handler, that DB is `ctx.db`: writes go through `ctx.db.actions` (which append events to the stream), reads come from `ctx.db.collections`. The runtime ships [built-in collections](#built-in-collections) for runs, tool calls, text deltas, errors, inbox, and more, and you add your own typed [state](#state) collections per entity type.
+
+**Inside a handler.** When a handler calls `ctx.useAgent()`, the runtime configures the agent on its behalf and routes every step — model call, text delta, tool invocation, error — through the same projection, so the agent loop becomes durable events on the entity's stream.
+
+**Outside the handler.** Any app or other entity can call [`createAgentsClient().observe(entity('/type/id'))`](/docs/agents/usage/clients-and-react) to load an entity's stream into a local DB and react to changes in real time, with the same schemas and types as the handler.
+
+## Entities
+
+Use entities to model anything long-lived and addressable — an agent session, a chat thread, a research job, a coordinator, a worker. You register a **type** with [`registry.define()`](/docs/agents/reference/entity-registry) and spawn **instances** at `/{type}/{id}`. Each instance has its own state, handler, and event stream. See [Defining entities](/docs/agents/usage/defining-entities).
+
+```ts
+const registry = createEntityRegistry()
+
+registry.define('assistant', {
+  description: 'A general-purpose AI assistant',
+  async handler(ctx) {
+    // ...
+  },
+})
+```
+
+## Handlers
+
+The function that runs when an entity wakes. Receives a [`HandlerContext`](/docs/agents/reference/handler-context) (`ctx`) and a [`WakeEvent`](/docs/agents/reference/wake-event) (`wake`). The handler decides how to respond: configure an agent, update state, spawn children, or any combination. See [Writing handlers](/docs/agents/usage/writing-handlers).
+
+```ts
+registry.define('support', {
+  async handler(ctx, wake) {
+    if (wake.type === 'message_received') {
+      ctx.useAgent({
+        systemPrompt: 'You are a support agent.',
+        model: 'claude-sonnet-4-5-20250929',
+        tools: [...ctx.electricTools, searchKbTool],
+      })
+      await ctx.agent.run()
+    }
+  },
+})
+```
+
+## Wakes
+
+Events that trigger a handler invocation. Wake sources include incoming messages, child completion, state changes, and timers (scheduled sends, cron, timeouts). The [`WakeEvent`](/docs/agents/reference/wake-event) tells the handler why it was woken. See [Waking entities](/docs/agents/usage/waking-entities).
+
+```ts
+async handler(ctx, wake) {
+  // wake.type — "message_received", "wake", etc.
+  // wake.source — who triggered the wake
+  // wake.payload — message content or wake data
+
+  if (wake.type === "message_received") {
+    const userMessage = wake.payload
+    // handle incoming message
+  }
+}
+```
+
+## State
+
+Custom persistent collections on the entity. Defined as part of the [entity definition](/docs/agents/reference/entity-definition) and accessed through `ctx.db` alongside the [built-in collections](#built-in-collections). State is local to the entity, typed, and survives restarts. Use it for things that belong to the entity but aren't part of the agent's event stream — an order's items, a research job's findings, a chat session's TODOs. See [Managing state](/docs/agents/usage/managing-state).
+
+```ts
+registry.define('tracker', {
+  state: {
+    items: {
+      schema: z.object({
+        key: z.string(),
+        name: z.string(),
+        done: z.boolean(),
+      }),
+      primaryKey: 'key',
+    },
+  },
+  async handler(ctx) {
+    // read
+    const item = ctx.db.collections.items.get('item-1')
+
+    // write
+    ctx.db.actions.items_insert({
+      row: { key: 'item-2', name: 'New', done: false },
+    })
+  },
+})
+```
+
+## Agent loop
+
+The core pattern is [`ctx.useAgent()`](/docs/agents/reference/agent-config) followed by `ctx.agent.run()`. This runs the LLM in a loop — it generates text, calls tools, and continues until it has nothing left to do. All activity is automatically persisted to the entity's stream. See [Configuring the agent](/docs/agents/usage/configuring-the-agent).
+
+```ts
+ctx.useAgent({
+  systemPrompt: 'You are a helpful assistant.',
+  model: 'claude-sonnet-4-5-20250929',
+  tools: [...ctx.electricTools, myCustomTool],
+})
+
+await ctx.agent.run()
+```
+
+## Tools
+
+Functions the LLM can call during the agent loop. Each tool has a name, description, parameters (defined with [TypeBox](https://github.com/sinclairzx81/typebox) or any [Standard Schema](https://standardschema.dev) validator), and an execute function. Tools run in the handler's context and have access to the entity's state and coordination primitives. See [Defining tools](/docs/agents/usage/defining-tools) and the [`AgentTool` reference](/docs/agents/reference/agent-tool).
+
+```ts
+const searchKbTool: AgentTool = {
+  name: 'search_kb',
+  label: 'Search knowledge base',
+  description: 'Search the knowledge base',
+  parameters: Type.Object({
+    query: Type.String({ description: 'Search query' }),
+  }),
+  execute: async (_toolCallId, params) => {
+    const { query } = params as { query: string }
+    const results = await searchKnowledgeBase(query)
+    return {
+      content: [{ type: 'text', text: JSON.stringify(results) }],
+      details: {},
+    }
+  },
+}
+```
+
+## Coordination
+
+Entities interact through structured primitives. An entity can `spawn` children, `observe` other entities, `send` messages, and [share state](/docs/agents/usage/shared-state). These operations are all durable — they survive restarts and are tracked in the event stream. See [Spawning and coordinating](/docs/agents/usage/spawning-and-coordinating).
+
+```ts
+async handler(ctx) {
+  // spawn a child entity — wake parent when it finishes
+  const child = await ctx.spawn(
+    "worker",
+    "task-1",
+    {
+      systemPrompt: "Analyse the report",
+      tools: ["read"],
+    },
+    { initialMessage: "Find the top three issues", wake: "runFinished" }
+  )
+
+  // send a message to another entity
+  ctx.send("/notify/alerts", { level: "info", text: "Task started" })
+
+  // observe another entity's state changes
+  await ctx.observe(entity("/order/99"), {
+    wake: { on: "change", collections: ["status"] },
+  })
+}
+```
+
+## Built-in collections
+
+Every entity automatically has collections for runs, steps, texts, tool calls, errors, inbox, and more. These are populated by the runtime as the agent operates and give you live observability into every step of the agent loop — useful for chat UIs, debugging tools, dashboards, and analytics. Query them from the handler or observe them externally. See the [Built-in collections reference](/docs/agents/reference/built-in-collections).
+
+```ts
+// from inside a handler
+const allRuns = ctx.db.collections.runs.toArray
+const lastError = ctx.db.collections.errors.toArray.at(-1)
+
+// from outside — load an entity's stream into a local DB
+const client = createAgentsClient({ baseUrl: 'http://localhost:4437' })
+const db = await client.observe(entity('/support/ticket-42'))
+console.log(db.collections.texts.toArray)
+```
+
+## Next steps
+
+- [Quickstart](/docs/agents/quickstart) — run the built-in `horton` agent and connect your own app.
+- [Usage overview](/docs/agents/usage/overview) — the full developer surface on one page.
+- [Defining entities](/docs/agents/usage/defining-entities) — entity types, schemas, and configuration.
+- [Writing handlers](/docs/agents/usage/writing-handlers) — handler lifecycle and the `ctx` API.
+- [Configuring the agent](/docs/agents/usage/configuring-the-agent) — `useAgent`, models, tools, and streaming.
+- [Spawning & coordinating](/docs/agents/usage/spawning-and-coordinating) — multi-entity topologies and shared state.
+- [Built-in agents](/docs/agents/entities/agents/horton) — Horton and Worker, the agents that ship with the runtime.
+- [Examples](/docs/agents/examples/playground) — pattern walkthroughs and demo apps.

--- a/packages/agents/docs/quickstart.md
+++ b/packages/agents/docs/quickstart.md
@@ -1,0 +1,201 @@
+---
+title: Quickstart
+titleTemplate: '... - Electric Agents'
+description: >-
+  Run the Electric Agents runtime and the built-in Horton assistant with a single CLI command, then connect from the web UI or define your own entities.
+outline: [2, 3]
+---
+
+# Quickstart
+
+One command starts the Electric Agents runtime, the web UI, and a local [Horton](./entities/agents/horton) assistant you can chat with right away. From there, define your own [entities](./usage/defining-entities) in your own app.
+
+```sh
+npx electric-ax agents quickstart
+```
+
+## What you'll need
+
+- **Node.js 18+**.
+- **[Docker](https://docs.docker.com/get-docker/)**. The runtime server, Postgres, and Electric run as containers.
+- **An [Anthropic API key](https://console.anthropic.com/settings/keys)**. Used by the built-in Horton agent.
+- _(Optional)_ A **[Brave Search API key](https://brave.com/search/api/)** if you want Horton to be able to search the web.
+
+## Set your API key
+
+Either export it in your shell:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Or persist it in a `.env` file in the directory you run the CLI from (this creates or overwrites `.env` in the current directory):
+
+```sh
+cat <<'EOF' > .env
+ANTHROPIC_API_KEY=sk-ant-...
+# BRAVE_SEARCH_API_KEY=BS...
+EOF
+```
+
+The CLI also accepts `--anthropic-api-key <key>` if you'd rather pass it inline.
+
+## Start the runtime
+
+```sh
+npx electric-ax agents quickstart
+```
+
+This:
+
+1. Starts Postgres, Electric, and the Electric Agents runtime server in Docker (the runtime serves both the API and the web UI on `http://localhost:4437`).
+2. Starts a built-in **Horton** runtime in the foreground that registers the `horton` and `worker` entity types.
+3. Prints onboarding commands you can copy into a second terminal.
+
+Leave this terminal running. Press `Ctrl-C` to stop the built-in Horton runtime — the runtime server containers keep running in the background until you call [`electric agents stop`](#stop-the-dev-environment).
+
+## Chat with Horton
+
+### From the web UI
+
+Open [http://localhost:4437](http://localhost:4437). Spawn a `horton` entity from the dashboard and send it a message — its timeline updates live as the agent thinks, calls tools, and responds.
+
+### From the CLI
+
+In a separate terminal:
+
+```sh
+npx electric-ax agents spawn /horton/onboarding
+npx electric-ax agents send /horton/onboarding 'Walk me through Electric Agents'
+npx electric-ax agents observe /horton/onboarding
+```
+
+- `spawn` creates a new entity instance at the given path.
+- `send` delivers a message to the entity's inbox, waking its handler.
+- `observe` streams the entity's events to your terminal in real time, with reasoning, tool calls, and text deltas rendered inline.
+
+See the [CLI reference](./reference/cli) for the full command surface.
+
+## Define your own entity types
+
+Once you're chatting with Horton, the next step is to define your own entity types in your own app. Your app is just a process that registers entity types with the runtime server and receives webhook callbacks when they wake.
+
+### 1. Install the runtime SDK
+
+```sh
+mkdir my-agents-app && cd my-agents-app
+npm init -y
+npm install @electric-ax/agents-runtime
+npm install --save-dev tsx
+```
+
+### 2. Create a server
+
+Create `server.ts`:
+
+```ts
+import http from 'node:http'
+import {
+  createEntityRegistry,
+  createRuntimeHandler,
+} from '@electric-ax/agents-runtime'
+
+const ELECTRIC_AGENTS_URL =
+  process.env.ELECTRIC_AGENTS_URL ?? 'http://localhost:4437'
+const PORT = Number(process.env.PORT ?? 3000)
+const SERVE_URL = process.env.SERVE_URL ?? `http://localhost:${PORT}`
+
+const registry = createEntityRegistry()
+
+registry.define('assistant', {
+  description: 'A general-purpose AI assistant',
+  async handler(ctx) {
+    ctx.useAgent({
+      systemPrompt: 'You are a helpful assistant.',
+      model: 'claude-sonnet-4-5-20250929',
+      tools: [...ctx.electricTools],
+    })
+    await ctx.agent.run()
+  },
+})
+
+const runtime = createRuntimeHandler({
+  baseUrl: ELECTRIC_AGENTS_URL,
+  serveEndpoint: `${SERVE_URL}/webhook`,
+  registry,
+})
+
+const server = http.createServer(async (req, res) => {
+  if (req.url === '/webhook' && req.method === 'POST') {
+    await runtime.onEnter(req, res)
+    return
+  }
+  res.writeHead(404)
+  res.end()
+})
+
+server.listen(PORT, async () => {
+  await runtime.registerTypes()
+  console.log(`App server ready on port ${PORT}`)
+})
+```
+
+This does four things:
+
+1. **Defines an entity type** called `assistant` with a handler that configures and runs an LLM agent.
+2. **Creates a runtime handler** that connects to the runtime server.
+3. **Starts an HTTP server** to receive webhook callbacks from the runtime.
+4. **Registers entity types** with the runtime server on startup.
+
+See [App setup](./usage/app-setup) for the full `createRuntimeHandler` configuration.
+
+### 3. Run your app
+
+With the runtime server already running (from `electric agents quickstart` or `electric agents start`), start your app:
+
+```sh
+npx tsx server.ts
+```
+
+Your handler calls `ctx.useAgent()` in this process, so make sure `ANTHROPIC_API_KEY` is exported in this shell (or copy your `.env` into `my-agents-app`).
+
+### 4. Interact with your entity
+
+Spawn an instance, send it a message, and observe the timeline:
+
+```sh
+npx electric-ax agents spawn /assistant/my-assistant
+npx electric-ax agents send /assistant/my-assistant 'Hello!'
+npx electric-ax agents observe /assistant/my-assistant
+```
+
+Or open the web UI at `http://localhost:4437` and pick `/assistant/my-assistant` from the entity list.
+
+## Stop the dev environment
+
+`Ctrl-C` in the quickstart terminal stops the built-in Horton runtime. The runtime server containers keep running. To stop them:
+
+```sh
+npx electric-ax agents stop                  # stop containers, keep data
+npx electric-ax agents stop --remove-volumes # stop containers and wipe data
+```
+
+## Run pieces independently
+
+`quickstart` runs `start` then `start-builtin` for you. Run them yourself if you want the runtime server up across multiple sessions, or to run your own agent process instead of the built-ins:
+
+```sh
+npx electric-ax agents start          # runtime server + UI (background, Docker)
+npx electric-ax agents start-builtin  # built-in Horton + worker (foreground)
+```
+
+See the [CLI reference](./reference/cli#start) for the full set of commands.
+
+## Next steps
+
+- [Overview](./) — the mental model behind entities, handlers, and wakes.
+- [Usage overview](./usage/overview) — the full developer surface on one page.
+- [Defining entities](./usage/defining-entities) — entity types, schemas, and configuration.
+- [Writing handlers](./usage/writing-handlers) — handler lifecycle and the `ctx` API.
+- [Configuring the agent](./usage/configuring-the-agent) — `useAgent`, models, tools, and streaming.
+- [Built-in agents](./entities/agents/horton) — Horton and Worker, the agents that ship with the runtime.

--- a/packages/agents/docs/reference/agent-config.md
+++ b/packages/agents/docs/reference/agent-config.md
@@ -1,0 +1,82 @@
+---
+title: AgentConfig
+titleTemplate: '... - Electric Agents'
+description: >-
+  API reference for AgentConfig: system prompt, model, tools, streaming, and test responses.
+outline: [2, 3]
+---
+
+# AgentConfig
+
+Configuration for the LLM agent loop. Passed to `ctx.useAgent()`.
+
+**Source:** `@electric-ax/agents-runtime`
+
+```ts
+interface AgentConfig {
+  systemPrompt: string
+  model: string | Model<any>
+  provider?: KnownProvider
+  tools: AgentTool[]
+  streamFn?: StreamFn
+  testResponses?: string[] | TestResponseFn
+}
+```
+
+## Fields
+
+| Field           | Type                         | Required | Description                                                                                                                                  |
+| --------------- | ---------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `systemPrompt`  | `string`                     | Yes      | System prompt sent to the LLM on each step.                                                                                                  |
+| `model`         | `string \| Model<any>`       | Yes      | Model identifier (e.g. `"claude-sonnet-4-5-20250929"`) or a resolved model object.                                                           |
+| `provider`      | `KnownProvider`              | No       | Provider to use when `model` is a string. Defaults to `"anthropic"`.                                                                         |
+| `tools`         | `AgentTool[]`                | Yes      | Tools available to the LLM. Spread `ctx.electricTools` when your runtime host provides runtime-level tools. See [`AgentTool`](./agent-tool). |
+| `streamFn`      | `StreamFn`                   | No       | Optional streaming callback passed to the underlying agent.                                                                                  |
+| `testResponses` | `string[] \| TestResponseFn` | No       | Mock LLM responses for testing. When set, no real LLM calls are made.                                                                        |
+
+## TestResponseFn
+
+```ts
+type TestResponseFn = (
+  message: string,
+  bridge: OutboundBridgeHandle
+) => Promise<string | undefined>
+```
+
+A function that receives the current trigger message and an outbound bridge, then returns a mock response string. Returning `undefined` emits no automatic text response.
+
+## AgentHandle
+
+Returned by `ctx.useAgent()`. Also available as `ctx.agent`.
+
+```ts
+interface AgentHandle {
+  run(input?: string): Promise<AgentRunResult>
+}
+```
+
+| Method        | Return Type               | Description                                                                  |
+| ------------- | ------------------------- | ---------------------------------------------------------------------------- |
+| `run(input?)` | `Promise<AgentRunResult>` | Execute the agent loop. Runs until the LLM stops or all tool calls complete. |
+
+**Parameters:**
+
+| Parameter | Type     | Required | Description                                                                      |
+| --------- | -------- | -------- | -------------------------------------------------------------------------------- |
+| `input`   | `string` | No       | Optional user message appended to the conversation before the agent loop starts. |
+
+## AgentRunResult
+
+```ts
+interface AgentRunResult {
+  writes: ChangeEvent[]
+  toolCalls: Array<{ name: string; args: unknown; result: unknown }>
+  usage: { tokens: number; duration: number }
+}
+```
+
+| Field       | Type                                   | Description                                                                             |
+| ----------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
+| `writes`    | `ChangeEvent[]`                        | Currently returned as an empty array placeholder.                                       |
+| `toolCalls` | `Array<{ name, args, result }>`        | Currently returned as an empty array placeholder.                                       |
+| `usage`     | `{ tokens: number; duration: number }` | Currently returned as `{ tokens: 0, duration: 0 }` until usage aggregation is wired in. |

--- a/packages/agents/docs/reference/agent-tool.md
+++ b/packages/agents/docs/reference/agent-tool.md
@@ -1,0 +1,58 @@
+---
+title: AgentTool
+titleTemplate: '... - Electric Agents'
+description: >-
+  Interface reference for AgentTool: name, description, TypeBox parameters schema, and execute function.
+outline: [2, 3]
+---
+
+# AgentTool
+
+Interface for tools the LLM can call during the agent loop. Re-exported from [`@mariozechner/pi-agent-core`](https://github.com/badlogic/pi-mono).
+
+**Source:** `@electric-ax/agents-runtime` (re-export)
+
+```ts
+interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any> {
+  name: string
+  label: string
+  description: string
+  parameters: TParameters
+  execute: (
+    toolCallId: string,
+    params: Static<TParameters>,
+    signal?: AbortSignal,
+    onUpdate?: AgentToolUpdateCallback<TDetails>
+  ) => Promise<AgentToolResult<TDetails>>
+}
+```
+
+## Fields
+
+| Field         | Type                                                                   | Required | Description                                                          |
+| ------------- | ---------------------------------------------------------------------- | -------- | -------------------------------------------------------------------- |
+| `name`        | `string`                                                               | Yes      | Unique tool name used in LLM function calling.                       |
+| `label`       | `string`                                                               | Yes      | Human-readable label for display.                                    |
+| `description` | `string`                                                               | Yes      | Description sent to the LLM to explain when and how to use the tool. |
+| `parameters`  | `TSchema`                                                              | Yes      | TypeBox JSON Schema defining the tool's parameters.                  |
+| `execute`     | `(toolCallId, params, signal?, onUpdate?) => Promise<AgentToolResult>` | Yes      | Function called when the LLM invokes the tool.                       |
+
+Parameters are defined using [TypeBox](https://github.com/sinclairzx81/typebox) (`@sinclair/typebox`). The schema is used for LLM function calling and argument validation.
+
+## AgentToolResult
+
+```ts
+interface AgentToolResult<T = any> {
+  content: (TextContent | ImageContent)[]
+  details: T
+}
+```
+
+| Field     | Type                              | Description                                                              |
+| --------- | --------------------------------- | ------------------------------------------------------------------------ |
+| `content` | `(TextContent \| ImageContent)[]` | Content returned to the LLM. Typically `{ type: 'text', text: string }`. |
+| `details` | `T`                               | Arbitrary metadata. Must be provided (use `{}` if no details).           |
+
+::: warning
+Every tool must return a `details` property. Omitting it causes a type error.
+:::

--- a/packages/agents/docs/reference/built-in-collections.md
+++ b/packages/agents/docs/reference/built-in-collections.md
@@ -1,0 +1,334 @@
+---
+title: Built-in collections
+titleTemplate: '... - Electric Agents'
+description: >-
+  Reference for the 17 runtime-managed collections: runs, steps, texts, toolCalls, inbox, errors, and more.
+outline: [2, 3]
+---
+
+# Built-in collections
+
+Every entity automatically has these 17 collections, populated by the runtime as the agent operates. Custom state collections defined in `EntityDefinition.state` are merged with these at creation time.
+
+**Source:** `@electric-ax/agents-runtime` -- `entity-schema.ts`
+
+## Collection summary
+
+| Collection         | Event Type         | Interface          | Description                  |
+| ------------------ | ------------------ | ------------------ | ---------------------------- |
+| `runs`             | `run`              | `Run`              | Agent run lifecycle          |
+| `steps`            | `step`             | `Step`             | LLM call step lifecycle      |
+| `texts`            | `text`             | `Text`             | Text message lifecycle       |
+| `textDeltas`       | `text_delta`       | `TextDelta`        | Incremental text content     |
+| `toolCalls`        | `tool_call`        | `ToolCall`         | Tool call lifecycle          |
+| `reasoning`        | `reasoning`        | `Reasoning`        | Reasoning block lifecycle    |
+| `errors`           | `error`            | `ErrorEvent`       | Diagnostic errors            |
+| `inbox`            | `message_received` | `MessageReceived`  | Inbound messages             |
+| `wakes`            | `wake`             | `WakeEntry`        | Wake delivery records        |
+| `entityCreated`    | `entity_created`   | `EntityCreated`    | Entity bootstrap metadata    |
+| `entityStopped`    | `entity_stopped`   | `EntityStopped`    | Entity shutdown signal       |
+| `childStatus`      | `child_status`     | `ChildStatusEntry` | Child/observed entity status |
+| `tags`             | `tags`             | `TagEntry`         | Entity tags                  |
+| `contextInserted`  | `context_inserted` | `ContextInserted`  | Context additions            |
+| `contextRemoved`   | `context_removed`  | `ContextRemoved`   | Context removals             |
+| `manifests`        | `manifest`         | `Manifest`         | Durable resource manifests   |
+| `replayWatermarks` | `replay_watermark` | `ReplayWatermark`  | Replay progress tracking     |
+
+All collections use `key` as the primary key.
+
+## Type definitions
+
+### Run
+
+```ts
+interface Run {
+  key: string
+  status: 'started' | 'completed' | 'failed'
+  finish_reason?: string
+}
+```
+
+### Step
+
+```ts
+interface Step {
+  key: string
+  run_id?: string
+  step_number: number
+  status: 'started' | 'completed'
+  finish_reason?: string
+  model_provider?: string
+  model_id?: string
+  duration_ms?: number
+}
+```
+
+### Text
+
+```ts
+interface Text {
+  key: string
+  run_id?: string
+  status: 'streaming' | 'completed'
+}
+```
+
+### TextDelta
+
+```ts
+interface TextDelta {
+  key: string
+  text_id: string
+  run_id: string
+  delta: string
+}
+```
+
+### ToolCall
+
+```ts
+interface ToolCall {
+  key: string
+  run_id?: string
+  tool_name: string
+  status: 'started' | 'args_complete' | 'executing' | 'completed' | 'failed'
+  args?: unknown
+  result?: unknown
+  error?: string
+  duration_ms?: number
+}
+```
+
+### Reasoning
+
+```ts
+interface Reasoning {
+  key: string
+  status: 'streaming' | 'completed'
+}
+```
+
+### ErrorEvent
+
+```ts
+interface ErrorEvent {
+  key: string
+  error_code: string
+  message: string
+  run_id?: string
+  step_id?: string
+  tool_call_id?: string
+}
+```
+
+### MessageReceived
+
+```ts
+interface MessageReceived {
+  key: string
+  from: string
+  payload?: unknown
+  timestamp: string
+  message_type?: string
+}
+```
+
+### WakeEntry
+
+```ts
+interface WakeEntry {
+  key: string
+  timestamp: string
+  source: string
+  timeout: boolean
+  changes: WakeChangeEntry[]
+  finished_child?: WakeFinishedChildEntry
+  other_children?: WakeOtherChildEntry[]
+}
+
+interface WakeChangeEntry {
+  collection: string
+  kind: 'insert' | 'update' | 'delete'
+  key: string
+}
+
+interface WakeFinishedChildEntry {
+  url: string
+  type: string
+  run_status: 'completed' | 'failed'
+  response?: string // concatenated text deltas from the finished run
+  error?: string // error message(s) if run_status is "failed"
+}
+
+interface WakeOtherChildEntry {
+  url: string
+  type: string
+  status: 'spawning' | 'running' | 'idle' | 'stopped'
+}
+```
+
+### EntityCreated
+
+```ts
+interface EntityCreated {
+  key: string
+  entity_type: string
+  timestamp: string
+  args: Record<string, JsonValue>
+  parent_url?: string
+}
+```
+
+### EntityStopped
+
+```ts
+interface EntityStopped {
+  key: string
+  timestamp: string
+  reason?: string
+}
+```
+
+### ChildStatusEntry
+
+```ts
+interface ChildStatusEntry {
+  key: string
+  entity_url: string
+  entity_type: string
+  status: 'spawning' | 'running' | 'idle' | 'stopped'
+}
+```
+
+### TagEntry
+
+```ts
+interface TagEntry {
+  key: string
+  value: string
+}
+```
+
+### ContextInserted
+
+```ts
+interface ContextInserted {
+  key: string
+  id: string
+  name: string
+  attrs: Record<string, string | number | boolean>
+  content: string
+  timestamp: string
+}
+```
+
+### ContextRemoved
+
+```ts
+interface ContextRemoved {
+  key: string
+  id: string
+  name: string
+  timestamp: string
+}
+```
+
+### Manifest
+
+Discriminated union by `kind`:
+
+```ts
+type Manifest =
+  | ManifestChildEntry
+  | ManifestSourceEntry
+  | ManifestSharedStateEntry
+  | ManifestEffectEntry
+  | ManifestContextEntry
+  | ManifestCronScheduleEntry
+  | ManifestFutureSendScheduleEntry
+
+interface ManifestChildEntry {
+  key: string
+  kind: 'child'
+  id: string
+  entity_type: string
+  entity_url: string
+  wake?: WakeConfig
+  observed: boolean
+}
+
+interface ManifestSourceEntry {
+  key: string
+  kind: 'source'
+  sourceType: string
+  sourceRef: string
+  wake?: WakeConfig
+  config: Record<string, unknown>
+}
+
+interface ManifestSharedStateEntry {
+  key: string
+  kind: 'shared-state'
+  id: string
+  mode: 'create' | 'connect'
+  collections: Record<string, { type: string; primaryKey: string }>
+  wake?: WakeConfig
+}
+
+interface ManifestEffectEntry {
+  key: string
+  kind: 'effect'
+  id: string
+  function_ref: string
+  config: unknown
+}
+
+interface ManifestContextEntry {
+  key: string
+  kind: 'context'
+  id: string
+  name: string
+  attrs: Record<string, string | number | boolean>
+  content: string
+  insertedAt: number
+}
+
+interface ManifestCronScheduleEntry {
+  key: string
+  kind: 'schedule'
+  id: string
+  scheduleType: 'cron'
+  expression: string
+  timezone?: string
+  payload?: unknown
+  wake?: WakeConfig
+}
+
+interface ManifestFutureSendScheduleEntry {
+  key: string
+  kind: 'schedule'
+  id: string
+  scheduleType: 'future_send'
+  fireAt: string
+  targetUrl: string
+  payload: unknown
+  producerId: string
+  from?: string
+  messageType?: string
+  status?: 'pending' | 'sent' | 'failed'
+  sentAt?: string
+  failedAt?: string
+  lastError?: string
+}
+```
+
+### ReplayWatermark
+
+```ts
+interface ReplayWatermark {
+  key: string
+  source_id: string
+  offset: string
+  updated_at: string
+}
+```

--- a/packages/agents/docs/reference/cli.md
+++ b/packages/agents/docs/reference/cli.md
@@ -1,0 +1,238 @@
+---
+title: CLI
+titleTemplate: '... - Electric Agents'
+description: >-
+  Command reference for the Electric Agents CLI: spawn, send, observe, inspect, list, and manage entities.
+outline: [2, 3]
+---
+
+# CLI reference
+
+The Electric Agents CLI manages entity types and entities. Install it from `electric-ax`, then use the `electric agents` command. You can also run one-off commands with `npx electric-ax agents ...`.
+
+```bash
+npm install -g electric-ax
+```
+
+## Environment variables
+
+| Variable                          | Default                 | Purpose                                       |
+| --------------------------------- | ----------------------- | --------------------------------------------- |
+| `ELECTRIC_AGENTS_URL`             | `http://localhost:4437` | Server URL for entity commands and built-ins  |
+| `ELECTRIC_AGENTS_IDENTITY`        | `user@hostname`         | Sender identity for messages                  |
+| `ELECTRIC_AGENTS_PORT`            | `4437`                  | Port used by `start` / `quickstart`           |
+| `ELECTRIC_AGENTS_BUILTIN_PORT`    | `4448`                  | Webhook port for `start-builtin`              |
+| `ELECTRIC_AGENTS_COMPOSE_PROJECT` | `electric-agents`       | Docker Compose project name                   |
+| `ANTHROPIC_API_KEY`               | -                       | Required for `start-builtin` and `quickstart` |
+
+## Commands
+
+### <span class="cli-command"><code>types</code></span> {#types}
+
+List registered entity types.
+
+```bash
+electric agents types
+```
+
+### <span class="cli-command"><code>types inspect &lt;name&gt;</code></span> {#types-inspect-name}
+
+Show entity type details. Outputs JSON.
+
+```bash
+electric agents types inspect chat
+```
+
+### <span class="cli-command"><code>types delete &lt;name&gt;</code></span> {#types-delete-name}
+
+Delete an entity type registration.
+
+```bash
+electric agents types delete chat
+```
+
+### <span class="cli-command"><code>spawn &lt;url-path&gt; [--args &lt;json&gt;]</code></span> {#spawn-url-path-args-json}
+
+Spawn an entity. URL path format: `/<type>/<id>`.
+
+```bash
+electric agents spawn /chat/my-convo
+electric agents spawn /chat/my-convo --args '{"topic": "AI safety"}'
+```
+
+| Option          | Description                    |
+| --------------- | ------------------------------ |
+| `--args <json>` | Spawn arguments as JSON object |
+
+### <span class="cli-command"><code>send &lt;url&gt; &lt;message...&gt; [--type &lt;msg-type&gt;] [--json]</code></span> {#send-url-message-type-json}
+
+Send a message to an entity. By default, wraps the message string as `{ text: "..." }`. Use `--json` to send raw JSON.
+
+```bash
+electric agents send /chat/my-convo 'Hello!'
+electric agents send /chat/my-convo '{"custom": "payload"}' --json
+electric agents send /chat/my-convo 'alert' --type warning
+```
+
+| Option              | Description                                                      |
+| ------------------- | ---------------------------------------------------------------- |
+| `--type <msg-type>` | Set the message type field                                       |
+| `--json`            | Parse message argument as JSON instead of wrapping as `{ text }` |
+
+### <span class="cli-command"><code>observe &lt;url&gt; [--from &lt;offset&gt;]</code></span> {#observe-url-from-offset}
+
+Stream entity events in real-time. Requires an interactive terminal.
+
+```bash
+electric agents observe /chat/my-convo
+electric agents observe /chat/my-convo --from 0
+```
+
+| Option            | Description                      |
+| ----------------- | -------------------------------- |
+| `--from <offset>` | Start streaming from this offset |
+
+### <span class="cli-command"><code>inspect &lt;url&gt;</code></span> {#inspect-url}
+
+Show entity details. Outputs JSON.
+
+```bash
+electric agents inspect /chat/my-convo
+```
+
+### <span class="cli-command"><code>ps [--type &lt;type&gt;] [--status &lt;status&gt;] [--parent &lt;url&gt;]</code></span> {#ps-type-status-parent}
+
+List entities with optional filters.
+
+```bash
+electric agents ps
+electric agents ps --type chat --status running
+electric agents ps --parent /manager/my-manager
+```
+
+| Option              | Description                 |
+| ------------------- | --------------------------- |
+| `--type <type>`     | Filter by entity type       |
+| `--status <status>` | Filter by status            |
+| `--parent <url>`    | Filter by parent entity URL |
+
+Output shows `URL`, `STATUS`, `CREATED`, and `LAST ACTIVE` columns with human-readable relative timestamps. Results are sorted by most recently active first.
+
+### <span class="cli-command"><code>kill &lt;url&gt;</code></span> {#kill-url}
+
+Delete an entity.
+
+```bash
+electric agents kill /chat/my-convo
+```
+
+### <span class="cli-command"><code>start</code></span> {#start}
+
+Start the local Electric Agents coordinator server, Postgres, Electric, and UI using Docker Compose.
+
+```bash
+electric agents start
+```
+
+### <span class="cli-command"><code>start-builtin [--anthropic-api-key &lt;key&gt;]</code></span> {#start-builtin}
+
+Start the built-in Horton runtime and register built-in agent types with the coordinator server.
+
+```bash
+electric agents start-builtin --anthropic-api-key sk-ant-...
+```
+
+| Option                      | Description                                      |
+| --------------------------- | ------------------------------------------------ |
+| `--anthropic-api-key <key>` | Anthropic API key for the built-in Horton server |
+
+### <span class="cli-command"><code>quickstart [--anthropic-api-key &lt;key&gt;]</code></span> {#quickstart}
+
+Start the coordinator server, print onboarding commands, and run the built-in agents runtime.
+
+```bash
+electric agents quickstart --anthropic-api-key sk-ant-...
+```
+
+| Option                      | Description                                      |
+| --------------------------- | ------------------------------------------------ |
+| `--anthropic-api-key <key>` | Anthropic API key for the built-in Horton server |
+
+### <span class="cli-command"><code>stop [--remove-volumes]</code></span> {#stop}
+
+Stop the local Electric Agents dev environment.
+
+```bash
+electric agents stop
+electric agents stop --remove-volumes
+```
+
+| Option             | Description                    |
+| ------------------ | ------------------------------ |
+| `--remove-volumes` | Remove Docker volumes as well. |
+
+### <span class="cli-command"><code>completion [action]</code></span> {#completion-action}
+
+Set up shell completions. Without arguments, prints setup instructions.
+
+```bash
+electric agents completion            # Show setup instructions
+electric agents completion install    # Auto-install into your shell init file
+```
+
+**Manual setup** (add to your shell init file):
+
+```bash
+# Bash (~/.bashrc) or Zsh (~/.zshrc)
+eval "$(electric --completion)"
+
+# Fish (~/.config/fish/config.fish)
+electric --completion-fish | source
+```
+
+Completions provide tab-completion for commands, flags, entity types, and entity URLs.
+
+## Programmatic CLI
+
+The `electric-ax` package also exports the Commander program and handler factory used by the binary. Use these APIs for tests, custom wrappers, or embedding the command tree in another tool.
+
+```ts
+import {
+  createElectricCliHandlers,
+  createElectricProgram,
+  getElectricCliEnv,
+  run,
+} from 'electric-ax'
+
+const env = getElectricCliEnv({
+  ELECTRIC_AGENTS_URL: 'http://localhost:4437',
+  ELECTRIC_AGENTS_IDENTITY: 'docs@example.com',
+})
+
+const handlers = createElectricCliHandlers(env, 'electric agents')
+const program = createElectricProgram({
+  env,
+  handlers,
+  commandName: 'electric',
+  commandPrefix: 'electric agents',
+})
+
+await program.parseAsync(['node', 'electric', 'agents', 'types'])
+```
+
+| Export                             | Purpose                                                               |
+| ---------------------------------- | --------------------------------------------------------------------- |
+| `DEFAULT_ELECTRIC_AGENTS_URL`      | Default server URL (`"http://localhost:4437"`).                       |
+| `getElectricCliEnv(env?)`          | Reads `ELECTRIC_AGENTS_URL` and `ELECTRIC_AGENTS_IDENTITY`.           |
+| `createElectricCliHandlers()`      | Creates the default command handlers.                                 |
+| `createElectricProgram()`          | Creates the Commander program.                                        |
+| `resolveCommandPrefix(argv, env?)` | Resolves help text examples for direct or package-manager invocation. |
+| `run(argv?)`                       | Runs the CLI entrypoint.                                              |
+
+The installed binaries are `electric` and `electric-ax`. The package also includes `electric-dev` for development workflows.
+
+<style scoped>
+.cli-command code::before {
+  content: "electric agents ";
+}
+</style>

--- a/packages/agents/docs/reference/entity-definition.md
+++ b/packages/agents/docs/reference/entity-definition.md
@@ -1,0 +1,57 @@
+---
+title: EntityDefinition
+titleTemplate: '... - Electric Agents'
+description: >-
+  Type reference for EntityDefinition: description, state, schemas, and handler function signature.
+outline: [2, 3]
+---
+
+# EntityDefinition
+
+Defines an entity type's schema, state, and handler. Passed to `registry.define()` or `defineEntity()`.
+
+**Source:** `@electric-ax/agents-runtime`
+
+```ts
+interface EntityDefinition {
+  description?: string
+  state?: Record<string, CollectionDefinition>
+  actions?: (
+    collections: Record<string, unknown>
+  ) => Record<string, (...args: unknown[]) => void>
+  creationSchema?: StandardJSONSchemaV1
+  inboxSchemas?: Record<string, StandardJSONSchemaV1>
+  outputSchemas?: Record<string, StandardJSONSchemaV1>
+  handler(ctx: HandlerContext, wake: WakeEvent): void | Promise<void>
+}
+```
+
+## Fields
+
+| Field            | Type                                                 | Required | Description                                                                                                                     |
+| ---------------- | ---------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `description`    | `string`                                             | No       | Human-readable description of the entity type. Used in type registration.                                                       |
+| `state`          | `Record<string, CollectionDefinition>`               | No       | Custom state collections exposed via `ctx.db.actions` (writes) and `ctx.db.collections` (reads).                                |
+| `actions`        | `(collections) => Record<string, (...args) => void>` | No       | Factory for custom non-CRUD actions. Receives TanStack DB collections, returns named action functions exposed on `ctx.actions`. |
+| `creationSchema` | `StandardJSONSchemaV1`                               | No       | JSON Schema for spawn arguments validation.                                                                                     |
+| `inboxSchemas`   | `Record<string, StandardJSONSchemaV1>`               | No       | JSON Schemas for inbound message types, keyed by message type.                                                                  |
+| `outputSchemas`  | `Record<string, StandardJSONSchemaV1>`               | No       | JSON Schemas for output event types. Defaults are provided by the runtime.                                                      |
+| `handler`        | `(ctx, wake) => void \| Promise<void>`               | Yes      | The function invoked on each wake. Receives [`HandlerContext`](./handler-context) and [`WakeEvent`](./wake-event).              |
+
+## CollectionDefinition
+
+Defines a custom state collection.
+
+```ts
+interface CollectionDefinition {
+  schema?: StandardSchemaV1
+  type?: string
+  primaryKey?: string
+}
+```
+
+| Field        | Type               | Default          | Description                                        |
+| ------------ | ------------------ | ---------------- | -------------------------------------------------- |
+| `schema`     | `StandardSchemaV1` | -                | Zod or Standard Schema validator for the row type. |
+| `type`       | `string`           | `"state:{name}"` | Event type string used in the durable stream.      |
+| `primaryKey` | `string`           | `"key"`          | Primary key field name on the row.                 |

--- a/packages/agents/docs/reference/entity-handle.md
+++ b/packages/agents/docs/reference/entity-handle.md
@@ -1,0 +1,63 @@
+---
+title: EntityHandle
+titleTemplate: '... - Electric Agents'
+description: >-
+  API reference for EntityHandle returned by spawn and observe: streams, status, text retrieval, and messaging.
+outline: [2, 3]
+---
+
+# EntityHandle
+
+Handle returned by `ctx.spawn()` and `ctx.observe()`. Provides access to a child or observed entity's stream and status.
+
+**Source:** `@electric-ax/agents-runtime`
+
+```ts
+interface EntityHandle {
+  entityUrl: string
+  type?: string
+  db: EntityStreamDB
+  events: ChangeEvent[]
+  run: Promise<void>
+  text(): Promise<string[]>
+  send(msg: unknown): void
+  status(): ChildStatus | undefined
+}
+```
+
+## Members
+
+| Member      | Type                       | Description                                                                         |
+| ----------- | -------------------------- | ----------------------------------------------------------------------------------- |
+| `entityUrl` | `string`                   | URL path of the entity (e.g. `"/chat/my-child"`).                                   |
+| `type`      | `string \| undefined`      | Entity type name, if known.                                                         |
+| `db`        | `EntityStreamDB`           | The entity's TanStack DB instance for querying its collections.                     |
+| `events`    | `ChangeEvent[]`            | All change events received from this entity's stream.                               |
+| `run`       | `Promise<void>`            | Promise that resolves when the entity's current run completes. Useful with `await`. |
+| `text()`    | `Promise<string[]>`        | Returns all text outputs from the entity's stream.                                  |
+| `send(msg)` | `void`                     | Send a message to this entity.                                                      |
+| `status()`  | `ChildStatus \| undefined` | Current status of the entity, or `undefined` if unknown.                            |
+
+## ChildStatus
+
+```ts
+type ChildStatus = ChildStatusEntry
+```
+
+```ts
+interface ChildStatusEntry {
+  key: string
+  entity_url: string
+  entity_type: string
+  status: 'spawning' | 'running' | 'idle' | 'stopped'
+}
+```
+
+Status values:
+
+| Status     | Description                                                 |
+| ---------- | ----------------------------------------------------------- |
+| `spawning` | Entity creation is in progress.                             |
+| `running`  | Handler is currently executing.                             |
+| `idle`     | Handler has completed; entity is waiting for the next wake. |
+| `stopped`  | Entity has been stopped or deleted.                         |

--- a/packages/agents/docs/reference/entity-registry.md
+++ b/packages/agents/docs/reference/entity-registry.md
@@ -1,0 +1,73 @@
+---
+title: EntityRegistry
+titleTemplate: '... - Electric Agents'
+description: >-
+  API reference for EntityRegistry: define, get, list, and clear entity type registrations.
+outline: [2, 3]
+---
+
+# EntityRegistry
+
+Manages entity type registrations. Create an isolated registry with `createEntityRegistry()`, or use the module-level convenience functions for a shared default registry.
+
+**Source:** `@electric-ax/agents-runtime`
+
+```ts
+class EntityRegistry {
+  define(name: string, definition: EntityDefinition): void
+  get(name: string): EntityTypeEntry | undefined
+  list(): EntityTypeEntry[]
+  clear(): void
+}
+
+function createEntityRegistry(): EntityRegistry
+```
+
+## Methods
+
+| Method                     | Parameters                                     | Return Type                    | Description                                                      |
+| -------------------------- | ---------------------------------------------- | ------------------------------ | ---------------------------------------------------------------- |
+| `define(name, definition)` | `name: string`, `definition: EntityDefinition` | `void`                         | Register an entity type. Throws if `name` is already registered. |
+| `get(name)`                | `name: string`                                 | `EntityTypeEntry \| undefined` | Look up a registered type by name.                               |
+| `list()`                   | -                                              | `EntityTypeEntry[]`            | Return all registered types.                                     |
+| `clear()`                  | -                                              | `void`                         | Remove all registrations.                                        |
+
+## EntityTypeEntry
+
+```ts
+interface EntityTypeEntry {
+  name: string
+  definition: EntityDefinition
+}
+```
+
+| Field        | Type                                      | Description                 |
+| ------------ | ----------------------------------------- | --------------------------- |
+| `name`       | `string`                                  | The registered type name.   |
+| `definition` | [`EntityDefinition`](./entity-definition) | The full entity definition. |
+
+## Module-level functions
+
+These operate on a shared default registry. Use them when you do not need isolated registries.
+
+```ts
+function defineEntity(name: string, definition: EntityDefinition): void
+
+function getEntityType(name: string): EntityTypeEntry | undefined
+
+function listEntityTypes(): EntityTypeEntry[]
+
+function clearRegistry(): void
+
+function resolveDefine(
+  registry?: EntityRegistry
+): (name: string, definition: EntityDefinition) => void
+```
+
+| Function                         | Description                                                                                                                             |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `defineEntity(name, definition)` | Register a type on the default registry.                                                                                                |
+| `getEntityType(name)`            | Look up a type on the default registry.                                                                                                 |
+| `listEntityTypes()`              | List all types on the default registry.                                                                                                 |
+| `clearRegistry()`                | Clear the default registry.                                                                                                             |
+| `resolveDefine(registry?)`       | Returns `registry.define` if a registry is provided, otherwise `defineEntity`. Convenience for code that optionally accepts a registry. |

--- a/packages/agents/docs/reference/handler-context.md
+++ b/packages/agents/docs/reference/handler-context.md
@@ -1,0 +1,108 @@
+---
+title: HandlerContext
+titleTemplate: '... - Electric Agents'
+description: >-
+  API reference for HandlerContext: state, coordination, agent configuration, and execution control.
+outline: [2, 3]
+---
+
+# HandlerContext
+
+The handler context is passed as the first argument to every entity handler. It provides access to state, coordination primitives, and agent configuration.
+
+**Source:** `@electric-ax/agents-runtime`
+
+```ts
+interface HandlerContext<TState extends StateProxy = StateProxy> {
+  firstWake: boolean
+  tags: Readonly<EntityTags>
+  entityUrl: string
+  entityType: string
+  args: Readonly<Record<string, unknown>>
+  db: EntityStreamDBWithActions
+  state: TState
+  events: Array<ChangeEvent>
+  actions: Record<string, (...args: unknown[]) => unknown>
+  electricTools: AgentTool[]
+  useAgent(config: AgentConfig): AgentHandle
+  useContext(config: UseContextConfig): void
+  timelineMessages(opts?: TimelineProjectionOpts): Array<TimestampedMessage>
+  insertContext(id: string, entry: ContextEntryInput): void
+  removeContext(id: string): void
+  getContext(id: string): ContextEntry | undefined
+  listContext(): Array<ContextEntry>
+  agent: AgentHandle
+  spawn(
+    type: string,
+    id: string,
+    args?: Record<string, unknown>,
+    opts?: {
+      initialMessage?: unknown
+      wake?: Wake
+      tags?: Record<string, string>
+      observe?: boolean
+    }
+  ): Promise<EntityHandle>
+  observe(
+    source: ObservationSource & { sourceType: 'entity' },
+    opts?: { wake?: Wake }
+  ): Promise<EntityHandle>
+  observe(
+    source: ObservationSource & { sourceType: 'db' },
+    opts?: { wake?: Wake }
+  ): Promise<SharedStateHandle & ObservationHandle>
+  observe(
+    source: ObservationSource,
+    opts?: { wake?: Wake }
+  ): Promise<ObservationHandle>
+  mkdb<T extends SharedStateSchemaMap>(
+    id: string,
+    schema: T
+  ): SharedStateHandle<T>
+  send(
+    entityUrl: string,
+    payload: unknown,
+    opts?: { type?: string; afterMs?: number }
+  ): void
+  setTag(key: string, value: string): Promise<void>
+  removeTag(key: string): Promise<void>
+  sleep(): void
+}
+```
+
+> **Tip:** Use the helper functions `entity()`, `cron()`, `entities()`, and `db()` from `@electric-ax/agents-runtime` to construct `ObservationSource` values for `observe()`.
+
+## Properties
+
+| Property        | Type                                              | Description                                                                                                                                   |
+| --------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `firstWake`     | `boolean`                                         | `true` on the entity's first-ever handler invocation.                                                                                         |
+| `tags`          | `Readonly<EntityTags>`                            | Entity tags — key/value metadata associated with this entity.                                                                                 |
+| `entityUrl`     | `string`                                          | URL path of this entity (e.g. `"/chat/my-convo"`).                                                                                            |
+| `entityType`    | `string`                                          | Registered type name (e.g. `"chat"`).                                                                                                         |
+| `args`          | `Readonly<Record<string, unknown>>`               | Spawn arguments passed when the entity was created.                                                                                           |
+| `db`            | `EntityStreamDBWithActions`                       | The entity's TanStack DB instance with registered actions.                                                                                    |
+| `state`         | `TState`                                          | Proxy object keyed by collection name. Each property is a [`StateCollectionProxy`](./state-collection-proxy).                                 |
+| `events`        | `Array<ChangeEvent>`                              | Change events that triggered this wake.                                                                                                       |
+| `actions`       | `Record<string, (...args: unknown[]) => unknown>` | Custom non-CRUD actions from the entity definition's `actions` factory. Auto-generated CRUD actions live on `ctx.db.actions` and `ctx.state`. |
+| `electricTools` | `AgentTool[]`                                     | Host-provided runtime-level tools to spread into agent config when needed. May be empty.                                                      |
+
+## Methods
+
+| Method                            | Return Type                                                       | Description                                                                                                                                                                                                                                |
+| --------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `useAgent(config)`                | `AgentHandle`                                                     | Configure the LLM agent. Must be called before `agent.run()`. See [`AgentConfig`](./agent-config).                                                                                                                                         |
+| `useContext(config)`              | `void`                                                            | Declare context sources with token budgets and cache tiers for the agent's context window. See [Context composition](/docs/agents/usage/context-composition).                                                                              |
+| `timelineMessages(opts?)`         | `Array<TimestampedMessage>`                                       | Project the entity timeline into an ordered array of LLM messages. Typically used as the `content` function of a volatile source. See [Context composition](/docs/agents/usage/context-composition#timelinemessages).                      |
+| `insertContext(id, entry)`        | `void`                                                            | Insert a durable context entry. Persists across wakes. Inserting with an existing `id` replaces the previous entry. See [Context entries](/docs/agents/usage/context-composition#context-entries).                                         |
+| `removeContext(id)`               | `void`                                                            | Remove a context entry by id.                                                                                                                                                                                                              |
+| `getContext(id)`                  | `ContextEntry \| undefined`                                       | Get a context entry by id, or `undefined` if not found.                                                                                                                                                                                    |
+| `listContext()`                   | `Array<ContextEntry>`                                             | List all context entries.                                                                                                                                                                                                                  |
+| `agent.run(input?)`               | `Promise<AgentRunResult>`                                         | Run the configured agent loop. Optional `input` string is appended as a user message before the loop starts.                                                                                                                               |
+| `spawn(type, id, args?, opts?)`   | `Promise<EntityHandle>`                                           | Spawn a child entity. `opts` accepts `tags`, `observe`, `initialMessage`, and `wake`. See [`EntityHandle`](./entity-handle).                                                                                                               |
+| `observe(source, opts?)`          | `Promise<EntityHandle \| SharedStateHandle \| ObservationHandle>` | Observe a source. Return type depends on source type: `EntityHandle` for entities, `SharedStateHandle & ObservationHandle` for db, `ObservationHandle` otherwise. Use `entity()`, `cron()`, `entities()`, `db()` helpers to build sources. |
+| `mkdb(id, schema)`                | `SharedStateHandle<T>`                                            | Create a new shared state stream. See [`SharedStateHandle`](./shared-state-handle).                                                                                                                                                        |
+| `send(entityUrl, payload, opts?)` | `void`                                                            | Send a message to another entity. `opts` accepts `type` and `afterMs` (delay in milliseconds).                                                                                                                                             |
+| `setTag(key, value)`              | `Promise<void>`                                                   | Set a tag on this entity.                                                                                                                                                                                                                  |
+| `removeTag(key)`                  | `Promise<void>`                                                   | Remove a tag from this entity.                                                                                                                                                                                                             |
+| `sleep()`                         | `void`                                                            | End the handler without running an agent. The entity remains idle until the next wake.                                                                                                                                                     |

--- a/packages/agents/docs/reference/runtime-handler.md
+++ b/packages/agents/docs/reference/runtime-handler.md
@@ -1,0 +1,136 @@
+---
+title: RuntimeHandler
+titleTemplate: '... - Electric Agents'
+description: >-
+  API reference for RuntimeHandler: webhook handling, type registration, and deployment configuration.
+outline: [2, 3]
+---
+
+# RuntimeHandler
+
+Factory functions that create the runtime request router and Node HTTP adapter. The router handles webhook wake delivery from the Electric Agents runtime server and registers entity types on startup.
+
+**Source:** `@electric-ax/agents-runtime`
+
+## RuntimeRouter
+
+```ts
+interface RuntimeRouter {
+  handleRequest(request: Request): Promise<Response | null>
+  handleWebhookRequest(request: Request): Promise<Response>
+  dispatchWebhookWake(notification: WebhookNotification): void
+  drainWakes(): Promise<void>
+  waitForSettled(): Promise<void>
+  abortWakes(): void
+  debugState(): RuntimeDebugState
+  readonly typeNames: string[]
+  registerTypes(): Promise<void>
+}
+```
+
+| Method                              | Return Type                 | Description                                                                                                               |
+| ----------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `handleRequest(request)`            | `Promise<Response \| null>` | Route a fetch `Request`. Returns `null` if the request path does not match `webhookPath`.                                 |
+| `handleWebhookRequest(request)`     | `Promise<Response>`         | Handle a webhook request directly, without route matching.                                                                |
+| `dispatchWebhookWake(notification)` | `void`                      | Dispatch an already-parsed webhook notification. Runs the wake handler in the background.                                 |
+| `drainWakes()`                      | `Promise<void>`             | Wait for all in-flight wake handlers to settle. Throws if any wake errored.                                               |
+| `waitForSettled()`                  | `Promise<void>`             | Wait for all in-flight wake handlers to settle.                                                                           |
+| `abortWakes()`                      | `void`                      | Abort in-flight wakes so host shutdown can complete quickly.                                                              |
+| `debugState()`                      | `RuntimeDebugState`         | Return a runtime-local snapshot for tests and shutdown diagnostics.                                                       |
+| `typeNames`                         | `string[]`                  | Names of all registered entity types (read-only).                                                                         |
+| `registerTypes()`                   | `Promise<void>`             | Register all entity types with the Electric Agents runtime server. Uses upsert semantics — safe to call on every startup. |
+
+## RuntimeHandler
+
+Extends `RuntimeRouter` with a Node HTTP adapter.
+
+```ts
+interface RuntimeHandler extends RuntimeRouter {
+  onEnter(req: IncomingMessage, res: ServerResponse): Promise<void>
+}
+```
+
+| Method              | Parameters                               | Description                                                                                           |
+| ------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `onEnter(req, res)` | Node `IncomingMessage`, `ServerResponse` | Node HTTP adapter. Converts the request to a fetch `Request` and delegates to `handleWebhookRequest`. |
+
+## RuntimeDebugState
+
+```ts
+interface RuntimeDebugState {
+  pendingWakeCount: number
+  pendingWakeLabels: string[]
+  wakeErrorCount: number
+  typeNames: string[]
+}
+```
+
+| Field               | Type       | Description                                             |
+| ------------------- | ---------- | ------------------------------------------------------- |
+| `pendingWakeCount`  | `number`   | Number of in-flight wake handlers.                      |
+| `pendingWakeLabels` | `string[]` | Labels identifying each pending wake (for diagnostics). |
+| `wakeErrorCount`    | `number`   | Number of wake handlers that have errored.              |
+| `typeNames`         | `string[]` | Names of all registered entity types.                   |
+
+## Factory functions
+
+```ts
+function createRuntimeRouter(config: RuntimeRouterConfig): RuntimeRouter
+
+function createRuntimeHandler(config: RuntimeHandlerConfig): RuntimeHandler
+```
+
+Both factory functions accept the same runtime router configuration.
+
+## RuntimeRouterConfig
+
+```ts
+interface RuntimeRouterConfig {
+  baseUrl: string
+  serveEndpoint?: string
+  webhookPath?: string
+  registry?: EntityRegistry
+  subscriptionPathForType?: (typeName: string) => string
+  idleTimeout?: number
+  heartbeatInterval?: number
+  createElectricTools?: (context: {
+    entityUrl: string
+    entityType: string
+    args: Readonly<Record<string, unknown>>
+    db: EntityStreamDBWithActions
+    events: Array<ChangeEvent>
+    upsertCronSchedule(opts: {
+      id: string
+      expression: string
+      timezone?: string
+      payload?: unknown
+      debounceMs?: number
+      timeoutMs?: number
+    }): Promise<{ txid: string }>
+    upsertFutureSendSchedule(opts: {
+      id: string
+      payload: unknown
+      targetUrl?: string
+      fireAt: string
+      from?: string
+      messageType?: string
+    }): Promise<{ txid: string }>
+    deleteSchedule(opts: { id: string }): Promise<{ txid: string }>
+  }) => AgentTool[] | Promise<AgentTool[]>
+  onWakeError?: (error: Error) => boolean | void
+  registrationConcurrency?: number
+}
+```
+
+| Field                     | Type                                       | Default                                                | Description                                                                                                       |
+| ------------------------- | ------------------------------------------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `baseUrl`                 | `string`                                   | -                                                      | Base URL of the Electric Agents runtime server (e.g. `"http://localhost:4437"`). Required.                        |
+| `serveEndpoint`           | `string`                                   | -                                                      | Full webhook callback URL exposed by your app. Used for type registration.                                        |
+| `webhookPath`             | `string`                                   | pathname from `serveEndpoint`, or `"/electric-agents"` | Path matched by `handleRequest()`.                                                                                |
+| `registry`                | `EntityRegistry`                           | default registry                                       | Entity registry for this handler. Falls back to the module-level default registry.                                |
+| `subscriptionPathForType` | `(typeName: string) => string`             | -                                                      | Override the webhook subscription path used per entity type registration.                                         |
+| `idleTimeout`             | `number`                                   | `20000`                                                | Idle timeout in milliseconds before closing a wake.                                                               |
+| `heartbeatInterval`       | `number`                                   | `30000`                                                | Heartbeat interval in milliseconds.                                                                               |
+| `createElectricTools`     | `(context) => AgentTool[] \| Promise<...>` | -                                                      | Optional tool factory invoked for each wake context before handler execution. Provides extra tools to the agent.  |
+| `onWakeError`             | `(error: Error) => boolean \| void`        | -                                                      | Observer for background wake failures. Return `true` to mark the error as handled so it is not rethrown on drain. |
+| `registrationConcurrency` | `number`                                   | `8`                                                    | Max number of concurrent entity-type registrations.                                                               |

--- a/packages/agents/docs/reference/shared-state-handle.md
+++ b/packages/agents/docs/reference/shared-state-handle.md
@@ -1,0 +1,74 @@
+---
+title: SharedStateHandle
+titleTemplate: '... - Electric Agents'
+description: >-
+  Type reference for SharedStateHandle: collection proxies and SharedStateSchemaMap interface.
+outline: [2, 3]
+---
+
+# SharedStateHandle
+
+Handle for a shared state stream, returned by `ctx.mkdb()` and `await ctx.observe(db(...))`. Provides typed collection proxies keyed by the collection names declared in the schema map.
+
+**Source:** `@electric-ax/agents-runtime`
+
+```ts
+type SharedStateHandle<
+  TSchema extends SharedStateSchemaMap = SharedStateSchemaMap,
+> = {
+  id: string
+} & { [K in keyof TSchema]: StateCollectionProxy }
+```
+
+## Properties
+
+| Property           | Type                                               | Description                                                                                   |
+| ------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `id`               | `string`                                           | The shared state stream identifier.                                                           |
+| `[collectionName]` | [`StateCollectionProxy`](./state-collection-proxy) | One property per collection defined in the schema. Provides insert/update/delete/get/toArray. |
+
+## SharedStateSchemaMap
+
+Defines the collections in a shared state stream.
+
+```ts
+type SharedStateSchemaMap = Record<string, SharedStateCollectionSchema>
+```
+
+## SharedStateCollectionSchema
+
+```ts
+interface SharedStateCollectionSchema {
+  schema?: StandardSchemaV1
+  type: string
+  primaryKey: string
+}
+```
+
+| Field        | Type               | Required | Description                                                      |
+| ------------ | ------------------ | -------- | ---------------------------------------------------------------- |
+| `schema`     | `StandardSchemaV1` | No       | Zod or Standard Schema validator for the row type.               |
+| `type`       | `string`           | Yes      | Event type string used in the durable stream (e.g. `"finding"`). |
+| `primaryKey` | `string`           | Yes      | Primary key field name on the row (must be a string field).      |
+
+## Example
+
+```ts
+import { db } from '@electric-ax/agents-runtime'
+
+const schema = {
+  findings: {
+    schema: z.object({
+      key: z.string(),
+      domain: z.string(),
+      finding: z.string(),
+    }),
+    type: 'finding',
+    primaryKey: 'key',
+  },
+}
+
+ctx.mkdb('research-findings', schema)
+const shared = await ctx.observe(db('research-findings', schema))
+shared.findings.insert({ key: 'f1', domain: 'security', finding: '...' })
+```

--- a/packages/agents/docs/reference/state-collection-proxy.md
+++ b/packages/agents/docs/reference/state-collection-proxy.md
@@ -1,0 +1,41 @@
+---
+title: StateCollectionProxy
+titleTemplate: '... - Electric Agents'
+description: >-
+  API reference for StateCollectionProxy: insert, update, delete, get, and toArray operations.
+outline: [2, 3]
+---
+
+# StateCollectionProxy
+
+Proxy handle for a state collection. Entity-local state exposes these proxies on `ctx.state.<collection>`, and shared state exposes them on a `SharedStateHandle` returned by `ctx.mkdb()` or `await ctx.observe(db(...))`. Mutations are routed through auto-generated CRUD actions. Reads delegate to the underlying TanStack DB collection.
+
+> **Note:** Entity state can also be accessed through the lower-level `ctx.db.actions.<coll>_insert/update/delete` and `ctx.db.collections.<coll>?.get/toArray` APIs. `ctx.state` is the proxy convenience layer over those APIs.
+
+**Source:** `@electric-ax/agents-runtime`
+
+```ts
+interface StateCollectionProxy<T extends object = Record<string, unknown>> {
+  insert(row: T): unknown
+  update(key: string, updater: (draft: T) => void): unknown
+  delete(key: string): unknown
+  get(key: string): T | undefined
+  toArray: T[]
+}
+```
+
+## Members
+
+| Member                 | Parameters                                   | Return Type      | Description                                                             |
+| ---------------------- | -------------------------------------------- | ---------------- | ----------------------------------------------------------------------- |
+| `insert(row)`          | `row: T`                                     | `Transaction`    | Insert a new row into the collection.                                   |
+| `update(key, updater)` | `key: string`, `updater: (draft: T) => void` | `Transaction`    | Update a row by key. The updater receives an Immer-style mutable draft. |
+| `delete(key)`          | `key: string`                                | `Transaction`    | Delete a row by key.                                                    |
+| `get(key)`             | `key: string`                                | `T \| undefined` | Read a single row by key. Returns `undefined` if not found.             |
+| `toArray`              | -                                            | `T[]`            | All rows as an array. This is a getter property, not a method.          |
+
+## Notes
+
+- Mutating methods (`insert`, `update`, `delete`) return a Transaction. These are fire-and-forget -- the write is persisted to the backing durable stream asynchronously.
+- The `update` method uses Immer-style drafts. Mutate the draft directly rather than returning a new object.
+- `toArray` is a property, not a method call. Access it without parentheses: `ctx.state.items.toArray` or `shared.items.toArray`.

--- a/packages/agents/docs/reference/wake-event.md
+++ b/packages/agents/docs/reference/wake-event.md
@@ -1,0 +1,132 @@
+---
+title: WakeEvent
+titleTemplate: '... - Electric Agents'
+description: >-
+  Type reference for WakeEvent and Wake configuration: runFinished and change-based wake conditions.
+outline: [2, 3]
+---
+
+# WakeEvent
+
+Describes why an entity handler was invoked. Passed as the second argument to the handler function.
+
+**Source:** `@electric-ax/agents-runtime`
+
+```ts
+type WakeEvent = {
+  source: string
+  type: string
+  fromOffset: number
+  toOffset: number
+  eventCount: number
+  payload?: unknown
+  summary?: string
+  fullRef?: string
+}
+```
+
+## Fields
+
+| Field        | Type      | Description                                                                                                                      |
+| ------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `source`     | `string`  | URL or identifier of the stream that triggered the wake.                                                                         |
+| `type`       | `string`  | Wake type. Usually `"message_received"` or `"wake"`; fallback webhook events can use `triggerEvent` or `"message"`. See catalog. |
+| `fromOffset` | `number`  | Start offset of new events in the source stream.                                                                                 |
+| `toOffset`   | `number`  | End offset (exclusive) of new events.                                                                                            |
+| `eventCount` | `number`  | Number of new events in this wake.                                                                                               |
+| `payload`    | `unknown` | Optional payload data associated with the wake. Shape depends on `type`.                                                         |
+| `summary`    | `string`  | Optional human-readable summary of the wake reason.                                                                              |
+| `fullRef`    | `string`  | Optional full reference identifier for the wake source.                                                                          |
+
+## Wake-type catalog
+
+Handlers usually see two values for `wake.type`. Direct inbox messages arrive as `"message_received"`. Most non-message triggers are flattened into `"wake"`, with the specifics carried on `wake.payload`. Low-level webhook fallbacks can surface `triggerEvent` directly, or `"message"` when no trigger event is provided.
+
+### `"message_received"`
+
+An external message landed in the entity's inbox — from `ctx.send()`, the CLI's `electric agents send`, or any direct `/send` HTTP call.
+
+| Field          | Shape                                                                             |
+| -------------- | --------------------------------------------------------------------------------- |
+| `wake.source`  | The `from` field of the message (sender identifier), or the entity URL if absent. |
+| `wake.payload` | The message payload (any JSON-serialisable value).                                |
+| `wake.summary` | The `message_type` if the sender set one.                                         |
+
+### `"wake"`
+
+A synthesised wake for any non-message trigger. `wake.payload` is a `WakeMessage`:
+
+```ts
+type WakeMessage = {
+  timestamp: string
+  source: string
+  timeout: boolean
+  changes: Array<{
+    collection: string
+    kind: 'insert' | 'update' | 'delete'
+    key: string
+  }>
+  finished_child?: {
+    url: string
+    type: string
+    run_status: 'completed' | 'failed'
+    response?: string
+    error?: string
+  }
+  other_children?: Array<{
+    url: string
+    type: string
+    status: 'spawning' | 'running' | 'idle' | 'stopped'
+  }>
+}
+```
+
+Inspect the payload to distinguish the sub-kind:
+
+| Sub-kind            | Producer                                                                    | Payload marker                                                                            |
+| ------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Child finished      | `ctx.spawn(..., { wake: 'runFinished' })` when the child completes or fails | `payload.finished_child` is set (with `run_status` and optional `response`)               |
+| Observed change     | `ctx.observe(..., { wake: { on: 'change' } })` or `observe(db(...))`        | `payload.changes` is non-empty                                                            |
+| Shared-state change | `await ctx.observe(db(...), { wake: { on: 'change' } })`                    | `payload.changes` is non-empty, `payload.source` identifies the shared-state stream       |
+| Cron fired          | A cron schedule entry on the entity's manifest                              | `payload.source` identifies the schedule; `payload.changes` is empty                      |
+| Scheduled send      | A `future_send` schedule fires                                              | Arrives as `"message_received"` (not `"wake"`) — the schedule produces a message delivery |
+| Timeout             | `timeoutMs` on a `change` wake config elapsed with no changes               | `payload.timeout === true`, `payload.changes` is empty                                    |
+
+For the narrative on how these are produced, see [Waking entities](../usage/waking-entities).
+
+## Wake
+
+The `Wake` type configures when a parent should be woken in response to a child, observed entity, or shared state change. Used in `ctx.spawn()`, `ctx.observe()`, and `ctx.observe(db(...))` options.
+
+```ts
+type Wake =
+  | 'runFinished'
+  | { on: 'runFinished'; includeResponse?: boolean }
+  | {
+      on: 'change'
+      collections?: string[]
+      ops?: ('insert' | 'update' | 'delete')[]
+      debounceMs?: number
+      timeoutMs?: number
+    }
+```
+
+### `'runFinished'`
+
+Wake the parent when the child's agent run completes (status changes to `completed` or `failed`). By default, the wake event includes the child's concatenated text response in `finished_child.response`.
+
+### `{ on: 'runFinished', includeResponse?: boolean }`
+
+Object form of `runFinished` with options. Set `includeResponse: false` to omit the child's text response from the wake event.
+
+### `{ on: 'change' }`
+
+Wake the parent when changes occur in the observed stream.
+
+| Field         | Type       | Description                                                           |
+| ------------- | ---------- | --------------------------------------------------------------------- |
+| `on`          | `'change'` | Required discriminant.                                                |
+| `collections` | `string[]` | Optional filter. Only wake on changes to these collections.           |
+| `ops`         | `string[]` | Optional operation filter: `"insert"`, `"update"`, and/or `"delete"`. |
+| `debounceMs`  | `number`   | Debounce interval in milliseconds. Batches rapid changes.             |
+| `timeoutMs`   | `number`   | Maximum time to wait before waking, even if no changes occur.         |

--- a/packages/agents/docs/usage/app-setup.md
+++ b/packages/agents/docs/usage/app-setup.md
@@ -1,0 +1,165 @@
+---
+title: App setup
+titleTemplate: '... - Electric Agents'
+description: >-
+  Connect your app to the Electric Agents runtime with createRuntimeHandler, webhooks, and type registration.
+outline: [2, 3]
+---
+
+# App setup
+
+The runtime handler connects your app's entity definitions to the Electric Agents runtime server via webhooks.
+
+## createRuntimeHandler
+
+Creates a runtime with a Node HTTP adapter:
+
+```ts
+import {
+  createEntityRegistry,
+  createRuntimeHandler,
+} from '@electric-ax/agents-runtime'
+
+const registry = createEntityRegistry()
+// ... register entity types ...
+
+const runtime = createRuntimeHandler({
+  baseUrl: 'http://localhost:4437',
+  serveEndpoint: 'http://localhost:3000/webhook',
+  registry,
+})
+```
+
+## Configuration
+
+```ts
+interface RuntimeRouterConfig {
+  baseUrl: string // Electric Agents server URL
+  serveEndpoint?: string // Webhook callback URL
+  webhookPath?: string // Path to match (default: derived from serveEndpoint)
+  registry?: EntityRegistry
+  subscriptionPathForType?: (typeName: string) => string
+  idleTimeout?: number // ms before closing idle wake (default: 20000)
+  heartbeatInterval?: number // ms between heartbeats (default: 30000)
+  createElectricTools?: (context: {
+    entityUrl: string
+    entityType: string
+    args: Readonly<Record<string, unknown>>
+    db: EntityStreamDBWithActions
+    events: Array<ChangeEvent>
+    upsertCronSchedule(opts: {
+      id: string
+      expression: string
+      timezone?: string
+      payload?: unknown
+      debounceMs?: number
+      timeoutMs?: number
+    }): Promise<{ txid: string }>
+    upsertFutureSendSchedule(opts: {
+      id: string
+      payload: unknown
+      targetUrl?: string
+      fireAt: string
+      from?: string
+      messageType?: string
+    }): Promise<{ txid: string }>
+    deleteSchedule(opts: { id: string }): Promise<{ txid: string }>
+  }) => AgentTool[] | Promise<AgentTool[]> // factory for extra agent tools
+  onWakeError?: (error: Error) => boolean | void // return true to mark handled
+  registrationConcurrency?: number // max concurrent type registrations (default: 8)
+}
+```
+
+## HTTP server
+
+Your app needs an HTTP server to receive webhook callbacks from the Electric Agents runtime server. Forward webhook POSTs to the runtime handler:
+
+```ts
+import http from 'node:http'
+
+const server = http.createServer(async (req, res) => {
+  if (req.url === '/webhook' && req.method === 'POST') {
+    await runtime.onEnter(req, res)
+    return
+  }
+  res.writeHead(404)
+  res.end()
+})
+
+server.listen(PORT, async () => {
+  await runtime.registerTypes()
+  console.log(`${runtime.typeNames.length} types registered`)
+})
+```
+
+## registerTypes
+
+Registers all entity types with the Electric Agents runtime server and creates webhook subscriptions. Uses upsert semantics — re-registering an existing type updates it rather than erroring.
+
+Must be called after your app starts listening.
+
+```ts
+await runtime.registerTypes()
+```
+
+This makes two requests per entity type:
+
+1. `POST /_electric/entity-types` — registers the type definition and schemas.
+2. `PUT /{type}/**?subscription={type}-handler` — creates a webhook subscription for the type.
+
+## RuntimeHandler
+
+```ts
+interface RuntimeHandler {
+  onEnter(req: IncomingMessage, res: ServerResponse): Promise<void>
+  handleRequest(request: Request): Promise<Response | null>
+  handleWebhookRequest(request: Request): Promise<Response>
+  dispatchWebhookWake(notification: WebhookNotification): void
+  drainWakes(): Promise<void>
+  waitForSettled(): Promise<void>
+  abortWakes(): void
+  debugState(): RuntimeDebugState
+  readonly typeNames: string[]
+  registerTypes(): Promise<void>
+}
+
+interface RuntimeDebugState {
+  pendingWakeCount: number
+  pendingWakeLabels: string[]
+  wakeErrorCount: number
+  typeNames: string[]
+}
+```
+
+| Method                 | Description                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| `onEnter`              | Node HTTP adapter — reads the request body and delegates to `handleWebhookRequest`       |
+| `handleRequest`        | Fetch-native router — returns `null` if the path does not match `webhookPath`            |
+| `handleWebhookRequest` | Processes a webhook POST directly, without path matching                                 |
+| `dispatchWebhookWake`  | Dispatches a pre-parsed notification (fire-and-forget)                                   |
+| `drainWakes`           | Waits for all in-flight wake handlers to settle; throws on errors                        |
+| `waitForSettled`       | Waits for all in-flight wakes; throws on errors                                          |
+| `abortWakes`           | Cancels all in-flight wake handlers immediately                                          |
+| `debugState`           | Returns a snapshot of internal runtime state for diagnostics                             |
+| `registerTypes`        | Registers entity types and webhook subscriptions with the Electric Agents runtime server |
+
+## createRuntimeRouter
+
+Fetch-native alternative with no Node HTTP dependency:
+
+```ts
+import { createRuntimeRouter } from '@electric-ax/agents-runtime'
+
+const router = createRuntimeRouter(config)
+const response = await router.handleRequest(request)
+```
+
+Use this when integrating with non-Node frameworks or edge runtimes.
+
+## Environment variables
+
+| Variable              | Default                 | Purpose                            |
+| --------------------- | ----------------------- | ---------------------------------- |
+| `ELECTRIC_AGENTS_URL` | `http://localhost:4437` | Electric Agents runtime server URL |
+| `PORT`                | `3000`                  | Your app's HTTP port               |
+| `ANTHROPIC_API_KEY`   | —                       | Claude API key                     |

--- a/packages/agents/docs/usage/clients-and-react.md
+++ b/packages/agents/docs/usage/clients-and-react.md
@@ -1,0 +1,191 @@
+---
+title: Clients & React
+titleTemplate: '... - Electric Agents'
+description: >-
+  Observe Electric Agents entities from app code, build reactive StreamDB handles,
+  and render chat timelines with the React useChat hook.
+outline: [2, 3]
+---
+
+# Clients & React
+
+Use the client APIs when you need to observe agents from application code rather than from inside a handler. They load entity or observation streams into TanStack DB-backed collections that can drive UI.
+
+## AgentsClient
+
+`createAgentsClient()` creates a small read client for observation sources.
+
+```ts
+import {
+  createAgentsClient,
+  entity,
+  entities,
+} from '@electric-ax/agents-runtime'
+
+const client = createAgentsClient({ baseUrl: 'http://localhost:4437' })
+
+// Observe a single entity stream.
+const entityDb = await client.observe(entity('/horton/onboarding'))
+console.log(entityDb.collections.texts.toArray)
+
+// Observe the entity membership stream for a tag query.
+const membersDb = await client.observe(entities({ tags: { project: 'alpha' } }))
+console.log(membersDb.collections.members.toArray)
+```
+
+### Types
+
+```ts
+interface AgentsClientConfig {
+  baseUrl: string
+  fetch?: typeof globalThis.fetch
+}
+
+interface AgentsClient {
+  observe(
+    source: ObservationSource
+  ): Promise<EntityStreamDB | ObservationStreamDB>
+}
+```
+
+`observe(entity(url))` returns an `EntityStreamDB`. `observe(entities(...))` and `observe(db(...))` return an `ObservationStreamDB`.
+
+:::: warning
+`client.observe(cron(...))` is not currently supported. Use cron sources from handler wake subscriptions, or schedule tools exposed through `ctx.electricTools`.
+::::
+
+## Observation Sources
+
+The same source helpers used by `ctx.observe()` can be used with `AgentsClient`.
+
+| Helper               | Use case                                            |
+| -------------------- | --------------------------------------------------- |
+| `entity(url)`        | Observe one entity by URL.                          |
+| `entities({ tags })` | Observe the entity membership stream matching tags. |
+| `db(id, schema)`     | Observe a shared-state stream.                      |
+| `cron(expression)`   | Build a cron source for wake subscriptions.         |
+
+```ts
+import { db } from '@electric-ax/agents-runtime'
+
+const shared = await client.observe(db('research-123', researchSchema))
+```
+
+## React useChat
+
+`@electric-ax/agents-runtime/react` exports `useChat()`, a React hook that turns an `EntityStreamDB` into sections suitable for a chat UI.
+
+```tsx
+import { useEffect, useState } from 'react'
+import { createAgentsClient, entity } from '@electric-ax/agents-runtime'
+import { useChat } from '@electric-ax/agents-runtime/react'
+import type { EntityStreamDB } from '@electric-ax/agents-runtime'
+
+const client = createAgentsClient({ baseUrl: 'http://localhost:4437' })
+
+export function AgentConversation({ entityUrl }: { entityUrl: string }) {
+  const [db, setDb] = useState<EntityStreamDB | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    let observedDb: EntityStreamDB | null = null
+    client.observe(entity(entityUrl)).then((observed) => {
+      observedDb = observed as EntityStreamDB
+      if (cancelled) {
+        observedDb.close()
+        return
+      }
+      if (!cancelled) setDb(observedDb)
+    })
+    return () => {
+      cancelled = true
+      observedDb?.close()
+    }
+  }, [entityUrl])
+
+  const chat = useChat(db)
+
+  return (
+    <ol>
+      {chat.sections.map((section, index) => (
+        <li key={index}>
+          {section.kind === 'user_message'
+            ? section.text
+            : section.items.map((item) =>
+                item.kind === 'text' ? item.text : item.toolName
+              )}
+        </li>
+      ))}
+    </ol>
+  )
+}
+```
+
+### UseChatResult
+
+```ts
+interface UseChatResult {
+  sections: EntityTimelineSection[]
+  state: 'pending' | 'queued' | 'working' | 'idle' | 'error'
+  runs: IncludesRun[]
+  inbox: IncludesInboxMessage[]
+  wakes: IncludesWakeMessage[]
+  entities: IncludesEntity[]
+}
+```
+
+`sections` are the high-level chat timeline. `runs`, `inbox`, `wakes`, and `entities` expose the normalized underlying data for richer UIs.
+
+## Timeline Helpers
+
+If you are not using React, the runtime also exports pure timeline helpers:
+
+```ts
+import {
+  buildSections,
+  buildTimelineEntries,
+  createEntityIncludesQuery,
+  defaultProjection,
+  getEntityState,
+  materializeTimeline,
+  normalizeEntityTimelineData,
+  timelineMessages,
+  timelineToMessages,
+} from '@electric-ax/agents-runtime'
+```
+
+Use these when you already have an `EntityStreamDB` and want to build your own UI integration.
+
+| Helper                              | Purpose                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `createEntityIncludesQuery(db)`     | Builds the TanStack DB query used by `useChat`.                        |
+| `normalizeEntityTimelineData()`     | Normalizes and sorts nested run, text, tool, wake, and entity data.    |
+| `getEntityState(runs, inbox)`       | Computes `pending`, `queued`, `working`, `idle`, or `error`.           |
+| `buildSections(runs, inbox)`        | Builds chat-friendly user/agent sections.                              |
+| `buildTimelineEntries(runs, inbox)` | Builds keyed timeline entries with response timestamps.                |
+| `materializeTimeline(data)`         | Converts normalized timeline data into prompt-oriented timeline items. |
+| `defaultProjection(item)`           | Projects one timeline item into LLM messages.                          |
+| `timelineMessages(db, opts?)`       | Reads an entity DB and returns timestamped LLM messages.               |
+| `timelineToMessages(db)`            | Convenience wrapper returning plain LLM messages.                      |
+
+## CLI Entity Stream DB
+
+The `electric-ax/entity-stream-db` subpath exposes a convenience loader used by CLI and UI code:
+
+```ts
+import { createEntityStreamDB } from 'electric-ax/entity-stream-db'
+
+const { db, close } = await createEntityStreamDB({
+  baseUrl: 'http://localhost:4437',
+  entityUrl: '/horton/onboarding',
+  initialOffset: '0',
+})
+
+try {
+  console.log(db.collections.runs.toArray)
+} finally {
+  close()
+}
+```
+
+This API fetches entity metadata from the server, opens the entity's main stream, preloads it, and returns an `EntityStreamDB`.

--- a/packages/agents/docs/usage/configuring-the-agent.md
+++ b/packages/agents/docs/usage/configuring-the-agent.md
@@ -1,0 +1,136 @@
+---
+title: Configuring the agent
+titleTemplate: '... - Electric Agents'
+description: >-
+  Set up LLM agents with ctx.useAgent(), including model selection, system prompts, tools, and test responses.
+outline: [2, 3]
+---
+
+# Configuring the agent
+
+Call `ctx.useAgent()` in your handler to set up the LLM, then `ctx.agent.run()` to execute it.
+
+## AgentConfig
+
+```ts
+interface AgentConfig {
+  systemPrompt: string
+  model: string | Model<any>
+  provider?: KnownProvider
+  tools: AgentTool[]
+  streamFn?: StreamFn
+  testResponses?: string[] | TestResponseFn
+}
+```
+
+| Field           | Required | Description                                                                                                            |
+| --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `systemPrompt`  | Yes      | The system prompt passed to the LLM.                                                                                   |
+| `model`         | Yes      | Model identifier string or resolved model object.                                                                      |
+| `provider`      | No       | Provider to use when `model` is a string. Defaults to `"anthropic"`.                                                   |
+| `tools`         | Yes      | Array of tools available to the agent. Spread `ctx.electricTools` when your runtime host provides runtime-level tools. |
+| `streamFn`      | No       | Optional streaming callback passed to the underlying agent.                                                            |
+| `testResponses` | No       | Mock responses for testing without calling the LLM.                                                                    |
+
+## Basic usage
+
+```ts
+async handler(ctx) {
+  ctx.useAgent({
+    systemPrompt: 'You are a helpful assistant.',
+    model: 'claude-sonnet-4-5-20250929',
+    tools: [...ctx.electricTools],
+  })
+  await ctx.agent.run()
+}
+```
+
+`useAgent` returns an `AgentHandle` and also sets `ctx.agent`. Both references are equivalent.
+
+To control what content fills the agent's context window (token budgets, cache tiers, external sources), use `ctx.useContext()` alongside `useAgent`. See [Context composition](./context-composition).
+
+## ctx.electricTools
+
+`ctx.electricTools` is an array of runtime-provided tools. It may be empty, or it may contain host-provided tools such as schedule management tools. Spread it into the `tools` array when you want the LLM agent to access those runtime-level tools:
+
+```ts
+tools: [...ctx.electricTools, myCustomTool, anotherTool]
+```
+
+Handler-level coordination APIs such as `ctx.spawn`, `ctx.observe`, and `ctx.send` are available on `HandlerContext` regardless of whether you pass `ctx.electricTools` to the LLM.
+
+## ctx.agent.run()
+
+Executes the agent loop. Blocks until the LLM finishes -- all tool calls are resolved and the final text response is emitted.
+
+```ts
+const result = await ctx.agent.run()
+```
+
+Returns an `AgentRunResult`:
+
+```ts
+type AgentRunResult = {
+  writes: ChangeEvent[]
+  toolCalls: Array<{ name: string; args: unknown; result: unknown }>
+  usage: { tokens: number; duration: number }
+}
+```
+
+| Field       | Description                                                                             |
+| ----------- | --------------------------------------------------------------------------------------- |
+| `writes`    | Currently returned as an empty array placeholder.                                       |
+| `toolCalls` | Currently returned as an empty array placeholder.                                       |
+| `usage`     | Currently returned as `{ tokens: 0, duration: 0 }` until usage aggregation is wired in. |
+
+## AgentHandle
+
+Returned by `useAgent`. Also accessible as `ctx.agent`.
+
+```ts
+interface AgentHandle {
+  run: (input?: string) => Promise<AgentRunResult>
+}
+```
+
+You must call `useAgent` before calling `run()`. Calling `ctx.agent.run()` without prior configuration throws an error.
+
+## Model
+
+When `model` is a string, the runtime resolves it through the configured `provider` (default `"anthropic"`). You can also pass a resolved `Model` object directly.
+
+```ts
+model: 'claude-sonnet-4-5-20250929'
+provider: 'anthropic'
+```
+
+## Test responses
+
+For testing handlers without making LLM calls, pass `testResponses`. Two forms are supported:
+
+**Array of strings** -- selected by the number of prior runs, useful for deterministic repeated wakes:
+
+```ts
+ctx.useAgent({
+  systemPrompt: '...',
+  model: 'claude-sonnet-4-5-20250929',
+  tools: [...ctx.electricTools],
+  testResponses: ['Hello! How can I help?', 'Sure, I can do that.'],
+})
+```
+
+**Function** -- called for each turn with the current message and an `OutboundBridgeHandle`:
+
+```ts
+ctx.useAgent({
+  // ...
+  testResponses: async (message, bridge) => {
+    if (message.includes('calculate')) {
+      return 'The answer is 42.'
+    }
+    return undefined // emits no automatic text response
+  },
+})
+```
+
+See [Testing](./testing) for more on writing tests with `testResponses`.

--- a/packages/agents/docs/usage/context-composition.md
+++ b/packages/agents/docs/usage/context-composition.md
@@ -1,0 +1,204 @@
+---
+title: Context composition
+titleTemplate: '... - Electric Agents'
+description: >-
+  Control what goes into the agent's context window using ctx.useContext() with token-budgeted sources, cache tiers, and imperative context entries.
+outline: [2, 3]
+---
+
+# Context composition
+
+By default, the runtime assembles the agent's context window from the entity's full timeline (messages, tool calls, text responses). `ctx.useContext()` gives you explicit control over what goes in and how much space each piece gets.
+
+## When to use it
+
+Most entities don't need `useContext` -- the default timeline assembly works well for simple conversational agents. Use `useContext` when you need to:
+
+- **Budget token space** across multiple content sources (docs, conversation history, retrieved context)
+- **Mix static and dynamic content** with different caching behavior
+- **Inject external content** (documentation, search results, knowledge bases) alongside conversation history
+
+## UseContextConfig
+
+```ts
+ctx.useContext({
+  sourceBudget: 18_000,
+  sources: {
+    docs: {
+      content: () => '# Reference docs\n...',
+      max: 6_000,
+      cache: 'stable',
+    },
+    conversation: {
+      content: () => ctx.timelineMessages(),
+      max: 12_000,
+      cache: 'volatile',
+    },
+  },
+})
+```
+
+| Field          | Type                           | Description                                              |
+| -------------- | ------------------------------ | -------------------------------------------------------- |
+| `sourceBudget` | `number`                       | Total token budget across all sources. Required.         |
+| `sources`      | `Record<string, SourceConfig>` | Named content sources. Must contain at least one source. |
+
+### SourceConfig
+
+Each source declares a content function, a max token allocation, and a cache tier:
+
+| Field     | Type                                                   | Description                                                                      |
+| --------- | ------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `content` | `() => string \| LLMMessage[] \| TimestampedMessage[]` | Function called each agent run to produce the source content. Can be async.      |
+| `max`     | `number`                                               | Maximum tokens this source may consume. Content is truncated if it exceeds this. |
+| `cache`   | `CacheTier`                                            | Caching hint that controls assembly ordering. See [Cache tiers](#cache-tiers).   |
+
+The `content` function can return:
+
+- A **string** -- inserted as a single system message
+- An **`LLMMessage[]`** array -- inserted as-is
+- A **`TimestampedMessage[]`** array -- interleaved by timestamp with other volatile sources
+
+### Cache tiers
+
+Cache tiers control assembly ordering and caching behavior. Sources are assembled from most stable to most volatile:
+
+| Tier              | Position | Use for                                                        |
+| ----------------- | -------- | -------------------------------------------------------------- |
+| `"pinned"`        | First    | Content that never changes (system instructions, schemas)      |
+| `"stable"`        | Second   | Content that changes rarely (docs TOC, reference material)     |
+| `"slow-changing"` | Third    | Content that updates occasionally (summaries, aggregations)    |
+| `"volatile"`      | Last     | Content that changes every wake (conversation, search results) |
+
+Non-volatile sources (`pinned`, `stable`, `slow-changing`) have their `max` values summed and validated against `sourceBudget` at registration time. Volatile sources share the remaining budget.
+
+## timelineMessages
+
+`ctx.timelineMessages()` projects the entity's timeline (inbox messages, agent runs, tool calls) into an ordered array of `TimestampedMessage` objects suitable for passing to an LLM.
+
+```ts
+const messages = ctx.timelineMessages()
+// or with options:
+const messages = ctx.timelineMessages({
+  since: 42,
+  projection: (item) => {
+    if (item.kind === 'run') return [{ role: 'assistant', content: '...' }]
+    return null // use default projection
+  },
+})
+```
+
+| Option       | Type                                           | Description                                                                            |
+| ------------ | ---------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `since`      | `number`                                       | Only include items after this timeline position.                                       |
+| `projection` | `(item: TimelineItem) => LLMMessage[] \| null` | Custom projection function. Return `null` to use the default projection for that item. |
+
+This is typically used as the `content` function of a `volatile` source:
+
+```ts
+ctx.useContext({
+  sourceBudget: 15_000,
+  sources: {
+    conversation: {
+      content: () => ctx.timelineMessages(),
+      max: 15_000,
+      cache: 'volatile',
+    },
+  },
+})
+```
+
+## Context entries
+
+Context entries are durable key-value items stored in the entity's stream. Unlike sources (which are recomputed each wake), context entries persist across wakes and are projected into the context window automatically when `useContext` is active.
+
+Use context entries for information the agent discovers during a run that should remain available in future wakes (e.g. user preferences, extracted facts, accumulated instructions).
+
+### insertContext
+
+```ts
+ctx.insertContext('user-prefs', {
+  name: 'User preferences',
+  content: 'Prefers concise responses. Timezone: PST.',
+  attrs: { priority: 'high' },
+})
+```
+
+Inserting with an existing `id` replaces the previous entry.
+
+### removeContext
+
+```ts
+ctx.removeContext('user-prefs')
+```
+
+### getContext / listContext
+
+```ts
+const entry = ctx.getContext('user-prefs')
+// { id: "user-prefs", name: "User preferences", content: "...", insertedAt: 1234 }
+
+const all = ctx.listContext()
+// Array<ContextEntry>
+```
+
+### ContextEntryInput
+
+| Field     | Type                | Description                         |
+| --------- | ------------------- | ----------------------------------- |
+| `name`    | `string`            | Human-readable label for the entry. |
+| `content` | `string`            | The text content.                   |
+| `attrs`   | `ContextEntryAttrs` | Optional metadata attributes.       |
+
+### ContextEntry
+
+Extends `ContextEntryInput` with:
+
+| Field        | Type     | Description                       |
+| ------------ | -------- | --------------------------------- |
+| `id`         | `string` | The id passed to `insertContext`. |
+| `insertedAt` | `number` | Timeline position when inserted.  |
+
+## Full example
+
+This example from the built-in Horton assistant shows all three source types working together:
+
+```ts
+async handler(ctx, wake) {
+  const tools = [...ctx.electricTools, ...customTools]
+
+  ctx.useContext({
+    sourceBudget: 18_000,
+    sources: {
+      docs_toc: {
+        content: () => renderCompressedToc(),
+        max: 3_000,
+        cache: "stable",
+      },
+      retrieved_docs: {
+        content: () => renderRetrievedDocs(wake, ctx.events),
+        max: 6_000,
+        cache: "volatile",
+      },
+      conversation: {
+        content: () => ctx.timelineMessages(),
+        max: 9_000,
+        cache: "volatile",
+      },
+    },
+  })
+
+  ctx.useAgent({
+    systemPrompt: "You are a helpful assistant.",
+    model: "claude-sonnet-4-5-20250929",
+    tools,
+  })
+  await ctx.agent.run()
+}
+```
+
+The `stable` docs TOC is assembled first and cached across wakes. The two `volatile` sources (retrieved docs and conversation) are recomputed each wake and share the remaining budget.
+
+## Entities without useContext
+
+Entities that don't call `useContext` are unchanged -- the runtime uses its default timeline assembly, building the full conversation history into the context window automatically. There is no need to migrate existing entities.

--- a/packages/agents/docs/usage/defining-entities.md
+++ b/packages/agents/docs/usage/defining-entities.md
@@ -1,0 +1,181 @@
+---
+title: Defining entities
+titleTemplate: '... - Electric Agents'
+description: >-
+  Register entity types with the EntityRegistry, define custom state collections, typed schemas, and handler functions.
+outline: [2, 3]
+---
+
+# Defining entities
+
+An entity type is registered with an `EntityRegistry`. The registry maps type names to `EntityDefinition` objects that declare the entity's state, schemas, and handler.
+
+## Registry
+
+`createEntityRegistry()` returns an `EntityRegistry`. Register types with `registry.define(name, definition)`.
+
+```ts
+import { createEntityRegistry } from '@electric-ax/agents-runtime'
+
+const registry = createEntityRegistry()
+
+registry.define('assistant', {
+  description: 'A general-purpose AI assistant',
+  async handler(ctx) {
+    ctx.useAgent({
+      systemPrompt: 'You are a helpful assistant.',
+      model: 'claude-sonnet-4-5-20250929',
+      tools: [...ctx.electricTools],
+    })
+    await ctx.agent.run()
+  },
+})
+```
+
+Calling `registry.define()` with a name that is already registered throws an error.
+
+## EntityDefinition
+
+```ts
+interface EntityDefinition {
+  description?: string
+  state?: Record<string, CollectionDefinition>
+  actions?: (
+    collections: Record<string, unknown>
+  ) => Record<string, (...args: unknown[]) => void>
+  creationSchema?: StandardJSONSchemaV1
+  inboxSchemas?: Record<string, StandardJSONSchemaV1>
+  outputSchemas?: Record<string, StandardJSONSchemaV1>
+  handler: (ctx: HandlerContext, wake: WakeEvent) => void | Promise<void>
+}
+```
+
+| Field            | Purpose                                                                                             |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| `description`    | Human-readable description. Shown in the Electric Agents UI and CLI.                                |
+| `state`          | Custom persistent collections accessed via `ctx.state`, `ctx.db.actions`, and `ctx.db.collections`. |
+| `actions`        | Factory that returns custom non-CRUD action functions exposed on `ctx.actions`.                     |
+| `creationSchema` | JSON Schema for arguments passed when the entity is spawned.                                        |
+| `inboxSchemas`   | JSON Schemas for typed inbox message categories.                                                    |
+| `outputSchemas`  | JSON Schemas for typed output message categories.                                                   |
+| `handler`        | The function that runs each time the entity wakes. Required.                                        |
+
+## Custom state
+
+Declare named collections in the `state` field. Each collection is a `CollectionDefinition`:
+
+```ts
+interface CollectionDefinition {
+  schema?: StandardSchemaV1
+  type?: string
+  primaryKey?: string
+}
+```
+
+| Field        | Default          | Purpose                                                                 |
+| ------------ | ---------------- | ----------------------------------------------------------------------- |
+| `schema`     | none             | Optional Standard Schema validator (e.g. Zod). Validates rows on write. |
+| `type`       | `"state:{name}"` | Event type string used in the durable stream.                           |
+| `primaryKey` | `"key"`          | The field used as the primary key for the collection.                   |
+
+Declared collections become available via `ctx.state` proxies and the lower-level `ctx.db.actions` / `ctx.db.collections` APIs:
+
+```ts
+import { z } from 'zod'
+
+const childSchema = z.object({
+  key: z.string(),
+  url: z.string(),
+  kind: z.string(),
+})
+
+registry.define('coordinator', {
+  description: 'Spawns and tracks child entities',
+  state: {
+    status: { primaryKey: 'key' },
+    children: { schema: childSchema, primaryKey: 'key' },
+  },
+
+  async handler(ctx) {
+    if (ctx.firstWake) {
+      ctx.db.actions.status_insert({ row: { key: 'current', value: 'idle' } })
+    }
+    // Convenience proxy:
+    ctx.state.children.insert({
+      key: 'child-1',
+      url: '/worker/child-1',
+      kind: 'worker',
+    })
+
+    // Lower-level APIs:
+    // Writes: ctx.db.actions.children_insert(), .children_update(), .children_delete()
+    // Reads: ctx.db.collections.children?.get(key), .children?.toArray
+  },
+})
+```
+
+For entity state, `ctx.state.<name>.insert/update/delete/get/toArray` is the convenience API. Lower-level writes use `ctx.db.actions.<name>_insert/update/delete`, and reads use `ctx.db.collections.<name>?.get(key)` and `ctx.db.collections.<name>?.toArray`.
+
+::: info
+`StateCollectionProxy` is used for both entity-local `ctx.state` and shared state handles. See [StateCollectionProxy](../reference/state-collection-proxy) for details.
+:::
+
+## Registry pattern
+
+For projects with multiple entity types, keep a separate registry file and import register functions:
+
+```ts
+// entities/registry.ts
+import { createEntityRegistry } from '@electric-ax/agents-runtime'
+import { registerAssistant } from './assistant'
+import { registerWorker } from './worker'
+
+export const registry = createEntityRegistry()
+registerAssistant(registry)
+registerWorker(registry)
+```
+
+```ts
+// entities/assistant.ts
+import type { EntityRegistry } from '@electric-ax/agents-runtime'
+
+export function registerAssistant(registry: EntityRegistry) {
+  registry.define('assistant', {
+    description: 'General-purpose assistant',
+    async handler(ctx) {
+      ctx.useAgent({
+        systemPrompt: 'You are a helpful assistant.',
+        model: 'claude-sonnet-4-5-20250929',
+        tools: [...ctx.electricTools],
+      })
+      await ctx.agent.run()
+    },
+  })
+}
+```
+
+This keeps each entity type isolated and the registry composition explicit.
+
+## Schemas
+
+`creationSchema`, `inboxSchemas`, and `outputSchemas` accept [`StandardJSONSchemaV1`](https://github.com/standard-schema/standard-schema) objects. Any schema library implementing the Standard JSON Schema interface works (e.g. Zod v4). These schemas are used for validation and for generating UI and documentation in the Electric Agents dashboard.
+
+```ts
+import { z } from 'zod/v4'
+
+registry.define('processor', {
+  description: 'Processes structured tasks',
+  creationSchema: z.object({
+    priority: z.enum(['low', 'medium', 'high']).default('medium'),
+  }),
+  inboxSchemas: {
+    task: z.object({
+      title: z.string(),
+      body: z.string().optional(),
+    }),
+  },
+  async handler(ctx) {
+    // ctx.args.priority is available from creationSchema
+  },
+})
+```

--- a/packages/agents/docs/usage/defining-tools.md
+++ b/packages/agents/docs/usage/defining-tools.md
@@ -1,0 +1,229 @@
+---
+title: Defining tools
+titleTemplate: '... - Electric Agents'
+description: >-
+  Create stateless, stateful, and handler-scoped tools for the LLM agent loop.
+outline: [2, 3]
+---
+
+# Defining tools
+
+Tools are functions the LLM can call during the agent loop. Each tool has a name, description, typed parameters, and an execute function.
+
+## AgentTool interface
+
+Re-exported from [`@mariozechner/pi-agent-core`](https://github.com/badlogic/pi-mono):
+
+```ts
+interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any> {
+  name: string
+  label: string
+  description: string
+  parameters: TParameters
+  execute: (
+    toolCallId: string,
+    params: Static<TParameters>,
+    signal?: AbortSignal,
+    onUpdate?: AgentToolUpdateCallback<TDetails>
+  ) => Promise<AgentToolResult<TDetails>>
+}
+```
+
+The return type:
+
+```ts
+interface AgentToolResult<T = any> {
+  content: Array<{ type: 'text'; text: string }>
+  details: T
+}
+```
+
+## Parameters
+
+Defined using [TypeBox](https://github.com/sinclairzx81/typebox) (`@sinclair/typebox`). The schema is used for LLM function calling and argument validation.
+
+```ts
+import { Type } from '@sinclair/typebox'
+
+parameters: Type.Object({
+  expression: Type.String({ description: 'Math expression to evaluate' }),
+  precision: Type.Optional(Type.Number({ description: 'Decimal places' })),
+})
+```
+
+## Stateless tools
+
+Pure functions with no side effects beyond what they compute. Define directly as an `AgentTool` object.
+
+```ts
+import { Type } from '@sinclair/typebox'
+import type { AgentTool } from '@electric-ax/agents-runtime'
+
+const calculatorTool: AgentTool = {
+  name: 'calculator',
+  label: 'Calculator',
+  description: 'Evaluate mathematical expressions.',
+  parameters: Type.Object({
+    expression: Type.String({ description: 'The expression to evaluate' }),
+  }),
+  execute: async (_toolCallId, params) => {
+    const { expression } = params as { expression: string }
+    const result = evaluate(expression)
+    return {
+      content: [{ type: 'text', text: String(result) }],
+      details: {},
+    }
+  },
+}
+```
+
+## Stateful tools
+
+Use a factory function that receives the `HandlerContext`. The state persists across wakes -- it is backed by the entity's durable stream. Reads go through `ctx.db.collections` and writes go through `ctx.db.actions`.
+
+```ts
+import { Type } from '@sinclair/typebox'
+import type { AgentTool, HandlerContext } from '@electric-ax/agents-runtime'
+
+function createMemoryStoreTool(ctx: HandlerContext): AgentTool {
+  return {
+    name: 'memory_store',
+    label: 'Memory Store',
+    description: 'Persistent key-value store.',
+    parameters: Type.Object({
+      operation: Type.Union([
+        Type.Literal('get'),
+        Type.Literal('set'),
+        Type.Literal('delete'),
+        Type.Literal('list'),
+      ]),
+      key: Type.Optional(Type.String()),
+      value: Type.Optional(Type.String()),
+    }),
+    execute: async (_, params) => {
+      const { operation, key, value } = params as {
+        operation: string
+        key?: string
+        value?: string
+      }
+      if (operation === 'set') {
+        const existing = ctx.db.collections.kv?.get(key!)
+        if (existing) {
+          ctx.db.actions.kv_update({
+            key: key!,
+            updater: (draft) => {
+              draft.value = value!
+            },
+          })
+        } else {
+          ctx.db.actions.kv_insert({ row: { key: key!, value: value! } })
+        }
+        return {
+          content: [{ type: 'text', text: `Stored "${key}"` }],
+          details: {},
+        }
+      }
+      if (operation === 'get') {
+        const entry = ctx.db.collections.kv?.get(key!)
+        const text = entry ? entry.value : `No value found for "${key}"`
+        return { content: [{ type: 'text', text }], details: {} }
+      }
+      if (operation === 'delete') {
+        ctx.db.actions.kv_delete({ key: key! })
+        return {
+          content: [{ type: 'text', text: `Deleted "${key}"` }],
+          details: {},
+        }
+      }
+      // list
+      const entries = ctx.db.collections.kv?.toArray ?? []
+      const text = entries.map((e) => `${e.key}: ${e.value}`).join('\n')
+      return {
+        content: [{ type: 'text', text: text || '(empty)' }],
+        details: {},
+      }
+    },
+  }
+}
+```
+
+The entity state API:
+
+| Operation | Write (via `ctx.db.actions`)                                       | Read (via `ctx.db.collections`)       |
+| --------- | ------------------------------------------------------------------ | ------------------------------------- |
+| Insert    | `ctx.db.actions.<coll>_insert({ row: {...} })`                     | -                                     |
+| Update    | `ctx.db.actions.<coll>_update({ key, updater: (draft) => {...} })` | -                                     |
+| Delete    | `ctx.db.actions.<coll>_delete({ key })`                            | -                                     |
+| Get       | -                                                                  | `ctx.db.collections.<coll>?.get(key)` |
+| List      | -                                                                  | `ctx.db.collections.<coll>?.toArray`  |
+
+## Handler-scoped tools
+
+Use a factory that receives the `HandlerContext`. These tools can spawn entities, observe streams, send messages, and use any other `ctx` primitive.
+
+```ts
+import { Type } from '@sinclair/typebox'
+import type { AgentTool, HandlerContext } from '@electric-ax/agents-runtime'
+
+function createDispatchTool(ctx: HandlerContext): AgentTool {
+  return {
+    name: 'dispatch',
+    label: 'Dispatch',
+    description: 'Spawn a child agent and wait for its response.',
+    parameters: Type.Object({
+      type: Type.String({ description: 'Entity type to spawn' }),
+      systemPrompt: Type.String({ description: 'System prompt for the child' }),
+      task: Type.String({ description: 'Task to send to the child' }),
+    }),
+    execute: async (_, params) => {
+      const { type, systemPrompt, task } = params as {
+        type: string
+        systemPrompt: string
+        task: string
+      }
+      const child = await ctx.spawn(
+        type,
+        `dispatch-${Date.now()}`,
+        { systemPrompt },
+        {
+          initialMessage: task,
+          wake: 'runFinished',
+        }
+      )
+      const text = (await child.text()).join('\n\n')
+      return {
+        content: [{ type: 'text', text }],
+        details: {},
+      }
+    },
+  }
+}
+```
+
+`ctx.spawn` returns an `EntityHandle`. Passing `wake: 'runFinished'` means the parent will be woken when the child's agent run completes. `child.text()` returns all text outputs from the child's stream.
+
+## Wiring tools together
+
+Tools are constructed in the handler and passed to `useAgent`. Include `ctx.electricTools` when your runtime host provides runtime-level tools that the LLM should be able to call:
+
+```ts
+registry.define('assistant', {
+  description: 'An assistant with memory and delegation',
+  state: {
+    kv: { primaryKey: 'key' },
+  },
+  async handler(ctx) {
+    const memoryTool = createMemoryStoreTool(ctx)
+    const dispatchTool = createDispatchTool(ctx)
+
+    ctx.useAgent({
+      systemPrompt: 'You are a helpful assistant with persistent memory.',
+      model: 'claude-sonnet-4-5-20250929',
+      tools: [...ctx.electricTools, memoryTool, dispatchTool, calculatorTool],
+    })
+    await ctx.agent.run()
+  },
+})
+```
+
+When you include `ctx.electricTools`, spread them before your custom tools so host-provided primitives keep their expected order.

--- a/packages/agents/docs/usage/embedded-builtins.md
+++ b/packages/agents/docs/usage/embedded-builtins.md
@@ -1,0 +1,180 @@
+---
+title: Embedded built-ins
+titleTemplate: '... - Electric Agents'
+description: >-
+  Embed the built-in Horton and worker runtime in your own process using
+  @electric-ax/agents, BuiltinAgentsServer, or the entrypoint helpers.
+outline: [2, 3]
+---
+
+# Embedded built-ins
+
+The CLI commands `electric agents start-builtin` and `electric agents quickstart` run the built-in Horton and worker runtime for you. If you need to host those built-ins inside your own process, use the exported APIs from `@electric-ax/agents`.
+
+## BuiltinAgentsServer
+
+`BuiltinAgentsServer` starts an HTTP webhook server, registers `horton` and `worker`, and forwards Electric Agents webhook wakes to the built-in handler.
+
+```ts
+import { BuiltinAgentsServer } from '@electric-ax/agents'
+
+const server = new BuiltinAgentsServer({
+  agentServerUrl: 'http://localhost:4437',
+  port: 4448,
+  workingDirectory: process.cwd(),
+})
+
+await server.start()
+
+console.log(server.url)
+console.log(server.registeredBaseUrl)
+
+// Later, during shutdown:
+await server.stop()
+```
+
+### Options
+
+```ts
+import type { RuntimeRouterConfig } from '@electric-ax/agents-runtime'
+
+type CreateElectricTools = RuntimeRouterConfig['createElectricTools']
+
+interface BuiltinAgentsServerOptions {
+  agentServerUrl: string
+  baseUrl?: string
+  port: number
+  host?: string
+  workingDirectory?: string
+  mockStreamFn?: StreamFn
+  webhookPath?: string
+  createElectricTools?: CreateElectricTools
+}
+```
+
+| Field                 | Description                                                                  |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `agentServerUrl`      | Electric Agents coordinator server URL.                                      |
+| `baseUrl`             | Public base URL used when registering the webhook. Defaults to local URL.    |
+| `port`                | Local webhook server port.                                                   |
+| `host`                | Bind host. Defaults to `127.0.0.1`.                                          |
+| `workingDirectory`    | Directory used by Horton and worker file tools. Defaults to `process.cwd()`. |
+| `mockStreamFn`        | Optional test stream function. Lets you run without `ANTHROPIC_API_KEY`.     |
+| `webhookPath`         | Webhook path. Defaults to `/_electric/builtin-agent-handler`.                |
+| `createElectricTools` | Optional factory for extra tools injected into built-in agent handlers.      |
+
+Without `mockStreamFn`, `ANTHROPIC_API_KEY` must be present before the built-in handler starts.
+
+## createBuiltinAgentHandler
+
+Use `createBuiltinAgentHandler()` when you already have an HTTP server and only need the request handler and runtime objects.
+
+```ts
+import {
+  createBuiltinAgentHandler,
+  registerBuiltinAgentTypes,
+} from '@electric-ax/agents'
+
+const bootstrap = await createBuiltinAgentHandler({
+  agentServerUrl: 'http://localhost:4437',
+  serveEndpoint: 'https://example.com/_electric/builtin-agent-handler',
+  workingDirectory: process.cwd(),
+})
+
+if (!bootstrap) {
+  throw new Error('ANTHROPIC_API_KEY is required for built-in agents')
+}
+
+await registerBuiltinAgentTypes(bootstrap)
+
+// In your HTTP server:
+await bootstrap.handler(req, res)
+```
+
+### Result
+
+```ts
+interface AgentHandlerResult {
+  handler(req: IncomingMessage, res: ServerResponse): Promise<void>
+  runtime: RuntimeHandler
+  registry: EntityRegistry
+  typeNames: string[]
+  skillsRegistry: SkillsRegistry | null
+}
+```
+
+## Extra Electric Tools
+
+Both `BuiltinAgentsServer` and `createBuiltinAgentHandler()` accept `createElectricTools`. The factory receives the same context shape as `RuntimeRouterConfig.createElectricTools` and can add host-specific tools to Horton.
+
+```ts
+import { Type } from '@sinclair/typebox'
+
+const server = new BuiltinAgentsServer({
+  agentServerUrl: 'http://localhost:4437',
+  port: 4448,
+  createElectricTools: ({ entityUrl, upsertCronSchedule }) => [
+    {
+      name: 'schedule_daily_summary',
+      label: 'Schedule daily summary',
+      description: 'Schedule a daily summary wake for this entity.',
+      parameters: Type.Object({
+        hour: Type.Number(),
+      }),
+      execute: async (_id, params) => {
+        const { hour } = params as { hour: number }
+        await upsertCronSchedule({
+          id: 'daily-summary',
+          expression: `0 ${hour} * * *`,
+          payload: `Run daily summary for ${entityUrl}`,
+        })
+        return { content: [{ type: 'text', text: 'Scheduled.' }], details: {} }
+      },
+    },
+  ],
+})
+```
+
+## Entrypoint Helpers
+
+`runBuiltinAgentsEntrypoint()` reads environment variables, creates a `BuiltinAgentsServer`, and starts it. This is what the `electric-agents` package binary uses.
+
+```ts
+import {
+  resolveBuiltinAgentsEntrypointOptions,
+  runBuiltinAgentsEntrypoint,
+} from '@electric-ax/agents'
+
+const options = resolveBuiltinAgentsEntrypointOptions(process.env)
+const { server, url } = await runBuiltinAgentsEntrypoint()
+
+console.log(options.agentServerUrl, url)
+await server.stop()
+```
+
+Environment variables:
+
+| Variable                            | Description                                      |
+| ----------------------------------- | ------------------------------------------------ |
+| `ELECTRIC_AGENTS_SERVER_URL`        | Required coordinator server URL.                 |
+| `ELECTRIC_AGENTS_BUILTIN_BASE_URL`  | Public webhook base URL for the built-in server. |
+| `ELECTRIC_AGENTS_BUILTIN_HOST`      | Bind host.                                       |
+| `ELECTRIC_AGENTS_BUILTIN_PORT`      | Built-in server port. Defaults to `4448`.        |
+| `ELECTRIC_AGENTS_WORKING_DIRECTORY` | Working directory for file tools.                |
+
+## Built-in Agent APIs
+
+The built-in agent exports are also available if you want to compose your own runtime:
+
+| Export                      | Purpose                                               |
+| --------------------------- | ----------------------------------------------------- |
+| `registerHorton()`          | Register the `horton` type on an `EntityRegistry`.    |
+| `registerWorker()`          | Register the `worker` type on an `EntityRegistry`.    |
+| `HORTON_MODEL`              | Default model id used by Horton and worker.           |
+| `buildHortonSystemPrompt()` | Build Horton's system prompt for a working directory. |
+| `createHortonTools()`       | Create Horton's base shell/file/search/worker tools.  |
+| `createSpawnWorkerTool()`   | Create the `spawn_worker` tool for another agent.     |
+| `WORKER_TOOL_NAMES`         | Valid primitive tool names for workers.               |
+| `createHortonDocsSupport()` | Create Horton's docs knowledge-base support.          |
+
+For the behavior of `horton` and `worker`, see [Horton](../entities/agents/horton) and [Worker](../entities/agents/worker).

--- a/packages/agents/docs/usage/managing-state.md
+++ b/packages/agents/docs/usage/managing-state.md
@@ -1,0 +1,93 @@
+---
+title: Managing state
+titleTemplate: '... - Electric Agents'
+description: >-
+  Declare and manage persistent entity state using custom collections with typed CRUD operations.
+outline: [2, 3]
+---
+
+# Managing state
+
+Entities can declare custom persistent collections. The convenience API is `ctx.state.<name>.insert/update/delete/get/toArray`; the lower-level APIs are `ctx.db.actions.<name>_insert/update/delete` for writes and `ctx.db.collections.<name>` for reads. State is backed by the entity's durable stream. Values survive process restarts and are available on every handler invocation.
+
+## Declaring state
+
+Define collections in the `state` field of the entity definition:
+
+```ts
+registry.define('my-entity', {
+  state: {
+    status: { primaryKey: 'key' },
+    items: {
+      schema: z.object({
+        key: z.string(),
+        name: z.string(),
+        count: z.number(),
+      }),
+      primaryKey: 'key',
+    },
+  },
+  async handler(ctx) {
+    /* ... */
+  },
+})
+```
+
+Each key in `state` becomes a collection exposed on `ctx.state`, `ctx.db.actions`, and `ctx.db.collections`.
+
+## CollectionDefinition
+
+```ts
+interface CollectionDefinition {
+  schema?: StandardSchemaV1 // Zod or any Standard Schema validator
+  type?: string // Event type in the stream. Defaults to "state:{name}"
+  primaryKey?: string // Key field. Defaults to "key"
+}
+```
+
+All fields are optional. A minimal collection like `{ primaryKey: 'key' }` works without a schema — rows are untyped.
+
+## Writing and reading state
+
+Use `ctx.state.<collection>` for normal handler code. Its `insert`, `update`, and `delete` methods route through generated actions; its `get` and `toArray` members read from the underlying TanStack DB collection.
+
+The lower-level `ctx.db.actions` object exposes action methods named `<collection>_insert`, `<collection>_update`, and `<collection>_delete`. Reads go through `ctx.db.collections`, which exposes TanStack DB collection objects with `.get(key)` and `.toArray`.
+
+Write helpers return a Transaction. Reads query the underlying TanStack DB collection.
+
+## CRUD operations
+
+```ts
+// Convenience API
+ctx.state.items.insert({ key: 'item-1', name: 'Widget', count: 5 })
+const itemViaState = ctx.state.items.get('item-1')
+const allViaState = ctx.state.items.toArray
+ctx.state.items.update('item-1', (draft) => {
+  draft.count += 1
+})
+ctx.state.items.delete('item-1')
+
+// Lower-level insert
+ctx.db.actions.items_insert({
+  row: { key: 'item-1', name: 'Widget', count: 5 },
+})
+
+// Lower-level read
+const item = ctx.db.collections.items?.get('item-1')
+const all = ctx.db.collections.items?.toArray
+
+// Lower-level update (Immer-style draft)
+ctx.db.actions.items_update({
+  key: 'item-1',
+  updater: (draft) => {
+    draft.count += 1
+  },
+})
+
+// Lower-level delete
+ctx.db.actions.items_delete({ key: 'item-1' })
+```
+
+## Built-in collections
+
+Every entity also has `ctx.db.collections` with runtime-managed collections: `runs`, `steps`, `texts`, `toolCalls`, `errors`, `inbox`, and more. These are read-only from the handler's perspective — the runtime writes to them as the agent operates. See [Built-in collections](../reference/built-in-collections) for details.

--- a/packages/agents/docs/usage/overview.md
+++ b/packages/agents/docs/usage/overview.md
@@ -1,0 +1,284 @@
+---
+title: Overview
+titleTemplate: '... - Electric Agents'
+description: >-
+  High level overview of the Electric Agents system and developer APIs.
+outline: [2, 3]
+---
+
+# Usage overview
+
+High level overview of the Electric&nbsp;Agents system and developer&nbsp;APIs.
+
+## 1. Entity definition (`registry.define()`)
+
+Agents are entities that handle events, defined as a:
+
+- `handler(ctx, wake)` with
+- `state` and [built in collections](#_8-built-in-collections)
+
+And schemas:
+
+- `creationSchema` -- validated spawn args
+- `inboxSchemas` -- typed message contracts
+- `outputSchemas` -- what the entity emits (for UI binding)
+
+See [Defining entities](/docs/agents/usage/defining-entities) and [EntityDefinition reference](/docs/agents/reference/entity-definition).
+
+## 2. Handler context (`ctx`)
+
+The context API passed into the handler:
+
+| Property/Method                     | Purpose                                                               |
+| ----------------------------------- | --------------------------------------------------------------------- |
+| `ctx.firstWake`                     | Boolean -- is this the entity's first activation?                     |
+| `ctx.entityUrl`                     | Identity -- `/type/id`                                                |
+| `ctx.entityType`                    | Type name string                                                      |
+| `ctx.args`                          | Readonly spawn arguments                                              |
+| `ctx.tags`                          | Entity tags -- key/value metadata                                     |
+| `ctx.db`                            | Full TanStack DB: `db.actions` for writes, `db.collections` for reads |
+| `ctx.state`                         | Proxy object keyed by collection name                                 |
+| `ctx.events`                        | Change events that triggered this wake                                |
+| `ctx.useAgent()`                    | Set up the LLM agent                                                  |
+| `ctx.useContext()`                  | Declare context sources with token budgets and cache tiers            |
+| `ctx.timelineMessages()`            | Project the entity timeline into LLM messages                         |
+| `ctx.insertContext(id, entry)`      | Insert a durable context entry                                        |
+| `ctx.agent.run()`                   | Execute the agent loop                                                |
+| `ctx.electricTools`                 | Runtime-provided tools to spread into agent config                    |
+| `ctx.spawn(type, id, args, opts)`   | Create child entity                                                   |
+| `ctx.observe(source, opts)`         | Subscribe to a source via `entity()`, `cron()`, `entities()`, `db()`  |
+| `ctx.send(url, payload, opts)`      | Send message to an entity                                             |
+| `ctx.sleep()`                       | Return to idle                                                        |
+| `ctx.mkdb(id, schema)`              | Create cross-entity shared state                                      |
+| `ctx.observe(db(id, schema), opts)` | Join existing shared state                                            |
+| `ctx.setTag(key, value)`            | Set a tag on this entity                                              |
+| `ctx.removeTag(key)`                | Remove a tag from this entity                                         |
+
+See [Writing handlers](/docs/agents/usage/writing-handlers) and [HandlerContext reference](/docs/agents/reference/handler-context).
+
+## 3. Agent configuration
+
+```ts
+ctx.useAgent({
+  systemPrompt: string,
+  model: string | Model<any>, // e.g. 'claude-sonnet-4-5-20250929'
+  provider?: KnownProvider,   // defaults to 'anthropic' for string models
+  tools: AgentTool[],      // [...ctx.electricTools, ...custom]
+  streamFn?: StreamFn,     // optional streaming callback
+  testResponses?: string[] // for testing without LLM
+})
+await ctx.agent.run()      // blocks until agent finishes
+```
+
+See [Configuring the agent](/docs/agents/usage/configuring-the-agent) and [AgentConfig reference](/docs/agents/reference/agent-config).
+
+## 4. Tool definition
+
+**Stateless tools** are pure functions:
+
+```ts
+const myTool: AgentTool = {
+  name: 'calculator',
+  label: 'Calculator',
+  description: 'Evaluate a mathematical expression.',
+  parameters: Type.Object({ expression: Type.String() }), // TypeBox
+  execute: async (_toolCallId, params) => {
+    const { expression } = params as { expression: string }
+    const result = evaluate(expression)
+    return {
+      content: [{ type: 'text', text: String(result) }],
+      details: {},
+    }
+  },
+}
+```
+
+**Stateful tools** are factories receiving `ctx` for state access:
+
+```ts
+function createMemoryTool(ctx: HandlerContext): AgentTool {
+  return {
+    name: 'memory_store',
+    label: 'Memory Store',
+    description: 'Persist a key-value memory row.',
+    parameters: Type.Object({
+      key: Type.String(),
+      value: Type.String(),
+    }),
+    execute: async (_, params) => {
+      const { key, value } = params as { key: string; value: string }
+      ctx.db.actions.memory_insert({ row: { key, value } }) // writes to entity state
+      return { content: [{ type: 'text', text: 'Stored.' }], details: {} }
+    },
+  }
+}
+```
+
+**Handler-scoped tools** are factories receiving `ctx`:
+
+```ts
+function createDispatchTool(ctx: HandlerContext): AgentTool {
+  return {
+    name: 'dispatch',
+    label: 'Dispatch',
+    description: 'Spawn a worker and return its text output.',
+    parameters: Type.Object({
+      id: Type.String(),
+      systemPrompt: Type.String(),
+      task: Type.String(),
+    }),
+    execute: async (_, params) => {
+      const { id, systemPrompt, task } = params as {
+        id: string
+        systemPrompt: string
+        task: string
+      }
+      const child = await ctx.spawn(
+        'worker',
+        id,
+        { systemPrompt, tools: ['read'] },
+        { initialMessage: task, wake: 'runFinished' }
+      )
+      const text = (await child.text()).join('\n\n')
+      return { content: [{ type: 'text', text }], details: {} }
+    },
+  }
+}
+```
+
+See [Defining tools](/docs/agents/usage/defining-tools) and [AgentTool reference](/docs/agents/reference/agent-tool).
+
+## 5. State collections (`ctx.db`)
+
+Custom state is accessed through `ctx.db`:
+
+**Writes** via `ctx.db.actions`:
+
+- `.<name>_insert({ row })` -- add new row
+- `.<name>_update({ key, updater: (draft) => { ... } })` -- Immer-style mutation
+- `.<name>_delete({ key })` -- remove by primary key
+
+**Reads** via `ctx.db.collections`:
+
+- `.<name>?.get(key)` -- read one
+- `.<name>?.toArray` -- read all (getter, not method)
+
+See [Managing state](/docs/agents/usage/managing-state).
+
+## 6. Entity coordination primitives
+
+- **`spawn(type, id, args, opts)`** -> `EntityHandle` -- create child
+  - `opts.initialMessage` -- first message to deliver
+  - `opts.wake` -- `'runFinished'`, `{ on: 'runFinished', includeResponse? }`, or `{ on: 'change', collections?, debounceMs?, timeoutMs? }`
+- **`observe(source, opts)`** -> `EntityHandle | ObservationHandle` -- subscribe via `entity()`, `cron()`, `entities()`, `db()`
+- **`send(url, payload, opts)`** -- fire-and-forget message
+- **`sleep()`** -- go idle
+
+**EntityHandle** returned from spawn/observe:
+
+- `.entityUrl`, `.type`, `.db` (read-only TanStack DB)
+- `.run` -- Promise that resolves when child completes
+- `.text()` -- get all completed text output
+- `.send(msg)` -- send follow-up message
+- `.status()` -- `ChildStatus | undefined` (object with `.status`, `.entity_url`, `.entity_type`)
+
+See [Spawning & coordinating](/docs/agents/usage/spawning-and-coordinating) and [EntityHandle reference](/docs/agents/reference/entity-handle).
+
+## 7. Shared state (cross-entity)
+
+Define a schema map, then create/connect:
+
+```ts
+const schema = {
+  findings: {
+    schema: z.object({ key: z.string(), text: z.string() }),
+    type: 'shared:finding',
+    primaryKey: 'key',
+  },
+}
+// Parent creates:
+ctx.mkdb('research-123', schema)
+// Children connect:
+const shared = await ctx.observe(db('research-123', schema))
+shared.findings.insert({ key: 'f1', text: '...' })
+```
+
+See [Shared state](/docs/agents/usage/shared-state) and [SharedStateHandle reference](/docs/agents/reference/shared-state-handle).
+
+## 8. Built-in collections
+
+Every entity automatically has 17 `ctx.db.collections`:
+
+| Collection         | Purpose                   | Key fields                                                             |
+| ------------------ | ------------------------- | ---------------------------------------------------------------------- |
+| `runs`             | Agent run lifecycle       | `status: started/completed/failed`                                     |
+| `steps`            | LLM call steps            | `step_number, model_id, duration_ms`                                   |
+| `texts`            | Text message blocks       | `status: streaming/completed`                                          |
+| `textDeltas`       | Incremental text chunks   | `text_id, delta`                                                       |
+| `toolCalls`        | Tool invocation lifecycle | `tool_name, status, args, result`                                      |
+| `reasoning`        | Extended thinking blocks  | `status: streaming/completed`                                          |
+| `errors`           | Diagnostic errors         | `error_code, message`                                                  |
+| `inbox`            | Received messages         | `from, payload, message_type`                                          |
+| `wakes`            | Wake event history        | `source, timeout, changes`                                             |
+| `entityCreated`    | Bootstrap metadata        | `entity_type, args, parent_url`                                        |
+| `entityStopped`    | Shutdown signal           | `timestamp, reason`                                                    |
+| `childStatus`      | Child entity status       | `entity_url, status`                                                   |
+| `manifests`        | Wiring declarations       | discriminated union: child/source/shared-state/effect/context/schedule |
+| `replayWatermarks` | Replay offset tracking    | `source_id, offset`                                                    |
+| `tags`             | Entity tags/labels        | `key, value`                                                           |
+| `contextInserted`  | Context additions         | `id, name, attrs, content, timestamp`                                  |
+| `contextRemoved`   | Context removals          | `id, name, timestamp`                                                  |
+
+See [Built-in collections](/docs/agents/reference/built-in-collections).
+
+## 9. CLI (`electric agents`)
+
+Interact with the system using the Electric Agents CLI:
+
+| Command                                         | Purpose                          |
+| ----------------------------------------------- | -------------------------------- |
+| `electric agents types`                         | List registered entity types     |
+| `electric agents types inspect <name>`          | Show type schema                 |
+| `electric agents spawn /type/id --args '{...}'` | Create entity                    |
+| `electric agents send /type/id 'message'`       | Send message                     |
+| `electric agents observe /type/id`              | Stream entity events             |
+| `electric agents inspect /type/id`              | Show entity state                |
+| `electric agents ps [--type --status --parent]` | List entities                    |
+| `electric agents kill /type/id`                 | Delete entity                    |
+| `electric agents start`                         | Start local dev environment      |
+| `electric agents start-builtin`                 | Start built-in Horton runtime    |
+| `electric agents quickstart`                    | Start local server and built-ins |
+| `electric agents stop`                          | Stop local dev environment       |
+
+See [CLI reference](/docs/agents/reference/cli).
+
+## 10. App setup
+
+```ts
+const registry = createEntityRegistry()
+registerMyEntity(registry)
+
+const runtime = createRuntimeHandler({
+  baseUrl: ELECTRIC_AGENTS_URL, // Electric Agents server
+  serveEndpoint: `${URL}/webhook`, // callback URL
+  registry,
+})
+
+// Node HTTP server, forward POST /webhook -> runtime.onEnter(req, res)
+await runtime.registerTypes() // register all types with runtime server
+```
+
+See [App setup](/docs/agents/usage/app-setup) and [RuntimeHandler reference](/docs/agents/reference/runtime-handler).
+
+## 11. App clients and embedded built-ins
+
+Use the client and embedding APIs when you need to work with agents outside an entity handler:
+
+| API                           | Use case                                                          |
+| ----------------------------- | ----------------------------------------------------------------- |
+| `createAgentsClient()`        | Observe entity, membership, or shared-state streams from app code |
+| `useChat()`                   | Render an observed `EntityStreamDB` in React                      |
+| `createRuntimeServerClient()` | Spawn, message, delete, tag, and schedule entities from services  |
+| `BuiltinAgentsServer`         | Host Horton and worker in your own process                        |
+
+See [Clients & React](/docs/agents/usage/clients-and-react), [Programmatic runtime client](/docs/agents/usage/programmatic-runtime-client), and [Embedded built-ins](/docs/agents/usage/embedded-builtins).

--- a/packages/agents/docs/usage/programmatic-runtime-client.md
+++ b/packages/agents/docs/usage/programmatic-runtime-client.md
@@ -1,0 +1,216 @@
+---
+title: Programmatic runtime client
+titleTemplate: '... - Electric Agents'
+description: >-
+  Use createRuntimeServerClient to spawn entities, send messages, register wakes,
+  manage schedules, and connect shared state from application code.
+outline: [2, 3]
+---
+
+# Programmatic runtime client
+
+`createRuntimeServerClient()` is the lower-level HTTP client for the Electric Agents server. Handler code should usually use `ctx.spawn()`, `ctx.send()`, `ctx.observe()`, and `ctx.mkdb()` instead. Use this client from application services, tests, CLIs, and integration code that needs to manage entities from outside a handler.
+
+```ts
+import { createRuntimeServerClient } from '@electric-ax/agents-runtime'
+
+const client = createRuntimeServerClient({
+  baseUrl: 'http://localhost:4437',
+})
+```
+
+## Config
+
+```ts
+interface RuntimeServerClientConfig {
+  baseUrl: string
+  fetch?: typeof globalThis.fetch
+  track?: <T>(promise: Promise<T>) => Promise<T>
+}
+```
+
+| Field     | Description                                                               |
+| --------- | ------------------------------------------------------------------------- |
+| `baseUrl` | Base URL for the Electric Agents server.                                  |
+| `fetch`   | Optional fetch implementation, useful in tests or non-standard runtimes.  |
+| `track`   | Optional wrapper for all requests, useful for telemetry or pending state. |
+
+## Entity Lifecycle
+
+### spawnEntity
+
+```ts
+const info = await client.spawnEntity({
+  type: 'horton',
+  id: 'onboarding',
+  args: { timezone: 'Europe/London' },
+  initialMessage: 'Help me get started.',
+  tags: { project: 'docs' },
+})
+
+console.log(info.entityUrl) // "/horton/onboarding"
+```
+
+`spawnEntity()` is idempotent for an existing `/{type}/{id}` URL: if the server reports a conflict and returns entity details, the client returns that entity info.
+
+```ts
+interface SpawnEntityOptions {
+  type: string
+  id: string
+  args?: Record<string, unknown>
+  parentUrl?: string
+  initialMessage?: unknown
+  tags?: Record<string, string>
+  wake?: {
+    subscriberUrl: string
+    condition:
+      | 'runFinished'
+      | {
+          on: 'change'
+          collections?: string[]
+          ops?: Array<'insert' | 'update' | 'delete'>
+        }
+    debounceMs?: number
+    timeoutMs?: number
+    includeResponse?: boolean
+  }
+}
+```
+
+### getEntityInfo
+
+```ts
+const info = await client.getEntityInfo('/horton/onboarding')
+// { entityUrl, entityType, streamPath }
+```
+
+### deleteEntity
+
+```ts
+await client.deleteEntity('/horton/onboarding')
+```
+
+Deleting an already-missing entity is treated as success.
+
+## Messages
+
+```ts
+await client.sendEntityMessage({
+  targetUrl: '/horton/onboarding',
+  payload: 'What changed since last time?',
+  from: 'support-ui',
+  type: 'user_message',
+})
+```
+
+```ts
+interface SendEntityMessageOptions {
+  targetUrl: string
+  payload: unknown
+  from?: string
+  type?: string
+  afterMs?: number
+}
+```
+
+`afterMs` asks the server to deliver the message later.
+
+## Shared State
+
+```ts
+const streamPath = await client.ensureSharedStateStream('research-123')
+// "/_electric/shared-state/research-123"
+
+const samePath = client.getSharedStateStreamPath('research-123')
+```
+
+Use `ensureSharedStateStream()` when app code needs to create a shared-state stream before entities connect to it.
+
+## Wakes and Sources
+
+### registerWake
+
+`registerWake()` creates a wake subscription from one source stream to a subscriber entity.
+
+```ts
+await client.registerWake({
+  subscriberUrl: '/coordinator/research',
+  sourceUrl: '/worker/analyst/main',
+  condition: 'runFinished',
+  includeResponse: true,
+})
+```
+
+For change wakes:
+
+```ts
+await client.registerWake({
+  subscriberUrl: '/monitor/main',
+  sourceUrl: '/horton/onboarding/main',
+  condition: {
+    on: 'change',
+    collections: ['runs', 'texts'],
+    ops: ['insert', 'update'],
+  },
+  debounceMs: 250,
+})
+```
+
+### registerCronSource
+
+```ts
+const streamUrl = await client.registerCronSource('0 9 * * *', 'Europe/London')
+```
+
+### registerEntitiesSource
+
+```ts
+const source = await client.registerEntitiesSource({ project: 'docs' })
+// { streamUrl, sourceRef }
+```
+
+This is the lower-level operation behind observing `entities({ tags })`.
+
+## Schedules
+
+Schedules are stored on an entity manifest and return the write transaction id.
+
+```ts
+await client.upsertCronSchedule({
+  entityUrl: '/horton/onboarding',
+  id: 'daily-checkin',
+  expression: '0 9 * * *',
+  timezone: 'Europe/London',
+  payload: 'Run the daily check-in.',
+})
+
+await client.upsertFutureSendSchedule({
+  entityUrl: '/horton/onboarding',
+  id: 'follow-up',
+  fireAt: new Date(Date.now() + 60_000).toISOString(),
+  payload: 'Follow up now.',
+})
+
+await client.deleteSchedule({
+  entityUrl: '/horton/onboarding',
+  id: 'follow-up',
+})
+```
+
+## Tags
+
+`setTag()` and `removeTag()` require the entity write token. Handler code should prefer `ctx.setTag()` and `ctx.removeTag()` because the runtime already has the write token.
+
+```ts
+await client.setTag('/horton/onboarding', 'title', 'Onboarding', writeToken)
+await client.removeTag('/horton/onboarding', 'title', writeToken)
+```
+
+## Choosing a Client
+
+| API                            | Use when                                                                     |
+| ------------------------------ | ---------------------------------------------------------------------------- |
+| `ctx.spawn/send/observe`       | You are inside an entity handler.                                            |
+| `createAgentsClient()`         | You need to observe streams and drive UI state.                              |
+| `createRuntimeServerClient()`  | You need to manage entities, messages, wakes, schedules, or tags externally. |
+| `electric-ax/entity-stream-db` | You need the CLI-style entity stream loader with `close()`.                  |

--- a/packages/agents/docs/usage/shared-state.md
+++ b/packages/agents/docs/usage/shared-state.md
@@ -1,0 +1,169 @@
+---
+title: Shared state
+titleTemplate: '... - Electric Agents'
+description: >-
+  Coordinate across entities with shared state streams, schema definition, and cross-entity reads and writes.
+outline: [2, 3]
+---
+
+# Shared state
+
+Shared state allows multiple entities to read and write the same collections. A parent entity creates a shared state stream, and children connect to it.
+
+## Schema definition
+
+Define a `SharedStateSchemaMap` — a record of collection names to their schemas:
+
+```ts
+const researchSchema = {
+  findings: {
+    schema: z.object({ key: z.string(), domain: z.string(), text: z.string() }),
+    type: 'shared:finding',
+    primaryKey: 'key',
+  },
+}
+```
+
+Each entry requires `type` and `primaryKey`. `schema` is optional but recommended for validation. The `type` is the event type string written to the backing durable stream.
+
+## Creating shared state
+
+The parent entity creates the shared DB stream, typically on `firstWake`:
+
+```ts
+if (ctx.firstWake) {
+  ctx.mkdb('research-123', researchSchema)
+}
+const shared = await ctx.observe(db('research-123', researchSchema))
+```
+
+`mkdb` creates the backing stream. It throws if the DB already exists — creation is always a one-time operation guarded by `firstWake` or your own state checks.
+
+`observe(db(id, schema))` returns a handle for reading and writing. Call it on any wake to get a handle to an existing shared DB.
+
+`observe` accepts an optional `wake` option to re-wake the entity when the shared state changes:
+
+```ts
+const shared = await ctx.observe(db('research-123', researchSchema), {
+  wake: { on: 'change', debounceMs: 500 },
+})
+```
+
+## Connecting from children
+
+Pass the shared DB config to children via spawn args:
+
+```ts
+const child = await ctx.spawn(
+  'worker',
+  'specialist-1',
+  {
+    systemPrompt: '...',
+    sharedDb: { id: 'research-123', schema: researchSchema },
+  },
+  { initialMessage: 'Research topic X', wake: 'runFinished' }
+)
+```
+
+The child entity connects using the args it receives:
+
+```ts
+async handler(ctx) {
+  const args = ctx.args as { sharedDb: { id: string; schema: SharedStateSchemaMap } }
+  const shared = await ctx.observe(db(args.sharedDb.id, args.sharedDb.schema))
+  // Use shared.findings to read and write
+}
+```
+
+## Using the handle
+
+`SharedStateHandle` exposes collection proxies via `StateCollectionProxy` (the same insert/update/delete/get/toArray API):
+
+```ts
+// Insert
+shared.findings.insert({
+  key: 'f1',
+  domain: 'physics',
+  text: 'Finding text...',
+})
+
+// Read
+shared.findings.get('f1')
+shared.findings.toArray
+
+// Update
+shared.findings.update('f1', (draft) => {
+  draft.text = 'Updated'
+})
+
+// Delete
+shared.findings.delete('f1')
+```
+
+## SharedStateHandle type
+
+```ts
+type SharedStateHandle<TSchema extends SharedStateSchemaMap> = {
+  id: string
+} & { [K in keyof TSchema]: StateCollectionProxy }
+```
+
+The `id` property holds the stream identifier. Each key from the schema map becomes a `StateCollectionProxy`.
+
+## Example: debate pattern
+
+The debate pattern uses shared state for pro/con arguments. A moderator creates the stream, spawns workers for each side, and reads all arguments to make a ruling.
+
+```ts
+const debateSchema = {
+  arguments: {
+    schema: z.object({
+      key: z.string(),
+      side: z.enum(['pro', 'con']),
+      text: z.string(),
+      round: z.number(),
+    }),
+    type: 'shared:argument',
+    primaryKey: 'key',
+  },
+}
+
+registry.define('debate', {
+  state: {
+    status: { primaryKey: 'key' },
+  },
+
+  async handler(ctx) {
+    if (ctx.firstWake) {
+      ctx.mkdb(`debate-${ctx.entityUrl}`, debateSchema)
+    }
+    const shared = await ctx.observe(
+      db(`debate-${ctx.entityUrl}`, debateSchema)
+    )
+
+    // Spawn pro and con workers with shared state access
+    const pro = await ctx.spawn(
+      'worker',
+      'debate-pro',
+      {
+        systemPrompt: 'Argue FOR the topic.',
+        sharedDb: { id: `debate-${ctx.entityUrl}`, schema: debateSchema },
+      },
+      { initialMessage: 'The topic is: ...', wake: 'runFinished' }
+    )
+
+    const con = await ctx.spawn(
+      'worker',
+      'debate-con',
+      {
+        systemPrompt: 'Argue AGAINST the topic.',
+        sharedDb: { id: `debate-${ctx.entityUrl}`, schema: debateSchema },
+      },
+      { initialMessage: 'The topic is: ...', wake: 'runFinished' }
+    )
+
+    // Read all arguments written by both workers
+    const allArgs = shared.arguments.toArray
+  },
+})
+```

--- a/packages/agents/docs/usage/spawning-and-coordinating.md
+++ b/packages/agents/docs/usage/spawning-and-coordinating.md
@@ -1,0 +1,165 @@
+---
+title: Spawning & coordinating
+titleTemplate: '... - Electric Agents'
+description: >-
+  Spawn child entities, observe existing ones, send messages, and use EntityHandle for coordination.
+outline: [2, 3]
+---
+
+# Spawning & coordinating
+
+Entities coordinate by spawning children, observing other entities, and sending messages.
+
+## spawn
+
+Create a child entity:
+
+```ts
+const child = await ctx.spawn(type, id, args?, opts?)
+```
+
+| Parameter             | Type                      | Description                            |
+| --------------------- | ------------------------- | -------------------------------------- |
+| `type`                | `string`                  | Entity type name (must be registered)  |
+| `id`                  | `string`                  | Unique child ID                        |
+| `args`                | `Record<string, unknown>` | Passed to child handler as `ctx.args`  |
+| `opts.initialMessage` | `unknown`                 | First message delivered to child       |
+| `opts.wake`           | `Wake`                    | When to wake the parent (see below)    |
+| `opts.tags`           | `Record<string, string>`  | Key-value tags applied to the child    |
+| `opts.observe`        | `boolean`                 | Also observe the child (default: true) |
+
+`spawn` is a creation-only operation. Calling it with a `(type, id)` pair that already exists in the entity's manifest throws an error. Use `observe(entity(url))` to get a handle to an existing child.
+
+The `wake` option controls when the parent's handler is re-invoked:
+
+- `'runFinished'` — wake when the child's agent run completes. The child's text response is included in the wake event by default.
+- `{ on: 'runFinished', includeResponse?: boolean }` — same as above, but set `includeResponse: false` to omit the child's text response from the wake event.
+- `{ on: 'change', collections?: string[], debounceMs?: number, timeoutMs?: number }` — wake when specified collections change.
+
+Returns an [`EntityHandle`](#entityhandle).
+
+## EntityHandle
+
+Returned by `spawn` and `observe`:
+
+```ts
+interface EntityHandle {
+  entityUrl: string
+  type?: string
+  db: EntityStreamDB // Read-only TanStack DB
+  events: ChangeEvent[]
+  run: Promise<void> // Resolves when child's run completes
+  text(): Promise<string[]> // Get completed text outputs
+  send(msg: unknown): void // Send follow-up message
+  status(): ChildStatus | undefined
+}
+```
+
+`status()` returns a `ChildStatus` object (or `undefined` if no status is known yet) with `.status`, `.entity_url`, `.entity_type`, and `.key`.
+
+## Waiting for children
+
+Wait for a single child:
+
+```ts
+await child.run
+const output = (await child.text()).join('\n\n')
+```
+
+Wait for multiple children in parallel:
+
+```ts
+const results = await Promise.all(
+  children.map(async ({ handle }) => ({
+    text: (await handle.text()).join('\n\n'),
+  }))
+)
+```
+
+## observe
+
+Subscribe to an existing entity without spawning it:
+
+```ts
+const handle = await ctx.observe(entity(entityUrl), {
+  wake: { on: 'change', collections: ['runs', 'childStatus'] },
+})
+```
+
+Returns an `EntityHandle`. Use `wake` to re-invoke the parent handler when the observed entity changes.
+
+## send
+
+Fire-and-forget message to another entity:
+
+```ts
+ctx.send('/assistant/target-id', { text: 'Hello' })
+ctx.send('/assistant/target-id', payload, { type: 'custom_type' })
+```
+
+Messages appear in the target entity's `inbox` collection.
+
+## sleep
+
+Return the entity to idle state, ending the current handler invocation:
+
+```ts
+ctx.sleep()
+```
+
+The entity remains alive and can be woken again by incoming messages or observed changes.
+
+## Working with existing children
+
+After spawning children in `firstWake`, use `observe` on subsequent wakes to get handles:
+
+```ts
+async handler(ctx) {
+  if (ctx.firstWake) {
+    await ctx.spawn(
+      "worker",
+      "analyst",
+      { systemPrompt: "...", tools: ["read"] },
+      {
+        initialMessage: "Initial task.",
+        wake: "runFinished",
+      }
+    )
+  }
+
+  const analyst = await ctx.observe(entity("/worker/analyst"))
+
+  if (wake.type === "message_received") {
+    analyst.send(wake.payload)
+  }
+}
+```
+
+`spawn` creates the child once. `observe` returns a handle on every wake — it's how you interact with children after creation.
+
+## Workers and authenticated APIs
+
+Workers are least-privilege sandboxes. The built-in `worker` receives a `systemPrompt`, a selected `tools` subset, an optional `sharedDb` config, and the `initialMessage` delivered at spawn time. Never interpolate secrets (`process.env.API_KEY`, auth tokens) into a worker's prompt or message — they are persisted in the entity's durable stream.
+
+**Manager-side prefetch** is the recommended pattern: the manager does the authenticated fetch and passes the raw data to the worker.
+
+```ts
+// In the manager's tool:
+const response = await fetch(apiUrl, {
+  headers: { Authorization: `Bearer ${process.env.API_KEY}` },
+})
+const data = await response.json()
+
+// Pass data, not credentials, to the worker
+await ctx.spawn(
+  'worker',
+  id,
+  { systemPrompt: 'Summarise this data.', tools: ['read'] },
+  {
+    initialMessage: JSON.stringify(data),
+    wake: 'runFinished',
+  }
+)
+```
+
+When the worker needs to make follow-up authenticated calls (pagination, conditional fetches), register a custom worker entity type in your app that closes over the credential at registration time — don't use the built-in `worker` type for this.

--- a/packages/agents/docs/usage/testing.md
+++ b/packages/agents/docs/usage/testing.md
@@ -1,0 +1,76 @@
+---
+title: Testing
+titleTemplate: '... - Electric Agents'
+description: >-
+  Test entity handlers with testResponses for LLM mocking, plus unit and integration testing patterns.
+outline: [2, 3]
+---
+
+# Testing
+
+## testResponses
+
+Test agent handlers without calling the LLM by providing canned responses:
+
+```ts
+ctx.useAgent({
+  systemPrompt: '...',
+  model: 'claude-sonnet-4-5-20250929',
+  tools: [...ctx.electricTools],
+  testResponses: ['Hello! How can I help?'],
+})
+await ctx.agent.run()
+```
+
+For array responses, the runtime picks a response based on the number of prior runs for the entity, which makes repeated wakes deterministic without calling an LLM. The selected string becomes the agent's text output for that run.
+
+## TestResponseFn
+
+For dynamic test responses, provide a function instead of an array:
+
+```ts
+testResponses: async (message, bridge) => {
+  bridge.onTextStart()
+  bridge.onTextDelta('Test response')
+  bridge.onTextEnd()
+  return 'Test response'
+}
+```
+
+The `bridge` parameter gives control over text-level events, letting you simulate tool calls, reasoning steps, and multi-turn interactions. Returning a string emits it as a text block automatically; returning `undefined` emits no automatic text response.
+
+::: info Runtime-managed lifecycle
+The runtime wraps your `TestResponseFn` with `bridge.onRunStart()` / `bridge.onRunEnd()` and step start/end calls automatically. Do not call these yourself — only use text-level bridge methods (e.g. `onTextStart`, `onTextDelta`, `onTextEnd`) or tool-level methods inside the function.
+:::
+
+## Unit testing entity registration
+
+```ts
+import { createEntityRegistry } from '@electric-ax/agents-runtime'
+
+const registry = createEntityRegistry()
+registerAssistant(registry)
+
+test('registers assistant', () => {
+  const entry = registry.get('assistant')
+  expect(entry).toBeDefined()
+  expect(entry!.definition.handler).toBeTypeOf('function')
+})
+```
+
+## Unit testing runtime creation
+
+```ts
+test('creates runtime with types', () => {
+  const runtime = createRuntimeHandler({
+    baseUrl: 'http://localhost:4437',
+    serveEndpoint: 'http://localhost:3000/webhook',
+    registry,
+  })
+  expect(runtime.typeNames).toContain('assistant')
+})
+```
+
+## Integration testing
+
+Integration testing with the full Electric Agents server is possible using the `@electric-ax/agents-server-conformance-tests` package, which provides test server utilities for running against a live server instance.

--- a/packages/agents/docs/usage/waking-entities.md
+++ b/packages/agents/docs/usage/waking-entities.md
@@ -1,0 +1,148 @@
+---
+title: Waking entities
+titleTemplate: '... - Electric Agents'
+description: >-
+  How entity handlers get invoked - the triggers that produce wakes, how wake config threads through spawn/observe/observe(db(...)), and how to read a WakeEvent in a handler.
+outline: [2, 3]
+---
+
+# Waking entities
+
+Entities in Electric Agents are driven by **wakes**. A wake is a single handler invocation triggered by something outside the handler: a new message, a child finishing, a change in an observed stream, or a schedule. Between wakes the entity is idle — no process, no memory, no running handler.
+
+Everything you do to make an entity respond to something — `ctx.spawn(..., { wake })`, `ctx.observe(..., { wake })`, `ctx.send()`, `upsertCronSchedule()` — is ultimately a way to produce a wake.
+
+## The mental model
+
+```
+external event  ─►  wake entry (persisted)  ─►  handler invocation  ─►  WakeEvent passed to handler
+```
+
+1. **External event.** A message arrives, a child transitions, a watched collection changes, a cron fires.
+2. **Wake entry is persisted** to the entity's stream. This is the durability guarantee — wakes survive process restarts, network blips, and crashes. A wake that was written will eventually be delivered to a handler.
+3. **Handler is invoked.** The runtime picks up the wake, loads the entity's state, and calls your handler with a `WakeEvent` describing what triggered this invocation.
+4. **Handler runs.** You read `ctx.events`, inspect `wake`, configure the agent, emit new events. When the handler returns (or calls `ctx.sleep()`), the entity goes idle until the next wake.
+
+This means handlers are re-entrant: the same handler function is called fresh on every wake. Use `ctx.firstWake` for one-time initialization, and `ctx.db.actions` / `ctx.db.collections` to carry state across wakes.
+
+## What produces a wake
+
+There are five things that can wake an entity:
+
+### 1. An incoming message
+
+Any external `/send` (via the CLI, HTTP, or another entity's `ctx.send()`) appends a `message_received` event to the entity's stream, which wakes the handler:
+
+```ts
+ctx.send('/assistant/peer', { text: 'hello' })
+```
+
+The receiving handler sees `wake.type === "message_received"` and finds the payload on `wake.payload`.
+
+### 2. A spawned child
+
+Pass `wake` when spawning a child to control when the parent wakes:
+
+```ts
+const child = await ctx.spawn(
+  'worker',
+  'analysis-1',
+  { systemPrompt: 'Analyse this input.', tools: ['read'] },
+  {
+    initialMessage: 'begin',
+    wake: { on: 'runFinished', includeResponse: true },
+  }
+)
+```
+
+See the full catalog of `Wake` values in [WakeEvent](../reference/wake-event#wake).
+
+### 3. An observed entity
+
+`ctx.observe()` subscribes to another entity's stream without spawning it. Pair it with a `wake` option to re-invoke this handler when the observed stream changes:
+
+```ts
+import { entity } from '@electric-ax/agents-runtime'
+
+await ctx.observe(entity(someEntityUrl), {
+  wake: { on: 'change', collections: ['status'], debounceMs: 250 },
+})
+```
+
+The `entity()` helper wraps a raw URL string into the correct observe target type.
+
+### 4. Shared state
+
+`observe(db(...))` connects to a shared-state stream and, with `wake`, re-wakes the connecting entity when its collections change:
+
+```ts
+await ctx.observe(db('board-1', schema), {
+  wake: { on: 'change', collections: ['findings'] },
+})
+```
+
+### 5. A schedule
+
+Runtime hosts can expose schedule-management tools through `ctx.electricTools`. The current schedule tool set is `list_schedules`, `upsert_cron_schedule`, `upsert_future_send`, and `delete_schedule`. Schedule entries live on the entity's manifest, so they survive restarts and can be updated or cancelled idempotently.
+
+## Reading a WakeEvent
+
+Your handler signature is:
+
+```ts
+handler(ctx: HandlerContext, wake: WakeEvent) => void | Promise<void>
+```
+
+The minimum useful pattern is to branch on `wake.type`:
+
+```ts
+async handler(ctx, wake) {
+  if (wake.type === "message_received") {
+    // external input - reply, dispatch, etc.
+    ctx.useAgent({ ... })
+    await ctx.agent.run()
+    return
+  }
+
+  // everything else (child finished, change, cron, timeout) arrives as type "wake".
+  // Inspect wake.payload for the specific sub-kind.
+  ctx.sleep()
+}
+```
+
+Two wake types reach handlers directly:
+
+- `"message_received"` — an external message was delivered to this entity's inbox.
+- `"wake"` — a synthesised wake for anything else (child finished, collection change, cron, timeout). The specifics are on `wake.payload`. A future-send schedule delivers a message, so it arrives as `"message_received"`.
+
+For the full payload shape (`changes[]`, `finished_child`, `other_children`, `timeout`), see the [wake-type catalog](../reference/wake-event#wake-type-catalog) in the reference.
+
+## Coalescing and idempotency
+
+Multiple external events that arrive while an entity is busy (or between acks) are coalesced into a single wake. The runtime guarantees that:
+
+- A wake covers a contiguous range of offsets in the source stream (`wake.fromOffset`..`wake.toOffset`).
+- `wake.eventCount` tells you how many new events this wake represents.
+- Handlers must be safe to re-run with the same input — at-least-once delivery. Use `ctx.firstWake` and idempotent writes to collections rather than side effects on each wake.
+
+If you need to deduplicate explicitly, key your writes by something stable (the child's entity URL, the message's producer/epoch/seq headers, etc.) and let the collection's primary key do the dedup.
+
+## Debounce and timeouts on `change` wakes
+
+`{ on: 'change' }` has two knobs worth understanding:
+
+- `debounceMs` — if set, rapid-fire changes are batched; the wake fires `debounceMs` after the last change.
+- `timeoutMs` — if set, the wake fires after this interval **even if nothing changed**. Useful for heartbeat-style handlers that need to periodically check state without requiring external events.
+
+Both are optional. If neither is set, every change produces a wake.
+
+## Sleeping between wakes
+
+When the handler finishes (or calls `ctx.sleep()`), the entity returns to idle. The runtime persists the ack offset so the next wake starts from the right place. You don't have to — and shouldn't — hold resources across wakes.
+
+## See also
+
+- [WakeEvent](../reference/wake-event) — full type reference and wake-type catalog.
+- [Spawning & coordinating](./spawning-and-coordinating) — using `wake` with `spawn` and `observe`.
+- [Shared state](./shared-state) — using `wake` with `observe(db(...))`.
+- [Writing handlers](./writing-handlers) — `HandlerContext` and `firstWake` patterns.

--- a/packages/agents/docs/usage/writing-handlers.md
+++ b/packages/agents/docs/usage/writing-handlers.md
@@ -1,0 +1,267 @@
+---
+title: Writing handlers
+titleTemplate: '... - Electric Agents'
+description: >-
+  Implement entity handlers using HandlerContext and WakeEvent, with patterns for first wake, messaging, and tool use.
+outline: [2, 3]
+---
+
+# Writing handlers
+
+The handler is the function that runs each time an entity wakes. It receives a `HandlerContext` and a `WakeEvent` describing what triggered the invocation.
+
+## Signature
+
+```ts
+handler(ctx: HandlerContext, wake: WakeEvent) => void | Promise<void>
+```
+
+## HandlerContext
+
+```ts
+interface HandlerContext<TState extends StateProxy = StateProxy> {
+  firstWake: boolean
+  tags: Readonly<EntityTags>
+  entityUrl: string
+  entityType: string
+  args: Readonly<Record<string, unknown>>
+  db: EntityStreamDBWithActions
+  state: TState
+  events: Array<ChangeEvent>
+  actions: Record<string, (...args: unknown[]) => unknown>
+  electricTools: AgentTool[]
+  useAgent: (config: AgentConfig) => AgentHandle
+  useContext: (config: UseContextConfig) => void
+  timelineMessages: (opts?: TimelineProjectionOpts) => Array<TimestampedMessage>
+  insertContext: (id: string, entry: ContextEntryInput) => void
+  removeContext: (id: string) => void
+  getContext: (id: string) => ContextEntry | undefined
+  listContext: () => Array<ContextEntry>
+  agent: AgentHandle
+  spawn: (
+    type: string,
+    id: string,
+    args?: Record<string, unknown>,
+    opts?: {
+      initialMessage?: unknown
+      wake?: Wake
+      tags?: Record<string, string>
+      observe?: boolean
+    }
+  ) => Promise<EntityHandle>
+  observe: (
+    source: ObservationSource,
+    opts?: { wake?: Wake }
+  ) => Promise<EntityHandle | SharedStateHandle | ObservationHandle>
+  mkdb: <T extends SharedStateSchemaMap>(
+    id: string,
+    schema: T
+  ) => SharedStateHandle<T>
+  send: (
+    entityUrl: string,
+    payload: unknown,
+    opts?: { type?: string; afterMs?: number }
+  ) => void
+  setTag: (key: string, value: string) => Promise<void>
+  removeTag: (key: string) => Promise<void>
+  sleep: () => void
+}
+```
+
+### Property reference
+
+| Property           | Description                                                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `firstWake`        | `true` on the entity's first activation ever. Use for initialization.                                                                                   |
+| `tags`             | Entity tags -- key/value metadata associated with this entity.                                                                                          |
+| `entityUrl`        | The entity's URL path, e.g. `"/assistant/my-chat"`.                                                                                                     |
+| `entityType`       | The registered type name, e.g. `"assistant"`.                                                                                                           |
+| `args`             | Arguments passed when the entity was spawned. Immutable.                                                                                                |
+| `db`               | The entity's stream database. Use `db.actions` for writes and `db.collections` for reads.                                                               |
+| `state`            | Proxy object keyed by collection name. Each property is a [`StateCollectionProxy`](../reference/state-collection-proxy).                                |
+| `events`           | Change events that triggered this wake.                                                                                                                 |
+| `actions`          | Custom non-CRUD action functions from the entity definition's `actions` factory.                                                                        |
+| `electricTools`    | Host-provided runtime-level tools to pass to `useAgent` when needed. May be empty.                                                                      |
+| `useAgent`         | Configures the LLM agent. Returns an `AgentHandle`. See [Configuring the agent](./configuring-the-agent).                                               |
+| `useContext`       | Declares context sources with token budgets and cache tiers. See [Context composition](./context-composition).                                          |
+| `timelineMessages` | Projects the entity timeline into LLM messages. See [Context composition](./context-composition#timelinemessages).                                      |
+| `insertContext`    | Inserts a durable context entry. See [Context composition](./context-composition#context-entries).                                                      |
+| `removeContext`    | Removes a context entry by id.                                                                                                                          |
+| `getContext`       | Gets a context entry by id, or `undefined` if not found.                                                                                                |
+| `listContext`      | Lists all context entries.                                                                                                                              |
+| `agent`            | The configured agent handle. Call `agent.run()` to start the agent loop.                                                                                |
+| `spawn`            | Creates a child entity. See [Spawning and coordinating](./spawning-and-coordinating).                                                                   |
+| `observe`          | Connects to another entity's stream or shared db. See [Reactive observers](../entities/patterns/reactive-observers) and [Shared state](./shared-state). |
+| `mkdb`             | Creates a new shared state stream. See [Shared state](./shared-state).                                                                                  |
+| `send`             | Sends a message to another entity's inbox. Supports delayed delivery via `afterMs`.                                                                     |
+| `setTag`           | Sets a tag on this entity.                                                                                                                              |
+| `removeTag`        | Removes a tag from this entity.                                                                                                                         |
+| `sleep`            | Returns the entity to idle without re-waking.                                                                                                           |
+
+## WakeEvent
+
+Describes what triggered this handler invocation.
+
+```ts
+type WakeEvent = {
+  source: string
+  type: string
+  fromOffset: number
+  toOffset: number
+  eventCount: number
+  payload?: unknown
+  summary?: string
+  fullRef?: string
+}
+```
+
+| Field        | Description                                                                                                                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `source`     | The stream or entity that caused the wake.                                                                                     |
+| `type`       | The wake type: `"message_received"` for inbox messages or `"wake"` for child completion, observed changes, cron, and timeouts. |
+| `fromOffset` | Start offset of the events that triggered this wake.                                                                           |
+| `toOffset`   | End offset of the events that triggered this wake.                                                                             |
+| `eventCount` | Number of new events since last wake.                                                                                          |
+| `payload`    | Optional payload from the trigger event.                                                                                       |
+| `summary`    | Optional human-readable summary.                                                                                               |
+| `fullRef`    | Optional full reference string for the trigger.                                                                                |
+
+## Typical handler pattern
+
+Most handlers follow the same structure: initialize state on first wake, configure the agent, run the agent.
+
+```ts
+registry.define('assistant', {
+  description: 'A general-purpose assistant',
+  state: {
+    status: { primaryKey: 'key' },
+  },
+
+  async handler(ctx) {
+    if (ctx.firstWake) {
+      ctx.db.actions.status_insert({ row: { key: 'current', value: 'idle' } })
+    }
+
+    ctx.useAgent({
+      systemPrompt: 'You are a helpful assistant.',
+      model: 'claude-sonnet-4-5-20250929',
+      tools: [...ctx.electricTools],
+    })
+    await ctx.agent.run()
+  },
+})
+```
+
+## AgentConfig
+
+Passed to `ctx.useAgent()`:
+
+```ts
+interface AgentConfig {
+  systemPrompt: string
+  model: string | Model<any>
+  provider?: KnownProvider
+  tools: AgentTool[]
+  streamFn?: StreamFn
+  testResponses?: string[] | TestResponseFn
+}
+```
+
+## firstWake
+
+`ctx.firstWake` is `true` only on the entity's very first activation. Use it for one-time initialization:
+
+```ts
+async handler(ctx) {
+  if (ctx.firstWake) {
+    ctx.db.actions.status_insert({ row: { key: 'current', value: 'idle' } })
+    ctx.db.actions.counters_insert({ row: { key: 'runs', value: 0 } })
+  }
+  // ...
+}
+```
+
+On subsequent wakes (new messages, child completion, etc.), `firstWake` is `false`.
+
+## sleep
+
+Call `ctx.sleep()` to return the entity to idle without triggering a re-wake. The handler exits and the entity waits for the next external event.
+
+```ts
+async handler(ctx, wake) {
+  if (wake.type === 'some-condition') {
+    // Nothing to do right now
+    ctx.sleep()
+    return
+  }
+  // Otherwise, run the agent
+  ctx.useAgent({ ... })
+  await ctx.agent.run()
+}
+```
+
+## Using spawn args
+
+Arguments passed at spawn time are available as `ctx.args`. This is how you parameterize entity behavior:
+
+```ts
+// Spawning side
+const child = await ctx.spawn('worker', 'analysis-1', {
+  systemPrompt: 'You are an analyst.',
+  tools: ['read'],
+})
+
+// Worker handler
+async handler(ctx) {
+  const { systemPrompt } = ctx.args as { systemPrompt: string }
+  ctx.useAgent({
+    systemPrompt,
+    model: 'claude-sonnet-4-5-20250929',
+    tools: [...ctx.electricTools],
+  })
+  await ctx.agent.run()
+}
+```
+
+## Adding custom tools
+
+Combine `ctx.electricTools` with custom tools:
+
+```ts
+async handler(ctx) {
+  const myTool: AgentTool = {
+    name: 'lookup',
+    label: 'Lookup',
+    description: 'Looks up a value by key',
+    parameters: Type.Object({
+      key: Type.String({ description: 'The key to look up' }),
+    }),
+    execute: async (_toolCallId, params) => {
+      const { key } = params as { key: string }
+      const row = ctx.db.collections.kv?.get(key)
+      return {
+        content: [{ type: 'text', text: row ? JSON.stringify(row) : 'Not found' }],
+        details: {},
+      }
+    },
+  }
+
+  ctx.useAgent({
+    systemPrompt: 'You are an assistant with lookup capabilities.',
+    model: 'claude-sonnet-4-5-20250929',
+    tools: [...ctx.electricTools, myTool],
+  })
+  await ctx.agent.run()
+}
+```
+
+## Sending messages
+
+Use `ctx.send()` to deliver a message to another entity's inbox:
+
+```ts
+ctx.send('/worker/task-1', { action: 'process', data: payload })
+ctx.send('/worker/task-1', payload, { type: 'custom_type' })
+```
+
+The target entity will be woken to process the message.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -60,6 +60,7 @@
   },
   "files": [
     "dist",
+    "docs",
     "skills"
   ],
   "sideEffects": false,

--- a/packages/agents/skills/quickstart.md
+++ b/packages/agents/skills/quickstart.md
@@ -105,6 +105,7 @@ Once the directory is confirmed, read `server.ts` in that directory:
 - Worker spawn args MUST include `tools` array (e.g. `tools: ["bash", "read"]`).
 - Prefer showing what changed between steps rather than repeating the entire file.
 - Use `edit` tool for small changes (like updating server.ts). Use `write` for full entity file updates.
+- If the user asks a question about Electric Agents concepts, APIs, or patterns between steps, use the `search_durable_agents_docs` tool to look up the answer in the built-in documentation before guessing or searching the web.
 
 ---
 

--- a/packages/agents/src/docs/knowledge-base.ts
+++ b/packages/agents/src/docs/knowledge-base.ts
@@ -331,6 +331,8 @@ export function resolveDocsRoot(workingDirectory: string): string | null {
     process.env.HORTON_DOCS_ROOT,
     path.resolve(workingDirectory, `electric-agents-docs/docs`),
     path.resolve(process.cwd(), `electric-agents-docs/docs`),
+    path.resolve(MODULE_DIR, `../docs`),
+    path.resolve(MODULE_DIR, `../../docs`),
     path.resolve(MODULE_DIR, `../../../../../electric-agents-docs/docs`),
   ].filter((value): value is string => typeof value === `string`)
 


### PR DESCRIPTION
## Summary

- Copies 39 markdown files from the [agents docs site](https://github.com/electric-sql/new-electric-website/tree/main/website/docs/agents) into `packages/agents/docs/` so Horton's knowledge base works out of the box
- Adds `"docs"` to the `files` field in `package.json` so docs ship with npm publish and Docker builds
- Updates `resolveDocsRoot` to find docs relative to the module directory — works in both dev (`src/docs/`) and production (`dist/`)
- Updates the quickstart skill to tell the agent to use `search_durable_agents_docs` when users ask questions between tutorial steps

## Test plan

- [x] `horton-docs-support` test passes (full ingestion + hybrid search pipeline)
- [x] `npm pack --dry-run` confirms all 39 doc files included in tarball
- [x] Verified `start-builtin` logs `[horton-docs] indexed 39 docs` and Horton answers docs questions using the search tool
- [x] Pre-existing test failures unchanged (5 suites need `agents-runtime` built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)