### PR TITLE
feat(agents): add Kimi Moonshot provider support

### DIFF
--- a/.changeset/kimi-moonshot-horton.md
+++ b/.changeset/kimi-moonshot-horton.md
@@ -1,0 +1,8 @@
+---
+"@electric-ax/agents-runtime": patch
+"@electric-ax/agents": patch
+"@electric-ax/agents-desktop": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Add Kimi / Moonshot API support for local Horton runtimes, including model catalog entries, runtime provider resolution, desktop credential persistence, and UI credential inputs.

--- a/packages/agents-desktop/src/credentials/api-keys.ts
+++ b/packages/agents-desktop/src/credentials/api-keys.ts
@@ -5,6 +5,7 @@ export const EMPTY_API_KEYS: ApiKeys = {
   anthropic: null,
   openai: null,
   deepseek: null,
+  moonshot: null,
   brave: null,
 }
 
@@ -15,6 +16,7 @@ export function captureEnvApiKeys(env: NodeJS.ProcessEnv): ApiKeys {
     anthropic: env.ANTHROPIC_API_KEY?.trim() || null,
     openai: env.OPENAI_API_KEY?.trim() || null,
     deepseek: env.DEEPSEEK_API_KEY?.trim() || null,
+    moonshot: env.MOONSHOT_API_KEY?.trim() || null,
     brave: env.BRAVE_SEARCH_API_KEY?.trim() || null,
   }
 }
