### PR TITLE
Keep desktop runtime awake while local runtime is active

### DIFF
--- a/.changeset/desktop-runtime-awake.md
+++ b/.changeset/desktop-runtime-awake.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-desktop': patch
+'@electric-ax/agents-server-ui': patch
+---
+
+Keep Electric Agents Desktop awake while the local runtime is active, with controls in Settings, onboarding, and the tray menu.

--- a/packages/agents-desktop/src/app/controller.ts
+++ b/packages/agents-desktop/src/app/controller.ts
@@ -286,6 +286,15 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     return status
   }
 
+  const getPreventAppSuspension = (): boolean =>
+    settings.preventAppSuspension !== false
+
+  const setPreventAppSuspension = async (enabled: boolean): Promise<void> => {
+    settings.preventAppSuspension = enabled
+    await saveSettings()
+    runtime.refreshPowerSaveBlocker()
+  }
+
   const syncLaunchAtLoginSetting = async (): Promise<void> => {
     await LoginItems.setLaunchAtLogin(settings.launchAtLogin === true)
   }
@@ -380,6 +389,8 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     getCloudAgentServers: ctx.getCloudAgentServers,
     getLaunchAtLoginStatus,
     setLaunchAtLogin,
+    getPreventAppSuspension,
+    setPreventAppSuspension,
   }
 
   const loadSettings = (): Promise<void> =>

--- a/packages/agents-desktop/src/app/controller.ts
+++ b/packages/agents-desktop/src/app/controller.ts
@@ -193,6 +193,8 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
       connectServer,
       disconnectServer,
       saveSettings,
+      preventAppSuspension: getPreventAppSuspension(),
+      setPreventAppSuspension,
       stopRuntimeEntry,
       restartRuntime,
       refreshDesktopState,

--- a/packages/agents-desktop/src/ipc/preferences.ts
+++ b/packages/agents-desktop/src/ipc/preferences.ts
@@ -1,9 +1,14 @@
 import { ipcMain } from 'electron'
-import type { LaunchAtLoginStatus } from '../shared/types'
+import type {
+  LaunchAtLoginStatus,
+  PreventAppSuspensionPreference,
+} from '../shared/types'
 
 export type PreferencesIpcDeps = {
   getLaunchAtLoginStatus: () => Promise<LaunchAtLoginStatus>
   setLaunchAtLogin: (enabled: boolean) => Promise<LaunchAtLoginStatus>
+  getPreventAppSuspension: () => PreventAppSuspensionPreference
+  setPreventAppSuspension: (enabled: boolean) => Promise<void>
 }
 
 export function registerPreferencesIpcHandlers(deps: PreferencesIpcDeps): void {
@@ -12,5 +17,13 @@ export function registerPreferencesIpcHandlers(deps: PreferencesIpcDeps): void {
   )
   ipcMain.handle(`desktop:set-launch-at-login`, (_event, enabled: boolean) =>
     deps.setLaunchAtLogin(Boolean(enabled))
+  )
+  ipcMain.handle(
+    `desktop:get-prevent-app-suspension`,
+    () => deps.getPreventAppSuspension()
+  )
+  ipcMain.handle(
+    `desktop:set-prevent-app-suspension`,
+    (_event, enabled: boolean) => deps.setPreventAppSuspension(Boolean(enabled))
   )
 }

