### PR TITLE
feat(agents-mobile): redesign onboarding to match desktop wizard

### DIFF
--- a/.changeset/mobile-onboarding-wizard-redesign.md
+++ b/.changeset/mobile-onboarding-wizard-redesign.md
@@ -1,0 +1,28 @@
+---
+"@electric-ax/agents-mobile": patch
+---
+
+Redesign mobile onboarding to mirror the desktop wizard and make it
+mandatory until a server connection is saved.
+
+* Two-step wizard (Cloud sign-in → Server selection) sharing the desktop
+  wizard's visual anatomy — step indicator, step header, section cards,
+  pinned footer respecting safe-area insets. Mobile has no local Horton
+  runtime so the "model providers" step is omitted.
+* Cloud server picker rows commit the connection on tap via a new
+  `onConnect(url)` callback, fixing the bug where tapping a cloud row
+  populated the URL input instead of connecting. Manual self-hosted URL
+  entry lives in a collapsible "Custom server" section with inline error
+  display.
+* Onboarding is now mandatory until `onComplete` saves a URL — the
+  "Don't show this again" and "Skip for now" escape valves are removed.
+  Invariant: `onboardingDismissed=true ⟹ serverUrl is set`.
+* `ServerSetupScreen` is rewritten on top of the step-2 anatomy so the
+  Settings → Server screen and the onboarding server step stay aligned.
+* Cloud → server auto-advance is a one-shot per sign-in transition,
+  seeded from `startStep` so warm restarts with a restored session
+  don't silently re-advance when the user taps Back.
+* `DiagnosticsScreen` gains a `__DEV__`-gated **Clear all local data**
+  action that wipes AsyncStorage, signs out of Cloud, and reloads the
+  JS bundle into a fresh onboarding flow. Copy mirrors the desktop
+  Settings → General → Reset wording.

--- a/packages/agents-mobile/app/_layout.tsx
+++ b/packages/agents-mobile/app/_layout.tsx
@@ -59,9 +59,9 @@ function RootNavigator(): React.ReactElement {
   }
 
   // First-launch onboarding takes precedence over the server-setup
