### PR TITLE
Fix otel-export Lux metric ordering

### DIFF
--- a/integration-tests/tests/otel-export.lux
+++ b/integration-tests/tests/otel-export.lux
@@ -210,40 +210,8 @@
   [global offset=$1]
 
 [shell otel_collector]
-  # Verify that the initial snapshot query span is exported from the Snapshotter path.
-  ?Span #[0-9]+
-  ?Name[ ]+: shape_snapshot\.execute_for_shape
-  ?->[ ]shape\.query_reason: Str\(initial_snapshot\)
-
-[shell psql]
-  !insert into items values ('3');
-  ??INSERT
-
-[shell client]
-  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&subset__where=val%20%3D%20%273%27"]
-
-  ??HTTP/1.1 200 OK
-  ??"metadata"
-
-[shell otel_collector]
-  # Verify that a direct subset snapshot query span is exported from the PartialModes path.
-  ?Span #[0-9]+
-  ?Name[ ]+: shape_snapshot\.execute_for_shape
-  ?->[ ]shape\.query_reason: Str\(subset_query\)
-
-[shell client]
-  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&live"]
-
-  ??HTTP/1.1 200 OK
-  ??"value":{"val":"3"}
-
-[shell psql]
-  !insert into items values ('4');
-  ??INSERT
-
-[shell otel_collector]
-  # Verify that new measurement exports from this branch are present
-  # Order matches actual OTEL export order (not alphabetical)
+  # Verify request/storage metrics emitted by the initial snapshot before later span matching
+  # consumes this export window.
   """?
   Metric #[0-9]+
   Descriptor:
@@ -262,6 +230,35 @@
        -> Name: electric\.storage\.snapshot_stored\.operations
   """
 
+  # Verify that the initial snapshot query span is exported from the Snapshotter path.
+  ?Name[ ]+: shape_snapshot\.execute_for_shape
+  ?->[ ]shape\.query_reason: Str\(initial_snapshot\)
+
+[shell psql]
+  !insert into items values ('3');
+  ??INSERT
+
+[shell client]
+  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&subset__where=val%20%3D%20%273%27"]
+
+  ??HTTP/1.1 200 OK
+  ??"metadata"
+
+[shell otel_collector]
+  # Verify request/storage metrics emitted after the insert + subset snapshot export window.
+  # Order matches actual OTEL export order (not alphabetical).
+  """?
+  Metric #[0-9]+
+  Descriptor:
+       -> Name: electric\.plug\.serve_shape\.count
+  """
+
+  """?
+  Metric #[0-9]+
+  Descriptor:
+       -> Name: electric\.plug\.serve_shape\.bytes
+  """
+
   """?
   Metric #[0-9]+
   Descriptor:
@@ -273,6 +270,20 @@
   Descriptor:
        -> Name: electric\.storage\.transaction_stored\.operations
   """
+
+  # Verify that a direct subset snapshot query span is exported from the PartialModes path.
+  ?Name[ ]+: shape_snapshot\.execute_for_shape
+  ?->[ ]shape\.query_reason: Str\(subset_query\)
+
+[shell client]
+  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&live"]
+
+  ??HTTP/1.1 200 OK
+  ??"value":{"val":"3"}
+
+[shell psql]
+  !insert into items values ('4');
+  ??INSERT
 
 ###
 


### PR DESCRIPTION
## Issue
- #4201 added new metric assertions to `otel-export.lux`, but it placed them in a later collector block than the one where those metrics are actually exported.
- In the failing run, `electric.plug.serve_shape.*` and the related storage metrics were already printed by the OTEL collector before the final Lux block started waiting for them.
- That meant Lux timed out even though the metrics were present in the collector log.
- An earlier fragility made this worse: the loose `?Span #[0-9]+` checks could match arbitrary earlier spans and advance the collector cursor past the export window we actually cared about.

## The Fix
- Move each metric assertion into the OTEL export window where that metric actually appears.
- Stop matching arbitrary `Span #N` lines and instead anchor directly on `shape_snapshot.execute_for_shape` plus the expected `shape.query_reason`.
- Keep the test aligned with the real collector output order, instead of assuming the metrics will still be visible in a later block.

## Implementation
- move the OTEL metric assertions to the export windows where the metrics actually appear
- stop matching arbitrary `Span #N` lines before `shape_snapshot.execute_for_shape`
- keep the test focused on Lux ordering rather than sync-service behavior
