### PR TITLE
Export defaultParser

### DIFF
--- a/packages/typescript-client/src/index.ts
+++ b/packages/typescript-client/src/index.ts
@@ -17,3 +17,4 @@ export {
   camelToSnake,
 } from './column-mapper'
 export { compileExpression, compileOrderBy } from './expression-compiler'
+export { defaultParser } from './parser'


### PR DESCRIPTION
Our use-case for this is to allow a local tanstack/db collection to achieve same `parser` behaviour as we get by default from an electric collection. This allows us to test our `useLiveQuery` hooks with a stubbed electric collection, created as local collection from JSON snapshots. 

Others may find it useful to extend the parser with behaviour falling back to the default.