### PR TITLE
feat(sync-service): hibernate before suspend to enable GC

### DIFF
--- a/.changeset/hibernate-then-suspend.md
+++ b/.changeset/hibernate-then-suspend.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': minor
+---
+
+Add hibernate-then-suspend behavior for Consumer processes. When suspend is enabled, consumers now hibernate first (triggering GC) before suspending. Adds `shape_suspend_after` config (default 60s) to control the delay between hibernation and suspension. Any activity cancels the pending suspend timer, restarting the cycle.

--- a/.changeset/hibernate-then-suspend.md
+++ b/.changeset/hibernate-then-suspend.md
@@ -2,4 +2,4 @@
 '@core/sync-service': minor
 ---
 
-Add hibernate-then-suspend behavior for Consumer processes. When suspend is enabled, consumers now hibernate first (triggering GC) before suspending. Adds `shape_suspend_after` config (default 60s) to control the delay between hibernation and suspension. Any activity cancels the pending suspend timer, restarting the cycle.
+Add hibernate-then-suspend behavior for Consumer processes. When suspend is enabled, consumers now hibernate first (triggering GC) before suspending. Adds `shape_suspend_after` config (default 10 minutes) to control the delay between hibernation and suspension. Any activity cancels the pending suspend timer, restarting the cycle.

--- a/.changeset/hibernate-then-suspend.md
+++ b/.changeset/hibernate-then-suspend.md
@@ -2,4 +2,4 @@
 '@core/sync-service': minor
 ---
 
-Add hibernate-then-suspend behavior for Consumer processes. When suspend is enabled, consumers now hibernate first (triggering GC) before suspending. Adds `shape_suspend_after` config (default 10 minutes) to control the delay between hibernation and suspension. Any activity cancels the pending suspend timer, restarting the cycle.
+Add hibernate-then-suspend behavior for Consumer processes. When suspend is enabled, consumers now hibernate first (triggering GC) before suspending. Adds `shape_suspend_after` config to control the delay between hibernation and suspension. Any activity cancels the pending suspend timer, restarting the cycle.

--- a/integration-tests/tests/shape-suspension-resumption.lux
+++ b/integration-tests/tests/shape-suspension-resumption.lux
@@ -20,7 +20,7 @@
 
 # Start Electric and wait for it to finish initialization.
 # Set a very small hibernation timeout so consumers will shutdown quickly
-[invoke setup_electric_with_env "ELECTRIC_SHAPE_HIBERNATE_AFTER=200ms ELECTRIC_SHAPE_SUSPEND_CONSUMER=true"]
+[invoke setup_electric_with_env "ELECTRIC_SHAPE_HIBERNATE_AFTER=200ms ELECTRIC_SHAPE_SUSPEND_AFTER=200ms ELECTRIC_SHAPE_SUSPEND_CONSUMER=true"]
 [shell electric]
   [timeout 10]
   ??[debug] Replication client started streaming

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -170,6 +170,9 @@ shape_hibernate_after =
 
 shape_enable_suspend? = env!("ELECTRIC_SHAPE_SUSPEND_CONSUMER", :boolean, nil)
 
