### PR TITLE
chore: narrower CI runs

### DIFF
--- a/.github/actions/test-example/action.yml
+++ b/.github/actions/test-example/action.yml
@@ -24,7 +24,12 @@ runs:
         cache: pnpm
     - shell: bash
       if: inputs.example_url != ''
-      run: pnpm install --frozen-lockfile
+      run: |
+        if [ -f "examples/${{ inputs.test_folder }}/package.json" ]; then
+          pnpm --filter "$(jq -r .name "examples/${{ inputs.test_folder }}/package.json")..." --filter @electric-examples/shared install --frozen-lockfile
+        else
+          pnpm install --frozen-lockfile
+        fi
     - name: Run browser tests
       if: inputs.example_url != ''
       working-directory: examples/${{ inputs.test_folder }}

--- a/.github/workflows/deploy_all_examples.yml
+++ b/.github/workflows/deploy_all_examples.yml
@@ -8,35 +8,26 @@ concurrency:
   group: ${{ github.event_name == 'push' && 'prod-deploy-group' || format('examples-pr-{0}', github.event.number) }}
 
 jobs:
+  example-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-example-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create example matrix
+        id: create-example-matrix
+        run: node scripts/ci/example-matrix.mjs deployAll
+
   deploy:
     name: Deploy ${{ matrix.example.name }} example
+    needs: example-matrix
     environment: 'Production'
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       fail-fast: false
-      matrix:
-        example:
-          - name: yjs
-            path: examples/yjs
-          - name: linearlite-read-only
-            path: examples/linearlite-read-only
-          - name: write-patterns
-            path: examples/write-patterns
-          - name: nextjs
-            path: examples/nextjs
-          - name: todo-app
-            path: examples/todo-app
-          - name: proxy-auth
-            path: examples/proxy-auth
-          - name: remix
-            path: examples/remix
-          - name: react
-            path: examples/react
-          - name: burn
-            path: examples/burn
-          - name: tanstack-db-web-starter
-            path: examples/tanstack-db-web-starter
+      matrix: ${{ fromJson(needs.example-matrix.outputs.matrix) }}
 
     env:
       DEPLOY_ENV: 'production'
@@ -73,7 +64,12 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          if [ -f "${{ matrix.example.path }}/package.json" ]; then
+            pnpm --filter "$(jq -r .name "${{ matrix.example.path }}/package.json")..." --filter @electric-examples/shared install --frozen-lockfile
+          else
+            pnpm install --frozen-lockfile
+          fi
 
       - name: Cache SST state
         uses: actions/cache@v4

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -10,69 +10,32 @@ concurrency:
   group: ${{ github.event_name == 'push' && 'prod-deploy-group' || format('examples-pr-{0}', github.event.number) }}
 
 jobs:
-  changed-files:
+  example-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.create-example-matrix.outputs.matrix }}
-      has_changes: ${{ steps.create-example-matrix.outputs.has_changes }}
+      has_examples: ${{ steps.create-example-matrix.outputs.has_examples }}
     steps:
       - uses: actions/checkout@v4
-      - name: Check for changed files
-        id: changed-files
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
         with:
