### PR TITLE
Fix self-send wake rendering

### DIFF
--- a/.changeset/self-send-wake-rendering.md
+++ b/.changeset/self-send-wake-rendering.md
@@ -1,0 +1,7 @@
+---
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents-server': patch
+'@electric-ax/agents-server-ui': patch
+---
+
+Render self-send wake notifications with the sent message payload in the agent timeline.

--- a/packages/agents-runtime/src/entity-schema.ts
+++ b/packages/agents-runtime/src/entity-schema.ts
@@ -79,6 +79,10 @@ type WakeChangeEntryValue = {
   collection: string
   kind: `insert` | `update` | `delete`
   key: string
+  from?: string
+  payload?: unknown
+  timestamp?: string
+  message_type?: string
 }
 type WakeFinishedChildEntryValue = {
   url: string
@@ -370,6 +374,10 @@ function createWakeChangeSchema(): Schema<WakeChangeEntryValue> {
     collection: z.string(),
     kind: z.enum([`insert`, `update`, `delete`]),
     key: z.string(),
+    from: z.string().optional(),
+    payload: z.unknown().optional(),
+    timestamp: z.string().optional(),
+    message_type: z.string().optional(),
   })
 }
 

--- a/packages/agents-server-ui/src/components/EntityTimeline.tsx
+++ b/packages/agents-server-ui/src/components/EntityTimeline.tsx
@@ -258,8 +258,40 @@ function timelineRowLabel(row: RenderTimelineRow): string {
   return `Agent response`
 }
 
