### PR TITLE
fix(agents): align TypeScript peer context

### DIFF
--- a/.changeset/smooth-state-aligns.md
+++ b/.changeset/smooth-state-aligns.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': patch
+---
+
+Align the agents package TypeScript peer context with agents-runtime so Durable Streams state and TanStack DB resolve to a single shared instance for live queries over runtime collections.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -71,7 +71,7 @@
     "cross-env": "^10.1.0",
     "tsdown": "^0.9.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.0.0",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.0"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1507,7 +1507,7 @@ importers:
     dependencies:
       '@durable-streams/state':
         specifier: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217
-        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.8.3)
+        version: https://pkg.pr.new/durable-streams/durable-streams/@durable-streams/state@5d5c217(typescript@5.9.3)
       '@electric-ax/agents-mcp':
         specifier: workspace:*
         version: link:../agents-mcp
@@ -1556,13 +1556,13 @@ importers:
         version: 10.1.0
       tsdown:
         specifier: ^0.9.0
-        version: 0.9.9(typescript@5.8.3)
+        version: 0.9.9(typescript@5.9.3)
       tsx:
         specifier: ^4.19.0
         version: 4.20.3
       typescript:
-        specifier: ^5.0.0
-        version: 5.8.3
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.0
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.2)(tsx@4.20.3)(yaml@2.8.1))


### PR DESCRIPTION
## Summary
- Align `@electric-ax/agents` with the `agents-runtime` TypeScript peer context so `@durable-streams/state` and TanStack DB resolve to a shared instance.
- Add a patch changeset for `@electric-ax/agents`.

## Test plan
- `pnpm --filter @electric-ax/agents exec vitest run test/generate-title.test.ts test/horton-tool-composition.test.ts test/horton-model-selection.test.ts`
- `pnpm --filter @electric-ax/agents typecheck`
- `pnpm --filter @electric-ax/agents-runtime typecheck`
- `pnpm --filter @electric-ax/agents build`
- `pnpm --filter @electric-ax/agents-desktop build`


Made with [Cursor](https://cursor.com)