### PR TITLE
docs(website): add account deletion page

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -103,6 +103,7 @@ const resourcesSidebar = [
     items: [
       { text: 'Terms', link: '/about/legal/terms' },
       { text: 'Privacy', link: '/about/legal/privacy' },
+      { text: 'Delete your account', link: '/about/legal/delete-account' },
     ],
     collapsed: false,
   },

--- a/website/about/legal/delete-account.md
+++ b/website/about/legal/delete-account.md
@@ -1,0 +1,83 @@
+---
+title: Delete your account
+description: >-
+  How to request deletion of your Electric account and the data
+  associated with it.
+outline: deep
+---
+
+# Delete your account
+
+This page explains how to request deletion of your Electric account
+(used by the Electric Agents mobile and desktop apps, the Electric
+dashboard at <https://dashboard.electric-sql.cloud>, and the Electric
+CLI) and the data we hold about you.
+
+If you only want to sign out of the app on a device, open the app's
+account screen and tap **Sign out** — that does not delete your account
+or any of the data stored on our servers.
+
+## How to request deletion
+
+Send an email to <a href="mailto:support@electric-sql.com?subject=Account%20deletion%20request">support@electric-sql.com</a>
+with the subject **"Account deletion request"** from the email address
+associated with your Electric account.
+
+Please include:
+
+- The email address tied to your Electric account.
+- The sign-in method you used (GitHub or Google).
+- Whether you want the account fully closed, or only specific data
+  removed (for example, a particular workspace, project, or agent
+  server).
+
+We will reply to confirm receipt, verify that the request is coming
+from the account holder, and then process the deletion.
+
+## What we delete
+
+When you request a full account deletion, we delete:
+
+- Your Electric account profile (name, email, sign-in identifiers from
+  GitHub or Google).
+- Workspaces, projects, environments and agent servers you own, and
+  the application data stored in them (sessions, messages, tool
+  invocation history, and any synced records).
+- Authentication tokens issued to your account.
+- Local device data is stored on your device — uninstalling the app
+  removes it. We do not need to take any action on our end for that.
+
+If a workspace is shared with other users, we will contact you to
+agree on how to handle the shared data before deleting it.
+
+## What we may retain
+
+We may retain a limited subset of data after deletion where we are
+required or permitted to by law:
+
+- **Billing and tax records** (invoices, payment history) for the
+  period required by tax and accounting law in our jurisdiction —
+  typically up to seven years.
+- **Audit and security logs** for a limited period, to investigate
+  abuse, fraud, or security incidents.
+- **A record of the deletion request itself**, so we can demonstrate
+  the request was honored.
+- **Aggregated or anonymized usage data** that can no longer be tied
+  back to you as an individual.
+
+We do not use any retained data for marketing or analytics tied to
+your identity after deletion.
+
+## How long it takes
+
+We aim to complete deletion requests within **30 days** of verifying
+the request. We will let you know if a particular request will take
+longer for any reason.
+
+## Other privacy rights
+
+Deletion is one of several rights described in our
+[Privacy Policy](/about/legal/privacy#your-choices). If you would
+rather export, correct, or restrict the use of your data instead of
+deleting it, the same email address handles those requests:
+<a href="mailto:support@electric-sql.com">support@electric-sql.com</a>.

--- a/website/about/legal/privacy.md
+++ b/website/about/legal/privacy.md
@@ -60,7 +60,7 @@ We may share your personal information with:
 - **Information.** You may have the right to obtain information about how we collect, use, and share your personal information. We provide this information within this Privacy Policy.
 - **Access** to a copy of the personal information that we have collected about you. Where applicable, we will provide the information in a portable, machine-readable, readily usable format.
 - **Correction** of personal information that is inaccurate, incomplete or otherwise out of date.
-- **Deletion** of personal information that we no longer need to provide the Services or for other lawful purposes.
+- **Deletion** of personal information that we no longer need to provide the Services or for other lawful purposes. See [Delete your account](/about/legal/delete-account) for how to request deletion of your Electric account.
 - **Restrict** our handling of your personal information.
 - **Object** to how we are using your personal information.
 - **Withdraw your consent** to us handling your personal information, where we are relying on your consent to process such personal information.


### PR DESCRIPTION
## Summary

Adds this page: https://deploy-preview-4427--electric-next.netlify.app/about/legal/delete-account

- Adds `/about/legal/delete-account` explaining how users can request deletion of their Electric account via email to support@electric-sql.com.
- Lists what gets deleted, what we may retain (billing/tax records, audit logs, anonymized analytics) and why, and commits to a 30-day timeline.
- Links from the Legal sidebar and from the Deletion bullet in the Privacy Policy's "Your choices" section.

Required for Google Play submission of the Electric Agents mobile app. Google Play's account-deletion policy (https://support.google.com/googleplay/android-developer/answer/13327111) requires a publicly accessible URL that documents the deletion process.

## Follow-up (separate PR)

Google Play also requires an **in-app** "Delete account" entry point — typically a button in the mobile app's Account / Settings screen that opens this URL. Not included here; will be a follow-up against `packages/agents-mobile/`.

## Test plan

- [ ] `cd website && npm run dev` → http://localhost:5173/about/legal/delete-account renders with the standard legal-page styling (light + dark mode).
- [ ] Sidebar shows "Delete your account" under Legal.
- [ ] http://localhost:5173/about/legal/privacy#your-choices — the Deletion bullet links to the new page.
- [ ] `npm run build` from `website/` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)