-          path: 'examples'
-          diff_relative: true
-          dir_names: true
-          dir_names_max_depth: 1
-          # Whitelist examples that need to be deployed
-          files: |
-            yjs/**
-            linearlite-read-only/**
-            write-patterns/**
-            nextjs/**
-            todo-app/**
-            proxy-auth/**
-            phoenix-liveview/**
-            tanstack/**
-            remix/**
-            react/**
-            burn/**
-            tanstack-db-web-starter/**
+          fetch-depth: 0
 
       - name: Create example matrix
         id: create-example-matrix
-        run: |
-          # Get changed example directories
-          CHANGED_DIRS="${{ steps.changed-files.outputs.all_changed_files }}"
-
-          # Initialize empty JSON array
-          MATRIX='{"example":[]}'
-          HAS_CHANGES="false"
-
-          # Add each changed directory to the matrix
-          if [ -n "$CHANGED_DIRS" ]; then
-            for dir in $CHANGED_DIRS; do
-              name=$(basename $dir)
-              MATRIX=$(echo $MATRIX | jq --arg name "$name" --arg path "examples/$name" '.example += [{"name": $name, "path": $path}]')
-              HAS_CHANGES="true"
-            done
-          fi
-
-          # Use jq to properly format and escape the JSON
-          echo "matrix=$(echo $MATRIX | jq -c '.')" >> $GITHUB_OUTPUT
-          echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
+        env:
+          BASE_SHA: ${{ github.event.before }}
+        run: node scripts/ci/example-matrix.mjs changed-deployable
 
   deploy:
     name: Deploy ${{ matrix.example.name }}
     environment: ${{ github.event_name == 'push' && 'Production' || 'Pull request' }}
     runs-on: ubuntu-latest
     continue-on-error: true
-    needs: changed-files
-    if: ${{ needs.changed-files.outputs.has_changes == 'true' }}
+    needs: example-matrix
+    if: ${{ needs.example-matrix.outputs.has_examples == 'true' }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.changed-files.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.example-matrix.outputs.matrix) }}
 
     outputs:
       yjs: ${{ steps.deploy.outputs.yjs }}
@@ -125,7 +88,12 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          if [ -f "${{ matrix.example.path }}/package.json" ]; then
+            pnpm --filter "$(jq -r .name "${{ matrix.example.path }}/package.json")..." --filter @electric-examples/shared install --frozen-lockfile
+          else
+            pnpm install --frozen-lockfile
+          fi
 
       - name: Cache SST state
         uses: actions/cache@v4
@@ -145,143 +113,22 @@ jobs:
           if [ -f ".sst/outputs.json" ]; then
             website=$(jq -r '.website' .sst/outputs.json)
             echo "${{ matrix.example.name }}=$website" >> $GITHUB_OUTPUT
+            echo "website=$website" >> $GITHUB_OUTPUT
           else
             echo "sst outputs file not found. Exiting."
             exit 123
           fi
 
-  test-examples:
-    name: Test examples
-    needs: deploy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test remix example
-        id: remix
-        continue-on-error: true
+      - name: Test deployed example
+        if: ${{ matrix.example.deploy_test_folder != '' }}
         uses: ./.github/actions/test-example
         with:
-          test_folder: remix
-          example_url: ${{ needs.deploy.outputs.remix || '' }}
-
-      - name: Test nextjs example
-        id: nextjs
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: nextjs
-          example_url: ${{ needs.deploy.outputs.nextjs || '' }}
-
-      - name: Test tanstack example
-        id: tanstack
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: tanstack
-          example_url: ${{ needs.deploy.outputs.tanstack || '' }}
-
-      - name: Test react example
-        id: react
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: ${{ needs.deploy.outputs.react || '' }}
-
-      - name: Test phoenix liveview example
-        id: liveview
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: phoenix-liveview
-          example_url: ${{ needs.deploy.outputs.phoenix-liveview || '' }}
-
-      - name: Test burn example
-        id: burn
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: burn
-          example_url: ${{ needs.deploy.outputs.burn || '' }}
-
-      - name: Test yjs example
-        id: yjs
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: ${{ needs.deploy.outputs.yjs || '' }}
-
-      - name: Test linearlite read-only example
-        id: linearlite-read-only
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: ${{ needs.deploy.outputs.linearlite-read-only || '' }}
-
-      - name: Test write patterns example
-        id: write-patterns
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: ${{ needs.deploy.outputs.write-patterns || '' }}
-
-      - name: Test todo-app example
-        id: todo-app
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: ${{ needs.deploy.outputs.todo-app || '' }}
-
-      - name: Report test failures
-        if: |
-          steps.remix.outcome == 'failure' ||
-          steps.nextjs.outcome == 'failure' ||
-          steps.tanstack.outcome == 'failure' ||
-          steps.react.outcome == 'failure' ||
-          steps.liveview.outcome == 'failure' ||
-          steps.yjs.outcome == 'failure' ||
-          steps.linearlite-read-only.outcome == 'failure' ||
-          steps.write-patterns.outcome == 'failure' ||
-          steps.todo-app.outcome == 'failure'
-        run: |
-          echo "The following examples failed:"
-          if [ "${{ steps.remix.outcome }}" == "failure" ]; then
-            echo "- Remix example"
-          fi
-          if [ "${{ steps.nextjs.outcome }}" == "failure" ]; then
-            echo "- Next.js example"
-          fi
-          if [ "${{ steps.tanstack.outcome }}" == "failure" ]; then
-            echo "- TanStack example"
-          fi
-          if [ "${{ steps.react.outcome }}" == "failure" ]; then
-            echo "- React example"
-          fi
-          if [ "${{ steps.liveview.outcome }}" == "failure" ]; then
-            echo "- Phoenix LiveView example"
-          fi
-          if [ "${{ steps.yjs.outcome }}" == "failure" ]; then
-            echo "- Yjs example"
-          fi
-          if [ "${{ steps.linearlite-read-only.outcome }}" == "failure" ]; then
-            echo "- LinearLite read-only example"
-          fi
-          if [ "${{ steps.write-patterns.outcome }}" == "failure" ]; then
-            echo "- Write patterns example"
-          fi
-          if [ "${{ steps.todo-app.outcome }}" == "failure" ]; then
-            echo "- Todo app example"
-          fi
-          exit 1
+          test_folder: ${{ matrix.example.deploy_test_folder }}
+          example_url: ${{ steps.deploy.outputs.website }}
 
   comment:
-    if: github.event_name == 'pull_request' && needs.changed-files.outputs.has_changes == 'true'
-    needs: [changed-files, deploy]
+    if: github.event_name == 'pull_request' && needs.example-matrix.outputs.has_examples == 'true'
+    needs: [example-matrix, deploy]
     runs-on: ubuntu-latest
     steps:
       - name: Create PR comment with deployment URLs
@@ -290,7 +137,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // Get the matrix of examples that were deployed
-            const matrix = JSON.parse(${{ toJSON(needs.changed-files.outputs.matrix) }})
+            const matrix = JSON.parse(${{ toJSON(needs.example-matrix.outputs.matrix) }})
 
             const urls = {
               yjs: "${{ needs.deploy.outputs.yjs }}",

--- a/.github/workflows/docker_multiarch_image.yml
+++ b/.github/workflows/docker_multiarch_image.yml
@@ -67,6 +67,29 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Derive push-by-digest image repositories
+        id: image_repos
+        env:
+          IMAGE_REPO: ${{ inputs.image_repo }}
+          IMAGE_TAGS: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+
+          repos_file="$(mktemp)"
+          printf '%s\n' "$IMAGE_REPO" >> "$repos_file"
+
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              printf '%s\n' "${tag%:*}" >> "$repos_file"
+            fi
+          done <<< "$IMAGE_TAGS"
+
+          {
+            echo "repos<<EOF"
+            sort -u "$repos_file"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: useblacksmith/build-push-action@v2
@@ -78,7 +101,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          tags: ${{ inputs.image_repo }}
+          tags: ${{ steps.image_repos.outputs.repos }}
 
       - name: Export digest
         run: |
@@ -110,22 +133,21 @@ jobs:
 
       - name: Create multi-arch manifest list
         env:
-          IMAGE_REPO: ${{ inputs.image_repo }}
           IMAGE_TAGS: ${{ inputs.tags }}
         run: |
           set -euo pipefail
 
-          TAG_ARGS=""
           while IFS= read -r tag; do
-            if [ -n "$tag" ]; then
-              TAG_ARGS="$TAG_ARGS -t $tag"
+            if [ -z "$tag" ]; then
+              continue
             fi
+
+            image_repo="${tag%:*}"
+            image_sources=$(
+              for f in /tmp/digests/*.digest; do
+                echo "$image_repo@$(cat "$f")"
+              done
+            )
+
+            docker buildx imagetools create -t "$tag" $image_sources
           done <<< "$IMAGE_TAGS"
-
-          IMAGE_SOURCES=$(
-            for f in /tmp/digests/*.digest; do
-              echo $IMAGE_REPO@$(cat "$f")
-            done
-          )
-
-          docker buildx imagetools create $TAG_ARGS $IMAGE_SOURCES

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,13 +3,19 @@ name: Lux Integration Tests
 on:
   push:
     branches: ['main']
-    paths-ignore:
-      - 'website/**'
-      - '**/README.md'
+    paths:
+      - '.github/workflows/integration_tests.yml'
+      - '.tool-versions'
+      - 'integration-tests/**'
+      - 'packages/electric-telemetry/**'
+      - 'packages/sync-service/**'
   pull_request:
