### PR TITLE
feat(agents-server): mirror user principals into users

### DIFF
--- a/.changeset/principal-users-table.md
+++ b/.changeset/principal-users-table.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-server": patch
+---
+
+Mirror user principals into the tenant-scoped `users` table when principal entities are materialized, while preserving any profile fields enriched by host-specific identity sync.

--- a/packages/agents-server/src/entity-manager.ts
+++ b/packages/agents-server/src/entity-manager.ts
@@ -497,7 +497,10 @@ export class EntityManager {
 
   async ensurePrincipal(principal: Principal): Promise<ElectricAgentsEntity> {
     const existing = await this.registry.getEntity(principal.url)
-    if (existing) return existing
+    if (existing) {
+      await this.ensureUserPrincipal(principal)
+      return existing
+    }
     await this.ensurePrincipalEntityType()
     try {
       const entity = await this.spawn(`principal`, {
@@ -522,6 +525,7 @@ export class EntityManager {
           },
         })
       )
+      await this.ensureUserPrincipal(principal)
       return entity
     } catch (error) {
       if (
@@ -529,9 +533,18 @@ export class EntityManager {
         error.code === ErrCodeDuplicateURL
       ) {
         const raced = await this.registry.getEntity(principal.url)
-        if (raced) return raced
+        if (raced) {
+          await this.ensureUserPrincipal(principal)
+          return raced
+        }
       }
       throw error
+    }
+  }
+
+  private async ensureUserPrincipal(principal: Principal): Promise<void> {
+    if (principal.kind === `user`) {
+      await this.registry.ensureUserForPrincipal(principal)
     }
   }
 

--- a/packages/agents-server/src/entity-registry.ts
+++ b/packages/agents-server/src/entity-registry.ts
@@ -15,6 +15,7 @@ import {
   runners,
   sharedStateLinks,
   tagStreamOutbox,
+  users,
 } from './db/schema.js'
 import {
   assertEntityStatus,
@@ -43,6 +44,7 @@ import type {
   PermissionSubjectKind,
 } from './electric-agents-types.js'
 import type { EntityTags } from '@electric-ax/agents-runtime'
+import type { Principal } from './principal.js'
 
 export class EntityAlreadyExistsError extends Error {
   constructor(public readonly url: string) {
@@ -193,6 +195,18 @@ export class PostgresRegistry {
   async initialize(): Promise<void> {}
 
   close(): void {}
+
+  async ensureUserForPrincipal(principal: Principal): Promise<void> {
+    if (principal.kind !== `user`) return
+
+    await this.db
+      .insert(users)
+      .values({
+        tenantId: this.tenantId,
+        id: principal.id,
+      })
+      .onConflictDoNothing()
+  }
 
   async createRunner(
     input: RegisterRunnerInput

--- a/packages/agents-server/test/electric-agents-manager-principals.test.ts
+++ b/packages/agents-server/test/electric-agents-manager-principals.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+import { EntityManager } from '../src/entity-manager'
+import { parsePrincipalKey } from '../src/principal'
+import type { ElectricAgentsEntity } from '../src/electric-agents-types'
+
+function createManager() {
+  const registry = {
+    getEntity: vi.fn(),
+    ensureEntityType: vi.fn().mockResolvedValue({
+      name: `principal`,
+      description: `built-in principal entity`,
+      revision: 1,
+      created_at: `2026-06-01T00:00:00.000Z`,
+      updated_at: `2026-06-01T00:00:00.000Z`,
+    }),
+    ensureUserForPrincipal: vi.fn().mockResolvedValue(undefined),
+  }
+  const streamClient = {
+    append: vi.fn().mockResolvedValue({ offset: `1` }),
+  }
+  const manager = new EntityManager({
+    registry: registry as any,
+    streamClient: streamClient as any,
+    validator: {} as any,
+    wakeRegistry: {
+      setTimeoutCallback: vi.fn(),
+      setDebounceCallback: vi.fn(),
+    } as any,
+  })
+
+  return { manager, registry, streamClient }
+}
+
+function principalEntity(principalKey: string): ElectricAgentsEntity & {
+  txid: number
+} {
+  return {
+    url: `/principal/${encodeURIComponent(principalKey)}`,
+    type: `principal`,
+    status: `idle`,
+    streams: {
+      main: `/principal/${encodeURIComponent(principalKey)}/main`,
+      error: `/principal/${encodeURIComponent(principalKey)}/error`,
+    },
+    subscription_id: `sub-principal`,
+    write_token: `write-token`,
+    tags: {},
+    created_at: Date.now(),
+    updated_at: Date.now(),
+    txid: 1,
+  }
+}
+
+describe(`ElectricAgentsManager principals`, () => {
+  it(`ensures a users row when materializing a user principal`, async () => {
+    const { manager, registry } = createManager()
+    registry.getEntity.mockResolvedValue(null)
+    const principal = parsePrincipalKey(`user:alice`)
+    vi.spyOn(manager, `spawn`).mockResolvedValue(principalEntity(principal.key))
+
+    await manager.ensurePrincipal(principal)
+
+    expect(registry.ensureUserForPrincipal).toHaveBeenCalledWith(principal)
+  })
+
+  it(`does not create a users row for non-user principals`, async () => {
+    const { manager, registry } = createManager()
+    const principal = parsePrincipalKey(`service:github`)
+    registry.getEntity.mockResolvedValue(principalEntity(principal.key))
+
+    await manager.ensurePrincipal(principal)
+
+    expect(registry.ensureUserForPrincipal).not.toHaveBeenCalled()
+  })
+})

--- a/packages/agents-server/test/user-registry.test.ts
+++ b/packages/agents-server/test/user-registry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { PostgresRegistry } from '../src/entity-registry'
+import { parsePrincipalKey } from '../src/principal'
+
+describe(`PostgresRegistry users`, () => {
+  it(`duplicates user principals into tenant-scoped users`, async () => {
+    const { registry, db } = fakeRegistry()
+
+    await registry.ensureUserForPrincipal(parsePrincipalKey(`user:alice`))
+
+    expect(db.insertValues).toEqual({
+      tenantId: `tenant-a`,
+      id: `alice`,
+    })
+    expect(db.onConflictDoNothing).toHaveBeenCalled()
+  })
+
+  it(`ignores non-user principals`, async () => {
+    const { registry, db } = fakeRegistry()
+
+    await registry.ensureUserForPrincipal(parsePrincipalKey(`service:github`))
+
+    expect(db.insert).not.toHaveBeenCalled()
+  })
+})
+
+function fakeRegistry() {
+  const db = {
+    insertValues: undefined as unknown,
+    insert: vi.fn(() => ({
+      values: vi.fn((values: unknown) => {
+        db.insertValues = values
+        return {
+          onConflictDoNothing: db.onConflictDoNothing,
+        }
+      }),
+    })),
+    onConflictDoNothing: vi.fn(async () => undefined),
+  }
+
+  return {
+    db,
+    registry: new PostgresRegistry(db as never, `tenant-a`),
+  }
+}


### PR DESCRIPTION
## Motivation

User principals are already materialized as built-in principal entities, but the tenant-scoped `users` table was not populated from that flow. That left hosts without a stable user row to join against or enrich.

## Changes

- Add tenant-scoped `users` persistence for user-principal materialization.
- Mirror `user:*` principals into `users` whenever `ensurePrincipal` materializes or observes the built-in principal entity.
- Keep the mirror path insert-only so host/cloud enrichment can never be clobbered by principal creation.
- Add focused tests for manager principal mirroring and registry user persistence behavior.
- Add a package changeset.

## Decisions

OSS stays intentionally identity-provider agnostic: principal creation only guarantees a tenant-scoped user id exists. Optional fields such as display name, email, avatar, auth provider, profile, and metadata remain open for host-specific integrations to populate. There is no OSS enrichment/upsert helper in this PR, so cloud-specific metadata merge semantics live in the cloud host instead of creating a divergent dead-code helper here.
