### PR TITLE
feat(sync-service): add txids to move-in/move-out control messages

### DIFF
--- a/.changeset/move-message-txids.md
+++ b/.changeset/move-message-txids.md
@@ -2,4 +2,4 @@
 '@core/sync-service': patch
 ---
 
-Add `txids` to `move-in`/`move-out` control messages, mirroring the per-row `headers.txids` already emitted on insert/update/delete log entries. The list contains the upstream Postgres xid(s) whose commit caused the dependency boundary to flip, threaded from the consumer through the materializer, MoveQueue, and ActiveMove into the broadcast headers.
+Add `txids` to `move-in`/`move-out` control messages, mirroring the per-row `headers.txids` already emitted on insert/update/delete log entries. The list contains the upstream Postgres xid(s) whose commit caused the dependency boundary to flip.

--- a/.changeset/move-message-txids.md
+++ b/.changeset/move-message-txids.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Add `txids` to `move-in`/`move-out` control messages, mirroring the per-row `headers.txids` already emitted on insert/update/delete log entries. The list contains the upstream Postgres xid(s) whose commit caused the dependency boundary to flip, threaded from the consumer through the materializer, MoveQueue, and ActiveMove into the broadcast headers.

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -308,7 +308,7 @@ defmodule Electric.Shapes.Consumer do
   end
 
   def handle_info(
-        {:materializer_changes, dep_handle, %{move_in: move_in, move_out: move_out}},
+        {:materializer_changes, dep_handle, %{move_in: move_in, move_out: move_out} = payload},
         state
       ) do
     Logger.debug(fn ->
@@ -317,10 +317,7 @@ defmodule Electric.Shapes.Consumer do
 
     handle_apply_event_result(
       state,
-      apply_event(
-        state,
-        {:materializer_changes, dep_handle, %{move_in: move_in, move_out: move_out}}
-      )
+      apply_event(state, {:materializer_changes, dep_handle, payload})
     )
   end
 
@@ -649,7 +646,8 @@ defmodule Electric.Shapes.Consumer do
         # The Materializer must see all txn changes for correct tracking of move-ins and
         # move-outs for the outer shape. The commit=false flag ensure it doesn't yet notify
         # outer consumers about those changes.
-        :ok = notify_materializer_of_new_changes(state, converted_changes, commit: false)
+        :ok =
+          notify_materializer_of_new_changes(state, converted_changes, commit: false, xid: xid)
 
         txn =
           PendingTxn.update_with_changes(
@@ -720,7 +718,7 @@ defmodule Electric.Shapes.Consumer do
       # Signal commit to storage to allow it to advance its internal txn offset
       writer = ShapeCache.Storage.signal_txn_commit!(txn.xid, writer)
 
-      :ok = notify_new_changes(state, [], state.latest_offset)
+      :ok = notify_new_changes_with_offset(state, [], state.latest_offset, xid: txn.xid)
 
       lag = calculate_replication_lag(txn_fragment.commit.commit_timestamp)
 
@@ -805,7 +803,7 @@ defmodule Electric.Shapes.Consumer do
 
       {state, notification, num_changes, total_size} ->
         if notification do
-          :ok = notify_new_changes(state, notification)
+          :ok = notify_new_changes(state, notification, xid: txn.xid)
 
           OpenTelemetry.add_span_attributes(%{
             num_bytes: total_size,
@@ -897,19 +895,21 @@ defmodule Electric.Shapes.Consumer do
     mark_for_removal(state)
   end
 
-  defp notify_new_changes(_state, nil), do: :ok
+  defp notify_new_changes(state, notification, opts \\ [])
+  defp notify_new_changes(_state, nil, _opts), do: :ok
 
-  defp notify_new_changes(state, {changes, upper_bound}) do
-    notify_new_changes(state, changes, upper_bound)
+  defp notify_new_changes(state, {changes, upper_bound}, opts) do
+    notify_new_changes_with_offset(state, changes, upper_bound, opts)
   end
 
-  @spec notify_new_changes(
+  @spec notify_new_changes_with_offset(
           state :: map(),
           changes_or_bounds :: list(Changes.change()) | {LogOffset.t(), LogOffset.t()},
-          latest_log_offset :: LogOffset.t()
+          latest_log_offset :: LogOffset.t(),
+          opts :: keyword()
         ) :: :ok
-  defp notify_new_changes(state, changes_or_bounds, latest_log_offset) do
-    :ok = notify_materializer_of_new_changes(state, changes_or_bounds)
+  defp notify_new_changes_with_offset(state, changes_or_bounds, latest_log_offset, opts) do
+    :ok = notify_materializer_of_new_changes(state, changes_or_bounds, opts)
     :ok = notify_clients_of_new_changes(state, latest_log_offset)
   end
 
@@ -937,8 +937,6 @@ defmodule Electric.Shapes.Consumer do
           changes_or_bounds :: list(Changes.change()) | {LogOffset.t(), LogOffset.t()},
           opts :: keyword()
         ) :: :ok
-  defp notify_materializer_of_new_changes(state, changes_or_bounds, opts \\ [])
-
   defp notify_materializer_of_new_changes(
          %{materializer_subscribed?: true} = state,
          changes_or_bounds,

--- a/packages/sync-service/lib/electric/shapes/consumer/event_handler/subqueries/buffering.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/event_handler/subqueries/buffering.ex
@@ -37,7 +37,7 @@ defmodule Electric.Shapes.Consumer.EventHandler.Subqueries.Buffering do
         %ShapeInfo{} = shape_info,
         views,
         %MoveQueue{} = queue,
-        {dep_move_kind, dep_index, values} = move,
+        {dep_move_kind, dep_index, values, txids} = move,
         subquery_ref,
         opts \\ []
       )
@@ -47,7 +47,7 @@ defmodule Electric.Shapes.Consumer.EventHandler.Subqueries.Buffering do
       queue: queue,
       active_move:
         views
-        |> ActiveMove.start(dep_index, dep_move_kind, subquery_ref, values)
+        |> ActiveMove.start(dep_index, dep_move_kind, subquery_ref, values, txids)
         |> ActiveMove.carry_latest_seen_lsn(Keyword.get(opts, :latest_seen_lsn))
     }
 
@@ -129,7 +129,8 @@ defmodule Electric.Shapes.Consumer.EventHandler.Subqueries.Buffering do
       index_effects =
         IndexChanges.effects_for_complete(
           state.shape_info.dnf_plan,
-          {active_move.dep_move_kind, active_move.dep_index, active_move.values},
+          {active_move.dep_move_kind, active_move.dep_index, active_move.values,
+           active_move.txids},
           active_move.subquery_ref
         )
 

--- a/packages/sync-service/lib/electric/shapes/consumer/event_handler/subqueries/steady.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/event_handler/subqueries/steady.ex
@@ -75,7 +75,7 @@ defmodule Electric.Shapes.Consumer.EventHandler.Subqueries.Steady do
       nil ->
         {:ok, state, effects}
 
-      {{dep_move_kind, dep_index, values} = move, queue} ->
+      {{dep_move_kind, dep_index, values, txids} = move, queue} ->
         subquery_ref = RefResolver.ref_from_dep_index!(state.shape_info.ref_resolver, dep_index)
         subscription_active? = Keyword.get(opts, :subscription_active?, false)
         latest_seen_lsn = Keyword.get(opts, :latest_seen_lsn)
@@ -108,7 +108,7 @@ defmodule Electric.Shapes.Consumer.EventHandler.Subqueries.Steady do
             effects =
               effects
               |> EffectList.append(
-                MoveBroadcast.effect_for_move_out(dep_index, values, state.shape_info)
+                MoveBroadcast.effect_for_move_out(dep_index, values, txids, state.shape_info)
               )
               |> EffectList.append_all(index_effects)
 

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -404,7 +404,7 @@ defmodule Electric.Shapes.Consumer.Materializer do
   end
 
   defp xid_set(nil), do: MapSet.new()
-  defp xid_set(xid) when is_integer(xid), do: MapSet.new([xid])
+  defp xid_set(xid) when is_integer(xid) and xid > 0, do: MapSet.new([xid])
 
   defp maybe_flush_pending_events(state, true) do
     events =

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -41,7 +41,8 @@ defmodule Electric.Shapes.Consumer.Materializer do
           :ok
   def new_changes(state, changes, opts \\ []) do
     commit? = Keyword.get(opts, :commit, true)
-    GenServer.call(name(state), {:new_changes, changes, commit?}, :infinity)
+    xid = Keyword.get(opts, :xid)
+    GenServer.call(name(state), {:new_changes, changes, xid, commit?}, :infinity)
   end
 
   def wait_until_ready(state) do
@@ -205,23 +206,23 @@ defmodule Electric.Shapes.Consumer.Materializer do
     {:reply, :ok, state}
   end
 
-  def handle_call({:new_changes, {range_start, range_end}, commit?}, _from, state) do
+  def handle_call({:new_changes, {range_start, range_end}, xid, commit?}, _from, state) do
     stack_storage = Storage.for_stack(state.stack_id)
     storage = Storage.for_shape(state.shape_handle, stack_storage)
 
     state =
       Storage.get_log_stream(range_start, range_end, storage)
       |> decode_json_stream()
-      |> apply_and_accumulate_events(state)
+      |> apply_and_accumulate_events(xid, state)
       |> maybe_flush_pending_events(commit?)
 
     {:reply, :ok, state}
   end
 
-  def handle_call({:new_changes, changes, commit?}, _from, state) when is_list(changes) do
+  def handle_call({:new_changes, changes, xid, commit?}, _from, state) when is_list(changes) do
     state =
       changes
-      |> apply_and_accumulate_events(state)
+      |> apply_and_accumulate_events(xid, state)
       |> maybe_flush_pending_events(commit?)
 
     {:reply, :ok, state}
@@ -343,21 +344,21 @@ defmodule Electric.Shapes.Consumer.Materializer do
             }
         end
 
-      %{"headers" => %{"event" => "move-out", "patterns" => patterns}} ->
+      %{"headers" => %{"event" => "move-out", "patterns" => patterns} = headers} ->
         patterns =
           Enum.map(patterns, fn %{"pos" => pos, "value" => value} ->
             %{pos: pos, value: value}
           end)
 
-        %{headers: %{event: "move-out", patterns: patterns}}
+        %{headers: %{event: "move-out", patterns: patterns, txids: Map.get(headers, "txids", [])}}
 
-      %{"headers" => %{"event" => "move-in", "patterns" => patterns}} ->
+      %{"headers" => %{"event" => "move-in", "patterns" => patterns} = headers} ->
         patterns =
           Enum.map(patterns, fn %{"pos" => pos, "value" => value} ->
             %{pos: pos, value: value}
           end)
 
-        %{headers: %{event: "move-in", patterns: patterns}}
+        %{headers: %{event: "move-in", patterns: patterns, txids: Map.get(headers, "txids", [])}}
     end)
   end
 
@@ -390,16 +391,28 @@ defmodule Electric.Shapes.Consumer.Materializer do
     Eval.Env.const_to_pg_string(Eval.Env.new(), value, type)
   end
 
-  defp apply_and_accumulate_events(changes, state) do
+  defp apply_and_accumulate_events(changes, xid, state) do
     {state, events} = apply_changes(changes, state)
+    events = with_txids(events, xid)
     %{state | pending_events: merge_events(state.pending_events, events)}
   end
+
+  defp with_txids(events, _xid) when events == %{}, do: events
+
+  defp with_txids(events, xid) do
+    Map.put(events, :txids, xid_set(xid))
+  end
+
+  defp xid_set(nil), do: MapSet.new()
+  defp xid_set(xid) when is_integer(xid), do: MapSet.new([xid])
 
   defp maybe_flush_pending_events(state, true) do
     events =
       cancel_matching_move_events(state.pending_events)
 
     if events != %{} do
+      events = finalize_txids(events)
+
       for pid <- state.subscribers do
         send(pid, {:materializer_changes, state.shape_handle, events})
       end
@@ -412,13 +425,19 @@ defmodule Electric.Shapes.Consumer.Materializer do
 
   defp maybe_flush_pending_events(state, _commit?), do: state
 
+  defp finalize_txids(events) do
+    Map.update(events, :txids, [], &Enum.sort(MapSet.to_list(&1)))
+  end
+
   defp merge_events(pending, new) when pending == %{}, do: new
   defp merge_events(pending, new) when new == %{}, do: pending
 
   defp merge_events(pending, new) do
     %{
       move_in: Map.get(new, :move_in, []) ++ Map.get(pending, :move_in, []),
-      move_out: Map.get(new, :move_out, []) ++ Map.get(pending, :move_out, [])
+      move_out: Map.get(new, :move_out, []) ++ Map.get(pending, :move_out, []),
+      txids:
+        MapSet.union(Map.get(pending, :txids, MapSet.new()), Map.get(new, :txids, MapSet.new()))
     }
   end
 
@@ -433,7 +452,11 @@ defmodule Electric.Shapes.Consumer.Materializer do
   defp cancel_matching_move_events(events) do
     ins = events |> Map.get(:move_in, []) |> Enum.sort_by(fn {v, _} -> v end)
     outs = events |> Map.get(:move_out, []) |> Enum.sort_by(fn {v, _} -> v end)
-    cancel_sorted_pairs(ins, outs, %{move_in: [], move_out: []})
+
+    case cancel_sorted_pairs(ins, outs, %{move_in: [], move_out: []}) do
+      empty when empty == %{} -> empty
+      result -> Map.put(result, :txids, Map.get(events, :txids, MapSet.new()))
+    end
   end
 
   defp cancel_sorted_pairs([{v, _} | ins], [{v, _} | outs], acc),

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -426,7 +426,7 @@ defmodule Electric.Shapes.Consumer.Materializer do
   defp maybe_flush_pending_events(state, _commit?), do: state
 
   defp finalize_txids(events) do
-    Map.update(events, :txids, [], &Enum.sort(MapSet.to_list(&1)))
+    Map.update(events, :txids, [], &Enum.sort(&1))
   end
 
   defp merge_events(pending, new) when pending == %{}, do: new

--- a/packages/sync-service/lib/electric/shapes/consumer/subqueries/active_move.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/subqueries/active_move.ex
@@ -22,6 +22,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.ActiveMove do
     :values,
     :views_before_move,
     :views_after_move,
+    txids: [],
     snapshot: nil,
     move_in_snapshot_name: nil,
     move_in_row_count: nil,
@@ -40,6 +41,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.ActiveMove do
           values: [move_value()],
           views_before_move: Views.t(),
           views_after_move: Views.t(),
+          txids: [non_neg_integer()],
           snapshot: {term(), term(), [term()]} | nil,
           move_in_snapshot_name: String.t() | nil,
           move_in_row_count: non_neg_integer() | nil,
@@ -51,14 +53,22 @@ defmodule Electric.Shapes.Consumer.Subqueries.ActiveMove do
           buffered_txns: [Transaction.t()]
         }
 
