### PR TITLE
fix: defer logger initialization to prevent /logs crash on macOS desktop

### DIFF
--- a/.changeset/fix-desktop-logs-crash.md
+++ b/.changeset/fix-desktop-logs-crash.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents': patch
+'@electric-ax/agents-server': patch
+---
+
+Defer logger initialization to first use so packaged Electron apps (where cwd is `/`) no longer crash trying to `mkdir '/logs'`. Logger init is now wrapped in try-catch with stderr fallback so logging infrastructure never throws. Add `ELECTRIC_AGENTS_LOG_FILE=false` escape hatch to the agents package for parity with agents-server.

--- a/packages/agents-server/src/utils/log.ts
+++ b/packages/agents-server/src/utils/log.ts
@@ -8,62 +8,73 @@ const USE_FILE_LOGS = process.env.ELECTRIC_AGENTS_LOG_FILE !== `false`
 const USE_PRETTY_LOGS =
   LOG_LEVEL !== `silent` && !process.env.VITEST && !IS_ELECTRON_MAIN
 
-const LOG_DIR = USE_FILE_LOGS
-  ? (process.env.ELECTRIC_AGENTS_LOG_DIR ?? path.resolve(process.cwd(), `logs`))
-  : undefined
-const LOG_FILE = LOG_DIR
-  ? path.join(LOG_DIR, `agent-server-${Date.now()}.jsonl`)
-  : undefined
+let _logger: pino.Logger | undefined
 
