### PR TITLE
fix: dedupe @tanstack/db + set agents-mobile iOS minimum to 16.4

### DIFF
--- a/.changeset/dedupe-tanstack-db.md
+++ b/.changeset/dedupe-tanstack-db.md
@@ -14,3 +14,8 @@ drifted to several `0.6.x` copies, breaking StreamDB collections. Adds a root
 `>=0.6.0 <0.7.0` so the legacy example starters pinned to `0.0.x`/`0.5.8` are
 untouched. Stopgap until `@durable-streams/state` ships `@tanstack/db` as a
 peer dependency.
+
+Also raises the `agents-mobile` iOS minimum deployment target to 16.4 (via
+`expo-build-properties`). The chat renders in an Expo DOM WebView whose markdown
+stack ships regex lookbehind, which JavaScriptCore only parses on iOS 16.4+;
+below that the whole DOM bundle fails to parse and the chat renders blank.

--- a/.changeset/dedupe-tanstack-db.md
+++ b/.changeset/dedupe-tanstack-db.md
@@ -1,0 +1,16 @@
+---
+'electric-ax': patch
+'@electric-ax/agents-server-ui': patch
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents-mobile': patch
+---
+
+Dedupe `@tanstack/db` to a single instance.
+
+`@tanstack/db` is effectively a singleton (collections/transactions/live
+queries use `instanceof` checks and module-level state), but the lockfile had
+drifted to several `0.6.x` copies, breaking StreamDB collections. Adds a root
+`pnpm.overrides` entry collapsing the `0.6.x` line to `0.6.7`, scoped to
+`>=0.6.0 <0.7.0` so the legacy example starters pinned to `0.0.x`/`0.5.8` are
+untouched. Stopgap until `@durable-streams/state` ships `@tanstack/db` as a
+peer dependency.

--- a/package.json
+++ b/package.json
@@ -38,9 +38,13 @@
     ],
     "*.{json,css,md,vue,yml,yaml}": "node_modules/.bin/prettier --write"
   },
+  "//pnpm.overrides": "Collapse the @tanstack/db 0.6.x line to a single version so collections/transactions/live-queries (singleton, instanceof-based) don't break from duplicate copies. @durable-streams/state declares an open ^0.6.0 while @tanstack/react-db pins an exact 0.6.x, so a single app pulls in two 0.6.x copies. Scoped to 0.6.x on purpose: the legacy example starters pin 0.0.x/0.5.8 and must not be forced onto 0.6.x. Stopgap — drop this once @durable-streams/state ships @tanstack/db as a peer dep (durable-streams PR #381) and we bump to it.",
   "pnpm": {
     "patchedDependencies": {
       "@microsoft/fetch-event-source": "patches/@microsoft__fetch-event-source.patch"
+    },
+    "overrides": {
+      "@tanstack/db@>=0.6.0 <0.7.0": "0.6.7"
     }
   }
 }