-  @spec start(Views.t(), non_neg_integer(), :move_in | :move_out, [String.t()], [move_value()]) ::
-          t()
-  def start(views, dep_index, dep_move_kind, subquery_ref, values) when is_map(views) do
+  @spec start(
+          Views.t(),
+          non_neg_integer(),
+          :move_in | :move_out,
+          [String.t()],
+          [move_value()],
+          [non_neg_integer()]
+        ) :: t()
+  def start(views, dep_index, dep_move_kind, subquery_ref, values, txids \\ [])
+      when is_map(views) do
     %__MODULE__{
       dep_index: dep_index,
       dep_move_kind: dep_move_kind,
       subquery_ref: subquery_ref,
       values: values,
+      txids: txids,
       views_before_move: views,
       views_after_move: Views.apply_move(views, subquery_ref, values, dep_move_kind)
     }

--- a/packages/sync-service/lib/electric/shapes/consumer/subqueries/index_changes.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/subqueries/index_changes.ex
@@ -57,7 +57,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.IndexChanges do
   alias Electric.Shapes.Consumer.Effects
   alias Electric.Shapes.DnfPlan
 
-  @type move :: {:move_in | :move_out, non_neg_integer(), list()}
+  @type move :: {:move_in | :move_out, non_neg_integer(), list(), [non_neg_integer()]}
 
   @doc """
   Returns index effects to apply when a dependency move event starts buffering.
@@ -68,7 +68,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.IndexChanges do
   """
   @spec effects_for_buffering(DnfPlan.t(), move(), [String.t()]) ::
           [Effects.AddToSubqueryIndex.t() | Effects.RemoveFromSubqueryIndex.t()]
