### PR TITLE
fix(agents-server): guard wake sync control messages

### DIFF
--- a/.changeset/bright-cars-wink.md
+++ b/.changeset/bright-cars-wink.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server': patch
+---
+
+Guard wake registry sync bootstrap against malformed shape messages without headers.

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -229,7 +229,7 @@ export class WakeRegistry {
               await this.applyShapeMessage(message)
               if (
                 !settled &&
-                `control` in message.headers &&
+                isControlMessage(message) &&
                 message.headers.control === `up-to-date`
               ) {
                 settled = true

--- a/packages/agents-server/test/wake-registry-sync.test.ts
+++ b/packages/agents-server/test/wake-registry-sync.test.ts
@@ -65,6 +65,29 @@ function createMockDb(): any {
 }
 
 describe(`WakeRegistry Electric sync`, () => {
+  it(`ignores malformed shape messages without headers while waiting for up-to-date`, async () => {
+    const registry = new WakeRegistry(createMockDb())
+
+    const startPromise = registry.startSync(`http://electric.test`)
+
+    await expect(
+      shapeStreamState.latest!.emit([
+        {
+          key: `ignored-malformed-message`,
+        },
+        {
+          headers: {
+            control: `up-to-date`,
+          },
+        },
+      ])
+    ).resolves.toBeUndefined()
+
+    await expect(startPromise).resolves.toBeUndefined()
+
+    await registry.stopSync()
+  })
+
   it(`hydrates and updates the cache from shape changes`, async () => {
     const registry = new WakeRegistry(createMockDb())
 


### PR DESCRIPTION
## Summary
- guard the wake-registry sync bootstrap path with `isControlMessage(message)`
- add a regression test for malformed shape messages without `headers`
- prevent `startSync()` from crashing before the `up-to-date` control message arrives

## Problem
When Horton spawned a worker against a cloud-connected server, the wake registry could crash while processing shape messages with:

```
TypeError: Cannot use 'in' operator to search for 'control' in undefined
```

The crash came from checking:

```ts
'control' in message.headers
```

in the `startSync()` subscription loop, where `message.headers` was not guaranteed to exist.

## Fix
Use the existing safe helper:

```ts
isControlMessage(message)
```

before reading `message.headers.control`.

## Testing
- added a failing regression test that emits a malformed shape message with no `headers`, followed by an `up-to-date` control message
- verified the targeted test passes:

```sh
pnpm vitest run test/wake-registry-sync.test.ts
```

## Notes
I also attempted a broader wake-registry-related test run in the worktree, but it hit unrelated workspace/test-environment issues, so this PR only claims the targeted regression coverage above.
