### PR TITLE
fix(sync-service): array cast assigns element type instead of array type

### DIFF
--- a/.changeset/fix-array-cast-type-wrapper.md
+++ b/.changeset/fix-array-cast-type-wrapper.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Fix `@>` (and other array operators) returning 400 when the right-hand side uses a non-foldable `ARRAY[...]::T[]` outer cast, e.g. `"organization_ids" @> ARRAY[$1]::uuid[]` with a column or parameter inside the constructor. The where-clause parser was assigning the element type (`:uuid`) instead of the array type (`{:array, :uuid}`) to array-cast and array-implicit-cast functions, which made the `@>` operator overload lookup fail with `Could not select an operator overload`.

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -1055,7 +1055,7 @@ defmodule Electric.Replication.Eval.Parser do
       bool_array =
         concrete
         |> from_concrete([lexpr, rexpr])
-        |> Map.put(:map_over_array_in_pos, 1)
+        |> Map.merge(%{map_over_array_in_pos: 1, type: {:array, :bool}})
 
       {name, impl} =
         case expr.kind do
@@ -1272,7 +1272,7 @@ defmodule Electric.Replication.Eval.Parser do
         {:ok,
          %Func{
            location: loc,
-           type: extract_base_type_name(target_type),
+           type: target_type,
            args: [arg],
            implementation: impl,
            map_over_array_in_pos: 0,
@@ -1350,7 +1350,7 @@ defmodule Electric.Replication.Eval.Parser do
            impl ->
              %Func{
                location: arg.location,
-               type: to_type,
+               type: {:array, to_type},
                args: [arg],
                implementation: impl,
                name: "#{from_type}_to_#{to_type}",
@@ -1579,7 +1579,7 @@ defmodule Electric.Replication.Eval.Parser do
     {:ok,
      %Const{
        value: value,
-       type: if(not is_nil(map_over_array_in_pos), do: {:array, func.type}, else: func.type),
+       type: func.type,
        location: func.location
      }}
   rescue

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -1088,5 +1088,10 @@ defmodule Electric.Replication.Eval.ParserTest do
                  sublink_queries: %{0 => ~S|SELECT value FROM project WHERE value > '5'::int4|}
                )
     end
+
+    test "outer `::T[]` cast on a non-foldable ARRAY constructor reports an array return type" do
+      assert {:ok, %Expr{returns: {:array, :uuid}}} =
+               Parser.parse_and_validate_expression(~S|ARRAY[v]::uuid[]|, refs: %{["v"] => :text})
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Where clauses like `"organization_ids" @> ARRAY[$1]::uuid[]` return HTTP 400 (`Could not select an operator overload`) whenever the inner `ARRAY[...]` constructor contains a non-foldable element (a column ref, or a parameter inside a sub-expression that the parser can't reduce ahead of the outer cast).
- Root cause is in `Electric.Replication.Eval.Parser.as_dynamic_cast/3`: the `:array_cast` branch built a `Func` with `type: extract_base_type_name(target_type)` plus `map_over_array_in_pos: 0`. So for target `{:array, :uuid}` it stored `.type = :uuid` while the runtime value is still an array — and the operator-overload lookup (`Lookups.pick_concrete_operator_overload/3`) reads `.type` literally, can't match `anyarray @> anyarray`, and the API surfaces a 400. `cast_implicit/3` and the ANY/ALL builder set the same misleading scalar type, and `try_applying/1` had a wrap-in-`{:array, _}` kludge at line 1582 to paper over it.

This PR changes the convention so `Func.type` always reflects the runtime type of the value the Func produces:
- `as_dynamic_cast/3` `:array_cast` branch now keeps the full target array type.
- `cast_implicit/3` array branch now stores `{:array, to_type}`.
- `handle_any_or_all/2`'s `bool_array` now stores `{:array, :bool}`.
- `try_applying/1` drops the conditional wrap.

The bug stayed hidden for the all-constant case because `do_maybe_reduce/1` folds `ARRAY[Const, ...]` into a `Const{type: {:array, T}, value: [...]}` before the outer cast runs; the parser test added in this PR uses a column ref to keep the Array unreduced and exposes the mis-typed Func directly.

## Test plan
- [x] `mix test packages/sync-service/test/electric/replication/eval/parser_test.exs` — 85 tests, including the new minimal assertion at `parser_test.exs:1092`
- [x] `mix test packages/sync-service/test/electric/replication/eval/` — 227 tests + 6 properties + 3 doctests, 0 failures
- [x] `mix test packages/sync-service/test/electric/shapes/filter_test.exs` — 135 tests, 0 failures (covers `array_field @> const_array` inclusion-index optimisation)
- [x] `mix test packages/sync-service/test/electric/shapes/querying_test.exs` — 28 tests, 0 failures
- [x] CI green