### PR TITLE
feat(agents): Add streaming tool call argument support

### DIFF
--- a/.changeset/streaming-tool-call-args.md
+++ b/.changeset/streaming-tool-call-args.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-runtime": minor
+---
+
+Add runtime support for streaming tool call arguments from Pi model events.

--- a/packages/agents-runtime/src/entity-schema.ts
+++ b/packages/agents-runtime/src/entity-schema.ts
@@ -195,6 +195,9 @@ type ToolCallValue = {
   error?: string
   duration_ms?: number
 }
+// Tool argument deltas intentionally mirror text deltas: every streamed chunk is
+// retained for replay/inspection, while the final parsed args are still stored
+// on the tool_call row for the normal result lifecycle.
 type ToolArgDeltaValue = {
   key?: string
   tool_call_key: string

--- a/packages/agents-runtime/src/entity-schema.ts
+++ b/packages/agents-runtime/src/entity-schema.ts
@@ -182,11 +182,27 @@ type ToolCallValue = {
   run_id?: string
   tool_call_id?: string
   tool_name: string
-  status: `started` | `args_complete` | `executing` | `completed` | `failed`
+  status:
+    | `started`
+    | `args_streaming`
+    | `args_complete`
+    | `executing`
+    | `completed`
+    | `failed`
   args?: unknown
+  args_preview?: unknown
   result?: unknown
   error?: string
   duration_ms?: number
+}
+type ToolArgDeltaValue = {
+  key?: string
+  tool_call_key: string
+  tool_call_id?: string
+  run_id?: string
+  seq: number
+  delta: string
+  content_index?: number
 }
 type ReasoningValue = {
   key?: string
@@ -553,15 +569,30 @@ function createToolCallSchema(): Schema<ToolCallValue> {
     tool_name: z.string(),
     status: z.enum([
       `started`,
+      `args_streaming`,
       `args_complete`,
       `executing`,
       `completed`,
       `failed`,
     ]),
     args: z.unknown().optional(),
+    args_preview: z.unknown().optional(),
     result: z.unknown().optional(),
     error: z.string().optional(),
     duration_ms: z.number().int().optional(),
+  })
+}
+
+function createToolArgDeltaSchema(): Schema<ToolArgDeltaValue> {
+  return z.object({
+    key: z.string().optional(),
+    ...timelineOrderField,
+    tool_call_key: z.string(),
+    tool_call_id: z.string().optional(),
+    run_id: z.string().optional(),
+    seq: z.number().int(),
+    delta: z.string(),
+    content_index: z.number().int().optional(),
   })
 }
 
@@ -927,6 +958,7 @@ export type Step = SequencedPersistedRow<StepValue>
 export type Text = SequencedPersistedRow<TextValue>
 export type TextDelta = SequencedPersistedRow<TextDeltaValue>
 export type ToolCall = SequencedPersistedRow<ToolCallValue>
+export type ToolArgDelta = SequencedPersistedRow<ToolArgDeltaValue>
 export type Reasoning = SequencedPersistedRow<ReasoningValue>
 export type ReasoningDelta = SequencedPersistedRow<ReasoningDeltaValue>
 export type ErrorEvent = SequencedPersistedRow<ErrorEventValue>
