### PR TITLE
feat(agents-mobile): unified server picker + auth refinement in kebab menu

### DIFF
--- a/.changeset/mobile-server-picker-refinements.md
+++ b/.changeset/mobile-server-picker-refinements.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-mobile": patch
+---
+
+Harden the mobile kebab-menu server picker: surface connect failures in-sheet instead of silently swallowing them, persist a Cloud server only after the switch succeeds, and let the submenu close animation finish before resetting to the root page.

--- a/packages/agents-mobile/src/components/BottomSheet.tsx
+++ b/packages/agents-mobile/src/components/BottomSheet.tsx
@@ -192,36 +192,53 @@ export function BottomSheetSection({
 
 export function BottomSheetItem({
   label,
+  subtitle,
   icon,
   trailing,
   active,
   onPress,
   destructive,
+  disabled,
 }: {
   label: string
+  subtitle?: string
   icon?: ReactNode
   trailing?: ReactNode
   active?: boolean
   onPress: () => void
   destructive?: boolean
+  disabled?: boolean
 }): React.ReactElement {
   const tokens = useTokens()
   const styles = useMemo(() => itemStyles(tokens), [tokens])
   return (
-    <Pressable onPress={onPress}>
+    <Pressable onPress={onPress} disabled={disabled}>
       {({ pressed }) => (
-        <View style={[styles.row, pressed ? styles.pressed : null]}>
+        <View
+          style={[
+            styles.row,
+            pressed && !disabled ? styles.pressed : null,
+            disabled ? styles.disabled : null,
+          ]}
+        >
           <View style={styles.icon}>{icon}</View>
-          <Text
-            numberOfLines={1}
-            style={[
-              styles.label,
-              destructive ? styles.destructive : null,
-              active ? styles.activeLabel : null,
-            ]}
-          >
-            {label}
-          </Text>
+          <View style={styles.labelColumn}>
+            <Text
+              numberOfLines={1}
+              style={[
+                styles.label,
+                destructive ? styles.destructive : null,
+                active ? styles.activeLabel : null,
+              ]}
+            >
+              {label}
+            </Text>
+            {subtitle ? (
+              <Text numberOfLines={1} style={styles.subtitle}>
+                {subtitle}
+              </Text>
+            ) : null}
+          </View>
           <View style={styles.trailing}>
             {trailing ?? (active ? <CheckGlyph color={tokens.text1} /> : null)}
           </View>
@@ -314,22 +331,33 @@ function itemStyles(tokens: Tokens) {
       flexDirection: `row`,
       alignItems: `center`,
       gap: spacing.sm,
-      height: rowHeight.lg,
+      minHeight: rowHeight.lg,
+      paddingVertical: 6,
       paddingHorizontal: spacing.sm,
       borderRadius: radii.md,
     },
     pressed: {
       backgroundColor: tokens.bgHover,
     },
+    disabled: {
+      opacity: 0.5,
+    },
     icon: {
       width: 22,
       alignItems: `center`,
       justifyContent: `center`,
     },
-    label: {
+    labelColumn: {
       flex: 1,
+      gap: 1,
+    },
+    label: {
       color: tokens.text1,
       fontSize: fontSize.base,
+    },
+    subtitle: {
+      color: tokens.text3,
+      fontSize: 11,
     },
     activeLabel: {
       fontWeight: `500`,

--- a/packages/agents-mobile/src/components/CloudServerPicker.tsx
+++ b/packages/agents-mobile/src/components/CloudServerPicker.tsx
@@ -27,7 +27,7 @@ export function CloudServerPicker({
   disabled,
   style,
 }: {
-  onConnect: (url: string) => Promise<void> | void
+  onConnect: (url: string, server: CloudAgentServer) => Promise<void> | void
   disabled?: boolean
   style?: StyleProp<ViewStyle>
 }): React.ReactElement | null {
@@ -42,7 +42,7 @@ export function CloudServerPicker({
     if (connectingKey) return
     setConnectingKey(server.id)
     try {
-      await onConnect(cloudAgentServerUrl(server.id))
+      await onConnect(cloudAgentServerUrl(server.id), server)
     } finally {
       setConnectingKey(null)
     }

--- a/packages/agents-mobile/src/components/HomeMenu.tsx
+++ b/packages/agents-mobile/src/components/HomeMenu.tsx
@@ -113,12 +113,14 @@ export function HomeMenu({
 
   const handleClose = (): void => {
     onClose()
-    // Reset the submenu so the next open shows the root page. Done
-    // after the dismiss animation so the user doesn't see a flash.
+    // Reset the submenu so the next open shows the root page. Done after
+    // the dismiss animation completes (BottomSheet closes over 190ms, the
+    // drill transition over 180ms) so the pane doesn't visibly snap back
+    // to root mid-close.
     setTimeout(() => {
       setPage(`root`)
       resetDrill()
-    }, 150)
+    }, 200)
   }
 
   const goTo = (next: Page, direction: 1 | -1): void => {
@@ -381,15 +383,23 @@ function ServerListPage({
   const { saveServerUrl } = useMobileAppState()
   const { state: cloudState } = useCloudAuth()
   const [connectingKey, setConnectingKey] = useState<string | null>(null)
+  const [connectError, setConnectError] = useState<string | null>(null)
 
   const selectServer = async (item: AvailableServer): Promise<void> => {
     if (connectingKey) return
     setConnectingKey(item.key)
+    setConnectError(null)
     try {
-      // For a live Cloud server not yet in the saved list, persist it so
-      // it survives a relaunch (and can be purged on sign-out).
+      // For a live Cloud server not yet in the saved list, register its
+      // auth headers first — Cloud rejects unauthenticated requests with
+      // 401, so this must succeed before we switch to it.
       if (!item.saved && item.kind === `cloud`) {
         await prepareServerHeaders(item.url)
+      }
+      await saveServerUrl(item.url)
+      // Persist only after the switch succeeds, so the saved list never
+      // holds a server we couldn't actually connect to.
+      if (!item.saved && item.kind === `cloud`) {
         const serviceId = getCloudServiceIdFromServerUrl(item.url)
         addSavedServer({
           id: serviceId ?? item.url,
@@ -398,8 +408,11 @@ function ServerListPage({
           source: `electric-cloud`,
         })
       }
-      await saveServerUrl(item.url)
       onClose()
+    } catch (err) {
+      // Surface the failure in-sheet rather than silently closing the
+      // spinner — mirrors ServerSetupScreen's cloudConnectError handling.
+      setConnectError(err instanceof Error ? err.message : String(err))
     } finally {
       setConnectingKey(null)
     }
@@ -455,6 +468,11 @@ function ServerListPage({
               }}
             />
           ))
+        )}
+        {connectError && (
+          <Text style={[styles.errorText, { color: tokens.red11 }]}>
+            {connectError}
+          </Text>
         )}
       </BottomSheetSection>
       <BottomSheetSeparator />
@@ -535,5 +553,11 @@ const styles = StyleSheet.create({
   },
   connecting: {
     fontSize: 16,
+  },
+  errorText: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 13,
+    lineHeight: 18,
   },
 })

--- a/packages/agents-mobile/src/components/HomeMenu.tsx
+++ b/packages/agents-mobile/src/components/HomeMenu.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Text } from 'react-native'
+import { Animated, StyleSheet, Text } from 'react-native'
 import { useLiveQuery } from '@tanstack/react-db'
 import {
   BottomSheet,
@@ -8,7 +8,14 @@ import {
   BottomSheetSeparator,
 } from './BottomSheet'
 import { Icon } from './Icon'
+import { useDrillTransition } from './useDrillTransition'
 import { useAgents } from '../lib/AgentsProvider'
+import { useMobileAppState } from '../lib/MobileAppState'
+import { useCloudAuth } from '../lib/CloudAuthContext'
+import { useAvailableServers } from '../lib/useAvailableServers'
+import { addSavedServer } from '../lib/savedServers'
+import { getCloudServiceIdFromServerUrl } from '../lib/cloudAgentUrls'
+import { prepareServerHeaders } from '../lib/serverHeaders'
 import {
   SIDEBAR_GROUP_BY_LABELS,
   SIDEBAR_GROUP_BY_OPTIONS,
@@ -25,6 +32,7 @@ import {
   type ThemePreference,
 } from '../lib/themePref'
 import { useTokens } from '../lib/ThemeProvider'
+import type { AvailableServer } from '../lib/useAvailableServers'
 
 const STATUSES: ReadonlyArray<string> = [
   `spawning`,
@@ -35,12 +43,16 @@ const STATUSES: ReadonlyArray<string> = [
 
 export type ServerHealth = `ok` | `down` | `unset`
 
+type Page = `root` | `server` | `type` | `status`
+
 /**
  * Bottom-sheet "more" menu for the home screen — combines the actions
  * the old `<SidebarFooter>` exposed (server, filter, settings) into a
- * single ChatGPT-style kebab popover. Submenus drill in/out of:
+ * single ChatGPT-style kebab popover. Submenus slide in/out (via
+ * `useDrillTransition`) between:
  *
- *   - root (default): Server / Group / Show / Theme / Diagnostics
+ *   - root (default): Server / Group / Show / Theme / Account / Diagnostics
+ *   - server: unified list of saved + Cloud agent servers
  *   - type: per-type visibility checkboxes
  *   - status: per-status visibility checkboxes
  */
@@ -63,7 +75,8 @@ export function HomeMenu({
   const { serverUrl, entitiesCollection } = useAgents()
   const prefs = useSidebarPrefs()
   const themePreference = useThemePreference()
-  const [page, setPage] = useState<`root` | `type` | `status`>(`root`)
+  const [page, setPage] = useState<Page>(`root`)
+  const { style: drillStyle, drill, reset: resetDrill } = useDrillTransition()
 
   const { data: entities = [] } = useLiveQuery(
     (query) =>
@@ -79,13 +92,17 @@ export function HomeMenu({
     return Array.from(seen).sort((a, b) => a.localeCompare(b))
   }, [entities])
 
+  const availableServers = useAvailableServers()
+
   const serverName = useMemo(() => {
+    const active = availableServers.find((s) => s.isActive)
+    if (active) return active.name
     try {
       return new URL(serverUrl).host || serverUrl
     } catch {
       return serverUrl
     }
-  }, [serverUrl])
+  }, [availableServers, serverUrl])
 
   const dotColor =
     serverHealth === `ok`
@@ -98,71 +115,89 @@ export function HomeMenu({
     onClose()
     // Reset the submenu so the next open shows the root page. Done
     // after the dismiss animation so the user doesn't see a flash.
-    setTimeout(() => setPage(`root`), 150)
+    setTimeout(() => {
+      setPage(`root`)
+      resetDrill()
+    }, 150)
   }
 
+  const goTo = (next: Page, direction: 1 | -1): void => {
+    setPage(next)
+    drill(direction)
+  }
+
+  const title =
+    page === `server`
+      ? `Server`
+      : page === `type`
+        ? `Show types`
+        : page === `status`
+          ? `Show statuses`
+          : undefined
+
   return (
-    <BottomSheet
-      open={open}
-      onClose={handleClose}
-      title={
-        page === `root`
-          ? undefined
-          : page === `type`
-            ? `Show types`
-            : `Show statuses`
-      }
-    >
-      {page === `root` && (
-        <RootPage
-          serverName={serverName}
-          dotColor={dotColor}
-          themePreference={themePreference}
-          groupBy={prefs.groupBy}
-          onShowTypes={() => setPage(`type`)}
-          onShowStatuses={() => setPage(`status`)}
-          onChangeServer={() => {
-            handleClose()
-            onChangeServer()
-          }}
-          onOpenDiagnostics={() => {
-            handleClose()
-            onOpenDiagnostics()
-          }}
-          onOpenAccount={() => {
-            handleClose()
-            onOpenAccount()
-          }}
-        />
-      )}
+    <BottomSheet open={open} onClose={handleClose} title={title}>
+      <Animated.View style={[styles.drillPane, drillStyle]}>
+        {page === `root` && (
+          <RootPage
+            serverName={serverName}
+            dotColor={dotColor}
+            themePreference={themePreference}
+            groupBy={prefs.groupBy}
+            onShowServers={() => goTo(`server`, 1)}
+            onShowTypes={() => goTo(`type`, 1)}
+            onShowStatuses={() => goTo(`status`, 1)}
+            onOpenDiagnostics={() => {
+              handleClose()
+              onOpenDiagnostics()
+            }}
+            onOpenAccount={() => {
+              handleClose()
+              onOpenAccount()
+            }}
+          />
+        )}
 
-      {page === `type` && (
-        <SubPage
-          onBack={() => setPage(`root`)}
-          rows={
-            distinctTypes.length === 0
-              ? [{ key: `_empty`, label: `No types yet`, onPress: () => {} }]
-              : distinctTypes.map((type) => ({
-                  key: type,
-                  label: titleCase(type),
-                  active: !prefs.hiddenTypes.has(type),
-                  onPress: () => toggleSidebarTypeVisibility(type),
-                }))
-          }
-        />
-      )}
+        {page === `server` && (
+          <ServerListPage
+            servers={availableServers}
+            onBack={() => goTo(`root`, -1)}
+            onClose={handleClose}
+            onAddCustom={() => {
+              handleClose()
+              onChangeServer()
+            }}
+          />
+        )}
 
-      {page === `status` && (
-        <SubPage
-          onBack={() => setPage(`root`)}
-          rows={STATUSES.map((status) => ({
-            key: status,
-            label: titleCase(status),
-            active: !prefs.hiddenStatuses.has(status),
-            onPress: () => toggleSidebarStatusVisibility(status),
-          }))}
-        />
-      )}
+        {page === `type` && (
+          <SubPage
+            onBack={() => goTo(`root`, -1)}
+            rows={
+              distinctTypes.length === 0
+                ? [{ key: `_empty`, label: `No types yet`, onPress: () => {} }]
+                : distinctTypes.map((type) => ({
+                    key: type,
+                    label: titleCase(type),
+                    active: !prefs.hiddenTypes.has(type),
+                    onPress: () => toggleSidebarTypeVisibility(type),
+                  }))
+            }
+          />
+        )}
+
+        {page === `status` && (
+          <SubPage
+            onBack={() => goTo(`root`, -1)}
+            rows={STATUSES.map((status) => ({
+              key: status,
+              label: titleCase(status),
+              active: !prefs.hiddenStatuses.has(status),
+              onPress: () => toggleSidebarStatusVisibility(status),
+            }))}
+          />
+        )}
+      </Animated.View>
     </BottomSheet>
   )
 }
@@ -172,9 +207,9 @@ function RootPage({
   dotColor,
   themePreference,
   groupBy,
+  onShowServers,
   onShowTypes,
   onShowStatuses,
-  onChangeServer,
   onOpenDiagnostics,
   onOpenAccount,
 }: {
@@ -182,13 +217,23 @@ function RootPage({
   dotColor: string
   themePreference: ThemePreference
   groupBy: `date` | `type` | `status`
+  onShowServers: () => void
   onShowTypes: () => void
   onShowStatuses: () => void
-  onChangeServer: () => void
   onOpenDiagnostics: () => void
   onOpenAccount: () => void
 }): React.ReactElement {
   const tokens = useTokens()
+  const { state: cloudState } = useCloudAuth()
+  const isSignedIn = cloudState.status === `signed-in`
+  const accountLabel = isSignedIn
+    ? (cloudState.name ?? cloudState.email ?? `Account`)
+    : `Sign in to Electric Cloud`
+  const accountSubtitle =
+    isSignedIn && cloudState.name && cloudState.email
+      ? cloudState.email
+      : undefined
+
   return (
     <>
       <BottomSheetSection label="Server">
@@ -196,9 +241,14 @@ function RootPage({
           label={serverName}
           icon={<Text style={{ color: dotColor, fontSize: 14 }}>●</Text>}
           trailing={
-            <Icon name="swap" size={18} color={tokens.text3} strokeWidth={2} />
+            <Icon
+              name="chevron-right"
+              size={18}
+              color={tokens.text3}
+              strokeWidth={2}
+            />
           }
-          onPress={onChangeServer}
+          onPress={onShowServers}
         />
       </BottomSheetSection>
 
@@ -290,9 +340,10 @@ function RootPage({
       <BottomSheetSeparator />
 
       <BottomSheetItem
-        label="Account"
+        label={accountLabel}
+        subtitle={accountSubtitle}
         icon={
-          <Icon name="server" size={18} color={tokens.text2} strokeWidth={2} />
+          <Icon name="user" size={18} color={tokens.text2} strokeWidth={2} />
         }
         trailing={
           <Icon
@@ -311,6 +362,124 @@ function RootPage({
         }
         onPress={onOpenDiagnostics}
       />
+    </>
+  )
+}
+
+function ServerListPage({
+  servers,
+  onBack,
+  onClose,
+  onAddCustom,
+}: {
+  servers: ReadonlyArray<AvailableServer>
+  onBack: () => void
+  onClose: () => void
+  onAddCustom: () => void
+}): React.ReactElement {
+  const tokens = useTokens()
+  const { saveServerUrl } = useMobileAppState()
+  const { state: cloudState } = useCloudAuth()
+  const [connectingKey, setConnectingKey] = useState<string | null>(null)
+
+  const selectServer = async (item: AvailableServer): Promise<void> => {
+    if (connectingKey) return
+    setConnectingKey(item.key)
+    try {
+      // For a live Cloud server not yet in the saved list, persist it so
+      // it survives a relaunch (and can be purged on sign-out).
+      if (!item.saved && item.kind === `cloud`) {
+        await prepareServerHeaders(item.url)
+        const serviceId = getCloudServiceIdFromServerUrl(item.url)
+        addSavedServer({
+          id: serviceId ?? item.url,
+          name: item.name,
+          url: item.url,
+          source: `electric-cloud`,
+        })
+      }
+      await saveServerUrl(item.url)
+      onClose()
+    } finally {
+      setConnectingKey(null)
+    }
+  }
+
+  const emptyHint =
+    cloudState.status === `signed-in`
+      ? `No agent servers yet. Add a custom server below.`
+      : `Sign in from Account to discover Cloud servers, or add a custom server below.`
+
+  return (
+    <>
+      <BottomSheetSection>
+        <BottomSheetItem
+          label="Back"
+          icon={
+            <Icon name="back" size={18} color={tokens.text2} strokeWidth={2} />
+          }
+          onPress={onBack}
+        />
+      </BottomSheetSection>
+      <BottomSheetSeparator />
+      <BottomSheetSection label="Servers">
+        {servers.length === 0 ? (
+          <Text style={[styles.hint, { color: tokens.text3 }]}>
+            {emptyHint}
+          </Text>
+        ) : (
+          servers.map((item) => (
+            <BottomSheetItem
+              key={item.key}
+              label={item.name}
+              subtitle={item.breadcrumb}
+              active={item.isActive}
+              disabled={connectingKey !== null && connectingKey !== item.key}
+              icon={
+                <Icon
+                  name={item.kind === `cloud` ? `cloud` : `server`}
+                  size={18}
+                  color={tokens.text2}
+                  strokeWidth={2}
+                />
+              }
+              trailing={
+                connectingKey === item.key ? (
+                  <Text style={[styles.connecting, { color: tokens.text3 }]}>
+                    …
+                  </Text>
+                ) : undefined
+              }
+              onPress={() => {
+                void selectServer(item)
+              }}
+            />
+          ))
+        )}
+      </BottomSheetSection>
+      <BottomSheetSeparator />
+      <BottomSheetSection>
+        <BottomSheetItem
+          label="Add custom server…"
+          icon={
+            <Icon
+              name="server"
+              size={18}
+              color={tokens.text2}
+              strokeWidth={2}
+            />
+          }
+          trailing={
+            <Icon
+              name="chevron-right"
+              size={18}
+              color={tokens.text3}
+              strokeWidth={2}
+            />
+          }
+          onPress={onAddCustom}
+        />
+      </BottomSheetSection>
     </>
   )
 }
@@ -353,3 +522,18 @@ function SubPage({
 function titleCase(id: string): string {
   return id.replace(/[-_]+/g, ` `).replace(/\b\w/g, (c) => c.toUpperCase())
 }
+
+const styles = StyleSheet.create({
+  drillPane: {
+    overflow: `hidden`,
+  },
+  hint: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  connecting: {
+    fontSize: 16,
+  },
+})

--- a/packages/agents-mobile/src/components/Icon.tsx
+++ b/packages/agents-mobile/src/components/Icon.tsx
@@ -36,6 +36,8 @@ export type IconName =
   | `square`
   | `github`
   | `google`
+  | `cloud`
+  | `user`
 
 const PATHS: Record<IconName, string> = {
   back: `M15 18l-6-6 6-6`,
@@ -51,6 +53,8 @@ const PATHS: Record<IconName, string> = {
   moon: `M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z`,
   system: `M4 5h16v11H4zM9 20h6M12 16v4`,
   server: `M5 5h14v6H5zM5 13h14v6H5zM8 8h.01M8 16h.01`,
+  cloud: `M17.5 19a4.5 4.5 0 1 0-1.4-8.78A6 6 0 1 0 6 16.66 4 4 0 0 0 7 19h10.5Z`,
+  user: `M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8ZM5 21a7 7 0 0 1 14 0`,
   filter: `M4 5h16l-6 8v6l-4-2v-4Z`,
   info: `M12 8v.01M11 12h1v4h1M12 21a9 9 0 1 1 0-18 9 9 0 0 1 0 18Z`,
   swap: `M7 4l-3 3 3 3M4 7h13M17 14l3 3-3 3M20 17H7`,

--- a/packages/agents-mobile/src/components/SessionMenu.tsx
+++ b/packages/agents-mobile/src/components/SessionMenu.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
-import { Animated, Easing, StyleSheet, Text, View } from 'react-native'
+import { useEffect, useState } from 'react'
+import { Animated, StyleSheet, Text, View } from 'react-native'
 import {
   BottomSheet,
   BottomSheetItem,
@@ -7,6 +7,7 @@ import {
   BottomSheetSeparator,
 } from './BottomSheet'
 import { Icon } from './Icon'
+import { useDrillTransition } from './useDrillTransition'
 import { useTokens } from '../lib/ThemeProvider'
 import type { ElectricEntity, EntitySignal } from '../lib/agentsClient'
 import type { EmbedViewId } from '../lib/embedView'
@@ -125,8 +126,11 @@ export function SessionMenu({
 }): React.ReactElement {
   const tokens = useTokens()
   const [signalMenuOpen, setSignalMenuOpen] = useState(false)
-  const [drillDirection, setDrillDirection] = useState(1)
-  const drillProgress = useRef(new Animated.Value(1)).current
+  const {
+    style: drillPaneStyle,
+    drill,
+    reset: resetDrill,
+  } = useDrillTransition()
 
   const dotKey = entity ? (STATUS_DOT_COLORS[entity.status] ?? `gray`) : `gray`
   const dotColor =
@@ -144,19 +148,12 @@ export function SessionMenu({
   }
   const handleClose = (): void => {
     setSignalMenuOpen(false)
-    drillProgress.setValue(1)
+    resetDrill()
     onClose()
   }
   const transitionToMenu = (nextSignalMenuOpen: boolean): void => {
-    setDrillDirection(nextSignalMenuOpen ? 1 : -1)
-    drillProgress.setValue(0)
     setSignalMenuOpen(nextSignalMenuOpen)
-    Animated.timing(drillProgress, {
-      toValue: 1,
-      duration: 180,
-      easing: Easing.out(Easing.cubic),
-      useNativeDriver: true,
-    }).start()
+    drill(nextSignalMenuOpen ? 1 : -1)
   }
   const canSignal =
     entity !== null &&
@@ -177,21 +174,9 @@ export function SessionMenu({
   useEffect(() => {
     if (!open) {
       setSignalMenuOpen(false)
-      drillProgress.setValue(1)
+      resetDrill()
     }
-  }, [drillProgress, open])
-
-  const drillPaneStyle = {
-    opacity: drillProgress,
-    transform: [
-      {
-        translateX: drillProgress.interpolate({
-          inputRange: [0, 1],
-          outputRange: [drillDirection * 28, 0],
-        }),
-      },
-    ],
-  }
+  }, [open])
 
   return (
     <BottomSheet

--- a/packages/agents-mobile/src/components/useDrillTransition.ts
+++ b/packages/agents-mobile/src/components/useDrillTransition.ts
@@ -1,0 +1,62 @@
+import { useRef, useState } from 'react'
+import { Animated, Easing } from 'react-native'
+
+/** Horizontal slide offset (px) a drilling pane animates in/out from. */
+const DRILL_OFFSET = 28
+const DRILL_DURATION_MS = 180
+
+type DrillDirection = 1 | -1
+
+/**
+ * Shared "drill" transition for bottom-sheet submenus — the pane slides
+ * + fades 28px horizontally over 180ms whenever the caller navigates
+ * between pages. Direction `1` slides in from the right (drilling
+ * deeper); `-1` slides in from the left (backing out).
+ *
+ * The caller owns the page state; it calls `drill(direction)` alongside
+ * its `setPage(...)` so the new pane animates in. Used by both
+ * `SessionMenu` (signals submenu) and `HomeMenu` (server/type/status
+ * submenus).
+ */
+export function useDrillTransition(): {
+  style: {
+    opacity: Animated.Value
+    transform: Array<{ translateX: Animated.AnimatedInterpolation<number> }>
+  }
+  drill: (direction: DrillDirection) => void
+  reset: () => void
+} {
+  const [direction, setDirection] = useState<DrillDirection>(1)
+  const progress = useRef(new Animated.Value(1)).current
+
+  const drill = (nextDirection: DrillDirection): void => {
+    setDirection(nextDirection)
+    progress.setValue(0)
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: DRILL_DURATION_MS,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start()
+  }
+
+  // Snap to the resting state without animating — used when the sheet
+  // closes so the next open doesn't flash a mid-transition frame.
+  const reset = (): void => {
+    progress.setValue(1)
+  }
+
+  const style = {
+    opacity: progress,
+    transform: [
+      {
+        translateX: progress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [direction * DRILL_OFFSET, 0],
+        }),
+      },
+    ],
+  }
+
+  return { style, drill, reset }
+}

--- a/packages/agents-mobile/src/lib/MobileAppState.tsx
+++ b/packages/agents-mobile/src/lib/MobileAppState.tsx
@@ -74,6 +74,10 @@ export function MobileAppStateProvider({
       // active self-hosted server in the saved list so it appears in the
       // unified picker. Cloud servers are intentionally skipped — they come
       // from the live shape list (and would be purged on sign-out anyway).
+      // Caveat: an old query-param-routed Cloud URL is not recognised by
+      // getCloudServiceIdFromServerUrl (returns null), so it migrates as
+      // `manual` and won't be purged on sign-out. Accepted — that legacy
+      // URL format predates the unified picker and affects few/no users.
       if (
         storedUrl &&
         getCloudServiceIdFromServerUrl(storedUrl) === null &&

--- a/packages/agents-mobile/src/lib/MobileAppState.tsx
+++ b/packages/agents-mobile/src/lib/MobileAppState.tsx
@@ -1,17 +1,40 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import * as Linking from 'expo-linking'
 import type { ReactNode } from 'react'
 import { cloudAuth } from './cloudAuth'
+import { resolveActiveAfterCloudSignOut } from './availableServers'
+import { getCloudServiceIdFromServerUrl } from './cloudAgentUrls'
+import {
+  addSavedServer,
+  getSavedServers,
+  removeCloudSavedServers,
+} from './savedServers'
 import { prepareServerHeaders } from './serverHeaders'
 
 const SERVER_URL_KEY = `electric-agents-mobile.server-url`
 const ONBOARDING_DISMISSED_KEY = `electric-agents-mobile.onboarding-dismissed`
 
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host || url
+  } catch {
+    return url
+  }
+}
+
 type MobileAppState = {
   loading: boolean
   serverUrl: string | null
-  saveServerUrl: (next: string) => Promise<void>
+  /** Set (or, with `null`, clear) the active server. */
+  saveServerUrl: (next: string | null) => Promise<void>
   launchUrl: string | null
   /**
    * Whether the user has finished or explicitly opted out of the
@@ -47,6 +70,22 @@ export function MobileAppStateProvider({
       // headers registered. Otherwise a race window lets early fetches
       // go out unauthenticated and 401 against Cloud servers.
       await prepareServerHeaders(storedUrl)
+      // Migrate users upgrading from the single-URL model: surface their
+      // active self-hosted server in the saved list so it appears in the
+      // unified picker. Cloud servers are intentionally skipped — they come
+      // from the live shape list (and would be purged on sign-out anyway).
+      if (
+        storedUrl &&
+        getCloudServiceIdFromServerUrl(storedUrl) === null &&
+        !getSavedServers().some((s) => s.url === storedUrl)
+      ) {
+        addSavedServer({
+          id: storedUrl,
+          name: hostOf(storedUrl),
+          url: storedUrl,
+          source: `manual`,
+        })
+      }
       setServerUrl(storedUrl)
       setLaunchUrl(initialUrl)
       setOnboardingDismissedState(storedOnboarding === `true`)
@@ -54,28 +93,54 @@ export function MobileAppStateProvider({
     })()
   }, [])
 
+  const persistServerUrl = useCallback(
+    async (next: string | null): Promise<void> => {
+      if (next) {
+        await AsyncStorage.setItem(SERVER_URL_KEY, next)
+      } else {
+        await AsyncStorage.removeItem(SERVER_URL_KEY)
+      }
+      setServerUrl(next)
+    },
+    []
+  )
+
   // Re-apply headers on cloud-auth transitions so a fresh sign-in
   // immediately makes the agents-token available to in-flight
   // collections without restarting the app. Also re-runs on serverUrl
   // change (covers `saveServerUrl`).
+  //
+  // On sign-out we additionally purge persisted Cloud servers and, if the
+  // active server was a Cloud server (now unreachable without a token),
+  // fall back to a remaining self-hosted server — or clear the active
+  // server, which routes the user to the server-setup screen.
   useEffect(() => {
     if (loading) return
-    void prepareServerHeaders(serverUrl)
-    const unsubscribe = cloudAuth.subscribe(() => {
+    const apply = (): void => {
+      if (cloudAuth.getState().status === `signed-out`) {
+        removeCloudSavedServers()
+        const next = resolveActiveAfterCloudSignOut(
+          serverUrl,
+          getSavedServers()
+        )
+        if (next.changed) {
+          void persistServerUrl(next.url)
+          return
+        }
+      }
       void prepareServerHeaders(serverUrl)
-    })
+    }
+    apply()
+    const unsubscribe = cloudAuth.subscribe(apply)
     return unsubscribe
-  }, [serverUrl, loading])
+  }, [serverUrl, loading, persistServerUrl])
 
   const value = useMemo<MobileAppState>(
     () => ({
       loading,
       serverUrl,
       launchUrl,
-      saveServerUrl: async (next: string) => {
-        await AsyncStorage.setItem(SERVER_URL_KEY, next)
-        setServerUrl(next)
-      },
+      saveServerUrl: persistServerUrl,
       onboardingDismissed,
       setOnboardingDismissed: async (next: boolean) => {
         if (next) {
@@ -86,7 +151,7 @@ export function MobileAppStateProvider({
         setOnboardingDismissedState(next)
       },
     }),
-    [loading, serverUrl, launchUrl, onboardingDismissed]
+    [loading, serverUrl, launchUrl, onboardingDismissed, persistServerUrl]
   )
 
   return (

--- a/packages/agents-mobile/src/lib/availableServers.test.ts
+++ b/packages/agents-mobile/src/lib/availableServers.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mergeAvailableServers,
+  resolveActiveAfterCloudSignOut,
+} from './availableServers'
+import type { CloudAgentServer } from './cloudAgentServers'
+import type { SavedServer } from './savedServers'
+
+const resolveCloudUrl = (id: string) =>
+  `https://agents.electric-sql.cloud/t/${id}/v1`
+
+const cloudServer = (
+  id: string,
+  name: string,
+  extra: Partial<CloudAgentServer> = {}
+): CloudAgentServer => ({
+  id,
+  name,
+  workspaceId: `w`,
+  workspaceName: `Acme`,
+  projectId: `p`,
+  projectName: `Web`,
+  environmentId: `e`,
+  environmentName: `prod`,
+  updatedAt: null,
+  ...extra,
+})
+
+const savedManual: SavedServer = {
+  id: `https://self.example/v1`,
+  name: `self.example`,
+  url: `https://self.example/v1`,
+  source: `manual`,
+}
+
+describe(`mergeAvailableServers`, () => {
+  it(`appends live cloud servers after saved ones`, () => {
+    const result = mergeAvailableServers(
+      [savedManual],
+      [cloudServer(`svc-1`, `Prod`)],
+      null,
+      resolveCloudUrl
+    )
+    expect(result.map((s) => s.key)).toEqual([
+      `saved:https://self.example/v1`,
+      `cloud:svc-1`,
+    ])
+    expect(result[0]).toMatchObject({ kind: `self-hosted`, saved: true })
+    expect(result[1]).toMatchObject({
+      kind: `cloud`,
+      saved: false,
+      url: `https://agents.electric-sql.cloud/t/svc-1/v1`,
+      breadcrumb: `Acme · Web · prod`,
+    })
+  })
+
+  it(`does not duplicate a cloud server already saved (dedup by service id)`, () => {
+    const savedCloud: SavedServer = {
+      id: `svc-1`,
+      name: `Prod`,
+      url: `https://agents.electric-sql.cloud/t/svc-1/v1`,
+      source: `electric-cloud`,
+    }
+    const result = mergeAvailableServers(
+      [savedCloud],
+      [cloudServer(`svc-1`, `Prod`), cloudServer(`svc-2`, `Staging`)],
+      null,
+      resolveCloudUrl
+    )
+    expect(result.map((s) => s.key)).toEqual([`saved:svc-1`, `cloud:svc-2`])
+    // The saved cloud entry is enriched with the live breadcrumb.
+    expect(result[0]).toMatchObject({
+      saved: true,
+      kind: `cloud`,
+      breadcrumb: `Acme · Web · prod`,
+    })
+  })
+
+  it(`marks the entry matching the active URL`, () => {
+    const result = mergeAvailableServers(
+      [savedManual],
+      [cloudServer(`svc-1`, `Prod`)],
+      `https://agents.electric-sql.cloud/t/svc-1/v1`,
+      resolveCloudUrl
+    )
+    expect(result.find((s) => s.isActive)?.key).toBe(`cloud:svc-1`)
+    expect(result.filter((s) => s.isActive)).toHaveLength(1)
+  })
+})
+
+describe(`resolveActiveAfterCloudSignOut`, () => {
+  const cloudUrl = `https://agents.electric-sql.cloud/t/svc-1/v1`
+
+  it(`leaves a self-hosted active server untouched`, () => {
+    expect(
+      resolveActiveAfterCloudSignOut(`https://self.example/v1`, [savedManual])
+    ).toEqual({ changed: false, url: `https://self.example/v1` })
+  })
+
+  it(`leaves a null active server untouched`, () => {
+    expect(resolveActiveAfterCloudSignOut(null, [])).toEqual({
+      changed: false,
+      url: null,
+    })
+  })
+
+  it(`falls back to a remaining self-hosted server when active was cloud`, () => {
+    expect(resolveActiveAfterCloudSignOut(cloudUrl, [savedManual])).toEqual({
+      changed: true,
+      url: `https://self.example/v1`,
+    })
+  })
+
+  it(`clears the active server when no self-hosted server remains`, () => {
+    expect(resolveActiveAfterCloudSignOut(cloudUrl, [])).toEqual({
+      changed: true,
+      url: null,
+    })
+  })
+})

--- a/packages/agents-mobile/src/lib/availableServers.ts
+++ b/packages/agents-mobile/src/lib/availableServers.ts
@@ -1,0 +1,104 @@
+import { getCloudServiceIdFromServerUrl } from './cloudAgentUrls'
+import type { CloudAgentServer } from './cloudAgentServers'
+import type { SavedServer } from './savedServers'
+
+/**
+ * Pure merge logic for the unified server picker, kept free of React /
+ * React Native imports so it can be unit-tested in isolation. The hook
+ * that wires it to live state lives in `useAvailableServers.ts`.
+ */
+
+export type AvailableServerKind = `self-hosted` | `cloud`
+
+export type AvailableServer = {
+  key: string
+  kind: AvailableServerKind
+  name: string
+  /** Connection URL to register as the active server. */
+  url: string
+  /** Cloud only: `workspace · project · environment`. */
+  breadcrumb?: string
+  /** Matches the currently-active server URL. */
+  isActive: boolean
+  /** Already in the persisted list (vs a live-only Cloud server). */
+  saved: boolean
+}
+
+function breadcrumbFor(server: CloudAgentServer): string | undefined {
+  const parts = [
+    server.workspaceName,
+    server.projectName,
+    server.environmentName,
+  ].filter((p): p is string => Boolean(p))
+  return parts.length > 0 ? parts.join(` · `) : undefined
+}
+
+/**
+ * Merge the persisted server list with the live Cloud agent servers into
+ * one deduped list. Dedup is by Cloud service id: a Cloud server already
+ * saved (because the user connected to it) is shown once, enriched with
+ * the live breadcrumb. `resolveCloudUrl` turns a Cloud service id into its
+ * tenant-scoped agents URL (injected so this stays free of network state).
+ */
+export function mergeAvailableServers(
+  saved: ReadonlyArray<SavedServer>,
+  cloudServers: ReadonlyArray<CloudAgentServer>,
+  activeUrl: string | null,
+  resolveCloudUrl: (serviceId: string) => string
+): ReadonlyArray<AvailableServer> {
+  const cloudById = new Map(cloudServers.map((s) => [s.id, s]))
+  const savedCloudServiceIds = new Set<string>()
+
+  const fromSaved = saved.map((s): AvailableServer => {
+    const isCloud = s.source === `electric-cloud`
+    const serviceId = isCloud
+      ? (getCloudServiceIdFromServerUrl(s.url) ?? s.id)
+      : null
+    if (serviceId) savedCloudServiceIds.add(serviceId)
+    const live = serviceId ? cloudById.get(serviceId) : undefined
+    return {
+      key: `saved:${s.id}`,
+      kind: isCloud ? `cloud` : `self-hosted`,
+      name: s.name,
+      url: s.url,
+      breadcrumb: live ? breadcrumbFor(live) : undefined,
+      isActive: s.url === activeUrl,
+      saved: true,
+    }
+  })
+
+  const fromCloud = cloudServers
+    .filter((s) => !savedCloudServiceIds.has(s.id))
+    .map((s): AvailableServer => {
+      const url = resolveCloudUrl(s.id)
+      return {
+        key: `cloud:${s.id}`,
+        kind: `cloud`,
+        name: s.name,
+        url,
+        breadcrumb: breadcrumbFor(s),
+        isActive: url === activeUrl,
+        saved: false,
+      }
+    })
+
+  return [...fromSaved, ...fromCloud]
+}
+
+/**
+ * Decide what the active server should become after Cloud sign-out (once
+ * the Cloud servers have been purged from `savedAfterPurge`). If the
+ * active server was a Cloud server it's now unreachable, so fall back to a
+ * remaining self-hosted server, or clear it (`null`). A non-Cloud active
+ * server is left untouched (`changed: false`).
+ */
+export function resolveActiveAfterCloudSignOut(
+  activeUrl: string | null,
+  savedAfterPurge: ReadonlyArray<SavedServer>
+): { changed: boolean; url: string | null } {
+  if (!activeUrl || getCloudServiceIdFromServerUrl(activeUrl) === null) {
+    return { changed: false, url: activeUrl }
+  }
+  const fallback = savedAfterPurge.find((s) => s.source === `manual`)
+  return { changed: true, url: fallback?.url ?? null }
+}

--- a/packages/agents-mobile/src/lib/savedServers.test.ts
+++ b/packages/agents-mobile/src/lib/savedServers.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SavedServer } from './savedServers'
+
+const store = vi.hoisted(() => ({ map: new Map<string, string>() }))
+
+vi.mock(`@react-native-async-storage/async-storage`, () => ({
+  default: {
+    getItem: vi.fn(async (key: string) => store.map.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      store.map.set(key, value)
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      store.map.delete(key)
+    }),
+  },
+}))
+
+const STORAGE_KEY = `electric-agents-mobile.servers`
+
+const manual: SavedServer = {
+  id: `https://self.example/v1`,
+  name: `self.example`,
+  url: `https://self.example/v1`,
+  source: `manual`,
+}
+const cloud: SavedServer = {
+  id: `svc-123`,
+  name: `Prod`,
+  url: `https://agents.electric-sql.cloud/t/svc-123/v1`,
+  source: `electric-cloud`,
+}
+
+// Re-import the module fresh each test so its module-level state + the
+// import-time hydration IIFE re-run against the current mock storage.
+async function freshModule() {
+  vi.resetModules()
+  const mod = await import(`./savedServers`)
+  // Let the async hydration IIFE settle.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  return mod
+}
+
+beforeEach(() => {
+  store.map.clear()
+  vi.clearAllMocks()
+})
+
+describe(`savedServers`, () => {
+  it(`adds servers and exposes them via the snapshot`, async () => {
+    const { addSavedServer, getSavedServers } = await freshModule()
+    addSavedServer(manual)
+    addSavedServer(cloud)
+    expect(getSavedServers()).toEqual([manual, cloud])
+  })
+
+  it(`upserts by URL instead of duplicating`, async () => {
+    const { addSavedServer, getSavedServers } = await freshModule()
+    addSavedServer(manual)
+    addSavedServer({ ...manual, name: `renamed` })
+    expect(getSavedServers()).toEqual([{ ...manual, name: `renamed` }])
+  })
+
+  it(`removes a server by id`, async () => {
+    const { addSavedServer, removeSavedServer, getSavedServers } =
+      await freshModule()
+    addSavedServer(manual)
+    addSavedServer(cloud)
+    removeSavedServer(cloud.id)
+    expect(getSavedServers()).toEqual([manual])
+  })
+
+  it(`removeCloudSavedServers drops only electric-cloud entries`, async () => {
+    const { addSavedServer, removeCloudSavedServers, getSavedServers } =
+      await freshModule()
+    addSavedServer(manual)
+    addSavedServer(cloud)
+    removeCloudSavedServers()
+    expect(getSavedServers()).toEqual([manual])
+  })
+
+  it(`persists to AsyncStorage and rehydrates on next load`, async () => {
+    const first = await freshModule()
+    first.addSavedServer(manual)
+    first.addSavedServer(cloud)
+    expect(store.map.get(STORAGE_KEY)).toBe(JSON.stringify([manual, cloud]))
+
+    // A fresh module instance should hydrate from the persisted blob.
+    const second = await freshModule()
+    expect(second.getSavedServers()).toEqual([manual, cloud])
+  })
+
+  it(`merges (does not clobber) when a mutation lands before hydration`, async () => {
+    // Persist a server, then simulate a fresh load where a mutation (e.g.
+    // the active-server migration) happens before hydration resolves.
+    store.map.set(STORAGE_KEY, JSON.stringify([cloud]))
+    vi.resetModules()
+    const mod = await import(`./savedServers`)
+    // Mutate synchronously, before the hydration IIFE's await settles.
+    mod.addSavedServer(manual)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Both the persisted cloud server and the pre-hydration manual server
+    // survive (deduped by URL).
+    expect(mod.getSavedServers()).toEqual([cloud, manual])
+  })
+
+  it(`ignores malformed persisted entries`, async () => {
+    store.map.set(
+      STORAGE_KEY,
+      JSON.stringify([manual, { id: `x` }, { foo: `bar` }, cloud])
+    )
+    const { getSavedServers } = await freshModule()
+    expect(getSavedServers()).toEqual([manual, cloud])
+  })
+})

--- a/packages/agents-mobile/src/lib/savedServers.test.ts
+++ b/packages/agents-mobile/src/lib/savedServers.test.ts
@@ -61,11 +61,11 @@ describe(`savedServers`, () => {
   })
 
   it(`removes a server by id`, async () => {
-    const { addSavedServer, removeSavedServer, getSavedServers } =
+    const { addSavedServer, removeSavedServerById, getSavedServers } =
       await freshModule()
     addSavedServer(manual)
     addSavedServer(cloud)
-    removeSavedServer(cloud.id)
+    removeSavedServerById(cloud.id)
     expect(getSavedServers()).toEqual([manual])
   })
 

--- a/packages/agents-mobile/src/lib/savedServers.ts
+++ b/packages/agents-mobile/src/lib/savedServers.ts
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+/**
+ * Persisted list of the agents servers the user has connected to —
+ * the mobile counterpart of the desktop's `ServerConfig[]` in
+ * `settings.json`. Mobile keeps the single *active* server URL in
+ * `MobileAppState`; this store remembers every server so the unified
+ * picker (`useAvailableServers` → `HomeMenu`'s server submenu) can list
+ * them and the user can switch between them without re-entering URLs.
+ *
+ * Implemented as a tiny module-level store (no provider), mirroring
+ * `sidebarPrefs.ts` — both React components (`useSavedServers`) and the
+ * non-React sign-out cleanup in `MobileAppState` (`getSavedServers`)
+ * subscribe to the same change stream.
+ *
+ * Cloud servers are stored with `source: 'electric-cloud'` so they can be
+ * purged on sign-out. We deliberately store no token/tenantId: the agents
+ * token is derived from the URL at request time by `prepareServerHeaders`.
+ */
+
+export type SavedServerSource = `manual` | `electric-cloud`
+
+export type SavedServer = {
+  /** For cloud servers, the `stream_services.id`; for manual servers, the URL. */
+  id: string
+  name: string
+  url: string
+  source: SavedServerSource
+}
+
+const STORAGE_KEY = `electric-agents-mobile.servers`
+
+let current: ReadonlyArray<SavedServer> = []
+const listeners = new Set<(servers: ReadonlyArray<SavedServer>) => void>()
+let hydrated = false
+// Set once a mutation happens so late-arriving hydration can't clobber a
+// server the user added during the (brief) startup hydration window.
+let dirty = false
+
+void (async () => {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const parsed = (JSON.parse(raw) as Array<Partial<SavedServer>>)
+        .filter(
+          (s): s is SavedServer =>
+            typeof s?.id === `string` &&
+            typeof s?.name === `string` &&
+            typeof s?.url === `string` &&
+            (s?.source === `manual` || s?.source === `electric-cloud`)
+        )
+        .map((s) => ({ id: s.id, name: s.name, url: s.url, source: s.source }))
+      if (dirty) {
+        // A mutation landed before hydration finished (e.g. the active-server
+        // migration in MobileAppState). Merge rather than clobber: keep the
+        // persisted entries, then append the just-added ones (deduped by URL).
+        const persistedUrls = new Set(parsed.map((s) => s.url))
+        current = [
+          ...parsed,
+          ...current.filter((s) => !persistedUrls.has(s.url)),
+        ]
+        persist()
+      } else {
+        current = parsed
+      }
+    }
+  } catch {
+    // Ignore hydration errors — fall back to an empty list.
+  } finally {
+    hydrated = true
+    for (const listener of listeners) listener(current)
+  }
+})()
+
+function persist(): void {
+  void AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(current)).catch(
+    () => {}
+  )
+}
+
+function update(next: ReadonlyArray<SavedServer>): void {
+  current = next
+  dirty = true
+  persist()
+  for (const listener of listeners) listener(current)
+}
+
+/** Synchronous snapshot for non-React callers (e.g. sign-out cleanup). */
+export function getSavedServers(): ReadonlyArray<SavedServer> {
+  return current
+}
+
+export function useSavedServers(): ReadonlyArray<SavedServer> {
+  const [state, setState] = useState<ReadonlyArray<SavedServer>>(current)
+  useEffect(() => {
+    listeners.add(setState)
+    if (hydrated) setState(current)
+    return () => {
+      listeners.delete(setState)
+    }
+  }, [])
+  return state
+}
+
+/**
+ * Insert or update a saved server. Identity is the connection URL — a
+ * re-connect to the same URL updates the existing entry (name/source)
+ * rather than creating a duplicate.
+ */
+export function addSavedServer(server: SavedServer): void {
+  const existingIndex = current.findIndex((s) => s.url === server.url)
+  if (existingIndex === -1) {
+    update([...current, server])
+    return
+  }
+  const next = current.slice()
+  next[existingIndex] = server
+  update(next)
+}
+
+export function removeSavedServer(id: string): void {
+  const next = current.filter((s) => s.id !== id)
+  if (next.length !== current.length) update(next)
+}
+
+/** Drop every cloud server — used when the user signs out of Electric Cloud. */
+export function removeCloudSavedServers(): void {
+  const next = current.filter((s) => s.source !== `electric-cloud`)
+  if (next.length !== current.length) update(next)
+}

--- a/packages/agents-mobile/src/lib/savedServers.ts
+++ b/packages/agents-mobile/src/lib/savedServers.ts
@@ -119,7 +119,7 @@ export function addSavedServer(server: SavedServer): void {
   update(next)
 }
 
-export function removeSavedServer(id: string): void {
+export function removeSavedServerById(id: string): void {
   const next = current.filter((s) => s.id !== id)
   if (next.length !== current.length) update(next)
 }

--- a/packages/agents-mobile/src/lib/useAvailableServers.ts
+++ b/packages/agents-mobile/src/lib/useAvailableServers.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react'
+import { cloudAgentServerUrl, useCloudAgentServers } from './cloudAgentServers'
+import { useMobileAppState } from './MobileAppState'
+import { useSavedServers } from './savedServers'
+import { mergeAvailableServers } from './availableServers'
+
+export type { AvailableServer, AvailableServerKind } from './availableServers'
+
+/**
+ * Merges the persisted server list (`savedServers`) with the live Cloud
+ * agent servers the signed-in user can see (`useCloudAgentServers`) into
+ * one deduped list for the unified server picker in `HomeMenu`. See
+ * `availableServers.ts` for the pure merge logic.
+ */
+export function useAvailableServers() {
+  const saved = useSavedServers()
+  const { servers: cloudServers } = useCloudAgentServers()
+  const { serverUrl } = useMobileAppState()
+  return useMemo(
+    () =>
+      mergeAvailableServers(
+        saved,
+        cloudServers,
+        serverUrl,
+        cloudAgentServerUrl
+      ),
+    [saved, cloudServers, serverUrl]
+  )
+}

--- a/packages/agents-mobile/src/lib/useAvailableServers.ts
+++ b/packages/agents-mobile/src/lib/useAvailableServers.ts
@@ -24,6 +24,6 @@ export function useAvailableServers() {
         serverUrl,
         cloudAgentServerUrl
       ),
-    [saved, cloudServers, serverUrl]
+    [saved, cloudServers, serverUrl, cloudAgentServerUrl]
   )
 }

--- a/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
+++ b/packages/agents-mobile/src/screens/ServerSetupScreen.tsx
@@ -17,6 +17,8 @@ import { useTokens } from '../lib/ThemeProvider'
 import { fontSize, lineHeight, radii, rowHeight, spacing } from '../lib/theme'
 import { checkServerHealth, normalizeServerUrl } from '../lib/agentsClient'
 import { prepareServerHeaders } from '../lib/serverHeaders'
+import { getCloudServiceIdFromServerUrl } from '../lib/cloudAgentUrls'
+import { addSavedServer } from '../lib/savedServers'
 import type { Tokens } from '../lib/theme'
 
 /**
@@ -47,13 +49,26 @@ export function ServerSetupScreen({
   const isCloudSignedIn = cloudState.status === `signed-in`
   const isSigningInToCloud = cloudState.status === `signing-in`
 
-  const commit = async (url: string): Promise<string | null> => {
+  const commit = async (
+    url: string,
+    displayName?: string
+  ): Promise<string | null> => {
     setSubmitting(true)
     try {
       // Cloud agent servers reject unauthenticated requests with 401,
       // so headers must be registered before the health probe.
       await prepareServerHeaders(url)
       await checkServerHealth(url)
+      // Remember the server so it appears in the unified picker and
+      // survives a relaunch. Cloud servers are tagged so they can be
+      // purged on sign-out.
+      const serviceId = getCloudServiceIdFromServerUrl(url)
+      const name = displayName ?? hostOf(url)
+      addSavedServer(
+        serviceId
+          ? { id: serviceId, name, url, source: `electric-cloud` }
+          : { id: url, name, url, source: `manual` }
+      )
       await onSave(url)
       return null
     } catch (err) {
@@ -63,9 +78,9 @@ export function ServerSetupScreen({
     }
   }
 
-  const connectCloudRow = async (url: string): Promise<void> => {
+  const connectCloudRow = async (url: string, name: string): Promise<void> => {
     setCloudConnectError(null)
-    const err = await commit(url)
+    const err = await commit(url, name)
     if (err) setCloudConnectError(err)
   }
 
@@ -148,7 +163,7 @@ export function ServerSetupScreen({
           )}
 
           <CloudServerPicker
-            onConnect={connectCloudRow}
+            onConnect={(url, server) => connectCloudRow(url, server.name)}
             disabled={submitting}
           />
 
@@ -213,6 +228,14 @@ export function ServerSetupScreen({
       </KeyboardAvoidingView>
     </Screen>
   )
+}
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host || url
+  } catch {
+    return url
+  }
 }
 
 function createStyles(tokens: Tokens) {


### PR DESCRIPTION
## Summary

Brings the mobile three-dots (kebab) menu closer to the desktop unified server experience.

- **Persisted multi-server list** — new `savedServers` store (AsyncStorage) mirroring desktop's `ServerConfig[]`. Mobile keeps the single *active* server URL in `MobileAppState`; this store remembers every server so the user can switch without re-entering URLs. Cloud servers are tagged `electric-cloud` so they can be purged on sign-out (no token/tenantId stored — derived from the URL at request time).
- **Unified picker** — new `useAvailableServers` merges the saved list with the live Cloud agent servers (`useCloudAgentServers`), deduped by service id, into one list.
- **In-sheet server submenu** — the kebab's "Server" row now slides into a submenu listing all servers (self-hosted + Cloud, with kind icons, breadcrumbs, active check, connect-in-place for live Cloud servers, and an "Add custom server…" row that pushes to `ServerSetupScreen`). The drill animation was extracted from `SessionMenu` into a reusable `useDrillTransition` hook.
- **Account row refinement** — reflects auth status: name/email when signed in, "Sign in to Electric Cloud" when out.
- **Cloud sign-out cleanup** — purges persisted Cloud servers; if the active server was a Cloud server, falls back to a remaining self-hosted server, else clears (routing to server setup).
- **Migration** — users upgrading from the single-URL model get their active self-hosted server surfaced in the saved list.
- `ServerSetupScreen` / `CloudServerPicker` now persist into the saved list on connect.

## Design notes

- Server submenu uses the horizontal **drill + Back row** pattern, kept consistent with the existing signals submenu (swipe-down dismisses the whole sheet). Considered a dedicated dismissible sheet / swipe-to-go-back; deferred in favor of consistency.

## Testing

- 19 unit tests (vitest): `savedServers` store (upsert/dedup/cloud-purge/round-trip/merge-on-hydrate), `mergeAvailableServers` (dedup + active flag), and the `resolveActiveAfterCloudSignOut` fallback resolver.
- `tsc --noEmit` and eslint clean.
- Manual emulator pass (drill, connect a Cloud server, sign-out behavior) still TODO.

## Out of scope (follow-ups)

- **Pre-existing `inbox` live-query crash** on opening a conversation — caused by three duplicate `@tanstack/db` versions (0.6.5 / 0.6.6 / 0.6.7) failing a cross-copy `instanceof Collection` check, not by this PR. Fix likely a root `pnpm.overrides` pin. Deferred to a separate PR.
- **Generally available "Clear all local data"** in Diagnostics (currently `__DEV__`-only because the restart relies on dev-only `DevSettings.reload()`). Deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)