### PR TITLE
feat(agents-mobile): add Delete account button

### DIFF
--- a/.changeset/mobile-delete-account-button.md
+++ b/.changeset/mobile-delete-account-button.md
@@ -1,0 +1,9 @@
+---
+'@electric-ax/agents-mobile': patch
+---
+
+Add an in-app "Delete account" button to the Account screen (visible
+when signed in to Electric Cloud). Tapping the button opens the
+account-deletion instructions page at
+https://electric-sql.com/about/legal/delete-account in the system
+browser. Required for Google Play submission.

--- a/packages/agents-mobile/src/screens/AccountScreen.tsx
+++ b/packages/agents-mobile/src/screens/AccountScreen.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import * as Linking from 'expo-linking'
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { Icon } from '../components/Icon'
 import { PrimaryButton } from '../components/PrimaryButton'
@@ -7,6 +8,8 @@ import { useTokens } from '../lib/ThemeProvider'
 import { useCloudAuth } from '../lib/CloudAuthContext'
 import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
+
+const DELETE_ACCOUNT_URL = `https://electric-sql.com/about/legal/delete-account`
 
 /**
  * Settings → Account screen. Mirrors the desktop's `AccountPage` —
@@ -58,58 +61,81 @@ export function AccountScreen({
         </View>
 
         {isSignedIn ? (
-          <View style={styles.card}>
-            <View style={styles.row}>
-              <Text style={styles.rowLabel}>Account</Text>
-              <View style={styles.rowValue}>
-                <Text style={styles.rowValueText} numberOfLines={2}>
-                  {state.name && state.email
-                    ? `${state.name} (${state.email})`
-                    : (state.name ?? state.email ?? `Signed in`)}
-                </Text>
+          <>
+            <View style={styles.card}>
+              <View style={styles.row}>
+                <Text style={styles.rowLabel}>Account</Text>
+                <View style={styles.rowValue}>
+                  <Text style={styles.rowValueText} numberOfLines={2}>
+                    {state.name && state.email
+                      ? `${state.name} (${state.email})`
+                      : (state.name ?? state.email ?? `Signed in`)}
+                  </Text>
+                </View>
               </View>
-            </View>
-            <View style={styles.rowDivider} />
-            <View style={styles.row}>
-              <Text style={styles.rowLabel}>Workspaces</Text>
-              <View style={styles.rowValue}>
-                {workspaces === null ? (
-                  <Text style={[styles.rowValueText, styles.rowValueMuted]}>
-                    Loading…
-                  </Text>
-                ) : workspaces.length === 0 ? (
-                  <Text style={[styles.rowValueText, styles.rowValueMuted]}>
-                    No workspaces yet
-                  </Text>
-                ) : (
-                  workspaces.map((w) => (
-                    <Text
-                      key={w.id}
-                      style={styles.rowValueText}
-                      numberOfLines={1}
-                    >
-                      {w.name}
+              <View style={styles.rowDivider} />
+              <View style={styles.row}>
+                <Text style={styles.rowLabel}>Workspaces</Text>
+                <View style={styles.rowValue}>
+                  {workspaces === null ? (
+                    <Text style={[styles.rowValueText, styles.rowValueMuted]}>
+                      Loading…
                     </Text>
-                  ))
-                )}
+                  ) : workspaces.length === 0 ? (
+                    <Text style={[styles.rowValueText, styles.rowValueMuted]}>
+                      No workspaces yet
+                    </Text>
+                  ) : (
+                    workspaces.map((w) => (
+                      <Text
+                        key={w.id}
+                        style={styles.rowValueText}
+                        numberOfLines={1}
+                      >
+                        {w.name}
+                      </Text>
+                    ))
+                  )}
+                </View>
+              </View>
+              <View style={styles.actions}>
+                <PrimaryButton
+                  title="Open Electric Cloud dashboard"
+                  onPress={() => {
+                    void openDashboard()
+                  }}
+                />
+                <PrimaryButton
+                  title="Sign out"
+                  variant="soft"
+                  onPress={() => {
+                    void signOut()
+                  }}
+                />
               </View>
             </View>
-            <View style={styles.actions}>
-              <PrimaryButton
-                title="Open Electric Cloud dashboard"
-                onPress={() => {
-                  void openDashboard()
-                }}
-              />
-              <PrimaryButton
-                title="Sign out"
-                variant="soft"
-                onPress={() => {
-                  void signOut()
-                }}
-              />
+
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Delete account</Text>
+              <Text style={styles.sectionCopy}>
+                Tap below to open the account-deletion page in your browser.
+                Your account is not deleted by tapping the button — the page
+                explains what gets deleted, what we may retain, and how to email
+                support to start the request.
+              </Text>
             </View>
-          </View>
+            <View style={styles.card}>
+              <View style={styles.actions}>
+                <PrimaryButton
+                  title="Delete account…"
+                  variant="ghost"
+                  onPress={() => {
+                    void Linking.openURL(DELETE_ACCOUNT_URL)
+                  }}
+                />
+              </View>
+            </View>
+          </>
         ) : (
           <View style={styles.card}>
             {state.error && (


### PR DESCRIPTION
## Summary

- Adds an in-app **Delete account** entry point on the Account screen, visible only when signed in to Electric Cloud.
- Tapping it opens https://electric-sql.com/about/legal/delete-account in the system browser, where the user can read what gets deleted, what may be retained, and email support to start the request.
- Pairs with #4427 (web page).

## Why

Google Play's account-deletion policy (https://support.google.com/googleplay/android-developer/answer/13327111) requires both an in-app option *and* a publicly accessible web URL describing the process. The web page alone won't pass review.

## UI placement

Sits below the existing Account / Workspaces / Open dashboard / Sign out card, in its own "Delete account" section with explanatory copy that the button just opens instructions — it doesn't perform the deletion directly. Uses the `ghost` button variant to visually de-emphasize it relative to the primary actions.

## Test plan

- [x] `pnpm --filter @electric-ax/agents-mobile run typecheck`
- [ ] Open the Account screen while signed in → "Delete account" section appears below the main card with the explanatory text + ghost button.
- [ ] Tap "Delete account…" → system browser opens to https://electric-sql.com/about/legal/delete-account.
- [ ] Open the Account screen while signed *out* → section is hidden (sign-in buttons shown instead, as before).

## Depends on

- #4427 — once that lands, the URL the button opens will be live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)