### PR TITLE
(sync-service) queryable_columns to only restrict columns changeable by the client

### DIFF
--- a/.changeset/queryable-columns.md
+++ b/.changeset/queryable-columns.md
@@ -2,4 +2,4 @@
 "@core/sync-service": patch
 ---
 
-Add `queryable_columns` as a server-side shape allow-list for columns that may be queried by subset snapshots or synced. This lets proxies decouple the `columns` sync projection from the subset-query security boundary while preventing subset filters and ordering, and projected columns, from referencing non-queryable columns.
+Add `queryable_columns` as a means to restrict access to sensitive columns, a server-side shape allow-list for columns that may be synced or queried by subset snapshots.

--- a/.changeset/queryable-columns.md
+++ b/.changeset/queryable-columns.md
@@ -2,4 +2,4 @@
 "@core/sync-service": patch
 ---
 
-Add `queryable_columns` as a server-side shape allow-list for columns that may be queried or synced. This lets proxies decouple the `columns` sync projection from the security boundary while preventing `where`, subset filters and ordering, and projected columns from referencing non-queryable columns.
+Add `queryable_columns` as a server-side shape allow-list for columns that may be queried by subset snapshots or synced. This lets proxies decouple the `columns` sync projection from the subset-query security boundary while preventing subset filters and ordering, and projected columns, from referencing non-queryable columns.

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -241,10 +241,7 @@ defmodule Electric.Shapes.Shape do
              supported_features,
              Map.put(opts, :queryable_columns, queryable_columns)
            ),
-         refs =
-           column_info
-           |> filter_columns(queryable_columns)
-           |> Inspector.columns_to_expr(),
+         refs = Inspector.columns_to_expr(column_info),
          {:ok, where, shape_dependencies} <-
            validate_where_clause(Map.get(opts, :where), opts, refs) do
       flags =
@@ -571,12 +568,6 @@ defmodule Electric.Shapes.Shape do
     else
       {:error, {:queryable_columns, [err_msg]}}
     end
-  end
-
-  defp filter_columns(column_info, nil), do: column_info
-
-  defp filter_columns(column_info, column_names) do
-    Enum.filter(column_info, &(&1.name in column_names))
   end
 
   defp table_not_found_error(relation),

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -1065,12 +1065,12 @@ defmodule Electric.Plug.RouterTest do
            "CREATE TABLE queryable_users (id BIGINT PRIMARY KEY, name TEXT NOT NULL, secret_token TEXT NOT NULL)",
            "INSERT INTO queryable_users VALUES (1, 'Alice', 'supersecret123')"
          ]
-    test "GET allows where clauses on queryable columns that are not selected", %{opts: opts} do
+    test "GET allows main where clauses outside queryable_columns", %{opts: opts} do
       conn =
         conn("GET", "/v1/shape", %{
           table: "queryable_users",
           offset: "-1",
-          queryable_columns: "id,name,secret_token",
+          queryable_columns: "id,name",
           columns: "id,name",
           where: "secret_token LIKE 'super%'"
         })
@@ -1091,21 +1091,7 @@ defmodule Electric.Plug.RouterTest do
            "CREATE TABLE queryable_users (id BIGINT PRIMARY KEY, name TEXT NOT NULL, secret_token TEXT NOT NULL)",
            "INSERT INTO queryable_users VALUES (1, 'Alice', 'supersecret123')"
          ]
