### PR TITLE
feat(agents-desktop): add launch at login

### DIFF
--- a/.changeset/warm-agents-login.md
+++ b/.changeset/warm-agents-login.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-desktop': patch
+'@electric-ax/agents-server-ui': patch
+---
+
+Add a launch-at-login preference for Electric Agents Desktop, including background startup handling, settings/onboarding controls, and a shared Base UI switch control.

--- a/packages/agents-desktop/src/app/controller.ts
+++ b/packages/agents-desktop/src/app/controller.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow } from 'electron'
 import type { DesktopAppContext } from './context'
 import * as AppLifecycle from './lifecycle'
+import * as LoginItems from './login-items'
 import * as CloudAuthInjection from '../cloud/auth-injection'
 import * as ServerFetch from '../cloud/server-fetch'
 import { createCredentialsController } from '../credentials/controller'
@@ -274,6 +275,21 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
       quitApp,
     })
 
+  const getLaunchAtLoginStatus = () => LoginItems.getLaunchAtLoginStatus()
+
+  const setLaunchAtLogin = async (enabled: boolean) => {
+    const status = await LoginItems.setLaunchAtLogin(enabled)
+    if (!status.supported) return status
+
+    settings.launchAtLogin = enabled
+    await saveSettings()
+    return status
+  }
+
+  const syncLaunchAtLoginSetting = async (): Promise<void> => {
+    await LoginItems.setLaunchAtLogin(settings.launchAtLogin === true)
+  }
+
   const applyNativeAppearance = (appearance: DesktopAppearance): void => {
     AppLifecycle.applyNativeAppearance(ctx, appearance)
   }
@@ -359,6 +375,8 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     lastMcpSnapshots,
     getCloudAuth: ctx.getCloudAuth,
     getCloudAgentServers: ctx.getCloudAgentServers,
+    getLaunchAtLoginStatus,
+    setLaunchAtLogin,
   }
 
   const loadSettings = (): Promise<void> =>
@@ -434,6 +452,7 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     buildApplicationMenu,
     createWindow,
     showOrCreateWindow,
+    syncLaunchAtLoginSetting,
     connectConfiguredServers,
     startDiscoveryLoop: localDiscovery.startDiscoveryLoop,
     quitApp,

