### PR TITLE
feat(sync-service): add Postgres concat(VARIADIC text) to shape subset eval

### DIFF
--- a/.changeset/moody-maps-approve.md
+++ b/.changeset/moody-maps-approve.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Add Postgres concat(variadic text) to shape subset WHERE evaluation, with NULL arguments skipped and SqlGenerator support for concat(...) round-trips.

--- a/.changeset/moody-maps-approve.md
+++ b/.changeset/moody-maps-approve.md
@@ -2,4 +2,4 @@
 '@core/sync-service': patch
 ---
 
-Add Postgres concat(variadic text) to shape subset WHERE evaluation, with NULL arguments skipped and SqlGenerator support for concat(...) round-trips.
+Add CONCAT(variadic text) support

--- a/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
+++ b/packages/sync-service/lib/electric/replication/eval/env/known_functions.ex
@@ -137,6 +137,17 @@ defmodule Electric.Replication.Eval.Env.KnownFunctions do
     end
   end
 
+  def concat_text(parts) when is_list(parts) do
+    parts
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join()
+  end
+
+  defpostgres("concat(VARIADIC text) -> text",
+    strict?: false,
+    delegate: &__MODULE__.concat_text/1
+  )
+
   defpostgres("lower(text) -> text", delegate: &String.downcase/1)
   defpostgres("upper(text) -> text", delegate: &String.upcase/1)
   defpostgres("text ~~ text -> bool", delegate: &Casting.like?/2)

--- a/packages/sync-service/lib/electric/replication/eval/sql_generator.ex
+++ b/packages/sync-service/lib/electric/replication/eval/sql_generator.ex
@@ -42,7 +42,7 @@ defmodule Electric.Replication.Eval.SqlGenerator do
   membership (IN), logical operators (AND, OR, NOT), boolean tests
   (IS TRUE, IS FALSE, IS UNKNOWN, etc.), column references, constants
   (strings, integers, floats, booleans, NULL), type casts, arithmetic
