### PR TITLE
Render markdown in inbox messages

### DIFF
--- a/.changeset/quiet-inboxes-link.md
+++ b/.changeset/quiet-inboxes-link.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-server-ui": patch
+---
+
+Render lightweight markdown links and formatting in inbox messages.

--- a/packages/agents-server-ui/src/components/UserMessage.module.css
+++ b/packages/agents-server-ui/src/components/UserMessage.module.css
@@ -80,8 +80,23 @@
 .body {
   font-size: var(--ds-chat-text);
   line-height: var(--ds-chat-text-lh);
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+/* User-authored text gets Slack/Discord-style lightweight markdown: links
+   (including bare URLs), emphasis, inline/fenced code, lists and quotes. Keep
+   it compact inside the message bubble and preserve plain newline behavior so
+   ordinary chat messages still look like chat, not documents. */
+.body > div > *:first-child {
+  margin-top: 0;
+}
+
+.body > div > *:last-child {
+  margin-bottom: 0;
+}
+
+.body p {
+  white-space: pre-wrap;
 }
 
 .attachments {

--- a/packages/agents-server-ui/src/components/UserMessage.tsx
+++ b/packages/agents-server-ui/src/components/UserMessage.tsx
@@ -1,4 +1,5 @@
 import { memo, useState } from 'react'
+import { Streamdown } from 'streamdown'
 import {
   Download,
   File as FileIcon,
@@ -8,6 +9,10 @@ import {
 import type { EntityTimelineSection } from '@electric-ax/agents-runtime/client'
 import { Icon, Stack, Text } from '../ui'
 import { downloadAttachment, formatAttachmentSize } from '../lib/attachments'
+import {
+  streamdownComponents,
+  streamdownControls,
+} from '../lib/streamdownConfig'
 import {
   AttachmentImagePreviewDialog,
   useAttachmentObjectUrl,
@@ -82,11 +87,7 @@ export const UserMessage = memo(function UserMessage({
             ))}
           </div>
         )}
-        {section.text ? (
-          <Text size={2} className={styles.body}>
-            {section.text}
-          </Text>
-        ) : null}
+        {section.text ? <UserMessageBody text={section.text} /> : null}
       </Stack>
       <Stack gap={2} align="center" className={styles.meta}>
         <Text size={1} tone="muted" title={sender.title}>
@@ -102,6 +103,42 @@ export const UserMessage = memo(function UserMessage({
         )}
       </Stack>
     </Stack>
+  )
+})
+
+const userMessageAllowedMarkdownElements = [
+  `p`,
+  `br`,
+  `a`,
+  `strong`,
+  `em`,
+  `del`,
+  `code`,
+  `pre`,
+  `blockquote`,
+  `ul`,
+  `ol`,
+  `li`,
+] as const
+
+const UserMessageBody = memo(function UserMessageBody({
+  text,
+}: {
+  text: string
+}): React.ReactElement {
+  return (
+    <div className={`agent-ui-markdown ${styles.body}`}>
+      <Streamdown
+        isAnimating={false}
+        linkSafety={{ enabled: false }}
+        allowedElements={userMessageAllowedMarkdownElements}
+        unwrapDisallowed
+        controls={streamdownControls}
+        components={streamdownComponents}
+      >
+        {text}
+      </Streamdown>
+    </div>
   )
 })
 


### PR DESCRIPTION
## Summary
- render inbox/user message text through Streamdown so links and lightweight markdown work
- reuse existing markdown component overrides for anchors, code, tables, and images
- keep user-message styling compact and preserve chat-like newline behavior

## Testing
- pnpm --filter @electric-ax/agents-server-ui typecheck *(fails: existing agents-runtime/TanStack DB duplicate-version type errors, not from changed UserMessage files)*