### PR TITLE
fix(sync-service): redact internal exception details from 500 responses

### DIFF
--- a/.changeset/redact-internal-error.md
+++ b/.changeset/redact-internal-error.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Redact internal exception details from 500 responses. Uncaught errors in the shape-serving plug previously returned the full Elixir stacktrace (internal module paths, library versions, partial query text) in the response body. Clients now receive a generic `"Internal server error"` message; the full detail is still captured server-side via OpenTelemetry.

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -157,8 +157,13 @@ defmodule Electric.Plug.ServeShapePlug do
     )
   end
 
+  # Catch-all: never echo the formatted exception (which carries the full
+  # stacktrace, internal module paths, library versions, and partial query
+  # text) back to the client. The detail is preserved server-side via
+  # OpenTelemetry.record_exception/3 in handle_error/4 and the `error.type`
+  # span attribute, so no observability is lost.
   defp handle_specific_error(conn, _kind, _reason) do
-    send_resp(conn, conn.status, Jason.encode!(%{error: conn.assigns[:error_str]}))
+    send_resp(conn, conn.status, Jason.encode!(%{error: "Internal server error"}))
   end
 
   # Parse JSON body for POST requests to support subset parameters in body

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -1445,6 +1445,31 @@ defmodule Electric.Plug.ServeShapePlugTest do
       assert %{initial: 0, existing: 0} == Electric.AdmissionControl.get_current(ctx.stack_id)
     end
 
+    test "500 response body redacts internal exception details", ctx do
+      # The raised message includes content that resembles internal detail
+      # (module paths, query text) that must never reach the client.
+      Repatch.patch(Electric.Shapes.Api, :load_shape_info, fn _request ->
+        raise RuntimeError,
+              "(Postgrex.Error) ERROR 42601 at query: SELECT * FROM secret_table"
+      end)
+
+      conn =
+        try do
+          ctx
+          |> conn(:get, %{"table" => "public.users"}, "?offset=-1")
+          |> ServeShapePlug.call(ctx.plug_opts)
+        catch
+          :error, %Plug.Conn.WrapperError{conn: conn} -> conn
+        end
+
+      assert conn.status == 500
+      assert Jason.decode!(conn.resp_body) == %{"error" => "Internal server error"}
+      # The leaked detail must not appear anywhere in the response body.
+      refute conn.resp_body =~ "Postgrex"
+      refute conn.resp_body =~ "secret_table"
+      refute conn.resp_body =~ "load_shape_info"
+    end
+
     # The `catch` only fires on the re-raise path (`handle_caught` sees
     # `{:plug_conn, :sent}` in the mailbox and re-raises). For the tests
     # in this describe block the exception is raised before any response is


### PR DESCRIPTION
## Summary
Uncaught exceptions in the shape-serving plug no longer leak the full Elixir stacktrace to HTTP clients.

Addresses security advisory [GHSA-p869-vmqw-939q](https://github.com/electric-sql/electric/security/advisories/GHSA-p869-vmqw-939q).

## Problem
When an uncaught exception reached the error handler in `ServeShapePlug`, the full Elixir stacktrace was serialized via `Exception.format/2` and returned to the HTTP client in the 500 response body. For example:

```json
{
  "error": "** (Postgrex.Error) ERROR 42601 (syntax_error) at query: SELECT ...\n    (electric 1.x.x) lib/electric/shapes/querying.ex:44: Electric.Shapes.Querying.query/3\n    (db_connection 2.6.0) lib/db_connection.ex:1855: DBConnection.execute/4"
}
```

This exposed internal module paths, function names, line numbers, library versions, and partial database query text to any caller.

## Solution
The catch-all `handle_specific_error/3` clause in `lib/electric/plug/serve_shape_plug.ex` now returns a generic `"Internal server error"` message instead of the formatted exception.

No observability is lost: the full detail is still recorded server-side via `OpenTelemetry.record_exception/3` in `handle_error/4`, and the `error.type` span attribute (assigned from `:error_str`) is retained. The more specific error clauses (e.g. `DBConnection.ConnectionError` → `"Database is unreachable"`) already returned static messages and are unchanged.

## Test Plan
- [x] New test `"500 response body redacts internal exception details"` raises an exception whose message mimics leaked internals and asserts the 500 body is exactly `{"error": "Internal server error"}` with no `Postgrex` / query text / function name leaking through.
- [x] Full `serve_shape_plug_test.exs` suite passes (51 tests, 0 failures).

---
Generated with [Claude Code](https://claude.com/claude-code)