### PR TITLE
feat(agents-mobile): Add agent signal controls

### DIFF
--- a/.changeset/mobile-agent-signal-controls.md
+++ b/.changeset/mobile-agent-signal-controls.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-mobile': patch
+'@electric-ax/agents-server-ui': patch
+---
+
+Add mobile agent signal controls. The mobile chat composer now shows a stop control while a run is active, the session menu exposes all entity signal types in a child menu, and the embedded chat timeline accounts for the native composer/drawer inset with aligned message widths and bottom fade masking.

--- a/packages/agents-mobile/app/session.tsx
+++ b/packages/agents-mobile/app/session.tsx
@@ -33,6 +33,7 @@ type SessionDomEmbedProps = {
   theme: `light` | `dark`
   scrollToBottomSignal?: number
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
+  bottomInset?: number
   onRequestOpenEntity: (entityUrl: string) => Promise<void>
   style?: StyleProp<ViewStyle>
   matchContents?: boolean
@@ -83,9 +84,9 @@ export default function SessionRoute(): React.ReactElement {
     () => ({
       top: embedTop,
       width: windowDimensions.width,
-      height: Math.max(0, windowDimensions.height - embedTop - composerInset),
+      height: Math.max(0, windowDimensions.height - embedTop),
     }),
-    [composerInset, embedTop, windowDimensions.height, windowDimensions.width]
+    [embedTop, windowDimensions.height, windowDimensions.width]
   )
   const embedSize = useMemo(
     () => ({
@@ -130,6 +131,7 @@ export default function SessionRoute(): React.ReactElement {
             theme={scheme}
             scrollToBottomSignal={chatLogScrollSignal}
             inlineQueuedMessages={inlineQueuedMessages}
+            bottomInset={composerInset}
             serverHeaders={serverHeaders}
             onRequestOpenEntity={async (target) => openSession(target)}
             dom={domOptions(styles, embedSize, tokens.bg)}

--- a/packages/agents-mobile/src/components/Icon.tsx
+++ b/packages/agents-mobile/src/components/Icon.tsx
@@ -31,7 +31,9 @@ export type IconName =
   | `swap`
   | `chat`
   | `database`
+  | `radio`
   | `arrow-up`
+  | `square`
 
 const PATHS: Record<IconName, string> = {
   back: `M15 18l-6-6 6-6`,
@@ -52,7 +54,9 @@ const PATHS: Record<IconName, string> = {
   swap: `M7 4l-3 3 3 3M4 7h13M17 14l3 3-3 3M20 17H7`,
   chat: `M4 4h16v12H8l-4 4Z`,
   database: `M5 5c0-1.1 3.1-2 7-2s7 .9 7 2v14c0 1.1-3.1 2-7 2s-7-.9-7-2V5ZM5 12c0 1.1 3.1 2 7 2s7-.9 7-2`,
+  radio: `M4.9 19.1a10 10 0 0 1 0-14.2M7.8 16.2a6 6 0 0 1 0-8.4M10.6 13.4a2 2 0 0 1 0-2.8M14 12h.01M16.2 7.8a6 6 0 0 1 0 8.4M19.1 4.9a10 10 0 0 1 0 14.2`,
   'arrow-up': `M12 19V5M5 12l7-7 7 7`,
+  square: `M7 7h10v10H7z`,
 }
 
 export function Icon({
@@ -72,6 +76,14 @@ export function Icon({
         <Circle cx={5} cy={12} r={1.7} fill={color} />
         <Circle cx={12} cy={12} r={1.7} fill={color} />
         <Circle cx={19} cy={12} r={1.7} fill={color} />
+      </Svg>
+    )
+  }
+
+  if (name === `square`) {
+    return (
+      <Svg width={size} height={size} viewBox="0 0 24 24">
+        <Path d={PATHS[name]} fill={color} />
       </Svg>
     )
   }

--- a/packages/agents-mobile/src/components/SessionMenu.tsx
+++ b/packages/agents-mobile/src/components/SessionMenu.tsx
@@ -1,4 +1,5 @@
-import { Text, View } from 'react-native'
+import { useEffect, useRef, useState } from 'react'
+import { Animated, Easing, StyleSheet, Text, View } from 'react-native'
 import {
   BottomSheet,
   BottomSheetItem,
@@ -7,15 +8,95 @@ import {
 } from './BottomSheet'
 import { Icon } from './Icon'
 import { useTokens } from '../lib/ThemeProvider'
-import type { ElectricEntity } from '../lib/agentsClient'
+import type { ElectricEntity, EntitySignal } from '../lib/agentsClient'
 import type { EmbedViewId } from '../lib/embedView'
 
 const STATUS_DOT_COLORS: Record<string, `green` | `blue` | `amber` | `gray`> = {
   running: `blue`,
   idle: `green`,
+  paused: `amber`,
+  stopping: `amber`,
   spawning: `amber`,
   stopped: `gray`,
+  killed: `gray`,
 }
+
+const SIGNAL_OPTION_GROUPS: ReadonlyArray<
+  ReadonlyArray<{
+    id: string
+    shortName: string
+    description: string
+    signal?: EntitySignal
+    composite?: `stop-immediately`
+    code: string
+    destructive?: boolean
+  }>
+> = [
+  [
+    {
+      id: `interrupt`,
+      signal: `SIGINT`,
+      shortName: `Interrupt`,
+      description: `Abort active run and continue`,
+      code: `SIGINT`,
+    },
+    {
+      id: `stop-immediately`,
+      composite: `stop-immediately`,
+      shortName: `Stop immediately`,
+      description: `Abort active run and pause`,
+      code: `SIGSTOP+SIGINT`,
+    },
+  ],
+  [
+    {
+      id: `stop`,
+      signal: `SIGSTOP`,
+      shortName: `Stop`,
+      description: `Pause after current run`,
+      code: `SIGSTOP`,
+    },
+    {
+      id: `reload`,
+      signal: `SIGHUP`,
+      shortName: `Reload`,
+      description: `Reload after current run`,
+      code: `SIGHUP`,
+    },
+    {
+      id: `resume`,
+      signal: `SIGCONT`,
+      shortName: `Resume`,
+      description: `Resume paused work`,
+      code: `SIGCONT`,
+    },
+    {
+      id: `custom`,
+      signal: `SIGUSR`,
+      shortName: `Custom`,
+      description: `Deliver to signal handler`,
+      code: `SIGUSR`,
+    },
+  ],
+  [
+    {
+      id: `terminate`,
+      signal: `SIGTERM`,
+      shortName: `Terminate`,
+      description: `Gracefully stop permanently`,
+      code: `SIGTERM`,
+      destructive: true,
+    },
+    {
+      id: `kill`,
+      signal: `SIGKILL`,
+      shortName: `Kill`,
+      description: `Immediately kill permanently`,
+      code: `SIGKILL`,
+      destructive: true,
+    },
+  ],
+]
 
 /**
  * Bottom-sheet "more" menu for the chat screen — exposes the view
@@ -29,14 +110,23 @@ export function SessionMenu({
   entity,
   view,
   onSetView,
+  signalError,
+  onSignal,
+  onStopImmediately,
 }: {
   open: boolean
   onClose: () => void
   entity: ElectricEntity | null
   view: EmbedViewId
   onSetView: (view: EmbedViewId) => void
+  signalError?: string | null
+  onSignal?: (signal: EntitySignal) => void
+  onStopImmediately?: () => void
 }): React.ReactElement {
   const tokens = useTokens()
+  const [signalMenuOpen, setSignalMenuOpen] = useState(false)
+  const [drillDirection, setDrillDirection] = useState(1)
+  const drillProgress = useRef(new Animated.Value(1)).current
 
   const dotKey = entity ? (STATUS_DOT_COLORS[entity.status] ?? `gray`) : `gray`
   const dotColor =
@@ -52,77 +142,230 @@ export function SessionMenu({
     onSetView(next)
     onClose()
   }
+  const handleClose = (): void => {
+    setSignalMenuOpen(false)
+    drillProgress.setValue(1)
+    onClose()
+  }
+  const transitionToMenu = (nextSignalMenuOpen: boolean): void => {
+    setDrillDirection(nextSignalMenuOpen ? 1 : -1)
+    drillProgress.setValue(0)
+    setSignalMenuOpen(nextSignalMenuOpen)
+    Animated.timing(drillProgress, {
+      toValue: 1,
+      duration: 180,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start()
+  }
+  const canSignal =
+    entity !== null &&
+    entity.status !== `stopped` &&
+    entity.status !== `killed` &&
+    Boolean(onSignal)
+  const handleSignalOption = (
+    option: (typeof SIGNAL_OPTION_GROUPS)[number][number]
+  ): void => {
+    if (option.composite === `stop-immediately`) {
+      onStopImmediately?.()
+    } else if (option.signal) {
+      onSignal?.(option.signal)
+    }
+    handleClose()
+  }
+
+  useEffect(() => {
+    if (!open) {
+      setSignalMenuOpen(false)
+      drillProgress.setValue(1)
+    }
+  }, [drillProgress, open])
+
+  const drillPaneStyle = {
+    opacity: drillProgress,
+    transform: [
+      {
+        translateX: drillProgress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [drillDirection * 28, 0],
+        }),
+      },
+    ],
+  }
 
   return (
-    <BottomSheet open={open} onClose={onClose}>
-      {entity && (
-        <>
-          <BottomSheetSection label="Status">
-            <View
-              style={{
-                flexDirection: `row`,
-                alignItems: `center`,
-                gap: 10,
-                paddingHorizontal: 12,
-                paddingVertical: 8,
-              }}
-            >
-              <View
-                style={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: 4,
-                  backgroundColor: dotColor,
-                }}
+    <BottomSheet
+      open={open}
+      onClose={handleClose}
+      title={signalMenuOpen ? `Send signal` : undefined}
+    >
+      <Animated.View style={[styles.drillPane, drillPaneStyle]}>
+        {signalMenuOpen ? (
+          <>
+            <BottomSheetSection>
+              <BottomSheetItem
+                label="Back"
+                icon={
+                  <Icon
+                    name="back"
+                    size={18}
+                    color={tokens.text2}
+                    strokeWidth={2}
+                  />
+                }
+                onPress={() => transitionToMenu(false)}
               />
-              <Text
-                style={{
-                  color: tokens.text1,
-                  fontSize: 14,
-                  textTransform: `capitalize`,
-                }}
-              >
-                {entity.status}
-              </Text>
-              <View style={{ flex: 1 }} />
-              <Text
-                style={{
-                  color: tokens.text3,
-                  fontSize: 12,
-                  textTransform: `lowercase`,
-                }}
-              >
-                {entity.type}
-              </Text>
-            </View>
-          </BottomSheetSection>
-          <BottomSheetSeparator />
-        </>
-      )}
+            </BottomSheetSection>
+            <BottomSheetSeparator />
+            <BottomSheetSection label="Signals">
+              {SIGNAL_OPTION_GROUPS.map((group, groupIndex) => (
+                <View key={groupIndex}>
+                  {groupIndex > 0 && <BottomSheetSeparator />}
+                  {group.map((option) => (
+                    <BottomSheetItem
+                      key={option.id}
+                      label={option.shortName}
+                      icon={
+                        <Icon
+                          name="radio"
+                          size={18}
+                          color={
+                            option.destructive ? tokens.red11 : tokens.text2
+                          }
+                          strokeWidth={2}
+                        />
+                      }
+                      destructive={option.destructive}
+                      onPress={() => handleSignalOption(option)}
+                    />
+                  ))}
+                </View>
+              ))}
+            </BottomSheetSection>
+          </>
+        ) : (
+          <>
+            {entity && (
+              <>
+                <BottomSheetSection label="Status">
+                  <View
+                    style={{
+                      flexDirection: `row`,
+                      alignItems: `center`,
+                      gap: 10,
+                      paddingHorizontal: 12,
+                      paddingVertical: 8,
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: 4,
+                        backgroundColor: dotColor,
+                      }}
+                    />
+                    <Text
+                      style={{
+                        color: tokens.text1,
+                        fontSize: 14,
+                        textTransform: `capitalize`,
+                      }}
+                    >
+                      {entity.status}
+                    </Text>
+                    <View style={{ flex: 1 }} />
+                    <Text
+                      style={{
+                        color: tokens.text3,
+                        fontSize: 12,
+                        textTransform: `lowercase`,
+                      }}
+                    >
+                      {entity.type}
+                    </Text>
+                  </View>
+                  {signalError ? (
+                    <Text
+                      style={{
+                        color: tokens.red11,
+                        fontSize: 12,
+                        paddingHorizontal: 12,
+                        paddingBottom: 8,
+                      }}
+                    >
+                      {signalError}
+                    </Text>
+                  ) : null}
+                </BottomSheetSection>
+                <BottomSheetSeparator />
+              </>
+            )}
 
-      <BottomSheetSection label="View">
-        <BottomSheetItem
-          label="Chat"
-          icon={
-            <Icon name="chat" size={18} color={tokens.text2} strokeWidth={2} />
-          }
-          active={view === `chat`}
-          onPress={() => handlePick(`chat`)}
-        />
-        <BottomSheetItem
-          label="State explorer"
-          icon={
-            <Icon
-              name="database"
-              size={18}
-              color={tokens.text2}
-              strokeWidth={2}
-            />
-          }
-          active={view === `state-explorer`}
-          onPress={() => handlePick(`state-explorer`)}
-        />
-      </BottomSheetSection>
+            <BottomSheetSection label="View">
+              <BottomSheetItem
+                label="Chat"
+                icon={
+                  <Icon
+                    name="chat"
+                    size={18}
+                    color={tokens.text2}
+                    strokeWidth={2}
+                  />
+                }
+                active={view === `chat`}
+                onPress={() => handlePick(`chat`)}
+              />
+              <BottomSheetItem
+                label="State explorer"
+                icon={
+                  <Icon
+                    name="database"
+                    size={18}
+                    color={tokens.text2}
+                    strokeWidth={2}
+                  />
+                }
+                active={view === `state-explorer`}
+                onPress={() => handlePick(`state-explorer`)}
+              />
+            </BottomSheetSection>
+            {canSignal && (
+              <>
+                <BottomSheetSeparator />
+                <BottomSheetSection>
+                  <BottomSheetItem
+                    label="Send signal"
+                    icon={
+                      <Icon
+                        name="radio"
+                        size={18}
+                        color={tokens.text2}
+                        strokeWidth={2}
+                      />
+                    }
+                    trailing={
+                      <Icon
+                        name="chevron-right"
+                        size={16}
+                        color={tokens.text3}
+                        strokeWidth={2}
+                      />
+                    }
+                    onPress={() => transitionToMenu(true)}
+                  />
+                </BottomSheetSection>
+              </>
+            )}
+          </>
+        )}
+      </Animated.View>
     </BottomSheet>
   )
 }
+
+const styles = StyleSheet.create({
+  drillPane: {
+    overflow: `hidden`,
+  },
+})

--- a/packages/agents-mobile/src/lib/AgentsProvider.tsx
+++ b/packages/agents-mobile/src/lib/AgentsProvider.tsx
@@ -3,8 +3,10 @@ import {
   createEntitiesCollection,
   createEntityTypesCollection,
   createRunnersCollection,
+  signalEntity,
   type EntitiesCollection,
   type EntityTypesCollection,
+  type EntitySignal,
   type RunnersCollection,
 } from './agentsClient'
 
@@ -13,6 +15,12 @@ type AgentsContextValue = {
   entitiesCollection: EntitiesCollection
   entityTypesCollection: EntityTypesCollection
   runnersCollection: RunnersCollection
+  signalEntity: (input: {
+    entityUrl: string
+    signal: EntitySignal
+    reason?: string
+    payload?: unknown
+  }) => Promise<void>
 }
 
 const AgentsContext = createContext<AgentsContextValue | null>(null)
@@ -30,6 +38,7 @@ export function AgentsProvider({
       entitiesCollection: createEntitiesCollection(serverUrl),
       entityTypesCollection: createEntityTypesCollection(serverUrl),
       runnersCollection: createRunnersCollection(serverUrl),
+      signalEntity: (input) => signalEntity({ baseUrl: serverUrl, ...input }),
     }
   }, [serverUrl])
 

--- a/packages/agents-mobile/src/lib/agentsClient.ts
+++ b/packages/agents-mobile/src/lib/agentsClient.ts
@@ -4,13 +4,31 @@ import { appendPathToUrl } from '@electric-ax/agents-runtime/client'
 import { serverFetch } from '@electric-ax/agents-server-ui/src/lib/auth-fetch'
 import { z } from 'zod'
 
-export type EntityStatus = `spawning` | `running` | `idle` | `stopped`
+export type EntityStatus =
+  | `spawning`
+  | `running`
+  | `idle`
+  | `paused`
+  | `stopping`
+  | `stopped`
+  | `killed`
+export type EntitySignal =
+  | `SIGINT`
+  | `SIGHUP`
+  | `SIGTERM`
+  | `SIGKILL`
+  | `SIGSTOP`
+  | `SIGCONT`
+  | `SIGUSR`
 
 const ENTITY_STATUSES: [EntityStatus, ...Array<EntityStatus>] = [
   `spawning`,
   `running`,
   `idle`,
+  `paused`,
+  `stopping`,
   `stopped`,
+  `killed`,
 ]
 
 export const entitySchema = z.object({
@@ -202,6 +220,39 @@ export async function spawnEntity({
   }
 
   return entityUrl
+}
+
+export async function signalEntity({
+  baseUrl,
+  entityUrl,
+  signal,
+  reason,
+  payload,
+}: {
+  baseUrl: string
+  entityUrl: string
+  signal: EntitySignal
+  reason?: string
+  payload?: unknown
+}): Promise<void> {
+  const body: Record<string, unknown> = { signal }
+  if (reason !== undefined) body.reason = reason
+  if (payload !== undefined) body.payload = payload
+
+  const res = await serverFetch(
+    appendPathToUrl(
+      baseUrl,
+      `/_electric/entities${entityUrl.startsWith(`/`) ? entityUrl : `/${entityUrl}`}/signal`
+    ),
+    {
+      method: `POST`,
+      headers: { 'content-type': `application/json` },
+      body: JSON.stringify(body),
+    }
+  )
+  if (!res.ok) {
+    throw new Error(await responseMessage(res, `Signal failed`))
+  }
 }
 
 export function getEntityDisplayTitle(entity: ElectricEntity): string {

--- a/packages/agents-mobile/src/screens/SessionScreen.tsx
+++ b/packages/agents-mobile/src/screens/SessionScreen.tsx
@@ -38,7 +38,7 @@ import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
 import type { EmbedViewId } from '../lib/embedView'
-import type { ElectricEntity } from '../lib/agentsClient'
+import type { ElectricEntity, EntitySignal } from '../lib/agentsClient'
 
 export const CHAT_COMPOSER_BASE_HEIGHT = 76
 export const CHAT_COMPOSER_OVERLAP = 20
@@ -139,13 +139,15 @@ export function SessionScreen({
     messages: Array<OptimisticInboxMessage>
   ) => void
 }): React.ReactElement {
-  const { entitiesCollection, serverUrl } = useAgents()
+  const { entitiesCollection, serverUrl, signalEntity } = useAgents()
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const [menuOpen, setMenuOpen] = useState(false)
   const [inlineQueuedMessages, setInlineQueuedMessages] = useState<
     Map<string, OptimisticInboxMessage>
   >(() => new Map())
+  const [stopPending, setStopPending] = useState(false)
+  const [signalError, setSignalError] = useState<string | null>(null)
   const inlineQueuedKeysRef = useRef(new Set<string>())
   const inlineTimeoutsRef = useRef(
     new Map<string, ReturnType<typeof setTimeout>>()
@@ -161,10 +163,8 @@ export function SessionScreen({
   const entity = matches.at(0) ?? null
   const streamEntityUrl =
     view === `chat` && entity?.status !== `spawning` ? entityUrl : null
-  const { timelineRows, pendingInbox, db } = useEntityTimeline(
-    serverUrl,
-    streamEntityUrl
-  )
+  const { timelineRows, pendingInbox, db, generationActive } =
+    useEntityTimeline(serverUrl, streamEntityUrl)
   const manifests = useMemo(
     () =>
       timelineRows
@@ -276,6 +276,67 @@ export function SessionScreen({
     onInlineQueuedMessagesChange?.(Array.from(inlineQueuedMessages.values()))
   }, [inlineQueuedMessages, onInlineQueuedMessagesChange])
 
+  useEffect(() => {
+    if (!generationActive) setStopPending(false)
+  }, [generationActive])
+
+  useEffect(() => {
+    setStopPending(false)
+    setSignalError(null)
+  }, [entityUrl])
+
+  const sendSignal = useCallback(
+    async (
+      signal: EntitySignal,
+      reason: string,
+      opts: { stopPending?: boolean } = {}
+    ): Promise<void> => {
+      if (!entity) return
+      if (opts.stopPending) setStopPending(true)
+      setSignalError(null)
+      try {
+        await signalEntity({ entityUrl, signal, reason })
+      } catch (err) {
+        if (opts.stopPending) setStopPending(false)
+        setSignalError(err instanceof Error ? err.message : String(err))
+      }
+    },
+    [entity, entityUrl, signalEntity]
+  )
+
+  const stopGeneration = useCallback((): void => {
+    if (!generationActive || stopPending) return
+    void sendSignal(`SIGINT`, `Stopped from mobile chat UI`, {
+      stopPending: true,
+    })
+  }, [generationActive, sendSignal, stopPending])
+
+  const stopImmediately = useCallback(async (): Promise<void> => {
+    if (!entity) return
+    setSignalError(null)
+    try {
+      await signalEntity({
+        entityUrl,
+        signal: `SIGSTOP`,
+        reason: `Stopped immediately from mobile session menu`,
+      })
+      await signalEntity({
+        entityUrl,
+        signal: `SIGINT`,
+        reason: `Interrupted current run for immediate stop`,
+      })
+    } catch (err) {
+      setSignalError(err instanceof Error ? err.message : String(err))
+    }
+  }, [entity, entityUrl, signalEntity])
+
+  const sendMenuSignal = useCallback(
+    (signal: EntitySignal): void => {
+      void sendSignal(signal, `Sent from mobile session menu`)
+    },
+    [sendSignal]
+  )
+
   const title = entity
     ? getEntityDisplayTitle(entity)
     : decodeURIComponent(entityUrl.replace(/^\//, ``))
@@ -309,17 +370,25 @@ export function SessionScreen({
           onOptimisticQueuedMessage={rememberInlineQueuedMessage}
           onOpenEntity={onOpenEntity}
           onOpenStateSource={onOpenStateSource}
+          generationActive={generationActive}
+          stopPending={stopPending}
+          onStop={stopGeneration}
           disabled={
-            !db || entity?.status === `stopped` || entity?.status === `spawning`
+            !db ||
+            entity?.status === `stopped` ||
+            entity?.status === `killed` ||
+            entity?.status === `spawning`
           }
           placeholder={
             entity?.status === `stopped`
               ? `Entity stopped`
-              : entity?.status === `spawning`
-                ? `Starting...`
-                : !db
-                  ? `Connecting...`
-                  : `Send a message...`
+              : entity?.status === `killed`
+                ? `Entity killed`
+                : entity?.status === `spawning`
+                  ? `Starting...`
+                  : !db
+                    ? `Connecting...`
+                    : `Send a message...`
           }
         />
       )}
@@ -330,6 +399,9 @@ export function SessionScreen({
         entity={entity}
         view={view}
         onSetView={onSetView}
+        signalError={signalError}
+        onSignal={sendMenuSignal}
+        onStopImmediately={() => void stopImmediately()}
       />
     </Screen>
   )
@@ -347,6 +419,9 @@ function NativeMessageComposer({
   onOptimisticQueuedMessage,
   onOpenEntity,
   onOpenStateSource,
+  generationActive,
+  stopPending,
+  onStop,
   disabled,
   placeholder,
 }: {
@@ -361,6 +436,9 @@ function NativeMessageComposer({
   onOptimisticQueuedMessage?: (message: OptimisticInboxMessage) => void
   onOpenEntity?: (entityUrl: string) => void
   onOpenStateSource?: (sourceId: string) => void
+  generationActive: boolean
+  stopPending: boolean
+  onStop: () => void
   disabled: boolean
   placeholder: string
 }): React.ReactElement {
@@ -403,6 +481,9 @@ function NativeMessageComposer({
     if (!db) return null
     return createSteerInboxMessageAction({ db, baseUrl: serverUrl, entityUrl })
   }, [db, serverUrl, entityUrl])
+  const showStop =
+    generationActive && text.length === 0 && !disabled && !editingMessage
+  const canStop = showStop && !stopPending
   const canSend = text.length > 0 && !disabled && !sending
   const setMeasuredInputHeight = (height: number): void => {
     const nextHeight = Math.min(
@@ -477,6 +558,14 @@ function NativeMessageComposer({
     setEditingMessage(null)
     onSendMessage?.()
     finishPersistedAction(tx.isPersisted.promise)
+  }
+
+  const handleComposerAction = (): void => {
+    if (showStop) {
+      if (canStop) onStop()
+      return
+    }
+    send()
   }
 
   const startEditing = useCallback(
@@ -601,24 +690,26 @@ function NativeMessageComposer({
           returnKeyType="default"
         />
         <Pressable
-          onPress={send}
-          disabled={!canSend}
+          onPress={handleComposerAction}
+          disabled={showStop ? stopPending : !canSend}
           hitSlop={8}
           accessibilityRole="button"
-          accessibilityLabel="Send message"
+          accessibilityLabel={showStop ? `Stop generating` : `Send message`}
           style={({ pressed }) => [
             styles.sendButton,
-            canSend ? styles.sendButtonActive : null,
-            pressed && canSend ? styles.sendButtonPressed : null,
+            canSend || showStop ? styles.sendButtonActive : null,
+            showStop ? styles.stopButton : null,
+            showStop && stopPending ? styles.stopButtonPending : null,
+            pressed && (canSend || showStop) ? styles.sendButtonPressed : null,
           ]}
         >
-          {sending ? (
+          {sending && !showStop ? (
             <ActivityIndicator size="small" color={tokens.textOnAccent} />
           ) : (
             <Icon
-              name="arrow-up"
-              size={18}
-              color={canSend ? tokens.textOnAccent : tokens.text4}
+              name={showStop ? `square` : `arrow-up`}
+              size={showStop ? 14 : 18}
+              color={canSend || showStop ? tokens.textOnAccent : tokens.text4}
               strokeWidth={2.4}
             />
           )}
@@ -1324,7 +1415,6 @@ function createComposerStyles(tokens: Tokens) {
       marginTop: -CHAT_COMPOSER_OVERLAP,
       paddingHorizontal: spacing.lg,
       paddingTop: 0,
-      backgroundColor: tokens.bg,
       zIndex: 10,
     },
     composer: {
@@ -1369,6 +1459,16 @@ function createComposerStyles(tokens: Tokens) {
     },
     sendButtonActive: {
       backgroundColor: tokens.accent9,
+    },
+    stopButton: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      margin: 5,
+      backgroundColor: tokens.accent9,
+    },
+    stopButtonPending: {
+      opacity: 0.72,
     },
     sendButtonPressed: {
       opacity: 0.8,

--- a/packages/agents-server-ui/src/components/EntityTimeline.tsx
+++ b/packages/agents-server-ui/src/components/EntityTimeline.tsx
@@ -1327,10 +1327,13 @@ export function EntityTimeline({
       <ScrollArea
         viewportRef={scrollAreaRef}
         className={styles.scroll}
-        viewportClassName={styles.scrollViewport}
+        viewportClassName={`${styles.scrollViewport} mobile-chat-scroll-viewport`}
         scrollbars="vertical"
       >
-        <div ref={contentRef} className={styles.content}>
+        <div
+          ref={contentRef}
+          className={`${styles.content} mobile-chat-content`}
+        >
           <Stack>
             {spawnTime ? (
               <Tooltip content={formatAbsoluteDateTimeVerbose(spawnTime)}>

--- a/packages/agents-server-ui/src/components/UserMessage.tsx
+++ b/packages/agents-server-ui/src/components/UserMessage.tsx
@@ -24,7 +24,11 @@ export const UserMessage = memo(function UserMessage({
   const sender = formatSender(section.from)
 
   return (
-    <Stack direction="column" gap={1} className={styles.root}>
+    <Stack
+      direction="column"
+      gap={1}
+      className={`${styles.root} mobile-user-message-root`}
+    >
       <Stack
         p={3}
         className={[styles.bubble, showStop ? styles.withStop : null]

--- a/packages/agents-server-ui/src/embed/EmbedApp.tsx
+++ b/packages/agents-server-ui/src/embed/EmbedApp.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useMemo, type ReactElement } from 'react'
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type CSSProperties,
+  type ReactElement,
+} from 'react'
 import {
   RouterProvider,
   createMemoryHistory,
@@ -69,6 +75,7 @@ type EmbedState = {
   theme: EmbedTheme
   scrollToBottomSignal?: number
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
+  bottomInset?: number
   // Forwarded across the Expo-DOM boundary so the embed's auth-fetch
   // module instance (separate from the native side) can inject the
   // Cloud `Authorization` + `x-electric-service` headers on every
@@ -163,6 +170,7 @@ function EmbedSurface({ state }: { state: EmbedState }): ReactElement {
       serverUrl={state.serverUrl}
       scrollToBottomSignal={state.scrollToBottomSignal}
       inlineQueuedMessages={state.inlineQueuedMessages}
+      bottomInset={state.bottomInset}
     />
   )
 }
@@ -173,12 +181,14 @@ function EntityHost({
   serverUrl,
   scrollToBottomSignal,
   inlineQueuedMessages,
+  bottomInset,
 }: {
   entityUrl: string
   view: EmbedView
   serverUrl: string
   scrollToBottomSignal?: number
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
+  bottomInset?: number
 }): ReactElement {
   const { entitiesCollection } = useElectricAgents()
   const { data: matches = [], isLoading } = useLiveQuery(
@@ -215,8 +225,11 @@ function EntityHost({
     )
   }
   if (view === `chat-log`) {
+    const style = {
+      '--mobile-chat-bottom-inset': `${Math.max(0, bottomInset ?? 0)}px`,
+    } as CSSProperties
     return (
-      <div className={styles.column}>
+      <div className={styles.column} style={style}>
         <ChatLogView
           {...props}
           scrollToBottomSignal={scrollToBottomSignal}

--- a/packages/agents-server-ui/src/embed/SessionDomEmbed.css
+++ b/packages/agents-server-ui/src/embed/SessionDomEmbed.css
@@ -38,10 +38,25 @@ html[data-electric-mobile-dom='true'] {
     'Courier New', monospace;
 }
 
-html[data-electric-mobile-dom='true']
-  [class*='EntityTimeline'][class*='_content_'] {
-  padding: var(--ds-space-4) var(--ds-space-4) 96px !important;
+html[data-electric-mobile-dom='true'] .mobile-chat-content {
+  padding: var(--ds-space-4) var(--ds-space-2)
+    calc(var(--ds-space-4) + var(--mobile-chat-bottom-inset, 0px)) !important;
   max-width: 100% !important;
+}
+
+html[data-electric-mobile-dom='true'] .mobile-chat-scroll-viewport {
+  mask-image: linear-gradient(
+    to bottom,
+    #000 0,
+    #000 calc(100% - min(160px, var(--mobile-chat-bottom-inset, 20px))),
+    transparent 100%
+  ) !important;
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    #000 0,
+    #000 calc(100% - min(160px, var(--mobile-chat-bottom-inset, 20px))),
+    transparent 100%
+  ) !important;
 }
 
 html[data-electric-mobile-dom='true'] [class*='MessageInput'][class*='_root_'] {
@@ -56,6 +71,10 @@ html[data-electric-mobile-dom='true'] [class*='MessageInput'][class*='_root_'] {
 html[data-electric-mobile-dom='true']
   [class*='UserMessage'][class*='_bubble_'] {
   padding: var(--ds-space-2) var(--ds-space-3) !important;
+}
+
+html[data-electric-mobile-dom='true'] .mobile-user-message-root {
+  width: max(0px, calc(100% - 24px)) !important;
 }
 
 html[data-electric-mobile-dom='true']

--- a/packages/agents-server-ui/src/embed/SessionDomEmbed.css
+++ b/packages/agents-server-ui/src/embed/SessionDomEmbed.css
@@ -48,13 +48,17 @@ html[data-electric-mobile-dom='true'] .mobile-chat-scroll-viewport {
   mask-image: linear-gradient(
     to bottom,
     #000 0,
-    #000 calc(100% - min(160px, var(--mobile-chat-bottom-inset, 20px))),
+    #000 calc(100% - var(--mobile-chat-bottom-inset, 20px)),
+    rgba(0, 0, 0, 0.35)
+      calc(100% - min(56px, var(--mobile-chat-bottom-inset, 20px))),
     transparent 100%
   ) !important;
   -webkit-mask-image: linear-gradient(
     to bottom,
     #000 0,
-    #000 calc(100% - min(160px, var(--mobile-chat-bottom-inset, 20px))),
+    #000 calc(100% - var(--mobile-chat-bottom-inset, 20px)),
+    rgba(0, 0, 0, 0.35)
+      calc(100% - min(56px, var(--mobile-chat-bottom-inset, 20px))),
     transparent 100%
   ) !important;
 }


### PR DESCRIPTION
## Summary
- Add mobile agent signal support, including stop controls in the composer and a signal submenu in the session menu.
- Pass composer/drawer inset into the embedded chat log so timeline content scrolls behind the native controls.
- Align mobile embedded chat message widths and fade masking with the native composer layout.

## Test plan
- pnpm --filter @electric-ax/agents-mobile typecheck
- pnpm --filter @electric-ax/agents-server-ui typecheck
- ReadLints on recently edited files

Made with [Cursor](https://cursor.com)