### PR TITLE
fix(website): track electric.ax in Plausible

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -655,7 +655,7 @@ export default defineConfig({
       'script',
       {
         defer: 'defer',
-        'data-domain': 'electric-sql.com',
+        'data-domain': 'electric-sql.com,electric.ax',
         src: 'https://plausible.io/js/script.js',
       },
     ],


### PR DESCRIPTION
## Summary
- Add `electric.ax` to the Plausible `data-domain` list so analytics continue when the website moves domains.

## Test plan
- Checked IDE diagnostics for `website/.vitepress/config.mts`.


Made with [Cursor](https://cursor.com)