### PR TITLE
feat(agents): add desktop model picker controls

### DIFF
--- a/.changeset/enabled-model-picker.md
+++ b/.changeset/enabled-model-picker.md
@@ -1,0 +1,7 @@
+---
+"@electric-ax/agents": patch
+"@electric-ax/agents-desktop": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Allow desktop users to choose which configured provider models appear in Horton's model picker, and group model dropdown entries by provider.

--- a/packages/agents-desktop/src/app/controller.ts
+++ b/packages/agents-desktop/src/app/controller.ts
@@ -360,6 +360,7 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     runDiscovery: localDiscovery.runDiscovery,
     getApiKeysStatus: credentials.getApiKeysStatus,
     setApiKeys: credentials.setApiKeys,
+    setEnabledModels: credentials.setEnabledModels,
     signInCodex: credentials.signInCodex,
     enableCodexSource: credentials.enableCodexSource,
     disableCodex: credentials.disableCodex,

--- a/packages/agents-desktop/src/credentials/api-keys.ts
+++ b/packages/agents-desktop/src/credentials/api-keys.ts
@@ -1,5 +1,6 @@
 import type { SecretStore } from '../services/secret-store'
 import type { ApiKeys, ApiKeysStatus, CodexStatus } from '../shared/types'
+import { createModelPickerStatus } from './model-picker'
 
 export const EMPTY_API_KEYS: ApiKeys = {
   anthropic: null,
@@ -111,6 +112,7 @@ export type ApiKeyStatusDeps = {
   apiKeys: ApiKeys
   launchEnv: ApiKeys
   getCodexStatus: () => Promise<CodexStatus>
+  enabledModelValues?: ReadonlyArray<string> | null
 }
 
 export async function getApiKeysStatus(
@@ -130,7 +132,19 @@ export async function getApiKeysStatus(
     brave: saved.brave ? null : deps.launchEnv.brave,
   }
   const codex = await deps.getCodexStatus()
-  return { hasAnyKey: hasAnyKey || codex.enabled, saved, suggested, codex }
+  const modelPicker = createModelPickerStatus({
+    saved,
+    suggested,
+    codex,
+    enabledModelValues: deps.enabledModelValues,
+  })
+  return {
+    hasAnyKey: hasAnyKey || codex.enabled,
+    saved,
+    suggested,
+    codex,
+    modelPicker,
+  }
 }
 
 export type SetApiKeysDeps = {

--- a/packages/agents-desktop/src/credentials/controller.ts
+++ b/packages/agents-desktop/src/credentials/controller.ts
@@ -1,6 +1,7 @@
 import { dialog } from 'electron'
 import * as ApiKeyCredentials from './api-keys'
 import * as CodexAuth from './codex-auth'
+import { normalizeEnabledModelValues } from './model-picker'
 import type { SecretStore } from '../services/secret-store'
 import type {
   ApiKeys,
@@ -60,6 +61,7 @@ export function createCredentialsController(deps: {
         apiKeys: deps.apiKeys,
         launchEnv: deps.launchEnv,
         getCodexStatus,
+        enabledModelValues: deps.settings.enabledModelValues,
       }),
     setApiKeys: (next: ApiKeys): Promise<void> =>
       ApiKeyCredentials.setApiKeys(
@@ -74,6 +76,17 @@ export function createCredentialsController(deps: {
         },
         next
       ),
+    setEnabledModels: async (values: Array<string>): Promise<void> => {
+      const normalized = normalizeEnabledModelValues(values)
+      const current = deps.settings.enabledModelValues ?? []
+      const changed =
+        normalized.length !== current.length ||
+        normalized.some((value, index) => value !== current[index])
+      deps.settings.enabledModelValues =
+        normalized.length > 0 ? normalized : undefined
+      await deps.saveSettings()
+      if (changed) markCredentialsDirty()
+    },
     getOnboardingState: (): OnboardingState => ({
       dismissed: deps.settings.onboardingDismissed === true,
       hasAnyKey: Boolean(

--- a/packages/agents-desktop/src/credentials/model-picker.ts
+++ b/packages/agents-desktop/src/credentials/model-picker.ts
@@ -1,0 +1,103 @@
+import {
+  builtinModelProviderLabel,
+  listBuiltinModelChoices,
+  type BuiltinModelProvider,
+} from '@electric-ax/agents'
+import type {
+  ApiKeys,
+  CodexStatus,
+  ModelPickerChoice,
+  ModelPickerStatus,
+} from '../shared/types'
+
+export const DEFAULT_ENABLED_MODEL_VALUES = [
+  `anthropic:claude-haiku-4-5`,
+  `anthropic:claude-opus-4-5`,
+  `anthropic:claude-opus-4-5-20251101`,
+  `anthropic:claude-opus-4-7`,
+  `anthropic:claude-sonnet-4-6`,
+  `openai:gpt-5.5`,
+  `openai-codex:gpt-5.4`,
+  `openai-codex:gpt-5.5`,
+  `deepseek:deepseek-v4-flash`,
+  `deepseek:deepseek-v4-pro`,
+  `moonshot:kimi-k2.6`,
+]
+
+export function normalizeEnabledModelValues(value: unknown): Array<string> {
+  if (!Array.isArray(value)) return []
+  const out: Array<string> = []
+  const seen = new Set<string>()
+  for (const entry of value) {
+    if (typeof entry !== `string`) continue
+    const trimmed = entry.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    out.push(trimmed)
+  }
+  return out
+}
+
+export function resolveEnabledModelValues(
+  value: ReadonlyArray<string> | null | undefined
+): Array<string> {
+  const normalized = normalizeEnabledModelValues(value)
+  return normalized.length > 0 ? normalized : DEFAULT_ENABLED_MODEL_VALUES
+}
+
+function hasModelKey(
+  saved: ApiKeys,
+  suggested: ApiKeys,
+  key: keyof Pick<ApiKeys, `anthropic` | `openai` | `deepseek` | `moonshot`>
+): boolean {
+  return Boolean(saved[key] || suggested[key])
+}
+
+function configuredProviders(
+  saved: ApiKeys,
+  suggested: ApiKeys,
+  codex: CodexStatus
+): Array<BuiltinModelProvider> {
+  const providers: Array<BuiltinModelProvider> = []
+  if (hasModelKey(saved, suggested, `anthropic`)) providers.push(`anthropic`)
+  if (hasModelKey(saved, suggested, `openai`)) providers.push(`openai`)
+  if (hasModelKey(saved, suggested, `deepseek`)) providers.push(`deepseek`)
+  if (hasModelKey(saved, suggested, `moonshot`)) providers.push(`moonshot`)
+  if (codex.enabled) providers.push(`openai-codex`)
+  return providers
+}
+
+export function createModelPickerStatus({
+  saved,
+  suggested,
+  codex,
+  enabledModelValues,
+}: {
+  saved: ApiKeys
+  suggested: ApiKeys
+  codex: CodexStatus
+  enabledModelValues?: ReadonlyArray<string> | null
+}): ModelPickerStatus {
+  const choices: Array<ModelPickerChoice> = listBuiltinModelChoices(
+    configuredProviders(saved, suggested, codex)
+  ).map((choice) => ({
+    provider: choice.provider,
+    providerLabel: builtinModelProviderLabel(choice.provider),
+    id: choice.id,
+    label: choice.label,
+    value: choice.value,
+  }))
+
+  const allValues = choices.map((choice) => choice.value)
+  const availableValues = new Set(allValues)
+  const savedEnabled = resolveEnabledModelValues(enabledModelValues)
+  const enabled =
+    savedEnabled.length === 0
+      ? allValues
+      : savedEnabled.filter((value) => availableValues.has(value))
+
+  return {
+    choices,
+    enabled: enabled.length > 0 ? enabled : allValues,
+  }
+}

--- a/packages/agents-desktop/src/ipc/credentials.ts
+++ b/packages/agents-desktop/src/ipc/credentials.ts
@@ -13,6 +13,7 @@ export type CredentialsIpcDeps = {
   }
   getApiKeysStatus: () => Promise<unknown>
   setApiKeys: (keys: ApiKeys) => Promise<void>
+  setEnabledModels: (values: Array<string>) => Promise<void>
   signInCodex: () => Promise<unknown>
   enableCodexSource: (source: CodexAuthSource) => Promise<unknown>
   disableCodex: () => Promise<unknown>
@@ -28,6 +29,12 @@ export function registerCredentialsIpcHandlers(deps: CredentialsIpcDeps): void {
   ipcMain.handle(`desktop:save-api-keys`, async (_event, keys: ApiKeys) => {
     await deps.setApiKeys(keys)
   })
+  ipcMain.handle(
+    `desktop:save-enabled-models`,
+    async (_event, values: Array<string>) => {
+      await deps.setEnabledModels(values)
+    }
+  )
   ipcMain.handle(`desktop:codex-sign-in`, () => deps.signInCodex())
   ipcMain.handle(
     `desktop:codex-enable-source`,

--- a/packages/agents-desktop/src/preload.ts
+++ b/packages/agents-desktop/src/preload.ts
@@ -158,6 +158,8 @@ const api = {
     ipcRenderer.invoke(`desktop:get-api-keys-status`),
   saveApiKeys: (keys: ApiKeys): Promise<void> =>
     ipcRenderer.invoke(`desktop:save-api-keys`, keys),
+  saveEnabledModels: (values: Array<string>): Promise<void> =>
+    ipcRenderer.invoke(`desktop:save-enabled-models`, values),
   codexSignIn: (): Promise<CodexStatus> =>
     ipcRenderer.invoke(`desktop:codex-sign-in`),
   codexEnableSource: (source: CodexAuthSource): Promise<CodexStatus> =>

--- a/packages/agents-desktop/src/runtime/lifecycle.ts
+++ b/packages/agents-desktop/src/runtime/lifecycle.ts
@@ -16,6 +16,7 @@ import {
 } from '../shared/headers'
 import type { CloudAgentServers } from '../cloud/cloud-agent-servers'
 import type { CloudAuthState } from '../cloud/cloud-auth'
+import { resolveEnabledModelValues } from '../credentials/model-picker'
 import { checkAgentsServerHealth, formatStartupNetworkError } from './health'
 import type {
   ConnectServerOptions,
@@ -33,6 +34,7 @@ export type RuntimeLifecycleDeps = {
     workingDirectory?: string | null
     mcp?: { servers: Array<McpServerConfig> }
     pullWakeRunnerId?: string | null
+    enabledModelValues?: Array<string>
   }
   runtimeEntries: Map<string, RuntimeEntry>
   windowSelections: Map<number, string | null>
@@ -247,6 +249,9 @@ export async function startRuntime(
     agentServerUrl: activeServer.url,
     workingDirectory: deps.settings.workingDirectory ?? app.getPath(`home`),
     extraMcpServers: deps.settings.mcp?.servers,
+    enabledModelValues: resolveEnabledModelValues(
+      deps.settings.enabledModelValues
+    ),
     loadProjectMcpConfig: true,
     mcpOAuthRedirectBase: MCP_OAUTH_REDIRECT_BASE,
     baseSkillsDir: AGENT_SKILLS_DIR,

--- a/packages/agents-desktop/src/settings/store.ts
+++ b/packages/agents-desktop/src/settings/store.ts
@@ -16,6 +16,7 @@ import {
   normalizeApiKeys,
   saveApiKeysToSecret,
 } from '../credentials/api-keys'
+import { normalizeEnabledModelValues } from '../credentials/model-picker'
 import { normalizeServer, normalizeServers } from './servers'
 
 export { settingsPath } from '../shared/paths'
@@ -148,6 +149,9 @@ export async function loadDesktopSettings(
       typeof parsed.apiKeysRef === `string` && parsed.apiKeysRef.trim()
         ? parsed.apiKeysRef.trim()
         : GLOBAL_API_KEYS_REF
+    const enabledModelValues = normalizeEnabledModelValues(
+      parsed.enabledModelValues
+    )
     Object.assign(deps.settings, {
       servers,
       defaultServerId,
@@ -159,6 +163,8 @@ export async function loadDesktopSettings(
       launchAtLogin: parsed.launchAtLogin === true,
       onboardingDismissed: parsed.onboardingDismissed === true,
       codex: normalizeCodexSettings(parsed.codex),
+      enabledModelValues:
+        enabledModelValues.length > 0 ? enabledModelValues : undefined,
       mcp: normalizeMcp(parsed.mcp),
       pullWakeRunnerId,
     })

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -1,5 +1,6 @@
 import type {
   BuiltinAgentsServer,
+  BuiltinModelProvider,
   McpServerConfig,
   RegistrySnapshot,
 } from '@electric-ax/agents'
@@ -100,6 +101,19 @@ export type ApiKeys = {
   brave: string | null
 }
 
+export type ModelPickerChoice = {
+  provider: BuiltinModelProvider
+  providerLabel: string
+  id: string
+  label: string
+  value: string
+}
+
+export type ModelPickerStatus = {
+  choices: Array<ModelPickerChoice>
+  enabled: Array<string>
+}
+
 export type CodexAuthSource = `desktop-oauth` | `codex-cli` | `opencode`
 
 export type CodexSettings = {
@@ -114,6 +128,7 @@ export type DesktopSettings = {
   apiKeysRef: string
   launchAtLogin?: boolean
   codex?: CodexSettings
+  enabledModelValues?: Array<string>
   onboardingDismissed?: boolean
   mcp?: { servers: Array<McpServerConfig> }
   pullWakeRunnerId?: string
@@ -165,6 +180,7 @@ export type ApiKeysStatus = {
   saved: ApiKeys
   suggested: ApiKeys
   codex: CodexStatus
+  modelPicker: ModelPickerStatus
 }
 
 export type CodexDetectedSource = {

--- a/packages/agents-server-ui/src/components/ApiKeysForm.tsx
+++ b/packages/agents-server-ui/src/components/ApiKeysForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useRef, useState, type ReactNode } from 'react'
 import { Eye, EyeOff, Sparkles } from 'lucide-react'
 import { Button, Field, Icon, IconButton, Input, Stack, Text } from '../ui'
 import {
@@ -17,6 +17,7 @@ export type ApiKeysFormValues = {
 }
 
 type ApiKeyFieldId = keyof ApiKeysFormValues
+type ModelApiKeyFieldId = Exclude<ApiKeyFieldId, `brave`>
 
 interface ApiKeysFormProps {
   initial: ApiKeysFormValues
@@ -41,6 +42,7 @@ interface ApiKeysFormProps {
   layout?: `form` | `settings`
   showModelKeys?: boolean
   showBrave?: boolean
+  modelControls?: Partial<Record<ModelApiKeyFieldId, ReactNode>>
   /**
    * When `true`, persist on field blur (after the user has typed)
    * instead of waiting for a Save click. Hides the explicit
@@ -77,6 +79,7 @@ export function ApiKeysForm({
   layout = `form`,
   showModelKeys = true,
   showBrave = true,
+  modelControls,
   autoSave = false,
 }: ApiKeysFormProps): React.ReactElement {
   const [anthropic, setAnthropic] = useState(initial.anthropic)
@@ -226,6 +229,7 @@ export function ApiKeysForm({
                 />
               }
             />
+            {modelControls?.anthropic}
             <SettingsRow
               label="OpenAI API"
               description="Used for GPT models. Looks like sk-…"
@@ -242,6 +246,7 @@ export function ApiKeysForm({
                 />
               }
             />
+            {modelControls?.openai}
             <SettingsRow
               label="DeepSeek API"
               description="Used for DeepSeek models. Looks like sk-…"
@@ -258,6 +263,7 @@ export function ApiKeysForm({
                 />
               }
             />
+            {modelControls?.deepseek}
             <SettingsRow
               label="Kimi / Moonshot API"
               description="Used for Kimi and Moonshot models. Looks like sk-…"
@@ -274,6 +280,7 @@ export function ApiKeysForm({
                 />
               }
             />
+            {modelControls?.moonshot}
           </>
         )}
         {showBrave && (

--- a/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.module.css
+++ b/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.module.css
@@ -1,0 +1,119 @@
+.modelPicker {
+  width: 100%;
+  padding: 0 16px 10px;
+  margin-top: -5px;
+}
+
+.modelCollapseTrigger {
+  width: 100%;
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: var(--ds-text-3);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.modelCollapseTrigger:hover {
+  color: var(--ds-text-2);
+}
+
+.modelCollapseTrigger:focus-visible {
+  outline: 2px solid var(--ds-accent-9);
+  outline-offset: 2px;
+  border-radius: var(--ds-radius-1);
+}
+
+.modelCollapseSummary {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--ds-text-xs);
+  line-height: var(--ds-text-xs-lh);
+  color: inherit;
+}
+
+.modelCollapseSaving {
+  flex-shrink: 0;
+  font-size: var(--ds-text-xs);
+  line-height: var(--ds-text-xs-lh);
+  color: var(--ds-text-3);
+}
+
+.modelCollapseIcon {
+  flex-shrink: 0;
+  color: currentColor;
+  transition: transform 120ms ease;
+}
+
+.modelCollapseTrigger[data-panel-open] .modelCollapseIcon {
+  transform: rotate(180deg);
+}
+
+.modelCollapsePanel {
+  padding-top: 6px;
+}
+
+.modelGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 4px 8px;
+  padding-left: 10px;
+}
+
+.modelOption {
+  min-width: 0;
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: var(--ds-radius-2);
+  color: var(--ds-text-1);
+  cursor: pointer;
+}
+
+.modelOption:hover {
+  background: var(--ds-bg-hover);
+}
+
+.modelOption[data-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.modelOption input {
+  flex-shrink: 0;
+}
+
+.modelOptionText {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.modelOptionName,
+.modelOptionId {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.modelOptionName {
+  font-size: var(--ds-text-sm);
+  line-height: var(--ds-text-sm-lh);
+}
+
+.modelOptionId {
+  font-size: var(--ds-text-xs);
+  line-height: var(--ds-text-xs-lh);
+  color: var(--ds-text-3);
+}

--- a/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
@@ -1,5 +1,6 @@
+import { Collapsible } from '@base-ui/react/collapsible'
 import { useEffect, useState } from 'react'
-import { RefreshCw } from 'lucide-react'
+import { ChevronDown, RefreshCw } from 'lucide-react'
 import { ApiKeysForm } from '../../ApiKeysForm'
 import {
   codexDisable,
@@ -10,9 +11,12 @@ import {
   onDesktopStateChanged,
   restartLocalRuntimes,
   saveApiKeys as persistApiKeys,
+  saveEnabledModels as persistEnabledModels,
   type ApiKeysStatus,
   type CodexAuthSource,
   type CodexStatus,
+  type ModelPickerChoice,
+  type ModelPickerStatus,
 } from '../../../lib/server-connection'
 import { Button, Icon, Text } from '../../../ui'
 import {
@@ -23,6 +27,7 @@ import {
   SettingsSection,
   SettingsStatusBadge,
 } from '../SettingsScreen'
+import styles from './CredentialsPage.module.css'
 
 export function CredentialsPage(): React.ReactElement {
   const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
@@ -139,6 +144,16 @@ export function CredentialsPage(): React.ReactElement {
                   setCodexBusy(null)
                 }
               }}
+              modelControl={
+                <ProviderModelSettings
+                  status={status.modelPicker}
+                  provider="openai-codex"
+                  onSave={async (values) => {
+                    await persistEnabledModels(values)
+                    await refreshStatus()
+                  }}
+                />
+              }
             />
             <ApiKeysForm
               layout="settings"
@@ -172,6 +187,48 @@ export function CredentialsPage(): React.ReactElement {
                   brave: status.saved.brave ?? null,
                 })
                 await refreshStatus()
+              }}
+              modelControls={{
+                anthropic: (
+                  <ProviderModelSettings
+                    status={status.modelPicker}
+                    provider="anthropic"
+                    onSave={async (values) => {
+                      await persistEnabledModels(values)
+                      await refreshStatus()
+                    }}
+                  />
+                ),
+                openai: (
+                  <ProviderModelSettings
+                    status={status.modelPicker}
+                    provider="openai"
+                    onSave={async (values) => {
+                      await persistEnabledModels(values)
+                      await refreshStatus()
+                    }}
+                  />
+                ),
+                deepseek: (
+                  <ProviderModelSettings
+                    status={status.modelPicker}
+                    provider="deepseek"
+                    onSave={async (values) => {
+                      await persistEnabledModels(values)
+                      await refreshStatus()
+                    }}
+                  />
+                ),
+                moonshot: (
+                  <ProviderModelSettings
+                    status={status.modelPicker}
+                    provider="moonshot"
+                    onSave={async (values) => {
+                      await persistEnabledModels(values)
+                      await refreshStatus()
+                    }}
+                  />
+                ),
               }}
             />
           </>
@@ -213,6 +270,112 @@ export function CredentialsPage(): React.ReactElement {
   )
 }
 
+function modelDisplayName(choice: ModelPickerChoice): string {
+  const prefix = `${choice.providerLabel} `
+  return choice.label.startsWith(prefix)
+    ? choice.label.slice(prefix.length)
+    : choice.label
+}
+
+function ProviderModelSettings({
+  status,
+  provider,
+  onSave,
+}: {
+  status: ModelPickerStatus
+  provider: ModelPickerChoice[`provider`]
+  onSave: (values: Array<string>) => Promise<void>
+}): React.ReactElement | null {
+  const [enabled, setEnabled] = useState(status.enabled)
+  const [saving, setSaving] = useState(false)
+  const statusKey = `${status.choices.map((choice) => choice.value).join(`\n`)}|${status.enabled.join(`\n`)}`
+
+  useEffect(() => {
+    setEnabled(status.enabled)
+  }, [statusKey, status.enabled])
+
+  const choices = status.choices.filter(
+    (choice) => choice.provider === provider
+  )
+  if (choices.length === 0) return null
+
+  const enabledSet = new Set(enabled)
+  const enabledCount = choices.filter((choice) =>
+    enabledSet.has(choice.value)
+  ).length
+
+  const saveNext = async (next: Array<string>): Promise<void> => {
+    setEnabled(next)
+    setSaving(true)
+    try {
+      await onSave(next)
+    } catch (error) {
+      setEnabled(status.enabled)
+      console.error(`[credentials] failed to save enabled models`, error)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Collapsible.Root className={styles.modelPicker} aria-busy={saving}>
+      <Collapsible.Trigger
+        type="button"
+        className={styles.modelCollapseTrigger}
+      >
+        <span className={styles.modelCollapseSummary}>
+          {enabledCount} of {choices.length} models shown in the model picker.
+        </span>
+        {saving && <span className={styles.modelCollapseSaving}>Saving…</span>}
+        <Icon
+          icon={ChevronDown}
+          size={2}
+          className={styles.modelCollapseIcon}
+        />
+      </Collapsible.Trigger>
+      <Collapsible.Panel keepMounted className={styles.modelCollapsePanel}>
+        <div className={styles.modelGrid}>
+          {choices.map((choice) => {
+            const checked = enabledSet.has(choice.value)
+            const disabled = saving || (checked && enabledSet.size <= 1)
+            return (
+              <label
+                key={choice.value}
+                className={styles.modelOption}
+                data-disabled={disabled ? `true` : undefined}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={disabled}
+                  onChange={(event) => {
+                    const nextSet = new Set(enabledSet)
+                    if (event.target.checked) {
+                      nextSet.add(choice.value)
+                    } else {
+                      nextSet.delete(choice.value)
+                    }
+                    const next = status.choices
+                      .map((candidate) => candidate.value)
+                      .filter((value) => nextSet.has(value))
+                    void saveNext(next)
+                  }}
+                />
+                <span className={styles.modelOptionText}>
+                  <span className={styles.modelOptionName}>
+                    {modelDisplayName(choice)}
+                  </span>
+                  <span className={styles.modelOptionId}>{choice.id}</span>
+                </span>
+              </label>
+            )
+          })}
+        </div>
+      </Collapsible.Panel>
+    </Collapsible.Root>
+  )
+}
+
 function RestartBanner({
   onRestart,
   restarting,
@@ -250,6 +413,7 @@ function CodexSettings({
   onSignIn,
   onUseSource,
   onDisable,
+  modelControl,
 }: {
   status: CodexStatus
   busy: string | null
@@ -257,6 +421,7 @@ function CodexSettings({
   onSignIn: () => Promise<void>
   onUseSource: (source: CodexAuthSource) => Promise<void>
   onDisable: () => Promise<void>
+  modelControl?: React.ReactNode
 }): React.ReactElement {
   const detected = status.availableSources.filter(
     (source) => source.source !== `desktop-oauth`
@@ -301,6 +466,7 @@ function CodexSettings({
           )
         }
       />
+      {modelControl}
       {!status.enabled &&
         detected.map((source) => (
           <SettingsRow

--- a/packages/agents-server-ui/src/components/views/NewSessionView.tsx
+++ b/packages/agents-server-ui/src/components/views/NewSessionView.tsx
@@ -745,6 +745,7 @@ function DefaultAgentComposer({
                   label={prop.title ?? key}
                   value={String(args[key] ?? ``)}
                   options={prop.enum.map((v) => String(v))}
+                  groupByProvider={isModelProperty(key)}
                   onChange={(next) => {
                     const original = prop.enum!.find((v) => String(v) === next)
                     if (isModelProperty(key)) persistLastPickedModel(next)
@@ -852,19 +853,70 @@ function RunnerPickerPill({
   )
 }
 
+const MODEL_PROVIDER_LABELS: Record<string, string> = {
+  anthropic: `Anthropic`,
+  openai: `OpenAI`,
+  'openai-codex': `OpenAI Codex`,
+  deepseek: `DeepSeek`,
+  moonshot: `Kimi`,
+}
+
+function modelProviderKey(value: string): string {
+  const index = value.indexOf(`:`)
+  return index > 0 ? value.slice(0, index) : `other`
+}
+
+function modelProviderLabel(provider: string): string {
+  return MODEL_PROVIDER_LABELS[provider] ?? provider
+}
+
+function modelOptionLabel(value: string): string {
+  const index = value.indexOf(`:`)
+  return index > 0 ? value.slice(index + 1) : value
+}
+
+function groupedModelOptions(
+  options: Array<string>
+): Array<{ provider: string; label: string; options: Array<string> }> {
+  const groups: Array<{
+    provider: string
+    label: string
+    options: Array<string>
+  }> = []
+  const byProvider = new Map<string, (typeof groups)[number]>()
+  for (const option of options) {
+    const provider = modelProviderKey(option)
+    let group = byProvider.get(provider)
+    if (!group) {
+      group = {
+        provider,
+        label: modelProviderLabel(provider),
+        options: [],
+      }
+      byProvider.set(provider, group)
+      groups.push(group)
+    }
+    group.options.push(option)
+  }
+  return groups
+}
+
 function PillSelect({
   label,
   value,
   options,
+  groupByProvider = false,
   onChange,
   disabled,
 }: {
   label: string
   value: string
   options: Array<string>
+  groupByProvider?: boolean
   onChange: (value: string) => void
   disabled?: boolean
 }): React.ReactElement {
+  const groups = groupByProvider ? groupedModelOptions(options) : []
   return (
     <Select.Root<string>
       value={value}
@@ -873,13 +925,33 @@ function PillSelect({
       }}
       disabled={disabled}
     >
-      <Select.Trigger size="pill" aria-label={label} title={label} />
+      <Select.Trigger
+        size="pill"
+        aria-label={label}
+        title={label}
+        renderValue={
+          groupByProvider
+            ? (current) => (current ? modelOptionLabel(current) : label)
+            : undefined
+        }
+      />
       <Select.Content>
-        {options.map((opt) => (
-          <Select.Item key={opt} value={opt}>
-            {opt}
-          </Select.Item>
-        ))}
+        {groupByProvider
+          ? groups.map((group) => (
+              <Select.Group key={group.provider}>
+                <Select.GroupLabel>{group.label}</Select.GroupLabel>
+                {group.options.map((opt) => (
+                  <Select.Item key={opt} value={opt}>
+                    {modelOptionLabel(opt)}
+                  </Select.Item>
+                ))}
+              </Select.Group>
+            ))
+          : options.map((opt) => (
+              <Select.Item key={opt} value={opt}>
+                {opt}
+              </Select.Item>
+            ))}
       </Select.Content>
     </Select.Root>
   )

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -116,6 +116,26 @@ export interface ApiKeys {
 
 export type CodexAuthSource = `desktop-oauth` | `codex-cli` | `opencode`
 
+export type ModelProvider =
+  | `anthropic`
+  | `openai`
+  | `openai-codex`
+  | `deepseek`
+  | `moonshot`
+
+export interface ModelPickerChoice {
+  provider: ModelProvider
+  providerLabel: string
+  id: string
+  label: string
+  value: string
+}
+
+export interface ModelPickerStatus {
+  choices: Array<ModelPickerChoice>
+  enabled: Array<string>
+}
+
 export type CodexDetectedSource = {
   source: CodexAuthSource
   label: string
@@ -147,6 +167,7 @@ export interface ApiKeysStatus {
    */
   suggested: ApiKeys
   codex: CodexStatus
+  modelPicker: ModelPickerStatus
 }
 
 /**
@@ -335,6 +356,7 @@ declare global {
       rescanServers?: () => Promise<Array<DiscoveredServer>>
       getApiKeysStatus?: () => Promise<ApiKeysStatus>
       saveApiKeys?: (keys: ApiKeys) => Promise<void>
+      saveEnabledModels?: (values: Array<string>) => Promise<void>
       codexSignIn?: () => Promise<CodexStatus>
       codexEnableSource?: (source: CodexAuthSource) => Promise<CodexStatus>
       codexDisable?: () => Promise<CodexStatus>
@@ -547,6 +569,10 @@ export async function loadApiKeysStatus(): Promise<ApiKeysStatus | null> {
 
 export async function saveApiKeys(keys: ApiKeys): Promise<void> {
   await window.electronAPI?.saveApiKeys?.(keys)
+}
+
+export async function saveEnabledModels(values: Array<string>): Promise<void> {
+  await window.electronAPI?.saveEnabledModels?.(values)
 }
 
 export async function codexSignIn(): Promise<CodexStatus | null> {

--- a/packages/agents-server-ui/src/ui/Select.module.css
+++ b/packages/agents-server-ui/src/ui/Select.module.css
@@ -105,6 +105,25 @@
   max-height: inherit;
 }
 
+.groupLabel {
+  padding: 7px 8px 3px;
+  font-size: var(--ds-text-xs);
+  line-height: var(--ds-text-xs-lh);
+  font-family: var(--ds-font-body);
+  font-weight: 600;
+  color: var(--ds-text-3);
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.groupLabel:first-child {
+  padding-top: 4px;
+}
+
+.groupLabel ~ .item {
+  padding-left: 16px;
+}
+
 /* Same concentric-halo geometry as Menu.Item — see Menu.module.css.
    Select items don't carry a trailing inner button so the right
    padding can stay symmetric (8px), but the radius is bumped to 7px

--- a/packages/agents-server-ui/src/ui/Select.tsx
+++ b/packages/agents-server-ui/src/ui/Select.tsx
@@ -66,6 +66,14 @@ interface ItemProps<V extends string>
   children: ReactNode
 }
 
+interface GroupProps {
+  children?: ReactNode
+}
+
+interface GroupLabelProps {
+  children: ReactNode
+}
+
 function Root<V extends string>({
   value,
   defaultValue,
@@ -169,6 +177,18 @@ function Item<V extends string>({
   )
 }
 
+function Group({ children }: GroupProps): React.ReactElement {
+  return <BaseSelect.Group>{children}</BaseSelect.Group>
+}
+
+function GroupLabel({ children }: GroupLabelProps): React.ReactElement {
+  return (
+    <BaseSelect.GroupLabel className={styles.groupLabel}>
+      {children}
+    </BaseSelect.GroupLabel>
+  )
+}
+
 /**
  * Native-style select — wraps `@base-ui/react/select`.
  *
@@ -182,4 +202,4 @@ function Item<V extends string>({
  *     </Select.Content>
  *   </Select.Root>
  */
-export const Select = { Root, Trigger, Content, Item }
+export const Select = { Root, Trigger, Content, Item, Group, GroupLabel }

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -45,6 +45,7 @@ export interface BuiltinAgentHandlerOptions {
   serveEndpoint?: string
   workingDirectory?: string
   streamFn?: StreamFn
+  enabledModelValues?: ReadonlyArray<string> | null
   publicUrl?: string
   runtimeName?: string
   /** Override for the built-in skills directory; required when embedders bundle this package. */
@@ -92,6 +93,7 @@ export async function createBuiltinAgentHandler(
     serveEndpoint,
     workingDirectory,
     streamFn,
+    enabledModelValues,
     createElectricTools,
     publicUrl,
     runtimeName,
@@ -102,6 +104,7 @@ export async function createBuiltinAgentHandler(
 
   const modelCatalog = await createBuiltinModelCatalog({
     allowMockFallback: Boolean(streamFn),
+    enabledModelValues,
   })
 
   if (!modelCatalog) {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -44,6 +44,15 @@ export {
   HORTON_MODEL,
   registerHorton,
 } from './agents/horton.js'
+export {
+  builtinModelProviderLabel,
+  listBuiltinModelChoices,
+} from './model-catalog.js'
+export type {
+  BuiltinModelCatalogOptions,
+  BuiltinModelChoice,
+  BuiltinModelProvider,
+} from './model-catalog.js'
 export { registerWorker } from './agents/worker.js'
 export {
   WORKER_TOOL_NAMES,

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -27,6 +27,11 @@ export interface BuiltinModelCatalog {
   defaultChoice: BuiltinModelChoice
 }
 
+export interface BuiltinModelCatalogOptions {
+  allowMockFallback?: boolean
+  enabledModelValues?: ReadonlyArray<string> | null
+}
+
 export const REASONING_EFFORT_VALUES = [
   `auto`,
   `minimal`,
@@ -59,7 +64,9 @@ function modelValue(provider: BuiltinModelProvider, id: string): string {
   return `${provider}:${id}`
 }
 
-function providerLabel(provider: BuiltinModelProvider): string {
+export function builtinModelProviderLabel(
+  provider: BuiltinModelProvider
+): string {
   if (provider === `anthropic`) return `Anthropic`
   if (provider === `openai-codex`) return `OpenAI Codex`
   if (provider === `deepseek`) return `DeepSeek`
@@ -132,39 +139,72 @@ async function fetchAvailableModelIds(
   }
 }
 
+function knownModelsForProvider(provider: BuiltinModelProvider) {
+  return provider === MOONSHOT_PROVIDER
+    ? getMoonshotModels()
+    : getModels(
+        provider as Exclude<BuiltinModelProvider, typeof MOONSHOT_PROVIDER>
+      )
+}
+
+function choiceForKnownModel(
+  provider: BuiltinModelProvider,
+  model: ReturnType<typeof knownModelsForProvider>[number]
+): BuiltinModelChoice {
+  return {
+    provider,
+    id: model.id,
+    label: `${builtinModelProviderLabel(provider)} ${model.name}`,
+    value: modelValue(provider, model.id),
+    reasoning: model.reasoning,
+  }
+}
+
+export function listBuiltinModelChoices(
+  providers: ReadonlyArray<BuiltinModelProvider>
+): Array<BuiltinModelChoice> {
+  return providers.flatMap((provider) =>
+    knownModelsForProvider(provider).map((model) =>
+      choiceForKnownModel(provider, model)
+    )
+  )
+}
+
 async function choicesForProvider(
   provider: BuiltinModelProvider
 ): Promise<Array<BuiltinModelChoice>> {
-  const knownModels =
-    provider === MOONSHOT_PROVIDER
-      ? getMoonshotModels()
-      : getModels(
-          provider as Exclude<BuiltinModelProvider, typeof MOONSHOT_PROVIDER>
-        )
+  const knownChoices = listBuiltinModelChoices([provider])
 
   if (provider === `openai-codex`) {
-    return knownModels.map((model) => ({
-      provider,
-      id: model.id,
-      label: `${providerLabel(provider)} ${model.name}`,
-      value: modelValue(provider, model.id),
-      reasoning: model.reasoning,
-    }))
+    return knownChoices
   }
 
   const availableIds = await fetchAvailableModelIds(provider)
-  const models =
-    availableIds === null
-      ? knownModels
-      : knownModels.filter((model) => availableIds.has(model.id))
+  return availableIds === null
+    ? knownChoices
+    : knownChoices.filter((choice) => availableIds.has(choice.id))
+}
 
-  return models.map((model) => ({
-    provider,
-    id: model.id,
-    label: `${providerLabel(provider)} ${model.name}`,
-    value: modelValue(provider, model.id),
-    reasoning: model.reasoning,
-  }))
+function enabledModelSet(
+  values: ReadonlyArray<string> | null | undefined
+): Set<string> | null {
+  if (!values) return null
+  const enabled = new Set<string>()
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (trimmed) enabled.add(trimmed)
+  }
+  return enabled.size > 0 ? enabled : null
+}
+
+function filterChoicesByEnabledModels(
+  choices: Array<BuiltinModelChoice>,
+  values: ReadonlyArray<string> | null | undefined
+): Array<BuiltinModelChoice> {
+  const enabled = enabledModelSet(values)
+  if (!enabled) return choices
+  const filtered = choices.filter((choice) => enabled.has(choice.value))
+  return filtered.length > 0 ? filtered : choices
 }
 
 function withProviderPayloadDefaults(
@@ -215,9 +255,7 @@ function parseReasoningEffort(value: unknown): ExplicitReasoningEffort | null {
 }
 
 export async function createBuiltinModelCatalog(
-  options: {
-    allowMockFallback?: boolean
-  } = {}
+  options: BuiltinModelCatalogOptions = {}
 ): Promise<BuiltinModelCatalog | null> {
   const providers = configuredProviders()
 
@@ -225,9 +263,13 @@ export async function createBuiltinModelCatalog(
     return mockFallbackCatalog()
   }
 
-  const choices = (
+  const providerChoices = (
     await Promise.all(providers.map((provider) => choicesForProvider(provider)))
   ).flat()
+  const choices = filterChoicesByEnabledModels(
+    providerChoices,
+    options.enabledModelValues
+  )
 
   if (choices.length === 0) {
     return options.allowMockFallback ? mockFallbackCatalog() : null

--- a/packages/agents/src/server.ts
+++ b/packages/agents/src/server.ts
@@ -74,6 +74,8 @@ export interface BuiltinAgentsServerOptions {
   loadProjectMcpConfig?: boolean
   /** Override for the built-in skills directory; required when embedders bundle this package. */
   baseSkillsDir?: string
+  /** Restrict the model values exposed by built-in agent creation schemas. */
+  enabledModelValues?: ReadonlyArray<string> | null
   createElectricTools?: NonNullable<ProcessWakeConfig[`createElectricTools`]>
 }
 
@@ -273,6 +275,7 @@ export class BuiltinAgentsServer {
         publicUrl,
         runtimeName: `builtin-agents`,
         baseSkillsDir: this.options.baseSkillsDir,
+        enabledModelValues: this.options.enabledModelValues,
         serverHeaders: pullWake.headers,
       })
       if (!this.bootstrap) {

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -53,6 +53,29 @@ describe(`model catalog`, () => {
     })
   })
 
+  it(`filters choices to enabled model values`, async () => {
+    const catalog = await createBuiltinModelCatalog({
+      enabledModelValues: [`openai:gpt-5`],
+    })
+
+    expect(catalog).not.toBeNull()
+    expect(catalog!.choices.map((choice) => choice.value)).toEqual([
+      `openai:gpt-5`,
+    ])
+    expect(catalog!.defaultChoice.value).toBe(`openai:gpt-5`)
+  })
+
+  it(`falls back to available choices when enabled model values are stale`, async () => {
+    const catalog = await createBuiltinModelCatalog({
+      enabledModelValues: [`deepseek:missing`],
+    })
+
+    expect(catalog).not.toBeNull()
+    expect(catalog!.choices.map((choice) => choice.value)).toContain(
+      `openai:gpt-4.1`
+    )
+  })
+
   it(`sets a valid reasoning effort for OpenAI reasoning models`, async () => {
     const catalog = await createBuiltinModelCatalog()
     const config = resolveBuiltinModelConfig(catalog!, {


### PR DESCRIPTION
## Motivation

The Kimi / Moonshot provider work adds another model provider to local Horton sessions, but the session model dropdown would still expose every available model for every configured provider. That makes the picker noisy and puts provider grouping in the wrong place: users configure credentials in Settings, so the enabled-model controls should live next to those credentials and feed into Horton startup.

## What changed

- Added persisted desktop settings and IPC for enabled model values.
- Threaded enabled model values through desktop runtime startup into the built-in Horton model catalog, so disabled models are omitted from local session creation.
- Added provider headers to the new-session model dropdown and indented model rows under each provider header.
- Added Base UI collapsible model controls under each provider credential in Credentials settings, including the ChatGPT / Codex login block.
- Seeded fresh model-picker settings with the requested defaults for Anthropic, DeepSeek, Kimi / Moonshot, and OpenAI Codex, including GPT-5.5.
- Added tests for catalog filtering behavior and a changeset for the touched agents packages.

## Decisions

Enabled models are stored as provider-prefixed values, for example anthropic:claude-sonnet-4-6, so overlapping model ids from different providers remain unambiguous. The desktop status payload only exposes controls for configured providers, and the catalog falls back to the full available model list if a saved/default enabled set has no valid intersection so a bad preference cannot leave Horton without any selectable model.

This PR is stacked on #4451 because the model controls include Kimi / Moonshot as one of the provider groups.
