### PR TITLE
feat(sync-service): record per-transaction fragment wall-time

### DIFF
--- a/.changeset/txn-fragments-wall-time.md
+++ b/.changeset/txn-fragments-wall-time.md
@@ -1,0 +1,12 @@
+---
+"@core/sync-service": patch
+---
+
+Add a `pg_txn.fragments_wall_duration_µs` attribute to the
+`pg_txn.replication_client.transaction_received` span (set on the commit
+fragment). It records the wall-clock time a transaction's fragments spanned as
+received from Postgres (begin → commit). Because the replication stream is
+consumed on demand (e.g. paused while database connections are scaled down),
+this includes idle gaps between fragments and can be far larger than the
+per-fragment processing time — making it possible to spot transactions whose
+fragments straddle a shape consumer's suspend threshold.

--- a/.changeset/txn-fragments-wall-time.md
+++ b/.changeset/txn-fragments-wall-time.md
@@ -2,5 +2,5 @@
 "@core/sync-service": patch
 ---
 
-Add a `pg_txn.fragments_wall_duration_µs` span attribute that tracks the
-wall-clock time taken to process all fragments of a single transaction.
+Add a `total_processing_time` span attribute that tracks the wall-clock time
+taken to process all fragments of a single transaction.

--- a/.changeset/txn-fragments-wall-time.md
+++ b/.changeset/txn-fragments-wall-time.md
@@ -2,11 +2,5 @@
 "@core/sync-service": patch
 ---
 
-Add a `pg_txn.fragments_wall_duration_µs` attribute to the
-`pg_txn.replication_client.transaction_received` span (set on the commit
-fragment). It records the wall-clock time a transaction's fragments spanned as
-received from Postgres (begin → commit). Because the replication stream is
-consumed on demand (e.g. paused while database connections are scaled down),
-this includes idle gaps between fragments and can be far larger than the
-per-fragment processing time — making it possible to spot transactions whose
-fragments straddle a shape consumer's suspend threshold.
+Add a `pg_txn.fragments_wall_duration_µs` span attribute that tracks the
+wall-clock time taken to process all fragments of a single transaction.

--- a/integration-tests/tests/otel-export.lux
+++ b/integration-tests/tests/otel-export.lux
@@ -10,7 +10,7 @@
 
 [invoke setup_pg]
 
-[invoke setup_electric_with_env "ELECTRIC_OTLP_ENDPOINT=http://localhost:4318 ELECTRIC_SYSTEM_METRICS_POLL_INTERVAL=1s ELECTRIC_STACK_TELEMETRY_INIT_DELAY=1s ELECTRIC_OTEL_EXPORT_PERIOD=2s DO_NOT_START_CONN_MAN_PING=1 ELECTRIC_LOG_LEVEL=info OTEL_RESOURCE_ATTRIBUTES=custom.attr=electric.val"]
+[invoke setup_electric_with_env "ELECTRIC_OTLP_ENDPOINT=http://localhost:4318 ELECTRIC_SYSTEM_METRICS_POLL_INTERVAL=1s ELECTRIC_STACK_TELEMETRY_INIT_DELAY=1s ELECTRIC_OTEL_EXPORT_PERIOD=2s ELECTRIC_OTEL_SAMPLING_RATIO=1.0 DO_NOT_START_CONN_MAN_PING=1 ELECTRIC_LOG_LEVEL=info OTEL_RESOURCE_ATTRIBUTES=custom.attr=electric.val"]
 
 # Spawn a process containing off-heap binary references and ensure it's in the top 5 by memory footprint.
 [shell electric]
@@ -118,6 +118,11 @@
 
   # A direct subset snapshot query span is exported from the SnapshotQuery.execute_for_subset path.
   [invoke grep_otel_collector_output "Span shape_snapshot\.execute_for_shape .*shape\.query_reason=subset_query"]
+
+  # The transaction_received span carries the per-transaction wall-time attribute.
+  # This span is only exported because the env above forces full sampling
+  # (ELECTRIC_OTEL_SAMPLING_RATIO=1.0); it is sampled at 1% by default.
+  [invoke grep_otel_collector_output "Span pg_txn\.replication_client\.transaction_received .*total_processing_time=[0-9]+"]
 
 ###
 

--- a/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
@@ -227,7 +227,8 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
       txn_change_count: state.tx_change_count,
       received_at_mono: now_mono,
       initial_receive_lag: initial_lag,
-      fragments_wall_duration_us: fragments_wall_duration_us(state, now_mono)
+      fragments_wall_duration_us:
+        System.convert_time_unit(now_mono - state.tx_started_at_mono, :native, :microsecond)
     }
 
     returned_txn_fragment =
@@ -243,18 +244,6 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
          tx_started_at_mono: nil,
          txn_fragment: nil
      }}
