### PR TITLE
fix(agents-runtime): skip copied fork history during wake replay

### DIFF
--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -905,11 +905,56 @@ export async function processWebhookWake(
             }
             return compareOffsets(offset, offsetBound) >= 0
           })
+    const eventOffset = (event: ChangeEvent): string | null => {
+      const offset = event.headers.offset
+      return typeof offset === `string` ? offset : null
+    }
+    const latestForkReconciliationOffset = (
+      events: Array<ChangeEvent>
+    ): string | null => {
+      let latest: string | null = null
+      for (const event of events) {
+        const headers = event.headers as Record<string, unknown>
+        if (typeof headers.forkedFrom !== `string`) {
+          continue
+        }
+        const offset = eventOffset(event)
+        if (!offset) {
+          continue
+        }
+        if (latest === null || compareOffsets(offset, latest) > 0) {
+          latest = offset
+        }
+      }
+      return latest
+    }
+    const filterEventsAfterOffset = (
+      events: Array<ChangeEvent>,
+      offsetBound: string | null
+    ): Array<ChangeEvent> => {
+      if (offsetBound === null) {
+        return events
+      }
+      return events.filter((event) => {
+        const offset = eventOffset(event)
+        if (offset === null) {
+          return true
+        }
+        return compareOffsets(offset, offsetBound) > 0
+      })
+    }
     const eventsAtOrAfterNotification =
       filterEventsAtOrAboveOffset(notificationOffset)
+    const forkReconciliationOffset = latestForkReconciliationOffset(
+      eventsAtOrAfterNotification
+    )
+    const actionableEventsAtOrAfterNotification = filterEventsAfterOffset(
+      eventsAtOrAfterNotification,
+      forkReconciliationOffset
+    )
     const initialFromCatchUp = notification.wakeEvent
       ? null
-      : selectWakeFromEvents(eventsAtOrAfterNotification, entityUrl)
+      : selectWakeFromEvents(actionableEventsAtOrAfterNotification, entityUrl)
     if (initialFromCatchUp) {
       currentWakeEvent = initialFromCatchUp.wakeEvent
       currentWakeOffset = initialFromCatchUp.offset ?? notificationOffset
@@ -921,7 +966,10 @@ export async function processWebhookWake(
     notifyCurrentWakeReady()
 
     const computeCurrentNotificationEvents = (): Array<ChangeEvent> =>
-      filterEventsAtOrAboveOffset(currentWakeOffset)
+      filterEventsAfterOffset(
+        filterEventsAtOrAboveOffset(currentWakeOffset),
+        forkReconciliationOffset
+      )
 
     const currentNotificationEvents = computeCurrentNotificationEvents()
 
@@ -934,8 +982,10 @@ export async function processWebhookWake(
       currentNotificationEvents.every(isManagementEvent)
     const shouldSkipInitialHandlerPass =
       !notification.wakeEvent &&
-      currentNotificationEvents.length > 0 &&
-      (!hasFreshCatchUpInput || hasOnlyManagementCatchUp)
+      ((currentNotificationEvents.length > 0 &&
+        (!hasFreshCatchUpInput || hasOnlyManagementCatchUp)) ||
+        (forkReconciliationOffset !== null &&
+          currentNotificationEvents.length === 0))
     if (debugWakeTypes) {
       log.info(
         `wake input type=${currentWakeEvent.type} offset=${currentWakeOffset}`

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -1247,6 +1247,62 @@ describe(`processWake`, () => {
     ])
   })
 
+  it(`skips copied fork history when catch-up ends with fork reconciliation`, async () => {
+    const handler = vi.fn()
+
+    defineEntity(`test-agent`, {
+      handler,
+    })
+
+    mockDbOffset.value = `20_0`
+    mockStreamOffset.value = `20_0`
+    mockDbPreload.mockImplementationOnce(async () => {
+      mockEntityOnBatch.current?.({
+        items: [
+          ev(
+            `message_received`,
+            `m-old`,
+            `insert`,
+            { payload: `historical prompt` },
+            { offset: `1_0` }
+          ),
+          ev(`run`, `run-old`, `update`, {
+            status: `completed`,
+          }),
+          ev(
+            `entity_created`,
+            `entity-created`,
+            `insert`,
+            {},
+            { offset: `20_0`, forkedFrom: `/test-agent/source` }
+          ),
+        ],
+        offset: `20_0`,
+      })
+    })
+
+    await processWake(
+      makeNotification({
+        triggerEvent: `message_received`,
+        streams: [{ path: `/streams/entity:agent-1`, offset: `0_0` }],
+      }),
+      { ...BASE_CONFIG, idleTimeout: 1 }
+    )
+
+    expect(handler).not.toHaveBeenCalled()
+
+    const doneCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes(`/_electric/wakes/wake-abc`)
+    )
+    const lastDoneCall = doneCalls[doneCalls.length - 1]!
+    const body = JSON.parse(lastDoneCall[1]!.body as string) as {
+      acks: Array<{ path: string; offset: string }>
+    }
+    expect(body.acks).toEqual([
+      { path: `/streams/entity:agent-1`, offset: `20_0` },
+    ])
+  })
+
   it(`collapses consecutive pending wake batches into one handler pass using the newest wake`, async () => {
     const wakeSummaries: Array<string> = []
     let firstPassSeenResolve: (() => void) | null = null

--- a/packages/agents/skills/quickstart/scaffold-ui/index.html
+++ b/packages/agents/skills/quickstart/scaffold-ui/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary
- Treat fork reconciliation events as a replay boundary when reconstructing the initial wake
- Skip copied historical inbox events that were already present before the fork
- Add a regression test covering the extra-turn fork scenario

## Testing
- Added a focused unit regression test in `packages/agents-runtime`
- Ran `process-wake.test.ts` and the full `agents-runtime` test suite
- Ran `agents-runtime` typecheck