-  def effects_for_buffering(dnf_plan, {dep_move_kind, dep_index, values}, subquery_ref) do
+  def effects_for_buffering(dnf_plan, {dep_move_kind, dep_index, values, _txids}, subquery_ref) do
     polarity = Map.get(dnf_plan.dependency_polarities, dep_index, :positive)
 
     case {polarity, dep_move_kind} do
@@ -104,7 +104,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.IndexChanges do
   """
   @spec effects_for_complete(DnfPlan.t(), move(), [String.t()]) ::
           [Effects.AddToSubqueryIndex.t() | Effects.RemoveFromSubqueryIndex.t()]
-  def effects_for_complete(dnf_plan, {dep_move_kind, dep_index, values}, subquery_ref) do
+  def effects_for_complete(dnf_plan, {dep_move_kind, dep_index, values, _txids}, subquery_ref) do
     polarity = Map.get(dnf_plan.dependency_polarities, dep_index, :positive)
 
     case {polarity, dep_move_kind} do

--- a/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_broadcast.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_broadcast.ex
@@ -17,6 +17,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveBroadcast do
           shape_info.dnf_plan,
           active_move.dep_index,
           active_move.values,
+          active_move.txids,
           "move-in",
           shape_info.stack_id,
           shape_info.shape_handle
@@ -24,15 +25,20 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveBroadcast do
     }
   end
 
-  @spec effect_for_move_out(non_neg_integer(), [move_value()], ShapeInfo.t()) ::
-          %Effects.AppendControl{}
-  def effect_for_move_out(dep_index, values, %ShapeInfo{} = shape_info) do
+  @spec effect_for_move_out(
+          non_neg_integer(),
+          [move_value()],
+          [non_neg_integer()],
+          ShapeInfo.t()
+        ) :: %Effects.AppendControl{}
+  def effect_for_move_out(dep_index, values, txids, %ShapeInfo{} = shape_info) do
     %Effects.AppendControl{
       message:
         make(
           shape_info.dnf_plan,
           dep_index,
           values,
+          txids,
           "move-out",
           shape_info.stack_id,
           shape_info.shape_handle
@@ -44,11 +50,12 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveBroadcast do
           DnfPlan.t(),
           non_neg_integer(),
           [move_value()],
+          [non_neg_integer()],
           String.t(),
           String.t(),
           String.t()
         ) :: map()
-  defp make(plan, dep_index, values, event, stack_id, shape_handle)
+  defp make(plan, dep_index, values, txids, event, stack_id, shape_handle)
        when event in ["move-in", "move-out"] do
     positions = Map.get(plan.dependency_positions, dep_index, [])
 
@@ -61,7 +68,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveBroadcast do
         end)
       end)
 
-    %{headers: %{event: event, patterns: patterns}}
+    %{headers: %{event: event, patterns: patterns, txids: List.wrap(txids)}}
   end
 
   defp make_hash(%{tag_columns: [_col]}, stack_id, shape_handle, value) do

--- a/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_broadcast.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_broadcast.ex
@@ -68,7 +68,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveBroadcast do
         end)
       end)
 
-    %{headers: %{event: event, patterns: patterns, txids: List.wrap(txids)}}
+    %{headers: %{event: event, patterns: patterns, txids: txids}}
   end
 
   defp make_hash(%{tag_columns: [_col]}, stack_id, shape_handle, value) do

--- a/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_broadcast.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_broadcast.ex
@@ -7,6 +7,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveBroadcast do
   alias Electric.Shapes.SubqueryTags
 
   @type move_value() :: {term(), term()}
+  @type txid() :: pos_integer()
   @type move() :: %{dep_index: non_neg_integer(), values: [move_value()]}
 
   @spec effect_for_move_in(move(), ShapeInfo.t()) :: %Effects.AppendControl{}
@@ -28,7 +29,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveBroadcast do
   @spec effect_for_move_out(
           non_neg_integer(),
           [move_value()],
-          [non_neg_integer()],
+          [txid()],
           ShapeInfo.t()
         ) :: %Effects.AppendControl{}
   def effect_for_move_out(dep_index, values, txids, %ShapeInfo{} = shape_info) do
@@ -50,7 +51,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveBroadcast do
           DnfPlan.t(),
           non_neg_integer(),
           [move_value()],
-          [non_neg_integer()],
+          [txid()],
           String.t(),
           String.t(),
           String.t()

--- a/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_queue.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_queue.ex
@@ -4,20 +4,26 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueue do
   with deduplication and redundancy elimination scoped per dependency.
 
   Move-outs from any dependency are drained before move-ins from any dependency.
+
+  Each per-dep batch also accumulates the upstream Postgres transaction ids that
+  contributed to it, so move-in/move-out broadcasts can carry `txids` for client
+  attribution (mirroring `Electric.LogItems.from_change/4`).
   """
 
   @type move_value() :: {term(), term()}
