### PR TITLE
Add schedule tools to Horton

### DIFF
--- a/.changeset/horton-schedule-tools.md
+++ b/.changeset/horton-schedule-tools.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents": patch
+---
+
+Add built-in schedule tools to Horton and document them in the system prompt.

--- a/packages/agents/src/agents/horton.ts
+++ b/packages/agents/src/agents/horton.ts
@@ -185,6 +185,7 @@ export function buildHortonSystemPrompt(
   opts: {
     hasDocsSupport?: boolean
     hasEventSourceTools?: boolean
+    hasScheduleTools?: boolean
     hasSkills?: boolean
     docsUrl?: string
     modelProvider?: string
@@ -196,6 +197,9 @@ export function buildHortonSystemPrompt(
     : ``
   const eventSourceTools = opts.hasEventSourceTools
     ? `\n- list_event_sources: list external webhook/event feeds you can subscribe to, including available buckets and parameters\n- subscribe_event_source: subscribe yourself to one of those feeds or buckets so matching future events wake you\n- list_event_source_subscriptions: list your active event source subscriptions\n- unsubscribe_event_source: remove one of your event source subscriptions by id`
+    : ``
+  const scheduleTools = opts.hasScheduleTools
+    ? `\n- upsert_cron_schedule: create or update a recurring cron wake for yourself. Always include payload with the concrete instruction/message you should receive when the cron fires.\n- delete_schedule: delete one of your cron or future-send schedules by stable id\n- list_schedules: list your manifest-backed cron and future-send schedules`
     : ``
   const skillsTools = opts.hasSkills
     ? `\n- use_skill: load a skill (knowledge, instructions, or a tutorial) into your context to help with the user's request\n- remove_skill: unload a skill from context when you're done with it`
@@ -262,7 +266,7 @@ When a user opens with a greeting ("hi", "hello", "hey", etc.) or a broad statem
 - fetch_url: fetch and convert a URL to markdown
 - spawn_worker: dispatch a subagent for an isolated task
 - send: send a message to an Electric Agent/entity. To schedule future work for yourself, call send with self: true and afterMs.
-${eventSourceTools}${docsTools}${skillsTools}
+${eventSourceTools}${scheduleTools}${docsTools}${skillsTools}
 
 # Working with files
 - Prefer edit over write when modifying existing files.
@@ -517,6 +521,9 @@ function createAssistantHandler(options: {
     const hasEventSourceTools = tools.some(
       (tool) => getToolName(tool) === `list_event_sources`
     )
+    const hasScheduleTools = tools.some(
+      (tool) => getToolName(tool) === `upsert_cron_schedule`
+    )
 
     const titlePromise = !ctx.tags.title
       ? (async () => {
@@ -649,6 +656,7 @@ function createAssistantHandler(options: {
         modelProvider: modelConfig.provider,
         modelId: String(modelConfig.model),
         hasEventSourceTools,
+        hasScheduleTools,
       }),
       ...modelConfig,
       // mcp.tools() inserts sentinel objects that the runtime's

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -8,7 +8,10 @@ import {
   createEntityRegistry,
   createRuntimeHandler,
 } from '@electric-ax/agents-runtime'
-import { createEventSourceTools } from '@electric-ax/agents-runtime/tools'
+import {
+  createEventSourceTools,
+  createScheduleTools,
+} from '@electric-ax/agents-runtime/tools'
 import {
   chooseDefaultSandbox,
   isE2BAvailable,
@@ -85,7 +88,10 @@ export function createBuiltinElectricTools(
   custom?: BuiltinElectricToolsFactory
 ): BuiltinElectricToolsFactory {
   return async (context) => {
-    const builtinTools = createEventSourceTools(context)
+    const builtinTools = [
+      ...createEventSourceTools(context),
+      ...createScheduleTools(context),
+    ]
     const customTools = custom ? await custom(context) : []
     return dedupeToolsByName([...builtinTools, ...customTools])
   }

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -90,7 +90,7 @@ export function createBuiltinElectricTools(
   return async (context) => {
     const builtinTools = [
       ...createEventSourceTools(context),
-      ...createScheduleTools(context),
+      ...createScheduleTools({ ...context, db: context.db as any }),
     ]
     const customTools = custom ? await custom(context) : []
     return dedupeToolsByName([...builtinTools, ...customTools])

--- a/packages/agents/test/horton-tool-composition.test.ts
+++ b/packages/agents/test/horton-tool-composition.test.ts
@@ -216,7 +216,7 @@ describe(`horton tool composition`, () => {
     )
   })
 
-  it(`adds event source tools through the built-in electric tool factory`, async () => {
+  it(`adds event source and schedule tools through the built-in electric tool factory`, async () => {
     const tools = await createBuiltinElectricTools()(
       createElectricToolsContext()
     )
@@ -228,6 +228,9 @@ describe(`horton tool composition`, () => {
         `subscribe_event_source`,
         `list_event_source_subscriptions`,
         `unsubscribe_event_source`,
+        `upsert_cron_schedule`,
+        `delete_schedule`,
+        `list_schedules`,
       ])
     )
     expect(
@@ -242,7 +245,7 @@ describe(`horton tool composition`, () => {
     ).not.toContain(`manifest-backed`)
   })
 
-  it(`includes event source electric tools in Horton and describes them in the prompt`, async () => {
+  it(`includes event source and schedule electric tools in Horton and describes them in the prompt`, async () => {
     const electricTools = await createBuiltinElectricTools()(
       createElectricToolsContext()
     )
@@ -253,8 +256,14 @@ describe(`horton tool composition`, () => {
 
     expect(names).toContain(`list_event_sources`)
     expect(names).toContain(`subscribe_event_source`)
+    expect(names).toContain(`upsert_cron_schedule`)
+    expect(names).toContain(`delete_schedule`)
+    expect(names).toContain(`list_schedules`)
     expect(cfg.systemPrompt).toContain(`list_event_sources`)
     expect(cfg.systemPrompt).toContain(`subscribe_event_source`)
+    expect(cfg.systemPrompt).toContain(`upsert_cron_schedule`)
+    expect(cfg.systemPrompt).toContain(`delete_schedule`)
+    expect(cfg.systemPrompt).toContain(`list_schedules`)
   })
 
   it(`includes the default built-in toolset`, async () => {


### PR DESCRIPTION
## Summary
- include schedule tools in built-in Electric tools alongside event source tools
- describe schedule tools in Horton's system prompt when present
- update Horton tool composition coverage for schedule tools

## Testing
- Attempted: `pnpm --filter @electric-ax/agents test -- horton-tool-composition.test.ts --run`
- Result: failed before tests ran because the fresh worktree has not had `pnpm install` run, leaving workspace/dependency links unresolved (e.g. undici, pino, better-sqlite3, @electric-ax/agents-runtime).