### PR TITLE
feat(agents): export createSkillsRegistry + createSkillTools for embedders

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -50,3 +50,11 @@ export {
 export type { WorkerToolName } from './tools/spawn-worker.js'
 export { createHortonDocsSupport } from './docs/knowledge-base.js'
 export { braveSearchTool } from '@electric-ax/agents-runtime/tools'
+
+// Skills loader + tools. Public so packages embedding agents-runtime
+// (e.g. discord-bot) can reuse the same `.md`-skill-directory loader
+// and mount the `use_skill`/`remove_skill` tools on their own entities
+// following the same shape Horton uses internally.
+export { createSkillsRegistry } from './skills/registry.js'
+export { createSkillTools } from './skills/tools.js'
+export type { SkillsRegistry, SkillMeta } from './skills/types.js'


### PR DESCRIPTION
## Summary

Surface the `.md`-skill-directory loader (`createSkillsRegistry`) and the per-entity `use_skill` / `remove_skill` tool builder (`createSkillTools`) as public exports of `@electric-ax/agents`, alongside the related `SkillsRegistry` / `SkillMeta` types.

These symbols already exist and are used internally by Horton + worker. There's no implementation change here — only the export.

## Motivation

OpenFactory's [`@electric-ax/discord-bot`](https://github.com/electric-sql/OpenFactory/tree/feat/discord-bot/packages/discord-bot) wires its entity against `@electric-ax/agents-runtime` and wants the same skill-loader pattern Horton uses (markdown skill pack with frontmatter for triggers / when-to-use / keywords, plus sibling reference files auto-loaded when a skill activates).

Without these exports the discord-bot has to either:
- vendor the implementation (~80 lines duplicated, drifts over time), or
- patch the published artifact (already done locally for testing, but the deploy is currently shipping with a vendored `.tgz` of this package).

Surfacing the symbols closes the gap.

## Scope

Single-file change to `packages/agents/src/index.ts` (3 export statements). No behaviour change, no runtime change, no new public types beyond re-export.

## Follow-up

Once this lands and `@electric-ax/agents` ships a new release, OpenFactory drops the vendored tarball + the file:-dep and re-pins to the real semver.