### PR TITLE
Render standalone entity stream errors

### DIFF
--- a/.changeset/render-standalone-entity-errors.md
+++ b/.changeset/render-standalone-entity-errors.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents-server-ui': patch
+---
+
+Render standalone entity stream errors in the timeline with their error code and message.

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -6,6 +6,7 @@ import {
   createLiveQueryCollection,
   eq,
   isNull,
+  isUndefined,
   like,
   localOnlyCollectionOptions,
   or,
@@ -1304,7 +1305,7 @@ function buildEntityTimelineQuery(
 
   const errorSource = q
     .from({ error: db.collections.errors })
-    .where(({ error }) => isNull(error.run_id))
+    .where(({ error }) => or(isNull(error.run_id), isUndefined(error.run_id)))
     .select(({ error }) => ({
       key: error.key,
       order: coalesce(error._timeline_order, `~`),
@@ -1643,7 +1644,9 @@ export function createEntityErrorsQuery(
   return (q: InitialQueryBuilder) =>
     q
       .from({ errors: db.collections.errors })
-      .where(({ errors }) => isNull(errors.run_id))
+      .where(({ errors }) =>
+        or(isNull(errors.run_id), isUndefined(errors.run_id))
+      )
       .select(({ errors }) => ({
         key: errors.key,
         error_code: errors.error_code,

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -250,6 +250,9 @@ export interface EntityTimelineRunRow {
 export type EntityTimelineInboxRow = IncludesInboxMessage
 export type EntityTimelineWakeRow = IncludesWakeMessage
 export type EntityTimelineSignalRow = IncludesSignal
+export type EntityTimelineErrorRow = EntityTimelineErrorItem & {
+  order: TimelineOrder
+}
 
 export type EntityTimelineQueryRow =
   | {
@@ -258,6 +261,7 @@ export type EntityTimelineQueryRow =
       run?: undefined
       wake?: undefined
       signal?: undefined
+      error?: undefined
       manifest?: undefined
     }
   | {
@@ -266,6 +270,7 @@ export type EntityTimelineQueryRow =
       run: EntityTimelineRunRow
       wake?: undefined
       signal?: undefined
+      error?: undefined
       manifest?: undefined
     }
   | {
@@ -274,6 +279,7 @@ export type EntityTimelineQueryRow =
       run?: undefined
       wake: EntityTimelineWakeRow
       signal?: undefined
+      error?: undefined
       manifest?: undefined
     }
   | {
@@ -282,6 +288,7 @@ export type EntityTimelineQueryRow =
       run?: undefined
       wake?: undefined
       signal: EntityTimelineSignalRow
+      error?: undefined
       manifest?: undefined
     }
   | {
@@ -290,6 +297,16 @@ export type EntityTimelineQueryRow =
       run?: undefined
       wake?: undefined
       signal?: undefined
+      error: EntityTimelineErrorRow
+      manifest?: undefined
+    }
+  | {
+      $key: string
+      inbox?: undefined
+      run?: undefined
+      wake?: undefined
+      signal?: undefined
+      error?: undefined
       manifest: ManifestEntry
     }
 
@@ -1285,6 +1302,17 @@ function buildEntityTimelineQuery(
       new_state: signal.new_state,
     }))
 
+  const errorSource = q
+    .from({ error: db.collections.errors })
+    .where(({ error }) => isNull(error.run_id))
+    .select(({ error }) => ({
+      key: error.key,
+      order: coalesce(error._timeline_order, `~`),
+      error_code: error.error_code,
+      message: error.message,
+      run_id: error.run_id,
+    }))
+
   const runItemsSource = q
     .unionAll({
       text: db.collections.texts,
@@ -1382,30 +1410,41 @@ function buildEntityTimelineQuery(
       run: runSource,
       wake: wakeSource,
       signal: signalSource,
+      error: errorSource,
       manifest: db.collections.manifests,
     })
-    .orderBy(({ inbox, run, wake, signal, manifest }) =>
+    .orderBy(({ inbox, run, wake, signal, error, manifest }) =>
       coalesce(
         inbox.order,
         run.order,
         wake.order,
         signal.order,
+        error.order,
         manifest._timeline_order,
         `~`
       )
     )
-    .orderBy(({ inbox, run, wake, signal, manifest }) =>
+    .orderBy(({ inbox, run, wake, signal, error, manifest }) =>
       coalesce(
         caseWhen(inbox.key, `inbox`),
         caseWhen(run.key, `run`),
         caseWhen(wake.key, `wake`),
         caseWhen(signal.key, `signal`),
+        caseWhen(error.key, `error`),
         caseWhen(manifest.key, `manifest`),
         ``
       )
     )
-    .orderBy(({ inbox, run, wake, signal, manifest }) =>
-      coalesce(inbox.key, run.key, wake.key, signal.key, manifest.key, ``)
+    .orderBy(({ inbox, run, wake, signal, error, manifest }) =>
+      coalesce(
+        inbox.key,
+        run.key,
+        wake.key,
+        signal.key,
+        error.key,
+        manifest.key,
+        ``
+      )
     )
 }
 

--- a/packages/agents-runtime/test/entity-timeline.test.ts
+++ b/packages/agents-runtime/test/entity-timeline.test.ts
@@ -6,7 +6,9 @@ import {
 import {
   buildEntityTimelineData,
   compareTimelineOrders,
+  createEntityErrorsQuery,
   createEntityIncludesQuery,
+  createEntityTimelineQuery,
   getEntityState,
   normalizeEntityTimelineData,
 } from '../src/entity-timeline'
@@ -1658,6 +1660,39 @@ describe(`entity includes query`, () => {
         },
       }
     }
+
+    it(`matches standalone errors when run_id is omitted`, async () => {
+      const { collections, sync } = createEntityCollections()
+      const errorsQuery = createLiveQueryCollection({
+        query: createEntityErrorsQuery({ collections } as any),
+        startSync: true,
+      })
+      const timelineQuery = createLiveQueryCollection({
+        query: createEntityTimelineQuery({ collections } as any),
+        startSync: true,
+      })
+      await Promise.all([errorsQuery.preload(), timelineQuery.preload()])
+
+      sync.errors.insert({
+        key: `err-omitted-run`,
+        error_code: `HANDLER_FAILED`,
+        message: `boom`,
+      })
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(getData(errorsQuery)).toMatchObject([
+        {
+          key: `err-omitted-run`,
+          error_code: `HANDLER_FAILED`,
+          message: `boom`,
+        },
+      ])
+      expect(getData(timelineQuery)[0]?.error).toMatchObject({
+        key: `err-omitted-run`,
+        error_code: `HANDLER_FAILED`,
+        message: `boom`,
+      })
+    })
 
     it(`reacts to changes in the top-level runs collection`, async () => {
       const { collections, sync } = createEntityCollections()

--- a/packages/agents-server-ui/src/components/EntityTimeline.tsx
+++ b/packages/agents-server-ui/src/components/EntityTimeline.tsx
@@ -265,6 +265,7 @@ function timelineRowSearchText(
     })
   }
   if (row.signal) return signalSearchText(row.signal)
+  if (row.error) return `${row.error.error_code} ${row.error.message}`
   if (row.manifest) return manifestSearchText(row.manifest)
   return runSearchTextByKey.get(row.$key) ?? runSearchTextFromSnapshot(row.run)
 }
@@ -274,6 +275,7 @@ function timelineRowLabel(row: RenderTimelineRow): string {
   if (row.inbox) return `User message`
   if (row.wake) return `Wake`
   if (row.signal) return `Signal`
+  if (row.error) return `Error`
   if (row.manifest) return `Manifest item`
   return `Agent response`
 }
@@ -428,6 +430,23 @@ function SignalTimelineRow({
         icon={CircleStop}
         title={`signal ${signal.signal}`}
         summary={signalSummary(signal)}
+        headerSurface
+      />
+    </div>
+  )
+}
+
+function ErrorTimelineRow({
+  error,
+}: {
+  error: NonNullable<RenderTimelineRow[`error`]>
+}): React.ReactElement {
+  return (
+    <div className={styles.manifestRow}>
+      <InlineEventCard
+        icon={CircleStop}
+        title={error.error_code || `error`}
+        summary={error.message}
         headerSurface
       />
     </div>
@@ -980,6 +999,10 @@ const TimelineRow = memo(function TimelineRow({
 
   if (row.signal) {
     return <SignalTimelineRow signal={row.signal} />
+  }
+
+  if (row.error) {
+    return <ErrorTimelineRow error={row.error} />
   }
 
   if (row.manifest) {


### PR DESCRIPTION
## Summary
- include standalone entity stream errors in the main timeline query
- render errors with their error code and message in the timeline UI
- keep existing run-attached error/fallback rendering unchanged

## Verification
- pnpm --dir packages/agents-server-ui typecheck
- pnpm --dir packages/agents-runtime test entity-timeline --run

Note: full packages/agents-runtime typecheck still fails on existing unrelated missing exports in test/pg-sync-source.test.ts.
