### PR TITLE
fix(agents-server-ui): surface signal failure toasts

### DIFF
--- a/.changeset/signal-failure-toasts.md
+++ b/.changeset/signal-failure-toasts.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-server-ui": patch
+---
+
+Surface failed signal and kill requests in the UI with toast notifications instead of silently swallowing persistence failures.

--- a/packages/agents-server-ui/AGENTS.md
+++ b/packages/agents-server-ui/AGENTS.md
@@ -1,0 +1,6 @@
+# Agents Server UI
+
+When adding or changing UI components in this package, default to Base UI
+(`@base-ui/react`) primitives whenever a suitable component exists. Wrap or
+style those primitives to match the local design system instead of introducing a
+new custom interaction model.

--- a/packages/agents-server-ui/src/components/ToastViewport.module.css
+++ b/packages/agents-server-ui/src/components/ToastViewport.module.css
@@ -1,0 +1,79 @@
+.viewport {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: var(--ds-z-toast);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(420px, calc(100vw - 32px));
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) 24px;
+  gap: 10px;
+  align-items: start;
+  padding: 12px;
+  border: 1px solid var(--ds-border-2);
+  border-left-width: 3px;
+  border-radius: 8px;
+  background: var(--ds-surface-raised);
+  box-shadow: var(--ds-shadow-3);
+}
+
+.toast[data-tone='danger'] {
+  border-left-color: var(--ds-red-9);
+}
+
+.toast[data-tone='warning'] {
+  border-left-color: var(--ds-amber-9);
+}
+
+.toast[data-tone='success'] {
+  border-left-color: var(--ds-green-9);
+}
+
+.toast[data-tone='info'] {
+  border-left-color: var(--ds-blue-9);
+}
+
+.icon {
+  margin-top: 2px;
+  color: var(--ds-text-2);
+}
+
+.toast[data-tone='danger'] .icon {
+  color: var(--ds-red-11);
+}
+
+.toast[data-tone='warning'] .icon {
+  color: var(--ds-amber-11);
+}
+
+.toast[data-tone='success'] .icon {
+  color: var(--ds-green-11);
+}
+
+.toast[data-tone='info'] .icon {
+  color: var(--ds-blue-11);
+}
+
+.content {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.description {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.close {
+  margin-top: -4px;
+  margin-right: -4px;
+}

--- a/packages/agents-server-ui/src/components/ToastViewport.module.css
+++ b/packages/agents-server-ui/src/components/ToastViewport.module.css
@@ -3,25 +3,119 @@
   right: 16px;
   bottom: 16px;
   z-index: var(--ds-z-toast);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
   width: min(420px, calc(100vw - 32px));
   pointer-events: none;
 }
 
 .toast {
+  --gap: 8px;
+  --peek: 8px;
+  --scale: calc(max(0, 1 - (var(--toast-index) * 0.08)));
+  --shrink: calc(1 - var(--scale));
+  --height: var(--toast-frontmost-height, var(--toast-height));
+  --offset-y: calc(
+    var(--toast-offset-y) * -1 + (var(--toast-index) * var(--gap) * -1) +
+      var(--toast-swipe-movement-y)
+  );
+
   pointer-events: auto;
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) 24px;
-  gap: 10px;
-  align-items: start;
-  padding: 12px;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: auto;
+  z-index: calc(1000 - var(--toast-index));
+  box-sizing: border-box;
+  width: 100%;
+  height: var(--height);
   border: 1px solid var(--ds-border-2);
   border-left-width: 3px;
   border-radius: 8px;
   background: var(--ds-surface-raised);
   box-shadow: var(--ds-shadow-3);
+  cursor: default;
+  user-select: none;
+  transform: translateX(var(--toast-swipe-movement-x))
+    translateY(
+      calc(
+        var(--toast-swipe-movement-y) - (var(--toast-index) * var(--peek)) -
+          (var(--shrink) * var(--height))
+      )
+    )
+    scale(var(--scale));
+  transform-origin: bottom center;
+  transition:
+    transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.5s,
+    height 0.15s;
+}
+
+.toast[data-expanded] {
+  height: var(--toast-height);
+  transform: translateX(var(--toast-swipe-movement-x))
+    translateY(var(--offset-y));
+}
+
+.toast[data-starting-style],
+.toast[data-ending-style]:not([data-limited]):not([data-swipe-direction]) {
+  transform: translateY(150%);
+}
+
+.toast[data-ending-style] {
+  opacity: 0;
+}
+
+.toast[data-limited] {
+  opacity: 0;
+}
+
+.toast[data-ending-style][data-swipe-direction='up'] {
+  transform: translateY(calc(var(--toast-swipe-movement-y) - 150%));
+}
+
+.toast[data-ending-style][data-swipe-direction='down'] {
+  transform: translateY(calc(var(--toast-swipe-movement-y) + 150%));
+}
+
+.toast[data-ending-style][data-swipe-direction='left'] {
+  transform: translateX(calc(var(--toast-swipe-movement-x) - 150%))
+    translateY(var(--offset-y));
+}
+
+.toast[data-ending-style][data-swipe-direction='right'] {
+  transform: translateX(calc(var(--toast-swipe-movement-x) + 150%))
+    translateY(var(--offset-y));
+}
+
+.toast[data-expanded][data-ending-style][data-swipe-direction='left'] {
+  transform: translateX(calc(var(--toast-swipe-movement-x) - 150%))
+    translateY(var(--offset-y));
+}
+
+.toast[data-expanded][data-ending-style][data-swipe-direction='right'] {
+  transform: translateX(calc(var(--toast-swipe-movement-x) + 150%))
+    translateY(var(--offset-y));
+}
+
+.toast[data-expanded][data-ending-style][data-swipe-direction='down'] {
+  transform: translateY(calc(var(--toast-swipe-movement-y) + 150%));
+}
+
+.toast[data-expanded][data-ending-style][data-swipe-direction='up'] {
+  transform: translateY(calc(var(--toast-swipe-movement-y) - 150%));
+}
+
+.toast::after {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  height: calc(var(--gap) + 1px);
+  content: '';
+}
+
+.toast:focus-visible {
+  outline: 2px solid var(--ds-focus-ring);
+  outline-offset: 2px;
 }
 
 .toast[data-tone='danger'] {
@@ -62,13 +156,45 @@
 }
 
 .content {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) 24px;
