### PR TITLE
feat(agents): support Ed25519 webhook signing

### DIFF
--- a/.changeset/healthy-webhooks-sign.md
+++ b/.changeset/healthy-webhooks-sign.md
@@ -1,0 +1,6 @@
+---
+"@electric-ax/agents-server": patch
+"@electric-ax/agents-runtime": patch
+---
+
+Update Durable Streams server webhook support to Ed25519/JWKS signatures. Agents-server now exposes its own stream-root JWKS endpoint, supports injectable webhook signing keys/signers, rewrites subscription signing metadata to the agents-server JWKS, and re-signs forwarded webhook deliveries. Agents-runtime now validates webhook signatures before dispatching wakes.

--- a/.changeset/healthy-webhooks-sign.md
+++ b/.changeset/healthy-webhooks-sign.md
@@ -3,4 +3,4 @@
 "@electric-ax/agents-runtime": patch
 ---
 
-Update Durable Streams server webhook support to Ed25519/JWKS signatures. Agents-server now exposes its own stream-root JWKS endpoint, supports injectable webhook signing keys/signers, rewrites subscription signing metadata to the agents-server JWKS, re-signs forwarded webhook deliveries, and preserves bodyless upstream 204/205/304 subscription responses. Agents-runtime now validates webhook signatures before dispatching wakes.
+Update Durable Streams server webhook support to Ed25519/JWKS signatures. Agents-server now exposes its own stream-root JWKS endpoint, supports injectable webhook signing keys/signers, validates upstream Durable Streams webhook signatures, rewrites subscription signing metadata to the agents-server JWKS, re-signs forwarded webhook deliveries, and preserves bodyless upstream 204/205/304 subscription responses. Agents-runtime now validates webhook signatures before dispatching wakes.

--- a/.changeset/healthy-webhooks-sign.md
+++ b/.changeset/healthy-webhooks-sign.md
@@ -3,4 +3,4 @@
 "@electric-ax/agents-runtime": patch
 ---
 
-Update Durable Streams server webhook support to Ed25519/JWKS signatures. Agents-server now exposes its own stream-root JWKS endpoint, supports injectable webhook signing keys/signers, rewrites subscription signing metadata to the agents-server JWKS, and re-signs forwarded webhook deliveries. Agents-runtime now validates webhook signatures before dispatching wakes.
+Update Durable Streams server webhook support to Ed25519/JWKS signatures. Agents-server now exposes its own stream-root JWKS endpoint, supports injectable webhook signing keys/signers, rewrites subscription signing metadata to the agents-server JWKS, re-signs forwarded webhook deliveries, and preserves bodyless upstream 204/205/304 subscription responses. Agents-runtime now validates webhook signatures before dispatching wakes.

--- a/packages/agents-runtime/package.json
+++ b/packages/agents-runtime/package.json
@@ -100,7 +100,7 @@
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
-    "@durable-streams/server": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217",
+    "@durable-streams/server": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^22.19.15",
     "@types/turndown": "^5.0.6",

--- a/packages/agents-runtime/src/create-handler.ts
+++ b/packages/agents-runtime/src/create-handler.ts
@@ -10,8 +10,10 @@ import { DEFAULT_OUTPUT_SCHEMAS } from './default-output-schemas'
 import { passthrough } from './entity-schema'
 import { runtimeLog } from './log'
 import { appendPathToUrl } from './url'
