### PR TITLE
feat(agents-mobile): pin sessions via long-press context menu

### DIFF
--- a/.changeset/agents-mobile-pin-sessions.md
+++ b/.changeset/agents-mobile-pin-sessions.md
@@ -1,0 +1,6 @@
+---
+"@electric-ax/agents-mobile": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Add session pinning to the mobile app: long-press a root session row to open a context sheet with the entity info (title, session id, type/status, subagents, runner, sandbox, spawned, last active) and a Pin/Unpin action. Pinned sessions surface in a Pinned section above the groups, persisted per-device in AsyncStorage — the mobile mirror of the web sidebar's pinning. Runner-param types in agents-server-ui's `entityRuntime` helpers are loosened to structural subsets so the mobile app can reuse them.

--- a/.changeset/agents-mobile-pin-sessions.md
+++ b/.changeset/agents-mobile-pin-sessions.md
@@ -3,4 +3,4 @@
 "@electric-ax/agents-server-ui": patch
 ---
 
-Add session pinning to the mobile app: long-press a root session row to open a context sheet with the entity info (title, session id, type/status, subagents, runner, sandbox, spawned, last active) and a Pin/Unpin action. Pinned sessions surface in a Pinned section above the groups, persisted per-device in AsyncStorage — the mobile mirror of the web sidebar's pinning. Runner-param types in agents-server-ui's `entityRuntime` helpers are loosened to structural subsets so the mobile app can reuse them.
+Add session pinning to the mobile app: long-press a root session row (or any search result) to open a context sheet with the entity info (title, session id, type/status, subagents, runner, sandbox, spawned, last active) and a Pin/Unpin action; the in-session kebab menu also gets a Pin/Unpin item, mirroring the desktop tile menu. Pinned sessions surface in a Pinned section above the groups, persisted per-device in AsyncStorage — the mobile mirror of the web sidebar's pinning. Runner-param types in agents-server-ui's `entityRuntime` helpers are loosened to structural subsets so the mobile app can reuse them.

--- a/packages/agents-mobile/src/components/Icon.tsx
+++ b/packages/agents-mobile/src/components/Icon.tsx
@@ -39,6 +39,7 @@ export type IconName =
   | `cloud`
   | `user`
   | `users`
