### PR TITLE
feat(agents-desktop): add dev principal support for local development

### DIFF
--- a/.changeset/desktop-dev-principal-support.md
+++ b/.changeset/desktop-dev-principal-support.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-desktop': patch
+'@electric-ax/agents-server-ui': patch
+---
+
+Add `ELECTRIC_DESKTOP_PRINCIPAL` env var for local development without auth. The desktop app injects the `electric-principal` header on all requests to the agents-server, enabling pull-wake runner registration and message sends to work locally. Also fix the UI to derive the optimistic message sender from the configured principal and stop sending the redundant `from` field in API requests.

--- a/packages/agents-desktop/README.md
+++ b/packages/agents-desktop/README.md
@@ -1,0 +1,35 @@
+# Electric Agents Desktop
+
+Desktop app for Electric Agents, built with Electron.
+
+## Development
+
+### Prerequisites
+
+- An agents-server running locally (e.g. at `http://localhost:4437`)
+
+### Running the dev server
+
+```bash
+ELECTRIC_DESKTOP_PRINCIPAL="system:dev-local" pnpm dev
+```
+
+This starts both the UI dev server (with HMR) and the Electron main process.
+
+### Environment variables
+
+| Variable                                     | Default            | Description                                                                                                                                               |
+| -------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ELECTRIC_DESKTOP_PRINCIPAL`                 | _(none)_           | Sets the `electric-principal` header on all requests to the agents-server. Use `system:dev-local` for local development without auth.                     |
+| `ELECTRIC_DESKTOP_PULL_WAKE_OWNER_USER_ID`   | `local-desktop`    | Override the `owner_user_id` used when registering the pull-wake runner. When `ELECTRIC_DESKTOP_PRINCIPAL` is set, this is derived from it automatically. |
+| `ELECTRIC_DESKTOP_PULL_WAKE_RUNNER_ID`       | _(auto-generated)_ | Fixed runner ID for the pull-wake runner.                                                                                                                 |
+| `ELECTRIC_DESKTOP_PULL_WAKE_REGISTER_RUNNER` | `true`             | Set to `false` to skip runner registration (runner must already exist on the server).                                                                     |
+
+### Settings
+
+Desktop settings are stored at:
+
+- **macOS**: `~/Library/Application Support/Electric Agents/settings.json`
+- **Linux**: `~/.config/Electric Agents/settings.json`
+
+You can configure servers, per-server headers, and working directory here. In most cases, the env vars above are sufficient for local dev.

--- a/packages/agents-desktop/src/main.ts
+++ b/packages/agents-desktop/src/main.ts
@@ -227,6 +227,21 @@ const PULL_WAKE_REGISTER_RUNNER =
 const PULL_WAKE_OWNER_USER_ID =
   process.env.ELECTRIC_DESKTOP_PULL_WAKE_OWNER_USER_ID?.trim() ||
   `local-desktop`
+const DEV_PRINCIPAL = ((): string | null => {
+  const raw = process.env.ELECTRIC_DESKTOP_PRINCIPAL?.trim() || null
+  if (!raw) return null
+  const colon = raw.indexOf(`:`)
+  if (colon <= 0) {
+    console.error(
+      `[agents-desktop] ELECTRIC_DESKTOP_PRINCIPAL="${raw}" is invalid. ` +
+        `Expected format: "kind:id" (e.g. "system:dev-local"). Ignoring.`
+    )
+    return null
+  }
+  console.info(`[agents-desktop] Using dev principal: ${raw}`)
+  return raw
+})()
+const ELECTRIC_PRINCIPAL_HEADER = `electric-principal`
 
 function mergeHeaders(
   ...sources: Array<Record<string, string> | undefined>
@@ -251,7 +266,11 @@ function runnerOwnerUserIdFromHeaders(
   headers: Record<string, string> | undefined
 ): string {
   const normalized = new Headers(headers)
-  return normalized.get(`authorization`)?.trim() || PULL_WAKE_OWNER_USER_ID
+  return (
+    normalized.get(`authorization`)?.trim() ||
+    normalized.get(ELECTRIC_PRINCIPAL_HEADER)?.trim() ||
+    PULL_WAKE_OWNER_USER_ID
+  )
 }
 
 /**
@@ -869,6 +888,14 @@ function localRuntimeStatusLabel(status: LocalRuntimeStatus): string {
   }
 }
 
+function injectDevPrincipalHeaders(server: ServerConfig): ServerConfig {
+  if (!DEV_PRINCIPAL) return server
+  return {
+    ...server,
+    headers: { ...server.headers, [ELECTRIC_PRINCIPAL_HEADER]: DEV_PRINCIPAL },
+  }
+}
+
 function desktopStateForWindow(win: BrowserWindow | null): DesktopState {
   const selectedServerId = selectedServerIdForWindow(win)
   const activeServer = findServer(selectedServerId)
@@ -881,7 +908,7 @@ function desktopStateForWindow(win: BrowserWindow | null): DesktopState {
     ),
     runtimeStatus: runtimeStatusForConnection(entry),
     runtimeUrl: entry?.runtimeUrl ?? null,
-    activeServer,
+    activeServer: activeServer ? injectDevPrincipalHeaders(activeServer) : null,
     workingDirectory: settings.workingDirectory,
     error: entry?.lastError ?? null,
     discoveredServers: state.discoveredServers,
@@ -1512,7 +1539,8 @@ async function startRuntime(serverId: string): Promise<void> {
   }
   setState({ pullWakeRunnerId: runnerId })
 
-  const runtimeHeaders = mergeHeaders(activeServer.headers)
+  const serverWithPrincipal = injectDevPrincipalHeaders(activeServer)
+  const runtimeHeaders = mergeHeaders(serverWithPrincipal.headers)
   const runnerOwnerUserId = runnerOwnerUserIdFromHeaders(runtimeHeaders)
   console.info(
     `[agents-desktop] Starting built-in agents runtime for server ${activeServer.url}`

--- a/packages/agents-server-ui/src/lib/auth-fetch.ts
+++ b/packages/agents-server-ui/src/lib/auth-fetch.ts
@@ -22,8 +22,11 @@ function normalizeHeaders(
     if (!name || !value) continue
     try {
       normalized.set(name, value)
-    } catch {
-      // Ignore persisted or hand-edited invalid header entries.
+    } catch (err) {
+      console.warn(
+        `[auth-fetch] Dropping invalid header "${name}":`,
+        err instanceof Error ? err.message : String(err)
+      )
     }
   }
   return Object.fromEntries(normalized.entries())
@@ -80,6 +83,10 @@ export function getConfiguredServerHeaders(
   input: RequestInfo | URL
 ): Record<string, string> {
   return matchesActiveServer(input) ? (activeServerHeaders?.headers ?? {}) : {}
+}
+
+export function getActivePrincipal(): string {
+  return activeServerHeaders?.headers[`electric-principal`] ?? `unknown`
 }
 
 export async function serverFetch(

--- a/packages/agents-server-ui/src/lib/sendMessage.ts
+++ b/packages/agents-server-ui/src/lib/sendMessage.ts
@@ -1,6 +1,6 @@
 import { createOptimisticAction } from '@tanstack/db'
 import { generateKeyBetween } from 'fractional-indexing'
-import { serverFetch } from './auth-fetch'
+import { getActivePrincipal, serverFetch } from './auth-fetch'
 import { entityApiUrl } from './entity-api'
 import type { EntityStreamDBWithActions } from '@electric-ax/agents-runtime/client'
 
@@ -148,7 +148,7 @@ export function createSendMessageAction({
   db,
   baseUrl,
   entityUrl,
-  from = `user`,
+  from = getActivePrincipal(),
   onOptimisticMessage,
 }: {
   db: EntityStreamDBWithActions
@@ -182,7 +182,6 @@ export function createSendMessageAction({
         method: `POST`,
         headers: { 'content-type': `application/json` },
         body: JSON.stringify({
-          from,
           key,
           payload: { text },
           mode,


### PR DESCRIPTION
## Add dev principal support for local desktop development

Running the desktop app locally against an agents-server required no auth, but the recent principals refactor (#4323) added `electric-principal` validation to runner registration and message sends. This PR adds an `ELECTRIC_DESKTOP_PRINCIPAL` env var so the desktop app can identify itself to the server in dev mode.

### Approach

The `electric-principal` header needs to be present on requests from two separate systems: the Electron main process (pull-wake runtime) and the renderer (UI API calls via `serverFetch`). Rather than configuring headers in `settings.json`, a single env var injects the header in both paths:

1. **`injectDevPrincipalHeaders()`** enriches the server config with the principal header
2. **`desktopStateForWindow()`** applies it to the `activeServer` sent to the renderer (which flows to `registerActiveServerHeaders` → `serverFetch`)
3. **`startRuntime()`** applies it to the runtime headers used for pull-wake runner registration

The `from` field in message send requests was also removed from the API body — the server already derives the sender from the authenticated principal, making the client-supplied `from` redundant (and a source of 400 errors when it didn't match). The optimistic UI `from` now reads from the configured principal header.

### Key invariants

- When `ELECTRIC_DESKTOP_PRINCIPAL` is unset, behavior is unchanged (no header injected)
- When set, it must be valid `kind:id` format — invalid values are logged and ignored
- `runnerOwnerUserIdFromHeaders` falls back through `authorization` → `electric-principal` → constant, so production auth takes precedence
- The `from` field is never sent in the API body; the server uses the principal

### Files changed

- **`packages/agents-desktop/src/main.ts`** — `DEV_PRINCIPAL` env var with startup validation, `injectDevPrincipalHeaders` helper, applied in `desktopStateForWindow` and `startRuntime`, extended `runnerOwnerUserIdFromHeaders` fallback chain
- **`packages/agents-server-ui/src/lib/sendMessage.ts`** — Removed `from` from API body, derive optimistic `from` from `getActivePrincipal()`
- **`packages/agents-server-ui/src/lib/auth-fetch.ts`** — Added `getActivePrincipal()`, replaced silent catch with warning log in `normalizeHeaders`
- **`packages/agents-desktop/README.md`** — Dev setup instructions with env var documentation

### Verification

```bash
ELECTRIC_DESKTOP_PRINCIPAL="system:dev-local" pnpm dev
# Spawn a new entity, send a message — pull-wake runner should claim and process it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)