### PR TITLE
Optimise relation shape routing

### DIFF
--- a/.changeset/fast-relation-shape-routing.md
+++ b/.changeset/fast-relation-shape-routing.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Speed up relation change routing by collecting shape ids directly from the filter's shape table instead of walking where-condition indexes.

--- a/packages/sync-service/lib/electric/shapes/filter.ex
+++ b/packages/sync-service/lib/electric/shapes/filter.ex
@@ -172,12 +172,7 @@ defmodule Electric.Shapes.Filter do
 
   defp shapes_affected_by_change(%Filter{} = filter, %Relation{} = relation) do
     # Check all shapes is all tables because the table may have been renamed
-    for shape_id <- all_shape_ids(filter),
-        [{_, shape}] = :ets.lookup(filter.shapes_table, shape_id),
-        Shape.is_affected_by_relation_change?(shape, relation),
-        into: MapSet.new() do
-      shape_id
-    end
+    all_shape_ids(filter, &Shape.is_affected_by_relation_change?(&1, relation))
   end
 
   defp shapes_affected_by_change(%Filter{} = filter, %NewRecord{
@@ -218,24 +213,22 @@ defmodule Electric.Shapes.Filter do
     candidates_from_where_condition
   end
 
-  defp all_shape_ids(%Filter{} = filter) do
+  defp all_shape_ids(%Filter{shapes_table: table}, include? \\ :all) do
     :ets.foldl(
-      fn {_table_name, where_cond_id}, acc ->
-        MapSet.union(acc, WhereCondition.all_shape_ids(filter, where_cond_id))
+      fn {shape_id, shape}, acc ->
+        if include? == :all || include?.(shape) do
+          MapSet.put(acc, shape_id)
+        else
+          acc
+        end
       end,
       MapSet.new(),
-      filter.tables_table
+      table
     )
   end
 
   defp shape_ids_for_table(%Filter{} = filter, table_name) do
-    from_where_condition =
-      case :ets.lookup(filter.tables_table, table_name) do
-        [] -> MapSet.new()
-        [{_, where_cond_id}] -> WhereCondition.all_shape_ids(filter, where_cond_id)
-      end
-
-    from_where_condition
+    all_shape_ids(filter, &(&1.root_table == table_name))
   end
 
   @doc """

--- a/packages/sync-service/test/electric/shapes/filter_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter_test.exs
@@ -814,6 +814,33 @@ defmodule Electric.Shapes.FilterTest do
     end
 
     @tag :performance
+    test "relation changes collect shapes without walking nested where condition indexes" do
+      filter = Filter.new()
+
+      Enum.each(1..@shape_count, fn i ->
+        shape = Shape.new!("t1", where: "id = #{i} AND number = 11", inspector: @inspector)
+        Filter.add_shape(filter, i, shape)
+      end)
+
+      relation = %Relation{
+        schema: "public",
+        table: "t1",
+        id: :erlang.phash2({"public", "t1"}),
+        columns: ["id", "number", "an_array"],
+        affected_columns: []
+      }
+
+      assert Filter.affected_shapes(filter, relation) == MapSet.new()
+
+      affected_reductions =
+        reductions(fn ->
+          Filter.affected_shapes(filter, relation)
+        end)
+
+      assert affected_reductions < 100_000
+    end
+
+    @tag :performance
     test "where clause in the form `array_field @> const_array` is optimised" do
       # The optimisation for `@>` is less performant than the other optimisations,
       # however it performs well with lots of shapes. While it can't do


### PR DESCRIPTION
We've seen relation change messages taking 10s to process in production for 20K shapes. This can cause WAL lag.

This PR optimises relation shape routing so that 10s becomes 20ms.

## Summary
- collect relation-affected shape ids directly from the filter shape table
- avoid walking nested where-condition indexes for relation and truncation events
- add a regression test for high-cardinality nested `AND` predicates

## Tests
- `mix test test/electric/shapes/filter_test.exs:817 --include performance`
- `mix test test/electric/shapes/filter_test.exs:124 test/electric/shapes/filter_test.exs:146 test/electric/shapes/filter_test.exs:163 test/electric/shapes/filter_test.exs:182 test/electric/shapes/filter_test.exs:204`

Full `mix test test/electric/shapes/filter_test.exs` was not run to completion locally because existing subquery tests require Postgres on `localhost:54321`.