### PR TITLE
feat(agents-server-ui): runner picker on the new-session view

### DIFF
--- a/.changeset/new-session-runner-picker.md
+++ b/.changeset/new-session-runner-picker.md
@@ -1,5 +1,5 @@
 ---
-'@electric-ax/agents-server-ui': minor
+'@electric-ax/agents-server-ui': patch
 '@electric-ax/agents-desktop': patch
 ---
 

--- a/.changeset/new-session-runner-picker.md
+++ b/.changeset/new-session-runner-picker.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-server-ui': minor
+'@electric-ax/agents-desktop': patch
+---
+
+Add a runner picker to the new-session view so users can choose which pull-wake runner handles a spawned entity. Defaults to the Electron shell's own runner when it's one of the enabled choices (preserves the previous single-runtime behaviour) and falls back to the first enabled runner otherwise. The picker is only rendered when at least one runner is registered, so servers using webhook-based dispatch are unaffected. Also extends `Select.Trigger` with an optional `renderValue` prop so triggers can show a human-readable label when option values are opaque keys (e.g. runner ids).

--- a/packages/agents-server-ui/src/components/views/NewSessionView.tsx
+++ b/packages/agents-server-ui/src/components/views/NewSessionView.tsx
@@ -642,14 +642,19 @@ function RunnerPickerPill({
   disabled?: boolean
 }): React.ReactElement | null {
   if (runners.length === 0) return null
-  // `BaseSelect.Value` renders the textContent of the currently-
-  // selected `Select.Item`, so each item's children is what shows in
-  // the trigger pill. We just label items by their human-readable
-  // `label` field (falling back to id) and key the selection by id.
-  const placeholder = `Pick runner`
+  // The trigger needs to display the runner's *label*, not its id.
+  // base-ui's `Select.Value` falls back to rendering the raw value
+  // string when its `children` render function is omitted — which
+  // would show the runner UUID. Use `renderValue` to look the label
+  // up out of the current `runners` list instead.
+  const renderValue = (id: string | null): React.ReactNode => {
+    if (!id) return `Pick runner`
+    const runner = runners.find((r) => r.id === id)
+    return runner ? runner.label || runner.id : id
+  }
   return (
     <Select.Root<string>
-      value={value ?? undefined}
+      value={value}
       onValueChange={(next) => onChange(next)}
       disabled={disabled}
     >
@@ -657,7 +662,8 @@ function RunnerPickerPill({
         size="pill"
         aria-label="Runner"
         title="Pull-wake runner that will handle this session"
-        placeholder={placeholder}
+        placeholder="Pick runner"
+        renderValue={renderValue}
       />
       <Select.Content>
         {runners.map((runner) => (

--- a/packages/agents-server-ui/src/components/views/NewSessionView.tsx
+++ b/packages/agents-server-ui/src/components/views/NewSessionView.tsx
@@ -13,11 +13,18 @@ import { nanoid } from 'nanoid'
 import { useElectricAgents } from '../../lib/ElectricAgentsProvider'
 import { useWorkspace } from '../../hooks/useWorkspace'
 import { useRecentWorkingDirectories } from '../../hooks/useRecentWorkingDirectories'
+import {
+  loadDesktopState,
+  onDesktopStateChanged,
+} from '../../lib/server-connection'
 import { Icon, Select, Stack, Text } from '../../ui'
 import { SchemaForm, hasSchemaProperties, isObjectSchema } from '../SchemaForm'
 import { WorkingDirectoryPicker } from '../WorkingDirectoryPicker'
 import styles from '../NewSessionPage.module.css'
-import type { ElectricEntityType } from '../../lib/ElectricAgentsProvider'
+import type {
+  ElectricEntityType,
+  ElectricRunner,
+} from '../../lib/ElectricAgentsProvider'
 import type { StandaloneViewProps } from '../../lib/workspace/viewRegistry'
 
 /**
@@ -92,7 +99,8 @@ export function NewSessionView({
   tileId,
   setToolbarTitle,
 }: StandaloneViewProps): React.ReactElement {
-  const { entityTypesCollection, spawnEntity } = useElectricAgents()
+  const { entityTypesCollection, runnersCollection, spawnEntity } =
+    useElectricAgents()
   const { helpers } = useWorkspace()
   const [selected, setSelected] = useState<ElectricEntityType | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -119,6 +127,63 @@ export function NewSessionView({
     [entityTypesCollection]
   )
 
+  const { data: enabledRunners = [] } = useLiveQuery(
+    (query) => {
+      if (!runnersCollection) return undefined
+      return query
+        .from({ r: runnersCollection })
+        .where(({ r }) => eq(r.admin_status, `enabled`))
+        .orderBy(({ r }) => r.label, `asc`)
+    },
+    [runnersCollection]
+  )
+
+  // The Electron shell registers its own pull-wake runner. When that
+  // runner is one of the available choices we prefer it as the default
+  // selection (preserves the old desktop behaviour of routing wakes to
+  // the bundled local runtime). `null` outside Electron / before the
+  // first state fetch.
+  const [desktopRunnerId, setDesktopRunnerId] = useState<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    void loadDesktopState().then((s) => {
+      if (cancelled) return
+      setDesktopRunnerId(s?.pullWakeRunnerId?.trim() || null)
+    })
+    const off = onDesktopStateChanged((s) =>
+      setDesktopRunnerId(s?.pullWakeRunnerId?.trim() || null)
+    )
+    return () => {
+      cancelled = true
+      off?.()
+    }
+  }, [])
+
+  const [selectedRunnerId, setSelectedRunnerId] = useState<string | null>(null)
+  // Re-evaluate the default whenever the list of runners or the
+  // desktop's runner id changes. Prefer the desktop's own runner if
+  // it's enabled, else fall back to the first runner.
+  useEffect(() => {
+    if (
+      selectedRunnerId &&
+      enabledRunners.some((r) => r.id === selectedRunnerId)
+    ) {
+      return
+    }
+    if (enabledRunners.length === 0) {
+      if (selectedRunnerId !== null) setSelectedRunnerId(null)
+      return
+    }
+    if (
+      desktopRunnerId &&
+      enabledRunners.some((r) => r.id === desktopRunnerId)
+    ) {
+      setSelectedRunnerId(desktopRunnerId)
+      return
+    }
+    setSelectedRunnerId(enabledRunners[0]!.id)
+  }, [enabledRunners, desktopRunnerId, selectedRunnerId])
+
   const defaultAgent = useMemo(
     () => entityTypes.find((t) => t.name === DEFAULT_AGENT_NAME) ?? null,
     [entityTypes]
@@ -142,16 +207,16 @@ export function NewSessionView({
       if (!spawnEntity) return
       setError(null)
       const name = nanoid(10)
-      const desktopState = await window.electronAPI?.getDesktopState?.()
-      const runnerId = desktopState?.pullWakeRunnerId?.trim() || null
       const tx = spawnEntity({
         type: typeName,
         name,
         args,
-        ...(runnerId
+        ...(selectedRunnerId
           ? {
               dispatch_policy: {
-                targets: [{ type: `runner` as const, runnerId }],
+                targets: [
+                  { type: `runner` as const, runnerId: selectedRunnerId },
+                ],
               },
             }
           : {}),
@@ -169,7 +234,7 @@ export function NewSessionView({
         )
       }
     },
-    [helpers, spawnEntity, tileId]
+    [helpers, selectedRunnerId, spawnEntity, tileId]
   )
 
   const handleSelectType = useCallback(
@@ -244,6 +309,9 @@ export function NewSessionView({
             error={error}
             workingDirectory={workingDirectory}
             onChangeWorkingDirectory={setWorkingDirectory}
+            runners={enabledRunners}
+            selectedRunnerId={selectedRunnerId}
+            onChangeSelectedRunner={setSelectedRunnerId}
           />
         )}
       </div>
@@ -260,6 +328,9 @@ function Picker({
   error,
   workingDirectory,
   onChangeWorkingDirectory,
+  runners,
+  selectedRunnerId,
+  onChangeSelectedRunner,
 }: {
   defaultAgent: ElectricEntityType | null
   otherAgents: Array<ElectricEntityType>
@@ -269,6 +340,9 @@ function Picker({
   error: string | null
   workingDirectory: string | null
   onChangeWorkingDirectory: (path: string | null) => void
+  runners: Array<ElectricRunner>
+  selectedRunnerId: string | null
+  onChangeSelectedRunner: (id: string | null) => void
 }): React.ReactElement {
   const hasAnyAgent = defaultAgent !== null || otherAgents.length > 0
   const [heroTitle] = useState(
@@ -297,6 +371,9 @@ function Picker({
           disabled={!spawnReady}
           workingDirectory={workingDirectory}
           onChangeWorkingDirectory={onChangeWorkingDirectory}
+          runners={runners}
+          selectedRunnerId={selectedRunnerId}
+          onChangeSelectedRunner={onChangeSelectedRunner}
         />
       )}
 
@@ -403,12 +480,18 @@ function DefaultAgentComposer({
   disabled,
   workingDirectory,
   onChangeWorkingDirectory,
+  runners,
+  selectedRunnerId,
+  onChangeSelectedRunner,
 }: {
   agent: ElectricEntityType
   onSubmit: (text: string, args: Record<string, unknown>) => void
   disabled?: boolean
   workingDirectory: string | null
   onChangeWorkingDirectory: (path: string | null) => void
+  runners: Array<ElectricRunner>
+  selectedRunnerId: string | null
+  onChangeSelectedRunner: (id: string | null) => void
 }): React.ReactElement {
   const [value, setValue] = useState(``)
   const [submitting, setSubmitting] = useState(false)
@@ -516,6 +599,14 @@ function DefaultAgentComposer({
             onChange={onChangeWorkingDirectory}
             disabled={submitting || disabled}
           />
+          {runners.length > 0 && (
+            <RunnerPickerPill
+              runners={runners}
+              value={selectedRunnerId}
+              onChange={onChangeSelectedRunner}
+              disabled={submitting || disabled}
+            />
+          )}
         </div>
         <div className={styles.composerSendCluster}>
           {submitting && <span className={styles.composerHint}>Starting…</span>}
@@ -536,6 +627,46 @@ function DefaultAgentComposer({
         </div>
       </div>
     </div>
+  )
+}
+
+function RunnerPickerPill({
+  runners,
+  value,
+  onChange,
+  disabled,
+}: {
+  runners: Array<ElectricRunner>
+  value: string | null
+  onChange: (id: string | null) => void
+  disabled?: boolean
+}): React.ReactElement | null {
+  if (runners.length === 0) return null
+  // `BaseSelect.Value` renders the textContent of the currently-
+  // selected `Select.Item`, so each item's children is what shows in
+  // the trigger pill. We just label items by their human-readable
+  // `label` field (falling back to id) and key the selection by id.
+  const placeholder = `Pick runner`
+  return (
+    <Select.Root<string>
+      value={value ?? undefined}
+      onValueChange={(next) => onChange(next)}
+      disabled={disabled}
+    >
+      <Select.Trigger
+        size="pill"
+        aria-label="Runner"
+        title="Pull-wake runner that will handle this session"
+        placeholder={placeholder}
+      />
+      <Select.Content>
+        {runners.map((runner) => (
+          <Select.Item key={runner.id} value={runner.id}>
+            {runner.label || runner.id}
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
   )
 }
 

--- a/packages/agents-server-ui/src/ui/Select.tsx
+++ b/packages/agents-server-ui/src/ui/Select.tsx
@@ -37,6 +37,13 @@ interface TriggerProps {
   [`aria-label`]?: string
   /** Tooltip-style hint shown on hover. */
   title?: string
+  /**
+   * Custom renderer for the displayed value. Use when the option's
+   * value is an opaque key (e.g. an entity id) and the user-facing
+   * label lives elsewhere. Without this, base-ui's `Select.Value`
+   * falls back to rendering the value as text.
+   */
+  renderValue?: (value: string | null) => ReactNode
 }
 
 interface ContentProps {
@@ -86,6 +93,7 @@ function Trigger({
   autoFocus,
   [`aria-label`]: ariaLabel,
   title,
+  renderValue,
 }: TriggerProps): React.ReactElement {
   const cls = [size === `pill` ? styles.triggerPill : styles.trigger, className]
     .filter(Boolean)
@@ -99,7 +107,11 @@ function Trigger({
       aria-label={ariaLabel}
       title={title}
     >
-      <BaseSelect.Value placeholder={placeholder} />
+      <BaseSelect.Value placeholder={placeholder}>
+        {renderValue
+          ? (value) => renderValue(value as string | null)
+          : undefined}
+      </BaseSelect.Value>
       <BaseSelect.Icon className={styles.icon}>
         <Icon icon={ChevronDown} size={iconSize} />
       </BaseSelect.Icon>


### PR DESCRIPTION
## Summary

- `NewSessionView` always routed new entities to the Electron shell's own pull-wake runner (read from `window.electronAPI.getDesktopState`), even when several runners were registered against the active server. With Cloud servers that often have multiple runners, users had no way to pick.
- Subscribe to the `runnersCollection`, lift the selected runner id to `NewSessionView`, and render a pill picker in the composer toolbar (next to the working-directory picker).
- Default selection prefers the desktop's own `pullWakeRunnerId` when it's one of the enabled runners (preserving prior behaviour for the common single-local-runtime case) and falls back to the first enabled runner otherwise. Re-evaluates if the selection drops out of the list (disabled / stopped).
- `doSpawn` now reads the lifted state instead of `await window.electronAPI.getDesktopState()` on every spawn. The other-agents grid spawns through the same callback so it picks up the selected runner without extra prop threading.
- The pill only renders when there are runners to choose from — fresh servers with no registered runners still fall through to the entity type's `default_dispatch_policy` (existing webhook/local behaviour preserved).
- Extended the shared `Select.Trigger` with an optional `renderValue?: (value) => ReactNode` prop so the picker can show each runner's `label` in the closed pill even though items use the `id` as their option value. Without it, base-ui's `Select.Value` falls back to the raw value string for closed dropdowns (items aren't mounted), and the pill would show the UUID — or the placeholder when items hadn't rendered yet.

## Test plan

- [x] `pnpm -C packages/agents-server-ui typecheck`
- [x] `pnpm -C packages/agents-server-ui test` (46 passing)
- [x] Manual: desktop connected to a Cloud agent server with one registered runner — picker auto-selects the desktop's local runtime and shows its label; spawning a session routes the wake correctly. Multi-runner case lets the user choose.