### PR TITLE
Fix Codex auth for low-cost tool calls

### DIFF
--- a/.changeset/fresh-codex-tool-auth.md
+++ b/.changeset/fresh-codex-tool-auth.md
@@ -1,0 +1,7 @@
+---
+"@electric-ax/agents": patch
+"@electric-ax/agents-runtime": patch
+"@electric-ax/agents-desktop": patch
+---
+
+Fix Codex auth for low-cost tool calls by passing fresh access tokens to URL extraction and worker tools.

--- a/packages/agents-desktop/src/credentials/codex-auth.ts
+++ b/packages/agents-desktop/src/credentials/codex-auth.ts
@@ -292,9 +292,11 @@ async function clearCodexAuth(deps: CodexAuthDeps): Promise<void> {
 
 export async function syncCodexEnvironment(deps: CodexAuthDeps): Promise<void> {
   process.env.ELECTRIC_CODEX_REQUIRE_OPT_IN = `1`
-  delete process.env.ELECTRIC_CODEX_ACCESS_TOKEN
   const codex = deps.settings.codex ?? { enabled: false, source: null }
-  if (!codex.enabled || !codex.source) return
+  if (!codex.enabled || !codex.source) {
+    delete process.env.ELECTRIC_CODEX_ACCESS_TOKEN
+    return
+  }
 
   const stored = await loadStoredCodexAuth(deps)
   const refreshed =
@@ -310,6 +312,7 @@ export async function syncCodexEnvironment(deps: CodexAuthDeps): Promise<void> {
   // produced. Desktop OAuth tokens should refresh through the OAuth token
   // endpoint above; stale tokens imported from CLI/opencode auth files should be
   // deleted rather than repeatedly trusted as an enabled desktop credential.
+  delete process.env.ELECTRIC_CODEX_ACCESS_TOKEN
   await clearCodexAuth(deps)
 }
 

--- a/packages/agents-runtime/src/model-runner.ts
+++ b/packages/agents-runtime/src/model-runner.ts
@@ -180,6 +180,7 @@ async function resolveLowCostApiKey(input: {
   if (input.modelConfig?.getApiKey) {
     return await input.modelConfig.getApiKey(input.provider)
   }
+  if (input.provider === `openai-codex`) return readCodexAccessToken()
   if (input.provider === MOONSHOT_PROVIDER) return getMoonshotApiKey()
   return undefined
 }

--- a/packages/agents-runtime/test/model-runner.test.ts
+++ b/packages/agents-runtime/test/model-runner.test.ts
@@ -48,6 +48,27 @@ describe(`completeWithLowCostModel`, () => {
     )
   })
 
+  test(`passes fresh ELECTRIC_CODEX_ACCESS_TOKEN for openai-codex low-cost models without modelConfig`, async () => {
+    process.env.ELECTRIC_CODEX_ACCESS_TOKEN = `codex-token`
+
+    await completeWithLowCostModel({
+      catalog: {
+        choices: [
+          { provider: `openai-codex`, id: `gpt-5.4-mini`, reasoning: false },
+        ],
+      },
+      purpose: `URL extraction`,
+      systemPrompt: `Custom instructions`,
+      prompt: `Extract the title`,
+      maxTokens: 128,
+    })
+
+    expect(completeSimple).toHaveBeenCalledOnce()
+    expect(completeSimple.mock.calls[0][2]).toMatchObject({
+      apiKey: `codex-token`,
+    })
+  })
+
   test(`passes MOONSHOT_API_KEY for moonshot low-cost models`, async () => {
     process.env.MOONSHOT_API_KEY = `moonshot-key`
 

--- a/packages/agents/src/agents/worker.ts
+++ b/packages/agents/src/agents/worker.ts
@@ -14,6 +14,7 @@ import { WORKER_TOOL_NAMES, createSpawnWorkerTool } from '../tools/spawn-worker'
 import {
   REASONING_EFFORT_VALUES,
   resolveBuiltinModelConfig,
+  type BuiltinAgentModelConfig,
   type BuiltinModelCatalog,
 } from '../model-catalog'
 import type { WorkerToolName } from '../tools/spawn-worker'
@@ -117,7 +118,11 @@ function buildToolsForWorker(
   tools: ReadonlyArray<WorkerToolName>,
   sandbox: Sandbox,
   ctx: HandlerContext,
-  readSet: Set<string>
+  readSet: Set<string>,
+  opts: {
+    modelCatalog: BuiltinModelCatalog
+    modelConfig: BuiltinAgentModelConfig
+  }
 ): Array<AgentTool> {
   const out: Array<AgentTool> = []
   for (const name of tools) {
@@ -138,7 +143,12 @@ function buildToolsForWorker(
         out.push(braveSearchTool)
         break
       case `fetch_url`:
-        out.push(createFetchUrlTool(sandbox))
+        out.push(
+          createFetchUrlTool(sandbox, {
+            catalog: opts.modelCatalog,
+            modelConfig: opts.modelConfig,
+          })
+        )
         break
       case `spawn_worker`:
         out.push(createSpawnWorkerTool(ctx))
@@ -298,15 +308,16 @@ export function registerWorker(
       // ctx.sandbox is provisioned and disposed by the runtime sandbox
       // pool — subsequent wakes for the same worker reuse the same
       // instance until idle-TTL eviction.
+      const modelConfig = resolveBuiltinModelConfig(
+        modelCatalog,
+        args as unknown as Readonly<Record<string, unknown>>
+      )
       const builtinTools = buildToolsForWorker(
         args.tools,
         ctx.sandbox,
         ctx,
-        readSet
-      )
-      const modelConfig = resolveBuiltinModelConfig(
-        modelCatalog,
-        args as unknown as Readonly<Record<string, unknown>>
+        readSet,
+        { modelCatalog, modelConfig }
       )
 
       const sharedStateTools: Array<AgentTool> = []


### PR DESCRIPTION
## Summary
- pass worker model config/catalog into fetch_url so spawned workers use the current Codex auth path
- fall back to reading the fresh Codex access token for openai-codex low-cost model calls without modelConfig
- avoid clearing ELECTRIC_CODEX_ACCESS_TOKEN during desktop Codex token refresh
- add regression coverage for Codex low-cost calls without modelConfig

## Tests
- pnpm --filter @electric-ax/agents-runtime test model-runner.test.ts -- --run
- pnpm --filter @electric-ax/agents test -- worker *(passed in the main worktree before moving changes; in the nested .worktrees checkout it fails to resolve workspace deps like pino/@electric-ax/agents-runtime)*
- pnpm --filter @electric-ax/agents-desktop typecheck
