### PR TITLE
feat(agents): add openai-codex provider via ~/.codex/auth.json

### DIFF
--- a/.changeset/add-openai-codex-provider.md
+++ b/.changeset/add-openai-codex-provider.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': patch
+---
+
+Add `openai-codex` as a built-in model provider. When the user has logged into OpenAI Codex CLI (`~/.codex/auth.json` exists), GPT-5.x models automatically appear in the dashboard model dropdown with reasoning effort support.

--- a/docs/superpowers/plans/2026-05-04-openai-codex-provider.md
+++ b/docs/superpowers/plans/2026-05-04-openai-codex-provider.md
@@ -1,0 +1,401 @@
+# OpenAI Codex Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Codex models (GPT-5.1–5.5) available in the built-in agents model dropdown when the user has a valid `~/.codex/auth.json`.
+
+**Architecture:** Extend the existing `BuiltinModelProvider` union and `configuredProviders()` in `model-catalog.ts` to detect Codex credentials. Deliver the access token via the existing `getApiKey` callback that pi-ai's runtime already supports.
+
+**Tech Stack:** TypeScript, pi-ai (already a dependency — has `openai-codex` models and `KnownProvider`), Node.js fs/os for reading the auth file.
+
+---
+
+## File Structure
+
+| File                                   | Action | Responsibility                                                               |
+| -------------------------------------- | ------ | ---------------------------------------------------------------------------- |
+| `packages/agents/src/model-catalog.ts` | Modify | Add `openai-codex` provider detection, model listing, and `getApiKey` wiring |
+
+That's it — single file change.
+
+---
+
+### Task 1: Add Codex Auth Detection
+
+**Files:**
+
+- Modify: `packages/agents/src/model-catalog.ts:1-61`
+
+- [ ] **Step 1: Add imports and type**
+
+Add `node:fs` and `node:os` imports, extend the `BuiltinModelProvider` type:
+
+```ts
+// At top of file, after existing imports:
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+```
+
+Change line 4 from:
+
+```ts
+export type BuiltinModelProvider = `anthropic` | `openai`
+```
+
+to:
+
+```ts
+export type BuiltinModelProvider = `anthropic` | `openai` | `openai-codex`
+```
+
+- [ ] **Step 2: Add `codexAuthPath()` and `readCodexAccessToken()` helpers**
+
+Add after the `hasEnv` function (after line 46):
+
+```ts
+function codexAuthPath(): string {
+  return join(homedir(), `.codex`, `auth.json`)
+}
+
+function readCodexAccessToken(): string | undefined {
+  try {
+    const raw = readFileSync(codexAuthPath(), `utf-8`)
+    const data = JSON.parse(raw) as {
+      auth_mode?: string
+      tokens?: { access_token?: string }
+    }
+    if (data.auth_mode !== `chatgpt`) return undefined
+    const token = data.tokens?.access_token?.trim()
+    return token && token.length > 0 ? token : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function hasCodexAuth(): boolean {
+  if (!existsSync(codexAuthPath())) return false
+  return readCodexAccessToken() !== undefined
+}
+```
+
+- [ ] **Step 3: Update `configuredProviders()`**
+
+Change from:
+
+```ts
+function configuredProviders(): Array<BuiltinModelProvider> {
+  const providers: Array<BuiltinModelProvider> = []
+  if (hasEnv(`ANTHROPIC_API_KEY`)) providers.push(`anthropic`)
+  if (hasEnv(`OPENAI_API_KEY`)) providers.push(`openai`)
+  return providers
+}
+```
+
+to:
+
+```ts
+function configuredProviders(): Array<BuiltinModelProvider> {
+  const providers: Array<BuiltinModelProvider> = []
+  if (hasEnv(`ANTHROPIC_API_KEY`)) providers.push(`anthropic`)
+  if (hasEnv(`OPENAI_API_KEY`)) providers.push(`openai`)
+  if (hasCodexAuth()) providers.push(`openai-codex`)
+  return providers
+}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `cd packages/agents && npx tsc --noEmit 2>&1 | head -20`
+Expected: Type errors about `providerLabel` or `fetchAvailableModelIds` not handling `openai-codex` — that's fine, we fix those in Task 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agents/src/model-catalog.ts
+git commit -m "feat(agents): detect openai-codex credentials from ~/.codex/auth.json"
+```
+
+---
+
+### Task 2: Model Listing and Provider Label
+
+**Files:**
+
+- Modify: `packages/agents/src/model-catalog.ts:48-127`
+
+- [ ] **Step 1: Update `providerLabel()`**
+
+Change from:
+
+```ts
+function providerLabel(provider: BuiltinModelProvider): string {
+  return provider === `anthropic` ? `Anthropic` : `OpenAI`
+}
+```
+
+to:
+
+```ts
+function providerLabel(provider: BuiltinModelProvider): string {
+  if (provider === `anthropic`) return `Anthropic`
+  if (provider === `openai-codex`) return `OpenAI Codex`
+  return `OpenAI`
+}
+```
+
+- [ ] **Step 2: Update `choicesForProvider()` to skip availability fetch for codex**
+
+Change from:
+
+```ts
+async function choicesForProvider(
+  provider: BuiltinModelProvider
+): Promise<Array<BuiltinModelChoice>> {
+  const knownModels = getModels(provider)
+  const availableIds = await fetchAvailableModelIds(provider)
+  const models =
+    availableIds === null
+      ? knownModels
+      : knownModels.filter((model) => availableIds.has(model.id))
+
+  return models.map((model) => ({
+    provider,
+    id: model.id,
+    label: `${providerLabel(provider)} ${model.name}`,
+    value: modelValue(provider, model.id),
+    reasoning: model.reasoning,
+  }))
+}
+```
+
+to:
+
+```ts
+async function choicesForProvider(
+  provider: BuiltinModelProvider
+): Promise<Array<BuiltinModelChoice>> {
+  const knownModels = getModels(provider)
+
+  if (provider === `openai-codex`) {
+    return knownModels.map((model) => ({
+      provider,
+      id: model.id,
+      label: `${providerLabel(provider)} ${model.name}`,
+      value: modelValue(provider, model.id),
+      reasoning: model.reasoning,
+    }))
+  }
+
+  const availableIds = await fetchAvailableModelIds(provider)
+  const models =
+    availableIds === null
+      ? knownModels
+      : knownModels.filter((model) => availableIds.has(model.id))
+
+  return models.map((model) => ({
+    provider,
+    id: model.id,
+    label: `${providerLabel(provider)} ${model.name}`,
+    value: modelValue(provider, model.id),
+    reasoning: model.reasoning,
+  }))
+}
+```
+
+- [ ] **Step 3: Update default model fallback in `createBuiltinModelCatalog()`**
+
+Change the `defaultChoice` resolution (around line 187) from:
+
+```ts
+const defaultChoice =
+  choices.find(
+    (choice) =>
+      choice.provider === `anthropic` && choice.id === DEFAULT_ANTHROPIC_MODEL
+  ) ??
+  choices.find(
+    (choice) =>
+      choice.provider === `openai` && choice.id === DEFAULT_OPENAI_MODEL
+  ) ??
+  choices[0]!
+```
+
+to:
+
+```ts
+const defaultChoice =
+  choices.find(
+    (choice) =>
+      choice.provider === `anthropic` && choice.id === DEFAULT_ANTHROPIC_MODEL
+  ) ??
+  choices.find(
+    (choice) =>
+      choice.provider === `openai` && choice.id === DEFAULT_OPENAI_MODEL
+  ) ??
+  choices.find(
+    (choice) =>
+      choice.provider === `openai-codex` && choice.id === DEFAULT_CODEX_MODEL
+  ) ??
+  choices[0]!
+```
+
+Also add the constant near the top (after line 42):
+
+```ts
+const DEFAULT_CODEX_MODEL = `gpt-5.4`
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `cd packages/agents && npx tsc --noEmit 2>&1 | head -20`
+Expected: Clean or only errors related to `getApiKey` (Task 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agents/src/model-catalog.ts
+git commit -m "feat(agents): list openai-codex models in catalog from pi-ai"
+```
+
+---
+
+### Task 3: Wire getApiKey for Codex Token Delivery
+
+**Files:**
+
+- Modify: `packages/agents/src/model-catalog.ts:30-35,201-225`
+
+- [ ] **Step 1: Add `getApiKey` to `BuiltinAgentModelConfig` type**
+
+Change from:
+
+```ts
+export type BuiltinAgentModelConfig = Pick<
+  AgentConfig,
+  `model` | `provider` | `onPayload`
+> & {
+  reasoningEffort?: ExplicitReasoningEffort
+}
+```
+
+to:
+
+```ts
+export type BuiltinAgentModelConfig = Pick<
+  AgentConfig,
+  `model` | `provider` | `onPayload` | `getApiKey`
+> & {
+  reasoningEffort?: ExplicitReasoningEffort
+}
+```
+
+- [ ] **Step 2: Update `resolveBuiltinModelConfig()` to attach `getApiKey` for codex**
+
+In the `resolveBuiltinModelConfig` function, change from:
+
+```ts
+const choice = selected ?? catalog.defaultChoice
+const config = {
+  provider: choice.provider,
+  model: choice.id,
+  ...(reasoningEffort && { reasoningEffort }),
+}
+
+return withProviderPayloadDefaults(config, choice, reasoningEffort)
+```
+
+to:
+
+```ts
+const choice = selected ?? catalog.defaultChoice
+const config: PersistedModelConfig & { getApiKey?: AgentConfig[`getApiKey`] } =
+  {
+    provider: choice.provider,
+    model: choice.id,
+    ...(reasoningEffort && { reasoningEffort }),
+    ...(choice.provider === `openai-codex` && {
+      getApiKey: (provider: string) => {
+        if (provider !== `openai-codex`) return undefined
+        return readCodexAccessToken()
+      },
+    }),
+  }
+
+return withProviderPayloadDefaults(config, choice, reasoningEffort)
+```
+
+- [ ] **Step 3: Update `withProviderPayloadDefaults` signature to pass through `getApiKey`**
+
+The `withProviderPayloadDefaults` function takes a `PersistedModelConfig` and returns `BuiltinAgentModelConfig`. Since `BuiltinAgentModelConfig` now includes `getApiKey`, and the input config may have it, update the input type. Change from:
+
+```ts
+function withProviderPayloadDefaults(
+  config: PersistedModelConfig,
+  choice: BuiltinModelChoice,
+  reasoningEffort: ExplicitReasoningEffort | null
+): BuiltinAgentModelConfig {
+  if (choice.provider !== `openai` || !choice.reasoning) return config
+```
+
+to:
+
+```ts
+function withProviderPayloadDefaults(
+  config: PersistedModelConfig & { getApiKey?: AgentConfig[`getApiKey`] },
+  choice: BuiltinModelChoice,
+  reasoningEffort: ExplicitReasoningEffort | null
+): BuiltinAgentModelConfig {
+  if (choice.provider !== `openai` || !choice.reasoning) return config
+```
+
+- [ ] **Step 4: Verify TypeScript compiles clean**
+
+Run: `cd packages/agents && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agents/src/model-catalog.ts
+git commit -m "feat(agents): wire getApiKey for openai-codex token delivery"
+```
+
+---
+
+### Task 4: Verify End-to-End
+
+- [ ] **Step 1: Confirm `~/.codex/auth.json` exists on this machine**
+
+Run: `test -f ~/.codex/auth.json && echo "exists" || echo "missing"`
+Expected: `exists`
+
+- [ ] **Step 2: Build the agents package**
+
+Run: `cd packages/agents && pnpm build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run existing tests to check for regressions**
+
+Run: `cd packages/agents && pnpm test 2>&1 | tail -20`
+Expected: All existing tests pass (no test file changes needed — existing tests mock providers or use env vars).
+
+- [ ] **Step 4: Quick smoke test — verify codex models appear in catalog**
+
+Run a quick inline script:
+
+```bash
+cd packages/agents && node -e "
+import('./src/model-catalog.ts')
+" 2>&1 | head -5
+```
+
+If that doesn't work with TS directly, verify via the build output or by checking `tsc --noEmit` passes. The real integration test is starting the agents server with `~/.codex/auth.json` present and seeing models in the dropdown.
+
+- [ ] **Step 5: Final commit (if any fixups needed)**
+
+```bash
+git add -A packages/agents/src/model-catalog.ts
+git commit -m "fix(agents): address any type or build issues from codex provider"
+```
+
+Only commit if there were fixes. Skip if clean.

--- a/docs/superpowers/specs/2026-05-04-openai-codex-provider-design.md
+++ b/docs/superpowers/specs/2026-05-04-openai-codex-provider-design.md
@@ -1,0 +1,137 @@
+# OpenAI Codex Provider — Read-only Interop with ~/.codex/auth.json
+
+## Summary
+
+Add `openai-codex` as a third built-in model provider in the agents model catalog. When a user has logged into OpenAI Codex CLI (`~/.codex/auth.json` exists with a valid token), Codex models (GPT-5.1 through GPT-5.5) automatically appear in the dashboard model dropdown alongside Anthropic and OpenAI API models.
+
+No OAuth flow of our own. No token refresh. Read-only interop with Codex CLI's credential file.
+
+## Scope
+
+- **Package**: `packages/agents` (model-catalog.ts only, plus minor type change)
+- **Not touched**: `packages/agents-runtime`, `packages/agents-server`
+
+## Design
+
+### Provider Detection
+
+In `configuredProviders()`, add a check for `~/.codex/auth.json`:
+
+```ts
+export type BuiltinModelProvider = `anthropic` | `openai` | `openai-codex`
+
+function configuredProviders(): Array<BuiltinModelProvider> {
+  const providers: Array<BuiltinModelProvider> = []
+  if (hasEnv(`ANTHROPIC_API_KEY`)) providers.push(`anthropic`)
+  if (hasEnv(`OPENAI_API_KEY`)) providers.push(`openai`)
+  if (hasCodexAuth()) providers.push(`openai-codex`)
+  return providers
+}
+```
+
+`hasCodexAuth()` reads `~/.codex/auth.json`, checks for `auth_mode === "chatgpt"` and a non-empty `tokens.access_token`. Uses `existsSync` + `readFileSync` with a try/catch (same style as the pi-ai CLI does it).
+
+### Model Listing
+
+For `openai-codex`, skip `fetchAvailableModelIds` (no list API exists). Use pi-ai's `getModels('openai-codex')` directly — same pattern as other providers, but without the availability filter.
+
+```ts
+async function choicesForProvider(provider: BuiltinModelProvider) {
+  const knownModels = getModels(provider)
+
+  // No model-list API for openai-codex; use full known set
+  if (provider === 'openai-codex') {
+    return knownModels.map(...)
+  }
+
+  const availableIds = await fetchAvailableModelIds(provider)
+  // ... existing logic
+}
+```
+
+### API Key (Token) Delivery
+
+Extend `BuiltinAgentModelConfig` to include `getApiKey`:
+
+```ts
+export type BuiltinAgentModelConfig = Pick<
+  AgentConfig,
+  `model` | `provider` | `onPayload` | `getApiKey`
+> & {
+  reasoningEffort?: ExplicitReasoningEffort
+}
+```
+
+When `provider === 'openai-codex'`, `resolveBuiltinModelConfig` returns a `getApiKey` function that reads the access token from `~/.codex/auth.json`:
+
+```ts
+getApiKey: (provider) => {
+  if (provider !== 'openai-codex') return undefined
+  return readCodexAccessToken() // reads tokens.access_token from ~/.codex/auth.json
+}
+```
+
+This gets spread into `ctx.useAgent(...)` in both Horton and Worker — no changes needed in those files since they already spread the full modelConfig.
+
+### Credential File Format
+
+`~/.codex/auth.json`:
+
+```json
+{
+  "auth_mode": "chatgpt",
+  "OPENAI_API_KEY": null,
+  "tokens": {
+    "id_token": "...",
+    "access_token": "...",
+    "refresh_token": "...",
+    "account_id": "..."
+  },
+  "last_refresh": "2026-05-04T..."
+}
+```
+
+We read `tokens.access_token`. Nothing else.
+
+### Error Behavior
+
+| Condition                             | Result                                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `~/.codex/auth.json` doesn't exist    | Provider not listed, no error                                                              |
+| File exists but malformed/empty token | Provider not listed, `console.warn`                                                        |
+| Token exists but API returns 401      | Runtime surfaces error naturally                                                           |
+| Token expired (API returns 401)       | Runtime surfaces error; user sees "Run `codex` to refresh your login" in the error context |
+
+### Provider Label
+
+```ts
+function providerLabel(provider: BuiltinModelProvider): string {
+  if (provider === 'anthropic') return 'Anthropic'
+  if (provider === 'openai') return 'OpenAI'
+  return 'OpenAI Codex'
+}
+```
+
+### Default Model Selection
+
+If codex is the only configured provider, default to `gpt-5.4`. Otherwise, existing default priority (Anthropic > OpenAI > Codex) is preserved.
+
+## Files Modified
+
+1. `packages/agents/src/model-catalog.ts` — all changes live here:
+   - Add `'openai-codex'` to `BuiltinModelProvider` type
+   - Add `hasCodexAuth()` and `readCodexAccessToken()` helper functions
+   - Update `configuredProviders()`
+   - Update `choicesForProvider()` to skip availability fetch for codex
+   - Update `providerLabel()`
+   - Add `getApiKey` to `BuiltinAgentModelConfig` type
+   - Update `resolveBuiltinModelConfig()` to attach `getApiKey` when provider is codex
+   - Update default model fallback chain
+
+## Not In Scope
+
+- OAuth login flow (future: approach C from brainstorming)
+- Token refresh / writing back to auth.json
+- Changes to agents-runtime or agents-server
+- CLI commands (`electric auth login` etc.)
+- Dashboard UI changes beyond the model dropdown (it already renders whatever the catalog returns)

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -32,7 +32,7 @@ type ExplicitReasoningEffort = Exclude<BuiltinReasoningEffort, `auto`>
 
 export type BuiltinAgentModelConfig = Pick<
   AgentConfig,
-  `model` | `provider` | `onPayload`
+  `model` | `provider` | `onPayload` | `getApiKey`
 > & {
   reasoningEffort?: ExplicitReasoningEffort
 }
@@ -169,7 +169,7 @@ async function choicesForProvider(
 }
 
 function withProviderPayloadDefaults(
-  config: PersistedModelConfig,
+  config: PersistedModelConfig & { getApiKey?: AgentConfig[`getApiKey`] },
   choice: BuiltinModelChoice,
   reasoningEffort: ExplicitReasoningEffort | null
 ): BuiltinAgentModelConfig {
@@ -265,6 +265,12 @@ export function resolveBuiltinModelConfig(
     provider: choice.provider,
     model: choice.id,
     ...(reasoningEffort && { reasoningEffort }),
+    ...(choice.provider === `openai-codex` && {
+      getApiKey: (provider: string) => {
+        if (provider !== `openai-codex`) return undefined
+        return readCodexAccessToken()
+      },
+    }),
   }
 
   return withProviderPayloadDefaults(config, choice, reasoningEffort)

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -1,6 +1,6 @@
 import { getModels } from '@mariozechner/pi-ai'
 import type { AgentConfig } from '@electric-ax/agents-runtime'
-import { existsSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
@@ -61,15 +61,13 @@ function readCodexAccessToken(): string | undefined {
       tokens?: { access_token?: string }
     }
     if (data.auth_mode !== `chatgpt`) return undefined
-    const token = data.tokens?.access_token?.trim()
-    return token && token.length > 0 ? token : undefined
+    return data.tokens?.access_token?.trim() || undefined
   } catch {
     return undefined
   }
 }
 
 function hasCodexAuth(): boolean {
-  if (!existsSync(codexAuthPath())) return false
   return readCodexAccessToken() !== undefined
 }
 
@@ -173,7 +171,11 @@ function withProviderPayloadDefaults(
   choice: BuiltinModelChoice,
   reasoningEffort: ExplicitReasoningEffort | null
 ): BuiltinAgentModelConfig {
-  if (choice.provider !== `openai` || !choice.reasoning) return config
+  if (
+    (choice.provider !== `openai` && choice.provider !== `openai-codex`) ||
+    !choice.reasoning
+  )
+    return config
 
   const effort = reasoningEffort ?? `minimal`
 
@@ -266,10 +268,7 @@ export function resolveBuiltinModelConfig(
     model: choice.id,
     ...(reasoningEffort && { reasoningEffort }),
     ...(choice.provider === `openai-codex` && {
-      getApiKey: (provider: string) => {
-        if (provider !== `openai-codex`) return undefined
-        return readCodexAccessToken()
-      },
+      getApiKey: () => readCodexAccessToken(),
     }),
   }
 

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -43,6 +43,7 @@ type PersistedModelConfig = Pick<AgentConfig, `model` | `provider`> & {
 
 const DEFAULT_ANTHROPIC_MODEL = `claude-sonnet-4-6`
 const DEFAULT_OPENAI_MODEL = `gpt-4.1`
+const DEFAULT_CODEX_MODEL = `gpt-5.4`
 
 function hasEnv(name: string): boolean {
   return (process.env[name]?.trim().length ?? 0) > 0
@@ -77,7 +78,9 @@ function modelValue(provider: BuiltinModelProvider, id: string): string {
 }
 
 function providerLabel(provider: BuiltinModelProvider): string {
-  return provider === `anthropic` ? `Anthropic` : `OpenAI`
+  if (provider === `anthropic`) return `Anthropic`
+  if (provider === `openai-codex`) return `OpenAI Codex`
+  return `OpenAI`
 }
 
 function configuredProviders(): Array<BuiltinModelProvider> {
@@ -139,6 +142,17 @@ async function choicesForProvider(
   provider: BuiltinModelProvider
 ): Promise<Array<BuiltinModelChoice>> {
   const knownModels = getModels(provider)
+
+  if (provider === `openai-codex`) {
+    return knownModels.map((model) => ({
+      provider,
+      id: model.id,
+      label: `${providerLabel(provider)} ${model.name}`,
+      value: modelValue(provider, model.id),
+      reasoning: model.reasoning,
+    }))
+  }
+
   const availableIds = await fetchAvailableModelIds(provider)
   const models =
     availableIds === null
@@ -220,6 +234,10 @@ export async function createBuiltinModelCatalog(
     choices.find(
       (choice) =>
         choice.provider === `openai` && choice.id === DEFAULT_OPENAI_MODEL
+    ) ??
+    choices.find(
+      (choice) =>
+        choice.provider === `openai-codex` && choice.id === DEFAULT_CODEX_MODEL
     ) ??
     choices[0]!
 

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -50,7 +50,7 @@ function hasEnv(name: string): boolean {
 }
 
 function codexAuthPath(): string {
-  return join(homedir(), `.codex`, `auth.json`)
+  return process.env.CODEX_AUTH_PATH ?? join(homedir(), `.codex`, `auth.json`)
 }
 
 function readCodexAccessToken(): string | undefined {

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -177,7 +177,11 @@ function withProviderPayloadDefaults(
   )
     return config
 
-  const effort = reasoningEffort ?? `minimal`
+  const defaultEffort = choice.provider === `openai-codex` ? `low` : `minimal`
+  const effort =
+    reasoningEffort === `minimal` && choice.provider === `openai-codex`
+      ? `low`
+      : (reasoningEffort ?? defaultEffort)
 
   return {
     ...config,

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -1,7 +1,10 @@
 import { getModels } from '@mariozechner/pi-ai'
 import type { AgentConfig } from '@electric-ax/agents-runtime'
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
-export type BuiltinModelProvider = `anthropic` | `openai`
+export type BuiltinModelProvider = `anthropic` | `openai` | `openai-codex`
 
 export interface BuiltinModelChoice {
   provider: BuiltinModelProvider
@@ -45,6 +48,30 @@ function hasEnv(name: string): boolean {
   return (process.env[name]?.trim().length ?? 0) > 0
 }
 
+function codexAuthPath(): string {
+  return join(homedir(), `.codex`, `auth.json`)
+}
+
+function readCodexAccessToken(): string | undefined {
+  try {
+    const raw = readFileSync(codexAuthPath(), `utf-8`)
+    const data = JSON.parse(raw) as {
+      auth_mode?: string
+      tokens?: { access_token?: string }
+    }
+    if (data.auth_mode !== `chatgpt`) return undefined
+    const token = data.tokens?.access_token?.trim()
+    return token && token.length > 0 ? token : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function hasCodexAuth(): boolean {
+  if (!existsSync(codexAuthPath())) return false
+  return readCodexAccessToken() !== undefined
+}
+
 function modelValue(provider: BuiltinModelProvider, id: string): string {
   return `${provider}:${id}`
 }
@@ -57,6 +84,7 @@ function configuredProviders(): Array<BuiltinModelProvider> {
   const providers: Array<BuiltinModelProvider> = []
   if (hasEnv(`ANTHROPIC_API_KEY`)) providers.push(`anthropic`)
   if (hasEnv(`OPENAI_API_KEY`)) providers.push(`openai`)
+  if (hasCodexAuth()) providers.push(`openai-codex`)
   return providers
 }
 

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -20,6 +20,7 @@ describe(`model catalog`, () => {
     process.env = { ...originalEnv }
     delete process.env.ANTHROPIC_API_KEY
     process.env.OPENAI_API_KEY = `test-openai-key`
+    process.env.CODEX_AUTH_PATH = `/nonexistent/auth.json`
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Add `openai-codex` as a third built-in model provider in the agents model catalog. When a user has logged into OpenAI Codex CLI, GPT-5.x models (GPT-5.1 through GPT-5.5) automatically appear in the dashboard model dropdown alongside Anthropic and OpenAI API models.

## Approach

**Read-only interop** — no OAuth flow, no token refresh, no writes. We detect `~/.codex/auth.json`, read the access token, and pass it via pi-ai's existing `getApiKey` callback. If the token expires, the user just runs `codex` to refresh it.

Key design decisions:

- **Separate provider namespace** (`openai-codex`) — the ChatGPT OAuth token targets `chatgpt.com/backend-api`, NOT `api.openai.com`. Conflating them causes 401s (this is [a known bug class](https://github.com/openclaw/openclaw/issues/38706) in other tools).
- **No model-list API call** — unlike `anthropic`/`openai` providers, we can't query for available models, so we use pi-ai's built-in model catalog directly.
- **Reasoning effort support** — `withProviderPayloadDefaults` now applies to both `openai` and `openai-codex` providers.

## Key Invariants

1. If `~/.codex/auth.json` doesn't exist or is malformed → provider silently not listed (no error)
2. `openai-codex` tokens never sent to `api.openai.com` endpoints
3. We never write to `~/.codex/auth.json`
4. Existing `anthropic`/`openai` provider behavior unchanged

## Non-goals

- Running our own OAuth flow (future work)
- Token refresh
- Changes to `agents-runtime` or `agents-server`
- CLI login commands

## Verification

```bash
cd packages/agents && pnpm test    # 78 tests pass
cd packages/agents && pnpm build   # builds clean
```

To verify models appear: start agents-server with `~/.codex/auth.json` present, open dashboard, check model dropdown.

## Files Changed

| File | Change |
|------|--------|
| `packages/agents/src/model-catalog.ts` | Add `openai-codex` provider detection, model listing, `getApiKey` wiring, reasoning effort support |
| `packages/agents/test/model-catalog.test.ts` | Set `CODEX_AUTH_PATH=/nonexistent` in beforeEach to isolate from real filesystem |
| `.changeset/add-openai-codex-provider.md` | Changeset for patch release |
| `docs/superpowers/specs/...` | Design spec |
| `docs/superpowers/plans/...` | Implementation plan |