### PR TITLE
docs: link ELECTRIC_MANUAL_TABLE_PUBLISHING to permissions guide

### DIFF
--- a/website/docs/sync/api/config.md
+++ b/website/docs/sync/api/config.md
@@ -191,7 +191,7 @@ Set to `true` to disable automatic addition/removal of database tables from the 
 
 In order to receive realtime updates as soon as they are committed in Postgres, Electric maintains a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) inside the database and automatically adds tables to it for which shape subscriptions are established. This only works if Electric's database role owns the table or is granted the [group role](https://www.postgresql.org/docs/current/role-membership.html#ROLE-MEMBERSHIP) that owns the table.
 
-If your permissions policies prevent Electric from using a role that can alter application tables, set this setting to `true` and manually add each table to the publication by executing
+If your permissions policies prevent Electric from using a role that can alter application tables, set this setting to `true` and manually add each table to the publication. See the [Manual Mode Setup guide](/docs/sync/guides/postgres-permissions#manual-mode-setup) for complete setup instructions, or use the following minimal steps:
 
 ```sql
 BEGIN;


### PR DESCRIPTION
## Summary
- Add cross-reference from the `ELECTRIC_MANUAL_TABLE_PUBLISHING` config option to the Manual Mode Setup guide
- Makes it easier for users to find complete setup instructions when using manual publishing mode

Closes #4285

## Test plan
- [x] Verify the link renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)