### PR TITLE
docs: warn about Bun's 256 concurrent fetch cap for proxies

### DIFF
--- a/.changeset/bun-fetch-concurrency-cap.md
+++ b/.changeset/bun-fetch-concurrency-cap.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/client': patch
+---
+
+Document Bun's default 256 concurrent `fetch()` cap in the proxy-auth and deployment skills. Auth/caching proxies running on Bun bottleneck under load unless `BUN_CONFIG_MAX_HTTP_REQUESTS` is raised; Node and Deno are unaffected.

--- a/packages/typescript-client/skills/electric-deployment/SKILL.md
+++ b/packages/typescript-client/skills/electric-deployment/SKILL.md
@@ -169,6 +169,24 @@ Electric caches shape logs on disk. Ephemeral storage causes full re-sync on eve
 
 Source: `website/docs/guides/deployment.md:133-157`
 
+### HIGH Bun proxy bottlenecks at 256 concurrent fetches
+
+Wrong:
+
+```sh
+bun run proxy.ts
+```
+
+Correct:
+
+```sh
+BUN_CONFIG_MAX_HTTP_REQUESTS=4096 bun run proxy.ts
+```
+
+When deploying an auth/caching proxy in front of Electric on the Bun runtime, set `BUN_CONFIG_MAX_HTTP_REQUESTS` to match expected concurrent shape requests. Bun's default cap of 256 simultaneous `fetch()` calls queues excess requests silently — the proxy appears responsive but upstream calls to Electric stall, surfacing as latency under load rather than errors. Max value is 65,336. Node and Deno do not impose this cap.
+
+Source: https://bun.com/docs/runtime/networking/fetch
+
 ### MEDIUM Using deprecated ELECTRIC_QUERY_DATABASE_URL
 
 Wrong:

--- a/packages/typescript-client/skills/electric-proxy-auth/SKILL.md
+++ b/packages/typescript-client/skills/electric-proxy-auth/SKILL.md
@@ -6,6 +6,7 @@ description: >
   definition (table, where, params), content-encoding/content-length header
   cleanup, CORS configuration for electric-offset/electric-handle/
   electric-schema/electric-cursor headers, auth token injection,
+  Bun fetch concurrency cap (BUN_CONFIG_MAX_HTTP_REQUESTS default 256),
   ELECTRIC_SECRET/SOURCE_SECRET server-side only, tenant isolation via
   WHERE positional params, onError 401 token refresh, and subset security
   (AND semantics). Load when creating proxy routes, adding auth, or
@@ -213,6 +214,24 @@ originUrl.searchParams.set('params[1]', user.orgId)
 String interpolation in WHERE clauses enables SQL injection. Use positional params (`$1`, `$2`).
 
 Source: `website/docs/guides/auth.md`
+
+### HIGH Bun fetch concurrency cap (256) bottlenecks the proxy under load
+
+Wrong:
+
+```sh
+bun run proxy.ts
+```
+
+Correct:
+
+```sh
+BUN_CONFIG_MAX_HTTP_REQUESTS=4096 bun run proxy.ts
+```
+
+Bun caps simultaneous `fetch()` calls at **256 per process** by default. Excess requests queue silently — the proxy keeps accepting inbound connections but upstream calls to Electric stall, surfacing as latency spikes rather than errors. Raise `BUN_CONFIG_MAX_HTTP_REQUESTS` (max 65,336) to match your expected concurrent shape requests. Node and Deno do not impose this cap.
+
+Source: https://bun.com/docs/runtime/networking/fetch
 
 ### HIGH Not exposing Electric response headers via CORS
 

