### PR TITLE
fix(sync-service): Stop the publication manager from getting flooded with duplicate casts

### DIFF
--- a/.changeset/suppress-publication-config-casts.md
+++ b/.changeset/suppress-publication-config-casts.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Suppress redundant publication-configuration casts while a submission is already in flight. Under a burst of shape arrivals the publication manager's RelationTracker no longer mints one Configurator cast per add_shape/remove_shape, preventing the `publication_manager_configurator` mailbox from growing unboundedly (issue #4396).

--- a/.changeset/suppress-publication-config-casts.md
+++ b/.changeset/suppress-publication-config-casts.md
@@ -2,4 +2,4 @@
 '@core/sync-service': patch
 ---
 
-Suppress redundant publication-configuration casts while a submission is already in flight. Under a burst of shape arrivals the publication manager's RelationTracker no longer mints one Configurator cast per add_shape/remove_shape, preventing the `publication_manager_configurator` mailbox from growing unboundedly (issue #4396).
+Avoid sending duplicate publication-configuration requests while one is already in progress. Under a burst of shape arrivals, the publication manager no longer issues a separate request for every shape added or removed, preventing the configurator's message queue from growing without bound (issue #4396).

--- a/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
@@ -307,11 +307,12 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
       )
     end
 
-    {:noreply, state, state.publication_refresh_period}
+    {:noreply, %{state | in_flight_relation_filters: nil}, state.publication_refresh_period}
   end
 
   def handle_cast({:configuration_error, {:error, error}}, state) do
-    {:noreply, reply_to_all_waiters({:error, error}, state), state.publication_refresh_period}
+    state = %{reply_to_all_waiters({:error, error}, state) | in_flight_relation_filters: nil}
+    {:noreply, state, state.publication_refresh_period}
   end
 
   @impl true

--- a/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
@@ -29,11 +29,12 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
     prepared_relation_filters: MapSet.new(),
     submitted_relation_filters: MapSet.new(),
     committed_relation_filters: MapSet.new(),
-    # Snapshot of the filter set carried by the cast currently being processed
-    # by the Configurator. While set, the "committed lags submitted" retry in
-    # update_needed?/1 is suppressed so a burst of add_shape/remove_shape calls
-    # cannot mint one redundant cast each. Cleared on a terminal signal from the
-    # Configurator (full commit, per-relation error, or global error).
+    # The relations covered by the configuration request the Configurator is
+    # currently working on, or nil when none is outstanding. While set, the
+    # "committed lags submitted, retry" branch in update_needed?/1 is held off,
+    # so a burst of add_shape/remove_shape calls can't each send another
+    # duplicate request. Reset to nil once the Configurator reports back (a full
+    # commit, a per-relation error, or a global error).
     in_flight_relation_filters: nil,
     waiters: %{},
     # start with optimistic assumption about what the
@@ -366,12 +367,12 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
        }) do
     prepared_changed? = not MapSet.equal?(prepared, submitted)
 
-    # The committed-lag check is the legitimate "previous attempt didn't fully
-    # commit, retry" signal, but it must not fire while a submission for the
-    # same filters is already in flight — otherwise every add_shape/remove_shape
-    # during that window mints a redundant cast. The publication_refresh_period
-    # inactivity timeout is the fallback retry if a chain dies without delivering
-    # any result.
+    # "submitted but not yet committed" is the legitimate "the last request
+    # didn't fully go through, retry it" signal. But we must not act on it while
+    # a request for the same relations is still outstanding, otherwise every
+    # add_shape/remove_shape in that window would send another duplicate request.
+    # If a request dies without ever reporting back, the publication_refresh_period
+    # inactivity timeout is the fallback that retries.
     retry_needed? = is_nil(in_flight) and not MapSet.equal?(submitted, committed)
 
     prepared_changed? or retry_needed?

--- a/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
@@ -30,11 +30,7 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
     submitted_relation_filters: MapSet.new(),
     committed_relation_filters: MapSet.new(),
     # The relations covered by the configuration request the Configurator is
-    # currently working on, or nil when none is outstanding. While set, the
-    # "committed lags submitted, retry" branch in update_needed?/1 is held off,
-    # so a burst of add_shape/remove_shape calls can't each send another
-    # duplicate request. Reset to nil once the Configurator reports back (a full
-    # commit, a per-relation error, or a global error).
+    # currently working on, or nil when none is outstanding.
     in_flight_relation_filters: nil,
     waiters: %{},
     # start with optimistic assumption about what the

