### PR TITLE
fix(agents-server): apply routing adapter to subscription paths

### DIFF
--- a/.changeset/agents-server-subscription-routing.md
+++ b/.changeset/agents-server-subscription-routing.md
@@ -4,6 +4,12 @@
 
 Fix webhook dispatch never firing for service-prefixed durable-streams deployments.
 
-`StreamClient` now accepts an optional `routing: { serviceId, adapter }` option that applies the `DurableStreamsRoutingAdapter` to subscription path payloads (patterns, stream paths, `wake_stream`, ack/release stream/path fields) and the inverse transform to response payloads. `AgentsHostTenantConfig` gains a `durableStreamsRouting` field that plumbs the adapter through to the per-tenant `StreamClient`.
+`StreamClient` now accepts an optional `subscriptionRouting: { serviceId, adapter }` option that applies the `DurableStreamsRoutingAdapter` to subscription path payloads (patterns, stream paths, `wake_stream`, ack/release `stream`/`path` fields) and the inverse transform to response payloads. `AgentsHostTenantConfig` gains a `durableStreamsRouting` field that plumbs the adapter through to the per-tenant `StreamClient`.
 
-Cloud / service-routed durable-streams deployments key appends on a service-prefixed backend path (`<serviceId>/<path>`), so subscriptions previously registered with the un-prefixed path never matched the HotBuffer lookup and webhook fanout silently dropped. Pull-wake dispatch was unaffected because it writes to an explicit `wake_stream` rather than relying on HotBuffer fanout. Tenant-root deployments are unaffected (no routing option passed → behavior unchanged).
+`dispatch-policy.subscriptionHasStream` now consults `ctx.durableStreamsRouting` to compute the backend-namespace comparison instead of hardcoding `${ctx.service}/${path}`, so adapters with non-trivial backend conventions are honoured.
+
+Cloud / service-routed durable-streams deployments key appends on a service-prefixed backend path (`<serviceId>/<path>`), so subscriptions previously registered with the un-prefixed path never matched the HotBuffer lookup and webhook fanout silently dropped. Pull-wake dispatch was unaffected because it writes to an explicit `wake_stream` rather than relying on HotBuffer fanout. Tenant-root deployments are unaffected (no routing option passed → behaviour unchanged, bit-identical to the prior slash-normalising code).
+
+The `DurableStreamsRoutingAdapter` interface now documents that `toBackendStreamPath` / `toRuntimeStreamPath` MUST be idempotent and side-effect free; subscription payloads round-trip through `toBackendStreamPath` on every refresh and an unconditionally-prefixing adapter would cause runaway double-prefixing across `getSubscription` → `addSubscriptionStreams` cycles.
+
+**Migration note:** webhook subscriptions persisted before this fix have un-prefixed `streams` entries on disk. They are not auto-healed: those subscriptions were already silently dropping every webhook event (the bug this PR fixes), so the only useful operator action is to delete and recreate any affected webhook subscription after upgrading. Pre-fix pull-wake subscriptions are unaffected.

--- a/.changeset/agents-server-subscription-routing.md
+++ b/.changeset/agents-server-subscription-routing.md
@@ -1,0 +1,9 @@
+---
+"@electric-ax/agents-server": patch
+---
+
+Fix webhook dispatch never firing for service-prefixed durable-streams deployments.
+
+`StreamClient` now accepts an optional `routing: { serviceId, adapter }` option that applies the `DurableStreamsRoutingAdapter` to subscription path payloads (patterns, stream paths, `wake_stream`, ack/release stream/path fields) and the inverse transform to response payloads. `AgentsHostTenantConfig` gains a `durableStreamsRouting` field that plumbs the adapter through to the per-tenant `StreamClient`.
+
+Cloud / service-routed durable-streams deployments key appends on a service-prefixed backend path (`<serviceId>/<path>`), so subscriptions previously registered with the un-prefixed path never matched the HotBuffer lookup and webhook fanout silently dropped. Pull-wake dispatch was unaffected because it writes to an explicit `wake_stream` rather than relying on HotBuffer fanout. Tenant-root deployments are unaffected (no routing option passed → behavior unchanged).

