### PR TITLE
feat(agents-desktop): UI improvements

### DIFF
--- a/.changeset/fuzzy-agents-ui.md
+++ b/.changeset/fuzzy-agents-ui.md
@@ -1,0 +1,7 @@
+---
+"@electric-ax/agents-server-ui": patch
+---
+
+Polish the agents UI with improved spawn-form model controls, tooltips,
+macOS sidebar vibrancy styling, select sizing fixes, and a response-footer
+fork action in the timeline.

--- a/packages/agents-server-ui/src/components/AgentResponse.module.css
+++ b/packages/agents-server-ui/src/components/AgentResponse.module.css
@@ -36,6 +36,10 @@
   gap: 2px;
 }
 
+.tooltipTrigger {
+  display: inline-flex;
+}
+
 .metaActionButton {
   color: var(--ds-text-4);
   opacity: 0.7;

--- a/packages/agents-server-ui/src/components/AgentResponse.module.css
+++ b/packages/agents-server-ui/src/components/AgentResponse.module.css
@@ -29,12 +29,18 @@
   width: 100%;
 }
 
-.copyButton {
+.metaActions {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.metaActionButton {
   color: var(--ds-text-4);
   opacity: 0.7;
 }
 
-.copyButton:hover {
+.metaActionButton:hover {
   opacity: 1;
 }

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -578,18 +578,20 @@ function ResponseMetaActions({
     <span className={styles.metaActions}>
       {showFork && (
         <Tooltip content={forkLabel} side="top">
-          <IconButton
-            size={1}
-            variant="ghost"
-            tone="neutral"
-            className={styles.metaActionButton}
-            disabled={forkDisabled}
-            onClick={forkFromHere?.onFork}
-            aria-label="Fork from here"
-            title={forkLabel}
-          >
-            <Icon icon={GitFork} size={1} />
-          </IconButton>
+          <span className={styles.tooltipTrigger}>
+            <IconButton
+              size={1}
+              variant="ghost"
+              tone="neutral"
+              className={styles.metaActionButton}
+              disabled={forkDisabled}
+              onClick={forkFromHere?.onFork}
+              aria-label="Fork from here"
+              title={forkLabel}
+            >
+              <Icon icon={GitFork} size={1} />
+            </IconButton>
+          </span>
         </Tooltip>
       )}
       {showCopy && (

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy } from 'lucide-react'
+import { Check, Copy, GitFork } from 'lucide-react'
 import {
   memo,
   useEffect,
@@ -28,6 +28,7 @@ import { ThinkingIndicator } from './ThinkingIndicator'
 import { ElapsedTime } from './ElapsedTime'
 import { formatElapsedDuration, toMillis } from '../lib/formatTime'
 import styles from './AgentResponse.module.css'
+import type { ForkFromHereAction } from './UserMessage'
 import type {
   EntityTimelineContentItem,
   EntityTimelineRunRow,
@@ -383,6 +384,7 @@ export const AgentResponseLive = memo(function AgentResponseLive({
   isStreaming,
   timestamp,
   renderWidth = 0,
+  forkFromHere,
   onSearchTextChange,
 }: {
   rowKey: string
@@ -390,6 +392,7 @@ export const AgentResponseLive = memo(function AgentResponseLive({
   isStreaming: boolean
   timestamp?: number | null
   renderWidth?: number
+  forkFromHere?: ForkFromHereAction
   onSearchTextChange?: (rowKey: string, text: string) => void
 }): React.ReactElement {
   const { data: items = [] } = useLiveQuery(
@@ -433,6 +436,7 @@ export const AgentResponseLive = memo(function AgentResponseLive({
     isStreaming && !done && !failureText && !lastTextHasContent
   const showTimestamp = timestamp != null && !isStreaming
   const hasLeadingMeta = showThinking || done || Boolean(failureText)
+  const showCopyAction = Boolean((done || failureText) && copyText)
   const [copied, setCopied] = useState(false)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -542,39 +546,86 @@ export const AgentResponseLive = memo(function AgentResponseLive({
             <TimeText ts={timestamp} className={styles.timeText} />
           </>
         )}
-        {(done || failureText) && copyText && (
-          <Tooltip content={copied ? `Copied!` : `Copy response`} side="top">
-            <IconButton
-              size={1}
-              variant="ghost"
-              tone="neutral"
-              className={styles.copyButton}
-              onClick={() => void copyResponseText()}
-              aria-label="Copy response text"
-            >
-              {copied ? (
-                <Icon icon={Check} size={1} />
-              ) : (
-                <Icon icon={Copy} size={1} />
-              )}
-            </IconButton>
-          </Tooltip>
-        )}
+        <ResponseMetaActions
+          showCopy={showCopyAction}
+          copied={copied}
+          onCopy={() => void copyResponseText()}
+          forkFromHere={done ? forkFromHere : undefined}
+        />
       </Stack>
     </Stack>
   )
 })
+
+function ResponseMetaActions({
+  showCopy,
+  copied,
+  onCopy,
+  forkFromHere,
+}: {
+  showCopy: boolean
+  copied: boolean
+  onCopy: () => void
+  forkFromHere?: ForkFromHereAction
+}): React.ReactElement | null {
+  const showFork = forkFromHere !== undefined
+  if (!showCopy && !showFork) return null
+
+  const forkDisabled = forkFromHere?.disabled === true || !forkFromHere?.onFork
+  const forkLabel = forkDisabled ? `Fork permission required` : `Fork from here`
+
+  return (
+    <span className={styles.metaActions}>
+      {showFork && (
+        <Tooltip content={forkLabel} side="top">
+          <IconButton
+            size={1}
+            variant="ghost"
+            tone="neutral"
+            className={styles.metaActionButton}
+            disabled={forkDisabled}
+            onClick={forkFromHere?.onFork}
+            aria-label="Fork from here"
+            title={forkLabel}
+          >
+            <Icon icon={GitFork} size={1} />
+          </IconButton>
+        </Tooltip>
+      )}
+      {showCopy && (
+        <Tooltip content={copied ? `Copied!` : `Copy response`} side="top">
+          <IconButton
+            size={1}
+            variant="ghost"
+            tone="neutral"
+            className={styles.metaActionButton}
+            onClick={onCopy}
+            aria-label="Copy response text"
+          >
+            {copied ? (
+              <Icon icon={Check} size={1} />
+            ) : (
+              <Icon icon={Copy} size={1} />
+            )}
+          </IconButton>
+        </Tooltip>
+      )}
+    </span>
+  )
+}
 
 export const AgentResponse = memo(function AgentResponse({
   section,
   isStreaming,
   timestamp,
   renderWidth = 0,
+  forkFromHere,
 }: {
   section: AgentResponseSection
   isStreaming: boolean
   timestamp?: number | null
   renderWidth?: number
+  forkFromHere?: ForkFromHereAction
 }): React.ReactElement {
   const canCache = !isStreaming && section.done === true
   const [copied, setCopied] = useState(false)
@@ -616,6 +667,7 @@ export const AgentResponse = memo(function AgentResponse({
     isStreaming && !section.done && !section.error && !lastTextHasContent
   const showTimestamp = timestamp != null && !isStreaming
   const hasLeadingMeta = showThinking || section.done || Boolean(section.error)
+  const showCopyAction = Boolean(section.done && copyText)
 
   // Mirror of the `sawStreamingRef` / `finalDurationMs` capture from
   // `AgentResponseLive` — see the comment there for why we only
@@ -696,36 +748,12 @@ export const AgentResponse = memo(function AgentResponse({
             <TimeText ts={timestamp} className={styles.timeText} />
           </>
         )}
-        {section.done && copyText && (
-          <Tooltip content={copied ? `Copied!` : `Copy response`} side="top">
-            <IconButton
-              size={1}
-              variant="ghost"
-              tone="neutral"
-              className={styles.copyButton}
-              onClick={() => void copyResponseText()}
-              aria-label="Copy response text"
-            >
-              {copied ? (
-                <Icon icon={Check} size={1} />
-              ) : (
-                <Icon icon={Copy} size={1} />
-              )}
-            </IconButton>
-          </Tooltip>
-        )}
-        {section.done && copyText && (
-          <button
-            type="button"
-            className={styles.copyButton}
-            onClick={() => void copyResponseText()}
-            aria-label="Copy response text"
-            title={copied ? `Copied` : `Copy all response text`}
-          >
-            {copied ? <Check size={12} /> : <Copy size={12} />}
-            <span>{copied ? `Copied` : `Copy`}</span>
-          </button>
-        )}
+        <ResponseMetaActions
+          showCopy={showCopyAction}
+          copied={copied}
+          onCopy={() => void copyResponseText()}
+          forkFromHere={section.done ? forkFromHere : undefined}
+        />
       </Stack>
     </Stack>
   )

--- a/packages/agents-server-ui/src/components/AttachmentDrafts.tsx
+++ b/packages/agents-server-ui/src/components/AttachmentDrafts.tsx
@@ -7,7 +7,7 @@ import {
   X,
 } from 'lucide-react'
 import { formatAttachmentSize } from '../lib/attachments'
-import { Icon, Menu, Text } from '../ui'
+import { Icon, Menu, Text, Tooltip } from '../ui'
 import styles from './AttachmentDrafts.module.css'
 
 type Focusable = {
@@ -294,17 +294,22 @@ export function AttachmentActionMenu({
       />
       <Menu.Root>
         <Menu.Trigger
-          render={
-            <button
-              type="button"
-              aria-label="Message actions"
-              title="Message actions"
-              className={styles.addMenuTrigger}
-              disabled={disabled}
-            >
-              <Icon icon={Plus} size={2} />
-            </button>
-          }
+          disabled={disabled}
+          render={(triggerProps) => (
+            <Tooltip content="Attach files" side="top" align="start">
+              <button
+                {...triggerProps}
+                type="button"
+                aria-label="Message actions"
+                className={[triggerProps.className, styles.addMenuTrigger]
+                  .filter(Boolean)
+                  .join(` `)}
+                disabled={disabled}
+              >
+                <Icon icon={Plus} size={2} />
+              </button>
+            </Tooltip>
+          )}
         />
         <Menu.Content side="top" align="start" sideOffset={8}>
           <Menu.Item disabled={disabled} onSelect={onAttach}>

--- a/packages/agents-server-ui/src/components/EntityTimeline.tsx
+++ b/packages/agents-server-ui/src/components/EntityTimeline.tsx
@@ -933,8 +933,9 @@ const TimelineRow = memo(function TimelineRow({
   stopUserMessageKey: string | null
   stopPending: boolean
   onStopGeneration?: () => void
-  /** When set on a user-message row, enables the "Fork from here" hover
-   * button. Caller pre-resolved the pointer; we just invoke. */
+  /** When set on a completed run row, shows the always-visible
+   * "Fork from here" footer action. Caller pre-resolved the pointer;
+   * we just invoke. */
   onForkFromHere?: ForkFromHereAction
   onRunSearchTextChange: (rowKey: string, text: string) => void
 }): React.ReactElement {
@@ -960,7 +961,6 @@ const TimelineRow = memo(function TimelineRow({
         }
         stopPending={stopPending}
         onStop={onStopGeneration}
-        forkFromHere={onForkFromHere}
       />
     )
   }
@@ -1004,6 +1004,7 @@ const TimelineRow = memo(function TimelineRow({
       isStreaming={!entityStopped && isStreaming}
       timestamp={responseTimestamp}
       renderWidth={renderWidth}
+      forkFromHere={onForkFromHere}
       onSearchTextChange={onRunSearchTextChange}
     />
   )
@@ -1022,7 +1023,7 @@ export function EntityTimeline({
   scrollToBottomSignal = 0,
   stopPending = false,
   onStopGeneration,
-  forkFromHereByInboxKey,
+  forkFromHereByRunKey,
 }: {
   rows: Array<EntityTimelineQueryRow>
   loading: boolean
@@ -1037,12 +1038,12 @@ export function EntityTimeline({
   stopPending?: boolean
   onStopGeneration?: () => void
   /**
-   * Per-inbox-row click handlers for the "Fork from here" hover button.
+   * Per-run-row click handlers for the "Fork from here" footer button.
    * The map is keyed by the row's `$key`; rows not in the map (or when
    * the prop is omitted) get no fork affordance. The caller resolves
    * the fork pointer and runs the fork → navigate flow.
    */
-  forkFromHereByInboxKey?: Map<string, ForkFromHereAction>
+  forkFromHereByRunKey?: Map<string, ForkFromHereAction>
 }): React.ReactElement {
   const { entitiesCollection, runnersCollection, usersCollection } =
     useElectricAgents()
@@ -1745,7 +1746,7 @@ export function EntityTimeline({
                         stopUserMessageKey={stopUserMessageKey}
                         stopPending={stopPending}
                         onStopGeneration={onStopGeneration}
-                        onForkFromHere={forkFromHereByInboxKey?.get(rowKey)}
+                        onForkFromHere={forkFromHereByRunKey?.get(rowKey)}
                         onRunSearchTextChange={updateRunSearchText}
                       />
                     </TimelineRowErrorBoundary>

--- a/packages/agents-server-ui/src/components/MessageInput.module.css
+++ b/packages/agents-server-ui/src/components/MessageInput.module.css
@@ -359,6 +359,10 @@
   line-height: var(--ds-text-xs-lh);
 }
 
+.tooltipTrigger {
+  display: inline-flex;
+}
+
 .composerSend {
   all: unset;
   display: inline-flex;

--- a/packages/agents-server-ui/src/components/MessageInput.tsx
+++ b/packages/agents-server-ui/src/components/MessageInput.tsx
@@ -11,7 +11,7 @@ import {
 } from '../lib/sendMessage'
 import { ComposerEditor, serializeComposerInput } from './ComposerEditor'
 import { ComposerShell } from './ComposerShell'
-import { Icon, Stack, Text } from '../ui'
+import { Icon, Stack, Text, Tooltip } from '../ui'
 import {
   AttachmentActionMenu,
   AttachmentPreviewTray,
@@ -295,7 +295,11 @@ export function MessageInput({
   )
 
   const isButtonActive = canSubmit || (showStop && !stopDisabled)
-
+  const sendTooltip = showStop
+    ? stopDisabled
+      ? `Signal permission required`
+      : `Stop generating`
+    : `Send message`
   return (
     <Stack direction="column" gap={0} className={styles.root}>
       {drawer?.({
@@ -355,43 +359,42 @@ export function MessageInput({
           ) : null
         }
         send={
-          <button
-            type="button"
-            aria-label={showStop ? `Stop generating` : `Send message`}
-            title={
-              showStop
-                ? stopDisabled
-                  ? `Signal permission required`
-                  : `Stop generating`
-                : `Send message`
-            }
-            // Keep the textarea focused when the user taps Send on a
-            // touch device. Without this, tapping the button blurs the
-            // textarea, dismisses the on-screen keyboard, and the
-            // viewport reflows between pointerdown and pointerup — the
-            // resulting `click` lands on a different element and the
-            // send never fires. `preventDefault` here skips the implicit
-            // focus transfer; the `click` still dispatches normally.
-            onPointerDown={(e) => {
-              if (e.pointerType !== `mouse`) e.preventDefault()
-            }}
-            onClick={handleComposerAction}
-            disabled={showStop ? !canStop : !isButtonActive}
-            className={[
-              styles.composerSend,
-              isButtonActive ? styles.active : null,
-              showStop ? styles.stop : null,
-              stopPending && showStop ? styles.stopPending : null,
-            ]
-              .filter(Boolean)
-              .join(` `)}
-          >
-            <Icon
-              icon={showStop ? Square : ArrowUp}
-              size={showStop ? 2 : 3}
-              {...(showStop ? { fill: `currentColor`, strokeWidth: 0 } : {})}
-            />
-          </button>
+          <Tooltip content={sendTooltip} side="top">
+            <span className={styles.tooltipTrigger}>
+              <button
+                type="button"
+                aria-label={showStop ? `Stop generating` : `Send message`}
+                // Keep the textarea focused when the user taps Send on a
+                // touch device. Without this, tapping the button blurs the
+                // textarea, dismisses the on-screen keyboard, and the
+                // viewport reflows between pointerdown and pointerup — the
+                // resulting `click` lands on a different element and the
+                // send never fires. `preventDefault` here skips the implicit
+                // focus transfer; the `click` still dispatches normally.
+                onPointerDown={(e) => {
+                  if (e.pointerType !== `mouse`) e.preventDefault()
+                }}
+                onClick={handleComposerAction}
+                disabled={showStop ? !canStop : !isButtonActive}
+                className={[
+                  styles.composerSend,
+                  isButtonActive ? styles.active : null,
+                  showStop ? styles.stop : null,
+                  stopPending && showStop ? styles.stopPending : null,
+                ]
+                  .filter(Boolean)
+                  .join(` `)}
+              >
+                <Icon
+                  icon={showStop ? Square : ArrowUp}
+                  size={showStop ? 2 : 3}
+                  {...(showStop
+                    ? { fill: `currentColor`, strokeWidth: 0 }
+                    : {})}
+                />
+              </button>
+            </span>
+          </Tooltip>
         }
       >
         <ComposerEditor

--- a/packages/agents-server-ui/src/components/NewSessionPage.module.css
+++ b/packages/agents-server-ui/src/components/NewSessionPage.module.css
@@ -362,6 +362,109 @@
 .pillButtonActive:hover {
   background: var(--ds-accent-a4);
 }
+
+.modelSettingsTrigger {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: min(320px, 100%);
+  height: 24px;
+  padding: 0 8px;
+  border-radius: var(--ds-radius-2);
+  font-size: var(--ds-text-xs);
+  line-height: 1.35;
+  font-family: var(--ds-font-body);
+  background: var(--ds-chip-bg);
+  color: var(--ds-text-1);
+  cursor: pointer;
+  outline: none;
+  box-sizing: border-box;
+  transition:
+    background 100ms ease,
+    color 100ms ease;
+}
+.modelSettingsTrigger:hover:not(:disabled),
+.modelSettingsTrigger[data-popup-open] {
+  background: var(--ds-bg-hover);
+}
+.modelSettingsTrigger:focus-visible {
+  box-shadow: 0 0 0 1px var(--ds-accent-9);
+}
+.modelSettingsTrigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.modelSettingsTriggerModel,
+.modelSettingsTriggerMeta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.35;
+}
+.modelSettingsTriggerModel {
+  flex: 1 1 auto;
+  color: var(--ds-text-1);
+}
+.modelSettingsTriggerMeta {
+  flex: 0 0 auto;
+  max-width: 80px;
+  color: var(--ds-text-3);
+}
+.modelSettingsMenu {
+  min-width: 220px;
+}
+.modelSettingsModelMenu {
+  min-width: 260px;
+  max-height: min(60vh, 360px);
+  overflow: auto;
+}
+.modelSettingsSubmenuTrigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: var(--ds-row-height-md);
+  padding: 3px 3px 3px 8px;
+  border-radius: var(--ds-radius-item);
+  font-size: var(--ds-text-sm);
+  line-height: 1.3;
+  font-family: var(--ds-font-body);
+  color: var(--ds-text-1);
+  cursor: pointer;
+  outline: none;
+  user-select: none;
+  text-align: start;
+  width: 100%;
+  box-sizing: border-box;
+}
+.modelSettingsSubmenuTrigger[data-highlighted] {
+  background: var(--ds-bg-hover);
+}
+.modelSettingsSubmenuValue {
+  min-width: 0;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-left: auto;
+  color: var(--ds-text-3);
+}
+.modelSettingsChevron {
+  flex-shrink: 0;
+  color: var(--ds-text-3);
+}
+.modelSettingsItemLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.modelSettingsActiveMark {
+  margin-left: auto;
+  margin-right: 5px;
+  color: var(--ds-text-2);
+}
 .composerSend {
   all: unset;
   display: inline-flex;

--- a/packages/agents-server-ui/src/components/NewSessionPage.module.css
+++ b/packages/agents-server-ui/src/components/NewSessionPage.module.css
@@ -465,6 +465,11 @@
   margin-right: 5px;
   color: var(--ds-text-2);
 }
+
+.tooltipTrigger {
+  display: inline-flex;
+}
+
 .composerSend {
   all: unset;
   display: inline-flex;

--- a/packages/agents-server-ui/src/components/Sidebar.module.css
+++ b/packages/agents-server-ui/src/components/Sidebar.module.css
@@ -12,6 +12,17 @@
   display: none;
 }
 
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .root::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: transparent;
+  -webkit-backdrop-filter: var(--ds-chrome-backdrop-filter);
+  backdrop-filter: var(--ds-chrome-backdrop-filter);
+}
+
 .root[data-resizing='true'] {
   transition: none;
 }
@@ -204,10 +215,15 @@
   left: 0;
   right: 0;
   height: 1px;
-  background: var(--ds-divider);
+  background: var(--ds-sidebar-divider);
 }
 .topDivider[data-visible='true'] {
   opacity: 1;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .topDivider::before {
+  mix-blend-mode: var(--ds-sidebar-divider-blend-mode);
 }
 
 /* Inner column wrapping the new-session row + session list.
@@ -265,6 +281,52 @@
 .newSessionRowSelected,
 .newSessionRowSelected:hover {
   background: var(--ds-accent-a3);
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .newSessionRow {
+  overflow: hidden;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .newSessionRow::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  background: transparent;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  transition: opacity 0.08s ease;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .newSessionRow:hover,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .newSessionRowSelected,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .newSessionRowSelected:hover {
+  background: transparent;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .newSessionRow:hover::before {
+  opacity: 1;
+  background: var(--ds-sidebar-item-hover-bg);
+  -webkit-backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .newSessionRowSelected::before,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .newSessionRowSelected:hover::before {
+  opacity: 1;
+  background: var(--ds-sidebar-item-active-bg);
+  -webkit-backdrop-filter: var(--ds-sidebar-item-active-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-active-backdrop-filter);
 }
 /* Same 22px slot, same 16px glyph and the SAME `--ds-text-1` colour
    as the sidebar/search IconButtons in SidebarHeader so the three

--- a/packages/agents-server-ui/src/components/SidebarFooter.module.css
+++ b/packages/agents-server-ui/src/components/SidebarFooter.module.css
@@ -6,6 +6,24 @@
   align-items: center;
   gap: 4px;
   padding: 8px;
-  border-top: 1px solid var(--ds-divider);
+  border-top: 1px solid var(--ds-sidebar-divider);
   flex-shrink: 0;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .footer {
+  border-top-color: transparent;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .footer::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 0;
+  right: 0;
+  height: 1px;
+  pointer-events: none;
+  background: var(--ds-sidebar-divider);
+  mix-blend-mode: var(--ds-sidebar-divider-blend-mode);
 }

--- a/packages/agents-server-ui/src/components/SidebarFooter.tsx
+++ b/packages/agents-server-ui/src/components/SidebarFooter.tsx
@@ -17,7 +17,7 @@ import styles from './SidebarFooter.module.css'
  */
 export function SidebarFooter(): React.ReactElement {
   return (
-    <div className={styles.footer}>
+    <div className={styles.footer} data-sidebar-control-surface="true">
       <ServerPicker />
       <SidebarViewMenu />
       <SettingsMenu />

--- a/packages/agents-server-ui/src/components/SidebarRow.module.css
+++ b/packages/agents-server-ui/src/components/SidebarRow.module.css
@@ -41,6 +41,52 @@
 .selected:hover {
   background: var(--ds-accent-a3);
 }
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .row {
+  overflow: hidden;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .row::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  background: transparent;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  transition: opacity 0.08s ease;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .row:hover,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .selected,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .selected:hover {
+  background: transparent;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .row:hover::before {
+  opacity: 1;
+  background: var(--ds-sidebar-item-hover-bg);
+  -webkit-backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .selected::before,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .selected:hover::before {
+  opacity: 1;
+  background: var(--ds-sidebar-item-active-bg);
+  -webkit-backdrop-filter: var(--ds-sidebar-item-active-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-active-backdrop-filter);
+}
 .stopped {
   opacity: 0.55;
 }
@@ -80,6 +126,54 @@
 .pinBtn:hover {
   background: var(--ds-gray-a4);
   color: var(--ds-text-1);
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .pinBtn,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .expandOverlay,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .expandBtnVisible {
+  overflow: hidden;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .pinBtn::before,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .expandOverlay::before,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .expandBtnVisible::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  background: transparent;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  transition: opacity 0.08s ease;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .pinBtn:hover,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .expandOverlay:hover,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .expandBtnVisible:hover {
+  background: transparent;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .pinBtn:hover::before,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .expandOverlay:hover::before,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .expandBtnVisible:hover::before {
+  opacity: 1;
+  background: var(--ds-sidebar-item-hover-bg);
+  -webkit-backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
 }
 /* Pin button is hover-only — even for already-pinned rows. The
    status dot stays visible at rest so the user can still see the
@@ -235,6 +329,7 @@
    count and just leave a permanent down-chevron the user can click
    to collapse. */
 .expandBtnVisible {
+  position: relative;
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;

--- a/packages/agents-server-ui/src/components/TitlebarControls.tsx
+++ b/packages/agents-server-ui/src/components/TitlebarControls.tsx
@@ -18,7 +18,7 @@ export function TitlebarControls(): React.ReactElement {
   const search = useSearchPalette()
 
   return (
-    <div className={styles.controls}>
+    <div className={styles.controls} data-sidebar-control-surface="true">
       <Tooltip
         content={collapsed ? `Show sidebar` : `Hide sidebar`}
         shortcut={modKeyLabel(`b`)}

--- a/packages/agents-server-ui/src/components/UserMessage.module.css
+++ b/packages/agents-server-ui/src/components/UserMessage.module.css
@@ -25,59 +25,6 @@
   padding-right: 44px;
 }
 
-/* "Fork from here" hover-revealed button. Sits in the same top-right
- * slot as `.stopButton`, but they're mutually exclusive: while a run is
- * generating we show stop; otherwise (eligible messages) we show fork.
- * Opacity-toggled rather than display-toggled so the layout doesn't
- * shift on hover. Always visible to keyboard users via :focus-within. */
-.forkButton {
-  all: unset;
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: var(--ds-radius-full);
-  background: var(--ds-gray-a3);
-  color: var(--ds-gray-12);
-  cursor: pointer;
-  opacity: 0;
-  transition:
-    opacity 0.12s ease,
-    background 0.12s ease;
-}
-
-.bubble:hover .forkButton,
-.bubble:focus-within .forkButton,
-.forkButton:focus-visible {
-  opacity: 1;
-}
-
-:global(html[data-electric-mobile-dom='true']) .forkButton {
-  opacity: 1;
-}
-
-.forkButton:hover {
-  background: var(--ds-gray-a4);
-}
-
-.forkButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.forkButton:disabled:hover {
-  background: var(--ds-gray-a3);
-}
-
-.forkButton:focus-visible {
-  outline: 2px solid var(--ds-accent-a6);
-  outline-offset: 2px;
-}
-
 .stopButton {
   all: unset;
   position: absolute;

--- a/packages/agents-server-ui/src/components/UserMessage.tsx
+++ b/packages/agents-server-ui/src/components/UserMessage.tsx
@@ -3,7 +3,6 @@ import { Streamdown } from 'streamdown'
 import {
   Download,
   File as FileIcon,
-  GitFork,
   Image as ImageIcon,
   Square,
 } from 'lucide-react'
@@ -50,7 +49,6 @@ export const UserMessage = memo(function UserMessage({
   currentPrincipal,
   usersById,
   onStop,
-  forkFromHere,
 }: {
   section: UserMessageSection
   attachments?: Array<UserMessageAttachment>
@@ -59,17 +57,8 @@ export const UserMessage = memo(function UserMessage({
   currentPrincipal?: string
   usersById?: Map<string, ElectricUser>
   onStop?: () => void
-  /**
-   * When provided, renders a hover-revealed "Fork from here" button on
-   * the bubble. The caller is responsible for eligibility — pass
-   * `undefined` for messages where no preceding completed run anchors a
-   * fork.
-   */
-  forkFromHere?: ForkFromHereAction
 }): React.ReactElement {
   const sender = formatSender(section.from, { currentPrincipal, usersById })
-  const showFork = !showStop && forkFromHere !== undefined
-  const forkDisabled = forkFromHere?.disabled === true || !forkFromHere?.onFork
 
   return (
     <Stack
@@ -100,22 +89,6 @@ export const UserMessage = memo(function UserMessage({
             onClick={onStop}
           >
             <Icon icon={Square} size={2} fill="currentColor" strokeWidth={0} />
-          </button>
-        )}
-        {showFork && (
-          <button
-            type="button"
-            aria-label="Fork from here"
-            title={
-              forkDisabled
-                ? `Fork permission required`
-                : `Fork from here — re-roll the conversation starting at this message`
-            }
-            className={styles.forkButton}
-            disabled={forkDisabled}
-            onClick={forkFromHere?.onFork}
-          >
-            <Icon icon={GitFork} size={2} />
           </button>
         )}
         {attachments.length > 0 && (

--- a/packages/agents-server-ui/src/components/WorkingDirectoryPicker.tsx
+++ b/packages/agents-server-ui/src/components/WorkingDirectoryPicker.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { Check, Folder, FolderOpen, Home, X } from 'lucide-react'
-import { Combobox, Icon, IconButton } from '../ui'
+import { Combobox, Icon, IconButton, Tooltip } from '../ui'
 import { useRecentWorkingDirectories } from '../hooks/useRecentWorkingDirectories'
 import { detectHomeDir, tildifyPath } from '../lib/pathDisplay'
 import styles from './WorkingDirectoryPicker.module.css'
@@ -115,20 +115,30 @@ export function WorkingDirectoryPicker({
       disabled={disabled}
     >
       <Combobox.Trigger
-        render={
-          <button
-            type="button"
-            className={styles.trigger}
-            data-empty={value === null ? `true` : undefined}
-            aria-label={
-              value ? `Working directory: ${value}` : `Set working directory`
+        render={(triggerProps) => (
+          <Tooltip
+            content={
+              value ? `Working directory: ${value}` : `Working directory`
             }
-            title={value ?? `Don’t work in a directory`}
+            side="top"
+            align="start"
           >
-            <Icon icon={Folder} size={1} className={styles.triggerIcon} />
-            <span className={styles.triggerLabel}>{triggerLabel}</span>
-          </button>
-        }
+            <button
+              {...triggerProps}
+              type="button"
+              className={[triggerProps.className, styles.trigger]
+                .filter(Boolean)
+                .join(` `)}
+              data-empty={value === null ? `true` : undefined}
+              aria-label={
+                value ? `Working directory: ${value}` : `Set working directory`
+              }
+            >
+              <Icon icon={Folder} size={1} className={styles.triggerIcon} />
+              <span className={styles.triggerLabel}>{triggerLabel}</span>
+            </button>
+          </Tooltip>
+        )}
       />
       <Combobox.Content side="bottom" align="start" className={styles.popup}>
         <Combobox.Input

--- a/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsScreen.module.css
@@ -10,13 +10,13 @@
   z-index: 1;
   border-left: 1px solid var(--ds-border-1);
   background: var(--ds-bg);
-  box-shadow: -1px 0 2px color-mix(in oklab, var(--ds-gray-12) 5%, transparent);
+  box-shadow: none;
   overflow: hidden;
   transition: border-top-left-radius 180ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-:global(html[data-theme='dark']) .root {
-  box-shadow: -1px 0 2px color-mix(in oklab, #000000 32%, transparent);
+:global(html[data-theme='light']) .root {
+  box-shadow: -1px 0 2px color-mix(in oklab, var(--ds-gray-12) 5%, transparent);
 }
 
 :global(

--- a/packages/agents-server-ui/src/components/settings/SettingsSidebar.module.css
+++ b/packages/agents-server-ui/src/components/settings/SettingsSidebar.module.css
@@ -9,6 +9,17 @@
   position: relative;
 }
 
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .root::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: transparent;
+  -webkit-backdrop-filter: var(--ds-chrome-backdrop-filter);
+  backdrop-filter: var(--ds-chrome-backdrop-filter);
+}
+
 /* Narrow-viewport overlay mode — see `useNarrowViewport` and the
    matching rules in `Sidebar.module.css`. Slide/fade transitions
    are driven by `data-state` toggled in SettingsSidebar.tsx
@@ -143,6 +154,7 @@
    row in the main sidebar. */
 .row {
   all: unset;
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -151,6 +163,7 @@
   border-radius: var(--ds-radius-item);
   cursor: pointer;
   color: var(--ds-text-1);
+  background: transparent;
   transition: background 0.08s ease;
 }
 .row:hover {
@@ -164,6 +177,52 @@
 .rowActive:hover {
   background: var(--ds-accent-a3);
   color: var(--ds-text-1);
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .row {
+  overflow: hidden;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .row::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  background: transparent;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  transition: opacity 0.08s ease;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .row:hover,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .rowActive,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .rowActive:hover {
+  background: transparent;
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .row:hover::before {
+  opacity: 1;
+  background: var(--ds-sidebar-item-hover-bg);
+  -webkit-backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+}
+
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .rowActive::before,
+:global(html[data-electric-desktop='true'][data-electric-platform='darwin'])
+  .rowActive:hover::before {
+  opacity: 1;
+  background: var(--ds-sidebar-item-active-bg);
+  -webkit-backdrop-filter: var(--ds-sidebar-item-active-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-active-backdrop-filter);
 }
 
 .iconSlot {

--- a/packages/agents-server-ui/src/components/settings/SettingsSidebar.tsx
+++ b/packages/agents-server-ui/src/components/settings/SettingsSidebar.tsx
@@ -156,7 +156,7 @@ export function SettingsSidebar({
         data-state={overlayState}
         className={`${styles.root} ${narrow ? styles.overlay : ``}`}
       >
-        <div className={styles.header}>
+        <div className={styles.header} data-sidebar-control-surface="true">
           <button
             type="button"
             onClick={() => {

--- a/packages/agents-server-ui/src/components/toolBlock.module.css
+++ b/packages/agents-server-ui/src/components/toolBlock.module.css
@@ -126,6 +126,10 @@
   flex-shrink: 0;
 }
 
+.headerActions + .toggleArrow {
+  margin-left: 0;
+}
+
 /* Tool name is the only mono token in the row — it's an identifier,
    so reading it as code helps. Summary + everything else stays in the
    body font for legibility at small sizes. */

--- a/packages/agents-server-ui/src/components/views/ChatView.tsx
+++ b/packages/agents-server-ui/src/components/views/ChatView.tsx
@@ -118,21 +118,22 @@ export function ChatLogView({
     }
   }, [error, navigate, isSpawning])
 
-  const forkFromHereByInboxKey = useMemo(() => {
+  const forkFromHereByRunKey = useMemo(() => {
     if (!forkEntity || !connectUrl || !db) return undefined
     const runOffsets = db.collections.runs.__electricRowOffsets
     if (!runOffsets) return undefined
     const map = new Map<string, ForkFromHereAction>()
-    let anchor: EventPointer | null = null
+    let anchor: { rowKey: string; pointer: EventPointer } | null = null
     for (const row of visibleRows) {
       if (row.run && row.run.status === `completed`) {
         const pointer = runOffsets.get(row.run.key)
-        if (pointer) anchor = pointer
+        anchor = pointer ? { rowKey: row.$key, pointer } : null
       }
       if (row.inbox && anchor) {
-        const capturedAnchor = anchor
+        const capturedAnchor = anchor.pointer
+        const capturedRunKey = anchor.rowKey
         map.set(
-          row.$key,
+          capturedRunKey,
           canFork
             ? {
                 onFork: () => {
@@ -165,7 +166,7 @@ export function ChatLogView({
       entityUrl={connectUrl}
       entities={entities}
       scrollToBottomSignal={scrollToBottomSignal}
-      forkFromHereByInboxKey={forkFromHereByInboxKey}
+      forkFromHereByRunKey={forkFromHereByRunKey}
     />
   )
 }
@@ -295,27 +296,28 @@ function GenericChatBody({
     })
   }, [canSignal, entityUrl, generationActive, signalEntity, stopPending])
 
-  // "Fork from here" anchor map. For each user-message inbox row, the
-  // anchor is the LATEST preceding completed `runs` row — its pointer
-  // identifies "fork up to and including this response, drop everything
-  // after." Rows without a preceding completed run (first message,
-  // in-flight run, etc.) get no entry, which suppresses the affordance
-  // in UserMessage.
-  const forkFromHereByInboxKey = useMemo(() => {
+  // "Fork from here" anchor map. For each completed `runs` row that is
+  // followed by a user-message inbox row, the run pointer identifies
+  // "fork up to and including this response, drop everything after."
+  // Completed runs without a following prompt (usually the current end
+  // of the conversation) get no entry, preserving the old "historic
+  // prompt" affordance while moving it to the response footer.
+  const forkFromHereByRunKey = useMemo(() => {
     if (!forkEntity || !entityUrl || !db) return undefined
     const runOffsets = db.collections.runs.__electricRowOffsets
     if (!runOffsets) return undefined
     const map = new Map<string, ForkFromHereAction>()
-    let anchor: EventPointer | null = null
+    let anchor: { rowKey: string; pointer: EventPointer } | null = null
     for (const row of timelineRowsWithInlinePending) {
       if (row.run && row.run.status === `completed`) {
         const pointer = runOffsets.get(row.run.key)
-        if (pointer) anchor = pointer
+        anchor = pointer ? { rowKey: row.$key, pointer } : null
       }
       if (row.inbox && anchor) {
-        const capturedAnchor = anchor
+        const capturedAnchor = anchor.pointer
+        const capturedRunKey = anchor.rowKey
         map.set(
-          row.$key,
+          capturedRunKey,
           canFork
             ? {
                 onFork: () => {
@@ -360,7 +362,7 @@ function GenericChatBody({
         scrollToBottomSignal={sentMessageSignal}
         onStopGeneration={stopGeneration}
         stopPending={stopPending}
-        forkFromHereByInboxKey={forkFromHereByInboxKey}
+        forkFromHereByRunKey={forkFromHereByRunKey}
       />
       <MessageInput
         db={db}

--- a/packages/agents-server-ui/src/components/views/NewSessionView.tsx
+++ b/packages/agents-server-ui/src/components/views/NewSessionView.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowUp, Cpu, Sparkles } from 'lucide-react'
+import {
+  ArrowUp,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Cpu,
+  Sparkles,
+} from 'lucide-react'
 import { eq, not, useLiveQuery } from '@tanstack/react-db'
 import { COMPOSER_INPUT_MESSAGE_TYPE } from '@electric-ax/agents-runtime/client'
 import { nanoid } from 'nanoid'
@@ -16,7 +23,7 @@ import {
   type CodexAuthSource,
 } from '../../lib/server-connection'
 import { sendEntityMessage } from '../../lib/sendMessage'
-import { Button, Icon, Select, Stack, Text } from '../../ui'
+import { Button, Icon, Menu, Select, Stack, Text } from '../../ui'
 import { SchemaForm, hasSchemaProperties, isObjectSchema } from '../SchemaForm'
 import { WorkingDirectoryPicker } from '../WorkingDirectoryPicker'
 import {
@@ -120,6 +127,8 @@ interface SchemaProperty {
   title?: string
   description?: string
 }
+
+type InlineSchemaProperty = { key: string; prop: SchemaProperty }
 
 /**
  * Standalone view: the new-session picker.
@@ -871,11 +880,9 @@ function SandboxProfileRow({
   )
 }
 
-function inlineSchemaProperties(
-  schema: unknown
-): Array<{ key: string; prop: SchemaProperty }> {
+function inlineSchemaProperties(schema: unknown): Array<InlineSchemaProperty> {
   if (!isObjectSchema(schema)) return []
-  const out: Array<{ key: string; prop: SchemaProperty }> = []
+  const out: Array<InlineSchemaProperty> = []
   for (const [key, raw] of Object.entries(schema.properties)) {
     const prop = raw as SchemaProperty
     if (prop.enum && prop.enum.length > 0) {
@@ -885,6 +892,31 @@ function inlineSchemaProperties(
     }
   }
   return out
+}
+
+function normalizedSchemaKey(key: string): string {
+  return key.replace(/[\s_-]/g, ``).toLowerCase()
+}
+
+function isReasoningProperty(key: string): boolean {
+  const normalized = normalizedSchemaKey(key)
+  return (
+    normalized === `reasoningeffort` ||
+    normalized === `reasoninglevel` ||
+    normalized === `thinkingeffort` ||
+    normalized === `thinkinglevel`
+  )
+}
+
+function isSpeedProperty(key: string): boolean {
+  const normalized = normalizedSchemaKey(key)
+  return (
+    normalized === `speed` ||
+    normalized === `speedlevel` ||
+    normalized === `speedmode` ||
+    normalized === `servicetier` ||
+    normalized === `latencytier`
+  )
 }
 
 function DefaultAgentComposer({
@@ -930,6 +962,28 @@ function DefaultAgentComposer({
     () => inlineSchemaProperties(agent.creation_schema),
     [agent.creation_schema]
   )
+  const modelSettingsProps = useMemo(() => {
+    const model = inlineProps.find(
+      ({ key, prop }) => isModelProperty(key) && prop.enum?.length
+    )
+    const reasoning = inlineProps.find(
+      ({ key, prop }) => isReasoningProperty(key) && prop.enum?.length
+    )
+    if (!model || !reasoning) return null
+    const speed = inlineProps.find(
+      ({ key, prop }) => isSpeedProperty(key) && prop.enum?.length
+    )
+    return { model, reasoning, speed }
+  }, [inlineProps])
+  const standaloneInlineProps = useMemo(() => {
+    if (!modelSettingsProps) return inlineProps
+    const combinedKeys = new Set([
+      modelSettingsProps.model.key,
+      modelSettingsProps.reasoning.key,
+      ...(modelSettingsProps.speed ? [modelSettingsProps.speed.key] : []),
+    ])
+    return inlineProps.filter(({ key }) => !combinedKeys.has(key))
+  }, [inlineProps, modelSettingsProps])
   const slashCommands = useMemo<Array<SlashCommandRow>>(
     () =>
       (agent.slash_commands ?? []).map((command) => ({
@@ -962,6 +1016,14 @@ function DefaultAgentComposer({
     }
     return init
   })
+  const setEnumArg = useCallback(
+    (key: string, prop: SchemaProperty, next: string) => {
+      const original = prop.enum?.find((v) => String(v) === next)
+      if (isModelProperty(key)) persistLastPickedModel(next)
+      setArgs((prev) => ({ ...prev, [key]: original ?? next }))
+    },
+    []
+  )
   const imageAttachmentsEnabled = schemaModelSupportsImageInput(
     agent.creation_schema,
     args
@@ -1069,7 +1131,17 @@ function DefaultAgentComposer({
                 onAttach={openAttachmentPicker}
               />
             )}
-            {inlineProps.map(({ key, prop }) =>
+            {modelSettingsProps && (
+              <ModelSettingsMenu
+                model={modelSettingsProps.model}
+                reasoning={modelSettingsProps.reasoning}
+                speed={modelSettingsProps.speed}
+                args={args}
+                onChange={setEnumArg}
+                disabled={submitting || disabled}
+              />
+            )}
+            {standaloneInlineProps.map(({ key, prop }) =>
               prop.enum ? (
                 <PillSelect
                   key={key}
@@ -1077,11 +1149,7 @@ function DefaultAgentComposer({
                   value={String(args[key] ?? ``)}
                   options={prop.enum.map((v) => String(v))}
                   groupByProvider={isModelProperty(key)}
-                  onChange={(next) => {
-                    const original = prop.enum!.find((v) => String(v) === next)
-                    if (isModelProperty(key)) persistLastPickedModel(next)
-                    setArgs((prev) => ({ ...prev, [key]: original ?? next }))
-                  }}
+                  onChange={(next) => setEnumArg(key, prop, next)}
                   disabled={submitting || disabled}
                 />
               ) : prop.type === `boolean` ? (
@@ -1258,6 +1326,214 @@ function groupedModelOptions(
     group.options.push(option)
   }
   return groups
+}
+
+function enumOptions(prop: SchemaProperty): Array<string> {
+  return (prop.enum ?? []).map((v) => String(v))
+}
+
+function selectedEnumValue(
+  item: InlineSchemaProperty,
+  args: Readonly<Record<string, unknown>>
+): string {
+  const current = args[item.key]
+  if (current !== undefined && current !== null && current !== ``) {
+    return String(current)
+  }
+  if (item.prop.default !== undefined && item.prop.default !== null) {
+    return String(item.prop.default)
+  }
+  const first = item.prop.enum?.[0]
+  return first !== undefined && first !== null ? String(first) : ``
+}
+
+function enumOptionLabel(value: string): string {
+  return value
+    .split(/[\s_-]+/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(` `)
+}
+
+function ModelSettingsMenu({
+  model,
+  reasoning,
+  speed,
+  args,
+  onChange,
+  disabled,
+}: {
+  model: InlineSchemaProperty
+  reasoning: InlineSchemaProperty
+  speed?: InlineSchemaProperty
+  args: Readonly<Record<string, unknown>>
+  onChange: (key: string, prop: SchemaProperty, value: string) => void
+  disabled?: boolean
+}): React.ReactElement {
+  const modelValue = selectedEnumValue(model, args)
+  const reasoningValue = selectedEnumValue(reasoning, args)
+  const speedValue = speed ? selectedEnumValue(speed, args) : ``
+  const modelLabel = modelValue ? modelOptionLabel(modelValue) : `Model`
+  const reasoningLabel = reasoningValue
+    ? enumOptionLabel(reasoningValue)
+    : `Auto`
+  const speedLabel = speedValue ? enumOptionLabel(speedValue) : `Speed`
+  const modelGroups = groupedModelOptions(enumOptions(model.prop))
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger
+        render={
+          <button
+            type="button"
+            className={styles.modelSettingsTrigger}
+            aria-label="Model and reasoning"
+            title="Model and reasoning"
+            disabled={disabled}
+          >
+            <span className={styles.modelSettingsTriggerModel}>
+              {modelLabel}
+            </span>
+            <span className={styles.modelSettingsTriggerMeta}>
+              {reasoningLabel}
+            </span>
+            <Icon
+              icon={ChevronDown}
+              size={1}
+              className={styles.modelSettingsChevron}
+            />
+          </button>
+        }
+      />
+      <Menu.Content
+        side="top"
+        align="start"
+        sideOffset={8}
+        className={styles.modelSettingsMenu}
+      >
+        <Menu.SubmenuRoot>
+          <Menu.SubmenuTrigger className={styles.modelSettingsSubmenuTrigger}>
+            <span>Model</span>
+            <span className={styles.modelSettingsSubmenuValue}>
+              {modelLabel}
+            </span>
+            <Icon
+              icon={ChevronRight}
+              size={2}
+              className={styles.modelSettingsChevron}
+            />
+          </Menu.SubmenuTrigger>
+          <Menu.Content
+            side="right"
+            align="start"
+            className={styles.modelSettingsModelMenu}
+          >
+            {modelGroups.map((group) => (
+              <Menu.Group key={group.provider}>
+                <Menu.Label>{group.label}</Menu.Label>
+                {group.options.map((option) => {
+                  const active = option === modelValue
+                  return (
+                    <Menu.Item
+                      key={option}
+                      onSelect={() => onChange(model.key, model.prop, option)}
+                    >
+                      <span className={styles.modelSettingsItemLabel}>
+                        {modelOptionLabel(option)}
+                      </span>
+                      {active && (
+                        <Icon
+                          icon={Check}
+                          size={2}
+                          className={styles.modelSettingsActiveMark}
+                        />
+                      )}
+                    </Menu.Item>
+                  )
+                })}
+              </Menu.Group>
+            ))}
+          </Menu.Content>
+        </Menu.SubmenuRoot>
+
+        <Menu.SubmenuRoot>
+          <Menu.SubmenuTrigger className={styles.modelSettingsSubmenuTrigger}>
+            <span>Reasoning</span>
+            <span className={styles.modelSettingsSubmenuValue}>
+              {reasoningLabel}
+            </span>
+            <Icon
+              icon={ChevronRight}
+              size={2}
+              className={styles.modelSettingsChevron}
+            />
+          </Menu.SubmenuTrigger>
+          <Menu.Content side="right" align="start">
+            {enumOptions(reasoning.prop).map((option) => {
+              const active = option === reasoningValue
+              return (
+                <Menu.Item
+                  key={option}
+                  onSelect={() =>
+                    onChange(reasoning.key, reasoning.prop, option)
+                  }
+                >
+                  <span className={styles.modelSettingsItemLabel}>
+                    {enumOptionLabel(option)}
+                  </span>
+                  {active && (
+                    <Icon
+                      icon={Check}
+                      size={2}
+                      className={styles.modelSettingsActiveMark}
+                    />
+                  )}
+                </Menu.Item>
+              )
+            })}
+          </Menu.Content>
+        </Menu.SubmenuRoot>
+
+        {speed && (
+          <Menu.SubmenuRoot>
+            <Menu.SubmenuTrigger className={styles.modelSettingsSubmenuTrigger}>
+              <span>Speed</span>
+              <span className={styles.modelSettingsSubmenuValue}>
+                {speedLabel}
+              </span>
+              <Icon
+                icon={ChevronRight}
+                size={2}
+                className={styles.modelSettingsChevron}
+              />
+            </Menu.SubmenuTrigger>
+            <Menu.Content side="right" align="start">
+              {enumOptions(speed.prop).map((option) => {
+                const active = option === speedValue
+                return (
+                  <Menu.Item
+                    key={option}
+                    onSelect={() => onChange(speed.key, speed.prop, option)}
+                  >
+                    <span className={styles.modelSettingsItemLabel}>
+                      {enumOptionLabel(option)}
+                    </span>
+                    {active && (
+                      <Icon
+                        icon={Check}
+                        size={2}
+                        className={styles.modelSettingsActiveMark}
+                      />
+                    )}
+                  </Menu.Item>
+                )
+              })}
+            </Menu.Content>
+          </Menu.SubmenuRoot>
+        )}
+      </Menu.Content>
+    </Menu.Root>
+  )
 }
 
 function PillSelect({

--- a/packages/agents-server-ui/src/components/views/NewSessionView.tsx
+++ b/packages/agents-server-ui/src/components/views/NewSessionView.tsx
@@ -23,7 +23,7 @@ import {
   type CodexAuthSource,
 } from '../../lib/server-connection'
 import { sendEntityMessage } from '../../lib/sendMessage'
-import { Button, Icon, Menu, Select, Stack, Text } from '../../ui'
+import { Button, Icon, Menu, Select, Stack, Text, Tooltip } from '../../ui'
 import { SchemaForm, hasSchemaProperties, isObjectSchema } from '../SchemaForm'
 import { WorkingDirectoryPicker } from '../WorkingDirectoryPicker'
 import {
@@ -846,6 +846,10 @@ function isSandboxProfileRemote(
   return name != null && profiles.some((p) => p.name === name && p.remote)
 }
 
+function sandboxProfileLabel(profile: ElectricSandboxProfile): string {
+  return profile.name === `local` ? `No sandbox` : profile.label
+}
+
 function SandboxProfileRow({
   profiles,
   value,
@@ -871,7 +875,7 @@ function SandboxProfileRow({
         <Select.Content>
           {profiles.map((p) => (
             <Select.Item key={p.name} value={p.name}>
-              {p.label}
+              {sandboxProfileLabel(p)}
             </Select.Item>
           ))}
         </Select.Content>
@@ -1096,6 +1100,9 @@ function DefaultAgentComposer({
     (value.trim() || attachmentCount > 0) && !disabled && !submitting
   )
   const placeholder = disabled ? `Connecting…` : `Ask ${agent.name} anything…`
+  const sendTooltip = submitting
+    ? `Starting ${agent.name} session`
+    : `Start ${agent.name} session`
 
   return (
     <div
@@ -1171,20 +1178,24 @@ function DefaultAgentComposer({
             {submitting && (
               <span className={styles.composerHint}>Starting…</span>
             )}
-            <button
-              type="button"
-              aria-label={`Start ${agent.name} session`}
-              onClick={() => submit()}
-              disabled={!isActive}
-              className={[
-                styles.composerSend,
-                isActive ? styles.composerSendActive : null,
-              ]
-                .filter(Boolean)
-                .join(` `)}
-            >
-              <Icon icon={ArrowUp} size={3} />
-            </button>
+            <Tooltip content={sendTooltip} side="top">
+              <span className={styles.tooltipTrigger}>
+                <button
+                  type="button"
+                  aria-label={`Start ${agent.name} session`}
+                  onClick={() => submit()}
+                  disabled={!isActive}
+                  className={[
+                    styles.composerSend,
+                    isActive ? styles.composerSendActive : null,
+                  ]
+                    .filter(Boolean)
+                    .join(` `)}
+                >
+                  <Icon icon={ArrowUp} size={3} />
+                </button>
+              </span>
+            </Tooltip>
           </>
         }
       >
@@ -1212,7 +1223,7 @@ function DefaultAgentComposer({
             value={selectedSandboxProfile ?? ``}
             options={sandboxProfiles.map((p) => p.name)}
             optionLabels={Object.fromEntries(
-              sandboxProfiles.map((p) => [p.name, p.label])
+              sandboxProfiles.map((p) => [p.name, sandboxProfileLabel(p)])
             )}
             onChange={(next) => setSandboxProfile(next)}
             disabled={submitting || disabled}
@@ -1264,7 +1275,7 @@ function RunnerPickerPill({
       <Select.Trigger
         size="pill"
         aria-label="Runner"
-        title="Pull-wake runner that will handle this session"
+        tooltip="Runner that will handle this session"
         placeholder="Pick runner"
         icon={Cpu}
         renderValue={renderValue}
@@ -1383,27 +1394,32 @@ function ModelSettingsMenu({
   return (
     <Menu.Root>
       <Menu.Trigger
-        render={
-          <button
-            type="button"
-            className={styles.modelSettingsTrigger}
-            aria-label="Model and reasoning"
-            title="Model and reasoning"
-            disabled={disabled}
-          >
-            <span className={styles.modelSettingsTriggerModel}>
-              {modelLabel}
-            </span>
-            <span className={styles.modelSettingsTriggerMeta}>
-              {reasoningLabel}
-            </span>
-            <Icon
-              icon={ChevronDown}
-              size={1}
-              className={styles.modelSettingsChevron}
-            />
-          </button>
-        }
+        disabled={disabled}
+        render={(triggerProps) => (
+          <Tooltip content="Model" side="top" align="start">
+            <button
+              {...triggerProps}
+              type="button"
+              className={[triggerProps.className, styles.modelSettingsTrigger]
+                .filter(Boolean)
+                .join(` `)}
+              aria-label="Model and reasoning"
+              disabled={disabled}
+            >
+              <span className={styles.modelSettingsTriggerModel}>
+                {modelLabel}
+              </span>
+              <span className={styles.modelSettingsTriggerMeta}>
+                {reasoningLabel}
+              </span>
+              <Icon
+                icon={ChevronDown}
+                size={1}
+                className={styles.modelSettingsChevron}
+              />
+            </button>
+          </Tooltip>
+        )}
       />
       <Menu.Content
         side="top"
@@ -1565,7 +1581,7 @@ function PillSelect({
       <Select.Trigger
         size="pill"
         aria-label={label}
-        title={label}
+        tooltip={label}
         renderValue={
           groupByProvider
             ? (current) => (current ? modelOptionLabel(current) : label)

--- a/packages/agents-server-ui/src/components/workspace/Workspace.module.css
+++ b/packages/agents-server-ui/src/components/workspace/Workspace.module.css
@@ -7,13 +7,13 @@
   z-index: 1;
   border-left: 1px solid var(--ds-border-1);
   background: var(--ds-bg);
-  box-shadow: -1px 0 2px color-mix(in oklab, var(--ds-gray-12) 5%, transparent);
+  box-shadow: none;
   overflow: hidden;
   transition: border-top-left-radius 180ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-:global(html[data-theme='dark']) .workspace {
-  box-shadow: -1px 0 2px color-mix(in oklab, #000000 32%, transparent);
+:global(html[data-theme='light']) .workspace {
+  box-shadow: -1px 0 2px color-mix(in oklab, var(--ds-gray-12) 5%, transparent);
 }
 
 :global([data-sidebar-state='closed']) .workspace {

--- a/packages/agents-server-ui/src/ui/Select.module.css
+++ b/packages/agents-server-ui/src/ui/Select.module.css
@@ -94,6 +94,7 @@
 }
 
 .popup {
+  box-sizing: border-box;
   padding: 3px;
   min-width: var(--anchor-width, 8rem);
   max-height: min(60vh, 360px);

--- a/packages/agents-server-ui/src/ui/Select.module.css
+++ b/packages/agents-server-ui/src/ui/Select.module.css
@@ -7,7 +7,7 @@
   height: 32px;
   min-width: 120px;
   font-size: var(--ds-text-sm);
-  line-height: 1;
+  line-height: var(--ds-text-sm-lh);
   font-family: var(--ds-font-body);
   color: var(--ds-text-1);
   background: var(--ds-input-bg);
@@ -47,7 +47,7 @@
   height: 24px;
   padding: 0 8px;
   font-size: var(--ds-text-xs);
-  line-height: 1;
+  line-height: 1.35;
   font-family: var(--ds-font-body);
   color: var(--ds-text-2);
   /* Solid chip surface (matches inline pills, project picker pill,

--- a/packages/agents-server-ui/src/ui/Select.module.css
+++ b/packages/agents-server-ui/src/ui/Select.module.css
@@ -78,6 +78,10 @@
   cursor: not-allowed;
 }
 
+.tooltipTrigger {
+  display: inline-flex;
+}
+
 .icon {
   display: inline-flex;
   color: var(--ds-text-3);

--- a/packages/agents-server-ui/src/ui/Select.tsx
+++ b/packages/agents-server-ui/src/ui/Select.tsx
@@ -5,6 +5,7 @@ import type { LucideIcon } from 'lucide-react'
 import { Icon } from './Icon'
 import popoverStyles from './Popover.module.css'
 import styles from './Select.module.css'
+import { Tooltip } from './Tooltip'
 
 export type SelectSize = `md` | `pill`
 
@@ -36,8 +37,10 @@ interface TriggerProps {
    * there is no visible Field label.
    */
   [`aria-label`]?: string
-  /** Tooltip-style hint shown on hover. */
+  /** @deprecated Use `tooltip` so hints render through the shared tooltip. */
   title?: string
+  /** Tooltip-style hint shown on hover. */
+  tooltip?: ReactNode
   /**
    * Optional leading icon rendered before the value. Slots in as a
    * sibling flex child of `<Select.Value>` so it gets the trigger's
@@ -109,6 +112,7 @@ function Trigger({
   autoFocus,
   [`aria-label`]: ariaLabel,
   title,
+  tooltip,
   icon,
   renderValue,
 }: TriggerProps): React.ReactElement {
@@ -116,14 +120,9 @@ function Trigger({
     .filter(Boolean)
     .join(` `)
   const iconSize = size === `pill` ? 1 : 2
-  return (
-    <BaseSelect.Trigger
-      className={cls}
-      style={style}
-      autoFocus={autoFocus}
-      aria-label={ariaLabel}
-      title={title}
-    >
+  const tooltipContent = tooltip ?? title
+  const triggerContent = (
+    <>
       {icon && (
         <span className={styles.leadingIcon}>
           <Icon icon={icon} size={iconSize} />
@@ -137,7 +136,23 @@ function Trigger({
       <BaseSelect.Icon className={styles.icon}>
         <Icon icon={ChevronDown} size={iconSize} />
       </BaseSelect.Icon>
+    </>
+  )
+  const trigger = (
+    <BaseSelect.Trigger
+      className={cls}
+      style={style}
+      autoFocus={autoFocus}
+      aria-label={ariaLabel}
+    >
+      {triggerContent}
     </BaseSelect.Trigger>
+  )
+  if (!tooltipContent) return trigger
+  return (
+    <Tooltip content={tooltipContent} side="top" align="start">
+      <span className={styles.tooltipTrigger}>{trigger}</span>
+    </Tooltip>
   )
 }
 

--- a/packages/agents-server-ui/src/ui/global.css
+++ b/packages/agents-server-ui/src/ui/global.css
@@ -49,6 +49,73 @@ html[data-electric-desktop='true'][data-theme='dark'] {
   --ds-chrome-bg: color-mix(in oklab, var(--ds-bg-subtle) 78%, transparent);
 }
 
+html[data-electric-desktop='true'][data-electric-platform='darwin'][data-theme='light'] {
+  --ds-chrome-bg: transparent;
+  --ds-chrome-backdrop-filter: saturate(1.08) sepia(0.08) hue-rotate(350deg);
+  --ds-sidebar-item-hover-bg: color-mix(
+    in oklab,
+    var(--ds-gray-12) 8%,
+    transparent
+  );
+  --ds-sidebar-item-active-bg: color-mix(
+    in oklab,
+    var(--ds-accent-base) 12%,
+    transparent
+  );
+  --ds-sidebar-item-hover-backdrop-filter: saturate(1.16) sepia(0.06)
+    hue-rotate(350deg) brightness(0.97);
+  --ds-sidebar-item-active-backdrop-filter: saturate(1.28) sepia(0.12)
+    hue-rotate(350deg) brightness(0.92);
+  --ds-sidebar-divider: color-mix(in oklab, var(--ds-gray-12) 7%, transparent);
+  --ds-sidebar-divider-blend-mode: multiply;
+}
+
+html[data-electric-desktop='true'][data-electric-platform='darwin'][data-theme='dark'] {
+  --ds-chrome-bg: transparent;
+  --ds-chrome-backdrop-filter: saturate(1.08) sepia(0.05) hue-rotate(350deg);
+  --ds-sidebar-item-hover-bg: color-mix(in oklab, #ffffff 10%, transparent);
+  --ds-sidebar-item-active-bg: color-mix(
+    in oklab,
+    var(--ds-accent-base) 16%,
+    transparent
+  );
+  --ds-sidebar-item-hover-backdrop-filter: saturate(1.18) sepia(0.04)
+    hue-rotate(350deg) brightness(1.14);
+  --ds-sidebar-item-active-backdrop-filter: saturate(1.32) sepia(0.06)
+    hue-rotate(350deg) brightness(1.24);
+  --ds-sidebar-divider: color-mix(in oklab, var(--ds-divider) 50%, transparent);
+  --ds-sidebar-divider-blend-mode: soft-light;
+}
+
+html[data-electric-desktop='true'][data-electric-platform='darwin']
+  [data-sidebar-control-surface]
+  button {
+  position: relative;
+  background-clip: border-box;
+}
+
+html[data-electric-desktop='true'][data-electric-platform='darwin']
+  [data-sidebar-control-surface]
+  button:hover:not(:disabled):not([data-disabled]),
+html[data-electric-desktop='true'][data-electric-platform='darwin']
+  [data-sidebar-control-surface]
+  button[data-popup-open]:not(:disabled):not([data-disabled]),
+html[data-electric-desktop='true'][data-electric-platform='darwin']
+  [data-sidebar-control-surface]
+  button[data-pressed]:not(:disabled):not([data-disabled]) {
+  background: var(--ds-sidebar-item-hover-bg) !important;
+  -webkit-backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-hover-backdrop-filter);
+}
+
+html[data-electric-desktop='true'][data-electric-platform='darwin']
+  [data-sidebar-control-surface]
+  button:active:not(:disabled):not([data-disabled]) {
+  background: var(--ds-sidebar-item-active-bg) !important;
+  -webkit-backdrop-filter: var(--ds-sidebar-item-active-backdrop-filter);
+  backdrop-filter: var(--ds-sidebar-item-active-backdrop-filter);
+}
+
 html[data-electric-desktop='true'] input,
 html[data-electric-desktop='true'] textarea,
 html[data-electric-desktop='true'] select,

--- a/packages/agents-server-ui/src/ui/tokens.css
+++ b/packages/agents-server-ui/src/ui/tokens.css
@@ -100,6 +100,13 @@
   --ds-bg: #f7f7f5;
   --ds-bg-subtle: #f0efed;
   --ds-chrome-bg: var(--ds-bg-subtle);
+  --ds-chrome-backdrop-filter: none;
+  --ds-sidebar-item-hover-bg: transparent;
+  --ds-sidebar-item-active-bg: transparent;
+  --ds-sidebar-item-hover-backdrop-filter: none;
+  --ds-sidebar-item-active-backdrop-filter: none;
+  --ds-sidebar-divider: var(--ds-divider);
+  --ds-sidebar-divider-blend-mode: normal;
   --ds-surface: #ffffff;
   --ds-surface-raised: #ffffff;
   --ds-input-bg: var(--ds-surface-raised);
@@ -318,6 +325,13 @@
   --ds-bg: #111318;
   --ds-bg-subtle: #16181f;
   --ds-chrome-bg: var(--ds-bg-subtle);
+  --ds-chrome-backdrop-filter: none;
+  --ds-sidebar-item-hover-bg: transparent;
+  --ds-sidebar-item-active-bg: transparent;
+  --ds-sidebar-item-hover-backdrop-filter: none;
+  --ds-sidebar-item-active-backdrop-filter: none;
+  --ds-sidebar-divider: var(--ds-divider);
+  --ds-sidebar-divider-blend-mode: normal;
   --ds-surface: #1a1d27;
   --ds-surface-raised: #22252f;
   /* Solid raised fill — same value the marketing site uses for its


### PR DESCRIPTION
## Summary

This PR collects several agents desktop/server UI improvements:

- Adds a nested Horton model settings menu that groups model, reasoning, and speed choices, with the closed trigger showing the model and lighter thinking-level text.
- Fixes select/menu presentation issues, including cropped descenders in select triggers and excess dropdown bottom spacing.
- Adds and corrects tooltips for spawn form/chat timeline controls, including attach, model, working directory, send, runner, and sandbox controls.
- Renames the local sandbox option to `No sandbox`.
- Refines macOS desktop sidebar vibrancy by using transparent chrome with backdrop-filter tinting, visible backdrop-aware hover/active states for sidebar rows and controls, blended full-width dividers, and light-mode-only content edge shadows.
- Moves the timeline “Fork from here” action from a hover-only historical prompt button to an always-visible assistant response footer action beside copy response.

## Validation

- `git diff --check`
- `asdf exec corepack pnpm --filter @electric-ax/agents-server-ui typecheck`