+import { verifyWebhookSignature } from './webhook-signature'
 import type { EntityRegistry } from './define-entity'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { WebhookSignatureVerifierConfig } from './webhook-signature'
 import type {
   AgentTool,
   EntityStreamDBWithActions,
@@ -51,6 +53,11 @@ export interface RuntimeRouterConfig {
   ) => DispatchPolicy | undefined
   /** Additional headers sent to agents-server control-plane requests. */
   serverHeaders?: HeadersProvider
+  /**
+   * Webhook signature verification. Enabled by default against
+   * `${baseUrl}/__ds/jwks.json`; set to false only for trusted in-process tests.
+   */
+  webhookSignature?: false | Partial<WebhookSignatureVerifierConfig>
   /** Idle timeout in ms before closing the wake (default: 20_000) */
   idleTimeout?: number
   /** Heartbeat interval in ms (default: 10_000) */
@@ -181,6 +188,7 @@ export function createRuntimeRouter(
     publicUrl,
     name: runtimeName,
     serverHeaders,
+    webhookSignature,
   } = normalized
 
   const wakeConfig: ProcessWakeConfig = {
@@ -311,9 +319,23 @@ export function createRuntimeRouter(
       return json({ error: `Method not allowed` }, 405)
     }
 
+    const body = new Uint8Array(await request.arrayBuffer())
+    if (webhookSignature) {
+      const verification = await verifyWebhookSignature(
+        body,
+        request.headers.get(`webhook-signature`),
+        webhookSignature
+      )
+      if (!verification.ok) {
+        return json({ error: verification.error }, verification.status)
+      }
+    }
+
     let notification: WebhookNotification
     try {
-      notification = (await request.json()) as WebhookNotification
+      notification = JSON.parse(
+        new TextDecoder().decode(body)
+      ) as WebhookNotification
     } catch (err) {
       return json(
         {
@@ -591,10 +613,22 @@ function normalizeConfig(config: RuntimeRouterConfig): {
   registrationConcurrency?: number
   publicUrl?: string
   name?: string
+  webhookSignature: false | WebhookSignatureVerifierConfig
 } {
   const serveEndpoint = config.serveEndpoint ?? config.handlerUrl
   const webhookPath =
     config.webhookPath ?? getPathname(serveEndpoint) ?? `/electric-agents`
+  const webhookSignature =
+    config.webhookSignature === false
+      ? false
+      : {
+          jwksUrl:
+            config.webhookSignature?.jwksUrl ??
+            appendPathToUrl(config.baseUrl, `/__ds/jwks.json`),
+          toleranceSeconds: config.webhookSignature?.toleranceSeconds,
+          cacheTtlMs: config.webhookSignature?.cacheTtlMs,
+          fetchClient: config.webhookSignature?.fetchClient,
+        }
 
   return {
     baseUrl: config.baseUrl,
@@ -610,6 +644,7 @@ function normalizeConfig(config: RuntimeRouterConfig): {
     registrationConcurrency: config.registrationConcurrency,
     publicUrl: config.publicUrl,
     name: config.name,
+    webhookSignature,
   }
 }
 

--- a/packages/agents-runtime/src/index.ts
+++ b/packages/agents-runtime/src/index.ts
@@ -227,6 +227,7 @@ export type {
 } from './model-runner'
 
 export { createRuntimeHandler, createRuntimeRouter } from './create-handler'
+export { verifyWebhookSignature } from './webhook-signature'
 export { createPullWakeRunner } from './pull-wake-runner'
 export type {
   RuntimeRouter,
@@ -235,6 +236,12 @@ export type {
   RuntimeHandlerConfig,
   RuntimeHandlerResult,
 } from './create-handler'
+export type {
+  WebhookJwks,
+  WebhookPublicJwk,
+  WebhookSignatureVerificationResult,
+  WebhookSignatureVerifierConfig,
+} from './webhook-signature'
 export type {
   PullWakeEvent,
   PullWakeRunner,

--- a/packages/agents-runtime/src/webhook-signature.ts
+++ b/packages/agents-runtime/src/webhook-signature.ts
@@ -1,0 +1,184 @@
+import { createPublicKey, verify as verifySignature } from 'node:crypto'
+import type { JsonWebKey as NodeJsonWebKey } from 'node:crypto'
+
+export interface WebhookPublicJwk {
+  kty: `OKP`
+  crv: `Ed25519`
+  x: string
+  kid: string
+  use?: `sig`
+  alg?: `EdDSA`
+}
+
+export interface WebhookJwks {
+  keys: Array<WebhookPublicJwk>
+}
+
+export interface WebhookSignatureVerifierConfig {
+  jwksUrl: string
+  toleranceSeconds?: number
+  cacheTtlMs?: number
+  fetchClient?: typeof fetch
+}
+
+export type WebhookSignatureVerificationResult =
+  | { ok: true }
+  | { ok: false; status: number; error: string }
+
+interface CachedJwks {
+  jwks: WebhookJwks
+  expiresAt: number
+}
+
+const DEFAULT_TOLERANCE_SECONDS = 300
+const DEFAULT_CACHE_TTL_MS = 300_000
+const encoder = new TextEncoder()
+const jwksCache = new Map<string, CachedJwks>()
+
+export async function verifyWebhookSignature(
+  body: Uint8Array,
+  signatureHeader: string | null,
+  config: WebhookSignatureVerifierConfig
+): Promise<WebhookSignatureVerificationResult> {
+  if (!signatureHeader?.trim()) {
+    return { ok: false, status: 401, error: `Missing webhook signature` }
+  }
+
+  const parsed = parseSignatureHeader(signatureHeader)
+  if (!parsed) {
+    return { ok: false, status: 401, error: `Invalid webhook signature` }
+  }
+
+  const toleranceSeconds = config.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS
+  const now = Math.floor(Date.now() / 1000)
+  if (Math.abs(now - parsed.timestamp) > toleranceSeconds) {
+    return { ok: false, status: 401, error: `Webhook signature expired` }
+  }
+
+  let jwks: WebhookJwks
+  try {
+    jwks = await fetchWebhookJwks(config)
+  } catch (err) {
+    return {
+      ok: false,
+      status: 503,
+      error: err instanceof Error ? err.message : `JWKS fetch failed`,
+    }
+  }
+
+  const jwk = jwks.keys.find((key) => key.kid === parsed.kid)
+  if (!jwk) {
+    return { ok: false, status: 401, error: `Unknown webhook signing key` }
+  }
+
+  try {
+    const publicKey = createPublicKey({
+      key: jwk as unknown as NodeJsonWebKey,
+      format: `jwk`,
+    })
+    const ok = verifySignature(
+      null,
+      bytesWithTimestamp(parsed.timestampText, body),
+      publicKey,
+      Buffer.from(parsed.signature, `base64url`)
+    )
+    return ok
+      ? { ok: true }
+      : { ok: false, status: 401, error: `Invalid webhook signature` }
+  } catch {
+    return { ok: false, status: 401, error: `Invalid webhook signature` }
+  }
+}
+
+function parseSignatureHeader(header: string): {
+  timestamp: number
+  timestampText: string
+  kid: string
+  signature: string
+} | null {
+  const values = new Map<string, string>()
+  for (const part of header.split(`,`)) {
+    const index = part.indexOf(`=`)
+    if (index <= 0) return null
+    const key = part.slice(0, index).trim()
+    const value = part.slice(index + 1).trim()
+    if (!key || !value) return null
+    values.set(key, value)
+  }
+
+  const timestampText = values.get(`t`)
+  const kid = values.get(`kid`)
+  const signature = values.get(`ed25519`)
+  if (!timestampText || !kid || !signature) return null
+  if (!/^\d+$/.test(timestampText)) return null
+  if (!/^[A-Za-z0-9_-]+$/.test(signature)) return null
+
+  return {
+    timestamp: Number.parseInt(timestampText, 10),
+    timestampText,
+    kid,
+    signature,
+  }
+}
+
+async function fetchWebhookJwks(
+  config: WebhookSignatureVerifierConfig
+): Promise<WebhookJwks> {
+  const now = Date.now()
+  const cached = jwksCache.get(config.jwksUrl)
+  if (cached && cached.expiresAt > now) return cached.jwks
+
+  const fetchClient = config.fetchClient ?? fetch
+  const response = await fetchClient(config.jwksUrl, {
+    headers: { accept: `application/jwk-set+json, application/json` },
+  })
+  if (!response.ok) {
+    throw new Error(`JWKS fetch failed: ${response.status}`)
+  }
+
+  const jwks = (await response.json()) as WebhookJwks
+  if (
+    !jwks ||
+    typeof jwks !== `object` ||
+    !Array.isArray(jwks.keys) ||
+    jwks.keys.some((key) => !isWebhookPublicJwk(key))
+  ) {
+    throw new Error(`JWKS response did not contain Ed25519 keys`)
+  }
+
+  jwksCache.set(config.jwksUrl, {
+    jwks,
+    expiresAt: now + cacheTtlMs(response, config.cacheTtlMs),
+  })
+  return jwks
+}
+
+function cacheTtlMs(response: Response, configured?: number): number {
+  if (configured !== undefined) return configured
+  const cacheControl = response.headers.get(`cache-control`) ?? ``
+  const maxAge = cacheControl.match(/(?:^|,\s*)max-age=(\d+)(?:\s*,|$)/i)
+  if (!maxAge) return DEFAULT_CACHE_TTL_MS
+  return Number.parseInt(maxAge[1]!, 10) * 1000
+}
+
+function isWebhookPublicJwk(value: unknown): value is WebhookPublicJwk {
+  if (!value || typeof value !== `object` || Array.isArray(value)) {
+    return false
+  }
+  const jwk = value as Partial<WebhookPublicJwk>
+  return (
+    jwk.kty === `OKP` &&
+    jwk.crv === `Ed25519` &&
+    typeof jwk.x === `string` &&
+    typeof jwk.kid === `string` &&
+    (jwk.use === undefined || jwk.use === `sig`) &&
+    (jwk.alg === undefined || jwk.alg === `EdDSA`)
+  )
+}
+
+function bytesWithTimestamp(timestamp: string, body: Uint8Array): Buffer {
+  return Buffer.concat([
+    Buffer.from(encoder.encode(`${timestamp}.`)),
+    Buffer.from(body),
+  ])
+}

--- a/packages/agents-runtime/test/create-handler.test.ts
+++ b/packages/agents-runtime/test/create-handler.test.ts
@@ -1,3 +1,4 @@
+import { createHash, generateKeyPairSync, sign } from 'node:crypto'
 import { Readable } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -6,6 +7,7 @@ import {
 } from '../src/create-handler'
 import { clearRegistry, defineEntity } from '../src/define-entity'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { KeyObject } from 'node:crypto'
 import type {
   StandardJSONSchemaV1,
   StandardSchemaV1,
@@ -66,6 +68,51 @@ function flushAsyncWork(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
+function signedWebhookRequest(
+  url: string,
+  body: string,
+  opts: {
+    kid: string
+    privateKey: KeyObject
+  }
+): Request {
+  const timestamp = Math.floor(Date.now() / 1000)
+  const payload = Buffer.concat([
+    Buffer.from(`${timestamp}.`),
+    Buffer.from(body),
+  ])
+  const signature = sign(null, payload, opts.privateKey).toString(`base64url`)
+  return new Request(url, {
+    method: `POST`,
+    headers: {
+      'content-type': `application/json`,
+      'webhook-signature': `t=${timestamp},kid=${opts.kid},ed25519=${signature}`,
+    },
+    body,
+  })
+}
+
+function publicJwkForKey(publicKey: KeyObject): {
+  kty: `OKP`
+  crv: `Ed25519`
+  x: string
+  kid: string
+  use: `sig`
+  alg: `EdDSA`
+} {
+  const exported = publicKey.export({ format: `jwk` }) as {
+    kty: `OKP`
+    crv: `Ed25519`
+    x: string
+  }
+  const kid = `ds_${createHash(`sha256`)
+    .update(
+      JSON.stringify({ crv: exported.crv, kty: exported.kty, x: exported.x })
+    )
+    .digest(`base64url`)}`
+  return { ...exported, kid, use: `sig`, alg: `EdDSA` }
+}
+
 describe(`createRuntimeHandler`, () => {
   beforeEach(() => {
     clearRegistry()
@@ -111,6 +158,7 @@ describe(`createRuntimeHandler`, () => {
       handlerUrl: `http://localhost:4000/electric-agents`,
       heartbeatInterval: 15_000,
       idleTimeout: 60_000,
+      webhookSignature: false,
     })
     const req = makeRequest(JSON.stringify(notification))
     const res = makeResponse()
@@ -167,6 +215,7 @@ describe(`createRuntimeHandler`, () => {
     const handler = createRuntimeHandler({
       baseUrl: `http://localhost:3000`,
       handlerUrl: `http://localhost:4000/electric-agents`,
+      webhookSignature: false,
     })
 
     const response = await handler.handleWebhookRequest(
@@ -203,6 +252,7 @@ describe(`createRuntimeHandler`, () => {
     const handler = createRuntimeHandler({
       baseUrl: `http://localhost:3000`,
       handlerUrl: `http://localhost:4000/electric-agents`,
+      webhookSignature: false,
     })
 
     const notification = {
@@ -256,6 +306,7 @@ describe(`createRuntimeHandler`, () => {
     const handler = createRuntimeHandler({
       baseUrl: `http://localhost:3000`,
       handlerUrl: `http://localhost:4000/electric-agents`,
+      webhookSignature: false,
     })
     const req = makeRequest(`{not-json`)
     const res = makeResponse()
@@ -309,6 +360,7 @@ describe(`createRuntimeHandler`, () => {
     const router = createRuntimeRouter({
       baseUrl: `http://localhost:3000`,
       webhookPath: `/custom-runtime`,
+      webhookSignature: false,
     })
 
     const response = await router.handleRequest(
@@ -323,6 +375,7 @@ describe(`createRuntimeHandler`, () => {
     const router = createRuntimeRouter({
       baseUrl: `http://localhost:3000`,
       webhookPath: `/custom-runtime`,
+      webhookSignature: false,
     })
 
     const notification = {
@@ -366,6 +419,7 @@ describe(`createRuntimeHandler`, () => {
       baseUrl: `http://localhost:3000`,
       webhookPath: `/custom-runtime`,
       serveEndpoint: `http://localhost:4000/custom-runtime`,
+      webhookSignature: false,
     })
 
     const notification = {
@@ -406,6 +460,97 @@ describe(`createRuntimeHandler`, () => {
         idleTimeout: undefined,
         shutdownSignal: expect.any(AbortSignal),
       })
+    )
+  })
+
+  it(`rejects unsigned webhook requests by default`, async () => {
+    defineEntity(`test-agent`, { handler: async () => {} })
+
+    const router = createRuntimeRouter({
+      baseUrl: `http://localhost:3000`,
+      webhookPath: `/custom-runtime`,
+    })
+
+    const response = await router.handleWebhookRequest(
+      new Request(`http://localhost/custom-runtime`, {
+        method: `POST`,
+        headers: { 'content-type': `application/json` },
+        body: JSON.stringify({
+          entity: {
+            type: `test-agent`,
+            url: `http://localhost:3000/test-agent/test-1`,
+          },
+        }),
+      })
+    )
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({
+      error: `Missing webhook signature`,
+    })
+    expect(processWakeMock).not.toHaveBeenCalled()
+  })
+
+  it(`verifies Ed25519 webhook signatures against the configured JWKS`, async () => {
+    defineEntity(`test-agent`, { handler: async () => {} })
+
+    const { privateKey, publicKey } = generateKeyPairSync(`ed25519`)
+    const jwk = publicJwkForKey(publicKey)
+    const jwksUrl = `http://localhost:3000/__ds/jwks.json?test=valid`
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValue(
+      new Response(JSON.stringify({ keys: [jwk] }), {
+        headers: {
+          'content-type': `application/jwk-set+json`,
+          'cache-control': `public, max-age=300`,
+        },
+      })
+    )
+    const router = createRuntimeRouter({
+      baseUrl: `http://localhost:3000`,
+      webhookPath: `/custom-runtime`,
+      webhookSignature: { jwksUrl },
+    })
+
+    const notification = {
+      consumerId: `consumer-1`,
+      epoch: 1,
+      wakeId: `wake-1`,
+      streamPath: `/streams/entity:test-1`,
+      streams: [{ path: `/streams/entity:test-1`, offset: `0_0` }],
+      callback: `http://localhost:3000/_electric/wakes/wake-1`,
+      claimToken: `tok-1`,
+      entity: {
+        type: `test-agent`,
+        status: `active`,
+        url: `http://localhost:3000/test-agent/test-1`,
+        streams: {
+          main: `/streams/entity:test-1`,
+          error: `/streams/entity-error:test-1`,
+        },
+      },
+    }
+    const body = JSON.stringify(notification)
+
+    const response = await router.handleWebhookRequest(
+      signedWebhookRequest(`http://localhost/custom-runtime`, body, {
+        kid: jwk.kid,
+        privateKey,
+      })
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledWith(
+      jwksUrl,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          accept: `application/jwk-set+json, application/json`,
+        }),
+      })
+    )
+    expect(processWakeMock).toHaveBeenCalledWith(
+      notification,
+      expect.objectContaining({ baseUrl: `http://localhost:3000` })
     )
   })
 

--- a/packages/agents-server/package.json
+++ b/packages/agents-server/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@durable-streams/client": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217",
-    "@durable-streams/server": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217",
+    "@durable-streams/server": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f",
     "@durable-streams/state": "https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217",
     "@electric-ax/agents-runtime": "workspace:*",
     "@electric-sql/client": "^1.5.18",

--- a/packages/agents-server/src/entrypoint-lib.ts
+++ b/packages/agents-server/src/entrypoint-lib.ts
@@ -139,6 +139,10 @@ export function resolveElectricAgentsEntrypointOptions(
     `ELECTRIC_URL`,
   ])
   const electricSecret = readEnv(env, [`ELECTRIC_AGENTS_ELECTRIC_SECRET`])
+  const webhookSigningKey = readEnv(env, [
+    `ELECTRIC_AGENTS_WEBHOOK_SIGNING_PRIVATE_KEY`,
+    `WEBHOOK_SIGNING_PRIVATE_KEY`,
+  ])
   const baseUrl = readEnv(env, [`ELECTRIC_AGENTS_BASE_URL`, `BASE_URL`])
   return {
     service: readEnv(env, [`ELECTRIC_AGENTS_SERVICE`, `SERVICE`]),
@@ -153,6 +157,7 @@ export function resolveElectricAgentsEntrypointOptions(
       ? validateUrl(`Electric URL`, electricUrl)
       : undefined,
     electricSecret,
+    webhookSigningKey,
     host: readEnv(env, [`ELECTRIC_AGENTS_HOST`, `HOST`]) ?? DEFAULT_HOST,
     port: readPort(env),
     workingDirectory:

--- a/packages/agents-server/src/index.ts
+++ b/packages/agents-server/src/index.ts
@@ -46,6 +46,19 @@ export type {
   DurableStreamsRoutingAdapter,
   DurableStreamsRoutingInput,
 } from './routing/durable-streams-routing-adapter.js'
+export {
+  createEd25519WebhookSigner,
+  getDefaultWebhookSigner,
+  webhookSigningMetadata,
+} from './webhook-signing.js'
+export type {
+  Ed25519WebhookSignerOptions,
+  WebhookJwks,
+  WebhookPublicJwk,
+  WebhookSigner,
+  WebhookSigningKeyInput,
+  WebhookSigningMetadata,
+} from './webhook-signing.js'
 export type { EntityBridgeCoordinator } from './entity-bridge-manager.js'
 export {
   DEFAULT_TENANT_ID,

--- a/packages/agents-server/src/routing/context.ts
+++ b/packages/agents-server/src/routing/context.ts
@@ -1,4 +1,5 @@
 import type { Agent } from 'undici'
+import type { WebhookSignatureVerifierConfig } from '@electric-ax/agents-runtime'
 import type { DrizzleDB } from '../db/index.js'
 import type { EntityBridgeCoordinator } from '../entity-bridge-manager.js'
 import type { EntityManager } from '../entity-manager.js'
@@ -25,6 +26,9 @@ export interface TenantContext {
   durableStreamsBearer?: DurableStreamsBearerProvider
   durableStreamsRouting?: DurableStreamsRoutingAdapter
   durableStreamsDispatcher: Agent
+  durableStreamsWebhookSignature?:
+    | false
+    | Partial<WebhookSignatureVerifierConfig>
   webhookSigner?: WebhookSigner
   electricUrl?: string
   electricSecret?: string

--- a/packages/agents-server/src/routing/context.ts
+++ b/packages/agents-server/src/routing/context.ts
@@ -7,6 +7,7 @@ import type { StreamClient } from '../stream-client.js'
 import type { DurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
 import type { Principal } from '../principal.js'
 import type { DurableStreamsBearerProvider } from '../stream-client.js'
+import type { WebhookSigner } from '../webhook-signing.js'
 
 /**
  * Per-request tenant context passed through every router and handler.
@@ -24,6 +25,7 @@ export interface TenantContext {
   durableStreamsBearer?: DurableStreamsBearerProvider
   durableStreamsRouting?: DurableStreamsRoutingAdapter
   durableStreamsDispatcher: Agent
+  webhookSigner?: WebhookSigner
   electricUrl?: string
   electricSecret?: string
   ownAgentHandlerPaths?: ReadonlyArray<string>

--- a/packages/agents-server/src/routing/durable-streams-router.ts
+++ b/packages/agents-server/src/routing/durable-streams-router.ts
@@ -100,11 +100,20 @@ function bodyFromBytes(body: Uint8Array): ArrayBuffer {
 }
 
 function responseFromUpstream(response: Response, body?: Uint8Array): Response {
-  return new Response(body ? bodyFromBytes(body) : response.body, {
+  const responseBody = forbidsResponseBody(response.status)
+    ? null
+    : body !== undefined
+      ? bodyFromBytes(body)
+      : response.body
+  return new Response(responseBody, {
     status: response.status,
     statusText: response.statusText,
     headers: responseHeaders(response),
   })
+}
+
+function forbidsResponseBody(status: number): boolean {
+  return status === 204 || status === 205 || status === 304
 }
 
 async function forwardToDurableStreams(

--- a/packages/agents-server/src/routing/durable-streams-router.ts
+++ b/packages/agents-server/src/routing/durable-streams-router.ts
@@ -15,10 +15,15 @@ import {
 import { validateBody } from './schema.js'
 import { rewriteLoopbackWebhookUrl } from '../utils/webhook-url.js'
 import { forwardFetchRequest } from '../utils/server-utils.js'
+import {
+  getDefaultWebhookSigner,
+  webhookSigningMetadata,
+} from '../webhook-signing.js'
 import { resolveDurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
 import type { IRequest, RouterType } from 'itty-router'
 import type { TenantContext } from './context.js'
 import type { DurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
+import type { WebhookSigner } from '../webhook-signing.js'
 
 const subscriptionProxyBodySchema = Type.Object(
   {
@@ -81,6 +86,7 @@ for (const action of subscriptionControlActions) {
     subscriptionAction(action)
   )
 }
+durableStreamsRouter.get(`/__ds/jwks.json`, webhookJwks)
 durableStreamsRouter.all(`/__ds`, controlPassThrough)
 durableStreamsRouter.all(`/__ds/*`, controlPassThrough)
 durableStreamsRouter.post(`*`, streamAppend)
@@ -178,12 +184,12 @@ function rewriteSubscriptionBodyForBackend(
   }
 }
 
-function rewriteSubscriptionResponseForClient(
+async function rewriteSubscriptionResponseForClient(
   bytes: Uint8Array,
   response: Response,
-  service: string,
+  ctx: TenantContext,
   routingAdapter: DurableStreamsRoutingAdapter
-): Uint8Array {
+): Promise<Uint8Array> {
   if (!response.headers.get(`content-type`)?.includes(`application/json`)) {
     return bytes
   }
@@ -192,14 +198,14 @@ function rewriteSubscriptionResponseForClient(
 
   if (typeof payload.pattern === `string`) {
     payload.pattern = routingAdapter.toRuntimeStreamPath(
-      service,
+      ctx.service,
       payload.pattern
     )
   }
   if (Array.isArray(payload.streams)) {
     payload.streams = payload.streams.map((stream) => {
       if (typeof stream === `string`) {
-        return routingAdapter.toRuntimeStreamPath(service, stream)
+        return routingAdapter.toRuntimeStreamPath(ctx.service, stream)
       }
       if (
         stream &&
@@ -209,7 +215,7 @@ function rewriteSubscriptionResponseForClient(
         return {
           ...(stream as Record<string, unknown>),
           path: routingAdapter.toRuntimeStreamPath(
-            service,
+            ctx.service,
             (stream as Record<string, string>).path
           ),
         }
@@ -219,25 +225,42 @@ function rewriteSubscriptionResponseForClient(
   }
   if (typeof payload.wake_stream === `string`) {
     payload.wake_stream = routingAdapter.toRuntimeStreamPath(
-      service,
+      ctx.service,
       payload.wake_stream
     )
   }
   if (typeof payload.stream === `string`) {
-    payload.stream = routingAdapter.toRuntimeStreamPath(service, payload.stream)
+    payload.stream = routingAdapter.toRuntimeStreamPath(
+      ctx.service,
+      payload.stream
+    )
   }
   if (Array.isArray(payload.acks)) {
     payload.acks = payload.acks.map((ack) => {
       if (!ack || typeof ack !== `object`) return ack
       const next = { ...(ack as Record<string, unknown>) }
       if (typeof next.stream === `string`) {
-        next.stream = routingAdapter.toRuntimeStreamPath(service, next.stream)
+        next.stream = routingAdapter.toRuntimeStreamPath(
+          ctx.service,
+          next.stream
+        )
       }
       if (typeof next.path === `string`) {
-        next.path = routingAdapter.toRuntimeStreamPath(service, next.path)
+        next.path = routingAdapter.toRuntimeStreamPath(ctx.service, next.path)
       }
       return next
     })
+  }
+  if (
+    payload.webhook &&
+    typeof payload.webhook === `object` &&
+    !Array.isArray(payload.webhook)
+  ) {
+    const webhook = payload.webhook as Record<string, unknown>
+    webhook.signing = await webhookSigningMetadata(
+      resolveWebhookSigner(ctx),
+      ctx.publicUrl
+    )
   }
 
   return new TextEncoder().encode(JSON.stringify(payload))
@@ -267,6 +290,10 @@ function subscriptionRoutingAdapter(
     ctx.durableStreamsRouting,
     ctx.durableStreamsUrl
   )
+}
+
+function resolveWebhookSigner(ctx: TenantContext): WebhookSigner {
+  return ctx.webhookSigner ?? getDefaultWebhookSigner()
 }
 
 async function rewriteSubscriptionRequestBody(
@@ -334,10 +361,10 @@ async function forwardSubscriptionRequest(
   let responseBytes: Uint8Array = upstream.body
     ? new Uint8Array(await upstream.arrayBuffer())
     : new Uint8Array()
-  responseBytes = rewriteSubscriptionResponseForClient(
+  responseBytes = await rewriteSubscriptionResponseForClient(
     responseBytes,
     upstream,
-    ctx.service,
+    ctx,
     routingAdapter
   )
   return {
@@ -528,6 +555,19 @@ async function controlPassThrough(
     `control`
   )
   return responseFromUpstream(upstream)
+}
+
+async function webhookJwks(
+  _request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  return new Response(JSON.stringify(await resolveWebhookSigner(ctx).jwks()), {
+    status: 200,
+    headers: {
+      'content-type': `application/jwk-set+json`,
+      'cache-control': `public, max-age=300`,
+    },
+  })
 }
 
 async function streamAppend(

--- a/packages/agents-server/src/routing/internal-router.ts
+++ b/packages/agents-server/src/routing/internal-router.ts
@@ -139,11 +139,20 @@ function bodyFromBytes(body: Uint8Array): ArrayBuffer {
 }
 
 function responseFromUpstream(response: Response, body?: Uint8Array): Response {
-  return new Response(body ? bodyFromBytes(body) : response.body, {
+  const responseBody = forbidsResponseBody(response.status)
+    ? null
+    : body !== undefined
+      ? bodyFromBytes(body)
+      : response.body
+  return new Response(responseBody, {
     status: response.status,
     statusText: response.statusText,
     headers: responseHeaders(response),
   })
+}
+
+function forbidsResponseBody(status: number): boolean {
+  return status === 204 || status === 205 || status === 304
 }
 
 function forwardHeadersFromRequest(request: IRequest): Headers {

--- a/packages/agents-server/src/routing/internal-router.ts
+++ b/packages/agents-server/src/routing/internal-router.ts
@@ -20,6 +20,7 @@ import {
 import { ATTR, tracer } from '../tracing.js'
 import { decodeJsonObject } from '../utils/server-utils.js'
 import { serverLog } from '../utils/log.js'
+import { getDefaultWebhookSigner } from '../webhook-signing.js'
 import { cronRouter } from './cron-router.js'
 import { resolveDurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
 import { electricProxyRouter } from './electric-proxy-router.js'
@@ -32,6 +33,7 @@ import { withLeadingSlash } from './tenant-stream-paths.js'
 import type { IRequest, RouterType } from 'itty-router'
 import type { TenantContext } from './context.js'
 import type { DurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
+import type { WebhookSigner } from '../webhook-signing.js'
 
 const wakeRegistrationBodySchema = Type.Object({
   subscriberUrl: Type.String(),
@@ -154,6 +156,10 @@ function durableStreamsSubscriptionCallback(value: string): string | null {
   return value.startsWith(DS_SUBSCRIPTION_CALLBACK_PREFIX)
     ? value.slice(DS_SUBSCRIPTION_CALLBACK_PREFIX.length)
     : null
+}
+
+function resolveWebhookSigner(ctx: TenantContext): WebhookSigner {
+  return ctx.webhookSigner ?? getDefaultWebhookSigner()
 }
 
 function claimTokenFromRequest(request: IRequest): string | undefined {
@@ -439,6 +445,10 @@ async function webhookForward(
   const headers = forwardHeadersFromRequest(request)
   headers.set(`content-type`, `application/json`)
   headers.delete(`content-length`)
+  headers.set(
+    `webhook-signature`,
+    await resolveWebhookSigner(ctx).sign(forwardBody)
+  )
 
   let upstream: Response
   try {

--- a/packages/agents-server/src/routing/internal-router.ts
+++ b/packages/agents-server/src/routing/internal-router.ts
@@ -2,7 +2,10 @@
  * Sub-router for /_electric/* control-plane routes.
  */
 
-import { appendPathToUrl } from '@electric-ax/agents-runtime'
+import {
+  appendPathToUrl,
+  verifyWebhookSignature,
+} from '@electric-ax/agents-runtime'
 import { Type, type Static } from '@sinclair/typebox'
 import { and, eq } from 'drizzle-orm'
 import { Router, json, status } from 'itty-router'
@@ -16,10 +19,12 @@ import {
   ErrCodeCallbackNotFound,
   ErrCodeForkInProgress,
   ErrCodeSubscriptionNotFound,
+  ErrCodeUnauthorized,
 } from '../electric-agents-types.js'
 import { ATTR, tracer } from '../tracing.js'
 import { decodeJsonObject } from '../utils/server-utils.js'
 import { serverLog } from '../utils/log.js'
+import { applyDurableStreamsBearer } from '../stream-client.js'
 import { getDefaultWebhookSigner } from '../webhook-signing.js'
 import { cronRouter } from './cron-router.js'
 import { resolveDurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
@@ -31,6 +36,7 @@ import { runnersRouter } from './runners-router.js'
 import { routeBody, validateOptionalJsonBody, withSchema } from './schema.js'
 import { withLeadingSlash } from './tenant-stream-paths.js'
 import type { IRequest, RouterType } from 'itty-router'
+import type { WebhookSignatureVerifierConfig } from '@electric-ax/agents-runtime'
 import type { TenantContext } from './context.js'
 import type { DurableStreamsRoutingAdapter } from './durable-streams-routing-adapter.js'
 import type { WebhookSigner } from '../webhook-signing.js'
@@ -171,6 +177,83 @@ function resolveWebhookSigner(ctx: TenantContext): WebhookSigner {
   return ctx.webhookSigner ?? getDefaultWebhookSigner()
 }
 
+function durableStreamsWebhookJwksUrl(ctx: TenantContext): string {
+  if (!ctx.durableStreamsRouting) {
+    return appendPathToUrl(ctx.durableStreamsUrl, `/__ds/jwks.json`)
+  }
+
+  return resolveDurableStreamsRoutingAdapter(
+    ctx.durableStreamsRouting,
+    ctx.durableStreamsUrl
+  )
+    .controlUrl({
+      durableStreamsUrl: ctx.durableStreamsUrl,
+      serviceId: ctx.service,
+      requestUrl: appendPathToUrl(ctx.publicUrl, `/__ds/jwks.json`),
+    })
+    .toString()
+}
+
+function durableStreamsJwksFetchClient(ctx: TenantContext): typeof fetch {
+  return async (input, init) => {
+    const headers = new Headers(init?.headers)
+    await applyDurableStreamsBearer(headers, ctx.durableStreamsBearer, {
+      overwrite: false,
+    })
+    const nextInit: RequestInit & {
+      dispatcher?: TenantContext[`durableStreamsDispatcher`]
+    } = {
+      ...(init ?? {}),
+      headers,
+    }
+    if (ctx.durableStreamsDispatcher) {
+      nextInit.dispatcher = ctx.durableStreamsDispatcher
+    }
+    return await fetch(input, nextInit as RequestInit)
+  }
+}
+
+function resolveDurableStreamsWebhookSignature(
+  ctx: TenantContext
+): false | WebhookSignatureVerifierConfig {
+  if (ctx.durableStreamsWebhookSignature === false) return false
+
+  return {
+    jwksUrl:
+      ctx.durableStreamsWebhookSignature?.jwksUrl ??
+      durableStreamsWebhookJwksUrl(ctx),
+    toleranceSeconds: ctx.durableStreamsWebhookSignature?.toleranceSeconds,
+    cacheTtlMs: ctx.durableStreamsWebhookSignature?.cacheTtlMs,
+    fetchClient:
+      ctx.durableStreamsWebhookSignature?.fetchClient ??
+      durableStreamsJwksFetchClient(ctx),
+  }
+}
+
+async function verifyDurableStreamsWebhook(
+  request: IRequest,
+  ctx: TenantContext,
+  body: Uint8Array
+): Promise<Response | null> {
+  const config = resolveDurableStreamsWebhookSignature(ctx)
+  if (config === false) return null
+
+  const verification = await verifyWebhookSignature(
+    body,
+    request.headers.get(`webhook-signature`),
+    config
+  )
+  if (verification.ok) return null
+
+  return apiError(
+    verification.status,
+    verification.status === 401
+      ? ErrCodeUnauthorized
+      : `WEBHOOK_SIGNATURE_UNAVAILABLE`,
+    verification.error
+  )
+}
+
 function claimTokenFromRequest(request: IRequest): string | undefined {
   const electricClaimToken = request.headers.get(`electric-claim-token`)?.trim()
   if (electricClaimToken) return electricClaimToken
@@ -264,7 +347,11 @@ async function webhookForward(
     subscriptionId
   )
 
-  const lookupPromise: Promise<string | null> = tracer.startActiveSpan(
+  const body = await readRequestBody(request as Request)
+  const signatureError = await verifyDurableStreamsWebhook(request, ctx, body)
+  if (signatureError) return signatureError
+
+  const targetWebhookUrl: string | null = await tracer.startActiveSpan(
     `db.lookupSubscription`,
     async (span) => {
       try {
@@ -284,11 +371,6 @@ async function webhookForward(
       }
     }
   )
-
-  const [targetWebhookUrl, body] = await Promise.all([
-    lookupPromise,
-    readRequestBody(request as Request),
-  ])
 
   if (!targetWebhookUrl) {
     return apiError(

--- a/packages/agents-server/src/server.ts
+++ b/packages/agents-server/src/server.ts
@@ -19,6 +19,7 @@ import {
 } from './electric-agents-types.js'
 import { ElectricAgentsError } from './entity-manager.js'
 import { serverLog } from './utils/log.js'
+import { createEd25519WebhookSigner } from './webhook-signing.js'
 import type { DrizzleDB, PgClient } from './db/index.js'
 import type { Server } from 'node:http'
 import type { DurableStreamTestServer } from '@durable-streams/server'
@@ -34,6 +35,10 @@ import type { DurableStreamsRoutingAdapter } from './routing/durable-streams-rou
 import type { OssServerContext } from './routing/oss-server-router.js'
 import type { StartedStandaloneAgentsRuntime } from './standalone-runtime.js'
 import type { DurableStreamsBearerProvider } from './stream-client.js'
+import type {
+  WebhookSigner,
+  WebhookSigningKeyInput,
+} from './webhook-signing.js'
 
 const MOCK_AGENT_HANDLER_PATH = `/_electric/mock-agent-handler`
 
@@ -45,6 +50,8 @@ export interface ElectricAgentsServerOptions {
   durableStreamsBearer?: DurableStreamsBearerProvider
   durableStreamsRouting?: DurableStreamsRoutingAdapter
   durableStreamsServer?: DurableStreamTestServer
+  webhookSigner?: WebhookSigner
+  webhookSigningKey?: WebhookSigningKeyInput
   port: number
   host?: string
   workingDirectory?: string
@@ -141,6 +148,7 @@ export class ElectricAgentsServer {
   private shuttingDown = false
   private streamsAgent?: Agent
   private standaloneRuntime?: StartedStandaloneAgentsRuntime
+  private readonly webhookSigner: WebhookSigner
 
   streamClient: StreamClient
   readonly options: ElectricAgentsServerOptions
@@ -152,6 +160,9 @@ export class ElectricAgentsServer {
       )
     }
     this.options = options
+    this.webhookSigner =
+      options.webhookSigner ??
+      createEd25519WebhookSigner({ privateKey: options.webhookSigningKey })
     this.streamClient = options.durableStreamsUrl
       ? new StreamClient(options.durableStreamsUrl, {
           bearer: options.durableStreamsBearer,
@@ -413,6 +424,7 @@ export class ElectricAgentsServer {
       durableStreamsBearer: this.options.durableStreamsBearer,
       durableStreamsRouting: this.options.durableStreamsRouting,
       durableStreamsDispatcher: this.streamsAgent,
+      webhookSigner: this.webhookSigner,
       electricUrl: this.options.electricUrl,
       electricSecret: this.options.electricSecret,
       ownAgentHandlerPaths: this.mockAgentBootstrap

--- a/packages/agents-server/src/server.ts
+++ b/packages/agents-server/src/server.ts
@@ -28,6 +28,7 @@ import type {
   AgentModel,
   EntityRegistry,
   RuntimeHandler,
+  WebhookSignatureVerifierConfig,
 } from '@electric-ax/agents-runtime'
 import type { Principal } from './principal.js'
 import type { EntityBridgeCoordinator } from './entity-bridge-manager.js'
@@ -50,6 +51,9 @@ export interface ElectricAgentsServerOptions {
   durableStreamsBearer?: DurableStreamsBearerProvider
   durableStreamsRouting?: DurableStreamsRoutingAdapter
   durableStreamsServer?: DurableStreamTestServer
+  durableStreamsWebhookSignature?:
+    | false
+    | Partial<WebhookSignatureVerifierConfig>
   webhookSigner?: WebhookSigner
   webhookSigningKey?: WebhookSigningKeyInput
   port: number
@@ -424,6 +428,8 @@ export class ElectricAgentsServer {
       durableStreamsBearer: this.options.durableStreamsBearer,
       durableStreamsRouting: this.options.durableStreamsRouting,
       durableStreamsDispatcher: this.streamsAgent,
+      durableStreamsWebhookSignature:
+        this.options.durableStreamsWebhookSignature,
       webhookSigner: this.webhookSigner,
       electricUrl: this.options.electricUrl,
       electricSecret: this.options.electricSecret,

--- a/packages/agents-server/src/stream-client.ts
+++ b/packages/agents-server/src/stream-client.ts
@@ -44,11 +44,17 @@ export interface SubscriptionResponse {
   type?: `webhook` | `pull-wake`
   pattern?: string
   streams?: Array<string | SubscriptionStreamInfo>
-  webhook?: { url?: string }
+  webhook?: {
+    url?: string
+    signing?: {
+      alg?: string
+      kid?: string
+      jwks_url?: string
+    }
+  }
   wake_stream?: string
   callback_url?: string
   callback_token?: string
-  webhook_secret?: string
 }
 
 export interface SubscriptionCreateInput {
@@ -535,14 +541,14 @@ export class StreamClient {
     subscriptionId: string,
     webhookUrl: string,
     description?: string
-  ): Promise<{ subscription_id: string; webhook_secret?: string }> {
+  ): Promise<SubscriptionResponse> {
     const res = await this.putSubscription(subscriptionId, {
       type: `webhook`,
       pattern: normalizeSubscriptionPattern(pattern),
       webhook: { url: webhookUrl },
       ...(description ? { description } : {}),
     })
-    return res as { subscription_id: string; webhook_secret?: string }
+    return res
   }
 
   async putSubscription(

--- a/packages/agents-server/src/webhook-signing.ts
+++ b/packages/agents-server/src/webhook-signing.ts
@@ -1,0 +1,173 @@
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign,
+} from 'node:crypto'
+import { appendPathToUrl } from '@electric-ax/agents-runtime'
+import type { JsonWebKey as NodeJsonWebKey, KeyObject } from 'node:crypto'
+
+export interface WebhookPublicJwk {
+  kty: `OKP`
+  crv: `Ed25519`
+  x: string
+  kid: string
+  use: `sig`
+  alg: `EdDSA`
+}
+
+export interface WebhookJwks {
+  keys: Array<WebhookPublicJwk>
+}
+
+export interface WebhookSigningMetadata {
+  alg: `ed25519`
+  kid: string
+  jwks_url: string
+}
+
+export interface WebhookSigner {
+  sign: (body: Uint8Array | string) => string | Promise<string>
+  jwks: () => WebhookJwks | Promise<WebhookJwks>
+}
+
+export type WebhookSigningKeyInput =
+  | string
+  | Buffer
+  | NodeJsonWebKey
+  | KeyObject
+
+export interface Ed25519WebhookSignerOptions {
+  privateKey?: WebhookSigningKeyInput
+  kid?: string
+}
+
+const encoder = new TextEncoder()
+const defaultWebhookSigner = createEd25519WebhookSigner()
+
+export function createEd25519WebhookSigner(
+  options: Ed25519WebhookSignerOptions = {}
+): WebhookSigner {
+  const privateKey = options.privateKey
+    ? importPrivateKey(options.privateKey)
+    : generateKeyPairSync(`ed25519`).privateKey
+
+  if (privateKey.asymmetricKeyType !== `ed25519`) {
+    throw new Error(`Webhook signing key must be an Ed25519 private key`)
+  }
+
+  const publicJwk = buildPublicJwk(privateKey, options.kid)
+
+  return {
+    sign: (body) => signWebhookBody(privateKey, publicJwk.kid, body),
+    jwks: () => ({ keys: [{ ...publicJwk }] }),
+  }
+}
+
+export function getDefaultWebhookSigner(): WebhookSigner {
+  return defaultWebhookSigner
+}
+
+export async function webhookSigningMetadata(
+  signer: WebhookSigner,
+  streamRootUrl: string
+): Promise<WebhookSigningMetadata> {
+  const jwks = await signer.jwks()
+  const key = jwks.keys[0]
+  if (!key) {
+    throw new Error(`Webhook signer did not provide any public keys`)
+  }
+
+  return {
+    alg: `ed25519`,
+    kid: key.kid,
+    jwks_url: appendPathToUrl(streamRootUrl, `/__ds/jwks.json`),
+  }
+}
+
+export function signWebhookBody(
+  privateKey: KeyObject,
+  kid: string,
+  body: Uint8Array | string
+): string {
+  const timestamp = Math.floor(Date.now() / 1000)
+  const payload = bytesWithTimestamp(timestamp, body)
+  const signature = sign(null, payload, privateKey).toString(`base64url`)
+  return `t=${timestamp},kid=${kid},ed25519=${signature}`
+}
+
+export function bytesWithTimestamp(
+  timestamp: number | string,
+  body: Uint8Array | string
+): Buffer {
+  const prefix = encoder.encode(`${timestamp}.`)
+  const bodyBytes = typeof body === `string` ? encoder.encode(body) : body
+  return Buffer.concat([Buffer.from(prefix), Buffer.from(bodyBytes)])
+}
+
+function importPrivateKey(input: WebhookSigningKeyInput): KeyObject {
+  if (isKeyObject(input)) return input
+
+  if (typeof input === `string`) {
+    const trimmed = input.trim()
+    if (trimmed.startsWith(`{`)) {
+      return createPrivateKey({
+        key: JSON.parse(trimmed) as NodeJsonWebKey,
+        format: `jwk`,
+      })
+    }
+    return createPrivateKey(trimmed.replace(/\\n/g, `\n`))
+  }
+
+  if (Buffer.isBuffer(input)) {
+    return createPrivateKey(input)
+  }
+
+  return createPrivateKey({ key: input, format: `jwk` })
+}
+
+function isKeyObject(input: WebhookSigningKeyInput): input is KeyObject {
+  return (
+    typeof input === `object` && `type` in input && input.type === `private`
+  )
+}
+
+function buildPublicJwk(
+  privateKey: KeyObject,
+  kid: string | undefined
+): WebhookPublicJwk {
+  const exported = createPublicKey(privateKey).export({ format: `jwk` }) as {
+    kty?: string
+    crv?: string
+    x?: string
+  }
+
+  if (exported.kty !== `OKP` || exported.crv !== `Ed25519` || !exported.x) {
+    throw new Error(`Failed to export Ed25519 webhook signing key`)
+  }
+
+  return {
+    kty: `OKP`,
+    crv: `Ed25519`,
+    x: exported.x,
+    kid:
+      kid ??
+      deriveKeyId({
+        kty: exported.kty,
+        crv: exported.crv,
+        x: exported.x,
+      }),
+    use: `sig`,
+    alg: `EdDSA`,
+  }
+}
+
+function deriveKeyId(jwk: { kty: string; crv: string; x: string }): string {
+  const thumbprintInput = JSON.stringify({
+    crv: jwk.crv,
+    kty: jwk.kty,
+    x: jwk.x,
+  })
+  return `ds_${createHash(`sha256`).update(thumbprintInput).digest(`base64url`)}`
+}

--- a/packages/agents-server/test/electric-agents-routes.test.ts
+++ b/packages/agents-server/test/electric-agents-routes.test.ts
@@ -68,6 +68,16 @@ function fakeInsertDb() {
   }
 }
 
+function fakeDeleteDb() {
+  const where = vi.fn().mockResolvedValue(undefined)
+  const delete_ = vi.fn(() => ({ where }))
+  return {
+    db: { delete: delete_ },
+    delete: delete_,
+    where,
+  }
+}
+
 const serviceRoutedTestAdapter: DurableStreamsRoutingAdapter = {
   streamUrl(input) {
     const incomingUrl = new URL(input.requestUrl, `http://localhost`)
@@ -565,6 +575,33 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
           },
         },
       })
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it(`forwards successful subscription deletes as bodyless 204 responses`, async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, `fetch`)
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    const db = fakeDeleteDb()
+
+    try {
+      const result = await globalRouter.fetch(
+        createRequest(`DELETE`, `/__ds/subscriptions/horton-handler`),
+        {
+          service: `tenant-a`,
+          durableStreamsUrl: `http://durable.local/v1/stream/tenant-a`,
+          pgDb: db.db,
+          isShuttingDown: () => false,
+        } as unknown as TenantContext
+      )
+
+      expect(result.status).toBe(204)
+      await expect(result.text()).resolves.toBe(``)
+      expect(fetchSpy).toHaveBeenCalledOnce()
+      expect(db.delete).toHaveBeenCalledOnce()
+      expect(db.where).toHaveBeenCalledOnce()
     } finally {
       fetchSpy.mockRestore()
     }

--- a/packages/agents-server/test/electric-agents-routes.test.ts
+++ b/packages/agents-server/test/electric-agents-routes.test.ts
@@ -96,6 +96,15 @@ const serviceRoutedTestAdapter: DurableStreamsRoutingAdapter = {
   },
 }
 
+const testJwk = {
+  kty: `OKP` as const,
+  crv: `Ed25519` as const,
+  x: `test-public-key`,
+  kid: `ds_test`,
+  use: `sig` as const,
+  alg: `EdDSA` as const,
+}
+
 describe(`ElectricAgentsRoutes schedule endpoints`, () => {
   it(`routes future-send schedule upserts to the manager and returns txid`, async () => {
     const manager = {
@@ -437,6 +446,29 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
     }
   })
 
+  it(`serves the agents-server webhook signing JWKS at the stream root`, async () => {
+    const webhookSigner = {
+      sign: vi.fn(),
+      jwks: vi.fn(() => ({ keys: [testJwk] })),
+    }
+
+    const result = await globalRouter.fetch(
+      createRequest(`GET`, `/__ds/jwks.json`),
+      {
+        service: `tenant-a`,
+        publicUrl: `http://agents.local`,
+        durableStreamsUrl: `http://durable.local/v1/stream/tenant-a`,
+        webhookSigner,
+        isShuttingDown: () => false,
+      } as unknown as TenantContext
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.headers.get(`content-type`)).toBe(`application/jwk-set+json`)
+    expect(result.headers.get(`cache-control`)).toBe(`public, max-age=300`)
+    await expect(result.json()).resolves.toEqual({ keys: [testJwk] })
+  })
+
   it(`rewrites webhook subscription targets and keeps the original target locally`, async () => {
     const fetchSpy = vi
       .spyOn(globalThis, `fetch`)
@@ -475,6 +507,63 @@ describe(`ElectricAgentsRoutes shared-state streams`, () => {
         tenantId: `tenant-a`,
         subscriptionId: `horton-handler`,
         webhookUrl: `http://localhost:4448/runtime-webhook`,
+      })
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it(`rewrites subscription webhook signing metadata to the agents-server JWKS`, async () => {
+    const fetchSpy = vi.spyOn(globalThis, `fetch`).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: `horton-handler`,
+          subscription_id: `horton-handler`,
+          type: `webhook`,
+          webhook: {
+            url: `http://agents.local/_electric/webhook-forward/horton-handler`,
+            signing: {
+              alg: `ed25519`,
+              kid: `ds_durable`,
+              jwks_url: `http://durable.local/v1/stream/__ds/jwks.json`,
+            },
+          },
+        }),
+        { status: 201, headers: { 'content-type': `application/json` } }
+      )
+    )
+    const db = fakeInsertDb()
+    const webhookSigner = {
+      sign: vi.fn(),
+      jwks: vi.fn(() => ({ keys: [testJwk] })),
+    }
+
+    try {
+      const result = await globalRouter.fetch(
+        createRequest(`PUT`, `/__ds/subscriptions/horton-handler`, {
+          type: `webhook`,
+          pattern: `horton/**`,
+          webhook: { url: `http://localhost:4448/runtime-webhook` },
+        }),
+        {
+          service: `tenant-a`,
+          publicUrl: `http://agents.local`,
+          durableStreamsUrl: `http://durable.local/v1/stream/tenant-a`,
+          webhookSigner,
+          pgDb: db.db,
+          isShuttingDown: () => false,
+        } as unknown as TenantContext
+      )
+
+      expect(result.status).toBe(201)
+      await expect(result.json()).resolves.toMatchObject({
+        webhook: {
+          signing: {
+            alg: `ed25519`,
+            kid: `ds_test`,
+            jwks_url: `http://agents.local/__ds/jwks.json`,
+          },
+        },
       })
     } finally {
       fetchSpy.mockRestore()

--- a/packages/agents-server/test/webhook-forward-routing.test.ts
+++ b/packages/agents-server/test/webhook-forward-routing.test.ts
@@ -136,6 +136,10 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
         headers: { 'content-type': `application/json` },
       })
     )
+    const webhookSigner = {
+      sign: vi.fn(() => `t=1,kid=ds_test,ed25519=test_signature`),
+      jwks: vi.fn(() => ({ keys: [] })),
+    }
 
     try {
       const response = await globalRouter.fetch(
@@ -156,6 +160,7 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
         }),
         buildContext({
           pgDb: { select: select.select, insert: insert.insert } as any,
+          webhookSigner,
         })
       )
 
@@ -177,6 +182,10 @@ describe(`webhook forwarding for Durable Streams subscriptions`, () => {
           url: `/horton/demo`,
         },
       })
+      expect(webhookSigner.sign).toHaveBeenCalledWith(expect.any(Uint8Array))
+      expect(new Headers(init?.headers).get(`webhook-signature`)).toBe(
+        `t=1,kid=ds_test,ed25519=test_signature`
+      )
       expect(insert.values).toHaveBeenCalledWith({
         tenantId: `tenant-a`,
         consumerId: `wake-1`,

--- a/packages/agents-server/test/webhook-forward-routing.test.ts
+++ b/packages/agents-server/test/webhook-forward-routing.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { ClaimWriteTokenStore } from '../src/claim-write-token-store'
 import { globalRouter } from '../src/routing/global-router'
+import { createEd25519WebhookSigner } from '../src/webhook-signing'
 import type { TenantContext } from '../src/routing/context'
 import type { DurableStreamsRoutingAdapter } from '../src/routing/durable-streams-routing-adapter'
+import type { WebhookSigner } from '../src/webhook-signing'
 
 function request(method: string, path: string, body?: unknown): Request {
   return new Request(`http://agents.local${path}`, {
@@ -10,6 +12,22 @@ function request(method: string, path: string, body?: unknown): Request {
     headers:
       body === undefined ? undefined : { 'content-type': `application/json` },
     body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+async function signedWebhookRequest(
+  path: string,
+  body: unknown,
+  signer: WebhookSigner
+): Promise<Request> {
+  const bodyText = JSON.stringify(body)
+  return new Request(`http://agents.local${path}`, {
+    method: `POST`,
+    headers: {
+      'content-type': `application/json`,
+      'webhook-signature': await signer.sign(bodyText),
+    },
+    body: bodyText,
   })
 }
 
@@ -40,6 +58,17 @@ function insertDb() {
   const values = vi.fn(() => ({ onConflictDoUpdate }))
   const insert = vi.fn(() => ({ values }))
   return { insert, values, onConflictDoUpdate }
+}
+
+function jwksFetch(signer: WebhookSigner): typeof fetch {
+  return vi.fn(async () => {
+    return new Response(JSON.stringify(await signer.jwks()), {
+      headers: {
+        'content-type': `application/jwk-set+json`,
+        'cache-control': `public, max-age=0`,
+      },
+    })
+  }) as unknown as typeof fetch
 }
 
 const serviceRoutedTestAdapter: DurableStreamsRoutingAdapter = {
@@ -95,6 +124,7 @@ function buildContext(overrides: Partial<TenantContext> = {}): TenantContext {
     publicUrl: `http://agents.local`,
     durableStreamsUrl: `http://durable.local/v1/stream/tenant-a`,
     durableStreamsDispatcher: undefined as any,
+    durableStreamsWebhookSignature: false,
     pgDb: undefined as any,
     entityManager: {
       registry: {
@@ -126,6 +156,133 @@ function buildContext(overrides: Partial<TenantContext> = {}): TenantContext {
 }
 
 describe(`webhook forwarding for Durable Streams subscriptions`, () => {
+  it(`validates upstream Durable Streams webhook signatures before forwarding`, async () => {
+    const select = selectDb([
+      { webhookUrl: `http://runtime.local/_electric/builtin-agent-handler` },
+    ])
+    const insert = insertDb()
+    const upstreamSigner = createEd25519WebhookSigner({ kid: `ds_upstream` })
+    const upstreamJwksUrl = `http://durable.local/v1/stream/tenant-a-default/__ds/jwks.json`
+    const downstreamSigner = {
+      sign: vi.fn(() => `t=1,kid=agents,ed25519=runtime_signature`),
+      jwks: vi.fn(() => ({ keys: [] })),
+    }
+    const fetchSpy = vi
+      .spyOn(globalThis, `fetch`)
+      .mockImplementation(async (input) => {
+        if (String(input) === upstreamJwksUrl) {
+          return new Response(JSON.stringify(await upstreamSigner.jwks()), {
+            headers: {
+              'content-type': `application/jwk-set+json`,
+              'cache-control': `public, max-age=0`,
+            },
+          })
+        }
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { 'content-type': `application/json` },
+        })
+      })
+
+    try {
+      const response = await globalRouter.fetch(
+        await signedWebhookRequest(
+          `/_electric/webhook-forward/horton-handler`,
+          {
+            subscription_id: `horton-handler`,
+            wake_id: `wake-signed`,
+            generation: 1,
+            streams: [
+              {
+                path: `horton/demo/main`,
+                acked_offset: `0`,
+                tail_offset: `1`,
+                has_pending: true,
+              },
+            ],
+            callback_url: `http://durable.local/v1/stream/tenant-a/__ds/subscriptions/horton-handler/callback`,
+            callback_token: `callback-token`,
+          },
+          upstreamSigner
+        ),
+        buildContext({
+          durableStreamsUrl: `http://durable.local/v1/stream/tenant-a-default`,
+          durableStreamsWebhookSignature: undefined,
+          pgDb: { select: select.select, insert: insert.insert } as any,
+          webhookSigner: downstreamSigner,
+        })
+      )
+
+      expect(response.status).toBe(200)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+      expect(String(fetchSpy.mock.calls[0]![0])).toBe(upstreamJwksUrl)
+      const forwardedHeaders = new Headers(fetchSpy.mock.calls[1]![1]?.headers)
+      expect(forwardedHeaders.get(`webhook-signature`)).toBe(
+        `t=1,kid=agents,ed25519=runtime_signature`
+      )
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it(`rejects webhook-forward requests with invalid upstream DS signatures`, async () => {
+    const select = selectDb([
+      { webhookUrl: `http://runtime.local/_electric/builtin-agent-handler` },
+    ])
+    const trustedSigner = createEd25519WebhookSigner({ kid: `ds_trusted` })
+    const untrustedSigner = createEd25519WebhookSigner({
+      kid: `ds_untrusted`,
+    })
+    const fetchJwks = jwksFetch(trustedSigner)
+    const fetchSpy = vi.spyOn(globalThis, `fetch`).mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { 'content-type': `application/json` },
+      })
+    )
+
+    try {
+      const response = await globalRouter.fetch(
+        await signedWebhookRequest(
+          `/_electric/webhook-forward/horton-handler`,
+          {
+            subscription_id: `horton-handler`,
+            wake_id: `wake-invalid`,
+            generation: 1,
+            streams: [
+              {
+                path: `horton/demo/main`,
+                acked_offset: `0`,
+                tail_offset: `1`,
+                has_pending: true,
+              },
+            ],
+          },
+          untrustedSigner
+        ),
+        buildContext({
+          durableStreamsWebhookSignature: {
+            jwksUrl: `http://durable.local/v1/stream/tenant-a/__ds/jwks.json?case=invalid`,
+            fetchClient: fetchJwks,
+            cacheTtlMs: 0,
+          },
+          pgDb: { select: select.select } as any,
+        })
+      )
+
+      expect(response.status).toBe(401)
+      await expect(response.json()).resolves.toMatchObject({
+        error: {
+          code: `UNAUTHORIZED`,
+          message: `Unknown webhook signing key`,
+        },
+      })
+      expect(fetchJwks).toHaveBeenCalledOnce()
+      expect(select.select).not.toHaveBeenCalled()
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   it(`adapts the new webhook wake payload into the runtime wake payload`, async () => {
     const select = selectDb([
       { webhookUrl: `http://runtime.local/_electric/builtin-agent-handler` },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1717,8 +1717,8 @@ importers:
         version: 3.25.2(zod@4.3.6)
     devDependencies:
       '@durable-streams/server':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f(typescript@5.8.3)
       '@types/jsdom':
         specifier: ^27.0.0
         version: 27.0.0
@@ -1750,8 +1750,8 @@ importers:
         specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
         version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
       '@durable-streams/server':
-        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217(typescript@5.8.3)
+        specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f(typescript@5.8.3)
       '@durable-streams/state':
         specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217
         version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
@@ -4174,14 +4174,26 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217':
-    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217}
-    version: 0.3.1
+  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@eac712f':
+    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@eac712f}
+    version: 0.2.4
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f':
+    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f}
+    version: 0.3.2
     engines: {node: '>=18.0.0'}
 
   '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217':
     resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217}
     version: 0.2.5
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@eac712f':
+    resolution: {tarball: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@eac712f}
+    version: 0.2.6
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -23177,10 +23189,15 @@ snapshots:
       '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
       fastq: 1.20.1
 
-  '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@5d5c217(typescript@5.8.3)':
+  '@durable-streams/client@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@eac712f':
     dependencies:
-      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
-      '@durable-streams/state': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
+      '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
+      fastq: 1.20.1
+
+  '@durable-streams/server@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/server@eac712f(typescript@5.8.3)':
+    dependencies:
+      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@eac712f
+      '@durable-streams/state': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@eac712f(typescript@5.8.3)
       '@neophi/sieve-cache': 1.5.0
       lmdb: 3.5.4
       pino: 10.3.1
@@ -23191,6 +23208,14 @@ snapshots:
   '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)':
     dependencies:
       '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@5d5c217
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db': 0.6.5(typescript@5.8.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@durable-streams/state@https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@eac712f(typescript@5.8.3)':
+    dependencies:
+      '@durable-streams/client': https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/client@eac712f
       '@standard-schema/spec': 1.1.0
       '@tanstack/db': 0.6.5(typescript@5.8.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Motivation

Durable Streams webhook subscriptions now expose Ed25519 signing metadata instead of returning per-subscription `webhook_secret` values. The signature is attached to each delivery as `Webhook-Signature: t=<timestamp>,kid=<key-id>,ed25519=<base64url-signature>`, and receivers discover public keys at the stream-root control path: `{stream-root}/__ds/jwks.json`.

Electric Agents cannot just pass the upstream Durable Streams signature through, because agents-server rewrites subscription targets and enriches webhook bodies before forwarding them to runtimes. Once the body changes, agents-server has to validate the original Durable Streams delivery, own the public signing metadata it advertises to runtimes, and re-sign each forwarded delivery.

## Changes

- Bump `@durable-streams/server` to the `eac712f` package in `agents-server` and the runtime test dependency.
- Add an agents-server webhook signing abstraction backed by Ed25519 keys.
- Serve agents-server public webhook signing keys at `GET /__ds/jwks.json` with `application/jwk-set+json` and public cache headers.
- Validate incoming Durable Streams webhook deliveries in agents-server before subscription lookup, body parsing, enrichment, or downstream forwarding.
- Rewrite webhook subscription responses so `webhook.signing.jwks_url` points at the agents-server stream root, not the upstream Durable Streams backend.
- Re-sign forwarded webhooks after agents-server adapts/enriches the body for the runtime.
- Allow runtime-bound signing to be injected per tenant through `TenantContext.webhookSigner`, or configured in the standalone server with `webhookSigner` / `webhookSigningKey` / `ELECTRIC_AGENTS_WEBHOOK_SIGNING_PRIVATE_KEY`.
- Allow upstream DS webhook verification to be customized per tenant with `TenantContext.durableStreamsWebhookSignature` or standalone `durableStreamsWebhookSignature`; default verification uses the upstream DS stream root JWKS.
- Add runtime-side Ed25519 webhook signature verification. It is enabled by default against `${baseUrl}/__ds/jwks.json` and can be customized or disabled with `webhookSignature`.
- Preserve bodyless upstream `204`/`205`/`304` subscription responses when rewrapping proxied DS responses.
- Remove `webhook_secret` from local subscription response typing and add the required changeset.

## Decisions

- The canonical JWKS URL exposed to runtimes is the agents-server stream root: `${publicUrl}/__ds/jwks.json`. This matches Durable Streams sub-root mounting rules and avoids publishing the upstream DS backend JWKS when agents-server is acting as the webhook boundary.
- Agents-server treats Durable Streams and agents-runtime as separate trust boundaries. It verifies the raw upstream DS webhook body against the upstream DS JWKS, then signs the mutated runtime body with the agents-server signer.
- Upstream DS verification defaults to `${durableStreamsUrl}/__ds/jwks.json` for normal stream-root routing, and uses the configured Durable Streams routing adapter for custom control-root routing.
- The default standalone server generates an Ed25519 signer in-process for local/dev use. Tenanted/cloud deployments should inject a stable tenant-aware signer instead of relying on that process-local default.
- Runtime verification fetches by `kid` from JWKS and validates the exact raw body bytes received by the runtime, preserving the required `timestamp.raw_body` signing contract.

## Paired tenanted-cloud update required

The tenanted cloud host should provide a `WebhookSigner` per tenant or per stream root when building `TenantContext` for agents-server routes. The signer needs to expose:

- `sign(body)` returning `t=<timestamp>,kid=<tenant-key-id>,ed25519=<signature>` over `<timestamp>.<raw_body>`.
- `jwks()` returning the tenant public key set with the matching `kid`.

For upstream Durable Streams validation, leave `TenantContext.durableStreamsWebhookSignature` unset only when the default upstream stream-root JWKS URL is correct and reachable by agents-server. If DS JWKS discovery needs tenant routing, internal auth, custom fetch plumbing, or a KMS-backed key cache, set `durableStreamsWebhookSignature` with the resolved `jwksUrl` and/or `fetchClient`. Do not set it to `false` outside trusted in-process tests.

For cloud rollout, make sure the tenant routing layer treats `GET {tenant-stream-root}/__ds/jwks.json` as an agents-server route for runtimes, not as an authenticated Durable Streams proxy pass-through. Subscription create/read responses should advertise that same tenant public URL in `webhook.signing.jwks_url`.

The agents-server process must also be able to fetch the upstream Durable Streams JWKS for the corresponding tenant stream root. If that upstream control path is behind service auth, wire the verification fetch client to include the required credentials.

The private key used by agents-server for runtime-bound signing must be stable across agent-server instances for the same tenant/stream root, or backed by a shared KMS/HSM signer. During rotation, publish old and new public keys in JWKS until all in-flight deliveries signed by the old key are outside the runtime tolerance window and any retry window you want to support.

If the cloud runtime talks to agents-server through tenant-auth headers, configure `webhookSignature.jwksUrl` or its `fetchClient` so runtime JWKS discovery can reach the tenant JWKS endpoint. Do not disable `webhookSignature` outside trusted in-process tests.