-function wakeReason(section: WakeSection): string {
+function firstSelfSendWakeChange(
+  section: WakeSection,
+  entityUrl?: string | null
+): WakeSection[`payload`][`changes`][number] | null {
+  if (!entityUrl || section.payload.source !== entityUrl) return null
+  return (
+    section.payload.changes.find((change) => change.collection === `inbox`) ??
+    null
+  )
+}
+
+function isSelfSendWake(
+  section: WakeSection,
+  entityUrl?: string | null
+): boolean {
+  return firstSelfSendWakeChange(section, entityUrl) !== null
+}
+
+function wakeSelfSendMessage(
+  section: WakeSection,
+  entityUrl?: string | null
+): string | null {
+  const change = firstSelfSendWakeChange(section, entityUrl)
+  if (!change) return null
+  const payload = change.payload
+  if (payload == null) return ``
+  return typeof payload === `string`
+    ? payload
+    : JSON.stringify(payload, null, 2)
+}
+
+function wakeReason(section: WakeSection, entityUrl?: string | null): string {
   const { payload } = section
+  if (isSelfSendWake(section, entityUrl)) return `sent to itself`
   if (payload.timeout) return `timeout`
   if (payload.finished_child) {
     return `child ${payload.finished_child.run_status}`
@@ -273,10 +305,13 @@ function wakeReason(section: WakeSection): string {
   return payload.source
 }
 
-function wakeSectionText(section: WakeSection): string {
+function wakeSectionText(
+  section: WakeSection,
+  entityUrl?: string | null
+): string {
   return [
     `woke`,
-    wakeReason(section),
+    wakeReason(section, entityUrl),
     section.payload.source,
     ...wakeDetails(section).map((detail) => `${detail.label} ${detail.value}`),
   ].join(` `)
@@ -284,12 +319,15 @@ function wakeSectionText(section: WakeSection): string {
 
 function WakeTimelineRow({
   section,
+  entityUrl,
 }: {
   section: WakeSection
+  entityUrl?: string | null
 }): React.ReactElement {
-  const reason = wakeReason(section)
-  const details = wakeDetails(section)
+  const reason = wakeReason(section, entityUrl)
+  const details = wakeDetails(section, entityUrl)
   const childOutput = wakeChildOutput(section)
+  const selfSendMessage = wakeSelfSendMessage(section, entityUrl)
   return (
     <div className={styles.manifestRow}>
       <InlineEventCard
@@ -307,6 +345,9 @@ function WakeTimelineRow({
             </div>
           ))}
         </div>
+        {selfSendMessage ? (
+          <pre className={styles.manifestJson}>{selfSendMessage}</pre>
+        ) : null}
         {childOutput ? (
           <pre className={styles.manifestJson}>{childOutput.value}</pre>
         ) : null}
@@ -364,14 +405,27 @@ function signalSummary(
 }
 
 function wakeDetails(
-  section: WakeSection
+  section: WakeSection,
+  entityUrl?: string | null
 ): Array<{ label: string; value: string }> {
   const { payload } = section
+  const selfSendChange = firstSelfSendWakeChange(section, entityUrl)
   const details = [
     { label: `Source`, value: payload.source },
-    { label: `Trigger`, value: wakeReason(section) },
+    { label: `Trigger`, value: wakeReason(section, entityUrl) },
     { label: `Time`, value: formatAbsoluteDateTimeVerbose(section.timestamp) },
   ]
+
+  if (selfSendChange) {
+    details.push({
+      label: `From`,
+      value: selfSendChange.from ?? payload.source,
+    })
+    const message = wakeSelfSendMessage(section, entityUrl)
+    if (message) {
+      details.push({ label: `Message`, value: message })
+    }
+  }
 
   if (payload.changes.length > 0) {
     details.push({
@@ -845,6 +899,7 @@ const TimelineRow = memo(function TimelineRow({
           payload: row.wake.payload,
           timestamp: Date.parse(row.wake.payload.timestamp),
         }}
+        entityUrl={entityUrl}
       />
     )
   }

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -41,6 +41,10 @@ export interface WakeEvalResult {
       collection: string
       kind: `insert` | `update` | `delete`
       key: string
+      from?: string
+      payload?: unknown
+      timestamp?: string
+      message_type?: string
     }>
   }
   runFinishedStatus?: `completed` | `failed`
@@ -885,11 +889,7 @@ export class WakeRegistry {
     reg: WakeRegistration,
     event: Record<string, unknown>
   ): {
-    change: {
-      collection: string
-      kind: `insert` | `update` | `delete`
-      key: string
-    }
+    change: WakeEvalResult[`wakeMessage`][`changes`][number]
     runFinishedStatus?: `completed` | `failed`
   } | null {
     if (reg.condition === `runFinished`) {
@@ -935,12 +935,23 @@ export class WakeRegistry {
       return null
     }
 
-    return {
-      change: {
-        collection: eventType,
-        kind,
-        key: (event.key as string) || ``,
-      },
+    const change: WakeEvalResult[`wakeMessage`][`changes`][number] = {
+      collection: eventType,
+      kind,
+      key: (event.key as string) || ``,
     }
+
+    if (eventType === `inbox`) {
+      const value = event.value as Record<string, unknown> | undefined
+      if (typeof value?.from === `string`) change.from = value.from
+      if (`payload` in (value ?? {})) change.payload = value?.payload
+      if (typeof value?.timestamp === `string`)
+        change.timestamp = value.timestamp
+      if (typeof value?.message_type === `string`) {
+        change.message_type = value.message_type
+      }
+    }
+
+    return { change }
   }
 }

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -277,6 +277,39 @@ describe(`Wake Registry`, () => {
     expect(results[0]!.wakeMessage.changes[0]!.kind).toBe(`insert`)
   })
 
+  it(`includes inbox message details in wake changes`, async () => {
+    const registry = new WakeRegistry(createMockDb())
+    await registry.register({
+      subscriberUrl: `/agent/self`,
+      sourceUrl: `/agent/self`,
+      condition: { on: `change`, collections: [`inbox`] },
+      oneShot: false,
+    })
+
+    const results = registry.evaluate(`/agent/self`, {
+      type: `inbox`,
+      key: `msg-1`,
+      value: {
+        from: `/principal/agent%3Aself`,
+        payload: { text: `wake up` },
+        timestamp: `2026-01-01T00:00:00.000Z`,
+        message_type: `reminder`,
+      },
+      headers: { operation: `insert` },
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]!.wakeMessage.changes[0]).toEqual({
+      collection: `inbox`,
+      kind: `insert`,
+      key: `msg-1`,
+      from: `/principal/agent%3Aself`,
+      payload: { text: `wake up` },
+      timestamp: `2026-01-01T00:00:00.000Z`,
+      message_type: `reminder`,
+    })
+  })
+
   it(`ignores events for non-matching collections`, async () => {
     const registry = new WakeRegistry(createMockDb())
     await registry.register({


### PR DESCRIPTION
## Summary
- include inbox message details in wake changes so wake events can render sent messages
- detect self-send inbox wakes in the entity timeline and label them as sent to itself
- render the self-send payload in the wake row
- add coverage for inbox wake change details

## Verification
- pnpm --filter @electric-ax/agents-server-ui typecheck
- pnpm --filter @electric-ax/agents-server typecheck
- cd packages/agents-server && pnpm exec vitest run test/wake-registry.test.ts -t "includes inbox message details" --run

Note: the full wake-registry test command exceeded the tool timeout in this environment.