### PR TITLE
feat(sync-service): self-heal stuck replication slot creation

### DIFF
--- a/.changeset/slot-creation-self-heal.md
+++ b/.changeset/slot-creation-self-heal.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Automatically recover sources whose replication slot creation is stuck waiting on a pending transaction, by periodically calling `pg_log_standby_snapshot()`. Previously such sources required a manual restart. When the function is unavailable (PostgreSQL < 14 or missing EXECUTE privilege), Electric falls back to the previous behavior and emits a one-time notice.

--- a/integration-tests/tests/self-heal-stuck-slot-creation.lux
+++ b/integration-tests/tests/self-heal-stuck-slot-creation.lux
@@ -1,0 +1,66 @@
+[doc Verify that Electric automatically unblocks a stuck replication slot creation by forcing a standby snapshot, recovering without a manual restart once the blocking transaction commits, even on an otherwise idle database]
+
+[include _macros.luxinc]
+
+[global pg_container_name=self-heal-stuck-slot__pg]
+
+###
+
+## Start a new Postgres cluster
+[invoke setup_pg]
+
+## Open a transaction that holds an xid, blocking logical slot creation
+[invoke start_psql]
+[shell psql]
+  !BEGIN;
+  ??BEGIN
+
+  !SELECT pg_current_xact_id();
+  ??pg_current_xact_id
+  ??(1 row)
+
+## Start Electric; it should block on slot creation
+[invoke setup_electric_shell_with_tenant "electric_1" "3000"]
+
+[shell electric_1]
+  # Prove replication does NOT start while the transaction is open.
+  -Starting replication from postgres|$fail_pattern
+
+  ??[debug] ReplicationClient step: create_slot
+
+  # This warning is only logged on the first configuration-check tick (~10s), so
+  # give the match enough headroom to avoid a risky-timer warning.
+  [timeout 30]
+  ??[warning] Waiting for the replication connection setup to complete...
+
+## Confirm the service reports "starting" (genuinely blocked, not yet active).
+## Poll rather than sleep+curl so a slow HTTP startup doesn't make this flaky.
+[shell client]
+  [invoke wait-for "curl -X GET http://localhost:3000/v1/health?database_id=integration_test_tenant" "\{\"status\":\"starting\"\}" 10 $PS1]
+
+## Commit the blocking transaction and then keep the database completely idle.
+## On a quiet database Postgres would not emit an XLOG_RUNNING_XACTS record for a
+## long time, so without intervention slot creation would stay stuck. Electric
+## must force a standby snapshot to recover promptly.
+[shell psql]
+  !COMMIT;
+  ??COMMIT
+
+## Verify Electric forced a standby snapshot and then started replicating.
+## The "Forced a standby snapshot" line only appears if the self-heal path ran,
+## so it is the proof of this feature (independent of organic recovery timing).
+[shell electric_1]
+  # Reset the failure pattern before the next match.
+  -$fail_pattern
+
+  # Allow time for the periodic unblock attempt (production check interval is 10s).
+  [timeout 30]
+  ??[debug] Forced a standby snapshot to unblock replication slot creation
+  ??[notice] Starting replication from postgres
+
+## The source becomes healthy and active.
+[shell client]
+  [invoke wait-for "curl -X GET http://localhost:3000/v1/health?database_id=integration_test_tenant" "\{\"status\":\"active\"\}" 10 $PS1]
+
+[cleanup]
+  [invoke teardown]

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -1224,10 +1224,14 @@ defmodule Electric.Connection.Manager do
 
     user_message =
       "Replication slot creation is blocked by a pending transaction. Electric might not be able to " <>
-        "automatically unblock it as soon as the transction commits/rolls back #{reason_prose}. " <>
+        "automatically unblock it as soon as the transaction commits/rolls back #{reason_prose}. " <>
         "Manually restarting the source may be needed once the offending transaction is no longer active."
 