-    paths-ignore:
-      - 'website/**'
-      - '**/README.md'
+    paths:
+      - '.github/workflows/integration_tests.yml'
+      - '.tool-versions'
+      - 'integration-tests/**'
+      - 'packages/electric-telemetry/**'
+      - 'packages/sync-service/**'
 
 permissions:
   contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
           node-version-file: '.tool-versions'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm --filter @electric-sql/client... --filter @electric-sql/react... --filter @electric-sql/y-electric... install --frozen-lockfile
       - name: Build Packages
         run: pnpm --filter @electric-sql/client --filter @electric-sql/react --filter @electric-sql/y-electric run build
       - name: Publish Previews

--- a/.github/workflows/sync_service_dockerhub_image.yml
+++ b/.github/workflows/sync_service_dockerhub_image.yml
@@ -44,6 +44,7 @@ jobs:
       short_commit_sha: ${{ steps.vars.outputs.short_commit_sha }}
       electric_version: ${{ steps.vars.outputs.electric_version }}
       docker_tag: ${{ steps.vars.outputs.docker_tag }}
+      image_tags: ${{ steps.vars.outputs.image_tags }}
 
     steps:
       - name: Determine the ref to check out
@@ -96,13 +97,11 @@ jobs:
           BUILD_MODE: ${{ steps.git_ref.outputs.build_mode }}
           INPUT_DOCKER_TAG: ${{ inputs.docker_tag }}
         run: |
-          echo "short_commit_sha=$(
-            git rev-parse --short HEAD
-          )" >> $GITHUB_OUTPUT
+          short_commit_sha="$(git rev-parse --short HEAD)"
 
-          echo "electric_version=$(
+          electric_version="$(
             git describe --abbrev=7 --tags --always --first-parent --match '@core/sync-service@*' | sed -En 's|^@core/sync-service@||p'
-          )" >> $GITHUB_OUTPUT
+          )"
 
           # Determine the docker tag to use
           if [ -n "$INPUT_DOCKER_TAG" ]; then
@@ -112,122 +111,46 @@ jobs:
           else
             docker_tag="canary"
           fi
-          echo "docker_tag=$docker_tag" >> $GITHUB_OUTPUT
 
