### PR TITLE
feat(agents-server-ui): defensive null guards and error boundary for timeline rows

### DIFF
--- a/.changeset/timeline-row-error-boundary.md
+++ b/.changeset/timeline-row-error-boundary.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server-ui': patch
+---
+
+Add defensive null guards for timeline run items and an error boundary around each timeline row to prevent a single malformed row from crashing the entire view.

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -253,6 +253,10 @@ function stringifyToolPayload(value: unknown): string | undefined {
   return JSON.stringify(value)
 }
 
+function textContent(item: EntityTimelineTextItem | null | undefined): string {
+  return typeof item?.content === `string` ? item.content : ``
+}
+
 function liveToolCallToContentItem(
   item: EntityTimelineToolCallItem
 ): Extract<EntityTimelineContentItem, { kind: `tool_call` }> {
@@ -300,9 +304,14 @@ function liveRunItemsToContentItems(
   const contentItems: Array<EntityTimelineContentItem> = []
   for (const item of items) {
     if (item.text) {
-      if (item.text.content.trim().length > 0) {
-        contentItems.push({ kind: `text`, text: item.text.content })
+      const content = textContent(item.text)
+      if (content.trim().length > 0) {
+        contentItems.push({ kind: `text`, text: content })
       }
+      continue
+    }
+    if (!item.toolCall) {
+      console.error(`Run item has neither text nor toolCall`, { item })
       continue
     }
     contentItems.push(liveToolCallToContentItem(item.toolCall))
@@ -327,7 +336,7 @@ const LiveTextItem = memo(function LiveTextItem({
 }): React.ReactElement {
   return (
     <MarkdownSegment
-      text={item.content}
+      text={textContent(item)}
       contentHash={0}
       isStreaming={isStreaming}
       renderWidth={renderWidth}
@@ -387,7 +396,7 @@ export const AgentResponseLive = memo(function AgentResponseLive({
     (run.status === `failed` ? `Run failed` : undefined)
   const lastItem = sortedItems[sortedItems.length - 1]
   const lastTextHasContent =
-    lastItem?.text !== undefined && lastItem.text.content.trim().length > 0
+    lastItem?.text !== undefined && textContent(lastItem.text).trim().length > 0
   const showThinking =
     isStreaming && !done && !failureText && !lastTextHasContent
   const showTimestamp = timestamp != null && !isStreaming
@@ -421,6 +430,11 @@ export const AgentResponseLive = memo(function AgentResponseLive({
               renderWidth={renderWidth}
             />
           )
+        }
+
+        if (!item.toolCall) {
+          console.error(`Run item has neither text nor toolCall`, { item })
+          return null
         }
 
         return (

--- a/packages/agents-server-ui/src/components/EntityTimeline.tsx
+++ b/packages/agents-server-ui/src/components/EntityTimeline.tsx
@@ -1,4 +1,5 @@
 import {
+  Component,
   memo,
   useCallback,
   useEffect,
@@ -53,6 +54,7 @@ import type {
   IncludesEntity,
   Manifest,
 } from '@electric-ax/agents-runtime/client'
+import type { ErrorInfo, ReactNode } from 'react'
 import type { PaneFindAdapter, PaneFindMatch } from '../hooks/usePaneFind'
 
 type RenderTimelineRow = EntityTimelineQueryRow
@@ -77,8 +79,14 @@ function stringifySearchPayload(value: unknown): string {
 }
 
 function runItemSearchText(item: EntityTimelineRunItem): string {
-  if (item.text) return item.text.content
+  if (item.text) {
+    return typeof item.text.content === `string` ? item.text.content : ``
+  }
   const toolCall = item.toolCall
+  if (!toolCall) {
+    console.error(`Run item has neither text nor toolCall`, { item })
+    return ``
+  }
   return [
     toolCall.tool_name,
     stringifySearchPayload(toolCall.args),
@@ -91,6 +99,72 @@ function runItemSearchText(item: EntityTimelineRunItem): string {
 
 function runSearchTextFromSnapshot(run: EntityTimelineRunRow): string {
   return run.items.toArray.map(runItemSearchText).join(` `)
+}
+
+interface TimelineRowErrorBoundaryProps {
+  rowKey: string
+  children: ReactNode
+}
+
+interface TimelineRowErrorBoundaryState {
+  rowKey: string
+  error: unknown
+}
+
+class TimelineRowErrorBoundary extends Component<
+  TimelineRowErrorBoundaryProps,
+  TimelineRowErrorBoundaryState
+> {
+  state: TimelineRowErrorBoundaryState = {
+    rowKey: this.props.rowKey,
+    error: null,
+  }
+
+  static getDerivedStateFromError(
+    error: unknown
+  ): Partial<TimelineRowErrorBoundaryState> {
+    return { error }
+  }
+
+  static getDerivedStateFromProps(
+    props: TimelineRowErrorBoundaryProps,
+    state: TimelineRowErrorBoundaryState
+  ): Partial<TimelineRowErrorBoundaryState> | null {
+    if (props.rowKey !== state.rowKey) {
+      return { rowKey: props.rowKey, error: null }
+    }
+    return null
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo): void {
+    console.error(`Error rendering timeline row`, {
+      rowKey: this.props.rowKey,
+      error,
+      componentStack: info.componentStack,
+    })
+  }
+
+  render(): ReactNode {
+    if (!this.state.error) {
+      return this.props.children
+    }
+
+    const message =
+      this.state.error instanceof Error
+        ? this.state.error.message
+        : String(this.state.error)
+
+    return (
+      <Stack direction="column" gap={1}>
+        <Text tone="danger" size={2}>
+          Could not render this timeline row.
+        </Text>
+        <Text tone="muted" size={1}>
+          {message}
+        </Text>
+      </Stack>
+    )
+  }
 }
 
 /**
@@ -1395,23 +1469,25 @@ export function EntityTimeline({
                       paddingBottom: timelineRowGap(row),
                     }}
                   >
-                    <TimelineRow
-                      row={row}
-                      responseTimestamp={
-                        responseTimestampByRowKey.get(rowKey) ?? null
-                      }
-                      isInitialUserMessage={rowKey === firstInboxRowKey}
-                      entityStopped={entityStopped}
-                      isStreaming={rowKey === lastStreamingAgentKey}
-                      renderWidth={textColumnWidth}
-                      entityUrl={entityUrl}
-                      tileId={tileId ?? null}
-                      entityStatusByUrl={entityStatusByUrl}
-                      stopUserMessageKey={stopUserMessageKey}
-                      stopPending={stopPending}
-                      onStopGeneration={onStopGeneration}
-                      onRunSearchTextChange={updateRunSearchText}
-                    />
+                    <TimelineRowErrorBoundary rowKey={rowKey}>
+                      <TimelineRow
+                        row={row}
+                        responseTimestamp={
+                          responseTimestampByRowKey.get(rowKey) ?? null
+                        }
+                        isInitialUserMessage={rowKey === firstInboxRowKey}
+                        entityStopped={entityStopped}
+                        isStreaming={rowKey === lastStreamingAgentKey}
+                        renderWidth={textColumnWidth}
+                        entityUrl={entityUrl}
+                        tileId={tileId ?? null}
+                        entityStatusByUrl={entityStatusByUrl}
+                        stopUserMessageKey={stopUserMessageKey}
+                        stopPending={stopPending}
+                        onStopGeneration={onStopGeneration}
+                        onRunSearchTextChange={updateRunSearchText}
+                      />
+                    </TimelineRowErrorBoundary>
                   </div>
                 )
               })}


### PR DESCRIPTION
## Summary

Add defensive null guards and a React error boundary to the agents timeline UI, preventing crashes when TanStack DB's `caseWhen`/`unionAll` produces `null` where TypeScript expects `undefined`.

## Root Cause

The `EntityTimelineRunItem` type is a discriminated union where `text` and `toolCall` are mutually exclusive. At the TypeScript level, the non-matching field is typed as `undefined`. However, at runtime, TanStack DB's `caseWhen` operator returns `null` for non-matching branches. This mismatch means accessing `.content` on a null `text` item or `.tool_name` on a null `toolCall` item throws, crashing the entire timeline.

## Approach

**Null-safe content access** — A `textContent()` helper safely extracts string content from text items, returning empty string for null/non-string values. Used consistently across all text content access points in `AgentResponse.tsx`.

**Guard clauses for toolCall** — Added `if (!item.toolCall)` guards before accessing tool call properties. These log a `console.error` for diagnostic visibility since an item with neither text nor toolCall indicates an unexpected data shape.

**Error boundary** — Wrapped each virtualized `TimelineRow` in a `TimelineRowErrorBoundary` class component. If a row throws during render, the boundary catches it, logs the error with `componentDidCatch` (including `rowKey` and component stack), and renders a fallback message. The boundary resets when `rowKey` changes, allowing virtualizer reuse.

## Key Invariants

- Every `EntityTimelineRunItem` should have either `text` or `toolCall` — guards log when neither is present
- A single broken timeline row must never crash the entire timeline view
- Error boundary logs full error context before displaying fallback UI

## Non-goals

- Not adding logging for the `textContent()` null-item case — that's the expected `caseWhen` behavior, not corruption
- Not sharing `textContent()` across files — the inline check in `EntityTimeline.tsx` search text is clear enough standalone

## Files Changed

- **`AgentResponse.tsx`** — Added `textContent()` helper, null guards with `console.error` for missing `toolCall`, updated all text content access sites
- **`EntityTimeline.tsx`** — Added `TimelineRowErrorBoundary` with `componentDidCatch` logging, null guard in `runItemSearchText`, wrapped `TimelineRow` in error boundary

## Verification

```bash
cd packages/agents-server-ui && pnpm exec tsc --noEmit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)