### PR TITLE
ci: harden privileged PR workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# GitHub Actions workflows and composite actions are privileged CI/CD code.
+# Require an explicit review from a repository admin before they change.
+.github/ @magnetised @samwillis @thruflo @KyleAMathews @paulharter @alco @balegas @icehaunter @msfstef @robacourt @kevin-dp

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
       contents: read
     name: Build image and run benchmarks on PR comment
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'CONTRIBUTOR') && (startsWith(github.event.comment.body, 'benchmark this') || startsWith(github.event.comment.body, 'Benchmark this'))}}
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && (startsWith(github.event.comment.body, 'benchmark this') || startsWith(github.event.comment.body, 'Benchmark this'))}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -31,6 +31,13 @@ jobs:
             const result = await github.rest.pulls.get(request)
             core.info(`GOT ${JSON.stringify(result)}`)
             return result.data
+
+      - name: Ensure PR branch is trusted
+        run: |
+          if [ '${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}' != '${{ github.repository }}' ]; then
+            echo 'Refusing to benchmark a fork PR with privileged credentials.' >&2
+            exit 1
+          fi
 
       - uses: docker/setup-buildx-action@v3
       - uses: actions/checkout@v4

--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.tool-versions'
-          cache: pnpm
       - uses: erlef/setup-beam@v1
         with:
           version-type: strict

--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
       contents: read
     name: Build image and run load test
-    if: ${{ github.event.label.name == 'load-test' }}
+    if: ${{ github.event.label.name == 'load-test' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ts_tests.yml
+++ b/.github/workflows/ts_tests.yml
@@ -15,7 +15,7 @@ on:
 
 permissions:
   contents: read
-  packages: write
+  packages: read
 
 jobs:
   detect_affected_workspaces:


### PR DESCRIPTION
## Summary

Immediate CI supply-chain hardening following the TanStack incident audit:

- remove implicit pnpm cache from the release workflow
- restrict privileged load-test runs to same-repo PR branches
- restrict benchmark comment trigger to MEMBER/OWNER and reject fork PRs before privileged steps
- remove CROSSREPO_PAT callback payloads from benchmark requests
- downgrade TS test workflow package permission from write to read
- add CODEOWNERS protection for .github CI/CD files

## Validation

- Parsed changed workflow YAML files with Ruby YAML loader:
  - .github/workflows/changesets_release.yml
  - .github/workflows/load_test.yml
  - .github/workflows/benchmarking.yml
  - .github/workflows/ts_tests.yml

Note: this PR is from the clean branch horton/ci-immediate-supply-chain-fixes-clean and contains only the immediate CI hardening commit.