### PR TITLE
Fix dropdowns over pane headers

### DIFF
--- a/.changeset/chatty-moles-hang.md
+++ b/.changeset/chatty-moles-hang.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-server-ui": patch
+---
+
+Keep shared dropdown overlays clickable when they overlap desktop pane titlebar regions.

--- a/packages/agents-server-ui/src/ui/Combobox.tsx
+++ b/packages/agents-server-ui/src/ui/Combobox.tsx
@@ -110,6 +110,7 @@ function Content({
   return (
     <BaseCombobox.Portal>
       <BaseCombobox.Positioner
+        className={popoverStyles.positioner}
         side={side}
         align={align}
         sideOffset={sideOffset}

--- a/packages/agents-server-ui/src/ui/HoverCard.tsx
+++ b/packages/agents-server-ui/src/ui/HoverCard.tsx
@@ -122,6 +122,7 @@ function Content({
   return (
     <BasePreviewCard.Portal>
       <BasePreviewCard.Positioner
+        className={popoverStyles.positioner}
         side={side}
         align={align}
         sideOffset={sideOffset}

--- a/packages/agents-server-ui/src/ui/Menu.tsx
+++ b/packages/agents-server-ui/src/ui/Menu.tsx
@@ -64,6 +64,7 @@ function Content({
   return (
     <BaseMenu.Portal>
       <BaseMenu.Positioner
+        className={popoverStyles.positioner}
         side={side}
         align={align}
         sideOffset={sideOffset}

--- a/packages/agents-server-ui/src/ui/Popover.module.css
+++ b/packages/agents-server-ui/src/ui/Popover.module.css
@@ -1,6 +1,15 @@
 /* Shared popup card style for Popover / HoverCard / Menu / Select.
    Keep selectors generic so each wrapper can add only the bits it needs. */
 
+.positioner {
+  z-index: var(--ds-z-popover);
+  /* Popups are portaled to <body>, but in the desktop shell they can
+     visually overlap a pane header marked as a draggable titlebar region.
+     Mark the positioned overlay subtree as no-drag so Electron doesn't
+     let that underlying header swallow clicks on menu items. */
+  -webkit-app-region: no-drag;
+}
+
 .popup {
   background: var(--ds-surface-raised);
   color: var(--ds-text-1);

--- a/packages/agents-server-ui/src/ui/Popover.tsx
+++ b/packages/agents-server-ui/src/ui/Popover.tsx
@@ -60,6 +60,7 @@ function Content({
   return (
     <BasePopover.Portal>
       <BasePopover.Positioner
+        className={styles.positioner}
         side={side}
         align={align}
         sideOffset={sideOffset}

--- a/packages/agents-server-ui/src/ui/Select.tsx
+++ b/packages/agents-server-ui/src/ui/Select.tsx
@@ -151,7 +151,10 @@ function Content({
     .join(` `)
   return (
     <BaseSelect.Portal>
-      <BaseSelect.Positioner sideOffset={6}>
+      <BaseSelect.Positioner
+        className={popoverStyles.positioner}
+        sideOffset={6}
+      >
         <BaseSelect.Popup className={cls} style={style}>
           <BaseSelect.List className={styles.list}>{children}</BaseSelect.List>
         </BaseSelect.Popup>


### PR DESCRIPTION
## Summary
- put shared popup positioners above pane chrome with the popover z-index token
- mark popup positioners as Electron no-drag so pane titlebar drag regions don’t swallow clicks
- apply the fix to Select, Combobox, Menu, Popover, and HoverCard overlays

## Testing
- pnpm exec prettier --write packages/agents-server-ui/src/ui/Select.tsx packages/agents-server-ui/src/ui/Combobox.tsx packages/agents-server-ui/src/ui/Menu.tsx packages/agents-server-ui/src/ui/Popover.tsx packages/agents-server-ui/src/ui/HoverCard.tsx packages/agents-server-ui/src/ui/Popover.module.css
- git diff --check

Note: package typecheck was attempted but currently fails on unrelated workspace dependency/type resolution issues in this worktree (missing React/TanStack modules and agents-runtime durable-streams API mismatches).