### PR TITLE
fix(agents-server): preserve consumer_claims.lease_expires_at across heartbeats

### DIFF
--- a/.changeset/preserve-lease-on-heartbeat.md
+++ b/.changeset/preserve-lease-on-heartbeat.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server': patch
+---
+
+Fix `materializeHeartbeatClaim` nulling out `consumer_claims.lease_expires_at` when called without a lease argument. The heartbeat path is now an alive-ping only — it updates `last_heartbeat_at` and leaves the lease (set at claim materialization time from the upstream `lease_ttl_ms`) intact. Callers that genuinely want to extend the lease can still pass `leaseExpiresAt` explicitly.

--- a/packages/agents-server/src/entity-registry.ts
+++ b/packages/agents-server/src/entity-registry.ts
@@ -360,11 +360,17 @@ export class PostgresRegistry {
     input: MaterializeHeartbeatClaimInput
   ): Promise<void> {
     const heartbeatAt = input.heartbeatAt ?? new Date()
+    // Only touch leaseExpiresAt when the caller explicitly provides one.
+    // The lease was set at materializeActiveClaim time from the upstream
+    // lease_ttl_ms and remains the authoritative expiry; heartbeats are
+    // alive-pings, not lease extensions.
     await this.db
       .update(consumerClaims)
       .set({
         lastHeartbeatAt: heartbeatAt,
-        leaseExpiresAt: input.leaseExpiresAt ?? null,
+        ...(input.leaseExpiresAt !== undefined
+          ? { leaseExpiresAt: input.leaseExpiresAt }
+          : {}),
         updatedAt: heartbeatAt,
       })
       .where(

--- a/packages/agents-server/test/consumer-claim-registry.test.ts
+++ b/packages/agents-server/test/consumer-claim-registry.test.ts
@@ -1,0 +1,97 @@
+import { and, eq } from 'drizzle-orm'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { createDb } from '../src/db/index'
+import { consumerClaims } from '../src/db/schema'
+import { PostgresRegistry } from '../src/entity-registry'
+import {
+  TEST_POSTGRES_URL,
+  resetElectricAgentsTestBackend,
+} from './test-backend'
+
+describe(`PostgresRegistry consumer-claim heartbeat (regression for #4341)`, () => {
+  let registry: PostgresRegistry
+  let db: ReturnType<typeof createDb>[`db`]
+  let client: ReturnType<typeof createDb>[`client`]
+
+  beforeAll(async () => {
+    await resetElectricAgentsTestBackend()
+    const connection = createDb(TEST_POSTGRES_URL)
+    db = connection.db
+    client = connection.client
+    registry = new PostgresRegistry(db)
+  }, 120_000)
+
+  beforeEach(async () => {
+    await resetElectricAgentsTestBackend()
+  }, 120_000)
+
+  afterAll(async () => {
+    await client?.end()
+  }, 120_000)
+
+  async function readLease(
+    consumerId: string,
+    epoch: number
+  ): Promise<Date | null> {
+    const rows = await db
+      .select()
+      .from(consumerClaims)
+      .where(
+        and(
+          eq(consumerClaims.consumerId, consumerId),
+          eq(consumerClaims.epoch, epoch)
+        )
+      )
+      .limit(1)
+    return rows[0]?.leaseExpiresAt ?? null
+  }
+
+  it(`preserves lease_expires_at when heartbeat is called without one`, async () => {
+    const claimedAt = new Date(`2026-05-19T10:00:00Z`)
+    const lease = new Date(`2026-05-19T10:00:30Z`)
+    await registry.materializeActiveClaim({
+      consumerId: `wake-preserve`,
+      epoch: 1,
+      entityUrl: `/horton/preserve`,
+      streamPath: `/horton/preserve/main`,
+      claimedAt,
+      leaseExpiresAt: lease,
+    })
+
+    expect(await readLease(`wake-preserve`, 1)).toEqual(lease)
+
+    // Heartbeat with no leaseExpiresAt — must not null the column.
+    await registry.materializeHeartbeatClaim({
+      consumerId: `wake-preserve`,
+      epoch: 1,
+      heartbeatAt: new Date(`2026-05-19T10:00:10Z`),
+    })
+
+    expect(await readLease(`wake-preserve`, 1)).toEqual(lease)
+  })
+
+  it(`updates lease_expires_at when heartbeat explicitly provides one`, async () => {
+    const claimedAt = new Date(`2026-05-19T10:00:00Z`)
+    const initialLease = new Date(`2026-05-19T10:00:30Z`)
+    const extendedLease = new Date(`2026-05-19T10:01:00Z`)
+    await registry.materializeActiveClaim({
+      consumerId: `wake-extend`,
+      epoch: 1,
+      entityUrl: `/horton/extend`,
+      streamPath: `/horton/extend/main`,
+      claimedAt,
+      leaseExpiresAt: initialLease,
+    })
+
+    expect(await readLease(`wake-extend`, 1)).toEqual(initialLease)
+
+    await registry.materializeHeartbeatClaim({
+      consumerId: `wake-extend`,
+      epoch: 1,
+      heartbeatAt: new Date(`2026-05-19T10:00:20Z`),
+      leaseExpiresAt: extendedLease,
+    })
+
+    expect(await readLease(`wake-extend`, 1)).toEqual(extendedLease)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #4341 — the per-wake heartbeat path nulls out `consumer_claims.lease_expires_at`, leaving every active claim row without an expiry after the first heartbeat (~10s after dispatch).

## Root cause

`packages/agents-server/src/entity-registry.ts` — `materializeHeartbeatClaim`:

```ts
.set({
  lastHeartbeatAt: heartbeatAt,
  leaseExpiresAt: input.leaseExpiresAt ?? null,  // ← unconditionally writes null if not provided
  updatedAt: heartbeatAt,
})
```

`packages/agents-server/src/routing/internal-router.ts:606-609` — the only production caller — never passes `leaseExpiresAt`. So every heartbeat overwrites the lease with `null`. The lease set correctly by `materializeActiveClaim` (from the upstream `lease_ttl_ms`, e.g. claimed_at + 30s) survives at most until the first heartbeat.

## Observed live

```
Initial (at claim):  lease_expires_at = 2026-05-19T11:01:41.631Z   (claimed_at + 30s)
After 1 heartbeat:   lease_expires_at = null
```

Captured via the health endpoint `claims.active[*]` field — issue #4341 has the full trace.

## The fix

Treat heartbeats as alive-pings only: update `last_heartbeat_at` and leave `lease_expires_at` alone unless the caller explicitly provides a new lease. The lease set by `materializeActiveClaim` from the upstream `lease_ttl_ms` stays authoritative.

```diff
 .set({
   lastHeartbeatAt: heartbeatAt,
-  leaseExpiresAt: input.leaseExpiresAt ?? null,
+  ...(input.leaseExpiresAt !== undefined
+    ? { leaseExpiresAt: input.leaseExpiresAt }
+    : {}),
   updatedAt: heartbeatAt,
 })
```

Callers that genuinely want to extend the lease can still pass `leaseExpiresAt` explicitly. The single production caller (`internal-router.ts:606-609`) doesn't, and shouldn't — it has no TTL signal to base an extension on, and the upstream lease is the authoritative window.

## Tests

New integration test `packages/agents-server/test/consumer-claim-registry.test.ts`:

1. **Lease preserved** — materialize an active claim with a lease, heartbeat without a lease, assert lease is still the original timestamp (not null).
2. **Lease extendable** — materialize, heartbeat with an explicit `leaseExpiresAt`, assert the new lease is written.

Both run against the integration postgres backend, in the style of `tag-stream-outbox-registry.test.ts`.

Existing unit tests pass unchanged.

## Not addressed in this PR

- **Pre-existing claim rows with `lease_expires_at: null`** — claims that already lost their lease under the unfixed code won't recover. They'd need a reaper or admin command to clean up. Not currently a problem because nothing reaps on lease today, but worth knowing if a reaper is added later.

## Base branch note

This PR targets `fix-pull-wake` (#4339), not `main`, because `materializeHeartbeatClaim` was introduced in #4308 which is part of the `fix-pull-wake` lineage but not yet in `main`. Merge order: this → fix-pull-wake → main. Independent of #4346 (the related #4340 fix); the two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
