### PR TITLE
Add queued inbox message modes for agents

### DIFF
--- a/AGENTS_INBOX_DELIVERY_MODES_PLAN.md
+++ b/AGENTS_INBOX_DELIVERY_MODES_PLAN.md
@@ -1,0 +1,516 @@
+# Agents Inbox Message Modes Plan
+
+## Goal
+
+Add first-class shared message queueing and steering to Electric Agents while keeping `/send` as the canonical way to send messages to an entity.
+
+The core model is:
+
+- `inbox` contains messages sent to an entity.
+- Each inbox message has a processing `mode` and lifecycle `status`.
+- Pending queued messages are synced across devices and editable before processing.
+- Processed messages are immutable conversation history and are visible to the agent runtime.
+- Steer messages interrupt the current generation and restart the loop around the promoted message.
+
+This should be a framework-level capability, with Horton as the polished default experience rather than a one-off special case.
+
+## Current State
+
+Today, `POST /{type}/{name}/send` appends an inbox insert directly to the entity main stream. The UI optimistically inserts the same shape into `db.collections.inbox`, so the message appears in the chat immediately.
+
+The runtime wakes on inbox inserts. Horton then calls `ctx.agent.run()`, and the runtime derives the trigger text from the current inbox row while history comes from `ctx.timelineMessages()`.
+
+There is no durable pending state today. Once a message is appended to `inbox`, it is treated as committed conversation history.
+
+## Proposed Model
+
+Extend inbox messages with processing metadata:
+
+```ts
+type InboxMode = 'immediate' | 'queued' | 'steer'
+type InboxStatus = 'pending' | 'processed' | 'cancelled'
+
+type InboxMessage = {
+  // Existing inbox fields.
+  key: string
+  from: string
+  payload: unknown
+  timestamp: string
+  message_type?: string
+
+  // New processing metadata.
+  mode: InboxMode
+  status: InboxStatus
+  position?: string
+  processed_at?: string
+  cancelled_at?: string
+}
+```
+
+Default behavior should preserve the existing semantics:
+
+- If `mode` is omitted, treat it as `immediate`.
+- If `status` is omitted on existing rows, treat it as `processed`.
+
+This allows existing stream history and existing callers to keep working while newer clients can opt into queueing and steering.
+
+## Processing Semantics
+
+### Immediate
+
+`mode: 'immediate'` is the current behavior.
+
+`/send` creates a processed inbox message and the runtime wakes normally:
+
+```text
+/send { mode: 'immediate', payload }
+-> inbox insert { mode: 'immediate', status: 'processed' }
+-> runtime handles inbox row
+```
+
+Use cases:
+
+- Existing API callers.
+- System messages.
+- Machine-to-machine messages.
+- Worker/child entity messages.
+- Any message type that should not wait behind a user queue.
+
+### Queued
+
+`mode: 'queued'` appends a shared pending inbox message:
+
+```text
+/send { mode: 'queued', payload }
+-> inbox insert { mode: 'queued', status: 'pending', position }
+-> UI renders pending message
+-> runtime ignores it until promotion
+```
+
+While pending, the message can be edited, reordered, cancelled, or promoted to steer.
+
+Normal promotion happens when the entity is ready for another user input:
+
+```text
+head pending queued message
+-> inbox update { status: 'processed', processed_at }
+-> runtime handles that message as the next trigger
+```
+
+Pending queued messages must not be included in `ctx.timelineMessages()` or default LLM context.
+
+### Queue Position
+
+`position` should be an opaque, lexicographically sortable string used only for ordering pending queued messages. The current recommendation is to use fractional indexing, similar to how collaborative list UIs order cards without renumbering the whole list.
+
+Sorting rule:
+
+```text
+pending queued messages
+-> sort by position asc
+-> then created stream order asc
+-> then key asc
+```
+
+The tie-breakers matter because multiple devices may submit or reorder at the same time. Runtime promotion must be deterministic even if two rows temporarily share a position.
+
+Suggested behavior:
+
+- New queued message with no explicit `position`: server assigns a position after the current queue tail.
+- Reorder to top: client/server assigns a position before the current first pending message.
+- Reorder between two messages: client/server assigns a position between the previous and next positions.
+- Reorder to bottom: client/server assigns a position after the current last pending message.
+- Missing `position` on a pending message: project it as after all positioned pending messages, ordered by stream order.
+
+The API should treat `position` as opaque. Clients can send a proposed position for optimistic UI, but the server/runtime should be allowed to normalize or replace it in the appended stream event.
+
+Example:
+
+```text
+A position "a0"
+B position "m0"
+C position "z0"
+
+move C between A and B -> C position "g0"
+```
+
+We should not use `_seq` as the primary queue order. `_seq` is the append order of stream events, which is perfect for transcript history but poor for reordering because moving an item would require projection tricks or full renumbering. `position` makes reorder an ordinary update to the pending message.
+
+### Steer
+
+`mode: 'steer'` means "process this now, interrupt current work, and restart the loop."
+
+For a new message:
+
+```text
+/send { mode: 'steer', payload }
+-> inbox insert { mode: 'steer', status: 'processed' }
+-> interrupt active generation
+-> restart handler with steer message as trigger
+```
+
+For an existing queued message:
+
+```text
+pending queued message
+-> update same row { mode: 'steer', status: 'processed', processed_at }
+-> interrupt active generation
+-> restart handler with that message as trigger
+```
+
+Steer messages become committed history immediately. They should not remain editable once processed.
+
+## State Transitions
+
+Allowed transitions:
+
+```text
+pending queued -> pending queued      edit/reorder
+pending queued -> cancelled           delete/cancel
+pending queued -> processed queued    normal promotion
+pending queued -> processed steer     steer now
+processed immediate                   send now
+processed steer                       steer now
+```
+
+Disallowed by default:
+
+```text
+processed -> pending
+processed -> cancelled
+processed -> edited payload
+cancelled -> processed
+```
+
+The invariant is:
+
+```text
+pending = editable intent
+processed = immutable transcript history
+cancelled = hidden or visibly cancelled queue history, not agent-visible
+```
+
+## API Shape
+
+Treat inbox messages as a REST-style resource. Sending a message creates an inbox row; editing, reordering, cancelling, processing, and steering are updates to that row.
+
+The clean resource shape is:
+
+```http
+POST /{type}/{name}/inbox
+PATCH /{type}/{name}/inbox/{messageKey}
+DELETE /{type}/{name}/inbox/{messageKey}
+```
+
+`POST` creates an inbox row:
+
+```ts
+type SendRequest = {
+  from?: string
+  key?: string
+  type?: string
+  payload?: unknown
+  mode?: 'immediate' | 'queued' | 'steer'
+  position?: string
+}
+```
+
+`from` and `payload` remain required after validation.
+
+`PATCH` modifies a pending row or performs controlled status transitions:
+
+These endpoints append updates to the entity stream. They should reject changes to processed or cancelled messages unless an explicit future admin/debug override is introduced.
+
+Patch examples:
+
+```ts
+// Edit payload while pending.
+{ payload: { text: 'updated prompt' } }
+
+// Reorder while pending.
+{ position: 'b7' }
+
+// Mark the head queued message as processed.
+{ status: 'processed' }
+
+// Promote queued message to steer and process it immediately.
+{ mode: 'steer', status: 'processed' }
+```
+
+`DELETE` cancels a pending row. At the stream layer this still produces a delete event for the inbox collection; it should not physically rewrite history.
+
+`POST /{type}/{name}/send` can remain as a compatibility alias for `POST /{type}/{name}/inbox`, or we can make the breaking rename now and move clients to `/inbox`.
+
+Steer may still deserve a dedicated helper route/action because it has side effects beyond row mutation: it requests cancellation and loop restart. The underlying state transition should still be the same inbox row update.
+
+## Runtime Changes
+
+### Inbox Schema
+
+Rename the built-in event/collection type from `message_received` to `inbox` so the runtime names the thing being inserted/updated/deleted rather than the event that happened.
+
+Update the built-in `inbox` schema to include:
+
+- `mode`
+- `status`
+- `position`
+- `processed_at`
+- `cancelled_at`
+
+Default old rows to `mode: 'immediate'` and `status: 'processed'` in projections.
+
+### Timeline Projection
+
+Split inbox handling into two projections:
+
+- `processedInbox`: messages with `status: 'processed'`.
+- `pendingInbox`: messages with `status: 'pending'`.
+
+`buildTimelineEntries()` should render processed messages in the existing conversation timeline. Pending messages can be returned separately or included as explicit pending sections so the UI can render a queue affordance without confusing them with committed conversation history.
+
+`timelineMessages()` and `timelineToMessages()` must only include processed messages.
+
+### Wake Selection
+
+Immediate processed messages should continue to wake the entity.
+
+Queued pending inserts should not invoke the handler as user input. They may wake or notify the runtime's queue manager, but they should not be selected by `getTriggerMessageText()` until promoted to processed.
+
+Promotion should be idempotent and claim exactly one pending message at a time.
+
+### Queue Promotion
+
+When the entity is idle or the current handler pass has completed, the runtime should inspect pending queued inbox messages ordered by `position` and promote the head message.
+
+Promotion appends an update event for the existing inbox row:
+
+```ts
+{
+  status: 'processed',
+  processed_at: new Date().toISOString()
+}
+```
+
+The promoted message then becomes the next message trigger.
+
+Concurrency requirements:
+
+- Only one worker/runtime instance may promote a given message.
+- Promotion must be idempotent if retried.
+- Reordering/editing should be rejected or conflict if the message was already processed by the time the mutation is processed.
+
+### Steer Interruption
+
+Steer requires cancellation support across the active generation loop.
+
+Runtime responsibilities:
+
+- Persist the steer message as processed.
+- Signal the active wake/run to stop.
+- Mark the current run as interrupted/cancelled, or add an interruption event that the timeline can render.
+- Abort model streaming if supported.
+- Abort or detach long-running tools where possible.
+- Restart processing with the steer message as the current trigger.
+
+This is the largest part of the feature and should be implemented after basic queued processing.
+
+## Entity Type Configuration
+
+This should be framework-level, not Horton-specific.
+
+Entity definitions should be able to express default processing behavior:
+
+```ts
+messageProcessing: {
+  defaultMode: 'immediate' | 'queued'
+  allowSteer?: boolean
+}
+```
+
+Potential later extension:
+
+```ts
+messageProcessing: {
+  defaultMode: 'queued',
+  byType: {
+    prompt: { defaultMode: 'queued', allowSteer: true },
+    control: { defaultMode: 'immediate', allowSteer: false },
+  },
+}
+```
+
+Horton should opt into:
+
+```ts
+messageProcessing: {
+  defaultMode: 'queued',
+  allowSteer: true,
+}
+```
+
+Other agents can remain immediate by default.
+
+## UI Changes
+
+### Message Input
+
+The composer should choose a mode based on entity configuration and state:
+
+- If entity defaults to immediate, send immediate.
+- If entity defaults to queued and the entity is busy, send queued.
+- If entity defaults to queued and no generation is active, either send immediate or queued-then-promote immediately. Prefer the latter if we want one consistent path.
+
+For Horton:
+
+- Normal submit uses queued processing.
+- If idle, the queued message is promoted immediately by the runtime.
+- If busy, it appears in the shared pending queue.
+- A "steer now" action promotes a pending queued message to steer.
+
+### Pending Queue UI
+
+Render pending inbox messages in `packages/agents-server-ui` as an expanded composer drawer above the chat input, similar to Cursor's queued follow-up UI.
+
+The existing `MessageInput` already accepts a `drawer` slot for content above the composer. Extend that pattern so the chat view can render a pending-message drawer that shares the composer width and visually attaches to the input.
+
+Suggested layout:
+
+```text
+⌄ 1 Queued
+  ○ Update the docs section...
+                         [edit] [steer] [delete]
+```
+
+Behavior:
+
+- The drawer is hidden when there are no pending inbox messages.
+- The drawer header shows the count, e.g. `1 Queued` or `3 Queued`.
+- Each row shows a compact single-line preview of the pending message payload.
+- Rows expose edit, steer, and delete controls.
+- The steer control can use an upward arrow icon and should promote that pending message to `mode: 'steer'` / `status: 'processed'`.
+- Delete issues the inbox delete/cancel action for pending messages.
+- Reorder can be added after the base drawer exists, using drag handles or up/down controls.
+
+Editing should reuse the main composer rather than opening an inline editor. Clicking edit:
+
+- Copies the pending message text/payload back into the input.
+- Puts the composer into an "editing queued message" state keyed by the inbox message key.
+- Shows a clear label above or inside the composer, e.g. `Editing queued message`, with a cancel affordance.
+- Changes the submit action from `POST /inbox` to `PATCH /inbox/{messageKey}`.
+- On successful save, clears the editing state and empties the composer.
+- Cancel editing restores normal compose mode without modifying the pending row.
+
+The first-class Horton path can start with text payloads (`{ text }`). The component should still be structured around generic inbox rows so other agents can provide typed payload renderers later.
+
+Required controls:
+
+- Edit payload.
+- Delete/cancel.
+- Reorder.
+- Steer now.
+
+The UI should be driven by stream state, not local-only draft state, so multiple devices see the same queue.
+
+### Timeline UI
+
+Processed messages render as today.
+
+Interrupted runs need a visible terminal state, for example:
+
+```text
+Interrupted by steer message
+```
+
+Pending messages should not look identical to processed chat bubbles. They are planned inputs, not transcript history.
+
+## Backwards Compatibility
+
+If we choose to preserve compatibility:
+
+- Existing `/send` calls without `mode` remain immediate.
+- Existing inbox rows without `mode` or `status` project as processed immediate.
+- Existing agents continue consuming inbox rows as before.
+
+If we choose a breaking cleanup:
+
+- Rename the logical collection from `inbox` to `messages`.
+- Make processing status mandatory.
+- Require clients to choose or inherit a mode.
+- Provide migration only for active development users.
+
+Given the product is early, either route is possible. The lower-risk path is additive metadata with compatibility defaults.
+
+## Open Questions
+
+- Should pending messages live in the same `inbox` collection permanently, or should we eventually rename the concept to `messages` for clarity?
+- Should normal queued promotion update the same row to processed, or append a separate processing event? Same-row updates are simpler for UI identity; separate events preserve stricter event sourcing.
+- Should `/send` with `mode: 'queued'` always queue, even when idle, or should the server/runtime immediately deliver it when possible?
+- Should cancelled pending messages remain visible in history, or disappear from default UI projections?
+- What is the exact terminal run status for interrupted generations: `cancelled`, `interrupted`, or `failed` with a reason?
+- How should long-running tools respond to steer: abort, finish in background, or detach and ignore output?
+
+## Implementation Phases
+
+### Phase 1: Processing Metadata
+
+- Extend inbox schema with `mode`, `status`, `position`, and lifecycle timestamps.
+- Add compatibility defaults for old rows.
+- Update timeline/context projections to only expose processed messages to agents.
+- Keep `/send` defaulting to immediate.
+
+### Phase 2: Shared Queued Messages
+
+- Add `/send { mode: 'queued' }`.
+- Add pending message edit/reorder/cancel endpoints.
+- Render pending messages in the UI from stream state.
+- Add runtime promotion of one pending queued message at a time.
+- Configure Horton to default user prompts to queued processing.
+
+### Phase 3: Steer
+
+- Add `/send { mode: 'steer' }`.
+- Add "promote queued message to steer" endpoint/action.
+- Add cancellation signal plumbing through runtime, model adapter, and tools.
+- Add interrupted run timeline rendering.
+- Restart the loop with the steer message as trigger.
+
+### Phase 4: Framework Polish
+
+- Add entity-level processing configuration.
+- Support per-message-type processing policy.
+- Document patterns for immediate, queued, and steer processing.
+- Add conformance tests for queue ordering, edit conflicts, multi-device sync, and steer interruption.
+
+## Test Plan
+
+Runtime tests:
+
+- Old inbox rows without processing metadata are treated as processed.
+- `timelineMessages()` excludes pending and cancelled messages.
+- Queued messages promote in position order.
+- Editing a pending message changes the eventual processed payload.
+- Reordering pending messages changes promotion order.
+- Cancelling a pending message prevents processing.
+- Concurrent promotion attempts deliver only one message once.
+
+Server tests:
+
+- `/send` without mode remains immediate.
+- `/send` with queued creates pending inbox message.
+- Pending edit/reorder/cancel endpoints reject processed messages.
+- Steer endpoint transitions pending queued to processed steer.
+
+UI tests:
+
+- Pending messages render from stream state.
+- Pending edits survive refresh and appear on another client.
+- Reorder controls update shared order.
+- Processed messages move from pending queue to transcript.
+- Steer now removes the pending item and shows interruption state.
+
+Horton tests:
+
+- Default prompt processing queues while a run is active.
+- Horton only sees processed messages in context.
+- Multiple queued prompts are handled one at a time.
+- Steer interrupts current generation and restarts with the selected message.

