### PR TITLE
Build and publish desktop app in CI

### DIFF
--- a/.changeset/agents-desktop-ci-publishing.md
+++ b/.changeset/agents-desktop-ci-publishing.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-desktop': patch
+---
+
+Add CI workflows for desktop app build artifacts and canary publishing.

--- a/.github/workflows/agents_desktop_build.yml
+++ b/.github/workflows/agents_desktop_build.yml
@@ -198,7 +198,7 @@ jobs:
         run: pnpm --filter @electric-ax/agents-desktop... install --frozen-lockfile
 
       - name: Build desktop type dependencies
-        run: pnpm --filter @electric-ax/agents... build
+        run: pnpm -r --filter @electric-ax/agents-desktop^... build
 
       - name: Typecheck desktop app
         run: pnpm --filter @electric-ax/agents-desktop typecheck

--- a/.github/workflows/agents_desktop_build.yml
+++ b/.github/workflows/agents_desktop_build.yml
@@ -1,0 +1,691 @@
+name: Agents Desktop Build
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      git_ref:
+        required: true
+        type: string
+      publish:
+        required: true
+        type: boolean
+      sign:
+        required: true
+        type: boolean
+      release_tag:
+        required: false
+        type: string
+        default: ''
+      release_name:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  prepare-release:
+    name: Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: ${{ inputs.publish || (inputs.channel == 'pr' && github.event_name == 'pull_request') }}
+        uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Create or update PR artifact comment
+        if: ${{ inputs.channel == 'pr' && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const marker = '<!-- electric-agents-desktop-pr-artifacts -->'
+            const platforms = [
+              ['macos-arm64', 'macOS Apple Silicon'],
+              ['macos-x64', 'macOS Intel'],
+              ['windows-x64', 'Windows x64'],
+              ['linux-x64', 'Linux x64'],
+            ]
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const sha = context.payload.pull_request.head.sha
+            const shortSha = sha.slice(0, 7)
+            const rows = platforms
+              .map(([, label]) => `| ${label} | Building | Pending |`)
+              .join('\n')
+            const body = [
+              marker,
+              '## Electric Agents Desktop Builds',
+              '',
+              `Build artifacts for commit \`${shortSha}\` are in progress.`,
+              '',
+              '| Platform | Status | Artifact |',
+              '| --- | --- | --- |',
+              rows,
+              '',
+              `[Workflow run](${runUrl})`,
+            ].join('\n')
+
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            })
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              })
+            }
+
+      - name: Create or update GitHub release
+        if: ${{ inputs.publish }}
+        shell: bash
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NAME: ${{ inputs.release_name }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SIGN: ${{ inputs.sign }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$RELEASE_TAG" ]]; then
+            echo "release_tag is required when publish is true" >&2
+            exit 1
+          fi
+
+          COMMIT_SHA="$(git rev-parse HEAD)"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          if [[ "$CHANNEL" == "canary" ]]; then
+            git tag -f "$RELEASE_TAG" "$COMMIT_SHA"
+            git push origin "refs/tags/${RELEASE_TAG}" --force
+
+            {
+              echo "Canary build for Electric Agents Desktop."
+              echo
+              echo "- Source commit: ${COMMIT_SHA}"
+              echo "- Workflow run: ${RUN_URL}"
+              echo "- Build timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+              echo "- Desktop package version: ${VERSION}"
+              echo "- Signed/notarized: ${SIGN}"
+              echo
+              echo "Canary builds are pre-release quality and may be unsigned."
+            } > release-notes.md
+
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release edit "$RELEASE_TAG" \
+                --title "$RELEASE_NAME" \
+                --notes-file release-notes.md \
+                --prerelease
+            else
+              gh release create "$RELEASE_TAG" \
+                --target "$COMMIT_SHA" \
+                --title "$RELEASE_NAME" \
+                --notes-file release-notes.md \
+                --prerelease
+            fi
+          else
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release edit "$RELEASE_TAG" --title "$RELEASE_NAME"
+            else
+              gh release create "$RELEASE_TAG" \
+                --target "$COMMIT_SHA" \
+                --title "$RELEASE_NAME" \
+                --notes "Desktop artifacts for Electric Agents ${VERSION}."
+            fi
+          fi
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: prepare-release
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS
+            id: macos
+            runs_on: macos-14
+            builder_args: --mac --arm64 --x64
+          - name: Windows x64
+            id: windows-x64
+            runs_on: windows-latest
+            builder_args: --win --x64
+          - name: Linux x64
+            id: linux-x64
+            runs_on: ubuntu-latest
+            builder_args: --linux --x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm --filter @electric-ax/agents-desktop... install --frozen-lockfile
+
+      - name: Build desktop type dependencies
+        run: pnpm --filter @electric-ax/agents... build
+
+      - name: Typecheck desktop app
+        run: pnpm --filter @electric-ax/agents-desktop typecheck
+
+      - name: Build desktop app
+        run: pnpm --filter @electric-ax/agents-desktop build
+
+      - name: Build desktop icons
+        run: pnpm --filter @electric-ax/agents-desktop build:icons
+
+      - name: Rebuild native modules
+        run: pnpm --filter @electric-ax/agents-desktop rebuild:native
+
+      - name: Package macOS desktop app
+        if: ${{ matrix.id == 'macos' }}
+        shell: bash
+        env:
+          CSC_FOR_PULL_REQUEST: ${{ inputs.sign && 'false' || 'true' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ inputs.sign && 'true' || 'false' }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          builder_args=(${{ matrix.builder_args }})
+          if [[ "${{ inputs.sign }}" != "true" ]]; then
+            builder_args+=("-c.mac.identity=-")
+          fi
+
+          pnpm --filter @electric-ax/agents-desktop exec electron-builder "${builder_args[@]}" --publish never
+
+      - name: Package desktop app
+        if: ${{ matrix.id != 'macos' }}
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ inputs.sign && 'true' || 'false' }}
+          GH_TOKEN: ${{ github.token }}
+        run: pnpm --filter @electric-ax/agents-desktop exec electron-builder ${{ matrix.builder_args }} --publish never
+
+      - name: Verify macOS app signatures
+        if: ${{ matrix.id == 'macos' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          verify_signature() {
+            local app_dir="$1"
+
+            codesign -dv --verbose=4 "$app_dir"
+            codesign --verify --deep --verbose=4 "$app_dir"
+          }
+
+          verify_signature "packages/agents-desktop/release/mac-arm64/Electric Agents.app"
+          verify_signature "packages/agents-desktop/release/mac/Electric Agents.app"
+
+      - name: Verify macOS native module architectures
+        if: ${{ matrix.id == 'macos' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          check_arch() {
+            local app_dir="$1"
+            local expected="$2"
+            local found=0
+
+            while IFS= read -r -d '' node_file; do
+              found=1
+              info="$(file "$node_file")"
+              echo "$info"
+              if [[ "$info" != *"$expected"* ]]; then
+                echo "Expected $node_file to contain $expected" >&2
+                exit 1
+              fi
+            done < <(find "$app_dir" -name '*.node' -print0)
+
+            if [[ "$found" -eq 0 ]]; then
+              echo "No native .node files found under $app_dir" >&2
+              exit 1
+            fi
+          }
+
+          check_arch "packages/agents-desktop/release/mac-arm64" "arm64"
+          check_arch "packages/agents-desktop/release/mac" "x86_64"
+
+      - name: Upload macOS Apple Silicon DMG
+        id: upload-macos-arm64-dmg
+        if: ${{ matrix.id == 'macos' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: electric-agents-desktop-${{ inputs.channel }}-macos-arm64-dmg
+          retention-days: ${{ inputs.channel == 'pr' && 7 || 30 }}
+          if-no-files-found: error
+          path: packages/agents-desktop/release/*mac-arm64.dmg
+
+      - name: Upload macOS Intel DMG
+        id: upload-macos-x64-dmg
+        if: ${{ matrix.id == 'macos' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: electric-agents-desktop-${{ inputs.channel }}-macos-x64-dmg
+          retention-days: ${{ inputs.channel == 'pr' && 7 || 30 }}
+          if-no-files-found: error
+          path: packages/agents-desktop/release/*mac-x64.dmg
+
+      - name: Upload Windows installer
+        id: upload-windows-x64-exe
+        if: ${{ matrix.id == 'windows-x64' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: electric-agents-desktop-${{ inputs.channel }}-windows-x64-exe
+          retention-days: ${{ inputs.channel == 'pr' && 7 || 30 }}
+          if-no-files-found: error
+          path: packages/agents-desktop/release/*.exe
+
+      - name: Upload Linux AppImage
+        id: upload-linux-x64-appimage
+        if: ${{ matrix.id == 'linux-x64' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: electric-agents-desktop-${{ inputs.channel }}-linux-x64-appimage
+          retention-days: ${{ inputs.channel == 'pr' && 7 || 30 }}
+          if-no-files-found: error
+          path: packages/agents-desktop/release/*.AppImage
+
+      - name: Upload Linux deb
+        id: upload-linux-x64-deb
+        if: ${{ matrix.id == 'linux-x64' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: electric-agents-desktop-${{ inputs.channel }}-linux-x64-deb
+          retention-days: ${{ inputs.channel == 'pr' && 7 || 30 }}
+          if-no-files-found: error
+          path: packages/agents-desktop/release/*.deb
+
+      - name: Update PR artifact comment for ${{ matrix.name }}
+        if: ${{ always() && inputs.channel == 'pr' && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        continue-on-error: true
+        env:
+          LINUX_APPIMAGE_URL: ${{ steps.upload-linux-x64-appimage.outputs.artifact-url }}
+          LINUX_DEB_URL: ${{ steps.upload-linux-x64-deb.outputs.artifact-url }}
+          MACOS_ARM64_DMG_URL: ${{ steps.upload-macos-arm64-dmg.outputs.artifact-url }}
+          MACOS_X64_DMG_URL: ${{ steps.upload-macos-x64-dmg.outputs.artifact-url }}
+          PLATFORM_ID: ${{ matrix.id }}
+          PLATFORM_LABEL: ${{ matrix.name }}
+          WINDOWS_EXE_URL: ${{ steps.upload-windows-x64-exe.outputs.artifact-url }}
+        with:
+          script: |
+            const marker = '<!-- electric-agents-desktop-pr-artifacts -->'
+            const platforms = [
+              ['macos-arm64', 'macOS Apple Silicon'],
+              ['macos-x64', 'macOS Intel'],
+              ['windows-x64', 'Windows x64'],
+              ['linux-x64', 'Linux x64'],
+            ]
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
+            const sha = context.payload.pull_request.head.sha
+            const shortSha = sha.slice(0, 7)
+            const label = process.env.PLATFORM_LABEL
+            const platformId = process.env.PLATFORM_ID
+            const rowsByLabel = buildRows()
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            })
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+            let nextBody = existing?.body ?? renderInitialBody()
+            for (const [platformLabel, row] of rowsByLabel) {
+              nextBody = replacePlatformRow(nextBody, platformLabel, row)
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body: nextBody,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: nextBody,
+              })
+            }
+
+            function renderInitialBody() {
+              return [
+                marker,
+                '## Electric Agents Desktop Builds',
+                '',
+                `Build artifacts for commit \`${shortSha}\` are in progress.`,
+                '',
+                '| Platform | Status | Artifact |',
+                '| --- | --- | --- |',
+                platforms
+                  .map(([, platformLabel]) => `| ${platformLabel} | Building | Pending |`)
+                  .join('\n'),
+                '',
+                `[Workflow run](${runUrl})`,
+              ].join('\n')
+            }
+
+            function replacePlatformRow(body, platformLabel, row) {
+              const lines = body.split('\n')
+              const rowIndex = lines.findIndex((line) =>
+                line.startsWith(`| ${platformLabel} |`)
+              )
+              if (rowIndex === -1) {
+                return body
+              }
+
+              lines[rowIndex] = row
+              return lines.join('\n')
+            }
+
+            function buildRows() {
+              switch (platformId) {
+                case 'macos':
+                  return [
+                    [
+                      'macOS Apple Silicon',
+                      buildRow(
+                        'macOS Apple Silicon',
+                        process.env.MACOS_ARM64_DMG_URL
+                          ? `[DMG](${process.env.MACOS_ARM64_DMG_URL})`
+                          : null
+                      ),
+                    ],
+                    [
+                      'macOS Intel',
+                      buildRow(
+                        'macOS Intel',
+                        process.env.MACOS_X64_DMG_URL
+                          ? `[DMG](${process.env.MACOS_X64_DMG_URL})`
+                          : null
+                      ),
+                    ],
+                  ]
+                case 'linux-x64':
+                  return [
+                    [
+                      'Linux x64',
+                      buildRow(
+                        'Linux x64',
+                        [
+                          process.env.LINUX_APPIMAGE_URL
+                            ? `[AppImage](${process.env.LINUX_APPIMAGE_URL})`
+                            : null,
+                          process.env.LINUX_DEB_URL
+                            ? `[deb](${process.env.LINUX_DEB_URL})`
+                            : null,
+                        ]
+                          .filter(Boolean)
+                          .join(' / ') || null
+                      ),
+                    ],
+                  ]
+                case 'windows-x64':
+                  return [
+                    [
+                      'Windows x64',
+                      buildRow(
+                        'Windows x64',
+                        process.env.WINDOWS_EXE_URL
+                          ? `[Installer](${process.env.WINDOWS_EXE_URL})`
+                          : null
+                      ),
+                    ],
+                  ]
+                default:
+                  return [[label, buildRow(label, null)]]
+              }
+            }
+
+            function buildRow(platformLabel, artifact) {
+              const status = artifact ? 'Passed' : 'Failed'
+              return `| ${platformLabel} | ${status} | ${artifact ?? 'Unavailable'} |`
+            }
+
+      - name: Prepare release assets
+        if: ${{ inputs.publish }}
+        shell: bash
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          MATRIX_ID: ${{ matrix.id }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          mkdir -p packages/agents-desktop/publish-assets
+
+          copy_first() {
+            local destination="$1"
+            shift
+
+            for file in "$@"; do
+              if [[ -f "$file" ]]; then
+                cp "$file" "packages/agents-desktop/publish-assets/${destination}"
+                return
+              fi
+            done
+
+            echo "No asset found for ${destination}" >&2
+            exit 1
+          }
+
+          if [[ "$CHANNEL" == "canary" ]]; then
+            case "$MATRIX_ID" in
+              macos)
+                copy_first "Electric-Agents-canary-mac-arm64.dmg" packages/agents-desktop/release/*mac-arm64.dmg packages/agents-desktop/release/*arm64.dmg
+                copy_first "Electric-Agents-canary-mac-arm64.zip" packages/agents-desktop/release/*mac-arm64.zip packages/agents-desktop/release/*arm64.zip
+                copy_first "Electric-Agents-canary-mac-x64.dmg" packages/agents-desktop/release/*mac-x64.dmg packages/agents-desktop/release/*x64.dmg
+                copy_first "Electric-Agents-canary-mac-x64.zip" packages/agents-desktop/release/*mac-x64.zip packages/agents-desktop/release/*x64.zip
+                ;;
+              windows-x64)
+                copy_first "Electric-Agents-canary-windows-x64.exe" packages/agents-desktop/release/*.exe
+                ;;
+              linux-x64)
+                copy_first "Electric-Agents-canary-linux-x64.AppImage" packages/agents-desktop/release/*.AppImage
+                copy_first "Electric-Agents-canary-linux-x64.deb" packages/agents-desktop/release/*.deb
+                ;;
+            esac
+          else
+            cp packages/agents-desktop/release/*.{dmg,zip,exe,AppImage,deb,blockmap,yml,yaml} \
+              packages/agents-desktop/publish-assets/ 2>/dev/null || true
+          fi
+
+          assets=(packages/agents-desktop/publish-assets/*)
+          if (( ${#assets[@]} == 0 )); then
+            echo "No publish assets were prepared" >&2
+            exit 1
+          fi
+
+      - name: Upload assets to GitHub release
+        if: ${{ inputs.publish }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: gh release upload "$RELEASE_TAG" packages/agents-desktop/publish-assets/* --clobber
+
+  update-pr-comment:
+    name: Update PR artifact comment
+    needs: build
+    if: ${{ always() && inputs.channel == 'pr' && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update PR artifact comment
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const marker = '<!-- electric-agents-desktop-pr-artifacts -->'
+            const platforms = [
+              {
+                id: 'macos',
+                label: 'macOS Apple Silicon',
+                jobName: 'build / Build macOS',
+                artifacts: [
+                  ['DMG', 'electric-agents-desktop-pr-macos-arm64-dmg'],
+                ],
+              },
+              {
+                id: 'macos',
+                label: 'macOS Intel',
+                jobName: 'build / Build macOS',
+                artifacts: [['DMG', 'electric-agents-desktop-pr-macos-x64-dmg']],
+              },
+              {
+                id: 'windows-x64',
+                label: 'Windows x64',
+                jobName: 'build / Build Windows x64',
+                artifacts: [
+                  ['Installer', 'electric-agents-desktop-pr-windows-x64-exe'],
+                ],
+              },
+              {
+                id: 'linux-x64',
+                label: 'Linux x64',
+                jobName: 'build / Build Linux x64',
+                artifacts: [
+                  ['AppImage', 'electric-agents-desktop-pr-linux-x64-appimage'],
+                  ['deb', 'electric-agents-desktop-pr-linux-x64-deb'],
+                ],
+              },
+            ]
+
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
+            const sha = context.payload.pull_request.head.sha
+            const shortSha = sha.slice(0, 7)
+
+            const [jobs, artifacts] = await Promise.all([
+              github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner,
+                repo,
+                run_id: context.runId,
+                per_page: 100,
+              }),
+              github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner,
+                repo,
+                run_id: context.runId,
+                per_page: 100,
+              }),
+            ])
+
+            const artifactByName = new Map(
+              artifacts.map((artifact) => [
+                artifact.name,
+                `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}/artifacts/${artifact.id}`,
+              ])
+            )
+
+            const rows = platforms
+              .map((platform) => {
+                const job = jobs.find((candidate) => candidate.name === platform.jobName)
+                const status = formatStatus(job)
+                const artifact = platform.artifacts
+                  .map(([label, artifactName]) => {
+                    const artifactUrl = artifactByName.get(artifactName)
+                    return artifactUrl ? `[${label}](${artifactUrl})` : null
+                  })
+                  .filter(Boolean)
+                  .join(' / ') || 'Unavailable'
+                return `| ${platform.label} | ${status} | ${artifact} |`
+              })
+              .join('\n')
+
+            const body = [
+              marker,
+              '## Electric Agents Desktop Builds',
+              '',
+              `Build artifacts for commit \`${shortSha}\`.`,
+              '',
+              '| Platform | Status | Artifact |',
+              '| --- | --- | --- |',
+              rows,
+              '',
+              `[Workflow run](${runUrl})`,
+            ].join('\n')
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            })
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              })
+            }
+
+            function formatStatus(job) {
+              if (!job) return 'Unknown'
+              if (job.status !== 'completed') return 'Building'
+
+              switch (job.conclusion) {
+                case 'success':
+                  return 'Passed'
+                case 'failure':
+                  return 'Failed'
+                case 'cancelled':
+                  return 'Cancelled'
+                case 'skipped':
+                  return 'Skipped'
+                default:
+                  return job.conclusion || 'Completed'
+              }
+            }

--- a/.github/workflows/agents_desktop_build.yml
+++ b/.github/workflows/agents_desktop_build.yml
@@ -106,6 +106,7 @@ jobs:
           RELEASE_NAME: ${{ inputs.release_name }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           SIGN: ${{ inputs.sign }}
+          STABLE_LATEST_TAG: agents-desktop-latest
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
@@ -154,6 +155,33 @@ jobs:
                 --target "$COMMIT_SHA" \
                 --title "$RELEASE_NAME" \
                 --notes "Desktop artifacts for Electric Agents ${VERSION}."
+            fi
+
+            if [[ "$CHANNEL" == "stable" ]]; then
+              git tag -f "$STABLE_LATEST_TAG" "$COMMIT_SHA"
+              git push origin "refs/tags/${STABLE_LATEST_TAG}" --force
+
+              {
+                echo "Latest stable Electric Agents Desktop build."
+                echo
+                echo "- Source release: ${RELEASE_TAG}"
+                echo "- Source commit: ${COMMIT_SHA}"
+                echo "- Workflow run: ${RUN_URL}"
+                echo "- Desktop package version: ${VERSION}"
+                echo "- Signed/notarized: ${SIGN}"
+              } > latest-release-notes.md
+
+              if gh release view "$STABLE_LATEST_TAG" >/dev/null 2>&1; then
+                gh release edit "$STABLE_LATEST_TAG" \
+                  --title "Electric Agents Desktop Latest" \
+                  --notes-file latest-release-notes.md
+              else
+                gh release create "$STABLE_LATEST_TAG" \
+                  --target "$COMMIT_SHA" \
+                  --title "Electric Agents Desktop Latest" \
+                  --notes-file latest-release-notes.md \
+                  --latest=false
+              fi
             fi
           fi
 
@@ -542,9 +570,18 @@ jobs:
         if: ${{ inputs.publish }}
         shell: bash
         env:
+          CHANNEL: ${{ inputs.channel }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
-        run: gh release upload "$RELEASE_TAG" packages/agents-desktop/publish-assets/* --clobber
+          STABLE_LATEST_TAG: agents-desktop-latest
+        run: |
+          set -euo pipefail
+
+          gh release upload "$RELEASE_TAG" packages/agents-desktop/publish-assets/* --clobber
+
+          if [[ "$CHANNEL" == "stable" ]]; then
+            gh release upload "$STABLE_LATEST_TAG" packages/agents-desktop/publish-assets/* --clobber
+          fi
 
   update-pr-comment:
     name: Update PR artifact comment

--- a/.github/workflows/agents_desktop_canary.yml
+++ b/.github/workflows/agents_desktop_canary.yml
@@ -1,0 +1,71 @@
+name: Agents Desktop Canary
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/agents-desktop/**'
+      - 'packages/agents-server-ui/**'
+      - 'packages/agents/**'
+      - 'packages/agents-mcp/**'
+      - 'packages/agents-runtime/**'
+      - '.github/workflows/agents_desktop_*.yml'
+      - 'scripts/ci/desktop-affected.mjs'
+      - '.npmrc'
+      - '.tool-versions'
+      - 'package.json'
+      - 'patches/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'tsconfig.build.json'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  detect:
+    name: Detect desktop impact
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.detect.outputs.should_build }}
+      reason: ${{ steps.detect.outputs.reason }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+
+      - name: Detect desktop impact
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.before }}
+        run: node scripts/ci/desktop-affected.mjs
+
+  build-and-publish:
+    needs: detect
+    if: ${{ needs.detect.outputs.should_build == 'true' }}
+    uses: ./.github/workflows/agents_desktop_build.yml
+    secrets: inherit
+    with:
+      channel: canary
+      version: canary-${{ github.run_number }}-${{ github.sha }}
+      git_ref: ${{ github.sha }}
+      publish: true
+      sign: false
+      release_tag: agents-desktop-canary
+      release_name: Electric Agents Desktop Canary

--- a/.github/workflows/agents_desktop_pr.yml
+++ b/.github/workflows/agents_desktop_pr.yml
@@ -1,0 +1,69 @@
+name: Agents Desktop PR
+
+on:
+  pull_request:
+    paths:
+      - 'packages/agents-desktop/**'
+      - 'packages/agents-server-ui/**'
+      - 'packages/agents/**'
+      - 'packages/agents-mcp/**'
+      - 'packages/agents-runtime/**'
+      - '.github/workflows/agents_desktop_*.yml'
+      - 'scripts/ci/desktop-affected.mjs'
+      - '.npmrc'
+      - '.tool-versions'
+      - 'package.json'
+      - 'patches/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'tsconfig.build.json'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  detect:
+    name: Detect desktop impact
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.detect.outputs.should_build }}
+      reason: ${{ steps.detect.outputs.reason }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+
+      - name: Detect desktop impact
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: node scripts/ci/desktop-affected.mjs
+
+  build:
+    needs: detect
+    if: ${{ needs.detect.outputs.should_build == 'true' }}
+    uses: ./.github/workflows/agents_desktop_build.yml
+    with:
+      channel: pr
+      version: pr-${{ github.event.pull_request.number || github.run_number }}-${{ github.sha }}
+      git_ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      publish: false
+      sign: false

--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -21,6 +21,8 @@ jobs:
       published: ${{ steps.changesets.outputs.published }}
       sync_service_release_tag: ${{ steps.sync_service_release_tag.outputs.tag }}
       agent_server_release_tag: ${{ steps.agent_server_release_tag.outputs.tag }}
+      desktop_release_version: ${{ steps.desktop_release.outputs.version }}
+      desktop_release_tag: ${{ steps.desktop_release.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,6 +65,16 @@ jobs:
           PUBLISHED_PACKAGES='${{ steps.changesets.outputs.publishedPackages }}'
           TAGS=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | select(.name == "@electric-ax/agents-server") | .name + "@" + .version')
           echo "tag=$TAGS" >> "$GITHUB_OUTPUT"
+      - name: Capture the new agents-desktop release as an output (if any)
+        id: desktop_release
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          PUBLISHED_PACKAGES='${{ steps.changesets.outputs.publishedPackages }}'
+          VERSION=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | select(.name == "@electric-ax/agents-desktop") | .version' | head -n 1)
+          if [ -n "$VERSION" ]; then
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "tag=@electric-ax/agents-desktop@$VERSION" >> "$GITHUB_OUTPUT"
+          fi
       - name: Add latest tag to published packages
         if: steps.changesets.outputs.published == 'true'
         run: node scripts/tag-latest.mjs
@@ -114,6 +126,22 @@ jobs:
               "agents_server_release_tag": "${{ needs.changesets.outputs.agent_server_release_tag }}",
               "agents_server_version": "${{ steps.agents_server.outputs.version }}"
             }
+
+  publish-agents-desktop:
+    needs: changesets
+    if: ${{ needs.changesets.outputs.published == 'true' && needs.changesets.outputs.desktop_release_tag != '' }}
+    uses: ./.github/workflows/agents_desktop_build.yml
+    permissions:
+      contents: write
+    secrets: inherit
+    with:
+      channel: stable
+      version: ${{ needs.changesets.outputs.desktop_release_version }}
+      git_ref: ${{ needs.changesets.outputs.desktop_release_tag }}
+      publish: true
+      sign: false
+      release_tag: ${{ needs.changesets.outputs.desktop_release_tag }}
+      release_name: Electric Agents Desktop v${{ needs.changesets.outputs.desktop_release_version }}
 
   update-cloud:
     name: Update Electric version used by Cloud

--- a/packages/agents-desktop/electron-builder.yml
+++ b/packages/agents-desktop/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.electric-sql.agents
 productName: Electric Agents
-artifactName: Electric-Agents-${version}-${os}-${arch}.${ext}
+artifactName: Electric-Agents-${os}-${arch}.${ext}
 
 directories:
   buildResources: build

--- a/packages/agents-desktop/electron-builder.yml
+++ b/packages/agents-desktop/electron-builder.yml
@@ -10,6 +10,7 @@ files:
   - dist/**/*
   - assets/**/*
   - package.json
+  - '!**/node_modules/@rollup/**'
 
 extraResources:
   - from: ../agents-server-ui/dist-desktop

--- a/scripts/ci/desktop-affected.mjs
+++ b/scripts/ci/desktop-affected.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+import { relative, sep } from 'node:path'
+
+const repoRoot = execFileSync(`git`, [`rev-parse`, `--show-toplevel`], {
+  encoding: `utf8`,
+}).trim()
+const baseRef = process.env.BASE_SHA || process.env.GITHUB_BASE_REF || `HEAD~1`
+const desktopPackage = `@electric-ax/agents-desktop`
+
+const globalChangePatterns = [
+  `.github/workflows/agents_desktop_*.yml`,
+  `.npmrc`,
+  `.tool-versions`,
+  `package.json`,
+  `patches/**`,
+  `pnpm-lock.yaml`,
+  `pnpm-workspace.yaml`,
+  `tsconfig.base.json`,
+  `tsconfig.build.json`,
+]
+
+const changedFiles = getChangedFiles(baseRef)
+const globalChange = shouldRunForGlobalChange(baseRef, changedFiles)
+const desktopClosure = listWorkspaces([`${desktopPackage}...`])
+const changedClosure = globalChange ? [] : listWorkspaces([`...[${baseRef}]`])
+const desktopClosureNames = new Set(
+  desktopClosure.map((workspace) => workspace.name)
+)
+const affectedWorkspaces = globalChange
+  ? desktopClosure
+  : changedClosure.filter((workspace) =>
+      desktopClosureNames.has(workspace.name)
+    )
+const shouldBuild = globalChange || affectedWorkspaces.length > 0
+
+const outputs = {
+  should_build: String(shouldBuild),
+  affected_workspaces: JSON.stringify(
+    affectedWorkspaces.map((workspace) => workspace.relativePath).sort()
+  ),
+  reason: globalChange
+    ? `global desktop build input changed`
+    : shouldBuild
+      ? `desktop package or dependency changed`
+      : `no desktop package dependency changed`,
+}
+
+writeOutputs(outputs)
+
+console.log(
+  JSON.stringify(
+    {
+      baseRef,
+      changedFiles,
+      desktopClosure: desktopClosure.map((workspace) => workspace.relativePath),
+      ...outputs,
+    },
+    null,
+    2
+  )
+)
+
+function listWorkspaces(filters) {
+  const args = [`-r`, `list`, `--depth`, `-1`, `--json`]
+  for (const filter of filters) {
+    args.push(`--filter`, filter)
+  }
+
+  try {
+    return parsePnpmList(run(`pnpm`, args))
+  } catch (error) {
+    console.warn(
+      `Falling back to building desktop because pnpm filtering failed.`
+    )
+    console.warn(error.message)
+    return [{ name: desktopPackage, relativePath: `packages/agents-desktop` }]
+  }
+}
+
+function parsePnpmList(output) {
+  return JSON.parse(output).map((workspace) => ({
+    ...workspace,
+    relativePath: toPosixPath(relative(repoRoot, workspace.path)),
+  }))
+}
+
+function getChangedFiles(base) {
+  if (!base || /^0+$/.test(base)) {
+    return []
+  }
+
+  try {
+    run(`git`, [`rev-parse`, `--verify`, `${base}^{commit}`])
+    return run(`git`, [`diff`, `--name-only`, base, `--`, `.`])
+      .split(`\n`)
+      .map((file) => file.trim())
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+function shouldRunForGlobalChange(base, files) {
+  if (!base || /^0+$/.test(base) || files.length === 0) {
+    return true
+  }
+
+  return files.some((file) =>
+    globalChangePatterns.some((pattern) => matchesPattern(file, pattern))
+  )
+}
+
+function matchesPattern(file, pattern) {
+  if (pattern.endsWith(`/**`)) {
+    return file.startsWith(pattern.slice(0, -3))
+  }
+
+  if (pattern.includes(`*`)) {
+    const escaped = pattern
+      .split(`*`)
+      .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`))
+      .join(`.*`)
+    return new RegExp(`^${escaped}$`).test(file)
+  }
+
+  return file === pattern
+}
+
+function writeOutputs(outputs) {
+  const outputFile = process.env.GITHUB_OUTPUT
+  if (!outputFile) {
+    return
+  }
+
+  appendFileSync(
+    outputFile,
+    Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(`\n`) + `\n`
+  )
+}
+
+function run(command, args) {
+  return execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: `utf8`,
+    stdio: [`ignore`, `pipe`, `pipe`],
+  })
+}
+
+function toPosixPath(value) {
+  return value.split(sep).join(`/`)
+}

--- a/website/app.md
+++ b/website/app.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Electric Agents App
+titleTemplate: false
+description: Download Electric Agents Desktop for macOS, Windows and Linux.
+sidebar: false
+pageClass: app-page
+mdExport:
+  mode: parse-html
+---
+
+<script setup>
+import AppDownloadPage from './src/components/app-download/AppDownloadPage.vue'
+</script>
+
+<MdExportParseHtml>
+  <AppDownloadPage />
+</MdExportParseHtml>

--- a/website/src/components/app-download/AppDownloadPage.vue
+++ b/website/src/components/app-download/AppDownloadPage.vue
@@ -46,6 +46,7 @@ type DesktopPlatform = {
   downloads: DownloadOption[]
 }
 
+const stableTag = `agents-desktop-latest`
 const canaryTag = `agents-desktop-canary`
 
 const desktopPlatforms: DesktopPlatform[] = [
@@ -177,7 +178,7 @@ function releaseUrl(tag: string, assetName: string): string {
 }
 
 function latestReleaseUrl(assetName: string): string {
-  return `${githubReleaseBase}/latest/download/${assetName}`
+  return releaseUrl(stableTag, assetName)
 }
 
 /* Detect the visitor's OS on mount; default to macOS Apple Silicon

--- a/website/src/components/app-download/AppDownloadPage.vue
+++ b/website/src/components/app-download/AppDownloadPage.vue
@@ -25,6 +25,7 @@ import Section from '../agents-home/Section.vue'
 import BottomCtaStrap from '../BottomCtaStrap.vue'
 
 const githubReleaseBase = `https://github.com/electric-sql/electric/releases`
+const appReleaseNotesUrl = `${githubReleaseBase}?q=%22%40electric-ax%2Fagents-desktop%22&expanded=true`
 
 type DesktopPlatformId =
   | 'macos-arm64'
@@ -45,8 +46,6 @@ type DesktopPlatform = {
   downloads: DownloadOption[]
 }
 
-const stableVersion = `0.1.4`
-const stableTag = `@electric-ax/agents-desktop@${stableVersion}`
 const canaryTag = `agents-desktop-canary`
 
 const desktopPlatforms: DesktopPlatform[] = [
@@ -58,7 +57,7 @@ const desktopPlatforms: DesktopPlatform[] = [
     downloads: [
       {
         label: `Download for Mac (Apple Silicon)`,
-        assetName: `Electric-Agents-${stableVersion}-mac-arm64.dmg`,
+        assetName: `Electric-Agents-mac-arm64.dmg`,
       },
     ],
   },
@@ -70,7 +69,7 @@ const desktopPlatforms: DesktopPlatform[] = [
     downloads: [
       {
         label: `Download for Mac (Intel)`,
-        assetName: `Electric-Agents-${stableVersion}-mac-x64.dmg`,
+        assetName: `Electric-Agents-mac-x64.dmg`,
       },
     ],
   },
@@ -82,7 +81,7 @@ const desktopPlatforms: DesktopPlatform[] = [
     downloads: [
       {
         label: `Download for Windows`,
-        assetName: `Electric-Agents-${stableVersion}-win-x64.exe`,
+        assetName: `Electric-Agents-win-x64.exe`,
       },
     ],
   },
@@ -94,11 +93,11 @@ const desktopPlatforms: DesktopPlatform[] = [
     downloads: [
       {
         label: `Download AppImage`,
-        assetName: `Electric-Agents-${stableVersion}-linux-x64.AppImage`,
+        assetName: `Electric-Agents-linux-x64.AppImage`,
       },
       {
         label: `Download DEB`,
-        assetName: `Electric-Agents-${stableVersion}-linux-x64.deb`,
+        assetName: `Electric-Agents-linux-x64.deb`,
       },
     ],
   },
@@ -177,6 +176,10 @@ function releaseUrl(tag: string, assetName: string): string {
   return `${githubReleaseBase}/download/${encodeURIComponent(tag)}/${assetName}`
 }
 
+function latestReleaseUrl(assetName: string): string {
+  return `${githubReleaseBase}/latest/download/${assetName}`
+}
+
 /* Detect the visitor's OS on mount; default to macOS Apple Silicon
    so SSR / first paint always renders a sensible primary. */
 const detectedId = ref<DesktopPlatformId>('macos-arm64')
@@ -247,9 +250,7 @@ const primaryPlatform = computed(
             size="medium"
             theme="brand"
             :text="primaryPlatform.downloads[0].label"
-            :href="
-              releaseUrl(stableTag, primaryPlatform.downloads[0].assetName)
-            "
+            :href="latestReleaseUrl(primaryPlatform.downloads[0].assetName)"
           />
           <VPButton
             tag="a"
@@ -261,10 +262,9 @@ const primaryPlatform = computed(
         </div>
 
         <p class="ad-hero-meta">
-          v{{ stableVersion }} ·
           <a
             class="ad-meta-link"
-            :href="`${githubReleaseBase}/tag/${encodeURIComponent(stableTag)}`"
+            :href="appReleaseNotesUrl"
             target="_blank"
             rel="noreferrer"
             >Release notes</a
@@ -312,7 +312,7 @@ const primaryPlatform = computed(
               size="medium"
               :theme="platform.id === detectedId && idx === 0 ? 'brand' : 'alt'"
               :text="opt.label"
-              :href="releaseUrl(stableTag, opt.assetName)"
+              :href="latestReleaseUrl(opt.assetName)"
             />
           </div>
         </article>

--- a/website/src/components/app-download/AppDownloadPage.vue
+++ b/website/src/components/app-download/AppDownloadPage.vue
@@ -283,9 +283,8 @@ const primaryPlatform = computed(
       <template #eyebrow>Desktop</template>
       <template #title>Choose your platform</template>
       <template #subtitle>
-        Pre-built artifacts for macOS, Windows and Linux. Signing and
-        notarization are still being wired up, so OS install warnings are
-        expected on this&nbsp;preview.
+        Install the desktop app to start, monitor and return to long-running
+        agents from your own computer.
       </template>
 
       <div class="ad-desktop-grid">
@@ -318,6 +317,25 @@ const primaryPlatform = computed(
           </div>
         </article>
       </div>
+
+      <aside class="custom-block warning ad-signing-note">
+        <p class="custom-block-title">Unsigned Preview</p>
+        <p>
+          App signing is still in progress, so macOS and Windows may need an
+          extra confirmation before opening Electric Agents for the first time.
+        </p>
+        <ul>
+          <li>
+            <strong>macOS:</strong> try opening the app, then go to
+            <strong>System Settings → Privacy &amp; Security</strong> and choose
+            <strong>Open Anyway</strong>.
+          </li>
+          <li>
+            <strong>Windows:</strong> choose <strong>More info</strong>, then
+            <strong>Run anyway</strong>.
+          </li>
+        </ul>
+      </aside>
     </Section>
 
     <!-- ─────────────────── §3 — Mobile (coming soon) ─────────────────── -->
@@ -639,6 +657,22 @@ const primaryPlatform = computed(
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.ad-signing-note {
+  margin-top: 24px;
+  padding-bottom: 18px;
+}
+
+.ad-signing-note p {
+  max-width: 700px;
+}
+
+.ad-signing-note ul {
+  margin: 8px 0 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
 }
 
 /* ── §3 mobile ──────────────────────────────────────────────── */

--- a/website/src/components/app-download/AppDownloadPage.vue
+++ b/website/src/components/app-download/AppDownloadPage.vue
@@ -1,0 +1,848 @@
+<script setup lang="ts">
+/* Hidden download page at /app.
+
+   Patterned on the existing agents / streams / sync landing pages
+   (Section blocks, eyebrow chips, brand-accented headline) plus
+   download-page conventions from Cursor / Linear / Raycast:
+   - Centred hero with a single platform-detected primary CTA.
+     A real app screenshot / mockup will land in a follow-up PR;
+     for now the hero is text + CTAs only.
+   - Platform glyphs from the Iconify `simple-icons` set, masked
+     via CSS to inherit the current text colour — same pattern the
+     rest of the site uses for social icons.
+   - Per-platform card CTAs use a muted dark/alt button rather than
+     the saturated brand teal so the hero stays the loudest CTA on
+     the page. Format labels (DMG/EXE/AppImage) are baked into the
+     button text rather than sitting beside it.
+   - Mobile section trimmed to icon + name + Coming-soon pill +
+     store badge with no prose descriptions.
+   - Canary section collapsed into a compact platform-per-row list
+     with inline download chips. */
+import { computed, onMounted, ref } from 'vue'
+import { VPButton } from 'vitepress/theme'
+
+import Section from '../agents-home/Section.vue'
+import BottomCtaStrap from '../BottomCtaStrap.vue'
+
+const githubReleaseBase = `https://github.com/electric-sql/electric/releases`
+
+type DesktopPlatformId =
+  | 'macos-arm64'
+  | 'macos-x64'
+  | 'windows-x64'
+  | 'linux-x64'
+
+type DownloadOption = {
+  label: string
+  assetName: string
+}
+
+type DesktopPlatform = {
+  id: DesktopPlatformId
+  icon: 'apple' | 'windows' | 'linux'
+  name: string
+  detail: string
+  downloads: DownloadOption[]
+}
+
+const stableVersion = `0.1.4`
+const stableTag = `@electric-ax/agents-desktop@${stableVersion}`
+const canaryTag = `agents-desktop-canary`
+
+const desktopPlatforms: DesktopPlatform[] = [
+  {
+    id: `macos-arm64`,
+    icon: `apple`,
+    name: `macOS Apple Silicon`,
+    detail: `M1, M2, M3 and newer.`,
+    downloads: [
+      {
+        label: `Download for Mac (Apple Silicon)`,
+        assetName: `Electric-Agents-${stableVersion}-mac-arm64.dmg`,
+      },
+    ],
+  },
+  {
+    id: `macos-x64`,
+    icon: `apple`,
+    name: `macOS Intel`,
+    detail: `For Intel-based Macs.`,
+    downloads: [
+      {
+        label: `Download for Mac (Intel)`,
+        assetName: `Electric-Agents-${stableVersion}-mac-x64.dmg`,
+      },
+    ],
+  },
+  {
+    id: `windows-x64`,
+    icon: `windows`,
+    name: `Windows`,
+    detail: `64-bit installer for Windows 10 and 11.`,
+    downloads: [
+      {
+        label: `Download for Windows`,
+        assetName: `Electric-Agents-${stableVersion}-win-x64.exe`,
+      },
+    ],
+  },
+  {
+    id: `linux-x64`,
+    icon: `linux`,
+    name: `Linux`,
+    detail: `Portable AppImage or Debian package.`,
+    downloads: [
+      {
+        label: `Download AppImage`,
+        assetName: `Electric-Agents-${stableVersion}-linux-x64.AppImage`,
+      },
+      {
+        label: `Download DEB`,
+        assetName: `Electric-Agents-${stableVersion}-linux-x64.deb`,
+      },
+    ],
+  },
+]
+
+type CanaryEntry = {
+  platform: string
+  icon: 'apple' | 'windows' | 'linux'
+  assets: { label: string; assetName: string }[]
+}
+
+const canaryEntries: CanaryEntry[] = [
+  {
+    platform: `macOS Apple Silicon`,
+    icon: `apple`,
+    assets: [
+      { label: `Download`, assetName: `Electric-Agents-canary-mac-arm64.dmg` },
+    ],
+  },
+  {
+    platform: `macOS Intel`,
+    icon: `apple`,
+    assets: [
+      { label: `Download`, assetName: `Electric-Agents-canary-mac-x64.dmg` },
+    ],
+  },
+  {
+    platform: `Windows`,
+    icon: `windows`,
+    assets: [
+      {
+        label: `Download`,
+        assetName: `Electric-Agents-canary-windows-x64.exe`,
+      },
+    ],
+  },
+  {
+    platform: `Linux`,
+    icon: `linux`,
+    assets: [
+      {
+        label: `AppImage`,
+        assetName: `Electric-Agents-canary-linux-x64.AppImage`,
+      },
+      { label: `DEB`, assetName: `Electric-Agents-canary-linux-x64.deb` },
+    ],
+  },
+]
+
+type MobilePlatform = {
+  id: 'ios' | 'android'
+  icon: 'apple' | 'android'
+  storeIcon: 'appstore' | 'googleplay'
+  name: string
+  storeLabel: string
+}
+
+const mobilePlatforms: MobilePlatform[] = [
+  {
+    id: `ios`,
+    icon: `apple`,
+    storeIcon: `appstore`,
+    name: `iOS`,
+    storeLabel: `App Store`,
+  },
+  {
+    id: `android`,
+    icon: `android`,
+    storeIcon: `googleplay`,
+    name: `Android`,
+    storeLabel: `Google Play`,
+  },
+]
+
+function releaseUrl(tag: string, assetName: string): string {
+  return `${githubReleaseBase}/download/${encodeURIComponent(tag)}/${assetName}`
+}
+
+/* Detect the visitor's OS on mount; default to macOS Apple Silicon
+   so SSR / first paint always renders a sensible primary. */
+const detectedId = ref<DesktopPlatformId>('macos-arm64')
+
+/* All Mac browsers still report `Intel Mac OS X` in the UA string on
+   Apple Silicon for legacy compat (it's a deliberate Apple/browser
+   decision), so the UA tells us nothing about CPU arch. We default
+   macOS to Apple Silicon (Intel Macs went EOL in 2023) and only flip
+   to Intel on a positive signal from the WebGL renderer string,
+   which differs between Apple GPU and Intel integrated graphics. */
+function detectMacArch(): 'macos-arm64' | 'macos-x64' {
+  try {
+    const canvas = document.createElement('canvas')
+    const gl = (canvas.getContext('webgl') ||
+      canvas.getContext('experimental-webgl')) as WebGLRenderingContext | null
+    if (!gl) return 'macos-arm64'
+    const ext = gl.getExtension('WEBGL_debug_renderer_info')
+    if (!ext) return 'macos-arm64'
+    const renderer = String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) ?? '')
+    // Apple Silicon: "Apple GPU" (Safari) or "ANGLE (Apple, M-series ...)" (Chrome)
+    // Intel Mac:     "Intel ..." (Safari) or "ANGLE (Intel, ...)" (Chrome)
+    if (/Intel/i.test(renderer) && !/Apple/i.test(renderer)) {
+      return 'macos-x64'
+    }
+    return 'macos-arm64'
+  } catch {
+    return 'macos-arm64'
+  }
+}
+
+onMounted(() => {
+  if (typeof navigator === 'undefined') return
+  const ua = `${navigator.userAgent || ''} ${navigator.platform || ''}`
+  if (/Win(dows|64|32)|WOW64|WinNT/i.test(ua)) {
+    detectedId.value = 'windows-x64'
+  } else if (
+    /Linux|X11|Ubuntu|Fedora|Debian/i.test(ua) &&
+    !/Android/i.test(ua)
+  ) {
+    detectedId.value = 'linux-x64'
+  } else if (/Mac|Macintosh|Darwin/i.test(ua)) {
+    detectedId.value = detectMacArch()
+  }
+})
+
+const primaryPlatform = computed(
+  () =>
+    desktopPlatforms.find((p) => p.id === detectedId.value) ??
+    desktopPlatforms[0]
+)
+</script>
+
+<template>
+  <div class="ad-page">
+    <!-- ─────────────────── §1 — Hero ─────────────────── -->
+    <section class="ad-hero">
+      <div class="ad-hero-inner">
+        <h1 class="ad-hero-name">
+          Electric&nbsp;<span class="ad-hero-accent">Agents</span>&nbsp;App
+        </h1>
+        <p class="ad-hero-text">
+          A native home for your long-running&nbsp;agents.
+        </p>
+
+        <div class="ad-hero-actions">
+          <VPButton
+            tag="a"
+            size="medium"
+            theme="brand"
+            :text="primaryPlatform.downloads[0].label"
+            :href="
+              releaseUrl(stableTag, primaryPlatform.downloads[0].assetName)
+            "
+          />
+          <VPButton
+            tag="a"
+            size="medium"
+            theme="alt"
+            text="Other platforms"
+            href="#desktop"
+          />
+        </div>
+
+        <p class="ad-hero-meta">
+          v{{ stableVersion }} ·
+          <a
+            class="ad-meta-link"
+            :href="`${githubReleaseBase}/tag/${encodeURIComponent(stableTag)}`"
+            target="_blank"
+            rel="noreferrer"
+            >Release notes</a
+          >
+        </p>
+      </div>
+
+      <!-- TODO(follow-up): app screenshot / mockup goes here. The
+           previous CSS-rendered agents-server-ui mockup was removed
+           to keep the hero clean ahead of a proper image asset. -->
+    </section>
+
+    <!-- ─────────────────── §2 — Desktop ─────────────────── -->
+    <Section id="desktop">
+      <template #eyebrow>Desktop</template>
+      <template #title>Choose your platform</template>
+      <template #subtitle>
+        Pre-built artifacts for macOS, Windows and Linux. Signing and
+        notarization are still being wired up, so OS install warnings are
+        expected on this&nbsp;preview.
+      </template>
+
+      <div class="ad-desktop-grid">
+        <article
+          v-for="platform in desktopPlatforms"
+          :key="platform.id"
+          class="ad-platform-card"
+          :class="{ 'is-recommended': platform.id === detectedId }"
+        >
+          <div class="ad-platform-head">
+            <span class="ad-platform-icon" aria-hidden="true">
+              <span class="ad-icon" :class="`ad-icon--${platform.icon}`" />
+            </span>
+            <div class="ad-platform-title">
+              <h3>{{ platform.name }}</h3>
+              <p>{{ platform.detail }}</p>
+            </div>
+          </div>
+
+          <div class="ad-platform-cta">
+            <VPButton
+              v-for="(opt, idx) in platform.downloads"
+              :key="opt.assetName"
+              tag="a"
+              size="medium"
+              :theme="platform.id === detectedId && idx === 0 ? 'brand' : 'alt'"
+              :text="opt.label"
+              :href="releaseUrl(stableTag, opt.assetName)"
+            />
+          </div>
+        </article>
+      </div>
+    </Section>
+
+    <!-- ─────────────────── §3 — Mobile (coming soon) ─────────────────── -->
+    <Section id="mobile" :dark="true">
+      <template #eyebrow>Mobile · Coming soon</template>
+      <template #title>Native iOS &amp; Android</template>
+      <template #subtitle>
+        Native mobile clients are in development. Same agents you run on the
+        desktop, in your&nbsp;pocket.
+      </template>
+
+      <div class="ad-mobile-grid">
+        <article
+          v-for="platform in mobilePlatforms"
+          :key="platform.id"
+          class="ad-mobile-card"
+          aria-disabled="true"
+        >
+          <span class="ad-mobile-icon" aria-hidden="true">
+            <span class="ad-icon" :class="`ad-icon--${platform.icon}`" />
+          </span>
+          <h3 class="ad-mobile-name">{{ platform.name }}</h3>
+          <span class="ad-soon-pill mono">Coming soon</span>
+          <span class="ad-store-badge">
+            <span
+              class="ad-store-glyph ad-icon"
+              :class="`ad-icon--${platform.storeIcon}`"
+              aria-hidden="true"
+            />
+            <span class="ad-store-label">{{ platform.storeLabel }}</span>
+          </span>
+        </article>
+      </div>
+    </Section>
+
+    <!-- ─────────────────── §4 — Canary ─────────────────── -->
+    <Section id="canary">
+      <template #eyebrow>Pre-release</template>
+      <template #title>Canary builds</template>
+      <template #subtitle>
+        Moving builds from the <code>main</code>&nbsp;branch. Useful for
+        previewing the newest desktop changes — prefer the release builds above
+        for day-to-day&nbsp;use.
+      </template>
+
+      <ul class="ad-canary-list">
+        <li
+          v-for="entry in canaryEntries"
+          :key="entry.platform"
+          class="ad-canary-item"
+        >
+          <span
+            class="ad-canary-icon ad-icon"
+            :class="`ad-icon--${entry.icon}`"
+            aria-hidden="true"
+          />
+          <span class="ad-canary-name">{{ entry.platform }}</span>
+          <span class="ad-canary-assets">
+            <a
+              v-for="asset in entry.assets"
+              :key="asset.assetName"
+              :href="releaseUrl(canaryTag, asset.assetName)"
+              target="_blank"
+              rel="noreferrer"
+              class="ad-canary-asset"
+            >
+              {{ asset.label }}
+              <span class="ad-canary-arrow" aria-hidden="true">↓</span>
+            </a>
+          </span>
+        </li>
+      </ul>
+
+      <p class="ad-canary-meta">
+        Release tag
+        <a
+          :href="`${githubReleaseBase}/tag/${canaryTag}`"
+          target="_blank"
+          rel="noreferrer"
+          ><code>{{ canaryTag }}</code></a
+        >
+      </p>
+    </Section>
+
+    <!-- ─────────────────── §5 — Bottom CTA ─────────────────── -->
+    <BottomCtaStrap id="get-started">
+      <template #eyebrow>
+        <span>Durable · long-running · cloud-connected</span>
+      </template>
+      <template #title>Build with Electric&nbsp;Agents</template>
+      <template #tagline>
+        Stand up the open-source runtime locally, or connect to
+        Electric&nbsp;Cloud.
+      </template>
+      <template #actions>
+        <VPButton
+          tag="a"
+          size="medium"
+          theme="brand"
+          text="Quickstart"
+          href="/docs/agents/quickstart"
+        />
+        <VPButton
+          tag="a"
+          size="medium"
+          theme="alt"
+          text="Agents docs"
+          href="/docs/agents/"
+        />
+        <VPButton
+          tag="a"
+          size="medium"
+          theme="alt"
+          text="Cloud"
+          href="/cloud/"
+        />
+      </template>
+    </BottomCtaStrap>
+  </div>
+</template>
+
+<style scoped>
+.ad-page {
+  overflow-x: hidden;
+  max-width: 100vw;
+}
+
+/* ── Iconify icon class ─────────────────────────────────────── *
+   Mirrors the `.vpi-*` pattern used elsewhere on the site
+   (SiteFooter.vue, custom.css). Each `.ad-icon--*` modifier sets
+   `--icon-url`; the base `.ad-icon` masks that into the current
+   text colour so icons inherit theme tints automatically.
+   Source: api.iconify.design (simple-icons + mdi sets). */
+.ad-icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  font-size: 18px;
+  background-color: currentColor;
+  -webkit-mask: var(--icon-url) no-repeat center / contain;
+  mask: var(--icon-url) no-repeat center / contain;
+  flex-shrink: 0;
+}
+
+.ad-icon--apple {
+  --icon-url: url('https://api.iconify.design/simple-icons/apple.svg');
+}
+.ad-icon--windows {
+  --icon-url: url('https://api.iconify.design/simple-icons/windows11.svg');
+}
+.ad-icon--linux {
+  --icon-url: url('https://api.iconify.design/mdi/linux.svg');
+}
+.ad-icon--android {
+  --icon-url: url('https://api.iconify.design/simple-icons/android.svg');
+}
+.ad-icon--appstore {
+  --icon-url: url('https://api.iconify.design/simple-icons/appstore.svg');
+}
+.ad-icon--googleplay {
+  --icon-url: url('https://api.iconify.design/simple-icons/googleplay.svg');
+}
+
+/* ── §1 hero ────────────────────────────────────────────────── */
+
+.ad-hero {
+  position: relative;
+  padding: 72px 24px 56px;
+  text-align: center;
+}
+
+.ad-hero-inner {
+  position: relative;
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.ad-hero-name {
+  font-size: 56px;
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--vp-c-text-1);
+  margin: 0;
+  padding-bottom: 4px;
+  text-wrap: balance;
+}
+
+.ad-hero-accent {
+  color: var(--vp-c-brand-1);
+}
+
+.ad-hero-text {
+  font-size: 22px;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+  margin: 18px auto 28px;
+  max-width: 660px;
+  line-height: 1.45;
+  text-wrap: balance;
+}
+
+.ad-hero-actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.ad-hero-meta {
+  margin: 18px 0 0;
+  font-size: 13px;
+  color: var(--vp-c-text-3);
+}
+
+.ad-meta-link {
+  color: var(--vp-c-text-2);
+  border-bottom: 1px solid var(--vp-c-divider);
+  text-decoration: none;
+  padding-bottom: 1px;
+}
+
+.ad-meta-link:hover {
+  color: var(--vp-c-brand-1);
+  border-bottom-color: var(--vp-c-brand-1);
+}
+
+/* ── §2 desktop ─────────────────────────────────────────────── */
+
+.ad-desktop-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+  margin-top: 8px;
+}
+
+.ad-platform-card {
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  background: var(--vp-c-bg);
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.ad-platform-card.is-recommended {
+  border-color: color-mix(
+    in srgb,
+    var(--vp-c-brand-1) 40%,
+    var(--vp-c-divider)
+  );
+}
+
+.ad-platform-card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(
+    in srgb,
+    var(--vp-c-brand-1) 55%,
+    var(--vp-c-divider)
+  );
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.08);
+}
+
+.ad-platform-head {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.ad-platform-icon {
+  font-size: 20px;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-1);
+}
+
+.ad-platform-icon .ad-icon {
+  font-size: 20px;
+}
+
+.ad-platform-title h3 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--vp-c-text-1);
+  line-height: 1.2;
+}
+
+.ad-platform-title p {
+  margin: 3px 0 0;
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  line-height: 1.4;
+}
+
+/* Per-platform CTA — uses the site's <VPButton> directly so the
+   pill styling, padding and theme-aware colours match every other
+   button on the site. Only the detected platform's first download
+   gets theme="brand"; the rest use theme="alt" to keep the visual
+   weight focused on the recommended download. Linux exposes both
+   AppImage and DEB as side-by-side buttons; the other platforms
+   ship a single download. */
+.ad-platform-cta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* ── §3 mobile ──────────────────────────────────────────────── */
+
+.ad-mobile-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.ad-mobile-card {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 20px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  background: var(--vp-c-bg);
+}
+
+.ad-mobile-icon {
+  font-size: 22px;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-1);
+}
+
+.ad-mobile-icon .ad-icon {
+  font-size: 22px;
+}
+
+.ad-mobile-name {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--vp-c-text-1);
+}
+
+.ad-soon-pill {
+  padding: 3px 9px;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--vp-c-brand-1) 16%, transparent);
+  color: var(--vp-c-brand-1);
+  border-radius: 999px;
+  white-space: nowrap;
+  justify-self: end;
+}
+
+.ad-store-badge {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.ad-store-glyph {
+  font-size: 18px;
+  color: var(--vp-c-text-1);
+}
+
+/* ── §4 canary ──────────────────────────────────────────────── *
+   Single compact list rather than four mini-card boxes. Each row:
+   icon + platform + inline download chips, hairline-separated
+   like an engineering reference table. */
+
+.ad-canary-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg);
+  overflow: hidden;
+}
+
+.ad-canary-item {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+}
+
+.ad-canary-item + .ad-canary-item {
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.ad-canary-icon {
+  font-size: 16px;
+  color: var(--vp-c-text-2);
+}
+
+.ad-canary-name {
+  color: var(--vp-c-text-1);
+  font-weight: 500;
+}
+
+.ad-canary-assets {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.ad-canary-asset {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.ad-canary-asset:hover {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+}
+
+.ad-canary-arrow {
+  font-family: var(--vp-font-family-mono);
+  color: var(--vp-c-text-3);
+}
+
+.ad-canary-meta {
+  margin: 16px 0 0;
+  font-size: 13px;
+  color: var(--vp-c-text-3);
+}
+
+.ad-canary-meta a {
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.ad-canary-meta a:hover {
+  color: var(--vp-c-brand-1);
+  border-bottom-color: var(--vp-c-brand-1);
+}
+
+.ad-canary-meta code {
+  font-size: 12px;
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .ad-desktop-grid,
+  .ad-mobile-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .ad-hero {
+    padding: 56px 20px 40px;
+  }
+  .ad-hero-name {
+    font-size: 38px;
+  }
+  .ad-hero-text {
+    font-size: 18px;
+  }
+}
+
+@media (max-width: 560px) {
+  .ad-hero-name {
+    font-size: 30px;
+  }
+  .ad-hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+    max-width: 280px;
+    margin: 0 auto;
+  }
+  .ad-mobile-card {
+    grid-template-columns: 36px minmax(0, 1fr) auto;
+  }
+  .ad-canary-item {
+    grid-template-columns: 20px minmax(0, 1fr);
+  }
+  .ad-canary-assets {
+    grid-column: 1 / -1;
+    flex-wrap: wrap;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- Adds CI for building Electric Agents Desktop across macOS, Windows, and Linux using a shared reusable workflow.
- Adds PR artifact builds, main-branch canary publishing, and Changesets-triggered stable desktop releases.
- Adds a hidden static `/app` download page for the desktop app, with platform-aware CTAs, mobile placeholders, canary links, and fixed GitHub release download URLs. See https://deploy-preview-4311--electric-next.netlify.app/app
- Updates desktop artifact naming to stable, non-versioned filenames so the website can stay static and link to fixed desktop release tags.

## What This Implements
This branch introduces a reusable `.github/workflows/agents_desktop_build.yml` workflow that all desktop build modes call. The reusable workflow:

- Builds a matrix for macOS, Windows x64, and Linux x64.
- Installs only the desktop package closure with `pnpm --filter @electric-ax/agents-desktop... install --frozen-lockfile`.
- Builds upstream workspace dependencies before typechecking with `pnpm -r --filter @electric-ax/agents-desktop^... build`.
- Runs the desktop typecheck, app build, icon build, and native module rebuild before packaging.
- Packages with Electron Builder:
  - macOS: arm64 + x64 DMGs (zip artifacts may also be produced for updater metadata / release completeness, but the download page links DMGs only).
  - Windows: x64 NSIS installer.
  - Linux: x64 AppImage and Debian package.
- Verifies macOS app signatures and checks native `.node` module architecture for both macOS builds.
- Excludes Rollup native packages from the packaged app to avoid carrying the wrong-architecture Rollup binary into macOS artifacts.
- Uses stable desktop artifact names (`Electric-Agents-mac-arm64.dmg`, `Electric-Agents-win-x64.exe`, etc.) so static download links do not need runtime metadata.

## PR Builds
`.github/workflows/agents_desktop_pr.yml` runs on pull requests that touch desktop app code, agent packages used by desktop, desktop workflows, the affected-build script, or global package/build inputs.

The workflow first runs `scripts/ci/desktop-affected.mjs`, which:

- Computes the changed files against the PR base SHA.
- Uses pnpm workspace filters to compare the changed workspace closure against the `@electric-ax/agents-desktop` dependency closure.
- Forces a build when global inputs change (`package.json`, lockfile, workspace config, Node/tooling config, desktop workflows, patches, etc.).
- Skips the expensive desktop matrix when the PR does not affect desktop or its dependencies.

When a build is required, the PR workflow calls the reusable desktop workflow with:

- `channel: pr`
- `publish: false`
- `sign: false`
- a PR/commit-derived version string

PR builds upload GitHub Actions artifacts with short retention and maintain a PR comment containing the current artifact links for:

- macOS Apple Silicon DMG
- macOS Intel DMG
- Windows x64 installer
- Linux x64 AppImage / deb

## Canary Builds
`.github/workflows/agents_desktop_canary.yml` runs on pushes to `main` that touch desktop-relevant paths, and can also be triggered manually.

It uses the same affected-build detection as PR builds. When desktop is affected, it calls the reusable desktop workflow with:

- `channel: canary`
- `publish: true`
- `sign: false`
- `release_tag: agents-desktop-canary`
- `release_name: Electric Agents Desktop Canary`

The canary publish path:

- Force-updates the fixed `agents-desktop-canary` tag to the source commit.
- Creates or edits a prerelease at that tag.
- Writes release notes with source commit, workflow run, timestamp, desktop package version, and signing status.
- Copies Electron Builder output into fixed canary asset names like `Electric-Agents-canary-mac-arm64.dmg` and `Electric-Agents-canary-linux-x64.AppImage`.
- Uploads assets with `gh release upload --clobber`, so the canary release always points at the newest main-branch build.

## Stable Releases
The existing Changesets workflow now captures `@electric-ax/agents-desktop` when Changesets publishes it:

- Extracts the published desktop version and release tag (`@electric-ax/agents-desktop@<version>`).
- Calls the reusable desktop build workflow only when a desktop package was published.
- Builds from the package release tag rather than an arbitrary branch SHA.
- Creates or edits the versioned desktop GitHub Release named `Electric Agents Desktop v<version>`.
- Uploads Electron Builder artifacts to that versioned package release.

Stable publishing also maintains a fixed `agents-desktop-latest` release:

- Force-updates the `agents-desktop-latest` tag to the published desktop release commit.
- Creates or edits the `Electric Agents Desktop Latest` release.
- Uploads the same stable assets with `gh release upload --clobber`.
- Uses `--latest=false` when creating the fixed release so it does not try to become GitHub's repo-wide latest release.

The static `/app` page links to the fixed desktop release tag, not GitHub's repo-wide `/releases/latest` redirect. This matters because this monorepo has many package releases, and the repo-wide Latest release may be `agents-server`, `sync-service`, or another package rather than `agents-desktop`.

Example stable links:

- `https://github.com/electric-sql/electric/releases/download/agents-desktop-latest/Electric-Agents-mac-arm64.dmg`
- `https://github.com/electric-sql/electric/releases/download/agents-desktop-latest/Electric-Agents-win-x64.exe`
- `https://github.com/electric-sql/electric/releases/download/agents-desktop-latest/Electric-Agents-linux-x64.AppImage`

That avoids runtime metadata, object storage, and website redeploys after every desktop release. Older versions remain downloadable from their specific GitHub Release pages because the same asset names are scoped by release tag.

## Download Page
Adds a hidden `/app` page that is not linked from the main site yet. It includes:

- A platform-detected hero CTA.
- macOS Apple Silicon / Intel, Windows, and Linux download cards.
- Linux AppImage and DEB buttons.
- Coming-soon placeholders for iOS and Android.
- Stable links to the fixed `agents-desktop-latest` release.
- Canary links to the fixed `agents-desktop-canary` prerelease.
- A release notes link filtered to the desktop package releases.

The page is intentionally static. Stable downloads use `agents-desktop-latest`, while canary downloads use `agents-desktop-canary`.

## Current Limitations / Follow-ups
- Stable and canary desktop packages are currently unsigned (`sign: false`). Developer ID signing, notarization, and Windows signing are follow-up work.
- Auto-update metadata/assets are produced by Electron Builder where applicable and uploaded with release assets, but app-side update wiring should be validated in a follow-up.
- The `/app` page currently omits the app screenshot/mockup; that will be added in a separate PR.

## Test Plan
- PR workflow exercises the unsigned desktop build matrix and artifact upload/commenting path.
- Canary workflow exercises publishing to the fixed prerelease tag on `main` when desktop-relevant files change.
- Stable publishing path is wired through Changesets and the reusable desktop build workflow when `@electric-ax/agents-desktop` is published.
- Stable publishing now maintains a fixed `agents-desktop-latest` release for static website links.
- Locally verified the `/app` page in the browser after the download-link changes.
- Pre-commit formatting ran on the committed website, workflow, and Electron Builder changes.

Made with [Cursor](https://cursor.com)