--- a/packages/agents-desktop/src/ipc/preferences.ts
+++ b/packages/agents-desktop/src/ipc/preferences.ts
@@ -18,9 +18,8 @@ export function registerPreferencesIpcHandlers(deps: PreferencesIpcDeps): void {
   ipcMain.handle(`desktop:set-launch-at-login`, (_event, enabled: boolean) =>
     deps.setLaunchAtLogin(Boolean(enabled))
   )
-  ipcMain.handle(
-    `desktop:get-prevent-app-suspension`,
-    () => deps.getPreventAppSuspension()
+  ipcMain.handle(`desktop:get-prevent-app-suspension`, () =>
+    deps.getPreventAppSuspension()
   )
   ipcMain.handle(
     `desktop:set-prevent-app-suspension`,

--- a/packages/agents-desktop/src/preload.ts
+++ b/packages/agents-desktop/src/preload.ts
@@ -19,6 +19,7 @@ import type {
   ElectricCliStatus,
   LaunchAtLoginStatus,
   OnboardingState,
+  PreventAppSuspensionPreference,
   ServerConfig,
 } from './shared/types'
 import type { CloudAgentServersState } from './cloud/cloud-agent-servers'
@@ -182,6 +183,10 @@ const api = {
     ipcRenderer.invoke(`desktop:get-onboarding-state`),
   setOnboardingDismissed: (dismissed: boolean): Promise<void> =>
     ipcRenderer.invoke(`desktop:set-onboarding-dismissed`, dismissed),
+  getPreventAppSuspension: (): Promise<PreventAppSuspensionPreference> =>
+    ipcRenderer.invoke(`desktop:get-prevent-app-suspension`),
+  setPreventAppSuspension: (enabled: boolean): Promise<void> =>
+    ipcRenderer.invoke(`desktop:set-prevent-app-suspension`, enabled),
   getWorkingDirectory: (): Promise<string | null> =>
     ipcRenderer.invoke(`desktop:get-working-directory`),
   chooseWorkingDirectory: (): Promise<string | null> =>

--- a/packages/agents-desktop/src/runtime/controller.ts
+++ b/packages/agents-desktop/src/runtime/controller.ts
@@ -89,6 +89,8 @@ export function createRuntimeController(deps: {
     lifecycleDeps,
     hasConnectedLocalRuntime: () =>
       RuntimeLifecycle.hasConnectedLocalRuntime(lifecycleDeps),
+    refreshPowerSaveBlocker: () =>
+      RuntimeLifecycle.refreshPowerSaveBlocker(lifecycleDeps),
     restartConnectedRuntimes: () =>
       RuntimeLifecycle.restartConnectedRuntimes(lifecycleDeps),
     stopExistingRuntime: () =>

--- a/packages/agents-desktop/src/runtime/lifecycle.ts
+++ b/packages/agents-desktop/src/runtime/lifecycle.ts
@@ -1,4 +1,4 @@
-import { app } from 'electron'
+import { app, powerSaveBlocker } from 'electron'
 import { AGENT_SKILLS_DIR } from '../shared/paths'
 import {
   MCP_OAUTH_REDIRECT_BASE,
@@ -24,6 +24,7 @@ import type {
   RegistrySnapshot,
   RuntimeEntry,
   ServerConfig,
+  LocalRuntimeStatus,
 } from '../shared/types'
 
 export type RuntimeLifecycleDeps = {
@@ -33,6 +34,7 @@ export type RuntimeLifecycleDeps = {
     workingDirectory?: string | null
     mcp?: { servers: Array<McpServerConfig> }
     pullWakeRunnerId?: string | null
+    preventAppSuspension?: boolean
   }
   runtimeEntries: Map<string, RuntimeEntry>
   windowSelections: Map<number, string | null>
@@ -56,6 +58,8 @@ export type RuntimeLifecycleDeps = {
   getCloudAuthState: () => CloudAuthState | undefined
 }
 
+let powerSaveBlockerId: number | null = null
+
 function reconnectDelayMs(attempt: number): number {
   const base = Math.min(
     RECONNECT_MAX_MS,
@@ -69,6 +73,42 @@ export function hasConnectedLocalRuntime(deps: RuntimeLifecycleDeps): boolean {
     (server) =>
       server.localRuntimeEnabled && server.desiredState === `connected`
   )
+}
+
+function shouldPreventAppSuspension(deps: RuntimeLifecycleDeps): boolean {
+  if (deps.settings.preventAppSuspension === false) return false
+  return [...deps.runtimeEntries.values()].some(
+    (entry) =>
+      entry.desiredState === `connected` &&
+      ([`starting`, `running`] as Array<LocalRuntimeStatus>).includes(
+        entry.localRuntimeStatus
+      )
+  )
+}
+
+export function refreshPowerSaveBlocker(deps: RuntimeLifecycleDeps): void {
+  const shouldBlock = shouldPreventAppSuspension(deps)
+  if (shouldBlock) {
+    if (
+      powerSaveBlockerId === null ||
+      !powerSaveBlocker.isStarted(powerSaveBlockerId)
+    ) {
+      powerSaveBlockerId = powerSaveBlocker.start(`prevent-app-suspension`)
+      console.info(
+        `[agents-desktop] Enabled power save blocker to keep the desktop runtime available while connected.`
+      )
+    }
+    return
+  }
+
+  if (
+    powerSaveBlockerId !== null &&
+    powerSaveBlocker.isStarted(powerSaveBlockerId)
+  ) {
+    powerSaveBlocker.stop(powerSaveBlockerId)
+    console.info(`[agents-desktop] Disabled power save blocker.`)
+  }
+  powerSaveBlockerId = null
 }
 
 export async function restartConnectedRuntimes(
@@ -132,6 +172,7 @@ export async function stopRuntimeEntry(
     ?.localRuntimeEnabled
     ? `stopped`
     : `disabled`
+  refreshPowerSaveBlocker(deps)
   if (current) {
     await current.stop()
   }
@@ -202,6 +243,7 @@ export async function startRuntime(
     entry.lastError = null
     entry.reconnectAttempt = 0
     entry.lastConnectedAt = Date.now()
+    refreshPowerSaveBlocker(deps)
     deps.refreshDesktopState()
     return
   }
@@ -272,6 +314,7 @@ export async function startRuntime(
   entry.runtime = nextRuntime
   entry.localRuntimeStatus = `starting`
   entry.runtimeError = null
+  refreshPowerSaveBlocker(deps)
   deps.refreshDesktopState()
 
   try {
@@ -287,6 +330,7 @@ export async function startRuntime(
     entry.lastError = null
     entry.reconnectAttempt = 0
     entry.lastConnectedAt = Date.now()
+    refreshPowerSaveBlocker(deps)
     deps.refreshDesktopState()
     const reg = nextRuntime.mcpRegistry
     if (reg) {
@@ -312,6 +356,7 @@ export async function startRuntime(
       startupNetworkError ??
       (error instanceof Error ? error.message : String(error))
     entry.reconnectAttempt += 1
+    refreshPowerSaveBlocker(deps)
     scheduleReconnect(deps, serverId)
   }
 }

--- a/packages/agents-desktop/src/settings/store.ts
+++ b/packages/agents-desktop/src/settings/store.ts
@@ -28,6 +28,7 @@ export const DEFAULT_SETTINGS: DesktopSettings = {
   workingDirectory: null,
   apiKeysRef: GLOBAL_API_KEYS_REF,
   launchAtLogin: false,
+  preventAppSuspension: true,
   codex: { enabled: false, source: null },
 }
 
@@ -157,6 +158,7 @@ export async function loadDesktopSettings(
           : null,
       apiKeysRef,
       launchAtLogin: parsed.launchAtLogin === true,
+      preventAppSuspension: parsed.preventAppSuspension !== false,
       onboardingDismissed: parsed.onboardingDismissed === true,
       codex: normalizeCodexSettings(parsed.codex),
       mcp: normalizeMcp(parsed.mcp),
@@ -177,6 +179,7 @@ export async function loadDesktopSettings(
       parsed.version !== SETTINGS_VERSION ||
       parsed.activeServer !== undefined ||
       parsed.apiKeys !== undefined ||
+      parsed.preventAppSuspension === undefined ||
       servers.some((server) => !(`id` in (server as object)))
   } catch (err) {
     console.error(`[agents-desktop] Failed to load settings:`, err)

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -112,6 +112,7 @@ export type DesktopSettings = {
   workingDirectory: string | null
   apiKeysRef: string
   launchAtLogin?: boolean
+  preventAppSuspension?: boolean
   codex?: CodexSettings
   onboardingDismissed?: boolean
   mcp?: { servers: Array<McpServerConfig> }
@@ -123,6 +124,8 @@ export type LaunchAtLoginStatus = {
   enabled: boolean
   reason: string | null
 }
+
+export type PreventAppSuspensionPreference = boolean
 
 export type ElectricCliInstallKind =
   | `not-installed`

--- a/packages/agents-desktop/src/ui/tray.ts
+++ b/packages/agents-desktop/src/ui/tray.ts
@@ -54,6 +54,8 @@ export type UpdateTrayDeps = {
   connectServer: (serverId: string) => Promise<void>
   disconnectServer: (serverId: string) => Promise<void>
   saveSettings: () => Promise<void>
+  preventAppSuspension: boolean
+  setPreventAppSuspension: (enabled: boolean) => Promise<void>
   stopRuntimeEntry: (entry: RuntimeEntry) => Promise<void>
   restartRuntime: (serverId?: string | null) => Promise<void>
   refreshDesktopState: () => void
@@ -85,6 +87,17 @@ export function updateTray(deps: UpdateTrayDeps): void {
     {
       label: `New Window`,
       click: () => deps.createWindow(),
+    },
+    { type: `separator` },
+    {
+      label: `Keep Awake While Local Runtime Is Active`,
+      type: `checkbox`,
+      checked: deps.preventAppSuspension,
+      click: (item) => {
+        void deps.setPreventAppSuspension(item.checked).then(() => {
+          deps.refreshDesktopState()
+        })
+      },
     },
     { type: `separator` },
     {

--- a/packages/agents-server-ui/src/components/OnboardingModal.tsx
+++ b/packages/agents-server-ui/src/components/OnboardingModal.tsx
@@ -11,6 +11,7 @@ import {
   Github,
   Laptop,
   LogIn,
+  Moon,
   Plug,
   Server,
   Sparkles,
@@ -26,12 +27,14 @@ import {
   loadDesktopState,
   installCli,
   loadLaunchAtLoginStatus,
+  loadPreventAppSuspensionPreference,
   loadOnboardingState,
   loadCliStatus,
   onCloudAuthStateChanged,
   prepareCloudAgentServerConnection,
   restartLocalRuntimes,
   saveApiKeys as persistApiKeys,
+  savePreventAppSuspensionPreference,
   setLaunchAtLogin,
   setOnboardingDismissed,
   type ApiKeys,
@@ -144,6 +147,7 @@ export function OnboardingModal(): React.ReactElement | null {
     useState<LaunchAtLoginStatus | null>(null)
   const [cliStatus, setCliStatus] = useState<ElectricCliStatus | null>(null)
   const [launchAtLoginEnabled, setLaunchAtLoginEnabled] = useState(false)
+  const [preventAppSuspension, setPreventAppSuspension] = useState(true)
   const [bootstrapped, setBootstrapped] = useState(false)
   const configAvailable = launchAtLoginStatus?.supported === true
   const steps = useMemo(
@@ -159,19 +163,22 @@ export function OnboardingModal(): React.ReactElement | null {
     let cancelled = false
 
     void (async () => {
-      const [onboarding, cloud, keys, launchAtLogin, cli] = await Promise.all([
-        loadOnboardingState(),
-        loadCloudAuthState(),
-        loadApiKeysStatus(),
-        loadLaunchAtLoginStatus(),
-        loadCliStatus(),
-      ])
+      const [onboarding, cloud, keys, launchAtLogin, cli, keepAwake] =
+        await Promise.all([
+          loadOnboardingState(),
+          loadCloudAuthState(),
+          loadApiKeysStatus(),
+          loadLaunchAtLoginStatus(),
+          loadCliStatus(),
+          loadPreventAppSuspensionPreference(),
+        ])
       if (cancelled) return
       setCloudState(cloud)
       setKeysStatus(keys)
       setLaunchAtLoginStatus(launchAtLogin)
       setCliStatus(cli)
       setLaunchAtLoginEnabled(launchAtLogin?.enabled ?? false)
+      setPreventAppSuspension(keepAwake ?? true)
       setBootstrapped(true)
 
       if (!onboarding || onboarding.dismissed) return
@@ -274,6 +281,8 @@ export function OnboardingModal(): React.ReactElement | null {
             <ConfigStep
               launchAtLoginEnabled={launchAtLoginEnabled}
               onLaunchAtLoginEnabledChange={setLaunchAtLoginEnabled}
+              preventAppSuspension={preventAppSuspension}
+              onPreventAppSuspensionChange={setPreventAppSuspension}
               cliStatus={cliStatus}
               onCliStatusChange={setCliStatus}
               onBack={() => setStep(`keys`)}
@@ -286,6 +295,7 @@ export function OnboardingModal(): React.ReactElement | null {
               onBack={() => setStep(configAvailable ? `config` : `keys`)}
               applyLaunchAtLogin={configAvailable}
               launchAtLoginEnabled={launchAtLoginEnabled}
+              preventAppSuspension={preventAppSuspension}
               onFinish={() => {
                 void closeModal()
               }}
@@ -300,6 +310,8 @@ export function OnboardingModal(): React.ReactElement | null {
 function ConfigStep({
   launchAtLoginEnabled,
   onLaunchAtLoginEnabledChange,
+  preventAppSuspension,
+  onPreventAppSuspensionChange,
   cliStatus,
   onCliStatusChange,
   onBack,
@@ -307,6 +319,8 @@ function ConfigStep({
 }: {
   launchAtLoginEnabled: boolean
   onLaunchAtLoginEnabledChange: (enabled: boolean) => void
+  preventAppSuspension: boolean
+  onPreventAppSuspensionChange: (enabled: boolean) => void
   cliStatus: ElectricCliStatus | null
   onCliStatusChange: (status: ElectricCliStatus | null) => void
   onBack: () => void
@@ -403,6 +417,25 @@ function ConfigStep({
                     ? `Repair`
                     : `Install command`}
             </Button>
+          </span>
+        </SectionRow>
+        <SectionRow>
+          <span className={styles.iconCircle}>
+            <Icon icon={Moon} size={2} />
+          </span>
+          <label className={styles.rowText} style={{ cursor: `pointer` }}>
+            <span className={styles.rowTitle}>Keep desktop awake</span>
+            <Text size={1} tone="muted">
+              Prevent full system sleep while the local runtime is starting or
+              running. The display can still sleep.
+            </Text>
+          </label>
+          <span className={styles.rowAside}>
+            <Switch
+              checked={preventAppSuspension}
+              onCheckedChange={onPreventAppSuspensionChange}
+              ariaLabel="Keep desktop awake while local runtime is active"
+            />
           </span>
         </SectionRow>
       </Section>
@@ -925,12 +958,14 @@ function ServerStep({
   onBack,
   applyLaunchAtLogin,
   launchAtLoginEnabled,
+  preventAppSuspension,
   onFinish,
 }: {
   cloudState: CloudAuthState | null
   onBack: () => void
   applyLaunchAtLogin: boolean
   launchAtLoginEnabled: boolean
+  preventAppSuspension: boolean
   onFinish: () => void | Promise<void>
 }): React.ReactElement {
   const { servers } = useAvailableServers()
@@ -953,6 +988,16 @@ function ServerStep({
           error instanceof Error
             ? error.message
             : `Could not enable open at login.`
+        )
+        return
+      }
+      try {
+        await savePreventAppSuspensionPreference(preventAppSuspension)
+      } catch (error) {
+        setServerError(
+          error instanceof Error
+            ? error.message
+            : `Could not save keep-awake preference.`
         )
         return
       }

--- a/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/GeneralPage.tsx
@@ -15,6 +15,8 @@ import { Button, ConfirmDialog, Icon, Switch, Text } from '../../../ui'
 import {
   clearAllLocalData,
   loadLaunchAtLoginStatus,
+  loadPreventAppSuspensionPreference,
+  savePreventAppSuspensionPreference,
   setLaunchAtLogin,
   type LaunchAtLoginStatus,
 } from '../../../lib/server-connection'
@@ -49,6 +51,10 @@ export function GeneralPage(): React.ReactElement {
   const [launchAtLoginError, setLaunchAtLoginError] = useState<string | null>(
     null
   )
+  const [preventAppSuspension, setPreventAppSuspension] = useState(true)
+  const [preventAppSuspensionError, setPreventAppSuspensionError] = useState<
+    string | null
+  >(null)
 
   useEffect(() => {
     if (!isDesktop) return
@@ -60,6 +66,17 @@ export function GeneralPage(): React.ReactElement {
       .catch((err) => {
         if (!cancelled) {
           setLaunchAtLoginError(
+            err instanceof Error ? err.message : String(err)
+          )
+        }
+      })
+    void loadPreventAppSuspensionPreference()
+      .then((value) => {
+        if (!cancelled && value !== null) setPreventAppSuspension(value)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setPreventAppSuspensionError(
             err instanceof Error ? err.message : String(err)
           )
         }
@@ -91,6 +108,21 @@ export function GeneralPage(): React.ReactElement {
       setLaunchAtLoginError(err instanceof Error ? err.message : String(err))
     } finally {
       setLaunchAtLoginBusy(false)
+    }
+  }
+
+  const handlePreventAppSuspensionChange = async (
+    enabled: boolean
+  ): Promise<void> => {
+    setPreventAppSuspension(enabled)
+    setPreventAppSuspensionError(null)
+    try {
+      await savePreventAppSuspensionPreference(enabled)
+    } catch (err) {
+      setPreventAppSuspension(!enabled)
+      setPreventAppSuspensionError(
+        err instanceof Error ? err.message : String(err)
+      )
     }
   }
 
@@ -193,6 +225,24 @@ export function GeneralPage(): React.ReactElement {
                     void handleLaunchAtLoginChange(checked)
                   }}
                   ariaLabel="Open Electric Agents at login"
+                />
+              }
+            />
+          )}
+          {isDesktop && (
+            <SettingsRow
+              label="Keep desktop awake while local runtime is active"
+              description={
+                preventAppSuspensionError ??
+                `Allows ongoing sessions and incoming mobile-triggered sessions to keep working while the local desktop runtime is active. The display can still sleep.`
+              }
+              control={
+                <Switch
+                  checked={preventAppSuspension}
+                  onCheckedChange={(checked) => {
+                    void handlePreventAppSuspensionChange(checked)
+                  }}
+                  ariaLabel="Keep desktop awake while local runtime is active"
                 />
               }
             />

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -165,6 +165,8 @@ export interface LaunchAtLoginStatus {
   reason: string | null
 }
 
+export type PreventAppSuspensionPreference = boolean
+
 export type ElectricCliInstallKind =
   | `not-installed`
   | `managed`
@@ -340,6 +342,8 @@ declare global {
       setLaunchAtLogin?: (enabled: boolean) => Promise<LaunchAtLoginStatus>
       getOnboardingState?: () => Promise<OnboardingState>
       setOnboardingDismissed?: (dismissed: boolean) => Promise<void>
+      getPreventAppSuspension?: () => Promise<PreventAppSuspensionPreference>
+      setPreventAppSuspension?: (enabled: boolean) => Promise<void>
       getWorkingDirectory?: () => Promise<string | null>
       chooseWorkingDirectory?: () => Promise<string | null>
       /**
@@ -594,6 +598,16 @@ export async function setOnboardingDismissed(
   dismissed: boolean
 ): Promise<void> {
   await window.electronAPI?.setOnboardingDismissed?.(dismissed)
+}
+
+export async function loadPreventAppSuspensionPreference(): Promise<PreventAppSuspensionPreference | null> {
+  return (await window.electronAPI?.getPreventAppSuspension?.()) ?? null
+}
+
+export async function savePreventAppSuspensionPreference(
+  enabled: boolean
+): Promise<void> {
+  await window.electronAPI?.setPreventAppSuspension?.(enabled)
 }
 
 export async function loadCloudAuthState(): Promise<CloudAuthState | null> {


### PR DESCRIPTION
## Summary
- prevent app suspension while the desktop local runtime is starting or running
- add a persisted desktop setting to disable that behavior
- expose the setting in Settings → General

## Testing
- pnpm --filter @electric-sql/client build
- pnpm --filter @electric-ax/agents-runtime build
- pnpm --filter @electric-ax/agents build
- cd packages/agents-desktop && pnpm typecheck
- cd ../agents-server-ui && pnpm typecheck