--- a/packages/agents-server/src/host.ts
+++ b/packages/agents-server/src/host.ts
@@ -325,7 +325,7 @@ export class AgentsHost {
         bearer: config.durableStreamsBearer,
         ...(config.durableStreamsRouting
           ? {
-              routing: {
+              subscriptionRouting: {
                 serviceId: config.serviceId,
                 adapter: config.durableStreamsRouting,
               },

--- a/packages/agents-server/src/host.ts
+++ b/packages/agents-server/src/host.ts
@@ -15,12 +15,6 @@ export interface AgentsHostTenantConfig {
   serviceId: string
   durableStreamsUrl?: string
   durableStreamsBearer?: DurableStreamsBearerProvider
-  /**
-   * Routing adapter applied to subscription path payloads so they match the
-   * backend stream-path namespace used for appends. Required for cloud /
-   * service-routed durable-streams deployments where appends are keyed on a
-   * service-prefixed path; safe to omit for tenant-root deployments.
-   */
   durableStreamsRouting?: DurableStreamsRoutingAdapter
   streamClient?: StreamClient
 }

--- a/packages/agents-server/src/host.ts
+++ b/packages/agents-server/src/host.ts
@@ -9,11 +9,19 @@ import { DEFAULT_TENANT_ID, UnregisteredTenantError } from './tenant.js'
 import { WakeRegistry } from './wake-registry.js'
 import type { DrizzleDB, PgClient } from './db/index.js'
 import type { DurableStreamsBearerProvider } from './stream-client.js'
+import type { DurableStreamsRoutingAdapter } from './routing/durable-streams-routing-adapter.js'
 
 export interface AgentsHostTenantConfig {
   serviceId: string
   durableStreamsUrl?: string
   durableStreamsBearer?: DurableStreamsBearerProvider
+  /**
+   * Routing adapter applied to subscription path payloads so they match the
+   * backend stream-path namespace used for appends. Required for cloud /
+   * service-routed durable-streams deployments where appends are keyed on a
+   * service-prefixed path; safe to omit for tenant-root deployments.
+   */
+  durableStreamsRouting?: DurableStreamsRoutingAdapter
   streamClient?: StreamClient
 }
 
@@ -315,6 +323,14 @@ export class AgentsHost {
     if (config.durableStreamsUrl) {
       return new StreamClient(config.durableStreamsUrl, {
         bearer: config.durableStreamsBearer,
+        ...(config.durableStreamsRouting
+          ? {
+              routing: {
+                serviceId: config.serviceId,
+                adapter: config.durableStreamsRouting,
+              },
+            }
+          : {}),
       })
     }
     throw new Error(

--- a/packages/agents-server/src/index.ts
+++ b/packages/agents-server/src/index.ts
@@ -10,6 +10,7 @@ export { StreamClient } from './stream-client.js'
 export type {
   DurableStreamsBearerProvider,
   StreamClientOptions,
+  StreamClientSubscriptionRouting,
   SubscriptionClaimResponse,
   SubscriptionCreateInput,
   SubscriptionResponse,

--- a/packages/agents-server/src/routing/dispatch-policy.ts
+++ b/packages/agents-server/src/routing/dispatch-policy.ts
@@ -119,7 +119,17 @@ function subscriptionHasStream(
   streamPath: string
 ): boolean {
   const normalizedStream = streamPath.replace(/^\/+/, ``)
-  const backendStream = `${ctx.service}/${normalizedStream}`
+  // Defence-in-depth: `StreamClient.subscriptionResponseBody` already maps
+  // server-returned paths back to the runtime namespace when an adapter is
+  // configured, so `existing.streams` should be runtime-namespaced. The
+  // backend-namespace comparison below catches cases where the response did
+  // not pass through the adapter (custom `streamClient`, older deployments,
+  // etc.) and also makes the intent of the comparison explicit.
+  const backendStream =
+    ctx.durableStreamsRouting?.toBackendStreamPath(
+      ctx.service,
+      normalizedStream
+    ) ?? normalizedStream
   return (
     existing.streams?.some((stream) => {
       const path = typeof stream === `string` ? stream : stream.path

--- a/packages/agents-server/src/routing/dispatch-policy.ts
+++ b/packages/agents-server/src/routing/dispatch-policy.ts
@@ -119,12 +119,6 @@ function subscriptionHasStream(
   streamPath: string
 ): boolean {
   const normalizedStream = streamPath.replace(/^\/+/, ``)
-  // Defence-in-depth: `StreamClient.subscriptionResponseBody` already maps
-  // server-returned paths back to the runtime namespace when an adapter is
-  // configured, so `existing.streams` should be runtime-namespaced. The
-  // backend-namespace comparison below catches cases where the response did
-  // not pass through the adapter (custom `streamClient`, older deployments,
-  // etc.) and also makes the intent of the comparison explicit.
   const backendStream =
     ctx.durableStreamsRouting?.toBackendStreamPath(
       ctx.service,

--- a/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
+++ b/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
@@ -7,7 +7,27 @@ export interface DurableStreamsRoutingInput {
 export interface DurableStreamsRoutingAdapter {
   streamUrl(input: DurableStreamsRoutingInput): URL
   controlUrl(input: DurableStreamsRoutingInput): URL
+  /**
+   * Map a runtime-namespace stream path to the backend (durable-streams
+   * worker) namespace under which it is stored / keyed.
+   *
+   * **Required to be idempotent:** if `streamPath` is already in the backend
+   * namespace, the implementation MUST return it unchanged. Subscription
+   * payloads round-trip through `toBackendStreamPath` whenever they are
+   * written or refreshed, so an adapter that unconditionally prefixes will
+   * cause runaway double-prefixing across `getSubscription` →
+   * `addSubscriptionStreams` cycles.
+   *
+   * Implementations should also be deterministic, side-effect free, and must
+   * not throw — exceptions surface inside subscription ack / release paths
+   * where they can cause re-dispatch storms.
+   */
   toBackendStreamPath(serviceId: string, streamPath: string): string
+  /**
+   * Inverse of `toBackendStreamPath`. Strip the backend transform so callers
+   * can reason in the runtime namespace. Must be idempotent for paths
+   * already in the runtime namespace.
+   */
   toRuntimeStreamPath(serviceId: string, streamPath: string): string
 }
 

--- a/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
+++ b/packages/agents-server/src/routing/durable-streams-routing-adapter.ts
@@ -7,27 +7,10 @@ export interface DurableStreamsRoutingInput {
 export interface DurableStreamsRoutingAdapter {
   streamUrl(input: DurableStreamsRoutingInput): URL
   controlUrl(input: DurableStreamsRoutingInput): URL
-  /**
-   * Map a runtime-namespace stream path to the backend (durable-streams
-   * worker) namespace under which it is stored / keyed.
-   *
-   * **Required to be idempotent:** if `streamPath` is already in the backend
-   * namespace, the implementation MUST return it unchanged. Subscription
-   * payloads round-trip through `toBackendStreamPath` whenever they are
-   * written or refreshed, so an adapter that unconditionally prefixes will
-   * cause runaway double-prefixing across `getSubscription` →
-   * `addSubscriptionStreams` cycles.
-   *
-   * Implementations should also be deterministic, side-effect free, and must
-   * not throw — exceptions surface inside subscription ack / release paths
-   * where they can cause re-dispatch storms.
-   */
+  // Both transforms MUST be idempotent: subscription payloads round-trip
+  // through them on every refresh, so an unconditional prefix would
+  // double-apply across getSubscription → addSubscriptionStreams cycles.
   toBackendStreamPath(serviceId: string, streamPath: string): string
-  /**
-   * Inverse of `toBackendStreamPath`. Strip the backend transform so callers
-   * can reason in the runtime namespace. Must be idempotent for paths
-   * already in the runtime namespace.
-   */
   toRuntimeStreamPath(serviceId: string, streamPath: string): string
 }
 

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -19,17 +19,22 @@ export interface StreamClientSubscriptionRouting {
 export interface StreamClientOptions {
   bearer?: DurableStreamsBearerProvider
   /**
-   * Optional routing adapter applied to subscription path payloads (patterns,
-   * stream paths, wake_streams, ack/release bodies, and server responses).
+   * Adapter applied to every subscription-payload field that names a stream
+   * path, in both directions: outgoing requests go through `toBackendStreamPath`
+   * and incoming responses are mapped back through `toRuntimeStreamPath` so
+   * callers always see the runtime namespace.
    *
    * Subscriptions are stored in the durable-streams worker keyed on the
    * backend stream path (e.g. service-prefixed `<serviceId>/<path>` in
-   * service-routed cloud deployments). Stream URLs use the same transform
-   * via the per-request router, so without this option the subscription's
+   * service-routed cloud deployments). Stream URLs use the same transform via
+   * the per-request router, so without this option the subscription's
    * registered streams never match the keys appends are indexed under, and
    * webhook fanout silently drops.
+   *
+   * Tenant-root / single-tenant deployments can omit this; the default
+   * behaviour is bit-identical to the prior slash-normalising code.
    */
-  routing?: StreamClientSubscriptionRouting
+  subscriptionRouting?: StreamClientSubscriptionRouting
 }
 
 export interface StreamAppendResult {
@@ -209,9 +214,14 @@ export class StreamClient {
     return headers
   }
 
+  /**
+   * Paired with `runtimeSubscriptionPath`. Apply on outgoing subscription
+   * payloads (request bodies); the inverse runs on incoming responses so
+   * callers always see the runtime namespace.
+   */
   private backendSubscriptionPath(path: string): string {
     const normalized = normalizeSubscriptionPath(path)
-    const routing = this.options.routing
+    const routing = this.options.subscriptionRouting
     if (!routing) return normalized
     return normalizeSubscriptionPath(
       routing.adapter.toBackendStreamPath(routing.serviceId, normalized)
@@ -220,7 +230,7 @@ export class StreamClient {
 
   private runtimeSubscriptionPath(path: string): string {
     const normalized = normalizeSubscriptionPath(path)
-    const routing = this.options.routing
+    const routing = this.options.subscriptionRouting
     if (!routing) return normalized
     return normalizeSubscriptionPath(
       routing.adapter.toRuntimeStreamPath(routing.serviceId, normalized)

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -18,22 +18,6 @@ export interface StreamClientSubscriptionRouting {
 
 export interface StreamClientOptions {
   bearer?: DurableStreamsBearerProvider
-  /**
-   * Adapter applied to every subscription-payload field that names a stream
-   * path, in both directions: outgoing requests go through `toBackendStreamPath`
-   * and incoming responses are mapped back through `toRuntimeStreamPath` so
-   * callers always see the runtime namespace.
-   *
-   * Subscriptions are stored in the durable-streams worker keyed on the
-   * backend stream path (e.g. service-prefixed `<serviceId>/<path>` in
-   * service-routed cloud deployments). Stream URLs use the same transform via
-   * the per-request router, so without this option the subscription's
-   * registered streams never match the keys appends are indexed under, and
-   * webhook fanout silently drops.
-   *
-   * Tenant-root / single-tenant deployments can omit this; the default
-   * behaviour is bit-identical to the prior slash-normalising code.
-   */
   subscriptionRouting?: StreamClientSubscriptionRouting
 }
 
@@ -214,11 +198,6 @@ export class StreamClient {
     return headers
   }
 
-  /**
-   * Paired with `runtimeSubscriptionPath`. Apply on outgoing subscription
-   * payloads (request bodies); the inverse runs on incoming responses so
-   * callers always see the runtime namespace.
-   */
   private backendSubscriptionPath(path: string): string {
     const normalized = normalizeSubscriptionPath(path)
     const routing = this.options.subscriptionRouting

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -7,11 +7,29 @@ import {
 import { ErrCodeNotFound } from './electric-agents-types.js'
 import { ATTR, injectTraceHeaders, withSpan } from './tracing.js'
 import type { HeadersRecord, MaybePromise } from '@durable-streams/client'
+import type { DurableStreamsRoutingAdapter } from './routing/durable-streams-routing-adapter.js'
 
 export type DurableStreamsBearerProvider = string | (() => MaybePromise<string>)
 
+export interface StreamClientSubscriptionRouting {
+  serviceId: string
+  adapter: DurableStreamsRoutingAdapter
+}
+
 export interface StreamClientOptions {
   bearer?: DurableStreamsBearerProvider
+  /**
+   * Optional routing adapter applied to subscription path payloads (patterns,
+   * stream paths, wake_streams, ack/release bodies, and server responses).
+   *
+   * Subscriptions are stored in the durable-streams worker keyed on the
+   * backend stream path (e.g. service-prefixed `<serviceId>/<path>` in
+   * service-routed cloud deployments). Stream URLs use the same transform
+   * via the per-request router, so without this option the subscription's
+   * registered streams never match the keys appends are indexed under, and
+   * webhook fanout silently drops.
+   */
+  routing?: StreamClientSubscriptionRouting
 }
 
 export interface StreamAppendResult {
@@ -192,11 +210,21 @@ export class StreamClient {
   }
 
   private backendSubscriptionPath(path: string): string {
-    return normalizeSubscriptionPath(path)
+    const normalized = normalizeSubscriptionPath(path)
+    const routing = this.options.routing
+    if (!routing) return normalized
+    return normalizeSubscriptionPath(
+      routing.adapter.toBackendStreamPath(routing.serviceId, normalized)
+    )
   }
 
   private runtimeSubscriptionPath(path: string): string {
-    return normalizeSubscriptionPath(path)
+    const normalized = normalizeSubscriptionPath(path)
+    const routing = this.options.routing
+    if (!routing) return normalized
+    return normalizeSubscriptionPath(
+      routing.adapter.toRuntimeStreamPath(routing.serviceId, normalized)
+    )
   }
 
   private subscriptionUrl(subscriptionId: string): string {

--- a/packages/agents-server/test/dispatch-policy-routing.test.ts
+++ b/packages/agents-server/test/dispatch-policy-routing.test.ts
@@ -328,9 +328,6 @@ describe(`dispatch policy routing`, () => {
     const dispatchPolicy: DispatchPolicy = {
       targets: [{ type: `runner`, runnerId: `runner-1` }],
     }
-    // Service-routed deployment: the worker returns backend-prefixed stream
-    // paths, so dispatch-policy's subscriptionHasStream must consult the
-    // adapter to recognise an already-linked stream.
     const ctx = buildContext({
       durableStreamsRouting: servicePrefixAdapter,
     })

--- a/packages/agents-server/test/dispatch-policy-routing.test.ts
+++ b/packages/agents-server/test/dispatch-policy-routing.test.ts
@@ -2,10 +2,29 @@ import { describe, expect, it, vi } from 'vitest'
 import { globalRouter } from '../src/routing/global-router'
 import { DurableStreamsSubscriptionError } from '../src/stream-client'
 import type { TenantContext } from '../src/routing/context'
+import type { DurableStreamsRoutingAdapter } from '../src/routing/durable-streams-routing-adapter'
 import type {
   DispatchPolicy,
   ElectricAgentsEntity,
 } from '../src/electric-agents-types'
+
+const servicePrefixAdapter: DurableStreamsRoutingAdapter = {
+  streamUrl: ({ durableStreamsUrl }) => new URL(durableStreamsUrl),
+  controlUrl: ({ durableStreamsUrl }) => new URL(durableStreamsUrl),
+  toBackendStreamPath: (serviceId, path) => {
+    const normalized = path.replace(/^\/+/, ``)
+    if (normalized === serviceId || normalized.startsWith(`${serviceId}/`)) {
+      return normalized
+    }
+    return `${serviceId}/${normalized}`
+  },
+  toRuntimeStreamPath: (serviceId, path) => {
+    const normalized = path.replace(/^\/+/, ``)
+    return normalized.startsWith(`${serviceId}/`)
+      ? normalized.slice(serviceId.length + 1)
+      : normalized
+  },
+}
 
 function request(method: string, path: string, body?: unknown): Request {
   return new Request(`http://server${path}`, {
@@ -309,7 +328,12 @@ describe(`dispatch policy routing`, () => {
     const dispatchPolicy: DispatchPolicy = {
       targets: [{ type: `runner`, runnerId: `runner-1` }],
     }
-    const ctx = buildContext()
+    // Service-routed deployment: the worker returns backend-prefixed stream
+    // paths, so dispatch-policy's subscriptionHasStream must consult the
+    // adapter to recognise an already-linked stream.
+    const ctx = buildContext({
+      durableStreamsRouting: servicePrefixAdapter,
+    })
     ;(ctx.entityManager.registry.getEntity as any).mockResolvedValue(
       entity(dispatchPolicy)
     )
@@ -357,7 +381,9 @@ describe(`dispatch policy routing`, () => {
     const dispatchPolicy: DispatchPolicy = {
       targets: [{ type: `runner`, runnerId: `runner-1` }],
     }
-    const ctx = buildContext()
+    const ctx = buildContext({
+      durableStreamsRouting: servicePrefixAdapter,
+    })
     ;(ctx.streamClient.getSubscription as any)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({

--- a/packages/agents-server/test/host.test.ts
+++ b/packages/agents-server/test/host.test.ts
@@ -157,4 +157,103 @@ describe(`AgentsHost`, () => {
     expect(runtime.stop).toHaveBeenCalledOnce()
     expect(host.getTenant(`svc-race`)).toBeUndefined()
   })
+
+  // Regression test for electric-sql/stratovolt#1519: webhook fanout silently
+  // dropped on service-routed deployments because subscription payloads were
+  // not run through the routing adapter. This test asserts the wire-through
+  // from `registerTenant({ durableStreamsRouting })` to the per-tenant
+  // `StreamClient`'s outgoing subscription request body.
+  it(`applies durableStreamsRouting adapter to per-tenant subscription payloads`, async () => {
+    const adapter = {
+      streamUrl: ({ durableStreamsUrl }: { durableStreamsUrl: string }) =>
+        new URL(durableStreamsUrl),
+      controlUrl: ({ durableStreamsUrl }: { durableStreamsUrl: string }) =>
+        new URL(durableStreamsUrl),
+      toBackendStreamPath: (serviceId: string, path: string) => {
+        const normalized = path.replace(/^\/+/, ``)
+        if (
+          normalized === serviceId ||
+          normalized.startsWith(`${serviceId}/`)
+        ) {
+          return normalized
+        }
+        return `${serviceId}/${normalized}`
+      },
+      toRuntimeStreamPath: (serviceId: string, path: string) => {
+        const normalized = path.replace(/^\/+/, ``)
+        return normalized.startsWith(`${serviceId}/`)
+          ? normalized.slice(serviceId.length + 1)
+          : normalized
+      },
+    }
+
+    const host = new AgentsHost({
+      db: createMockDb(),
+      pgClient: vi.fn() as any,
+    })
+
+    const runtime = await host.registerTenant({
+      serviceId: `svc-routed-tenant`,
+      durableStreamsUrl: `https://streams.test/v1/stream/svc-routed-tenant`,
+      durableStreamsRouting: adapter,
+    })
+
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
+      new Response(JSON.stringify({ subscription_id: `sub-host` }), {
+        headers: { 'content-type': `application/json` },
+      })
+    )
+
+    try {
+      await runtime.streamClient.putSubscription(`sub-host`, {
+        type: `webhook`,
+        streams: [`/discord-bot/abc/main`],
+        webhook: { url: `http://agent.local/webhook` },
+      })
+
+      const [, init] = fetchMock.mock.calls[0]!
+      expect(JSON.parse(init?.body as string)).toMatchObject({
+        type: `webhook`,
+        streams: [`svc-routed-tenant/discord-bot/abc/main`],
+      })
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  // Mirror without `durableStreamsRouting`: confirms the default branch is
+  // bit-identical to the prior slash-normalising behaviour for tenant-root
+  // deployments.
+  it(`omits the routing adapter when durableStreamsRouting is not provided`, async () => {
+    const host = new AgentsHost({
+      db: createMockDb(),
+      pgClient: vi.fn() as any,
+    })
+
+    const runtime = await host.registerTenant({
+      serviceId: `svc-default-tenant`,
+      durableStreamsUrl: `https://streams.test/v1/stream/svc-default-tenant`,
+    })
+
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
+      new Response(JSON.stringify({ subscription_id: `sub-default` }), {
+        headers: { 'content-type': `application/json` },
+      })
+    )
+
+    try {
+      await runtime.streamClient.putSubscription(`sub-default`, {
+        type: `webhook`,
+        streams: [`/discord-bot/abc/main`],
+        webhook: { url: `http://agent.local/webhook` },
+      })
+
+      const [, init] = fetchMock.mock.calls[0]!
+      expect(JSON.parse(init?.body as string)).toMatchObject({
+        streams: [`discord-bot/abc/main`],
+      })
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
 })

--- a/packages/agents-server/test/host.test.ts
+++ b/packages/agents-server/test/host.test.ts
@@ -158,11 +158,6 @@ describe(`AgentsHost`, () => {
     expect(host.getTenant(`svc-race`)).toBeUndefined()
   })
 
-  // Regression test for electric-sql/stratovolt#1519: webhook fanout silently
-  // dropped on service-routed deployments because subscription payloads were
-  // not run through the routing adapter. This test asserts the wire-through
-  // from `registerTenant({ durableStreamsRouting })` to the per-tenant
-  // `StreamClient`'s outgoing subscription request body.
   it(`applies durableStreamsRouting adapter to per-tenant subscription payloads`, async () => {
     const adapter = {
       streamUrl: ({ durableStreamsUrl }: { durableStreamsUrl: string }) =>
@@ -221,9 +216,6 @@ describe(`AgentsHost`, () => {
     }
   })
 
-  // Mirror without `durableStreamsRouting`: confirms the default branch is
-  // bit-identical to the prior slash-normalising behaviour for tenant-root
-  // deployments.
   it(`omits the routing adapter when durableStreamsRouting is not provided`, async () => {
     const host = new AgentsHost({
       db: createMockDb(),

--- a/packages/agents-server/test/stream-client.test.ts
+++ b/packages/agents-server/test/stream-client.test.ts
@@ -1,6 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { StreamClient } from '../src/stream-client'
+import type { DurableStreamsRoutingAdapter } from '../src/routing/durable-streams-routing-adapter'
+
+function servicePrefixRoutingAdapter(): DurableStreamsRoutingAdapter {
+  return {
+    streamUrl: ({ durableStreamsUrl }) => new URL(durableStreamsUrl),
+    controlUrl: ({ durableStreamsUrl }) => new URL(durableStreamsUrl),
+    toBackendStreamPath: (serviceId, path) => {
+      const normalized = path.replace(/^\/+/, ``)
+      if (normalized === serviceId || normalized.startsWith(`${serviceId}/`)) {
+        return normalized
+      }
+      return `${serviceId}/${normalized}`
+    },
+    toRuntimeStreamPath: (serviceId, path) => {
+      const normalized = path.replace(/^\/+/, ``)
+      return normalized.startsWith(`${serviceId}/`)
+        ? normalized.slice(serviceId.length + 1)
+        : normalized
+    },
+  }
+}
 
 const {
   appendMock,
@@ -217,6 +238,162 @@ describe(`StreamClient`, () => {
       expect(
         new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get(`authorization`)
       ).toBe(`Bearer service-token-2`)
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it(`service-prefixes subscription paths via the routing adapter on putSubscription`, async () => {
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          subscription_id: `sub-1`,
+          pattern: `svc-tenant-a/discord-bot/abc/main`,
+          streams: [
+            { path: `svc-tenant-a/discord-bot/abc/main`, tail_offset: `0` },
+          ],
+          wake_stream: `svc-tenant-a/runners/runner-1/wake`,
+        }),
+        { headers: { 'content-type': `application/json` } }
+      )
+    )
+    const client = new StreamClient(
+      `https://streams.test/v1/stream/svc-tenant-a`,
+      {
+        routing: {
+          serviceId: `svc-tenant-a`,
+          adapter: servicePrefixRoutingAdapter(),
+        },
+      }
+    )
+
+    try {
+      const response = await client.putSubscription(`sub-1`, {
+        type: `webhook`,
+        streams: [`/discord-bot/abc/main`],
+        webhook: { url: `http://agent.local/webhook` },
+        wake_stream: `/runners/runner-1/wake`,
+      })
+
+      const [, init] = fetchMock.mock.calls[0]!
+      expect(JSON.parse(init?.body as string)).toMatchObject({
+        type: `webhook`,
+        streams: [`svc-tenant-a/discord-bot/abc/main`],
+        webhook: { url: `http://agent.local/webhook` },
+        wake_stream: `svc-tenant-a/runners/runner-1/wake`,
+      })
+
+      // Response paths are stripped back to the logical (runtime) namespace.
+      expect(response.pattern).toBe(`discord-bot/abc/main`)
+      expect(response.wake_stream).toBe(`runners/runner-1/wake`)
+      expect(response.streams).toEqual([
+        { path: `discord-bot/abc/main`, tail_offset: `0` },
+      ])
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it(`service-prefixes subscription paths on addSubscriptionStreams`, async () => {
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
+      new Response(JSON.stringify({ subscription_id: `sub-1` }), {
+        headers: { 'content-type': `application/json` },
+      })
+    )
+    const client = new StreamClient(
+      `https://streams.test/v1/stream/svc-tenant-a`,
+      {
+        routing: {
+          serviceId: `svc-tenant-a`,
+          adapter: servicePrefixRoutingAdapter(),
+        },
+      }
+    )
+
+    try {
+      await client.addSubscriptionStreams(`sub-1`, [
+        `/discord-bot/abc/main`,
+        `/discord-bot/def/main`,
+      ])
+
+      const [, init] = fetchMock.mock.calls[0]!
+      expect(JSON.parse(init?.body as string)).toEqual({
+        streams: [
+          `svc-tenant-a/discord-bot/abc/main`,
+          `svc-tenant-a/discord-bot/def/main`,
+        ],
+      })
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it(`service-prefixes ack stream/path fields via the routing adapter`, async () => {
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { 'content-type': `application/json` },
+      })
+    )
+    const client = new StreamClient(
+      `https://streams.test/v1/stream/svc-tenant-a`,
+      {
+        bearer: `service-token`,
+        routing: {
+          serviceId: `svc-tenant-a`,
+          adapter: servicePrefixRoutingAdapter(),
+        },
+      }
+    )
+
+    try {
+      await client.ackSubscription(`sub-1`, `claim-token`, {
+        wake_id: `wake-1`,
+        generation: 1,
+        acks: [
+          { stream: `/discord-bot/abc/main`, offset: `5` },
+          { path: `/discord-bot/def/main`, offset: `6` },
+        ],
+      })
+
+      const [, init] = fetchMock.mock.calls[0]!
+      expect(JSON.parse(init?.body as string)).toMatchObject({
+        acks: [
+          { stream: `svc-tenant-a/discord-bot/abc/main`, offset: `5` },
+          { path: `svc-tenant-a/discord-bot/def/main`, offset: `6` },
+        ],
+      })
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it(`leaves already-prefixed subscription paths idempotent`, async () => {
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
+      new Response(JSON.stringify({ subscription_id: `sub-1` }), {
+        headers: { 'content-type': `application/json` },
+      })
+    )
+    const client = new StreamClient(
+      `https://streams.test/v1/stream/svc-tenant-a`,
+      {
+        routing: {
+          serviceId: `svc-tenant-a`,
+          adapter: servicePrefixRoutingAdapter(),
+        },
+      }
+    )
+
+    try {
+      await client.putSubscription(`sub-1`, {
+        type: `webhook`,
+        streams: [`svc-tenant-a/discord-bot/abc/main`],
+        webhook: { url: `http://agent.local/webhook` },
+      })
+
+      const [, init] = fetchMock.mock.calls[0]!
+      expect(JSON.parse(init?.body as string)).toMatchObject({
+        streams: [`svc-tenant-a/discord-bot/abc/main`],
+      })
     } finally {
       fetchMock.mockRestore()
     }

--- a/packages/agents-server/test/stream-client.test.ts
+++ b/packages/agents-server/test/stream-client.test.ts
@@ -260,7 +260,7 @@ describe(`StreamClient`, () => {
     const client = new StreamClient(
       `https://streams.test/v1/stream/svc-tenant-a`,
       {
-        routing: {
+        subscriptionRouting: {
           serviceId: `svc-tenant-a`,
           adapter: servicePrefixRoutingAdapter(),
         },
@@ -303,7 +303,7 @@ describe(`StreamClient`, () => {
     const client = new StreamClient(
       `https://streams.test/v1/stream/svc-tenant-a`,
       {
-        routing: {
+        subscriptionRouting: {
           serviceId: `svc-tenant-a`,
           adapter: servicePrefixRoutingAdapter(),
         },
@@ -338,7 +338,7 @@ describe(`StreamClient`, () => {
       `https://streams.test/v1/stream/svc-tenant-a`,
       {
         bearer: `service-token`,
-        routing: {
+        subscriptionRouting: {
           serviceId: `svc-tenant-a`,
           adapter: servicePrefixRoutingAdapter(),
         },
@@ -367,6 +367,39 @@ describe(`StreamClient`, () => {
     }
   })
 
+  it(`service-prefixes release stream/path fields via the routing adapter`, async () => {
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { 'content-type': `application/json` },
+      })
+    )
+    const client = new StreamClient(
+      `https://streams.test/v1/stream/svc-tenant-a`,
+      {
+        bearer: `service-token`,
+        subscriptionRouting: {
+          serviceId: `svc-tenant-a`,
+          adapter: servicePrefixRoutingAdapter(),
+        },
+      }
+    )
+
+    try {
+      await client.releaseSubscription(`sub-1`, `claim-token`, {
+        wake_id: `wake-1`,
+        generation: 1,
+        stream: `/discord-bot/abc/main`,
+      })
+
+      const [, init] = fetchMock.mock.calls[0]!
+      expect(JSON.parse(init?.body as string)).toMatchObject({
+        stream: `svc-tenant-a/discord-bot/abc/main`,
+      })
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
   it(`leaves already-prefixed subscription paths idempotent`, async () => {
     const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValueOnce(
       new Response(JSON.stringify({ subscription_id: `sub-1` }), {
@@ -376,7 +409,7 @@ describe(`StreamClient`, () => {
     const client = new StreamClient(
       `https://streams.test/v1/stream/svc-tenant-a`,
       {
-        routing: {
+        subscriptionRouting: {
           serviceId: `svc-tenant-a`,
           adapter: servicePrefixRoutingAdapter(),
         },


### PR DESCRIPTION
## Summary

- Plumb the `DurableStreamsRoutingAdapter` through `StreamClient` so subscription path payloads (`pattern`, `streams`, `wake_stream`, ack/release `stream`/`path`) use `toBackendStreamPath`, and worker responses are mapped back via `toRuntimeStreamPath`.
- Add a matching `durableStreamsRouting` field to `AgentsHostTenantConfig` that flows the adapter through to the per-tenant `StreamClient` constructor.
- `dispatch-policy.subscriptionHasStream` now consults `ctx.durableStreamsRouting` instead of hardcoding `${ctx.service}/${path}`, so adapters with non-trivial backend conventions are honoured end-to-end.
- Default (no routing option) behaviour is unchanged — tenant-root deployments are bit-identical to the prior slash-normalising code.

## Why

Reported against the hosted cloud tenant (stratovolt's `cloud-agents-server`): webhook dispatch never fires for tenanted entities, while pull-wake works. Root cause is a two-tier path-namespace mismatch on the subscription path that doesn't exist on the data path:

- **Stream appends** are routed through the cloud's `serviceRoutedDurableStreamsAdapter`, so they land in the durable-streams worker keyed on the service-prefixed backend path (`<serviceId>/<type>/<id>/main`).
- **Subscription registrations** went through `StreamClient.backendSubscriptionPath`, which only slash-normalised. So the subscription's `streams` were stored as the un-prefixed path (`<type>/<id>/main`).

The worker's HotBuffer lookup keyed on the append's resource id never matched the subscription link, and webhook fanout silently dropped. Pull-wake worked only because the runner writes a wake notification directly to its own `wake_stream` and reads it back — no HotBuffer fanout coordination needed.

The cloud-side companion change (wire `durableStreamsRouting: serviceRoutedDurableStreamsAdapter` into `agentsHost.registerTenant`) lives in electric-sql/stratovolt#1521 and ships behind a dep bump.

## Changes

- `src/stream-client.ts` — `StreamClientOptions.subscriptionRouting?: { serviceId, adapter }`; `backendSubscriptionPath` / `runtimeSubscriptionPath` consult the adapter when set, applying `toBackendStreamPath` / `toRuntimeStreamPath` then re-normalising. This single change covers `putSubscription`, `addSubscriptionStreams`, the ack/release `subscriptionRequestBody` mapping, and the symmetric `subscriptionResponseBody` reverse-mapping.
- `src/host.ts` — `AgentsHostTenantConfig.durableStreamsRouting?: DurableStreamsRoutingAdapter`; threaded into `createStreamClient`.
- `src/index.ts` — re-exports `StreamClientSubscriptionRouting`.
- `src/routing/durable-streams-routing-adapter.ts` — documents idempotence + no-throw contract on `toBackendStreamPath` / `toRuntimeStreamPath` (subscription payloads round-trip on every refresh; unconditional prefixing would cause runaway double-prefixing).
- `src/routing/dispatch-policy.ts` — `subscriptionHasStream` uses `ctx.durableStreamsRouting?.toBackendStreamPath(...)` instead of a hardcoded service-prefix.
- `test/stream-client.test.ts` — 5 new tests covering `putSubscription`, `addSubscriptionStreams`, `ackSubscription`, `releaseSubscription`, and idempotence of already-prefixed paths, plus the runtime-namespace round-trip on responses.
- `test/host.test.ts` — 2 new regression tests: (a) `AgentsHost`-level wire-through of `durableStreamsRouting` to outgoing subscription bodies; (b) bit-identical default behaviour when the field is omitted.
- `test/dispatch-policy-routing.test.ts` — 2 existing tests with backend-prefixed fixtures (`tenant-test/...`) now set `durableStreamsRouting` explicitly; their previous implicit assumption now matches reality.

## Migration

Webhook subscriptions persisted before this fix have un-prefixed `streams` entries on disk. They are **not** auto-healed: those subscriptions were already silently dropping every webhook event (the bug this PR fixes), so the only useful operator action is to delete and recreate any affected webhook subscription after upgrading. Pre-fix pull-wake subscriptions are unaffected.

## Test plan

- [x] `pnpm test -- test/stream-client.test.ts` — 14/14 pass
- [x] `pnpm test -- test/host.test.ts` — 7/7 pass
- [x] `pnpm test -- test/dispatch-policy-routing.test.ts` — 8/8 pass
- [x] Combined sweep of `stream-client*`, `host`, `dispatch-policy*`, `electric-agents-routes`, `webhook-forward-routing` — 62/62 pass
- [x] `pnpm typecheck` — zero errors in `agents-server/src`; remaining cross-package errors are pre-existing `../agents/src/` issues not introduced by this branch
- [x] `pnpm stylecheck` — clean
- [ ] End-to-end repro against hosted tenant after stratovolt wires `durableStreamsRouting` and bumps the dep (OpenFactory discord-bot per the issue)

Fixes electric-sql/stratovolt#1519
Closes #4357

🤖 Generated with [Claude Code](https://claude.com/claude-code)