### PR TITLE
feat(agents)!: Horton requires an explicit MCP allowlist

### DIFF
--- a/.changeset/horton-mcp-allowlist.md
+++ b/.changeset/horton-mcp-allowlist.md
@@ -1,0 +1,16 @@
+---
+'@electric-ax/agents': patch
+'@electric-ax/agents-desktop': patch
+---
+
+Horton no longer auto-exposes every registered MCP server's tools. `registerHorton`, `createBuiltinAgentHandler`, and `BuiltinAgentsServer` now require an `mcpAllowlist` field of type `'*' | ReadonlyArray<string>`:
+
+- `'*'` — every currently-registered MCP server (the previous default, now explicit-unsafe).
+- `[]` — disable MCP tools entirely.
+- `['server-a', 'server-b']` — restrict to the named servers.
+
+**Breaking, TS-loud:** existing callers fail at compile time with a missing-property error and update one line. Pick `'*'` to keep current behavior, `[]` for the secure default, or an array for the considered choice.
+
+The desktop app passes `'*'` because the user already explicitly configures which MCP servers to attach via the desktop settings UI; a per-server allowlist surfaced in the UI would be a separate change. The `electric-agents` CLI entrypoint reads `ELECTRIC_AGENTS_MCP_ALLOWLIST` (comma-separated, or `*`) and defaults to `[]` — operators must opt in explicitly.
+
+`createAgentHandler(agentServerUrl, ...)` gains `mcpAllowlist` as its second positional argument.