-  end
-
-  # Wall-clock time spanned by the transaction's fragments as received from
-  # Postgres, i.e. from the begin message to this commit. Because Electric
-  # consumes the replication stream on demand (e.g. it can be paused while
-  # database connections are scaled down), this includes any idle gaps between
-  # fragments and so can be much larger than the time spent processing them.
-  # nil when the begin was not seen by this converter (e.g. after a reconnect).
-  defp fragments_wall_duration_us(%__MODULE__{tx_started_at_mono: nil}, _now_mono), do: nil
-
-  defp fragments_wall_duration_us(%__MODULE__{tx_started_at_mono: started_mono}, now_mono) do
-    System.convert_time_unit(now_mono - started_mono, :native, :microsecond)
   end
 
   defguard in_transaction?(converter) when not is_nil(converter.txn_fragment)

--- a/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
@@ -225,7 +225,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
       commit_timestamp: msg.commit_timestamp,
       transaction_size: state.tx_size,
       txn_change_count: state.tx_change_count,
-      received_at_mono: now_mono,
+      received_at: now_mono,
       initial_receive_lag: initial_lag,
       fragments_wall_duration_us:
         System.convert_time_unit(now_mono - state.tx_started_at, :native, :microsecond)

--- a/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
@@ -218,14 +218,13 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
   end
 
   def convert(%LR.Commit{} = msg, %__MODULE__{txn_fragment: fragment} = state) do
-    now_mono = System.monotonic_time()
     initial_lag = Commit.calculate_initial_receive_lag(msg.commit_timestamp, DateTime.utc_now())
 
     commit = %Commit{
       commit_timestamp: msg.commit_timestamp,
       transaction_size: state.tx_size,
       txn_change_count: state.tx_change_count,
-      received_at: now_mono,
+      received_at: System.monotonic_time(),
       initial_receive_lag: initial_lag,
       tx_started_at: state.tx_started_at
     }

--- a/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
@@ -32,6 +32,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
             tx_op_index: nil,
             tx_change_count: 0,
             tx_size: 0,
+            tx_started_at_mono: nil,
             max_tx_size: nil,
             max_batch_size: nil,
             txn_fragment: nil
@@ -41,6 +42,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
           tx_op_index: non_neg_integer() | nil,
           tx_change_count: non_neg_integer(),
           tx_size: non_neg_integer(),
+          tx_started_at_mono: integer() | nil,
           max_tx_size: non_neg_integer() | nil,
           max_batch_size: non_neg_integer(),
           txn_fragment: TransactionFragment.t() | nil
@@ -79,6 +81,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
        | tx_op_index: 0,
          tx_size: 0,
          tx_change_count: 0,
+         tx_started_at_mono: System.monotonic_time(),
          txn_fragment: %TransactionFragment{
            xid: msg.xid,
            lsn: msg.final_lsn,
@@ -223,7 +226,8 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
       transaction_size: state.tx_size,
       txn_change_count: state.tx_change_count,
       received_at_mono: now_mono,
-      initial_receive_lag: initial_lag
+      initial_receive_lag: initial_lag,
+      fragments_wall_duration_us: fragments_wall_duration_us(state, now_mono)
     }
 
     returned_txn_fragment =
@@ -236,8 +240,21 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
        | tx_op_index: nil,
          tx_size: 0,
          tx_change_count: 0,
+         tx_started_at_mono: nil,
          txn_fragment: nil
      }}
+  end
+
+  # Wall-clock time spanned by the transaction's fragments as received from
+  # Postgres, i.e. from the begin message to this commit. Because Electric
+  # consumes the replication stream on demand (e.g. it can be paused while
+  # database connections are scaled down), this includes any idle gaps between
+  # fragments and so can be much larger than the time spent processing them.
+  # nil when the begin was not seen by this converter (e.g. after a reconnect).
+  defp fragments_wall_duration_us(%__MODULE__{tx_started_at_mono: nil}, _now_mono), do: nil
+
+  defp fragments_wall_duration_us(%__MODULE__{tx_started_at_mono: started_mono}, now_mono) do
+    System.convert_time_unit(now_mono - started_mono, :native, :microsecond)
   end
 
   defguard in_transaction?(converter) when not is_nil(converter.txn_fragment)

--- a/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
@@ -32,7 +32,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
             tx_op_index: nil,
             tx_change_count: 0,
             tx_size: 0,
-            tx_started_at_mono: nil,
+            tx_started_at: nil,
             max_tx_size: nil,
             max_batch_size: nil,
             txn_fragment: nil
@@ -42,7 +42,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
           tx_op_index: non_neg_integer() | nil,
           tx_change_count: non_neg_integer(),
           tx_size: non_neg_integer(),
-          tx_started_at_mono: integer() | nil,
+          tx_started_at: integer() | nil,
           max_tx_size: non_neg_integer() | nil,
           max_batch_size: non_neg_integer(),
           txn_fragment: TransactionFragment.t() | nil
@@ -81,7 +81,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
        | tx_op_index: 0,
          tx_size: 0,
          tx_change_count: 0,
