### PR TITLE
Allow readonly array for `Value` type

### DIFF
--- a/packages/typescript-client/src/types.ts
+++ b/packages/typescript-client/src/types.ts
@@ -10,6 +10,7 @@ export type Value<Extensions = never> =
   | null
   | Extensions
   | Value<Extensions>[]
+  | readonly Value<Extensions>[]
   | { [key: string]: Value<Extensions> }
 
 export type Row<Extensions = never> = Record<string, Value<Extensions>>


### PR DESCRIPTION
We infer OpenAPI types from our shapes defined on the backend, and these define arrays as `readonly`, which is desirable to prevent mutation of the data synced from Electric. With this change, we allow both mutable and immutable arrays.

<img width="471" height="37" alt="image" src="https://github.com/user-attachments/assets/b5ef0699-f503-4882-9bf9-49072f8a85c3" />