--- a/packages/agents-desktop/src/main.ts
+++ b/packages/agents-desktop/src/main.ts
@@ -2107,6 +2107,8 @@ async function startRuntime(serverId: string): Promise<void> {
     workingDirectory: settings.workingDirectory ?? app.getPath(`home`),
     extraMcpServers: settings.mcp?.servers,
     loadProjectMcpConfig: true,
+    // MCP servers are already curated in the desktop settings UI.
+    mcpAllowlist: `*`,
     mcpOAuthRedirectBase: MCP_OAUTH_REDIRECT_BASE,
     baseSkillsDir: AGENT_SKILLS_DIR,
     openAuthorizeUrl: (url, server) => {

--- a/packages/agents/src/agents/horton.ts
+++ b/packages/agents/src/agents/horton.ts
@@ -347,6 +347,9 @@ function readAgentsMd(workingDirectory: string): string | null {
   }
 }
 
+/** `'*'` for every registered MCP server, or a list of server names (`[]` disables MCP). */
+export type HortonMcpAllowlist = `*` | ReadonlyArray<string>
+
 function createAssistantHandler(options: {
   workingDirectory: string
   streamFn?: StreamFn
@@ -355,6 +358,7 @@ function createAssistantHandler(options: {
   skillsRegistry: SkillsRegistry | null
   modelCatalog: BuiltinModelCatalog
   docsUrl?: string
+  mcpAllowlist: HortonMcpAllowlist
 }) {
   const {
     workingDirectory,
@@ -364,6 +368,7 @@ function createAssistantHandler(options: {
     skillsRegistry,
     modelCatalog,
     docsUrl,
+    mcpAllowlist,
   } = options
   const hasSkills = Boolean(skillsRegistry && skillsRegistry.catalog.size > 0)
 
@@ -393,7 +398,11 @@ function createAssistantHandler(options: {
       ...(skillsRegistry && skillsRegistry.catalog.size > 0
         ? createSkillTools(skillsRegistry, ctx)
         : []),
-      ...mcp.tools(),
+      ...(mcpAllowlist === `*`
+        ? mcp.tools()
+        : mcpAllowlist.length > 0
+          ? mcp.tools([...mcpAllowlist])
+          : []),
     ]
 
     const titlePromise =
@@ -548,6 +557,7 @@ export function registerHorton(
     skillsRegistry?: SkillsRegistry | null
     modelCatalog: BuiltinModelCatalog
     docsUrl?: string
+    mcpAllowlist: HortonMcpAllowlist
   }
 ): Array<string> {
   const {
@@ -555,6 +565,7 @@ export function registerHorton(
     streamFn,
     skillsRegistry = null,
     modelCatalog,
+    mcpAllowlist,
   } = options
   const docsUrl = options.docsUrl ?? process.env.HORTON_DOCS_URL
 
@@ -587,6 +598,7 @@ export function registerHorton(
     skillsRegistry,
     modelCatalog,
     docsUrl,
+    mcpAllowlist,
   })
 
   const hortonCreationSchema = z.object({

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -9,7 +9,7 @@ import {
   createRuntimeHandler,
 } from '@electric-ax/agents-runtime'
 import { serverLog } from './log'
-import { registerHorton } from './agents/horton'
+import { registerHorton, type HortonMcpAllowlist } from './agents/horton'
 import { registerWorker } from './agents/worker'
 import { createBuiltinModelCatalog } from './model-catalog'
 import { createSkillsRegistry } from './skills/registry'
@@ -49,6 +49,7 @@ export interface BuiltinAgentHandlerOptions {
   defaultDispatchPolicyForType?: (
     typeName: string
   ) => DispatchPolicy | undefined
+  mcpAllowlist: HortonMcpAllowlist
   createElectricTools?: (context: {
     entityUrl: string
     entityType: string
@@ -131,6 +132,7 @@ export async function createBuiltinAgentHandler(
     streamFn,
     skillsRegistry,
     modelCatalog,
+    mcpAllowlist: options.mcpAllowlist,
   })
 
   registerWorker(registry, { workingDirectory: cwd, streamFn, modelCatalog })
@@ -160,6 +162,7 @@ export async function createBuiltinAgentHandler(
 
 export async function createAgentHandler(
   agentServerUrl: string,
+  mcpAllowlist: HortonMcpAllowlist,
   workingDirectory?: string,
   streamFn?: StreamFn,
   createElectricTools?: BuiltinAgentHandlerOptions[`createElectricTools`],
@@ -171,6 +174,7 @@ export async function createAgentHandler(
     workingDirectory,
     streamFn,
     createElectricTools,
+    mcpAllowlist,
   })
 }
 

--- a/packages/agents/src/entrypoint-lib.ts
+++ b/packages/agents/src/entrypoint-lib.ts
@@ -1,6 +1,16 @@
 import { BuiltinAgentsServer } from './server.js'
 import { mergeElectricPrincipalHeader } from './server-headers.js'
+import type { HortonMcpAllowlist } from './agents/horton.js'
 import type { BuiltinAgentsServerOptions } from './server.js'
+
+function parseMcpAllowlistEnv(raw: string | undefined): HortonMcpAllowlist {
+  if (!raw) return []
+  if (raw === `*`) return `*`
+  return raw
+    .split(`,`)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
 
 type EnvSource = Record<string, string | undefined>
 
@@ -136,6 +146,10 @@ export function resolveBuiltinAgentsEntrypointOptions(
         `ELECTRIC_AGENTS_WORKING_DIRECTORY`,
         `WORKING_DIRECTORY`,
       ]) ?? cwd,
+    // ELECTRIC_AGENTS_MCP_ALLOWLIST: `*`, comma-separated names, or empty/unset for no MCP.
+    mcpAllowlist: parseMcpAllowlistEnv(
+      readEnv(env, [`ELECTRIC_AGENTS_MCP_ALLOWLIST`])
+    ),
     pullWake: {
       runnerId,
       registerRunner:

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -42,6 +42,7 @@ export {
   HORTON_MODEL,
   registerHorton,
 } from './agents/horton.js'
+export type { HortonMcpAllowlist } from './agents/horton.js'
 export { registerWorker } from './agents/worker.js'
 export {
   WORKER_TOOL_NAMES,

--- a/packages/agents/src/server.ts
+++ b/packages/agents/src/server.ts
@@ -4,6 +4,7 @@ import {
   createBuiltinAgentHandler,
   registerBuiltinAgentTypes,
 } from './bootstrap.js'
+import type { HortonMcpAllowlist } from './agents/horton.js'
 import {
   createRegistry as createMcpRegistry,
   loadConfig as loadMcpConfig,
@@ -76,6 +77,7 @@ export interface BuiltinAgentsServerOptions {
   loadProjectMcpConfig?: boolean
   /** Override for the built-in skills directory; required when embedders bundle this package. */
   baseSkillsDir?: string
+  mcpAllowlist: HortonMcpAllowlist
   createElectricTools?: (context: {
     entityUrl: string
     entityType: string
@@ -299,6 +301,7 @@ export class BuiltinAgentsServer {
         runtimeName: `builtin-agents`,
         baseSkillsDir: this.options.baseSkillsDir,
         serverHeaders: pullWake.headers,
+        mcpAllowlist: this.options.mcpAllowlist,
       })
       if (!this.bootstrap) {
         throw new Error(

--- a/packages/agents/test/bootstrap-mcp.test.ts
+++ b/packages/agents/test/bootstrap-mcp.test.ts
@@ -104,6 +104,7 @@ describe(`BuiltinAgentsServer — MCP merge`, () => {
     server = new BuiltinAgentsServer({
       agentServerUrl: mockServer.url,
       pullWake: { runnerId: `test-runner` },
+      mcpAllowlist: `*`,
       mockStreamFn,
       workingDirectory: workspace,
       loadProjectMcpConfig: true,
@@ -133,6 +134,7 @@ describe(`BuiltinAgentsServer — MCP merge`, () => {
     server = new BuiltinAgentsServer({
       agentServerUrl: mockServer.url,
       pullWake: { runnerId: `test-runner` },
+      mcpAllowlist: `*`,
       mockStreamFn,
       workingDirectory: workspace,
       loadProjectMcpConfig: true,
@@ -154,6 +156,7 @@ describe(`BuiltinAgentsServer — MCP merge`, () => {
     server = new BuiltinAgentsServer({
       agentServerUrl: mockServer.url,
       pullWake: { runnerId: `test-runner` },
+      mcpAllowlist: `*`,
       mockStreamFn,
       workingDirectory: workspace,
       loadProjectMcpConfig: true,
@@ -183,6 +186,7 @@ describe(`BuiltinAgentsServer — MCP merge`, () => {
     server = new BuiltinAgentsServer({
       agentServerUrl: mockServer.url,
       pullWake: { runnerId: `test-runner` },
+      mcpAllowlist: `*`,
       mockStreamFn,
       workingDirectory: workspace,
       loadProjectMcpConfig: true,
@@ -220,6 +224,7 @@ describe(`BuiltinAgentsServer — MCP merge`, () => {
     server = new BuiltinAgentsServer({
       agentServerUrl: mockServer.url,
       pullWake: { runnerId: `test-runner` },
+      mcpAllowlist: `*`,
       mockStreamFn,
       workingDirectory: workspace,
       extraMcpServers: [
@@ -249,6 +254,7 @@ describe(`BuiltinAgentsServer — MCP merge`, () => {
     server = new BuiltinAgentsServer({
       agentServerUrl: mockServer.url,
       pullWake: { runnerId: `test-runner` },
+      mcpAllowlist: `*`,
       mockStreamFn,
       workingDirectory: workspace,
       loadProjectMcpConfig: true,

--- a/packages/agents/test/builtin-pull-wake-registration.test.ts
+++ b/packages/agents/test/builtin-pull-wake-registration.test.ts
@@ -83,6 +83,7 @@ describe(`BuiltinAgentsServer pull-wake registration`, () => {
       agentServerUrl: agentsServer.url,
       mockStreamFn,
       pullWake: { runnerId: `test-runner` },
+      mcpAllowlist: `*`,
     })
 
     await builtinServer.start()

--- a/packages/agents/test/horton-model-selection.test.ts
+++ b/packages/agents/test/horton-model-selection.test.ts
@@ -35,6 +35,7 @@ describe(`horton model selection`, () => {
     registerHorton(registry, {
       workingDirectory: `/tmp`,
       modelCatalog,
+      mcpAllowlist: [],
     })
 
     const def = registry.get(`horton`)
@@ -69,6 +70,7 @@ describe(`horton model selection`, () => {
     registerHorton(registry, {
       workingDirectory: `/tmp`,
       modelCatalog,
+      mcpAllowlist: [],
     })
 
     const def = registry.get(`horton`)

--- a/packages/agents/test/horton-tool-composition.test.ts
+++ b/packages/agents/test/horton-tool-composition.test.ts
@@ -4,7 +4,7 @@ import {
   isMcpToolsSentinel,
   type McpToolsSentinel,
 } from '@electric-ax/agents-mcp'
-import { registerHorton } from '../src/agents/horton'
+import { registerHorton, type HortonMcpAllowlist } from '../src/agents/horton'
 import type { BuiltinModelCatalog } from '../src/model-catalog'
 
 const modelCatalog: BuiltinModelCatalog = {
@@ -26,14 +26,16 @@ const modelCatalog: BuiltinModelCatalog = {
   ],
 }
 
-// Characterization: Horton today builds a fixed built-in toolset and
-// unconditionally appends `...mcp.tools()` — every registered MCP server,
-// no allowlist (`horton.ts:396`). The tests below capture that composition
-// so a follow-up PR can flip MCP to an opt-in allowlist with a one-line
-// expectation change.
-async function captureToolset(args: Record<string, unknown> = {}) {
+async function captureToolset(
+  mcpAllowlist: HortonMcpAllowlist,
+  args: Record<string, unknown> = {}
+) {
   const registry = createEntityRegistry()
-  registerHorton(registry, { workingDirectory: `/tmp`, modelCatalog })
+  registerHorton(registry, {
+    workingDirectory: `/tmp`,
+    modelCatalog,
+    mcpAllowlist,
+  })
   const useAgent = vi.fn(() => ({ run: vi.fn(async () => {}) }))
   const fakeCtx = {
     args,
@@ -57,8 +59,8 @@ async function captureToolset(args: Record<string, unknown> = {}) {
 }
 
 describe(`horton tool composition`, () => {
-  it(`includes the default built-in toolset`, async () => {
-    const tools = await captureToolset()
+  it(`always includes the default built-in toolset`, async () => {
+    const tools = await captureToolset(`*`)
     const names = tools
       .filter((t) => !isMcpToolsSentinel(t))
       .map((t) => (t as { name: string }).name)
@@ -75,17 +77,34 @@ describe(`horton tool composition`, () => {
     )
   })
 
-  it(`appends an unconditional MCP tools sentinel with no allowlist`, async () => {
-    const tools = await captureToolset()
+  it(`mcpAllowlist: '*' emits an unrestricted MCP sentinel (all servers)`, async () => {
+    const tools = await captureToolset(`*`)
     const sentinels = tools.filter(isMcpToolsSentinel) as McpToolsSentinel[]
     expect(sentinels).toHaveLength(1)
     expect(sentinels[0]!.allowlist).toBeUndefined()
   })
 
-  it(`MCP sentinel is present regardless of args`, async () => {
-    const withArgs = await captureToolset({
-      model: `anthropic:claude-sonnet-4-6`,
-    })
-    expect(withArgs.some(isMcpToolsSentinel)).toBe(true)
+  it(`mcpAllowlist: [] emits no MCP sentinel at all`, async () => {
+    const tools = await captureToolset([])
+    expect(tools.some(isMcpToolsSentinel)).toBe(false)
+  })
+
+  it(`mcpAllowlist: ['gmail'] emits a sentinel restricted to that server`, async () => {
+    const tools = await captureToolset([`gmail`])
+    const sentinels = tools.filter(isMcpToolsSentinel) as McpToolsSentinel[]
+    expect(sentinels).toHaveLength(1)
+    expect(sentinels[0]!.allowlist).toEqual([`gmail`])
+  })
+
+  it(`built-in toolset is unchanged regardless of mcpAllowlist`, async () => {
+    const namesFor = async (allowlist: HortonMcpAllowlist) => {
+      const tools = await captureToolset(allowlist)
+      return tools
+        .filter((t) => !isMcpToolsSentinel(t))
+        .map((t) => (t as { name: string }).name)
+        .sort()
+    }
+    expect(await namesFor(`*`)).toEqual(await namesFor([]))
+    expect(await namesFor(`*`)).toEqual(await namesFor([`gmail`]))
   })
 })


### PR DESCRIPTION
## Summary

Closes the "every MCP server's tools auto-attached to Horton" surface (`horton.ts:396` — unconditional `...mcp.tools()`). `registerHorton`, `createBuiltinAgentHandler`, and `BuiltinAgentsServer` now require an `mcpAllowlist: '*' | ReadonlyArray<string>`:

- \`'*'\` — every currently-registered MCP server (the previous default, now explicit-unsafe).
- \`[]\` — disable MCP entirely.
- \`['gmail', 'github']\` — restrict to named servers.

Stacked on #4354 (the characterization tests, base branch). When that lands, this auto-rebases to `main`.

See `plans/sandboxing-investigation.md` §1.4, §1.6, §3.5.

## Why required (not optional with a default)

A silent default — even a safe one like \`[]\` — would let customers ship with the wrong toolset without realizing it. Forcing the choice catches the failure mode at compile time. One line per callsite to update.

## Cross-package edit

The desktop app's \`BuiltinAgentsServer\` callsite (`packages/agents-desktop/src/main.ts:2105`) is updated to pass \`'*'\`. Rationale: the user already curates the MCP server list in the desktop settings UI, so the choice of "expose them all to Horton" is explicit at the configuration layer. A per-server allowlist surfaced in the UI would be a separate change.

The env-driven CLI entrypoint reads \`ELECTRIC_AGENTS_MCP_ALLOWLIST\` (\`*\` or comma-separated names) and defaults to \`[]\` for secure-by-default deployment — operators opt in explicitly.

## Breaking

Compile-time error on every direct caller. Migration is one line per callsite:

\`\`\`ts
registerHorton(registry, { ..., mcpAllowlist: '*' })           // keep old behavior
registerHorton(registry, { ..., mcpAllowlist: [] })            // disable MCP
registerHorton(registry, { ..., mcpAllowlist: ['gmail'] })     // explicit list
\`\`\`

\`createAgentHandler(agentServerUrl, ...)\` gains \`mcpAllowlist\` as its second positional argument.

## Test plan

- [x] Horton composition characterization from PR 0 updated:
  - \`mcpAllowlist: '*'\` → unrestricted MCP sentinel present
  - \`mcpAllowlist: []\` → no MCP sentinel at all
  - \`mcpAllowlist: ['gmail']\` → sentinel with that allowlist
- [x] Built-in toolset unaffected regardless of allowlist
- [x] Existing \`horton-model-selection\` / \`bootstrap-mcp\` / \`builtin-pull-wake-registration\` tests updated for new required field
- [x] \`pnpm test\` (67/67), \`pnpm typecheck\`, \`pnpm stylecheck\` clean in agents
- [x] desktop \`pnpm typecheck\` clean (modulo pre-existing \`@electric-sql/client\` import errors in \`cloud-agent-servers.ts\`, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)