-    dispatch_stack_event({:replication_slot_unblock_unavailable, user_message}, state)
+    # Also log it: stack events are only seen by external subscribers (e.g. the cloud
+    # control plane), so a self-hosted operator watching logs needs this signal too.
+    # Gated once via slot_unblock_notice_sent (see the head clause above).
+    Logger.warning(user_message)
+    dispatch_stack_event({:replication_slot_unblock_unavailable, %{message: user_message}}, state)
     %{state | slot_unblock_notice_sent: true}
   end
 

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -120,7 +120,8 @@ defmodule Electric.Connection.Manager do
       pool_pids: %{admin: nil, snapshot: nil},
       validated_connection_opts: %{replication: nil, pool: nil},
       drop_slot_requested: false,
-      connection_status_check_interval: nil
+      connection_status_check_interval: nil,
+      slot_unblock_notice_sent: false
     ]
   end
 
@@ -131,6 +132,9 @@ defmodule Electric.Connection.Manager do
   alias Electric.StatusMonitor
 
   require Logger
+
+  defguardp admin_pool_available(state)
+            when not is_nil(state.pool_pids.admin) and is_pid(elem(state.pool_pids.admin, 0))
 
   @type status :: :waiting | :starting | :active
 
@@ -145,6 +149,9 @@ defmodule Electric.Connection.Manager do
   @type options :: [option]
 
   @connection_status_check_interval 10_000
+
+  # pg_log_standby_snapshot() is available from PostgreSQL 14.
+  @force_standby_snapshot_min_pg_version 140_000
 
   # Time after establishing replication connection before we consider it successful
   # from a retrying perspective, to allow for setup errors sent over the stream
@@ -366,6 +373,7 @@ defmodule Electric.Connection.Manager do
           state
           | replication_client_pid: pid,
             replication_configuration_blocked_by_pending_transaction: false,
+            slot_unblock_notice_sent: false,
             current_step: {:start_replication_client, :connecting}
         }
 
@@ -567,6 +575,29 @@ defmodule Electric.Connection.Manager do
     {:noreply, state}
   end
 
+  def handle_continue(
+        :unblock_slot_creation,
+        %State{current_step: {:start_replication_client, :configuring_connection}} = state
+      )
+      when admin_pool_available(state) do
+    if is_integer(state.pg_version) and
+         state.pg_version >= @force_standby_snapshot_min_pg_version do
+      pool = pool_name(state.stack_id, :admin)
+
+      case execute_force_standby_snapshot_query(pool) do
+        :ok ->
+          {:noreply, state}
+
+        {:unavailable, reason} ->
+          {:noreply, notify_slot_unblock_unavailable(state, reason)}
+      end
+    else
+      {:noreply, notify_slot_unblock_unavailable(state, :pg_version_too_old)}
+    end
+  end
+
+  def handle_continue(:unblock_slot_creation, state), do: {:noreply, state}
+
   @impl true
   def handle_info(
         {:timeout, tref, {:check_status, :replication_lock}},
@@ -609,7 +640,7 @@ defmodule Electric.Connection.Manager do
         replication_configuration_blocked_by_pending_transaction: true
     }
 
-    {:noreply, state}
+    {:noreply, state, {:continue, :unblock_slot_creation}}
   end
 
   def handle_info({:timeout, tref, {:check_status, _}}, state) do
@@ -1133,6 +1164,48 @@ defmodule Electric.Connection.Manager do
 
   defp pooled_connection_opts(state), do: state.connection_opts
 
