### PR TITLE
fix(agents): preserve volatile context source order

### DIFF
--- a/.changeset/fix-sigint-context-order.md
+++ b/.changeset/fix-sigint-context-order.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-runtime': patch
+---
+
+Preserve volatile context source order in `assembleContext()` instead of globally sorting by `at` timestamp. Fixes a bug where the SIGINT reordering performed by `reorderInterruptedRuns()` was undone by a downstream sort, causing interrupted run output to appear after the interrupt marker in the model transcript.

--- a/packages/agents-runtime/src/context-assembly.ts
+++ b/packages/agents-runtime/src/context-assembly.ts
@@ -313,7 +313,12 @@ export async function assembleContext(
     }
   }
 
-  volatileMessages.sort((left, right) => left.at - right.at)
+  // Preserve volatile source order. Volatile sources such as
+  // ctx.timelineMessages() may return a model-facing transcript order that
+  // intentionally differs from raw stream-offset order, e.g. interrupted run
+  // output before the SIGINT marker that raced ahead of buffered runtime
+  // writes. `at` remains metadata for truncation ranges and load tools, but it
+  // must not globally reorder already-projected context.
 
   const remainingBudget = Math.max(0, config.sourceBudget - budgetUsed)
   const accepted: Array<VolatileMessage> = []

--- a/packages/agents-runtime/src/context-assembly.ts
+++ b/packages/agents-runtime/src/context-assembly.ts
@@ -313,13 +313,6 @@ export async function assembleContext(
     }
   }
 
-  // Preserve volatile source order. Volatile sources such as
-  // ctx.timelineMessages() may return a model-facing transcript order that
-  // intentionally differs from raw stream-offset order, e.g. interrupted run
-  // output before the SIGINT marker that raced ahead of buffered runtime
-  // writes. `at` remains metadata for truncation ranges and load tools, but it
-  // must not globally reorder already-projected context.
-
   const remainingBudget = Math.max(0, config.sourceBudget - budgetUsed)
   const accepted: Array<VolatileMessage> = []
   const droppedOffsets: Array<number> = []

