### PR TITLE
feat(consumer): bound Shape.Consumer heap growth via spawn opts + adaptive GC

### DIFF
--- a/.changeset/consumer-heap-gc.md
+++ b/.changeset/consumer-heap-gc.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Bound Shape.Consumer heap growth: make the consumer family's process spawn options (incl. `fullsweep_after`) configurable per process via `ELECTRIC_PROCESS_SPAWN_OPTS`, and add an opt-in adaptive GC that runs after a transaction fragment when the consumer's heap exceeds the runtime-tunable `ELECTRIC_CONSUMER_GC_HEAP_THRESHOLD` (off by default).

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -291,6 +291,7 @@ config :electric,
   process_registry_partitions: env!("ELECTRIC_TWEAKS_PROCESS_REGISTRY_PARTITIONS", :integer, nil),
   process_spawn_opts:
     env!("ELECTRIC_PROCESS_SPAWN_OPTS", &Electric.Config.parse_spawn_opts!/1, %{}),
+  consumer_gc_heap_threshold: env!("ELECTRIC_CONSUMER_GC_HEAP_THRESHOLD", :integer, nil),
   http_api_num_acceptors: env!("ELECTRIC_TWEAKS_HTTP_API_NUM_ACCEPTORS", :integer, 100),
   conn_max_requests: env!("ELECTRIC_TWEAKS_CONN_MAX_REQUESTS", :integer, nil),
   handler_fullsweep_after: env!("ELECTRIC_TWEAKS_HANDLER_FULLSWEEP_AFTER", :integer, nil),

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -156,7 +156,8 @@ defmodule Electric.Application do
         shape_suspend_after: get_env(opts, :shape_suspend_after),
         conn_max_requests: get_env(opts, :conn_max_requests),
         handler_fullsweep_after: get_env(opts, :handler_fullsweep_after),
