### PR TITLE
Emit telemetry spans for move_in_query snapshot operations

### DIFF
--- a/.changeset/move-in-query-telemetry.md
+++ b/.changeset/move-in-query-telemetry.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Emit `shape_snapshot.execute_for_shape` and `shape_snapshot.query_fn` spans for `move_in_query` operations. Previously these spans were silently dropped because the spawned move-in task had no parent span context, and `with_child_span` skips emission when no parent exists. A `shape_snapshot.move_in_task` root span is now opened inside the task (mirroring `shape_snapshot.create_snapshot_task` for initial snapshots) so the existing child spans are emitted with `shape.query_reason="move_in_query"`.

--- a/packages/sync-service/lib/electric/postgres/snapshot_query.ex
+++ b/packages/sync-service/lib/electric/postgres/snapshot_query.ex
@@ -42,12 +42,12 @@ defmodule Electric.Postgres.SnapshotQuery do
     query_fn = Access.fetch!(opts, :query_fn)
     snapshot_info_fn = Access.fetch!(opts, :snapshot_info_fn)
     query_reason = Access.get(opts, :query_reason, "initial_snapshot")
-    shape_attrs = shape_attrs(shape_handle, shape, query_reason)
+    span_attrs = Shape.otel_attrs(shape_handle, shape, query_reason: query_reason)
     stack_id = Access.fetch!(opts, :stack_id)
 
     OpenTelemetry.with_child_span(
       "shape_snapshot.execute_for_shape",
-      shape_attrs,
+      span_attrs,
       stack_id,
       fn ->
         OpenTelemetry.start_interval(:"shape_snapshot.checkout_wait.duration_µs")
@@ -60,7 +60,7 @@ defmodule Electric.Postgres.SnapshotQuery do
             ctx = %{
               conn: conn,
               stack_id: stack_id,
-              span_attrs: shape_attrs
+              span_attrs: span_attrs
             }
 
             query!(ctx, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
@@ -83,7 +83,7 @@ defmodule Electric.Postgres.SnapshotQuery do
             result =
               OpenTelemetry.with_child_span(
                 "shape_snapshot.query_fn",
-                shape_attrs,
+                span_attrs,
                 stack_id,
                 fn -> query_fn.(conn, pg_snapshot, lsn) end
               )
@@ -101,15 +101,6 @@ defmodule Electric.Postgres.SnapshotQuery do
   catch
     :exit, {_, {DBConnection.Holder, :checkout, _}} ->
       raise SnapshotError.connection_not_available()
-  end
-
-  defp shape_attrs(shape_handle, shape, query_reason) do
-    [
-      "shape.handle": shape_handle,
-      "shape.root_table": shape.root_table,
-      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil),
-      "shape.query_reason": query_reason
-    ]
   end
 
   @spec query!(map(), String.t() | [String.t()], Keyword.t()) :: [Postgrex.Result.t(), ...]

--- a/packages/sync-service/lib/electric/shapes/consumer/effects.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/effects.ex
@@ -269,47 +269,56 @@ defmodule Electric.Shapes.Consumer.Effects do
     # `with_child_span` calls in the task would be silently dropped.
     trace_context = OpenTelemetry.get_current_context()
 
+    span_attrs = [
+      "shape.handle": shape_handle,
+      "shape.root_table": shape.root_table,
+      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil),
+      "shape.query_reason": "move_in_query"
+    ]
+
     Task.Supervisor.start_child(supervisor, fn ->
       OpenTelemetry.set_current_context(trace_context)
 
       snapshot_name = Electric.Utils.uuid4()
 
       try do
-        SnapshotQuery.execute_for_shape(pool, shape_handle, shape,
-          stack_id: stack_id,
-          query_reason: "move_in_query",
-          snapshot_info_fn: fn _, pg_snapshot, _lsn ->
-            send(consumer_pid, {:pg_snapshot_known, pg_snapshot})
-          end,
-          query_fn: fn conn, _pg_snapshot, lsn ->
-            task_pid = self()
+        OpenTelemetry.with_span("shape_snapshot.move_in_task", span_attrs, stack_id, fn ->
+          SnapshotQuery.execute_for_shape(pool, shape_handle, shape,
+            stack_id: stack_id,
+            query_reason: "move_in_query",
+            snapshot_info_fn: fn _, pg_snapshot, _lsn ->
+              send(consumer_pid, {:pg_snapshot_known, pg_snapshot})
+            end,
+            query_fn: fn conn, _pg_snapshot, lsn ->
+              task_pid = self()
 
-            Querying.query_move_in(conn, stack_id, shape_handle, shape, {where, params},
-              dnf_plan: request.dnf_plan,
-              views: request.views_after_move
-            )
-            |> Stream.transform(
-              fn -> {0, 0} end,
-              fn [_, _, json] = row, {row_count, row_bytes} ->
-                {[row], {row_count + 1, row_bytes + IO.iodata_length(json)}}
-              end,
-              fn {row_count, row_bytes} ->
-                send(task_pid, {:move_in_snapshot_stats, row_count, row_bytes})
-              end
-            )
-            |> Storage.write_move_in_snapshot!(snapshot_name, consumer_state.storage)
+              Querying.query_move_in(conn, stack_id, shape_handle, shape, {where, params},
+                dnf_plan: request.dnf_plan,
+                views: request.views_after_move
+              )
+              |> Stream.transform(
+                fn -> {0, 0} end,
+                fn [_, _, json] = row, {row_count, row_bytes} ->
+                  {[row], {row_count + 1, row_bytes + IO.iodata_length(json)}}
+                end,
+                fn {row_count, row_bytes} ->
+                  send(task_pid, {:move_in_snapshot_stats, row_count, row_bytes})
+                end
+              )
+              |> Storage.write_move_in_snapshot!(snapshot_name, consumer_state.storage)
 
-            {row_count, row_bytes} =
-              receive do
-                {:move_in_snapshot_stats, row_count, row_bytes} -> {row_count, row_bytes}
-              end
+              {row_count, row_bytes} =
+                receive do
+                  {:move_in_snapshot_stats, row_count, row_bytes} -> {row_count, row_bytes}
+                end
 
-            send(
-              consumer_pid,
-              {:query_move_in_complete, snapshot_name, row_count, row_bytes, lsn}
-            )
-          end
-        )
+              send(
+                consumer_pid,
+                {:query_move_in_complete, snapshot_name, row_count, row_bytes, lsn}
+              )
+            end
+          )
+        end)
       rescue
         error ->
           send(consumer_pid, {:query_move_in_error, error, __STACKTRACE__})

--- a/packages/sync-service/lib/electric/shapes/consumer/effects.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/effects.ex
@@ -240,25 +240,49 @@ defmodule Electric.Shapes.Consumer.Effects do
   end
 
   @spec query_move_in_async(pid() | atom(), map(), StartMoveInQuery.t(), pid()) :: :ok
-  def query_move_in_async(
-        supervisor,
-        consumer_state,
-        %StartMoveInQuery{} = request,
-        consumer_pid
-      ) do
+  def query_move_in_async(supervisor, consumer_state, %StartMoveInQuery{} = request, consumer_pid) do
+    %{stack_id: stack_id, shape_handle: shape_handle, shape: shape, storage: storage} =
+      consumer_state
+
     {where, params} =
       Querying.move_in_where_clause(
         request.dnf_plan,
         request.trigger_dep_index,
         request.views_before_move,
         request.views_after_move,
-        consumer_state.shape.where.used_refs
+        shape.where.used_refs
       )
 
-    pool = Manager.pool_name(consumer_state.stack_id, :snapshot)
-    stack_id = consumer_state.stack_id
-    shape = consumer_state.shape
-    shape_handle = consumer_state.shape_handle
+    snapshot_name = Electric.Utils.uuid4()
+
+    query_fn = fn conn, _pg_snapshot, lsn ->
+      task_pid = self()
+
+      Querying.query_move_in(conn, stack_id, shape_handle, shape, {where, params},
+        dnf_plan: request.dnf_plan,
+        views: request.views_after_move
+      )
+      |> Stream.transform(
+        fn -> {0, 0} end,
+        fn [_, _, json] = row, {row_count, row_bytes} ->
+          {[row], {row_count + 1, row_bytes + IO.iodata_length(json)}}
+        end,
+        fn {row_count, row_bytes} ->
+          send(task_pid, {:move_in_snapshot_stats, row_count, row_bytes})
+        end
+      )
+      |> Storage.write_move_in_snapshot!(snapshot_name, storage)
+
+      {row_count, row_bytes} =
+        receive do
+          {:move_in_snapshot_stats, row_count, row_bytes} -> {row_count, row_bytes}
+        end
+
+      send(
+        consumer_pid,
+        {:query_move_in_complete, snapshot_name, row_count, row_bytes, lsn}
+      )
+    end
 
     :telemetry.execute([:electric, :subqueries, :move_in_triggered], %{count: 1}, %{
       stack_id: stack_id
@@ -269,58 +293,34 @@ defmodule Electric.Shapes.Consumer.Effects do
     # `with_child_span` calls in the task would be silently dropped.
     trace_context = OpenTelemetry.get_current_context()
 
-    span_attrs = Shape.otel_attrs(shape_handle, shape, query_reason: "move_in_query")
-
     Task.Supervisor.start_child(supervisor, fn ->
       OpenTelemetry.set_current_context(trace_context)
 
-      snapshot_name = Electric.Utils.uuid4()
-
-      try do
-        OpenTelemetry.with_span("shape_snapshot.move_in_task", span_attrs, stack_id, fn ->
-          SnapshotQuery.execute_for_shape(pool, shape_handle, shape,
-            stack_id: stack_id,
-            query_reason: "move_in_query",
-            snapshot_info_fn: fn _, pg_snapshot, _lsn ->
-              send(consumer_pid, {:pg_snapshot_known, pg_snapshot})
-            end,
-            query_fn: fn conn, _pg_snapshot, lsn ->
-              task_pid = self()
-
-              Querying.query_move_in(conn, stack_id, shape_handle, shape, {where, params},
-                dnf_plan: request.dnf_plan,
-                views: request.views_after_move
-              )
-              |> Stream.transform(
-                fn -> {0, 0} end,
-                fn [_, _, json] = row, {row_count, row_bytes} ->
-                  {[row], {row_count + 1, row_bytes + IO.iodata_length(json)}}
-                end,
-                fn {row_count, row_bytes} ->
-                  send(task_pid, {:move_in_snapshot_stats, row_count, row_bytes})
-                end
-              )
-              |> Storage.write_move_in_snapshot!(snapshot_name, consumer_state.storage)
-
-              {row_count, row_bytes} =
-                receive do
-                  {:move_in_snapshot_stats, row_count, row_bytes} -> {row_count, row_bytes}
-                end
-
-              send(
-                consumer_pid,
-                {:query_move_in_complete, snapshot_name, row_count, row_bytes, lsn}
-              )
-            end
-          )
-        end)
-      rescue
-        error ->
-          send(consumer_pid, {:query_move_in_error, error, __STACKTRACE__})
-      end
+      OpenTelemetry.with_span(
+        "shape_snapshot.move_in_task",
+        Shape.otel_attrs(shape_handle, shape, query_reason: "move_in_query"),
+        stack_id,
+        fn -> execute_move_in_query(stack_id, shape_handle, shape, consumer_pid, query_fn) end
+      )
     end)
 
     :ok
+  end
+
+  # Synchronous core of query_move_in_async(). Expects the current OTel context to already be set up by the caller.
+  defp execute_move_in_query(stack_id, shape_handle, shape, consumer_pid, query_fn) do
+    pool = Manager.pool_name(stack_id, :snapshot)
+
+    SnapshotQuery.execute_for_shape(pool, shape_handle, shape,
+      stack_id: stack_id,
+      query_reason: "move_in_query",
+      snapshot_info_fn: fn _, pg_snapshot, _lsn ->
+        send(consumer_pid, {:pg_snapshot_known, pg_snapshot})
+      end,
+      query_fn: query_fn
+    )
+  rescue
+    error -> send(consumer_pid, {:query_move_in_error, error, __STACKTRACE__})
   end
 
   defp consider_flushed(state, log_offset) do

--- a/packages/sync-service/lib/electric/shapes/consumer/effects.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/effects.ex
@@ -269,12 +269,7 @@ defmodule Electric.Shapes.Consumer.Effects do
     # `with_child_span` calls in the task would be silently dropped.
     trace_context = OpenTelemetry.get_current_context()
 
-    span_attrs = [
-      "shape.handle": shape_handle,
-      "shape.root_table": shape.root_table,
-      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil),
-      "shape.query_reason": "move_in_query"
-    ]
+    span_attrs = Shape.otel_attrs(shape_handle, shape, query_reason: "move_in_query")
 
     Task.Supervisor.start_child(supervisor, fn ->
       OpenTelemetry.set_current_context(trace_context)

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -44,18 +44,20 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
 
     if not is_nil(state.otel_ctx), do: OpenTelemetry.set_current_context(state.otel_ctx)
 
+    span_attrs = Shapes.Shape.otel_attrs(shape_handle, shape)
+
     result =
       case Shapes.Consumer.whereis(stack_id, shape_handle) do
         consumer when is_pid(consumer) ->
           OpenTelemetry.with_span(
             "shape_snapshot.create_snapshot_task",
-            telemetry_shape_attrs(shape_handle, shape),
+            span_attrs,
             stack_id,
             fn ->
               try do
                 OpenTelemetry.with_span(
                   "shape_snapshot.prepare_tables",
-                  telemetry_shape_attrs(shape_handle, shape),
+                  span_attrs,
                   stack_id,
                   fn ->
                     Electric.Replication.PublicationManager.add_shape(
@@ -297,18 +299,10 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
             count: 1,
             operations: ops
           },
-          Map.merge(Map.new(telemetry_shape_attrs(shape_handle, shape)), %{stack_id: stack_id})
+          Map.merge(Map.new(Shapes.Shape.otel_attrs(shape_handle, shape)), %{stack_id: stack_id})
         )
       end
     )
-  end
-
-  defp telemetry_shape_attrs(shape_handle, shape) do
-    [
-      "shape.handle": shape_handle,
-      "shape.root_table": shape.root_table,
-      "shape.where": if(not is_nil(shape.where), do: shape.where.query, else: nil)
-    ]
   end
 
   if Mix.env() == :test do

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -1108,6 +1108,23 @@ defmodule Electric.Shapes.Shape do
   defp column_info_from_json({"type_kind", kind}), do: {:type_kind, String.to_existing_atom(kind)}
   defp column_info_from_json({"type", type}), do: {:type, String.to_atom(type)}
   defp column_info_from_json({key, value}), do: {String.to_atom(key), value}
+
+  def otel_attrs(handle, shape, extra \\ []) do
+    Keyword.merge(
+      [
+        "shape.handle": handle,
+        "shape.root_table": shape.root_table,
+        "shape.where": if(where = shape.where, do: where.query)
+      ],
+      extra_attrs(extra)
+    )
+  end
+
+  # Mapping function for known attrs to avoid repeatedly concatenating OTel attribute names at runtime.
+  defp extra_attrs([{:query_reason, query_reason} | rest]),
+    do: [{:"shape.query_reason", query_reason} | extra_attrs(rest)]
+
+  defp extra_attrs([]), do: []
 end
 
 defimpl Inspect, for: Electric.Shapes.Shape do


### PR DESCRIPTION
## Summary

`shape_snapshot.execute_for_shape` and `shape_snapshot.query_fn` spans were missing from production traces for `move_in_query` operations, while `initial_snapshot` and `subset_query` worked fine. This wires up a parent span so the existing child spans get emitted.

## Problem

Sampling for `shape_snapshot.query_fn` is a plain `included?(_) -> true` (no rate limiting), so the absence of `move_in_query` spans wasn't a sampling issue — the spans were never being created.