-  // redirect — the wizard subsumes the URL input as its step 2, and
-  // dismissing it falls back to `/server-setup` only if the user
-  // still hasn't configured a server.
+  // redirect — the wizard subsumes the URL input as its step 2 and
+  // runs until `onComplete` saves a URL. After that `/server-setup`
+  // is only reachable via menu navigation.
   if (
     !onboardingDismissed &&
     pathname !== `/onboarding` &&

--- a/packages/agents-mobile/app/onboarding.tsx
+++ b/packages/agents-mobile/app/onboarding.tsx
@@ -5,10 +5,8 @@ import { useCloudAuth } from '../src/lib/CloudAuthContext'
 
 /**
  * First-launch onboarding route. The root layout redirects users here
- * when `onboardingDismissed` is false; the wizard either finishes
- * (server URL saved → dismissed → home) or is opted out of (footer
- * link / "Skip for now" → dismissed → either home or the existing
- * `/server-setup` redirect if no URL is set yet).
+ * while `onboardingDismissed` is false; the wizard is mandatory until
+ * a server connection is confirmed via `onComplete`.
  */
 export default function OnboardingRoute(): React.ReactElement {
   const router = useRouter()
@@ -25,13 +23,6 @@ export default function OnboardingRoute(): React.ReactElement {
       onComplete={async ({ serverUrl: nextUrl }) => {
         await saveServerUrl(nextUrl)
         await setOnboardingDismissed(true)
-        router.replace(`/`)
-      }}
-      onDismissForever={async () => {
-        await setOnboardingDismissed(true)
-        // If the user dismisses without configuring a server, the root
-        // layout's `!serverUrl` redirect picks them up and forces them
-        // onto `/server-setup` next render.
         router.replace(`/`)
       }}
     />

--- a/packages/agents-mobile/src/components/CloudServerPicker.tsx
+++ b/packages/agents-mobile/src/components/CloudServerPicker.tsx
@@ -1,5 +1,13 @@
-import { useMemo } from 'react'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { useMemo, useState } from 'react'
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native'
+import { Icon } from './Icon'
 import {
   cloudAgentServerUrl,
   useCloudAgentServers,
@@ -10,77 +18,94 @@ import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
 
 /**
- * Lists the Electric Cloud agent servers the signed-in user can see.
- * Subscribes to the four admin-API shapes via `useCloudAgentServers`
- * and renders each as a tappable card; tapping derives the agent-server
- * tenant URL and calls `onPick` so the parent screen can drop it into its
- * input / save flow.
- *
- * Renders nothing when the user isn't signed in to Cloud — the manual
- * URL entry on the parent screen remains the entry point in that case.
+ * Lists the Electric Cloud agent servers the signed-in user can see and
+ * commits the connection in-place when a row is tapped. Renders nothing
+ * when the user isn't signed in.
  */
 export function CloudServerPicker({
-  onPick,
+  onConnect,
   disabled,
+  style,
 }: {
-  onPick: (url: string) => void
+  onConnect: (url: string) => Promise<void> | void
   disabled?: boolean
+  style?: StyleProp<ViewStyle>
 }): React.ReactElement | null {
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const { status, servers, error } = useCloudAgentServers()
+  const [connectingKey, setConnectingKey] = useState<string | null>(null)
 
   if (status === `idle`) return null
 
+  const handlePress = async (server: CloudAgentServer): Promise<void> => {
+    if (connectingKey) return
+    setConnectingKey(server.id)
+    try {
+      await onConnect(cloudAgentServerUrl(server.id))
+    } finally {
+      setConnectingKey(null)
+    }
+  }
+
+  const anyConnecting = connectingKey !== null
+  const placeholder =
+    status === `loading` && servers.length === 0
+      ? `Loading…`
+      : status === `unauthorized`
+        ? `Cloud session expired — sign in again from the Account screen.`
+        : status !== `loading` && servers.length === 0
+          ? `No agent servers visible. Create one in the Electric Cloud dashboard, then return here.`
+          : null
+  const dividerWhenNotFirst = servers.length === 0 ? null : styles.rowDivider
+
   return (
-    <View style={styles.wrap}>
-      <Text style={styles.label}>Your Electric Cloud servers</Text>
-      {status === `loading` && servers.length === 0 && (
-        <Text style={styles.muted}>Loading…</Text>
-      )}
-      {status === `unauthorized` && (
-        <Text style={styles.muted}>
-          Cloud session expired — sign in again from the Account screen.
-        </Text>
+    <View style={[styles.section, style]}>
+      {servers.map((server, index) => (
+        <CloudServerRow
+          key={server.id}
+          server={server}
+          styles={styles}
+          tokens={tokens}
+          first={index === 0}
+          connecting={connectingKey === server.id}
+          disabled={disabled || (anyConnecting && connectingKey !== server.id)}
+          onPress={() => {
+            void handlePress(server)
+          }}
+        />
+      ))}
+      {placeholder && (
+        <View style={[styles.placeholderRow, dividerWhenNotFirst]}>
+          <Text style={styles.placeholderText}>{placeholder}</Text>
+        </View>
       )}
       {status === `error` && error && (
-        <Text style={styles.errorText}>{error}</Text>
+        <View style={[styles.placeholderRow, dividerWhenNotFirst]}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
       )}
-      {status !== `unauthorized` &&
-        servers.length === 0 &&
-        status !== `loading` && (
-          <Text style={styles.muted}>
-            No agent servers visible. Create one in the Electric Cloud
-            dashboard, then return here.
-          </Text>
-        )}
-      <View style={styles.list}>
-        {servers.map((server) => (
-          <CloudServerCard
-            key={server.id}
-            server={server}
-            tokens={tokens}
-            disabled={disabled}
-            onPress={() => onPick(cloudAgentServerUrl(server.id))}
-          />
-        ))}
-      </View>
     </View>
   )
 }
 
-function CloudServerCard({
+function CloudServerRow({
   server,
+  styles,
   tokens,
+  first,
+  connecting,
   disabled,
   onPress,
 }: {
   server: CloudAgentServer
+  styles: ReturnType<typeof createStyles>
   tokens: Tokens
-  disabled?: boolean
+  first: boolean
+  connecting: boolean
+  disabled: boolean
   onPress: () => void
 }): React.ReactElement {
-  const styles = useMemo(() => createStyles(tokens), [tokens])
   const breadcrumb = [
     server.workspaceName,
     server.projectName,
@@ -88,64 +113,114 @@ function CloudServerCard({
   ]
     .filter((p): p is string => Boolean(p))
     .join(` · `)
+
   return (
-    <TouchableOpacity
+    <Pressable
       onPress={onPress}
       disabled={disabled}
-      style={[styles.card, disabled ? styles.cardDisabled : null]}
+      style={({ pressed }) => [
+        styles.row,
+        first ? null : styles.rowDivider,
+        disabled ? styles.rowDisabled : null,
+        pressed && !disabled ? styles.rowPressed : null,
+      ]}
     >
-      <Text style={styles.cardName}>{server.name}</Text>
-      {breadcrumb.length > 0 && (
-        <Text numberOfLines={1} style={styles.cardBreadcrumb}>
-          {breadcrumb}
+      <View style={styles.iconCircle}>
+        <Icon name="server" size={16} color={tokens.text2} strokeWidth={1.75} />
+      </View>
+      <View style={styles.rowText}>
+        <Text numberOfLines={1} style={styles.rowTitle}>
+          {server.name}
         </Text>
-      )}
-    </TouchableOpacity>
+        {breadcrumb.length > 0 && (
+          <Text numberOfLines={1} style={styles.rowMeta}>
+            {breadcrumb}
+          </Text>
+        )}
+      </View>
+      <View style={styles.rowAside}>
+        {connecting ? (
+          <Text style={styles.connectingText}>Connecting…</Text>
+        ) : (
+          <Icon
+            name="chevron-right"
+            size={16}
+            color={tokens.text3}
+            strokeWidth={1.75}
+          />
+        )}
+      </View>
+    </Pressable>
   )
 }
 
 function createStyles(tokens: Tokens) {
   return StyleSheet.create({
-    wrap: {
-      gap: spacing.xs,
+    section: {
+      borderWidth: 1,
+      borderColor: tokens.border1,
+      borderRadius: radii.md,
+      backgroundColor: tokens.surface,
+      overflow: `hidden`,
     },
-    label: {
+    row: {
+      flexDirection: `row`,
+      alignItems: `center`,
+      gap: spacing.md,
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.lg,
+    },
+    rowDivider: {
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: tokens.border1,
+    },
+    rowDisabled: {
+      opacity: 0.6,
+    },
+    rowPressed: {
+      backgroundColor: tokens.bgHover,
+    },
+    iconCircle: {
+      width: 32,
+      height: 32,
+      borderRadius: 16,
+      backgroundColor: tokens.bgSubtle,
+      alignItems: `center`,
+      justifyContent: `center`,
+    },
+    rowText: {
+      flex: 1,
+      gap: 2,
+    },
+    rowTitle: {
+      color: tokens.text1,
+      fontSize: fontSize.base,
+      fontWeight: `500`,
+    },
+    rowMeta: {
+      color: tokens.text2,
+      fontSize: fontSize.sm,
+      lineHeight: lineHeight.sm,
+    },
+    rowAside: {
+      alignItems: `flex-end`,
+      justifyContent: `center`,
+    },
+    connectingText: {
       color: tokens.text3,
       fontSize: fontSize.xs,
-      fontWeight: `500`,
-      letterSpacing: 0.6,
-      textTransform: `uppercase`,
     },
-    list: {
-      gap: spacing.xs,
+    placeholderRow: {
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.lg,
     },
-    muted: {
+    placeholderText: {
       color: tokens.text3,
       fontSize: fontSize.sm,
       lineHeight: lineHeight.sm,
     },
     errorText: {
       color: tokens.red11,
-      fontSize: fontSize.sm,
-    },
-    card: {
-      borderWidth: 1,
-      borderColor: tokens.border1,
-      borderRadius: radii.md,
-      backgroundColor: tokens.surface,
-      padding: spacing.md,
-    },
-    cardDisabled: {
-      opacity: 0.5,
-    },
-    cardName: {
-      color: tokens.text1,
-      fontSize: fontSize.base,
-      fontWeight: `500`,
-    },
-    cardBreadcrumb: {
-      marginTop: spacing.xs,
-      color: tokens.text2,
       fontSize: fontSize.sm,
       lineHeight: lineHeight.sm,
     },

--- a/packages/agents-mobile/src/components/Icon.tsx
+++ b/packages/agents-mobile/src/components/Icon.tsx
@@ -34,6 +34,8 @@ export type IconName =
   | `radio`
   | `arrow-up`
   | `square`
+  | `github`
+  | `google`
 
 const PATHS: Record<IconName, string> = {
   back: `M15 18l-6-6 6-6`,
@@ -57,6 +59,11 @@ const PATHS: Record<IconName, string> = {
   radio: `M4.9 19.1a10 10 0 0 1 0-14.2M7.8 16.2a6 6 0 0 1 0-8.4M10.6 13.4a2 2 0 0 1 0-2.8M14 12h.01M16.2 7.8a6 6 0 0 1 0 8.4M19.1 4.9a10 10 0 0 1 0 14.2`,
   'arrow-up': `M12 19V5M5 12l7-7 7 7`,
   square: `M7 7h10v10H7z`,
+  github: `M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4M9 18c-4.51 2-5-2-7-2`,
+  // Official Google "G" mark, rendered in a single fill colour. Google's
+  // brand guidelines permit monochrome use in CTA contexts where the
+  // multi-colour mark would clash with the surrounding palette.
+  google: `M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09zM12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23zM5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62zM12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z`,
 }
 
 export function Icon({
@@ -80,7 +87,7 @@ export function Icon({
     )
   }
 
-  if (name === `square`) {
+  if (name === `square` || name === `google`) {
     return (
       <Svg width={size} height={size} viewBox="0 0 24 24">
         <Path d={PATHS[name]} fill={color} />

--- a/packages/agents-mobile/src/components/PrimaryButton.tsx
+++ b/packages/agents-mobile/src/components/PrimaryButton.tsx
@@ -4,8 +4,10 @@ import {
   Pressable,
   StyleSheet,
   Text,
+  View,
   type PressableProps,
 } from 'react-native'
+import { Icon, type IconName } from './Icon'
 import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, radii, rowHeight, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
@@ -17,11 +19,15 @@ export function PrimaryButton({
   loading,
   disabled,
   variant = `solid`,
+  leadingIcon,
+  trailingIcon,
   ...props
 }: PressableProps & {
   title: string
   loading?: boolean
   variant?: Variant
+  leadingIcon?: IconName
+  trailingIcon?: IconName
 }): React.ReactElement {
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
@@ -38,8 +44,12 @@ export function PrimaryButton({
       : variant === `soft`
         ? styles.softText
         : styles.ghostText
-  const indicatorColor =
-    variant === `solid` ? tokens.textOnAccent : tokens.text1
+  const foreground =
+    variant === `solid`
+      ? tokens.textOnAccent
+      : variant === `soft`
+        ? tokens.accent11
+        : tokens.text1
 
   return (
     <Pressable
@@ -53,9 +63,27 @@ export function PrimaryButton({
       ]}
     >
       {loading ? (
-        <ActivityIndicator color={indicatorColor} />
+        <ActivityIndicator color={foreground} />
       ) : (
-        <Text style={[styles.text, variantText]}>{title}</Text>
+        <View style={styles.content}>
+          {leadingIcon && (
+            <Icon
+              name={leadingIcon}
+              size={16}
+              color={foreground}
+              strokeWidth={1.75}
+            />
+          )}
+          <Text style={[styles.text, variantText]}>{title}</Text>
+          {trailingIcon && (
+            <Icon
+              name={trailingIcon}
+              size={16}
+              color={foreground}
+              strokeWidth={1.75}
+            />
+          )}
+        </View>
       )}
     </Pressable>
   )
@@ -86,6 +114,11 @@ function createStyles(tokens: Tokens) {
     },
     pressed: {
       opacity: 0.85,
+    },
+    content: {
+      flexDirection: `row`,
+      alignItems: `center`,
+      gap: spacing.sm,
     },
     text: {
       fontSize: fontSize.sm,

--- a/packages/agents-mobile/src/screens/DiagnosticsScreen.tsx
+++ b/packages/agents-mobile/src/screens/DiagnosticsScreen.tsx
@@ -1,11 +1,21 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native'
+import {
+  Alert,
+  DevSettings,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import Constants from 'expo-constants'
 import { Header, HeaderBackButton } from '../components/Header'
 import { PrimaryButton } from '../components/PrimaryButton'
 import { Screen } from '../components/Screen'
 import { useAgents } from '../lib/AgentsProvider'
 import { checkServerHealth } from '../lib/agentsClient'
+import { cloudAuth } from '../lib/cloudAuth'
 import { useColorSchemeMode, useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
 import type { Tokens } from '../lib/theme'
@@ -37,6 +47,7 @@ export function DiagnosticsScreen({
   const tokens = useTokens()
   const scheme = useColorSchemeMode()
   const styles = useMemo(() => createStyles(tokens), [tokens])
+  const [clearing, setClearing] = useState(false)
 
   const [health, setHealth] = useState<HealthState>({ kind: `idle` })
 
@@ -62,6 +73,36 @@ export function DiagnosticsScreen({
   useEffect(() => {
     void probe()
   }, [probe])
+
+  const clearAllLocalData = useCallback(() => {
+    Alert.alert(
+      `Clear all local data?`,
+      `Deletes saved settings, server connection, and sign-in state. The app will reload into onboarding.`,
+      [
+        { text: `Cancel`, style: `cancel` },
+        {
+          text: `Clear & reload`,
+          style: `destructive`,
+          onPress: () => {
+            void (async () => {
+              setClearing(true)
+              try {
+                // Independent local ops — sign out clears in-memory
+                // auth state, AsyncStorage.clear() wipes persisted state
+                // (including the token signOut also touches).
+                await Promise.allSettled([
+                  cloudAuth.signOut(),
+                  AsyncStorage.clear(),
+                ])
+              } finally {
+                DevSettings.reload()
+              }
+            })()
+          },
+        },
+      ]
+    )
+  }, [])
 
   const appVersion = Constants.expoConfig?.version ?? `0.0.0`
   const sdkVersion = Constants.expoConfig?.sdkVersion ?? Constants.sdkVersion
@@ -123,6 +164,25 @@ export function DiagnosticsScreen({
           />
           <Field label="Theme" value={`${scheme} (resolved)`} tokens={tokens} />
         </Section>
+
+        {__DEV__ && (
+          <Section label="Developer" tokens={tokens}>
+            <Field
+              label="Clear all local data"
+              value="Deletes saved settings, server connection, and sign-in state. The app reloads into onboarding."
+              tokens={tokens}
+            />
+            <View style={styles.actionRow}>
+              <PrimaryButton
+                title={clearing ? `Reloading…` : `Clear all local data`}
+                variant="soft"
+                loading={clearing}
+                disabled={clearing}
+                onPress={clearAllLocalData}
+              />
+            </View>
+          </Section>
+        )}
       </ScrollView>
     </Screen>
   )

--- a/packages/agents-mobile/src/screens/DiagnosticsScreen.tsx
+++ b/packages/agents-mobile/src/screens/DiagnosticsScreen.tsx
@@ -94,7 +94,7 @@ export function DiagnosticsScreen({
                 AsyncStorage.clear(),
               ])
               // Drop the spinner before reload so the button doesn't
-              // hang at "Reloading…" if DevSettings.reload() ever no-ops.
+              // hang at "Restarting…" if DevSettings.reload() ever no-ops.
               setClearing(false)
               DevSettings.reload()
             })()

--- a/packages/agents-mobile/src/screens/DiagnosticsScreen.tsx
+++ b/packages/agents-mobile/src/screens/DiagnosticsScreen.tsx
@@ -77,26 +77,26 @@ export function DiagnosticsScreen({
   const clearAllLocalData = useCallback(() => {
     Alert.alert(
       `Clear all local data?`,
-      `Deletes saved settings, server connection, and sign-in state. The app will reload into onboarding.`,
+      `Deletes saved settings, server connections, and sign-in state. The app will restart and return to the onboarding flow.`,
       [
         { text: `Cancel`, style: `cancel` },
         {
-          text: `Clear & reload`,
+          text: `Clear data and restart`,
           style: `destructive`,
           onPress: () => {
             void (async () => {
               setClearing(true)
-              try {
-                // Independent local ops — sign out clears in-memory
-                // auth state, AsyncStorage.clear() wipes persisted state
-                // (including the token signOut also touches).
-                await Promise.allSettled([
-                  cloudAuth.signOut(),
-                  AsyncStorage.clear(),
-                ])
-              } finally {
-                DevSettings.reload()
-              }
+              // Independent local ops — sign out clears in-memory
+              // auth state, AsyncStorage.clear() wipes persisted state
+              // (including the token signOut also touches).
+              await Promise.allSettled([
+                cloudAuth.signOut(),
+                AsyncStorage.clear(),
+              ])
+              // Drop the spinner before reload so the button doesn't
+              // hang at "Reloading…" if DevSettings.reload() ever no-ops.
+              setClearing(false)
+              DevSettings.reload()
             })()
           },
         },
@@ -169,12 +169,12 @@ export function DiagnosticsScreen({
           <Section label="Developer" tokens={tokens}>
             <Field
               label="Clear all local data"
-              value="Deletes saved settings, server connection, and sign-in state. The app reloads into onboarding."
+              value="Deletes saved settings, server connections, and sign-in state. The app will restart into onboarding."
               tokens={tokens}
             />
             <View style={styles.actionRow}>
               <PrimaryButton
-                title={clearing ? `Reloading…` : `Clear all local data`}
+                title={clearing ? `Restarting…` : `Clear all local data`}
                 variant="soft"
                 loading={clearing}
                 disabled={clearing}

--- a/packages/agents-mobile/src/screens/OnboardingScreen.tsx
+++ b/packages/agents-mobile/src/screens/OnboardingScreen.tsx
@@ -109,6 +109,8 @@ export function OnboardingScreen({
     setCustomUrlOpen((open) => !open)
   }
 
+  const bottomInset = Math.max(insets.bottom, spacing.md)
+
   return (
     <Screen>
       <KeyboardAvoidingView
@@ -156,62 +158,28 @@ export function OnboardingScreen({
           )}
         </ScrollView>
 
-        <View
-          style={[
-            styles.footerArea,
-            { paddingBottom: Math.max(insets.bottom, spacing.md) },
-          ]}
-        >
+        <View style={[styles.footerArea, { paddingBottom: bottomInset }]}>
           {step === `cloud` ? (
-            <CloudFooter
-              isSignedIn={isSignedIn}
-              onContinue={() => setStep(`server`)}
+            <PrimaryButton
+              title={isSignedIn ? `Continue` : `Continue without Cloud`}
+              variant="soft"
+              trailingIcon="chevron-right"
+              onPress={() => setStep(`server`)}
             />
           ) : (
-            <ServerFooter
-              submitting={submitting}
-              onBack={() => setStep(`cloud`)}
-            />
+            <View style={styles.footerLeft}>
+              <PrimaryButton
+                title="Back"
+                leadingIcon="back"
+                variant="ghost"
+                onPress={() => setStep(`cloud`)}
+                disabled={submitting}
+              />
+            </View>
           )}
         </View>
       </KeyboardAvoidingView>
     </Screen>
-  )
-}
-
-/* ── Footers (pinned to bottom of the viewport) ───────────── */
-
-function CloudFooter({
-  isSignedIn,
-  onContinue,
-}: {
-  isSignedIn: boolean
-  onContinue: () => void
-}): React.ReactElement {
-  return (
-    <PrimaryButton
-      title={isSignedIn ? `Continue` : `Continue without Cloud`}
-      variant="soft"
-      trailingIcon="chevron-right"
-      onPress={onContinue}
-    />
-  )
-}
-
-function ServerFooter({
-  submitting,
-  onBack,
-}: {
-  submitting: boolean
-  onBack: () => void
-}): React.ReactElement {
-  return (
-    <PrimaryButton
-      title="Back"
-      variant="ghost"
-      onPress={onBack}
-      disabled={submitting}
-    />
   )
 }
 
@@ -742,6 +710,10 @@ function createStyles(tokens: Tokens) {
       borderTopColor: tokens.border1,
       backgroundColor: tokens.bg,
       gap: spacing.sm,
+    },
+    footerLeft: {
+      flexDirection: `row`,
+      justifyContent: `flex-start`,
     },
   })
 }

--- a/packages/agents-mobile/src/screens/OnboardingScreen.tsx
+++ b/packages/agents-mobile/src/screens/OnboardingScreen.tsx
@@ -60,8 +60,10 @@ export function OnboardingScreen({
   const isSignedIn = cloudStatus === `signed-in`
 
   // Auto-advance from cloud → server on the sign-in transition only —
-  // never on a manual `Back` while already signed in.
-  const hasAutoAdvancedRef = useRef(false)
+  // never on a manual `Back` while already signed in. When the wizard
+  // opens straight on `server` (warm restart with a restored session),
+  // treat the advance as already spent so Back stays on `cloud`.
+  const hasAutoAdvancedRef = useRef(startStep === `server`)
   useEffect(() => {
     if (!isSignedIn) {
       hasAutoAdvancedRef.current = false
@@ -463,18 +465,15 @@ function StepIndicator({
 
 function StepHeader({
   styles,
-  eyebrow,
   title,
   description,
 }: {
   styles: ReturnType<typeof createStyles>
-  eyebrow?: string
   title: string
   description: string
 }): React.ReactElement {
   return (
     <View style={styles.stepHeader}>
-      {eyebrow && <Text style={styles.eyebrow}>{eyebrow}</Text>}
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.description}>{description}</Text>
     </View>
@@ -576,10 +575,6 @@ function createStyles(tokens: Tokens) {
     },
     stepHeader: {
       gap: spacing.xs,
-    },
-    eyebrow: {
-      color: tokens.text3,
-      fontSize: fontSize.sm,
     },
     title: {
       color: tokens.text1,

--- a/packages/agents-mobile/src/screens/OnboardingScreen.tsx
+++ b/packages/agents-mobile/src/screens/OnboardingScreen.tsx
@@ -2,7 +2,6 @@ import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import {
   KeyboardAvoidingView,
   Platform,
-  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -38,12 +37,10 @@ export function OnboardingScreen({
   initialServerUrl,
   startStep = `cloud`,
   onComplete,
-  onDismissForever,
 }: {
   initialServerUrl?: string | null
   startStep?: Step
   onComplete: (params: { serverUrl: string }) => Promise<void>
-  onDismissForever: () => Promise<void>
 }): React.ReactElement {
   const tokens = useTokens()
   const insets = useSafeAreaInsets()
@@ -167,21 +164,13 @@ export function OnboardingScreen({
         >
           {step === `cloud` ? (
             <CloudFooter
-              styles={styles}
               isSignedIn={isSignedIn}
               onContinue={() => setStep(`server`)}
-              onDismissForever={() => {
-                void onDismissForever()
-              }}
             />
           ) : (
             <ServerFooter
-              styles={styles}
               submitting={submitting}
               onBack={() => setStep(`cloud`)}
-              onSkip={() => {
-                void onDismissForever()
-              }}
             />
           )}
         </View>
@@ -193,64 +182,36 @@ export function OnboardingScreen({
 /* ── Footers (pinned to bottom of the viewport) ───────────── */
 
 function CloudFooter({
-  styles,
   isSignedIn,
   onContinue,
-  onDismissForever,
 }: {
-  styles: ReturnType<typeof createStyles>
   isSignedIn: boolean
   onContinue: () => void
-  onDismissForever: () => void
 }): React.ReactElement {
   return (
-    <>
-      <PrimaryButton
-        title={isSignedIn ? `Continue` : `Continue without Cloud`}
-        variant="soft"
-        trailingIcon="chevron-right"
-        onPress={onContinue}
-      />
-      <Pressable
-        onPress={onDismissForever}
-        hitSlop={spacing.sm}
-        style={({ pressed }) => [
-          styles.dismissLink,
-          pressed ? styles.dismissLinkPressed : null,
-        ]}
-      >
-        <Text style={styles.dismissLinkText}>Don&apos;t show this again</Text>
-      </Pressable>
-    </>
+    <PrimaryButton
+      title={isSignedIn ? `Continue` : `Continue without Cloud`}
+      variant="soft"
+      trailingIcon="chevron-right"
+      onPress={onContinue}
+    />
   )
 }
 
 function ServerFooter({
-  styles,
   submitting,
   onBack,
-  onSkip,
 }: {
-  styles: ReturnType<typeof createStyles>
   submitting: boolean
   onBack: () => void
-  onSkip: () => void
 }): React.ReactElement {
   return (
-    <View style={styles.footerRow}>
-      <PrimaryButton
-        title="Back"
-        variant="ghost"
-        onPress={onBack}
-        disabled={submitting}
-      />
-      <PrimaryButton
-        title="Skip for now"
-        variant="ghost"
-        onPress={onSkip}
-        disabled={submitting}
-      />
-    </View>
+    <PrimaryButton
+      title="Back"
+      variant="ghost"
+      onPress={onBack}
+      disabled={submitting}
+    />
   )
 }
 
@@ -781,25 +742,6 @@ function createStyles(tokens: Tokens) {
       borderTopColor: tokens.border1,
       backgroundColor: tokens.bg,
       gap: spacing.sm,
-    },
-    footerRow: {
-      flexDirection: `row`,
-      alignItems: `center`,
-      justifyContent: `space-between`,
-      gap: spacing.sm,
-    },
-    dismissLink: {
-      alignSelf: `center`,
-      paddingVertical: spacing.xs,
-      paddingHorizontal: spacing.md,
-    },
-    dismissLinkPressed: {
-      opacity: 0.6,
-    },
-    dismissLinkText: {
-      color: tokens.text3,
-      fontSize: fontSize.sm,
-      textDecorationLine: `underline`,
     },
   })
 }

--- a/packages/agents-mobile/src/screens/OnboardingScreen.tsx
+++ b/packages/agents-mobile/src/screens/OnboardingScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import {
   KeyboardAvoidingView,
   Platform,
@@ -9,6 +9,8 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import * as WebBrowser from 'expo-web-browser'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { CloudServerPicker } from '../components/CloudServerPicker'
 import { Icon } from '../components/Icon'
 import { PrimaryButton } from '../components/PrimaryButton'
@@ -22,28 +24,15 @@ import type { Tokens } from '../lib/theme'
 
 type Step = `cloud` | `server`
 
+const STEPS: ReadonlyArray<{ id: Step; label: string }> = [
+  { id: `cloud`, label: `Cloud` },
+  { id: `server`, label: `Server` },
+]
+
 /**
- * First-launch onboarding wizard for the mobile app. Mirrors the
- * desktop wizard's spirit (sign-in to Electric Cloud → configure the
- * runtime) with the inputs that make sense on mobile:
- *
- *  1. Sign in to Electric Cloud (GitHub / Google). Skippable.
- *  2. Connect to an agents server. The mobile app doesn't bundle a
- *     local Horton runtime so the analog of the desktop "API keys"
- *     step is picking a remote server URL — the same input the
- *     standalone `ServerSetupScreen` exposes.
- *
- * Auto-advances from step 1 → step 2 as soon as cloud sign-in
- * completes. If the user is already signed in at boot we open the
- * wizard directly on step 2 (cloud step has nothing to do).
- *
- * Persistence: `onboardingDismissed` in `MobileAppState` (AsyncStorage).
- * Saving a server URL marks the wizard dismissed automatically; "Skip
- * for now" and the trailing "Don't show this again" link expose the
- * two manual escape hatches.
- *
- * Rendered by `app/onboarding.tsx`; the root layout redirects to it
- * on first launch in place of the bare `/server-setup` redirect.
+ * First-launch onboarding wizard. Two steps: Cloud sign-in (skippable)
+ * and server selection. Mirrors the desktop wizard without the
+ * model-providers step — mobile has no local Horton runtime.
  */
 export function OnboardingScreen({
   initialServerUrl,
@@ -57,51 +46,70 @@ export function OnboardingScreen({
   onDismissForever: () => Promise<void>
 }): React.ReactElement {
   const tokens = useTokens()
+  const insets = useSafeAreaInsets()
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const { state: cloudState, signIn } = useCloudAuth()
   const [step, setStep] = useState<Step>(startStep)
-  const [serverUrlValue, setServerUrlValue] = useState(initialServerUrl ?? ``)
-  const [submittingServer, setSubmittingServer] = useState(false)
-  const [serverError, setServerError] = useState<string | null>(null)
+  const [customUrlOpen, setCustomUrlOpen] = useState(false)
+  const [customUrlValue, setCustomUrlValue] = useState(initialServerUrl ?? ``)
+  const [submitting, setSubmitting] = useState(false)
+  const [cloudConnectError, setCloudConnectError] = useState<string | null>(
+    null
+  )
+  const [customUrlError, setCustomUrlError] = useState<string | null>(null)
 
   const cloudStatus = cloudState.status
   const isSigningIn = cloudStatus === `signing-in`
   const isSignedIn = cloudStatus === `signed-in`
 
-  // Auto-advance from cloud → server as soon as sign-in completes.
-  // Only fires while the user is on the cloud step so a separate
-  // future sign-in (e.g. from Account) doesn't snap them off whatever
-  // step they were on.
+  // Auto-advance from cloud → server on the sign-in transition only —
+  // never on a manual `Back` while already signed in.
+  const hasAutoAdvancedRef = useRef(false)
   useEffect(() => {
-    if (step === `cloud` && isSignedIn) {
+    if (!isSignedIn) {
+      hasAutoAdvancedRef.current = false
+    } else if (step === `cloud` && !hasAutoAdvancedRef.current) {
+      hasAutoAdvancedRef.current = true
       setStep(`server`)
     }
   }, [step, isSignedIn])
 
-  const submitServer = async (): Promise<void> => {
-    const normalized = normalizeServerUrl(serverUrlValue)
-    if (!normalized) {
-      setServerError(`Enter an agents server URL.`)
-      return
-    }
-    setSubmittingServer(true)
-    setServerError(null)
+  const commit = async (url: string): Promise<string | null> => {
+    setSubmitting(true)
     try {
-      // Inject Cloud auth headers (if applicable) before the health
-      // check probes the server — Cloud agent servers reject
-      // unauthenticated requests with 401.
-      await prepareServerHeaders(normalized)
-      await checkServerHealth(normalized)
-      await onComplete({ serverUrl: normalized })
+      // Cloud agent servers reject unauthenticated requests with 401,
+      // so headers must be registered before the health probe.
+      await prepareServerHeaders(url)
+      await checkServerHealth(url)
+      await onComplete({ serverUrl: url })
+      return null
     } catch (err) {
-      setServerError(err instanceof Error ? err.message : String(err))
+      return err instanceof Error ? err.message : String(err)
     } finally {
-      setSubmittingServer(false)
+      setSubmitting(false)
     }
   }
 
-  const goNextFromCloud = (): void => {
-    setStep(`server`)
+  const connectCloudRow = async (url: string): Promise<void> => {
+    setCloudConnectError(null)
+    const err = await commit(url)
+    if (err) setCloudConnectError(err)
+  }
+
+  const submitCustom = async (): Promise<void> => {
+    const normalized = normalizeServerUrl(customUrlValue)
+    if (!normalized) {
+      setCustomUrlError(`Enter an agents server URL.`)
+      return
+    }
+    setCustomUrlError(null)
+    const err = await commit(normalized)
+    if (err) setCustomUrlError(err)
+  }
+
+  const toggleCustomUrl = (): void => {
+    setCustomUrlError(null)
+    setCustomUrlOpen((open) => !open)
   }
 
   return (
@@ -111,181 +119,459 @@ export function OnboardingScreen({
         style={styles.flex}
       >
         <ScrollView
+          style={styles.flex}
           contentContainerStyle={styles.scroll}
           keyboardShouldPersistTaps="handled"
         >
-          <StepIndicator step={step} styles={styles} />
+          <StepIndicator step={step} styles={styles} tokens={tokens} />
 
           {step === `cloud` ? (
-            <View style={styles.section}>
-              <Text style={styles.eyebrow}>Electric Agents</Text>
-              <Text style={styles.title}>Welcome</Text>
-              <Text style={styles.copy}>
-                Sign in to Electric Cloud so your agents can sync with your
-                workspaces and the dashboard. You can skip this and set it up
-                later from the Account screen.
-              </Text>
-
-              {isSignedIn ? (
-                <View style={styles.signedInBanner}>
-                  <Icon
-                    name="check"
-                    size={18}
-                    color={tokens.green11}
-                    strokeWidth={2}
-                  />
-                  <Text style={styles.signedInText}>
-                    {cloudState.name
-                      ? `Signed in as ${cloudState.name}.`
-                      : `Signed in.`}
-                  </Text>
-                </View>
-              ) : (
-                <>
-                  {cloudState.error && (
-                    <View style={styles.errorRow}>
-                      <Text style={styles.errorText}>{cloudState.error}</Text>
-                    </View>
-                  )}
-                  <View style={styles.actions}>
-                    <PrimaryButton
-                      title={
-                        isSigningIn ? `Opening browser…` : `Sign in with GitHub`
-                      }
-                      disabled={isSigningIn}
-                      onPress={() => {
-                        void signIn(`github`)
-                      }}
-                    />
-                    <PrimaryButton
-                      title={
-                        isSigningIn ? `Opening browser…` : `Sign in with Google`
-                      }
-                      variant="soft"
-                      disabled={isSigningIn}
-                      onPress={() => {
-                        void signIn(`google`)
-                      }}
-                    />
-                  </View>
-                  <Text style={styles.hint}>
-                    Opens a sign-in window pointed at
-                    dashboard.electric-sql.cloud. It closes automatically once
-                    you&apos;ve authorized.
-                  </Text>
-                </>
-              )}
-
-              <View style={styles.secondaryAction}>
-                <PrimaryButton
-                  title={isSignedIn ? `Continue` : `Skip`}
-                  variant="ghost"
-                  onPress={goNextFromCloud}
-                />
-              </View>
-            </View>
+            <CloudStep
+              styles={styles}
+              tokens={tokens}
+              cloudError={cloudState.error}
+              cloudName={cloudState.name}
+              cloudEmail={cloudState.email}
+              isSignedIn={isSignedIn}
+              isSigningIn={isSigningIn}
+              onSignIn={(provider) => {
+                void signIn(provider)
+              }}
+            />
           ) : (
-            <View style={styles.section}>
-              <Text style={styles.eyebrow}>Step 2 of 2</Text>
-              <Text style={styles.title}>Connect to an agents server</Text>
-              <Text style={styles.copy}>
-                Mobile connects to a running server. It does not bundle a local
-                Horton runtime.
-              </Text>
-
-              <CloudServerPicker
-                onPick={(picked) => setServerUrlValue(picked)}
-                disabled={submittingServer}
-              />
-
-              <View style={styles.field}>
-                <Text style={styles.label}>Server URL</Text>
-                <TextInput
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  keyboardType="url"
-                  placeholder="https://agents.example.com"
-                  placeholderTextColor={tokens.text3}
-                  value={serverUrlValue}
-                  onChangeText={setServerUrlValue}
-                  onSubmitEditing={() => {
-                    void submitServer()
-                  }}
-                  returnKeyType="go"
-                  style={styles.input}
-                />
-              </View>
-
-              {serverError && (
-                <View style={styles.errorRow}>
-                  <Text style={styles.errorText}>{serverError}</Text>
-                </View>
-              )}
-
-              <View style={styles.actions}>
-                <PrimaryButton
-                  title="Connect & finish"
-                  loading={submittingServer}
-                  disabled={submittingServer}
-                  onPress={() => {
-                    void submitServer()
-                  }}
-                />
-                <PrimaryButton
-                  title="Skip for now"
-                  variant="ghost"
-                  disabled={submittingServer}
-                  onPress={() => {
-                    // Closes the wizard without persisting a URL. The
-                    // root layout's `!serverUrl` redirect will kick the
-                    // user back to /server-setup until they configure
-                    // one, so this is a "remind me later" path.
-                    void onDismissForever()
-                  }}
-                />
-              </View>
-            </View>
+            <ServerStep
+              styles={styles}
+              tokens={tokens}
+              submitting={submitting}
+              cloudConnectError={cloudConnectError}
+              customUrlError={customUrlError}
+              customUrlOpen={customUrlOpen}
+              customUrlValue={customUrlValue}
+              isCloudSignedIn={isSignedIn}
+              onSetCustomUrlValue={setCustomUrlValue}
+              onToggleCustomUrl={toggleCustomUrl}
+              onConnectCloudRow={connectCloudRow}
+              onSubmitCustom={() => {
+                void submitCustom()
+              }}
+              onSignInToCloud={() => setStep(`cloud`)}
+            />
           )}
-
-          <Pressable
-            onPress={() => {
-              void onDismissForever()
-            }}
-            hitSlop={spacing.sm}
-            style={({ pressed }) => [
-              styles.dismissForever,
-              pressed ? styles.dismissForeverPressed : null,
-            ]}
-          >
-            <Text style={styles.dismissForeverText}>
-              Don&apos;t show this again
-            </Text>
-          </Pressable>
         </ScrollView>
+
+        <View
+          style={[
+            styles.footerArea,
+            { paddingBottom: Math.max(insets.bottom, spacing.md) },
+          ]}
+        >
+          {step === `cloud` ? (
+            <CloudFooter
+              styles={styles}
+              isSignedIn={isSignedIn}
+              onContinue={() => setStep(`server`)}
+              onDismissForever={() => {
+                void onDismissForever()
+              }}
+            />
+          ) : (
+            <ServerFooter
+              styles={styles}
+              submitting={submitting}
+              onBack={() => setStep(`cloud`)}
+              onSkip={() => {
+                void onDismissForever()
+              }}
+            />
+          )}
+        </View>
       </KeyboardAvoidingView>
     </Screen>
   )
 }
 
+/* ── Footers (pinned to bottom of the viewport) ───────────── */
+
+function CloudFooter({
+  styles,
+  isSignedIn,
+  onContinue,
+  onDismissForever,
+}: {
+  styles: ReturnType<typeof createStyles>
+  isSignedIn: boolean
+  onContinue: () => void
+  onDismissForever: () => void
+}): React.ReactElement {
+  return (
+    <>
+      <PrimaryButton
+        title={isSignedIn ? `Continue` : `Continue without Cloud`}
+        variant="soft"
+        trailingIcon="chevron-right"
+        onPress={onContinue}
+      />
+      <Pressable
+        onPress={onDismissForever}
+        hitSlop={spacing.sm}
+        style={({ pressed }) => [
+          styles.dismissLink,
+          pressed ? styles.dismissLinkPressed : null,
+        ]}
+      >
+        <Text style={styles.dismissLinkText}>Don&apos;t show this again</Text>
+      </Pressable>
+    </>
+  )
+}
+
+function ServerFooter({
+  styles,
+  submitting,
+  onBack,
+  onSkip,
+}: {
+  styles: ReturnType<typeof createStyles>
+  submitting: boolean
+  onBack: () => void
+  onSkip: () => void
+}): React.ReactElement {
+  return (
+    <View style={styles.footerRow}>
+      <PrimaryButton
+        title="Back"
+        variant="ghost"
+        onPress={onBack}
+        disabled={submitting}
+      />
+      <PrimaryButton
+        title="Skip for now"
+        variant="ghost"
+        onPress={onSkip}
+        disabled={submitting}
+      />
+    </View>
+  )
+}
+
+/* ── Step content ──────────────────────────────────────────── */
+
+function CloudStep({
+  styles,
+  tokens,
+  cloudError,
+  cloudName,
+  cloudEmail,
+  isSignedIn,
+  isSigningIn,
+  onSignIn,
+}: {
+  styles: ReturnType<typeof createStyles>
+  tokens: Tokens
+  cloudError: string | null
+  cloudName: string | null
+  cloudEmail: string | null
+  isSignedIn: boolean
+  isSigningIn: boolean
+  onSignIn: (provider: `github` | `google`) => void
+}): React.ReactElement {
+  return (
+    <View style={styles.step}>
+      <StepHeader
+        styles={styles}
+        title="Electric Cloud"
+        description="The data platform for multi-agent systems. Sign in to discover hosted agents servers, provision new ones, and connect this app to your Electric Cloud workspaces."
+      />
+
+      {isSignedIn ? (
+        <View style={styles.section}>
+          <View style={styles.signedInRow}>
+            <View style={styles.signedInIcon}>
+              <Icon
+                name="check"
+                size={16}
+                color={tokens.green11}
+                strokeWidth={2}
+              />
+            </View>
+            <View style={styles.signedInText}>
+              <Text style={styles.signedInTitle}>
+                {cloudName || `Signed in`}
+              </Text>
+              {cloudEmail && (
+                <Text style={styles.signedInMeta}>{cloudEmail}</Text>
+              )}
+            </View>
+          </View>
+        </View>
+      ) : (
+        <>
+          {cloudError && (
+            <View style={styles.errorRow}>
+              <Text style={styles.errorText}>{cloudError}</Text>
+            </View>
+          )}
+          <View style={styles.actionsStack}>
+            <PrimaryButton
+              title={isSigningIn ? `Opening browser…` : `Sign in with GitHub`}
+              leadingIcon="github"
+              disabled={isSigningIn}
+              onPress={() => onSignIn(`github`)}
+            />
+            <PrimaryButton
+              title={isSigningIn ? `Opening browser…` : `Sign in with Google`}
+              variant="soft"
+              leadingIcon="google"
+              disabled={isSigningIn}
+              onPress={() => onSignIn(`google`)}
+            />
+          </View>
+          <Text style={styles.hint}>
+            Opens a sign-in window pointed at dashboard.electric-sql.cloud. It
+            closes automatically once you&apos;ve authorized.
+          </Text>
+          <Text style={styles.hint}>
+            By signing in, you agree to our{` `}
+            <Text
+              style={styles.legalLink}
+              onPress={() => {
+                void WebBrowser.openBrowserAsync(
+                  `https://electric.ax/about/legal/terms`
+                )
+              }}
+            >
+              terms of service
+            </Text>
+            {` `}and{` `}
+            <Text
+              style={styles.legalLink}
+              onPress={() => {
+                void WebBrowser.openBrowserAsync(
+                  `https://electric.ax/about/legal/privacy`
+                )
+              }}
+            >
+              privacy policy
+            </Text>
+            .
+          </Text>
+        </>
+      )}
+    </View>
+  )
+}
+
+function ServerStep({
+  styles,
+  tokens,
+  submitting,
+  cloudConnectError,
+  customUrlError,
+  customUrlOpen,
+  customUrlValue,
+  isCloudSignedIn,
+  onSetCustomUrlValue,
+  onToggleCustomUrl,
+  onConnectCloudRow,
+  onSubmitCustom,
+  onSignInToCloud,
+}: {
+  styles: ReturnType<typeof createStyles>
+  tokens: Tokens
+  submitting: boolean
+  cloudConnectError: string | null
+  customUrlError: string | null
+  customUrlOpen: boolean
+  customUrlValue: string
+  isCloudSignedIn: boolean
+  onSetCustomUrlValue: (next: string) => void
+  onToggleCustomUrl: () => void
+  onConnectCloudRow: (url: string) => Promise<void>
+  onSubmitCustom: () => void
+  onSignInToCloud: () => void
+}): React.ReactElement {
+  return (
+    <View style={styles.step}>
+      <StepHeader
+        styles={styles}
+        title="Choose your first server"
+        description="Pick the agents server this app should connect to."
+      />
+
+      {!isCloudSignedIn && (
+        <SectionHeader
+          styles={styles}
+          title="Electric Cloud"
+          description="Sign in to Electric Cloud to discover and provision hosted agents servers."
+          action={
+            <PrimaryButton
+              title="Sign in"
+              variant="soft"
+              onPress={onSignInToCloud}
+              disabled={submitting}
+            />
+          }
+        />
+      )}
+
+      <CloudServerPicker onConnect={onConnectCloudRow} disabled={submitting} />
+
+      {cloudConnectError && (
+        <View style={styles.errorRow}>
+          <Text style={styles.errorText}>{cloudConnectError}</Text>
+        </View>
+      )}
+
+      <SectionHeader
+        styles={styles}
+        title="Custom server"
+        description="Connect to a self-hosted agents server."
+        action={
+          <PrimaryButton
+            title={customUrlOpen ? `Cancel` : `Add custom URL`}
+            variant="ghost"
+            onPress={onToggleCustomUrl}
+            disabled={submitting}
+          />
+        }
+      />
+
+      {customUrlOpen && (
+        <View style={styles.customUrlPanel}>
+          <View style={styles.field}>
+            <Text style={styles.label}>Server URL</Text>
+            <TextInput
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+              placeholder="https://agents.example.com"
+              placeholderTextColor={tokens.text3}
+              value={customUrlValue}
+              onChangeText={onSetCustomUrlValue}
+              onSubmitEditing={onSubmitCustom}
+              returnKeyType="go"
+              style={styles.input}
+            />
+          </View>
+          {customUrlError && (
+            <View style={styles.errorRow}>
+              <Text style={styles.errorText}>{customUrlError}</Text>
+            </View>
+          )}
+          <PrimaryButton
+            title="Connect"
+            loading={submitting}
+            disabled={submitting}
+            onPress={onSubmitCustom}
+          />
+        </View>
+      )}
+    </View>
+  )
+}
+
+/* ── Local primitives ─────────────────────────────────────── */
+
 function StepIndicator({
   step,
   styles,
+  tokens,
 }: {
   step: Step
   styles: ReturnType<typeof createStyles>
+  tokens: Tokens
 }): React.ReactElement {
+  const currentIndex = STEPS.findIndex((s) => s.id === step)
   return (
     <View style={styles.steps}>
-      <View
-        style={[styles.stepDot, step === `cloud` ? styles.stepDotActive : null]}
-      />
-      <View style={styles.stepBar} />
-      <View
-        style={[
-          styles.stepDot,
-          step === `server` ? styles.stepDotActive : null,
-        ]}
-      />
+      {STEPS.map((item, idx) => {
+        const isActive = idx === currentIndex
+        const isComplete = idx < currentIndex
+        return (
+          <Fragment key={item.id}>
+            <View style={styles.stepItem}>
+              <View
+                style={[
+                  styles.stepCircle,
+                  isActive ? styles.stepCircleActive : null,
+                  isComplete ? styles.stepCircleComplete : null,
+                ]}
+              >
+                {isComplete ? (
+                  <Icon
+                    name="check"
+                    size={14}
+                    color={tokens.green11}
+                    strokeWidth={2.5}
+                  />
+                ) : (
+                  <Text
+                    style={[
+                      styles.stepNumber,
+                      isActive ? styles.stepNumberActive : null,
+                    ]}
+                  >
+                    {idx + 1}
+                  </Text>
+                )}
+              </View>
+              <Text
+                style={[
+                  styles.stepLabel,
+                  isActive ? styles.stepLabelActive : null,
+                ]}
+              >
+                {item.label}
+              </Text>
+            </View>
+            {idx < STEPS.length - 1 && <View style={styles.stepBar} />}
+          </Fragment>
+        )
+      })}
+    </View>
+  )
+}
+
+function StepHeader({
+  styles,
+  eyebrow,
+  title,
+  description,
+}: {
+  styles: ReturnType<typeof createStyles>
+  eyebrow?: string
+  title: string
+  description: string
+}): React.ReactElement {
+  return (
+    <View style={styles.stepHeader}>
+      {eyebrow && <Text style={styles.eyebrow}>{eyebrow}</Text>}
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.description}>{description}</Text>
+    </View>
+  )
+}
+
+function SectionHeader({
+  styles,
+  title,
+  description,
+  action,
+}: {
+  styles: ReturnType<typeof createStyles>
+  title: string
+  description?: string
+  action?: React.ReactNode
+}): React.ReactElement {
+  return (
+    <View style={styles.sectionHeader}>
+      <View style={styles.sectionHeaderText}>
+        <Text style={styles.sectionHeaderTitle}>{title}</Text>
+        {description && (
+          <Text style={styles.sectionHeaderDescription}>{description}</Text>
+        )}
+      </View>
+      {action && <View style={styles.sectionHeaderAction}>{action}</View>}
     </View>
   )
 }
@@ -296,35 +582,71 @@ function createStyles(tokens: Tokens) {
       flex: 1,
     },
     scroll: {
-      flexGrow: 1,
-      justifyContent: `center`,
       paddingHorizontal: spacing.xl,
-      paddingVertical: spacing.xxxl,
+      paddingTop: spacing.xl,
+      paddingBottom: spacing.lg,
       gap: spacing.lg,
     },
+
+    // Step indicator — compact centered group; bar width fixed so the
+    // two steps read as one widget rather than floating apart.
     steps: {
       flexDirection: `row`,
       alignItems: `center`,
+      justifyContent: `center`,
       gap: spacing.sm,
-      alignSelf: `center`,
-      marginBottom: spacing.md,
     },
-    stepDot: {
-      width: 8,
-      height: 8,
-      borderRadius: 4,
-      backgroundColor: tokens.border2,
+    stepItem: {
+      flexDirection: `row`,
+      alignItems: `center`,
+      gap: spacing.sm,
     },
-    stepDotActive: {
+    stepCircle: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: tokens.border2,
+      alignItems: `center`,
+      justifyContent: `center`,
+      backgroundColor: tokens.surface,
+    },
+    stepCircleActive: {
       backgroundColor: tokens.text1,
+      borderColor: tokens.text1,
+    },
+    stepCircleComplete: {
+      backgroundColor: tokens.greenA3,
+      borderColor: tokens.greenA3,
+    },
+    stepNumber: {
+      color: tokens.text2,
+      fontSize: fontSize.sm,
+      fontWeight: `600`,
+    },
+    stepNumberActive: {
+      color: tokens.textOnAccent,
+    },
+    stepLabel: {
+      color: tokens.text3,
+      fontSize: fontSize.sm,
+      fontWeight: `500`,
+    },
+    stepLabelActive: {
+      color: tokens.text1,
     },
     stepBar: {
-      width: 24,
+      width: 32,
       height: StyleSheet.hairlineWidth,
       backgroundColor: tokens.divider,
     },
-    section: {
+
+    // Step content
+    step: {
       gap: spacing.md,
+    },
+    stepHeader: {
+      gap: spacing.xs,
     },
     eyebrow: {
       color: tokens.text3,
@@ -336,24 +658,63 @@ function createStyles(tokens: Tokens) {
       fontWeight: `400`,
       lineHeight: lineHeight.xxxl,
     },
-    copy: {
+    description: {
       color: tokens.text2,
       fontSize: fontSize.base,
       lineHeight: lineHeight.base,
     },
-    signedInBanner: {
+
+    // Cloud step signed-in row
+    section: {
+      borderWidth: 1,
+      borderColor: tokens.border1,
+      borderRadius: radii.md,
+      backgroundColor: tokens.surface,
+      overflow: `hidden`,
+    },
+    signedInRow: {
       flexDirection: `row`,
       alignItems: `center`,
-      gap: spacing.sm,
-      paddingVertical: spacing.sm,
-      paddingHorizontal: spacing.md,
-      borderRadius: radii.sm,
+      gap: spacing.md,
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.lg,
+    },
+    signedInIcon: {
+      width: 32,
+      height: 32,
+      borderRadius: 16,
       backgroundColor: tokens.greenA3,
+      alignItems: `center`,
+      justifyContent: `center`,
     },
     signedInText: {
-      color: tokens.green11,
-      fontSize: fontSize.sm,
+      flex: 1,
+      gap: 2,
     },
+    signedInTitle: {
+      color: tokens.text1,
+      fontSize: fontSize.base,
+      fontWeight: `500`,
+    },
+    signedInMeta: {
+      color: tokens.text2,
+      fontSize: fontSize.sm,
+      lineHeight: lineHeight.sm,
+    },
+
+    actionsStack: {
+      gap: spacing.md,
+    },
+    hint: {
+      color: tokens.text3,
+      fontSize: fontSize.sm,
+      lineHeight: lineHeight.sm,
+    },
+    legalLink: {
+      color: tokens.text2,
+      textDecorationLine: `underline`,
+    },
+
     errorRow: {
       borderRadius: radii.sm,
       backgroundColor: tokens.redA2,
@@ -364,17 +725,32 @@ function createStyles(tokens: Tokens) {
       color: tokens.red11,
       fontSize: fontSize.sm,
     },
-    actions: {
+
+    // Custom-URL affordance
+    sectionHeader: {
+      flexDirection: `row`,
+      alignItems: `center`,
+      gap: spacing.md,
+    },
+    sectionHeaderText: {
+      flex: 1,
+      gap: 2,
+    },
+    sectionHeaderTitle: {
+      color: tokens.text1,
+      fontSize: fontSize.base,
+      fontWeight: `500`,
+    },
+    sectionHeaderDescription: {
+      color: tokens.text2,
+      fontSize: fontSize.sm,
+      lineHeight: lineHeight.sm,
+    },
+    sectionHeaderAction: {
+      flexShrink: 0,
+    },
+    customUrlPanel: {
       gap: spacing.sm,
-    },
-    hint: {
-      color: tokens.text3,
-      fontSize: fontSize.xs,
-      lineHeight: lineHeight.xs,
-    },
-    secondaryAction: {
-      alignSelf: `flex-end`,
-      marginTop: spacing.sm,
     },
     field: {
       gap: spacing.xs,
@@ -394,18 +770,35 @@ function createStyles(tokens: Tokens) {
       paddingHorizontal: spacing.md,
       paddingVertical: spacing.sm,
     },
-    dismissForever: {
-      alignSelf: `center`,
-      paddingVertical: spacing.sm,
-      paddingHorizontal: spacing.md,
-      marginTop: spacing.md,
+
+    // Lives outside the ScrollView so escape actions stay pinned at
+    // thumb reach rather than flowing with content.
+    footerArea: {
+      paddingHorizontal: spacing.xl,
+      paddingTop: spacing.md,
+      paddingBottom: spacing.md,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: tokens.border1,
+      backgroundColor: tokens.bg,
+      gap: spacing.sm,
     },
-    dismissForeverPressed: {
+    footerRow: {
+      flexDirection: `row`,
+      alignItems: `center`,
+      justifyContent: `space-between`,
+      gap: spacing.sm,
+    },
+    dismissLink: {
+      alignSelf: `center`,
+      paddingVertical: spacing.xs,
+      paddingHorizontal: spacing.md,
+    },
+    dismissLinkPressed: {
       opacity: 0.6,
     },
-    dismissForeverText: {
+    dismissLinkText: {
       color: tokens.text3,
-      fontSize: fontSize.xs,
+      fontSize: fontSize.sm,
       textDecorationLine: `underline`,
     },
   })

--- a/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
+++ b/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
@@ -36,26 +36,29 @@ export function ServerSetupScreen({
   const isSignedInToCloud = cloudState.status === `signed-in`
   const isSigningInToCloud = cloudState.status === `signing-in`
 
+  const commit = async (url: string): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      // Cloud agent servers reject unauthenticated requests with 401,
+      // so headers must be registered before the health probe.
+      await prepareServerHeaders(url)
+      await checkServerHealth(url)
+      await onSave(url)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
   const submit = async () => {
     const normalized = normalizeServerUrl(value)
     if (!normalized) {
       setError(`Enter an agents server URL.`)
       return
     }
-    setLoading(true)
-    setError(null)
-    try {
-      // Inject Cloud auth headers (if applicable) before the health
-      // check probes the server — Cloud agent servers reject
-      // unauthenticated requests with 401.
-      await prepareServerHeaders(normalized)
-      await checkServerHealth(normalized)
-      await onSave(normalized)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setLoading(false)
-    }
+    await commit(normalized)
   }
 
   return (
@@ -77,7 +80,7 @@ export function ServerSetupScreen({
             </Text>
             {isSignedInToCloud ? (
               <Text style={styles.hint}>
-                Signed in to Electric Cloud as{' '}
+                Signed in to Electric Cloud as{` `}
                 {cloudState.email ?? `this account`}. Want to try a different
                 Google account? Sign out below, then sign in again.
               </Text>
@@ -89,10 +92,7 @@ export function ServerSetupScreen({
             )}
           </View>
 
-          <CloudServerPicker
-            onPick={(picked) => setValue(picked)}
-            disabled={loading}
-          />
+          <CloudServerPicker onConnect={commit} disabled={loading} />
 
           <View style={styles.field}>
             <Text style={styles.label}>Server URL</Text>

--- a/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
+++ b/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native'
 import { CloudServerPicker } from '../components/CloudServerPicker'
+import { Header, HeaderBackButton } from '../components/Header'
 import { PrimaryButton } from '../components/PrimaryButton'
 import { Screen } from '../components/Screen'
 import { useCloudAuth } from '../lib/CloudAuthContext'
@@ -18,6 +19,11 @@ import { checkServerHealth, normalizeServerUrl } from '../lib/agentsClient'
 import { prepareServerHeaders } from '../lib/serverHeaders'
 import type { Tokens } from '../lib/theme'
 
+/**
+ * Standalone "select or add an agents server" screen, reached from the
+ * Home menu (with `onCancel`) or as the `!serverUrl` fallback from the
+ * root layout. Mirrors the onboarding step-2 anatomy.
+ */
 export function ServerSetupScreen({
   initialUrl,
   onCancel,
@@ -29,36 +35,54 @@ export function ServerSetupScreen({
 }): React.ReactElement {
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
-  const { state: cloudState, signIn, signOut } = useCloudAuth()
-  const [value, setValue] = useState(initialUrl ?? ``)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const isSignedInToCloud = cloudState.status === `signed-in`
+  const { state: cloudState, signIn } = useCloudAuth()
+  const [customUrlOpen, setCustomUrlOpen] = useState(false)
+  const [customUrlValue, setCustomUrlValue] = useState(initialUrl ?? ``)
+  const [submitting, setSubmitting] = useState(false)
+  const [cloudConnectError, setCloudConnectError] = useState<string | null>(
+    null
+  )
+  const [customUrlError, setCustomUrlError] = useState<string | null>(null)
+
+  const isCloudSignedIn = cloudState.status === `signed-in`
   const isSigningInToCloud = cloudState.status === `signing-in`
 
-  const commit = async (url: string): Promise<void> => {
-    setLoading(true)
-    setError(null)
+  const commit = async (url: string): Promise<string | null> => {
+    setSubmitting(true)
     try {
       // Cloud agent servers reject unauthenticated requests with 401,
       // so headers must be registered before the health probe.
       await prepareServerHeaders(url)
       await checkServerHealth(url)
       await onSave(url)
+      return null
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      return err instanceof Error ? err.message : String(err)
     } finally {
-      setLoading(false)
+      setSubmitting(false)
     }
   }
 
-  const submit = async () => {
-    const normalized = normalizeServerUrl(value)
+  const connectCloudRow = async (url: string): Promise<void> => {
+    setCloudConnectError(null)
+    const err = await commit(url)
+    if (err) setCloudConnectError(err)
+  }
+
+  const submitCustom = async (): Promise<void> => {
+    const normalized = normalizeServerUrl(customUrlValue)
     if (!normalized) {
-      setError(`Enter an agents server URL.`)
+      setCustomUrlError(`Enter an agents server URL.`)
       return
     }
-    await commit(normalized)
+    setCustomUrlError(null)
+    const err = await commit(normalized)
+    if (err) setCustomUrlError(err)
+  }
+
+  const toggleCustomUrl = (): void => {
+    setCustomUrlError(null)
+    setCustomUrlOpen((open) => !open)
   }
 
   return (
@@ -67,108 +91,124 @@ export function ServerSetupScreen({
         behavior={Platform.OS === `ios` ? `padding` : undefined}
         style={styles.flex}
       >
+        {onCancel && (
+          <Header
+            align="center"
+            title="Server"
+            leading={<HeaderBackButton onPress={onCancel} />}
+          />
+        )}
+
         <ScrollView
+          style={styles.flex}
           contentContainerStyle={styles.scroll}
           keyboardShouldPersistTaps="handled"
         >
-          <View style={styles.heading}>
-            <Text style={styles.eyebrow}>Electric Agents</Text>
-            <Text style={styles.title}>Connect to an agents server</Text>
-            <Text style={styles.copy}>
-              Mobile connects to a running server. It does not bundle a local
-              Horton runtime.
-            </Text>
-            {isSignedInToCloud ? (
-              <Text style={styles.hint}>
-                Signed in to Electric Cloud as{` `}
-                {cloudState.email ?? `this account`}. Want to try a different
-                Google account? Sign out below, then sign in again.
-              </Text>
-            ) : (
-              <Text style={styles.hint}>
-                Not signed in to Electric Cloud. Sign in below to discover your
-                cloud-hosted agent servers automatically.
-              </Text>
-            )}
-          </View>
+          {!onCancel && <Text style={styles.title}>Server</Text>}
+          <Text style={styles.description}>
+            Choose or add the agents server this app connects to.
+          </Text>
 
-          <CloudServerPicker onConnect={commit} disabled={loading} />
-
-          <View style={styles.field}>
-            <Text style={styles.label}>Server URL</Text>
-            <TextInput
-              autoCapitalize="none"
-              autoCorrect={false}
-              keyboardType="url"
-              placeholder="https://agents.example.com"
-              placeholderTextColor={tokens.text3}
-              value={value}
-              onChangeText={setValue}
-              onSubmitEditing={submit}
-              returnKeyType="go"
-              style={styles.input}
-            />
-          </View>
-
-          {error && (
-            <View style={styles.errorRow}>
-              <Text style={styles.errorText}>{error}</Text>
+          {!isCloudSignedIn && (
+            <View style={styles.cloudSignIn}>
+              <View style={styles.sectionHeader}>
+                <View style={styles.sectionHeaderText}>
+                  <Text style={styles.sectionHeaderTitle}>Electric Cloud</Text>
+                  <Text style={styles.sectionHeaderDescription}>
+                    Sign in to discover hosted agents servers.
+                  </Text>
+                </View>
+              </View>
+              <PrimaryButton
+                title={
+                  isSigningInToCloud
+                    ? `Opening browser…`
+                    : `Sign in with GitHub`
+                }
+                leadingIcon="github"
+                disabled={isSigningInToCloud || submitting}
+                onPress={() => {
+                  void signIn(`github`)
+                }}
+              />
+              <PrimaryButton
+                title={
+                  isSigningInToCloud
+                    ? `Opening browser…`
+                    : `Sign in with Google`
+                }
+                variant="soft"
+                leadingIcon="google"
+                disabled={isSigningInToCloud || submitting}
+                onPress={() => {
+                  void signIn(`google`)
+                }}
+              />
             </View>
           )}
 
-          <View style={styles.actions}>
-            {onCancel && (
+          <CloudServerPicker
+            onConnect={connectCloudRow}
+            disabled={submitting}
+          />
+
+          {cloudConnectError && (
+            <View style={styles.errorRow}>
+              <Text style={styles.errorText}>{cloudConnectError}</Text>
+            </View>
+          )}
+
+          <View style={styles.sectionHeader}>
+            <View style={styles.sectionHeaderText}>
+              <Text style={styles.sectionHeaderTitle}>Custom server</Text>
+              <Text style={styles.sectionHeaderDescription}>
+                Connect to a self-hosted agents server.
+              </Text>
+            </View>
+            <View style={styles.sectionHeaderAction}>
               <PrimaryButton
-                title="Cancel"
+                title={customUrlOpen ? `Cancel` : `Add custom URL`}
                 variant="ghost"
-                onPress={onCancel}
-                disabled={loading || isSigningInToCloud}
+                onPress={toggleCustomUrl}
+                disabled={submitting}
               />
-            )}
-            {isSignedInToCloud ? (
-              <PrimaryButton
-                title="Sign out"
-                variant="ghost"
-                onPress={() => {
-                  void signOut()
-                }}
-                disabled={loading || isSigningInToCloud}
-              />
-            ) : (
-              <>
-                <PrimaryButton
-                  title={
-                    isSigningInToCloud
-                      ? `Opening browser…`
-                      : `Sign in with GitHub`
-                  }
-                  variant="ghost"
-                  onPress={() => {
-                    void signIn(`github`)
-                  }}
-                  disabled={loading || isSigningInToCloud}
-                />
-                <PrimaryButton
-                  title={
-                    isSigningInToCloud
-                      ? `Opening browser…`
-                      : `Sign in with Google`
-                  }
-                  variant="ghost"
-                  onPress={() => {
-                    void signIn(`google`)
-                  }}
-                  disabled={loading || isSigningInToCloud}
-                />
-              </>
-            )}
-            <PrimaryButton
-              title="Connect"
-              loading={loading}
-              onPress={submit}
-              disabled={loading || isSigningInToCloud}
-            />
+            </View>
           </View>
+
+          {customUrlOpen && (
+            <View style={styles.customUrlPanel}>
+              <View style={styles.field}>
+                <Text style={styles.label}>Server URL</Text>
+                <TextInput
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="url"
+                  placeholder="https://agents.example.com"
+                  placeholderTextColor={tokens.text3}
+                  value={customUrlValue}
+                  onChangeText={setCustomUrlValue}
+                  onSubmitEditing={() => {
+                    void submitCustom()
+                  }}
+                  returnKeyType="go"
+                  style={styles.input}
+                />
+              </View>
+              {customUrlError && (
+                <View style={styles.errorRow}>
+                  <Text style={styles.errorText}>{customUrlError}</Text>
+                </View>
+              )}
+              <PrimaryButton
+                title="Connect"
+                loading={submitting}
+                disabled={submitting}
+                onPress={() => {
+                  void submitCustom()
+                }}
+              />
+            </View>
+          )}
         </ScrollView>
       </KeyboardAvoidingView>
     </Screen>
@@ -181,20 +221,10 @@ function createStyles(tokens: Tokens) {
       flex: 1,
     },
     scroll: {
-      flexGrow: 1,
-      justifyContent: `center`,
       paddingHorizontal: spacing.xl,
-      paddingVertical: spacing.xxxl,
+      paddingTop: spacing.xl,
+      paddingBottom: spacing.xxxl,
       gap: spacing.lg,
-    },
-    heading: {
-      alignItems: `flex-start`,
-      gap: spacing.sm,
-      paddingBottom: spacing.md,
-    },
-    eyebrow: {
-      color: tokens.text3,
-      fontSize: fontSize.sm,
     },
     title: {
       color: tokens.text1,
@@ -202,18 +232,41 @@ function createStyles(tokens: Tokens) {
       fontWeight: `400`,
       lineHeight: lineHeight.xxxl,
     },
-    copy: {
+    description: {
       color: tokens.text2,
       fontSize: fontSize.base,
       lineHeight: lineHeight.base,
     },
+    cloudSignIn: {
+      gap: spacing.md,
+    },
+    sectionHeader: {
+      flexDirection: `row`,
+      alignItems: `center`,
+      gap: spacing.md,
+    },
+    sectionHeaderText: {
+      flex: 1,
+      gap: 2,
+    },
+    sectionHeaderTitle: {
+      color: tokens.text1,
+      fontSize: fontSize.base,
+      fontWeight: `500`,
+    },
+    sectionHeaderDescription: {
+      color: tokens.text2,
+      fontSize: fontSize.sm,
+      lineHeight: lineHeight.sm,
+    },
+    sectionHeaderAction: {
+      flexShrink: 0,
+    },
+    customUrlPanel: {
+      gap: spacing.sm,
+    },
     field: {
       gap: spacing.xs,
-    },
-    hint: {
-      color: tokens.text3,
-      fontSize: fontSize.xs,
-      lineHeight: lineHeight.xs,
     },
     label: {
       color: tokens.text2,
@@ -239,12 +292,6 @@ function createStyles(tokens: Tokens) {
     errorText: {
       color: tokens.red11,
       fontSize: fontSize.sm,
-    },
-    actions: {
-      flexDirection: `row`,
-      gap: spacing.sm,
-      justifyContent: `flex-end`,
-      paddingTop: spacing.sm,
     },
   })
 }


### PR DESCRIPTION
## Summary

- Reshapes mobile onboarding to mirror the desktop wizard's visual anatomy (step indicator, step header, section cards, pinned footer) while staying native on iOS/Android. Two steps only — Cloud sign-in and Server selection — since mobile has no local Horton runtime to configure.
- Cloud server picker rows now commit the connection on tap via a new `onConnect(url)` callback, fixing the "selecting a cloud server fills the URL input" bug. Manual self-hosted URL entry lives in a collapsible "Custom server" section with its own inline error display.
- Onboarding is now mandatory until a server connection is saved — both escape valves ("Don't show this again" on step 1, "Skip for now" on step 2) are gone, so `onboardingDismissed=true ⟹ serverUrl is set`. `ServerSetupScreen` has been rewritten on top of the same step-2 anatomy so the two screens stay aligned.
- `DiagnosticsScreen` gains a `__DEV__`-gated **Clear all local data** action (mirrors desktop's `GeneralPage` equivalent): wipes AsyncStorage, signs out of Cloud, and reloads the JS bundle into a fresh onboarding flow.

### Notable details
- Step indicator: numbered circles + inline labels, joined by a fixed-width hairline bar; completed steps render in `greenA3` with a check icon.
- Footer is pinned outside the `ScrollView` and respects `useSafeAreaInsets().bottom` so escape actions sit at thumb reach, never under the home indicator.
- `Sign in with GitHub` button gains the lucide GitHub icon; `Sign in with Google` uses the official Google "G" mark rendered as a single fill colour (brand-compliant in CTA contexts).
- Terms of service and privacy policy links open via `expo-web-browser`, matching the existing OAuth flow.
- Auto-advance from cloud → server is a one-shot per sign-in transition (`useRef`-tracked, seeded from `startStep` so warm restarts with a restored session don't silently re-advance on Back).
- Single `commit(url)` helper in both `OnboardingScreen` and `ServerSetupScreen` returns `Promise<string | null>` instead of re-throwing — caller routes the error to whichever state slot is contextually relevant.

## Test plan

- [ ] First-launch onboarding: signed-out path → step 1 GitHub/Google buttons → tap **Continue without Cloud** → step 2 with cloud sign-in prompt + custom server section → tap **Add custom URL**, enter `http://<lan-ip>:4437`, tap **Connect** → lands on home.
- [ ] Signed-in path: cloud sign-in succeeds → auto-advances to step 2 → tap a cloud row → row shows `Connecting…` → lands on home. URL input never visible.
- [ ] Back/Forward navigation: from step 2 tap **Back** → step 1 shows signed-in confirmation card → tap **Continue** → back on step 2. No bouncing or silent re-advance.
- [ ] Warm restart with a restored cloud session: wizard opens straight on step 2; tap **Back** → step 1 stays put (does not auto-advance back to step 2).
- [ ] Validation: open **Custom server** panel, tap **Connect** with empty input → "Enter an agents server URL." error appears under the field. Tap **Cancel** → panel collapses, error is cleared.
- [ ] Cloud-row connect failure: error appears between picker and Custom server section (not inside the panel).
- [ ] Mandatory wizard: relaunching the app before a server URL is saved drops back into the wizard — there is no skip/dismiss escape.
- [ ] `ServerSetupScreen` (Settings → Server): cloud row tap commits directly; URL input is never auto-populated by the picker.
- [ ] Dev: Diagnostics → **Clear all local data** → confirm → app restarts into onboarding.
- [ ] Light + dark themes; iPhone 14 Pro and an Android with edge-to-edge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)