+  gap: 10px;
+  align-items: start;
+  height: 100%;
+  padding: 12px;
+  overflow: hidden;
+  transition: opacity 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.content[data-behind] {
+  opacity: 0;
+}
+
+.content[data-expanded] {
+  opacity: 1;
+}
+
+.text {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
+.title {
+  margin: 0;
+  color: var(--ds-text-1);
+  font-size: var(--ds-text-sm);
+  font-weight: 500;
+  line-height: var(--ds-text-sm-lh);
+}
+
 .description {
+  margin: 0;
+  color: var(--ds-text-2);
+  font-size: var(--ds-text-xs);
+  line-height: var(--ds-text-xs-lh);
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
@@ -76,4 +202,29 @@
 .close {
   margin-top: -4px;
   margin-right: -4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  color: var(--ds-text-2);
+  background: transparent;
+  cursor: pointer;
+}
+
+.close:hover {
+  color: var(--ds-text-1);
+  background: var(--ds-bg-hover);
+}
+
+.close:active {
+  background: var(--ds-gray-a4);
+}
+
+.close:focus-visible {
+  outline: 2px solid var(--ds-focus-ring);
+  outline-offset: 2px;
 }

--- a/packages/agents-server-ui/src/components/ToastViewport.tsx
+++ b/packages/agents-server-ui/src/components/ToastViewport.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+import { AlertCircle, CheckCircle2, Info, TriangleAlert, X } from 'lucide-react'
+import { subscribeToasts, type ToastMessage } from '../lib/toast'
+import { Icon, IconButton, Text } from '../ui'
+import styles from './ToastViewport.module.css'
+
+function ToastIcon({
+  tone,
+}: {
+  tone: ToastMessage[`tone`]
+}): React.ReactElement {
+  const icon =
+    tone === `danger`
+      ? AlertCircle
+      : tone === `warning`
+        ? TriangleAlert
+        : tone === `success`
+          ? CheckCircle2
+          : Info
+  return <Icon icon={icon} size={2} className={styles.icon} />
+}
+
+export function ToastViewport(): React.ReactElement | null {
+  const [toasts, setToasts] = useState<Array<ToastMessage>>([])
+
+  useEffect(
+    () =>
+      subscribeToasts((toast) => {
+        setToasts((current) => [...current, toast].slice(-4))
+      }),
+    []
+  )
+
+  useEffect(() => {
+    if (toasts.length === 0) return
+    const timers = toasts
+      .filter((toast) => toast.timeoutMs > 0)
+      .map((toast) =>
+        window.setTimeout(() => {
+          setToasts((current) =>
+            current.filter((candidate) => candidate.id !== toast.id)
+          )
+        }, toast.timeoutMs)
+      )
+    return () => {
+      for (const timer of timers) window.clearTimeout(timer)
+    }
+  }, [toasts])
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div className={styles.viewport} role="region" aria-label="Notifications">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          role={toast.tone === `danger` ? `alert` : `status`}
+          className={styles.toast}
+          data-tone={toast.tone}
+        >
+          <ToastIcon tone={toast.tone} />
+          <div className={styles.content}>
+            <Text size={2} weight="medium">
+              {toast.title}
+            </Text>
+            {toast.description && (
+              <Text
+                size={1}
+                tone="muted"
+                className={styles.description}
+                as="div"
+              >
+                {toast.description}
+              </Text>
+            )}
+          </div>
+          <IconButton
+            type="button"
+            variant="ghost"
+            tone="neutral"
+            size={1}
+            aria-label="Dismiss notification"
+            title="Dismiss notification"
+            className={styles.close}
+            onClick={() => {
+              setToasts((current) =>
+                current.filter((candidate) => candidate.id !== toast.id)
+              )
+            }}
+          >
+            <Icon icon={X} size={2} />
+          </IconButton>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/agents-server-ui/src/components/ToastViewport.tsx
+++ b/packages/agents-server-ui/src/components/ToastViewport.tsx
@@ -1,14 +1,29 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
+import { Toast as BaseToast } from '@base-ui/react/toast'
 import { AlertCircle, CheckCircle2, Info, TriangleAlert, X } from 'lucide-react'
-import { subscribeToasts, type ToastMessage } from '../lib/toast'
-import { Icon, IconButton, Text } from '../ui'
+import type { ReactNode } from 'react'
+import { subscribeToasts, type ToastTone } from '../lib/toast'
+import { Icon } from '../ui'
 import styles from './ToastViewport.module.css'
 
-function ToastIcon({
-  tone,
-}: {
-  tone: ToastMessage[`tone`]
-}): React.ReactElement {
+type ToastData = {
+  tone: ToastTone
+}
+
+const TOAST_TONES: ReadonlySet<string> = new Set([
+  `danger`,
+  `info`,
+  `success`,
+  `warning`,
+])
+
+function toastTone(toast: BaseToast.Root.ToastObject<ToastData>): ToastTone {
+  if (toast.data?.tone) return toast.data.tone
+  if (toast.type && TOAST_TONES.has(toast.type)) return toast.type as ToastTone
+  return `info`
+}
+
+function ToastIcon({ tone }: { tone: ToastTone }): React.ReactElement {
   const icon =
     tone === `danger`
       ? AlertCircle
@@ -20,78 +35,97 @@ function ToastIcon({
   return <Icon icon={icon} size={2} className={styles.icon} />
 }
 
-export function ToastViewport(): React.ReactElement | null {
-  const [toasts, setToasts] = useState<Array<ToastMessage>>([])
+function ToastEventBridge(): null {
+  const toastManager = BaseToast.useToastManager()
 
   useEffect(
     () =>
       subscribeToasts((toast) => {
-        setToasts((current) => [...current, toast].slice(-4))
+        toastManager.add<ToastData>({
+          id: toast.id,
+          title: toast.title,
+          description: toast.description,
+          timeout: toast.timeoutMs,
+          type: toast.tone,
+          priority: toast.tone === `danger` ? `high` : `low`,
+          data: {
+            tone: toast.tone,
+          },
+        })
       }),
-    []
+    [toastManager]
   )
 
-  useEffect(() => {
-    if (toasts.length === 0) return
-    const timers = toasts
-      .filter((toast) => toast.timeoutMs > 0)
-      .map((toast) =>
-        window.setTimeout(() => {
-          setToasts((current) =>
-            current.filter((candidate) => candidate.id !== toast.id)
-          )
-        }, toast.timeoutMs)
-      )
-    return () => {
-      for (const timer of timers) window.clearTimeout(timer)
-    }
-  }, [toasts])
+  return null
+}
 
-  if (toasts.length === 0) return null
+function ToastList(): React.ReactElement {
+  const { toasts } = BaseToast.useToastManager()
 
   return (
-    <div className={styles.viewport} role="region" aria-label="Notifications">
+    <>
       {toasts.map((toast) => (
-        <div
+        <ToastItem
           key={toast.id}
-          role={toast.tone === `danger` ? `alert` : `status`}
-          className={styles.toast}
-          data-tone={toast.tone}
-        >
-          <ToastIcon tone={toast.tone} />
-          <div className={styles.content}>
-            <Text size={2} weight="medium">
-              {toast.title}
-            </Text>
-            {toast.description && (
-              <Text
-                size={1}
-                tone="muted"
-                className={styles.description}
-                as="div"
-              >
-                {toast.description}
-              </Text>
-            )}
-          </div>
-          <IconButton
-            type="button"
-            variant="ghost"
-            tone="neutral"
-            size={1}
-            aria-label="Dismiss notification"
-            title="Dismiss notification"
-            className={styles.close}
-            onClick={() => {
-              setToasts((current) =>
-                current.filter((candidate) => candidate.id !== toast.id)
-              )
-            }}
-          >
-            <Icon icon={X} size={2} />
-          </IconButton>
-        </div>
+          toast={toast as BaseToast.Root.ToastObject<ToastData>}
+        />
       ))}
-    </div>
+    </>
+  )
+}
+
+function ToastItem({
+  toast,
+}: {
+  toast: BaseToast.Root.ToastObject<ToastData>
+}): React.ReactElement {
+  const tone = toastTone(toast)
+
+  return (
+    <BaseToast.Root
+      toast={toast}
+      swipeDirection="right"
+      className={styles.toast}
+      data-tone={tone}
+    >
+      <BaseToast.Content className={styles.content}>
+        <ToastIcon tone={tone} />
+        <div className={styles.text}>
+          <BaseToast.Title className={styles.title} />
+          {toast.description && (
+            <BaseToast.Description className={styles.description} />
+          )}
+        </div>
+        <BaseToast.Close
+          type="button"
+          aria-label="Dismiss notification"
+          title="Dismiss notification"
+          className={styles.close}
+        >
+          <Icon icon={X} size={2} />
+        </BaseToast.Close>
+      </BaseToast.Content>
+    </BaseToast.Root>
+  )
+}
+
+export function ToastProvider({
+  children,
+}: {
+  children: ReactNode
+}): React.ReactElement {
+  return (
+    <BaseToast.Provider limit={4} timeout={7000}>
+      {children}
+      <ToastEventBridge />
+      <BaseToast.Portal>
+        <BaseToast.Viewport
+          className={styles.viewport}
+          aria-label="Notifications"
+        >
+          <ToastList />
+        </BaseToast.Viewport>
+      </BaseToast.Portal>
+    </BaseToast.Provider>
   )
 }

--- a/packages/agents-server-ui/src/lib/ElectricAgentsProvider.tsx
+++ b/packages/agents-server-ui/src/lib/ElectricAgentsProvider.tsx
@@ -6,6 +6,7 @@ import { appendPathToUrl } from '@electric-ax/agents-runtime/client'
 import type { ReactNode } from 'react'
 import { serverFetch } from './auth-fetch'
 import { entityApiUrl, entitySpawnApiUrl } from './entity-api'
+import { showToast } from './toast'
 
 type EntityStatus =
   | `spawning`
@@ -276,6 +277,52 @@ export interface SignalInput {
   payload?: unknown
 }
 
+function parseErrorResponse(text: string): string | null {
+  if (!text) return null
+  try {
+    const data = JSON.parse(text) as {
+      error?: { message?: unknown }
+      message?: unknown
+    }
+    if (typeof data.error?.message === `string`) return data.error.message
+    if (typeof data.message === `string`) return data.message
+  } catch {
+    // Keep the raw response text below.
+  }
+  return text
+}
+
+function compactToastText(text: string): string {
+  const trimmed = text.trim()
+  return trimmed.length > 360 ? `${trimmed.slice(0, 357)}...` : trimmed
+}
+
+function showSignalFailureToast(input: {
+  action: `kill` | `signal`
+  entityUrl: string
+  signal: EntitySignal
+  status?: number
+  responseText?: string
+  error?: unknown
+}): void {
+  const title = input.action === `kill` ? `Kill failed` : `Signal failed`
+  const status = input.status ? ` (${input.status})` : ``
+  const parsed =
+    input.responseText !== undefined
+      ? parseErrorResponse(input.responseText)
+      : input.error instanceof Error
+        ? input.error.message
+        : input.error
+          ? String(input.error)
+          : null
+  const details = parsed ? compactToastText(parsed) : `No response details.`
+  showToast({
+    tone: `danger`,
+    title: `${title}${status}`,
+    description: `${input.signal} to ${input.entityUrl}: ${details}`,
+  })
+}
+
 function createSpawnAction(
   baseUrl: string,
   entitiesCollection: EntitiesCollection
@@ -350,19 +397,35 @@ function createKillAction(
       })
     },
     mutationFn: async (entityUrl) => {
-      const res = await serverFetch(
-        entityApiUrl(baseUrl, entityUrl, `/signal`),
-        {
+      const url = entityApiUrl(baseUrl, entityUrl, `/signal`)
+      let res: Response
+      try {
+        res = await serverFetch(url, {
           method: `POST`,
           headers: { 'content-type': `application/json` },
           body: JSON.stringify({
             signal: `SIGKILL`,
             reason: `Killed from agents UI`,
           }),
-        }
-      )
+        })
+      } catch (err) {
+        showSignalFailureToast({
+          action: `kill`,
+          entityUrl,
+          signal: `SIGKILL`,
+          error: err,
+        })
+        throw err
+      }
       if (!res.ok) {
         const text = await res.text().catch(() => ``)
+        showSignalFailureToast({
+          action: `kill`,
+          entityUrl,
+          signal: `SIGKILL`,
+          status: res.status,
+          responseText: text,
+        })
         throw new Error(text || `Kill failed (${res.status})`)
       }
       const data = (await res.json()) as { txid: number }
@@ -413,16 +476,32 @@ function createSignalAction(
       if (reason !== undefined) body.reason = reason
       if (payload !== undefined) body.payload = payload
 
-      const res = await serverFetch(
-        entityApiUrl(baseUrl, entityUrl, `/signal`),
-        {
+      const url = entityApiUrl(baseUrl, entityUrl, `/signal`)
+      let res: Response
+      try {
+        res = await serverFetch(url, {
           method: `POST`,
           headers: { 'content-type': `application/json` },
           body: JSON.stringify(body),
-        }
-      )
+        })
+      } catch (err) {
+        showSignalFailureToast({
+          action: `signal`,
+          entityUrl,
+          signal,
+          error: err,
+        })
+        throw err
+      }
       if (!res.ok) {
         const text = await res.text().catch(() => ``)
+        showSignalFailureToast({
+          action: `signal`,
+          entityUrl,
+          signal,
+          status: res.status,
+          responseText: text,
+        })
         throw new Error(text || `Signal failed (${res.status})`)
       }
       const data = (await res.json()) as { txid: number }

--- a/packages/agents-server-ui/src/lib/toast.ts
+++ b/packages/agents-server-ui/src/lib/toast.ts
@@ -1,0 +1,41 @@
+export type ToastTone = `danger` | `info` | `success` | `warning`
+
+export interface ToastInput {
+  title: string
+  description?: string
+  tone?: ToastTone
+  timeoutMs?: number
+}
+
+export interface ToastMessage
+  extends Required<Omit<ToastInput, `description`>> {
+  id: string
+  createdAt: number
+  description?: string
+}
+
+type ToastListener = (toast: ToastMessage) => void
+
+const listeners = new Set<ToastListener>()
+let nextToastId = 0
+
+export function showToast(input: ToastInput): string {
+  const id = `toast:${Date.now()}:${nextToastId++}`
+  const toast: ToastMessage = {
+    id,
+    title: input.title,
+    description: input.description,
+    tone: input.tone ?? `info`,
+    timeoutMs: input.timeoutMs ?? 7000,
+    createdAt: Date.now(),
+  }
+  for (const listener of listeners) listener(toast)
+  return id
+}
+
+export function subscribeToasts(listener: ToastListener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}

--- a/packages/agents-server-ui/src/router.tsx
+++ b/packages/agents-server-ui/src/router.tsx
@@ -41,7 +41,7 @@ import { Sidebar } from './components/Sidebar'
 import { SearchPalette } from './components/SearchPalette'
 import { Workspace } from './components/workspace/Workspace'
 import { OnboardingModal } from './components/OnboardingModal'
-import { ToastViewport } from './components/ToastViewport'
+import { ToastProvider } from './components/ToastViewport'
 import { DesktopTitleBar } from './components/DesktopTitleBar'
 import { TitlebarControls } from './components/TitlebarControls'
 import {
@@ -120,8 +120,9 @@ function RootLayout(): React.ReactElement {
       <SearchPaletteProvider>
         <WorkspaceProvider>
           <PaneFindProvider>
-            <RootShell />
-            <ToastViewport />
+            <ToastProvider>
+              <RootShell />
+            </ToastProvider>
           </PaneFindProvider>
         </WorkspaceProvider>
       </SearchPaletteProvider>

--- a/packages/agents-server-ui/src/router.tsx
+++ b/packages/agents-server-ui/src/router.tsx
@@ -41,6 +41,7 @@ import { Sidebar } from './components/Sidebar'
 import { SearchPalette } from './components/SearchPalette'
 import { Workspace } from './components/workspace/Workspace'
 import { OnboardingModal } from './components/OnboardingModal'
+import { ToastViewport } from './components/ToastViewport'
 import { DesktopTitleBar } from './components/DesktopTitleBar'
 import { TitlebarControls } from './components/TitlebarControls'
 import {
@@ -120,6 +121,7 @@ function RootLayout(): React.ReactElement {
         <WorkspaceProvider>
           <PaneFindProvider>
             <RootShell />
+            <ToastViewport />
           </PaneFindProvider>
         </WorkspaceProvider>
       </SearchPaletteProvider>


### PR DESCRIPTION
Signal and kill requests can fail after optimistic UI state has already been applied, for example when the server rejects persistence because a migration is missing. Previously those failures were easy to miss because the action callers intentionally swallowed rejected termination attempts, which made failed termination look like a no-op from the UI.

This PR adds a small server UI toast channel and mounts a global Base UI toast provider/viewport so local UI actions can surface failures without coupling every caller to notification rendering. The channel keeps the existing imperative showToast(...) API for non-React action code, then bridges those events into Base UI's toast manager.

The kill and signal optimistic action mutation functions now emit danger toasts for non-2xx responses and request-level failures, including the HTTP status and compacted server error text when available, while preserving the existing rejected mutation behavior.

The toast rendering is scoped to agents-server-ui and now uses @base-ui/react/toast primitives for provider, viewport, root, content, title, description, close, timeout handling, limits, and high-priority announcements for danger toasts. Styling stays on the existing design tokens plus lucide icons. A patch changeset is included for @electric-ax/agents-server-ui.