### PR TITLE
CI: run where clause filter performance tests

### DIFF
--- a/.github/workflows/sync_service_tests.yml
+++ b/.github/workflows/sync_service_tests.yml
@@ -36,7 +36,7 @@ jobs:
         image: 'ghcr.io/${{ github.repository }}/postgres:${{ matrix.postgres_version }}-alpine-logical'
         env:
           POSTGRES_PASSWORD: password
-        options: >-
+        options: &postgres_health_check >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
@@ -44,7 +44,7 @@ jobs:
         ports:
           - 54321:5432
 
-      pgbouncer:
+      pgbouncer: &pgbouncer_service
         image: bitnamilegacy/pgbouncer:latest
         env:
           PGBOUNCER_AUTH_TYPE: trust
@@ -57,17 +57,21 @@ jobs:
         ports:
           - 65432:6432
     steps:
-      - uses: actions/checkout@v4
+      - &checkout_source
+        uses: actions/checkout@v4
 
-      - name: Seed the database
+      - &seed_database
+        name: Seed the database
         run: psql -d postgresql://postgres:password@localhost:54321/postgres?sslmode=disable -f dev/init.sql
 
-      - uses: erlef/setup-beam@v1
+      - &setup_beam
+        uses: erlef/setup-beam@v1
         with:
           version-type: strict
           version-file: '.tool-versions'
 
-      - name: Cache dependencies
+      - &cache_dependencies
+        name: Cache dependencies
         uses: actions/cache@v4
         with:
           path: packages/sync-service/deps
@@ -77,7 +81,8 @@ jobs:
             ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}
             ${{ runner.os }}-sync-service-deps
 
-      - name: Cache compiled code
+      - &cache_compiled_code
+        name: Cache compiled code
         uses: actions/cache@v4
         with:
           path: |
@@ -90,10 +95,12 @@ jobs:
             ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}
             ${{ runner.os }}-sync-service-build
 
-      - name: Install dependencies
+      - &install_dependencies
+        name: Install dependencies
         run: mix do deps.get + deps.compile
 
-      - name: Compile package
+      - &compile_package
+        name: Compile package
         run: mix compile
 
       - name: Run tests
@@ -138,65 +145,19 @@ jobs:
         image: 'ghcr.io/${{ github.repository }}/postgres:17-alpine-logical'
         env:
           POSTGRES_PASSWORD: password
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+        options: *postgres_health_check
         ports:
           - 54321:5432
 
-      pgbouncer:
-        image: bitnamilegacy/pgbouncer:latest
-        env:
-          PGBOUNCER_AUTH_TYPE: trust
-          PGBOUNCER_DATABASE: '*'
-          PGBOUNCER_POOL_MODE: transaction
-          POSTGRESQL_HOST: postgres
-          POSTGRESQL_DATABASE: electric
-          POSTGRESQL_USERNAME: postgres
-          POSTGRESQL_PASSWORD: password
-        ports:
-          - 65432:6432
+      pgbouncer: *pgbouncer_service
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Seed the database
-        run: psql -d postgresql://postgres:password@localhost:54321/postgres?sslmode=disable -f dev/init.sql
-
-      - uses: erlef/setup-beam@v1
-        with:
-          version-type: strict
-          version-file: '.tool-versions'
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: packages/sync-service/deps
-          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
-          restore-keys: |
-            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
-            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}
-            ${{ runner.os }}-sync-service-deps
-
-      - name: Cache compiled code
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/sync-service/_build/*/lib
-            !packages/sync-service/_build/*/lib/electric
-            !packages/sync-service/_build/*/lib/electric_telemetry
-          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
-          restore-keys: |
-            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
-            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}
-            ${{ runner.os }}-sync-service-build
-
-      - name: Install dependencies
-        run: mix do deps.get + deps.compile
-
-      - name: Compile package
-        run: mix compile
+      - *checkout_source
+      - *seed_database
+      - *setup_beam
+      - *cache_dependencies
+      - *cache_compiled_code
+      - *install_dependencies
+      - *compile_package
 
       - name: Run oracle property test
         run: mix test --only oracle test/integration/oracle_property_test.exs
@@ -227,65 +188,19 @@ jobs:
         image: 'ghcr.io/${{ github.repository }}/postgres:17-alpine-logical'
         env:
           POSTGRES_PASSWORD: password
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+        options: *postgres_health_check
         ports:
           - 54321:5432
 
-      pgbouncer:
-        image: bitnamilegacy/pgbouncer:latest
-        env:
-          PGBOUNCER_AUTH_TYPE: trust
-          PGBOUNCER_DATABASE: '*'
-          PGBOUNCER_POOL_MODE: transaction
-          POSTGRESQL_HOST: postgres
-          POSTGRESQL_DATABASE: electric
-          POSTGRESQL_USERNAME: postgres
-          POSTGRESQL_PASSWORD: password
-        ports:
-          - 65432:6432
+      pgbouncer: *pgbouncer_service
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Seed the database
-        run: psql -d postgresql://postgres:password@localhost:54321/postgres?sslmode=disable -f dev/init.sql
-
-      - uses: erlef/setup-beam@v1
-        with:
-          version-type: strict
-          version-file: '.tool-versions'
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: packages/sync-service/deps
-          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
-          restore-keys: |
-            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
-            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}
-            ${{ runner.os }}-sync-service-deps
-
-      - name: Cache compiled code
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/sync-service/_build/*/lib
-            !packages/sync-service/_build/*/lib/electric
-            !packages/sync-service/_build/*/lib/electric_telemetry
-          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
-          restore-keys: |
-            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
-            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}
-            ${{ runner.os }}-sync-service-build
-
-      - name: Install dependencies
-        run: mix do deps.get + deps.compile
-
-      - name: Compile package
-        run: mix compile
+      - *checkout_source
+      - *seed_database
+      - *setup_beam
+      - *cache_dependencies
+      - *cache_compiled_code
+      - *install_dependencies
+      - *compile_package
 
       - name: Run performance test
         run: SKIP_REPATCH_PREWARM=true mix test --only performance

