### PR TITLE
test(sync-service): make StackSupervisor telemetry test synchronous

### DIFF
--- a/.changeset/fix-telemetry-test-isolation.md
+++ b/.changeset/fix-telemetry-test-isolation.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Test-only: make the StackSupervisor telemetry test synchronous to avoid serve_shape counter contamination from concurrently running tests. No runtime changes.

--- a/packages/sync-service/test/electric/stack_supervisor/telemetry_test.exs
+++ b/packages/sync-service/test/electric/stack_supervisor/telemetry_test.exs
@@ -1,6 +1,10 @@
 if Electric.telemetry_enabled?() and Code.ensure_loaded?(ElectricTelemetry.Reporters.Prometheus) do
   defmodule Electric.StackSupervisor.TelemetryTest do
-    use ExUnit.Case, async: true
+    # Not async: the Prometheus reporter attaches a global :telemetry handler for
+    # [:electric, :plug, :serve_shape], so concurrent async tests that emit that
+    # event (via the real serve_shape plug) leak into this reporter's per-status
+    # counters and make the exact-count assertions below non-deterministic.
+    use ExUnit.Case, async: false
 
     alias Electric.StackSupervisor.Telemetry
 


### PR DESCRIPTION
## Summary

Fixes a flaky test: `Electric.StackSupervisor.TelemetryTest` "per-status HTTP
request counts are scrapable".

The test starts a Prometheus reporter and asserts exact per-status counters
after emitting a fixed set of `[:electric, :plug, :serve_shape]` events.
Telemetry handlers are global, so the reporter's handler also counts
`serve_shape` events emitted by any other test running concurrently — the real
`serve_shape` plug emits this event on every shape request. Under `async: true`
this produced non-deterministic counts (e.g. `status="200"` observed as 3
instead of the expected 2).

Marking the module `async: false` makes ExUnit never schedule it concurrently
with other tests, so the exact-count assertions become deterministic. The
metric aggregates only by `:status`, so there's no way to scope the reporter's
global handler per-test while keeping the module async.

## Context

This flake surfaced while validating the Elixir/OTP upgrade in #3992, where
OTP 29's scheduling timing made the latent contamination trip more often. It's
an independent test-isolation bug on `main`, so it's split out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