--- a/packages/agents-runtime/src/context-factory.ts
+++ b/packages/agents-runtime/src/context-factory.ts
@@ -150,16 +150,24 @@ function getTriggerMessageText(
   events: Array<ChangeEvent>,
   wakeOffset: string
 ): string {
-  if (wakeEvent.type === `message_received`) {
+  if (wakeEvent.type === `inbox` || wakeEvent.type === `message_received`) {
     let latestPayload: unknown = wakeEvent.payload
     for (let index = events.length - 1; index >= 0; index--) {
       const event = events[index]!
-      if (event.type !== `message_received`) {
+      if (event.type !== `inbox` && event.type !== `message_received`) {
         continue
       }
 
-      const payload = (event.value as { payload?: unknown } | undefined)
-        ?.payload
+      const value = event.value as
+        | {
+            payload?: unknown
+            status?: `pending` | `processed` | `cancelled`
+          }
+        | undefined
+      if (value?.status === `cancelled`) {
+        continue
+      }
+      const payload = value?.payload
       if (latestPayload === undefined) {
         latestPayload = payload
       }

--- a/packages/agents-runtime/src/entity-schema.ts
+++ b/packages/agents-runtime/src/entity-schema.ts
@@ -135,7 +135,7 @@ type MessageReceivedValue = {
   payload?: unknown
   timestamp?: string
   message_type?: string
-  mode?: `immediate` | `queued` | `steer`
+  mode?: `immediate` | `queued` | `paused` | `steer`
   status?: `pending` | `processed` | `cancelled`
   position?: string
   processed_at?: string
@@ -400,7 +400,7 @@ function createMessageReceivedSchema(): Schema<MessageReceivedValue> {
     payload: z.unknown().optional(),
     timestamp: z.string().optional(),
     message_type: z.string().optional(),
-    mode: z.enum([`immediate`, `queued`, `steer`]).optional(),
+    mode: z.enum([`immediate`, `queued`, `paused`, `steer`]).optional(),
     status: z.enum([`pending`, `processed`, `cancelled`]).optional(),
     position: z.string().optional(),
     processed_at: z.string().optional(),

--- a/packages/agents-runtime/src/entity-schema.ts
+++ b/packages/agents-runtime/src/entity-schema.ts
@@ -131,10 +131,15 @@ type ErrorEventValue = {
 }
 type MessageReceivedValue = {
   key?: string
-  from: string
+  from?: string
   payload?: unknown
-  timestamp: string
+  timestamp?: string
   message_type?: string
+  mode?: `immediate` | `queued` | `steer`
+  status?: `pending` | `processed` | `cancelled`
+  position?: string
+  processed_at?: string
+  cancelled_at?: string
 }
 type WakeEntryValue = {
   key?: string
@@ -391,10 +396,15 @@ function createErrorEventSchema(): Schema<ErrorEventValue> {
 function createMessageReceivedSchema(): Schema<MessageReceivedValue> {
   return z.object({
     key: z.string().optional(),
-    from: z.string(),
+    from: z.string().optional(),
     payload: z.unknown().optional(),
-    timestamp: z.string(),
+    timestamp: z.string().optional(),
     message_type: z.string().optional(),
+    mode: z.enum([`immediate`, `queued`, `steer`]).optional(),
+    status: z.enum([`pending`, `processed`, `cancelled`]).optional(),
+    position: z.string().optional(),
+    processed_at: z.string().optional(),
+    cancelled_at: z.string().optional(),
   })
 }
 
@@ -671,6 +681,8 @@ export const BUILT_IN_EVENT_SCHEMAS = {
   reasoning:
     createReasoningSchema() as unknown as BuiltInEntitySchema<Reasoning>,
   error: createErrorEventSchema() as unknown as BuiltInEntitySchema<ErrorEvent>,
+  inbox:
+    createMessageReceivedSchema() as unknown as BuiltInEntitySchema<MessageReceived>,
   message_received:
     createMessageReceivedSchema() as unknown as BuiltInEntitySchema<MessageReceived>,
   wake: createWakeSchema() as unknown as BuiltInEntitySchema<WakeEntry>,
@@ -760,7 +772,7 @@ export const builtInCollections: EntityCollectionsDefinition = {
   inbox: {
     schema:
       BUILT_IN_EVENT_SCHEMAS.message_received as StandardSchemaV1<MessageReceived>,
-    type: `message_received`,
+    type: `inbox`,
     primaryKey: `key`,
   },
   wakes: {

--- a/packages/agents-runtime/src/entity-stream-db.ts
+++ b/packages/agents-runtime/src/entity-stream-db.ts
@@ -139,6 +139,11 @@ export function createEntityStreamDB(
     collectionNameByEventType.set(def.type, name)
     rowOffsetsByCollection.set(name, new Map())
   }
+  // Back-compat for streams written before the inbox collection's event type
+  // was renamed from the event-ish `message_received` to the collection name.
+  if (collectionNameByEventType.get(`inbox`) === `inbox`) {
+    collectionNameByEventType.set(`message_received`, `inbox`)
+  }
 
   // Build a reverse map from TanStack DB collection id to schema key
   const collIdToSchemaKey: Record<string, string> = {}

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -109,7 +109,7 @@ export interface IncludesInboxMessage {
   from: string
   payload: unknown
   timestamp: string
-  mode?: `immediate` | `queued` | `steer`
+  mode?: `immediate` | `queued` | `paused` | `steer`
   status?: `pending` | `processed` | `cancelled`
   position?: string
   processed_at?: string

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -109,6 +109,11 @@ export interface IncludesInboxMessage {
   from: string
   payload: unknown
   timestamp: string
+  mode?: `immediate` | `queued` | `steer`
+  status?: `pending` | `processed` | `cancelled`
+  position?: string
+  processed_at?: string
+  cancelled_at?: string
 }
 
 export interface IncludesWakeMessage {
@@ -654,9 +659,14 @@ function buildInboxMessages(
   return [...inbox].sort(compareTimelineOrder).map((message) => ({
     key: message.key,
     order: message.order,
-    from: message.from,
+    from: message.from ?? `unknown`,
     payload: message.payload,
-    timestamp: message.timestamp,
+    timestamp: message.timestamp ?? new Date(0).toISOString(),
+    mode: message.mode ?? `immediate`,
+    status: message.status ?? `processed`,
+    position: message.position,
+    processed_at: message.processed_at,
+    cancelled_at: message.cancelled_at,
   }))
 }
 
@@ -953,6 +963,11 @@ const getEntityInboxCollection = cachedCollectionFactory((db: EntityStreamDB) =>
         from: inbox.from,
         payload: inbox.payload,
         timestamp: inbox.timestamp,
+        mode: coalesce(inbox.mode, `immediate`),
+        status: coalesce(inbox.status, `processed`),
+        position: inbox.position,
+        processed_at: inbox.processed_at,
+        cancelled_at: inbox.cancelled_at,
       })),
   })
 )
@@ -1087,6 +1102,11 @@ export function createEntityIncludesQuery(
             from: inbox.from,
             payload: inbox.payload,
             timestamp: inbox.timestamp,
+            mode: inbox.mode,
+            status: inbox.status,
+            position: inbox.position,
+            processed_at: inbox.processed_at,
+            cancelled_at: inbox.cancelled_at,
           }))
       ),
       wakes: toArray(

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -136,7 +136,7 @@ function changeEventToWakeEvent(
       | {
           from?: string
           payload?: unknown
-          mode?: `immediate` | `queued` | `steer`
+          mode?: `immediate` | `queued` | `paused` | `steer`
           message_type?: string
           status?: `pending` | `processed` | `cancelled`
         }
@@ -144,7 +144,11 @@ function changeEventToWakeEvent(
     if (value?.status === `cancelled`) {
       return null
     }
-    if (value?.payload === undefined && value?.mode !== `steer`) {
+    if (
+      value?.payload === undefined &&
+      value?.mode !== `queued` &&
+      value?.mode !== `steer`
+    ) {
       return null
     }
     return {
@@ -491,13 +495,15 @@ export async function processWebhookWake(
         const value = event.value as
           | {
               payload?: unknown
-              mode?: `immediate` | `queued` | `steer`
+              mode?: `immediate` | `queued` | `paused` | `steer`
               status?: `pending` | `processed` | `cancelled`
             }
           | undefined
         if (
           value?.status !== `cancelled` &&
-          (value?.payload !== undefined || value?.mode === `steer`)
+          (value?.payload !== undefined ||
+            value?.mode === `queued` ||
+            value?.mode === `steer`)
         ) {
           return `inbox`
         }
@@ -1262,14 +1268,16 @@ export async function processWebhookWake(
       }
     }
     let currentWakeIsPromotedQueueMessage = false
+    let queueHeadPaused = false
     const promotedQueuedMessageKeys = new Set<string>()
     const promoteNextPendingInboxMessage = async (): Promise<boolean> => {
+      queueHeadPaused = false
       const rows = [...db.collections.inbox.toArray].filter((row) => {
         const status = row.status ?? `processed`
         const mode = row.mode ?? `immediate`
         return (
           status === `pending` &&
-          mode === `queued` &&
+          (mode === `queued` || mode === `paused`) &&
           !promotedQueuedMessageKeys.has(String(row.key))
         )
       })
@@ -1292,6 +1300,11 @@ export async function processWebhookWake(
       })
 
       const next = rows[0]!
+      if ((next.mode ?? `immediate`) === `paused`) {
+        queueHeadPaused = true
+        log.info(`queued inbox message paused, closing wake`)
+        return false
+      }
       promotedQueuedMessageKeys.add(String(next.key))
       const processedAt = new Date().toISOString()
       writeEvent(
@@ -1584,6 +1597,9 @@ export async function processWebhookWake(
         log.info(`queued inbox message pending, continuing in-process`)
         currentWakeEvents = []
         continue
+      }
+      if (queueHeadPaused) {
+        break
       }
 
       const resumed = await awaitIdleForFreshWork(

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -45,12 +45,33 @@ interface WakeDeltaWindow {
   events: Array<ChangeEvent>
 }
 
+type FreshKind = `inbox` | `wake`
+
 const DEFAULT_IDLE_TIMEOUT = 20_000
 const DEFAULT_HEARTBEAT_INTERVAL = 30_000
 type EntityStreamOptions = NonNullable<
   Parameters<typeof createEntityStreamDB>[3]
 >
 type EntityStreamHandle = NonNullable<EntityStreamOptions[`stream`]>
+
+function isInboxEvent(event: ChangeEvent): boolean {
+  return event.type === `inbox` || event.type === `message_received`
+}
+
+function isInboxCancellationEvent(event: ChangeEvent): boolean {
+  if (!isInboxEvent(event)) {
+    return false
+  }
+  if (event.headers.operation === `delete`) {
+    return true
+  }
+  const value = event.value as { status?: string } | undefined
+  return value?.status === `cancelled`
+}
+
+function inboxEventKey(event: ChangeEvent): string {
+  return String(event.key)
+}
 
 function toError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err))
@@ -65,11 +86,17 @@ function constructWakeEvent(
     return notification.wakeEvent
   }
   if (catchUpEvents) {
+    const cancelledInboxKeys = new Set<string>()
     for (let i = catchUpEvents.length - 1; i >= 0; i--) {
-      const wakeEvent = changeEventToWakeEvent(
-        catchUpEvents[i]!,
-        fallbackSource
-      )
+      const event = catchUpEvents[i]!
+      if (isInboxCancellationEvent(event)) {
+        cancelledInboxKeys.add(inboxEventKey(event))
+        continue
+      }
+      if (isInboxEvent(event) && cancelledInboxKeys.has(inboxEventKey(event))) {
+        continue
+      }
+      const wakeEvent = changeEventToWakeEvent(event, fallbackSource)
       if (wakeEvent) {
         return wakeEvent
       }
@@ -101,13 +128,28 @@ function changeEventToWakeEvent(
     }
   }
 
-  if (event.type === `message_received`) {
+  if (isInboxEvent(event)) {
+    if (event.headers.operation === `delete`) {
+      return null
+    }
     const value = event.value as
-      | { from?: string; payload?: unknown; message_type?: string }
+      | {
+          from?: string
+          payload?: unknown
+          mode?: `immediate` | `queued` | `steer`
+          message_type?: string
+          status?: `pending` | `processed` | `cancelled`
+        }
       | undefined
+    if (value?.status === `cancelled`) {
+      return null
+    }
+    if (value?.payload === undefined && value?.mode !== `steer`) {
+      return null
+    }
     return {
       source: value?.from ?? fallbackSource,
-      type: `message_received`,
+      type: `inbox`,
       fromOffset: 0,
       toOffset: 0,
       eventCount: 0,
@@ -122,11 +164,24 @@ function changeEventToWakeEvent(
 function selectWakeFromEvents(
   events: Array<ChangeEvent>,
   fallbackSource: string,
-  preferredKind?: `message_received` | `wake`
+  preferredKind?: FreshKind
 ): { wakeEvent: WakeEvent; offset: string | null } | null {
+  const cancelledInboxKeys = new Set<string>()
   for (let i = events.length - 1; i >= 0; i--) {
     const event = events[i]!
-    if (preferredKind && event.type !== preferredKind) {
+    if (isInboxCancellationEvent(event)) {
+      cancelledInboxKeys.add(inboxEventKey(event))
+      continue
+    }
+    if (isInboxEvent(event) && cancelledInboxKeys.has(inboxEventKey(event))) {
+      continue
+    }
+    const eventKind = isInboxEvent(event)
+      ? `inbox`
+      : event.type === `wake`
+        ? `wake`
+        : null
+    if (preferredKind && eventKind !== preferredKind) {
       continue
     }
 
@@ -420,13 +475,32 @@ export async function processWebhookWake(
     }
   }
 
-  const getFreshKind = (
-    events: Array<ChangeEvent>
-  ): `message_received` | `wake` | null => {
+  const getFreshKind = (events: Array<ChangeEvent>): FreshKind | null => {
     let hasWake = false
-    for (const event of events) {
-      if (event.type === `message_received`) {
-        return `message_received`
+    const cancelledInboxKeys = new Set<string>()
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i]!
+      if (isInboxCancellationEvent(event)) {
+        cancelledInboxKeys.add(inboxEventKey(event))
+        continue
+      }
+      if (isInboxEvent(event)) {
+        if (cancelledInboxKeys.has(inboxEventKey(event))) {
+          continue
+        }
+        const value = event.value as
+          | {
+              payload?: unknown
+              mode?: `immediate` | `queued` | `steer`
+              status?: `pending` | `processed` | `cancelled`
+            }
+          | undefined
+        if (
+          value?.status !== `cancelled` &&
+          (value?.payload !== undefined || value?.mode === `steer`)
+        ) {
+          return `inbox`
+        }
       }
       if (event.type === `wake`) {
         hasWake = true
@@ -436,7 +510,11 @@ export async function processWebhookWake(
   }
 
   const isFreshEvent = (event: ChangeEvent): boolean => {
-    return event.type === `message_received` || event.type === `wake`
+    return (
+      event.type === `inbox` ||
+      event.type === `message_received` ||
+      event.type === `wake`
+    )
   }
 
   const filterAcceptedLiveEvents = (
@@ -480,7 +558,10 @@ export async function processWebhookWake(
   }
 
   const waitForCurrentWakeInput = async (): Promise<void> => {
-    if (currentWakeEvent.type !== `message_received`) {
+    if (
+      currentWakeEvent.type !== `inbox` &&
+      currentWakeEvent.type !== `message_received`
+    ) {
       return
     }
 
@@ -488,7 +569,7 @@ export async function processWebhookWake(
       currentWakeEvent.payload !== undefined ||
       catchUpEvents.some(
         (event) =>
-          event.type === `message_received` &&
+          (event.type === `inbox` || event.type === `message_received`) &&
           (currentWakeOffset === `-1` ||
             event.headers.offset === currentWakeOffset)
       )
@@ -538,16 +619,16 @@ export async function processWebhookWake(
 
     const batches: Array<JsonBatch<StateEvent>> = []
     const deltaEvents: Array<ChangeEvent> = []
-    let selectedKind: `message_received` | `wake` | null = null
+    let selectedKind: FreshKind | null = null
 
     while (pendingLiveBatches.length > 0) {
       const batch = pendingLiveBatches[0]!
       const changeEvents = toChangeEvents(batch)
       const freshKind = getFreshKind(changeEvents)
 
-      // Keep wake-only work together, but let a later message start its own
+      // Keep wake-only work together, but let a later inbox message start its own
       // handler pass so message-triggered runs are not hidden behind older wakes.
-      if (selectedKind === `wake` && freshKind === `message_received`) {
+      if (selectedKind === `wake` && freshKind === `inbox`) {
         break
       }
 
@@ -555,8 +636,8 @@ export async function processWebhookWake(
       batches.push(batch)
       deltaEvents.push(...changeEvents)
 
-      if (freshKind === `message_received`) {
-        selectedKind = `message_received`
+      if (freshKind === `inbox`) {
+        selectedKind = `inbox`
       } else if (freshKind === `wake` && selectedKind === null) {
         selectedKind = `wake`
       }
@@ -580,9 +661,14 @@ export async function processWebhookWake(
       selectedKind
     )
     if (!selectedWake) {
-      throw new Error(
-        `[agent-runtime] Invariant violation: selected fresh kind "${selectedKind}" but could not derive a wake event from pending batches`
+      log.warn(
+        `fresh ${selectedKind} batch did not contain runnable wake input; acking as no-op`
       )
+      for (const event of deltaEvents) {
+        handleRuntimeSideEffectEvent(event)
+      }
+      setSafeAckOffset(batches[batches.length - 1]!.offset)
+      return null
     }
 
     return {
@@ -1175,6 +1261,62 @@ export async function processWebhookWake(
         await sdb.drainPendingWrites?.()
       }
     }
+    let currentWakeIsPromotedQueueMessage = false
+    const promotedQueuedMessageKeys = new Set<string>()
+    const promoteNextPendingInboxMessage = async (): Promise<boolean> => {
+      const rows = [...db.collections.inbox.toArray].filter((row) => {
+        const status = row.status ?? `processed`
+        const mode = row.mode ?? `immediate`
+        return (
+          status === `pending` &&
+          mode === `queued` &&
+          !promotedQueuedMessageKeys.has(String(row.key))
+        )
+      })
+      if (rows.length === 0) {
+        return false
+      }
+
+      rows.sort((left, right) => {
+        const leftPosition = left.position
+        const rightPosition = right.position
+        if (leftPosition && rightPosition && leftPosition !== rightPosition) {
+          return leftPosition < rightPosition ? -1 : 1
+        }
+        if (leftPosition && !rightPosition) return -1
+        if (!leftPosition && rightPosition) return 1
+        const leftSeq = left._seq ?? Number.MAX_SAFE_INTEGER
+        const rightSeq = right._seq ?? Number.MAX_SAFE_INTEGER
+        if (leftSeq !== rightSeq) return leftSeq - rightSeq
+        return String(left.key).localeCompare(String(right.key))
+      })
+
+      const next = rows[0]!
+      promotedQueuedMessageKeys.add(String(next.key))
+      const processedAt = new Date().toISOString()
+      writeEvent(
+        entityStateSchema.inbox.update({
+          key: next.key,
+          value: {
+            status: `processed`,
+            processed_at: processedAt,
+          } as never,
+          headers: { from: entityUrl },
+        }) as ChangeEvent
+      )
+      currentWakeEvent = {
+        source: next.from ?? entityUrl,
+        type: `inbox`,
+        fromOffset: 0,
+        toOffset: 0,
+        eventCount: 0,
+        payload: next.payload,
+        summary: next.message_type,
+      }
+      currentWakeIsPromotedQueueMessage = true
+      await flushProducedWrites()
+      return true
+    }
     setSafeAckOffset(lastCatchUpOffset)
 
     let setupComplete = false
@@ -1288,6 +1430,10 @@ export async function processWebhookWake(
               }),
           })
         : []
+
+      if (!currentWakeIsPromotedQueueMessage) {
+        await promoteNextPendingInboxMessage()
+      }
 
       const { ctx: handlerCtx, getSleepRequested } = createHandlerContext({
         entityUrl,
@@ -1429,6 +1575,14 @@ export async function processWebhookWake(
         currentWakeOffset = nextWake.wakeOffset
         currentWakeAckOffset = nextWake.ackOffset
         currentWakeEvents = nextWake.events
+        currentWakeIsPromotedQueueMessage = false
+        continue
+      }
+
+      currentWakeIsPromotedQueueMessage = false
+      if (await promoteNextPendingInboxMessage()) {
+        log.info(`queued inbox message pending, continuing in-process`)
+        currentWakeEvents = []
         continue
       }
 

--- a/packages/agents-runtime/src/runtime-server-client.ts
+++ b/packages/agents-runtime/src/runtime-server-client.ts
@@ -40,6 +40,8 @@ export interface SendEntityMessageOptions {
   from?: string
   type?: string
   afterMs?: number
+  mode?: `immediate` | `queued` | `steer`
+  position?: string
 }
 
 export interface RegisterWakeOptions {
@@ -171,11 +173,15 @@ export function createRuntimeServerClient(
     from,
     type,
     afterMs,
+    mode,
+    position,
   }: SendEntityMessageOptions): Promise<void> => {
     const body: Record<string, unknown> = { payload }
     if (from !== undefined) body.from = from
     if (type !== undefined) body.type = type
     if (afterMs !== undefined) body.afterMs = afterMs
+    if (mode !== undefined) body.mode = mode
+    if (position !== undefined) body.position = position
 
     const response = await request(`${targetUrl}/send`, {
       method: `POST`,

--- a/packages/agents-runtime/src/runtime-server-client.ts
+++ b/packages/agents-runtime/src/runtime-server-client.ts
@@ -40,7 +40,7 @@ export interface SendEntityMessageOptions {
   from?: string
   type?: string
   afterMs?: number
-  mode?: `immediate` | `queued` | `steer`
+  mode?: `immediate` | `queued` | `paused` | `steer`
   position?: string
 }
 

--- a/packages/agents-runtime/src/timeline-context.ts
+++ b/packages/agents-runtime/src/timeline-context.ts
@@ -214,11 +214,13 @@ export function materializeTimeline(
         item: IncludesContextRemoved
       }
   > = [
-    ...data.inbox.map((item) => ({
-      kind: `inbox` as const,
-      order: item.order,
-      item,
-    })),
+    ...data.inbox
+      .filter((item) => (item.status ?? `processed`) === `processed`)
+      .map((item) => ({
+        kind: `inbox` as const,
+        order: item.order,
+        item,
+      })),
     ...data.wakes.map((item) => ({
       kind: `wake` as const,
       order: item.order,

--- a/packages/agents-runtime/src/use-chat.ts
+++ b/packages/agents-runtime/src/use-chat.ts
@@ -221,6 +221,10 @@ function fingerprintMessage(msg: IncludesInboxMessage): string {
   return `${msg.from}|${msg.timestamp}|${payloadToText(msg.payload)}`
 }
 
+function isProcessedInboxMessage(msg: IncludesInboxMessage): boolean {
+  return (msg.status ?? `processed`) === `processed`
+}
+
 function buildUserSection(
   msg: IncludesInboxMessage,
   isInitial: boolean
@@ -349,7 +353,9 @@ export function buildTimelineEntries(
     | { kind: `run`; data: IncludesRun }
 
   const items: Array<TimelineItem> = [
-    ...inbox.map((data): TimelineItem => ({ kind: `inbox`, data })),
+    ...inbox
+      .filter(isProcessedInboxMessage)
+      .map((data): TimelineItem => ({ kind: `inbox`, data })),
     ...wakes.map((data): TimelineItem => ({ kind: `wake`, data })),
     ...runs.map((data): TimelineItem => ({ kind: `run`, data })),
   ]

--- a/packages/agents-server-ui/package.json
+++ b/packages/agents-server-ui/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-router": "^1.167.4",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.23",
+    "fractional-indexing": "^3.2.0",
     "katex": "^0.16.45",
     "lucide-react": "^0.561.0",
     "mermaid": "^11.14.0",

--- a/packages/agents-server-ui/src/components/EntityContextDrawer.module.css
+++ b/packages/agents-server-ui/src/components/EntityContextDrawer.module.css
@@ -103,10 +103,80 @@
   display: flex;
   align-items: center;
   min-width: 0;
+  position: relative;
 }
 
 .rowShell > .row {
   flex: 1;
+}
+
+.pendingActions {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: -2px;
+}
+
+.pendingActionButton {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  color: var(--ds-gray-11);
+}
+
+.pendingActionButton:hover {
+  background: var(--ds-gray-a5);
+  color: var(--ds-gray-12);
+}
+
+.pendingTextRow {
+  cursor: grab;
+}
+
+.pendingTextRow:hover {
+  background: var(--ds-bg-hover);
+}
+
+.pendingTextRow:active {
+  cursor: grabbing;
+}
+
+.pendingDragging {
+  opacity: 0.48;
+}
+
+.pendingDropBefore::before,
+.pendingDropAfter::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  height: 2px;
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-accent-a8);
+  pointer-events: none;
+}
+
+.pendingDropBefore::before {
+  top: 0;
+}
+
+.pendingDropAfter::after {
+  bottom: 0;
+}
+
+.pendingRowEditing {
+  background: var(--ds-accent-a2);
+  box-shadow: inset 0 0 0 1px var(--ds-accent-a5);
+}
+
+.pendingTextRow.pendingRowEditing:hover {
+  background: var(--ds-accent-a2);
+}
+
+.dragHandle {
+  color: var(--ds-text-3);
+  opacity: 0.7;
 }
 
 .sideButton {

--- a/packages/agents-server-ui/src/components/EntityContextDrawer.tsx
+++ b/packages/agents-server-ui/src/components/EntityContextDrawer.tsx
@@ -1,5 +1,13 @@
 import { useMemo, useState } from 'react'
-import { ChevronDown, ChevronRight, SplitSquareHorizontal } from 'lucide-react'
+import {
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  GripVertical,
+  Pencil,
+  SplitSquareHorizontal,
+  Trash2,
+} from 'lucide-react'
 import { useLiveQuery } from '@tanstack/react-db'
 import { inArray } from '@tanstack/db'
 import { useWorkspace } from '../hooks/useWorkspace'
@@ -8,9 +16,11 @@ import { Icon, IconButton, Text, Tooltip } from '../ui'
 import { StatusDot } from './StatusDot'
 import { JsonInspectDialog } from './JsonInspectDialog'
 import { getEntityDisplayTitle } from '../lib/entityDisplay'
+import { createQueuePositionBetween, readTextPayload } from '../lib/sendMessage'
 import styles from './EntityContextDrawer.module.css'
 import type {
   EntityStreamDBWithActions,
+  EntityTimelineData,
   Manifest,
 } from '@electric-ax/agents-runtime/client'
 import type { ElectricEntity } from '../lib/ElectricAgentsProvider'
@@ -80,10 +90,22 @@ export function EntityContextDrawer({
   entity,
   db,
   tileId,
+  pendingMessages = [],
+  pendingEditingKey = null,
+  onEditPending,
+  onDeletePending,
+  onSteerPending,
+  onReorderPending,
 }: {
   entity: ElectricEntity
   db: EntityStreamDBWithActions | null
   tileId: string
+  pendingMessages?: EntityTimelineData[`inbox`]
+  pendingEditingKey?: string | null
+  onEditPending?: (message: EntityTimelineData[`inbox`][number]) => void
+  onDeletePending?: (key: string) => void
+  onSteerPending?: (key: string) => void
+  onReorderPending?: (key: string, position: string) => void
 }): React.ReactElement | null {
   const { entitiesCollection } = useElectricAgents()
   const { helpers } = useWorkspace()
@@ -146,7 +168,14 @@ export function EntityContextDrawer({
     [parent, manifests, entitiesByUrl]
   )
 
-  if (groups.length === 0) return null
+  const hasPendingSection =
+    pendingMessages.length > 0 &&
+    onEditPending !== undefined &&
+    onDeletePending !== undefined &&
+    onSteerPending !== undefined &&
+    onReorderPending !== undefined
+
+  if (groups.length === 0 && !hasPendingSection) return null
 
   const openEntity = (url: string, side = false): void => {
     helpers.openEntity(url, {
@@ -183,6 +212,16 @@ export function EntityContextDrawer({
   return (
     <>
       <div className={styles.drawer}>
+        {hasPendingSection && (
+          <PendingInboxSection
+            messages={pendingMessages}
+            editingKey={pendingEditingKey}
+            onEdit={onEditPending}
+            onDelete={onDeletePending}
+            onSteer={onSteerPending}
+            onReorder={onReorderPending}
+          />
+        )}
         {groups.map((group) => (
           <ManifestSection
             key={group.key}
@@ -201,6 +240,213 @@ export function EntityContextDrawer({
         value={inspectTarget?.value ?? null}
       />
     </>
+  )
+}
+
+function PendingInboxSection({
+  messages,
+  editingKey,
+  onEdit,
+  onDelete,
+  onSteer,
+  onReorder,
+}: {
+  messages: EntityTimelineData[`inbox`]
+  editingKey: string | null
+  onEdit: (message: EntityTimelineData[`inbox`][number]) => void
+  onDelete: (key: string) => void
+  onSteer: (key: string) => void
+  onReorder: (key: string, position: string) => void
+}): React.ReactElement {
+  const [expanded, setExpanded] = useState(true)
+  const [draggingKey, setDraggingKey] = useState<string | null>(null)
+  const [dropTarget, setDropTarget] = useState<{
+    key: string
+    placement: `before` | `after`
+  } | null>(null)
+  const Chevron = expanded ? ChevronDown : ChevronRight
+
+  const clearDragState = (): void => {
+    setDraggingKey(null)
+    setDropTarget(null)
+  }
+
+  const getDropPlacement = (
+    event: React.DragEvent<HTMLElement>
+  ): `before` | `after` => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    return event.clientY < rect.top + rect.height / 2 ? `before` : `after`
+  }
+
+  const reorderMessage = (
+    draggedKey: string,
+    targetKey: string,
+    placement: `before` | `after`
+  ): void => {
+    const fromIndex = messages.findIndex(
+      (message) => message.key === draggedKey
+    )
+    const targetIndex = messages.findIndex(
+      (message) => message.key === targetKey
+    )
+    if (fromIndex < 0 || targetIndex < 0 || draggedKey === targetKey) {
+      return
+    }
+
+    const nextOrder = [...messages]
+    const [moved] = nextOrder.splice(fromIndex, 1)
+    if (!moved) return
+    const targetIndexAfterRemoval = nextOrder.findIndex(
+      (message) => message.key === targetKey
+    )
+    if (targetIndexAfterRemoval < 0) return
+    const insertIndex =
+      placement === `before`
+        ? targetIndexAfterRemoval
+        : targetIndexAfterRemoval + 1
+    nextOrder.splice(insertIndex, 0, moved)
+
+    const movedIndex = nextOrder.findIndex(
+      (message) => message.key === draggedKey
+    )
+    const previous = movedIndex > 0 ? nextOrder[movedIndex - 1] : undefined
+    const next =
+      movedIndex >= 0 && movedIndex < nextOrder.length - 1
+        ? nextOrder[movedIndex + 1]
+        : undefined
+    const position = createQueuePositionBetween(
+      previous?.position,
+      next?.position
+    )
+    onReorder(draggedKey, position)
+  }
+
+  return (
+    <div className={styles.section}>
+      <button
+        type="button"
+        className={styles.row}
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span className={styles.iconSlot}>
+          <Icon icon={Chevron} size={2} className={styles.chevron} />
+        </span>
+        <Text size={2} className={styles.headerLabel}>
+          {messages.length} Queued
+        </Text>
+      </button>
+      {expanded &&
+        messages.map((message) => (
+          <div
+            key={message.key}
+            className={[
+              styles.rowShell,
+              draggingKey === message.key ? styles.pendingDragging : null,
+              dropTarget?.key === message.key &&
+              dropTarget.placement === `before`
+                ? styles.pendingDropBefore
+                : null,
+              dropTarget?.key === message.key &&
+              dropTarget.placement === `after`
+                ? styles.pendingDropAfter
+                : null,
+            ]
+              .filter(Boolean)
+              .join(` `)}
+            draggable
+            onDragStart={(event) => {
+              setDraggingKey(message.key)
+              event.dataTransfer.effectAllowed = `move`
+              event.dataTransfer.setData(`text/plain`, message.key)
+            }}
+            onDragOver={(event) => {
+              if (!draggingKey || draggingKey === message.key) return
+              event.preventDefault()
+              event.dataTransfer.dropEffect = `move`
+              setDropTarget({
+                key: message.key,
+                placement: getDropPlacement(event),
+              })
+            }}
+            onDragLeave={() => {
+              setDropTarget((current) =>
+                current?.key === message.key ? null : current
+              )
+            }}
+            onDrop={(event) => {
+              event.preventDefault()
+              const draggedKey =
+                event.dataTransfer.getData(`text/plain`) || draggingKey
+              const placement = getDropPlacement(event)
+              clearDragState()
+              if (draggedKey) {
+                reorderMessage(draggedKey, message.key, placement)
+              }
+            }}
+            onDragEnd={clearDragState}
+          >
+            <div
+              className={[
+                styles.row,
+                styles.pendingTextRow,
+                editingKey === message.key ? styles.pendingRowEditing : null,
+              ]
+                .filter(Boolean)
+                .join(` `)}
+              title={readTextPayload(message.payload)}
+            >
+              <span className={styles.iconSlot}>
+                <Icon
+                  icon={GripVertical}
+                  size={1}
+                  className={styles.dragHandle}
+                />
+              </span>
+              <span className={styles.rowMain}>
+                <Text size={2} className={styles.rowTitle}>
+                  {readTextPayload(message.payload) || `Untitled message`}
+                </Text>
+              </span>
+            </div>
+            <span className={styles.pendingActions}>
+              <IconButton
+                type="button"
+                size={1}
+                variant="ghost"
+                tone="neutral"
+                className={styles.pendingActionButton}
+                aria-label="Edit queued message"
+                onClick={() => onEdit(message)}
+              >
+                <Icon icon={Pencil} size={1} />
+              </IconButton>
+              <IconButton
+                type="button"
+                size={1}
+                variant="ghost"
+                tone="neutral"
+                className={styles.pendingActionButton}
+                aria-label="Steer now"
+                onClick={() => onSteer(message.key)}
+              >
+                <Icon icon={ArrowUp} size={1} />
+              </IconButton>
+              <IconButton
+                type="button"
+                size={1}
+                variant="ghost"
+                tone="neutral"
+                className={styles.pendingActionButton}
+                aria-label="Delete queued message"
+                onClick={() => onDelete(message.key)}
+              >
+                <Icon icon={Trash2} size={1} />
+              </IconButton>
+            </span>
+          </div>
+        ))}
+    </div>
   )
 }
 

--- a/packages/agents-server-ui/src/components/MessageInput.module.css
+++ b/packages/agents-server-ui/src/components/MessageInput.module.css
@@ -27,6 +27,7 @@
 }
 
 .composer {
+  box-sizing: border-box;
   /* Solid raised-surface fill (also what `--ds-input-bg` resolves to,
      since both inherit from `--ds-surface-raised`). The composer
      docks at the bottom of a scrolling chat surface and chat content
@@ -74,8 +75,76 @@
   z-index: 1;
 }
 
+.inlineIconButton {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--ds-radius-3);
+  color: var(--ds-text-3);
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.inlineIconButton:hover {
+  background: var(--ds-bg-hover);
+  color: var(--ds-text-1);
+}
+
+.inlineIconButton:focus-visible {
+  outline: 2px solid var(--ds-accent-a6);
+  outline-offset: -2px;
+}
+
+.editingBanner {
+  box-sizing: border-box;
+  width: calc(100% + 24px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: -12px -12px 8px;
+  padding: 5px 12px 5px 14px;
+  border-bottom: 1px solid var(--ds-gray-a4);
+  border-radius: var(--ds-radius-5) var(--ds-radius-5) 0 0;
+  background: var(--ds-gray-a2);
+}
+
+.editingCancel {
+  all: unset;
+  border-radius: var(--ds-radius-3);
+  color: var(--ds-text-2);
+  cursor: pointer;
+  font-family: var(--ds-font-body);
+  font-size: var(--ds-text-xs);
+  line-height: var(--ds-text-xs-lh);
+  padding: 0 2px;
+}
+
+.editingCancel:hover {
+  color: var(--ds-text-1);
+}
+
+.editingCancel:focus-visible {
+  outline: 2px solid var(--ds-accent-a6);
+  outline-offset: 2px;
+}
+
+.composerBody {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--ds-space-2);
+  min-width: 0;
+  width: 100%;
+}
+
 .textarea {
   flex: 1;
+  min-width: 0;
   border: none;
   outline: none;
   background: transparent;

--- a/packages/agents-server-ui/src/components/MessageInput.tsx
+++ b/packages/agents-server-ui/src/components/MessageInput.tsx
@@ -92,7 +92,12 @@ export function MessageInput({
     const shouldSendImmediately =
       !generationActive && pendingMessages.length === 0
     const tx = editingMessage
-      ? updateAction?.({ key: editingMessage.key, text })
+      ? updateAction?.({
+          key: editingMessage.key,
+          text,
+          mode: `queued`,
+          status: `pending`,
+        })
       : sendAction?.({
           text,
           mode: shouldSendImmediately ? `immediate` : `queued`,
@@ -116,17 +121,35 @@ export function MessageInput({
   const startEditing = useCallback(
     (message: EntityTimelineData[`inbox`][number]) => {
       const text = readTextPayload(message.payload)
+      setError(null)
+      updateAction?.({
+        key: message.key,
+        mode: `paused`,
+        status: `pending`,
+      }).isPersisted.promise.catch((err: Error) => {
+        setError(err.message)
+      })
       setEditingMessage({ key: message.key, originalText: text })
       setValue(text)
       textareaRef.current?.focus()
     },
-    []
+    [updateAction]
   )
 
   const cancelEditing = useCallback(() => {
+    if (editingMessage) {
+      setError(null)
+      updateAction?.({
+        key: editingMessage.key,
+        mode: `queued`,
+        status: `pending`,
+      }).isPersisted.promise.catch((err: Error) => {
+        setError(err.message)
+      })
+    }
     setEditingMessage(null)
     setValue(``)
-  }, [])
+  }, [editingMessage, updateAction])
 
   const deleteMessage = useCallback(
     (key: string) => {

--- a/packages/agents-server-ui/src/components/MessageInput.tsx
+++ b/packages/agents-server-ui/src/components/MessageInput.tsx
@@ -1,21 +1,32 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { ArrowUp } from 'lucide-react'
 import type { EntityStreamDBWithActions } from '@electric-ax/agents-runtime/client'
-import { createSendMessageAction } from '../lib/sendMessage'
+import {
+  createDeleteInboxMessageAction,
+  createSendMessageAction,
+  createSteerInboxMessageAction,
+  createUpdateInboxMessageAction,
+  readTextPayload,
+} from '../lib/sendMessage'
 import { Icon, Stack, Text } from '../ui'
 import styles from './MessageInput.module.css'
+import type { EntityTimelineData } from '@electric-ax/agents-runtime/client'
 
 export function MessageInput({
   db,
   baseUrl,
   entityUrl,
   disabled,
+  pendingMessages = [],
+  generationActive,
   drawer,
 }: {
   db: EntityStreamDBWithActions | null
   baseUrl: string
   entityUrl: string
   disabled: boolean
+  pendingMessages?: EntityTimelineData[`inbox`]
+  generationActive: boolean
   /**
    * Optional content rendered above the composer, sharing its docked
    * width and lift into the timeline above. The composer is z-indexed
@@ -23,10 +34,21 @@ export function MessageInput({
    * bottom edge underneath the composer for a "tray" effect (see
    * `EntityContextDrawer`).
    */
-  drawer?: React.ReactNode
+  drawer?: (props: {
+    pendingMessages: EntityTimelineData[`inbox`]
+    editingKey: string | null
+    onEdit: (message: EntityTimelineData[`inbox`][number]) => void
+    onDelete: (key: string) => void
+    onSteer: (key: string) => void
+    onReorder: (key: string, position: string) => void
+  }) => React.ReactNode
 }): React.ReactElement {
   const [value, setValue] = useState(``)
   const [error, setError] = useState<string | null>(null)
+  const [editingMessage, setEditingMessage] = useState<{
+    key: string
+    originalText: string
+  } | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   // Auto-grow the composer as the user types. We reset to `auto`
@@ -50,61 +72,164 @@ export function MessageInput({
       entityUrl,
     })
   }, [db, baseUrl, entityUrl])
+  const updateAction = useMemo(() => {
+    if (!db) return null
+    return createUpdateInboxMessageAction({ db, baseUrl, entityUrl })
+  }, [db, baseUrl, entityUrl])
+  const deleteAction = useMemo(() => {
+    if (!db) return null
+    return createDeleteInboxMessageAction({ db, baseUrl, entityUrl })
+  }, [db, baseUrl, entityUrl])
+  const steerAction = useMemo(() => {
+    if (!db) return null
+    return createSteerInboxMessageAction({ db, baseUrl, entityUrl })
+  }, [db, baseUrl, entityUrl])
 
   const handleSubmit = useCallback(() => {
-    if (!value.trim() || !sendAction || disabled) return
+    if (!value.trim() || disabled) return
     setError(null)
-    const tx = sendAction({ text: value.trim() })
+    const text = value.trim()
+    const shouldSendImmediately =
+      !generationActive && pendingMessages.length === 0
+    const tx = editingMessage
+      ? updateAction?.({ key: editingMessage.key, text })
+      : sendAction?.({
+          text,
+          mode: shouldSendImmediately ? `immediate` : `queued`,
+        })
+    if (!tx) return
     setValue(``)
+    setEditingMessage(null)
     tx.isPersisted.promise.catch((err: Error) => {
       setError(err.message)
     })
-  }, [value, sendAction, disabled])
+  }, [
+    value,
+    sendAction,
+    updateAction,
+    editingMessage,
+    disabled,
+    generationActive,
+    pendingMessages.length,
+  ])
+
+  const startEditing = useCallback(
+    (message: EntityTimelineData[`inbox`][number]) => {
+      const text = readTextPayload(message.payload)
+      setEditingMessage({ key: message.key, originalText: text })
+      setValue(text)
+      textareaRef.current?.focus()
+    },
+    []
+  )
+
+  const cancelEditing = useCallback(() => {
+    setEditingMessage(null)
+    setValue(``)
+  }, [])
+
+  const deleteMessage = useCallback(
+    (key: string) => {
+      if (!deleteAction) return
+      setError(null)
+      deleteAction({ key }).isPersisted.promise.catch((err: Error) => {
+        setError(err.message)
+      })
+      if (editingMessage?.key === key) cancelEditing()
+    },
+    [deleteAction, editingMessage?.key, cancelEditing]
+  )
+
+  const steerMessage = useCallback(
+    (key: string) => {
+      if (!steerAction) return
+      setError(null)
+      steerAction({ key }).isPersisted.promise.catch((err: Error) => {
+        setError(err.message)
+      })
+      if (editingMessage?.key === key) cancelEditing()
+    },
+    [steerAction, editingMessage?.key, cancelEditing]
+  )
+  const reorderMessage = useCallback(
+    (key: string, position: string) => {
+      if (!updateAction) return
+      setError(null)
+      updateAction({ key, position }).isPersisted.promise.catch(
+        (err: Error) => {
+          setError(err.message)
+        }
+      )
+    },
+    [updateAction]
+  )
 
   const isActive = Boolean(value.trim() && !disabled)
 
   return (
     <Stack direction="column" gap={0} className={styles.root}>
-      {drawer}
+      {drawer?.({
+        pendingMessages,
+        editingKey: editingMessage?.key ?? null,
+        onEdit: startEditing,
+        onDelete: deleteMessage,
+        onSteer: steerMessage,
+        onReorder: reorderMessage,
+      })}
       {error && (
         <Text size={1} tone="danger" className={styles.errorText}>
           {error}
         </Text>
       )}
-      <Stack
-        align="end"
-        gap={2}
+      <div
         className={[styles.composer, disabled ? styles.disabled : null]
           .filter(Boolean)
           .join(` `)}
       >
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === `Enter` && !e.shiftKey) {
-              e.preventDefault()
-              handleSubmit()
-            }
-          }}
-          placeholder={disabled ? `Entity stopped` : `Send a message...`}
-          disabled={disabled}
-          rows={1}
-          className={styles.textarea}
-        />
-        <button
-          type="button"
-          aria-label="Send message"
-          onClick={handleSubmit}
-          disabled={!isActive}
-          className={[styles.composerSend, isActive ? styles.active : null]
-            .filter(Boolean)
-            .join(` `)}
-        >
-          <Icon icon={ArrowUp} size={3} />
-        </button>
-      </Stack>
+        {editingMessage && (
+          <div className={styles.editingBanner}>
+            <Text size={1} tone="muted">
+              Editing queued message
+            </Text>
+            <button
+              type="button"
+              aria-label="Cancel editing queued message"
+              onClick={cancelEditing}
+              className={styles.editingCancel}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+        <div className={styles.composerBody}>
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === `Enter` && !e.shiftKey) {
+                e.preventDefault()
+                handleSubmit()
+              }
+            }}
+            placeholder={disabled ? `Entity stopped` : `Send a message...`}
+            disabled={disabled}
+            rows={1}
+            className={styles.textarea}
+          />
+          <button
+            type="button"
+            aria-label="Send message"
+            onClick={handleSubmit}
+            disabled={!isActive}
+            className={[styles.composerSend, isActive ? styles.active : null]
+              .filter(Boolean)
+              .join(` `)}
+          >
+            <Icon icon={ArrowUp} size={3} />
+          </button>
+        </div>
+      </div>
     </Stack>
   )
 }

--- a/packages/agents-server-ui/src/components/MessageInput.tsx
+++ b/packages/agents-server-ui/src/components/MessageInput.tsx
@@ -11,6 +11,7 @@ import {
 import { Icon, Stack, Text } from '../ui'
 import styles from './MessageInput.module.css'
 import type { EntityTimelineData } from '@electric-ax/agents-runtime/client'
+import type { OptimisticInboxMessage } from '../lib/sendMessage'
 
 export function MessageInput({
   db,
@@ -18,7 +19,8 @@ export function MessageInput({
   entityUrl,
   disabled,
   pendingMessages = [],
-  generationActive,
+  inlineQueuedSubmits = false,
+  onOptimisticQueuedMessage,
   drawer,
 }: {
   db: EntityStreamDBWithActions | null
@@ -26,7 +28,8 @@ export function MessageInput({
   entityUrl: string
   disabled: boolean
   pendingMessages?: EntityTimelineData[`inbox`]
-  generationActive: boolean
+  inlineQueuedSubmits?: boolean
+  onOptimisticQueuedMessage?: (message: OptimisticInboxMessage) => void
   /**
    * Optional content rendered above the composer, sharing its docked
    * width and lift into the timeline above. The composer is z-indexed
@@ -70,8 +73,13 @@ export function MessageInput({
       db,
       baseUrl,
       entityUrl,
+      onOptimisticMessage: (message) => {
+        if (inlineQueuedSubmits && message.mode === `queued`) {
+          onOptimisticQueuedMessage?.(message)
+        }
+      },
     })
-  }, [db, baseUrl, entityUrl])
+  }, [db, baseUrl, entityUrl, inlineQueuedSubmits, onOptimisticQueuedMessage])
   const updateAction = useMemo(() => {
     if (!db) return null
     return createUpdateInboxMessageAction({ db, baseUrl, entityUrl })
@@ -89,8 +97,6 @@ export function MessageInput({
     if (!value.trim() || disabled) return
     setError(null)
     const text = value.trim()
-    const shouldSendImmediately =
-      !generationActive && pendingMessages.length === 0
     const tx = editingMessage
       ? updateAction?.({
           key: editingMessage.key,
@@ -100,7 +106,7 @@ export function MessageInput({
         })
       : sendAction?.({
           text,
-          mode: shouldSendImmediately ? `immediate` : `queued`,
+          mode: `queued`,
         })
     if (!tx) return
     setValue(``)
@@ -108,15 +114,7 @@ export function MessageInput({
     tx.isPersisted.promise.catch((err: Error) => {
       setError(err.message)
     })
-  }, [
-    value,
-    sendAction,
-    updateAction,
-    editingMessage,
-    disabled,
-    generationActive,
-    pendingMessages.length,
-  ])
+  }, [value, sendAction, updateAction, editingMessage, disabled])
 
   const startEditing = useCallback(
     (message: EntityTimelineData[`inbox`][number]) => {

--- a/packages/agents-server-ui/src/components/views/ChatView.tsx
+++ b/packages/agents-server-ui/src/components/views/ChatView.tsx
@@ -54,10 +54,8 @@ function GenericChatBody({
   isSpawning: boolean
   tileId: string
 }): React.ReactElement {
-  const { entries, entities, db, loading, error } = useEntityTimeline(
-    baseUrl || null,
-    entityUrl
-  )
+  const { entries, pendingInbox, entities, db, loading, error } =
+    useEntityTimeline(baseUrl || null, entityUrl)
   const navigate = useNavigate()
 
   // If the timeline subscription errors out for an entity that isn't
@@ -87,7 +85,21 @@ function GenericChatBody({
         baseUrl={baseUrl}
         entityUrl={entityUrl ?? ``}
         disabled={entityStopped || !db}
-        drawer={<EntityContextDrawer entity={entity} db={db} tileId={tileId} />}
+        pendingMessages={pendingInbox}
+        generationActive={entity.status === `running`}
+        drawer={(pending) => (
+          <EntityContextDrawer
+            entity={entity}
+            db={db}
+            tileId={tileId}
+            pendingMessages={pending.pendingMessages}
+            pendingEditingKey={pending.editingKey}
+            onEditPending={pending.onEdit}
+            onDeletePending={pending.onDelete}
+            onSteerPending={pending.onSteer}
+            onReorderPending={pending.onReorder}
+          />
+        )}
       />
     </>
   )

--- a/packages/agents-server-ui/src/components/views/ChatView.tsx
+++ b/packages/agents-server-ui/src/components/views/ChatView.tsx
@@ -1,10 +1,15 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { useEntityTimeline } from '../../hooks/useEntityTimeline'
 import { EntityTimeline } from '../EntityTimeline'
 import { MessageInput } from '../MessageInput'
 import { EntityContextDrawer } from '../EntityContextDrawer'
+import { readTextPayload } from '../../lib/sendMessage'
 import type { ViewProps } from '../../lib/workspace/viewRegistry'
+import type { TimelineEntry } from '../../lib/timelineEntries'
+import type { OptimisticInboxMessage } from '../../lib/sendMessage'
+
+const INLINE_QUEUED_TIMEOUT_MS = 15_000
 
 /**
  * The default view: chat / timeline + message composer.
@@ -57,6 +62,111 @@ function GenericChatBody({
   const { entries, pendingInbox, entities, db, loading, error } =
     useEntityTimeline(baseUrl || null, entityUrl)
   const navigate = useNavigate()
+  const [inlineQueuedMessages, setInlineQueuedMessages] = useState<
+    Map<string, OptimisticInboxMessage>
+  >(() => new Map())
+  const inlineTimeoutsRef = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>()
+  )
+  const processedInboxKeys = useMemo(
+    () =>
+      new Set(
+        entries
+          .filter((entry) => entry.section.kind === `user_message`)
+          .map((entry) => entry.key.replace(/^inbox:/, ``))
+      ),
+    [entries]
+  )
+  const pendingInboxByKey = useMemo(
+    () => new Map(pendingInbox.map((message) => [message.key, message])),
+    [pendingInbox]
+  )
+  const projectedPendingMessage = useMemo(() => {
+    for (const [key, message] of inlineQueuedMessages) {
+      if (processedInboxKeys.has(key)) continue
+      return pendingInboxByKey.get(key) ?? message
+    }
+    return null
+  }, [inlineQueuedMessages, pendingInboxByKey, processedInboxKeys])
+  const visiblePendingInbox = useMemo(
+    () =>
+      projectedPendingMessage
+        ? pendingInbox.filter(
+            (message) => message.key !== projectedPendingMessage.key
+          )
+        : pendingInbox,
+    [pendingInbox, projectedPendingMessage]
+  )
+  const visibleEntries = useMemo<Array<TimelineEntry>>(() => {
+    if (!projectedPendingMessage) return entries
+    const timestamp = Date.parse(projectedPendingMessage.timestamp)
+    const hasUserMessage = entries.some(
+      (entry) => entry.section.kind === `user_message`
+    )
+    return [
+      ...entries,
+      {
+        key: `pending-inbox:${projectedPendingMessage.key}`,
+        order: Number.MAX_SAFE_INTEGER,
+        responseTimestamp: null,
+        section: {
+          kind: `user_message`,
+          from: projectedPendingMessage.from ?? `user`,
+          text: readTextPayload(projectedPendingMessage.payload),
+          timestamp: Number.isFinite(timestamp) ? timestamp : Date.now(),
+          isInitial: !hasUserMessage,
+        },
+      },
+    ]
+  }, [entries, projectedPendingMessage])
+
+  const rememberInlineQueuedMessage = useCallback(
+    (message: OptimisticInboxMessage) => {
+      setInlineQueuedMessages((current) => {
+        const next = new Map(current)
+        next.set(message.key, message)
+        return next
+      })
+      const existingTimeout = inlineTimeoutsRef.current.get(message.key)
+      if (existingTimeout) clearTimeout(existingTimeout)
+      const timeout = setTimeout(() => {
+        inlineTimeoutsRef.current.delete(message.key)
+        setInlineQueuedMessages((current) => {
+          if (!current.has(message.key)) return current
+          const next = new Map(current)
+          next.delete(message.key)
+          return next
+        })
+      }, INLINE_QUEUED_TIMEOUT_MS)
+      inlineTimeoutsRef.current.set(message.key, timeout)
+    },
+    []
+  )
+
+  useEffect(() => {
+    setInlineQueuedMessages((current) => {
+      let next: Map<string, OptimisticInboxMessage> | null = null
+      for (const key of current.keys()) {
+        if (!processedInboxKeys.has(key)) continue
+        next ??= new Map(current)
+        next.delete(key)
+        const timeout = inlineTimeoutsRef.current.get(key)
+        if (timeout) clearTimeout(timeout)
+        inlineTimeoutsRef.current.delete(key)
+      }
+      return next ?? current
+    })
+  }, [processedInboxKeys])
+
+  useEffect(
+    () => () => {
+      for (const timeout of inlineTimeoutsRef.current.values()) {
+        clearTimeout(timeout)
+      }
+      inlineTimeoutsRef.current.clear()
+    },
+    []
+  )
 
   // If the timeline subscription errors out for an entity that isn't
   // currently spawning (so the failure isn't transient), bounce back to
@@ -71,7 +181,7 @@ function GenericChatBody({
   return (
     <>
       <EntityTimeline
-        entries={entries}
+        entries={visibleEntries}
         loading={loading}
         error={error}
         entityStopped={entityStopped}
@@ -85,8 +195,14 @@ function GenericChatBody({
         baseUrl={baseUrl}
         entityUrl={entityUrl ?? ``}
         disabled={entityStopped || !db}
-        pendingMessages={pendingInbox}
-        generationActive={entity.status === `running`}
+        pendingMessages={visiblePendingInbox}
+        inlineQueuedSubmits={
+          !entityStopped &&
+          entity.status !== `running` &&
+          pendingInbox.length === 0 &&
+          inlineQueuedMessages.size === 0
+        }
+        onOptimisticQueuedMessage={rememberInlineQueuedMessage}
         drawer={(pending) => (
           <EntityContextDrawer
             entity={entity}

--- a/packages/agents-server-ui/src/components/views/NewSessionView.tsx
+++ b/packages/agents-server-ui/src/components/views/NewSessionView.tsx
@@ -170,6 +170,7 @@ export function NewSessionView({
             })
             await sendInitialMessage({
               text: initialUserText,
+              mode: `immediate`,
             }).isPersisted.promise
           } finally {
             connection.close()

--- a/packages/agents-server-ui/src/hooks/useEntityTimeline.ts
+++ b/packages/agents-server-ui/src/hooks/useEntityTimeline.ts
@@ -6,11 +6,13 @@ import {
   createEntityIncludesQuery,
   normalizeEntityTimelineData,
 } from '@electric-ax/agents-runtime/client'
+import { eq } from '@tanstack/db'
 import { connectEntityStream } from '../lib/entity-connection'
 import type { TimelineEntry } from '../lib/timelineEntries'
 import type {
   EntityStreamDBWithActions,
   EntityTimelineData,
+  IncludesInboxMessage,
   IncludesEntity,
   Manifest,
 } from '@electric-ax/agents-runtime/client'
@@ -20,6 +22,7 @@ export function useEntityTimeline(
   entityUrl: string | null
 ): {
   entries: Array<TimelineEntry>
+  pendingInbox: EntityTimelineData[`inbox`]
   entities: Array<IncludesEntity>
   db: EntityStreamDBWithActions | null
   loading: boolean
@@ -84,6 +87,16 @@ export function useEntityTimeline(
         : undefined,
     [db]
   )
+  const { data: pendingInboxRows = [] } = useLiveQuery(
+    (q) =>
+      db
+        ? q
+            .from({ inbox: db.collections.inbox })
+            .where(({ inbox }) => eq(inbox.status, `pending`))
+            .orderBy(({ inbox }) => inbox._seq, `asc`)
+        : undefined,
+    [db]
+  )
   const timelineData = useMemo(
     () =>
       normalizeEntityTimelineData(
@@ -137,5 +150,52 @@ export function useEntityTimeline(
       .map(({ entry }) => entry)
   }, [manifests, timelineData.runs, timelineData.inbox, timelineData.wakes])
 
-  return { entries, entities: timelineData.entities, db, loading, error }
+  const pendingInbox = useMemo(
+    () =>
+      (pendingInboxRows as Array<Record<string, any>>)
+        .map(
+          (msg): IncludesInboxMessage => ({
+            key: msg.key,
+            order: msg._seq ?? Number.MAX_SAFE_INTEGER,
+            from: msg.from,
+            payload: msg.payload,
+            timestamp: msg.timestamp,
+            mode: msg.mode ?? `queued`,
+            status: msg.status ?? `pending`,
+            position: msg.position,
+            processed_at: msg.processed_at,
+            cancelled_at: msg.cancelled_at,
+          })
+        )
+        .filter((msg) => msg.status === `pending`)
+        .sort((left, right) => {
+          if (
+            left.position &&
+            right.position &&
+            left.position !== right.position
+          ) {
+            return left.position < right.position ? -1 : 1
+          }
+          if (left.position && !right.position) return -1
+          if (!left.position && right.position) return 1
+          if (
+            left.timestamp &&
+            right.timestamp &&
+            left.timestamp !== right.timestamp
+          ) {
+            return left.timestamp < right.timestamp ? -1 : 1
+          }
+          return compareTimelineOrders(left.order, right.order)
+        }),
+    [pendingInboxRows]
+  )
+
+  return {
+    entries,
+    pendingInbox,
+    entities: timelineData.entities,
+    db,
+    loading,
+    error,
+  }
 }

--- a/packages/agents-server-ui/src/lib/sendMessage.ts
+++ b/packages/agents-server-ui/src/lib/sendMessage.ts
@@ -15,7 +15,7 @@ type OptimisticInboxMessage = {
   from: string
   payload: { text: string }
   timestamp: string
-  mode: `immediate` | `queued` | `steer`
+  mode: `immediate` | `queued` | `paused` | `steer`
   status: `pending` | `processed` | `cancelled`
   position?: string
   processed_at?: string
@@ -23,7 +23,7 @@ type OptimisticInboxMessage = {
 
 type SendMessageInput = {
   text: string
-  mode: `immediate` | `queued` | `steer`
+  mode: `immediate` | `queued` | `paused` | `steer`
   key: string
   seq: number
   position?: string
@@ -33,6 +33,8 @@ type UpdateInboxMessageInput = {
   key: string
   text?: string
   position?: string
+  mode?: `immediate` | `queued` | `paused` | `steer`
+  status?: `pending` | `processed` | `cancelled`
 }
 
 type InboxMessageKeyInput = {
@@ -161,9 +163,12 @@ export function createSendMessageAction({
         payload: { text },
         timestamp: now,
         mode,
-        status: mode === `queued` ? `pending` : `processed`,
+        status:
+          mode === `queued` || mode === `paused` ? `pending` : `processed`,
         ...(position ? { position } : {}),
-        ...(mode === `queued` ? {} : { processed_at: now }),
+        ...(mode === `queued` || mode === `paused`
+          ? {}
+          : { processed_at: now }),
       }
       db.collections.inbox.insert(message)
     },
@@ -186,12 +191,15 @@ export function createSendMessageAction({
     position,
   }: {
     text: string
-    mode?: `immediate` | `queued` | `steer`
+    mode?: `immediate` | `queued` | `paused` | `steer`
     position?: string
   }) => {
     const seq = nextOptimisticInboxSeq()
     const effectivePosition =
-      position ?? (mode === `queued` ? createInitialQueuePosition() : undefined)
+      position ??
+      (mode === `queued` || mode === `paused`
+        ? createInitialQueuePosition()
+        : undefined)
     return action({
       text,
       mode,
@@ -212,7 +220,7 @@ export function createUpdateInboxMessageAction({
   entityUrl: string
 }) {
   return createOptimisticAction<UpdateInboxMessageInput>({
-    onMutate: ({ key, text, position }) => {
+    onMutate: ({ key, text, position, mode, status }) => {
       db.collections.inbox.update(key, (draft) => {
         if (text !== undefined) {
           draft.payload = { text }
@@ -220,15 +228,32 @@ export function createUpdateInboxMessageAction({
         if (position !== undefined) {
           draft.position = position
         }
+        if (mode !== undefined) {
+          draft.mode = mode
+        }
+        if (status !== undefined) {
+          draft.status = status
+        }
       })
     },
-    mutationFn: async ({ key, text, position }) => {
-      const body: { payload?: { text: string }; position?: string } = {}
+    mutationFn: async ({ key, text, position, mode, status }) => {
+      const body: {
+        payload?: { text: string }
+        position?: string
+        mode?: `immediate` | `queued` | `paused` | `steer`
+        status?: `pending` | `processed` | `cancelled`
+      } = {}
       if (text !== undefined) {
         body.payload = { text }
       }
       if (position !== undefined) {
         body.position = position
+      }
+      if (mode !== undefined) {
+        body.mode = mode
+      }
+      if (status !== undefined) {
+        body.status = status
       }
       const res = await fetch(
         `${baseUrl}${entityUrl}/inbox/${encodeURIComponent(key)}`,

--- a/packages/agents-server-ui/src/lib/sendMessage.ts
+++ b/packages/agents-server-ui/src/lib/sendMessage.ts
@@ -1,4 +1,5 @@
 import { createOptimisticAction } from '@tanstack/db'
+import { generateKeyBetween } from 'fractional-indexing'
 import type { EntityStreamDBWithActions } from '@electric-ax/agents-runtime/client'
 
 // Timeline queries sort inbox messages by `_seq`. Pending local rows do not
@@ -14,12 +15,28 @@ type OptimisticInboxMessage = {
   from: string
   payload: { text: string }
   timestamp: string
+  mode: `immediate` | `queued` | `steer`
+  status: `pending` | `processed` | `cancelled`
+  position?: string
+  processed_at?: string
 }
 
 type SendMessageInput = {
   text: string
+  mode: `immediate` | `queued` | `steer`
   key: string
   seq: number
+  position?: string
+}
+
+type UpdateInboxMessageInput = {
+  key: string
+  text?: string
+  position?: string
+}
+
+type InboxMessageKeyInput = {
+  key: string
 }
 
 function createOptimisticInboxKey(seq: number): string {
@@ -32,6 +49,74 @@ function nextOptimisticInboxSeq(): number {
     optimisticInboxSeq = OPTIMISTIC_INBOX_SEQ_START
   }
   return optimisticInboxSeq
+}
+
+const QUEUE_POSITION_TIMESTAMP_WIDTH = 16
+const QUEUE_POSITION_SEPARATOR = `:`
+
+function padQueueTimestamp(timestamp: number): string {
+  return String(Math.max(0, Math.floor(timestamp))).padStart(
+    QUEUE_POSITION_TIMESTAMP_WIDTH,
+    `0`
+  )
+}
+
+function parseQueuePosition(position: string | undefined): {
+  timestamp: string
+  index: string | null
+} | null {
+  if (!position) return null
+  const match = /^(\d{16})(?::(.+))?$/.exec(position)
+  if (!match) return null
+  return { timestamp: match[1]!, index: match[2] ?? null }
+}
+
+function formatQueuePosition(timestamp: string, index: string): string {
+  return `${timestamp}${QUEUE_POSITION_SEPARATOR}${index}`
+}
+
+export function createInitialQueuePosition(now = Date.now()): string {
+  return formatQueuePosition(
+    padQueueTimestamp(now),
+    generateKeyBetween(null, null)
+  )
+}
+
+export function createQueuePositionBetween(
+  previousPosition: string | undefined,
+  nextPosition: string | undefined
+): string {
+  const previous = parseQueuePosition(previousPosition)
+  const next = parseQueuePosition(nextPosition)
+
+  if (previous && next && previous.timestamp === next.timestamp) {
+    return formatQueuePosition(
+      previous.timestamp,
+      generateKeyBetween(previous.index, next.index)
+    )
+  }
+
+  if (previous) {
+    return formatQueuePosition(
+      previous.timestamp,
+      generateKeyBetween(previous.index, null)
+    )
+  }
+
+  if (next) {
+    if (next.index !== null) {
+      return formatQueuePosition(
+        next.timestamp,
+        generateKeyBetween(null, next.index)
+      )
+    }
+    return formatQueuePosition(
+      padQueueTimestamp(Number(next.timestamp) - 1),
+      generateKeyBetween(null, null)
+    )
+  }
+
+  return createInitialQueuePosition()
 }
 
 function readSendError(status: number, body: string): Error {
@@ -47,6 +132,14 @@ function readSendError(status: number, body: string): Error {
   return new Error(message)
 }
 
+export function readTextPayload(payload: unknown): string {
+  if (payload && typeof payload === `object`) {
+    const text = (payload as { text?: unknown }).text
+    if (typeof text === `string`) return text
+  }
+  return typeof payload === `string` ? payload : ``
+}
+
 export function createSendMessageAction({
   db,
   baseUrl,
@@ -59,21 +152,26 @@ export function createSendMessageAction({
   from?: string
 }) {
   const action = createOptimisticAction<SendMessageInput>({
-    onMutate: ({ text, key, seq }) => {
+    onMutate: ({ text, mode, key, seq, position }) => {
+      const now = new Date().toISOString()
       const message: OptimisticInboxMessage = {
         key,
         _seq: seq,
         from,
         payload: { text },
-        timestamp: new Date().toISOString(),
+        timestamp: now,
+        mode,
+        status: mode === `queued` ? `pending` : `processed`,
+        ...(position ? { position } : {}),
+        ...(mode === `queued` ? {} : { processed_at: now }),
       }
       db.collections.inbox.insert(message)
     },
-    mutationFn: async ({ text, key }) => {
-      const res = await fetch(`${baseUrl}${entityUrl}/send`, {
+    mutationFn: async ({ text, key, mode, position }) => {
+      const res = await fetch(`${baseUrl}${entityUrl}/inbox`, {
         method: `POST`,
         headers: { 'content-type': `application/json` },
-        body: JSON.stringify({ from, key, payload: { text } }),
+        body: JSON.stringify({ from, key, payload: { text }, mode, position }),
       })
       if (!res.ok) {
         const body = await res.text().catch(() => ``)
@@ -82,8 +180,129 @@ export function createSendMessageAction({
     },
   })
 
-  return ({ text }: { text: string }) => {
+  return ({
+    text,
+    mode = `queued`,
+    position,
+  }: {
+    text: string
+    mode?: `immediate` | `queued` | `steer`
+    position?: string
+  }) => {
     const seq = nextOptimisticInboxSeq()
-    return action({ text, key: createOptimisticInboxKey(seq), seq })
+    const effectivePosition =
+      position ?? (mode === `queued` ? createInitialQueuePosition() : undefined)
+    return action({
+      text,
+      mode,
+      key: createOptimisticInboxKey(seq),
+      seq,
+      position: effectivePosition,
+    })
   }
+}
+
+export function createUpdateInboxMessageAction({
+  db,
+  baseUrl,
+  entityUrl,
+}: {
+  db: EntityStreamDBWithActions
+  baseUrl: string
+  entityUrl: string
+}) {
+  return createOptimisticAction<UpdateInboxMessageInput>({
+    onMutate: ({ key, text, position }) => {
+      db.collections.inbox.update(key, (draft) => {
+        if (text !== undefined) {
+          draft.payload = { text }
+        }
+        if (position !== undefined) {
+          draft.position = position
+        }
+      })
+    },
+    mutationFn: async ({ key, text, position }) => {
+      const body: { payload?: { text: string }; position?: string } = {}
+      if (text !== undefined) {
+        body.payload = { text }
+      }
+      if (position !== undefined) {
+        body.position = position
+      }
+      const res = await fetch(
+        `${baseUrl}${entityUrl}/inbox/${encodeURIComponent(key)}`,
+        {
+          method: `PATCH`,
+          headers: { 'content-type': `application/json` },
+          body: JSON.stringify(body),
+        }
+      )
+      if (!res.ok) {
+        const body = await res.text().catch(() => ``)
+        throw readSendError(res.status, body)
+      }
+    },
+  })
+}
+
+export function createDeleteInboxMessageAction({
+  db,
+  baseUrl,
+  entityUrl,
+}: {
+  db: EntityStreamDBWithActions
+  baseUrl: string
+  entityUrl: string
+}) {
+  return createOptimisticAction<InboxMessageKeyInput>({
+    onMutate: ({ key }) => {
+      db.collections.inbox.delete(key)
+    },
+    mutationFn: async ({ key }) => {
+      const res = await fetch(
+        `${baseUrl}${entityUrl}/inbox/${encodeURIComponent(key)}`,
+        { method: `DELETE` }
+      )
+      if (!res.ok) {
+        const body = await res.text().catch(() => ``)
+        throw readSendError(res.status, body)
+      }
+    },
+  })
+}
+
+export function createSteerInboxMessageAction({
+  db,
+  baseUrl,
+  entityUrl,
+}: {
+  db: EntityStreamDBWithActions
+  baseUrl: string
+  entityUrl: string
+}) {
+  return createOptimisticAction<InboxMessageKeyInput>({
+    onMutate: ({ key }) => {
+      const now = new Date().toISOString()
+      db.collections.inbox.update(key, (draft) => {
+        draft.mode = `steer`
+        draft.status = `processed`
+        draft.processed_at = now
+      })
+    },
+    mutationFn: async ({ key }) => {
+      const res = await fetch(
+        `${baseUrl}${entityUrl}/inbox/${encodeURIComponent(key)}`,
+        {
+          method: `PATCH`,
+          headers: { 'content-type': `application/json` },
+          body: JSON.stringify({ mode: `steer`, status: `processed` }),
+        }
+      )
+      if (!res.ok) {
+        const body = await res.text().catch(() => ``)
+        throw readSendError(res.status, body)
+      }
+    },
+  })
 }

--- a/packages/agents-server-ui/src/lib/sendMessage.ts
+++ b/packages/agents-server-ui/src/lib/sendMessage.ts
@@ -9,7 +9,7 @@ const OPTIMISTIC_INBOX_SEQ_START = Number.MAX_SAFE_INTEGER - 1_000_000
 
 let optimisticInboxSeq = OPTIMISTIC_INBOX_SEQ_START
 
-type OptimisticInboxMessage = {
+export type OptimisticInboxMessage = {
   key: string
   _seq: number
   from: string
@@ -147,11 +147,13 @@ export function createSendMessageAction({
   baseUrl,
   entityUrl,
   from = `user`,
+  onOptimisticMessage,
 }: {
   db: EntityStreamDBWithActions
   baseUrl: string
   entityUrl: string
   from?: string
+  onOptimisticMessage?: (message: OptimisticInboxMessage) => void
 }) {
   const action = createOptimisticAction<SendMessageInput>({
     onMutate: ({ text, mode, key, seq, position }) => {
@@ -171,6 +173,7 @@ export function createSendMessageAction({
           : { processed_at: now }),
       }
       db.collections.inbox.insert(message)
+      onOptimisticMessage?.(message)
     },
     mutationFn: async ({ text, key, mode, position }) => {
       const res = await fetch(`${baseUrl}${entityUrl}/inbox`, {

--- a/packages/agents-server/src/electric-agents-manager.ts
+++ b/packages/agents-server/src/electric-agents-manager.ts
@@ -1686,14 +1686,17 @@ export class ElectricAgentsManager {
       payload: req.payload,
       timestamp: now,
       mode: req.mode ?? `immediate`,
-      status: req.mode === `queued` ? `pending` : `processed`,
+      status:
+        req.mode === `queued` || req.mode === `paused`
+          ? `pending`
+          : `processed`,
     }
     if (req.type) {
       value.message_type = req.type
     }
     if (req.position) {
       value.position = req.position
-    } else if (value.mode === `queued`) {
+    } else if (value.mode === `queued` || value.mode === `paused`) {
       value.position = createInitialQueuePosition(new Date(now))
     }
     if (value.status === `processed`) {
@@ -1733,7 +1736,7 @@ export class ElectricAgentsManager {
     req: {
       payload?: unknown
       position?: string
-      mode?: `immediate` | `queued` | `steer`
+      mode?: `immediate` | `queued` | `paused` | `steer`
       status?: `pending` | `processed` | `cancelled`
     }
   ): Promise<void> {

--- a/packages/agents-server/src/electric-agents-manager.ts
+++ b/packages/agents-server/src/electric-agents-manager.ts
@@ -63,6 +63,10 @@ type SpawnPersistResult = [
 ]
 type SpawnPersistJob = () => Promise<SpawnPersistResult>
 
+function createInitialQueuePosition(date: Date): string {
+  return `${String(date.getTime()).padStart(16, `0`)}:a0`
+}
+
 type ForkSubtreeOptions = {
   rootInstanceId?: string
   waitTimeoutMs?: number
@@ -1681,9 +1685,19 @@ export class ElectricAgentsManager {
       from: req.from,
       payload: req.payload,
       timestamp: now,
+      mode: req.mode ?? `immediate`,
+      status: req.mode === `queued` ? `pending` : `processed`,
     }
     if (req.type) {
       value.message_type = req.type
+    }
+    if (req.position) {
+      value.position = req.position
+    } else if (value.mode === `queued`) {
+      value.position = createInitialQueuePosition(new Date(now))
+    }
+    if (value.status === `processed`) {
+      value.processed_at = now
     }
 
     const envelope = entityStateSchema.inbox.insert({
@@ -1711,6 +1725,69 @@ export class ElectricAgentsManager {
       }
       throw err
     }
+  }
+
+  async updateInboxMessage(
+    entityUrl: string,
+    key: string,
+    req: {
+      payload?: unknown
+      position?: string
+      mode?: `immediate` | `queued` | `steer`
+      status?: `pending` | `processed` | `cancelled`
+    }
+  ): Promise<void> {
+    const entity = await this.registry.getEntity(entityUrl)
+    if (!entity) {
+      throw new ElectricAgentsError(ErrCodeNotFound, `Entity not found`, 404)
+    }
+    if (entity.status === `stopped`) {
+      throw new ElectricAgentsError(ErrCodeNotRunning, `Entity is stopped`, 409)
+    }
+
+    const now = new Date().toISOString()
+    const value: Record<string, unknown> = {}
+    if (`payload` in req) value.payload = req.payload
+    if (req.position !== undefined) value.position = req.position
+    if (req.mode !== undefined) value.mode = req.mode
+    if (req.status !== undefined) {
+      value.status = req.status
+      if (req.status === `processed`) value.processed_at = now
+      if (req.status === `cancelled`) value.cancelled_at = now
+    }
+
+    if (Object.keys(value).length === 0) {
+      throw new ElectricAgentsError(
+        ErrCodeInvalidRequest,
+        `No inbox fields to update`,
+        400
+      )
+    }
+
+    const envelope = entityStateSchema.inbox.update({
+      key,
+      value,
+    } as any)
+    await this.streamClient.append(
+      entity.streams.main,
+      this.encodeChangeEvent(envelope as Record<string, unknown>)
+    )
+  }
+
+  async deleteInboxMessage(entityUrl: string, key: string): Promise<void> {
+    const entity = await this.registry.getEntity(entityUrl)
+    if (!entity) {
+      throw new ElectricAgentsError(ErrCodeNotFound, `Entity not found`, 404)
+    }
+    if (entity.status === `stopped`) {
+      throw new ElectricAgentsError(ErrCodeNotRunning, `Entity is stopped`, 409)
+    }
+
+    const envelope = entityStateSchema.inbox.delete({ key } as any)
+    await this.streamClient.append(
+      entity.streams.main,
+      this.encodeChangeEvent(envelope as Record<string, unknown>)
+    )
   }
 
   // ==========================================================================
@@ -2062,6 +2139,8 @@ export class ElectricAgentsManager {
         payload: req.payload,
         key: req.key,
         type: req.type,
+        mode: req.mode,
+        position: req.position,
       },
       fireAt
     )

--- a/packages/agents-server/src/electric-agents-routes.ts
+++ b/packages/agents-server/src/electric-agents-routes.ts
@@ -372,7 +372,7 @@ export class ElectricAgentsRoutes {
       payload?: unknown
       key?: string
       type?: string
-      mode?: `immediate` | `queued` | `steer`
+      mode?: `immediate` | `queued` | `paused` | `steer`
       position?: string
       afterMs?: number
     }>(req, res)
@@ -418,7 +418,7 @@ export class ElectricAgentsRoutes {
     const parsed = await parseJsonBody<{
       payload?: unknown
       position?: string
-      mode?: `immediate` | `queued` | `steer`
+      mode?: `immediate` | `queued` | `paused` | `steer`
       status?: `pending` | `processed` | `cancelled`
     }>(req, res)
     if (!parsed) return

--- a/packages/agents-server/src/electric-agents-routes.ts
+++ b/packages/agents-server/src/electric-agents-routes.ts
@@ -147,6 +147,67 @@ export class ElectricAgentsRoutes {
       return false
     }
 
+    const inboxItemMatch = path.match(
+      /^(\/(?!_)[^/*]+\/[^/*]+)\/inbox\/([^/*]+)$/
+    )
+    if (inboxItemMatch) {
+      const entityUrl = inboxItemMatch[1]!
+      const messageKey = decodeURIComponent(inboxItemMatch[2]!)
+
+      const entity = await this.manager.registry.getEntity(entityUrl)
+      if (!entity) {
+        const typeName = entityUrl.split(`/`)[1]!
+        const entityType = await this.manager.registry.getEntityType(typeName)
+        if (entityType) {
+          sendJsonError(
+            res,
+            404,
+            `NOT_FOUND`,
+            `Entity not found at ${entityUrl}`
+          )
+          return true
+        }
+        return false
+      }
+
+      if (method === `PATCH`) {
+        await this.handleUpdateInboxMessage(entityUrl, messageKey, req, res)
+        return true
+      }
+      if (method === `DELETE`) {
+        await this.handleDeleteInboxMessage(entityUrl, messageKey, res)
+        return true
+      }
+      return false
+    }
+
+    const inboxMatch = path.match(/^(\/(?!_)[^/*]+\/[^/*]+)\/inbox$/)
+    if (inboxMatch) {
+      const entityUrl = inboxMatch[1]!
+
+      const entity = await this.manager.registry.getEntity(entityUrl)
+      if (!entity) {
+        const typeName = entityUrl.split(`/`)[1]!
+        const entityType = await this.manager.registry.getEntityType(typeName)
+        if (entityType) {
+          sendJsonError(
+            res,
+            404,
+            `NOT_FOUND`,
+            `Entity not found at ${entityUrl}`
+          )
+          return true
+        }
+        return false
+      }
+
+      if (method === `POST`) {
+        await this.handleSend(entityUrl, req, res)
+        return true
+      }
+      return false
+    }
+
     const actionMatch = path.match(/^(\/(?!_)[^/*]+\/[^/*]+)\/send$/)
     if (actionMatch) {
       const entityUrl = actionMatch[1]!
@@ -311,6 +372,8 @@ export class ElectricAgentsRoutes {
       payload?: unknown
       key?: string
       type?: string
+      mode?: `immediate` | `queued` | `steer`
+      position?: string
       afterMs?: number
     }>(req, res)
     if (!parsed) return
@@ -324,6 +387,8 @@ export class ElectricAgentsRoutes {
             payload: parsed.payload,
             key: parsed.key,
             type: parsed.type,
+            mode: parsed.mode,
+            position: parsed.position,
           },
           new Date(Date.now() + parsed.afterMs)
         )
@@ -333,8 +398,47 @@ export class ElectricAgentsRoutes {
           payload: parsed.payload,
           key: parsed.key,
           type: parsed.type,
+          mode: parsed.mode,
+          position: parsed.position,
         })
       }
+      res.writeHead(204)
+      res.end()
+    } catch (err) {
+      handleElectricAgentsError(err, res)
+    }
+  }
+
+  private async handleUpdateInboxMessage(
+    entityUrl: string,
+    messageKey: string,
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> {
+    const parsed = await parseJsonBody<{
+      payload?: unknown
+      position?: string
+      mode?: `immediate` | `queued` | `steer`
+      status?: `pending` | `processed` | `cancelled`
+    }>(req, res)
+    if (!parsed) return
+
+    try {
+      await this.manager.updateInboxMessage(entityUrl, messageKey, parsed)
+      res.writeHead(204)
+      res.end()
+    } catch (err) {
+      handleElectricAgentsError(err, res)
+    }
+  }
+
+  private async handleDeleteInboxMessage(
+    entityUrl: string,
+    messageKey: string,
+    res: ServerResponse
+  ): Promise<void> {
+    try {
+      await this.manager.deleteInboxMessage(entityUrl, messageKey)
       res.writeHead(204)
       res.end()
     } catch (err) {

--- a/packages/agents-server/src/electric-agents-types.ts
+++ b/packages/agents-server/src/electric-agents-types.ts
@@ -121,7 +121,7 @@ export interface SendRequest {
   payload?: unknown
   key?: string
   type?: string
-  mode?: `immediate` | `queued` | `steer`
+  mode?: `immediate` | `queued` | `paused` | `steer`
   position?: string
 }
 

--- a/packages/agents-server/src/electric-agents-types.ts
+++ b/packages/agents-server/src/electric-agents-types.ts
@@ -121,6 +121,8 @@ export interface SendRequest {
   payload?: unknown
   key?: string
   type?: string
+  mode?: `immediate` | `queued` | `steer`
+  position?: string
 }
 
 export interface SetTagRequest {

--- a/packages/agents-server/src/scheduler.ts
+++ b/packages/agents-server/src/scheduler.ts
@@ -7,6 +7,8 @@ export interface DelayedSendPayload {
   payload: unknown
   key?: string
   type?: string
+  mode?: `immediate` | `queued` | `steer`
+  position?: string
   producerId?: string
   manifest?: {
     ownerEntityUrl: string

--- a/packages/agents-server/src/scheduler.ts
+++ b/packages/agents-server/src/scheduler.ts
@@ -7,7 +7,7 @@ export interface DelayedSendPayload {
   payload: unknown
   key?: string
   type?: string
-  mode?: `immediate` | `queued` | `steer`
+  mode?: `immediate` | `queued` | `paused` | `steer`
   position?: string
   producerId?: string
   manifest?: {

--- a/packages/agents-server/src/server.ts
+++ b/packages/agents-server/src/server.ts
@@ -332,6 +332,8 @@ export class ElectricAgentsServer {
                       payload: payload.payload,
                       key: payload.key ?? `scheduled-task-${taskId}`,
                       type: payload.type,
+                      mode: payload.mode,
+                      position: payload.position,
                     },
                     {
                       producerId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,6 +918,34 @@ importers:
         specifier: ^4.18.1
         version: 4.24.4
 
+  examples/replay-loop-repro:
+    dependencies:
+      '@electric-sql/client':
+        specifier: workspace:*
+        version: link:../../packages/typescript-client
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.1
+      '@vitejs/plugin-react':
+        specifier: ^4.3.1
+        version: 4.3.3(vite@5.4.10(@types/node@25.6.0)(lightningcss@1.30.1)(terser@5.46.2))
+      typescript:
+        specifier: ^5.5.3
+        version: 5.8.3
+      vite:
+        specifier: ^5.3.4
+        version: 5.4.10(@types/node@25.6.0)(lightningcss@1.30.1)(terser@5.46.2)
+
   examples/tanstack:
     dependencies:
       '@electric-sql/client':
@@ -1858,6 +1886,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.13.23
         version: 3.13.24(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      fractional-indexing:
+        specifier: ^3.2.0
+        version: 3.2.0
       katex:
         specifier: ^0.16.45
         version: 0.16.45
@@ -5910,19 +5941,23 @@ packages:
   '@mariozechner/pi-agent-core@0.57.1':
     resolution: {integrity: sha512-WXsBbkNWOObFGHkhixaT8GXJpHDd3+fn8QntYF+4R8Sa9WB90ENXWidO6b7vcKX+JX0jjO5dIsQxmzosARJKlg==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-agent-core instead going forward
 
   '@mariozechner/pi-agent-core@0.70.2':
     resolution: {integrity: sha512-g1hIdKyDwmQOoBGO0R4OhpemKeMENeK0vE5FJtuQKqEcsdCAkVBgZAK6aZUARYZVxMA718JS6WPLFWoddzjD7g==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-agent-core instead going forward
 
   '@mariozechner/pi-ai@0.57.1':
     resolution: {integrity: sha512-Bd/J4a3YpdzJVyHLih0vDSdB0QPL4ti0XsAwtHOK/8eVhB0fHM1CpcgIrcBFJ23TMcKXMi0qamz18ERfp8tmgg==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-ai instead going forward
     hasBin: true
 
   '@mariozechner/pi-ai@0.70.2':
     resolution: {integrity: sha512-+30LRPjXsXF+oI96DvGWMbdPGeqoLJvadh6UPev7wx2DzhC9FEqXkQcoMZ0usbCm7E9pl8ua8a9s/pQ5ikaUbg==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-ai instead going forward
     hasBin: true
 
   '@mermaid-js/parser@1.1.0':
@@ -28987,7 +29022,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.2)(tsx@4.20.3)(yaml@2.8.1))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@7.1.7(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.2)(tsx@4.20.3)(yaml@2.8.1))
 
   '@vitest/expect@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- Add first-class inbox message delivery modes (`queued`, `steer`, and `paused`) with pending/processed/cancelled status metadata across the agents runtime and server APIs.
- Promote queued inbox messages one at a time in the runtime, pause at edited messages, and avoid deleted/cancelled lifecycle events waking agents as runnable prompts.
- Add the agents UI queued-message drawer with edit/delete/steer/reorder controls, fractional queue positions, and inline optimistic display for idle queued sends.

## Test plan
- `pnpm -C packages/agents-runtime typecheck`
- `pnpm -C packages/agents-server typecheck`
- `pnpm -C packages/agents-server-ui typecheck`
- Browser smoke tested `http://localhost:5173/__agent_ui/` for queued sends, inline idle optimistic display, and Horton generation.

Made with [Cursor](https://cursor.com)