### PR TITLE
feat(agents-desktop): seed @playwright/mcp as a default MCP server

### DIFF
--- a/.changeset/agents-desktop-default-playwright-mcp.md
+++ b/.changeset/agents-desktop-default-playwright-mcp.md
@@ -1,0 +1,13 @@
+---
+'@electric-ax/agents-desktop': patch
+---
+
+Seed `@playwright/mcp` into the desktop's `settings.json mcp.servers`
+block on first launch — gives every new install browser automation
+out of the box. The default is opt-out friendly: after the seed runs,
+the entry behaves like any other settings.json MCP server (Edit,
+Remove, Disable all work normally), and removing it sticks across
+restarts thanks to a per-name `seededDefaultMcpServerNames` flag.
+Future built-in defaults can be added to `DEFAULT_MCP_SERVERS` in
+`settings/mcp-defaults.ts`; existing installs will pick them up on
+the next launch as long as the name isn't already recorded as seeded.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_store
 .vscode
 **/*.vitest-temp.json
+**/.playwright-mcp/
 **/dist/**
 /packages/sync-service/state/
 /website/.netlify

--- a/packages/agents-desktop/src/settings/bootstrap.ts
+++ b/packages/agents-desktop/src/settings/bootstrap.ts
@@ -1,5 +1,6 @@
 import { normalizeServer } from './servers'
 import { loadDesktopSettings } from './store'
+import { seedDefaultMcpServers } from './mcp-defaults'
 import { INITIAL_SERVER_URL, PULL_WAKE_RUNNER_ID } from '../shared/constants'
 import type {
   ApiKeys,
@@ -79,11 +80,17 @@ export async function loadSettings(deps: SettingsBootstrapDeps): Promise<void> {
     ensureRuntimeEntry: deps.ensureRuntimeEntry,
     pullWakeRunnerId: PULL_WAKE_RUNNER_ID,
   })
+  // Seed built-in MCP servers (opt-out): mutates settings + flips the
+  // per-name seeded flag. Runs after the disk load so removals from a
+  // previous launch (stored in `seededDefaultMcpServerNames`) are
+  // honored, and before any runtime starts so the first connection
+  // sees these in its `extraMcpServers`.
+  const mcpSeeded = seedDefaultMcpServers(deps.settings)
   Object.assign(deps.state, deps.desktopStateForWindow(null))
   await applyInitialServerFromEnv(deps)
   deps.applyApiKeys()
   await deps.syncCodexEnvironment()
-  if (shouldSave) {
+  if (shouldSave || mcpSeeded) {
     await deps.saveSettings()
   }
 }

--- a/packages/agents-desktop/src/settings/mcp-defaults.ts
+++ b/packages/agents-desktop/src/settings/mcp-defaults.ts
@@ -1,0 +1,56 @@
+import { upsertMcpServerInSettings } from './store'
+import type { DesktopSettings, McpServerConfig } from '../shared/types'
+
+/**
+ * Built-in MCP servers we seed into a fresh install's `settings.json`
+ * `mcp.servers` block. Behaves as an "opt-out" default — after the
+ * first launch, each entry here behaves like any other settings.json
+ * MCP server: editable, removable, and disabling sticks.
+ *
+ * Each entry is seeded at most once per install per name (see
+ * `seededDefaultMcpServerNames` in DesktopSettings). Removing an entry
+ * after first launch does NOT cause it to be re-seeded, so the user's
+ * intent is respected.
+ *
+ * To add a new default in a future release: append a new entry here.
+ * Existing installs will pick it up on the next launch as long as the
+ * name isn't already in `seededDefaultMcpServerNames`.
+ */
+export const DEFAULT_MCP_SERVERS: ReadonlyArray<McpServerConfig> = [
+  {
+    name: `playwright`,
+    transport: `stdio`,
+    command: `npx`,
+    args: [`-y`, `@playwright/mcp`],
+  },
+]
+
+/**
+ * Seed any `DEFAULT_MCP_SERVERS` entries that haven't been considered
+ * yet for this install. Returns true iff `settings` was mutated (so the
+ * caller knows to persist).
+ *
+ * Skips defaults whose name is already in `settings.mcp.servers` (the
+ * user may have hand-added that name before this feature shipped — we
+ * don't overwrite). The name is still recorded as seeded so we won't
+ * try again on the next launch.
+ */
+export function seedDefaultMcpServers(settings: DesktopSettings): boolean {
+  const seeded = new Set(settings.seededDefaultMcpServerNames ?? [])
+  let mutated = false
+  for (const cfg of DEFAULT_MCP_SERVERS) {
+    if (seeded.has(cfg.name)) continue
+    const existing = (settings.mcp?.servers ?? []).some(
+      (s) => s.name === cfg.name
+    )
+    if (!existing) {
+      upsertMcpServerInSettings(settings, cfg)
+    }
+    seeded.add(cfg.name)
+    mutated = true
+  }
+  if (mutated) {
+    settings.seededDefaultMcpServerNames = [...seeded].sort()
+  }
+  return mutated
+}