+shape_suspend_after =
+  env!("ELECTRIC_SHAPE_SUSPEND_AFTER", &Electric.Config.parse_human_readable_time!/1, nil)
+
 system_metrics_poll_interval =
   env!(
     "ELECTRIC_SYSTEM_METRICS_POLL_INTERVAL",
@@ -270,6 +273,7 @@ config :electric,
     env!("ELECTRIC_SUBQUERY_BUFFER_MAX_TRANSACTIONS", :integer, nil),
   shape_hibernate_after: shape_hibernate_after,
   shape_enable_suspend?: shape_enable_suspend?,
+  shape_suspend_after: shape_suspend_after,
   storage_dir: storage_dir,
   storage: storage_spec,
   cleanup_interval_ms:

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -153,6 +153,7 @@ defmodule Electric.Application do
         cleanup_interval_ms: get_env(opts, :cleanup_interval_ms),
         shape_hibernate_after: get_env(opts, :shape_hibernate_after),
         shape_enable_suspend?: get_env(opts, :shape_enable_suspend?),
+        shape_suspend_after: get_env(opts, :shape_suspend_after),
         conn_max_requests: get_env(opts, :conn_max_requests),
         handler_fullsweep_after: get_env(opts, :handler_fullsweep_after),
         process_spawn_opts: get_env(opts, :process_spawn_opts)

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -85,11 +85,14 @@ defmodule Electric.Config do
     otel_sampling_ratio: 0.01,
     metrics_sampling_ratio: 1,
     ## Memory
+    # After this duration of inactivity, consumer processes will hibernate
+    # to allow garbage collection
     shape_hibernate_after: :timer.seconds(30),
-    # Should we terminate consumer processes after `shape_hibernate_after` ms
-    # or just hibernate them?
+    # If enabled, terminate (suspend) consumer processes after hibernating.
+    # This frees memory more aggressively than hibernation alone.
     shape_enable_suspend?: false,
-    # How long after hibernation before suspending (terminating) the consumer
+    # After hibernating, wait this duration before suspending (terminating).
+    # Only applies when shape_enable_suspend? is true.
     shape_suspend_after: :timer.minutes(10),
     # Sets max_requests for Bandit handler processes:
     # https://hexdocs.pm/bandit/Bandit.html#t:http_1_options/0

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -89,6 +89,8 @@ defmodule Electric.Config do
     # Should we terminate consumer processes after `shape_hibernate_after` ms
     # or just hibernate them?
     shape_enable_suspend?: false,
+    # How long after hibernation before suspending (terminating) the consumer
+    shape_suspend_after: :timer.minutes(10),
     # Sets max_requests for Bandit handler processes:
     # https://hexdocs.pm/bandit/Bandit.html#t:http_1_options/0
     # "The maximum number of requests to serve in a single HTTP/{1,2}

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -175,6 +175,13 @@ defmodule Electric.Shapes.Consumer do
   end
 
   @impl GenServer
+  # Any incoming message counts as activity: cancel the pending suspend timer (if
+  # any) before dispatching to the real clause, which we reach by recursing with a
+  # cleared timer so this guard no longer matches.
+  def handle_call(msg, from, %{suspend_timer: ref} = state) when not is_nil(ref) do
+    handle_call(msg, from, cancel_suspend_timer(state))
+  end
+
   def handle_call({:monitor, pid}, _from, %{monitors: monitors} = state) do
     ref = make_ref()
     {:reply, ref, %{state | monitors: [{pid, ref} | monitors]}, state.hibernate_after}
@@ -215,6 +222,11 @@ defmodule Electric.Shapes.Consumer do
   end
 
   @impl GenServer
+  # See the handle_call/3 interceptor above - cancel the suspend timer on activity.
+  def handle_cast(msg, %{suspend_timer: ref} = state) when not is_nil(ref) do
+    handle_cast(msg, cancel_suspend_timer(state))
+  end
+
   def handle_cast(
         {:pg_snapshot_known, shape_handle, {xmin, xmax, xip_list} = snapshot},
         %{shape_handle: shape_handle} = state
@@ -252,6 +264,33 @@ defmodule Electric.Shapes.Consumer do
   end
 
   @impl GenServer
+  # Genuine suspend timer: it is still the armed timer (suspend_timer is set), which
+  # means no activity cancelled it since it was scheduled. Suspend if still eligible.
+  def handle_info(:suspend_timeout, %{suspend_timer: ref} = state) when not is_nil(ref) do
+    state = %{state | suspend_timer: nil}
+
+    if consumer_suspend_enabled?(state) and consumer_can_suspend?(state) do
+      Logger.debug(fn -> ["Suspending consumer ", to_string(state.shape_handle)] end)
+      {:stop, ShapeCleaner.consumer_suspend_reason(), state}
+    else
+      # Conditions changed - just restart the hibernate timeout
+      {:noreply, state, state.hibernate_after}
+    end
+  end
+
+  # Stale suspend timer: activity already cancelled it (suspend_timer is nil), but the
+  # timer had fired and enqueued this message before the cancellation. Ignore it.
+  def handle_info(:suspend_timeout, state) do
+    {:noreply, state, state.hibernate_after}
+  end
+
+  # Any incoming message counts as activity: cancel the pending suspend timer (if any)
+  # before dispatching to the real clause. The :suspend_timeout clauses above are
+  # matched first, so this never intercepts the timer message itself.
+  def handle_info(msg, %{suspend_timer: ref} = state) when not is_nil(ref) do
+    handle_info(msg, cancel_suspend_timer(state))
+  end
+
   def handle_info({:initialize_shape, shape, opts}, state) do
     %{stack_id: stack_id, shape_handle: shape_handle} = state
 
@@ -402,20 +441,6 @@ defmodule Electric.Shapes.Consumer do
     {:noreply, state, :hibernate}
   end
 
-  # Suspend timer uses a generation number to handle stale timers. If activity
-  # occurred after the timer was scheduled, a new timer with a higher generation
-  # will have been scheduled, making this one stale (generation mismatch).
-  def handle_info({:suspend_timeout, generation}, state) do
-    if generation == state.suspend_generation and
-         consumer_suspend_enabled?(state) and consumer_can_suspend?(state) do
-      Logger.debug(fn -> ["Suspending consumer ", to_string(state.shape_handle)] end)
-      {:stop, ShapeCleaner.consumer_suspend_reason(), state}
-    else
-      # Stale timer or conditions changed - just restart the hibernate timeout
-      {:noreply, state, state.hibernate_after}
-    end
-  end
-
   defp consumer_suspend_enabled?(%{stack_id: stack_id}) do
     Electric.StackConfig.lookup(stack_id, :shape_enable_suspend?, true)
   end
@@ -427,10 +452,16 @@ defmodule Electric.Shapes.Consumer do
 
   defp schedule_suspend_timer(%{suspend_after: nil} = state), do: state
 
-  defp schedule_suspend_timer(%{suspend_after: suspend_after, suspend_generation: gen} = state) do
-    next_gen = gen + 1
-    :erlang.send_after(suspend_after, self(), {:suspend_timeout, next_gen})
-    %{state | suspend_generation: next_gen}
+  defp schedule_suspend_timer(%{suspend_after: suspend_after} = state) do
+    ref = :erlang.send_after(suspend_after, self(), :suspend_timeout)
+    %{state | suspend_timer: ref}
+  end
+
+  defp cancel_suspend_timer(%{suspend_timer: nil} = state), do: state
+
+  defp cancel_suspend_timer(%{suspend_timer: ref} = state) do
+    :erlang.cancel_timer(ref)
+    %{state | suspend_timer: nil}
   end
 
   @impl GenServer

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -186,8 +186,8 @@ defmodule Electric.Shapes.Consumer do
 
   def handle_call(:await_snapshot_start, from, state) do
     Logger.debug("Starting a wait on the snapshot #{state.shape_handle} for #{inspect(from)}}")
-
-    {:noreply, State.add_waiter(state, from), state.hibernate_after}
+    state = State.add_waiter(state, from)
+    {:noreply, state, state.hibernate_after}
   end
 
   def handle_call({:handle_event, event, trace_context}, _from, state) do
@@ -205,9 +205,8 @@ defmodule Electric.Shapes.Consumer do
   def handle_call({:subscribe_materializer, pid}, _from, state) do
     Logger.debug("Subscribing materializer for #{state.shape_handle}")
     Process.monitor(pid, tag: :materializer_down)
-
-    {:reply, {:ok, state.latest_offset}, %{state | materializer_subscribed?: true},
-     state.hibernate_after}
+    state = %{state | materializer_subscribed?: true}
+    {:reply, {:ok, state.latest_offset}, state, state.hibernate_after}
   end
 
   def handle_call({:stop, reason}, _from, state) do
@@ -383,31 +382,37 @@ defmodule Electric.Shapes.Consumer do
     {:stop, reason, state}
   end
 
-  # Set a new value for hibernate after and set a timeout between
-  # hibernate_after and max_timeout in order to spread
-  # consumer suspend events.
-  def handle_info({:configure_suspend, hibernate_after, jitter_period}, state) do
-    {:noreply, %{state | hibernate_after: hibernate_after},
-     Enum.random(hibernate_after..jitter_period)}
+  # Set new values for hibernate_after and suspend_after, and set a jittered
+  # timeout between hibernate_after and jitter_period to spread hibernation
+  # events. Each consumer will hibernate at the jittered timeout, then schedule
+  # suspension for suspend_after ms later.
+  def handle_info({:configure_suspend, hibernate_after, suspend_after, jitter_period}, state) do
+    state = %{state | hibernate_after: hibernate_after, suspend_after: suspend_after}
+    {:noreply, state, Enum.random(hibernate_after..jitter_period)}
   end
 
   def handle_info(:timeout, state) do
-    # we can only suspend (terminate) the consumer process if
-    #
-    # 1. Consumer suspend has been enabled in the stack config
-    # 2. we're not waiting for snapshot information
-    # 3. we are not part of a subquery dependency tree, that is either
-    #   a. we have no dependent shapes
-    #   b. we don't have a materializer subscribed
-    # 4. we're not in the middle of processing a multi-fragment transaction
+    state = %{state | writer: ShapeCache.Storage.hibernate(state.writer)}
 
-    if consumer_suspend_enabled?(state) and consumer_can_suspend?(state) do
+    state =
+      if consumer_suspend_enabled?(state) and consumer_can_suspend?(state),
+        do: schedule_suspend_timer(state),
+        else: state
+
+    {:noreply, state, :hibernate}
+  end
+
+  # Suspend timer uses a generation number to handle stale timers. If activity
+  # occurred after the timer was scheduled, a new timer with a higher generation
+  # will have been scheduled, making this one stale (generation mismatch).
+  def handle_info({:suspend_timeout, generation}, state) do
+    if generation == state.suspend_generation and
+         consumer_suspend_enabled?(state) and consumer_can_suspend?(state) do
       Logger.debug(fn -> ["Suspending consumer ", to_string(state.shape_handle)] end)
       {:stop, ShapeCleaner.consumer_suspend_reason(), state}
     else
-      state = %{state | writer: ShapeCache.Storage.hibernate(state.writer)}
-
-      {:noreply, state, :hibernate}
+      # Stale timer or conditions changed - just restart the hibernate timeout
+      {:noreply, state, state.hibernate_after}
     end
   end
 
@@ -418,6 +423,14 @@ defmodule Electric.Shapes.Consumer do
   defp consumer_can_suspend?(state) do
     is_snapshot_started(state) and not Shape.has_dependencies(state.shape) and
       not state.materializer_subscribed? and is_nil(state.pending_txn)
+  end
+
+  defp schedule_suspend_timer(%{suspend_after: nil} = state), do: state
+
+  defp schedule_suspend_timer(%{suspend_after: suspend_after, suspend_generation: gen} = state) do
+    next_gen = gen + 1
+    :erlang.send_after(suspend_after, self(), {:suspend_timeout, next_gen})
+    %{state | suspend_generation: next_gen}
   end
 
   @impl GenServer

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -176,8 +176,7 @@ defmodule Electric.Shapes.Consumer do
 
   @impl GenServer
   # Any incoming message counts as activity: cancel the pending suspend timer (if
-  # any) before dispatching to the real clause, which we reach by recursing with a
-  # cleared timer so this guard no longer matches.
+  # any) and recurse for actual handling of the call.
   def handle_call(msg, from, %{suspend_timer: ref} = state) when not is_nil(ref) do
     handle_call(msg, from, cancel_suspend_timer(state))
   end
@@ -222,7 +221,7 @@ defmodule Electric.Shapes.Consumer do
   end
 
   @impl GenServer
-  # See the handle_call/3 interceptor above - cancel the suspend timer on activity.
+  # Cancel the suspend timer on activity, then recurse for the actual handling of the cast.
   def handle_cast(msg, %{suspend_timer: ref} = state) when not is_nil(ref) do
     handle_cast(msg, cancel_suspend_timer(state))
   end
@@ -264,8 +263,6 @@ defmodule Electric.Shapes.Consumer do
   end
 
   @impl GenServer
-  # Genuine suspend timer: it is still the armed timer (suspend_timer is set), which
-  # means no activity cancelled it since it was scheduled. Suspend if still eligible.
   def handle_info(:suspend_timeout, %{suspend_timer: ref} = state) when not is_nil(ref) do
     state = %{state | suspend_timer: nil}
 
@@ -278,15 +275,13 @@ defmodule Electric.Shapes.Consumer do
     end
   end
 
-  # Stale suspend timer: activity already cancelled it (suspend_timer is nil), but the
-  # timer had fired and enqueued this message before the cancellation. Ignore it.
+  # Timer already cancelled. Ignore the trigger.
   def handle_info(:suspend_timeout, state) do
     {:noreply, state, state.hibernate_after}
   end
 
   # Any incoming message counts as activity: cancel the pending suspend timer (if any)
-  # before dispatching to the real clause. The :suspend_timeout clauses above are
-  # matched first, so this never intercepts the timer message itself.
+  # and recurse for the actual handling of the message.
   def handle_info(msg, %{suspend_timer: ref} = state) when not is_nil(ref) do
     handle_info(msg, cancel_suspend_timer(state))
   end

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -42,8 +42,10 @@ defmodule Electric.Shapes.Consumer.State do
     # transaction, we defer the notification and store the max flushed offset
     # here. Multiple deferred notifications are collapsed into a single most recent offset.
     pending_flush_offset: nil,
-    # Timer reference for scheduled suspend, set when entering hibernation
-    suspend_timer: nil,
+    # Generation counter for suspend timers - incremented each time we schedule
+    # a new suspend timer. When a timer fires, it checks if its generation matches
+    # the current one; if not, activity occurred and the timer is stale (ignored).
+    suspend_generation: 0,
     # How long after hibernation to suspend (in ms)
     suspend_after: nil
   ]

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -41,7 +41,11 @@ defmodule Electric.Shapes.Consumer.State do
     # When a {Storage, :flushed, offset} message arrives during a pending
     # transaction, we defer the notification and store the max flushed offset
     # here. Multiple deferred notifications are collapsed into a single most recent offset.
-    pending_flush_offset: nil
+    pending_flush_offset: nil,
+    # Timer reference for scheduled suspend, set when entering hibernation
+    suspend_timer: nil,
+    # How long after hibernation to suspend (in ms)
+    suspend_after: nil
   ]
 
   @type pg_snapshot() :: SnapshotQuery.pg_snapshot()