+  # Forces Postgres to emit an XLOG_RUNNING_XACTS record so that a logical slot
+  # creation that is waiting for a consistent snapshot can proceed as soon as the
+  # blocking transaction(s) have ended. Returns :ok on success or transient
+  # failure (we'll retry on the next tick), or {:unavailable, code} when the
+  # function cannot be run at all (missing privilege or function).
+  defp execute_force_standby_snapshot_query(pool) do
+    case Postgrex.query(pool, "SELECT pg_log_standby_snapshot()", [], timeout: 5_000) do
+      {:ok, _result} ->
+        Logger.debug("Forced a standby snapshot to unblock replication slot creation")
+        :ok
+
+      {:error, %Postgrex.Error{postgres: %{code: code}}}
+      when code in [:insufficient_privilege, :undefined_function] ->
+        {:unavailable, code}
+
+      {:error, error} ->
+        Logger.warning("Failed to force a standby snapshot: #{inspect(error)}")
+        :ok
+    end
+  catch
+    kind, error ->
+      Logger.warning(
+        "Failed to force a standby snapshot: #{Exception.format(kind, error, __STACKTRACE__)}"
+      )
+
+      :ok
+  end
+
+  defp notify_slot_unblock_unavailable(%State{slot_unblock_notice_sent: true} = state, _reason),
+    do: state
+
+  defp notify_slot_unblock_unavailable(state, reason) do
+    Logger.warning(
+      "Replication slot creation is blocked by a pending transaction and Electric cannot " <>
+        "automatically unblock it (#{reason}). Grant EXECUTE ON FUNCTION pg_log_standby_snapshot() " <>
+        "to Electric's database role (PostgreSQL 14+) so the source can recover without a manual restart."
+    )
+
+    dispatch_stack_event(:replication_slot_unblock_unavailable, state)
+    %{state | slot_unblock_notice_sent: true}
+  end
+
   defp execute_lock_breaker_query(pool, lock_name, pg_backend_pid, database) do
     query = lock_breaker_query(lock_name, pg_backend_pid, database)
 
@@ -1216,9 +1289,6 @@ defmodule Electric.Connection.Manager do
         error
     end
   end
-
-  defguardp admin_pool_available(state)
-            when not is_nil(state.pool_pids.admin) and is_pid(elem(state.pool_pids.admin, 0))
 
   defp drop_publication(state) when not admin_pool_available(state) do
     Logger.warning("Skipping publication drop, pool connection not available")

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -608,7 +608,13 @@ defmodule Electric.Connection.Manager do
         } = state
       ) do
     Logger.warning(fn -> "Waiting for postgres lock to be acquired..." end)
-    tref = schedule_periodic_connection_status_check(:replication_lock, state.connection_status_check_interval)
+
+    tref =
+      schedule_periodic_connection_status_check(
+        :replication_lock,
+        state.connection_status_check_interval
+      )
+
     state = %{state | replication_lock_timer: tref}
     {:noreply, state, {:continue, :check_lock_not_abandoned}}
   end
@@ -632,7 +638,11 @@ defmodule Electric.Connection.Manager do
       dispatch_stack_event(:replication_slot_creation_blocked_by_pending_transactions, state)
     end
 
-    tref = schedule_periodic_connection_status_check(:replication_configuration, state.connection_status_check_interval)
+    tref =
+      schedule_periodic_connection_status_check(
+        :replication_configuration,
+        state.connection_status_check_interval
+      )
 
     state = %{
       state
@@ -724,7 +734,12 @@ defmodule Electric.Connection.Manager do
       ) do
     dispatch_stack_event(:waiting_for_connection_lock, state)
     state = mark_connection_succeeded(state)
-    tref = schedule_periodic_connection_status_check(:replication_lock, state.connection_status_check_interval)
+
+    tref =
+      schedule_periodic_connection_status_check(
+        :replication_lock,
+        state.connection_status_check_interval
+      )
 
     state = %{
       state
@@ -762,7 +777,12 @@ defmodule Electric.Connection.Manager do
       ) do
     Electric.StatusMonitor.mark_pg_lock_acquired(state.stack_id, state.replication_client_pid)
     dispatch_stack_event(:connection_lock_acquired, state)
-    tref = schedule_periodic_connection_status_check(:replication_configuration, state.connection_status_check_interval)
+
+    tref =
+      schedule_periodic_connection_status_check(
+        :replication_configuration,
+        state.connection_status_check_interval
+      )
 
     # Refresh shape metadata now that the lock is acquired and storage is
     # entirely within this service's control

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -119,7 +119,8 @@ defmodule Electric.Connection.Manager do
       # PIDs of the database connection pools
       pool_pids: %{admin: nil, snapshot: nil},
       validated_connection_opts: %{replication: nil, pool: nil},
-      drop_slot_requested: false
+      drop_slot_requested: false,
+      connection_status_check_interval: nil
     ]
   end
 
