### PR TITLE
Flatten 1:1 shape GET child spans into Plug_shape_get root-span attributes

### DIFF
--- a/.changeset/flatten-shape-get-spans.md
+++ b/.changeset/flatten-shape-get-spans.md
@@ -3,3 +3,5 @@
 ---
 
 Reduce OTel span volume for shape GET requests: the `shape_get.api.load_shape_info` and `shape_get.plug.serve_shape_log` child spans (strictly 1:1 with the root request span) are no longer emitted. Their timing and process-memory information is preserved as attributes on the `Plug_shape_get` root span instead (`load_shape_info.duration_ms`, `load_shape_info.memory.{start,end}.*`, `serve_shape_log.duration_ms`, `serve_shape_log.memory.{start,end}.*`).
+
+Note for operators: since these two names no longer exist as spans, listing them in `ELECTRIC_EXCLUDE_SPANS` (the `Sampler` `:exclude_spans` setting) no longer has any effect — the data is recorded as root-span attributes whenever the request trace is sampled. In embedded usage (elixir-client / Phoenix.Sync) `Api.serve_shape_log/1` previously created a standalone root span; it now records attributes onto the caller's current span if one exists (e.g. the Phoenix request span in OTel-instrumented apps) and emits nothing otherwise.

--- a/.changeset/flatten-shape-get-spans.md
+++ b/.changeset/flatten-shape-get-spans.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Reduce OTel span volume for shape GET requests: the `shape_get.api.load_shape_info` and `shape_get.plug.serve_shape_log` child spans (strictly 1:1 with the root request span) are no longer emitted. Their timing and process-memory information is preserved as attributes on the `Plug_shape_get` root span instead (`load_shape_info.duration_ms`, `load_shape_info.memory.{start,end}.*`, `serve_shape_log.duration_ms`, `serve_shape_log.memory.{start,end}.*`).

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -295,8 +295,11 @@ defmodule Electric.Shapes.Api do
     Request.update_response(request, &%{&1 | up_to_date: true, offset: request.last_offset})
   end
 
+  # Recorded as `load_shape_info.*` attributes on the enclosing span rather
+  # than as a child span: this code is strictly 1:1 with the root request span,
+  # so a separate span only added event volume, not information.
   defp do_load_shape_info(%Request{} = request) do