@@ -94,6 +98,12 @@ defmodule Electric.Shapes.Consumer.State do
           stack_id,
           :shape_hibernate_after,
           Electric.Config.default(:shape_hibernate_after)
+        ),
+      suspend_after:
+        Electric.StackConfig.lookup(
+          stack_id,
+          :shape_suspend_after,
+          Electric.Config.default(:shape_suspend_after)
         ),
       buffering?: true
     }

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -42,10 +42,10 @@ defmodule Electric.Shapes.Consumer.State do
     # transaction, we defer the notification and store the max flushed offset
     # here. Multiple deferred notifications are collapsed into a single most recent offset.
     pending_flush_offset: nil,
-    # Generation counter for suspend timers - incremented each time we schedule
-    # a new suspend timer. When a timer fires, it checks if its generation matches
-    # the current one; if not, activity occurred and the timer is stale (ignored).
-    suspend_generation: 0,
+    # Reference of the pending suspend timer, or nil if none is armed. The timer
+    # is armed when the consumer settles into hibernation and is cancelled as soon
+    # as any message arrives (activity), so at most one is ever live at a time.
+    suspend_timer: nil,
     # How long after hibernation to suspend (in ms)
     suspend_after: nil
   ]

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -217,14 +217,15 @@ defmodule Electric.Shapes.ConsumerRegistry do
   disabled, because the configuration message will have the side-effect of
   waking all consumers from hibernation.
 
