### PR TITLE
fix(agents-mobile): prevent stream transition flash

### DIFF
--- a/.changeset/mobile-stream-flash.md
+++ b/.changeset/mobile-stream-flash.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-mobile": patch
+---
+
+Prevent the mobile session screen from flashing white while the embedded stream WebView boots by applying the themed background to all native DOM/WebView layers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,12 @@ Before making changes to `packages/typescript-client`, **always read `packages/t
 
 ## Testing
 
+Before running `pnpm typecheck`, `pnpm test`, or package-level variants such as
+`pnpm run typecheck`, run `pnpm install` from the repository/worktree root first.
+Fresh worktrees do not have package-local dependency links until install has
+materialized the workspace, which can otherwise produce misleading TypeScript or
+module-resolution errors.
+
 ### Unit testing (mocked)
 
 ```ts

--- a/packages/agents-mobile/app/session.tsx
+++ b/packages/agents-mobile/app/session.tsx
@@ -193,6 +193,8 @@ function domOptions(
   embedSize: { width: number; height: number },
   backgroundColor: string
 ) {
+  const backgroundStyle = [styles.domEmbedWeb, embedSize, { backgroundColor }]
+
   return {
     useExpoDOMWebView: false,
     matchContents: false,
@@ -201,8 +203,13 @@ function domOptions(
     automaticallyAdjustContentInsets: false,
     automaticallyAdjustsScrollIndicatorInsets: false,
     contentInsetAdjustmentBehavior: `never`,
-    style: [styles.domEmbedWeb, embedSize, { backgroundColor }],
-    containerStyle: [styles.domEmbedWeb, embedSize, { backgroundColor }],
+    // The native WebView briefly paints its own default background while the
+    // DOM bundle boots. Keep every layer themed so route transitions to a
+    // stream don't flash white, especially in dark mode.
+    backgroundColor,
+    style: backgroundStyle,
+    containerStyle: backgroundStyle,
+    webViewStyle: backgroundStyle,
   }
 }
 


### PR DESCRIPTION
## Summary
- theme the native DOM/WebView background used by the mobile session embed
- avoid a white flash while the stream DOM bundle boots, especially in dark mode
- document that fresh worktrees need `pnpm install` before typecheck/tests

## Verification
- `pnpm install` from worktree root
- `pnpm run build` in `packages/agents-runtime`
- `pnpm run typecheck` in `packages/agents-mobile`