### PR TITLE
Refine desktop agents onboarding and settings

### DIFF
--- a/.changeset/clean-ravens-smile.md
+++ b/.changeset/clean-ravens-smile.md
@@ -1,0 +1,6 @@
+---
+"@electric-ax/agents-desktop": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Refine desktop agents onboarding and settings server management.

--- a/packages/agents-desktop/src/cloud-auth.ts
+++ b/packages/agents-desktop/src/cloud-auth.ts
@@ -261,6 +261,14 @@ export class CloudAuth {
     void shell.openExternal(getCloudBaseUrl())
   }
 
+  openCreateAgentsServer(): void {
+    const url = new URL(`/`, getCloudBaseUrl())
+    url.searchParams.set(`intent`, `create`)
+    url.searchParams.set(`serviceType`, `streams`)
+    url.searchParams.set(`variant`, `agent-streams`)
+    void shell.openExternal(url.toString())
+  }
+
   /**
    * Open the OAuth flow for `provider` in a new BrowserWindow. Resolves
    * when the user completes (or cancels) the flow.

--- a/packages/agents-desktop/src/main.ts
+++ b/packages/agents-desktop/src/main.ts
@@ -38,6 +38,9 @@ import type { Dispatcher } from 'undici'
 
 type ServerSource = `manual` | `local-discovery` | `electric-cloud`
 type ServerDesiredState = `connected` | `disconnected`
+type ConnectServerOptions = {
+  localRuntimeEnabled?: boolean
+}
 
 type ServerConfig = {
   id: string
@@ -2218,9 +2221,15 @@ async function startRuntime(serverId: string): Promise<void> {
   }
 }
 
-async function connectServer(serverId: string): Promise<void> {
+async function connectServer(
+  serverId: string,
+  options: ConnectServerOptions = {}
+): Promise<void> {
   const server = findServer(serverId)
   if (!server) return
+  if (typeof options.localRuntimeEnabled === `boolean`) {
+    server.localRuntimeEnabled = options.localRuntimeEnabled
+  }
   server.desiredState = `connected`
   const entry = ensureRuntimeEntry(server)
   entry.desiredState = `connected`
@@ -2239,6 +2248,27 @@ async function disconnectServer(serverId: string): Promise<void> {
   entry.status = `disconnected`
   entry.lastError = null
   entry.reconnectAttempt = 0
+  await saveSettings()
+  refreshDesktopState()
+}
+
+async function forgetServer(serverId: string): Promise<void> {
+  const server = findServer(serverId)
+  if (!server) return
+  await disconnectServer(serverId)
+  settings.servers = settings.servers.filter((entry) => entry.id !== serverId)
+  runtimeEntries.delete(serverId)
+  if (server.tenantId) {
+    await getCloudAgentServers().forgetAgentsToken(server.tenantId)
+  }
+  if (settings.defaultServerId === serverId) {
+    settings.defaultServerId = settings.servers[0]?.id ?? null
+  }
+  for (const [windowId, selectedServerId] of windowSelections) {
+    if (selectedServerId === serverId) {
+      windowSelections.set(windowId, settings.defaultServerId)
+    }
+  }
   await saveSettings()
   refreshDesktopState()
 }
@@ -2548,11 +2578,17 @@ function registerIpcHandlers(): void {
       typeof serverId === `string` ? serverId : null
     )
   })
-  ipcMain.handle(`desktop:connect-server`, async (_event, serverId) => {
-    if (typeof serverId === `string`) await connectServer(serverId)
-  })
+  ipcMain.handle(
+    `desktop:connect-server`,
+    async (_event, serverId, options?: ConnectServerOptions) => {
+      if (typeof serverId === `string`) await connectServer(serverId, options)
+    }
+  )
   ipcMain.handle(`desktop:disconnect-server`, async (_event, serverId) => {
     if (typeof serverId === `string`) await disconnectServer(serverId)
+  })
+  ipcMain.handle(`desktop:forget-server`, async (_event, serverId) => {
+    if (typeof serverId === `string`) await forgetServer(serverId)
   })
   ipcMain.handle(
     `desktop:restart-runtime`,

--- a/packages/agents-desktop/src/main.ts
+++ b/packages/agents-desktop/src/main.ts
@@ -28,7 +28,7 @@ import {
   shell,
 } from 'electron'
 import fixPath from 'fix-path'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { readFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import path from 'node:path'
@@ -2362,6 +2362,20 @@ async function quitApp(): Promise<void> {
   app.quit()
 }
 
+async function clearAllLocalDataAndRelaunch(): Promise<void> {
+  await getCloudAuth().signOut()
+  await getCloudAgentServers().stop()
+  await Promise.all([
+    session.defaultSession.clearStorageData(),
+    session.defaultSession.clearCache(),
+    rm(settingsPath(), { force: true }),
+    rm(secretsPath(), { force: true }),
+  ])
+  secretStore = null
+  app.relaunch()
+  await quitApp()
+}
+
 /**
  * Localhost ports we probe for running `agents-server` instances.
  *
@@ -2562,6 +2576,9 @@ function registerIpcHandlers(): void {
   ipcMain.handle(`desktop:get-api-keys-status`, () => getApiKeysStatus())
   ipcMain.handle(`desktop:save-api-keys`, async (_event, keys: ApiKeys) => {
     await setApiKeys(keys)
+  })
+  ipcMain.handle(`desktop:clear-all-local-data`, async () => {
+    await clearAllLocalDataAndRelaunch()
   })
   ipcMain.handle(`desktop:get-onboarding-state`, () => getOnboardingState())
   ipcMain.handle(

--- a/packages/agents-desktop/src/main.ts
+++ b/packages/agents-desktop/src/main.ts
@@ -2734,6 +2734,9 @@ function registerIpcHandlers(): void {
   ipcMain.handle(`desktop:cloud-auth-open-dashboard`, () => {
     getCloudAuth().openDashboard()
   })
+  ipcMain.handle(`desktop:cloud-auth-open-create-agents-server`, () => {
+    getCloudAuth().openCreateAgentsServer()
+  })
 
   // ── Cloud agent servers ─────────────────────────────────────────
   // The user-scoped shape stream of agent stream services

--- a/packages/agents-desktop/src/preload.ts
+++ b/packages/agents-desktop/src/preload.ts
@@ -306,6 +306,8 @@ const api = {
     ipcRenderer.invoke(`desktop:get-api-keys-status`),
   saveApiKeys: (keys: ApiKeys): Promise<void> =>
     ipcRenderer.invoke(`desktop:save-api-keys`, keys),
+  clearAllLocalData: (): Promise<void> =>
+    ipcRenderer.invoke(`desktop:clear-all-local-data`),
   getOnboardingState: (): Promise<OnboardingState> =>
     ipcRenderer.invoke(`desktop:get-onboarding-state`),
   setOnboardingDismissed: (dismissed: boolean): Promise<void> =>

--- a/packages/agents-desktop/src/preload.ts
+++ b/packages/agents-desktop/src/preload.ts
@@ -46,6 +46,10 @@ type ServerConfig = {
   tenantId?: string
 }
 
+type ConnectServerOptions = {
+  localRuntimeEnabled?: boolean
+}
+
 type DesktopRuntimeStatus = `stopped` | `starting` | `running` | `error`
 type LocalRuntimeStatus =
   | `disabled`
@@ -289,10 +293,15 @@ const api = {
     ipcRenderer.invoke(`desktop:set-active-server`, server),
   setSelectedServer: (serverId: string | null): Promise<void> =>
     ipcRenderer.invoke(`desktop:set-selected-server`, serverId),
-  connectServer: (serverId: string): Promise<void> =>
-    ipcRenderer.invoke(`desktop:connect-server`, serverId),
+  connectServer: (
+    serverId: string,
+    options?: ConnectServerOptions
+  ): Promise<void> =>
+    ipcRenderer.invoke(`desktop:connect-server`, serverId, options),
   disconnectServer: (serverId: string): Promise<void> =>
     ipcRenderer.invoke(`desktop:disconnect-server`, serverId),
+  forgetServer: (serverId: string): Promise<void> =>
+    ipcRenderer.invoke(`desktop:forget-server`, serverId),
   restartRuntime: (): Promise<void> =>
     ipcRenderer.invoke(`desktop:restart-runtime`),
   restartServerRuntime: (serverId: string): Promise<void> =>

--- a/packages/agents-desktop/src/preload.ts
+++ b/packages/agents-desktop/src/preload.ts
@@ -422,6 +422,8 @@ const api = {
       ipcRenderer.invoke(`desktop:cloud-auth-sign-out`),
     openDashboard: (): Promise<void> =>
       ipcRenderer.invoke(`desktop:cloud-auth-open-dashboard`),
+    openCreateAgentsServer: (): Promise<void> =>
+      ipcRenderer.invoke(`desktop:cloud-auth-open-create-agents-server`),
     onStateChanged: (
       callback: (state: CloudAuthState) => void
     ): (() => void) => {

--- a/packages/agents-server-ui/src/components/ApiKeysForm.module.css
+++ b/packages/agents-server-ui/src/components/ApiKeysForm.module.css
@@ -8,6 +8,10 @@
   gap: var(--ds-space-4);
 }
 
+.settingsForm {
+  display: contents;
+}
+
 .hint {
   display: flex;
   align-items: center;
@@ -21,6 +25,10 @@
 
 .secretInput {
   position: relative;
+}
+
+.settingsForm .secretInput {
+  width: 100%;
 }
 
 .secretInputControl {

--- a/packages/agents-server-ui/src/components/ApiKeysForm.module.css
+++ b/packages/agents-server-ui/src/components/ApiKeysForm.module.css
@@ -19,6 +19,21 @@
   color: var(--ds-text-2);
 }
 
+.secretInput {
+  position: relative;
+}
+
+.secretInputControl {
+  padding-right: 34px;
+}
+
+.secretInputToggle {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+}
+
 .actions {
   margin-top: var(--ds-space-2);
 }

--- a/packages/agents-server-ui/src/components/ApiKeysForm.tsx
+++ b/packages/agents-server-ui/src/components/ApiKeysForm.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useState } from 'react'
 import { Eye, EyeOff, Sparkles } from 'lucide-react'
 import { Button, Field, Icon, IconButton, Input, Stack, Text } from '../ui'
+import {
+  SettingsActions,
+  SettingsPanel,
+  SettingsRow,
+} from './settings/SettingsScreen'
 import styles from './ApiKeysForm.module.css'
 
 export type ApiKeysFormValues = {
@@ -31,6 +36,8 @@ interface ApiKeysFormProps {
   savingLabel?: string
   /** Auto-focus the Anthropic field on mount. Defaults to `false`. */
   autoFocus?: boolean
+  /** Use Settings rows instead of the compact onboarding form layout. */
+  layout?: `form` | `settings`
 }
 
 /**
@@ -55,6 +62,7 @@ export function ApiKeysForm({
   saveLabel = `Save`,
   savingLabel = `Saving…`,
   autoFocus = false,
+  layout = `form`,
 }: ApiKeysFormProps): React.ReactElement {
   const [anthropic, setAnthropic] = useState(initial.anthropic)
   const [openai, setOpenai] = useState(initial.openai)
@@ -92,6 +100,100 @@ export function ApiKeysForm({
   const toggleVisible = useCallback((field: ApiKeyFieldId) => {
     setVisibleKeys((current) => ({ ...current, [field]: !current[field] }))
   }, [])
+
+  if (layout === `settings`) {
+    return (
+      <form onSubmit={handleSubmit} className={styles.settingsForm}>
+        {showSuggestionHint && (
+          <SettingsPanel>
+            <div className={styles.hint}>
+              <Icon icon={Sparkles} size={2} />
+              <Text size={1} tone="muted">
+                Pre-filled from your environment. Click save to persist them.
+              </Text>
+            </div>
+          </SettingsPanel>
+        )}
+        <SettingsRow
+          label="Anthropic API key"
+          description="Used for Claude models. Looks like sk-ant-…"
+          stackedControl
+          control={
+            <ApiKeyInput
+              field="anthropic"
+              placeholder="sk-ant-…"
+              value={anthropic}
+              visible={visibleKeys.anthropic}
+              onChange={setAnthropic}
+              onToggleVisible={toggleVisible}
+              autoFocus={autoFocus}
+            />
+          }
+        />
+        <SettingsRow
+          label="OpenAI API key"
+          description="Used for GPT models. Looks like sk-…"
+          stackedControl
+          control={
+            <ApiKeyInput
+              field="openai"
+              placeholder="sk-…"
+              value={openai}
+              visible={visibleKeys.openai}
+              onChange={setOpenai}
+              onToggleVisible={toggleVisible}
+            />
+          }
+        />
+        <SettingsRow
+          label="DeepSeek API key"
+          description="Used for DeepSeek models. Looks like sk-…"
+          stackedControl
+          control={
+            <ApiKeyInput
+              field="deepseek"
+              placeholder="sk-…"
+              value={deepseek}
+              visible={visibleKeys.deepseek}
+              onChange={setDeepseek}
+              onToggleVisible={toggleVisible}
+            />
+          }
+        />
+        <SettingsRow
+          label="Brave Search API key"
+          description="Powers the web-search tool. Without it, search falls back to Anthropic's built-in search."
+          stackedControl
+          control={
+            <ApiKeyInput
+              field="brave"
+              placeholder="BSA…"
+              value={brave}
+              visible={visibleKeys.brave}
+              onChange={setBrave}
+              onToggleVisible={toggleVisible}
+            />
+          }
+        />
+        <SettingsActions separator>
+          {onSecondary && secondaryLabel && (
+            <Button
+              type="button"
+              variant="soft"
+              tone="neutral"
+              onClick={onSecondary}
+              disabled={saving}
+            >
+              {secondaryLabel}
+            </Button>
+          )}
+          <Button type="submit" disabled={!canSave || saving}>
+            {saving ? savingLabel : saveLabel}
+          </Button>
+        </SettingsActions>
+      </form>
+    )
+  }
 
   return (
     <form onSubmit={handleSubmit} className={styles.form}>

--- a/packages/agents-server-ui/src/components/ApiKeysForm.tsx
+++ b/packages/agents-server-ui/src/components/ApiKeysForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
-import { Sparkles } from 'lucide-react'
-import { Button, Field, Icon, Input, Stack, Text } from '../ui'
+import { Eye, EyeOff, Sparkles } from 'lucide-react'
+import { Button, Field, Icon, IconButton, Input, Stack, Text } from '../ui'
 import styles from './ApiKeysForm.module.css'
 
 export type ApiKeysFormValues = {
@@ -9,6 +9,8 @@ export type ApiKeysFormValues = {
   deepseek: string
   brave: string
 }
+
+type ApiKeyFieldId = keyof ApiKeysFormValues
 
 interface ApiKeysFormProps {
   initial: ApiKeysFormValues
@@ -58,6 +60,14 @@ export function ApiKeysForm({
   const [openai, setOpenai] = useState(initial.openai)
   const [deepseek, setDeepseek] = useState(initial.deepseek)
   const [brave, setBrave] = useState(initial.brave)
+  const [visibleKeys, setVisibleKeys] = useState<
+    Record<ApiKeyFieldId, boolean>
+  >({
+    anthropic: false,
+    openai: false,
+    deepseek: false,
+    brave: false,
+  })
   const [saving, setSaving] = useState(false)
   const canSave =
     anthropic.trim().length > 0 ||
@@ -79,6 +89,10 @@ export function ApiKeysForm({
     [anthropic, openai, deepseek, brave, canSave, saving, onSave]
   )
 
+  const toggleVisible = useCallback((field: ApiKeyFieldId) => {
+    setVisibleKeys((current) => ({ ...current, [field]: !current[field] }))
+  }, [])
+
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
       {showSuggestionHint && (
@@ -94,12 +108,13 @@ export function ApiKeysForm({
           label="Anthropic API key"
           description="Used for Claude models. Looks like sk-ant-…"
         >
-          <Input
-            type="password"
+          <ApiKeyInput
+            field="anthropic"
             placeholder="sk-ant-…"
             value={anthropic}
-            onChange={(e) => setAnthropic(e.target.value)}
-            size={2}
+            visible={visibleKeys.anthropic}
+            onChange={setAnthropic}
+            onToggleVisible={toggleVisible}
             autoFocus={autoFocus}
           />
         </Field>
@@ -107,36 +122,39 @@ export function ApiKeysForm({
           label="OpenAI API key"
           description="Used for GPT models. Looks like sk-…"
         >
-          <Input
-            type="password"
+          <ApiKeyInput
+            field="openai"
             placeholder="sk-…"
             value={openai}
-            onChange={(e) => setOpenai(e.target.value)}
-            size={2}
+            visible={visibleKeys.openai}
+            onChange={setOpenai}
+            onToggleVisible={toggleVisible}
           />
         </Field>
         <Field
           label="DeepSeek API key (optional)"
           description="Used for DeepSeek models. Looks like sk-…"
         >
-          <Input
-            type="password"
+          <ApiKeyInput
+            field="deepseek"
             placeholder="sk-…"
             value={deepseek}
-            onChange={(e) => setDeepseek(e.target.value)}
-            size={2}
+            visible={visibleKeys.deepseek}
+            onChange={setDeepseek}
+            onToggleVisible={toggleVisible}
           />
         </Field>
         <Field
           label="Brave Search API key (optional)"
           description="Powers the web-search tool. Without it, search falls back to Anthropic's built-in search."
         >
-          <Input
-            type="password"
+          <ApiKeyInput
+            field="brave"
             placeholder="BSA…"
             value={brave}
-            onChange={(e) => setBrave(e.target.value)}
-            size={2}
+            visible={visibleKeys.brave}
+            onChange={setBrave}
+            onToggleVisible={toggleVisible}
           />
         </Field>
       </Stack>
@@ -157,5 +175,52 @@ export function ApiKeysForm({
         </Button>
       </Stack>
     </form>
+  )
+}
+
+function ApiKeyInput({
+  field,
+  placeholder,
+  value,
+  visible,
+  onChange,
+  onToggleVisible,
+  autoFocus = false,
+}: {
+  field: ApiKeyFieldId
+  placeholder: string
+  value: string
+  visible: boolean
+  onChange: (value: string) => void
+  onToggleVisible: (field: ApiKeyFieldId) => void
+  autoFocus?: boolean
+}): React.ReactElement {
+  const label = visible ? `Hide API key` : `Show API key`
+
+  return (
+    <div className={styles.secretInput}>
+      <Input
+        type={visible ? `text` : `password`}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        size={2}
+        autoFocus={autoFocus}
+        mono
+        className={styles.secretInputControl}
+      />
+      <IconButton
+        type="button"
+        variant="ghost"
+        tone="neutral"
+        size={1}
+        aria-label={label}
+        title={label}
+        className={styles.secretInputToggle}
+        onClick={() => onToggleVisible(field)}
+      >
+        <Icon icon={visible ? EyeOff : Eye} size={2} />
+      </IconButton>
+    </div>
   )
 }

--- a/packages/agents-server-ui/src/components/OnboardingModal.module.css
+++ b/packages/agents-server-ui/src/components/OnboardingModal.module.css
@@ -1,42 +1,426 @@
 /*
- * Two-step onboarding wizard styling. The popup is wider than the
- * default Dialog (520px instead of 480px) so the step indicator and
- * the API-keys form share the same comfortable column width.
- *
- * The footer is wired to render below whichever step is active —
- * it carries the "Don't show again" link so the user can opt out
- * from either screen without scrolling.
+ * Onboarding wizard styling. The wrapper visually matches the
+ * Settings shell — section headings ("API Keys", "Electric Cloud")
+ * sit above bordered card bodies (1px border, radius-3, faintly
+ * tinted surface) with rows separated by 1px borders. Row padding
+ * (12px 16px) + the leading 32px icon column come from the
+ * SettingsScreen / ServerPicker conventions so the same icon column
+ * aligns vertically across server rows, API key rows, and the
+ * "signed in" cloud row.
  */
 
-.providerButtons {
+.content {
   display: flex;
   flex-direction: column;
+  gap: var(--ds-space-4);
+  padding: var(--ds-space-4);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-4);
+}
+
+/* ── Step indicator ──────────────────────────────────────────── */
+.steps {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--ds-space-5);
+  padding-bottom: var(--ds-space-3);
+  border-bottom: 1px solid var(--ds-border-1);
+}
+
+.step {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--ds-text-3);
+  font-size: var(--ds-text-sm);
+}
+
+.stepActive {
+  color: var(--ds-text-1);
+}
+
+.stepComplete {
+  color: var(--ds-text-2);
+}
+
+.stepNumber {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  border: 1px solid var(--ds-border-2);
+  background: transparent;
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+  color: inherit;
+}
+
+.stepActive .stepNumber {
+  background: var(--ds-text-1);
+  border-color: var(--ds-text-1);
+  color: var(--ds-bg);
+}
+
+.stepComplete .stepNumber {
+  border-color: var(--ds-green-9);
+  color: var(--ds-green-11);
+  background: var(--ds-green-a3);
+}
+
+.stepLabel {
+  white-space: nowrap;
+}
+
+/* ── Step header ─────────────────────────────────────────────── */
+.stepHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stepHeader > h2,
+.stepHeader > p {
+  margin: 0;
+}
+
+/* ── Section header (no card body — title + optional action) ── */
+.sectionHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ds-space-3);
+}
+
+.sectionHeaderText {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sectionHeaderTitle {
+  margin: 0;
+  font-size: var(--ds-text-base);
+  font-weight: 500; /* matches Settings .sectionTitle */
+  color: var(--ds-text-1);
+}
+
+.sectionHeaderAction {
+  flex-shrink: 0;
+}
+
+/* ── Card surface (mirrors SettingsScreen .sectionBody) ─────── */
+.section {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ds-border-1);
+  border-radius: var(--ds-radius-3);
+  background: color-mix(in oklab, var(--ds-surface-raised) 35%, var(--ds-bg));
+  overflow: hidden;
+}
+
+.sectionRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--ds-border-1);
+}
+
+.sectionRow:first-child {
+  border-top: 0;
+}
+
+/* ── Shared row layout ───────────────────────────────────────── */
+.iconCircle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: var(--ds-bg-subtle);
+  color: var(--ds-text-2);
+  flex-shrink: 0;
+}
+
+.iconCircle[data-tone='success'] {
+  background: var(--ds-green-a3);
+  color: var(--ds-green-11);
+}
+
+.rowText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.rowTitle {
+  font-size: var(--ds-text-sm);
+  color: var(--ds-text-1);
+}
+
+.accordionTrigger .rowTitle {
+  font-weight: 500;
+}
+
+.accordionTrigger .rowText,
+.accordionTrigger .rowText p,
+.accordionTrigger .rowAside {
+  font-weight: 400;
+}
+
+.rowTitleLine {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rowMeta {
+  word-break: break-all;
+}
+
+.rowAside {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  color: var(--ds-text-3);
+}
+
+.kindTag {
+  font-size: 10px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--ds-bg-subtle);
+  color: var(--ds-text-3);
+}
+
+.kindTag[data-kind='model'] {
+  background: var(--ds-accent-a3);
+  color: var(--ds-accent-11);
+}
+
+/* ── Cloud step ──────────────────────────────────────────────── */
+.cloudSignIn {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.signedIn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.providerButtons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--ds-space-2);
 }
 