-  The `jitter_period` value allows for spreading the suspension of existing
-  consumers over a large time period to avoid a sudden rush of consumer
-  shutdowns after `hibernate_after` ms.
+  The `jitter_period` value allows for spreading the hibernation of existing
+  consumers over a time period to avoid a sudden rush of hibernation events.
+  Each consumer picks a random timeout between `hibernate_after` and `jitter_period`,
+  then hibernates and schedules suspension for `suspend_after` ms later.
 
   To re-enable consumer suspend:
 
-      # set the hibernation timeout to 1 minute, suspend 4 minutes after hibernation,
-      # and phase the suspension of existing consumers over a 20 minute period
+      # hibernation timeout: 1 min, suspend timeout: 4 min, jitter window: 20 min
+      # Consumers will hibernate between 1-20 min, then suspend 4 min after hibernating
       Electric.Shapes.ConsumerRegistry.enable_suspend(stack_id, 60_000, 4 * 60_000, 60_000 * 20)
 
   Disabling suspension is as easy as:

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -223,9 +223,9 @@ defmodule Electric.Shapes.ConsumerRegistry do
 
   To re-enable consumer suspend:
 
-      # set the hibernation timeout to 1 minute, suspend 1 minute after hibernation,
+      # set the hibernation timeout to 1 minute, suspend 4 minutes after hibernation,
       # and phase the suspension of existing consumers over a 20 minute period
-      Electric.Shapes.ConsumerRegistry.enable_suspend(stack_id, 60_000, 60_000, 60_000 * 20)
+      Electric.Shapes.ConsumerRegistry.enable_suspend(stack_id, 60_000, 4 * 60_000, 60_000 * 20)
 
   Disabling suspension is as easy as:
 

--- a/packages/sync-service/lib/electric/shapes/consumer_registry.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer_registry.ex
@@ -223,27 +223,28 @@ defmodule Electric.Shapes.ConsumerRegistry do
 
   To re-enable consumer suspend:
 
