### PR TITLE
fix(agents): align permission test fixtures with runtime changes

### DIFF
--- a/packages/agents-runtime/test/runtime-dsl.ts
+++ b/packages/agents-runtime/test/runtime-dsl.ts
@@ -42,6 +42,8 @@ type TestBackendModule = {
 const agentServerModulePath = `../../agents-server/src/server`
 const agentServerTestBackendModulePath = `../../agents-server/test/test-backend`
 const TEST_PRINCIPAL_KEY = `system:runtime-dsl-test`
+const TEST_PRINCIPAL_URL = `/principal/${encodeURIComponent(TEST_PRINCIPAL_KEY)}`
+const TEST_INSPECTOR_PRINCIPAL_KEY = `system:dev-local`
 
 async function loadElectricAgentsServer(): Promise<ElectricAgentsServerConstructor> {
   const module = (await import(agentServerModulePath)) as {
@@ -628,7 +630,7 @@ export function runtimeTest(): RuntimeTestBuilder {
     url.searchParams.set(`live`, `false`)
 
     const res = await fetch(url, {
-      headers: { 'electric-principal': TEST_PRINCIPAL_KEY },
+      headers: { 'electric-principal': TEST_INSPECTOR_PRINCIPAL_KEY },
     })
     if (res.status === 204 || res.status === 404) return []
     if (!res.ok) {
@@ -876,7 +878,17 @@ export function runtimeTest(): RuntimeTestBuilder {
 
   const builder: RuntimeTestBuilder = {
     define(name: string, definition: EntityDefinition) {
-      registry.define(name, definition as unknown as EntityDefinition)
+      registry.define(name, {
+        ...definition,
+        permissionGrants: [
+          ...(definition.permissionGrants ?? []),
+          {
+            subject_kind: `principal`,
+            subject_value: TEST_PRINCIPAL_URL,
+            permission: `spawn`,
+          },
+        ],
+      } as unknown as EntityDefinition)
       return builder
     },
 

--- a/packages/agents-server/test/dispatch-policy-routing.test.ts
+++ b/packages/agents-server/test/dispatch-policy-routing.test.ts
@@ -65,6 +65,8 @@ function buildContext(overrides: Partial<TenantContext> = {}): TenantContext {
           updated_at: new Date(0).toISOString(),
         })),
         getEntity: vi.fn(async () => null),
+        hasEntityPermission: vi.fn(async () => true),
+        hasEntityTypePermission: vi.fn(async () => true),
         updateEntityDispatchPolicy: vi.fn(async (_url, policy) =>
           entity(policy)
         ),

--- a/packages/agents-server/test/electric-agents-manager-write-validation.test.ts
+++ b/packages/agents-server/test/electric-agents-manager-write-validation.test.ts
@@ -53,6 +53,7 @@ function createAttachmentManager({
         }),
         getEntityType: vi.fn(),
         replaceEntityManifestSource: vi.fn(),
+        replaceSharedStateLink: vi.fn(),
         close: vi.fn(),
       } as any,
       streamClient: {
@@ -265,6 +266,7 @@ function createManifestManager(calls: Array<string>) {
       }),
       getEntityType: vi.fn(),
       replaceEntityManifestSource: vi.fn(),
+      replaceSharedStateLink: vi.fn(),
       close: vi.fn(),
     } as any,
     streamClient: {

--- a/packages/agents-server/test/electric-agents-status.test.ts
+++ b/packages/agents-server/test/electric-agents-status.test.ts
@@ -414,6 +414,7 @@ describe(`ElectricAgentsManager.forkSubtree`, () => {
       }),
       deleteEntity: vi.fn(),
       replaceEntityManifestSource: vi.fn(),
+      replaceSharedStateLink: vi.fn(),
     }
 
     const streamClient = {
@@ -597,6 +598,7 @@ describe(`ElectricAgentsManager.forkSubtree`, () => {
         }),
         deleteEntity: vi.fn(),
         replaceEntityManifestSource: vi.fn(),
+        replaceSharedStateLink: vi.fn(),
       } as any,
       streamClient: streamClient as any,
       validator: {} as any,
@@ -655,6 +657,7 @@ describe(`ElectricAgentsManager.forkSubtree`, () => {
         createEntity: vi.fn(),
         deleteEntity: vi.fn(),
         replaceEntityManifestSource: vi.fn(),
+        replaceSharedStateLink: vi.fn(),
       } as any,
       streamClient: streamClient as any,
       validator: {} as any,

--- a/packages/agents-server/test/event-source-subscriptions-route.test.ts
+++ b/packages/agents-server/test/event-source-subscriptions-route.test.ts
@@ -174,6 +174,7 @@ function tenantContext(
         : undefined
     ),
     getEntityType: vi.fn(),
+    hasEntityPermission: vi.fn(async () => true),
   }
   return {
     service: `svc-agent-1`,

--- a/packages/agents-server/test/server-start.test.ts
+++ b/packages/agents-server/test/server-start.test.ts
@@ -105,6 +105,10 @@ vi.mock(`../src/entity-registry`, () => ({
       return Promise.resolve()
     }
 
+    replaceSharedStateLink(): Promise<void> {
+      return Promise.resolve()
+    }
+
     releaseTagOutboxClaims(): Promise<void> {
       return Promise.resolve()
     }


### PR DESCRIPTION
## Summary
- Update the runtime DSL test helper to use the inspector principal for inspection requests and grant the test principal explicit `spawn` access when defining entities.
- Extend server test doubles with the missing permission and shared-state methods required by the current agent registry and dispatch flow.
- Keep the agent-server test suite aligned with the latest interfaces so permission-sensitive paths can be exercised without brittle fixture failures.