-        process_spawn_opts: get_env(opts, :process_spawn_opts)
+        process_spawn_opts: get_env(opts, :process_spawn_opts),
+        consumer_gc_heap_threshold: get_env(opts, :consumer_gc_heap_threshold)
       ],
       manual_table_publishing?: get_env(opts, :manual_table_publishing?),
       shape_db_opts: [

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -115,8 +115,7 @@ defmodule Electric.Config do
     # e.g. %{shape_log_collector: [min_heap_size: 1024 * 1024, min_bin_vheap_size: 1024 * 1024]}
     process_spawn_opts: %{},
     # Heap-size threshold (in BYTES) above which a consumer runs :erlang.garbage_collect()
-    # after processing a transaction fragment. nil disables adaptive GC. Looked up at
-    # runtime via StackConfig so it can be changed from a live IEx shell.
+    # after processing a transaction fragment.
     consumer_gc_heap_threshold: nil,
     ## Misc
     process_registry_partitions: &Electric.Config.Defaults.process_registry_partitions/0,

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -114,6 +114,10 @@ defmodule Electric.Config do
     #
     # e.g. %{shape_log_collector: [min_heap_size: 1024 * 1024, min_bin_vheap_size: 1024 * 1024]}
     process_spawn_opts: %{},
+    # Heap-size threshold (in BYTES) above which a consumer runs :erlang.garbage_collect()
+    # after processing a transaction fragment. nil disables adaptive GC. Looked up at
+    # runtime via StackConfig so it can be changed from a live IEx shell.
+    consumer_gc_heap_threshold: nil,
     ## Misc
     process_registry_partitions: &Electric.Config.Defaults.process_registry_partitions/0,
     feature_flags: if(Mix.env() == :test, do: @known_feature_flags, else: []),

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -897,7 +897,10 @@ defmodule Electric.Shapes.Consumer do
     {txn_fragments, state} = State.pop_buffered(state)
 
     Enum.reduce_while(txn_fragments, state, fn txn_fragment, state ->
-      state = handle_txn_fragment(txn_fragment, state)
+      state =
+        txn_fragment
+        |> handle_txn_fragment(state)
+        |> maybe_garbage_collect()
 
       if state.terminating? do
         {:halt, state}

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -518,7 +518,32 @@ defmodule Electric.Shapes.Consumer do
 
   defp handle_event(%TransactionFragment{} = txn_fragment, state) do
     Logger.debug(fn -> "Txn fragment received in Shapes.Consumer: #{inspect(txn_fragment)}" end)
-    handle_txn_fragment(txn_fragment, state)
+
+    txn_fragment
+    |> handle_txn_fragment(state)
+    |> maybe_garbage_collect()
+  end
+
+  defp maybe_garbage_collect(%State{stack_id: stack_id} = state) do
+    threshold = Electric.StackConfig.lookup(stack_id, :consumer_gc_heap_threshold, nil)
+
+    if not is_nil(threshold) do
+      {:total_heap_size, heap_words} = :erlang.process_info(self(), :total_heap_size)
+
+      if over_heap_threshold?(heap_words, threshold) do
+        :erlang.garbage_collect()
+      end
+    end
+
+    state
+  end
+
+  @doc false
+  # heap_words: process total_heap_size in words; threshold_bytes: configured byte threshold (or nil)
+  def over_heap_threshold?(_heap_words, nil), do: false
+
+  def over_heap_threshold?(heap_words, threshold_bytes) when is_integer(threshold_bytes) do
+    heap_words * :erlang.system_info(:wordsize) > threshold_bytes
   end
 
   # A consumer process starts with buffering?=true before it has PG snapshot info (xmin, xmax, xip_list).

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -121,77 +121,16 @@ defmodule Electric.Shapes.Consumer do
 
   @doc """
   Set the adaptive-GC heap threshold (bytes, or nil to disable) for a single stack.
-  Takes effect immediately for that stack's consumers — safe to call from IEx.
 
-  **Critical-path note**: this GC runs synchronously on the replication path —
-  the ShapeLogCollector blocks until every consumer replies. Prefer a conservative
-  (high) threshold to minimise added publish latency. The per-process
-  `fullsweep_after` spawn-opt (configured via `ELECTRIC_PROCESS_SPAWN_OPTS`) is
-  the lower-risk lever for steady-state heap bounding; this adaptive GC is a
-  targeted, runtime-tunable backstop. Forced-GC frequency is capped to at most
-  once per `@gc_min_interval_ms` (see `should_force_gc?/5`).
+  Consumers cache this value at startup (see `State.new/2`), so the new threshold only
+  applies to consumers started after this call — already-running consumers keep the
+  threshold they read when they booted. Safe to call from IEx.
   """
   @spec set_gc_heap_threshold(Electric.stack_id(), non_neg_integer() | nil) :: :ok
   def set_gc_heap_threshold(stack_id, threshold_bytes)
       when is_nil(threshold_bytes) or (is_integer(threshold_bytes) and threshold_bytes >= 0) do
     Electric.StackConfig.put(stack_id, :consumer_gc_heap_threshold, threshold_bytes)
     :ok
-  end
-
-  @doc """
-  Set the adaptive-GC heap threshold for every live stack on this node.
-  Returns `{:ok, number_of_stacks_updated}`. Pass nil to disable everywhere.
-  Intended for live experimentation from an IEx shell.
-  """
-  @spec set_gc_heap_threshold_all_stacks(non_neg_integer() | nil) :: {:ok, non_neg_integer()}
-  def set_gc_heap_threshold_all_stacks(threshold_bytes) do
-    stack_ids = list_stack_ids()
-
-    # Guard against a stack dying between enumeration and the put: if the
-    # StackConfig ETS table vanishes, StackConfig.put/3 raises ArgumentError.
-    # We skip such stale entries rather than crashing the operator call.
-    # Only successfully-written stacks are counted so the returned value
-    # reflects reality even when stacks die mid-iteration.
-    count =
-      Enum.reduce(stack_ids, 0, fn stack_id, acc ->
-        try do
-          set_gc_heap_threshold(stack_id, threshold_bytes)
-          acc + 1
-        rescue
-          ArgumentError -> acc
-        end
-      end)
-
-    {:ok, count}
-  end
-
-  # Enumerate live stacks by scanning ETS tables whose names match the
-  # Electric.StackConfig table-name prefix ("Electric.StackConfig:<stack_id>").
-  # This is the most direct approach: StackConfig creates one named ETS table per
-  # stack, so the set of live tables IS the set of live stacks.
-  # No first-class listing API exists in the codebase (grep confirmed).
-  # A race (stack dies mid-iteration) is harmless: StackConfig.put/3 on a vanished
-  # table would raise ArgumentError, which we rescue and skip.
-  defp list_stack_ids do
-    prefix = "#{inspect(Electric.StackConfig)}:"
-    prefix_len = byte_size(prefix)
-
-    :ets.all()
-    |> Enum.flat_map(fn tab ->
-      case :ets.info(tab, :name) do
-        :undefined ->
-          []
-
-        name ->
-          name_str = Atom.to_string(name)
-
-          if String.starts_with?(name_str, prefix) do
-            [binary_part(name_str, prefix_len, byte_size(name_str) - prefix_len)]
-          else
-            []
-          end
-      end
-    end)
   end
 
   def start_link(%{stack_id: stack_id, shape_handle: shape_handle} = _config) do
@@ -608,47 +547,29 @@ defmodule Electric.Shapes.Consumer do
     |> maybe_garbage_collect()
   end
 
-  # NOTE: this runs synchronously on the replication critical path — the
-  # ShapeLogCollector blocks until every consumer replies. A forced
-  # :erlang.garbage_collect() can add measurable publish latency, especially
-  # during a buffered-fragment drain where maybe_garbage_collect/1 is called
-  # for every queued fragment in a tight loop.
-  #
-  # Two safeguards limit the impact:
-  #   1. The nil fast-path exits immediately when no threshold is configured.
-  #   2. Hysteresis (@gc_min_interval_ms) prevents back-to-back full sweeps even
-  #      when the consumer sits just above the threshold across many fragments.
-  #
-  # Operators should prefer a CONSERVATIVE (high) threshold. For steady-state
-  # heap bounding the per-process `fullsweep_after` spawn-opt (set via
-  # ELECTRIC_PROCESS_SPAWN_OPTS) is a lower-risk alternative; this adaptive GC
-  # is a targeted, runtime-tunable backstop.
-  defp maybe_garbage_collect(%State{stack_id: stack_id} = state) do
-    case Electric.StackConfig.lookup(stack_id, :consumer_gc_heap_threshold, nil) do
-      nil ->
-        # Fast path: adaptive GC is disabled — skip all process_info/time calls.
-        state
+  # Fast path: adaptive GC is disabled — skip all process_info/time calls.
+  defp maybe_garbage_collect(%State{gc_heap_threshold: nil} = state), do: state
 
-      threshold ->
-        {:total_heap_size, heap_words} = :erlang.process_info(self(), :total_heap_size)
-        now = System.monotonic_time(:millisecond)
+  defp maybe_garbage_collect(%State{gc_heap_threshold: threshold_bytes} = state) do
+    {:total_heap_size, heap_words} = :erlang.process_info(self(), :total_heap_size)
+    heap_bytes = heap_words * @word_size
+    now = System.monotonic_time(:millisecond)
 
-        if should_force_gc?(heap_words, threshold, state.last_forced_gc_at, now) do
-          :erlang.garbage_collect()
-          %{state | last_forced_gc_at: now}
-        else
-          state
-        end
+    if should_force_gc?(heap_bytes, threshold_bytes, state.last_forced_gc_at, now) do
+      :erlang.garbage_collect()
+      %{state | last_forced_gc_at: now}
+    else
+      state
     end
   end
 
   @doc false
-  # heap_words: process total_heap_size in words; threshold_bytes: configured byte threshold (or nil)
+  # heap_bytes: process total_heap_size in bytes; threshold_bytes: configured byte threshold (or nil)
   @spec over_heap_threshold?(non_neg_integer(), non_neg_integer() | nil) :: boolean()
-  def over_heap_threshold?(_heap_words, nil), do: false
+  def over_heap_threshold?(_heap_bytes, nil), do: false
 
-  def over_heap_threshold?(heap_words, threshold_bytes) when is_integer(threshold_bytes) do
-    heap_words * @word_size > threshold_bytes
+  def over_heap_threshold?(heap_bytes, threshold_bytes) when is_integer(threshold_bytes) do
+    heap_bytes > threshold_bytes
   end
 
   @doc false
@@ -665,17 +586,17 @@ defmodule Electric.Shapes.Consumer do
           non_neg_integer()
         ) :: boolean()
   def should_force_gc?(
-        heap_words,
+        heap_bytes,
         threshold_bytes,
         last_gc_at,
         now_ms,
         min_interval_ms \\ @gc_min_interval_ms
       )
 
-  def should_force_gc?(_heap_words, nil, _last_gc_at, _now_ms, _min_interval_ms), do: false
+  def should_force_gc?(_heap_bytes, nil, _last_gc_at, _now_ms, _min_interval_ms), do: false
 
-  def should_force_gc?(heap_words, threshold_bytes, last_gc_at, now_ms, min_interval_ms) do
-    over_heap_threshold?(heap_words, threshold_bytes) and
+  def should_force_gc?(heap_bytes, threshold_bytes, last_gc_at, now_ms, min_interval_ms) do
+    over_heap_threshold?(heap_bytes, threshold_bytes) and
       (is_nil(last_gc_at) or now_ms - last_gc_at >= min_interval_ms)
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -132,15 +132,19 @@ defmodule Electric.Shapes.Consumer do
     # Guard against a stack dying between enumeration and the put: if the
     # StackConfig ETS table vanishes, StackConfig.put/3 raises ArgumentError.
     # We skip such stale entries rather than crashing the operator call.
-    Enum.each(stack_ids, fn stack_id ->
-      try do
-        set_gc_heap_threshold(stack_id, threshold_bytes)
-      rescue
-        ArgumentError -> :ok
-      end
-    end)
+    # Only successfully-written stacks are counted so the returned value
+    # reflects reality even when stacks die mid-iteration.
+    count =
+      Enum.reduce(stack_ids, 0, fn stack_id, acc ->
+        try do
+          set_gc_heap_threshold(stack_id, threshold_bytes)
+          acc + 1
+        rescue
+          ArgumentError -> acc
+        end
+      end)
 
-    {:ok, length(stack_ids)}
+    {:ok, count}
   end
 
   # Enumerate live stacks by scanning ETS tables whose names match the

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -564,20 +564,11 @@ defmodule Electric.Shapes.Consumer do
   end
 
   @doc false
-  # heap_bytes: process total_heap_size in bytes; threshold_bytes: configured byte threshold (or nil)
-  @spec over_heap_threshold?(non_neg_integer(), non_neg_integer() | nil) :: boolean()
-  def over_heap_threshold?(_heap_bytes, nil), do: false
-
-  def over_heap_threshold?(heap_bytes, threshold_bytes) when is_integer(threshold_bytes) do
-    heap_bytes > threshold_bytes
-  end
-
-  @doc false
-  # Decide whether to force a full GC sweep: heap must be over the threshold AND
-  # at least @gc_min_interval_ms must have elapsed since the last forced GC.
-  # last_gc_at / now_ms are monotonic milliseconds; last_gc_at is nil if this
-  # consumer has never forced a GC (always fire on first over-threshold event).
-  # Passing explicit min_interval_ms enables deterministic unit tests.
+  # Decide whether to force a full GC sweep: heap (bytes) must be over the
+  # threshold (bytes) AND at least @gc_min_interval_ms must have elapsed since the
+  # last forced GC. last_gc_at / now_ms are monotonic milliseconds; last_gc_at is
+  # nil if this consumer has never forced a GC (always fire on first over-threshold
+  # event). Passing explicit min_interval_ms enables deterministic unit tests.
   @spec should_force_gc?(
           non_neg_integer(),
           non_neg_integer() | nil,
@@ -596,7 +587,7 @@ defmodule Electric.Shapes.Consumer do
   def should_force_gc?(_heap_bytes, nil, _last_gc_at, _now_ms, _min_interval_ms), do: false
 
   def should_force_gc?(heap_bytes, threshold_bytes, last_gc_at, now_ms, min_interval_ms) do
-    over_heap_threshold?(heap_bytes, threshold_bytes) and
+    heap_bytes > threshold_bytes and
       (is_nil(last_gc_at) or now_ms - last_gc_at >= min_interval_ms)
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -40,6 +40,14 @@ defmodule Electric.Shapes.Consumer do
   @stop_and_clean_reason ShapeCleaner.consumer_cleanup_reason()
   @word_size :erlang.system_info(:wordsize)
 
+  # Minimum wall-clock interval (ms) between consumer-forced full GC sweeps.
+  # Prevents GC-thrashing on the replication critical path: the ShapeLogCollector
+  # blocks until every consumer replies, so a forced GC on every fragment (e.g.
+  # during a buffered-fragment drain) would add publish latency proportional to
+  # the number of fragments. Hysteresis caps the worst-case frequency to at most
+  # one forced sweep per @gc_min_interval_ms regardless of fragment rate.
+  @gc_min_interval_ms 1_000
+
   @type initialize_shape_opts() :: %{
           :action => :create | :restore,
           optional(:otel_ctx) => OpenTelemetry.otel_ctx() | nil,
@@ -114,7 +122,16 @@ defmodule Electric.Shapes.Consumer do
   @doc """
   Set the adaptive-GC heap threshold (bytes, or nil to disable) for a single stack.
   Takes effect immediately for that stack's consumers — safe to call from IEx.
+
+  **Critical-path note**: this GC runs synchronously on the replication path —
+  the ShapeLogCollector blocks until every consumer replies. Prefer a conservative
+  (high) threshold to minimise added publish latency. The per-process
+  `fullsweep_after` spawn-opt (configured via `ELECTRIC_PROCESS_SPAWN_OPTS`) is
+  the lower-risk lever for steady-state heap bounding; this adaptive GC is a
+  targeted, runtime-tunable backstop. Forced-GC frequency is capped to at most
+  once per `@gc_min_interval_ms` (see `should_force_gc?/5`).
   """
+  @spec set_gc_heap_threshold(Electric.stack_id(), non_neg_integer() | nil) :: :ok
   def set_gc_heap_threshold(stack_id, threshold_bytes)
       when is_nil(threshold_bytes) or (is_integer(threshold_bytes) and threshold_bytes >= 0) do
     Electric.StackConfig.put(stack_id, :consumer_gc_heap_threshold, threshold_bytes)
@@ -126,6 +143,7 @@ defmodule Electric.Shapes.Consumer do
   Returns `{:ok, number_of_stacks_updated}`. Pass nil to disable everywhere.
   Intended for live experimentation from an IEx shell.
   """
+  @spec set_gc_heap_threshold_all_stacks(non_neg_integer() | nil) :: {:ok, non_neg_integer()}
   def set_gc_heap_threshold_all_stacks(threshold_bytes) do
     stack_ids = list_stack_ids()
 
@@ -590,24 +608,75 @@ defmodule Electric.Shapes.Consumer do
     |> maybe_garbage_collect()
   end
 
+  # NOTE: this runs synchronously on the replication critical path — the
+  # ShapeLogCollector blocks until every consumer replies. A forced
+  # :erlang.garbage_collect() can add measurable publish latency, especially
+  # during a buffered-fragment drain where maybe_garbage_collect/1 is called
+  # for every queued fragment in a tight loop.
+  #
+  # Two safeguards limit the impact:
+  #   1. The nil fast-path exits immediately when no threshold is configured.
+  #   2. Hysteresis (@gc_min_interval_ms) prevents back-to-back full sweeps even
+  #      when the consumer sits just above the threshold across many fragments.
+  #
+  # Operators should prefer a CONSERVATIVE (high) threshold. For steady-state
+  # heap bounding the per-process `fullsweep_after` spawn-opt (set via
+  # ELECTRIC_PROCESS_SPAWN_OPTS) is a lower-risk alternative; this adaptive GC
+  # is a targeted, runtime-tunable backstop.
   defp maybe_garbage_collect(%State{stack_id: stack_id} = state) do
     case Electric.StackConfig.lookup(stack_id, :consumer_gc_heap_threshold, nil) do
       nil ->
+        # Fast path: adaptive GC is disabled — skip all process_info/time calls.
         state
 
       threshold ->
         {:total_heap_size, heap_words} = :erlang.process_info(self(), :total_heap_size)
-        if over_heap_threshold?(heap_words, threshold), do: :erlang.garbage_collect()
-        state
+        now = System.monotonic_time(:millisecond)
+
+        if should_force_gc?(heap_words, threshold, state.last_forced_gc_at, now) do
+          :erlang.garbage_collect()
+          %{state | last_forced_gc_at: now}
+        else
+          state
+        end
     end
   end
 
   @doc false
   # heap_words: process total_heap_size in words; threshold_bytes: configured byte threshold (or nil)
+  @spec over_heap_threshold?(non_neg_integer(), non_neg_integer() | nil) :: boolean()
   def over_heap_threshold?(_heap_words, nil), do: false
 
   def over_heap_threshold?(heap_words, threshold_bytes) when is_integer(threshold_bytes) do
     heap_words * @word_size > threshold_bytes
+  end
+
+  @doc false
+  # Decide whether to force a full GC sweep: heap must be over the threshold AND
+  # at least @gc_min_interval_ms must have elapsed since the last forced GC.
+  # last_gc_at / now_ms are monotonic milliseconds; last_gc_at is nil if this
+  # consumer has never forced a GC (always fire on first over-threshold event).
+  # Passing explicit min_interval_ms enables deterministic unit tests.
+  @spec should_force_gc?(
+          non_neg_integer(),
+          non_neg_integer() | nil,
+          integer() | nil,
+          integer(),
+          non_neg_integer()
+        ) :: boolean()
+  def should_force_gc?(
+        heap_words,
+        threshold_bytes,
+        last_gc_at,
+        now_ms,
+        min_interval_ms \\ @gc_min_interval_ms
+      )
+
+  def should_force_gc?(_heap_words, nil, _last_gc_at, _now_ms, _min_interval_ms), do: false
+
+  def should_force_gc?(heap_words, threshold_bytes, last_gc_at, now_ms, min_interval_ms) do
+    over_heap_threshold?(heap_words, threshold_bytes) and
+      (is_nil(last_gc_at) or now_ms - last_gc_at >= min_interval_ms)
   end
 
   # A consumer process starts with buffering?=true before it has PG snapshot info (xmin, xmax, xip_list).

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -40,12 +40,9 @@ defmodule Electric.Shapes.Consumer do
   @stop_and_clean_reason ShapeCleaner.consumer_cleanup_reason()
   @word_size :erlang.system_info(:wordsize)
 
-  # Minimum wall-clock interval (ms) between consumer-forced full GC sweeps.
-  # Prevents GC-thrashing on the replication critical path: the ShapeLogCollector
-  # blocks until every consumer replies, so a forced GC on every fragment (e.g.
-  # during a buffered-fragment drain) would add publish latency proportional to
-  # the number of fragments. Hysteresis caps the worst-case frequency to at most
-  # one forced sweep per @gc_min_interval_ms regardless of fragment rate.
+  # Minimum wall-clock interval (ms) between consumer-forced full GC sweeps. Caps how much CPU
+  # a busy consumer spends on full sweeps to at most one per @gc_min_interval_ms regardless of
+  # fragment rate.
   @gc_min_interval_ms 1_000
 
   @type initialize_shape_opts() :: %{
@@ -194,8 +191,17 @@ defmodule Electric.Shapes.Consumer do
     if state.terminating? do
       {:noreply, state, {:continue, :stop_and_clean}}
     else
-      {:noreply, state, state.hibernate_after}
+      {:noreply, state, {:continue, :maybe_gc}}
     end
+  end
+
+  # Deferred adaptive GC. Reached via {:continue, :maybe_gc} after a fragment (or a
+  # full buffer drain) has been processed, so a forced full sweep runs off the
+  # reply/critical path rather than blocking the ShapeLogCollector. Re-establishes
+  # the hibernate_after timeout that the {:continue, …} return could not carry.
+  def handle_continue(:maybe_gc, state) do
+    state = maybe_garbage_collect(state)
+    {:noreply, state, state.hibernate_after}
   end
 
   @impl GenServer
@@ -228,7 +234,7 @@ defmodule Electric.Shapes.Consumer do
         {:reply, :ok, state, {:continue, :stop_and_clean}}
 
       state ->
-        {:reply, :ok, state, state.hibernate_after}
+        {:reply, :ok, state, {:continue, :maybe_gc}}
     end
   end
 
@@ -542,10 +548,14 @@ defmodule Electric.Shapes.Consumer do
   defp handle_event(%TransactionFragment{} = txn_fragment, state) do
     Logger.debug(fn -> "Txn fragment received in Shapes.Consumer: #{inspect(txn_fragment)}" end)
 
-    txn_fragment
-    |> handle_txn_fragment(state)
-    |> maybe_garbage_collect()
+    handle_txn_fragment(txn_fragment, state)
   end
+
+  # Adaptive GC check. Always invoked from a {:continue, :maybe_gc} handler so the
+  # forced full sweep runs off the ShapeLogCollector's synchronous publish path: the
+  # SLC has already received :ok by the time this runs. Because the SLC publishes
+  # fragments to a given consumer sequentially, the continue typically completes
+  # before the next fragment arrives, so it does not block steady-state throughput.
 
   # Fast path: adaptive GC is disabled — skip all process_info/time calls.
   defp maybe_garbage_collect(%State{gc_heap_threshold: nil} = state), do: state
@@ -878,10 +888,7 @@ defmodule Electric.Shapes.Consumer do
     {txn_fragments, state} = State.pop_buffered(state)
 
     Enum.reduce_while(txn_fragments, state, fn txn_fragment, state ->
-      state =
-        txn_fragment
-        |> handle_txn_fragment(state)
-        |> maybe_garbage_collect()
+      state = handle_txn_fragment(txn_fragment, state)
 
       if state.terminating? do
         {:halt, state}

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -111,6 +111,67 @@ defmodule Electric.Shapes.Consumer do
     ConsumerRegistry.whereis(stack_id, shape_handle)
   end
 
+  @doc """
+  Set the adaptive-GC heap threshold (bytes, or nil to disable) for a single stack.
+  Takes effect immediately for that stack's consumers — safe to call from IEx.
+  """
+  def set_gc_heap_threshold(stack_id, threshold_bytes)
+      when is_nil(threshold_bytes) or (is_integer(threshold_bytes) and threshold_bytes >= 0) do
+    Electric.StackConfig.put(stack_id, :consumer_gc_heap_threshold, threshold_bytes)
+    :ok
+  end
+
+  @doc """
+  Set the adaptive-GC heap threshold for every live stack on this node.
+  Returns `{:ok, number_of_stacks_updated}`. Pass nil to disable everywhere.
+  Intended for live experimentation from an IEx shell.
+  """
+  def set_gc_heap_threshold_all_stacks(threshold_bytes) do
+    stack_ids = list_stack_ids()
+
+    # Guard against a stack dying between enumeration and the put: if the
+    # StackConfig ETS table vanishes, StackConfig.put/3 raises ArgumentError.
+    # We skip such stale entries rather than crashing the operator call.
+    Enum.each(stack_ids, fn stack_id ->
+      try do
+        set_gc_heap_threshold(stack_id, threshold_bytes)
+      rescue
+        ArgumentError -> :ok
+      end
+    end)
+
+    {:ok, length(stack_ids)}
+  end
+
+  # Enumerate live stacks by scanning ETS tables whose names match the
+  # Electric.StackConfig table-name prefix ("Electric.StackConfig:<stack_id>").
+  # This is the most direct approach: StackConfig creates one named ETS table per
+  # stack, so the set of live tables IS the set of live stacks.
+  # No first-class listing API exists in the codebase (grep confirmed).
+  # A race (stack dies mid-iteration) is harmless: StackConfig.put/3 on a vanished
+  # table would raise ArgumentError, which we rescue and skip.
+  defp list_stack_ids do
+    prefix = "#{inspect(Electric.StackConfig)}:"
+    prefix_len = byte_size(prefix)
+
+    :ets.all()
+    |> Enum.flat_map(fn tab ->
+      case :ets.info(tab, :name) do
+        :undefined ->
+          []
+
+        name ->
+          name_str = Atom.to_string(name)
+
+          if String.starts_with?(name_str, prefix) do
+            [binary_part(name_str, prefix_len, byte_size(name_str) - prefix_len)]
+          else
+            []
+          end
+      end
+    end)
+  end
+
   def start_link(%{stack_id: stack_id, shape_handle: shape_handle} = _config) do
     GenServer.start_link(__MODULE__, %{stack_id: stack_id, shape_handle: shape_handle},
       name: name(stack_id, shape_handle),

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -112,7 +112,8 @@ defmodule Electric.Shapes.Consumer do
 
   def start_link(%{stack_id: stack_id, shape_handle: shape_handle} = _config) do
     GenServer.start_link(__MODULE__, %{stack_id: stack_id, shape_handle: shape_handle},
-      name: name(stack_id, shape_handle)
+      name: name(stack_id, shape_handle),
+      spawn_opt: Electric.StackConfig.spawn_opts(stack_id, :consumer)
     )
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -38,6 +38,7 @@ defmodule Electric.Shapes.Consumer do
   @default_snapshot_timeout 45_000
   @stop_and_clean_timeout 30_000
   @stop_and_clean_reason ShapeCleaner.consumer_cleanup_reason()
+  @word_size :erlang.system_info(:wordsize)
 
   @type initialize_shape_opts() :: %{
           :action => :create | :restore,
@@ -525,17 +526,15 @@ defmodule Electric.Shapes.Consumer do
   end
 
   defp maybe_garbage_collect(%State{stack_id: stack_id} = state) do
-    threshold = Electric.StackConfig.lookup(stack_id, :consumer_gc_heap_threshold, nil)
+    case Electric.StackConfig.lookup(stack_id, :consumer_gc_heap_threshold, nil) do
+      nil ->
+        state
 
-    if not is_nil(threshold) do
-      {:total_heap_size, heap_words} = :erlang.process_info(self(), :total_heap_size)
-
-      if over_heap_threshold?(heap_words, threshold) do
-        :erlang.garbage_collect()
-      end
+      threshold ->
+        {:total_heap_size, heap_words} = :erlang.process_info(self(), :total_heap_size)
+        if over_heap_threshold?(heap_words, threshold), do: :erlang.garbage_collect()
+        state
     end
-
-    state
   end
 
   @doc false
@@ -543,7 +542,7 @@ defmodule Electric.Shapes.Consumer do
   def over_heap_threshold?(_heap_words, nil), do: false
 
   def over_heap_threshold?(heap_words, threshold_bytes) when is_integer(threshold_bytes) do
-    heap_words * :erlang.system_info(:wordsize) > threshold_bytes
+    heap_words * @word_size > threshold_bytes
   end
 
   # A consumer process starts with buffering?=true before it has PG snapshot info (xmin, xmax, xip_list).

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -547,7 +547,6 @@ defmodule Electric.Shapes.Consumer do
 
   defp handle_event(%TransactionFragment{} = txn_fragment, state) do
     Logger.debug(fn -> "Txn fragment received in Shapes.Consumer: #{inspect(txn_fragment)}" end)
-
     handle_txn_fragment(txn_fragment, state)
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -111,7 +111,10 @@ defmodule Electric.Shapes.Consumer.Materializer do
     do: subscribe(%{stack_id: stack_id, shape_handle: shape_handle})
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: name(opts))
+    GenServer.start_link(__MODULE__, opts,
+      name: name(opts),
+      spawn_opt: Electric.StackConfig.spawn_opts(opts.stack_id, :consumer_materializer)
+    )
   end
 
   def init(opts) do

--- a/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/snapshotter.ex
@@ -20,7 +20,10 @@ defmodule Electric.Shapes.Consumer.Snapshotter do
   end
 
   def start_link(config) when is_map(config) do
-    GenServer.start_link(__MODULE__, config, name: name(config))
+    GenServer.start_link(__MODULE__, config,
+      name: name(config),
+      spawn_opt: Electric.StackConfig.spawn_opts(config.stack_id, :consumer_snapshotter)
+    )
   end
 
   def init(config) do

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -47,7 +47,10 @@ defmodule Electric.Shapes.Consumer.State do
     # as any message arrives (activity), so at most one is ever live at a time.
     suspend_timer: nil,
     # How long after hibernation to suspend (in ms)
-    suspend_after: nil
+    suspend_after: nil,
+    # Monotonic millisecond timestamp of the last consumer-forced GC (nil if never).
+    # Used by hysteresis logic in maybe_garbage_collect/1 to cap forced-GC frequency.
+    last_forced_gc_at: nil
   ]
 
   @type pg_snapshot() :: SnapshotQuery.pg_snapshot()

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -50,7 +50,13 @@ defmodule Electric.Shapes.Consumer.State do
     suspend_after: nil,
     # Monotonic millisecond timestamp of the last consumer-forced GC (nil if never).
     # Used by hysteresis logic in maybe_garbage_collect/1 to cap forced-GC frequency.
-    last_forced_gc_at: nil
+    last_forced_gc_at: nil,
+    # Adaptive-GC heap threshold (bytes) cached at consumer startup, or nil when
+    # disabled. Read once from StackConfig in new/2 so the per-fragment GC check on
+    # the replication critical path stays a plain struct field access instead of an
+    # ETS lookup. Changing the StackConfig value only affects consumers started
+    # afterwards (see Consumer.set_gc_heap_threshold/2).
+    gc_heap_threshold: nil
   ]
 
   @type pg_snapshot() :: SnapshotQuery.pg_snapshot()
@@ -110,6 +116,7 @@ defmodule Electric.Shapes.Consumer.State do
           :shape_suspend_after,
           Electric.Config.default(:shape_suspend_after)
         ),
+      gc_heap_threshold: Electric.StackConfig.lookup(stack_id, :consumer_gc_heap_threshold, nil),
       buffering?: true
     }
   end

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -52,10 +52,7 @@ defmodule Electric.Shapes.Consumer.State do
     # Used by hysteresis logic in maybe_garbage_collect/1 to cap forced-GC frequency.
     last_forced_gc_at: nil,
     # Adaptive-GC heap threshold (bytes) cached at consumer startup, or nil when
-    # disabled. Read once from StackConfig in new/2 so the per-fragment GC check on
-    # the replication critical path stays a plain struct field access instead of an
-    # ETS lookup. Changing the StackConfig value only affects consumers started
-    # afterwards (see Consumer.set_gc_heap_threshold/2).
+    # disabled.
     gc_heap_threshold: nil
   ]
 

--- a/packages/sync-service/lib/electric/stack_config.ex
+++ b/packages/sync-service/lib/electric/stack_config.ex
@@ -33,7 +33,8 @@ defmodule Electric.StackConfig do
       shape_suspend_after: Electric.Config.default(:shape_suspend_after),
       chunk_bytes_threshold: Electric.ShapeCache.LogChunker.default_chunk_size_threshold(),
       feature_flags: [],
-      process_spawn_opts: %{}
+      process_spawn_opts: %{},
+      consumer_gc_heap_threshold: Electric.Config.default(:consumer_gc_heap_threshold)
     ]
   end
 

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -154,6 +154,10 @@ defmodule Electric.StackSupervisor do
                        default: nil
                      ],
                      process_spawn_opts: [type: :map, default: %{}],
+                     consumer_gc_heap_threshold: [
+                       type: {:or, [:non_neg_integer, nil]},
+                       default: Electric.Config.default(:consumer_gc_heap_threshold)
+                     ],
                      consumer_partitions: [type: {:or, [:pos_integer, nil]}, default: nil]
                    ]
                  ],
@@ -357,6 +361,7 @@ defmodule Electric.StackSupervisor do
     shape_enable_suspend? = Keyword.fetch!(config.tweaks, :shape_enable_suspend?)
     shape_suspend_after = Keyword.fetch!(config.tweaks, :shape_suspend_after)
     process_spawn_opts = Keyword.fetch!(config.tweaks, :process_spawn_opts)
+    consumer_gc_heap_threshold = Keyword.fetch!(config.tweaks, :consumer_gc_heap_threshold)
 
     shape_cache_opts = [
       stack_id: stack_id
@@ -407,6 +412,7 @@ defmodule Electric.StackSupervisor do
            shape_enable_suspend?: shape_enable_suspend?,
            shape_suspend_after: shape_suspend_after,
            process_spawn_opts: process_spawn_opts,
+           consumer_gc_heap_threshold: consumer_gc_heap_threshold,
            feature_flags: Map.get(config, :feature_flags, [])
          ]},
         {Electric.AsyncDeleter,

--- a/packages/sync-service/test/electric/config_test.exs
+++ b/packages/sync-service/test/electric/config_test.exs
@@ -130,4 +130,43 @@ defmodule Electric.ConfigTest do
       end
     end
   end
+
+  describe "tweaks propagation" do
+    setup do
+      initial_config = Application.get_all_env(:electric)
+
+      for {key, _} <- initial_config do
+        Application.delete_env(:electric, key)
+      end
+
+      on_exit(fn ->
+        Application.put_all_env([{:electric, initial_config}])
+      end)
+
+      [initial_config: initial_config]
+    end
+
+    test "consumer_gc_heap_threshold opt is threaded into tweaks", ctx do
+      threshold = 209_715_200
+
+      config =
+        Electric.Application.configuration(
+          Keyword.merge(
+            Keyword.take(ctx.initial_config, [:replication_connection_opts]),
+            consumer_gc_heap_threshold: threshold
+          )
+        )
+
+      assert Keyword.fetch!(config[:tweaks], :consumer_gc_heap_threshold) == threshold
+    end
+
+    test "consumer_gc_heap_threshold defaults to nil in tweaks", ctx do
+      config =
+        Electric.Application.configuration(
+          Keyword.take(ctx.initial_config, [:replication_connection_opts])
+        )
+
+      assert Keyword.fetch!(config[:tweaks], :consumer_gc_heap_threshold) == nil
+    end
+  end
 end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2891,6 +2891,32 @@ defmodule Electric.Shapes.ConsumerTest do
     end
   end
 
+  describe "set_gc_heap_threshold helpers" do
+    # with_stack_id_from_test (line 87) already starts ProcessRegistry + StackConfig
+    # for ctx.stack_id — no heavier setup is needed for these pure-config tests.
+
+    test "set_gc_heap_threshold/2 writes the value into StackConfig", ctx do
+      assert :ok = Electric.Shapes.Consumer.set_gc_heap_threshold(ctx.stack_id, 2_000_000)
+
+      assert 2_000_000 ==
+               Electric.StackConfig.lookup(ctx.stack_id, :consumer_gc_heap_threshold, nil)
+    end
+
+    test "set_gc_heap_threshold/2 accepts nil to disable", ctx do
+      Electric.Shapes.Consumer.set_gc_heap_threshold(ctx.stack_id, 123)
+      assert :ok = Electric.Shapes.Consumer.set_gc_heap_threshold(ctx.stack_id, nil)
+      assert nil == Electric.StackConfig.lookup(ctx.stack_id, :consumer_gc_heap_threshold, nil)
+    end
+
+    test "set_gc_heap_threshold_all_stacks/1 sets the live stack", ctx do
+      assert {:ok, n} = Electric.Shapes.Consumer.set_gc_heap_threshold_all_stacks(3_000_000)
+      assert n >= 1
+
+      assert 3_000_000 ==
+               Electric.StackConfig.lookup(ctx.stack_id, :consumer_gc_heap_threshold, nil)
+    end
+  end
+
   defp get_log_items_from_storage(offset, shape_storage) do
     Storage.get_log_stream(offset, shape_storage) |> Enum.map(&Jason.decode!/1)
   end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2693,8 +2693,7 @@ defmodule Electric.Shapes.ConsumerTest do
       assert_receive {Support.TestStorage, :init_writer!, @shape_handle1, @shape1}
       :started = Consumer.await_snapshot_start(ctx.stack_id, @shape_handle1)
 
-      pid = Consumer.name(ctx.stack_id, @shape_handle1) |> GenServer.whereis()
-      info = Process.info(pid)
+      info = Process.info(consumer)
 
       assert info[:priority] == :high
       assert info[:garbage_collection][:fullsweep_after] == 4

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2722,24 +2722,6 @@ defmodule Electric.Shapes.ConsumerTest do
     :ok
   end
 
-  describe "over_heap_threshold?/2" do
-    test "false when threshold is nil" do
-      refute Electric.Shapes.Consumer.over_heap_threshold?(1_000_000, nil)
-    end
-
-    test "false when heap is below threshold" do
-      refute Electric.Shapes.Consumer.over_heap_threshold?(10, 1024)
-    end
-
-    test "true when heap exceeds threshold" do
-      assert Electric.Shapes.Consumer.over_heap_threshold?(1000, 1)
-    end
-
-    test "exactly-equal is not over threshold" do
-      refute Electric.Shapes.Consumer.over_heap_threshold?(1024, 1024)
-    end
-  end
-
   describe "should_force_gc?/5" do
     # All tests pass explicit now_ms / last_gc_at / min_interval_ms so they are
     # fully deterministic and do not depend on wall-clock time.
@@ -2775,6 +2757,10 @@ defmodule Electric.Shapes.ConsumerTest do
 
     test "false when heap is under threshold even if interval would have elapsed" do
       refute Electric.Shapes.Consumer.should_force_gc?(1, 1_000, 0, 5_000, 1_000)
+    end
+
+    test "false when heap exactly equals threshold (strict comparison)" do
+      refute Electric.Shapes.Consumer.should_force_gc?(1_000, 1_000, nil, 5_000, 1_000)
     end
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2741,6 +2741,44 @@ defmodule Electric.Shapes.ConsumerTest do
     end
   end
 
+  describe "should_force_gc?/5" do
+    # All tests pass explicit now_ms / last_gc_at / min_interval_ms so they are
+    # fully deterministic and do not depend on wall-clock time.
+
+    test "false when threshold is nil (adaptive GC disabled)" do
+      refute Electric.Shapes.Consumer.should_force_gc?(1_000_000, nil, nil, 5_000, 1_000)
+    end
+
+    test "true when heap over threshold and consumer has never forced a GC (last_gc_at nil)" do
+      # 1 000 words * 8 bytes/word = 8 000 bytes > threshold of 1 byte
+      assert Electric.Shapes.Consumer.should_force_gc?(1_000, 1, nil, 5_000, 1_000)
+    end
+
+    test "false when heap over threshold but interval has not elapsed" do
+      # last_gc_at=4_500, now=5_000 → delta=500 < min_interval=1_000 → no GC
+      refute Electric.Shapes.Consumer.should_force_gc?(1_000, 1, 4_500, 5_000, 1_000)
+    end
+
+    test "true when heap over threshold and interval has elapsed" do
+      # last_gc_at=3_000, now=5_000 → delta=2_000 >= min_interval=1_000 → GC
+      assert Electric.Shapes.Consumer.should_force_gc?(1_000, 1, 3_000, 5_000, 1_000)
+    end
+
+    test "true at exactly the min interval boundary" do
+      # last_gc_at=4_000, now=5_000 → delta=1_000 == min_interval=1_000 → GC
+      assert Electric.Shapes.Consumer.should_force_gc?(1_000, 1, 4_000, 5_000, 1_000)
+    end
+
+    test "false when heap is under threshold regardless of timing" do
+      # heap_words=1 * wordsize (8) = 8 bytes; threshold=1_000 bytes → under
+      refute Electric.Shapes.Consumer.should_force_gc?(1, 1_000, nil, 5_000, 1_000)
+    end
+
+    test "false when heap is under threshold even if interval would have elapsed" do
+      refute Electric.Shapes.Consumer.should_force_gc?(1, 1_000, 0, 5_000, 1_000)
+    end
+  end
+
   describe "adaptive GC after fragment processing" do
     @describetag :tmp_dir
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2722,6 +2722,137 @@ defmodule Electric.Shapes.ConsumerTest do
     :ok
   end
 
+  describe "over_heap_threshold?/2" do
+    test "false when threshold is nil" do
+      refute Electric.Shapes.Consumer.over_heap_threshold?(1_000_000, nil)
+    end
+
+    test "false when heap (words) is below threshold (bytes)" do
+      refute Electric.Shapes.Consumer.over_heap_threshold?(10, 1024)
+    end
+
+    test "true when heap (words) exceeds threshold (bytes)" do
+      assert Electric.Shapes.Consumer.over_heap_threshold?(1000, 1)
+    end
+
+    test "exactly-equal is not over threshold" do
+      wordsize = :erlang.system_info(:wordsize)
+      refute Electric.Shapes.Consumer.over_heap_threshold?(1, wordsize)
+    end
+  end
+
+  describe "adaptive GC after fragment processing" do
+    @describetag :tmp_dir
+
+    setup do
+      %{inspector: @base_inspector, pool: nil}
+    end
+
+    setup [
+      :with_registry,
+      :with_pure_file_storage,
+      :with_shape_status,
+      :with_lsn_tracker,
+      :with_log_chunking,
+      :with_persistent_kv,
+      :with_async_deleter,
+      :with_shape_cleaner,
+      :with_shape_log_collector,
+      :with_noop_publication_manager,
+      :with_status_monitor
+    ]
+
+    setup(ctx) do
+      patch_snapshotter(fn parent, shape_handle, _shape, %{snapshot_fun: snapshot_fun} ->
+        pg_snapshot = {10, 11, [10]}
+        GenServer.cast(parent, {:pg_snapshot_known, shape_handle, pg_snapshot})
+        GenServer.cast(parent, {:snapshot_started, shape_handle})
+        snapshot_fun.([])
+      end)
+
+      Electric.StackConfig.put(ctx.stack_id, :shape_hibernate_after, 10_000)
+      :ok
+    end
+
+    setup ctx do
+      %{consumer_supervisor: consumer_supervisor, shape_cache: shape_cache} =
+        Support.ComponentSetup.with_shape_cache(ctx)
+
+      %{
+        consumer_supervisor: consumer_supervisor,
+        shape_cache: shape_cache
+      }
+    end
+
+    test "GC runs when heap exceeds tiny threshold", ctx do
+      Electric.StackConfig.put(ctx.stack_id, :consumer_gc_heap_threshold, 1)
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, ctx.stack_id)
+      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
+
+      consumer_pid = Consumer.whereis(ctx.stack_id, shape_handle)
+      ref = Shapes.Consumer.register_for_changes(ctx.stack_id, shape_handle)
+
+      xid = 11
+      lsn = Lsn.from_integer(10)
+
+      {:total_heap_size, heap_before} = :erlang.process_info(consumer_pid, :total_heap_size)
+
+      # Inflate the consumer's heap by sending a large binary payload
+      large_binary = :binary.copy(<<0>>, 200_000)
+
+      txn =
+        complete_txn_fragment(xid, lsn, [
+          %Changes.NewRecord{
+            relation: {"public", "test_table"},
+            record: %{"id" => "1", "value" => large_binary},
+            log_offset: LogOffset.new(lsn, 0)
+          }
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
+
+      # Wait for the consumer to process the fragment
+      assert_receive {^ref, :new_changes, _}, @receive_timeout
+
+      {:total_heap_size, heap_after} = :erlang.process_info(consumer_pid, :total_heap_size)
+
+      # GC should have run (heap_after <= heap_before is the indicator),
+      # or at minimum the heap hasn't grown unboundedly relative to what we sent.
+      # Since threshold=1 forces GC on every fragment, the heap post-GC should
+      # be well below the inflated size. We verify the GC fired by checking that
+      # the post-fragment heap is not larger than the pre-fragment heap (i.e., GC ran).
+      assert heap_after <= heap_before * 2,
+             "Expected GC to reclaim heap after large fragment (before=#{heap_before} words, after=#{heap_after} words)"
+    end
+
+    test "no GC by default (threshold=nil)", ctx do
+      # Ensure no threshold is set (default behaviour)
+      assert nil == Electric.StackConfig.lookup(ctx.stack_id, :consumer_gc_heap_threshold, nil)
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, ctx.stack_id)
+      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
+
+      ref = Shapes.Consumer.register_for_changes(ctx.stack_id, shape_handle)
+
+      xid = 11
+      lsn = Lsn.from_integer(10)
+
+      txn =
+        complete_txn_fragment(xid, lsn, [
+          %Changes.NewRecord{
+            relation: {"public", "test_table"},
+            record: %{"id" => "1"},
+            log_offset: LogOffset.new(lsn, 0)
+          }
+        ])
+
+      # Should process without error even when no GC threshold is configured
+      assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
+      assert_receive {^ref, :new_changes, _}, @receive_timeout
+    end
+  end
+
   defp get_log_items_from_storage(offset, shape_storage) do
     Storage.get_log_stream(offset, shape_storage) |> Enum.map(&Jason.decode!/1)
   end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2827,8 +2827,6 @@ defmodule Electric.Shapes.ConsumerTest do
 
       xid = 11
       lsn = Lsn.from_integer(10)
-
-      # Inflate the consumer's heap by sending a large binary payload
       large_binary = :binary.copy(<<0>>, 200_000)
 
       txn =
@@ -2841,19 +2839,17 @@ defmodule Electric.Shapes.ConsumerTest do
         ])
 
       assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
-
-      # Wait for the consumer to process the fragment
       assert_receive {^ref, :new_changes, _}, @receive_timeout
 
-      {:total_heap_size, heap_after} = :erlang.process_info(consumer_pid, :total_heap_size)
+      # GC runs in the deferred {:continue, :maybe_gc} after the reply. A synchronous
+      # call is queued behind the pending continue, so :sys.get_state returns only
+      # once the GC has run — and lets us read last_forced_gc_at, which the consumer
+      # stamps iff it forced a sweep. That is a direct signal of our decision,
+      # immune to natural BEAM GCs and heap-size timing.
+      assert %{last_forced_gc_at: forced_at} = :sys.get_state(consumer_pid)
 
-      # threshold=1 forces a full GC after this fragment. Because the ~200 KB payload is
-      # transient garbage (not live state), the post-GC heap must be far below the payload
-      # size. Without GC the heap grows ~185x (observed), so this assertion fails loudly.
-      payload_words = div(200_000, :erlang.system_info(:wordsize))
-
-      assert heap_after < payload_words,
-             "heap_after (#{heap_after} words) should be far below payload (#{payload_words} words) after GC"
+      refute is_nil(forced_at),
+             "threshold=1 keeps the heap over threshold, so a forced GC should be recorded"
     end
 
     test "GC does not run when threshold is very large", ctx do
@@ -2868,8 +2864,6 @@ defmodule Electric.Shapes.ConsumerTest do
 
       xid = 11
       lsn = Lsn.from_integer(10)
-
-      # Inflate the consumer's heap by sending a large binary payload
       large_binary = :binary.copy(<<0>>, 200_000)
 
       txn =
@@ -2882,18 +2876,14 @@ defmodule Electric.Shapes.ConsumerTest do
         ])
 
       assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
-
-      # Wait for the consumer to process the fragment
       assert_receive {^ref, :new_changes, _}, @receive_timeout
 
-      {:total_heap_size, heap_after} = :erlang.process_info(consumer_pid, :total_heap_size)
+      # Flush the deferred :maybe_gc continue and read the state. The heap stays well
+      # under the 1 GB threshold, so the consumer must not have forced a sweep.
+      assert %{last_forced_gc_at: forced_at} = :sys.get_state(consumer_pid)
 
-      # GC was NOT triggered (threshold too high), so the heap still reflects
-      # the retained payload — it must be >= payload_words.
-      payload_words = div(200_000, :erlang.system_info(:wordsize))
-
-      assert heap_after >= payload_words,
-             "heap_after (#{heap_after} words) should be >= payload (#{payload_words} words) when GC is skipped"
+      assert is_nil(forced_at),
+             "no forced GC should be recorded while under threshold, got #{inspect(forced_at)}"
     end
 
     test "no GC by default (threshold=nil)", ctx do
@@ -2924,10 +2914,10 @@ defmodule Electric.Shapes.ConsumerTest do
 
     @tag delay_snapshot_creation?: true
     test "GC runs during buffered-fragment drain when heap exceeds threshold", ctx do
-      # threshold=1 forces GC after every fragment processed during the buffer drain.
-      # The consumer starts with buffering?=true; fragments sent before pg_snapshot_known
-      # land in the buffer. When we unblock the snapshotter it fires pg_snapshot_known
-      # which triggers :consume_buffer → process_buffered_txn_fragments (our new GC call).
+      # threshold=1 forces a GC once the buffered fragments are drained. The consumer
+      # starts with buffering?=true; fragments sent before pg_snapshot_known land in the
+      # buffer. When we unblock the snapshotter it fires pg_snapshot_known which triggers
+      # :consume_buffer → drains the buffer → {:continue, :maybe_gc} runs the GC once.
       Electric.StackConfig.put(ctx.stack_id, :consumer_gc_heap_threshold, 1)
 
       {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, ctx.stack_id)
@@ -2936,9 +2926,6 @@ defmodule Electric.Shapes.ConsumerTest do
       assert_receive {:snapshot, ^shape_handle, snapshotter_pid}
 
       consumer_pid = Consumer.whereis(ctx.stack_id, shape_handle)
-
-      # Trace GC events on the consumer to count full GCs fired during the drain.
-      :erlang.trace(consumer_pid, true, [:garbage_collection])
 
       # Send a large-payload fragment while buffering?=true — it goes into the buffer.
       large_binary = :binary.copy(<<0>>, 200_000)
@@ -2956,34 +2943,20 @@ defmodule Electric.Shapes.ConsumerTest do
 
       assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
 
-      # Unblock the snapshotter: fires pg_snapshot_known → :consume_buffer →
-      # process_buffered_txn_fragments where our new maybe_garbage_collect() call fires.
+      # Unblock the snapshotter: fires pg_snapshot_known → :consume_buffer → drains the
+      # buffer, then defers a single GC via {:continue, :maybe_gc}.
       send(snapshotter_pid, {self(), :resume})
 
       ref = Shapes.Consumer.register_for_changes(ctx.stack_id, shape_handle)
       assert_receive {^ref, :new_changes, _}, @receive_timeout
 
-      :erlang.trace(consumer_pid, false, [:garbage_collection])
+      # The deferred GC runs in the :maybe_gc continue after the drain. Flush it with a
+      # synchronous call (queued behind the continue), then check last_forced_gc_at —
+      # the consumer stamps it iff it forced a sweep for the drained fragment.
+      assert %{last_forced_gc_at: forced_at} = :sys.get_state(consumer_pid)
 
-      # Count how many full GC (garbage_collect) trace messages arrived.
-      # :garbage_collection traces emit {:trace, pid, :gc_major_start, info} /
-      # :gc_major_end pairs (one per full :erlang.garbage_collect() call).
-      gc_events =
-        Stream.repeatedly(fn ->
-          receive do
-            {:trace, ^consumer_pid, :gc_major_start, _} -> :gc
-            {:trace, ^consumer_pid, :gc_minor_start, _} -> :minor
-            {:trace, ^consumer_pid, :gc_major_end, _} -> :skip
-            {:trace, ^consumer_pid, :gc_minor_end, _} -> :skip
-          after
-            0 -> :done
-          end
-        end)
-        |> Stream.take_while(&(&1 != :done))
-        |> Enum.count(&(&1 == :gc))
-
-      assert gc_events >= 1,
-             "expected at least one full GC during buffered-fragment drain, got #{gc_events}"
+      refute is_nil(forced_at),
+             "expected a forced GC to be recorded after the buffered-fragment drain"
     end
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2727,17 +2727,16 @@ defmodule Electric.Shapes.ConsumerTest do
       refute Electric.Shapes.Consumer.over_heap_threshold?(1_000_000, nil)
     end
 
-    test "false when heap (words) is below threshold (bytes)" do
+    test "false when heap is below threshold" do
       refute Electric.Shapes.Consumer.over_heap_threshold?(10, 1024)
     end
 
-    test "true when heap (words) exceeds threshold (bytes)" do
+    test "true when heap exceeds threshold" do
       assert Electric.Shapes.Consumer.over_heap_threshold?(1000, 1)
     end
 
     test "exactly-equal is not over threshold" do
-      wordsize = :erlang.system_info(:wordsize)
-      refute Electric.Shapes.Consumer.over_heap_threshold?(1, wordsize)
+      refute Electric.Shapes.Consumer.over_heap_threshold?(1024, 1024)
     end
   end
 
@@ -2750,7 +2749,7 @@ defmodule Electric.Shapes.ConsumerTest do
     end
 
     test "true when heap over threshold and consumer has never forced a GC (last_gc_at nil)" do
-      # 1 000 words * 8 bytes/word = 8 000 bytes > threshold of 1 byte
+      # 1_000 bytes > threshold of 1 byte
       assert Electric.Shapes.Consumer.should_force_gc?(1_000, 1, nil, 5_000, 1_000)
     end
 
@@ -2770,7 +2769,7 @@ defmodule Electric.Shapes.ConsumerTest do
     end
 
     test "false when heap is under threshold regardless of timing" do
-      # heap_words=1 * wordsize (8) = 8 bytes; threshold=1_000 bytes → under
+      # heap=1 byte; threshold=1_000 bytes → under
       refute Electric.Shapes.Consumer.should_force_gc?(1, 1_000, nil, 5_000, 1_000)
     end
 
@@ -3017,14 +3016,6 @@ defmodule Electric.Shapes.ConsumerTest do
       Electric.Shapes.Consumer.set_gc_heap_threshold(ctx.stack_id, 123)
       assert :ok = Electric.Shapes.Consumer.set_gc_heap_threshold(ctx.stack_id, nil)
       assert nil == Electric.StackConfig.lookup(ctx.stack_id, :consumer_gc_heap_threshold, nil)
-    end
-
-    test "set_gc_heap_threshold_all_stacks/1 sets the live stack", ctx do
-      assert {:ok, n} = Electric.Shapes.Consumer.set_gc_heap_threshold_all_stacks(3_000_000)
-      assert n >= 1
-
-      assert 3_000_000 ==
-               Electric.StackConfig.lookup(ctx.stack_id, :consumer_gc_heap_threshold, nil)
     end
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2763,7 +2763,16 @@ defmodule Electric.Shapes.ConsumerTest do
     ]
 
     setup(ctx) do
+      delay_snapshot_creation? = Map.get(ctx, :delay_snapshot_creation?)
+      test_pid = self()
+
       patch_snapshotter(fn parent, shape_handle, _shape, %{snapshot_fun: snapshot_fun} ->
+        if delay_snapshot_creation? do
+          receive do
+            {^test_pid, :resume} -> :ok
+          end
+        end
+
         pg_snapshot = {10, 11, [10]}
         GenServer.cast(parent, {:pg_snapshot_known, shape_handle, pg_snapshot})
         GenServer.cast(parent, {:snapshot_started, shape_handle})
@@ -2888,6 +2897,70 @@ defmodule Electric.Shapes.ConsumerTest do
       # Should process without error even when no GC threshold is configured
       assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
       assert_receive {^ref, :new_changes, _}, @receive_timeout
+    end
+
+    @tag delay_snapshot_creation?: true
+    test "GC runs during buffered-fragment drain when heap exceeds threshold", ctx do
+      # threshold=1 forces GC after every fragment processed during the buffer drain.
+      # The consumer starts with buffering?=true; fragments sent before pg_snapshot_known
+      # land in the buffer. When we unblock the snapshotter it fires pg_snapshot_known
+      # which triggers :consume_buffer → process_buffered_txn_fragments (our new GC call).
+      Electric.StackConfig.put(ctx.stack_id, :consumer_gc_heap_threshold, 1)
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, ctx.stack_id)
+
+      # The snapshotter is now running but blocked on `receive {^test_pid, :resume}`.
+      assert_receive {:snapshot, ^shape_handle, snapshotter_pid}
+
+      consumer_pid = Consumer.whereis(ctx.stack_id, shape_handle)
+
+      # Trace GC events on the consumer to count full GCs fired during the drain.
+      :erlang.trace(consumer_pid, true, [:garbage_collection])
+
+      # Send a large-payload fragment while buffering?=true — it goes into the buffer.
+      large_binary = :binary.copy(<<0>>, 200_000)
+      xid = 11
+      lsn = Lsn.from_integer(10)
+
+      txn =
+        complete_txn_fragment(xid, lsn, [
+          %Changes.NewRecord{
+            relation: {"public", "test_table"},
+            record: %{"id" => "1", "value" => large_binary},
+            log_offset: LogOffset.new(lsn, 0)
+          }
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
+
+      # Unblock the snapshotter: fires pg_snapshot_known → :consume_buffer →
+      # process_buffered_txn_fragments where our new maybe_garbage_collect() call fires.
+      send(snapshotter_pid, {self(), :resume})
+
+      ref = Shapes.Consumer.register_for_changes(ctx.stack_id, shape_handle)
+      assert_receive {^ref, :new_changes, _}, @receive_timeout
+
+      :erlang.trace(consumer_pid, false, [:garbage_collection])
+
+      # Count how many full GC (garbage_collect) trace messages arrived.
+      # :garbage_collection traces emit {:trace, pid, :gc_major_start, info} /
+      # :gc_major_end pairs (one per full :erlang.garbage_collect() call).
+      gc_events =
+        Stream.repeatedly(fn ->
+          receive do
+            {:trace, ^consumer_pid, :gc_major_start, _} -> :gc
+            {:trace, ^consumer_pid, :gc_minor_start, _} -> :minor
+            {:trace, ^consumer_pid, :gc_major_end, _} -> :skip
+            {:trace, ^consumer_pid, :gc_minor_end, _} -> :skip
+          after
+            0 -> :done
+          end
+        end)
+        |> Stream.take_while(&(&1 != :done))
+        |> Enum.count(&(&1 == :gc))
+
+      assert gc_events >= 1,
+             "expected at least one full GC during buffered-fragment drain, got #{gc_events}"
     end
   end
 

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2652,6 +2652,77 @@ defmodule Electric.Shapes.ConsumerTest do
     )
   end
 
+  describe "process gc configuration" do
+    setup [
+      :with_registry,
+      :with_in_memory_storage,
+      :with_shape_status,
+      :with_lsn_tracker,
+      :with_persistent_kv,
+      :with_status_monitor,
+      :with_dynamic_consumer_supervisor,
+      :with_noop_publication_manager,
+      :with_shape_cleaner
+    ]
+
+    setup ctx do
+      start_link_supervised!({
+        ShapeLogCollector.Supervisor,
+        stack_id: ctx.stack_id, persistent_kv: ctx.persistent_kv, inspector: @base_inspector
+      })
+
+      ShapeLogCollector.mark_as_ready(ctx.stack_id)
+      [shape_position: @shape_position]
+    end
+
+    @tag process_spawn_opts: %{consumer: [fullsweep_after: 4, priority: :high]}
+    test "spawn_opts are correctly passed to consumer process", ctx do
+      support_test_storage_wrap(ctx, @shape_handle1, @shape1)
+
+      {:ok, consumer} =
+        start_supervised(
+          {Consumer,
+           %{
+             shape_handle: @shape_handle1,
+             stack_id: ctx.stack_id
+           }},
+          id: {Consumer, @shape_handle1}
+        )
+
+      Consumer.initialize_shape(consumer, @shape1, %{action: :create})
+      assert_receive {Support.TestStorage, :init_writer!, @shape_handle1, @shape1}
+      :started = Consumer.await_snapshot_start(ctx.stack_id, @shape_handle1)
+
+      pid = Consumer.name(ctx.stack_id, @shape_handle1) |> GenServer.whereis()
+      info = Process.info(pid)
+
+      assert info[:priority] == :high
+      assert info[:garbage_collection][:fullsweep_after] == 4
+    end
+  end
+
+  defp support_test_storage_wrap(ctx, shape_handle, shape) do
+    %{snapshot_xmin: xmin} = shape_status(shape_handle, ctx)
+    shapes = %{shape_handle => shape}
+
+    storage =
+      Support.TestStorage.wrap(ctx.storage, %{
+        shape_handle => [
+          {:mark_snapshot_as_started, []},
+          {:set_pg_snapshot, [%{xmin: xmin, xmax: xmin + 1, xip_list: [xmin]}]}
+        ]
+      })
+
+    Electric.StackConfig.put(ctx.stack_id, Electric.ShapeCache.Storage, storage)
+    Electric.StackConfig.put(ctx.stack_id, :inspector, @base_inspector)
+
+    patch_shape_status(fetch_shape_by_handle: fn _, sh -> Map.fetch(shapes, sh) end)
+
+    Support.TestUtils.activate_mocks_for_descendant_procs(Consumer)
+    Support.TestUtils.activate_mocks_for_descendant_procs(Electric.ShapeCache.ShapeCleaner)
+    :ok
+  end
+
   defp get_log_items_from_storage(offset, shape_storage) do
     Storage.get_log_stream(offset, shape_storage) |> Enum.map(&Jason.decode!/1)
   end

--- a/packages/sync-service/test/electric/shapes/consumer_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer_test.exs
@@ -2796,7 +2796,46 @@ defmodule Electric.Shapes.ConsumerTest do
       xid = 11
       lsn = Lsn.from_integer(10)
 
-      {:total_heap_size, heap_before} = :erlang.process_info(consumer_pid, :total_heap_size)
+      # Inflate the consumer's heap by sending a large binary payload
+      large_binary = :binary.copy(<<0>>, 200_000)
+
+      txn =
+        complete_txn_fragment(xid, lsn, [
+          %Changes.NewRecord{
+            relation: {"public", "test_table"},
+            record: %{"id" => "1", "value" => large_binary},
+            log_offset: LogOffset.new(lsn, 0)
+          }
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
+
+      # Wait for the consumer to process the fragment
+      assert_receive {^ref, :new_changes, _}, @receive_timeout
+
+      {:total_heap_size, heap_after} = :erlang.process_info(consumer_pid, :total_heap_size)
+
+      # threshold=1 forces a full GC after this fragment. Because the ~200 KB payload is
+      # transient garbage (not live state), the post-GC heap must be far below the payload
+      # size. Without GC the heap grows ~185x (observed), so this assertion fails loudly.
+      payload_words = div(200_000, :erlang.system_info(:wordsize))
+
+      assert heap_after < payload_words,
+             "heap_after (#{heap_after} words) should be far below payload (#{payload_words} words) after GC"
+    end
+
+    test "GC does not run when threshold is very large", ctx do
+      # 1 GB threshold — the consumer heap will never reach this, so GC must NOT fire.
+      Electric.StackConfig.put(ctx.stack_id, :consumer_gc_heap_threshold, 1_000_000_000)
+
+      {shape_handle, _} = ShapeCache.get_or_create_shape_handle(@shape1, ctx.stack_id)
+      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
+
+      consumer_pid = Consumer.whereis(ctx.stack_id, shape_handle)
+      ref = Shapes.Consumer.register_for_changes(ctx.stack_id, shape_handle)
+
+      xid = 11
+      lsn = Lsn.from_integer(10)
 
       # Inflate the consumer's heap by sending a large binary payload
       large_binary = :binary.copy(<<0>>, 200_000)
@@ -2817,13 +2856,12 @@ defmodule Electric.Shapes.ConsumerTest do
 
       {:total_heap_size, heap_after} = :erlang.process_info(consumer_pid, :total_heap_size)
 
-      # GC should have run (heap_after <= heap_before is the indicator),
-      # or at minimum the heap hasn't grown unboundedly relative to what we sent.
-      # Since threshold=1 forces GC on every fragment, the heap post-GC should
-      # be well below the inflated size. We verify the GC fired by checking that
-      # the post-fragment heap is not larger than the pre-fragment heap (i.e., GC ran).
-      assert heap_after <= heap_before * 2,
-             "Expected GC to reclaim heap after large fragment (before=#{heap_before} words, after=#{heap_after} words)"
+      # GC was NOT triggered (threshold too high), so the heap still reflects
+      # the retained payload — it must be >= payload_words.
+      payload_words = div(200_000, :erlang.system_info(:wordsize))
+
+      assert heap_after >= payload_words,
+             "heap_after (#{heap_after} words) should be >= payload (#{payload_words} words) when GC is skipped"
     end
 
     test "no GC by default (threshold=nil)", ctx do


### PR DESCRIPTION
Closes #4476

## Summary

Bounds runaway old-heap growth of `Shape.Consumer` processes (issue #4476). On a production node with 5,043 consumers, ~36 GB was unreclaimable garbage (7–9 MB heaps each holding ~8 KB of live state) because consumers inherit the BEAM default `fullsweep_after: 65535` and rarely hibernate, so a full sweep is effectively never triggered.

Two complementary, independently-tunable levers:

1. **Per-process spawn opts (env-driven).** `Consumer`, `Consumer.Snapshotter`, and `Consumer.Materializer` now pass `spawn_opt: Electric.StackConfig.spawn_opts(stack_id, key)` (keys `:consumer`, `:consumer_snapshotter`, `:consumer_materializer`), mirroring `ShapeLogCollector`. This lets `ELECTRIC_PROCESS_SPAWN_OPTS` set `fullsweep_after` per process type. No baked-in defaults — purely env-configured.

2. **Adaptive GC, opt-in.** After processing a transaction fragment (including during the startup buffer drain), the consumer forces `:erlang.garbage_collect()` only if its heap exceeds `consumer_gc_heap_threshold` (bytes; `nil` = off, the default). The threshold is cached per-consumer at startup (`State.new/2`), so changing it affects consumers started afterwards. The forced sweep runs **off the reply path** via a `{:continue, :maybe_gc}` step, so it never blocks the `ShapeLogCollector`'s synchronous publish call, and a hysteresis interval (`@gc_min_interval_ms`) caps how much CPU a busy consumer spends sweeping. See `Electric.Shapes.Consumer.set_gc_heap_threshold/2`.

Request-handler (`GET /v1/shape`) processes are intentionally untouched — they already expose `fullsweep_after` via `ELECTRIC_TWEAKS_HANDLER_FULLSWEEP_AFTER` and force GC before long-poll blocking.

## Config

| Env var | Meaning | Default |
|---|---|---|
| `ELECTRIC_PROCESS_SPAWN_OPTS` | JSON map; now accepts `consumer`/`consumer_snapshotter`/`consumer_materializer` keys (e.g. `{"consumer":{"fullsweep_after":4}}`) | `%{}` |
| `ELECTRIC_CONSUMER_GC_HEAP_THRESHOLD` | adaptive-GC heap threshold in bytes; `nil` disables | `nil` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