--- a/website/docs/sync/guides/deployment.md
+++ b/website/docs/sync/guides/deployment.md
@@ -57,6 +57,9 @@ You also often want to proxy requests to Electric through your API, or other pro
 
 Note also that, when running Electric behind a CDN, you may want your proxy in front of the CDN. This is where primitives like [edge functions](/docs/sync/integrations/supabase#sync-into-edge-function) and [edge workers](/docs/sync/integrations/cloudflare#workers) can be very useful.
 
+> [!Tip] Running the proxy on Bun?
+> Raise `BUN_CONFIG_MAX_HTTP_REQUESTS` to match your concurrency. See [Bun fetch concurrency cap](/docs/sync/guides/troubleshooting#bun-fetch-concurrency-cap-why-is-my-proxy-slow-under-load) in troubleshooting.
+
 ### Securing data access
 
 By default, Electric exposes public access to the contents of your database. You generally don't want to expose the contents of your database, so you need to [lock down access](/docs/sync/guides/security#secure-data-access) to the Electric HTTP API.

--- a/website/docs/sync/guides/troubleshooting.md
+++ b/website/docs/sync/guides/troubleshooting.md
@@ -200,6 +200,20 @@ Live long-poll connections are lightweight Erlang processes, so most hardware ca
 
 **Reduce the number of concurrent shape subscriptions** by lazy-loading shapes only when needed (e.g. per screen) rather than subscribing to all shapes on app boot.
 
+### Bun fetch concurrency cap &mdash; why is my proxy slow under load?
+
+If you run your auth/caching proxy on the [Bun runtime](https://bun.com), Bun caps simultaneous `fetch()` calls at **256 per process** by default. When inbound traffic exceeds that, additional upstream calls to Electric queue silently &mdash; the proxy keeps accepting connections and CPU/memory look fine, but shape requests stall and surface as latency, not errors. Node and Deno have no equivalent cap.
+
+##### Solution &mdash; raise `BUN_CONFIG_MAX_HTTP_REQUESTS`
+
+Set the env var to match your expected concurrent shape requests (max 65,336):
+
+```sh
+BUN_CONFIG_MAX_HTTP_REQUESTS=4096 bun run proxy.ts
+```
+
+See [Bun's fetch docs](https://bun.com/docs/runtime/networking/fetch) for details.
+
 ### WAL growth &mdash; why is my Postgres database storage filling up?
 
 Electric creates a logical replication slot in Postgres to stream changes. This slot tracks a position in the Write-Ahead Log (WAL) and prevents Postgres from removing WAL segments that Electric hasn't yet processed. If the slot doesn't advance, WAL accumulates and consumes disk space.


### PR DESCRIPTION
## Summary

Document that Bun's runtime caps simultaneous `fetch()` calls at **256 per process** by default, which silently bottlenecks auth/caching proxies sitting in front of Electric. Confirmed against [Bun's fetch docs](https://bun.com/docs/runtime/networking/fetch) and [oven-sh/bun#12214](https://github.com/oven-sh/bun/issues/12214) after a user reported patching this in their proxy.

User-visible impact: docs/skills now point Bun users at `BUN_CONFIG_MAX_HTTP_REQUESTS` so they don't have to rediscover the cap themselves.

## Reviewer guidance

### Root cause

Bun's default cap is 256 in-flight `fetch()` calls per process. Excess requests **queue silently** — the proxy keeps accepting inbound connections and CPU/memory look healthy, but upstream calls to Electric stall, so the symptom is latency rather than errors. Node and Deno have no equivalent cap, so it's specifically a Bun-runtime trap.

### Approach

One canonical home (troubleshooting), three cross-references (deployment guide, two skills):

- **`website/docs/sync/guides/troubleshooting.md`** — new H3 under `## Production`, placed right after `503 — concurrent request limit exceeded`, which is the closest semantic neighbor (also "looks healthy but throughput is capped"). Includes the diagnosis, the env var, and a max-value reference.
- **`website/docs/sync/guides/deployment.md`** — short `> [!Tip]` callout in the existing "Proxying requests to Electric" section, linking to the troubleshooting entry. No duplication.
- **`packages/typescript-client/skills/electric-proxy-auth/SKILL.md`** — new `HIGH` entry under "Common Mistakes" so the proxy-auth skill flags this when LLMs scaffold a Bun proxy. Frontmatter description updated so the skill matcher picks up "Bun fetch concurrency cap" queries.
- **`packages/typescript-client/skills/electric-deployment/SKILL.md`** — parallel `HIGH` entry under "Common Mistakes" for the deployment skill, since the env var is a runtime-config concern.

### Key invariants

- The troubleshooting entry is the single source of truth; the deployment guide links to it rather than restating the content.
- Anchor URL in `deployment.md` matches VitePress's auto-generated slug from the troubleshooting H3.
- Skill changes are mechanical: same `HIGH` severity tier already used for other proxy/deployment caveats, same "Wrong / Correct / Source" structure.

### Non-goals

- Not touching example READMEs (`examples/proxy-auth/`, `examples/gatekeeper-auth/`) — they're demo walkthroughs, not deployment guidance. One canonical doc home is enough.
- Not adding a runtime-detection check inside the proxy examples themselves; docs-only fix.
- Not changing `website/docs/sync/guides/security.md` even though it mentions auth proxies — it already delegates to the auth guide for proxy specifics.

### Trade-offs

Considered putting the note inline under the proxy code example in `auth.md` (next to the `fetch(originUrl)` line that actually hits the cap). Decided against it: troubleshooting is where users land when they have the *symptom* ("my proxy is slow"), and the deployment-guide callout is enough discoverability for users reading the setup path.

## Verification

```sh
# Lint/format already ran via lint-staged pre-commit hook (prettier).
# Render check — confirm the troubleshooting anchor resolves:
cd website && pnpm dev
# then open http://localhost:5173/docs/sync/guides/deployment#proxying-requests-to-electric
# and click the troubleshooting link.
```

No code paths changed, no tests to run.

## Files changed

- `website/docs/sync/guides/troubleshooting.md` — new H3 "Bun fetch concurrency cap" under `## Production`.
- `website/docs/sync/guides/deployment.md` — `> [!Tip]` callout in "Proxying requests to Electric" linking to the troubleshooting entry.
- `packages/typescript-client/skills/electric-proxy-auth/SKILL.md` — new HIGH common-mistake entry; frontmatter description extended.
- `packages/typescript-client/skills/electric-deployment/SKILL.md` — new HIGH common-mistake entry.
- `.changeset/bun-fetch-concurrency-cap.md` — patch bump for `@electric-sql/client` (skills ship with the package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)