### PR TITLE
fix(ci): grant PR-comment permissions to mobile canary workflow

### DIFF
--- a/.github/workflows/agents_mobile_canary.yml
+++ b/.github/workflows/agents_mobile_canary.yml
@@ -27,6 +27,12 @@ concurrency:
 permissions:
   actions: read
   contents: read
+  # Declared (but unused in canary mode) so the reusable
+  # `agents_mobile_build.yml` job, which requests these to write PR
+  # comments in `channel == 'pr'`, can load. GitHub refuses to start a
+  # reusable workflow whose declared permissions exceed the caller's.
+  issues: write
+  pull-requests: write
 
 jobs:
   detect:


### PR DESCRIPTION
## Summary

- The first canary run after #4408 merged failed at startup with: *"The nested job 'build' is requesting 'issues: write, pull-requests: write', but is only allowed 'issues: none, pull-requests: none'."* ([run](https://github.com/electric-sql/electric/actions/runs/26503339580))
- Root cause: `agents_mobile_canary.yml` only grants `actions: read, contents: read`, but the reusable `agents_mobile_build.yml` declares `issues: write, pull-requests: write` on its build job (used to update PR comments when `channel == 'pr'`). GitHub refuses to start a reusable workflow whose declared permissions exceed the caller's.
- Fix: grant those two permissions at the canary caller. Token is not used in canary mode (the comment-writing step is gated on `channel == 'pr'`); only the *declaration* has to be there for the nested-permissions check to pass.
- `agents_mobile_pr.yml` and `changesets_release.yml` already grant these at top level, so they were never affected.

## Test plan

- [ ] After merge, the next push to `main` that touches a mobile-impacting path triggers `Agents Mobile Canary` successfully — the `build` (canary APK) and `submit-play-internal` (canary-store AAB → Play internal track) jobs both start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)