### PR TITLE
CI: run oracle property tests

### DIFF
--- a/.github/workflows/sync_service_tests.yml
+++ b/.github/workflows/sync_service_tests.yml
@@ -116,3 +116,98 @@ jobs:
           fail_ci_if_error: true
           flags: elixir,unit-tests,sync-service,postgres-${{ env.POSTGRES_VERSION }}
           files: ./junit/regular-test-junit-report.xml,./junit/telemetry-test-junit-report.xml
+
+  oracle_property_test:
+    name: 'Oracle property test, pg17'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    defaults:
+      run:
+        working-directory: packages/sync-service
+    env:
+      MIX_ENV: test
+      MIX_TARGET: application
+      POSTGRES_VERSION: '170000'
+      CHECK_TIMEOUT: 60000
+      SHAPE_COUNT: 200
+      MUTATIONS_PER_TXN: 10
+      TXNS_PER_BATCH: 10
+      BATCH_COUNT: 50
+      SKIP_REPATCH_PREWARM: 'true'
+    services:
+      postgres:
+        image: 'ghcr.io/${{ github.repository }}/postgres:17-alpine-logical'
+        env:
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 54321:5432
+
+      pgbouncer:
+        image: bitnamilegacy/pgbouncer:latest
+        env:
+          PGBOUNCER_AUTH_TYPE: trust
+          PGBOUNCER_DATABASE: '*'
+          PGBOUNCER_POOL_MODE: transaction
+          POSTGRESQL_HOST: postgres
+          POSTGRESQL_DATABASE: electric
+          POSTGRESQL_USERNAME: postgres
+          POSTGRESQL_PASSWORD: password
+        ports:
+          - 65432:6432
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Seed the database
+        run: psql -d postgresql://postgres:password@localhost:54321/postgres?sslmode=disable -f dev/init.sql
+
+      - uses: erlef/setup-beam@v1
+        with:
+          version-type: strict
+          version-file: '.tool-versions'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: packages/sync-service/deps
+          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}
+            ${{ runner.os }}-sync-service-deps
+
+      - name: Cache compiled code
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/sync-service/_build/*/lib
+            !packages/sync-service/_build/*/lib/electric
+            !packages/sync-service/_build/*/lib/electric_telemetry
+          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}
+            ${{ runner.os }}-sync-service-build
+
+      - name: Install dependencies
+        run: mix do deps.get + deps.compile
+
+      - name: Compile package
+        run: mix compile
+
+      - name: Run oracle property test
+        run: mix test --only oracle test/integration/oracle_property_test.exs
+
+      - name: Upload test results to CodeCov
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
+        if: ${{ !cancelled() }}
+        env:
+          DUMMY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}-dummy
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          flags: elixir,oracle-tests,sync-service,postgres-${{ env.POSTGRES_VERSION }}
+          files: ./junit/regular-test-junit-report.xml


### PR DESCRIPTION
## Summary
- add a dedicated `oracle_property_test` job to the sync-service workflow
- keep it independent from the existing matrix job so it runs in parallel

You can see that they've run [here](https://github.com/electric-sql/electric/actions/runs/25119178438/job/73614761171?pr=4238)