### PR TITLE
feat(agents-desktop): Add/Edit/Remove UI for MCP servers

### DIFF
--- a/.changeset/agents-desktop-mcp-add-edit.md
+++ b/.changeset/agents-desktop-mcp-add-edit.md
@@ -1,0 +1,26 @@
+---
+'@electric-ax/agents-desktop': patch
+'@electric-ax/agents-server-ui': patch
+'@electric-ax/agents': patch
+---
+
+Add a form-based **Add / Edit / Remove** flow for MCP servers in the
+desktop's Settings → MCP Servers page. Before this, the only way to
+register a server was to hand-edit `settings.json` or a workspace
+`mcp.json`. The dialog supports both `http` and `stdio` transports, all
+four auth modes, and writes through to the global `settings.json
+mcp.servers` block.
+
+The MCP page also gains provenance + shadowing awareness:
+
+- Entries from a workspace `mcp.json` render a "from mcp.json" badge
+  and are read-only (no Edit/Remove). Lifecycle verbs still apply.
+- When a name in `settings.json` collides with one in workspace
+  `mcp.json`, the workspace still wins (existing rule); the shadowed
+  settings entry is rendered grayed-out next to the running workspace
+  twin so the user can see what's been overridden.
+
+`BuiltinAgentsServer` gains a public `setExtraMcpServers(extras)` so
+the desktop can push add/edit/remove changes to the live MCP registry
+without restarting. Workspace `mcp.json` continues to win on name
+collision through the same merge path used by the file watcher.

--- a/packages/agents-desktop/src/app/context.ts
+++ b/packages/agents-desktop/src/app/context.ts
@@ -9,9 +9,9 @@ import { captureEnvApiKeys, EMPTY_API_KEYS } from '../credentials/api-keys'
 import { DEFAULT_SETTINGS } from '../settings/store'
 import type {
   ApiKeys,
+  DesktopMcpSnapshot,
   DesktopSettings,
   DesktopState,
-  RegistrySnapshot,
   RuntimeEntry,
 } from '../shared/types'
 
@@ -30,7 +30,7 @@ export type DesktopAppContext = {
   windows: Set<BrowserWindow>
   windowSelections: Map<number, string | null>
   runtimeEntries: Map<string, RuntimeEntry>
-  lastMcpSnapshots: Map<string, RegistrySnapshot>
+  lastMcpSnapshots: Map<string, DesktopMcpSnapshot>
   shell: {
     tray: Tray | null
     aboutWindow: BrowserWindow | null

--- a/packages/agents-desktop/src/app/controller.ts
+++ b/packages/agents-desktop/src/app/controller.ts
@@ -373,6 +373,7 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     popupApplicationMenuSection,
     popupAppIconMenu,
     lastMcpSnapshots,
+    windows,
     getCloudAuth: ctx.getCloudAuth,
     getCloudAgentServers: ctx.getCloudAgentServers,
     getLaunchAtLoginStatus,

--- a/packages/agents-desktop/src/ipc/mcp.ts
+++ b/packages/agents-desktop/src/ipc/mcp.ts
@@ -5,12 +5,22 @@ import {
   enableMcpServer,
   getMcpSnapshot,
   reconnectMcpServer,
+  removeMcpServer,
+  upsertMcpServer,
 } from '../runtime/mcp'
-import type { RegistrySnapshot, RuntimeEntry } from '../shared/types'
+import type {
+  DesktopMcpSnapshot,
+  DesktopSettings,
+  McpServerConfig,
+  RuntimeEntry,
+} from '../shared/types'
 
 export type McpIpcDeps = {
+  settings: DesktopSettings
+  saveSettings: () => Promise<void>
   runtimeEntries: Map<string, RuntimeEntry>
-  lastMcpSnapshots: Map<string, RegistrySnapshot>
+  lastMcpSnapshots: Map<string, DesktopMcpSnapshot>
+  windows: Set<BrowserWindow>
   selectedServerIdForWindow: (win: BrowserWindow | null) => string | null
 }
 
@@ -67,4 +77,28 @@ export function registerMcpIpcHandlers(deps: McpIpcDeps): void {
       await enableMcpServer(deps.runtimeEntries, id, name)
     }
   )
+  // Add/Edit and Remove operate on the global settings.json `mcp.servers`
+  // block. The runtimeEntries / snapshot args from per-server callers are
+  // ignored here because settings.json is shared across every connected
+  // runtime — every live runtime gets the new extras pushed at once.
+  ipcMain.handle(`desktop:mcp-upsert`, async (_event, cfg: McpServerConfig) => {
+    await upsertMcpServer({
+      settings: deps.settings,
+      saveSettings: deps.saveSettings,
+      runtimeEntries: deps.runtimeEntries,
+      snapshots: deps.lastMcpSnapshots,
+      windows: deps.windows,
+      cfg,
+    })
+  })
+  ipcMain.handle(`desktop:mcp-remove`, async (_event, name: string) => {
+    await removeMcpServer({
+      settings: deps.settings,
+      saveSettings: deps.saveSettings,
+      runtimeEntries: deps.runtimeEntries,
+      snapshots: deps.lastMcpSnapshots,
+      windows: deps.windows,
+      name,
+    })
+  })
 }

--- a/packages/agents-desktop/src/preload.ts
+++ b/packages/agents-desktop/src/preload.ts
@@ -17,6 +17,7 @@ import type {
   DesktopState,
   DiscoveredServer,
   LaunchAtLoginStatus,
+  McpServerConfig,
   OnboardingState,
   ServerConfig,
 } from './shared/types'
@@ -262,6 +263,10 @@ const api = {
       ipcRenderer.invoke(`desktop:mcp-disable`, name, serverId),
     enable: (name: string, serverId?: string): Promise<void> =>
       ipcRenderer.invoke(`desktop:mcp-enable`, name, serverId),
+    upsert: (cfg: McpServerConfig): Promise<void> =>
+      ipcRenderer.invoke(`desktop:mcp-upsert`, cfg),
+    remove: (name: string): Promise<void> =>
+      ipcRenderer.invoke(`desktop:mcp-remove`, name),
   },
   // ── Electric Cloud auth surface ────────────────────────────────
   // Sign-in opens a child BrowserWindow that intercepts the

