### PR TITLE
Scale Horton context budget by model

### DIFF
--- a/.changeset/horton-context-budget.md
+++ b/.changeset/horton-context-budget.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': patch
+---
+
+Size Horton's context source budget from the selected model's known context window, including Moonshot metadata, while preserving the previous default for unknown models.

--- a/packages/agents/src/agents/horton.ts
+++ b/packages/agents/src/agents/horton.ts
@@ -9,6 +9,7 @@ import {
   modelChoiceValues,
   REASONING_EFFORT_VALUES,
   resolveBuiltinModelConfig,
+  resolveBuiltinModelSourceBudget,
   type BuiltinAgentModelConfig,
   type BuiltinModelCatalog,
 } from '../model-catalog'
@@ -460,6 +461,7 @@ function createAssistantHandler(options: {
   ): Promise<void> {
     const readSet = new Set<string>()
     const modelConfig = resolveBuiltinModelConfig(modelCatalog, ctx.args)
+    const sourceBudget = resolveBuiltinModelSourceBudget(modelConfig)
     // The sandbox's own working directory is the single source of truth for
     // where the agent operates — `/work` in a remote VM, or the host project
     // root for a local sandbox (the local profile derives that from
@@ -529,7 +531,7 @@ function createAssistantHandler(options: {
 
     if (docsSupport) {
       ctx.useContext({
-        sourceBudget: 100_000,
+        sourceBudget,
         sources: {
           docs_toc: {
             content: () => docsSupport.renderCompressedToc(),
@@ -572,7 +574,7 @@ function createAssistantHandler(options: {
       })
     } else if (skillsRegistry && skillsRegistry.catalog.size > 0) {
       ctx.useContext({
-        sourceBudget: 100_000,
+        sourceBudget,
         sources: {
           skills_catalog: {
             content: () => skillsRegistry.renderCatalog(2_000),
@@ -596,7 +598,7 @@ function createAssistantHandler(options: {
       })
     } else if (agentsMd) {
       ctx.useContext({
-        sourceBudget: 100_000,
+        sourceBudget,
         sources: {
           conversation: {
             content: () => ctx.timelineMessages(),

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -4,6 +4,7 @@ import {
   MOONSHOT_PROVIDER,
   detectAvailableProviders,
   getMoonshotApiKey,
+  getMoonshotModel,
   getMoonshotModels,
   readCodexAccessToken,
 } from '@electric-ax/agents-runtime'
@@ -150,6 +151,30 @@ function knownModelsForProvider(provider: BuiltinModelProvider) {
     : getModels(
         provider as Exclude<BuiltinModelProvider, typeof MOONSHOT_PROVIDER>
       )
+}
+
+export function resolveBuiltinModelContextWindow(
+  modelConfig: Pick<BuiltinAgentModelConfig, `model` | `provider`>
+): number | null {
+  const modelId = String(modelConfig.model)
+
+  if (modelConfig.provider === MOONSHOT_PROVIDER) {
+    return getMoonshotModel(modelId)?.contextWindow ?? null
+  }
+
+  if (!modelConfig.provider) return null
+
+  return (
+    knownModelsForProvider(modelConfig.provider as BuiltinModelProvider).find(
+      (model) => model.id === modelId
+    )?.contextWindow ?? null
+  )
+}
+
+export function resolveBuiltinModelSourceBudget(
+  modelConfig: Pick<BuiltinAgentModelConfig, `model` | `provider`>
+): number {
+  return resolveBuiltinModelContextWindow(modelConfig) ?? 100_000
 }
 
 function choiceForKnownModel(

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createBuiltinModelCatalog,
   resolveBuiltinModelConfig,
+  resolveBuiltinModelContextWindow,
+  resolveBuiltinModelSourceBudget,
 } from '../src/model-catalog'
 
 const originalEnv = { ...process.env }
@@ -51,6 +53,36 @@ describe(`model catalog`, () => {
       provider: `openai`,
       model: `gpt-4.1`,
     })
+  })
+
+  it(`resolves model context windows and source budgets from known model metadata`, () => {
+    expect(
+      resolveBuiltinModelContextWindow({
+        provider: `openai`,
+        model: `gpt-4.1`,
+      })
+    ).toBe(1_047_576)
+    expect(
+      resolveBuiltinModelSourceBudget({
+        provider: `anthropic`,
+        model: `claude-sonnet-4-6`,
+      })
+    ).toBe(1_000_000)
+    expect(
+      resolveBuiltinModelSourceBudget({
+        provider: `moonshot`,
+        model: `moonshot-v1-8k`,
+      })
+    ).toBe(8_192)
+  })
+
+  it(`falls back to the previous source budget for unknown model metadata`, () => {
+    expect(
+      resolveBuiltinModelSourceBudget({
+        provider: `openai`,
+        model: `unknown-model`,
+      })
+    ).toBe(100_000)
   })
 
   it(`filters choices to enabled model values`, async () => {


### PR DESCRIPTION
## Summary
- derive Horton's context source budget from selected model metadata instead of a fixed 100k
- add model catalog helpers for context window/source budget lookup
- cover OpenAI, Anthropic, Moonshot, and unknown-model fallback cases

## Test plan
- pnpm --filter @electric-ax/agents typecheck
- pnpm --filter @electric-ax/agents test test/model-catalog.test.ts