### PR TITLE
Link to rqlite home page

### DIFF
--- a/website/docs/sync/reference/alternatives.md
+++ b/website/docs/sync/reference/alternatives.md
@@ -140,7 +140,7 @@ Other interesting projects include:
 - [Macrometa](https://www.macrometa.com)
 - [MotherDuck](https://motherduck.com)
 - [RainbowFS](https://rainbowfs.lip6.fr)
-- [rqlite](https://github.com/rqlite/rqlite)
+- [rqlite](https://rqlite.io)
 - [SOLID](https://solidproject.org)
 - [Source](https://source.network)
 - [Spanner](https://cloud.google.com/spanner/)


### PR DESCRIPTION
It seems most links link to a project's home page, not the associated GitHub repo. Do the same thing for rqlite.

Disclaimer: I am the creator of rqlite.