### PR TITLE
fix(website): align title template and bluesky links with electric.ax rebrand

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -796,7 +796,7 @@ export default defineConfig({
     }
 
     const pageTitle = fm.title || siteData.title
-    const titleTemplate = fm.titleTemplate || ':title | ElectricSQL'
+    const titleTemplate = fm.titleTemplate || ':title | Electric'
     const title = titleTemplate.replace(':title', pageTitle)
     const description = fm.description || siteData.description
 

--- a/website/src/components/SiteFooter.vue
+++ b/website/src/components/SiteFooter.vue
@@ -45,7 +45,7 @@ import MarkdownLink from './MarkdownLink.vue'
           <span class="social-name">X</span>
         </a>
         <a
-          href="https://bsky.app/profile/electric-sql.com"
+          href="https://bsky.app/profile/electric.ax"
           aria-label="Bluesky"
         >
           <span class="vpi-social-bluesky"></span>

--- a/website/src/components/SiteFooter.vue
+++ b/website/src/components/SiteFooter.vue
@@ -44,10 +44,7 @@ import MarkdownLink from './MarkdownLink.vue'
           <span class="vpi-social-x"></span>
           <span class="social-name">X</span>
         </a>
-        <a
-          href="https://bsky.app/profile/electric.ax"
-          aria-label="Bluesky"
-        >
+        <a href="https://bsky.app/profile/electric.ax" aria-label="Bluesky">
           <span class="vpi-social-bluesky"></span>
           <span class="social-name">Bluesky</span>
         </a>

--- a/website/src/components/SocialLinks.vue
+++ b/website/src/components/SocialLinks.vue
@@ -9,8 +9,8 @@
 const links = [
   {
     icon: 'bluesky',
-    label: '@electric-sql.com',
-    href: 'https://bsky.app/profile/electric-sql.com',
+    label: '@electric.ax',
+    href: 'https://bsky.app/profile/electric.ax',
   },
   {
     icon: 'bluesky',


### PR DESCRIPTION
## Summary

Three small cleanups that align the website with the electric.ax rebrand started in #4246:

- Default page title template: `:title | ElectricSQL` → `:title | Electric`
- `SiteFooter.vue` bluesky link → `https://bsky.app/profile/electric.ax`
- `SocialLinks.vue` bluesky label and href → `@electric.ax` / `https://bsky.app/profile/electric.ax`

## Test plan

- [ ] `pnpm dev` in `website/`, verify the bluesky icon in the footer and on the social-links component links to the new profile
- [ ] view-source on a non-overridden page and confirm `<title>… | Electric</title>`