### PR TITLE
fix: route durable streams control through __ds

### DIFF
--- a/.changeset/durable-streams-ds-routing.md
+++ b/.changeset/durable-streams-ds-routing.md
@@ -3,4 +3,4 @@
 "@electric-ax/agents-server-conformance-tests": patch
 ---
 
-Route Durable Streams subscription control traffic through the reserved `__ds` prefix under each stream URL. Agents-server now proxies control routes before normal stream operations, supports tenant-root cloud stream URLs, and keeps tenant-relative stream names for `/v1/streams/:service` roots.
+Route Durable Streams subscription control traffic through the reserved `__ds` prefix under each stream URL. Agents-server now accepts control routes at the server-root `__ds` prefix, proxies them before normal stream operations, supports tenant-root cloud stream URLs, and keeps tenant-relative stream names for `/v1/streams/:service` roots.

--- a/.changeset/durable-streams-ds-routing.md
+++ b/.changeset/durable-streams-ds-routing.md
@@ -1,0 +1,6 @@
+---
+"@electric-ax/agents-server": patch
+"@electric-ax/agents-server-conformance-tests": patch
+---
+
+Route Durable Streams subscription control traffic through the reserved `__ds` prefix under each stream URL. Agents-server now proxies control routes before normal stream operations, supports tenant-root cloud stream URLs, and keeps tenant-relative stream names for `/v1/streams/:service` roots.

--- a/.changeset/durable-streams-ds-routing.md
+++ b/.changeset/durable-streams-ds-routing.md
@@ -3,4 +3,4 @@
 "@electric-ax/agents-server-conformance-tests": patch
 ---
 
-Route Durable Streams subscription control traffic through the reserved `__ds` prefix under each stream URL. Agents-server now accepts control routes at the server-root `__ds` prefix, proxies them before normal stream operations, supports tenant-root cloud stream URLs, and keeps tenant-relative stream names for `/v1/streams/:service` roots.
+Route Durable Streams subscription control traffic through the reserved `__ds` prefix under each stream URL. Agents-server now accepts control routes at the server-root `__ds` prefix, proxies them before normal stream operations, and forwards Durable Streams requests through the resolved tenant stream root instead of inferring cloud-specific URL shapes.

