### PR TITLE
fix(agents-server): add agents-mcp to Dockerfile

### DIFF
--- a/.changeset/fix-agents-server-dockerfile-agents-mcp.md
+++ b/.changeset/fix-agents-server-dockerfile-agents-mcp.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server': patch
+---
+
+Fix Docker build by adding missing `agents-mcp` package to the Dockerfile.

--- a/packages/agents-server/Dockerfile
+++ b/packages/agents-server/Dockerfile
@@ -25,6 +25,7 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY patches ./patches
 COPY packages/typescript-client/package.json ./packages/typescript-client/package.json
+COPY packages/agents-mcp/package.json ./packages/agents-mcp/package.json
 COPY packages/agents-runtime/package.json ./packages/agents-runtime/package.json
 COPY packages/agents/package.json ./packages/agents/package.json
 COPY packages/agents-server-conformance-tests/package.json ./packages/agents-server-conformance-tests/package.json
@@ -36,6 +37,9 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 COPY tsconfig.base.json tsconfig.build.json ./
 COPY packages/typescript-client ./packages/typescript-client
 RUN pnpm --filter @electric-sql/client build
+
+COPY packages/agents-mcp ./packages/agents-mcp
+RUN pnpm --filter @electric-ax/agents-mcp build
 
 COPY packages/agents-runtime ./packages/agents-runtime
 RUN pnpm --filter @electric-ax/agents-runtime build


### PR DESCRIPTION
## Problem

`@electric-ax/agents-mcp` was added as a workspace dependency of `agents-runtime` in #4289, but was never added to the `agents-server` Dockerfile. This caused the Docker build to fail with:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In packages/agents-runtime: "@electric-ax/agents-mcp@workspace:*" is in the dependencies but no package named "@electric-ax/agents-mcp" is present in the workspace
```

This broke the `publish-agent-server-to-dockerhub` job in the Changesets release run triggered by #4252.

## Fix

Add `agents-mcp/package.json` to the manifest-copy stage and add a `COPY` + build step for `agents-mcp` before `agents-runtime` (which depends on it).