### PR TITLE
Restore server-side reasoning content projection (pending upstream TanStack DB fix)

### DIFF
--- a/packages/agents-runtime/src/client.ts
+++ b/packages/agents-runtime/src/client.ts
@@ -65,7 +65,6 @@ export type {
   EntityTimelineRunItem,
   EntityTimelineSection,
   EntityTimelineState,
-  EntityTimelineReasoningDeltaItem,
   EntityTimelineTextChunk,
   EntityTimelineTextItem,
   EntityTimelineToolCallItem,

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -225,9 +225,11 @@ export interface EntityTimelineReasoningItem {
   run_id?: string
   order: TimelineOrder
   status: `streaming` | `completed`
-  // Concatenated content from all `reasoning_delta` rows for this row,
-  // built live by the query (mirrors `EntityTimelineTextItem.content`).
-  content: string
+  // The concatenated `reasoning_delta` content lives under
+  // `body.content` rather than top-level — the wrapper is what
+  // forces TanStack DB to materialize the include before the row
+  // reaches `useLiveQuery`. See the timeline-query comment.
+  body?: { content: string }
   // Optional bolded title parsed at write time — only OpenAI Responses
   // emits these; null for Anthropic / DeepSeek / Moonshot.
   summary_title?: string
@@ -1346,6 +1348,43 @@ function buildEntityTimelineQuery(
       }),
     }))
 
