### PR TITLE
fix(agents-server,agents-runtime): unblock fresh-tenant first wake for shared-state writers

### DIFF
--- a/.changeset/shared-state-bootstrap-and-child-preload.md
+++ b/.changeset/shared-state-bootstrap-and-child-preload.md
@@ -1,0 +1,12 @@
+---
+'@electric-ax/agents-server': patch
+'@electric-ax/agents-runtime': patch
+---
+
+agents-server, agents-runtime: fix two first-spawn races that prevented writer-side shared-state entities from reaching their first handler run on a fresh tenant.
+
+**agents-server**: `PUT /_electric/shared-state/<id>` now inserts the corresponding `shared_state_links` row synchronously whenever the request carries a valid `electric-owner-entity` header and the principal can access the entity. Previously this PUT only ran the authz check; the link row was created later — asynchronously — when the entity's manifest stream event was processed via `applyManifestEntitySource`. The runtime's `mkdb` wiring schedules the PUT and the preload GET back-to-back, so the GET always raced ahead of the eventually-consistent link insert and returned `401 UNAUTHORIZED: Principal is not allowed to read shared state` on every fresh-tenant first wake.
+
+**agents-runtime**: `createChildDb` (used by entity observations) now swallows `Stream not found` / `404` on initial preload. A handler may legitimately observe an entity that hasn't been spawned yet — e.g. a parent observes its own future child to wake on the child's `runFinished`. Treating the 404 as "no events yet" matches the spirit of the observation (we'll be woken when the entity appears); the previous unconditional throw aborted the entire wake with `HTTP Error 404 ... Stream not found`, and the entity could never recover because the spawn that would create the child never ran.
+
+Verified end-to-end with OpenFactory's `daily-digest` entity (uses `mkdb` + `observe(db(...))` + `observe(entity(<future child>))`) against a freshly torn-down local agents-server: the first `run-now` now writes the digest row, the discord-router subscriber picks it up, and the digest reaches Discord — without manual SQL or out-of-band link bootstrapping.

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -1408,7 +1408,17 @@ export async function processWake(
           close: () => childDb.close(),
         })
         if (opts?.preload !== false) {
-          await childDb.preload()
+          try {
+            await childDb.preload()
+          } catch (err) {
+            // An observation may target an entity that hasn't been spawned
+            // yet (e.g. a daily-digest entity observes its child writer
+            // before the first spawn). 404 / Stream not found is fine — we
+            // treat the stream as empty for this wake; subsequent wakes
+            // pick up state once the entity is created.
+            const msg = err instanceof Error ? err.message : String(err)
+            if (!/Stream not found|404/i.test(msg)) throw err
+          }
         }
         return childDb
       },

--- a/packages/agents-server/src/routing/durable-streams-router.ts
+++ b/packages/agents-server/src/routing/durable-streams-router.ts
@@ -717,6 +717,19 @@ async function authorizeDurableStreamAccess(
         ownerEntityUrl
       )
     ) {
+      // Bootstrap the link synchronously so subsequent reads on this stream
+      // (e.g. the runtime's preload right after `mkdb`) can resolve the owner
+      // without waiting for the entity's manifest stream event to be
+      // processed eventually-consistently. Without this, a brand-new
+      // shared-state always 401s on the first preload because the link row
+      // is only created later via `applyManifestEntitySource`.
+      if (ownerEntityUrl) {
+        await ctx.entityManager.registry.replaceSharedStateLink(
+          ownerEntityUrl,
+          `shared-state:${sharedStateId}`,
+          sharedStateId
+        )
+      }
       return undefined
     }
     return apiError(

--- a/packages/agents-server/test/permissions-routes.test.ts
+++ b/packages/agents-server/test/permissions-routes.test.ts
@@ -83,6 +83,7 @@ function ctx(
     listSharedStateLinkedEntityUrls: vi.fn(
       async () => overrides.linkedSharedStateEntityUrls ?? [currentEntity.url]
     ),
+    replaceSharedStateLink: vi.fn(async () => undefined),
     hasEntityPermission: vi.fn(async (_url, permission) =>
       typeof overrides.hasEntityPermission === `function`
         ? overrides.hasEntityPermission(permission)


### PR DESCRIPTION
## Summary

Two first-spawn races prevented writer-side shared-state entities from ever reaching their first handler run on a fresh tenant.

- **`agents-server` `durable-streams-router.ts:708-735`** — `PUT /_electric/shared-state/<id>` now inserts the `shared_state_links` row synchronously when a valid `electric-owner-entity` header is supplied. Was previously created only when the entity's manifest stream event was processed eventually-consistently, so the runtime's own preload GET (issued right after the PUT) always 401'd on the first wake.
- **`agents-runtime` `process-wake.ts:1410-1424`** — `createChildDb` swallows `Stream not found` / 404 on the initial entity-observation preload. A handler may legitimately observe an entity that hasn't been spawned yet (parent observing its own future child); the previous unconditional throw aborted the wake and prevented the entity from ever recovering.

20 lines of source, plus a 1-line test mock update and a changeset.

## Why

Reproduction with OpenFactory's `daily-digest` entity (uses `mkdb` + `observe(db(...))` + `observe(entity(<future writer>))`) against a freshly torn-down local `agents-server`:

```text
[/daily-digest/main-1] handler failed: HTTP Error 401 at .../shared-state/daily-digest?offset=-1: Principal is not allowed to read shared state
```

with `shared_state_links` empty despite the runtime having just issued the bootstrap PUT seconds earlier. Once the server-side patch lands the link row, the next preload reads through `created_by` matching and the handler proceeds. The handler then tries to observe its own future writer (`/horton/daily-digest-writer-main-1`) which doesn't exist yet — the runtime patch turns that 404 into a deferred "no events yet" instead of aborting the wake.

Combined, the two patches let `daily-digest` self-bootstrap end-to-end on a clean tenant without manual SQL or out-of-band link insertion.

## Test plan

- [x] `pnpm --filter @electric-ax/agents-runtime typecheck` — clean
- [x] `pnpm --filter @electric-ax/agents-server typecheck` — clean
- [x] `pnpm --filter @electric-ax/agents-runtime test` — **827 pass, 2 skipped (66 files)**
- [x] `pnpm --filter @electric-ax/agents-server test` — **402 pass, 41 skipped, 2 failing** (the two failing `oss-server-router` dashboard tests fail on `origin/main` without this PR — verified by stashing the patch and re-running, unrelated)
- [x] End-to-end against a freshly torn-down local agents-server (this PR's build) + OpenFactory's daily-digest entity: first \`spawn-daily-digest.sh --run-now\` writes the digest, the discord-router subscriber posts to Discord. No manual DB inserts, no out-of-band link bootstrapping.

## Out of scope

A few related concerns surfaced during diagnosis but aren't fixed here:

- `setup-context.ts:749` uses string concat for `serverBaseUrl + streamPath` which produces `http://localhost:4437//horton/...` when the env URL has a trailing slash. Cosmetic — most servers normalise — but worth a follow-up using `appendPathToUrl`.
- The runtime's `prepareAgentRun` / post-handler ordering (`process-wake.ts:2146-2152`) runs `waitForSharedStateWiring` *before* `commitManifestEntries`. Once this PR's server-side link bootstrap lands, the manifest event becomes a redundant secondary write rather than the only source of truth, so the ordering is benign — but conceptually the manifest should be committed before the wiring waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)