--- a/.github/workflows/sync_service_tests.yml
+++ b/.github/workflows/sync_service_tests.yml
@@ -31,6 +31,8 @@ jobs:
       MIX_ENV: test
       MIX_TARGET: application
       POSTGRES_VERSION: '${{ matrix.postgres_version }}0000'
+      CODECOV_FLAGS: elixir,unit-tests,sync-service,postgres-${{ matrix.postgres_version }}0000
+      CODECOV_TEST_RESULTS_FILES: ./junit/regular-test-junit-report.xml,./junit/telemetry-test-junit-report.xml
     services:
       postgres:
         image: 'ghcr.io/${{ github.repository }}/postgres:${{ matrix.postgres_version }}-alpine-logical'
@@ -110,10 +112,11 @@ jobs:
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: elixir,unit-tests,sync-service,postgres-${{ env.POSTGRES_VERSION }}
+          flags: ${{ env.CODECOV_FLAGS }}
           files: ./cover/excoveralls.json
 
-      - name: Upload test results to CodeCov
+      - &upload_test_results_to_codecov
+        name: Upload test results to CodeCov
         uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
         if: ${{ !cancelled() }}
         env:
@@ -121,8 +124,8 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          flags: elixir,unit-tests,sync-service,postgres-${{ env.POSTGRES_VERSION }}
-          files: ./junit/regular-test-junit-report.xml,./junit/telemetry-test-junit-report.xml
+          flags: ${{ env.CODECOV_FLAGS }}
+          files: ${{ env.CODECOV_TEST_RESULTS_FILES }}
 
   oracle_property_test:
     name: 'Oracle property test, pg17'
@@ -134,6 +137,8 @@ jobs:
       MIX_ENV: test
       MIX_TARGET: application
       POSTGRES_VERSION: '170000'
+      CODECOV_FLAGS: elixir,oracle-tests,sync-service,postgres-170000
+      CODECOV_TEST_RESULTS_FILES: ./junit/regular-test-junit-report.xml
       CHECK_TIMEOUT: 60000
       SHAPE_COUNT: 200
       MUTATIONS_PER_TXN: 10
@@ -162,16 +167,7 @@ jobs:
       - name: Run oracle property test
         run: mix test --only oracle test/integration/oracle_property_test.exs
 
