### PR TITLE
fix(ci): grant mobile publish workflow permissions

### DIFF
--- a/.changeset/fix-mobile-release-permissions.md
+++ b/.changeset/fix-mobile-release-permissions.md
@@ -1,0 +1,4 @@
+---
+---
+
+Allow mobile build workflows to grant the GitHub token permissions declared by the reusable mobile build job. This is a no-op for package versions because only CI workflow configuration changed.

--- a/.github/workflows/agents_mobile_ios_simulator.yml
+++ b/.github/workflows/agents_mobile_ios_simulator.yml
@@ -15,6 +15,11 @@ concurrency:
 permissions:
   actions: read
   contents: read
+  # Declared so the reusable `agents_mobile_build.yml` job can load. Its
+  # PR-commenting steps are skipped for this channel, but GitHub validates the
+  # reusable job's declared permissions before evaluating those conditions.
+  issues: write
+  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -159,6 +159,14 @@ jobs:
     needs: changesets
     if: ${{ needs.changesets.outputs.published == 'true' && needs.changesets.outputs.mobile_release_tag != '' }}
     uses: ./.github/workflows/agents_mobile_build.yml
+    # The reusable workflow declares PR-comment permissions even when the stable
+    # release channel skips those steps. GitHub validates declared permissions
+    # before evaluating those conditions.
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
     secrets: inherit
     with:
       channel: stable


### PR DESCRIPTION
The Changesets publish workflow was failing validation before jobs ran because `publish-agents-mobile` called `agents_mobile_build.yml` without granting the reusable job's declared permissions. That made publishing fail with GitHub rejecting the nested `build` job's `actions: read` request.

Changes:
- Grant the mobile release caller the permissions declared by the reusable mobile build workflow.
- Align the iOS simulator caller with the same reusable workflow permission contract.
- Add an empty changeset for this CI-only workflow change.