### PR TITLE
feat(agents-mobile): list Cloud agent servers in the server-setup flow

### DIFF
--- a/.changeset/agents-mobile-cloud-servers-picker.md
+++ b/.changeset/agents-mobile-cloud-servers-picker.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-mobile': patch
+---
+
+Surface the user's Electric Cloud agent servers in the mobile app's server-setup flow. When signed in to Electric Cloud, both the onboarding wizard's step 2 and the standalone server-setup screen now list every agent server the user can see (joined Workspace › Project › Environment › Server breadcrumb), one tap to fill in the URL. Manual URL entry still works for local / off-Cloud servers. Mirrors the desktop app's cloud-servers picker — subscribes to the same four admin-API shapes (`agent-servers`, `environments`, `projects`, `workspaces`) and joins them client-side.

--- a/packages/agents-mobile/src/components/CloudServerPicker.tsx
+++ b/packages/agents-mobile/src/components/CloudServerPicker.tsx
@@ -1,0 +1,153 @@
+import { useMemo } from 'react'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import {
+  cloudAgentServerUrl,
+  useCloudAgentServers,
+  type CloudAgentServer,
+} from '../lib/cloudAgentServers'
+import { useTokens } from '../lib/ThemeProvider'
+import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
+import type { Tokens } from '../lib/theme'
+
+/**
+ * Lists the Electric Cloud agent servers the signed-in user can see.
+ * Subscribes to the four admin-API shapes via `useCloudAgentServers`
+ * and renders each as a tappable card; tapping derives the agent-server
+ * URL (host swap + `?service=`) and calls `onPick` so the parent screen
+ * can drop it into its input / save flow.
+ *
+ * Renders nothing when the user isn't signed in to Cloud — the manual
+ * URL entry on the parent screen remains the entry point in that case.
+ */
+export function CloudServerPicker({
+  onPick,
+  disabled,
+}: {
+  onPick: (url: string) => void
+  disabled?: boolean
+}): React.ReactElement | null {
+  const tokens = useTokens()
+  const styles = useMemo(() => createStyles(tokens), [tokens])
+  const { status, servers, error } = useCloudAgentServers()
+
+  if (status === `idle`) return null
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.label}>Your Electric Cloud servers</Text>
+      {status === `loading` && servers.length === 0 && (
+        <Text style={styles.muted}>Loading…</Text>
+      )}
+      {status === `unauthorized` && (
+        <Text style={styles.muted}>
+          Cloud session expired — sign in again from the Account screen.
+        </Text>
+      )}
+      {status === `error` && error && (
+        <Text style={styles.errorText}>{error}</Text>
+      )}
+      {status !== `unauthorized` &&
+        servers.length === 0 &&
+        status !== `loading` && (
+          <Text style={styles.muted}>
+            No agent servers visible. Create one in the Electric Cloud
+            dashboard, then return here.
+          </Text>
+        )}
+      <View style={styles.list}>
+        {servers.map((server) => (
+          <CloudServerCard
+            key={server.id}
+            server={server}
+            tokens={tokens}
+            disabled={disabled}
+            onPress={() => onPick(cloudAgentServerUrl(server.id))}
+          />
+        ))}
+      </View>
+    </View>
+  )
+}
+
+function CloudServerCard({
+  server,
+  tokens,
+  disabled,
+  onPress,
+}: {
+  server: CloudAgentServer
+  tokens: Tokens
+  disabled?: boolean
+  onPress: () => void
+}): React.ReactElement {
+  const styles = useMemo(() => createStyles(tokens), [tokens])
+  const breadcrumb = [
+    server.workspaceName,
+    server.projectName,
+    server.environmentName,
+  ]
+    .filter((p): p is string => Boolean(p))
+    .join(` · `)
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      style={[styles.card, disabled ? styles.cardDisabled : null]}
+    >
+      <Text style={styles.cardName}>{server.name}</Text>
+      {breadcrumb.length > 0 && (
+        <Text numberOfLines={1} style={styles.cardBreadcrumb}>
+          {breadcrumb}
+        </Text>
+      )}
+    </TouchableOpacity>
+  )
+}
+
+function createStyles(tokens: Tokens) {
+  return StyleSheet.create({
+    wrap: {
+      gap: spacing.xs,
+    },
+    label: {
+      color: tokens.text3,
+      fontSize: fontSize.xs,
+      fontWeight: `500`,
+      letterSpacing: 0.6,
+      textTransform: `uppercase`,
+    },
+    list: {
+      gap: spacing.xs,
+    },
+    muted: {
+      color: tokens.text3,
+      fontSize: fontSize.sm,
+      lineHeight: lineHeight.sm,
+    },
+    errorText: {
+      color: tokens.red11,
+      fontSize: fontSize.sm,
+    },
+    card: {
+      borderWidth: 1,
+      borderColor: tokens.border1,
+      borderRadius: radii.md,
+      backgroundColor: tokens.surface,
+      padding: spacing.md,
+    },
+    cardDisabled: {
+      opacity: 0.5,
+    },
+    cardName: {
+      color: tokens.text1,
+      fontSize: fontSize.base,
+      fontWeight: `500`,
+    },
+    cardBreadcrumb: {
+      marginTop: spacing.xs,
+      color: tokens.text2,
+      fontSize: fontSize.sm,
+      lineHeight: lineHeight.sm,
+    },
+  })
+}