--- a/packages/agents-desktop/src/settings/store.ts
+++ b/packages/agents-desktop/src/settings/store.ts
@@ -168,6 +168,16 @@ export async function loadDesktopSettings(
       enabledModelValues:
         enabledModelValues.length > 0 ? enabledModelValues : undefined,
       mcp: normalizeMcp(parsed.mcp),
+      seededDefaultMcpServerNames: Array.isArray(
+        (parsed as { seededDefaultMcpServerNames?: unknown })
+          .seededDefaultMcpServerNames
+      )
+        ? (
+            parsed as { seededDefaultMcpServerNames: Array<unknown> }
+          ).seededDefaultMcpServerNames.filter(
+            (n): n is string => typeof n === `string`
+          )
+        : undefined,
       pullWakeRunnerId,
     })
     if (parsed.apiKeys !== undefined) {

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -133,6 +133,7 @@ export type DesktopSettings = {
   enabledModelValues?: Array<string>
   onboardingDismissed?: boolean
   mcp?: { servers: Array<McpServerConfig> }
+  seededDefaultMcpServerNames?: Array<string>
   pullWakeRunnerId?: string
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #4471. Seeds `@playwright/mcp` into the desktop's
`settings.json mcp.servers` block on first launch so every new install
gets browser automation out of the box, without making it feel like an
unremovable system tool.

**Opt-out friendly:** after the seed runs, the Playwright entry is an
ordinary `settings.json` MCP server — editable, removable, and the
removal persists across restarts.

## How removal persistence works

A new `seededDefaultMcpServerNames: Array<string>` field on
`DesktopSettings` tracks which default names this install has already
considered. On boot, `seedDefaultMcpServers(settings)` walks
`DEFAULT_MCP_SERVERS` and, for each entry whose name isn't already in
that list:

1. If the user doesn't already have a server with this name in
   `settings.mcp.servers`, upsert it (so a hand-added Playwright with a
   custom config wouldn't be overwritten).
2. Either way, add the name to `seededDefaultMcpServerNames`.

That means:

- **New install** — Playwright gets seeded, name recorded. User sees a
  `playwright` row in Settings → MCP Servers.
- **Existing install upgrading to this version** — same as new install
  for the first launch.
- **User removes Playwright after first launch** — `playwright` is
  already in `seededDefaultMcpServerNames`, so it never re-seeds.
- **Future release adds a second default (e.g. `fetch`)** — existing
  installs get `fetch` seeded on the next launch without re-adding any
  defaults the user has previously removed.

## Files

- `src/settings/mcp-defaults.ts` (new) — `DEFAULT_MCP_SERVERS` constant + `seedDefaultMcpServers(settings)`.
- `src/shared/types.ts` — new `seededDefaultMcpServerNames` field on `DesktopSettings`.
- `src/settings/store.ts` — parses the new field on load (string-array filter).
- `src/settings/bootstrap.ts` — calls `seedDefaultMcpServers` after `loadDesktopSettings`, before any runtime starts; saves settings if seeding mutated anything.

## Test plan

- [x] `pnpm --filter @electric-ax/agents-desktop typecheck`.
- [ ] **Fresh install** (delete `~/Library/Application Support/Electric Agents/settings.json`, relaunch) — Settings → MCP Servers shows `playwright` row, ready after `npx -y @playwright/mcp` resolves. `settings.json` now contains `mcp.servers.playwright` and `seededDefaultMcpServerNames: ["playwright"]`.
- [ ] **Existing install** (no `mcp` block in settings.json) — same as above on next launch.
- [ ] **Removal persists** — Remove `playwright` from the UI, relaunch desktop. Row stays gone, `settings.json` still has `seededDefaultMcpServerNames: ["playwright"]`.
- [ ] **Hand-added Playwright preserved** — pre-populate `settings.json` with a custom `playwright` entry, then relaunch. Custom config is not overwritten, but `playwright` is still recorded in `seededDefaultMcpServerNames`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)