### PR TITLE
fix(agents-mobile): align session list ordering

### DIFF
--- a/.changeset/mobile-session-list-parity.md
+++ b/.changeset/mobile-session-list-parity.md
@@ -1,0 +1,7 @@
+---
+'@electric-ax/agents-mobile': patch
+---
+
+Align the mobile sessions overview with the desktop sidebar by hiding
+principal entities and using the same lifecycle ordering for status
+groups.

--- a/packages/agents-mobile/src/lib/sessionBuckets.ts
+++ b/packages/agents-mobile/src/lib/sessionBuckets.ts
@@ -84,8 +84,11 @@ export function groupByType(
 const STATUS_ORDER: Record<string, number> = {
   running: 0,
   idle: 1,
-  spawning: 2,
-  stopped: 3,
+  paused: 2,
+  spawning: 3,
+  stopping: 4,
+  stopped: 5,
+  killed: 6,
 }
 
 export function groupByStatus(

--- a/packages/agents-mobile/src/screens/SessionListScreen.tsx
+++ b/packages/agents-mobile/src/screens/SessionListScreen.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   View,
 } from 'react-native'
-import { useLiveQuery } from '@tanstack/react-db'
+import { eq, not, useLiveQuery } from '@tanstack/react-db'
 import { Fab } from '../components/Fab'
 import { Header } from '../components/Header'
 import { HomeMenu, type ServerHealth } from '../components/HomeMenu'
@@ -80,6 +80,7 @@ export function SessionListScreen({
     (q) =>
       q
         .from({ entity: entitiesCollection })
+        .where(({ entity }) => not(eq(entity.type, `principal`)))
         .orderBy(({ entity }) => entity.updated_at, `desc`),
     [entitiesCollection]
   )


### PR DESCRIPTION
## Summary
- Filter principal entities out of the mobile sessions overview to match desktop.
- Keep mobile sessions explicitly sorted by updated_at descending after client-side filters.
- Align mobile status group ordering with desktop lifecycle ordering.

## Testing
- git diff --check
- pnpm --filter @electric-ax/agents-mobile test: fails in this worktree before running tests because expo/tsconfig.base cannot be resolved.
- pnpm --filter @electric-ax/agents-mobile typecheck: fails in this worktree due missing/unresolved mobile dependencies/tsconfig, e.g. expo-router, react-native, expo/tsconfig.base, JSX config.
