### PR TITLE
feat(agents-runtime): tighten shared state typing

### DIFF
--- a/examples/deep-survey/src/server/orchestrator.ts
+++ b/examples/deep-survey/src/server/orchestrator.ts
@@ -319,9 +319,7 @@ export function registerOrchestrator(registry: EntityRegistry) {
         ctx.mkdb(sharedStateId, swarmSharedSchema)
       }
 
-      const shared = (await ctx.observe(
-        db(sharedStateId, swarmSharedSchema)
-      )) as unknown as SwarmSharedState
+      const shared = await ctx.observe(db(sharedStateId, swarmSharedSchema))
 
       ctx.useAgent({
         systemPrompt: ORCHESTRATOR_SYSTEM_PROMPT,

--- a/examples/deep-survey/src/server/shared-tools.ts
+++ b/examples/deep-survey/src/server/shared-tools.ts
@@ -1,9 +1,5 @@
 import { Type } from '@sinclair/typebox'
-import type {
-  AgentTool,
-  SharedStateHandle,
-  StateCollectionProxy,
-} from '@electric-ax/agents-runtime'
+import type { AgentTool, SharedStateHandle } from '@electric-ax/agents-runtime'
 import {
   swarmSharedSchema,
   wikiEntrySchema,
@@ -22,16 +18,6 @@ function textResult(text: string, details: Record<string, unknown> = {}) {
     content: [{ type: `text` as const, text }],
     details,
   }
-}
-
-function wikiCollection(
-  shared: SwarmSharedState
-): StateCollectionProxy<WikiEntry> {
-  return shared.wiki as unknown as StateCollectionProxy<WikiEntry>
-}
-
-function xrefCollection(shared: SwarmSharedState): StateCollectionProxy<Xref> {
-  return shared.xrefs as unknown as StateCollectionProxy<Xref>
 }
 
 async function awaitPersisted(transaction: unknown): Promise<void> {
@@ -197,7 +183,7 @@ export function createWriteWikiTool(shared: SwarmSharedState): AgentTool {
     }),
     execute: async (_toolCallId, params) => {
       const parsed = wikiEntrySchema.parse(params)
-      const collection = wikiCollection(shared)
+      const collection = shared.wiki
       const existing = collection.get(parsed.key)
       const transaction = existing
         ? collection.update(parsed.key, (draft) => {
@@ -228,8 +214,8 @@ export function createReadWikiTool(shared: SwarmSharedState): AgentTool {
     }),
     execute: async (_toolCallId, params) => {
       const { query } = params as { query?: string }
-      const allEntries = wikiCollection(shared).toArray
-      const xrefs = xrefCollection(shared).toArray
+      const allEntries = shared.wiki.toArray
+      const xrefs = shared.xrefs.toArray
       const entries = query
         ? allEntries.filter((entry) => {
             const needle = query.toLowerCase()
@@ -279,7 +265,7 @@ export function createWriteXrefsTool(shared: SwarmSharedState): AgentTool {
         a: raw.a,
         b: raw.b,
       })
-      const collection = xrefCollection(shared)
+      const collection = shared.xrefs
       const existing = collection.get(parsed.key)
       const transaction = existing
         ? collection.update(parsed.key, (draft) => {

--- a/examples/deep-survey/src/server/survey-worker.ts
+++ b/examples/deep-survey/src/server/survey-worker.ts
@@ -5,7 +5,6 @@ import {
   createFetchUrlTool,
   createSharedWikiTools,
   createWebSearchTool,
-  type SwarmSharedState,
 } from './shared-tools.js'
 import { surveyWorkerModelConfig } from './model-config.js'
 import type { EntityRegistry } from '@electric-ax/agents-runtime'
@@ -23,10 +22,10 @@ export function registerSurveyWorker(registry: EntityRegistry): void {
     creationSchema: surveyWorkerArgsSchema,
 
     async handler(ctx) {
-      const args = surveyWorkerArgsSchema.parse(ctx.args)
-      const shared = (await ctx.observe(
+      const args = ctx.args
+      const shared = await ctx.observe(
         db(args.sharedStateId, swarmSharedSchema)
-      )) as unknown as SwarmSharedState
+      )
 
       ctx.useAgent({
         systemPrompt: args.systemPrompt,

--- a/packages/agents-runtime/src/context-factory.ts
+++ b/packages/agents-runtime/src/context-factory.ts
@@ -534,11 +534,11 @@ export function createHandlerContext<TState extends StateProxy = StateProxy>(
       useContextRegistrations: () => useContextRegistrations,
     },
     agent,
-    observe(source: ObservationSource, opts?: { wake?: Wake }) {
+    observe: ((source: ObservationSource, opts?: { wake?: Wake }) => {
       return config.doObserve(source, opts?.wake) as Promise<
         ObservationHandle & EntityHandle & SharedStateHandle
       >
-    },
+    }) as DebugHandlerContext<TState>[`observe`],
     spawn(
       type: string,
       id: string,

--- a/packages/agents-runtime/src/define-entity.ts
+++ b/packages/agents-runtime/src/define-entity.ts
@@ -1,15 +1,29 @@
-import type { EntityDefinition, EntityTypeEntry } from './types'
+import type {
+  AnyEntityDefinition,
+  EntityActionMap,
+  EntityDefinition,
+  EntitySchema,
+  EntityStateDefinition,
+  EntityTypeEntry,
+} from './types'
 
 export class EntityRegistry {
   private entries = new Map<string, EntityTypeEntry>()
 
-  define(name: string, definition: EntityDefinition): void {
+  define<
+    const TCreationSchema extends EntitySchema | undefined = undefined,
+    const TState extends EntityStateDefinition | undefined = undefined,
+    TActions extends EntityActionMap = {},
+  >(
+    name: string,
+    definition: EntityDefinition<TCreationSchema, TState, TActions>
+  ): void {
     if (this.entries.has(name)) {
       throw new Error(`Entity type "${name}" is already registered`)
     }
     this.entries.set(name, {
       name,
-      definition,
+      definition: definition as AnyEntityDefinition,
     })
   }
 
@@ -38,7 +52,14 @@ export function createEntityRegistry(): EntityRegistry {
  * Registers the entity definition (handler, state, actions)
  * with the runtime. On each run the runtime calls `handler(ctx, wake)`.
  */
-export function defineEntity(name: string, definition: EntityDefinition): void {
+export function defineEntity<
+  const TCreationSchema extends EntitySchema | undefined = undefined,
+  const TState extends EntityStateDefinition | undefined = undefined,
+  TActions extends EntityActionMap = {},
+>(
+  name: string,
+  definition: EntityDefinition<TCreationSchema, TState, TActions>
+): void {
   defaultRegistry.define(name, definition)
 }
 
@@ -62,6 +83,6 @@ export function clearRegistry(): void {
  */
 export function resolveDefine(
   registry?: EntityRegistry
-): (name: string, definition: EntityDefinition) => void {
+): (name: string, definition: AnyEntityDefinition) => void {
   return registry ? registry.define.bind(registry) : defineEntity
 }

--- a/packages/agents-runtime/src/index.ts
+++ b/packages/agents-runtime/src/index.ts
@@ -27,7 +27,15 @@ export type {
   CodingSessionMetaRow,
   CodingSessionStatus,
   EntityDefinition,
+  EntityActionsFactory,
+  EntityActionMap,
+  EntityArgs,
+  EntitySchema,
+  EntityStateDefinition,
+  EntityStreamDB,
+  EntityStreamDBWithActions,
   EntityTypeEntry,
+  AnyEntityDefinition,
   SharedStateHandleInfo,
   SpawnHandleInfo,
   UseCodingAgentOptions,
@@ -49,8 +57,17 @@ export type {
   ContextInserted,
   ContextRemoved,
   ContextEntryAttrs,
+  CollectionInsert,
+  CollectionKey,
+  CollectionRow,
+  EntityTransaction,
+  GeneratedStateActions,
+  HandlerActions,
   ManifestContextEntry as ManifestContextRow,
+  SchemaInput,
+  SchemaOutput,
   SourceConfig,
+  StateProxyFrom,
   TimelineItem,
   TimelineProjectionOpts,
   TimestampedMessage,
@@ -87,10 +104,6 @@ export type {
 } from './entity-schema'
 
 export { createEntityStreamDB } from './entity-stream-db'
-export type {
-  EntityStreamDB,
-  EntityStreamDBWithActions,
-} from './entity-stream-db'
 export {
   assertTags,
   buildTagsIndex,

--- a/packages/agents-runtime/src/observation-sources.ts
+++ b/packages/agents-runtime/src/observation-sources.ts
@@ -159,17 +159,19 @@ export function entities(query: EntitiesQuery): EntitiesObservationSource {
   }
 }
 
-export interface DbObservationSource extends ObservationSource {
+export interface DbObservationSource<
+  TSchema extends SharedStateSchemaMap = SharedStateSchemaMap,
+> extends ObservationSource {
   readonly sourceType: `db`
   readonly dbId: string
-  readonly schema: SharedStateSchemaMap
+  readonly schema: TSchema
   readonly streamUrl: string
 }
 
-export function db(
+export function db<const TSchema extends SharedStateSchemaMap>(
   id: string,
-  dbSchema: SharedStateSchemaMap
-): DbObservationSource {
+  dbSchema: TSchema
+): DbObservationSource<TSchema> {
   const streamPath = getSharedStateStreamPath(id)
   return {
     sourceType: `db`,

--- a/packages/agents-runtime/src/types.ts
+++ b/packages/agents-runtime/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   StandardJSONSchemaV1,
   StandardSchemaV1,
+  StandardTypedV1,
 } from '@standard-schema/spec'
 import type {
   StreamDB as BaseStreamDB,
@@ -10,6 +11,7 @@ import type {
 } from '@durable-streams/state'
 import type { EntityRegistry } from './define-entity'
 import type {
+  Collection as TanStackCollection,
   Context as QueryContext,
   DeltaEvent as TanStackDeltaEvent,
   Effect as TanStackEffect,
@@ -48,7 +50,16 @@ import type {
 import type { EntityTags, TagOperation } from './tags'
 
 export type EntityStreamDB = RuntimeEntityStreamDB
-export type EntityStreamDBWithActions = RuntimeEntityStreamDBWithActions
+export type EntityStreamDBWithActions<
+  TState extends EntityStateDefinition | undefined =
+    | EntityStateDefinition
+    | undefined,
+  TActions extends EntityActionMap = EntityActionMap,
+> = Omit<RuntimeEntityStreamDBWithActions, `actions` | `collections`> & {
+  collections: RuntimeEntityStreamDBWithActions[`collections`] &
+    EntityCollectionsFromState<TState>
+  actions: GeneratedStateActions<TState> & HandlerActions<TActions>
+}
 export type ChildStatus = ChildStatusEntry
 export type ObservationCollectionMap = Record<string, StateCollectionDefinition>
 export type ObservationStreamDB = BaseStreamDB<ObservationCollectionMap>
@@ -64,6 +75,125 @@ export type JsonValue =
   | null
   | Array<JsonValue>
   | { [key: string]: JsonValue }
+
+export type EntitySchema = StandardTypedV1<any, any>
+
+type AnyFunction = (...args: Array<any>) => unknown
+export type EntityActionMap = Record<string, AnyFunction>
+export type EntityStateDefinition = Record<string, CollectionDefinition>
+
+export interface EntityTransaction {
+  isPersisted: {
+    promise: Promise<unknown>
+  }
+}
+
+type UnionToIntersection<T> = (
+  T extends unknown ? (value: T) => void : never
+) extends (value: infer R) => void
+  ? R
+  : never
+
+type ObjectOutput<T> = T extends object ? T : Record<string, unknown>
+
+export type SchemaInput<TSchema> = TSchema extends StandardTypedV1
+  ? StandardTypedV1.InferInput<TSchema>
+  : unknown
+
+export type SchemaOutput<TSchema> = TSchema extends StandardTypedV1
+  ? StandardTypedV1.InferOutput<TSchema>
+  : unknown
+
+type CollectionSchema<TCollection> = TCollection extends {
+  schema?: infer TSchema
+}
+  ? NonNullable<TSchema>
+  : never
+
+export type CollectionRow<TCollection> = [
+  CollectionSchema<TCollection>,
+] extends [never]
+  ? Record<string, unknown>
+  : ObjectOutput<SchemaOutput<CollectionSchema<TCollection>>>
+
+export type CollectionInsert<TCollection> = [
+  CollectionSchema<TCollection>,
+] extends [never]
+  ? CollectionRow<TCollection>
+  : ObjectOutput<SchemaInput<CollectionSchema<TCollection>>>
+
+export type CollectionKey<TCollection> = TCollection extends {
+  primaryKey: infer TPrimaryKey extends string
+}
+  ? TPrimaryKey extends keyof CollectionRow<TCollection>
+    ? Extract<CollectionRow<TCollection>[TPrimaryKey], string> extends never
+      ? string
+      : Extract<CollectionRow<TCollection>[TPrimaryKey], string>
+    : string
+  : `key` extends keyof CollectionRow<TCollection>
+    ? Extract<CollectionRow<TCollection>[`key`], string> extends never
+      ? string
+      : Extract<CollectionRow<TCollection>[`key`], string>
+    : string
+
+export type StateProxyFrom<TState> =
+  TState extends Record<string, unknown>
+    ? {
+        [K in keyof TState & string]: StateCollectionProxy<
+          CollectionRow<TState[K]>,
+          CollectionInsert<TState[K]>,
+          CollectionKey<TState[K]>
+        >
+      }
+    : {}
+
+type EntityCollectionsFromState<TState> =
+  TState extends Record<string, unknown>
+    ? {
+        [K in keyof TState & string]: TanStackCollection<
+          CollectionRow<TState[K]>,
+          CollectionKey<TState[K]>,
+          any,
+          any,
+          CollectionInsert<TState[K]>
+        >
+      }
+    : {}
+
+type GeneratedActionUnion<TState extends Record<string, unknown>> = {
+  [K in keyof TState & string]: {
+    [P in `${K}_insert`]: (args: {
+      row: CollectionInsert<TState[K]>
+    }) => EntityTransaction
+  } & {
+    [P in `${K}_update`]: (args: {
+      key: CollectionKey<TState[K]>
+      updater: (draft: CollectionRow<TState[K]>) => void
+    }) => EntityTransaction
+  } & {
+    [P in `${K}_delete`]: (args: {
+      key: CollectionKey<TState[K]>
+    }) => EntityTransaction
+  }
+}[keyof TState & string]
+
+export type GeneratedStateActions<TState> =
+  TState extends Record<string, unknown>
+    ? [keyof TState & string] extends [never]
+      ? {}
+      : UnionToIntersection<GeneratedActionUnion<TState>>
+    : {}
+
+export type HandlerActions<TActions extends EntityActionMap> = {
+  [K in keyof TActions]: TActions[K] extends (...args: infer TParams) => unknown
+    ? (...args: TParams) => EntityTransaction
+    : never
+}
+
+export type EntityArgs<TCreationSchema> =
+  TCreationSchema extends StandardTypedV1
+    ? Readonly<ObjectOutput<SchemaInput<TCreationSchema>>>
+    : Readonly<Record<string, unknown>>
 
 // Re-export TanStack DB effect types
 export type DeltaEvent<
@@ -261,11 +391,13 @@ export type EffectConfig<
  */
 export interface StateCollectionProxy<
   T extends object = Record<string, unknown>,
+  TInsert extends object = T,
+  TKey extends string = string,
 > {
-  insert: (row: T) => unknown // Transaction
-  update: (key: string, updater: (draft: T) => void) => unknown // Transaction
-  delete: (key: string) => unknown // Transaction
-  get: (key: string) => T | undefined
+  insert: (row: TInsert) => EntityTransaction
+  update: (key: TKey, updater: (draft: T) => void) => EntityTransaction
+  delete: (key: TKey) => EntityTransaction
+  get: (key: TKey) => T | undefined
   toArray: Array<T>
 }
 
@@ -276,9 +408,13 @@ export type StateProxy = Record<string, StateCollectionProxy>
  * Mirrors how entity `state:` collections are defined but is self-contained
  * so shared state schemas can be declared inline.
  */
-export interface SharedStateCollectionSchema {
+export interface SharedStateCollectionSchema<
+  TSchema extends StandardSchemaV1<any, any> | undefined =
+    | StandardSchemaV1<any, any>
+    | undefined,
+> {
   /** Zod (or any Standard Schema) validator for the row type */
-  schema?: StandardSchemaV1
+  schema?: TSchema
   /** Event type string used in the durable stream (e.g. `"finding"`) */
   type: string
   /** Primary key field name (must be a string field on the row) */
@@ -311,7 +447,11 @@ export type SharedStateHandle<
   /** The shared state stream identifier */
   id: string
 } & {
-  [K in keyof TSchema]: StateCollectionProxy
+  [K in keyof TSchema]: StateCollectionProxy<
+    CollectionRow<TSchema[K]>,
+    CollectionInsert<TSchema[K]>,
+    CollectionKey<TSchema[K]>
+  >
 }
 
 export interface RuntimeContext {
@@ -335,10 +475,10 @@ export interface RuntimeContext {
     source: ObservationSource & { sourceType: `entity` },
     opts?: { wake?: Wake }
   ) => Promise<EntityHandle>) &
-    ((
-      source: ObservationSource & { sourceType: `db` },
+    (<TSchema extends SharedStateSchemaMap>(
+      source: ObservationSource & { sourceType: `db`; schema: TSchema },
       opts?: { wake?: Wake }
-    ) => Promise<SharedStateHandle & ObservationHandle>) &
+    ) => Promise<SharedStateHandle<TSchema> & ObservationHandle>) &
     ((
       source: ObservationSource,
       opts?: { wake?: Wake }
@@ -411,17 +551,23 @@ export interface SourceHandleInfo {
   ) => void | Promise<void>
 }
 
-export interface CollectionDefinition {
-  schema?: StandardSchemaV1
+export interface CollectionDefinition<
+  TSchema extends StandardSchemaV1<any, any> | undefined =
+    | StandardSchemaV1<any, any>
+    | undefined,
+> {
+  schema?: TSchema
   /** Event type string used in the durable stream (e.g. `"counter_value"`). Defaults to `"state:${name}"`. */
   type?: string
   /** Primary key field name. Defaults to `"key"`. */
   primaryKey?: string
 }
 
-export interface EntityTypeEntry {
+export interface EntityTypeEntry<
+  TDefinition extends AnyEntityDefinition = AnyEntityDefinition,
+> {
   name: string
-  definition: EntityDefinition
+  definition: TDefinition
 }
 
 // Re-export upstream types used in signatures above so consumers can import from one place
@@ -733,16 +879,26 @@ export interface RunHandle {
   attachResponse(text: string): void
 }
 
-export interface HandlerContext<TState extends StateProxy = StateProxy> {
+export interface HandlerContext<
+  TState extends StateProxy = StateProxy,
+  TArgs extends Readonly<Record<string, unknown>> = Readonly<
+    Record<string, unknown>
+  >,
+  TActions extends Record<string, (...args: Array<any>) => unknown> = Record<
+    string,
+    (...args: Array<any>) => unknown
+  >,
+  TDb extends EntityStreamDBWithActions = EntityStreamDBWithActions,
+> {
   firstWake: boolean
   tags: Readonly<EntityTags>
   entityUrl: string
   entityType: string
-  args: Readonly<Record<string, unknown>>
-  db: EntityStreamDBWithActions
+  args: TArgs
+  db: TDb
   state: TState
   events: Array<ChangeEvent>
-  actions: Record<string, (...args: Array<unknown>) => unknown>
+  actions: TActions
   electricTools: Array<AgentTool>
   useAgent: (config: AgentConfig) => AgentHandle
   useContext: (config: UseContextConfig) => void
@@ -773,10 +929,10 @@ export interface HandlerContext<TState extends StateProxy = StateProxy> {
     source: ObservationSource & { sourceType: `entity` },
     opts?: { wake?: Wake }
   ) => Promise<EntityHandle>) &
-    ((
-      source: ObservationSource & { sourceType: `db` },
+    (<TSchema extends SharedStateSchemaMap>(
+      source: ObservationSource & { sourceType: `db`; schema: TSchema },
       opts?: { wake?: Wake }
-    ) => Promise<SharedStateHandle & ObservationHandle>) &
+    ) => Promise<SharedStateHandle<TSchema> & ObservationHandle>) &
     ((
       source: ObservationSource,
       opts?: { wake?: Wake }
@@ -814,15 +970,44 @@ export interface HandlerContext<TState extends StateProxy = StateProxy> {
   removeTag: (key: string) => Promise<void>
 }
 
-export interface EntityDefinition {
+export type EntityActionsFactory<
+  TState extends EntityStateDefinition | undefined,
+  TActions extends EntityActionMap,
+> = (collections: EntityCollectionsFromState<TState>) => TActions
+
+export interface EntityDefinition<
+  TCreationSchema extends EntitySchema | undefined = EntitySchema | undefined,
+  TState extends EntityStateDefinition | undefined =
+    | EntityStateDefinition
+    | undefined,
+  TActions extends EntityActionMap = EntityActionMap,
+> {
   description?: string
-  state?: Record<string, CollectionDefinition>
-  actions?: (
-    collections: Record<string, unknown>
-  ) => Record<string, (...args: Array<unknown>) => void>
-  creationSchema?: StandardJSONSchemaV1
+  state?: TState
+  actions?: EntityActionsFactory<TState, TActions>
+  creationSchema?: TCreationSchema
   inboxSchemas?: Record<string, StandardJSONSchemaV1>
   outputSchemas?: Record<string, StandardJSONSchemaV1>
 
+  handler: (
+    ctx: HandlerContext<
+      StateProxyFrom<TState>,
+      EntityArgs<TCreationSchema>,
+      HandlerActions<TActions>,
+      EntityStreamDBWithActions<TState, TActions>
+    >,
+    wake: WakeEvent
+  ) => void | Promise<void>
+}
+
+export type AnyEntityDefinition = Omit<
+  EntityDefinition<
+    EntitySchema | undefined,
+    EntityStateDefinition | undefined,
+    EntityActionMap
+  >,
+  `actions` | `handler`
+> & {
+  actions?: (collections: Record<string, unknown>) => EntityActionMap
   handler: (ctx: HandlerContext, wake: WakeEvent) => void | Promise<void>
 }

--- a/packages/agents-runtime/test/typed-entity-definition-public-types.ts
+++ b/packages/agents-runtime/test/typed-entity-definition-public-types.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+import { db, defineEntity, type SharedStateHandle } from '../src/index'
+
+const noteSchema = z.object({
+  key: z.string(),
+  count: z.number().default(0),
+})
+
+const sharedSchema = {
+  notes: {
+    schema: noteSchema,
+    type: `shared:note`,
+    primaryKey: `key`,
+  },
+} as const
+
+type SharedNotes = SharedStateHandle<typeof sharedSchema>
+
+declare const shared: SharedNotes
+
+shared.notes.insert({ key: `note-1` })
+shared.notes.update(`note-1`, (draft) => {
+  draft.count += 1
+})
+shared.notes.get(`note-1`)?.count.toFixed()
+
+// @ts-expect-error count must be a number when provided
+shared.notes.insert({ key: `note-1`, count: `wrong` })
+
+defineEntity(`typed-agent`, {
+  creationSchema: z.object({
+    topic: z.string(),
+    depth: z.number(),
+  }),
+  state: {
+    notes: {
+      schema: noteSchema,
+      type: `state:note`,
+      primaryKey: `key`,
+    },
+  },
+  actions: (collections) => ({
+    touch(key: string) {
+      collections.notes.get(key)?.count.toFixed()
+    },
+  }),
+  async handler(ctx) {
+    ctx.args.topic.toUpperCase()
+    ctx.args.depth.toFixed()
+
+    // @ts-expect-error args are inferred from creationSchema
+    ctx.args.missing
+
+    ctx.state.notes.insert({ key: `note-1` })
+    ctx.state.notes.update(`note-1`, (draft) => {
+      draft.count += 1
+    })
+    ctx.state.notes.get(`note-1`)?.count.toFixed()
+
+    ctx.db.actions.notes_insert({ row: { key: `note-1` } })
+    ctx.db.actions.notes_update({
+      key: `note-1`,
+      updater: (draft) => {
+        draft.count += 1
+      },
+    })
+    ctx.db.actions.notes_delete({ key: `note-1` })
+
+    // @ts-expect-error generated insert action uses the collection schema input
+    ctx.db.actions.notes_insert({ row: { key: `note-1`, count: `wrong` } })
+
+    ctx.actions.touch(`note-1`)
+    // @ts-expect-error custom action parameters are preserved
+    ctx.actions.touch(123)
+
+    const observed = await ctx.observe(db(`shared-notes`, sharedSchema))
+    observed.notes.insert({ key: `note-2` })
+    observed.notes.get(`note-2`)?.count.toFixed()
+  },
+})
+
+defineEntity(`stateless-agent`, {
+  handler(ctx) {
+    // @ts-expect-error no declared state means no generated state proxy
+    ctx.state.notes
+
+    // @ts-expect-error no declared state means no generated db action
+    ctx.db.actions.notes_insert
+  },
+})

--- a/packages/agents/skills/quickstart/scaffold-ui/index.html
+++ b/packages/agents/skills/quickstart/scaffold-ui/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary
- Make `db(id, schema)` preserve the concrete shared-state schema type
- Propagate shared state schema typing into `ctx.observe(...)` and shared collection proxies
- Narrow `defineEntity` handler args, state, and generated action types from declared schemas
- Update deep-survey to use the new inferred types and remove cast-heavy helpers

## Testing
- Existing package and example typechecks passed in local validation
- Added a type-focused regression test covering shared state handles, entity args, and generated actions