--- a/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
+++ b/packages/sync-service/lib/electric/replication/publication_manager/relation_tracker.ex
@@ -29,6 +29,12 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
     prepared_relation_filters: MapSet.new(),
     submitted_relation_filters: MapSet.new(),
     committed_relation_filters: MapSet.new(),
+    # Snapshot of the filter set carried by the cast currently being processed
+    # by the Configurator. While set, the "committed lags submitted" retry in
+    # update_needed?/1 is suppressed so a burst of add_shape/remove_shape calls
+    # cannot mint one redundant cast each. Cleared on a terminal signal from the
+    # Configurator (full commit, per-relation error, or global error).
+    in_flight_relation_filters: nil,
     waiters: %{},
     # start with optimistic assumption about what the
     # publication supports (altering and generated columns)
@@ -48,6 +54,7 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
            prepared_relation_filters: internal_relation_filters(),
            submitted_relation_filters: internal_relation_filters(),
            committed_relation_filters: internal_relation_filters(),
+           in_flight_relation_filters: internal_relation_filters() | nil,
            waiters: %{Electric.relation_id() => [waiter(), ...]},
            publication_name: String.t(),
            publishes_generated_columns?: boolean(),
@@ -265,16 +272,20 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
   def handle_cast({:relation_configuration_result, {oid, _rel}, {:ok, :dropped}}, state) do
     new_committed_filters = MapSet.delete(state.committed_relation_filters, oid)
 
-    {:noreply, %{state | committed_relation_filters: new_committed_filters},
-     state.publication_refresh_period}
+    state =
+      clear_in_flight_if_committed(%{state | committed_relation_filters: new_committed_filters})
+
+    {:noreply, state, state.publication_refresh_period}
   end
 
   def handle_cast({:relation_configuration_result, {oid, _} = oid_rel, {:ok, :configured}}, state) do
     state = reply_to_relation_waiters(oid_rel, :ok, state)
     new_committed_filters = MapSet.put(state.committed_relation_filters, oid)
 
-    {:noreply, %{state | committed_relation_filters: new_committed_filters},
-     state.publication_refresh_period}
+    state =
+      clear_in_flight_if_committed(%{state | committed_relation_filters: new_committed_filters})
+
+    {:noreply, state, state.publication_refresh_period}
   end
 
   def handle_cast({:relation_configuration_result, oid_rel, {:error, error}}, state) do
@@ -328,7 +339,11 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
       expand_oids(state.prepared_relation_filters, state)
     )
 
-    %{state | submitted_relation_filters: state.prepared_relation_filters}
+    %{
+      state
+      | submitted_relation_filters: state.prepared_relation_filters,
+        in_flight_relation_filters: state.prepared_relation_filters
+    }
   end
 
   @spec expand_oids(MapSet.t(Electric.relation_id()), state()) ::
@@ -345,9 +360,34 @@ defmodule Electric.Replication.PublicationManager.RelationTracker do
   defp update_needed?(%__MODULE__{
          prepared_relation_filters: prepared,
          submitted_relation_filters: submitted,
-         committed_relation_filters: committed
+         committed_relation_filters: committed,
+         in_flight_relation_filters: in_flight
        }) do
-    not MapSet.equal?(prepared, submitted) or not MapSet.equal?(submitted, committed)
+    prepared_changed? = not MapSet.equal?(prepared, submitted)
+
+    # The committed-lag check is the legitimate "previous attempt didn't fully
+    # commit, retry" signal, but it must not fire while a submission for the
+    # same filters is already in flight — otherwise every add_shape/remove_shape
+    # during that window mints a redundant cast. The publication_refresh_period
+    # inactivity timeout is the fallback retry if a chain dies without delivering
+    # any result.
+    retry_needed? = is_nil(in_flight) and not MapSet.equal?(submitted, committed)
+
+    prepared_changed? or retry_needed?
+  end
+
+  @spec clear_in_flight_if_committed(state()) :: state()
+  defp clear_in_flight_if_committed(
+         %__MODULE__{
+           committed_relation_filters: committed,
+           in_flight_relation_filters: in_flight
+         } = state
+       ) do
+    if not is_nil(in_flight) and MapSet.equal?(committed, in_flight) do
+      %{state | in_flight_relation_filters: nil}
+    else
+      state
+    end
   end
 
   @spec add_shape_to_publication_filters(shape_handle(), publication_filter(), state()) :: state()

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -265,6 +265,75 @@ defmodule Electric.Replication.PublicationManagerTest do
       assert MapSet.size(filters) == 1
       refute_receive {:configure_cast, _}, 200
     end