-  operators (+, -, *, /, ^, |/, @, &, |, #, ~), string concatenation (||),
+  operators (+, -, *, /, ^, |/, @, &, |, #, ~), string concatenation (||, concat),
   array operators (@>, <@, &&), array/slice access, DISTINCT/NOT DISTINCT,
   ANY/ALL, and sublink membership checks.
 
@@ -216,6 +216,10 @@ defmodule Electric.Replication.Eval.SqlGenerator do
 
   defp to_sql_prec(%Func{name: "\"&&\"", args: [left, right]}),
     do: binary_op(left, "&&", right, @prec_other_op)
+
+  # Variadic concat — parser stores arguments as a single Array (see Parser.from_concrete/2).
+  defp to_sql_prec(%Func{name: "concat", args: [%Array{elements: elements}]}),
+    do: {"concat(#{Enum.map_join(elements, ", ", &to_sql/1)})", @prec_atom}
 
   # Named functions (lower, upper, like, ilike, array_*, justify_*, timezone, casts, etc.)
   # These are Func nodes where the name is a plain identifier (no quotes around operators)

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -283,9 +283,7 @@ defmodule Electric.Replication.Eval.ParserTest do
 
       assert {:error,
               "At location 0: explicit VARIADIC function calls are not currently supported"} =
-               Parser.parse_and_validate_expression(
-                 ~S|concat(VARIADIC NULL::text[])|
-               )
+               Parser.parse_and_validate_expression(~S|concat(VARIADIC NULL::text[])|)
     end
 
     test "should reject concat with char(n) until bpchar support exists" do

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -266,6 +266,35 @@ defmodule Electric.Replication.Eval.ParserTest do
                )
     end
 
+    test "should reject concat with non-text date arguments" do
+      assert {:error, msg} =
+               Parser.parse_and_validate_expression(~S|concat(date '2025-05-01', 'x')|)
+
+      assert msg =~ "Could not select a function overload for concat("
+      assert msg =~ "date"
+    end
+
+    test "should keep explicit variadic concat array forms unsupported" do
+      assert {:error,
+              "At location 0: explicit VARIADIC function calls are not currently supported"} =
+               Parser.parse_and_validate_expression(
+                 ~S|concat(VARIADIC ARRAY['a', NULL::text, 'b'])|
+               )
+
+      assert {:error,
+              "At location 0: explicit VARIADIC function calls are not currently supported"} =
+               Parser.parse_and_validate_expression(
+                 ~S|concat(VARIADIC NULL::text[])|
+               )
+    end
+
+    test "should reject concat with char(n) until bpchar support exists" do
+      assert {:error, msg} =
+               Parser.parse_and_validate_expression(~S|concat('x'::char(3), 'y')|)
+
+      assert msg =~ "unsupported type bpchar"
+    end
+
     test "should correctly parse coalesce special form as a variadic function" do
       assert {:ok, %Expr{eval: result}} =
                Parser.parse_and_validate_expression(

--- a/packages/sync-service/test/electric/replication/eval/runner_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/runner_test.exs
@@ -244,6 +244,45 @@ defmodule Electric.Replication.Eval.RunnerTest do
                |> Runner.execute(%{})
     end
 
+    test "supports concat as a variadic text function, skipping NULL arguments" do
+      assert {:ok, "ab"} =
+               ~S|concat('a', 'b')|
+               |> Parser.parse_and_validate_expression!()
+               |> Runner.execute(%{})
+
+      assert {:ok, "ab"} =
+               ~S|concat('a', NULL::text, 'b')|
+               |> Parser.parse_and_validate_expression!()
+               |> Runner.execute(%{})
+
+      assert {:ok, ""} =
+               ~S|concat(NULL::text, NULL::text)|
+               |> Parser.parse_and_validate_expression!()
+               |> Runner.execute(%{})
+
+      expr =
+        ~S|concat('x', "mid", 'z')|
+        |> Parser.parse_and_validate_expression!(refs: %{["mid"] => :text})
+
+      assert {:ok, "xbz"} = Runner.execute(expr, %{["mid"] => "b"})
+      assert {:ok, "xz"} = Runner.execute(expr, %{["mid"] => nil})
+
+      assert {:ok, true} =
+               ~S|ilike(concat('%', "value", '%'), '%foo%')|
+               |> Parser.parse_and_validate_expression!(refs: %{["value"] => :text})
+               |> Runner.execute(%{["value"] => "foo"})
+
+      assert {:ok, nil} =
+               ~S{'a' || NULL::text || 'b'}
+               |> Parser.parse_and_validate_expression!()
+               |> Runner.execute(%{})
+    end
+
+    test "concat() with zero arguments is not a supported overload" do
+      assert {:error, msg} = Parser.parse_and_validate_expression(~S|concat()|)
+      assert msg =~ "unknown or unsupported function concat/0"
+    end
+
     test "subquery" do
       assert {:ok, true} =
                ~S|test IN (SELECT val FROM tester)|

--- a/packages/sync-service/test/electric/replication/eval/sql_generator_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/sql_generator_test.exs
@@ -315,6 +315,23 @@ defmodule Electric.Replication.Eval.SqlGeneratorTest do
       ast = %Func{name: "\"||\"", args: [%Ref{path: ["first"]}, %Ref{path: ["last"]}]}
       assert SqlGenerator.to_sql(ast) == ~s("first" || "last")
     end
+
+    test "concat variadic (parser Array wrapper)" do
+      ast = %Func{
+        name: "concat",
+        args: [
+          %Array{
+            elements: [
+              %Ref{path: ["first_name"]},
+              %Const{value: " "},
+              %Ref{path: ["last_name"]}
+            ]
+          }
+        ]
+      }
+
+      assert SqlGenerator.to_sql(ast) == ~s|concat("first_name", ' ', "last_name")|
+    end
   end
 
   describe "array operators" do


### PR DESCRIPTION
Register concat with NULL-skipping semantics (empty string when all args are NULL), matching text concat behavior distinct from || with NULL.

Tests cover literals, refs, ilike(concat(...)), contrast with ||, and document that concat() is unsupported (no concat/0 overload).