+  @type txid() :: non_neg_integer()
+  @type entry() :: {[move_value()], MapSet.t(txid())}
 
-  # move_out/move_in are maps from dep_index to [move_value]
+  # move_out/move_in are maps from dep_index to {[move_value], MapSet<txid>}
   defstruct move_out: %{}, move_in: %{}
 
   @type t() :: %__MODULE__{
-          move_out: %{non_neg_integer() => [move_value()]},
-          move_in: %{non_neg_integer() => [move_value()]}
+          move_out: %{non_neg_integer() => entry()},
+          move_in: %{non_neg_integer() => entry()}
         }
 
   @type batch_kind() :: :move_out | :move_in
-  @type batch() :: {batch_kind(), non_neg_integer(), [move_value()]}
+  @type batch() :: {batch_kind(), non_neg_integer(), [move_value()], [txid()]}
 
   @spec new() :: t()
   def new, do: %__MODULE__{}
@@ -28,20 +34,24 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueue do
   end
 
   defp count_values(map) do
-    Enum.reduce(map, 0, fn {_, vs}, acc -> acc + Kernel.length(vs) end)
+    Enum.reduce(map, 0, fn {_, {vs, _}}, acc -> acc + Kernel.length(vs) end)
   end
 
   @doc """
   Enqueue a materializer payload for a specific dependency.
   `dep_view` is the current view for this dependency, used for redundancy elimination.
+
+  The payload may include a `:txids` key listing the upstream xids that produced
+  the moves. Those xids are unioned with any already accumulated for this dep.
   """
   @spec enqueue(t(), non_neg_integer(), map() | keyword(), MapSet.t()) :: t()
   def enqueue(%__MODULE__{} = queue, dep_index, payload, %MapSet{} = dep_view)
       when is_map(payload) or is_list(payload) do
     payload = Map.new(payload)
