### PR TITLE
Show "Fork from here" button on the mobile chat

### DIFF
--- a/.changeset/fork-from-here-mobile.md
+++ b/.changeset/fork-from-here-mobile.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server-ui': patch
+---
+
+Make the "Fork from here" affordance work in the mobile Expo DOM embed. Two pieces: (1) wire the fork-anchor map in `ChatLogView` (the view the mobile embed mounts) so `EntityTimeline` actually receives the per-row callbacks; (2) add a `:global(html[data-electric-mobile-dom='true']) .forkButton { opacity: 1 }` rule in `UserMessage.module.css` so the button is visible without a hover/tap (touch devices don't fire `:hover`). The fork POST and post-fork navigation already route through the existing `serverFetch` + `onRequestOpenEntity` callback, so no changes to the mobile package itself.

--- a/packages/agents-server-ui/src/components/UserMessage.module.css
+++ b/packages/agents-server-ui/src/components/UserMessage.module.css
@@ -56,6 +56,10 @@
   opacity: 1;
 }
 
+:global(html[data-electric-mobile-dom='true']) .forkButton {
+  opacity: 1;
+}
+
 .forkButton:hover {
   background: var(--ds-gray-a4);
 }

--- a/packages/agents-server-ui/src/components/views/ChatView.tsx
+++ b/packages/agents-server-ui/src/components/views/ChatView.tsx
@@ -59,8 +59,9 @@ export function ChatLogView({
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
 }): React.ReactElement {
   const connectUrl = isSpawning ? null : entityUrl
-  const { timelineRows, pendingInbox, entities, loading, error } =
+  const { timelineRows, pendingInbox, entities, db, loading, error } =
     useEntityTimeline(baseUrl || null, connectUrl)
+  const { forkEntity } = useElectricAgents()
   const navigate = useNavigate()
   const processedInboxKeys = useMemo(
     () =>
@@ -103,6 +104,34 @@ export function ChatLogView({
     }
   }, [error, navigate, isSpawning])
 
+  const forkFromHereByInboxKey = useMemo(() => {
+    if (!forkEntity || !connectUrl || !db) return undefined
+    const runOffsets = db.collections.runs.__electricRowOffsets
+    if (!runOffsets) return undefined
+    const map = new Map<string, () => void>()
+    let anchor: EventPointer | null = null
+    for (const row of visibleRows) {
+      if (row.run && row.run.status === `completed`) {
+        const pointer = runOffsets.get(row.run.key)
+        if (pointer) anchor = pointer
+      }
+      if (row.inbox && anchor) {
+        const capturedAnchor = anchor
+        map.set(row.$key, () => {
+          void forkEntity(connectUrl, { pointer: capturedAnchor })
+            .then((res) =>
+              navigate({
+                to: `/entity/$`,
+                params: { _splat: res.url.replace(/^\//, ``) },
+              })
+            )
+            .catch(() => {})
+        })
+      }
+    }
+    return map
+  }, [visibleRows, db, forkEntity, connectUrl, navigate])
+
   return (
     <EntityTimeline
       rows={visibleRows}
@@ -115,6 +144,7 @@ export function ChatLogView({
       entityUrl={connectUrl}
       entities={entities}
       scrollToBottomSignal={scrollToBottomSignal}
+      forkFromHereByInboxKey={forkFromHereByInboxKey}
     />
   )
 }


### PR DESCRIPTION
Follow-up to #4410: extends the per-message "Fork from here" affordance to the mobile chat (and any other surface that mounts agents-server-ui via an Expo "use dom" embed).

## What changes

Two source files, both in `packages/agents-server-ui`:

1. **`src/components/views/ChatView.tsx`** — `ChatLogView` (the view the mobile embed mounts under `view='chat-log'`) now computes the same `forkFromHereByInboxKey` map that `ChatView` already had on the web side. It pulls `db` from `useEntityTimeline`, `forkEntity` from `useElectricAgents`, walks `visibleRows` to find the latest preceding completed `runs` row's pointer, and threads the per-row callback to `EntityTimeline`. Without this, `UserMessage` rendered in the mobile embed never received an `onForkFromHere` prop and the button stayed off the DOM regardless of CSS.

2. **`src/components/UserMessage.module.css`** — adds a touch-targeted reveal rule scoped via `:global(html[data-electric-mobile-dom='true']) .forkButton { opacity: 1 }`. Touch devices don't fire `:hover`, and `.bubble:focus-within` only kicks in after a tap, so without the override the button stayed invisible until interaction. The reveal lives inside the CSS module (rather than a sibling stylesheet that targets the hashed class by substring) so whichever pipeline is in play — Vite for the web/desktop bundles, Metro for the Expo DOM embed — hashes `.forkButton` consistently with the JSX.

The mobile package itself doesn't change. The embed already mounts `ChatView` → `EntityTimeline` → `UserMessage`, the fork POST already routes through `serverFetch()` running in the embed's JS context, and post-fork navigation already routes through `onRequestOpenEntity` → `openSession(target)`. Once `ChatLogView` produces the callback map and CSS makes the button visible, the whole flow lights up.

## Why split from #4410

#4410 was framed as the web/desktop release. The mobile surface depends on the same wiring but ships separately so the web work can land without being held by mobile-specific UX polish. Once both merge, the affordance is uniform across web, desktop, and mobile.

## Test plan

- [ ] Build + run #4410's base. Start the mobile app with `pnpm -C packages/agents-mobile ios`.
- [ ] Open any session with at least two completed runs.
- [ ] The second user-message bubble shows the GitFork icon at full opacity, top-right corner of the bubble.
- [ ] Tap it. The app navigates to a new entity URL ending in `-fork-<hash>`; the new session contains only the first exchange.
- [ ] Send a new prompt in the fork; it runs independently.
- [ ] First user message in a chat shows no button. While Horton is streaming a reply, the triggering message shows no button. Button returns after `✓ done`.
- [ ] On desktop and web, hover-reveal still works as before (the mobile rule is scoped via the `data-electric-mobile-dom` attribute the embed sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
