### PR TITLE
Fix stale Codex auth state in desktop

### DIFF
--- a/.changeset/fix-codex-stale-auth.md
+++ b/.changeset/fix-codex-stale-auth.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-desktop': patch
+---
+
+Clear stale Codex auth in the desktop app when no usable access token can be produced, preventing the UI from showing Codex as enabled while runs cannot authenticate.

--- a/packages/agents-desktop/src/credentials/codex-auth.ts
+++ b/packages/agents-desktop/src/credentials/codex-auth.ts
@@ -283,19 +283,44 @@ async function refreshCodexAuthIfNeeded(
   return next
 }
 
+async function clearCodexAuth(
+  deps: Pick<
+    CodexAuthDeps,
+    `settings` | `getSecretStore` | `saveSettings` | `markCredentialsDirty`
+  >
+): Promise<void> {
+  deps.settings.codex = { enabled: false, source: null }
+  await deps.getSecretStore().delete(CODEX_AUTH_REF)
+  await deps.saveSettings()
+  deps.markCredentialsDirty()
+}
+
 export async function syncCodexEnvironment(
-  deps: Pick<CodexAuthDeps, `settings` | `getSecretStore`>
+  deps: Pick<
+    CodexAuthDeps,
+    `settings` | `getSecretStore` | `saveSettings` | `markCredentialsDirty`
+  >
 ): Promise<void> {
   process.env.ELECTRIC_CODEX_REQUIRE_OPT_IN = `1`
   delete process.env.ELECTRIC_CODEX_ACCESS_TOKEN
   const codex = deps.settings.codex ?? { enabled: false, source: null }
   if (!codex.enabled || !codex.source) return
+
   const stored = await loadStoredCodexAuth(deps)
-  if (!stored) return
-  const refreshed = await refreshCodexAuthIfNeeded(deps, stored)
+  const refreshed =
+    stored?.source === codex.source
+      ? await refreshCodexAuthIfNeeded(deps, stored)
+      : null
   if (refreshed?.access) {
     process.env.ELECTRIC_CODEX_ACCESS_TOKEN = refreshed.access
+    return
   }
+
+  // Avoid showing a false "Enabled" state when no usable access token can be
+  // produced. Desktop OAuth tokens should refresh through the OAuth token
+  // endpoint above; stale tokens imported from CLI/opencode auth files should be
+  // deleted rather than repeatedly trusted as an enabled desktop credential.
+  await clearCodexAuth(deps)
 }
 
 async function detectCodexSources(

--- a/packages/agents-desktop/src/credentials/codex-auth.ts
+++ b/packages/agents-desktop/src/credentials/codex-auth.ts
@@ -283,24 +283,14 @@ async function refreshCodexAuthIfNeeded(
   return next
 }
 
-async function clearCodexAuth(
-  deps: Pick<
-    CodexAuthDeps,
-    `settings` | `getSecretStore` | `saveSettings` | `markCredentialsDirty`
-  >
-): Promise<void> {
+async function clearCodexAuth(deps: CodexAuthDeps): Promise<void> {
   deps.settings.codex = { enabled: false, source: null }
   await deps.getSecretStore().delete(CODEX_AUTH_REF)
   await deps.saveSettings()
   deps.markCredentialsDirty()
 }
 
-export async function syncCodexEnvironment(
-  deps: Pick<
-    CodexAuthDeps,
-    `settings` | `getSecretStore` | `saveSettings` | `markCredentialsDirty`
-  >
-): Promise<void> {
+export async function syncCodexEnvironment(deps: CodexAuthDeps): Promise<void> {
   process.env.ELECTRIC_CODEX_REQUIRE_OPT_IN = `1`
   delete process.env.ELECTRIC_CODEX_ACCESS_TOKEN
   const codex = deps.settings.codex ?? { enabled: false, source: null }


### PR DESCRIPTION
## Summary
- clear stale Codex desktop auth when no usable access token can be produced
- keep desktop OAuth refresh as the only refresh path for stored credentials
- avoid showing Codex as enabled when the runtime cannot set ELECTRIC_CODEX_ACCESS_TOKEN

## Test
- pnpm --filter @electric-ax/agents-desktop typecheck