### PR TITLE
fix(sync-service): make live electric-cursor strictly monotonic

### DIFF
--- a/.changeset/fix-monotonic-live-cursor.md
+++ b/.changeset/fix-monotonic-live-cursor.md
@@ -1,0 +1,11 @@
+---
+'@core/sync-service': patch
+---
+
+Fix a 2-cycle infinite refetch loop on `live=true&live_sse=true` shape requests caused by a non-monotonic `electric-cursor` header.
+
+`Electric.Plug.Utils.get_next_interval_timestamp/2` could return a cursor smaller than the `prev_interval` the client sent: when the client polled with a previously-jittered value (`bucket + delta`, `delta ∈ 1..3_600`) and the wall clock had not yet crossed that value, the function fell through to the plain bucket value and returned a cursor below the client's. Combined with `Cache-Control: public, max-age=<sse_timeout - 1>` on live SSE responses (added intentionally to enable CDN request collapsing), two cached entries could end up pointing at each other: `?cursor=A` → `electric-cursor: B`, and `?cursor=B` → `electric-cursor: A`. Once both entries were warm, the client would bounce between them at line rate (>600 req/s) until the cache window expired, all within the original `max-age` window.
+
+`get_next_interval_timestamp/2` now guarantees that the returned cursor is strictly greater than `prev_interval` — when bucket math would return a value `<= prev`, the function jitters strictly forward from `prev` instead.
+
+This is a server-side-only fix; clients on any current version recover automatically once existing CDN-cached cycle entries age out (≤ `sse_timeout`).

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -76,11 +76,6 @@ defmodule Electric.Plug.Utils do
     next_interval = ceil(diff_in_seconds / long_poll_timeout_sec) * long_poll_timeout_sec
     prev_int = parse_prev_interval(prev_interval)
 
-    # The returned cursor MUST be strictly greater than the client's prev
-    # cursor. Otherwise CDN-cached live responses (cached for ~sse_timeout
-    # via `Cache-Control: public, max-age=<sse_timeout-1>` to enable request
-    # collapsing) can end up referencing each other in a cycle, causing the
-    # client to bounce between two cached entries at line rate.
     if next_interval > prev_int do
       next_interval
     else

--- a/packages/sync-service/lib/electric/plug/utils.ex
+++ b/packages/sync-service/lib/electric/plug/utils.ex
@@ -74,11 +74,26 @@ defmodule Electric.Plug.Utils do
     long_poll_timeout_sec = div(long_poll_timeout_ms, 1000)
     diff_in_seconds = DateTime.diff(DateTime.utc_now(), @oct9th2024, :second)
     next_interval = ceil(diff_in_seconds / long_poll_timeout_sec) * long_poll_timeout_sec
+    prev_int = parse_prev_interval(prev_interval)
 
-    if "#{next_interval}" == prev_interval do
-      next_interval + Enum.random(1..3_600)
-    else
+    # The returned cursor MUST be strictly greater than the client's prev
+    # cursor. Otherwise CDN-cached live responses (cached for ~sse_timeout
+    # via `Cache-Control: public, max-age=<sse_timeout-1>` to enable request
+    # collapsing) can end up referencing each other in a cycle, causing the
+    # client to bounce between two cached entries at line rate.
+    if next_interval > prev_int do
       next_interval
+    else
+      prev_int + Enum.random(1..3_600)
+    end
+  end
+
+  defp parse_prev_interval(nil), do: 0
+
+  defp parse_prev_interval(prev_interval) when is_binary(prev_interval) do
+    case Integer.parse(prev_interval) do
+      {n, ""} -> n
+      _ -> 0
     end
   end
 

--- a/packages/sync-service/test/electric/plug/utils_test.exs
+++ b/packages/sync-service/test/electric/plug/utils_test.exs
@@ -231,5 +231,35 @@ defmodule Electric.Plug.UtilsTest do
                "#{expected_interval}"
              ) != expected_interval
     end
