### PR TITLE
fix(agents): grant Worker manage permission to users

### DIFF
--- a/.changeset/worker-user-manage-permission.md
+++ b/.changeset/worker-user-manage-permission.md
@@ -1,0 +1,6 @@
+---
+"@electric-ax/agents": patch
+"@electric-ax/agents-server": patch
+---
+
+Grant all users manage permission on the built-in Worker entity type by default, and backfill existing agents-server installations that already registered Worker without that grant.

--- a/packages/agents-server/drizzle/0013_worker_user_manage_permission.sql
+++ b/packages/agents-server/drizzle/0013_worker_user_manage_permission.sql
@@ -1,0 +1,25 @@
+INSERT INTO "entity_type_permission_grants" (
+  "tenant_id",
+  "entity_type",
+  "permission",
+  "subject_kind",
+  "subject_value"
+)
+SELECT
+  "entity_types"."tenant_id",
+  "entity_types"."name",
+  'manage',
+  'principal_kind',
+  'user'
+FROM "entity_types"
+WHERE "entity_types"."name" = 'worker'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "entity_type_permission_grants"
+    WHERE "entity_type_permission_grants"."tenant_id" = "entity_types"."tenant_id"
+      AND "entity_type_permission_grants"."entity_type" = "entity_types"."name"
+      AND "entity_type_permission_grants"."permission" = 'manage'
+      AND "entity_type_permission_grants"."subject_kind" = 'principal_kind'
+      AND "entity_type_permission_grants"."subject_value" = 'user'
+      AND "entity_type_permission_grants"."expires_at" IS NULL
+  );

--- a/packages/agents-server/drizzle/meta/_journal.json
+++ b/packages/agents-server/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1780584581000,
       "tag": "0012_horton_user_manage_permission",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1780588695000,
+      "tag": "0013_worker_user_manage_permission",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/agents/src/agents/worker.ts
+++ b/packages/agents/src/agents/worker.ts
@@ -308,6 +308,11 @@ export function registerWorker(
         subject_value: `user`,
         permission: `spawn`,
       },
+      {
+        subject_kind: `principal_kind`,
+        subject_value: `user`,
+        permission: `manage`,
+      },
     ],
     async handler(ctx) {
       const args = parseWorkerArgs(ctx.args)

--- a/packages/agents/test/builtin-pull-wake-registration.test.ts
+++ b/packages/agents/test/builtin-pull-wake-registration.test.ts
@@ -135,6 +135,11 @@ describe(`BuiltinAgentsServer pull-wake registration`, () => {
       subject_value: `user`,
       permission: `spawn`,
     })
+    expect(worker?.permission_grants).toContainEqual({
+      subject_kind: `principal_kind`,
+      subject_value: `user`,
+      permission: `manage`,
+    })
   })
 
   it(`registers through tenant path-prefixed server URLs`, async () => {


### PR DESCRIPTION
## Motivation

The Horton default permission fix in #4511 left the built-in Worker type with the same gap: all user principals can spawn Worker by default, but they do not receive manage permission on the Worker entity type. That makes Worker inconsistent with the intended default built-in type permissions and leaves existing servers without the grant after upgrade.

## Changes

- Add a `principal_kind=user` `manage` grant to the built-in Worker registration payload alongside the existing `spawn` grant.
- Add an agents-server migration that backfills a permanent user manage grant for every existing tenant-scoped `worker` entity type when the matching non-expiring grant is missing.
- Update built-in registration coverage to assert Worker includes both default user grants.
- Add a patch changeset for `@electric-ax/agents` and `@electric-ax/agents-server`.