### PR TITLE
[codex] Fix Horton quickstart webhook binding

### DIFF
--- a/.changeset/tidy-horton-webhooks.md
+++ b/.changeset/tidy-horton-webhooks.md
@@ -1,0 +1,5 @@
+---
+"electric-ax": patch
+---
+
+Bind the local built-in agents server to all interfaces by default so Docker-backed quickstart coordinators can reach Horton webhooks via host.docker.internal.

--- a/packages/electric-ax/src/start.ts
+++ b/packages/electric-ax/src/start.ts
@@ -16,6 +16,7 @@ export { readDotEnvFile, resolveAnthropicApiKey } from './env.js'
 
 const DEFAULT_ELECTRIC_AGENTS_PORT = 4437
 const DEFAULT_BUILTIN_AGENTS_PORT = 4448
+const DEFAULT_BUILTIN_AGENTS_HOST = `0.0.0.0`
 const DEFAULT_COMPOSE_PROJECT_NAME = `electric-agents`
 const DOCKER_COMPOSE_FILE = fileURLToPath(
   new URL(`../docker-compose.full.yml`, import.meta.url)
@@ -57,6 +58,17 @@ export function resolveBuiltinAgentsPort(
     throw new Error(`ELECTRIC_AGENTS_BUILTIN_PORT must be a positive integer`)
   }
   return parsed
+}
+
+export function resolveBuiltinAgentsHost(
+  env: NodeJS.ProcessEnv = process.env,
+  fileEnv: Record<string, string> = readDotEnvFile()
+): string {
+  return (
+    env.ELECTRIC_AGENTS_BUILTIN_HOST?.trim() ||
+    fileEnv.ELECTRIC_AGENTS_BUILTIN_HOST?.trim() ||
+    DEFAULT_BUILTIN_AGENTS_HOST
+  )
 }
 
 export function resolveElectricAgentsPort(
@@ -288,6 +300,7 @@ export async function startBuiltinAgentsServer(
   const cwd = params.cwd ?? process.cwd()
   const fileEnv = readDotEnvFile(cwd)
   const anthropicApiKey = resolveAnthropicApiKey(options, env, fileEnv)
+  const host = resolveBuiltinAgentsHost(env, fileEnv)
   const port = resolveBuiltinAgentsPort(env, fileEnv)
   const agentServerUrl =
     params.agentServerUrl ??
@@ -299,6 +312,7 @@ export async function startBuiltinAgentsServer(
 
   const server = new BuiltinAgentsServer({
     agentServerUrl,
+    host,
     port,
     workingDirectory: cwd,
   })

--- a/packages/electric-ax/test/start.test.ts
+++ b/packages/electric-ax/test/start.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   readDotEnvFile,
   resolveAnthropicApiKey,
+  resolveBuiltinAgentsHost,
   resolveBuiltinAgentsPort,
   resolveComposeProjectName,
   resolveElectricAgentsPort,
@@ -79,6 +80,30 @@ describe(`resolveBuiltinAgentsPort`, () => {
 
   it(`defaults to 4448`, () => {
     expect(resolveBuiltinAgentsPort({}, {})).toBe(4448)
+  })
+})
+
+describe(`resolveBuiltinAgentsHost`, () => {
+  it(`uses process env when present`, () => {
+    expect(
+      resolveBuiltinAgentsHost(
+        { ELECTRIC_AGENTS_BUILTIN_HOST: `127.0.0.1` },
+        {}
+      )
+    ).toBe(`127.0.0.1`)
+  })
+
+  it(`falls back to .env`, () => {
+    expect(
+      resolveBuiltinAgentsHost(
+        {},
+        { ELECTRIC_AGENTS_BUILTIN_HOST: `localhost` }
+      )
+    ).toBe(`localhost`)
+  })
+
+  it(`defaults to all interfaces so Docker can reach the host runtime`, () => {
+    expect(resolveBuiltinAgentsHost({}, {})).toBe(`0.0.0.0`)
   })
 })
 


### PR DESCRIPTION
## Summary

- Bind the local built-in agents server to `0.0.0.0` by default in `electric-ax`.
- Add `ELECTRIC_AGENTS_BUILTIN_HOST` env/`.env` resolution so users can override the bind host when needed.
- Add focused tests and a changeset for the patch release.

## Root Cause

`electric-ax agents quickstart` starts the coordinator in Docker and the built-in Horton runtime on the host. The coordinator rewrites loopback webhooks to `host.docker.internal`, but the host-side built-in server was still listening only on `127.0.0.1`. On native Linux Docker networking, container calls to `host.docker.internal:4448` target the host bridge address, not host loopback, so Horton wakes failed with `ECONNREFUSED` and sent messages never produced replies.

Binding the built-in server to all interfaces keeps the registered local URL as `127.0.0.1` while allowing the Docker coordinator to reach the host runtime through `host.docker.internal`.

## Validation

- `pnpm --filter electric-ax exec vitest run test/start.test.ts`
- `pnpm --filter electric-ax typecheck`
- `pnpm exec prettier --check packages/electric-ax/src/start.ts packages/electric-ax/test/start.test.ts .changeset/tidy-horton-webhooks.md`
- Manual Docker topology verification:
  - Started the coordinator from `packages/electric-ax/docker-compose.full.yml` on default port `4437`.
  - Started the patched built-in server on `4448`; it resolved `host` to `0.0.0.0` while reporting `http://127.0.0.1:4448` as its local URL.
  - Confirmed the coordinator registered Horton as `http://host.docker.internal:4448/_electric/builtin-agent-handler`.
  - Confirmed `docker exec electric-agents-electric-agents-1 node -e "fetch('http://host.docker.internal:4448/_electric/health')..."` returned `200`.
  - Spawned `/horton/verify-patched`, sent a message, and confirmed the entity stream received Horton `text_delta` output.
