### PR TITLE
fix(agents-server-ui): mobile composer submit (Send button + soft-keyboard Enter)

### DIFF
--- a/.changeset/agent-ui-mobile-submit.md
+++ b/.changeset/agent-ui-mobile-submit.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server-ui': patch
+---
+
+Fix Agent UI message submission on mobile browsers. The Send button now keeps the textarea focused on tap so the on-screen keyboard does not dismiss and reflow the viewport mid-click, and the composer recognises the soft-keyboard return key via `enterKeyHint="send"` plus a `beforeinput` fallback (Android Chrome / GBoard route it as `insertLineBreak` without a matching `keydown`). The Enter handler now also ignores IME composition (`keyCode === 229`).

--- a/packages/agents-server-ui/src/components/MessageInput.tsx
+++ b/packages/agents-server-ui/src/components/MessageInput.tsx
@@ -249,8 +249,31 @@ export function MessageInput({
             ref={textareaRef}
             value={value}
             onChange={(e) => setValue(e.target.value)}
+            // Tell mobile virtual keyboards that Enter means "send" so the
+            // GBoard / iOS keyboard surfaces a send-shaped action key and
+            // — critically on Android Chrome — fires `keydown` with
+            // `key === 'Enter'` reliably. Without this hint the soft
+            // keyboard's return key inside a textarea inserts a newline
+            // and may fire `key === 'Unidentified'` / `keyCode === 229`.
+            enterKeyHint="send"
             onKeyDown={(e) => {
-              if (e.key === `Enter` && !e.shiftKey) {
+              if (e.key !== `Enter` || e.shiftKey) return
+              // Don't submit while an IME composition is in progress —
+              // Enter is committing the candidate, not sending. Android
+              // Chrome reports composing as `keyCode === 229` rather than
+              // setting `isComposing`, so check both.
+              if (e.nativeEvent.isComposing || e.keyCode === 229) return
+              e.preventDefault()
+              handleSubmit()
+            }}
+            // Fallback for soft keyboards (notably Android Chrome / GBoard)
+            // that route the return key through `beforeinput` as an
+            // `insertLineBreak` without firing a `keydown` we can match
+            // on `key === 'Enter'`.
+            onBeforeInput={(e) => {
+              if (
+                (e.nativeEvent as InputEvent).inputType === `insertLineBreak`
+              ) {
                 e.preventDefault()
                 handleSubmit()
               }
@@ -265,6 +288,16 @@ export function MessageInput({
             type="button"
             aria-label={showStop ? `Stop generating` : `Send message`}
             title={showStop ? `Stop generating` : `Send message`}
+            // Keep the textarea focused when the user taps Send on a
+            // touch device. Without this, tapping the button blurs the
+            // textarea, dismisses the on-screen keyboard, and the
+            // viewport reflows between pointerdown and pointerup — the
+            // resulting `click` lands on a different element and the
+            // send never fires. `preventDefault` here skips the implicit
+            // focus transfer; the `click` still dispatches normally.
+            onPointerDown={(e) => {
+              if (e.pointerType !== `mouse`) e.preventDefault()
+            }}
             onClick={handleComposerAction}
             disabled={showStop ? stopPending : !isButtonActive}
             className={[


### PR DESCRIPTION
Fixes #4401.

## Problem

The agent UI composer at `/__agent_ui/` silently dropped message submissions on mobile browsers — both Send button taps and virtual-keyboard Enter were non-functional. The textarea accepted text but nothing was ever sent.

Two distinct root causes, both in `packages/agents-server-ui/src/components/MessageInput.tsx`:

**Send button.** Tapping the button blurred the textarea, the on-screen keyboard began dismissing, and the viewport reflowed between `pointerdown` and `pointerup`. The resulting `click` landed off the button and the send never fired.

**Virtual-keyboard Enter.** The `keydown` handler only matched `e.key === 'Enter'`, but Android Chrome / GBoard frequently report `key === 'Unidentified'` / `keyCode === 229` (IME-coordinated path) or route the return key through `beforeinput` as `insertLineBreak` with no matching `keydown` at all.

## Fix

- **`enterKeyHint="send"`** on the textarea so soft keyboards surface a send-shaped action key and (critically on Android Chrome) fire `keydown` with `key === 'Enter'` reliably.
- **IME guard** in the `keydown` handler — skip submit while `e.nativeEvent.isComposing` is true, and explicitly skip `e.keyCode === 229` (Android Chrome doesn't always set `isComposing`).
- **`onBeforeInput` fallback** matching `inputType === 'insertLineBreak'` for soft keyboards that route the return key through `beforeinput` without a matching `keydown`.
- **`onPointerDown` preventDefault for non-mouse pointers** on the Send button — keeps focus on the textarea so the on-screen keyboard doesn't dismiss, the viewport doesn't reflow between pointerdown and pointerup, and the resulting `click` lands on the button as intended. Mouse pointers are excluded so desktop click behaviour is unchanged.

## Tested on

- ✅ Android Chrome — Send button and virtual-keyboard Enter both submit
- ✅ iOS Chrome — same
- ✅ Desktop (Linux Chrome) — Enter and click still work; no regressions

Verified locally against the bundled UI in `electricax/agents-server:latest` with `packages/agents-server-ui/dist` volume-mounted in.

## Changeset

A patch-level `@electric-ax/agents-server-ui` changeset is included (`.changeset/agent-ui-mobile-submit.md`).