--- a/packages/agents-mobile/src/lib/cloudAgentServers.ts
+++ b/packages/agents-mobile/src/lib/cloudAgentServers.ts
@@ -1,0 +1,309 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createCollection } from '@tanstack/react-db'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+import { useLiveQuery } from '@tanstack/react-db'
+import { z } from 'zod'
+import { cloudAuth, getCloudBaseUrl } from './cloudAuth'
+import type { CloudAuthState } from './cloudAuth'
+
+/**
+ * Continuously-synced, denormalized view of the Cloud agent servers the
+ * signed-in user can see.
+ *
+ * Mirrors `packages/agents-desktop/src/cloud-agent-servers.ts` — it
+ * subscribes to four admin-API shapes (`agent-servers`, `environments`,
+ * `projects`, `workspaces`) and joins them so each row carries the full
+ * Workspace › Project › Environment › Server breadcrumb the picker UI
+ * needs.
+ *
+ * Differences from desktop:
+ *   - No IPC layer; consumed via a React hook (`useCloudAgentServers`).
+ *   - No `SecretStore` for per-service tokens — `cloudAuth.getAgentsToken`
+ *     already handles in-memory caching, and `serverHeaders.prepareServerHeaders`
+ *     plumbs the token in on every outbound request via `serverFetch`.
+ *   - The shape collections' `fetchClient` reads the user's dashboard
+ *     bearer from `cloudAuth.getToken()` on every request, so a token
+ *     refresh (or sign-out) just propagates the next time Electric
+ *     polls — no need to tear down and recreate the collections.
+ */
+
+export type CloudAgentServerStatus =
+  | `idle`
+  | `loading`
+  | `ready`
+  | `unauthorized`
+  | `error`
+
+export type CloudAgentServer = {
+  /** `stream_services.id` — also the tenant identifier in the agents URL's `?service=`. */
+  id: string
+  name: string
+  workspaceId: string | null
+  workspaceName: string | null
+  projectId: string | null
+  projectName: string | null
+  environmentId: string | null
+  environmentName: string | null
+  updatedAt: string | null
+}
+
+export type CloudAgentServersResult = {
+  status: CloudAgentServerStatus
+  servers: ReadonlyArray<CloudAgentServer>
+  error: string | null
+}
+
+const agentServerSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  environment_id: z.string(),
+  type: z.string().optional(),
+  variant: z.string().optional(),
+  created_at: z.string().nullable().optional(),
+  updated_at: z.string().nullable().optional(),
+  deleted_at: z.string().nullable().optional(),
+})
+
+const environmentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  project_id: z.string(),
+  deleted_at: z.string().nullable().optional(),
+})
+
+const projectSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  workspace_id: z.string(),
+  deleted_at: z.string().nullable().optional(),
+})
+
+const workspaceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  deleted_at: z.string().nullable().optional(),
+})
+
+const SHAPE_PATHS = {
+  agentServers: `/api/internal/v1/agent-servers`,
+  environments: `/api/internal/v1/environments`,
+  projects: `/api/internal/v1/projects`,
+  workspaces: `/api/internal/v1/workspaces`,
+} as const
+
+/**
+ * Inject the user's Cloud bearer token on every shape request. Resolves
+ * the token from `cloudAuth.getToken()` on each call so token rotation
+ * / sign-out propagates without us having to recreate the collections.
+ */
+async function cloudFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  const token = await cloudAuth.getToken()
+  const headers = new Headers(init?.headers)
+  if (token) headers.set(`Authorization`, `Bearer ${token}`)
+  return fetch(input, { ...init, headers })
+}
+
+function createAgentServersCollection(dashboardUrl: string) {
+  return createCollection(
+    electricCollectionOptions({
+      id: `cloud-agent-servers:${dashboardUrl}`,
+      schema: agentServerSchema,
+      shapeOptions: {
+        url: new URL(SHAPE_PATHS.agentServers, dashboardUrl).toString(),
+        fetchClient: cloudFetch,
+      },
+      getKey: (item) => item.id,
+    })
+  )
+}
+
+function createEnvironmentsCollection(dashboardUrl: string) {
+  return createCollection(
+    electricCollectionOptions({
+      id: `cloud-environments:${dashboardUrl}`,
+      schema: environmentSchema,
+      shapeOptions: {
+        url: new URL(SHAPE_PATHS.environments, dashboardUrl).toString(),
+        fetchClient: cloudFetch,
+      },
+      getKey: (item) => item.id,
+    })
+  )
+}
+
+function createProjectsCollection(dashboardUrl: string) {
+  return createCollection(
+    electricCollectionOptions({
+      id: `cloud-projects:${dashboardUrl}`,
+      schema: projectSchema,
+      shapeOptions: {
+        url: new URL(SHAPE_PATHS.projects, dashboardUrl).toString(),
+        fetchClient: cloudFetch,
+      },
+      getKey: (item) => item.id,
+    })
+  )
+}
+
+function createWorkspacesCollection(dashboardUrl: string) {
+  return createCollection(
+    electricCollectionOptions({
+      id: `cloud-workspaces:${dashboardUrl}`,
+      schema: workspaceSchema,
+      shapeOptions: {
+        url: new URL(SHAPE_PATHS.workspaces, dashboardUrl).toString(),
+        fetchClient: cloudFetch,
+      },
+      getKey: (item) => item.id,
+    })
+  )
+}
+
+type CollectionSet = {
+  agentServers: ReturnType<typeof createAgentServersCollection>
+  environments: ReturnType<typeof createEnvironmentsCollection>
+  projects: ReturnType<typeof createProjectsCollection>
+  workspaces: ReturnType<typeof createWorkspacesCollection>
+}
+
+// Module-level cache so multiple components share a single set of
+// shape subscriptions per dashboard URL.
+const collectionsByDashboard = new Map<string, CollectionSet>()
+
+function getOrCreateCollections(dashboardUrl: string): CollectionSet {
+  const existing = collectionsByDashboard.get(dashboardUrl)
+  if (existing) return existing
+  const set: CollectionSet = {
+    agentServers: createAgentServersCollection(dashboardUrl),
+    environments: createEnvironmentsCollection(dashboardUrl),
+    projects: createProjectsCollection(dashboardUrl),
+    workspaces: createWorkspacesCollection(dashboardUrl),
+  }
+  collectionsByDashboard.set(dashboardUrl, set)
+  return set
+}
+
+/**
+ * Resolve the Cloud agents server base URL for a service id. Same shape
+ * the desktop produces — host swap `dashboard` → `agents`, service id
+ * carried in the `?service=` query param so multiple Cloud servers on
+ * the same host stay routable.
+ */
+export function cloudAgentServerUrl(serviceId: string): string {
+  const dashboardUrl = new URL(getCloudBaseUrl())
+  const agentsUrl = new URL(dashboardUrl.toString())
+  if (/^dashboard([.-]|$)/.test(dashboardUrl.hostname)) {
+    agentsUrl.hostname = dashboardUrl.hostname.replace(
+      /^dashboard(?=[.-]|$)/,
+      `agents`
+    )
+  }
+  agentsUrl.pathname = `/`
+  agentsUrl.search = ``
+  agentsUrl.hash = ``
+  agentsUrl.searchParams.set(`service`, serviceId)
+  return agentsUrl.toString()
+}
+
+/**
+ * Reactively project the four shapes into a sorted, denormalized list
+ * of Cloud agent servers the signed-in user can see. Returns an empty
+ * list when signed out (no subscriptions are opened in that case).
+ */
+export function useCloudAgentServers(): CloudAgentServersResult {
+  const [authStatus, setAuthStatus] = useState<CloudAuthState[`status`]>(
+    () => cloudAuth.getState().status
+  )
+  useEffect(() => {
+    setAuthStatus(cloudAuth.getState().status)
+    return cloudAuth.subscribe((s) => setAuthStatus(s.status))
+  }, [])
+
+  const collections = useMemo(() => {
+    if (authStatus !== `signed-in`) return null
+    return getOrCreateCollections(getCloudBaseUrl())
+  }, [authStatus])
+
+  const { data: agentServerRows = [], status: agentServersStatus } =
+    useLiveQuery(
+      (query) => {
+        if (!collections) return undefined
+        return query.from({ s: collections.agentServers })
+      },
+      [collections]
+    )
+  const { data: environmentRows = [] } = useLiveQuery(
+    (query) => {
+      if (!collections) return undefined
+      return query.from({ e: collections.environments })
+    },
+    [collections]
+  )
+  const { data: projectRows = [] } = useLiveQuery(
+    (query) => {
+      if (!collections) return undefined
+      return query.from({ p: collections.projects })
+    },
+    [collections]
+  )
+  const { data: workspaceRows = [] } = useLiveQuery(
+    (query) => {
+      if (!collections) return undefined
+      return query.from({ w: collections.workspaces })
+    },
+    [collections]
+  )
+
+  return useMemo<CloudAgentServersResult>(() => {
+    if (!collections) {
+      return { status: `idle`, servers: [], error: null }
+    }
+    const environments = new Map(environmentRows.map((r) => [r.id, r]))
+    const projects = new Map(projectRows.map((r) => [r.id, r]))
+    const workspaces = new Map(workspaceRows.map((r) => [r.id, r]))
+    const servers: Array<CloudAgentServer> = agentServerRows
+      .filter((row) => !row.deleted_at)
+      .map((row) => {
+        const env = environments.get(row.environment_id) ?? null
+        const project = env ? (projects.get(env.project_id) ?? null) : null
+        const workspace = project
+          ? (workspaces.get(project.workspace_id) ?? null)
+          : null
+        return {
+          id: row.id,
+          name: row.name,
+          environmentId: env?.id ?? row.environment_id ?? null,
+          environmentName: env?.name ?? null,
+          projectId: project?.id ?? null,
+          projectName: project?.name ?? null,
+          workspaceId: workspace?.id ?? null,
+          workspaceName: workspace?.name ?? null,
+          updatedAt: row.updated_at ?? null,
+        }
+      })
+    servers.sort((a, b) => {
+      const wa = (a.workspaceName ?? `￿`).localeCompare(b.workspaceName ?? `￿`)
+      if (wa !== 0) return wa
+      const pa = (a.projectName ?? `￿`).localeCompare(b.projectName ?? `￿`)
+      if (pa !== 0) return pa
+      const ea = (a.environmentName ?? `￿`).localeCompare(
+        b.environmentName ?? `￿`
+      )
+      if (ea !== 0) return ea
+      return a.name.localeCompare(b.name)
+    })
+    const status: CloudAgentServerStatus =
+      agentServersStatus === `loading` ? `loading` : `ready`
+    return { status, servers, error: null }
+  }, [
+    collections,
+    agentServerRows,
+    environmentRows,
+    projectRows,
+    workspaceRows,
+    agentServersStatus,
+  ])
+}

