### PR TITLE
feat(agents-server-ui): show per-response token usage in meta row

### DIFF
--- a/.changeset/agent-token-usage.md
+++ b/.changeset/agent-token-usage.md
@@ -1,0 +1,27 @@
+---
+'@electric-ax/agents-server-ui': patch
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents-desktop': patch
+---
+
+Show per-response token usage in the agent meta row, e.g. `1.2k ↑ 412
+↓`. Updates as each step settles — for a single-turn call this lands
+once at done; for tool-using runs the counter jumps at each step
+boundary (the LLM SDK only emits `usage` at end-of-step, so we can't
+tick smoothly between tokens).
+
+Plumbing:
+
+- `StepValue` gains optional `input_tokens` / `output_tokens` columns
+  (Zod + TS). Strictly additive: events recorded before this change
+  stay valid since both fields are optional, so no migration.
+- `outbound-bridge.ts:onStepEnd` now persists the `tokenInput` /
+  `tokenOutput` it already received from `pi-adapter.ts` — previously
+  those values were accepted and silently dropped.
+- `EntityTimelineStepItem` / `IncludesStep` surface the new fields,
+  and the three `.select()` blocks that materialize steps include
+  them.
+- The cached `agent_response` section gets a `tokens?: { input?,
+  output? }` summed across the run's steps at section-build time, and
+  the section-cache fingerprint factors in step token deltas so a
+  late-arriving `onStepEnd` invalidates a stale section.

--- a/packages/agents-runtime/src/entity-schema.ts
+++ b/packages/agents-runtime/src/entity-schema.ts
@@ -154,6 +154,12 @@ type StepValue = {
   model_provider?: string
   model_id?: string
   duration_ms?: number
+  // Token usage for this step as reported by the provider's
+  // end-of-message `usage` payload. Populated on `onStepEnd` when the
+  // adapter has the data — older events without these fields stay
+  // valid (both optional), so this is a strictly additive change.
+  input_tokens?: number
+  output_tokens?: number
 }
 type TextValue = {
   key?: string
@@ -471,6 +477,8 @@ function createStepSchema(): Schema<StepValue> {
     model_provider: z.string().optional(),
     model_id: z.string().optional(),
     duration_ms: z.number().int().optional(),
+    input_tokens: z.number().int().nonnegative().optional(),
+    output_tokens: z.number().int().nonnegative().optional(),
   })
 }
 

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -57,6 +57,13 @@ export type EntityTimelineSection =
       items: Array<EntityTimelineContentItem>
       done?: true
       error?: string
+      // Summed across all steps of the run that produced this section.
+      // Either side may be missing if the provider didn't report it
+      // (e.g. older events recorded before tokens were persisted).
+      tokens?: {
+        input?: number
+        output?: number
+      }
     }
   | {
       kind: `wake`
@@ -103,6 +110,8 @@ export interface IncludesStep {
   status: `started` | `completed`
   model_id?: string
   duration_ms?: number
+  input_tokens?: number
+  output_tokens?: number
 }
 
 export interface IncludesError {
@@ -228,6 +237,8 @@ export interface EntityTimelineStepItem {
   status: `started` | `completed`
   model_id?: string
   duration_ms?: number
+  input_tokens?: number
+  output_tokens?: number
 }
 
 export interface EntityTimelineErrorItem {
@@ -778,6 +789,8 @@ function buildIncludesRuns(input: {
       status: step.status,
       model_id: step.model_id,
       duration_ms: step.duration_ms,
+      input_tokens: step.input_tokens,
+      output_tokens: step.output_tokens,
     })
     stepsByRun.set(step.run_id, entries)
   }
@@ -1363,6 +1376,8 @@ function buildEntityTimelineQuery(
         status: step.status,
         model_id: step.model_id,
         duration_ms: step.duration_ms,
+        input_tokens: step.input_tokens,
+        output_tokens: step.output_tokens,
       })),
     errors: q
       .from({ error: db.collections.errors })
@@ -1492,6 +1507,8 @@ export function createEntityIncludesQuery(
                   status: step.status,
                   model_id: step.model_id,
                   duration_ms: step.duration_ms,
+                  input_tokens: step.input_tokens,
+                  output_tokens: step.output_tokens,
                 }))
             ),
             errors: toArray(

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -2,13 +2,16 @@ import {
   and,
   coalesce,
   concat,
+  count,
   createCollection,
   createLiveQueryCollection,
   eq,
+  gt,
   isNull,
   like,
   localOnlyCollectionOptions,
   or,
+  sum,
   toArray,
 } from '@durable-streams/state/db'
 import { caseWhen } from '@tanstack/db'
@@ -80,6 +83,15 @@ export interface IncludesRun {
   toolCalls: Array<IncludesToolCall>
   steps: Array<IncludesStep>
   errors: Array<IncludesError>
+  // Per-run token totals summed across all `steps` of the run.
+  // Either side is omitted if no step reported that side; the whole
+  // field is omitted if no step reported either. Computed in the
+  // query layer (or by `buildIncludesRuns` for in-memory snapshots)
+  // so consumers don't re-aggregate.
+  tokens?: {
+    input?: number
+    output?: number
+  }
 }
 
 export interface IncludesText {
@@ -256,6 +268,14 @@ export interface EntityTimelineRunRow {
   items: Collection<EntityTimelineRunItem>
   steps: Collection<EntityTimelineStepItem>
   errors: Collection<EntityTimelineErrorItem>
+  // Per-run token totals summed across all `steps` of the run.
+  // Same shape as `IncludesRun.tokens` — the query layer resolves
+  // both sides' presence via `count`, so the UI can render `tokens`
+  // as-is without re-aggregating step rows.
+  tokens?: {
+    input?: number
+    output?: number
+  }
 }
 
 export type EntityTimelineInboxRow = IncludesInboxMessage
@@ -807,20 +827,58 @@ function buildIncludesRuns(input: {
     errorsByRun.set(error.run_id, entries)
   }
 
-  return [...input.runs].sort(compareTimelineOrder).map((run) => ({
-    key: run.key,
-    order: run.order,
-    status: run.status,
-    finish_reason: run.finish_reason,
-    texts: [...(textsByRun.get(run.key) ?? [])].sort(compareTimelineOrder),
-    toolCalls: [...(toolCallsByRun.get(run.key) ?? [])].sort(
-      compareTimelineOrder
-    ),
-    steps: [...(stepsByRun.get(run.key) ?? [])].sort(
+  return [...input.runs].sort(compareTimelineOrder).map((run) => {
+    const runSteps = [...(stepsByRun.get(run.key) ?? [])].sort(
       (left, right) => left.step_number - right.step_number
-    ),
-    errors: [...(errorsByRun.get(run.key) ?? [])],
-  }))
+    )
+    const tokens = aggregateRunTokens(runSteps)
+    return {
+      key: run.key,
+      order: run.order,
+      status: run.status,
+      finish_reason: run.finish_reason,
+      texts: [...(textsByRun.get(run.key) ?? [])].sort(compareTimelineOrder),
+      toolCalls: [...(toolCallsByRun.get(run.key) ?? [])].sort(
+        compareTimelineOrder
+      ),
+      steps: runSteps,
+      errors: [...(errorsByRun.get(run.key) ?? [])],
+      ...(tokens && { tokens }),
+    }
+  })
+}
+
+/**
+ * In-memory token aggregator used by `buildIncludesRuns` to match the
+ * shape that `createEntityIncludesQuery` / `createEntityTimelineQuery`
+ * produce via `sum` / `count` over the steps collection.
+ *
+ * Returns `undefined` when no step reported a token count on either
+ * side, so the consumer can elide the meta row entirely instead of
+ * showing "0 / 0" for runs whose provider never emitted usage data.
+ */
+function aggregateRunTokens(
+  steps: ReadonlyArray<{ input_tokens?: number; output_tokens?: number }>
+): { input?: number; output?: number } | undefined {
+  let inSum = 0
+  let outSum = 0
+  let sawIn = false
+  let sawOut = false
+  for (const step of steps) {
+    if (typeof step.input_tokens === `number`) {
+      inSum += step.input_tokens
+      sawIn = true
+    }
+    if (typeof step.output_tokens === `number`) {
+      outSum += step.output_tokens
+      sawOut = true
+    }
+  }
+  if (!sawIn && !sawOut) return undefined
+  return {
+    ...(sawIn && { input: inSum }),
+    ...(sawOut && { output: outSum }),
+  }
 }
 
 function buildInboxMessages(
@@ -1335,61 +1393,96 @@ function buildEntityTimelineQuery(
       }),
     }))
 