-         tx_started_at_mono: System.monotonic_time(),
+         tx_started_at: System.monotonic_time(),
          txn_fragment: %TransactionFragment{
            xid: msg.xid,
            lsn: msg.final_lsn,
@@ -228,7 +228,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
       received_at_mono: now_mono,
       initial_receive_lag: initial_lag,
       fragments_wall_duration_us:
-        System.convert_time_unit(now_mono - state.tx_started_at_mono, :native, :microsecond)
+        System.convert_time_unit(now_mono - state.tx_started_at, :native, :microsecond)
     }
 
     returned_txn_fragment =
@@ -241,7 +241,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
        | tx_op_index: nil,
          tx_size: 0,
          tx_change_count: 0,
-         tx_started_at_mono: nil,
+         tx_started_at: nil,
          txn_fragment: nil
      }}
   end

--- a/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/message_converter.ex
@@ -227,8 +227,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverter do
       txn_change_count: state.tx_change_count,
       received_at: now_mono,
       initial_receive_lag: initial_lag,
-      fragments_wall_duration_us:
-        System.convert_time_unit(now_mono - state.tx_started_at, :native, :microsecond)
+      tx_started_at: state.tx_started_at
     }
 
     returned_txn_fragment =

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -39,14 +39,14 @@ defmodule Electric.Replication.Changes do
             commit_timestamp: DateTime.t() | nil,
             transaction_size: non_neg_integer(),
             txn_change_count: non_neg_integer(),
