### PR TITLE
feat(agents): seed `service` principal_kind grants on horton/worker

### DIFF
--- a/.changeset/horton-worker-service-grants.md
+++ b/.changeset/horton-worker-service-grants.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': patch
+---
+
+agents: built-in `horton` and `worker` types now seed `principal_kind=service` grants (`spawn` + `manage`) at registration time, alongside the existing `user` grants. Without this, service-principal deployers (e.g. a long-running runtime authenticating as `service:my-bot`) hit `UNAUTHORIZED: Principal is not allowed to manage horton` on first boot against a fresh tenant — there's no way for a service principal to bootstrap the built-in agents without an out-of-band SQL insert or a user-principal admin call. The `user` grants are preserved unchanged.

--- a/packages/agents/src/agents/horton.ts
+++ b/packages/agents/src/agents/horton.ts
@@ -771,6 +771,16 @@ export function registerHorton(
         subject_value: `user`,
         permission: `manage`,
       },
+      {
+        subject_kind: `principal_kind`,
+        subject_value: `service`,
+        permission: `spawn`,
+      },
+      {
+        subject_kind: `principal_kind`,
+        subject_value: `service`,
+        permission: `manage`,
+      },
     ],
     slashCommands: buildSkillSlashCommands(skillsRegistry),
     handler: assistantHandler,

--- a/packages/agents/src/agents/worker.ts
+++ b/packages/agents/src/agents/worker.ts
@@ -313,6 +313,16 @@ export function registerWorker(
         subject_value: `user`,
         permission: `manage`,
       },
+      {
+        subject_kind: `principal_kind`,
+        subject_value: `service`,
+        permission: `spawn`,
+      },
+      {
+        subject_kind: `principal_kind`,
+        subject_value: `service`,
+        permission: `manage`,
+      },
     ],
     async handler(ctx) {
       const args = parseWorkerArgs(ctx.args)


### PR DESCRIPTION
## Summary

- Built-in `horton` and `worker` types now seed `principal_kind=service` grants (`spawn` + `manage`) at registration time, alongside the existing `principal_kind=user` grants.
- 20-line diff across `packages/agents/src/agents/horton.ts` and `packages/agents/src/agents/worker.ts`. `user` grants preserved unchanged.

## Why

Any deployer authenticating as a service principal (e.g. a long-running runtime as `service:my-bot`) hits this on the very first boot against a fresh tenant:

```
ERROR: [agent-runtime] Failed to register type "horton":
  {"code":"UNAUTHORIZED","message":"Principal is not allowed to manage horton"}
ERROR: [agent-runtime] Failed to register type "worker":
  {"code":"UNAUTHORIZED","message":"Principal is not allowed to manage worker"}
Error: [agent-runtime] 0/N entity types registered
```

The current seeded grants only cover `principal_kind=user`, so there's no path for a service principal to bootstrap horton/worker without an out-of-band SQL insert into `entity_type_permission_grants` or a user-principal admin issuing grants via the REST API. That's a real bootstrap-gap for anyone running an automated agent fleet — we hit it deploying OpenFactory (`electric-sql/OpenFactory`) and again locally when validating against a fresh tenant.

Adding `service` kind grants for both `spawn` and `manage` makes the bootstrap self-sufficient. `user` grants are unchanged, so nothing regresses for interactive admin use.

## Test plan

- [x] `pnpm --filter @electric-ax/agents typecheck` — clean
- [x] `pnpm --filter @electric-ax/agents test` — 59 tests pass
- [x] Verified end-to-end against a freshly migrated local agents-server: boot factory as `service:factory`, all 6 entity types register, `ctx.spawn('horton', ...)` works, follow-up `ctx.send` calls work (combined with the write-token forwarding from #4522)

## Notes

This complements server-side PR #4475 (permission enforcement) and #4522 (`from_agent` write-token escape). With this change the full bootstrap path for service principals is unblocked end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)