+    new_txids = payload |> Map.get(:txids, []) |> MapSet.new()
 
-    existing_outs = Map.get(queue.move_out, dep_index, [])
-    existing_ins = Map.get(queue.move_in, dep_index, [])
+    {existing_outs, existing_out_txids} = Map.get(queue.move_out, dep_index, {[], MapSet.new()})
+    {existing_ins, existing_in_txids} = Map.get(queue.move_in, dep_index, {[], MapSet.new()})
 
     ops =
       Enum.map(existing_outs, &{:move_out, &1}) ++
@@ -51,8 +61,20 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueue do
     {new_outs, new_ins} = reduce(ops, dep_view)
 
     %__MODULE__{
-      move_out: put_or_delete(queue.move_out, dep_index, new_outs),
-      move_in: put_or_delete(queue.move_in, dep_index, new_ins)
+      move_out:
+        put_or_delete(
+          queue.move_out,
+          dep_index,
+          new_outs,
+          MapSet.union(existing_out_txids, new_txids)
+        ),
+      move_in:
+        put_or_delete(
+          queue.move_in,
+          dep_index,
+          new_ins,
+          MapSet.union(existing_in_txids, new_txids)
+        )
     }
   end
 
@@ -62,17 +84,23 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueue do
   """
   @spec pop_next(t()) :: {batch(), t()} | nil
   def pop_next(%__MODULE__{move_out: move_out} = queue) when move_out != %{} do
-    {dep_index, values} = Enum.min_by(move_out, &elem(&1, 0))
-    {{:move_out, dep_index, values}, %{queue | move_out: Map.delete(move_out, dep_index)}}
+    {dep_index, {values, txids}} = Enum.min_by(move_out, &elem(&1, 0))
+
+    {{:move_out, dep_index, values, sorted_txids(txids)},
+     %{queue | move_out: Map.delete(move_out, dep_index)}}
   end
 
   def pop_next(%__MODULE__{move_out: move_out, move_in: move_in} = queue)
       when move_out == %{} and move_in != %{} do
-    {dep_index, values} = Enum.min_by(move_in, &elem(&1, 0))
-    {{:move_in, dep_index, values}, %{queue | move_in: Map.delete(move_in, dep_index)}}
+    {dep_index, {values, txids}} = Enum.min_by(move_in, &elem(&1, 0))
+
+    {{:move_in, dep_index, values, sorted_txids(txids)},
+     %{queue | move_in: Map.delete(move_in, dep_index)}}
   end
 
   def pop_next(%__MODULE__{}), do: nil
+
+  defp sorted_txids(%MapSet{} = txids), do: txids |> MapSet.to_list() |> Enum.sort()
 
   defp payload_to_ops(payload) do
     Enum.map(Map.get(payload, :move_out, []), &{:move_out, &1}) ++
@@ -104,6 +132,6 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueue do
     not MapSet.member?(base_view, value)
   end
 
-  defp put_or_delete(map, key, []), do: Map.delete(map, key)
-  defp put_or_delete(map, key, values), do: Map.put(map, key, values)
+  defp put_or_delete(map, key, [], _txids), do: Map.delete(map, key)
+  defp put_or_delete(map, key, values, txids), do: Map.put(map, key, {values, txids})
 end

--- a/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_queue.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_queue.ex
@@ -100,7 +100,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueue do
 
   def pop_next(%__MODULE__{}), do: nil
 
-  defp sorted_txids(%MapSet{} = txids), do: txids |> MapSet.to_list() |> Enum.sort()
+  defp sorted_txids(%MapSet{} = txids), do: Enum.sort(txids)
 
   defp payload_to_ops(payload) do
     Enum.map(Map.get(payload, :move_out, []), &{:move_out, &1}) ++

--- a/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_queue.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/subqueries/move_queue.ex
@@ -11,7 +11,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueue do
   """
 
   @type move_value() :: {term(), term()}
