### PR TITLE
Preserve Cloud auth dispatcher when enabling fetch cache

### DIFF
--- a/.changeset/fix-desktop-cloud-auth-dispatcher.md
+++ b/.changeset/fix-desktop-cloud-auth-dispatcher.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents": patch
+---
+
+Preserve existing undici global dispatcher interceptors when installing the Durable Streams fetch cache so Electric Agents Desktop keeps injecting Cloud auth headers after the built-in agents runtime starts.

--- a/packages/agents/src/durable-streams-cache.ts
+++ b/packages/agents/src/durable-streams-cache.ts
@@ -1,4 +1,9 @@
-import { Agent, cacheStores, interceptors, setGlobalDispatcher } from 'undici'
+import {
+  cacheStores,
+  getGlobalDispatcher,
+  interceptors,
+  setGlobalDispatcher,
+} from 'undici'
 
 const MEMORY_CACHE_SIZE_BYTES = 100 * 1024 * 1024
 
@@ -25,8 +30,13 @@ export function installDurableStreamsFetchCache(
           maxSize: MEMORY_CACHE_SIZE_BYTES,
         })
 
+  // Compose on top of the current global dispatcher instead of replacing it.
+  // Electric Agents Desktop installs its Cloud auth injector as a global
+  // dispatcher interceptor before starting the built-in agents runtime; using a
+  // fresh Agent() here drops that auth injector and Cloud requests start
+  // failing with 401 Missing bearer token.
   setGlobalDispatcher(
-    new Agent().compose(
+    getGlobalDispatcher().compose(
       interceptors.cache({
         store,
       })

--- a/packages/agents/test/durable-streams-cache.test.ts
+++ b/packages/agents/test/durable-streams-cache.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const compose = vi.fn()
+const getGlobalDispatcher = vi.fn()
+const setGlobalDispatcher = vi.fn()
+const cacheInterceptor = vi.fn()
+const memoryStore = { kind: `memory-store` }
+const sqliteStore = { kind: `sqlite-store` }
+const MemoryCacheStore = vi.fn(function MemoryCacheStore() {
+  return memoryStore
+})
+const SqliteCacheStore = vi.fn(function SqliteCacheStore() {
+  return sqliteStore
+})
+
+vi.mock(`undici`, () => ({
+  cacheStores: {
+    MemoryCacheStore,
+    SqliteCacheStore,
+  },
+  getGlobalDispatcher,
+  interceptors: {
+    cache: cacheInterceptor,
+  },
+  setGlobalDispatcher,
+}))
+
+describe(`installDurableStreamsFetchCache`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    compose.mockReturnValue(`composed-dispatcher`)
+    getGlobalDispatcher.mockReturnValue({ compose })
+    cacheInterceptor.mockReturnValue(`cache-interceptor`)
+  })
+
+  test(`composes cache interceptor on the existing global dispatcher`, async () => {
+    const { installDurableStreamsFetchCache } = await import(
+      `../src/durable-streams-cache.js`
+    )
+
+    installDurableStreamsFetchCache()
+
+    expect(getGlobalDispatcher).toHaveBeenCalledTimes(1)
+    expect(cacheInterceptor).toHaveBeenCalledWith({ store: memoryStore })
+    expect(compose).toHaveBeenCalledWith(`cache-interceptor`)
+    expect(setGlobalDispatcher).toHaveBeenCalledWith(`composed-dispatcher`)
+  })
+})


### PR DESCRIPTION
## Summary
- compose the Durable Streams fetch cache on top of the existing undici global dispatcher instead of replacing it
- preserve Electric Agents Desktop's Cloud auth header injector after the built-in agents runtime starts
- add a regression test for dispatcher composition

## Testing
- pnpm --filter @electric-ax/agents test test/durable-streams-cache.test.ts
- pnpm --filter @electric-ax/agents typecheck
- pnpm --filter @electric-ax/agents build

## Notes
Debugging showed Cloud setup succeeded, but after the built-in agents runtime installed the Durable Streams cache, subsequent Cloud requests lost Authorization and returned 401 {"error":"Missing bearer token"}.