+
+    @tag update_debounce_timeout: 0
+    test "re-issues a configure cast after a global configuration error", ctx do
+      test_pid = self()
+
+      Repatch.patch(
+        PublicationManager.Configurator,
+        :configure_publication,
+        [mode: :shared],
+        fn _stack_id, _filters -> send(test_pid, :configure_cast) end
+      )
+
+      relation_tracker = PublicationManager.RelationTracker.name(ctx.stack_id)
+
+      shape1 = generate_shape(ctx.relation_with_oid, @where_clause_1)
+      run_async(fn -> PublicationManager.add_shape(ctx.stack_id, @shape_handle_1, shape1) end)
+
+      # First submission is now in flight.
+      assert_receive :configure_cast
+
+      # Simulate the in-flight chain dying with a global configuration error.
+      GenServer.cast(
+        relation_tracker,
+        {:configuration_error, {:error, %RuntimeError{message: "boom"}}}
+      )
+
+      # A subsequent add on the SAME relation (no change to prepared filters)
+      # must re-arm the retry path and issue a fresh cast.
+      shape2 = generate_shape(ctx.relation_with_oid, @where_clause_2)
+      run_async(fn -> PublicationManager.add_shape(ctx.stack_id, @shape_handle_2, shape2) end)
+
+      assert_receive :configure_cast, 500
+    end
+
+    @tag update_debounce_timeout: 0
+    test "still issues a cast for a new relation while another submission is in flight", ctx do
+      Postgrex.query!(
+        ctx.pool,
+        "CREATE TABLE other_table (id UUID PRIMARY KEY, value TEXT NOT NULL)",
+        []
+      )
+
+      alt_relation = {"public", "other_table"}
+      alt_relation_oid = lookup_relation_oid(ctx.pool, alt_relation)
+
+      test_pid = self()
+
+      Repatch.patch(
+        PublicationManager.Configurator,
+        :configure_publication,
+        [mode: :shared],
+        fn _stack_id, filters -> send(test_pid, {:configure_cast, filters}) end
+      )
+
+      shape1 = generate_shape(ctx.relation_with_oid, @where_clause_1)
+      run_async(fn -> PublicationManager.add_shape(ctx.stack_id, @shape_handle_1, shape1) end)
+
+      # First relation's submission is in flight (no result delivered).
+      assert_receive {:configure_cast, first_filters}
+      assert MapSet.size(first_filters) == 1
+
+      # Adding a DIFFERENT relation changes `prepared`, so a fresh cast must
+      # still be issued despite the in-flight submission.
+      shape2 = generate_shape({alt_relation_oid, alt_relation}, @where_clause_1)
+      run_async(fn -> PublicationManager.add_shape(ctx.stack_id, @shape_handle_2, shape2) end)
+
+      assert_receive {:configure_cast, second_filters}, 500
+      assert MapSet.size(second_filters) == 2
+    end
   end
 
   describe "remove_shape/2" do

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -233,6 +233,40 @@ defmodule Electric.Replication.PublicationManagerTest do
     end
   end
 
+  describe "cast issuance" do
+    @tag update_debounce_timeout: 0
+    test "issues a single configure cast while a submission is in flight", ctx do
+      test_pid = self()
+
+      # Capture casts to the Configurator without forwarding them, so the
+      # submission never produces a result and `committed` stays behind
+      # `submitted` for the whole test — exactly the in-flight window.
+      Repatch.patch(
+        PublicationManager.Configurator,
+        :configure_publication,
+        [mode: :shared],
+        fn _stack_id, filters -> send(test_pid, {:configure_cast, filters}) end
+      )
+
+      # Three shapes on the SAME relation (same oid) → a single relation
+      # transition. Run them async because, with no result delivered, each
+      # add_shape blocks as a waiter.
+      for {handle, where} <- [
+            {@shape_handle_1, @where_clause_1},
+            {@shape_handle_2, @where_clause_2},
+            {@shape_handle_3, @where_clause_3}
+          ] do
+        shape = generate_shape(ctx.relation_with_oid, where)
+        run_async(fn -> PublicationManager.add_shape(ctx.stack_id, handle, shape) end)
+      end
+
+      # Exactly one cast, carrying the single-relation filter set.
+      assert_receive {:configure_cast, filters}
+      assert MapSet.size(filters) == 1
+      refute_receive {:configure_cast, _}, 200
+    end
+  end
+
   describe "remove_shape/2" do
     test "removes single relation when last shape removed", ctx do
       shape = generate_shape(ctx.relation_with_oid, @where_clause_1)

