### PR TITLE
Fix pending tool result causing Anthropic API contract violation on runtime restart

### DIFF
--- a/.changeset/fix-pending-tool-on-restart.md
+++ b/.changeset/fix-pending-tool-on-restart.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-runtime': patch
+---
+
+Fix Anthropic API contract violation when an agent restart leaves a tool call without a result. The timeline projection now synthesizes a synthetic error tool_result for interrupted tool calls so every tool_use has a matching tool_result.

--- a/packages/agents-runtime/src/timeline-context.ts
+++ b/packages/agents-runtime/src/timeline-context.ts
@@ -153,6 +153,14 @@ export function defaultProjection(
             toolCallId: runItem.key,
             isError: runItem.status === `failed`,
           })
+        } else {
+          // Tool was interrupted (crashed mid-execution) - synthesize error result
+          messages.push({
+            role: `tool_result`,
+            content: `Tool execution was interrupted before completion (status: ${runItem.status})`,
+            toolCallId: runItem.key,
+            isError: true,
+          })
         }
       }
 


### PR DESCRIPTION
## Summary

When the agent runtime is interrupted mid-tool-execution (e.g. desktop app crash), the tool call is persisted to the timeline with a non-terminal status (`started`, `args_complete`, or `executing`) but no `tool_result` is ever written. On the next wake, `defaultProjection` in `timeline-context.ts` emits the `tool_call` message but skips the `tool_result` because it only emits one for `completed`/`failed` statuses. The resulting message history sent to Anthropic violates the API contract that every `tool_use` block must be followed by a matching `tool_result`, and the API rejects the request with:

> `tool_use` ids were found without `tool_result` blocks immediately after: tc-NN

This puts the agent into a permanent error loop — every subsequent wake replays the same broken history and fails identically.

## Fix

Synthesize an error `tool_result` for any tool call that is not in a terminal state. The result's content notes that the tool was interrupted and includes the last-known status, so the model can see what happened and proceed instead of being trapped.

This is the smallest change that restores API compliance and lets a crashed agent recover on its own.

## Test plan

- [ ] Reproduce the failure by crashing the desktop app mid-`bash` tool execution and confirm the agent recovers on next wake instead of looping on `400 invalid_request_error`
- [ ] Verify a fresh conversation with no interrupted tools is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)