-  @type txid() :: non_neg_integer()
+  @type txid() :: pos_integer()
   @type entry() :: {[move_value()], MapSet.t(txid())}
 
   # move_out/move_in are maps from dep_index to {[move_value], MapSet<txid>}

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2419,14 +2419,20 @@ defmodule Electric.Plug.RouterTest do
 
       task = live_shape_req(req, opts)
 
-      Postgrex.query!(db_conn, "UPDATE inner_table SET value = 3 WHERE id = 1", [])
+      %Postgrex.Result{rows: [[xid]]} =
+        Postgrex.query!(
+          db_conn,
+          "UPDATE inner_table SET value = 3 WHERE id = 1 RETURNING xmin::text::bigint",
+          []
+        )
 
       assert {_req, 200, [data, %{"headers" => %{"control" => "up-to-date"}}]} = Task.await(task)
 
       assert %{
                "headers" => %{
                  "event" => "move-out",
-                 "patterns" => [%{"pos" => 0, "value" => ^tag}]
+                 "patterns" => [%{"pos" => 0, "value" => ^tag}],
+                 "txids" => [^xid]
                }
              } = data
     end
@@ -2460,7 +2466,12 @@ defmodule Electric.Plug.RouterTest do
       task = live_shape_req(req, opts)
 
       # Move in reflects in the new shape without invalidating it
