### PR TITLE
fix(agents-desktop): prefer live Cloud server metadata

### DIFF
--- a/.changeset/cloud-server-shape-overlay.md
+++ b/.changeset/cloud-server-shape-overlay.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server-ui': patch
+---
+
+Prefer live Electric Cloud server metadata when rendering saved Cloud servers so project, environment, and workspace names stay up to date in the desktop server picker.

--- a/packages/agents-server-ui/src/hooks/useAvailableServers.ts
+++ b/packages/agents-server-ui/src/hooks/useAvailableServers.ts
@@ -146,10 +146,14 @@ export function useAvailableServers(): AvailableServersState {
           : server.desiredState === `connected`
             ? `offline`
             : `disconnected`)
+      const isCloud = server.source === `electric-cloud`
+      const displayName = isCloud
+        ? (cloudServer?.name ?? server.name)
+        : server.name
       return {
         key: `saved:${server.id}`,
         kind: `saved`,
-        name: server.name,
+        name: displayName,
         description: cloudPath,
         url: server.url,
         tenantId: server.tenantId ?? null,
@@ -164,7 +168,7 @@ export function useAvailableServers(): AvailableServersState {
           (server.localRuntimeEnabled === false ? `disabled` : `stopped`),
         isSelected: server.id === activeServer?.id,
         isSaved: true,
-        isCloud: server.source === `electric-cloud`,
+        isCloud,
         isLocal: isLocalServerUrl(server.url),
       }
     })


### PR DESCRIPTION
## Summary
- Overlay live Electric Cloud agent server metadata onto saved desktop server entries
- Prefer the Cloud shape stream name for saved Cloud servers, with the local settings name as fallback
- Reuse the computed Cloud flag when building available server entries

## Testing
- pnpm install
- pnpm --dir packages/agents-server-ui typecheck
- git diff --check