-      - name: Upload test results to CodeCov
-        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
-        if: ${{ !cancelled() }}
-        env:
-          DUMMY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}-dummy
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          flags: elixir,oracle-tests,sync-service,postgres-${{ env.POSTGRES_VERSION }}
-          files: ./junit/regular-test-junit-report.xml
+      - *upload_test_results_to_codecov
 
   performance_test:
     name: 'Performance test, pg17'
@@ -183,6 +179,8 @@ jobs:
       MIX_ENV: test
       MIX_TARGET: application
       POSTGRES_VERSION: '170000'
+      CODECOV_FLAGS: elixir,performance-tests,sync-service,postgres-170000
+      CODECOV_TEST_RESULTS_FILES: ./junit/regular-test-junit-report.xml
     services:
       postgres:
         image: 'ghcr.io/${{ github.repository }}/postgres:17-alpine-logical'
@@ -205,13 +203,4 @@ jobs:
       - name: Run performance test
         run: SKIP_REPATCH_PREWARM=true mix test --only performance
 
-      - name: Upload test results to CodeCov
-        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
-        if: ${{ !cancelled() }}
-        env:
-          DUMMY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}-dummy
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          flags: elixir,performance-tests,sync-service,postgres-${{ env.POSTGRES_VERSION }}
-          files: ./junit/regular-test-junit-report.xml
+      - *upload_test_results_to_codecov

--- a/.github/workflows/sync_service_tests.yml
+++ b/.github/workflows/sync_service_tests.yml
@@ -211,3 +211,92 @@ jobs:
           fail_ci_if_error: true
           flags: elixir,oracle-tests,sync-service,postgres-${{ env.POSTGRES_VERSION }}
           files: ./junit/regular-test-junit-report.xml
+
+  performance_test:
+    name: 'Performance test, pg17'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    defaults:
+      run:
+        working-directory: packages/sync-service
+    env:
+      MIX_ENV: test
+      MIX_TARGET: application
+      POSTGRES_VERSION: '170000'
+    services:
+      postgres:
+        image: 'ghcr.io/${{ github.repository }}/postgres:17-alpine-logical'
+        env:
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 54321:5432
+
+      pgbouncer:
+        image: bitnamilegacy/pgbouncer:latest
+        env:
+          PGBOUNCER_AUTH_TYPE: trust
+          PGBOUNCER_DATABASE: '*'
+          PGBOUNCER_POOL_MODE: transaction
+          POSTGRESQL_HOST: postgres
+          POSTGRESQL_DATABASE: electric
+          POSTGRESQL_USERNAME: postgres
+          POSTGRESQL_PASSWORD: password
+        ports:
+          - 65432:6432
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Seed the database
+        run: psql -d postgresql://postgres:password@localhost:54321/postgres?sslmode=disable -f dev/init.sql
+
+      - uses: erlef/setup-beam@v1
+        with:
+          version-type: strict
+          version-file: '.tool-versions'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: packages/sync-service/deps
+          key: "${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-deps-${{ env.MIX_ENV }}
+            ${{ runner.os }}-sync-service-deps
+
+      - name: Cache compiled code
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/sync-service/_build/*/lib
+            !packages/sync-service/_build/*/lib/electric
+            !packages/sync-service/_build/*/lib/electric_telemetry
+          key: "${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}-${{ hashFiles('packages/sync-service/mix.lock') }}
+            ${{ runner.os }}-sync-service-build-${{ env.MIX_ENV }}
+            ${{ runner.os }}-sync-service-build
+
+      - name: Install dependencies
+        run: mix do deps.get + deps.compile
+
+      - name: Compile package
+        run: mix compile
+
+      - name: Run performance test
+        run: SKIP_REPATCH_PREWARM=true mix test --only performance
+
+      - name: Upload test results to CodeCov
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
+        if: ${{ !cancelled() }}
+        env:
+          DUMMY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}-dummy
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          flags: elixir,performance-tests,sync-service,postgres-${{ env.POSTGRES_VERSION }}
+          files: ./junit/regular-test-junit-report.xml


### PR DESCRIPTION
## Summary
- add a dedicated `performance_test` job to the sync-service workflow
- run `mix test --only performance` in parallel with the existing jobs
- set `SKIP_REPATCH_PREWARM=true` as Repatch was making the tests flakey.

I've run them 5 times on CI and pass every time now that Repatch is out of the way: https://github.com/electric-sql/electric/actions/runs/25120421568/job/73619279602?pr=4240