### PR TITLE
fix: keep OpenAI reasoning responses stateful

### DIFF
--- a/.changeset/openai-reasoning-store-true.md
+++ b/.changeset/openai-reasoning-store-true.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': patch
+---
+
+Force `store: true` for built-in OpenAI reasoning model payloads so reasoning/tool-call continuations can replay `rs_*` reasoning items without follow-up requests failing due to missing persisted items.

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -267,6 +267,11 @@ function withProviderPayloadDefaults(
 
       return {
         ...body,
+        // OpenAI Responses reasoning/tool-call continuations replay rs_*
+        // reasoning items. With store:false, OpenAI does not persist those
+        // items server-side, which can make follow-up requests fail with
+        // "Item with id ... not found". Keep Responses stateful for built-ins.
+        store: true,
         reasoning: {
           ...existingReasoning,
           effort,

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -126,6 +126,7 @@ describe(`model catalog`, () => {
     )
 
     expect(payload).toEqual({
+      store: true,
       reasoning: { effort: `minimal` },
     })
   })
@@ -145,8 +146,49 @@ describe(`model catalog`, () => {
     )
 
     expect(payload).toEqual({
+      store: true,
       reasoning: { effort: `high` },
     })
+  })
+
+  it(`forces store true only for OpenAI reasoning model payloads`, async () => {
+    const openAiCatalog = await createBuiltinModelCatalog()
+    const openAiConfig = resolveBuiltinModelConfig(openAiCatalog!, {
+      model: `openai:gpt-5`,
+    })
+
+    expect(
+      openAiConfig.onPayload!(
+        { store: false, reasoning: { effort: `none` } },
+        {} as any
+      )
+    ).toEqual({
+      store: true,
+      reasoning: { effort: `minimal` },
+    })
+
+    delete process.env.OPENAI_API_KEY
+    process.env.DEEPSEEK_API_KEY = `test-deepseek-key`
+    vi.stubGlobal(
+      `fetch`,
+      vi.fn(async (url: string) => {
+        if (String(url).includes(`deepseek.com`)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ data: [{ id: `deepseek-v4-flash` }] }),
+          }
+        }
+        return { ok: false, status: 401, json: async () => ({}) }
+      })
+    )
+
+    const deepseekCatalog = await createBuiltinModelCatalog()
+    const deepseekConfig = resolveBuiltinModelConfig(deepseekCatalog!, {
+      model: `deepseek:deepseek-v4-flash`,
+    })
+
+    expect(deepseekConfig.onPayload).toBeUndefined()
   })
 
   it(`does not expose providers whose keys are rejected`, async () => {


### PR DESCRIPTION
## Executive Summary

Built-in OpenAI/OpenAI Codex reasoning model payloads now force `store: true` so OpenAI Responses continuations can replay reasoning/tool-call state reliably. This prevents follow-up agent steps from failing with missing `rs_*` reasoning item errors.

## Root Cause

OpenAI Responses reasoning/tool-call continuations can include prior `rs_*` reasoning items in subsequent requests. The upstream Responses payload defaults to `store: false`, which means OpenAI does not persist those items server-side. When a later request references one of those non-persisted item ids, OpenAI can return:

> Item with id ... not found

## Approach

When applying built-in provider payload defaults for OpenAI reasoning models, keep the existing reasoning-effort normalization and also force the Responses payload to be stateful:

```ts
return {
  ...body,
  store: true,
  reasoning: {
    ...existingReasoning,
    effort,
  },
}
```

The test coverage verifies that:

- OpenAI reasoning payloads get `store: true`.
- An incoming `store: false` is intentionally overridden.
- Non-OpenAI providers, such as DeepSeek, do not receive this payload override.

## Key Invariants

- Only built-in OpenAI/OpenAI Codex reasoning model payload defaults should force `store: true`.
- Existing payload fields should be preserved unless intentionally overridden.
- Existing reasoning effort normalization should continue to apply.

## Non-goals

- This does not change non-OpenAI provider behavior.
- This does not implement a stateless/ZDR-compatible encrypted reasoning replay path.
- This does not patch `@mariozechner/pi-ai`; it applies the built-in agent payload default at our integration layer.

## Trade-offs

The alternative is to keep `store: false` and preserve/replay full `reasoning.encrypted_content` for stateless operation. That is more complex and unnecessary for the built-in agent default path. Using `store: true` matches OpenAI's stateful Responses flow and directly fixes the observed continuation failure.

## Verification

```bash
GITHUB_BASE_REF=main node scripts/check-changeset.mjs
pnpm --filter @electric-ax/agents exec vitest run test/model-catalog.test.ts
pnpm --filter @electric-ax/agents typecheck
```

Also attempted the prep command's suggested Vitest thread flag:

```bash
pnpm --filter @electric-ax/agents exec vitest run test/model-catalog.test.ts --pool-options.threads.maxThreads=2
```

That failed because this Vitest version rejects the flag as an unknown option (`--poolOptions`). The same targeted test passes without that unsupported flag.

## Files Changed

- `.changeset/openai-reasoning-store-true.md` — patch changeset for `@electric-ax/agents`.
- `packages/agents/src/model-catalog.ts` — forces `store: true` for built-in OpenAI reasoning payload defaults.
- `packages/agents/test/model-catalog.test.ts` — updates expectations and adds regression coverage for OpenAI-only `store: true` behavior.