-      Postgrex.query!(db_conn, "UPDATE inner_table SET value = 1 WHERE id = 2", [])
+      %Postgrex.Result{rows: [[xid]]} =
+        Postgrex.query!(
+          db_conn,
+          "UPDATE inner_table SET value = 1 WHERE id = 2 RETURNING xmin::text::bigint",
+          []
+        )
 
       tag2 =
         :crypto.hash(:md5, stack_id <> req.handle <> "v:2")
@@ -2468,7 +2479,7 @@ defmodule Electric.Plug.RouterTest do
 
       assert {_, 200,
               [
-                %{"headers" => %{"event" => "move-in"}},
+                %{"headers" => %{"event" => "move-in", "txids" => [^xid]}},
                 data,
                 %{"headers" => %{"control" => "snapshot-end"}},
                 up_to_date_ctl()

--- a/packages/sync-service/test/electric/shapes/consumer/event_handler/subqueries_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/event_handler/subqueries_test.exs
@@ -546,7 +546,7 @@ defmodule Electric.Shapes.Consumer.EventHandler.SubqueriesTest do
                  {:materializer_changes, dep_handle, %{move_in: [{2, "2"}], move_out: []}}
                )
 
-      assert queue.move_in == %{0 => [{2, "2"}]}
+      assert {[{2, "2"}], _} = Map.fetch!(queue.move_in, 0)
 
       assert {:ok, %Buffering{active_move: %ActiveMove{}} = handler, []} =
                EventHandler.handle_event(handler, {:pg_snapshot_known, {100, 200, []}})

--- a/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/materializer_test.exs
@@ -114,6 +114,39 @@ defmodule Electric.Shapes.Consumer.MaterializerTest do
       assert_receive {:materializer_changes, _, %{move_in: [{1, "1"}]}}
     end
 
+    test "the supplied xid is included in the broadcast payload's txids", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(
+        ctx,
+        [%Changes.NewRecord{key: "1", record: %{"value" => "1"}}],
+        xid: 4242
+      )
+
+      assert_receive {:materializer_changes, _, %{move_in: [{1, "1"}], txids: [4242]}}
+    end
+
+    test "txids accumulate across multiple non-committing batches", ctx do
+      ctx = with_materializer(ctx)
+
+      Materializer.new_changes(
+        ctx,
+        [%Changes.NewRecord{key: "1", record: %{"value" => "1"}}],
+        xid: 100,
+        commit: false
+      )
+
+      Materializer.new_changes(
+        ctx,
+        [%Changes.NewRecord{key: "2", record: %{"value" => "2"}}],
+        xid: 200,
+        commit: true
+      )
+
+      assert_receive {:materializer_changes, _,
+                      %{move_in: [{1, "1"}, {2, "2"}], txids: [100, 200]}}
+    end
+
     @tag snapshot_data: [%Changes.NewRecord{record: %{"id" => "1", "value" => "10"}}]
     test "on-load insert of a new value is seen & does not cause a move-in", ctx do
       ctx = with_materializer(ctx)

--- a/packages/sync-service/test/electric/shapes/consumer/subqueries/move_queue_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/subqueries/move_queue_test.exs
@@ -49,7 +49,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueueTest do
       |> MoveQueue.enqueue(@dep, %{move_in: [{1, "01"}]}, MapSet.new())
       |> MoveQueue.enqueue(@dep, %{move_in: [{1, "1"}], move_out: []}, MapSet.new())
 
-    assert %MoveQueue{move_in: %{0 => [{1, "1"}]}, move_out: empty_out} = queue
+    assert %MoveQueue{move_in: %{0 => {[{1, "1"}], _}}, move_out: empty_out} = queue
     assert empty_out == %{}
   end
 
@@ -59,7 +59,7 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueueTest do
       |> MoveQueue.enqueue(@dep, %{move_out: [{1, "01"}]}, MapSet.new([1]))
       |> MoveQueue.enqueue(@dep, %{move_out: [{1, "1"}], move_in: []}, MapSet.new([1]))
 
-    assert %MoveQueue{move_out: %{0 => [{1, "1"}]}, move_in: empty_in} = queue
+    assert %MoveQueue{move_out: %{0 => {[{1, "1"}], _}}, move_in: empty_in} = queue
     assert empty_in == %{}
   end
 
@@ -69,7 +69,10 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueueTest do
       |> MoveQueue.enqueue(@dep, %{move_in: [{2, "2"}]}, MapSet.new([1]))
       |> MoveQueue.enqueue(@dep, %{move_out: [{1, "1"}]}, MapSet.new([1]))
 
-    assert %MoveQueue{move_out: %{0 => [{1, "1"}]}, move_in: %{0 => [{2, "2"}]}} = queue
+    assert %MoveQueue{
+             move_out: %{0 => {[{1, "1"}], _}},
+             move_in: %{0 => {[{2, "2"}], _}}
+           } = queue
   end
 
   test "uses the provided base view when reducing buffering follow-up moves" do
@@ -89,14 +92,31 @@ defmodule Electric.Shapes.Consumer.Subqueries.MoveQueueTest do
       |> MoveQueue.enqueue(@dep, %{move_in: [{2, "2"}], move_out: [{1, "1"}]}, MapSet.new([1]))
       |> MoveQueue.enqueue(@dep, %{move_in: [{3, "3"}]}, MapSet.new([1]))
 
-    assert {{:move_out, 0, [{1, "1"}]}, queue} = MoveQueue.pop_next(queue)
+    assert {{:move_out, 0, [{1, "1"}], []}, queue} = MoveQueue.pop_next(queue)
     assert queue.move_out == %{}
-    assert queue.move_in == %{0 => [{2, "2"}, {3, "3"}]}
+    assert {[{2, "2"}, {3, "3"}], _} = Map.fetch!(queue.move_in, 0)
 
-    assert {{:move_in, 0, [{2, "2"}, {3, "3"}]}, queue} = MoveQueue.pop_next(queue)
+    assert {{:move_in, 0, [{2, "2"}, {3, "3"}], []}, queue} = MoveQueue.pop_next(queue)
     assert queue.move_out == %{}
     assert queue.move_in == %{}
     assert nil == MoveQueue.pop_next(queue)
+  end
+
+  test "accumulates txids from successive enqueues per dependency" do
+    queue =
+      MoveQueue.new()
+      |> MoveQueue.enqueue(
+        @dep,
+        %{move_in: [{1, "1"}], txids: [10]},
+        MapSet.new()
+      )
+      |> MoveQueue.enqueue(
+        @dep,
+        %{move_in: [{2, "2"}], txids: [20]},
+        MapSet.new()
+      )
+
+    assert {{:move_in, 0, _, [10, 20]}, _queue} = MoveQueue.pop_next(queue)
   end
 
   test "length counts queued values across both batches" do


### PR DESCRIPTION
## Summary

Move-in/move-out control messages now carry `headers.txids`, mirroring the per-row `headers.txids` already emitted on insert/update/delete log entries. The list contains the upstream Postgres xid(s) whose commit caused the dependency boundary to flip.