### PR TITLE
fix(agents): grant Horton manage permission to users

### DIFF
--- a/.changeset/horton-user-manage-permission.md
+++ b/.changeset/horton-user-manage-permission.md
@@ -1,0 +1,6 @@
+---
+"@electric-ax/agents": patch
+"@electric-ax/agents-server": patch
+---
+
+Grant all users manage permission on the built-in Horton entity type by default, and backfill existing agents-server installations that already registered Horton without that grant.

--- a/packages/agents-server/drizzle/0012_horton_user_manage_permission.sql
+++ b/packages/agents-server/drizzle/0012_horton_user_manage_permission.sql
@@ -1,0 +1,25 @@
+INSERT INTO "entity_type_permission_grants" (
+  "tenant_id",
+  "entity_type",
+  "permission",
+  "subject_kind",
+  "subject_value"
+)
+SELECT
+  "entity_types"."tenant_id",
+  "entity_types"."name",
+  'manage',
+  'principal_kind',
+  'user'
+FROM "entity_types"
+WHERE "entity_types"."name" = 'horton'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "entity_type_permission_grants"
+    WHERE "entity_type_permission_grants"."tenant_id" = "entity_types"."tenant_id"
+      AND "entity_type_permission_grants"."entity_type" = "entity_types"."name"
+      AND "entity_type_permission_grants"."permission" = 'manage'
+      AND "entity_type_permission_grants"."subject_kind" = 'principal_kind'
+      AND "entity_type_permission_grants"."subject_value" = 'user'
+      AND "entity_type_permission_grants"."expires_at" IS NULL
+  );

--- a/packages/agents-server/drizzle/meta/_journal.json
+++ b/packages/agents-server/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1779050000000,
       "tag": "0011_entity_permissions",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1780584581000,
+      "tag": "0012_horton_user_manage_permission",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/agents/src/agents/horton.ts
+++ b/packages/agents/src/agents/horton.ts
@@ -711,6 +711,11 @@ export function registerHorton(
         subject_value: `user`,
         permission: `spawn`,
       },
+      {
+        subject_kind: `principal_kind`,
+        subject_value: `user`,
+        permission: `manage`,
+      },
     ],
     handler: assistantHandler,
   })

--- a/packages/agents/test/builtin-pull-wake-registration.test.ts
+++ b/packages/agents/test/builtin-pull-wake-registration.test.ts
@@ -104,7 +104,7 @@ describe(`BuiltinAgentsServer pull-wake registration`, () => {
     ).toBe(false)
   })
 
-  it(`grants all users spawn permission on built-in entity types`, async () => {
+  it(`grants all users default built-in entity type permissions`, async () => {
     agentsServer = await startRecordingAgentsServer()
     builtinServer = new BuiltinAgentsServer({
       agentServerUrl: agentsServer.url,
@@ -124,6 +124,11 @@ describe(`BuiltinAgentsServer pull-wake registration`, () => {
       subject_kind: `principal_kind`,
       subject_value: `user`,
       permission: `spawn`,
+    })
+    expect(horton?.permission_grants).toContainEqual({
+      subject_kind: `principal_kind`,
+      subject_value: `user`,
+      permission: `manage`,
     })
     expect(worker?.permission_grants).toContainEqual({
       subject_kind: `principal_kind`,


### PR DESCRIPTION
## Motivation

Horton is a built-in entity type that all user principals can spawn by default, but existing default grants did not give those same users manage permission on the Horton type. That made the default built-in type less manageable than intended and left existing servers without the grant after upgrade.

## Changes

- Add a `principal_kind=user` `manage` grant to the built-in Horton registration payload alongside the existing `spawn` grant.
- Add an agents-server migration that backfills a permanent user manage grant for every existing tenant-scoped `horton` entity type when the matching non-expiring grant is missing.
- Update built-in registration coverage to assert Horton includes both default user grants.
- Add a patch changeset for `@electric-ax/agents` and `@electric-ax/agents-server`.