@@ -295,7 +296,9 @@ defmodule Electric.Connection.Manager do
         persistent_kv: Keyword.fetch!(opts, :persistent_kv),
         manual_table_publishing?: Keyword.get(opts, :manual_table_publishing?, false),
         max_shapes: Keyword.fetch!(opts, :max_shapes),
-        lock_breaker_guard: Keyword.get(opts, :lock_breaker_guard)
+        lock_breaker_guard: Keyword.get(opts, :lock_breaker_guard),
+        connection_status_check_interval:
+          Keyword.get(opts, :connection_status_check_interval, @connection_status_check_interval)
       }
       |> initialize_connection_opts(opts)
 
@@ -574,7 +577,7 @@ defmodule Electric.Connection.Manager do
         } = state
       ) do
     Logger.warning(fn -> "Waiting for postgres lock to be acquired..." end)
-    tref = schedule_periodic_connection_status_check(:replication_lock)
+    tref = schedule_periodic_connection_status_check(:replication_lock, state.connection_status_check_interval)
     state = %{state | replication_lock_timer: tref}
     {:noreply, state, {:continue, :check_lock_not_abandoned}}
   end
@@ -598,7 +601,7 @@ defmodule Electric.Connection.Manager do
       dispatch_stack_event(:replication_slot_creation_blocked_by_pending_transactions, state)
     end
 
-    tref = schedule_periodic_connection_status_check(:replication_configuration)
+    tref = schedule_periodic_connection_status_check(:replication_configuration, state.connection_status_check_interval)
 
     state = %{
       state
@@ -690,7 +693,7 @@ defmodule Electric.Connection.Manager do
       ) do
     dispatch_stack_event(:waiting_for_connection_lock, state)
     state = mark_connection_succeeded(state)
-    tref = schedule_periodic_connection_status_check(:replication_lock)
+    tref = schedule_periodic_connection_status_check(:replication_lock, state.connection_status_check_interval)
 
     state = %{
       state
@@ -728,7 +731,7 @@ defmodule Electric.Connection.Manager do
       ) do
     Electric.StatusMonitor.mark_pg_lock_acquired(state.stack_id, state.replication_client_pid)
     dispatch_stack_event(:connection_lock_acquired, state)
-    tref = schedule_periodic_connection_status_check(:replication_configuration)
+    tref = schedule_periodic_connection_status_check(:replication_configuration, state.connection_status_check_interval)
 
     # Refresh shape metadata now that the lock is acquired and storage is
     # entirely within this service's control
@@ -1279,8 +1282,8 @@ defmodule Electric.Connection.Manager do
       )
   end
 
-  defp schedule_periodic_connection_status_check(type) do
-    :erlang.start_timer(@connection_status_check_interval, self(), {:check_status, type})
+  defp schedule_periodic_connection_status_check(type, interval) do
+    :erlang.start_timer(interval, self(), {:check_status, type})
   end
 
   # It's possible that the exit signal received from an exiting process includes a

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -560,10 +560,9 @@ defmodule Electric.Connection.Manager do
     if lock_breaker_allowed and
          state.current_step == {:start_replication_client, :acquiring_lock} and
          not is_nil(pg_backend_pid) do
-      pool = pool_name(state.stack_id, :admin)
       lock_name = Keyword.fetch!(state.replication_opts, :slot_name)
       database = replication_connection_opts(state)[:database]
-      execute_lock_breaker_query(pool, lock_name, pg_backend_pid, database)
+      execute_lock_breaker_query(admin_pool(state.stack_id), lock_name, pg_backend_pid, database)
     else
       if not lock_breaker_allowed do
         Logger.notice(
@@ -578,25 +577,12 @@ defmodule Electric.Connection.Manager do
   def handle_continue(
         :unblock_slot_creation,
         %State{current_step: {:start_replication_client, :configuring_connection}} = state
-      )
-      when admin_pool_available(state) do
-    if is_integer(state.pg_version) and
-         state.pg_version >= @force_standby_snapshot_min_pg_version do
-      pool = pool_name(state.stack_id, :admin)
-
-      case execute_force_standby_snapshot_query(pool) do
-        :ok ->
-          {:noreply, state}
-
-        {:unavailable, reason} ->
-          {:noreply, notify_slot_unblock_unavailable(state, reason)}
-      end
-    else
-      {:noreply, notify_slot_unblock_unavailable(state, :pg_version_too_old)}
+      ) do
+    case execute_force_standby_snapshot_query(state) do
+      :ok -> {:noreply, state}
+      {:unavailable, reason} -> {:noreply, notify_slot_unblock_unavailable(state, reason)}
     end
   end
