### PR TITLE
fix(agents): pin Durable Streams dependency commit

### DIFF
--- a/.changeset/pin-durable-streams-commit.md
+++ b/.changeset/pin-durable-streams-commit.md
@@ -1,0 +1,10 @@
+---
+"@electric-ax/agents": patch
+"@electric-ax/agents-runtime": patch
+"@electric-ax/agents-server": patch
+"@electric-ax/agents-server-ui": patch
+"@electric-ax/agents-server-conformance-tests": patch
+"electric-ax": patch
+---
+
+Pin Durable Streams dependencies to commit `5d5c217` so local development resolves the same subscription-control routing code as the PR build.

--- a/packages/agents-runtime/package.json
+++ b/packages/agents-runtime/package.json
@@ -81,8 +81,8 @@
   "dependencies": {
     "@electric-ax/agents-mcp": "workspace:*",
     "@anthropic-ai/sdk": "^0.78.0",
-    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350",
-    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350",
+    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217",
+    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217",
     "@mariozechner/pi-agent-core": "^0.70.2",
     "@mariozechner/pi-ai": "^0.70.2",
     "@mozilla/readability": "^0.6.0",
@@ -100,7 +100,7 @@
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
-    "@durable-streams/server": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350",
+    "@durable-streams/server": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^22.19.15",
     "@types/turndown": "^5.0.6",

--- a/packages/agents-server-conformance-tests/package.json
+++ b/packages/agents-server-conformance-tests/package.json
@@ -41,7 +41,7 @@
     "stylecheck": "eslint . --quiet"
   },
   "dependencies": {
-    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350",
+    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217",
     "@electric-sql/client": "^1.5.18",
     "fast-check": "^4.6.0",
     "vitest": "^4.1.0"

--- a/packages/agents-server-ui/package.json
+++ b/packages/agents-server-ui/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350",
-    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350",
+    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217",
+    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217",
     "@electric-ax/agents-runtime": "workspace:*",
     "@streamdown/math": "^1.0.2",
     "@tanstack/db": "^0.6.4",

--- a/packages/agents-server/package.json
+++ b/packages/agents-server/package.json
@@ -45,9 +45,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350",
-    "@durable-streams/server": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350",
-    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350",
+    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217",
+    "@durable-streams/server": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217",
+    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217",
     "@electric-ax/agents-runtime": "workspace:*",
     "@electric-sql/client": "^1.5.18",
     "@mariozechner/pi-agent-core": "^0.70.2",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -51,7 +51,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350",
+    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217",
     "@electric-ax/agents-mcp": "workspace:*",
     "@electric-ax/agents-runtime": "workspace:*",
     "@mariozechner/pi-agent-core": "^0.70.2",

--- a/packages/electric-ax/package.json
+++ b/packages/electric-ax/package.json
@@ -45,8 +45,8 @@
     "stylecheck": "eslint . --quiet"
   },
   "dependencies": {
-    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350",
-    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350",
+    "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217",
+    "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217",
     "@electric-ax/agents": "workspace:*",
     "@electric-ax/agents-runtime": "workspace:*",
     "@electric-sql/client": "^1.5.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1506,8 +1506,8 @@ importers:
   packages/agents:
     dependencies:
       '@durable-streams/state':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
       '@electric-ax/agents-mcp':
         specifier: workspace:*
         version: link:../agents-mcp
@@ -1656,11 +1656,11 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
       '@durable-streams/client':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@durable-streams/state':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
       '@electric-ax/agents-mcp':
         specifier: workspace:*
         version: link:../agents-mcp
@@ -1717,8 +1717,8 @@ importers:
         version: 3.25.2(zod@4.3.6)
     devDependencies:
       '@durable-streams/server':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217(typescript@5.8.3)
       '@types/jsdom':
         specifier: ^27.0.0
         version: 27.0.0
@@ -1747,14 +1747,14 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
       '@durable-streams/client':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@durable-streams/server':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217(typescript@5.8.3)
       '@durable-streams/state':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../agents-runtime
@@ -1841,8 +1841,8 @@ importers:
   packages/agents-server-conformance-tests:
     dependencies:
       '@durable-streams/client':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@electric-sql/client':
         specifier: ^1.5.18
         version: link:../typescript-client
@@ -1872,11 +1872,11 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@durable-streams/client':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@durable-streams/state':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
       '@electric-ax/agents-runtime':
         specifier: workspace:*
         version: link:../agents-runtime
@@ -1960,11 +1960,11 @@ importers:
   packages/electric-ax:
     dependencies:
       '@durable-streams/client':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@durable-streams/state':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
       '@electric-ax/agents':
         specifier: workspace:*
         version: link:../agents
@@ -4168,28 +4168,16 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350':
-    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350}
-    version: 0.2.3
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
   '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217':
     resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217}
     version: 0.2.3
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350':
-    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350}
+  '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217':
+    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217}
     version: 0.3.1
     engines: {node: '>=18.0.0'}
-
-  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350':
-    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350}
-    version: 0.2.5
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217':
     resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217}
@@ -23184,17 +23172,12 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@350':
-    dependencies:
-      '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
-      fastq: 1.20.1
-
   '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217':
     dependencies:
       '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
       fastq: 1.20.1
 
-  '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@350(typescript@5.8.3)':
+  '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217(typescript@5.8.3)':
     dependencies:
       '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@durable-streams/state': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
@@ -23202,14 +23185,6 @@ snapshots:
       lmdb: 3.5.4
       pino: 10.3.1
       pino-pretty: 13.1.3
-    transitivePeerDependencies:
-      - typescript
-
-  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@350(typescript@5.8.3)':
-    dependencies:
-      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
-      '@standard-schema/spec': 1.1.0
-      '@tanstack/db': 0.6.5(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 


### PR DESCRIPTION
## Summary
- Pin direct `@durable-streams/client`, `@durable-streams/server`, and `@durable-streams/state` `pkg.pr.new` references to commit `5d5c217` instead of the mutable PR alias.
- Regenerate `pnpm-lock.yaml` so installs resolve the same Durable Streams artifacts across the agents packages.
- Add a changeset for the affected published agents packages.

## Motivation
The mutable `@350` package URL could resolve to a stale `@durable-streams/server` artifact that still used the old `/v1/stream-meta/subscriptions` control routing. In local development, agents-server was already sending subscription control traffic through `/v1/stream/__ds/subscriptions`, so the embedded Durable Streams server treated those requests as ordinary streams and never emitted pull-wake notifications. Pinning to `5d5c217` makes local installs reproducible and keeps the server package aligned with the expected `__ds` routing behavior.