--- a/packages/agents-desktop/src/app/login-items.ts
+++ b/packages/agents-desktop/src/app/login-items.ts
@@ -1,0 +1,143 @@
+import { app } from 'electron'
+import { access, mkdir, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { BACKGROUND_LAUNCH_ARG } from '../shared/constants'
+import type { LaunchAtLoginStatus } from '../shared/types'
+
+const LAUNCH_AGENT_LABEL = `com.electric-sql.agents.launch-at-login`
+
+function isMac(): boolean {
+  return process.platform === `darwin`
+}
+
+function isWindows(): boolean {
+  return process.platform === `win32`
+}
+
+function hasBackgroundLaunchArg(argv: ReadonlyArray<string>): boolean {
+  return argv.includes(BACKGROUND_LAUNCH_ARG)
+}
+
+export function isBackgroundLaunch(argv = process.argv): boolean {
+  return hasBackgroundLaunchArg(argv)
+}
+
+export function shouldOpenWindowForSecondInstance(
+  argv: ReadonlyArray<string>
+): boolean {
+  return !hasBackgroundLaunchArg(argv)
+}
+
+function launchAgentsDir(): string {
+  return path.join(app.getPath(`home`), `Library`, `LaunchAgents`)
+}
+
+function launchAgentPath(): string {
+  return path.join(launchAgentsDir(), `${LAUNCH_AGENT_LABEL}.plist`)
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll(`&`, `&amp;`)
+    .replaceAll(`<`, `&lt;`)
+    .replaceAll(`>`, `&gt;`)
+    .replaceAll(`"`, `&quot;`)
+    .replaceAll(`'`, `&apos;`)
+}
+
+function appLaunchArguments(): Array<string> {
+  return app.isPackaged
+    ? [process.execPath, BACKGROUND_LAUNCH_ARG]
+    : [process.execPath, app.getAppPath(), BACKGROUND_LAUNCH_ARG]
+}
+
+function launchAgentPlist(): string {
+  const args = appLaunchArguments()
+    .map((arg) => `    <string>${xmlEscape(arg)}</string>`)
+    .join(`\n`)
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCH_AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>
+`
+}
+
+async function launchAgentExists(): Promise<boolean> {
+  try {
+    await access(launchAgentPath())
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function setMacLaunchAtLogin(enabled: boolean): Promise<void> {
+  if (enabled) {
+    await mkdir(launchAgentsDir(), { recursive: true })
+    await writeFile(launchAgentPath(), launchAgentPlist(), `utf8`)
+    return
+  }
+
+  await rm(launchAgentPath(), { force: true })
+}
+
+function setNativeLaunchAtLogin(enabled: boolean): void {
+  app.setLoginItemSettings({
+    openAtLogin: enabled,
+    args: [BACKGROUND_LAUNCH_ARG],
+  })
+}
+
+export async function setLaunchAtLogin(
+  enabled: boolean
+): Promise<LaunchAtLoginStatus> {
+  if (isMac()) {
+    await setMacLaunchAtLogin(enabled)
+    return getLaunchAtLoginStatus()
+  }
+
+  if (isWindows()) {
+    setNativeLaunchAtLogin(enabled)
+    return getLaunchAtLoginStatus()
+  }
+
+  return getLaunchAtLoginStatus()
+}
+
+export async function getLaunchAtLoginStatus(): Promise<LaunchAtLoginStatus> {
+  if (isMac()) {
+    return {
+      supported: true,
+      enabled: await launchAgentExists(),
+      reason: null,
+    }
+  }
+
+  if (isWindows()) {
+    const settings = app.getLoginItemSettings({
+      args: [BACKGROUND_LAUNCH_ARG],
+    })
+    return {
+      supported: true,
+      enabled: settings.openAtLogin,
+      reason: null,
+    }
+  }
+
+  return {
+    supported: false,
+    enabled: false,
+    reason: `Launch at login is not supported on this platform yet.`,
+  }
+}

--- a/packages/agents-desktop/src/ipc/preferences.ts
+++ b/packages/agents-desktop/src/ipc/preferences.ts
@@ -1,0 +1,16 @@
+import { ipcMain } from 'electron'
+import type { LaunchAtLoginStatus } from '../shared/types'
+
+export type PreferencesIpcDeps = {
+  getLaunchAtLoginStatus: () => Promise<LaunchAtLoginStatus>
+  setLaunchAtLogin: (enabled: boolean) => Promise<LaunchAtLoginStatus>
+}
+
+export function registerPreferencesIpcHandlers(deps: PreferencesIpcDeps): void {
+  ipcMain.handle(`desktop:get-launch-at-login`, () =>
+    deps.getLaunchAtLoginStatus()
+  )
+  ipcMain.handle(`desktop:set-launch-at-login`, (_event, enabled: boolean) =>
+    deps.setLaunchAtLogin(Boolean(enabled))
+  )
+}

--- a/packages/agents-desktop/src/ipc/register.ts
+++ b/packages/agents-desktop/src/ipc/register.ts
@@ -2,12 +2,14 @@ import { registerCloudIpcHandlers } from './cloud'
 import { registerChromeIpcHandlers } from './chrome'
 import { registerCredentialsIpcHandlers } from './credentials'
 import { registerMcpIpcHandlers } from './mcp'
+import { registerPreferencesIpcHandlers } from './preferences'
 import { registerRuntimeIpcHandlers } from './runtime'
 import { registerServerIpcHandlers } from './servers'
 import type { CloudIpcDeps } from './cloud'
 import type { ChromeIpcDeps } from './chrome'
 import type { CredentialsIpcDeps } from './credentials'
 import type { McpIpcDeps } from './mcp'
+import type { PreferencesIpcDeps } from './preferences'
 import type { RuntimeIpcDeps } from './runtime'
 import type { ServerIpcDeps } from './servers'
 
@@ -16,6 +18,7 @@ export type RegisterDesktopIpcDeps = ServerIpcDeps &
   CredentialsIpcDeps &
   CloudIpcDeps &
   McpIpcDeps &
+  PreferencesIpcDeps &
   ChromeIpcDeps
 
 export function registerIpcHandlers(deps: RegisterDesktopIpcDeps): void {
@@ -24,5 +27,6 @@ export function registerIpcHandlers(deps: RegisterDesktopIpcDeps): void {
   registerCredentialsIpcHandlers(deps)
   registerCloudIpcHandlers(deps)
   registerMcpIpcHandlers(deps)
+  registerPreferencesIpcHandlers(deps)
   registerChromeIpcHandlers(deps)
 }

--- a/packages/agents-desktop/src/main.ts
+++ b/packages/agents-desktop/src/main.ts
@@ -1,4 +1,5 @@
 import * as AppLifecycle from './app/lifecycle'
+import * as LoginItems from './app/login-items'
 import {
   createDesktopMainController,
   type DesktopMainController,
@@ -66,8 +67,10 @@ async function main(): Promise<void> {
     return
   }
 
-  app.on(`second-instance`, () => {
-    desktopController?.showOrCreateWindow()
+  app.on(`second-instance`, (_event, argv) => {
+    if (LoginItems.shouldOpenWindowForSecondInstance(argv)) {
+      desktopController?.showOrCreateWindow()
+    }
   })
 
   app.on(`window-all-closed`, () => {
@@ -98,6 +101,9 @@ async function main(): Promise<void> {
   }
   AppLifecycle.configureRuntimeEnvironment()
   await controller.loadSettings()
+  await controller.syncLaunchAtLoginSetting().catch((error) => {
+    console.warn(`[agents-desktop] Failed to sync login item settings:`, error)
+  })
   controller.registerIpcHandlers()
   await desktopContext.getCloudAuth().initialize()
   // Hydrate the per-tenant agents-token cache from `SecretStore`
@@ -120,7 +126,9 @@ async function main(): Promise<void> {
 
   controller.createTray()
   controller.buildApplicationMenu()
-  controller.createWindow()
+  if (!LoginItems.isBackgroundLaunch()) {
+    controller.createWindow()
+  }
   controller.connectConfiguredServers()
   controller.startDiscoveryLoop()
 }

--- a/packages/agents-desktop/src/preload.ts
+++ b/packages/agents-desktop/src/preload.ts
@@ -16,6 +16,7 @@ import type {
   DesktopServerFetchResponse,
   DesktopState,
   DiscoveredServer,
+  LaunchAtLoginStatus,
   OnboardingState,
   ServerConfig,
 } from './shared/types'
@@ -166,6 +167,10 @@ const api = {
     ipcRenderer.invoke(`desktop:restart-local-runtimes`),
   clearAllLocalData: (): Promise<void> =>
     ipcRenderer.invoke(`desktop:clear-all-local-data`),
+  getLaunchAtLoginStatus: (): Promise<LaunchAtLoginStatus> =>
+    ipcRenderer.invoke(`desktop:get-launch-at-login`),
+  setLaunchAtLogin: (enabled: boolean): Promise<LaunchAtLoginStatus> =>
+    ipcRenderer.invoke(`desktop:set-launch-at-login`, enabled),
   getOnboardingState: (): Promise<OnboardingState> =>
     ipcRenderer.invoke(`desktop:get-onboarding-state`),
   setOnboardingDismissed: (dismissed: boolean): Promise<void> =>

--- a/packages/agents-desktop/src/settings/store.ts
+++ b/packages/agents-desktop/src/settings/store.ts
@@ -27,6 +27,7 @@ export const DEFAULT_SETTINGS: DesktopSettings = {
   defaultServerId: null,
   workingDirectory: null,
   apiKeysRef: GLOBAL_API_KEYS_REF,
+  launchAtLogin: false,
   codex: { enabled: false, source: null },
 }
 
@@ -155,6 +156,7 @@ export async function loadDesktopSettings(
           ? parsed.workingDirectory
           : null,
       apiKeysRef,
+      launchAtLogin: parsed.launchAtLogin === true,
       onboardingDismissed: parsed.onboardingDismissed === true,
       codex: normalizeCodexSettings(parsed.codex),
       mcp: normalizeMcp(parsed.mcp),

--- a/packages/agents-desktop/src/shared/constants.ts
+++ b/packages/agents-desktop/src/shared/constants.ts
@@ -40,6 +40,7 @@ export const INITIAL_SERVER_URL =
   null
 export const DEV_SERVER_URL =
   process.env.ELECTRIC_DESKTOP_DEV_SERVER_URL ?? null
+export const BACKGROUND_LAUNCH_ARG = `--electric-background-launch`
 
 export const PULL_WAKE_RUNNER_ID =
   process.env.ELECTRIC_DESKTOP_PULL_WAKE_RUNNER_ID?.trim() || null

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -111,10 +111,17 @@ export type DesktopSettings = {
   defaultServerId: string | null
   workingDirectory: string | null
   apiKeysRef: string
+  launchAtLogin?: boolean
   codex?: CodexSettings
   onboardingDismissed?: boolean
   mcp?: { servers: Array<McpServerConfig> }
   pullWakeRunnerId?: string
+}
+
+export type LaunchAtLoginStatus = {
+  supported: boolean
+  enabled: boolean
+  reason: string | null
 }
 
 export type RuntimeEntry = {

--- a/packages/agents-server-ui/src/components/OnboardingModal.tsx
+++ b/packages/agents-server-ui/src/components/OnboardingModal.tsx
@@ -10,6 +10,7 @@ import {
   EyeOff,
   Github,
   Laptop,
+  LogIn,
   Plug,
   Server,
   Sparkles,
@@ -22,11 +23,13 @@ import {
   loadApiKeysStatus,
   loadCloudAuthState,
   loadDesktopState,
+  loadLaunchAtLoginStatus,
   loadOnboardingState,
   onCloudAuthStateChanged,
   prepareCloudAgentServerConnection,
   restartLocalRuntimes,
   saveApiKeys as persistApiKeys,
+  setLaunchAtLogin,
   setOnboardingDismissed,
   type ApiKeys,
   type ApiKeysStatus,
@@ -34,20 +37,31 @@ import {
   type ConnectServerOptions,
   type CodexAuthSource,
   type CodexStatus,
+  type LaunchAtLoginStatus,
 } from '../lib/server-connection'
 import {
   useAvailableServers,
   type AvailableServer,
 } from '../hooks/useAvailableServers'
 import { useServerConnection } from '../hooks/useServerConnection'
-import { Button, Dialog, Icon, IconButton, Input, Link, Text } from '../ui'
+import {
+  Button,
+  Dialog,
+  Icon,
+  IconButton,
+  Input,
+  Link,
+  Switch,
+  Text,
+} from '../ui'
 import styles from './OnboardingModal.module.css'
 
-type Step = `cloud` | `keys` | `server`
+type Step = `cloud` | `keys` | `config` | `server`
 
-const STEPS: ReadonlyArray<{ id: Step; label: string }> = [
+const BASE_STEPS: ReadonlyArray<{ id: Step; label: string }> = [
   { id: `cloud`, label: `Cloud` },
   { id: `keys`, label: `Models` },
+  { id: `config`, label: `Config` },
   { id: `server`, label: `Server` },
 ]
 
@@ -122,28 +136,44 @@ export function OnboardingModal(): React.ReactElement | null {
   const [step, setStep] = useState<Step>(`cloud`)
   const [cloudState, setCloudState] = useState<CloudAuthState | null>(null)
   const [keysStatus, setKeysStatus] = useState<ApiKeysStatus | null>(null)
+  const [launchAtLoginStatus, setLaunchAtLoginStatus] =
+    useState<LaunchAtLoginStatus | null>(null)
+  const [launchAtLoginEnabled, setLaunchAtLoginEnabled] = useState(false)
   const [bootstrapped, setBootstrapped] = useState(false)
+  const configAvailable = launchAtLoginStatus?.supported === true
+  const steps = useMemo(
+    () =>
+      configAvailable
+        ? BASE_STEPS
+        : BASE_STEPS.filter((candidate) => candidate.id !== `config`),
+    [configAvailable]
+  )
 
   useEffect(() => {
     if (!isDesktop) return
     let cancelled = false
 
     void (async () => {
-      const [onboarding, cloud, keys] = await Promise.all([
+      const [onboarding, cloud, keys, launchAtLogin] = await Promise.all([
         loadOnboardingState(),
         loadCloudAuthState(),
         loadApiKeysStatus(),
+        loadLaunchAtLoginStatus(),
       ])
       if (cancelled) return
       setCloudState(cloud)
       setKeysStatus(keys)
+      setLaunchAtLoginStatus(launchAtLogin)
+      setLaunchAtLoginEnabled(launchAtLogin?.enabled ?? false)
       setBootstrapped(true)
 
       if (!onboarding || onboarding.dismissed) return
       setStep(
         onboarding.signedIn
           ? onboarding.hasAnyKey
-            ? `server`
+            ? launchAtLogin?.supported
+              ? `config`
+              : `server`
             : `keys`
           : `cloud`
       )
@@ -216,7 +246,7 @@ export function OnboardingModal(): React.ReactElement | null {
       }}
     >
       <Dialog.Content maxWidth={640} className={styles.content}>
-        <StepIndicator step={step} />
+        <StepIndicator step={step} steps={steps} />
         <div className={styles.body}>
           {step === `cloud` && (
             <CloudStep
@@ -230,13 +260,23 @@ export function OnboardingModal(): React.ReactElement | null {
               keysStatus={keysStatus}
               onKeysStatusChange={setKeysStatus}
               onBack={() => setStep(`cloud`)}
+              onContinue={() => setStep(configAvailable ? `config` : `server`)}
+            />
+          )}
+          {step === `config` && configAvailable && (
+            <ConfigStep
+              launchAtLoginEnabled={launchAtLoginEnabled}
+              onLaunchAtLoginEnabledChange={setLaunchAtLoginEnabled}
+              onBack={() => setStep(`keys`)}
               onContinue={() => setStep(`server`)}
             />
           )}
           {step === `server` && (
             <ServerStep
               cloudState={cloudState}
-              onBack={() => setStep(`keys`)}
+              onBack={() => setStep(configAvailable ? `config` : `keys`)}
+              applyLaunchAtLogin={configAvailable}
+              launchAtLoginEnabled={launchAtLoginEnabled}
               onFinish={() => {
                 void closeModal()
               }}
@@ -245,6 +285,73 @@ export function OnboardingModal(): React.ReactElement | null {
         </div>
       </Dialog.Content>
     </Dialog.Root>
+  )
+}
+
+function ConfigStep({
+  launchAtLoginEnabled,
+  onLaunchAtLoginEnabledChange,
+  onBack,
+  onContinue,
+}: {
+  launchAtLoginEnabled: boolean
+  onLaunchAtLoginEnabledChange: (enabled: boolean) => void
+  onBack: () => void
+  onContinue: () => void
+}): React.ReactElement {
+  return (
+    <>
+      <StepHeader
+        title="Config"
+        description="Choose how Electric Agents should run on this machine."
+      />
+      <Section>
+        <SectionRow>
+          <span className={styles.iconCircle}>
+            <Icon icon={LogIn} size={2} />
+          </span>
+          <label className={styles.rowText} style={{ cursor: `pointer` }}>
+            <span className={styles.rowTitle}>Open at login</span>
+            <Text size={1} tone="muted">
+              Start Electric Agents when you sign in and keep it available from
+              the system tray.
+            </Text>
+          </label>
+          <span className={styles.rowAside}>
+            <Switch
+              checked={launchAtLoginEnabled}
+              onCheckedChange={onLaunchAtLoginEnabledChange}
+              ariaLabel="Open Electric Agents at login"
+            />
+          </span>
+        </SectionRow>
+      </Section>
+      <Footer
+        leading={
+          <Button
+            type="button"
+            variant="ghost"
+            tone="neutral"
+            size={2}
+            onClick={onBack}
+          >
+            Back
+          </Button>
+        }
+        trailing={
+          <Button
+            type="button"
+            variant="solid"
+            tone="accent"
+            size={2}
+            onClick={onContinue}
+          >
+            Continue
+            <Icon icon={ArrowRight} size={2} />
+          </Button>
+        }
+      />
+    </>
   )
 }
 
@@ -736,17 +843,42 @@ function ProviderItem({
 function ServerStep({
   cloudState,
   onBack,
+  applyLaunchAtLogin,
+  launchAtLoginEnabled,
   onFinish,
 }: {
   cloudState: CloudAuthState | null
   onBack: () => void
-  onFinish: () => void
+  applyLaunchAtLogin: boolean
+  launchAtLoginEnabled: boolean
+  onFinish: () => void | Promise<void>
 }): React.ReactElement {
   const { servers } = useAvailableServers()
   const { addServer, connectServer, setActiveServer } = useServerConnection()
   const [serverError, setServerError] = useState<string | null>(null)
   const [connectingKey, setConnectingKey] = useState<string | null>(null)
   const cloudSignedIn = cloudState?.status === `signed-in`
+
+  const finish = async (): Promise<void> => {
+    setServerError(null)
+    if (applyLaunchAtLogin) {
+      try {
+        const status = await setLaunchAtLogin(launchAtLoginEnabled)
+        if (status && !status.supported) {
+          setServerError(status.reason ?? `Open at login is not supported.`)
+          return
+        }
+      } catch (error) {
+        setServerError(
+          error instanceof Error
+            ? error.message
+            : `Could not enable open at login.`
+        )
+        return
+      }
+    }
+    await onFinish()
+  }
 
   const connectAvailableServer = async (item: AvailableServer) => {
     setServerError(null)
@@ -756,7 +888,7 @@ function ServerStep({
       if (item.server) {
         setActiveServer(item.server)
         connectServer(item.server.id, options)
-        onFinish()
+        await finish()
         return
       }
 
@@ -776,7 +908,7 @@ function ServerStep({
           },
           options
         )
-        onFinish()
+        await finish()
         return
       }
 
@@ -791,7 +923,7 @@ function ServerStep({
           },
           options
         )
-        onFinish()
+        await finish()
       }
     } catch (error) {
       setServerError(
@@ -882,7 +1014,9 @@ function ServerStep({
             variant="ghost"
             tone="neutral"
             size={2}
-            onClick={onFinish}
+            onClick={() => {
+              void finish()
+            }}
           >
             Skip for now
           </Button>
@@ -1008,12 +1142,18 @@ function Footer({
   )
 }
 
-function StepIndicator({ step }: { step: Step }): React.ReactElement {
-  const activeIndex = STEPS.findIndex((candidate) => candidate.id === step)
+function StepIndicator({
+  step,
+  steps,
+}: {
+  step: Step
+  steps: ReadonlyArray<{ id: Step; label: string }>
+}): React.ReactElement {
+  const activeIndex = steps.findIndex((candidate) => candidate.id === step)
 
   return (
     <div className={styles.steps} aria-label="Onboarding progress">
-      {STEPS.map((candidate, index) => {
+      {steps.map((candidate, index) => {
         const active = candidate.id === step
         const complete = index < activeIndex
         return (

--- a/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
@@ -1,16 +1,22 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import {
   Brain,
   KeyRound,
+  LogIn,
   Palette,
   Plug,
   Server,
   Trash2,
   UserCircle,
 } from 'lucide-react'
-import { Button, ConfirmDialog, Icon, Text } from '../../../ui'
-import { clearAllLocalData } from '../../../lib/server-connection'
+import { Button, ConfirmDialog, Icon, Switch, Text } from '../../../ui'
+import {
+  clearAllLocalData,
+  loadLaunchAtLoginStatus,
+  setLaunchAtLogin,
+  type LaunchAtLoginStatus,
+} from '../../../lib/server-connection'
 import {
   SettingsPanel,
   SettingsRow,
@@ -36,6 +42,31 @@ export function GeneralPage(): React.ReactElement {
   const [isClearing, setIsClearing] = useState(false)
   const [showResetConfirm, setShowResetConfirm] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [launchAtLogin, setLaunchAtLoginStatus] =
+    useState<LaunchAtLoginStatus | null>(null)
+  const [launchAtLoginBusy, setLaunchAtLoginBusy] = useState(false)
+  const [launchAtLoginError, setLaunchAtLoginError] = useState<string | null>(
+    null
+  )
+
+  useEffect(() => {
+    if (!isDesktop) return
+    let cancelled = false
+    void loadLaunchAtLoginStatus()
+      .then((status) => {
+        if (!cancelled) setLaunchAtLoginStatus(status)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setLaunchAtLoginError(
+            err instanceof Error ? err.message : String(err)
+          )
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isDesktop])
 
   const handleClearAllLocalData = async (): Promise<void> => {
     setError(null)
@@ -46,6 +77,19 @@ export function GeneralPage(): React.ReactElement {
       setIsClearing(false)
       setShowResetConfirm(false)
       setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const handleLaunchAtLoginChange = async (enabled: boolean): Promise<void> => {
+    setLaunchAtLoginBusy(true)
+    setLaunchAtLoginError(null)
+    try {
+      const next = await setLaunchAtLogin(enabled)
+      setLaunchAtLoginStatus(next)
+    } catch (err) {
+      setLaunchAtLoginError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLaunchAtLoginBusy(false)
     }
   }
 
@@ -82,7 +126,7 @@ export function GeneralPage(): React.ReactElement {
               navigate({ to: `/settings/$category`, params: { category } })
             }
           />
-          {isDesktop && (
+          {isDesktop && launchAtLogin?.supported && (
             <SettingsLinkRow
               icon={Brain}
               label="Local Runtime"
@@ -106,6 +150,41 @@ export function GeneralPage(): React.ReactElement {
           )}
         </SettingsSection>
         <SettingsSection title="Preferences">
+          {isDesktop && (
+            <SettingsRow
+              label={
+                <span
+                  style={{
+                    display: `inline-flex`,
+                    alignItems: `center`,
+                    gap: 8,
+                  }}
+                >
+                  <Icon icon={LogIn} size={2} />
+                  Open at login
+                </span>
+              }
+              description={
+                launchAtLoginError ??
+                launchAtLogin?.reason ??
+                `Start Electric Agents when you sign in and keep the runtime available from the system tray.`
+              }
+              control={
+                <Switch
+                  checked={launchAtLogin?.enabled ?? false}
+                  disabled={
+                    launchAtLoginBusy ||
+                    !launchAtLogin ||
+                    !launchAtLogin.supported
+                  }
+                  onCheckedChange={(checked) => {
+                    void handleLaunchAtLoginChange(checked)
+                  }}
+                  ariaLabel="Open Electric Agents at login"
+                />
+              }
+            />
+          )}
           <SettingsLinkRow
             icon={Palette}
             label="Appearance"

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -159,6 +159,12 @@ export interface OnboardingState {
   signedIn: boolean
 }
 
+export interface LaunchAtLoginStatus {
+  supported: boolean
+  enabled: boolean
+  reason: string | null
+}
+
 /**
  * Commands fired from the Electron application menu / tray over the
  * `desktop:command` IPC channel. The renderer's command handler (see
@@ -308,6 +314,8 @@ declare global {
       codexDisable?: () => Promise<CodexStatus>
       restartLocalRuntimes?: () => Promise<void>
       clearAllLocalData?: () => Promise<void>
+      getLaunchAtLoginStatus?: () => Promise<LaunchAtLoginStatus>
+      setLaunchAtLogin?: (enabled: boolean) => Promise<LaunchAtLoginStatus>
       getOnboardingState?: () => Promise<OnboardingState>
       setOnboardingDismissed?: (dismissed: boolean) => Promise<void>
       getWorkingDirectory?: () => Promise<string | null>
@@ -532,6 +540,16 @@ export async function restartLocalRuntimes(): Promise<void> {
 
 export async function clearAllLocalData(): Promise<void> {
   await window.electronAPI?.clearAllLocalData?.()
+}
+
+export async function loadLaunchAtLoginStatus(): Promise<LaunchAtLoginStatus | null> {
+  return (await window.electronAPI?.getLaunchAtLoginStatus?.()) ?? null
+}
+
+export async function setLaunchAtLogin(
+  enabled: boolean
+): Promise<LaunchAtLoginStatus | null> {
+  return (await window.electronAPI?.setLaunchAtLogin?.(enabled)) ?? null
 }
 
 export async function loadOnboardingState(): Promise<OnboardingState | null> {

--- a/packages/agents-server-ui/src/ui/Switch.module.css
+++ b/packages/agents-server-ui/src/ui/Switch.module.css
@@ -1,0 +1,71 @@
+.root {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  width: 32px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-gray-a6);
+  cursor: pointer;
+  outline: none;
+  transition:
+    background 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.root::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px var(--ds-gray-a3);
+  pointer-events: none;
+}
+
+.root:hover:not([data-disabled]) {
+  background: var(--ds-gray-a7);
+}
+
+.root[data-checked] {
+  background: var(--ds-accent-9);
+}
+
+.root[data-checked]::before {
+  box-shadow: inset 0 0 0 1px var(--ds-accent-a3);
+}
+
+.root[data-checked]:hover:not([data-disabled]) {
+  background: var(--ds-accent-10);
+}
+
+.root:focus-visible {
+  box-shadow:
+    0 0 0 2px var(--ds-bg),
+    0 0 0 4px var(--ds-focus-ring);
+}
+
+.root[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.thumb {
+  display: block;
+  width: 14px;
+  height: 14px;
+  margin: 2px;
+  border-radius: var(--ds-radius-full);
+  background: #ffffff;
+  box-shadow:
+    0 1px 1px rgba(15, 15, 30, 0.12),
+    0 1px 3px rgba(15, 15, 30, 0.16);
+  transform: translateX(0);
+  transition: transform 180ms cubic-bezier(0.32, 0.72, 0.24, 1.18);
+}
+
+.root[data-checked] .thumb {
+  transform: translateX(14px);
+}

--- a/packages/agents-server-ui/src/ui/Switch.tsx
+++ b/packages/agents-server-ui/src/ui/Switch.tsx
@@ -1,0 +1,28 @@
+import { Switch as BaseSwitch } from '@base-ui/react/switch'
+import styles from './Switch.module.css'
+
+type SwitchProps = {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+  disabled?: boolean
+  ariaLabel?: string
+}
+
+export function Switch({
+  checked,
+  onCheckedChange,
+  disabled = false,
+  ariaLabel,
+}: SwitchProps): React.ReactElement {
+  return (
+    <BaseSwitch.Root
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      className={styles.root}
+    >
+      <BaseSwitch.Thumb className={styles.thumb} />
+    </BaseSwitch.Root>
+  )
+}

--- a/packages/agents-server-ui/src/ui/index.ts
+++ b/packages/agents-server-ui/src/ui/index.ts
@@ -59,6 +59,8 @@ export { Tooltip, TooltipProvider } from './Tooltip'
 export { Select } from './Select'
 export type { SelectSize } from './Select'
 
+export { Switch } from './Switch'
+
 export { Combobox } from './Combobox'
 
 export { ScrollArea } from './ScrollArea'


### PR DESCRIPTION
## Summary
- Add an Electric Agents Desktop launch-at-login preference with background startup support so login launches keep the app in the tray instead of opening a window.
- Surface the setting in Settings and in a supported-platform onboarding Config step.
- Add a patch changeset for the desktop and server UI packages.
- Supports Mac and Widows, but not linux.

## Stack
- Stacked on #4430: https://github.com/electric-sql/electric/pull/4430

## Screenshots

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/b9d6f79a-5303-4e05-bdf4-a6a78362ad88" />

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/50a04c45-4a01-4182-acb7-48f9b977c4ed" />

## Test plan
- `source ~/.nvm/nvm.sh && nvm use 22.13.0 >/dev/null && pnpm --filter @electric-ax/agents-desktop typecheck`
- `source ~/.nvm/nvm.sh && nvm use 22.13.0 >/dev/null && pnpm --filter @electric-ax/agents-server-ui typecheck`

Made with [Cursor](https://cursor.com)