+
+    test "never returns a cursor smaller than prev_interval" do
+      # Reproduces a 2-cycle observed in production: when a client polls with
+      # a jittered cursor (bucket + delta) and the wall clock has not yet
+      # crossed that jittered value, the function used to return the plain
+      # bucket value — i.e. a cursor smaller than the one the client sent.
+      # Combined with `Cache-Control: public, max-age=<sse_timeout-1>` on the
+      # response, two cached entries would end up pointing at each other and
+      # the client would bounce between them at line rate.
+      long_poll_timeout_ms = 20_000
+      long_poll_timeout_sec = div(long_poll_timeout_ms, 1000)
+
+      now = DateTime.utc_now()
+      oct9th2024 = DateTime.from_naive!(~N[2024-10-09 00:00:00], "Etc/UTC")
+      diff_in_seconds = DateTime.diff(now, oct9th2024, :second)
+      current_bucket = ceil(diff_in_seconds / long_poll_timeout_sec) * long_poll_timeout_sec
+
+      # Simulate a jittered prev cursor that sits ahead of the current bucket
+      # for every possible delta the jitter branch can produce (1..3_600).
+      for delta <- 1..3_600 do
+        prev = current_bucket + delta
+
+        result =
+          Utils.get_next_interval_timestamp(long_poll_timeout_ms, "#{prev}")
+
+        assert result > prev,
+               "cursor went backward: prev=#{prev}, result=#{result}, " <>
+                 "current_bucket=#{current_bucket}"
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Live SSE shape requests could enter an infinite 2-cycle refetch loop where the client bounced between two cursor values (`?cursor=A` ⇄ `?cursor=B`) at >600 req/s, observed in a customer HAR with 3,724 looping requests over 6 seconds.

Root cause: `Electric.Plug.Utils.get_next_interval_timestamp/2` could return a cursor smaller than the `prev_interval` the client sent.

`get_next_interval_timestamp/2` returned one of:
- `next_interval = ceil(now / T) * T` (a bucket boundary), or
- `next_interval + Enum.random(1..3_600)` (only when `prev_interval == next_interval`).

When the client polled with a **jittered** cursor `bucket + δ` (`δ ∈ 1..3_600`) and wall-clock had not yet crossed `bucket + δ`, the function fell through the `==` check, returned the plain `bucket`, and the response carried a cursor **smaller** than the client's input.

Combined with `Cache-Control: public, max-age=<sse_timeout - 1>` on live SSE responses (`response.ex:298-308` — added intentionally to enable CDN request collapsing), two cached entries could end up referencing each other:

| Cache key (request URL) | Cached `electric-cursor` response header |
|---|---|
| `…?cursor=A…` (clean bucket boundary, e.g. `49694000`) | `B` = `A + δ` (e.g. `49694039`) |
| `…?cursor=B…` (jittered value)                          | `A` (plain bucket, since `B != next_interval`) |

Once both entries warmed up, every client request was a cache hit returning the *other* cursor → infinite cycle within the `max-age` window. The HAR captured this exactly: every looping response shared the same `Date` header (proving cache replay), all 31 bytes (Electric's own SSE keep-alive output) with `electric-cursor: A` and `electric-cursor: B` strictly alternating.

## Fix

`get_next_interval_timestamp/2` now guarantees a strictly monotonic cursor: when bucket math would return a value `<= prev_interval`, jitter forward from `prev` instead of from the bucket. Backward cursors become structurally impossible, so a 2-cycle in cache cannot form regardless of CDN behaviour.

```elixir
prev_int = parse_prev_interval(prev_interval)

if next_interval > prev_int do
  next_interval
else
  prev_int + Enum.random(1..3_600)
end
```

This subsumes the original same-cursor case (`next_interval == prev_int` falls into the `else` branch and still jitters) that PR #1856 was patching.

## Reproduction / regression test

Added `test/electric/plug/utils_test.exs:235` "never returns a cursor smaller than prev_interval". It walks the full jitter range `1..3_600`, asserting `result > prev`. **Fails on `main`** with `cursor went backward: prev=…481, result=…480, current_bucket=…480` — the exact same pattern as the customer HAR. **Passes with the fix.**

```
mix test test/electric/plug/utils_test.exs
1 doctest, 14 tests, 0 failures

mix test test/electric/plug/serve_shape_plug_test.exs
45 tests, 0 failures
```

## Out of scope

Per discussion, this PR does **not** invalidate existing in-flight cached cycle pairs at CDN edges. They expire naturally within `sse_timeout` (≤ 60 s by default).

## Test plan

- [x] New regression test fails on `main`, passes with fix
- [x] `mix test test/electric/plug/utils_test.exs` — 14 tests + 1 doctest pass
- [x] `mix test test/electric/plug/serve_shape_plug_test.exs` — 45 tests pass (function is exercised end-to-end here)
- [ ] Manual: customer reproduction with `live=true&live_sse=true` no longer cycles after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)