### PR TITLE
test(agents): characterize bash/read/write/edit/fetch_url + Horton composition

### DIFF
--- a/packages/agents-runtime/test/bash-tool.test.ts
+++ b/packages/agents-runtime/test/bash-tool.test.ts
@@ -27,4 +27,34 @@ describe(`bash tool`, () => {
       .split(`\n`)
     expect(lines).toEqual([await realpath(cwd), process.env.HOME ?? homedir()])
   })
+
+  // Characterization: the bash tool currently passes `env: { ...process.env }`
+  // wholesale to spawned children (`bash.ts:23`). The two tests below capture
+  // that behavior so the env-scrubbing change planned for a follow-up PR has
+  // an explicit regression target.
+  it(`leaks the parent PATH into the child process (no env scrubbing)`, async () => {
+    const tool = createBashTool(cwd)
+    const result = await tool.execute(`call-path`, {
+      command: `printf '%s' "$PATH"`,
+    })
+    expect((result.content[0] as { text: string }).text).toBe(
+      process.env.PATH ?? ``
+    )
+  })
+
+  it(`leaks an ANTHROPIC_API_KEY-style env var to the child process`, async () => {
+    const sentinel = `sk-test-bash-leak-${Date.now()}`
+    const prev = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = sentinel
+    try {
+      const tool = createBashTool(cwd)
+      const result = await tool.execute(`call-key`, {
+        command: `printf '%s' "$ANTHROPIC_API_KEY"`,
+      })
+      expect((result.content[0] as { text: string }).text).toBe(sentinel)
+    } finally {
+      if (prev === undefined) delete process.env.ANTHROPIC_API_KEY
+      else process.env.ANTHROPIC_API_KEY = prev
+    }
+  })
 })

