### PR TITLE
Require system prompts for low-cost model calls

### DIFF
--- a/.changeset/require-low-cost-system-prompts.md
+++ b/.changeset/require-low-cost-system-prompts.md
@@ -1,0 +1,6 @@
+---
+"@electric-ax/agents-runtime": patch
+"@electric-ax/agents": patch
+---
+
+Require low-cost model calls to provide an explicit system prompt and add prompts for URL extraction and skill metadata extraction.

--- a/packages/agents-runtime/src/model-runner.ts
+++ b/packages/agents-runtime/src/model-runner.ts
@@ -130,7 +130,7 @@ export async function completeWithLowCostModel(input: {
   log?: (message: string) => void
   logPrefix?: string
   purpose: string
-  systemPrompt?: string
+  systemPrompt: string
   prompt: string
   maxTokens: number
 }): Promise<string> {
@@ -155,7 +155,7 @@ export async function completeWithLowCostModel(input: {
   const res = await completeSimple(
     model,
     {
-      ...(input.systemPrompt && { systemPrompt: input.systemPrompt }),
+      systemPrompt: input.systemPrompt,
       messages: [
         { role: `user`, content: input.prompt, timestamp: Date.now() },
       ],

--- a/packages/agents-runtime/src/tools/fetch-url.ts
+++ b/packages/agents-runtime/src/tools/fetch-url.ts
@@ -40,6 +40,7 @@ function createPiRunnerExtractor(opts: {
       log: opts.log,
       logPrefix: opts.logPrefix,
       purpose: `URL extraction`,
+      systemPrompt: `Extract the requested information from the page content. Return only the extracted content, without commentary about the extraction process.`,
       prompt: `${prompt}\n\n<page_content>\n${text}\n</page_content>`,
       maxTokens: 2048,
     })

--- a/packages/agents-runtime/test/model-runner.test.ts
+++ b/packages/agents-runtime/test/model-runner.test.ts
@@ -20,7 +20,9 @@ describe(`completeWithLowCostModel`, () => {
   test(`passes required system prompt`, async () => {
     await completeWithLowCostModel({
       catalog: {
-        choices: [{ provider: `openai-codex`, id: `gpt-5.4-mini`, reasoning: false }],
+        choices: [
+          { provider: `openai-codex`, id: `gpt-5.4-mini`, reasoning: false },
+        ],
       },
       purpose: `URL extraction`,
       systemPrompt: `Custom instructions`,

--- a/packages/agents-runtime/test/model-runner.test.ts
+++ b/packages/agents-runtime/test/model-runner.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const completeSimple = vi.fn()
+const getModel = vi.fn(() => ({ provider: `openai-codex`, id: `gpt-5.4-mini` }))
+
+vi.mock(`@mariozechner/pi-ai`, () => ({ completeSimple, getModel }))
+
+const { completeWithLowCostModel } = await import(`../src/model-runner`)
+
+describe(`completeWithLowCostModel`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    completeSimple.mockResolvedValue({
+      content: [{ type: `text`, text: `ok` }],
+      stopReason: `stop`,
+      errorMessage: undefined,
+    })
+  })
+
+  test(`passes required system prompt`, async () => {
+    await completeWithLowCostModel({
+      catalog: {
+        choices: [{ provider: `openai-codex`, id: `gpt-5.4-mini`, reasoning: false }],
+      },
+      purpose: `URL extraction`,
+      systemPrompt: `Custom instructions`,
+      prompt: `Extract the title`,
+      maxTokens: 128,
+    })
+
+    expect(completeSimple).toHaveBeenCalledOnce()
+    expect(completeSimple.mock.calls[0][1].systemPrompt).toBe(
+      `Custom instructions`
+    )
+  })
+})

--- a/packages/agents/src/skills/extract-meta.ts
+++ b/packages/agents/src/skills/extract-meta.ts
@@ -76,6 +76,7 @@ Return raw JSON, no markdown fences.`
 
   const text = await completeWithLowCostModel({
     purpose: `skill metadata extraction`,
+    systemPrompt: `Extract metadata from skill documents. Return only valid JSON that matches the requested schema.`,
     prompt,
     maxTokens: 256,
     log: (message) => serverLog.info(message),


### PR DESCRIPTION
## Summary
- make completeWithLowCostModel require a systemPrompt at the type level
- add explicit system prompts for fetch_url extraction and skill metadata extraction
- add a focused test that verifies the system prompt is passed through

## Testing
- pnpm exec vitest run packages/agents-runtime/test/model-runner.test.ts

Note: broader typecheck was not run after pnpm install; prior attempt hit dependency/type resolution issues in the fresh worktree.