### PR TITLE
fix(agents-server): enable postgres type fetching

### DIFF
--- a/.changeset/quiet-masks-drum.md
+++ b/.changeset/quiet-masks-drum.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-server": patch
+---
+
+Enable Postgres type fetching so array parameters bind with the correct PostgreSQL array OIDs.

--- a/packages/agents-server/src/db/index.ts
+++ b/packages/agents-server/src/db/index.ts
@@ -16,7 +16,7 @@ export function createDb(postgresUrl: string): {
   const poolMax = Number(process.env.ELECTRIC_AGENTS_PG_POOL_MAX ?? `100`)
   const client = postgres(postgresUrl, {
     max: poolMax,
-    fetch_types: false,
+    fetch_types: true,
   })
   const db = drizzle(client, { schema })
   return { db, client }


### PR DESCRIPTION
## Summary
- Enable Postgres.js type fetching for the agents-server database client.
- Add a patch changeset for @electric-ax/agents-server.

This lets Postgres.js resolve array type OIDs for scheduler tenant filters that use single array parameters with ANY(...).

## Tests
- pnpm --filter @electric-ax/agents-server test
- pnpm --filter @electric-ax/agents-server typecheck
- pnpm --filter @electric-ax/agents-server stylecheck
- pnpm --filter @electric-ax/agents-server build