--- a/packages/agents-runtime/test/fetch-url-ssrf.test.ts
+++ b/packages/agents-runtime/test/fetch-url-ssrf.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createFetchUrlTool } from '../src/tools/fetch-url'
+
+// Characterization: createFetchUrlTool today has no host policy — no
+// allowlist, no private-IP denylist, no cloud-metadata IP filter. The tests
+// below capture that surface so a follow-up SSRF-hardening PR has an explicit
+// regression target.
+describe(`fetch_url — current SSRF surface`, () => {
+  const originalFetch = globalThis.fetch
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(`ok`, {
+          status: 200,
+          headers: { 'content-type': `text/plain` },
+        })
+    )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it.each([
+    `http://169.254.169.254/latest/meta-data/`, // AWS / GCP metadata IP
+    `http://127.0.0.1:8080/`, // loopback
+    `http://10.0.0.1/`, // RFC1918
+    `http://192.168.1.1/`, // RFC1918
+  ])(`fetches %s without rejecting it`, async (url) => {
+    const tool = createFetchUrlTool({ extractWithLLM: async (t) => t })
+    const result = await tool.execute(`call`, {
+      url,
+      prompt: `extract content`,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(url)
+    // The tool returns the extracted content, not an SSRF guard error.
+    expect((result.content[0] as { text: string }).text).toBe(`ok`)
+  })
+
+  it(`follows redirects (redirect: 'follow') — DNS-rebinding / redirect-to-private not blocked`, async () => {
+    const tool = createFetchUrlTool({ extractWithLLM: async (t) => t })
+    await tool.execute(`call`, {
+      url: `http://example.com/`,
+      prompt: `extract`,
+    })
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(init?.redirect).toBe(`follow`)
+  })
+})

--- a/packages/agents-runtime/test/tool-path-symlink.test.ts
+++ b/packages/agents-runtime/test/tool-path-symlink.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createEditTool } from '../src/tools/edit'
+import { createReadFileTool } from '../src/tools/read-file'
+import { createWriteTool } from '../src/tools/write'
+
+// Characterization: read/write/edit guard the working directory using a
+// path-prefix check (resolve + relative + startsWith('..')) but do NOT call
+// `realpath`, so a symlink inside the working directory that points outside
+// is followed transparently — CVE-2025-53109/53110 class bypass. A follow-up
+// PR will add realpath resolution; update these expectations when it lands.
+describe(`tool path traversal — current symlink behavior`, () => {
+  let cwd: string
+  let outside: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), `path-symlink-`))
+    outside = await mkdtemp(join(tmpdir(), `path-outside-`))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+    await rm(outside, { recursive: true, force: true })
+  })
+
+  it(`read: ".." escape is rejected by the prefix check`, async () => {
+    const tool = createReadFileTool(cwd)
+    const result = await tool.execute(`r-dotdot`, { path: `../escape.txt` })
+    expect((result.content[0] as { text: string }).text).toMatch(
+      /outside the working directory/
+    )
+  })
+
+  it(`read: symlink inside cwd pointing outside currently succeeds`, async () => {
+    const secret = join(outside, `secret.txt`)
+    await writeFile(secret, `secret data`, `utf-8`)
+    await symlink(secret, join(cwd, `link.txt`))
+    const tool = createReadFileTool(cwd)
+    const result = await tool.execute(`r-link`, { path: `link.txt` })
+    expect((result.content[0] as { text: string }).text).toBe(`secret data`)
+  })
+
+  it(`write: ".." escape is rejected by the prefix check`, async () => {
+    const tool = createWriteTool(cwd)
+    const result = await tool.execute(`w-dotdot`, {
+      path: `../escape.txt`,
+      content: `nope`,
+    })
+    expect((result.content[0] as { text: string }).text).toMatch(
+      /outside the working directory/
+    )
+  })
+
+  it(`write: symlink inside cwd pointing outside currently clobbers the target`, async () => {
+    const target = join(outside, `target.txt`)
+    await writeFile(target, `original`, `utf-8`)
+    await symlink(target, join(cwd, `link.txt`))
+    const tool = createWriteTool(cwd)
+    const result = await tool.execute(`w-link`, {
+      path: `link.txt`,
+      content: `clobbered`,
+    })
+    expect(result.details).toMatchObject({ bytesWritten: 9 })
+    expect(await readFile(target, `utf-8`)).toBe(`clobbered`)
+  })
+
+  it(`edit: ".." escape is rejected by the prefix check`, async () => {
+    const tool = createEditTool(cwd, new Set())
+    const result = await tool.execute(`e-dotdot`, {
+      path: `../escape.txt`,
+      old_string: `a`,
+      new_string: `b`,
+    })
+    expect((result.content[0] as { text: string }).text).toMatch(
+      /outside the working directory/
+    )
+  })
+
+  it(`edit: symlink inside cwd pointing outside currently edits through the link`, async () => {
+    const target = join(outside, `t.txt`)
+    await writeFile(target, `hello world`, `utf-8`)
+    const linkPath = join(cwd, `link.txt`)
+    await symlink(target, linkPath)
+    // The edit tool requires the file to be in readSet; populate it with the
+    // resolved path the tool would compute. This mirrors what read would have
+    // done in the same session.
+    const tool = createEditTool(cwd, new Set([linkPath]))
+    const result = await tool.execute(`e-link`, {
+      path: `link.txt`,
+      old_string: `world`,
+      new_string: `there`,
+    })
+    expect(result.details).toMatchObject({ replacements: 1 })
+    expect(await readFile(target, `utf-8`)).toBe(`hello there`)
+  })
+})

