### PR TITLE
feat(agents-mobile): connect to Electric Cloud agent servers

### DIFF
--- a/.changeset/agents-mobile-cloud-fetch.md
+++ b/.changeset/agents-mobile-cloud-fetch.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-mobile': patch
+'@electric-ax/agents-server-ui': patch
+---
+
+Connect the Electric mobile app to Electric Cloud agent servers end-to-end. Trade the dashboard JWT for a per-service agents token, inject `Authorization`/`x-electric-service`/`electric-principal` on every outbound request (via `serverFetch` + `fetchClient` on shape collections, including the React Native long-poll `DurableStream`), forward those headers across the Expo DOM-embed boundary as a prop so the embed's own `auth-fetch` instance picks them up, switch URL composition to `appendPathToUrl` (Cloud URLs carry `?service=…`), spawn via the canonical `/_electric/entities/<type>/<name>` endpoint with `initialMessage` in the body (fixes a STREAM_NOT_FOUND race), and add a runner picker so users target a specific pull-wake runner.

--- a/packages/agents-mobile/app/session.tsx
+++ b/packages/agents-mobile/app/session.tsx
@@ -22,6 +22,7 @@ import {
 import type { EmbedViewId } from '../src/lib/embedView'
 import SessionChatLogDomEmbedModule from '@electric-ax/agents-server-ui/src/embed/SessionChatLogDomEmbed'
 import SessionStateInspectorDomEmbedModule from '@electric-ax/agents-server-ui/src/embed/SessionStateInspectorDomEmbed'
+import { getActiveServerHeadersSnapshot } from '@electric-ax/agents-server-ui/src/lib/auth-fetch'
 import type { OptimisticInboxMessage } from '@electric-ax/agents-server-ui/src/lib/sendMessage'
 
 const HEADER_HEIGHT = 44
@@ -35,6 +36,7 @@ type SessionDomEmbedProps = {
   onRequestOpenEntity: (entityUrl: string) => Promise<void>
   style?: StyleProp<ViewStyle>
   matchContents?: boolean
+  serverHeaders?: { url: string; headers: Record<string, string> } | null
   dom?: unknown
 }
 
@@ -67,6 +69,10 @@ export default function SessionRoute(): React.ReactElement {
     ? params.entityUrl[0]
     : (params.entityUrl ?? ``)
   const view = params.view === `state-explorer` ? `state-explorer` : `chat`
+
+  // Read once per render — the DOM embed receives this as a prop and
+  // re-registers it on its side of the JS-context boundary.
+  const serverHeaders = getActiveServerHeadersSnapshot()
 
   const embedTop = insets.top + HEADER_HEIGHT
   const composerInset =
@@ -124,6 +130,7 @@ export default function SessionRoute(): React.ReactElement {
             theme={scheme}
             scrollToBottomSignal={chatLogScrollSignal}
             inlineQueuedMessages={inlineQueuedMessages}
+            serverHeaders={serverHeaders}
             onRequestOpenEntity={async (target) => openSession(target)}
             dom={domOptions(styles, embedSize, tokens.bg)}
           />
@@ -134,6 +141,7 @@ export default function SessionRoute(): React.ReactElement {
             serverUrl={serverUrl}
             entityUrl={entityUrl}
             theme={scheme}
+            serverHeaders={serverHeaders}
             onRequestOpenEntity={async (target) => openSession(target)}
             dom={domOptions(styles, embedSize, tokens.bg)}
           />

--- a/packages/agents-mobile/src/lib/AgentsProvider.tsx
+++ b/packages/agents-mobile/src/lib/AgentsProvider.tsx
@@ -2,14 +2,17 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import {
   createEntitiesCollection,
   createEntityTypesCollection,
+  createRunnersCollection,
   type EntitiesCollection,
   type EntityTypesCollection,
+  type RunnersCollection,
 } from './agentsClient'
 
 type AgentsContextValue = {
   serverUrl: string
   entitiesCollection: EntitiesCollection
   entityTypesCollection: EntityTypesCollection
+  runnersCollection: RunnersCollection
 }
 
 const AgentsContext = createContext<AgentsContextValue | null>(null)
@@ -26,6 +29,7 @@ export function AgentsProvider({
       serverUrl,
       entitiesCollection: createEntitiesCollection(serverUrl),
       entityTypesCollection: createEntityTypesCollection(serverUrl),
+      runnersCollection: createRunnersCollection(serverUrl),
     }
   }, [serverUrl])
 

--- a/packages/agents-mobile/src/lib/MobileAppState.tsx
+++ b/packages/agents-mobile/src/lib/MobileAppState.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { ReactNode } from 'react'
+import { cloudAuth } from './cloudAuth'
+import { prepareServerHeaders } from './serverHeaders'
 
 const SERVER_URL_KEY = `electric-agents-mobile.server-url`
 const ONBOARDING_DISMISSED_KEY = `electric-agents-mobile.onboarding-dismissed`
@@ -31,16 +33,34 @@ export function MobileAppStateProvider({
   const [onboardingDismissed, setOnboardingDismissedState] = useState(false)
 
   useEffect(() => {
-    Promise.all([
-      AsyncStorage.getItem(SERVER_URL_KEY),
-      AsyncStorage.getItem(ONBOARDING_DISMISSED_KEY),
-    ])
-      .then(([storedUrl, storedOnboarding]) => {
-        setServerUrl(storedUrl)
-        setOnboardingDismissedState(storedOnboarding === `true`)
-      })
-      .finally(() => setLoading(false))
+    void (async () => {
+      const [storedUrl, storedOnboarding] = await Promise.all([
+        AsyncStorage.getItem(SERVER_URL_KEY),
+        AsyncStorage.getItem(ONBOARDING_DISMISSED_KEY),
+      ])
+      // Inject server headers BEFORE flipping `loading` to false so any
+      // screen that mounts on the next render already has auth-fetch
+      // headers registered. Otherwise a race window lets early fetches
+      // go out unauthenticated and 401 against Cloud servers.
+      await prepareServerHeaders(storedUrl)
+      setServerUrl(storedUrl)
+      setOnboardingDismissedState(storedOnboarding === `true`)
+      setLoading(false)
+    })()
   }, [])
+
+  // Re-apply headers on cloud-auth transitions so a fresh sign-in
+  // immediately makes the agents-token available to in-flight
+  // collections without restarting the app. Also re-runs on serverUrl
+  // change (covers `saveServerUrl`).
+  useEffect(() => {
+    if (loading) return
+    void prepareServerHeaders(serverUrl)
+    const unsubscribe = cloudAuth.subscribe(() => {
+      void prepareServerHeaders(serverUrl)
+    })
+    return unsubscribe
+  }, [serverUrl, loading])
 
   const value = useMemo<MobileAppState>(
     () => ({

--- a/packages/agents-mobile/src/lib/agentsClient.ts
+++ b/packages/agents-mobile/src/lib/agentsClient.ts
@@ -38,13 +38,27 @@ export const entityTypeSchema = z.object({
   updated_at: z.string(),
 })
 
+// Minimal subset of the runners shape — just the columns the mobile
+// picker needs to identify a runner and pass it as the dispatch
+// target on spawn.
+export const runnerSchema = z.object({
+  id: z.string(),
+  owner_principal: z.string(),
+  label: z.string(),
+  kind: z.string(),
+  admin_status: z.enum([`enabled`, `disabled`]),
+  last_seen_at: z.string().nullable().optional(),
+})
+
 export type ElectricEntity = z.infer<typeof entitySchema>
 export type ElectricEntityType = z.infer<typeof entityTypeSchema>
+export type ElectricRunner = z.infer<typeof runnerSchema>
 
 export type EntitiesCollection = ReturnType<typeof createEntitiesCollection>
 export type EntityTypesCollection = ReturnType<
   typeof createEntityTypesCollection
 >
+export type RunnersCollection = ReturnType<typeof createRunnersCollection>
 
 export function normalizeServerUrl(input: string): string {
   const trimmed = input.trim().replace(/\/+$/, ``)
@@ -115,14 +129,46 @@ export function createEntityTypesCollection(baseUrl: string) {
   )
 }
 
+export function createRunnersCollection(baseUrl: string) {
+  return createCollection(
+    electricCollectionOptions({
+      id: `mobile-runners:${baseUrl}`,
+      schema: runnerSchema,
+      shapeOptions: {
+        url: appendPathToUrl(baseUrl, `/_electric/electric/v1/shape`),
+        fetchClient: serverFetch,
+        params: {
+          table: `runners`,
+          columns: [
+            `id`,
+            `owner_principal`,
+            `label`,
+            `kind`,
+            `admin_status`,
+            `last_seen_at`,
+          ],
+        },
+      },
+      getKey: (item) => item.id,
+    })
+  )
+}
+
 export async function spawnEntity({
   baseUrl,
   type,
   initialMessage,
+  runnerId,
 }: {
   baseUrl: string
   type: string
   initialMessage?: string
+  // When set, the cloud agents-server routes wake events for this
+  // entity to the named pull-wake runner. Without it, dispatch falls
+  // back to the entity type's `default_dispatch_policy` — typically a
+  // webhook to a local serveEndpoint, which the cloud server can't
+  // reach.
+  runnerId?: string
 }): Promise<string> {
   const name = makeEntityName()
   const entityUrl = `/${type}/${name}`
@@ -135,6 +181,11 @@ export async function spawnEntity({
   const body: Record<string, unknown> = {}
   const text = initialMessage?.trim()
   if (text) body.initialMessage = text
+  if (runnerId) {
+    body.dispatch_policy = {
+      targets: [{ type: `runner`, runnerId }],
+    }
+  }
   const spawnRes = await serverFetch(
     appendPathToUrl(
       baseUrl,

--- a/packages/agents-mobile/src/lib/agentsClient.ts
+++ b/packages/agents-mobile/src/lib/agentsClient.ts
@@ -1,6 +1,7 @@
 import { createCollection } from '@tanstack/react-db'
 import { electricCollectionOptions } from '@tanstack/electric-db-collection'
 import { appendPathToUrl } from '@electric-ax/agents-runtime/client'
+import { serverFetch } from '@electric-ax/agents-server-ui/src/lib/auth-fetch'
 import { z } from 'zod'
 
 export type EntityStatus = `spawning` | `running` | `idle` | `stopped`
@@ -55,9 +56,10 @@ export function normalizeServerUrl(input: string): string {
 export async function checkServerHealth(serverUrl: string): Promise<void> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 5000)
-  const res = await fetch(appendPathToUrl(serverUrl, `/_electric/health`), {
-    signal: controller.signal,
-  }).finally(() => clearTimeout(timeout))
+  const res = await serverFetch(
+    appendPathToUrl(serverUrl, `/_electric/health`),
+    { signal: controller.signal }
+  ).finally(() => clearTimeout(timeout))
   if (!res.ok) {
     throw new Error(`Health check failed (${res.status})`)
   }
@@ -70,6 +72,9 @@ export function createEntitiesCollection(baseUrl: string) {
       schema: entitySchema,
       shapeOptions: {
         url: appendPathToUrl(baseUrl, `/_electric/electric/v1/shape`),
+        // Inject Authorization / x-electric-service from the active
+        // server's registered headers on every shape fetch.
+        fetchClient: serverFetch,
         params: {
           table: `entities`,
           columns: [
@@ -102,6 +107,7 @@ export function createEntityTypesCollection(baseUrl: string) {
       schema: entityTypeSchema,
       shapeOptions: {
         url: appendPathToUrl(baseUrl, `/_electric/electric/v1/shape`),
+        fetchClient: serverFetch,
         params: { table: `entity_types` },
       },
       getKey: (item) => item.name,
@@ -120,7 +126,7 @@ export async function spawnEntity({
 }): Promise<string> {
   const name = makeEntityName()
   const entityUrl = `/${type}/${name}`
-  const spawnRes = await fetch(appendPathToUrl(baseUrl, entityUrl), {
+  const spawnRes = await serverFetch(appendPathToUrl(baseUrl, entityUrl), {
     method: `PUT`,
     headers: { 'content-type': `application/json` },
     body: JSON.stringify({}),
@@ -131,14 +137,17 @@ export async function spawnEntity({
 
   const text = initialMessage?.trim()
   if (text) {
-    const sendRes = await fetch(appendPathToUrl(baseUrl, `${entityUrl}/send`), {
-      method: `POST`,
-      headers: { 'content-type': `application/json` },
-      body: JSON.stringify({
-        from: `user`,
-        payload: { text },
-      }),
-    })
+    const sendRes = await serverFetch(
+      appendPathToUrl(baseUrl, `${entityUrl}/send`),
+      {
+        method: `POST`,
+        headers: { 'content-type': `application/json` },
+        body: JSON.stringify({
+          from: `user`,
+          payload: { text },
+        }),
+      }
+    )
     if (!sendRes.ok) {
       throw new Error(await responseMessage(sendRes, `Send failed`))
     }

--- a/packages/agents-mobile/src/lib/agentsClient.ts
+++ b/packages/agents-mobile/src/lib/agentsClient.ts
@@ -126,31 +126,28 @@ export async function spawnEntity({
 }): Promise<string> {
   const name = makeEntityName()
   const entityUrl = `/${type}/${name}`
-  const spawnRes = await serverFetch(appendPathToUrl(baseUrl, entityUrl), {
-    method: `PUT`,
-    headers: { 'content-type': `application/json` },
-    body: JSON.stringify({}),
-  })
+  // Spawn endpoint lives under `/_electric/entities/<type>/<name>` and
+  // takes `initialMessage` in the request body — the server creates
+  // the entity, provisions its streams, and writes the first inbox
+  // row atomically. Doing this as PUT-then-POST(/send) used to race:
+  // the spawn ack could return before the streams were ready, and the
+  // immediate /send would 404 with STREAM_NOT_FOUND.
+  const body: Record<string, unknown> = {}
+  const text = initialMessage?.trim()
+  if (text) body.initialMessage = text
+  const spawnRes = await serverFetch(
+    appendPathToUrl(
+      baseUrl,
+      `/_electric/entities/${encodeURIComponent(type)}/${encodeURIComponent(name)}`
+    ),
+    {
+      method: `PUT`,
+      headers: { 'content-type': `application/json` },
+      body: JSON.stringify(body),
+    }
+  )
   if (!spawnRes.ok) {
     throw new Error(await responseMessage(spawnRes, `Spawn failed`))
-  }
-
-  const text = initialMessage?.trim()
-  if (text) {
-    const sendRes = await serverFetch(
-      appendPathToUrl(baseUrl, `${entityUrl}/send`),
-      {
-        method: `POST`,
-        headers: { 'content-type': `application/json` },
-        body: JSON.stringify({
-          from: `user`,
-          payload: { text },
-        }),
-      }
-    )
-    if (!sendRes.ok) {
-      throw new Error(await responseMessage(sendRes, `Send failed`))
-    }
   }
 
   return entityUrl

--- a/packages/agents-mobile/src/lib/cloudAuth.ts
+++ b/packages/agents-mobile/src/lib/cloudAuth.ts
@@ -165,6 +165,47 @@ function isExpired(expiresAtIso: string): boolean {
 }
 
 /**
+ * Pull the token out of the dashboard's `getTokenForAgents` response.
+ * The endpoint has seen both bare-string and JSON-wrapped shapes; this
+ * accepts either to stay forward-compatible across admin-API versions.
+ */
+function extractAgentsToken(body: unknown): string | null {
+  if (typeof body === `string`) {
+    const trimmed = body.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  if (!body || typeof body !== `object`) return null
+  const root = body as Record<string, unknown>
+  const inner =
+    `json` in root && root.json && typeof root.json === `object`
+      ? (root.json as Record<string, unknown>)
+      : root
+  for (const key of [`token`, `agents_token`, `agentsToken`] as const) {
+    const value = inner[key]
+    if (typeof value === `string` && value.trim().length > 0) {
+      return value.trim()
+    }
+  }
+  return null
+}
+
+/**
+ * Detect a Cloud agent-server URL and return the service-id embedded in
+ * its `?service=` query param. Returns `null` for local URLs (which
+ * don't need a service-scoped agents token).
+ */
+export function getCloudServiceIdFromServerUrl(
+  serverUrl: string
+): string | null {
+  try {
+    const parsed = new URL(serverUrl)
+    return parsed.searchParams.get(`service`)
+  } catch {
+    return null
+  }
+}
+
+/**
  * Singleton state machine that owns the cloud-auth session.
  *
  * The class isn't a React hook — instead the `CloudAuthContext` wraps
@@ -182,6 +223,10 @@ export class CloudAuth {
   }
   private listeners = new Set<(state: CloudAuthState) => void>()
   private initialized = false
+  // Per-service agents tokens fetched via `getTokenForAgents`. Kept in
+  // memory only — on restart they'll be re-fetched from the dashboard
+  // when the active server is restored. Cleared on sign-out.
+  private agentsTokens = new Map<string, string>()
 
   getState(): CloudAuthState {
     return this.state
@@ -312,6 +357,7 @@ export class CloudAuth {
 
   async signOut(): Promise<void> {
     await AsyncStorage.removeItem(STORAGE_KEY)
+    this.agentsTokens.clear()
     this.setState({
       status: `signed-out`,
       email: null,
@@ -328,6 +374,61 @@ export class CloudAuth {
     const stored = await this.loadStored()
     if (!stored || isExpired(stored.expiresAt)) return null
     return stored.token
+  }
+
+  /**
+   * Fetch (or return cached) per-service agents token for connecting to
+   * a Cloud agent server. Mirrors the desktop app's `prepareConnection`
+   * flow: trade the user's dashboard JWT for a service-scoped token via
+   * `/api/v1/services/streams/:serviceId/getTokenForAgents`, then cache
+   * it in memory so subsequent requests reuse the same token without an
+   * extra round-trip to the dashboard.
+   *
+   * Returns `null` when the user is signed out or the dashboard rejects
+   * the exchange (revoked session, no permission for this service);
+   * callers should fall back to unauthenticated requests, which the
+   * agents server will reject with 401 — exposing the failure to the
+   * UI rather than masking it.
+   */
+  async getAgentsToken(serviceId: string): Promise<string | null> {
+    const cached = this.agentsTokens.get(serviceId)
+    if (cached) return cached
+    const userToken = await this.getToken()
+    if (!userToken) return null
+    const url = new URL(
+      `/api/v1/services/streams/${encodeURIComponent(serviceId)}/getTokenForAgents`,
+      getCloudBaseUrl()
+    ).toString()
+    let res: Response
+    try {
+      res = await fetch(url, {
+        method: `POST`,
+        headers: {
+          'content-type': `application/json`,
+          authorization: `Bearer ${userToken}`,
+        },
+        body: `{}`,
+      })
+    } catch (err) {
+      console.warn(`[agents-mobile] cloud-auth: getTokenForAgents fetch:`, err)
+      return null
+    }
+    if (!res.ok) {
+      console.warn(
+        `[agents-mobile] cloud-auth: getTokenForAgents returned ${res.status}`
+      )
+      return null
+    }
+    let body: unknown
+    try {
+      body = await res.json()
+    } catch {
+      body = null
+    }
+    const token = extractAgentsToken(body)
+    if (!token) return null
+    this.agentsTokens.set(serviceId, token)
+    return token
   }
 
   /**

--- a/packages/agents-mobile/src/lib/serverHeaders.ts
+++ b/packages/agents-mobile/src/lib/serverHeaders.ts
@@ -33,13 +33,19 @@ export async function prepareServerHeaders(
   const token = await cloudAuth.getAgentsToken(serviceId)
   registerActiveBaseUrl(serverUrl)
   if (token) {
-    registerActiveServerHeaders({
-      url: serverUrl,
-      headers: {
-        authorization: `Bearer ${token}`,
-        'x-electric-service': serviceId,
-      },
-    })
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${token}`,
+      'x-electric-service': serviceId,
+    }
+    // Inform agents-server-ui's `resolveSenderPrincipalUrl` who the
+    // current user is. Without this, `sendMessage` falls back to
+    // `system:dev-local` (since `loadCloudAuthState` is gated on
+    // `window.electronAPI` and so returns `null` on React Native) —
+    // and the cloud server 400s because the sender doesn't match the
+    // authenticated bearer.
+    const userId = cloudAuth.getState().userId
+    if (userId) headers[`electric-principal`] = `user:${userId}`
+    registerActiveServerHeaders({ url: serverUrl, headers })
   } else {
     // Sign-in expired / token exchange failed — keep the base URL
     // registered (so URL-matching still works) but drop any stale

--- a/packages/agents-mobile/src/lib/serverHeaders.ts
+++ b/packages/agents-mobile/src/lib/serverHeaders.ts
@@ -1,0 +1,50 @@
+import { registerActiveServerHeaders } from '@electric-ax/agents-server-ui/src/lib/auth-fetch'
+import { registerActiveBaseUrl } from '@electric-ax/agents-server-ui/src/lib/entity-connection'
+import { cloudAuth, getCloudServiceIdFromServerUrl } from './cloudAuth'
+
+/**
+ * Bind the agents-server-ui auth-fetch / entity-connection modules to
+ * the mobile app's currently-active server URL. For Cloud agent servers
+ * (URL carries `?service=<id>`), we trade the user's dashboard JWT for
+ * a per-service agents token via `cloudAuth.getAgentsToken` and inject
+ * `Authorization: Bearer …` + `x-electric-service: <id>` on outbound
+ * requests. For local servers we just register the base URL.
+ *
+ * Pass `null` to clear (e.g. on sign-out or server reset).
+ *
+ * Mirrors what the desktop app does via Electron's
+ * `webRequest.onBeforeSendHeaders` — but in user-space, because React
+ * Native has no equivalent network interceptor.
+ */
+export async function prepareServerHeaders(
+  serverUrl: string | null
+): Promise<void> {
+  if (!serverUrl) {
+    registerActiveBaseUrl(null)
+    registerActiveServerHeaders(null)
+    return
+  }
+  const serviceId = getCloudServiceIdFromServerUrl(serverUrl)
+  if (!serviceId) {
+    registerActiveBaseUrl(serverUrl)
+    registerActiveServerHeaders(null)
+    return
+  }
+  const token = await cloudAuth.getAgentsToken(serviceId)
+  registerActiveBaseUrl(serverUrl)
+  if (token) {
+    registerActiveServerHeaders({
+      url: serverUrl,
+      headers: {
+        authorization: `Bearer ${token}`,
+        'x-electric-service': serviceId,
+      },
+    })
+  } else {
+    // Sign-in expired / token exchange failed — keep the base URL
+    // registered (so URL-matching still works) but drop any stale
+    // headers. Outbound requests will 401, surfacing the failure to
+    // the user rather than silently masking it.
+    registerActiveServerHeaders(null)
+  }
+}

--- a/packages/agents-mobile/src/screens/NewSessionScreen.tsx
+++ b/packages/agents-mobile/src/screens/NewSessionScreen.tsx
@@ -10,11 +10,16 @@ import {
   View,
 } from 'react-native'
 import { useLiveQuery } from '@tanstack/react-db'
+import { eq } from '@tanstack/db'
 import { Header, HeaderBackButton } from '../components/Header'
 import { PrimaryButton } from '../components/PrimaryButton'
 import { Screen } from '../components/Screen'
 import { useAgents } from '../lib/AgentsProvider'
-import { spawnEntity, type ElectricEntityType } from '../lib/agentsClient'
+import {
+  spawnEntity,
+  type ElectricEntityType,
+  type ElectricRunner,
+} from '../lib/agentsClient'
 import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
@@ -28,11 +33,12 @@ export function NewSessionScreen({
   onBack: () => void
   onOpenSession: (entityUrl: string) => void
 }): React.ReactElement {
-  const { entityTypesCollection, serverUrl } = useAgents()
+  const { entityTypesCollection, runnersCollection, serverUrl } = useAgents()
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const [message, setMessage] = useState(``)
   const [selectedType, setSelectedType] = useState<string | null>(null)
+  const [selectedRunner, setSelectedRunner] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -42,6 +48,15 @@ export function NewSessionScreen({
         .from({ type: entityTypesCollection })
         .orderBy(({ type }) => type.name, `asc`),
     [entityTypesCollection]
+  )
+
+  const { data: enabledRunners = [] } = useLiveQuery(
+    (query) =>
+      query
+        .from({ runner: runnersCollection })
+        .where(({ runner }) => eq(runner.admin_status, `enabled`))
+        .orderBy(({ runner }) => runner.label, `asc`),
+    [runnersCollection]
   )
 
   const visibleTypes = useMemo(
@@ -56,9 +71,22 @@ export function NewSessionScreen({
     [visibleTypes]
   )
   const activeTypeName = selectedType ?? defaultType?.name ?? null
+  // Auto-pick when there's exactly one runner so the common case
+  // (single desktop runtime) doesn't require a click.
+  const activeRunnerId =
+    selectedRunner ??
+    (enabledRunners.length === 1 ? enabledRunners[0]!.id : null)
 
   const start = async () => {
     if (!activeTypeName || loading) return
+    if (!activeRunnerId) {
+      setError(
+        enabledRunners.length === 0
+          ? `No runners are online for this server.`
+          : `Pick a runner to handle this session.`
+      )
+      return
+    }
     setLoading(true)
     setError(null)
     try {
@@ -66,6 +94,7 @@ export function NewSessionScreen({
         baseUrl: serverUrl,
         type: activeTypeName,
         initialMessage: message,
+        runnerId: activeRunnerId,
       })
       onOpenSession(entityUrl)
     } catch (err) {
@@ -132,6 +161,26 @@ export function NewSessionScreen({
             </Text>
           )}
 
+          <Text style={styles.sectionLabel}>Runner</Text>
+          {enabledRunners.length === 0 ? (
+            <Text style={styles.empty}>
+              No runners are online. Start a local runtime (e.g. the desktop
+              app) to register one.
+            </Text>
+          ) : (
+            <View style={styles.typeList}>
+              {enabledRunners.map((runner) => (
+                <RunnerCard
+                  key={runner.id}
+                  runner={runner}
+                  tokens={tokens}
+                  selected={runner.id === activeRunnerId}
+                  onPress={() => setSelectedRunner(runner.id)}
+                />
+              ))}
+            </View>
+          )}
+
           {error && (
             <View style={styles.errorRow}>
               <Text style={styles.errorText}>{error}</Text>
@@ -142,7 +191,7 @@ export function NewSessionScreen({
             <PrimaryButton
               title="Start session"
               loading={loading}
-              disabled={!activeTypeName || loading}
+              disabled={!activeTypeName || !activeRunnerId || loading}
               onPress={start}
             />
           </View>
@@ -175,6 +224,31 @@ function AgentTypeCard({
           {type.description}
         </Text>
       ) : null}
+    </TouchableOpacity>
+  )
+}
+
+function RunnerCard({
+  runner,
+  tokens,
+  selected,
+  onPress,
+}: {
+  runner: ElectricRunner
+  tokens: Tokens
+  selected: boolean
+  onPress: () => void
+}): React.ReactElement {
+  const styles = useMemo(() => createStyles(tokens), [tokens])
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={[styles.typeCard, selected ? styles.typeCardSelected : null]}
+    >
+      <Text style={styles.typeName}>{runner.label || runner.id}</Text>
+      <Text numberOfLines={1} style={styles.typeDescription}>
+        {runner.kind} · {runner.id}
+      </Text>
     </TouchableOpacity>
   )
 }

--- a/packages/agents-mobile/src/screens/OnboardingScreen.tsx
+++ b/packages/agents-mobile/src/screens/OnboardingScreen.tsx
@@ -14,6 +14,7 @@ import { PrimaryButton } from '../components/PrimaryButton'
 import { Screen } from '../components/Screen'
 import { useCloudAuth } from '../lib/CloudAuthContext'
 import { checkServerHealth, normalizeServerUrl } from '../lib/agentsClient'
+import { prepareServerHeaders } from '../lib/serverHeaders'
 import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, rowHeight, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
@@ -85,6 +86,10 @@ export function OnboardingScreen({
     setSubmittingServer(true)
     setServerError(null)
     try {
+      // Inject Cloud auth headers (if applicable) before the health
+      // check probes the server — Cloud agent servers reject
+      // unauthenticated requests with 401.
+      await prepareServerHeaders(normalized)
       await checkServerHealth(normalized)
       await onComplete({ serverUrl: normalized })
     } catch (err) {

--- a/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
+++ b/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
@@ -13,6 +13,7 @@ import { Screen } from '../components/Screen'
 import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, rowHeight, spacing } from '../lib/theme'
 import { checkServerHealth, normalizeServerUrl } from '../lib/agentsClient'
+import { prepareServerHeaders } from '../lib/serverHeaders'
 import type { Tokens } from '../lib/theme'
 
 export function ServerSetupScreen({
@@ -39,6 +40,10 @@ export function ServerSetupScreen({
     setLoading(true)
     setError(null)
     try {
+      // Inject Cloud auth headers (if applicable) before the health
+      // check probes the server — Cloud agent servers reject
+      // unauthenticated requests with 401.
+      await prepareServerHeaders(normalized)
       await checkServerHealth(normalized)
       await onSave(normalized)
     } catch (err) {

--- a/packages/agents-server-ui/src/embed/EmbedApp.tsx
+++ b/packages/agents-server-ui/src/embed/EmbedApp.tsx
@@ -15,6 +15,7 @@ import {
 import { ThemeProvider } from '../ui/ThemeProvider'
 import { ChatLogView, ChatView } from '../components/views/ChatView'
 import { StateExplorerView } from '../components/views/StateExplorerView'
+import { registerActiveServerHeaders } from '../lib/auth-fetch'
 import styles from './EmbedApp.module.css'
 import type { OptimisticInboxMessage } from '../lib/sendMessage'
 
@@ -31,6 +32,15 @@ export function EmbedSessionRoot({
   onNavigatePathname,
   ...state
 }: EmbedSessionProps): ReactElement {
+  // Register the Cloud auth headers in THIS context's auth-fetch
+  // module before ElectricAgentsProvider creates its collections —
+  // they fetch synchronously on first render, so a later useEffect
+  // registration would race the initial 401.
+  if (state.serverHeaders) {
+    registerActiveServerHeaders(state.serverHeaders)
+  } else {
+    registerActiveServerHeaders(null)
+  }
   return (
     <ThemeProvider appearance={state.theme}>
       <ElectricAgentsProvider baseUrl={state.serverUrl}>
@@ -59,6 +69,14 @@ type EmbedState = {
   theme: EmbedTheme
   scrollToBottomSignal?: number
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
+  // Forwarded across the Expo-DOM boundary so the embed's auth-fetch
+  // module instance (separate from the native side) can inject the
+  // Cloud `Authorization` + `x-electric-service` headers on every
+  // outbound request. `null` means no headers required (local server).
+  serverHeaders?: {
+    url: string
+    headers: Record<string, string>
+  } | null
 }
 
 const EmbedStateContext = createContext<EmbedState | null>(null)

--- a/packages/agents-server-ui/src/lib/auth-fetch.ts
+++ b/packages/agents-server-ui/src/lib/auth-fetch.ts
@@ -174,6 +174,23 @@ export function registerActiveServerHeaders(
       : null
 }
 
+/**
+ * Snapshot of the currently-registered server + headers. Mobile uses
+ * this to forward headers to its DOM-embed children, which run in a
+ * separate JS context with their own `auth-fetch` module instance and
+ * therefore can't see the registration done on the native side.
+ */
+export function getActiveServerHeadersSnapshot(): {
+  url: string
+  headers: Record<string, string>
+} | null {
+  if (!activeServerHeaders) return null
+  return {
+    url: activeServerHeaders.baseUrl,
+    headers: { ...activeServerHeaders.headers },
+  }
+}
+
 export function getConfiguredServerHeaders(
   input: RequestInfo | URL
 ): Record<string, string> {

--- a/packages/agents-server-ui/src/lib/entity-connection.ts
+++ b/packages/agents-server-ui/src/lib/entity-connection.ts
@@ -105,6 +105,7 @@ function createReactNativeStream(streamUrl: string): EntityStreamHandle {
   const stream = new DurableStream({
     url: streamUrl,
     contentType: `application/json`,
+    fetch: serverFetch,
   })
 
   return {


### PR DESCRIPTION
Stacked on top of #4317 (Cloud sign-in). #4317 gets the user a dashboard JWT; this PR teaches the mobile app to actually use it to talk to a Cloud agent server end-to-end.

## Summary

- **Per-service agents-token exchange.** `cloudAuth.getAgentsToken(serviceId)` trades the user's dashboard JWT for a service-scoped agents token via the admin-API's `getTokenForAgents` endpoint (cached in-memory, cleared on sign-out). Mirrors the desktop app's `prepareConnection` flow.
- **`serverFetch` everywhere.** Plain `fetch` calls in `agentsClient.ts` switched to `serverFetch`; both shape collections get `fetchClient: serverFetch`. The React Native `DurableStream` path in `entity-connection.ts` now also takes `fetch: serverFetch`. The desktop equivalent is Electron's `webRequest` hook — RN has no network interceptor, so injection happens in user-space.
- **`serverHeaders` wiring.** New `prepareServerHeaders(serverUrl)` helper: detects `?service=` Cloud URLs, fetches the agents token, registers `Authorization` + `x-electric-service` + `electric-principal` via `registerActiveServerHeaders`. Runs before `loading` flips to false (cold-start) and on every cloud-auth state transition (post-sign-in).
- **DOM-embed boundary.** Expo DOM components bundle into a separate JS context with their own `auth-fetch` module instance — the native registration is invisible to them. Mobile reads a snapshot via the new `getActiveServerHeadersSnapshot()` and passes it as a prop; `EmbedSessionRoot` re-registers synchronously before its children render.
- **URL composition.** Replaced naive `\${baseUrl}/_electric/…` template concatenation with `appendPathToUrl` — needed because Cloud URLs carry a `?service=…` query param that naive concat pushes the path *into*.
- **Atomic spawn.** Mobile was doing `PUT /<type>/<name>` + `POST /<type>/<name>/send`, both at the legacy path. Switched to the post-refactor `PUT /_electric/entities/<type>/<name>` with `initialMessage` in the body (matches `ElectricAgentsProvider.spawnEntity` on web). Removes a STREAM_NOT_FOUND race and fixes the URL.
- **Runner picker.** Cloud dispatch routing relies on the spawn's `dispatch_policy`. Without one, mobile-spawned entities fell through to the entity type's `default_dispatch_policy` — typically a webhook to a local `serveEndpoint` the cloud server can't reach. Added a runners shape + picker so the user can target a specific pull-wake runner (auto-selects when there's only one — usually a single desktop runtime).
- **Sender principal.** `sendMessage`'s `resolveSenderPrincipalUrl` was falling to `system:dev-local` on mobile because step 3 reads `window.electronAPI` (undefined on RN). Registering `electric-principal: user:<userId>` makes step 2 of the chain pick up the right sender, which the cloud agents-server then accepts on follow-up `/send` POSTs.

## Test plan

- [x] Typecheck passes (\`agents-mobile\`, \`agents-server-ui\`)
- [x] Existing agents-server-ui tests still pass
- [x] End-to-end on the dashboard-pr-1504 deployment: sign in → enter Cloud server URL → onboarding wizard completes → new session picks Horton + the desktop's local runtime → message sends and Horton replies → follow-up message also sends and Horton replies