-      # set the hibernation timeout to 1 minute but phase the suspension of
-      # existing consumers over a 20 minute period
-      Electric.Shapes.ConsumerRegistry.enable_suspend(stack_id, 60_000, 60_000 * 20)
+      # set the hibernation timeout to 1 minute, suspend 1 minute after hibernation,
+      # and phase the suspension of existing consumers over a 20 minute period
+      Electric.Shapes.ConsumerRegistry.enable_suspend(stack_id, 60_000, 60_000, 60_000 * 20)
 
   Disabling suspension is as easy as:
 
       Electric.StackConfig.put(stack_id, :shape_enable_suspend?, false)
 
   """
-  @spec enable_suspend(stack_id(), pos_integer(), pos_integer()) ::
+  @spec enable_suspend(stack_id(), pos_integer(), pos_integer(), pos_integer()) ::
           consumer_count :: non_neg_integer()
-  def enable_suspend(stack_id, hibernate_after, jitter_period)
-      when is_integer(hibernate_after) and is_integer(jitter_period) and
-             jitter_period > hibernate_after do
+  def enable_suspend(stack_id, hibernate_after, suspend_after, jitter_period)
+      when is_integer(hibernate_after) and is_integer(suspend_after) and
+             is_integer(jitter_period) and jitter_period > hibernate_after do
     Electric.StackConfig.put(stack_id, :shape_hibernate_after, hibernate_after)
+    Electric.StackConfig.put(stack_id, :shape_suspend_after, suspend_after)
     Electric.StackConfig.put(stack_id, :shape_enable_suspend?, true)
 
     :ets.foldl(
       fn {_shape_handle, pid}, n ->
         if Process.alive?(pid),
-          do: send(pid, {:configure_suspend, hibernate_after, jitter_period})
+          do: send(pid, {:configure_suspend, hibernate_after, suspend_after, jitter_period})
 
         n + 1
       end,

--- a/packages/sync-service/lib/electric/stack_config.ex
+++ b/packages/sync-service/lib/electric/stack_config.ex
@@ -30,6 +30,7 @@ defmodule Electric.StackConfig do
       snapshot_timeout_to_first_data: :timer.seconds(30),
       shape_hibernate_after: Electric.Config.default(:shape_hibernate_after),
       shape_enable_suspend?: Electric.Config.default(:shape_enable_suspend?),
+      shape_suspend_after: Electric.Config.default(:shape_suspend_after),
       chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
       feature_flags: [],
       process_spawn_opts: %{}

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -136,6 +136,10 @@ defmodule Electric.StackSupervisor do
                        type: :boolean,
                        default: Electric.Config.default(:shape_enable_suspend?)
                      ],
+                     shape_suspend_after: [
+                       type: :non_neg_integer,
+                       default: Electric.Config.default(:shape_suspend_after)
+                     ],
                      snapshot_timeout_to_first_data: [
                        type: :pos_integer,
                        default: Electric.Config.default(:snapshot_timeout_to_first_data)
@@ -351,6 +355,7 @@ defmodule Electric.StackSupervisor do
 
     shape_hibernate_after = Keyword.fetch!(config.tweaks, :shape_hibernate_after)
     shape_enable_suspend? = Keyword.fetch!(config.tweaks, :shape_enable_suspend?)
+    shape_suspend_after = Keyword.fetch!(config.tweaks, :shape_suspend_after)
     process_spawn_opts = Keyword.fetch!(config.tweaks, :process_spawn_opts)
 
     shape_cache_opts = [
@@ -400,6 +405,7 @@ defmodule Electric.StackSupervisor do
            inspector: inspector,
            shape_hibernate_after: shape_hibernate_after,
            shape_enable_suspend?: shape_enable_suspend?,
+           shape_suspend_after: shape_suspend_after,
            process_spawn_opts: process_spawn_opts,
            feature_flags: Map.get(config, :feature_flags, [])
          ]},

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -598,6 +598,12 @@ defmodule Electric.Shapes.ConsumerTest do
         Map.get(ctx, :hibernate_after, 10_000)
       )
 
+      Electric.StackConfig.put(
+        ctx.stack_id,
+        :shape_suspend_after,
+        Map.get(ctx, :shape_suspend_after, 10_000)
+      )
+
       if not Map.get(ctx, :allow_subqueries, true) do
         Electric.StackConfig.put(ctx.stack_id, :feature_flags, [])
       end
@@ -1375,7 +1381,8 @@ defmodule Electric.Shapes.ConsumerTest do
       assert_receive {:flush_boundary_updated, 301}, 1_000
     end
 
-    @tag hibernate_after: 10, with_pure_file_storage_opts: [flush_period: 1]
+    @tag hibernate_after: 10, shape_suspend_after: 10
+    @tag with_pure_file_storage_opts: [flush_period: 1]
     @tag suspend: true
     test "should terminate after :hibernate_after ms", ctx do
       register_as_replication_client(ctx.stack_id)
@@ -1409,7 +1416,8 @@ defmodule Electric.Shapes.ConsumerTest do
       refute Consumer.whereis(ctx.stack_id, shape_handle)
     end
 
-    @tag hibernate_after: 10, with_pure_file_storage_opts: [flush_period: 1]
+    @tag hibernate_after: 10, shape_suspend_after: 10
+    @tag with_pure_file_storage_opts: [flush_period: 1]
     @tag suspend: true
     test "should hibernate not suspend if has dependencies", ctx do
       register_as_replication_client(ctx.stack_id)
@@ -1564,7 +1572,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert Consumer.whereis(ctx.stack_id, shape_handle)
 
-      Shapes.ConsumerRegistry.enable_suspend(ctx.stack_id, 5, 10)
+      Shapes.ConsumerRegistry.enable_suspend(ctx.stack_id, 5, 5, 10)
 
       Process.sleep(60)
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -601,7 +601,7 @@ defmodule Electric.Shapes.ConsumerTest do
       Electric.StackConfig.put(
         ctx.stack_id,
         :shape_suspend_after,
-        Map.get(ctx, :shape_suspend_after, 10_000)
+        Map.get(ctx, :shape_suspend_after, 60_000)
       )
 
       if not Map.get(ctx, :allow_subqueries, true) do
@@ -1381,10 +1381,10 @@ defmodule Electric.Shapes.ConsumerTest do
       assert_receive {:flush_boundary_updated, 301}, 1_000
     end
 
-    @tag hibernate_after: 10, shape_suspend_after: 10
+    @tag hibernate_after: 10, shape_suspend_after: 20
     @tag with_pure_file_storage_opts: [flush_period: 1]
     @tag suspend: true
-    test "should terminate after :hibernate_after ms", ctx do
+    test "should suspend after hibernate_after + shape_suspend_after ms", ctx do
       register_as_replication_client(ctx.stack_id)
 
       {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, ctx.stack_id)
@@ -1572,6 +1572,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert Consumer.whereis(ctx.stack_id, shape_handle)
 
+      # hibernate_after=5, shape_suspend_after=5, jitter_period=10
       Shapes.ConsumerRegistry.enable_suspend(ctx.stack_id, 5, 5, 10)
 
       Process.sleep(60)
@@ -1579,6 +1580,118 @@ defmodule Electric.Shapes.ConsumerTest do
       assert_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}
 
       refute Consumer.whereis(ctx.stack_id, shape_handle)
+    end
+
+    @tag hibernate_after: 10, shape_suspend_after: 150, with_pure_file_storage_opts: [flush_period: 1]
+    @tag suspend: true
+    test "should hibernate first then suspend after shape_suspend_after ms", ctx do
+      register_as_replication_client(ctx.stack_id)
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, ctx.stack_id)
+      lsn1 = Lsn.from_integer(300)
+
+      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
+
+      consumer_pid = Consumer.whereis(ctx.stack_id, shape_handle)
+      assert is_pid(consumer_pid)
+      ref = Process.monitor(consumer_pid)
+
+      txn =
+        complete_txn_fragment(2, lsn1, [
+          %Changes.NewRecord{
+            relation: {"public", "test_table"},
+            record: %{"id" => "21"},
+            log_offset: LogOffset.new(lsn1, 0)
+          }
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
+
+      assert_receive {:flush_boundary_updated, 300}, 1_000
+
+      # Wait for hibernate_after (10ms) + small buffer
+      # Suspend won't happen until hibernate_after + shape_suspend_after = 10 + 150 = 160ms
+      Process.sleep(50)
+
+      # Should be hibernated, not suspended yet (we're at ~50ms, suspend at ~160ms)
+      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
+               Process.info(consumer_pid, :current_function)
+
+      refute_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}, 0
+
+      # Wait for shape_suspend_after (150ms from hibernate) to complete
+      # We're at ~50ms, need to wait another ~150ms to be past 160ms
+      Process.sleep(180)
+
+      # Now should be suspended
+      assert_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}
+
+      refute Consumer.whereis(ctx.stack_id, shape_handle)
+    end
+
+    @tag hibernate_after: 10, shape_suspend_after: 200, with_pure_file_storage_opts: [flush_period: 1]
+    @tag suspend: true
+    test "activity during hibernation cancels pending suspend", ctx do
+      register_as_replication_client(ctx.stack_id)
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, ctx.stack_id)
+      lsn1 = Lsn.from_integer(300)
+      lsn2 = Lsn.from_integer(301)
+
+      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
+
+      consumer_pid = Consumer.whereis(ctx.stack_id, shape_handle)
+      assert is_pid(consumer_pid)
+      ref = Process.monitor(consumer_pid)
+
+      txn1 =
+        complete_txn_fragment(2, lsn1, [
+          %Changes.NewRecord{
+            relation: {"public", "test_table"},
+            record: %{"id" => "21"},
+            log_offset: LogOffset.new(lsn1, 0)
+          }
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(txn1, ctx.stack_id)
+      assert_receive {:flush_boundary_updated, 300}, 1_000
+
+      # Wait for hibernate (hibernate_after=10ms + buffer)
+      Process.sleep(30)
+
+      # Should be hibernated
+      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
+               Process.info(consumer_pid, :current_function)
+
+      # Wait ~50ms so suspend timer has been running but not fired yet
+      # (shape_suspend_after=200ms, so we're at ~80ms total, well before 200ms)
+      Process.sleep(50)
+
+      # Send another transaction - this should cancel the suspend timer
+      txn2 =
+        complete_txn_fragment(3, lsn2, [
+          %Changes.NewRecord{
+            relation: {"public", "test_table"},
+            record: %{"id" => "22"},
+            log_offset: LogOffset.new(lsn2, 0)
+          }
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(txn2, ctx.stack_id)
+      assert_receive {:flush_boundary_updated, 301}, 1_000
+
+      # Wait past what would have been the original shape_suspend_after window
+      # Original timer started at ~30ms, would fire at ~230ms
+      # We're now at ~80ms, wait 160ms to reach ~240ms
+      # But new timer started at ~80ms, would fire at ~280ms
+      # So at ~240ms the process should still be alive
+      Process.sleep(160)
+
+      # Should NOT have suspended because activity reset the timer
+      refute_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}, 0
+
+      # Process should still be alive (hibernated again)
+      assert Process.alive?(consumer_pid)
     end
 
     @tag with_pure_file_storage_opts: [compaction_period: 5, keep_complete_chunks: 133]

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -120,8 +120,7 @@ defmodule Electric.Shapes.ConsumerTest do
   end
 
   # Repeatedly evaluate `fun` until it returns `{:ok, value}` (returning value)
-  # or `timeout` ms elapse (failing the test). The 1ms tick is the only sleep
-  # involved and it ends the moment the condition holds.
+  # or `timeout` ms elapse (failing the test).
   defp poll_until(timeout, fun) do
     deadline = System.monotonic_time(:millisecond) + timeout
     do_poll_until(deadline, fun)
@@ -134,7 +133,7 @@ defmodule Electric.Shapes.ConsumerTest do
 
       :retry ->
         if System.monotonic_time(:millisecond) < deadline do
-          Process.sleep(1)
+          Process.sleep(50)
           do_poll_until(deadline, fun)
         else
           flunk("poll_until/2 timed out waiting for condition")

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -105,6 +105,43 @@ defmodule Electric.Shapes.ConsumerTest do
     Lsn.from_integer(offset)
   end
 
+  # Block until `pid` is hibernating, then return its armed suspend-timer ref
+  # (or nil if none is armed).
+  defp await_hibernation(pid, timeout \\ 2_000) do
+    poll_until(timeout, fn ->
+      case Process.info(pid, :current_function) do
+        {:current_function, {:gen_server, :loop_hibernate, _}} ->
+          {:ok, :sys.get_state(pid).suspend_timer}
+
+        _ ->
+          :retry
+      end
+    end)
+  end
+
+  # Repeatedly evaluate `fun` until it returns `{:ok, value}` (returning value)
+  # or `timeout` ms elapse (failing the test). The 1ms tick is the only sleep
+  # involved and it ends the moment the condition holds.
+  defp poll_until(timeout, fun) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_poll_until(deadline, fun)
+  end
+
+  defp do_poll_until(deadline, fun) do
+    case fun.() do
+      {:ok, value} ->
+        value
+
+      :retry ->
+        if System.monotonic_time(:millisecond) < deadline do
+          Process.sleep(1)
+          do_poll_until(deadline, fun)
+        else
+          flunk("poll_until/2 timed out waiting for condition")
+        end
+    end
+  end
+
   describe "event handling" do
     setup [
       :with_registry,
@@ -1409,9 +1446,8 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert_receive {:flush_boundary_updated, 300}, 1_000
 
-      Process.sleep(60)
-
-      assert_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}
+      # The consumer hibernates, then suspends shape_suspend_after later;
+      assert_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}, 200
 
       refute Consumer.whereis(ctx.stack_id, shape_handle)
     end
@@ -1449,22 +1485,13 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert_receive {:flush_boundary_updated, 300}, 1_000
 
-      Process.sleep(100)
-
-      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
-               Process.info(consumer_pid, :current_function)
-
-      Process.sleep(20)
-
-      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
-               Process.info(consumer_pid, :current_function)
+      # A shape with dependencies hibernates but never arms a suspend timer
+      # (consumer_can_suspend? is false), so it can never suspend. Observing a
+      # nil suspend_timer once hibernated proves this deterministically.
+      assert is_nil(await_hibernation(consumer_pid))
 
       dependent_consumer_pid = Consumer.whereis(ctx.stack_id, dependent_shape_handle)
-
-      Process.sleep(20)
-
-      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
-               Process.info(dependent_consumer_pid, :current_function)
+      assert is_nil(await_hibernation(dependent_consumer_pid))
 
       assert is_pid(Consumer.whereis(ctx.stack_id, shape_handle))
     end
@@ -1568,19 +1595,16 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert_receive {:flush_boundary_updated, 300}, 1_000
 
-      Process.sleep(60)
-
-      refute_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}
-
+      # Suspend is disabled (@tag suspend: false), so the consumer never suspends
+      # on its own and stays alive.
+      refute_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}, 100
       assert Consumer.whereis(ctx.stack_id, shape_handle)
 
       # hibernate_after=5, shape_suspend_after=5, jitter_period=10
       Shapes.ConsumerRegistry.enable_suspend(ctx.stack_id, 5, 5, 10)
 
-      Process.sleep(60)
-
-      assert_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}
-
+      # Enabling suspend on the live consumer makes it suspend on the next cycle.
+      assert_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}, 200
       refute Consumer.whereis(ctx.stack_id, shape_handle)
     end
 
@@ -1613,22 +1637,14 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert_receive {:flush_boundary_updated, 300}, 1_000
 
-      # Wait for hibernate_after (10ms) + small buffer
-      # Suspend won't happen until hibernate_after + shape_suspend_after = 10 + 150 = 160ms
-      Process.sleep(50)
+      # The consumer hibernates first (for GC) and arms a suspend timer rather
+      # than suspending directly. Observing an armed timer while hibernated
+      # proves the "hibernate, then suspend" ordering without racing the clock.
+      assert is_reference(await_hibernation(consumer_pid))
+      assert Process.alive?(consumer_pid)
 
-      # Should be hibernated, not suspended yet (we're at ~50ms, suspend at ~160ms)
-      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
-               Process.info(consumer_pid, :current_function)
-
-      refute_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}, 0
-
-      # Wait for shape_suspend_after (150ms from hibernate) to complete
-      # We're at ~50ms, need to wait another ~150ms to be past 160ms
-      Process.sleep(180)
-
-      # Now should be suspended
-      assert_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}
+      # It then suspends once shape_suspend_after elapses.
+      assert_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}, 300
 
       refute Consumer.whereis(ctx.stack_id, shape_handle)
     end
@@ -1662,18 +1678,11 @@ defmodule Electric.Shapes.ConsumerTest do
       assert :ok = ShapeLogCollector.handle_event(txn1, ctx.stack_id)
       assert_receive {:flush_boundary_updated, 300}, 1_000
 
-      # Wait for hibernate (hibernate_after=10ms + buffer)
-      Process.sleep(30)
+      # Once hibernated, a suspend timer is armed.
+      ref1 = await_hibernation(consumer_pid)
+      assert is_reference(ref1)
 
-      # Should be hibernated
-      assert {:current_function, {:gen_server, :loop_hibernate, 4}} =
-               Process.info(consumer_pid, :current_function)
-
-      # Wait ~50ms so suspend timer has been running but not fired yet
-      # (shape_suspend_after=200ms, so we're at ~80ms total, well before 200ms)
-      Process.sleep(50)
-
-      # Send another transaction - this should cancel the suspend timer
+      # Activity (a new transaction) must cancel that timer.
       txn2 =
         complete_txn_fragment(3, lsn2, [
           %Changes.NewRecord{
@@ -1686,16 +1695,15 @@ defmodule Electric.Shapes.ConsumerTest do
       assert :ok = ShapeLogCollector.handle_event(txn2, ctx.stack_id)
       assert_receive {:flush_boundary_updated, 301}, 1_000
 
-      # Wait past what would have been the original shape_suspend_after window.
-      # The original timer was armed when the consumer first hibernated (~10ms
-      # after txn1, i.e. hibernate_after later), so it would have fired at ~210ms.
-      # The activity at ~80ms cancelled it; the consumer re-hibernates ~10ms after
-      # that activity, arming a new timer at ~90ms that fires at ~290ms.
-      # We're now at ~80ms; wait 160ms to reach ~240ms, past the original ~210ms
-      # deadline but before the new ~290ms one, so the process should still be alive.
-      Process.sleep(160)
+      # After re-hibernating, a *fresh* timer is armed and the original one reads
+      # as cancelled - proving the activity reset the suspend cycle rather than
+      # letting the original timer fire.
+      ref2 = await_hibernation(consumer_pid)
+      assert is_reference(ref2)
+      assert ref2 != ref1
+      assert :erlang.read_timer(ref1) == false
 
-      # Should NOT have suspended because activity reset the timer
+      # No suspend happened.
       refute_receive {:DOWN, ^ref, :process, ^consumer_pid, {:shutdown, :suspend}}, 0
 
       # Process should still be alive (hibernated again)

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -1469,7 +1469,9 @@ defmodule Electric.Shapes.ConsumerTest do
       assert is_pid(Consumer.whereis(ctx.stack_id, shape_handle))
     end
 
-    @tag hibernate_after: 10, with_pure_file_storage_opts: [flush_period: 1]
+    @tag hibernate_after: 10,
+         shape_suspend_after: 20,
+         with_pure_file_storage_opts: [flush_period: 1]
     @tag suspend: true
     test "should hibernate not suspend while a multi-fragment transaction is pending", ctx do
       register_as_replication_client(ctx.stack_id)

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -1686,11 +1686,13 @@ defmodule Electric.Shapes.ConsumerTest do
       assert :ok = ShapeLogCollector.handle_event(txn2, ctx.stack_id)
       assert_receive {:flush_boundary_updated, 301}, 1_000
 
-      # Wait past what would have been the original shape_suspend_after window
-      # Original timer started at ~30ms, would fire at ~230ms
-      # We're now at ~80ms, wait 160ms to reach ~240ms
-      # But new timer started at ~80ms, would fire at ~280ms
-      # So at ~240ms the process should still be alive
+      # Wait past what would have been the original shape_suspend_after window.
+      # The original timer was armed when the consumer first hibernated (~10ms
+      # after txn1, i.e. hibernate_after later), so it would have fired at ~210ms.
+      # The activity at ~80ms cancelled it; the consumer re-hibernates ~10ms after
+      # that activity, arming a new timer at ~90ms that fires at ~290ms.
+      # We're now at ~80ms; wait 160ms to reach ~240ms, past the original ~210ms
+      # deadline but before the new ~290ms one, so the process should still be alive.
       Process.sleep(160)
 
       # Should NOT have suspended because activity reset the timer

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -1582,7 +1582,9 @@ defmodule Electric.Shapes.ConsumerTest do
       refute Consumer.whereis(ctx.stack_id, shape_handle)
     end
 
-    @tag hibernate_after: 10, shape_suspend_after: 150, with_pure_file_storage_opts: [flush_period: 1]
+    @tag hibernate_after: 10,
+         shape_suspend_after: 150,
+         with_pure_file_storage_opts: [flush_period: 1]
     @tag suspend: true
     test "should hibernate first then suspend after shape_suspend_after ms", ctx do
       register_as_replication_client(ctx.stack_id)
@@ -1629,7 +1631,9 @@ defmodule Electric.Shapes.ConsumerTest do
       refute Consumer.whereis(ctx.stack_id, shape_handle)
     end
 
-    @tag hibernate_after: 10, shape_suspend_after: 200, with_pure_file_storage_opts: [flush_period: 1]
+    @tag hibernate_after: 10,
+         shape_suspend_after: 200,
+         with_pure_file_storage_opts: [flush_period: 1]
     @tag suspend: true
     test "activity during hibernation cancels pending suspend", ctx do
       register_as_replication_client(ctx.stack_id)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -110,6 +110,7 @@ defmodule Support.ComponentSetup do
              shape_changes_registry:
                Map.get(ctx, :registry, Electric.StackSupervisor.registry_name(stack_id)),
              shape_hibernate_after: Map.get(ctx, :shape_hibernate_after, 1_000),
+             shape_suspend_after: Map.get(ctx, :shape_suspend_after, 1_000),
              shape_enable_suspend?: Map.get(ctx, :suspend, false),
              feature_flags: Electric.Config.get_env(:feature_flags),
              process_spawn_opts: Map.get(ctx, :process_spawn_opts, %{})


### PR DESCRIPTION
## Summary

When consumer suspend is enabled, consumers now hibernate first (triggering GC) before eventually suspending (terminating). Previously, consumers went directly to suspend without hibernating, and due to a large timeout for suspend, consumer processes could hold onto garbage memory for longer than necessary.

- Add `shape_suspend_after` config (default 10 minutes) - delay between hibernation and suspension
- Consumer hibernates on `hibernate_after` timeout, schedules suspend timer
- Suspend timer fires after `suspend_after` ms, terminates process if still idle
- Any activity cancels the pending suspend timer, restarting the cycle
- Update `ConsumerRegistry.enable_suspend/4` to include suspend_after parameter

🤖 Generated with [Claude Code](https://claude.ai/code)
