### PR TITLE
Change spawn worker tool instructions to put the bulk of instructions in the initial message not the system prompt

### DIFF
--- a/.changeset/desktop-dev-principal-support.md
+++ b/.changeset/desktop-dev-principal-support.md
@@ -1,5 +1,4 @@
 ---
-'@electric-ax/agents': patch
 '@electric-ax/agents-desktop': patch
 '@electric-ax/agents-server-ui': patch
 ---

--- a/.changeset/desktop-dev-principal-support.md
+++ b/.changeset/desktop-dev-principal-support.md
@@ -1,4 +1,5 @@
 ---
+'@electric-ax/agents': patch
 '@electric-ax/agents-desktop': patch
 '@electric-ax/agents-server-ui': patch
 ---

--- a/.changeset/spawn-worker-instructions.md
+++ b/.changeset/spawn-worker-instructions.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents": patch
+---
+
+Move spawn worker tool instructions from system prompt to initial message for better worker briefing

--- a/packages/agents/src/tools/spawn-worker.ts
+++ b/packages/agents/src/tools/spawn-worker.ts
@@ -24,10 +24,10 @@ export function createSpawnWorkerTool(
   return {
     name: `spawn_worker`,
     label: `Spawn Worker`,
-    description: `Dispatch a subagent (worker) to perform an isolated subtask. Provide a system prompt that briefs the worker like a colleague who just walked into the room (file paths, line numbers, what specifically to do, what form of answer you want back) and pick the subset of tools the worker needs.`,
+    description: `Dispatch a subagent (worker) to perform an isolated subtask. Provide a brief system prompt to give it its role and then a detailed initialMessage which briefs the worker like a colleague who just walked into the room (file paths, line numbers, what specifically to do, what form of answer you want back) and pick the subset of tools the worker needs.`,
     parameters: Type.Object({
       systemPrompt: Type.String({
-        description: `System prompt for the worker. Be concrete: include file paths, line numbers, and the form of answer you want back.`,
+        description: `System prompt for the worker.`,
       }),
       tools: Type.Array(
         Type.Union(WORKER_TOOL_NAMES.map((n) => Type.Literal(n))),
@@ -36,7 +36,7 @@ export function createSpawnWorkerTool(
         }
       ),
       initialMessage: Type.String({
-        description: `First user message sent to the worker. This is what kicks off its run — without it the worker will idle. Describe the concrete task to perform.`,
+        description: `First user message sent to the worker. Be concrete: include file paths, line numbers, and the form of answer you want back. This is what kicks off its run — without it the worker will idle. Describe the concrete task to perform and what form of message you want back.`,
       }),
     }),
     execute: async (_toolCallId, params) => {


### PR DESCRIPTION
This makes worker instructions always viewable as system prompts aren't generally visible when looking at agents.

Also cleaner separation — system prompt is "who are you" and initial message is "what you need to do".