-  const runSource = q.from({ run: db.collections.runs }).select(({ run }) => ({
-    key: run.key,
-    order: coalesce(run._timeline_order, `~`),
-    status: run.status,
-    finish_reason: run.finish_reason,
-    items: q
-      .from({ item: runItemsSource })
-      .where(({ item }) => eq(item.run_id, run.key))
-      .orderBy(({ item }) => item.order)
-      .orderBy(({ item }) =>
-        coalesce(
-          caseWhen(item.text.key, `text`),
-          caseWhen(item.toolCall.key, `toolCall`),
-          ``
+  const runTokensSource = q
+    .from({ step: db.collections.steps })
+    .groupBy(({ step }) => step.run_id)
+    .select(({ step }) => ({
+      run_id: step.run_id,
+      input: sum(coalesce(step.input_tokens, 0)),
+      output: sum(coalesce(step.output_tokens, 0)),
+      input_count: count(step.input_tokens),
+      output_count: count(step.output_tokens),
+    }))
+
+  const runSource = q
+    .from({ run: db.collections.runs })
+    .leftJoin({ runTokens: runTokensSource }, ({ run, runTokens }) =>
+      eq(run.key, runTokens.run_id)
+    )
+    .select(({ run, runTokens }) => ({
+      key: run.key,
+      order: coalesce(run._timeline_order, `~`),
+      status: run.status,
+      finish_reason: run.finish_reason,
+      // Mirrors the `tokens` shape produced by `createEntityIncludesQuery`
+      // so the UI can read `run.tokens` directly off the live row without
+      // re-summing step contents.
+      tokens: caseWhen(
+        or(
+          gt(coalesce(runTokens.input_count, 0), 0),
+          gt(coalesce(runTokens.output_count, 0), 0)
+        ),
+        {
+          input: caseWhen(
+            gt(coalesce(runTokens.input_count, 0), 0),
+            runTokens.input
+          ),
+          output: caseWhen(
+            gt(coalesce(runTokens.output_count, 0), 0),
+            runTokens.output
+          ),
+        }
+      ),
+      items: q
+        .from({ item: runItemsSource })
+        .where(({ item }) => eq(item.run_id, run.key))
+        .orderBy(({ item }) => item.order)
+        .orderBy(({ item }) =>
+          coalesce(
+            caseWhen(item.text.key, `text`),
+            caseWhen(item.toolCall.key, `toolCall`),
+            ``
+          )
         )
-      )
-      .orderBy(({ item }) => coalesce(item.text.key, item.toolCall.key, ``))
-      .select(({ item }) => ({
-        text: caseWhen(item.text.key, {
-          key: item.text.key,
-          run_id: item.text.run_id,
-          order: item.text.order,
-          status: item.text.status,
-          content: item.textContent,
-        }),
-        toolCall: item.toolCall,
-      })),
-    steps: q
-      .from({ step: db.collections.steps })
-      .where(({ step }) => eq(step.run_id, run.key))
-      .orderBy(({ step }) => step.step_number)
-      .orderBy(({ step }) => coalesce(step._timeline_order, `~`))
-      .orderBy(({ step }) => step.key)
-      .select(({ step }) => ({
-        key: step.key,
-        run_id: step.run_id,
-        order: coalesce(step._timeline_order, `~`),
-        step_number: step.step_number,
-        status: step.status,
-        model_id: step.model_id,
-        duration_ms: step.duration_ms,
-        input_tokens: step.input_tokens,
-        output_tokens: step.output_tokens,
-      })),
-    errors: q
-      .from({ error: db.collections.errors })
-      .where(({ error }) => eq(error.run_id, run.key))
-      .orderBy(({ error }) => error.key)
-      .select(({ error }) => ({
-        key: error.key,
-        run_id: error.run_id,
-        error_code: error.error_code,
-        message: error.message,
-      })),
-  }))
+        .orderBy(({ item }) => coalesce(item.text.key, item.toolCall.key, ``))
+        .select(({ item }) => ({
+          text: caseWhen(item.text.key, {
+            key: item.text.key,
+            run_id: item.text.run_id,
+            order: item.text.order,
+            status: item.text.status,
+            content: item.textContent,
+          }),
+          toolCall: item.toolCall,
+        })),
+      steps: q
+        .from({ step: db.collections.steps })
+        .where(({ step }) => eq(step.run_id, run.key))
+        .orderBy(({ step }) => step.step_number)
+        .orderBy(({ step }) => coalesce(step._timeline_order, `~`))
+        .orderBy(({ step }) => step.key)
+        .select(({ step }) => ({
+          key: step.key,
+          run_id: step.run_id,
+          order: coalesce(step._timeline_order, `~`),
+          step_number: step.step_number,
+          status: step.status,
+          model_id: step.model_id,
+          duration_ms: step.duration_ms,
+          input_tokens: step.input_tokens,
+          output_tokens: step.output_tokens,
+        })),
+      errors: q
+        .from({ error: db.collections.errors })
+        .where(({ error }) => eq(error.run_id, run.key))
+        .orderBy(({ error }) => error.key)
+        .select(({ error }) => ({
+          key: error.key,
+          run_id: error.run_id,
+          error_code: error.error_code,
+          message: error.message,
+        })),
+    }))
 
   return q
     .unionAll({
@@ -1442,13 +1535,50 @@ export function createEntityIncludesQuery(
       runs: toArray(
         q
           .from({ run: runsCollection })
+          .leftJoin(
+            {
+              runTokens: q
+                .from({ step: db.collections.steps })
+                .groupBy(({ step }) => step.run_id)
+                .select(({ step }) => ({
+                  run_id: step.run_id,
+                  input: sum(coalesce(step.input_tokens, 0)),
+                  output: sum(coalesce(step.output_tokens, 0)),
+                  input_count: count(step.input_tokens),
+                  output_count: count(step.output_tokens),
+                })),
+            },
+            ({ run, runTokens }) => eq(run.key, runTokens.run_id)
+          )
           .where(({ run }) => eq(run.timelineKey, timeline.key))
           .orderBy(({ run }) => run.order)
-          .select(({ run }) => ({
+          .select(({ run, runTokens }) => ({
             key: run.key,
             order: run.order,
             status: run.status,
             finish_reason: run.finish_reason,
+            // Per-run token totals — `caseWhen` collapses the
+            // joined aggregate row down to the same
+            // `{ input?, output? } | undefined` shape consumers
+            // expect, dropping a side whose `count` is zero so a
+            // provider that only reported one side renders as
+            // "input only" rather than "input + 0 output".
+            tokens: caseWhen(
+              or(
+                gt(coalesce(runTokens.input_count, 0), 0),
+                gt(coalesce(runTokens.output_count, 0), 0)
+              ),
+              {
+                input: caseWhen(
+                  gt(coalesce(runTokens.input_count, 0), 0),
+                  runTokens.input
+                ),
+                output: caseWhen(
+                  gt(coalesce(runTokens.output_count, 0), 0),
+                  runTokens.output
+                ),
+              }
+            ),
             texts: toArray(
               q
                 .from({ text: db.collections.texts })

--- a/packages/agents-runtime/src/outbound-bridge.ts
+++ b/packages/agents-runtime/src/outbound-bridge.ts
@@ -231,6 +231,12 @@ export function createOutboundBridge(
             ...(opts?.durationMs !== undefined && {
               duration_ms: opts.durationMs,
             }),
+            ...(opts?.tokenInput !== undefined && {
+              input_tokens: opts.tokenInput,
+            }),
+            ...(opts?.tokenOutput !== undefined && {
+              output_tokens: opts.tokenOutput,
+            }),
           } as never,
         }) as ChangeEvent
       )

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -351,12 +351,34 @@ export function createPiAgentAdapter(
                     : hasToolCalls
                       ? `tool_calls`
                       : `stop`
+                // pi-ai's `Usage` declares `input`/`output` as required
+                // numbers, but we still pick them up defensively (a
+                // future provider might omit a side). We deliberately
+                // do NOT coerce a missing side to `0` — doing so would
+                // surface as "0 input / N output" in the meta row,
+                // indistinguishable from a real zero-token step. Sides
+                // that don't arrive as `number` are forwarded as
+                // `undefined` so `onStepEnd` skips the column entirely
+                // and the query-layer aggregate's `count(...)` treats
+                // them as absent.
+                const usageInput =
+                  typeof usage?.input === `number`
+                    ? usage.input
+                    : typeof usage?.inputTokens === `number`
+                      ? usage.inputTokens
+                      : undefined
+                const usageOutput =
+                  typeof usage?.output === `number`
+                    ? usage.output
+                    : typeof usage?.outputTokens === `number`
+                      ? usage.outputTokens
+                      : undefined
                 bridge.onStepEnd({
                   finishReason,
                   durationMs: Date.now() - stepStartTime,
-                  ...(usage && {
-                    tokenInput: usage.input ?? usage.inputTokens ?? 0,
-                    tokenOutput: usage.output ?? usage.outputTokens ?? 0,
+                  ...(usageInput !== undefined && { tokenInput: usageInput }),
+                  ...(usageOutput !== undefined && {
+                    tokenOutput: usageOutput,
                   }),
                 })
 

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -351,22 +351,48 @@ export function createPiAgentAdapter(
                     : hasToolCalls
                       ? `tool_calls`
                       : `stop`
-                // pi-ai's `Usage` declares `input`/`output` as required
-                // numbers, but we still pick them up defensively (a
-                // future provider might omit a side). We deliberately
-                // do NOT coerce a missing side to `0` — doing so would
-                // surface as "0 input / N output" in the meta row,
-                // indistinguishable from a real zero-token step. Sides
-                // that don't arrive as `number` are forwarded as
-                // `undefined` so `onStepEnd` skips the column entirely
-                // and the query-layer aggregate's `count(...)` treats
-                // them as absent.
+                // pi-ai's `Usage` splits the input side across three
+                // counters: `input` (new uncached tokens this turn),
+                // `cacheRead` (prompt-cache hits — typically the
+                // system prompt + prior history once the cache is
+                // warm) and `cacheWrite` (tokens added to the cache
+                // this turn). What the user wants in the meta row is
+                // the total prompt volume the model actually saw, so
+                // we sum every side that arrived as a number. Reading
+                // only `usage.input` undercounts massively on second+
+                // turns where most of the prompt hits the cache and
+                // `usage.input` collapses to a handful of tokens.
+                //
+                // `inputTokens` / `outputTokens` are legacy flat
+                // aliases (kept as a fallback for non-pi-ai providers
+                // that don't split the cache columns). We deliberately
+                // do NOT coerce a missing side to `0` — doing so
+                // would be indistinguishable from a real zero-token
+                // step in the meta row, and the query-layer
+                // `count(...)` aggregate would mark the side as
+                // present when it really isn't.
+                const sumPresentNumbers = (
+                  parts: Array<unknown>
+                ): number | undefined => {
+                  let total = 0
+                  let saw = false
+                  for (const part of parts) {
+                    if (typeof part === `number`) {
+                      total += part
+                      saw = true
+                    }
+                  }
+                  return saw ? total : undefined
+                }
                 const usageInput =
-                  typeof usage?.input === `number`
-                    ? usage.input
-                    : typeof usage?.inputTokens === `number`
-                      ? usage.inputTokens
-                      : undefined
+                  sumPresentNumbers([
+                    usage?.input,
+                    usage?.cacheRead,
+                    usage?.cacheWrite,
+                  ]) ??
+                  (typeof usage?.inputTokens === `number`
+                    ? usage.inputTokens
+                    : undefined)
                 const usageOutput =
                   typeof usage?.output === `number`
                     ? usage.output

--- a/packages/agents-runtime/src/use-chat.ts
+++ b/packages/agents-runtime/src/use-chat.ts
@@ -148,14 +148,12 @@ function fingerprintRun(run: IncludesRun): string {
   for (const tc of run.toolCalls) {
     fp += `:${tc.key}.${tc.status}${payloadSniff(`a`, tc.args)}${payloadSniff(`r`, tc.result)}`
   }
-  // Steps participate in the fingerprint because the section now
-  // surfaces summed token counts from them — without this, a step
-  // landing its `input_tokens` / `output_tokens` after the run
-  // already settled would not invalidate the cached section.
-  fp += `|s:${run.steps.length}`
-  for (const s of run.steps) {
-    fp += `:${s.key}.${s.status}.${s.input_tokens ?? `-`}.${s.output_tokens ?? `-`}`
-  }
+  // Token totals participate in the fingerprint because the section
+  // surfaces them — a late `onStepEnd` landing its usage data after
+  // the run already settled would otherwise not invalidate the cached
+  // section. We fingerprint the resolved `run.tokens` (already summed
+  // by the query layer) rather than each individual step.
+  fp += `|tk:${run.tokens?.input ?? `-`}.${run.tokens?.output ?? `-`}`
   return fp
 }
 
@@ -335,39 +333,17 @@ function buildAgentSection(run: IncludesRun): AgentResponseSection {
       failedToolText ?? finishReason ?? `Run failed (no error details recorded)`
   }
 
-  // Token totals across this run's steps. We accumulate per side and
-  // only attach `tokens` to the section if at least one step reported
-  // a number — that way a run whose provider never emitted usage data
-  // (older events, test fixtures, future providers without `usage`)
-  // continues to render with no token row instead of "0 / 0".
-  let tokenInputSum = 0
-  let tokenOutputSum = 0
-  let sawTokenInput = false
-  let sawTokenOutput = false
-  for (const step of run.steps) {
-    if (typeof step.input_tokens === `number`) {
-      tokenInputSum += step.input_tokens
-      sawTokenInput = true
-    }
-    if (typeof step.output_tokens === `number`) {
-      tokenOutputSum += step.output_tokens
-      sawTokenOutput = true
-    }
-  }
-  const tokens =
-    sawTokenInput || sawTokenOutput
-      ? {
-          ...(sawTokenInput && { input: tokenInputSum }),
-          ...(sawTokenOutput && { output: tokenOutputSum }),
-        }
-      : undefined
-
+  // Token totals come pre-aggregated on `run.tokens` from the query
+  // layer (`createEntityIncludesQuery` / `buildIncludesRuns`), so we
+  // surface them as-is. A run whose provider never emitted usage data
+  // has `run.tokens` left undefined and renders with no token row
+  // instead of "0 / 0".
   const section: AgentResponseSection = {
     kind: `agent_response`,
     items: contentItems,
     ...(run.status === `completed` && { done: true as const }),
     ...(errorText && { error: errorText }),
-    ...(tokens && { tokens }),
+    ...(run.tokens && { tokens: run.tokens }),
   }
   // Always cache (terminal or in-flight). Fingerprint check above
   // guarantees we never serve a stale streaming section — text growth

--- a/packages/agents-runtime/src/use-chat.ts
+++ b/packages/agents-runtime/src/use-chat.ts
@@ -148,6 +148,14 @@ function fingerprintRun(run: IncludesRun): string {
   for (const tc of run.toolCalls) {
     fp += `:${tc.key}.${tc.status}${payloadSniff(`a`, tc.args)}${payloadSniff(`r`, tc.result)}`
   }
+  // Steps participate in the fingerprint because the section now
+  // surfaces summed token counts from them — without this, a step
+  // landing its `input_tokens` / `output_tokens` after the run
+  // already settled would not invalidate the cached section.
+  fp += `|s:${run.steps.length}`
+  for (const s of run.steps) {
+    fp += `:${s.key}.${s.status}.${s.input_tokens ?? `-`}.${s.output_tokens ?? `-`}`
+  }
   return fp
 }
 
@@ -327,11 +335,39 @@ function buildAgentSection(run: IncludesRun): AgentResponseSection {
       failedToolText ?? finishReason ?? `Run failed (no error details recorded)`
   }
 
+  // Token totals across this run's steps. We accumulate per side and
+  // only attach `tokens` to the section if at least one step reported
+  // a number — that way a run whose provider never emitted usage data
+  // (older events, test fixtures, future providers without `usage`)
+  // continues to render with no token row instead of "0 / 0".
+  let tokenInputSum = 0
+  let tokenOutputSum = 0
+  let sawTokenInput = false
+  let sawTokenOutput = false
+  for (const step of run.steps) {
+    if (typeof step.input_tokens === `number`) {
+      tokenInputSum += step.input_tokens
+      sawTokenInput = true
+    }
+    if (typeof step.output_tokens === `number`) {
+      tokenOutputSum += step.output_tokens
+      sawTokenOutput = true
+    }
+  }
+  const tokens =
+    sawTokenInput || sawTokenOutput
+      ? {
+          ...(sawTokenInput && { input: tokenInputSum }),
+          ...(sawTokenOutput && { output: tokenOutputSum }),
+        }
+      : undefined
+
   const section: AgentResponseSection = {
     kind: `agent_response`,
     items: contentItems,
     ...(run.status === `completed` && { done: true as const }),
     ...(errorText && { error: errorText }),
+    ...(tokens && { tokens }),
   }
   // Always cache (terminal or in-flight). Fingerprint check above
   // guarantees we never serve a stale streaming section — text growth

--- a/packages/agents-runtime/test/entity-timeline.test.ts
+++ b/packages/agents-runtime/test/entity-timeline.test.ts
@@ -2257,5 +2257,227 @@ describe(`entity includes query`, () => {
       expect(liveEntity?.type).toBeUndefined()
       expect(liveEntity?.status).toBeUndefined()
     })
+
+    it(`aggregates per-run token totals from steps`, async () => {
+      const { collections, sync } = createEntityCollections()
+      const queryFn = createEntityIncludesQuery({ collections } as any)
+      const liveQuery = createLiveQueryCollection({
+        query: queryFn,
+        startSync: true,
+      })
+      await liveQuery.preload()
+
+      sync.runs.insert({ key: `run-1`, status: `started` })
+      sync.steps.insert({
+        key: `step-1`,
+        run_id: `run-1`,
+        step_number: 1,
+        status: `completed`,
+        input_tokens: 100,
+        output_tokens: 40,
+      })
+      sync.steps.insert({
+        key: `step-2`,
+        run_id: `run-1`,
+        step_number: 2,
+        status: `completed`,
+        input_tokens: 150,
+        output_tokens: 60,
+      })
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(getTimelineData(liveQuery)?.runs[0]?.tokens).toEqual({
+        input: 250,
+        output: 100,
+      })
+    })
+
+    it(`leaves tokens undefined when no step reports either side`, async () => {
+      const { collections, sync } = createEntityCollections()
+      const queryFn = createEntityIncludesQuery({ collections } as any)
+      const liveQuery = createLiveQueryCollection({
+        query: queryFn,
+        startSync: true,
+      })
+      await liveQuery.preload()
+
+      sync.runs.insert({ key: `run-1`, status: `completed` })
+      sync.steps.insert({
+        key: `step-1`,
+        run_id: `run-1`,
+        step_number: 1,
+        status: `completed`,
+        // no input_tokens / output_tokens — older events recorded
+        // before usage was persisted
+      })
+      await new Promise((r) => setTimeout(r, 50))
+
+      // TanStack DB's `caseWhen` with no default surfaces a SQL-style
+      // null at runtime; the TS contract types it as
+      // `{...} | undefined`, but consumers check `if (run.tokens)`
+      // which handles both — we mirror that here with `!= null`.
+      expect(getTimelineData(liveQuery)?.runs[0]?.tokens ?? undefined).toBe(
+        undefined
+      )
+    })
+
+    it(`surfaces only the present side when one side is missing`, async () => {
+      const { collections, sync } = createEntityCollections()
+      const queryFn = createEntityIncludesQuery({ collections } as any)
+      const liveQuery = createLiveQueryCollection({
+        query: queryFn,
+        startSync: true,
+      })
+      await liveQuery.preload()
+
+      sync.runs.insert({ key: `run-1`, status: `completed` })
+      sync.steps.insert({
+        key: `step-1`,
+        run_id: `run-1`,
+        step_number: 1,
+        status: `completed`,
+        input_tokens: 200,
+        // output_tokens omitted
+      })
+      await new Promise((r) => setTimeout(r, 50))
+
+      const tokens = getTimelineData(liveQuery)?.runs[0]?.tokens
+      expect(tokens?.input).toBe(200)
+      expect(tokens?.output ?? undefined).toBeUndefined()
+    })
+  })
+})
+
+describe(`buildEntityTimelineData token aggregation`, () => {
+  it(`sums input_tokens and output_tokens across a run's steps`, () => {
+    const timeline = buildEntityTimelineData({
+      collections: {
+        runs: {
+          toArray: [{ key: `run-1`, status: `completed`, _seq: 1 }],
+        },
+        texts: { toArray: [] },
+        textDeltas: { toArray: [] },
+        toolCalls: { toArray: [] },
+        steps: {
+          toArray: [
+            {
+              key: `step-1`,
+              run_id: `run-1`,
+              step_number: 1,
+              status: `completed`,
+              input_tokens: 100,
+              output_tokens: 40,
+              _seq: 2,
+            },
+            {
+              key: `step-2`,
+              run_id: `run-1`,
+              step_number: 2,
+              status: `completed`,
+              input_tokens: 150,
+              output_tokens: 60,
+              _seq: 3,
+            },
+          ],
+        },
+        errors: { toArray: [] },
+        inbox: { toArray: [] },
+        wakes: { toArray: [] },
+        signals: { toArray: [] },
+        contextInserted: { toArray: [], __electricRowOffsets: new Map() },
+        contextRemoved: { toArray: [], __electricRowOffsets: new Map() },
+        manifests: { toArray: [], __electricRowOffsets: new Map() },
+        childStatus: { toArray: [], __electricRowOffsets: new Map() },
+      },
+    } as any)
+
+    expect(timeline.runs[0]?.tokens).toEqual({ input: 250, output: 100 })
+  })
+
+  it(`omits tokens when no step reported a value`, () => {
+    const timeline = buildEntityTimelineData({
+      collections: {
+        runs: {
+          toArray: [{ key: `run-1`, status: `completed`, _seq: 1 }],
+        },
+        texts: { toArray: [] },
+        textDeltas: { toArray: [] },
+        toolCalls: { toArray: [] },
+        steps: {
+          toArray: [
+            {
+              key: `step-1`,
+              run_id: `run-1`,
+              step_number: 1,
+              status: `completed`,
+              _seq: 2,
+            },
+          ],
+        },
+        errors: { toArray: [] },
+        inbox: { toArray: [] },
+        wakes: { toArray: [] },
+        signals: { toArray: [] },
+        contextInserted: { toArray: [], __electricRowOffsets: new Map() },
+        contextRemoved: { toArray: [], __electricRowOffsets: new Map() },
+        manifests: { toArray: [], __electricRowOffsets: new Map() },
+        childStatus: { toArray: [], __electricRowOffsets: new Map() },
+      },
+    } as any)
+
+    expect(timeline.runs[0]?.tokens).toBeUndefined()
+  })
+})
+
+describe(`buildAgentSection token plumbing`, () => {
+  beforeEach(() => {
+    __resetSectionCachesForTesting()
+  })
+
+  it(`reads tokens directly off run.tokens without re-aggregating steps`, () => {
+    const runs: Array<IncludesRun> = [
+      {
+        key: `run-with-tokens`,
+        order: order(1),
+        status: `completed`,
+        texts: [],
+        toolCalls: [],
+        // steps deliberately don't carry token values here — the
+        // section should pick up `run.tokens` as-is.
+        steps: [
+          {
+            key: `step-1`,
+            run_id: `run-with-tokens`,
+            order: order(2),
+            step_number: 1,
+            status: `completed`,
+          },
+        ],
+        errors: [],
+        tokens: { input: 1234, output: 567 },
+      },
+    ]
+    const sections = buildSections(runs, [])
+    expect(sections[0]).toMatchObject({
+      kind: `agent_response`,
+      tokens: { input: 1234, output: 567 },
+    })
+  })
+
+  it(`omits section.tokens when run.tokens is undefined`, () => {
+    const runs: Array<IncludesRun> = [
+      {
+        key: `run-no-tokens`,
+        order: order(1),
+        status: `completed`,
+        texts: [],
+        toolCalls: [],
+        steps: [],
+        errors: [],
+      },
+    ]
+    const sections = buildSections(runs, [])
+    expect(sections[0]).toMatchObject({ kind: `agent_response` })
+    expect((sections[0] as any).tokens).toBeUndefined()
   })
 })

--- a/packages/agents-runtime/test/outbound-bridge.test.ts
+++ b/packages/agents-runtime/test/outbound-bridge.test.ts
@@ -297,4 +297,46 @@ describe(`createOutboundBridge`, () => {
     expect((writes[1]!.value as Record<string, unknown>).run_id).toBe(`run-0`)
     expect((writes[2]!.value as Record<string, unknown>).run_id).toBe(`run-0`)
   })
+
+  it(`onStepEnd surfaces token counts on the step update event`, () => {
+    const writes: Array<ChangeEvent> = []
+    const bridge = createOutboundBridge([], (e) => {
+      writes.push(e)
+    })
+
+    bridge.onRunStart()
+    bridge.onStepStart({ modelId: `gpt-4` })
+    bridge.onStepEnd({
+      finishReason: `stop`,
+      tokenInput: 1234,
+      tokenOutput: 567,
+    })
+
+    const stepUpdate = writes[writes.length - 1]!
+    expect(stepUpdate.type).toBe(`step`)
+    expect(stepUpdate.headers.operation).toBe(`update`)
+    const value = stepUpdate.value as Record<string, unknown>
+    expect(value.input_tokens).toBe(1234)
+    expect(value.output_tokens).toBe(567)
+  })
+
+  it(`onStepEnd omits token columns when a side is undefined`, () => {
+    const writes: Array<ChangeEvent> = []
+    const bridge = createOutboundBridge([], (e) => {
+      writes.push(e)
+    })
+
+    bridge.onRunStart()
+    bridge.onStepStart({ modelId: `gpt-4` })
+    // Only one side reported — the other should be absent on the
+    // event so `steps.input_tokens` / `steps.output_tokens` stays
+    // null for that step (and the query-layer `count(...)` treats
+    // it as missing rather than zero).
+    bridge.onStepEnd({ finishReason: `stop`, tokenInput: 42 })
+
+    const stepUpdate = writes[writes.length - 1]!
+    const value = stepUpdate.value as Record<string, unknown>
+    expect(value.input_tokens).toBe(42)
+    expect(`output_tokens` in value).toBe(false)
+  })
 })

--- a/packages/agents-runtime/test/pi-adapter.test.ts
+++ b/packages/agents-runtime/test/pi-adapter.test.ts
@@ -525,4 +525,99 @@ describe(`toAgentHistory`, () => {
       }
     }
   })
+
+  describe(`token usage plumbing`, () => {
+    function makeCompletedMessage(
+      usage: Partial<AssistantMessage[`usage`]>
+    ): AssistantMessage {
+      return {
+        role: `assistant`,
+        content: [{ type: `text`, text: `hello` }],
+        api: `anthropic-messages`,
+        provider: `anthropic`,
+        model: `claude-sonnet-4-5-20250929`,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+          ...usage,
+        },
+        stopReason: `stop`,
+        timestamp: Date.now(),
+      }
+    }
+
+    function findStepUpdate(
+      events: Array<ChangeEvent>
+    ): Record<string, unknown> | undefined {
+      const step = [...events]
+        .reverse()
+        .find((e) => e.type === `step` && e.headers.operation === `update`)
+      return step?.value as Record<string, unknown> | undefined
+    }
+
+    async function runOnce(
+      message: AssistantMessage
+    ): Promise<Array<ChangeEvent>> {
+      const events: Array<ChangeEvent> = []
+      const factory = createPiAgentAdapter({
+        systemPrompt: `Test system prompt`,
+        model: `claude-sonnet-4-5-20250929`,
+        tools: [],
+        streamFn: () => {
+          const stream = createAssistantMessageEventStream()
+          // pi-ai's stream resolves the run when we call `end()`
+          // with a terminal `AssistantMessage`; the adapter
+          // synthesizes `message_start` / `message_end` from it
+          // and routes the `usage` payload through to `onStepEnd`.
+          queueMicrotask(() => stream.end(message))
+          return stream
+        },
+      })
+      const handle = factory({
+        entityUrl: `test/entity-1`,
+        epoch: 1,
+        messages: [],
+        outboundIdSeed: { run: 0, step: 0, msg: 0, tc: 0 },
+        writeEvent: (e: ChangeEvent) => {
+          events.push(e)
+        },
+      })
+      await handle.run(`hello`, new AbortController().signal)
+      return events
+    }
+
+    it(`forwards numeric usage onto the step update event`, async () => {
+      const events = await runOnce(
+        makeCompletedMessage({ input: 1234, output: 567 })
+      )
+      const stepValue = findStepUpdate(events)
+      expect(stepValue?.input_tokens).toBe(1234)
+      expect(stepValue?.output_tokens).toBe(567)
+    })
+
+    it(`omits a side from the step event when usage doesn't report it`, async () => {
+      // Build a usage payload missing `output` to simulate a future
+      // provider (or a partial pi-ai response). The adapter should
+      // NOT fabricate a 0 — the column must stay absent so the
+      // query-layer `count(output_tokens)` reads as zero and the
+      // display row says "input only" instead of "input + 0 output".
+      const message = makeCompletedMessage({ input: 100 })
+      delete (message.usage as Partial<typeof message.usage>).output
+
+      const events = await runOnce(message)
+      const stepValue = findStepUpdate(events)
+      expect(stepValue?.input_tokens).toBe(100)
+      expect(`output_tokens` in (stepValue ?? {})).toBe(false)
+    })
+  })
 })

--- a/packages/agents-runtime/test/pi-adapter.test.ts
+++ b/packages/agents-runtime/test/pi-adapter.test.ts
@@ -605,6 +605,24 @@ describe(`toAgentHistory`, () => {
       expect(stepValue?.output_tokens).toBe(567)
     })
 
+    it(`sums input + cacheRead + cacheWrite into the input token total`, async () => {
+      // Anthropic + other prompt-cache providers split input across
+      // three counters; reading only `usage.input` would surface
+      // tiny "3 input" labels on cache-warm turns. The adapter sums
+      // all three so the meta row reflects the real prompt volume.
+      const events = await runOnce(
+        makeCompletedMessage({
+          input: 50,
+          cacheRead: 1200,
+          cacheWrite: 100,
+          output: 80,
+        })
+      )
+      const stepValue = findStepUpdate(events)
+      expect(stepValue?.input_tokens).toBe(1350)
+      expect(stepValue?.output_tokens).toBe(80)
+    })
+
     it(`omits a side from the step event when usage doesn't report it`, async () => {
       // Build a usage payload missing `output` to simulate a future
       // provider (or a partial pi-ai response). The adapter should

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -26,6 +26,7 @@ import { ToolCallView } from './ToolCallView'
 import { TimeText } from './TimeText'
 import { ThinkingIndicator } from './ThinkingIndicator'
 import { ElapsedTime } from './ElapsedTime'
+import { TokenUsage } from './TokenUsage'
 import { formatElapsedDuration, toMillis } from '../lib/formatTime'
 import styles from './AgentResponse.module.css'
 import type { ForkFromHereAction } from './UserMessage'
@@ -403,6 +404,39 @@ export const AgentResponseLive = memo(function AgentResponseLive({
     (q) => (run.errors ? q.from({ error: run.errors }) : undefined),
     [run.errors]
   )
+  // Live token aggregation: subscribe to this run's step rows and
+  // sum `input_tokens` / `output_tokens` across them. Steps land
+  // their token counts on `onStepEnd`, so for a single-turn LLM call
+  // this updates once; for a tool-using run with N model calls it
+  // jumps N times as each step settles.
+  const { data: stepRows = [] } = useLiveQuery(
+    (q) => (run.steps ? q.from({ step: run.steps }) : undefined),
+    [run.steps]
+  )
+  const liveTokens = useMemo(() => {
+    let inSum = 0
+    let outSum = 0
+    let sawIn = false
+    let sawOut = false
+    for (const s of stepRows as Array<{
+      input_tokens?: number
+      output_tokens?: number
+    }>) {
+      if (typeof s.input_tokens === `number`) {
+        inSum += s.input_tokens
+        sawIn = true
+      }
+      if (typeof s.output_tokens === `number`) {
+        outSum += s.output_tokens
+        sawOut = true
+      }
+    }
+    if (!sawIn && !sawOut) return null
+    return {
+      input: sawIn ? inSum : undefined,
+      output: sawOut ? outSum : undefined,
+    }
+  }, [stepRows])
   const sortedItems = useMemo(
     () => [...items].sort(compareLiveRunItems),
     [items]
@@ -536,9 +570,24 @@ export const AgentResponseLive = memo(function AgentResponseLive({
             <ElapsedTime ts={timestamp} enabled={isStreaming} />
           </>
         )}
+        {/* Token usage — sums every step's `input_tokens` /
+            `output_tokens` as they land. Updates at step boundaries
+            (the LLM SDK only emits `usage` at end-of-step), so for a
+            single-turn call it appears once at done; for tool-using
+            runs it jumps as each step completes. */}
+        {liveTokens && (
+          <>
+            {(hasLeadingMeta || (isStreaming && timestamp != null)) && (
+              <Text size={1} tone="muted" className={styles.metaSeparator}>
+                ·
+              </Text>
+            )}
+            <TokenUsage input={liveTokens.input} output={liveTokens.output} />
+          </>
+        )}
         {showTimestamp && (
           <>
-            {hasLeadingMeta && (
+            {(hasLeadingMeta || liveTokens) && (
               <Text size={1} tone="muted" className={styles.metaSeparator}>
                 ·
               </Text>
@@ -736,13 +785,29 @@ export const AgentResponse = memo(function AgentResponse({
             <ElapsedTime ts={timestamp} enabled={isStreaming} />
           </>
         )}
+        {/* Token usage — `section.tokens` is the sum across the
+            run's steps, materialized at section-build time. Mirrors
+            the live render above so cached + live look identical. */}
+        {section.tokens && (
+          <>
+            {(hasLeadingMeta || (isStreaming && timestamp != null)) && (
+              <Text size={1} tone="muted" className={styles.metaSeparator}>
+                ·
+              </Text>
+            )}
+            <TokenUsage
+              input={section.tokens.input}
+              output={section.tokens.output}
+            />
+          </>
+        )}
         {/* Timestamp only on a settled response — while the agent is
             still streaming we let `ThinkingIndicator` + `ElapsedTime`
             own the meta row so it doesn't sit inline with a timestamp
             that hasn't really happened yet. */}
         {showTimestamp && (
           <>
-            {hasLeadingMeta && (
+            {(hasLeadingMeta || section.tokens) && (
               <Text size={1} tone="muted" className={styles.metaSeparator}>
                 ·
               </Text>

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -404,39 +404,22 @@ export const AgentResponseLive = memo(function AgentResponseLive({
     (q) => (run.errors ? q.from({ error: run.errors }) : undefined),
     [run.errors]
   )
-  // Live token aggregation: subscribe to this run's step rows and
-  // sum `input_tokens` / `output_tokens` across them. Steps land
-  // their token counts on `onStepEnd`, so for a single-turn LLM call
-  // this updates once; for a tool-using run with N model calls it
-  // jumps N times as each step settles.
-  const { data: stepRows = [] } = useLiveQuery(
-    (q) => (run.steps ? q.from({ step: run.steps }) : undefined),
-    [run.steps]
-  )
+  // Token totals are aggregated in the query layer
+  // (`createEntityTimelineQuery`) — see the `runTokensSource`
+  // leftJoin in `entity-timeline.ts`. The query sums each step's
+  // `input_tokens` / `output_tokens` and surfaces a single
+  // `{ input?, output? } | undefined` row that updates at step
+  // boundaries (the LLM SDK only emits `usage` at end-of-step). We
+  // coerce `null` (TanStack DB's "no value" for a side whose
+  // `count` was zero) to `undefined` so `TokenUsage` can use a
+  // single `!= null` check.
   const liveTokens = useMemo(() => {
-    let inSum = 0
-    let outSum = 0
-    let sawIn = false
-    let sawOut = false
-    for (const s of stepRows as Array<{
-      input_tokens?: number
-      output_tokens?: number
-    }>) {
-      if (typeof s.input_tokens === `number`) {
-        inSum += s.input_tokens
-        sawIn = true
-      }
-      if (typeof s.output_tokens === `number`) {
-        outSum += s.output_tokens
-        sawOut = true
-      }
-    }
-    if (!sawIn && !sawOut) return null
-    return {
-      input: sawIn ? inSum : undefined,
-      output: sawOut ? outSum : undefined,
-    }
-  }, [stepRows])
+    if (!run.tokens) return null
+    const input = run.tokens.input ?? undefined
+    const output = run.tokens.output ?? undefined
+    if (input === undefined && output === undefined) return null
+    return { input, output }
+  }, [run.tokens])
   const sortedItems = useMemo(
     () => [...items].sort(compareLiveRunItems),
     [items]

--- a/packages/agents-server-ui/src/components/TokenUsage.module.css
+++ b/packages/agents-server-ui/src/components/TokenUsage.module.css
@@ -1,0 +1,8 @@
+/* Match the dimmed tone of the other meta-row siblings (done text,
+ * elapsed time, timestamp). `tabular-nums` keeps the digit column
+ * from jittering as the counts tick up on each step boundary. */
+.usage {
+  color: var(--ds-text-4);
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/agents-server-ui/src/components/TokenUsage.tsx
+++ b/packages/agents-server-ui/src/components/TokenUsage.tsx
@@ -1,0 +1,57 @@
+import { Text } from '../ui'
+import styles from './TokenUsage.module.css'
+
+/**
+ * Compact token-usage label, e.g. `1.2k ↑ 412 ↓`.
+ *
+ * Rendered next to the elapsed-time ticker in the agent response
+ * meta row, with `tabular-nums` to keep the digit column from
+ * jittering as numbers tick up (input grows when a tool result is
+ * fed back; output grows when the model streams a new step).
+ *
+ * Either side may be `undefined` (the provider didn't emit it, or
+ * the section is historical and was recorded before tokens were
+ * persisted) — we skip the missing half rather than print `0`.
+ */
+export function TokenUsage({
+  input,
+  output,
+}: {
+  input: number | undefined
+  output: number | undefined
+}): React.ReactElement | null {
+  if (input == null && output == null) return null
+  const parts: Array<string> = []
+  if (input != null) parts.push(`${formatTokenCount(input)} ↑`)
+  if (output != null) parts.push(`${formatTokenCount(output)} ↓`)
+  const text = parts.join(` `)
+  const ariaParts: Array<string> = []
+  if (input != null) ariaParts.push(`${input} input tokens`)
+  if (output != null) ariaParts.push(`${output} output tokens`)
+  return (
+    <Text
+      size={1}
+      tone="muted"
+      className={styles.usage}
+      aria-label={ariaParts.join(`, `)}
+    >
+      {text}
+    </Text>
+  )
+}
+
+/**
+ * `Intl.NumberFormat` with `notation: 'compact'` gives us "1.2K",
+ * "12K", "1.2M" etc., locale-aware and bounded in width — better
+ * than a hand-rolled rounder. We force lowercase `k`/`m` afterward
+ * so the suffix tone matches the muted meta row.
+ */
+const compactFormatter = new Intl.NumberFormat(undefined, {
+  notation: `compact`,
+  maximumFractionDigits: 1,
+})
+
+function formatTokenCount(n: number): string {
+  if (n < 1000) return String(n)
+  return compactFormatter.format(n).toLowerCase()
+}


### PR DESCRIPTION
## Summary

Adds a token-usage label to the agent response meta row, e.g.
`Thinking · 12s · 1.2k ↑ 412 ↓` while streaming and
`✓ done in 12s · 1.2k ↑ 412 ↓ · 14:18` once settled. Counter updates at
step boundaries — for a single-turn LLM call it lands once at done;
for tool-using runs it jumps as each step completes (the LLM SDK only
emits `usage` at end-of-step, so we can't tick smoothly between
streamed tokens — the elapsed-time ticker still ticks every second
alongside it).

## Plumbing

The runtime already had the token data — `pi-adapter.ts:358-359`
extracts `tokenInput`/`tokenOutput` from the provider's per-step
`usage` payload — but the bridge silently dropped them before
persistence. This PR closes that gap and surfaces them all the way to
the UI:

- `StepValue` gains optional `input_tokens` / `output_tokens` columns
  (Zod + TS). Strictly additive: events recorded before this change
  still validate (both fields optional), so no migration is needed.
- `outbound-bridge.ts:onStepEnd` now persists the values it was
  already receiving from `pi-adapter.ts`.
- `IncludesStep` / `EntityTimelineStepItem` surface the new fields,
  and the three `.select()` blocks that materialize step rows include
  them.
- The cached `agent_response` section grows a
  `tokens?: { input?, output? }` summed across the run's steps at
  section-build time, and the `fingerprintRun` cache key includes
  per-step token deltas so a late-arriving `onStepEnd` invalidates a
  stale cached section.
- New `<TokenUsage>` component in `agents-server-ui` with
  `tabular-nums` so digits don't jitter, locale-aware compact
  formatting via `Intl.NumberFormat`. Renders next to `<ElapsedTime>`
  in both the live and cached meta rows.

## Test plan

- [x] `pnpm typecheck` clean in `agents-runtime` + `agents-server-ui`
- [x] `pnpm test` in `agents-server-ui` (66 passed)
- [x] `pnpm test outbound-bridge use-chat entity-timeline` in
      `agents-runtime` (74 passed)
- [x] Full `agents-runtime` test suite: my branch matches the same
      pre-existing 401 failures observed on clean `main` (unrelated
      permission-system breakage in the test harness, not introduced
      by this PR)
- [x] Manual: launch a turn that uses tools and watch the counter
      jump at each step boundary
- [ ] Manual: pure-text turn — counter lands once at done

## Notes

- Historical responses recorded before this change have no token data
  persisted (older `steps` rows lack the columns). The `tokens` field
  is conditional on at least one step reporting a number, so those
  sections continue to render with no token row instead of "0 / 0".
- Display format `1.2k ↑ 412 ↓` chosen for compactness in the meta
  row. Open to changing to `1.2k in / 412 out` or similar if the
  arrow direction is unclear — input goes up to the model, output
  comes down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)