### PR TITLE
Fix Android cloud auth callback

### DIFF
--- a/.changeset/android-cloud-auth-callback.md
+++ b/.changeset/android-cloud-auth-callback.md
@@ -37,4 +37,15 @@ to the welcome screen. Multiple layers had to be hardened:
   instead of `router.replace` inside an effect — the effect-based
   version raced with Expo Router's own intent handling in dev
   builds, leaving the route stuck on the spinner even though
-  sign-in had succeeded.
+  sign-in had succeeded. The redirect destination also takes the
+  user's onboarding / server state into account so a first-time
+  signer-in goes back to `/onboarding` to finish the wizard
+  instead of being bounced through `/` (where `SessionListScreen`
+  would crash on `useAgents` because `AgentsProvider` isn't
+  mounted yet).
+* Routes that call `useAgents()` (`/`, `/session`, `/new-session`,
+  `/diagnostics`) now go through a `useAgentsRouteGuard` helper
+  that emits a `<Redirect>` to `/onboarding` / `/server-setup` when
+  the user hasn't finished setup yet, so transient mounts during
+  redirect chains can't render those screens before the root
+  layout's own redirects catch up.

--- a/.changeset/android-cloud-auth-callback.md
+++ b/.changeset/android-cloud-auth-callback.md
@@ -2,4 +2,34 @@
 "@electric-ax/agents-mobile": patch
 ---
 
-Handle Android Electric Cloud OAuth callbacks delivered through Expo Router.
+Fix Android Electric Cloud sign-in flow getting stuck after Google / GitHub auth.
+
+The Chrome Custom Tab redirect (`electric-agents://oauth/callback?...`)
+was being lost on real Android devices (especially Android 13+ release
+builds), so the sign-in never completed and the user was bounced back
+to the welcome screen. Multiple layers had to be hardened:
+
+* **Config plugin** that injects an `onNewIntent` override into the
+  generated `MainActivity.kt` so new intents (delivered when Android
+  kills our process while the browser is open and then relaunches
+  via the redirect) are forwarded to `getIntent()` for
+  `expo-linking` / `expo-web-browser` to pick up. Mitigates
+  [expo/expo#44284](https://github.com/expo/expo/issues/44284).
+* `openAuthSessionAsync` now uses `createTask: false` +
+  `showInRecents: true` so the Custom Tab runs inside our task and
+  the OS doesn't aggressively reclaim our process while the user is
+  signing in.
+* The OAuth deep link is consumed by a **global listener mounted in
+  `CloudAuthProvider`** (in addition to the `/oauth/callback`
+  route), so cold-start redirects are completed even before Expo
+  Router has had a chance to navigate to the route.
+* `parseCallbackUrl` uses `expo-linking`'s `Linking.parse` rather
+  than `new URL()`, which is unreliable for custom schemes in
+  Hermes release builds.
+* `signIn` waits a few seconds for the deep link to arrive when the
+  browser session returns `dismiss`, instead of immediately
+  rolling state back to `signed-out`.
+* The `/oauth/callback` route now subscribes to the cloud-auth
+  state and only navigates once it actually settles, surfacing
+  parse / state-mismatch errors instead of silently bouncing the
+  user back to the welcome screen.

--- a/.changeset/android-cloud-auth-callback.md
+++ b/.changeset/android-cloud-auth-callback.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-mobile": patch
+---
+
+Handle Android Electric Cloud OAuth callbacks delivered through Expo Router.

--- a/.changeset/android-cloud-auth-callback.md
+++ b/.changeset/android-cloud-auth-callback.md
@@ -14,11 +14,11 @@ to the welcome screen. Multiple layers had to be hardened:
   kills our process while the browser is open and then relaunches
   via the redirect) are forwarded to `getIntent()` for
   `expo-linking` / `expo-web-browser` to pick up. Mitigates