-  build_and_push_image:
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            platform_id: amd64
-            runner: blacksmith-4vcpu-ubuntu-2404
-          - platform: linux/arm64/v8
-            platform_id: arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm
-    runs-on: ${{ matrix.runner }}
-    needs: [derive_build_vars]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.derive_build_vars.outputs.git_ref }}
-
-      - uses: useblacksmith/setup-docker-builder@v1
-
-      - uses: docker/login-action@v3
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push by digest
-        id: build
-        uses: useblacksmith/build-push-action@v2
-        with:
-          context: packages/sync-service
-          build-contexts: |
-            electric-telemetry=packages/electric-telemetry
-          build-args: |
-            ELECTRIC_VERSION=${{ needs.derive_build_vars.outputs.build_mode == 'custom' && needs.derive_build_vars.outputs.docker_tag || needs.derive_build_vars.outputs.electric_version }}
-          platforms: ${{ matrix.platform }}
-          push: true
-          # push an untagged image and export its digest
-          # the subsequent merge job will assemble the manifest list and apply tags
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          tags: |
-            ${{ env.DOCKERHUB_REPO }}
-            ${{ env.DOCKERHUB_CANARY_REPO }}
-
-      # Save the digest so the merge job can find both platform images
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.platform_id }}.digest"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: electric-digests-${{ matrix.platform_id }}
-          path: /tmp/digests/*
-
-  publish_tagged_image:
-    needs: [derive_build_vars, build_and_push_image]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    steps:
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: useblacksmith/setup-docker-builder@v1
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: electric-digests-*
-          merge-multiple: true
-          path: /tmp/digests
-
-      - name: Derive image tags from the build mode
-        env:
-          BUILD_MODE: ${{ needs.derive_build_vars.outputs.build_mode }}
-          DOCKER_TAG: ${{ needs.derive_build_vars.outputs.docker_tag }}
-          ELECTRIC_VERSION: ${{ needs.derive_build_vars.outputs.electric_version }}
-          SHORT_SHA: ${{ needs.derive_build_vars.outputs.short_commit_sha }}
-        run: |
           if [ "$BUILD_MODE" = "release" ]; then
-            # A release triggers official release image publishing
-            echo "ELECTRIC_TAGS=-t $DOCKERHUB_REPO:latest -t $DOCKERHUB_REPO:$ELECTRIC_VERSION" >> $GITHUB_ENV
-            echo "ELECTRIC_CANARY_TAGS=" >> $GITHUB_ENV
-          elif [ "$BUILD_MODE" = "custom" ]; then
-            # A custom build publishes with the caller-specified tag only
-            echo "ELECTRIC_TAGS=-t $DOCKERHUB_REPO:$DOCKER_TAG" >> $GITHUB_ENV
-            echo "ELECTRIC_CANARY_TAGS=" >> $GITHUB_ENV
-          else
-            # A regular push to the main branch triggers canary image publishing
-            echo "ELECTRIC_TAGS=-t $DOCKERHUB_REPO:canary" >> $GITHUB_ENV
-            echo "ELECTRIC_CANARY_TAGS=-t $DOCKERHUB_CANARY_REPO:latest -t $DOCKERHUB_CANARY_REPO:$SHORT_SHA" >> $GITHUB_ENV
-          fi
-
-      - name: Create multi-arch manifest list
-        run: |
-          set -euo pipefail
-
-          # Build a list of $DOCKERHUB_REPO@sha256:... source images
-          ELECTRIC_IMAGES=$(
-            for f in /tmp/digests/*.digest; do
-              echo $DOCKERHUB_REPO@$(cat $f)
-            done
-          )
-
-          # Create a manifest list that includes both platforms
-          docker buildx imagetools create $ELECTRIC_TAGS $ELECTRIC_IMAGES
-
-          if [ -n "$ELECTRIC_CANARY_TAGS" ]; then
-            # Build a list of $DOCKERHUB_CANARY_REPO@sha256:... source images
-            ELECTRIC_CANARY_IMAGES=$(
-              for f in /tmp/digests/*.digest; do
-                echo $DOCKERHUB_CANARY_REPO@$(cat $f)
-              done
+            image_tags=$(
+              printf '%s\n%s\n' \
+                "${DOCKERHUB_REPO}:latest" \
+                "${DOCKERHUB_REPO}:${electric_version}"
             )
-
-            # Create a manifest list for $DOCKERHUB_CANARY_REPO:... that includes both platforms
-            docker buildx imagetools create $ELECTRIC_CANARY_TAGS $ELECTRIC_CANARY_IMAGES
+          elif [ "$BUILD_MODE" = "custom" ]; then
+            image_tags="${DOCKERHUB_REPO}:${docker_tag}"
+          else
+            image_tags=$(
+              printf '%s\n%s\n%s\n' \
+                "${DOCKERHUB_REPO}:canary" \
+                "${DOCKERHUB_CANARY_REPO}:latest" \
+                "${DOCKERHUB_CANARY_REPO}:${short_commit_sha}"
+            )
           fi
+
+          echo "short_commit_sha=$short_commit_sha" >> "$GITHUB_OUTPUT"
+          echo "electric_version=$electric_version" >> "$GITHUB_OUTPUT"
+          echo "docker_tag=$docker_tag" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "image_tags<<EOF"
+            echo "$image_tags"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  build_and_publish_image:
+    needs: [derive_build_vars]
+    uses: ./.github/workflows/docker_multiarch_image.yml
+    secrets: inherit
+    with:
+      git_ref: ${{ needs.derive_build_vars.outputs.git_ref }}
+      image_repo: electricsql/electric
+      artifact_prefix: electric
+      context: packages/sync-service
+      file: packages/sync-service/Dockerfile
+      build_contexts: |
+        electric-telemetry=packages/electric-telemetry
+      build_args: |
+        ELECTRIC_VERSION=${{ needs.derive_build_vars.outputs.build_mode == 'custom' && needs.derive_build_vars.outputs.docker_tag || needs.derive_build_vars.outputs.electric_version }}
+      tags: ${{ needs.derive_build_vars.outputs.image_tags }}

--- a/.github/workflows/teardown_examples_pr_stack.yml
+++ b/.github/workflows/teardown_examples_pr_stack.yml
@@ -9,27 +9,25 @@ concurrency:
   group: examples-pr-${{ github.event.number }}
 
 jobs:
+  example-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-example-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create example matrix
+        id: create-example-matrix
+        run: node scripts/ci/example-matrix.mjs teardown
+
   teardown-pr-stack:
     name: Teardown Examples PR stack
+    needs: example-matrix
     environment: Pull request
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        example:
-          [
-            'yjs',
-            'linearlite-read-only',
-            'write-patterns',
-            'nextjs',
-            'todo-app',
-            'proxy-auth',
-            'phoenix-liveview',
-            'tanstack',
-            'remix',
-            'react',
-            'burn',
-          ]
+      matrix: ${{ fromJson(needs.example-matrix.outputs.matrix) }}
 
     env:
       DEPLOY_ENV: ${{ github.event_name == 'push' && 'production' || format('pr-{0}', github.event.number) }}
@@ -55,7 +53,12 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          if [ -f "${{ matrix.example.path }}/package.json" ]; then
+            pnpm --filter "$(jq -r .name "${{ matrix.example.path }}/package.json")..." --filter @electric-examples/shared install --frozen-lockfile
+          else
+            pnpm install --frozen-lockfile
+          fi
 
       - name: Cache SST state
         uses: actions/cache@v4
@@ -65,8 +68,8 @@ jobs:
           restore-keys: |
             sst-cache-${{ runner.os }}
 
-      - name: Remove ${{ matrix.example }} example
-        working-directory: ./examples/${{ matrix.example }}
+      - name: Remove ${{ matrix.example.name }} example
+        working-directory: ./${{ matrix.example.path }}
         run: |
           export PR_NUMBER=${{ github.event.number }}
           echo "Removing stage pr-$PR_NUMBER"

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -1,195 +1,35 @@
 name: Test Examples
 
 on:
+  workflow_call:
   schedule:
     - cron: '0 9 * * *' # Runs daily at 9 AM UTC
   workflow_dispatch: # Allow manual triggering
 
 jobs:
-  test:
-    name: Run e2e tests on examples
+  example-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-example-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test remix example
-        id: remix
-        continue-on-error: true
+      - name: Create example matrix
+        id: create-example-matrix
+        run: node scripts/ci/example-matrix.mjs productionTest
+
+  test:
+    name: Test ${{ matrix.example.name }} example
+    needs: example-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.example-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test ${{ matrix.example.name }} example
         uses: ./.github/actions/test-example
         with:
-          test_folder: remix
-          example_url: https://remix.examples.electric-sql.com
-
-      - name: Test nextjs example
-        id: nextjs
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: nextjs
-          example_url: https://nextjs.examples.electric-sql.com
-
-      - name: Test tanstack example
-        id: tanstack
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: tanstack
-          example_url: https://tanstack.examples.electric-sql.com
-
-      - name: Test phoenix liveview example
-        id: liveview
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: phoenix-liveview
-          example_url: https://phoenix-liveview.examples.electric-sql.com
-
-      - name: Test burn example
-        id: burn
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: burn
-          example_url: https://burn.examples.electric-sql.com
-
-      - name: Test react example
-        id: react
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://react.examples.electric-sql.com
-
-      - name: Test linearlite example
-        id: linearlite
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://linearlite.examples.electric-sql.com
-
-      - name: Test linearlite read-only example
-        id: linearlite-read-only
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://linearlite-read-only.examples.electric-sql.com
-
-      - name: Test proxy-auth example
-        id: proxy-auth
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://proxy-auth.examples.electric-sql.com/?org_id=1
-
-      - name: Test write-patterns example
-        id: write-patterns
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://write-patterns.examples.electric-sql.com
-
-      - name: Test yjs example
-        id: yjs
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://yjs.examples.electric-sql.com
-
-      - name: Test todo-app example
-        id: todo-app
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://todo-app.examples.electric-sql.com
-
-      - name: Test notes example
-        id: notes
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://notes.examples.electric-sql.com
-
-      - name: Test pixel art example
-        id: pixel-art
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://pixel-art.examples.electric-sql.com
-
-      - name: Test ai chat example
-        id: ai-chat
-        continue-on-error: true
-        uses: ./.github/actions/test-example
-        with:
-          test_folder: '.shared'
-          example_url: https://electric-ai-chat.examples.electric-sql.com
-
-      - name: Report test failures
-        if: |
-          steps.remix.outcome == 'failure' ||
-          steps.nextjs.outcome == 'failure' ||
-          steps.tanstack.outcome == 'failure' ||
-          steps.react.outcome == 'failure' ||
-          steps.liveview.outcome == 'failure' ||
-          steps.linearlite.outcome == 'failure' ||
-          steps.linearlite-read-only.outcome == 'failure' ||
-          steps.proxy-auth.outcome == 'failure' ||
-          steps.write-patterns.outcome == 'failure' ||
-          steps.yjs.outcome == 'failure' ||
-          steps.todo-app.outcome == 'failure' ||
-          steps.notes.outcome == 'failure' ||
-          steps.pixel-art.outcome == 'failure' ||
-          steps.ai-chat.outcome == 'failure'
-        run: |
-          echo "The following examples failed:"
-          if [ "${{ steps.remix.outcome }}" == "failure" ]; then
-            echo "- Remix example"
-          fi
-          if [ "${{ steps.nextjs.outcome }}" == "failure" ]; then
-            echo "- Next.js example"
-          fi
-          if [ "${{ steps.tanstack.outcome }}" == "failure" ]; then
-            echo "- TanStack example"
-          fi
-          if [ "${{ steps.react.outcome }}" == "failure" ]; then
-            echo "- React example"
-          fi
-          if [ "${{ steps.liveview.outcome }}" == "failure" ]; then
-            echo "- Phoenix LiveView example"
-          fi
-          if [ "${{ steps.linearlite.outcome }}" == "failure" ]; then
-            echo "- LinearLite example"
-          fi
-          if [ "${{ steps.linearlite-read-only.outcome }}" == "failure" ]; then
-            echo "- LinearLite Read-Only example"
-          fi
-          if [ "${{ steps.proxy-auth.outcome }}" == "failure" ]; then
-            echo "- Proxy Auth example"
-          fi
-          if [ "${{ steps.write-patterns.outcome }}" == "failure" ]; then
-            echo "- Write Patterns example"
-          fi
-          if [ "${{ steps.yjs.outcome }}" == "failure" ]; then
-            echo "- Yjs example"
-          fi
-          if [ "${{ steps.todo-app.outcome }}" == "failure" ]; then
-            echo "- Todo App example"
-          fi
-          if [ "${{ steps.notes.outcome }}" == "failure" ]; then
-            echo "- Notes example"
-          fi
-          if [ "${{ steps.pixel-art.outcome }}" == "failure" ]; then
-            echo "- Pixel Art example"
-          fi
-          if [ "${{ steps.ai-chat.outcome }}" == "failure" ]; then
-            echo "- AI Chat example"
-          fi
-          exit 1
+          test_folder: ${{ matrix.example.test_folder }}
+          example_url: ${{ matrix.example.production_url }}

--- a/.github/workflows/ts_tests.yml
+++ b/.github/workflows/ts_tests.yml
@@ -18,29 +18,45 @@ permissions:
   packages: write
 
 jobs:
-  list_ts_packages_and_examples:
-    name: List TS packages and examples
+  detect_affected_workspaces:
+    name: Detect affected TS workspaces
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
-      package_directories: ${{ steps.list_ts_packages.outputs.directories }}
-      example_names: ${{ steps.list_examples.outputs.example_names }}
+      package_directories: ${{ steps.detect.outputs.package_directories }}
+      packages_with_shared_sync_service: ${{ steps.detect.outputs.packages_with_shared_sync_service }}
+      packages_without_shared_sync_service: ${{ steps.detect.outputs.packages_without_shared_sync_service }}
+      example_directories: ${{ steps.detect.outputs.example_directories }}
+      has_packages: ${{ steps.detect.outputs.has_packages }}
+      has_shared_sync_service_packages: ${{ steps.detect.outputs.has_shared_sync_service_packages }}
+      has_non_shared_sync_service_packages: ${{ steps.detect.outputs.has_non_shared_sync_service_packages }}
+      has_examples: ${{ steps.detect.outputs.has_examples }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - run: echo "directories=`find packages/ -mindepth 1 -maxdepth 1 -type d -exec test -e '{}'/tsconfig.json \; -print | jq -R -s -c 'split("\n")[:-1]'`" >> $GITHUB_OUTPUT
-        id: list_ts_packages
+      - uses: pnpm/action-setup@v4
 
-      - run: echo "example_names=$(find examples/ -mindepth 1 -maxdepth 2 -type f -name package.json | xargs dirname | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
-        id: list_examples
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+          cache: pnpm
+
+      - name: Detect affected workspaces
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: node scripts/ci/affected-workspaces.mjs
 
   typecheck_packages:
     name: Build and typecheck ${{ matrix.package_dir }}
-    needs: [list_ts_packages_and_examples]
+    needs: [detect_affected_workspaces]
+    if: ${{ needs.detect_affected_workspaces.outputs.has_packages == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
-        package_dir: ${{ fromJson(needs.list_ts_packages_and_examples.outputs.package_directories) }}
+        package_dir: ${{ fromJson(needs.detect_affected_workspaces.outputs.package_directories) }}
     defaults:
       run:
         working-directory: ${{ matrix.package_dir }}
@@ -51,7 +67,7 @@ jobs:
         with:
           node-version-file: '.tool-versions'
           cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter "$(jq -r .name package.json)..." install --frozen-lockfile
       - run: pnpm -r --filter "$(jq '.name' -r package.json)^..." build
       - run: pnpm run typecheck
       - name: Run shape stream static analysis
@@ -59,17 +75,20 @@ jobs:
         run: pnpm run analyze:shape-stream -- --fail-on-findings
 
   ensure_sync_service_image:
+    needs: [detect_affected_workspaces]
+    if: ${{ needs.detect_affected_workspaces.outputs.has_shared_sync_service_packages == 'true' }}
     uses: ./.github/workflows/ensure_sync_service_image.yml
 
-  build_and_test_packages:
+  build_and_test_packages_with_shared_sync_service:
     name: 'Test ${{ matrix.package_dir }} w/ sync-service'
-    needs: [list_ts_packages_and_examples, ensure_sync_service_image]
+    needs: [detect_affected_workspaces, ensure_sync_service_image]
+    if: ${{ needs.detect_affected_workspaces.outputs.has_shared_sync_service_packages == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        package_dir: ${{ fromJson(needs.list_ts_packages_and_examples.outputs.package_directories) }}
+        package_dir: ${{ fromJson(needs.detect_affected_workspaces.outputs.packages_with_shared_sync_service) }}
     defaults:
       run:
         working-directory: ${{ matrix.package_dir }}
@@ -86,7 +105,7 @@ jobs:
           cache: pnpm
 
       - name: Install Node dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm --filter "$(jq -r .name package.json)..." install --frozen-lockfile
 
       - name: Build Node dependencies, if any
         run: pnpm -r --filter "$(jq '.name' -r package.json)^..." build
@@ -116,14 +135,75 @@ jobs:
           flags: typescript,unit-tests,${{ matrix.package_dir }}
           files: ./junit/test-report.junit.xml
 
+  build_and_test_packages_without_shared_sync_service:
+    name: 'Test ${{ matrix.package_dir }}'
+    needs: [detect_affected_workspaces]
+    if: ${{ needs.detect_affected_workspaces.outputs.has_non_shared_sync_service_packages == 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package_dir: ${{ fromJson(needs.detect_affected_workspaces.outputs.packages_without_shared_sync_service) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.package_dir }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+          cache: pnpm
+
+      - name: Install Node dependencies
+        run: |
+          package_name="$(jq -r .name package.json)"
+          if [ "$package_name" = "@electric-ax/agents-runtime" ]; then
+            pnpm --filter "$package_name..." --filter "@electric-ax/agents-server..." install --frozen-lockfile
+          else
+            pnpm --filter "$package_name..." install --frozen-lockfile
+          fi
+
+      - name: Build Node dependencies, if any
+        run: pnpm -r --filter "$(jq '.name' -r package.json)^..." build
+
+      - name: Run tests with coverage
+        run: pnpm run coverage --run
+
+      - name: Upload coverage reports to CodeCov
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: typescript,unit-tests,${{ matrix.package_dir }}
+
+      - name: Upload test results to CodeCov
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
+        if: ${{ !cancelled() }}
+        env:
+          DUMMY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}-dummy
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          flags: typescript,unit-tests,${{ matrix.package_dir }}
+          files: ./junit/test-report.junit.xml
+
   check_and_build_examples:
     name: Check and build ${{ matrix.example_folder }}
-    needs: [list_ts_packages_and_examples, build_and_test_packages]
+    needs:
+      [
+        detect_affected_workspaces,
+        build_and_test_packages_with_shared_sync_service,
+        build_and_test_packages_without_shared_sync_service,
+      ]
+    if: ${{ always() && needs.detect_affected_workspaces.outputs.has_examples == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
-        example_folder: ${{ fromJson(needs.list_ts_packages_and_examples.outputs.example_names) }}
+        example_folder: ${{ fromJson(needs.detect_affected_workspaces.outputs.example_directories) }}
     defaults:
       run:
         working-directory: ${{ matrix.example_folder }}
@@ -134,7 +214,7 @@ jobs:
         with:
           node-version-file: '.tool-versions'
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter "$(jq -r .name package.json)..." --filter @electric-examples/shared install --frozen-lockfile
       - run: pnpm -r --filter "$(jq '.name' -r package.json)^..." build
       - run: pnpm --if-present run prepare
       - run: pnpm --if-present run typecheck

--- a/scripts/ci/affected-workspaces.mjs
+++ b/scripts/ci/affected-workspaces.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, existsSync } from 'node:fs'
+import { relative, sep } from 'node:path'
+
+const repoRoot = execFileSync(`git`, [`rev-parse`, `--show-toplevel`], {
+  encoding: `utf8`,
+}).trim()
+const baseRef = process.env.BASE_SHA || process.env.GITHUB_BASE_REF || `HEAD~1`
+
+const globalChangePatterns = [
+  `.github/workflows/ensure_sync_service_image.yml`,
+  `.github/workflows/ts_tests.yml`,
+  `.npmrc`,
+  `.tool-versions`,
+  `package.json`,
+  `packages/electric-telemetry/**`,
+  `packages/sync-service/**`,
+  `patches/**`,
+  `pnpm-lock.yaml`,
+  `pnpm-workspace.yaml`,
+  `scripts/**`,
+  `tsconfig.base.json`,
+  `tsconfig.build.json`,
+]
+
+const packagesThatNeedSharedSyncService = new Set([
+  `packages/experimental`,
+  `packages/react-hooks`,
+  `packages/typescript-client`,
+])
+
+const allWorkspaces = listWorkspaces()
+const changedFiles = getChangedFiles(baseRef)
+const shouldRunAll = shouldRunAllWorkspaces(baseRef, changedFiles)
+const affectedWorkspaces = shouldRunAll
+  ? allWorkspaces
+  : listAffectedWorkspaces(baseRef)
+
+const packageDirectories = directoriesFor(affectedWorkspaces, isTsPackage)
+const packagesWithSharedSyncService = packageDirectories.filter((directory) =>
+  packagesThatNeedSharedSyncService.has(directory)
+)
+const packagesWithoutSharedSyncService = packageDirectories.filter(
+  (directory) => !packagesThatNeedSharedSyncService.has(directory)
+)
+const exampleDirectories = directoriesFor(affectedWorkspaces, isExample)
+
+const outputs = {
+  package_directories: JSON.stringify(packageDirectories),
+  packages_with_shared_sync_service: JSON.stringify(
+    packagesWithSharedSyncService
+  ),
+  packages_without_shared_sync_service: JSON.stringify(
+    packagesWithoutSharedSyncService
+  ),
+  example_directories: JSON.stringify(exampleDirectories),
+  has_packages: String(packageDirectories.length > 0),
+  has_shared_sync_service_packages: String(
+    packagesWithSharedSyncService.length > 0
+  ),
+  has_non_shared_sync_service_packages: String(
+    packagesWithoutSharedSyncService.length > 0
+  ),
+  has_examples: String(exampleDirectories.length > 0),
+}
+
+writeOutputs(outputs)
+
+console.log(
+  JSON.stringify(
+    {
+      baseRef,
+      changedFiles,
+      mode: shouldRunAll ? `all` : `affected`,
+      ...outputs,
+    },
+    null,
+    2
+  )
+)
+
+function listAffectedWorkspaces(base) {
+  try {
+    return parsePnpmList(
+      run(`pnpm`, [
+        `-r`,
+        `list`,
+        `--depth`,
+        `-1`,
+        `--json`,
+        `--filter`,
+        `...[${base}]`,
+      ])
+    )
+  } catch (error) {
+    console.warn(
+      `Falling back to all workspaces because pnpm changed-package filtering failed.`
+    )
+    console.warn(error.message)
+    return allWorkspaces
+  }
+}
+
+function listWorkspaces() {
+  return parsePnpmList(run(`pnpm`, [`-r`, `list`, `--depth`, `-1`, `--json`]))
+}
+
+function parsePnpmList(output) {
+  return JSON.parse(output).map((workspace) => ({
+    ...workspace,
+    relativePath: toPosixPath(relative(repoRoot, workspace.path)),
+  }))
+}
+
+function directoriesFor(workspaces, predicate) {
+  return Array.from(
+    new Set(
+      workspaces
+        .filter(predicate)
+        .map((workspace) => workspace.relativePath)
+        .sort()
+    )
+  )
+}
+
+function isTsPackage(workspace) {
+  return (
+    workspace.relativePath.startsWith(`packages/`) &&
+    existsSync(`${workspace.path}/tsconfig.json`)
+  )
+}
+
+function isExample(workspace) {
+  return (
+    workspace.relativePath.startsWith(`examples/`) &&
+    existsSync(`${workspace.path}/package.json`)
+  )
+}
+
+function getChangedFiles(base) {
+  if (!base || /^0+$/.test(base)) {
+    return []
+  }
+
+  try {
+    run(`git`, [`rev-parse`, `--verify`, `${base}^{commit}`])
+    return run(`git`, [`diff`, `--name-only`, base, `--`, `.`])
+      .split(`\n`)
+      .map((file) => file.trim())
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+function shouldRunAllWorkspaces(base, files) {
+  if (!base || /^0+$/.test(base) || files.length === 0) {
+    return true
+  }
+
+  return files.some((file) =>
+    globalChangePatterns.some((pattern) => matchesPattern(file, pattern))
+  )
+}
+
+function matchesPattern(file, pattern) {
+  if (pattern.endsWith(`/**`)) {
+    return file.startsWith(pattern.slice(0, -3))
+  }
+
+  return file === pattern
+}
+
+function writeOutputs(outputs) {
+  const outputFile = process.env.GITHUB_OUTPUT
+  if (!outputFile) {
+    return
+  }
+
+  appendFileSync(
+    outputFile,
+    Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(`\n`) + `\n`
+  )
+}
+
+function run(command, args) {
+  return execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: `utf8`,
+    stdio: [`ignore`, `pipe`, `pipe`],
+  })
+}
+
+function toPosixPath(value) {
+  return value.split(sep).join(`/`)
+}

--- a/scripts/ci/example-matrix.mjs
+++ b/scripts/ci/example-matrix.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+
+const repoRoot = execFileSync(`git`, [`rev-parse`, `--show-toplevel`], {
+  encoding: `utf8`,
+}).trim()
+
+const examples = [
+  {
+    name: `yjs`,
+    path: `examples/yjs`,
+    testFolder: `.shared`,
+    productionUrl: `https://yjs.examples.electric-sql.com`,
+    deployOnChanges: true,
+    deployAll: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `linearlite-read-only`,
+    path: `examples/linearlite-read-only`,
+    testFolder: `.shared`,
+    productionUrl: `https://linearlite-read-only.examples.electric-sql.com`,
+    deployOnChanges: true,
+    deployAll: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `write-patterns`,
+    path: `examples/write-patterns`,
+    testFolder: `.shared`,
+    productionUrl: `https://write-patterns.examples.electric-sql.com`,
+    deployOnChanges: true,
+    deployAll: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `todo-app`,
+    path: `examples/todo-app`,
+    testFolder: `.shared`,
+    productionUrl: `https://todo-app.examples.electric-sql.com`,
+    deployOnChanges: true,
+    deployAll: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `proxy-auth`,
+    path: `examples/proxy-auth`,
+    testFolder: `.shared`,
+    productionUrl: `https://proxy-auth.examples.electric-sql.com/?org_id=1`,
+    deployOnChanges: true,
+    deployAll: true,
+    teardown: true,
+    productionTest: true,
+  },
+  {
+    name: `phoenix-liveview`,
+    path: `examples/phoenix-liveview`,
+    testFolder: `phoenix-liveview`,
+    productionUrl: `https://phoenix-liveview.examples.electric-sql.com`,
+    deployOnChanges: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `tanstack`,
+    path: `examples/tanstack`,
+    testFolder: `tanstack`,
+    productionUrl: `https://tanstack.examples.electric-sql.com`,
+    deployOnChanges: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `remix`,
+    path: `examples/remix`,
+    testFolder: `remix`,
+    productionUrl: `https://remix.examples.electric-sql.com`,
+    deployOnChanges: true,
+    deployAll: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `react`,
+    path: `examples/react`,
+    testFolder: `.shared`,
+    productionUrl: `https://react.examples.electric-sql.com`,
+    deployOnChanges: true,
+    deployAll: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `burn`,
+    path: `examples/burn`,
+    testFolder: `burn`,
+    productionUrl: `https://burn.examples.electric-sql.com`,
+    deployOnChanges: true,
+    deployAll: true,
+    teardown: true,
+    deployTest: true,
+    productionTest: true,
+  },
+  {
+    name: `tanstack-db-web-starter`,
+    path: `examples/tanstack-db-web-starter`,
+    deployOnChanges: true,
+    deployAll: true,
+  },
+  {
+    name: `linearlite`,
+    testFolder: `.shared`,
+    productionUrl: `https://linearlite.examples.electric-sql.com`,
+    productionTest: true,
+  },
+  {
+    name: `notes`,
+    testFolder: `.shared`,
+    productionUrl: `https://notes.examples.electric-sql.com`,
+    productionTest: true,
+  },
+  {
+    name: `pixel-art`,
+    testFolder: `.shared`,
+    productionUrl: `https://pixel-art.examples.electric-sql.com`,
+    productionTest: true,
+  },
+  {
+    name: `ai-chat`,
+    testFolder: `.shared`,
+    productionUrl: `https://electric-ai-chat.examples.electric-sql.com`,
+    productionTest: true,
+  },
+]
+
+const mode = process.argv[2]
+const selectors = {
+  deployable: (example) => example.deployOnChanges,
+  deployAll: (example) => example.deployAll,
+  teardown: (example) => example.teardown,
+  productionTest: (example) => example.productionTest,
+}
+
+const selectedExamples = selectExamples(mode)
+const matrix = {
+  example: selectedExamples.map((example) => ({
+    name: example.name,
+    path: example.path ?? ``,
+    test_folder: example.testFolder ?? ``,
+    deploy_test_folder: example.deployTest ? example.testFolder : ``,
+    production_url: example.productionUrl ?? ``,
+  })),
+}
+
+const outputs = {
+  matrix: JSON.stringify(matrix),
+  has_examples: String(matrix.example.length > 0),
+}
+
+writeOutputs(outputs)
+console.log(JSON.stringify({ mode, ...outputs }, null, 2))
+
+function selectExamples(selectedMode) {
+  if (selectedMode === `changed-deployable`) {
+    const changedExampleNames = new Set(changedExamples())
+    return examples.filter(
+      (example) =>
+        example.deployOnChanges && changedExampleNames.has(example.name)
+    )
+  }
+
+  const selector = selectors[selectedMode]
+  if (!selector) {
+    throw new Error(
+      `Usage: example-matrix.mjs changed-deployable|deployAll|teardown|productionTest`
+    )
+  }
+
+  return examples.filter(selector)
+}
+
+function changedExamples() {
+  const base = process.env.BASE_SHA
+
+  if (!base || /^0+$/.test(base)) {
+    return examples
+      .filter((example) => example.deployOnChanges)
+      .map((example) => example.name)
+  }
+
+  try {
+    run(`git`, [`rev-parse`, `--verify`, `${base}^{commit}`])
+    return Array.from(
+      new Set(
+        run(`git`, [`diff`, `--name-only`, base, `--`, `examples`])
+          .split(`\n`)
+          .map((file) => file.trim().split(`/`)[1])
+          .filter(Boolean)
+      )
+    )
+  } catch {
+    return examples
+      .filter((example) => example.deployOnChanges)
+      .map((example) => example.name)
+  }
+}
+
+function writeOutputs(outputs) {
+  const outputFile = process.env.GITHUB_OUTPUT
+  if (!outputFile) {
+    return
+  }
+
+  appendFileSync(
+    outputFile,
+    Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(`\n`) + `\n`
+  )
+}
+
+function run(command, args) {
+  return execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: `utf8`,
+    stdio: [`ignore`, `pipe`, `pipe`],
+  })
+}


### PR DESCRIPTION
Greatly simplifies CI matrices so package, example, and image jobs do less unrelated work for a given change. The main goal is to avoid testing or installing packages that are not affected by a PR, while keeping broad fallback behavior for changes that can affect the whole workspace.

What changed:

- Added `scripts/ci/affected-workspaces.mjs` to compute affected pnpm workspaces from the PR/base diff, with a full-workspace fallback for global inputs like root package metadata, lockfiles, shared tsconfig files, CI scripts, sync-service, and telemetry changes.
- Updated `ts_tests.yml` to use the affected workspace matrix instead of testing every TS package and example every time.
- Split TS package tests into packages that need the shared sync-service stack and packages that do not, so agents/start/y-electric-style packages no longer build or wait on a shared Electric image.
- Kept sync-service-backed tests for the packages that need it: `packages/typescript-client`, `packages/react-hooks`, and `packages/experimental`.
- Switched TS package, example, PR preview, and example browser-test installs to filtered `pnpm --filter ... install` where the workflow has a concrete package/example target.
- Added the `agents-runtime` test-only install exception for `@electric-ax/agents-server...`, because the runtime DSL tests dynamically import the agents server test harness.
- Added `scripts/ci/example-matrix.mjs` as the shared source of truth for deployable examples, production example tests, deploy-all, and teardown matrices.
- Simplified example deploy/test workflows to consume the generated example matrix instead of duplicating long hard-coded step lists.
- Runs browser tests directly for deployed examples when the matrix entry defines a deploy test folder, and keeps URL-only production tests for externally hosted examples.
- Removed stale/missing `nextjs` example entries from generated deploy/test matrices.
- Updated example deploy, deploy-all, teardown, and test-example installs to use filtered installs when the target example has a workspace `package.json`, with fallback full install only for non-workspace example paths.
- Scoped Lux integration tests to sync-service-related changes only: sync-service, electric-telemetry, integration test harness files, `.tool-versions`, and the workflow itself.
- Simplified sync-service Docker publishing by moving the Electric image build/publish flow onto the shared `docker_multiarch_image.yml` workflow.
- Extended the shared multi-arch Docker workflow to support tags that target multiple repositories, so the sync-service workflow can publish both `electricsql/electric` and `electricsql/electric-canary` tags through the reusable workflow.
- Kept the TypeScript package preview workflow narrower by installing only the previewed packages and their workspace dependencies.