### PR TITLE
Show detailed agent run failures

### DIFF
--- a/.changeset/agent-run-failure-details.md
+++ b/.changeset/agent-run-failure-details.md
@@ -1,0 +1,6 @@
+---
+"@electric-ax/agents-runtime": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Show detailed agent run failure information in the timeline instead of the generic `Run failed` fallback. Run errors now include their error code, failed tool calls preserve and render their error text, and failed runs fall back to tool errors or finish reasons when no run error row is available.

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -39,6 +39,7 @@ export type EntityTimelineContentItem =
       args: Record<string, unknown>
       status: `started` | `args_complete` | `executing` | `completed` | `failed`
       result?: string
+      error?: string
       isError: boolean
     }
 

--- a/packages/agents-runtime/src/use-chat.ts
+++ b/packages/agents-runtime/src/use-chat.ts
@@ -136,7 +136,11 @@ export function __resetSectionCachesForTesting(): void {
  * sorted-by-order arrays, so the fingerprint string is deterministic.
  */
 function fingerprintRun(run: IncludesRun): string {
-  let fp = `${run.status}|e:${run.errors.length}|t:${run.texts.length}`
+  let fp = `${run.status}|f:${run.finish_reason ?? ``}|e:${run.errors.length}`
+  for (const e of run.errors) {
+    fp += `:${e.key}.${e.error_code}.${e.message.length}`
+  }
+  fp += `|t:${run.texts.length}`
   for (const t of run.texts) {
     fp += `:${t.key}.${t.text.length}.${t.status}`
   }
@@ -295,7 +299,8 @@ function buildAgentSection(run: IncludesRun): AgentResponseSection {
       toolName: tc.tool_name,
       args: parseToolArgs(tc.args),
       status: tc.status,
-      isError: tc.status === `failed`,
+      isError: tc.status === `failed` || Boolean(tc.error),
+      ...(tc.error != null && { error: tc.error }),
       ...(tc.result != null && {
         result:
           typeof tc.result === `string` ? tc.result : JSON.stringify(tc.result),
@@ -305,9 +310,21 @@ function buildAgentSection(run: IncludesRun): AgentResponseSection {
 
   let errorText: string | undefined
   if (run.errors.length > 0) {
-    errorText = run.errors.map((e) => e.message).join(`; `)
+    errorText = run.errors
+      .map((e) => (e.error_code ? `${e.error_code}: ${e.message}` : e.message))
+      .join(`; `)
   } else if (run.status === `failed`) {
-    errorText = `Run failed`
+    const failedTool = run.toolCalls.find(
+      (tc) => tc.status === `failed` && typeof tc.error === `string`
+    )
+    const failedToolText = failedTool
+      ? `${failedTool.tool_name} failed: ${failedTool.error}`
+      : undefined
+    const finishReason = run.finish_reason
+      ? `finish_reason=${run.finish_reason}`
+      : undefined
+    errorText =
+      failedToolText ?? finishReason ?? `Run failed (no error details recorded)`
   }
 
   const section: AgentResponseSection = {

--- a/packages/agents-runtime/test/entity-timeline.test.ts
+++ b/packages/agents-runtime/test/entity-timeline.test.ts
@@ -517,7 +517,7 @@ describe(`entity includes query`, () => {
       expect(sections).toHaveLength(1)
       expect(sections[0]).toMatchObject({
         kind: `agent_response`,
-        error: `boom`,
+        error: `TOOL_FAILED: boom`,
       })
     })
 
@@ -644,7 +644,7 @@ describe(`entity includes query`, () => {
       expect(sections).toHaveLength(1)
       expect(sections[0]).toMatchObject({
         kind: `agent_response`,
-        error: `Run failed`,
+        error: `Run failed (no error details recorded)`,
       })
     })
 
@@ -672,7 +672,7 @@ describe(`entity includes query`, () => {
       expect(sections).toHaveLength(1)
       expect(sections[0]).toMatchObject({
         kind: `agent_response`,
-        error: `db connection lost`,
+        error: `TOOL_FAILED: db connection lost`,
       })
     })
 

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -270,6 +270,7 @@ function liveToolCallToContentItem(
         : {},
     status: item.status,
     result: stringifyToolPayload(item.result),
+    error: typeof item.error === `string` ? item.error : undefined,
     isError: item.status === `failed` || Boolean(item.error),
   }
 }
@@ -321,8 +322,37 @@ function liveRunItemsToContentItems(
 
 function errorText(errors: Array<EntityTimelineErrorItem>): string | undefined {
   return errors.length > 0
-    ? errors.map((error) => error.message).join(`; `)
+    ? errors
+        .map((error) =>
+          error.error_code
+            ? `${error.error_code}: ${error.message}`
+            : error.message
+        )
+        .join(`; `)
     : undefined
+}
+
+function failedRunText(
+  run: EntityTimelineRunRow,
+  items: Array<EntityTimelineRunItem>
+): string | undefined {
+  if (run.status !== `failed`) return undefined
+
+  const failedTool = items.find(
+    (item) =>
+      item.toolCall?.status === `failed` &&
+      typeof item.toolCall.error === `string` &&
+      item.toolCall.error.trim().length > 0
+  )?.toolCall
+  if (failedTool) {
+    return `${failedTool.tool_name} failed: ${failedTool.error}`
+  }
+
+  if (run.finish_reason) {
+    return `Run failed (finish_reason=${run.finish_reason})`
+  }
+
+  return `Run failed (no error details recorded)`
 }
 
 const LiveTextItem = memo(function LiveTextItem({
@@ -393,7 +423,7 @@ export const AgentResponseLive = memo(function AgentResponseLive({
   const done = run.status === `completed`
   const failureText =
     errorText(errors as Array<EntityTimelineErrorItem>) ??
-    (run.status === `failed` ? `Run failed` : undefined)
+    failedRunText(run, sortedItems)
   const lastItem = sortedItems[sortedItems.length - 1]
   const lastTextHasContent =
     lastItem?.text !== undefined && textContent(lastItem.text).trim().length > 0

--- a/packages/agents-server-ui/src/components/ToolCallView.tsx
+++ b/packages/agents-server-ui/src/components/ToolCallView.tsx
@@ -142,6 +142,7 @@ function statusBadge(item: ToolCallItem): StatusBadge {
 function ToolBody({ item }: { item: ToolCallItem }): React.ReactElement {
   const args = item.args
   const r = parseResult(item.result)
+  const errorText = item.error?.trim()
 
   const fallbackDiff =
     item.toolName === `edit` &&
@@ -164,6 +165,11 @@ function ToolBody({ item }: { item: ToolCallItem }): React.ReactElement {
         <Stack direction="column" gap={2}>
           <span className={toolBlock.sectionLabel}>Command</span>
           <pre className={toolBlock.codeBlock}>{args.command as string}</pre>
+          {errorText && (
+            <Text size={1} tone="danger">
+              {errorText}
+            </Text>
+          )}
           {r.text && (
             <>
               <Stack align="center" gap={2}>
@@ -190,6 +196,11 @@ function ToolBody({ item }: { item: ToolCallItem }): React.ReactElement {
       return (
         <Stack direction="column" gap={2}>
           <span className={toolBlock.sectionLabel}>Content</span>
+          {errorText && (
+            <Text size={1} tone="danger">
+              {errorText}
+            </Text>
+          )}
           <pre className={toolBlock.codeBlock}>
             {r.text ? truncate(r.text, 2000) : `(empty)`}
           </pre>
@@ -208,6 +219,11 @@ function ToolBody({ item }: { item: ToolCallItem }): React.ReactElement {
               />
             </>
           ) : null}
+          {errorText && (
+            <Text size={1} tone="danger">
+              {errorText}
+            </Text>
+          )}
           {r.text && (
             <Text size={1} tone={item.isError ? `danger` : `success`}>
               {r.text}
@@ -223,6 +239,11 @@ function ToolBody({ item }: { item: ToolCallItem }): React.ReactElement {
           <pre className={toolBlock.codeBlock}>
             {JSON.stringify(args, null, 2)}
           </pre>
+          {errorText && (
+            <Text size={1} tone="danger">
+              {errorText}
+            </Text>
+          )}
           {r.text && (
             <>
               <span className={toolBlock.sectionLabel}>Output</span>


### PR DESCRIPTION
## Summary
- include error codes/messages in run failure metadata instead of generic "Run failed"
- fall back to failed tool errors or finish reasons when no run error rows exist
- surface tool call error details inside expanded tool call cards

## Verification
- pnpm --filter @electric-ax/agents-server-ui typecheck
- pnpm --filter @electric-ax/agents-runtime typecheck *(fails due existing pg-sync-source test imports: getPgSyncStreamPath, pgSync)*