### PR TITLE
Fix malformed offset validation

### DIFF
--- a/.changeset/invalid-offset-validation.md
+++ b/.changeset/invalid-offset-validation.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Reject malformed shape offsets with negative parts as invalid requests instead of raising `FunctionClauseError`.

--- a/packages/sync-service/lib/electric/replication/log_offset.ex
+++ b/packages/sync-service/lib/electric/replication/log_offset.ex
@@ -377,8 +377,8 @@ defmodule Electric.Replication.LogOffset do
         with [tx_offset_str, op_offset_str] <- String.split(str, "_"),
              {tx_offset, ""} <- Integer.parse(tx_offset_str),
              {op_offset, ""} <- parse_int_or_inf(op_offset_str),
-             offset <- new(tx_offset, op_offset) do
-          {:ok, offset}
+             true <- valid_offset_parts?(tx_offset, op_offset) do
+          {:ok, new(tx_offset, op_offset)}
         else
           _ -> {:error, "has invalid format"}
         end
@@ -387,6 +387,18 @@ defmodule Electric.Replication.LogOffset do
 
   defp parse_int_or_inf("inf"), do: {:infinity, ""}
   defp parse_int_or_inf(int), do: Integer.parse(int)
+
+  defp valid_offset_parts?(-1, 0), do: true
+
+  defp valid_offset_parts?(tx_offset, op_offset)
+       when is_integer(tx_offset) and tx_offset >= 0 and is_integer(op_offset) and op_offset >= 0,
+       do: true
+
+  defp valid_offset_parts?(tx_offset, :infinity)
+       when is_integer(tx_offset) and tx_offset >= 0,
+       do: true
+
+  defp valid_offset_parts?(_, _), do: false
 
   defimpl Inspect do
     def inspect(%LogOffset{tx_offset: -1, op_offset: 0}, _opts) do

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -145,6 +145,22 @@ defmodule Electric.Plug.ServeShapePlugTest do
              }
     end
 
+    test "returns 400 for offset with negative parts", ctx do
+      conn =
+        ctx
+        |> conn(:get, %{"table" => "foo"}, "?offset=0_-1")
+        |> call_serve_shape_plug(ctx)
+
+      assert conn.status == 400
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "message" => "Invalid request",
+               "errors" => %{
+                 "offset" => ["has invalid format"]
+               }
+             }
+    end
+
     test "returns 400 when table param is missing", ctx do
       conn =
         ctx

--- a/packages/sync-service/test/electric/replication/log_offset_test.exs
+++ b/packages/sync-service/test/electric/replication/log_offset_test.exs
@@ -35,4 +35,10 @@ defmodule Electric.Replication.LogOffsetTest do
     assert to_charlist(LogOffset.new(10, 2)) == ~c"10_2"
     assert to_charlist(LogOffset.before_all()) == ~c"-1"
   end
+
+  test "from_string rejects invalid negative offset parts without raising" do
+    assert {:error, "has invalid format"} = LogOffset.from_string("0_-1")
+    assert {:error, "has invalid format"} = LogOffset.from_string("-2_0")
+    assert {:error, "has invalid format"} = LogOffset.from_string("-1_inf")
+  end
 end


### PR DESCRIPTION
## Summary
- validate parsed log offset parts before constructing LogOffset structs
- return 400 for malformed shape offsets like `0_-1` instead of raising FunctionClauseError
- add regression coverage for offset parsing and shape request validation

## Testing
- `mix test test/electric/replication/log_offset_test.exs test/electric/plug/serve_shape_plug_test.exs --trace`