### PR TITLE
Preserve HOME in bash tool

### DIFF
--- a/.changeset/fix-bash-tool-home.md
+++ b/.changeset/fix-bash-tool-home.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-runtime': patch
+---
+
+Preserve the caller's HOME environment variable when running bash tool commands so CLIs can find user-level config and credentials.

--- a/packages/agents-runtime/src/tools/bash.ts
+++ b/packages/agents-runtime/src/tools/bash.ts
@@ -20,7 +20,7 @@ export function createBashTool(workingDirectory: string): AgentTool {
           cwd: workingDirectory,
           timeout: TIMEOUT_MS,
           maxBuffer: 1024 * 1024,
-          env: { ...process.env, HOME: workingDirectory },
+          env: { ...process.env },
         })
 
         let stdout = ``

--- a/packages/agents-runtime/test/bash-tool.test.ts
+++ b/packages/agents-runtime/test/bash-tool.test.ts
@@ -22,7 +22,9 @@ describe(`bash tool`, () => {
     })
 
     expect(result.details).toMatchObject({ exitCode: 0, timedOut: false })
-    const lines = (result.content[0] as { text: string }).text.trim().split(`\n`)
+    const lines = (result.content[0] as { text: string }).text
+      .trim()
+      .split(`\n`)
     expect(lines).toEqual([await realpath(cwd), process.env.HOME ?? homedir()])
   })
 })

--- a/packages/agents-runtime/test/bash-tool.test.ts
+++ b/packages/agents-runtime/test/bash-tool.test.ts
@@ -1,0 +1,28 @@
+import { mkdtemp, realpath, rm } from 'node:fs/promises'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createBashTool } from '../src/tools/bash'
+
+describe(`bash tool`, () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), `bash-tool-`))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  it(`runs commands in the working directory without overriding HOME`, async () => {
+    const tool = createBashTool(cwd)
+    const result = await tool.execute(`call-1`, {
+      command: `node -e "console.log(process.cwd()); console.log(process.env.HOME)"`,
+    })
+
+    expect(result.details).toMatchObject({ exitCode: 0, timedOut: false })
+    const lines = (result.content[0] as { text: string }).text.trim().split(`\n`)
+    expect(lines).toEqual([await realpath(cwd), process.env.HOME ?? homedir()])
+  })
+})


### PR DESCRIPTION
Preserve the caller's `HOME` environment variable when running bash tool commands.

Previously the bash tool overrode `HOME` with the tool working directory:

```ts
env: { ...process.env, HOME: workingDirectory }
```

That kept commands scoped to the workspace, but it also made CLIs look for user-level config, credentials, and caches under the repo/workspace path rather than the actual user home directory. In practice this broke tools like `gh`, which could no longer find the user's existing GitHub auth config.

## Approach

- Keep `cwd: workingDirectory` so commands still execute in the sandboxed working directory.
- Stop overriding `HOME`, preserving the inherited process environment instead.
- Add a regression test that verifies both invariants:
  - command `cwd` is the configured working directory
  - `HOME` remains inherited from the parent process

## Verification

```bash
cd packages/agents-runtime
pnpm exec vitest run test/bash-tool.test.ts
```

Result:

```text
1 test passed
```

I also ran `pnpm -C packages/agents-runtime typecheck`, but it failed on existing dependency/type issues in the package before reaching anything specific to this change.