+  | `pin`
 
 const PATHS: Record<IconName, string> = {
   back: `M15 18l-6-6 6-6`,
@@ -64,6 +65,8 @@ const PATHS: Record<IconName, string> = {
   database: `M5 5c0-1.1 3.1-2 7-2s7 .9 7 2v14c0 1.1-3.1 2-7 2s-7-.9-7-2V5ZM5 12c0 1.1 3.1 2 7 2s7-.9 7-2`,
   radio: `M4.9 19.1a10 10 0 0 1 0-14.2M7.8 16.2a6 6 0 0 1 0-8.4M10.6 13.4a2 2 0 0 1 0-2.8M14 12h.01M16.2 7.8a6 6 0 0 1 0 8.4M19.1 4.9a10 10 0 0 1 0 14.2`,
   'arrow-up': `M12 19V5M5 12l7-7 7 7`,
+  // Lucide `pin` — matches the desktop sidebar's pin toggle glyph.
+  pin: `M12 17v5M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z`,
   square: `M7 7h10v10H7z`,
   github: `M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4M9 18c-4.51 2-5-2-7-2`,
   // Official Google "G" mark, rendered in a single fill colour. Google's

--- a/packages/agents-mobile/src/components/SessionMenu.tsx
+++ b/packages/agents-mobile/src/components/SessionMenu.tsx
@@ -8,6 +8,7 @@ import {
 } from './BottomSheet'
 import { Icon } from './Icon'
 import { useDrillTransition } from './useDrillTransition'
+import { togglePin, usePinnedUrls } from '../lib/pinnedEntities'
 import { useTokens } from '../lib/ThemeProvider'
 import type { ElectricEntity, EntitySignal } from '../lib/agentsClient'
 import type { EmbedViewId } from '../lib/embedView'
@@ -101,7 +102,8 @@ const SIGNAL_OPTION_GROUPS: ReadonlyArray<
 
 /**
  * Bottom-sheet "more" menu for the chat screen — exposes the view
- * toggle (chat / state explorer) plus a status header. Tapping a
+ * toggle (chat / state explorer), a pin toggle (mirror of the
+ * desktop tile menu's Pin/Unpin), plus a status header. Tapping a
  * row immediately switches the view and dismisses the sheet, so the
  * user can swap between modes in one tap-tap gesture (kebab → mode).
  */
@@ -127,6 +129,8 @@ export function SessionMenu({
   signalDisabled?: boolean
 }): React.ReactElement {
   const tokens = useTokens()
+  const pinnedUrls = usePinnedUrls()
+  const pinned = entity !== null && pinnedUrls.includes(entity.url)
   const [signalMenuOpen, setSignalMenuOpen] = useState(false)
   const {
     style: drillPaneStyle,
@@ -318,6 +322,28 @@ export function SessionMenu({
                 onPress={() => handlePick(`state-explorer`)}
               />
             </BottomSheetSection>
+            {entity && (
+              <>
+                <BottomSheetSeparator />
+                <BottomSheetSection>
+                  <BottomSheetItem
+                    label={pinned ? `Unpin` : `Pin`}
+                    icon={
+                      <Icon
+                        name="pin"
+                        size={18}
+                        color={tokens.text2}
+                        strokeWidth={2}
+                      />
+                    }
+                    onPress={() => {
+                      togglePin(entity.url)
+                      handleClose()
+                    }}
+                  />
+                </BottomSheetSection>
+              </>
+            )}
             {canOpenSignalMenu && (
               <>
                 <BottomSheetSeparator />

--- a/packages/agents-mobile/src/components/SessionRow.tsx
+++ b/packages/agents-mobile/src/components/SessionRow.tsx
@@ -101,6 +101,9 @@ export const SessionRow = memo(function SessionRow({
         onLongPress={onLongPress}
         // 350ms; RN's 500ms default feels unresponsive for a context menu.
         delayLongPress={350}
+        accessibilityHint={
+          onLongPress ? `Long press for session options` : undefined
+        }
       >
         {({ pressed }) => (
           <>

--- a/packages/agents-mobile/src/components/SessionRow.tsx
+++ b/packages/agents-mobile/src/components/SessionRow.tsx
@@ -59,6 +59,7 @@ export const SessionRow = memo(function SessionRow({
   expanded = false,
   onToggleExpand,
   onPress,
+  onLongPress,
   connector = null,
   currentPrincipalUrl = null,
 }: {
@@ -68,6 +69,7 @@ export const SessionRow = memo(function SessionRow({
   expanded?: boolean
   onToggleExpand?: () => void
   onPress: () => void
+  onLongPress?: () => void
   connector?: SessionRowConnector | null
   currentPrincipalUrl?: string | null
 }): React.ReactElement {
@@ -93,7 +95,13 @@ export const SessionRow = memo(function SessionRow({
         />
       ) : null}
 
-      <Pressable style={[styles.rowMain, { paddingLeft }]} onPress={onPress}>
+      <Pressable
+        style={[styles.rowMain, { paddingLeft }]}
+        onPress={onPress}
+        onLongPress={onLongPress}
+        // 350ms; RN's 500ms default feels unresponsive for a context menu.
+        delayLongPress={350}
+      >
         {({ pressed }) => (
           <>
             <View

--- a/packages/agents-mobile/src/components/SessionRowMenu.tsx
+++ b/packages/agents-mobile/src/components/SessionRowMenu.tsx
@@ -1,0 +1,182 @@
+import { useMemo } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { useLiveQuery } from '@tanstack/react-db'
+import {
+  formatAbsoluteDateTime,
+  formatRelativeTime,
+} from '@electric-ax/agents-server-ui/src/lib/formatTime'
+import {
+  getEntityRunnerId,
+  resolveEffectiveSandbox,
+  resolveRunner,
+  runnerDisplayLabel,
+} from '@electric-ax/agents-server-ui/src/lib/entityRuntime'
+import {
+  BottomSheet,
+  BottomSheetItem,
+  BottomSheetSection,
+  BottomSheetSeparator,
+} from './BottomSheet'
+import { Icon } from './Icon'
+import { useAgents } from '../lib/AgentsProvider'
+import { getEntityDisplayTitle, type ElectricEntity } from '../lib/agentsClient'
+import { useTokens } from '../lib/ThemeProvider'
+import { fontSize, monoFontFamily } from '../lib/theme'
+import type { Tokens } from '../lib/theme'
+
+/**
+ * Long-press context menu for a session row on the home screen.
+ * Mobile counterpart of two web-sidebar hover affordances at once:
+ * the row info popout (`SidebarRowInfo` — same fields, same
+ * formatting helpers) and the pin toggle. Only root rows open this
+ * menu (the caller gates it) — pinning is root-only, matching the
+ * web sidebar.
+ */
+export function SessionRowMenu({
+  open,
+  onClose,
+  entity,
+  childCount,
+  pinned,
+  onTogglePin,
+}: {
+  open: boolean
+  onClose: () => void
+  entity: ElectricEntity | null
+  childCount: number
+  pinned: boolean
+  onTogglePin: () => void
+}): React.ReactElement {
+  const tokens = useTokens()
+  const styles = useMemo(() => createStyles(tokens), [tokens])
+  const { runnersCollection } = useAgents()
+
+  // Resolve runner/sandbox labels via the shared pure helpers (the
+  // web's `useEntityRuntimeInfo` reads its own provider context, so
+  // mobile queries its runners collection directly).
+  const { data: runners = [] } = useLiveQuery(
+    (q) => q.from({ r: runnersCollection }),
+    [runnersCollection]
+  )
+
+  const runnerId = entity ? getEntityRunnerId(entity) : null
+  const runner = resolveRunner(runners, runnerId)
+  const runnerLabel = runnerId ? runnerDisplayLabel(runner, runnerId) : null
+  const sandboxLabel = entity
+    ? resolveEffectiveSandbox(runners, entity, runner).label
+    : null
+
+  return (
+    <BottomSheet open={open} onClose={onClose}>
+      {entity && (
+        <>
+          {/* Info header — field-for-field mirror of the web hover card. */}
+          <View style={styles.info}>
+            <Text style={styles.infoTitle} numberOfLines={2}>
+              {getEntityDisplayTitle(entity)}
+            </Text>
+            <Text style={styles.infoId} numberOfLines={1}>
+              {entity.url.replace(/^\//, ``)}
+            </Text>
+            <Text style={styles.infoMeta} numberOfLines={1}>
+              {entity.type} · {entity.status}
+              {childCount > 0
+                ? ` · ${childCount} subagent${childCount === 1 ? `` : `s`}`
+                : ``}
+            </Text>
+            <View style={styles.infoRows}>
+              {runnerLabel && <InfoRow label="Runner" value={runnerLabel} />}
+              {sandboxLabel && <InfoRow label="Sandbox" value={sandboxLabel} />}
+              <InfoRow
+                label="Spawned"
+                value={formatAbsoluteDateTime(entity.created_at)}
+              />
+              <InfoRow
+                label="Last active"
+                value={formatRelativeTime(entity.updated_at)}
+              />
+            </View>
+          </View>
+          <BottomSheetSeparator />
+        </>
+      )}
+      <BottomSheetSection>
+        <BottomSheetItem
+          label={pinned ? `Unpin` : `Pin`}
+          icon={
+            <Icon name="pin" size={18} color={tokens.text2} strokeWidth={2} />
+          }
+          onPress={() => {
+            onTogglePin()
+            onClose()
+          }}
+        />
+      </BottomSheetSection>
+    </BottomSheet>
+  )
+}
+
+function InfoRow({
+  label,
+  value,
+}: {
+  label: string
+  value: string
+}): React.ReactElement {
+  const tokens = useTokens()
+  const styles = useMemo(() => createStyles(tokens), [tokens])
+  return (
+    <View style={styles.infoRow}>
+      <Text style={styles.infoRowLabel}>{label}</Text>
+      <Text style={styles.infoRowValue} numberOfLines={1}>
+        {value}
+      </Text>
+    </View>
+  )
+}
+
+function createStyles(tokens: Tokens) {
+  return StyleSheet.create({
+    info: {
+      paddingHorizontal: 12,
+      paddingTop: 6,
+      paddingBottom: 8,
+      gap: 2,
+    },
+    infoTitle: {
+      color: tokens.text1,
+      fontSize: fontSize.base,
+      fontWeight: `500`,
+      lineHeight: 20,
+    },
+    infoId: {
+      color: tokens.text3,
+      fontSize: fontSize.sm,
+      fontFamily: monoFontFamily,
+    },
+    infoMeta: {
+      color: tokens.text3,
+      fontSize: fontSize.sm,
+    },
+    infoRows: {
+      marginTop: 8,
+      gap: 4,
+    },
+    infoRow: {
+      flexDirection: `row`,
+      alignItems: `baseline`,
+      gap: 12,
+    },
+    infoRowLabel: {
+      width: 80,
+      flexShrink: 0,
+      color: tokens.text3,
+      fontSize: fontSize.sm,
+    },
+    infoRowValue: {
+      flex: 1,
+      color: tokens.text2,
+      fontSize: fontSize.sm,
+    },
+  })
+}

--- a/packages/agents-mobile/src/components/SessionRowMenu.tsx
+++ b/packages/agents-mobile/src/components/SessionRowMenu.tsx
@@ -28,9 +28,10 @@ import type { Tokens } from '../lib/theme'
  * Long-press context menu for a session row on the home screen.
  * Mobile counterpart of two web-sidebar hover affordances at once:
  * the row info popout (`SidebarRowInfo` — same fields, same
- * formatting helpers) and the pin toggle. Only root rows open this
- * menu (the caller gates it) — pinning is root-only, matching the
- * web sidebar.
+ * formatting helpers) and the pin toggle. In tree mode only root
+ * rows open it (the caller gates it, matching the web sidebar);
+ * search hits open it at any depth, like the desktop tile menu —
+ * a pinned child hoists into the Pinned section.
  */
 export function SessionRowMenu({
   open,

--- a/packages/agents-mobile/src/components/SessionRowMenu.tsx
+++ b/packages/agents-mobile/src/components/SessionRowMenu.tsx
@@ -49,55 +49,12 @@ export function SessionRowMenu({
   onTogglePin: () => void
 }): React.ReactElement {
   const tokens = useTokens()
-  const styles = useMemo(() => createStyles(tokens), [tokens])
-  const { runnersCollection } = useAgents()
-
-  // Resolve runner/sandbox labels via the shared pure helpers (the
-  // web's `useEntityRuntimeInfo` reads its own provider context, so
-  // mobile queries its runners collection directly).
-  const { data: runners = [] } = useLiveQuery(
-    (q) => q.from({ r: runnersCollection }),
-    [runnersCollection]
-  )
-
-  const runnerId = entity ? getEntityRunnerId(entity) : null
-  const runner = resolveRunner(runners, runnerId)
-  const runnerLabel = runnerId ? runnerDisplayLabel(runner, runnerId) : null
-  const sandboxLabel = entity
-    ? resolveEffectiveSandbox(runners, entity, runner).label
-    : null
 
   return (
     <BottomSheet open={open} onClose={onClose}>
       {entity && (
         <>
-          {/* Info header — field-for-field mirror of the web hover card. */}
-          <View style={styles.info}>
-            <Text style={styles.infoTitle} numberOfLines={2}>
-              {getEntityDisplayTitle(entity)}
-            </Text>
-            <Text style={styles.infoId} numberOfLines={1}>
-              {entity.url.replace(/^\//, ``)}
-            </Text>
-            <Text style={styles.infoMeta} numberOfLines={1}>
-              {entity.type} · {entity.status}
-              {childCount > 0
-                ? ` · ${childCount} subagent${childCount === 1 ? `` : `s`}`
-                : ``}
-            </Text>
-            <View style={styles.infoRows}>
-              {runnerLabel && <InfoRow label="Runner" value={runnerLabel} />}
-              {sandboxLabel && <InfoRow label="Sandbox" value={sandboxLabel} />}
-              <InfoRow
-                label="Spawned"
-                value={formatAbsoluteDateTime(entity.created_at)}
-              />
-              <InfoRow
-                label="Last active"
-                value={formatRelativeTime(entity.updated_at)}
-              />
-            </View>
-          </View>
+          <EntityInfo entity={entity} childCount={childCount} />
           <BottomSheetSeparator />
         </>
       )}
@@ -114,6 +71,65 @@ export function SessionRowMenu({
         />
       </BottomSheetSection>
     </BottomSheet>
+  )
+}
+
+/**
+ * Info header — field-for-field mirror of the web hover card. Split
+ * out so the runners live query only subscribes while the sheet has
+ * an entity (it stays mounted, closed, for the screen's lifetime).
+ */
+function EntityInfo({
+  entity,
+  childCount,
+}: {
+  entity: ElectricEntity
+  childCount: number
+}): React.ReactElement {
+  const tokens = useTokens()
+  const styles = useMemo(() => createStyles(tokens), [tokens])
+  const { runnersCollection } = useAgents()
+
+  // Resolve runner/sandbox labels via the shared pure helpers (the
+  // web's `useEntityRuntimeInfo` reads its own provider context, so
+  // mobile queries its runners collection directly).
+  const { data: runners = [] } = useLiveQuery(
+    (q) => q.from({ r: runnersCollection }),
+    [runnersCollection]
+  )
+
+  const runnerId = getEntityRunnerId(entity)
+  const runner = resolveRunner(runners, runnerId)
+  const runnerLabel = runnerId ? runnerDisplayLabel(runner, runnerId) : null
+  const sandboxLabel = resolveEffectiveSandbox(runners, entity, runner).label
+
+  return (
+    <View style={styles.info}>
+      <Text style={styles.infoTitle} numberOfLines={2}>
+        {getEntityDisplayTitle(entity)}
+      </Text>
+      <Text style={styles.infoId} numberOfLines={1}>
+        {entity.url.replace(/^\//, ``)}
+      </Text>
+      <Text style={styles.infoMeta} numberOfLines={1}>
+        {entity.type} · {entity.status}
+        {childCount > 0
+          ? ` · ${childCount} subagent${childCount === 1 ? `` : `s`}`
+          : ``}
+      </Text>
+      <View style={styles.infoRows}>
+        {runnerLabel && <InfoRow label="Runner" value={runnerLabel} />}
+        {sandboxLabel && <InfoRow label="Sandbox" value={sandboxLabel} />}
+        <InfoRow
+          label="Spawned"
+          value={formatAbsoluteDateTime(entity.created_at)}
+        />
+        <InfoRow
+          label="Last active"
+          value={formatRelativeTime(entity.updated_at)}
+        />
+      </View>
+    </View>
   )
 }
 

--- a/packages/agents-mobile/src/components/SessionTree.tsx
+++ b/packages/agents-mobile/src/components/SessionTree.tsx
@@ -36,6 +36,8 @@ export const SessionTree = memo(function SessionTree({
   parentTrunkX,
   onSelectEntity,
   currentPrincipalUrl = null,
+  onLongPressRoot,
+  pinnedSet,
 }: {
   entity: ElectricEntity
   childrenByParent: Map<string, Array<ElectricEntity>>
@@ -49,9 +51,16 @@ export const SessionTree = memo(function SessionTree({
   parentTrunkX?: number
   onSelectEntity: (url: string) => void
   currentPrincipalUrl?: string | null
+  /** Opens the row context menu; not forwarded to children (pinning is root-only). */
+  onLongPressRoot?: (entity: ElectricEntity) => void
+  /** Pinned entities render in the Pinned section, so filter them out of subtrees. */
+  pinnedSet?: ReadonlySet<string>
 }): React.ReactElement {
   const expanded = useIsExpanded(entity.url)
-  const children = childrenByParent.get(entity.url) ?? []
+  const allChildren = childrenByParent.get(entity.url) ?? []
+  const children = pinnedSet
+    ? allChildren.filter((c) => !pinnedSet.has(c.url))
+    : allChildren
   const hasChildren = children.length > 0
 
   // Trunk x for *this* row's children, computed once per render.
@@ -69,6 +78,9 @@ export const SessionTree = memo(function SessionTree({
         }
         onPress={() => onSelectEntity(entity.url)}
         currentPrincipalUrl={currentPrincipalUrl}
+        onLongPress={
+          onLongPressRoot ? () => onLongPressRoot(entity) : undefined
+        }
         connector={
           parentTrunkX !== undefined
             ? { trunkX: parentTrunkX, isLastSibling }
@@ -87,6 +99,7 @@ export const SessionTree = memo(function SessionTree({
               parentTrunkX={myTrunkX}
               onSelectEntity={onSelectEntity}
               currentPrincipalUrl={currentPrincipalUrl}
+              pinnedSet={pinnedSet}
             />
           ))}
         </View>

--- a/packages/agents-mobile/src/lib/agentsClient.ts
+++ b/packages/agents-mobile/src/lib/agentsClient.ts
@@ -31,12 +31,33 @@ const ENTITY_STATUSES: [EntityStatus, ...Array<EntityStatus>] = [
   `killed`,
 ]
 
+// Mirrors `dispatchPolicySchema` in agents-server-ui's
+// `ElectricAgentsProvider.tsx` — permissive so unknown target shapes
+// still sync; only the `runner` target's id is read (for display).
+const dispatchPolicySchema = z.object({
+  targets: z
+    .array(
+      z.object({
+        type: z.string(),
+        runnerId: z.string().optional(),
+        url: z.string().optional(),
+        subscription_id: z.string().optional(),
+      })
+    )
+    .default([]),
+})
+
 export const entitySchema = z.object({
   url: z.string(),
   type: z.string(),
   status: z.enum(ENTITY_STATUSES),
   tags: z.record(z.string(), z.string()).default({}),
   spawn_args: z.record(z.string(), z.unknown()).default({}),
+  sandbox: z
+    .object({ profile: z.string(), key: z.string().optional() })
+    .nullable()
+    .optional(),
+  dispatch_policy: dispatchPolicySchema.nullable().optional(),
   parent: z.string().nullable(),
   created_by: z.string().nullable().optional(),
   type_revision: z.coerce.number().nullable().optional(),
@@ -57,9 +78,19 @@ export const entityTypeSchema = z.object({
   updated_at: z.string(),
 })
 
-// Minimal subset of the runners shape — just the columns the mobile
-// picker needs to identify a runner and pass it as the dispatch
-// target on spawn.
+const sandboxProfileAdvertisementSchema = z.object({
+  name: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  // True for off-host (remote-provider) sandboxes: the workspace lives in the
+  // provider VM, so a host working directory doesn't apply.
+  remote: z.boolean().optional(),
+})
+
+// Minimal subset of the runners shape — the columns the mobile picker
+// needs to identify a runner and pass it as the dispatch target on
+// spawn, plus `sandbox_profiles` so the session-row info sheet can
+// resolve sandbox labels like the desktop hover card does.
 export const runnerSchema = z.object({
   id: z.string(),
   owner_principal: z.string(),
@@ -67,6 +98,12 @@ export const runnerSchema = z.object({
   kind: z.string(),
   admin_status: z.enum([`enabled`, `disabled`]),
   last_seen_at: z.string().nullable().optional(),
+  // Coerce a missing/null jsonb column to an empty list — `.default([])`
+  // covers `undefined` but not a Postgres NULL.
+  sandbox_profiles: z.preprocess(
+    (v) => (Array.isArray(v) ? v : []),
+    z.array(sandboxProfileAdvertisementSchema)
+  ),
 })
 
 export const userSchema = z.object({
@@ -145,6 +182,8 @@ export function createEntitiesCollection(baseUrl: string) {
             `status`,
             `tags`,
             `spawn_args`,
+            `sandbox`,
+            `dispatch_policy`,
             `parent`,
             `created_by`,
             `type_revision`,
@@ -195,6 +234,7 @@ export function createRunnersCollection(baseUrl: string) {
             `kind`,
             `admin_status`,
             `last_seen_at`,
+            `sandbox_profiles`,
           ],
         },
       },

--- a/packages/agents-mobile/src/lib/pinnedEntities.test.ts
+++ b/packages/agents-mobile/src/lib/pinnedEntities.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const store = vi.hoisted(() => ({
+  map: new Map<string, string>(),
+  // When set, getItem blocks until the promise resolves — lets tests
+  // hold the hydration IIFE open to exercise the pre-hydration path.
+  gate: null as Promise<void> | null,
+}))
+
+vi.mock(`@react-native-async-storage/async-storage`, () => ({
+  default: {
+    getItem: vi.fn(async (key: string) => {
+      // Snapshot at call time (real AsyncStorage serializes FIFO, so a
+      // getItem issued before a setItem sees the pre-write value), then
+      // optionally block on the gate before resolving.
+      const value = store.map.get(key) ?? null
+      if (store.gate) await store.gate
+      return value
+    }),
+    setItem: vi.fn(async (key: string, value: string) => {
+      store.map.set(key, value)
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      store.map.delete(key)
+    }),
+  },
+}))
+
+const STORAGE_KEY = `electric-agents-mobile.pinned-entities`
+
+// Re-import the module fresh each test so its module-level state + the
+// import-time hydration IIFE re-run against the current mock storage.
+async function freshModule() {
+  vi.resetModules()
+  const mod = await import(`./pinnedEntities`)
+  // Let the async hydration IIFE settle.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  return mod
+}
+
+beforeEach(() => {
+  store.map.clear()
+  store.gate = null
+  vi.clearAllMocks()
+})
+
+describe(`pinnedEntities`, () => {
+  it(`togglePin adds a url and exposes it via the snapshot`, async () => {
+    const { togglePin, getPinnedUrls } = await freshModule()
+    togglePin(`/horton/one`)
+    togglePin(`/horton/two`)
+    expect(getPinnedUrls()).toEqual([`/horton/one`, `/horton/two`])
+  })
+
+  it(`toggling the same url twice removes it`, async () => {
+    const { togglePin, getPinnedUrls } = await freshModule()
+    togglePin(`/horton/one`)
+    togglePin(`/horton/two`)
+    togglePin(`/horton/one`)
+    expect(getPinnedUrls()).toEqual([`/horton/two`])
+  })
+
+  it(`persists to AsyncStorage and rehydrates on next load`, async () => {
+    const first = await freshModule()
+    first.togglePin(`/horton/one`)
+    first.togglePin(`/horton/two`)
+    expect(store.map.get(STORAGE_KEY)).toBe(
+      JSON.stringify([`/horton/one`, `/horton/two`])
+    )
+
+    // A fresh module instance should hydrate from the persisted blob.
+    const second = await freshModule()
+    expect(second.getPinnedUrls()).toEqual([`/horton/one`, `/horton/two`])
+  })
+
+  it(`merges (does not clobber) when a toggle lands before hydration`, async () => {
+    // Persist a pin, then hold hydration open with the gate so a toggle
+    // genuinely lands during the startup hydration window.
+    store.map.set(STORAGE_KEY, JSON.stringify([`/horton/persisted`]))
+    let release!: () => void
+    store.gate = new Promise((resolve) => {
+      release = resolve
+    })
+    vi.resetModules()
+    const mod = await import(`./pinnedEntities`)
+    mod.togglePin(`/horton/early`)
+    release()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Both the persisted pin and the pre-hydration pin survive.
+    expect(mod.getPinnedUrls()).toEqual([`/horton/persisted`, `/horton/early`])
+  })
+
+  it(`pre-hydration pin of an already-persisted url does not duplicate it`, async () => {
+    store.map.set(
+      STORAGE_KEY,
+      JSON.stringify([`/horton/persisted`, `/horton/other`])
+    )
+    let release!: () => void
+    store.gate = new Promise((resolve) => {
+      release = resolve
+    })
+    vi.resetModules()
+    const mod = await import(`./pinnedEntities`)
+    // The pre-hydration set is empty, so this toggle *pins* — the merge
+    // must not resurrect it as a duplicate once the persisted set lands.
+    mod.togglePin(`/horton/persisted`)
+    release()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mod.getPinnedUrls()).toEqual([`/horton/persisted`, `/horton/other`])
+  })
+
+  it(`ignores malformed persisted payloads`, async () => {
+    store.map.set(
+      STORAGE_KEY,
+      JSON.stringify([`/horton/one`, 42, null, { url: `/x` }, `/horton/two`])
+    )
+    const { getPinnedUrls } = await freshModule()
+    expect(getPinnedUrls()).toEqual([`/horton/one`, `/horton/two`])
+  })
+
+  it(`ignores a non-array persisted payload`, async () => {
+    store.map.set(STORAGE_KEY, JSON.stringify({ not: `an array` }))
+    const { getPinnedUrls } = await freshModule()
+    expect(getPinnedUrls()).toEqual([])
+  })
+})

--- a/packages/agents-mobile/src/lib/pinnedEntities.ts
+++ b/packages/agents-mobile/src/lib/pinnedEntities.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+/**
+ * Pinned session URLs for the home-screen list, persisted across
+ * launches. Mobile mirror of the desktop's `usePinnedEntities`
+ * (array-of-urls in `localStorage`) — per-device UI state, never
+ * synced to the server. Tiny module-level store (no provider),
+ * mirroring `sidebarPrefs.ts` / `savedServers.ts`.
+ */
+
+const STORAGE_KEY = `electric-agents-mobile.pinned-entities`
+
+let current: ReadonlyArray<string> = []
+const listeners = new Set<(urls: ReadonlyArray<string>) => void>()
+let hydrated = false
+// Set once a mutation happens so late-arriving hydration can't clobber a
+// pin the user toggled during the (brief) startup hydration window.
+let dirty = false
+
+void (async () => {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as unknown
+      const persisted = Array.isArray(parsed)
+        ? parsed.filter((v): v is string => typeof v === `string`)
+        : []
+      if (dirty) {
+        // Toggle landed pre-hydration: merge persisted + just-added
+        // (deduped by url) rather than clobber.
+        const persistedSet = new Set(persisted)
+        current = [
+          ...persisted,
+          ...current.filter((url) => !persistedSet.has(url)),
+        ]
+        persist()
+      } else {
+        current = persisted
+      }
+    }
+  } catch {
+    // Ignore hydration errors — fall back to an empty list.
+  } finally {
+    hydrated = true
+    for (const listener of listeners) listener(current)
+  }
+})()
+
+function persist(): void {
+  void AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(current)).catch(
+    () => {}
+  )
+}
+
+function update(next: ReadonlyArray<string>): void {
+  current = next
+  dirty = true
+  persist()
+  for (const listener of listeners) listener(current)
+}
+
+/** Synchronous snapshot for non-React callers (and tests). */
+export function getPinnedUrls(): ReadonlyArray<string> {
+  return current
+}
+
+export function togglePin(url: string): void {
+  if (current.includes(url)) {
+    update(current.filter((u) => u !== url))
+  } else {
+    update([...current, url])
+  }
+}
+
+export function usePinnedUrls(): ReadonlyArray<string> {
+  const [state, setState] = useState<ReadonlyArray<string>>(current)
+  useEffect(() => {
+    listeners.add(setState)
+    if (hydrated) setState(current)
+    return () => {
+      listeners.delete(setState)
+    }
+  }, [])
+  return state
+}

--- a/packages/agents-mobile/src/lib/theme.ts
+++ b/packages/agents-mobile/src/lib/theme.ts
@@ -6,6 +6,7 @@
  * functions at runtime so the token table is the single source of truth
  * for both the native shell and the embedded web bundle.
  */
+import { Platform } from 'react-native'
 
 export type ColorScheme = `light` | `dark`
 
@@ -249,3 +250,5 @@ export const rowHeight = {
   lg: 36,
   xl: 44,
 }
+
+export const monoFontFamily = Platform.OS === `ios` ? `Menlo` : `monospace`

--- a/packages/agents-mobile/src/screens/DiagnosticsScreen.tsx
+++ b/packages/agents-mobile/src/screens/DiagnosticsScreen.tsx
@@ -17,7 +17,13 @@ import { useAgents } from '../lib/AgentsProvider'
 import { checkServerHealth } from '../lib/agentsClient'
 import { cloudAuth } from '../lib/cloudAuth'
 import { useColorSchemeMode, useTokens } from '../lib/ThemeProvider'
-import { fontSize, lineHeight, radii, spacing } from '../lib/theme'
+import {
+  fontSize,
+  lineHeight,
+  monoFontFamily,
+  radii,
+  spacing,
+} from '../lib/theme'
 import type { Tokens } from '../lib/theme'
 
 type HealthState =
@@ -281,7 +287,7 @@ function createStyles(tokens: Tokens) {
       lineHeight: lineHeight.sm,
     },
     fieldValueMono: {
-      fontFamily: Platform.OS === `ios` ? `Menlo` : `monospace`,
+      fontFamily: monoFontFamily,
     },
     actionRow: {
       flexDirection: `row`,

--- a/packages/agents-mobile/src/screens/SessionListScreen.tsx
+++ b/packages/agents-mobile/src/screens/SessionListScreen.tsx
@@ -60,10 +60,11 @@ import type { Tokens } from '../lib/theme'
  * since that reads better than pretending matches still belong to
  * time buckets or to a particular subtree.
  *
- * Long-pressing a root row opens `SessionRowMenu` (entity info + a
- * pin toggle). Pinned sessions render in the PINNED section above
- * the groups and are removed from the groups below — the mobile
- * mirror of the web sidebar's pinning.
+ * Long-pressing a root row — or any search hit — opens
+ * `SessionRowMenu` (entity info + a pin toggle). Pinned sessions
+ * render in the PINNED section above the groups and are removed
+ * from the groups below — the mobile mirror of the web sidebar's
+ * pinning.
  */
 export function SessionListScreen({
   onOpenSession,
@@ -94,7 +95,7 @@ export function SessionListScreen({
 
   // Long-pressed row whose context menu (info + pin) is open.
   const [menuEntity, setMenuEntity] = useState<ElectricEntity | null>(null)
-  const onLongPressRoot = useCallback(
+  const openRowMenu = useCallback(
     (entity: ElectricEntity) => setMenuEntity(entity),
     []
   )
@@ -300,7 +301,7 @@ export function SessionListScreen({
                 childrenByParent={childrenByParent}
                 onSelectEntity={onOpenSession}
                 currentPrincipalUrl={currentPrincipalUrl}
-                onLongPressRoot={onLongPressRoot}
+                onLongPressRoot={openRowMenu}
                 pinnedSet={pinnedSet}
               />
             ))}
@@ -320,9 +321,9 @@ export function SessionListScreen({
             <Text style={styles.sectionLabel}>{group.label}</Text>
             {trimmedQuery
               ? // Flat list when searching — no expand chevrons, no
-                // tree connectors, no child-count chips, no long-press
-                // menu. The user is looking for a specific session by
-                // name.
+                // tree connectors, no child-count chips. Long-press
+                // still opens the context menu (any depth, like the
+                // desktop tile menu) so a found session can be pinned.
                 group.items.map((entity) => (
                   <SessionRow
                     key={entity.url}
@@ -330,6 +331,7 @@ export function SessionListScreen({
                     depth={0}
                     onPress={() => onOpenSession(entity.url)}
                     currentPrincipalUrl={currentPrincipalUrl}
+                    onLongPress={() => openRowMenu(entity)}
                   />
                 ))
               : // Default mode — every group item is a tree root. The
@@ -342,7 +344,7 @@ export function SessionListScreen({
                     childrenByParent={childrenByParent}
                     onSelectEntity={onOpenSession}
                     currentPrincipalUrl={currentPrincipalUrl}
-                    onLongPressRoot={onLongPressRoot}
+                    onLongPressRoot={openRowMenu}
                     pinnedSet={pinnedSet}
                   />
                 ))}

--- a/packages/agents-mobile/src/screens/SessionListScreen.tsx
+++ b/packages/agents-mobile/src/screens/SessionListScreen.tsx
@@ -93,10 +93,14 @@ export function SessionListScreen({
   const [query, setQuery] = useState(``)
   const [menuOpen, setMenuOpen] = useState(false)
 
-  // Long-pressed row whose context menu (info + pin) is open.
-  const [menuEntity, setMenuEntity] = useState<ElectricEntity | null>(null)
+  // Long-pressed row whose context menu (info + pin) is open. The
+  // snapshot only identifies the row — the rendered entity is
+  // re-resolved from the live query below so the sheet tracks
+  // updates (status, title) while open, falling back to the
+  // snapshot if the entity leaves the collection.
+  const [menuSnapshot, setMenuSnapshot] = useState<ElectricEntity | null>(null)
   const openRowMenu = useCallback(
-    (entity: ElectricEntity) => setMenuEntity(entity),
+    (entity: ElectricEntity) => setMenuSnapshot(entity),
     []
   )
 
@@ -111,6 +115,11 @@ export function SessionListScreen({
         .orderBy(({ entity }) => entity.updated_at, `desc`),
     [entitiesCollection]
   )
+
+  const menuEntity = useMemo(() => {
+    if (!menuSnapshot) return null
+    return entities.find((e) => e.url === menuSnapshot.url) ?? menuSnapshot
+  }, [entities, menuSnapshot])
 
   // Apply Show > Type / Show > Status filters before the tree build
   // so a hidden parent doesn't take its (visible) children with it —
@@ -391,7 +400,7 @@ export function SessionListScreen({
 
       <SessionRowMenu
         open={menuEntity !== null}
-        onClose={() => setMenuEntity(null)}
+        onClose={() => setMenuSnapshot(null)}
         entity={menuEntity}
         childCount={menuChildCount}
         pinned={menuEntity ? pinnedSet.has(menuEntity.url) : false}

--- a/packages/agents-mobile/src/screens/SessionListScreen.tsx
+++ b/packages/agents-mobile/src/screens/SessionListScreen.tsx
@@ -14,6 +14,7 @@ import { HomeMenu, type ServerHealth } from '../components/HomeMenu'
 import { Screen } from '../components/Screen'
 import { SearchBar } from '../components/SearchBar'
 import { SessionRow } from '../components/SessionRow'
+import { SessionRowMenu } from '../components/SessionRowMenu'
 import { buildEntityTree, SessionTree } from '../components/SessionTree'
 import { TopBarIconButton } from '../components/TopBarIconButton'
 import { useAgents } from '../lib/AgentsProvider'
@@ -22,6 +23,7 @@ import {
   getEntityDisplayTitle,
   type ElectricEntity,
 } from '../lib/agentsClient'
+import { togglePin, usePinnedUrls } from '../lib/pinnedEntities'
 import {
   bucketEntities,
   groupByStatus,
@@ -41,6 +43,8 @@ import type { Tokens } from '../lib/theme'
  *   ┌──────────────────────────────────────────────┐
  *   │ Electric Agents          🔍  ⋯               │
  *   ├──────────────────────────────────────────────┤
+ *   │ PINNED                                       │
+ *   │   ● fav-agent                      horton ›  │
  *   │ TODAY                                        │
  *   │   ● horton-1                       horton ›  │
  *   │   ● horton-2                       horton ›  │
@@ -55,6 +59,11 @@ import type { Tokens } from '../lib/theme'
  * filtering — matches render as a flat list (no tree, no grouping)
  * since that reads better than pretending matches still belong to
  * time buckets or to a particular subtree.
+ *
+ * Long-pressing a root row opens `SessionRowMenu` (entity info + a
+ * pin toggle). Pinned sessions render in the PINNED section above
+ * the groups and are removed from the groups below — the mobile
+ * mirror of the web sidebar's pinning.
  */
 export function SessionListScreen({
   onOpenSession,
@@ -82,6 +91,16 @@ export function SessionListScreen({
   const [searchOpen, setSearchOpen] = useState(false)
   const [query, setQuery] = useState(``)
   const [menuOpen, setMenuOpen] = useState(false)
+
+  // Long-pressed row whose context menu (info + pin) is open.
+  const [menuEntity, setMenuEntity] = useState<ElectricEntity | null>(null)
+  const onLongPressRoot = useCallback(
+    (entity: ElectricEntity) => setMenuEntity(entity),
+    []
+  )
+
+  const pinnedUrls = usePinnedUrls()
+  const pinnedSet = useMemo(() => new Set(pinnedUrls), [pinnedUrls])
 
   const { data: entities = [] } = useLiveQuery(
     (q) =>
@@ -122,6 +141,18 @@ export function SessionListScreen({
     [visibleEntities]
   )
 
+  // Pinned entities get their own section above the groups and are
+  // removed from the groups below (web-sidebar parity). Derived from
+  // `visibleEntities` so pins respect the type/status filters.
+  const pinnedEntities = useMemo(
+    () => visibleEntities.filter((entity) => pinnedSet.has(entity.url)),
+    [visibleEntities, pinnedSet]
+  )
+  const unpinnedRoots = useMemo(
+    () => roots.filter((root) => !pinnedSet.has(root.url)),
+    [roots, pinnedSet]
+  )
+
   // Search overrides bucketing AND tree structure: a flat hit list
   // matches every visible entity (any depth) whose title contains
   // the query. Filters and group-by are still applied because they
@@ -147,14 +178,26 @@ export function SessionListScreen({
     }
     switch (prefs.groupBy) {
       case `type`:
-        return groupByType(roots)
+        return groupByType(unpinnedRoots)
       case `status`:
-        return groupByStatus(roots)
+        return groupByStatus(unpinnedRoots)
       case `date`:
       default:
-        return bucketEntities(roots)
+        return bucketEntities(unpinnedRoots)
     }
-  }, [roots, prefs.groupBy, trimmedQuery, searchResults])
+  }, [unpinnedRoots, prefs.groupBy, trimmedQuery, searchResults])
+
+  // No Pinned section while searching — results are a flat hit list.
+  const showPinned = !trimmedQuery && pinnedEntities.length > 0
+
+  // Pinned-filtered, like the rendered subtree (and the web hover
+  // card), so the count matches the rows shown when expanded.
+  const menuChildCount = useMemo(() => {
+    if (!menuEntity) return 0
+    return (childrenByParent.get(menuEntity.url) ?? []).filter(
+      (child) => !pinnedSet.has(child.url)
+    ).length
+  }, [menuEntity, childrenByParent, pinnedSet])
 
   // Same connectivity ping the old footer used — feeds the green/red
   // dot in the home menu.
@@ -245,16 +288,41 @@ export function SessionListScreen({
           />
         }
       >
+        {showPinned && (
+          <View style={[styles.section, styles.sectionFirst]}>
+            <Text style={styles.sectionLabel}>Pinned</Text>
+            {pinnedEntities.map((root) => (
+              <SessionTree
+                // Prefixed so the key can't collide with the same
+                // entity rendered in a group below.
+                key={`pinned:${root.url}`}
+                entity={root}
+                childrenByParent={childrenByParent}
+                onSelectEntity={onOpenSession}
+                currentPrincipalUrl={currentPrincipalUrl}
+                onLongPressRoot={onLongPressRoot}
+                pinnedSet={pinnedSet}
+              />
+            ))}
+          </View>
+        )}
+
         {groups.map((group, idx) => (
           <View
             key={group.id}
-            style={[styles.section, idx === 0 ? styles.sectionFirst : null]}
+            style={[
+              styles.section,
+              // The Pinned section owns the tighter top margin when
+              // it's rendered; otherwise the first group does.
+              idx === 0 && !showPinned ? styles.sectionFirst : null,
+            ]}
           >
             <Text style={styles.sectionLabel}>{group.label}</Text>
             {trimmedQuery
               ? // Flat list when searching — no expand chevrons, no
-                // tree connectors, no child-count chips. The user is
-                // looking for a specific session by name.
+                // tree connectors, no child-count chips, no long-press
+                // menu. The user is looking for a specific session by
+                // name.
                 group.items.map((entity) => (
                   <SessionRow
                     key={entity.url}
@@ -274,6 +342,8 @@ export function SessionListScreen({
                     childrenByParent={childrenByParent}
                     onSelectEntity={onOpenSession}
                     currentPrincipalUrl={currentPrincipalUrl}
+                    onLongPressRoot={onLongPressRoot}
+                    pinnedSet={pinnedSet}
                   />
                 ))}
           </View>
@@ -315,6 +385,17 @@ export function SessionListScreen({
         onChangeServer={onChangeServer}
         onOpenDiagnostics={onOpenDiagnostics}
         onOpenAccount={onOpenAccount}
+      />
+
+      <SessionRowMenu
+        open={menuEntity !== null}
+        onClose={() => setMenuEntity(null)}
+        entity={menuEntity}
+        childCount={menuChildCount}
+        pinned={menuEntity ? pinnedSet.has(menuEntity.url) : false}
+        onTogglePin={() => {
+          if (menuEntity) togglePin(menuEntity.url)
+        }}
       />
     </Screen>
   )

--- a/packages/agents-server-ui/src/lib/entityRuntime.ts
+++ b/packages/agents-server-ui/src/lib/entityRuntime.ts
@@ -13,7 +13,13 @@ import type {
  * have no associated runner. The sandbox profile name lives on `entity.sandbox`;
  * its human label / description / `remote` flag are resolved against the
  * runner-advertised profile list.
+ *
+ * Runner params are typed against the structural subset of fields actually
+ * read so callers that sync a narrower runners shape (the mobile app's
+ * `agentsClient.ts`) can reuse these helpers without casts.
  */
+
+type RunnerLike = Pick<ElectricRunner, `id` | `label` | `sandbox_profiles`>
 
 /** The pinned runner id from the entity's dispatch policy, if any. */
 export function getEntityRunnerId(
@@ -35,10 +41,10 @@ export function getEntitySandboxProfileName(
 }
 
 /** Look up a runner by id from a runners list. */
-export function resolveRunner(
-  runners: ReadonlyArray<ElectricRunner>,
+export function resolveRunner<R extends RunnerLike>(
+  runners: ReadonlyArray<R>,
   id: string | null
-): ElectricRunner | null {
+): R | null {
   if (!id) return null
   return runners.find((r) => r.id === id) ?? null
 }
@@ -49,9 +55,9 @@ export function resolveRunner(
  * back to the first match across all runners.
  */
 export function resolveSandboxProfile(
-  runners: ReadonlyArray<ElectricRunner>,
+  runners: ReadonlyArray<RunnerLike>,
   name: string | null,
-  preferredRunner?: ElectricRunner | null
+  preferredRunner?: RunnerLike | null
 ): ElectricSandboxProfile | null {
   if (!name) return null
   const fromPreferred = preferredRunner?.sandbox_profiles?.find(
@@ -75,7 +81,7 @@ export function shortenId(id: string): string {
  * shortened form of the id, else a generic fallback.
  */
 export function runnerDisplayLabel(
-  runner: ElectricRunner | null,
+  runner: Pick<ElectricRunner, `id` | `label`> | null,
   id: string | null
 ): string {
   if (runner) return runner.label || shortenId(runner.id)
@@ -116,9 +122,9 @@ export interface EffectiveSandbox {
 }
 
 export function resolveEffectiveSandbox(
-  runners: ReadonlyArray<ElectricRunner>,
+  runners: ReadonlyArray<RunnerLike>,
   entity: ElectricEntity,
-  runner?: ElectricRunner | null
+  runner?: RunnerLike | null
 ): EffectiveSandbox {
   const explicit = getEntitySandboxProfileName(entity)
   if (explicit) {


### PR DESCRIPTION
## Intent

The web sidebar lets users pin sessions so frequently-used ones stay at the top regardless of grouping; mobile had no equivalent, so important sessions sink into the date buckets. This ports the pinning feature to the mobile app, adapted for touch — and folds the web's row *hover info card* into the same surface, since mobile had no way to see session metadata from the list either.

## UX

- **Long-press a root session row — or any search result** → bottom sheet with the entity info + a **Pin/Unpin** action.
  - Info is a field-for-field mirror of the web hover card (`SidebarRowInfo`): title, mono session id, `type · status · N subagents`, Runner (only when a runner is pinned), Sandbox (incl. the implicit "Local" default), Spawned (absolute), Last active (relative) — using the same shared formatters/helpers, so values match the web exactly.
- **In-session kebab menu** also gets a **Pin/Unpin** item — the mirror of the desktop tile menu's Pin/Unpin (and the ⌘K "Pin current entity" action), so a session can be pinned from inside it. Together with search long-press this closes the "searched for a session, now want to pin it" gap.
- **Pinned section** renders above the date/type/status groups; pinned roots are removed from the groups and from parent subtrees below (same de-dup as `SidebarTree`), ordered by recency like the web.
- Pinned entities **respect the type/status visibility filters** (web parity — the pinned set derives from the filtered entities).
- In tree mode pinning is **root-only** (web-sidebar parity); long-press on child subtree rows is a no-op. **Search results accept long-press at any depth** (desktop-tile-menu parity) — a pinned child hoists into the Pinned section and is filtered out of its parent's subtree.

### Deliberate divergences from the web (touch context)

| Web | Mobile | Why |
|---|---|---|
| Hover reveals pin icon + info card | Long-press sheet combining both | no hover on touch |
| Pinned section header is collapsible | Not collapsible | no mobile section is collapsible today |
| ⌘K palette groups search results into Pinned/Sessions | Search results stay a flat list (no pinned section/indicator) | search targets a known session by name; can add later |
| "Last active" has absolute-time tooltip | Relative only | no tooltip affordance |
| Per-row pinned glyph (filled, rotated) | None — section placement is the indicator | rows stay clean |

## Implementation choices

- **Storage**: per-device AsyncStorage array of entity urls (`electric-agents-mobile.pinned-entities`) — the mobile mirror of the web's `localStorage` model; not synced to the server. Module-level store like `sidebarPrefs.ts`/`savedServers.ts` (whole-set subscription — a pin toggle changes list composition, so per-url listener buckets à la `expandedTree.ts` would buy nothing), incl. the `dirty`-guarded hydration merge so a toggle during the startup window isn't clobbered. Unit-tested (vitest, gated AsyncStorage mock that genuinely exercises the pre-hydration path).
- **Synced columns extended**: entities now sync `dispatch_policy` + `sandbox`, runners sync `sandbox_profiles` (zod defs mirrored from `ElectricAgentsProvider.tsx`) so the menu can resolve runner/sandbox labels.
- **Shared-code reuse over reimplementation**: the menu reuses `formatTime` + `entityRuntime` helpers from `agents-server-ui`. The only shared-file change is type-level — `entityRuntime`'s *runner* params are loosened to a structural `Pick` subset (`RunnerLike`) since mobile's runner schema is narrower; entity params were left untouched (mobile's entity type is fully assignable).
- **Tree-mode root gating by construction**: `onLongPressRoot` isn't forwarded into the `SessionTree` recursion, so child subtree rows can't get a menu; `pinnedSet` *is* forwarded so pinned entities are filtered out of subtrees before child-count/connector geometry is computed. Search rows wire the long-press directly (flat list, any depth) — safe because the subtree filtering above already handles pinned children.
- The in-session menu reads/toggles the pin via the module store directly (no prop-drilling through `SessionScreen`), closing the sheet on toggle like the row menu does.
- The subagent count in the info sheet is pinned-filtered, matching both the rendered subtree and the web hover card.
- **Review follow-ups** (from the Claude review): the sheet re-resolves the long-pressed entity from the live query while open (snapshot fallback), so its header tracks status/title updates like the child count already did; the runners live query mounts only while the sheet has an entity instead of subscribing for the screen's lifetime; rows with a context menu expose an `accessibilityHint` so the long-press affordance is announced to screen readers.

## Testing

- `pnpm --filter @electric-ax/agents-mobile typecheck && test` — 26 passed (7 new for the pin store)
- `pnpm --filter @electric-ax/agents-server-ui typecheck && test` — 66 passed (type-only change)
- No RN component-test harness in the package, so the UI wiring was verified by review (independent parity + scope reviews) — worth a manual pass in Expo before merge: pin/unpin round-trip, persistence across relaunch, child-row no-op in tree mode, pin from a search result, pin/unpin from the in-session menu, filter interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