-    test "GET rejects where clauses and selected columns outside queryable_columns", %{opts: opts} do
-      conn =
-        conn("GET", "/v1/shape", %{
-          table: "queryable_users",
-          offset: "-1",
-          queryable_columns: "id,name",
-          columns: "id,name",
-          where: "secret_token LIKE 'super%'"
-        })
-        |> Router.call(opts)
-
-      assert %{status: 400} = conn
-      assert %{"errors" => %{"where" => [message]}} = Jason.decode!(conn.resp_body)
-      assert message =~ "unknown reference secret_token"
-
+    test "GET rejects selected columns outside queryable_columns", %{opts: opts} do
       conn =
         conn("GET", "/v1/shape", %{
           table: "queryable_users",
@@ -3612,6 +3598,29 @@ defmodule Electric.Plug.RouterTest do
       assert %{status: 400} = conn
 
       assert %{"errors" => %{"subset" => %{"where" => [message]}}} =
+               Jason.decode!(conn.resp_body)
+
+      assert message =~ "unknown reference secret_token"
+    end
+
+    @tag with_sql: [
+           "CREATE TABLE queryable_users (id BIGINT PRIMARY KEY, name TEXT NOT NULL, secret_token TEXT NOT NULL)",
+           "INSERT INTO queryable_users VALUES (1, 'Alice', 'supersecret123')"
+         ]
+    test "subset snapshots reject subset__order_by outside queryable_columns", ctx do
+      conn =
+        conn("GET", "/v1/shape", %{
+          "table" => "queryable_users",
+          "offset" => "-1",
+          "queryable_columns" => "id,name",
+          "columns" => "id,name",
+          "subset__order_by" => "secret_token ASC"
+        })
+        |> Router.call(ctx.opts)
+
+      assert %{status: 400} = conn
+
+      assert %{"errors" => %{"subset" => %{"order_by" => [message]}}} =
                Jason.decode!(conn.resp_body)
 
       assert message =~ "unknown reference secret_token"

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -681,7 +681,7 @@ defmodule Electric.Shapes.ShapeTest do
     @tag with_sql: [
            "CREATE TABLE IF NOT EXISTS col_table (id INT PRIMARY KEY, value1 TEXT, value2 TEXT)"
          ]
-    test "validates selected columns and where clauses against queryable columns", %{
+    test "validates selected columns against queryable columns but allows main where", %{
       inspector: inspector
     } do
       assert {:error, {:columns, ["The following columns are not found on the table: value2"]}} =
@@ -691,15 +691,18 @@ defmodule Electric.Shapes.ShapeTest do
                  columns: ["id", "value2"]
                )
 
-      assert {:error, {:where, message}} =
+      assert {:ok,
+              %Shape{
+                selected_columns: ["id", "value1"],
+                queryable_columns: ["id", "value1"],
+                where: %{query: "value2 = 'allowed'"}
+              }} =
                Shape.new("col_table",
                  inspector: inspector,
                  queryable_columns: ["id", "value1"],
                  columns: ["id", "value1"],
-                 where: "value2 = 'blocked'"
+                 where: "value2 = 'allowed'"
                )
-
-      assert message =~ "unknown reference value2"
     end
 
     @tag with_sql: [

--- a/website/docs/sync/guides/auth.md
+++ b/website/docs/sync/guides/auth.md
@@ -306,8 +306,8 @@ Electric separates parameters by purpose:
 - `table` — Root table name (required)
 - `offset` — Shape log position (required, e.g., `-1` for initial sync)
 - `handle` — Shape handle for continuation requests
-- `queryable_columns` — Column allow-list for subset filtering, subset ordering, and synced projections
-- `columns` — Synced column projection
+- `columns` — Columns to sync on the table (if not set, defaults to all columns)
+- `queryable_columns` — Column allow-list for subset filtering, subset ordering, and which columns are synced
 - `where` — Main shape WHERE clause (for non-subset queries)
 - `replica`, `log`, `live`, `live_sse` — Protocol options
 - `secret` / `api_secret` — API authentication
@@ -334,7 +334,7 @@ The proxy must set these **shape definition parameters** server-side — they de
 | Parameter | Where | Security Consideration |
 |-----------|-------|------------------------|
 | `table` | URL | **Must be set server-side.** Letting clients specify the table allows access to any table. |
-| `queryable_columns` | URL | **Must be set server-side if the table has sensitive columns.** Column allow-list for subset filters, subset ordering, and synced projections. It does not restrict the main shape WHERE clause. |
+| `queryable_columns` | URL | **Must be set server-side if the table has sensitive columns.** Column allow-list for subset filters, subset ordering, and which columns are synced. It does not restrict the main shape WHERE clause. |
 | `where` | URL | **Must be set server-side.** This is your authorization filter — the main shape WHERE that restricts all queries. |
 | `secret` | URL | **Must be set server-side.** Never expose the API secret to clients. |
 

--- a/website/docs/sync/guides/auth.md
+++ b/website/docs/sync/guides/auth.md
@@ -306,7 +306,7 @@ Electric separates parameters by purpose:
 - `table` — Root table name (required)
 - `offset` — Shape log position (required, e.g., `-1` for initial sync)
 - `handle` — Shape handle for continuation requests
-- `queryable_columns` — Column allow-list for WHERE, subset filtering, ordering, and synced projections
+- `queryable_columns` — Column allow-list for subset filtering, subset ordering, and synced projections
 - `columns` — Synced column projection
 - `where` — Main shape WHERE clause (for non-subset queries)
 - `replica`, `log`, `live`, `live_sse` — Protocol options
@@ -325,7 +325,7 @@ Electric always combines the main shape WHERE (URL) with the subset WHERE (POST 
 WHERE {main_shape_where} AND ({subset_where})
 ```
 
-This means **subset queries can only narrow results, never widen them**. Even if a client sends `where: "1=1"` in the POST body, the main shape WHERE still applies. The subset WHERE is validated for syntax and prohibited from containing subqueries.
+This means **subset queries can only narrow results, never widen them**. Even if a client sends `where: "1=1"` in the POST body, the main shape WHERE still applies. The subset WHERE is validated for syntax, prohibited from containing subqueries, and limited to columns in `queryable_columns` when it is set.
 
 ##### Parameters your proxy must control
 
@@ -334,7 +334,7 @@ The proxy must set these **shape definition parameters** server-side — they de
 | Parameter | Where | Security Consideration |
 |-----------|-------|------------------------|
 | `table` | URL | **Must be set server-side.** Letting clients specify the table allows access to any table. |
-| `queryable_columns` | URL | **Must be set server-side if the table has sensitive columns.** Column allow-list for WHERE clauses, subset filters, ordering, and synced projections. |
+| `queryable_columns` | URL | **Must be set server-side if the table has sensitive columns.** Column allow-list for subset filters, subset ordering, and synced projections. It does not restrict the main shape WHERE clause. |
 | `where` | URL | **Must be set server-side.** This is your authorization filter — the main shape WHERE that restricts all queries. |
 | `secret` | URL | **Must be set server-side.** Never expose the API secret to clients. |
 
@@ -357,7 +357,7 @@ These parameters are safe because they either can't widen data access or are nee
 | `order_by` | POST body | Sorting for pagination |
 
 :::tip Key Principle
-Your proxy is an **authorization layer** that controls the **shape definition** (table, queryable columns, main WHERE). Clients can freely use subset parameters to filter and paginate within that shape — Electric ensures they can never escape the main WHERE clause and can only reference queryable columns.
+Your proxy is an **authorization layer** that controls the **shape definition** (table, queryable columns, main WHERE). Clients can freely use subset parameters to filter and paginate within that shape — Electric ensures they can never escape the main WHERE clause and can only reference queryable columns in subset filters and sorting.
 :::
 
 ##### Implementing POST support in your proxy
@@ -394,7 +394,7 @@ export async function handler(request: Request) {
 
   // Set shape definition server-side (this is your authorization layer)
   originUrl.searchParams.set(`table`, `items`)
-  originUrl.searchParams.set(`queryable_columns`, `id,title,organization_id`)
+  originUrl.searchParams.set(`queryable_columns`, `id,title,created_at`)
   originUrl.searchParams.set(`columns`, `id,title`)
   originUrl.searchParams.set(`where`, `"organization_id" = '${user.org_id}'`)
   originUrl.searchParams.set(`secret`, process.env.ELECTRIC_SECRET)

--- a/website/docs/sync/guides/shapes.md
+++ b/website/docs/sync/guides/shapes.md
@@ -47,7 +47,7 @@ Shapes are defined by:
 - a [table](#table), such as `items`
 - an optional [where clause](#where-clause) to filter which rows are included in the shape
 - an optional [columns](#columns) clause to select which columns are included
-- an optional [queryable columns](#queryable-columns) clause to restrict which columns may be queried or synced
+- an optional [queryable columns](#queryable-columns) clause to restrict which columns may be queried by subset snapshots or synced
 
 A shape contains all of the rows in the table that match the where clause, if provided. If a columns clause is provided, the synced rows will only contain those selected columns.
 
@@ -249,12 +249,14 @@ The specified columns must always include the primary key column(s), and should 
 
 ### Queryable columns
 
-This is an optional list of columns that may be referenced by shape `where` clauses, subset `where` clauses, subset `order_by` clauses, and the `columns` projection. It is an allow-list for what a request may query or sync; it does not force every listed column to be synced.
+This is an optional list of columns that may be referenced by subset `where` clauses, subset `order_by` clauses, and the `columns` projection. It is an allow-list for what client-controlled subset requests may query or sync; it does not force every listed column to be synced.
 
-For example, this shape can filter by `org_id` without syncing `org_id` to the client:
+`queryable_columns` does not restrict the main shape `where` clause. The main `where` is part of the server-defined shape and should be set by your server or proxy, not by clients.
+
+For example, this shape can filter server-side by `org_id` without syncing `org_id` to the client or allowing client subset requests to reference it:
 
 ```http
-/v1/shape?table=projects&queryable_columns=id,title,org_id&columns=id,title&where=org_id=$1&params[1]=org_123
+/v1/shape?table=projects&queryable_columns=id,title&columns=id,title&where=org_id=$1&params[1]=org_123
 ```
 
 The specified queryable columns must include the primary key column(s). If `queryable_columns` is set and `columns` is omitted, Electric syncs the queryable columns by default.

--- a/website/electric-api.yaml
+++ b/website/electric-api.yaml
@@ -241,11 +241,12 @@ paths:
           schema:
             type: string
           description: |-
-            Optional list of columns that may be referenced by the shape WHERE clause,
-            subset WHERE clauses, subset ORDER BY clauses, and the `columns` projection.
+            Optional list of columns that may be referenced by subset WHERE clauses,
+            subset ORDER BY clauses, and the `columns` projection.
 
-            This is an allow-list for what the request may query or sync. It does not
-            force every listed column to be synced.
+            This is an allow-list for what client-controlled subset requests may query
+            or sync. It does not force every listed column to be synced, and it does
+            not restrict the main shape WHERE clause.
 
             Queryable columns should always include the primary key columns, and should
             be formed as a comma separated list of column names exactly as they are in
@@ -901,8 +902,9 @@ paths:
           schema:
             type: string
           description: |-
-            Optional list of columns that may be referenced by WHERE clauses,
-            subset filters, subset ordering, and the columns projection.
+            Optional list of columns that may be referenced by subset filters,
+            subset ordering, and the columns projection. It does not restrict the
+            main shape WHERE clause.
         - name: replica
           in: query
           schema:


### PR DESCRIPTION
PR #4531 made `queryable_columns` apply to normal shape `where` clauses, but as https://github.com/electric-sql/electric/pull/4531#issuecomment-4650457200 pointed out, sensitive columns could still be accessed via subqueries. Making arbitrary `where` clauses with subqueries secure would require more than a root-table column allow-list: we would also need a table allow-list plus per-table `queryable_columns` for every table referenced by a subquery.

However, normal where clauses are supposed to be restricted and only set server-side. There's no need to restrict them at all. The are to restrict is the subset snapshots, where clients can change subset `where` and `order_by`. 

This PR makes the behavior consistent by allowing any server-defined main `where` clause while keeping `queryable_columns` enforcement for subset `where` and subset `order_by`. It also updates the docs to make this distinction clear too.

## Summary
- allow main shape `where` clauses to reference any table column even when `queryable_columns` is set
- keep `queryable_columns` enforcement for synced projections, subset `where`, and subset `order_by`
- update docs, OpenAPI, and the existing changeset to describe the narrower boundary