### PR TITLE
feat(ci): dispatch agents-server release updates to Stratovolt

### DIFF
--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -89,6 +89,32 @@ jobs:
     with:
       git_ref: ${{ needs.changesets.outputs.agent_server_release_tag }}
 
+  update-cloud-agents-server:
+    name: Update Agents Server version used by Cloud
+    runs-on: ubuntu-latest
+    needs: changesets
+    if: ${{ needs.changesets.outputs.published == 'true' && needs.changesets.outputs.agent_server_release_tag != '' }}
+    steps:
+      - name: Get Agents Server version
+        id: agents_server
+        run: |
+          RELEASE_TAG='${{ needs.changesets.outputs.agent_server_release_tag }}'
+          VERSION="${RELEASE_TAG##*@}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger cloud agents server update
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CROSSREPO_PAT }}
+          repository: electric-sql/stratovolt
+          event-type: update-agents-server
+          client-payload: |
+            {
+              "electric_commit_sha": "${{ github.sha }}",
+              "agents_server_release_tag": "${{ needs.changesets.outputs.agent_server_release_tag }}",
+              "agents_server_version": "${{ steps.agents_server.outputs.version }}"
+            }
+
   update-cloud:
     name: Update Electric version used by Cloud
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

Stratovolt's `packages/cloud-agents-server` pins `@electric-ax/agents-server`, but Electric only had automation for updating the sync-service dependency in Stratovolt. When `@electric-ax/agents-server` is published from Changesets, Stratovolt should receive a targeted update signal instead of relying on manual dependency bumps.

## Changes

- Add an `update-cloud-agents-server` job to the Changesets release workflow.
- Gate the job on a successful Changesets publish that includes `@electric-ax/agents-server`.
- Extract the published package version from the existing `agent_server_release_tag` output.
- Dispatch `update-agents-server` to `electric-sql/stratovolt` with the Electric commit SHA, release tag, and package version.

## Notes

This is paired with the Stratovolt workflow that receives `update-agents-server` and opens the dependency bump PR for `packages/cloud-agents-server`.

No changeset is included because this only changes GitHub Actions automation and does not alter a published package.