--- a/packages/agents-desktop/src/runtime/controller.ts
+++ b/packages/agents-desktop/src/runtime/controller.ts
@@ -6,6 +6,7 @@ import type { CloudAgentServers } from '../cloud/cloud-agent-servers'
 import type { CloudAuthState } from '../cloud/cloud-auth'
 import type {
   ConnectServerOptions,
+  DesktopMcpSnapshot,
   DesktopSettings,
   DesktopState,
   RegistrySnapshot,
@@ -20,7 +21,7 @@ export function createRuntimeController(deps: {
   runtimeEntries: Map<string, RuntimeEntry>
   windowSelections: Map<number, string | null>
   windows: Set<BrowserWindow>
-  lastMcpSnapshots: Map<string, RegistrySnapshot>
+  lastMcpSnapshots: Map<string, DesktopMcpSnapshot>
   findServer: (serverId: string | null | undefined) => ServerConfig | null
   ensureRuntimeEntry: (server: ServerConfig) => RuntimeEntry
   saveSettings: () => Promise<void>
@@ -39,8 +40,12 @@ export function createRuntimeController(deps: {
     serverId: string,
     snapshot: RegistrySnapshot
   ): void => {
-    McpRuntime.broadcastMcpSnapshot(
-      { snapshots: deps.lastMcpSnapshots, windows: deps.windows },
+    McpRuntime.broadcastEnrichedSnapshot(
+      {
+        snapshots: deps.lastMcpSnapshots,
+        windows: deps.windows,
+        settings: deps.settings,
+      },
       serverId,
       snapshot
     )

--- a/packages/agents-desktop/src/runtime/mcp.ts
+++ b/packages/agents-desktop/src/runtime/mcp.ts
@@ -1,22 +1,158 @@
-import { BrowserWindow } from 'electron'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { BrowserWindow, app } from 'electron'
 import { openAuthorizeWindow } from '../oauth-window'
-import type { RegistrySnapshot, RuntimeEntry } from '../shared/types'
+import {
+  removeMcpServerFromSettings,
+  upsertMcpServerInSettings,
+  validateMcpServerConfig,
+} from '../settings/store'
+import type {
+  DesktopMcpServerRow,
+  DesktopMcpSnapshot,
+  DesktopSettings,
+  McpServerConfig,
+  RegistrySnapshot,
+  RuntimeEntry,
+} from '../shared/types'
 
-export const EMPTY_MCP_SNAPSHOT: RegistrySnapshot = { seq: 0, servers: [] }
+export const EMPTY_MCP_SNAPSHOT: DesktopMcpSnapshot = { seq: 0, servers: [] }
 
-export function broadcastMcpSnapshot(
+/**
+ * Sync-read the workspace `mcp.json` and return the set of server
+ * names it declares. The file is small and reads are cheap; we re-read
+ * on every snapshot broadcast rather than cache + watch because the
+ * runtime already watches and re-applies when it changes.
+ */
+function readWorkspaceMcpNames(
+  workingDirectory: string | null | undefined
+): Set<string> {
+  const dir = workingDirectory ?? app.getPath(`home`)
+  try {
+    const raw = readFileSync(path.join(dir, `mcp.json`), `utf8`)
+    const parsed = JSON.parse(raw) as { servers?: Record<string, unknown> }
+    const servers = parsed?.servers
+    if (!servers || typeof servers !== `object`) return new Set()
+    return new Set(Object.keys(servers))
+  } catch {
+    return new Set()
+  }
+}
+
+/**
+ * Combine the live registry snapshot with the desktop's settings.json
+ * extras and the workspace mcp.json names to produce a UI-friendly
+ * snapshot with provenance + shadowing baked in.
+ *
+ * Workspace `mcp.json` wins on name collision (same precedence the
+ * runtime applies internally) — settings.json rows with a workspace
+ * twin get an extra "shadowed" entry alongside the running workspace
+ * one so the user understands why their global config isn't in effect.
+ */
+function enrichSnapshot(
+  snapshot: RegistrySnapshot,
+  settingsServers: ReadonlyArray<McpServerConfig>,
+  workspaceNames: Set<string>
+): DesktopMcpSnapshot {
+  const settingsByName = new Map(settingsServers.map((s) => [s.name, s]))
+  const rows: DesktopMcpServerRow[] = []
+
+  for (const entry of snapshot.servers) {
+    const isWorkspace = workspaceNames.has(entry.name)
+    const settingsConfig = settingsByName.get(entry.name)
+    const provenance = isWorkspace
+      ? `workspace`
+      : settingsConfig
+        ? `settings`
+        : `extras`
+    rows.push({
+      name: entry.name,
+      status: entry.status,
+      toolCount: entry.toolCount,
+      transport: entry.transport,
+      authMode: entry.authMode,
+      authUrl: entry.authUrl,
+      error: entry.error,
+      tools: entry.tools as DesktopMcpServerRow[`tools`],
+      provenance,
+      shadowed: false,
+      config: provenance === `settings` ? settingsConfig : undefined,
+    })
+  }
+
+  // Fabricate "shadowed" rows for settings.json entries whose name is
+  // claimed by workspace mcp.json — the registry doesn't see them at
+  // all (workspace wins), but the UI surfaces them as a grayed-out
+  // configured-but-overridden entry.
+  const runningNames = new Set(snapshot.servers.map((s) => s.name))
+  for (const cfg of settingsServers) {
+    if (!workspaceNames.has(cfg.name)) continue
+    if (!runningNames.has(cfg.name)) continue
+    rows.push({
+      name: cfg.name,
+      status: `shadowed`,
+      toolCount: 0,
+      transport: cfg.transport,
+      authMode: cfg.auth?.mode,
+      provenance: `settings`,
+      shadowed: true,
+      config: cfg,
+    })
+  }
+
+  return { seq: snapshot.seq, servers: rows }
+}
+
+/**
+ * Compute and broadcast an enriched snapshot for a given runtime
+ * entry. Reads workspace mcp.json synchronously each call (file is
+ * tiny, callers are rare).
+ */
+export function broadcastEnrichedSnapshot(
   deps: {
-    snapshots: Map<string, RegistrySnapshot>
+    snapshots: Map<string, DesktopMcpSnapshot>
     windows: Set<BrowserWindow>
+    settings: DesktopSettings
   },
   serverId: string,
   snapshot: RegistrySnapshot
 ): void {
-  deps.snapshots.set(serverId, snapshot)
+  const enriched = enrichSnapshot(
+    snapshot,
+    deps.settings.mcp?.servers ?? [],
+    readWorkspaceMcpNames(deps.settings.workingDirectory)
+  )
+  deps.snapshots.set(serverId, enriched)
   for (const win of deps.windows) {
     if (!win.isDestroyed()) {
-      win.webContents.send(`desktop:mcp-state`, { serverId, snapshot })
+      win.webContents.send(`desktop:mcp-state`, {
+        serverId,
+        snapshot: enriched,
+      })
     }
+  }
+}
+
+/**
+ * Re-broadcast every connected runtime's snapshot — used after a
+ * settings.json edit so the renderer picks up new provenance even when
+ * the registry hasn't fired its own event.
+ */
+export function rebroadcastAllSnapshots(deps: {
+  runtimeEntries: Map<string, RuntimeEntry>
+  snapshots: Map<string, DesktopMcpSnapshot>
+  windows: Set<BrowserWindow>
+  settings: DesktopSettings
+}): void {
+  for (const [serverId, entry] of deps.runtimeEntries) {
+    const reg = entry.runtime?.mcpRegistry
+    if (!reg) continue
+    const list = reg.list()
+    const seq = deps.snapshots.get(serverId)?.seq ?? 0
+    broadcastEnrichedSnapshot(deps, serverId, {
+      seq,
+      servers: list,
+    } as RegistrySnapshot)
   }
 }
 
@@ -47,9 +183,9 @@ export async function handleAuthorizeUrl(deps: {
 }
 
 export function getMcpSnapshot(
-  snapshots: Map<string, RegistrySnapshot>,
+  snapshots: Map<string, DesktopMcpSnapshot>,
   serverId: string | null | undefined
-): RegistrySnapshot {
+): DesktopMcpSnapshot {
   return (serverId ? snapshots.get(serverId) : null) ?? EMPTY_MCP_SNAPSHOT
 }
 
@@ -105,4 +241,65 @@ export async function enableMcpServer(
     .catch((err: unknown) => {
       console.warn(`[agents-desktop] mcp-enable ${name}:`, err)
     })
+}
+
+/**
+ * Persist an Add or Edit of an MCP server in `settings.json mcp.servers`
+ * and push the updated extras list to every live runtime so the registry
+ * picks the change up without a restart.
+ *
+ * Resolves as soon as settings.json is on disk. The registry rebuild
+ * (`setExtraMcpServers` → re-merge → transport teardown/rebuild → MCP
+ * handshake → tool list) runs in the background — for stdio servers
+ * that means several seconds we don't make the UI wait on. The row's
+ * status will animate `connecting → ready` (or `error`) through the
+ * registry's existing snapshot subscription.
+ */
+export async function upsertMcpServer(deps: {
+  settings: DesktopSettings
+  saveSettings: () => Promise<void>
+  runtimeEntries: Map<string, RuntimeEntry>
+  snapshots: Map<string, DesktopMcpSnapshot>
+  windows: Set<BrowserWindow>
+  cfg: McpServerConfig
+}): Promise<void> {
+  const error = validateMcpServerConfig(deps.cfg)
+  if (error) throw new Error(error)
+  upsertMcpServerInSettings(deps.settings, deps.cfg)
+  await deps.saveSettings()
+  // Rebroadcast first so the UI sees the new provenance/config (badges,
+  // pre-fill for the next Edit, etc.) before the transport rebuild lands.
+  rebroadcastAllSnapshots(deps)
+  void applyExtrasToAllRuntimes(deps)
+}
+
+export async function removeMcpServer(deps: {
+  settings: DesktopSettings
+  saveSettings: () => Promise<void>
+  runtimeEntries: Map<string, RuntimeEntry>
+  snapshots: Map<string, DesktopMcpSnapshot>
+  windows: Set<BrowserWindow>
+  name: string
+}): Promise<void> {
+  const removed = removeMcpServerFromSettings(deps.settings, deps.name)
+  if (!removed) return
+  await deps.saveSettings()
+  rebroadcastAllSnapshots(deps)
+  void applyExtrasToAllRuntimes(deps)
+}
+
+async function applyExtrasToAllRuntimes(deps: {
+  settings: DesktopSettings
+  runtimeEntries: Map<string, RuntimeEntry>
+}): Promise<void> {
+  const extras = deps.settings.mcp?.servers ?? []
+  await Promise.all(
+    [...deps.runtimeEntries.values()].map(async (entry) => {
+      const runtime = entry.runtime
+      if (!runtime) return
+      await runtime.setExtraMcpServers(extras).catch((err: unknown) => {
+        console.warn(`[agents-desktop] setExtraMcpServers failed:`, err)
+      })
+    })
+  )
 }

--- a/packages/agents-desktop/src/settings/store.ts
+++ b/packages/agents-desktop/src/settings/store.ts
@@ -218,3 +218,55 @@ export async function saveDesktopSettings(
     JSON.stringify(serializeSettings(settings), null, 2)
   )
 }
+
+// Anthropic tool-name regex — server names get prefixed `mcp__<server>__<tool>`,
+// so the server name's allowed character set must match.
+const MCP_SERVER_NAME_RE = /^[a-zA-Z0-9_-]{1,128}$/
+
+export function validateMcpServerConfig(cfg: McpServerConfig): string | null {
+  if (!cfg || typeof cfg !== `object`) return `Config must be an object`
+  if (typeof cfg.name !== `string` || !MCP_SERVER_NAME_RE.test(cfg.name)) {
+    return `Name must match ${MCP_SERVER_NAME_RE.source}`
+  }
+  if (cfg.transport === `http`) {
+    if (!cfg.url || typeof cfg.url !== `string`) return `HTTP url is required`
+    if (!/^https?:\/\//.test(cfg.url))
+      return `HTTP url must start with http(s)://`
+    if (!cfg.auth || typeof cfg.auth !== `object`) return `Auth is required`
+  } else if (cfg.transport === `stdio`) {
+    if (!cfg.command || typeof cfg.command !== `string`) {
+      return `Stdio command is required`
+    }
+  } else {
+    return `Transport must be 'http' or 'stdio'`
+  }
+  return null
+}
+
+/**
+ * Upsert an MCP server in `settings.mcp.servers` by name. The caller
+ * is responsible for persisting via `saveDesktopSettings` and pushing
+ * the updated extras to any live runtime.
+ */
+export function upsertMcpServerInSettings(
+  settings: DesktopSettings,
+  cfg: McpServerConfig
+): void {
+  const error = validateMcpServerConfig(cfg)
+  if (error) throw new Error(error)
+  const existing = settings.mcp?.servers ?? []
+  const filtered = existing.filter((s) => s.name !== cfg.name)
+  filtered.push(cfg)
+  settings.mcp = { servers: filtered }
+}
+
+export function removeMcpServerFromSettings(
+  settings: DesktopSettings,
+  name: string
+): boolean {
+  const existing = settings.mcp?.servers ?? []
+  const next = existing.filter((s) => s.name !== name)
+  if (next.length === existing.length) return false
+  settings.mcp = next.length > 0 ? { servers: next } : undefined
+  return true
+}

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -214,3 +214,50 @@ export type DesktopContextMenuRequest = {
 }
 
 export type { McpServerConfig, RegistrySnapshot }
+
+/**
+ * Where an MCP server row in the snapshot came from:
+ * - `settings` — the desktop's global `settings.json mcp.servers` block.
+ * - `workspace` — the workspace's `mcp.json` file.
+ * - `extras` — programmatic extras passed by another embedder (not the
+ *   desktop). Unused on the desktop today, kept for completeness.
+ */
+export type McpServerProvenance = `settings` | `workspace` | `extras`
+
+/**
+ * UI-friendly row shape broadcast from the desktop main process. Includes
+ * the registry-driven runtime fields plus provenance + shadowing so the
+ * renderer can gate per-row affordances (Edit/Remove only on `settings`
+ * rows, gray out `shadowed` rows where workspace `mcp.json` wins, etc).
+ */
+export interface DesktopMcpServerRow {
+  name: string
+  status:
+    | `connecting`
+    | `authenticating`
+    | `ready`
+    | `error`
+    | `disabled`
+    | `shadowed`
+  toolCount: number
+  transport?: string
+  url?: string
+  authMode?: string
+  authUrl?: string
+  error?: { kind: string; message: string }
+  tools?: Array<{ name: string; description?: string }>
+  provenance: McpServerProvenance
+  /** True iff a settings.json entry is overridden by a workspace mcp.json one. */
+  shadowed: boolean
+  /**
+   * Original config object — only populated for `provenance === 'settings'`
+   * rows so the renderer's Edit form can pre-fill. Workspace and extras
+   * rows omit this since they're read-only in the UI anyway.
+   */
+  config?: McpServerConfig
+}
+
+export interface DesktopMcpSnapshot {
+  seq: number
+  servers: ReadonlyArray<DesktopMcpServerRow>
+}

--- a/packages/agents-server-ui/src/components/settings/pages/McpServerFormDialog.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/McpServerFormDialog.tsx
@@ -130,7 +130,29 @@ function parseEnv(input: string): Record<string, string> | undefined {
   return Object.keys(env).length > 0 ? env : undefined
 }
 
-function buildConfig(state: FormState): {
+/**
+ * Pull the baseline auth object out of an existing config — but only if
+ * its mode matches what the form has selected. When the user switches
+ * auth modes the prior shape is structurally incompatible (different
+ * required fields, different unknowns), so we start fresh.
+ */
+function baselineAuthForMode(
+  baseline: McpServerConfigInput | undefined,
+  mode: AuthMode
+): Record<string, unknown> {
+  if (!baseline || baseline.transport !== `http`) return {}
+  const existing = baseline.auth as Record<string, unknown> | undefined
+  if (!existing || existing.mode !== mode) return {}
+  // Shallow copy — we only overwrite top-level auth fields below, so
+  // a structural clone is overkill; sub-objects (`client`, `tokens`)
+  // are preserved by reference but never mutated in place.
+  return { ...existing }
+}
+
+function buildConfig(
+  state: FormState,
+  baseline?: McpServerConfigInput
+): {
   cfg?: McpServerConfigInput
   error?: string
 } {
@@ -157,11 +179,21 @@ function buildConfig(state: FormState): {
       auth = { mode: `none` }
     } else if (state.authMode === `apiKey`) {
       if (!state.apiKey.key.trim()) return { error: `API key is required` }
-      auth = { mode: `apiKey`, key: state.apiKey.key }
+      auth = {
+        ...baselineAuthForMode(baseline, `apiKey`),
+        mode: `apiKey`,
+        key: state.apiKey.key,
+      }
       if (state.apiKey.headerName.trim()) {
         auth.headerName = state.apiKey.headerName.trim()
+      } else {
+        delete auth.headerName
       }
-      if (state.apiKey.valuePrefix) auth.valuePrefix = state.apiKey.valuePrefix
+      if (state.apiKey.valuePrefix) {
+        auth.valuePrefix = state.apiKey.valuePrefix
+      } else {
+        delete auth.valuePrefix
+      }
     } else if (state.authMode === `clientCredentials`) {
       if (
         !state.clientCredentials.tokenUrl.trim() ||
@@ -172,7 +204,11 @@ function buildConfig(state: FormState): {
           error: `Token URL, client id, and client secret are required for clientCredentials`,
         }
       }
+      // Preserve baseline `audience`, `resource`, and any other fields
+      // we don't render — the form is a strict subset of the
+      // McpServerConfig.auth schema.
       auth = {
+        ...baselineAuthForMode(baseline, `clientCredentials`),
         mode: `clientCredentials`,
         tokenUrl: state.clientCredentials.tokenUrl.trim(),
         clientId: state.clientCredentials.clientId.trim(),
@@ -180,32 +216,57 @@ function buildConfig(state: FormState): {
       }
       const scopes = splitCsv(state.clientCredentials.scopes)
       if (scopes.length > 0) auth.scopes = scopes
+      else delete auth.scopes
     } else {
-      auth = { mode: `authorizationCode` }
+      // Preserve baseline `resource`, `redirectUri`, `client`, `tokens`,
+      // `oauthProviderRef`, and any persistence-helper callbacks. The
+      // form only renders `scopes` for this mode.
+      auth = {
+        ...baselineAuthForMode(baseline, `authorizationCode`),
+        mode: `authorizationCode`,
+      }
       const scopes = splitCsv(state.authorizationCode.scopes)
       if (scopes.length > 0) auth.scopes = scopes
+      else delete auth.scopes
     }
-    const cfg: McpServerConfigInput = {
+    // Spread baseline first so any top-level keys we don't render
+    // (e.g. unknown future fields someone added by hand) survive.
+    const baselineTop =
+      baseline?.transport === `http`
+        ? (baseline as Record<string, unknown>)
+        : {}
+    const cfg = {
+      ...baselineTop,
       name,
-      transport: `http`,
+      transport: `http` as const,
       url,
       auth,
-    }
+    } as McpServerConfigInput
     if (timeoutMs !== undefined) cfg.timeoutMs = timeoutMs
+    else delete cfg.timeoutMs
     return { cfg }
   }
   const command = state.command.trim()
   if (!command) return { error: `Command is required` }
-  const cfg: McpServerConfigInput = {
+  // Preserve any baseline top-level fields we don't render (most
+  // notably `auth`, which is typically `none` for stdio but the
+  // schema does permit it).
+  const baselineTop =
+    baseline?.transport === `stdio` ? (baseline as Record<string, unknown>) : {}
+  const cfg = {
+    ...baselineTop,
     name,
-    transport: `stdio`,
+    transport: `stdio` as const,
     command,
-  }
+  } as McpServerConfigInput
   const args = splitLines(state.args)
   if (args.length > 0) cfg.args = args
+  else delete cfg.args
   const env = parseEnv(state.env)
   if (env) cfg.env = env
+  else delete cfg.env
   if (timeoutMs !== undefined) cfg.timeoutMs = timeoutMs
+  else delete cfg.timeoutMs
   return { cfg }
 }
 
@@ -251,7 +312,7 @@ export function McpServerFormDialog({
   }, [isEdit, state.name, existingNames])
 
   const handleSubmit = async (): Promise<void> => {
-    const { cfg, error: validationError } = buildConfig(state)
+    const { cfg, error: validationError } = buildConfig(state, initial)
     if (validationError || !cfg) {
       setError(validationError ?? `Invalid configuration`)
       return

--- a/packages/agents-server-ui/src/components/settings/pages/McpServerFormDialog.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/McpServerFormDialog.tsx
@@ -1,0 +1,604 @@
+import { useEffect, useMemo, useState } from 'react'
+import { X } from 'lucide-react'
+import {
+  Button,
+  Dialog,
+  Field,
+  Icon,
+  IconButton,
+  Input,
+  Stack,
+  Text,
+  Textarea,
+} from '../../../ui'
+import inputStyles from '../../../ui/Input.module.css'
+import type { McpServerConfigInput } from '../../../hooks/useMcpServersIpc'
+
+const NAME_REGEX = /^[a-zA-Z0-9_-]{1,128}$/
+
+type Transport = `http` | `stdio`
+type AuthMode = `none` | `apiKey` | `clientCredentials` | `authorizationCode`
+
+interface FormState {
+  name: string
+  transport: Transport
+  url: string
+  authMode: AuthMode
+  apiKey: { key: string; headerName: string; valuePrefix: string }
+  clientCredentials: {
+    tokenUrl: string
+    clientId: string
+    clientSecret: string
+    scopes: string
+  }
+  authorizationCode: { scopes: string }
+  command: string
+  args: string
+  env: string
+  timeoutMs: string
+}
+
+function emptyForm(): FormState {
+  return {
+    name: ``,
+    transport: `http`,
+    url: ``,
+    authMode: `none`,
+    apiKey: { key: ``, headerName: ``, valuePrefix: `` },
+    clientCredentials: {
+      tokenUrl: ``,
+      clientId: ``,
+      clientSecret: ``,
+      scopes: ``,
+    },
+    authorizationCode: { scopes: `` },
+    command: ``,
+    args: ``,
+    env: ``,
+    timeoutMs: ``,
+  }
+}
+
+function formFromConfig(cfg: McpServerConfigInput): FormState {
+  const base = emptyForm()
+  base.name = cfg.name
+  base.transport = cfg.transport
+  if (cfg.transport === `http`) {
+    base.url = typeof cfg.url === `string` ? cfg.url : ``
+    const auth = cfg.auth as Record<string, unknown> | undefined
+    const mode = auth?.mode as AuthMode | undefined
+    if (mode === `apiKey`) {
+      base.authMode = `apiKey`
+      base.apiKey.key = (auth?.key as string) ?? ``
+      base.apiKey.headerName = (auth?.headerName as string) ?? ``
+      base.apiKey.valuePrefix = (auth?.valuePrefix as string) ?? ``
+    } else if (mode === `clientCredentials`) {
+      base.authMode = `clientCredentials`
+      base.clientCredentials.tokenUrl = (auth?.tokenUrl as string) ?? ``
+      base.clientCredentials.clientId = (auth?.clientId as string) ?? ``
+      base.clientCredentials.clientSecret = (auth?.clientSecret as string) ?? ``
+      base.clientCredentials.scopes = Array.isArray(auth?.scopes)
+        ? (auth?.scopes as string[]).join(`, `)
+        : ``
+    } else if (mode === `authorizationCode`) {
+      base.authMode = `authorizationCode`
+      base.authorizationCode.scopes = Array.isArray(auth?.scopes)
+        ? (auth?.scopes as string[]).join(`, `)
+        : ``
+    } else {
+      base.authMode = `none`
+    }
+  } else if (cfg.transport === `stdio`) {
+    base.command = (cfg.command as string) ?? ``
+    const args = cfg.args
+    base.args = Array.isArray(args) ? (args as string[]).join(`\n`) : ``
+    const env = cfg.env as Record<string, string> | undefined
+    base.env = env
+      ? Object.entries(env)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(`\n`)
+      : ``
+  }
+  base.timeoutMs =
+    typeof cfg.timeoutMs === `number` ? String(cfg.timeoutMs) : ``
+  return base
+}
+
+function splitLines(input: string): string[] {
+  return input
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+}
+
+function splitCsv(input: string): string[] {
+  return input
+    .split(`,`)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+function parseEnv(input: string): Record<string, string> | undefined {
+  const lines = splitLines(input)
+  if (lines.length === 0) return undefined
+  const env: Record<string, string> = {}
+  for (const line of lines) {
+    const eq = line.indexOf(`=`)
+    if (eq <= 0) continue
+    env[line.slice(0, eq).trim()] = line.slice(eq + 1)
+  }
+  return Object.keys(env).length > 0 ? env : undefined
+}
+
+function buildConfig(state: FormState): {
+  cfg?: McpServerConfigInput
+  error?: string
+} {
+  const name = state.name.trim()
+  if (!NAME_REGEX.test(name)) {
+    return { error: `Name must match ${NAME_REGEX.source}` }
+  }
+  const timeoutMs = state.timeoutMs.trim()
+    ? Number(state.timeoutMs.trim())
+    : undefined
+  if (
+    timeoutMs !== undefined &&
+    (!Number.isFinite(timeoutMs) || timeoutMs <= 0)
+  ) {
+    return { error: `Timeout must be a positive number` }
+  }
+  if (state.transport === `http`) {
+    const url = state.url.trim()
+    if (!/^https?:\/\//.test(url)) {
+      return { error: `URL must start with http:// or https://` }
+    }
+    let auth: Record<string, unknown>
+    if (state.authMode === `none`) {
+      auth = { mode: `none` }
+    } else if (state.authMode === `apiKey`) {
+      if (!state.apiKey.key.trim()) return { error: `API key is required` }
+      auth = { mode: `apiKey`, key: state.apiKey.key }
+      if (state.apiKey.headerName.trim()) {
+        auth.headerName = state.apiKey.headerName.trim()
+      }
+      if (state.apiKey.valuePrefix) auth.valuePrefix = state.apiKey.valuePrefix
+    } else if (state.authMode === `clientCredentials`) {
+      if (
+        !state.clientCredentials.tokenUrl.trim() ||
+        !state.clientCredentials.clientId.trim() ||
+        !state.clientCredentials.clientSecret.trim()
+      ) {
+        return {
+          error: `Token URL, client id, and client secret are required for clientCredentials`,
+        }
+      }
+      auth = {
+        mode: `clientCredentials`,
+        tokenUrl: state.clientCredentials.tokenUrl.trim(),
+        clientId: state.clientCredentials.clientId.trim(),
+        clientSecret: state.clientCredentials.clientSecret,
+      }
+      const scopes = splitCsv(state.clientCredentials.scopes)
+      if (scopes.length > 0) auth.scopes = scopes
+    } else {
+      auth = { mode: `authorizationCode` }
+      const scopes = splitCsv(state.authorizationCode.scopes)
+      if (scopes.length > 0) auth.scopes = scopes
+    }
+    const cfg: McpServerConfigInput = {
+      name,
+      transport: `http`,
+      url,
+      auth,
+    }
+    if (timeoutMs !== undefined) cfg.timeoutMs = timeoutMs
+    return { cfg }
+  }
+  const command = state.command.trim()
+  if (!command) return { error: `Command is required` }
+  const cfg: McpServerConfigInput = {
+    name,
+    transport: `stdio`,
+    command,
+  }
+  const args = splitLines(state.args)
+  if (args.length > 0) cfg.args = args
+  const env = parseEnv(state.env)
+  if (env) cfg.env = env
+  if (timeoutMs !== undefined) cfg.timeoutMs = timeoutMs
+  return { cfg }
+}
+
+/**
+ * Add/Edit MCP server form. Used for both adding new entries and
+ * editing existing ones — in edit mode the name and transport are
+ * read-only because they're the keying fields (and changing transport
+ * would discard most of the form anyway).
+ */
+export function McpServerFormDialog({
+  open,
+  onOpenChange,
+  initial,
+  onSubmit,
+  existingNames,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initial?: McpServerConfigInput
+  onSubmit: (cfg: McpServerConfigInput) => Promise<void>
+  /** Names already in settings.json — used to detect "you'd be overwriting" on Add. */
+  existingNames: ReadonlyArray<string>
+}): React.ReactElement {
+  const isEdit = !!initial
+  const [state, setState] = useState<FormState>(() =>
+    initial ? formFromConfig(initial) : emptyForm()
+  )
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset state whenever the dialog opens or the initial config changes.
+  useEffect(() => {
+    if (!open) return
+    setState(initial ? formFromConfig(initial) : emptyForm())
+    setError(null)
+    setSubmitting(false)
+  }, [open, initial])
+
+  const collidesOnAdd = useMemo(() => {
+    if (isEdit) return false
+    const trimmed = state.name.trim()
+    return !!trimmed && existingNames.includes(trimmed)
+  }, [isEdit, state.name, existingNames])
+
+  const handleSubmit = async (): Promise<void> => {
+    const { cfg, error: validationError } = buildConfig(state)
+    if (validationError || !cfg) {
+      setError(validationError ?? `Invalid configuration`)
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      await onSubmit(cfg)
+      onOpenChange(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content
+        maxWidth={560}
+        style={{ maxHeight: `90vh`, overflow: `auto` }}
+      >
+        <div
+          style={{
+            display: `flex`,
+            alignItems: `flex-start`,
+            justifyContent: `space-between`,
+            marginBottom: 12,
+          }}
+        >
+          <div>
+            <Dialog.Title>
+              {isEdit ? `Edit MCP server` : `Add MCP server`}
+            </Dialog.Title>
+            <Dialog.Description>
+              {isEdit
+                ? `Update the configuration. Name and transport are immutable — remove and re-add to change them.`
+                : `Add a server to your desktop settings. Use stdio for a locally-spawned process or http for a remote MCP endpoint.`}
+            </Dialog.Description>
+          </div>
+          <Dialog.Close
+            render={
+              <IconButton
+                type="button"
+                size={1}
+                variant="ghost"
+                tone="neutral"
+                round
+                aria-label="Close dialog"
+              >
+                <Icon icon={X} size={2} />
+              </IconButton>
+            }
+          />
+        </div>
+
+        <Stack direction="column" gap={3}>
+          <Field
+            label="Name"
+            required
+            description={
+              collidesOnAdd
+                ? `A server with this name already exists — saving will overwrite it.`
+                : `Allowed: letters, digits, _ and -. Used as the tool prefix mcp__<name>__.`
+            }
+          >
+            <Input
+              value={state.name}
+              disabled={isEdit}
+              onChange={(e) =>
+                setState((s) => ({ ...s, name: e.target.value }))
+              }
+              placeholder="my-mcp-server"
+            />
+          </Field>
+
+          <Field label="Transport" required>
+            <select
+              className={`${inputStyles.input} ${inputStyles.size2}`}
+              value={state.transport}
+              disabled={isEdit}
+              onChange={(e) =>
+                setState((s) => ({
+                  ...s,
+                  transport: e.target.value as Transport,
+                }))
+              }
+            >
+              <option value="http">HTTP (remote)</option>
+              <option value="stdio">stdio (local process)</option>
+            </select>
+          </Field>
+
+          {state.transport === `http` ? (
+            <>
+              <Field label="URL" required>
+                <Input
+                  value={state.url}
+                  onChange={(e) =>
+                    setState((s) => ({ ...s, url: e.target.value }))
+                  }
+                  placeholder="https://example.com/mcp"
+                />
+              </Field>
+              <Field label="Auth mode">
+                <select
+                  className={`${inputStyles.input} ${inputStyles.size2}`}
+                  value={state.authMode}
+                  onChange={(e) =>
+                    setState((s) => ({
+                      ...s,
+                      authMode: e.target.value as AuthMode,
+                    }))
+                  }
+                >
+                  <option value="none">None</option>
+                  <option value="apiKey">API key</option>
+                  <option value="clientCredentials">Client credentials</option>
+                  <option value="authorizationCode">
+                    Authorization code (OAuth)
+                  </option>
+                </select>
+              </Field>
+
+              {state.authMode === `apiKey` && (
+                <>
+                  <Field
+                    label="API key"
+                    required
+                    description="Stored plaintext in settings.json."
+                  >
+                    <Input
+                      type="password"
+                      value={state.apiKey.key}
+                      onChange={(e) =>
+                        setState((s) => ({
+                          ...s,
+                          apiKey: { ...s.apiKey, key: e.target.value },
+                        }))
+                      }
+                    />
+                  </Field>
+                  <Field
+                    label="Header name"
+                    description="Default: Authorization."
+                  >
+                    <Input
+                      value={state.apiKey.headerName}
+                      onChange={(e) =>
+                        setState((s) => ({
+                          ...s,
+                          apiKey: {
+                            ...s.apiKey,
+                            headerName: e.target.value,
+                          },
+                        }))
+                      }
+                      placeholder="Authorization"
+                    />
+                  </Field>
+                  <Field
+                    label="Value prefix"
+                    description={`Optional, e.g. "Bearer ".`}
+                  >
+                    <Input
+                      value={state.apiKey.valuePrefix}
+                      onChange={(e) =>
+                        setState((s) => ({
+                          ...s,
+                          apiKey: {
+                            ...s.apiKey,
+                            valuePrefix: e.target.value,
+                          },
+                        }))
+                      }
+                      placeholder="Bearer "
+                    />
+                  </Field>
+                </>
+              )}
+
+              {state.authMode === `clientCredentials` && (
+                <>
+                  <Field label="Token URL" required>
+                    <Input
+                      value={state.clientCredentials.tokenUrl}
+                      onChange={(e) =>
+                        setState((s) => ({
+                          ...s,
+                          clientCredentials: {
+                            ...s.clientCredentials,
+                            tokenUrl: e.target.value,
+                          },
+                        }))
+                      }
+                      placeholder="https://auth.example.com/oauth/token"
+                    />
+                  </Field>
+                  <Field label="Client ID" required>
+                    <Input
+                      value={state.clientCredentials.clientId}
+                      onChange={(e) =>
+                        setState((s) => ({
+                          ...s,
+                          clientCredentials: {
+                            ...s.clientCredentials,
+                            clientId: e.target.value,
+                          },
+                        }))
+                      }
+                    />
+                  </Field>
+                  <Field
+                    label="Client secret"
+                    required
+                    description="Stored plaintext in settings.json."
+                  >
+                    <Input
+                      type="password"
+                      value={state.clientCredentials.clientSecret}
+                      onChange={(e) =>
+                        setState((s) => ({
+                          ...s,
+                          clientCredentials: {
+                            ...s.clientCredentials,
+                            clientSecret: e.target.value,
+                          },
+                        }))
+                      }
+                    />
+                  </Field>
+                  <Field
+                    label="Scopes"
+                    description="Comma-separated, optional."
+                  >
+                    <Input
+                      value={state.clientCredentials.scopes}
+                      onChange={(e) =>
+                        setState((s) => ({
+                          ...s,
+                          clientCredentials: {
+                            ...s.clientCredentials,
+                            scopes: e.target.value,
+                          },
+                        }))
+                      }
+                      placeholder="mcp:read, mcp:write"
+                    />
+                  </Field>
+                </>
+              )}
+
+              {state.authMode === `authorizationCode` && (
+                <Field
+                  label="Scopes"
+                  description="Comma-separated, optional. You'll authorize via your browser after saving."
+                >
+                  <Input
+                    value={state.authorizationCode.scopes}
+                    onChange={(e) =>
+                      setState((s) => ({
+                        ...s,
+                        authorizationCode: {
+                          ...s.authorizationCode,
+                          scopes: e.target.value,
+                        },
+                      }))
+                    }
+                    placeholder="mcp:read"
+                  />
+                </Field>
+              )}
+            </>
+          ) : (
+            <>
+              <Field label="Command" required>
+                <Input
+                  value={state.command}
+                  onChange={(e) =>
+                    setState((s) => ({ ...s, command: e.target.value }))
+                  }
+                  placeholder="npx"
+                />
+              </Field>
+              <Field label="Arguments" description="One per line.">
+                <Textarea
+                  rows={4}
+                  mono
+                  value={state.args}
+                  onChange={(e) =>
+                    setState((s) => ({ ...s, args: e.target.value }))
+                  }
+                  placeholder={`-y\n@modelcontextprotocol/server-git\n--repository\n\${workspaceRoot}`}
+                />
+              </Field>
+              <Field
+                label="Environment"
+                description="One KEY=VALUE per line. Stored plaintext in settings.json."
+              >
+                <Textarea
+                  rows={3}
+                  mono
+                  value={state.env}
+                  onChange={(e) =>
+                    setState((s) => ({ ...s, env: e.target.value }))
+                  }
+                  placeholder="MY_VAR=value"
+                />
+              </Field>
+            </>
+          )}
+
+          <Field
+            label="Timeout (ms)"
+            description="Per-call timeout. Default 30000."
+          >
+            <Input
+              type="number"
+              inputMode="numeric"
+              value={state.timeoutMs}
+              onChange={(e) =>
+                setState((s) => ({ ...s, timeoutMs: e.target.value }))
+              }
+              placeholder="30000"
+            />
+          </Field>
+
+          {error && (
+            <Text size={1} tone="danger">
+              {error}
+            </Text>
+          )}
+
+          <Stack direction="row" gap={2} justify="end">
+            <Dialog.Close
+              render={
+                <Button variant="soft" tone="neutral" disabled={submitting}>
+                  Cancel
+                </Button>
+              }
+            />
+            <Button onClick={() => void handleSubmit()} disabled={submitting}>
+              {isEdit ? `Save changes` : `Add server`}
+            </Button>
+          </Stack>
+        </Stack>
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}

--- a/packages/agents-server-ui/src/components/settings/pages/McpServerFormDialog.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/McpServerFormDialog.tsx
@@ -1,16 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { X } from 'lucide-react'
-import {
-  Button,
-  Dialog,
-  Field,
-  Icon,
-  IconButton,
-  Input,
-  Stack,
-  Text,
-  Textarea,
-} from '../../../ui'
+import { Button, Dialog, Field, Input, Text, Textarea } from '../../../ui'
 import inputStyles from '../../../ui/Input.module.css'
 import type { McpServerConfigInput } from '../../../hooks/useMcpServersIpc'
 
@@ -331,45 +320,19 @@ export function McpServerFormDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Content
-        maxWidth={560}
-        style={{ maxHeight: `90vh`, overflow: `auto` }}
-      >
-        <div
-          style={{
-            display: `flex`,
-            alignItems: `flex-start`,
-            justifyContent: `space-between`,
-            marginBottom: 12,
-          }}
-        >
-          <div>
-            <Dialog.Title>
-              {isEdit ? `Edit MCP server` : `Add MCP server`}
-            </Dialog.Title>
-            <Dialog.Description>
-              {isEdit
-                ? `Update the configuration. Name and transport are immutable — remove and re-add to change them.`
-                : `Add a server to your desktop settings. Use stdio for a locally-spawned process or http for a remote MCP endpoint.`}
-            </Dialog.Description>
-          </div>
-          <Dialog.Close
-            render={
-              <IconButton
-                type="button"
-                size={1}
-                variant="ghost"
-                tone="neutral"
-                round
-                aria-label="Close dialog"
-              >
-                <Icon icon={X} size={2} />
-              </IconButton>
-            }
-          />
-        </div>
+      <Dialog.Content maxWidth={560} style={{ maxHeight: `90vh` }}>
+        <Dialog.Header>
+          <Dialog.Title>
+            {isEdit ? `Edit MCP server` : `Add MCP server`}
+          </Dialog.Title>
+          <Dialog.Description>
+            {isEdit
+              ? `Update the configuration. Name and transport are immutable — remove and re-add to change them.`
+              : `Add a server to your desktop settings. Use stdio for a locally-spawned process or http for a remote MCP endpoint.`}
+          </Dialog.Description>
+        </Dialog.Header>
 
-        <Stack direction="column" gap={3}>
+        <Dialog.Body>
           <Field
             label="Name"
             required
@@ -645,20 +608,20 @@ export function McpServerFormDialog({
               {error}
             </Text>
           )}
+        </Dialog.Body>
 
-          <Stack direction="row" gap={2} justify="end">
-            <Dialog.Close
-              render={
-                <Button variant="soft" tone="neutral" disabled={submitting}>
-                  Cancel
-                </Button>
-              }
-            />
-            <Button onClick={() => void handleSubmit()} disabled={submitting}>
-              {isEdit ? `Save changes` : `Add server`}
-            </Button>
-          </Stack>
-        </Stack>
+        <Dialog.Footer>
+          <Dialog.Close
+            render={
+              <Button variant="soft" tone="neutral" disabled={submitting}>
+                Cancel
+              </Button>
+            }
+          />
+          <Button onClick={() => void handleSubmit()} disabled={submitting}>
+            {isEdit ? `Save changes` : `Add server`}
+          </Button>
+        </Dialog.Footer>
       </Dialog.Content>
     </Dialog.Root>
   )

--- a/packages/agents-server-ui/src/components/settings/pages/McpServersPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/McpServersPage.tsx
@@ -1,11 +1,19 @@
-import { useState } from 'react'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from 'lucide-react'
 import {
   useMcpServersIpc,
+  type McpServerConfigInput,
   type UseMcpServersIpcResult,
 } from '../../../hooks/useMcpServersIpc'
 import type { McpServerRow, McpStatus } from '../../../hooks/mcpServerTypes'
-import { Button, Text } from '../../../ui'
+import {
+  Badge,
+  Button,
+  ConfirmDialog,
+  Icon,
+  IconButton,
+  Text,
+} from '../../../ui'
 import {
   SettingsActions,
   SettingsInset,
@@ -16,6 +24,7 @@ import {
   SettingsStatusBadge,
   type SettingsStatusTone,
 } from '../SettingsScreen'
+import { McpServerFormDialog } from './McpServerFormDialog'
 
 const STATUS_TONES: Record<
   McpStatus,
@@ -26,19 +35,35 @@ const STATUS_TONES: Record<
   authenticating: { label: `Sign in required`, tone: `warning` },
   error: { label: `Error`, tone: `danger` },
   disabled: { label: `Disabled`, tone: `neutral` },
+  shadowed: { label: `Overridden`, tone: `neutral` },
 }
 
 /**
  * Settings → MCP Servers. Shows the in-process MCP registry's servers,
  * pushed over IPC from the embedded BuiltinAgentsServer's registry.
  *
+ * Add / Edit / Remove operate on the desktop's global `settings.json`
+ * mcp.servers block. Rows that came from workspace `mcp.json` or from
+ * programmatic extras are read-only. When a settings.json entry's name
+ * is also claimed by workspace mcp.json, the workspace wins (existing
+ * registry rule) and the settings entry renders as `shadowed`.
+ *
  * Desktop-only: in non-Electron contexts the hook returns an empty list
- * and the page renders a hint to launch the desktop app. The sidebar
- * entry is also hidden when `electronAPI` isn't present.
+ * and the page renders a hint to launch the desktop app.
  */
 export function McpServersPage(): React.ReactElement {
   const isDesktop = typeof window !== `undefined` && Boolean(window.electronAPI)
   const ipc = useMcpServersIpc()
+  const [formOpen, setFormOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<McpServerConfigInput | null>(
+    null
+  )
+
+  const existingSettingsNames = useMemo(
+    () =>
+      ipc.servers.filter((s) => s.provenance === `settings`).map((s) => s.name),
+    [ipc.servers]
+  )
 
   if (!isDesktop) {
     return (
@@ -57,8 +82,24 @@ export function McpServersPage(): React.ReactElement {
     )
   }
 
+  const addAction = (
+    <Button
+      onClick={() => {
+        setEditTarget(null)
+        setFormOpen(true)
+      }}
+    >
+      <Icon icon={Plus} size={2} />
+      Add server
+    </Button>
+  )
+
+  const handleSubmit = async (cfg: McpServerConfigInput): Promise<void> => {
+    await ipc.upsert(cfg)
+  }
+
   return (
-    <SettingsScreen title="MCP Servers">
+    <SettingsScreen title="MCP Servers" action={addAction}>
       {ipc.loading ? (
         <SettingsSection title="Loading">
           <SettingsPanel>
@@ -70,7 +111,7 @@ export function McpServersPage(): React.ReactElement {
       ) : ipc.servers.length === 0 ? (
         <SettingsSection
           title="No servers"
-          description="MCP servers declared in mcp.json will appear here once the runtime starts."
+          description="Click 'Add server' to register your first MCP server, or define entries in a workspace mcp.json."
         >
           <SettingsPanel>
             <Text size={2} tone="muted">
@@ -84,10 +125,28 @@ export function McpServersPage(): React.ReactElement {
           description="Connected Model Context Protocol servers and their tools."
         >
           {ipc.servers.map((s) => (
-            <ServerEntry key={s.name} server={s} ipc={ipc} />
+            <ServerEntry
+              key={`${s.name}:${s.shadowed ? `shadowed` : `live`}`}
+              server={s}
+              ipc={ipc}
+              onEdit={() => {
+                if (s.config) {
+                  setEditTarget(s.config as McpServerConfigInput)
+                  setFormOpen(true)
+                }
+              }}
+            />
           ))}
         </SettingsSection>
       )}
+
+      <McpServerFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        initial={editTarget ?? undefined}
+        onSubmit={handleSubmit}
+        existingNames={existingSettingsNames}
+      />
     </SettingsScreen>
   )
 }
@@ -95,13 +154,18 @@ export function McpServersPage(): React.ReactElement {
 function ServerEntry({
   server,
   ipc,
+  onEdit,
 }: {
   server: McpServerRow
   ipc: UseMcpServersIpcResult
+  onEdit: () => void
 }): React.ReactElement {
   const [busy, setBusy] = useState(false)
   const [showTools, setShowTools] = useState(false)
+  const [confirmRemove, setConfirmRemove] = useState(false)
   const statusInfo = STATUS_TONES[server.status]
+  const isSettings = server.provenance === `settings`
+  const isShadowed = server.shadowed
 
   const wrap = (fn: () => Promise<void>) => async () => {
     setBusy(true)
@@ -115,12 +179,14 @@ function ServerEntry({
   const metaPieces: string[] = []
   if (server.transport) metaPieces.push(server.transport)
   if (server.authMode) metaPieces.push(`auth: ${server.authMode}`)
-  metaPieces.push(
-    `${server.toolCount} tool${server.toolCount === 1 ? `` : `s`}`
-  )
+  if (!isShadowed) {
+    metaPieces.push(
+      `${server.toolCount} tool${server.toolCount === 1 ? `` : `s`}`
+    )
+  }
 
   return (
-    <>
+    <div style={isShadowed ? { opacity: 0.55 } : undefined}>
       <SettingsRow
         label={
           <span
@@ -135,6 +201,21 @@ function ServerEntry({
             <Text size={1} tone="muted">
               {metaPieces.join(` · `)}
             </Text>
+            {server.provenance === `workspace` && (
+              <Badge size={1} tone="neutral" variant="soft">
+                from mcp.json
+              </Badge>
+            )}
+            {server.provenance === `extras` && (
+              <Badge size={1} tone="neutral" variant="soft">
+                programmatic
+              </Badge>
+            )}
+            {isShadowed && (
+              <Badge size={1} tone="warning" variant="soft">
+                overridden by mcp.json
+              </Badge>
+            )}
           </span>
         }
         control={
@@ -146,7 +227,12 @@ function ServerEntry({
 
       {/* Status-line slot — always rendered so row height stays stable. */}
       <SettingsInset>
-        {server.status === `error` && server.error ? (
+        {isShadowed ? (
+          <Text size={1} tone="muted">
+            The workspace mcp.json defines a server with the same name —
+            workspace wins. Remove the workspace entry to use this one.
+          </Text>
+        ) : server.status === `error` && server.error ? (
           <Text size={1} tone="danger">
             {server.error.kind}: {server.error.message}
           </Text>
@@ -222,15 +308,62 @@ function ServerEntry({
       </SettingsInset>
 
       <SettingsActions>
-        {server.status === `disabled` ? (
-          <Button
-            variant="soft"
-            tone="neutral"
-            onClick={wrap(() => ipc.enable(server.name))}
-            disabled={busy}
-          >
-            Enable
-          </Button>
+        {isShadowed ? (
+          // Settings-side entry that's been overridden — only Edit/Remove
+          // make sense here (lifecycle verbs go to the workspace twin).
+          <>
+            <Button
+              variant="soft"
+              tone="neutral"
+              onClick={onEdit}
+              disabled={busy}
+            >
+              <Icon icon={Pencil} size={1} />
+              Edit
+            </Button>
+            <Button
+              variant="soft"
+              tone="danger"
+              onClick={() => setConfirmRemove(true)}
+              disabled={busy}
+            >
+              <Icon icon={Trash2} size={1} />
+              Remove
+            </Button>
+          </>
+        ) : server.status === `disabled` ? (
+          <>
+            <Button
+              variant="soft"
+              tone="neutral"
+              onClick={wrap(() => ipc.enable(server.name))}
+              disabled={busy}
+            >
+              Enable
+            </Button>
+            {isSettings && (
+              <>
+                <Button
+                  variant="soft"
+                  tone="neutral"
+                  onClick={onEdit}
+                  disabled={busy}
+                >
+                  <Icon icon={Pencil} size={1} />
+                  Edit
+                </Button>
+                <Button
+                  variant="soft"
+                  tone="danger"
+                  onClick={() => setConfirmRemove(true)}
+                  disabled={busy}
+                >
+                  <Icon icon={Trash2} size={1} />
+                  Remove
+                </Button>
+              </>
+            )}
+          </>
         ) : (
           <>
             {server.authMode === `authorizationCode` && (
@@ -263,9 +396,45 @@ function ServerEntry({
             >
               Disable
             </Button>
+            {isSettings && (
+              <>
+                <IconButton
+                  variant="ghost"
+                  tone="neutral"
+                  size={1}
+                  aria-label="Edit"
+                  onClick={onEdit}
+                  disabled={busy || server.status === `authenticating`}
+                >
+                  <Icon icon={Pencil} size={2} />
+                </IconButton>
+                <IconButton
+                  variant="ghost"
+                  tone="danger"
+                  size={1}
+                  aria-label="Remove"
+                  onClick={() => setConfirmRemove(true)}
+                  disabled={busy}
+                >
+                  <Icon icon={Trash2} size={2} />
+                </IconButton>
+              </>
+            )}
           </>
         )}
       </SettingsActions>
-    </>
+
+      <ConfirmDialog
+        open={confirmRemove}
+        onOpenChange={setConfirmRemove}
+        title={`Remove "${server.name}"?`}
+        description={`This removes ${server.name} from settings.json. Workspace mcp.json entries are not affected.`}
+        confirmLabel="Remove"
+        confirmTone="danger"
+        onConfirm={async () => {
+          await ipc.remove(server.name)
+        }}
+      />
+    </div>
   )
 }

--- a/packages/agents-server-ui/src/hooks/mcpServerTypes.ts
+++ b/packages/agents-server-ui/src/hooks/mcpServerTypes.ts
@@ -1,6 +1,7 @@
-// Shape of a server row in the MCP registry's snapshot, mirrored from
-// `agents-mcp/src/registry.ts`'s `ListedEntry`. Defined in the UI
-// package so renderers don't pull in a Node-only dep transitively.
+// Shape of a server row broadcast from the Electron main process. Mirrors
+// `agents-mcp/src/registry.ts`'s `ListedEntry` plus desktop-only fields
+// (provenance + shadowing) computed from settings.json + workspace mcp.json.
+// Defined in the UI package so renderers don't pull a Node-only dep.
 
 export type McpStatus =
   | `connecting`
@@ -8,6 +9,15 @@ export type McpStatus =
   | `ready`
   | `error`
   | `disabled`
+  /**
+   * Synthetic state: a settings.json entry whose name is also defined
+   * in the workspace mcp.json — workspace wins, the settings copy is
+   * not running. Rendered grayed out next to the workspace twin.
+   */
+  | `shadowed`
+
+/** Where the entry originated. Drives per-row Edit/Remove gating in the UI. */
+export type McpProvenance = `settings` | `workspace` | `extras`
 
 export interface McpServerRow {
   name: string
@@ -19,4 +29,18 @@ export interface McpServerRow {
   error?: { kind: string; message: string }
   toolCount: number
   tools?: Array<{ name: string; description?: string }>
+  /** Where this entry came from. */
+  provenance: McpProvenance
+  /** True iff a settings.json entry is overridden by a workspace mcp.json one. */
+  shadowed: boolean
+  /**
+   * Original config blob — present only for `provenance === 'settings'`
+   * rows so the Edit form can pre-fill from the source-of-truth, not
+   * the registry's runtime view (which doesn't carry url/command/auth).
+   */
+  config?: {
+    name: string
+    transport: `http` | `stdio`
+    [key: string]: unknown
+  }
 }

--- a/packages/agents-server-ui/src/hooks/useMcpServersIpc.ts
+++ b/packages/agents-server-ui/src/hooks/useMcpServersIpc.ts
@@ -1,6 +1,17 @@
 import { useEffect, useState } from 'react'
 import type { McpServerRow } from './mcpServerTypes'
 
+/**
+ * Shape of the config object accepted by `upsert`. Mirrors
+ * `McpServerConfig` from `@electric-ax/agents-mcp`; defined as `unknown`
+ * here to keep the hook surface free of a Node-only dep.
+ */
+export type McpServerConfigInput = {
+  name: string
+  transport: `http` | `stdio`
+  [key: string]: unknown
+}
+
 export interface UseMcpServersIpcResult {
   servers: ReadonlyArray<McpServerRow>
   /** True until the first snapshot lands. */
@@ -14,6 +25,10 @@ export interface UseMcpServersIpcResult {
   reconnect(name: string): Promise<void>
   disable(name: string): Promise<void>
   enable(name: string): Promise<void>
+  /** Add (new name) or edit (existing name) a settings.json MCP entry. */
+  upsert(cfg: McpServerConfigInput): Promise<void>
+  /** Remove a settings.json MCP entry by name. */
+  remove(name: string): Promise<void>
 }
 
 const noopAction = async () => {}
@@ -63,6 +78,8 @@ export function useMcpServersIpc(): UseMcpServersIpcResult {
       reconnect: noopAction,
       disable: noopAction,
       enable: noopAction,
+      upsert: noopAction,
+      remove: noopAction,
     }
   }
 
@@ -73,5 +90,7 @@ export function useMcpServersIpc(): UseMcpServersIpcResult {
     reconnect: mcp.reconnect,
     disable: mcp.disable,
     enable: mcp.enable,
+    upsert: (cfg) => mcp.upsert(cfg),
+    remove: (name) => mcp.remove(name),
   }
 }

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -378,6 +378,15 @@ declare global {
         reconnect: (name: string, serverId?: string) => Promise<void>
         disable: (name: string, serverId?: string) => Promise<void>
         enable: (name: string, serverId?: string) => Promise<void>
+        /**
+         * Add (when the name is new) or edit (when it already exists in
+         * settings.json) an MCP server in the desktop's global config.
+         * Writes settings.json, pushes the new extras list to every
+         * live runtime, and re-broadcasts the enriched snapshot.
+         */
+        upsert: (cfg: unknown) => Promise<void>
+        /** Remove an MCP server from the desktop's global config. */
+        remove: (name: string) => Promise<void>
       }
       /**
        * Electric Cloud sign-in surface. The Electron main process owns

--- a/packages/agents-server-ui/src/ui/Dialog.module.css
+++ b/packages/agents-server-ui/src/ui/Dialog.module.css
@@ -60,3 +60,35 @@
   color: var(--ds-text-2);
   margin: 0 0 var(--ds-space-4) 0;
 }
+
+/* ── Header / Body / Footer ─────────────────────────────────── */
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ds-space-3);
+  margin-bottom: var(--ds-space-3);
+}
+
+/* Title + Description live in here; they keep their own bottom
+   margins so the header collapses to whichever pieces the consumer
+   actually renders. */
+.headerText {
+  flex: 1;
+  min-width: 0;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-3);
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  margin-top: var(--ds-space-4);
+}

--- a/packages/agents-server-ui/src/ui/Dialog.tsx
+++ b/packages/agents-server-ui/src/ui/Dialog.tsx
@@ -1,5 +1,8 @@
 import { Dialog as BaseDialog } from '@base-ui/react/dialog'
+import { X } from 'lucide-react'
 import type { CSSProperties, ReactNode } from 'react'
+import { Icon } from './Icon'
+import { IconButton } from './IconButton'
 import styles from './Dialog.module.css'
 
 interface RootProps {
@@ -118,6 +121,84 @@ function Description({
   )
 }
 
+/**
+ * Standard dialog header — title/description on the left, an X close
+ * button on the right. Pair with `Dialog.Title` + `Dialog.Description`
+ * as children. Replaces the ad-hoc flex row that consumers were
+ * hand-rolling around `Dialog.Title` + an IconButton-Close.
+ */
+function Header({
+  children,
+  closeAriaLabel = `Close dialog`,
+}: {
+  children: ReactNode
+  closeAriaLabel?: string
+}): React.ReactElement {
+  return (
+    <div className={styles.header}>
+      <div className={styles.headerText}>{children}</div>
+      <CloseButton ariaLabel={closeAriaLabel} />
+    </div>
+  )
+}
+
+/** Scrollable body — vertical Stack-like layout with the standard gap. */
+function Body({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}): React.ReactElement {
+  return (
+    <div className={[styles.body, className].filter(Boolean).join(` `)}>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Footer for actions — right-aligned row. Wrap cancel + submit buttons.
+ * The cancel button is typically a `Dialog.Close` render-prop wrapping
+ * a `Button` so it dismisses without consumer wiring.
+ */
+function Footer({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}): React.ReactElement {
+  return (
+    <div className={[styles.footer, className].filter(Boolean).join(` `)}>
+      {children}
+    </div>
+  )
+}
+
+function CloseButton({
+  ariaLabel = `Close dialog`,
+}: {
+  ariaLabel?: string
+}): React.ReactElement {
+  return (
+    <BaseDialog.Close
+      render={
+        <IconButton
+          type="button"
+          size={1}
+          variant="ghost"
+          tone="neutral"
+          round
+          aria-label={ariaLabel}
+        >
+          <Icon icon={X} size={2} />
+        </IconButton>
+      }
+    />
+  )
+}
+
 export const Dialog = {
   Root,
   Trigger: BaseDialog.Trigger,
@@ -125,4 +206,8 @@ export const Dialog = {
   Content,
   Title,
   Description,
+  Header,
+  Body,
+  Footer,
+  CloseButton,
 }

--- a/packages/agents/src/server.ts
+++ b/packages/agents/src/server.ts
@@ -86,6 +86,11 @@ export class BuiltinAgentsServer {
   private mcpToolProviderName: string | null = null
   private mcpApplyInFlight: Set<Promise<void>> = new Set()
   private mcpStopping = false
+  // Live extras list — mutated by `setExtraMcpServers` and re-merged with
+  // `mcpLastJsonConfig` on every apply. Workspace `mcp.json` still wins
+  // on name collision (same rule as boot-time merge).
+  private mcpExtras: ReadonlyArray<McpServerConfig> = []
+  private mcpLastJsonConfig: McpConfig | null = null
   private pullWakeRunner: PullWakeRunner | null = null
   readonly options: BuiltinAgentsServerOptions
 
@@ -96,6 +101,73 @@ export class BuiltinAgentsServer {
   /** Embedded MCP registry. `null` until `start()` has run. */
   get mcpRegistry(): McpRegistry | null {
     return this._mcpRegistry
+  }
+
+  /**
+   * Replace the in-memory `extras` list and re-apply the merged config
+   * against the last-known workspace `mcp.json` state. Workspace
+   * `mcp.json` still wins on name collision. No-op once `stop()` has
+   * latched `mcpStopping`.
+   */
+  async setExtraMcpServers(
+    extras: ReadonlyArray<McpServerConfig>
+  ): Promise<void> {
+    if (!this._mcpRegistry || this.mcpStopping) return
+    this.mcpExtras = extras
+    await this.applyMerged(this.mcpLastJsonConfig)
+  }
+
+  private async wirePersistence(cfg: McpConfig): Promise<McpConfig> {
+    const servers: McpServerConfig[] = []
+    for (const s of cfg.servers) {
+      if (s.transport === `http` && s.auth?.mode === `authorizationCode`) {
+        const persist = await keychainPersistence({ server: s.name })
+        servers.push({
+          ...s,
+          auth: { ...s.auth, ...persist },
+        })
+      } else {
+        servers.push(s)
+      }
+    }
+    return { ...cfg, servers }
+  }
+
+  // On name conflict between extras and mcp.json, mcp.json wins.
+  private mergeMcp(jsonCfg: McpConfig | null): McpConfig {
+    const jsonServers = jsonCfg?.servers ?? []
+    const jsonNames = new Set(jsonServers.map((s) => s.name))
+    const filteredExtras = this.mcpExtras.filter((s) => !jsonNames.has(s.name))
+    return {
+      servers: [...filteredExtras, ...jsonServers],
+      raw: jsonCfg?.raw,
+    }
+  }
+
+  private async runApply(jsonCfg: McpConfig | null): Promise<void> {
+    if (this.mcpStopping) return
+    const registry = this._mcpRegistry
+    if (!registry) return
+    try {
+      const wired = await this.wirePersistence(this.mergeMcp(jsonCfg))
+      if (this.mcpStopping) return
+      await registry.applyConfig(wired)
+    } catch (e) {
+      serverLog.error(`[mcp] applyConfig:`, e)
+      try {
+        this.options.onConfigError?.(e)
+      } catch (cbErr) {
+        serverLog.error(`[mcp] onConfigError callback failed:`, cbErr)
+      }
+    }
+  }
+
+  private applyMerged(jsonCfg: McpConfig | null): Promise<void> {
+    this.mcpLastJsonConfig = jsonCfg
+    const p = this.runApply(jsonCfg)
+    this.mcpApplyInFlight.add(p)
+    void p.finally(() => this.mcpApplyInFlight.delete(p))
+    return p
   }
 
   async start(): Promise<string> {
@@ -123,91 +195,41 @@ export class BuiltinAgentsServer {
             `mcp.json`
           )
         : null
-      const extras = this.options.extraMcpServers ?? []
-
-      const wirePersistence = async (cfg: McpConfig): Promise<McpConfig> => {
-        const servers: McpServerConfig[] = []
-        for (const s of cfg.servers) {
-          if (s.transport === `http` && s.auth?.mode === `authorizationCode`) {
-            const persist = await keychainPersistence({ server: s.name })
-            servers.push({
-              ...s,
-              auth: { ...s.auth, ...persist },
-            })
-          } else {
-            servers.push(s)
-          }
-        }
-        return { ...cfg, servers }
-      }
-
-      // On name conflict between extras and mcp.json, mcp.json wins.
-      const merge = (jsonCfg: McpConfig | null): McpConfig => {
-        const jsonServers = jsonCfg?.servers ?? []
-        const jsonNames = new Set(jsonServers.map((s) => s.name))
-        const filteredExtras = extras.filter((s) => !jsonNames.has(s.name))
-        return {
-          servers: [...filteredExtras, ...jsonServers],
-          raw: jsonCfg?.raw,
-        }
-      }
-
-      const onConfigError = this.options.onConfigError
-      const runApply = async (jsonCfg: McpConfig | null): Promise<void> => {
-        if (this.mcpStopping) return
-        try {
-          const wired = await wirePersistence(merge(jsonCfg))
-          if (this.mcpStopping) return
-          await mcpRegistry.applyConfig(wired)
-        } catch (e) {
-          serverLog.error(`[mcp] applyConfig:`, e)
-          try {
-            onConfigError?.(e)
-          } catch (cbErr) {
-            serverLog.error(`[mcp] onConfigError callback failed:`, cbErr)
-          }
-        }
-      }
-      const applyMerged = (jsonCfg: McpConfig | null): Promise<void> => {
-        const p = runApply(jsonCfg)
-        this.mcpApplyInFlight.add(p)
-        void p.finally(() => this.mcpApplyInFlight.delete(p))
-        return p
-      }
+      this.mcpExtras = this.options.extraMcpServers ?? []
 
       if (mcpConfigPath) {
         try {
           const cfg = await loadMcpConfig(mcpConfigPath, process.env)
-          void applyMerged(cfg)
+          void this.applyMerged(cfg)
         } catch (err) {
           if ((err as NodeJS.ErrnoException).code !== `ENOENT`) throw err
-          if (extras.length === 0) {
+          if (this.mcpExtras.length === 0) {
             serverLog.info(
               `[mcp] no ${mcpConfigPath} — starting with no servers`
             )
           } else {
             serverLog.info(
-              `[mcp] no ${mcpConfigPath} — starting with ${extras.length} server(s) from extras`
+              `[mcp] no ${mcpConfigPath} — starting with ${this.mcpExtras.length} server(s) from extras`
             )
           }
-          void applyMerged(null)
+          void this.applyMerged(null)
         }
 
         try {
           this.mcpWatcherCloser = await watchMcpConfig(mcpConfigPath, {
-            onChange: (cfg) => void applyMerged(cfg),
+            onChange: (cfg) => void this.applyMerged(cfg),
             onError: (e) => serverLog.error(`[mcp] config error:`, e),
           })
         } catch (e) {
           serverLog.error(`[mcp] config watcher failed to start:`, e)
         }
       } else {
-        if (extras.length > 0) {
+        if (this.mcpExtras.length > 0) {
           serverLog.info(
-            `[mcp] starting with ${extras.length} server(s) from extras`
+            `[mcp] starting with ${this.mcpExtras.length} server(s) from extras`
           )
         }
-        void applyMerged(null)
+        void this.applyMerged(null)
       }
 
       this.mcpToolProviderName = `mcp`

--- a/packages/agents/test/bootstrap-mcp.test.ts
+++ b/packages/agents/test/bootstrap-mcp.test.ts
@@ -236,6 +236,55 @@ describe(`BuiltinAgentsServer — MCP merge`, () => {
     expect(server.mcpRegistry!.get(`workspace-only`)).toBeUndefined()
   })
 
+  it(`setExtraMcpServers re-applies merged config at runtime`, async () => {
+    // Start with a single extras entry; mcp.json is empty.
+    server = new BuiltinAgentsServer({
+      agentServerUrl: mockServer.url,
+      pullWake: { runnerId: `test-runner` },
+      mockStreamFn,
+      workingDirectory: workspace,
+      loadProjectMcpConfig: true,
+      extraMcpServers: [
+        {
+          name: `initial`,
+          transport: `http`,
+          url: `https://example.invalid/mcp`,
+          auth: { mode: `apiKey`, key: `k`, headerName: `X-Api-Key` },
+        },
+      ],
+    })
+    await server.start()
+    await waitForServers(server, [`initial`])
+
+    // Replace extras with a brand-new entry — the prior one should be
+    // dropped from the registry without a restart.
+    await server.setExtraMcpServers([
+      {
+        name: `replacement`,
+        transport: `http`,
+        url: `https://example.invalid/mcp`,
+        auth: { mode: `apiKey`, key: `k`, headerName: `X-Api-Key` },
+      },
+    ])
+    await waitForServers(server, [`replacement`])
+
+    // Re-applying with the same extras list shouldn't blow up either —
+    // idempotent, no churn in the registry.
+    await server.setExtraMcpServers([
+      {
+        name: `replacement`,
+        transport: `http`,
+        url: `https://example.invalid/mcp`,
+        auth: { mode: `apiKey`, key: `k`, headerName: `X-Api-Key` },
+      },
+    ])
+    await waitForServers(server, [`replacement`])
+
+    // Clearing extras removes everything.
+    await server.setExtraMcpServers([])
+    await waitForServers(server, [])
+  })
+
   it(`stop() tears down MCP registry, watcher, and tool provider`, async () => {
     await writeMcpJson(workspace, {
       servers: {


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric/issues/4465

## Summary

Adds a form-based **Add / Edit / Remove** flow for MCP servers in the desktop's Settings → MCP Servers page. Before this, the only way to register a server was to hand-edit `settings.json` or a workspace `mcp.json`.

The dialog supports both transports (`http` + `stdio`), all four auth modes (`none`, `apiKey`, `clientCredentials`, `authorizationCode`), and writes through to the global `settings.json mcp.servers` block. Updates flow into the live MCP registry without a runtime restart.

## What changed

### `@electric-ax/agents` — `BuiltinAgentsServer.setExtraMcpServers(extras)`

Lifts the previously-closure-captured `extras` + last-known mcp.json state onto the class so a public `setExtraMcpServers()` method can replay the same merge path the workspace `mcp.json` watcher already uses. Workspace `mcp.json` still wins on name collision (same precedence rule, single code path).

### `@electric-ax/agents-desktop`

- New IPC verbs `desktop:mcp-upsert` + `desktop:mcp-remove` in `ipc/mcp.ts`.
- `runtime/mcp.ts`:
  - `upsertMcpServer` / `removeMcpServer` — persist to `settings.json mcp.servers`, fire-and-forget push to `setExtraMcpServers`, immediate snapshot rebroadcast so the dialog closes the moment the disk write is done (the transport rebuild — npm install for stdio, MCP handshake — runs in the background and the row animates `connecting → ready`).
  - `enrichSnapshot` — produces a UI-friendly snapshot that knows where each server came from (`settings` / `workspace` / `extras`) and surfaces shadow rows when a `settings.json` name collides with a workspace `mcp.json` entry.
- `settings/store.ts` — `validateMcpServerConfig`, `upsertMcpServerInSettings`, `removeMcpServerFromSettings` helpers (regex-validated against Anthropic's tool-name shape since the server name becomes the `mcp__<server>__<tool>` prefix).

### `@electric-ax/agents-server-ui`

- New `McpServerFormDialog` covering Add + Edit. Per-transport fields, per-auth-mode subforms, name regex validation, "would overwrite" warning on Add when the name already exists in `settings.json`.
- `McpServersPage` gains an Add CTA, per-row Edit + Remove on `settings` rows, "from mcp.json" + "programmatic" provenance badges, grayed-out treatment + "overridden by mcp.json" badge on shadowed `settings` rows that render next to the running workspace twin.

## Notes for reviewers

- **Secrets posture unchanged.** `apiKey.key` and `clientCredentials.clientSecret` still land in `settings.json` plaintext — same as today. Routing them through `SecretStore.encryptString` was discussed and deferred (out of scope).
- **Add only writes to `settings.json`.** The desktop never writes to workspace `mcp.json`; other tools own that file (and it can be checked into git).
- **Workspace-wins still holds.** Editing a workspace-shadowed `settings.json` entry only affects the `settings.json` copy. The row stays grayed-out until the workspace entry is removed.
- **Optimistic close.** Save resolves as soon as `settings.json` is written. Errors during the registry rebuild surface in the row's `error` status, not the dialog.

## Test plan

- [x] `pnpm --filter @electric-ax/agents test` — 48 tests pass, including a new `setExtraMcpServers re-applies merged config at runtime` case in `bootstrap-mcp.test.ts`.
- [x] `pnpm --filter @electric-ax/agents typecheck`; same for `agents-desktop`, `agents-server-ui`.
- [x] Manual smoke (local dev): Add a stdio MCP server (`npx -y @modelcontextprotocol/server-everything`) via the form → row reaches `ready` with the expected tool list → spawn a fresh Horton session → `mcp__everything__echo` resolves end-to-end.
- [ ] Reviewer should verify the shadowing path: with the smoke MCP added via the form, drop a workspace `mcp.json` containing a server with the same name and confirm the settings row goes grayed-out next to the workspace twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)