-    with_span(request, "shape_get.api.load_shape_info", fn ->
+    OpenTelemetry.with_flattened_span("load_shape_info", fn ->
       request
       |> get_or_create_shape_handle()
       |> handle_shape_info(request)
@@ -601,7 +604,9 @@ defmodule Electric.Shapes.Api do
   def serve_shape_log(%Request{} = request) do
     validate_serve_usage!(request)
 
-    with_span(request, "shape_get.plug.serve_shape_log", fn ->
+    # Recorded as `serve_shape_log.*` attributes on the enclosing span rather
+    # than as a child span — see do_load_shape_info/1.
+    OpenTelemetry.with_flattened_span("serve_shape_log", fn ->
       request
       |> do_serve_shape_log()
       |> Response.ensure_cleanup()

--- a/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
+++ b/packages/sync-service/lib/electric/telemetry/open_telemetry.ex
@@ -142,6 +142,57 @@ defmodule Electric.Telemetry.OpenTelemetry do
   end
 
   @doc """
+  Execute `fun`, recording its duration and process-memory footprint as
+  attributes on the current span.
+
+  This is a flattened alternative to `with_span/4` for code that is strictly
+  1:1 with its enclosing span: instead of emitting a separate child span, the
+  same information is recorded as attributes on the current span, prefixed
+  with `name`:
+
+    * `<name>.duration_ms` — execution time of `fun` in milliseconds
+    * `<name>.memory.start.*` / `<name>.memory.end.*` — the process-memory
+      footprint attributes from `process_memory_attributes/1`, captured before
+      and after `fun` runs
+
+  The attributes are recorded even when `fun` raises, mirroring how a child
+  span would still have been ended with its duration. The exception itself
+  propagates up unchanged, to be recorded on the enclosing span by its error
+  handling (see `record_exception/4`).
+
+  When there is no active span context this is a no-op apart from calling
+  `fun`, avoiding the `Process.info/2` cost on unsampled requests.
+  """
+  @spec with_flattened_span(attr_name(), (-> t)) :: t when t: term
+  def with_flattened_span(name, fun) when is_binary(name) do
+    if in_span_context?() do
+      start_attrs = prefix_attrs(name, process_memory_attributes(:start))
+      start_time = System.monotonic_time()
+
+      try do
+        fun.()
+      after
+        duration_ms =
+          System.convert_time_unit(System.monotonic_time() - start_time, :native, :microsecond) /
+            1000
+
+        end_attrs = prefix_attrs(name, process_memory_attributes(:end))
+
+        start_attrs
+        |> Map.merge(end_attrs)
+        |> Map.put("#{name}.duration_ms", duration_ms)
+        |> add_span_attributes()
+      end
+    else
+      fun.()
+    end
+  end
+
+  defp prefix_attrs(prefix, attrs) do
+    Map.new(attrs, fn {key, value} -> {"#{prefix}.#{key}", value} end)
+  end
+
+  @doc """
   Add dynamic attributes to the current span.
 
   For example, if a span is started prior to issuing a DB request, an attribute named

--- a/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
+++ b/packages/sync-service/test/electric/telemetry/open_telemetry_test.exs
@@ -119,6 +119,62 @@ defmodule Electric.Telemetry.OpenTelemetryTest do
     end
   end
 
+  describe "with_flattened_span/2" do
+    test "records duration and prefixed memory attributes on the current span" do
+      test_pid = self()
+
+      Repatch.patch(:otel_span, :set_attributes, fn ctx, attrs ->
+        send(test_pid, {:set_attributes, attrs})
+        Repatch.real(:otel_span, :set_attributes, [ctx, attrs])
+      end)
+
+      result =
+        OpenTelemetry.with_span("test_span", %{}, @stack_id, fn ->
+          OpenTelemetry.with_flattened_span("inner_op", fn -> :some_result end)
+        end)
+
+      assert result == :some_result
+
+      assert_received {:set_attributes,
+                       %{
+                         "inner_op.duration_ms" => duration_ms,
+                         "inner_op.memory.start.process_bytes" => start_process_bytes,
+                         "inner_op.memory.start.binary_bytes" => _,
+                         "inner_op.memory.end.process_bytes" => _,
+                         "inner_op.memory.end.binary_bytes" => _
+                       }}
+
+      assert is_float(duration_ms) and duration_ms >= 0
+      assert is_integer(start_process_bytes) and start_process_bytes > 0
+    end
+
+    test "still records attributes when the function raises" do
+      test_pid = self()
+
+      Repatch.patch(:otel_span, :set_attributes, fn ctx, attrs ->
+        send(test_pid, {:set_attributes, attrs})
+        Repatch.real(:otel_span, :set_attributes, [ctx, attrs])
+      end)
+
+      assert_raise RuntimeError, "boom", fn ->
+        OpenTelemetry.with_span("test_span", %{}, @stack_id, fn ->
+          OpenTelemetry.with_flattened_span("inner_op", fn -> raise "boom" end)
+        end)
+      end
+
+      assert_received {:set_attributes, %{"inner_op.duration_ms" => _}}
+    end
+
+    test "only calls the function when outside any span context" do
+      Repatch.spy(:otel_span)
+
+      assert OpenTelemetry.with_flattened_span("inner_op", fn -> :some_result end) ==
+               :some_result
+
+      refute Repatch.called?(:otel_span, :set_attributes, 2)
+    end
+  end
+
   describe "process_memory_attributes/1" do
     test "returns process and binary memory for :start phase" do
       attrs = OpenTelemetry.process_memory_attributes(:start)


### PR DESCRIPTION
## Motivation

We are over our Honeycomb event budget, and two spans are an outsized contributor: `shape_get.api.load_shape_info` and `shape_get.plug.serve_shape_log` together produce ~147M events/week — roughly 33% of the org's event budget.

Both spans are strictly 1:1 with the `Plug_shape_get` root span (one `load_shape_info` per request; one `serve_shape_log` per request on the log-serving path), and neither carries information that can't live on the root span. `load_shape_info` is a leaf span; `serve_shape_log`'s only children are the `shape_get.plug.stream_chunk` spans, which are untouched by this PR and now parent directly to the root.

## What changed

- New helper `Electric.Telemetry.OpenTelemetry.with_flattened_span/2`: runs a function and records its duration and process-memory footprint as attributes on the **current** span instead of emitting a child span.
- `Electric.Shapes.Api.do_load_shape_info/1` and `serve_shape_log/1` now use it instead of `with_span/4`. No other spans were changed (`shape_get.plug.serve_subset_response` and `shape_get.plug.stream_chunk` are left as-is).
- Changeset: patch bump for `@core/sync-service`.

## What's preserved, and where

All numeric data the child spans used to carry now lands on the `Plug_shape_get` root span:

| Was (child span) | Now (root-span attribute) |
|---|---|
| `shape_get.api.load_shape_info` duration | `load_shape_info.duration_ms` (float ms, sub-ms precision) |
| its `memory.start.{process,binary}_bytes` / `memory.end.{process,binary}_bytes` | `load_shape_info.memory.start.*` / `load_shape_info.memory.end.*` |
| `shape_get.plug.serve_shape_log` duration | `serve_shape_log.duration_ms` |
| its `memory.start.*` / `memory.end.*` | `serve_shape_log.memory.start.*` / `serve_shape_log.memory.end.*` |

The memory attributes are prefixed with the flattened span's short name so they don't collide with the root span's own `memory.start.*` / `memory.end.*` attributes.

Error semantics are unchanged: attributes (including duration) are recorded in an `after` block even when the wrapped code raises, and the exception propagates up to `ServeShapePlug`'s error handler, which records the exception event and sets error status on the root span exactly as before (the child spans never carried error status themselves — `:otel_tracer.with_span/4` only ends the span on raise).

## Trade-offs

- Trace waterfalls lose the visual split between "load shape info" and "serve shape log" inside a request — but no numeric data is lost; the same timings are queryable as root-span attributes.
- The `[:electric, :shape_get, :api, :load_shape_info, :start|:stop|:exception]` and `[:electric, :shape_get, :plug, :serve_shape_log, ...]` `:telemetry.span` events are no longer emitted. A repo-wide search found no handlers attached to them.
- In embedded (elixir-client) usage, `Api.serve_shape_log/1` previously created a root span of its own; with no enclosing span the helper is now a no-op (it just runs the function), so embedded calls produce no span — consistent with the unsampled-request path.

## Verification

- `mix test test/electric/telemetry/open_telemetry_test.exs test/electric/shapes/api_test.exs test/electric/plug/serve_shape_plug_test.exs test/electric/plug/serve_shape_plug_logging_test.exs` — 121 tests, 0 failures.
- New unit tests for `with_flattened_span/2` cover attribute recording, the raise path, and the no-span-context no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
