### PR TITLE
refactor(agents-server-ui): redesign new-session prompt form

### DIFF
--- a/.changeset/horton-prompt-form-redesign.md
+++ b/.changeset/horton-prompt-form-redesign.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server-ui': patch
+---
+
+Refactor the new-session prompt form. Move the working-directory and runner pickers out of the composer's inline pill row into a "session context" tray that tucks under the composer's curved bottom edge (mirrors the chat screen's `<EntityContextDrawer>` pattern, just flipped). Give the runner picker visual parity with the working-directory picker via a new optional leading-icon slot on `Select.Trigger`, and reword the working-directory "None" option to "Don't work in a directory".

--- a/packages/agents-server-ui/src/components/NewSessionPage.module.css
+++ b/packages/agents-server-ui/src/components/NewSessionPage.module.css
@@ -224,10 +224,33 @@
 
 /* Default-agent quick-start composer -----------------------------
  *
- * Same trick as `.typeGrid` above: the composer extends outward by
- * its inner horizontal padding so the textarea content (placeholder,
- * typed text) lines up with the page title and subtitle above. */
-
+ * Same trick as `.typeGrid` above: the wrap (composer + meta row)
+ * extends outward by its inner horizontal padding so the textarea
+ * content (placeholder, typed text) lines up with the page title and
+ * subtitle above.
+ *
+ * Layout is split into two rows so the working-directory and runner
+ * pickers can sit on their own row *outside* the bordered input
+ * surface (mirrors the chat screen's `<EntityContextDrawer>` pattern,
+ * just flipped — drawer-above-composer there, meta-below-composer
+ * here):
+ *
+ *   .composerWrap                        ← outdented column
+ *     .composer       (bordered card)    ← textarea + inline pills
+ *     .composerMeta   (tray under)       ← cwd / runner pickers
+ *
+ * The meta row tucks UNDER the composer via a `-20px` top margin and
+ * matching `padding-top`, with the composer z-indexed above so its
+ * curved bottom edge visually overlaps the tray. Same geometry as
+ * `EntityContextDrawer.module.css → .drawer`. */
+.composerWrap {
+  display: flex;
+  flex-direction: column;
+  /* No flex gap — the meta row's negative top margin handles the
+     overlap. Any gap here would just leave a visible seam. */
+  gap: 0;
+  margin: 0 calc(-1 * var(--ds-space-4));
+}
 .composer {
   display: flex;
   flex-direction: column;
@@ -240,13 +263,58 @@
     0 1px 3px rgba(15, 15, 30, 0.04),
     0 1px 1px rgba(15, 15, 30, 0.02);
   transition: border-color 0.15s ease;
-  margin: 0 calc(-1 * var(--ds-space-4));
+  /* Stack on top of `.composerMeta` so its bottom edge paints over
+     the meta tray's hidden top 20px (mirrors the chat composer's
+     z-indexing over `<EntityContextDrawer>`). */
+  position: relative;
+  z-index: 1;
 }
 .composer:focus-within {
   border-color: var(--ds-accent-a6);
 }
 .composerDisabled {
   opacity: 0.6;
+}
+
+/* Meta row beneath the input — a "session context" tray so the
+ * working-directory and runner pickers read as deliberate session
+ * metadata tucked behind the composer rather than two loose chips
+ * floating below it.
+ *
+ * Mirrors `EntityContextDrawer.module.css → .drawer` (the drawer that
+ * docks ABOVE the chat composer), just flipped: where the chat
+ * drawer hides its bottom 20px behind the composer above it, this
+ * tray hides its top 20px behind the composer above it. Same border,
+ * radius, shadow, and 12px horizontal inset so the two patterns read
+ * as the same system element. The fill is one step *below* the page
+ * bg (`--ds-bg-subtle`) so the tray reads as a recessed surface the
+ * composer sits forward of, and so the picker pills (chip-bg = the
+ * raised surface white) pop on top instead of disappearing into it.
+ *
+ * Inner padding is `7px` (12px outer radius − 1px border − 4px pill
+ * radius) so the picker pills sit *concentrically* inside the tray —
+ * the gap between every pill edge and the tray edge is identical on
+ * all sides, just like the chat drawer's rows sit 3px from its 12px
+ * outer corner. The top adds the 20px composer overlap on top of
+ * that, for a 27px hidden-+-visible top padding. */
+.composerMeta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  background: var(--ds-bg-subtle);
+  border: 1px solid var(--ds-gray-a4);
+  border-radius: var(--ds-radius-5);
+  box-shadow:
+    0 1px 3px rgba(15, 15, 30, 0.04),
+    0 1px 1px rgba(15, 15, 30, 0.02);
+  padding: 27px 7px 7px;
+  /* Horizontal inset matches the chat drawer's 12px so the tray
+     visually nests inside the composer's border radius. -20px top
+     overlap is the composer overlap. */
+  margin: -20px 12px 0;
+  position: relative;
+  z-index: 0;
 }
 
 /* Auto-grow is driven by inline `height = scrollHeight` from

--- a/packages/agents-server-ui/src/components/WorkingDirectoryPicker.tsx
+++ b/packages/agents-server-ui/src/components/WorkingDirectoryPicker.tsx
@@ -58,7 +58,7 @@ export function WorkingDirectoryPicker({
   )
 
   const triggerLabel = useMemo(
-    () => (value ? tildifyPath(value, homeDir) : `None`),
+    () => (value ? tildifyPath(value, homeDir) : `No working directory`),
     [value, homeDir]
   )
 
@@ -123,7 +123,7 @@ export function WorkingDirectoryPicker({
             aria-label={
               value ? `Working directory: ${value}` : `Set working directory`
             }
-            title={value ?? `Use the server's default working directory`}
+            title={value ?? `Don’t work in a directory`}
           >
             <Icon icon={Folder} size={1} className={styles.triggerIcon} />
             <span className={styles.triggerLabel}>{triggerLabel}</span>
@@ -148,7 +148,9 @@ export function WorkingDirectoryPicker({
           <Combobox.Item value={NONE_VALUE} className={styles.pathItem}>
             <span className={styles.menuRow}>
               <Icon icon={Home} size={2} className={styles.menuRowIcon} />
-              <span className={styles.menuRowLabel}>None</span>
+              <span className={styles.menuRowLabel}>
+                Don’t work in a directory
+              </span>
               <span className={styles.trailing}>
                 {value === null && (
                   <span className={styles.trailingCheck}>

--- a/packages/agents-server-ui/src/components/views/NewSessionView.tsx
+++ b/packages/agents-server-ui/src/components/views/NewSessionView.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { ArrowUp, Sparkles } from 'lucide-react'
+import { ArrowUp, Cpu, Sparkles } from 'lucide-react'
 import { eq, not, useLiveQuery } from '@tanstack/react-db'
 import { nanoid } from 'nanoid'
 import { useElectricAgents } from '../../lib/ElectricAgentsProvider'
@@ -712,85 +712,94 @@ function DefaultAgentComposer({
 
   return (
     <div
-      className={[styles.composer, disabled ? styles.composerDisabled : null]
+      className={[
+        styles.composerWrap,
+        disabled ? styles.composerDisabled : null,
+      ]
         .filter(Boolean)
         .join(` `)}
     >
-      <textarea
-        ref={textareaRef}
-        autoFocus
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === `Enter` && !e.shiftKey) {
-            e.preventDefault()
-            submit()
-          }
-        }}
-        placeholder={placeholder}
-        disabled={disabled || submitting}
-        rows={1}
-        className={styles.composerTextarea}
-      />
-      <div className={styles.composerFooter}>
-        <div className={styles.composerControls}>
-          {inlineProps.map(({ key, prop }) =>
-            prop.enum ? (
-              <PillSelect
-                key={key}
-                label={prop.title ?? key}
-                value={String(args[key] ?? ``)}
-                options={prop.enum.map((v) => String(v))}
-                onChange={(next) => {
-                  const original = prop.enum!.find((v) => String(v) === next)
-                  if (isModelProperty(key)) persistLastPickedModel(next)
-                  setArgs((prev) => ({ ...prev, [key]: original ?? next }))
-                }}
-                disabled={submitting || disabled}
-              />
-            ) : prop.type === `boolean` ? (
-              <PillToggle
-                key={key}
-                label={prop.title ?? key}
-                checked={Boolean(args[key])}
-                onChange={(checked) =>
-                  setArgs((prev) => ({ ...prev, [key]: checked }))
-                }
-                disabled={submitting || disabled}
-              />
-            ) : null
-          )}
-          <WorkingDirectoryPicker
-            value={workingDirectory}
-            onChange={onChangeWorkingDirectory}
+      <div className={styles.composer}>
+        <textarea
+          ref={textareaRef}
+          autoFocus
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === `Enter` && !e.shiftKey) {
+              e.preventDefault()
+              submit()
+            }
+          }}
+          placeholder={placeholder}
+          disabled={disabled || submitting}
+          rows={1}
+          className={styles.composerTextarea}
+        />
+        <div className={styles.composerFooter}>
+          <div className={styles.composerControls}>
+            {inlineProps.map(({ key, prop }) =>
+              prop.enum ? (
+                <PillSelect
+                  key={key}
+                  label={prop.title ?? key}
+                  value={String(args[key] ?? ``)}
+                  options={prop.enum.map((v) => String(v))}
+                  onChange={(next) => {
+                    const original = prop.enum!.find((v) => String(v) === next)
+                    if (isModelProperty(key)) persistLastPickedModel(next)
+                    setArgs((prev) => ({ ...prev, [key]: original ?? next }))
+                  }}
+                  disabled={submitting || disabled}
+                />
+              ) : prop.type === `boolean` ? (
+                <PillToggle
+                  key={key}
+                  label={prop.title ?? key}
+                  checked={Boolean(args[key])}
+                  onChange={(checked) =>
+                    setArgs((prev) => ({ ...prev, [key]: checked }))
+                  }
+                  disabled={submitting || disabled}
+                />
+              ) : null
+            )}
+          </div>
+          <div className={styles.composerSendCluster}>
+            {submitting && (
+              <span className={styles.composerHint}>Starting…</span>
+            )}
+            <button
+              type="button"
+              aria-label={`Start ${agent.name} session`}
+              onClick={submit}
+              disabled={!isActive}
+              className={[
+                styles.composerSend,
+                isActive ? styles.composerSendActive : null,
+              ]
+                .filter(Boolean)
+                .join(` `)}
+            >
+              <Icon icon={ArrowUp} size={3} />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className={styles.composerMeta}>
+        <WorkingDirectoryPicker
+          value={workingDirectory}
+          onChange={onChangeWorkingDirectory}
+          disabled={submitting || disabled}
+        />
+        {runners.length > 0 && (
+          <RunnerPickerPill
+            runners={runners}
+            value={selectedRunnerId}
+            onChange={onChangeSelectedRunner}
             disabled={submitting || disabled}
           />
-          {runners.length > 0 && (
-            <RunnerPickerPill
-              runners={runners}
-              value={selectedRunnerId}
-              onChange={onChangeSelectedRunner}
-              disabled={submitting || disabled}
-            />
-          )}
-        </div>
-        <div className={styles.composerSendCluster}>
-          {submitting && <span className={styles.composerHint}>Starting…</span>}
-          <button
-            type="button"
-            aria-label={`Start ${agent.name} session`}
-            onClick={submit}
-            disabled={!isActive}
-            className={[
-              styles.composerSend,
-              isActive ? styles.composerSendActive : null,
-            ]
-              .filter(Boolean)
-              .join(` `)}
-          >
-            <Icon icon={ArrowUp} size={3} />
-          </button>
-        </div>
+        )}
       </div>
     </div>
   )
@@ -829,6 +838,7 @@ function RunnerPickerPill({
         aria-label="Runner"
         title="Pull-wake runner that will handle this session"
         placeholder="Pick runner"
+        icon={Cpu}
         renderValue={renderValue}
       />
       <Select.Content>

--- a/packages/agents-server-ui/src/ui/Select.module.css
+++ b/packages/agents-server-ui/src/ui/Select.module.css
@@ -84,6 +84,15 @@
   flex-shrink: 0;
 }
 
+/* Leading icon slot — sibling of `<Select.Value>`. Same muted tone
+   as the trailing chevron so the trigger reads as `[icon] label [⌄]`
+   with consistent icon weight on either side of the label. */
+.leadingIcon {
+  display: inline-flex;
+  color: var(--ds-text-3);
+  flex-shrink: 0;
+}
+
 .popup {
   padding: 3px;
   min-width: var(--anchor-width, 8rem);

--- a/packages/agents-server-ui/src/ui/Select.tsx
+++ b/packages/agents-server-ui/src/ui/Select.tsx
@@ -1,6 +1,7 @@
 import { Select as BaseSelect } from '@base-ui/react/select'
 import { Check, ChevronDown } from 'lucide-react'
 import type { CSSProperties, ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
 import { Icon } from './Icon'
 import popoverStyles from './Popover.module.css'
 import styles from './Select.module.css'
@@ -37,6 +38,13 @@ interface TriggerProps {
   [`aria-label`]?: string
   /** Tooltip-style hint shown on hover. */
   title?: string
+  /**
+   * Optional leading icon rendered before the value. Slots in as a
+   * sibling flex child of `<Select.Value>` so it gets the trigger's
+   * own gap/alignment, and inherits the trigger's muted icon color
+   * via the shared `.icon` class.
+   */
+  icon?: LucideIcon
   /**
    * Custom renderer for the displayed value. Use when the option's
    * value is an opaque key (e.g. an entity id) and the user-facing
@@ -93,6 +101,7 @@ function Trigger({
   autoFocus,
   [`aria-label`]: ariaLabel,
   title,
+  icon,
   renderValue,
 }: TriggerProps): React.ReactElement {
   const cls = [size === `pill` ? styles.triggerPill : styles.trigger, className]
@@ -107,6 +116,11 @@ function Trigger({
       aria-label={ariaLabel}
       title={title}
     >
+      {icon && (
+        <span className={styles.leadingIcon}>
+          <Icon icon={icon} size={iconSize} />
+        </span>
+      )}
       <BaseSelect.Value placeholder={placeholder}>
         {renderValue
           ? (value) => renderValue(value as string | null)


### PR DESCRIPTION
## Summary

Reworks the Horton "new session" prompt input so it reads more like Codex's composer: working-directory and runner pickers move out of the bordered input's inline pill row into a dedicated **session-context tray** docked directly under the composer.

- **Tray geometry mirrors `<EntityContextDrawer>`** — same border, radius, shadow, 12px horizontal inset, and `-20px` overlap, just flipped so the tray tucks UNDER the composer instead of over it. The composer gets `position: relative; z-index: 1` so its curved bottom corner paints over the tray's hidden top 20px (matches the chat composer's z-indexing).
- **Concentric inner padding** (`27px 7px 7px`): 12px outer radius − 1px border − 4px pill radius = 7px breathing room from every visible tray edge to every picker pill edge. Top adds the 20px composer overlap.
- **Recessed surface** — fill is `--ds-bg-subtle` (one step below the page bg in both light and dark mode) so the tray reads as a recessed tray the composer sits forward of, and the picker pills (chip-bg = raised-surface white) pop on top instead of disappearing into it.
- **Runner picker icon parity** — added an optional `icon` prop to `Select.Trigger`, used to give the runner pill a `Cpu` leading icon so it matches the working-directory pill's folder icon.
- **Working-directory copy** — renamed the "None" option / trigger label to "Don't work in a directory" so the empty state reads as a deliberate choice rather than an unset field.

## Visual

Before: two picker chips floated loose below a bordered input.
After: a single recessed tray docks under the composer with consistent 7px concentric spacing around both icon-bearing picker pills.

<img width="1392" height="1012" alt="image" src="https://github.com/user-attachments/assets/7274160e-d12c-42cc-9071-d0968aa58b07" />

## PR base

Stacked on top of #4430 (`agents-desktop-main-refactor`) — please merge that first. Once it lands, this PR's diff will only contain the prompt-form changes against `main`.

## Test plan

- [ ] Verify the prompt form on the Horton "new session" view (desktop + web build): composer renders normally with model/inline pills inside; tray below shows folder + cpu pickers.
- [ ] Verify hover/focus on the pickers; verify the composer's `:focus-within` border still highlights.
- [ ] Verify disabled state dims both composer and tray together.
- [ ] Verify the working-directory dropdown's first row reads "Don't work in a directory" and selecting it clears the path.
- [ ] Check both light and dark themes — tray should appear slightly recessed below the composer, pills should pop on top of it.


Made with [Cursor](https://cursor.com)