@@ -31,12 +33,19 @@ export function normalizeApiKeys(value: unknown): ApiKeys {
     anthropic: pick(maybe.anthropic),
     openai: pick(maybe.openai),
     deepseek: pick(maybe.deepseek),
+    moonshot: pick(maybe.moonshot),
     brave: pick(maybe.brave),
   }
 }
 
 export function hasAnyApiKey(keys: ApiKeys): boolean {
-  return Boolean(keys.anthropic || keys.openai || keys.deepseek || keys.brave)
+  return Boolean(
+    keys.anthropic ||
+      keys.openai ||
+      keys.deepseek ||
+      keys.moonshot ||
+      keys.brave
+  )
 }
 
 export async function loadApiKeysFromSecret(
@@ -81,6 +90,7 @@ export function applyApiKeysToEnv(
       | `ANTHROPIC_API_KEY`
       | `OPENAI_API_KEY`
       | `DEEPSEEK_API_KEY`
+      | `MOONSHOT_API_KEY`
       | `BRAVE_SEARCH_API_KEY`
   ): void => {
     const next = value ?? fallback
@@ -93,6 +103,7 @@ export function applyApiKeysToEnv(
   resolveSlot(saved.anthropic, launchEnv.anthropic, `ANTHROPIC_API_KEY`)
   resolveSlot(saved.openai, launchEnv.openai, `OPENAI_API_KEY`)
   resolveSlot(saved.deepseek, launchEnv.deepseek, `DEEPSEEK_API_KEY`)
+  resolveSlot(saved.moonshot, launchEnv.moonshot, `MOONSHOT_API_KEY`)
   resolveSlot(saved.brave, launchEnv.brave, `BRAVE_SEARCH_API_KEY`)
 }
 
@@ -108,11 +119,14 @@ export async function getApiKeysStatus(
   const saved = deps.apiKeys
   // Brave is optional (falls back to Anthropic built-in search), so it doesn't
   // count toward "the app is configured".
-  const hasAnyKey = Boolean(saved.anthropic || saved.openai || saved.deepseek)
+  const hasAnyKey = Boolean(
+    saved.anthropic || saved.openai || saved.deepseek || saved.moonshot
+  )
   const suggested: ApiKeys = {
     anthropic: saved.anthropic ? null : deps.launchEnv.anthropic,
     openai: saved.openai ? null : deps.launchEnv.openai,
     deepseek: saved.deepseek ? null : deps.launchEnv.deepseek,
+    moonshot: saved.moonshot ? null : deps.launchEnv.moonshot,
     brave: saved.brave ? null : deps.launchEnv.brave,
   }
   const codex = await deps.getCodexStatus()
@@ -138,6 +152,7 @@ export async function setApiKeys(
     normalized.anthropic !== deps.apiKeys.anthropic ||
     normalized.openai !== deps.apiKeys.openai ||
     normalized.deepseek !== deps.apiKeys.deepseek ||
+    normalized.moonshot !== deps.apiKeys.moonshot ||
     normalized.brave !== deps.apiKeys.brave
   Object.assign(deps.apiKeys, normalized)
   await saveApiKeysToSecret(deps.secretStore, deps.apiKeysRef(), deps.apiKeys)

--- a/packages/agents-desktop/src/credentials/controller.ts
+++ b/packages/agents-desktop/src/credentials/controller.ts
@@ -80,6 +80,7 @@ export function createCredentialsController(deps: {
         deps.apiKeys.anthropic ||
           deps.apiKeys.openai ||
           deps.apiKeys.deepseek ||
+          deps.apiKeys.moonshot ||
           deps.settings.codex?.enabled
       ),
       signedIn: deps.getCloudAuthStatus() === `signed-in`,

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -96,6 +96,7 @@ export type ApiKeys = {
   anthropic: string | null
   openai: string | null
   deepseek: string | null
+  moonshot: string | null
   brave: string | null
 }
 

--- a/packages/agents-runtime/src/index.ts
+++ b/packages/agents-runtime/src/index.ts
@@ -283,6 +283,15 @@ export type {
   LowCostModelChoice,
   LowCostModelConfig,
 } from './model-runner'
+export {
+  MOONSHOT_API_BASE_URL,
+  MOONSHOT_API_KEY_ENV,
+  MOONSHOT_PROVIDER,
+  getMoonshotApiKey,
+  getMoonshotModel,
+  getMoonshotModels,
+} from './moonshot-models'
+export type { MoonshotModel, MoonshotProvider } from './moonshot-models'
 
 export { createRuntimeHandler, createRuntimeRouter } from './create-handler'
 export { verifyWebhookSignature } from './webhook-signature'

--- a/packages/agents-runtime/src/model-runner.ts
+++ b/packages/agents-runtime/src/model-runner.ts
@@ -2,6 +2,11 @@ import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { completeSimple, getModel } from '@mariozechner/pi-ai'
+import {
+  MOONSHOT_PROVIDER,
+  getMoonshotApiKey,
+  getMoonshotModel,
+} from './moonshot-models'
 import type { AgentConfig } from './types'
 import type { KnownProvider } from '@mariozechner/pi-ai'
 
@@ -26,6 +31,7 @@ const PREFERRED_IDS_BY_PROVIDER: Record<string, Array<string>> = {
   openai: [`gpt-4.1-nano`, `gpt-4o-mini`, `gpt-4.1-mini`],
   'openai-codex': [`gpt-5.4-mini`, `gpt-5.1-codex-mini`],
   deepseek: [`deepseek-v4-flash`, `deepseek-v4-pro`],
+  moonshot: [`kimi-k2.6`, `kimi-k2.5`, `moonshot-v1-8k`],
 }
 
 function hasEnv(name: string): boolean {
@@ -58,12 +64,14 @@ export type AvailableProvider =
   | `openai`
   | `openai-codex`
   | `deepseek`
+  | typeof MOONSHOT_PROVIDER
 
 export function detectAvailableProviders(): Array<AvailableProvider> {
   const providers: Array<AvailableProvider> = []
   if (hasEnv(`ANTHROPIC_API_KEY`)) providers.push(`anthropic`)
   if (hasEnv(`OPENAI_API_KEY`)) providers.push(`openai`)
   if (hasEnv(`DEEPSEEK_API_KEY`)) providers.push(`deepseek`)
+  if (getMoonshotApiKey()) providers.push(MOONSHOT_PROVIDER)
   if (readCodexAccessToken() !== undefined) providers.push(`openai-codex`)
   return providers
 }
@@ -101,6 +109,13 @@ function envCatalog(): LowCostModelCatalog {
       reasoning: true,
     })
   }
+  if (providers.includes(MOONSHOT_PROVIDER)) {
+    choices.push({
+      provider: MOONSHOT_PROVIDER,
+      id: `kimi-k2.6`,
+      reasoning: false,
+    })
+  }
   return { choices, defaultChoice: choices[0] }
 }
 
@@ -115,6 +130,7 @@ export function selectLowCostModelChoice(
     `openai`,
     `anthropic`,
     `deepseek`,
+    MOONSHOT_PROVIDER,
   ].filter((provider): provider is string => Boolean(provider))
 
   for (const provider of providerOrder) {
@@ -149,6 +165,25 @@ export function selectLowCostModelChoice(
   )
 }
 
+function resolveLowCostModel(choice: LowCostModelChoice) {
+  if (choice.provider === MOONSHOT_PROVIDER) return getMoonshotModel(choice.id)
+  return getModel(
+    choice.provider as Parameters<typeof getModel>[0],
+    choice.id as Parameters<typeof getModel>[1]
+  )
+}
+
+async function resolveLowCostApiKey(input: {
+  provider: string
+  modelConfig?: LowCostModelConfig
+}): Promise<string | undefined> {
+  if (input.modelConfig?.getApiKey) {
+    return await input.modelConfig.getApiKey(input.provider)
+  }
+  if (input.provider === MOONSHOT_PROVIDER) return getMoonshotApiKey()
+  return undefined
+}
+
 export async function completeWithLowCostModel(input: {
   catalog?: LowCostModelCatalog
   modelConfig?: LowCostModelConfig
@@ -160,10 +195,7 @@ export async function completeWithLowCostModel(input: {
   maxTokens: number
 }): Promise<string> {
   const choice = selectLowCostModelChoice(input.catalog, input.modelConfig)
-  const model = getModel(
-    choice.provider as Parameters<typeof getModel>[0],
-    choice.id as Parameters<typeof getModel>[1]
-  )
+  const model = resolveLowCostModel(choice)
   if (!model) {
     throw new Error(
       `unknown ${input.purpose} model "${choice.id}" for provider "${choice.provider}"`
@@ -174,9 +206,10 @@ export async function completeWithLowCostModel(input: {
     `${input.logPrefix ?? ``}${input.logPrefix ? ` ` : ``}${input.purpose} using ${choice.provider}:${choice.id}`
   )
 
-  const apiKey = input.modelConfig?.getApiKey
-    ? await input.modelConfig.getApiKey(choice.provider)
-    : undefined
+  const apiKey = await resolveLowCostApiKey({
+    provider: choice.provider,
+    modelConfig: input.modelConfig,
+  })
   const res = await completeSimple(
     model,
     {

--- a/packages/agents-runtime/src/moonshot-models.ts
+++ b/packages/agents-runtime/src/moonshot-models.ts
@@ -1,0 +1,141 @@
+import type { Model } from '@mariozechner/pi-ai'
+
+export const MOONSHOT_PROVIDER = `moonshot` as const
+export type MoonshotProvider = typeof MOONSHOT_PROVIDER
+
+export const MOONSHOT_API_KEY_ENV = `MOONSHOT_API_KEY`
+export const MOONSHOT_API_BASE_URL = `https://api.moonshot.ai/v1`
+
+export type MoonshotModel = Model<`openai-completions`> & {
+  provider: MoonshotProvider
+}
+
+const MOONSHOT_OPENAI_COMPAT: MoonshotModel[`compat`] = {
+  supportsStore: false,
+  supportsDeveloperRole: false,
+  supportsReasoningEffort: false,
+  maxTokensField: `max_completion_tokens`,
+}
+
+const MOONSHOT_MODELS: Array<MoonshotModel> = [
+  {
+    id: `kimi-k2.6`,
+    name: `Kimi K2.6`,
+    api: `openai-completions`,
+    provider: MOONSHOT_PROVIDER,
+    baseUrl: MOONSHOT_API_BASE_URL,
+    compat: MOONSHOT_OPENAI_COMPAT,
+    reasoning: true,
+    input: [`text`, `image`],
+    cost: { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 },
+    contextWindow: 262_144,
+    maxTokens: 32_768,
+  },
+  {
+    id: `kimi-k2.5`,
+    name: `Kimi K2.5`,
+    api: `openai-completions`,
+    provider: MOONSHOT_PROVIDER,
+    baseUrl: MOONSHOT_API_BASE_URL,
+    compat: MOONSHOT_OPENAI_COMPAT,
+    reasoning: true,
+    input: [`text`, `image`],
+    cost: { input: 0.6, output: 3, cacheRead: 0.08, cacheWrite: 0 },
+    contextWindow: 262_144,
+    maxTokens: 32_768,
+  },
+  {
+    id: `moonshot-v1-8k`,
+    name: `Moonshot V1 8K`,
+    api: `openai-completions`,
+    provider: MOONSHOT_PROVIDER,
+    baseUrl: MOONSHOT_API_BASE_URL,
+    compat: MOONSHOT_OPENAI_COMPAT,
+    reasoning: false,
+    input: [`text`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8_192,
+    maxTokens: 8_192,
+  },
+  {
+    id: `moonshot-v1-32k`,
+    name: `Moonshot V1 32K`,
+    api: `openai-completions`,
+    provider: MOONSHOT_PROVIDER,
+    baseUrl: MOONSHOT_API_BASE_URL,
+    compat: MOONSHOT_OPENAI_COMPAT,
+    reasoning: false,
+    input: [`text`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32_768,
+    maxTokens: 32_768,
+  },
+  {
+    id: `moonshot-v1-128k`,
+    name: `Moonshot V1 128K`,
+    api: `openai-completions`,
+    provider: MOONSHOT_PROVIDER,
+    baseUrl: MOONSHOT_API_BASE_URL,
+    compat: MOONSHOT_OPENAI_COMPAT,
+    reasoning: false,
+    input: [`text`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 131_072,
+    maxTokens: 131_072,
+  },
+  {
+    id: `moonshot-v1-8k-vision-preview`,
+    name: `Moonshot V1 8K Vision Preview`,
+    api: `openai-completions`,
+    provider: MOONSHOT_PROVIDER,
+    baseUrl: MOONSHOT_API_BASE_URL,
+    compat: MOONSHOT_OPENAI_COMPAT,
+    reasoning: false,
+    input: [`text`, `image`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8_192,
+    maxTokens: 8_192,
+  },
+  {
+    id: `moonshot-v1-32k-vision-preview`,
+    name: `Moonshot V1 32K Vision Preview`,
+    api: `openai-completions`,
+    provider: MOONSHOT_PROVIDER,
+    baseUrl: MOONSHOT_API_BASE_URL,
+    compat: MOONSHOT_OPENAI_COMPAT,
+    reasoning: false,
+    input: [`text`, `image`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32_768,
+    maxTokens: 32_768,
+  },
+  {
+    id: `moonshot-v1-128k-vision-preview`,
+    name: `Moonshot V1 128K Vision Preview`,
+    api: `openai-completions`,
+    provider: MOONSHOT_PROVIDER,
+    baseUrl: MOONSHOT_API_BASE_URL,
+    compat: MOONSHOT_OPENAI_COMPAT,
+    reasoning: false,
+    input: [`text`, `image`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 131_072,
+    maxTokens: 131_072,
+  },
+]
+
+const MOONSHOT_MODELS_BY_ID = new Map(
+  MOONSHOT_MODELS.map((model) => [model.id, model])
+)
+
+export function getMoonshotModels(): Array<MoonshotModel> {
+  return MOONSHOT_MODELS.slice()
+}
+
+export function getMoonshotModel(id: string): MoonshotModel | undefined {
+  return MOONSHOT_MODELS_BY_ID.get(id)
+}
+
+export function getMoonshotApiKey(): string | undefined {
+  return process.env[MOONSHOT_API_KEY_ENV]?.trim() || undefined
+}

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -10,6 +10,7 @@
 import { Agent } from '@mariozechner/pi-agent-core'
 import { getModel } from '@mariozechner/pi-ai'
 import { createOutboundBridge } from './outbound-bridge'
+import { MOONSHOT_PROVIDER, getMoonshotModel } from './moonshot-models'
 import { runtimeLog } from './log'
 import type { OutboundIdSeed } from './outbound-bridge'
 import type { ChangeEvent } from '@durable-streams/state'
@@ -22,6 +23,7 @@ import type {
 import type {
   KnownProvider,
   Model,
+  Provider,
   SimpleStreamOptions,
 } from '@mariozechner/pi-ai'
 import type { LLMMessage } from './types'
@@ -33,7 +35,7 @@ import type { LLMMessage } from './types'
 export interface PiAdapterOptions {
   systemPrompt: string
   model: string | Model<any>
-  provider?: KnownProvider
+  provider?: Provider
   tools: Array<AgentTool>
   streamFn?: StreamFn
   getApiKey?: (
@@ -62,14 +64,20 @@ type PiAgentAdapterFactory = (config: PiAgentAdapterConfig) => PiAgentHandle
 
 export function resolvePiModel(opts: {
   model: string | Model<any>
-  provider?: KnownProvider
+  provider?: Provider
 }): Model<any> {
   if (typeof opts.model !== `string`) {
     return opts.model
   }
 
   const provider = opts.provider ?? `anthropic`
-  const model = getModel(provider, opts.model as Parameters<typeof getModel>[1])
+  const model =
+    provider === MOONSHOT_PROVIDER
+      ? getMoonshotModel(opts.model)
+      : getModel(
+          provider as KnownProvider,
+          opts.model as Parameters<typeof getModel>[1]
+        )
 
   if (!model) {
     throw new Error(

--- a/packages/agents-runtime/src/types.ts
+++ b/packages/agents-runtime/src/types.ts
@@ -23,11 +23,7 @@ import type {
   AgentTool as PiAgentTool,
   StreamFn,
 } from '@mariozechner/pi-agent-core'
-import type {
-  KnownProvider,
-  Model,
-  SimpleStreamOptions,
-} from '@mariozechner/pi-ai'
+import type { Model, Provider, SimpleStreamOptions } from '@mariozechner/pi-ai'
 import type {
   EntityStreamDB as RuntimeEntityStreamDB,
   EntityStreamDBWithActions as RuntimeEntityStreamDBWithActions,
@@ -778,7 +774,7 @@ export type AgentModel = string | Model<any>
 export interface AgentConfig {
   systemPrompt: string
   model: AgentModel
-  provider?: KnownProvider
+  provider?: Provider
   tools: Array<AgentTool>
   streamFn?: StreamFn
   getApiKey?: (

--- a/packages/agents-runtime/test/model-runner.test.ts
+++ b/packages/agents-runtime/test/model-runner.test.ts
@@ -16,11 +16,17 @@ const originalEnv = { ...process.env }
 describe(`completeWithLowCostModel`, () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    process.env = { ...originalEnv }
+    delete process.env.MOONSHOT_API_KEY
     completeSimple.mockResolvedValue({
       content: [{ type: `text`, text: `ok` }],
       stopReason: `stop`,
       errorMessage: undefined,
     })
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
   })
 
   test(`passes required system prompt`, async () => {
@@ -41,6 +47,35 @@ describe(`completeWithLowCostModel`, () => {
       `Custom instructions`
     )
   })
+
+  test(`passes MOONSHOT_API_KEY for moonshot low-cost models`, async () => {
+    process.env.MOONSHOT_API_KEY = `moonshot-key`
+
+    await completeWithLowCostModel({
+      catalog: {
+        choices: [{ provider: `moonshot`, id: `kimi-k2.6`, reasoning: false }],
+        defaultChoice: {
+          provider: `moonshot`,
+          id: `kimi-k2.6`,
+          reasoning: false,
+        },
+      },
+      purpose: `URL extraction`,
+      systemPrompt: `Custom instructions`,
+      prompt: `Extract the title`,
+      maxTokens: 128,
+    })
+
+    expect(completeSimple).toHaveBeenCalledOnce()
+    expect(completeSimple.mock.calls[0][0]).toMatchObject({
+      provider: `moonshot`,
+      id: `kimi-k2.6`,
+      baseUrl: `https://api.moonshot.ai/v1`,
+    })
+    expect(completeSimple.mock.calls[0][2]).toMatchObject({
+      apiKey: `moonshot-key`,
+    })
+  })
 })
 
 describe(`detectAvailableProviders`, () => {
@@ -49,6 +84,7 @@ describe(`detectAvailableProviders`, () => {
     delete process.env.ANTHROPIC_API_KEY
     delete process.env.OPENAI_API_KEY
     delete process.env.DEEPSEEK_API_KEY
+    delete process.env.MOONSHOT_API_KEY
     process.env.CODEX_AUTH_PATH = `/nonexistent/auth.json`
   })
 
@@ -65,12 +101,23 @@ describe(`detectAvailableProviders`, () => {
     expect(detectAvailableProviders()).not.toContain(`deepseek`)
   })
 
+  test(`detects moonshot when MOONSHOT_API_KEY is set`, () => {
+    process.env.MOONSHOT_API_KEY = `test-key`
+    expect(detectAvailableProviders()).toContain(`moonshot`)
+  })
+
+  test(`does not include moonshot when MOONSHOT_API_KEY is absent`, () => {
+    expect(detectAvailableProviders()).not.toContain(`moonshot`)
+  })
+
   test(`detects multiple providers simultaneously`, () => {
     process.env.ANTHROPIC_API_KEY = `ant-key`
     process.env.DEEPSEEK_API_KEY = `ds-key`
+    process.env.MOONSHOT_API_KEY = `moonshot-key`
     const providers = detectAvailableProviders()
     expect(providers).toContain(`anthropic`)
     expect(providers).toContain(`deepseek`)
+    expect(providers).toContain(`moonshot`)
   })
 })
 
@@ -93,5 +140,27 @@ describe(`selectLowCostModelChoice with deepseek`, () => {
     })
     expect(choice.provider).toBe(`deepseek`)
     expect(choice.id).toBe(`deepseek-v4-flash`)
+  })
+})
+
+describe(`selectLowCostModelChoice with moonshot`, () => {
+  test(`selects kimi-k2.6 as preferred moonshot low-cost model`, () => {
+    const catalog = {
+      choices: [
+        { provider: `moonshot`, id: `kimi-k2.5`, reasoning: true },
+        { provider: `moonshot`, id: `kimi-k2.6`, reasoning: true },
+      ],
+      defaultChoice: {
+        provider: `moonshot`,
+        id: `kimi-k2.5`,
+        reasoning: true,
+      },
+    }
+    const choice = selectLowCostModelChoice(catalog, {
+      provider: `moonshot`,
+      model: `kimi-k2.5`,
+    })
+    expect(choice.provider).toBe(`moonshot`)
+    expect(choice.id).toBe(`kimi-k2.6`)
   })
 })

--- a/packages/agents-runtime/test/pi-adapter.test.ts
+++ b/packages/agents-runtime/test/pi-adapter.test.ts
@@ -301,6 +301,18 @@ describe(`resolvePiModel`, () => {
     expect(model.id).toBe(`gpt-4o-mini`)
   })
 
+  it(`resolves Moonshot string model ids to OpenAI-compatible models`, () => {
+    const model = resolvePiModel({
+      provider: `moonshot`,
+      model: `kimi-k2.6`,
+    })
+
+    expect(model.provider).toBe(`moonshot`)
+    expect(model.id).toBe(`kimi-k2.6`)
+    expect(model.api).toBe(`openai-completions`)
+    expect(model.baseUrl).toBe(`https://api.moonshot.ai/v1`)
+  })
+
   it(`accepts custom Model objects directly`, () => {
     const customModel: Model<`openai-completions`> = {
       id: `deepseek-v4-flash`,

--- a/packages/agents-server-ui/src/components/ApiKeysForm.tsx
+++ b/packages/agents-server-ui/src/components/ApiKeysForm.tsx
@@ -12,6 +12,7 @@ export type ApiKeysFormValues = {
   anthropic: string
   openai: string
   deepseek: string
+  moonshot: string
   brave: string
 }
 
@@ -81,6 +82,7 @@ export function ApiKeysForm({
   const [anthropic, setAnthropic] = useState(initial.anthropic)
   const [openai, setOpenai] = useState(initial.openai)
   const [deepseek, setDeepseek] = useState(initial.deepseek)
+  const [moonshot, setMoonshot] = useState(initial.moonshot)
   const [brave, setBrave] = useState(initial.brave)
   const [visibleKeys, setVisibleKeys] = useState<
     Record<ApiKeyFieldId, boolean>
@@ -88,6 +90,7 @@ export function ApiKeysForm({
     anthropic: false,
     openai: false,
     deepseek: false,
+    moonshot: false,
     brave: false,
   })
   const [saving, setSaving] = useState(false)
@@ -103,6 +106,7 @@ export function ApiKeysForm({
     anthropic: false,
     openai: false,
     deepseek: false,
+    moonshot: false,
     brave: false,
   })
 
@@ -110,19 +114,20 @@ export function ApiKeysForm({
     (showModelKeys &&
       (anthropic.trim().length > 0 ||
         openai.trim().length > 0 ||
-        deepseek.trim().length > 0)) ||
+        deepseek.trim().length > 0 ||
+        moonshot.trim().length > 0)) ||
     (showBrave && brave.trim().length > 0)
 
   const handleSave = useCallback(async (): Promise<void> => {
     if (!canSave || saving) return
     setSaving(true)
     try {
-      await onSave({ anthropic, openai, deepseek, brave })
-      persistedRef.current = { anthropic, openai, deepseek, brave }
+      await onSave({ anthropic, openai, deepseek, moonshot, brave })
+      persistedRef.current = { anthropic, openai, deepseek, moonshot, brave }
     } finally {
       setSaving(false)
     }
-  }, [anthropic, openai, deepseek, brave, canSave, saving, onSave])
+  }, [anthropic, openai, deepseek, moonshot, brave, canSave, saving, onSave])
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -154,9 +159,15 @@ export function ApiKeysForm({
   const handleAutoSaveBlur = useCallback(
     (field: ApiKeyFieldId) => {
       if (!autoSave) return
-      void persistIfDirty(field, { anthropic, openai, deepseek, brave })
+      void persistIfDirty(field, {
+        anthropic,
+        openai,
+        deepseek,
+        moonshot,
+        brave,
+      })
     },
-    [autoSave, anthropic, openai, deepseek, brave, persistIfDirty]
+    [autoSave, anthropic, openai, deepseek, moonshot, brave, persistIfDirty]
   )
 
   const wrapOnChange = useCallback(
@@ -243,6 +254,22 @@ export function ApiKeysForm({
                   visible={visibleKeys.deepseek}
                   onChange={wrapOnChange(`deepseek`, setDeepseek)}
                   onBlur={() => handleAutoSaveBlur(`deepseek`)}
+                  onToggleVisible={toggleVisible}
+                />
+              }
+            />
+            <SettingsRow
+              label="Kimi / Moonshot API"
+              description="Used for Kimi and Moonshot models. Looks like sk-…"
+              splitLayout
+              control={
+                <ApiKeyInput
+                  field="moonshot"
+                  placeholder="sk-…"
+                  value={moonshot}
+                  visible={visibleKeys.moonshot}
+                  onChange={wrapOnChange(`moonshot`, setMoonshot)}
+                  onBlur={() => handleAutoSaveBlur(`moonshot`)}
                   onToggleVisible={toggleVisible}
                 />
               }
@@ -347,6 +374,19 @@ export function ApiKeysForm({
                 value={deepseek}
                 visible={visibleKeys.deepseek}
                 onChange={setDeepseek}
+                onToggleVisible={toggleVisible}
+              />
+            </Field>
+            <Field
+              label="Kimi / Moonshot API (optional)"
+              description="Used for Kimi and Moonshot models. Looks like sk-…"
+            >
+              <ApiKeyInput
+                field="moonshot"
+                placeholder="sk-…"
+                value={moonshot}
+                visible={visibleKeys.moonshot}
+                onChange={setMoonshot}
                 onToggleVisible={toggleVisible}
               />
             </Field>

--- a/packages/agents-server-ui/src/components/OnboardingModal.tsx
+++ b/packages/agents-server-ui/src/components/OnboardingModal.tsx
@@ -59,6 +59,7 @@ const MODEL_PROVIDER_IDS: ReadonlyArray<ProviderId> = [
   `anthropic`,
   `openai`,
   `deepseek`,
+  `moonshot`,
 ]
 
 const MODEL_PROVIDERS: ReadonlyArray<{
@@ -86,6 +87,13 @@ const MODEL_PROVIDERS: ReadonlyArray<{
     id: `deepseek`,
     name: `DeepSeek API`,
     description: `DeepSeek's hosted reasoning models.`,
+    placeholder: `sk-…`,
+    kind: `model`,
+  },
+  {
+    id: `moonshot`,
+    name: `Kimi / Moonshot API`,
+    description: `Kimi models from Moonshot's OpenAI-compatible API.`,
     placeholder: `sk-…`,
     kind: `model`,
   },
@@ -637,6 +645,7 @@ function ProviderItem({
         anthropic: keysStatus.saved.anthropic ?? null,
         openai: keysStatus.saved.openai ?? null,
         deepseek: keysStatus.saved.deepseek ?? null,
+        moonshot: keysStatus.saved.moonshot ?? null,
         brave: keysStatus.saved.brave ?? null,
         [provider.id]: next,
       }

--- a/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
@@ -149,6 +149,8 @@ export function CredentialsPage(): React.ReactElement {
                 openai: status.saved.openai ?? status.suggested.openai ?? ``,
                 deepseek:
                   status.saved.deepseek ?? status.suggested.deepseek ?? ``,
+                moonshot:
+                  status.saved.moonshot ?? status.suggested.moonshot ?? ``,
                 brave: status.saved.brave ?? ``,
               }}
               showBrave={false}
@@ -157,14 +159,16 @@ export function CredentialsPage(): React.ReactElement {
                 Boolean(
                   status.suggested.anthropic ||
                     status.suggested.openai ||
-                    status.suggested.deepseek
+                    status.suggested.deepseek ||
+                    status.suggested.moonshot
                 )
               }
-              onSave={async ({ anthropic, openai, deepseek }) => {
+              onSave={async ({ anthropic, openai, deepseek, moonshot }) => {
                 await persistApiKeys({
                   anthropic: anthropic.trim() || null,
                   openai: openai.trim() || null,
                   deepseek: deepseek.trim() || null,
+                  moonshot: moonshot.trim() || null,
                   brave: status.saved.brave ?? null,
                 })
                 await refreshStatus()
@@ -185,6 +189,7 @@ export function CredentialsPage(): React.ReactElement {
               anthropic: status.saved.anthropic ?? ``,
               openai: status.saved.openai ?? ``,
               deepseek: status.saved.deepseek ?? ``,
+              moonshot: status.saved.moonshot ?? ``,
               brave: status.saved.brave ?? status.suggested.brave ?? ``,
             }}
             showModelKeys={false}
@@ -196,6 +201,7 @@ export function CredentialsPage(): React.ReactElement {
                 anthropic: status.saved.anthropic ?? null,
                 openai: status.saved.openai ?? null,
                 deepseek: status.saved.deepseek ?? null,
+                moonshot: status.saved.moonshot ?? null,
                 brave: brave.trim() || null,
               })
               await refreshStatus()

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -85,9 +85,9 @@ export interface ServerConnectionState {
  * `null` means "not set". The renderer never reads these from
  * `process.env` directly — that only exists in main.
  *
- * - `anthropic` / `openai` / `deepseek`: LLM provider keys. At least
- *   one is required for the local Horton runtime to be useful; the
- *   first-launch dialog auto-opens until one is set.
+ * - `anthropic` / `openai` / `deepseek` / `moonshot`: LLM provider
+ *   keys. At least one is required for the local Horton runtime to be
+ *   useful; the first-launch dialog auto-opens until one is set.
  * - `brave`: optional search-tool auxiliary. Mirrored to
  *   `BRAVE_SEARCH_API_KEY` to enable Horton's `brave_search` tool;
  *   without it, web search falls back to Anthropic's built-in search.
@@ -105,6 +105,12 @@ export interface ApiKeys {
    * counts toward that check.
    */
   deepseek: string | null
+  /**
+   * Optional. Mirrored to `MOONSHOT_API_KEY` so the runtime can use
+   * Kimi / Moonshot models. Treated as a peer LLM provider alongside
+   * `anthropic`, `openai`, and `deepseek`.
+   */
+  moonshot: string | null
   brave: string | null
 }
 
@@ -135,8 +141,9 @@ export interface ApiKeysStatus {
   /**
    * Per-slot ENV-derived suggestions: a value is provided only for
    * slots that are NOT already saved, so the dialog can pre-fill
-   * empty inputs from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` without
-   * overwriting the user's saved choice.
+   * empty inputs from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` /
+   * `DEEPSEEK_API_KEY` / `MOONSHOT_API_KEY` without overwriting the
+   * user's saved choice.
    */
   suggested: ApiKeys
   codex: CodexStatus

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -106,7 +106,7 @@ export async function createBuiltinAgentHandler(
 
   if (!modelCatalog) {
     serverLog.warn(
-      `[builtin-agents] no supported model provider API key found — set ANTHROPIC_API_KEY or OPENAI_API_KEY`
+      `[builtin-agents] no supported model provider API key found — set ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, or MOONSHOT_API_KEY`
     )
     return null
   }

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -1,6 +1,10 @@
 import { getModels } from '@mariozechner/pi-ai'
 import {
+  MOONSHOT_API_BASE_URL,
+  MOONSHOT_PROVIDER,
   detectAvailableProviders,
+  getMoonshotApiKey,
+  getMoonshotModels,
   readCodexAccessToken,
 } from '@electric-ax/agents-runtime'
 import type {
@@ -49,6 +53,7 @@ const DEFAULT_ANTHROPIC_MODEL = `claude-sonnet-4-6`
 const DEFAULT_OPENAI_MODEL = `gpt-4.1`
 const DEFAULT_CODEX_MODEL = `gpt-5.4`
 const DEFAULT_DEEPSEEK_MODEL = `deepseek-v4-flash`
+const DEFAULT_MOONSHOT_MODEL = `kimi-k2.6`
 
 function modelValue(provider: BuiltinModelProvider, id: string): string {
   return `${provider}:${id}`
@@ -58,6 +63,7 @@ function providerLabel(provider: BuiltinModelProvider): string {
   if (provider === `anthropic`) return `Anthropic`
   if (provider === `openai-codex`) return `OpenAI Codex`
   if (provider === `deepseek`) return `DeepSeek`
+  if (provider === MOONSHOT_PROVIDER) return `Kimi`
   return `OpenAI`
 }
 
@@ -96,12 +102,19 @@ async function fetchAvailableModelIds(
               },
               signal: AbortSignal.timeout(3_000),
             })
-          : await fetch(`https://api.openai.com/v1/models`, {
-              headers: {
-                authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ``}`,
-              },
-              signal: AbortSignal.timeout(3_000),
-            })
+          : provider === MOONSHOT_PROVIDER
+            ? await fetch(`${MOONSHOT_API_BASE_URL}/models`, {
+                headers: {
+                  authorization: `Bearer ${getMoonshotApiKey() ?? ``}`,
+                },
+                signal: AbortSignal.timeout(3_000),
+              })
+            : await fetch(`https://api.openai.com/v1/models`, {
+                headers: {
+                  authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ``}`,
+                },
+                signal: AbortSignal.timeout(3_000),
+              })
 
     if (res.status === 401 || res.status === 403) return new Set()
     if (!res.ok) return null
@@ -122,7 +135,12 @@ async function fetchAvailableModelIds(
 async function choicesForProvider(
   provider: BuiltinModelProvider
 ): Promise<Array<BuiltinModelChoice>> {
-  const knownModels = getModels(provider)
+  const knownModels =
+    provider === MOONSHOT_PROVIDER
+      ? getMoonshotModels()
+      : getModels(
+          provider as Exclude<BuiltinModelProvider, typeof MOONSHOT_PROVIDER>
+        )
 
   if (provider === `openai-codex`) {
     return knownModels.map((model) => ({
@@ -232,6 +250,11 @@ export async function createBuiltinModelCatalog(
       (choice) =>
         choice.provider === `deepseek` && choice.id === DEFAULT_DEEPSEEK_MODEL
     ) ??
+    choices.find(
+      (choice) =>
+        choice.provider === MOONSHOT_PROVIDER &&
+        choice.id === DEFAULT_MOONSHOT_MODEL
+    ) ??
     choices[0]!
 
   return { choices, defaultChoice }
@@ -260,6 +283,9 @@ export function resolveBuiltinModelConfig(
     ...(reasoningEffort && { reasoningEffort }),
     ...(choice.provider === `openai-codex` && {
       getApiKey: () => readCodexAccessToken(),
+    }),
+    ...(choice.provider === MOONSHOT_PROVIDER && {
+      getApiKey: () => getMoonshotApiKey(),
     }),
   }
 

--- a/packages/agents/src/server.ts
+++ b/packages/agents/src/server.ts
@@ -277,7 +277,7 @@ export class BuiltinAgentsServer {
       })
       if (!this.bootstrap) {
         throw new Error(
-          `ANTHROPIC_API_KEY or OPENAI_API_KEY must be set before starting builtin agents`
+          `ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, or MOONSHOT_API_KEY must be set before starting builtin agents`
         )
       }
 

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -19,6 +19,8 @@ describe(`model catalog`, () => {
     )
     process.env = { ...originalEnv }
     delete process.env.ANTHROPIC_API_KEY
+    delete process.env.DEEPSEEK_API_KEY
+    delete process.env.MOONSHOT_API_KEY
     process.env.OPENAI_API_KEY = `test-openai-key`
     process.env.CODEX_AUTH_PATH = `/nonexistent/auth.json`
   })
@@ -167,5 +169,64 @@ describe(`model catalog`, () => {
       provider: `deepseek`,
       model: `deepseek-v4-flash`,
     })
+  })
+
+  it(`lists Kimi / Moonshot models when MOONSHOT_API_KEY is set`, async () => {
+    delete process.env.OPENAI_API_KEY
+    process.env.MOONSHOT_API_KEY = `test-moonshot-key`
+    vi.stubGlobal(
+      `fetch`,
+      vi.fn(async (url: string) => {
+        if (String(url).includes(`api.moonshot.ai`)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: [{ id: `kimi-k2.6` }, { id: `moonshot-v1-8k` }],
+            }),
+          }
+        }
+        return { ok: false, status: 401, json: async () => ({}) }
+      })
+    )
+
+    const catalog = await createBuiltinModelCatalog()
+
+    expect(catalog).not.toBeNull()
+    expect(catalog!.choices.map((c) => c.provider)).toContain(`moonshot`)
+    expect(catalog!.choices.map((c) => c.value)).toContain(`moonshot:kimi-k2.6`)
+    expect(catalog!.choices.map((c) => c.value)).toContain(
+      `moonshot:moonshot-v1-8k`
+    )
+  })
+
+  it(`resolves Kimi / Moonshot model config with a runtime API key hook`, async () => {
+    delete process.env.OPENAI_API_KEY
+    process.env.MOONSHOT_API_KEY = `test-moonshot-key`
+    vi.stubGlobal(
+      `fetch`,
+      vi.fn(async (url: string) => {
+        if (String(url).includes(`api.moonshot.ai`)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ data: [{ id: `kimi-k2.6` }] }),
+          }
+        }
+        return { ok: false, status: 401, json: async () => ({}) }
+      })
+    )
+
+    const catalog = await createBuiltinModelCatalog()
+    const config = resolveBuiltinModelConfig(catalog!, {
+      model: `moonshot:kimi-k2.6`,
+    })
+
+    expect(config).toMatchObject({
+      provider: `moonshot`,
+      model: `kimi-k2.6`,
+    })
+    expect(config.getApiKey).toBeTypeOf(`function`)
+    expect(await config.getApiKey?.(`moonshot`)).toBe(`test-moonshot-key`)
   })
 })

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -70,9 +70,9 @@ cmd_build() {
 preflight() {
   cd "$REPO_ROOT"
 
-  [[ -f .env ]] || die ".env not found at repo root. Create one with ANTHROPIC_API_KEY or OPENAI_API_KEY."
-  grep -qE '^(ANTHROPIC_API_KEY|OPENAI_API_KEY)=' .env \
-    || die ".env is missing ANTHROPIC_API_KEY or OPENAI_API_KEY."
+  [[ -f .env ]] || die ".env not found at repo root. Create one with ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, or MOONSHOT_API_KEY."
+  grep -qE '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|DEEPSEEK_API_KEY|MOONSHOT_API_KEY)=' .env \
+    || die ".env is missing ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, or MOONSHOT_API_KEY."
 
   for pkg in typescript-client agents-runtime agents-mcp agents-server agents; do
     [[ -d "packages/$pkg/dist" ]] || die "packages/$pkg/dist is missing. Run: $0 build"


### PR DESCRIPTION
## Motivation

The desktop UI can configure Anthropic, OpenAI, Codex, and DeepSeek credentials for local Horton runtimes, but it could not configure Kimi / Moonshot API keys or select Moonshot-hosted models. Users who want to run Horton against Moonshot's OpenAI-compatible API needed a first-class provider path from desktop credentials through model selection and runtime execution.

## What changed

- Added a Moonshot provider definition in agents-runtime with the official Moonshot API base URL, MOONSHOT_API_KEY lookup, and supported Kimi / Moonshot model metadata.
- Taught provider detection, low-cost model selection, and the pi-ai adapter to resolve Moonshot models and pass the runtime API key explicitly.
- Added Moonshot to the built-in Horton model catalog, including model availability probing via the Moonshot /models endpoint and model config API-key handoff.
- Threaded a new moonshot credential slot through the Electron desktop main process, saved API key normalization, environment mirroring, onboarding, and Credentials settings UI.
- Updated local runtime startup messaging and dev preflight checks so MOONSHOT_API_KEY counts as a valid model provider key.
- Added a changeset covering the touched agents packages.

## Decisions

Moonshot is represented as a local provider id, moonshot, rather than using pi-ai's kimi-coding provider because the user-facing API here is Moonshot's OpenAI-compatible endpoint at https://api.moonshot.ai/v1 with MOONSHOT_API_KEY credentials. The runtime keeps model selection string-based so worker spawn arguments remain serializable, while the adapter maps Moonshot model ids to custom OpenAI-compatible model objects at execution time.