-
-  def handle_continue(:unblock_slot_creation, state), do: {:noreply, state}
 
   @impl true
   def handle_info(
@@ -1186,11 +1172,16 @@ defmodule Electric.Connection.Manager do
 
   # Forces Postgres to emit an XLOG_RUNNING_XACTS record so that a logical slot
   # creation that is waiting for a consistent snapshot can proceed as soon as the
-  # blocking transaction(s) have ended. Returns :ok on success or transient
-  # failure (we'll retry on the next tick), or {:unavailable, code} when the
-  # function cannot be run at all (missing privilege or function).
-  defp execute_force_standby_snapshot_query(pool) do
-    case Postgrex.query(pool, "SELECT pg_log_standby_snapshot()", [], timeout: 5_000) do
+  # blocking transaction(s) have ended.
+  defp execute_force_standby_snapshot_query(state)
+       when not is_integer(state.pg_version) or
+              state.pg_version < @force_standby_snapshot_min_pg_version,
+       do: {:unavailable, :pg_version_too_old}
+
+  defp execute_force_standby_snapshot_query(state) when admin_pool_available(state) do
+    case Postgrex.query(admin_pool(state.stack_id), "SELECT pg_log_standby_snapshot()", [],
+           timeout: 5_000
+         ) do
       {:ok, _result} ->
         Logger.debug("Forced a standby snapshot to unblock replication slot creation")
         :ok
@@ -1204,6 +1195,7 @@ defmodule Electric.Connection.Manager do
         :ok
     end
   catch
+    # Guard against potential named process non-existence, checkout timeout or process crashes.
     kind, error ->
       Logger.warning(
         "Failed to force a standby snapshot: #{Exception.format(kind, error, __STACKTRACE__)}"
@@ -1212,17 +1204,30 @@ defmodule Electric.Connection.Manager do
       :ok
   end
 
+  defp execute_force_standby_snapshot_query(_state), do: :ok
+
   defp notify_slot_unblock_unavailable(%State{slot_unblock_notice_sent: true} = state, _reason),
     do: state
 
   defp notify_slot_unblock_unavailable(state, reason) do
-    Logger.warning(
-      "Replication slot creation is blocked by a pending transaction and Electric cannot " <>
-        "automatically unblock it (#{reason}). Grant EXECUTE ON FUNCTION pg_log_standby_snapshot() " <>
-        "to Electric's database role (PostgreSQL 14+) so the source can recover without a manual restart."
-    )
+    reason_prose =
+      case reason do
+        :insufficient_privilege ->
+          "due to the missing EXECUTE ON FUNCTION pg_log_standby_snapshot() privilege"
 
-    dispatch_stack_event(:replication_slot_unblock_unavailable, state)
+        :undefined_function ->
+          "because pg_log_standby_snapshot() is undefined"
+
+        :pg_version_too_old ->
+          "because pg_log_standby_snapshot() is not available in the current PG version"
+      end
+
+    user_message =
+      "Replication slot creation is blocked by a pending transaction. Electric might not be able to " <>
+        "automatically unblock it as soon as the transction commits/rolls back #{reason_prose}. " <>
+        "Manually restarting the source may be needed once the offending transaction is no longer active."
+
+    dispatch_stack_event({:replication_slot_unblock_unavailable, user_message}, state)
     %{state | slot_unblock_notice_sent: true}
   end
 
@@ -1319,9 +1324,12 @@ defmodule Electric.Connection.Manager do
   end
 
   defp drop_publication(state) do
-    pool = pool_name(state.stack_id, :admin)
     publication_name = Keyword.fetch!(state.replication_opts, :publication_name)
-    execute_and_log_errors(pool, "DROP PUBLICATION IF EXISTS #{publication_name}")
+
+    execute_and_log_errors(
+      admin_pool(state.stack_id),
+      "DROP PUBLICATION IF EXISTS #{publication_name}"
+    )
   end
 
   defp drop_slot(state) when not admin_pool_available(state) do
@@ -1329,12 +1337,14 @@ defmodule Electric.Connection.Manager do
   end
 
   defp drop_slot(state) do
-    pool = pool_name(state.stack_id, :admin)
     slot_name = Keyword.fetch!(state.replication_opts, :slot_name)
     slot_temporary? = Keyword.fetch!(state.replication_opts, :slot_temporary?)
 
     if not slot_temporary? do
-      execute_and_log_errors(pool, "SELECT pg_drop_replication_slot('#{slot_name}');")
+      execute_and_log_errors(
+        admin_pool(state.stack_id),
+        "SELECT pg_drop_replication_slot('#{slot_name}');"
+      )
     end
   end
 
@@ -1349,8 +1359,11 @@ defmodule Electric.Connection.Manager do
   end
 
   defp kill_replication_backend(%State{replication_pg_backend_pid: pg_backend_pid} = state) do
-    pool = pool_name(state.stack_id, :admin)
-    execute_and_log_errors(pool, "SELECT pg_terminate_backend(#{pg_backend_pid});")
+    execute_and_log_errors(
+      admin_pool(state.stack_id),
+      "SELECT pg_terminate_backend(#{pg_backend_pid});"
+    )
+
     %{state | replication_pg_backend_pid: nil}
   end
 

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -584,6 +584,11 @@ defmodule Electric.Connection.Manager do
     end
   end
 
+  # Defensive no-op: the only dispatcher of this continue is gated on the
+  # :configuring_connection step, but keep crash-safety if a future caller ever
+  # dispatches it from a different step.
+  def handle_continue(:unblock_slot_creation, state), do: {:noreply, state}
+
   @impl true
   def handle_info(
         {:timeout, tref, {:check_status, :replication_lock}},

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -54,7 +54,8 @@ defmodule Electric.Connection.ConnectionManagerTest do
       max_shapes: nil,
       persistent_kv: ctx.persistent_kv,
       stack_events_registry: stack_events_registry,
-      lock_breaker_guard: ctx[:lock_breaker_guard]
+      lock_breaker_guard: ctx[:lock_breaker_guard],
+      connection_status_check_interval: Map.get(ctx, :connection_status_check_interval, 10_000)
     ]
 
     core_sup =
@@ -79,6 +80,16 @@ defmodule Electric.Connection.ConnectionManagerTest do
     {:ok, socket} = :gen_tcp.listen(0, [])
     {:ok, port} = :inet.port(socket)
     [unresponsive_port: port]
+  end
+
+  describe "connection status check interval" do
+    setup [:start_connection_manager]
+
+    @tag connection_status_check_interval: 50
+    test "is configurable via opts", %{stack_id: stack_id} do
+      manager = stack_id |> Connection.Manager.name() |> GenServer.whereis()
+      assert :sys.get_state(manager).connection_status_check_interval == 50
+    end
   end
 
   describe "status monitor" do

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -141,15 +141,17 @@ defmodule Electric.Connection.ConnectionManagerTest do
       start_connection_manager(ctx)
 
       assert_receive {:stack_status, _,
-                      :replication_slot_creation_blocked_by_pending_transactions},
-                     5_000
+                      :replication_slot_creation_blocked_by_pending_transactions}
 
       # The notice fires once despite many timer ticks (interval = 50 ms).
-      assert_receive {:stack_status, _, :replication_slot_unblock_unavailable}, 5_000
-      refute_receive {:stack_status, _, :replication_slot_unblock_unavailable}, 500
+      assert_receive {:stack_status, _,
+                      {:replication_slot_unblock_unavailable,
+                       "Replication slot creation is blocked by a pending transaction. " <>
+                         "Electric might not be able to automatically unblock it" <> _}}
+
+      refute_receive {:stack_status, _, {:replication_slot_unblock_unavailable, _}}, 200
 
       Postgrex.query!(blocker, "COMMIT", [])
-      GenServer.stop(blocker)
     end
   end
 

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -92,6 +92,67 @@ defmodule Electric.Connection.ConnectionManagerTest do
     end
   end
 
+  describe "self-healing stuck slot creation" do
+    @tag connection_status_check_interval: 50
+    test "emits a one-time notice and keeps waiting when the function is not permitted",
+         %{stack_id: stack_id} = ctx do
+      parent = self()
+
+      # Intercept only the pg_log_standby_snapshot() call (issued from the manager
+      # process); pass every other Postgrex query through unchanged.
+      Repatch.patch(Postgrex, :query, [mode: :shared], fn
+        _pool, "SELECT pg_log_standby_snapshot()", _params, _opts ->
+          {:error,
+           %Postgrex.Error{
+             postgres: %{
+               code: :insufficient_privilege,
+               severity: "ERROR",
+               message: "permission denied"
+             }
+           }}
+
+        pool, query, params, opts ->
+          Repatch.real(Postgrex, :query, [pool, query, params, opts])
+      end)
+
+      # Allowance doesn't follow the supervision tree, so allow the manager process
+      # to see the shared patch as soon as it has started.
+      spawn_link(fn ->
+        Stream.repeatedly(fn -> 0 end)
+        |> Enum.reduce_while(0, fn _, _ ->
+          case GenServer.whereis(Electric.Connection.Manager.name(stack_id)) do
+            nil ->
+              {:cont, 0}
+
+            pid ->
+              Repatch.allow(parent, pid)
+              {:halt, 0}
+          end
+        end)
+      end)
+
+      # Hold an xid-bearing transaction open so CREATE_REPLICATION_SLOT blocks.
+      # db_config carries an obfuscated password, so deobfuscate it like the test
+      # support does before opening a raw connection.
+      {:ok, blocker} = Postgrex.start_link(Electric.Utils.deobfuscate_password(ctx.db_config))
+      Postgrex.query!(blocker, "BEGIN", [])
+      Postgrex.query!(blocker, "SELECT txid_current()", [])
+
+      start_connection_manager(ctx)
+
+      assert_receive {:stack_status, _,
+                      :replication_slot_creation_blocked_by_pending_transactions},
+                     5_000
+
+      # The notice fires once despite many timer ticks (interval = 50 ms).
+      assert_receive {:stack_status, _, :replication_slot_unblock_unavailable}, 5_000
+      refute_receive {:stack_status, _, :replication_slot_unblock_unavailable}, 500
+
+      Postgrex.query!(blocker, "COMMIT", [])
+      GenServer.stop(blocker)
+    end
+  end
+
   describe "status monitor" do
     setup [:start_connection_manager]
 

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -143,12 +143,11 @@ defmodule Electric.Connection.ConnectionManagerTest do
       # Connection bring-up + lock acquisition is the slow, load-sensitive part. Wait for
       # it via StatusMonitor (the source sits at conn: :starting while blocked on slot
       # creation) rather than a multi-second assert_receive, so the assertions below can
-      # use short, reliable timeouts.
+      # use short, default timeouts.
       wait_until_conn_starting(stack_id)
 
       assert_receive {:stack_status, _,
-                      :replication_slot_creation_blocked_by_pending_transactions},
-                     2_000
+                      :replication_slot_creation_blocked_by_pending_transactions}
 
       # The notice fires once despite many timer ticks (interval = 50 ms).
       assert_receive {:stack_status, _,
@@ -158,9 +157,9 @@ defmodule Electric.Connection.ConnectionManagerTest do
                            "Replication slot creation is blocked by a pending transaction. " <>
                              "Electric might not be able to automatically unblock it" <> _
                        }}},
