### PR TITLE
Make otel-export lux test reliable via normalized output and per-pattern grep

### DIFF
--- a/integration-tests/support_files/normalize-otel-output.py
+++ b/integration-tests/support_files/normalize-otel-output.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Normalizes OTel collector debug output to single-line format.
+
+Input (multi-line):
+    info	ResourceMetrics #0
+    Resource attributes:
+         -> custom.attr: Str(electric.val)
+         -> service.name: Str(electric)
+    Metric #0
+    Descriptor:
+         -> Name: process.bin_memory.total
+         -> DataType: Gauge
+    Data point attributes:
+         -> process_type: Str(A_memory_hog)
+    Value: 12345
+
+Output (single-line per event):
+    ResourceMetrics custom.attr=electric.val service.name=electric
+    Metric process.bin_memory.total DataType=Gauge process_type=A_memory_hog Value=12345
+
+    Span shape_snapshot.execute_for_shape shape.query_reason=initial_snapshot
+"""
+
+import re
+import sys
+
+# Patterns
+RESOURCE_BLOCK = re.compile(r'Resource(Metrics|Logs|Spans) #\d+')
+SCOPE_BLOCK = re.compile(r'Scope(Metrics|Logs|Spans) #\d+')
+METRIC = re.compile(r'Metric #\d+')
+LOG_RECORD = re.compile(r'LogRecord #\d+')
+SPAN = re.compile(r'Span #\d+')
+ATTR = re.compile(r'^\s*->\s*([^:]+):\s*(?:Str\(([^)]*)\)|Int\(([^)]*)\)|Double\(([^)]*)\)|Bool\(([^)]*)\)|(.+))$')
+NAME = re.compile(r'^\s*->\s*Name:\s*(.+)$')
+SPAN_NAME = re.compile(r'^\s*Name\s*:\s*(.+)$')
+VALUE = re.compile(r'^Value:\s*(.+)$')
+
+
+def flush_event(event_type, name, attrs):
+    """Output a single-line event."""
+    if not event_type:
+        return
+    parts = [event_type]
+    if name:
+        parts.append(name)
+    for k, v in attrs:
+        parts.append(f"{k}={v}")
+    print(" ".join(parts), flush=True)
+
+
+def main():
+    resource_attrs = []
+    event_type = None
+    event_name = None
+    event_attrs = []
+    in_resource_attrs = False
+    in_data_point_attrs = False
+    in_descriptor = False
+
+    for line in sys.stdin:
+        line = line.rstrip('\n')
+
+        # New Resource* block (Metrics, Logs, or Spans)
+        if RESOURCE_BLOCK.search(line):
+            flush_event(event_type, event_name, resource_attrs + event_attrs)
+            event_type = None
+            event_name = None
+            event_attrs = []
+            resource_attrs = []
+            in_resource_attrs = False
+            in_data_point_attrs = False
+            in_descriptor = False
+            continue
+
+        # Track attribute sections
+        if 'Resource attributes:' in line:
+            in_resource_attrs = True
+            in_data_point_attrs = False
+            in_descriptor = False
+            continue
+
+        if 'Data point attributes:' in line or 'Attributes:' in line:
+            in_data_point_attrs = True
+            in_resource_attrs = False
+            in_descriptor = False
+            continue
+
+        if 'Descriptor:' in line:
+            in_descriptor = True
+            in_resource_attrs = False
+            in_data_point_attrs = False
+            continue
+
+        if SCOPE_BLOCK.search(line):
+            in_resource_attrs = False
+            in_data_point_attrs = False
+            in_descriptor = False
+            continue
+
+        # New Metric
+        if METRIC.search(line):
+            flush_event(event_type, event_name, resource_attrs + event_attrs)
+            event_type = "Metric"
+            event_name = None
+            event_attrs = []
+            in_descriptor = False
+            in_data_point_attrs = False
+            continue
+
+        # New Span
+        if SPAN.search(line):
+            flush_event(event_type, event_name, resource_attrs + event_attrs)
+            event_type = "Span"
+            event_name = None
+            event_attrs = []
+            in_descriptor = False
+            in_data_point_attrs = False
+            continue
+
+        # New LogRecord
+        if LOG_RECORD.search(line):
+            flush_event(event_type, event_name, resource_attrs + event_attrs)
+            event_type = "LogRecord"
+            event_name = None
+            event_attrs = []
+            in_descriptor = False
+            in_data_point_attrs = False
+            continue
+
+        # Parse Name in descriptor
+        if in_descriptor:
+            m = NAME.match(line)
+            if m:
+                event_name = m.group(1).strip()
+                continue
+
+        # Parse Span name (different format)
+        if event_type == "Span" and not event_name:
+            m = SPAN_NAME.match(line)
+            if m:
+                event_name = m.group(1).strip()
+                continue
+
+        # Parse attributes
+        m = ATTR.match(line)
+        if m:
+            key = m.group(1).strip()
+            # Get the first non-None value group
+            val = m.group(2) or m.group(3) or m.group(4) or m.group(5) or m.group(6) or ""
+            val = val.strip()
+
+            if in_resource_attrs:
+                resource_attrs.append((key, val))
+            elif in_data_point_attrs or event_type:
+                event_attrs.append((key, val))
+            continue
+
+        # Parse Value
+        m = VALUE.match(line)
+        if m and event_type:
+            event_attrs.append(("Value", m.group(1).strip()))
+            continue
+
+    # Flush final event
+    flush_event(event_type, event_name, resource_attrs + event_attrs)
+
+
+if __name__ == "__main__":
+    main()

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -243,11 +243,12 @@
     ??Everything is ready. Begin running and processing data.
 
     -
+    [timeout 10]
 [endmacro]
 
-[macro dump_sorted_otel_collector_output]
-  # Sorted and compacted output for pattern matching
-  !docker logs $otel_collector_container_name 2>&1 | python3 $(realpath ../support_files/normalize-otel-output.py) | sort
+[macro grep_otel_collector_output pat]
+  !docker logs $otel_collector_container_name 2>&1 | python3 $(realpath ../support_files/normalize-otel-output.py) | grep "$pat" && FOUND
+  ??FOUND
 [endmacro]
 
 [macro teardown_container container_name]

--- a/integration-tests/tests/_macros.luxinc
+++ b/integration-tests/tests/_macros.luxinc
@@ -225,8 +225,12 @@
 [endmacro]
 
 [macro setup_otel_collector]
-  [shell otel_collector]
+  [shell otel_collector_startup]
+    -$fail_pattern
+
+    # Start collector in detached mode
     !docker run \
+      --rm \
       --name $otel_collector_container_name \
       -p 4318:4318 \
       -v $(realpath ../support_files/otel-collector-config.yaml):/conf/otel-collector-config.yaml \
@@ -235,12 +239,15 @@
     # Allow time for docker to pull the image if not cached
     [timeout 120]
 
-    ??Starting HTTP server
-    ?"endpoint": "(0\.0\.0\.0|\[::\]):4318"
+    # Wait for collector to be ready
     ??Everything is ready. Begin running and processing data.
 
-    # Reset the timeout for subsequent pattern matching
-    [timeout 10]
+    -
+[endmacro]
+
+[macro dump_sorted_otel_collector_output]
+  # Sorted and compacted output for pattern matching
+  !docker logs $otel_collector_container_name 2>&1 | python3 $(realpath ../support_files/normalize-otel-output.py) | sort
 [endmacro]
 
 [macro teardown_container container_name]

--- a/integration-tests/tests/otel-export.lux
+++ b/integration-tests/tests/otel-export.lux
@@ -60,41 +60,64 @@
   ??HTTP/1.1 200 OK
   ??"value":{"val":"3"}
 
+[sleep 10]
+
+[shell otel_collector_startup]
+  # Verify that the Collector receives application metrics from Electric with expected resource attributes
+  """?
+  info	ResourceMetrics #0
+  Resource SchemaURL: 
+  Resource attributes:
+       -> custom.attr: Str\(electric.val\)
+       -> instance.id: Str\([-a-f0-9]+\)
+       -> name: Str\(metrics\)
+       -> service.name: Str\(electric\)
+       -> service.version: Str\([0-9.]+\)
+  ScopeMetrics #0
+  """
+
+  # Verify that the Collector receives stack metrics from Electric with expected resource attributes
+  """?
+  info	ResourceMetrics #0
+  Resource SchemaURL: 
+  Resource attributes:
+       -> custom.attr: Str\(electric.val\)
+       -> instance.id: Str\([-a-f0-9]+\)
+       -> name: Str\(metrics\)
+       -> service.name: Str\(electric\)
+       -> service.version: Str\([0-9.]+\)
+       -> stack_id: Str\(single_stack\)
+  ScopeMetrics #0
+  """
+
 [shell otel_collector]
-  [sleep 10]
+  # Verify the presence of process.bin_memory.* metrics
+  [invoke grep_otel_collector_output "Metric process\.bin_memory\.avg_bin_count .*process_type=A_memory_hog.*Value=[.0-9]+"]
+  [invoke grep_otel_collector_output "Metric process\.bin_memory\.avg_ref_count .*process_type=A_memory_hog.*Value=[.0-9]+"]
+  [invoke grep_otel_collector_output "Metric process\.bin_memory\.max_bin_count .*process_type=A_memory_hog.*Value=[0-9]+"]
+  [invoke grep_otel_collector_output "Metric process\.bin_memory\.max_ref_count .*process_type=A_memory_hog.*Value=[0-9]+"]
+  [invoke grep_otel_collector_output "Metric process\.bin_memory\.total .*process_type=A_memory_hog.*Value=[0-9]+"]
 
-  [invoke dump_sorted_otel_collector_output]
+  # Verify the presence of process.memory.total metric
+  [invoke grep_otel_collector_output "Metric process\.memory\.total .*process_type=A_memory_hog.*Value=[0-9]+"]
 
-  # Patterns below must be ordered alphabetically, so all metrics are matched first, followed by spans.
+  # Verify that LSN metrics are exported
+  [invoke grep_otel_collector_output "Metric electric\.postgres\.replication\.pg_wal_offset .*stack_id=single_stack"]
+  [invoke grep_otel_collector_output "Metric electric\.postgres\.replication\.slot_confirmed_flush_lsn_lag .*stack_id=single_stack"]
+  [invoke grep_otel_collector_output "Metric electric\.postgres\.replication\.slot_retained_wal_size .*stack_id=single_stack"]
 
-  # Verify export of resource attributes
-  ?Metric electric\.connection\.consumers_ready\.total custom\.attr=electric\.val instance\.id=[-a-f0-9]+ \
-     name=metrics service\.name=electric service\.version=[0-9.]+ stack_id=single_stack
+  # Regression check: These metrics haven't been exporting until recently
+  [invoke grep_otel_collector_output "Metric electric\.plug\.serve_shape\.bytes .*stack_id=single_stack"]
+  [invoke grep_otel_collector_output "Metric electric\.plug\.serve_shape\.count .*stack_id=single_stack"]
+  [invoke grep_otel_collector_output "Metric electric\.storage\.snapshot_stored\.operations .*stack_id=single_stack"]
+  [invoke grep_otel_collector_output "Metric electric\.storage\.transaction_stored\.bytes .*stack_id=single_stack"]
+  [invoke grep_otel_collector_output "Metric electric\.storage\.transaction_stored\.operations .*stack_id=single_stack"]
 
-  ?Metric electric\.plug\.serve_shape\.bytes .*stack_id=single_stack
-  ?Metric electric\.plug\.serve_shape\.count .*stack_id=single_stack
-
-  ?Metric electric\.postgres\.replication\.pg_wal_offset .*stack_id=single_stack
-  ?Metric electric\.postgres\.replication\.slot_confirmed_flush_lsn_lag .*stack_id=single_stack
-  ?Metric electric\.postgres\.replication\.slot_retained_wal_size .*stack_id=single_stack
-
-  ?Metric electric\.storage\.snapshot_stored\.operations .*stack_id=single_stack
-  ?Metric electric\.storage\.transaction_stored\.bytes .*stack_id=single_stack
-  ?Metric electric\.storage\.transaction_stored\.operations .*stack_id=single_stack
-
-  # Export of process memory metrics by application telemetry
-  ?Metric process\.bin_memory\.avg_bin_count .*process_type=A_memory_hog.*Value=[.0-9]+
-  ?Metric process\.bin_memory\.avg_ref_count .*process_type=A_memory_hog.*Value=[.0-9]+
-  ?Metric process\.bin_memory\.max_bin_count .*process_type=A_memory_hog.*Value=[0-9]+
-  ?Metric process\.bin_memory\.max_ref_count .*process_type=A_memory_hog.*Value=[0-9]+
-  ?Metric process\.bin_memory\.total .*process_type=A_memory_hog.*Value=[0-9]+
-  ?Metric process\.memory\.total .*process_type=A_memory_hog.*Value=[0-9]+
-
-  # The initial snapshot query span is exported from the Snapshotter path.
-  ?Span shape_snapshot\.execute_for_shape .*shape\.query_reason=initial_snapshot
+  # The initial snapshot query span is exported from the Snapshotter path."]
+  [invoke grep_otel_collector_output "Span shape_snapshot\.execute_for_shape .*shape\.query_reason=initial_snapshot"]
 
   # A direct subset snapshot query span is exported from the PartialModes path.
-  ?Span shape_snapshot\.execute_for_shape .*shape\.query_reason=subset_query
+  [invoke grep_otel_collector_output "Span shape_snapshot\.execute_for_shape .*shape\.query_reason=subset_query"]
 
 ###
 

--- a/integration-tests/tests/otel-export.lux
+++ b/integration-tests/tests/otel-export.lux
@@ -12,9 +12,7 @@
 
 [invoke setup_electric_with_env "ELECTRIC_OTLP_ENDPOINT=http://localhost:4318 ELECTRIC_SYSTEM_METRICS_POLL_INTERVAL=1s ELECTRIC_STACK_TELEMETRY_INIT_DELAY=1s ELECTRIC_OTEL_EXPORT_PERIOD=2s DO_NOT_START_CONN_MAN_PING=1 ELECTRIC_LOG_LEVEL=info OTEL_RESOURCE_ATTRIBUTES=custom.attr=electric.val"]
 
-# Spawn a process containing off-heap binary references and ensure its in the top 5 by memory footprint.
-# Otel Collector sorts metrics in its debug output, so the process label for our process needs
-# to be first lexicographically for easier output matching further down.
+# Spawn a process containing off-heap binary references and ensure it's in the top 5 by memory footprint.
 [shell electric]
   """!
   _pid = spawn_link(fn ->
@@ -34,166 +32,6 @@
 
   ??#PID
 
-[shell otel_collector]
-  # Verify that the Collector receives expected application metrics from Electric
-  """?
-  info	ResourceMetrics #0
-  Resource SchemaURL: 
-  Resource attributes:
-       -> custom.attr: Str\(electric.val\)
-       -> instance.id: Str\([-a-f0-9]+\)
-       -> name: Str\(metrics\)
-       -> service.name: Str\(electric\)
-       -> service.version: Str\([0-9.]+\)
-  ScopeMetrics #0
-  """
-
-  # Verify the presence of process.bin_memory.* metrics
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: process\.bin_memory\.avg_bin_count
-       -> Description: 
-       -> Unit: 
-       -> DataType: Gauge
-  NumberDataPoints #0
-  Data point attributes:
-       -> process_type: Str\(A_memory_hog\)
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: [.0-9]+
-  """
-
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: process\.bin_memory\.avg_ref_count
-       -> Description: 
-       -> Unit: 
-       -> DataType: Gauge
-  NumberDataPoints #0
-  Data point attributes:
-       -> process_type: Str\(A_memory_hog\)
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: 1\.000000
-  """
-
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: process\.bin_memory\.max_bin_count
-       -> Description: 
-       -> Unit: 
-       -> DataType: Gauge
-  NumberDataPoints #0
-  Data point attributes:
-       -> process_type: Str\(A_memory_hog\)
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: [0-9]+
-  """
-
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: process\.bin_memory\.max_ref_count
-       -> Description: 
-       -> Unit: 
-       -> DataType: Gauge
-  NumberDataPoints #0
-  Data point attributes:
-       -> process_type: Str\(A_memory_hog\)
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: [0-9]+
-  """
-
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: process\.bin_memory\.total
-       -> Description: 
-       -> Unit: By
-       -> DataType: Gauge
-  NumberDataPoints #0
-  Data point attributes:
-       -> process_type: Str\(A_memory_hog\)
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: [0-9]+
-  """
-
-  # Verify the presence of process.memory.total metric
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: process\.memory\.total
-       -> Description: 
-       -> Unit: By
-       -> DataType: Gauge
-  NumberDataPoints #0
-  Data point attributes:
-       -> process_type: Str\(A_memory_hog\)
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: [0-9]+
-  """
-
-  # Verify that the Collector receives stack metrics from Electric with expected resource attributes
-  """?
-  info	ResourceMetrics #0
-  Resource SchemaURL: 
-  Resource attributes:
-       -> custom.attr: Str\(electric.val\)
-       -> instance.id: Str\([-a-f0-9]+\)
-       -> name: Str\(metrics\)
-       -> service.name: Str\(electric\)
-       -> service.version: Str\([0-9.]+\)
-       -> stack_id: Str\(single_stack\)
-  ScopeMetrics #0
-  """
-
-  # Verify that LSN metrics are exported
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: electric\.postgres\.replication\.pg_wal_offset
-       -> Description: 
-       -> Unit: 
-       -> DataType: Gauge
-  NumberDataPoints #0
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: [-+.0-9]+
-  """
-
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: electric\.postgres\.replication\.slot_confirmed_flush_lsn_lag
-       -> Description: 
-       -> Unit: By
-       -> DataType: Gauge
-  NumberDataPoints #0
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: [-+.0-9]+
-  """
-
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: electric\.postgres\.replication\.slot_retained_wal_size
-       -> Description: 
-       -> Unit: By
-       -> DataType: Gauge
-  NumberDataPoints #0
-  StartTimestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Timestamp: [-0-9]+ [.:0-9]+ [-+0-9]+ UTC
-  Value: [-+.0-9]+
-  """
-
 [invoke start_psql]
 
 [shell psql]
@@ -209,70 +47,54 @@
   ?electric-offset: ([\w\d_]+)
   [global offset=$1]
 
-[shell otel_collector]
-  # Verify that the initial snapshot query span is exported from the Snapshotter path.
-  ?Span #[0-9]+
-  ?Name[ ]+: shape_snapshot\.execute_for_shape
-  ?->[ ]shape\.query_reason: Str\(initial_snapshot\)
-
 [shell psql]
   !insert into items values ('3');
   ??INSERT
 
 [shell client]
   [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&subset__where=val%20%3D%20%273%27"]
-
   ??HTTP/1.1 200 OK
   ??"metadata"
 
-[shell otel_collector]
-  # Verify that a direct subset snapshot query span is exported from the PartialModes path.
-  ?Span #[0-9]+
-  ?Name[ ]+: shape_snapshot\.execute_for_shape
-  ?->[ ]shape\.query_reason: Str\(subset_query\)
-
-[shell client]
-  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset&live"]
-
+  [invoke curl_shape "http://localhost:3000/v1/shape?table=items&handle=$handle&offset=$offset"]
   ??HTTP/1.1 200 OK
   ??"value":{"val":"3"}
 
-[shell psql]
-  !insert into items values ('4');
-  ??INSERT
-
 [shell otel_collector]
-  # Verify that new measurement exports from this branch are present
-  # Order matches actual OTEL export order (not alphabetical)
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: electric\.plug\.serve_shape\.count
-  """
+  [sleep 10]
 
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: electric\.plug\.serve_shape\.bytes
-  """
+  [invoke dump_sorted_otel_collector_output]
 
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: electric\.storage\.snapshot_stored\.operations
-  """
+  # Patterns below must be ordered alphabetically, so all metrics are matched first, followed by spans.
 
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: electric\.storage\.transaction_stored\.bytes
-  """
+  # Verify export of resource attributes
+  ?Metric electric\.connection\.consumers_ready\.total custom\.attr=electric\.val instance\.id=[-a-f0-9]+ \
+     name=metrics service\.name=electric service\.version=[0-9.]+ stack_id=single_stack
 
-  """?
-  Metric #[0-9]+
-  Descriptor:
-       -> Name: electric\.storage\.transaction_stored\.operations
-  """
+  ??Metric electric.plug.serve_shape.bytes
+  ??Metric electric.plug.serve_shape.count
+
+  ?Metric electric\.postgres\.replication\.pg_wal_offset .*stack_id=single_stack
+  ?Metric electric\.postgres\.replication\.slot_confirmed_flush_lsn_lag .*stack_id=single_stack
+  ?Metric electric\.postgres\.replication\.slot_retained_wal_size .*stack_id=single_stack
+
+  ??Metric electric.storage.snapshot_stored.operations
+  ??Metric electric.storage.transaction_stored.bytes
+  ??Metric electric.storage.transaction_stored.operations
+
+  # Export of process memory metrics by application telemetry
+  ?Metric process\.bin_memory\.avg_bin_count .*process_type=A_memory_hog.*Value=[.0-9]+
+  ?Metric process\.bin_memory\.avg_ref_count .*process_type=A_memory_hog.*Value=[.0-9]+
+  ?Metric process\.bin_memory\.max_bin_count .*process_type=A_memory_hog.*Value=[0-9]+
+  ?Metric process\.bin_memory\.max_ref_count .*process_type=A_memory_hog.*Value=[0-9]+
+  ?Metric process\.bin_memory\.total .*process_type=A_memory_hog.*Value=[0-9]+
+  ?Metric process\.memory\.total .*process_type=A_memory_hog.*Value=[0-9]+
+
+  # The initial snapshot query span is exported from the Snapshotter path.
+  ?Span shape_snapshot\.execute_for_shape .*shape\.query_reason=initial_snapshot
+
+  # A direct subset snapshot query span is exported from the PartialModes path.
+  ?Span shape_snapshot\.execute_for_shape .*shape\.query_reason=subset_query
 
 ###
 

--- a/integration-tests/tests/otel-export.lux
+++ b/integration-tests/tests/otel-export.lux
@@ -71,16 +71,16 @@
   ?Metric electric\.connection\.consumers_ready\.total custom\.attr=electric\.val instance\.id=[-a-f0-9]+ \
      name=metrics service\.name=electric service\.version=[0-9.]+ stack_id=single_stack
 
-  ??Metric electric.plug.serve_shape.bytes
-  ??Metric electric.plug.serve_shape.count
+  ?Metric electric\.plug\.serve_shape\.bytes .*stack_id=single_stack
+  ?Metric electric\.plug\.serve_shape\.count .*stack_id=single_stack
 
   ?Metric electric\.postgres\.replication\.pg_wal_offset .*stack_id=single_stack
   ?Metric electric\.postgres\.replication\.slot_confirmed_flush_lsn_lag .*stack_id=single_stack
   ?Metric electric\.postgres\.replication\.slot_retained_wal_size .*stack_id=single_stack
 
-  ??Metric electric.storage.snapshot_stored.operations
-  ??Metric electric.storage.transaction_stored.bytes
-  ??Metric electric.storage.transaction_stored.operations
+  ?Metric electric\.storage\.snapshot_stored\.operations .*stack_id=single_stack
+  ?Metric electric\.storage\.transaction_stored\.bytes .*stack_id=single_stack
+  ?Metric electric\.storage\.transaction_stored\.operations .*stack_id=single_stack
 
   # Export of process memory metrics by application telemetry
   ?Metric process\.bin_memory\.avg_bin_count .*process_type=A_memory_hog.*Value=[.0-9]+


### PR DESCRIPTION
## Summary

Reworks the `otel-export.lux` integration test so its assertions no longer depend on the raw, ordering-sensitive output of the OtelCollector debug exporter.

- Adds `integration-tests/support_files/normalize-otel-output.py`, which collapses the verbose collector log into a compact, stable one-line-per-metric/span representation.
- Adds a `grep_otel_collector_output` macro in `_macros.luxinc` so each expected metric/span is asserted independently against the normalized output.
- Rewrites `otel-export.lux` to verify resource attributes for both application and stack metrics on collector startup, then assert each expected metric and span via the new macro — removing the previous coupling to alphabetical ordering of patterns.

## Test plan

- [x] `otel-export.lux` integration test passes locally
- [x] CI green