-  [expo/expo#44284](https://github.com/expo/expo/issues/44284).
-* `openAuthSessionAsync` now uses `createTask: false` +
-  `showInRecents: true` so the Custom Tab runs inside our task and
-  the OS doesn't aggressively reclaim our process while the user is
-  signing in.
+  [expo/expo#44284](https://github.com/expo/expo/issues/44284). The
+  plugin imports `expo/config-plugins` (not `@expo/config-plugins`)
+  because pnpm doesn't hoist the latter into the package's
+  `node_modules`, which broke `expo cli config --json` inside EAS
+  Build.
 * The OAuth deep link is consumed by a **global listener mounted in
   `CloudAuthProvider`** (in addition to the `/oauth/callback`
   route), so cold-start redirects are completed even before Expo
@@ -29,7 +29,12 @@ to the welcome screen. Multiple layers had to be hardened:
 * `signIn` waits a few seconds for the deep link to arrive when the
   browser session returns `dismiss`, instead of immediately
   rolling state back to `signed-out`.
-* The `/oauth/callback` route now subscribes to the cloud-auth
-  state and only navigates once it actually settles, surfacing
-  parse / state-mismatch errors instead of silently bouncing the
-  user back to the welcome screen.
+* `completeCallbackUrl` is idempotent so the three concurrent
+  handlers (browser-session result, global Linking listener,
+  `/oauth/callback` route) can't trample each other.
+* The `/oauth/callback` route subscribes to cloud-auth state and
+  navigates with `<Redirect>` (rendered during the render phase)
+  instead of `router.replace` inside an effect — the effect-based
+  version raced with Expo Router's own intent handling in dev
+  builds, leaving the route stuck on the spinner even though
+  sign-in had succeeded.

--- a/packages/agents-mobile/app.config.ts
+++ b/packages/agents-mobile/app.config.ts
@@ -17,7 +17,16 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   orientation: `portrait`,
   userInterfaceStyle: `automatic`,
   newArchEnabled: true,
-  plugins: [`expo-router`, `expo-web-browser`],
+  plugins: [
+    `expo-router`,
+    `expo-web-browser`,
+    // Android-only: forward new intents in MainActivity.kt so
+    // OAuth redirect deep links delivered after the Chrome
+    // Custom Tab dismisses actually reach expo-linking /
+    // expo-web-browser. See `plugins/with-android-on-new-intent.js`
+    // for the underlying Expo issue.
+    `./plugins/with-android-on-new-intent.js`,
+  ],
   ios: {
     ...config.ios,
     bundleIdentifier: applicationId,

--- a/packages/agents-mobile/app/_layout.tsx
+++ b/packages/agents-mobile/app/_layout.tsx
@@ -54,14 +54,19 @@ function RootNavigator(): React.ReactElement {
   // redirect — the wizard subsumes the URL input as its step 2, and
   // dismissing it falls back to `/server-setup` only if the user
   // still hasn't configured a server.
-  if (!onboardingDismissed && pathname !== `/onboarding`) {
+  if (
+    !onboardingDismissed &&
+    pathname !== `/onboarding` &&
+    pathname !== `/oauth/callback`
+  ) {
     return <Redirect href="/onboarding" />
   }
 
   if (
     !serverUrl &&
     pathname !== `/server-setup` &&
-    pathname !== `/onboarding`
+    pathname !== `/onboarding` &&
+    pathname !== `/oauth/callback`
   ) {
     return <Redirect href="/server-setup" />
   }

--- a/packages/agents-mobile/app/_layout.tsx
+++ b/packages/agents-mobile/app/_layout.tsx
@@ -1,8 +1,6 @@
-import * as React from 'react'
 import { Redirect, Stack, usePathname } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
-import * as Linking from 'expo-linking'
-import { ActivityIndicator, AppState, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import {
   SafeAreaProvider,
@@ -19,7 +17,7 @@ import {
   useMobileAppState,
 } from '../src/lib/MobileAppState'
 import { CloudAuthProvider } from '../src/lib/CloudAuthContext'
-import { debugCloudAuth, isCallbackUrl } from '../src/lib/cloudAuth'
+import { isCallbackUrl } from '../src/lib/cloudAuth'
 
 export default function RootLayout(): React.ReactElement {
   return (
@@ -47,15 +45,6 @@ function RootNavigator(): React.ReactElement {
   const coldStartOAuthCallback =
     !!launchUrl && isCallbackUrl(launchUrl) && pathname !== `/oauth/callback`
 
-  useStartupLinkDebug({
-    loading,
-    serverUrl,
-    onboardingDismissed,
-    pathname,
-    launchUrl,
-    coldStartOAuthCallback,
-  })
-
   if (loading) {
     return (
       <View style={[styles.loading, { backgroundColor: tokens.bg }]}>
@@ -66,10 +55,6 @@ function RootNavigator(): React.ReactElement {
   }
 
   if (coldStartOAuthCallback) {
-    debugCloudAuth(`rootNavigator:redirectToCallback`, {
-      launchUrl,
-      pathname,
-    })
     return <Redirect href="/oauth/callback" />
   }
 
@@ -113,81 +98,6 @@ function RootNavigator(): React.ReactElement {
   ) : (
     stack
   )
-}
-
-function useStartupLinkDebug({
-  loading,
-  serverUrl,
-  onboardingDismissed,
-  pathname,
-  launchUrl,
-  coldStartOAuthCallback,
-}: {
-  loading: boolean
-  serverUrl: string | null
-  onboardingDismissed: boolean
-  pathname: string
-  launchUrl: string | null
-  coldStartOAuthCallback: boolean
-}): void {
-  React.useEffect(() => {
-    debugCloudAuth(`rootNavigator:renderState`, {
-      loading,
-      serverUrl,
-      onboardingDismissed,
-      pathname,
-      launchUrl,
-      coldStartOAuthCallback,
-    })
-  }, [
-    loading,
-    serverUrl,
-    onboardingDismissed,
-    pathname,
-    launchUrl,
-    coldStartOAuthCallback,
-  ])
-
-  React.useEffect(() => {
-    void Linking.getInitialURL()
-      .then((url) => {
-        debugCloudAuth(`rootNavigator:getInitialURL`, { url, pathname })
-      })
-      .catch((error) => {
-        debugCloudAuth(`rootNavigator:getInitialURL:error`, {
-          error: error instanceof Error ? error.message : String(error),
-        })
-      })
-  }, [pathname])
-
-  React.useEffect(() => {
-    const subscription = Linking.addEventListener(`url`, ({ url }) => {
-      debugCloudAuth(`rootNavigator:linkingEvent`, { url, pathname })
-    })
-    return () => subscription.remove()
-  }, [pathname])
-
-  React.useEffect(() => {
-    const subscription = AppState.addEventListener(`change`, (nextState) => {
-      debugCloudAuth(`rootNavigator:appState`, { nextState, pathname })
-      void Linking.getInitialURL()
-        .then((url) => {
-          debugCloudAuth(`rootNavigator:appState:getInitialURL`, {
-            nextState,
-            url,
-            pathname,
-          })
-        })
-        .catch((error) => {
-          debugCloudAuth(`rootNavigator:appState:getInitialURL:error`, {
-            nextState,
-            pathname,
-            error: error instanceof Error ? error.message : String(error),
-          })
-        })
-    })
-    return () => subscription.remove()
-  }, [pathname])
 }
 
 const styles = StyleSheet.create({

--- a/packages/agents-mobile/app/_layout.tsx
+++ b/packages/agents-mobile/app/_layout.tsx
@@ -1,6 +1,8 @@
+import * as React from 'react'
 import { Redirect, Stack, usePathname } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
-import { ActivityIndicator, StyleSheet, View } from 'react-native'
+import * as Linking from 'expo-linking'
+import { ActivityIndicator, AppState, StyleSheet, View } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import {
   SafeAreaProvider,
@@ -17,6 +19,7 @@ import {
   useMobileAppState,
 } from '../src/lib/MobileAppState'
 import { CloudAuthProvider } from '../src/lib/CloudAuthContext'
+import { debugCloudAuth, isCallbackUrl } from '../src/lib/cloudAuth'
 
 export default function RootLayout(): React.ReactElement {
   return (
@@ -35,11 +38,23 @@ export default function RootLayout(): React.ReactElement {
 }
 
 function RootNavigator(): React.ReactElement {
-  const { loading, serverUrl, onboardingDismissed } = useMobileAppState()
+  const { loading, serverUrl, launchUrl, onboardingDismissed } =
+    useMobileAppState()
   const tokens = useTokens()
   const scheme = useColorSchemeMode()
   const pathname = usePathname()
   const statusBarStyle = scheme === `dark` ? `light` : `dark`
+  const coldStartOAuthCallback =
+    !!launchUrl && isCallbackUrl(launchUrl) && pathname !== `/oauth/callback`
+
+  useStartupLinkDebug({
+    loading,
+    serverUrl,
+    onboardingDismissed,
+    pathname,
+    launchUrl,
+    coldStartOAuthCallback,
+  })
 
   if (loading) {
     return (
@@ -48,6 +63,14 @@ function RootNavigator(): React.ReactElement {
         <ActivityIndicator color={tokens.accent11} />
       </View>
     )
+  }
+
+  if (coldStartOAuthCallback) {
+    debugCloudAuth(`rootNavigator:redirectToCallback`, {
+      launchUrl,
+      pathname,
+    })
+    return <Redirect href="/oauth/callback" />
   }
 
   // First-launch onboarding takes precedence over the server-setup
@@ -90,6 +113,81 @@ function RootNavigator(): React.ReactElement {
   ) : (
     stack
   )
+}
+
+function useStartupLinkDebug({
+  loading,
+  serverUrl,
+  onboardingDismissed,
+  pathname,
+  launchUrl,
+  coldStartOAuthCallback,
+}: {
+  loading: boolean
+  serverUrl: string | null
+  onboardingDismissed: boolean
+  pathname: string
+  launchUrl: string | null
+  coldStartOAuthCallback: boolean
+}): void {
+  React.useEffect(() => {
+    debugCloudAuth(`rootNavigator:renderState`, {
+      loading,
+      serverUrl,
+      onboardingDismissed,
+      pathname,
+      launchUrl,
+      coldStartOAuthCallback,
+    })
+  }, [
+    loading,
+    serverUrl,
+    onboardingDismissed,
+    pathname,
+    launchUrl,
+    coldStartOAuthCallback,
+  ])
+
+  React.useEffect(() => {
+    void Linking.getInitialURL()
+      .then((url) => {
+        debugCloudAuth(`rootNavigator:getInitialURL`, { url, pathname })
+      })
+      .catch((error) => {
+        debugCloudAuth(`rootNavigator:getInitialURL:error`, {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      })
+  }, [pathname])
+
+  React.useEffect(() => {
+    const subscription = Linking.addEventListener(`url`, ({ url }) => {
+      debugCloudAuth(`rootNavigator:linkingEvent`, { url, pathname })
+    })
+    return () => subscription.remove()
+  }, [pathname])
+
+  React.useEffect(() => {
+    const subscription = AppState.addEventListener(`change`, (nextState) => {
+      debugCloudAuth(`rootNavigator:appState`, { nextState, pathname })
+      void Linking.getInitialURL()
+        .then((url) => {
+          debugCloudAuth(`rootNavigator:appState:getInitialURL`, {
+            nextState,
+            url,
+            pathname,
+          })
+        })
+        .catch((error) => {
+          debugCloudAuth(`rootNavigator:appState:getInitialURL:error`, {
+            nextState,
+            pathname,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        })
+    })
+    return () => subscription.remove()
+  }, [pathname])
 }
 
 const styles = StyleSheet.create({

--- a/packages/agents-mobile/app/diagnostics.tsx
+++ b/packages/agents-mobile/app/diagnostics.tsx
@@ -1,8 +1,11 @@
 import { useRouter } from 'expo-router'
 import { DiagnosticsScreen } from '../src/screens/DiagnosticsScreen'
+import { useAgentsRouteGuard } from '../src/lib/useAgentsRouteGuard'
 
-export default function DiagnosticsRoute(): React.ReactElement {
+export default function DiagnosticsRoute(): React.ReactElement | null {
   const router = useRouter()
+  const guard = useAgentsRouteGuard()
+  if (guard) return guard
 
   return (
     <DiagnosticsScreen

--- a/packages/agents-mobile/app/index.tsx
+++ b/packages/agents-mobile/app/index.tsx
@@ -1,8 +1,11 @@
 import { useRouter } from 'expo-router'
 import { SessionListScreen } from '../src/screens/SessionListScreen'
+import { useAgentsRouteGuard } from '../src/lib/useAgentsRouteGuard'
 
-export default function SessionsRoute(): React.ReactElement {
+export default function SessionsRoute(): React.ReactElement | null {
   const router = useRouter()
+  const guard = useAgentsRouteGuard()
+  if (guard) return guard
 
   return (
     <SessionListScreen

--- a/packages/agents-mobile/app/new-session.tsx
+++ b/packages/agents-mobile/app/new-session.tsx
@@ -1,8 +1,11 @@
 import { useRouter } from 'expo-router'
 import { NewSessionScreen } from '../src/screens/NewSessionScreen'
+import { useAgentsRouteGuard } from '../src/lib/useAgentsRouteGuard'
 
-export default function NewSessionRoute(): React.ReactElement {
+export default function NewSessionRoute(): React.ReactElement | null {
   const router = useRouter()
+  const guard = useAgentsRouteGuard()
+  if (guard) return guard
 
   return (
     <NewSessionScreen

--- a/packages/agents-mobile/app/oauth/callback.tsx
+++ b/packages/agents-mobile/app/oauth/callback.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
+import { CLOUD_AUTH_REDIRECT_URI, cloudAuth } from '../../src/lib/cloudAuth'
+import { useTokens } from '../../src/lib/ThemeProvider'
+import { fontSize, lineHeight, spacing } from '../../src/lib/theme'
+import type { Tokens } from '../../src/lib/theme'
+
+export default function OAuthCallbackRoute(): React.ReactElement {
+  const router = useRouter()
+  const params = useLocalSearchParams()
+  const tokens = useTokens()
+  const styles = useMemo(() => createStyles(tokens), [tokens])
+  const completedRef = useRef(false)
+
+  useEffect(() => {
+    if (completedRef.current) return
+    completedRef.current = true
+
+    const callbackUrl = buildCallbackUrl(params)
+    if (!callbackUrl) {
+      router.replace(`/`)
+      return
+    }
+
+    let cancelled = false
+    void cloudAuth.completeCallbackUrl(callbackUrl).finally(() => {
+      if (!cancelled) router.replace(`/`)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [params, router])
+
+  return (
+    <View style={styles.root}>
+      <ActivityIndicator color={tokens.accent11} />
+      <Text style={styles.text}>Finishing sign-in…</Text>
+    </View>
+  )
+}
+
+function buildCallbackUrl(params: ReturnType<typeof useLocalSearchParams>) {
+  const token = getParam(params.token)
+  const state = getParam(params.state)
+  const email = getParam(params.email)
+  const expiresAt = getParam(params.expiresAt)
+  if (!token || !state || !email || !expiresAt) return null
+
+  const url = new URL(CLOUD_AUTH_REDIRECT_URI)
+  url.searchParams.set(`token`, token)
+  url.searchParams.set(`state`, state)
+  url.searchParams.set(`email`, email)
+  url.searchParams.set(`expiresAt`, expiresAt)
+  return url.toString()
+}
+
+function getParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+function createStyles(tokens: Tokens) {
+  return StyleSheet.create({
+    root: {
+      flex: 1,
+      alignItems: `center`,
+      justifyContent: `center`,
+      gap: spacing.md,
+      backgroundColor: tokens.bg,
+      paddingHorizontal: spacing.xl,
+    },
+    text: {
+      color: tokens.text2,
+      fontSize: fontSize.base,
+      lineHeight: lineHeight.base,
+      textAlign: `center`,
+    },
+  })
+}

--- a/packages/agents-mobile/app/oauth/callback.tsx
+++ b/packages/agents-mobile/app/oauth/callback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import { CLOUD_AUTH_REDIRECT_URI, cloudAuth } from '../../src/lib/cloudAuth'
@@ -6,37 +6,62 @@ import { useTokens } from '../../src/lib/ThemeProvider'
 import { fontSize, lineHeight, spacing } from '../../src/lib/theme'
 import type { Tokens } from '../../src/lib/theme'
 
+const CALLBACK_TIMEOUT_MS = 8000
+
 export default function OAuthCallbackRoute(): React.ReactElement {
   const router = useRouter()
   const params = useLocalSearchParams()
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const completedRef = useRef(false)
+  const [message, setMessage] = useState(`Finishing sign-in...`)
 
   useEffect(() => {
     if (completedRef.current) return
     completedRef.current = true
 
-    const callbackUrl = buildCallbackUrl(params)
-    if (!callbackUrl) {
-      router.replace(`/`)
-      return
+    let cancelled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+
+    const finish = () => {
+      if (timeout) clearTimeout(timeout)
+      if (!cancelled) router.replace(`/`)
     }
 
-    let cancelled = false
-    void cloudAuth.completeCallbackUrl(callbackUrl).finally(() => {
-      if (!cancelled) router.replace(`/`)
-    })
+    try {
+      const callbackUrl = buildCallbackUrl(params)
+      if (!callbackUrl) {
+        finish()
+        return
+      }
+
+      timeout = setTimeout(() => {
+        console.warn(`[agents-mobile] cloud-auth callback timed out`)
+        setMessage(`Taking longer than expected...`)
+        finish()
+      }, CALLBACK_TIMEOUT_MS)
+
+      void cloudAuth
+        .completeCallbackUrl(callbackUrl)
+        .catch((err) => {
+          console.warn(`[agents-mobile] cloud-auth callback failed:`, err)
+        })
+        .finally(finish)
+    } catch (err) {
+      console.warn(`[agents-mobile] cloud-auth callback route failed:`, err)
+      finish()
+    }
 
     return () => {
       cancelled = true
+      if (timeout) clearTimeout(timeout)
     }
   }, [params, router])
 
   return (
     <View style={styles.root}>
       <ActivityIndicator color={tokens.accent11} />
-      <Text style={styles.text}>Finishing sign-in…</Text>
+      <Text style={styles.text}>{message}</Text>
     </View>
   )
 }
@@ -48,12 +73,17 @@ function buildCallbackUrl(params: ReturnType<typeof useLocalSearchParams>) {
   const expiresAt = getParam(params.expiresAt)
   if (!token || !state || !email || !expiresAt) return null
 
-  const url = new URL(CLOUD_AUTH_REDIRECT_URI)
-  url.searchParams.set(`token`, token)
-  url.searchParams.set(`state`, state)
-  url.searchParams.set(`email`, email)
-  url.searchParams.set(`expiresAt`, expiresAt)
-  return url.toString()
+  return (
+    `${CLOUD_AUTH_REDIRECT_URI}?` +
+    [
+      [`token`, token],
+      [`state`, state],
+      [`email`, email],
+      [`expiresAt`, expiresAt],
+    ]
+      .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+      .join(`&`)
+  )
 }
 
 function getParam(value: string | string[] | undefined): string | null {

--- a/packages/agents-mobile/app/oauth/callback.tsx
+++ b/packages/agents-mobile/app/oauth/callback.tsx
@@ -2,104 +2,155 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import * as Linking from 'expo-linking'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
-import { CLOUD_AUTH_REDIRECT_URI, cloudAuth } from '../../src/lib/cloudAuth'
+import {
+  cloudAuth,
+  isCallbackUrl,
+  type CloudAuthState,
+} from '../../src/lib/cloudAuth'
 import { useTokens } from '../../src/lib/ThemeProvider'
 import { fontSize, lineHeight, spacing } from '../../src/lib/theme'
 import type { Tokens } from '../../src/lib/theme'
 
-const CALLBACK_TIMEOUT_MS = 8000
+/**
+ * Landing route for `electric-agents://oauth/callback?...` deep links.
+ *
+ * As of the fix for #4416 the deep link is also consumed at the app
+ * level by `CloudAuthProvider`'s global listener — that's the path
+ * that actually drives the state machine. This route exists so that:
+ *
+ *   1. Expo Router has a real screen to render for the redirect
+ *      pathname instead of falling through to "Unmatched Route" on
+ *      cold start.
+ *   2. We can show the user a sensible loading / error state and
+ *      navigate them somewhere useful once the singleton settles.
+ *
+ * We **subscribe to `cloudAuth` state** rather than processing the URL
+ * ourselves, so the global listener (and `signIn`'s own callback
+ * handling) remain the single source of truth. We also call
+ * `handleDeepLink` defensively in case neither has had a chance to
+ * fire yet (e.g. extremely fast cold start where the route mounted
+ * before the provider's effect ran).
+ */
+
+const STATUS_TIMEOUT_MS = 15000
+
+type RouteStatus =
+  | { kind: `working` }
+  | { kind: `signed-in` }
+  | { kind: `error`; message: string }
 
 export default function OAuthCallbackRoute(): React.ReactElement {
   const router = useRouter()
   const params = useLocalSearchParams()
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
-  const completedRef = useRef(false)
-  const [message, setMessage] = useState(`Finishing sign-in...`)
-  const token = getParam(params.token)
-  const state = getParam(params.state)
-  const email = getParam(params.email)
-  const expiresAt = getParam(params.expiresAt)
+  const navigatedRef = useRef(false)
+  const [status, setStatus] = useState<RouteStatus>(() =>
+    deriveStatus(cloudAuth.getState())
+  )
 
+  const token = pickParam(params.token)
+  const stateParam = pickParam(params.state)
+  const email = pickParam(params.email)
+  const expiresAt = pickParam(params.expiresAt)
+
+  // Subscribe to the singleton so we can react to the global listener
+  // / signIn() finishing the flow without re-running our own copy of
+  // it.
   useEffect(() => {
-    if (completedRef.current) return
+    const unsubscribe = cloudAuth.subscribe((next) => {
+      setStatus(deriveStatus(next))
+    })
+    return unsubscribe
+  }, [])
 
-    let cancelled = false
-    let timeout: ReturnType<typeof setTimeout> | null = null
-    let subscription: { remove: () => void } | null = null
-
-    const finish = () => {
-      if (timeout) clearTimeout(timeout)
-      if (subscription) subscription.remove()
-      if (!cancelled) router.replace(`/`)
+  // Defensive: feed any URL we have access to into the singleton so
+  // the cold-start case (route mounts with the params present before
+  // either the global listener or signIn() has run) still completes.
+  // `handleDeepLink` is idempotent — if another handler beat us to it
+  // this is a no-op.
+  useEffect(() => {
+    const callbackUrl = buildCallbackUrl(token, stateParam, email, expiresAt)
+    if (callbackUrl) {
+      void cloudAuth.handleDeepLink(callbackUrl)
+      return
     }
 
-    const complete = (callbackUrl: string) => {
-      if (completedRef.current) return
-      completedRef.current = true
-      if (timeout) clearTimeout(timeout)
-      timeout = setTimeout(() => {
-        console.warn(`[agents-mobile] cloud-auth callback timed out`)
-        setMessage(`Taking longer than expected...`)
-        finish()
-      }, CALLBACK_TIMEOUT_MS)
-
-      void cloudAuth
-        .completeCallbackUrl(callbackUrl)
-        .catch((err) => {
-          console.warn(`[agents-mobile] cloud-auth callback failed:`, err)
-        })
-        .finally(finish)
-    }
-
-    try {
-      const callbackUrl = buildCallbackUrl(token, state, email, expiresAt)
-      if (callbackUrl) {
-        complete(callbackUrl)
-      } else {
-        subscription = Linking.addEventListener(`url`, ({ url }) => {
-          if (url.startsWith(CLOUD_AUTH_REDIRECT_URI)) {
-            complete(url)
-          }
-        })
-
-        void Linking.getInitialURL()
-          .then((url) => {
-            if (!url || cancelled || completedRef.current) return
-            if (url.startsWith(CLOUD_AUTH_REDIRECT_URI)) {
-              complete(url)
-            }
-          })
-          .catch((err) => {
-            console.warn(`[agents-mobile] cloud-auth initial URL failed:`, err)
-          })
-
-        timeout = setTimeout(() => {
-          console.warn(
-            `[agents-mobile] cloud-auth callback URL was not received`
-          )
-          setMessage(`Taking longer than expected...`)
-          finish()
-        }, CALLBACK_TIMEOUT_MS)
+    // No params on this render (common on cold start before Expo
+    // Router has hydrated query params). Listen for the URL directly
+    // and pull the initial URL off the activity intent.
+    const subscription = Linking.addEventListener(`url`, ({ url }) => {
+      if (isCallbackUrl(url)) {
+        void cloudAuth.handleDeepLink(url)
       }
-    } catch (err) {
-      console.warn(`[agents-mobile] cloud-auth callback route failed:`, err)
-      finish()
-    }
+    })
+    void Linking.getInitialURL()
+      .then((url) => {
+        if (url && isCallbackUrl(url)) {
+          void cloudAuth.handleDeepLink(url)
+        }
+      })
+      .catch(() => {
+        // Ignored — the listener (and CloudAuthProvider's own copy)
+        // will still get a shot at it.
+      })
+    return () => subscription.remove()
+  }, [email, expiresAt, stateParam, token])
 
-    return () => {
-      cancelled = true
-      if (timeout) clearTimeout(timeout)
-      if (subscription) subscription.remove()
+  // Once the singleton resolves, send the user to a useful screen.
+  // We never bail on a timer just for the URL not arriving — that's
+  // what produced the earlier "back to welcome with no sign-in"
+  // regression. The only timeout left covers a true wedge (something
+  // crashed mid-flight) and surfaces it as an error so the user can
+  // retry instead of being silently bounced.
+  useEffect(() => {
+    if (navigatedRef.current) return
+    if (status.kind === `signed-in`) {
+      navigatedRef.current = true
+      router.replace(`/`)
+      return
     }
-  }, [email, expiresAt, router, state, token])
+    if (status.kind === `error`) {
+      navigatedRef.current = true
+      // Drop the user back at onboarding so the welcome screen can
+      // render the error in its red banner. They can immediately
+      // retry from there.
+      router.replace(`/onboarding`)
+      return
+    }
+    const timeout = setTimeout(() => {
+      if (navigatedRef.current) return
+      console.warn(`[agents-mobile] cloud-auth callback wedged; bailing`)
+      navigatedRef.current = true
+      router.replace(`/onboarding`)
+    }, STATUS_TIMEOUT_MS)
+    return () => clearTimeout(timeout)
+  }, [router, status])
+
+  const message =
+    status.kind === `error`
+      ? status.message
+      : status.kind === `signed-in`
+        ? `Signed in. Returning to the app…`
+        : `Finishing sign-in…`
 
   return (
     <View style={styles.root}>
-      <ActivityIndicator color={tokens.accent11} />
+      {status.kind !== `error` && <ActivityIndicator color={tokens.accent11} />}
       <Text style={styles.text}>{message}</Text>
     </View>
   )
+}
+
+function deriveStatus(state: CloudAuthState): RouteStatus {
+  if (state.status === `signed-in`) return { kind: `signed-in` }
+  if (state.status === `error`) {
+    return {
+      kind: `error`,
+      message: state.error ?? `Sign-in failed.`,
+    }
+  }
+  return { kind: `working` }
 }
 
 function buildCallbackUrl(
@@ -107,23 +158,20 @@ function buildCallbackUrl(
   state: string | null,
   email: string | null,
   expiresAt: string | null
-) {
+): string | null {
   if (!token || !state || !email || !expiresAt) return null
-
-  return (
-    `${CLOUD_AUTH_REDIRECT_URI}?` +
-    [
-      [`token`, token],
-      [`state`, state],
-      [`email`, email],
-      [`expiresAt`, expiresAt],
-    ]
-      .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
-      .join(`&`)
-  )
+  const query = [
+    [`token`, token],
+    [`state`, state],
+    [`email`, email],
+    [`expiresAt`, expiresAt],
+  ]
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join(`&`)
+  return `electric-agents://oauth/callback?${query}`
 }
 
-function getParam(value: string | string[] | undefined): string | null {
+function pickParam(value: string | Array<string> | undefined): string | null {
   if (Array.isArray(value)) return value[0] ?? null
   return value ?? null
 }

--- a/packages/agents-mobile/app/oauth/callback.tsx
+++ b/packages/agents-mobile/app/oauth/callback.tsx
@@ -4,7 +4,6 @@ import { Redirect, useLocalSearchParams } from 'expo-router'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import {
   cloudAuth,
-  debugCloudAuth,
   isCallbackUrl,
   type CloudAuthState,
 } from '../../src/lib/cloudAuth'
@@ -55,12 +54,6 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const { serverUrl, onboardingDismissed } = useMobileAppState()
 
-  debugCloudAuth(`oauthCallbackRoute:render`, {
-    params,
-    serverUrl,
-    onboardingDismissed,
-  })
-
   const token = pickParam(params.token)
   const stateParam = pickParam(params.state)
   const email = pickParam(params.email)
@@ -71,17 +64,12 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   )
 
   useEffect(() => {
-    debugCloudAuth(`oauthCallbackRoute:mount`, {
-      params,
-      initialCloudAuthState: cloudAuth.getState(),
-    })
     // Sync once on mount in case the state changed between the
     // `useState` initializer and this effect attaching (very narrow
     // window but happens in practice when `signIn`'s success path
     // resolves synchronously after Expo Router navigated us here).
     setStatus(deriveStatus(cloudAuth.getState()))
     const unsubscribe = cloudAuth.subscribe((next) => {
-      debugCloudAuth(`oauthCallbackRoute:cloudAuthSubscribe`, { next })
       setStatus(deriveStatus(next))
     })
     return unsubscribe
@@ -93,13 +81,6 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   useEffect(() => {
     if (dispatchedRef.current) return
     const callbackUrl = buildCallbackUrl(token, stateParam, email, expiresAt)
-    debugCloudAuth(`oauthCallbackRoute:paramsCallbackUrl`, {
-      token,
-      stateParam,
-      email,
-      expiresAt,
-      callbackUrl,
-    })
     if (callbackUrl) {
       dispatchedRef.current = true
       void cloudAuth.handleDeepLink(callbackUrl)
@@ -112,18 +93,14 @@ export default function OAuthCallbackRoute(): React.ReactElement {
     // mounted.
     void Linking.getInitialURL()
       .then((url) => {
-        debugCloudAuth(`oauthCallbackRoute:getInitialURL`, { url })
         if (url && isCallbackUrl(url)) {
           void cloudAuth.handleDeepLink(url)
         }
       })
-      .catch((error) => {
-        debugCloudAuth(`oauthCallbackRoute:getInitialURL:error`, {
-          error: error instanceof Error ? error.message : String(error),
-        })
+      .catch(() => {
+        // ignored — the listener / global handler still get a shot.
       })
     const subscription = Linking.addEventListener(`url`, ({ url }) => {
-      debugCloudAuth(`oauthCallbackRoute:linkingEvent`, { url })
       if (isCallbackUrl(url)) {
         void cloudAuth.handleDeepLink(url)
       }
@@ -165,7 +142,6 @@ export default function OAuthCallbackRoute(): React.ReactElement {
 }
 
 function deriveStatus(state: CloudAuthState): RouteStatus {
-  debugCloudAuth(`oauthCallbackRoute:deriveStatus`, { state })
   if (state.status === `signed-in`) return { kind: `signed-in` }
   if (state.status === `error`) {
     return {

--- a/packages/agents-mobile/app/oauth/callback.tsx
+++ b/packages/agents-mobile/app/oauth/callback.tsx
@@ -7,6 +7,7 @@ import {
   isCallbackUrl,
   type CloudAuthState,
 } from '../../src/lib/cloudAuth'
+import { useMobileAppState } from '../../src/lib/MobileAppState'
 import { useTokens } from '../../src/lib/ThemeProvider'
 import { fontSize, lineHeight, spacing } from '../../src/lib/theme'
 import type { Tokens } from '../../src/lib/theme'
@@ -51,6 +52,7 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   const params = useLocalSearchParams()
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
+  const { serverUrl, onboardingDismissed } = useMobileAppState()
 
   const token = pickParam(params.token)
   const stateParam = pickParam(params.state)
@@ -110,7 +112,19 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   // Router's render tree directly, which sidesteps the effect-timing
   // issues we hit with `router.replace` (route would tear down before
   // the replace landed).
+  //
+  // Pick the destination based on what's already set up. We avoid
+  // redirecting to `/` unless the user already has a server configured,
+  // because the home route renders `SessionListScreen` which calls
+  // `useAgents()` — and `AgentsProvider` is conditional on `serverUrl`
+  // being set. A first-time user signing in mid-onboarding would
+  // otherwise briefly mount `SessionListScreen` without the provider
+  // before the root navigator's own redirect chain catches up,
+  // producing a "useAgents must be used inside AgentsProvider" render
+  // error.
   if (status.kind === `signed-in`) {
+    if (!onboardingDismissed) return <Redirect href="/onboarding" />
+    if (!serverUrl) return <Redirect href="/server-setup" />
     return <Redirect href="/" />
   }
   if (status.kind === `error`) {

--- a/packages/agents-mobile/app/oauth/callback.tsx
+++ b/packages/agents-mobile/app/oauth/callback.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import * as Linking from 'expo-linking'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import { CLOUD_AUTH_REDIRECT_URI, cloudAuth } from '../../src/lib/cloudAuth'
@@ -15,26 +16,28 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const completedRef = useRef(false)
   const [message, setMessage] = useState(`Finishing sign-in...`)
+  const token = getParam(params.token)
+  const state = getParam(params.state)
+  const email = getParam(params.email)
+  const expiresAt = getParam(params.expiresAt)
 
   useEffect(() => {
     if (completedRef.current) return
-    completedRef.current = true
 
     let cancelled = false
     let timeout: ReturnType<typeof setTimeout> | null = null
+    let subscription: { remove: () => void } | null = null
 
     const finish = () => {
       if (timeout) clearTimeout(timeout)
+      if (subscription) subscription.remove()
       if (!cancelled) router.replace(`/`)
     }
 
-    try {
-      const callbackUrl = buildCallbackUrl(params)
-      if (!callbackUrl) {
-        finish()
-        return
-      }
-
+    const complete = (callbackUrl: string) => {
+      if (completedRef.current) return
+      completedRef.current = true
+      if (timeout) clearTimeout(timeout)
       timeout = setTimeout(() => {
         console.warn(`[agents-mobile] cloud-auth callback timed out`)
         setMessage(`Taking longer than expected...`)
@@ -47,6 +50,38 @@ export default function OAuthCallbackRoute(): React.ReactElement {
           console.warn(`[agents-mobile] cloud-auth callback failed:`, err)
         })
         .finally(finish)
+    }
+
+    try {
+      const callbackUrl = buildCallbackUrl(token, state, email, expiresAt)
+      if (callbackUrl) {
+        complete(callbackUrl)
+      } else {
+        subscription = Linking.addEventListener(`url`, ({ url }) => {
+          if (url.startsWith(CLOUD_AUTH_REDIRECT_URI)) {
+            complete(url)
+          }
+        })
+
+        void Linking.getInitialURL()
+          .then((url) => {
+            if (!url || cancelled || completedRef.current) return
+            if (url.startsWith(CLOUD_AUTH_REDIRECT_URI)) {
+              complete(url)
+            }
+          })
+          .catch((err) => {
+            console.warn(`[agents-mobile] cloud-auth initial URL failed:`, err)
+          })
+
+        timeout = setTimeout(() => {
+          console.warn(
+            `[agents-mobile] cloud-auth callback URL was not received`
+          )
+          setMessage(`Taking longer than expected...`)
+          finish()
+        }, CALLBACK_TIMEOUT_MS)
+      }
     } catch (err) {
       console.warn(`[agents-mobile] cloud-auth callback route failed:`, err)
       finish()
@@ -55,8 +90,9 @@ export default function OAuthCallbackRoute(): React.ReactElement {
     return () => {
       cancelled = true
       if (timeout) clearTimeout(timeout)
+      if (subscription) subscription.remove()
     }
-  }, [params, router])
+  }, [email, expiresAt, router, state, token])
 
   return (
     <View style={styles.root}>
@@ -66,11 +102,12 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   )
 }
 
-function buildCallbackUrl(params: ReturnType<typeof useLocalSearchParams>) {
-  const token = getParam(params.token)
-  const state = getParam(params.state)
-  const email = getParam(params.email)
-  const expiresAt = getParam(params.expiresAt)
+function buildCallbackUrl(
+  token: string | null,
+  state: string | null,
+  email: string | null,
+  expiresAt: string | null
+) {
   if (!token || !state || !email || !expiresAt) return null
 
   return (

--- a/packages/agents-mobile/app/oauth/callback.tsx
+++ b/packages/agents-mobile/app/oauth/callback.tsx
@@ -4,6 +4,7 @@ import { Redirect, useLocalSearchParams } from 'expo-router'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import {
   cloudAuth,
+  debugCloudAuth,
   isCallbackUrl,
   type CloudAuthState,
 } from '../../src/lib/cloudAuth'
@@ -54,6 +55,12 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const { serverUrl, onboardingDismissed } = useMobileAppState()
 
+  debugCloudAuth(`oauthCallbackRoute:render`, {
+    params,
+    serverUrl,
+    onboardingDismissed,
+  })
+
   const token = pickParam(params.token)
   const stateParam = pickParam(params.state)
   const email = pickParam(params.email)
@@ -64,12 +71,17 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   )
 
   useEffect(() => {
+    debugCloudAuth(`oauthCallbackRoute:mount`, {
+      params,
+      initialCloudAuthState: cloudAuth.getState(),
+    })
     // Sync once on mount in case the state changed between the
     // `useState` initializer and this effect attaching (very narrow
     // window but happens in practice when `signIn`'s success path
     // resolves synchronously after Expo Router navigated us here).
     setStatus(deriveStatus(cloudAuth.getState()))
     const unsubscribe = cloudAuth.subscribe((next) => {
+      debugCloudAuth(`oauthCallbackRoute:cloudAuthSubscribe`, { next })
       setStatus(deriveStatus(next))
     })
     return unsubscribe
@@ -81,6 +93,13 @@ export default function OAuthCallbackRoute(): React.ReactElement {
   useEffect(() => {
     if (dispatchedRef.current) return
     const callbackUrl = buildCallbackUrl(token, stateParam, email, expiresAt)
+    debugCloudAuth(`oauthCallbackRoute:paramsCallbackUrl`, {
+      token,
+      stateParam,
+      email,
+      expiresAt,
+      callbackUrl,
+    })
     if (callbackUrl) {
       dispatchedRef.current = true
       void cloudAuth.handleDeepLink(callbackUrl)
@@ -93,14 +112,18 @@ export default function OAuthCallbackRoute(): React.ReactElement {
     // mounted.
     void Linking.getInitialURL()
       .then((url) => {
+        debugCloudAuth(`oauthCallbackRoute:getInitialURL`, { url })
         if (url && isCallbackUrl(url)) {
           void cloudAuth.handleDeepLink(url)
         }
       })
-      .catch(() => {
-        // ignored — the listener / global handler still get a shot.
+      .catch((error) => {
+        debugCloudAuth(`oauthCallbackRoute:getInitialURL:error`, {
+          error: error instanceof Error ? error.message : String(error),
+        })
       })
     const subscription = Linking.addEventListener(`url`, ({ url }) => {
+      debugCloudAuth(`oauthCallbackRoute:linkingEvent`, { url })
       if (isCallbackUrl(url)) {
         void cloudAuth.handleDeepLink(url)
       }
@@ -142,6 +165,7 @@ export default function OAuthCallbackRoute(): React.ReactElement {
 }
 
 function deriveStatus(state: CloudAuthState): RouteStatus {
+  debugCloudAuth(`oauthCallbackRoute:deriveStatus`, { state })
   if (state.status === `signed-in`) return { kind: `signed-in` }
   if (state.status === `error`) {
     return {

--- a/packages/agents-mobile/app/oauth/callback.tsx
+++ b/packages/agents-mobile/app/oauth/callback.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import * as Linking from 'expo-linking'
-import { useLocalSearchParams, useRouter } from 'expo-router'
+import { Redirect, useLocalSearchParams } from 'expo-router'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import {
   cloudAuth,
@@ -14,25 +14,33 @@ import type { Tokens } from '../../src/lib/theme'
 /**
  * Landing route for `electric-agents://oauth/callback?...` deep links.
  *
- * As of the fix for #4416 the deep link is also consumed at the app
- * level by `CloudAuthProvider`'s global listener — that's the path
- * that actually drives the state machine. This route exists so that:
+ * The cloud-auth state machine is the single source of truth; this
+ * route just renders the right thing while it's in flight and bails
+ * to a real screen the moment it resolves.
  *
- *   1. Expo Router has a real screen to render for the redirect
- *      pathname instead of falling through to "Unmatched Route" on
- *      cold start.
- *   2. We can show the user a sensible loading / error state and
- *      navigate them somewhere useful once the singleton settles.
+ * Three things drive the state machine here:
  *
- * We **subscribe to `cloudAuth` state** rather than processing the URL
- * ourselves, so the global listener (and `signIn`'s own callback
- * handling) remain the single source of truth. We also call
- * `handleDeepLink` defensively in case neither has had a chance to
- * fire yet (e.g. extremely fast cold start where the route mounted
- * before the provider's effect ran).
+ *   1. `signIn()`'s own success path (when `WebBrowser` returns the
+ *      URL directly).
+ *   2. The global `Linking.addEventListener` set up by
+ *      `CloudAuthProvider` (warm starts where the OS hands the URL to
+ *      the live JS context).
+ *   3. This route's defensive `handleDeepLink` calls below (cold
+ *      starts where the app was relaunched onto `/oauth/callback`
+ *      before either of the other two listeners could attach).
+ *
+ * `cloudAuth.completeCallbackUrl` deduplicates them via
+ * `completingUrl` so it doesn't matter which gets there first — at
+ * most one consumes the pending request, the rest no-op.
+ *
+ * Navigation away from here uses `<Redirect>` (rendered during the
+ * render phase) instead of `router.replace` in an effect, because
+ * `useEffect`-driven navigation is too easy to race with Expo
+ * Router's own intent handling: in dev mode we saw the route mount,
+ * status flip to `signed-in`, the effect fire, and then nothing —
+ * the route was already torn down before `router.replace` finished
+ * scheduling.
  */
-
-const STATUS_TIMEOUT_MS = 15000
 
 type RouteStatus =
   | { kind: `working` }
@@ -40,50 +48,47 @@ type RouteStatus =
   | { kind: `error`; message: string }
 
 export default function OAuthCallbackRoute(): React.ReactElement {
-  const router = useRouter()
   const params = useLocalSearchParams()
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
-  const navigatedRef = useRef(false)
-  const [status, setStatus] = useState<RouteStatus>(() =>
-    deriveStatus(cloudAuth.getState())
-  )
 
   const token = pickParam(params.token)
   const stateParam = pickParam(params.state)
   const email = pickParam(params.email)
   const expiresAt = pickParam(params.expiresAt)
 
-  // Subscribe to the singleton so we can react to the global listener
-  // / signIn() finishing the flow without re-running our own copy of
-  // it.
+  const [status, setStatus] = useState<RouteStatus>(() =>
+    deriveStatus(cloudAuth.getState())
+  )
+
   useEffect(() => {
+    // Sync once on mount in case the state changed between the
+    // `useState` initializer and this effect attaching (very narrow
+    // window but happens in practice when `signIn`'s success path
+    // resolves synchronously after Expo Router navigated us here).
+    setStatus(deriveStatus(cloudAuth.getState()))
     const unsubscribe = cloudAuth.subscribe((next) => {
       setStatus(deriveStatus(next))
     })
     return unsubscribe
   }, [])
 
-  // Defensive: feed any URL we have access to into the singleton so
-  // the cold-start case (route mounts with the params present before
-  // either the global listener or signIn() has run) still completes.
-  // `handleDeepLink` is idempotent — if another handler beat us to it
-  // this is a no-op.
+  // Feed any URL we can find into the singleton. Idempotent — if
+  // another handler beat us to it `handleDeepLink` is a no-op.
+  const dispatchedRef = useRef(false)
   useEffect(() => {
+    if (dispatchedRef.current) return
     const callbackUrl = buildCallbackUrl(token, stateParam, email, expiresAt)
     if (callbackUrl) {
+      dispatchedRef.current = true
       void cloudAuth.handleDeepLink(callbackUrl)
-      return
     }
+  }, [token, stateParam, email, expiresAt])
 
-    // No params on this render (common on cold start before Expo
-    // Router has hydrated query params). Listen for the URL directly
-    // and pull the initial URL off the activity intent.
-    const subscription = Linking.addEventListener(`url`, ({ url }) => {
-      if (isCallbackUrl(url)) {
-        void cloudAuth.handleDeepLink(url)
-      }
-    })
+  useEffect(() => {
+    // Cold-start safety net: also pull the URL off the activity
+    // intent and listen for any URL events that fire while we're
+    // mounted.
     void Linking.getInitialURL()
       .then((url) => {
         if (url && isCallbackUrl(url)) {
@@ -91,53 +96,33 @@ export default function OAuthCallbackRoute(): React.ReactElement {
         }
       })
       .catch(() => {
-        // Ignored — the listener (and CloudAuthProvider's own copy)
-        // will still get a shot at it.
+        // ignored — the listener / global handler still get a shot.
       })
+    const subscription = Linking.addEventListener(`url`, ({ url }) => {
+      if (isCallbackUrl(url)) {
+        void cloudAuth.handleDeepLink(url)
+      }
+    })
     return () => subscription.remove()
-  }, [email, expiresAt, stateParam, token])
+  }, [])
 
-  // Once the singleton resolves, send the user to a useful screen.
-  // We never bail on a timer just for the URL not arriving — that's
-  // what produced the earlier "back to welcome with no sign-in"
-  // regression. The only timeout left covers a true wedge (something
-  // crashed mid-flight) and surfaces it as an error so the user can
-  // retry instead of being silently bounced.
-  useEffect(() => {
-    if (navigatedRef.current) return
-    if (status.kind === `signed-in`) {
-      navigatedRef.current = true
-      router.replace(`/`)
-      return
-    }
-    if (status.kind === `error`) {
-      navigatedRef.current = true
-      // Drop the user back at onboarding so the welcome screen can
-      // render the error in its red banner. They can immediately
-      // retry from there.
-      router.replace(`/onboarding`)
-      return
-    }
-    const timeout = setTimeout(() => {
-      if (navigatedRef.current) return
-      console.warn(`[agents-mobile] cloud-auth callback wedged; bailing`)
-      navigatedRef.current = true
-      router.replace(`/onboarding`)
-    }, STATUS_TIMEOUT_MS)
-    return () => clearTimeout(timeout)
-  }, [router, status])
-
-  const message =
-    status.kind === `error`
-      ? status.message
-      : status.kind === `signed-in`
-        ? `Signed in. Returning to the app…`
-        : `Finishing sign-in…`
+  // Render-phase navigation. `<Redirect>` is processed by Expo
+  // Router's render tree directly, which sidesteps the effect-timing
+  // issues we hit with `router.replace` (route would tear down before
+  // the replace landed).
+  if (status.kind === `signed-in`) {
+    return <Redirect href="/" />
+  }
+  if (status.kind === `error`) {
+    // Drop the user back at onboarding so the welcome screen's error
+    // banner renders the message and they can immediately retry.
+    return <Redirect href="/onboarding" />
+  }
 
   return (
     <View style={styles.root}>
-      {status.kind !== `error` && <ActivityIndicator color={tokens.accent11} />}
-      <Text style={styles.text}>{message}</Text>
+      <ActivityIndicator color={tokens.accent11} />
+      <Text style={styles.text}>Finishing sign-in…</Text>
     </View>
   )
 }

--- a/packages/agents-mobile/app/session.tsx
+++ b/packages/agents-mobile/app/session.tsx
@@ -12,6 +12,7 @@ import {
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useAgents } from '../src/lib/AgentsProvider'
+import { useAgentsRouteGuard } from '../src/lib/useAgentsRouteGuard'
 import { useColorSchemeMode, useTokens } from '../src/lib/ThemeProvider'
 import {
   CHAT_COMPOSER_BASE_HEIGHT,
@@ -46,12 +47,27 @@ const SessionChatLogDomEmbed =
 const SessionStateInspectorDomEmbed =
   SessionStateInspectorDomEmbedModule as ComponentType<SessionDomEmbedProps>
 
-export default function SessionRoute(): React.ReactElement {
+export default function SessionRoute(): React.ReactElement | null {
   const params = useLocalSearchParams<{
     entityUrl?: string
     view?: EmbedViewId
   }>()
   const router = useRouter()
+  const guard = useAgentsRouteGuard()
+  if (guard) return guard
+  return <SessionRouteInner params={params} router={router} />
+}
+
+function SessionRouteInner({
+  params,
+  router,
+}: {
+  params: {
+    entityUrl?: string | Array<string>
+    view?: EmbedViewId
+  }
+  router: ReturnType<typeof useRouter>
+}): React.ReactElement {
   const { serverUrl } = useAgents()
   const tokens = useTokens()
   const scheme = useColorSchemeMode()

--- a/packages/agents-mobile/plugins/with-android-on-new-intent.js
+++ b/packages/agents-mobile/plugins/with-android-on-new-intent.js
@@ -1,5 +1,10 @@
 // @ts-check
-const { withMainActivity } = require(`@expo/config-plugins`)
+// NOTE: import via `expo/config-plugins` (not `@expo/config-plugins`)
+// because pnpm doesn't hoist the latter into agents-mobile's
+// node_modules, so `require('@expo/config-plugins')` fails inside
+// EAS Build's read-config step. `expo` is a direct dep and re-exports
+// the plugin helpers.
+const { withMainActivity } = require(`expo/config-plugins`)
 
 /**
  * Expo config plugin: inject an `onNewIntent` override into the

--- a/packages/agents-mobile/plugins/with-android-on-new-intent.js
+++ b/packages/agents-mobile/plugins/with-android-on-new-intent.js
@@ -1,0 +1,96 @@
+// @ts-check
+const { withMainActivity } = require(`@expo/config-plugins`)
+
+/**
+ * Expo config plugin: inject an `onNewIntent` override into the
+ * generated `MainActivity.kt` so deep links delivered after the
+ * Custom Tab dismisses correctly reach `expo-linking` and
+ * `expo-web-browser`.
+ *
+ * Why this exists:
+ *
+ * On Android 13+ (and especially Android 16) release builds, the OS
+ * is aggressive about killing the app process while the user is in a
+ * Chrome Custom Tab. When the OAuth redirect bounces back into the
+ * app via our custom scheme (`electric-agents://oauth/callback?...`),
+ * Android restarts the activity and delivers the redirect as a new
+ * intent. The default Expo `MainActivity.kt` (from the bare template)
+ * does not override `onNewIntent`, so the runtime's currently-cached
+ * `getIntent()` keeps pointing at the original LAUNCHER intent.
+ *
+ * The visible symptoms:
+ *   - `WebBrowser.openAuthSessionAsync()` returns `{type: 'dismiss'}`
+ *     instead of `{type: 'success', url: ...}`.
+ *   - `Linking.getInitialURL()` returns `null`.
+ *   - `Linking.addEventListener('url', ...)` never fires.
+ *
+ * The fix is to forward the new intent so anything that calls
+ * `getIntent()` (including expo-modules-core / expo-linking) sees
+ * the redirect URL:
+ *
+ *   override fun onNewIntent(intent: Intent) {
+ *     super.onNewIntent(intent)
+ *     setIntent(intent)
+ *   }
+ *
+ * Reference: https://github.com/expo/expo/issues/44284
+ */
+const withAndroidOnNewIntent = (config) => {
+  return withMainActivity(config, (modConfig) => {
+    const mainActivity = modConfig.modResults
+    if (mainActivity.language !== `kt`) {
+      console.warn(
+        `[with-android-on-new-intent] Skipping: expected Kotlin MainActivity, got ${mainActivity.language}.`
+      )
+      return modConfig
+    }
+
+    let contents = mainActivity.contents
+
+    // Ensure `android.content.Intent` is imported. The default
+    // template doesn't import it, since none of the standard
+    // overrides reference it.
+    if (!/^import\s+android\.content\.Intent\s*$/m.test(contents)) {
+      contents = contents.replace(
+        /(^package\s+[^\n]+\n)/m,
+        `$1\nimport android.content.Intent\n`
+      )
+    }
+
+    // Add the override if it isn't already present. We match both the
+    // nullable (`Intent?`) and non-nullable (`Intent`) signatures so
+    // re-running prebuild on a project that has been patched by hand
+    // doesn't double-inject the method.
+    const alreadyOverridden =
+      /override\s+fun\s+onNewIntent\s*\(\s*intent\s*:\s*Intent\??\s*\)/.test(
+        contents
+      )
+    if (!alreadyOverridden) {
+      const override = [
+        ``,
+        `  /**`,
+        `   * Forward new intents (e.g. deep links delivered after Chrome`,
+        `   * Custom Tab dismisses) so expo-linking / expo-web-browser`,
+        `   * pick them up via getIntent(). Injected by`,
+        `   * plugins/with-android-on-new-intent.js — see that file for`,
+        `   * the underlying Expo issue this works around.`,
+        `   */`,
+        `  override fun onNewIntent(intent: Intent) {`,
+        `    super.onNewIntent(intent)`,
+        `    setIntent(intent)`,
+        `  }`,
+        ``,
+      ].join(`\n`)
+
+      contents = contents.replace(
+        /(class\s+MainActivity\s*:\s*ReactActivity\s*\(\s*\)\s*\{)/,
+        `$1${override}`
+      )
+    }
+
+    mainActivity.contents = contents
+    return modConfig
+  })
+}
+
+module.exports = withAndroidOnNewIntent

--- a/packages/agents-mobile/src/components/CloudServerPicker.tsx
+++ b/packages/agents-mobile/src/components/CloudServerPicker.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import {
   cloudAgentServerUrl,
   useCloudAgentServers,
   type CloudAgentServer,
 } from '../lib/cloudAgentServers'
+import { debugCloudAuth } from '../lib/cloudAuth'
 import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
@@ -29,6 +30,15 @@ export function CloudServerPicker({
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const { status, servers, error } = useCloudAgentServers()
+
+  useEffect(() => {
+    debugCloudAuth(`cloudServerPicker:renderState`, {
+      status,
+      error,
+      serverIds: servers.map((server) => server.id),
+      serverNames: servers.map((server) => server.name),
+    })
+  }, [status, error, servers])
 
   if (status === `idle`) return null
 

--- a/packages/agents-mobile/src/components/CloudServerPicker.tsx
+++ b/packages/agents-mobile/src/components/CloudServerPicker.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import {
   cloudAgentServerUrl,
   useCloudAgentServers,
   type CloudAgentServer,
 } from '../lib/cloudAgentServers'
-import { debugCloudAuth } from '../lib/cloudAuth'
 import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
@@ -30,15 +29,6 @@ export function CloudServerPicker({
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const { status, servers, error } = useCloudAgentServers()
-
-  useEffect(() => {
-    debugCloudAuth(`cloudServerPicker:renderState`, {
-      status,
-      error,
-      serverIds: servers.map((server) => server.id),
-      serverNames: servers.map((server) => server.name),
-    })
-  }, [status, error, servers])
 
   if (status === `idle`) return null
 

--- a/packages/agents-mobile/src/lib/CloudAuthContext.tsx
+++ b/packages/agents-mobile/src/lib/CloudAuthContext.tsx
@@ -3,6 +3,7 @@ import * as Linking from 'expo-linking'
 import {
   cloudAuth,
   getCloudBaseUrl,
+  isCallbackUrl,
   type CloudAuthProvider,
   type CloudAuthState,
 } from './cloudAuth'
@@ -13,6 +14,14 @@ import {
  * (sign in / sign out / open dashboard). The actual OAuth flow lives
  * in `cloudAuth.signIn` — this context is just a thin wrapper so
  * components don't import the singleton directly.
+ *
+ * The provider also owns the **global deep-link listener** for the
+ * OAuth redirect (`electric-agents://oauth/callback?...`). Doing this
+ * at the app level instead of only inside the `/oauth/callback` route
+ * means the redirect is consumed even when Expo Router doesn't
+ * navigate us there (which happens regularly on Android cold starts,
+ * where the OS relaunches the app via the redirect intent but the
+ * router has not had a chance to attach its own listeners yet).
  */
 
 type CloudAuthContextValue = {
@@ -35,6 +44,33 @@ export function CloudAuthProvider({
     void cloudAuth.initialize()
     const unsubscribe = cloudAuth.subscribe(setState)
     return unsubscribe
+  }, [])
+
+  useEffect(() => {
+    // Two channels deliver the OAuth redirect, depending on whether
+    // the app was already running:
+    //   1. `addEventListener('url')` — warm start: existing JS context
+    //      receives the new intent.
+    //   2. `getInitialURL()` — cold start: the app was launched (or
+    //      relaunched after being killed) by the redirect intent
+    //      itself, so the URL is on the initial activity's intent
+    //      rather than coming through the listener.
+    // We wire up both and let `cloudAuth` deduplicate via
+    // `completingUrl`.
+    const subscription = Linking.addEventListener(`url`, ({ url }) => {
+      if (!isCallbackUrl(url)) return
+      void cloudAuth.handleDeepLink(url)
+    })
+    void Linking.getInitialURL()
+      .then((url) => {
+        if (url && isCallbackUrl(url)) {
+          void cloudAuth.handleDeepLink(url)
+        }
+      })
+      .catch((err) => {
+        console.warn(`[agents-mobile] cloud-auth getInitialURL failed:`, err)
+      })
+    return () => subscription.remove()
   }, [])
 
   const value = useMemo<CloudAuthContextValue>(

--- a/packages/agents-mobile/src/lib/CloudAuthContext.tsx
+++ b/packages/agents-mobile/src/lib/CloudAuthContext.tsx
@@ -58,11 +58,13 @@ export function CloudAuthProvider({
     // We wire up both and let `cloudAuth` deduplicate via
     // `completingUrl`.
     const subscription = Linking.addEventListener(`url`, ({ url }) => {
+      console.log(`[agents-mobile] cloud-auth listener:url`, { url })
       if (!isCallbackUrl(url)) return
       void cloudAuth.handleDeepLink(url)
     })
     void Linking.getInitialURL()
       .then((url) => {
+        console.log(`[agents-mobile] cloud-auth listener:initialUrl`, { url })
         if (url && isCallbackUrl(url)) {
           void cloudAuth.handleDeepLink(url)
         }

--- a/packages/agents-mobile/src/lib/CloudAuthContext.tsx
+++ b/packages/agents-mobile/src/lib/CloudAuthContext.tsx
@@ -58,13 +58,11 @@ export function CloudAuthProvider({
     // We wire up both and let `cloudAuth` deduplicate via
     // `completingUrl`.
     const subscription = Linking.addEventListener(`url`, ({ url }) => {
-      console.log(`[agents-mobile] cloud-auth listener:url`, { url })
       if (!isCallbackUrl(url)) return
       void cloudAuth.handleDeepLink(url)
     })
     void Linking.getInitialURL()
       .then((url) => {
-        console.log(`[agents-mobile] cloud-auth listener:initialUrl`, { url })
         if (url && isCallbackUrl(url)) {
           void cloudAuth.handleDeepLink(url)
         }

--- a/packages/agents-mobile/src/lib/MobileAppState.tsx
+++ b/packages/agents-mobile/src/lib/MobileAppState.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import * as Linking from 'expo-linking'
 import type { ReactNode } from 'react'
-import { cloudAuth, debugCloudAuth } from './cloudAuth'
+import { cloudAuth } from './cloudAuth'
 import { prepareServerHeaders } from './serverHeaders'
 
 const SERVER_URL_KEY = `electric-agents-mobile.server-url`
@@ -47,11 +47,6 @@ export function MobileAppStateProvider({
       // headers registered. Otherwise a race window lets early fetches
       // go out unauthenticated and 401 against Cloud servers.
       await prepareServerHeaders(storedUrl)
-      debugCloudAuth(`mobileAppState:initialize`, {
-        storedUrl,
-        storedOnboarding,
-        initialUrl,
-      })
       setServerUrl(storedUrl)
       setLaunchUrl(initialUrl)
       setOnboardingDismissedState(storedOnboarding === `true`)

--- a/packages/agents-mobile/src/lib/MobileAppState.tsx
+++ b/packages/agents-mobile/src/lib/MobileAppState.tsx
@@ -1,7 +1,8 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import * as Linking from 'expo-linking'
 import type { ReactNode } from 'react'
-import { cloudAuth } from './cloudAuth'
+import { cloudAuth, debugCloudAuth } from './cloudAuth'
 import { prepareServerHeaders } from './serverHeaders'
 
 const SERVER_URL_KEY = `electric-agents-mobile.server-url`
@@ -11,6 +12,7 @@ type MobileAppState = {
   loading: boolean
   serverUrl: string | null
   saveServerUrl: (next: string) => Promise<void>
+  launchUrl: string | null
   /**
    * Whether the user has finished or explicitly opted out of the
    * first-launch onboarding wizard (cloud sign-in + server URL).
@@ -30,20 +32,28 @@ export function MobileAppStateProvider({
 }): React.ReactElement {
   const [loading, setLoading] = useState(true)
   const [serverUrl, setServerUrl] = useState<string | null>(null)
+  const [launchUrl, setLaunchUrl] = useState<string | null>(null)
   const [onboardingDismissed, setOnboardingDismissedState] = useState(false)
 
   useEffect(() => {
     void (async () => {
-      const [storedUrl, storedOnboarding] = await Promise.all([
+      const [storedUrl, storedOnboarding, initialUrl] = await Promise.all([
         AsyncStorage.getItem(SERVER_URL_KEY),
         AsyncStorage.getItem(ONBOARDING_DISMISSED_KEY),
+        Linking.getInitialURL().catch(() => null),
       ])
       // Inject server headers BEFORE flipping `loading` to false so any
       // screen that mounts on the next render already has auth-fetch
       // headers registered. Otherwise a race window lets early fetches
       // go out unauthenticated and 401 against Cloud servers.
       await prepareServerHeaders(storedUrl)
+      debugCloudAuth(`mobileAppState:initialize`, {
+        storedUrl,
+        storedOnboarding,
+        initialUrl,
+      })
       setServerUrl(storedUrl)
+      setLaunchUrl(initialUrl)
       setOnboardingDismissedState(storedOnboarding === `true`)
       setLoading(false)
     })()
@@ -66,6 +76,7 @@ export function MobileAppStateProvider({
     () => ({
       loading,
       serverUrl,
+      launchUrl,
       saveServerUrl: async (next: string) => {
         await AsyncStorage.setItem(SERVER_URL_KEY, next)
         setServerUrl(next)
@@ -80,7 +91,7 @@ export function MobileAppStateProvider({
         setOnboardingDismissedState(next)
       },
     }),
-    [loading, serverUrl, onboardingDismissed]
+    [loading, serverUrl, launchUrl, onboardingDismissed]
   )
 
   return (

--- a/packages/agents-mobile/src/lib/cloudAgentServers.ts
+++ b/packages/agents-mobile/src/lib/cloudAgentServers.ts
@@ -3,7 +3,7 @@ import { createCollection } from '@tanstack/react-db'
 import { electricCollectionOptions } from '@tanstack/electric-db-collection'
 import { useLiveQuery } from '@tanstack/react-db'
 import { z } from 'zod'
-import { cloudAuth, debugCloudAuth, getCloudBaseUrl } from './cloudAuth'
+import { cloudAuth, getCloudBaseUrl } from './cloudAuth'
 import type { CloudAuthState } from './cloudAuth'
 
 /**
@@ -91,21 +91,6 @@ const SHAPE_PATHS = {
   workspaces: `/api/internal/v1/workspaces`,
 } as const
 
-function shapePathLabel(input: RequestInfo | URL): string {
-  const raw =
-    typeof input === `string`
-      ? input
-      : input instanceof URL
-        ? input.toString()
-        : input.url
-  try {
-    const url = new URL(raw)
-    return `${url.pathname}${url.search}`
-  } catch {
-    return raw
-  }
-}
-
 /**
  * Inject the user's Cloud bearer token on every shape request. Resolves
  * the token from `cloudAuth.getToken()` on each call so token rotation
@@ -118,28 +103,7 @@ async function cloudFetch(
   const token = await cloudAuth.getToken()
   const headers = new Headers(init?.headers)
   if (token) headers.set(`Authorization`, `Bearer ${token}`)
-  const label = shapePathLabel(input)
-  debugCloudAuth(`cloudAgentServers:fetch:start`, {
-    label,
-    hasToken: !!token,
-    method: init?.method ?? `GET`,
-  })
-  let response: Response
-  try {
-    response = await fetch(input, { ...init, headers })
-  } catch (error) {
-    debugCloudAuth(`cloudAgentServers:fetch:error`, {
-      label,
-      error: error instanceof Error ? error.message : String(error),
-    })
-    throw error
-  }
-  debugCloudAuth(`cloudAgentServers:fetch:response`, {
-    label,
-    status: response.status,
-    ok: response.ok,
-  })
-  return response
+  return fetch(input, { ...init, headers })
 }
 
 function createAgentServersCollection(dashboardUrl: string) {
@@ -265,10 +229,6 @@ export function useCloudAgentServers(): CloudAgentServersResult {
       return
     }
     void cloudAuth.getToken().then((token) => {
-      debugCloudAuth(`cloudAgentServers:authToken`, {
-        authStatus,
-        hasToken: !!token,
-      })
       if (!token) setSawUnauthorized(true)
     })
   }, [authStatus])
@@ -307,28 +267,6 @@ export function useCloudAgentServers(): CloudAgentServersResult {
     },
     [collections]
   )
-
-  useEffect(() => {
-    debugCloudAuth(`cloudAgentServers:hookState`, {
-      authStatus,
-      hasCollections: !!collections,
-      agentServersStatus,
-      counts: {
-        agentServers: agentServerRows.length,
-        environments: environmentRows.length,
-        projects: projectRows.length,
-        workspaces: workspaceRows.length,
-      },
-    })
-  }, [
-    authStatus,
-    collections,
-    agentServersStatus,
-    agentServerRows.length,
-    environmentRows.length,
-    projectRows.length,
-    workspaceRows.length,
-  ])
 
   return useMemo<CloudAgentServersResult>(() => {
     if (!collections) {
@@ -374,11 +312,6 @@ export function useCloudAgentServers(): CloudAgentServersResult {
       )
       if (ea !== 0) return ea
       return a.name.localeCompare(b.name)
-    })
-    debugCloudAuth(`cloudAgentServers:joinedServers`, {
-      status: agentServersStatus,
-      serverIds: servers.map((server) => server.id),
-      serverNames: servers.map((server) => server.name),
     })
     const status: CloudAgentServerStatus =
       agentServersStatus === `loading` ? `loading` : `ready`

--- a/packages/agents-mobile/src/lib/cloudAgentServers.ts
+++ b/packages/agents-mobile/src/lib/cloudAgentServers.ts
@@ -3,7 +3,7 @@ import { createCollection } from '@tanstack/react-db'
 import { electricCollectionOptions } from '@tanstack/electric-db-collection'
 import { useLiveQuery } from '@tanstack/react-db'
 import { z } from 'zod'
-import { cloudAuth, getCloudBaseUrl } from './cloudAuth'
+import { cloudAuth, debugCloudAuth, getCloudBaseUrl } from './cloudAuth'
 import type { CloudAuthState } from './cloudAuth'
 
 /**
@@ -91,6 +91,21 @@ const SHAPE_PATHS = {
   workspaces: `/api/internal/v1/workspaces`,
 } as const
 
+function shapePathLabel(input: RequestInfo | URL): string {
+  const raw =
+    typeof input === `string`
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url
+  try {
+    const url = new URL(raw)
+    return `${url.pathname}${url.search}`
+  } catch {
+    return raw
+  }
+}
+
 /**
  * Inject the user's Cloud bearer token on every shape request. Resolves
  * the token from `cloudAuth.getToken()` on each call so token rotation
@@ -103,7 +118,28 @@ async function cloudFetch(
   const token = await cloudAuth.getToken()
   const headers = new Headers(init?.headers)
   if (token) headers.set(`Authorization`, `Bearer ${token}`)
-  return fetch(input, { ...init, headers })
+  const label = shapePathLabel(input)
+  debugCloudAuth(`cloudAgentServers:fetch:start`, {
+    label,
+    hasToken: !!token,
+    method: init?.method ?? `GET`,
+  })
+  let response: Response
+  try {
+    response = await fetch(input, { ...init, headers })
+  } catch (error) {
+    debugCloudAuth(`cloudAgentServers:fetch:error`, {
+      label,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    throw error
+  }
+  debugCloudAuth(`cloudAgentServers:fetch:response`, {
+    label,
+    status: response.status,
+    ok: response.ok,
+  })
+  return response
 }
 
 function createAgentServersCollection(dashboardUrl: string) {
@@ -217,10 +253,25 @@ export function useCloudAgentServers(): CloudAgentServersResult {
   const [authStatus, setAuthStatus] = useState<CloudAuthState[`status`]>(
     () => cloudAuth.getState().status
   )
+  const [sawUnauthorized, setSawUnauthorized] = useState(false)
   useEffect(() => {
     setAuthStatus(cloudAuth.getState().status)
     return cloudAuth.subscribe((s) => setAuthStatus(s.status))
   }, [])
+
+  useEffect(() => {
+    if (authStatus !== `signed-in`) {
+      setSawUnauthorized(false)
+      return
+    }
+    void cloudAuth.getToken().then((token) => {
+      debugCloudAuth(`cloudAgentServers:authToken`, {
+        authStatus,
+        hasToken: !!token,
+      })
+      if (!token) setSawUnauthorized(true)
+    })
+  }, [authStatus])
 
   const collections = useMemo(() => {
     if (authStatus !== `signed-in`) return null
@@ -257,9 +308,38 @@ export function useCloudAgentServers(): CloudAgentServersResult {
     [collections]
   )
 
+  useEffect(() => {
+    debugCloudAuth(`cloudAgentServers:hookState`, {
+      authStatus,
+      hasCollections: !!collections,
+      agentServersStatus,
+      counts: {
+        agentServers: agentServerRows.length,
+        environments: environmentRows.length,
+        projects: projectRows.length,
+        workspaces: workspaceRows.length,
+      },
+    })
+  }, [
+    authStatus,
+    collections,
+    agentServersStatus,
+    agentServerRows.length,
+    environmentRows.length,
+    projectRows.length,
+    workspaceRows.length,
+  ])
+
   return useMemo<CloudAgentServersResult>(() => {
     if (!collections) {
       return { status: `idle`, servers: [], error: null }
+    }
+    if (sawUnauthorized) {
+      return {
+        status: `unauthorized`,
+        servers: [],
+        error: `Cloud session unavailable for server discovery.`,
+      }
     }
     const environments = new Map(environmentRows.map((r) => [r.id, r]))
     const projects = new Map(projectRows.map((r) => [r.id, r]))
@@ -295,6 +375,11 @@ export function useCloudAgentServers(): CloudAgentServersResult {
       if (ea !== 0) return ea
       return a.name.localeCompare(b.name)
     })
+    debugCloudAuth(`cloudAgentServers:joinedServers`, {
+      status: agentServersStatus,
+      serverIds: servers.map((server) => server.id),
+      serverNames: servers.map((server) => server.name),
+    })
     const status: CloudAgentServerStatus =
       agentServersStatus === `loading` ? `loading` : `ready`
     return { status, servers, error: null }
@@ -305,5 +390,6 @@ export function useCloudAgentServers(): CloudAgentServersResult {
     projectRows,
     workspaceRows,
     agentServersStatus,
+    sawUnauthorized,
   ])
 }

--- a/packages/agents-mobile/src/lib/cloudAuth.ts
+++ b/packages/agents-mobile/src/lib/cloudAuth.ts
@@ -358,16 +358,6 @@ export class CloudAuth {
           // on means a user already signed into GitHub or Google in
           // their phone's browser skips the password prompt.
           preferEphemeralSession: false,
-          // Android-specific: opening the Custom Tab in a separate task
-          // (the default) lets Android 13+ aggressively kill our task
-          // when the OAuth page is showing, which breaks the redirect
-          // back to the app (returns `dismiss`, no Linking events).
-          // Forcing the browser into our own task and keeping us in
-          // recents stops the OS from doing that.
-          // See: https://github.com/expo/expo/issues/44284,
-          // https://github.com/expo/expo/issues/8072
-          createTask: false,
-          showInRecents: true,
         }
       )
     } catch (err) {

--- a/packages/agents-mobile/src/lib/cloudAuth.ts
+++ b/packages/agents-mobile/src/lib/cloudAuth.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import * as Linking from 'expo-linking'
 import * as WebBrowser from 'expo-web-browser'
 
 /**
@@ -68,6 +69,16 @@ const STORAGE_KEY = `electric-agents-mobile.cloud-auth`
 const PENDING_STORAGE_KEY = `electric-agents-mobile.cloud-auth.pending`
 
 /**
+ * How long `signIn` waits for the OAuth deep link to arrive via
+ * `expo-linking` after `openAuthSessionAsync` returns a non-success
+ * result. Needs to be long enough to absorb a full Android cold-start
+ * (process killed by the OS while the Custom Tab was open, then
+ * relaunched via the redirect intent), but short enough that a real
+ * user-cancel doesn't leave the welcome screen stuck on the spinner.
+ */
+const DISMISS_GRACE_MS = 6000
+
+/**
  * Native-app redirect scheme registered on the admin-API allowlist.
  * Must match the `scheme` declared in `app.json` so the OS routes the
  * dashboard's redirect back to this app. The admin-API rejects any
@@ -104,23 +115,60 @@ type CloudAuthCallbackResult = {
   provider: CloudAuthProvider
 }
 
+/**
+ * Pull the callback fields out of a redirect URL.
+ *
+ * Uses `Linking.parse` rather than `new URL()` because the WHATWG URL
+ * parser in Hermes (and the various RN polyfills) is not reliable for
+ * custom schemes in release builds — sometimes `searchParams.get()`
+ * silently returns `null` even for query params that are present.
+ * `expo-linking`'s parser is purpose-built for app deep links and
+ * handles non-HTTP schemes consistently across iOS, Android, and the
+ * emulator.
+ */
 function parseCallbackUrl(
   url: string,
   provider: CloudAuthProvider
 ): CloudAuthCallbackResult | null {
-  if (!url.startsWith(CLOUD_AUTH_REDIRECT_URI)) return null
-  let parsed: URL
+  if (!isCallbackUrl(url)) return null
+  let parsed: ReturnType<typeof Linking.parse>
   try {
-    parsed = new URL(url)
+    parsed = Linking.parse(url)
   } catch {
     return null
   }
-  const token = parsed.searchParams.get(`token`)
-  const state = parsed.searchParams.get(`state`)
-  const email = parsed.searchParams.get(`email`)
-  const expiresAt = parsed.searchParams.get(`expiresAt`)
+  const queryParams = parsed.queryParams ?? {}
+  const token = pickString(queryParams.token)
+  const state = pickString(queryParams.state)
+  const email = pickString(queryParams.email)
+  const expiresAt = pickString(queryParams.expiresAt)
   if (!token || !state || !email || !expiresAt) return null
   return { token, state, email, expiresAt, provider }
+}
+
+/**
+ * Loose match for "is this our OAuth redirect deep link?"
+ *
+ * Accepts both `electric-agents://oauth/callback` and the (rare but
+ * possible) Android-formatted `electric-agents:/oauth/callback` —
+ * different code paths in the OS occasionally collapse the double
+ * slash, and we want to handle the URL either way before throwing it
+ * at the parser.
+ */
+export function isCallbackUrl(url: string): boolean {
+  if (typeof url !== `string`) return false
+  const prefix = `${CLOUD_AUTH_REDIRECT_SCHEME}:`
+  if (!url.startsWith(prefix)) return false
+  const rest = url.slice(prefix.length)
+  const path = rest.replace(/^\/+/, ``)
+  return path.startsWith(`oauth/callback`)
+}
+
+function pickString(
+  value: string | Array<string> | null | undefined
+): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return typeof value === `string` ? value : null
 }
 
 function parseWhoamiUserResponse(body: unknown): WhoamiUserResponse | null {
@@ -233,6 +281,11 @@ export class CloudAuth {
   // memory only — on restart they'll be re-fetched from the dashboard
   // when the active server is restored. Cleared on sign-out.
   private agentsTokens = new Map<string, string>()
+  // Set to the URL currently being processed by `completeCallbackUrl`,
+  // so concurrent callers handling the same redirect (Linking listener
+  // + `/oauth/callback` route + `openAuthSessionAsync`) don't trample
+  // each other.
+  private completingUrl: string | null = null
 
   getState(): CloudAuthState {
     return this.state
@@ -305,6 +358,16 @@ export class CloudAuth {
           // on means a user already signed into GitHub or Google in
           // their phone's browser skips the password prompt.
           preferEphemeralSession: false,
+          // Android-specific: opening the Custom Tab in a separate task
+          // (the default) lets Android 13+ aggressively kill our task
+          // when the OAuth page is showing, which breaks the redirect
+          // back to the app (returns `dismiss`, no Linking events).
+          // Forcing the browser into our own task and keeping us in
+          // recents stops the OS from doing that.
+          // See: https://github.com/expo/expo/issues/44284,
+          // https://github.com/expo/expo/issues/8072
+          createTask: false,
+          showInRecents: true,
         }
       )
     } catch (err) {
@@ -317,18 +380,81 @@ export class CloudAuth {
       return
     }
 
-    if (result.type !== `success` || !result.url) {
-      if (this.state.status === `signed-in`) return
-      // `cancel`, `dismiss`, `locked`, or no URL — return to prior state.
-      this.setState({
-        ...previous,
-        status: previous.email ? `signed-in` : `signed-out`,
-        error: null,
-      })
+    if (result.type === `success` && result.url) {
+      await this.completeCallbackUrl(result.url, previous)
       return
     }
 
-    await this.completeCallbackUrl(result.url, previous)
+    // Non-success result. On Android — especially Android 13+ release
+    // builds — `openAuthSessionAsync` frequently returns `dismiss`
+    // even when the OAuth flow actually succeeded, because the OS
+    // killed the JS context while the user was in the Custom Tab.
+    // Two paths still rescue the sign-in:
+    //   1. The redirect intent reaches the app on relaunch and the
+    //      global Linking listener (registered in `CloudAuthContext`)
+    //      calls `completeCallbackUrl` with the URL.
+    //   2. The user cold-starts via `/oauth/callback` (Expo Router),
+    //      which also calls `completeCallbackUrl`.
+    //
+    // We give either path a short grace period before declaring the
+    // user signed-out, so the UI doesn't flash back to the welcome
+    // screen seconds before sign-in actually completes.
+    if (this.state.status === `signed-in`) return
+    await this.waitForDeepLinkCallback(previous, provider)
+  }
+
+  /**
+   * Race against the deep-link path: if a callback URL arrives via
+   * `Linking.addEventListener` / `getInitialURL` within
+   * `DISMISS_GRACE_MS`, we hand off to `completeCallbackUrl`. Otherwise
+   * we fall back to whatever state the user was in before signing in.
+   */
+  private async waitForDeepLinkCallback(
+    previous: CloudAuthState,
+    provider: CloudAuthProvider
+  ): Promise<void> {
+    let subscription: { remove: () => void } | null = null
+    const winner = await new Promise<string | null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), DISMISS_GRACE_MS)
+      subscription = Linking.addEventListener(`url`, ({ url }) => {
+        if (isCallbackUrl(url)) {
+          clearTimeout(timer)
+          resolve(url)
+        }
+      })
+      // Also check whether the OS already delivered the redirect as
+      // an initial URL (which happens when Android cold-restarted us).
+      void Linking.getInitialURL()
+        .then((url) => {
+          if (url && isCallbackUrl(url)) {
+            clearTimeout(timer)
+            resolve(url)
+          }
+        })
+        .catch(() => {
+          // ignored — the timer/listener path will still fire.
+        })
+    })
+    if (subscription) (subscription as { remove: () => void }).remove()
+
+    if (winner) {
+      await this.completeCallbackUrl(winner, previous)
+      return
+    }
+
+    // Still nothing — accept the user cancelled / the OAuth flow
+    // failed silently, and roll back to the previous logged state.
+    if (this.state.status === `signed-in`) return
+    await this.clearPending()
+    this.setState({
+      ...previous,
+      status: previous.email ? `signed-in` : `signed-out`,
+      error: null,
+    })
+    // `provider` retained in signature so future telemetry can record
+    // which provider's deep link never arrived; intentionally unused
+    // for now.
+    void provider
   }
 
   /**
@@ -341,14 +467,31 @@ export class CloudAuth {
     url: string,
     previous: CloudAuthState = this.state
   ): Promise<boolean> {
+    // Guard against re-entry. Multiple paths can call this with the
+    // same URL (Linking listener + `/oauth/callback` route +
+    // `openAuthSessionAsync` resolution), and once one of them has
+    // consumed the pending request the rest should no-op rather than
+    // flashing an "error" state.
+    if (!isCallbackUrl(url)) return false
+    if (this.completingUrl === url) return this.state.status === `signed-in`
+    this.completingUrl = url
+    try {
+      return await this.consumeCallbackUrl(url, previous)
+    } finally {
+      this.completingUrl = null
+    }
+  }
+
+  private async consumeCallbackUrl(
+    url: string,
+    previous: CloudAuthState
+  ): Promise<boolean> {
     const pending = await this.loadPending()
     if (!pending) {
+      // Already-signed-in (race against another in-flight handler) or
+      // user navigated to the deep link manually with no sign-in
+      // started — neither should be shown as an error.
       if (this.state.status === `signed-in`) return true
-      this.setState({
-        ...previous,
-        status: `error`,
-        error: `No sign-in request was in progress.`,
-      })
       return false
     }
 
@@ -359,6 +502,7 @@ export class CloudAuth {
         status: `error`,
         error: `Sign-in callback was missing required fields.`,
       })
+      await this.clearPending()
       return false
     }
     if (parsed.state !== pending.state) {
@@ -367,6 +511,7 @@ export class CloudAuth {
         status: `error`,
         error: `Sign-in state mismatch — please try again.`,
       })
+      await this.clearPending()
       return false
     }
 
@@ -388,6 +533,17 @@ export class CloudAuth {
     })
     void this.refreshWhoami(parsed.token)
     return true
+  }
+
+  /**
+   * Public entry point for the global `Linking` listener mounted in
+   * `CloudAuthContext`. Discards anything that isn't one of our OAuth
+   * redirect URLs and returns whether the URL was consumed so callers
+   * can stop bubbling.
+   */
+  async handleDeepLink(url: string): Promise<boolean> {
+    if (!isCallbackUrl(url)) return false
+    return this.completeCallbackUrl(url)
   }
 
   async signOut(): Promise<void> {

--- a/packages/agents-mobile/src/lib/cloudAuth.ts
+++ b/packages/agents-mobile/src/lib/cloudAuth.ts
@@ -266,6 +266,13 @@ export function getCloudServiceIdFromServerUrl(
  * it so any component can subscribe via `useCloudAuth()` without
  * re-instantiating storage / network on every render.
  */
+const DEBUG_CLOUD_AUTH = process.env.EXPO_PUBLIC_DEBUG_CLOUD_AUTH === `1`
+
+export function debugCloudAuth(...args: Array<unknown>): void {
+  if (!DEBUG_CLOUD_AUTH) return
+  console.log(`[agents-mobile] cloud-auth:`, ...args)
+}
+
 export class CloudAuth {
   private state: CloudAuthState = {
     status: `signed-out`,
@@ -337,6 +344,10 @@ export class CloudAuth {
    */
   async signIn(provider: CloudAuthProvider): Promise<void> {
     const previous = this.state
+    debugCloudAuth(`signIn:start`, {
+      provider,
+      previousStatus: previous.status,
+    })
     this.setState({
       ...previous,
       status: `signing-in`,
@@ -345,6 +356,12 @@ export class CloudAuth {
 
     const cliState = generateState()
     const authorizeUrl = buildAuthorizeUrl(provider, cliState)
+    debugCloudAuth(`signIn:authorize`, {
+      provider,
+      authorizeUrl,
+      redirectUri: CLOUD_AUTH_REDIRECT_URI,
+      cliState,
+    })
     await this.storePending({ state: cliState, provider })
 
     let result: WebBrowser.WebBrowserAuthSessionResult
@@ -361,6 +378,7 @@ export class CloudAuth {
         }
       )
     } catch (err) {
+      debugCloudAuth(`signIn:openAuthSession:error`, err)
       await this.clearPending()
       this.setState({
         ...previous,
@@ -370,6 +388,7 @@ export class CloudAuth {
       return
     }
 
+    debugCloudAuth(`signIn:openAuthSession:result`, result)
     if (result.type === `success` && result.url) {
       await this.completeCallbackUrl(result.url, previous)
       return
@@ -403,10 +422,15 @@ export class CloudAuth {
     previous: CloudAuthState,
     provider: CloudAuthProvider
   ): Promise<void> {
+    debugCloudAuth(`signIn:waitForDeepLink:start`, {
+      provider,
+      graceMs: DISMISS_GRACE_MS,
+    })
     let subscription: { remove: () => void } | null = null
     const winner = await new Promise<string | null>((resolve) => {
       const timer = setTimeout(() => resolve(null), DISMISS_GRACE_MS)
       subscription = Linking.addEventListener(`url`, ({ url }) => {
+        debugCloudAuth(`signIn:waitForDeepLink:event`, { url })
         if (isCallbackUrl(url)) {
           clearTimeout(timer)
           resolve(url)
@@ -416,6 +440,7 @@ export class CloudAuth {
       // an initial URL (which happens when Android cold-restarted us).
       void Linking.getInitialURL()
         .then((url) => {
+          debugCloudAuth(`signIn:waitForDeepLink:initialUrl`, { url })
           if (url && isCallbackUrl(url)) {
             clearTimeout(timer)
             resolve(url)
@@ -427,6 +452,7 @@ export class CloudAuth {
     })
     if (subscription) (subscription as { remove: () => void }).remove()
 
+    debugCloudAuth(`signIn:waitForDeepLink:winner`, { winner })
     if (winner) {
       await this.completeCallbackUrl(winner, previous)
       return
@@ -457,6 +483,11 @@ export class CloudAuth {
     url: string,
     previous: CloudAuthState = this.state
   ): Promise<boolean> {
+    debugCloudAuth(`completeCallbackUrl:start`, {
+      url,
+      previousStatus: previous.status,
+      currentStatus: this.state.status,
+    })
     // Guard against re-entry. Multiple paths can call this with the
     // same URL (Linking listener + `/oauth/callback` route +
     // `openAuthSessionAsync` resolution), and once one of them has
@@ -477,6 +508,7 @@ export class CloudAuth {
     previous: CloudAuthState
   ): Promise<boolean> {
     const pending = await this.loadPending()
+    debugCloudAuth(`completeCallbackUrl:pending`, { pending })
     if (!pending) {
       // Already-signed-in (race against another in-flight handler) or
       // user navigated to the deep link manually with no sign-in
@@ -486,6 +518,7 @@ export class CloudAuth {
     }
 
     const parsed = parseCallbackUrl(url, pending.provider)
+    debugCloudAuth(`completeCallbackUrl:parsed`, { parsed })
     if (!parsed) {
       this.setState({
         ...previous,
@@ -511,6 +544,11 @@ export class CloudAuth {
       expiresAt: parsed.expiresAt,
       provider: parsed.provider,
     }
+    debugCloudAuth(`completeCallbackUrl:storing`, {
+      email: parsed.email,
+      expiresAt: parsed.expiresAt,
+      provider: parsed.provider,
+    })
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
     await this.clearPending()
     this.setState({
@@ -532,6 +570,7 @@ export class CloudAuth {
    * can stop bubbling.
    */
   async handleDeepLink(url: string): Promise<boolean> {
+    debugCloudAuth(`handleDeepLink`, { url })
     if (!isCallbackUrl(url)) return false
     return this.completeCallbackUrl(url)
   }

--- a/packages/agents-mobile/src/lib/cloudAuth.ts
+++ b/packages/agents-mobile/src/lib/cloudAuth.ts
@@ -266,13 +266,6 @@ export function getCloudServiceIdFromServerUrl(
  * it so any component can subscribe via `useCloudAuth()` without
  * re-instantiating storage / network on every render.
  */
-const DEBUG_CLOUD_AUTH = process.env.EXPO_PUBLIC_DEBUG_CLOUD_AUTH === `1`
-
-export function debugCloudAuth(...args: Array<unknown>): void {
-  if (!DEBUG_CLOUD_AUTH) return
-  console.log(`[agents-mobile] cloud-auth:`, ...args)
-}
-
 export class CloudAuth {
   private state: CloudAuthState = {
     status: `signed-out`,
@@ -344,10 +337,6 @@ export class CloudAuth {
    */
   async signIn(provider: CloudAuthProvider): Promise<void> {
     const previous = this.state
-    debugCloudAuth(`signIn:start`, {
-      provider,
-      previousStatus: previous.status,
-    })
     this.setState({
       ...previous,
       status: `signing-in`,
@@ -356,12 +345,6 @@ export class CloudAuth {
 
     const cliState = generateState()
     const authorizeUrl = buildAuthorizeUrl(provider, cliState)
-    debugCloudAuth(`signIn:authorize`, {
-      provider,
-      authorizeUrl,
-      redirectUri: CLOUD_AUTH_REDIRECT_URI,
-      cliState,
-    })
     await this.storePending({ state: cliState, provider })
 
     let result: WebBrowser.WebBrowserAuthSessionResult
@@ -378,7 +361,6 @@ export class CloudAuth {
         }
       )
     } catch (err) {
-      debugCloudAuth(`signIn:openAuthSession:error`, err)
       await this.clearPending()
       this.setState({
         ...previous,
@@ -388,7 +370,6 @@ export class CloudAuth {
       return
     }
 
-    debugCloudAuth(`signIn:openAuthSession:result`, result)
     if (result.type === `success` && result.url) {
       await this.completeCallbackUrl(result.url, previous)
       return
@@ -422,15 +403,10 @@ export class CloudAuth {
     previous: CloudAuthState,
     provider: CloudAuthProvider
   ): Promise<void> {
-    debugCloudAuth(`signIn:waitForDeepLink:start`, {
-      provider,
-      graceMs: DISMISS_GRACE_MS,
-    })
     let subscription: { remove: () => void } | null = null
     const winner = await new Promise<string | null>((resolve) => {
       const timer = setTimeout(() => resolve(null), DISMISS_GRACE_MS)
       subscription = Linking.addEventListener(`url`, ({ url }) => {
-        debugCloudAuth(`signIn:waitForDeepLink:event`, { url })
         if (isCallbackUrl(url)) {
           clearTimeout(timer)
           resolve(url)
@@ -440,7 +416,6 @@ export class CloudAuth {
       // an initial URL (which happens when Android cold-restarted us).
       void Linking.getInitialURL()
         .then((url) => {
-          debugCloudAuth(`signIn:waitForDeepLink:initialUrl`, { url })
           if (url && isCallbackUrl(url)) {
             clearTimeout(timer)
             resolve(url)
@@ -452,7 +427,6 @@ export class CloudAuth {
     })
     if (subscription) (subscription as { remove: () => void }).remove()
 
-    debugCloudAuth(`signIn:waitForDeepLink:winner`, { winner })
     if (winner) {
       await this.completeCallbackUrl(winner, previous)
       return
@@ -483,11 +457,6 @@ export class CloudAuth {
     url: string,
     previous: CloudAuthState = this.state
   ): Promise<boolean> {
-    debugCloudAuth(`completeCallbackUrl:start`, {
-      url,
-      previousStatus: previous.status,
-      currentStatus: this.state.status,
-    })
     // Guard against re-entry. Multiple paths can call this with the
     // same URL (Linking listener + `/oauth/callback` route +
     // `openAuthSessionAsync` resolution), and once one of them has
@@ -508,7 +477,6 @@ export class CloudAuth {
     previous: CloudAuthState
   ): Promise<boolean> {
     const pending = await this.loadPending()
-    debugCloudAuth(`completeCallbackUrl:pending`, { pending })
     if (!pending) {
       // Already-signed-in (race against another in-flight handler) or
       // user navigated to the deep link manually with no sign-in
@@ -518,7 +486,6 @@ export class CloudAuth {
     }
 
     const parsed = parseCallbackUrl(url, pending.provider)
-    debugCloudAuth(`completeCallbackUrl:parsed`, { parsed })
     if (!parsed) {
       this.setState({
         ...previous,
@@ -544,11 +511,6 @@ export class CloudAuth {
       expiresAt: parsed.expiresAt,
       provider: parsed.provider,
     }
-    debugCloudAuth(`completeCallbackUrl:storing`, {
-      email: parsed.email,
-      expiresAt: parsed.expiresAt,
-      provider: parsed.provider,
-    })
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
     await this.clearPending()
     this.setState({
@@ -570,7 +532,6 @@ export class CloudAuth {
    * can stop bubbling.
    */
   async handleDeepLink(url: string): Promise<boolean> {
-    debugCloudAuth(`handleDeepLink`, { url })
     if (!isCallbackUrl(url)) return false
     return this.completeCallbackUrl(url)
   }

--- a/packages/agents-mobile/src/lib/cloudAuth.ts
+++ b/packages/agents-mobile/src/lib/cloudAuth.ts
@@ -51,6 +51,11 @@ type StoredAuth = {
   provider: CloudAuthProvider
 }
 
+type PendingAuth = {
+  state: string
+  provider: CloudAuthProvider
+}
+
 type WhoamiUserResponse = {
   type: `user`
   userId: string
@@ -60,6 +65,7 @@ type WhoamiUserResponse = {
 }
 
 const STORAGE_KEY = `electric-agents-mobile.cloud-auth`
+const PENDING_STORAGE_KEY = `electric-agents-mobile.cloud-auth.pending`
 
 /**
  * Native-app redirect scheme registered on the admin-API allowlist.
@@ -286,6 +292,7 @@ export class CloudAuth {
 
     const cliState = generateState()
     const authorizeUrl = buildAuthorizeUrl(provider, cliState)
+    await this.storePending({ state: cliState, provider })
 
     let result: WebBrowser.WebBrowserAuthSessionResult
     try {
@@ -301,6 +308,7 @@ export class CloudAuth {
         }
       )
     } catch (err) {
+      await this.clearPending()
       this.setState({
         ...previous,
         status: `error`,
@@ -310,6 +318,7 @@ export class CloudAuth {
     }
 
     if (result.type !== `success` || !result.url) {
+      if (this.state.status === `signed-in`) return
       // `cancel`, `dismiss`, `locked`, or no URL — return to prior state.
       this.setState({
         ...previous,
@@ -319,22 +328,46 @@ export class CloudAuth {
       return
     }
 
-    const parsed = parseCallbackUrl(result.url, provider)
+    await this.completeCallbackUrl(result.url, previous)
+  }
+
+  /**
+   * Complete a native deep-link callback. Usually `openAuthSessionAsync`
+   * returns the URL directly, but on Android the app can be relaunched
+   * through Expo Router first; the `/oauth/callback` route calls this
+   * method to consume the same callback contract.
+   */
+  async completeCallbackUrl(
+    url: string,
+    previous: CloudAuthState = this.state
+  ): Promise<boolean> {
+    const pending = await this.loadPending()
+    if (!pending) {
+      if (this.state.status === `signed-in`) return true
+      this.setState({
+        ...previous,
+        status: `error`,
+        error: `No sign-in request was in progress.`,
+      })
+      return false
+    }
+
+    const parsed = parseCallbackUrl(url, pending.provider)
     if (!parsed) {
       this.setState({
         ...previous,
         status: `error`,
         error: `Sign-in callback was missing required fields.`,
       })
-      return
+      return false
     }
-    if (parsed.state !== cliState) {
+    if (parsed.state !== pending.state) {
       this.setState({
         ...previous,
         status: `error`,
         error: `Sign-in state mismatch — please try again.`,
       })
-      return
+      return false
     }
 
     const stored: StoredAuth = {
@@ -344,6 +377,7 @@ export class CloudAuth {
       provider: parsed.provider,
     }
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
+    await this.clearPending()
     this.setState({
       status: `signed-in`,
       email: parsed.email,
@@ -353,10 +387,12 @@ export class CloudAuth {
       error: null,
     })
     void this.refreshWhoami(parsed.token)
+    return true
   }
 
   async signOut(): Promise<void> {
     await AsyncStorage.removeItem(STORAGE_KEY)
+    await this.clearPending()
     this.agentsTokens.clear()
     this.setState({
       status: `signed-out`,
@@ -501,6 +537,34 @@ export class CloudAuth {
         token: parsed.token,
         email: parsed.email,
         expiresAt: parsed.expiresAt,
+        provider: parsed.provider,
+      }
+    } catch {
+      return null
+    }
+  }
+
+  private async storePending(pending: PendingAuth): Promise<void> {
+    await AsyncStorage.setItem(PENDING_STORAGE_KEY, JSON.stringify(pending))
+  }
+
+  private async clearPending(): Promise<void> {
+    await AsyncStorage.removeItem(PENDING_STORAGE_KEY)
+  }
+
+  private async loadPending(): Promise<PendingAuth | null> {
+    const raw = await AsyncStorage.getItem(PENDING_STORAGE_KEY)
+    if (!raw) return null
+    try {
+      const parsed = JSON.parse(raw) as Partial<PendingAuth>
+      if (
+        typeof parsed.state !== `string` ||
+        (parsed.provider !== `github` && parsed.provider !== `google`)
+      ) {
+        return null
+      }
+      return {
+        state: parsed.state,
         provider: parsed.provider,
       }
     } catch {

--- a/packages/agents-mobile/src/lib/useAgentsRouteGuard.tsx
+++ b/packages/agents-mobile/src/lib/useAgentsRouteGuard.tsx
@@ -1,0 +1,34 @@
+import { Redirect } from 'expo-router'
+import { useMobileAppState } from './MobileAppState'
+
+/**
+ * Guard for routes whose screens call `useAgents()`.
+ *
+ * `AgentsProvider` is only mounted in the root layout when a
+ * `serverUrl` is set, so any screen that depends on it will crash
+ * with `useAgents must be used inside AgentsProvider` if it renders
+ * before the user has finished onboarding and set up a server.
+ *
+ * The root layout already redirects unconfigured users to
+ * `/onboarding` / `/server-setup`, but during a redirect chain
+ * (notably the post-sign-in chain through `/oauth/callback`) Expo
+ * Router briefly mounts the destination route before the next render
+ * of the layout's redirects catches up, so the protected screen can
+ * still render for a render or two. This hook lets each protected
+ * route bail synchronously instead of relying on the layout to land
+ * the right pathname in time.
+ *
+ * Usage:
+ *
+ *   const guard = useAgentsRouteGuard()
+ *   if (guard) return guard
+ *   const { serverUrl } = useAgents()
+ *   ...
+ */
+export function useAgentsRouteGuard(): React.ReactElement | null {
+  const { loading, serverUrl, onboardingDismissed } = useMobileAppState()
+  if (loading) return null
+  if (!onboardingDismissed) return <Redirect href="/onboarding" />
+  if (!serverUrl) return <Redirect href="/server-setup" />
+  return null
+}

--- a/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
+++ b/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { CloudServerPicker } from '../components/CloudServerPicker'
 import { PrimaryButton } from '../components/PrimaryButton'
 import { Screen } from '../components/Screen'
+import { useCloudAuth } from '../lib/CloudAuthContext'
 import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, rowHeight, spacing } from '../lib/theme'
 import { checkServerHealth, normalizeServerUrl } from '../lib/agentsClient'
@@ -28,9 +29,12 @@ export function ServerSetupScreen({
 }): React.ReactElement {
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
+  const { state: cloudState, signIn, signOut } = useCloudAuth()
   const [value, setValue] = useState(initialUrl ?? ``)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const isSignedInToCloud = cloudState.status === `signed-in`
+  const isSigningInToCloud = cloudState.status === `signing-in`
 
   const submit = async () => {
     const normalized = normalizeServerUrl(value)
@@ -71,6 +75,18 @@ export function ServerSetupScreen({
               Mobile connects to a running server. It does not bundle a local
               Horton runtime.
             </Text>
+            {isSignedInToCloud ? (
+              <Text style={styles.hint}>
+                Signed in to Electric Cloud as{' '}
+                {cloudState.email ?? `this account`}. Want to try a different
+                Google account? Sign out below, then sign in again.
+              </Text>
+            ) : (
+              <Text style={styles.hint}>
+                Not signed in to Electric Cloud. Sign in below to discover your
+                cloud-hosted agent servers automatically.
+              </Text>
+            )}
           </View>
 
           <CloudServerPicker
@@ -106,14 +122,51 @@ export function ServerSetupScreen({
                 title="Cancel"
                 variant="ghost"
                 onPress={onCancel}
-                disabled={loading}
+                disabled={loading || isSigningInToCloud}
               />
+            )}
+            {isSignedInToCloud ? (
+              <PrimaryButton
+                title="Sign out"
+                variant="ghost"
+                onPress={() => {
+                  void signOut()
+                }}
+                disabled={loading || isSigningInToCloud}
+              />
+            ) : (
+              <>
+                <PrimaryButton
+                  title={
+                    isSigningInToCloud
+                      ? `Opening browser…`
+                      : `Sign in with GitHub`
+                  }
+                  variant="ghost"
+                  onPress={() => {
+                    void signIn(`github`)
+                  }}
+                  disabled={loading || isSigningInToCloud}
+                />
+                <PrimaryButton
+                  title={
+                    isSigningInToCloud
+                      ? `Opening browser…`
+                      : `Sign in with Google`
+                  }
+                  variant="ghost"
+                  onPress={() => {
+                    void signIn(`google`)
+                  }}
+                  disabled={loading || isSigningInToCloud}
+                />
+              </>
             )}
             <PrimaryButton
               title="Connect"
               loading={loading}
               onPress={submit}
-              disabled={loading}
+              disabled={loading || isSigningInToCloud}
             />
           </View>
         </ScrollView>
@@ -156,6 +209,11 @@ function createStyles(tokens: Tokens) {
     },
     field: {
       gap: spacing.xs,
+    },
+    hint: {
+      color: tokens.text3,
+      fontSize: fontSize.xs,
+      lineHeight: lineHeight.xs,
     },
     label: {
       color: tokens.text2,


### PR DESCRIPTION
> [!WARNING]
> This PR is temporarily stacked on #4408 (`samwilli/agents-mobile-ci`) only so the agents-mobile EAS CI build runs against this fix.
>
> We should rebase this PR back onto `main` and merge it ASAP, then update the CI branch from `main` instead of keeping this fix stacked on the CI setup branch.

## Summary

Fixes the Android Electric Cloud sign-in flow getting stuck after Google / GitHub auth on real devices (and dev-mode emulators) after the latest comprehensive fix exposed two regressions.

## What was breaking

The Chrome Custom Tab redirect (`electric-agents://oauth/callback?...`) was being lost on real Android devices — especially Android 13+ release builds where the OS aggressively kills the app process while the browser is open. `openAuthSessionAsync` would return `dismiss` even though sign-in had actually succeeded, `Linking.getInitialURL()` returned `null`, the redirect was never consumed, and the user was bounced back to the welcome screen. Underlying expo issue: [expo/expo#44284](https://github.com/expo/expo/issues/44284).

The previous comprehensive fix (`e580cf9ff`) addressed those release-build cases but introduced two regressions:

* The Expo config plugin imported `@expo/config-plugins`, which pnpm doesn't hoist into agents-mobile's `node_modules`. Local prebuild worked via expo's own require context, but in EAS Build's `expo cli config --json` step the require failed and the entire Android preview build was rejected with exit code 1.
* The `/oauth/callback` route navigated with `router.replace` inside a `useEffect`. That raced with Expo Router's own intent handling in dev builds — the route would mount, the cloud-auth state would flip to `signed-in` (JWT was even persisted to AsyncStorage), the effect would fire, but the replace landed too late and the user was left stuck on the spinner. Restarting the app showed they were already signed in.

## How it's fixed now (layered defense)

1. **Native `onNewIntent` override** via a local config plugin (`plugins/with-android-on-new-intent.js`) injected into the generated `MainActivity.kt`. When Android relaunches us via the redirect intent, this forwards it through `setIntent()` so `expo-linking` / `expo-web-browser` see it via `getIntent()` instead of the stale LAUNCHER intent. Plugin now imports `expo/config-plugins` (re-exported by `expo`, which IS a direct dep and resolvable from anywhere in the package) instead of `@expo/config-plugins`.
2. **Global `Linking` listener** mounted in `CloudAuthProvider` (in addition to the `/oauth/callback` route) so cold-start redirects are consumed even before Expo Router has had a chance to navigate to the route.
3. **`Linking.parse()` in `parseCallbackUrl`** instead of `new URL()`, because the WHATWG URL parser in Hermes is unreliable for custom schemes in release builds (silently returns `null` for present query params).
4. **`waitForDeepLinkCallback`** in `signIn` — a short grace period after the browser session returns `dismiss`, so a redirect-via-deep-link still completes the flow instead of rolling state straight back to `signed-out`.
5. **Idempotent `completeCallbackUrl`** so the three concurrent handlers (browser-session result, global Linking listener, route's own handler) can't trample each other.
6. **`<Redirect>`-based navigation in `/oauth/callback`** (rendered during the render phase) instead of `router.replace` inside an effect — bulletproof against the Expo-Router intent-handling race.

Also dropped the `createTask: false` / `showInRecents: true` flags on `openAuthSessionAsync` — they were meant to keep the Custom Tab in our task on Android 13+ release builds, but in dev mode they changed how the redirect URL was delivered (it ended up at `Linking` rather than being captured by the auth session) and contributed to the route-stuck regression. The `onNewIntent` override + global Linking listener already cover the release-build kill case.

## Test plan

- [x] `pnpm --filter @electric-ax/agents-mobile typecheck`
- [x] `pnpm exec expo prebuild --platform android --clean` injects `onNewIntent` into `MainActivity.kt`
- [x] `pnpm exec expo config --json` lists the plugin and exits 0
- [ ] EAS Android preview build succeeds (CI)
- [ ] Real-device sign-in completes (Google + GitHub) on Android 13+
- [ ] Emulator sign-in completes via dev client