--- a/packages/agents/test/horton-tool-composition.test.ts
+++ b/packages/agents/test/horton-tool-composition.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createEntityRegistry } from '@electric-ax/agents-runtime'
+import {
+  isMcpToolsSentinel,
+  type McpToolsSentinel,
+} from '@electric-ax/agents-mcp'
+import { registerHorton } from '../src/agents/horton'
+import type { BuiltinModelCatalog } from '../src/model-catalog'
+
+const modelCatalog: BuiltinModelCatalog = {
+  defaultChoice: {
+    provider: `anthropic`,
+    id: `claude-sonnet-4-6`,
+    label: `Anthropic Claude Sonnet 4.6`,
+    value: `anthropic:claude-sonnet-4-6`,
+    reasoning: true,
+  },
+  choices: [
+    {
+      provider: `anthropic`,
+      id: `claude-sonnet-4-6`,
+      label: `Anthropic Claude Sonnet 4.6`,
+      value: `anthropic:claude-sonnet-4-6`,
+      reasoning: true,
+    },
+  ],
+}
+
+// Characterization: Horton today builds a fixed built-in toolset and
+// unconditionally appends `...mcp.tools()` — every registered MCP server,
+// no allowlist (`horton.ts:396`). The tests below capture that composition
+// so a follow-up PR can flip MCP to an opt-in allowlist with a one-line
+// expectation change.
+async function captureToolset(args: Record<string, unknown> = {}) {
+  const registry = createEntityRegistry()
+  registerHorton(registry, { workingDirectory: `/tmp`, modelCatalog })
+  const useAgent = vi.fn(() => ({ run: vi.fn(async () => {}) }))
+  const fakeCtx = {
+    args,
+    electricTools: [],
+    events: [],
+    firstWake: false,
+    tags: {},
+    db: { collections: { inbox: { toArray: [] } } },
+    useContext: vi.fn(),
+    useAgent,
+    agent: { run: vi.fn(async () => {}) },
+  } as any
+  await registry
+    .get(`horton`)!
+    .definition.handler(fakeCtx, { type: `inbox` } as any)
+  expect(useAgent).toHaveBeenCalledTimes(1)
+  const cfg = (
+    useAgent.mock.calls as unknown as Array<[{ tools: Array<unknown> }]>
+  )[0]![0]
+  return cfg.tools
+}
+
+describe(`horton tool composition`, () => {
+  it(`includes the default built-in toolset`, async () => {
+    const tools = await captureToolset()
+    const names = tools
+      .filter((t) => !isMcpToolsSentinel(t))
+      .map((t) => (t as { name: string }).name)
+    expect(names).toEqual(
+      expect.arrayContaining([
+        `bash`,
+        `read`,
+        `write`,
+        `edit`,
+        `web_search`,
+        `fetch_url`,
+        `spawn_worker`,
+      ])
+    )
+  })
+
+  it(`appends an unconditional MCP tools sentinel with no allowlist`, async () => {
+    const tools = await captureToolset()
+    const sentinels = tools.filter(isMcpToolsSentinel) as McpToolsSentinel[]
+    expect(sentinels).toHaveLength(1)
+    expect(sentinels[0]!.allowlist).toBeUndefined()
+  })
+
+  it(`MCP sentinel is present regardless of args`, async () => {
+    const withArgs = await captureToolset({
+      model: `anthropic:claude-sonnet-4-6`,
+    })
+    expect(withArgs.some(isMcpToolsSentinel)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Characterization tests (Feathers' term) for the runtime tool surface targeted by the security cleanup tracked in `plans/sandboxing-investigation.md`. These assert **what the code does today, including the broken parts**, so each follow-up fix lands as a one-line expectation change rather than as new test infrastructure.

This is PR 0 of a five-PR series. It is intentionally inert: no production code changes, no new test scaffolding, just additional vitest cases reusing the existing per-tool test idioms.

## What's captured

- **bash** (`bash-tool.test.ts`) — parent `PATH` and `ANTHROPIC_API_KEY` pass through to the spawned child (env scrubbing missing at `bash.ts:23`).
- **read / write / edit** (`tool-path-symlink.test.ts`) — `..` escape rejected by the prefix check, but a symlink inside cwd pointing outside is followed transparently because no `realpath` is called.
- **fetch_url** (`fetch-url-ssrf.test.ts`) — loopback, RFC1918, and `169.254.169.254` are all fetchable; `redirect: 'follow'` is unconditional. Uses a `globalThis.fetch` spy + injected `extractWithLLM` identity — no network, no flakes.
- **Horton composition** (`horton-tool-composition.test.ts`) — invokes the handler with a mocked `useAgent` (same pattern as `horton-model-selection.test.ts`) and asserts the built-in toolset is present and `...mcp.tools()` is unconditionally appended with no allowlist (`horton.ts:396`).

## Scoping notes

- Plain vitest tests inside the existing per-package `test/` directories — not the conformance-test harness, which models server protocol rather than per-`useAgent` tool composition.
- No production code changes. No new test infrastructure.
- All currently-broken behaviors are asserted *as-is*; comments at the top of each file flag what the upcoming PR will change.

## Test plan

- [x] `pnpm test` passes in `packages/agents-runtime` (442/442)
- [x] `pnpm test` passes in `packages/agents` (67/67)
- [x] `pnpm typecheck` clean in both packages
- [x] `pnpm stylecheck` clean in both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)