+  // Mirror `runItemsSource`'s shape for reasoning rows: the
+  // `concat(toArray(...))` include is *defined* on this top-level
+  // source, then the `reasoning:` consumer inside `runSource.select`
+  // below dereferences it into `content: r.reasoningContent`. The
+  // two-layer source/consumer split is load-bearing: `useLiveQuery`
+  // reads of a sub-collection that has an include co-defined in the
+  // same select return the row with `content: null` + a deferred
+  // `Symbol(includesRouting)` marker. Naming the include field in a
+  // downstream `.select` is what forces materialization — exactly
+  // how `items.text.content` pulls `item.textContent` out of
+  // `runItemsSource`. Alias is `reasoningChunk` to avoid colliding
+  // with `textChunk` used above.
+  const runReasoningSource = q
+    .from({ reasoning: db.collections.reasoning })
+    .select(({ reasoning }) => ({
+      key: reasoning.key,
+      run_id: reasoning.run_id,
+      order: coalesce(reasoning._timeline_order, `~`),
+      status: reasoning.status,
+      summary_title: reasoning.summary_title,
+      encrypted: reasoning.encrypted,
+      reasoningContent: concat(
+        toArray(
+          q
+            .from({ reasoningChunk: db.collections.reasoningDeltas })
+            .where(({ reasoningChunk }) =>
+              eq(reasoningChunk.reasoning_id, reasoning.key)
+            )
+            .orderBy(({ reasoningChunk }) =>
+              coalesce(reasoningChunk._timeline_order, `~`)
+            )
+            .orderBy(({ reasoningChunk }) => reasoningChunk.key)
+            .select(({ reasoningChunk }) => reasoningChunk.delta)
+        )
+      ),
+    }))
+
   const runSource = q.from({ run: db.collections.runs }).select(({ run }) => ({
     key: run.key,
     order: coalesce(run._timeline_order, `~`),
@@ -1374,34 +1413,26 @@ function buildEntityTimelineQuery(
         toolCall: item.toolCall,
       })),
     reasoning: q
-      .from({ reasoning: db.collections.reasoning })
-      .where(({ reasoning }) => eq(reasoning.run_id, run.key))
-      .orderBy(({ reasoning }) => coalesce(reasoning._timeline_order, `~`))
-      .orderBy(({ reasoning }) => reasoning.key)
-      .select(({ reasoning }) => ({
-        key: reasoning.key,
-        run_id: reasoning.run_id,
-        order: coalesce(reasoning._timeline_order, `~`),
-        status: reasoning.status,
-        // Same delta-join pattern as `items.text.content` above. Alias
-        // is `reasoningChunk` (not the generic `chunk`) — see the
-        // text-content comment above for the alias-collision bug.
-        content: concat(
-          toArray(
-            q
-              .from({ reasoningChunk: db.collections.reasoningDeltas })
-              .where(({ reasoningChunk }) =>
-                eq(reasoningChunk.reasoning_id, reasoning.key)
-              )
-              .orderBy(({ reasoningChunk }) =>
-                coalesce(reasoningChunk._timeline_order, `~`)
-              )
-              .orderBy(({ reasoningChunk }) => reasoningChunk.key)
-              .select(({ reasoningChunk }) => reasoningChunk.delta)
-          )
-        ),
-        summary_title: reasoning.summary_title,
-        encrypted: reasoning.encrypted,
+      .from({ r: runReasoningSource })
+      .where(({ r }) => eq(r.run_id, run.key))
+      .orderBy(({ r }) => r.order)
+      .orderBy(({ r }) => r.key)
+      .select(({ r }) => ({
+        key: r.key,
+        run_id: r.run_id,
+        order: r.order,
+        status: r.status,
+        // Wrap the include reference inside a `caseWhen` object body
+        // — the same construct items uses to materialize
+        // `item.textContent` into `text.content`. Bare top-level
+        // references leave the include deferred until UI reads it
+        // through `useLiveQuery`, which never gets through. UI reads
+        // `entry.body?.content` instead of `entry.content`.
+        body: caseWhen(r.key, {
+          content: r.reasoningContent,
+        }),
+        summary_title: r.summary_title,
+        encrypted: r.encrypted,
       })),
     steps: q
       .from({ step: db.collections.steps })

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -225,19 +225,15 @@ export interface EntityTimelineReasoningItem {
   run_id?: string
   order: TimelineOrder
   status: `streaming` | `completed`
+  // Concatenated content from all `reasoning_delta` rows for this row,
+  // built live by the query (mirrors `EntityTimelineTextItem.content`).
+  content: string
   // Optional bolded title parsed at write time — only OpenAI Responses
   // emits these; null for Anthropic / DeepSeek / Moonshot.
   summary_title?: string
   // Anthropic redacted-thinking opaque payload. Persist verbatim so we
   // can echo it back on the next turn; the UI shows a placeholder.
   encrypted?: string
-}
-
-export interface EntityTimelineReasoningDeltaItem {
-  key: string
-  reasoning_id: string
-  delta: string
-  order: TimelineOrder
 }
 
 export interface EntityTimelineStepItem {
@@ -264,7 +260,6 @@ export interface EntityTimelineRunRow {
   finish_reason?: string
   items: Collection<EntityTimelineRunItem>
   reasoning: Collection<EntityTimelineReasoningItem>
-  reasoningDeltas: Collection<EntityTimelineReasoningDeltaItem>
   steps: Collection<EntityTimelineStepItem>
   errors: Collection<EntityTimelineErrorItem>
 }
@@ -1388,27 +1383,25 @@ function buildEntityTimelineQuery(
         run_id: reasoning.run_id,
         order: coalesce(reasoning._timeline_order, `~`),
         status: reasoning.status,
-        // `content` intentionally left undefined here — the previous
-        // `concat(toArray(...))` correlated sub-query went stale
-        // (returning `null` even though deltas were present) after the
-        // row's status flipped to `completed`. The UI assembles
-        // content client-side from `run.reasoningDeltas` below, which
-        // is a plain non-correlated query and stays reactive.
+        // Same delta-join pattern as `items.text.content` above. Alias
+        // is `reasoningChunk` (not the generic `chunk`) — see the
+        // text-content comment above for the alias-collision bug.
+        content: concat(
+          toArray(
+            q
+              .from({ reasoningChunk: db.collections.reasoningDeltas })
+              .where(({ reasoningChunk }) =>
+                eq(reasoningChunk.reasoning_id, reasoning.key)
+              )
+              .orderBy(({ reasoningChunk }) =>
+                coalesce(reasoningChunk._timeline_order, `~`)
+              )
+              .orderBy(({ reasoningChunk }) => reasoningChunk.key)
+              .select(({ reasoningChunk }) => reasoningChunk.delta)
+          )
+        ),
         summary_title: reasoning.summary_title,
         encrypted: reasoning.encrypted,
-      })),
-    reasoningDeltas: q
-      .from({ reasoningDelta: db.collections.reasoningDeltas })
-      .where(({ reasoningDelta }) => eq(reasoningDelta.run_id, run.key))
-      .orderBy(({ reasoningDelta }) =>
-        coalesce(reasoningDelta._timeline_order, `~`)
-      )
-      .orderBy(({ reasoningDelta }) => reasoningDelta.key)
-      .select(({ reasoningDelta }) => ({
-        key: reasoningDelta.key,
-        reasoning_id: reasoningDelta.reasoning_id,
-        delta: reasoningDelta.delta,
-        order: coalesce(reasoningDelta._timeline_order, `~`),
       })),
     steps: q
       .from({ step: db.collections.steps })

--- a/packages/agents-runtime/test/entity-timeline.test.ts
+++ b/packages/agents-runtime/test/entity-timeline.test.ts
@@ -2460,7 +2460,7 @@ describe(`entity includes query`, () => {
       expect(runRow).toBeTruthy()
       const reasoning = Array.from(runRow.run.reasoning.toArray) as Array<any>
       expect(reasoning).toHaveLength(1)
-      expect(reasoning[0].content).toBe(`AB`)
+      expect(reasoning[0].body?.content).toBe(`AB`)
     })
 
     it(`reasoning content populates even when text deltas are also present`, async () => {
@@ -2531,7 +2531,9 @@ describe(`entity includes query`, () => {
       expect(runRow).toBeTruthy()
       const reasoning = Array.from(runRow.run.reasoning.toArray) as Array<any>
       expect(reasoning).toHaveLength(1)
-      expect(reasoning[0].content).toBe(`Thinking part 1. Thinking part 2.`)
+      expect(reasoning[0].body?.content).toBe(
+        `Thinking part 1. Thinking part 2.`
+      )
       const items = Array.from(runRow.run.items.toArray) as Array<any>
       expect(items).toHaveLength(1)
       expect(items[0].text?.content).toBe(`Answer part 1. Answer part 2.`)
@@ -2589,7 +2591,7 @@ describe(`entity includes query`, () => {
       expect(reasoning).toHaveLength(1)
       expect(reasoning[0].key).toBe(`reasoning-0`)
       expect(reasoning[0].status).toBe(`completed`)
-      expect(reasoning[0].content).toBe(
+      expect(reasoning[0].body?.content).toBe(
         `First thinking step. Second thinking step.`
       )
     })

--- a/packages/agents-runtime/test/entity-timeline.test.ts
+++ b/packages/agents-runtime/test/entity-timeline.test.ts
@@ -2393,26 +2393,6 @@ describe(`entity includes query`, () => {
       expect(item.text?.content).toBe(`Hello world`)
     })
 
-    it(`legacy reasoning sub-query: returns content even after status flip + post-status updates (currently skipped — sub-query goes stale; see #TODO)`, async () => {
-      // This test reproduces a staleness symptom we saw in the running
-      // app where the reasoning sub-collection's `content` field
-      // (built via `concat(toArray(<correlated delta-join>))`) returned
-      // `null` after the row's status flipped to `completed`. The
-      // current production code doesn't read that field anymore — the
-      // UI assembles content from `run.reasoningDeltas` instead — but
-      // this test is left in place as a placeholder for when we
-      // investigate / fix the underlying TanStack DB correlated
-      // sub-query behavior.
-      //
-      // Skipped by default until the projection is restored.
-      //
-      // To debug: remove the `.skip` and add a `content` field back to
-      // the reasoning sub-collection select in
-      // `entity-timeline.ts:buildEntityTimelineQuery`, then iterate
-      // with very small change-sets between assertions until you find
-      // the trigger.
-    })
-
     it(`reasoning content survives multiple run-row updates in sequence`, async () => {
       // Even closer to production: the run row gets updated MULTIPLE
       // times (each delta + status flip), which may invalidate the
@@ -2480,15 +2460,7 @@ describe(`entity includes query`, () => {
       expect(runRow).toBeTruthy()
       const reasoning = Array.from(runRow.run.reasoning.toArray) as Array<any>
       expect(reasoning).toHaveLength(1)
-      const deltas = Array.from(runRow.run.reasoningDeltas.toArray) as Array<{
-        reasoning_id: string
-        delta: string
-      }>
-      const content = deltas
-        .filter((d) => d.reasoning_id === `reasoning-0`)
-        .map((d) => d.delta)
-        .join(``)
-      expect(content).toBe(`AB`)
+      expect(reasoning[0].content).toBe(`AB`)
     })
 
     it(`reasoning content populates even when text deltas are also present`, async () => {
@@ -2559,14 +2531,7 @@ describe(`entity includes query`, () => {
       expect(runRow).toBeTruthy()
       const reasoning = Array.from(runRow.run.reasoning.toArray) as Array<any>
       expect(reasoning).toHaveLength(1)
-      const reasoningDeltas = Array.from(
-        runRow.run.reasoningDeltas.toArray
-      ) as Array<{ reasoning_id: string; delta: string }>
-      const reasoningContent = reasoningDeltas
-        .filter((d) => d.reasoning_id === `reasoning-0`)
-        .map((d) => d.delta)
-        .join(``)
-      expect(reasoningContent).toBe(`Thinking part 1. Thinking part 2.`)
+      expect(reasoning[0].content).toBe(`Thinking part 1. Thinking part 2.`)
       const items = Array.from(runRow.run.items.toArray) as Array<any>
       expect(items).toHaveLength(1)
       expect(items[0].text?.content).toBe(`Answer part 1. Answer part 2.`)
@@ -2624,14 +2589,9 @@ describe(`entity includes query`, () => {
       expect(reasoning).toHaveLength(1)
       expect(reasoning[0].key).toBe(`reasoning-0`)
       expect(reasoning[0].status).toBe(`completed`)
-      const reasoningDeltas = Array.from(
-        runRow.run.reasoningDeltas.toArray
-      ) as Array<{ reasoning_id: string; delta: string }>
-      const content = reasoningDeltas
-        .filter((d) => d.reasoning_id === `reasoning-0`)
-        .map((d) => d.delta)
-        .join(``)
-      expect(content).toBe(`First thinking step. Second thinking step.`)
+      expect(reasoning[0].content).toBe(
+        `First thinking step. Second thinking step.`
+      )
     })
   })
 })

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -401,54 +401,25 @@ export const AgentResponseLive = memo(function AgentResponseLive({
     (q) => (run.errors ? q.from({ error: run.errors }) : undefined),
     [run.errors]
   )
-  // Subscribe to the run's reasoning rows + deltas. We assemble
-  // `content` client-side from the deltas rather than reading it
-  // off the projected `reasoning.content`, because the correlated
-  // sub-query that produced that field went stale (returning `null`)
-  // after the row's status flipped to `completed`. Client-side
-  // concat is reliable and effectively free at this scale.
+  // Subscribe to the run's reasoning rows so the section ticks as
+  // each `reasoning_delta` arrives. Empty array for runs without
+  // any reasoning content (most non-extended-thinking models).
   const { data: reasoningRows = [] } = useLiveQuery(
     (q) => (run.reasoning ? q.from({ reasoning: run.reasoning }) : undefined),
     [run.reasoning]
   )
-  const { data: reasoningDeltaRows = [] } = useLiveQuery(
-    (q) =>
-      run.reasoningDeltas ? q.from({ delta: run.reasoningDeltas }) : undefined,
-    [run.reasoningDeltas]
-  )
-  const reasoningEntries = useMemo<Array<ReasoningEntry>>(() => {
-    const contentByReasoningId = new Map<string, string>()
-    for (const delta of reasoningDeltaRows as Array<{
-      reasoning_id: string
-      delta: string
-    }>) {
-      contentByReasoningId.set(
-        delta.reasoning_id,
-        (contentByReasoningId.get(delta.reasoning_id) ?? ``) + delta.delta
-      )
-    }
-    return (
-      (
-        reasoningRows as Array<
-          Omit<ReasoningEntry, `content`> & { order?: unknown }
-        >
-      )
+  const reasoningEntries = useMemo<Array<ReasoningEntry>>(
+    () =>
+      (reasoningRows as Array<ReasoningEntry & { order?: unknown }>)
         .slice()
         // The live query already orders by `_timeline_order` then key,
         // but TanStack's projection isn't guaranteed stable across
         // re-mounts — sort by `key` here as a cheap deterministic
         // tiebreaker so the section doesn't visibly reflow between
         // renders if two rows share an order.
-        .sort((a, b) => a.key.localeCompare(b.key))
-        .map<ReasoningEntry>((row) => ({
-          key: row.key,
-          status: row.status,
-          summary_title: row.summary_title,
-          encrypted: row.encrypted,
-          content: contentByReasoningId.get(row.key) ?? ``,
-        }))
-    )
-  }, [reasoningRows, reasoningDeltaRows])
+        .sort((a, b) => a.key.localeCompare(b.key)),
+    [reasoningRows]
+  )
   const sortedItems = useMemo(
     () => [...items].sort(compareLiveRunItems),
     [items]

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -410,14 +410,33 @@ export const AgentResponseLive = memo(function AgentResponseLive({
   )
   const reasoningEntries = useMemo<Array<ReasoningEntry>>(
     () =>
-      (reasoningRows as Array<ReasoningEntry & { order?: unknown }>)
+      (
+        reasoningRows as Array<{
+          key: string
+          status: `streaming` | `completed`
+          body?: { content?: string }
+          summary_title?: string
+          encrypted?: string
+          order?: unknown
+        }>
+      )
         .slice()
         // The live query already orders by `_timeline_order` then key,
         // but TanStack's projection isn't guaranteed stable across
         // re-mounts — sort by `key` here as a cheap deterministic
         // tiebreaker so the section doesn't visibly reflow between
         // renders if two rows share an order.
-        .sort((a, b) => a.key.localeCompare(b.key)),
+        .sort((a, b) => a.key.localeCompare(b.key))
+        .map<ReasoningEntry>((row) => ({
+          key: row.key,
+          status: row.status,
+          summary_title: row.summary_title,
+          encrypted: row.encrypted,
+          // The projection in `entity-timeline.ts` wraps content under
+          // `body` (inside a caseWhen) to force include materialization.
+          // See the comment there.
+          content: row.body?.content ?? ``,
+        })),
     [reasoningRows]
   )
   const sortedItems = useMemo(


### PR DESCRIPTION
## Summary

Follow-up to #4508. Restores the proper server-side projection for
reasoning content — i.e. `run.reasoning.content` computed via
`concat(toArray(<delta-join>))` directly in the timeline live query
— and removes the client-side concatenation workaround that ships in
the parent PR.

**Currently broken in production** against \`@tanstack/db@0.6.7\`.
Holding as a draft so the work isn't lost. **Do not merge** until
the upstream TanStack DB issue is fixed (see below).

## Why this PR exists

In #4508 we shipped client-side delta concatenation because the
server-side projection silently went stale in the running app:
\`run.reasoning[i].content\` came back as \`null\` once the row's
status flipped to \`completed\`, even though the deltas were still
present in \`db.collections.reasoningDeltas\`. A fresh subscription
(reload, navigate-away-and-back) always recovered. Unit tests of the
same projection shape pass cleanly — the bug only reproduces in the
running stack with a long-lived stream-fed live query.

I tried seven reproduction variants against TanStack DB's
\`localOnlyCollectionOptions\` (basic \`.update()\`, deltas-after-
update, concurrent update+sibling-insert, \`_seq\` bump, second live
query mid-flight, immediate-after-update polling, stringly-typed
order). All passed. Suspected differences vs. production:

- \`@durable-streams/state\` sync layer applies events differently
  than direct \`.insert()\` / \`.update()\` calls.
- React-DOM scheduler interactions with \`useLiveQuery\` under
  transitions / suspense.
- HMR-accumulated live-query state (the production session showed
  \`live-query-15\` and later \`live-query-33\` against the same
  underlying collections).

## What this PR changes vs. #4508

- \`entity-timeline.ts\` — add \`content: concat(toArray(<delta-join>))\`
  back to \`reasoning.select(...)\`. Drop the parallel
  \`reasoningDeltas\` sub-collection on \`EntityTimelineRunRow\`.
  Alias stays \`reasoningChunk\` (not \`chunk\`) to avoid the
  alias-collision class of bug we hit and fixed for text-content
  in the parent PR.
- \`EntityTimelineReasoningItem\` — reinstates \`content: string\`.
- \`EntityTimelineReasoningDeltaItem\` — removed.
- \`client.ts\` — drops the now-unused export.
- \`AgentResponseLive\` — drops the \`run.reasoningDeltas\`
  subscription and the client-side concat. \`reasoningEntries\`
  reads \`content\` straight off the projected row.
- Tests — three reasoning-content tests assert
  \`reasoning[0].content\` directly (rather than concatenating raw
  deltas client-side).

All 60 unit tests still pass — the bug doesn't surface in tests.

## Merge criteria

1. Upstream TanStack DB ships a fix for the long-lived
   \`concat(toArray)\` correlated sub-query staleness.
2. The reasoning-content tests in \`entity-timeline.test.ts\` pass
   against a real Electron renderer session — i.e. exercise the
   placeholder "Thought for Ns" expand path on \`kevin/reasoning-content-server-projection\`
   without seeing \`content: null\`.

Until then this PR stays a draft and #4508 ships the client-side
workaround.

## Test plan

- [ ] TanStack DB upstream fix lands and #4508 is rebased onto a
      bumped \`@tanstack/db\` peer.
- [ ] \`pnpm -C packages/agents-runtime test\` — entity-timeline tests
      still pass.
- [ ] Manual: send a Claude prompt with extended thinking, wait for
      reasoning + answer to finish, click "Thought for Ns" → full
      content renders without needing a renderer reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)