-.providerActions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: var(--ds-space-3);
-}
-
-.signedInBanner {
+.hint {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
   border-radius: var(--ds-radius-2);
-  background: var(--ds-bg-subtle);
-  border: 1px solid var(--ds-border-1);
+  background: var(--ds-accent-a2);
   color: var(--ds-text-2);
 }
 
+/* ── Status pills inside rows ────────────────────────────────── */
+.statusConfigured {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--ds-text-xs);
+  color: var(--ds-green-11);
+}
+
+.statusSuggested {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--ds-text-xs);
+  color: var(--ds-accent-11);
+}
+
+.statusEmpty {
+  font-size: var(--ds-text-xs);
+  color: var(--ds-text-3);
+}
+
+/* ── API keys: Accordion (uses .section as its surface) ──────── */
+.accordionItem {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--ds-border-1);
+}
+
+.accordionItem:first-child {
+  border-top: 0;
+}
+
+.accordionHeader {
+  margin: 0;
+}
+
+.accordionTrigger {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 16px;
+  box-sizing: border-box;
+}
+
+.accordionTrigger:hover {
+  background: var(--ds-bg-hover);
+}
+
+.accordionTrigger:focus-visible {
+  outline: 2px solid var(--ds-accent-a8);
+  outline-offset: -2px;
+  border-radius: var(--ds-radius-2);
+}
+
+.chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  transition: transform 180ms ease;
+  color: var(--ds-text-3);
+}
+
+.accordionTrigger[data-panel-open] .chevron {
+  transform: rotate(180deg);
+  color: var(--ds-text-2);
+}
+
+.accordionPanel {
+  overflow: hidden;
+  height: var(--accordion-panel-height);
+  transition: height 200ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.accordionPanel[data-starting-style],
+.accordionPanel[data-ending-style] {
+  height: 0;
+}
+
+.accordionPanelInner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 16px 14px; /* top breathing room so the input's focus
+                             outline isn't clipped by the panel's
+                             overflow:hidden height transition */
+  box-sizing: border-box;
+}
+
+.secretInput {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.secretInputControl {
+  width: 100%;
+  padding-right: 34px;
+}
+
+.secretInputToggle {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+}
+
+/* ── Server step rows ────────────────────────────────────────── */
+.serverRow {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--ds-border-1);
+  box-sizing: border-box;
+}
+
+.serverRow:first-child {
+  border-top: 0;
+}
+
+.serverRow:hover {
+  background: var(--ds-bg-hover);
+}
+
+.serverRow:focus-visible {
+  outline: 2px solid var(--ds-accent-a8);
+  outline-offset: -2px;
+  border-radius: var(--ds-radius-2);
+}
+
+.serverRow:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+.serverChevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ds-text-3);
+  transition: transform 120ms ease;
+}
+
+.serverRow:hover .serverChevron {
+  color: var(--ds-text-1);
+  transform: translateX(2px);
+}
+
+/* ── Footer ──────────────────────────────────────────────────── */
 .footer {
   display: flex;
-  justify-content: center;
-  margin-top: var(--ds-space-4);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-space-3);
   padding-top: var(--ds-space-3);
   border-top: 1px solid var(--ds-border-1);
+}
+
+.footerLeading,
+.footerTrailing {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  min-width: 0;
+}
+
+.footerLeading {
+  flex: 1;
+  min-width: 0;
 }
 
 .footerLink {
@@ -46,7 +430,6 @@
   cursor: pointer;
   color: var(--ds-text-3);
   font-size: var(--ds-text-xs);
-  line-height: var(--ds-text-xs-lh);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
@@ -55,26 +438,11 @@
   color: var(--ds-text-2);
 }
 
-.steps {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-space-2);
-  margin-bottom: var(--ds-space-3);
-}
-
-.stepDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--ds-border-2);
-}
-
-.stepDotActive {
-  background: var(--ds-text-1);
-}
-
-.stepBar {
-  flex: 0 1 24px;
-  height: 1px;
-  background: var(--ds-border-1);
+@media (max-width: 640px) {
+  .providerButtons {
+    grid-template-columns: 1fr;
+  }
+  .steps {
+    gap: var(--ds-space-3);
+  }
 }

--- a/packages/agents-server-ui/src/components/OnboardingModal.module.css
+++ b/packages/agents-server-ui/src/components/OnboardingModal.module.css
@@ -220,7 +220,8 @@
 .cloudSignIn {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 14px;
+  margin-top: 2px;
 }
 
 .signedIn {
@@ -233,6 +234,21 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--ds-space-2);
+}
+
+.cloudFinePrintStack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cloudFinePrint {
+  color: var(--ds-text-3);
+}
+
+.finePrintLink {
+  color: inherit;
+  text-decoration-color: currentColor;
 }
 
 .hint {

--- a/packages/agents-server-ui/src/components/OnboardingModal.tsx
+++ b/packages/agents-server-ui/src/components/OnboardingModal.tsx
@@ -1,49 +1,105 @@
-import { useEffect, useMemo, useState } from 'react'
-import { CheckCircle2, Github } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Accordion } from '@base-ui/react/accordion'
 import {
+  ArrowRight,
+  CheckCircle2,
+  ChevronDown,
+  Cloud,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Github,
+  Laptop,
+  Plug,
+  Server,
+  Sparkles,
+} from 'lucide-react'
+import {
+  cloudOpenCreateAgentsServer,
   cloudSignIn,
   loadApiKeysStatus,
   loadCloudAuthState,
   loadOnboardingState,
   onCloudAuthStateChanged,
+  prepareCloudAgentServerConnection,
   saveApiKeys as persistApiKeys,
   setOnboardingDismissed,
+  type ApiKeys,
   type ApiKeysStatus,
   type CloudAuthState,
+  type ConnectServerOptions,
 } from '../lib/server-connection'
-import { Button, Dialog, Icon, Stack, Text } from '../ui'
-import { ApiKeysForm } from './ApiKeysForm'
+import {
+  useAvailableServers,
+  type AvailableServer,
+} from '../hooks/useAvailableServers'
+import { useServerConnection } from '../hooks/useServerConnection'
+import { Button, Dialog, Icon, IconButton, Input, Text } from '../ui'
 import styles from './OnboardingModal.module.css'
 
-type Step = `cloud` | `keys`
+type Step = `cloud` | `keys` | `server`
+
+const STEPS: ReadonlyArray<{ id: Step; label: string }> = [
+  { id: `cloud`, label: `Cloud` },
+  { id: `keys`, label: `API Keys` },
+  { id: `server`, label: `Server` },
+]
+
+type ProviderId = keyof ApiKeys
+
+type ProviderKind = `model` | `tool`
+
+const MODEL_PROVIDER_IDS: ReadonlyArray<ProviderId> = [
+  `anthropic`,
+  `openai`,
+  `deepseek`,
+]
+
+const PROVIDERS: ReadonlyArray<{
+  id: ProviderId
+  name: string
+  description: string
+  placeholder: string
+  kind: ProviderKind
+}> = [
+  {
+    id: `anthropic`,
+    name: `Anthropic`,
+    description: `Claude models — the default for the local runtime.`,
+    placeholder: `sk-ant-…`,
+    kind: `model`,
+  },
+  {
+    id: `openai`,
+    name: `OpenAI`,
+    description: `GPT models, including the GPT-5 family.`,
+    placeholder: `sk-…`,
+    kind: `model`,
+  },
+  {
+    id: `deepseek`,
+    name: `DeepSeek`,
+    description: `DeepSeek's hosted reasoning models.`,
+    placeholder: `sk-…`,
+    kind: `model`,
+  },
+  {
+    id: `brave`,
+    name: `Brave Search`,
+    description: `Adds the brave_search tool. Without it, agents fall back to Anthropic's built-in search.`,
+    placeholder: `BSA…`,
+    kind: `tool`,
+  },
+]
 
 /**
  * First-launch onboarding wizard for the Electron desktop app.
  *
- * Two steps:
- *  1. Sign in to Electric Cloud (GitHub / Google). Skippable.
- *  2. Configure provider API keys for the bundled local runtime.
- *     Skippable. Saving the keys ends onboarding.
- *
- * Web build: returns `null` — neither sign-in nor key storage is
- * meaningful in a regular browser tab.
- *
- * Persistence:
- *  - Shows automatically on every launch until the user clicks "Don't
- *    show this again" OR completes the API-keys step (saving the
- *    keys marks `onboardingDismissed=true` on its way out).
- *  - "Skip" on either step closes the modal without marking dismissed,
- *    so it reappears next launch — Settings → Account + Settings →
- *    General are the manual paths in the meantime.
- *
- * Step 1 auto-advances as soon as the cloud-auth state flips to
- * `signed-in`, so the user lands on step 2 without an extra click.
- * If they were already signed in when the app launched we open the
- * wizard directly on step 2 (cloud step has nothing to do).
- *
- * Replaces the previous `<ApiKeysModal>` — the keys-only flow is now
- * subsumed by this wizard. `ApiKeysForm` is still shared with
- * Settings → General.
+ * Three steps with visuals matching the Settings shell: section
+ * headings sit above bordered card surfaces (1px border + radius +
+ * tinted background) with their rows separated by 1px borders. The
+ * API keys step is rendered as a base-ui Accordion so only one
+ * provider is editable at a time.
  */
 export function OnboardingModal(): React.ReactElement | null {
   const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
@@ -68,17 +124,14 @@ export function OnboardingModal(): React.ReactElement | null {
       setKeysStatus(keys)
       setBootstrapped(true)
 
-      if (!onboarding) return
-      if (onboarding.dismissed) return
-      // Already fully configured — nothing left to onboard, just
-      // record dismissal so we don't pop the modal next launch.
-      if (onboarding.signedIn && onboarding.hasAnyKey) {
-        void setOnboardingDismissed(true)
-        return
-      }
-      // Skip the cloud step if the user already has a restored
-      // session — there's nothing to do there.
-      setStep(onboarding.signedIn ? `keys` : `cloud`)
+      if (!onboarding || onboarding.dismissed) return
+      setStep(
+        onboarding.signedIn
+          ? onboarding.hasAnyKey
+            ? `server`
+            : `keys`
+          : `cloud`
+      )
       setOpen(true)
     })()
 
@@ -91,20 +144,15 @@ export function OnboardingModal(): React.ReactElement | null {
     }
   }, [isDesktop])
 
-  // Auto-advance from cloud → keys as soon as sign-in completes.
-  // We only do this while the wizard is open and on the cloud step;
-  // otherwise the same status flip from Settings → Account would
-  // also jump the user to the keys step, which is wrong.
   useEffect(() => {
     if (!open) return
     if (step !== `cloud`) return
-    if (cloudState?.status === `signed-in`) {
-      setStep(`keys`)
-    }
+    if (cloudState?.status === `signed-in`) setStep(`keys`)
   }, [open, step, cloudState?.status])
 
   const closeModal = useMemo(
-    () => () => {
+    () => async () => {
+      await setOnboardingDismissed(true)
       setOpen(false)
     },
     []
@@ -122,168 +170,653 @@ export function OnboardingModal(): React.ReactElement | null {
   if (!bootstrapped) return null
   if (!keysStatus) return null
 
-  const cloudStatus = cloudState?.status ?? `signed-out`
-  const cloudSigningIn = cloudStatus === `signing-in`
-  const cloudSignedIn = cloudStatus === `signed-in`
-
   return (
-    <Dialog.Root
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next)
-      }}
-    >
-      <Dialog.Content maxWidth={520}>
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Content maxWidth={640} className={styles.content}>
         <StepIndicator step={step} />
-        {step === `cloud` ? (
-          <>
-            <Dialog.Title>Welcome to Electric Agents</Dialog.Title>
-            <Dialog.Description>
-              Sign in to Electric Cloud so your local runtime can use your
-              workspaces and the dashboard. You can skip this and configure it
-              later from Settings → Account.
-            </Dialog.Description>
-            {cloudSignedIn ? (
-              <div className={styles.signedInBanner}>
-                <Icon icon={CheckCircle2} size={2} />
-                <Text size={2} tone="muted">
-                  {cloudState?.name
-                    ? `Signed in as ${cloudState.name}.`
-                    : `Signed in.`}
-                </Text>
-              </div>
-            ) : (
-              <Stack direction="column" gap={3}>
-                {cloudState?.error && (
-                  <Text size={2} tone="danger">
-                    {cloudState.error}
-                  </Text>
-                )}
-                <div className={styles.providerButtons}>
-                  <Button
-                    variant="solid"
-                    tone="neutral"
-                    size={2}
-                    disabled={cloudSigningIn}
-                    onClick={() => {
-                      void cloudSignIn(`github`)
-                    }}
-                  >
-                    <Icon icon={Github} size={2} />
-                    Sign in with GitHub
-                  </Button>
-                  <Button
-                    variant="soft"
-                    tone="neutral"
-                    size={2}
-                    disabled={cloudSigningIn}
-                    onClick={() => {
-                      void cloudSignIn(`google`)
-                    }}
-                  >
-                    Sign in with Google
-                  </Button>
-                </div>
-                <Text size={1} tone="muted">
-                  Opens a sign-in window pointed at
-                  dashboard.electric-sql.cloud. The window closes automatically
-                  once you've authorized.
-                </Text>
-              </Stack>
-            )}
-            <div className={styles.providerActions}>
-              <Button
-                type="button"
-                variant="soft"
-                tone="neutral"
-                onClick={() => setStep(`keys`)}
-              >
-                {cloudSignedIn ? `Continue` : `Skip`}
-              </Button>
-            </div>
-          </>
-        ) : (
-          <>
-            <Dialog.Title>Set up your API keys</Dialog.Title>
-            <Dialog.Description>
-              Electric Agents bundles a local runtime that calls the LLM
-              provider of your choice. Provide an Anthropic, OpenAI, or DeepSeek
-              API key (you can configure more than one) — stored on this machine
-              only. Brave Search is optional and powers the web-search tool.
-            </Dialog.Description>
-            <ApiKeysForm
-              initial={{
-                anthropic:
-                  keysStatus.suggested.anthropic ??
-                  keysStatus.saved.anthropic ??
-                  ``,
-                openai:
-                  keysStatus.suggested.openai ?? keysStatus.saved.openai ?? ``,
-                deepseek:
-                  keysStatus.suggested.deepseek ??
-                  keysStatus.saved.deepseek ??
-                  ``,
-                brave:
-                  keysStatus.suggested.brave ?? keysStatus.saved.brave ?? ``,
-              }}
-              showSuggestionHint={Boolean(
-                keysStatus.suggested.anthropic ||
-                  keysStatus.suggested.openai ||
-                  keysStatus.suggested.deepseek ||
-                  keysStatus.suggested.brave
-              )}
-              autoFocus
-              onSave={async ({ anthropic, openai, deepseek, brave }) => {
-                await persistApiKeys({
-                  anthropic: anthropic.trim() || null,
-                  openai: openai.trim() || null,
-                  deepseek: deepseek.trim() || null,
-                  brave: brave.trim() || null,
-                })
-                // Finishing the keys step means onboarding is done.
-                // Persist that so we don't pop the modal on next launch.
-                await setOnboardingDismissed(true)
-                closeModal()
-                const next = await loadApiKeysStatus()
-                if (next) setKeysStatus(next)
-              }}
-              onSecondary={closeModal}
-              secondaryLabel="Skip for now"
-              saveLabel="Save & finish"
+        <div className={styles.body}>
+          {step === `cloud` && (
+            <CloudStep
+              cloudState={cloudState}
+              onContinue={() => setStep(`keys`)}
+              onDismissForever={dismissForever}
             />
-          </>
-        )}
-        <div className={styles.footer}>
-          <button
-            type="button"
-            className={styles.footerLink}
-            onClick={dismissForever}
-          >
-            Don't show this again
-          </button>
+          )}
+          {step === `keys` && (
+            <KeysStep
+              keysStatus={keysStatus}
+              onKeysStatusChange={setKeysStatus}
+              onBack={() => setStep(`cloud`)}
+              onContinue={() => setStep(`server`)}
+            />
+          )}
+          {step === `server` && (
+            <ServerStep
+              cloudState={cloudState}
+              onBack={() => setStep(`keys`)}
+              onFinish={() => {
+                void closeModal()
+              }}
+            />
+          )}
         </div>
       </Dialog.Content>
     </Dialog.Root>
   )
 }
 