--- a/packages/sync-service/test/electric/replication/publication_manager_test.exs
+++ b/packages/sync-service/test/electric/replication/publication_manager_test.exs
@@ -334,6 +334,41 @@ defmodule Electric.Replication.PublicationManagerTest do
       assert_receive {:configure_cast, second_filters}, 500
       assert MapSet.size(second_filters) == 2
     end
+
+    @tag update_debounce_timeout: 0
+    test "re-issues a configure cast after a per-relation configuration error", ctx do
+      test_pid = self()
+
+      Repatch.patch(
+        PublicationManager.Configurator,
+        :configure_publication,
+        [mode: :shared],
+        fn _stack_id, _filters -> send(test_pid, :configure_cast) end
+      )
+
+      relation_tracker = PublicationManager.RelationTracker.name(ctx.stack_id)
+      oid_rel = ctx.relation_with_oid
+
+      shape1 = generate_shape(ctx.relation_with_oid, @where_clause_1)
+      run_async(fn -> PublicationManager.add_shape(ctx.stack_id, @shape_handle_1, shape1) end)
+
+      # First submission is now in flight.
+      assert_receive :configure_cast
+
+      # Simulate the in-flight chain reporting a per-relation error for the
+      # relation it was configuring.
+      GenServer.cast(
+        relation_tracker,
+        {:relation_configuration_result, oid_rel, {:error, %RuntimeError{message: "boom"}}}
+      )
+
+      # A subsequent add on the SAME relation (no change to prepared filters)
+      # must re-arm the retry path and issue a fresh cast.
+      shape2 = generate_shape(ctx.relation_with_oid, @where_clause_2)
+      run_async(fn -> PublicationManager.add_shape(ctx.stack_id, @shape_handle_2, shape2) end)
+
+      assert_receive :configure_cast, 500
+    end
   end
 
   describe "remove_shape/2" do


### PR DESCRIPTION
## Summary

Fixes #4396.

Adding or removing a shape can make `RelationTracker` ask the `Configurator` to reconfigure the Postgres publication. The bug: while one such reconfiguration was still in progress, *every* further `add_shape`/`remove_shape` fired off another, redundant request. This happened because the check that decides whether a new request is needed (`update_needed?/1`) treated "request sent but not yet fully committed" as "still needs work", so it kept saying yes for the whole duration of the in-flight request. The Configurator already merges these requests and skips redundant SQL, so the *database* work stayed bounded — but the redundant request *messages* piled up in its mailbox. During the 2026-04-28 Ohm deploy this reached **705,925** queued messages.

The fix gives `RelationTracker` a memory of the request it currently has outstanding (`in_flight_relation_filters`):

- When it sends a reconfigure request, it records which relations that request covers.
- While a request is outstanding, it no longer sends a duplicate just because the previous one hasn't finished committing yet. So a burst of `add_shape`/`remove_shape` calls produces at most one request. (A genuinely new relation is still a real change, so it still triggers exactly one fresh request.)
- It forgets the outstanding request as soon as the Configurator reports back — whether that's a successful commit, a per-relation error, or a global error — which frees it to send the next one.
- If a request silently dies without ever reporting back, a 60s timer still kicks in and retries, so nothing gets stuck forever.

### Note on forgetting the request after a per-relation error

The issue suggested forgetting the outstanding request only on a successful commit or a global error. This PR also forgets it when a *single* relation fails, because the existing behaviour ("keep retrying a relation that keeps failing") depends on it.

This is safe and does **not** bring back the message flood. We only forget the request once the Configurator has actually reported a result back — and getting a result, even an error, means the request ran and made progress. In the production incident there were no results at all (the work was stuck waiting on database locks), so the request would have correctly stayed remembered the whole time. Either way, the number of requests sent is capped by how fast results come back plus the 60s timer — never by how long a single request takes to finish.