### PR TITLE
Demote the log entry about expiring shapes from notice to info

### DIFF
--- a/.changeset/quiet-dolphins-return.md
+++ b/.changeset/quiet-dolphins-return.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Demote the log entry about expiring shapes to level info so that it's excluded from logs in Honeycomb.

--- a/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
+++ b/packages/sync-service/lib/electric/shape_cache/expiry_manager.ex
@@ -74,7 +74,7 @@ defmodule Electric.ShapeCache.ExpiryManager do
     number_to_expire = shape_count - state.max_shapes
     {handles_to_expire, min_age} = least_recently_used(state, number_to_expire)
 
-    Logger.notice(
+    Logger.info(
       "Expiring shapes as the number of shapes has exceeded the limit",
       number_to_expire: number_to_expire,
       max_shapes: state.max_shapes


### PR DESCRIPTION
There's little use for this message in our observability platform, it's mostly noise.

<img width="2389" height="1190" alt="Screenshot From 2026-05-05 15-15-59" src="https://github.com/user-attachments/assets/ad1b1095-2436-4a99-99e3-4937d364f24d" />