-function StepIndicator({ step }: { step: Step }): React.ReactElement {
+function CloudStep({
+  cloudState,
+  onContinue,
+  onDismissForever,
+}: {
+  cloudState: CloudAuthState | null
+  onContinue: () => void
+  onDismissForever: () => void
+}): React.ReactElement {
+  const cloudStatus = cloudState?.status ?? `signed-out`
+  const cloudSigningIn = cloudStatus === `signing-in`
+  const cloudSignedIn = cloudStatus === `signed-in`
+
   return (
-    <div className={styles.steps} aria-hidden>
-      <span
-        className={[
-          styles.stepDot,
-          step === `cloud` ? styles.stepDotActive : ``,
-        ]
-          .filter(Boolean)
-          .join(` `)}
+    <>
+      <StepHeader
+        title="Sign in to Electric Cloud"
+        description="Connect this app to your Electric Cloud workspaces to discover hosted agents servers and provision new ones — or skip ahead to use a local or self-hosted server."
       />
-      <span className={styles.stepBar} />
-      <span
-        className={[styles.stepDot, step === `keys` ? styles.stepDotActive : ``]
-          .filter(Boolean)
-          .join(` `)}
+      {cloudSignedIn ? (
+        <div className={styles.signedIn}>
+          <span className={styles.iconCircle} data-tone="success">
+            <Icon icon={CheckCircle2} size={2} />
+          </span>
+          <div className={styles.rowText}>
+            <span className={styles.rowTitle}>
+              {cloudState?.name ?? `Signed in`}
+            </span>
+            {cloudState?.email && (
+              <Text size={1} tone="muted">
+                {cloudState.email}
+              </Text>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className={styles.cloudSignIn}>
+          <div className={styles.providerButtons}>
+            <Button
+              variant="solid"
+              tone="neutral"
+              size={3}
+              disabled={cloudSigningIn}
+              onClick={() => {
+                void cloudSignIn(`github`)
+              }}
+            >
+              <Icon icon={Github} size={2} />
+              Sign in with GitHub
+            </Button>
+            <Button
+              variant="soft"
+              tone="neutral"
+              size={3}
+              disabled={cloudSigningIn}
+              onClick={() => {
+                void cloudSignIn(`google`)
+              }}
+            >
+              Sign in with Google
+            </Button>
+          </div>
+          <Text size={1} tone="muted">
+            Opens dashboard.electric-sql.cloud in a sign-in window. It closes
+            automatically once you've authorized.
+          </Text>
+          {cloudState?.error && (
+            <Text size={2} tone="danger">
+              {cloudState.error}
+            </Text>
+          )}
+        </div>
+      )}
+      <Footer
+        leading={
+          <button
+            type="button"
+            className={styles.footerLink}
+            onClick={onDismissForever}
+          >
+            Don't show this again
+          </button>
+        }
+        trailing={
+          <Button
+            type="button"
+            variant="solid"
+            tone="accent"
+            size={2}
+            onClick={onContinue}
+          >
+            {cloudSignedIn ? `Continue` : `Continue without Cloud`}
+            <Icon icon={ArrowRight} size={2} />
+          </Button>
+        }
       />
+    </>
+  )
+}
+
+function KeysStep({
+  keysStatus,
+  onKeysStatusChange,
+  onBack,
+  onContinue,
+}: {
+  keysStatus: ApiKeysStatus
+  onKeysStatusChange: (status: ApiKeysStatus) => void
+  onBack: () => void
+  onContinue: () => void
+}): React.ReactElement {
+  const hasAnySuggestion = PROVIDERS.some((provider) =>
+    Boolean(keysStatus.suggested[provider.id])
+  )
+  const hasAnyModelKey = MODEL_PROVIDER_IDS.some((id) =>
+    Boolean(keysStatus.saved[id])
+  )
+
+  const refreshStatus = async () => {
+    const next = await loadApiKeysStatus()
+    if (next) onKeysStatusChange(next)
+  }
+
+  return (
+    <>
+      <StepHeader
+        title="Add provider API keys"
+        description="All keys are optional — but to run agents in the bundled local runtime you'll need at least one model provider key (Anthropic, OpenAI, or DeepSeek). Keys are stored on this machine and can be changed anytime in Settings."
+      />
+      {hasAnySuggestion && !hasAnyModelKey && (
+        <div className={styles.hint}>
+          <Icon icon={Sparkles} size={2} />
+          <Text size={1} tone="muted">
+            We found provider keys in your environment. Open a row to review and
+            save it.
+          </Text>
+        </div>
+      )}
+      <Accordion.Root className={styles.section} multiple>
+        {PROVIDERS.map((provider) => (
+          <ProviderItem
+            key={provider.id}
+            provider={provider}
+            keysStatus={keysStatus}
+            onSaved={refreshStatus}
+          />
+        ))}
+      </Accordion.Root>
+      <Footer
+        leading={
+          <Button
+            type="button"
+            variant="ghost"
+            tone="neutral"
+            size={2}
+            onClick={onBack}
+          >
+            Back
+          </Button>
+        }
+        trailing={
+          <Button
+            type="button"
+            variant="solid"
+            tone="accent"
+            size={2}
+            onClick={onContinue}
+          >
+            {hasAnyModelKey ? `Continue` : `Skip for now`}
+            <Icon icon={ArrowRight} size={2} />
+          </Button>
+        }
+      />
+    </>
+  )
+}
+
+function ProviderItem({
+  provider,
+  keysStatus,
+  onSaved,
+}: {
+  provider: (typeof PROVIDERS)[number]
+  keysStatus: ApiKeysStatus
+  onSaved: () => Promise<void>
+}): React.ReactElement {
+  const saved = keysStatus.saved[provider.id]
+  const suggested = keysStatus.suggested[provider.id]
+  const isConfigured = Boolean(saved)
+  const initialValue = saved ?? suggested ?? ``
+
+  const [value, setValue] = useState(initialValue)
+  const [visible, setVisible] = useState(false)
+  const [savedFlash, setSavedFlash] = useState(false)
+  const savingRef = useRef(false)
+
+  // Keep local value in sync with parent state (e.g. after persist).
+  useEffect(() => {
+    setValue(initialValue)
+  }, [initialValue])
+
+  const persistIfDirty = async () => {
+    if (savingRef.current) return
+    const trimmed = value.trim()
+    const next = trimmed.length > 0 ? trimmed : null
+    const current = saved ?? null
+    if (next === current) return
+
+    savingRef.current = true
+    try {
+      const nextKeys: ApiKeys = {
+        anthropic: keysStatus.saved.anthropic ?? null,
+        openai: keysStatus.saved.openai ?? null,
+        deepseek: keysStatus.saved.deepseek ?? null,
+        brave: keysStatus.saved.brave ?? null,
+        [provider.id]: next,
+      }
+      await persistApiKeys(nextKeys)
+      await onSaved()
+      setSavedFlash(true)
+      window.setTimeout(() => setSavedFlash(false), 1600)
+    } finally {
+      savingRef.current = false
+    }
+  }
+
+  return (
+    <Accordion.Item value={provider.id} className={styles.accordionItem}>
+      <Accordion.Header className={styles.accordionHeader}>
+        <Accordion.Trigger className={styles.accordionTrigger}>
+          <span className={styles.rowText}>
+            <span className={styles.rowTitleLine}>
+              <span className={styles.rowTitle}>{provider.name}</span>
+              <span
+                className={styles.kindTag}
+                data-kind={provider.kind}
+                aria-hidden
+              >
+                {provider.kind === `model` ? `Model` : `Tool`}
+              </span>
+            </span>
+            <Text size={1} tone="muted">
+              {provider.description}
+            </Text>
+          </span>
+          <span className={styles.rowAside}>
+            {savedFlash ? (
+              <span className={styles.statusConfigured}>
+                <Icon icon={CheckCircle2} size={1} />
+                Saved
+              </span>
+            ) : isConfigured ? (
+              <span className={styles.statusConfigured}>
+                <Icon icon={CheckCircle2} size={1} />
+                Configured
+              </span>
+            ) : suggested ? (
+              <span className={styles.statusSuggested}>
+                <Icon icon={Sparkles} size={1} />
+                From environment
+              </span>
+            ) : (
+              <span className={styles.statusEmpty}>Not set</span>
+            )}
+            <span className={styles.chevron} aria-hidden>
+              <Icon icon={ChevronDown} size={2} />
+            </span>
+          </span>
+        </Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Panel className={styles.accordionPanel}>
+        <div className={styles.accordionPanelInner}>
+          <div className={styles.secretInput}>
+            <Input
+              type={visible ? `text` : `password`}
+              placeholder={provider.placeholder}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onBlur={() => {
+                void persistIfDirty()
+              }}
+              size={2}
+              mono
+              autoFocus
+              className={styles.secretInputControl}
+              onKeyDown={(event) => {
+                if (event.key === `Enter`) {
+                  event.preventDefault()
+                  ;(event.currentTarget as HTMLInputElement).blur()
+                }
+              }}
+            />
+            <IconButton
+              type="button"
+              variant="ghost"
+              tone="neutral"
+              size={1}
+              aria-label={visible ? `Hide API key` : `Show API key`}
+              className={styles.secretInputToggle}
+              onClick={() => setVisible((v) => !v)}
+            >
+              <Icon icon={visible ? EyeOff : Eye} size={2} />
+            </IconButton>
+          </div>
+        </div>
+      </Accordion.Panel>
+    </Accordion.Item>
+  )
+}
+
+function ServerStep({
+  cloudState,
+  onBack,
+  onFinish,
+}: {
+  cloudState: CloudAuthState | null
+  onBack: () => void
+  onFinish: () => void
+}): React.ReactElement {
+  const { servers } = useAvailableServers()
+  const { addServer, connectServer, setActiveServer } = useServerConnection()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [connectingKey, setConnectingKey] = useState<string | null>(null)
+  const cloudSignedIn = cloudState?.status === `signed-in`
+
+  const connectAvailableServer = async (item: AvailableServer) => {
+    setServerError(null)
+    setConnectingKey(item.key)
+    const options: ConnectServerOptions = { localRuntimeEnabled: true }
+    try {
+      if (item.server) {
+        setActiveServer(item.server)
+        connectServer(item.server.id, options)
+        onFinish()
+        return
+      }
+
+      if (item.cloudServer) {
+        const result = await prepareCloudAgentServerConnection(
+          item.cloudServer.id
+        )
+        if (!result) throw new Error(`Could not prepare the cloud connection.`)
+        addServer(
+          {
+            name: item.cloudServer.name,
+            url: result.url,
+            source: `electric-cloud`,
+            desiredState: `connected`,
+            localRuntimeEnabled: true,
+            tenantId: result.tenantId,
+          },
+          options
+        )
+        onFinish()
+        return
+      }
+
+      if (item.discoveredServer) {
+        addServer(
+          {
+            name: item.name,
+            url: item.discoveredServer.url,
+            source: `local-discovery`,
+            desiredState: `connected`,
+            localRuntimeEnabled: true,
+          },
+          options
+        )
+        onFinish()
+      }
+    } catch (error) {
+      setServerError(
+        error instanceof Error ? error.message : `Connection failed`
+      )
+    } finally {
+      setConnectingKey(null)
+    }
+  }
+
+  return (
+    <>
+      <StepHeader
+        title="Choose your first server"
+        description="Pick the agents server this app should connect to. Local connections start the bundled runtime automatically."
+      />
+      {servers.length > 0 ? (
+        <Section>
+          {servers.map((item) => (
+            <OnboardingServerRow
+              key={item.key}
+              item={item}
+              connecting={connectingKey === item.key}
+              onSelect={() => {
+                void connectAvailableServer(item)
+              }}
+            />
+          ))}
+        </Section>
+      ) : (
+        <Section>
+          <SectionRow>
+            <span className={styles.iconCircle}>
+              <Icon icon={Server} size={2} />
+            </span>
+            <div className={styles.rowText}>
+              <Text size={2} tone="muted">
+                No servers found yet. Create a hosted one in Electric Cloud
+                below, or add a local or self-hosted server later from Settings.
+              </Text>
+            </div>
+          </SectionRow>
+        </Section>
+      )}
+      {serverError && (
+        <Text size={2} tone="danger">
+          {serverError}
+        </Text>
+      )}
+      <SectionHeader
+        title="Electric Cloud"
+        description={
+          cloudSignedIn
+            ? `Provision a new hosted agents server from the dashboard.`
+            : `Sign in to Electric Cloud to provision a hosted agents server.`
+        }
+        action={
+          <Button
+            type="button"
+            variant="solid"
+            tone="accent"
+            size={2}
+            disabled={!cloudSignedIn}
+            onClick={() => {
+              void cloudOpenCreateAgentsServer()
+            }}
+          >
+            <Icon icon={ExternalLink} size={2} />
+            Create server
+          </Button>
+        }
+      />
+      <Footer
+        leading={
+          <Button
+            type="button"
+            variant="ghost"
+            tone="neutral"
+            size={2}
+            onClick={onBack}
+          >
+            Back
+          </Button>
+        }
+        trailing={
+          <Button
+            type="button"
+            variant="ghost"
+            tone="neutral"
+            size={2}
+            onClick={onFinish}
+          >
+            Skip for now
+          </Button>
+        }
+      />
+    </>
+  )
+}
+
+function OnboardingServerRow({
+  item,
+  connecting,
+  onSelect,
+}: {
+  item: AvailableServer
+  connecting: boolean
+  onSelect: () => void
+}): React.ReactElement {
+  const KindIcon = item.isCloud ? Cloud : item.isLocal ? Laptop : Plug
+  const meta = item.isCloud ? item.cloudPath : (item.url ?? item.description)
+  return (
+    <button
+      type="button"
+      className={styles.serverRow}
+      onClick={onSelect}
+      disabled={connecting}
+    >
+      <span className={styles.iconCircle}>
+        <Icon icon={KindIcon} size={2} />
+      </span>
+      <span className={styles.rowText}>
+        <span className={styles.rowTitle}>{item.name}</span>
+        {meta && (
+          <Text size={1} tone="muted" className={styles.rowMeta}>
+            {meta}
+          </Text>
+        )}
+      </span>
+      <span className={styles.rowAside}>
+        {connecting ? (
+          <Text size={1} tone="muted">
+            Connecting…
+          </Text>
+        ) : (
+          <span className={styles.serverChevron}>
+            <Icon icon={ArrowRight} size={2} />
+          </span>
+        )}
+      </span>
+    </button>
+  )
+}
+
+/* ── Layout primitives (local to onboarding) ───────────────── */
+
+function Section({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactElement {
+  return <div className={styles.section}>{children}</div>
+}
+
+function SectionRow({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactElement {
+  return <div className={styles.sectionRow}>{children}</div>
+}
+
+function SectionHeader({
+  title,
+  description,
+  action,
+}: {
+  title: string
+  description?: string
+  action?: React.ReactNode
+}): React.ReactElement {
+  return (
+    <div className={styles.sectionHeader}>
+      <div className={styles.sectionHeaderText}>
+        <h3 className={styles.sectionHeaderTitle}>{title}</h3>
+        {description && (
+          <Text size={1} tone="muted">
+            {description}
+          </Text>
+        )}
+      </div>
+      {action && <div className={styles.sectionHeaderAction}>{action}</div>}
+    </div>
+  )
+}
+
+function StepHeader({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}): React.ReactElement {
+  return (
+    <div className={styles.stepHeader}>
+      <Dialog.Title>{title}</Dialog.Title>
+      <Dialog.Description>{description}</Dialog.Description>
+    </div>
+  )
+}
+
+function Footer({
+  leading,
+  trailing,
+}: {
+  leading: React.ReactNode
+  trailing: React.ReactNode
+}): React.ReactElement {
+  return (
+    <div className={styles.footer}>
+      <div className={styles.footerLeading}>{leading}</div>
+      <div className={styles.footerTrailing}>{trailing}</div>
+    </div>
+  )
+}
+
+function StepIndicator({ step }: { step: Step }): React.ReactElement {
+  const activeIndex = STEPS.findIndex((candidate) => candidate.id === step)
+
+  return (
+    <div className={styles.steps} aria-label="Onboarding progress">
+      {STEPS.map((candidate, index) => {
+        const active = candidate.id === step
+        const complete = index < activeIndex
+        return (
+          <div
+            key={candidate.id}
+            className={[
+              styles.step,
+              active ? styles.stepActive : ``,
+              complete ? styles.stepComplete : ``,
+            ]
+              .filter(Boolean)
+              .join(` `)}
+            aria-current={active ? `step` : undefined}
+          >
+            <span className={styles.stepNumber}>
+              {complete ? <Icon icon={CheckCircle2} size={2} /> : index + 1}
+            </span>
+            <span className={styles.stepLabel}>{candidate.label}</span>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/packages/agents-server-ui/src/components/OnboardingModal.tsx
+++ b/packages/agents-server-ui/src/components/OnboardingModal.tsx
@@ -34,7 +34,7 @@ import {
   type AvailableServer,
 } from '../hooks/useAvailableServers'
 import { useServerConnection } from '../hooks/useServerConnection'
-import { Button, Dialog, Icon, IconButton, Input, Text } from '../ui'
+import { Button, Dialog, Icon, IconButton, Input, Link, Text } from '../ui'
 import styles from './OnboardingModal.module.css'
 
 type Step = `cloud` | `keys` | `server`
@@ -221,8 +221,8 @@ function CloudStep({
   return (
     <>
       <StepHeader
-        title="Sign in to Electric Cloud"
-        description="Connect this app to your Electric Cloud workspaces to discover hosted agents servers and provision new ones — or skip ahead to use a local or self-hosted server."
+        title="Electric Cloud"
+        description="The data platform for multi-agent systems. Sign in to discover hosted agents servers, provision new ones, and connect this desktop app to your Electric Cloud workspaces."
       />
       {cloudSignedIn ? (
         <div className={styles.signedIn}>
@@ -267,10 +267,35 @@ function CloudStep({
               Sign in with Google
             </Button>
           </div>
-          <Text size={1} tone="muted">
-            Opens dashboard.electric-sql.cloud in a sign-in window. It closes
-            automatically once you've authorized.
-          </Text>
+          <div className={styles.cloudFinePrintStack}>
+            <Text size={1} tone="muted" className={styles.cloudFinePrint}>
+              Opens dashboard.electric-sql.cloud in a sign-in window. It closes
+              automatically once you've authorized.
+            </Text>
+            <Text size={1} tone="muted" className={styles.cloudFinePrint}>
+              By signing in, you agree to our{` `}
+              <Link
+                size={1}
+                href="https://electric.ax/about/legal/terms"
+                target="_blank"
+                rel="noreferrer"
+                className={styles.finePrintLink}
+              >
+                terms of service
+              </Link>
+              {` `}and{` `}
+              <Link
+                size={1}
+                href="https://electric.ax/about/legal/privacy"
+                target="_blank"
+                rel="noreferrer"
+                className={styles.finePrintLink}
+              >
+                privacy policy
+              </Link>
+              .
+            </Text>
+          </div>
           {cloudState?.error && (
             <Text size={2} tone="danger">
               {cloudState.error}

--- a/packages/agents-server-ui/src/components/ServerPicker.module.css
+++ b/packages/agents-server-ui/src/components/ServerPicker.module.css
@@ -90,6 +90,16 @@
   color: var(--ds-text-3);
 }
 
+.kindIcon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ds-text-3);
+}
+
 .connectionBtn {
   margin-left: auto;
 }

--- a/packages/agents-server-ui/src/components/ServerPicker.tsx
+++ b/packages/agents-server-ui/src/components/ServerPicker.tsx
@@ -1,12 +1,23 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Brain, ChevronsUpDown, Plug, Server, Unplug } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  Brain,
+  ChevronsUpDown,
+  Cloud,
+  Laptop,
+  Plug,
+  Server,
+  Unplug,
+} from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
+import {
+  useAvailableServers,
+  type AvailableServer,
+} from '../hooks/useAvailableServers'
 import { useServerConnection } from '../hooks/useServerConnection'
 import {
-  loadDesktopState,
-  onDesktopStateChanged,
+  prepareCloudAgentServerConnection,
   rescanDiscoveredServers,
-  type DiscoveredServer,
+  type ConnectServerOptions,
 } from '../lib/server-connection'
 import { Icon, IconButton, Menu, Text, Tooltip } from '../ui'
 import styles from './ServerPicker.module.css'
@@ -19,61 +30,26 @@ type ServerStatus = `ok` | `down` | `unset`
 /**
  * Footer-anchored server picker tile.
  *
- * Renders a single-line tile showing `[● status] [server name] [chevron]`
- * that opens a menu listing saved servers, quick connect controls,
- * discovered localhost hints, and a link to the full Servers settings.
+ * Renders a single-line tile showing `[status] [server name] [chevron]`
+ * that opens one deduped list of saved, cloud, and local servers.
  */
 export function ServerPicker(): React.ReactElement {
   const {
-    servers,
     activeServer,
     connected,
     connection,
+    addServer,
     setActiveServer,
     connectServer,
     disconnectServer,
   } = useServerConnection()
+  const { servers } = useAvailableServers()
   const navigate = useNavigate()
   const [menuOpen, setMenuOpen] = useState(false)
-  const [discovered, setDiscovered] = useState<Array<DiscoveredServer>>([])
   const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
 
-  // Mirror the main process's discovered-server set into local state
-  // via the same desktop-state broadcast channel the rest of the
-  // desktop UI listens on. Web mode never receives a payload here.
-  useEffect(() => {
-    if (!isDesktop) return
-    void loadDesktopState().then((s) => {
-      if (s?.discoveredServers) setDiscovered(s.discoveredServers)
-    })
-    const unsubscribe = onDesktopStateChanged((s) =>
-      setDiscovered(s.discoveredServers ?? [])
-    )
-    return () => {
-      unsubscribe?.()
-    }
-  }, [isDesktop])
-
-  // Hide URLs the user has already saved — the saved-servers list
-  // covers them. Sort by port for a stable display order.
-  const savedUrls = useMemo(() => new Set(servers.map((s) => s.url)), [servers])
-  const newDiscovered = useMemo(
-    () =>
-      discovered
-        .filter((entry) => !savedUrls.has(entry.url))
-        .sort((a, b) => a.port - b.port),
-    [discovered, savedUrls]
-  )
-
   // While the menu is open, re-probe localhost on a 5-second cadence
-  // so newly-started agents servers appear (and stopped ones drop)
-  // without a manual refresh button. Background discovery in the
-  // main process still runs every 30s when the menu is closed —
-  // this loop just tightens the cadence for the moment the user
-  // is actively looking at the list. Probe results are broadcast
-  // via `desktop:state-changed`, so our existing subscription
-  // updates `discovered` automatically; we don't need the return
-  // value here.
+  // so newly-started agents servers appear without a manual refresh.
   useEffect(() => {
     if (!isDesktop || !menuOpen) return
     let cancelled = false
@@ -91,6 +67,46 @@ export function ServerPicker(): React.ReactElement {
       clearInterval(interval)
     }
   }, [isDesktop, menuOpen])
+
+  const connectAvailableServer = async (
+    item: AvailableServer,
+    options: ConnectServerOptions
+  ): Promise<void> => {
+    if (item.server) {
+      connectServer(item.server.id, options)
+      return
+    }
+    if (item.cloudServer) {
+      const result = await prepareCloudAgentServerConnection(
+        item.cloudServer.id
+      )
+      if (!result) return
+      addServer(
+        {
+          name: item.cloudServer.name,
+          url: result.url,
+          source: `electric-cloud`,
+          desiredState: `connected`,
+          localRuntimeEnabled: options.localRuntimeEnabled !== false,
+          tenantId: result.tenantId,
+        },
+        options
+      )
+      return
+    }
+    if (item.discoveredServer) {
+      addServer(
+        {
+          name: item.name,
+          url: item.discoveredServer.url,
+          source: `local-discovery`,
+          desiredState: `connected`,
+          localRuntimeEnabled: options.localRuntimeEnabled !== false,
+        },
+        options
+      )
+    }
+  }
 
   const status: ServerStatus = !activeServer
     ? `unset`
@@ -122,94 +138,27 @@ export function ServerPicker(): React.ReactElement {
         }
       />
       <Menu.Content side="top" align="start">
-        {servers.map((server, i) => {
-          const itemStatus: ServerStatus =
-            server.id === activeServer?.id
-              ? status
-              : server.desiredState === `connected`
-                ? `down`
-                : `unset`
-          const isConnected = server.desiredState === `connected`
-          return (
-            <Menu.Item
-              key={`${server.url}-${i}`}
-              onSelect={() => setActiveServer(server)}
-            >
-              <span className={styles.menuRow}>
-                <span className={styles.dot} data-state={itemStatus} />
-                <Text size={2} className={styles.menuRowName}>
-                  {server.name}
-                </Text>
-                {isDesktop && server.localRuntimeEnabled !== false && (
-                  <Tooltip
-                    content="Local runtime enabled for this server"
-                    side="right"
-                  >
-                    <span
-                      className={styles.runtimeBadge}
-                      aria-label="Local runtime enabled for this server"
-                    >
-                      <Icon icon={Brain} size={1} />
-                    </span>
-                  </Tooltip>
-                )}
-                <Tooltip
-                  content={
-                    isConnected
-                      ? `Disconnect ${server.name}`
-                      : `Connect ${server.name}`
-                  }
-                  side="right"
-                >
-                  <IconButton
-                    size={1}
-                    variant="ghost"
-                    tone="neutral"
-                    className={styles.connectionBtn}
-                    data-state={isConnected ? `connected` : `disconnected`}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      e.preventDefault()
-                      if (isConnected) disconnectServer(server.id)
-                      else connectServer(server.id)
-                    }}
-                    aria-label={
-                      isConnected
-                        ? `Disconnect ${server.name}`
-                        : `Connect ${server.name}`
-                    }
-                  >
-                    <Icon icon={isConnected ? Plug : Unplug} size={1} />
-                  </IconButton>
-                </Tooltip>
-              </span>
-            </Menu.Item>
-          )
-        })}
-        {isDesktop && newDiscovered.length > 0 && (
-          <>
-            {servers.length > 0 && <Menu.Separator />}
-            {newDiscovered.map((entry) => (
-              <Menu.Item
-                key={entry.url}
-                onSelect={() => {
-                  navigate({
-                    to: `/settings/$category`,
-                    params: { category: `servers` },
-                  })
-                }}
-              >
-                <span className={styles.menuRow}>
-                  <span className={styles.dot} data-state="unset" />
-                  <Text size={2} className={styles.menuRowName}>
-                    localhost:{entry.port}
-                  </Text>
-                </span>
-              </Menu.Item>
-            ))}
-          </>
-        )}
-        <Menu.Separator />
+        {servers.map((item) => (
+          <ServerMenuItem
+            key={item.key}
+            item={item}
+            onSelect={() => {
+              if (item.server) setActiveServer(item.server)
+              else
+                void connectAvailableServer(item, {
+                  localRuntimeEnabled: true,
+                })
+            }}
+            onConnect={(options) => {
+              void connectAvailableServer(item, options)
+            }}
+            onDisconnect={() => {
+              if (item.server) disconnectServer(item.server.id)
+            }}
+            isDesktop={isDesktop}
+          />
+        ))}
+        {servers.length > 0 && <Menu.Separator />}
         <Menu.Item
           onSelect={() =>
             navigate({
@@ -219,9 +168,104 @@ export function ServerPicker(): React.ReactElement {
           }
         >
           <Icon icon={Server} size={2} />
-          <Text size={2}>Servers…</Text>
+          <Text size={2}>Servers...</Text>
         </Menu.Item>
       </Menu.Content>
     </Menu.Root>
+  )
+}
+
+function ServerMenuItem({
+  item,
+  onSelect,
+  onConnect,
+  onDisconnect,
+  isDesktop,
+}: {
+  item: AvailableServer
+  onSelect: () => void
+  onConnect: (options: ConnectServerOptions) => void
+  onDisconnect: () => void
+  isDesktop: boolean
+}): React.ReactElement {
+  const isConnected = item.server?.desiredState === `connected`
+  const itemStatus: ServerStatus =
+    item.status === `connected` ||
+    item.status === `connecting` ||
+    item.status === `reconnecting`
+      ? `ok`
+      : item.status === `offline` || item.status === `error`
+        ? `down`
+        : `unset`
+
+  return (
+    <Menu.Item onSelect={onSelect}>
+      <span className={styles.menuRow}>
+        <span className={styles.dot} data-state={itemStatus} />
+        <ServerKindIcon item={item} />
+        <Text size={2} className={styles.menuRowName}>
+          {item.name}
+        </Text>
+        {isDesktop &&
+          isConnected &&
+          item.server?.localRuntimeEnabled !== false && (
+            <Tooltip content="Local runtime enabled" side="right">
+              <span
+                className={styles.runtimeBadge}
+                aria-label="Local runtime enabled"
+              >
+                <Icon icon={Brain} size={1} />
+              </span>
+            </Tooltip>
+          )}
+        {isDesktop && (
+          <Tooltip
+            content={
+              isConnected ? `Disconnect ${item.name}` : `Connect ${item.name}`
+            }
+            side="right"
+          >
+            <IconButton
+              size={1}
+              variant="ghost"
+              tone="neutral"
+              className={styles.connectionBtn}
+              data-state={isConnected ? `connected` : `disconnected`}
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                if (isConnected) onDisconnect()
+                else onConnect({ localRuntimeEnabled: true })
+              }}
+              aria-label={
+                isConnected ? `Disconnect ${item.name}` : `Connect ${item.name}`
+              }
+            >
+              <Icon icon={isConnected ? Plug : Unplug} size={1} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </span>
+    </Menu.Item>
+  )
+}
+
+function ServerKindIcon({
+  item,
+}: {
+  item: AvailableServer
+}): React.ReactElement {
+  const icon = item.isCloud ? Cloud : item.isLocal ? Laptop : Server
+  const label = item.isCloud
+    ? `Cloud server`
+    : item.isLocal
+      ? `Local server`
+      : `Self-hosted server`
+  return (
+    <Tooltip content={label} side="right">
+      <span className={styles.kindIcon} aria-label={label}>
+        <Icon icon={icon} size={1} />
+      </span>
+    </Tooltip>
   )
 }

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
@@ -172,6 +172,11 @@
   flex-shrink: 0;
 }
 
+.sectionAction[data-align='description'] {
+  margin-left: 12px;
+  padding-top: 24px;
+}
+
 .sectionDescription {
   margin: 0;
   font-size: var(--ds-text-sm);
@@ -184,6 +189,33 @@
   border-radius: var(--ds-radius-3);
   background: color-mix(in oklab, var(--ds-surface-raised) 35%, var(--ds-bg));
   overflow: hidden;
+}
+
+.panel {
+  padding: 12px 16px;
+}
+
+.inset {
+  padding: 0 16px 12px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  padding: 0 16px 16px;
+}
+
+.actions[data-separator='true'] {
+  padding-top: 12px;
+  border-top: 1px solid var(--ds-border-1);
+}
+
+.actions:first-child,
+.actions[data-separator='true']:first-child {
+  padding-top: 12px;
+  border-top: 0;
 }
 
 /* Stacked rows inside a section — labelled left, control on the
@@ -214,6 +246,16 @@
   min-width: 44%;
 }
 
+.row[data-layout='stacked'] {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.row[data-layout='stacked'] .rowText {
+  width: 100%;
+}
+
 .rowLabel {
   font-size: var(--ds-text-sm);
   color: var(--ds-text-1);
@@ -238,6 +280,12 @@
 
 .row[data-layout='split'] .rowControl {
   flex: 1 1 56%;
+}
+
+.row[data-layout='stacked'] .rowControl {
+  width: 100%;
+  justify-content: stretch;
+  text-align: left;
 }
 
 .rowControl > * {

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
@@ -114,12 +114,24 @@
   padding: 8px 32px 64px;
 }
 
-.pageTitle {
+.pageTitleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-space-3);
   margin: 16px 0 24px;
+}
+
+.pageTitle {
+  margin: 0;
   font-size: var(--ds-text-2xl);
   line-height: 1.2;
   font-weight: 600;
   color: var(--ds-text-1);
+}
+
+.pageAction {
+  flex-shrink: 0;
 }
 
 .sections {
@@ -192,8 +204,9 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
-  flex: 1;
-  min-width: 0;
+  flex: 0 1 44%;
+  min-width: 44%;
+  align-self: flex-start;
 }
 
 .rowLabel {
@@ -208,9 +221,22 @@
 }
 
 .rowControl {
-  flex-shrink: 0;
+  min-width: 0;
+  flex: 1 1 56%;
   align-self: flex-start;
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 6px;
+  text-align: right;
+}
+
+.rowControl > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.wrapControlValue > * {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
@@ -137,6 +137,14 @@
 
 .sectionHeader {
   display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ds-space-3);
+}
+
+.sectionHeaderText {
+  min-width: 0;
+  display: flex;
   flex-direction: column;
   gap: 4px;
 }
@@ -146,6 +154,10 @@
   font-size: var(--ds-text-base);
   font-weight: 500;
   color: var(--ds-text-1);
+}
+
+.sectionAction {
+  flex-shrink: 0;
 }
 
 .sectionDescription {

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
@@ -191,7 +191,7 @@
 .rowText {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
   flex: 1;
   min-width: 0;
 }
@@ -209,6 +209,7 @@
 
 .rowControl {
   flex-shrink: 0;
+  align-self: flex-start;
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
@@ -199,6 +199,10 @@
   padding: 0 16px 12px;
 }
 
+.statusBadge {
+  justify-content: center;
+}
+
 .actions {
   display: flex;
   flex-wrap: wrap;

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
@@ -204,9 +204,14 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  flex: 1;
+  min-width: 0;
+  align-self: flex-start;
+}
+
+.row[data-layout='split'] .rowText {
   flex: 0 1 44%;
   min-width: 44%;
-  align-self: flex-start;
 }
 
 .rowLabel {
@@ -222,13 +227,17 @@
 
 .rowControl {
   min-width: 0;
-  flex: 1 1 56%;
+  flex-shrink: 0;
   align-self: flex-start;
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
   gap: 6px;
   text-align: right;
+}
+
+.row[data-layout='split'] .rowControl {
+  flex: 1 1 56%;
 }
 
 .rowControl > * {

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
@@ -78,21 +78,26 @@ export function SettingsScreen({
 export function SettingsSection({
   title,
   description,
+  action,
   children,
 }: {
   title: string
   description?: ReactNode
-  children: ReactNode
+  action?: ReactNode
+  children?: ReactNode
 }): React.ReactElement {
   return (
     <section className={styles.section}>
       <header className={styles.sectionHeader}>
-        <h2 className={styles.sectionTitle}>{title}</h2>
-        {description && (
-          <p className={styles.sectionDescription}>{description}</p>
-        )}
+        <div className={styles.sectionHeaderText}>
+          <h2 className={styles.sectionTitle}>{title}</h2>
+          {description && (
+            <p className={styles.sectionDescription}>{description}</p>
+          )}
+        </div>
+        {action && <div className={styles.sectionAction}>{action}</div>}
       </header>
-      <div className={styles.sectionBody}>{children}</div>
+      {children && <div className={styles.sectionBody}>{children}</div>}
     </section>
   )
 }

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
@@ -116,14 +116,16 @@ export function SettingsRow({
   description,
   control,
   wrapControlValue,
+  splitLayout,
 }: {
   label: ReactNode
   description?: ReactNode
   control: ReactNode
   wrapControlValue?: boolean
+  splitLayout?: boolean
 }): React.ReactElement {
   return (
-    <div className={styles.row}>
+    <div className={styles.row} data-layout={splitLayout ? `split` : undefined}>
       <div className={styles.rowText}>
         <span className={styles.rowLabel}>{label}</span>
         {description && (

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
@@ -84,11 +84,13 @@ export function SettingsSection({
   title,
   description,
   action,
+  actionAlign = `title`,
   children,
 }: {
   title: string
   description?: ReactNode
   action?: ReactNode
+  actionAlign?: `title` | `description`
   children?: ReactNode
 }): React.ReactElement {
   return (
@@ -100,11 +102,48 @@ export function SettingsSection({
             <p className={styles.sectionDescription}>{description}</p>
           )}
         </div>
-        {action && <div className={styles.sectionAction}>{action}</div>}
+        {action && (
+          <div className={styles.sectionAction} data-align={actionAlign}>
+            {action}
+          </div>
+        )}
       </header>
       {children && <div className={styles.sectionBody}>{children}</div>}
     </section>
   )
+}
+
+export function SettingsPanel({
+  children,
+}: {
+  children: ReactNode
+}): React.ReactElement {
+  return <div className={styles.panel}>{children}</div>
+}
+
+export function SettingsActions({
+  children,
+  separator = false,
+}: {
+  children: ReactNode
+  separator?: boolean
+}): React.ReactElement {
+  return (
+    <div
+      className={styles.actions}
+      data-separator={separator ? `true` : undefined}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function SettingsInset({
+  children,
+}: {
+  children: ReactNode
+}): React.ReactElement {
+  return <div className={styles.inset}>{children}</div>
 }
 
 /**
@@ -117,15 +156,19 @@ export function SettingsRow({
   control,
   wrapControlValue,
   splitLayout,
+  stackedControl,
 }: {
   label: ReactNode
   description?: ReactNode
   control: ReactNode
   wrapControlValue?: boolean
   splitLayout?: boolean
+  stackedControl?: boolean
 }): React.ReactElement {
+  const layout = stackedControl ? `stacked` : splitLayout ? `split` : undefined
+
   return (
-    <div className={styles.row} data-layout={splitLayout ? `split` : undefined}>
+    <div className={styles.row} data-layout={layout}>
       <div className={styles.rowText}>
         <span className={styles.rowLabel}>{label}</span>
         {description && (

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
@@ -23,9 +23,11 @@ import styles from './SettingsScreen.module.css'
  */
 export function SettingsScreen({
   title,
+  action,
   children,
 }: {
   title: string
+  action?: ReactNode
   children: ReactNode
 }): React.ReactElement {
   // On narrow viewports the SettingsSidebar floats over the
@@ -59,7 +61,10 @@ export function SettingsScreen({
       </div>
       <ScrollArea className={styles.scroll}>
         <div className={styles.body} data-desktop-selection-context>
-          <h1 className={styles.pageTitle}>{title}</h1>
+          <div className={styles.pageTitleRow}>
+            <h1 className={styles.pageTitle}>{title}</h1>
+            {action && <div className={styles.pageAction}>{action}</div>}
+          </div>
           <Stack direction="column" gap={6} className={styles.sections}>
             {children}
           </Stack>
@@ -110,10 +115,12 @@ export function SettingsRow({
   label,
   description,
   control,
+  wrapControlValue,
 }: {
   label: ReactNode
   description?: ReactNode
   control: ReactNode
+  wrapControlValue?: boolean
 }): React.ReactElement {
   return (
     <div className={styles.row}>
@@ -123,7 +130,13 @@ export function SettingsRow({
           <span className={styles.rowDescription}>{description}</span>
         )}
       </div>
-      <div className={styles.rowControl}>{control}</div>
+      <div
+        className={`${styles.rowControl} ${
+          wrapControlValue ? styles.wrapControlValue : ``
+        }`}
+      >
+        {control}
+      </div>
     </div>
   )
 }

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.tsx
@@ -1,6 +1,14 @@
 import type { ReactNode } from 'react'
 import { PanelLeft } from 'lucide-react'
-import { Icon, IconButton, ScrollArea, Stack, Tooltip } from '../../ui'
+import {
+  Badge,
+  Icon,
+  IconButton,
+  ScrollArea,
+  Stack,
+  Tooltip,
+  type BadgeTone,
+} from '../../ui'
 import { useSidebarCollapsed } from '../../hooks/useSidebarCollapsed'
 import { useNarrowViewport } from '../../hooks/useNarrowViewport'
 import { modKeyLabel } from '../../lib/keyLabels'
@@ -144,6 +152,25 @@ export function SettingsInset({
   children: ReactNode
 }): React.ReactElement {
   return <div className={styles.inset}>{children}</div>
+}
+
+export type SettingsStatusTone = Extract<
+  BadgeTone,
+  `neutral` | `success` | `warning` | `danger` | `info`
+>
+
+export function SettingsStatusBadge({
+  children,
+  tone,
+}: {
+  children: ReactNode
+  tone: SettingsStatusTone
+}): React.ReactElement {
+  return (
+    <Badge size={1} tone={tone} className={styles.statusBadge}>
+      {children}
+    </Badge>
+  )
 }
 
 /**

--- a/packages/agents-server-ui/src/components/settings/SettingsSidebar.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsSidebar.module.css
@@ -122,8 +122,19 @@
 }
 
 .list {
-  padding: 4px 8px 8px;
-  gap: 1px;
+  padding: 4px 8px 12px;
+  gap: 14px;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.groupLabel {
+  padding: 0 8px 2px;
+  text-transform: none;
 }
 
 /* Category rows — match the geometry of `<SidebarRow>` so the column

--- a/packages/agents-server-ui/src/components/settings/SettingsSidebar.tsx
+++ b/packages/agents-server-ui/src/components/settings/SettingsSidebar.tsx
@@ -32,6 +32,11 @@ interface CategoryDef {
   visible: boolean
 }
 
+interface CategorySectionDef {
+  title: string | null
+  categories: ReadonlyArray<CategoryDef>
+}
+
 /**
  * Settings sidebar — replaces the regular `<Sidebar>` while the user
  * is on a `/settings/*` route. Mirrors the visual chrome of the main
@@ -63,53 +68,68 @@ export function SettingsSidebar({
     if (narrow) setCollapsed(true)
   }, [narrow, setCollapsed])
 
-  const categories: ReadonlyArray<CategoryDef> = [
+  const sections: ReadonlyArray<CategorySectionDef> = [
     {
-      id: `general`,
-      label: `General`,
-      icon: <Icon icon={SettingsIcon} size={2} />,
-      visible: true,
+      title: null,
+      categories: [
+        {
+          id: `general`,
+          label: `General`,
+          icon: <Icon icon={SettingsIcon} size={2} />,
+          visible: true,
+        },
+      ],
     },
     {
-      id: `account`,
-      label: `Account`,
-      icon: <Icon icon={UserCircle} size={2} />,
-      // Sign-in only makes sense in the desktop build; the web build
-      // doesn't have IPC to safely hold the resulting JWT.
-      visible: isDesktop,
+      title: `Setup`,
+      categories: [
+        {
+          id: `account`,
+          label: `Account`,
+          icon: <Icon icon={UserCircle} size={2} />,
+          // Sign-in only makes sense in the desktop build; the web build
+          // doesn't have IPC to safely hold the resulting JWT.
+          visible: isDesktop,
+        },
+        {
+          id: `servers`,
+          label: `Servers`,
+          icon: <Icon icon={Server} size={2} />,
+          visible: true,
+        },
+        {
+          id: `credentials`,
+          label: `Credentials`,
+          icon: <Icon icon={KeyRound} size={2} />,
+          visible: true,
+        },
+        {
+          id: `local-runtime`,
+          label: `Local Runtime`,
+          icon: <Icon icon={Brain} size={2} />,
+          visible: isDesktop,
+        },
+        {
+          id: `mcp-servers`,
+          label: `MCP Servers`,
+          icon: <Plug size={14} />,
+          // Push-based view of the in-process MCP registry — desktop only.
+          // The web build doesn't have access to BuiltinAgentsServer's
+          // registry over IPC, and remote runtimes are no longer aggregated.
+          visible: isDesktop,
+        },
+      ],
     },
     {
-      id: `servers`,
-      label: `Servers`,
-      icon: <Icon icon={Server} size={2} />,
-      visible: true,
-    },
-    {
-      id: `credentials`,
-      label: `Credentials`,
-      icon: <Icon icon={KeyRound} size={2} />,
-      visible: true,
-    },
-    {
-      id: `appearance`,
-      label: `Appearance`,
-      icon: <Icon icon={Palette} size={2} />,
-      visible: true,
-    },
-    {
-      id: `local-runtime`,
-      label: `Local Runtime`,
-      icon: <Icon icon={Brain} size={2} />,
-      visible: isDesktop,
-    },
-    {
-      id: `mcp-servers`,
-      label: `MCP Servers`,
-      icon: <Plug size={14} />,
-      // Push-based view of the in-process MCP registry — desktop only.
-      // The web build doesn't have access to BuiltinAgentsServer's
-      // registry over IPC, and remote runtimes are no longer aggregated.
-      visible: isDesktop,
+      title: `Preferences`,
+      categories: [
+        {
+          id: `appearance`,
+          label: `Appearance`,
+          icon: <Icon icon={Palette} size={2} />,
+          visible: true,
+        },
+      ],
     },
   ]
 
@@ -146,27 +166,47 @@ export function SettingsSidebar({
 
         <ScrollArea className={styles.scrollFlex}>
           <Stack direction="column" className={styles.list}>
-            {categories
-              .filter((c) => c.visible)
-              .map((c) => (
-                <button
-                  key={c.id}
-                  type="button"
-                  onClick={() => {
-                    navigate({
-                      to: `/settings/$category`,
-                      params: { category: c.id },
-                    })
-                    closeIfOverlay()
-                  }}
-                  className={`${styles.row} ${
-                    activeCategory === c.id ? styles.rowActive : ``
-                  }`}
-                >
-                  <span className={styles.iconSlot}>{c.icon}</span>
-                  <span className={styles.label}>{c.label}</span>
-                </button>
-              ))}
+            {sections.map((section) => {
+              const visibleCategories = section.categories.filter(
+                (c) => c.visible
+              )
+              if (visibleCategories.length === 0) return null
+              return (
+                <div key={section.title ?? `root`} className={styles.group}>
+                  {section.title && (
+                    <Text
+                      size={1}
+                      tone="muted"
+                      weight="medium"
+                      className={styles.groupLabel}
+                    >
+                      {section.title}
+                    </Text>
+                  )}
+                  <Stack direction="column" gap={1}>
+                    {visibleCategories.map((c) => (
+                      <button
+                        key={c.id}
+                        type="button"
+                        onClick={() => {
+                          navigate({
+                            to: `/settings/$category`,
+                            params: { category: c.id },
+                          })
+                          closeIfOverlay()
+                        }}
+                        className={`${styles.row} ${
+                          activeCategory === c.id ? styles.rowActive : ``
+                        }`}
+                      >
+                        <span className={styles.iconSlot}>{c.icon}</span>
+                        <span className={styles.label}>{c.label}</span>
+                      </button>
+                    ))}
+                  </Stack>
+                </div>
+              )
+            })}
           </Stack>
         </ScrollArea>
       </Stack>

--- a/packages/agents-server-ui/src/components/settings/pages/AccountPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/AccountPage.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from 'react'
 import { ExternalLink, Github, LogOut } from 'lucide-react'
 import { Badge, Button, Icon, Stack, Text } from '../../../ui'
-import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
+import {
+  SettingsActions,
+  SettingsPanel,
+  SettingsRow,
+  SettingsScreen,
+  SettingsSection,
+} from '../SettingsScreen'
 import {
   cloudOpenDashboard,
   cloudSignIn,
@@ -49,12 +55,12 @@ export function AccountPage(): React.ReactElement {
           title="Electric Cloud"
           description="Sign-in is only available in the desktop build of Electric Agents."
         >
-          <div style={{ padding: `16px` }}>
+          <SettingsPanel>
             <Text size={2} tone="muted">
               Open this app in the desktop runtime to sign in to your Electric
               Cloud account.
             </Text>
-          </div>
+          </SettingsPanel>
         </SettingsSection>
       </SettingsScreen>
     )
@@ -76,7 +82,7 @@ export function AccountPage(): React.ReactElement {
         }
       >
         {isSignedIn ? (
-          <Stack direction="column" gap={3} style={{ padding: `16px` }}>
+          <>
             <SettingsRow
               label="Account"
               description={
@@ -118,7 +124,7 @@ export function AccountPage(): React.ReactElement {
                 )
               }
             />
-            <Stack direction="row" gap={2} style={{ marginTop: `8px` }}>
+            <SettingsActions>
               <Button
                 variant="solid"
                 tone="neutral"
@@ -141,48 +147,50 @@ export function AccountPage(): React.ReactElement {
                 <Icon icon={LogOut} size={2} />
                 Sign out
               </Button>
-            </Stack>
-          </Stack>
+            </SettingsActions>
+          </>
         ) : (
-          <Stack direction="column" gap={3} style={{ padding: `16px` }}>
-            {state?.error && (
-              <Text size={2} tone="danger">
-                {state.error}
-              </Text>
-            )}
-            <Stack direction="row" gap={2}>
-              <Button
-                variant="solid"
-                tone="neutral"
-                size={2}
-                disabled={isBusy}
-                onClick={() => {
-                  void cloudSignIn(`github`)
-                }}
-              >
-                <Icon icon={Github} size={2} />
-                Sign in with GitHub
-              </Button>
-              <Button
-                variant="soft"
-                tone="neutral"
-                size={2}
-                disabled={isBusy}
-                onClick={() => {
-                  void cloudSignIn(`google`)
-                }}
-              >
-                Sign in with Google
-              </Button>
-            </Stack>
-            <Text size={1} tone="muted">
-              Opens a sign-in window pointed at{` `}
+          <SettingsPanel>
+            <Stack direction="column" gap={3}>
+              {state?.error && (
+                <Text size={2} tone="danger">
+                  {state.error}
+                </Text>
+              )}
+              <Stack direction="row" gap={2}>
+                <Button
+                  variant="solid"
+                  tone="neutral"
+                  size={2}
+                  disabled={isBusy}
+                  onClick={() => {
+                    void cloudSignIn(`github`)
+                  }}
+                >
+                  <Icon icon={Github} size={2} />
+                  Sign in with GitHub
+                </Button>
+                <Button
+                  variant="soft"
+                  tone="neutral"
+                  size={2}
+                  disabled={isBusy}
+                  onClick={() => {
+                    void cloudSignIn(`google`)
+                  }}
+                >
+                  Sign in with Google
+                </Button>
+              </Stack>
               <Text size={1} tone="muted">
-                dashboard.electric-sql.cloud
+                Opens a sign-in window pointed at{` `}
+                <Text size={1} tone="muted">
+                  dashboard.electric-sql.cloud
+                </Text>
+                . The window closes automatically once you've authorized.
               </Text>
-              . The window closes automatically once you've authorized.
-            </Text>
-          </Stack>
+            </Stack>
+          </SettingsPanel>
         )}
       </SettingsSection>
     </SettingsScreen>

--- a/packages/agents-server-ui/src/components/settings/pages/AccountPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/AccountPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react'
 import { ExternalLink, Github, LogOut } from 'lucide-react'
-import { Badge, Button, Icon, Stack, Text } from '../../../ui'
+import { Button, Icon, Stack, Text } from '../../../ui'
 import {
   SettingsActions,
   SettingsPanel,
   SettingsRow,
   SettingsScreen,
   SettingsSection,
+  SettingsStatusBadge,
 } from '../SettingsScreen'
 import {
   cloudOpenDashboard,
@@ -91,9 +92,9 @@ export function AccountPage(): React.ReactElement {
                   : (state?.name ?? state?.email ?? `Signed in`)
               }
               control={
-                <Badge tone="success" size={1}>
+                <SettingsStatusBadge tone="success">
                   Signed in
-                </Badge>
+                </SettingsStatusBadge>
               }
             />
             <SettingsRow

--- a/packages/agents-server-ui/src/components/settings/pages/AppearancePage.module.css
+++ b/packages/agents-server-ui/src/components/settings/pages/AppearancePage.module.css
@@ -6,7 +6,7 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
-  padding: 16px;
+  padding: 12px 16px;
 }
 
 .tile {

--- a/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
@@ -6,7 +6,11 @@ import {
   type ApiKeysStatus,
 } from '../../../lib/server-connection'
 import { Text } from '../../../ui'
-import { SettingsScreen, SettingsSection } from '../SettingsScreen'
+import {
+  SettingsPanel,
+  SettingsScreen,
+  SettingsSection,
+} from '../SettingsScreen'
 
 export function CredentialsPage(): React.ReactElement {
   const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
@@ -36,53 +40,52 @@ export function CredentialsPage(): React.ReactElement {
         }
       >
         {!isDesktop ? (
-          <div style={{ padding: `16px` }}>
+          <SettingsPanel>
             <Text size={2} tone="muted">
               No editable provider keys in the web build.
             </Text>
-          </div>
+          </SettingsPanel>
         ) : !status ? (
-          <div style={{ padding: `16px` }}>
+          <SettingsPanel>
             <Text size={2} tone="muted">
               Loading…
             </Text>
-          </div>
+          </SettingsPanel>
         ) : (
-          <div style={{ padding: `16px` }}>
-            <ApiKeysForm
-              key={savedAt ?? `initial`}
-              initial={{
-                anthropic:
-                  status.saved.anthropic ?? status.suggested.anthropic ?? ``,
-                openai: status.saved.openai ?? status.suggested.openai ?? ``,
-                deepseek:
-                  status.saved.deepseek ?? status.suggested.deepseek ?? ``,
-                brave: status.saved.brave ?? status.suggested.brave ?? ``,
-              }}
-              showSuggestionHint={
-                !status.hasAnyKey &&
-                Boolean(
-                  status.suggested.anthropic ||
-                    status.suggested.openai ||
-                    status.suggested.deepseek ||
-                    status.suggested.brave
-                )
-              }
-              onSave={async ({ anthropic, openai, deepseek, brave }) => {
-                await persistApiKeys({
-                  anthropic: anthropic.trim() || null,
-                  openai: openai.trim() || null,
-                  deepseek: deepseek.trim() || null,
-                  brave: brave.trim() || null,
-                })
-                const next = await loadApiKeysStatus()
-                if (next) setStatus(next)
-                setSavedAt(Date.now())
-              }}
-              saveLabel="Save changes"
-              savingLabel="Saving…"
-            />
-          </div>
+          <ApiKeysForm
+            key={savedAt ?? `initial`}
+            layout="settings"
+            initial={{
+              anthropic:
+                status.saved.anthropic ?? status.suggested.anthropic ?? ``,
+              openai: status.saved.openai ?? status.suggested.openai ?? ``,
+              deepseek:
+                status.saved.deepseek ?? status.suggested.deepseek ?? ``,
+              brave: status.saved.brave ?? status.suggested.brave ?? ``,
+            }}
+            showSuggestionHint={
+              !status.hasAnyKey &&
+              Boolean(
+                status.suggested.anthropic ||
+                  status.suggested.openai ||
+                  status.suggested.deepseek ||
+                  status.suggested.brave
+              )
+            }
+            onSave={async ({ anthropic, openai, deepseek, brave }) => {
+              await persistApiKeys({
+                anthropic: anthropic.trim() || null,
+                openai: openai.trim() || null,
+                deepseek: deepseek.trim() || null,
+                brave: brave.trim() || null,
+              })
+              const next = await loadApiKeysStatus()
+              if (next) setStatus(next)
+              setSavedAt(Date.now())
+            }}
+            saveLabel="Save changes"
+            savingLabel="Saving…"
+          />
         )}
       </SettingsSection>
     </SettingsScreen>

--- a/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
@@ -1,8 +1,18 @@
 import { useState } from 'react'
-import { Trash2 } from 'lucide-react'
+import { useNavigate } from '@tanstack/react-router'
+import {
+  Brain,
+  KeyRound,
+  Palette,
+  Plug,
+  Server,
+  Trash2,
+  UserCircle,
+} from 'lucide-react'
 import { Button, ConfirmDialog, Icon, Stack, Text } from '../../../ui'
 import { clearAllLocalData } from '../../../lib/server-connection'
 import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
+import type { SettingsCategoryId } from '../SettingsSidebar'
 
 /**
  * Settings → General. Currently surfaces the provider API keys for
@@ -16,6 +26,7 @@ import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
  * an explanatory message instead.
  */
 export function GeneralPage(): React.ReactElement {
+  const navigate = useNavigate()
   const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
   const [isClearing, setIsClearing] = useState(false)
   const [showResetConfirm, setShowResetConfirm] = useState(false)
@@ -36,19 +47,72 @@ export function GeneralPage(): React.ReactElement {
   return (
     <>
       <SettingsScreen title="General">
-        <SettingsSection
-          title="Startup"
-          description="General app-level preferences will live here as the desktop settings model expands."
-        >
-          <div style={{ padding: `16px` }}>
-            <Text size={2} tone="muted">
-              Connected servers are restored on launch and kept alive from the
-              tray when all windows are closed.
-            </Text>
-          </div>
+        <SettingsSection title="Setup">
+          {isDesktop && (
+            <SettingsLinkRow
+              icon={UserCircle}
+              label="Account"
+              description="Sign in to Electric Cloud and manage workspace access."
+              category="account"
+              onNavigate={(category) =>
+                navigate({ to: `/settings/$category`, params: { category } })
+              }
+            />
+          )}
+          <SettingsLinkRow
+            icon={Server}
+            label="Servers"
+            description="Connect to local, self-hosted, and Electric Cloud agents servers."
+            category="servers"
+            onNavigate={(category) =>
+              navigate({ to: `/settings/$category`, params: { category } })
+            }
+          />
+          <SettingsLinkRow
+            icon={KeyRound}
+            label="Credentials"
+            description="Configure model provider keys for local agents."
+            category="credentials"
+            onNavigate={(category) =>
+              navigate({ to: `/settings/$category`, params: { category } })
+            }
+          />
+          {isDesktop && (
+            <SettingsLinkRow
+              icon={Brain}
+              label="Local Runtime"
+              description="Inspect and control the bundled local runtime."
+              category="local-runtime"
+              onNavigate={(category) =>
+                navigate({ to: `/settings/$category`, params: { category } })
+              }
+            />
+          )}
+          {isDesktop && (
+            <SettingsLinkRow
+              icon={Plug}
+              label="MCP Servers"
+              description="Manage tools available to local agents."
+              category="mcp-servers"
+              onNavigate={(category) =>
+                navigate({ to: `/settings/$category`, params: { category } })
+              }
+            />
+          )}
+        </SettingsSection>
+        <SettingsSection title="Preferences">
+          <SettingsLinkRow
+            icon={Palette}
+            label="Appearance"
+            description="Choose theme and visual preferences."
+            category="appearance"
+            onNavigate={(category) =>
+              navigate({ to: `/settings/$category`, params: { category } })
+            }
+          />
         </SettingsSection>
         <SettingsSection
-          title="Local data"
+          title="Reset"
           description="Reset this desktop app back to first-run setup."
         >
           <Stack direction="column" gap={3} style={{ padding: `16px` }}>
@@ -99,5 +163,40 @@ export function GeneralPage(): React.ReactElement {
         }}
       />
     </>
+  )
+}
+
+function SettingsLinkRow({
+  icon,
+  label,
+  description,
+  category,
+  onNavigate,
+}: {
+  icon: typeof Server
+  label: string
+  description: string
+  category: SettingsCategoryId
+  onNavigate: (category: SettingsCategoryId) => void
+}): React.ReactElement {
+  return (
+    <SettingsRow
+      label={
+        <span style={{ display: `inline-flex`, alignItems: `center`, gap: 8 }}>
+          <Icon icon={icon} size={2} />
+          {label}
+        </span>
+      }
+      description={description}
+      control={
+        <Button
+          variant="soft"
+          tone="neutral"
+          onClick={() => onNavigate(category)}
+        >
+          Open
+        </Button>
+      }
+    />
   )
 }

--- a/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
@@ -9,9 +9,14 @@ import {
   Trash2,
   UserCircle,
 } from 'lucide-react'
-import { Button, ConfirmDialog, Icon, Stack, Text } from '../../../ui'
+import { Button, ConfirmDialog, Icon, Text } from '../../../ui'
 import { clearAllLocalData } from '../../../lib/server-connection'
-import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
+import {
+  SettingsPanel,
+  SettingsRow,
+  SettingsScreen,
+  SettingsSection,
+} from '../SettingsScreen'
 import type { SettingsCategoryId } from '../SettingsSidebar'
 
 /**
@@ -115,33 +120,33 @@ export function GeneralPage(): React.ReactElement {
           title="Reset"
           description="Reset this desktop app back to first-run setup."
         >
-          <Stack direction="column" gap={3} style={{ padding: `16px` }}>
-            <SettingsRow
-              label="Clear all local data"
-              description={
-                isDesktop
-                  ? `Deletes saved settings, API keys, server connections, and sign-in state. The app will restart into onboarding.`
-                  : `Only available in the desktop app.`
-              }
-              control={
-                <Button
-                  variant="soft"
-                  tone="danger"
-                  size={2}
-                  disabled={!isDesktop || isClearing}
-                  onClick={() => setShowResetConfirm(true)}
-                >
-                  <Icon icon={Trash2} size={2} />
-                  {isClearing ? `Restarting…` : `Clear all local data`}
-                </Button>
-              }
-            />
-            {error && (
+          <SettingsRow
+            label="Clear all local data"
+            description={
+              isDesktop
+                ? `Deletes saved settings, API keys, server connections, and sign-in state. The app will restart into onboarding.`
+                : `Only available in the desktop app.`
+            }
+            control={
+              <Button
+                variant="soft"
+                tone="danger"
+                size={2}
+                disabled={!isDesktop || isClearing}
+                onClick={() => setShowResetConfirm(true)}
+              >
+                <Icon icon={Trash2} size={2} />
+                {isClearing ? `Restarting…` : `Clear all local data`}
+              </Button>
+            }
+          />
+          {error && (
+            <SettingsPanel>
               <Text size={2} tone="danger">
                 {error}
               </Text>
-            )}
-          </Stack>
+            </SettingsPanel>
+          )}
         </SettingsSection>
       </SettingsScreen>
 

--- a/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
@@ -1,5 +1,8 @@
-import { Text } from '../../../ui'
-import { SettingsScreen, SettingsSection } from '../SettingsScreen'
+import { useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { Button, Dialog, Icon, Stack, Text } from '../../../ui'
+import { clearAllLocalData } from '../../../lib/server-connection'
+import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
 
 /**
  * Settings → General. Currently surfaces the provider API keys for
@@ -13,19 +16,110 @@ import { SettingsScreen, SettingsSection } from '../SettingsScreen'
  * an explanatory message instead.
  */
 export function GeneralPage(): React.ReactElement {
+  const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
+  const [isClearing, setIsClearing] = useState(false)
+  const [showResetConfirm, setShowResetConfirm] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleClearAllLocalData = async (): Promise<void> => {
+    setError(null)
+    setIsClearing(true)
+    try {
+      await clearAllLocalData()
+    } catch (err) {
+      setIsClearing(false)
+      setShowResetConfirm(false)
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
   return (
-    <SettingsScreen title="General">
-      <SettingsSection
-        title="Startup"
-        description="General app-level preferences will live here as the desktop settings model expands."
+    <>
+      <SettingsScreen title="General">
+        <SettingsSection
+          title="Startup"
+          description="General app-level preferences will live here as the desktop settings model expands."
+        >
+          <div style={{ padding: `16px` }}>
+            <Text size={2} tone="muted">
+              Connected servers are restored on launch and kept alive from the
+              tray when all windows are closed.
+            </Text>
+          </div>
+        </SettingsSection>
+        <SettingsSection
+          title="Local data"
+          description="Reset this desktop app back to first-run setup."
+        >
+          <Stack direction="column" gap={3} style={{ padding: `16px` }}>
+            <SettingsRow
+              label="Clear all local data"
+              description={
+                isDesktop
+                  ? `Deletes saved settings, API keys, server connections, and sign-in state. The app will restart into onboarding.`
+                  : `Only available in the desktop app.`
+              }
+              control={
+                <Button
+                  variant="soft"
+                  tone="danger"
+                  size={2}
+                  disabled={!isDesktop || isClearing}
+                  onClick={() => setShowResetConfirm(true)}
+                >
+                  <Icon icon={Trash2} size={2} />
+                  {isClearing ? `Restarting…` : `Clear all local data`}
+                </Button>
+              }
+            />
+            {error && (
+              <Text size={2} tone="danger">
+                {error}
+              </Text>
+            )}
+          </Stack>
+        </SettingsSection>
+      </SettingsScreen>
+
+      <Dialog.Root
+        open={showResetConfirm}
+        onOpenChange={(open) => {
+          if (!isClearing) setShowResetConfirm(open)
+        }}
       >
-        <div style={{ padding: `16px` }}>
-          <Text size={2} tone="muted">
-            Connected servers are restored on launch and kept alive from the
-            tray when all windows are closed.
-          </Text>
-        </div>
-      </SettingsSection>
-    </SettingsScreen>
+        <Dialog.Content maxWidth={440}>
+          <Dialog.Title>Clear all local data?</Dialog.Title>
+          <Dialog.Description>
+            This deletes saved settings, API keys, server connections, and
+            sign-in state. Electric Agents will restart and return to the
+            onboarding flow.
+          </Dialog.Description>
+          <Stack justify="end" gap={2}>
+            <Dialog.Close
+              render={
+                <Button variant="soft" tone="neutral" disabled={isClearing}>
+                  Cancel
+                </Button>
+              }
+            />
+            <Button
+              tone="danger"
+              disabled={isClearing}
+              onClick={() => {
+                void handleClearAllLocalData()
+              }}
+            >
+              <Icon icon={Trash2} size={2} />
+              {isClearing ? `Restarting…` : `Clear data and restart`}
+            </Button>
+          </Stack>
+          {error && (
+            <Text size={2} tone="danger">
+              {error}
+            </Text>
+          )}
+        </Dialog.Content>
+      </Dialog.Root>
+    </>
   )
 }

--- a/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Trash2 } from 'lucide-react'
-import { Button, Dialog, Icon, Stack, Text } from '../../../ui'
+import { Button, ConfirmDialog, Icon, Stack, Text } from '../../../ui'
 import { clearAllLocalData } from '../../../lib/server-connection'
 import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
 
@@ -81,45 +81,23 @@ export function GeneralPage(): React.ReactElement {
         </SettingsSection>
       </SettingsScreen>
 
-      <Dialog.Root
+      <ConfirmDialog
         open={showResetConfirm}
         onOpenChange={(open) => {
           if (!isClearing) setShowResetConfirm(open)
         }}
-      >
-        <Dialog.Content maxWidth={440}>
-          <Dialog.Title>Clear all local data?</Dialog.Title>
-          <Dialog.Description>
-            This deletes saved settings, API keys, server connections, and
-            sign-in state. Electric Agents will restart and return to the
-            onboarding flow.
-          </Dialog.Description>
-          <Stack justify="end" gap={2}>
-            <Dialog.Close
-              render={
-                <Button variant="soft" tone="neutral" disabled={isClearing}>
-                  Cancel
-                </Button>
-              }
-            />
-            <Button
-              tone="danger"
-              disabled={isClearing}
-              onClick={() => {
-                void handleClearAllLocalData()
-              }}
-            >
-              <Icon icon={Trash2} size={2} />
-              {isClearing ? `Restarting…` : `Clear data and restart`}
-            </Button>
-          </Stack>
-          {error && (
-            <Text size={2} tone="danger">
-              {error}
-            </Text>
-          )}
-        </Dialog.Content>
-      </Dialog.Root>
+        title="Clear all local data?"
+        description="This deletes saved settings, API keys, server connections, and sign-in state. Electric Agents will restart and return to the onboarding flow."
+        confirmLabel="Clear data and restart"
+        loadingLabel="Restarting..."
+        confirmTone="danger"
+        confirmIcon={Trash2}
+        loading={isClearing}
+        error={error}
+        onConfirm={() => {
+          void handleClearAllLocalData()
+        }}
+      />
     </>
   )
 }

--- a/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
@@ -17,18 +17,20 @@ import {
   type ElectricRunnerRuntimeDiagnostics,
 } from '../../../lib/ElectricAgentsProvider'
 import { formatRelativeTime } from '../../../lib/formatTime'
-import { Badge, Button, Icon, Select, Stack, Text } from '../../../ui'
+import { Button, Icon, Select, Stack, Text } from '../../../ui'
 import {
   SettingsPanel,
   SettingsRow,
   SettingsScreen,
   SettingsSection,
+  SettingsStatusBadge,
+  type SettingsStatusTone,
 } from '../SettingsScreen'
 import type { ServerConfig } from '../../../lib/types'
 
 const STATUS_TONES: Record<
   LocalRuntimeStatus,
-  { label: string; tone: `success` | `warning` | `danger` | `info` | `neutral` }
+  { label: string; tone: SettingsStatusTone }
 > = {
   running: { label: `Running`, tone: `success` },
   starting: { label: `Starting`, tone: `info` },
@@ -39,7 +41,7 @@ const STATUS_TONES: Record<
 
 const RUNNER_HEALTH_TONES: Record<
   `healthy` | `degraded` | `unhealthy` | `unknown`,
-  { label: string; tone: `success` | `warning` | `danger` | `neutral` }
+  { label: string; tone: SettingsStatusTone }
 > = {
   healthy: { label: `Healthy`, tone: `success` },
   degraded: { label: `Degraded`, tone: `warning` },
@@ -309,7 +311,11 @@ export function LocalRuntimePage(): React.ReactElement {
         <SettingsRow
           label="Runtime"
           description={`The bundled Horton runtime is currently ${statusInfo.label.toLowerCase()}.`}
-          control={<Badge tone={statusInfo.tone}>{statusInfo.label}</Badge>}
+          control={
+            <SettingsStatusBadge tone={statusInfo.tone}>
+              {statusInfo.label}
+            </SettingsStatusBadge>
+          }
         />
         <SettingsRow
           label="Connection"
@@ -350,7 +356,11 @@ export function LocalRuntimePage(): React.ReactElement {
           description={
             health.issues.length > 0 ? health.issues.join(`, `) : `No issues`
           }
-          control={<Badge tone={healthTone.tone}>{healthTone.label}</Badge>}
+          control={
+            <SettingsStatusBadge tone={healthTone.tone}>
+              {healthTone.label}
+            </SettingsStatusBadge>
+          }
         />
         <SettingsRow
           label="Health endpoint"
@@ -367,7 +377,7 @@ export function LocalRuntimePage(): React.ReactElement {
           label="Stream"
           description={`Offset ${runnerTelemetry?.wake_stream_offset ?? runner?.wake_stream_offset ?? `-`}`}
           control={
-            <Badge
+            <SettingsStatusBadge
               tone={
                 diagnostics?.stream_connected === false
                   ? `warning`
@@ -381,7 +391,7 @@ export function LocalRuntimePage(): React.ReactElement {
                 : diagnostics?.stream_connected === true
                   ? `Connected`
                   : `Unknown`}
-            </Badge>
+            </SettingsStatusBadge>
           }
         />
         <SettingsRow
@@ -406,9 +416,11 @@ export function LocalRuntimePage(): React.ReactElement {
           label="Claims"
           description={`Succeeded ${countLabel(diagnostics?.claims_succeeded)} · skipped ${countLabel(diagnostics?.claims_skipped)} · failed ${countLabel(diagnostics?.claims_failed)}`}
           control={
-            <Badge tone={diagnostics?.claims_failed ? `danger` : `neutral`}>
+            <SettingsStatusBadge
+              tone={diagnostics?.claims_failed ? `danger` : `neutral`}
+            >
               {diagnostics?.last_claim_result ?? `none`}
-            </Badge>
+            </SettingsStatusBadge>
           }
         />
         {diagnostics?.last_error && (

--- a/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
@@ -18,7 +18,12 @@ import {
 } from '../../../lib/ElectricAgentsProvider'
 import { formatRelativeTime } from '../../../lib/formatTime'
 import { Badge, Button, Icon, Select, Stack, Text } from '../../../ui'
-import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
+import {
+  SettingsPanel,
+  SettingsRow,
+  SettingsScreen,
+  SettingsSection,
+} from '../SettingsScreen'
 import type { ServerConfig } from '../../../lib/types'
 
 const STATUS_TONES: Record<
@@ -269,12 +274,12 @@ export function LocalRuntimePage(): React.ReactElement {
           title="About"
           description="The local runtime is bundled with the Electric Agents desktop app. The web build connects to a remote agents-server instead."
         >
-          <div style={{ padding: `16px` }}>
+          <SettingsPanel>
             <Text size={2} tone="muted">
               Run Electric Agents on your machine to manage the bundled local
               Horton runtime here.
             </Text>
-          </div>
+          </SettingsPanel>
         </SettingsSection>
       </SettingsScreen>
     )
@@ -422,9 +427,9 @@ export function LocalRuntimePage(): React.ReactElement {
       <SettingsSection
         title="Controls"
         description="Restart picks up new API keys or other environment changes; stop frees the port if you'd rather connect to a different server."
-      >
-        <div style={{ padding: `16px` }}>
-          <Stack gap={2}>
+        actionAlign="description"
+        action={
+          <Stack direction="row" gap={2}>
             {canStart ? (
               <Button
                 variant="solid"
@@ -471,8 +476,8 @@ export function LocalRuntimePage(): React.ReactElement {
               <Icon icon={Square} size={2} /> Stop runtime
             </Button>
           </Stack>
-        </div>
-      </SettingsSection>
+        }
+      />
     </SettingsScreen>
   )
 }

--- a/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useSearch } from '@tanstack/react-router'
 import { eq, useLiveQuery } from '@tanstack/react-db'
 import { appendPathToUrl } from '@electric-ax/agents-runtime/client'
 import { Play, RefreshCw, Square } from 'lucide-react'
@@ -6,25 +7,29 @@ import {
   loadDesktopState,
   onDesktopStateChanged,
   type DesktopState,
+  type LocalRuntimeStatus,
 } from '../../../lib/server-connection'
 import {
+  createRunnersCollection,
   createRunnerRuntimeDiagnosticsCollection,
   useElectricAgents,
   type ElectricRunner,
   type ElectricRunnerRuntimeDiagnostics,
 } from '../../../lib/ElectricAgentsProvider'
 import { formatRelativeTime } from '../../../lib/formatTime'
-import { Badge, Button, Icon, Stack, Text } from '../../../ui'
+import { Badge, Button, Icon, Select, Stack, Text } from '../../../ui'
 import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
+import type { ServerConfig } from '../../../lib/types'
 
 const STATUS_TONES: Record<
-  DesktopState[`runtimeStatus`],
-  { label: string; tone: `success` | `warning` | `danger` | `info` }
+  LocalRuntimeStatus,
+  { label: string; tone: `success` | `warning` | `danger` | `info` | `neutral` }
 > = {
   running: { label: `Running`, tone: `success` },
   starting: { label: `Starting`, tone: `info` },
   stopped: { label: `Stopped`, tone: `warning` },
   error: { label: `Error`, tone: `danger` },
+  disabled: { label: `Disabled`, tone: `neutral` },
 }
 
 const RUNNER_HEALTH_TONES: Record<
@@ -136,9 +141,42 @@ function runnerHealthEndpoint(
  */
 export function LocalRuntimePage(): React.ReactElement {
   const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
+  const search = useSearch({ strict: false }) as { serverId?: string }
+  const requestedServerId = search.serverId ?? null
   const [state, setState] = useState<DesktopState | null>(null)
+  const [selectedServerId, setSelectedServerId] = useState<string | null>(null)
   const [now, setNow] = useState(() => Date.now())
-  const { runnersCollection } = useElectricAgents()
+  const { runnersCollection: activeRunnersCollection } = useElectricAgents()
+  const runtimeServers = useMemo(
+    () =>
+      (state?.servers ?? []).filter(
+        (server) => server.localRuntimeEnabled !== false
+      ),
+    [state?.servers]
+  )
+  const selectedServer =
+    runtimeServers.find((server) => server.id === selectedServerId) ?? null
+  const connectionByServerId = useMemo(
+    () =>
+      new Map(
+        (state?.connections ?? []).map((entry) => [entry.serverId, entry])
+      ),
+    [state?.connections]
+  )
+  const selectedConnection = selectedServer
+    ? (connectionByServerId.get(selectedServer.id) ?? null)
+    : null
+  const selectedRuntimeStatus: LocalRuntimeStatus =
+    selectedConnection?.localRuntimeStatus ??
+    (selectedServer?.localRuntimeEnabled === false ? `disabled` : `stopped`)
+  const selectedServerIsActive = selectedServer?.id === state?.activeServer?.id
+  const selectedServerRunnersCollection = useMemo(() => {
+    if (!selectedServer?.url || selectedServerIsActive) return null
+    return createRunnersCollection(selectedServer.url)
+  }, [selectedServer?.url, selectedServerIsActive])
+  const runnersCollection = selectedServerIsActive
+    ? activeRunnersCollection
+    : selectedServerRunnersCollection
   const runnerId = state?.pullWakeRunnerId ?? null
   const { data: runnerRows = [] } = useLiveQuery(
     (query) => {
@@ -150,17 +188,14 @@ export function LocalRuntimePage(): React.ReactElement {
     [runnersCollection, runnerId]
   )
   const runner = runnerRows[0] ?? null
-  const healthEndpoint = runnerHealthEndpoint(
-    state?.activeServer?.url,
-    runnerId
-  )
+  const healthEndpoint = runnerHealthEndpoint(selectedServer?.url, runnerId)
   const diagnosticsCollection = useMemo(() => {
-    if (!state?.activeServer?.url || !runnerId) return null
+    if (!selectedServer?.url || !runnerId) return null
     return createRunnerRuntimeDiagnosticsCollection(
-      state.activeServer.url,
+      selectedServer.url,
       runnerId
     )
-  }, [state?.activeServer?.url, runnerId])
+  }, [selectedServer?.url, runnerId])
   const { data: runtimeDiagnosticsRows = [] } = useLiveQuery(
     (query) => {
       if (!diagnosticsCollection) return undefined
@@ -187,6 +222,12 @@ export function LocalRuntimePage(): React.ReactElement {
   }, [diagnosticsCollection])
 
   useEffect(() => {
+    return () => {
+      selectedServerRunnersCollection?.cleanup()
+    }
+  }, [selectedServerRunnersCollection])
+
+  useEffect(() => {
     if (!isDesktop) return
     let cancelled = false
     void loadDesktopState().then((s) => {
@@ -199,6 +240,27 @@ export function LocalRuntimePage(): React.ReactElement {
       off?.()
     }
   }, [isDesktop])
+
+  useEffect(() => {
+    if (!state) return
+    const requestedRuntimeServer = runtimeServers.find(
+      (server) => server.id === requestedServerId
+    )
+    if (requestedRuntimeServer && selectedServerId !== requestedServerId) {
+      setSelectedServerId(requestedServerId)
+      return
+    }
+    const currentStillExists = runtimeServers.some(
+      (server) => server.id === selectedServerId
+    )
+    if (currentStillExists) return
+    const activeRuntimeServer = runtimeServers.find(
+      (server) => server.id === state.activeServer?.id
+    )
+    setSelectedServerId(
+      activeRuntimeServer?.id ?? runtimeServers[0]?.id ?? null
+    )
+  }, [requestedServerId, runtimeServers, selectedServerId, state])
 
   if (!isDesktop) {
     return (
@@ -218,14 +280,23 @@ export function LocalRuntimePage(): React.ReactElement {
     )
   }
 
-  const status = state?.runtimeStatus ?? `stopped`
-  const statusInfo = STATUS_TONES[status]
-  const isRunning = status === `running`
-  const isStarting = status === `starting`
+  const statusInfo = STATUS_TONES[selectedRuntimeStatus]
+  const isRunning = selectedRuntimeStatus === `running`
+  const isStarting = selectedRuntimeStatus === `starting`
+  const isDisabled = selectedRuntimeStatus === `disabled`
   const canStart = !isRunning && !isStarting
 
   return (
-    <SettingsScreen title="Local Runtime">
+    <SettingsScreen
+      title="Local Runtime"
+      action={
+        <RuntimeServerSelect
+          servers={runtimeServers}
+          value={selectedServerId}
+          onValueChange={setSelectedServerId}
+        />
+      }
+    >
       <SettingsSection
         title="Status"
         description="The Electron app starts a local Horton runtime in-process so the desktop UI works without an external agents-server."
@@ -240,16 +311,16 @@ export function LocalRuntimePage(): React.ReactElement {
           description="The runtime connects to the selected agents-server and receives wake events over pull-wake."
           control={
             <Text size={1} family={`mono`} tone={`muted`}>
-              {runtimeConnectionLabel(state?.runtimeUrl)}
+              {runtimeConnectionLabel(selectedConnection?.runtimeUrl)}
             </Text>
           }
         />
-        {state?.error && (
+        {selectedConnection?.runtimeError && (
           <SettingsRow
             label="Error"
             control={
               <Text size={1} tone={`danger`}>
-                {state.error}
+                {selectedConnection.runtimeError}
               </Text>
             }
           />
@@ -279,6 +350,7 @@ export function LocalRuntimePage(): React.ReactElement {
         <SettingsRow
           label="Health endpoint"
           description="GET endpoint on the selected agents-server for runner diagnostics."
+          wrapControlValue
           control={
             <Text size={1} family="mono" tone="muted">
               {healthEndpoint ?? `-`}
@@ -356,7 +428,14 @@ export function LocalRuntimePage(): React.ReactElement {
               <Button
                 variant="solid"
                 tone="accent"
-                onClick={() => void window.electronAPI?.restartRuntime?.()}
+                onClick={() =>
+                  selectedServer
+                    ? void window.electronAPI?.restartServerRuntime?.(
+                        selectedServer.id
+                      )
+                    : undefined
+                }
+                disabled={!selectedServer || isDisabled}
               >
                 <Icon icon={Play} size={2} /> Start runtime
               </Button>
@@ -364,8 +443,14 @@ export function LocalRuntimePage(): React.ReactElement {
               <Button
                 variant="soft"
                 tone="neutral"
-                onClick={() => void window.electronAPI?.restartRuntime?.()}
-                disabled={isStarting}
+                onClick={() =>
+                  selectedServer
+                    ? void window.electronAPI?.restartServerRuntime?.(
+                        selectedServer.id
+                      )
+                    : undefined
+                }
+                disabled={!selectedServer || isStarting || isDisabled}
               >
                 <Icon icon={RefreshCw} size={2} /> Restart runtime
               </Button>
@@ -373,8 +458,14 @@ export function LocalRuntimePage(): React.ReactElement {
             <Button
               variant="soft"
               tone="neutral"
-              onClick={() => void window.electronAPI?.stopRuntime?.()}
-              disabled={!isRunning && !isStarting}
+              onClick={() =>
+                selectedServer
+                  ? void window.electronAPI?.stopServerRuntime?.(
+                      selectedServer.id
+                    )
+                  : undefined
+              }
+              disabled={!selectedServer || (!isRunning && !isStarting)}
             >
               <Icon icon={Square} size={2} /> Stop runtime
             </Button>
@@ -382,5 +473,38 @@ export function LocalRuntimePage(): React.ReactElement {
         </div>
       </SettingsSection>
     </SettingsScreen>
+  )
+}
+
+function RuntimeServerSelect({
+  servers,
+  value,
+  onValueChange,
+}: {
+  servers: Array<ServerConfig>
+  value: string | null
+  onValueChange: (value: string | null) => void
+}): React.ReactElement {
+  const labelById = useMemo(
+    () => new Map(servers.map((server) => [server.id, server.name])),
+    [servers]
+  )
+  return (
+    <Select.Root value={value} onValueChange={onValueChange}>
+      <Select.Trigger
+        placeholder="No local runtimes"
+        renderValue={(selected) =>
+          selected ? (labelById.get(selected) ?? selected) : `No local runtimes`
+        }
+        style={{ minWidth: 220 }}
+      />
+      <Select.Content>
+        {servers.map((server) => (
+          <Select.Item key={server.id} value={server.id}>
+            {server.name}
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
   )
 }

--- a/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
@@ -351,6 +351,7 @@ export function LocalRuntimePage(): React.ReactElement {
           label="Health endpoint"
           description="GET endpoint on the selected agents-server for runner diagnostics."
           wrapControlValue
+          splitLayout
           control={
             <Text size={1} family="mono" tone="muted">
               {healthEndpoint ?? `-`}

--- a/packages/agents-server-ui/src/components/settings/pages/McpServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/McpServersPage.tsx
@@ -5,7 +5,7 @@ import {
   type UseMcpServersIpcResult,
 } from '../../../hooks/useMcpServersIpc'
 import type { McpServerRow, McpStatus } from '../../../hooks/mcpServerTypes'
-import { Badge, Button, Text } from '../../../ui'
+import { Button, Text } from '../../../ui'
 import {
   SettingsActions,
   SettingsInset,
@@ -13,11 +13,13 @@ import {
   SettingsRow,
   SettingsScreen,
   SettingsSection,
+  SettingsStatusBadge,
+  type SettingsStatusTone,
 } from '../SettingsScreen'
 
 const STATUS_TONES: Record<
   McpStatus,
-  { label: string; tone: `success` | `warning` | `danger` | `info` | `neutral` }
+  { label: string; tone: SettingsStatusTone }
 > = {
   ready: { label: `Ready`, tone: `success` },
   connecting: { label: `Connecting`, tone: `info` },
@@ -135,7 +137,11 @@ function ServerEntry({
             </Text>
           </span>
         }
-        control={<Badge tone={statusInfo.tone}>{statusInfo.label}</Badge>}
+        control={
+          <SettingsStatusBadge tone={statusInfo.tone}>
+            {statusInfo.label}
+          </SettingsStatusBadge>
+        }
       />
 
       {/* Status-line slot — always rendered so row height stays stable. */}

--- a/packages/agents-server-ui/src/components/settings/pages/McpServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/McpServersPage.tsx
@@ -6,7 +6,14 @@ import {
 } from '../../../hooks/useMcpServersIpc'
 import type { McpServerRow, McpStatus } from '../../../hooks/mcpServerTypes'
 import { Badge, Button, Text } from '../../../ui'
-import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
+import {
+  SettingsActions,
+  SettingsInset,
+  SettingsPanel,
+  SettingsRow,
+  SettingsScreen,
+  SettingsSection,
+} from '../SettingsScreen'
 
 const STATUS_TONES: Record<
   McpStatus,
@@ -38,11 +45,11 @@ export function McpServersPage(): React.ReactElement {
           title="About"
           description="MCP server management is part of the desktop app. The web build connects to a remote agents-server instead."
         >
-          <div style={{ padding: `16px` }}>
+          <SettingsPanel>
             <Text size={2} tone="muted">
               Run Electric Agents on your machine to manage MCP servers here.
             </Text>
-          </div>
+          </SettingsPanel>
         </SettingsSection>
       </SettingsScreen>
     )
@@ -52,22 +59,22 @@ export function McpServersPage(): React.ReactElement {
     <SettingsScreen title="MCP Servers">
       {ipc.loading ? (
         <SettingsSection title="Loading">
-          <div style={{ padding: `16px` }}>
+          <SettingsPanel>
             <Text size={2} tone="muted">
               Connecting to runtime…
             </Text>
-          </div>
+          </SettingsPanel>
         </SettingsSection>
       ) : ipc.servers.length === 0 ? (
         <SettingsSection
           title="No servers"
           description="MCP servers declared in mcp.json will appear here once the runtime starts."
         >
-          <div style={{ padding: `16px` }}>
+          <SettingsPanel>
             <Text size={2} tone="muted">
               No MCP servers registered.
             </Text>
-          </div>
+          </SettingsPanel>
         </SettingsSection>
       ) : (
         <SettingsSection
@@ -132,7 +139,7 @@ function ServerEntry({
       />
 
       {/* Status-line slot — always rendered so row height stays stable. */}
-      <div style={{ padding: `0 16px 12px` }}>
+      <SettingsInset>
         {server.status === `error` && server.error ? (
           <Text size={1} tone="danger">
             {server.error.kind}: {server.error.message}
@@ -206,16 +213,9 @@ function ServerEntry({
               ))}
             </ul>
           )}
-      </div>
+      </SettingsInset>
 
-      <div
-        style={{
-          display: `flex`,
-          flexWrap: `wrap`,
-          gap: 8,
-          padding: `0 16px 16px`,
-        }}
-      >
+      <SettingsActions>
         {server.status === `disabled` ? (
           <Button
             variant="soft"
@@ -259,7 +259,7 @@ function ServerEntry({
             </Button>
           </>
         )}
-      </div>
+      </SettingsActions>
     </>
   )
 }

--- a/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
@@ -261,7 +261,7 @@ function ServerRow({
                 </Text>
               )}
             </Stack>
-            {item.url && !item.isCloud && item.url !== item.description && (
+            {item.url && item.url !== item.description && (
               <Text size={1} tone="muted" family="mono">
                 {item.url}
               </Text>

--- a/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
@@ -3,12 +3,12 @@ import {
   Brain,
   ChevronDown,
   Cloud,
+  ExternalLink,
   Laptop,
   Plug,
   RefreshCw,
-  Square,
   Trash2,
-  Zap,
+  Unplug,
 } from 'lucide-react'
 import {
   useAvailableServers,
@@ -28,6 +28,7 @@ import {
 } from '../../../ui'
 import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
 import {
+  cloudOpenCreateAgentsServer,
   prepareCloudAgentServerConnection,
   type CloudAgentServersState,
   type ConnectServerOptions,
@@ -170,11 +171,28 @@ export function ServersPage(): React.ReactElement {
           )}
         </SettingsSection>
         <SettingsSection
-          title="Add Server"
+          title="Electric Cloud"
+          description="Create a hosted agents server in Electric Cloud."
+          action={
+            <Button
+              variant="solid"
+              tone="accent"
+              disabled={!isDesktop}
+              onClick={() => {
+                void cloudOpenCreateAgentsServer()
+              }}
+            >
+              <Icon icon={ExternalLink} size={2} />
+              Create Server in Electric Cloud
+            </Button>
+          }
+        />
+        <SettingsSection
+          title="Add Local Or Self-Hosted Server"
           description={
             isDesktop
-              ? `Add a server URL manually. New connections start the local runtime by default.`
-              : `Add another agents server URL for this browser.`
+              ? `Add a local or self-hosted server URL manually. New connections start the local runtime by default.`
+              : `Add another local or self-hosted agents server URL for this browser.`
           }
         >
           <AddServerForm
@@ -302,7 +320,7 @@ function ServerRow({
               <Icon icon={RefreshCw} size={2} /> Retry
             </Button>
             <Button variant="soft" tone="neutral" onClick={onDisconnect}>
-              <Icon icon={Square} size={2} /> Disconnect
+              <Icon icon={Plug} size={2} /> Disconnect
             </Button>
           </>
         ) : isDesktop ? (
@@ -340,7 +358,7 @@ function ConnectSplitButton({
         style={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
         onClick={() => onConnect({ localRuntimeEnabled: true })}
       >
-        <Icon icon={Zap} size={2} /> Connect
+        <Icon icon={Unplug} size={2} /> Connect
       </Button>
       <Menu.Root open={open} onOpenChange={setOpen}>
         <Menu.Trigger

--- a/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
 import {
   Brain,
   ChevronDown,
@@ -21,10 +22,12 @@ import {
   ConfirmDialog,
   Field,
   Icon,
+  IconButton,
   Input,
   Menu,
   Stack,
   Text,
+  Tooltip,
 } from '../../../ui'
 import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
 import {
@@ -50,6 +53,7 @@ const STATUS_TONES: Record<
 }
 
 export function ServersPage(): React.ReactElement {
+  const navigate = useNavigate()
   const {
     addServer,
     setActiveServer,
@@ -165,6 +169,14 @@ export function ServersPage(): React.ReactElement {
                 onForget={() => {
                   if (item.server) setServerToForget(item.server)
                 }}
+                onInspectRuntime={() => {
+                  if (!item.server) return
+                  void navigate({
+                    to: `/settings/$category`,
+                    params: { category: `local-runtime` },
+                    search: { serverId: item.server.id },
+                  })
+                }}
                 isDesktop={isDesktop}
               />
             ))
@@ -233,6 +245,7 @@ function ServerRow({
   onDisconnect,
   onToggleLocalRuntime,
   onForget,
+  onInspectRuntime,
   isDesktop,
 }: {
   item: AvailableServer
@@ -241,36 +254,70 @@ function ServerRow({
   onDisconnect: () => void
   onToggleLocalRuntime: () => void
   onForget: () => void
+  onInspectRuntime: () => void
   isDesktop: boolean
 }): React.ReactElement {
   const statusInfo = STATUS_TONES[item.status]
   const connectedIntent = item.server?.desiredState === `connected`
   const canUseLocalRuntime = isDesktop && item.isSaved
+  const canInspectRuntime =
+    canUseLocalRuntime &&
+    connectedIntent &&
+    item.status === `connected` &&
+    item.server?.localRuntimeEnabled !== false
   const badgeText = item.isCloud ? item.cloudPath : item.description
   return (
     <>
       <SettingsRow
         label={item.name}
         description={
+          <Stack direction="row" gap={2} align="center">
+            <ServerKindBadge item={item} />
+            {badgeText && (
+              <Text size={1} tone="muted">
+                {badgeText}
+              </Text>
+            )}
+          </Stack>
+        }
+        control={<Badge tone={statusInfo.tone}>{statusInfo.label}</Badge>}
+      />
+      {(item.url ||
+        canUseLocalRuntime ||
+        item.connection?.runtimeError ||
+        item.connection?.lastError) && (
+        <div style={{ padding: `0 16px 12px` }}>
           <Stack direction="column" gap={1}>
-            <Stack direction="row" gap={2} align="center">
-              <ServerKindBadge item={item} />
-              {badgeText && (
-                <Text size={1} tone="muted">
-                  {badgeText}
-                </Text>
-              )}
-            </Stack>
             {item.url && item.url !== item.description && (
               <Text size={1} tone="muted" family="mono">
                 {item.url}
               </Text>
             )}
             {canUseLocalRuntime && (
-              <Text size={1} tone="muted">
-                Local runtime:{` `}
-                {runtimeStatusLabel(item.runtimeStatus)}
-              </Text>
+              <span
+                style={{
+                  display: `inline-flex`,
+                  alignItems: `center`,
+                  gap: 6,
+                }}
+              >
+                <Text size={1} tone="muted">
+                  Local runtime: {runtimeStatusLabel(item.runtimeStatus)}
+                </Text>
+                {canInspectRuntime && (
+                  <Tooltip content="Inspect local runtime">
+                    <IconButton
+                      size={1}
+                      variant="ghost"
+                      tone="neutral"
+                      onClick={onInspectRuntime}
+                      aria-label={`Inspect runtime for ${item.name}`}
+                    >
+                      <Icon icon={ExternalLink} size={1} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </span>
             )}
             {item.connection?.runtimeError && (
               <Text size={1} tone="danger">
@@ -283,9 +330,8 @@ function ServerRow({
               </Text>
             )}
           </Stack>
-        }
-        control={<Badge tone={statusInfo.tone}>{statusInfo.label}</Badge>}
-      />
+        </div>
+      )}
       <div
         style={{
           display: `flex`,

--- a/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
@@ -1,17 +1,36 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Brain, RefreshCw, Square, Trash2, Zap } from 'lucide-react'
+import { useState } from 'react'
+import {
+  Brain,
+  ChevronDown,
+  Cloud,
+  Laptop,
+  Plug,
+  RefreshCw,
+  Square,
+  Trash2,
+  Zap,
+} from 'lucide-react'
+import {
+  useAvailableServers,
+  type AvailableServer,
+} from '../../../hooks/useAvailableServers'
 import { useServerConnection } from '../../../hooks/useServerConnection'
-import { Badge, Button, Field, Icon, Input, Stack, Text } from '../../../ui'
+import {
+  Badge,
+  Button,
+  ConfirmDialog,
+  Field,
+  Icon,
+  Input,
+  Menu,
+  Stack,
+  Text,
+} from '../../../ui'
 import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
 import {
-  loadCloudAgentServersState,
-  loadDesktopState,
-  onCloudAgentServersStateChanged,
-  onDesktopStateChanged,
   prepareCloudAgentServerConnection,
-  type CloudAgentServer,
   type CloudAgentServersState,
-  type DiscoveredServer,
+  type ConnectServerOptions,
   type LocalRuntimeStatus,
   type ServerConnectionStatus,
 } from '../../../lib/server-connection'
@@ -31,268 +50,218 @@ const STATUS_TONES: Record<
 
 export function ServersPage(): React.ReactElement {
   const {
-    servers,
-    activeServer,
-    connected,
-    connections,
     addServer,
     setActiveServer,
     connectServer,
     disconnectServer,
-    removeServer,
+    forgetServer,
     updateServer,
   } = useServerConnection()
-  const [discovered, setDiscovered] = useState<Array<DiscoveredServer>>([])
+  const { servers, cloudState } = useAvailableServers()
   const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
-  const connectionByServer = useMemo(
-    () => new Map(connections.map((entry) => [entry.serverId, entry])),
-    [connections]
-  )
-  const savedUrls = useMemo(() => new Set(servers.map((s) => s.url)), [servers])
-  const savedCloudTenantIds = useMemo(
-    () =>
-      new Set(
-        servers
-          .filter((s) => s.source === `electric-cloud` && s.tenantId)
-          .map((s) => s.tenantId as string)
-      ),
-    [servers]
-  )
-  const newDiscovered = useMemo(
-    () =>
-      discovered
-        .filter((entry) => !savedUrls.has(entry.url))
-        .sort((a, b) => a.port - b.port),
-    [discovered, savedUrls]
-  )
-  const statusForServer = (server: ServerConfig): ServerConnectionStatus => {
-    const stored = connectionByServer.get(server.id)?.status
-    if (stored) return stored
-    if (!isDesktop && server.id === activeServer?.id) {
-      return connected ? `connected` : `offline`
-    }
-    return server.desiredState === `connected` ? `offline` : `disconnected`
-  }
-  const runtimeStatusForServer = (server: ServerConfig): LocalRuntimeStatus => {
-    if (!isDesktop) return `disabled`
-    return (
-      connectionByServer.get(server.id)?.localRuntimeStatus ??
-      (server.localRuntimeEnabled ? `stopped` : `disabled`)
-    )
-  }
-
-  useEffect(() => {
-    if (!isDesktop) return
-    let cancelled = false
-    void loadDesktopState().then((state) => {
-      if (!cancelled) setDiscovered(state?.discoveredServers ?? [])
-    })
-    const off = onDesktopStateChanged((state) =>
-      setDiscovered(state.discoveredServers ?? [])
-    )
-    return () => {
-      cancelled = true
-      off?.()
-    }
-  }, [isDesktop])
-
-  const [cloudAgents, setCloudAgents] = useState<CloudAgentServersState | null>(
+  const [serverToForget, setServerToForget] = useState<ServerConfig | null>(
     null
   )
-  useEffect(() => {
-    if (!isDesktop) return
-    let cancelled = false
-    void loadCloudAgentServersState().then((state) => {
-      if (!cancelled) setCloudAgents(state)
-    })
-    const off = onCloudAgentServersStateChanged((next) => {
-      setCloudAgents(next)
-    })
-    return () => {
-      cancelled = true
-      off?.()
+
+  const connectAvailableServer = async (
+    item: AvailableServer,
+    options: ConnectServerOptions
+  ): Promise<void> => {
+    if (item.server) {
+      connectServer(item.server.id, options)
+      return
     }
-  }, [isDesktop])
+    if (item.cloudServer) {
+      const result = await prepareCloudAgentServerConnection(
+        item.cloudServer.id
+      )
+      if (!result) throw new Error(`Could not prepare the cloud connection.`)
+      addServer(
+        {
+          name: item.cloudServer.name,
+          url: result.url,
+          source: `electric-cloud`,
+          desiredState: `connected`,
+          localRuntimeEnabled: options.localRuntimeEnabled !== false,
+          tenantId: result.tenantId,
+        },
+        options
+      )
+      return
+    }
+    if (item.discoveredServer) {
+      addServer(
+        {
+          name: item.name,
+          url: item.discoveredServer.url,
+          source: `local-discovery`,
+          desiredState: `connected`,
+          localRuntimeEnabled: options.localRuntimeEnabled !== false,
+        },
+        options
+      )
+    }
+  }
+
+  const cloudDescription = cloudStatusDescription(cloudState)
 
   return (
-    <SettingsScreen title="Servers">
-      <SettingsSection
-        title="Configured Servers"
-        description={
-          isDesktop
-            ? `Manage remote agents servers and the optional local runtime attached to each connected server.`
-            : `Manage the agents server this web UI connects to. Local runtimes are only available in the desktop app.`
-        }
-      >
-        {servers.length === 0 ? (
-          <div style={{ padding: `16px` }}>
-            <Text size={2} tone="muted">
-              No configured servers yet. Add one from the server switcher.
-            </Text>
-          </div>
-        ) : (
-          servers.map((server) => (
-            <ServerRow
-              key={server.id}
-              server={server}
-              selected={server.id === activeServer?.id}
-              status={statusForServer(server)}
-              lastError={connectionByServer.get(server.id)?.lastError ?? null}
-              runtimeStatus={runtimeStatusForServer(server)}
-              runtimeUrl={connectionByServer.get(server.id)?.runtimeUrl ?? null}
-              runtimeError={
-                connectionByServer.get(server.id)?.runtimeError ?? null
-              }
-              onSelect={() => setActiveServer(server)}
-              onConnect={() => connectServer(server.id)}
-              onDisconnect={() => disconnectServer(server.id)}
-              onToggleLocalRuntime={() => {
-                if (!isDesktop) return
-                updateServer({
-                  ...server,
-                  localRuntimeEnabled: server.localRuntimeEnabled === false,
-                })
-              }}
-              onRemove={() => {
-                if (
-                  window.confirm(
-                    `Remove ${server.name}? This will remove it from your configured servers.`
-                  )
-                ) {
-                  removeServer(server.url)
-                }
-              }}
-              isDesktop={isDesktop}
-            />
-          ))
-        )}
-      </SettingsSection>
-      {isDesktop && (
-        <CloudAgentServersSection
-          state={cloudAgents}
-          savedTenantIds={savedCloudTenantIds}
-          onAdd={addServer}
-        />
-      )}
-      <SettingsSection
-        title="Add Server"
-        description={
-          isDesktop
-            ? `Add a remote agents server. Connecting can run with or without a local bundled runtime.`
-            : `Add another agents server URL for this browser. Local runtime options are not available on the web.`
-        }
-      >
-        <AddServerForm
-          onAdd={(server) => {
-            addServer(server)
-          }}
-        />
-      </SettingsSection>
-      {isDesktop && newDiscovered.length > 0 && (
+    <>
+      <SettingsScreen title="Servers">
         <SettingsSection
-          title="Discovered Local Servers"
-          description="Local servers are not saved until you connect them."
+          title="Servers"
+          description={
+            isDesktop
+              ? `Connect to local, self-hosted, or Electric Cloud agents servers.`
+              : `Manage the agents server this web UI connects to.`
+          }
         >
-          {newDiscovered.map((entry) => (
-            <SettingsRow
-              key={entry.url}
-              label={`localhost:${entry.port}`}
-              description={entry.url}
-              control={
-                <Button
-                  variant="soft"
-                  tone="neutral"
-                  onClick={() =>
-                    addServer({
-                      name: `localhost:${entry.port}`,
-                      url: entry.url,
-                      source: `local-discovery`,
-                      desiredState: `connected`,
+          {cloudDescription && (
+            <div style={{ padding: `8px 16px 0` }}>
+              <Text
+                size={1}
+                tone={cloudState?.status === `error` ? `danger` : `muted`}
+              >
+                {cloudDescription}
+              </Text>
+            </div>
+          )}
+          {servers.length === 0 ? (
+            <div style={{ padding: 16 }}>
+              <Text size={2} tone="muted">
+                No servers yet. Add one below or sign in to Electric Cloud.
+              </Text>
+            </div>
+          ) : (
+            servers.map((item) => (
+              <ServerRow
+                key={item.key}
+                item={item}
+                onSelect={() => item.server && setActiveServer(item.server)}
+                onConnect={(options) => {
+                  void connectAvailableServer(item, options)
+                }}
+                onDisconnect={() =>
+                  item.server && disconnectServer(item.server.id)
+                }
+                onToggleLocalRuntime={() => {
+                  if (!item.server) return
+                  const localRuntimeEnabled =
+                    item.server.localRuntimeEnabled === false
+                  updateServer({
+                    ...item.server,
+                    localRuntimeEnabled,
+                  })
+                  if (
+                    localRuntimeEnabled &&
+                    item.server.desiredState === `connected`
+                  ) {
+                    connectServer(item.server.id, {
                       localRuntimeEnabled: true,
                     })
                   }
-                >
-                  Connect
-                </Button>
-              }
-            />
-          ))}
+                }}
+                onForget={() => {
+                  if (item.server) setServerToForget(item.server)
+                }}
+                isDesktop={isDesktop}
+              />
+            ))
+          )}
         </SettingsSection>
-      )}
-    </SettingsScreen>
+        <SettingsSection
+          title="Add Server"
+          description={
+            isDesktop
+              ? `Add a server URL manually. New connections start the local runtime by default.`
+              : `Add another agents server URL for this browser.`
+          }
+        >
+          <AddServerForm
+            onAdd={(server) => {
+              addServer(server, {
+                localRuntimeEnabled: server.localRuntimeEnabled,
+              })
+            }}
+          />
+        </SettingsSection>
+      </SettingsScreen>
+      <ConfirmDialog
+        open={serverToForget !== null}
+        onOpenChange={(open) => {
+          if (!open) setServerToForget(null)
+        }}
+        title={
+          serverToForget ? `Forget ${serverToForget.name}?` : `Forget server?`
+        }
+        description="This will disconnect the server and remove its saved settings."
+        confirmLabel="Forget server"
+        confirmTone="danger"
+        confirmIcon={Trash2}
+        onConfirm={() => {
+          if (!serverToForget) return
+          forgetServer(serverToForget.id)
+          setServerToForget(null)
+        }}
+      />
+    </>
   )
 }
 
 function ServerRow({
-  server,
-  selected,
-  status,
-  runtimeStatus,
-  lastError,
-  runtimeUrl,
-  runtimeError,
+  item,
   onSelect,
   onConnect,
   onDisconnect,
   onToggleLocalRuntime,
-  onRemove,
+  onForget,
   isDesktop,
 }: {
-  server: ServerConfig
-  selected: boolean
-  status: ServerConnectionStatus
-  runtimeStatus: LocalRuntimeStatus
-  lastError: string | null
-  runtimeUrl: string | null
-  runtimeError: string | null
+  item: AvailableServer
   onSelect: () => void
-  onConnect: () => void
+  onConnect: (options: ConnectServerOptions) => void
   onDisconnect: () => void
   onToggleLocalRuntime: () => void
-  onRemove: () => void
+  onForget: () => void
   isDesktop: boolean
 }): React.ReactElement {
-  const statusInfo = STATUS_TONES[status]
-  const connectedIntent = server.desiredState === `connected`
+  const statusInfo = STATUS_TONES[item.status]
+  const connectedIntent = item.server?.desiredState === `connected`
+  const canUseLocalRuntime = isDesktop && item.isSaved
+  const badgeText = item.isCloud ? item.cloudPath : item.description
   return (
     <>
       <SettingsRow
-        label={server.name}
+        label={item.name}
         description={
           <Stack direction="column" gap={1}>
-            <Text size={1} tone="muted" family="mono">
-              {server.url}
-            </Text>
-            {runtimeUrl && (
+            <Stack direction="row" gap={2} align="center">
+              <ServerKindBadge item={item} />
+              {badgeText && (
+                <Text size={1} tone="muted">
+                  {badgeText}
+                </Text>
+              )}
+            </Stack>
+            {item.url && !item.isCloud && item.url !== item.description && (
               <Text size={1} tone="muted" family="mono">
-                Runtime: Pull-wake
+                {item.url}
               </Text>
             )}
-            {isDesktop ? (
+            {canUseLocalRuntime && (
               <Text size={1} tone="muted">
-                <Icon icon={Brain} size={1} /> Local runtime for this server:
-                {` `}
-                {runtimeStatus}
-              </Text>
-            ) : (
-              <Text size={1} tone="muted">
-                Local runtime: desktop app only
+                Local runtime:{` `}
+                {runtimeStatusLabel(item.runtimeStatus)}
               </Text>
             )}
-            {runtimeError && (
+            {item.connection?.runtimeError && (
               <Text size={1} tone="danger">
-                Runtime: {runtimeError}
+                Runtime: {item.connection.runtimeError}
               </Text>
             )}
-            {isDesktop && (
-              <Text size={1} tone="muted">
-                Logs: runtime logs are written under the app data logs
-                directory.
-              </Text>
-            )}
-            {lastError && (
+            {item.connection?.lastError && (
               <Text size={1} tone="danger">
-                {lastError}
+                {item.connection.lastError}
               </Text>
             )}
           </Stack>
@@ -308,17 +277,28 @@ function ServerRow({
           padding: `0 16px 16px`,
         }}
       >
-        <Button
-          variant="soft"
-          tone="neutral"
-          onClick={onSelect}
-          disabled={selected}
-        >
-          {selected ? `Selected` : `Select`}
-        </Button>
+        {item.server && (
+          <Button
+            variant="soft"
+            tone="neutral"
+            onClick={onSelect}
+            disabled={item.isSelected}
+          >
+            {item.isSelected ? `Selected` : `Select`}
+          </Button>
+        )}
         {isDesktop && connectedIntent ? (
           <>
-            <Button variant="soft" tone="neutral" onClick={onConnect}>
+            <Button
+              variant="soft"
+              tone="neutral"
+              onClick={() =>
+                onConnect({
+                  localRuntimeEnabled:
+                    item.server?.localRuntimeEnabled !== false,
+                })
+              }
+            >
               <Icon icon={RefreshCw} size={2} /> Retry
             </Button>
             <Button variant="soft" tone="neutral" onClick={onDisconnect}>
@@ -326,180 +306,126 @@ function ServerRow({
             </Button>
           </>
         ) : isDesktop ? (
-          <Button variant="solid" tone="accent" onClick={onConnect}>
-            <Icon icon={Zap} size={2} /> Connect
-          </Button>
+          <ConnectSplitButton onConnect={onConnect} />
         ) : null}
-        {isDesktop && (
+        {canUseLocalRuntime && connectedIntent && (
           <Button variant="soft" tone="neutral" onClick={onToggleLocalRuntime}>
             <Icon icon={Brain} size={2} />
-            {server.localRuntimeEnabled === false
+            {item.server?.localRuntimeEnabled === false
               ? `Enable local runtime`
               : `Disable local runtime`}
           </Button>
         )}
-        <Button variant="soft" tone="neutral" onClick={onRemove}>
-          <Icon icon={Trash2} size={2} /> Remove
-        </Button>
+        {item.server && (
+          <Button variant="soft" tone="neutral" onClick={onForget}>
+            <Icon icon={Trash2} size={2} /> Forget
+          </Button>
+        )}
       </div>
     </>
   )
 }
 
-function CloudAgentServersSection({
-  state,
-  savedTenantIds,
-  onAdd,
+function ConnectSplitButton({
+  onConnect,
 }: {
-  state: CloudAgentServersState | null
-  savedTenantIds: Set<string>
-  onAdd: (server: {
-    name: string
-    url: string
-    source: `manual` | `local-discovery` | `electric-cloud`
-    desiredState: `connected` | `disconnected`
-    localRuntimeEnabled: boolean
-    tenantId?: string
-  }) => void
+  onConnect: (options: ConnectServerOptions) => void
 }): React.ReactElement {
-  const status = state?.status ?? `idle`
-  const servers = state?.servers ?? []
-  const description =
-    status === `idle`
-      ? `Sign in to Electric Cloud (Settings → Account) to see the agent servers your workspaces have access to.`
-      : status === `loading`
-        ? `Loading agent servers from Electric Cloud…`
-        : status === `unauthorized`
-          ? `Sign-in expired. Sign back in (Settings → Account) to refresh the list.`
-          : servers.length === 0
-            ? `No agent servers in your workspaces yet. Create one from the Electric Cloud dashboard.`
-            : `Agent servers across the workspaces you're a member of. Click Connect on one to make it the active server for this window.`
-
+  const [open, setOpen] = useState(false)
   return (
-    <SettingsSection title="Cloud Agent Servers" description={description}>
-      {state?.error && status !== `unauthorized` && (
-        <div style={{ padding: `8px 16px 0` }}>
-          <Text size={1} tone="danger">
-            {state.error}
-          </Text>
-        </div>
-      )}
-      {servers.length > 0 && (
-        <div>
-          {servers.map((server) => (
-            <CloudAgentServerRow
-              key={server.id}
-              server={server}
-              savedTenantIds={savedTenantIds}
-              onAdd={onAdd}
-            />
-          ))}
-        </div>
-      )}
-    </SettingsSection>
+    <div style={{ display: `inline-flex`, gap: 1 }}>
+      <Button
+        variant="solid"
+        tone="accent"
+        style={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
+        onClick={() => onConnect({ localRuntimeEnabled: true })}
+      >
+        <Icon icon={Zap} size={2} /> Connect
+      </Button>
+      <Menu.Root open={open} onOpenChange={setOpen}>
+        <Menu.Trigger
+          render={
+            <Button
+              variant="solid"
+              tone="accent"
+              aria-label="Connection options"
+              style={{
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+                paddingInline: 8,
+              }}
+            >
+              <Icon icon={ChevronDown} size={2} />
+            </Button>
+          }
+        />
+        <Menu.Content side="bottom" align="end">
+          <Menu.Item onSelect={() => onConnect({ localRuntimeEnabled: true })}>
+            Connect and start local runtime
+          </Menu.Item>
+          <Menu.Item onSelect={() => onConnect({ localRuntimeEnabled: false })}>
+            Connect without local runtime
+          </Menu.Item>
+        </Menu.Content>
+      </Menu.Root>
+    </div>
   )
 }
 
-function CloudAgentServerRow({
-  server,
-  savedTenantIds,
-  onAdd,
+function ServerKindBadge({
+  item,
 }: {
-  server: CloudAgentServer
-  savedTenantIds: Set<string>
-  onAdd: (server: {
-    name: string
-    url: string
-    source: `manual` | `local-discovery` | `electric-cloud`
-    desiredState: `connected` | `disconnected`
-    localRuntimeEnabled: boolean
-    tenantId?: string
-  }) => void
+  item: AvailableServer
 }): React.ReactElement {
-  const [connecting, setConnecting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const alreadyAdded = savedTenantIds.has(server.id)
-
-  const path = [
-    server.workspaceName,
-    server.projectName,
-    server.environmentName,
-  ]
-    .filter((segment): segment is string => Boolean(segment))
-    .join(` › `)
-
-  const handleConnect = async (): Promise<void> => {
-    if (connecting || alreadyAdded) return
-    setConnecting(true)
-    setError(null)
-    try {
-      const result = await prepareCloudAgentServerConnection(server.id)
-      if (!result) {
-        throw new Error(`Could not prepare the cloud connection.`)
-      }
-      onAdd({
-        name: server.name,
-        url: result.url,
-        source: `electric-cloud`,
-        desiredState: `connected`,
-        // The cloud-agents-server itself is just a tenanted router —
-        // entity-type registration (Horton, Worker) and the actual
-        // runtime execution still live on this machine. Same wiring
-        // as a local server; the only difference is the agents-server
-        // URL points at the cloud instead of `localhost`.
-        localRuntimeEnabled: true,
-        // Persisted alongside the URL so main's webRequest hook + the
-        // undici global interceptor can look up the matching agents
-        // token from SecretStore on every outbound request to this server.
-        tenantId: result.tenantId,
-      })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setConnecting(false)
-    }
+  if (item.isCloud) {
+    return (
+      <Badge tone="info" size={1}>
+        <Icon icon={Cloud} size={1} /> Cloud
+      </Badge>
+    )
   }
-
+  if (item.isLocal) {
+    return (
+      <Badge tone="neutral" size={1}>
+        <Icon icon={Laptop} size={1} /> Local
+      </Badge>
+    )
+  }
   return (
-    <SettingsRow
-      label={server.name}
-      description={
-        <Stack direction="column" gap={1}>
-          {path && (
-            <Text size={1} tone="muted">
-              {path}
-            </Text>
-          )}
-          <Text size={1} tone="muted" family="mono">
-            {server.id}
-          </Text>
-          {error && (
-            <Text size={1} tone="danger">
-              {error}
-            </Text>
-          )}
-        </Stack>
-      }
-      control={
-        <Stack direction="row" gap={2} align="center">
-          <Badge tone="info" size={1}>
-            Cloud
-          </Badge>
-          <Button
-            variant="soft"
-            tone="neutral"
-            size={1}
-            disabled={connecting || alreadyAdded}
-            onClick={() => {
-              void handleConnect()
-            }}
-          >
-            {alreadyAdded ? `Added` : connecting ? `Connecting…` : `Connect`}
-          </Button>
-        </Stack>
-      }
-    />
+    <Badge tone="neutral" size={1}>
+      <Icon icon={Plug} size={1} /> Self-hosted
+    </Badge>
   )
+}
+
+function runtimeStatusLabel(status: LocalRuntimeStatus): string {
+  switch (status) {
+    case `disabled`:
+      return `disabled`
+    case `stopped`:
+      return `stopped`
+    case `starting`:
+      return `starting`
+    case `running`:
+      return `running`
+    case `error`:
+      return `error`
+  }
+}
+
+function cloudStatusDescription(
+  state: CloudAgentServersState | null
+): string | null {
+  if (!state) return null
+  if (state.status === `idle`) {
+    return `Sign in to Electric Cloud from Account settings to see cloud servers.`
+  }
+  if (state.status === `loading`) return `Loading Electric Cloud servers...`
+  if (state.status === `unauthorized`) {
+    return `Electric Cloud sign-in expired. Sign back in from Account settings.`
+  }
+  if (state.status === `error`) return state.error
+  return null
 }
 
 function AddServerForm({
@@ -569,7 +495,7 @@ function AddServerForm({
               checked={localRuntimeEnabled}
               onChange={(event) => setLocalRuntimeEnabled(event.target.checked)}
             />
-            <Text size={2}>Start a local runtime for this server</Text>
+            <Text size={2}>Start local runtime when connecting</Text>
           </label>
         )}
       </Stack>

--- a/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
@@ -36,6 +36,8 @@ import {
   SettingsRow,
   SettingsScreen,
   SettingsSection,
+  SettingsStatusBadge,
+  type SettingsStatusTone,
 } from '../SettingsScreen'
 import {
   cloudOpenCreateAgentsServer,
@@ -49,7 +51,7 @@ import type { ServerConfig } from '../../../lib/types'
 
 const STATUS_TONES: Record<
   ServerConnectionStatus,
-  { label: string; tone: `success` | `warning` | `danger` | `info` | `neutral` }
+  { label: string; tone: SettingsStatusTone }
 > = {
   connected: { label: `Connected`, tone: `success` },
   connecting: { label: `Connecting`, tone: `info` },
@@ -287,7 +289,11 @@ function ServerRow({
             )}
           </Stack>
         }
-        control={<Badge tone={statusInfo.tone}>{statusInfo.label}</Badge>}
+        control={
+          <SettingsStatusBadge tone={statusInfo.tone}>
+            {statusInfo.label}
+          </SettingsStatusBadge>
+        }
       />
       {(item.url ||
         canUseLocalRuntime ||

--- a/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/ServersPage.tsx
@@ -29,7 +29,14 @@ import {
   Text,
   Tooltip,
 } from '../../../ui'
-import { SettingsRow, SettingsScreen, SettingsSection } from '../SettingsScreen'
+import {
+  SettingsActions,
+  SettingsInset,
+  SettingsPanel,
+  SettingsRow,
+  SettingsScreen,
+  SettingsSection,
+} from '../SettingsScreen'
 import {
   cloudOpenCreateAgentsServer,
   prepareCloudAgentServerConnection,
@@ -122,21 +129,21 @@ export function ServersPage(): React.ReactElement {
           }
         >
           {cloudDescription && (
-            <div style={{ padding: `8px 16px 0` }}>
+            <SettingsPanel>
               <Text
                 size={1}
                 tone={cloudState?.status === `error` ? `danger` : `muted`}
               >
                 {cloudDescription}
               </Text>
-            </div>
+            </SettingsPanel>
           )}
           {servers.length === 0 ? (
-            <div style={{ padding: 16 }}>
+            <SettingsPanel>
               <Text size={2} tone="muted">
                 No servers yet. Add one below or sign in to Electric Cloud.
               </Text>
-            </div>
+            </SettingsPanel>
           ) : (
             servers.map((item) => (
               <ServerRow
@@ -286,7 +293,7 @@ function ServerRow({
         canUseLocalRuntime ||
         item.connection?.runtimeError ||
         item.connection?.lastError) && (
-        <div style={{ padding: `0 16px 12px` }}>
+        <SettingsInset>
           <Stack direction="column" gap={1}>
             {item.url && item.url !== item.description && (
               <Text size={1} tone="muted" family="mono">
@@ -330,17 +337,9 @@ function ServerRow({
               </Text>
             )}
           </Stack>
-        </div>
+        </SettingsInset>
       )}
-      <div
-        style={{
-          display: `flex`,
-          flexWrap: `wrap`,
-          justifyContent: `flex-end`,
-          gap: 8,
-          padding: `0 16px 16px`,
-        }}
-      >
+      <SettingsActions>
         {item.server && (
           <Button
             variant="soft"
@@ -385,7 +384,7 @@ function ServerRow({
             <Icon icon={Trash2} size={2} /> Forget
           </Button>
         )}
-      </div>
+      </SettingsActions>
     </>
   )
 }
@@ -531,7 +530,7 @@ function AddServerForm({
         display: `flex`,
         flexDirection: `column`,
         gap: 16,
-        padding: 16,
+        padding: `12px 16px`,
       }}
     >
       <Stack direction="column" gap={3}>
@@ -552,7 +551,9 @@ function AddServerForm({
             size={2}
           />
         </Field>
-        {isDesktop && (
+      </Stack>
+      <Stack direction="row" align="center" justify="between" gap={3}>
+        {isDesktop ? (
           <label style={{ display: `flex`, gap: 8, alignItems: `center` }}>
             <input
               type="checkbox"
@@ -561,9 +562,9 @@ function AddServerForm({
             />
             <Text size={2}>Start local runtime when connecting</Text>
           </label>
+        ) : (
+          <span />
         )}
-      </Stack>
-      <Stack justify="end">
         <Button type="submit" disabled={!canSubmit}>
           Add and connect
         </Button>

--- a/packages/agents-server-ui/src/hooks/useAvailableServers.ts
+++ b/packages/agents-server-ui/src/hooks/useAvailableServers.ts
@@ -1,0 +1,269 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useServerConnection } from './useServerConnection'
+import {
+  loadCloudAuthState,
+  loadCloudAgentServersState,
+  loadDesktopState,
+  onCloudAuthStateChanged,
+  onCloudAgentServersStateChanged,
+  onDesktopStateChanged,
+  type CloudAuthState,
+  type CloudAgentServer,
+  type CloudAgentServersState,
+  type DiscoveredServer,
+  type LocalRuntimeStatus,
+  type ServerConnectionState,
+  type ServerConnectionStatus,
+} from '../lib/server-connection'
+import type { ServerConfig } from '../lib/types'
+
+export type AvailableServerKind = `saved` | `cloud` | `local`
+
+export interface AvailableServer {
+  key: string
+  kind: AvailableServerKind
+  name: string
+  description: string | null
+  url: string | null
+  tenantId: string | null
+  cloudPath: string | null
+  server: ServerConfig | null
+  cloudServer: CloudAgentServer | null
+  discoveredServer: DiscoveredServer | null
+  connection: ServerConnectionState | null
+  status: ServerConnectionStatus
+  runtimeStatus: LocalRuntimeStatus
+  isSelected: boolean
+  isSaved: boolean
+  isCloud: boolean
+  isLocal: boolean
+}
+
+export interface AvailableServersState {
+  servers: Array<AvailableServer>
+  cloudState: CloudAgentServersState | null
+  discoveredServers: Array<DiscoveredServer>
+}
+
+export function useAvailableServers(): AvailableServersState {
+  const { servers, activeServer, connected, connections } =
+    useServerConnection()
+  const [discoveredServers, setDiscoveredServers] = useState<
+    Array<DiscoveredServer>
+  >([])
+  const [cloudState, setCloudState] = useState<CloudAgentServersState | null>(
+    null
+  )
+  const [cloudAuthState, setCloudAuthState] = useState<CloudAuthState | null>(
+    null
+  )
+  const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
+
+  useEffect(() => {
+    if (!isDesktop) return
+    let cancelled = false
+    void loadDesktopState().then((state) => {
+      if (!cancelled) setDiscoveredServers(state?.discoveredServers ?? [])
+    })
+    const off = onDesktopStateChanged((state) => {
+      setDiscoveredServers(state.discoveredServers ?? [])
+    })
+    return () => {
+      cancelled = true
+      off?.()
+    }
+  }, [isDesktop])
+
+  useEffect(() => {
+    if (!isDesktop) return
+    let cancelled = false
+    void loadCloudAuthState().then((state) => {
+      if (!cancelled) setCloudAuthState(state)
+    })
+    const off = onCloudAuthStateChanged((next) => {
+      setCloudAuthState(next)
+    })
+    return () => {
+      cancelled = true
+      off?.()
+    }
+  }, [isDesktop])
+
+  useEffect(() => {
+    if (!isDesktop) return
+    let cancelled = false
+    void loadCloudAgentServersState().then((state) => {
+      if (!cancelled) setCloudState(state)
+    })
+    const off = onCloudAgentServersStateChanged((next) => {
+      setCloudState(next)
+    })
+    return () => {
+      cancelled = true
+      off?.()
+    }
+  }, [isDesktop])
+
+  return useMemo(() => {
+    const connectionByServer = new Map(
+      connections.map((entry) => [entry.serverId, entry])
+    )
+    const cloudByTenant = new Map(
+      (cloudState?.servers ?? []).map((server) => [server.id, server])
+    )
+    const workspaceNameById = new Map(
+      (cloudAuthState?.workspaces ?? []).map((workspace) => [
+        workspace.id,
+        workspace.name,
+      ])
+    )
+    const savedUrls = new Set(servers.map((server) => server.url))
+    const savedTenantIds = new Set(
+      servers
+        .filter(
+          (server) => server.source === `electric-cloud` && server.tenantId
+        )
+        .map((server) => server.tenantId as string)
+    )
+
+    const savedItems = servers.map((server): AvailableServer => {
+      const connection = connectionByServer.get(server.id) ?? null
+      const cloudServer = server.tenantId
+        ? (cloudByTenant.get(server.tenantId) ?? null)
+        : null
+      const cloudPath = cloudServer
+        ? cloudServerPath(
+            cloudServer,
+            workspaceNameById.get(cloudServer.workspaceId ?? ``) ?? null
+          )
+        : null
+      const status =
+        connection?.status ??
+        (!isDesktop && server.id === activeServer?.id
+          ? connected
+            ? `connected`
+            : `offline`
+          : server.desiredState === `connected`
+            ? `offline`
+            : `disconnected`)
+      return {
+        key: `saved:${server.id}`,
+        kind: `saved`,
+        name: server.name,
+        description: cloudPath,
+        url: server.url,
+        tenantId: server.tenantId ?? null,
+        cloudPath,
+        server,
+        cloudServer,
+        discoveredServer: null,
+        connection,
+        status,
+        runtimeStatus:
+          connection?.localRuntimeStatus ??
+          (server.localRuntimeEnabled === false ? `disabled` : `stopped`),
+        isSelected: server.id === activeServer?.id,
+        isSaved: true,
+        isCloud: server.source === `electric-cloud`,
+        isLocal: isLocalServerUrl(server.url),
+      }
+    })
+
+    const cloudItems = (cloudState?.servers ?? [])
+      .filter((server) => !savedTenantIds.has(server.id))
+      .map((server): AvailableServer => {
+        const cloudPath = cloudServerPath(
+          server,
+          workspaceNameById.get(server.workspaceId ?? ``) ?? null
+        )
+        return {
+          key: `cloud:${server.id}`,
+          kind: `cloud`,
+          name: server.name,
+          description: cloudPath,
+          url: null,
+          tenantId: server.id,
+          cloudPath,
+          server: null,
+          cloudServer: server,
+          discoveredServer: null,
+          connection: null,
+          status: `disconnected`,
+          runtimeStatus: `disabled`,
+          isSelected: false,
+          isSaved: false,
+          isCloud: true,
+          isLocal: false,
+        }
+      })
+
+    const localItems = discoveredServers
+      .filter((entry) => !savedUrls.has(entry.url))
+      .sort((a, b) => a.port - b.port)
+      .map(
+        (entry): AvailableServer => ({
+          key: `local:${entry.url}`,
+          kind: `local`,
+          name: `localhost:${entry.port}`,
+          description: entry.url,
+          url: entry.url,
+          tenantId: null,
+          cloudPath: null,
+          server: null,
+          cloudServer: null,
+          discoveredServer: entry,
+          connection: null,
+          status: `disconnected`,
+          runtimeStatus: `disabled`,
+          isSelected: false,
+          isSaved: false,
+          isCloud: false,
+          isLocal: true,
+        })
+      )
+
+    return {
+      servers: [...savedItems, ...cloudItems, ...localItems],
+      cloudState,
+      discoveredServers,
+    }
+  }, [
+    activeServer?.id,
+    cloudAuthState,
+    cloudState,
+    connected,
+    connections,
+    discoveredServers,
+    isDesktop,
+    servers,
+  ])
+}
+
+function cloudServerPath(
+  server: CloudAgentServer,
+  fallbackWorkspaceName: string | null
+): string | null {
+  const path = [
+    server.workspaceName ?? fallbackWorkspaceName,
+    server.projectName,
+    server.environmentName,
+  ]
+    .filter((segment): segment is string => Boolean(segment))
+    .join(` / `)
+  return path || null
+}
+
+function isLocalServerUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase()
+    return (
+      hostname === `localhost` ||
+      hostname === `127.0.0.1` ||
+      hostname === `0.0.0.0` ||
+      hostname === `::1` ||
+      hostname === `[::1]`
+    )
+  } catch {
+    return false
+  }
+}

--- a/packages/agents-server-ui/src/hooks/useServerConnection.tsx
+++ b/packages/agents-server-ui/src/hooks/useServerConnection.tsx
@@ -8,12 +8,14 @@ import {
 import {
   connectServer as connectDesktopServer,
   disconnectServer as disconnectDesktopServer,
+  forgetServer as forgetDesktopServer,
   loadDesktopState,
   loadServers,
   onDesktopStateChanged,
   saveActiveServer,
   saveSelectedServer,
   saveServers,
+  type ConnectServerOptions,
   type ServerConnectionState as RuntimeConnectionState,
 } from '../lib/server-connection'
 import { appendPathToUrl } from '@electric-ax/agents-runtime/client'
@@ -98,11 +100,12 @@ interface ServerConnectionState {
   connection: RuntimeConnectionState | null
   connections: Array<RuntimeConnectionState>
   setActiveServer: (server: ServerConfig | null) => void
-  addServer: (server: ServerInput) => void
+  addServer: (server: ServerInput, options?: ConnectServerOptions) => void
   removeServer: (url: string) => void
   updateServer: (server: ServerConfig) => void
-  connectServer: (serverId: string) => void
+  connectServer: (serverId: string, options?: ConnectServerOptions) => void
   disconnectServer: (serverId: string) => void
+  forgetServer: (serverId: string) => void
 }
 
 const ServerConnectionContext = createContext<ServerConnectionState | null>(
@@ -270,9 +273,12 @@ export function ServerConnectionProvider({
   }, [])
 
   const addServer = useCallback(
-    (server: ServerInput) => {
+    (server: ServerInput, options?: ConnectServerOptions) => {
       if (servers.some((s) => s.url === server.url)) return
       const normalized = normalizeServerConfig(server as ServerConfig)
+      if (typeof options?.localRuntimeEnabled === `boolean`) {
+        normalized.localRuntimeEnabled = options.localRuntimeEnabled
+      }
       const next = [...servers, normalized]
       setServers(next)
       setActiveServerState(normalized)
@@ -281,7 +287,7 @@ export function ServerConnectionProvider({
       void saveServers(next).then(async () => {
         if (window.electronAPI) {
           await saveSelectedServer(normalized.id)
-          await connectDesktopServer(normalized.id)
+          await connectDesktopServer(normalized.id, options)
         } else {
           await saveActiveServer(normalized)
         }
@@ -315,9 +321,9 @@ export function ServerConnectionProvider({
   )
 
   const connectServer = useCallback(
-    (serverId: string) => {
+    (serverId: string, options?: ConnectServerOptions) => {
       if (window.electronAPI) {
-        void connectDesktopServer(serverId)
+        void connectDesktopServer(serverId, options)
       } else if (activeServer?.id === serverId) {
         setBrowserRetry((value) => value + 1)
       }
@@ -328,6 +334,18 @@ export function ServerConnectionProvider({
   const disconnectServer = useCallback((serverId: string) => {
     void disconnectDesktopServer(serverId)
   }, [])
+
+  const forgetServer = useCallback(
+    (serverId: string) => {
+      if (window.electronAPI) {
+        void forgetDesktopServer(serverId)
+      } else {
+        const server = servers.find((entry) => entry.id === serverId)
+        if (server) removeServer(server.url)
+      }
+    },
+    [servers, removeServer]
+  )
 
   return (
     <ServerConnectionContext.Provider
@@ -343,6 +361,7 @@ export function ServerConnectionProvider({
         updateServer,
         connectServer,
         disconnectServer,
+        forgetServer,
       }}
     >
       {children}

--- a/packages/agents-server-ui/src/lib/ElectricAgentsProvider.tsx
+++ b/packages/agents-server-ui/src/lib/ElectricAgentsProvider.tsx
@@ -165,7 +165,7 @@ function createEntityTypesCollection(baseUrl: string) {
   )
 }
 
-function createRunnersCollection(baseUrl: string) {
+export function createRunnersCollection(baseUrl: string) {
   return createCollection(
     electricCollectionOptions({
       id: `runners`,

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -267,6 +267,7 @@ declare global {
       rescanServers?: () => Promise<Array<DiscoveredServer>>
       getApiKeysStatus?: () => Promise<ApiKeysStatus>
       saveApiKeys?: (keys: ApiKeys) => Promise<void>
+      clearAllLocalData?: () => Promise<void>
       getOnboardingState?: () => Promise<OnboardingState>
       setOnboardingDismissed?: (dismissed: boolean) => Promise<void>
       getWorkingDirectory?: () => Promise<string | null>
@@ -461,6 +462,10 @@ export async function loadApiKeysStatus(): Promise<ApiKeysStatus | null> {
 
 export async function saveApiKeys(keys: ApiKeys): Promise<void> {
   await window.electronAPI?.saveApiKeys?.(keys)
+}
+
+export async function clearAllLocalData(): Promise<void> {
+  await window.electronAPI?.clearAllLocalData?.()
 }
 
 export async function loadOnboardingState(): Promise<OnboardingState | null> {

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -41,6 +41,10 @@ export interface DesktopState {
   pullWakeRunnerId: string | null
 }
 
+export interface ConnectServerOptions {
+  localRuntimeEnabled?: boolean
+}
+
 export interface DesktopServerFetchRequest {
   url: string
   method: string
@@ -258,8 +262,12 @@ declare global {
       setNativeAppearance?: (appearance: DesktopAppearance) => Promise<void>
       setActiveServer?: (server: ServerConfig | null) => Promise<void>
       setSelectedServer?: (serverId: string | null) => Promise<void>
-      connectServer?: (serverId: string) => Promise<void>
+      connectServer?: (
+        serverId: string,
+        options?: ConnectServerOptions
+      ) => Promise<void>
       disconnectServer?: (serverId: string) => Promise<void>
+      forgetServer?: (serverId: string) => Promise<void>
       restartRuntime?: () => Promise<void>
       restartServerRuntime?: (serverId: string) => Promise<void>
       stopRuntime?: () => Promise<void>
@@ -430,12 +438,19 @@ export async function saveSelectedServer(
   await window.electronAPI?.setSelectedServer?.(serverId)
 }
 
-export async function connectServer(serverId: string): Promise<void> {
-  await window.electronAPI?.connectServer?.(serverId)
+export async function connectServer(
+  serverId: string,
+  options?: ConnectServerOptions
+): Promise<void> {
+  await window.electronAPI?.connectServer?.(serverId, options)
 }
 
 export async function disconnectServer(serverId: string): Promise<void> {
   await window.electronAPI?.disconnectServer?.(serverId)
+}
+
+export async function forgetServer(serverId: string): Promise<void> {
+  await window.electronAPI?.forgetServer?.(serverId)
 }
 
 export function onDesktopStateChanged(

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -349,6 +349,7 @@ declare global {
         signIn: (provider: CloudAuthProvider) => Promise<void>
         signOut: () => Promise<void>
         openDashboard: () => Promise<void>
+        openCreateAgentsServer: () => Promise<void>
         onStateChanged: (
           callback: (state: CloudAuthState) => void
         ) => () => void
@@ -507,6 +508,10 @@ export async function cloudSignOut(): Promise<void> {
 
 export async function cloudOpenDashboard(): Promise<void> {
   await window.electronAPI?.cloudAuth?.openDashboard?.()
+}
+
+export async function cloudOpenCreateAgentsServer(): Promise<void> {
+  await window.electronAPI?.cloudAuth?.openCreateAgentsServer?.()
 }
 
 export function onCloudAuthStateChanged(

--- a/packages/agents-server-ui/src/router.tsx
+++ b/packages/agents-server-ui/src/router.tsx
@@ -466,6 +466,10 @@ const workspaceSearchSchema = z.object({
   layout: z.string().optional(),
 })
 
+const settingsSearchSchema = z.object({
+  serverId: z.string().optional(),
+})
+
 /**
  * Thin route component — all the rendering work happens inside
  * `<Workspace>`, which reads the route params (entity splat + ?view)
@@ -534,6 +538,7 @@ const settingsIndexRoute = createRoute({
 const settingsCategoryRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: `/settings/$category`,
+  validateSearch: settingsSearchSchema,
   component: SettingsCategoryPage,
 })
 

--- a/packages/agents-server-ui/src/ui/ConfirmDialog.module.css
+++ b/packages/agents-server-ui/src/ui/ConfirmDialog.module.css
@@ -1,0 +1,15 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-4);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+}
+
+.error {
+  margin-top: calc(var(--ds-space-2) * -1);
+}

--- a/packages/agents-server-ui/src/ui/ConfirmDialog.tsx
+++ b/packages/agents-server-ui/src/ui/ConfirmDialog.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+import { Button, type ButtonTone } from './Button'
+import { Dialog } from './Dialog'
+import { Icon } from './Icon'
+import { Text } from './Text'
+import styles from './ConfirmDialog.module.css'
+import type { LucideIcon } from 'lucide-react'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: ReactNode
+  description: ReactNode
+  confirmLabel: ReactNode
+  cancelLabel?: ReactNode
+  confirmTone?: ButtonTone
+  confirmIcon?: LucideIcon
+  loading?: boolean
+  loadingLabel?: ReactNode
+  error?: ReactNode
+  maxWidth?: number | string
+  onConfirm: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = `Cancel`,
+  confirmTone = `accent`,
+  confirmIcon,
+  loading = false,
+  loadingLabel,
+  error,
+  maxWidth = 440,
+  onConfirm,
+}: ConfirmDialogProps): React.ReactElement {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!loading) onOpenChange(nextOpen)
+      }}
+    >
+      <Dialog.Content maxWidth={maxWidth}>
+        <div className={styles.body}>
+          <div>
+            <Dialog.Title>{title}</Dialog.Title>
+            <Dialog.Description>{description}</Dialog.Description>
+          </div>
+          {error && (
+            <Text size={2} tone="danger" className={styles.error}>
+              {error}
+            </Text>
+          )}
+          <div className={styles.actions}>
+            <Dialog.Close
+              render={
+                <Button variant="soft" tone="neutral" disabled={loading}>
+                  {cancelLabel}
+                </Button>
+              }
+            />
+            <Button tone={confirmTone} disabled={loading} onClick={onConfirm}>
+              {confirmIcon && <Icon icon={confirmIcon} size={2} />}
+              {loading ? (loadingLabel ?? confirmLabel) : confirmLabel}
+            </Button>
+          </div>
+        </div>
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}

--- a/packages/agents-server-ui/src/ui/index.ts
+++ b/packages/agents-server-ui/src/ui/index.ts
@@ -48,6 +48,7 @@ export { Textarea } from './Textarea'
 export { Field } from './Field'
 
 export { Dialog } from './Dialog'
+export { ConfirmDialog } from './ConfirmDialog'
 
 export { Popover } from './Popover'
 export { HoverCard } from './HoverCard'

--- a/packages/agents-server-ui/src/ui/index.web.ts
+++ b/packages/agents-server-ui/src/ui/index.web.ts
@@ -45,6 +45,7 @@ export { Textarea } from './Textarea'
 export { Field } from './Field'
 
 export { Dialog } from './Dialog'
+export { ConfirmDialog } from './ConfirmDialog'
 
 export { Popover } from './Popover'
 export { HoverCard } from './HoverCard'


### PR DESCRIPTION
## Summary
- Unify desktop server management into a single available-servers view with cloud/local/self-hosted context, forget actions, and split connect options for local runtime startup.
- Polish the Settings surfaces with reusable confirmation/status/layout primitives, clearer navigation, local runtime inspection links, and Electric Cloud server creation.
- Redesign first-run onboarding into a three-step flow for Cloud sign-in, optional provider keys, and initial server selection.

## Onbarding Screenshots

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/d742592f-dc95-4e92-9820-b11cae26571a" />

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/516791e8-0ffd-4623-9198-047c537a5c4e" />

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/c6e13de5-03d9-4bed-9374-953bf6bc154a" />

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/ffa675d7-858d-4bdc-999f-b79ba92434ba" />

## Settings Screenshots

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/d093160d-0073-47bf-92ff-fe8933faf6be" />

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/bb31c3a9-b208-42a9-88d7-3a985cc8b756" />

<img width="1392" height="1173" alt="image" src="https://github.com/user-attachments/assets/fa460b0b-a46c-4f6f-bdd8-1e71f5a2c291" />

<img width="1392" height="1051" alt="image" src="https://github.com/user-attachments/assets/d08fa03f-f447-4121-b0d3-fd2f457b3fc8" />

<img width="1392" height="1051" alt="image" src="https://github.com/user-attachments/assets/e6b5f0dc-2206-4bbe-9b8f-46095fe56e93" />

<img width="1392" height="1051" alt="image" src="https://github.com/user-attachments/assets/b0eaf9d3-2f02-4c3b-88ff-69ec40302e3d" />

<img width="1392" height="1051" alt="image" src="https://github.com/user-attachments/assets/79513451-da09-4e92-b7e4-e2b63adb9614" />


## Test plan
- tsc --noEmit in packages/agents-server-ui
- Existing pre-commit lint-staged checks passed while committing


Made with [Cursor](https://cursor.com)