### PR TITLE
test: reproduce desktop PR build

### DIFF
--- a/packages/agents-desktop/electron-builder.yml
+++ b/packages/agents-desktop/electron-builder.yml
@@ -10,6 +10,8 @@ files:
   - dist/**/*
   - assets/**/*
   - package.json
+  # Reproduction-only PR change: trigger the desktop app build without
+  # changing packaging behavior.
   - '!**/node_modules/@rollup/**'
 
 extraResources:


### PR DESCRIPTION
## Summary
- Adds a comment-only change in the desktop Electron builder config to trigger the Agents Desktop PR workflow.
- Does not change packaging, build, or runtime behavior; this PR is only to reproduce the desktop PR build path from `main`.

## Test plan
- CI should run `Agents Desktop PR` and exercise the reusable desktop app build workflow.


Made with [Cursor](https://cursor.com)