### PR TITLE
feat(agents-server-ui): show elapsed time while agent is thinking

### DIFF
--- a/.changeset/elapsed-time-thinking-indicator.md
+++ b/.changeset/elapsed-time-thinking-indicator.md
@@ -1,0 +1,12 @@
+---
+'@electric-ax/agents-server-ui': patch
+'@electric-ax/agents-desktop': patch
+---
+
+Show elapsed time while an agent is responding. While a turn is
+streaming, the meta row now ticks `Thinking · 12s` (or just `12s` once
+tokens start flowing). When a turn settles, the bare `✓ done` becomes
+`✓ done in 1m 5s` for turns completed in-session. Historical turns
+(already complete on page load) keep the bare label, since the client
+has no reliable completion timestamp for those — only the user message
+time, and subtracting `now()` would lie about the duration.

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -25,6 +25,8 @@ import { Icon, IconButton, Stack, Text, Tooltip } from '../ui'
 import { ToolCallView } from './ToolCallView'
 import { TimeText } from './TimeText'
 import { ThinkingIndicator } from './ThinkingIndicator'
+import { ElapsedTime } from './ElapsedTime'
+import { formatElapsedDuration, toMillis } from '../lib/formatTime'
 import styles from './AgentResponse.module.css'
 import type {
   EntityTimelineContentItem,
@@ -434,6 +436,31 @@ export const AgentResponseLive = memo(function AgentResponseLive({
   const [copied, setCopied] = useState(false)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // "Done in Xs" closure cue. We only know the real run duration for
+  // responses that finished WHILE this component instance was mounted
+  // — `sawStreamingRef` records whether we ever observed an
+  // in-flight state, and we snapshot `Date.now() - timestamp` at the
+  // first frame where the run reports completion. For runs that were
+  // already `completed` on initial mount (historical scrollback,
+  // session reopen, hard reload mid-conversation) we don't have a
+  // reliable end time on the client — `timestamp` here is the user
+  // message time, not the completion time, so subtracting `now()`
+  // would lie about the duration. In that case we keep the bare
+  // `✓ done` label rather than print a wrong number.
+  const sawStreamingRef = useRef<boolean>(isStreaming)
+  if (isStreaming) sawStreamingRef.current = true
+  const [finalDurationMs, setFinalDurationMs] = useState<number | null>(null)
+  useEffect(() => {
+    if (
+      done &&
+      sawStreamingRef.current &&
+      timestamp != null &&
+      finalDurationMs == null
+    ) {
+      setFinalDurationMs(Math.max(0, Date.now() - toMillis(timestamp)))
+    }
+  }, [done, timestamp, finalDurationMs])
+
   useEffect(() => {
     return () => {
       if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
@@ -479,13 +506,31 @@ export const AgentResponseLive = memo(function AgentResponseLive({
         {showThinking && <ThinkingIndicator />}
         {done && (
           <Text size={1} tone="muted" className={styles.doneText}>
-            ✓ done
+            {finalDurationMs != null
+              ? `✓ done in ${formatElapsedDuration(finalDurationMs)}`
+              : `✓ done`}
           </Text>
         )}
         {failureText && (
           <Text size={1} tone="danger">
             ✗ {failureText}
           </Text>
+        )}
+        {/* Elapsed-time ticker — visible while the response is still
+            in flight so the user can see how long the model has been
+            working ("Thinking · 12s", or just "12s" once tokens are
+            streaming). Anchored to the same `timestamp` we'd display
+            statically post-stream, so the timer's zero point matches
+            the eventual settled-state timestamp. */}
+        {isStreaming && timestamp != null && (
+          <>
+            {showThinking && (
+              <Text size={1} tone="muted" className={styles.metaSeparator}>
+                ·
+              </Text>
+            )}
+            <ElapsedTime ts={timestamp} enabled={isStreaming} />
+          </>
         )}
         {showTimestamp && (
           <>
@@ -572,6 +617,23 @@ export const AgentResponse = memo(function AgentResponse({
   const showTimestamp = timestamp != null && !isStreaming
   const hasLeadingMeta = showThinking || section.done || Boolean(section.error)
 
+  // Mirror of the `sawStreamingRef` / `finalDurationMs` capture from
+  // `AgentResponseLive` — see the comment there for why we only
+  // surface a duration when we actually witnessed streaming→done.
+  const sawStreamingRef = useRef<boolean>(isStreaming)
+  if (isStreaming) sawStreamingRef.current = true
+  const [finalDurationMs, setFinalDurationMs] = useState<number | null>(null)
+  useEffect(() => {
+    if (
+      section.done &&
+      sawStreamingRef.current &&
+      timestamp != null &&
+      finalDurationMs == null
+    ) {
+      setFinalDurationMs(Math.max(0, Date.now() - toMillis(timestamp)))
+    }
+  }, [section.done, timestamp, finalDurationMs])
+
   return (
     <Stack direction="column" gap={2} className={styles.root}>
       {section.items.map((item: EntityTimelineContentItem, i: number) => {
@@ -597,7 +659,9 @@ export const AgentResponse = memo(function AgentResponse({
         {showThinking && <ThinkingIndicator />}
         {section.done && (
           <Text size={1} tone="muted" className={styles.doneText}>
-            ✓ done
+            {finalDurationMs != null
+              ? `✓ done in ${formatElapsedDuration(finalDurationMs)}`
+              : `✓ done`}
           </Text>
         )}
         {section.error && (
@@ -605,10 +669,23 @@ export const AgentResponse = memo(function AgentResponse({
             ✗ {section.error}
           </Text>
         )}
+        {/* Elapsed-time ticker — kept in sync with the live variant
+            above so cached sections (rare during streaming, but the
+            type permits it) render the same meta row. */}
+        {isStreaming && timestamp != null && (
+          <>
+            {showThinking && (
+              <Text size={1} tone="muted" className={styles.metaSeparator}>
+                ·
+              </Text>
+            )}
+            <ElapsedTime ts={timestamp} enabled={isStreaming} />
+          </>
+        )}
         {/* Timestamp only on a settled response — while the agent is
-            still streaming we let `ThinkingIndicator` (or the
-            streaming text itself) own the meta row so it doesn't sit
-            inline with a timestamp that hasn't really happened yet. */}
+            still streaming we let `ThinkingIndicator` + `ElapsedTime`
+            own the meta row so it doesn't sit inline with a timestamp
+            that hasn't really happened yet. */}
         {showTimestamp && (
           <>
             {hasLeadingMeta && (

--- a/packages/agents-server-ui/src/components/ElapsedTime.module.css
+++ b/packages/agents-server-ui/src/components/ElapsedTime.module.css
@@ -1,0 +1,12 @@
+/* Match the dimmed tone of the meta-row siblings (done text,
+ * timestamp, separator dot) so the elapsed timer reads as part of
+ * the same row rather than as a primary signal.
+ *
+ * `tabular-nums` locks digit widths so the label doesn't jitter
+ * horizontally as seconds tick over (most proportional fonts render
+ * `1` narrower than `0`/`8`). */
+.elapsed {
+  color: var(--ds-text-4);
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/agents-server-ui/src/components/ElapsedTime.tsx
+++ b/packages/agents-server-ui/src/components/ElapsedTime.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import { Text } from '../ui'
+import { formatElapsedDuration, toMillis } from '../lib/formatTime'
+import styles from './ElapsedTime.module.css'
+
+/**
+ * Live "Xs / Xm Ys / Xh Ym" elapsed-time label, updated once per
+ * second while `enabled` is true. Used in the agent response meta row
+ * to show how long the model has been working on the current
+ * response — anchored to the preceding user message timestamp so the
+ * value reads as "elapsed since I pressed send".
+ *
+ * We deliberately tear down the interval once `enabled` flips off so
+ * settled responses don't keep ticking and re-rendering the timeline.
+ *
+ * `tabular-nums` (via the module CSS) keeps the digit column from
+ * jittering as the seconds tick over.
+ */
+export function ElapsedTime({
+  ts,
+  enabled = true,
+}: {
+  ts: number | null | undefined
+  enabled?: boolean
+}): React.ReactElement | null {
+  const startMs = ts != null ? toMillis(ts) : null
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!enabled || startMs == null) return
+    // Snap to current time on (re)enable so a paused timer doesn't
+    // show a stale value for up to a second after resuming.
+    setNow(Date.now())
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [enabled, startMs])
+
+  if (startMs == null) return null
+  const elapsed = Math.max(0, now - startMs)
+  const text = formatElapsedDuration(elapsed)
+  return (
+    <Text
+      size={1}
+      tone="muted"
+      className={styles.elapsed}
+      aria-label={`Elapsed time: ${text}`}
+      aria-live="off"
+    >
+      {text}
+    </Text>
+  )
+}

--- a/packages/agents-server-ui/src/lib/formatTime.ts
+++ b/packages/agents-server-ui/src/lib/formatTime.ts
@@ -74,6 +74,31 @@ export function formatAbsoluteDateTimeVerbose(ts: number): string {
   })
 }
 
+/**
+ * Compact elapsed-duration label intended for live "thinking" timers
+ * (next to the agent's `Thinking` indicator while a response is in
+ * flight). Returns one of:
+ *   - `0s` … `59s`
+ *   - `1m`, `1m 5s`, `12m 7s`
+ *   - `1h`, `1h 3m`, `2h 47m`
+ *
+ * Takes raw milliseconds (the caller is expected to have already
+ * subtracted the start timestamp); not seconds/ms-ambiguous like
+ * `toMillis`, since the input is a duration, not a wall-clock value.
+ */
+export function formatElapsedDuration(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  if (total < 60) return `${total}s`
+  if (total < 3600) {
+    const m = Math.floor(total / 60)
+    const s = total % 60
+    return s === 0 ? `${m}m` : `${m}m ${s}s`
+  }
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  return m === 0 ? `${h}h` : `${h}h ${m}m`
+}
+
 /** Short clock-style label, e.g. `14:18`. Locale chooses 24h vs am/pm. */
 export function formatShortTime(ts: number): string {
   const d = new Date(toMillis(ts))


### PR DESCRIPTION
## Summary

While a response is streaming, the agent meta row now ticks `Thinking · 12s` (or just `12s` once tokens start flowing). When the response settles in-session the existing `✓ done` becomes `✓ done in 1m 5s`.

- `ElapsedTime` component (self-ticking once a second; tears down its interval on disable; uses `tabular-nums` so the digits don't jitter).
- `formatElapsedDuration(ms)` in `lib/formatTime.ts` for compact duration labels (`0s` → `1m 5s` → `2h 47m`).
- Capture pattern (`sawStreamingRef` + `finalDurationMs`) wires `✓ done in Xs` into both `AgentResponseLive` and the cached `AgentResponse`. Responses that were already complete on page load keep the bare `✓ done` — the client has no reliable completion timestamp for those (only the user message time), so subtracting `now()` would lie about the duration.

## Test plan

- [x] `pnpm test` in `agents-server-ui` (66 passed)
- [x] `pnpm typecheck` in `agents-server-ui` (no new errors in the changed files; pre-existing errors in `EntityContextDrawer.tsx` and `agents-runtime/*` are unchanged from `main`)
- [x] Web — manually verified in `http://localhost:5175/__agent_ui/` against a local agents-server; thinking ticker counts up, `✓ done in Xs` lands on completion
- [x] Electron — manually verified in the desktop dev build; same behavior
- [ ] Mobile (Expo DOM embed via `ChatLogView` → `EntityTimeline` → `AgentResponse`) — not verified in this PR. The mobile dev client hit an unrelated pre-existing crash in `agents-runtime/src/entity-timeline.ts:1225` (`Invalid source for live query: alias 'inbox' is not a Collection`) when connected to the Electric Cloud workspace, blocking validation. The change here is a pure additive UI render in shared components, so mobile should pick it up automatically once that crash is sorted; following up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)