--- a/packages/agents-mobile/app.config.ts
+++ b/packages/agents-mobile/app.config.ts
@@ -28,6 +28,10 @@ export default ({ config }: ConfigContext): ExpoConfig =>
       plugins: [
         `expo-router`,
         `expo-web-browser`,
+        // The chat WebView (Expo DOM / streamdown) ships regex lookbehind,
+        // which JavaScriptCore only parses on iOS 16.4+. Below that the whole
+        // DOM bundle fails to parse and the chat renders blank.
+        [`expo-build-properties`, { ios: { deploymentTarget: `16.4` } }],
         // Android-only: forward new intents in MainActivity.kt so
         // OAuth redirect deep links delivered after the Chrome
         // Custom Tab dismisses actually reach expo-linking /

--- a/packages/agents-mobile/package.json
+++ b/packages/agents-mobile/package.json
@@ -26,6 +26,7 @@
     "@tanstack/electric-db-collection": "^0.3.3",
     "@tanstack/react-db": "^0.1.83",
     "expo": "54.0.35",
+    "expo-build-properties": "~1.0.10",
     "expo-constants": "~18.0.13",
     "expo-linking": "~8.0.12",
     "expo-router": "~6.0.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@tanstack/db@>=0.6.0 <0.7.0': 0.6.7
+
 patchedDependencies:
   '@microsoft/fetch-event-source':
     hash: 46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188
@@ -102,8 +105,8 @@ importers:
         specifier: ^0.34.0
         version: 0.34.49
       '@tanstack/db':
-        specifier: ^0.6.0
-        version: 0.6.5(typescript@5.8.3)
+        specifier: 0.6.7
+        version: 0.6.7(typescript@5.8.3)
       '@tanstack/react-db':
         specifier: ^0.1.78
         version: 0.1.83(react@19.2.5)(typescript@5.8.3)
@@ -182,7 +185,7 @@ importers:
         specifier: ^0.34.0
         version: 0.34.49
       '@tanstack/db':
-        specifier: ^0.6.6
+        specifier: 0.6.7
         version: 0.6.7(typescript@5.8.3)
       '@tanstack/react-db':
         specifier: ^0.1.78
@@ -1683,8 +1686,8 @@ importers:
         specifier: ~7.2.0
         version: 7.2.0(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@tanstack/db':
-        specifier: ^0.6.5
-        version: 0.6.6(typescript@5.9.3)
+        specifier: 0.6.7
+        version: 0.6.7(typescript@5.9.3)
       '@tanstack/electric-db-collection':
         specifier: ^0.3.3
         version: 0.3.4(typescript@5.9.3)
@@ -1798,8 +1801,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       '@tanstack/db':
-        specifier: ^0.6.6
-        version: 0.6.6(typescript@5.9.3)
+        specifier: 0.6.7
+        version: 0.6.7(typescript@5.9.3)
       '@tanstack/react-db':
         specifier: '>=0.1.78'
         version: 0.1.83(react@19.2.0)(typescript@5.9.3)
@@ -2014,8 +2017,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(react@19.1.0)
       '@tanstack/db':
-        specifier: ^0.6.6
-        version: 0.6.6(typescript@5.9.3)
+        specifier: 0.6.7
+        version: 0.6.7(typescript@5.9.3)
       '@tanstack/electric-db-collection':
         specifier: ^0.3.4
         version: 0.3.4(typescript@5.9.3)
@@ -2105,8 +2108,8 @@ importers:
         specifier: ^1.5.20
         version: link:../typescript-client
       '@tanstack/db':
-        specifier: ^0.6.4
-        version: 0.6.5(typescript@5.8.3)
+        specifier: 0.6.7
+        version: 0.6.7(typescript@5.8.3)
       '@tanstack/react-db':
         specifier: ^0.1.82
         version: 0.1.83(react@19.2.0)(typescript@5.8.3)
@@ -9544,16 +9547,6 @@ packages:
 
   '@tanstack/db@0.5.8':
     resolution: {integrity: sha512-X6z/OFTzQ8tyOKiWCEqQPSH/w+pmEWack+EMPweAyssXvT6qbfBayRxSoKl93ZTTdgWHBpGlQE75+vVkT1Szqw==}
-    peerDependencies:
-      typescript: '>=4.7'
-
-  '@tanstack/db@0.6.5':
-    resolution: {integrity: sha512-gtCuAo4UtC9SR/kTMu5fVEff6qZ2R1FZi9X7MybtHKA6wve7RePifGG6qBI4OmMB+7juT5/+glNbnqZOrG0/pg==}
-    peerDependencies:
-      typescript: '>=4.7'
-
-  '@tanstack/db@0.6.6':
-    resolution: {integrity: sha512-v1Mphjtwy/6m3ixhNFackRp8XYgdJYGFUUBQ80d0lsipk0MYKHIoePpHGSum95nerLDcP/8+fu5qj0Vrvmskqw==}
     peerDependencies:
       typescript: '>=4.7'
 
@@ -30371,27 +30364,6 @@ snapshots:
       '@tanstack/pacer-lite': 0.1.1
       typescript: 5.7.2
 
-  '@tanstack/db@0.6.5(typescript@5.8.3)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@tanstack/db-ivm': 0.1.18(typescript@5.8.3)
-      '@tanstack/pacer-lite': 0.2.1
-      typescript: 5.8.3
-
-  '@tanstack/db@0.6.5(typescript@5.9.3)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@tanstack/db-ivm': 0.1.18(typescript@5.9.3)
-      '@tanstack/pacer-lite': 0.2.1
-      typescript: 5.9.3
-
-  '@tanstack/db@0.6.6(typescript@5.9.3)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@tanstack/db-ivm': 0.1.18(typescript@5.9.3)
-      '@tanstack/pacer-lite': 0.2.1
-      typescript: 5.9.3
-
   '@tanstack/db@0.6.7(typescript@5.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -30477,7 +30449,7 @@ snapshots:
     dependencies:
       '@electric-sql/client': 1.5.18
       '@standard-schema/spec': 1.1.0
-      '@tanstack/db': 0.6.6(typescript@5.9.3)
+      '@tanstack/db': 0.6.7(typescript@5.9.3)
       '@tanstack/store': 0.9.3
       debug: 4.4.3
     transitivePeerDependencies:
@@ -30525,7 +30497,7 @@ snapshots:
 
   '@tanstack/react-db@0.1.83(react@19.2.0)(typescript@5.8.3)':
     dependencies:
-      '@tanstack/db': 0.6.5(typescript@5.8.3)
+      '@tanstack/db': 0.6.7(typescript@5.8.3)
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
     transitivePeerDependencies:
@@ -30533,7 +30505,7 @@ snapshots:
 
   '@tanstack/react-db@0.1.83(react@19.2.0)(typescript@5.9.3)':
     dependencies:
-      '@tanstack/db': 0.6.5(typescript@5.9.3)
+      '@tanstack/db': 0.6.7(typescript@5.9.3)
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
     transitivePeerDependencies:
@@ -30541,7 +30513,7 @@ snapshots:
 
   '@tanstack/react-db@0.1.83(react@19.2.5)(typescript@5.8.3)':
     dependencies:
-      '@tanstack/db': 0.6.5(typescript@5.8.3)
+      '@tanstack/db': 0.6.7(typescript@5.8.3)
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
     transitivePeerDependencies:
@@ -30549,7 +30521,7 @@ snapshots:
 
   '@tanstack/react-db@0.1.84(react@19.1.0)(typescript@5.9.3)':
     dependencies:
-      '@tanstack/db': 0.6.6(typescript@5.9.3)
+      '@tanstack/db': 0.6.7(typescript@5.9.3)
       react: 19.1.0
       use-sync-external-store: 1.6.0(react@19.1.0)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1697,6 +1697,9 @@ importers:
       expo:
         specifier: 54.0.35
         version: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-build-properties:
+        specifier: ~1.0.10
+        version: 1.0.10(expo@54.0.35)
       expo-constants:
         specifier: ~18.0.13
         version: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
@@ -13760,6 +13763,11 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-build-properties@1.0.10:
+    resolution: {integrity: sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==}
+    peerDependencies:
+      expo: '*'
+
   expo-constants@17.1.7:
     resolution: {integrity: sha512-byBjGsJ6T6FrLlhOBxw4EaiMXrZEn/MlUYIj/JAd+FS7ll5X/S4qVRbIimSJtdW47hXMq0zxPfJX6njtA56hHA==}
     peerDependencies:
@@ -24160,7 +24168,7 @@ snapshots:
       interrogator: 2.0.1
       is-interactive: 1.0.0
       parameter-reducers: 2.1.0
-      semver: 7.6.3
+      semver: 7.7.4
 
   '@databases/pg-config@3.2.0(typescript@5.6.3)':
     dependencies:
@@ -36160,6 +36168,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-build-properties@1.0.10(expo@54.0.35):
+    dependencies:
+      ajv: 8.20.0
+      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      semver: 7.7.4
 
   expo-constants@17.1.7(expo@53.0.20(@babel/core@7.28.0)(@expo/metro-runtime@5.0.4(react-native@0.80.1(@babel/core@7.28.0)(@types/react@19.1.17)(react@19.1.0)))(react-native-webview@13.16.1(react-native@0.80.1(@babel/core@7.28.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.80.1(@babel/core@7.28.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.80.1(@babel/core@7.28.0)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:


### PR DESCRIPTION
## What

Adds a root `pnpm.overrides` entry collapsing the `@tanstack/db` `0.6.x` line to a single version (`0.6.7`).

## Why

`@tanstack/db` is effectively a singleton — collections, transactions, and live queries rely on `instanceof` checks and module-level shared state, and `Collection` carries private fields, so two copies are nominally distinct types. The lockfile had drifted to multiple `0.6.x` copies at once (`0.6.5`, `0.6.6`, `0.6.7`) because `@tanstack/react-db` pins an exact `@tanstack/db` per release while `@durable-streams/state` declares an open `^0.6.0`. A single app therefore resolved two `0.6.x` copies, breaking StreamDB collections at the type and runtime level.

## Scope

The override is deliberately scoped to `>=0.6.0 <0.7.0` rather than a blanket pin, so the legacy example starters (`burn-client`, `tanstack-start-db-electric-starter`, `expo-db-electric-starter`) that still depend on `@tanstack/db` `0.0.x`/`0.5.8` via old `react-db`/`electric-db-collection` are left untouched — forcing them onto `0.6.x` would break them with API mismatches.

## Verification

- Lockfile: the `0.6.x` line now resolves to a single `0.6.7`; `0.0.27`/`0.0.33`/`0.5.8` entries from the legacy starters are unchanged.
- The full agents-mobile bundle closure (agents-mobile + agents-runtime + agents-server-ui + `@durable-streams/state`) resolves to one physical `@tanstack/db@0.6.7`.
- Affected packages build/typecheck cleanly (no new `@tanstack/db`-related errors).

## Stopgap

This is a deliberate stopgap. The durable fix is upstream — `@durable-streams/state` is moving `@tanstack/db` from a regular dependency to a peer dependency (durable-streams PR #381). Once that ships and we bump `@durable-streams/state`, the state-induced duplication resolves on its own and this override can likely be removed (the legacy-starter versions are a separate cleanup).

---

## Also in this PR: agents-mobile iOS minimum deployment target → 16.4

Separate commit (`fix(agents-mobile): set iOS minimum deployment target to 16.4`).

**What:** adds the `expo-build-properties` plugin with `ios.deploymentTarget: "16.4"`.

**Why:** the mobile chat renders inside an Expo DOM WebView whose markdown stack (`streamdown` → `remend` / `mdast-util-gfm-autolink-literal`) ships regex lookbehind `(?<=…)`. JavaScriptCore only parses lookbehind on **iOS 16.4+**; below that the entire DOM bundle fails to *parse*, so the chat renders blank with no surfaced error (reproduced on an iOS 16.2 simulator). Pinning the deployment target to 16.4 stops the app installing on engines that can't run it. Confirmed rendering correctly on iOS 17.4. These deps have shipped since the agents feature first landed, so this is a longstanding minimum-iOS reality, not a regression.

**Lockfile note:** adding `expo-build-properties` pulls in `semver ^7.7`, so pnpm deduped the existing transitive `@databases/pg-typed` `semver` from `7.6.3` → `7.7.4` to keep a single `semver@7` instance. Intentional dedup, not a wider install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