@@ -1050,6 +1082,8 @@ export const BUILT_IN_EVENT_SCHEMAS = {
   text_delta:
     createTextDeltaSchema() as unknown as BuiltInEntitySchema<TextDelta>,
   tool_call: createToolCallSchema() as unknown as BuiltInEntitySchema<ToolCall>,
+  tool_arg_delta:
+    createToolArgDeltaSchema() as unknown as BuiltInEntitySchema<ToolArgDelta>,
   reasoning:
     createReasoningSchema() as unknown as BuiltInEntitySchema<Reasoning>,
   reasoning_delta:
@@ -1088,6 +1122,7 @@ type EntityCollectionsDefinition = {
   texts: CollectionDefinition<Text>
   textDeltas: CollectionDefinition<TextDelta>
   toolCalls: CollectionDefinition<ToolCall>
+  toolArgDeltas: CollectionDefinition<ToolArgDelta>
   reasoning: CollectionDefinition<Reasoning>
   reasoningDeltas: CollectionDefinition<ReasoningDelta>
   errors: CollectionDefinition<ErrorEvent>
@@ -1135,6 +1170,12 @@ export const builtInCollections: EntityCollectionsDefinition = {
   toolCalls: {
     schema: BUILT_IN_EVENT_SCHEMAS.tool_call as StandardSchemaV1<ToolCall>,
     type: `tool_call`,
+    primaryKey: `key`,
+  },
+  toolArgDeltas: {
+    schema:
+      BUILT_IN_EVENT_SCHEMAS.tool_arg_delta as StandardSchemaV1<ToolArgDelta>,
+    type: `tool_arg_delta`,
     primaryKey: `key`,
   },
   reasoning: {

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -44,7 +44,13 @@ export type EntityTimelineContentItem =
       toolCallId: string
       toolName: string
       args: Record<string, unknown>
-      status: `started` | `args_complete` | `executing` | `completed` | `failed`
+      status:
+        | `started`
+        | `args_streaming`
+        | `args_complete`
+        | `executing`
+        | `completed`
+        | `failed`
       result?: string
       error?: string
       isError: boolean
@@ -113,7 +119,13 @@ export interface IncludesToolCall {
   run_id: string
   order: TimelineOrder
   tool_name: string
-  status: `started` | `args_complete` | `executing` | `completed` | `failed`
+  status:
+    | `started`
+    | `args_streaming`
+    | `args_complete`
+    | `executing`
+    | `completed`
+    | `failed`
   args?: unknown
   result?: unknown
   error?: string
@@ -243,7 +255,13 @@ export interface EntityTimelineToolCallItem {
   order: TimelineOrder
   tool_call_id?: string
   tool_name: string
-  status: `started` | `args_complete` | `executing` | `completed` | `failed`
+  status:
+    | `started`
+    | `args_streaming`
+    | `args_complete`
+    | `executing`
+    | `completed`
+    | `failed`
   args?: unknown
   result?: unknown
   error?: string

--- a/packages/agents-runtime/src/outbound-bridge.ts
+++ b/packages/agents-runtime/src/outbound-bridge.ts
@@ -577,8 +577,9 @@ export function createOutboundBridge(
         ids.push(toolCallId)
         legacyToolCallIdsByName.set(name, ids)
       }
+      const existing = toolCallsById.has(toolCallId)
       ensureToolCall(toolCallId, name, {
-        status: `executing`,
+        status: existing ? `executing` : `started`,
         args,
       })
     },

--- a/packages/agents-runtime/src/outbound-bridge.ts
+++ b/packages/agents-runtime/src/outbound-bridge.ts
@@ -178,6 +178,18 @@ export interface OutboundBridge {
   onReasoningStart: () => void
   onReasoningDelta: (delta: string) => void
   onReasoningEnd: (opts?: { encrypted?: string; summaryTitle?: string }) => void
+  onToolCallArgsStart(
+    toolCallId: string,
+    name: string,
+    argsPreview?: unknown
+  ): void
+  onToolCallArgsDelta(
+    toolCallId: string,
+    name: string,
+    delta: string,
+    opts?: { contentIndex?: number; argsPreview?: unknown }
+  ): void
+  onToolCallArgsEnd(toolCallId: string, name: string, args: unknown): void
   onToolCallStart(toolCallId: string, name: string, args: unknown): void
   onToolCallStart(name: string, args: unknown): void
   onToolCallEnd(
@@ -244,7 +256,7 @@ export function createOutboundBridge(
   let currentReasoningRunKey: string | null = null
   const toolCallsById = new Map<
     string,
-    { key: string; runKey: string; args: unknown }
+    { key: string; runKey: string; args: unknown; argSeq: number }
   >()
   const legacyToolCallIdsByName = new Map<string, Array<string>>()
   const requireActiveRun = (action: string): string => {
@@ -254,6 +266,65 @@ export function createOutboundBridge(
       )
     }
     return currentRunKey
+  }
+  const ensureToolCall = (
+    toolCallId: string,
+    name: string,
+    opts?: {
+      args?: unknown
+      argsPreview?: unknown
+      status?: `started` | `args_streaming` | `args_complete` | `executing`
+    }
+  ): { key: string; runKey: string; args: unknown; argSeq: number } => {
+    const runKey = requireActiveRun(`ensureToolCall`)
+    const existing = toolCallsById.get(toolCallId)
+    if (existing) {
+      if (opts && (`args` in opts || `argsPreview` in opts || opts.status)) {
+        const nextArgs = `args` in opts ? opts.args : existing.args
+        if (`args` in opts) existing.args = opts.args
+        writeEvent(
+          entityStateSchema.toolCalls.update({
+            key: existing.key,
+            value: {
+              tool_call_id: toolCallId,
+              tool_name: name,
+              status: opts.status ?? `args_streaming`,
+              args: nextArgs,
+              ...(opts.argsPreview !== undefined && {
+                args_preview: opts.argsPreview,
+              }),
+              run_id: existing.runKey,
+            } as never,
+          }) as ChangeEvent
+        )
+      }
+      return existing
+    }
+    const key = `tc-${counters.tc++}`
+    persistSeed()
+    const created = {
+      key,
+      runKey,
+      args: opts && `args` in opts ? opts.args : undefined,
+      argSeq: 0,
+    }
+    toolCallsById.set(toolCallId, created)
+    writeEvent(
+      entityStateSchema.toolCalls.insert({
+        key,
+        value: {
+          tool_call_id: toolCallId,
+          tool_name: name,
+          status: opts?.status ?? `started`,
+          args: created.args,
+          ...(opts?.argsPreview !== undefined && {
+            args_preview: opts.argsPreview,
+          }),
+          run_id: runKey,
+        } as never,
+      }) as ChangeEvent
+    )
+    return created
   }
 
   return {
@@ -444,15 +515,61 @@ export function createOutboundBridge(
       currentReasoningRunKey = null
     },
 
+    onToolCallArgsStart(
+      toolCallId: string,
+      name: string,
+      argsPreview?: unknown
+    ) {
+      ensureToolCall(toolCallId, name, {
+        status: `args_streaming`,
+        argsPreview,
+      })
+    },
+
+    onToolCallArgsDelta(
+      toolCallId: string,
+      name: string,
+      delta: string,
+      opts?: { contentIndex?: number; argsPreview?: unknown }
+    ) {
+      const toolCall =
+        toolCallsById.get(toolCallId) ??
+        ensureToolCall(toolCallId, name, {
+          status: `args_streaming`,
+          argsPreview: opts?.argsPreview,
+        })
+      const seq = toolCall.argSeq++
+      writeEvent(
+        entityStateSchema.toolArgDeltas.insert({
+          key: `${toolCall.key}:args-${seq}`,
+          value: {
+            tool_call_key: toolCall.key,
+            tool_call_id: toolCallId,
+            run_id: toolCall.runKey,
+            seq,
+            delta,
+            ...(opts?.contentIndex !== undefined && {
+              content_index: opts.contentIndex,
+            }),
+          } as never,
+        }) as ChangeEvent
+      )
+    },
+
+    onToolCallArgsEnd(toolCallId: string, name: string, args: unknown) {
+      ensureToolCall(toolCallId, name, {
+        status: `args_complete`,
+        args,
+      })
+    },
+
     onToolCallStart(
       toolCallIdOrName: string,
       nameOrArgs: string | unknown,
       maybeArgs?: unknown
     ) {
-      const runKey = requireActiveRun(`onToolCallStart`)
-      const key = `tc-${counters.tc++}`
       const legacyCall = maybeArgs === undefined
-      const toolCallId = legacyCall ? key : toolCallIdOrName
+      const toolCallId = legacyCall ? `tc-${counters.tc}` : toolCallIdOrName
       const name = legacyCall ? toolCallIdOrName : (nameOrArgs as string)
       const args = legacyCall ? nameOrArgs : maybeArgs
       if (legacyCall) {
@@ -460,20 +577,10 @@ export function createOutboundBridge(
         ids.push(toolCallId)
         legacyToolCallIdsByName.set(name, ids)
       }
-      persistSeed()
-      toolCallsById.set(toolCallId, { key, runKey, args })
-      writeEvent(
-        entityStateSchema.toolCalls.insert({
-          key,
-          value: {
-            tool_call_id: toolCallId,
-            tool_name: name,
-            status: `started`,
-            args,
-            run_id: runKey,
-          } as never,
-        }) as ChangeEvent
-      )
+      ensureToolCall(toolCallId, name, {
+        status: `executing`,
+        args,
+      })
     },
 
     onToolCallEnd(

--- a/packages/agents-runtime/src/outbound-bridge.ts
+++ b/packages/agents-runtime/src/outbound-bridge.ts
@@ -521,7 +521,7 @@ export function createOutboundBridge(
       argsPreview?: unknown
     ) {
       ensureToolCall(toolCallId, name, {
-        status: `args_streaming`,
+        status: `started`,
         argsPreview,
       })
     },
@@ -532,12 +532,18 @@ export function createOutboundBridge(
       delta: string,
       opts?: { contentIndex?: number; argsPreview?: unknown }
     ) {
-      const toolCall =
-        toolCallsById.get(toolCallId) ??
+      let toolCall = toolCallsById.get(toolCallId)
+      if (toolCall) {
         ensureToolCall(toolCallId, name, {
           status: `args_streaming`,
           argsPreview: opts?.argsPreview,
         })
+      } else {
+        toolCall = ensureToolCall(toolCallId, name, {
+          status: `args_streaming`,
+          argsPreview: opts?.argsPreview,
+        })
+      }
       const seq = toolCall.argSeq++
       writeEvent(
         entityStateSchema.toolArgDeltas.insert({
@@ -569,7 +575,9 @@ export function createOutboundBridge(
       maybeArgs?: unknown
     ) {
       const legacyCall = maybeArgs === undefined
-      const toolCallId = legacyCall ? `tc-${counters.tc}` : toolCallIdOrName
+      const toolCallId = legacyCall
+        ? `legacy-tc-${counters.tc}`
+        : toolCallIdOrName
       const name = legacyCall ? toolCallIdOrName : (nameOrArgs as string)
       const args = legacyCall ? nameOrArgs : maybeArgs
       if (legacyCall) {

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -21,7 +21,6 @@ import type { ChangeEvent } from '@durable-streams/state'
 import type {
   AgentEvent,
   AgentMessage,
-  AgentTool,
   StreamFn,
 } from '@mariozechner/pi-agent-core'
 import type {
@@ -30,7 +29,12 @@ import type {
   Provider,
   SimpleStreamOptions,
 } from '@mariozechner/pi-ai'
-import type { LLMContentBlock, LLMMessage, LLMMessageContent } from './types'
+import type {
+  AgentTool,
+  LLMContentBlock,
+  LLMMessage,
+  LLMMessageContent,
+} from './types'
 
 /**
  * Split a streamed reasoning blob into `{ title, body }`.
@@ -347,7 +351,24 @@ export function createPiAgentAdapter(
               case `message_update`: {
                 const assistantEvent = (event as Record<string, unknown>)
                   .assistantMessageEvent as
-                  | { type: string; delta?: string }
+                  | {
+                      type: string
+                      contentIndex?: number
+                      delta?: string
+                      toolCall?: {
+                        id?: string
+                        name?: string
+                        arguments?: Record<string, unknown>
+                      }
+                      partial?: {
+                        content?: Array<{
+                          type?: string
+                          id?: string
+                          name?: string
+                          arguments?: Record<string, unknown>
+                        }>
+                      }
+                    }
                   | undefined
                 if (assistantEvent?.type === `text_delta`) {
                   if (!textStarted) {
@@ -391,6 +412,61 @@ export function createPiAgentAdapter(
                     )
                     reasoningStarted = false
                     reasoningAccum = ``
+                  }
+                } else if (
+                  assistantEvent?.type === `toolcall_start` ||
+                  assistantEvent?.type === `toolcall_delta` ||
+                  assistantEvent?.type === `toolcall_end`
+                ) {
+                  const contentIndex = assistantEvent.contentIndex
+                  const partialToolCall =
+                    typeof contentIndex === `number`
+                      ? assistantEvent.partial?.content?.[contentIndex]
+                      : undefined
+                  const toolCall = assistantEvent.toolCall ?? partialToolCall
+                  const toolCallId = toolCall?.id
+                  const toolName = toolCall?.name
+                  const argsPreview = toolCall?.arguments
+                  if (toolCallId && toolName) {
+                    if (assistantEvent.type === `toolcall_start`) {
+                      bridge.onToolCallArgsStart(
+                        toolCallId,
+                        toolName,
+                        argsPreview
+                      )
+                    } else if (assistantEvent.type === `toolcall_delta`) {
+                      const delta = assistantEvent.delta ?? ``
+                      bridge.onToolCallArgsDelta(toolCallId, toolName, delta, {
+                        contentIndex,
+                        argsPreview,
+                      })
+                      const tool = opts.tools.find(
+                        (candidate) => candidate.name === toolName
+                      )
+                      if (tool?.onArgsDelta) {
+                        void Promise.resolve(
+                          tool.onArgsDelta({
+                            toolCallId,
+                            toolName,
+                            contentIndex,
+                            delta,
+                            argsPreview,
+                          })
+                        ).catch((error) => {
+                          runtimeLog.warn(
+                            logPrefix,
+                            `streaming tool arg hook failed for ${toolName}:`,
+                            error
+                          )
+                        })
+                      }
+                    } else {
+                      bridge.onToolCallArgsEnd(
+                        toolCallId,
+                        toolName,
+                        argsPreview
+                      )
+                    }
                   }
                 } else {
                   runtimeLog.debug(

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -273,6 +273,8 @@ export function createPiAgentAdapter(
     let reasoningStarted = false
     let reasoningAccum = ``
     let abortedRun = false
+    let activeRunSignal: AbortSignal | undefined
+    const pendingToolArgDeltaHooks = new Map<string, Promise<void>>()
 
     const model = resolvePiModel({
       model: opts.model,
@@ -288,11 +290,61 @@ export function createPiAgentAdapter(
         timeoutMs: modelTimeoutMs,
         maxRetries: modelMaxRetries,
       })
+    const awaitToolArgDeltaHooks = async (
+      toolCallId: string | undefined
+    ): Promise<void> => {
+      if (!toolCallId) return
+      await pendingToolArgDeltaHooks.get(toolCallId)
+    }
+    const enqueueToolArgDeltaHook = (
+      tool: AgentTool,
+      context: {
+        toolCallId: string
+        toolName: string
+        contentIndex?: number
+        delta: string
+        argsPreview?: unknown
+      },
+      logPrefix: string
+    ): void => {
+      if (!tool.onArgsDelta) return
+      const previous =
+        pendingToolArgDeltaHooks.get(context.toolCallId) ?? Promise.resolve()
+      const next = previous
+        .catch(() => undefined)
+        .then(async () => {
+          try {
+            await tool.onArgsDelta?.(context, activeRunSignal)
+          } catch (error) {
+            runtimeLog.warn(
+              logPrefix,
+              `streaming tool arg hook failed for ${context.toolName}:`,
+              error
+            )
+          }
+        })
+      pendingToolArgDeltaHooks.set(context.toolCallId, next)
+      void next.finally(() => {
+        if (pendingToolArgDeltaHooks.get(context.toolCallId) === next) {
+          pendingToolArgDeltaHooks.delete(context.toolCallId)
+        }
+      })
+    }
+    const agentTools = opts.tools.map(
+      (tool): AgentTool => ({
+        ...tool,
+        execute: (async (...args: Parameters<AgentTool[`execute`]>) => {
+          const toolCallId = typeof args[0] === `string` ? args[0] : undefined
+          await awaitToolArgDeltaHooks(toolCallId)
+          return tool.execute(...args)
+        }) as AgentTool[`execute`],
+      })
+    )
 
     const agentOptions = {
       initialState: {
         systemPrompt: opts.systemPrompt,
-        tools: opts.tools as Array<never>,
+        tools: agentTools as Array<never>,
         messages: history as Array<never>,
         model,
       },
@@ -443,22 +495,18 @@ export function createPiAgentAdapter(
                       const tool = opts.tools.find(
                         (candidate) => candidate.name === toolName
                       )
-                      if (tool?.onArgsDelta) {
-                        void Promise.resolve(
-                          tool.onArgsDelta({
+                      if (tool) {
+                        enqueueToolArgDeltaHook(
+                          tool,
+                          {
                             toolCallId,
                             toolName,
                             contentIndex,
                             delta,
                             argsPreview,
-                          })
-                        ).catch((error) => {
-                          runtimeLog.warn(
-                            logPrefix,
-                            `streaming tool arg hook failed for ${toolName}:`,
-                            error
-                          )
-                        })
+                          },
+                          logPrefix
+                        )
                       }
                     } else {
                       bridge.onToolCallArgsEnd(
@@ -467,6 +515,11 @@ export function createPiAgentAdapter(
                         argsPreview
                       )
                     }
+                  } else {
+                    runtimeLog.debug(
+                      logPrefix,
+                      `pi-adapter message_update missing tool call identity type=${assistantEvent.type}`
+                    )
                   }
                 } else {
                   runtimeLog.debug(
@@ -702,6 +755,7 @@ export function createPiAgentAdapter(
       async run(input?: string, abortSignal?: AbortSignal): Promise<void> {
         running = true
         abortedRun = false
+        activeRunSignal = abortSignal
 
         bridge.onRunStart()
 
@@ -719,6 +773,7 @@ export function createPiAgentAdapter(
             settled = true
             clearAbortFallback()
             running = false
+            activeRunSignal = undefined
             abortSignal?.removeEventListener(`abort`, abortRun)
             unsubscribe()
             bridge.onRunEnd({ finishReason })
@@ -752,6 +807,7 @@ export function createPiAgentAdapter(
               if (settled) return
               settled = true
               running = false
+              activeRunSignal = undefined
               clearAbortFallback()
               abortSignal?.removeEventListener(`abort`, abortRun)
               unsubscribe()

--- a/packages/agents-runtime/src/types.ts
+++ b/packages/agents-runtime/src/types.ts
@@ -410,6 +410,7 @@ export type TimelineItem =
             error: string | null
             status:
               | `started`
+              | `args_streaming`
               | `args_complete`
               | `executing`
               | `completed`
@@ -947,7 +948,20 @@ export type AgentRunResult = {
   usage: { tokens: number; duration: number }
 }
 
-export type AgentTool = PiAgentTool
+export interface ToolArgumentDeltaContext {
+  toolCallId: string
+  toolName: string
+  contentIndex?: number
+  delta: string
+  argsPreview?: unknown
+}
+
+export type AgentTool = PiAgentTool & {
+  onArgsDelta?: (
+    context: ToolArgumentDeltaContext,
+    signal?: AbortSignal
+  ) => Promise<void> | void
+}
 export type AgentModel = string | Model<any>
 
 export interface AgentConfig {

--- a/packages/agents-runtime/test/outbound-bridge.test.ts
+++ b/packages/agents-runtime/test/outbound-bridge.test.ts
@@ -97,8 +97,62 @@ describe(`createOutboundBridge`, () => {
     expect((writes[1]!.value as Record<string, unknown>).tool_name).toBe(
       `search`
     )
-    expect((writes[1]!.value as Record<string, unknown>).status).toBe(`started`)
+    expect((writes[1]!.value as Record<string, unknown>).status).toBe(
+      `executing`
+    )
     expect((writes[1]!.value as Record<string, unknown>).run_id).toBe(`run-0`)
+  })
+
+  it(`persists streaming tool call argument deltas`, () => {
+    const writes: Array<ChangeEvent> = []
+    const bridge = createOutboundBridge([], (e) => {
+      writes.push(e)
+    })
+
+    bridge.onRunStart()
+    bridge.onToolCallArgsStart(`call-draft`, `draft`, { text: `He` })
+    bridge.onToolCallArgsDelta(`call-draft`, `draft`, `llo`, {
+      contentIndex: 1,
+      argsPreview: { text: `Hello` },
+    })
+    bridge.onToolCallArgsEnd(`call-draft`, `draft`, { text: `Hello` })
+
+    expect(writes[1]).toMatchObject({
+      type: `tool_call`,
+      key: `tc-0`,
+      headers: { operation: `insert` },
+      value: {
+        tool_call_id: `call-draft`,
+        tool_name: `draft`,
+        status: `args_streaming`,
+        args_preview: { text: `He` },
+        run_id: `run-0`,
+      },
+    })
+    expect(writes[2]).toMatchObject({
+      type: `tool_arg_delta`,
+      key: `tc-0:args-0`,
+      value: {
+        tool_call_key: `tc-0`,
+        tool_call_id: `call-draft`,
+        run_id: `run-0`,
+        seq: 0,
+        delta: `llo`,
+        content_index: 1,
+      },
+    })
+    expect(writes[3]).toMatchObject({
+      type: `tool_call`,
+      key: `tc-0`,
+      headers: { operation: `update` },
+      value: {
+        tool_call_id: `call-draft`,
+        tool_name: `draft`,
+        status: `args_complete`,
+        args: { text: `Hello` },
+        run_id: `run-0`,
+      },
+    })
   })
 
   it(`maps tool_call_end to tool_call update with result`, () => {

--- a/packages/agents-runtime/test/outbound-bridge.test.ts
+++ b/packages/agents-runtime/test/outbound-bridge.test.ts
@@ -97,9 +97,7 @@ describe(`createOutboundBridge`, () => {
     expect((writes[1]!.value as Record<string, unknown>).tool_name).toBe(
       `search`
     )
-    expect((writes[1]!.value as Record<string, unknown>).status).toBe(
-      `executing`
-    )
+    expect((writes[1]!.value as Record<string, unknown>).status).toBe(`started`)
     expect((writes[1]!.value as Record<string, unknown>).run_id).toBe(`run-0`)
   })
 

--- a/packages/agents-runtime/test/outbound-bridge.test.ts
+++ b/packages/agents-runtime/test/outbound-bridge.test.ts
@@ -122,12 +122,24 @@ describe(`createOutboundBridge`, () => {
       value: {
         tool_call_id: `call-draft`,
         tool_name: `draft`,
-        status: `args_streaming`,
+        status: `started`,
         args_preview: { text: `He` },
         run_id: `run-0`,
       },
     })
     expect(writes[2]).toMatchObject({
+      type: `tool_call`,
+      key: `tc-0`,
+      headers: { operation: `update` },
+      value: {
+        tool_call_id: `call-draft`,
+        tool_name: `draft`,
+        status: `args_streaming`,
+        args_preview: { text: `Hello` },
+        run_id: `run-0`,
+      },
+    })
+    expect(writes[3]).toMatchObject({
       type: `tool_arg_delta`,
       key: `tc-0:args-0`,
       value: {
@@ -139,7 +151,7 @@ describe(`createOutboundBridge`, () => {
         content_index: 1,
       },
     })
-    expect(writes[3]).toMatchObject({
+    expect(writes[4]).toMatchObject({
       type: `tool_call`,
       key: `tc-0`,
       headers: { operation: `update` },
@@ -149,6 +161,104 @@ describe(`createOutboundBridge`, () => {
         status: `args_complete`,
         args: { text: `Hello` },
         run_id: `run-0`,
+      },
+    })
+  })
+
+  it(`transitions a streamed tool call to executing before completion`, () => {
+    const writes: Array<ChangeEvent> = []
+    const bridge = createOutboundBridge([], (e) => {
+      writes.push(e)
+    })
+
+    bridge.onRunStart()
+    bridge.onToolCallArgsStart(`call-draft`, `draft`, { text: `He` })
+    bridge.onToolCallArgsDelta(`call-draft`, `draft`, `llo`, {
+      argsPreview: { text: `Hello` },
+    })
+    bridge.onToolCallArgsEnd(`call-draft`, `draft`, { text: `Hello` })
+    bridge.onToolCallStart(`call-draft`, `draft`, { text: `Hello` })
+    bridge.onToolCallEnd(`call-draft`, `draft`, `ok`, false)
+
+    expect(writes[5]).toMatchObject({
+      type: `tool_call`,
+      key: `tc-0`,
+      headers: { operation: `update` },
+      value: {
+        tool_call_id: `call-draft`,
+        tool_name: `draft`,
+        status: `executing`,
+        args: { text: `Hello` },
+        run_id: `run-0`,
+      },
+    })
+    expect(writes[6]).toMatchObject({
+      type: `tool_call`,
+      key: `tc-0`,
+      value: {
+        status: `completed`,
+        args: { text: `Hello` },
+        result: `ok`,
+      },
+    })
+  })
+
+  it(`creates a streaming tool call when a delta arrives before start`, () => {
+    const writes: Array<ChangeEvent> = []
+    const bridge = createOutboundBridge([], (e) => {
+      writes.push(e)
+    })
+
+    bridge.onRunStart()
+    bridge.onToolCallArgsDelta(`call-draft`, `draft`, `He`, {
+      argsPreview: { text: `He` },
+    })
+
+    expect(writes[1]).toMatchObject({
+      type: `tool_call`,
+      key: `tc-0`,
+      headers: { operation: `insert` },
+      value: {
+        tool_call_id: `call-draft`,
+        tool_name: `draft`,
+        status: `args_streaming`,
+        args_preview: { text: `He` },
+      },
+    })
+    expect(writes[2]).toMatchObject({
+      type: `tool_arg_delta`,
+      key: `tc-0:args-0`,
+      value: {
+        tool_call_key: `tc-0`,
+        tool_call_id: `call-draft`,
+        seq: 0,
+        delta: `He`,
+      },
+    })
+  })
+
+  it(`keeps legacy synthetic tool ids distinct from provider ids`, () => {
+    const writes: Array<ChangeEvent> = []
+    const bridge = createOutboundBridge([], (e) => {
+      writes.push(e)
+    })
+
+    bridge.onRunStart()
+    bridge.onToolCallArgsStart(`tc-0`, `provider`, {})
+    bridge.onToolCallStart(`legacy`, {})
+
+    expect(writes[1]).toMatchObject({
+      key: `tc-0`,
+      value: {
+        tool_call_id: `tc-0`,
+        tool_name: `provider`,
+      },
+    })
+    expect(writes[2]).toMatchObject({
+      key: `tc-1`,
+      value: {
+        tool_call_id: `legacy-tc-1`,
+        tool_name: `legacy`,
       },
     })
   })

--- a/packages/agents-runtime/test/pi-adapter.test.ts
+++ b/packages/agents-runtime/test/pi-adapter.test.ts
@@ -570,6 +570,141 @@ describe(`createPiAgentAdapter`, () => {
     )
   })
 
+  it(`dispatches streamed tool call arguments to the bridge and tool hook`, async () => {
+    let streamReadyResolve:
+      | ((stream: ReturnType<typeof createAssistantMessageEventStream>) => void)
+      | null = null
+    const streamReady = new Promise<
+      ReturnType<typeof createAssistantMessageEventStream>
+    >((resolve) => {
+      streamReadyResolve = resolve
+    })
+    const partialMessage: AssistantMessage = {
+      role: `assistant`,
+      content: [
+        {
+          type: `toolCall`,
+          id: `call-draft`,
+          name: `draft`,
+          arguments: { text: `Hello` },
+        },
+      ],
+      api: `anthropic-messages`,
+      provider: `anthropic`,
+      model: `claude-sonnet-4-5-20250929`,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: `toolUse`,
+      timestamp: Date.now(),
+    }
+    const completedMessage: AssistantMessage = {
+      ...partialMessage,
+      content: [{ type: `text`, text: `` }],
+      stopReason: `stop`,
+    }
+    const argDeltas: Array<unknown> = []
+    const events: Array<ChangeEvent> = []
+    const factory = createPiAgentAdapter({
+      systemPrompt: `Test system prompt`,
+      model: `claude-sonnet-4-5-20250929`,
+      tools: [
+        {
+          name: `draft`,
+          label: `Draft`,
+          description: `Draft text`,
+          parameters: {
+            type: `object`,
+            properties: { text: { type: `string` } },
+            required: [`text`],
+          } as never,
+          onArgsDelta: (context) => {
+            argDeltas.push(context)
+          },
+          execute: async () => ({
+            content: [{ type: `text`, text: `ok` }],
+            details: null,
+          }),
+        },
+      ],
+      streamFn: () => {
+        const stream = createAssistantMessageEventStream()
+        streamReadyResolve?.(stream)
+        return stream
+      },
+    })
+    const handle = factory({
+      entityUrl: `test/entity-1`,
+      epoch: 1,
+      messages: [],
+      outboundIdSeed: { run: 0, step: 0, msg: 0, tc: 0 },
+      writeEvent: (event: ChangeEvent) => {
+        events.push(event)
+      },
+    })
+
+    const runPromise = handle.run(`hello`)
+    const stream = await streamReady
+    stream.push({
+      type: `start`,
+      partial: partialMessage,
+    })
+    stream.push({
+      type: `toolcall_start`,
+      contentIndex: 0,
+      partial: partialMessage,
+    })
+    stream.push({
+      type: `toolcall_delta`,
+      contentIndex: 0,
+      delta: `"Hello"`,
+      partial: partialMessage,
+    })
+    stream.push({
+      type: `toolcall_end`,
+      contentIndex: 0,
+      toolCall: partialMessage.content[0] as never,
+      partial: partialMessage,
+    })
+    stream.push({
+      type: `done`,
+      reason: `stop`,
+      message: completedMessage,
+    })
+    await runPromise
+
+    expect(argDeltas).toEqual([
+      {
+        toolCallId: `call-draft`,
+        toolName: `draft`,
+        contentIndex: 0,
+        delta: `"Hello"`,
+        argsPreview: { text: `Hello` },
+      },
+    ])
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: `tool_arg_delta`,
+        value: expect.objectContaining({
+          tool_call_id: `call-draft`,
+          delta: `"Hello"`,
+          content_index: 0,
+        }),
+      })
+    )
+  })
+
   it(`isRunning returns false initially`, () => {
     const factory = createPiAgentAdapter({
       systemPrompt: `Test system prompt`,

--- a/packages/agents-runtime/test/pi-adapter.test.ts
+++ b/packages/agents-runtime/test/pi-adapter.test.ts
@@ -7,9 +7,8 @@ import {
 import { createAssistantMessageEventStream } from '@mariozechner/pi-ai'
 import { Type } from '@sinclair/typebox'
 import type { OutboundIdSeed } from '../src/outbound-bridge'
-import type { LLMMessage } from '../src/types'
+import type { AgentTool, LLMMessage } from '../src/types'
 import type { ChangeEvent } from '@durable-streams/state'
-import type { AgentTool } from '@mariozechner/pi-agent-core'
 import type {
   AssistantMessage,
   Model,
@@ -615,7 +614,9 @@ describe(`createPiAgentAdapter`, () => {
       stopReason: `stop`,
     }
     const argDeltas: Array<unknown> = []
+    const signals: Array<AbortSignal | undefined> = []
     const events: Array<ChangeEvent> = []
+    const controller = new AbortController()
     const factory = createPiAgentAdapter({
       systemPrompt: `Test system prompt`,
       model: `claude-sonnet-4-5-20250929`,
@@ -629,8 +630,9 @@ describe(`createPiAgentAdapter`, () => {
             properties: { text: { type: `string` } },
             required: [`text`],
           } as never,
-          onArgsDelta: (context) => {
+          onArgsDelta: (context, signal) => {
             argDeltas.push(context)
+            signals.push(signal)
           },
           execute: async () => ({
             content: [{ type: `text`, text: `ok` }],
@@ -648,13 +650,13 @@ describe(`createPiAgentAdapter`, () => {
       entityUrl: `test/entity-1`,
       epoch: 1,
       messages: [],
-      outboundIdSeed: { run: 0, step: 0, msg: 0, tc: 0 },
+      outboundIdSeed: { run: 0, step: 0, msg: 0, tc: 0, reasoning: 0 },
       writeEvent: (event: ChangeEvent) => {
         events.push(event)
       },
     })
 
-    const runPromise = handle.run(`hello`)
+    const runPromise = handle.run(`hello`, controller.signal)
     const stream = await streamReady
     stream.push({
       type: `start`,
@@ -693,6 +695,7 @@ describe(`createPiAgentAdapter`, () => {
         argsPreview: { text: `Hello` },
       },
     ])
+    expect(signals).toEqual([controller.signal])
     expect(events).toContainEqual(
       expect.objectContaining({
         type: `tool_arg_delta`,
@@ -703,6 +706,248 @@ describe(`createPiAgentAdapter`, () => {
         }),
       })
     )
+  })
+
+  it(`serializes streamed tool argument hooks before tool execution`, async () => {
+    let streamReadyResolve:
+      | ((stream: ReturnType<typeof createAssistantMessageEventStream>) => void)
+      | null = null
+    const streamReady = new Promise<
+      ReturnType<typeof createAssistantMessageEventStream>
+    >((resolve) => {
+      streamReadyResolve = resolve
+    })
+    let releaseFirstDelta!: () => void
+    const firstDeltaBarrier = new Promise<void>((resolve) => {
+      releaseFirstDelta = resolve
+    })
+    const usage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    }
+    const toolCallMessage: AssistantMessage = {
+      role: `assistant`,
+      content: [
+        {
+          type: `toolCall`,
+          id: `call-draft`,
+          name: `draft`,
+          arguments: { text: `AB` },
+        },
+      ],
+      api: `anthropic-messages`,
+      provider: `anthropic`,
+      model: `claude-sonnet-4-5-20250929`,
+      usage,
+      stopReason: `toolUse`,
+      timestamp: Date.now(),
+    }
+    const completedMessage: AssistantMessage = {
+      ...toolCallMessage,
+      content: [{ type: `text`, text: `done` }],
+      stopReason: `stop`,
+    }
+    const order: Array<string> = []
+    let streamCount = 0
+    const factory = createPiAgentAdapter({
+      systemPrompt: `Test system prompt`,
+      model: `claude-sonnet-4-5-20250929`,
+      tools: [
+        {
+          name: `draft`,
+          label: `Draft`,
+          description: `Draft text`,
+          parameters: Type.Object({ text: Type.String() }),
+          onArgsDelta: async ({ delta }) => {
+            order.push(`start:${delta}`)
+            if (delta === `A`) {
+              await firstDeltaBarrier
+            }
+            order.push(`end:${delta}`)
+          },
+          execute: async () => {
+            order.push(`execute`)
+            return {
+              content: [{ type: `text`, text: `ok` }],
+              details: null,
+            }
+          },
+        },
+      ],
+      streamFn: () => {
+        const stream = createAssistantMessageEventStream()
+        streamCount++
+        if (streamCount === 1) {
+          streamReadyResolve?.(stream)
+        } else {
+          queueMicrotask(() => stream.end(completedMessage))
+        }
+        return stream
+      },
+    })
+    const handle = factory({
+      entityUrl: `test/entity-1`,
+      epoch: 1,
+      messages: [],
+      outboundIdSeed: { run: 0, step: 0, msg: 0, tc: 0, reasoning: 0 },
+      writeEvent: (_event: ChangeEvent) => {},
+    })
+
+    const runPromise = handle.run(`hello`)
+    const stream = await streamReady
+    stream.push({ type: `start`, partial: toolCallMessage })
+    stream.push({
+      type: `toolcall_start`,
+      contentIndex: 0,
+      partial: toolCallMessage,
+    })
+    stream.push({
+      type: `toolcall_delta`,
+      contentIndex: 0,
+      delta: `A`,
+      partial: toolCallMessage,
+    })
+    stream.push({
+      type: `toolcall_delta`,
+      contentIndex: 0,
+      delta: `B`,
+      partial: toolCallMessage,
+    })
+    stream.push({
+      type: `toolcall_end`,
+      contentIndex: 0,
+      toolCall: toolCallMessage.content[0] as never,
+      partial: toolCallMessage,
+    })
+    stream.push({
+      type: `done`,
+      reason: `toolUse`,
+      message: toolCallMessage,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(order).toEqual([`start:A`])
+
+    releaseFirstDelta()
+    await runPromise
+
+    expect(order).toEqual([`start:A`, `end:A`, `start:B`, `end:B`, `execute`])
+  })
+
+  it(`continues tool execution after a streamed argument hook rejects`, async () => {
+    let streamReadyResolve:
+      | ((stream: ReturnType<typeof createAssistantMessageEventStream>) => void)
+      | null = null
+    const streamReady = new Promise<
+      ReturnType<typeof createAssistantMessageEventStream>
+    >((resolve) => {
+      streamReadyResolve = resolve
+    })
+    const usage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    }
+    const toolCallMessage: AssistantMessage = {
+      role: `assistant`,
+      content: [
+        {
+          type: `toolCall`,
+          id: `call-draft`,
+          name: `draft`,
+          arguments: { text: `A` },
+        },
+      ],
+      api: `anthropic-messages`,
+      provider: `anthropic`,
+      model: `claude-sonnet-4-5-20250929`,
+      usage,
+      stopReason: `toolUse`,
+      timestamp: Date.now(),
+    }
+    const completedMessage: AssistantMessage = {
+      ...toolCallMessage,
+      content: [{ type: `text`, text: `done` }],
+      stopReason: `stop`,
+    }
+    let executed = false
+    let streamCount = 0
+    const factory = createPiAgentAdapter({
+      systemPrompt: `Test system prompt`,
+      model: `claude-sonnet-4-5-20250929`,
+      tools: [
+        {
+          name: `draft`,
+          label: `Draft`,
+          description: `Draft text`,
+          parameters: Type.Object({ text: Type.String() }),
+          onArgsDelta: async () => {
+            throw new Error(`hook failed`)
+          },
+          execute: async () => {
+            executed = true
+            return {
+              content: [{ type: `text`, text: `ok` }],
+              details: null,
+            }
+          },
+        },
+      ],
+      streamFn: () => {
+        const stream = createAssistantMessageEventStream()
+        streamCount++
+        if (streamCount === 1) {
+          streamReadyResolve?.(stream)
+        } else {
+          queueMicrotask(() => stream.end(completedMessage))
+        }
+        return stream
+      },
+    })
+    const handle = factory({
+      entityUrl: `test/entity-1`,
+      epoch: 1,
+      messages: [],
+      outboundIdSeed: { run: 0, step: 0, msg: 0, tc: 0, reasoning: 0 },
+      writeEvent: (_event: ChangeEvent) => {},
+    })
+
+    const runPromise = handle.run(`hello`)
+    const stream = await streamReady
+    stream.push({ type: `start`, partial: toolCallMessage })
+    stream.push({
+      type: `toolcall_delta`,
+      contentIndex: 0,
+      delta: `A`,
+      partial: toolCallMessage,
+    })
+    stream.push({
+      type: `done`,
+      reason: `toolUse`,
+      message: toolCallMessage,
+    })
+
+    await expect(runPromise).resolves.toBeUndefined()
+    expect(executed).toBe(true)
   })
 
   it(`isRunning returns false initially`, () => {


### PR DESCRIPTION
## Summary

Adds generic runtime support for tools that want to observe partial tool-call arguments while Pi is still streaming them. This PR is intentionally limited to the runtime protocol and persistence layer; it does not add any markdown-document behavior.

What changes:

- Adds `AgentTool.onArgsDelta(context, signal)` as an optional hook on runtime tools.
- Wires Pi `toolcall_start`, `toolcall_delta`, and `toolcall_end` assistant-message events through the runtime adapter.
- Persists streaming argument lifecycle on `tool_call` rows using `args_streaming` and `args_complete` statuses.
- Adds a `tool_arg_delta` built-in collection so streamed argument chunks are durable and inspectable.
- Preserves the existing non-streaming tool-call behavior: ordinary tool execution still inserts a `tool_call` row with `status: "started"`.

## Example

```ts
import { Type } from '@sinclair/typebox'
import type { AgentTool } from '@electric-ax/agents-runtime'

export const streamingDraftTool: AgentTool = {
  name: 'streaming_draft',
  label: 'Streaming Draft',
  description: 'Apply text as the model streams the tool arguments.',
  parameters: Type.Object({
    documentId: Type.String(),
    content: Type.String(),
  }),

  async onArgsDelta({ toolCallId, delta, argsPreview }, signal) {
    // Called for each Pi `toolcall_delta` before final tool execution.
    // `delta` is the raw streamed argument chunk.
    // `argsPreview` is Pi's best current parsed argument object.
    const args = argsPreview as
      | { documentId?: string; content?: string }
      | undefined

    if (signal?.aborted || !args?.documentId) return

    await appendPartialContent({
      toolCallId,
      documentId: args.documentId,
      delta,
      previewContent: args.content ?? '',
    })
  },

  async execute(_toolCallId, args) {
    // Final execution still runs after Pi completes the tool call args.
    await finishDraft(args.documentId, args.content)
    return {
      content: [{ type: 'text', text: 'Draft complete.' }],
      details: { documentId: args.documentId },
    }
  },
}
```

## Validation

- `pnpm --filter @electric-ax/agents-runtime typecheck`
- `pnpm --filter @electric-ax/agents-runtime exec vitest run test/outbound-bridge.test.ts test/pi-adapter.test.ts`
- `pnpm --filter @electric-ax/agents-runtime exec vitest run test/runtime-dsl.test.ts`