--- a/packages/agents-server-conformance-tests/src/cli-dsl.ts
+++ b/packages/agents-server-conformance-tests/src/cli-dsl.ts
@@ -56,7 +56,7 @@ export interface CliHistory {
 }
 
 function subscriptionEndpoint(baseUrl: string, id: string): string {
-  return `${baseUrl}/v1/stream-meta/subscriptions/${encodeURIComponent(id)}`
+  return `${baseUrl}/__ds/subscriptions/${encodeURIComponent(id)}`
 }
 
 function subscriptionPattern(pattern: string): string {

--- a/packages/agents-server-conformance-tests/src/electric-agents-dsl.ts
+++ b/packages/agents-server-conformance-tests/src/electric-agents-dsl.ts
@@ -495,7 +495,7 @@ function isEntityStreamPath(pathname: string): boolean {
 }
 
 function subscriptionEndpoint(baseUrl: string, id: string): string {
-  return `${baseUrl}/v1/stream-meta/subscriptions/${encodeURIComponent(id)}`
+  return `${baseUrl}/__ds/subscriptions/${encodeURIComponent(id)}`
 }
 
 function subscriptionPattern(pattern: string): string {

--- a/packages/agents-server-conformance-tests/src/electric-agents-tests.ts
+++ b/packages/agents-server-conformance-tests/src/electric-agents-tests.ts
@@ -2642,7 +2642,7 @@ export function runElectricAgentsConformanceTests(
 
     test(`write to non-entity stream requires no auth`, async () => {
       const id = Date.now()
-      const streamPath = `/v1/stream/plain-stream-auth-test-${id}`
+      const streamPath = `/plain-stream-auth-test-${id}`
 
       // Create a regular stream
       const createRes = await fetch(`${config.baseUrl}${streamPath}`, {

--- a/packages/agents-server/src/index.ts
+++ b/packages/agents-server/src/index.ts
@@ -37,7 +37,10 @@ export type { Principal, PrincipalKind } from './principal.js'
 export { globalRouter } from './routing/global-router.js'
 export type { GlobalRoutes } from './routing/global-router.js'
 export type { TenantContext } from './routing/context.js'
-export { pathPrefixedSingleTenantDurableStreamsRoutingAdapter } from './routing/durable-streams-routing-adapter.js'
+export {
+  pathPrefixedSingleTenantDurableStreamsRoutingAdapter,
+  tenantRootDurableStreamsRoutingAdapter,
+} from './routing/durable-streams-routing-adapter.js'
 export type {
   DurableStreamsRoutingAdapter,
   DurableStreamsRoutingInput,

--- a/packages/agents-server/src/index.ts
+++ b/packages/agents-server/src/index.ts
@@ -38,6 +38,7 @@ export { globalRouter } from './routing/global-router.js'
 export type { GlobalRoutes } from './routing/global-router.js'
 export type { TenantContext } from './routing/context.js'
 export {
+  streamRootDurableStreamsRoutingAdapter,
   pathPrefixedSingleTenantDurableStreamsRoutingAdapter,
   tenantRootDurableStreamsRoutingAdapter,
 } from './routing/durable-streams-routing-adapter.js'

--- a/packages/agents-server/src/routing/context.ts
+++ b/packages/agents-server/src/routing/context.ts
@@ -19,6 +19,7 @@ export interface TenantContext {
   principal: Principal
   publicUrl: string
   localUrl?: string
+  /** Resolved Durable Streams root URL for this tenant. */
   durableStreamsUrl: string
   durableStreamsBearer?: DurableStreamsBearerProvider
   durableStreamsRouting?: DurableStreamsRoutingAdapter

--- a/packages/agents-server/src/routing/durable-streams-control-path.ts
+++ b/packages/agents-server/src/routing/durable-streams-control-path.ts
@@ -1,5 +1,0 @@
-export function durableStreamsControlPath(pathname: string): string | null {
-  const segments = pathname.split(`/`).filter(Boolean)
-  if (segments[0] !== `__ds`) return null
-  return `/${segments.join(`/`)}`
-}

--- a/packages/agents-server/src/routing/durable-streams-control-path.ts
+++ b/packages/agents-server/src/routing/durable-streams-control-path.ts
@@ -1,0 +1,5 @@
+export function durableStreamsControlPath(pathname: string): string | null {
+  const segments = pathname.split(`/`).filter(Boolean)
+  if (segments[0] !== `__ds`) return null
+  return `/${segments.join(`/`)}`
+}

--- a/packages/agents-server/src/routing/durable-streams-router.ts
+++ b/packages/agents-server/src/routing/durable-streams-router.ts
@@ -16,6 +16,7 @@ import { validateBody } from './schema.js'
 import { rewriteLoopbackWebhookUrl } from '../utils/webhook-url.js'
 import { forwardFetchRequest } from '../utils/server-utils.js'
 import { resolveDurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
+import { durableStreamsControlPath } from './durable-streams-control-path.js'
 import type { IRequest, RouterType } from 'itty-router'
 import type { TenantContext } from './context.js'
 import type { DurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
@@ -121,32 +122,14 @@ interface SubscriptionProxyRoute {
   streamPath?: string
 }
 
-function controlPathSuffix(pathname: string): string | null {
-  const segments = pathname.split(`/`).filter(Boolean)
-  const controlIndex =
-    segments[0] === `__ds`
-      ? 0
-      : segments[0] === `v1` &&
-          segments[1] === `stream` &&
-          segments[2] === `__ds`
-        ? 2
-        : segments[0] === `v1` &&
-            segments[1] === `streams` &&
-            segments[3] === `__ds`
-          ? 3
-          : -1
-  if (controlIndex < 0) return null
-  return `/${segments.slice(controlIndex).join(`/`)}`
-}
-
 function isReservedControlPath(pathname: string): boolean {
-  return controlPathSuffix(pathname) !== null
+  return durableStreamsControlPath(pathname) !== null
 }
 
 function subscriptionRouteFromPath(
   pathname: string
 ): SubscriptionProxyRoute | null {
-  const routePath = controlPathSuffix(pathname)
+  const routePath = durableStreamsControlPath(pathname)
   if (!routePath) return null
 
   const segments = routePath.split(`/`).filter(Boolean)

--- a/packages/agents-server/src/routing/durable-streams-router.ts
+++ b/packages/agents-server/src/routing/durable-streams-router.ts
@@ -48,7 +48,7 @@ export const durableStreamsRouter: DurableStreamsRoutes = Router<
   Response | undefined
 >()
 
-durableStreamsRouter.all(`/v1/stream-meta/subscriptions/*`, subscriptionProxy)
+durableStreamsRouter.all(`*`, subscriptionProxy)
 durableStreamsRouter.post(`*`, streamAppend)
 durableStreamsRouter.all(`*`, proxyPassThrough)
 
@@ -71,7 +71,7 @@ async function forwardToDurableStreams(
   ctx: TenantContext,
   request: IRequest,
   body?: Uint8Array,
-  route: `stream` | `stream-meta` = `stream`,
+  route: `stream` | `control` = `stream`,
   urlOverride?: string
 ): Promise<Response> {
   const headers = new Headers(request.headers)
@@ -106,22 +106,88 @@ async function forwardToDurableStreams(
   })
 }
 
-function subscriptionIdFromPath(pathname: string): string | null {
-  const match = /^\/v1\/stream-meta\/subscriptions\/([^/]+)(?:\/.*)?$/.exec(
-    pathname
-  )
-  return match ? decodeURIComponent(match[1]!) : null
+type SubscriptionProxyAction =
+  | `base`
+  | `streams`
+  | `stream`
+  | `callback`
+  | `claim`
+  | `ack`
+  | `release`
+
+interface SubscriptionProxyRoute {
+  subscriptionId: string
+  action: SubscriptionProxyAction
+  streamPath?: string
+}
+
+function controlPathSuffix(pathname: string): string | null {
+  const segments = pathname.split(`/`).filter(Boolean)
+  const controlIndex =
+    segments[0] === `__ds`
+      ? 0
+      : segments[0] === `v1` &&
+          segments[1] === `stream` &&
+          segments[2] === `__ds`
+        ? 2
+        : segments[0] === `v1` &&
+            segments[1] === `streams` &&
+            segments[3] === `__ds`
+          ? 3
+          : -1
+  if (controlIndex < 0) return null
+  return `/${segments.slice(controlIndex).join(`/`)}`
+}
+
+function isReservedControlPath(pathname: string): boolean {
+  return controlPathSuffix(pathname) !== null
+}
+
+function subscriptionRouteFromPath(
+  pathname: string
+): SubscriptionProxyRoute | null {
+  const routePath = controlPathSuffix(pathname)
+  if (!routePath) return null
+
+  const segments = routePath.split(`/`).filter(Boolean)
+  if (segments[0] !== `__ds` || segments[1] !== `subscriptions`) return null
+
+  const subscriptionId = segments[2] ? decodeURIComponent(segments[2]) : ``
+  if (!subscriptionId) return null
+
+  const tail = segments.slice(3)
+  if (tail.length === 0) return { subscriptionId, action: `base` }
+  if (tail[0] === `streams` && tail.length === 1) {
+    return { subscriptionId, action: `streams` }
+  }
+  if (tail[0] === `streams` && tail.length > 1) {
+    return {
+      subscriptionId,
+      action: `stream`,
+      streamPath: decodeURIComponent(tail.slice(1).join(`/`)),
+    }
+  }
+  if (
+    tail.length === 1 &&
+    [`callback`, `claim`, `ack`, `release`].includes(tail[0]!)
+  ) {
+    return {
+      subscriptionId,
+      action: tail[0] as SubscriptionProxyAction,
+    }
+  }
+
+  return null
 }
 
 function isSubscriptionBasePath(pathname: string): boolean {
-  return /^\/v1\/stream-meta\/subscriptions\/[^/]+\/?$/.test(pathname)
+  return subscriptionRouteFromPath(pathname)?.action === `base`
 }
 
 function usesSubscriptionScopedBearer(requestUrl: string): boolean {
   const pathname = new URL(requestUrl, `http://localhost`).pathname
-  return /^\/v1\/stream-meta\/subscriptions\/[^/]+\/(?:ack|release|callback)\/?$/.test(
-    pathname
-  )
+  const action = subscriptionRouteFromPath(pathname)?.action
+  return action === `ack` || action === `release` || action === `callback`
 }
 
 function rewriteSubscriptionBodyForBackend(
@@ -244,16 +310,17 @@ function rewriteSubscriptionStreamPathInUrl(
   service: string,
   routingAdapter: DurableStreamsRoutingAdapter
 ): string {
-  const match =
-    /^(\/v1\/stream-meta\/subscriptions\/[^/]+\/streams\/)(.+)$/.exec(
-      requestUrl.pathname
-    )
-  if (!match) return requestUrl.toString()
+  const route = subscriptionRouteFromPath(requestUrl.pathname)
+  if (route?.action !== `stream` || !route.streamPath) {
+    return requestUrl.toString()
+  }
 
-  const [, prefix, encodedPath] = match
-  const streamPath = decodeURIComponent(encodedPath!)
+  const prefix = requestUrl.pathname.slice(
+    0,
+    requestUrl.pathname.indexOf(`/streams/`) + `/streams/`.length
+  )
   requestUrl.pathname = `${prefix}${encodeURIComponent(
-    routingAdapter.toBackendStreamPath(service, streamPath)
+    routingAdapter.toBackendStreamPath(service, route.streamPath)
   )}`
   return requestUrl.toString()
 }
@@ -263,11 +330,22 @@ async function subscriptionProxy(
   ctx: TenantContext
 ): Promise<Response | undefined> {
   const url = new URL(request.url)
-  const subscriptionId = subscriptionIdFromPath(url.pathname)
-  if (!subscriptionId) return undefined
+  if (!isReservedControlPath(url.pathname)) return undefined
+  const route = subscriptionRouteFromPath(url.pathname)
+  if (!route) {
+    const upstream = await forwardToDurableStreams(
+      ctx,
+      request,
+      undefined,
+      `control`
+    )
+    return responseFromUpstream(upstream)
+  }
+  const { subscriptionId } = route
 
   const routingAdapter = resolveDurableStreamsRoutingAdapter(
-    ctx.durableStreamsRouting
+    ctx.durableStreamsRouting,
+    ctx.durableStreamsUrl
   )
   let requestBody: Uint8Array | undefined
   let targetWebhookUrl: string | null = null
@@ -296,10 +374,7 @@ async function subscriptionProxy(
     }
   }
 
-  if (
-    request.method.toUpperCase() === `DELETE` &&
-    /\/streams\/.+$/.test(url.pathname)
-  ) {
+  if (request.method.toUpperCase() === `DELETE` && route.action === `stream`) {
     requestUrl = rewriteSubscriptionStreamPathInUrl(
       url,
       ctx.service,
@@ -311,7 +386,7 @@ async function subscriptionProxy(
     ctx,
     request,
     requestBody,
-    `stream-meta`,
+    `control`,
     requestUrl
   )
   let responseBytes: Uint8Array = upstream.body
@@ -391,7 +466,7 @@ async function proxyPassThrough(
   const upstream = await forwardToDurableStreams(ctx, request)
   const streamPath = new URL(request.url).pathname
   const method = request.method.toUpperCase()
-  const isControlPath = streamPath.startsWith(`/v1/stream-meta/`)
+  const isControlPath = isReservedControlPath(streamPath)
   const endTrackedRead =
     method === `GET` && !isControlPath
       ? await ctx.entityBridgeManager.beginClientRead(streamPath)

--- a/packages/agents-server/src/routing/durable-streams-router.ts
+++ b/packages/agents-server/src/routing/durable-streams-router.ts
@@ -57,23 +57,23 @@ export const durableStreamsRouter: DurableStreamsRoutes = Router<
 
 durableStreamsRouter.put(
   `/__ds/subscriptions/:subscriptionId`,
-  subscriptionBase
+  putSubscriptionBase
 )
 durableStreamsRouter.get(
   `/__ds/subscriptions/:subscriptionId`,
-  subscriptionBase
+  getSubscriptionBase
 )
 durableStreamsRouter.delete(
   `/__ds/subscriptions/:subscriptionId`,
-  subscriptionBase
+  deleteSubscriptionBase
 )
 durableStreamsRouter.post(
   `/__ds/subscriptions/:subscriptionId/streams`,
-  subscriptionStreams
+  postSubscriptionStreams
 )
 durableStreamsRouter.delete(
   `/__ds/subscriptions/:subscriptionId/streams/:streamPath+`,
-  subscriptionStream
+  deleteSubscriptionStream
 )
 for (const action of subscriptionControlActions) {
   durableStreamsRouter.post(
@@ -137,20 +137,7 @@ async function forwardToDurableStreams(
   })
 }
 
-type SubscriptionProxyAction =
-  | `base`
-  | `streams`
-  | `stream`
-  | `callback`
-  | `claim`
-  | `ack`
-  | `release`
-
-interface SubscriptionProxyRoute {
-  subscriptionId: string
-  action: SubscriptionProxyAction
-  streamPath?: string
-}
+type SubscriptionControlAction = (typeof subscriptionControlActions)[number]
 
 function rewriteSubscriptionBodyForBackend(
   payload: Record<string, unknown>,
@@ -273,56 +260,125 @@ function routeParam(request: IRequest, name: string): string {
   return decodeURIComponent(raw ?? ``)
 }
 
-function subscriptionBase(
-  request: IRequest,
+function subscriptionRoutingAdapter(
   ctx: TenantContext
-): Promise<Response> {
-  return subscriptionProxy(request, ctx, {
-    subscriptionId: routeParam(request, `subscriptionId`),
-    action: `base`,
-  })
+): DurableStreamsRoutingAdapter {
+  return resolveDurableStreamsRoutingAdapter(
+    ctx.durableStreamsRouting,
+    ctx.durableStreamsUrl
+  )
 }
 
-function subscriptionStreams(
+async function rewriteSubscriptionRequestBody(
   request: IRequest,
-  ctx: TenantContext
-): Promise<Response> {
-  return subscriptionProxy(request, ctx, {
-    subscriptionId: routeParam(request, `subscriptionId`),
-    action: `streams`,
-  })
+  ctx: TenantContext,
+  subscriptionId: string,
+  routingAdapter: DurableStreamsRoutingAdapter
+): Promise<
+  | {
+      ok: true
+      body: Uint8Array
+      targetWebhookUrl: string | null
+    }
+  | { ok: false; response: Response }
+> {
+  const body = await readRequestBody(request as Request)
+  if (body.length === 0) {
+    return { ok: true, body, targetWebhookUrl: null }
+  }
+
+  const validation = validateBody(subscriptionProxyBodySchema, body)
+  if (!validation.ok) return { ok: false, response: validation.response }
+
+  const payload = validation.value as SubscriptionProxyBody
+  let targetWebhookUrl: string | null = null
+  if (payload.webhook?.url !== undefined) {
+    targetWebhookUrl = rewriteLoopbackWebhookUrl(payload.webhook.url) ?? null
+    payload.webhook.url = appendPathToUrl(
+      ctx.publicUrl,
+      `/_electric/webhook-forward/${encodeURIComponent(subscriptionId)}`
+    )
+  }
+
+  rewriteSubscriptionBodyForBackend(
+    payload as Record<string, unknown>,
+    ctx.service,
+    routingAdapter
+  )
+
+  return {
+    ok: true,
+    body: new TextEncoder().encode(JSON.stringify(payload)),
+    targetWebhookUrl,
+  }
 }
 
-function subscriptionStream(
+async function forwardSubscriptionRequest(
   request: IRequest,
-  ctx: TenantContext
-): Promise<Response> {
-  return subscriptionProxy(request, ctx, {
-    subscriptionId: routeParam(request, `subscriptionId`),
-    action: `stream`,
-    streamPath: routeParam(request, `streamPath`),
-  })
-}
-
-function subscriptionAction(action: SubscriptionProxyAction) {
-  return (request: IRequest, ctx: TenantContext): Promise<Response> =>
-    subscriptionProxy(request, ctx, {
-      subscriptionId: routeParam(request, `subscriptionId`),
-      action,
-    })
-}
-
-async function controlPassThrough(
-  request: IRequest,
-  ctx: TenantContext
-): Promise<Response> {
+  ctx: TenantContext,
+  routingAdapter: DurableStreamsRoutingAdapter,
+  opts: {
+    body?: Uint8Array
+    requestUrl?: string
+    bearerMode?: `overwrite` | `if-missing`
+  } = {}
+): Promise<{ upstream: Response; response: Response }> {
   const upstream = await forwardToDurableStreams(
     ctx,
     request,
-    undefined,
-    `control`
+    opts.body,
+    `control`,
+    opts.requestUrl,
+    opts.bearerMode ?? `overwrite`
   )
-  return responseFromUpstream(upstream)
+  let responseBytes: Uint8Array = upstream.body
+    ? new Uint8Array(await upstream.arrayBuffer())
+    : new Uint8Array()
+  responseBytes = rewriteSubscriptionResponseForClient(
+    responseBytes,
+    upstream,
+    ctx.service,
+    routingAdapter
+  )
+  return {
+    upstream,
+    response: responseFromUpstream(upstream, responseBytes),
+  }
+}
+
+async function upsertSubscriptionWebhook(
+  ctx: TenantContext,
+  subscriptionId: string,
+  targetWebhookUrl: string
+): Promise<void> {
+  await ctx.pgDb
+    .insert(subscriptionWebhooks)
+    .values({
+      tenantId: ctx.service,
+      subscriptionId,
+      webhookUrl: targetWebhookUrl,
+    })
+    .onConflictDoUpdate({
+      target: [
+        subscriptionWebhooks.tenantId,
+        subscriptionWebhooks.subscriptionId,
+      ],
+      set: { webhookUrl: targetWebhookUrl },
+    })
+}
+
+async function deleteSubscriptionWebhook(
+  ctx: TenantContext,
+  subscriptionId: string
+): Promise<void> {
+  await ctx.pgDb
+    .delete(subscriptionWebhooks)
+    .where(
+      and(
+        eq(subscriptionWebhooks.tenantId, ctx.service),
+        eq(subscriptionWebhooks.subscriptionId, subscriptionId)
+      )
+    )
 }
 
 function rewriteSubscriptionStreamPathInUrl(
@@ -341,108 +397,137 @@ function rewriteSubscriptionStreamPathInUrl(
   return requestUrl.toString()
 }
 
-async function subscriptionProxy(
+async function putSubscriptionBase(
   request: IRequest,
-  ctx: TenantContext,
-  route: SubscriptionProxyRoute
+  ctx: TenantContext
 ): Promise<Response> {
-  const url = new URL(request.url)
-  const { subscriptionId } = route
-
-  const routingAdapter = resolveDurableStreamsRoutingAdapter(
-    ctx.durableStreamsRouting,
-    ctx.durableStreamsUrl
+  const subscriptionId = routeParam(request, `subscriptionId`)
+  const routingAdapter = subscriptionRoutingAdapter(ctx)
+  const rewrite = await rewriteSubscriptionRequestBody(
+    request,
+    ctx,
+    subscriptionId,
+    routingAdapter
   )
-  let requestBody: Uint8Array | undefined
-  let targetWebhookUrl: string | null = null
-  let requestUrl = request.url
+  if (!rewrite.ok) return rewrite.response
 
-  if ([`PUT`, `POST`].includes(request.method.toUpperCase())) {
-    requestBody = await readRequestBody(request as Request)
-    if (requestBody.length > 0) {
-      const validation = validateBody(subscriptionProxyBodySchema, requestBody)
-      if (!validation.ok) return validation.response
-      const payload = validation.value as SubscriptionProxyBody
-      if (payload.webhook?.url !== undefined) {
-        targetWebhookUrl =
-          rewriteLoopbackWebhookUrl(payload.webhook.url) ?? null
-        payload.webhook.url = appendPathToUrl(
-          ctx.publicUrl,
-          `/_electric/webhook-forward/${encodeURIComponent(subscriptionId)}`
-        )
-      }
-      rewriteSubscriptionBodyForBackend(
-        payload as Record<string, unknown>,
-        ctx.service,
-        routingAdapter
-      )
-      requestBody = new TextEncoder().encode(JSON.stringify(payload))
-    }
-  }
-
-  if (request.method.toUpperCase() === `DELETE` && route.action === `stream`) {
-    requestUrl = rewriteSubscriptionStreamPathInUrl(
-      url,
-      ctx.service,
-      routingAdapter,
-      route.streamPath ?? ``
+  const { upstream, response } = await forwardSubscriptionRequest(
+    request,
+    ctx,
+    routingAdapter,
+    { body: rewrite.body }
+  )
+  if (upstream.ok && rewrite.targetWebhookUrl) {
+    await upsertSubscriptionWebhook(
+      ctx,
+      subscriptionId,
+      rewrite.targetWebhookUrl
     )
   }
+  return response
+}
 
-  const durableStreamsBearerMode =
-    route.action === `ack` ||
-    route.action === `release` ||
-    route.action === `callback`
-      ? `if-missing`
-      : `overwrite`
+async function getSubscriptionBase(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  const routingAdapter = subscriptionRoutingAdapter(ctx)
+  return (await forwardSubscriptionRequest(request, ctx, routingAdapter))
+    .response
+}
+
+async function deleteSubscriptionBase(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  const subscriptionId = routeParam(request, `subscriptionId`)
+  const routingAdapter = subscriptionRoutingAdapter(ctx)
+  const { upstream, response } = await forwardSubscriptionRequest(
+    request,
+    ctx,
+    routingAdapter
+  )
+  if (upstream.ok) {
+    await deleteSubscriptionWebhook(ctx, subscriptionId)
+  }
+  return response
+}
+
+async function postSubscriptionStreams(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  const subscriptionId = routeParam(request, `subscriptionId`)
+  const routingAdapter = subscriptionRoutingAdapter(ctx)
+  const rewrite = await rewriteSubscriptionRequestBody(
+    request,
+    ctx,
+    subscriptionId,
+    routingAdapter
+  )
+  if (!rewrite.ok) return rewrite.response
+
+  return (
+    await forwardSubscriptionRequest(request, ctx, routingAdapter, {
+      body: rewrite.body,
+    })
+  ).response
+}
+
+async function deleteSubscriptionStream(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  const routingAdapter = subscriptionRoutingAdapter(ctx)
+  const requestUrl = rewriteSubscriptionStreamPathInUrl(
+    new URL(request.url),
+    ctx.service,
+    routingAdapter,
+    routeParam(request, `streamPath`)
+  )
+  return (
+    await forwardSubscriptionRequest(request, ctx, routingAdapter, {
+      requestUrl,
+    })
+  ).response
+}
+
+function subscriptionAction(action: SubscriptionControlAction) {
+  return async (request: IRequest, ctx: TenantContext): Promise<Response> => {
+    const subscriptionId = routeParam(request, `subscriptionId`)
+    const routingAdapter = subscriptionRoutingAdapter(ctx)
+    const rewrite = await rewriteSubscriptionRequestBody(
+      request,
+      ctx,
+      subscriptionId,
+      routingAdapter
+    )
+    if (!rewrite.ok) return rewrite.response
+
+    const bearerMode =
+      action === `ack` || action === `release` || action === `callback`
+        ? `if-missing`
+        : `overwrite`
+    return (
+      await forwardSubscriptionRequest(request, ctx, routingAdapter, {
+        body: rewrite.body,
+        bearerMode,
+      })
+    ).response
+  }
+}
+
+async function controlPassThrough(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
   const upstream = await forwardToDurableStreams(
     ctx,
     request,
-    requestBody,
-    `control`,
-    requestUrl,
-    durableStreamsBearerMode
+    undefined,
+    `control`
   )
-  let responseBytes: Uint8Array = upstream.body
-    ? new Uint8Array(await upstream.arrayBuffer())
-    : new Uint8Array()
-  responseBytes = rewriteSubscriptionResponseForClient(
-    responseBytes,
-    upstream,
-    ctx.service,
-    routingAdapter
-  )
-  const response = responseFromUpstream(upstream, responseBytes)
-
-  if (!upstream.ok) return response
-
-  if (request.method.toUpperCase() === `DELETE` && route.action === `base`) {
-    await ctx.pgDb
-      .delete(subscriptionWebhooks)
-      .where(
-        and(
-          eq(subscriptionWebhooks.tenantId, ctx.service),
-          eq(subscriptionWebhooks.subscriptionId, subscriptionId)
-        )
-      )
-  } else if (targetWebhookUrl) {
-    await ctx.pgDb
-      .insert(subscriptionWebhooks)
-      .values({
-        tenantId: ctx.service,
-        subscriptionId,
-        webhookUrl: targetWebhookUrl,
-      })
-      .onConflictDoUpdate({
-        target: [
-          subscriptionWebhooks.tenantId,
-          subscriptionWebhooks.subscriptionId,
-        ],
-        set: { webhookUrl: targetWebhookUrl },
-      })
-  }
-
-  return response
+  return responseFromUpstream(upstream)
 }
 
 async function streamAppend(

--- a/packages/agents-server/src/routing/durable-streams-router.ts
+++ b/packages/agents-server/src/routing/durable-streams-router.ts
@@ -122,6 +122,8 @@ interface SubscriptionProxyRoute {
   streamPath?: string
 }
 
+const subscriptionControlActions = [`callback`, `claim`, `ack`, `release`]
+
 function isReservedControlPath(pathname: string): boolean {
   return durableStreamsControlPath(pathname) !== null
 }
@@ -129,35 +131,27 @@ function isReservedControlPath(pathname: string): boolean {
 function subscriptionRouteFromPath(
   pathname: string
 ): SubscriptionProxyRoute | null {
-  const routePath = durableStreamsControlPath(pathname)
-  if (!routePath) return null
-
-  const segments = routePath.split(`/`).filter(Boolean)
-  if (segments[0] !== `__ds` || segments[1] !== `subscriptions`) return null
-
-  const subscriptionId = segments[2] ? decodeURIComponent(segments[2]) : ``
-  if (!subscriptionId) return null
-
-  const tail = segments.slice(3)
-  if (tail.length === 0) return { subscriptionId, action: `base` }
-  if (tail[0] === `streams` && tail.length === 1) {
-    return { subscriptionId, action: `streams` }
+  const [prefix, resource, encodedId, action, ...tail] = pathname
+    .split(`/`)
+    .filter(Boolean)
+  if (prefix !== `__ds` || resource !== `subscriptions` || !encodedId) {
+    return null
   }
-  if (tail[0] === `streams` && tail.length > 1) {
+
+  const subscriptionId = decodeURIComponent(encodedId)
+  if (!action) return { subscriptionId, action: `base` }
+
+  if (action === `streams`) {
+    if (tail.length === 0) return { subscriptionId, action: `streams` }
     return {
       subscriptionId,
       action: `stream`,
-      streamPath: decodeURIComponent(tail.slice(1).join(`/`)),
+      streamPath: decodeURIComponent(tail.join(`/`)),
     }
   }
-  if (
-    tail.length === 1 &&
-    [`callback`, `claim`, `ack`, `release`].includes(tail[0]!)
-  ) {
-    return {
-      subscriptionId,
-      action: tail[0] as SubscriptionProxyAction,
-    }
+
+  if (tail.length === 0 && subscriptionControlActions.includes(action)) {
+    return { subscriptionId, action: action as SubscriptionProxyAction }
   }
 
   return null

--- a/packages/agents-server/src/routing/durable-streams-router.ts
+++ b/packages/agents-server/src/routing/durable-streams-router.ts
@@ -16,7 +16,6 @@ import { validateBody } from './schema.js'
 import { rewriteLoopbackWebhookUrl } from '../utils/webhook-url.js'
 import { forwardFetchRequest } from '../utils/server-utils.js'
 import { resolveDurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
-import { durableStreamsControlPath } from './durable-streams-control-path.js'
 import type { IRequest, RouterType } from 'itty-router'
 import type { TenantContext } from './context.js'
 import type { DurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
@@ -37,6 +36,13 @@ const subscriptionProxyBodySchema = Type.Object(
 
 type SubscriptionProxyBody = Static<typeof subscriptionProxyBodySchema>
 
+const subscriptionControlActions = [
+  `callback`,
+  `claim`,
+  `ack`,
+  `release`,
+] as const
+
 export type DurableStreamsRoutes = RouterType<
   IRequest,
   [TenantContext],
@@ -49,7 +55,34 @@ export const durableStreamsRouter: DurableStreamsRoutes = Router<
   Response | undefined
 >()
 
-durableStreamsRouter.all(`*`, subscriptionProxy)
+durableStreamsRouter.put(
+  `/__ds/subscriptions/:subscriptionId`,
+  subscriptionBase
+)
+durableStreamsRouter.get(
+  `/__ds/subscriptions/:subscriptionId`,
+  subscriptionBase
+)
+durableStreamsRouter.delete(
+  `/__ds/subscriptions/:subscriptionId`,
+  subscriptionBase
+)
+durableStreamsRouter.post(
+  `/__ds/subscriptions/:subscriptionId/streams`,
+  subscriptionStreams
+)
+durableStreamsRouter.delete(
+  `/__ds/subscriptions/:subscriptionId/streams/:streamPath+`,
+  subscriptionStream
+)
+for (const action of subscriptionControlActions) {
+  durableStreamsRouter.post(
+    `/__ds/subscriptions/:subscriptionId/${action}`,
+    subscriptionAction(action)
+  )
+}
+durableStreamsRouter.all(`/__ds`, controlPassThrough)
+durableStreamsRouter.all(`/__ds/*`, controlPassThrough)
 durableStreamsRouter.post(`*`, streamAppend)
 durableStreamsRouter.all(`*`, proxyPassThrough)
 
@@ -73,7 +106,8 @@ async function forwardToDurableStreams(
   request: IRequest,
   body?: Uint8Array,
   route: `stream` | `control` = `stream`,
-  urlOverride?: string
+  urlOverride?: string,
+  durableStreamsBearerMode: `overwrite` | `if-missing` = `overwrite`
 ): Promise<Response> {
   const headers = new Headers(request.headers)
   headers.delete(`host`)
@@ -95,11 +129,7 @@ async function forwardToDurableStreams(
     body: requestBody,
     durableStreamsUrl: ctx.durableStreamsUrl,
     durableStreamsBearer: ctx.durableStreamsBearer,
-    durableStreamsBearerMode: usesSubscriptionScopedBearer(
-      urlOverride ?? request.url
-    )
-      ? `if-missing`
-      : `overwrite`,
+    durableStreamsBearerMode,
     durableStreamsRouting: ctx.durableStreamsRouting,
     serviceId: ctx.service,
     dispatcher: ctx.durableStreamsDispatcher,
@@ -120,51 +150,6 @@ interface SubscriptionProxyRoute {
   subscriptionId: string
   action: SubscriptionProxyAction
   streamPath?: string
-}
-
-const subscriptionControlActions = [`callback`, `claim`, `ack`, `release`]
-
-function isReservedControlPath(pathname: string): boolean {
-  return durableStreamsControlPath(pathname) !== null
-}
-
-function subscriptionRouteFromPath(
-  pathname: string
-): SubscriptionProxyRoute | null {
-  const [prefix, resource, encodedId, action, ...tail] = pathname
-    .split(`/`)
-    .filter(Boolean)
-  if (prefix !== `__ds` || resource !== `subscriptions` || !encodedId) {
-    return null
-  }
-
-  const subscriptionId = decodeURIComponent(encodedId)
-  if (!action) return { subscriptionId, action: `base` }
-
-  if (action === `streams`) {
-    if (tail.length === 0) return { subscriptionId, action: `streams` }
-    return {
-      subscriptionId,
-      action: `stream`,
-      streamPath: decodeURIComponent(tail.join(`/`)),
-    }
-  }
-
-  if (tail.length === 0 && subscriptionControlActions.includes(action)) {
-    return { subscriptionId, action: action as SubscriptionProxyAction }
-  }
-
-  return null
-}
-
-function isSubscriptionBasePath(pathname: string): boolean {
-  return subscriptionRouteFromPath(pathname)?.action === `base`
-}
-
-function usesSubscriptionScopedBearer(requestUrl: string): boolean {
-  const pathname = new URL(requestUrl, `http://localhost`).pathname
-  const action = subscriptionRouteFromPath(pathname)?.action
-  return action === `ack` || action === `release` || action === `callback`
 }
 
 function rewriteSubscriptionBodyForBackend(
@@ -282,42 +267,86 @@ function decodeJson(bytes: Uint8Array): Record<string, unknown> | null {
   }
 }
 
+function routeParam(request: IRequest, name: string): string {
+  const value = request.params[name]
+  const raw = Array.isArray(value) ? value[0] : value
+  return decodeURIComponent(raw ?? ``)
+}
+
+function subscriptionBase(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  return subscriptionProxy(request, ctx, {
+    subscriptionId: routeParam(request, `subscriptionId`),
+    action: `base`,
+  })
+}
+
+function subscriptionStreams(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  return subscriptionProxy(request, ctx, {
+    subscriptionId: routeParam(request, `subscriptionId`),
+    action: `streams`,
+  })
+}
+
+function subscriptionStream(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  return subscriptionProxy(request, ctx, {
+    subscriptionId: routeParam(request, `subscriptionId`),
+    action: `stream`,
+    streamPath: routeParam(request, `streamPath`),
+  })
+}
+
+function subscriptionAction(action: SubscriptionProxyAction) {
+  return (request: IRequest, ctx: TenantContext): Promise<Response> =>
+    subscriptionProxy(request, ctx, {
+      subscriptionId: routeParam(request, `subscriptionId`),
+      action,
+    })
+}
+
+async function controlPassThrough(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  const upstream = await forwardToDurableStreams(
+    ctx,
+    request,
+    undefined,
+    `control`
+  )
+  return responseFromUpstream(upstream)
+}
+
 function rewriteSubscriptionStreamPathInUrl(
   requestUrl: URL,
   service: string,
-  routingAdapter: DurableStreamsRoutingAdapter
+  routingAdapter: DurableStreamsRoutingAdapter,
+  streamPath: string
 ): string {
-  const route = subscriptionRouteFromPath(requestUrl.pathname)
-  if (route?.action !== `stream` || !route.streamPath) {
-    return requestUrl.toString()
-  }
-
   const prefix = requestUrl.pathname.slice(
     0,
     requestUrl.pathname.indexOf(`/streams/`) + `/streams/`.length
   )
   requestUrl.pathname = `${prefix}${encodeURIComponent(
-    routingAdapter.toBackendStreamPath(service, route.streamPath)
+    routingAdapter.toBackendStreamPath(service, streamPath)
   )}`
   return requestUrl.toString()
 }
 
 async function subscriptionProxy(
   request: IRequest,
-  ctx: TenantContext
-): Promise<Response | undefined> {
+  ctx: TenantContext,
+  route: SubscriptionProxyRoute
+): Promise<Response> {
   const url = new URL(request.url)
-  if (!isReservedControlPath(url.pathname)) return undefined
-  const route = subscriptionRouteFromPath(url.pathname)
-  if (!route) {
-    const upstream = await forwardToDurableStreams(
-      ctx,
-      request,
-      undefined,
-      `control`
-    )
-    return responseFromUpstream(upstream)
-  }
   const { subscriptionId } = route
 
   const routingAdapter = resolveDurableStreamsRoutingAdapter(
@@ -355,16 +384,24 @@ async function subscriptionProxy(
     requestUrl = rewriteSubscriptionStreamPathInUrl(
       url,
       ctx.service,
-      routingAdapter
+      routingAdapter,
+      route.streamPath ?? ``
     )
   }
 
+  const durableStreamsBearerMode =
+    route.action === `ack` ||
+    route.action === `release` ||
+    route.action === `callback`
+      ? `if-missing`
+      : `overwrite`
   const upstream = await forwardToDurableStreams(
     ctx,
     request,
     requestBody,
     `control`,
-    requestUrl
+    requestUrl,
+    durableStreamsBearerMode
   )
   let responseBytes: Uint8Array = upstream.body
     ? new Uint8Array(await upstream.arrayBuffer())
@@ -379,10 +416,7 @@ async function subscriptionProxy(
 
   if (!upstream.ok) return response
 
-  if (
-    request.method.toUpperCase() === `DELETE` &&
-    isSubscriptionBasePath(url.pathname)
-  ) {
+  if (request.method.toUpperCase() === `DELETE` && route.action === `base`) {
     await ctx.pgDb
       .delete(subscriptionWebhooks)
       .where(
@@ -443,13 +477,12 @@ async function proxyPassThrough(
   const upstream = await forwardToDurableStreams(ctx, request)
   const streamPath = new URL(request.url).pathname
   const method = request.method.toUpperCase()
-  const isControlPath = isReservedControlPath(streamPath)
   const endTrackedRead =
-    method === `GET` && !isControlPath
+    method === `GET`
       ? await ctx.entityBridgeManager.beginClientRead(streamPath)
       : null
   try {
-    if (method === `HEAD` && !isControlPath) {
+    if (method === `HEAD`) {
       await ctx.entityBridgeManager.touchByStreamPath(streamPath)
     }
     return responseFromUpstream(upstream)

--- a/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
+++ b/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
@@ -2,6 +2,7 @@ import {
   prefixTenantStreamPath,
   stripTenantStreamPrefix,
 } from './tenant-stream-paths.js'
+import { durableStreamsControlPath } from './durable-streams-control-path.js'
 
 export interface DurableStreamsRoutingInput {
   durableStreamsUrl: string
@@ -30,46 +31,14 @@ function withoutTrailingSlash(pathname: string): string {
   return pathname.replace(/\/+$/, ``) || `/`
 }
 
-function splitControlPath(pathname: string): string | null {
-  const segments = pathname.split(`/`).filter(Boolean)
-  const controlIndex =
-    segments[0] === `__ds`
-      ? 0
-      : segments[0] === `v1` &&
-          segments[1] === `stream` &&
-          segments[2] === `__ds`
-        ? 2
-        : segments[0] === `v1` &&
-            segments[1] === `streams` &&
-            segments[3] === `__ds`
-          ? 3
-          : -1
-  if (controlIndex < 0) return null
-  return `/${segments.slice(controlIndex).join(`/`)}`
-}
-
-function logicalStreamPathFromRequest(
-  requestUrl: string,
-  serviceId: string
-): { incomingUrl: URL; streamPath: string } {
+function logicalStreamPathFromRequest(requestUrl: string): {
+  incomingUrl: URL
+  streamPath: string
+} {
   const incomingUrl = new URL(requestUrl, `http://localhost`)
-  const segments = incomingUrl.pathname.split(`/`).filter(Boolean)
-  if (segments[0] === `v1` && segments[1] === `stream`) {
-    return {
-      incomingUrl,
-      streamPath: segments.length > 2 ? `/${segments.slice(3).join(`/`)}` : `/`,
-    }
-  }
-  if (segments[0] === `v1` && segments[1] === `streams`) {
-    return {
-      incomingUrl,
-      streamPath: segments.length > 2 ? `/${segments.slice(3).join(`/`)}` : `/`,
-    }
-  }
-
   return {
     incomingUrl,
-    streamPath: incomingUrl.pathname || `/${serviceId}`,
+    streamPath: incomingUrl.pathname,
   }
 }
 
@@ -92,7 +61,7 @@ function backendStreamUrl(rootUrl: URL, backendStreamPath: string): URL {
 
 function pathPrefixedControlUrl(input: DurableStreamsRoutingInput): URL {
   const incomingUrl = new URL(input.requestUrl, `http://localhost`)
-  const controlPath = splitControlPath(incomingUrl.pathname)
+  const controlPath = durableStreamsControlPath(incomingUrl.pathname)
   if (!controlPath)
     return removeServiceQuery(appendSearch(incomingUrl, incomingUrl))
   const root = pathPrefixedStreamRootUrl(input)
@@ -133,7 +102,7 @@ function tenantRootBackendUrl(rootUrl: URL, streamPath: string): URL {
 
 function tenantRootControlUrl(input: DurableStreamsRoutingInput): URL {
   const incomingUrl = new URL(input.requestUrl, `http://localhost`)
-  const controlPath = splitControlPath(incomingUrl.pathname)
+  const controlPath = durableStreamsControlPath(incomingUrl.pathname)
   if (!controlPath)
     return removeServiceQuery(appendSearch(incomingUrl, incomingUrl))
   const root = tenantRootStreamRootUrl(input)
@@ -145,8 +114,7 @@ export const pathPrefixedSingleTenantDurableStreamsRoutingAdapter: DurableStream
   {
     streamUrl(input) {
       const { incomingUrl, streamPath } = logicalStreamPathFromRequest(
-        input.requestUrl,
-        input.serviceId
+        input.requestUrl
       )
       const target = backendStreamUrl(
         pathPrefixedStreamRootUrl(input),
@@ -170,8 +138,7 @@ export const tenantRootDurableStreamsRoutingAdapter: DurableStreamsRoutingAdapte
   {
     streamUrl(input) {
       const { incomingUrl, streamPath } = logicalStreamPathFromRequest(
-        input.requestUrl,
-        input.serviceId
+        input.requestUrl
       )
       const target = tenantRootBackendUrl(
         tenantRootStreamRootUrl(input),

--- a/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
+++ b/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
@@ -11,7 +11,7 @@ export interface DurableStreamsRoutingInput {
 
 export interface DurableStreamsRoutingAdapter {
   streamUrl(input: DurableStreamsRoutingInput): URL
-  streamMetaUrl(input: DurableStreamsRoutingInput): URL
+  controlUrl(input: DurableStreamsRoutingInput): URL
   toBackendStreamPath(serviceId: string, streamPath: string): string
   toRuntimeStreamPath(serviceId: string, streamPath: string): string
 }
@@ -26,6 +26,28 @@ function removeServiceQuery(target: URL): URL {
   return target
 }
 
+function withoutTrailingSlash(pathname: string): string {
+  return pathname.replace(/\/+$/, ``) || `/`
+}
+
+function splitControlPath(pathname: string): string | null {
+  const segments = pathname.split(`/`).filter(Boolean)
+  const controlIndex =
+    segments[0] === `__ds`
+      ? 0
+      : segments[0] === `v1` &&
+          segments[1] === `stream` &&
+          segments[2] === `__ds`
+        ? 2
+        : segments[0] === `v1` &&
+            segments[1] === `streams` &&
+            segments[3] === `__ds`
+          ? 3
+          : -1
+  if (controlIndex < 0) return null
+  return `/${segments.slice(controlIndex).join(`/`)}`
+}
+
 function logicalStreamPathFromRequest(
   requestUrl: string,
   serviceId: string
@@ -38,6 +60,12 @@ function logicalStreamPathFromRequest(
       streamPath: segments.length > 2 ? `/${segments.slice(3).join(`/`)}` : `/`,
     }
   }
+  if (segments[0] === `v1` && segments[1] === `streams`) {
+    return {
+      incomingUrl,
+      streamPath: segments.length > 2 ? `/${segments.slice(3).join(`/`)}` : `/`,
+    }
+  }
 
   return {
     incomingUrl,
@@ -45,23 +73,72 @@ function logicalStreamPathFromRequest(
   }
 }
 
-function backendStreamUrl(
-  input: DurableStreamsRoutingInput,
-  backendStreamPath: string
-): URL {
+function pathPrefixedStreamRootUrl(input: DurableStreamsRoutingInput): URL {
+  const base = new URL(input.durableStreamsUrl)
+  const match = /^(.*)\/v1\/stream(?:\/[^/]+)?\/?$/.exec(base.pathname)
+  const prefix = match?.[1] || ``
+  base.pathname = `${prefix}/v1/stream`
+  base.search = ``
+  base.hash = ``
+  return base
+}
+
+function backendStreamUrl(rootUrl: URL, backendStreamPath: string): URL {
   const path = backendStreamPath.replace(/^\/+/, ``)
-  const target = new URL(`/v1/stream/${path}`, input.durableStreamsUrl)
+  const target = new URL(rootUrl)
+  target.pathname = `${withoutTrailingSlash(rootUrl.pathname)}/${path}`
   return target
 }
 
-function streamMetaUrlWithoutService(input: DurableStreamsRoutingInput): URL {
+function pathPrefixedControlUrl(input: DurableStreamsRoutingInput): URL {
   const incomingUrl = new URL(input.requestUrl, `http://localhost`)
-  return removeServiceQuery(
-    appendSearch(
-      new URL(incomingUrl.pathname, input.durableStreamsUrl),
-      incomingUrl
-    )
-  )
+  const controlPath = splitControlPath(incomingUrl.pathname)
+  if (!controlPath)
+    return removeServiceQuery(appendSearch(incomingUrl, incomingUrl))
+  const root = pathPrefixedStreamRootUrl(input)
+  root.pathname = `${withoutTrailingSlash(root.pathname)}${controlPath}`
+  return removeServiceQuery(appendSearch(root, incomingUrl))
+}
+
+function isElectricCloudUrl(url: URL): boolean {
+  return url.hostname === `api.electric-sql.cloud`
+}
+
+function tenantRootStreamRootUrl(input: DurableStreamsRoutingInput): URL {
+  const base = new URL(input.durableStreamsUrl)
+  const path = withoutTrailingSlash(base.pathname)
+  const encodedServiceId = encodeURIComponent(input.serviceId)
+  if (/\/v1\/streams\/[^/]+$/.test(path)) {
+    base.pathname = path
+  } else if (path.endsWith(`/v1/streams`)) {
+    base.pathname = `${path}/${encodedServiceId}`
+  } else if (isElectricCloudUrl(base)) {
+    base.pathname = `/v1/streams/${encodedServiceId}`
+  } else {
+    base.pathname = `${path === `/` ? `` : path}/v1/streams/${encodedServiceId}`
+  }
+  base.search = ``
+  base.hash = ``
+  return base
+}
+
+function tenantRootBackendUrl(rootUrl: URL, streamPath: string): URL {
+  const normalized = streamPath.replace(/^\/+/, ``)
+  const target = new URL(rootUrl)
+  target.pathname = normalized
+    ? `${withoutTrailingSlash(rootUrl.pathname)}/${normalized}`
+    : withoutTrailingSlash(rootUrl.pathname)
+  return target
+}
+
+function tenantRootControlUrl(input: DurableStreamsRoutingInput): URL {
+  const incomingUrl = new URL(input.requestUrl, `http://localhost`)
+  const controlPath = splitControlPath(incomingUrl.pathname)
+  if (!controlPath)
+    return removeServiceQuery(appendSearch(incomingUrl, incomingUrl))
+  const root = tenantRootStreamRootUrl(input)
+  root.pathname = `${withoutTrailingSlash(root.pathname)}${controlPath}`
+  return removeServiceQuery(appendSearch(root, incomingUrl))
 }
 
 export const pathPrefixedSingleTenantDurableStreamsRoutingAdapter: DurableStreamsRoutingAdapter =
@@ -72,13 +149,13 @@ export const pathPrefixedSingleTenantDurableStreamsRoutingAdapter: DurableStream
         input.serviceId
       )
       const target = backendStreamUrl(
-        input,
+        pathPrefixedStreamRootUrl(input),
         prefixTenantStreamPath(streamPath, input.serviceId)
       )
       return removeServiceQuery(appendSearch(target, incomingUrl))
     },
 
-    streamMetaUrl: streamMetaUrlWithoutService,
+    controlUrl: pathPrefixedControlUrl,
 
     toBackendStreamPath(serviceId, streamPath) {
       return prefixTenantStreamPath(streamPath, serviceId)
@@ -89,8 +166,41 @@ export const pathPrefixedSingleTenantDurableStreamsRoutingAdapter: DurableStream
     },
   }
 
+export const tenantRootDurableStreamsRoutingAdapter: DurableStreamsRoutingAdapter =
+  {
+    streamUrl(input) {
+      const { incomingUrl, streamPath } = logicalStreamPathFromRequest(
+        input.requestUrl,
+        input.serviceId
+      )
+      const target = tenantRootBackendUrl(
+        tenantRootStreamRootUrl(input),
+        streamPath
+      )
+      return removeServiceQuery(appendSearch(target, incomingUrl))
+    },
+
+    controlUrl: tenantRootControlUrl,
+
+    toBackendStreamPath(_serviceId, streamPath) {
+      return streamPath.replace(/^\/+/, ``)
+    },
+
+    toRuntimeStreamPath(_serviceId, streamPath) {
+      return streamPath.replace(/^\/+/, ``)
+    },
+  }
+
 export function resolveDurableStreamsRoutingAdapter(
-  adapter?: DurableStreamsRoutingAdapter
+  adapter?: DurableStreamsRoutingAdapter,
+  durableStreamsUrl?: string
 ): DurableStreamsRoutingAdapter {
-  return adapter ?? pathPrefixedSingleTenantDurableStreamsRoutingAdapter
+  if (adapter) return adapter
+  if (durableStreamsUrl) {
+    const url = new URL(durableStreamsUrl)
+    if (/\/v1\/streams(?:\/|$)/.test(url.pathname) || isElectricCloudUrl(url)) {
+      return tenantRootDurableStreamsRoutingAdapter
+    }
+  }
+  return pathPrefixedSingleTenantDurableStreamsRoutingAdapter
 }

--- a/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
+++ b/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
@@ -1,9 +1,3 @@
-import {
-  prefixTenantStreamPath,
-  stripTenantStreamPrefix,
-} from './tenant-stream-paths.js'
-import { durableStreamsControlPath } from './durable-streams-control-path.js'
-
 export interface DurableStreamsRoutingInput {
   durableStreamsUrl: string
   serviceId: string
@@ -31,123 +25,21 @@ function withoutTrailingSlash(pathname: string): string {
   return pathname.replace(/\/+$/, ``) || `/`
 }
 
-function logicalStreamPathFromRequest(requestUrl: string): {
-  incomingUrl: URL
-  streamPath: string
-} {
-  const incomingUrl = new URL(requestUrl, `http://localhost`)
-  return {
-    incomingUrl,
-    streamPath: incomingUrl.pathname,
-  }
-}
-
-function pathPrefixedStreamRootUrl(input: DurableStreamsRoutingInput): URL {
-  const base = new URL(input.durableStreamsUrl)
-  const match = /^(.*)\/v1\/stream(?:\/[^/]+)?\/?$/.exec(base.pathname)
-  const prefix = match?.[1] || ``
-  base.pathname = `${prefix}/v1/stream`
-  base.search = ``
-  base.hash = ``
-  return base
-}
-
-function backendStreamUrl(rootUrl: URL, backendStreamPath: string): URL {
-  const path = backendStreamPath.replace(/^\/+/, ``)
-  const target = new URL(rootUrl)
-  target.pathname = `${withoutTrailingSlash(rootUrl.pathname)}/${path}`
-  return target
-}
-
-function pathPrefixedControlUrl(input: DurableStreamsRoutingInput): URL {
+function appendRequestPathToStreamRoot(input: DurableStreamsRoutingInput): URL {
   const incomingUrl = new URL(input.requestUrl, `http://localhost`)
-  const controlPath = durableStreamsControlPath(incomingUrl.pathname)
-  if (!controlPath)
-    return removeServiceQuery(appendSearch(incomingUrl, incomingUrl))
-  const root = pathPrefixedStreamRootUrl(input)
-  root.pathname = `${withoutTrailingSlash(root.pathname)}${controlPath}`
-  return removeServiceQuery(appendSearch(root, incomingUrl))
+  const path = incomingUrl.pathname.replace(/^\/+/, ``)
+  const target = new URL(input.durableStreamsUrl)
+  target.pathname = path
+    ? `${withoutTrailingSlash(target.pathname)}/${path}`
+    : withoutTrailingSlash(target.pathname)
+  return removeServiceQuery(appendSearch(target, incomingUrl))
 }
 
-function isElectricCloudUrl(url: URL): boolean {
-  return url.hostname === `api.electric-sql.cloud`
-}
-
-function tenantRootStreamRootUrl(input: DurableStreamsRoutingInput): URL {
-  const base = new URL(input.durableStreamsUrl)
-  const path = withoutTrailingSlash(base.pathname)
-  const encodedServiceId = encodeURIComponent(input.serviceId)
-  if (/\/v1\/streams\/[^/]+$/.test(path)) {
-    base.pathname = path
-  } else if (path.endsWith(`/v1/streams`)) {
-    base.pathname = `${path}/${encodedServiceId}`
-  } else if (isElectricCloudUrl(base)) {
-    base.pathname = `/v1/streams/${encodedServiceId}`
-  } else {
-    base.pathname = `${path === `/` ? `` : path}/v1/streams/${encodedServiceId}`
-  }
-  base.search = ``
-  base.hash = ``
-  return base
-}
-
-function tenantRootBackendUrl(rootUrl: URL, streamPath: string): URL {
-  const normalized = streamPath.replace(/^\/+/, ``)
-  const target = new URL(rootUrl)
-  target.pathname = normalized
-    ? `${withoutTrailingSlash(rootUrl.pathname)}/${normalized}`
-    : withoutTrailingSlash(rootUrl.pathname)
-  return target
-}
-
-function tenantRootControlUrl(input: DurableStreamsRoutingInput): URL {
-  const incomingUrl = new URL(input.requestUrl, `http://localhost`)
-  const controlPath = durableStreamsControlPath(incomingUrl.pathname)
-  if (!controlPath)
-    return removeServiceQuery(appendSearch(incomingUrl, incomingUrl))
-  const root = tenantRootStreamRootUrl(input)
-  root.pathname = `${withoutTrailingSlash(root.pathname)}${controlPath}`
-  return removeServiceQuery(appendSearch(root, incomingUrl))
-}
-
-export const pathPrefixedSingleTenantDurableStreamsRoutingAdapter: DurableStreamsRoutingAdapter =
+export const streamRootDurableStreamsRoutingAdapter: DurableStreamsRoutingAdapter =
   {
-    streamUrl(input) {
-      const { incomingUrl, streamPath } = logicalStreamPathFromRequest(
-        input.requestUrl
-      )
-      const target = backendStreamUrl(
-        pathPrefixedStreamRootUrl(input),
-        prefixTenantStreamPath(streamPath, input.serviceId)
-      )
-      return removeServiceQuery(appendSearch(target, incomingUrl))
-    },
+    streamUrl: appendRequestPathToStreamRoot,
 
-    controlUrl: pathPrefixedControlUrl,
-
-    toBackendStreamPath(serviceId, streamPath) {
-      return prefixTenantStreamPath(streamPath, serviceId)
-    },
-
-    toRuntimeStreamPath(serviceId, streamPath) {
-      return stripTenantStreamPrefix(streamPath, serviceId)
-    },
-  }
-
-export const tenantRootDurableStreamsRoutingAdapter: DurableStreamsRoutingAdapter =
-  {
-    streamUrl(input) {
-      const { incomingUrl, streamPath } = logicalStreamPathFromRequest(
-        input.requestUrl
-      )
-      const target = tenantRootBackendUrl(
-        tenantRootStreamRootUrl(input),
-        streamPath
-      )
-      return removeServiceQuery(appendSearch(target, incomingUrl))
-    },
-
-    controlUrl: tenantRootControlUrl,
+    controlUrl: appendRequestPathToStreamRoot,
 
     toBackendStreamPath(_serviceId, streamPath) {
       return streamPath.replace(/^\/+/, ``)
@@ -158,16 +50,15 @@ export const tenantRootDurableStreamsRoutingAdapter: DurableStreamsRoutingAdapte
     },
   }
 
+export const pathPrefixedSingleTenantDurableStreamsRoutingAdapter =
+  streamRootDurableStreamsRoutingAdapter
+
+export const tenantRootDurableStreamsRoutingAdapter =
+  streamRootDurableStreamsRoutingAdapter
+
 export function resolveDurableStreamsRoutingAdapter(
   adapter?: DurableStreamsRoutingAdapter,
-  durableStreamsUrl?: string
+  _durableStreamsUrl?: string
 ): DurableStreamsRoutingAdapter {
-  if (adapter) return adapter
-  if (durableStreamsUrl) {
-    const url = new URL(durableStreamsUrl)
-    if (/\/v1\/streams(?:\/|$)/.test(url.pathname) || isElectricCloudUrl(url)) {
-      return tenantRootDurableStreamsRoutingAdapter
-    }
-  }
-  return pathPrefixedSingleTenantDurableStreamsRoutingAdapter
+  return adapter ?? streamRootDurableStreamsRoutingAdapter
 }

--- a/packages/agents-server/src/routing/internal-router.ts
+++ b/packages/agents-server/src/routing/internal-router.ts
@@ -294,7 +294,8 @@ async function webhookForward(
   const parsedBody = parsedBodyResult.value as WebhookForwardBody | undefined
   const newWebhook = newWebhookPayload(parsedBody)
   const routingAdapter = resolveDurableStreamsRoutingAdapter(
-    ctx.durableStreamsRouting
+    ctx.durableStreamsRouting,
+    ctx.durableStreamsUrl
   )
 
   if (parsedBody) {
@@ -537,7 +538,10 @@ async function callbackForward(
     ctx.service,
     consumerId,
     requestBody,
-    resolveDurableStreamsRoutingAdapter(ctx.durableStreamsRouting)
+    resolveDurableStreamsRoutingAdapter(
+      ctx.durableStreamsRouting,
+      ctx.durableStreamsUrl
+    )
   )
 
   let upstream: Response

--- a/packages/agents-server/src/runtime.ts
+++ b/packages/agents-server/src/runtime.ts
@@ -64,7 +64,9 @@ export class ElectricAgentsTenantRuntime {
       this.streamClient = options.streamClient
     } else if (options.durableStreamsUrl) {
       this.streamClient = new StreamClient(
-        durableStreamsServiceUrl(options.durableStreamsUrl, this.serviceId),
+        durableStreamsServiceUrl(options.durableStreamsUrl, this.serviceId, {
+          scope: `stream-root`,
+        }),
         { bearer: options.durableStreamsBearer }
       )
     } else {

--- a/packages/agents-server/src/server.ts
+++ b/packages/agents-server/src/server.ts
@@ -7,7 +7,6 @@ import {
   createRuntimeHandler,
 } from '@electric-ax/agents-runtime'
 import { createDb, runMigrations } from './db/index.js'
-import { pathPrefixedSingleTenantDurableStreamsRoutingAdapter } from './routing/durable-streams-routing-adapter.js'
 import { ossServerRouter } from './routing/oss-server-router.js'
 import { startStandaloneAgentsRuntime } from './standalone-runtime.js'
 import { StreamClient, durableStreamsServiceUrl } from './stream-client.js'
@@ -403,9 +402,7 @@ export class ElectricAgentsServer {
       localUrl: this._url,
       durableStreamsUrl: this.options.durableStreamsUrl,
       durableStreamsBearer: this.options.durableStreamsBearer,
-      durableStreamsRouting:
-        this.options.durableStreamsRouting ??
-        pathPrefixedSingleTenantDurableStreamsRoutingAdapter,
+      durableStreamsRouting: this.options.durableStreamsRouting,
       durableStreamsDispatcher: this.streamsAgent,
       electricUrl: this.options.electricUrl,
       electricSecret: this.options.electricSecret,

--- a/packages/agents-server/src/server.ts
+++ b/packages/agents-server/src/server.ts
@@ -400,7 +400,7 @@ export class ElectricAgentsServer {
       principal,
       publicUrl: this.publicUrl,
       localUrl: this._url,
-      durableStreamsUrl: this.options.durableStreamsUrl,
+      durableStreamsUrl: this.streamClient.baseUrl,
       durableStreamsBearer: this.options.durableStreamsBearer,
       durableStreamsRouting: this.options.durableStreamsRouting,
       durableStreamsDispatcher: this.streamsAgent,

--- a/packages/agents-server/src/server.ts
+++ b/packages/agents-server/src/server.ts
@@ -144,7 +144,9 @@ export class ElectricAgentsServer {
     this.options = options
     this.streamClient = options.durableStreamsUrl
       ? new StreamClient(
-          durableStreamsServiceUrl(options.durableStreamsUrl, this.tenantId),
+          durableStreamsServiceUrl(options.durableStreamsUrl, this.tenantId, {
+            scope: `stream-root`,
+          }),
           { bearer: options.durableStreamsBearer }
         )
       : null!
@@ -185,7 +187,9 @@ export class ElectricAgentsServer {
         )
         this.options.durableStreamsUrl = streamsUrl
         this.streamClient = new StreamClient(
-          durableStreamsServiceUrl(streamsUrl, this.tenantId),
+          durableStreamsServiceUrl(streamsUrl, this.tenantId, {
+            scope: `stream-root`,
+          }),
           { bearer: this.options.durableStreamsBearer }
         )
       }

--- a/packages/agents-server/src/standalone-runtime.ts
+++ b/packages/agents-server/src/standalone-runtime.ts
@@ -58,7 +58,9 @@ export async function startStandaloneAgentsRuntime(
     options.streamClient ??
     (options.durableStreamsUrl
       ? new StreamClient(
-          durableStreamsServiceUrl(options.durableStreamsUrl, serviceId),
+          durableStreamsServiceUrl(options.durableStreamsUrl, serviceId, {
+            scope: `stream-root`,
+          }),
           { bearer: options.durableStreamsBearer }
         )
       : undefined)

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -14,6 +14,8 @@ export interface StreamClientOptions {
   bearer?: DurableStreamsBearerProvider
 }
 
+type DurableStreamsUrlScope = `service` | `stream-root`
+
 export interface StreamAppendResult {
   offset: string
 }
@@ -141,7 +143,8 @@ function durableStreamsBearerHeaders(
 
 export function durableStreamsServiceUrl(
   baseUrl: string,
-  serviceId: string
+  serviceId: string,
+  options: { scope?: DurableStreamsUrlScope } = {}
 ): string {
   const url = new URL(baseUrl)
   if (/\/v1\/streams\/[^/]+\/?$/.test(url.pathname)) {
@@ -150,12 +153,15 @@ export function durableStreamsServiceUrl(
   if (/\/v1\/stream\/[^/]+\/?$/.test(url.pathname)) {
     return baseUrl.replace(/\/+$/, ``)
   }
+  const scope = options.scope ?? `service`
   const encodedServiceId = encodeURIComponent(serviceId)
   const path = url.pathname.replace(/\/+$/, ``) || `/`
   if (path.endsWith(`/v1/streams`)) {
     url.pathname = `${path}/${encodedServiceId}`
   } else if (path.endsWith(`/v1/stream`)) {
-    url.pathname = `${path}/${encodedServiceId}`
+    url.pathname = scope === `service` ? `${path}/${encodedServiceId}` : path
+  } else if (scope === `stream-root`) {
+    url.pathname = `${path === `/` ? `` : path}/v1/stream`
   } else {
     url.pathname = `${path === `/` ? `` : path}/v1/stream/${encodedServiceId}`
   }

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -144,11 +144,24 @@ export function durableStreamsServiceUrl(
   serviceId: string
 ): string {
   const url = new URL(baseUrl)
-  if (/^\/v1\/stream\/[^/]+\/?$/.test(url.pathname)) {
+  if (/\/v1\/streams\/[^/]+\/?$/.test(url.pathname)) {
     return baseUrl.replace(/\/+$/, ``)
   }
-  const base = baseUrl.replace(/\/+$/, ``)
-  return `${base}/v1/stream/${encodeURIComponent(serviceId)}`
+  if (/\/v1\/stream\/[^/]+\/?$/.test(url.pathname)) {
+    return baseUrl.replace(/\/+$/, ``)
+  }
+  const encodedServiceId = encodeURIComponent(serviceId)
+  const path = url.pathname.replace(/\/+$/, ``) || `/`
+  if (path.endsWith(`/v1/streams`)) {
+    url.pathname = `${path}/${encodedServiceId}`
+  } else if (path.endsWith(`/v1/stream`)) {
+    url.pathname = `${path}/${encodedServiceId}`
+  } else if (url.hostname === `api.electric-sql.cloud`) {
+    url.pathname = `/v1/streams/${encodedServiceId}`
+  } else {
+    url.pathname = `${path === `/` ? `` : path}/v1/stream/${encodedServiceId}`
+  }
+  return url.toString().replace(/\/+$/, ``)
 }
 
 function isNotFoundError(err: unknown): boolean {
@@ -177,6 +190,12 @@ function normalizeSubscriptionPath(path: string): string {
   return path.replace(/^\/+/, ``).replace(/\/+$/, ``)
 }
 
+interface SubscriptionUrlInfo {
+  mode: `path-prefixed` | `tenant-root` | `plain`
+  serviceId: string | null
+  controlPath: string
+}
+
 export class StreamClient {
   constructor(
     readonly baseUrl: string,
@@ -202,16 +221,41 @@ export class StreamClient {
     return headers
   }
 
-  private subscriptionServiceId(): string | null {
+  private subscriptionUrlInfo(): SubscriptionUrlInfo {
     const url = new URL(this.baseUrl)
-    const match = /^(.*)\/v1\/stream\/([^/]+)\/?$/.exec(url.pathname)
-    return match ? decodeURIComponent(match[2]!) : null
+    const pathPrefixedMatch = /^(.*)\/v1\/stream\/([^/]+)\/?$/.exec(
+      url.pathname
+    )
+    if (pathPrefixedMatch) {
+      const [, prefix = ``, serviceId] = pathPrefixedMatch
+      return {
+        mode: `path-prefixed`,
+        serviceId: decodeURIComponent(serviceId!),
+        controlPath: `${prefix}/v1/stream/__ds`,
+      }
+    }
+
+    const tenantRootMatch = /^(.*)\/v1\/streams\/([^/]+)\/?$/.exec(url.pathname)
+    if (tenantRootMatch) {
+      const [, prefix = ``, serviceId] = tenantRootMatch
+      return {
+        mode: `tenant-root`,
+        serviceId: decodeURIComponent(serviceId!),
+        controlPath: `${prefix}/v1/streams/${serviceId}/__ds`,
+      }
+    }
+
+    return {
+      mode: `plain`,
+      serviceId: null,
+      controlPath: `${url.pathname.replace(/\/+$/, ``)}/__ds`,
+    }
   }
 
   private backendSubscriptionPath(path: string): string {
     const normalized = normalizeSubscriptionPath(path)
-    const serviceId = this.subscriptionServiceId()
-    if (!serviceId) return normalized
+    const { mode, serviceId } = this.subscriptionUrlInfo()
+    if (mode !== `path-prefixed` || !serviceId) return normalized
     if (normalized === serviceId || normalized.startsWith(`${serviceId}/`)) {
       return normalized
     }
@@ -220,8 +264,8 @@ export class StreamClient {
 
   private runtimeSubscriptionPath(path: string): string {
     const normalized = normalizeSubscriptionPath(path)
-    const serviceId = this.subscriptionServiceId()
-    if (!serviceId) return normalized
+    const { mode, serviceId } = this.subscriptionUrlInfo()
+    if (mode !== `path-prefixed` || !serviceId) return normalized
     return normalized.startsWith(`${serviceId}/`)
       ? normalized.slice(serviceId.length + 1)
       : normalized
@@ -229,15 +273,8 @@ export class StreamClient {
 
   private subscriptionUrl(subscriptionId: string): string {
     const url = new URL(this.baseUrl)
-    const match = /^(.*)\/v1\/stream\/([^/]+)\/?$/.exec(url.pathname)
-    if (match) {
-      const [, prefix = ``, serviceId] = match
-      url.pathname = `${prefix}/v1/stream-meta/subscriptions/${encodeURIComponent(subscriptionId)}`
-      url.searchParams.set(`service`, decodeURIComponent(serviceId!))
-      return url.toString()
-    }
-
-    url.pathname = `${url.pathname.replace(/\/+$/, ``)}/v1/stream-meta/subscriptions/${encodeURIComponent(subscriptionId)}`
+    const { controlPath } = this.subscriptionUrlInfo()
+    url.pathname = `${controlPath.replace(/\/+$/, ``)}/subscriptions/${encodeURIComponent(subscriptionId)}`
     return url.toString()
   }
 

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -156,8 +156,6 @@ export function durableStreamsServiceUrl(
     url.pathname = `${path}/${encodedServiceId}`
   } else if (path.endsWith(`/v1/stream`)) {
     url.pathname = `${path}/${encodedServiceId}`
-  } else if (url.hostname === `api.electric-sql.cloud`) {
-    url.pathname = `/v1/streams/${encodedServiceId}`
   } else {
     url.pathname = `${path === `/` ? `` : path}/v1/stream/${encodedServiceId}`
   }
@@ -190,12 +188,6 @@ function normalizeSubscriptionPath(path: string): string {
   return path.replace(/^\/+/, ``).replace(/\/+$/, ``)
 }
 
-interface SubscriptionUrlInfo {
-  mode: `path-prefixed` | `tenant-root` | `plain`
-  serviceId: string | null
-  controlPath: string
-}
-
 export class StreamClient {
   constructor(
     readonly baseUrl: string,
@@ -221,60 +213,17 @@ export class StreamClient {
     return headers
   }
 
-  private subscriptionUrlInfo(): SubscriptionUrlInfo {
-    const url = new URL(this.baseUrl)
-    const pathPrefixedMatch = /^(.*)\/v1\/stream\/([^/]+)\/?$/.exec(
-      url.pathname
-    )
-    if (pathPrefixedMatch) {
-      const [, prefix = ``, serviceId] = pathPrefixedMatch
-      return {
-        mode: `path-prefixed`,
-        serviceId: decodeURIComponent(serviceId!),
-        controlPath: `${prefix}/v1/stream/__ds`,
-      }
-    }
-
-    const tenantRootMatch = /^(.*)\/v1\/streams\/([^/]+)\/?$/.exec(url.pathname)
-    if (tenantRootMatch) {
-      const [, prefix = ``, serviceId] = tenantRootMatch
-      return {
-        mode: `tenant-root`,
-        serviceId: decodeURIComponent(serviceId!),
-        controlPath: `${prefix}/v1/streams/${serviceId}/__ds`,
-      }
-    }
-
-    return {
-      mode: `plain`,
-      serviceId: null,
-      controlPath: `${url.pathname.replace(/\/+$/, ``)}/__ds`,
-    }
-  }
-
   private backendSubscriptionPath(path: string): string {
-    const normalized = normalizeSubscriptionPath(path)
-    const { mode, serviceId } = this.subscriptionUrlInfo()
-    if (mode !== `path-prefixed` || !serviceId) return normalized
-    if (normalized === serviceId || normalized.startsWith(`${serviceId}/`)) {
-      return normalized
-    }
-    return `${serviceId}/${normalized}`
+    return normalizeSubscriptionPath(path)
   }
 
   private runtimeSubscriptionPath(path: string): string {
-    const normalized = normalizeSubscriptionPath(path)
-    const { mode, serviceId } = this.subscriptionUrlInfo()
-    if (mode !== `path-prefixed` || !serviceId) return normalized
-    return normalized.startsWith(`${serviceId}/`)
-      ? normalized.slice(serviceId.length + 1)
-      : normalized
+    return normalizeSubscriptionPath(path)
   }
 
   private subscriptionUrl(subscriptionId: string): string {
     const url = new URL(this.baseUrl)
-    const { controlPath } = this.subscriptionUrlInfo()
-    url.pathname = `${controlPath.replace(/\/+$/, ``)}/subscriptions/${encodeURIComponent(subscriptionId)}`
+    url.pathname = `${url.pathname.replace(/\/+$/, ``)}/__ds/subscriptions/${encodeURIComponent(subscriptionId)}`
     return url.toString()
   }
 

--- a/packages/agents-server/src/utils/server-utils.ts
+++ b/packages/agents-server/src/utils/server-utils.ts
@@ -167,12 +167,13 @@ export async function forwardFetchRequest(options: {
   serviceId: string
   body?: Uint8Array
   dispatcher?: Agent
-  route?: `stream` | `stream-meta`
+  route?: `stream` | `control`
   durableStreamsBearer?: DurableStreamsBearerProvider
   durableStreamsBearerMode?: `overwrite` | `if-missing` | `none`
 }): Promise<Response> {
   const routingAdapter = resolveDurableStreamsRoutingAdapter(
-    options.durableStreamsRouting
+    options.durableStreamsRouting,
+    options.durableStreamsUrl
   )
   const routingInput = {
     durableStreamsUrl: options.durableStreamsUrl,
@@ -180,8 +181,8 @@ export async function forwardFetchRequest(options: {
     requestUrl: options.request.url,
   }
   const upstreamUrl =
-    options.route === `stream-meta`
-      ? routingAdapter.streamMetaUrl(routingInput)
+    options.route === `control`
+      ? routingAdapter.controlUrl(routingInput)
       : routingAdapter.streamUrl(routingInput)
 
   const headers = new Headers(options.request.headers)

--- a/packages/agents-server/test/electric-agents-routes.test.ts
+++ b/packages/agents-server/test/electric-agents-routes.test.ts
@@ -267,7 +267,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         createRequest(`PUT`, `/_electric/shared-state/board-1`),
         {
           service: `test`,
-          durableStreamsUrl: `http://durable.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/test`,
           isShuttingDown: () => false,
         } as unknown as TenantContext
       )
@@ -294,7 +294,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         createRequest(`GET`, `/__ds/subscriptions/sub-1`),
         {
           service: `test`,
-          durableStreamsUrl: `http://durable.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/test`,
           isShuttingDown: () => false,
         } as unknown as TenantContext
       )
@@ -303,7 +303,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
       expect(fetchSpy).toHaveBeenCalledOnce()
       const [url, init] = fetchSpy.mock.calls[0]!
       expect(String(url)).toBe(
-        `http://durable.local/v1/stream/__ds/subscriptions/sub-1`
+        `http://durable.local/v1/stream/test/__ds/subscriptions/sub-1`
       )
       expect(init).toMatchObject({ method: `GET` })
     } finally {
@@ -321,7 +321,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         createRequest(`POST`, `/__ds/unknown-control-route`),
         {
           service: `test`,
-          durableStreamsUrl: `http://durable.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/test`,
           isShuttingDown: () => false,
         } as unknown as TenantContext
       )
@@ -330,7 +330,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
       expect(fetchSpy).toHaveBeenCalledOnce()
       const [url, init] = fetchSpy.mock.calls[0]!
       expect(String(url)).toBe(
-        `http://durable.local/v1/stream/__ds/unknown-control-route`
+        `http://durable.local/v1/stream/test/__ds/unknown-control-route`
       )
       expect(init).toMatchObject({ method: `POST` })
     } finally {
@@ -350,7 +350,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         createRequest(`GET`, `/v1/stream/__ds/subscriptions/sub-1`),
         {
           service: `test`,
-          durableStreamsUrl: `http://durable.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/test`,
           entityBridgeManager: {
             beginClientRead,
             touchByStreamPath: vi.fn(),
@@ -388,7 +388,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         }),
         {
           service: `test`,
-          durableStreamsUrl: `http://durable.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/test`,
           durableStreamsBearer: `service-token`,
           isShuttingDown: () => false,
         } as unknown as TenantContext
@@ -421,7 +421,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         }),
         {
           service: `test`,
-          durableStreamsUrl: `http://durable.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/test`,
           durableStreamsBearer: `service-token`,
           isShuttingDown: () => false,
         } as unknown as TenantContext
@@ -453,7 +453,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         {
           service: `tenant-a`,
           publicUrl: `http://agents.local`,
-          durableStreamsUrl: `http://durable.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/tenant-a`,
           pgDb: db.db,
           isShuttingDown: () => false,
         } as unknown as TenantContext
@@ -462,11 +462,11 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
       expect(result.status).toBe(201)
       const [url, init] = fetchSpy.mock.calls[0]!
       expect(String(url)).toBe(
-        `http://durable.local/v1/stream/__ds/subscriptions/horton-handler`
+        `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler`
       )
       expect(JSON.parse(requestBodyText(init?.body))).toEqual({
         type: `webhook`,
-        pattern: `tenant-a/horton/**`,
+        pattern: `horton/**`,
         webhook: {
           url: `http://agents.local/_electric/webhook-forward/horton-handler`,
         },
@@ -536,15 +536,15 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
     }
   })
 
-  it(`prefixes explicit subscription streams for the tenant before proxying`, async () => {
+  it(`keeps subscription stream paths relative to the resolved stream root`, async () => {
     const fetchSpy = vi.spyOn(globalThis, `fetch`).mockResolvedValue(
       new Response(
         JSON.stringify({
           id: `horton-handler`,
-          pattern: `tenant-a/horton/**`,
+          pattern: `horton/**`,
           streams: [
             {
-              path: `tenant-a/horton/demo/main`,
+              path: `horton/demo/main`,
               link_type: `explicit`,
               acked_offset: `0`,
             },
@@ -560,13 +560,13 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         createRequest(`PUT`, `/__ds/subscriptions/horton-handler`, {
           type: `webhook`,
           pattern: `horton/**`,
-          streams: [`horton/demo/main`, `tenant-a/horton/existing/main`],
+          streams: [`horton/demo/main`, `horton/existing/main`],
           webhook: { url: `http://localhost:4448/runtime-webhook` },
         }),
         {
           service: `tenant-a`,
           publicUrl: `http://agents.local`,
-          durableStreamsUrl: `http://durable.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/tenant-a`,
           pgDb: db.db,
           isShuttingDown: () => false,
         } as unknown as TenantContext
@@ -575,8 +575,8 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
       expect(result.status).toBe(201)
       const [, init] = fetchSpy.mock.calls[0]!
       expect(JSON.parse(requestBodyText(init?.body))).toMatchObject({
-        pattern: `tenant-a/horton/**`,
-        streams: [`tenant-a/horton/demo/main`, `tenant-a/horton/existing/main`],
+        pattern: `horton/**`,
+        streams: [`horton/demo/main`, `horton/existing/main`],
       })
       await expect(result.json()).resolves.toMatchObject({
         pattern: `horton/**`,

--- a/packages/agents-server/test/electric-agents-routes.test.ts
+++ b/packages/agents-server/test/electric-agents-routes.test.ts
@@ -338,6 +338,43 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
     }
   })
 
+  it(`treats prefixed __ds paths as normal stream paths`, async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, `fetch`)
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    const endRead = vi.fn()
+    const beginClientRead = vi.fn().mockResolvedValue(endRead)
+
+    try {
+      const result = await globalRouter.fetch(
+        createRequest(`GET`, `/v1/stream/__ds/subscriptions/sub-1`),
+        {
+          service: `test`,
+          durableStreamsUrl: `http://durable.local`,
+          entityBridgeManager: {
+            beginClientRead,
+            touchByStreamPath: vi.fn(),
+          },
+          isShuttingDown: () => false,
+        } as unknown as TenantContext
+      )
+
+      expect(result.status).toBe(204)
+      expect(fetchSpy).toHaveBeenCalledOnce()
+      const [url, init] = fetchSpy.mock.calls[0]!
+      expect(String(url)).toBe(
+        `http://durable.local/v1/stream/test/v1/stream/__ds/subscriptions/sub-1`
+      )
+      expect(init).toMatchObject({ method: `GET` })
+      expect(beginClientRead).toHaveBeenCalledWith(
+        `/v1/stream/__ds/subscriptions/sub-1`
+      )
+      expect(endRead).toHaveBeenCalledOnce()
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   it(`uses configured durable streams bearer auth for service-scoped subscription traffic`, async () => {
     const fetchSpy = vi
       .spyOn(globalThis, `fetch`)

--- a/packages/agents-server/test/electric-agents-routes.test.ts
+++ b/packages/agents-server/test/electric-agents-routes.test.ts
@@ -73,17 +73,19 @@ const serviceRoutedTestAdapter: DurableStreamsRoutingAdapter = {
     const incomingUrl = new URL(input.requestUrl, `http://localhost`)
     const path = incomingUrl.pathname.replace(/^\/+/, ``)
     const target = new URL(
-      `/v1/stream/${input.serviceId}/${path}`,
+      `/v1/streams/${input.serviceId}/${path}`,
       input.durableStreamsUrl
     )
     target.search = incomingUrl.search
     return target
   },
-  streamMetaUrl(input) {
+  controlUrl(input) {
     const incomingUrl = new URL(input.requestUrl, `http://localhost`)
-    const target = new URL(incomingUrl.pathname, input.durableStreamsUrl)
+    const target = new URL(
+      `/v1/streams/${input.serviceId}${incomingUrl.pathname}`,
+      input.durableStreamsUrl
+    )
     target.search = incomingUrl.search
-    target.searchParams.set(`service`, input.serviceId)
     return target
   },
   toBackendStreamPath(_serviceId, streamPath) {
@@ -289,7 +291,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
 
     try {
       const result = await globalRouter.fetch(
-        createRequest(`GET`, `/v1/stream-meta/subscriptions/sub-1`),
+        createRequest(`GET`, `/__ds/subscriptions/sub-1`),
         {
           service: `test`,
           durableStreamsUrl: `http://durable.local`,
@@ -301,9 +303,36 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
       expect(fetchSpy).toHaveBeenCalledOnce()
       const [url, init] = fetchSpy.mock.calls[0]!
       expect(String(url)).toBe(
-        `http://durable.local/v1/stream-meta/subscriptions/sub-1`
+        `http://durable.local/v1/stream/__ds/subscriptions/sub-1`
       )
       expect(init).toMatchObject({ method: `GET` })
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it(`reserves __ds control paths before normal stream operations`, async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, `fetch`)
+      .mockResolvedValue(new Response(null, { status: 404 }))
+
+    try {
+      const result = await globalRouter.fetch(
+        createRequest(`POST`, `/__ds/unknown-control-route`),
+        {
+          service: `test`,
+          durableStreamsUrl: `http://durable.local`,
+          isShuttingDown: () => false,
+        } as unknown as TenantContext
+      )
+
+      expect(result.status).toBe(404)
+      expect(fetchSpy).toHaveBeenCalledOnce()
+      const [url, init] = fetchSpy.mock.calls[0]!
+      expect(String(url)).toBe(
+        `http://durable.local/v1/stream/__ds/unknown-control-route`
+      )
+      expect(init).toMatchObject({ method: `POST` })
     } finally {
       fetchSpy.mockRestore()
     }
@@ -316,7 +345,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
 
     try {
       const result = await globalRouter.fetch(
-        new Request(`http://localhost/v1/stream-meta/subscriptions/sub-1`, {
+        new Request(`http://localhost/__ds/subscriptions/sub-1`, {
           method: `GET`,
           headers: { authorization: `Bearer caller-token` },
         }),
@@ -345,7 +374,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
 
     try {
       const result = await globalRouter.fetch(
-        new Request(`http://localhost/v1/stream-meta/subscriptions/sub-1/ack`, {
+        new Request(`http://localhost/__ds/subscriptions/sub-1/ack`, {
           method: `POST`,
           headers: {
             authorization: `Bearer claim-token`,
@@ -379,7 +408,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
 
     try {
       const result = await globalRouter.fetch(
-        createRequest(`PUT`, `/v1/stream-meta/subscriptions/horton-handler`, {
+        createRequest(`PUT`, `/__ds/subscriptions/horton-handler`, {
           type: `webhook`,
           pattern: `horton/**`,
           webhook: { url: `http://localhost:4448/runtime-webhook` },
@@ -396,7 +425,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
       expect(result.status).toBe(201)
       const [url, init] = fetchSpy.mock.calls[0]!
       expect(String(url)).toBe(
-        `http://durable.local/v1/stream-meta/subscriptions/horton-handler`
+        `http://durable.local/v1/stream/__ds/subscriptions/horton-handler`
       )
       expect(JSON.parse(requestBodyText(init?.body))).toEqual({
         type: `webhook`,
@@ -436,7 +465,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
 
     try {
       const result = await globalRouter.fetch(
-        createRequest(`PUT`, `/v1/stream-meta/subscriptions/horton-handler`, {
+        createRequest(`PUT`, `/__ds/subscriptions/horton-handler`, {
           type: `webhook`,
           pattern: `horton/**`,
           streams: [`horton/demo/main`],
@@ -455,7 +484,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
       expect(result.status).toBe(201)
       const [url, init] = fetchSpy.mock.calls[0]!
       expect(String(url)).toBe(
-        `http://durable.local/v1/stream-meta/subscriptions/horton-handler?service=tenant-a`
+        `http://durable.local/v1/streams/tenant-a/__ds/subscriptions/horton-handler`
       )
       expect(JSON.parse(requestBodyText(init?.body))).toMatchObject({
         pattern: `horton/**`,
@@ -491,7 +520,7 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
 
     try {
       const result = await globalRouter.fetch(
-        createRequest(`PUT`, `/v1/stream-meta/subscriptions/horton-handler`, {
+        createRequest(`PUT`, `/__ds/subscriptions/horton-handler`, {
           type: `webhook`,
           pattern: `horton/**`,
           streams: [`horton/demo/main`, `tenant-a/horton/existing/main`],

--- a/packages/agents-server/test/host.test.ts
+++ b/packages/agents-server/test/host.test.ts
@@ -53,13 +53,13 @@ describe(`AgentsHost`, () => {
 
     const runtime = await host.registerTenant({
       serviceId: `svc-coastal-stork`,
-      durableStreamsUrl: `https://api.electric-sql.cloud/v1/stream/svc-coastal-stork`,
+      durableStreamsUrl: `https://api.electric-sql.cloud/v1/streams/svc-coastal-stork`,
     })
 
     expect(runtime.serviceId).toBe(`svc-coastal-stork`)
     expect(host.getTenant(`svc-coastal-stork`)).toBe(runtime)
     expect(runtime.streamClient.baseUrl).toBe(
-      `https://api.electric-sql.cloud/v1/stream/svc-coastal-stork`
+      `https://api.electric-sql.cloud/v1/streams/svc-coastal-stork`
     )
     expect(runtime.wakeRegistry).toBe(host.wakeRegistry)
     expect(runtime.manager.registry.tenantId).toBe(`svc-coastal-stork`)
@@ -67,7 +67,7 @@ describe(`AgentsHost`, () => {
 
   it(`uses an explicitly supplied tenant stream client`, async () => {
     const streamClient = new StreamClient(
-      `https://api.electric-sql.cloud/v1/stream/svc-direct-client`
+      `https://api.electric-sql.cloud/v1/streams/svc-direct-client`
     )
     const host = new AgentsHost({
       db: createMockDb(),
@@ -90,7 +90,7 @@ describe(`AgentsHost`, () => {
 
     const runtime = await host.registerTenant({
       serviceId: `svc-before-start`,
-      durableStreamsUrl: `https://api.electric-sql.cloud/v1/stream/svc-before-start`,
+      durableStreamsUrl: `https://api.electric-sql.cloud/v1/streams/svc-before-start`,
     })
     const rehydrate = vi
       .spyOn(runtime, `rehydrateCronSchedules`)
@@ -140,7 +140,7 @@ describe(`AgentsHost`, () => {
 
     const registration = host.registerTenant({
       serviceId: `svc-race`,
-      durableStreamsUrl: `https://api.electric-sql.cloud/v1/stream/svc-race`,
+      durableStreamsUrl: `https://api.electric-sql.cloud/v1/streams/svc-race`,
     })
     await Promise.resolve()
 

--- a/packages/agents-server/test/host.test.ts
+++ b/packages/agents-server/test/host.test.ts
@@ -53,13 +53,13 @@ describe(`AgentsHost`, () => {
 
     const runtime = await host.registerTenant({
       serviceId: `svc-coastal-stork`,
-      durableStreamsUrl: `https://api.electric-sql.cloud/v1/streams/svc-coastal-stork`,
+      durableStreamsUrl: `https://streams.test/v1/streams/svc-coastal-stork`,
     })
 
     expect(runtime.serviceId).toBe(`svc-coastal-stork`)
     expect(host.getTenant(`svc-coastal-stork`)).toBe(runtime)
     expect(runtime.streamClient.baseUrl).toBe(
-      `https://api.electric-sql.cloud/v1/streams/svc-coastal-stork`
+      `https://streams.test/v1/streams/svc-coastal-stork`
     )
     expect(runtime.wakeRegistry).toBe(host.wakeRegistry)
     expect(runtime.manager.registry.tenantId).toBe(`svc-coastal-stork`)
@@ -67,7 +67,7 @@ describe(`AgentsHost`, () => {
 
   it(`uses an explicitly supplied tenant stream client`, async () => {
     const streamClient = new StreamClient(
-      `https://api.electric-sql.cloud/v1/streams/svc-direct-client`
+      `https://streams.test/v1/streams/svc-direct-client`
     )
     const host = new AgentsHost({
       db: createMockDb(),
@@ -90,7 +90,7 @@ describe(`AgentsHost`, () => {
 
     const runtime = await host.registerTenant({
       serviceId: `svc-before-start`,
-      durableStreamsUrl: `https://api.electric-sql.cloud/v1/streams/svc-before-start`,
+      durableStreamsUrl: `https://streams.test/v1/streams/svc-before-start`,
     })
     const rehydrate = vi
       .spyOn(runtime, `rehydrateCronSchedules`)
@@ -140,7 +140,7 @@ describe(`AgentsHost`, () => {
 
     const registration = host.registerTenant({
       serviceId: `svc-race`,
-      durableStreamsUrl: `https://api.electric-sql.cloud/v1/streams/svc-race`,
+      durableStreamsUrl: `https://streams.test/v1/streams/svc-race`,
     })
     await Promise.resolve()
 

--- a/packages/agents-server/test/oss-server-router.test.ts
+++ b/packages/agents-server/test/oss-server-router.test.ts
@@ -20,7 +20,7 @@ function buildTenantContext(
       url: `/principal/system:framework`,
     },
     publicUrl: `http://server`,
-    durableStreamsUrl: `http://durable.local`,
+    durableStreamsUrl: `http://durable.local/v1/stream/tenant-test`,
     durableStreamsDispatcher: undefined as any,
     pgDb: undefined as any,
     entityManager: undefined as any,

--- a/packages/agents-server/test/stream-client.test.ts
+++ b/packages/agents-server/test/stream-client.test.ts
@@ -97,7 +97,7 @@ describe(`StreamClient`, () => {
     await expect(client.exists(`/_cron/test`)).rejects.toBe(error)
   })
 
-  it(`createSubscription uses the stream-meta subscription contract`, async () => {
+  it(`createSubscription uses the reserved __ds subscription contract`, async () => {
     const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
       new Response(JSON.stringify({ subscription_id: `sub-1` }), {
         headers: { 'content-type': `application/json` },
@@ -114,7 +114,7 @@ describe(`StreamClient`, () => {
       )
 
       expect(fetchMock).toHaveBeenCalledWith(
-        `http://127.0.0.1:4545/v1/stream-meta/subscriptions/sub-1?service=tenant-a`,
+        `http://127.0.0.1:4545/v1/stream/__ds/subscriptions/sub-1`,
         expect.objectContaining({ method: `PUT` })
       )
       const [, init] = fetchMock.mock.calls[0]!
@@ -123,6 +123,37 @@ describe(`StreamClient`, () => {
         pattern: `tenant-a/chat/**`,
         webhook: { url: `http://agent.local/webhook` },
         description: `test subscription`,
+      })
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it(`does not tenant-prefix subscription streams for tenant-root URLs`, async () => {
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
+      new Response(JSON.stringify({ subscription_id: `sub-1` }), {
+        headers: { 'content-type': `application/json` },
+      })
+    )
+    const client = new StreamClient(
+      `https://api.electric-sql.cloud/v1/streams/svc-tenant-a`
+    )
+
+    try {
+      await client.putSubscription(`sub-1`, {
+        type: `pull-wake`,
+        streams: [`/chat/one/main`],
+        wake_stream: `/runners/runner-1/wake`,
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.electric-sql.cloud/v1/streams/svc-tenant-a/__ds/subscriptions/sub-1`,
+        expect.objectContaining({ method: `PUT` })
+      )
+      const [, init] = fetchMock.mock.calls[0]!
+      expect(JSON.parse(init?.body as string)).toMatchObject({
+        streams: [`chat/one/main`],
+        wake_stream: `runners/runner-1/wake`,
       })
     } finally {
       fetchMock.mockRestore()

--- a/packages/agents-server/test/stream-client.test.ts
+++ b/packages/agents-server/test/stream-client.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { StreamClient } from '../src/stream-client'
+import { StreamClient, durableStreamsServiceUrl } from '../src/stream-client'
 
 const {
   appendMock,
@@ -243,5 +243,31 @@ describe(`StreamClient`, () => {
     } finally {
       fetchMock.mockRestore()
     }
+  })
+})
+
+describe(`durableStreamsServiceUrl`, () => {
+  it(`derives a single-tenant stream root from a bare server origin`, () => {
+    expect(
+      durableStreamsServiceUrl(`http://127.0.0.1:4545`, `tenant-a`, {
+        scope: `stream-root`,
+      })
+    ).toBe(`http://127.0.0.1:4545/v1/stream`)
+  })
+
+  it(`derives a service-scoped stream root for host tenant registrations`, () => {
+    expect(durableStreamsServiceUrl(`http://127.0.0.1:4545`, `tenant-a`)).toBe(
+      `http://127.0.0.1:4545/v1/stream/tenant-a`
+    )
+  })
+
+  it(`preserves explicitly scoped stream roots`, () => {
+    expect(
+      durableStreamsServiceUrl(
+        `https://streams.test/v1/streams/tenant-a`,
+        `tenant-a`,
+        { scope: `stream-root` }
+      )
+    ).toBe(`https://streams.test/v1/streams/tenant-a`)
   })
 })

--- a/packages/agents-server/test/stream-client.test.ts
+++ b/packages/agents-server/test/stream-client.test.ts
@@ -114,13 +114,13 @@ describe(`StreamClient`, () => {
       )
 
       expect(fetchMock).toHaveBeenCalledWith(
-        `http://127.0.0.1:4545/v1/stream/__ds/subscriptions/sub-1`,
+        `http://127.0.0.1:4545/v1/stream/tenant-a/__ds/subscriptions/sub-1`,
         expect.objectContaining({ method: `PUT` })
       )
       const [, init] = fetchMock.mock.calls[0]!
       expect(JSON.parse(init?.body as string)).toEqual({
         type: `webhook`,
-        pattern: `tenant-a/chat/**`,
+        pattern: `chat/**`,
         webhook: { url: `http://agent.local/webhook` },
         description: `test subscription`,
       })
@@ -136,7 +136,7 @@ describe(`StreamClient`, () => {
       })
     )
     const client = new StreamClient(
-      `https://api.electric-sql.cloud/v1/streams/svc-tenant-a`
+      `https://streams.test/v1/streams/svc-tenant-a`
     )
 
     try {
@@ -147,7 +147,7 @@ describe(`StreamClient`, () => {
       })
 
       expect(fetchMock).toHaveBeenCalledWith(
-        `https://api.electric-sql.cloud/v1/streams/svc-tenant-a/__ds/subscriptions/sub-1`,
+        `https://streams.test/v1/streams/svc-tenant-a/__ds/subscriptions/sub-1`,
         expect.objectContaining({ method: `PUT` })
       )
       const [, init] = fetchMock.mock.calls[0]!

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -883,7 +883,7 @@ describe(`Wake Registry Integration`, () => {
     pattern: string
   ): Promise<void> {
     const subRes = await fetch(
-      `${baseUrl}/v1/stream-meta/subscriptions/${encodeURIComponent(id)}`,
+      `${baseUrl}/__ds/subscriptions/${encodeURIComponent(id)}`,
       {
         method: `PUT`,
         headers: { 'content-type': `application/json` },

--- a/packages/agents-server/test/webhook-forward-routing.test.ts
+++ b/packages/agents-server/test/webhook-forward-routing.test.ts
@@ -47,17 +47,19 @@ const serviceRoutedTestAdapter: DurableStreamsRoutingAdapter = {
     const incomingUrl = new URL(input.requestUrl, `http://localhost`)
     const path = incomingUrl.pathname.replace(/^\/+/, ``)
     const target = new URL(
-      `/v1/stream/${input.serviceId}/${path}`,
+      `/v1/streams/${input.serviceId}/${path}`,
       input.durableStreamsUrl
     )
     target.search = incomingUrl.search
     return target
   },
-  streamMetaUrl(input) {
+  controlUrl(input) {
     const incomingUrl = new URL(input.requestUrl, `http://localhost`)
-    const target = new URL(incomingUrl.pathname, input.durableStreamsUrl)
+    const target = new URL(
+      `/v1/streams/${input.serviceId}${incomingUrl.pathname}`,
+      input.durableStreamsUrl
+    )
     target.search = incomingUrl.search
-    target.searchParams.set(`service`, input.serviceId)
     return target
   },
   toBackendStreamPath(_serviceId, streamPath) {
@@ -149,7 +151,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
               has_pending: true,
             },
           ],
-          callback_url: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+          callback_url: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
           callback_token: `callback-token`,
         }),
         buildContext({
@@ -178,7 +180,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(insert.values).toHaveBeenCalledWith({
         tenantId: `tenant-a`,
         consumerId: `wake-1`,
-        callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       })
     } finally {
@@ -232,7 +234,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
               has_pending: true,
             },
           ],
-          callback_url: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+          callback_url: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
           callback_token: `callback-token`,
         }),
         buildContext({
@@ -272,7 +274,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(insert.values).toHaveBeenCalledWith({
         tenantId: `tenant-a`,
         consumerId: `wake-2`,
-        callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/pending/main`,
       })
     } finally {
@@ -317,7 +319,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
               has_pending: true,
             },
           ],
-          callback_url: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+          callback_url: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
           callback_token: `callback-token`,
         }),
         buildContext({
@@ -357,7 +359,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(insert.values).toHaveBeenCalledWith({
         tenantId: `tenant-a`,
         consumerId: `wake-prefixed`,
-        callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       })
     } finally {
@@ -368,7 +370,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
   it(`claims new webhook wakes locally and returns a tenant-scoped claim write token`, async () => {
     const select = selectDb([
       {
-        callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       },
     ])
@@ -435,7 +437,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
               has_pending: true,
             },
           ],
-          callback_url: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+          callback_url: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
           callback_token: `callback-token`,
         }),
         buildContext({
@@ -462,7 +464,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
   it(`translates runtime done callbacks to the new Durable Streams callback shape`, async () => {
     const select = selectDb([
       {
-        callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       },
     ])
@@ -500,7 +502,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(response.status).toBe(200)
       const [url, init] = fetchSpy.mock.calls[0]!
       expect(String(url)).toBe(
-        `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`
+        `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`
       )
       expect(init).toMatchObject({
         method: `POST`,
@@ -536,7 +538,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
   it(`lets a routing adapter own callback ack stream paths`, async () => {
     const select = selectDb([
       {
-        callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       },
     ])

--- a/packages/agents-server/test/webhook-forward-routing.test.ts
+++ b/packages/agents-server/test/webhook-forward-routing.test.ts
@@ -93,7 +93,7 @@ function buildContext(overrides: Partial<TenantContext> = {}): TenantContext {
       url: `/principal/system:framework`,
     },
     publicUrl: `http://agents.local`,
-    durableStreamsUrl: `http://durable.local`,
+    durableStreamsUrl: `http://durable.local/v1/stream/tenant-a`,
     durableStreamsDispatcher: undefined as any,
     pgDb: undefined as any,
     entityManager: {
@@ -151,7 +151,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
               has_pending: true,
             },
           ],
-          callback_url: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+          callback_url: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
           callback_token: `callback-token`,
         }),
         buildContext({
@@ -180,7 +180,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(insert.values).toHaveBeenCalledWith({
         tenantId: `tenant-a`,
         consumerId: `wake-1`,
-        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+        callbackUrl: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       })
     } finally {
@@ -234,7 +234,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
               has_pending: true,
             },
           ],
-          callback_url: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+          callback_url: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
           callback_token: `callback-token`,
         }),
         buildContext({
@@ -274,7 +274,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(insert.values).toHaveBeenCalledWith({
         tenantId: `tenant-a`,
         consumerId: `wake-2`,
-        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+        callbackUrl: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/pending/main`,
       })
     } finally {
@@ -282,7 +282,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
     }
   })
 
-  it(`normalizes tenant-prefixed DS wake stream paths before forwarding to the runtime`, async () => {
+  it(`keeps root-relative DS wake stream paths before forwarding to the runtime`, async () => {
     const select = selectDb([
       { webhookUrl: `http://runtime.local/_electric/builtin-agent-handler` },
     ])
@@ -313,13 +313,13 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
           generation: 9,
           streams: [
             {
-              path: `tenant-a/horton/demo/main`,
+              path: `horton/demo/main`,
               acked_offset: `0`,
               tail_offset: `1`,
               has_pending: true,
             },
           ],
-          callback_url: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+          callback_url: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
           callback_token: `callback-token`,
         }),
         buildContext({
@@ -359,7 +359,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(insert.values).toHaveBeenCalledWith({
         tenantId: `tenant-a`,
         consumerId: `wake-prefixed`,
-        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+        callbackUrl: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       })
     } finally {
@@ -370,7 +370,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
   it(`claims new webhook wakes locally and returns a tenant-scoped claim write token`, async () => {
     const select = selectDb([
       {
-        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+        callbackUrl: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       },
     ])
@@ -437,7 +437,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
               has_pending: true,
             },
           ],
-          callback_url: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+          callback_url: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
           callback_token: `callback-token`,
         }),
         buildContext({
@@ -464,7 +464,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
   it(`translates runtime done callbacks to the new Durable Streams callback shape`, async () => {
     const select = selectDb([
       {
-        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+        callbackUrl: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       },
     ])
@@ -502,7 +502,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(response.status).toBe(200)
       const [url, init] = fetchSpy.mock.calls[0]!
       expect(String(url)).toBe(
-        `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`
+        `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`
       )
       expect(init).toMatchObject({
         method: `POST`,
@@ -513,7 +513,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       expect(requestBodyJson(init?.body)).toEqual({
         wake_id: `wake-1`,
         generation: 7,
-        acks: [{ stream: `tenant-a/horton/demo/main`, offset: `1` }],
+        acks: [{ stream: `horton/demo/main`, offset: `1` }],
         done: true,
       })
       expect(ctx.entityManager.registry.updateStatus).toHaveBeenCalledWith(
@@ -538,7 +538,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
   it(`lets a routing adapter own callback ack stream paths`, async () => {
     const select = selectDb([
       {
-        callbackUrl: `http://durable.local/v1/stream/__ds/subscriptions/horton-handler/callback`,
+        callbackUrl: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
         primaryStream: `/horton/demo/main`,
       },
     ])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4162,14 +4162,14 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@262cb1f':
-    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@262cb1f}
+  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350':
+    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350}
     version: 0.2.3
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350':
-    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350}
+  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217':
+    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217}
     version: 0.2.3
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -4179,14 +4179,14 @@ packages:
     version: 0.3.1
     engines: {node: '>=18.0.0'}
 
-  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@262cb1f':
-    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@262cb1f}
+  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350':
+    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350}
     version: 0.2.5
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350':
-    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350}
+  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217':
+    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217}
     version: 0.2.5
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -23186,20 +23186,20 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@262cb1f':
+  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350':
     dependencies:
       '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
       fastq: 1.20.1
 
-  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350':
+  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217':
     dependencies:
       '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
       fastq: 1.20.1
 
   '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350(typescript@5.8.3)':
     dependencies:
-      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@262cb1f
-      '@durable-streams/state': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@262cb1f(typescript@5.8.3)
+      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
+      '@durable-streams/state': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
       '@neophi/sieve-cache': 1.5.0
       lmdb: 3.5.4
       pino: 10.3.1
@@ -23207,17 +23207,17 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@262cb1f(typescript@5.8.3)':
+  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350(typescript@5.8.3)':
     dependencies:
-      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@262cb1f
+      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@standard-schema/spec': 1.1.0
       '@tanstack/db': 0.6.5(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 
-  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350(typescript@5.8.3)':
+  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)':
     dependencies:
-      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@262cb1f
+      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@standard-schema/spec': 1.1.0
       '@tanstack/db': 0.6.5(typescript@5.8.3)
     transitivePeerDependencies:


### PR DESCRIPTION
Durable Streams moved subscription control routes under the reserved `__ds` prefix attached to each stream URL. This updates agents-server to reserve and proxy `__ds` before normal stream operations, so subscription control requests no longer depend on the old global metadata namespace.

The routing layer now supports both embedded/path-prefixed stream roots and tenant-root cloud URLs. Local `/v1/stream` deployments keep backend tenant prefixing for stream names, while cloud-style `/v1/streams/:service` URLs keep stream names tenant-relative and put the tenant in the stream root.

`StreamClient`, webhook callback forwarding, conformance helpers, and focused route tests now use `{stream-url}/__ds/subscriptions/:id`. The lockfile also refreshes the mutable `@350` durable-streams packages so their transitive durable-streams dependencies point at the newer published internals.