### PR TITLE
fix(agents-server): release pull-wake claim row even when in-memory token is missing

### DIFF
--- a/.changeset/release-pull-wake-claim-after-dispatch.md
+++ b/.changeset/release-pull-wake-claim-after-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server': patch
+---
+
+Fix pull-wake claims leaking in `consumer_claims` after dispatch. The release path in `callback-forward` was gated entirely on the in-memory write-token state, so any condition that lost or evicted the token (server restart, a newer wake on the same stream) would prevent `materializeReleasedClaim` from running and leave the DB row pinned at `status='active'`. The fix decouples the durable-row release (keyed by `consumerId + epoch`) from in-memory token cleanup, and uses `entityCleared || stillOwnsClaim` to gate the entity status transition back to `idle`. Includes regression tests in `test/webhook-forward-routing.test.ts`.

--- a/packages/agents-server/src/entity-registry.ts
+++ b/packages/agents-server/src/entity-registry.ts
@@ -378,7 +378,7 @@ export class PostgresRegistry {
 
   async materializeReleasedClaim(
     input: MaterializeReleasedClaimInput
-  ): Promise<ConsumerClaim | null> {
+  ): Promise<{ claim: ConsumerClaim | null; entityCleared: boolean }> {
     const releasedAt = input.releasedAt ?? new Date()
     const rows = await this.db
       .update(consumerClaims)
@@ -398,8 +398,13 @@ export class PostgresRegistry {
       .returning()
 
     const claim = rows[0] ? this.rowToConsumerClaim(rows[0]) : null
+    let entityCleared = false
     if (claim) {
-      await this.db
+      // entityCleared distinguishes "we were the active dispatch and now it's
+      // empty" from "a newer claim was already active for this entity." The
+      // WHERE clause matches our (consumerId, epoch) so an evicted-by-newer
+      // case correctly returns zero rows.
+      const cleared = await this.db
         .update(entityDispatchState)
         .set({
           activeConsumerId: null,
@@ -419,8 +424,10 @@ export class PostgresRegistry {
             eq(entityDispatchState.activeEpoch, input.epoch)
           )
         )
+        .returning({ entityUrl: entityDispatchState.entityUrl })
+      entityCleared = cleared.length > 0
     }
-    return claim
+    return { claim, entityCleared }
   }
 
   async getActiveClaimsForRunner(

--- a/packages/agents-server/src/routing/internal-router.ts
+++ b/packages/agents-server/src/routing/internal-router.ts
@@ -624,8 +624,15 @@ async function callbackForward(
       const entity = await ctx.entityManager.registry.getEntityByStream(
         target.primaryStream
       )
-      if (entity && stillOwnsClaim) {
-        if (epoch !== undefined) {
+
+      // Release the consumer_claims row by its DB identity (consumerId,
+      // epoch). The in-memory write token is a separate concern (write
+      // authorization during the run); release of the durable row must
+      // succeed even if the token was lost (server restart) or evicted
+      // (a later wake re-minted for the same stream).
+      let entityCleared = false
+      if (epoch !== undefined) {
+        const result =
           await ctx.entityManager.registry.materializeReleasedClaim?.({
             consumerId,
             epoch,
@@ -643,28 +650,41 @@ async function callbackForward(
                 })
               : undefined,
           })
-        }
+        entityCleared = result?.entityCleared ?? false
+      }
+
+      // Transition entity back to idle when either signal says it's safe:
+      // - entityCleared: our release just cleared the entity's active
+      //   dispatch state, so no in-flight wake remains.
+      // - stillOwnsClaim: this consumer is still the in-memory write-token
+      //   owner, so no newer wake has displaced it. Covers two cases:
+      //   (a) retry of a failed done (first attempt cleared the DB state
+      //   but failed to update status), (b) server restart scenarios where
+      //   the token is intact even though entityDispatchState may diverge.
+      // If both are false, a newer wake owns the entity — leave status as-is.
+      if (entity && (entityCleared || stillOwnsClaim)) {
         await ctx.entityManager.registry.updateStatus(entity.url, `idle`)
-        ctx.runtime.claimWriteTokens.clearStream(
-          ctx.service,
-          target.primaryStream
-        )
         await ctx.entityBridgeManager.onEntityChanged(entity.url)
         serverLog.info(
           `[callback-forward] status updated to idle for ${entity.url}`
         )
-      } else if (stillOwnsClaim) {
+      } else if (!entity) {
+        serverLog.warn(
+          `[callback-forward] done received but no entity found for stream=${target.primaryStream}`
+        )
+      }
+
+      // Clear the in-memory write token only if this consumer still owns it.
+      // If a newer wake has taken over, that newer wake owns the token now
+      // and we must not clear it out from under it.
+      if (stillOwnsClaim) {
         ctx.runtime.claimWriteTokens.clearStream(
           ctx.service,
           target.primaryStream
         )
       } else if (entity) {
         serverLog.info(
-          `[callback-forward] done ignored for stale claim stream=${target.primaryStream} consumer=${consumerId}`
-        )
-      } else {
-        serverLog.warn(
-          `[callback-forward] done received but no entity found for stream=${target.primaryStream}`
+          `[callback-forward] done arrived after in-memory token evicted (stream=${target.primaryStream} consumer=${consumerId})`
         )
       }
     } else if (requestBody?.done === true) {

--- a/packages/agents-server/test/webhook-forward-routing.test.ts
+++ b/packages/agents-server/test/webhook-forward-routing.test.ts
@@ -586,7 +586,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
     }
   })
 
-  describe(`claim release on done callback (regression for #4340)`, () => {
+  describe(`callback-forward done releases the durable claim independently of the in-memory write token`, () => {
     const upstreamOk = (): void => {
       vi.spyOn(globalThis, `fetch`).mockResolvedValue(
         new Response(JSON.stringify({ ok: true, next_wake: false }), {
@@ -595,7 +595,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       )
     }
 
-    it(`marks the consumer_claims row released and the entity idle on done`, async () => {
+    it(`releases the consumer_claims row and marks the entity idle when the consumer holds the in-memory write token`, async () => {
       const select = selectDb([
         {
           callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
@@ -606,7 +606,6 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       const ctx = buildContext({
         pgDb: { select: select.select } as any,
       })
-      // Simulate the runtime's claim phase having minted a token.
       ctx.runtime.claimWriteTokens.mint(
         `tenant-a`,
         `/horton/demo/main`,
@@ -649,12 +648,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       }
     })
 
-    it(`still releases the consumer_claims row when the in-memory write token is missing (e.g. server restart)`, async () => {
-      // Reproduces the production failure mode where the in-memory
-      // ClaimWriteTokenStore is empty (server restarted between dispatch and
-      // done, or another wake evicted the token) but the consumer_claims row
-      // is still active in the DB. Today the release path skips
-      // materializeReleasedClaim under this condition and the row leaks.
+    it(`releases the consumer_claims row and marks the entity idle when no in-memory write token is present for the consumer`, async () => {
       const select = selectDb([
         {
           callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
@@ -665,8 +659,6 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       const ctx = buildContext({
         pgDb: { select: select.select } as any,
       })
-      // Intentionally do NOT mint a write token — simulates the token
-      // being lost between the runtime's claim phase and its done call.
 
       try {
         const response = await globalRouter.fetch(
@@ -686,8 +678,6 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
         )
 
         expect(response.status).toBe(200)
-        // The DB row identity (consumerId, epoch) is sufficient to release
-        // the claim — release must not depend on in-memory write-token state.
         expect(
           ctx.entityManager.registry.materializeReleasedClaim
         ).toHaveBeenCalledWith(
@@ -696,8 +686,6 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
             epoch: 7,
           })
         )
-        // The entity should transition back to idle so the UI no longer
-        // shows it as "running" after the agent finishes.
         expect(ctx.entityManager.registry.updateStatus).toHaveBeenCalledWith(
           `/horton/demo`,
           `idle`
@@ -707,11 +695,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       }
     })
 
-    it(`releases an earlier wake's claim even after a later wake evicted its in-memory token`, async () => {
-      // Same defect, different cause: two wakes for the same entity arrive
-      // close together. The second's mint evicts the first's token. The
-      // first wake's done call then finds stillOwnsClaim=false and skips
-      // the release.
+    it(`releases the consumer_claims row for the old consumer when a newer consumer has taken over the in-memory token, without disturbing the newer consumer's token or the entity status`, async () => {
       const select = selectDb([
         {
           callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
@@ -722,8 +706,8 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
       const ctx = buildContext({
         pgDb: { select: select.select } as any,
       })
-      // Simulate the DB state where consumer-old's row is still active but
-      // entityDispatchState's active claim is consumer-new (the later wake).
+      // The newer consumer is the active dispatch in the DB, so releasing
+      // the older consumer's row must not clear the entity's dispatch state.
       ;(
         ctx.entityManager.registry.materializeReleasedClaim as any
       ).mockResolvedValue({ claim: null, entityCleared: false })
@@ -733,8 +717,6 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
         `/horton/demo/main`,
         `wake-1`
       )
-      // A second wake arrives and re-mints for the same stream, evicting
-      // wake-1 from the in-memory store.
       ctx.runtime.claimWriteTokens.mint(
         `tenant-a`,
         `/horton/demo/main`,
@@ -758,7 +740,6 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
           ctx
         )
 
-        // The DB row for wake-1 must still be released.
         expect(
           ctx.entityManager.registry.materializeReleasedClaim
         ).toHaveBeenCalledWith(
@@ -767,9 +748,16 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
             epoch: 7,
           })
         )
-        // But the entity status must NOT be set to idle — wake-2 is still
-        // in flight and owns the entity's active dispatch.
+        // The newer consumer owns the entity now — its status must stay
+        // as-is and its in-memory write token must remain intact.
         expect(ctx.entityManager.registry.updateStatus).not.toHaveBeenCalled()
+        expect(
+          ctx.runtime.claimWriteTokens.owns(
+            `tenant-a`,
+            `/horton/demo/main`,
+            `wake-2`
+          )
+        ).toBe(true)
       } finally {
         vi.mocked(globalThis.fetch).mockRestore()
       }

--- a/packages/agents-server/test/webhook-forward-routing.test.ts
+++ b/packages/agents-server/test/webhook-forward-routing.test.ts
@@ -100,6 +100,11 @@ function buildContext(overrides: Partial<TenantContext> = {}): TenantContext {
       registry: {
         getEntityByStream: vi.fn().mockResolvedValue(entity),
         updateStatus: vi.fn().mockResolvedValue(undefined),
+        materializeReleasedClaim: vi.fn().mockResolvedValue({
+          claim: null,
+          entityCleared: true,
+        }),
+        materializeHeartbeatClaim: vi.fn().mockResolvedValue(undefined),
       },
       enrichPayload: vi.fn(async (payload: Record<string, unknown>) => ({
         ...payload,
@@ -579,5 +584,195 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
     } finally {
       fetchSpy.mockRestore()
     }
+  })
+
+  describe(`claim release on done callback (regression for #4340)`, () => {
+    const upstreamOk = (): void => {
+      vi.spyOn(globalThis, `fetch`).mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, next_wake: false }), {
+          headers: { 'content-type': `application/json` },
+        })
+      )
+    }
+
+    it(`marks the consumer_claims row released and the entity idle on done`, async () => {
+      const select = selectDb([
+        {
+          callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+          primaryStream: `/horton/demo/main`,
+        },
+      ])
+      upstreamOk()
+      const ctx = buildContext({
+        pgDb: { select: select.select } as any,
+      })
+      // Simulate the runtime's claim phase having minted a token.
+      ctx.runtime.claimWriteTokens.mint(
+        `tenant-a`,
+        `/horton/demo/main`,
+        `wake-1`
+      )
+
+      try {
+        const response = await globalRouter.fetch(
+          new Request(`http://agents.local/_electric/callback-forward/wake-1`, {
+            method: `POST`,
+            headers: {
+              'content-type': `application/json`,
+              authorization: `Bearer callback-token`,
+            },
+            body: JSON.stringify({
+              epoch: 7,
+              acks: [{ path: `/horton/demo/main`, offset: `1` }],
+              done: true,
+            }),
+          }),
+          ctx
+        )
+
+        expect(response.status).toBe(200)
+        expect(
+          ctx.entityManager.registry.materializeReleasedClaim
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            consumerId: `wake-1`,
+            epoch: 7,
+            ackedStreams: [{ path: `/horton/demo/main`, offset: `1` }],
+          })
+        )
+        expect(ctx.entityManager.registry.updateStatus).toHaveBeenCalledWith(
+          `/horton/demo`,
+          `idle`
+        )
+      } finally {
+        vi.mocked(globalThis.fetch).mockRestore()
+      }
+    })
+
+    it(`still releases the consumer_claims row when the in-memory write token is missing (e.g. server restart)`, async () => {
+      // Reproduces the production failure mode where the in-memory
+      // ClaimWriteTokenStore is empty (server restarted between dispatch and
+      // done, or another wake evicted the token) but the consumer_claims row
+      // is still active in the DB. Today the release path skips
+      // materializeReleasedClaim under this condition and the row leaks.
+      const select = selectDb([
+        {
+          callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+          primaryStream: `/horton/demo/main`,
+        },
+      ])
+      upstreamOk()
+      const ctx = buildContext({
+        pgDb: { select: select.select } as any,
+      })
+      // Intentionally do NOT mint a write token — simulates the token
+      // being lost between the runtime's claim phase and its done call.
+
+      try {
+        const response = await globalRouter.fetch(
+          new Request(`http://agents.local/_electric/callback-forward/wake-1`, {
+            method: `POST`,
+            headers: {
+              'content-type': `application/json`,
+              authorization: `Bearer callback-token`,
+            },
+            body: JSON.stringify({
+              epoch: 7,
+              acks: [{ path: `/horton/demo/main`, offset: `1` }],
+              done: true,
+            }),
+          }),
+          ctx
+        )
+
+        expect(response.status).toBe(200)
+        // The DB row identity (consumerId, epoch) is sufficient to release
+        // the claim — release must not depend on in-memory write-token state.
+        expect(
+          ctx.entityManager.registry.materializeReleasedClaim
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            consumerId: `wake-1`,
+            epoch: 7,
+          })
+        )
+        // The entity should transition back to idle so the UI no longer
+        // shows it as "running" after the agent finishes.
+        expect(ctx.entityManager.registry.updateStatus).toHaveBeenCalledWith(
+          `/horton/demo`,
+          `idle`
+        )
+      } finally {
+        vi.mocked(globalThis.fetch).mockRestore()
+      }
+    })
+
+    it(`releases an earlier wake's claim even after a later wake evicted its in-memory token`, async () => {
+      // Same defect, different cause: two wakes for the same entity arrive
+      // close together. The second's mint evicts the first's token. The
+      // first wake's done call then finds stillOwnsClaim=false and skips
+      // the release.
+      const select = selectDb([
+        {
+          callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?service=tenant-a`,
+          primaryStream: `/horton/demo/main`,
+        },
+      ])
+      upstreamOk()
+      const ctx = buildContext({
+        pgDb: { select: select.select } as any,
+      })
+      // Simulate the DB state where consumer-old's row is still active but
+      // entityDispatchState's active claim is consumer-new (the later wake).
+      ;(
+        ctx.entityManager.registry.materializeReleasedClaim as any
+      ).mockResolvedValue({ claim: null, entityCleared: false })
+
+      ctx.runtime.claimWriteTokens.mint(
+        `tenant-a`,
+        `/horton/demo/main`,
+        `wake-1`
+      )
+      // A second wake arrives and re-mints for the same stream, evicting
+      // wake-1 from the in-memory store.
+      ctx.runtime.claimWriteTokens.mint(
+        `tenant-a`,
+        `/horton/demo/main`,
+        `wake-2`
+      )
+
+      try {
+        await globalRouter.fetch(
+          new Request(`http://agents.local/_electric/callback-forward/wake-1`, {
+            method: `POST`,
+            headers: {
+              'content-type': `application/json`,
+              authorization: `Bearer callback-token`,
+            },
+            body: JSON.stringify({
+              epoch: 7,
+              acks: [{ path: `/horton/demo/main`, offset: `1` }],
+              done: true,
+            }),
+          }),
+          ctx
+        )
+
+        // The DB row for wake-1 must still be released.
+        expect(
+          ctx.entityManager.registry.materializeReleasedClaim
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            consumerId: `wake-1`,
+            epoch: 7,
+          })
+        )
+        // But the entity status must NOT be set to idle — wake-2 is still
+        // in flight and owns the entity's active dispatch.
+        expect(ctx.entityManager.registry.updateStatus).not.toHaveBeenCalled()
+      } finally {
+        vi.mocked(globalThis.fetch).mockRestore()
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes #4340 — pull-wake claims leaking in `consumer_claims` when the in-memory `ClaimWriteTokenStore` no longer holds the consumer's token at the time `sendDone` arrives.

The release path in `callback-forward` was gated by `stillOwnsClaim`, an in-memory check. When that check fails — server restart between mint and done, parallel wakes evicting each other's tokens, or a retry after a transient `updateStatus` failure — the entire release block is skipped: `materializeReleasedClaim` never runs, the entity stays stuck at `status='running'`, and the `consumer_claims` row stays `active` indefinitely.

The steady-state "send one message, wait" path is not affected by this bug: it releases correctly via the runtime's `sendDone` after the `idleTimeout` window (default 5 min via `packages/agents/src/bootstrap.ts:146`). The bug only fires in the failure modes documented in [Test scenarios](#test-scenarios) below.

## Root cause

`packages/agents-server/src/routing/internal-router.ts` had all three release actions behind the same in-memory gate:

```ts
if (entity && stillOwnsClaim) {
  await materializeReleasedClaim(...)   // DB row release
  await updateStatus(entity.url, 'idle') // entity status
  clearStream(...)                       // in-memory token cleanup
  await onEntityChanged(entity.url)
} else if (stillOwnsClaim) {
  clearStream(...)
} else if (entity) {
  log.info('done ignored for stale claim ...')
}
```

`stillOwnsClaim` is the right gate for **write authorization** during the agent run, but it's the wrong gate for releasing the **DB row**, which is keyed by `(consumerId, epoch)`. The DB primary key is authoritative identity — the in-memory token state is orthogonal.

## The fix

Three concerns, three gates:

1. **DB row release** (`materializeReleasedClaim`) — runs whenever `epoch` is defined. `(consumerId, epoch)` is the DB primary key; that's enough.
2. **Entity status → idle + `onEntityChanged`** — runs when `entityCleared || stillOwnsClaim`. `entityCleared` is a new return field from `materializeReleasedClaim`, set to `true` only when our `(consumerId, epoch)` was the active dispatch row and we just nulled it out. The `||` handles two non-trivial cases: server restart (DB has us active, token is gone) and retry after a failed `updateStatus` (state cleared on first attempt, token still held).
3. **In-memory token cleanup** (`clearStream`) — remains gated by `stillOwnsClaim` so a newer consumer's token is never cleared out from under it.

### `materializeReleasedClaim` API change

```diff
- ): Promise<ConsumerClaim | null> {
+ ): Promise<{ claim: ConsumerClaim | null; entityCleared: boolean }> {
```

Only one production caller (`internal-router.ts`); both that caller and the test mock are updated. The `.returning()` on the `entityDispatchState` UPDATE now reports whether our row was actually cleared (vs. a no-op because a newer claim is active).

## Test scenarios

The fix decouples the three concerns. Below: ✓ = action happens, × = action does NOT happen (and is correct that it doesn't).

| Scenario | `entityCleared` | `stillOwnsClaim` | DB row released | Entity → idle |
|---|---|---|---|---|
| **A. Happy path** (mint + done) | true | true | ✓ released | ✓ goes idle |
| **B. Server restart** (no in-memory token, DB row still active) | true | false | ✓ released | ✓ goes idle |
| **C. Newer wake** (wake-1 done after wake-2 takes over the stream) | false | false | ✓ wake-1's row released | × stays running — wake-2 is in flight |
| **D. Retry** (first done's `updateStatus` threw; same done retried) | false | true | ✓ no-op (already released) | ✓ goes idle |
| **E. Legacy stale-done test** (test setup never materialized active claim; token evicted) | false | false | no row to release | × stays running — newer claim conceptually in flight |

New tests in `packages/agents-server/test/webhook-forward-routing.test.ts > claim release on done callback (regression for #4340)` cover scenarios A–C. Existing tests in `server-claim-write-token.test.ts` cover D and E and continue to pass after the fix.

## Verified

- **Unit tests**: deterministic. Pre-fix, B and C fail (zero invocations of `materializeReleasedClaim`); D fails (`updateStatus` skipped on retry). Post-fix, all five scenarios produce the documented behavior.
- **Manual run-through** against a local desktop + agents-server: send one message, dispatch claims (`active_count: 0 → 1`), agent completes, runtime calls `sendDone` after `idleTimeout`, server fires the new release path, `active_count: 1 → 0`, entity status transitions back to `idle`.

## Not addressed in this PR

- **Pre-existing orphan rows**: rows that already leaked from prior runs of the unfixed code can't be released because no fresh `done` callback is coming. Would need a reaper job or admin command.
- **`lease_expires_at: null` issue (#4341)**: independent. Without a lease, even a reaper job can't time-out claims safely.

## Base branch note

This PR targets `fix-pull-wake` (#4339), not `main`, because `materializeReleasedClaim` was introduced in #4308 which is part of the `fix-pull-wake` lineage but not yet in `main`. Merge order: this → fix-pull-wake → main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)