-            received_at_mono: integer() | nil,
+            received_at: integer() | nil,
             initial_receive_lag: non_neg_integer() | nil,
             fragments_wall_duration_us: non_neg_integer() | nil
           }
 
     defstruct [
       :commit_timestamp,
-      :received_at_mono,
+      :received_at,
       :initial_receive_lag,
       :fragments_wall_duration_us,
       transaction_size: 0,
@@ -87,7 +87,7 @@ defmodule Electric.Replication.Changes do
     def calculate_final_receive_lag(%__MODULE__{} = commit, current_mono) do
       elapsed_in_electric =
         System.convert_time_unit(
-          current_mono - commit.received_at_mono,
+          current_mono - commit.received_at,
           :native,
           :millisecond
         )

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -84,10 +84,10 @@ defmodule Electric.Replication.Changes do
     end-to-end lag from Postgres commit to acknowledgement.
     """
     @spec calculate_final_receive_lag(t(), integer()) :: non_neg_integer()
-    def calculate_final_receive_lag(%__MODULE__{} = commit, current_mono) do
+    def calculate_final_receive_lag(%__MODULE__{} = commit, timestamp) do
       elapsed_in_electric =
         System.convert_time_unit(
-          current_mono - commit.received_at,
+          timestamp - commit.received_at,
           :native,
           :millisecond
         )

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -41,14 +41,14 @@ defmodule Electric.Replication.Changes do
             txn_change_count: non_neg_integer(),
             received_at: integer() | nil,
             initial_receive_lag: non_neg_integer() | nil,
-            fragments_wall_duration_us: non_neg_integer() | nil
+            tx_started_at: integer() | nil
           }
 
     defstruct [
       :commit_timestamp,
       :received_at,
       :initial_receive_lag,
-      :fragments_wall_duration_us,
+      :tx_started_at,
       transaction_size: 0,
       txn_change_count: 0
     ]

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -40,13 +40,15 @@ defmodule Electric.Replication.Changes do
             transaction_size: non_neg_integer(),
             txn_change_count: non_neg_integer(),
             received_at_mono: integer() | nil,
-            initial_receive_lag: non_neg_integer() | nil
+            initial_receive_lag: non_neg_integer() | nil,
+            fragments_wall_duration_us: non_neg_integer() | nil
           }
 
     defstruct [
       :commit_timestamp,
       :received_at_mono,
       :initial_receive_lag,
+      :fragments_wall_duration_us,
       transaction_size: 0,
       txn_change_count: 0
     ]

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -460,7 +460,7 @@ defmodule Electric.Replication.ShapeLogCollector do
         num_relations: MapSet.size(txn_fragment.affected_relations),
         xid: txn_fragment.xid,
         complete_transaction?: TransactionFragment.complete_transaction?(txn_fragment)
-      ],
+      ] ++ fragments_wall_duration_attrs(txn_fragment),
       state.stack_id,
       fn ->
         OpenTelemetry.start_interval(:"shape_log_collector.logging.duration_µs")
@@ -488,6 +488,21 @@ defmodule Electric.Replication.ShapeLogCollector do
       end
     )
   end
+
+  # On the commit fragment, surface the wall-clock time the whole transaction's
+  # fragments spanned as received from Postgres (begin -> commit). Because the
+  # replication stream is consumed on demand, this can be far larger than the
+  # per-fragment processing time and is the signal for transactions whose
+  # fragments straddle a consumer's suspend threshold.
+  defp fragments_wall_duration_attrs(%TransactionFragment{commit: commit})
+       when not is_nil(commit) do
+    case commit.fragments_wall_duration_us do
+      nil -> []
+      us -> ["pg_txn.fragments_wall_duration_µs": us]
+    end
+  end
+
+  defp fragments_wall_duration_attrs(_txn_fragment), do: []
 
   # If we've already processed a txn_fragment, then drop it without processing
   defp handle_txn_fragment(%{last_processed_offset: last_processed_offset} = state, txn_fragment)

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -460,7 +460,7 @@ defmodule Electric.Replication.ShapeLogCollector do
         num_relations: MapSet.size(txn_fragment.affected_relations),
         xid: txn_fragment.xid,
         complete_transaction?: TransactionFragment.complete_transaction?(txn_fragment)
-      ] ++ fragments_wall_duration_attrs(txn_fragment),
+      ],
       state.stack_id,
       fn ->
         OpenTelemetry.start_interval(:"shape_log_collector.logging.duration_µs")
@@ -484,21 +484,24 @@ defmodule Electric.Replication.ShapeLogCollector do
           total_attribute: :"shape_log_collector.transaction.total_duration_µs"
         )
 
+        put_wall_clock_duration_if_commit(txn_fragment)
+
         result
       end
     )
   end
 
-  # On the commit fragment, surface the wall-clock time the transaction's
-  # fragments spanned as received from Postgres (begin -> commit). Because the
-  # replication stream is consumed on demand, this can far exceed the
-  # per-fragment processing time.
-  defp fragments_wall_duration_attrs(%TransactionFragment{
-         commit: %{fragments_wall_duration_us: us}
-       }),
-       do: ["pg_txn.fragments_wall_duration_µs": us]
+  defp put_wall_clock_duration_if_commit(%TransactionFragment{
+         commit: %{tx_started_at: tx_started_at}
+       })
+       when is_integer(tx_started_at) do
+    OpenTelemetry.add_span_attributes(
+      total_processing_time:
+        System.convert_time_unit(System.monotonic_time() - tx_started_at, :native, :millisecond)
+    )
+  end
 
-  defp fragments_wall_duration_attrs(_txn_fragment), do: []
+  defp put_wall_clock_duration_if_commit(_txn_fragment), do: :ok
 
   # If we've already processed a txn_fragment, then drop it without processing
   defp handle_txn_fragment(%{last_processed_offset: last_processed_offset} = state, txn_fragment)

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -489,18 +489,14 @@ defmodule Electric.Replication.ShapeLogCollector do
     )
   end
 
-  # On the commit fragment, surface the wall-clock time the whole transaction's
+  # On the commit fragment, surface the wall-clock time the transaction's
   # fragments spanned as received from Postgres (begin -> commit). Because the
-  # replication stream is consumed on demand, this can be far larger than the
-  # per-fragment processing time and is the signal for transactions whose
-  # fragments straddle a consumer's suspend threshold.
-  defp fragments_wall_duration_attrs(%TransactionFragment{commit: commit})
-       when not is_nil(commit) do
-    case commit.fragments_wall_duration_us do
-      nil -> []
-      us -> ["pg_txn.fragments_wall_duration_µs": us]
-    end
-  end
+  # replication stream is consumed on demand, this can far exceed the
+  # per-fragment processing time.
+  defp fragments_wall_duration_attrs(%TransactionFragment{
+         commit: %{fragments_wall_duration_us: us}
+       }),
+       do: ["pg_txn.fragments_wall_duration_µs": us]
 
   defp fragments_wall_duration_attrs(_txn_fragment), do: []
 

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -492,9 +492,8 @@ defmodule Electric.Replication.ShapeLogCollector do
   end
 
   defp put_wall_clock_duration_if_commit(%TransactionFragment{
-         commit: %{tx_started_at: tx_started_at}
-       })
-       when is_integer(tx_started_at) do
+         commit: %Changes.Commit{tx_started_at: tx_started_at}
+       }) do
     OpenTelemetry.add_span_attributes(
       total_processing_time:
         System.convert_time_unit(System.monotonic_time() - tx_started_at, :native, :millisecond)

--- a/packages/sync-service/test/electric/postgres/replication_client/message_converter_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client/message_converter_test.exs
@@ -123,6 +123,36 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverterTest do
       assert MapSet.equal?(affected, MapSet.new([{"public", "users"}]))
     end
 
+    test "records the wall-clock duration spanned by a transaction's fragments on commit",
+         %{converter: converter} do
+      {:buffering, converter} =
+        MessageConverter.convert(
+          %LR.Begin{final_lsn: @test_lsn, commit_timestamp: DateTime.utc_now(), xid: 456},
+          converter
+        )
+
+      {:buffering, converter} =
+        MessageConverter.convert(
+          %LR.Insert{relation_id: 1, tuple_data: ["123"], bytes: 3},
+          converter
+        )
+
+      assert {:ok,
+              %TransactionFragment{
+                commit: %Commit{fragments_wall_duration_us: duration}
+              }, _converter} =
+               MessageConverter.convert(
+                 %LR.Commit{
+                   lsn: @test_lsn,
+                   end_lsn: @test_end_lsn,
+                   commit_timestamp: ~U[2024-01-01 00:00:00Z]
+                 },
+                 converter
+               )
+
+      assert is_integer(duration) and duration >= 0
+    end
+
     test "returns TransactionFragment with UpdatedRecord for update", %{converter: converter} do
       {:buffering, converter} =
         MessageConverter.convert(

--- a/packages/sync-service/test/electric/postgres/replication_client/message_converter_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client/message_converter_test.exs
@@ -123,8 +123,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverterTest do
       assert MapSet.equal?(affected, MapSet.new([{"public", "users"}]))
     end
 
-    test "records the wall-clock duration spanned by a transaction's fragments on commit",
-         %{converter: converter} do
+    test "records the transaction's begin timestamp on the commit", %{converter: converter} do
       {:buffering, converter} =
         MessageConverter.convert(
           %LR.Begin{final_lsn: @test_lsn, commit_timestamp: DateTime.utc_now(), xid: 456},
@@ -139,7 +138,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverterTest do
 
       assert {:ok,
               %TransactionFragment{
-                commit: %Commit{fragments_wall_duration_us: duration}
+                commit: %Commit{tx_started_at: tx_started_at}
               }, _converter} =
                MessageConverter.convert(
                  %LR.Commit{
@@ -150,7 +149,7 @@ defmodule Electric.Postgres.ReplicationClient.MessageConverterTest do
                  converter
                )
 
-      assert is_integer(duration) and duration >= 0
+      assert is_integer(tx_started_at)
     end
 
     test "returns TransactionFragment with UpdatedRecord for update", %{converter: converter} do

--- a/packages/sync-service/test/electric/replication/changes_test.exs
+++ b/packages/sync-service/test/electric/replication/changes_test.exs
@@ -38,18 +38,18 @@ defmodule Electric.Replication.ChangesTest do
 
   describe "Commit.calculate_final_receive_lag/2" do
     test "returns initial lag plus elapsed time in Electric" do
-      received_at_mono = System.monotonic_time()
+      received_at = System.monotonic_time()
       initial_lag = 100
       elapsed_ms = 50
 
       commit = %Commit{
         commit_timestamp: ~U[2024-01-01 12:00:00.000Z],
-        received_at_mono: received_at_mono,
+        received_at: received_at,
         initial_receive_lag: initial_lag
       }
 
       current_mono =
-        received_at_mono + System.convert_time_unit(elapsed_ms, :millisecond, :native)
+        received_at + System.convert_time_unit(elapsed_ms, :millisecond, :native)
 
       lag = Commit.calculate_final_receive_lag(commit, current_mono)
 
@@ -62,7 +62,7 @@ defmodule Electric.Replication.ChangesTest do
 
       commit = %Commit{
         commit_timestamp: ~U[2024-01-01 12:00:00.000Z],
-        received_at_mono: mono_time,
+        received_at: mono_time,
         initial_receive_lag: initial_lag
       }
 
@@ -76,7 +76,7 @@ defmodule Electric.Replication.ChangesTest do
 
       commit = %Commit{
         commit_timestamp: ~U[2024-01-01 12:00:00.000Z],
-        received_at_mono: mono_time,
+        received_at: mono_time,
         initial_receive_lag: 0
       }
 

--- a/packages/sync-service/test/electric/replication/changes_test.exs
+++ b/packages/sync-service/test/electric/replication/changes_test.exs
@@ -48,10 +48,10 @@ defmodule Electric.Replication.ChangesTest do
         initial_receive_lag: initial_lag
       }
 
-      current_mono =
+      timestamp =
         received_at + System.convert_time_unit(elapsed_ms, :millisecond, :native)
 
-      lag = Commit.calculate_final_receive_lag(commit, current_mono)
+      lag = Commit.calculate_final_receive_lag(commit, timestamp)
 
       assert lag == initial_lag + elapsed_ms
     end

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -209,6 +209,84 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       xids = Support.TransactionConsumer.assert_consume([{1, consumer}], [txn])
       assert xids == [xmin]
     end
+
+    @tag restore_shapes: [{@shape_handle, @shape}, {@shape_handle <> "-2", @shape}],
+         inspector: @inspector
+    test "sets total_processing_time on the span exactly once for a multi-shape transaction",
+         ctx do
+      test_pid = self()
+
+      Repatch.patch(
+        Electric.Telemetry.OpenTelemetry,
+        :add_span_attributes,
+        [mode: :shared],
+        fn attrs ->
+          if Keyword.keyword?(attrs) and Keyword.has_key?(attrs, :total_processing_time) do
+            send(
+              test_pid,
+              {:total_processing_time, Keyword.fetch!(attrs, :total_processing_time)}
+            )
+          end
+
+          true
+        end
+      )
+
+      lsn = Lsn.from_string("0/10")
+
+      consumer1 =
+        start_link_supervised!(
+          {Support.TransactionConsumer,
+           id: 1,
+           stack_id: ctx.stack_id,
+           parent: test_pid,
+           shape: @shape,
+           shape_handle: @shape_handle,
+           action: :restore},
+          id: {:consumer, 1}
+        )
+
+      consumer2 =
+        start_link_supervised!(
+          {Support.TransactionConsumer,
+           id: 2,
+           stack_id: ctx.stack_id,
+           parent: test_pid,
+           shape: @shape,
+           shape_handle: @shape_handle <> "-2",
+           action: :restore},
+          id: {:consumer, 2}
+        )
+
+      :ok =
+        Electric.Shapes.ConsumerRegistry.register_consumer(consumer1, @shape_handle, ctx.stack_id)
+
+      :ok =
+        Electric.Shapes.ConsumerRegistry.register_consumer(
+          consumer2,
+          @shape_handle <> "-2",
+          ctx.stack_id
+        )
+
+      txn =
+        transaction(100, lsn, [
+          %Changes.NewRecord{
+            relation: {"public", "test_table"},
+            record: %{"id" => "2", "name" => "foo"},
+            log_offset: LogOffset.new(lsn, 0)
+          }
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
+
+      # The single incoming fragment is resliced to both shapes by the EventRouter...
+      Support.TransactionConsumer.assert_consume([{1, consumer1}, {2, consumer2}], [txn])
+
+      # ...but the wall-clock attribute is set once, on the original incoming commit fragment.
+      assert_receive {:total_processing_time, value}
+      assert is_integer(value) and value >= 0
+      refute_receive {:total_processing_time, _}
+    end
   end
 
   describe "lazy consumer initialization" do

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -484,7 +484,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         lsn: lsn,
         last_log_offset: LogOffset.new(lsn, 2),
         has_begin?: false,
-        commit: %Commit{},
+        commit: %Commit{tx_started_at: System.monotonic_time()},
         changes: [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
@@ -537,7 +537,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         lsn: lsn,
         last_log_offset: LogOffset.new(lsn, 2),
         has_begin?: true,
-        commit: %Commit{},
+        commit: %Commit{tx_started_at: System.monotonic_time()},
         changes: [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
@@ -1314,7 +1314,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         lsn: lsn,
         last_log_offset: LogOffset.new(lsn, 5),
         has_begin?: false,
-        commit: %Changes.Commit{},
+        commit: %Changes.Commit{tx_started_at: System.monotonic_time()},
         changes: [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
@@ -1357,7 +1357,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       lsn: lsn,
       last_log_offset: last_log_offset,
       has_begin?: true,
-      commit: %Commit{},
+      commit: %Commit{tx_started_at: System.monotonic_time()},
       changes: changes,
       affected_relations: MapSet.new(changes, & &1.relation)
     }

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -17,7 +17,12 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   alias Support.RepatchExt
 
   import Support.TestUtils,
-    only: [patch_calls: 3, expect_calls: 2, register_as_replication_client: 1]
+    only: [
+      patch_calls: 3,
+      expect_calls: 2,
+      register_as_replication_client: 1,
+      complete_txn_fragment: 3
+    ]
 
   import Support.ComponentSetup
 
@@ -141,7 +146,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         Electric.Shapes.ConsumerRegistry.register_consumer(consumer, @shape_handle, ctx.stack_id)
 
       txn =
-        transaction(xmin, lsn, [
+        complete_txn_fragment(xmin, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -196,7 +201,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       # Any root-table change should route to the shape via fallback,
       # even if the record wouldn't match the subquery membership.
       txn =
-        transaction(xmin, lsn, [
+        complete_txn_fragment(xmin, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "999"},
@@ -269,7 +274,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         )
 
       txn =
-        transaction(100, lsn, [
+        complete_txn_fragment(100, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -335,7 +340,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       last_log_offset = LogOffset.new(lsn, 0)
 
       txn =
-        transaction(xmin, lsn, [
+        complete_txn_fragment(xmin, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -357,7 +362,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       ShapeLogCollector.monitor(ctx.stack_id)
 
       txn =
-        transaction(xmin, lsn, [
+        complete_txn_fragment(xmin, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -442,7 +447,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       next_log_offset = LogOffset.new(next_lsn, 0)
 
       txn =
-        transaction(xmin, lsn, [
+        complete_txn_fragment(xmin, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -458,7 +463,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       assert xids == [xmin]
 
       txn2 =
-        transaction(xid, next_lsn, [
+        complete_txn_fragment(xid, next_lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "bar"},
@@ -490,7 +495,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         prev_log_offset = LogOffset.new(prev_lsn, 0)
 
         txn =
-          transaction(xid, lsn, [
+          complete_txn_fragment(xid, lsn, [
             %Changes.NewRecord{
               relation: {"public", "test_table"},
               record: %{"id" => "2", "name" => "foo"},
@@ -507,7 +512,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
         )
 
         txn2 =
-          transaction(xid, lsn, [
+          complete_txn_fragment(xid, lsn, [
             %Changes.NewRecord{
               relation: {"public", "test_table"},
               record: %{"id" => "2", "name" => "foo"},
@@ -516,7 +521,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
           ])
 
         txn3 =
-          transaction(prev_xid, prev_lsn, [
+          complete_txn_fragment(prev_xid, prev_lsn, [
             %Changes.NewRecord{
               relation: {"public", "test_table"},
               record: %{"id" => "2", "name" => "foo"},
@@ -658,7 +663,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       log_offset = LogOffset.new(lsn, 0)
 
       txn =
-        transaction(1, lsn, [
+        complete_txn_fragment(1, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => nil, "name" => "foo"},
@@ -676,14 +681,14 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
       register_as_replication_client(ctx.stack_id)
 
-      irrelevant_txn = transaction(99, prev_lsn, [])
+      irrelevant_txn = complete_txn_fragment(99, prev_lsn, [])
 
       assert :ok = ShapeLogCollector.handle_event(irrelevant_txn, ctx.stack_id)
       expected_lsn = Lsn.to_integer(prev_lsn)
       assert_receive {:flush_boundary_updated, ^expected_lsn}, 50
 
       txn =
-        transaction(100, lsn, [
+        complete_txn_fragment(100, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -725,7 +730,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       log_offset = LogOffset.new(lsn, 0)
 
       txn =
-        transaction(100, lsn, [
+        complete_txn_fragment(100, lsn, [
           %Changes.NewRecord{
             relation: {"public", "irrelevant_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -747,7 +752,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       log_offset = LogOffset.new(lsn, 0)
 
       txn =
-        transaction(100, lsn, [
+        complete_txn_fragment(100, lsn, [
           %Changes.NewRecord{
             relation: {"public", "irrelevant_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -766,7 +771,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       log_offset = LogOffset.new(lsn, 0)
 
       txn =
-        transaction(100, lsn, [
+        complete_txn_fragment(100, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2"},
@@ -795,7 +800,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       log_offset = LogOffset.new(lsn, 0)
 
       txn =
-        transaction(100, lsn, [
+        complete_txn_fragment(100, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -902,7 +907,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     test "rejects new transactions", ctx do
       lsn = Lsn.from_string("0/10")
 
-      txn = transaction(100, lsn, [])
+      txn = complete_txn_fragment(100, lsn, [])
 
       assert {:error, :not_ready} = ShapeLogCollector.handle_event(txn, ctx.stack_id)
     end
@@ -930,7 +935,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     )
 
     txn =
-      transaction(xmin, lsn, [
+      complete_txn_fragment(xmin, lsn, [
         %Changes.NewRecord{
           relation: {"public", "test_table"},
           record: %{"id" => "1"},
@@ -996,7 +1001,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     ShapeLogCollector.mark_as_ready(ctx.stack_id)
 
     txn_to_drop =
-      transaction(100, start_lsn, [
+      complete_txn_fragment(100, start_lsn, [
         %Changes.NewRecord{
           relation: {"public", "test_table"},
           record: %{"id" => "1"},
@@ -1018,7 +1023,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
 
     # should accept a transaction with a higher LSN and update it
     txn_to_process =
-      transaction(101, next_lsn, [
+      complete_txn_fragment(101, next_lsn, [
         %Changes.NewRecord{
           relation: {"public", "test_table"},
           record: %{"id" => "3"},
@@ -1137,7 +1142,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       )
 
       txn =
-        transaction(100, Lsn.from_string("0/10"), [
+        complete_txn_fragment(100, Lsn.from_string("0/10"), [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "11"},
@@ -1154,7 +1159,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
     test "should not crash if the materializer is not there, instead skipping the depenencies",
          ctx do
       txn =
-        transaction(100, Lsn.from_string("0/10"), [
+        complete_txn_fragment(100, Lsn.from_string("0/10"), [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "11"},
@@ -1222,7 +1227,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       log_offset = LogOffset.new(lsn, 0)
 
       txn =
-        transaction(100, lsn, [
+        complete_txn_fragment(100, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{"id" => "2", "name" => "foo"},
@@ -1318,7 +1323,7 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       log_offset = LogOffset.new(lsn, 0)
 
       txn =
-        transaction(100, lsn, [
+        complete_txn_fragment(100, lsn, [
           %Changes.NewRecord{
             relation: {"public", "test_table"},
             record: %{
@@ -1421,24 +1426,6 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       expected_lsn = Lsn.to_integer(lsn)
       assert_receive {:flush_boundary_updated, ^expected_lsn}
     end
-  end
-
-  defp transaction(xid, lsn, changes) do
-    last_log_offset =
-      case Enum.reverse(changes) do
-        [%{log_offset: offset} | _] -> offset
-        [] -> LogOffset.new(lsn, 0)
-      end
-
-    %TransactionFragment{
-      xid: xid,
-      lsn: lsn,
-      last_log_offset: last_log_offset,
-      has_begin?: true,
-      commit: %Commit{tx_started_at: System.monotonic_time()},
-      changes: changes,
-      affected_relations: MapSet.new(changes, & &1.relation)
-    }
   end
 
   defp kill_consumer(pid, reason) do

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1530,7 +1530,7 @@ defmodule Electric.ShapeCacheTest do
       lsn: lsn,
       last_log_offset: last_log_offset,
       has_begin?: true,
-      commit: %Changes.Commit{},
+      commit: %Changes.Commit{tx_started_at: System.monotonic_time()},
       changes: changes,
       affected_relations: MapSet.new(changes, & &1.relation)
     }

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -4,7 +4,6 @@ defmodule Electric.ShapeCacheTest do
 
   alias Electric.Replication.Changes
   alias Electric.Replication.LogOffset
-  alias Electric.Replication.Changes.TransactionFragment
   alias Electric.Replication.ShapeLogCollector
   alias Electric.ShapeCache
   alias Electric.ShapeCache.{Storage, ShapeStatus}
@@ -22,7 +21,8 @@ defmodule Electric.ShapeCacheTest do
       activate_mocks_for_descendant_procs: 1,
       assert_shape_cleanup: 1,
       patch_shape_status: 1,
-      patch_shape_cache: 1
+      patch_shape_cache: 1,
+      complete_txn_fragment: 3
     ]
 
   @stub_inspector Support.StubInspector.new(
@@ -1274,7 +1274,7 @@ defmodule Electric.ShapeCacheTest do
       ref = Shapes.Consumer.register_for_changes(ctx.stack_id, shape_handle)
 
       ShapeLogCollector.handle_event(
-        transaction(@xid, @lsn, [@change]),
+        complete_txn_fragment(@xid, @lsn, [@change]),
         ctx.stack_id
       )
 
@@ -1520,19 +1520,5 @@ defmodule Electric.ShapeCacheTest do
       assert_receive {:snapshot, ^handle, _snapshotter_pid}
       handle
     end)
-  end
-
-  defp transaction(xid, lsn, changes) do
-    [%{log_offset: last_log_offset} | _] = Enum.reverse(changes)
-
-    %TransactionFragment{
-      xid: xid,
-      lsn: lsn,
-      last_log_offset: last_log_offset,
-      has_begin?: true,
-      commit: %Changes.Commit{tx_started_at: System.monotonic_time()},
-      changes: changes,
-      affected_relations: MapSet.new(changes, & &1.relation)
-    }
   end
 end

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -44,7 +44,10 @@ defmodule Support.TestUtils do
       lsn: lsn,
       last_log_offset: last_log_offset,
       has_begin?: Keyword.get(opts, :has_begin?, false),
-      commit: if(Keyword.get(opts, :has_commit?, false), do: %Changes.Commit{}),
+      commit:
+        if(Keyword.get(opts, :has_commit?, false),
+          do: %Changes.Commit{tx_started_at: System.monotonic_time()}
+        ),
       changes: changes,
       change_count: length(changes),
       affected_relations: MapSet.new(changes, & &1.relation)

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -31,12 +31,16 @@ defmodule Support.TestUtils do
   Build a transaction fragment that may or may not have begin and commit parts.
   """
   def txn_fragment(xid, lsn, changes, opts) do
-    [%{log_offset: last_log_offset} | _] = Enum.reverse(changes)
-
     lsn =
       case lsn do
         %Electric.Postgres.Lsn{} -> lsn
         num when is_integer(num) -> Electric.Postgres.Lsn.from_integer(num)
+      end
+
+    last_log_offset =
+      case Enum.reverse(changes) do
+        [%{log_offset: offset} | _] -> offset
+        [] -> LogOffset.new(lsn, 0)
       end
 
     %TransactionFragment{


### PR DESCRIPTION
## Summary

Adds a `total_processing_time` attribute to the `pg_txn.replication_client.transaction_received` span, set on the commit fragment. It records the **wall-clock time taken to process all fragments of a single transaction** — from when the begin was received to when the commit fragment finishes processing.

Today our spans only measure per-fragment *processing* time (~ms). They can't tell us how long a transaction's fragments are smeared across in wall-clock terms — which is the quantity that determines whether a shape consumer can idle past its suspend threshold mid-transaction (see #4501 / #4503).

Unlike `receive_lag` — which is anchored on the Postgres commit timestamp and measures end-to-end delivery lag, from when Postgres committed the transaction to when Electric finished processing it — `total_processing_time` is anchored entirely within Electric: it spans receipt of the begin fragment to completion of the commit fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