-                     2_000
+                     200
 
-      refute_receive {:stack_status, _, {:replication_slot_unblock_unavailable, _}}, 200
+      refute_receive {:stack_status, _, {:replication_slot_unblock_unavailable, _}}, 400
 
       Postgrex.query!(blocker, "COMMIT", [])
     end

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -140,14 +140,25 @@ defmodule Electric.Connection.ConnectionManagerTest do
 
       start_connection_manager(ctx)
 
+      # Connection bring-up + lock acquisition is the slow, load-sensitive part. Wait for
+      # it via StatusMonitor (the source sits at conn: :starting while blocked on slot
+      # creation) rather than a multi-second assert_receive, so the assertions below can
+      # use short, reliable timeouts.
+      wait_until_conn_starting(stack_id)
+
       assert_receive {:stack_status, _,
-                      :replication_slot_creation_blocked_by_pending_transactions}
+                      :replication_slot_creation_blocked_by_pending_transactions},
+                     2_000
 
       # The notice fires once despite many timer ticks (interval = 50 ms).
       assert_receive {:stack_status, _,
                       {:replication_slot_unblock_unavailable,
-                       "Replication slot creation is blocked by a pending transaction. " <>
-                         "Electric might not be able to automatically unblock it" <> _}}
+                       %{
+                         message:
+                           "Replication slot creation is blocked by a pending transaction. " <>
+                             "Electric might not be able to automatically unblock it" <> _
+                       }}},
+                     2_000
 
       refute_receive {:stack_status, _, {:replication_slot_unblock_unavailable, _}}, 200
 
