### PR TITLE
fix(agents-desktop): restore shell PATH in packaged app

### DIFF
--- a/.changeset/fix-desktop-shell-path.md
+++ b/.changeset/fix-desktop-shell-path.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-desktop': patch
+---
+
+Restore the user's shell PATH in the packaged desktop app so CLI tools like `gh` are discoverable when launched from Finder or other GUI launchers.

--- a/packages/agents-desktop/package.json
+++ b/packages/agents-desktop/package.json
@@ -29,6 +29,7 @@
     "@electric-sql/client": "^1.5.18",
     "@mixmark-io/domino": "^2.2.0",
     "better-sqlite3": "^12.9.0",
+    "fix-path": "^4.0.0",
     "jsdom": "^28.1.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/packages/agents-desktop/src/main.ts
+++ b/packages/agents-desktop/src/main.ts
@@ -232,11 +232,8 @@ const INITIAL_SERVER_URL =
   process.env.ELECTRIC_AGENTS_SERVER_URL?.trim() ||
   null
 
-// Packaged macOS apps launched via Finder / LaunchServices do not inherit
-// the user's interactive shell PATH, so Homebrew-installed tools like `gh`
-// can disappear even though they work in Terminal. Normalize PATH up front in
-// the main process so all later child-process launches see the shell-resolved
-// command path.
+// GUI-launched desktop apps don't inherit the user's shell PATH — restore it
+// so child processes can find CLI tools like `gh`.
 fixPath()
 
 if (DESKTOP_USER_DATA_DIR) {

--- a/packages/agents-desktop/src/main.ts
+++ b/packages/agents-desktop/src/main.ts
@@ -27,6 +27,7 @@ import {
   session,
   shell,
 } from 'electron'
+import fixPath from 'fix-path'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { readFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
@@ -230,6 +231,13 @@ const INITIAL_SERVER_URL =
   process.env.ELECTRIC_DESKTOP_SERVER_URL?.trim() ||
   process.env.ELECTRIC_AGENTS_SERVER_URL?.trim() ||
   null
+
+// Packaged macOS apps launched via Finder / LaunchServices do not inherit
+// the user's interactive shell PATH, so Homebrew-installed tools like `gh`
+// can disappear even though they work in Terminal. Normalize PATH up front in
+// the main process so all later child-process launches see the shell-resolved
+// command path.
+fixPath()
 
 if (DESKTOP_USER_DATA_DIR) {
   app.setPath(`userData`, path.resolve(DESKTOP_USER_DATA_DIR))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1578,6 +1578,9 @@ importers:
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
+      fix-path:
+        specifier: ^4.0.0
+        version: 4.0.0
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0(@noble/hashes@2.0.1)
@@ -12204,6 +12207,10 @@ packages:
     resolution: {integrity: sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==}
     engines: {node: '>=18'}
 
+  default-shell@2.2.0:
+    resolution: {integrity: sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
@@ -13525,6 +13532,10 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  fix-path@4.0.0:
+    resolution: {integrity: sha512-g31GX207Tt+psI53ZSaB1egprYbEN0ZYl90aKcO22A2LmCNnFsSq3b5YpoKp3E/QEiWByTXGJOkFQG4S07Bc1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
@@ -17959,6 +17970,14 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-env@4.0.3:
+    resolution: {integrity: sha512-Ioe5h+hCDZ7pKL5+JGzbtPvZ5ESMHePZ8nLxohlDL+twmlcmutttMhRkrQOed8DeLT8mkYBgbwZfohe8pqaA3g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  shell-path@3.1.0:
+    resolution: {integrity: sha512-s/9q9PEtcRmDTz69+cJ3yYBAe9yGrL7e46gm2bU4pQ9N48ecPK9QrGFnLwYgb4smOHskx4PL7wCNMktW2AoD+g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
@@ -32580,6 +32599,8 @@ snapshots:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
 
+  default-shell@2.2.0: {}
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
@@ -34381,6 +34402,10 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fix-path@4.0.0:
+    dependencies:
+      shell-path: 3.1.0
 
   flat-cache@3.2.0:
     dependencies:
@@ -39834,6 +39859,16 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-env@4.0.3:
+    dependencies:
+      default-shell: 2.2.0
+      execa: 5.1.1
+      strip-ansi: 7.2.0
+
+  shell-path@3.1.0:
+    dependencies:
+      shell-env: 4.0.3
 
   shell-quote@1.8.1: {}
 


### PR DESCRIPTION
## Summary

Packaged Electron apps launched from Finder (macOS) or GUI launchers (Linux) don't inherit the user's interactive shell PATH. This means CLI tools installed via Homebrew, nix, or other package managers — like `gh` — silently disappear, even though they work fine in Terminal. This PR adds [`fix-path`](https://github.com/sindresorhus/fix-path) to restore the shell PATH at startup, before any child processes are spawned.

## Approach

Uses `fix-path` (by Sindre Sorhus), the de facto standard solution for this Electron issue — also used by VS Code. The library spawns the user's default login shell once at startup, reads its PATH, and replaces `process.env.PATH`. It no-ops on Windows where this isn't an issue.

`fixPath()` is called at module scope, before `app.setPath()` and `app.whenReady()`, ensuring all subsequent child process launches (e.g., the Bash tool in agents runtime) see the correct PATH.

**Non-goals:** This doesn't change PATH handling for any other package — it's scoped to the desktop app's main process.

## Verification

```bash
# Build the desktop app
pnpm --filter @electric-ax/agents-desktop dist:mac

# Launch from Finder (not Terminal) and verify CLI tools are found
# e.g. run a tool that invokes `gh` or other Homebrew-installed CLI
```

## Files changed

| File | Change |
|------|--------|
| `packages/agents-desktop/package.json` | Add `fix-path` ^4.0.0 dependency |
| `packages/agents-desktop/src/main.ts` | Import and call `fixPath()` early in startup |
| `pnpm-lock.yaml` | Lockfile update (adds `fix-path`, `shell-path`, `shell-env`, `default-shell`) |
| `.changeset/fix-desktop-shell-path.md` | Changeset for patch release |