### PR TITLE
Fix duplicate runFinished wakes for spawned children

### DIFF
--- a/.changeset/rude-pens-unite.md
+++ b/.changeset/rude-pens-unite.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents-server': patch
+---
+
+fix: no more duplicated runFinished wakes

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -10,6 +10,7 @@ import { createSetupContext } from './setup-context'
 import { createEntityLogPrefix, runtimeLog } from './log'
 import { createRuntimeServerClient } from './runtime-server-client'
 import { appendPathToUrl } from './url'
+import { manifestChildKey } from './manifest-helpers'
 import type {
   CronObservationSource,
   EntitiesObservationSource,
@@ -1198,6 +1199,7 @@ export async function processWake(
                 typeof opts.wake === `object` && opts.wake.on === `runFinished`
                   ? opts.wake.includeResponse
                   : undefined,
+              manifestKey: manifestChildKey(childType, childId),
             }
           : undefined
         return serverClient.spawnEntity({

--- a/packages/agents-runtime/src/runtime-server-client.ts
+++ b/packages/agents-runtime/src/runtime-server-client.ts
@@ -51,6 +51,7 @@ export interface SpawnEntityOptions {
     debounceMs?: number
     timeoutMs?: number
     includeResponse?: boolean
+    manifestKey?: string
   }
 }
 

--- a/packages/agents-runtime/test/runtime-dsl.test.ts
+++ b/packages/agents-runtime/test/runtime-dsl.test.ts
@@ -6296,6 +6296,41 @@ describe(`N: wake primitives verification`, () => {
     expect(childUrls.has(finishedUrl)).toBe(true)
   }, 30_000)
 
+  it(`N3b: spawn wake and child manifest share one runFinished registration`, async () => {
+    const childId = `idle-test-child-dedupe-${Date.now()}`
+    const parent = await t.spawn(
+      TYPES.n3IdleWakeParent,
+      `idle-test-dedupe-${Date.now()}`
+    )
+    await parent.send(`spawn ${childId}`)
+    await parent.waitForRun()
+
+    const child = t.entity(`/${TYPES.n3IdleWakeChild}/${childId}`)
+    await child.send(`do work`)
+    await child.waitForRun()
+    await parent.waitFor((history) => history.some(`wake`), 10_000)
+    await t.waitForSettled(10_000)
+
+    const events = await t.readStream(parent.entityUrl)
+    const childUrl = `/${TYPES.n3IdleWakeChild}/${childId}`
+    const runFinishedWakes = events.filter((event) => {
+      if (event.type !== `wake`) return false
+      const value = event.value as Record<string, unknown> | undefined
+      const finishedChild = value?.finished_child as
+        | Record<string, unknown>
+        | undefined
+      return finishedChild?.url === childUrl
+    })
+
+    expect(runFinishedWakes.length).toBeGreaterThan(0)
+    const runKeys = runFinishedWakes.map((event) => {
+      const value = event.value as Record<string, unknown>
+      const changes = value.changes as Array<Record<string, unknown>>
+      return changes[0]?.key
+    })
+    expect(new Set(runKeys).size).toBe(runKeys.length)
+  }, 30_000)
+
   it(`N3: wake events are delivered as wake when the parent is re-woken`, async () => {
     // The parent records wake.type on every wake.
     //

--- a/packages/agents-server/src/electric-agents-types.ts
+++ b/packages/agents-server/src/electric-agents-types.ts
@@ -400,6 +400,7 @@ export interface TypedSpawnRequest {
     debounceMs?: number
     timeoutMs?: number
     includeResponse?: boolean
+    manifestKey?: string
   }
 }
 

--- a/packages/agents-server/src/entity-manager.ts
+++ b/packages/agents-server/src/entity-manager.ts
@@ -554,6 +554,7 @@ export class EntityManager {
         timeoutMs: req.wake.timeoutMs,
         oneShot: false,
         includeResponse: req.wake.includeResponse,
+        manifestKey: req.wake.manifestKey,
       })
     }
 

--- a/packages/agents-server/src/routing/entities-router.ts
+++ b/packages/agents-server/src/routing/entities-router.ts
@@ -84,6 +84,7 @@ const spawnBodySchema = Type.Object({
       debounceMs: Type.Optional(Type.Number()),
       timeoutMs: Type.Optional(Type.Number()),
       includeResponse: Type.Optional(Type.Boolean()),
+      manifestKey: Type.Optional(Type.String()),
     })
   ),
 })


### PR DESCRIPTION
## Summary
- pass the child manifest key through spawn-time wake registration
- persist that manifest key on the server so spawn-time and manifest-side wake registrations dedupe
- add a regression test covering duplicate child runFinished wake delivery

## Test plan
- pnpm vitest run test/runtime-dsl.test.ts -t "N3b"
- pnpm --filter @electric-ax/agents-runtime typecheck
- pnpm --filter @electric-ax/agents-server typecheck

Note: typechecks were run after building required local package outputs with pnpm --filter @electric-sql/client build, pnpm --filter @electric-ax/agents-mcp build, and pnpm --filter @electric-ax/agents-runtime build.