@@ -721,6 +732,23 @@ defmodule Electric.Connection.ConnectionManagerTest do
     |> Electric.Postgres.ReplicationClient.name()
     |> GenServer.whereis()
     |> Process.monitor()
+  end
+
+  # Polls until the source has acquired its lock and reached the configuring stage
+  # (conn: :starting). StatusMonitor.wait_until/3 only supports :read_only/:active,
+  # which a slot-creation-blocked source never reaches, so we poll the status here.
+  defp wait_until_conn_starting(stack_id, attempts \\ 200)
+
+  defp wait_until_conn_starting(_stack_id, 0),
+    do: flunk("source did not reach conn: :starting in time")
+
+  defp wait_until_conn_starting(stack_id, attempts) do
+    if StatusMonitor.status(stack_id).conn == :starting do
+      :ok
+    else
+      Process.sleep(25)
+      wait_until_conn_starting(stack_id, attempts - 1)
+    end
   end
 
   defp wait_for_pg_backend_pid(manager_pid, attempts \\ 100) do


### PR DESCRIPTION
## Summary

When a source's logical replication slot creation is blocked waiting on pending transactions, Electric now self-heals instead of requiring a manual source restart.

- `Connection.Manager` periodically runs `SELECT pg_log_standby_snapshot()` on the admin pool while slot creation is blocked, so Postgres can emit an `XLOG_RUNNING_XACTS` record and the logical snapshot builder reaches `CONSISTENT` as soon as the blocking transaction ends.
- Piggybacks on the existing `:replication_configuration` status-check timer (it already detects the blocked state and dispatches `:replication_slot_creation_blocked_by_pending_transactions`); mirrors the existing `:check_lock_not_abandoned` admin-pool query pattern.
- Degrades gracefully when the function is unavailable (PostgreSQL < 14 or missing `EXECUTE` privilege): falls back to the previous behavior and emits a one-time `:replication_slot_unblock_unavailable` stack event + warning with remediation.
- Makes the connection-status-check interval configurable so the behavior can be tested deterministically and fast.

## Background

From an SRE investigation of a customer ("Ajax") with repeated source-inactivity incidents: a long-running transaction pins the slot's `restart_lsn`, retained WAL grows past `max_slot_wal_keep_size` (4 GB) and Postgres invalidates the slot. Recreating the slot then blocks on the same transaction — and on an otherwise-idle database, Postgres does not emit a fresh `XLOG_RUNNING_XACTS` record for a long time after the transaction commits, so the source stays stuck until someone restarts it. `pg_log_standby_snapshot()` forces that record on demand, making recovery automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
