### PR TITLE
ci(agents-mobile): gate EAS build behind `mobile-eas-build` label

### DIFF
--- a/.github/workflows/agents_mobile_pr.yml
+++ b/.github/workflows/agents_mobile_pr.yml
@@ -2,6 +2,8 @@ name: Agents Mobile PR
 
 on:
   pull_request:
+    # `labeled` so adding `mobile-eas-build` triggers a build immediately.
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'packages/agents-mobile/**'
       - 'packages/agents-server-ui/**'
@@ -20,7 +22,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+  # Don't let a label change cancel an in-progress build/checks run; only new pushes supersede.
+  cancel-in-progress: ${{ !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
 
 permissions:
   actions: read
@@ -31,6 +34,8 @@ permissions:
 jobs:
   detect:
     name: Detect mobile impact
+    # Skip label events unless it's `mobile-eas-build`, so unrelated labels don't re-run checks.
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'mobile-eas-build' }}
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.detect.outputs.should_build }}
@@ -93,7 +98,8 @@ jobs:
     needs:
       - detect
       - local-checks
-    if: ${{ needs.detect.outputs.should_build == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # PRs build only with the `mobile-eas-build` label (and not from a fork, so secrets exist); workflow_dispatch always builds.
+    if: ${{ needs.detect.outputs.should_build == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'mobile-eas-build'))) }}
     uses: ./.github/workflows/agents_mobile_build.yml
     secrets: inherit
     with:
@@ -109,12 +115,16 @@ jobs:
     needs:
       - detect
       - local-checks
-    if: ${{ needs.detect.outputs.should_build == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    # Build was relevant but skipped: fork PR (no secrets) or no `mobile-eas-build` label.
+    if: ${{ needs.detect.outputs.should_build == 'true' && github.event_name == 'pull_request' && !(github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'mobile-eas-build')) }}
     runs-on: ubuntu-latest
     steps:
-      - name: Comment on fork PR
+      - name: Comment that the EAS build was skipped
         uses: actions/github-script@v7
         continue-on-error: true
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+          BUILD_LABEL: mobile-eas-build
         with:
           script: |
             const marker = '<!-- electric-agents-mobile-pr-build -->'
@@ -123,14 +133,18 @@ jobs:
             const sha = context.payload.pull_request.head.sha
             const shortSha = sha.slice(0, 7)
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
+            const isFork = process.env.IS_FORK === 'true'
+            const label = process.env.BUILD_LABEL
+            const reason = isFork
+              ? 'The EAS Android preview build was skipped because this PR comes from a fork and repository secrets are unavailable.\nA maintainer can run the workflow manually from a trusted branch to produce an installable preview build.'
+              : `The EAS Android preview build was skipped because the \`${label}\` label is not present.\nAdd the \`${label}\` label to this PR to produce an installable preview build.`
             const body = [
               marker,
               '## Electric Agents Mobile Build',
               '',
               `Local mobile checks ran for commit \`${shortSha}\`.`,
               '',
-              'The EAS Android preview build was skipped because this PR comes from a fork and repository secrets are unavailable.',
-              'A maintainer can run the workflow manually from a trusted branch to produce an installable preview build.',
+              reason,
               '',
               `[Workflow run](${runUrl})`,
             ].join('\n')

--- a/.github/workflows/agents_mobile_pr.yml
+++ b/.github/workflows/agents_mobile_pr.yml
@@ -3,6 +3,7 @@ name: Agents Mobile PR
 on:
   pull_request:
     # `labeled` so adding `mobile-eas-build` triggers a build immediately.
+    # `paths` applies to label events too, so the label only acts on PRs that touch these paths.
     types: [opened, synchronize, reopened, labeled]
     paths:
       - 'packages/agents-mobile/**'


### PR DESCRIPTION
## Problem

The EAS Android preview build for `agents-mobile` fires on **every push to every PR** that touches mobile paths — and even on unrelated PRs, because the global change triggers include root `package.json` / `pnpm-lock.yaml`. Any dependency bump anywhere in the monorepo touches the lockfile and forces a full mobile EAS build, burning EAS build minutes.

The `detect` gate doesn't help here: it diffs against the **PR base**, not the previous commit, so once a PR's cumulative diff includes a mobile path, every subsequent push rebuilds regardless of what that push changed.

## Change

Gate the expensive EAS build behind a `mobile-eas-build` label. Cheap local checks still run on every push for fast feedback.

- **`eas-preview`** now runs only when the PR carries the `mobile-eas-build` label (and is from this repo, so secrets exist). `workflow_dispatch` still always builds.
- **`labeled`** added to the PR event types so applying the label triggers a build immediately rather than waiting for the next push.
- **`local-checks`** (ci:check, iOS export) are unchanged — they run on every push to a mobile PR.
- **`detect`** skips label events other than `mobile-eas-build`, so adding unrelated labels doesn't re-run the checks.
- **`cancel-in-progress`** no longer lets a label change cancel an in-progress run; only new pushes supersede a running build.
- The skip comment now explains whether the build was skipped because of a fork (no secrets) or a missing label, and tells contributors how to trigger it.

## Follow-up note (not in this PR)

The broad global-change triggers (root `package.json`, `pnpm-lock.yaml`, etc.) still fire `detect` + `local-checks` on unrelated dependency PRs. That no longer costs EAS minutes now that the build is label-gated, but we could tighten it separately if the local-checks noise is bothersome.

> [!NOTE]
> Requires the `mobile-eas-build` label to exist in the repo — it has been created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)