--- a/packages/agents-runtime/test/use-context-volatile-interleave.test.ts
+++ b/packages/agents-runtime/test/use-context-volatile-interleave.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { assembleContext } from '../src/context-assembly'
 
 describe(`volatile interleave`, () => {
-  it(`merges volatile sources by at`, async () => {
+  it(`preserves volatile source order and per-source message order`, async () => {
     const messages = await assembleContext({
       sourceBudget: 10_000,
       sources: {
@@ -27,9 +27,37 @@ describe(`volatile interleave`, () => {
 
     expect(messages.map((message) => message.content)).toEqual([
       `A1`,
-      `B3`,
       `A5`,
+      `B3`,
       `B7`,
+    ])
+  })
+
+  it(`preserves semantic order returned by a volatile source when at values race`, async () => {
+    const messages = await assembleContext({
+      sourceBudget: 10_000,
+      sources: {
+        conversation: {
+          content: () => [
+            { role: `user` as const, content: `start`, at: 1 },
+            { role: `assistant` as const, content: `partial`, at: 3 },
+            {
+              role: `user` as const,
+              content: `<agent_signal signal="SIGINT" />`,
+              at: 2,
+            },
+            { role: `user` as const, content: `continue`, at: 4 },
+          ],
+          cache: `volatile`,
+        },
+      },
+    })
+
+    expect(messages.map((message) => message.content)).toEqual([
+      `start`,
+      `partial`,
+      `<agent_signal signal="SIGINT" />`,
+      `continue`,
     ])
   })
 })

--- a/packages/agents-runtime/test/use-context-volatile-interleave.test.ts
+++ b/packages/agents-runtime/test/use-context-volatile-interleave.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { assembleContext } from '../src/context-assembly'
-import {
-  defaultProjection,
-  materializeTimeline,
-} from '../src/timeline-context'
+import { defaultProjection, materializeTimeline } from '../src/timeline-context'
 import type {
   IncludesInboxMessage,
   IncludesRun,
@@ -48,9 +45,7 @@ describe(`volatile interleave`, () => {
       sourceBudget: 10_000,
       sources: {
         alpha: {
-          content: () => [
-            { role: `user` as const, content: `A1`, at: 9 },
-          ],
+          content: () => [{ role: `user` as const, content: `A1`, at: 9 }],
           max: 1_000,
           cache: `volatile`,
         },
@@ -63,9 +58,7 @@ describe(`volatile interleave`, () => {
           cache: `volatile`,
         },
         gamma: {
-          content: () => [
-            { role: `user` as const, content: `C1`, at: 1 },
-          ],
+          content: () => [{ role: `user` as const, content: `C1`, at: 1 }],
           max: 1_000,
           cache: `volatile`,
         },

--- a/packages/agents-runtime/test/use-context-volatile-interleave.test.ts
+++ b/packages/agents-runtime/test/use-context-volatile-interleave.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { assembleContext } from '../src/context-assembly'
+import {
+  defaultProjection,
+  materializeTimeline,
+} from '../src/timeline-context'
+import type {
+  IncludesInboxMessage,
+  IncludesRun,
+  IncludesSignal,
+} from '../src/entity-timeline'
 
 describe(`volatile interleave`, () => {
   it(`preserves volatile source order and per-source message order`, async () => {
@@ -31,6 +40,45 @@ describe(`volatile interleave`, () => {
       `B3`,
       `B7`,
     ])
+    expect(messages.map((message) => message.at)).toEqual([1, 5, 3, 7])
+  })
+
+  it(`concatenates three volatile sources in registration order`, async () => {
+    const messages = await assembleContext({
+      sourceBudget: 10_000,
+      sources: {
+        alpha: {
+          content: () => [
+            { role: `user` as const, content: `A1`, at: 9 },
+          ],
+          max: 1_000,
+          cache: `volatile`,
+        },
+        beta: {
+          content: () => [
+            { role: `user` as const, content: `B1`, at: 2 },
+            { role: `user` as const, content: `B2`, at: 4 },
+          ],
+          max: 1_000,
+          cache: `volatile`,
+        },
+        gamma: {
+          content: () => [
+            { role: `user` as const, content: `C1`, at: 1 },
+          ],
+          max: 1_000,
+          cache: `volatile`,
+        },
+      },
+    })
+
+    expect(messages.map((message) => message.content)).toEqual([
+      `A1`,
+      `B1`,
+      `B2`,
+      `C1`,
+    ])
+    expect(messages.map((message) => message.at)).toEqual([9, 2, 4, 1])
   })
 
   it(`preserves semantic order returned by a volatile source when at values race`, async () => {
@@ -59,5 +107,92 @@ describe(`volatile interleave`, () => {
       `<agent_signal signal="SIGINT" />`,
       `continue`,
     ])
+    expect(messages.map((message) => message.at)).toEqual([1, 3, 2, 4])
+  })
+
+  it(`end-to-end: timeline SIGINT reorder survives assembleContext`, async () => {
+    function order(index: number): string {
+      return index.toString().padStart(20, `0`)
+    }
+
+    const inbox: Array<IncludesInboxMessage> = [
+      {
+        key: `msg-1`,
+        order: order(1),
+        from: `user`,
+        payload: `start`,
+        timestamp: `2026-06-01T00:00:00.000Z`,
+      },
+      {
+        key: `msg-2`,
+        order: order(4),
+        from: `user`,
+        payload: `continue`,
+        timestamp: `2026-06-01T00:00:03.000Z`,
+      },
+    ]
+    const signals: Array<IncludesSignal> = [
+      {
+        key: `sig-1`,
+        order: order(2),
+        signal: `SIGINT`,
+        status: `handled`,
+        timestamp: `2026-06-01T00:00:02.000Z`,
+        outcome: `aborted`,
+      },
+    ]
+    const runs: Array<IncludesRun> = [
+      {
+        key: `run-1`,
+        order: order(3),
+        status: `completed`,
+        finish_reason: `aborted`,
+        texts: [
+          {
+            key: `text-1`,
+            run_id: `run-1`,
+            order: order(5),
+            status: `completed`,
+            text: `partial response`,
+          },
+        ],
+        toolCalls: [],
+        steps: [],
+        errors: [],
+      },
+    ]
+
+    const timelineItems = materializeTimeline({
+      runs,
+      inbox,
+      wakes: [],
+      signals,
+      contextInserted: [],
+      contextRemoved: [],
+      entities: [],
+    })
+
+    const volatileContent = timelineItems.flatMap((item) => {
+      const msgs = defaultProjection(item) ?? []
+      return msgs.map((m) => ({ ...m, at: item.at }))
+    })
+
+    const messages = await assembleContext({
+      sourceBudget: 10_000,
+      sources: {
+        conversation: {
+          content: () => volatileContent,
+          cache: `volatile`,
+        },
+      },
+    })
+
+    expect(messages.map((m) => m.content)).toEqual([
+      `start`,
+      `partial response`,
+      expect.stringContaining(`SIGINT`),
+      `continue`,
+    ])
+    expect(messages.map((m) => m.at)).toEqual([1, 3, 2, 4])
   })
 })


### PR DESCRIPTION
## Summary

Remove a global `.sort()` by `at` timestamp in `assembleContext()` that was undoing the semantic reordering performed by `reorderInterruptedRuns()`. When SIGINT races ahead of buffered runtime writes, the interrupted assistant run now correctly appears before the interrupt marker in the model transcript.

## Root Cause

`assembleContext()` collected volatile messages from all sources, then globally sorted them by their `at` (stream offset) value. Meanwhile, `reorderInterruptedRuns()` in the timeline layer intentionally reorders aborted runs before the SIGINT signal that raced ahead of them—giving the model a coherent transcript where the partial response precedes the interruption.

The global sort undid this reordering: the SIGINT (lower offset, because it's appended directly by the server) was placed before the aborted run output (higher offset, because it's buffered through the runtime producer). The model then saw an interruption marker before any assistant output, breaking transcript coherence.

## Approach

Remove the `volatileMessages.sort()` call entirely. Volatile sources already return messages in their intended order—`timelineMessages()` projects through `materializeTimeline()` → `reorderInterruptedRuns()` to produce the correct model-facing sequence. The `at` field is preserved as metadata for budget truncation ranges and load tools, but no longer drives global ordering.

**Key invariant**: volatile messages appear in source-registration order (all messages from source A, then all from source B, etc.), with each source's internal order preserved exactly as returned.

**Trade-off**: budget truncation under pressure now drops messages from earlier-registered sources first (instead of oldest-by-timestamp first). This is the intended behavior—source ordering is more semantically meaningful than raw stream offsets.

## Non-goals

- The CI hardening commit (`2a95b8a17`) is bundled here but independent—it adds CODEOWNERS for `.github/`, fork-PR guards on benchmarking/load-test workflows, and least-privilege permission tightening.

## Verification

```bash
cd packages/agents-runtime
pnpm vitest run test/use-context-volatile-interleave.test.ts
pnpm vitest run test/timeline-context.test.ts
```

## Files changed

| File | Change |
|------|--------|
| `packages/agents-runtime/src/context-assembly.ts` | Remove `volatileMessages.sort()` call |
| `packages/agents-runtime/test/use-context-volatile-interleave.test.ts` | Update existing test expectations, add `at` assertions, three-source ordering test, and end-to-end integration test wiring `materializeTimeline` through `assembleContext` |
| `.github/CODEOWNERS` | Require admin review for `.github/` changes |
| `.github/workflows/benchmarking.yml` | Drop CONTRIBUTOR from trigger, add fork-PR guard |
| `.github/workflows/load_test.yml` | Add fork-PR guard |
| `.github/workflows/ts_tests.yml` | Downgrade `packages: write` → `read` |
| `.github/workflows/changesets_release.yml` | Remove `cache: pnpm` from setup-node |
| `.changeset/fix-sigint-context-order.md` | Changeset for `@electric-ax/agents-runtime` patch |