### PR TITLE
fix(electric-ax): suppress stale error before first API key prompt

### DIFF
--- a/.changeset/quiet-pumas-jump.md
+++ b/.changeset/quiet-pumas-jump.md
@@ -1,0 +1,5 @@
+---
+'electric-ax': patch
+---
+
+fix: don't show a stale error before the first API key prompt when no key is configured

--- a/packages/electric-ax/src/prompt-api-key.ts
+++ b/packages/electric-ax/src/prompt-api-key.ts
@@ -117,16 +117,28 @@ export async function ensureAnthropicApiKey(
     return explicitKey
   }
 
+  let resolvedKey: string | undefined
   try {
-    const key = resolveAnthropicApiKey(options)
-    assertAnthropicApiKeyPrefix(key)
-    await validate(key)
-    return key
+    resolvedKey = resolveAnthropicApiKey(options)
   } catch (error) {
     if (!io.isTTY) {
       throw error
     }
-    initialError = error
+    // No key configured and we're interactive — fall through to the prompt
+    // without a redundant error message; FRIENDLY_INTRO covers this case.
+  }
+
+  if (resolvedKey !== undefined) {
+    try {
+      assertAnthropicApiKeyPrefix(resolvedKey)
+      await validate(resolvedKey)
+      return resolvedKey
+    } catch (error) {
+      if (!io.isTTY) {
+        throw error
+      }
+      initialError = error
+    }
   }
 
   io.output.write(FRIENDLY_INTRO)

--- a/packages/electric-ax/test/prompt-api-key.test.ts
+++ b/packages/electric-ax/test/prompt-api-key.test.ts
@@ -160,6 +160,20 @@ describe(`ensureAnthropicApiKey`, () => {
     expect(existsSync(join(fake.cwd, `.env`))).toBe(false)
   })
 
+  it(`prompts without showing an error when no key is configured`, async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    const fake = createFakeIO({ inputLines: [``] })
+    cleanups.push(fake.cleanup)
+
+    await expect(ensureAnthropicApiKey({}, fake.io)).rejects.toThrow(
+      `__exit__:0`
+    )
+
+    expect(fake.output()).toContain(`Provide an Anthropic Claude key`)
+    expect(fake.output()).not.toContain(`Could not use that Anthropic key`)
+    expect(fake.output()).not.toContain(`ANTHROPIC_API_KEY is required`)
+  })
+
   it(`writes a directly pasted key to a new .env`, async () => {
     delete process.env.ANTHROPIC_API_KEY
     const fake = createFakeIO({ inputLines: [`sk-ant-pasted`] })


### PR DESCRIPTION
## Summary

When `electric-ax agents quickstart` (or any electric-ax CLI that calls `ensureAnthropicApiKey`) is run with no Anthropic key configured, the interactive prompt rendered the friendly intro followed by a confusing line:

> Could not use that Anthropic key: ANTHROPIC_API_KEY is required. Pass --anthropic-api-key, export it in your shell, or set it in .env.

…even though the user had not pasted any key yet. The "is required / pass / export / set in .env" advice was also redundant — the prompt itself is the path to provide one.

The fix splits the resolution from the validation in `ensureAnthropicApiKey`. Only validation failures populate `initialError` now; a missing key in a TTY context falls through to the prompt cleanly. Non-TTY behavior is unchanged — the helpful "ANTHROPIC_API_KEY is required" error still throws.

## Test plan

- [x] new regression test `prompts without showing an error when no key is configured`
- [x] `pnpm vitest run` in `packages/electric-ax` — all 75 tests pass
- [x] `tsc --noEmit` clean
- [ ] manual: run `npx electric-ax agents quickstart` in a tmp dir with `ANTHROPIC_API_KEY` unset and confirm the prompt appears without the "Could not use that Anthropic key" line