--- a/packages/agents-mobile/src/screens/OnboardingScreen.tsx
+++ b/packages/agents-mobile/src/screens/OnboardingScreen.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import { CloudServerPicker } from '../components/CloudServerPicker'
 import { Icon } from '../components/Icon'
 import { PrimaryButton } from '../components/PrimaryButton'
 import { Screen } from '../components/Screen'
@@ -191,6 +192,11 @@ export function OnboardingScreen({
                 Mobile connects to a running server. It does not bundle a local
                 Horton runtime.
               </Text>
+
+              <CloudServerPicker
+                onPick={(picked) => setServerUrlValue(picked)}
+                disabled={submittingServer}
+              />
 
               <View style={styles.field}>
                 <Text style={styles.label}>Server URL</Text>

--- a/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
+++ b/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import { CloudServerPicker } from '../components/CloudServerPicker'
 import { PrimaryButton } from '../components/PrimaryButton'
 import { Screen } from '../components/Screen'
 import { useTokens } from '../lib/ThemeProvider'
@@ -71,6 +72,11 @@ export function ServerSetupScreen({
               Horton runtime.
             </Text>
           </View>
+
+          <CloudServerPicker
+            onPick={(picked) => setValue(picked)}
+            disabled={loading}
+          />
 
           <View style={styles.field}>
             <Text style={styles.label}>Server URL</Text>


### PR DESCRIPTION
## Summary

Brings the mobile app to parity with the Electron desktop on Cloud server discovery. When the user is signed in to Electric Cloud, both the onboarding wizard's step 2 and the standalone server-setup screen now list every agent server the user can see — one tap fills in the URL, no more copy-paste from the dashboard. Manual entry still works for local / off-Cloud servers.

Mirrors `packages/agents-desktop/src/cloud-agent-servers.ts`: subscribes to the four admin-API shapes (`/api/internal/v1/{agent-servers,environments,projects,workspaces}`) and joins them client-side into a sorted Workspace › Project › Environment › Server projection. The agent-server URL is derived with the same host swap (`dashboard` → `agents`) + `?service=<id>` the desktop uses.

## Implementation notes

- **Idiomatic mobile** — uses `createCollection` + `electricCollectionOptions` (the same wrapper the existing entity / runner shapes use) instead of `ShapeStream` + a class. The join is two cheap `useLiveQuery` calls feeding a `useMemo`. Module-level collection cache keyed by dashboard URL so multiple components share one set of subscriptions.
- **Token rotation comes for free** — the shape `fetchClient` reads the user's dashboard bearer from `cloudAuth.getToken()` on every request, so sign-out / token refresh just propagates the next time Electric polls. No need to tear down and recreate collections.
- **Per-service agents tokens** still go through the existing `cloudAuth.getAgentsToken` + `prepareServerHeaders` plumbing — the picker only derives the URL, the existing save flow handles the rest (auth header injection, health check, save).
- **Renders nothing when signed out** — non-Cloud users see exactly today's UI.

## Test plan

- [x] `pnpm -C packages/agents-mobile typecheck`
- [x] Manual: signed in to Cloud, both onboarding step 2 and server-setup show the user's servers grouped by workspace breadcrumb. Tap → URL field populates → Connect saves and the rest of the flow (header injection, runner picker, sending messages) keeps working unchanged.
- [x] Signed-out path: picker is hidden, manual URL entry behaves as before.