### PR TITLE
fix(sync-service): match Postgres LIKE semantics for newlines and escaped wildcards

### DIFF
--- a/.changeset/like-postgres-semantics.md
+++ b/.changeset/like-postgres-semantics.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix `LIKE`/`ILIKE` to follow Postgres semantics: `%` and `_` now match newline characters, a trailing newline in the value is no longer ignored, and a backslash-escaped `%` or `_` matches the literal character instead of the wildcard (including the backslash).

--- a/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
+++ b/packages/sync-service/lib/electric/replication/postgres_interop/casting.ex
@@ -94,6 +94,16 @@ defmodule Electric.Replication.PostgresInterop.Casting do
   @doc """
   LIKE function from SQL. Case sensitive by default.
 
+  Follows Postgres semantics:
+
+    * `%` matches any sequence of zero or more characters,
+    * `_` matches any single character,
+    * both wildcards also match newline characters,
+    * the pattern must match the entire string (a trailing newline in the value
+      is not ignored), and
+    * a backslash escapes the following character, so an escaped `%` or `_`
+      matches the literal character instead of acting as a wildcard.
+
   ## Examples
 
       iex> like?("hello", "hell_")
@@ -112,17 +122,35 @@ defmodule Electric.Replication.PostgresInterop.Casting do
       true
   """
   def like?(text, pattern, ignore_case? \\ false) do
-    pattern
-    |> String.split(~r/(?<!\\)[_%]/, include_captures: true, trim: true)
-    |> Enum.map_join(fn
-      "%" -> ".*"
-      "_" -> "."
-      text -> Regex.escape(text)
-    end)
-    |> then(&("^" <> &1 <> "$"))
-    |> Regex.compile!(if ignore_case?, do: [:caseless], else: [])
+    # `:dotall` makes `.` (from `%`/`_`) match newlines like Postgres does, and
+    # `\A..\z` anchors the match to the absolute string boundaries so a trailing
+    # newline in the value is not silently ignored (which `^..$` would do).
+    options = if ignore_case?, do: [:caseless, :dotall], else: [:dotall]
+
+    ("\\A" <> like_pattern_to_regex(pattern) <> "\\z")
+    |> Regex.compile!(options)
     |> Regex.match?(text)
   end
+
+  # Translate a SQL LIKE pattern into a regex source string following Postgres
+  # semantics: `%` -> `.*`, `_` -> `.`, a backslash escapes the next character,
+  # and everything else is matched literally.
+  defp like_pattern_to_regex(pattern), do: like_pattern_to_regex(pattern, [])
+
+  defp like_pattern_to_regex(<<>>, acc),
+    do: acc |> Enum.reverse() |> IO.iodata_to_binary()
+
+  defp like_pattern_to_regex(<<?\\, next::utf8, rest::binary>>, acc),
+    do: like_pattern_to_regex(rest, [Regex.escape(<<next::utf8>>) | acc])
+
+  defp like_pattern_to_regex(<<?%, rest::binary>>, acc),
+    do: like_pattern_to_regex(rest, [".*" | acc])
+
+  defp like_pattern_to_regex(<<?_, rest::binary>>, acc),
+    do: like_pattern_to_regex(rest, ["." | acc])
+
+  defp like_pattern_to_regex(<<c::utf8, rest::binary>>, acc),
+    do: like_pattern_to_regex(rest, [Regex.escape(<<c::utf8>>) | acc])
 
   def ilike?(text, pattern), do: like?(text, pattern, true)
 

--- a/packages/sync-service/test/electric/replication/postgres_interop/casting_test.exs
+++ b/packages/sync-service/test/electric/replication/postgres_interop/casting_test.exs
@@ -1,4 +1,31 @@
 defmodule Electric.Replication.PostgresInterop.CastingTest do
   use ExUnit.Case, async: true
+  import Electric.Replication.PostgresInterop.Casting
   doctest Electric.Replication.PostgresInterop.Casting, import: true
+
+  describe "like?/2 Postgres compatibility" do
+    test "`%` and `_` match newline characters" do
+      # In Postgres both wildcards match any character, including newlines.
+      assert like?("hello\nworld", "hello%world")
+      assert like?("a\nb", "a_b")
+    end
+
+    test "the pattern must match the whole value, including a trailing newline" do
+      # 'trailing\n' LIKE 'trailing' is false in Postgres; the newline is a
+      # real character that the (anchored) pattern must account for.
+      refute like?("trailing\n", "trailing")
+      assert like?("trailing\n", "trailing%")
+    end
+
+    test "a backslash escapes `%` and `_` to match the literal character" do
+      assert like?("100%", "100\\%")
+      assert like?("a_b", "a\\_b")
+      refute like?("hello", "hell\\%")
+    end
+
+    test "ilike?/2 keeps the corrected semantics while ignoring case" do
+      assert ilike?("HELLO\nWORLD", "hello%world")
+      assert ilike?("100%", "100\\%")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Electric.Replication.PostgresInterop.Casting.like?/3` — used by `LIKE`/`ILIKE`
in shape `where` clauses — compiles a SQL `LIKE` pattern into a regex anchored
with `^…$` and **without** the dotall flag. That diverges from Postgres `LIKE`
semantics in three ways. Because `like?/3` decides row membership for a shape
filter, each divergence can **silently include or exclude the wrong rows**
relative to Postgres.

## Divergences (reduced repros, at the function level)

| Input | Postgres | `Casting.like?` (before) |
|---|---|---|
| `like?("a\nb", "a%b")` | `true` | `false` |
| `like?("a\nb", "a_b")` | `true` | `false` |
| `like?("ab\n", "ab")` | `false` | `true` |
| `like?("hell%", "hell\\%")` | `true` | `false` |
| `like?("hell_", "hell\\_")` | `true` | `false` |

Root causes:

1. `%`→`.*` and `_`→`.`, but `.` does not match newlines without the dotall
   flag, so the wildcards don't span newlines (Postgres' do).
2. The pattern is anchored with `^…$`; in PCRE/`:re`, `$` also matches *before*
   a trailing newline, so `'ab\n' LIKE 'ab'` wrongly matches. Postgres requires
   the pattern to cover the whole value.
3. Splitting on `(?<!\\)[_%]` leaves escaped wildcards inside literal chunks, so
   `Regex.escape/1` escapes the **backslash too** — `\%` ends up matching a
   literal `\%` rather than a literal `%`.

## Fix

- Translate the pattern in a single backslash-aware pass: `\X` → literal `X`
  (so `\%`, `\_`, `\\` become literal `%`, `_`, `\`), `%` → `.*`, `_` → `.`,
  everything else → `Regex.escape/1`.
- Anchor with `\A…\z` (absolute string boundaries) instead of `^…$`.
- Compile with `:dotall` so the wildcards match newlines.

## Tests

Adds `describe "like?/2 Postgres compatibility"` in `casting_test.exs` covering
all three cases (newlines, trailing newline, escaped wildcards) plus an
`ilike?/2` case. The existing `like?` doctests are unchanged and still pass.

## Notes

- The pattern→regex mapping was cross-checked against a small, language-agnostic
  reference implementation of both the old and new behaviour against Postgres'
  documented semantics. Opened as a **draft** pending a CI / `mix test` run for
  the sync-service package.
- A trailing lone backslash is currently treated as a literal backslash;
  Postgres instead raises `LIKE pattern must not end with escape character`.
  Happy to switch to raising if you'd prefer to match that exactly.