-if (LOG_DIR) {
-  fs.mkdirSync(LOG_DIR, { recursive: true })
-}
+function getLogger(): pino.Logger {
+  if (_logger) return _logger
 
-export const LOG_FILE_PATH = LOG_FILE
+  const streams: Array<pino.StreamEntry> = []
 
-const streams: Array<pino.StreamEntry> = []
-if (LOG_FILE) {
-  streams.push({
-    stream: pino.destination({
-      dest: LOG_FILE,
-      sync: IS_ELECTRON_MAIN,
-    }),
-  })
-}
-if (USE_PRETTY_LOGS) {
-  streams.push({
-    stream: pino.transport({
-      target: `pino-pretty`,
-      options: {
-        colorize: true,
-        ignore: `pid,hostname,name`,
-        translateTime: `SYS:HH:MM:ss`,
-      },
-    }),
-  })
-}
-
-const logger =
-  streams.length > 0
-    ? pino(
-        {
-          base: undefined,
-          level: LOG_LEVEL,
-        },
-        pino.multistream(streams)
-      )
-    : pino({
-        base: undefined,
-        enabled: false,
-        level: LOG_LEVEL,
+  try {
+    if (USE_FILE_LOGS) {
+      const logDir =
+        process.env.ELECTRIC_AGENTS_LOG_DIR ??
+        path.resolve(process.cwd(), `logs`)
+      fs.mkdirSync(logDir, { recursive: true })
+      const logFile = path.join(logDir, `agent-server-${Date.now()}.jsonl`)
+      streams.push({
+        stream: pino.destination({
+          dest: logFile,
+          sync: IS_ELECTRON_MAIN,
+        }),
       })
+    }
+  } catch (err) {
+    process.stderr.write(
+      `[agents-server] Failed to initialize file logging: ${err instanceof Error ? err.message : err}\n`
+    )
+  }
+
+  try {
+    if (USE_PRETTY_LOGS) {
+      streams.push({
+        stream: pino.transport({
+          target: `pino-pretty`,
+          options: {
+            colorize: true,
+            ignore: `pid,hostname,name`,
+            translateTime: `SYS:HH:MM:ss`,
+          },
+        }),
+      })
+    }
+  } catch {
+    // pino-pretty unavailable — continue without pretty logging
+  }
+
+  _logger =
+    streams.length > 0
+      ? pino(
+          {
+            base: undefined,
+            level: LOG_LEVEL,
+          },
+          pino.multistream(streams)
+        )
+      : pino({
+          base: undefined,
+          enabled: false,
+          level: LOG_LEVEL,
+        })
+  return _logger
+}
 
 function formatArgs(args: Array<unknown>): { err?: Error; msg: string } {
   const errors: Array<Error> = []
   const parts: Array<string> = []
-  for (const a of args) {
-    if (a instanceof Error) errors.push(a)
-    else parts.push(typeof a === `string` ? a : JSON.stringify(a))
+  for (const value of args) {
+    if (value instanceof Error) errors.push(value)
+    else parts.push(typeof value === `string` ? value : JSON.stringify(value))
   }
   return {
     err: errors[0],
@@ -74,22 +85,22 @@ function formatArgs(args: Array<unknown>): { err?: Error; msg: string } {
 export const serverLog = {
   info(...args: Array<unknown>): void {
     const { msg } = formatArgs(args)
-    logger.info(msg)
+    getLogger().info(msg)
   },
 
   warn(...args: Array<unknown>): void {
     const { err, msg } = formatArgs(args)
-    if (err) logger.warn({ err }, msg)
-    else logger.warn(msg)
+    if (err) getLogger().warn({ err }, msg)
+    else getLogger().warn(msg)
   },
 
   error(...args: Array<unknown>): void {
     const { err, msg } = formatArgs(args)
-    if (err) logger.error({ err }, msg)
-    else logger.error(msg)
+    if (err) getLogger().error({ err }, msg)
+    else getLogger().error(msg)
   },
 
   event(obj: Record<string, unknown>, msg: string): void {
-    logger.info(obj, msg)
+    getLogger().info(obj, msg)
   },
 }

--- a/packages/agents/src/log.ts
+++ b/packages/agents/src/log.ts
@@ -2,44 +2,72 @@ import path from 'node:path'
 import fs from 'node:fs'
 import pino from 'pino'
 
-const LOG_DIR =
-  process.env.ELECTRIC_AGENTS_LOG_DIR ?? path.resolve(process.cwd(), `logs`)
-fs.mkdirSync(LOG_DIR, { recursive: true })
-
-const LOG_FILE = path.join(LOG_DIR, `builtin-agents-${Date.now()}.jsonl`)
 const LOG_LEVEL = process.env.ELECTRIC_AGENTS_LOG_LEVEL ?? `info`
 const IS_ELECTRON_MAIN = Boolean(process.versions.electron)
+const USE_FILE_LOGS = process.env.ELECTRIC_AGENTS_LOG_FILE !== `false`
 const USE_PRETTY_LOGS =
   LOG_LEVEL !== `silent` && !process.env.VITEST && !IS_ELECTRON_MAIN
 
-const streams: Array<pino.StreamEntry> = [
-  {
-    stream: pino.destination({
-      dest: LOG_FILE,
-      sync: IS_ELECTRON_MAIN,
-    }),
-  },
-]
-if (USE_PRETTY_LOGS) {
-  streams.push({
-    stream: pino.transport({
-      target: `pino-pretty`,
-      options: {
-        colorize: true,
-        ignore: `pid,hostname,name`,
-        translateTime: `SYS:HH:MM:ss`,
-      },
-    }),
-  })
-}
+let _logger: pino.Logger | undefined
 
-const logger = pino(
-  {
-    base: undefined,
-    level: LOG_LEVEL,
-  },
-  pino.multistream(streams)
-)
+function getLogger(): pino.Logger {
+  if (_logger) return _logger
+
+  const streams: Array<pino.StreamEntry> = []
+
+  try {
+    if (USE_FILE_LOGS) {
+      const logDir =
+        process.env.ELECTRIC_AGENTS_LOG_DIR ??
+        path.resolve(process.cwd(), `logs`)
+      fs.mkdirSync(logDir, { recursive: true })
+      const logFile = path.join(logDir, `builtin-agents-${Date.now()}.jsonl`)
+      streams.push({
+        stream: pino.destination({
+          dest: logFile,
+          sync: IS_ELECTRON_MAIN,
+        }),
+      })
+    }
+  } catch (err) {
+    process.stderr.write(
+      `[agents] Failed to initialize file logging: ${err instanceof Error ? err.message : err}\n`
+    )
+  }
+
+  try {
+    if (USE_PRETTY_LOGS) {
+      streams.push({
+        stream: pino.transport({
+          target: `pino-pretty`,
+          options: {
+            colorize: true,
+            ignore: `pid,hostname,name`,
+            translateTime: `SYS:HH:MM:ss`,
+          },
+        }),
+      })
+    }
+  } catch {
+    // pino-pretty unavailable — continue without pretty logging
+  }
+
+  _logger =
+    streams.length > 0
+      ? pino(
+          {
+            base: undefined,
+            level: LOG_LEVEL,
+          },
+          pino.multistream(streams)
+        )
+      : pino({
+          base: undefined,
+          enabled: false,
+          level: LOG_LEVEL,
+        })
+  return _logger
+}
 
 function formatArgs(args: Array<unknown>): { err?: Error; msg: string } {
   const errors: Array<Error> = []
@@ -57,27 +85,27 @@ function formatArgs(args: Array<unknown>): { err?: Error; msg: string } {
 export const serverLog = {
   debug(...args: Array<unknown>): void {
     const { msg } = formatArgs(args)
-    logger.debug(msg)
+    getLogger().debug(msg)
   },
 
   info(...args: Array<unknown>): void {
     const { msg } = formatArgs(args)
-    logger.info(msg)
+    getLogger().info(msg)
   },
 
   warn(...args: Array<unknown>): void {
     const { err, msg } = formatArgs(args)
-    if (err) logger.warn({ err }, msg)
-    else logger.warn(msg)
+    if (err) getLogger().warn({ err }, msg)
+    else getLogger().warn(msg)
   },
 
   error(...args: Array<unknown>): void {
     const { err, msg } = formatArgs(args)
-    if (err) logger.error({ err }, msg)
-    else logger.error(msg)
+    if (err) getLogger().error({ err }, msg)
+    else getLogger().error(msg)
   },
 
   event(obj: Record<string, unknown>, msg: string): void {
-    logger.info(obj, msg)
+    getLogger().info(obj, msg)
   },
 }


### PR DESCRIPTION
## Summary

Fixes a crash on macOS where the packaged desktop app tries to `mkdir '/logs'` at startup, caused by module-level `mkdirSync` running before the desktop has a chance to set `ELECTRIC_AGENTS_LOG_DIR`.

## Root Cause

Packaged Electron apps on macOS launch with `process.cwd() === '/'`. Both `packages/agents/src/log.ts` and `packages/agents-server/src/utils/log.ts` called `fs.mkdirSync(path.resolve(process.cwd(), 'logs'))` at **module load time**. The desktop's `configureRuntimeEnvironment()` sets `ELECTRIC_AGENTS_LOG_DIR` to `~/Library/Application Support/Electric Agents/logs`, but static imports resolve before any module-level code in `main.ts` executes — so the `mkdirSync('/logs')` fires first and crashes.

## Approach

- Move all logger initialization (directory creation, pino setup) into a lazy `getLogger()` that runs on the first actual log call, after `configureRuntimeEnvironment()` has set the env var.
- Wrap file-logging init and `pino.transport()` in separate try-catch blocks so logging infrastructure never throws — if file logging fails, a warning goes to stderr and the process continues with console-only (or disabled) logging. This prevents cascading failures when `serverLog.error()` is called inside catch blocks.
- Add `ELECTRIC_AGENTS_LOG_FILE=false` support to the `agents` package for parity with `agents-server`.
- Remove unused `LOG_FILE_PATH` export from `agents-server`.

## Key Invariants

- `getLogger()` is a synchronous singleton — `_logger` is assigned exactly once, all subsequent calls return the cached instance.
- `mkdirSync` and `pino.destination()` only run inside `getLogger()`, never at module scope.
- Logger methods never throw — if init fails, the fallback is a disabled pino logger.

## Non-goals

- No changes to `configureRuntimeEnvironment()` in the desktop — the lazy init is the correct fix since it removes the ordering dependency entirely.
- No changes to `agents-runtime/src/log.ts` — it doesn't use file logging and wasn't affected.

## Verification

```bash
pnpm --filter @electric-ax/agents exec tsc --noEmit
pnpm --filter @electric-ax/agents-server exec tsc --noEmit
```

## Files changed

| File | Change |
|------|--------|
| `packages/agents/src/log.ts` | Lazy `getLogger()`, try-catch fallback, add `USE_FILE_LOGS` toggle |
| `packages/agents-server/src/utils/log.ts` | Lazy `getLogger()`, try-catch fallback, remove unused `LOG_FILE_PATH` export |

🤖 Generated with [Claude Code](https://claude.com/claude-code)