### PR TITLE
fix: send spawn initial message before dispatch link

### DIFF
--- a/.changeset/early-wakes-arrive.md
+++ b/.changeset/early-wakes-arrive.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-server": patch
+---
+
+Fix pull-wake dispatch for spawns with an initial message by appending the inbox message before linking the dispatch subscription.

--- a/packages/agents-server/src/routing/entities-router.ts
+++ b/packages/agents-server/src/routing/entities-router.ts
@@ -614,13 +614,13 @@ async function spawnEntity(
     wake: parsed.wake,
     created_by: principal.url,
   })
-  await linkEntityDispatchSubscription(ctx, entity)
   if (parsed.initialMessage !== undefined) {
     await ctx.entityManager.send(entity.url, {
       from: principal.url,
       payload: parsed.initialMessage,
     })
   }
+  await linkEntityDispatchSubscription(ctx, entity)
 
   return json(
     { ...toPublicEntity(entity), txid: entity.txid },

--- a/packages/agents-server/test/dispatch-policy-routing.test.ts
+++ b/packages/agents-server/test/dispatch-policy-routing.test.ts
@@ -151,6 +151,48 @@ describe(`dispatch policy routing`, () => {
     expect(ctx.pgDb.insert).toHaveBeenCalled()
   })
 
+  it(`sends spawn initialMessage before linking pull-wake dispatch`, async () => {
+    const dispatchPolicy: DispatchPolicy = {
+      targets: [{ type: `runner`, runnerId: `runner-1` }],
+    }
+    const ctx = buildContext()
+    ctx.entityManager.send = vi.fn(async () => undefined)
+
+    const response = await globalRouter.fetch(
+      request(`PUT`, `/_electric/entities/chat/one`, {
+        dispatch_policy: dispatchPolicy,
+        initialMessage: `hello`,
+      }),
+      ctx
+    )
+
+    expect(response.status).toBe(201)
+    expect(ctx.entityManager.spawn).toHaveBeenCalledWith(
+      `chat`,
+      expect.objectContaining({
+        dispatch_policy: dispatchPolicy,
+        initialMessage: undefined,
+      })
+    )
+    expect(ctx.entityManager.send).toHaveBeenCalledWith(`/chat/one`, {
+      from: `/principal/user:owner@example.com`,
+      payload: `hello`,
+    })
+    expect(ctx.streamClient.putSubscription).toHaveBeenCalledWith(
+      `runner:runner-1`,
+      expect.objectContaining({
+        type: `pull-wake`,
+        streams: [`/chat/one/main`],
+        wake_stream: `/runners/runner-1/wake`,
+      })
+    )
+    expect(
+      (ctx.entityManager.send as any).mock.invocationCallOrder[0]
+    ).toBeLessThan(
+      (ctx.streamClient.putSubscription as any).mock.invocationCallOrder[0]
+    )
+  })
+
   it(`links legacy entities through the type default before sending`, async () => {
     const dispatchPolicy: DispatchPolicy = {
       targets: [{ type: `runner`, runnerId: `runner-1` }],


### PR DESCRIPTION
Fixes the pull-wake spawn race where an entity created with `initialMessage` could link its dispatch subscription before the inbox append existed. The route still calls `entityManager.send()` so inbox schema validation and dispatch policy checks run, but it now appends the initial inbox message before `linkEntityDispatchSubscription()`.

Adds a route-level regression test that asserts spawn keeps `initialMessage` out of `entityManager.spawn()` and calls `send()` before creating the pull-wake subscription.
